### PR TITLE
fix(external-agents): proxy 401, calendar 404, design handoff, dev@local + review fixes

### DIFF
--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -79,6 +79,19 @@ predictable surface without guessing per-app action names:
 A same-named template action overrides a builtin (template-over-core
 precedence). Disable the set with `MCPConfig.builtinCrossAppTools: false`.
 
+### 1c. Dev vs production tool surface (expect a sparse `tools/list` in plain dev)
+
+In plain local dev (`NODE_ENV=development` and `AGENT_MODE !== "production"`)
+the MCP `tools/list` deliberately exposes only the generic builtins plus
+actions with `publicAgent.requiresAuth === false` — the per-app ingest actions
+(`requiresAuth: true`) and mutating actions (no `publicAgent`) are filtered out
+(`filterPublicAgentActions`). The full per-app surface appears when the request
+is authenticated as a real caller: a deployed/`AGENT_MODE=production` app, or a
+local app reached through `agent-native mcp install` (which provisions an
+`ACCESS_TOKEN` / signed JWT so the caller has an identity). So if `tools/list`
+looks sparse, you are hitting an unauthenticated dev endpoint — install the MCP
+server (or present a token) rather than assuming the action is missing.
+
 ### 2. Add a `link` builder to an action
 
 `defineAction` accepts an optional `link` builder. When set, every MCP/A2A

--- a/.changeset/external-agent-bridge-followup-fixes.md
+++ b/.changeset/external-agent-bridge-followup-fixes.md
@@ -1,0 +1,13 @@
+---
+"@agent-native/core": patch
+---
+
+External-agent bridge follow-up fixes: add `/_agent-native/mcp` to the auth
+bypass allowlist so the stdio proxy / external MCP clients reach the endpoint's
+own `verifyAuth` (was 401); static `ACCESS_TOKEN` requests now carry caller
+identity via `AGENT_NATIVE_OWNER_EMAIL`/`X-Agent-Native-Owner-Email`; `open_app`
+/ `create_workspace_app` use the target app origin and `ask_app` routes
+cross-app over A2A honestly; validate decoded compose `draft.id` in
+`/_agent-native/open`; swallow benign post-flush `ERR_STREAM_WRITE_AFTER_END`;
+fix the local-dev auto-account email (`dev@local` → `dev@local.test`, rejected
+by better-auth 1.6.0) with legacy dual-exclusion.

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -26,6 +26,15 @@ import { getBuiltinCrossAppTools } from "./builtin-tools.js";
 export interface MCPConfig {
   /** App name shown in MCP server info */
   name: string;
+  /**
+   * Canonical app id (directory under `apps/`, e.g. `mail`) this MCP server
+   * is mounted for. Optional & back-compat: when omitted the builtin
+   * cross-app tools fall back to lowercasing `name`. Used by `open_app` /
+   * `ask_app` / `create_workspace_app` to tell "this app" from a cross-app
+   * target so they resolve the *target* app's origin rather than echoing the
+   * current request origin.
+   */
+  appId?: string;
   /** App description */
   description: string;
   /** Version string (default "1.0.0") */
@@ -156,12 +165,27 @@ export async function createMCPServerForRequest(
   // generic cross-app builtins (template wins on name collision).
   const actions = mergeBuiltinTools(config);
 
+  // Resolve the effective caller identity. JWT / header-derived identity
+  // (passed by `mountMCP` via `verifyAuth`) wins. When the caller passed no
+  // identity — the stdio **standalone** path — fall back to the
+  // `AGENT_NATIVE_OWNER_EMAIL` env the `agent-native mcp install` flow writes
+  // into the `agent-native mcp serve` process env, so standalone tool runs are
+  // tenant-scoped to the configured owner instead of running unscoped. Stays
+  // undefined for true dev-open (no token, no secret, no owner) — behavior
+  // there is unchanged.
+  const ownerFromEnv = process.env.AGENT_NATIVE_OWNER_EMAIL?.trim();
+  const effectiveIdentity: MCPCallerIdentity | undefined =
+    identity ??
+    (ownerFromEnv
+      ? { userEmail: ownerFromEnv, orgDomain: undefined }
+      : undefined);
+
   // Resolve orgId once per request (DB lookup) so subsequent wraps are
-  // synchronous. The caller identity may be undefined for ACCESS_TOKEN
-  // auth — in that case we run with no userEmail/orgId, which makes
-  // downstream tools that require per-user scope return empty results
-  // rather than cross-tenant data (the safe default).
-  const orgIdPromise = resolveOrgIdFromDomain(identity?.orgDomain);
+  // synchronous. The caller identity may be undefined for true dev-open —
+  // in that case we run with no userEmail/orgId, which makes downstream
+  // tools that require per-user scope return empty results rather than
+  // cross-tenant data (the safe default).
+  const orgIdPromise = resolveOrgIdFromDomain(effectiveIdentity?.orgDomain);
 
   /**
    * Wrap a callback in `runWithRequestContext({ userEmail, orgId }, fn)`.
@@ -172,7 +196,7 @@ export async function createMCPServerForRequest(
   async function withCallerContext<T>(fn: () => Promise<T>): Promise<T> {
     const orgId = await orgIdPromise;
     return runWithRequestContext(
-      { userEmail: identity?.userEmail, orgId },
+      { userEmail: effectiveIdentity?.userEmail, orgId },
       fn,
     ) as Promise<T>;
   }
@@ -299,9 +323,40 @@ export function getAccessTokens(): string[] {
 }
 
 /**
+ * Resolve the caller identity for a static-token (or dev-open) auth path.
+ *
+ * Static `ACCESS_TOKEN` / `ACCESS_TOKENS` auth carries no per-caller claims,
+ * so without this the MCP endpoint would run every tool with
+ * `userEmail === undefined` and per-user / per-org scoped actions
+ * (`accessFilter`, `resolveAccess`, `resolveCredential`) would return
+ * empty / wrong data. The `agent-native mcp install` flow writes
+ * `AGENT_NATIVE_OWNER_EMAIL` into the client config env and the stdio proxy
+ * forwards it as the `X-Agent-Native-Owner-Email` request header (see
+ * `mcp/stdio.ts#authHeaders`). We trust that owner hint *only* on the
+ * static-token path — JWT auth already carries a cryptographically verified
+ * `sub`, so the header is ignored there and never widens JWT scope.
+ *
+ * Returns `undefined` when no owner email is available (true dev-open: no
+ * token, no secret, no owner) so behavior there stays unchanged.
+ */
+function deriveStaticTokenIdentity(
+  ownerEmailHeader: string | undefined,
+): MCPCallerIdentity | undefined {
+  const owner =
+    (typeof ownerEmailHeader === "string" && ownerEmailHeader.trim()) ||
+    process.env.AGENT_NATIVE_OWNER_EMAIL?.trim() ||
+    "";
+  if (!owner) return undefined;
+  return { userEmail: owner, orgDomain: undefined };
+}
+
+/**
  * Verify the inbound auth header. Returns:
- *   - { authed: true, identity } when verified — `identity` may be empty
- *     when authed via a static ACCESS_TOKEN (no caller email available).
+ *   - { authed: true, identity } when verified — `identity` is derived from
+ *     the JWT (`sub` / `org_domain`) for JWT auth, or from the
+ *     `AGENT_NATIVE_OWNER_EMAIL` env / `X-Agent-Native-Owner-Email` header
+ *     for static-token auth (the `agent-native mcp install` flow). `identity`
+ *     is undefined only for true dev-open with no owner hint.
  *   - { authed: false } on rejection.
  *
  * When A2A_SECRET is set we extract the JWT's `sub` (caller email) and
@@ -309,15 +364,25 @@ export function getAccessTokens(): string[] {
  * `runWithRequestContext({ userEmail, orgId })`. Without that wrap, the
  * MCP endpoint loses tenant identity and downstream `accessFilter` /
  * `resolveCredential` calls fall back to platform-wide defaults.
+ *
+ * `ownerEmailHeader` is the forwarded `X-Agent-Native-Owner-Email` value; it
+ * is consulted ONLY on the static-token / dev-open path (never to influence
+ * verified JWT identity), so the install flow runs tools as the configured
+ * owner instead of an unscoped anonymous caller.
  */
 export async function verifyAuth(
   authHeader: string | undefined,
+  ownerEmailHeader?: string | undefined,
 ): Promise<{ authed: boolean; identity?: MCPCallerIdentity }> {
-  // No auth configured → allow (dev mode), but no identity to propagate.
+  // No auth configured → allow (dev mode). Still honour an owner hint
+  // (env or forwarded header) so the install flow stays tenant-scoped.
   const accessTokens = getAccessTokens();
   const hasA2ASecret = !!process.env.A2A_SECRET;
   if (accessTokens.length === 0 && !hasA2ASecret) {
-    return { authed: true };
+    return {
+      authed: true,
+      identity: deriveStaticTokenIdentity(ownerEmailHeader),
+    };
   }
 
   if (!authHeader?.startsWith("Bearer ")) return { authed: false };
@@ -346,9 +411,14 @@ export async function verifyAuth(
     }
   }
 
-  // Try ACCESS_TOKEN / ACCESS_TOKENS exact match (no per-caller identity).
+  // Try ACCESS_TOKEN / ACCESS_TOKENS exact match. Static tokens carry no
+  // per-caller claims, so derive identity from the forwarded owner-email
+  // hint (install flow) — otherwise tools would run unscoped.
   if (accessTokens.length > 0 && accessTokens.includes(token)) {
-    return { authed: true };
+    return {
+      authed: true,
+      identity: deriveStaticTokenIdentity(ownerEmailHeader),
+    };
   }
 
   return { authed: false };

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -188,15 +188,24 @@ export async function createMCPServerForRequest(
   const orgIdPromise = resolveOrgIdFromDomain(effectiveIdentity?.orgDomain);
 
   /**
-   * Wrap a callback in `runWithRequestContext({ userEmail, orgId }, fn)`.
+   * Wrap a callback in
+   * `runWithRequestContext({ userEmail, orgId, requestOrigin }, fn)`.
    * Both the tools/list and tools/call handlers go through this so
    * downstream `accessFilter`, `resolveCredential`, and per-user MCP
-   * visibility checks see the verified caller's identity.
+   * visibility checks see the verified caller's identity. `requestOrigin`
+   * is the live server origin derived from the inbound request (same value
+   * used to absolutize deep links) so actions that build fetchable URLs
+   * (e.g. design `export-coding-handoff`'s signed raw-code URL) resolve the
+   * correct local-workspace origin instead of a prod/localhost fallback.
    */
   async function withCallerContext<T>(fn: () => Promise<T>): Promise<T> {
     const orgId = await orgIdPromise;
     return runWithRequestContext(
-      { userEmail: effectiveIdentity?.userEmail, orgId },
+      {
+        userEmail: effectiveIdentity?.userEmail,
+        orgId,
+        ...(requestMeta?.origin ? { requestOrigin: requestMeta.origin } : {}),
+      },
       fn,
     ) as Promise<T>;
   }
@@ -336,6 +345,17 @@ export function getAccessTokens(): string[] {
  * static-token path — JWT auth already carries a cryptographically verified
  * `sub`, so the header is ignored there and never widens JWT scope.
  *
+ * Precedence is server-trusted-first: the server process's
+ * `AGENT_NATIVE_OWNER_EMAIL` env (set out-of-band by the operator / deploy)
+ * ALWAYS wins, and a client-supplied `X-Agent-Native-Owner-Email` header is
+ * honored *only as a fallback when that env is unset*. A static `ACCESS_TOKEN`
+ * is a shared bearer secret; letting a request header override a
+ * server-configured owner would let anyone holding a leaked token act as any
+ * user. The header path remains for the single-tenant local-dev install flow
+ * where the app server process has no owner env and the token *is* the
+ * workspace secret; multi-tenant deployments must use A2A JWT (verified `sub`),
+ * not a static token, for per-user scope.
+ *
  * Returns `undefined` when no owner email is available (true dev-open: no
  * token, no secret, no owner) so behavior there stays unchanged.
  */
@@ -343,8 +363,8 @@ function deriveStaticTokenIdentity(
   ownerEmailHeader: string | undefined,
 ): MCPCallerIdentity | undefined {
   const owner =
-    (typeof ownerEmailHeader === "string" && ownerEmailHeader.trim()) ||
     process.env.AGENT_NATIVE_OWNER_EMAIL?.trim() ||
+    (typeof ownerEmailHeader === "string" && ownerEmailHeader.trim()) ||
     "";
   if (!owner) return undefined;
   return { userEmail: owner, orgDomain: undefined };

--- a/packages/core/src/mcp/builtin-cross-app.spec.ts
+++ b/packages/core/src/mcp/builtin-cross-app.spec.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { verifyAuth } from "./build-server.js";
+import { getBuiltinCrossAppTools } from "./builtin-tools.js";
+import type { MCPConfig } from "./build-server.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function resetEnv() {
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.ACCESS_TOKEN;
+  delete process.env.ACCESS_TOKENS;
+  delete process.env.A2A_SECRET;
+  delete process.env.AGENT_NATIVE_OWNER_EMAIL;
+}
+
+beforeEach(resetEnv);
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+// ---------------------------------------------------------------------------
+// Issue 1 — ACCESS_TOKEN auth must not lose caller identity
+// ---------------------------------------------------------------------------
+
+describe("verifyAuth — static-token caller identity", () => {
+  it("dev-open with no owner hint has no identity (unchanged behavior)", async () => {
+    const res = await verifyAuth(undefined);
+    expect(res.authed).toBe(true);
+    expect(res.identity).toBeUndefined();
+  });
+
+  it("dev-open derives identity from AGENT_NATIVE_OWNER_EMAIL env", async () => {
+    process.env.AGENT_NATIVE_OWNER_EMAIL = "owner@example.com";
+    const res = await verifyAuth(undefined);
+    expect(res.authed).toBe(true);
+    expect(res.identity?.userEmail).toBe("owner@example.com");
+  });
+
+  it("dev-open derives identity from the forwarded owner-email header", async () => {
+    const res = await verifyAuth(undefined, "hdr@example.com");
+    expect(res.identity?.userEmail).toBe("hdr@example.com");
+  });
+
+  it("static ACCESS_TOKEN match derives identity from owner env", async () => {
+    process.env.ACCESS_TOKEN = "tok-123";
+    process.env.AGENT_NATIVE_OWNER_EMAIL = "env-owner@example.com";
+    const res = await verifyAuth("Bearer tok-123");
+    expect(res.authed).toBe(true);
+    expect(res.identity?.userEmail).toBe("env-owner@example.com");
+  });
+
+  it("forwarded header wins over env on the static-token path", async () => {
+    process.env.ACCESS_TOKEN = "tok-123";
+    process.env.AGENT_NATIVE_OWNER_EMAIL = "env-owner@example.com";
+    const res = await verifyAuth("Bearer tok-123", "header-owner@example.com");
+    expect(res.identity?.userEmail).toBe("header-owner@example.com");
+  });
+
+  it("rejects an unknown token regardless of owner hint", async () => {
+    process.env.ACCESS_TOKEN = "tok-123";
+    const res = await verifyAuth("Bearer wrong", "owner@example.com");
+    expect(res.authed).toBe(false);
+    expect(res.identity).toBeUndefined();
+  });
+
+  it("a valid JWT identity is not overridden by the owner header", async () => {
+    process.env.A2A_SECRET = "jwt-secret";
+    const jose = await import("jose");
+    const token = await new jose.SignJWT({
+      sub: "jwt-user@example.com",
+      org_domain: "acme.com",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(new TextEncoder().encode("jwt-secret"));
+    const res = await verifyAuth(`Bearer ${token}`, "spoof@evil.com");
+    expect(res.authed).toBe(true);
+    expect(res.identity?.userEmail).toBe("jwt-user@example.com");
+    expect(res.identity?.orgDomain).toBe("acme.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue 2 / 3 — open_app + ask_app honesty for same-app / standalone
+// (cross-app workspace resolution needs a real workspace dir and is covered
+//  by the workspace-resolve path; here we lock the deterministic behavior.)
+// ---------------------------------------------------------------------------
+
+function baseConfig(over: Partial<MCPConfig> = {}): MCPConfig {
+  return {
+    name: "Mail",
+    appId: "mail",
+    description: "test",
+    actions: {},
+    ...over,
+  };
+}
+
+describe("open_app — same-app / standalone keeps a relative deep link", () => {
+  it("returns a relative /_agent-native/open path for the current app", async () => {
+    const tools = getBuiltinCrossAppTools(baseConfig());
+    const result: any = await tools.open_app.run({
+      app: "mail",
+      view: "inbox",
+      params: { threadId: "abc" },
+    });
+    expect(result.url).toBe(
+      "/_agent-native/open?app=mail&view=inbox&threadId=abc",
+    );
+    expect(result.url.startsWith("/")).toBe(true);
+  });
+});
+
+describe("ask_app — honest routing metadata", () => {
+  it("answers locally and reports routedVia:local for the current app", async () => {
+    let received: string | undefined;
+    const tools = getBuiltinCrossAppTools(
+      baseConfig({
+        askAgent: async (m: string) => {
+          received = m;
+          return "local-answer";
+        },
+      }),
+    );
+    const result: any = await tools.ask_app.run({
+      app: "mail",
+      message: "hello",
+    });
+    expect(received).toBe("hello");
+    expect(result.routedVia).toBe("local");
+    expect(result.app).toBe("mail");
+    expect(result.response).toBe("local-answer");
+    expect(result.note).toBeUndefined();
+  });
+
+  it("does not falsely claim delegation when the target is unreachable", async () => {
+    const tools = getBuiltinCrossAppTools(
+      baseConfig({
+        askAgent: async () => "local-answer",
+      }),
+    );
+    // "calendar" is not a resolvable workspace app in this test env, so it
+    // falls back to local but must say so honestly.
+    const result: any = await tools.ask_app.run({
+      app: "calendar",
+      message: "hi",
+    });
+    expect(result.routedVia).toBe("local");
+    expect(result.app).toBe("mail");
+    expect(typeof result.note).toBe("string");
+    expect(result.note).toContain("calendar");
+  });
+
+  it("throws when no agent handler exists and target is local", async () => {
+    const tools = getBuiltinCrossAppTools(baseConfig());
+    await expect(tools.ask_app.run({ message: "hi" })).rejects.toThrow(
+      /does not expose an agent/,
+    );
+  });
+});

--- a/packages/core/src/mcp/builtin-cross-app.spec.ts
+++ b/packages/core/src/mcp/builtin-cross-app.spec.ts
@@ -49,10 +49,19 @@ describe("verifyAuth — static-token caller identity", () => {
     expect(res.identity?.userEmail).toBe("env-owner@example.com");
   });
 
-  it("forwarded header wins over env on the static-token path", async () => {
+  it("server env wins over the forwarded header on the static-token path (no impersonation via a leaked token)", async () => {
     process.env.ACCESS_TOKEN = "tok-123";
     process.env.AGENT_NATIVE_OWNER_EMAIL = "env-owner@example.com";
+    const res = await verifyAuth("Bearer tok-123", "attacker@evil.com");
+    expect(res.authed).toBe(true);
+    expect(res.identity?.userEmail).toBe("env-owner@example.com");
+  });
+
+  it("forwarded header is used only as a fallback when the owner env is unset", async () => {
+    process.env.ACCESS_TOKEN = "tok-123";
+    delete process.env.AGENT_NATIVE_OWNER_EMAIL;
     const res = await verifyAuth("Bearer tok-123", "header-owner@example.com");
+    expect(res.authed).toBe(true);
     expect(res.identity?.userEmail).toBe("header-owner@example.com");
   });
 

--- a/packages/core/src/mcp/builtin-tools.ts
+++ b/packages/core/src/mcp/builtin-tools.ts
@@ -13,8 +13,15 @@
  * | --------------------- | ------------ | ---------------------------------------- |
  * | `list_apps`           | none         | `{ apps: [{ id, url, running }] }`       |
  * | `open_app`            | none         | `{ url }` (+ deep-link `link`)           |
- * | `ask_app`             | agent loop   | `{ app, response }`                      |
+ * | `ask_app`             | agent loop   | `{ app, routedVia, response }`           |
  * | `create_workspace_app`| scaffolds    | `{ name, url, port, deepLink }` (+ link) |
+ *
+ * `open_app` / `create_workspace_app` return an **absolute** URL on the
+ * *target* app's origin when it differs from this app (so a workspace link
+ * lands in the right app), and a relative path for the same app / standalone.
+ * `ask_app` routes to a *different* workspace app over A2A when possible and
+ * reports `routedVia: "a2a"`; otherwise it answers locally
+ * (`routedVia: "local"`) and never falsely claims cross-app delegation.
  * | `list_templates`      | none         | `{ templates: [...] }` (allow-list only) |
  *
  * Node-only at call time (workspace resolution + scaffolding use `fs`), but
@@ -55,6 +62,45 @@ function tool(
   };
 }
 
+/**
+ * The canonical app id this MCP server is mounted for. `MCPConfig.appId` is
+ * authoritative; fall back to lowercasing `name` (which is the capitalized
+ * app id at every call site) for back-compat with configs that predate the
+ * `appId` field.
+ */
+function currentAppId(config: MCPConfig): string {
+  return (config.appId || config.name || "app").toLowerCase();
+}
+
+/**
+ * Resolve the absolute origin of a *target* workspace app (e.g.
+ * `http://127.0.0.1:8101`) so cross-app deep links / A2A calls point at the
+ * right app instead of the current request's origin. Reuses the same
+ * workspace resolution `list_apps` / the stdio proxy use.
+ *
+ * Returns `null` when:
+ *   - the target is the current app (caller should keep relative behavior),
+ *   - there is no workspace info (standalone / single app), or
+ *   - the target app is unknown.
+ */
+async function resolveTargetAppOrigin(
+  config: MCPConfig,
+  targetAppId: string,
+): Promise<{ origin: string; id: string } | null> {
+  const target = targetAppId.trim().toLowerCase();
+  if (!target || target === currentAppId(config)) return null;
+  try {
+    const { resolveWorkspace } = await import("./workspace-resolve.js");
+    const ws = await resolveWorkspace();
+    if (!ws.isWorkspace) return null;
+    const match = ws.apps.find((a) => a.id.toLowerCase() === target);
+    if (!match) return null;
+    return { origin: match.url, id: match.id };
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // list_apps
 // ---------------------------------------------------------------------------
@@ -89,7 +135,7 @@ function listAppsTool(): ActionEntry {
 // open_app
 // ---------------------------------------------------------------------------
 
-function openAppTool(): ActionEntry {
+function openAppTool(config: MCPConfig): ActionEntry {
   return {
     tool: tool(
       "Build a deep link that opens an app at a specific view/record. No side " +
@@ -128,7 +174,18 @@ function openAppTool(): ActionEntry {
           params = undefined;
         }
       }
-      const url = buildDeepLink({ app, view, params });
+      const relUrl = buildDeepLink({ app, view, params });
+
+      // Cross-app target in a workspace: resolve the TARGET app's origin and
+      // return an absolute URL. Otherwise the MCP layer would prefix the
+      // relative path with the CURRENT request origin, landing the user in
+      // the wrong app (e.g. open_app({app:"calendar"}) served from Mail).
+      // Same-app / standalone keeps the relative path (current behavior).
+      const targetApp = await resolveTargetAppOrigin(config, app);
+      const url = targetApp
+        ? `${targetApp.origin.replace(/\/+$/, "")}${relUrl}`
+        : relUrl;
+
       return { app, view, url };
     },
     link: ({ result }) => {
@@ -154,7 +211,9 @@ function askAppTool(config: MCPConfig): ActionEntry {
       "Send a natural-language message to an app's AI agent and get its " +
         "response. Use for complex, multi-step tasks needing the agent's " +
         "reasoning and full app context. In a single-app project the 'app' " +
-        "param is optional (defaults to this app).",
+        "param is optional (defaults to this app). When 'app' names a " +
+        "different workspace app it is routed there over A2A; the result's " +
+        "'routedVia' field reports whether it ran cross-app or locally.",
       {
         app: {
           type: "string",
@@ -171,21 +230,65 @@ function askAppTool(config: MCPConfig): ActionEntry {
       const message = String(args.message ?? "").trim();
       if (!message) throw new Error("ask_app requires a 'message'.");
       const requestedApp = String(args.app ?? "").trim();
+      const selfId = currentAppId(config);
 
-      // This MCP server is mounted for a single app (`config`). Delegate to
-      // its own ask-agent handler — that is the same entry point the HTTP MCP
-      // mount + A2A use, so there is no second agent runner. Cross-app routing
-      // (talking to a *different* workspace app's agent) is intentionally not
-      // done here: the stdio proxy connects to one app, and cross-app fan-out
-      // is the workspace control plane's job (Dispatch / A2A).
+      // Cross-app: the caller named a *different* workspace app. Route the
+      // message to THAT app's agent over A2A (its `/_agent-native/a2a`
+      // endpoint runs the real agent loop with JWT identity) rather than
+      // silently answering from this app's agent and claiming delegation.
+      const targetApp = await resolveTargetAppOrigin(config, requestedApp);
+      if (targetApp) {
+        try {
+          const { callAgent } = await import("../a2a/client.js");
+          const { getRequestUserEmail } =
+            await import("../server/request-context.js");
+          // The MCP handler runs inside `runWithRequestContext`, so this is
+          // the verified caller's email — it lets `callAgent` mint a signed
+          // A2A JWT so the target app honours per-user scope.
+          const response = await callAgent(targetApp.origin, message, {
+            userEmail: getRequestUserEmail(),
+            // Bound the wait — cross-app A2A polls async by default.
+            timeoutMs: 5 * 60_000,
+          });
+          return {
+            app: targetApp.id,
+            routedVia: "a2a",
+            response,
+          };
+        } catch (err: any) {
+          // Be honest: routing was attempted and failed — do NOT fall back to
+          // this app's agent and pretend it was the target.
+          throw new Error(
+            `Failed to route ask_app to "${targetApp.id}" via A2A: ` +
+              `${err?.message ?? err}`,
+          );
+        }
+      }
+
+      // Same app (or no workspace / unknown target): answer locally with this
+      // app's own ask-agent handler — the same entry point the HTTP MCP mount
+      // + A2A use, so there is no second agent runner.
       if (!config.askAgent) {
         throw new Error(
           "This app does not expose an agent (no ask-agent handler).",
         );
       }
+
+      // If the caller named an app we couldn't route to (unknown id, or no
+      // workspace), say so honestly instead of claiming we reached it.
+      const unresolved =
+        !!requestedApp && requestedApp.toLowerCase() !== selfId;
       const response = await config.askAgent(message);
       return {
-        app: requestedApp || config.name,
+        app: selfId,
+        routedVia: "local",
+        ...(unresolved
+          ? {
+              note:
+                `Requested app "${requestedApp}" is not a reachable workspace ` +
+                `app; answered with this app ("${selfId}") instead.`,
+            }
+          : {}),
         response,
       };
     },
@@ -305,7 +408,15 @@ function createWorkspaceAppTool(): ActionEntry {
       const ws = await resolveWorkspace(root);
       const appInfo = ws.apps.find((a) => a.id === name);
       const port = appInfo?.port;
-      const deepLink = buildDeepLink({ app: name, view: "home" });
+      // The scaffolded app is always a *different* app from the host MCP
+      // server, so anchor the deep link to the new app's own origin. A
+      // relative path would otherwise be prefixed with the current request
+      // origin and land on the wrong app. Fall back to the relative path
+      // only if the gateway hasn't reported the new app's URL yet.
+      const relDeepLink = buildDeepLink({ app: name, view: "home" });
+      const deepLink = appInfo?.url
+        ? `${appInfo.url.replace(/\/+$/, "")}${relDeepLink}`
+        : relDeepLink;
 
       return {
         name,
@@ -345,7 +456,7 @@ export function getBuiltinCrossAppTools(
 ): Record<string, ActionEntry> {
   return {
     list_apps: listAppsTool(),
-    open_app: openAppTool(),
+    open_app: openAppTool(config),
     ask_app: askAppTool(config),
     create_workspace_app: createWorkspaceAppTool(),
     list_templates: listTemplatesTool(),

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -63,10 +63,17 @@ export function mountMCP(
 
       const method = getMethod(event);
 
-      // Auth check — also extracts the caller's identity from the JWT so
-      // downstream tools run inside `runWithRequestContext`.
+      // Auth check — extracts the caller's identity from the JWT (`sub`),
+      // or, on the static-token / dev-open path, from the forwarded
+      // `X-Agent-Native-Owner-Email` hint the stdio proxy sends (the
+      // `agent-native mcp install` flow). Without this the install flow
+      // would run every tool unscoped (userEmail === undefined).
       const authHeader = getRequestHeader(event, "authorization");
-      const authResult = await verifyAuth(authHeader);
+      const ownerEmailHeader = getRequestHeader(
+        event,
+        "x-agent-native-owner-email",
+      );
+      const authResult = await verifyAuth(authHeader, ownerEmailHeader);
       if (!authResult.authed) {
         setResponseStatus(event, 401);
         return { error: "Unauthorized" };
@@ -135,7 +142,22 @@ export function mountMCP(
         setResponseStatus(event, 501);
         return { error: "MCP requires Node runtime" };
       }
-      await transport.handleRequest(nodeReq, nodeRes, body);
+      try {
+        await transport.handleRequest(nodeReq, nodeRes, body);
+      } catch (err: any) {
+        // The SDK transport writes directly to the Node response. If the
+        // socket is already closed/ended (client disconnected, or the host
+        // stream layer also flushed), Node throws ERR_STREAM_WRITE_AFTER_END
+        // *after* the MCP payload was already delivered correctly. Swallow
+        // that benign post-flush write so an external agent disconnecting
+        // mid-stream can never take down the server process; rethrow
+        // anything else.
+        if (err?.code !== "ERR_STREAM_WRITE_AFTER_END") throw err;
+        if (process.env.DEBUG)
+          console.log(
+            "[mcp] ignored post-flush ERR_STREAM_WRITE_AFTER_END (client disconnected)",
+          );
+      }
 
       // Prevent H3 from double-writing the response
       (event as any)._handled = true;

--- a/packages/core/src/mcp/stdio.ts
+++ b/packages/core/src/mcp/stdio.ts
@@ -211,6 +211,7 @@ async function runStandalone(opts: RunMCPStdioOptions): Promise<void> {
   const server = await createMCPServerForRequest(
     {
       name: appId.charAt(0).toUpperCase() + appId.slice(1),
+      appId,
       description: `Agent-native ${appId} app (standalone MCP)`,
       actions,
       // No askAgent in standalone — there is no running engine/runtime here.

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -3788,6 +3788,7 @@ export function createAgentChatPlugin(
         name: options?.appId
           ? options.appId.charAt(0).toUpperCase() + options.appId.slice(1)
           : "Agent",
+        appId: options?.appId,
         description: `Agent-native ${options?.appId ?? "app"} agent`,
         actions: allScripts,
         askAgent: async (message: string) => {

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -2489,6 +2489,33 @@ describe("server/auth", () => {
       );
     });
   });
+
+  // Regression guard: better-auth 1.6.0 validates emails with Zod v4's
+  // `z.email()`. The original auto dev-account email `dev@local` has no
+  // TLD and is rejected as INVALID_EMAIL, which silently broke the
+  // zero-setup auto-sign-in on every fresh local dev DB. The fix moves
+  // the constant to `dev@local.test` (RFC 6761 reserved, never resolves)
+  // while keeping `dev@local` recognized as the legacy dev account.
+  describe("auto dev account email format", () => {
+    // Must mirror AUTO_DEV_ACCOUNT_EMAIL / LEGACY_AUTO_DEV_ACCOUNT_EMAIL
+    // in auth.ts (module-private constants).
+    const AUTO_DEV_ACCOUNT_EMAIL = "dev@local.test";
+    const LEGACY_AUTO_DEV_ACCOUNT_EMAIL = "dev@local";
+
+    it("uses an address that passes better-auth's z.email() validator", async () => {
+      const z = await import("zod");
+      expect(z.email().safeParse(AUTO_DEV_ACCOUNT_EMAIL).success).toBe(true);
+      // The pre-fix address is exactly the one that failed validation.
+      expect(z.email().safeParse(LEGACY_AUTO_DEV_ACCOUNT_EMAIL).success).toBe(
+        false,
+      );
+    });
+
+    it("keeps the new and legacy emails distinct so both are excluded as the dev account", () => {
+      expect(AUTO_DEV_ACCOUNT_EMAIL).not.toBe(LEGACY_AUTO_DEV_ACCOUNT_EMAIL);
+      expect(AUTO_DEV_ACCOUNT_EMAIL).toMatch(/\.test$/);
+    });
+  });
 });
 
 // --- Mock helpers ---

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1276,6 +1276,18 @@ function createAuthGuardFn(): (
       return;
     }
 
+    // MCP protocol endpoint. `mountMCP` runs its own `verifyAuth` (Bearer
+    // ACCESS_TOKEN/ACCESS_TOKENS or A2A_SECRET JWT, open in dev) and is the
+    // authoritative gate — exactly like A2A above. Without this bypass the
+    // guard's blanket 401-for-/_agent-native/* below shadows that check, so
+    // an external coding agent (Claude Code / Codex / Cowork) connecting via
+    // the stdio proxy or HTTP can never reach it. Exact path only: the MCP
+    // handler returns early for `/_agent-native/mcp/*` management subroutes,
+    // which keep their normal session auth.
+    if (p === "/_agent-native/mcp") {
+      return;
+    }
+
     // Internal processor endpoint for the A2A async-mode fanout. Mirrors the
     // integration webhook fanout: when `message/send` is called with
     // `async: true`, the JSON-RPC handler enqueues to a2a_tasks and self-
@@ -1383,8 +1395,8 @@ function createAuthGuardFn(): (
     }
 
     // Local-dev convenience: on the first page GET of a freshly-scaffolded
-    // app, transparently create + sign in `dev@local` instead of showing the
-    // sign-up form. Gated on NODE_ENV=development AND no real users in the
+    // app, transparently create + sign in `dev@local.test` instead of
+    // showing the sign-up form. Gated on NODE_ENV=development AND no real users in the
     // DB, so production and any app that has ever had a real signup are
     // unaffected. See maybeAutoCreateDevSession for full conditions.
     if (getMethod(event) === "GET") {
@@ -1399,29 +1411,40 @@ function createAuthGuardFn(): (
   };
 }
 
-const AUTO_DEV_ACCOUNT_EMAIL = "dev@local";
+// `.test` is an RFC 6761 reserved TLD that never resolves, so this stays a
+// safe local-only address while still passing better-auth's `z.email()`
+// validator (a bare `dev@local` has no TLD and is rejected as INVALID_EMAIL,
+// which silently broke the zero-setup auto-sign-in on every fresh dev DB).
+const AUTO_DEV_ACCOUNT_EMAIL = "dev@local.test";
 const AUTO_DEV_ACCOUNT_PASSWORD = "local-dev-account";
+
+// Pre-fix local dev DBs may already contain a `dev@local` user. Treat that
+// legacy address as the dev account too, so the "any real users?" check
+// below doesn't mistake the old auto-account for a real signup (which would
+// permanently disable auto-create) and the post-logout guard still fires.
+const LEGACY_AUTO_DEV_ACCOUNT_EMAIL = "dev@local";
 
 /**
  * Local-dev convenience: skip the sign-up wall on first run.
  *
  * When NODE_ENV=development AND the `user` table has no rows for any
- * email other than `dev@local`, transparently sign up (or sign back in
+ * email other than the dev account (`dev@local.test`, or the legacy
+ * `dev@local` on pre-fix DBs), transparently sign up (or sign back in
  * to) the auto-managed dev account and return a 302 to the original URL
  * with a session cookie set. A developer who just ran `pnpm dev` lands
  * in the app immediately instead of being asked to fill in name + email
  * + password to try the framework.
  *
- * Auto-create fires exactly once per local DB: as soon as `dev@local`
- * (or any real user) exists in the `user` table, the helper returns
- * null and the normal login flow takes over. Signing out then leaves
- * the user on the regular sign-in form; without this guard the
+ * Auto-create fires exactly once per local DB: as soon as the dev
+ * account (or any real user) exists in the `user` table, the helper
+ * returns null and the normal login flow takes over. Signing out then
+ * leaves the user on the regular sign-in form; without this guard the
  * post-logout reload would silently re-create the session.
  *
  * The fixed password is intentional: it means a developer who signs
- * out can sign back in with `dev@local` / `local-dev-account` from
- * the regular login form. To get the auto-flow back, drop the user
- * row or wipe the local DB. Set
+ * out can sign back in with `dev@local.test` / `local-dev-account`
+ * from the regular login form. To get the auto-flow back, drop the
+ * user row or wipe the local DB. Set
  * `AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT=1` to opt out entirely
  * (useful for tests that exercise the unauthenticated branch). This
  * is local-only — the helper is gated on NODE_ENV.
@@ -1435,22 +1458,28 @@ async function maybeAutoCreateDevSession(
 
   try {
     const db = getDbExec();
+    // Exclude BOTH the current and the legacy dev-account email so a
+    // pre-fix local DB that still holds a `dev@local` row isn't treated
+    // as having a "real user" (which would permanently disable
+    // auto-create on that DB).
     const { rows: realUsers } = await db.execute({
-      sql: 'SELECT 1 FROM "user" WHERE email != ? LIMIT 1',
-      args: [AUTO_DEV_ACCOUNT_EMAIL],
+      sql: 'SELECT 1 FROM "user" WHERE email NOT IN (?, ?) LIMIT 1',
+      args: [AUTO_DEV_ACCOUNT_EMAIL, LEGACY_AUTO_DEV_ACCOUNT_EMAIL],
     });
     if (realUsers.length > 0) return null;
 
-    // If `dev@local` already exists, this is not a freshly-scaffolded
+    // If the dev account already exists, this is not a freshly-scaffolded
     // app — the user has been through the auto-create flow at least
     // once. Skip auto-create so signing out actually works: without
     // this guard, the post-logout reload immediately re-creates the
-    // session and the user is stuck in dev@local forever (or has to
-    // set AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT=1). To get the demo
-    // experience back, drop the row or wipe the local DB.
+    // session and the user is stuck in the dev account forever (or has
+    // to set AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT=1). To get the demo
+    // experience back, drop the row or wipe the local DB. The legacy
+    // `dev@local` address is matched too so pre-fix DBs still suppress
+    // re-create after logout.
     const { rows: devUsers } = await db.execute({
-      sql: 'SELECT 1 FROM "user" WHERE email = ? LIMIT 1',
-      args: [AUTO_DEV_ACCOUNT_EMAIL],
+      sql: 'SELECT 1 FROM "user" WHERE email IN (?, ?) LIMIT 1',
+      args: [AUTO_DEV_ACCOUNT_EMAIL, LEGACY_AUTO_DEV_ACCOUNT_EMAIL],
     });
     if (devUsers.length > 0) return null;
 

--- a/packages/core/src/server/open-route.ts
+++ b/packages/core/src/server/open-route.ts
@@ -24,7 +24,7 @@
 import type { H3Event } from "h3";
 import { defineEventHandler, getMethod } from "h3";
 import { getSession, getConfiguredLoginHtml } from "./auth.js";
-import { appStatePut } from "../application-state/store.js";
+import { appStatePut, appStateGet } from "../application-state/store.js";
 
 /** Query keys that are route control, not navigation payload. */
 const RESERVED = new Set(["app", "view", "to", "compose"]);
@@ -146,9 +146,29 @@ export function createOpenRouteHandler(options: OpenRouteOptions = {}) {
               typeof draft.id === "string" &&
               COMPOSE_ID.test(draft.id)
             ) {
-              await appStatePut(session.email, `compose-${draft.id}`, draft, {
-                requestSource: "deep-link",
-              });
+              const composeKey = `compose-${draft.id}`;
+              // A compact deep link may carry only `{ id, subject }` when the
+              // full draft was too large to inline in the URL. The complete
+              // draft is already persisted at `compose-<id>` by manage-draft
+              // on create/update. Never let the truncated stub overwrite that
+              // richer saved draft (would silently lose body / recipients /
+              // reply metadata). Only write when the payload actually carries
+              // content, or when nothing is saved yet (composer still opens).
+              const hasContent =
+                (typeof draft.body === "string" && draft.body.length > 0) ||
+                !!draft.to ||
+                !!draft.cc ||
+                !!draft.bcc ||
+                !!draft.html ||
+                !!draft.replyToThreadId;
+              const existing = hasContent
+                ? null
+                : await appStateGet(session.email, composeKey);
+              if (hasContent || !existing) {
+                await appStatePut(session.email, composeKey, draft, {
+                  requestSource: "deep-link",
+                });
+              }
             }
           } catch {
             // Malformed compose payload — skip; the view still opens.

--- a/packages/core/src/server/open-route.ts
+++ b/packages/core/src/server/open-route.ts
@@ -33,6 +33,12 @@ const RESERVED = new Set(["app", "view", "to", "compose"]);
 // file stays plain ASCII.
 const CONTROL_CHARS = new RegExp("[\\u0000-\\u001f\\u007f]");
 
+// Compose-draft id charset. Mirrors `sanitizeDraftId` in
+// templates/mail/actions/manage-draft.ts so the id we concatenate into the
+// `compose-<id>` application-state key can't escape the key namespace
+// (path-traversal / key injection guard).
+const COMPOSE_ID = /^[a-zA-Z0-9_-]{1,64}$/;
+
 export interface OpenRouteOptions {
   /** Per-template override that turns the parsed deep-link params into the
    *  client-side SPA path to redirect to. Return `null` to use the default
@@ -130,7 +136,16 @@ export function createOpenRouteHandler(options: OpenRouteOptions = {}) {
         if (compose) {
           try {
             const draft = JSON.parse(decodeBase64Url(compose));
-            if (draft && typeof draft === "object" && draft.id) {
+            // Validate the id before using it as a key segment. An unsafe id
+            // could escape the `compose-` namespace and clobber an unrelated
+            // application-state key; skip the write (the view still opens),
+            // mirroring the malformed-payload branch below.
+            if (
+              draft &&
+              typeof draft === "object" &&
+              typeof draft.id === "string" &&
+              COMPOSE_ID.test(draft.id)
+            ) {
               await appStatePut(session.email, `compose-${draft.id}`, draft, {
                 requestSource: "deep-link",
               });

--- a/packages/core/src/server/request-context.ts
+++ b/packages/core/src/server/request-context.ts
@@ -63,6 +63,14 @@ export interface RequestContext {
   orgId?: string;
   timezone?: string;
   /**
+   * Origin of the inbound request (e.g. `http://127.0.0.1:8100`). Set by the
+   * MCP mount from the request headers so actions that build externally
+   * fetchable URLs (e.g. design `export-coding-handoff`'s signed raw-code URL)
+   * resolve the real local-workspace origin instead of a prod/localhost
+   * fallback. Optional — absent on paths that don't populate it.
+   */
+  requestOrigin?: string;
+  /**
    * True when this request is being processed by an integration-platform
    * webhook (Slack, Telegram, etc.) where the function timeout is the
    * binding constraint. Code that calls slow remote APIs can use this to apply

--- a/templates/calendar/server/plugins/core-routes.ts
+++ b/templates/calendar/server/plugins/core-routes.ts
@@ -4,4 +4,15 @@ import { envKeys } from "../lib/env-config.js";
 export default createCoreRoutesPlugin({
   sseRoute: "/_agent-native/sse",
   envKeys,
+  // Land deep links (`/_agent-native/open?app=calendar&view=calendar&eventId=…&date=…`)
+  // straight on the real SPA path. The calendar UI renders at the ROOT route
+  // (`app/routes/_app._index.tsx`), not `/calendar`, so the framework default
+  // redirect to `/calendar` would 404. Map the `calendar` deep-link view to `/`;
+  // the polled one-shot `navigate` command (written by `/open`) still carries
+  // `eventId`/`date`, which `use-navigation-state` consumes to focus the event
+  // after load. Unknown views fall back to the framework default.
+  resolveOpenPath: ({ view }) => {
+    if (view === "calendar") return "/";
+    return null;
+  },
 });

--- a/templates/content/actions/pull-document.ts
+++ b/templates/content/actions/pull-document.ts
@@ -1,11 +1,11 @@
 import { defineAction } from "@agent-native/core";
 import { resolveAccess } from "@agent-native/core/sharing";
-import { buildDeepLink } from "@agent-native/core/server";
+import { buildDeepLink, getRequestUserEmail } from "@agent-native/core/server";
 import { hasCollabState } from "@agent-native/core/collab";
 import {
-  readAppState,
-  writeAppState,
-  deleteAppState,
+  appStateGet,
+  appStatePut,
+  appStateDelete,
 } from "@agent-native/core/application-state";
 import { z } from "zod";
 import "../server/db/index.js";
@@ -20,17 +20,26 @@ import "../server/db/index.js";
  * ProseMirror -> markdown serializer server-side:
  *
  *   1. If a collab session exists for this doc, write a one-shot
- *      `flush-request-<id>` app-state key (scoped to the caller's browser
- *      session — same scoping the `navigate` command uses).
+ *      `flush-request-<id>` app-state key under the DOCUMENT OWNER's session
+ *      (and, for back-compat, the caller's own session). The open editor polls
+ *      `/_agent-native/application-state/flush-request-<id>`, which the
+ *      framework scopes to the *logged-in browser user* — i.e. the human with
+ *      the editor open, which is the document owner. Scoping the write to the
+ *      external agent caller's session (the old behavior) meant the editor
+ *      never saw the key, so every external `pull-document` waited the full
+ *      timeout and returned stale DB content.
  *   2. The editor polls that key, serializes its current Y.Doc to markdown
  *      through its existing serializer, calls `update-document`, then deletes
  *      the key.
- *   3. We poll for the key to disappear (flush acknowledged) and then read the
- *      now-fresh row. If the key never clears (no editor actually open), we
- *      fall back to the DB column, which is the best available snapshot.
+ *   3. We poll (across both candidate sessions) for the key to disappear
+ *      (flush acknowledged) and then read the now-fresh row. If the key never
+ *      clears (no editor actually open), we fall back to the DB column, which
+ *      is the best available snapshot.
  *
  * When there is no live collab session the DB column is authoritative and we
- * skip the handshake entirely.
+ * skip the handshake entirely. The handshake itself is bounded by
+ * FLUSH_TIMEOUT_MS so a stale `hasCollabState` (presence lingering with no tab
+ * actually open) can never hang the request longer than a few seconds.
  */
 
 const FLUSH_POLL_INTERVAL_MS = 200;
@@ -58,15 +67,49 @@ export default defineAction({
     // for it to acknowledge by clearing the flush-request key.
     if (await hasCollabState(id)) {
       const flushKey = `flush-request-${id}`;
-      await writeAppState(flushKey, { id, ts: Date.now() });
+      // The editor polls `flush-request-<id>` via the framework app-state
+      // route, which scopes reads to the logged-in browser user (the document
+      // owner). Writing under the caller's (external agent's) session — what
+      // the old `writeAppState` helper did — meant the editor never saw the
+      // key. Write under the owner's session so the open editor's poll picks
+      // it up; also write under the caller's own session for back-compat (e.g.
+      // an in-app agent that is itself the owner), de-duped.
+      const ownerEmail =
+        (access.resource.ownerEmail as string | undefined) || undefined;
+      const callerEmail = getRequestUserEmail() || undefined;
+      const targetSessions = Array.from(
+        new Set(
+          [ownerEmail, callerEmail].filter(
+            (s): s is string => typeof s === "string" && s.length > 0,
+          ),
+        ),
+      );
+      const flushValue = { id, ts: Date.now() };
+      await Promise.all(
+        targetSessions.map((s) =>
+          appStatePut(s, flushKey, flushValue, {
+            requestSource: "agent",
+          }).catch(() => {}),
+        ),
+      );
       const deadline = Date.now() + FLUSH_TIMEOUT_MS;
       while (Date.now() < deadline) {
         await new Promise((r) => setTimeout(r, FLUSH_POLL_INTERVAL_MS));
-        const pending = await readAppState(flushKey);
-        if (!pending) break;
+        // The editor deletes the key from whichever session it polls. Treat
+        // the flush as acknowledged once it is gone from all target sessions.
+        const pending = await Promise.all(
+          targetSessions.map((s) => appStateGet(s, flushKey)),
+        );
+        if (pending.every((p) => !p)) break;
       }
       // Best-effort cleanup if the editor never picked it up (no tab open).
-      await deleteAppState(flushKey).catch(() => {});
+      await Promise.all(
+        targetSessions.map((s) =>
+          appStateDelete(s, flushKey, { requestSource: "agent" }).catch(
+            () => {},
+          ),
+        ),
+      );
     }
 
     // Re-resolve so we read the now-fresh row (and re-check access).

--- a/templates/design/actions/export-coding-handoff.ts
+++ b/templates/design/actions/export-coding-handoff.ts
@@ -1,5 +1,9 @@
 import { defineAction } from "@agent-native/core";
-import { signShortLivedToken, buildDeepLink } from "@agent-native/core/server";
+import {
+  signShortLivedToken,
+  buildDeepLink,
+  getAppProductionUrl,
+} from "@agent-native/core/server";
 import { assertAccess } from "@agent-native/core/sharing";
 import { z } from "zod";
 import { schema } from "../server/db/index.js";
@@ -64,10 +68,17 @@ export default defineAction({
       ttlSeconds: HANDOFF_TTL_SECONDS,
     });
     const handoffFormat = normalizeHandoffFormat(format);
+    // External agents (MCP / A2A) that don't pass `origin` would otherwise get
+    // a relative URL they can't fetch. Fall back to the canonical app origin —
+    // the same resolution `buildDeepLink` absolutization uses for deployed
+    // first-party apps (env override → registry prodUrl → platform URL →
+    // localhost) — so `rawUrl` is absolute by default. An explicitly-passed
+    // `origin` still wins.
+    const resolvedOrigin = origin || getAppProductionUrl();
     const rawUrl = buildRawHandoffUrl({
       id,
       token,
-      origin,
+      origin: resolvedOrigin,
       format: handoffFormat,
     });
     const prompt = buildCodingHandoffPrompt({

--- a/templates/design/actions/export-coding-handoff.ts
+++ b/templates/design/actions/export-coding-handoff.ts
@@ -3,6 +3,7 @@ import {
   signShortLivedToken,
   buildDeepLink,
   getAppProductionUrl,
+  getRequestContext,
 } from "@agent-native/core/server";
 import { assertAccess } from "@agent-native/core/sharing";
 import { z } from "zod";
@@ -69,12 +70,16 @@ export default defineAction({
     });
     const handoffFormat = normalizeHandoffFormat(format);
     // External agents (MCP / A2A) that don't pass `origin` would otherwise get
-    // a relative URL they can't fetch. Fall back to the canonical app origin —
-    // the same resolution `buildDeepLink` absolutization uses for deployed
-    // first-party apps (env override → registry prodUrl → platform URL →
-    // localhost) — so `rawUrl` is absolute by default. An explicitly-passed
-    // `origin` still wins.
-    const resolvedOrigin = origin || getAppProductionUrl();
+    // a relative URL they can't fetch. Resolution order:
+    //   1. explicit `origin` arg (caller knows best),
+    //   2. the live request origin from the request context (set by the MCP
+    //      layer from the inbound request — the actual local-workspace app
+    //      origin, e.g. http://127.0.0.1:8085, so the signed raw-code URL is
+    //      fetchable in dev/workspace setups), then
+    //   3. the canonical first-party app origin (env override → registry
+    //      prodUrl → platform URL → localhost) for deployed apps.
+    const resolvedOrigin =
+      origin || getRequestContext()?.requestOrigin || getAppProductionUrl();
     const rawUrl = buildRawHandoffUrl({
       id,
       token,

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core";
+import { buildDeepLink } from "@agent-native/core/server";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
@@ -9,6 +10,15 @@ import {
   applyText,
   seedFromText,
 } from "@agent-native/core/collab";
+
+/** Editor deep link so external agents can surface "Open design". */
+function designDeepLink(designId: string): string {
+  return buildDeepLink({
+    app: "design",
+    view: "editor",
+    params: { designId },
+  });
+}
 
 export default defineAction({
   description:
@@ -244,6 +254,16 @@ export default defineAction({
       renderable: true,
       savedFiles,
       fileCount: savedFiles.length,
+    };
+  },
+  link: ({ result }) => {
+    if (!result || typeof result !== "object") return null;
+    const designId = (result as { designId?: string }).designId;
+    if (!designId) return null;
+    return {
+      url: designDeepLink(designId),
+      label: "Open design",
+      view: "editor",
     };
   },
 });

--- a/templates/design/server/plugins/auth.ts
+++ b/templates/design/server/plugins/auth.ts
@@ -11,4 +11,13 @@ export default createAuthPlugin({
       "Export your work or share it with a link",
     ],
   },
+  // The coding-handoff bundle endpoint is intentionally public so external
+  // coding agents (over MCP) can fetch the raw design without a browser
+  // cookie. It is not actually open: GET /api/design-handoff/:id is gated by
+  // a signed, expiring handoff token bound to the design id (see
+  // server/routes/api/design-handoff/[id].get.ts — verifyShortLivedToken).
+  // publicPaths uses prefix matching, so this covers
+  // /api/design-handoff/<id>?token=... while keeping every other /api/* and
+  // /_agent-native/* route behind auth.
+  publicPaths: ["/api/design-handoff"],
 });

--- a/templates/mail/actions/manage-draft.ts
+++ b/templates/mail/actions/manage-draft.ts
@@ -10,6 +10,18 @@ import { getRequestUserEmail, buildDeepLink } from "@agent-native/core/server";
 import { z } from "zod";
 import { appendSignatureToBody } from "../shared/signature.js";
 
+/**
+ * Cap for the base64url `compose=` query param. A full draft (recipients +
+ * subject + entire body) base64-encoded can be many KB, and browsers / inline
+ * webviews silently truncate or reject very long URLs. When the self-contained
+ * payload would exceed this, we fall back to an id-only deep link: the draft
+ * is already persisted as a `compose-{id}` app-state entry by this action, so
+ * the compose panel resurfaces it from the persisted row for the creator. The
+ * threshold is conservative (well under the ~8KB practical URL ceiling, with
+ * headroom for the rest of the query string and host prefix).
+ */
+const MAX_COMPOSE_PAYLOAD_BYTES = 1536;
+
 /** Base64url-encode a compose draft so `/_agent-native/open?compose=…`
  *  decodes it back into a `compose-{id}` app-state entry the compose panel
  *  auto-opens. */
@@ -17,12 +29,32 @@ function encodeComposeDraft(draft: Record<string, string>): string {
   return Buffer.from(JSON.stringify(draft)).toString("base64url");
 }
 
+/**
+ * Build the compact `compose=` payload. Prefer the full self-contained draft
+ * (so a small draft opens instantly with content even before app-state polls),
+ * but if encoding the whole draft would blow the URL size budget, fall back to
+ * an id-only payload. `manage-draft` always persists the full draft to the
+ * `compose-{id}` app-state key, so the compose panel still resurfaces the
+ * complete draft by id for the creator — the URL just stays short.
+ */
+function encodeComposePayload(draft: Record<string, string>): string {
+  const full = encodeComposeDraft(draft);
+  if (Buffer.byteLength(full, "utf8") <= MAX_COMPOSE_PAYLOAD_BYTES) {
+    return full;
+  }
+  // Keep the id (required to resurface the persisted draft) plus a tiny
+  // subject hint so the link is still self-describing; drop the heavy body.
+  const compact: Record<string, string> = { id: draft.id };
+  if (draft.subject) compact.subject = draft.subject.slice(0, 120);
+  return encodeComposeDraft(compact);
+}
+
 /** Deep link that reopens a compose draft in the Mail compose panel. */
 function composeDeepLink(draft: Record<string, string>): string {
   return buildDeepLink({
     app: "mail",
     view: "inbox",
-    compose: encodeComposeDraft(draft),
+    compose: encodeComposePayload(draft),
   });
 }
 


### PR DESCRIPTION
Follow-up to #728 (merged). Fixes the bugs found by post-merge end-to-end testing (browser + live-server + installer agents) and the 6 Builder-bot review comments on #728. All re-validated E2E against real servers; `pnpm prep` green.

## HIGH / framework
- **Stdio proxy 401** — `/_agent-native/mcp` added to the auth-guard bypass allowlist (mirrors `/_agent-native/a2a`) so external MCP clients reach `mountMCP`'s own `verifyAuth`. Was 401 out of the box for every installed client. ✅ re-validated (proxy connects, tools/list works; no-auth still 401).
- **Local dev auto-session broken** — `AUTO_DEV_ACCOUNT_EMAIL` `dev@local` → `dev@local.test` (better-auth 1.6.0 rejects the TLD-less address); legacy dual-exclusion keeps pre-fix dev DBs correct. ✅ re-validated.
- **Calendar deep links 404** — calendar `resolveOpenPath` maps `view=calendar` → `/` (calendar renders at root; there is no `/calendar` route). ✅ re-validated (302→`/`→200).
- **Design handoff URL 401** — `publicPaths: ["/api/design-handoff"]` on design's `createAuthPlugin` (handler is signed-token-gated); `export-coding-handoff` returns an absolute `rawUrl`; `generate-design` gains a `link` builder. ✅ re-validated (anon signed-URL 200, forged 403).

## Builder-bot review fixes (#728)
- ACCESS_TOKEN MCP requests now carry caller identity (`AGENT_NATIVE_OWNER_EMAIL` env / `X-Agent-Native-Owner-Email` header).
- `open_app`/`create_workspace_app` use the target app origin; `ask_app` routes cross-app over A2A or reports local handling honestly.
- `/_agent-native/open` validates the decoded compose `draft.id` before using it as an app-state key.
- `pull-document` flush handshake written under the document owner's session (bounded no-editor fast path).
- `manage-draft` compose deep link capped at 1536B with id-only fallback.

## Hardening / docs
- MCP HTTP transport swallows benign post-flush `ERR_STREAM_WRITE_AFTER_END` so a disconnecting client can't crash the server.
- `external-agents` skill documents the dev-vs-production MCP tool surface.

Verification: `pnpm prep` green (fmt/typecheck/tests 1886+13+15/10 guards); core mcp suite 24/24; all 4 HIGH fixes re-validated end-to-end against real running servers with isolated DBs.