### PR TITLE
feat: cap Postgres pool on serverless + clips desktop Tooltip/app polish

### DIFF
--- a/.changeset/cap-postgres-pool-serverless.md
+++ b/.changeset/cap-postgres-pool-serverless.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Cap the Postgres connection pool to a single connection per instance on serverless runtimes (Netlify Functions / AWS Lambda). Concurrent frozen Lambda instances each holding postgres.js's default 10-connection pool were exhausting Neon/Postgres' connection limit, causing "Max client connections reached" and HTTP 500s on every `/_agent-native/*` route. Long-lived Node servers keep the normal pool.

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -342,6 +342,57 @@ export async function retryOnConnectionError<T>(
 }
 
 // ---------------------------------------------------------------------------
+// Serverless-aware Postgres pool options
+// ---------------------------------------------------------------------------
+
+/**
+ * True on serverless function runtimes (Netlify Functions / AWS Lambda) where
+ * every concurrent request can spin up its own frozen process. Connections
+ * cannot be shared across instances, so each instance must keep its pool tiny
+ * — otherwise dozens of warm Lambdas each holding postgres.js's default
+ * 10-connection pool blow past Neon/Postgres' connection cap and every
+ * `/_agent-native/*` route 500s with "Max client connections reached".
+ */
+export function isServerlessRuntime(): boolean {
+  return (
+    !!process.env.NETLIFY ||
+    !!process.env.AWS_LAMBDA_FUNCTION_NAME ||
+    !!process.env.LAMBDA_TASK_ROOT
+  );
+}
+
+/**
+ * postgres.js pool options tuned per runtime. A serverless instance handles
+ * one request at a time, so a single connection per instance is enough and
+ * bounds total connections to ≈ concurrent-instance count instead of 10× that.
+ * idle_timeout is shortened on serverless so a thawed-but-idle instance
+ * releases its connection quickly. Long-lived Node servers keep the normal
+ * pool for throughput.
+ */
+export function pgPoolOptions(url: string): Record<string, unknown> {
+  const serverless = isServerlessRuntime();
+  return {
+    onnotice: () => {},
+    max: serverless ? 1 : 10,
+    idle_timeout: serverless ? 20 : 240,
+    max_lifetime: 60 * 30,
+    connect_timeout: 10,
+    // Supabase's connection pooler (Transaction mode) requires prepare:false.
+    // Only disable for Supabase URLs to avoid degrading other deployments.
+    ...(url.includes("supabase") ? { prepare: false } : {}),
+  };
+}
+
+/**
+ * Connection cap for the @neondatabase/serverless `Pool`. Same Lambda
+ * accumulation risk as postgres.js — a single connection per instance is
+ * enough on serverless and keeps total connections bounded.
+ */
+export function neonPoolMax(): number {
+  return isServerlessRuntime() ? 1 : 10;
+}
+
+// ---------------------------------------------------------------------------
 // Singleton client — lazy-initialized on first execute() call
 // ---------------------------------------------------------------------------
 
@@ -396,7 +447,7 @@ async function createDbExecInternal(
     // and keeps the same `pg`-compatible query(...) interface we need here.
     if (isNeonUrl(url)) {
       const { Pool } = await import("@neondatabase/serverless");
-      const pool = new Pool({ connectionString: url });
+      const pool = new Pool({ connectionString: url, max: neonPoolMax() });
       // Neon's serverless Pool extends EventEmitter and emits 'error'
       // when its WebSocket connection drops (idle timeout, Lambda
       // suspend, network blip). Without a listener, Node 24 surfaces
@@ -457,18 +508,12 @@ async function createDbExecInternal(
         },
       };
     } else {
-      // Node.js: reuse connection pool.
-      // idle_timeout:240 closes idle connections before Neon's ~5min server-side
-      // timeout, avoiding ECONNRESET when the server hangs up on us.
-      const pool = postgres(url, {
-        onnotice: () => {},
-        idle_timeout: 240,
-        max_lifetime: 60 * 30,
-        connect_timeout: 10,
-        // Supabase's connection pooler (Transaction mode) requires prepare: false.
-        // Only disable for Supabase URLs to avoid degrading other Postgres deployments.
-        ...(url.includes("supabase") ? { prepare: false } : {}),
-      });
+      // Node.js: reuse connection pool. pgPoolOptions caps the pool to a
+      // single connection on serverless (Netlify/Lambda) so concurrent frozen
+      // instances don't exhaust Neon/Postgres' connection limit; idle_timeout
+      // also closes idle connections before Neon's ~5min server-side timeout,
+      // avoiding ECONNRESET when the server hangs up on us.
+      const pool = postgres(url, pgPoolOptions(url));
       if (trackSingletonResources) _pgPool = pool;
 
       return {

--- a/packages/core/src/db/create-get-db.ts
+++ b/packages/core/src/db/create-get-db.ts
@@ -7,6 +7,8 @@ import {
   isLocalSqliteUrl,
   prepareLocalSqliteUrl,
   sqliteFilenameFromUrl,
+  pgPoolOptions,
+  neonPoolMax,
 } from "./client.js";
 
 // Lazy driver loaders — cached promises so dynamic import only runs once.
@@ -102,7 +104,7 @@ export function createGetDb<T extends Record<string, unknown>>(schema: T) {
     if (dialect === "postgres") {
       if (isNeonUrl(url)) {
         _dbReady = getNeonServerlessDrizzle().then(({ drizzle, Pool }) => {
-          const pool = new Pool({ connectionString: url });
+          const pool = new Pool({ connectionString: url, max: neonPoolMax() });
           // Neon Pool emits 'error' on WebSocket drops (idle, Lambda
           // suspend, network). Without a listener Node 24 throws
           // `Unhandled error` as a fatal uncaught exception. The next
@@ -117,13 +119,10 @@ export function createGetDb<T extends Record<string, unknown>>(schema: T) {
         });
       } else {
         _dbReady = getPgDrizzle().then(({ drizzle, postgres }) => {
-          const client = postgres(url, {
-            onnotice: () => {},
-            idle_timeout: 240,
-            max_lifetime: 60 * 30,
-            connect_timeout: 10,
-            ...(url.includes("supabase") ? { prepare: false } : {}),
-          });
+          // pgPoolOptions caps the pool to one connection on serverless so
+          // concurrent frozen Lambda instances don't exhaust Neon/Postgres'
+          // connection limit ("Max client connections reached").
+          const client = postgres(url, pgPoolOptions(url));
           _db = drizzle(client, { schema });
         });
       }

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -15,7 +15,10 @@ export async function createDb(config: DbConfig) {
   if (config.driver === "postgres") {
     const { drizzle: drizzlePg } = await import("drizzle-orm/postgres-js");
     const { default: pg } = await import("postgres");
-    return drizzlePg(pg(config.connectionString));
+    const { pgPoolOptions } = await import("./client.js");
+    return drizzlePg(
+      pg(config.connectionString, pgPoolOptions(config.connectionString)),
+    );
   }
   if (config.driver === "sqlite") {
     const sqlite = new Database(config.filename);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1987,6 +1987,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tabler/icons-react':
         specifier: ^3.26.0
         version: 3.41.1(react@19.2.5)

--- a/templates/clips/desktop/package.json
+++ b/templates/clips/desktop/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tabler/icons-react": "^3.26.0",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-fs": "2.5.1",

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -33,6 +33,7 @@ import {
 } from "./lib/voice-dictation";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { FeedbackButton } from "./components/FeedbackButton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./components/Tooltip";
 import { useFeatureConfig, type LocalRecordingMode } from "./shared/config";
 import {
   IconArrowLeft,
@@ -4324,9 +4325,14 @@ function SettingLabel({
   return (
     <label className="setup-label" htmlFor={htmlFor}>
       <span>{label}</span>
-      <span className="setup-help" title={hint} aria-label={hint} role="img">
-        <IconInfoCircle size={14} stroke={1.75} />
-      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button type="button" className="setup-help" aria-label={hint}>
+            <IconInfoCircle size={14} stroke={1.75} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{hint}</TooltipContent>
+      </Tooltip>
     </label>
   );
 }

--- a/templates/clips/desktop/src/components/Tooltip.tsx
+++ b/templates/clips/desktop/src/components/Tooltip.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+/**
+ * shadcn-style Tooltip for the Tauri tray app.
+ *
+ * Mirrors shadcn/ui's tooltip API (Tooltip / TooltipTrigger / TooltipContent),
+ * but styled with the desktop app's plain-CSS theme tokens instead of Tailwind
+ * — this app has no Tailwind/shadcn build. Radix gives us a portaled,
+ * collision-aware tooltip so it never gets clipped by the small scrollable
+ * settings popover (a hand-rolled `position:absolute` tooltip would), plus
+ * keyboard focus support and an instant show that the slow native
+ * `title="..."` attribute can't provide.
+ */
+
+function TooltipProvider({
+  delayDuration = 150,
+  skipDelayDuration = 300,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      delayDuration={delayDuration}
+      skipDelayDuration={skipDelayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip(
+  props: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>,
+) {
+  // Each Tooltip bundles its own provider so callers don't have to mount one
+  // at the app root (matches shadcn's current tooltip.tsx).
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root {...props} />
+    </TooltipProvider>
+  );
+}
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, children, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={["tooltip-content", className].filter(Boolean).join(" ")}
+      {...props}
+    >
+      {children}
+      <TooltipPrimitive.Arrow className="tooltip-arrow" width={10} height={5} />
+    </TooltipPrimitive.Content>
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1307,14 +1307,86 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
 .setup-help {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
   color: var(--fg-muted);
   opacity: 0.6;
   cursor: help;
   transition: opacity 120ms;
 }
 
-.setup-help:hover {
+.setup-help:hover,
+.setup-help:focus-visible,
+.setup-help[data-state="delayed-open"],
+.setup-help[data-state="instant-open"] {
   opacity: 1;
+}
+
+.setup-help:focus-visible {
+  outline: none;
+  border-radius: 4px;
+  box-shadow: 0 0 0 2px var(--brand-ring);
+}
+
+/* ------------------------------------------------------------------------- */
+/* Tooltip (shadcn-style, Radix-backed)                                       */
+/* ------------------------------------------------------------------------- */
+
+.tooltip-content {
+  z-index: 60;
+  max-width: 260px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--fg);
+  box-shadow: var(--shadow-md);
+  padding: 6px 10px;
+  font-size: 12px;
+  line-height: 1.45;
+  text-align: left;
+  user-select: none;
+  transform-origin: var(--radix-tooltip-content-transform-origin);
+}
+
+.tooltip-content[data-state="delayed-open"],
+.tooltip-content[data-state="instant-open"] {
+  animation: tooltip-in 120ms ease-out;
+}
+
+.tooltip-content[data-state="closed"] {
+  animation: tooltip-out 90ms ease-in;
+}
+
+.tooltip-arrow {
+  fill: var(--bg);
+}
+
+@keyframes tooltip-in {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes tooltip-out {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: scale(0.96);
+  }
 }
 
 .setup-toggle-row {


### PR DESCRIPTION
Concurrent-agent sweep: cap the Postgres connection pool for serverless deploys (db client/create-get-db/index + changeset), and add a clips desktop Tooltip component with app/styles refinements. PR opened so CI + review agents run.