### PR TITLE
fix(auth): isolate session cookies per app in local dev

### DIFF
--- a/.changeset/dev-cookie-isolation.md
+++ b/.changeset/dev-cookie-isolation.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix cross-app auth interference when running two templates side-by-side in local dev. Browsers scope cookies by host only (not port), so two `localhost:*` dev servers previously stomped on the same `an_session` cookie and Better Auth `an.*` cookies, signing each other out. The framework now derives a per-app cookie suffix from `npm_package_name` / `package.json:name` in dev (`NODE_ENV !== "production"`), producing `an_session_<app>` and Better Auth prefix `an_<app>`. Production is unchanged — explicit `APP_NAME`, `COOKIE_DOMAIN`, and workspace mode still drive cookie naming as before.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -2489,6 +2489,68 @@ describe("server/auth", () => {
       );
     });
   });
+
+  describe("COOKIE_NAME — dev-mode auto-suffix", () => {
+    it("uses npm_package_name as the suffix in dev when APP_NAME is unset", async () => {
+      vi.stubEnv("APP_NAME", "");
+      vi.stubEnv("COOKIE_DOMAIN", "");
+      vi.stubEnv("AGENT_NATIVE_WORKSPACE", "");
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("npm_package_name", "calendar");
+      const { COOKIE_NAME, BETTER_AUTH_COOKIE_PREFIX } =
+        await import("./auth.js");
+      expect(COOKIE_NAME).toBe("an_session_calendar");
+      expect(BETTER_AUTH_COOKIE_PREFIX).toBe("an_calendar");
+    });
+
+    it("keeps the unsuffixed cookie in production even when npm_package_name is set", async () => {
+      vi.stubEnv("APP_NAME", "");
+      vi.stubEnv("COOKIE_DOMAIN", "");
+      vi.stubEnv("AGENT_NATIVE_WORKSPACE", "");
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("npm_package_name", "calendar");
+      const { COOKIE_NAME, BETTER_AUTH_COOKIE_PREFIX } =
+        await import("./auth.js");
+      expect(COOKIE_NAME).toBe("an_session");
+      expect(BETTER_AUTH_COOKIE_PREFIX).toBe("an");
+    });
+
+    it("explicit APP_NAME wins over the dev fallback", async () => {
+      vi.stubEnv("APP_NAME", "mail");
+      vi.stubEnv("COOKIE_DOMAIN", "");
+      vi.stubEnv("AGENT_NATIVE_WORKSPACE", "");
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("npm_package_name", "calendar");
+      const { COOKIE_NAME, BETTER_AUTH_COOKIE_PREFIX } =
+        await import("./auth.js");
+      expect(COOKIE_NAME).toBe("an_session_mail");
+      expect(BETTER_AUTH_COOKIE_PREFIX).toBe("an_mail");
+    });
+
+    it("COOKIE_DOMAIN keeps the shared `an_session` cookie name", async () => {
+      vi.stubEnv("APP_NAME", "");
+      vi.stubEnv("AGENT_NATIVE_WORKSPACE", "");
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("COOKIE_DOMAIN", ".agent-native.com");
+      vi.stubEnv("npm_package_name", "calendar");
+      const { COOKIE_NAME, BETTER_AUTH_COOKIE_PREFIX } =
+        await import("./auth.js");
+      expect(COOKIE_NAME).toBe("an_session");
+      expect(BETTER_AUTH_COOKIE_PREFIX).toBe("an");
+    });
+
+    it("workspace mode keeps `an_session_workspace`", async () => {
+      vi.stubEnv("APP_NAME", "");
+      vi.stubEnv("COOKIE_DOMAIN", "");
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
+      vi.stubEnv("npm_package_name", "calendar");
+      const { COOKIE_NAME, BETTER_AUTH_COOKIE_PREFIX } =
+        await import("./auth.js");
+      expect(COOKIE_NAME).toBe("an_session_workspace");
+      expect(BETTER_AUTH_COOKIE_PREFIX).toBe("an");
+    });
+  });
 });
 
 // --- Mock helpers ---

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1,4 +1,6 @@
 import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import {
   defineEventHandler,
   getMethod,
@@ -276,10 +278,49 @@ export interface AuthOptions {
  * signs the user into all of them. Per-app suffixes would defeat the
  * shared cookie since each subdomain reads a different name.
  */
-const APP_NAME_SLUG = (process.env.APP_NAME || "")
-  .toLowerCase()
-  .replace(/[^a-z0-9]+/g, "_")
-  .replace(/^_+|_+$/g, "");
+function readPackageJsonName(): string {
+  try {
+    const pkgPath = path.join(process.cwd(), "package.json");
+    const raw = fs.readFileSync(pkgPath, "utf8");
+    const parsed = JSON.parse(raw) as { name?: unknown };
+    return typeof parsed.name === "string" ? parsed.name : "";
+  } catch {
+    return "";
+  }
+}
+
+function slugifyAppName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+/**
+ * Resolve the per-app cookie suffix.
+ *
+ * - Explicit `APP_NAME` wins everywhere (prod + dev).
+ * - In dev only, fall back to `npm_package_name` (set automatically by
+ *   npm/pnpm/yarn/bun when running a script) and then to `package.json:name`
+ *   so two templates running side-by-side on `localhost:<portA>` and
+ *   `localhost:<portB>` do not stomp on a shared `an_session` cookie.
+ *   Browsers scope cookies by host (NOT host+port — RFC 6265), so a single
+ *   `an_session` is shared across every `localhost:*` dev server otherwise.
+ * - In production this fallback is intentionally disabled — switching a
+ *   live deploy from `an_session` to `an_session_<name>` would invalidate
+ *   every existing user session (the server only reads `COOKIE_NAME`).
+ *   Real prod deploys set `APP_NAME` or `COOKIE_DOMAIN` explicitly.
+ */
+function resolveAppNameSlug(): string {
+  const explicit = process.env.APP_NAME;
+  if (explicit) return slugifyAppName(explicit);
+  if (process.env.NODE_ENV === "production") return "";
+  const fromNpm = process.env.npm_package_name;
+  if (fromNpm) return slugifyAppName(fromNpm);
+  return slugifyAppName(readPackageJsonName());
+}
+
+const APP_NAME_SLUG = resolveAppNameSlug();
 const IS_WORKSPACE_MODE = process.env.AGENT_NATIVE_WORKSPACE === "1";
 
 /**
@@ -303,6 +344,17 @@ export const COOKIE_NAME = HAS_COOKIE_DOMAIN
     : APP_NAME_SLUG
       ? `an_session_${APP_NAME_SLUG}`
       : "an_session";
+
+/**
+ * Cookie prefix used by Better Auth. In prod it stays `"an"` so existing
+ * session cookies (`an.session_token`, `an.session_data`, `an.csrf_token`)
+ * keep working. In dev with a resolved slug, it becomes `"an_<slug>"`
+ * so two templates on `localhost` do not collide.
+ */
+export const BETTER_AUTH_COOKIE_PREFIX =
+  HAS_COOKIE_DOMAIN || IS_WORKSPACE_MODE || !APP_NAME_SLUG
+    ? "an"
+    : `an_${APP_NAME_SLUG}`;
 
 /**
  * Cookie domain attribute spread into every `setCookie`/`deleteCookie`.

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -18,6 +18,7 @@ import {
   renderVerifySignupEmail,
 } from "./email-templates.js";
 import { getAppProductionUrl } from "./app-url.js";
+import { BETTER_AUTH_COOKIE_PREFIX } from "./auth.js";
 import { getDbExec, isPostgres } from "../db/client.js";
 import { acceptPendingInvitationsForEmail } from "../org/accept-pending.js";
 import { autoJoinDomainMatchingOrgs } from "../org/auto-join-domain.js";
@@ -785,7 +786,7 @@ async function createBetterAuthInstance(
       },
     },
     advanced: {
-      cookiePrefix: "an",
+      cookiePrefix: BETTER_AUTH_COOKIE_PREFIX,
       // Emit `SameSite=None; Secure` when the app is served over HTTPS so
       // session cookies are delivered inside third-party iframes (e.g. the
       // Builder.io editor). Plain-HTTP dev keeps the default (Lax) because


### PR DESCRIPTION
## Summary

- Two agent-native templates running side-by-side on `localhost:<portA>` and `localhost:<portB>` previously stomped on each other's session cookies, signing each other out. Browsers scope cookies by host only (RFC 6265 — not host+port), so both apps shared `an_session` and Better Auth's `an.*` cookies on the `localhost` cookie jar.
- In dev only (`NODE_ENV !== "production"`), the framework now derives a per-app cookie suffix from `npm_package_name` then `package.json:name` when `APP_NAME` is unset. Templates running solo via `pnpm dev` automatically get `an_session_<app>` and Better Auth prefix `an_<app>`, so cookies no longer collide.
- Production is intentionally unchanged. Switching a live deploy's cookie name would invalidate existing sessions (the server only reads `COOKIE_NAME`), so the fallback is gated behind `NODE_ENV !== "production"`. Real deploys with explicit `APP_NAME`, `COOKIE_DOMAIN`, or workspace mode behave exactly as before.

### Behavior matrix

| Scenario                                       | `COOKIE_NAME`                | Better Auth prefix |
| ---------------------------------------------- | ---------------------------- | ------------------ |
| Dev, `APP_NAME` unset, `npm_package_name=mail` | `an_session_mail` *(new)*    | `an_mail` *(new)*  |
| Dev, `APP_NAME=calendar`                       | `an_session_calendar`        | `an_calendar`      |
| `COOKIE_DOMAIN=.agent-native.com`              | `an_session`                 | `an`               |
| `AGENT_NATIVE_WORKSPACE=1`                     | `an_session_workspace`       | `an`               |
| `NODE_ENV=production`, `APP_NAME` unset        | `an_session`                 | `an`               |

## Test plan

- [x] New unit tests in `packages/core/src/server/auth.spec.ts` cover all five scenarios in the matrix (5/5 passing, full suite 100/100)
- [x] `pnpm --filter @agent-native/core typecheck` — no errors in `auth.ts` or `better-auth-instance.ts`
- [ ] Manual browser verification: `cd templates/calendar && pnpm dev` + `cd templates/mail && pnpm dev` in separate terminals; sign in to both in the same browser; confirm distinct cookies (`an_session_calendar`, `an_session_mail`, `an_calendar.session_token`, `an_mail.session_token`) and that signing into one no longer kicks the other out
- [ ] Production smoke: confirm at least one already-deployed app still presents the same `an_session` / `an.*` cookie names it did before (sanity check that no live sessions are invalidated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)