### PR TITLE
Fix extension preview sync after agent edits

### DIFF
--- a/.changeset/fresh-extension-previews.md
+++ b/.changeset/fresh-extension-previews.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep extension previews fresh after agent-side edits and clarify chat recovery after repeated connection failures.

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2660,6 +2660,16 @@ function isProviderQueryRunError(info: RunErrorInfo): boolean {
   );
 }
 
+function isConnectionRecoveryRunError(info: RunErrorInfo): boolean {
+  const code = (info.errorCode ?? "").toLowerCase();
+  const message = info.message.toLowerCase();
+  return (
+    code === "connection_error" ||
+    message.includes("connection kept failing") ||
+    message.includes("automatic recovery attempts")
+  );
+}
+
 function getMessageText(message: unknown): string {
   const msg = (message as { message?: unknown })?.message ?? message;
   const content = (msg as { content?: unknown })?.content;
@@ -2698,6 +2708,7 @@ function RunErrorRecoveryCard({
     builderReconnect.hasFetchedStatus &&
     builderReconnect.configured;
   const isQueryError = isProviderQueryRunError(info);
+  const isConnectionRecoveryError = isConnectionRecoveryRunError(info);
   const copyLabel =
     info.runId || info.errorCode || info.details ? "Copy debug" : "Copy";
   const copyDetails = useCallback(() => {
@@ -2713,6 +2724,10 @@ function RunErrorRecoveryCard({
     setCopied(true);
     setTimeout(() => setCopied(false), 1200);
   }, [info]);
+  const startNewChat = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("agent-chat:new-chat"));
+    onDismiss();
+  }, [onDismiss]);
 
   useEffect(() => {
     if (builderReconnectResolved) {
@@ -2739,6 +2754,12 @@ function RunErrorRecoveryCard({
             <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
               The current Builder.io or model-provider credential was rejected.
               Reconnect Builder.io, then retry this message.
+            </p>
+          )}
+          {isConnectionRecoveryError && (
+            <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+              If retry lands on the same error, start a new chat session and
+              continue from what already changed.
             </p>
           )}
           {(info.runId || info.errorCode || info.details) && (
@@ -2816,7 +2837,17 @@ function RunErrorRecoveryCard({
             </button>
           </>
         )}
-        {canRecover && onFork && (
+        {canRecover && isConnectionRecoveryError && (
+          <button
+            type="button"
+            onClick={startNewChat}
+            className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-background px-3 text-xs font-medium text-foreground hover:bg-accent"
+          >
+            <IconPlus size={13} />
+            New chat
+          </button>
+        )}
+        {canRecover && onFork && !isConnectionRecoveryError && (
           <button
             type="button"
             onClick={onFork}

--- a/packages/core/src/extensions/change-marker.ts
+++ b/packages/core/src/extensions/change-marker.ts
@@ -1,0 +1,54 @@
+export const EXTENSION_CHANGE_MARKER_KEY = "__extensions_change__";
+export const EXTENSION_CHANGE_MARKER_ORG_PREFIX = "__org__:";
+
+export interface ExtensionChangeTarget {
+  owner?: string;
+  orgId?: string;
+}
+
+export function extensionChangeMarkerSession(
+  target: ExtensionChangeTarget,
+): string | null {
+  if (target.owner) return target.owner;
+  if (target.orgId)
+    return `${EXTENSION_CHANGE_MARKER_ORG_PREFIX}${target.orgId}`;
+  return null;
+}
+
+export function extensionChangeMarkerValue(
+  target: ExtensionChangeTarget,
+): Record<string, string> {
+  return {
+    source: "extensions",
+    ...(target.owner ? { owner: target.owner } : {}),
+    ...(target.orgId ? { orgId: target.orgId } : {}),
+  };
+}
+
+export function parseExtensionChangeMarker(
+  sessionId: unknown,
+  value: unknown,
+): ExtensionChangeTarget | null {
+  let parsed: unknown = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      parsed = null;
+    }
+  }
+
+  if (parsed && typeof parsed === "object") {
+    const record = parsed as Record<string, unknown>;
+    const owner = typeof record.owner === "string" ? record.owner : undefined;
+    const orgId = typeof record.orgId === "string" ? record.orgId : undefined;
+    if (owner || orgId) return { owner, orgId };
+  }
+
+  if (typeof sessionId !== "string" || !sessionId) return null;
+  if (sessionId.startsWith(EXTENSION_CHANGE_MARKER_ORG_PREFIX)) {
+    const orgId = sessionId.slice(EXTENSION_CHANGE_MARKER_ORG_PREFIX.length);
+    return orgId ? { orgId } : null;
+  }
+  return { owner: sessionId };
+}

--- a/packages/core/src/extensions/html-shell.spec.ts
+++ b/packages/core/src/extensions/html-shell.spec.ts
@@ -105,6 +105,16 @@ describe("buildExtensionHtml", () => {
     expect(html).toContain('body:has(> [data-extension-padding="none"])');
     expect(html).toContain("body:has(> .agent-native-extension-bleed)");
   });
+
+  it("keeps runtime error toasts dismissible after a fix request", () => {
+    const html = buildExtensionHtml("<div/>", ":root{}", false, "extension-1");
+
+    expect(html).toContain('id="__extension-error-dismiss"');
+    expect(html).toContain("agent-native-extension-error-fix");
+    expect(
+      html.match(/__extension-error-toast'\)\.style\.display = 'none'/g),
+    ).toHaveLength(2);
+  });
 });
 
 describe("extension iframe sandbox attribute (CI guard)", () => {

--- a/packages/core/src/extensions/routes.ts
+++ b/packages/core/src/extensions/routes.ts
@@ -156,7 +156,7 @@ async function dispatch(
       return { error: "name is required" };
     }
     const extension = await createExtension(body);
-    recordChange({ source: "action", type: "change" });
+    recordChange({ source: "extensions", type: "change", key: "*" });
     setResponseStatus(event, 201);
     return extension;
   }
@@ -221,7 +221,7 @@ async function dispatch(
       setResponseStatus(event, 404);
       return { error: "Extension not found" };
     }
-    recordChange({ source: "action", type: "change" });
+    recordChange({ source: "extensions", type: "change", key: "*" });
     return { ok: true, hidden: true };
   }
 
@@ -232,7 +232,7 @@ async function dispatch(
       setResponseStatus(event, 404);
       return { error: "Extension not found" };
     }
-    recordChange({ source: "action", type: "change" });
+    recordChange({ source: "extensions", type: "change", key: "*" });
     return { ok: true, hidden: false };
   }
 
@@ -264,7 +264,7 @@ async function dispatch(
       setResponseStatus(event, 404);
       return { error: "Extension not found" };
     }
-    recordChange({ source: "action", type: "change" });
+    recordChange({ source: "extensions", type: "change", key: "*" });
     return result;
   }
 
@@ -275,7 +275,7 @@ async function dispatch(
       setResponseStatus(event, 404);
       return { error: "Extension not found" };
     }
-    recordChange({ source: "action", type: "change" });
+    recordChange({ source: "extensions", type: "change", key: "*" });
     return { ok: true };
   }
 

--- a/packages/core/src/extensions/routes.ts
+++ b/packages/core/src/extensions/routes.ts
@@ -8,7 +8,6 @@ import {
 } from "h3";
 import { readBody } from "../server/h3-helpers.js";
 import { getSession } from "../server/auth.js";
-import { recordChange } from "../server/poll.js";
 import {
   runWithRequestContext,
   getRequestOrgId,
@@ -156,7 +155,6 @@ async function dispatch(
       return { error: "name is required" };
     }
     const extension = await createExtension(body);
-    recordChange({ source: "extensions", type: "change", key: "*" });
     setResponseStatus(event, 201);
     return extension;
   }
@@ -221,7 +219,6 @@ async function dispatch(
       setResponseStatus(event, 404);
       return { error: "Extension not found" };
     }
-    recordChange({ source: "extensions", type: "change", key: "*" });
     return { ok: true, hidden: true };
   }
 
@@ -232,7 +229,6 @@ async function dispatch(
       setResponseStatus(event, 404);
       return { error: "Extension not found" };
     }
-    recordChange({ source: "extensions", type: "change", key: "*" });
     return { ok: true, hidden: false };
   }
 
@@ -264,7 +260,6 @@ async function dispatch(
       setResponseStatus(event, 404);
       return { error: "Extension not found" };
     }
-    recordChange({ source: "extensions", type: "change", key: "*" });
     return result;
   }
 
@@ -275,7 +270,6 @@ async function dispatch(
       setResponseStatus(event, 404);
       return { error: "Extension not found" };
     }
-    recordChange({ source: "extensions", type: "change", key: "*" });
     return { ok: true };
   }
 

--- a/packages/core/src/extensions/schema.ts
+++ b/packages/core/src/extensions/schema.ts
@@ -138,6 +138,7 @@ export const EXTENSION_DATA_DROP_OLD_INDEX_SQL_PG = `DROP INDEX IF EXISTS tool_d
 
 export const EXTENSIONS_OWNER_INDEX_SQL = `CREATE INDEX IF NOT EXISTS tools_owner_idx ON tools (owner_email)`;
 export const EXTENSIONS_ORG_INDEX_SQL = `CREATE INDEX IF NOT EXISTS tools_org_idx ON tools (org_id)`;
+export const EXTENSIONS_UPDATED_INDEX_SQL = `CREATE INDEX IF NOT EXISTS tools_updated_at_idx ON tools (updated_at)`;
 export const EXTENSION_SHARES_RESOURCE_INDEX_SQL = `CREATE INDEX IF NOT EXISTS tool_shares_resource_idx ON tool_shares (resource_id)`;
 
 export const EXTENSION_HIDES_CREATE_SQL = `CREATE TABLE IF NOT EXISTS tool_hidden_extensions (

--- a/packages/core/src/extensions/store.spec.ts
+++ b/packages/core/src/extensions/store.spec.ts
@@ -20,6 +20,7 @@ describe("extensions/store", () => {
     vi.doMock("../db/client.js", () => ({
       getDbExec: () => client,
       getDialect: () => "sqlite",
+      intType: () => "INTEGER",
       isPostgres: () => false,
       retryOnDdlRace: <T>(fn: () => Promise<T>) => fn(),
     }));
@@ -68,6 +69,7 @@ describe("extensions/store", () => {
     vi.doMock("../db/client.js", () => ({
       getDbExec: () => client,
       getDialect: () => "sqlite",
+      intType: () => "INTEGER",
       isPostgres: () => false,
       retryOnDdlRace: <T>(fn: () => Promise<T>) => fn(),
     }));
@@ -106,6 +108,7 @@ describe("extensions/store", () => {
     vi.doMock("../db/client.js", () => ({
       getDbExec: () => client,
       getDialect: () => "sqlite",
+      intType: () => "INTEGER",
       isPostgres: () => false,
       retryOnDdlRace: <T>(fn: () => Promise<T>) => fn(),
     }));
@@ -143,6 +146,7 @@ describe("extensions/store", () => {
     vi.doMock("../db/client.js", () => ({
       getDbExec: () => client,
       getDialect: () => "sqlite",
+      intType: () => "INTEGER",
       isPostgres: () => false,
       retryOnDdlRace: <T>(fn: () => Promise<T>) => fn(),
     }));
@@ -176,6 +180,60 @@ describe("extensions/store", () => {
     expect(insertedRows[0]).toMatchObject({ visibility: "private" });
   });
 
+  it("surfaces extension marker persistence failures", async () => {
+    const insertedRows: unknown[] = [];
+    const db = {
+      insert: vi.fn(() => ({
+        values: vi.fn(async (row: unknown) => {
+          insertedRows.push(row);
+        }),
+      })),
+    };
+    const client = {
+      execute: vi.fn(async () => ({ rows: [], rowsAffected: 0 })),
+    };
+    const appStatePut = vi.fn(async () => {
+      throw new Error("marker unavailable");
+    });
+
+    vi.doMock("../application-state/store.js", () => ({
+      appStatePut,
+    }));
+    vi.doMock("../db/client.js", () => ({
+      getDbExec: () => client,
+      getDialect: () => "sqlite",
+      intType: () => "INTEGER",
+      isPostgres: () => false,
+      retryOnDdlRace: <T>(fn: () => Promise<T>) => fn(),
+    }));
+    vi.doMock("../db/create-get-db.js", () => ({
+      createGetDb: () => () => db,
+    }));
+    vi.doMock("../sharing/registry.js", () => ({
+      registerShareableResource: vi.fn(),
+    }));
+
+    const { runWithRequestContext } =
+      await import("../server/request-context.js");
+    const { createExtension } = await import("./store.js");
+
+    await expect(
+      runWithRequestContext({ userEmail: "owner@example.com" }, () =>
+        createExtension({
+          name: "Foobar",
+          content: "<div>Foobar</div>",
+        }),
+      ),
+    ).rejects.toThrow("marker unavailable");
+
+    expect(insertedRows).toHaveLength(1);
+    expect(appStatePut).toHaveBeenCalledWith(
+      "owner@example.com",
+      "__extensions_change__",
+      expect.objectContaining({ owner: "owner@example.com" }),
+    );
+  });
+
   it("refuses to flip an existing extension to public visibility", async () => {
     // Defense in depth — the framework `set-resource-visibility` action
     // already rejects 'public' for extensions, but `updateExtension` is also
@@ -189,6 +247,7 @@ describe("extensions/store", () => {
     vi.doMock("../db/client.js", () => ({
       getDbExec: () => client,
       getDialect: () => "sqlite",
+      intType: () => "INTEGER",
       isPostgres: () => false,
       retryOnDdlRace: <T>(fn: () => Promise<T>) => fn(),
     }));

--- a/packages/core/src/extensions/store.ts
+++ b/packages/core/src/extensions/store.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
+import { appStatePut } from "../application-state/store.js";
 import { getDbExec, isPostgres, retryOnDdlRace } from "../db/client.js";
 import { createGetDb } from "../db/create-get-db.js";
+import { recordChange } from "../server/poll.js";
 import {
   accessFilter,
   assertAccess,
@@ -38,6 +40,12 @@ import {
   EXTENSION_CONSENTS_CREATE_SQL_PG,
   EXTENSION_CONSENTS_VIEWER_INDEX_SQL,
 } from "./schema.js";
+import {
+  EXTENSION_CHANGE_MARKER_KEY,
+  extensionChangeMarkerSession,
+  extensionChangeMarkerValue,
+  type ExtensionChangeTarget,
+} from "./change-marker.js";
 
 const getDb = createGetDb({ extensions, extensionShares, extensionHides });
 
@@ -232,6 +240,101 @@ export interface ExtensionRow {
   visibility: "private" | "org" | "public";
 }
 
+function targetKey(target: ExtensionChangeTarget): string | null {
+  if (target.owner) return `owner:${target.owner}`;
+  if (target.orgId) return `org:${target.orgId}`;
+  return null;
+}
+
+function addExtensionChangeTarget(
+  targets: Map<string, ExtensionChangeTarget>,
+  target: ExtensionChangeTarget,
+): void {
+  const key = targetKey(target);
+  if (key) targets.set(key, target);
+}
+
+async function extensionChangeTargetsForRow(
+  row: ExtensionRow,
+): Promise<ExtensionChangeTarget[]> {
+  const targets = new Map<string, ExtensionChangeTarget>();
+  addExtensionChangeTarget(targets, { owner: row.ownerEmail });
+  if (row.visibility === "org" && row.orgId) {
+    addExtensionChangeTarget(targets, { orgId: row.orgId });
+  }
+
+  const db = getDb();
+  const shares = (await db
+    .select({
+      principalType: extensionShares.principalType,
+      principalId: extensionShares.principalId,
+    })
+    .from(extensionShares)
+    .where(eq(extensionShares.resourceId, row.id))) as Array<{
+    principalType: "user" | "org";
+    principalId: string;
+  }>;
+
+  for (const share of shares) {
+    if (share.principalType === "user") {
+      addExtensionChangeTarget(targets, { owner: share.principalId });
+    } else if (share.principalType === "org") {
+      addExtensionChangeTarget(targets, { orgId: share.principalId });
+    }
+  }
+
+  return Array.from(targets.values());
+}
+
+async function extensionChangeTargetsForId(
+  id: string,
+): Promise<ExtensionChangeTarget[]> {
+  const db = getDb();
+  const rows = await db.select().from(extensions).where(eq(extensions.id, id));
+  const row = rows[0] as ExtensionRow | undefined;
+  return row ? extensionChangeTargetsForRow(row) : [];
+}
+
+function dedupeExtensionChangeTargets(
+  targets: ExtensionChangeTarget[],
+): ExtensionChangeTarget[] {
+  const unique = new Map<string, ExtensionChangeTarget>();
+  for (const target of targets) {
+    const key = targetKey(target);
+    if (key) unique.set(key, target);
+  }
+  return Array.from(unique.values());
+}
+
+async function notifyExtensionChanged(
+  targets: ExtensionChangeTarget[],
+): Promise<void> {
+  const uniqueTargets = dedupeExtensionChangeTargets(targets);
+  if (uniqueTargets.length === 0) return;
+
+  for (const target of uniqueTargets) {
+    recordChange({
+      source: "extensions",
+      type: "change",
+      key: "*",
+      ...(target.owner ? { owner: target.owner } : {}),
+      ...(target.orgId ? { orgId: target.orgId } : {}),
+    });
+  }
+
+  await Promise.allSettled(
+    uniqueTargets.map(async (target) => {
+      const sessionId = extensionChangeMarkerSession(target);
+      if (!sessionId) return;
+      await appStatePut(
+        sessionId,
+        EXTENSION_CHANGE_MARKER_KEY,
+        extensionChangeMarkerValue(target),
+      );
+    }),
+  );
+}
+
 export interface ListExtensionsOptions {
   includeHidden?: boolean;
 }
@@ -289,6 +392,7 @@ export async function createExtension(
     visibility: "private",
   };
   await db.insert(extensions).values(row);
+  await notifyExtensionChanged([{ owner: row.ownerEmail }]);
   return row;
 }
 
@@ -320,6 +424,7 @@ export async function updateExtension(
     );
   }
   const db = getDb();
+  const beforeTargets = await extensionChangeTargetsForId(id);
   const updates: Record<string, unknown> = {
     updatedAt: new Date().toISOString(),
   };
@@ -329,7 +434,14 @@ export async function updateExtension(
   if (data.visibility !== undefined) updates.visibility = data.visibility;
   await db.update(extensions).set(updates).where(eq(extensions.id, id));
   const rows = await db.select().from(extensions).where(eq(extensions.id, id));
-  return (rows[0] as ExtensionRow) ?? null;
+  const row = (rows[0] as ExtensionRow) ?? null;
+  if (row) {
+    await notifyExtensionChanged([
+      ...beforeTargets,
+      ...(await extensionChangeTargetsForRow(row)),
+    ]);
+  }
+  return row;
 }
 
 export interface UpdateExtensionContentOpts {
@@ -362,12 +474,20 @@ export async function updateExtensionContent(
     return null;
   }
 
+  const beforeTargets = await extensionChangeTargetsForId(id);
   await db
     .update(extensions)
     .set({ content: newContent, updatedAt: new Date().toISOString() })
     .where(eq(extensions.id, id));
   const rows = await db.select().from(extensions).where(eq(extensions.id, id));
-  return (rows[0] as ExtensionRow) ?? null;
+  const row = (rows[0] as ExtensionRow) ?? null;
+  if (row) {
+    await notifyExtensionChanged([
+      ...beforeTargets,
+      ...(await extensionChangeTargetsForRow(row)),
+    ]);
+  }
+  return row;
 }
 
 export async function deleteExtension(id: string): Promise<boolean> {
@@ -375,7 +495,9 @@ export async function deleteExtension(id: string): Promise<boolean> {
   await assertAccess("extension", id, "admin");
   const db = getDb();
   const rows = await db.select().from(extensions).where(eq(extensions.id, id));
-  if (!rows[0]) return false;
+  const row = rows[0] as ExtensionRow | undefined;
+  if (!row) return false;
+  const targets = await extensionChangeTargetsForRow(row);
   await db.delete(extensionShares).where(eq(extensionShares.resourceId, id));
   await db.delete(extensionHides).where(eq(extensionHides.extensionId, id));
   await getDbExec().execute({
@@ -385,6 +507,7 @@ export async function deleteExtension(id: string): Promise<boolean> {
   const { cascadeDeleteExtensionSlots } = await import("./slots/store.js");
   await cascadeDeleteExtensionSlots(id);
   await db.delete(extensions).where(eq(extensions.id, id));
+  await notifyExtensionChanged(targets);
   return true;
 }
 
@@ -416,6 +539,7 @@ export async function hideExtension(id: string): Promise<boolean> {
       ON CONFLICT (owner_email, tool_id) DO NOTHING`,
     args: [randomUUID(), id, userEmail, now],
   });
+  await notifyExtensionChanged([{ owner: userEmail }]);
   return true;
 }
 
@@ -428,5 +552,6 @@ export async function unhideExtension(id: string): Promise<boolean> {
     sql: `DELETE FROM tool_hidden_extensions WHERE tool_id = ? AND owner_email = ?`,
     args: [id, userEmail],
   });
+  await notifyExtensionChanged([{ owner: userEmail }]);
   return true;
 }

--- a/packages/core/src/extensions/store.ts
+++ b/packages/core/src/extensions/store.ts
@@ -31,6 +31,7 @@ import {
   EXTENSION_DATA_DROP_OLD_INDEX_SQL_PG,
   EXTENSIONS_OWNER_INDEX_SQL,
   EXTENSIONS_ORG_INDEX_SQL,
+  EXTENSIONS_UPDATED_INDEX_SQL,
   EXTENSION_SHARES_RESOURCE_INDEX_SQL,
   EXTENSION_HIDES_CREATE_SQL,
   EXTENSION_HIDES_CREATE_SQL_PG,
@@ -84,6 +85,7 @@ export async function ensureExtensionsTables(): Promise<void> {
       );
       await retryOnDdlRace(() => client.execute(EXTENSIONS_OWNER_INDEX_SQL));
       await retryOnDdlRace(() => client.execute(EXTENSIONS_ORG_INDEX_SQL));
+      await retryOnDdlRace(() => client.execute(EXTENSIONS_UPDATED_INDEX_SQL));
       await retryOnDdlRace(() =>
         client.execute(EXTENSION_SHARES_RESOURCE_INDEX_SQL),
       );
@@ -329,7 +331,7 @@ async function notifyExtensionChanged(
     });
   }
 
-  await Promise.allSettled(
+  await Promise.all(
     uniqueTargets.map(async (target) => {
       const sessionId = extensionChangeMarkerSession(target);
       if (!sessionId) return;

--- a/packages/core/src/extensions/store.ts
+++ b/packages/core/src/extensions/store.ts
@@ -295,6 +295,13 @@ async function extensionChangeTargetsForId(
   return row ? extensionChangeTargetsForRow(row) : [];
 }
 
+export async function getExtensionChangeTargets(
+  id: string,
+): Promise<ExtensionChangeTarget[]> {
+  await ensureExtensionsTables();
+  return extensionChangeTargetsForId(id);
+}
+
 function dedupeExtensionChangeTargets(
   targets: ExtensionChangeTarget[],
 ): ExtensionChangeTarget[] {
@@ -333,6 +340,17 @@ async function notifyExtensionChanged(
       );
     }),
   );
+}
+
+export async function notifyExtensionChangeForResource(
+  id: string,
+  beforeTargets: ExtensionChangeTarget[] = [],
+): Promise<void> {
+  await ensureExtensionsTables();
+  await notifyExtensionChanged([
+    ...beforeTargets,
+    ...(await extensionChangeTargetsForId(id)),
+  ]);
 }
 
 export interface ListExtensionsOptions {

--- a/packages/core/src/server/poll-handler.spec.ts
+++ b/packages/core/src/server/poll-handler.spec.ts
@@ -220,7 +220,25 @@ describe("poll handler", () => {
         owner: "test@example.com",
       }),
     ]);
-    expect(executedSql()).not.toContain("FROM tools WHERE updated_at > ?");
+    const toolRowQueries = mockExecute.mock.calls
+      .map(([query]) => query)
+      .filter((query: any) => {
+        const sql = typeof query === "string" ? query : query?.sql;
+        return (
+          typeof sql === "string" &&
+          sql.includes("SELECT id, owner_email") &&
+          sql.includes("FROM tools")
+        );
+      });
+    const latestToolRowQuery = toolRowQueries[toolRowQueries.length - 1] as {
+      sql: string;
+      args?: unknown[];
+    };
+    expect(latestToolRowQuery.sql).toContain("FROM tools WHERE updated_at > ?");
+    expect(latestToolRowQuery.args).toEqual(["2026-05-15T12:00:00.000Z"]);
+    expect(executedSql()).not.toContain(
+      "SELECT id, owner_email, org_id, visibility, updated_at FROM tools ORDER BY updated_at ASC",
+    );
   });
 
   it("emits extension changes from durable markers for delete and hide fallback", async () => {

--- a/packages/core/src/server/poll-handler.spec.ts
+++ b/packages/core/src/server/poll-handler.spec.ts
@@ -68,7 +68,7 @@ describe("poll handler", () => {
       if (
         sql.includes("FROM application_state") &&
         sql.includes("key = ?") &&
-        sql.includes("updated_at > ?")
+        sql.includes("SELECT session_id, value, updated_at")
       ) {
         return { rows: [] };
       }
@@ -166,7 +166,7 @@ describe("poll handler", () => {
       if (
         sql.includes("FROM application_state") &&
         sql.includes("key = ?") &&
-        sql.includes("updated_at > ?")
+        sql.includes("SELECT session_id, value, updated_at")
       ) {
         return { rows: [] };
       }
@@ -183,12 +183,7 @@ describe("poll handler", () => {
         sql.includes("SELECT id, owner_email") &&
         sql.includes("FROM tools")
       ) {
-        const since = Number(query.args?.[0]) || 0;
-        return {
-          rows: extensionRows.filter(
-            (row) => Date.parse(String(row.updated_at)) > since,
-          ),
-        };
+        return { rows: extensionRows };
       }
       if (sql.includes("FROM tool_shares")) {
         return { rows: [] };
@@ -225,6 +220,7 @@ describe("poll handler", () => {
         owner: "test@example.com",
       }),
     ]);
+    expect(executedSql()).not.toContain("FROM tools WHERE updated_at > ?");
   });
 
   it("emits extension changes from durable markers for delete and hide fallback", async () => {
@@ -258,14 +254,9 @@ describe("poll handler", () => {
       if (
         sql.includes("FROM application_state") &&
         sql.includes("key = ?") &&
-        sql.includes("updated_at > ?")
+        sql.includes("SELECT session_id, value, updated_at")
       ) {
-        const since = Number(query.args?.[1]) || 0;
-        return {
-          rows: extensionMarkerRows.filter(
-            (row) => Number(row.updated_at) > since,
-          ),
-        };
+        return { rows: extensionMarkerRows };
       }
       if (
         sql.includes("SELECT session_id, key, updated_at") &&
@@ -324,5 +315,14 @@ describe("poll handler", () => {
         owner: "test@example.com",
       }),
     ]);
+    expect(executedSql()).not.toContain(
+      "application_state WHERE key = ? AND updated_at > ?",
+    );
   });
 });
+
+function executedSql(): string {
+  return mockExecute.mock.calls
+    .map(([query]) => (typeof query === "string" ? query : (query?.sql ?? "")))
+    .join("\n");
+}

--- a/packages/core/src/server/poll-handler.spec.ts
+++ b/packages/core/src/server/poll-handler.spec.ts
@@ -32,6 +32,7 @@ describe("poll handler", () => {
   it("emits screen-refresh events when the refresh marker changes", async () => {
     let appStateTs = 1_000;
     let settingsTs = 900;
+    let extensionsTs = 800;
     let refreshTs = 500;
     let refreshValue = JSON.stringify({ scope: "initial" });
     let appStateRows = [
@@ -52,6 +53,9 @@ describe("poll handler", () => {
       }
       if (sql.includes("MAX(updated_at)") && sql.includes("settings")) {
         return { rows: [{ max_ts: settingsTs }] };
+      }
+      if (sql.includes("MAX(updated_at)") && sql.includes("tools")) {
+        return { rows: [{ max_ts: extensionsTs }] };
       }
       if (
         sql.includes("SELECT session_id, key, updated_at") &&
@@ -77,6 +81,7 @@ describe("poll handler", () => {
     vi.setSystemTime(101_500);
     appStateTs = 2_000;
     settingsTs = 900;
+    extensionsTs = 800;
     refreshTs = 2_000;
     refreshValue = JSON.stringify({ scope: "documents" });
     appStateRows = [
@@ -106,5 +111,57 @@ describe("poll handler", () => {
         }),
       ]),
     );
+  });
+
+  it("emits extension changes from the tools table for serverless fallback polling", async () => {
+    let appStateTs = 1_000;
+    let settingsTs = 900;
+    let extensionsTs = "2026-05-15T12:00:00.000Z";
+
+    mockExecute.mockImplementation(async (query: any) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      if (
+        sql.includes("MAX(updated_at)") &&
+        sql.includes("application_state")
+      ) {
+        return { rows: [{ max_ts: appStateTs }] };
+      }
+      if (sql.includes("MAX(updated_at)") && sql.includes("settings")) {
+        return { rows: [{ max_ts: settingsTs }] };
+      }
+      if (sql.includes("MAX(updated_at)") && sql.includes("tools")) {
+        return { rows: [{ max_ts: extensionsTs }] };
+      }
+      if (
+        sql.includes("SELECT session_id, key, updated_at") &&
+        sql.includes("application_state")
+      ) {
+        return { rows: [] };
+      }
+      if (sql.includes("WHERE key = ?")) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+
+    const { createPollHandler } = await import("./poll.js");
+    const handler = createPollHandler() as any;
+
+    const baseline = await handler({ query: { since: "0" } });
+    expect(baseline.events).toEqual([]);
+
+    vi.setSystemTime(101_500);
+    extensionsTs = "2026-05-15T12:00:01.250Z";
+
+    const next = await handler({ query: { since: String(baseline.version) } });
+
+    expect(next.version).toBeGreaterThan(baseline.version);
+    expect(next.events).toEqual([
+      expect.objectContaining({
+        source: "extensions",
+        type: "change",
+        key: "*",
+      }),
+    ]);
   });
 });

--- a/packages/core/src/server/poll-handler.spec.ts
+++ b/packages/core/src/server/poll-handler.spec.ts
@@ -33,6 +33,7 @@ describe("poll handler", () => {
     let appStateTs = 1_000;
     let settingsTs = 900;
     let extensionsTs = 800;
+    let extensionMarkerTs = 0;
     let refreshTs = 500;
     let refreshValue = JSON.stringify({ scope: "initial" });
     let appStateRows = [
@@ -47,6 +48,13 @@ describe("poll handler", () => {
       const sql = typeof query === "string" ? query : query.sql;
       if (
         sql.includes("MAX(updated_at)") &&
+        sql.includes("application_state") &&
+        sql.includes("WHERE key = ?")
+      ) {
+        return { rows: [{ max_ts: extensionMarkerTs }] };
+      }
+      if (
+        sql.includes("MAX(updated_at)") &&
         sql.includes("application_state")
       ) {
         return { rows: [{ max_ts: appStateTs }] };
@@ -56,6 +64,13 @@ describe("poll handler", () => {
       }
       if (sql.includes("MAX(updated_at)") && sql.includes("tools")) {
         return { rows: [{ max_ts: extensionsTs }] };
+      }
+      if (
+        sql.includes("FROM application_state") &&
+        sql.includes("key = ?") &&
+        sql.includes("updated_at > ?")
+      ) {
+        return { rows: [] };
       }
       if (
         sql.includes("SELECT session_id, key, updated_at") &&
@@ -68,6 +83,12 @@ describe("poll handler", () => {
       }
       if (sql.includes("WHERE key = ?")) {
         return { rows: [{ updated_at: refreshTs, value: refreshValue }] };
+      }
+      if (
+        sql.includes("SELECT id, owner_email") &&
+        sql.includes("FROM tools")
+      ) {
+        return { rows: [] };
       }
       return { rows: [] };
     });
@@ -82,6 +103,7 @@ describe("poll handler", () => {
     appStateTs = 2_000;
     settingsTs = 900;
     extensionsTs = 800;
+    extensionMarkerTs = 0;
     refreshTs = 2_000;
     refreshValue = JSON.stringify({ scope: "documents" });
     appStateRows = [
@@ -113,13 +135,22 @@ describe("poll handler", () => {
     );
   });
 
-  it("emits extension changes from the tools table for serverless fallback polling", async () => {
+  it("emits scoped extension changes from the tools table fallback", async () => {
     let appStateTs = 1_000;
     let settingsTs = 900;
     let extensionsTs = "2026-05-15T12:00:00.000Z";
+    let extensionMarkerTs = 700;
+    let extensionRows: Array<Record<string, unknown>> = [];
 
     mockExecute.mockImplementation(async (query: any) => {
       const sql = typeof query === "string" ? query : query.sql;
+      if (
+        sql.includes("MAX(updated_at)") &&
+        sql.includes("application_state") &&
+        sql.includes("WHERE key = ?")
+      ) {
+        return { rows: [{ max_ts: extensionMarkerTs }] };
+      }
       if (
         sql.includes("MAX(updated_at)") &&
         sql.includes("application_state")
@@ -133,12 +164,33 @@ describe("poll handler", () => {
         return { rows: [{ max_ts: extensionsTs }] };
       }
       if (
+        sql.includes("FROM application_state") &&
+        sql.includes("key = ?") &&
+        sql.includes("updated_at > ?")
+      ) {
+        return { rows: [] };
+      }
+      if (
         sql.includes("SELECT session_id, key, updated_at") &&
         sql.includes("application_state")
       ) {
         return { rows: [] };
       }
       if (sql.includes("WHERE key = ?")) {
+        return { rows: [] };
+      }
+      if (
+        sql.includes("SELECT id, owner_email") &&
+        sql.includes("FROM tools")
+      ) {
+        const since = Number(query.args?.[0]) || 0;
+        return {
+          rows: extensionRows.filter(
+            (row) => Date.parse(String(row.updated_at)) > since,
+          ),
+        };
+      }
+      if (sql.includes("FROM tool_shares")) {
         return { rows: [] };
       }
       return { rows: [] };
@@ -152,6 +204,15 @@ describe("poll handler", () => {
 
     vi.setSystemTime(101_500);
     extensionsTs = "2026-05-15T12:00:01.250Z";
+    extensionRows = [
+      {
+        id: "ext-1",
+        owner_email: "test@example.com",
+        org_id: "org-1",
+        visibility: "private",
+        updated_at: extensionsTs,
+      },
+    ];
 
     const next = await handler({ query: { since: String(baseline.version) } });
 
@@ -161,6 +222,106 @@ describe("poll handler", () => {
         source: "extensions",
         type: "change",
         key: "*",
+        owner: "test@example.com",
+      }),
+    ]);
+  });
+
+  it("emits extension changes from durable markers for delete and hide fallback", async () => {
+    let appStateTs = 1_000;
+    let settingsTs = 900;
+    let extensionsTs = 800;
+    let extensionMarkerTs = 700;
+    let extensionMarkerRows: Array<Record<string, unknown>> = [];
+
+    mockExecute.mockImplementation(async (query: any) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      if (
+        sql.includes("MAX(updated_at)") &&
+        sql.includes("application_state") &&
+        sql.includes("WHERE key = ?")
+      ) {
+        return { rows: [{ max_ts: extensionMarkerTs }] };
+      }
+      if (
+        sql.includes("MAX(updated_at)") &&
+        sql.includes("application_state")
+      ) {
+        return { rows: [{ max_ts: appStateTs }] };
+      }
+      if (sql.includes("MAX(updated_at)") && sql.includes("settings")) {
+        return { rows: [{ max_ts: settingsTs }] };
+      }
+      if (sql.includes("MAX(updated_at)") && sql.includes("tools")) {
+        return { rows: [{ max_ts: extensionsTs }] };
+      }
+      if (
+        sql.includes("FROM application_state") &&
+        sql.includes("key = ?") &&
+        sql.includes("updated_at > ?")
+      ) {
+        const since = Number(query.args?.[1]) || 0;
+        return {
+          rows: extensionMarkerRows.filter(
+            (row) => Number(row.updated_at) > since,
+          ),
+        };
+      }
+      if (
+        sql.includes("SELECT session_id, key, updated_at") &&
+        sql.includes("application_state")
+      ) {
+        const since = Number(query.args?.[0]) || 0;
+        return {
+          rows: extensionMarkerRows
+            .filter((row) => Number(row.updated_at) > since)
+            .map((row) => ({
+              session_id: row.session_id,
+              key: "__extensions_change__",
+              updated_at: row.updated_at,
+            })),
+        };
+      }
+      if (sql.includes("WHERE key = ?")) {
+        return { rows: [] };
+      }
+      if (
+        sql.includes("SELECT id, owner_email") &&
+        sql.includes("FROM tools")
+      ) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+
+    const { createPollHandler } = await import("./poll.js");
+    const handler = createPollHandler() as any;
+
+    const baseline = await handler({ query: { since: "0" } });
+    expect(baseline.events).toEqual([]);
+
+    vi.setSystemTime(101_500);
+    appStateTs = 2_000;
+    extensionMarkerTs = 2_000;
+    extensionMarkerRows = [
+      {
+        session_id: "test@example.com",
+        value: JSON.stringify({
+          source: "extensions",
+          owner: "test@example.com",
+        }),
+        updated_at: 2_000,
+      },
+    ];
+
+    const next = await handler({ query: { since: String(baseline.version) } });
+
+    expect(next.events).toEqual([
+      expect.objectContaining({
+        source: "extensions",
+        type: "change",
+        key: "*",
+        owner: "test@example.com",
       }),
     ]);
   });

--- a/packages/core/src/server/poll.ts
+++ b/packages/core/src/server/poll.ts
@@ -205,14 +205,10 @@ function recordExtensionChanges(targets: ExtensionChangeTarget[]): void {
   }
 }
 
-async function readExtensionTargetsForRow(
-  db: {
-    execute: (
-      query: string | { sql: string; args?: unknown[] },
-    ) => Promise<{ rows: Array<Record<string, unknown>> }>;
-  },
+function extensionTargetsForRow(
   row: Record<string, unknown>,
-): Promise<ExtensionChangeTarget[]> {
+  shareRows: Array<Record<string, unknown>>,
+): ExtensionChangeTarget[] {
   const targets = new Map<string, ExtensionChangeTarget>();
   const owner = typeof row.owner_email === "string" ? row.owner_email : "";
   const orgId = typeof row.org_id === "string" ? row.org_id : "";
@@ -222,30 +218,60 @@ async function readExtensionTargetsForRow(
   if (owner) addExtensionTarget(targets, { owner });
   if (visibility === "org" && orgId) addExtensionTarget(targets, { orgId });
 
-  const extensionId = typeof row.id === "string" ? row.id : "";
-  if (extensionId) {
+  for (const share of shareRows) {
+    const principalType =
+      typeof share.principal_type === "string" ? share.principal_type : "";
+    const principalId =
+      typeof share.principal_id === "string" ? share.principal_id : "";
+    if (principalType === "user" && principalId) {
+      addExtensionTarget(targets, { owner: principalId });
+    } else if (principalType === "org" && principalId) {
+      addExtensionTarget(targets, { orgId: principalId });
+    }
+  }
+
+  return Array.from(targets.values());
+}
+
+async function readExtensionTargetsForRows(
+  db: {
+    execute: (
+      query: string | { sql: string; args?: unknown[] },
+    ) => Promise<{ rows: Array<Record<string, unknown>> }>;
+  },
+  rows: Array<Record<string, unknown>>,
+): Promise<ExtensionChangeTarget[][]> {
+  const ids = rows
+    .map((row) => (typeof row.id === "string" ? row.id : ""))
+    .filter(Boolean);
+  const sharesByResourceId = new Map<string, Array<Record<string, unknown>>>();
+
+  if (ids.length > 0) {
     try {
+      const placeholders = ids.map(() => "?").join(", ");
       const shareResult = await db.execute({
-        sql: "SELECT principal_type, principal_id FROM tool_shares WHERE resource_id = ?",
-        args: [extensionId],
+        sql: `SELECT resource_id, principal_type, principal_id FROM tool_shares WHERE resource_id IN (${placeholders})`,
+        args: ids,
       });
       for (const share of shareResult.rows) {
-        const principalType =
-          typeof share.principal_type === "string" ? share.principal_type : "";
-        const principalId =
-          typeof share.principal_id === "string" ? share.principal_id : "";
-        if (principalType === "user" && principalId) {
-          addExtensionTarget(targets, { owner: principalId });
-        } else if (principalType === "org" && principalId) {
-          addExtensionTarget(targets, { orgId: principalId });
-        }
+        const resourceId =
+          typeof share.resource_id === "string" ? share.resource_id : "";
+        if (!resourceId) continue;
+        const bucket = sharesByResourceId.get(resourceId) ?? [];
+        bucket.push(share);
+        sharesByResourceId.set(resourceId, bucket);
       }
     } catch {
       // Sharing tables are optional during early app initialization.
     }
   }
 
-  return Array.from(targets.values());
+  return rows.map((row) =>
+    extensionTargetsForRow(
+      row,
+      sharesByResourceId.get(typeof row.id === "string" ? row.id : "") ?? [],
+    ),
+  );
 }
 
 /** Get all changes after a given version. */
@@ -450,9 +476,11 @@ async function checkExternalDbChanges(): Promise<void> {
         _lastExtensionsTs,
       );
       if (_lastExtensionsTs > 0) {
-        for (const row of extensionResult.rows) {
-          recordExtensionChanges(await readExtensionTargetsForRow(db, row));
-        }
+        const targetsByRow = await readExtensionTargetsForRows(
+          db,
+          extensionResult.rows,
+        );
+        for (const targets of targetsByRow) recordExtensionChanges(targets);
       }
       _lastExtensionsTs = extensionsTs;
     }

--- a/packages/core/src/server/poll.ts
+++ b/packages/core/src/server/poll.ts
@@ -17,6 +17,11 @@ import { EventEmitter } from "node:events";
 import { defineEventHandler, getQuery, setResponseStatus } from "h3";
 import { getAppStateEmitter } from "../application-state/emitter.js";
 import { getDbExec } from "../db/client.js";
+import {
+  EXTENSION_CHANGE_MARKER_KEY,
+  parseExtensionChangeMarker,
+  type ExtensionChangeTarget,
+} from "../extensions/change-marker.js";
 import { getSettingsEmitter } from "../settings/store.js";
 import { getSession } from "./auth.js";
 
@@ -60,6 +65,7 @@ let _lastDbCheck = 0;
 let _lastAppStateTs = 0;
 let _lastSettingsTs = 0;
 let _lastExtensionsTs = 0;
+let _lastExtensionMarkerTs = 0;
 
 /**
  * Tracks the latest updated_at seen on the `__screen_refresh__` key in
@@ -99,7 +105,7 @@ function timestampValue(value: unknown): number {
 async function readMaxUpdatedAt(
   db: {
     execute: (
-      query: string,
+      query: string | { sql: string; args?: unknown[] },
     ) => Promise<{ rows: Array<Record<string, unknown>> }>;
   },
   table: "application_state" | "settings" | "tools",
@@ -111,6 +117,22 @@ async function readMaxUpdatedAt(
     return timestampValue(result.rows[0]?.max_ts);
   } catch {
     // Optional framework tables may not exist in every app yet.
+    return 0;
+  }
+}
+
+async function readExtensionMarkerMaxUpdatedAt(db: {
+  execute: (
+    query: string | { sql: string; args?: unknown[] },
+  ) => Promise<{ rows: Array<Record<string, unknown>> }>;
+}): Promise<number> {
+  try {
+    const result = await db.execute({
+      sql: "SELECT MAX(updated_at) as max_ts FROM application_state WHERE key = ?",
+      args: [EXTENSION_CHANGE_MARKER_KEY],
+    });
+    return timestampValue(result.rows[0]?.max_ts);
+  } catch {
     return 0;
   }
 }
@@ -153,6 +175,77 @@ export function recordChange(event: {
     _buffer.splice(0, _buffer.length - MAX_BUFFER);
   }
   _pollEmitter.emit(POLL_CHANGE_EVENT, entry);
+}
+
+function extensionTargetKey(target: ExtensionChangeTarget): string | null {
+  if (target.owner) return `owner:${target.owner}`;
+  if (target.orgId) return `org:${target.orgId}`;
+  return null;
+}
+
+function addExtensionTarget(
+  targets: Map<string, ExtensionChangeTarget>,
+  target: ExtensionChangeTarget,
+): void {
+  const key = extensionTargetKey(target);
+  if (key) targets.set(key, target);
+}
+
+function recordExtensionChanges(targets: ExtensionChangeTarget[]): void {
+  const uniqueTargets = new Map<string, ExtensionChangeTarget>();
+  for (const target of targets) addExtensionTarget(uniqueTargets, target);
+  for (const target of uniqueTargets.values()) {
+    recordChange({
+      source: "extensions",
+      type: "change",
+      key: "*",
+      ...(target.owner ? { owner: target.owner } : {}),
+      ...(target.orgId ? { orgId: target.orgId } : {}),
+    });
+  }
+}
+
+async function readExtensionTargetsForRow(
+  db: {
+    execute: (
+      query: string | { sql: string; args?: unknown[] },
+    ) => Promise<{ rows: Array<Record<string, unknown>> }>;
+  },
+  row: Record<string, unknown>,
+): Promise<ExtensionChangeTarget[]> {
+  const targets = new Map<string, ExtensionChangeTarget>();
+  const owner = typeof row.owner_email === "string" ? row.owner_email : "";
+  const orgId = typeof row.org_id === "string" ? row.org_id : "";
+  const visibility =
+    typeof row.visibility === "string" ? row.visibility : "private";
+
+  if (owner) addExtensionTarget(targets, { owner });
+  if (visibility === "org" && orgId) addExtensionTarget(targets, { orgId });
+
+  const extensionId = typeof row.id === "string" ? row.id : "";
+  if (extensionId) {
+    try {
+      const shareResult = await db.execute({
+        sql: "SELECT principal_type, principal_id FROM tool_shares WHERE resource_id = ?",
+        args: [extensionId],
+      });
+      for (const share of shareResult.rows) {
+        const principalType =
+          typeof share.principal_type === "string" ? share.principal_type : "";
+        const principalId =
+          typeof share.principal_id === "string" ? share.principal_id : "";
+        if (principalType === "user" && principalId) {
+          addExtensionTarget(targets, { owner: principalId });
+        } else if (principalType === "org" && principalId) {
+          addExtensionTarget(targets, { orgId: principalId });
+        }
+      }
+    } catch {
+      // Sharing tables are optional during early app initialization.
+    }
+  }
+
+  return Array.from(targets.values());
 }
 
 /** Get all changes after a given version. */
@@ -203,27 +296,36 @@ async function seedVersionFromDb(): Promise<void> {
   try {
     const db = getDbExec();
 
-    const [appTs, settingsTs, extensionsTs, refreshResult] = await Promise.all([
-      readMaxUpdatedAt(db, "application_state"),
-      readMaxUpdatedAt(db, "settings"),
-      readMaxUpdatedAt(db, "tools"),
-      db
-        .execute({
-          sql: "SELECT updated_at FROM application_state WHERE key = ?",
-          args: [SCREEN_REFRESH_KEY],
-        })
-        .catch(() => ({ rows: [] })),
-    ]);
+    const [appTs, settingsTs, extensionsTs, extensionMarkerTs, refreshResult] =
+      await Promise.all([
+        readMaxUpdatedAt(db, "application_state"),
+        readMaxUpdatedAt(db, "settings"),
+        readMaxUpdatedAt(db, "tools"),
+        readExtensionMarkerMaxUpdatedAt(db),
+        db
+          .execute({
+            sql: "SELECT updated_at FROM application_state WHERE key = ?",
+            args: [SCREEN_REFRESH_KEY],
+          })
+          .catch(() => ({ rows: [] })),
+      ]);
 
     const refreshTs = timestampValue(refreshResult.rows[0]?.updated_at);
 
     // Seed version — never decrease an already-set value
-    _version = Math.max(_version, appTs, settingsTs, extensionsTs);
+    _version = Math.max(
+      _version,
+      appTs,
+      settingsTs,
+      extensionsTs,
+      extensionMarkerTs,
+    );
 
     // Set baselines so checkExternalDbChanges detects future writes
     _lastAppStateTs = appTs;
     _lastSettingsTs = settingsTs;
     _lastExtensionsTs = extensionsTs;
+    _lastExtensionMarkerTs = extensionMarkerTs;
     _lastScreenRefreshTs = refreshTs;
     _screenRefreshInitialized = true;
   } catch {
@@ -259,6 +361,7 @@ async function checkExternalDbChanges(): Promise<void> {
       if (_lastAppStateTs > 0) {
         for (const row of appResult.rows) {
           const key = typeof row.key === "string" ? row.key : "*";
+          if (key === EXTENSION_CHANGE_MARKER_KEY) continue;
           const owner =
             typeof row.session_id === "string" ? row.session_id : undefined;
           recordChange({
@@ -302,6 +405,29 @@ async function checkExternalDbChanges(): Promise<void> {
       _lastScreenRefreshTs = refreshTs;
     }
 
+    // Extension mutations write a durable marker row so delete and hide/unhide
+    // operations are visible across serverless invocations. Translate those
+    // marker rows back into extension-source events for targeted client
+    // invalidation while preserving user/org scope.
+    const extensionMarkerResult = await db.execute({
+      sql: "SELECT session_id, value, updated_at FROM application_state WHERE key = ? AND updated_at > ? ORDER BY updated_at ASC",
+      args: [EXTENSION_CHANGE_MARKER_KEY, _lastExtensionMarkerTs],
+    });
+    if (extensionMarkerResult.rows.length > 0) {
+      const markerTs = extensionMarkerResult.rows.reduce(
+        (max, row) => Math.max(max, timestampValue(row.updated_at)),
+        _lastExtensionMarkerTs,
+      );
+      if (_lastExtensionMarkerTs > 0) {
+        recordExtensionChanges(
+          extensionMarkerResult.rows
+            .map((row) => parseExtensionChangeMarker(row.session_id, row.value))
+            .filter((target): target is ExtensionChangeTarget => !!target),
+        );
+      }
+      _lastExtensionMarkerTs = markerTs;
+    }
+
     // Check settings for external writes
     const settingsTs = await readMaxUpdatedAt(db, "settings");
     if (settingsTs > _lastSettingsTs) {
@@ -311,14 +437,22 @@ async function checkExternalDbChanges(): Promise<void> {
       _lastSettingsTs = settingsTs;
     }
 
-    // Extension rows live in the legacy physical `tools` table. Agent-created
-    // extensions are often updated from a different serverless invocation than
-    // the browser's poll request, so an in-memory recordChange() alone is not
-    // enough to keep open previews fresh.
-    const extensionsTs = await readMaxUpdatedAt(db, "tools");
-    if (extensionsTs > _lastExtensionsTs) {
+    // Extension rows live in the legacy physical `tools` table. Keep this as a
+    // compatibility fallback for direct table writes, but scope events to the
+    // resource owner/share targets instead of broadcasting deployment-wide.
+    const extensionResult = await db.execute({
+      sql: "SELECT id, owner_email, org_id, visibility, updated_at FROM tools WHERE updated_at > ? ORDER BY updated_at ASC",
+      args: [_lastExtensionsTs],
+    });
+    if (extensionResult.rows.length > 0) {
+      const extensionsTs = extensionResult.rows.reduce(
+        (max, row) => Math.max(max, timestampValue(row.updated_at)),
+        _lastExtensionsTs,
+      );
       if (_lastExtensionsTs > 0) {
-        recordChange({ source: "extensions", type: "change", key: "*" });
+        for (const row of extensionResult.rows) {
+          recordExtensionChanges(await readExtensionTargetsForRow(db, row));
+        }
       }
       _lastExtensionsTs = extensionsTs;
     }

--- a/packages/core/src/server/poll.ts
+++ b/packages/core/src/server/poll.ts
@@ -65,6 +65,7 @@ let _lastDbCheck = 0;
 let _lastAppStateTs = 0;
 let _lastSettingsTs = 0;
 let _lastExtensionsTs = 0;
+let _lastExtensionsUpdatedAt: string | number | undefined;
 let _lastExtensionMarkerTs = 0;
 
 /**
@@ -102,6 +103,31 @@ function timestampValue(value: unknown): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+function sqlWatermarkValue(value: unknown): string | number | undefined {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return undefined;
+}
+
+async function readMaxUpdatedAtRaw(
+  db: {
+    execute: (
+      query: string | { sql: string; args?: unknown[] },
+    ) => Promise<{ rows: Array<Record<string, unknown>> }>;
+  },
+  table: "application_state" | "settings" | "tools",
+): Promise<unknown> {
+  try {
+    const result = await db.execute(
+      `SELECT MAX(updated_at) as max_ts FROM ${table}`,
+    );
+    return result.rows[0]?.max_ts;
+  } catch {
+    // Optional framework tables may not exist in every app yet.
+    return undefined;
+  }
+}
+
 async function readMaxUpdatedAt(
   db: {
     execute: (
@@ -110,15 +136,7 @@ async function readMaxUpdatedAt(
   },
   table: "application_state" | "settings" | "tools",
 ): Promise<number> {
-  try {
-    const result = await db.execute(
-      `SELECT MAX(updated_at) as max_ts FROM ${table}`,
-    );
-    return timestampValue(result.rows[0]?.max_ts);
-  } catch {
-    // Optional framework tables may not exist in every app yet.
-    return 0;
-  }
+  return timestampValue(await readMaxUpdatedAtRaw(db, table));
 }
 
 async function readExtensionMarkerMaxUpdatedAt(db: {
@@ -322,20 +340,26 @@ async function seedVersionFromDb(): Promise<void> {
   try {
     const db = getDbExec();
 
-    const [appTs, settingsTs, extensionsTs, extensionMarkerTs, refreshResult] =
-      await Promise.all([
-        readMaxUpdatedAt(db, "application_state"),
-        readMaxUpdatedAt(db, "settings"),
-        readMaxUpdatedAt(db, "tools"),
-        readExtensionMarkerMaxUpdatedAt(db),
-        db
-          .execute({
-            sql: "SELECT updated_at FROM application_state WHERE key = ?",
-            args: [SCREEN_REFRESH_KEY],
-          })
-          .catch(() => ({ rows: [] })),
-      ]);
+    const [
+      appTs,
+      settingsTs,
+      extensionsMaxUpdatedAt,
+      extensionMarkerTs,
+      refreshResult,
+    ] = await Promise.all([
+      readMaxUpdatedAt(db, "application_state"),
+      readMaxUpdatedAt(db, "settings"),
+      readMaxUpdatedAtRaw(db, "tools"),
+      readExtensionMarkerMaxUpdatedAt(db),
+      db
+        .execute({
+          sql: "SELECT updated_at FROM application_state WHERE key = ?",
+          args: [SCREEN_REFRESH_KEY],
+        })
+        .catch(() => ({ rows: [] })),
+    ]);
 
+    const extensionsTs = timestampValue(extensionsMaxUpdatedAt);
     const refreshTs = timestampValue(refreshResult.rows[0]?.updated_at);
 
     // Seed version — never decrease an already-set value
@@ -351,6 +375,7 @@ async function seedVersionFromDb(): Promise<void> {
     _lastAppStateTs = appTs;
     _lastSettingsTs = settingsTs;
     _lastExtensionsTs = extensionsTs;
+    _lastExtensionsUpdatedAt = sqlWatermarkValue(extensionsMaxUpdatedAt);
     _lastExtensionMarkerTs = extensionMarkerTs;
     _lastScreenRefreshTs = refreshTs;
     _screenRefreshInitialized = true;
@@ -435,17 +460,14 @@ async function checkExternalDbChanges(): Promise<void> {
     // operations are visible across serverless invocations. Translate those
     // marker rows back into extension-source events for targeted client
     // invalidation while preserving user/org scope.
-    const extensionMarkerResult = await db.execute({
-      sql: "SELECT session_id, value, updated_at FROM application_state WHERE key = ? ORDER BY updated_at ASC",
-      args: [EXTENSION_CHANGE_MARKER_KEY],
-    });
-    const changedExtensionMarkers = extensionMarkerResult.rows.filter(
-      (row) => timestampValue(row.updated_at) > _lastExtensionMarkerTs,
-    );
-    if (changedExtensionMarkers.length > 0) {
-      const markerTs = changedExtensionMarkers.reduce(
-        (max, row) => Math.max(max, timestampValue(row.updated_at)),
-        _lastExtensionMarkerTs,
+    const extensionMarkerTs = await readExtensionMarkerMaxUpdatedAt(db);
+    if (extensionMarkerTs > _lastExtensionMarkerTs) {
+      const extensionMarkerResult = await db.execute({
+        sql: "SELECT session_id, value, updated_at FROM application_state WHERE key = ? ORDER BY updated_at ASC",
+        args: [EXTENSION_CHANGE_MARKER_KEY],
+      });
+      const changedExtensionMarkers = extensionMarkerResult.rows.filter(
+        (row) => timestampValue(row.updated_at) > _lastExtensionMarkerTs,
       );
       if (_lastExtensionMarkerTs > 0) {
         recordExtensionChanges(
@@ -454,7 +476,7 @@ async function checkExternalDbChanges(): Promise<void> {
             .filter((target): target is ExtensionChangeTarget => !!target),
         );
       }
-      _lastExtensionMarkerTs = markerTs;
+      _lastExtensionMarkerTs = extensionMarkerTs;
     }
 
     // Check settings for external writes
@@ -469,17 +491,22 @@ async function checkExternalDbChanges(): Promise<void> {
     // Extension rows live in the legacy physical `tools` table. Keep this as a
     // compatibility fallback for direct table writes, but scope events to the
     // resource owner/share targets instead of broadcasting deployment-wide.
-    const extensionResult = await db.execute({
-      sql: "SELECT id, owner_email, org_id, visibility, updated_at FROM tools ORDER BY updated_at ASC",
-      args: [],
-    });
-    const changedExtensionRows = extensionResult.rows.filter(
-      (row) => timestampValue(row.updated_at) > _lastExtensionsTs,
-    );
-    if (changedExtensionRows.length > 0) {
-      const extensionsTs = changedExtensionRows.reduce(
-        (max, row) => Math.max(max, timestampValue(row.updated_at)),
-        _lastExtensionsTs,
+    const extensionsMaxUpdatedAt = await readMaxUpdatedAtRaw(db, "tools");
+    const extensionsTs = timestampValue(extensionsMaxUpdatedAt);
+    if (extensionsTs > _lastExtensionsTs) {
+      const since = _lastExtensionsUpdatedAt;
+      const extensionResult =
+        since === undefined
+          ? await db.execute({
+              sql: "SELECT id, owner_email, org_id, visibility, updated_at FROM tools ORDER BY updated_at ASC",
+              args: [],
+            })
+          : await db.execute({
+              sql: "SELECT id, owner_email, org_id, visibility, updated_at FROM tools WHERE updated_at > ? ORDER BY updated_at ASC",
+              args: [since],
+            });
+      const changedExtensionRows = extensionResult.rows.filter(
+        (row) => timestampValue(row.updated_at) > _lastExtensionsTs,
       );
       if (_lastExtensionsTs > 0) {
         const targetsByRow = await readExtensionTargetsForRows(
@@ -489,6 +516,7 @@ async function checkExternalDbChanges(): Promise<void> {
         for (const targets of targetsByRow) recordExtensionChanges(targets);
       }
       _lastExtensionsTs = extensionsTs;
+      _lastExtensionsUpdatedAt = sqlWatermarkValue(extensionsMaxUpdatedAt);
     }
   } catch {
     // Tables may not exist yet — ignore

--- a/packages/core/src/server/poll.ts
+++ b/packages/core/src/server/poll.ts
@@ -436,17 +436,20 @@ async function checkExternalDbChanges(): Promise<void> {
     // marker rows back into extension-source events for targeted client
     // invalidation while preserving user/org scope.
     const extensionMarkerResult = await db.execute({
-      sql: "SELECT session_id, value, updated_at FROM application_state WHERE key = ? AND updated_at > ? ORDER BY updated_at ASC",
-      args: [EXTENSION_CHANGE_MARKER_KEY, _lastExtensionMarkerTs],
+      sql: "SELECT session_id, value, updated_at FROM application_state WHERE key = ? ORDER BY updated_at ASC",
+      args: [EXTENSION_CHANGE_MARKER_KEY],
     });
-    if (extensionMarkerResult.rows.length > 0) {
-      const markerTs = extensionMarkerResult.rows.reduce(
+    const changedExtensionMarkers = extensionMarkerResult.rows.filter(
+      (row) => timestampValue(row.updated_at) > _lastExtensionMarkerTs,
+    );
+    if (changedExtensionMarkers.length > 0) {
+      const markerTs = changedExtensionMarkers.reduce(
         (max, row) => Math.max(max, timestampValue(row.updated_at)),
         _lastExtensionMarkerTs,
       );
       if (_lastExtensionMarkerTs > 0) {
         recordExtensionChanges(
-          extensionMarkerResult.rows
+          changedExtensionMarkers
             .map((row) => parseExtensionChangeMarker(row.session_id, row.value))
             .filter((target): target is ExtensionChangeTarget => !!target),
         );
@@ -467,18 +470,21 @@ async function checkExternalDbChanges(): Promise<void> {
     // compatibility fallback for direct table writes, but scope events to the
     // resource owner/share targets instead of broadcasting deployment-wide.
     const extensionResult = await db.execute({
-      sql: "SELECT id, owner_email, org_id, visibility, updated_at FROM tools WHERE updated_at > ? ORDER BY updated_at ASC",
-      args: [_lastExtensionsTs],
+      sql: "SELECT id, owner_email, org_id, visibility, updated_at FROM tools ORDER BY updated_at ASC",
+      args: [],
     });
-    if (extensionResult.rows.length > 0) {
-      const extensionsTs = extensionResult.rows.reduce(
+    const changedExtensionRows = extensionResult.rows.filter(
+      (row) => timestampValue(row.updated_at) > _lastExtensionsTs,
+    );
+    if (changedExtensionRows.length > 0) {
+      const extensionsTs = changedExtensionRows.reduce(
         (max, row) => Math.max(max, timestampValue(row.updated_at)),
         _lastExtensionsTs,
       );
       if (_lastExtensionsTs > 0) {
         const targetsByRow = await readExtensionTargetsForRows(
           db,
-          extensionResult.rows,
+          changedExtensionRows,
         );
         for (const targets of targetsByRow) recordExtensionChanges(targets);
       }

--- a/packages/core/src/server/poll.ts
+++ b/packages/core/src/server/poll.ts
@@ -59,6 +59,7 @@ let _versionSeeded = false;
 let _lastDbCheck = 0;
 let _lastAppStateTs = 0;
 let _lastSettingsTs = 0;
+let _lastExtensionsTs = 0;
 
 /**
  * Tracks the latest updated_at seen on the `__screen_refresh__` key in
@@ -84,6 +85,34 @@ function wireLocalEmitters(): void {
   getSettingsEmitter().on("settings", (event) => {
     recordChange(event);
   });
+}
+
+function timestampValue(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string") return 0;
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) return numeric;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+async function readMaxUpdatedAt(
+  db: {
+    execute: (
+      query: string,
+    ) => Promise<{ rows: Array<Record<string, unknown>> }>;
+  },
+  table: "application_state" | "settings" | "tools",
+): Promise<number> {
+  try {
+    const result = await db.execute(
+      `SELECT MAX(updated_at) as max_ts FROM ${table}`,
+    );
+    return timestampValue(result.rows[0]?.max_ts);
+  } catch {
+    // Optional framework tables may not exist in every app yet.
+    return 0;
+  }
 }
 
 /** Get the current global version counter. */
@@ -174,25 +203,27 @@ async function seedVersionFromDb(): Promise<void> {
   try {
     const db = getDbExec();
 
-    const [appResult, settingsResult, refreshResult] = await Promise.all([
-      db.execute("SELECT MAX(updated_at) as max_ts FROM application_state"),
-      db.execute("SELECT MAX(updated_at) as max_ts FROM settings"),
-      db.execute({
-        sql: "SELECT updated_at FROM application_state WHERE key = ?",
-        args: [SCREEN_REFRESH_KEY],
-      }),
+    const [appTs, settingsTs, extensionsTs, refreshResult] = await Promise.all([
+      readMaxUpdatedAt(db, "application_state"),
+      readMaxUpdatedAt(db, "settings"),
+      readMaxUpdatedAt(db, "tools"),
+      db
+        .execute({
+          sql: "SELECT updated_at FROM application_state WHERE key = ?",
+          args: [SCREEN_REFRESH_KEY],
+        })
+        .catch(() => ({ rows: [] })),
     ]);
 
-    const appTs = Number(appResult.rows[0]?.max_ts) || 0;
-    const settingsTs = Number(settingsResult.rows[0]?.max_ts) || 0;
-    const refreshTs = Number(refreshResult.rows[0]?.updated_at) || 0;
+    const refreshTs = timestampValue(refreshResult.rows[0]?.updated_at);
 
     // Seed version — never decrease an already-set value
-    _version = Math.max(_version, appTs, settingsTs);
+    _version = Math.max(_version, appTs, settingsTs, extensionsTs);
 
     // Set baselines so checkExternalDbChanges detects future writes
     _lastAppStateTs = appTs;
     _lastSettingsTs = settingsTs;
+    _lastExtensionsTs = extensionsTs;
     _lastScreenRefreshTs = refreshTs;
     _screenRefreshInitialized = true;
   } catch {
@@ -222,7 +253,7 @@ async function checkExternalDbChanges(): Promise<void> {
     });
     if (appResult.rows.length > 0) {
       const appTs = appResult.rows.reduce(
-        (max, row) => Math.max(max, Number(row.updated_at) || 0),
+        (max, row) => Math.max(max, timestampValue(row.updated_at)),
         _lastAppStateTs,
       );
       if (_lastAppStateTs > 0) {
@@ -249,7 +280,7 @@ async function checkExternalDbChanges(): Promise<void> {
       sql: "SELECT updated_at, value FROM application_state WHERE key = ?",
       args: [SCREEN_REFRESH_KEY],
     });
-    const refreshTs = Number(refreshResult.rows[0]?.updated_at) || 0;
+    const refreshTs = timestampValue(refreshResult.rows[0]?.updated_at);
     if (!_screenRefreshInitialized) {
       _lastScreenRefreshTs = refreshTs;
       _screenRefreshInitialized = true;
@@ -272,15 +303,24 @@ async function checkExternalDbChanges(): Promise<void> {
     }
 
     // Check settings for external writes
-    const settingsResult = await db.execute(
-      "SELECT MAX(updated_at) as max_ts FROM settings",
-    );
-    const settingsTs = Number(settingsResult.rows[0]?.max_ts) || 0;
+    const settingsTs = await readMaxUpdatedAt(db, "settings");
     if (settingsTs > _lastSettingsTs) {
       if (_lastSettingsTs > 0) {
         recordChange({ source: "settings", type: "change", key: "*" });
       }
       _lastSettingsTs = settingsTs;
+    }
+
+    // Extension rows live in the legacy physical `tools` table. Agent-created
+    // extensions are often updated from a different serverless invocation than
+    // the browser's poll request, so an in-memory recordChange() alone is not
+    // enough to keep open previews fresh.
+    const extensionsTs = await readMaxUpdatedAt(db, "tools");
+    if (extensionsTs > _lastExtensionsTs) {
+      if (_lastExtensionsTs > 0) {
+        recordChange({ source: "extensions", type: "change", key: "*" });
+      }
+      _lastExtensionsTs = extensionsTs;
     }
   } catch {
     // Tables may not exist yet — ignore

--- a/packages/core/src/sharing/actions/extension-change.ts
+++ b/packages/core/src/sharing/actions/extension-change.ts
@@ -1,0 +1,22 @@
+import type { ExtensionChangeTarget } from "../../extensions/change-marker.js";
+
+export async function getExtensionShareChangeTargets(
+  resourceType: string,
+  resourceId: string,
+): Promise<ExtensionChangeTarget[]> {
+  if (resourceType !== "extension") return [];
+  const { getExtensionChangeTargets } =
+    await import("../../extensions/store.js");
+  return getExtensionChangeTargets(resourceId);
+}
+
+export async function notifyExtensionShareChanged(
+  resourceType: string,
+  resourceId: string,
+  beforeTargets: ExtensionChangeTarget[],
+): Promise<void> {
+  if (resourceType !== "extension") return;
+  const { notifyExtensionChangeForResource } =
+    await import("../../extensions/store.js");
+  await notifyExtensionChangeForResource(resourceId, beforeTargets);
+}

--- a/packages/core/src/sharing/actions/set-resource-visibility.ts
+++ b/packages/core/src/sharing/actions/set-resource-visibility.ts
@@ -4,6 +4,10 @@ import { defineAction } from "../../action.js";
 import { getRequestOrgId } from "../../server/request-context.js";
 import { assertAccess, ForbiddenError } from "../access.js";
 import { requireShareableResource } from "../registry.js";
+import {
+  getExtensionShareChangeTargets,
+  notifyExtensionShareChanged,
+} from "./extension-change.js";
 
 export default defineAction({
   description:
@@ -28,6 +32,10 @@ export default defineAction({
       args.resourceId,
       "admin",
     );
+    const beforeExtensionTargets = await getExtensionShareChangeTargets(
+      args.resourceType,
+      args.resourceId,
+    );
     const db = reg.getDb() as any;
     const update: Record<string, unknown> = { visibility: args.visibility };
     const currentOrgId = getRequestOrgId();
@@ -38,6 +46,11 @@ export default defineAction({
       .update(reg.resourceTable)
       .set(update)
       .where(eq(reg.resourceTable.id, args.resourceId));
+    await notifyExtensionShareChanged(
+      args.resourceType,
+      args.resourceId,
+      beforeExtensionTargets,
+    );
     return { ok: true, visibility: args.visibility };
   },
 });

--- a/packages/core/src/sharing/actions/share-resource.ts
+++ b/packages/core/src/sharing/actions/share-resource.ts
@@ -8,6 +8,10 @@ import { sendEmail, isEmailConfigured } from "../../server/email.js";
 import { renderEmail, emailStrong } from "../../server/email-template.js";
 import { getAppProductionUrl } from "../../server/app-url.js";
 import { getDbExec } from "../../db/client.js";
+import {
+  getExtensionShareChangeTargets,
+  notifyExtensionShareChanged,
+} from "./extension-change.js";
 
 export function isSyntheticQaEmail(email: string): boolean {
   const trimmed = email.trim().toLowerCase();
@@ -158,6 +162,10 @@ export default defineAction({
     );
     const actor = getRequestUserEmail();
     if (!actor) throw new ForbiddenError("Not signed in");
+    const beforeExtensionTargets = await getExtensionShareChangeTargets(
+      args.resourceType,
+      args.resourceId,
+    );
 
     if (reg.requireOrgMemberForUserShares) {
       const resourceOrgId = access.resource?.orgId as string | undefined | null;
@@ -203,6 +211,11 @@ export default defineAction({
         .update(reg.sharesTable)
         .set({ role: args.role })
         .where(eq(reg.sharesTable.id, existing.id));
+      await notifyExtensionShareChanged(
+        args.resourceType,
+        args.resourceId,
+        beforeExtensionTargets,
+      );
       return { id: existing.id, updated: true };
     }
 
@@ -216,6 +229,11 @@ export default defineAction({
       createdBy: actor,
       createdAt: new Date().toISOString(),
     });
+    await notifyExtensionShareChanged(
+      args.resourceType,
+      args.resourceId,
+      beforeExtensionTargets,
+    );
 
     if (
       args.notify !== false &&

--- a/packages/core/src/sharing/actions/unshare-resource.ts
+++ b/packages/core/src/sharing/actions/unshare-resource.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 import { defineAction } from "../../action.js";
 import { assertAccess } from "../access.js";
 import { requireShareableResource } from "../registry.js";
+import {
+  getExtensionShareChangeTargets,
+  notifyExtensionShareChanged,
+} from "./extension-change.js";
 
 export default defineAction({
   description:
@@ -18,6 +22,10 @@ export default defineAction({
   run: async (args) => {
     const reg = requireShareableResource(args.resourceType);
     await assertAccess(args.resourceType, args.resourceId, "admin");
+    const beforeExtensionTargets = await getExtensionShareChangeTargets(
+      args.resourceType,
+      args.resourceId,
+    );
     const db = reg.getDb() as any;
     await db
       .delete(reg.sharesTable)
@@ -28,6 +36,11 @@ export default defineAction({
           eq(reg.sharesTable.principalId, args.principalId),
         ),
       );
+    await notifyExtensionShareChanged(
+      args.resourceType,
+      args.resourceId,
+      beforeExtensionTargets,
+    );
     return { ok: true };
   },
 });


### PR DESCRIPTION
## Summary
- emit extension-specific change events for extension mutations
- watch the backing tools table in fallback polling so open previews refresh after agent-side edits
- add recovery guidance for repeated agent connection failures

## Verification
- pnpm --dir packages/core exec vitest --run src/server/poll-handler.spec.ts src/extensions/html-shell.spec.ts
- pnpm --filter @agent-native/core typecheck

## Notes
- Checked the linked feedback error ID in accessible Sentry projects; no matching event was found.