### PR TITLE
Improve Code chat UX and identity SSO

### DIFF
--- a/.agents/skills/authentication/SKILL.md
+++ b/.agents/skills/authentication/SKILL.md
@@ -48,6 +48,17 @@ Set `A2A_SECRET` (same value) on all apps that must verify each other's identity
 - Inbound calls are verified cryptographically
 - Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev)
 
+## Cross-App SSO (Dispatch identity hub)
+
+Each hosted `*.agent-native.com` app has its **own user store**, so "sign in once" is identity federation, not a shared cookie. **Dispatch is the identity authority.**
+
+- **Opt-in per app via one env var:** set `AGENT_NATIVE_IDENTITY_HUB_URL=https://dispatch.agent-native.com` and the app shows a "Sign in with Agent-Native" option. **Unset = zero behavior change** — the whole path is dormant. Reversible at any time.
+- **Flow:** app → `GET <hub>/_agent-native/identity/authorize?app=&redirect_uri=&state=` → user logs in at Dispatch → 302 back with a short-lived (`≤5min`) `A2A_SECRET`-signed identity JWT (`sub`/`email`/`name`/`org_domain`/`scope:"identity"`). Strict `redirect_uri` allowlist (`*.agent-native.com` + localhost). App verifies the token, **JIT-links strictly by verified email** (existing same-email user → reused unchanged; new email → created), then mints a normal local session.
+- **Invariant (do not break):** identity rows are only ever **added** — never modified, renamed, or deleted. Enabling SSO logs users out, but they always log back into the **same email-matched account with data intact**. Email is the only thing that crosses the trust boundary; the app never trusts a user id, role, or org from the wire.
+- **Canary rollout:** deploy with the env unset everywhere (no-op) → set it on **one** app (mail) only → verify (logout → SSO → Dispatch → back to the same pre-existing account, data intact, direct logins still work) → expand app-by-app → rollback = unset the env on that app's deploy (instant, no data change).
+
+Full runbook + flow detail: [Cross-App SSO doc](/docs/cross-app-sso).
+
 ## Builder Browser Access
 
 Apps can connect to Builder via the `cli-auth` flow and persist shared browser credentials in `.env`. Agents then use the built-in `get-browser-connection` tool to provision a real browser session via AI Services.
@@ -86,3 +97,4 @@ Bookmarked private paths already work without any plumbing — the framework's l
 
 - `security` — Data scoping, SQL injection, secrets
 - `actions` — Auto-protected by the auth guard
+- [Cross-App SSO doc](/docs/cross-app-sso) — Dispatch identity hub, federation flow, canary runbook

--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -13,12 +13,15 @@ description: >-
 ## Rule
 
 An agent-native app is reachable by any external coding agent (Claude Code,
-Cowork, Codex) over MCP. Every action that produces or lists a navigable
-resource SHOULD return a deep link from a `link` builder, so the external agent
-can surface an **"Open in <app> →"** link that drops the user back into the
-running UI at the right view and record. The link is a pure pointer — the
-record-focusing write is always scoped to the **browser session**, never the
-agent's token.
+Cowork, Codex) over MCP. The **recommended** way to connect to a deployed app
+is the one-command hosted flow — `npx @agent-native/core connect <url>` — which
+mints a per-user, scoped, revocable token from a logged-in browser session; no
+shared secret is copied. Once connected, every action that produces or lists a
+navigable resource SHOULD return a deep link from a `link` builder, so the
+external agent can surface an **"Open in <app> →"** link that drops the user
+back into the running UI at the right view and record. The link is a pure
+pointer — the record-focusing write is always scoped to the **browser
+session**, never the agent's token.
 
 ## Why
 
@@ -33,40 +36,38 @@ mechanism.
 
 ## How
 
-### 1. Connect an external agent over MCP
+### 1. Connect to a hosted app (recommended)
 
-The framework already mounts an HTTP MCP endpoint at `/_agent-native/mcp`
-(`mountMCP`). Every `defineAction` is exposed as an MCP tool, plus the
-`ask-agent` meta-tool that runs the full agent loop (same entry point A2A
-uses — see **a2a-protocol**). Hosted apps point an external agent at that URL
-with a bearer token (`ACCESS_TOKEN` / `A2A_SECRET` JWT carrying the caller's
-`sub` + `org_domain`, so tool runs stay tenant-scoped via
-`runWithRequestContext`).
-
-For local Claude Code / Codex / Cowork, one command writes the client config:
+The first-party hosted apps live at `mail.agent-native.com`,
+`calendar.agent-native.com`, etc. One command wires every detected agent
+client (Claude Code, Codex, Cowork) to one of them:
 
 ```bash
-agent-native mcp install --client claude-code|claude-code-cli|codex|cowork \
-  [--app <id>] [--scope user|project]
+npx @agent-native/core connect https://mail.agent-native.com
+# or connect every first-party hosted app at once:
+npx @agent-native/core connect --all
 ```
 
-It provisions a token (random `ACCESS_TOKEN` into the workspace `.env` for
-local dev, or a `signA2AToken` JWT for hosted) and writes an idempotent stdio
-server entry — `.mcp.json` / `~/.claude.json` for Claude Code, the
-`[mcp_servers.*]` block in `~/.codex/config.toml` for Codex, the Claude-Code
-JSON shape for Cowork. The entry runs `agent-native mcp serve --app <id>`,
-which by default is a **thin stdio proxy** to the running local app's
-`/_agent-native/mcp` (live action registry + HMR + correct deep links stay the
-single source of truth; `--standalone` builds the registry in-process).
-Companion subcommands: `mcp uninstall`, `mcp status`, `mcp token [--rotate]`.
+It opens the browser at the app; the user is already logged in and clicks
+**Authorize** once. No token to copy, no local server. The connection is
+**per-user, scoped, and revocable**. The no-CLI equivalent is the in-app
+**Connect** affordance served at `https://<app>/_agent-native/mcp/connect`,
+which hands back a one-click deep link or a ready-to-paste `.mcp.json` block.
 
-### 1b. Generic cross-app verbs + scaffolding
+Under the hood: a logged-in browser session mints an `A2A_SECRET`-signed JWT
+carrying the caller's `sub` + `org_domain` and a unique `jti`, so tool runs
+stay tenant-scoped via `runWithRequestContext`. The existing
+`/_agent-native/mcp` endpoint accepts it like any bearer — no new endpoint.
+The same Connect page lists and revokes minted tokens by `jti`; treat them
+like personal access tokens. Nothing exposes the deployment's shared secret.
 
-On top of the per-action tools the MCP server also exposes a stable verb set
-(see `packages/core/src/mcp/builtin-tools.ts`) so an external agent has a
-predictable surface without guessing per-app action names:
+### 1a. Generic cross-app verbs + scaffolding
 
-- `list_apps` — workspace apps + their dev URLs / running state.
+Once connected, on top of the per-action tools the MCP server also exposes a
+stable verb set (see `packages/core/src/mcp/builtin-tools.ts`) so an external
+agent has a predictable surface without guessing per-app action names:
+
+- `list_apps` — workspace apps + their URLs / running state.
 - `open_app({ app, view, params? })` — returns a `buildDeepLink` URL (no side
   effects); surfaces as an "Open …" link.
 - `ask_app({ app, message })` — routes a natural-language task to that app's
@@ -78,19 +79,6 @@ predictable surface without guessing per-app action names:
 
 A same-named template action overrides a builtin (template-over-core
 precedence). Disable the set with `MCPConfig.builtinCrossAppTools: false`.
-
-### 1c. Dev vs production tool surface (expect a sparse `tools/list` in plain dev)
-
-In plain local dev (`NODE_ENV=development` and `AGENT_MODE !== "production"`)
-the MCP `tools/list` deliberately exposes only the generic builtins plus
-actions with `publicAgent.requiresAuth === false` — the per-app ingest actions
-(`requiresAuth: true`) and mutating actions (no `publicAgent`) are filtered out
-(`filterPublicAgentActions`). The full per-app surface appears when the request
-is authenticated as a real caller: a deployed/`AGENT_MODE=production` app, or a
-local app reached through `agent-native mcp install` (which provisions an
-`ACCESS_TOKEN` / signed JWT so the caller has an identity). So if `tools/list`
-looks sparse, you are hitting an unauthenticated dev endpoint — install the MCP
-server (or present a token) rather than assuming the action is missing.
 
 ### 2. Add a `link` builder to an action
 
@@ -177,8 +165,43 @@ MCP/A2A exposure). Design/content ingest actions MUST read **live** state
 (e.g. the Yjs document) — not the stale DB snapshot column — so the external
 agent sees what the user actually has on screen.
 
+### 5. Advanced: local development & manual setup
+
+The hosted `connect` flow above is the recommended path. For local dev, run
+the app (`pnpm dev` / `agent-native dev`) then point a local agent at it:
+
+```bash
+agent-native mcp install --client claude-code|claude-code-cli|codex|cowork \
+  [--app <id>] [--scope user|project]
+```
+
+It provisions a token (random `ACCESS_TOKEN` into the workspace `.env` for
+local dev, or a `signA2AToken` JWT for a detected hosted origin) and writes an
+idempotent stdio server entry — `.mcp.json` / `~/.claude.json` for Claude Code,
+the `[mcp_servers.*]` block in `~/.codex/config.toml` for Codex, the
+Claude-Code JSON shape for Cowork. The entry runs `agent-native mcp serve
+--app <id>`, by default a **thin stdio proxy** to the running local app's
+`/_agent-native/mcp` (live registry + HMR + correct deep links stay the single
+source of truth; `--standalone` builds the registry in-process). Companion
+subcommands: `mcp uninstall`, `mcp status`, `mcp token [--rotate]`. You can
+also hand-write an `http` `.mcp.json` entry with a token you supply yourself —
+the unmanaged equivalent of what `connect` writes.
+
+**Dev vs production tool surface:** in plain local dev
+(`NODE_ENV=development` and `AGENT_MODE !== "production"`) the MCP `tools/list`
+deliberately exposes only the generic builtins plus actions with
+`publicAgent.requiresAuth === false` — per-app ingest (`requiresAuth: true`)
+and mutating actions are filtered out (`filterPublicAgentActions`). The full
+surface appears when authenticated as a real caller: a deployed /
+`AGENT_MODE=production` app, or a local app reached through `connect` /
+`agent-native mcp install` (which provisions an identity-bearing token). A
+sparse `tools/list` means you are hitting an unauthenticated dev endpoint —
+connect or present a token rather than assuming the action is missing.
+
 ## Do
 
+- Do connect to a hosted app with `npx @agent-native/core connect <url>` (or
+  `--all`) — it mints a per-user, revocable token; no shared secret copied.
 - Do add a `link` builder to any action that produces or lists a navigable
   resource (draft, event, dashboard, document).
 - Do build the URL with `buildDeepLink(...)` — it is the single source of truth
@@ -192,6 +215,8 @@ agent sees what the user actually has on screen.
 
 ## Don't
 
+- Don't copy a deployment's shared `ACCESS_TOKEN` / `A2A_SECRET` into a client
+  config when `connect` can mint a per-user, revocable token instead.
 - Don't hand-format the `/_agent-native/open` URL — always go through
   `buildDeepLink`.
 - Don't do I/O, awaits, DB reads, or app-state reads inside a `link` builder.
@@ -211,3 +236,4 @@ agent sees what the user actually has on screen.
 - **a2a-protocol** — the `ask-agent` meta-tool and JSON-RPC peer calls
 - **adding-a-feature** — the four-area checklist (add a `link` builder when a
   feature produces a navigable resource)
+</content>

--- a/.changeset/cross-app-sso.md
+++ b/.changeset/cross-app-sso.md
@@ -1,0 +1,19 @@
+---
+"@agent-native/core": minor
+---
+
+Cross-app SSO ("Sign in with Agent-Native", Dispatch as identity authority).
+New opt-in env `AGENT_NATIVE_IDENTITY_HUB_URL`: when set, an app exposes
+`/_agent-native/identity/login` + `/callback`, redirects to the hub's
+`/_agent-native/identity/authorize`, verifies the short-lived `A2A_SECRET`-
+signed identity token (strict `scope:"identity"`, single-use CSRF state,
+`iat`/`exp` bounds), and **JIT-links to the local Better Auth user strictly by
+verified email** — existing same-email user is linked (additive `account` row
+via the adapter; the user/session rows are never modified, renamed, or
+deleted), new email is created via the normal signup path — then mints a normal
+local session. Unset = zero behavior change (fully reversible; per-app canary
+via one env var). Identity rows are only ever added to, so rolling this out
+logs users out once and they log back into the *same* account with data intact.
+Includes the `redirect()` staged-`Set-Cookie`-on-302 fix so the session
+survives the federated callback. The Dispatch-side identity authority lives in
+the (private) dispatch template.

--- a/.changeset/cross-app-sso.md
+++ b/.changeset/cross-app-sso.md
@@ -13,7 +13,7 @@ via the adapter; the user/session rows are never modified, renamed, or
 deleted), new email is created via the normal signup path — then mints a normal
 local session. Unset = zero behavior change (fully reversible; per-app canary
 via one env var). Identity rows are only ever added to, so rolling this out
-logs users out once and they log back into the *same* account with data intact.
+logs users out once and they log back into the _same_ account with data intact.
 Includes the `redirect()` staged-`Set-Cookie`-on-302 fix so the session
 survives the federated callback. The Dispatch-side identity authority lives in
 the (private) dispatch template.

--- a/.changeset/dev-auto-signin-cookie.md
+++ b/.changeset/dev-auto-signin-cookie.md
@@ -1,0 +1,15 @@
+---
+"@agent-native/core": patch
+---
+
+Fix local-dev zero-setup auto-sign-in: the session cookie is now emitted on
+the 302 itself. `maybeAutoCreateDevSession` returned a bare
+`new Response("", { status: 302, headers: { Location } })` after staging the
+session cookie via `setFrameworkSessionCookie`. h3 v2's `prepareResponse`
+only merges the event's staged response headers into a returned web
+`Response` when that Response is 2xx — its `!val.ok` early-return hands a
+non-2xx Response (like a 302) back as-is, dropping the staged `Set-Cookie`.
+A fresh `pnpm dev` therefore 302'd straight to the app and bounced back to
+the login form. A new `redirectWithStagedCookies` helper mirrors the staged
+cookies onto the redirect Response's own headers so the 302 actually carries
+the session.

--- a/.changeset/dev-auto-signin-cookie.md
+++ b/.changeset/dev-auto-signin-cookie.md
@@ -13,3 +13,12 @@ A fresh `pnpm dev` therefore 302'd straight to the app and bounced back to
 the login form. A new `redirectWithStagedCookies` helper mirrors the staged
 cookies onto the redirect Response's own headers so the 302 actually carries
 the session.
+
+Also hardens the dev auto-account so the convenience can't become an
+exposure: it now (1) only fires for **loopback** requests — a new shared
+`isLoopbackRequest` helper (also adopted by the desktop-SSO broker) so a
+tunnelled / reverse-proxied / misconfigured-non-prod dev server never
+auto-signs-in a remote visitor; and (2) mints a **random per-DB password**
+printed to the server console once, instead of the source-code-known fixed
+`local-dev-account`, so there is no shared credential to reuse. Still gated
+on `NODE_ENV` and `AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT=1`.

--- a/.changeset/mcp-connect-flow.md
+++ b/.changeset/mcp-connect-flow.md
@@ -1,0 +1,16 @@
+---
+"@agent-native/core": minor
+---
+
+Frictionless connect for external agents. New `agent-native connect <url>`
+(and `connect --all`) drives an OAuth-style device-code flow: a logged-in
+browser session mints a per-user, scoped, **revocable** MCP token (an
+`A2A_SECRET`-signed JWT with a `jti`) and the CLI writes the HTTP MCP server
+entry for every detected client (Claude Code desktop/CLI, Codex, Cowork) — no
+shared secret copying, no local server. Adds the framework-served
+`/_agent-native/mcp/connect` page + token mint / device-code / list / revoke
+endpoints (mounted by the core routes plugin, gated by `disableMcpConnect`),
+two additive framework tables (`mcp_connect_tokens`, `mcp_device_codes`), a
+`jti` revoke check in the MCP `verifyAuth`, and an optional `extraClaims` on
+`signA2AToken`. Connecting to hosted apps is now the primary documented path;
+local-dev `mcp install` / stdio remains as the advanced path.

--- a/.changeset/resources-panel-context-cleanup.md
+++ b/.changeset/resources-panel-context-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Remove the "Effective context" card grid from the resources editor and replace the section-title hover tooltips (Workspace / Organization / Personal) with a dedicated small help icon. The inherited Workspace section is now hidden unless workspace context exists.

--- a/.changeset/shared-code-tab-chat.md
+++ b/.changeset/shared-code-tab-chat.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Share composer submit intent, transcript normalization, and conversation scroll primitives with Agent-Native Code.

--- a/.github/workflows/hide-preview-bot-comments.yml
+++ b/.github/workflows/hide-preview-bot-comments.yml
@@ -1,4 +1,4 @@
-name: Hide Cloudflare Pages bot comment
+name: Hide preview bot comments
 
 on:
   issue_comment:
@@ -10,7 +10,10 @@ permissions:
 
 jobs:
   minimize:
-    if: github.event.issue.pull_request && github.event.comment.user.login == 'cloudflare-workers-and-pages[bot]'
+    if: >-
+      github.event.issue.pull_request &&
+      (github.event.comment.user.login == 'cloudflare-workers-and-pages[bot]' ||
+       github.event.comment.user.login == 'netlify[bot]')
     runs-on: ubuntu-latest
     steps:
       - name: Minimize comment

--- a/README.md
+++ b/README.md
@@ -141,17 +141,7 @@ Message, manage, and delegate to agents from Slack, Telegram, or the web. Dispat
 Generate forms from a prompt, branch logic with the agent, and own every response in your own database.
 
 </td>
-<td width="33%" align="center" valign="top">
-
-**Brain**
-
-<a href="https://agent-native.com/templates/brain"><strong>Open Brain template</strong></a>
-
-**Company chat with cited memory**
-
-Ask clean company chat questions backed by cited institutional memory from approved Slack, meetings, transcripts, GitHub, and webhooks. For live app-owned data, Brain can delegate to specialized agents instead of owning every connector itself.
-
-</td>
+<td width="33%" align="center" valign="top"></td>
 <td width="33%" align="center" valign="top"></td>
 </tr>
 </table>

--- a/packages/code-agents-ui/src/CodeAgentsApp.tsx
+++ b/packages/code-agents-ui/src/CodeAgentsApp.tsx
@@ -22,6 +22,7 @@ import {
   IconPinnedOff,
   IconPlus,
   IconPlayerPlay,
+  IconPlayerStop,
   IconQrcode,
   IconRefresh,
   IconRoute,
@@ -31,13 +32,16 @@ import {
 } from "@tabler/icons-react";
 import { QRCodeSVG } from "qrcode.react";
 import {
+  AgentConversation,
   PromptComposer,
+  type AgentConversationMessage,
   type PromptComposerFile,
   type SlashCommand,
   type TiptapComposerHandle,
 } from "@agent-native/core/client";
 import { toast } from "sonner";
 import { readCodeAgentPromptAttachment } from "./composer-primitives.js";
+import { normalizeCodeAgentTranscriptForConversation } from "./transcript-conversation.js";
 import {
   CODE_AGENT_GOALS,
   DEFAULT_CODE_AGENT_PERMISSION_MODE,
@@ -100,6 +104,7 @@ import type {
   CodeAgentTranscriptEvent,
   CodeAgentTranscriptRequest,
   CodeAgentTranscriptResult,
+  CodeAgentTranscriptSubscriptionBatch,
   CodeAgentUpdateRunRequest,
   CodeAgentUpdateRunResult,
   CodeAgentsOpenRequest,
@@ -119,6 +124,10 @@ export interface CodeAgentsHost {
   readTranscript(
     request: CodeAgentTranscriptRequest,
   ): Promise<CodeAgentTranscriptResult>;
+  subscribeTranscript?(
+    request: CodeAgentTranscriptRequest,
+    callback: (batch: CodeAgentTranscriptSubscriptionBatch) => void,
+  ): () => void;
   appendFollowUp(
     request: CodeAgentFollowUpRequest,
   ): Promise<CodeAgentFollowUpResult>;
@@ -318,8 +327,6 @@ export default function CodeAgentsApp({
   const [modelSelection, setModelSelection] = useState<CodeAgentModelSelection>(
     () => readStoredModelSelection(),
   );
-  const [followUpMode, setFollowUpMode] =
-    useState<CodeAgentFollowUpMode>("immediate");
   const [remoteConnectorStatus, setRemoteConnectorStatus] =
     useState<CodeAgentRemoteConnectorStatus | null>(null);
   const [remoteConnectorError, setRemoteConnectorError] = useState<
@@ -707,12 +714,34 @@ export default function CodeAgentsApp({
   useEffect(() => {
     void loadTranscript(selectedRunId, true);
     if (!selectedRunId) return;
+    const unsubscribe = host.subscribeTranscript?.(
+      { goalId: selectedGoal.id, runId: selectedRunId },
+      (batch) => {
+        if (batch.runId && batch.runId !== selectedRunId) return;
+        if (batch.error) setTranscriptError(batch.error);
+        if (batch.status === "ok" && batch.events.length > 0) {
+          setTranscriptError(null);
+          setTranscriptEvents((current) =>
+            mergeTranscriptEvents(current, batch.events),
+          );
+        }
+      },
+    );
     const interval = window.setInterval(
       () => void loadTranscript(selectedRunId),
       selectedRunIsActive ? 1_000 : 5_000,
     );
-    return () => window.clearInterval(interval);
-  }, [loadTranscript, selectedRunId, selectedRunIsActive]);
+    return () => {
+      unsubscribe?.();
+      window.clearInterval(interval);
+    };
+  }, [
+    host,
+    loadTranscript,
+    selectedGoal.id,
+    selectedRunId,
+    selectedRunIsActive,
+  ]);
 
   async function selectProjectFolder(pathValue: string) {
     if (!pathValue) return;
@@ -1496,21 +1525,18 @@ export default function CodeAgentsApp({
                     transcriptLoading={transcriptLoading}
                     transcriptError={transcriptError}
                     followUpPrompt={followUpPrompt}
-                    followUpMode={followUpMode}
                     submittingFollowUp={submittingFollowUp}
                     permissionMode={selectedPermissionMode}
                     modelSelection={selectedModelSelection}
                     modelOptions={modelOptions}
                     updatingPermissionMode={updatingPermissionMode}
                     onFollowUpPromptChange={setFollowUpPrompt}
-                    onFollowUpModeChange={setFollowUpMode}
                     onPermissionModeChange={changeSelectedPermissionMode}
                     onModelSelectionChange={setModelSelection}
                     onSubmitFollowUp={submitFollowUp}
                     onOpenWorkbench={() => setWorkbenchOpen(true)}
                     onOpenTerminal={canOpenTerminal ? openTerminal : undefined}
                     onResume={() => controlRun("resume")}
-                    onRefreshStatus={() => controlRun("status")}
                     onStop={() => controlRun("stop")}
                     onApprove={() => controlRun("approve")}
                     onRetry={host.retryRun ? retrySelectedRun : undefined}
@@ -1736,37 +1762,34 @@ function CodeAgentComposer({
   inputRef,
   submitting,
   permissionMode,
-  followUpMode = "immediate",
-  showFollowUpMode = false,
   modelSelection,
   modelOptions,
   slashCommands = [],
   placeholder,
   variant = "compact",
   disabled = false,
+  stopActive = false,
   onPromptChange,
   onPermissionModeChange,
-  onFollowUpModeChange,
   onModelSelectionChange,
   onSlashCommand,
   onSubmit,
+  onStop,
 }: {
   prompt: string;
   promptSeed?: string | number;
   inputRef?: React.RefObject<TiptapComposerHandle | null>;
   submitting: boolean;
   permissionMode: CodeAgentPermissionMode;
-  followUpMode?: CodeAgentFollowUpMode;
-  showFollowUpMode?: boolean;
   modelSelection: CodeAgentModelSelection;
   modelOptions: CodeAgentModelOption[];
   slashCommands?: SlashCommand[];
   placeholder: string;
   variant?: "hero" | "compact";
   disabled?: boolean;
+  stopActive?: boolean;
   onPromptChange: (value: string) => void;
   onPermissionModeChange: (value: CodeAgentPermissionMode) => void;
-  onFollowUpModeChange?: (value: CodeAgentFollowUpMode) => void;
   onModelSelectionChange: (value: CodeAgentModelSelection) => void;
   onSlashCommand?: (command: string) => void;
   onSubmit: (
@@ -1774,6 +1797,7 @@ function CodeAgentComposer({
     attachments: CodeAgentPromptAttachment[],
     followUpMode?: CodeAgentFollowUpMode,
   ) => void;
+  onStop?: () => void;
 }) {
   const composerModelGroups = useMemo(
     () => modelOptionsToComposerGroups(modelOptions),
@@ -1824,14 +1848,21 @@ function CodeAgentComposer({
         onChange={onPermissionModeChange}
         compact
       />
-      {showFollowUpMode && onFollowUpModeChange && (
-        <FollowUpModeSelect
-          value={followUpMode}
-          onChange={onFollowUpModeChange}
-        />
-      )}
     </div>
   );
+
+  const stopButton =
+    stopActive && onStop ? (
+      <button
+        type="button"
+        onClick={onStop}
+        className="code-agents-composer-stop-button"
+        aria-label="Stop session"
+        title="Stop session (Esc)"
+      >
+        <IconPlayerStop size={14} strokeWidth={1.9} />
+      </button>
+    ) : undefined;
 
   return (
     <PromptComposer
@@ -1850,6 +1881,7 @@ function CodeAgentComposer({
       initialText={promptSeed !== undefined ? prompt : undefined}
       initialTextKey={promptSeed}
       toolbarSlot={modeControl}
+      actionButton={stopButton}
       availableModels={composerModelGroups}
       selectedModel={selectedModel}
       selectedEngine={selectedEngine}
@@ -1860,9 +1892,13 @@ function CodeAgentComposer({
       slashCommands={slashCommands}
       includeDefaultSlashSkills={false}
       onSlashCommand={onSlashCommand}
-      onSubmit={async (text, files) => {
+      onSubmit={async (text, files, _references, options) => {
         const attachments = await readPromptFiles(files);
-        onSubmit(text, attachments, followUpMode);
+        onSubmit(
+          text,
+          attachments,
+          options.intent === "queued" ? "queued" : "immediate",
+        );
       }}
       attachmentsEnabled
       voiceEnabled
@@ -2153,47 +2189,6 @@ function RunModeSelect({
   );
 }
 
-function FollowUpModeSelect({
-  value,
-  onChange,
-}: {
-  value: CodeAgentFollowUpMode;
-  onChange: (value: CodeAgentFollowUpMode) => void;
-}) {
-  return (
-    <Select
-      value={value}
-      onValueChange={(nextValue) =>
-        onChange(nextValue === "queued" ? "queued" : "immediate")
-      }
-    >
-      <SelectTrigger
-        className="code-agents-follow-up-mode-select"
-        aria-label="Follow-up delivery"
-        title="Choose how this follow-up reaches the active run"
-      >
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectGroup>
-          <SelectItem
-            value="immediate"
-            description="Send to the active run at its next safe steering point."
-          >
-            Send now
-          </SelectItem>
-          <SelectItem
-            value="queued"
-            description="Run after the current turn finishes."
-          >
-            Queue
-          </SelectItem>
-        </SelectGroup>
-      </SelectContent>
-    </Select>
-  );
-}
-
 function runModeFromPermissionMode(
   permissionMode: CodeAgentPermissionMode,
 ): CodeAgentRunMode {
@@ -2406,6 +2401,33 @@ function findTranscriptSearchMatch(
   return event ? getSearchMatchSnippet(event.text, tokens) : null;
 }
 
+function mergeTranscriptEvents(
+  current: CodeAgentTranscriptEvent[],
+  incoming: CodeAgentTranscriptEvent[],
+): CodeAgentTranscriptEvent[] {
+  if (incoming.length === 0) return current;
+  const byId = new Map(current.map((event) => [event.id, event]));
+  for (const event of incoming) byId.set(event.id, event);
+  return [...byId.values()].sort(compareTranscriptEvents);
+}
+
+function compareTranscriptEvents(
+  a: CodeAgentTranscriptEvent,
+  b: CodeAgentTranscriptEvent,
+): number {
+  const seqA = getTranscriptSeq(a);
+  const seqB = getTranscriptSeq(b);
+  if (seqA !== null && seqB !== null && seqA !== seqB) return seqA - seqB;
+  const created = a.createdAt.localeCompare(b.createdAt);
+  if (created !== 0) return created;
+  return a.id.localeCompare(b.id);
+}
+
+function getTranscriptSeq(event: CodeAgentTranscriptEvent): number | null {
+  const value = event.metadata?.seq;
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
 function getSearchMatchSnippet(text: string, tokens: string[]): string {
   const compact = text.trim().replace(/\s+/g, " ");
   if (!compact) return "";
@@ -2436,58 +2458,6 @@ function getSearchResultMeta(run: CodeAgentRun): string {
     .join(" · ");
 }
 
-function transcriptEventsForChat(
-  events: CodeAgentTranscriptEvent[],
-  options: { hideCredentialMessages?: boolean } = {},
-): CodeAgentTranscriptEvent[] {
-  const compactEvents: CodeAgentTranscriptEvent[] = [];
-  const seenCredentialMessages = new Set<string>();
-
-  for (const event of events) {
-    if (isLowSignalTranscriptEvent(event)) continue;
-    if (options.hideCredentialMessages && isCredentialTranscriptEvent(event)) {
-      continue;
-    }
-
-    const normalizedText = normalizeTranscriptText(event.text);
-    if (isCredentialTranscriptEvent(event)) {
-      if (seenCredentialMessages.has(normalizedText)) continue;
-      seenCredentialMessages.add(normalizedText);
-    }
-
-    const previous = compactEvents[compactEvents.length - 1];
-    if (
-      previous &&
-      previous.type === event.type &&
-      (previous.title ?? "") === (event.title ?? "") &&
-      normalizeTranscriptText(previous.text) === normalizedText
-    ) {
-      continue;
-    }
-
-    compactEvents.push(event);
-  }
-
-  return compactEvents;
-}
-
-function isLowSignalTranscriptEvent(event: CodeAgentTranscriptEvent): boolean {
-  if (event.type !== "status") return false;
-  const text = normalizeTranscriptText(event.text);
-  return (
-    text === "Agent-Native Code run started." ||
-    text === "Agent-Native Code process exited."
-  );
-}
-
-function isCredentialTranscriptEvent(event: CodeAgentTranscriptEvent): boolean {
-  return /No LLM provider key was found|Missing credentials/i.test(event.text);
-}
-
-function normalizeTranscriptText(value: string): string {
-  return value.trim().replace(/\s+/g, " ");
-}
-
 function getRunStatusText(run: CodeAgentRun): string {
   if (run.status === "completed" || run.phase === "complete") return "Done";
   if (run.phase === "missing-credentials") return "Needs provider";
@@ -2504,38 +2474,14 @@ function getSessionMeta(run: CodeAgentRun, sourceLabel: string | null): string {
     .join(" · ");
 }
 
-function getTranscriptEventAuthor(event: CodeAgentTranscriptEvent): string {
-  if (event.title && event.title !== "Status") return event.title;
-  if (event.type === "user") return "You";
-  if (event.type === "artifact") return "Artifact";
-  if (event.type === "status") return "Update";
-  return "Agent";
-}
-
-function getTranscriptEventTone(event: CodeAgentTranscriptEvent): string {
-  if (event.type === "user") return "user";
-  if (event.type === "artifact") return "artifact";
-  if (isCredentialTranscriptEvent(event)) return "warning";
-  if (event.type === "status") return "status";
-  return "agent";
-}
-
 function runControlButtons({
-  run,
   goal,
-  onResume,
-  onRefreshStatus,
-  onStop,
   onRetry,
   onRerun,
   onOpenWorkbench,
   onOpenTerminal,
 }: {
-  run: CodeAgentRun;
   goal: CodeAgentGoalDefinition;
-  onResume: () => void;
-  onRefreshStatus: () => void;
-  onStop: () => void;
   onRetry?: () => void;
   onRerun?: () => void;
   onOpenWorkbench: () => void;
@@ -2547,28 +2493,6 @@ function runControlButtons({
   onClick: () => void;
 }> {
   return [
-    {
-      key: "resume",
-      label: "Resume",
-      icon: <IconPlayerPlay size={14} strokeWidth={1.8} />,
-      onClick: onResume,
-    },
-    {
-      key: "status",
-      label: "Status",
-      icon: <IconRefresh size={14} strokeWidth={1.8} />,
-      onClick: onRefreshStatus,
-    },
-    ...(run.status !== "completed" && run.phase !== "complete"
-      ? [
-          {
-            key: "stop",
-            label: "Stop",
-            icon: <IconAlertCircle size={14} strokeWidth={1.8} />,
-            onClick: onStop,
-          },
-        ]
-      : []),
     ...(onRetry
       ? [
           {
@@ -3123,21 +3047,18 @@ function RunDetailCard({
   transcriptLoading,
   transcriptError,
   followUpPrompt,
-  followUpMode,
   submittingFollowUp,
   permissionMode,
   modelSelection,
   modelOptions,
   updatingPermissionMode,
   onFollowUpPromptChange,
-  onFollowUpModeChange,
   onPermissionModeChange,
   onModelSelectionChange,
   onSubmitFollowUp,
   onOpenWorkbench,
   onOpenTerminal,
   onResume,
-  onRefreshStatus,
   onStop,
   onApprove,
   onRetry,
@@ -3154,14 +3075,12 @@ function RunDetailCard({
   transcriptLoading: boolean;
   transcriptError: string | null;
   followUpPrompt: string;
-  followUpMode: CodeAgentFollowUpMode;
   submittingFollowUp: boolean;
   permissionMode: CodeAgentPermissionMode;
   modelSelection: CodeAgentModelSelection;
   modelOptions: CodeAgentModelOption[];
   updatingPermissionMode: boolean;
   onFollowUpPromptChange: (value: string) => void;
-  onFollowUpModeChange: (value: CodeAgentFollowUpMode) => void;
   onPermissionModeChange: (value: CodeAgentPermissionMode) => void;
   onModelSelectionChange: (value: CodeAgentModelSelection) => void;
   onSubmitFollowUp: (
@@ -3172,7 +3091,6 @@ function RunDetailCard({
   onOpenWorkbench: () => void;
   onOpenTerminal?: () => void;
   onResume: () => void;
-  onRefreshStatus: () => void;
   onStop: () => void;
   onApprove: () => void;
   onRetry?: () => void;
@@ -3182,6 +3100,19 @@ function RunDetailCard({
   onConnectBuilder: () => void;
   onOpenSettings?: () => void;
 }) {
+  const runIsActive = run ? isRunActive(run) : false;
+
+  useEffect(() => {
+    if (!runIsActive) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      onStop();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onStop, runIsActive]);
+
   if (!run) {
     return (
       <div className="code-agents-detail code-agents-detail--empty">
@@ -3210,11 +3141,7 @@ function RunDetailCard({
   const hasCredentialGap = hasMissingCredentialSignal(run, transcriptEvents);
   const pendingApproval = hasCredentialGap ? null : getPendingApproval(run);
   const controlButtons = runControlButtons({
-    run,
     goal,
-    onResume,
-    onRefreshStatus,
-    onStop,
     onRetry,
     onRerun,
     onOpenWorkbench,
@@ -3309,23 +3236,41 @@ function RunDetailCard({
         </div>
       )}
 
+      {!pendingApproval &&
+        (run.status === "paused" || run.phase === "paused") && (
+          <div className="code-agents-approval-callout">
+            <IconPlayerPlay size={16} strokeWidth={1.8} />
+            <div>
+              <strong>Session paused</strong>
+              <span>Resume when you are ready for Code to continue.</span>
+            </div>
+            <button
+              type="button"
+              className="code-agents-button code-agents-button--primary"
+              onClick={onResume}
+            >
+              <IconPlayerPlay size={14} strokeWidth={1.8} />
+              Resume
+            </button>
+          </div>
+        )}
+
       <TranscriptPanel
         events={transcriptEvents}
         loading={transcriptLoading}
         error={transcriptError}
         followUpPrompt={followUpPrompt}
-        followUpMode={followUpMode}
-        runIsActive={isRunActive(run)}
+        runIsActive={runIsActive}
         submitting={submittingFollowUp}
         permissionMode={permissionMode}
         modelSelection={modelSelection}
         modelOptions={modelOptions}
         hideCredentialMessages={hasCredentialGap}
         onFollowUpPromptChange={onFollowUpPromptChange}
-        onFollowUpModeChange={onFollowUpModeChange}
         onPermissionModeChange={onPermissionModeChange}
         onModelSelectionChange={onModelSelectionChange}
         onSubmitFollowUp={onSubmitFollowUp}
+        onStop={onStop}
       />
     </div>
   );
@@ -3336,7 +3281,6 @@ function TranscriptPanel({
   loading,
   error,
   followUpPrompt,
-  followUpMode,
   runIsActive,
   submitting,
   permissionMode,
@@ -3344,16 +3288,15 @@ function TranscriptPanel({
   modelOptions,
   hideCredentialMessages = false,
   onFollowUpPromptChange,
-  onFollowUpModeChange,
   onPermissionModeChange,
   onModelSelectionChange,
   onSubmitFollowUp,
+  onStop,
 }: {
   events: CodeAgentTranscriptEvent[];
   loading: boolean;
   error: string | null;
   followUpPrompt: string;
-  followUpMode: CodeAgentFollowUpMode;
   runIsActive: boolean;
   submitting: boolean;
   permissionMode: CodeAgentPermissionMode;
@@ -3361,7 +3304,6 @@ function TranscriptPanel({
   modelOptions: CodeAgentModelOption[];
   hideCredentialMessages?: boolean;
   onFollowUpPromptChange: (value: string) => void;
-  onFollowUpModeChange: (value: CodeAgentFollowUpMode) => void;
   onPermissionModeChange: (value: CodeAgentPermissionMode) => void;
   onModelSelectionChange: (value: CodeAgentModelSelection) => void;
   onSubmitFollowUp: (
@@ -3369,149 +3311,43 @@ function TranscriptPanel({
     attachments: CodeAgentPromptAttachment[],
     followUpMode?: CodeAgentFollowUpMode,
   ) => void;
+  onStop: () => void;
 }) {
-  const timelineRef = useRef<HTMLDivElement | null>(null);
-  const visibleEvents = useMemo(
+  const messages = useMemo<AgentConversationMessage[]>(
     () =>
-      transcriptEventsForChat(events, {
+      normalizeCodeAgentTranscriptForConversation(events, {
         hideCredentialMessages,
       }),
     [events, hideCredentialMessages],
   );
 
-  useEffect(() => {
-    const timeline = timelineRef.current;
-    if (!timeline) return;
-    timeline.scrollTo({ top: timeline.scrollHeight, behavior: "smooth" });
-  }, [visibleEvents.length]);
-
   return (
-    <section className="code-agents-transcript" aria-label="Session transcript">
-      {error && (
-        <div className="code-agents-transcript__error">
-          <IconAlertCircle size={14} strokeWidth={1.8} />
-          <span>{error}</span>
-        </div>
-      )}
-
-      <div className="code-agents-transcript__timeline" ref={timelineRef}>
-        {loading && visibleEvents.length === 0 ? (
-          <div className="code-agents-transcript__empty">
-            <IconRefresh
-              size={16}
-              strokeWidth={1.8}
-              className="code-agents-spin"
-            />
-            <p>Loading session...</p>
-          </div>
-        ) : visibleEvents.length === 0 ? (
-          <div className="code-agents-transcript__empty">
-            <IconClock size={18} strokeWidth={1.7} />
-            <p>No messages yet.</p>
-          </div>
-        ) : (
-          visibleEvents.map((event) => (
-            <TranscriptEventItem key={event.id} event={event} />
-          ))
-        )}
-      </div>
-
-      <CodeAgentComposer
-        prompt={followUpPrompt}
-        submitting={submitting}
-        permissionMode={permissionMode}
-        followUpMode={followUpMode}
-        showFollowUpMode={runIsActive}
-        modelSelection={modelSelection}
-        modelOptions={modelOptions}
-        placeholder="Ask for follow-up changes"
-        onPromptChange={onFollowUpPromptChange}
-        onFollowUpModeChange={onFollowUpModeChange}
-        onPermissionModeChange={onPermissionModeChange}
-        onModelSelectionChange={onModelSelectionChange}
-        onSubmit={onSubmitFollowUp}
-      />
-    </section>
+    <AgentConversation
+      className="code-agents-transcript"
+      timelineClassName="code-agents-transcript__timeline"
+      messages={messages}
+      loading={loading}
+      error={error}
+      streaming={runIsActive}
+      emptyTitle="No messages yet."
+      composer={
+        <CodeAgentComposer
+          prompt={followUpPrompt}
+          submitting={submitting}
+          permissionMode={permissionMode}
+          modelSelection={modelSelection}
+          modelOptions={modelOptions}
+          placeholder="Ask for follow-up changes"
+          onPromptChange={onFollowUpPromptChange}
+          onPermissionModeChange={onPermissionModeChange}
+          onModelSelectionChange={onModelSelectionChange}
+          onSubmit={onSubmitFollowUp}
+          stopActive={runIsActive}
+          onStop={onStop}
+        />
+      }
+    />
   );
-}
-
-function TranscriptEventItem({ event }: { event: CodeAgentTranscriptEvent }) {
-  const toolName = getTranscriptToolName(event);
-  const toolInput = getMetadataPreview(event.metadata?.input);
-  const toolResult = getMetadataPreview(event.metadata?.result);
-  const tone = getTranscriptEventTone(event);
-  return (
-    <article
-      className={`code-agents-transcript-event code-agents-transcript-event--${tone}`}
-    >
-      <div className="code-agents-transcript-event__body">
-        <div className="code-agents-transcript-event__meta">
-          <span>{getTranscriptEventAuthor(event)}</span>
-          <time dateTime={event.createdAt}>
-            {formatRelativeTime(event.createdAt)}
-          </time>
-        </div>
-        <p>{event.text}</p>
-        {toolName && (
-          <details className="code-agents-tool-event">
-            <summary>
-              <span>{toolName}</span>
-              <span>{toolEventLabel(event)}</span>
-            </summary>
-            {(toolInput || toolResult) && (
-              <div className="code-agents-tool-event__body">
-                {toolInput && (
-                  <pre>
-                    <strong>input</strong>
-                    {toolInput}
-                  </pre>
-                )}
-                {toolResult && (
-                  <pre>
-                    <strong>result</strong>
-                    {toolResult}
-                  </pre>
-                )}
-              </div>
-            )}
-          </details>
-        )}
-        {(event.artifactPath || event.artifactUrl) && (
-          <div className="code-agents-transcript-event__artifact">
-            {event.artifactPath && <code>{event.artifactPath}</code>}
-            {event.artifactUrl && (
-              <a href={event.artifactUrl} target="_blank" rel="noreferrer">
-                <IconExternalLink size={13} strokeWidth={1.8} />
-                Open artifact
-              </a>
-            )}
-          </div>
-        )}
-      </div>
-    </article>
-  );
-}
-
-function getTranscriptToolName(event: CodeAgentTranscriptEvent): string | null {
-  const value = event.metadata?.tool;
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
-function toolEventLabel(event: CodeAgentTranscriptEvent): string {
-  const value = event.metadata?.type;
-  if (value === "tool_start") return "started";
-  if (value === "tool_done") return "finished";
-  if (value === "activity") return "activity";
-  return "tool event";
-}
-
-function getMetadataPreview(value: unknown): string | null {
-  if (value === undefined || value === null) return null;
-  const text =
-    typeof value === "string" ? value : (JSON.stringify(value, null, 2) ?? "");
-  const trimmed = text.trim();
-  if (!trimmed) return null;
-  return trimmed.length > 1800 ? `${trimmed.slice(0, 1800)}\n...` : trimmed;
 }
 
 function Field({ label, value }: { label: string; value: string }) {

--- a/packages/code-agents-ui/src/styles.css
+++ b/packages/code-agents-ui/src/styles.css
@@ -1757,10 +1757,6 @@
   min-width: 0;
 }
 
-.code-agents-follow-up-mode-select {
-  width: 112px;
-}
-
 .desktop-select-trigger {
   display: inline-flex;
   height: 30px;
@@ -2076,6 +2072,268 @@
   padding: 4px 2px 8px;
 }
 
+.agent-conversation {
+  position: relative;
+}
+
+.agent-conversation__error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid hsl(var(--destructive) / 0.24);
+  border-radius: var(--radius);
+  background: hsl(var(--destructive) / 0.08);
+  color: hsl(var(--destructive-foreground));
+  font-size: 12px;
+}
+
+.agent-conversation__empty {
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  color: hsl(var(--muted-foreground));
+  font-size: 12px;
+}
+
+.agent-conversation__empty span {
+  color: hsl(var(--muted-foreground));
+}
+
+.agent-conversation__scroll-bottom {
+  position: absolute;
+  right: 18px;
+  bottom: 92px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 999px;
+  background: hsl(var(--popover));
+  color: hsl(var(--foreground));
+  box-shadow: 0 10px 30px hsl(var(--background) / 0.28);
+  cursor: pointer;
+}
+
+.agent-conversation-message {
+  display: flex;
+  width: 100%;
+}
+
+.agent-conversation-message--user {
+  justify-content: flex-end;
+}
+
+.agent-conversation-message--assistant,
+.agent-conversation-message--system {
+  justify-content: flex-start;
+}
+
+.agent-conversation-message__body {
+  min-width: 0;
+  max-width: min(100%, 880px);
+}
+
+.agent-conversation-message--user .agent-conversation-message__body {
+  max-width: min(78%, 720px);
+  padding: 9px 11px;
+  border-radius: calc(var(--radius) + 4px);
+  background: hsl(var(--muted));
+}
+
+.agent-conversation-message--pending .agent-conversation-message__body {
+  opacity: 0.72;
+}
+
+.agent-conversation-markdown {
+  color: hsl(var(--foreground) / 0.82);
+  font-size: 13px;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.agent-conversation-message--user .agent-conversation-markdown {
+  color: hsl(var(--foreground) / 0.92);
+}
+
+.agent-conversation-markdown > :first-child {
+  margin-top: 0;
+}
+
+.agent-conversation-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.agent-conversation-markdown p,
+.agent-conversation-markdown ul,
+.agent-conversation-markdown ol,
+.agent-conversation-markdown pre {
+  margin: 0 0 10px;
+}
+
+.agent-conversation-markdown code {
+  border-radius: 4px;
+  background: hsl(var(--muted));
+  padding: 1px 4px;
+  font-size: 12px;
+}
+
+.agent-conversation-message__tools,
+.agent-conversation-message__notices,
+.agent-conversation-message__artifacts {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.agent-conversation-tool {
+  max-width: min(100%, 760px);
+  border: 1px solid hsl(var(--border) / 0.9);
+  border-radius: var(--radius);
+  background: hsl(var(--card) / 0.58);
+  color: hsl(var(--muted-foreground));
+  font-size: 12px;
+}
+
+.agent-conversation-tool summary,
+.agent-conversation-tool:not(details) {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 32px;
+  padding: 0 10px;
+}
+
+.agent-conversation-tool summary {
+  cursor: pointer;
+}
+
+.agent-conversation-tool__icon {
+  display: inline-flex;
+  color: hsl(var(--foreground) / 0.7);
+}
+
+.agent-conversation-tool__name {
+  color: hsl(var(--foreground) / 0.82);
+  font-weight: 500;
+}
+
+.agent-conversation-tool__summary {
+  margin-left: auto;
+  font-size: 11px;
+}
+
+.agent-conversation-tool__chevron {
+  transition: transform 140ms ease;
+}
+
+.agent-conversation-tool[open] .agent-conversation-tool__chevron {
+  transform: rotate(180deg);
+}
+
+.agent-conversation-tool__details {
+  display: grid;
+  gap: 8px;
+  padding: 0 10px 10px;
+}
+
+.agent-conversation-tool__details pre {
+  max-height: 220px;
+  overflow: auto;
+  margin: 0;
+  padding: 8px;
+  border-radius: calc(var(--radius) - 2px);
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground) / 0.72);
+  font-size: 11px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.agent-conversation-tool__details strong {
+  display: block;
+  margin-bottom: 5px;
+  color: hsl(var(--foreground) / 0.86);
+  font-size: 10px;
+}
+
+.agent-conversation-notice,
+.agent-conversation-artifact {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  max-width: min(100%, 760px);
+  padding: 9px 10px;
+  border-radius: var(--radius);
+  font-size: 12px;
+}
+
+.agent-conversation-notice {
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--muted) / 0.55);
+  color: hsl(var(--foreground) / 0.78);
+}
+
+.agent-conversation-notice--warning {
+  border-color: hsl(45 90% 50% / 0.22);
+  background: hsl(45 90% 50% / 0.07);
+}
+
+.agent-conversation-notice--error {
+  border-color: hsl(var(--destructive) / 0.24);
+  background: hsl(var(--destructive) / 0.08);
+}
+
+.agent-conversation-notice strong {
+  display: block;
+  margin-bottom: 2px;
+  color: hsl(var(--foreground) / 0.88);
+}
+
+.agent-conversation-artifact {
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card) / 0.58);
+  color: hsl(var(--muted-foreground));
+}
+
+.agent-conversation-artifact code {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-conversation-artifact a {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: auto;
+  color: hsl(var(--muted-foreground));
+  text-decoration: none;
+}
+
+.code-agents-composer-stop-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: var(--radius);
+  background: hsl(var(--destructive));
+  color: hsl(var(--destructive-foreground));
+  cursor: pointer;
+}
+
+.code-agents-composer-stop-button:hover {
+  opacity: 0.9;
+}
+
 .code-agents-transcript__empty {
   min-height: 180px;
   display: flex;
@@ -2296,7 +2554,8 @@
   );
 }
 
-.code-agents-spin {
+.code-agents-spin,
+.agent-conversation-spin {
   animation: spin 1s linear infinite;
 }
 

--- a/packages/code-agents-ui/src/styles.css
+++ b/packages/code-agents-ui/src/styles.css
@@ -2150,6 +2150,16 @@
   opacity: 0.72;
 }
 
+.agent-conversation-message__part + .agent-conversation-message__part {
+  margin-top: 10px;
+}
+
+.agent-conversation-message__part--tool,
+.agent-conversation-message__part--notice,
+.agent-conversation-message__part--artifact {
+  display: block;
+}
+
 .agent-conversation-markdown {
   color: hsl(var(--foreground) / 0.82);
   font-size: 13px;
@@ -2176,6 +2186,36 @@
   margin: 0 0 10px;
 }
 
+.agent-conversation-markdown ul,
+.agent-conversation-markdown ol {
+  padding-left: 20px;
+}
+
+.agent-conversation-markdown li {
+  margin: 3px 0;
+  padding-left: 2px;
+}
+
+.agent-conversation-markdown li > p {
+  margin: 0;
+}
+
+.agent-conversation-markdown strong {
+  color: hsl(var(--foreground) / 0.92);
+  font-weight: 650;
+}
+
+.agent-conversation-markdown a {
+  color: #60a5fa;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.agent-conversation-markdown a:hover {
+  color: #93c5fd;
+}
+
 .agent-conversation-markdown code {
   border-radius: 4px;
   background: hsl(var(--muted));
@@ -2183,12 +2223,19 @@
   font-size: 12px;
 }
 
-.agent-conversation-message__tools,
-.agent-conversation-message__notices,
-.agent-conversation-message__artifacts {
-  display: grid;
-  gap: 8px;
-  margin-top: 10px;
+.agent-conversation-markdown pre {
+  max-width: 100%;
+  overflow: auto;
+  padding: 10px;
+  border-radius: var(--radius);
+  background: hsl(var(--muted) / 0.72);
+}
+
+.agent-conversation-markdown pre code {
+  display: block;
+  padding: 0;
+  background: transparent;
+  white-space: pre;
 }
 
 .agent-conversation-tool {

--- a/packages/code-agents-ui/src/transcript-conversation.ts
+++ b/packages/code-agents-ui/src/transcript-conversation.ts
@@ -1,6 +1,7 @@
 import type {
   AgentConversationArtifact,
   AgentConversationMessage,
+  AgentConversationMessagePart,
   AgentConversationNotice,
   AgentConversationToolCall,
 } from "@agent-native/core/client";
@@ -10,7 +11,7 @@ import {
   type NormalizedCodeAgentStatusEvent,
   type NormalizedCodeAgentToolEvent,
   type NormalizedCodeAgentTranscriptItem,
-} from "@agent-native/core/code-agents";
+} from "@agent-native/core/code-agents/transcript-normalizer";
 import type { CodeAgentTranscriptEvent } from "./types.js";
 
 export interface NormalizeCodeAgentTranscriptOptions {
@@ -35,6 +36,7 @@ export function normalizeCodeAgentTranscriptForConversation(
       role: "assistant",
       createdAt: item.createdAt,
       text: "",
+      parts: [],
       tools: [],
       notices: [],
       artifacts: [],
@@ -58,16 +60,39 @@ export function normalizeCodeAgentTranscriptForConversation(
 
     const assistant = assistantForItem(item);
     if (item.type === "assistant") {
-      assistant.text = appendAssistantText(assistant.text ?? "", item.text);
+      appendPart(assistant, {
+        id: item.id,
+        type: "text",
+        text: item.text,
+      });
+      assistant.text = `${assistant.text ?? ""}${item.text}`;
     } else if (item.type === "tool") {
-      assistant.tools = [...(assistant.tools ?? []), toConversationTool(item)];
+      const tool = toConversationTool(item);
+      appendPart(assistant, {
+        id: item.id,
+        type: "tool",
+        tool,
+      });
+      assistant.tools = [...(assistant.tools ?? []), tool];
     } else if (item.type === "status") {
       const artifact = toConversationArtifact(item);
       if (artifact) {
+        appendPart(assistant, {
+          id: item.id,
+          type: "artifact",
+          artifact,
+        });
         assistant.artifacts = [...(assistant.artifacts ?? []), artifact];
       } else {
         const notice = toConversationNotice(item, options);
-        if (notice) assistant.notices = [...(assistant.notices ?? []), notice];
+        if (notice) {
+          appendPart(assistant, {
+            id: item.id,
+            type: "notice",
+            notice,
+          });
+          assistant.notices = [...(assistant.notices ?? []), notice];
+        }
       }
     }
   }
@@ -75,10 +100,18 @@ export function normalizeCodeAgentTranscriptForConversation(
   return messages.filter(
     (message) =>
       message.text?.trim() ||
+      message.parts?.length ||
       message.tools?.length ||
       message.notices?.length ||
       message.artifacts?.length,
   );
+}
+
+function appendPart(
+  message: AgentConversationMessage,
+  part: AgentConversationMessagePart,
+): void {
+  message.parts = [...(message.parts ?? []), part];
 }
 
 function toCoreTranscriptEvent(
@@ -163,14 +196,6 @@ function toConversationArtifact(
     path: artifactPath,
     url: artifactUrl,
   };
-}
-
-function appendAssistantText(current: string, next: string): string {
-  if (!next.trim()) return current;
-  if (!current.trim()) return next.trim();
-  if (/\s$/.test(current) || /^\s/.test(next)) return `${current}${next}`;
-  if (/^[.,!?;:)\]}'"`]/.test(next)) return `${current}${next}`;
-  return `${current} ${next.trim()}`;
 }
 
 function preview(value: unknown): string | undefined {

--- a/packages/code-agents-ui/src/transcript-conversation.ts
+++ b/packages/code-agents-ui/src/transcript-conversation.ts
@@ -1,0 +1,195 @@
+import type {
+  AgentConversationArtifact,
+  AgentConversationMessage,
+  AgentConversationNotice,
+  AgentConversationToolCall,
+} from "@agent-native/core/client";
+import {
+  normalizeCodeAgentTranscript,
+  type CodeAgentTranscriptEvent as CoreCodeAgentTranscriptEvent,
+  type NormalizedCodeAgentStatusEvent,
+  type NormalizedCodeAgentToolEvent,
+  type NormalizedCodeAgentTranscriptItem,
+} from "@agent-native/core/code-agents";
+import type { CodeAgentTranscriptEvent } from "./types.js";
+
+export interface NormalizeCodeAgentTranscriptOptions {
+  hideCredentialMessages?: boolean;
+}
+
+export function normalizeCodeAgentTranscriptForConversation(
+  events: CodeAgentTranscriptEvent[],
+  options: NormalizeCodeAgentTranscriptOptions = {},
+): AgentConversationMessage[] {
+  const normalized = normalizeCodeAgentTranscript(
+    events.map(toCoreTranscriptEvent),
+  );
+  const messages: AgentConversationMessage[] = [];
+  const assistantByTurn = new Map<number, AgentConversationMessage>();
+
+  const assistantForItem = (item: NormalizedCodeAgentTranscriptItem) => {
+    const existing = assistantByTurn.get(item.turnIndex);
+    if (existing) return existing;
+    const message: AgentConversationMessage = {
+      id: `assistant-${item.id}`,
+      role: "assistant",
+      createdAt: item.createdAt,
+      text: "",
+      tools: [],
+      notices: [],
+      artifacts: [],
+    };
+    assistantByTurn.set(item.turnIndex, message);
+    messages.push(message);
+    return message;
+  };
+
+  for (const item of normalized.items) {
+    if (item.type === "user") {
+      messages.push({
+        id: item.id,
+        role: "user",
+        text: item.text,
+        createdAt: item.createdAt,
+        pending: item.events.some((event) => event.metadata?.pending === true),
+      });
+      continue;
+    }
+
+    const assistant = assistantForItem(item);
+    if (item.type === "assistant") {
+      assistant.text = appendAssistantText(assistant.text ?? "", item.text);
+    } else if (item.type === "tool") {
+      assistant.tools = [...(assistant.tools ?? []), toConversationTool(item)];
+    } else if (item.type === "status") {
+      const artifact = toConversationArtifact(item);
+      if (artifact) {
+        assistant.artifacts = [...(assistant.artifacts ?? []), artifact];
+      } else {
+        const notice = toConversationNotice(item, options);
+        if (notice) assistant.notices = [...(assistant.notices ?? []), notice];
+      }
+    }
+  }
+
+  return messages.filter(
+    (message) =>
+      message.text?.trim() ||
+      message.tools?.length ||
+      message.notices?.length ||
+      message.artifacts?.length,
+  );
+}
+
+function toCoreTranscriptEvent(
+  event: CodeAgentTranscriptEvent,
+): CoreCodeAgentTranscriptEvent {
+  return {
+    schemaVersion: 1,
+    id: event.id,
+    runId: event.runId,
+    kind: event.type as CoreCodeAgentTranscriptEvent["kind"],
+    message: event.text,
+    createdAt: event.createdAt,
+    metadata: {
+      ...(event.metadata ?? {}),
+      ...(event.title ? { title: event.title } : {}),
+      ...(event.artifactPath ? { artifactPath: event.artifactPath } : {}),
+      ...(event.artifactUrl ? { artifactUrl: event.artifactUrl } : {}),
+    },
+  };
+}
+
+function toConversationTool(
+  item: NormalizedCodeAgentToolEvent,
+): AgentConversationToolCall {
+  return {
+    id: item.id,
+    name: item.tool ?? "tool",
+    state:
+      item.state === "completed"
+        ? "completed"
+        : item.state === "activity"
+          ? "activity"
+          : "running",
+    input: preview(item.input),
+    result: preview(item.result),
+    summary:
+      item.state === "completed"
+        ? "finished"
+        : item.state === "activity"
+          ? "working"
+          : "started",
+  };
+}
+
+function toConversationNotice(
+  item: NormalizedCodeAgentStatusEvent,
+  options: NormalizeCodeAgentTranscriptOptions,
+): AgentConversationNotice | null {
+  if (options.hideCredentialMessages && isCredentialText(item.text))
+    return null;
+  if (item.level === "info" && item.statusKind !== "note") return null;
+  return {
+    id: item.id,
+    tone:
+      item.level === "error"
+        ? "error"
+        : item.level === "warning" || item.level === "approval"
+          ? "warning"
+          : "info",
+    title:
+      item.level === "approval"
+        ? "Approval pending"
+        : item.statusKind === "note"
+          ? "Note"
+          : undefined,
+    text: item.text,
+  };
+}
+
+function toConversationArtifact(
+  item: NormalizedCodeAgentStatusEvent,
+): AgentConversationArtifact | null {
+  if (item.statusKind !== "artifact") return null;
+  const event = item.events[0];
+  const artifactPath =
+    stringMetadata(event?.metadata, "artifactPath") ??
+    stringMetadata(event?.metadata, "path");
+  const artifactUrl = stringMetadata(event?.metadata, "artifactUrl");
+  return {
+    id: item.id,
+    label: item.text || "Artifact",
+    path: artifactPath,
+    url: artifactUrl,
+  };
+}
+
+function appendAssistantText(current: string, next: string): string {
+  if (!next.trim()) return current;
+  if (!current.trim()) return next.trim();
+  if (/\s$/.test(current) || /^\s/.test(next)) return `${current}${next}`;
+  if (/^[.,!?;:)\]}'"`]/.test(next)) return `${current}${next}`;
+  return `${current} ${next.trim()}`;
+}
+
+function preview(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const text =
+    typeof value === "string" ? value : (JSON.stringify(value, null, 2) ?? "");
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > 1800 ? `${trimmed.slice(0, 1800)}\n...` : trimmed;
+}
+
+function stringMetadata(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isCredentialText(value: string): boolean {
+  return /No LLM provider key was found|Missing credentials/i.test(value);
+}

--- a/packages/code-agents-ui/src/types.ts
+++ b/packages/code-agents-ui/src/types.ts
@@ -192,6 +192,11 @@ export interface CodeAgentTranscriptResult {
   error?: string;
 }
 
+export interface CodeAgentTranscriptSubscriptionBatch extends CodeAgentTranscriptResult {
+  subscriptionId?: string;
+  reason?: string;
+}
+
 export interface CodeAgentCreateRunRequest {
   goalId?: string;
   prompt: string;

--- a/packages/core/docs/content/code-agents-ui.md
+++ b/packages/core/docs/content/code-agents-ui.md
@@ -31,6 +31,8 @@ const host: CodeAgentsHost = {
   listRuns: (goalId) => listRunsSomehow(goalId),
   listCodePacks: () => listCodePacksSomehow(),
   createRun: (request) => createRunSomehow(request),
+  subscribeTranscript: (request, callback) =>
+    subscribeToTranscriptSomehow(request, callback),
   readTranscript: (request) => readTranscriptSomehow(request),
   appendFollowUp: (request) => appendFollowUpSomehow(request),
   updateRun: (request) => updateRunSomehow(request),
@@ -193,7 +195,8 @@ AGENT_NATIVE_CODE_AGENTS_HOME=./data/code-agents pnpm dev
 | `listRuns(goalId?)`                                   | List sessions for the selected goal                    |
 | `listCodePacks?()`                                    | List `.agents/commands` and `.agents/skills`           |
 | `createRun(request)`                                  | Start a new run                                        |
-| `readTranscript(request)`                             | Read transcript/tool/status events                     |
+| `subscribeTranscript?(request, callback)`             | Push transcript updates to the shared conversation     |
+| `readTranscript(request)`                             | Poll transcript events as a compatibility fallback     |
 | `appendFollowUp(request)`                             | Add a follow-up, either steering active work or queued |
 | `updateRun(request)`                                  | Update mode or run metadata                            |
 | `retryRun?(request)`                                  | Retry the selected run in place                        |
@@ -226,6 +229,12 @@ shared Code UI may add slots for:
 Everything else stays in the shared composer: attachments, references, slash and
 skill insertion, pasted-text handling, voice dictation, drafts, keyboard
 shortcuts, and submission semantics.
+
+The user-facing transcript should stay conversational. Code hosts normalize raw
+transcript/status/tool events into the shared conversation renderer: assistant
+text coalesces into one turn, low-signal lifecycle noise stays out of the main
+surface, and tool activity renders as compact inline summaries with details
+available when needed.
 
 ## Slash Commands
 
@@ -278,8 +287,10 @@ adapter, `run-manager`, or `agent-teams` rather than a bespoke queue/runner.
 
 Follow-ups on active runs support two delivery modes:
 
-- **Send now** records a steering prompt that the active runner applies at the next safe continuation point.
-- **Queue** runs after the current turn finishes.
+- Pressing Enter or clicking send records an immediate steering prompt that the
+  active runner applies at the next safe continuation point.
+- Pressing Cmd+Enter on macOS or Ctrl+Enter elsewhere queues the prompt to run
+  after the current turn finishes.
 
 Inactive runs keep the compatible behavior: the follow-up is appended and the run resumes immediately.
 

--- a/packages/core/docs/content/cross-app-sso.md
+++ b/packages/core/docs/content/cross-app-sso.md
@@ -1,0 +1,118 @@
+---
+title: "Cross-App SSO"
+description: "Sign in once across every hosted agent-native app via identity federation with Dispatch as the identity authority — opt-in per app, reversible with a single env var."
+---
+
+# Cross-App SSO
+
+Each hosted app at `*.agent-native.com` runs its own deployment with its **own separate user store**. `mail.agent-native.com` and `calendar.agent-native.com` do not share a database, a session table, or a cookie domain. So "sign in once, use every app" cannot be a shared cookie — it has to be **identity federation**, with [Dispatch](/docs/dispatch) acting as the identity authority for the workspace.
+
+This is the same trust primitive [A2A](/docs/a2a-protocol) and [External Agents](/docs/external-agents) already use — an `A2A_SECRET`-signed JWT verified at the request boundary — applied to the human sign-in path instead of agent-to-agent calls.
+
+## What & why {#what-why}
+
+Per-app user stores mean there is no single place a browser cookie could live that every app trusts. The federation model instead names one app — **Dispatch** — as the identity authority. Any other app can delegate "who is this person?" to Dispatch, get back a short-lived signed assertion of the user's verified email, and then **link that to its own local account by email**.
+
+The linking rule is deliberately narrow and additive:
+
+- **Existing same-email user → linked.** The local account is matched by verified email and reused as-is. It is **never modified, renamed, or deleted** — the federation layer only ever reads it and mints a session for it.
+- **New email → created.** A fresh local account is created for that verified email, then a normal local session is minted.
+
+This makes the rollout safe even though it logs people out. **Logout is expected.** When an app turns this on, existing sessions end and users re-authenticate through Dispatch. But they always log back into the **same email-matched account, with all their data intact**, because identity rows are only ever _added to_ — never destroyed, renamed, or repointed. There is no migration, no table rename, no destructive write anywhere in this path. (See the auth invariants in [Authentication](/docs/authentication) and [Security & Data Scoping](/docs/security).)
+
+## How it works {#how-it-works}
+
+The flow is a standard authorize → signed-token → callback redirect, with email as the only thing that crosses the trust boundary.
+
+1. **App → Dispatch (authorize).** The app sends the user to the identity authority:
+
+   ```
+   GET https://dispatch.agent-native.com/_agent-native/identity/authorize
+       ?app=<requesting-app>
+       &redirect_uri=<app-callback-url>
+       &state=<csrf-state>
+   ```
+
+2. **Dispatch authenticates the human.** If the user already has a Dispatch session, this is transparent. If not, Dispatch shows its own normal login (email/password, Google, etc. — see [Authentication](/docs/authentication)). Dispatch is just a regular agent-native app here; it is not running a special auth mode.
+
+3. **Dispatch → App (signed identity token).** Dispatch validates `redirect_uri` against a **strict allowlist** (`*.agent-native.com` plus localhost — nothing else) and 302-redirects back to the app's `redirect_uri` carrying a short-lived **`A2A_SECRET`-signed identity JWT**. The token's claims are intentionally minimal:
+
+   | Claim        | Meaning                                                  |
+   | ------------ | -------------------------------------------------------- |
+   | `sub`        | Stable user id at the identity authority                 |
+   | `email`      | The user's **verified** email — the only join key        |
+   | `name`       | Display name (non-authoritative, for UI only)            |
+   | `org_domain` | Workspace/org domain, when present                       |
+   | `scope`      | Always `"identity"` — this token authorizes sign-in only |
+   | `exp`        | **≤ 5 minutes** from issue                               |
+
+4. **App verifies and JIT-links by email.** The app verifies the token signature with its own `A2A_SECRET`, checks `scope: "identity"` and `exp`, then performs **just-in-time linking strictly by verified email**:
+   - If a local user with that email exists → reuse it unchanged.
+   - If not → create a local user for that email.
+
+5. **App mints a normal local session.** From here on the user has an ordinary local session in that app's own store — every existing access check, org scoping, and action guard works exactly as before. The federation only happened at the front door.
+
+### Opting in {#opt-in}
+
+An app participates **only** when this environment variable is set on its deployment:
+
+```bash
+AGENT_NATIVE_IDENTITY_HUB_URL=https://dispatch.agent-native.com
+```
+
+- **Set** → the app shows a **"Sign in with Agent-Native"** option that runs the flow above. Direct local login (email/password, Google) still works alongside it.
+- **Unset (default)** → **zero behavior change.** The app authenticates exactly as it did before; the federation code path is dormant. There is no schema change and nothing to migrate, so flipping the variable on or off is fully reversible at any time.
+
+## Security {#security}
+
+The whole model rests on a few deliberately small guarantees:
+
+- **Short-lived signed token.** The identity assertion is an `A2A_SECRET`-signed JWT with a **≤ 5-minute** expiry and `scope: "identity"`. It authorizes a single sign-in and cannot be replayed for long or repurposed for API/A2A access. Verification runs at the request boundary before any session is minted — same boundary discipline as [A2A auth](/docs/a2a-protocol#auth-policy).
+- **Strict `redirect_uri` allowlist.** Dispatch only ever redirects to `*.agent-native.com` or localhost. Arbitrary, scheme-relative (`//host`), and cross-origin redirect targets are rejected, so the authority can't be turned into an open-redirect or token-exfiltration oracle.
+- **Email-only join from a verified token.** The _only_ thing that crosses the trust boundary is the verified email in a signed token. The app does not accept a user id, role, org membership, or any privileged state from the wire — it derives everything locally from the matched account.
+- **Additive-only identity writes.** Linking either reuses an existing same-email account untouched or inserts a new one. No update, rename, repoint, or delete of identity rows ever happens on this path — consistent with the framework's "no breaking database changes" rule.
+- **Off by default.** With `AGENT_NATIVE_IDENTITY_HUB_URL` unset the entire feature is inert. Enabling or disabling it is one env var on one deploy, with no data side effects.
+
+## Canary rollout runbook {#canary-rollout}
+
+Cutover and rollback are **a single environment variable per app deployment**. Roll out one app at a time, verify, then expand. Do not set the variable on every app at once.
+
+**1. Deploy the code — no behavior change.**
+Ship the release to every app with `AGENT_NATIVE_IDENTITY_HUB_URL` **unset everywhere**. Because the feature is off by default, this deploy is a no-op for users: every app keeps authenticating exactly as before. Confirm normal logins still work on a couple of apps.
+
+**2. Enable the canary on ONE app (mail) only.**
+Set, on the **mail** deployment only:
+
+```bash
+AGENT_NATIVE_IDENTITY_HUB_URL=https://dispatch.agent-native.com
+```
+
+Leave every other app's environment unset. Redeploy/restart mail so it picks up the variable.
+
+**3. Verify the canary (checklist).**
+On mail, walk the full loop:
+
+- Log **out** of mail.
+- The login screen now shows **"Sign in with Agent-Native"**. Click it.
+- You are taken to **Dispatch** and complete its login (or pass straight through if already signed in there).
+- You are redirected **back to mail, logged in** — and it is the **same pre-existing account** (same email) you had before, not a new one.
+- **Mail data is intact** — your existing mailboxes, drafts, settings, and org scoping are all exactly as they were.
+- **Existing direct logins still work** — email/password and Google sign-in on mail continue to function for users who don't use the SSO button.
+
+If any check fails, go straight to step 5 (rollback) — it is instant and data-safe.
+
+**4. Expand app-by-app.**
+Once mail is verified, repeat steps 2–3 for the next app, then the next — setting `AGENT_NATIVE_IDENTITY_HUB_URL` on one deployment at a time and running the same checklist after each. Never batch-enable.
+
+**5. Rollback = unset the env var on that app's deploy.**
+To revert any app, **remove `AGENT_NATIVE_IDENTITY_HUB_URL` from that app's environment and redeploy/restart it.** The app immediately returns to its prior auth behavior. There is **no data change to undo** — identity rows were only ever added, and unsetting the variable simply makes the federation path dormant again. Each app's cutover and rollback are independent and reversible.
+
+> The rollout logs users out as each app is enabled (they re-auth via Dispatch), but they always log back into the **same email-matched account with data intact**, because identity rows are never destroyed or renamed — only added.
+
+## Related {#related}
+
+- [Authentication](/docs/authentication) — local auth modes, sessions, orgs, the `A2A_SECRET` env var.
+- [A2A Protocol](/docs/a2a-protocol) — the signed-JWT, verify-at-the-boundary trust model this reuses.
+- [External Agents](/docs/external-agents) — the same `A2A_SECRET`-signed identity pattern applied to agent connections and deep links.
+- [Dispatch](/docs/dispatch) — the workspace identity authority and routing hub.
+- [Security & Data Scoping](/docs/security) — additive-only data writes and per-account scoping.

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -1,56 +1,90 @@
 ---
 title: "External Agents"
-description: "Connect Claude Code, Cowork, and Codex to an agent-native app over MCP — with deep links that drop the user back into the running UI and live artifact round-trip."
+description: "Connect your own Claude Code, Cowork, or Codex to a hosted agent-native app in one command — then round-trip artifacts back into the running UI with deep links."
 ---
 
 # External Agents
 
 An agent-native app is reachable by any external coding agent — Claude Code (desktop & CLI), Claude Cowork, Codex — over [MCP](/docs/mcp-protocol). External agents are great at producing artifacts (a draft, an event, a dashboard) but they live in a terminal or another app. Without a bridge, the user gets a wall of JSON and has to go find the thing.
 
-The external-agent bridge closes the loop: the agent does the work over MCP, then hands the user a single **"Open in &lt;app&gt; →"** link that opens the real app focused on exactly what was produced. It reuses the existing `navigate` / `application_state` contract the UI already drains every 2s (see [Context Awareness](/docs/context-awareness)) — there is no second navigation mechanism.
+The external-agent bridge closes the loop. First you connect your own agent to a **hosted** app — one command, no token copying. Then the agent does the work over MCP and hands the user a single **"Open in &lt;app&gt; →"** link that opens the real app focused on exactly what was produced. It reuses the existing `navigate` / `application_state` contract the UI already drains every 2s (see [Context Awareness](/docs/context-awareness)) — there is no second navigation mechanism.
 
-## Overview {#overview}
+## Connect in one command {#connect}
 
-- **One-command setup** — `agent-native mcp install --client <c>` writes the client config and provisions a token.
-- **`link` builder** — any action that produces or lists a navigable resource returns a deep link; MCP/A2A surfaces auto-append an "Open in … →" link.
-- **`/_agent-native/open` route** — a pure pointer (view + record ids + filters); the record-focusing write is always scoped to the **browser session**, never the agent's token.
-- **Ingest actions** — GET + `readOnly` + `publicAgent` actions let an external agent pull **live** app state into its own context.
-- **Generic cross-app verbs** — a stable verb set (`list_apps`, `open_app`, `ask_app`, `create_workspace_app`, `list_templates`) so an external agent has a predictable surface without guessing per-app action names.
-
-## Connect an external agent {#connect}
-
-The framework already mounts an HTTP MCP endpoint at `/_agent-native/mcp` (see [MCP Protocol](/docs/mcp-protocol)). Every `defineAction` is exposed as an MCP tool, plus the `ask-agent` meta-tool that runs the full agent loop (the same entry point [A2A](/docs/a2a-protocol) uses). Hosted apps point an external agent at that URL with a bearer token (`ACCESS_TOKEN`, or an `A2A_SECRET` JWT carrying the caller's `sub` + `org_domain` so tool runs stay tenant-scoped).
-
-For local Claude Code / Codex / Cowork, one command writes the client config:
+The first-party hosted apps live at `mail.agent-native.com`, `calendar.agent-native.com`, `analytics.agent-native.com`, and so on. To wire your own Claude Code (and Codex / Cowork if detected) to one of them:
 
 ```bash
-agent-native mcp install --client claude-code|claude-code-cli|codex|cowork \
-  [--app <id>] [--scope user|project]
+npx @agent-native/core connect https://mail.agent-native.com
 ```
 
-It provisions a token (a random `ACCESS_TOKEN` into the workspace `.env` for local dev, or a signed JWT for a detected hosted deployment) and writes an idempotent stdio server entry:
+This opens your browser at the app. You are already logged in, so you just click **Authorize** once. The command detects every installed agent client and writes the MCP config for each — no token to copy, no local server to run. Connect every first-party hosted app at once with:
 
-- **claude-code / claude-code-cli** — an `mcpServers` entry in `.mcp.json` (project scope, default) or `~/.claude.json` (`--scope user`).
-- **cowork** — the same Claude Code JSON shape in `~/.cowork/mcp.json`.
-- **codex** — an `[mcp_servers.<name>]` block in `~/.codex/config.toml`.
+```bash
+npx @agent-native/core connect --all
+```
 
-The entry runs `agent-native mcp serve --app <id>`, which by default is a **thin stdio proxy** to the running local app's `/_agent-native/mcp` — so the live action registry, HMR, and correct deep links stay the single source of truth. Pass `--standalone` to build the registry in-process instead. When `agent-native mcp install` detects a hosted origin (a non-localhost `APP_URL` / `BETTER_AUTH_URL` / `AGENT_NATIVE_MCP_URL` in the workspace `.env`), it writes an `http` client entry pointing at `<origin>/_agent-native/mcp` with a `Bearer` JWT instead of a stdio entry.
+The connection is **per-user, scoped, and revocable**. The browser session you authorized with is the identity the agent acts as; nothing exposes the deployment's shared secret.
 
-Companion subcommands:
+### No-CLI alternative {#no-cli}
 
-| Command                                   | What it does                                                        |
-| ----------------------------------------- | ------------------------------------------------------------------- |
-| `agent-native mcp serve [--app <id>]`     | Run the MCP stdio transport (what client configs spawn).            |
-| `agent-native mcp install --client <c>`   | Provision a token + write the client's MCP config (idempotent).     |
-| `agent-native mcp uninstall --client <c>` | Remove the named MCP entry from a client's config (idempotent).     |
-| `agent-native mcp status`                 | Show resolved MCP URL/port, token state, and per-client entries.    |
-| `agent-native mcp token [--rotate]`       | Print (or rotate) the local `ACCESS_TOKEN` in the workspace `.env`. |
+If you'd rather not run a command, open the app in your browser and use its **Connect** affordance (served at `https://<app>/_agent-native/mcp/connect`). While logged in, click **Connect / Authorize**. The page hands you either a one-click deep link that configures a detected agent, or a ready-to-paste `.mcp.json` block:
 
-Restart the client after `install` so it picks up the new MCP server.
+```jsonc
+// .mcp.json
+{
+  "mcpServers": {
+    "mail": {
+      "type": "url",
+      "url": "https://mail.agent-native.com/_agent-native/mcp",
+      "headers": { "Authorization": "Bearer <minted-token>" },
+    },
+  },
+}
+```
 
-## The `link` builder {#link-builder}
+Restart the agent client after connecting so it picks up the new MCP server.
 
-`defineAction` accepts an optional `link` builder. When set, every MCP/A2A result for that tool auto-appends a markdown `[label →](absoluteUrl)` block and a structured `_meta["agent-native/openLink"] = { label, view, webUrl, desktopUrl }`. `tools/list` adds `annotations["agent-native/producesOpenLink"]` and a description suffix so the external agent knows the tool yields an openable link and should surface it.
+## What you can do once connected {#what-you-can-do}
+
+Once your agent is connected, the app's full action surface is available as MCP tools, plus the `ask-agent` meta-tool that runs the full agent loop (the same entry point [A2A](/docs/a2a-protocol) uses). Ask your agent to do real work and it hands back a link straight into the running app:
+
+```
+> draft an email to John about the Q3 report
+
+Claude Code calls: manage-draft(to: "john@example.com", subject: "Q3 Report", body: "…")
+→ Open draft in Mail → https://mail.agent-native.com/_agent-native/open?app=mail&view=inbox&compose=…
+```
+
+Click that link and Mail opens with the draft restored — focused exactly where you, the logged-in user, are. The agent never had to know your session; it just produced the artifact.
+
+### Generic cross-app verbs {#cross-app}
+
+On top of the per-action tools the MCP server exposes a stable verb set, so an external agent has a predictable surface without guessing per-app action names:
+
+| Tool                                       | Side effects | Returns                                                                              |
+| ------------------------------------------ | ------------ | ------------------------------------------------------------------------------------ |
+| `list_apps`                                | none         | workspace apps + their URLs / running state                                          |
+| `open_app({ app, view, params? })`         | none         | a `buildDeepLink` URL (surfaces as an "Open …" link)                                 |
+| `ask_app({ app, message })`                | agent loop   | routes a natural-language task to that app's in-app agent (delegates to `ask-agent`) |
+| `create_workspace_app({ name, template })` | scaffolds    | a new app booted via the workspace path, plus its running URL + deep link            |
+| `list_templates`                           | none         | the allow-listed templates only                                                      |
+
+`create_workspace_app` rejects any non-allow-listed template — the public template allow-list in `packages/shared-app-config/templates.ts` is authoritative and CI-guarded; an external agent cannot widen it. A same-named template action overrides a builtin (template-over-core precedence). Disable the whole set with `MCPConfig.builtinCrossAppTools: false`.
+
+### Per-app tour {#tour}
+
+Every allow-listed template that produces or lists a navigable resource ships a `link` builder, and the ingest-heavy ones ship a GET + `publicAgent` action so a connected agent can pull live state:
+
+- **Mail** — `manage-draft` returns a `compose`-encoded deep link; clicking it opens the inbox with the draft restored into a `compose-<id>`. `list-emails` / `search-emails` point at a filtered inbox view.
+- **Calendar** — `create-event` returns `buildDeepLink({ app: "calendar", view: "calendar", params: { eventId, date } })`; the click lands on the calendar with that event focused on its date.
+- **Analytics** — `update-dashboard` / `save-analysis` return `buildDeepLink({ app: "analytics", view: "adhoc", params: { dashboardId } })`; the agent builds a dashboard over MCP and hands back "Open dashboard in Analytics".
+- **Design** — `get-design-snapshot` is the GET + `publicAgent` ingest action: it returns the **live** Yjs file contents plus the resolved tweak values so the agent continues from the tuned design, not the original tokens. `apply-tweaks` round-trips back with an "Open design" editor link.
+- **Content** — `pull-document` is the GET + `publicAgent` ingest action: it flushes any open live collaborative session to SQL first so the external agent ingests exactly what the user sees, then surfaces a deep link to the document.
+- **Brain** — `ask-brain` / `search-everything` return a cited answer plus a deep link to the underlying knowledge/capture, so a terminal agent's lookup links straight back into the source in the running app.
+
+## Authoring: the `link` builder {#link-builder}
+
+This section is for template authors. `defineAction` accepts an optional `link` builder. When set, every MCP/A2A result for that tool auto-appends a markdown `[label →](absoluteUrl)` block and a structured `_meta["agent-native/openLink"] = { label, view, webUrl, desktopUrl }`. `tools/list` adds `annotations["agent-native/producesOpenLink"]` and a description suffix so the external agent knows the tool yields an openable link and should surface it.
 
 Build the URL with `buildDeepLink(...)` — it is the single source of truth for the open-route format. Never hand-format the `/_agent-native/open` URL.
 
@@ -91,7 +125,7 @@ The `link` builder is **pure and synchronous — no I/O, no awaits**. It runs be
 
 `buildDeepLink({ app, view, params?, to?, compose? })` returns the app-relative path `/_agent-native/open?app=…&view=…&<recordId>=…`. The MCP layer turns that into an absolute web URL (`toAbsoluteOpenUrl`, using the request origin) and a desktop `agentnative://open?…` URL (`toDesktopOpenUrl`); the markdown link uses the desktop URL when the client signals `target: "desktop"`.
 
-## The `/_agent-native/open` route {#open-route}
+### The `/_agent-native/open` route {#open-route}
 
 When the user clicks the link in any browser or inline webview, `GET /_agent-native/open` (`createOpenRouteHandler`, mounted by the core routes plugin):
 
@@ -102,11 +136,11 @@ When the user clicks the link in any browser or inline webview, `GET /_agent-nat
 
 Cross-origin, scheme-relative `//host`, and control-char redirects are rejected (open-redirect guard). The route can be disabled per app via `disableOpenRoute`.
 
-### The browser-session identity rule {#identity-rule}
+#### The browser-session identity rule {#identity-rule}
 
 The link carries **no privileged state** — it is just `view` + record ids + filters. The record-focusing `navigate` write is scoped to whoever is logged into the **browser**, never the external agent's MCP token. So an agent authenticated as one identity can hand a user a link, and when that user clicks it the record opens where _the user_ is logged in. This is what makes the deep link safe to surface in a terminal or chat transcript. See [Context Awareness](/docs/context-awareness) for the `navigate` / `application_state` contract this bridges to.
 
-## Ingest actions {#ingest}
+### Ingest actions {#ingest}
 
 An action an external agent reads to pull live app state into its own context must be:
 
@@ -125,43 +159,86 @@ export default defineAction({
 
 `GET` + `readOnly` keeps the action side-effect-free and out of the screen-refresh poll. `publicAgent` is the **explicit opt-in** — a public web route never implies public MCP/A2A exposure; see [Actions](/docs/actions). Design/content ingest actions MUST read **live** state (the Yjs collaborative document, not the stale DB snapshot column) so the external agent sees what the user actually has on screen. Content's `pull-document` flushes any open live collab session to SQL first; design's `get-design-snapshot` returns the live Yjs file contents plus the user's resolved tweak values.
 
-## Generic cross-app verbs + scaffolding {#cross-app}
+## Advanced: local development & manual setup {#advanced}
 
-On top of the per-action tools the MCP server exposes a stable verb set so an external agent has a predictable surface without guessing per-app action names:
+The hosted `connect` flow above is the recommended path. The options below are for local development and hand-rolled setups.
 
-| Tool                                       | Side effects | Returns                                                                              |
-| ------------------------------------------ | ------------ | ------------------------------------------------------------------------------------ |
-| `list_apps`                                | none         | workspace apps + their dev URLs / running state                                      |
-| `open_app({ app, view, params? })`         | none         | a `buildDeepLink` URL (surfaces as an "Open …" link)                                 |
-| `ask_app({ app, message })`                | agent loop   | routes a natural-language task to that app's in-app agent (delegates to `ask-agent`) |
-| `create_workspace_app({ name, template })` | scaffolds    | a new app booted via the workspace path, plus its running URL + deep link            |
-| `list_templates`                           | none         | the allow-listed templates only                                                      |
+### Local development {#local-dev}
 
-`create_workspace_app` rejects any non-allow-listed template — the public template allow-list in `packages/shared-app-config/templates.ts` is authoritative and CI-guarded; an external agent cannot widen it. A same-named template action overrides a builtin (template-over-core precedence). Disable the whole set with `MCPConfig.builtinCrossAppTools: false`.
+Run your app locally (`pnpm dev` / `agent-native dev`), then point a local agent at it with one command:
 
-## Per-app tour {#tour}
+```bash
+agent-native mcp install --client claude-code|claude-code-cli|codex|cowork \
+  [--app <id>] [--scope user|project]
+```
 
-Every allow-listed template that produces or lists a navigable resource ships a `link` builder, and the ingest-heavy ones ship a GET + `publicAgent` action:
+It provisions a token (a random `ACCESS_TOKEN` into the workspace `.env` for local dev, or a signed JWT if it detects a hosted origin) and writes an idempotent stdio server entry:
 
-- **Mail** — `manage-draft` returns a `compose`-encoded deep link; clicking it opens the inbox with the draft restored into a `compose-<id>`. `list-emails` / `search-emails` point at a filtered inbox view.
-- **Calendar** — `create-event` returns `buildDeepLink({ app: "calendar", view: "calendar", params: { eventId, date } })`; the click lands on the calendar with that event focused on its date.
-- **Analytics** — `update-dashboard` / `save-analysis` return `buildDeepLink({ app: "analytics", view: "adhoc", params: { dashboardId } })`; the agent builds a dashboard over MCP and hands back "Open dashboard in Analytics".
-- **Design** — `get-design-snapshot` is the GET + `publicAgent` ingest action: it returns the **live** Yjs file contents plus the resolved tweak values so the agent continues from the tuned design, not the original tokens. `apply-tweaks` round-trips back with an "Open design" editor link.
-- **Content** — `pull-document` is the GET + `publicAgent` ingest action: it flushes any open live collaborative session to SQL first so the external agent ingests exactly what the user sees, then surfaces a deep link to the document.
-- **Brain** — `ask-brain` / `search-everything` return a cited answer plus a deep link to the underlying knowledge/capture, so a terminal agent's lookup links straight back into the source in the running app.
+- **claude-code / claude-code-cli** — an `mcpServers` entry in `.mcp.json` (project scope, default) or `~/.claude.json` (`--scope user`).
+- **cowork** — the same Claude Code JSON shape in `~/.cowork/mcp.json`.
+- **codex** — an `[mcp_servers.<name>]` block in `~/.codex/config.toml`.
+
+The entry runs `agent-native mcp serve --app <id>`, which by default is a **thin stdio proxy** to the running local app's `/_agent-native/mcp` — so the live action registry, HMR, and correct deep links stay the single source of truth. Pass `--standalone` to build the registry in-process instead. When `agent-native mcp install` detects a hosted origin (a non-localhost `APP_URL` / `BETTER_AUTH_URL` / `AGENT_NATIVE_MCP_URL` in the workspace `.env`), it writes an `http` client entry pointing at `<origin>/_agent-native/mcp` with a `Bearer` JWT instead of a stdio entry.
+
+Companion subcommands:
+
+| Command                                   | What it does                                                        |
+| ----------------------------------------- | ------------------------------------------------------------------- |
+| `agent-native mcp serve [--app <id>]`     | Run the MCP stdio transport (what client configs spawn).            |
+| `agent-native mcp install --client <c>`   | Provision a token + write the client's MCP config (idempotent).     |
+| `agent-native mcp uninstall --client <c>` | Remove the named MCP entry from a client's config (idempotent).     |
+| `agent-native mcp status`                 | Show resolved MCP URL/port, token state, and per-client entries.    |
+| `agent-native mcp token [--rotate]`       | Print (or rotate) the local `ACCESS_TOKEN` in the workspace `.env`. |
+
+Restart the client after `install` so it picks up the new MCP server.
+
+### Manual `.mcp.json` HTTP entry {#manual-entry}
+
+You can also write the MCP client config by hand against any deployed endpoint with a token you supply yourself (an `ACCESS_TOKEN`, or an `A2A_SECRET`-signed JWT carrying the caller's `sub` + `org_domain` so tool runs stay tenant-scoped):
+
+```jsonc
+// .mcp.json
+{
+  "mcpServers": {
+    "analytics": {
+      "type": "url",
+      "url": "https://analytics.agent-native.com/_agent-native/mcp",
+      "headers": { "Authorization": "Bearer <ACCESS_TOKEN-or-JWT>" },
+    },
+  },
+}
+```
+
+This is the unmanaged equivalent of what `connect` writes for you. See [MCP Protocol](/docs/mcp-protocol) for the full auth env-var matrix.
+
+### Dev vs production tool surface {#dev-vs-prod}
+
+In plain local dev (`NODE_ENV=development` and `AGENT_MODE !== "production"`) the MCP `tools/list` deliberately exposes only the generic builtins plus actions with `publicAgent.requiresAuth === false` — the per-app ingest actions (`requiresAuth: true`) and mutating actions (no `publicAgent`) are filtered out (`filterPublicAgentActions`). The full per-app surface appears when the request is authenticated as a real caller: a deployed / `AGENT_MODE=production` app, or a local app reached through `connect` / `agent-native mcp install` (which provisions a token so the caller has an identity). So if `tools/list` looks sparse, you are hitting an unauthenticated dev endpoint — connect (or present a token) rather than assuming the action is missing.
+
+## How it works & security {#how-it-works}
+
+The hosted `connect` flow never copies the deployment's shared secret. Instead:
+
+- A logged-in browser session mints a **per-user, scoped, revocable** token — an `A2A_SECRET`-signed JWT carrying the caller's `sub` + `org_domain` and a unique `jti`, so every tool run stays tenant-scoped via `runWithRequestContext`.
+- The existing `/_agent-native/mcp` endpoint accepts that token like any other bearer (see [MCP Protocol](/docs/mcp-protocol)) — no new endpoint, no new transport.
+- The same Connect page lists every token you've minted and lets you **revoke** any of them by `jti`. Treat them like personal access tokens: one per agent client, revoke when a machine is decommissioned.
+- The deep link the agent hands back carries no privileged state. The record-focusing `navigate` write is always scoped to the **browser** session, never the agent's token — so a link is safe to paste into a terminal or chat transcript.
 
 ## Do / Don't {#do-dont}
 
 **Do**
 
+- Connect your own agent to a hosted app with `npx @agent-native/core connect <url>` (or `--all`) — it's the frictionless path.
 - Add a `link` builder to any action that produces or lists a navigable resource (draft, event, dashboard, document).
 - Build the URL with `buildDeepLink(...)` — the single source of truth for the open-route format.
 - Keep `link` pure and synchronous; return `null` when there's nothing to open.
 - Make external-agent ingest actions GET + `readOnly` + `publicAgent`, and read live (Yjs) state, not the stale DB column.
 - Let the open route resolve the browser session; pass record ids as deep-link params and let the UI focus them via the polled `navigate` command.
+- Revoke a minted connect token by `jti` when an agent client is decommissioned.
 
 **Don't**
 
+- Copy a deployment's shared `ACCESS_TOKEN` / `A2A_SECRET` into a client config when `connect` can mint a per-user, revocable token instead.
 - Hand-format the `/_agent-native/open` URL — always go through `buildDeepLink`.
 - Do I/O, awaits, DB reads, or app-state reads inside a `link` builder.
 - Scope the `navigate` write to the agent token, or pass privileged state through the deep link — it's a pure pointer.
@@ -175,3 +252,5 @@ Every allow-listed template that produces or lists a navigable resource ships a 
 - [A2A Protocol](/docs/a2a-protocol) — the `ask-agent` meta-tool and JSON-RPC peer calls.
 - [Actions](/docs/actions) — defining actions, `publicAgent`, GET / `readOnly`.
 - [Context Awareness](/docs/context-awareness) — the `navigate` / `application_state` contract the open route bridges to.
+  </content>
+  </invoke>

--- a/packages/core/docs/content/migration-workbench.md
+++ b/packages/core/docs/content/migration-workbench.md
@@ -209,7 +209,7 @@ In Agent-Native Code, Desktop, or the internal run surface, connect providers th
 
 ## Agent-Native Code
 
-Agent-Native Desktop includes a **Agent-Native Code** hub for long-running coding-agent sessions. It is the general Code app/surface in Desktop, and it pairs with the `agent-native code` shell as the primary CLI/Desktop coding experience. A bare prompt is the generic coding session, and `/migrate` is one specialized capability there: the hub shows recent and active runs, opens a transcript-first session view, renders tool events and artifacts, sends follow-up prompts, stops tracked runners, opens a terminal in the run workspace, and handles links like:
+Agent-Native Desktop includes a **Agent-Native Code** hub for long-running coding-agent sessions. It is the general Code app/surface in Desktop, and it pairs with the `agent-native code` shell as the primary CLI/Desktop coding experience. A bare prompt is the generic coding session, and `/migrate` is one specialized capability there: the hub shows recent and active runs, opens a transcript-first session view with compact tool summaries and artifacts, sends follow-up prompts, stops tracked runners, opens a terminal in the run workspace, and handles links like:
 
 ```text
 agentnative://open?goal=migrate&run=<runId>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,6 +78,7 @@
     "./usage": "./dist/usage/store.js",
     "./connections": "./dist/connections/index.js",
     "./code-agents": "./dist/code-agents/index.js",
+    "./code-agents/transcript-normalizer": "./dist/code-agents/transcript-normalizer.js",
     "./workspace-connections": "./dist/workspace-connections/index.js",
     "./notifications": "./dist/notifications/index.js",
     "./client/notifications": "./dist/client/notifications/index.js",

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -39,7 +39,17 @@ export async function signA2AToken(
   email: string,
   orgDomain?: string,
   orgSecret?: string,
-  options?: { expiresIn?: string | number; preferGlobalSecret?: boolean },
+  options?: {
+    expiresIn?: string | number;
+    preferGlobalSecret?: boolean;
+    /**
+     * Extra JWT claims to merge alongside `sub` / `org_domain`. Used by the
+     * MCP connect flow to add a revocable `jti` and a `scope: "mcp-connect"`
+     * marker. Reserved claims (`sub`, `org_domain`) cannot be overridden —
+     * they are spread last so a caller can never spoof identity via this map.
+     */
+    extraClaims?: Record<string, unknown>;
+  },
 ): Promise<string> {
   const secret = options?.preferGlobalSecret
     ? process.env.A2A_SECRET || orgSecret
@@ -57,6 +67,9 @@ export async function signA2AToken(
     "http://localhost:3000";
 
   return new jose.SignJWT({
+    ...(options?.extraClaims ?? {}),
+    // `sub` / `org_domain` are spread AFTER extraClaims so a caller-supplied
+    // map can never override the verified identity claims.
     sub: email,
     ...(orgDomain ? { org_domain: orgDomain } : {}),
   })

--- a/packages/core/src/cli/connect.spec.ts
+++ b/packages/core/src/cli/connect.spec.ts
@@ -245,6 +245,82 @@ describe("runDeviceFlow", () => {
     });
     expect(grant).toBeNull();
   });
+
+  it("returns null immediately when polling gets a server error", async () => {
+    const err = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    let pollCount = 0;
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (String(url).endsWith("/device/start")) {
+        return new Response(
+          JSON.stringify({
+            device_code: "dev-123",
+            user_code: "WXYZ-1234",
+            verification_uri: "https://app.example.com/connect",
+            verification_uri_complete:
+              "https://app.example.com/connect?code=WXYZ-1234",
+            interval: 1,
+            expires_in: 600,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      pollCount++;
+      return new Response(JSON.stringify({ error: "database unavailable" }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const grant = await runDeviceFlow("https://app.example.com", "app", "all", {
+      fetchImpl,
+      sleep: noopSleep,
+      openBrowser: vi.fn(),
+    });
+
+    expect(grant).toBeNull();
+    expect(pollCount).toBe(1);
+    expect(err.mock.calls.flat().join("")).toContain("database unavailable");
+  });
+
+  it("returns null immediately when polling returns a terminal error body", async () => {
+    const err = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    let pollCount = 0;
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (String(url).endsWith("/device/start")) {
+        return new Response(
+          JSON.stringify({
+            device_code: "dev-123",
+            user_code: "WXYZ-1234",
+            verification_uri: "https://app.example.com/connect",
+            verification_uri_complete:
+              "https://app.example.com/connect?code=WXYZ-1234",
+            interval: 1,
+            expires_in: 600,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      pollCount++;
+      return new Response(
+        JSON.stringify({ status: "not_found", message: "unknown code" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const grant = await runDeviceFlow("https://app.example.com", "app", "all", {
+      fetchImpl,
+      sleep: noopSleep,
+      openBrowser: vi.fn(),
+    });
+
+    expect(grant).toBeNull();
+    expect(pollCount).toBe(1);
+    expect(err.mock.calls.flat().join("")).toContain("unknown code");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/cli/connect.spec.ts
+++ b/packages/core/src/cli/connect.spec.ts
@@ -1,0 +1,447 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ConnectDeps,
+  hostedApps,
+  normalizeUrl,
+  parseConnectArgs,
+  resolveClients,
+  runConnect,
+  runDeviceFlow,
+  writeConfigs,
+} from "./connect.js";
+
+const tmpRoots: string[] = [];
+
+beforeEach(() => {
+  // Keep CLI output out of the test log; individual tests that assert on
+  // output re-spy with their own captured implementation.
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  for (const root of tmpRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+});
+
+function tmpDir(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "an-connect-"));
+  tmpRoots.push(root);
+  return root;
+}
+
+const noopSleep = () => Promise.resolve();
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+describe("parseConnectArgs", () => {
+  it("parses the positional url and defaults", () => {
+    const p = parseConnectArgs(["https://mail.agent-native.com"]);
+    expect(p.url).toBe("https://mail.agent-native.com");
+    expect(p.client).toBe("all");
+    expect(p.scope).toBe("project");
+    expect(p.all).toBe(false);
+    expect(p.token).toBeUndefined();
+  });
+
+  it("parses flags in both --flag value and --flag=value forms", () => {
+    const p = parseConnectArgs([
+      "https://x.com",
+      "--client",
+      "codex",
+      "--scope=user",
+      "--name",
+      "my-server",
+      "--token=abc123",
+    ]);
+    expect(p.client).toBe("codex");
+    expect(p.scope).toBe("user");
+    expect(p.name).toBe("my-server");
+    expect(p.token).toBe("abc123");
+  });
+
+  it("parses --all without a url", () => {
+    const p = parseConnectArgs(["--all", "--client", "claude-code"]);
+    expect(p.all).toBe(true);
+    expect(p.url).toBeUndefined();
+    expect(p.client).toBe("claude-code");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URL normalization
+// ---------------------------------------------------------------------------
+
+describe("normalizeUrl", () => {
+  it("strips trailing slashes and keeps the origin", () => {
+    expect(normalizeUrl("https://mail.agent-native.com/")).toBe(
+      "https://mail.agent-native.com",
+    );
+    expect(normalizeUrl("https://mail.agent-native.com///")).toBe(
+      "https://mail.agent-native.com",
+    );
+    expect(normalizeUrl("  http://localhost:3000  ")).toBe(
+      "http://localhost:3000",
+    );
+  });
+
+  it("rejects empty input", () => {
+    expect(() => normalizeUrl("")).toThrow(/Missing app URL/);
+  });
+
+  it("rejects non-URLs", () => {
+    expect(() => normalizeUrl("mail.agent-native.com")).toThrow(
+      /Not a valid URL/,
+    );
+  });
+
+  it("rejects unsupported schemes", () => {
+    expect(() => normalizeUrl("ftp://example.com")).toThrow(
+      /Unsupported URL scheme/,
+    );
+  });
+});
+
+describe("resolveClients", () => {
+  it("expands 'all' to every supported client", () => {
+    expect(resolveClients("all")).toEqual([
+      "claude-code",
+      "claude-code-cli",
+      "codex",
+      "cowork",
+    ]);
+  });
+
+  it("returns a single client when named", () => {
+    expect(resolveClients("codex")).toEqual(["codex"]);
+  });
+
+  it("throws on an unknown client", () => {
+    expect(() => resolveClients("vim")).toThrow(/Unknown --client/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Device-flow poll state machine
+// ---------------------------------------------------------------------------
+
+function makeFetch(
+  pollResponses: any[],
+  start: Record<string, unknown> = {},
+): typeof fetch {
+  let pollIdx = 0;
+  return vi.fn(async (url: string) => {
+    if (String(url).endsWith("/device/start")) {
+      return new Response(
+        JSON.stringify({
+          device_code: "dev-123",
+          user_code: "WXYZ-1234",
+          verification_uri: "https://app.example.com/connect",
+          verification_uri_complete:
+            "https://app.example.com/connect?code=WXYZ-1234",
+          interval: 1,
+          expires_in: 600,
+          ...start,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    const body = pollResponses[Math.min(pollIdx++, pollResponses.length - 1)];
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+describe("runDeviceFlow", () => {
+  it("polls pending then resolves on approved", async () => {
+    const open = vi.fn();
+    const deps: ConnectDeps = {
+      fetchImpl: makeFetch([
+        { status: "pending" },
+        { status: "pending" },
+        {
+          status: "approved",
+          token: "tok-abc",
+          mcpUrl: "https://app.example.com/_agent-native/mcp",
+          serverName: "agent-native-app",
+        },
+      ]),
+      sleep: noopSleep,
+      openBrowser: open,
+    };
+    const grant = await runDeviceFlow(
+      "https://app.example.com",
+      "app",
+      "all",
+      deps,
+    );
+    expect(grant).toEqual({
+      token: "tok-abc",
+      mcpUrl: "https://app.example.com/_agent-native/mcp",
+      serverName: "agent-native-app",
+    });
+    expect(open).toHaveBeenCalledWith(
+      "https://app.example.com/connect?code=WXYZ-1234",
+    );
+  });
+
+  it("returns null on expired", async () => {
+    const grant = await runDeviceFlow("https://app.example.com", "app", "all", {
+      fetchImpl: makeFetch([{ status: "pending" }, { status: "expired" }]),
+      sleep: noopSleep,
+      openBrowser: vi.fn(),
+    });
+    expect(grant).toBeNull();
+  });
+
+  it("returns null on consumed", async () => {
+    const grant = await runDeviceFlow("https://app.example.com", "app", "all", {
+      fetchImpl: makeFetch([{ status: "consumed" }]),
+      sleep: noopSleep,
+      openBrowser: vi.fn(),
+    });
+    expect(grant).toBeNull();
+  });
+
+  it("times out when the deadline passes with no approval", async () => {
+    let t = 0;
+    const grant = await runDeviceFlow("https://app.example.com", "app", "all", {
+      fetchImpl: makeFetch([{ status: "pending" }], { expires_in: 2 }),
+      sleep: noopSleep,
+      openBrowser: vi.fn(),
+      // First call (deadline calc) → 0; subsequent loop checks advance past
+      // the 2s expiry so the loop exits.
+      now: () => (t === 0 ? ((t = 1), 0) : 5000),
+    });
+    expect(grant).toBeNull();
+  });
+
+  it("returns null when the start endpoint is unreachable", async () => {
+    const grant = await runDeviceFlow("https://app.example.com", "app", "all", {
+      fetchImpl: vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }) as unknown as typeof fetch,
+      sleep: noopSleep,
+      openBrowser: vi.fn(),
+    });
+    expect(grant).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotent config writing
+// ---------------------------------------------------------------------------
+
+describe("writeConfigs", () => {
+  it("writes a JSON HTTP entry for claude-code (project scope)", () => {
+    const root = tmpDir();
+    const written = writeConfigs(
+      ["claude-code"],
+      "agent-native-mail",
+      "https://mail.agent-native.com/_agent-native/mcp",
+      "tok-1",
+      "project",
+      root,
+    );
+    const file = written[0].file;
+    expect(file).toBe(path.join(root, ".mcp.json"));
+    const cfg = JSON.parse(fs.readFileSync(file, "utf-8"));
+    expect(cfg.mcpServers["agent-native-mail"]).toEqual({
+      type: "http",
+      url: "https://mail.agent-native.com/_agent-native/mcp",
+      headers: { Authorization: "Bearer tok-1" },
+    });
+  });
+
+  it("is idempotent: re-running replaces the same entry, no duplicates", () => {
+    const root = tmpDir();
+    writeConfigs(
+      ["claude-code"],
+      "agent-native-mail",
+      "https://mail.agent-native.com/_agent-native/mcp",
+      "tok-1",
+      "project",
+      root,
+    );
+    writeConfigs(
+      ["claude-code"],
+      "agent-native-mail",
+      "https://mail.agent-native.com/_agent-native/mcp",
+      "tok-2",
+      "project",
+      root,
+    );
+    const cfg = JSON.parse(
+      fs.readFileSync(path.join(root, ".mcp.json"), "utf-8"),
+    );
+    expect(Object.keys(cfg.mcpServers)).toEqual(["agent-native-mail"]);
+    expect(cfg.mcpServers["agent-native-mail"].headers.Authorization).toBe(
+      "Bearer tok-2",
+    );
+  });
+
+  it("preserves unrelated existing JSON entries", () => {
+    const root = tmpDir();
+    fs.writeFileSync(
+      path.join(root, ".mcp.json"),
+      JSON.stringify({ mcpServers: { other: { command: "x" } } }, null, 2),
+    );
+    writeConfigs(
+      ["claude-code"],
+      "agent-native-mail",
+      "https://mail.agent-native.com/_agent-native/mcp",
+      "tok-1",
+      "project",
+      root,
+    );
+    const cfg = JSON.parse(
+      fs.readFileSync(path.join(root, ".mcp.json"), "utf-8"),
+    );
+    expect(cfg.mcpServers.other).toEqual({ command: "x" });
+    expect(cfg.mcpServers["agent-native-mail"].type).toBe("http");
+  });
+
+  it("writes a Codex TOML block with HTTP url + auth header", () => {
+    const root = tmpDir();
+    const codexFile = path.join(root, "config.toml");
+    const HOME = process.env.HOME;
+    // Point HOME at our tmp dir so ~/.codex/config.toml lands under it.
+    const codexHome = tmpDir();
+    process.env.HOME = codexHome;
+    try {
+      const written = writeConfigs(
+        ["codex"],
+        "agent-native-mail",
+        "https://mail.agent-native.com/_agent-native/mcp",
+        "tok-1",
+        "project",
+        root,
+      );
+      const f = written[0].file;
+      expect(f).toBe(path.join(codexHome, ".codex", "config.toml"));
+      const toml = fs.readFileSync(f, "utf-8");
+      expect(toml).toContain("[mcp_servers.agent-native-mail]");
+      expect(toml).toContain(
+        'url = "https://mail.agent-native.com/_agent-native/mcp"',
+      );
+      expect(toml).toContain("Bearer tok-1");
+      // Re-run is idempotent (single block).
+      writeConfigs(
+        ["codex"],
+        "agent-native-mail",
+        "https://mail.agent-native.com/_agent-native/mcp",
+        "tok-2",
+        "project",
+        root,
+      );
+      const toml2 = fs.readFileSync(f, "utf-8");
+      const occurrences =
+        toml2.split("[mcp_servers.agent-native-mail]").length - 1;
+      expect(occurrences).toBe(1);
+      expect(toml2).toContain("Bearer tok-2");
+    } finally {
+      process.env.HOME = HOME;
+      void codexFile;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hostedApps respects the allow-list
+// ---------------------------------------------------------------------------
+
+describe("hostedApps", () => {
+  it("returns only visible (non-hidden) templates that have a prodUrl", () => {
+    const apps = hostedApps();
+    const names = apps.map((a) => a.name);
+    // Allow-listed hosted apps are present.
+    expect(names).toContain("mail");
+    expect(names).toContain("calendar");
+    // Hidden templates must never appear.
+    expect(names).not.toContain("voice");
+    expect(names).not.toContain("scheduling");
+    expect(names).not.toContain("macros");
+    // Every returned app has an https prodUrl.
+    for (const a of apps) {
+      expect(a.url).toMatch(/^https:\/\//);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runConnect end-to-end (token fallback + exit codes)
+// ---------------------------------------------------------------------------
+
+describe("runConnect", () => {
+  const originalExitCode = process.exitCode;
+  const originalCwd = process.cwd();
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    process.chdir(originalCwd);
+  });
+
+  it("token fallback skips the device flow and writes the entry", async () => {
+    const root = tmpDir();
+    process.chdir(root);
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runConnect([
+      "https://mail.agent-native.com",
+      "--client",
+      "claude-code",
+      "--token",
+      "tok-fallback",
+    ]);
+
+    expect(process.exitCode).toBeFalsy();
+    const cfg = JSON.parse(
+      fs.readFileSync(path.join(root, ".mcp.json"), "utf-8"),
+    );
+    expect(cfg.mcpServers["agent-native-mail"]).toEqual({
+      type: "http",
+      url: "https://mail.agent-native.com/_agent-native/mcp",
+      headers: { Authorization: "Bearer tok-fallback" },
+    });
+  });
+
+  it("sets a non-zero exit code when no url and not --all", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    await runConnect([]);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("sets a non-zero exit code when the device flow fails", async () => {
+    const root = tmpDir();
+    process.chdir(root);
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    await runConnect(["https://app.example.com", "--client", "claude-code"], {
+      fetchImpl: makeFetch([{ status: "expired" }]),
+      sleep: noopSleep,
+      openBrowser: vi.fn(),
+    });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("prints help and exits cleanly for --help", async () => {
+    const out = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    await runConnect(["--help"]);
+    expect(process.exitCode).toBeFalsy();
+    expect(out.mock.calls.flat().join("")).toContain("agent-native connect");
+  });
+});

--- a/packages/core/src/cli/connect.spec.ts
+++ b/packages/core/src/cli/connect.spec.ts
@@ -47,7 +47,7 @@ describe("parseConnectArgs", () => {
     const p = parseConnectArgs(["https://mail.agent-native.com"]);
     expect(p.url).toBe("https://mail.agent-native.com");
     expect(p.client).toBe("all");
-    expect(p.scope).toBe("project");
+    expect(p.scope).toBe("user");
     expect(p.all).toBe(false);
     expect(p.token).toBeUndefined();
   });
@@ -106,6 +106,15 @@ describe("normalizeUrl", () => {
   it("rejects unsupported schemes", () => {
     expect(() => normalizeUrl("ftp://example.com")).toThrow(
       /Unsupported URL scheme/,
+    );
+  });
+
+  it("rejects plaintext HTTP for non-loopback hosts", () => {
+    expect(() => normalizeUrl("http://mail.agent-native.com")).toThrow(
+      /Refusing plaintext HTTP/,
+    );
+    expect(normalizeUrl("http://127.0.0.1:3000/app")).toBe(
+      "http://127.0.0.1:3000/app",
     );
   });
 });
@@ -330,7 +339,7 @@ describe("writeConfigs", () => {
       const f = written[0].file;
       expect(f).toBe(path.join(codexHome, ".codex", "config.toml"));
       const toml = fs.readFileSync(f, "utf-8");
-      expect(toml).toContain("[mcp_servers.agent-native-mail]");
+      expect(toml).toContain('[mcp_servers."agent-native-mail"]');
       expect(toml).toContain(
         'url = "https://mail.agent-native.com/_agent-native/mcp"',
       );
@@ -346,12 +355,64 @@ describe("writeConfigs", () => {
       );
       const toml2 = fs.readFileSync(f, "utf-8");
       const occurrences =
-        toml2.split("[mcp_servers.agent-native-mail]").length - 1;
+        toml2.split('[mcp_servers."agent-native-mail"]').length - 1;
       expect(occurrences).toBe(1);
       expect(toml2).toContain("Bearer tok-2");
     } finally {
       process.env.HOME = HOME;
       void codexFile;
+    }
+  });
+
+  it("quotes Codex TOML server names with punctuation", () => {
+    const root = tmpDir();
+    const HOME = process.env.HOME;
+    const codexHome = tmpDir();
+    process.env.HOME = codexHome;
+    try {
+      const written = writeConfigs(
+        ["codex"],
+        'agent.native "mail"',
+        "https://mail.agent-native.com/_agent-native/mcp",
+        "tok-1",
+        "project",
+        root,
+      );
+      const toml = fs.readFileSync(written[0].file, "utf-8");
+      expect(toml).toContain('[mcp_servers."agent.native \\"mail\\""]');
+    } finally {
+      process.env.HOME = HOME;
+    }
+  });
+
+  it("replaces legacy unquoted Codex TOML blocks for safe names", () => {
+    const root = tmpDir();
+    const HOME = process.env.HOME;
+    const codexHome = tmpDir();
+    const codexFile = path.join(codexHome, ".codex", "config.toml");
+    fs.mkdirSync(path.dirname(codexFile), { recursive: true });
+    fs.writeFileSync(
+      codexFile,
+      '[mcp_servers.agent-native-mail]\nurl = "https://old.example/mcp"\n',
+    );
+    process.env.HOME = codexHome;
+    try {
+      writeConfigs(
+        ["codex"],
+        "agent-native-mail",
+        "https://mail.agent-native.com/_agent-native/mcp",
+        "tok-1",
+        "project",
+        root,
+      );
+      const toml = fs.readFileSync(codexFile, "utf-8");
+      expect(toml).not.toContain("[mcp_servers.agent-native-mail]");
+      expect(toml).toContain('[mcp_servers."agent-native-mail"]');
+      expect(toml).toContain(
+        'url = "https://mail.agent-native.com/_agent-native/mcp"',
+      );
+    } finally {
+      process.env.HOME = HOME;
     }
   });
 });
@@ -400,6 +461,8 @@ describe("runConnect", () => {
       "https://mail.agent-native.com",
       "--client",
       "claude-code",
+      "--scope",
+      "project",
       "--token",
       "tok-fallback",
     ]);

--- a/packages/core/src/cli/connect.ts
+++ b/packages/core/src/cli/connect.ts
@@ -1,0 +1,534 @@
+/**
+ * `agent-native connect <url>` — wire your local Claude Code / Codex / Cowork
+ * to a DEPLOYED agent-native app using a browser device-code flow. No token
+ * copying: open the verification URL, approve in the browser, and the minted
+ * HTTP MCP server entry is written into your client config(s) idempotently.
+ *
+ *   agent-native connect <url> [--client all|claude-code|claude-code-cli|
+ *                               codex|cowork] [--scope user|project]
+ *                               [--name <serverName>]
+ *   agent-native connect <url> --token <token>   (no-browser fallback)
+ *   agent-native connect --all  [--client ...]   (every first-party app)
+ *
+ * Server contract (implemented by another agent on `<url>`):
+ *   POST <url>/_agent-native/mcp/connect/device/start  (no auth)
+ *     body { client?, app? }
+ *     → { device_code, user_code, verification_uri,
+ *         verification_uri_complete, interval, expires_in }
+ *   POST <url>/_agent-native/mcp/connect/device/poll   (no auth)
+ *     body { device_code }
+ *     → { status: "pending" }
+ *     | { status: "approved", token, mcpUrl, serverName, mcpServerEntry }
+ *     | { status: "expired" }
+ *     | { status: "consumed" }
+ *
+ * Node-only CLI module. No new npm deps (Node built-ins + global fetch only).
+ */
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+import { findWorkspaceRoot } from "../mcp/workspace-resolve.js";
+import {
+  CLIENTS,
+  ClientId,
+  writeHttpEntryForClient,
+} from "./mcp-config-writers.js";
+import { visibleTemplates } from "./templates-meta.js";
+
+const DEVICE_START_PATH = "/_agent-native/mcp/connect/device/start";
+const DEVICE_POLL_PATH = "/_agent-native/mcp/connect/device/poll";
+const SERVER_NAME_PREFIX = "agent-native";
+
+function logOut(msg: string): void {
+  process.stdout.write(`${msg}\n`);
+}
+function logErr(msg: string): void {
+  process.stderr.write(`${msg}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+export interface ParsedConnectArgs {
+  /** Positional URL (the deployed app origin). Undefined for `--all`. */
+  url?: string;
+  /** all | claude-code | claude-code-cli | codex | cowork (default "all"). */
+  client: string;
+  /** user | project (default "project"). */
+  scope: string;
+  /** Override the minted MCP server name. */
+  name?: string;
+  /** No-browser fallback: skip device flow, use this token directly. */
+  token?: string;
+  /** Connect every first-party hosted app. */
+  all: boolean;
+}
+
+export function parseConnectArgs(argv: string[]): ParsedConnectArgs {
+  const out: ParsedConnectArgs = {
+    client: "all",
+    scope: "project",
+    all: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const eat = (flag: string): string | undefined => {
+      if (a === flag) return argv[++i];
+      if (a.startsWith(`${flag}=`)) return a.slice(flag.length + 1);
+      return undefined;
+    };
+    let v: string | undefined;
+    if (a === "--all") out.all = true;
+    else if ((v = eat("--client")) !== undefined) out.client = v;
+    else if ((v = eat("--scope")) !== undefined) out.scope = v;
+    else if ((v = eat("--name")) !== undefined) out.name = v;
+    else if ((v = eat("--token")) !== undefined) out.token = v;
+    else if (!a.startsWith("-") && !out.url) out.url = a;
+  }
+  return out;
+}
+
+/**
+ * Normalize a user-supplied app URL: trim, require http/https, strip the
+ * trailing slash. Throws a friendly Error otherwise.
+ */
+export function normalizeUrl(raw: string): string {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) {
+    throw new Error("Missing app URL. Usage: agent-native connect <url>");
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(
+      `Not a valid URL: "${raw}". Pass a full origin, e.g. ` +
+        `agent-native connect https://mail.agent-native.com`,
+    );
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(
+      `Unsupported URL scheme "${parsed.protocol}". Use http:// or https://`,
+    );
+  }
+  // origin + pathname, trailing slash stripped (origin keeps no path).
+  const base = `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, "");
+  return base;
+}
+
+/** Resolve the requested clients list. "all" → every supported client. */
+export function resolveClients(client: string): ClientId[] {
+  const c = (client ?? "all").toLowerCase();
+  if (c === "all" || c === "") return [...CLIENTS];
+  if ((CLIENTS as string[]).includes(c)) return [c as ClientId];
+  throw new Error(
+    `Unknown --client "${client}". Use: all, ${CLIENTS.join(", ")}`,
+  );
+}
+
+/** Derive an app slug from a deployed origin, e.g. mail.agent-native.com → mail. */
+function appSlugFromUrl(url: string): string {
+  try {
+    const host = new URL(url).hostname;
+    const first = host.split(".")[0];
+    return first && first !== "www" ? first : "app";
+  } catch {
+    return "app";
+  }
+}
+
+function defaultServerName(url: string): string {
+  return `${SERVER_NAME_PREFIX}-${appSlugFromUrl(url)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Browser open (mirrors workspace-dev.ts openBrowser)
+// ---------------------------------------------------------------------------
+
+function openInBrowser(url: string): void {
+  if (process.env.AGENT_NATIVE_NO_OPEN === "1") return;
+  try {
+    const command =
+      process.platform === "darwin"
+        ? "open"
+        : process.platform === "win32"
+          ? "cmd"
+          : "xdg-open";
+    const openArgs =
+      process.platform === "win32" ? ["/c", "start", "", url] : [url];
+    const child = spawn(command, openArgs, {
+      stdio: "ignore",
+      detached: true,
+    });
+    child.unref();
+  } catch {
+    // Non-fatal: the user can open the URL manually (we already printed it).
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Device-code flow
+// ---------------------------------------------------------------------------
+
+interface DeviceStartResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete: string;
+  interval?: number;
+  expires_in?: number;
+}
+
+interface DevicePollResponse {
+  status: "pending" | "approved" | "expired" | "consumed";
+  token?: string;
+  mcpUrl?: string;
+  serverName?: string;
+  mcpServerEntry?: Record<string, unknown>;
+}
+
+/** Injectable hooks so the poll state machine is unit-testable. */
+export interface ConnectDeps {
+  /** Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Sleep between polls (ms). Defaults to real setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Open the verification URL. Defaults to the platform browser opener. */
+  openBrowser?: (url: string) => void;
+  /** Override "now" for the expiry cap (ms epoch). Defaults to Date.now. */
+  now?: () => number;
+}
+
+function realSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function postJson(
+  fetchImpl: typeof fetch,
+  url: string,
+  body: unknown,
+): Promise<{ status: number; json: any }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30_000);
+  try {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body ?? {}),
+      signal: controller.signal,
+    });
+    let json: any = null;
+    try {
+      json = await response.json();
+    } catch {
+      json = null;
+    }
+    return { status: response.status, json };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/**
+ * Run the device-code flow against `baseUrl` and return the approved grant.
+ * Resolves with `null` (and prints a clear message) on expired/consumed or
+ * other terminal failure — the caller maps that to a non-zero exit.
+ */
+export async function runDeviceFlow(
+  baseUrl: string,
+  appSlug: string,
+  clientArg: string,
+  deps: ConnectDeps = {},
+): Promise<{ token: string; mcpUrl: string; serverName: string } | null> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const sleep = deps.sleep ?? realSleep;
+  const open = deps.openBrowser ?? openInBrowser;
+  const now = deps.now ?? (() => Date.now());
+
+  let start: DeviceStartResponse;
+  try {
+    const { status, json } = await postJson(
+      fetchImpl,
+      `${baseUrl}${DEVICE_START_PATH}`,
+      { client: clientArg, app: appSlug },
+    );
+    if (status < 200 || status >= 300 || !json?.device_code) {
+      logErr(
+        `  Could not start the connect flow on ${baseUrl} ` +
+          `(HTTP ${status}). Is this an agent-native app, and is it ` +
+          `deployed with the connect endpoint enabled?`,
+      );
+      return null;
+    }
+    start = json as DeviceStartResponse;
+  } catch (err: any) {
+    logErr(
+      `  Could not reach ${baseUrl} (${err?.message ?? err}). ` +
+        `Check the URL and your network.`,
+    );
+    return null;
+  }
+
+  const interval = Math.max(1, Number(start.interval) || 5);
+  const expiresIn = Math.max(interval, Number(start.expires_in) || 600);
+  const deadline = now() + expiresIn * 1000;
+
+  logOut("");
+  logOut(`  Connecting to ${baseUrl}`);
+  logOut("");
+  logOut(`  Your code:  ${start.user_code}`);
+  logOut(`  Open:       ${start.verification_uri_complete}`);
+  logOut("");
+  logOut("  Approve in the browser to finish. Opening it now…");
+  open(start.verification_uri_complete);
+
+  let spin = 0;
+  const isTTY = !!process.stdout.isTTY;
+  while (now() < deadline) {
+    let poll: DevicePollResponse;
+    try {
+      const { json } = await postJson(
+        fetchImpl,
+        `${baseUrl}${DEVICE_POLL_PATH}`,
+        { device_code: start.device_code },
+      );
+      poll = (json ?? { status: "pending" }) as DevicePollResponse;
+    } catch {
+      // Transient network error — keep polling until the deadline.
+      poll = { status: "pending" };
+    }
+
+    if (poll.status === "approved") {
+      if (isTTY) process.stdout.write("\r\x1b[K");
+      const token = poll.token ?? "";
+      const mcpUrl = poll.mcpUrl ?? `${baseUrl}/_agent-native/mcp`;
+      const serverName = poll.serverName ?? `${SERVER_NAME_PREFIX}-${appSlug}`;
+      if (!token) {
+        logErr("  Server approved but returned no token. Aborting.");
+        return null;
+      }
+      logOut("  Approved.");
+      return { token, mcpUrl, serverName };
+    }
+    if (poll.status === "expired") {
+      if (isTTY) process.stdout.write("\r\x1b[K");
+      logErr("  The connect request expired before it was approved.");
+      logErr("  Run the command again to retry.");
+      return null;
+    }
+    if (poll.status === "consumed") {
+      if (isTTY) process.stdout.write("\r\x1b[K");
+      logErr("  This connect code was already used. Run the command again.");
+      return null;
+    }
+
+    if (isTTY) {
+      process.stdout.write(
+        `\r  ${SPINNER[spin++ % SPINNER.length]} Waiting for approval…`,
+      );
+    }
+    await sleep(interval * 1000);
+  }
+
+  if (isTTY) process.stdout.write("\r\x1b[K");
+  logErr("  Timed out waiting for approval. Run the command again to retry.");
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Writing config(s)
+// ---------------------------------------------------------------------------
+
+function projectBaseDir(): string {
+  const cwd = process.cwd();
+  return findWorkspaceRoot(cwd) ?? path.resolve(cwd);
+}
+
+/**
+ * Write the HTTP MCP entry into every requested client config idempotently.
+ * Returns the list of files written so the caller can print them.
+ */
+export function writeConfigs(
+  clients: ClientId[],
+  serverName: string,
+  mcpUrl: string,
+  token: string,
+  scope: string,
+  baseDir: string = projectBaseDir(),
+): { client: ClientId; file: string }[] {
+  const written: { client: ClientId; file: string }[] = [];
+  for (const client of clients) {
+    const file = writeHttpEntryForClient(
+      client,
+      serverName,
+      mcpUrl,
+      token,
+      baseDir,
+      scope,
+    );
+    written.push({ client, file });
+  }
+  return written;
+}
+
+// ---------------------------------------------------------------------------
+// Single-app connect
+// ---------------------------------------------------------------------------
+
+async function connectOne(
+  rawUrl: string,
+  parsed: ParsedConnectArgs,
+  deps: ConnectDeps,
+): Promise<{ ok: boolean; serverName?: string; files?: string[] }> {
+  const baseUrl = normalizeUrl(rawUrl);
+  const appSlug = appSlugFromUrl(baseUrl);
+  const clients = resolveClients(parsed.client);
+  const scope = parsed.scope === "user" ? "user" : "project";
+
+  let token: string;
+  let mcpUrl: string;
+  let serverName: string;
+
+  if (parsed.token) {
+    // No-browser fallback: skip the device flow entirely.
+    token = parsed.token;
+    mcpUrl = `${baseUrl}/_agent-native/mcp`;
+    serverName = parsed.name ?? defaultServerName(baseUrl);
+    logOut("");
+    logOut(`  Using supplied --token for ${baseUrl} (skipping browser flow).`);
+  } else {
+    const grant = await runDeviceFlow(baseUrl, appSlug, parsed.client, deps);
+    if (!grant) return { ok: false };
+    token = grant.token;
+    mcpUrl = grant.mcpUrl;
+    serverName = parsed.name ?? grant.serverName ?? defaultServerName(baseUrl);
+  }
+
+  const written = writeConfigs(clients, serverName, mcpUrl, token, scope);
+
+  logOut("");
+  logOut(`  Connected "${serverName}" → ${mcpUrl}`);
+  for (const w of written) {
+    logOut(`    ${w.client.padEnd(18)} ${w.file}`);
+  }
+  logOut("");
+  logOut("  Restart your coding agent to pick up the new MCP server.");
+  return { ok: true, serverName, files: written.map((w) => w.file) };
+}
+
+// ---------------------------------------------------------------------------
+// --all : connect every first-party hosted app
+// ---------------------------------------------------------------------------
+
+/** Hosted first-party apps: visible (non-hidden) templates with a prodUrl. */
+export function hostedApps(): { name: string; url: string }[] {
+  return visibleTemplates()
+    .filter((t) => typeof t.prodUrl === "string" && t.prodUrl.length > 0)
+    .map((t) => ({ name: t.name, url: t.prodUrl as string }));
+}
+
+async function connectAll(
+  parsed: ParsedConnectArgs,
+  deps: ConnectDeps,
+): Promise<boolean> {
+  const apps = hostedApps();
+  if (apps.length === 0) {
+    logErr("  No hosted first-party apps found in the template registry.");
+    return false;
+  }
+  logOut("");
+  logOut(`  Connecting ${apps.length} first-party hosted apps…`);
+
+  const results: { name: string; status: string; files: string[] }[] = [];
+  for (const app of apps) {
+    logOut("");
+    logOut(`  ── ${app.name} (${app.url}) ──`);
+    try {
+      const res = await connectOne(app.url, parsed, deps);
+      results.push({
+        name: app.name,
+        status: res.ok ? "connected" : "skipped",
+        files: res.files ?? [],
+      });
+    } catch (err: any) {
+      logErr(`  ${app.name}: ${err?.message ?? err}`);
+      results.push({ name: app.name, status: "error", files: [] });
+    }
+  }
+
+  logOut("");
+  logOut("  Summary");
+  for (const r of results) {
+    const files = r.files.length ? r.files.join(", ") : "—";
+    logOut(`    ${r.name.padEnd(14)} ${r.status.padEnd(10)} ${files}`);
+  }
+  return results.every((r) => r.status === "connected");
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+const HELP = `agent-native connect — wire your coding agent to a deployed app
+
+Usage:
+  agent-native connect <url> [--client <c>] [--scope user|project] [--name <n>]
+      Browser device-code flow. Prints a code, opens the verification URL,
+      polls until approved, then writes the HTTP MCP entry into your
+      client config(s). Idempotent — re-running replaces the same entry.
+
+  agent-native connect <url> --token <token>
+      No-browser fallback. Skip the device flow and write the entry with
+      the supplied token (get it from the app's Connect page).
+
+  agent-native connect --all [--client <c>] [--scope user|project]
+      Connect every first-party hosted app at once.
+
+Clients:  all (default), claude-code, claude-code-cli, codex, cowork
+Scope:    project (default, .mcp.json) or user (~/.claude.json)`;
+
+/**
+ * `agent-native connect` entry point. `deps` is injectable for tests; the
+ * dispatcher in index.ts calls it with just `args`.
+ *
+ * Sets `process.exitCode = 1` on failure (so the process exits non-zero
+ * once the event loop drains) rather than calling `process.exit`, keeping
+ * the function testable — same pattern as `audit-agent-web`.
+ */
+export async function runConnect(
+  args: string[],
+  deps: ConnectDeps = {},
+): Promise<void> {
+  if (args[0] === "--help" || args[0] === "-h" || args[0] === "help") {
+    logOut(HELP);
+    return;
+  }
+
+  const parsed = parseConnectArgs(args);
+
+  try {
+    if (parsed.all) {
+      const ok = await connectAll(parsed, deps);
+      if (!ok) process.exitCode = 1;
+      return;
+    }
+
+    if (!parsed.url) {
+      logErr("  Missing app URL.");
+      logErr("");
+      logOut(HELP);
+      process.exitCode = 1;
+      return;
+    }
+
+    const res = await connectOne(parsed.url, parsed, deps);
+    if (!res.ok) process.exitCode = 1;
+  } catch (err: any) {
+    logErr(`  ${err?.message ?? err}`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/core/src/cli/connect.ts
+++ b/packages/core/src/cli/connect.ts
@@ -21,6 +21,7 @@
  *     | { status: "approved", token, mcpUrl, serverName, mcpServerEntry }
  *     | { status: "expired" }
  *     | { status: "consumed" }
+ *     | { status: "error" | "not_found", message? }
  *
  * Node-only CLI module. No new npm deps (Node built-ins + global fetch only).
  */
@@ -195,11 +196,19 @@ interface DeviceStartResponse {
 }
 
 interface DevicePollResponse {
-  status: "pending" | "approved" | "expired" | "consumed";
+  status:
+    | "pending"
+    | "approved"
+    | "expired"
+    | "consumed"
+    | "error"
+    | "not_found";
   token?: string;
   mcpUrl?: string;
   serverName?: string;
   mcpServerEntry?: Record<string, unknown>;
+  message?: string;
+  error?: string;
 }
 
 /** Injectable hooks so the poll state machine is unit-testable. */
@@ -242,6 +251,16 @@ async function postJson(
   } finally {
     clearTimeout(timeout);
   }
+}
+
+function responseMessage(json: any, fallback: string): string {
+  const message =
+    typeof json?.message === "string"
+      ? json.message
+      : typeof json?.error === "string"
+        ? json.error
+        : "";
+  return message.trim() || fallback;
 }
 
 const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -304,11 +323,19 @@ export async function runDeviceFlow(
   while (now() < deadline) {
     let poll: DevicePollResponse;
     try {
-      const { json } = await postJson(
+      const { status, json } = await postJson(
         fetchImpl,
         `${baseUrl}${DEVICE_POLL_PATH}`,
         { device_code: start.device_code },
       );
+      if (status < 200 || status >= 300) {
+        if (isTTY) process.stdout.write("\r\x1b[K");
+        logErr(
+          `  Connect polling failed (HTTP ${status}): ` +
+            responseMessage(json, "server returned an error."),
+        );
+        return null;
+      }
       poll = (json ?? { status: "pending" }) as DevicePollResponse;
     } catch {
       // Transient network error — keep polling until the deadline.
@@ -336,6 +363,18 @@ export async function runDeviceFlow(
     if (poll.status === "consumed") {
       if (isTTY) process.stdout.write("\r\x1b[K");
       logErr("  This connect code was already used. Run the command again.");
+      return null;
+    }
+    if (poll.status === "error" || poll.status === "not_found") {
+      if (isTTY) process.stdout.write("\r\x1b[K");
+      logErr(
+        `  Connect polling failed: ${responseMessage(
+          poll,
+          poll.status === "not_found"
+            ? "device code was not found."
+            : "server returned an error.",
+        )}`,
+      );
       return null;
     }
 

--- a/packages/core/src/cli/connect.ts
+++ b/packages/core/src/cli/connect.ts
@@ -56,7 +56,7 @@ export interface ParsedConnectArgs {
   url?: string;
   /** all | claude-code | claude-code-cli | codex | cowork (default "all"). */
   client: string;
-  /** user | project (default "project"). */
+  /** user | project (default "user"). */
   scope: string;
   /** Override the minted MCP server name. */
   name?: string;
@@ -69,7 +69,7 @@ export interface ParsedConnectArgs {
 export function parseConnectArgs(argv: string[]): ParsedConnectArgs {
   const out: ParsedConnectArgs = {
     client: "all",
-    scope: "project",
+    scope: "user",
     all: false,
   };
   for (let i = 0; i < argv.length; i++) {
@@ -111,6 +111,19 @@ export function normalizeUrl(raw: string): string {
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new Error(
       `Unsupported URL scheme "${parsed.protocol}". Use http:// or https://`,
+    );
+  }
+  const host = parsed.hostname.toLowerCase();
+  const isLoopback =
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "[::1]" ||
+    host.startsWith("127.");
+  if (parsed.protocol === "http:" && !isLoopback) {
+    throw new Error(
+      `Refusing plaintext HTTP for non-loopback host "${parsed.hostname}". ` +
+        `Use https:// so bearer tokens are not sent in cleartext.`,
     );
   }
   // origin + pathname, trailing slash stripped (origin keeps no path).

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -600,6 +600,19 @@ switch (command) {
     break;
   }
 
+  case "connect": {
+    // Wire your local coding agent to a DEPLOYED agent-native app via a
+    // browser device-code flow (no token copying). `--all` connects every
+    // first-party hosted app; `--token` is the no-browser fallback.
+    import("./connect.js")
+      .then((m) => m.runConnect(args))
+      .catch((err) => {
+        console.error(err?.message ?? err);
+        process.exit(1);
+      });
+    break;
+  }
+
   case "create-workspace": {
     // Deprecated alias for `create` (since workspace is now the default).
     const parsed = parseScaffoldArgs(args);
@@ -692,6 +705,10 @@ Usage:
                                 cmds: serve | install | uninstall | status |
                                 token (--client claude-code|claude-code-cli|
                                 codex|cowork)
+  agent-native connect <url>    Wire your coding agent to a DEPLOYED app via
+                                a browser device-code flow. --all connects
+                                every first-party app; --token is the
+                                no-browser fallback.
   agent-native migrate <source> Create an Agent-Native Code /migrate session, or use
                                 --emit for a portable own-agent dossier.
   agent-native add-app [name]   Add one or more apps to the current workspace

--- a/packages/core/src/cli/mcp-config-writers.ts
+++ b/packages/core/src/cli/mcp-config-writers.ts
@@ -1,0 +1,264 @@
+/**
+ * Shared MCP client-config writers.
+ *
+ * Extracted so both `agent-native mcp install` (see `mcp.ts`) and
+ * `agent-native connect` (see `connect.ts`) write the EXACT same on-disk
+ * config file targets and formats for every supported client. `mcp.ts`
+ * intentionally keeps its own hand-rolled copies of these writers (its
+ * external behavior is unchanged); new code should import from here so the
+ * formats never diverge.
+ *
+ * Supported clients and their config files:
+ *   - claude-code / claude-code-cli → `.mcp.json` (project) or
+ *     `~/.claude.json` (user). JSON `mcpServers[name] = entry`.
+ *   - cowork                        → `~/.cowork/mcp.json`. Same JSON shape.
+ *   - codex                         → `~/.codex/config.toml`.
+ *     `[mcp_servers.<name>]` block.
+ *
+ * Node-only. No new npm deps — hand-rolled JSON merge + minimal TOML block
+ * merge, mirroring `mcp.ts`.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export type ClientId = "claude-code" | "claude-code-cli" | "codex" | "cowork";
+
+export const CLIENTS: ClientId[] = [
+  "claude-code",
+  "claude-code-cli",
+  "codex",
+  "cowork",
+];
+
+/** The HTTP MCP server entry written into a JSON client config. */
+export interface HttpMcpEntry {
+  type: "http";
+  url: string;
+  headers?: Record<string, string>;
+}
+
+/** Build the HTTP MCP server entry for a deployed agent-native app. */
+export function buildHttpMcpEntry(
+  mcpUrl: string,
+  token?: string,
+): HttpMcpEntry {
+  return {
+    type: "http",
+    url: mcpUrl,
+    ...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Config file locations — kept identical to `mcp.ts`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Cowork consumes MCP exactly like Claude Code (same JSON server-entry
+ * shape). Resolved lazily so `os.homedir()` reflects the current `$HOME`.
+ */
+export function coworkConfigPath(): string {
+  return path.join(os.homedir(), ".cowork", "mcp.json");
+}
+
+export function claudeCodeProjectConfig(baseDir: string): string {
+  return path.join(baseDir, ".mcp.json");
+}
+
+export function claudeCodeUserConfig(): string {
+  return path.join(os.homedir(), ".claude.json");
+}
+
+export function codexConfigPath(): string {
+  return path.join(os.homedir(), ".codex", "config.toml");
+}
+
+/**
+ * Resolve the on-disk config path for a client.
+ *
+ * `scope` only affects Claude Code / Claude Code CLI: `"user"` → the global
+ * `~/.claude.json`, anything else → the project-local `.mcp.json` rooted at
+ * `baseDir`.
+ */
+export function configPathFor(
+  client: ClientId,
+  baseDir: string,
+  scope: string | undefined,
+): string {
+  switch (client) {
+    case "claude-code":
+    case "claude-code-cli":
+      return scope === "user"
+        ? claudeCodeUserConfig()
+        : claudeCodeProjectConfig(baseDir);
+    case "cowork":
+      return coworkConfigPath();
+    case "codex":
+      return codexConfigPath();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JSON client configs (Claude Code, Claude Code CLI, Cowork)
+// ---------------------------------------------------------------------------
+
+function readJsonFile(file: string): Record<string, any> {
+  try {
+    const raw = fs.readFileSync(file, "utf-8");
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Idempotently write `mcpServers[name] = entry` into a JSON config file.
+ * Pass `entry === null` to delete the named entry. Re-running with the same
+ * name replaces the existing entry in place — never duplicates.
+ */
+export function writeJsonMcpEntry(
+  file: string,
+  name: string,
+  entry: Record<string, unknown> | null,
+): void {
+  const config = readJsonFile(file);
+  if (!config.mcpServers || typeof config.mcpServers !== "object") {
+    config.mcpServers = {};
+  }
+  if (entry === null) {
+    delete config.mcpServers[name];
+  } else {
+    config.mcpServers[name] = entry;
+  }
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(config, null, 2) + "\n", "utf-8");
+}
+
+export function hasJsonMcpEntry(file: string, name: string): boolean {
+  const config = readJsonFile(file);
+  return !!config?.mcpServers && name in config.mcpServers;
+}
+
+// ---------------------------------------------------------------------------
+// Codex TOML (hand-rolled minimal block merge, no new dep)
+// ---------------------------------------------------------------------------
+
+function tomlQuote(s: string): string {
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/** Build a `[mcp_servers.<name>]` block for an HTTP-type MCP server. */
+export function buildCodexHttpBlock(
+  name: string,
+  mcpUrl: string,
+  token?: string,
+): string {
+  const lines: string[] = [`[mcp_servers.${name}]`];
+  lines.push(`url = ${tomlQuote(mcpUrl)}`);
+  if (token) {
+    lines.push(
+      `http_headers = { Authorization = ${tomlQuote(`Bearer ${token}`)} }`,
+    );
+  }
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Replace (or append) the `[mcp_servers.<name>]` block in a TOML file
+ * without disturbing other content. A block is the header line plus every
+ * following line until the next top-level `[` table header or EOF. Pass
+ * `block === null` to remove the block. Identical algorithm to `mcp.ts`'s
+ * `writeCodexBlock` so the two never diverge.
+ */
+export function writeCodexBlock(
+  file: string,
+  name: string,
+  block: string | null,
+): void {
+  let content = "";
+  try {
+    content = fs.readFileSync(file, "utf-8");
+  } catch {
+    content = "";
+  }
+
+  const header = `[mcp_servers.${name}]`;
+  const lines = content.split(/\r?\n/);
+  const out: string[] = [];
+  let i = 0;
+  let removed = false;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.trim() === header) {
+      // Skip this block entirely (header + body until next table header).
+      removed = true;
+      i++;
+      while (i < lines.length && !/^\s*\[/.test(lines[i])) i++;
+      continue;
+    }
+    out.push(line);
+    i++;
+  }
+
+  let next = out
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/\n*$/, "\n");
+  if (block !== null) {
+    next = next.replace(/\n*$/, "\n");
+    if (next.trim().length) next += "\n";
+    next += block;
+  }
+  if (block === null && !removed) return; // nothing to do
+
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, next, "utf-8");
+}
+
+export function codexHasBlock(file: string, name: string): boolean {
+  try {
+    const content = fs.readFileSync(file, "utf-8");
+    return new RegExp(`^\\s*\\[mcp_servers\\.${name}\\]\\s*$`, "m").test(
+      content,
+    );
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unified write helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Idempotently write the HTTP MCP server entry for `serverName` into the
+ * given client's config file and return the file path that was written.
+ * Re-running replaces the same named entry — never duplicates.
+ */
+export function writeHttpEntryForClient(
+  client: ClientId,
+  serverName: string,
+  mcpUrl: string,
+  token: string | undefined,
+  baseDir: string,
+  scope: string | undefined,
+): string {
+  const file = configPathFor(client, baseDir, scope);
+  if (client === "codex") {
+    writeCodexBlock(
+      file,
+      serverName,
+      buildCodexHttpBlock(serverName, mcpUrl, token),
+    );
+  } else {
+    writeJsonMcpEntry(
+      file,
+      serverName,
+      buildHttpMcpEntry(mcpUrl, token) as unknown as Record<string, unknown>,
+    );
+  }
+  return file;
+}

--- a/packages/core/src/cli/mcp-config-writers.ts
+++ b/packages/core/src/cli/mcp-config-writers.ts
@@ -150,13 +150,21 @@ function tomlQuote(s: string): string {
   return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
+function codexMcpHeader(name: string): string {
+  return `[mcp_servers.${tomlQuote(name)}]`;
+}
+
+function legacyCodexMcpHeader(name: string): string | null {
+  return /^[A-Za-z0-9_-]+$/.test(name) ? `[mcp_servers.${name}]` : null;
+}
+
 /** Build a `[mcp_servers.<name>]` block for an HTTP-type MCP server. */
 export function buildCodexHttpBlock(
   name: string,
   mcpUrl: string,
   token?: string,
 ): string {
-  const lines: string[] = [`[mcp_servers.${name}]`];
+  const lines: string[] = [codexMcpHeader(name)];
   lines.push(`url = ${tomlQuote(mcpUrl)}`);
   if (token) {
     lines.push(
@@ -185,14 +193,18 @@ export function writeCodexBlock(
     content = "";
   }
 
-  const header = `[mcp_servers.${name}]`;
+  const headers = new Set(
+    [codexMcpHeader(name), legacyCodexMcpHeader(name)].filter(
+      Boolean,
+    ) as string[],
+  );
   const lines = content.split(/\r?\n/);
   const out: string[] = [];
   let i = 0;
   let removed = false;
   while (i < lines.length) {
     const line = lines[i];
-    if (line.trim() === header) {
+    if (headers.has(line.trim())) {
       // Skip this block entirely (header + body until next table header).
       removed = true;
       i++;
@@ -221,9 +233,12 @@ export function writeCodexBlock(
 export function codexHasBlock(file: string, name: string): boolean {
   try {
     const content = fs.readFileSync(file, "utf-8");
-    return new RegExp(`^\\s*\\[mcp_servers\\.${name}\\]\\s*$`, "m").test(
-      content,
+    const headers = new Set(
+      [codexMcpHeader(name), legacyCodexMcpHeader(name)].filter(
+        Boolean,
+      ) as string[],
     );
+    return content.split(/\r?\n/).some((line) => headers.has(line.trim()));
   } catch {
     return false;
   }

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -44,6 +44,7 @@ import {
 } from "./sse-event-processor.js";
 import { captureError, trackEvent } from "./analytics.js";
 import { cn } from "./utils.js";
+import { useNearBottomAutoscroll } from "./conversation/index.js";
 import { TextAttachmentAdapter } from "./composer/attachment-accept.js";
 import { AgentTaskCard } from "./AgentTaskCard.js";
 import { ConnectBuilderCard } from "./ConnectBuilderCard.js";
@@ -72,6 +73,7 @@ import {
 import { ThumbsFeedback } from "./observability/ThumbsFeedback.js";
 import {
   TiptapComposer,
+  type ComposerSubmitIntent,
   type TiptapComposerHandle,
 } from "./composer/TiptapComposer.js";
 import { AgentComposerFrame } from "./composer/AgentComposerFrame.js";
@@ -3314,7 +3316,6 @@ const AssistantChatInner = forwardRef<
   },
   ref,
 ) {
-  const scrollRef = useRef<HTMLDivElement>(null);
   const thread = useThread();
   const threadRuntime = useThreadRuntime();
   const composerRuntime = useComposerRuntime();
@@ -4257,6 +4258,7 @@ const AssistantChatInner = forwardRef<
       references?: Reference[],
       attachments?: ReadonlyArray<unknown>,
       requestMode?: AgentRequestMode,
+      intent: ComposerSubmitIntent = "queued",
     ) => {
       setShowContinue(false);
       setLoopLimitInfo(null);
@@ -4273,8 +4275,7 @@ const AssistantChatInner = forwardRef<
       // user had scrolled up to read history. The sticky-bottom override
       // exists to stop streaming from yanking the viewport, not to swallow
       // direct sends.
-      isNearBottomRef.current = true;
-      setShowScrollToBottom(false);
+      markNearBottom();
       const queuedAttachments = await serializeQueuedAttachments(attachments);
       // Snapshot the exec mode at enqueue time when the caller didn't
       // pass an explicit override. Without this, a plan-mode message that
@@ -4287,7 +4288,7 @@ const AssistantChatInner = forwardRef<
           : execMode === "build"
             ? "act"
             : undefined);
-      if (isRunning) {
+      if (isRunning && intent === "queued") {
         setQueuedMessages((prev) => [
           ...prev,
           {
@@ -4355,41 +4356,17 @@ const AssistantChatInner = forwardRef<
     [addToQueue, messages.length, thread.isRunning, threadRuntime],
   );
 
-  // Track whether user has scrolled away from bottom
-  const isNearBottomRef = useRef(true);
-  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    function onScroll() {
-      if (!el) return;
-      const threshold = 40;
-      const nearBottom =
-        el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
-      isNearBottomRef.current = nearBottom;
-      setShowScrollToBottom(!nearBottom && messages.length > 0);
-    }
-    el.addEventListener("scroll", onScroll, { passive: true });
-    return () => el.removeEventListener("scroll", onScroll);
-  }, [messages.length]);
-
-  const scrollToBottom = useCallback(() => {
-    const el = scrollRef.current;
-    if (el) {
-      el.scrollTop = el.scrollHeight;
-      isNearBottomRef.current = true;
-      setShowScrollToBottom(false);
-    }
-  }, []);
-
-  const scrollToBottomAfterPaint = useCallback(() => {
-    scrollToBottom();
-    requestAnimationFrame(() => {
-      scrollToBottom();
-      requestAnimationFrame(scrollToBottom);
-    });
-    setTimeout(scrollToBottom, 80);
-  }, [scrollToBottom]);
+  const {
+    scrollRef,
+    isNearBottomRef,
+    showScrollToBottom,
+    markNearBottom,
+    scrollToBottom,
+    scrollToBottomAfterPaint,
+  } = useNearBottomAutoscroll<HTMLDivElement>({
+    followKey: [messages, queuedMessages],
+    streaming: isRunning,
+  });
 
   const scrollToBottomWhileLayoutSettles = useCallback(() => {
     scrollToBottomAfterPaint();
@@ -4424,32 +4401,11 @@ const AssistantChatInner = forwardRef<
     }
   }, [isRestoring, scrollToBottomWhileLayoutSettles]);
 
-  // Auto-scroll on new messages or queued messages (only if near bottom)
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el && isNearBottomRef.current) {
-      scrollToBottomAfterPaint();
-    }
-  }, [messages, queuedMessages, scrollToBottomAfterPaint]);
-
   useEffect(() => {
     if (!isRunning && isNearBottomRef.current) {
       scrollToBottomAfterPaint();
     }
   }, [isRunning, scrollToBottomAfterPaint]);
-
-  // Continuous auto-scroll while streaming (only if near bottom)
-  useEffect(() => {
-    if (!isRunning) return;
-    const el = scrollRef.current;
-    if (!el) return;
-    const interval = setInterval(() => {
-      if (isNearBottomRef.current) {
-        el.scrollTop = el.scrollHeight;
-      }
-    }, 100);
-    return () => clearInterval(interval);
-  }, [isRunning]);
 
   const { isDevMode: cpDevMode } = useDevMode(apiUrl);
   const checkpointCtx = useMemo(
@@ -4854,18 +4810,20 @@ const AssistantChatInner = forwardRef<
                         "Open Desktop to use this chat.")
                       : isRunning
                         ? queuedMessages.length > 0
-                          ? `${queuedMessages.length} queued — type another...`
-                          : "Queue a message..."
+                          ? `${queuedMessages.length} queued — send a follow-up...`
+                          : "Send a follow-up..."
                         : undefined
                 }
                 onSubmit={
                   isRunning
-                    ? (text, references, attachments) =>
+                    ? (text, references, attachments, options) =>
                         void addToQueue(
                           text,
                           undefined,
                           references.length > 0 ? references : undefined,
                           attachments,
+                          undefined,
+                          options?.intent ?? "immediate",
                         )
                     : undefined
                 }

--- a/packages/core/src/client/composer/PromptComposer.tsx
+++ b/packages/core/src/client/composer/PromptComposer.tsx
@@ -29,7 +29,12 @@ import {
 import { IconX } from "@tabler/icons-react";
 import { cn } from "../utils.js";
 import { AgentComposerFrame } from "./AgentComposerFrame.js";
-import { TiptapComposer, type TiptapComposerHandle } from "./TiptapComposer.js";
+import {
+  TiptapComposer,
+  type ComposerSubmitIntent,
+  type TiptapComposerHandle,
+  type TiptapComposerSubmitOptions,
+} from "./TiptapComposer.js";
 import type {
   AgentComposerLayoutVariant,
   Reference,
@@ -56,6 +61,7 @@ const MAX_INLINE_TEXT_FILE_CHARS = 60_000;
 export type PromptComposerFile = File;
 
 export interface PromptComposerSubmitOptions {
+  intent?: ComposerSubmitIntent;
   model?: string;
   engine?: string;
   effort?: ReasoningEffort;
@@ -99,6 +105,10 @@ export interface PromptComposerProps {
   modeControl?: ReactNode;
   /** Explicit host-owned toolbar slot rendered directly after the "+" button. */
   toolbarSlot?: ReactNode;
+  /** Custom action button to render instead of the default send button. */
+  actionButton?: ReactNode;
+  /** Extra button rendered alongside the default send button. */
+  extraActionButton?: ReactNode;
   /** Shared sizing/layout variant for host surfaces. Default keeps sidebar behavior. */
   layoutVariant?: AgentComposerLayoutVariant;
   /** Additional slash commands surfaced in the shared / menu. */
@@ -447,6 +457,8 @@ function PromptComposerInner({
   initialTextKey,
   modeControl,
   toolbarSlot,
+  actionButton,
+  extraActionButton,
   layoutVariant,
   slashCommands,
   slashSkills,
@@ -501,6 +513,7 @@ function PromptComposerInner({
       text: string,
       references: Reference[],
       attachments?: ReadonlyArray<unknown>,
+      submitOptions?: TiptapComposerSubmitOptions,
     ) => {
       // PromptComposer hosts (NewWorkspaceAppFlow, create-extension, create-deck,
       // …) submit a single string prompt — they don't run the assistant-ui
@@ -513,6 +526,7 @@ function PromptComposerInner({
         attachments,
       });
       onSubmit(finalText, files, references, {
+        intent: submitOptions?.intent ?? "immediate",
         model: composerModel,
         engine: composerEngine,
         effort: composerEffort,
@@ -543,6 +557,8 @@ function PromptComposerInner({
         }
         modeControl={modeControl}
         toolbarSlot={toolbarSlot}
+        actionButton={actionButton}
+        extraActionButton={extraActionButton}
         layoutVariant={layoutVariant}
         slashCommands={slashCommands}
         slashSkills={slashSkills}

--- a/packages/core/src/client/composer/TiptapComposer.spec.ts
+++ b/packages/core/src/client/composer/TiptapComposer.spec.ts
@@ -6,6 +6,7 @@ import {
   canSubmitComposerContent,
   createTiptapComposerExtensions,
   displayableComposerModeMessage,
+  getComposerSubmitIntentForEnterKey,
 } from "./TiptapComposer.js";
 
 describe("createTiptapComposerExtensions", () => {
@@ -67,5 +68,35 @@ describe("createTiptapComposerExtensions", () => {
         attachmentCount: 1,
       }),
     ).toBe("Create an extension: Use the attached context.");
+  });
+
+  it("maps Enter keybindings to immediate and queued submit intents", () => {
+    const enter = {
+      key: "Enter",
+      shiftKey: false,
+      metaKey: false,
+      ctrlKey: false,
+    };
+
+    expect(getComposerSubmitIntentForEnterKey(enter, true)).toBe("immediate");
+    expect(getComposerSubmitIntentForEnterKey(enter, false)).toBe("immediate");
+    expect(
+      getComposerSubmitIntentForEnterKey({ ...enter, metaKey: true }, true),
+    ).toBe("queued");
+    expect(
+      getComposerSubmitIntentForEnterKey({ ...enter, ctrlKey: true }, false),
+    ).toBe("queued");
+    expect(
+      getComposerSubmitIntentForEnterKey(
+        { ...enter, shiftKey: true, metaKey: true },
+        true,
+      ),
+    ).toBeNull();
+    expect(
+      getComposerSubmitIntentForEnterKey({ ...enter, ctrlKey: true }, true),
+    ).toBeNull();
+    expect(
+      getComposerSubmitIntentForEnterKey({ ...enter, metaKey: true }, false),
+    ).toBeNull();
   });
 });

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -70,6 +70,12 @@ export interface TiptapComposerHandle {
   focus(): void;
 }
 
+export type ComposerSubmitIntent = "immediate" | "queued";
+
+export interface TiptapComposerSubmitOptions {
+  intent?: ComposerSubmitIntent;
+}
+
 export function canSubmitComposerContent(options: {
   hasEditorContent: boolean;
   attachmentCount: number;
@@ -79,6 +85,20 @@ export function canSubmitComposerContent(options: {
     !options.disabled &&
     (options.hasEditorContent || options.attachmentCount > 0)
   );
+}
+
+export function getComposerSubmitIntentForEnterKey(
+  event: Pick<KeyboardEvent, "key" | "shiftKey" | "metaKey" | "ctrlKey">,
+  isMac: boolean,
+): ComposerSubmitIntent | null {
+  if (event.key !== "Enter" || event.shiftKey) return null;
+
+  const queuedModifierPressed = isMac ? event.metaKey : event.ctrlKey;
+  if (queuedModifierPressed) return "queued";
+
+  if (!event.metaKey && !event.ctrlKey) return "immediate";
+
+  return null;
 }
 
 export function displayableComposerModeMessage(options: {
@@ -259,6 +279,7 @@ interface TiptapComposerProps {
     text: string,
     references: Reference[],
     attachments?: ReadonlyArray<unknown>,
+    options?: TiptapComposerSubmitOptions,
   ) => void;
   /**
    * Clear the editor after an onSubmit handler runs. Standalone workflows that
@@ -1181,15 +1202,12 @@ export function TiptapComposer({
           return true;
         }
 
-        // Submit on Enter (Shift+Enter for newline)
-        if (
-          event.key === "Enter" &&
-          !event.shiftKey &&
-          !event.metaKey &&
-          !event.ctrlKey
-        ) {
+        // Submit on Enter. Shift+Enter falls through to Tiptap for a newline;
+        // Cmd+Enter on macOS / Ctrl+Enter elsewhere marks the submit queued.
+        const submitIntent = getComposerSubmitIntentForEnterKey(event, isMac);
+        if (submitIntent) {
           event.preventDefault();
-          submitComposer();
+          submitComposer(submitIntent);
           return true;
         }
 
@@ -1464,125 +1482,129 @@ export function TiptapComposer({
     return { text, references };
   }, [composerRuntime, extractComposerPayload]);
 
-  const submitComposer = useCallback(() => {
-    const ed = editor;
-    if (!ed) return;
+  const submitComposer = useCallback(
+    (intent: ComposerSubmitIntent = "immediate") => {
+      const ed = editor;
+      if (!ed) return;
 
-    const { text, references } = syncComposerState();
-    const attachments = composerRuntime.getState().attachments;
-    if (!text.trim() && references.length === 0 && attachments.length === 0)
-      return;
-    const cancelActiveVoice = () => {
-      if (
-        voice.state === "recording" ||
-        voice.state === "starting" ||
-        voice.state === "transcribing"
-      ) {
-        voice.cancel();
+      const { text, references } = syncComposerState();
+      const attachments = composerRuntime.getState().attachments;
+      if (!text.trim() && references.length === 0 && attachments.length === 0)
+        return;
+      const cancelActiveVoice = () => {
+        if (
+          voice.state === "recording" ||
+          voice.state === "starting" ||
+          voice.state === "transcribing"
+        ) {
+          voice.cancel();
+        }
+      };
+
+      // Intercept slash commands typed directly (e.g. "/clear" + Enter)
+      const trimmed = text.trim();
+      if (trimmed.startsWith("/") && references.length === 0) {
+        const cmdName = normalizeSlashCommandName(trimmed);
+        const matched = allSlashCommands.find((c) => c.name === cmdName);
+        if (matched) {
+          ed.commands.clearContent();
+          try {
+            localStorage.removeItem(draftKey);
+          } catch {}
+          closePopover();
+          onSlashCommandRef.current?.(matched.name);
+          return;
+        }
       }
-    };
 
-    // Intercept slash commands typed directly (e.g. "/clear" + Enter)
-    const trimmed = text.trim();
-    if (trimmed.startsWith("/") && references.length === 0) {
-      const cmdName = normalizeSlashCommandName(trimmed);
-      const matched = allSlashCommands.find((c) => c.name === cmdName);
-      if (matched) {
+      // Composer mode: send with context via agent chat bridge
+      if (composerMode) {
+        const config = COMPOSER_MODE_CONFIGS[composerMode];
+        config.beforeSend?.();
+        const message = displayableComposerModeMessage({
+          messagePrefix: config.messagePrefix,
+          trimmedText: trimmed,
+          attachmentCount: attachments.length,
+        });
+        const modePrompt =
+          trimmed ||
+          (attachments.length > 0 ? "Use the attached context." : "");
+        if (attachments.length > 0) {
+          composerRuntime.setText(
+            `${message}\n\n<context>\n${config.getContext(modePrompt)}\n</context>`,
+          );
+          composerRuntime.send();
+        } else {
+          sendToAgentChat({
+            message,
+            context: config.getContext(modePrompt),
+            submit: true,
+          });
+        }
+        cancelActiveVoice();
         ed.commands.clearContent();
+        setEditorHasText(false);
+        setComposerMode(null);
+        composerModeRef.current = null;
         try {
           localStorage.removeItem(draftKey);
         } catch {}
         closePopover();
-        onSlashCommandRef.current?.(matched.name);
         return;
       }
-    }
 
-    // Composer mode: send with context via agent chat bridge
-    if (composerMode) {
-      const config = COMPOSER_MODE_CONFIGS[composerMode];
-      config.beforeSend?.();
-      const message = displayableComposerModeMessage({
-        messagePrefix: config.messagePrefix,
-        trimmedText: trimmed,
-        attachmentCount: attachments.length,
-      });
-      const modePrompt =
-        trimmed || (attachments.length > 0 ? "Use the attached context." : "");
-      if (attachments.length > 0) {
-        composerRuntime.setText(
-          `${message}\n\n<context>\n${config.getContext(modePrompt)}\n</context>`,
-        );
-        composerRuntime.send();
-      } else {
-        sendToAgentChat({
-          message,
-          context: config.getContext(modePrompt),
-          submit: true,
-        });
-      }
-      cancelActiveVoice();
-      ed.commands.clearContent();
-      setEditorHasText(false);
-      setComposerMode(null);
-      composerModeRef.current = null;
-      try {
-        localStorage.removeItem(draftKey);
-      } catch {}
-      closePopover();
-      return;
-    }
-
-    // Builder iframe delegation: when this app is mounted inside the
-    // Builder.io webview and the user typed a "build me an app/agent"
-    // prompt, hand it up to the parent Builder chat instead of sending
-    // it to this app's domain agent. Builder is the code-writing agent;
-    // the local agent (dispatch, mail, etc.) cannot scaffold workspace
-    // apps from inside its own iframe.
-    if (
-      interceptBuildRequestsForBuilder &&
-      tryDelegateBuildRequestToBuilder(trimmed)
-    ) {
-      cancelActiveVoice();
-      ed.commands.clearContent();
-      setEditorHasText(false);
-      try {
-        localStorage.removeItem(draftKey);
-      } catch {}
-      closePopover();
-      return;
-    }
-
-    if (onSubmit) {
-      onSubmit(text, references, attachments);
-      // Clear any pending attachments now that the host has them.
-      void composerRuntime.clearAttachments().catch(() => {});
-      if (!clearOnSubmit) {
+      // Builder iframe delegation: when this app is mounted inside the
+      // Builder.io webview and the user typed a "build me an app/agent"
+      // prompt, hand it up to the parent Builder chat instead of sending
+      // it to this app's domain agent. Builder is the code-writing agent;
+      // the local agent (dispatch, mail, etc.) cannot scaffold workspace
+      // apps from inside its own iframe.
+      if (
+        interceptBuildRequestsForBuilder &&
+        tryDelegateBuildRequestToBuilder(trimmed)
+      ) {
+        cancelActiveVoice();
+        ed.commands.clearContent();
+        setEditorHasText(false);
+        try {
+          localStorage.removeItem(draftKey);
+        } catch {}
         closePopover();
         return;
       }
-    } else {
-      composerRuntime.send();
-    }
-    cancelActiveVoice();
-    ed.commands.clearContent();
-    setEditorHasText(false);
-    try {
-      localStorage.removeItem(draftKey);
-    } catch {}
-    closePopover();
-  }, [
-    closePopover,
-    composerMode,
-    composerRuntime,
-    editor,
-    interceptBuildRequestsForBuilder,
-    clearOnSubmit,
-    onSubmit,
-    syncComposerState,
-    voice,
-    allSlashCommands,
-  ]);
+
+      if (onSubmit) {
+        onSubmit(text, references, attachments, { intent });
+        // Clear any pending attachments now that the host has them.
+        void composerRuntime.clearAttachments().catch(() => {});
+        if (!clearOnSubmit) {
+          closePopover();
+          return;
+        }
+      } else {
+        composerRuntime.send();
+      }
+      cancelActiveVoice();
+      ed.commands.clearContent();
+      setEditorHasText(false);
+      try {
+        localStorage.removeItem(draftKey);
+      } catch {}
+      closePopover();
+    },
+    [
+      closePopover,
+      composerMode,
+      composerRuntime,
+      editor,
+      interceptBuildRequestsForBuilder,
+      clearOnSubmit,
+      onSubmit,
+      syncComposerState,
+      voice,
+      allSlashCommands,
+    ],
+  );
 
   // Helper functions that operate on the editor view directly
   // These are called from handleKeyDown which can't use React state
@@ -1855,26 +1877,22 @@ export function TiptapComposer({
           ))}
         {toolbarSlot ?? modeControl}
         <div data-agent-composer-slot="toolbar-spacer" className="flex-1" />
-        {!actionButton && (
-          <>
-            {selectedModel && availableModels && onModelChange && (
-              <ModelSelector
-                model={selectedModel}
-                effort={selectedEffort}
-                engines={availableModels}
-                onChange={onModelChange}
-                onEffortChange={onEffortChange}
-              />
-            )}
-            {execMode && onExecModeChange && (
-              <ModeSelector
-                mode={execMode}
-                onChange={onExecModeChange}
-                planModeDisabled={planModeDisabled}
-                planModeDisabledReason={planModeDisabledReason}
-              />
-            )}
-          </>
+        {selectedModel && availableModels && onModelChange && (
+          <ModelSelector
+            model={selectedModel}
+            effort={selectedEffort}
+            engines={availableModels}
+            onChange={onModelChange}
+            onEffortChange={onEffortChange}
+          />
+        )}
+        {execMode && onExecModeChange && (
+          <ModeSelector
+            mode={execMode}
+            onChange={onExecModeChange}
+            planModeDisabled={planModeDisabled}
+            planModeDisabledReason={planModeDisabledReason}
+          />
         )}
         {actionButton ?? (
           <>
@@ -1886,7 +1904,7 @@ export function TiptapComposer({
               <TooltipTrigger asChild>
                 <button
                   type="button"
-                  onClick={submitComposer}
+                  onClick={() => submitComposer("immediate")}
                   disabled={!canSend}
                   data-agent-composer-slot="send-button"
                   className="agent-composer-send-button shrink-0 flex h-7 w-7 items-center justify-center rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-30 disabled:cursor-not-allowed"

--- a/packages/core/src/client/conversation/AgentConversation.spec.tsx
+++ b/packages/core/src/client/conversation/AgentConversation.spec.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentConversationMessageView } from "./AgentConversation.js";
+
+describe("AgentConversationMessageView", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders text and tool parts in transcript order", () => {
+    act(() => {
+      root.render(
+        <AgentConversationMessageView
+          message={{
+            id: "message-1",
+            role: "assistant",
+            parts: [
+              { id: "text-1", type: "text", text: "Before tool." },
+              {
+                id: "tool-1",
+                type: "tool",
+                tool: {
+                  id: "tool-1",
+                  name: "list_files",
+                  state: "completed",
+                  summary: "finished",
+                },
+              },
+              { id: "text-2", type: "text", text: "After tool." },
+            ],
+          }}
+        />,
+      );
+    });
+
+    expect(container.textContent).toMatch(
+      /Before tool\.\s*list_files\s*finished\s*After tool\./,
+    );
+  });
+
+  it("opens markdown links in a new external window", () => {
+    const open = vi
+      .spyOn(window, "open")
+      .mockImplementation(() => null as Window | null);
+
+    act(() => {
+      root.render(
+        <AgentConversationMessageView
+          message={{
+            id: "message-1",
+            role: "assistant",
+            parts: [
+              {
+                id: "text-1",
+                type: "text",
+                text: "[Builder](https://builder.io/docs)",
+              },
+            ],
+          }}
+        />,
+      );
+    });
+
+    container
+      .querySelector("a")
+      ?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+
+    expect(open).toHaveBeenCalledWith(
+      "https://builder.io/docs",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+});

--- a/packages/core/src/client/conversation/AgentConversation.tsx
+++ b/packages/core/src/client/conversation/AgentConversation.tsx
@@ -1,0 +1,275 @@
+import React from "react";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import {
+  IconAlertTriangle,
+  IconArrowDown,
+  IconCheck,
+  IconChevronDown,
+  IconCircleX,
+  IconClock,
+  IconExternalLink,
+  IconLoader2,
+  IconTool,
+} from "@tabler/icons-react";
+import { cn } from "../utils.js";
+import { useNearBottomAutoscroll } from "./use-near-bottom-autoscroll.js";
+import type {
+  AgentConversationArtifact,
+  AgentConversationMessage,
+  AgentConversationNotice,
+  AgentConversationToolCall,
+} from "./types.js";
+
+export interface AgentConversationProps {
+  messages: AgentConversationMessage[];
+  loading?: boolean;
+  error?: string | null;
+  streaming?: boolean;
+  className?: string;
+  timelineClassName?: string;
+  emptyTitle?: string;
+  emptyDescription?: string;
+  composer?: React.ReactNode;
+}
+
+export function AgentConversation({
+  messages,
+  loading = false,
+  error,
+  streaming = false,
+  className,
+  timelineClassName,
+  emptyTitle = "No messages yet",
+  emptyDescription,
+  composer,
+}: AgentConversationProps) {
+  const followKey = `${messages.length}:${
+    messages[messages.length - 1]?.text?.length ?? 0
+  }`;
+  const { scrollRef, showScrollToBottom, scrollToBottom } =
+    useNearBottomAutoscroll<HTMLDivElement>({
+      followKey,
+      streaming,
+    });
+
+  return (
+    <section className={cn("agent-conversation", className)}>
+      {error && (
+        <div className="agent-conversation__error" role="alert">
+          <IconAlertTriangle size={15} strokeWidth={1.8} />
+          <span>{error}</span>
+        </div>
+      )}
+      <div
+        ref={scrollRef}
+        className={cn("agent-conversation__timeline", timelineClassName)}
+      >
+        {loading && messages.length === 0 ? (
+          <ConversationEmpty
+            icon={<IconLoader2 size={17} className="agent-conversation-spin" />}
+            title="Loading session..."
+          />
+        ) : messages.length === 0 ? (
+          <ConversationEmpty
+            icon={<IconClock size={18} />}
+            title={emptyTitle}
+            description={emptyDescription}
+          />
+        ) : (
+          messages.map((message) => (
+            <AgentConversationMessageView key={message.id} message={message} />
+          ))
+        )}
+      </div>
+      {showScrollToBottom && (
+        <button
+          type="button"
+          className="agent-conversation__scroll-bottom"
+          onClick={scrollToBottom}
+          aria-label="Scroll to bottom"
+        >
+          <IconArrowDown size={15} strokeWidth={1.9} />
+        </button>
+      )}
+      {composer}
+    </section>
+  );
+}
+
+function ConversationEmpty({
+  icon,
+  title,
+  description,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description?: string;
+}) {
+  return (
+    <div className="agent-conversation__empty">
+      {icon}
+      <p>{title}</p>
+      {description && <span>{description}</span>}
+    </div>
+  );
+}
+
+export function AgentConversationMessageView({
+  message,
+}: {
+  message: AgentConversationMessage;
+}) {
+  return (
+    <article
+      className={cn(
+        "agent-conversation-message",
+        `agent-conversation-message--${message.role}`,
+        message.pending && "agent-conversation-message--pending",
+      )}
+    >
+      <div className="agent-conversation-message__body">
+        {message.text && <ConversationMarkdown text={message.text} />}
+        {message.tools && message.tools.length > 0 && (
+          <div className="agent-conversation-message__tools">
+            {message.tools.map((tool) => (
+              <ConversationToolCall key={tool.id} tool={tool} />
+            ))}
+          </div>
+        )}
+        {message.notices && message.notices.length > 0 && (
+          <div className="agent-conversation-message__notices">
+            {message.notices.map((notice) => (
+              <ConversationNotice key={notice.id} notice={notice} />
+            ))}
+          </div>
+        )}
+        {message.artifacts && message.artifacts.length > 0 && (
+          <div className="agent-conversation-message__artifacts">
+            {message.artifacts.map((artifact) => (
+              <ConversationArtifact key={artifact.id} artifact={artifact} />
+            ))}
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function ConversationMarkdown({ text }: { text: string }) {
+  return (
+    <div className="agent-conversation-markdown">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        urlTransform={(url) => {
+          if (url.startsWith("file://")) return url;
+          return defaultUrlTransform(url);
+        }}
+        components={{
+          a({ children, href }) {
+            return (
+              <a href={href} target="_blank" rel="noreferrer">
+                {children}
+              </a>
+            );
+          },
+        }}
+      >
+        {text}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+function ConversationToolCall({ tool }: { tool: AgentConversationToolCall }) {
+  const hasDetails = Boolean(tool.input || tool.result);
+  const icon =
+    tool.state === "running" || tool.state === "activity" ? (
+      <IconLoader2 size={14} className="agent-conversation-spin" />
+    ) : tool.state === "errored" ? (
+      <IconCircleX size={14} />
+    ) : (
+      <IconCheck size={14} />
+    );
+
+  const content = (
+    <>
+      <span className="agent-conversation-tool__icon">{icon}</span>
+      <span className="agent-conversation-tool__name">{tool.name}</span>
+      {tool.summary && (
+        <span className="agent-conversation-tool__summary">{tool.summary}</span>
+      )}
+    </>
+  );
+
+  if (!hasDetails) {
+    return <div className="agent-conversation-tool">{content}</div>;
+  }
+
+  return (
+    <details className="agent-conversation-tool">
+      <summary>
+        {content}
+        <IconChevronDown
+          size={13}
+          className="agent-conversation-tool__chevron"
+        />
+      </summary>
+      <div className="agent-conversation-tool__details">
+        {tool.input && (
+          <pre>
+            <strong>input</strong>
+            {tool.input}
+          </pre>
+        )}
+        {tool.result && (
+          <pre>
+            <strong>result</strong>
+            {tool.result}
+          </pre>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function ConversationNotice({ notice }: { notice: AgentConversationNotice }) {
+  return (
+    <div
+      className={cn(
+        "agent-conversation-notice",
+        `agent-conversation-notice--${notice.tone}`,
+      )}
+    >
+      <IconAlertTriangle size={15} />
+      <div>
+        {notice.title && <strong>{notice.title}</strong>}
+        <span>{notice.text}</span>
+      </div>
+      {notice.action}
+    </div>
+  );
+}
+
+function ConversationArtifact({
+  artifact,
+}: {
+  artifact: AgentConversationArtifact;
+}) {
+  return (
+    <div className="agent-conversation-artifact">
+      <IconTool size={14} />
+      {artifact.path ? (
+        <code>{artifact.path}</code>
+      ) : (
+        <span>{artifact.label}</span>
+      )}
+      {artifact.url && (
+        <a href={artifact.url} target="_blank" rel="noreferrer">
+          <IconExternalLink size={13} />
+          Open
+        </a>
+      )}
+    </div>
+  );
+}

--- a/packages/core/src/client/conversation/AgentConversation.tsx
+++ b/packages/core/src/client/conversation/AgentConversation.tsx
@@ -17,6 +17,7 @@ import { useNearBottomAutoscroll } from "./use-near-bottom-autoscroll.js";
 import type {
   AgentConversationArtifact,
   AgentConversationMessage,
+  AgentConversationMessagePart,
   AgentConversationNotice,
   AgentConversationToolCall,
 } from "./types.js";
@@ -120,6 +121,8 @@ export function AgentConversationMessageView({
 }: {
   message: AgentConversationMessage;
 }) {
+  const parts = message.parts ?? legacyPartsForMessage(message);
+
   return (
     <article
       className={cn(
@@ -129,30 +132,67 @@ export function AgentConversationMessageView({
       )}
     >
       <div className="agent-conversation-message__body">
-        {message.text && <ConversationMarkdown text={message.text} />}
-        {message.tools && message.tools.length > 0 && (
-          <div className="agent-conversation-message__tools">
-            {message.tools.map((tool) => (
-              <ConversationToolCall key={tool.id} tool={tool} />
-            ))}
-          </div>
-        )}
-        {message.notices && message.notices.length > 0 && (
-          <div className="agent-conversation-message__notices">
-            {message.notices.map((notice) => (
-              <ConversationNotice key={notice.id} notice={notice} />
-            ))}
-          </div>
-        )}
-        {message.artifacts && message.artifacts.length > 0 && (
-          <div className="agent-conversation-message__artifacts">
-            {message.artifacts.map((artifact) => (
-              <ConversationArtifact key={artifact.id} artifact={artifact} />
-            ))}
-          </div>
-        )}
+        {parts.map((part) => (
+          <ConversationMessagePartView key={part.id} part={part} />
+        ))}
       </div>
     </article>
+  );
+}
+
+function legacyPartsForMessage(
+  message: AgentConversationMessage,
+): AgentConversationMessagePart[] {
+  return [
+    ...(message.text
+      ? [
+          {
+            id: `${message.id}-text`,
+            type: "text" as const,
+            text: message.text,
+          },
+        ]
+      : []),
+    ...(message.tools ?? []).map((tool) => ({
+      id: `${message.id}-tool-${tool.id}`,
+      type: "tool" as const,
+      tool,
+    })),
+    ...(message.notices ?? []).map((notice) => ({
+      id: `${message.id}-notice-${notice.id}`,
+      type: "notice" as const,
+      notice,
+    })),
+    ...(message.artifacts ?? []).map((artifact) => ({
+      id: `${message.id}-artifact-${artifact.id}`,
+      type: "artifact" as const,
+      artifact,
+    })),
+  ];
+}
+
+function ConversationMessagePartView({
+  part,
+}: {
+  part: AgentConversationMessagePart;
+}) {
+  return (
+    <div
+      className={cn(
+        "agent-conversation-message__part",
+        `agent-conversation-message__part--${part.type}`,
+      )}
+    >
+      {part.type === "text" ? (
+        <ConversationMarkdown text={part.text} />
+      ) : part.type === "tool" ? (
+        <ConversationToolCall tool={part.tool} />
+      ) : part.type === "notice" ? (
+        <ConversationNotice notice={part.notice} />
+      ) : (
+        <ConversationArtifact artifact={part.artifact} />
+      )}
+    </div>
   );
 }
 
@@ -168,7 +208,12 @@ function ConversationMarkdown({ text }: { text: string }) {
         components={{
           a({ children, href }) {
             return (
-              <a href={href} target="_blank" rel="noreferrer">
+              <a
+                href={href}
+                target="_blank"
+                rel="noreferrer"
+                onClick={(event) => openMarkdownLink(event, href)}
+              >
                 {children}
               </a>
             );
@@ -179,6 +224,24 @@ function ConversationMarkdown({ text }: { text: string }) {
       </ReactMarkdown>
     </div>
   );
+}
+
+function openMarkdownLink(
+  event: React.MouseEvent<HTMLAnchorElement>,
+  href: string | undefined,
+) {
+  if (!href) return;
+
+  let url: URL;
+  try {
+    url = new URL(href, window.location.href);
+  } catch {
+    return;
+  }
+
+  if (!["http:", "https:", "mailto:", "tel:"].includes(url.protocol)) return;
+  event.preventDefault();
+  window.open(url.href, "_blank", "noopener,noreferrer");
 }
 
 function ConversationToolCall({ tool }: { tool: AgentConversationToolCall }) {

--- a/packages/core/src/client/conversation/index.ts
+++ b/packages/core/src/client/conversation/index.ts
@@ -6,6 +6,7 @@ export { useNearBottomAutoscroll } from "./use-near-bottom-autoscroll.js";
 export type {
   AgentConversationArtifact,
   AgentConversationMessage,
+  AgentConversationMessagePart,
   AgentConversationMessageRole,
   AgentConversationNotice,
   AgentConversationNoticeTone,

--- a/packages/core/src/client/conversation/index.ts
+++ b/packages/core/src/client/conversation/index.ts
@@ -1,0 +1,14 @@
+export {
+  AgentConversation,
+  AgentConversationMessageView,
+} from "./AgentConversation.js";
+export { useNearBottomAutoscroll } from "./use-near-bottom-autoscroll.js";
+export type {
+  AgentConversationArtifact,
+  AgentConversationMessage,
+  AgentConversationMessageRole,
+  AgentConversationNotice,
+  AgentConversationNoticeTone,
+  AgentConversationToolCall,
+  AgentConversationToolState,
+} from "./types.js";

--- a/packages/core/src/client/conversation/types.ts
+++ b/packages/core/src/client/conversation/types.ts
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+
+export type AgentConversationMessageRole = "user" | "assistant" | "system";
+
+export type AgentConversationToolState =
+  | "running"
+  | "completed"
+  | "errored"
+  | "activity";
+
+export interface AgentConversationToolCall {
+  id: string;
+  name: string;
+  state: AgentConversationToolState;
+  input?: string;
+  result?: string;
+  summary?: string;
+}
+
+export type AgentConversationNoticeTone = "info" | "warning" | "error";
+
+export interface AgentConversationNotice {
+  id: string;
+  tone: AgentConversationNoticeTone;
+  title?: string;
+  text: string;
+  action?: ReactNode;
+}
+
+export interface AgentConversationArtifact {
+  id: string;
+  label: string;
+  path?: string;
+  url?: string;
+}
+
+export interface AgentConversationMessage {
+  id: string;
+  role: AgentConversationMessageRole;
+  text?: string;
+  createdAt?: string;
+  pending?: boolean;
+  tools?: AgentConversationToolCall[];
+  notices?: AgentConversationNotice[];
+  artifacts?: AgentConversationArtifact[];
+}

--- a/packages/core/src/client/conversation/types.ts
+++ b/packages/core/src/client/conversation/types.ts
@@ -34,12 +34,35 @@ export interface AgentConversationArtifact {
   url?: string;
 }
 
+export type AgentConversationMessagePart =
+  | {
+      id: string;
+      type: "text";
+      text: string;
+    }
+  | {
+      id: string;
+      type: "tool";
+      tool: AgentConversationToolCall;
+    }
+  | {
+      id: string;
+      type: "notice";
+      notice: AgentConversationNotice;
+    }
+  | {
+      id: string;
+      type: "artifact";
+      artifact: AgentConversationArtifact;
+    };
+
 export interface AgentConversationMessage {
   id: string;
   role: AgentConversationMessageRole;
   text?: string;
   createdAt?: string;
   pending?: boolean;
+  parts?: AgentConversationMessagePart[];
   tools?: AgentConversationToolCall[];
   notices?: AgentConversationNotice[];
   artifacts?: AgentConversationArtifact[];

--- a/packages/core/src/client/conversation/use-near-bottom-autoscroll.ts
+++ b/packages/core/src/client/conversation/use-near-bottom-autoscroll.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface UseNearBottomAutoscrollOptions {
+  followKey: unknown;
+  streaming?: boolean;
+  threshold?: number;
+  enabled?: boolean;
+}
+
+export function useNearBottomAutoscroll<TElement extends HTMLElement>({
+  followKey,
+  streaming = false,
+  threshold = 40,
+  enabled = true,
+}: UseNearBottomAutoscrollOptions) {
+  const scrollRef = useRef<TElement | null>(null);
+  const isNearBottomRef = useRef(true);
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+
+  const updateNearBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const nearBottom =
+      el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
+    isNearBottomRef.current = nearBottom;
+    setShowScrollToBottom(!nearBottom);
+  }, [threshold]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !enabled) return;
+    const onScroll = () => updateNearBottom();
+    el.addEventListener("scroll", onScroll, { passive: true });
+    updateNearBottom();
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [enabled, updateNearBottom]);
+
+  const scrollToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    isNearBottomRef.current = true;
+    setShowScrollToBottom(false);
+  }, []);
+
+  const scrollToBottomAfterPaint = useCallback(() => {
+    scrollToBottom();
+    requestAnimationFrame(() => {
+      scrollToBottom();
+      requestAnimationFrame(scrollToBottom);
+    });
+    window.setTimeout(scrollToBottom, 80);
+  }, [scrollToBottom]);
+
+  const markNearBottom = useCallback(() => {
+    isNearBottomRef.current = true;
+    setShowScrollToBottom(false);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !isNearBottomRef.current) return;
+    scrollToBottomAfterPaint();
+  }, [enabled, followKey, scrollToBottomAfterPaint]);
+
+  useEffect(() => {
+    if (!enabled || !streaming) return;
+    const id = window.setInterval(() => {
+      if (isNearBottomRef.current) scrollToBottom();
+    }, 100);
+    return () => window.clearInterval(id);
+  }, [enabled, scrollToBottom, streaming]);
+
+  return {
+    scrollRef,
+    isNearBottomRef,
+    showScrollToBottom,
+    markNearBottom,
+    scrollToBottom,
+    scrollToBottomAfterPaint,
+  };
+}

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -31,6 +31,7 @@ export {
   useNearBottomAutoscroll,
   type AgentConversationArtifact,
   type AgentConversationMessage,
+  type AgentConversationMessagePart,
   type AgentConversationMessageRole,
   type AgentConversationNotice,
   type AgentConversationNoticeTone,

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -26,6 +26,18 @@ export {
   type CodeRequiredDialogProps,
 } from "./components/CodeRequiredDialog.js";
 export {
+  AgentConversation,
+  AgentConversationMessageView,
+  useNearBottomAutoscroll,
+  type AgentConversationArtifact,
+  type AgentConversationMessage,
+  type AgentConversationMessageRole,
+  type AgentConversationNotice,
+  type AgentConversationNoticeTone,
+  type AgentConversationToolCall,
+  type AgentConversationToolState,
+} from "./conversation/index.js";
+export {
   CodeAgentIndicator,
   type CodeAgentIndicatorProps,
 } from "./components/CodeAgentIndicator.js";

--- a/packages/core/src/client/resources/ResourceTree.tsx
+++ b/packages/core/src/client/resources/ResourceTree.tsx
@@ -16,6 +16,7 @@ import {
   IconBulb,
   IconClockHour3,
   IconLoader2,
+  IconHelpCircle,
 } from "@tabler/icons-react";
 import { cn } from "../utils.js";
 import type { TreeNode, ResourceMeta, JobMetadata } from "./use-resources.js";
@@ -544,30 +545,28 @@ export function ResourceTree({
       {/* Section heading */}
       <div className="group/root flex items-center justify-between px-1.5 py-1">
         <TooltipProvider delayDuration={200}>
-          {titleTooltip ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/60">
-                  {title}
-                  {headingHint && (
-                    <span className="text-[10px] font-normal normal-case tracking-normal text-muted-foreground/50">
-                      {headingHint}
-                    </span>
-                  )}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>{titleTooltip}</TooltipContent>
-            </Tooltip>
-          ) : (
-            <span className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/60">
-              {title}
-              {headingHint && (
-                <span className="text-[10px] font-normal normal-case tracking-normal text-muted-foreground/50">
-                  {headingHint}
-                </span>
-              )}
-            </span>
-          )}
+          <span className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/60">
+            {title}
+            {headingHint && (
+              <span className="text-[10px] font-normal normal-case tracking-normal text-muted-foreground/50">
+                {headingHint}
+              </span>
+            )}
+            {titleTooltip && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={`About ${title}`}
+                    className="flex h-3.5 w-3.5 items-center justify-center rounded-full text-muted-foreground/40 hover:text-muted-foreground"
+                  >
+                    <IconHelpCircle className="h-3 w-3" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{titleTooltip}</TooltipContent>
+              </Tooltip>
+            )}
+          </span>
           {!readOnly && (
             <Tooltip>
               <TooltipTrigger asChild>

--- a/packages/core/src/client/resources/ResourcesPanel.tsx
+++ b/packages/core/src/client/resources/ResourcesPanel.tsx
@@ -29,7 +29,6 @@ import { serializeFrontmatter } from "../../resources/metadata.js";
 import {
   useResourceTree,
   useResource,
-  useEffectiveResourceContext,
   useCreateResource,
   useUpdateResource,
   useDeleteResource,
@@ -38,7 +37,6 @@ import {
   withAgentScratchFolder,
   type ResourceScope,
   type ResourceMeta,
-  type EffectiveResourceContext,
 } from "./use-resources.js";
 import {
   formatMcpServerError,
@@ -976,80 +974,6 @@ Workspace resources are for files users intentionally add, edit, or manage. Agen
 const WORKSPACE_RESOURCE_OWNER = "__workspace__";
 const SHARED_RESOURCE_OWNER = "__shared__";
 
-function EffectiveContextPanel({
-  context,
-  isLoading,
-}: {
-  context?: EffectiveResourceContext;
-  isLoading: boolean;
-}) {
-  if (isLoading && !context) {
-    return (
-      <div className="border-b border-border bg-muted/20 px-3 py-2">
-        <div className="h-3 w-40 animate-pulse rounded bg-muted-foreground/10" />
-      </div>
-    );
-  }
-
-  if (!context) return null;
-
-  return (
-    <div className="border-b border-border bg-muted/20 px-3 py-2">
-      <div className="mb-1 flex items-center justify-between gap-2">
-        <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground/70">
-          Effective context
-        </span>
-        <span className="truncate text-[11px] text-muted-foreground/60">
-          Active: {context.effectiveScope ?? "none"}
-        </span>
-      </div>
-      <div className="grid gap-1 sm:grid-cols-3">
-        {context.layers.map((layer) => {
-          const state = layer.effective
-            ? "Active"
-            : layer.overridden
-              ? "Overridden"
-              : layer.exists
-                ? "Available"
-                : "No file";
-          return (
-            <div
-              key={layer.scope}
-              className={cn(
-                "rounded-md border px-2 py-1.5",
-                layer.effective
-                  ? "border-foreground/20 bg-background"
-                  : "border-border/70 bg-background/50",
-              )}
-            >
-              <div className="flex items-center justify-between gap-2">
-                <span className="truncate text-[11px] font-medium text-foreground">
-                  {layer.label}
-                </span>
-                <span
-                  className={cn(
-                    "shrink-0 text-[10px]",
-                    layer.effective
-                      ? "text-foreground"
-                      : layer.overridden
-                        ? "text-muted-foreground"
-                        : "text-muted-foreground/60",
-                  )}
-                >
-                  {state}
-                </span>
-              </div>
-              <div className="mt-0.5 truncate text-[10px] text-muted-foreground/60">
-                {layer.resource?.path ?? context.path}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
 // BuilderBrowserCard moved to settings/BrowserSection.tsx
 
 export function ResourcesPanel() {
@@ -1174,9 +1098,6 @@ export function ResourcesPanel() {
       !parseMcpBuiltinVirtualId(selectedResourceId)
       ? selectedResourceId
       : null,
-  );
-  const effectiveContextQuery = useEffectiveResourceContext(
-    resourceQuery.data?.path ?? null,
   );
   const createResource = useCreateResource();
   const updateResource = useUpdateResource();
@@ -1597,10 +1518,6 @@ export function ResourcesPanel() {
             </div>
           ) : selectedResourceId && resourceQuery.data ? (
             <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
-              <EffectiveContextPanel
-                context={effectiveContextQuery.data}
-                isLoading={effectiveContextQuery.isLoading}
-              />
               <ResourceEditor
                 resource={resourceQuery.data}
                 onSave={handleSave}
@@ -1658,28 +1575,30 @@ export function ResourcesPanel() {
                   </a>
                 </div>
               )}
-            <ResourceTree
-              tree={workspaceTree}
-              isLoading={workspaceTreeQuery.isLoading}
-              deletingId={
-                deleteResource.isPending
-                  ? (deleteResource.variables as string)
-                  : deleteMcpServer.isPending
-                    ? `mcp:${(deleteMcpServer.variables as { scope: string }).scope}:${(deleteMcpServer.variables as { id: string }).id}`
-                    : null
-              }
-              selectedId={selectedResourceId}
-              onSelect={handleSelect}
-              onCreateFile={() => {}}
-              onCreateFolder={() => {}}
-              onDelete={() => {}}
-              onRename={() => {}}
-              onDrop={() => {}}
-              title="Workspace"
-              titleTooltip="Global resources inherited from Dispatch by every app. Read-only here."
-              readOnly
-              headingHint="Inherited"
-            />
+            {workspaceTree.length > 0 && (
+              <ResourceTree
+                tree={workspaceTree}
+                isLoading={workspaceTreeQuery.isLoading}
+                deletingId={
+                  deleteResource.isPending
+                    ? (deleteResource.variables as string)
+                    : deleteMcpServer.isPending
+                      ? `mcp:${(deleteMcpServer.variables as { scope: string }).scope}:${(deleteMcpServer.variables as { id: string }).id}`
+                      : null
+                }
+                selectedId={selectedResourceId}
+                onSelect={handleSelect}
+                onCreateFile={() => {}}
+                onCreateFolder={() => {}}
+                onDelete={() => {}}
+                onRename={() => {}}
+                onDrop={() => {}}
+                title="Workspace"
+                titleTooltip="Global resources inherited from Dispatch by every app. Read-only here."
+                readOnly
+                headingHint="Inherited"
+              />
+            )}
             <ResourceTree
               tree={sharedTree}
               isLoading={sharedTreeQuery.isLoading}

--- a/packages/core/src/code-agents/index.ts
+++ b/packages/core/src/code-agents/index.ts
@@ -23,6 +23,16 @@ export {
   type ListBackgroundAgentRunsOptions,
 } from "./background-run.js";
 export {
+  normalizeCodeAgentTranscript,
+  type NormalizedCodeAgentAssistantTurn,
+  type NormalizedCodeAgentStatusEvent,
+  type NormalizedCodeAgentToolEvent,
+  type NormalizedCodeAgentTranscript,
+  type NormalizedCodeAgentTranscriptBase,
+  type NormalizedCodeAgentTranscriptItem,
+  type NormalizedCodeAgentUserTurn,
+} from "./transcript-normalizer.js";
+export {
   CODE_AGENT_PERMISSION_MODES,
   appendCodeAgentTranscriptEvent,
   codeAgentRunArtifactsDir,

--- a/packages/core/src/code-agents/transcript-normalizer.spec.ts
+++ b/packages/core/src/code-agents/transcript-normalizer.spec.ts
@@ -51,17 +51,30 @@ describe("normalizeCodeAgentTranscript", () => {
   it("coalesces assistant_delta system chunks and suppresses the final duplicate", () => {
     const events = [
       event("evt-user", "user", "Keep going."),
-      event("evt-delta-1", "system", "Now let", {
+      event(
+        "evt-engine",
+        "system",
+        "[builder-engine] → POST https://example.test\n",
+        {
+          type: "assistant_delta",
+          seq: 0,
+        },
+      ),
+      event("evt-delta-1", "system", "**Agent-", {
         type: "assistant_delta",
         seq: 1,
       }),
-      event("evt-delta-2", "system", "me look.", {
+      event("evt-delta-2", "system", "Native**\n\n- `core`", {
         type: "assistant_delta",
         seq: 2,
       }),
-      event("evt-final", "system", "Now let me look.", {
-        role: "assistant",
+      event("evt-delta-3", "system", " package", {
+        type: "assistant_delta",
         seq: 3,
+      }),
+      event("evt-final", "system", "**Agent-Native**\n\n- `core` package", {
+        role: "assistant",
+        seq: 4,
       }),
     ];
 
@@ -72,10 +85,14 @@ describe("normalizeCodeAgentTranscript", () => {
       expect.objectContaining({
         type: "assistant",
         source: "runner-stdout",
-        text: "Now let me look.",
-        eventIds: ["evt-delta-1", "evt-delta-2", "evt-final"],
+        text: "**Agent-Native**\n\n- `core` package",
+        eventIds: ["evt-delta-1", "evt-delta-2", "evt-delta-3", "evt-final"],
         suppressedDuplicateEventIds: ["evt-final"],
       }),
+    ]);
+    expect(transcript.hiddenEvents.map((item) => item.id)).toEqual([
+      "evt-engine",
+      "evt-final",
     ]);
   });
 
@@ -133,6 +150,36 @@ describe("normalizeCodeAgentTranscript", () => {
         result: "1 passed",
         activities: ["Running tests"],
         eventIds: ["evt-tool-start", "evt-tool-activity", "evt-tool-done"],
+      }),
+    ]);
+  });
+
+  it("merges activity before tool_start so a completed tool does not keep working forever", () => {
+    const events = [
+      event("evt-tool-activity", "status", "Preparing list_files action", {
+        type: "activity",
+        tool: "list_files",
+      }),
+      event("evt-tool-start", "status", "Running list_files.", {
+        type: "tool_start",
+        tool: "list_files",
+      }),
+      event("evt-tool-done", "status", "Finished list_files.", {
+        type: "tool_done",
+        tool: "list_files",
+      }),
+    ];
+
+    const transcript = normalizeCodeAgentTranscript(events);
+
+    expect(transcript.items).toEqual([
+      expect.objectContaining({
+        type: "tool",
+        tool: "list_files",
+        label: "Running list_files.",
+        state: "completed",
+        activities: ["Preparing list_files action"],
+        eventIds: ["evt-tool-activity", "evt-tool-start", "evt-tool-done"],
       }),
     ]);
   });

--- a/packages/core/src/code-agents/transcript-normalizer.spec.ts
+++ b/packages/core/src/code-agents/transcript-normalizer.spec.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+
+import type { CodeAgentTranscriptEvent } from "../cli/code-agent-runs.js";
+import { normalizeCodeAgentTranscript } from "./transcript-normalizer.js";
+
+describe("normalizeCodeAgentTranscript", () => {
+  it("coalesces legacy runner stdout and suppresses duplicate final assistant text", () => {
+    const events = [
+      event("evt-user", "user", "Fix the failing test."),
+      event("evt-start", "status", "Agent-Native Code run started.", {
+        status: "running",
+        phase: "executing",
+      }),
+      event("evt-stdout-1", "status", "I checked", {
+        source: "runner-stdout",
+      }),
+      event("evt-stdout-2", "status", "the specs.", {
+        source: "runner-stdout",
+      }),
+      event("evt-final", "system", "I checked the specs.", {
+        role: "assistant",
+      }),
+      event("evt-complete", "status", "Agent-Native Code run completed.", {
+        status: "completed",
+        phase: "complete",
+      }),
+    ];
+
+    const transcript = normalizeCodeAgentTranscript(events);
+
+    expect(transcript.items).toHaveLength(2);
+    expect(transcript.items[0]).toMatchObject({
+      type: "user",
+      text: "Fix the failing test.",
+    });
+    expect(transcript.items[1]).toMatchObject({
+      type: "assistant",
+      source: "runner-stdout",
+      text: "I checked the specs.",
+      eventIds: ["evt-stdout-1", "evt-stdout-2", "evt-final"],
+      suppressedDuplicateEventIds: ["evt-final"],
+    });
+    expect(transcript.hiddenEvents.map((item) => item.id)).toEqual([
+      "evt-start",
+      "evt-final",
+      "evt-complete",
+    ]);
+    expect(transcript.rawEvents).toEqual(events);
+  });
+
+  it("coalesces assistant_delta system chunks and suppresses the final duplicate", () => {
+    const events = [
+      event("evt-user", "user", "Keep going."),
+      event("evt-delta-1", "system", "Now let", {
+        type: "assistant_delta",
+        seq: 1,
+      }),
+      event("evt-delta-2", "system", "me look.", {
+        type: "assistant_delta",
+        seq: 2,
+      }),
+      event("evt-final", "system", "Now let me look.", {
+        role: "assistant",
+        seq: 3,
+      }),
+    ];
+
+    const transcript = normalizeCodeAgentTranscript(events);
+
+    expect(transcript.items).toEqual([
+      expect.objectContaining({ type: "user" }),
+      expect.objectContaining({
+        type: "assistant",
+        source: "runner-stdout",
+        text: "Now let me look.",
+        eventIds: ["evt-delta-1", "evt-delta-2", "evt-final"],
+        suppressedDuplicateEventIds: ["evt-final"],
+      }),
+    ]);
+  });
+
+  it("keeps regular assistant system messages when they are not stdout duplicates", () => {
+    const events = [
+      event("evt-user", "user", "Summarize the changes."),
+      event("evt-final", "system", "I changed the tests only.", {
+        role: "assistant",
+      }),
+    ];
+
+    const transcript = normalizeCodeAgentTranscript(events);
+
+    expect(transcript.items).toEqual([
+      expect.objectContaining({
+        type: "user",
+        text: "Summarize the changes.",
+      }),
+      expect.objectContaining({
+        type: "assistant",
+        source: "system",
+        text: "I changed the tests only.",
+      }),
+    ]);
+    expect(transcript.hiddenEvents).toEqual([]);
+  });
+
+  it("groups tool start, activity, and done events into one compact tool item", () => {
+    const events = [
+      event("evt-tool-start", "status", "Running exec_command.", {
+        type: "tool_start",
+        tool: "exec_command",
+        input: { cmd: "pnpm test" },
+      }),
+      event("evt-tool-activity", "status", "Running tests", {
+        type: "activity",
+        tool: "exec_command",
+      }),
+      event("evt-tool-done", "status", "Finished exec_command.", {
+        type: "tool_done",
+        tool: "exec_command",
+        result: "1 passed",
+      }),
+    ];
+
+    const transcript = normalizeCodeAgentTranscript(events);
+
+    expect(transcript.items).toEqual([
+      expect.objectContaining({
+        type: "tool",
+        tool: "exec_command",
+        label: "Running exec_command.",
+        state: "completed",
+        input: { cmd: "pnpm test" },
+        result: "1 passed",
+        activities: ["Running tests"],
+        eventIds: ["evt-tool-start", "evt-tool-activity", "evt-tool-done"],
+      }),
+    ]);
+  });
+
+  it("shows important approval and error statuses while hiding lifecycle noise", () => {
+    const events = [
+      event("evt-queued", "status", "Remote Agent-Native Code run queued.", {
+        status: "queued",
+        phase: "queued",
+      }),
+      event("evt-approval", "status", "Approval required: Run pnpm test.", {
+        status: "needs-approval",
+        phase: "approval-required",
+        pendingApprovalId: "approval-1",
+      }),
+      event("evt-error", "status", "Model call failed.", {
+        type: "error",
+        errorCode: "provider_error",
+      }),
+      event("evt-mcp", "status", "Connected 2 MCP tools for this run.", {
+        type: "mcp-tools-connected",
+      }),
+    ];
+
+    const transcript = normalizeCodeAgentTranscript(events);
+
+    expect(transcript.items).toEqual([
+      expect.objectContaining({
+        type: "status",
+        level: "approval",
+        text: "Approval required: Run pnpm test.",
+      }),
+      expect.objectContaining({
+        type: "status",
+        level: "error",
+        text: "Model call failed.",
+      }),
+    ]);
+    expect(transcript.hiddenEvents.map((item) => item.id)).toEqual([
+      "evt-queued",
+      "evt-mcp",
+    ]);
+  });
+
+  it("retains note and artifact events in the normal output", () => {
+    const events = [
+      event("evt-artifact", "artifact", "Migration dossier created.", {
+        path: "/tmp/dossier",
+      }),
+      event("evt-note", "note", "Use the dossier with another coding agent.", {
+        source: "migration-dossier",
+      }),
+    ];
+
+    const transcript = normalizeCodeAgentTranscript(events);
+
+    expect(transcript.items).toEqual([
+      expect.objectContaining({
+        type: "status",
+        statusKind: "artifact",
+        text: "Migration dossier created.",
+      }),
+      expect.objectContaining({
+        type: "status",
+        statusKind: "note",
+        text: "Use the dossier with another coding agent.",
+      }),
+    ]);
+  });
+});
+
+function event(
+  id: string,
+  kind: CodeAgentTranscriptEvent["kind"],
+  message: string,
+  metadata?: Record<string, unknown>,
+): CodeAgentTranscriptEvent {
+  return {
+    schemaVersion: 1,
+    id,
+    runId: "run-1",
+    kind,
+    message,
+    createdAt: `2026-05-17T12:${id.length.toString().padStart(2, "0")}:00.000Z`,
+    metadata,
+  };
+}

--- a/packages/core/src/code-agents/transcript-normalizer.ts
+++ b/packages/core/src/code-agents/transcript-normalizer.ts
@@ -1,5 +1,7 @@
 import type { CodeAgentTranscriptEvent } from "../cli/code-agent-runs.js";
 
+export type { CodeAgentTranscriptEvent } from "../cli/code-agent-runs.js";
+
 export type NormalizedCodeAgentTranscriptItem =
   | NormalizedCodeAgentUserTurn
   | NormalizedCodeAgentAssistantTurn
@@ -75,16 +77,21 @@ export function normalizeCodeAgentTranscript(
 
     const assistantSource = assistantTextSource(event);
     if (assistantSource) {
+      const text = assistantTextForEvent(event, assistantSource);
+      if (!text) {
+        hiddenEvents.push(event);
+        continue;
+      }
       const previous = items.at(-1);
       if (
         previous?.type === "assistant" &&
         previous.source === assistantSource &&
         previous.turnIndex === currentTurnIndex
       ) {
-        appendAssistantChunk(previous, event);
+        appendAssistantChunk(previous, event, text);
       } else {
         items.push(
-          createAssistantTurn(event, assistantSource, currentTurnIndex),
+          createAssistantTurn(event, assistantSource, currentTurnIndex, text),
         );
       }
       continue;
@@ -136,12 +143,13 @@ function createAssistantTurn(
   event: CodeAgentTranscriptEvent,
   source: NormalizedCodeAgentAssistantTurn["source"],
   turnIndex: number,
+  text: string,
 ): NormalizedCodeAgentAssistantTurn {
   return {
     type: "assistant",
     role: "assistant",
     id: event.id,
-    text: event.message,
+    text,
     source,
     createdAt: event.createdAt,
     updatedAt: event.createdAt,
@@ -154,8 +162,11 @@ function createAssistantTurn(
 function appendAssistantChunk(
   item: NormalizedCodeAgentAssistantTurn,
   event: CodeAgentTranscriptEvent,
+  text: string,
 ): void {
-  item.text = joinAssistantChunks(item.text, event.message);
+  item.text = shouldAppendAssistantChunkExactly(item, event)
+    ? `${item.text}${text}`
+    : joinAssistantChunks(item.text, text);
   item.updatedAt = event.createdAt;
   item.eventIds.push(event.id);
   item.events.push(event);
@@ -190,10 +201,7 @@ function appendToolEvent(
   turnIndex: number,
 ): void {
   const tool = stringMetadata(event.metadata, "tool");
-  const item =
-    toolType === "tool_start"
-      ? null
-      : findOpenToolEvent(items, tool, turnIndex);
+  const item = findOpenToolEvent(items, tool, turnIndex);
 
   if (!item) {
     items.push(createToolEvent(event, toolType, turnIndex));
@@ -207,6 +215,19 @@ function appendToolEvent(
   if (toolType === "activity") {
     item.activities.push(event.message);
     if (item.state === "activity") item.label = event.message;
+    return;
+  }
+
+  if (toolType === "tool_start") {
+    const wasActivity = item.state === "activity";
+    item.state = "running";
+    item.startedAt = item.startedAt ?? event.createdAt;
+    if (hasMetadataKey(event.metadata, "input")) {
+      item.input = event.metadata?.input;
+    }
+    if (wasActivity || item.label === item.activities.at(-1)) {
+      item.label = event.message;
+    }
     return;
   }
 
@@ -285,9 +306,10 @@ function suppressDuplicateFinalAssistantText(
     );
     if (
       stdoutItems.length === 0 ||
-      canonicalText(
+      !isSameAssistantText(
         stdoutItems.map((candidate) => candidate.text).join(" "),
-      ) !== canonicalText(item.text)
+        item.text,
+      )
     ) {
       result.push(item);
       continue;
@@ -348,6 +370,7 @@ function isLowSignalLifecycleEvent(event: CodeAgentTranscriptEvent): boolean {
 const LOW_SIGNAL_STATUS_MESSAGES = [
   /^Agent-Native Code run started\.?$/i,
   /^Agent-Native Code run completed\.?$/i,
+  /^Agent-Native Code process exited\.?$/i,
   /^Starting local Agent-Native Code execution\.?$/i,
   /^Remote Agent-Native Code run queued\.?$/i,
   /^Connected \d+ MCP tools? for this run\.?$/i,
@@ -414,6 +437,39 @@ function assistantTextSource(
   return null;
 }
 
+function shouldAppendAssistantChunkExactly(
+  item: NormalizedCodeAgentAssistantTurn,
+  event: CodeAgentTranscriptEvent,
+): boolean {
+  return (
+    item.source === "runner-stdout" &&
+    (isAssistantDeltaEvent(event) || item.events.some(isAssistantDeltaEvent))
+  );
+}
+
+function isAssistantDeltaEvent(event: CodeAgentTranscriptEvent): boolean {
+  return stringMetadata(event.metadata, "type") === "assistant_delta";
+}
+
+function assistantTextForEvent(
+  event: CodeAgentTranscriptEvent,
+  source: NormalizedCodeAgentAssistantTurn["source"],
+): string {
+  if (source === "runner-stdout") return stripRunnerDiagnostics(event.message);
+  return event.message;
+}
+
+function stripRunnerDiagnostics(value: string): string {
+  return value
+    .replace(RUNNER_DIAGNOSTIC_LINE_PATTERNS.engineDetect, "")
+    .replace(RUNNER_DIAGNOSTIC_LINE_PATTERNS.builderEngine, "");
+}
+
+const RUNNER_DIAGNOSTIC_LINE_PATTERNS = {
+  engineDetect: /^\[engine-detect\][^\r\n]*(?:\r?\n|$)/gm,
+  builderEngine: /^\[builder-engine\]\s*[←→][^\r\n]*(?:\r?\n|$)/gm,
+};
+
 function toolEventType(
   event: CodeAgentTranscriptEvent,
 ): "activity" | "tool_done" | "tool_start" | null {
@@ -436,6 +492,15 @@ function joinAssistantChunks(previous: string, next: string): string {
 
 function canonicalText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
+}
+
+function isSameAssistantText(left: string, right: string): boolean {
+  if (canonicalText(left) === canonicalText(right)) return true;
+  return compactText(left) === compactText(right);
+}
+
+function compactText(value: string): string {
+  return canonicalText(value).replace(/\s+/g, "");
 }
 
 function stringMetadata(

--- a/packages/core/src/code-agents/transcript-normalizer.ts
+++ b/packages/core/src/code-agents/transcript-normalizer.ts
@@ -1,0 +1,456 @@
+import type { CodeAgentTranscriptEvent } from "../cli/code-agent-runs.js";
+
+export type NormalizedCodeAgentTranscriptItem =
+  | NormalizedCodeAgentUserTurn
+  | NormalizedCodeAgentAssistantTurn
+  | NormalizedCodeAgentToolEvent
+  | NormalizedCodeAgentStatusEvent;
+
+export interface NormalizedCodeAgentTranscript {
+  items: NormalizedCodeAgentTranscriptItem[];
+  rawEvents: CodeAgentTranscriptEvent[];
+  hiddenEvents: CodeAgentTranscriptEvent[];
+}
+
+export interface NormalizedCodeAgentTranscriptBase {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  eventIds: string[];
+  events: CodeAgentTranscriptEvent[];
+  turnIndex: number;
+}
+
+export interface NormalizedCodeAgentUserTurn extends NormalizedCodeAgentTranscriptBase {
+  type: "user";
+  role: "user";
+  text: string;
+}
+
+export interface NormalizedCodeAgentAssistantTurn extends NormalizedCodeAgentTranscriptBase {
+  type: "assistant";
+  role: "assistant";
+  text: string;
+  source: "system" | "runner-stdout";
+  suppressedDuplicateEventIds?: string[];
+}
+
+export interface NormalizedCodeAgentToolEvent extends NormalizedCodeAgentTranscriptBase {
+  type: "tool";
+  tool?: string;
+  label: string;
+  state: "activity" | "running" | "completed";
+  input?: unknown;
+  result?: unknown;
+  activities: string[];
+  startedAt?: string;
+  completedAt?: string;
+}
+
+export interface NormalizedCodeAgentStatusEvent extends NormalizedCodeAgentTranscriptBase {
+  type: "status";
+  level: "info" | "warning" | "error" | "approval";
+  text: string;
+  statusKind: CodeAgentTranscriptEvent["kind"];
+  status?: string;
+  phase?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export function normalizeCodeAgentTranscript(
+  events: readonly CodeAgentTranscriptEvent[],
+): NormalizedCodeAgentTranscript {
+  const items: NormalizedCodeAgentTranscriptItem[] = [];
+  const hiddenEvents: CodeAgentTranscriptEvent[] = [];
+  const eventOrder = new Map(events.map((event, index) => [event.id, index]));
+  let turnIndex = -1;
+
+  for (const event of events) {
+    const currentTurnIndex = Math.max(turnIndex, 0);
+    if (event.kind === "user") {
+      turnIndex = turnIndex < 0 ? (items.length === 0 ? 0 : 1) : turnIndex + 1;
+      items.push(createUserTurn(event, turnIndex));
+      continue;
+    }
+
+    const assistantSource = assistantTextSource(event);
+    if (assistantSource) {
+      const previous = items.at(-1);
+      if (
+        previous?.type === "assistant" &&
+        previous.source === assistantSource &&
+        previous.turnIndex === currentTurnIndex
+      ) {
+        appendAssistantChunk(previous, event);
+      } else {
+        items.push(
+          createAssistantTurn(event, assistantSource, currentTurnIndex),
+        );
+      }
+      continue;
+    }
+
+    const toolType = toolEventType(event);
+    if (toolType) {
+      appendToolEvent(items, event, toolType, currentTurnIndex);
+      continue;
+    }
+
+    if (shouldShowStatusEvent(event)) {
+      items.push(createStatusEvent(event, currentTurnIndex));
+    } else {
+      hiddenEvents.push(event);
+    }
+  }
+
+  const dedupedItems = suppressDuplicateFinalAssistantText(items, hiddenEvents);
+  hiddenEvents.sort(
+    (a, b) => (eventOrder.get(a.id) ?? 0) - (eventOrder.get(b.id) ?? 0),
+  );
+
+  return {
+    items: dedupedItems,
+    rawEvents: [...events],
+    hiddenEvents,
+  };
+}
+
+function createUserTurn(
+  event: CodeAgentTranscriptEvent,
+  turnIndex: number,
+): NormalizedCodeAgentUserTurn {
+  return {
+    type: "user",
+    role: "user",
+    id: event.id,
+    text: event.message,
+    createdAt: event.createdAt,
+    updatedAt: event.createdAt,
+    eventIds: [event.id],
+    events: [event],
+    turnIndex,
+  };
+}
+
+function createAssistantTurn(
+  event: CodeAgentTranscriptEvent,
+  source: NormalizedCodeAgentAssistantTurn["source"],
+  turnIndex: number,
+): NormalizedCodeAgentAssistantTurn {
+  return {
+    type: "assistant",
+    role: "assistant",
+    id: event.id,
+    text: event.message,
+    source,
+    createdAt: event.createdAt,
+    updatedAt: event.createdAt,
+    eventIds: [event.id],
+    events: [event],
+    turnIndex,
+  };
+}
+
+function appendAssistantChunk(
+  item: NormalizedCodeAgentAssistantTurn,
+  event: CodeAgentTranscriptEvent,
+): void {
+  item.text = joinAssistantChunks(item.text, event.message);
+  item.updatedAt = event.createdAt;
+  item.eventIds.push(event.id);
+  item.events.push(event);
+}
+
+function createStatusEvent(
+  event: CodeAgentTranscriptEvent,
+  turnIndex: number,
+): NormalizedCodeAgentStatusEvent {
+  const metadata = event.metadata;
+  return {
+    type: "status",
+    id: event.id,
+    text: event.message,
+    level: statusEventLevel(event),
+    statusKind: event.kind,
+    status: stringMetadata(metadata, "status"),
+    phase: stringMetadata(metadata, "phase"),
+    metadata,
+    createdAt: event.createdAt,
+    updatedAt: event.createdAt,
+    eventIds: [event.id],
+    events: [event],
+    turnIndex,
+  };
+}
+
+function appendToolEvent(
+  items: NormalizedCodeAgentTranscriptItem[],
+  event: CodeAgentTranscriptEvent,
+  toolType: "activity" | "tool_done" | "tool_start",
+  turnIndex: number,
+): void {
+  const tool = stringMetadata(event.metadata, "tool");
+  const item =
+    toolType === "tool_start"
+      ? null
+      : findOpenToolEvent(items, tool, turnIndex);
+
+  if (!item) {
+    items.push(createToolEvent(event, toolType, turnIndex));
+    return;
+  }
+
+  item.updatedAt = event.createdAt;
+  item.eventIds.push(event.id);
+  item.events.push(event);
+
+  if (toolType === "activity") {
+    item.activities.push(event.message);
+    if (item.state === "activity") item.label = event.message;
+    return;
+  }
+
+  item.state = "completed";
+  item.completedAt = event.createdAt;
+  if (hasMetadataKey(event.metadata, "result")) {
+    item.result = event.metadata?.result;
+  }
+}
+
+function createToolEvent(
+  event: CodeAgentTranscriptEvent,
+  toolType: "activity" | "tool_done" | "tool_start",
+  turnIndex: number,
+): NormalizedCodeAgentToolEvent {
+  const metadata = event.metadata;
+  const state =
+    toolType === "tool_done"
+      ? "completed"
+      : toolType === "tool_start"
+        ? "running"
+        : "activity";
+  return {
+    type: "tool",
+    id: event.id,
+    tool: stringMetadata(metadata, "tool"),
+    label: event.message,
+    state,
+    input: hasMetadataKey(metadata, "input") ? metadata?.input : undefined,
+    result: hasMetadataKey(metadata, "result") ? metadata?.result : undefined,
+    activities: toolType === "activity" ? [event.message] : [],
+    startedAt: toolType === "tool_start" ? event.createdAt : undefined,
+    completedAt: toolType === "tool_done" ? event.createdAt : undefined,
+    createdAt: event.createdAt,
+    updatedAt: event.createdAt,
+    eventIds: [event.id],
+    events: [event],
+    turnIndex,
+  };
+}
+
+function findOpenToolEvent(
+  items: readonly NormalizedCodeAgentTranscriptItem[],
+  tool: string | undefined,
+  turnIndex: number,
+): NormalizedCodeAgentToolEvent | null {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    if (item.type !== "tool") continue;
+    if (item.turnIndex !== turnIndex) continue;
+    if (item.state === "completed") continue;
+    if (tool && item.tool !== tool) continue;
+    if (!tool && item.tool) continue;
+    return item;
+  }
+  return null;
+}
+
+function suppressDuplicateFinalAssistantText(
+  items: readonly NormalizedCodeAgentTranscriptItem[],
+  hiddenEvents: CodeAgentTranscriptEvent[],
+): NormalizedCodeAgentTranscriptItem[] {
+  const result: NormalizedCodeAgentTranscriptItem[] = [];
+
+  for (const item of items) {
+    if (item.type !== "assistant" || item.source !== "system") {
+      result.push(item);
+      continue;
+    }
+
+    const stdoutItems = result.filter(
+      (candidate): candidate is NormalizedCodeAgentAssistantTurn =>
+        candidate.type === "assistant" &&
+        candidate.source === "runner-stdout" &&
+        candidate.turnIndex === item.turnIndex,
+    );
+    if (
+      stdoutItems.length === 0 ||
+      canonicalText(
+        stdoutItems.map((candidate) => candidate.text).join(" "),
+      ) !== canonicalText(item.text)
+    ) {
+      result.push(item);
+      continue;
+    }
+
+    hiddenEvents.push(...item.events);
+    const target =
+      stdoutItems.length === 1 ? stdoutItems[0] : stdoutItems.at(-1);
+    if (!target) continue;
+    if (stdoutItems.length === 1) {
+      target.text = item.text;
+      target.updatedAt = item.updatedAt;
+    }
+    target.eventIds.push(...item.eventIds);
+    target.events.push(...item.events);
+    target.suppressedDuplicateEventIds = [
+      ...(target.suppressedDuplicateEventIds ?? []),
+      ...item.eventIds,
+    ];
+  }
+
+  return result;
+}
+
+function shouldShowStatusEvent(event: CodeAgentTranscriptEvent): boolean {
+  if (event.kind === "artifact" || event.kind === "note") return true;
+  if (event.kind !== "status") return false;
+  if (isLowSignalLifecycleEvent(event)) return false;
+  return true;
+}
+
+function isLowSignalLifecycleEvent(event: CodeAgentTranscriptEvent): boolean {
+  const metadata = event.metadata;
+  const type = stringMetadata(metadata, "type");
+  if (type === "mcp-tools-connected") return true;
+  if (statusEventLevel(event) !== "info") return false;
+
+  const status = stringMetadata(metadata, "status");
+  const phase = stringMetadata(metadata, "phase");
+  if (status === "queued" || status === "running" || status === "completed") {
+    return true;
+  }
+  if (
+    phase === "queued" ||
+    phase === "starting" ||
+    phase === "executing" ||
+    phase === "follow-up" ||
+    phase === "complete"
+  ) {
+    return true;
+  }
+
+  return LOW_SIGNAL_STATUS_MESSAGES.some((pattern) =>
+    pattern.test(event.message),
+  );
+}
+
+const LOW_SIGNAL_STATUS_MESSAGES = [
+  /^Agent-Native Code run started\.?$/i,
+  /^Agent-Native Code run completed\.?$/i,
+  /^Starting local Agent-Native Code execution\.?$/i,
+  /^Remote Agent-Native Code run queued\.?$/i,
+  /^Connected \d+ MCP tools? for this run\.?$/i,
+];
+
+function statusEventLevel(
+  event: CodeAgentTranscriptEvent,
+): NormalizedCodeAgentStatusEvent["level"] {
+  const metadata = event.metadata;
+  const status = stringMetadata(metadata, "status");
+  const phase = stringMetadata(metadata, "phase");
+  const source = stringMetadata(metadata, "source");
+  const type = stringMetadata(metadata, "type");
+
+  if (
+    status === "needs-approval" ||
+    Boolean(metadata?.pendingApproval) ||
+    Boolean(metadata?.pendingApprovalId) ||
+    Boolean(metadata?.approvalId) ||
+    phase?.includes("approval") ||
+    /\bapproval\b/i.test(event.message)
+  ) {
+    return "approval";
+  }
+
+  if (
+    event.kind === "status" &&
+    (status === "errored" ||
+      type === "error" ||
+      type?.endsWith("-error") ||
+      Boolean(metadata?.failed) ||
+      typeof metadata?.errorCode === "string" ||
+      source === "runner-stderr")
+  ) {
+    return "error";
+  }
+
+  if (
+    status === "paused" ||
+    phase === "missing-credentials" ||
+    phase === "stopped" ||
+    /\b(missing|stopped|unavailable|denied)\b/i.test(event.message)
+  ) {
+    return "warning";
+  }
+
+  return "info";
+}
+
+function assistantTextSource(
+  event: CodeAgentTranscriptEvent,
+): NormalizedCodeAgentAssistantTurn["source"] | null {
+  const source = stringMetadata(event.metadata, "source");
+  const type = stringMetadata(event.metadata, "type");
+  if (type === "assistant_delta") {
+    return "runner-stdout";
+  }
+  if (event.kind === "status" && source === "runner-stdout") {
+    return "runner-stdout";
+  }
+  if (event.kind === "system" || event.metadata?.role === "assistant") {
+    return "system";
+  }
+  return null;
+}
+
+function toolEventType(
+  event: CodeAgentTranscriptEvent,
+): "activity" | "tool_done" | "tool_start" | null {
+  if (event.kind !== "status") return null;
+  const type = stringMetadata(event.metadata, "type");
+  if (type === "activity" || type === "tool_done" || type === "tool_start") {
+    return type;
+  }
+  return null;
+}
+
+function joinAssistantChunks(previous: string, next: string): string {
+  if (!previous) return next;
+  if (!next) return previous;
+  if (/\s$/.test(previous) || /^\s/.test(next)) return `${previous}${next}`;
+  if (/^[.,!?;:)\]}'"`]/.test(next)) return `${previous}${next}`;
+  if (/[(\[{'"`]$/.test(previous)) return `${previous}${next}`;
+  return `${previous} ${next}`;
+}
+
+function canonicalText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function stringMetadata(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = metadata?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function hasMetadataKey(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+): boolean {
+  return (
+    Boolean(metadata) && Object.prototype.hasOwnProperty.call(metadata, key)
+  );
+}

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -418,6 +418,12 @@ export async function verifyAuth(
         new TextEncoder().encode(process.env.A2A_SECRET!),
       );
 
+      const tokenScope =
+        typeof payload.scope === "string" ? payload.scope : undefined;
+      if (tokenScope && tokenScope !== MCP_CONNECT_SCOPE) {
+        return { authed: false };
+      }
+
       // Connect-minted tokens (scope === "mcp-connect") carry a random `jti`
       // and are individually revocable. Only these tokens hit the revoke
       // store — ordinary A2A delegation JWTs skip the DB lookup entirely so
@@ -426,11 +432,10 @@ export async function verifyAuth(
       // connected agent out. The signature was already cryptographically
       // verified above, so failing open here only widens the explicit-revoke
       // gate, never the trust boundary.
-      if (
-        payload.scope === MCP_CONNECT_SCOPE &&
-        typeof payload.jti === "string" &&
-        payload.jti
-      ) {
+      if (tokenScope === MCP_CONNECT_SCOPE) {
+        if (typeof payload.jti !== "string" || !payload.jti) {
+          return { authed: false };
+        }
         const jti = payload.jti;
         try {
           const { isJtiRevoked, touchTokenUsed } =

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -22,6 +22,7 @@ import type { ActionEntry } from "../agent/production-agent.js";
 import { runWithRequestContext } from "../server/request-context.js";
 import { toAbsoluteOpenUrl, toDesktopOpenUrl } from "../server/deep-link.js";
 import { getBuiltinCrossAppTools } from "./builtin-tools.js";
+import { MCP_CONNECT_SCOPE } from "./connect-store.js";
 
 export interface MCPConfig {
   /** App name shown in MCP server info */
@@ -416,6 +417,34 @@ export async function verifyAuth(
         token,
         new TextEncoder().encode(process.env.A2A_SECRET!),
       );
+
+      // Connect-minted tokens (scope === "mcp-connect") carry a random `jti`
+      // and are individually revocable. Only these tokens hit the revoke
+      // store — ordinary A2A delegation JWTs skip the DB lookup entirely so
+      // the hot path is unchanged. The revoke check FAILS OPEN on any
+      // store/DB error: a transient Neon WS drop must never lock every
+      // connected agent out. The signature was already cryptographically
+      // verified above, so failing open here only widens the explicit-revoke
+      // gate, never the trust boundary.
+      if (
+        payload.scope === MCP_CONNECT_SCOPE &&
+        typeof payload.jti === "string" &&
+        payload.jti
+      ) {
+        const jti = payload.jti;
+        try {
+          const { isJtiRevoked, touchTokenUsed } =
+            await import("./connect-store.js");
+          if (await isJtiRevoked(jti)) {
+            return { authed: false };
+          }
+          // Best-effort usage telemetry — never blocks / throws.
+          void touchTokenUsed(jti);
+        } catch {
+          // Store import / lookup failed — fail open (see comment above).
+        }
+      }
+
       return {
         authed: true,
         identity: {

--- a/packages/core/src/mcp/build-server.verify-auth.spec.ts
+++ b/packages/core/src/mcp/build-server.verify-auth.spec.ts
@@ -46,6 +46,30 @@ describe("verifyAuth — connect-token revoke check", () => {
     expect(touchTokenUsedMock).not.toHaveBeenCalled();
   });
 
+  it("rejects identity-scoped SSO JWTs on the MCP endpoint", async () => {
+    const token = await sign({
+      sub: "a@example.com",
+      scope: "identity",
+      jti: "identity-jti",
+    });
+    const res = await verifyAuth(`Bearer ${token}`);
+    expect(res.authed).toBe(false);
+    expect(res.identity).toBeUndefined();
+    expect(isJtiRevokedMock).not.toHaveBeenCalled();
+    expect(touchTokenUsedMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown scoped JWTs on the MCP endpoint", async () => {
+    const token = await sign({
+      sub: "a@example.com",
+      scope: "some-other-scope",
+    });
+    const res = await verifyAuth(`Bearer ${token}`);
+    expect(res.authed).toBe(false);
+    expect(res.identity).toBeUndefined();
+    expect(isJtiRevokedMock).not.toHaveBeenCalled();
+  });
+
   it("accepts a connect-scoped token whose jti is not revoked", async () => {
     isJtiRevokedMock.mockResolvedValue(false);
     const token = await sign({
@@ -62,6 +86,17 @@ describe("verifyAuth — connect-token revoke check", () => {
     });
     expect(isJtiRevokedMock).toHaveBeenCalledWith("jti-active");
     expect(touchTokenUsedMock).toHaveBeenCalledWith("jti-active");
+  });
+
+  it("rejects a connect-scoped token without a jti", async () => {
+    const token = await sign({
+      sub: "a@example.com",
+      scope: "mcp-connect",
+    });
+    const res = await verifyAuth(`Bearer ${token}`);
+    expect(res.authed).toBe(false);
+    expect(res.identity).toBeUndefined();
+    expect(isJtiRevokedMock).not.toHaveBeenCalled();
   });
 
   it("rejects a connect-scoped token whose jti has been revoked", async () => {

--- a/packages/core/src/mcp/build-server.verify-auth.spec.ts
+++ b/packages/core/src/mcp/build-server.verify-auth.spec.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as jose from "jose";
+
+// Stub the heavy MCP SDK + builtin-tools so importing build-server.ts is cheap
+// — these specs only exercise verifyAuth's revoke-check addition.
+vi.mock("./builtin-tools.js", () => ({ getBuiltinCrossAppTools: () => ({}) }));
+
+const isJtiRevokedMock = vi.fn();
+const touchTokenUsedMock = vi.fn(async () => {});
+vi.mock("./connect-store.js", () => ({
+  MCP_CONNECT_SCOPE: "mcp-connect",
+  isJtiRevoked: (...a: any[]) => isJtiRevokedMock(...a),
+  touchTokenUsed: (...a: any[]) => touchTokenUsedMock(...a),
+}));
+
+const { verifyAuth } = await import("./build-server.js");
+
+const SECRET = "verify-auth-secret";
+const enc = new TextEncoder().encode(SECRET);
+
+async function sign(claims: Record<string, unknown>): Promise<string> {
+  return new jose.SignJWT(claims)
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(enc);
+}
+
+describe("verifyAuth — connect-token revoke check", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.A2A_SECRET = SECRET;
+    delete process.env.ACCESS_TOKEN;
+    delete process.env.ACCESS_TOKENS;
+  });
+  afterEach(() => {
+    delete process.env.A2A_SECRET;
+  });
+
+  it("does NOT query the revoke store for an ordinary A2A JWT (hot path untouched)", async () => {
+    const token = await sign({ sub: "a@example.com" });
+    const res = await verifyAuth(`Bearer ${token}`);
+    expect(res.authed).toBe(true);
+    expect(res.identity?.userEmail).toBe("a@example.com");
+    expect(isJtiRevokedMock).not.toHaveBeenCalled();
+    expect(touchTokenUsedMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts a connect-scoped token whose jti is not revoked", async () => {
+    isJtiRevokedMock.mockResolvedValue(false);
+    const token = await sign({
+      sub: "a@example.com",
+      scope: "mcp-connect",
+      jti: "jti-active",
+      org_domain: "builder.io",
+    });
+    const res = await verifyAuth(`Bearer ${token}`);
+    expect(res.authed).toBe(true);
+    expect(res.identity).toEqual({
+      userEmail: "a@example.com",
+      orgDomain: "builder.io",
+    });
+    expect(isJtiRevokedMock).toHaveBeenCalledWith("jti-active");
+    expect(touchTokenUsedMock).toHaveBeenCalledWith("jti-active");
+  });
+
+  it("rejects a connect-scoped token whose jti has been revoked", async () => {
+    isJtiRevokedMock.mockResolvedValue(true);
+    const token = await sign({
+      sub: "a@example.com",
+      scope: "mcp-connect",
+      jti: "jti-revoked",
+    });
+    const res = await verifyAuth(`Bearer ${token}`);
+    expect(res.authed).toBe(false);
+    expect(res.identity).toBeUndefined();
+  });
+
+  it("fails OPEN: a store error never locks out a valid-signature token", async () => {
+    isJtiRevokedMock.mockRejectedValue(new Error("db down"));
+    const token = await sign({
+      sub: "a@example.com",
+      scope: "mcp-connect",
+      jti: "jti-x",
+    });
+    const res = await verifyAuth(`Bearer ${token}`);
+    // Signature already verified; a transient DB blip must not 401 everyone.
+    expect(res.authed).toBe(true);
+    expect(res.identity?.userEmail).toBe("a@example.com");
+  });
+
+  it("still rejects a bad signature regardless of scope claim", async () => {
+    const forged = await new jose.SignJWT({
+      sub: "a@example.com",
+      scope: "mcp-connect",
+      jti: "jti-x",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime("1h")
+      .sign(new TextEncoder().encode("WRONG-SECRET"));
+    const res = await verifyAuth(`Bearer ${forged}`);
+    expect(res.authed).toBe(false);
+    expect(isJtiRevokedMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/mcp/connect-route.spec.ts
+++ b/packages/core/src/mcp/connect-route.spec.ts
@@ -97,6 +97,25 @@ vi.mock("./connect-store.js", () => ({
     r.tokenJti = jti;
     return { ...r, status: "approved" };
   }),
+  claimDeviceCodeForMint: vi.fn(async (dc: string, jti: string) => {
+    const r = deviceRows.find((d) => d.deviceCode === dc);
+    if (!r || r.status !== "approved") return null;
+    r.status = "minting";
+    r.tokenJti = jti;
+    return { ...r, status: "approved" };
+  }),
+  finishDeviceCodeMint: vi.fn(async (dc: string, jti: string) => {
+    const r = deviceRows.find((d) => d.deviceCode === dc);
+    if (!r || r.status !== "minting" || r.tokenJti !== jti) return false;
+    r.status = "consumed";
+    return true;
+  }),
+  releaseDeviceCodeMint: vi.fn(async (dc: string, jti: string) => {
+    const r = deviceRows.find((d) => d.deviceCode === dc);
+    if (!r || r.status !== "minting" || r.tokenJti !== jti) return;
+    r.status = "approved";
+    r.tokenJti = null;
+  }),
   expireDeviceCode: vi.fn(async () => {}),
 }));
 
@@ -308,6 +327,33 @@ describe("handleMcpConnect", () => {
       );
       expect(data.interval).toBe(3);
       expect(data.expires_in).toBe(600);
+    });
+
+    it("device/start and returned MCP config include APP_BASE_PATH", async () => {
+      process.env.APP_BASE_PATH = "/mail";
+      try {
+        await handleMcpConnect(ev({ method: "POST" }), "/device/start");
+        const dc = deviceRows[0].deviceCode;
+        getSessionMock.mockResolvedValue({ email: "u@example.com" });
+        await handleMcpConnect(
+          ev({ method: "POST", body: { user_code: "ABCD-2345" } }),
+          "/device/authorize",
+        );
+        getSessionMock.mockResolvedValue(null);
+        const res = await handleMcpConnect(
+          ev({ method: "POST", body: { device_code: dc } }),
+          "/device/poll",
+        );
+        const data = await res.json();
+        expect(data.mcpUrl).toBe(
+          "https://mail.agent-native.com/mail/_agent-native/mcp",
+        );
+        expect(data.cli).toBe(
+          "agent-native connect https://mail.agent-native.com/mail",
+        );
+      } finally {
+        delete process.env.APP_BASE_PATH;
+      }
     });
 
     it("device/authorize requires a session and binds the user", async () => {

--- a/packages/core/src/mcp/connect-route.spec.ts
+++ b/packages/core/src/mcp/connect-route.spec.ts
@@ -1,0 +1,404 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as jose from "jose";
+
+// --- h3 + helper mocks (mirror sibling specs) ---
+vi.mock("h3", () => ({
+  getMethod: (event: any) => event.method ?? "GET",
+  getHeader: (event: any, name: string) =>
+    event.headers?.[name.toLowerCase()] ?? event.headers?.[name],
+}));
+
+vi.mock("../server/h3-helpers.js", () => ({
+  readBody: vi.fn(async (event: any) => event.body ?? {}),
+}));
+
+const getSessionMock = vi.fn();
+const getConfiguredLoginHtmlMock = vi.fn(() => null);
+vi.mock("../server/auth.js", () => ({
+  getSession: (...a: any[]) => getSessionMock(...a),
+  getConfiguredLoginHtml: (...a: any[]) => getConfiguredLoginHtmlMock(...a),
+}));
+
+vi.mock("../org/context.js", () => ({
+  getOrgDomain: vi.fn(async () => "builder.io"),
+}));
+
+// In-memory store mock — exercises mint/revoke + device lifecycle via the
+// route, while letting us reach into raw state for assertions.
+const tokenRows: any[] = [];
+const deviceRows: any[] = [];
+vi.mock("./connect-store.js", () => ({
+  MCP_CONNECT_SCOPE: "mcp-connect",
+  DEFAULT_TOKEN_TTL_DAYS: 90,
+  MIN_TOKEN_TTL_DAYS: 1,
+  MAX_TOKEN_TTL_DAYS: 365,
+  DEVICE_CODE_TTL_MS: 600_000,
+  recordMintedToken: vi.fn(async (p: any) => {
+    const id = "id-" + tokenRows.length;
+    tokenRows.push({ id, ...p, revokedAt: null });
+    return id;
+  }),
+  listTokens: vi.fn(async (email: string) =>
+    tokenRows
+      .filter((t) => t.ownerEmail === email)
+      .map((t) => ({
+        id: t.id,
+        jti: t.jti,
+        ownerEmail: t.ownerEmail,
+        orgId: t.orgId ?? null,
+        label: t.label ?? null,
+        createdAt: 1000,
+        lastUsedAt: null,
+        revokedAt: t.revokedAt,
+      })),
+  ),
+  revokeToken: vi.fn(async (email: string, id: string) => {
+    const t = tokenRows.find(
+      (r) => r.id === id && r.ownerEmail === email && r.revokedAt == null,
+    );
+    if (!t) return false;
+    t.revokedAt = Date.now();
+    return true;
+  }),
+  createDeviceCode: vi.fn(async () => {
+    const row = {
+      deviceCode: "dev-" + deviceRows.length,
+      userCode: "ABCD-2345",
+      ownerEmail: null,
+      orgId: null,
+      status: "pending",
+      tokenJti: null,
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 600_000,
+      consumedAt: null,
+    };
+    deviceRows.push(row);
+    return { ...row };
+  }),
+  getDeviceCode: vi.fn(async (dc: string) => {
+    const r = deviceRows.find((d) => d.deviceCode === dc);
+    return r ? { ...r } : null;
+  }),
+  approveDeviceCode: vi.fn(
+    async (uc: string, email: string, orgId: string | null) => {
+      const r = deviceRows.find((d) => d.userCode === uc);
+      if (!r) return "not_found";
+      if (r.status !== "pending") return "already";
+      r.status = "approved";
+      r.ownerEmail = email;
+      r.orgId = orgId;
+      return { ...r };
+    },
+  ),
+  consumeDeviceCode: vi.fn(async (dc: string, jti: string) => {
+    const r = deviceRows.find((d) => d.deviceCode === dc);
+    if (!r || r.status !== "approved") return null;
+    r.status = "consumed";
+    r.tokenJti = jti;
+    return { ...r, status: "approved" };
+  }),
+  expireDeviceCode: vi.fn(async () => {}),
+}));
+
+const { handleMcpConnect } = await import("./connect-route.js");
+
+function ev(opts: {
+  method?: string;
+  path?: string;
+  body?: any;
+  host?: string;
+}): any {
+  return {
+    method: opts.method ?? "GET",
+    body: opts.body,
+    headers: { host: opts.host ?? "mail.agent-native.com" },
+    node: { req: { url: opts.path ?? "/" } },
+    path: opts.path ?? "/",
+    url: { pathname: (opts.path ?? "/").split("?")[0] },
+  };
+}
+
+const SECRET = "test-a2a-secret";
+
+describe("handleMcpConnect", () => {
+  beforeEach(() => {
+    tokenRows.length = 0;
+    deviceRows.length = 0;
+    getSessionMock.mockReset();
+    getConfiguredLoginHtmlMock.mockReturnValue(null);
+    process.env.A2A_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.A2A_SECRET;
+  });
+
+  describe("connect page", () => {
+    it("serves the configured login HTML when unauthenticated", async () => {
+      getSessionMock.mockResolvedValue(null);
+      getConfiguredLoginHtmlMock.mockReturnValue("<html>login</html>");
+      const res = await handleMcpConnect(ev({}), "/");
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("<html>login</html>");
+    });
+
+    it("renders the connect page for a logged-in user", async () => {
+      getSessionMock.mockResolvedValue({ email: "u@example.com" });
+      const res = await handleMcpConnect(ev({}), "/");
+      const body = await res.text();
+      expect(res.status).toBe(200);
+      expect(body).toContain("Connect an external agent");
+      expect(body).toContain("u@example.com");
+      // The page never embeds a token.
+      expect(body).not.toContain("Bearer ey");
+    });
+
+    it("shows the device user_code when present and well-formed", async () => {
+      getSessionMock.mockResolvedValue({ email: "u@example.com" });
+      const res = await handleMcpConnect(
+        ev({ path: "/?user_code=ABCD-2345" }),
+        "/",
+      );
+      expect(await res.text()).toContain("ABCD-2345");
+    });
+  });
+
+  describe("POST /token", () => {
+    it("requires a session", async () => {
+      getSessionMock.mockResolvedValue(null);
+      const res = await handleMcpConnect(ev({ method: "POST" }), "/token");
+      expect(res.status).toBe(401);
+    });
+
+    it("mints a connect-scoped JWT with jti and records it", async () => {
+      getSessionMock.mockResolvedValue({
+        email: "u@example.com",
+        orgId: "org-1",
+      });
+      const res = await handleMcpConnect(
+        ev({ method: "POST", body: { label: "laptop", ttlDays: 30 } }),
+        "/token",
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.mcpUrl).toBe(
+        "https://mail.agent-native.com/_agent-native/mcp",
+      );
+      expect(data.serverName).toBe("agent-native-mail");
+      expect(data.mcpServerEntry).toEqual({
+        type: "http",
+        url: "https://mail.agent-native.com/_agent-native/mcp",
+        headers: { Authorization: `Bearer ${data.token}` },
+      });
+      expect(data.cli).toBe(
+        "agent-native connect https://mail.agent-native.com",
+      );
+
+      const { payload } = await jose.jwtVerify(
+        data.token,
+        new TextEncoder().encode(SECRET),
+      );
+      expect(payload.sub).toBe("u@example.com");
+      expect(payload.scope).toBe("mcp-connect");
+      expect(typeof payload.jti).toBe("string");
+      expect(payload.org_domain).toBe("builder.io");
+
+      expect(tokenRows).toHaveLength(1);
+      expect(tokenRows[0]).toMatchObject({
+        ownerEmail: "u@example.com",
+        orgId: "org-1",
+        label: "laptop",
+        jti: payload.jti,
+      });
+    });
+
+    it("clamps ttlDays into the 1-365 range", async () => {
+      getSessionMock.mockResolvedValue({ email: "u@example.com" });
+      const res = await handleMcpConnect(
+        ev({ method: "POST", body: { ttlDays: 9999 } }),
+        "/token",
+      );
+      const { token } = await res.json();
+      const { payload } = await jose.jwtVerify(
+        token,
+        new TextEncoder().encode(SECRET),
+      );
+      const lifetimeDays =
+        ((payload.exp as number) - (payload.iat as number)) / 86400;
+      expect(Math.round(lifetimeDays)).toBe(365);
+    });
+
+    it("returns 503 when no A2A_SECRET is configured", async () => {
+      delete process.env.A2A_SECRET;
+      getSessionMock.mockResolvedValue({ email: "u@example.com" });
+      const res = await handleMcpConnect(ev({ method: "POST" }), "/token");
+      expect(res.status).toBe(503);
+    });
+  });
+
+  describe("token list + revoke", () => {
+    it("lists only the caller's tokens and never the token value", async () => {
+      getSessionMock.mockResolvedValue({ email: "u@example.com" });
+      tokenRows.push(
+        { id: "id-0", jti: "j0", ownerEmail: "u@example.com", revokedAt: null },
+        { id: "id-1", jti: "j1", ownerEmail: "other@x.com", revokedAt: null },
+      );
+      const res = await handleMcpConnect(ev({}), "/tokens");
+      const data = await res.json();
+      expect(data.tokens).toHaveLength(1);
+      expect(data.tokens[0]).not.toHaveProperty("jti");
+      expect(data.tokens[0]).not.toHaveProperty("token");
+      expect(data.tokens[0].id).toBe("id-0");
+    });
+
+    it("revoke only succeeds for a token the caller owns", async () => {
+      getSessionMock.mockResolvedValue({ email: "u@example.com" });
+      tokenRows.push({
+        id: "id-0",
+        jti: "j0",
+        ownerEmail: "someoneelse@x.com",
+        revokedAt: null,
+      });
+      const denied = await handleMcpConnect(
+        ev({ method: "POST", body: { id: "id-0" } }),
+        "/tokens/revoke",
+      );
+      expect((await denied.json()).ok).toBe(false);
+      expect(tokenRows[0].revokedAt).toBeNull();
+
+      tokenRows.push({
+        id: "id-1",
+        jti: "j1",
+        ownerEmail: "u@example.com",
+        revokedAt: null,
+      });
+      const ok = await handleMcpConnect(
+        ev({ method: "POST", body: { id: "id-1" } }),
+        "/tokens/revoke",
+      );
+      expect((await ok.json()).ok).toBe(true);
+      expect(tokenRows[1].revokedAt).not.toBeNull();
+    });
+
+    it("revoke requires a session", async () => {
+      getSessionMock.mockResolvedValue(null);
+      const res = await handleMcpConnect(
+        ev({ method: "POST", body: { id: "x" } }),
+        "/tokens/revoke",
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("device-code flow", () => {
+    it("device/start is unauth and returns the verification URIs", async () => {
+      getSessionMock.mockResolvedValue(null);
+      const res = await handleMcpConnect(
+        ev({ method: "POST" }),
+        "/device/start",
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.device_code).toBeTruthy();
+      expect(data.user_code).toMatch(/^[A-Z2-7]{4}-[A-Z2-7]{4}$/);
+      expect(data.verification_uri).toBe(
+        "https://mail.agent-native.com/_agent-native/mcp/connect",
+      );
+      expect(data.verification_uri_complete).toContain(
+        "?user_code=" + data.user_code,
+      );
+      expect(data.interval).toBe(3);
+      expect(data.expires_in).toBe(600);
+    });
+
+    it("device/authorize requires a session and binds the user", async () => {
+      // start
+      await handleMcpConnect(ev({ method: "POST" }), "/device/start");
+
+      // unauth authorize → 401
+      getSessionMock.mockResolvedValue(null);
+      const unauth = await handleMcpConnect(
+        ev({ method: "POST", body: { user_code: "ABCD-2345" } }),
+        "/device/authorize",
+      );
+      expect(unauth.status).toBe(401);
+
+      // authed authorize → 200 + bound
+      getSessionMock.mockResolvedValue({
+        email: "u@example.com",
+        orgId: "org-7",
+      });
+      const ok = await handleMcpConnect(
+        ev({ method: "POST", body: { user_code: "ABCD-2345" } }),
+        "/device/authorize",
+      );
+      expect(ok.status).toBe(200);
+      expect(deviceRows[0].ownerEmail).toBe("u@example.com");
+      expect(deviceRows[0].status).toBe("approved");
+    });
+
+    it("rejects a malformed user_code", async () => {
+      getSessionMock.mockResolvedValue({ email: "u@example.com" });
+      const res = await handleMcpConnect(
+        ev({ method: "POST", body: { user_code: "not a code" } }),
+        "/device/authorize",
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("poll: pending → approved (mints once) → consumed", async () => {
+      await handleMcpConnect(ev({ method: "POST" }), "/device/start");
+      const dc = deviceRows[0].deviceCode;
+
+      // pending
+      getSessionMock.mockResolvedValue(null);
+      let res = await handleMcpConnect(
+        ev({ method: "POST", body: { device_code: dc } }),
+        "/device/poll",
+      );
+      expect((await res.json()).status).toBe("pending");
+
+      // approve via the browser
+      getSessionMock.mockResolvedValue({ email: "u@example.com" });
+      await handleMcpConnect(
+        ev({ method: "POST", body: { user_code: "ABCD-2345" } }),
+        "/device/authorize",
+      );
+
+      // poll → approved + token (unauth)
+      getSessionMock.mockResolvedValue(null);
+      res = await handleMcpConnect(
+        ev({ method: "POST", body: { device_code: dc } }),
+        "/device/poll",
+      );
+      const data = await res.json();
+      expect(data.status).toBe("approved");
+      const { payload } = await jose.jwtVerify(
+        data.token,
+        new TextEncoder().encode(SECRET),
+      );
+      expect(payload.sub).toBe("u@example.com");
+      expect(payload.scope).toBe("mcp-connect");
+
+      // poll again → consumed (single-use, no second token)
+      res = await handleMcpConnect(
+        ev({ method: "POST", body: { device_code: dc } }),
+        "/device/poll",
+      );
+      const again = await res.json();
+      expect(again.status).toBe("consumed");
+      expect(again.token).toBeUndefined();
+    });
+
+    it("poll returns expired for a past-TTL code", async () => {
+      await handleMcpConnect(ev({ method: "POST" }), "/device/start");
+      const dc = deviceRows[0].deviceCode;
+      deviceRows[0].expiresAt = Date.now() - 1;
+      getSessionMock.mockResolvedValue(null);
+      const res = await handleMcpConnect(
+        ev({ method: "POST", body: { device_code: dc } }),
+        "/device/poll",
+      );
+      expect((await res.json()).status).toBe("expired");
+    });
+  });
+});

--- a/packages/core/src/mcp/connect-route.ts
+++ b/packages/core/src/mcp/connect-route.ts
@@ -41,7 +41,9 @@ import {
   createDeviceCode,
   getDeviceCode,
   approveDeviceCode,
-  consumeDeviceCode,
+  claimDeviceCodeForMint,
+  finishDeviceCodeMint,
+  releaseDeviceCodeMint,
   expireDeviceCode,
   MCP_CONNECT_SCOPE,
   DEFAULT_TOKEN_TTL_DAYS,
@@ -86,6 +88,25 @@ function deriveOrigin(event: H3Event): string {
     forwardedProto?.split(",")[0]?.trim() ||
     (host && /^(localhost|127\.0\.0\.1)(:|$)/.test(host) ? "http" : "https");
   return host ? `${proto}://${host}` : "";
+}
+
+function normalizeBasePath(raw: string | undefined): string {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed || trimmed === "/") return "";
+  const withSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withSlash.replace(/\/+$/, "");
+}
+
+function configuredBasePath(): string {
+  return normalizeBasePath(
+    process.env.APP_BASE_PATH || process.env.VITE_APP_BASE_PATH,
+  );
+}
+
+function joinAppPath(basePath: string, path: string): string {
+  if (!basePath) return path;
+  if (path === "/") return basePath;
+  return `${basePath}${path.startsWith("/") ? path : `/${path}`}`;
 }
 
 function appLabel(origin: string, options: McpConnectRouteOptions): string {
@@ -167,12 +188,12 @@ async function mintConnectToken(params: {
 }
 
 function mcpResultPayload(
-  origin: string,
+  appUrl: string,
   token: string,
   options: McpConnectRouteOptions,
 ) {
-  const mcpUrl = `${origin}/_agent-native/mcp`;
-  const name = serverName(origin, options);
+  const mcpUrl = `${appUrl}/_agent-native/mcp`;
+  const name = serverName(appUrl, options);
   return {
     token,
     mcpUrl,
@@ -182,7 +203,7 @@ function mcpResultPayload(
       url: mcpUrl,
       headers: { Authorization: `Bearer ${token}` },
     },
-    cli: `agent-native connect ${origin}`,
+    cli: `agent-native connect ${appUrl}`,
   };
 }
 
@@ -192,11 +213,12 @@ function mcpResultPayload(
 
 function renderConnectPage(params: {
   origin: string;
+  connectBasePath: string;
   email: string;
   appName: string;
   userCode: string | null;
 }): string {
-  const { origin, email, appName, userCode } = params;
+  const { origin, connectBasePath, email, appName, userCode } = params;
   const safeOrigin = escapeHtml(origin);
   const safeEmail = escapeHtml(email);
   const safeApp = escapeHtml(appName);
@@ -322,7 +344,7 @@ function renderConnectPage(params: {
 </div>
 <script>
 (function () {
-  var BASE = "/_agent-native/mcp/connect";
+  var BASE = ${JSON.stringify(joinAppPath(connectBasePath, "/_agent-native/mcp/connect"))};
   var USER_CODE = ${JSON.stringify(safeUserCode || null)};
   var msgEl = document.getElementById("msg");
   function showMsg(text, kind) {
@@ -451,6 +473,8 @@ export async function handleMcpConnect(
 ): Promise<Response> {
   const method = getMethod(event);
   const origin = deriveOrigin(event);
+  const basePath = configuredBasePath();
+  const appUrl = `${origin}${basePath}`;
   const sub = ("/" + subpath.replace(/^\/+/, "").replace(/\/+$/, "")).replace(
     /^\/$/,
     "",
@@ -470,9 +494,10 @@ export async function handleMcpConnect(
       // Fully-open app (no auth guard): nothing to scope a mint to.
       return html(
         renderConnectPage({
-          origin,
+          origin: appUrl,
+          connectBasePath: basePath,
           email: "(no auth configured)",
-          appName: options.appName || appLabel(origin, options),
+          appName: options.appName || appLabel(appUrl, options),
           userCode: null,
         }),
       );
@@ -490,9 +515,10 @@ export async function handleMcpConnect(
     }
     return html(
       renderConnectPage({
-        origin,
+        origin: appUrl,
+        connectBasePath: basePath,
         email: session.email,
-        appName: options.appName || appLabel(origin, options),
+        appName: options.appName || appLabel(appUrl, options),
         userCode,
       }),
     );
@@ -528,7 +554,7 @@ export async function handleMcpConnect(
         label,
         ttlDays,
       });
-      return json(mcpResultPayload(origin, token, options));
+      return json(mcpResultPayload(appUrl, token, options));
     } catch {
       return json({ error: "Failed to mint token." }, 500);
     }
@@ -539,7 +565,7 @@ export async function handleMcpConnect(
     if (method !== "POST") return json({ error: "Method not allowed" }, 405);
     try {
       const row = await createDeviceCode();
-      const verificationUri = `${origin}/_agent-native/mcp/connect`;
+      const verificationUri = `${appUrl}/_agent-native/mcp/connect`;
       return json({
         device_code: row.deviceCode,
         user_code: row.userCode,
@@ -605,7 +631,11 @@ export async function handleMcpConnect(
       if (row.status !== "expired") void expireDeviceCode(deviceCode);
       return json({ status: "expired" });
     }
-    if (row.status === "pending" || !row.ownerEmail) {
+    if (
+      row.status === "pending" ||
+      row.status === "minting" ||
+      !row.ownerEmail
+    ) {
       return json({ status: "pending" });
     }
     // status === "approved" && ownerEmail bound → mint exactly once.
@@ -614,34 +644,38 @@ export async function handleMcpConnect(
     }
     try {
       const jti = randomUUID();
-      // Claim the single-use transition FIRST (atomic), then mint. If the
-      // claim fails we lost the race / it was already consumed.
-      const claimed = await consumeDeviceCode(deviceCode, jti);
+      // Claim a retryable minting state first. If signing or recording fails,
+      // release the row back to approved so the CLI can poll again.
+      const claimed = await claimDeviceCodeForMint(deviceCode, jti);
       if (!claimed) {
         const fresh = await getDeviceCode(deviceCode);
         if (fresh?.status === "consumed") return json({ status: "consumed" });
         return json({ status: "pending" });
       }
-      const orgDomain = await resolveOrgDomain(claimed.orgId ?? undefined);
-      const token = await signA2AToken(
-        claimed.ownerEmail!,
-        orgDomain,
-        undefined,
-        {
+      let token: string;
+      try {
+        const orgDomain = await resolveOrgDomain(claimed.orgId ?? undefined);
+        token = await signA2AToken(claimed.ownerEmail!, orgDomain, undefined, {
           preferGlobalSecret: true,
           expiresIn: `${DEFAULT_TOKEN_TTL_DAYS}d`,
           extraClaims: { jti, scope: MCP_CONNECT_SCOPE },
-        },
-      );
-      await recordMintedToken({
-        jti,
-        ownerEmail: claimed.ownerEmail!,
-        orgId: claimed.orgId,
-        label: "Device connection",
-      });
+        });
+        await recordMintedToken({
+          jti,
+          ownerEmail: claimed.ownerEmail!,
+          orgId: claimed.orgId,
+          label: "Device connection",
+        });
+        if (!(await finishDeviceCodeMint(deviceCode, jti))) {
+          return json({ status: "pending" });
+        }
+      } catch (err) {
+        await releaseDeviceCodeMint(deviceCode, jti);
+        throw err;
+      }
       return json({
         status: "approved",
-        ...mcpResultPayload(origin, token, options),
+        ...mcpResultPayload(appUrl, token, options),
       });
     } catch {
       return json({ status: "error", error: "Failed to mint token." }, 500);

--- a/packages/core/src/mcp/connect-route.ts
+++ b/packages/core/src/mcp/connect-route.ts
@@ -1,0 +1,683 @@
+/**
+ * `/_agent-native/mcp/connect` — frictionless external-agent connection.
+ *
+ * A logged-in user on a deployed agent-native app (e.g. mail.agent-native.com)
+ * mints a per-user, scoped, revocable MCP bearer token WITHOUT ever copying a
+ * shared deployment secret. Two surfaces:
+ *
+ *   1. Browser  — `GET /connect` renders a minimal in-app page (same inline
+ *      HTML approach as the auth pages). The Authorize button POSTs to
+ *      `/connect/token`, then shows the ready-to-paste `.mcp.json` entry, the
+ *      `agent-native connect <origin>` one-liner, and the user's existing
+ *      tokens with Revoke buttons.
+ *   2. CLI      — an OAuth-2.0-device-authorization-style flow:
+ *        POST /connect/device/start      (unauth)  → device_code + user_code
+ *        GET  /connect?user_code=…       (browser) → user signs in & approves
+ *        POST /connect/device/authorize  (session) → binds user to the code
+ *        POST /connect/device/poll       (unauth)  → mints + returns the token
+ *
+ * The minted token reuses the existing A2A signer (`signA2AToken`) — no new
+ * crypto. We only add a random `jti` + `scope: "mcp-connect"` claim so it can
+ * be revoked. `verifyAuth` already verifies A2A_SECRET JWTs and extracts
+ * `sub`/`org_domain`, so a minted token works against `/_agent-native/mcp`
+ * with no verify changes for the happy path (the revoke check is the only
+ * addition there).
+ *
+ * Node-only (crypto + the A2A signer), bundled alongside the other framework
+ * routes. Dialect-agnostic SQL lives in `connect-store.ts`.
+ */
+
+import type { H3Event } from "h3";
+import { getMethod, getHeader } from "h3";
+import { readBody } from "../server/h3-helpers.js";
+import { getSession, getConfiguredLoginHtml } from "../server/auth.js";
+import { signA2AToken } from "../a2a/client.js";
+import { getOrgDomain } from "../org/context.js";
+import { randomUUID } from "node:crypto";
+import {
+  recordMintedToken,
+  listTokens,
+  revokeToken,
+  createDeviceCode,
+  getDeviceCode,
+  approveDeviceCode,
+  consumeDeviceCode,
+  expireDeviceCode,
+  MCP_CONNECT_SCOPE,
+  DEFAULT_TOKEN_TTL_DAYS,
+  MIN_TOKEN_TTL_DAYS,
+  MAX_TOKEN_TTL_DAYS,
+  DEVICE_CODE_TTL_MS,
+} from "./connect-store.js";
+
+/** Device-flow poll interval hint (seconds). */
+const DEVICE_POLL_INTERVAL_S = 3;
+
+// Human-typable user code: 8 base32 chars, dashed XXXX-XXXX.
+const USER_CODE_RE = /^[A-Z2-7]{4}-[A-Z2-7]{4}$/;
+
+export interface McpConnectRouteOptions {
+  /** App id (directory under apps/, e.g. `mail`). Used for the server name. */
+  appId?: string;
+  /** Human app name shown on the connect page. */
+  appName?: string;
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function html(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+/** Derive the running app's origin from request headers (same logic mountMCP
+ *  uses) — `https` in prod / for non-loopback hosts, `http` for localhost. */
+function deriveOrigin(event: H3Event): string {
+  const forwardedProto = getHeader(event, "x-forwarded-proto");
+  const host = getHeader(event, "x-forwarded-host") || getHeader(event, "host");
+  const proto =
+    forwardedProto?.split(",")[0]?.trim() ||
+    (host && /^(localhost|127\.0\.0\.1)(:|$)/.test(host) ? "http" : "https");
+  return host ? `${proto}://${host}` : "";
+}
+
+function appLabel(origin: string, options: McpConnectRouteOptions): string {
+  if (options.appId) return options.appId;
+  try {
+    const h = new URL(origin).hostname;
+    return h.split(".")[0] || h;
+  } catch {
+    return options.appName || "app";
+  }
+}
+
+function serverName(origin: string, options: McpConnectRouteOptions): string {
+  return `agent-native-${appLabel(origin, options)}`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Resolve the org domain for a session. Used as the JWT `org_domain` claim so
+ * the receiving MCP endpoint can map it back to an org id (same as A2A). Best
+ * effort — a missing org just yields a user-scoped (no-org) token.
+ */
+async function resolveOrgDomain(
+  orgId: string | undefined,
+): Promise<string | undefined> {
+  if (!orgId) return undefined;
+  try {
+    return (await getOrgDomain(orgId)) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function clampTtlDays(input: unknown): number {
+  const n = Number(input);
+  if (!Number.isFinite(n)) return DEFAULT_TOKEN_TTL_DAYS;
+  return Math.min(
+    MAX_TOKEN_TTL_DAYS,
+    Math.max(MIN_TOKEN_TTL_DAYS, Math.floor(n)),
+  );
+}
+
+/**
+ * Mint a connect-scoped JWT and record it. The JWT is signed by the existing
+ * A2A signer (HS256 over A2A_SECRET); we add a random `jti` and
+ * `scope: "mcp-connect"` so the token is individually revocable. The token
+ * value is returned to the caller exactly once and never persisted.
+ */
+async function mintConnectToken(params: {
+  email: string;
+  orgId: string | undefined;
+  label: string | null;
+  ttlDays: number;
+}): Promise<{ token: string; jti: string }> {
+  const orgDomain = await resolveOrgDomain(params.orgId);
+  const jti = randomUUID();
+  // signA2AToken signs { sub: email, org_domain? } over A2A_SECRET (global)
+  // or the org secret. We extend its claims via the standard jose builder by
+  // re-using the same signer with extra claims threaded through `options`.
+  const token = await signA2AToken(params.email, orgDomain, undefined, {
+    preferGlobalSecret: true,
+    expiresIn: `${params.ttlDays}d`,
+    extraClaims: { jti, scope: MCP_CONNECT_SCOPE },
+  });
+  await recordMintedToken({
+    jti,
+    ownerEmail: params.email,
+    orgId: params.orgId ?? null,
+    label: params.label,
+  });
+  return { token, jti };
+}
+
+function mcpResultPayload(
+  origin: string,
+  token: string,
+  options: McpConnectRouteOptions,
+) {
+  const mcpUrl = `${origin}/_agent-native/mcp`;
+  const name = serverName(origin, options);
+  return {
+    token,
+    mcpUrl,
+    serverName: name,
+    mcpServerEntry: {
+      type: "http" as const,
+      url: mcpUrl,
+      headers: { Authorization: `Bearer ${token}` },
+    },
+    cli: `agent-native connect ${origin}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Connect page (server-rendered HTML string)
+// ---------------------------------------------------------------------------
+
+function renderConnectPage(params: {
+  origin: string;
+  email: string;
+  appName: string;
+  userCode: string | null;
+}): string {
+  const { origin, email, appName, userCode } = params;
+  const safeOrigin = escapeHtml(origin);
+  const safeEmail = escapeHtml(email);
+  const safeApp = escapeHtml(appName);
+  const safeUserCode =
+    userCode && USER_CODE_RE.test(userCode) ? escapeHtml(userCode) : "";
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Connect ${safeApp}</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    color-scheme: dark;
+    --bg: #09090b; --panel: #141417; --border: rgba(255,255,255,0.1);
+    --text: #f4f4f5; --muted: #a1a1aa; --subtle: #71717a;
+    --accent: #f4f4f5; --accent-fg: #09090b;
+    --error: #fca5a5; --error-bg: rgba(127,29,29,0.18);
+    --ok: #86efac; --ok-bg: rgba(20,83,45,0.2);
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: linear-gradient(180deg, #111114 0%, var(--bg) 58%);
+    color: var(--text); display: flex; align-items: center;
+    justify-content: center; min-height: 100vh; padding: 1rem;
+  }
+  .card {
+    width: 100%; max-width: 520px; padding: 2rem;
+    background: var(--panel); border: 1px solid var(--border);
+    border-radius: 12px; box-shadow: 0 24px 80px rgba(0,0,0,0.35);
+  }
+  h1 { font-size: 1.35rem; font-weight: 650; margin-bottom: 0.35rem; }
+  .sub { color: var(--muted); font-size: 0.9rem; margin-bottom: 1.25rem; }
+  .row { color: var(--subtle); font-size: 0.8rem; margin-bottom: 1.25rem; }
+  .code-callout {
+    border: 1px solid var(--border); border-radius: 8px; padding: 0.85rem 1rem;
+    margin-bottom: 1.25rem; background: rgba(255,255,255,0.03);
+  }
+  .code-callout .label { font-size: 0.72rem; color: var(--subtle);
+    text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 0.35rem; }
+  .code-callout .value { font-size: 1.5rem; font-weight: 700;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    letter-spacing: 0.08em; }
+  button {
+    cursor: pointer; font: inherit; font-weight: 600; border: none;
+    border-radius: 8px; padding: 0.7rem 1.1rem;
+  }
+  .primary { background: var(--accent); color: var(--accent-fg); width: 100%; }
+  .primary:disabled { opacity: 0.6; cursor: default; }
+  .ghost {
+    background: transparent; color: var(--muted);
+    border: 1px solid var(--border); padding: 0.35rem 0.7rem;
+    font-size: 0.78rem; font-weight: 500;
+  }
+  pre {
+    background: #0c0c0e; border: 1px solid var(--border); border-radius: 8px;
+    padding: 0.9rem; font-size: 0.78rem; line-height: 1.5; overflow-x: auto;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: #d4d4d8; margin: 0.5rem 0 1rem;
+  }
+  .field { margin-bottom: 1rem; }
+  .field label { display: block; font-size: 0.8rem; color: var(--muted);
+    margin-bottom: 0.35rem; }
+  .field input {
+    width: 100%; padding: 0.55rem 0.7rem; font: inherit; color: var(--text);
+    background: #0c0c0e; border: 1px solid var(--border); border-radius: 6px;
+  }
+  .inline { display: flex; gap: 0.5rem; }
+  .inline input { flex: 1; }
+  .tokens { margin-top: 1.75rem; border-top: 1px solid var(--border);
+    padding-top: 1.25rem; }
+  .tokens h2 { font-size: 0.95rem; font-weight: 600; margin-bottom: 0.75rem; }
+  .tok { display: flex; align-items: center; justify-content: space-between;
+    gap: 0.75rem; padding: 0.55rem 0; border-bottom: 1px solid var(--border);
+    font-size: 0.83rem; }
+  .tok:last-child { border-bottom: none; }
+  .tok .meta { color: var(--subtle); font-size: 0.74rem; }
+  .tok.revoked { opacity: 0.45; }
+  .msg { font-size: 0.83rem; padding: 0.6rem 0.8rem; border-radius: 6px;
+    margin-bottom: 1rem; display: none; }
+  .msg.err { display: block; color: var(--error); background: var(--error-bg); }
+  .msg.ok { display: block; color: var(--ok); background: var(--ok-bg); }
+  .hidden { display: none !important; }
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>Connect an external agent</h1>
+  <div class="sub">Mint a personal token for <strong>${safeApp}</strong> so a coding agent (Claude Code, Codex, Cowork) can act as you.</div>
+  <div class="row">Signed in as ${safeEmail} &middot; ${safeOrigin}</div>
+
+  <div id="codeCallout" class="code-callout ${safeUserCode ? "" : "hidden"}">
+    <div class="label">Authorizing device code</div>
+    <div class="value" id="userCodeValue">${safeUserCode}</div>
+  </div>
+
+  <div id="msg" class="msg"></div>
+
+  <div id="mintForm">
+    <div class="field">
+      <label for="label">Label (optional)</label>
+      <input id="label" type="text" placeholder="e.g. Claude Code on my laptop" maxlength="120" />
+    </div>
+    <div class="field">
+      <label for="ttl">Expires in (days, 1–365)</label>
+      <input id="ttl" type="number" min="1" max="365" value="${DEFAULT_TOKEN_TTL_DAYS}" />
+    </div>
+    <button id="authorizeBtn" class="primary">${safeUserCode ? "Authorize device" : "Create connection token"}</button>
+  </div>
+
+  <div id="result" class="hidden">
+    <p class="sub" id="resultMsg">Token created. Paste this into your agent's MCP config:</p>
+    <pre id="mcpJson"></pre>
+    <p class="sub">Or from a terminal:</p>
+    <pre id="cliLine"></pre>
+  </div>
+
+  <div class="tokens">
+    <h2>Your connections</h2>
+    <div id="tokenList"><div class="meta">Loading…</div></div>
+  </div>
+</div>
+<script>
+(function () {
+  var BASE = "/_agent-native/mcp/connect";
+  var USER_CODE = ${JSON.stringify(safeUserCode || null)};
+  var msgEl = document.getElementById("msg");
+  function showMsg(text, kind) {
+    msgEl.textContent = text;
+    msgEl.className = "msg " + (kind || "err");
+  }
+  function clearMsg() { msgEl.className = "msg"; msgEl.textContent = ""; }
+
+  function renderResult(data) {
+    document.getElementById("mintForm").classList.add("hidden");
+    var entry = {};
+    entry[data.serverName] = data.mcpServerEntry;
+    document.getElementById("mcpJson").textContent =
+      JSON.stringify({ mcpServers: entry }, null, 2);
+    document.getElementById("cliLine").textContent = data.cli;
+    document.getElementById("result").classList.remove("hidden");
+  }
+
+  async function postJson(path, body) {
+    var res = await fetch(BASE + path, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "same-origin",
+      body: JSON.stringify(body || {})
+    });
+    var data = null;
+    try { data = await res.json(); } catch (e) {}
+    return { ok: res.ok, status: res.status, data: data };
+  }
+
+  async function loadTokens() {
+    var listEl = document.getElementById("tokenList");
+    try {
+      var res = await fetch(BASE + "/tokens", { credentials: "same-origin" });
+      if (!res.ok) { listEl.innerHTML = '<div class="meta">Could not load.</div>'; return; }
+      var data = await res.json();
+      var tokens = (data && data.tokens) || [];
+      if (!tokens.length) { listEl.innerHTML = '<div class="meta">No connections yet.</div>'; return; }
+      listEl.innerHTML = "";
+      tokens.forEach(function (t) {
+        var div = document.createElement("div");
+        div.className = "tok" + (t.revokedAt ? " revoked" : "");
+        var when = t.createdAt ? new Date(t.createdAt).toLocaleString() : "";
+        var used = t.lastUsedAt ? " · last used " + new Date(t.lastUsedAt).toLocaleString() : "";
+        var left = document.createElement("div");
+        var label = document.createElement("div");
+        label.textContent = t.label || "(unlabeled)";
+        var meta = document.createElement("div");
+        meta.className = "meta";
+        meta.textContent = (t.revokedAt ? "Revoked · " : "Created ") + when + used;
+        left.appendChild(label); left.appendChild(meta);
+        div.appendChild(left);
+        if (!t.revokedAt) {
+          var btn = document.createElement("button");
+          btn.className = "ghost";
+          btn.textContent = "Revoke";
+          btn.onclick = async function () {
+            btn.disabled = true;
+            var r = await postJson("/tokens/revoke", { id: t.id });
+            if (r.ok) { loadTokens(); }
+            else { btn.disabled = false; showMsg("Could not revoke token."); }
+          };
+          div.appendChild(btn);
+        }
+        listEl.appendChild(div);
+      });
+    } catch (e) {
+      listEl.innerHTML = '<div class="meta">Could not load.</div>';
+    }
+  }
+
+  document.getElementById("authorizeBtn").onclick = async function () {
+    var btn = this;
+    btn.disabled = true;
+    clearMsg();
+    var label = document.getElementById("label").value || undefined;
+    var ttlDays = parseInt(document.getElementById("ttl").value, 10) || undefined;
+    try {
+      if (USER_CODE) {
+        var a = await postJson("/device/authorize", { user_code: USER_CODE });
+        if (!a.ok) {
+          btn.disabled = false;
+          showMsg((a.data && a.data.error) || "Could not authorize this device code.");
+          return;
+        }
+        showMsg("Device authorized. You can return to your terminal — it will connect automatically.", "ok");
+        btn.classList.add("hidden");
+        document.getElementById("mintForm").classList.add("hidden");
+      } else {
+        var m = await postJson("/token", { label: label, ttlDays: ttlDays });
+        if (!m.ok) {
+          btn.disabled = false;
+          showMsg((m.data && m.data.error) || "Could not create token.");
+          return;
+        }
+        renderResult(m.data);
+      }
+      loadTokens();
+    } catch (e) {
+      btn.disabled = false;
+      showMsg("Network error. Please try again.");
+    }
+  };
+
+  loadTokens();
+})();
+</script>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Handler — single entry point; core-routes-plugin dispatches the subpath.
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle a `/_agent-native/mcp/connect[...]` request. `subpath` is the part
+ * after `/connect` (empty string = the page itself, otherwise e.g.
+ * `/token`, `/device/start`). The core-routes-plugin computes it from the
+ * stripped event path so this module stays mount-agnostic.
+ */
+export async function handleMcpConnect(
+  event: H3Event,
+  subpath: string,
+  options: McpConnectRouteOptions = {},
+): Promise<Response> {
+  const method = getMethod(event);
+  const origin = deriveOrigin(event);
+  const sub = ("/" + subpath.replace(/^\/+/, "").replace(/\/+$/, "")).replace(
+    /^\/$/,
+    "",
+  );
+
+  // ---- The connect page (GET) ------------------------------------------
+  if (sub === "") {
+    if (method !== "GET" && method !== "HEAD") {
+      return json({ error: "Method not allowed" }, 405);
+    }
+    const session = await getSession(event);
+    if (!session?.email) {
+      // Serve the SAME login form the guard would, at this same URL — the
+      // login form reloads window.location so we re-enter here authed.
+      const loginHtml = getConfiguredLoginHtml(event);
+      if (loginHtml) return html(loginHtml, 200);
+      // Fully-open app (no auth guard): nothing to scope a mint to.
+      return html(
+        renderConnectPage({
+          origin,
+          email: "(no auth configured)",
+          appName: options.appName || appLabel(origin, options),
+          userCode: null,
+        }),
+      );
+    }
+    let userCode: string | null = null;
+    try {
+      const u = new URL(
+        event.node?.req?.url ?? event.path ?? "/",
+        "http://an.invalid",
+      );
+      const raw = u.searchParams.get("user_code");
+      if (raw && USER_CODE_RE.test(raw)) userCode = raw;
+    } catch {
+      userCode = null;
+    }
+    return html(
+      renderConnectPage({
+        origin,
+        email: session.email,
+        appName: options.appName || appLabel(origin, options),
+        userCode,
+      }),
+    );
+  }
+
+  // ---- POST /token  (session-required) ---------------------------------
+  if (sub === "/token") {
+    if (method !== "POST") return json({ error: "Method not allowed" }, 405);
+    const session = await getSession(event);
+    if (!session?.email) return json({ error: "Unauthorized" }, 401);
+    if (!process.env.A2A_SECRET) {
+      return json(
+        {
+          error:
+            "This deployment has no A2A_SECRET configured, so connect tokens cannot be minted.",
+        },
+        503,
+      );
+    }
+    const body = ((await readBody(event).catch(() => ({}))) ?? {}) as {
+      label?: unknown;
+      ttlDays?: unknown;
+    };
+    const label =
+      typeof body.label === "string" && body.label.trim()
+        ? body.label.trim().slice(0, 120)
+        : null;
+    const ttlDays = clampTtlDays(body.ttlDays);
+    try {
+      const { token } = await mintConnectToken({
+        email: session.email,
+        orgId: session.orgId,
+        label,
+        ttlDays,
+      });
+      return json(mcpResultPayload(origin, token, options));
+    } catch {
+      return json({ error: "Failed to mint token." }, 500);
+    }
+  }
+
+  // ---- POST /device/start  (UNAUTH) ------------------------------------
+  if (sub === "/device/start") {
+    if (method !== "POST") return json({ error: "Method not allowed" }, 405);
+    try {
+      const row = await createDeviceCode();
+      const verificationUri = `${origin}/_agent-native/mcp/connect`;
+      return json({
+        device_code: row.deviceCode,
+        user_code: row.userCode,
+        verification_uri: verificationUri,
+        verification_uri_complete: `${verificationUri}?user_code=${row.userCode}`,
+        interval: DEVICE_POLL_INTERVAL_S,
+        expires_in: Math.floor(DEVICE_CODE_TTL_MS / 1000),
+      });
+    } catch (err: any) {
+      if (err?.message === "RATE_LIMITED") {
+        return json({ error: "Rate limited. Try again shortly." }, 429);
+      }
+      return json({ error: "Could not start device flow." }, 500);
+    }
+  }
+
+  // ---- POST /device/authorize  (session-required) ----------------------
+  if (sub === "/device/authorize") {
+    if (method !== "POST") return json({ error: "Method not allowed" }, 405);
+    const session = await getSession(event);
+    if (!session?.email) return json({ error: "Unauthorized" }, 401);
+    const body = ((await readBody(event).catch(() => ({}))) ?? {}) as {
+      user_code?: unknown;
+    };
+    const userCode =
+      typeof body.user_code === "string" ? body.user_code.trim() : "";
+    if (!USER_CODE_RE.test(userCode)) {
+      return json({ error: "Invalid user code." }, 400);
+    }
+    const orgId =
+      typeof session.orgId === "string" && session.orgId.trim()
+        ? session.orgId.trim()
+        : null;
+    const result = await approveDeviceCode(userCode, session.email, orgId);
+    if (result === "not_found") {
+      return json({ error: "Unknown device code." }, 404);
+    }
+    if (result === "expired") {
+      return json({ error: "This device code has expired." }, 410);
+    }
+    if (result === "already") {
+      return json({ error: "This device code was already used." }, 409);
+    }
+    return json({ status: "approved" });
+  }
+
+  // ---- POST /device/poll  (UNAUTH) -------------------------------------
+  if (sub === "/device/poll") {
+    if (method !== "POST") return json({ error: "Method not allowed" }, 405);
+    const body = ((await readBody(event).catch(() => ({}))) ?? {}) as {
+      device_code?: unknown;
+    };
+    const deviceCode =
+      typeof body.device_code === "string" ? body.device_code : "";
+    if (!deviceCode) return json({ error: "device_code required" }, 400);
+    const row = await getDeviceCode(deviceCode);
+    if (!row) return json({ status: "not_found" }, 404);
+    if (row.status === "consumed") return json({ status: "consumed" });
+    if (
+      row.status === "expired" ||
+      (row.expiresAt != null && row.expiresAt < Date.now())
+    ) {
+      if (row.status !== "expired") void expireDeviceCode(deviceCode);
+      return json({ status: "expired" });
+    }
+    if (row.status === "pending" || !row.ownerEmail) {
+      return json({ status: "pending" });
+    }
+    // status === "approved" && ownerEmail bound → mint exactly once.
+    if (!process.env.A2A_SECRET) {
+      return json({ status: "error", error: "A2A_SECRET not configured" }, 503);
+    }
+    try {
+      const jti = randomUUID();
+      // Claim the single-use transition FIRST (atomic), then mint. If the
+      // claim fails we lost the race / it was already consumed.
+      const claimed = await consumeDeviceCode(deviceCode, jti);
+      if (!claimed) {
+        const fresh = await getDeviceCode(deviceCode);
+        if (fresh?.status === "consumed") return json({ status: "consumed" });
+        return json({ status: "pending" });
+      }
+      const orgDomain = await resolveOrgDomain(claimed.orgId ?? undefined);
+      const token = await signA2AToken(
+        claimed.ownerEmail!,
+        orgDomain,
+        undefined,
+        {
+          preferGlobalSecret: true,
+          expiresIn: `${DEFAULT_TOKEN_TTL_DAYS}d`,
+          extraClaims: { jti, scope: MCP_CONNECT_SCOPE },
+        },
+      );
+      await recordMintedToken({
+        jti,
+        ownerEmail: claimed.ownerEmail!,
+        orgId: claimed.orgId,
+        label: "Device connection",
+      });
+      return json({
+        status: "approved",
+        ...mcpResultPayload(origin, token, options),
+      });
+    } catch {
+      return json({ status: "error", error: "Failed to mint token." }, 500);
+    }
+  }
+
+  // ---- GET /tokens  (session-required) ---------------------------------
+  if (sub === "/tokens") {
+    if (method !== "GET") return json({ error: "Method not allowed" }, 405);
+    const session = await getSession(event);
+    if (!session?.email) return json({ error: "Unauthorized" }, 401);
+    const rows = await listTokens(session.email);
+    return json({
+      tokens: rows.map((r) => ({
+        id: r.id,
+        label: r.label,
+        createdAt: r.createdAt,
+        lastUsedAt: r.lastUsedAt,
+        revokedAt: r.revokedAt,
+      })),
+    });
+  }
+
+  // ---- POST /tokens/revoke  (session-required) -------------------------
+  if (sub === "/tokens/revoke") {
+    if (method !== "POST") return json({ error: "Method not allowed" }, 405);
+    const session = await getSession(event);
+    if (!session?.email) return json({ error: "Unauthorized" }, 401);
+    const body = ((await readBody(event).catch(() => ({}))) ?? {}) as {
+      id?: unknown;
+    };
+    const id = typeof body.id === "string" ? body.id : "";
+    if (!id) return json({ error: "id required" }, 400);
+    const revoked = await revokeToken(session.email, id);
+    return json({ ok: revoked });
+  }
+
+  return json({ error: "Not found" }, 404);
+}

--- a/packages/core/src/mcp/connect-store.spec.ts
+++ b/packages/core/src/mcp/connect-store.spec.ts
@@ -113,7 +113,11 @@ const exec = async (input: string | { sql: string; args?: unknown[] }) => {
     const d = devices.find((r) => r.user_code === args[0]);
     return { rows: d ? [{ ...d }] : [], rowsAffected: 0 };
   }
-  if (/^UPDATE mcp_device_codes SET status = 'approved'/i.test(sql)) {
+  if (
+    /^UPDATE mcp_device_codes SET status = 'approved', owner_email = \?/i.test(
+      sql,
+    )
+  ) {
     const d = devices.find(
       (r) => r.user_code === args[2] && r.status === "pending",
     );
@@ -125,12 +129,41 @@ const exec = async (input: string | { sql: string; args?: unknown[] }) => {
   }
   if (/^UPDATE mcp_device_codes SET status = 'consumed'/i.test(sql)) {
     const d = devices.find(
-      (r) => r.device_code === args[2] && r.status === "approved",
+      (r) =>
+        (r.device_code === args[2] && r.status === "approved") ||
+        (r.device_code === args[0] &&
+          r.status === "minting" &&
+          r.token_jti === args[1]),
     );
     if (!d) return { rows: [], rowsAffected: 0 };
     d.status = "consumed";
+    if (args.length > 2) {
+      d.token_jti = args[0];
+      d.consumed_at = args[1];
+    }
+    return { rows: [], rowsAffected: 1 };
+  }
+  if (/^UPDATE mcp_device_codes SET status = 'minting'/i.test(sql)) {
+    const d = devices.find(
+      (r) => r.device_code === args[2] && r.status === "approved",
+    );
+    if (!d) return { rows: [], rowsAffected: 0 };
+    d.status = "minting";
     d.token_jti = args[0];
     d.consumed_at = args[1];
+    return { rows: [], rowsAffected: 1 };
+  }
+  if (/^UPDATE mcp_device_codes SET status = 'approved'/i.test(sql)) {
+    const d = devices.find(
+      (r) =>
+        r.device_code === args[0] &&
+        r.status === "minting" &&
+        r.token_jti === args[1],
+    );
+    if (!d) return { rows: [], rowsAffected: 0 };
+    d.status = "approved";
+    d.token_jti = null;
+    d.consumed_at = null;
     return { rows: [], rowsAffected: 1 };
   }
   if (/^UPDATE mcp_device_codes SET status = 'expired'/i.test(sql)) {
@@ -297,6 +330,36 @@ describe("connect-store", () => {
       const row = await store.getDeviceCode(created.deviceCode);
       expect(row?.status).toBe("consumed");
       expect(row?.tokenJti).toBe("jti-x");
+    });
+
+    it("claim mint can be released and retried before final consume", async () => {
+      const created = await store.createDeviceCode();
+      await store.approveDeviceCode(created.userCode, "u@example.com", "org-1");
+      const claimed = await store.claimDeviceCodeForMint(
+        created.deviceCode,
+        "jti-1",
+      );
+      expect(claimed?.ownerEmail).toBe("u@example.com");
+      expect((await store.getDeviceCode(created.deviceCode))?.status).toBe(
+        "minting",
+      );
+
+      await store.releaseDeviceCodeMint(created.deviceCode, "jti-1");
+      expect((await store.getDeviceCode(created.deviceCode))?.status).toBe(
+        "approved",
+      );
+
+      const claimedAgain = await store.claimDeviceCodeForMint(
+        created.deviceCode,
+        "jti-2",
+      );
+      expect(claimedAgain?.ownerEmail).toBe("u@example.com");
+      expect(
+        await store.finishDeviceCodeMint(created.deviceCode, "jti-2"),
+      ).toBe(true);
+      expect((await store.getDeviceCode(created.deviceCode))?.status).toBe(
+        "consumed",
+      );
     });
 
     it("rejects approving an unknown / already-used code", async () => {

--- a/packages/core/src/mcp/connect-store.spec.ts
+++ b/packages/core/src/mcp/connect-store.spec.ts
@@ -29,12 +29,19 @@ interface DeviceRow {
 
 let tokens: TokenRow[] = [];
 let devices: DeviceRow[] = [];
+let failNextCreateTable = false;
 
 const exec = async (input: string | { sql: string; args?: unknown[] }) => {
   const sql = (typeof input === "string" ? input : input.sql).trim();
   const args = (typeof input === "string" ? [] : (input.args ?? [])) as any[];
 
-  if (/^CREATE TABLE/i.test(sql)) return { rows: [], rowsAffected: 0 };
+  if (/^CREATE TABLE/i.test(sql)) {
+    if (failNextCreateTable) {
+      failNextCreateTable = false;
+      throw new Error("transient create-table failure");
+    }
+    return { rows: [], rowsAffected: 0 };
+  }
 
   // --- mcp_connect_tokens ---
   if (/^INSERT INTO mcp_connect_tokens/i.test(sql)) {
@@ -153,7 +160,26 @@ describe("connect-store", () => {
   beforeEach(() => {
     tokens = [];
     devices = [];
+    failNextCreateTable = false;
     vi.restoreAllMocks();
+  });
+
+  it("retries table initialization after a transient failure", async () => {
+    failNextCreateTable = true;
+    await expect(
+      store.recordMintedToken({
+        jti: "jti-fail-once",
+        ownerEmail: "a@example.com",
+      }),
+    ).rejects.toThrow("transient create-table failure");
+
+    await expect(
+      store.recordMintedToken({
+        jti: "jti-retry",
+        ownerEmail: "a@example.com",
+      }),
+    ).resolves.toBeTruthy();
+    expect(tokens.map((t) => t.jti)).toEqual(["jti-retry"]);
   });
 
   describe("token records", () => {

--- a/packages/core/src/mcp/connect-store.spec.ts
+++ b/packages/core/src/mcp/connect-store.spec.ts
@@ -1,0 +1,306 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * In-memory SQL simulator just rich enough for the two connect tables. We
+ * pattern-match the small, fixed set of statements the store issues rather
+ * than implementing a SQL engine — same approach as sibling store specs.
+ */
+interface TokenRow {
+  id: string;
+  jti: string;
+  owner_email: string;
+  org_id: string | null;
+  label: string | null;
+  created_at: number | null;
+  last_used_at: number | null;
+  revoked_at: number | null;
+}
+interface DeviceRow {
+  device_code: string;
+  user_code: string;
+  owner_email: string | null;
+  org_id: string | null;
+  status: string;
+  token_jti: string | null;
+  created_at: number | null;
+  expires_at: number | null;
+  consumed_at: number | null;
+}
+
+let tokens: TokenRow[] = [];
+let devices: DeviceRow[] = [];
+
+const exec = async (input: string | { sql: string; args?: unknown[] }) => {
+  const sql = (typeof input === "string" ? input : input.sql).trim();
+  const args = (typeof input === "string" ? [] : (input.args ?? [])) as any[];
+
+  if (/^CREATE TABLE/i.test(sql)) return { rows: [], rowsAffected: 0 };
+
+  // --- mcp_connect_tokens ---
+  if (/^INSERT INTO mcp_connect_tokens/i.test(sql)) {
+    tokens.push({
+      id: args[0],
+      jti: args[1],
+      owner_email: args[2],
+      org_id: args[3],
+      label: args[4],
+      created_at: args[5],
+      last_used_at: args[6],
+      revoked_at: args[7],
+    });
+    return { rows: [], rowsAffected: 1 };
+  }
+  if (/^SELECT revoked_at FROM mcp_connect_tokens WHERE jti = \?/i.test(sql)) {
+    const t = tokens.find((r) => r.jti === args[0]);
+    return { rows: t ? [{ revoked_at: t.revoked_at }] : [], rowsAffected: 0 };
+  }
+  if (
+    /^SELECT id, jti, owner_email.* FROM mcp_connect_tokens WHERE owner_email = \?/i.test(
+      sql,
+    )
+  ) {
+    const rows = tokens
+      .filter((r) => r.owner_email === args[0])
+      .sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0));
+    return { rows, rowsAffected: 0 };
+  }
+  if (/^UPDATE mcp_connect_tokens SET revoked_at = \?/i.test(sql)) {
+    const t = tokens.find(
+      (r) =>
+        r.id === args[1] && r.owner_email === args[2] && r.revoked_at == null,
+    );
+    if (!t) return { rows: [], rowsAffected: 0 };
+    t.revoked_at = args[0];
+    return { rows: [], rowsAffected: 1 };
+  }
+  if (/^UPDATE mcp_connect_tokens SET last_used_at = \?/i.test(sql)) {
+    const t = tokens.find((r) => r.jti === args[1]);
+    if (t) t.last_used_at = args[0];
+    return { rows: [], rowsAffected: t ? 1 : 0 };
+  }
+
+  // --- mcp_device_codes ---
+  if (/^SELECT COUNT\(\*\) AS n FROM mcp_device_codes/i.test(sql)) {
+    const n = devices.filter((d) => (d.created_at ?? 0) > args[0]).length;
+    return { rows: [{ n }], rowsAffected: 0 };
+  }
+  if (/^INSERT INTO mcp_device_codes/i.test(sql)) {
+    devices.push({
+      device_code: args[0],
+      user_code: args[1],
+      owner_email: args[2],
+      org_id: args[3],
+      status: args[4],
+      token_jti: args[5],
+      created_at: args[6],
+      expires_at: args[7],
+      consumed_at: args[8],
+    });
+    return { rows: [], rowsAffected: 1 };
+  }
+  if (/^SELECT \* FROM mcp_device_codes WHERE device_code = \?/i.test(sql)) {
+    const d = devices.find((r) => r.device_code === args[0]);
+    return { rows: d ? [{ ...d }] : [], rowsAffected: 0 };
+  }
+  if (/^SELECT \* FROM mcp_device_codes WHERE user_code = \?/i.test(sql)) {
+    const d = devices.find((r) => r.user_code === args[0]);
+    return { rows: d ? [{ ...d }] : [], rowsAffected: 0 };
+  }
+  if (/^UPDATE mcp_device_codes SET status = 'approved'/i.test(sql)) {
+    const d = devices.find(
+      (r) => r.user_code === args[2] && r.status === "pending",
+    );
+    if (!d) return { rows: [], rowsAffected: 0 };
+    d.status = "approved";
+    d.owner_email = args[0];
+    d.org_id = args[1];
+    return { rows: [], rowsAffected: 1 };
+  }
+  if (/^UPDATE mcp_device_codes SET status = 'consumed'/i.test(sql)) {
+    const d = devices.find(
+      (r) => r.device_code === args[2] && r.status === "approved",
+    );
+    if (!d) return { rows: [], rowsAffected: 0 };
+    d.status = "consumed";
+    d.token_jti = args[0];
+    d.consumed_at = args[1];
+    return { rows: [], rowsAffected: 1 };
+  }
+  if (/^UPDATE mcp_device_codes SET status = 'expired'/i.test(sql)) {
+    const d = devices.find(
+      (r) =>
+        r.device_code === args[0] &&
+        (r.status === "pending" || r.status === "approved"),
+    );
+    if (!d) return { rows: [], rowsAffected: 0 };
+    d.status = "expired";
+    return { rows: [], rowsAffected: 1 };
+  }
+
+  throw new Error("unhandled SQL in mock: " + sql);
+};
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => ({ execute: exec }),
+  isConnectionError: () => false,
+  isPostgres: () => false,
+  intType: () => "INTEGER",
+}));
+
+const store = await import("./connect-store.js");
+
+describe("connect-store", () => {
+  beforeEach(() => {
+    tokens = [];
+    devices = [];
+    vi.restoreAllMocks();
+  });
+
+  describe("token records", () => {
+    it("records a minted token and never stores the token value", async () => {
+      const id = await store.recordMintedToken({
+        jti: "jti-1",
+        ownerEmail: "a@example.com",
+        orgId: "org-1",
+        label: "laptop",
+      });
+      expect(id).toBeTruthy();
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0]).toMatchObject({
+        jti: "jti-1",
+        owner_email: "a@example.com",
+        org_id: "org-1",
+        label: "laptop",
+        revoked_at: null,
+      });
+      // The row has no column for the token value at all.
+      expect(Object.keys(tokens[0])).not.toContain("token");
+    });
+
+    it("isJtiRevoked is false for an active token and true after revoke", async () => {
+      await store.recordMintedToken({ jti: "j", ownerEmail: "a@example.com" });
+      expect(await store.isJtiRevoked("j")).toBe(false);
+      const id = tokens[0].id;
+      expect(await store.revokeToken("a@example.com", id)).toBe(true);
+      expect(await store.isJtiRevoked("j")).toBe(true);
+    });
+
+    it("isJtiRevoked is false for an unknown jti", async () => {
+      expect(await store.isJtiRevoked("nope")).toBe(false);
+    });
+
+    it("revokeToken only affects tokens owned by the caller", async () => {
+      const id = await store.recordMintedToken({
+        jti: "j",
+        ownerEmail: "owner@example.com",
+      });
+      expect(await store.revokeToken("attacker@example.com", id)).toBe(false);
+      expect(tokens[0].revoked_at).toBeNull();
+      expect(await store.revokeToken("owner@example.com", id)).toBe(true);
+    });
+
+    it("revokeToken is idempotent (re-revoke is a no-op)", async () => {
+      const id = await store.recordMintedToken({
+        jti: "j",
+        ownerEmail: "o@example.com",
+      });
+      expect(await store.revokeToken("o@example.com", id)).toBe(true);
+      const first = tokens[0].revoked_at;
+      expect(await store.revokeToken("o@example.com", id)).toBe(false);
+      expect(tokens[0].revoked_at).toBe(first);
+    });
+
+    it("listTokens returns only the caller's tokens, newest first", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(1000);
+      await store.recordMintedToken({ jti: "j1", ownerEmail: "a@example.com" });
+      vi.spyOn(Date, "now").mockReturnValue(2000);
+      await store.recordMintedToken({ jti: "j2", ownerEmail: "a@example.com" });
+      await store.recordMintedToken({ jti: "j3", ownerEmail: "b@example.com" });
+      const list = await store.listTokens("a@example.com");
+      expect(list.map((t) => t.jti)).toEqual(["j2", "j1"]);
+    });
+
+    it("touchTokenUsed never throws and stamps last_used_at", async () => {
+      await store.recordMintedToken({ jti: "j", ownerEmail: "a@example.com" });
+      await expect(store.touchTokenUsed("j")).resolves.toBeUndefined();
+      expect(tokens[0].last_used_at).not.toBeNull();
+      // Unknown jti is a silent no-op (best-effort telemetry).
+      await expect(store.touchTokenUsed("missing")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("device-code lifecycle", () => {
+    it("creates a crypto-random device + dashed user code with a 10-min TTL", async () => {
+      const t = 1_000_000;
+      vi.spyOn(Date, "now").mockReturnValue(t);
+      const row = await store.createDeviceCode();
+      expect(row.userCode).toMatch(/^[A-Z2-7]{4}-[A-Z2-7]{4}$/);
+      expect(row.deviceCode.length).toBeGreaterThan(20);
+      expect(row.status).toBe("pending");
+      expect(row.expiresAt).toBe(t + store.DEVICE_CODE_TTL_MS);
+    });
+
+    it("rate-limits device code creation within the window", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(5_000_000);
+      for (let i = 0; i < store.DEVICE_START_MAX; i++) {
+        await store.createDeviceCode();
+      }
+      await expect(store.createDeviceCode()).rejects.toThrow("RATE_LIMITED");
+    });
+
+    it("approve binds the user, then consume mints exactly once", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(1000);
+      const created = await store.createDeviceCode();
+
+      const approved = await store.approveDeviceCode(
+        created.userCode,
+        "user@example.com",
+        "org-9",
+      );
+      expect(approved).not.toBe("not_found");
+      expect(typeof approved === "object" && approved.status).toBe("approved");
+
+      const first = await store.consumeDeviceCode(created.deviceCode, "jti-x");
+      expect(first?.ownerEmail).toBe("user@example.com");
+      expect(first?.orgId).toBe("org-9");
+
+      // Single-use: a second consume returns null.
+      const second = await store.consumeDeviceCode(created.deviceCode, "jti-y");
+      expect(second).toBeNull();
+
+      const row = await store.getDeviceCode(created.deviceCode);
+      expect(row?.status).toBe("consumed");
+      expect(row?.tokenJti).toBe("jti-x");
+    });
+
+    it("rejects approving an unknown / already-used code", async () => {
+      expect(
+        await store.approveDeviceCode(" AAAA-AAAA", "u@example.com", null),
+      ).toBe("not_found");
+
+      const created = await store.createDeviceCode();
+      await store.approveDeviceCode(created.userCode, "u@example.com", null);
+      expect(
+        await store.approveDeviceCode(created.userCode, "u@example.com", null),
+      ).toBe("already");
+    });
+
+    it("rejects approving an expired code", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(1000);
+      const created = await store.createDeviceCode();
+      vi.spyOn(Date, "now").mockReturnValue(
+        1000 + store.DEVICE_CODE_TTL_MS + 1,
+      );
+      expect(
+        await store.approveDeviceCode(created.userCode, "u@example.com", null),
+      ).toBe("expired");
+    });
+
+    it("cannot consume a code that was never approved", async () => {
+      const created = await store.createDeviceCode();
+      expect(
+        await store.consumeDeviceCode(created.deviceCode, "jti"),
+      ).toBeNull();
+    });
+  });
+});

--- a/packages/core/src/mcp/connect-store.ts
+++ b/packages/core/src/mcp/connect-store.ts
@@ -232,7 +232,7 @@ export interface DeviceCodeRow {
   userCode: string;
   ownerEmail: string | null;
   orgId: string | null;
-  status: "pending" | "approved" | "consumed" | "expired";
+  status: "pending" | "approved" | "minting" | "consumed" | "expired";
   tokenJti: string | null;
   createdAt: number | null;
   expiresAt: number | null;
@@ -424,6 +424,57 @@ export async function consumeDeviceCode(
   });
   if (result.rowsAffected === 0) return null; // lost the single-use race
   return row;
+}
+
+/**
+ * Claim an approved device code for token minting without making it terminal.
+ * If signing or token recording fails, callers release this back to approved
+ * so the CLI can retry the poll instead of being stuck at "consumed".
+ */
+export async function claimDeviceCodeForMint(
+  deviceCode: string,
+  tokenJti: string,
+): Promise<DeviceCodeRow | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const row = await getDeviceCode(deviceCode);
+  if (!row || row.status !== "approved") return null;
+  const result = await client.execute({
+    sql: `UPDATE mcp_device_codes SET status = 'minting', token_jti = ?, consumed_at = ? WHERE device_code = ? AND status = 'approved'`,
+    args: [tokenJti, Date.now(), deviceCode],
+  });
+  if (result.rowsAffected === 0) return null;
+  return row;
+}
+
+export async function finishDeviceCodeMint(
+  deviceCode: string,
+  tokenJti: string,
+): Promise<boolean> {
+  await ensureTable();
+  const client = getDbExec();
+  const result = await client.execute({
+    sql: `UPDATE mcp_device_codes SET status = 'consumed' WHERE device_code = ? AND status = 'minting' AND token_jti = ?`,
+    args: [deviceCode, tokenJti],
+  });
+  return result.rowsAffected > 0;
+}
+
+export async function releaseDeviceCodeMint(
+  deviceCode: string,
+  tokenJti: string,
+): Promise<void> {
+  try {
+    await ensureTable();
+    const client = getDbExec();
+    await client.execute({
+      sql: `UPDATE mcp_device_codes SET status = 'approved', token_jti = NULL, consumed_at = NULL WHERE device_code = ? AND status = 'minting' AND token_jti = ?`,
+      args: [deviceCode, tokenJti],
+    });
+  } catch {
+    // The next poll will keep returning pending for a minting row until a
+    // later cleanup/retry path can observe or repair it. Do not throw here.
+  }
 }
 
 /**

--- a/packages/core/src/mcp/connect-store.ts
+++ b/packages/core/src/mcp/connect-store.ts
@@ -82,7 +82,12 @@ async function ensureTable(): Promise<void> {
           consumed_at ${intType()}
         )
       `);
-    })();
+    })().catch((err) => {
+      // Don't cache a rejected init. A transient DB blip should let the next
+      // connect/mint/revoke call retry rather than wedging the process.
+      _initPromise = undefined;
+      throw err;
+    });
   }
   return _initPromise;
 }

--- a/packages/core/src/mcp/connect-store.ts
+++ b/packages/core/src/mcp/connect-store.ts
@@ -1,0 +1,446 @@
+/**
+ * Framework-table store for the "connect external agents" feature.
+ *
+ * Two additive, dialect-agnostic tables back the browser **Connect** page and
+ * the OAuth-style **device-code flow** a CLI drives:
+ *
+ *   - `mcp_connect_tokens`  — one row per minted MCP token. We never store the
+ *     token value (it's a signed JWT); only its `jti` so revocation is a
+ *     SQL lookup. Revoking sets `revoked_at`; the row is never deleted.
+ *   - `mcp_device_codes`    — short-lived (10 min) device/user code pairs for
+ *     the OAuth 2.0 device-authorization-style CLI flow. Single-use
+ *     (`consumed_at`), rate-limited at creation.
+ *
+ * Mirrors `application-state/store.ts`: lazy `ensureTable()`, `getDbExec()`,
+ * `isPostgres()` dialect branching for upserts, `isConnectionError()` swallow
+ * so a transient Neon WS drop never 500s. `CREATE TABLE IF NOT EXISTS` only —
+ * strictly additive, never DROP / ALTER (shared prod DB rule).
+ */
+
+import {
+  getDbExec,
+  isConnectionError,
+  isPostgres,
+  intType,
+} from "../db/client.js";
+import { randomBytes, randomUUID } from "node:crypto";
+
+let _initPromise: Promise<void> | undefined;
+
+/**
+ * Scope claim that marks a connect-minted token (vs. an ordinary A2A
+ * delegation JWT). Only tokens carrying this scope go through the revoke
+ * lookup in `verifyAuth` — defined here so both `connect-route.ts` and
+ * `build-server.ts` import it from the leaf store without a cycle.
+ */
+export const MCP_CONNECT_SCOPE = "mcp-connect";
+
+/** Device codes are valid for 10 minutes. */
+export const DEVICE_CODE_TTL_MS = 10 * 60_000;
+
+/** Default minted-token lifetime. Configurable per-request 1–365 days. */
+export const DEFAULT_TOKEN_TTL_DAYS = 90;
+export const MIN_TOKEN_TTL_DAYS = 1;
+export const MAX_TOKEN_TTL_DAYS = 365;
+
+/**
+ * Rate limit for `device/start`: at most this many device codes may be created
+ * within `DEVICE_START_WINDOW_MS`. Unauthenticated endpoint — keep it tight so
+ * a hostile client can't flood the table or brute-force user codes.
+ */
+export const DEVICE_START_MAX = 20;
+export const DEVICE_START_WINDOW_MS = 60_000;
+
+async function ensureTable(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = (async () => {
+      const client = getDbExec();
+      // Additive only. Never DROP / ALTER — this DB is shared across every
+      // deploy context (preview/branch/prod) for hosted templates.
+      await client.execute(`
+        CREATE TABLE IF NOT EXISTS mcp_connect_tokens (
+          id TEXT PRIMARY KEY,
+          jti TEXT UNIQUE NOT NULL,
+          owner_email TEXT NOT NULL,
+          org_id TEXT,
+          label TEXT,
+          created_at ${intType()},
+          last_used_at ${intType()},
+          revoked_at ${intType()}
+        )
+      `);
+      await client.execute(`
+        CREATE TABLE IF NOT EXISTS mcp_device_codes (
+          device_code TEXT PRIMARY KEY,
+          user_code TEXT NOT NULL,
+          owner_email TEXT,
+          org_id TEXT,
+          status TEXT NOT NULL DEFAULT 'pending',
+          token_jti TEXT,
+          created_at ${intType()},
+          expires_at ${intType()},
+          consumed_at ${intType()}
+        )
+      `);
+    })();
+  }
+  return _initPromise;
+}
+
+// ---------------------------------------------------------------------------
+// Minted-token records
+// ---------------------------------------------------------------------------
+
+export interface MintedTokenRow {
+  id: string;
+  jti: string;
+  ownerEmail: string;
+  orgId: string | null;
+  label: string | null;
+  createdAt: number | null;
+  lastUsedAt: number | null;
+  revokedAt: number | null;
+}
+
+/**
+ * Persist a record of a minted token. The token value itself (a signed JWT)
+ * is NEVER stored — only its `jti`, so revocation is a cheap SQL lookup.
+ */
+export async function recordMintedToken(params: {
+  jti: string;
+  ownerEmail: string;
+  orgId?: string | null;
+  label?: string | null;
+}): Promise<string> {
+  await ensureTable();
+  const client = getDbExec();
+  const id = randomUUID();
+  await client.execute({
+    sql: `INSERT INTO mcp_connect_tokens (id, jti, owner_email, org_id, label, created_at, last_used_at, revoked_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      id,
+      params.jti,
+      params.ownerEmail,
+      params.orgId ?? null,
+      params.label ?? null,
+      Date.now(),
+      null,
+      null,
+    ],
+  });
+  return id;
+}
+
+/**
+ * Returns true when the given `jti` corresponds to a token that has been
+ * revoked. Fails OPEN on a store/DB error: a transient Neon WS drop must not
+ * lock every connected agent out. Signature verification is unaffected — this
+ * is only the post-verify revoke check (see `verifyAuth` in build-server.ts).
+ */
+export async function isJtiRevoked(jti: string): Promise<boolean> {
+  try {
+    await ensureTable();
+    const client = getDbExec();
+    const { rows } = await client.execute({
+      sql: `SELECT revoked_at FROM mcp_connect_tokens WHERE jti = ?`,
+      args: [jti],
+    });
+    if (rows.length === 0) return false;
+    const revokedAt = rows[0].revoked_at ?? rows[0].revokedAt;
+    return revokedAt != null;
+  } catch (err) {
+    // Fail open: a DB blip must not turn every minted token into a 401.
+    // (Signature checks already passed; this only gates explicit revokes.)
+    if (isConnectionError(err)) return false;
+    return false;
+  }
+}
+
+export async function listTokens(
+  ownerEmail: string,
+): Promise<MintedTokenRow[]> {
+  try {
+    await ensureTable();
+    const client = getDbExec();
+    const { rows } = await client.execute({
+      sql: `SELECT id, jti, owner_email, org_id, label, created_at, last_used_at, revoked_at FROM mcp_connect_tokens WHERE owner_email = ? ORDER BY created_at DESC`,
+      args: [ownerEmail],
+    });
+    return rows.map((r: any) => ({
+      id: r.id as string,
+      jti: r.jti as string,
+      ownerEmail: (r.owner_email ?? r.ownerEmail) as string,
+      orgId: (r.org_id ?? r.orgId ?? null) as string | null,
+      label: (r.label ?? null) as string | null,
+      createdAt: numOrNull(r.created_at ?? r.createdAt),
+      lastUsedAt: numOrNull(r.last_used_at ?? r.lastUsedAt),
+      revokedAt: numOrNull(r.revoked_at ?? r.revokedAt),
+    }));
+  } catch (err) {
+    if (isConnectionError(err)) return [];
+    throw err;
+  }
+}
+
+/**
+ * Revoke a token, but ONLY if it is owned by `ownerEmail` (the caller). The
+ * `owner_email = ?` predicate is the access scope — a caller can never revoke
+ * another user's token. Idempotent: re-revoking keeps the first timestamp.
+ * Returns true when a row was actually transitioned to revoked.
+ */
+export async function revokeToken(
+  ownerEmail: string,
+  id: string,
+): Promise<boolean> {
+  await ensureTable();
+  const client = getDbExec();
+  const result = await client.execute({
+    sql: `UPDATE mcp_connect_tokens SET revoked_at = ? WHERE id = ? AND owner_email = ? AND revoked_at IS NULL`,
+    args: [Date.now(), id, ownerEmail],
+  });
+  return result.rowsAffected > 0;
+}
+
+/**
+ * Best-effort: stamp `last_used_at` for a token. Swallows all errors — this is
+ * pure telemetry and must never affect the auth path.
+ */
+export async function touchTokenUsed(jti: string): Promise<void> {
+  try {
+    await ensureTable();
+    const client = getDbExec();
+    await client.execute({
+      sql: `UPDATE mcp_connect_tokens SET last_used_at = ? WHERE jti = ?`,
+      args: [Date.now(), jti],
+    });
+  } catch {
+    // last_used_at is informational only — never throw from the hot path.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Device-code flow (OAuth 2.0 device-authorization style)
+// ---------------------------------------------------------------------------
+
+export interface DeviceCodeRow {
+  deviceCode: string;
+  userCode: string;
+  ownerEmail: string | null;
+  orgId: string | null;
+  status: "pending" | "approved" | "consumed" | "expired";
+  tokenJti: string | null;
+  createdAt: number | null;
+  expiresAt: number | null;
+  consumedAt: number | null;
+}
+
+const USER_CODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"; // Crockford-ish base32, no 0/1/O/I
+
+/** Crypto-random short human-typable code, formatted `XXXX-XXXX`. */
+function generateUserCode(): string {
+  const bytes = randomBytes(8);
+  let out = "";
+  for (let i = 0; i < 8; i++) {
+    out += USER_CODE_ALPHABET[bytes[i] % USER_CODE_ALPHABET.length];
+    if (i === 3) out += "-";
+  }
+  return out;
+}
+
+function generateDeviceCode(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+/**
+ * Create a new device+user code pair. Rate-limited: at most
+ * `DEVICE_START_MAX` codes within `DEVICE_START_WINDOW_MS`. The window count
+ * is a coarse global cap (this endpoint is unauthenticated) — enough to stop
+ * table flooding / user-code brute force without per-IP plumbing.
+ *
+ * Throws `RATE_LIMITED` when the cap is exceeded so the route can map it to a
+ * 429.
+ */
+export async function createDeviceCode(): Promise<DeviceCodeRow> {
+  await ensureTable();
+  const client = getDbExec();
+
+  const now = Date.now();
+  try {
+    const { rows } = await client.execute({
+      sql: `SELECT COUNT(*) AS n FROM mcp_device_codes WHERE created_at > ?`,
+      args: [now - DEVICE_START_WINDOW_MS],
+    });
+    const n = Number(rows[0]?.n ?? rows[0]?.["COUNT(*)"] ?? 0);
+    if (Number.isFinite(n) && n >= DEVICE_START_MAX) {
+      throw new Error("RATE_LIMITED");
+    }
+  } catch (err: any) {
+    if (err?.message === "RATE_LIMITED") throw err;
+    // A read failure here should not block legitimate device starts — the
+    // single-use + short-TTL design is the primary protection. Continue.
+  }
+
+  const deviceCode = generateDeviceCode();
+  const userCode = generateUserCode();
+  const expiresAt = now + DEVICE_CODE_TTL_MS;
+  await client.execute({
+    sql: `INSERT INTO mcp_device_codes (device_code, user_code, owner_email, org_id, status, token_jti, created_at, expires_at, consumed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      deviceCode,
+      userCode,
+      null,
+      null,
+      "pending",
+      null,
+      now,
+      expiresAt,
+      null,
+    ],
+  });
+  return {
+    deviceCode,
+    userCode,
+    ownerEmail: null,
+    orgId: null,
+    status: "pending",
+    tokenJti: null,
+    createdAt: now,
+    expiresAt,
+    consumedAt: null,
+  };
+}
+
+function mapDeviceRow(r: any): DeviceCodeRow {
+  return {
+    deviceCode: (r.device_code ?? r.deviceCode) as string,
+    userCode: (r.user_code ?? r.userCode) as string,
+    ownerEmail: (r.owner_email ?? r.ownerEmail ?? null) as string | null,
+    orgId: (r.org_id ?? r.orgId ?? null) as string | null,
+    status: (r.status ?? "pending") as DeviceCodeRow["status"],
+    tokenJti: (r.token_jti ?? r.tokenJti ?? null) as string | null,
+    createdAt: numOrNull(r.created_at ?? r.createdAt),
+    expiresAt: numOrNull(r.expires_at ?? r.expiresAt),
+    consumedAt: numOrNull(r.consumed_at ?? r.consumedAt),
+  };
+}
+
+export async function getDeviceCode(
+  deviceCode: string,
+): Promise<DeviceCodeRow | null> {
+  try {
+    await ensureTable();
+    const client = getDbExec();
+    const { rows } = await client.execute({
+      sql: `SELECT * FROM mcp_device_codes WHERE device_code = ?`,
+      args: [deviceCode],
+    });
+    if (rows.length === 0) return null;
+    return mapDeviceRow(rows[0]);
+  } catch (err) {
+    if (isConnectionError(err)) return null;
+    throw err;
+  }
+}
+
+export async function getDeviceCodeByUserCode(
+  userCode: string,
+): Promise<DeviceCodeRow | null> {
+  try {
+    await ensureTable();
+    const client = getDbExec();
+    const { rows } = await client.execute({
+      sql: `SELECT * FROM mcp_device_codes WHERE user_code = ?`,
+      args: [userCode],
+    });
+    if (rows.length === 0) return null;
+    return mapDeviceRow(rows[0]);
+  } catch (err) {
+    if (isConnectionError(err)) return null;
+    throw err;
+  }
+}
+
+/**
+ * Bind the logged-in user (email + org) to a pending device code, identified
+ * by its human-typable `user_code`. Only transitions a non-expired, still
+ * `pending` row. Returns the bound row, or a string error code:
+ *   - `not_found`  — no such user_code
+ *   - `expired`    — past its TTL
+ *   - `already`    — already approved/consumed (not re-bindable)
+ */
+export async function approveDeviceCode(
+  userCode: string,
+  ownerEmail: string,
+  orgId: string | null,
+): Promise<DeviceCodeRow | "not_found" | "expired" | "already"> {
+  await ensureTable();
+  const client = getDbExec();
+  const row = await getDeviceCodeByUserCode(userCode);
+  if (!row) return "not_found";
+  if ((row.expiresAt ?? 0) < Date.now()) return "expired";
+  if (row.status !== "pending") return "already";
+
+  const result = await client.execute({
+    sql: `UPDATE mcp_device_codes SET status = 'approved', owner_email = ?, org_id = ? WHERE user_code = ? AND status = 'pending'`,
+    args: [ownerEmail, orgId, userCode],
+  });
+  if (result.rowsAffected === 0) {
+    // Lost a race with another approve — re-read to report the real state.
+    const fresh = await getDeviceCodeByUserCode(userCode);
+    return fresh && fresh.status !== "pending" ? "already" : "not_found";
+  }
+  return {
+    ...row,
+    status: "approved",
+    ownerEmail,
+    orgId,
+  };
+}
+
+/**
+ * Atomically transition an approved device code to consumed and stamp the
+ * minted token's jti. Single-use: only succeeds when the row is currently
+ * `approved` (not already consumed). Returns the pre-consume row on success,
+ * or null when it could not be consumed (already consumed / not approved /
+ * gone). The caller mints the token only after this returns a row.
+ */
+export async function consumeDeviceCode(
+  deviceCode: string,
+  tokenJti: string,
+): Promise<DeviceCodeRow | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const row = await getDeviceCode(deviceCode);
+  if (!row) return null;
+  if (row.status !== "approved") return null;
+  const result = await client.execute({
+    sql: `UPDATE mcp_device_codes SET status = 'consumed', token_jti = ?, consumed_at = ? WHERE device_code = ? AND status = 'approved'`,
+    args: [tokenJti, Date.now(), deviceCode],
+  });
+  if (result.rowsAffected === 0) return null; // lost the single-use race
+  return row;
+}
+
+/**
+ * Best-effort: flip an expired, still-pending/approved row to `expired` so
+ * the poll endpoint can report a clean terminal state. Swallows errors.
+ */
+export async function expireDeviceCode(deviceCode: string): Promise<void> {
+  try {
+    await ensureTable();
+    const client = getDbExec();
+    await client.execute({
+      sql: `UPDATE mcp_device_codes SET status = 'expired' WHERE device_code = ? AND status IN ('pending','approved')`,
+      args: [deviceCode],
+    });
+  } catch {
+    // The poll handler already treats past-TTL rows as expired regardless of
+    // whether this housekeeping write lands.
+  }
+}
+
+function numOrNull(v: unknown): number | null {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -2558,6 +2558,40 @@ describe("server/auth", () => {
       expect(AUTO_DEV_ACCOUNT_EMAIL).toMatch(/\.test$/);
     });
   });
+
+  describe("isLoopbackAddress", () => {
+    it("accepts loopback peers (IPv4, IPv6, IPv4-mapped, 127/8, zone id)", async () => {
+      const { isLoopbackAddress } = await import("./auth.js");
+      for (const ip of [
+        "127.0.0.1",
+        "127.5.6.7",
+        "::1",
+        "::1%lo0",
+        "::ffff:127.0.0.1",
+      ]) {
+        expect(isLoopbackAddress(ip)).toBe(true);
+      }
+    });
+
+    it("rejects every non-loopback / unknown peer (the dev auto-account + desktop-SSO gate)", async () => {
+      const { isLoopbackAddress } = await import("./auth.js");
+      for (const ip of [
+        "203.0.113.5",
+        "192.168.4.70",
+        "10.0.0.2",
+        "169.254.1.1",
+        "0.0.0.0",
+        "::",
+        "::ffff:192.168.4.70",
+        "1.127.0.0", // must NOT match the 127/8 prefix check
+        "localhost",
+        "",
+        undefined,
+      ]) {
+        expect(isLoopbackAddress(ip)).toBe(false);
+      }
+    });
+  });
 });
 
 // --- Mock helpers ---

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -620,6 +620,48 @@ describe("server/auth", () => {
       }
     });
 
+    it("env-gates the federated-SSO route bypass (no-op when AGENT_NATIVE_IDENTITY_HUB_URL is unset)", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ACCESS_TOKEN", "my-secret");
+      delete process.env.AGENT_NATIVE_IDENTITY_HUB_URL;
+      const { autoMountAuth } = await import("./auth.js");
+
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const app = createMockApp();
+      await autoMountAuth(app);
+      logSpy.mockRestore();
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      // Env UNSET → the identity routes are NOT bypassed: the guard must
+      // treat them like any other unauthenticated /_agent-native/* request
+      // (it returns a 401 body, i.e. NOT `undefined`). This is the
+      // regression assertion for the env-unset-no-op invariant.
+      for (const path of [
+        "/_agent-native/identity/login",
+        "/_agent-native/identity/callback",
+      ]) {
+        const result = await guard(createMockEvent({ path }));
+        expect(result).not.toBeUndefined();
+      }
+
+      // Env SET → both routes bypass the blanket guard so the handler can
+      // run its own signature/CSRF verification.
+      vi.stubEnv(
+        "AGENT_NATIVE_IDENTITY_HUB_URL",
+        "https://dispatch.agent-native.com",
+      );
+      for (const path of [
+        "/_agent-native/identity/login",
+        "/_agent-native/identity/callback",
+      ]) {
+        await expect(guard(createMockEvent({ path }))).resolves.toBeUndefined();
+      }
+    });
+
     it("serves mounted login and signup pages from the framework guard", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("APP_BASE_PATH", "/dispatch");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -521,6 +521,37 @@ export function getConfiguredLoginHtml(event: H3Event): string | null {
 }
 
 /**
+ * True only when the request originates from the local machine — the raw
+ * socket peer is `127.0.0.0/8`, `::1`, or the IPv4-mapped `::ffff:127.0.0.1`
+ * (an optional IPv6 zone id like `fe80::1%en0` is stripped first).
+ *
+ * `getRequestIP(event)` is called WITHOUT `{ xForwardedFor: true }`, so it
+ * returns the real connection peer and never an attacker-controlled
+ * `X-Forwarded-For` value — a remote client cannot spoof its way past this.
+ * Used to scope local-only conveniences (the desktop SSO broker and the dev
+ * auto-account) so a directly network-reachable dev server never exposes
+ * them to a remote visitor. NOTE: a reverse proxy / tunnel that connects to
+ * the dev server over localhost still appears as loopback, so this is a
+ * necessary but not sufficient gate — callers pair it with NODE_ENV and,
+ * for the dev account, a throwaway per-DB password.
+ */
+function isLoopbackRequest(event: H3Event): boolean {
+  let ip: string | undefined;
+  try {
+    ip = getRequestIP(event) ?? undefined;
+  } catch {
+    ip = undefined;
+  }
+  const normalised = (ip ?? "").split("%")[0];
+  return (
+    normalised === "127.0.0.1" ||
+    normalised === "::1" ||
+    normalised === "::ffff:127.0.0.1" ||
+    normalised.startsWith("127.")
+  );
+}
+
+/**
  * Read the desktop-SSO broker file, but only if the request is plausibly
  * from the Electron desktop app *and* coming from the local machine.
  *
@@ -539,21 +570,7 @@ async function readDesktopSsoSafely(
 ): Promise<Awaited<ReturnType<typeof readDesktopSso>>> {
   if (process.env.NODE_ENV === "production") return null;
   if (!isElectronRequest(event)) return null;
-  // Loopback-only: 127.0.0.1, ::1, and the IPv4-mapped form.
-  let ip: string | undefined;
-  try {
-    ip = getRequestIP(event) ?? undefined;
-  } catch {
-    ip = undefined;
-  }
-  // Strip an optional zone id (e.g. "fe80::1%en0") before comparing.
-  const normalised = (ip ?? "").split("%")[0];
-  const isLoopback =
-    normalised === "127.0.0.1" ||
-    normalised === "::1" ||
-    normalised === "::ffff:127.0.0.1" ||
-    normalised.startsWith("127.");
-  if (!isLoopback) return null;
+  if (!isLoopbackRequest(event)) return null;
   return await readDesktopSso();
 }
 
@@ -1463,7 +1480,8 @@ function createAuthGuardFn(): (
 // validator (a bare `dev@local` has no TLD and is rejected as INVALID_EMAIL,
 // which silently broke the zero-setup auto-sign-in on every fresh dev DB).
 const AUTO_DEV_ACCOUNT_EMAIL = "dev@local.test";
-const AUTO_DEV_ACCOUNT_PASSWORD = "local-dev-account";
+// No fixed password: maybeAutoCreateDevSession mints a random one per DB
+// and prints it to the console once (see there).
 
 // Pre-fix local dev DBs may already contain a `dev@local` user. Treat that
 // legacy address as the dev account too, so the "any real users?" check
@@ -1488,13 +1506,21 @@ const LEGACY_AUTO_DEV_ACCOUNT_EMAIL = "dev@local";
  * leaves the user on the regular sign-in form; without this guard the
  * post-logout reload would silently re-create the session.
  *
- * The fixed password is intentional: it means a developer who signs
- * out can sign back in with `dev@local.test` / `local-dev-account`
- * from the regular login form. To get the auto-flow back, drop the
- * user row or wipe the local DB. Set
- * `AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT=1` to opt out entirely
- * (useful for tests that exercise the unauthenticated branch). This
- * is local-only — the helper is gated on NODE_ENV.
+ * Hardening (this is a convenience, not an auth bypass — it uses the
+ * real Better Auth sign-up/sign-in, but a known-credential local account
+ * is still worth not shipping):
+ *  - **Loopback only.** Gated on `isLoopbackRequest`, so a tunnelled /
+ *    reverse-proxied / misconfigured-non-prod dev server never auto-signs
+ *    in a directly-remote visitor (mirrors the desktop SSO broker).
+ *  - **Random per-DB password.** The account password is freshly
+ *    generated on creation and printed to the server console exactly
+ *    once — there is no source-code-known credential. After logout the
+ *    auto-flow won't refire (dev row exists), so signing back in uses
+ *    that printed password; lost it ⇒ drop the row or wipe the local DB.
+ *  - **NODE_ENV.** Still gated on development/test.
+ *
+ * Set `AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT=1` to opt out entirely
+ * (useful for tests that exercise the unauthenticated branch).
  */
 async function maybeAutoCreateDevSession(
   event: H3Event,
@@ -1502,6 +1528,9 @@ async function maybeAutoCreateDevSession(
 ): Promise<Response | null> {
   if (!isDevEnvironment()) return null;
   if (process.env.AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT === "1") return null;
+  // Local machine only: never auto-sign-in a remote visitor, even if a
+  // dev server is exposed (tunnel, reverse proxy, misconfigured NODE_ENV).
+  if (!isLoopbackRequest(event)) return null;
 
   try {
     const db = getDbExec();
@@ -1533,14 +1562,22 @@ async function maybeAutoCreateDevSession(
     const auth = await getBetterAuth();
     if (!auth) return null;
 
-    // Idempotent sign-up: succeeds on first run, throws an "already exists"
-    // failure on subsequent runs (which we swallow before falling through
-    // to the sign-in path below).
+    // Random per-DB password — there is no source-code-known credential
+    // for this account. Printed once below so the developer can sign back
+    // in after logout (the auto-flow won't refire while the dev row
+    // exists).
+    const devPassword = crypto.randomBytes(18).toString("base64url");
+
+    // The dev account does not exist at this point (the devUsers check
+    // above returned early otherwise). The "already exists" swallow only
+    // matters under a rare concurrent first-hit race — in that case the
+    // sign-in below fails the password check and we return null, leaving
+    // the racing request that already won to keep the session.
     try {
       await auth.api.signUpEmail({
         body: {
           email: AUTO_DEV_ACCOUNT_EMAIL,
-          password: AUTO_DEV_ACCOUNT_PASSWORD,
+          password: devPassword,
           name: "Dev",
         },
       });
@@ -1551,13 +1588,24 @@ async function maybeAutoCreateDevSession(
     const result = await auth.api.signInEmail({
       body: {
         email: AUTO_DEV_ACCOUNT_EMAIL,
-        password: AUTO_DEV_ACCOUNT_PASSWORD,
+        password: devPassword,
       },
     });
     if (!result?.token) return null;
 
     setFrameworkSessionCookie(event, result.token);
     await addSession(result.token, AUTO_DEV_ACCOUNT_EMAIL);
+
+    // Print the throwaway credential exactly once so the developer can
+    // sign back in manually after logout (auto-flow won't refire once the
+    // dev row exists). Local console only — never Sentry.
+    console.log(
+      `\n[agent-native] Local dev auto-login ready.\n` +
+        `  email:    ${AUTO_DEV_ACCOUNT_EMAIL}\n` +
+        `  password: ${devPassword}\n` +
+        `  (random, this DB only — needed to sign back in after logout.\n` +
+        `   Set AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT=1 to disable.)\n`,
+    );
 
     // Emit the session cookie ON the 302 itself. Returning a bare
     // `new Response(...)` here drops the cookie staged on event.node.res

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -535,13 +535,8 @@ export function getConfiguredLoginHtml(event: H3Event): string | null {
  * necessary but not sufficient gate — callers pair it with NODE_ENV and,
  * for the dev account, a throwaway per-DB password.
  */
-function isLoopbackRequest(event: H3Event): boolean {
-  let ip: string | undefined;
-  try {
-    ip = getRequestIP(event) ?? undefined;
-  } catch {
-    ip = undefined;
-  }
+export function isLoopbackAddress(ip: string | undefined): boolean {
+  // Strip an optional IPv6 zone id (e.g. "fe80::1%en0") before comparing.
   const normalised = (ip ?? "").split("%")[0];
   return (
     normalised === "127.0.0.1" ||
@@ -549,6 +544,16 @@ function isLoopbackRequest(event: H3Event): boolean {
     normalised === "::ffff:127.0.0.1" ||
     normalised.startsWith("127.")
   );
+}
+
+function isLoopbackRequest(event: H3Event): boolean {
+  let ip: string | undefined;
+  try {
+    ip = getRequestIP(event) ?? undefined;
+  } catch {
+    ip = undefined;
+  }
+  return isLoopbackAddress(ip);
 }
 
 /**

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1288,6 +1288,32 @@ function createAuthGuardFn(): (
       return;
     }
 
+    // MCP connect — frictionless external-agent connection. Like /open
+    // above, the connect *page* resolves the browser session itself and
+    // serves its own login form when unauthenticated (so the post-login
+    // reload returns to the same URL, carrying the device user_code in the
+    // query). The two unauthenticated device endpoints below are the CLI's
+    // OAuth-style polling pair: `device/start` (mint a device+user code) and
+    // `device/poll` (exchange an approved code for the token) — both must be
+    // reachable without a browser session because the CLI has none. They are
+    // protected by short-TTL, single-use, crypto-random codes + a creation
+    // rate-limit, not cookies.
+    //
+    // Everything that MINTS or MUTATES on behalf of the user — `/token`,
+    // `/device/authorize`, `/tokens`, `/tokens/revoke` — is intentionally
+    // NOT bypassed: the guard's default 401-for-/_agent-native/* is the
+    // correct gate for them. Those are POSTed by the in-page fetch, which
+    // carries the session cookie, so the guard (which only 401s when there
+    // is no session) lets the authenticated same-origin request through and
+    // the handler then re-checks the session itself (defense in depth).
+    if (
+      p === "/_agent-native/mcp/connect" ||
+      p === "/_agent-native/mcp/connect/device/start" ||
+      p === "/_agent-native/mcp/connect/device/poll"
+    ) {
+      return;
+    }
+
     // Internal processor endpoint for the A2A async-mode fanout. Mirrors the
     // integration webhook fanout: when `message/send` is called with
     // `async: true`, the JSON-RPC handler enqueues to a2a_tasks and self-

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -101,6 +101,10 @@ import {
   verifyBuilderCallbackStateAndGetOwner,
   verifyBuilderConnectTokenAndGetOwner,
 } from "./builder-browser.js";
+// Pure env-read feature switch from a leaf module (no dependency back on
+// auth.ts), so the guard and the SSO route handler share one validator and
+// can never disagree about whether federated SSO is enabled.
+import { isIdentitySsoEnabled } from "./identity-sso-store.js";
 
 /**
  * Get the configured session max age. Desktop SSO broker writes from
@@ -675,7 +679,7 @@ const EXPECTED_AUTH_FAILURE_PATTERNS: RegExp[] = [
   /not\s+verified/i,
 ];
 
-function isExpectedAuthFailure(error: unknown): boolean {
+export function isExpectedAuthFailure(error: unknown): boolean {
   const msg = (error as { message?: unknown })?.message;
   if (typeof msg !== "string") return false;
   return EXPECTED_AUTH_FAILURE_PATTERNS.some((re) => re.test(msg));
@@ -1314,6 +1318,23 @@ function createAuthGuardFn(): (
       return;
     }
 
+    // Cross-app SSO ("Sign in with Agent-Native") — CLIENT side. Both the
+    // `/login` entry point and the `/callback` (hit by a user who is, by
+    // definition, NOT yet signed in to THIS app) must bypass the blanket
+    // 401-for-/_agent-native/*: they resolve / mint the browser session
+    // themselves and verify a signature-bound, single-use, CSRF-stated
+    // hub token — not a cookie. This bypass is GATED on the opt-in env var
+    // so an unset `AGENT_NATIVE_IDENTITY_HUB_URL` is a true no-op (the
+    // guard's behaviour is byte-for-byte unchanged when SSO is off). The
+    // handler itself 404s when disabled as defence in depth.
+    if (
+      isIdentitySsoEnabled() &&
+      (p === "/_agent-native/identity/login" ||
+        p === "/_agent-native/identity/callback")
+    ) {
+      return;
+    }
+
     // Internal processor endpoint for the A2A async-mode fanout. Mirrors the
     // integration webhook fanout: when `message/send` is called with
     // `async: true`, the JSON-RPC handler enqueues to a2a_tasks and self-
@@ -1538,10 +1559,11 @@ async function maybeAutoCreateDevSession(
     setFrameworkSessionCookie(event, result.token);
     await addSession(result.token, AUTO_DEV_ACCOUNT_EMAIL);
 
-    return new Response("", {
-      status: 302,
-      headers: { Location: redirectTo },
-    });
+    // Emit the session cookie ON the 302 itself. Returning a bare
+    // `new Response(...)` here drops the cookie staged on event.node.res
+    // (see redirectWithStagedCookies), so the developer would 302 to the
+    // app and immediately bounce back to the login form.
+    return redirectWithStagedCookies(event, redirectTo);
   } catch (e) {
     // Local-dev only — log to console for debugging, but don't surface
     // through Sentry. Falling back to the regular login form is the
@@ -1704,6 +1726,37 @@ export function setFrameworkSessionCookie(event: H3Event, token: string): void {
     path: "/",
     maxAge: sessionMaxAge,
   });
+}
+
+/**
+ * Build a redirect `Response` that carries whatever `Set-Cookie` headers were
+ * just staged on the event (e.g. by `setFrameworkSessionCookie`).
+ *
+ * h3 v2's `setCookie` appends the cookie onto `event.res.headers`. When a
+ * handler returns a plain object/string, h3's `prepareResponse` merges those
+ * staged headers into the synthesized response, so the cookie survives. But
+ * when a handler returns a web `Response`, `prepareResponse` only merges the
+ * staged headers if the Response is 2xx — its `!val.ok` early-return hands a
+ * non-2xx Response (like a 302) straight back WITHOUT merging. A bare
+ * `new Response("", { status: 302, headers: { Location } })` therefore 302s
+ * the browser with no session cookie, so the zero-setup dev auto-sign-in
+ * bounces straight back to the login form.
+ *
+ * Mirroring the staged cookies onto the redirect Response's own headers makes
+ * them part of the Response that's returned as-is, so the 302 actually
+ * carries the session cookie. (`event.res.headers` is also left intact for
+ * any non-Response continuation path; h3 only skips the merge for the
+ * Response branch, so there's no double-emit.)
+ */
+function redirectWithStagedCookies(
+  event: H3Event,
+  location: string,
+  status = 302,
+): Response {
+  const headers = new Headers({ Location: location });
+  const staged = event.res?.headers?.getSetCookie?.() ?? [];
+  for (const cookie of staged) headers.append("set-cookie", cookie);
+  return new Response("", { status, headers });
 }
 
 function isHttpsRequest(event: H3Event): boolean {

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -555,6 +555,64 @@ export function getBetterAuthSync(): BetterAuthInstance | undefined {
   return _auth;
 }
 
+/**
+ * The subset of Better Auth's internal adapter we use for federated-SSO
+ * JIT account linking. Better Auth owns these writes (id + timestamp +
+ * schema handling), so callers never hand-roll SQL against `user`/`account`.
+ * Read-only lookups + strictly-additive `linkAccount`/`createUser` only — no
+ * update/delete of existing identity rows.
+ */
+export interface BetterAuthInternalAdapter {
+  findUserByEmail: (
+    email: string,
+    options?: { includeAccounts: boolean },
+  ) => Promise<{
+    user: { id: string; email: string; name?: string };
+    accounts: Array<{ providerId: string; accountId: string }>;
+  } | null>;
+  linkAccount: (account: {
+    userId: string;
+    providerId: string;
+    accountId: string;
+  }) => Promise<unknown>;
+  createUser: (user: {
+    email: string;
+    name: string;
+    emailVerified?: boolean;
+  }) => Promise<{ id: string }>;
+}
+
+/**
+ * Resolve Better Auth's internal adapter via the live instance's
+ * `$context`. The framework's narrowed `BetterAuthInstance` interface omits
+ * `$context`, but the underlying object created by `betterAuth(...)` always
+ * exposes it (see Better Auth's `Auth` type) — so this is a safe, typed
+ * accessor for the federated-SSO client. Returns `undefined` if the context
+ * shape is unexpected (older/newer Better Auth) so callers can fall back.
+ */
+export async function getBetterAuthInternalAdapter(
+  config?: BetterAuthConfig,
+): Promise<BetterAuthInternalAdapter | undefined> {
+  const auth = (await getBetterAuth(config)) as unknown as {
+    $context?: Promise<{ internalAdapter?: BetterAuthInternalAdapter }>;
+  };
+  try {
+    const ctx = await auth.$context;
+    const ia = ctx?.internalAdapter;
+    if (
+      ia &&
+      typeof ia.findUserByEmail === "function" &&
+      typeof ia.linkAccount === "function" &&
+      typeof ia.createUser === "function"
+    ) {
+      return ia;
+    }
+  } catch {
+    // Context resolution failed — caller falls back to the signup path.
+  }
+  return undefined;
+}
+
 /** Reset for testing */
 export async function resetBetterAuth(): Promise<void> {
   _auth = undefined;

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -22,6 +22,8 @@ import path from "node:path";
 import { createPollHandler } from "./poll.js";
 import { createPollEventsHandler } from "./poll-events.js";
 import { createOpenRouteHandler } from "./open-route.js";
+import { handleMcpConnect } from "../mcp/connect-route.js";
+import { getAppName } from "./app-name.js";
 import { upsertEnvFile } from "./create-server.js";
 import type { EnvKeyConfig } from "./create-server.js";
 import { readBody } from "./h3-helpers.js";
@@ -302,6 +304,18 @@ export interface CoreRoutesPluginOptions {
   disableAppState?: boolean;
   /** Disable the /_agent-native/open deep-link route. */
   disableOpenRoute?: boolean;
+  /**
+   * Disable the /_agent-native/mcp/connect routes (browser Connect page +
+   * CLI device-code flow that mints per-user, revocable MCP tokens).
+   * Enabled by default — the routes are session-gated where they mint and
+   * back-compat with deployments that have no A2A_SECRET (they return a
+   * clear 503 instead of minting).
+   */
+  disableMcpConnect?: boolean;
+  /** Canonical app id (e.g. `mail`) for the MCP connect server name. */
+  mcpConnectAppId?: string;
+  /** Human app name shown on the MCP connect page. */
+  mcpConnectAppName?: string;
   /** Per-template override mapping deep-link params → client SPA path.
    *  See `createOpenRouteHandler`. */
   resolveOpenPath?: import("./open-route.js").OpenRouteOptions["resolveOpenPath"];
@@ -2502,6 +2516,32 @@ export function createCoreRoutesPlugin(
         return { error: "Method not allowed" };
       }),
     );
+
+    if (!options.disableMcpConnect) {
+      // Frictionless external-agent connection. A logged-in user mints a
+      // per-user, scoped, revocable MCP bearer token here — via the browser
+      // Connect page or the OAuth-style device-code flow a CLI drives — so
+      // they never copy a shared deployment secret. The handler resolves the
+      // browser session itself and serves its own login form (like /open)
+      // for the page + unauth device endpoints; the /token, /device/authorize,
+      // /tokens, /tokens/revoke subpaths require a session and 401 without it.
+      // The auth guard bypasses ONLY the page + device/start + device/poll
+      // (see createAuthGuardFn in auth.ts).
+      const mcpConnectOpts = {
+        appId: options.mcpConnectAppId,
+        appName: options.mcpConnectAppName ?? getAppName(),
+      };
+      getH3App(nitroApp).use(
+        `${P}/mcp/connect`,
+        defineEventHandler(async (event: H3Event) => {
+          // The framework strips the mount prefix from event.url.pathname,
+          // so what remains is the subpath after `/connect` (e.g. `/token`,
+          // `/device/start`, or `` for the page itself).
+          const subpath = event.url?.pathname || "";
+          return handleMcpConnect(event, subpath, mcpConnectOpts);
+        }),
+      );
+    }
 
     if (!options.disableOpenRoute) {
       // Stable deep-link route. External agents (MCP/A2A) surface

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -23,6 +23,8 @@ import { createPollHandler } from "./poll.js";
 import { createPollEventsHandler } from "./poll-events.js";
 import { createOpenRouteHandler } from "./open-route.js";
 import { handleMcpConnect } from "../mcp/connect-route.js";
+import { handleIdentitySso } from "./identity-sso.js";
+import { isIdentitySsoEnabled } from "./identity-sso-store.js";
 import { getAppName } from "./app-name.js";
 import { upsertEnvFile } from "./create-server.js";
 import type { EnvKeyConfig } from "./create-server.js";
@@ -2539,6 +2541,26 @@ export function createCoreRoutesPlugin(
           // `/device/start`, or `` for the page itself).
           const subpath = event.url?.pathname || "";
           return handleMcpConnect(event, subpath, mcpConnectOpts);
+        }),
+      );
+    }
+
+    // Cross-app SSO ("Sign in with Agent-Native") — CLIENT side. Mounted
+    // ONLY when `AGENT_NATIVE_IDENTITY_HUB_URL` is set, so an unset env var
+    // means the route is never even registered: zero new surface, existing
+    // auth byte-for-byte unchanged. `/login` 302s to the identity hub;
+    // `/callback` verifies the hub-issued A2A-signed identity JWT and JIT-
+    // links the verified email into this app's local Better Auth store. The
+    // handler 404s if disabled (defence in depth). The auth guard bypasses
+    // these two exact paths under the same env gate.
+    if (isIdentitySsoEnabled()) {
+      getH3App(nitroApp).use(
+        `${P}/identity`,
+        defineEventHandler(async (event: H3Event) => {
+          // Framework strips the mount prefix; what remains is the subpath
+          // after `/identity` (e.g. `/login`, `/callback`).
+          const subpath = event.url?.pathname || "";
+          return handleIdentitySso(event, subpath);
         }),
       );
     }

--- a/packages/core/src/server/identity-sso-store.spec.ts
+++ b/packages/core/src/server/identity-sso-store.spec.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * In-memory SQL simulator rich enough for the two identity-SSO tables. We
+ * pattern-match the small fixed set of statements the store issues — same
+ * approach as `mcp/connect-store.spec.ts`.
+ */
+interface StateRow {
+  state: string;
+  return_path: string | null;
+  created_at: number | null;
+  expires_at: number | null;
+  consumed_at: number | null;
+}
+let states: StateRow[] = [];
+let jtis: { jti: string; seen_at: number }[] = [];
+
+const exec = async (input: string | { sql: string; args?: unknown[] }) => {
+  const sql = (typeof input === "string" ? input : input.sql).trim();
+  const args = (typeof input === "string" ? [] : (input.args ?? [])) as any[];
+
+  if (/^CREATE TABLE/i.test(sql)) return { rows: [], rowsAffected: 0 };
+
+  // --- identity_sso_state ---
+  if (/^SELECT COUNT\(\*\) AS n FROM identity_sso_state/i.test(sql)) {
+    const since = args[0] as number;
+    const n = states.filter((s) => (s.created_at ?? 0) > since).length;
+    return { rows: [{ n }], rowsAffected: 0 };
+  }
+  if (/^INSERT INTO identity_sso_state/i.test(sql)) {
+    states.push({
+      state: args[0],
+      return_path: args[1],
+      created_at: args[2],
+      expires_at: args[3],
+      consumed_at: args[4],
+    });
+    return { rows: [], rowsAffected: 1 };
+  }
+  if (
+    /^SELECT state, return_path, expires_at, consumed_at FROM identity_sso_state WHERE state = \?/i.test(
+      sql,
+    )
+  ) {
+    const r = states.find((s) => s.state === args[0]);
+    return {
+      rows: r
+        ? [
+            {
+              state: r.state,
+              return_path: r.return_path,
+              expires_at: r.expires_at,
+              consumed_at: r.consumed_at,
+            },
+          ]
+        : [],
+      rowsAffected: 0,
+    };
+  }
+  if (
+    /^UPDATE identity_sso_state SET consumed_at = \? WHERE state = \? AND consumed_at IS NULL/i.test(
+      sql,
+    )
+  ) {
+    const r = states.find((s) => s.state === args[1]);
+    if (r && r.consumed_at == null) {
+      r.consumed_at = args[0];
+      return { rows: [], rowsAffected: 1 };
+    }
+    return { rows: [], rowsAffected: 0 };
+  }
+
+  // --- identity_sso_jti ---
+  if (/^INSERT INTO identity_sso_jti/i.test(sql)) {
+    if (jtis.some((j) => j.jti === args[0])) {
+      const e: any = new Error(
+        "UNIQUE constraint failed: identity_sso_jti.jti",
+      );
+      throw e;
+    }
+    jtis.push({ jti: args[0], seen_at: args[1] });
+    return { rows: [], rowsAffected: 1 };
+  }
+
+  throw new Error("unexpected SQL in test: " + sql);
+};
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => ({ execute: exec }),
+  isConnectionError: () => false,
+  intType: () => "INTEGER",
+}));
+
+const store = await import("./identity-sso-store.js");
+
+beforeEach(() => {
+  states = [];
+  jtis = [];
+});
+afterEach(() => {
+  delete process.env.AGENT_NATIVE_IDENTITY_HUB_URL;
+});
+
+describe("getIdentityHubUrl / isIdentitySsoEnabled", () => {
+  it("returns undefined / false when the env is unset", () => {
+    delete process.env.AGENT_NATIVE_IDENTITY_HUB_URL;
+    expect(store.getIdentityHubUrl()).toBeUndefined();
+    expect(store.isIdentitySsoEnabled()).toBe(false);
+  });
+
+  it("normalises a valid https URL and strips trailing slashes", () => {
+    process.env.AGENT_NATIVE_IDENTITY_HUB_URL =
+      "https://dispatch.agent-native.com/";
+    expect(store.getIdentityHubUrl()).toBe("https://dispatch.agent-native.com");
+    expect(store.isIdentitySsoEnabled()).toBe(true);
+  });
+
+  it("treats a malformed value as OFF (no throw)", () => {
+    process.env.AGENT_NATIVE_IDENTITY_HUB_URL = "not a url";
+    expect(store.getIdentityHubUrl()).toBeUndefined();
+    expect(store.isIdentitySsoEnabled()).toBe(false);
+  });
+
+  it("rejects a non-http(s) scheme", () => {
+    process.env.AGENT_NATIVE_IDENTITY_HUB_URL = "javascript:alert(1)";
+    expect(store.getIdentityHubUrl()).toBeUndefined();
+  });
+});
+
+describe("CSRF state — single use + expiry", () => {
+  it("a freshly minted state is consumable exactly once", async () => {
+    const s = await store.createSsoState("/inbox");
+    const first = await store.consumeSsoState(s);
+    expect(first).toEqual({ ok: true, returnPath: "/inbox" });
+    const second = await store.consumeSsoState(s);
+    expect(second.ok).toBe(false);
+  });
+
+  it("an unknown state is rejected", async () => {
+    expect((await store.consumeSsoState("nope")).ok).toBe(false);
+    expect((await store.consumeSsoState("")).ok).toBe(false);
+  });
+
+  it("an expired state is rejected", async () => {
+    const s = await store.createSsoState(null);
+    // Force the stored row to be expired.
+    states[0].expires_at = Date.now() - 1000;
+    expect((await store.consumeSsoState(s)).ok).toBe(false);
+  });
+});
+
+describe("jti replay guard", () => {
+  it("first sighting is not a replay; the second is", async () => {
+    expect(await store.isJtiReplayed("abc")).toBe(false);
+    expect(await store.isJtiReplayed("abc")).toBe(true);
+  });
+
+  it("an undefined jti is never treated as a replay", async () => {
+    expect(await store.isJtiReplayed(undefined)).toBe(false);
+    expect(await store.isJtiReplayed(undefined)).toBe(false);
+  });
+});

--- a/packages/core/src/server/identity-sso-store.ts
+++ b/packages/core/src/server/identity-sso-store.ts
@@ -1,0 +1,263 @@
+/**
+ * Framework-table store for the cross-app SSO ("Sign in with Agent-Native")
+ * CLIENT side. Backs two pieces of the federated login round-trip:
+ *
+ *   - `identity_sso_state` — short-lived (10 min), single-use, crypto-random
+ *     CSRF `state` values. Minted at `/_agent-native/identity/login`,
+ *     consumed exactly once at `/_agent-native/identity/callback`. Carries an
+ *     optional same-origin `return` path so the user lands back where they
+ *     started after federated sign-in.
+ *   - `identity_sso_jti` — replayed-token guard. The hub-issued identity JWT
+ *     carries a random `jti`; the first callback that verifies a given `jti`
+ *     records it here, and any later callback that presents the same `jti`
+ *     is rejected. Best-effort: a DB blip never widens the trust boundary
+ *     (signature + exp + scope + single-use state are still enforced), it
+ *     only relaxes the extra replay gate.
+ *
+ * Mirrors `mcp/connect-store.ts`: lazy `ensureTable()`, `getDbExec()`,
+ * dialect-agnostic SQL via `intType()`, `isConnectionError()` swallow so a
+ * transient Neon WS drop never 500s. `CREATE TABLE IF NOT EXISTS` only —
+ * strictly additive, never DROP / ALTER (shared prod DB rule).
+ *
+ * Node-only (crypto), bundled alongside the other framework auth modules.
+ */
+
+import { getDbExec, isConnectionError, intType } from "../db/client.js";
+import { randomBytes } from "node:crypto";
+
+let _initPromise: Promise<void> | undefined;
+
+// ---------------------------------------------------------------------------
+// Feature switch — the SINGLE source of truth for whether the federated-SSO
+// client is active. Lives here (a leaf module with no dependency on auth.ts)
+// so BOTH the auth guard and the route handler import the identical
+// validator and can never drift. Pure env read, no I/O — safe on the guard
+// hot path.
+// ---------------------------------------------------------------------------
+
+/**
+ * Read + normalise `AGENT_NATIVE_IDENTITY_HUB_URL`. Returns `undefined`
+ * (feature OFF) unless it is set to a syntactically valid http(s) URL. A
+ * malformed value is treated as OFF rather than throwing, so a typo can
+ * never brick an app's login — it just behaves as if SSO were unconfigured.
+ */
+export function getIdentityHubUrl(): string | undefined {
+  const raw = process.env.AGENT_NATIVE_IDENTITY_HUB_URL?.trim();
+  if (!raw) return undefined;
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== "https:" && u.protocol !== "http:") return undefined;
+    return `${u.protocol}//${u.host}${u.pathname}`.replace(/\/+$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Whether the federated-SSO client is active. When false, NOTHING in the
+ * SSO module has any effect: the route 404s, the guard bypass is inert, the
+ * login button is not rendered. This is the single switch the
+ * env-unset-no-op invariant is asserted against.
+ */
+export function isIdentitySsoEnabled(): boolean {
+  return !!getIdentityHubUrl();
+}
+
+/**
+ * The conditional "Sign in with Agent-Native" entry injected into the login
+ * page — ONLY when the feature is enabled. Returns an empty string when
+ * disabled so the login HTML is byte-for-byte identical to today's output
+ * with the env unset (asserted by the env-unset-no-op regression test). Pure
+ * string builder, no I/O — safe to call during HTML render. Lives in this
+ * leaf module so `onboarding-html.ts` can import it without creating an
+ * `auth.ts` ↔ `identity-sso.ts` import cycle.
+ */
+export function identitySsoLoginButtonHtml(): string {
+  if (!isIdentitySsoEnabled()) return "";
+  return (
+    `\n  <a class="btn-identity-sso" id="identity-sso-btn" ` +
+    `href="/_agent-native/identity/login" ` +
+    `style="display:flex;align-items:center;justify-content:center;gap:0.5rem;` +
+    `width:100%;padding:0.7rem 1rem;margin-bottom:0.75rem;border-radius:8px;` +
+    `border:1px solid rgba(255,255,255,0.18);background:transparent;` +
+    `color:inherit;font:inherit;font-weight:600;text-decoration:none;` +
+    `cursor:pointer">Sign in with Agent-Native</a>\n`
+  );
+}
+
+/** CSRF state values are valid for 10 minutes. */
+export const SSO_STATE_TTL_MS = 10 * 60_000;
+
+/**
+ * Rate limit for `identity/login`: at most this many state rows may be
+ * created within `SSO_LOGIN_WINDOW_MS`. The endpoint is reachable without a
+ * session (it's the entry point), so keep a coarse global cap to stop table
+ * flooding without per-IP plumbing.
+ */
+export const SSO_LOGIN_MAX = 60;
+export const SSO_LOGIN_WINDOW_MS = 60_000;
+
+async function ensureTable(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = (async () => {
+      const client = getDbExec();
+      // Additive only. Never DROP / ALTER — this DB is shared across every
+      // deploy context (preview/branch/prod) for hosted templates.
+      await client.execute(`
+        CREATE TABLE IF NOT EXISTS identity_sso_state (
+          state TEXT PRIMARY KEY,
+          return_path TEXT,
+          created_at ${intType()},
+          expires_at ${intType()},
+          consumed_at ${intType()}
+        )
+      `);
+      await client.execute(`
+        CREATE TABLE IF NOT EXISTS identity_sso_jti (
+          jti TEXT PRIMARY KEY,
+          seen_at ${intType()}
+        )
+      `);
+    })().catch((err) => {
+      // Don't cache a rejection — let the next caller retry a fresh init.
+      _initPromise = undefined;
+      throw err;
+    });
+  }
+  return _initPromise;
+}
+
+function numOrNull(v: unknown): number | null {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+// ---------------------------------------------------------------------------
+// CSRF state
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint a fresh crypto-random `state` value, persist it with an optional
+ * same-origin return path, and return it. Rate-limited at creation: at most
+ * `SSO_LOGIN_MAX` rows within `SSO_LOGIN_WINDOW_MS`. Throws `RATE_LIMITED`
+ * when the cap is exceeded so the route can map it to a 429.
+ */
+export async function createSsoState(
+  returnPath: string | null,
+): Promise<string> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+
+  try {
+    const { rows } = await client.execute({
+      sql: `SELECT COUNT(*) AS n FROM identity_sso_state WHERE created_at > ?`,
+      args: [now - SSO_LOGIN_WINDOW_MS],
+    });
+    const n = Number(rows[0]?.n ?? rows[0]?.["COUNT(*)"] ?? 0);
+    if (Number.isFinite(n) && n >= SSO_LOGIN_MAX) {
+      throw new Error("RATE_LIMITED");
+    }
+  } catch (err: any) {
+    if (err?.message === "RATE_LIMITED") throw err;
+    // A read failure must not block legitimate logins — single-use +
+    // short-TTL state is the primary protection. Continue.
+  }
+
+  const state = randomBytes(32).toString("base64url");
+  const expiresAt = now + SSO_STATE_TTL_MS;
+  await client.execute({
+    sql: `INSERT INTO identity_sso_state (state, return_path, created_at, expires_at, consumed_at) VALUES (?, ?, ?, ?, ?)`,
+    args: [state, returnPath ?? null, now, expiresAt, null],
+  });
+  return state;
+}
+
+export interface SsoStateConsumeResult {
+  ok: boolean;
+  returnPath: string | null;
+}
+
+/**
+ * Atomically consume a `state` value. Returns `{ ok: true, returnPath }` only
+ * when the state existed, had not expired, and had not been consumed before —
+ * and this call is the one that transitioned it to consumed (single-use,
+ * enforced via a conditional UPDATE so a double callback can't both pass).
+ * Any other condition returns `{ ok: false }`.
+ */
+export async function consumeSsoState(
+  state: string,
+): Promise<SsoStateConsumeResult> {
+  if (!state) return { ok: false, returnPath: null };
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+
+  const { rows } = await client.execute({
+    sql: `SELECT state, return_path, expires_at, consumed_at FROM identity_sso_state WHERE state = ?`,
+    args: [state],
+  });
+  if (rows.length === 0) return { ok: false, returnPath: null };
+  const row: any = rows[0];
+  const expiresAt = numOrNull(row.expires_at ?? row.expiresAt);
+  const consumedAt = numOrNull(row.consumed_at ?? row.consumedAt);
+  if (consumedAt != null) return { ok: false, returnPath: null };
+  if (expiresAt != null && expiresAt < now) {
+    return { ok: false, returnPath: null };
+  }
+
+  // Single-use: only the caller that flips `consumed_at` from NULL wins.
+  const result = await client.execute({
+    sql: `UPDATE identity_sso_state SET consumed_at = ? WHERE state = ? AND consumed_at IS NULL`,
+    args: [now, state],
+  });
+  if (result.rowsAffected === 0) {
+    // Lost the race to a concurrent callback — treat as already consumed.
+    return { ok: false, returnPath: null };
+  }
+  const returnPath = (row.return_path ?? row.returnPath ?? null) as
+    | string
+    | null;
+  return { ok: true, returnPath };
+}
+
+// ---------------------------------------------------------------------------
+// Replay (jti) guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the given identity-token `jti` has already been seen
+ * (i.e. this is a replay). On the first sighting, records the `jti` and
+ * returns false. Best-effort: a store/DB error returns `false` (not a
+ * replay) so a transient Neon WS drop never blocks a legitimate first-time
+ * sign-in — signature + exp + scope + single-use CSRF state remain the hard
+ * gates; this only adds defence in depth against token replay.
+ */
+export async function isJtiReplayed(jti: string | undefined): Promise<boolean> {
+  if (!jti) return false;
+  try {
+    await ensureTable();
+    const client = getDbExec();
+    const result = await client.execute({
+      sql: `INSERT INTO identity_sso_jti (jti, seen_at) VALUES (?, ?)`,
+      args: [jti, Date.now()],
+    });
+    // A successful insert means this jti was never seen → not a replay.
+    return result.rowsAffected === 0;
+  } catch (err) {
+    // Primary-key conflict = the jti already exists = replay.
+    const msg = String((err as any)?.message ?? "").toLowerCase();
+    if (
+      msg.includes("unique") ||
+      msg.includes("duplicate") ||
+      msg.includes("constraint")
+    ) {
+      return true;
+    }
+    // Any other error (incl. connection blips): fail open — do not block a
+    // legitimate first sign-in over a transient DB issue.
+    if (isConnectionError(err)) return false;
+    return false;
+  }
+}

--- a/packages/core/src/server/identity-sso.spec.ts
+++ b/packages/core/src/server/identity-sso.spec.ts
@@ -1,0 +1,469 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as jose from "jose";
+
+// --- h3 mock (mirror sibling specs) ---
+vi.mock("h3", () => ({
+  getMethod: (event: any) => event.method ?? "GET",
+  getHeader: (event: any, name: string) =>
+    event.headers?.[name.toLowerCase()] ?? event.headers?.[name],
+}));
+
+// --- auth.js mock: getSession + the two pure helpers we re-use ---
+const getSessionMock = vi.fn();
+const isExpectedAuthFailureMock = vi.fn((e: any) =>
+  /already\s+exists|user\s+already/i.test(String(e?.message ?? "")),
+);
+vi.mock("./auth.js", () => ({
+  getSession: (...a: any[]) => getSessionMock(...a),
+  // Real same-origin validator behaviour is exercised by auth.spec.ts; here
+  // we just need a faithful-enough stand-in for the redirect target.
+  safeReturnPath: (raw: string | null | undefined) => {
+    if (!raw) return "/";
+    if (/[\x00-\x1f]/.test(raw)) return "/";
+    try {
+      const u = new URL(raw, "http://safe-base.invalid");
+      if (u.origin !== "http://safe-base.invalid") return "/";
+      return u.pathname + u.search + u.hash;
+    } catch {
+      return "/";
+    }
+  },
+  isExpectedAuthFailure: (...a: any[]) => isExpectedAuthFailureMock(...a),
+}));
+
+// --- google-oauth.js mock: the literal session-mint path we re-use ---
+const createOAuthSessionMock = vi.fn(async () => ({
+  sessionToken: "fresh-session-token",
+}));
+vi.mock("./google-oauth.js", () => ({
+  createOAuthSession: (...a: any[]) => createOAuthSessionMock(...a),
+  getOrigin: (event: any) =>
+    `https://${event.headers?.host ?? "mail.agent-native.com"}`,
+}));
+
+vi.mock("./app-name.js", () => ({ getAppName: () => "mail" }));
+
+// --- Better Auth: signUpEmail (new-user path) + internal adapter ---
+const signUpEmailMock = vi.fn(async () => ({}));
+const adapterUsers: Array<{
+  id: string;
+  email: string;
+  accounts: Array<{ providerId: string; accountId: string }>;
+}> = [];
+const linkAccountMock = vi.fn(async (a: any) => {
+  const u = adapterUsers.find((x) => x.id === a.userId);
+  if (u) u.accounts.push({ providerId: a.providerId, accountId: a.accountId });
+  return {};
+});
+const findUserByEmailMock = vi.fn(async (email: string) => {
+  const u = adapterUsers.find((x) => x.email === email);
+  return u
+    ? { user: { id: u.id, email: u.email }, accounts: u.accounts }
+    : null;
+});
+vi.mock("./better-auth-instance.js", () => ({
+  getBetterAuth: async () => ({
+    api: { signUpEmail: (...a: any[]) => signUpEmailMock(...a) },
+  }),
+  getBetterAuthInternalAdapter: async () => ({
+    findUserByEmail: (...a: any[]) => findUserByEmailMock(...a),
+    linkAccount: (...a: any[]) => linkAccountMock(...a),
+    createUser: vi.fn(),
+  }),
+}));
+
+// --- store mock: in-memory CSRF state + jti, real feature switch ---
+const stateRows = new Map<
+  string,
+  { returnPath: string | null; consumed: boolean; expired: boolean }
+>();
+const jtiSeen = new Set<string>();
+let nextState = "state-0";
+vi.mock("./identity-sso-store.js", () => ({
+  getIdentityHubUrl: () => {
+    const raw = process.env.AGENT_NATIVE_IDENTITY_HUB_URL?.trim();
+    if (!raw) return undefined;
+    try {
+      const u = new URL(raw);
+      if (u.protocol !== "https:" && u.protocol !== "http:") return undefined;
+      return `${u.protocol}//${u.host}${u.pathname}`.replace(/\/+$/, "");
+    } catch {
+      return undefined;
+    }
+  },
+  isIdentitySsoEnabled: () => !!process.env.AGENT_NATIVE_IDENTITY_HUB_URL,
+  identitySsoLoginButtonHtml: () =>
+    process.env.AGENT_NATIVE_IDENTITY_HUB_URL ? "<a>sso</a>" : "",
+  createSsoState: vi.fn(async (returnPath: string | null) => {
+    const s = nextState;
+    nextState = `state-${stateRows.size + 1}`;
+    stateRows.set(s, { returnPath, consumed: false, expired: false });
+    return s;
+  }),
+  consumeSsoState: vi.fn(async (state: string) => {
+    const row = stateRows.get(state);
+    if (!row || row.consumed || row.expired)
+      return { ok: false, returnPath: null };
+    row.consumed = true;
+    return { ok: true, returnPath: row.returnPath };
+  }),
+  isJtiReplayed: vi.fn(async (jti: string | undefined) => {
+    if (!jti) return false;
+    if (jtiSeen.has(jti)) return true;
+    jtiSeen.add(jti);
+    return false;
+  }),
+}));
+
+const { handleIdentitySso } = await import("./identity-sso.js");
+
+const HUB = "https://dispatch.agent-native.com";
+const SECRET = "test-a2a-secret";
+
+function ev(opts: { method?: string; path?: string; host?: string }): any {
+  const path = opts.path ?? "/";
+  return {
+    method: opts.method ?? "GET",
+    headers: { host: opts.host ?? "mail.agent-native.com" },
+    node: { req: { url: path } },
+    path,
+    url: { pathname: path.split("?")[0] },
+  };
+}
+
+async function signIdentity(
+  claims: Record<string, unknown>,
+  opts: { secret?: string; expiresIn?: string; iat?: number } = {},
+): Promise<string> {
+  const b = new jose.SignJWT(claims)
+    .setProtectedHeader({ alg: "HS256" })
+    .setExpirationTime(opts.expiresIn ?? "5m");
+  if (opts.iat !== undefined) b.setIssuedAt(opts.iat);
+  else b.setIssuedAt();
+  return b.sign(new TextEncoder().encode(opts.secret ?? SECRET));
+}
+
+beforeEach(() => {
+  stateRows.clear();
+  jtiSeen.clear();
+  adapterUsers.length = 0;
+  nextState = "state-0";
+  getSessionMock.mockReset();
+  getSessionMock.mockResolvedValue(null);
+  signUpEmailMock.mockClear();
+  linkAccountMock.mockClear();
+  findUserByEmailMock.mockClear();
+  createOAuthSessionMock.mockClear();
+  process.env.A2A_SECRET = SECRET;
+  process.env.AGENT_NATIVE_IDENTITY_HUB_URL = HUB;
+});
+afterEach(() => {
+  delete process.env.A2A_SECRET;
+  delete process.env.AGENT_NATIVE_IDENTITY_HUB_URL;
+});
+
+describe("identity SSO — env-unset is a no-op", () => {
+  it("404s every subpath when AGENT_NATIVE_IDENTITY_HUB_URL is unset", async () => {
+    delete process.env.AGENT_NATIVE_IDENTITY_HUB_URL;
+    for (const p of ["/login", "/callback", "/", "/anything"]) {
+      const res = await handleIdentitySso(ev({ path: p }), p);
+      expect(res.status).toBe(404);
+    }
+    // No session minted, no Better Auth touched, no state created.
+    expect(createOAuthSessionMock).not.toHaveBeenCalled();
+    expect(signUpEmailMock).not.toHaveBeenCalled();
+    expect(stateRows.size).toBe(0);
+  });
+
+  it("the conditional login button is empty when disabled and present when enabled", async () => {
+    const mod = await import("./identity-sso-store.js");
+    delete process.env.AGENT_NATIVE_IDENTITY_HUB_URL;
+    expect(mod.identitySsoLoginButtonHtml()).toBe("");
+    process.env.AGENT_NATIVE_IDENTITY_HUB_URL = HUB;
+    expect(mod.identitySsoLoginButtonHtml()).not.toBe("");
+  });
+});
+
+describe("identity SSO — /login", () => {
+  it("302s to the hub authorize endpoint with app, redirect_uri and state", async () => {
+    const res = await handleIdentitySso(
+      ev({ path: "/login?return=/inbox" }),
+      "/login",
+    );
+    expect(res.status).toBe(302);
+    const loc = res.headers.get("Location")!;
+    expect(loc.startsWith(`${HUB}/_agent-native/identity/authorize`)).toBe(
+      true,
+    );
+    const u = new URL(loc);
+    expect(u.searchParams.get("app")).toBe("mail");
+    expect(u.searchParams.get("redirect_uri")).toBe(
+      "https://mail.agent-native.com/_agent-native/identity/callback",
+    );
+    expect(u.searchParams.get("state")).toBeTruthy();
+    expect(stateRows.size).toBe(1);
+  });
+
+  it("skips the round-trip and 302s to the return path when already signed in", async () => {
+    getSessionMock.mockResolvedValue({ email: "a@b.com" });
+    const res = await handleIdentitySso(
+      ev({ path: "/login?return=/inbox" }),
+      "/login",
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/inbox");
+    expect(stateRows.size).toBe(0);
+  });
+});
+
+describe("identity SSO — /callback rejects bad tokens", () => {
+  async function mintState(returnPath: string | null = null): Promise<string> {
+    const store = await import("./identity-sso-store.js");
+    return store.createSsoState(returnPath);
+  }
+
+  it("rejects a bad signature", async () => {
+    const state = await mintState();
+    const token = await signIdentity(
+      { email: "x@y.com", scope: "identity", jti: "j1" },
+      { secret: "WRONG-SECRET" },
+    );
+    const res = await handleIdentitySso(
+      ev({ path: `/callback?token=${token}&state=${state}` }),
+      "/callback",
+    );
+    expect(res.status).toBe(400);
+    expect(createOAuthSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an expired token", async () => {
+    const state = await mintState();
+    const token = await signIdentity(
+      { email: "x@y.com", scope: "identity", jti: "j2" },
+      { expiresIn: "-1m" },
+    );
+    const res = await handleIdentitySso(
+      ev({ path: `/callback?token=${token}&state=${state}` }),
+      "/callback",
+    );
+    expect(res.status).toBe(400);
+    expect(createOAuthSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects the wrong scope (an A2A delegation token)", async () => {
+    const state = await mintState();
+    const token = await signIdentity({
+      email: "x@y.com",
+      scope: "mcp-connect",
+      jti: "j3",
+    });
+    const res = await handleIdentitySso(
+      ev({ path: `/callback?token=${token}&state=${state}` }),
+      "/callback",
+    );
+    expect(res.status).toBe(400);
+    expect(createOAuthSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing/unknown CSRF state", async () => {
+    const token = await signIdentity({
+      email: "x@y.com",
+      scope: "identity",
+      jti: "j4",
+    });
+    const res = await handleIdentitySso(
+      ev({ path: `/callback?token=${token}&state=does-not-exist` }),
+      "/callback",
+    );
+    expect(res.status).toBe(400);
+    expect(createOAuthSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a replayed (reused) CSRF state", async () => {
+    const state = await mintState();
+    const t1 = await signIdentity({
+      email: "x@y.com",
+      scope: "identity",
+      jti: "ra",
+    });
+    const ok = await handleIdentitySso(
+      ev({ path: `/callback?token=${t1}&state=${state}` }),
+      "/callback",
+    );
+    expect(ok.status).toBe(302);
+    // Same state again → rejected.
+    const t2 = await signIdentity({
+      email: "x@y.com",
+      scope: "identity",
+      jti: "rb",
+    });
+    const res = await handleIdentitySso(
+      ev({ path: `/callback?token=${t2}&state=${state}` }),
+      "/callback",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a replayed jti even with a fresh valid state", async () => {
+    const s1 = await mintState();
+    const tok = await signIdentity({
+      email: "x@y.com",
+      scope: "identity",
+      jti: "dup-jti",
+    });
+    expect(
+      (
+        await handleIdentitySso(
+          ev({ path: `/callback?token=${tok}&state=${s1}` }),
+          "/callback",
+        )
+      ).status,
+    ).toBe(302);
+    const s2 = await mintState();
+    const tok2 = await signIdentity({
+      email: "x@y.com",
+      scope: "identity",
+      jti: "dup-jti",
+    });
+    const res = await handleIdentitySso(
+      ev({ path: `/callback?token=${tok2}&state=${s2}` }),
+      "/callback",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("never trusts a query-param email — identity comes only from the verified token", async () => {
+    const state = await mintState();
+    // Token says alice; query says attacker.
+    const token = await signIdentity({
+      email: "alice@corp.com",
+      scope: "identity",
+      jti: "qp",
+    });
+    const res = await handleIdentitySso(
+      ev({
+        path: `/callback?token=${token}&state=${state}&email=attacker@evil.com`,
+      }),
+      "/callback",
+    );
+    expect(res.status).toBe(302);
+    // Session minted for the VERIFIED email, not the query param.
+    expect(createOAuthSessionMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "alice@corp.com",
+      expect.objectContaining({ hasProductionSession: false }),
+    );
+  });
+});
+
+describe("identity SSO — JIT link semantics", () => {
+  it("EXISTING email → adds the federated account link, never mutates the user, logs into the SAME user id", async () => {
+    adapterUsers.push({
+      id: "user-existing-1",
+      email: "existing@corp.com",
+      accounts: [{ providerId: "credential", accountId: "existing@corp.com" }],
+    });
+    const store = await import("./identity-sso-store.js");
+    const state = await store.createSsoState(null);
+    const token = await signIdentity({
+      email: "existing@corp.com",
+      sub: "hub-sub-123",
+      scope: "identity",
+      jti: "e1",
+      name: "Existing User",
+    });
+    const res = await handleIdentitySso(
+      ev({ path: `/callback?token=${token}&state=${state}` }),
+      "/callback",
+    );
+    expect(res.status).toBe(302);
+
+    // New user path NOT taken — no signup for an existing email.
+    expect(signUpEmailMock).not.toHaveBeenCalled();
+    // The federated link was added additively via Better Auth's adapter.
+    expect(linkAccountMock).toHaveBeenCalledWith({
+      userId: "user-existing-1",
+      providerId: "agent-native",
+      accountId: "hub-sub-123",
+    });
+    // Original user row untouched: same id, email, and its pre-existing
+    // credential account is still present (only an additive row was added).
+    const u = adapterUsers.find((x) => x.id === "user-existing-1")!;
+    expect(u.email).toBe("existing@corp.com");
+    expect(u.accounts).toContainEqual({
+      providerId: "credential",
+      accountId: "existing@corp.com",
+    });
+    expect(u.accounts).toContainEqual({
+      providerId: "agent-native",
+      accountId: "hub-sub-123",
+    });
+    // Session minted for the SAME user's email via the Google-OAuth path.
+    expect(createOAuthSessionMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "existing@corp.com",
+      expect.objectContaining({ hasProductionSession: false }),
+    );
+  });
+
+  it("EXISTING email already linked → no duplicate link, still mints a session", async () => {
+    adapterUsers.push({
+      id: "u2",
+      email: "linked@corp.com",
+      accounts: [{ providerId: "agent-native", accountId: "linked@corp.com" }],
+    });
+    const store = await import("./identity-sso-store.js");
+    const state = await store.createSsoState(null);
+    const token = await signIdentity({
+      email: "linked@corp.com",
+      scope: "identity",
+      jti: "l1",
+    });
+    const res = await handleIdentitySso(
+      ev({ path: `/callback?token=${token}&state=${state}` }),
+      "/callback",
+    );
+    expect(res.status).toBe(302);
+    expect(linkAccountMock).not.toHaveBeenCalled();
+    expect(createOAuthSessionMock).toHaveBeenCalled();
+  });
+
+  it("NEW email → creates the user via the app's own signUpEmail path, then sessions", async () => {
+    // findUserByEmail starts empty; after signUpEmail the test adapter
+    // 'creates' the row so the post-create lookup resolves.
+    signUpEmailMock.mockImplementation(async (opts: any) => {
+      adapterUsers.push({
+        id: "new-user-9",
+        email: opts.body.email,
+        accounts: [{ providerId: "credential", accountId: opts.body.email }],
+      });
+      return {};
+    });
+    const store = await import("./identity-sso-store.js");
+    const state = await store.createSsoState("/welcome");
+    const token = await signIdentity({
+      email: "brand-new@corp.com",
+      scope: "identity",
+      jti: "n1",
+      name: "Brand New",
+    });
+    const res = await handleIdentitySso(
+      ev({ path: `/callback?token=${token}&state=${state}` }),
+      "/callback",
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/welcome");
+    // Created via the SAME Better Auth signup API the app already uses.
+    expect(signUpEmailMock).toHaveBeenCalledWith({
+      body: expect.objectContaining({
+        email: "brand-new@corp.com",
+        name: "Brand New",
+      }),
+    });
+    expect(createOAuthSessionMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "brand-new@corp.com",
+      expect.objectContaining({ hasProductionSession: false }),
+    );
+  });
+});

--- a/packages/core/src/server/identity-sso.spec.ts
+++ b/packages/core/src/server/identity-sso.spec.ts
@@ -135,7 +135,12 @@ async function signIdentity(
   claims: Record<string, unknown>,
   opts: { secret?: string; expiresIn?: string; iat?: number } = {},
 ): Promise<string> {
-  const b = new jose.SignJWT(claims)
+  const b = new jose.SignJWT({
+    aud: "https://mail.agent-native.com/_agent-native/identity/callback",
+    redirect_uri:
+      "https://mail.agent-native.com/_agent-native/identity/callback",
+    ...claims,
+  })
     .setProtectedHeader({ alg: "HS256" })
     .setExpirationTime(opts.expiresIn ?? "5m");
   if (opts.iat !== undefined) b.setIssuedAt(opts.iat);
@@ -257,6 +262,43 @@ describe("identity SSO — /callback rejects bad tokens", () => {
       scope: "mcp-connect",
       jti: "j3",
     });
+    const res = await handleIdentitySso(
+      ev({ path: `/callback?token=${token}&state=${state}` }),
+      "/callback",
+    );
+    expect(res.status).toBe(400);
+    expect(createOAuthSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a token minted for another app callback", async () => {
+    const state = await mintState();
+    const token = await signIdentity({
+      email: "x@y.com",
+      scope: "identity",
+      jti: "wrong-aud",
+      aud: "https://calendar.agent-native.com/_agent-native/identity/callback",
+      redirect_uri:
+        "https://calendar.agent-native.com/_agent-native/identity/callback",
+    });
+    const res = await handleIdentitySso(
+      ev({ path: `/callback?token=${token}&state=${state}` }),
+      "/callback",
+    );
+    expect(res.status).toBe(400);
+    expect(createOAuthSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a legacy identity token without an audience", async () => {
+    const state = await mintState();
+    const token = await new jose.SignJWT({
+      email: "x@y.com",
+      scope: "identity",
+      jti: "missing-aud",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(new TextEncoder().encode(SECRET));
     const res = await handleIdentitySso(
       ev({ path: `/callback?token=${token}&state=${state}` }),
       "/callback",

--- a/packages/core/src/server/identity-sso.ts
+++ b/packages/core/src/server/identity-sso.ts
@@ -111,8 +111,19 @@ function html(body: string, status = 200): Response {
   });
 }
 
-function redirect(location: string): Response {
-  return new Response("", { status: 302, headers: { Location: location } });
+function redirect(event: H3Event, location: string): Response {
+  // Mirror any Set-Cookie staged on the event (e.g. the framework session
+  // cookie set by `createOAuthSession`) onto the 302. h3 v2's
+  // `prepareResponse` only merges staged Set-Cookie into a *2xx* web
+  // Response and drops them for non-2xx — so a bare
+  // `new Response("", { status: 302 })` here would silently lose the
+  // session cookie and the user would finish "Sign in with Agent-Native"
+  // still logged out. This mirrors the framework's `redirectWithStagedCookies`
+  // (auth.ts) exactly; it is a no-op when nothing is staged.
+  const headers = new Headers({ Location: location });
+  const staged = (event as any).res?.headers?.getSetCookie?.() ?? [];
+  for (const cookie of staged) headers.append("set-cookie", cookie);
+  return new Response("", { status: 302, headers });
 }
 
 /**
@@ -355,7 +366,7 @@ export async function handleIdentitySso(
       returnPath = "/";
     }
     if (existing?.email) {
-      return redirect(returnPath);
+      return redirect(event, returnPath);
     }
 
     let state: string;
@@ -380,7 +391,7 @@ export async function handleIdentitySso(
       `?app=${encodeURIComponent(resolveAppId(event))}` +
       `&redirect_uri=${encodeURIComponent(redirectUri)}` +
       `&state=${encodeURIComponent(state)}`;
-    return redirect(authorizeUrl);
+    return redirect(event, authorizeUrl);
   }
 
   // ---- GET /callback → verify token, JIT-link, mint session ------------
@@ -463,7 +474,7 @@ export async function handleIdentitySso(
 
     // Land the user back where they started (validated same-origin path).
     const dest = safeReturnPath(stateResult.returnPath);
-    return redirect(dest);
+    return redirect(event, dest);
   }
 
   return new Response("Not found", { status: 404 });

--- a/packages/core/src/server/identity-sso.ts
+++ b/packages/core/src/server/identity-sso.ts
@@ -1,0 +1,486 @@
+/**
+ * Cross-app SSO ("Sign in with Agent-Native") — the CLIENT side.
+ *
+ * Each hosted `*.agent-native.com` app has its OWN Better Auth user store
+ * (a separate database per app). This module lets an app federate sign-in to
+ * an identity authority (Dispatch) so a user logged in there can land in this
+ * app without re-entering credentials.
+ *
+ * Opt-in, OFF by default, fully reversible. Everything here is gated on the
+ * single env var `AGENT_NATIVE_IDENTITY_HUB_URL`:
+ *
+ *   - UNSET  → `isIdentitySsoEnabled()` is false. The route handler 404s, the
+ *     auth-guard bypass does not apply, and the login page renders no SSO
+ *     button. Existing auth is byte-for-byte unchanged.
+ *   - SET    (e.g. `https://dispatch.agent-native.com`) → two routes mount:
+ *       GET /_agent-native/identity/login
+ *         302 → `<HUB>/_agent-native/identity/authorize?app=<id>
+ *                 &redirect_uri=<thisOrigin>/_agent-native/identity/callback
+ *                 &state=<single-use CSRF state>`
+ *       GET /_agent-native/identity/callback?token=<jwt>&state=<state>
+ *         Verifies the hub-issued identity JWT (HS256 over the SHARED A2A
+ *         secret — the exact verify path A2A / MCP `verifyAuth` use), checks
+ *         `scope:"identity"`, `exp`, single-use CSRF `state`, and (best
+ *         effort) `jti` replay, then JIT-links the verified email into this
+ *         app's local Better Auth store and mints a normal framework session
+ *         the SAME way the Google OAuth callback does.
+ *
+ * Crypto reuse: the hub signs with `jose.SignJWT(...).sign(A2A_SECRET)` (the
+ * existing `signA2AToken` builder). We verify with the identical
+ * `jose.jwtVerify(token, A2A_SECRET)` call `mcp/build-server.ts#verifyAuth`
+ * uses — no new crypto, no new keys.
+ *
+ * Session reuse: a NEW email is created via `auth.api.signUpEmail` — the
+ * exact Better Auth signup path `maybeAutoCreateDevSession` already uses, so
+ * the adapter creates the `user` (+ adapter-managed credential `account`)
+ * row schema-correctly and the normal `databaseHooks.user.create.after`
+ * (org auto-join, analytics) fires. The framework session is then minted via
+ * `createOAuthSession` — the literal Google-OAuth session-mint path
+ * (`addSession` + `setFrameworkSessionCookie`). An EXISTING email is never
+ * mutated: we only ADD an inert federated-provider `account` row (if absent)
+ * and mint the same framework session. Removing the env returns the app to
+ * its prior auth with no residue.
+ */
+
+import type { H3Event } from "h3";
+import { getMethod } from "h3";
+import * as jose from "jose";
+import { createHash } from "node:crypto";
+import {
+  getBetterAuth,
+  getBetterAuthInternalAdapter,
+} from "./better-auth-instance.js";
+import { getSession, safeReturnPath, isExpectedAuthFailure } from "./auth.js";
+import { createOAuthSession, getOrigin } from "./google-oauth.js";
+import { getAppName } from "./app-name.js";
+import {
+  createSsoState,
+  consumeSsoState,
+  isJtiReplayed,
+  getIdentityHubUrl,
+  isIdentitySsoEnabled,
+  identitySsoLoginButtonHtml,
+} from "./identity-sso-store.js";
+
+export { getIdentityHubUrl, isIdentitySsoEnabled, identitySsoLoginButtonHtml };
+
+/**
+ * The provider id recorded on the additive `account` row we link for an
+ * EXISTING local user. Must match the value the Dispatch authority agent
+ * expects to interoperate with — documented in the report so the two sides
+ * stay in sync. Inert when this provider is unused, so removing the env var
+ * leaves no behavioural residue.
+ */
+export const IDENTITY_SSO_PROVIDER_ID = "agent-native";
+
+/**
+ * The JWT `scope` claim the hub MUST set on the identity token. The callback
+ * rejects any token whose `scope` is not exactly this value, so an A2A
+ * delegation JWT (no scope, or `scope:"mcp-connect"`) can never be replayed
+ * as an identity assertion.
+ */
+export const IDENTITY_SSO_SCOPE = "identity";
+
+/** Identity tokens older than this are rejected even if `exp` is generous. */
+const MAX_TOKEN_AGE_SECONDS = 10 * 60;
+
+/**
+ * A stable id for THIS app, sent to the hub as `?app=` so the authority can
+ * record / display which app requested sign-in. Best-effort, non-secret,
+ * never trusted for identity. Falls back to the request host.
+ */
+function resolveAppId(event: H3Event): string {
+  const configured =
+    process.env.AGENT_NATIVE_APP_ID?.trim() ||
+    process.env.AGENT_NATIVE_WORKSPACE_APP_ID?.trim();
+  if (configured) return configured;
+  const name = getAppName();
+  if (name && name !== "app") return name;
+  try {
+    const origin = getOrigin(event);
+    return new URL(origin).hostname.split(".")[0] || "app";
+  } catch {
+    return "app";
+  }
+}
+
+function html(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+function redirect(location: string): Response {
+  return new Response("", { status: 302, headers: { Location: location } });
+}
+
+/**
+ * Minimal self-contained error page (same inline-HTML approach as the auth /
+ * connect pages). Used when the federated round-trip fails so the user gets
+ * an actionable message instead of a raw 4xx. `message` is plain text.
+ */
+function errorPage(message: string, loginPath: string): Response {
+  const safe = message
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  const safeHref = loginPath.replace(/"/g, "&quot;");
+  return html(
+    `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">` +
+      `<meta name="viewport" content="width=device-width, initial-scale=1">` +
+      `<title>Sign-in failed</title>` +
+      `<style>body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;` +
+      `background:#09090b;color:#f4f4f5;display:flex;align-items:center;` +
+      `justify-content:center;min-height:100vh;margin:0;padding:1rem}` +
+      `.card{max-width:420px;padding:2rem;background:#141417;` +
+      `border:1px solid rgba(255,255,255,0.1);border-radius:12px;text-align:center}` +
+      `h1{font-size:1.15rem;margin:0 0 .5rem}p{color:#a1a1aa;font-size:.9rem;margin:0 0 1.25rem}` +
+      `a{color:#f4f4f5;font-weight:600;text-decoration:none;border:1px solid ` +
+      `rgba(255,255,255,0.18);border-radius:8px;padding:.6rem 1.1rem;display:inline-block}</style>` +
+      `</head><body><div class="card"><h1>Could not sign you in</h1>` +
+      `<p>${safe}</p><a href="${safeHref}">Back to sign in</a></div></body></html>`,
+    400,
+  );
+}
+
+/**
+ * Derive a strong, deterministic, NEVER-exposed credential for a JIT-created
+ * SSO user. Bound to the shared A2A secret + email so it is stable across
+ * function executions but unguessable without the deployment secret. Only
+ * ever used as the `password` argument to Better Auth's own
+ * `signUpEmail` / `signInEmail` — never returned, logged, or sent anywhere.
+ */
+function deriveSsoCredential(email: string): string {
+  const secret = process.env.A2A_SECRET || "";
+  // A salted SHA-256 over secret + email: stable across function executions
+  // (so the same SSO user always derives the same stand-in password) but
+  // unguessable without the deployment secret. This account's only sign-in
+  // path is the signature-verified hub token, so the value is never used by
+  // anyone but Better Auth's own signUpEmail.
+  const digest = createHash("sha256")
+    .update(`${secret}:agent-native-sso:${email}`)
+    .digest("base64url");
+  return `an-sso_${digest}`;
+}
+
+/**
+ * JIT-link the verified hub identity into THIS app's local Better Auth
+ * store, strictly by verified email and strictly additively.
+ *
+ *   - EXISTING email → the local `user` / `session` / existing `account`
+ *     rows are NEVER read-modify-written. We only ADD (if absent) one
+ *     federated-provider `account` row via Better Auth's OWN
+ *     `internalAdapter.linkAccount` — so id, timestamps, and schema stay
+ *     adapter-correct. The row is inert (no template path reads
+ *     `provider_id = "agent-native"`), so removing the env var leaves zero
+ *     behavioural residue.
+ *   - NEW email → created via the SAME `auth.api.signUpEmail` path the app
+ *     already uses (`maybeAutoCreateDevSession` uses the identical call), so
+ *     the adapter creates the `user` (+ a schema-correct credential
+ *     `account`) and `databaseHooks.user.create.after` (org auto-join,
+ *     analytics) fires exactly as for a normal first-time signup. Idempotent
+ *     under a concurrent create (the "already exists" failure is swallowed).
+ *
+ * Returns nothing — success is implied by not throwing. Account-link
+ * failures for an existing user are swallowed (the verified email already
+ * authenticated them; the link row is bookkeeping and must never block the
+ * session).
+ */
+async function jitLinkIdentity(identity: VerifiedIdentity): Promise<void> {
+  const adapter = await getBetterAuthInternalAdapter();
+
+  // Look up the local user via Better Auth's own adapter (read-only).
+  let existing = adapter
+    ? await adapter
+        .findUserByEmail(identity.email, { includeAccounts: true })
+        .catch(() => null)
+    : null;
+
+  if (!existing) {
+    // No local user → create via the SAME signup path the app already uses.
+    const auth = await getBetterAuth();
+    try {
+      await auth.api.signUpEmail({
+        body: {
+          email: identity.email,
+          password: deriveSsoCredential(identity.email),
+          name: identity.name || identity.email.split("@")[0] || "User",
+        },
+      });
+    } catch (e) {
+      // "already exists" (concurrent create / pre-existing user the adapter
+      // lookup missed) is expected and fine — fall through to linking.
+      if (!isExpectedAuthFailure(e)) throw e;
+    }
+    if (adapter) {
+      existing = await adapter
+        .findUserByEmail(identity.email, { includeAccounts: true })
+        .catch(() => null);
+    }
+  }
+
+  // ADD the inert federated-provider link iff a local user resolved and the
+  // link is absent. Better Auth's `linkAccount` is the additive, schema-
+  // correct API — we never UPDATE/DELETE/RENAME any identity row.
+  if (adapter && existing?.user?.id) {
+    const accountId = identity.sub || identity.email;
+    const alreadyLinked = (existing.accounts ?? []).some(
+      (a) =>
+        a.providerId === IDENTITY_SSO_PROVIDER_ID && a.accountId === accountId,
+    );
+    if (!alreadyLinked) {
+      try {
+        await adapter.linkAccount({
+          userId: existing.user.id,
+          providerId: IDENTITY_SSO_PROVIDER_ID,
+          accountId,
+        });
+      } catch {
+        // Inert bookkeeping row — never block sign-in on a link failure.
+      }
+    }
+  }
+}
+
+interface VerifiedIdentity {
+  email: string;
+  name: string;
+  orgDomain?: string;
+  sub: string;
+  jti?: string;
+}
+
+/**
+ * Verify the hub-issued identity JWT using the EXACT same path A2A / MCP use:
+ * `jose.jwtVerify(token, A2A_SECRET)`. `jwtVerify` enforces `exp`
+ * automatically. We additionally require:
+ *   - `scope === "identity"` (so an A2A delegation token can't be replayed)
+ *   - a non-empty `email` claim (the join key — comes ONLY from the verified
+ *     token, never a query param)
+ *   - issued no more than `MAX_TOKEN_AGE_SECONDS` ago (belt-and-braces on top
+ *     of `exp` in case the hub mints long-lived tokens)
+ *
+ * Returns the verified identity, or `null` for ANY failure (bad signature,
+ * expired, wrong scope, missing email, malformed). The caller maps `null` to
+ * a generic error — it never leaks which check failed.
+ */
+async function verifyIdentityToken(
+  token: string,
+): Promise<VerifiedIdentity | null> {
+  const secret = process.env.A2A_SECRET;
+  if (!secret || !token) return null;
+  try {
+    const { payload } = await jose.jwtVerify(
+      token,
+      new TextEncoder().encode(secret),
+    );
+    if (payload.scope !== IDENTITY_SSO_SCOPE) return null;
+    const email =
+      typeof payload.email === "string" && payload.email.includes("@")
+        ? payload.email.trim().toLowerCase()
+        : null;
+    if (!email) return null;
+    const iat = typeof payload.iat === "number" ? payload.iat : undefined;
+    if (iat !== undefined && Date.now() / 1000 - iat > MAX_TOKEN_AGE_SECONDS) {
+      return null;
+    }
+    const sub =
+      typeof payload.sub === "string" && payload.sub ? payload.sub : email;
+    return {
+      email,
+      name:
+        typeof payload.name === "string" && payload.name.trim()
+          ? payload.name.trim()
+          : "",
+      orgDomain:
+        typeof payload.org_domain === "string" && payload.org_domain
+          ? payload.org_domain
+          : undefined,
+      sub,
+      jti:
+        typeof payload.jti === "string" && payload.jti
+          ? payload.jti
+          : undefined,
+    };
+  } catch {
+    // Bad signature / expired / malformed — never reveal which.
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route handler — single entry point; the core-routes-plugin dispatches the
+// subpath, mirroring `handleMcpConnect`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle a `/_agent-native/identity/*` request. `subpath` is the part after
+ * `/identity` (e.g. `/login`, `/callback`). Returns a 404 Response whenever
+ * the feature is disabled so an unset env var is a true no-op even if the
+ * route somehow gets mounted.
+ */
+export async function handleIdentitySso(
+  event: H3Event,
+  subpath: string,
+): Promise<Response> {
+  const hub = getIdentityHubUrl();
+  if (!hub) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const method = getMethod(event);
+  const sub = ("/" + subpath.replace(/^\/+/, "").replace(/\/+$/, "")).replace(
+    /^\/$/,
+    "",
+  );
+  const origin = getOrigin(event);
+  const loginPath = "/_agent-native/sign-in";
+
+  // ---- GET /login → 302 to the hub authorize endpoint ------------------
+  if (sub === "/login") {
+    if (method !== "GET" && method !== "HEAD") {
+      return new Response("Method not allowed", { status: 405 });
+    }
+    // Already signed in here? Skip the round-trip.
+    const existing = await getSession(event).catch(() => null);
+    let returnPath = "/";
+    try {
+      const u = new URL(
+        (event as any).node?.req?.url ?? event.path ?? "/",
+        "http://an.invalid",
+      );
+      returnPath = safeReturnPath(u.searchParams.get("return"));
+    } catch {
+      returnPath = "/";
+    }
+    if (existing?.email) {
+      return redirect(returnPath);
+    }
+
+    let state: string;
+    try {
+      state = await createSsoState(returnPath === "/" ? null : returnPath);
+    } catch (e: any) {
+      if (e?.message === "RATE_LIMITED") {
+        return errorPage(
+          "Too many sign-in attempts. Please wait a moment and try again.",
+          loginPath,
+        );
+      }
+      return errorPage(
+        "Could not start federated sign-in. Please try again.",
+        loginPath,
+      );
+    }
+
+    const redirectUri = `${origin}/_agent-native/identity/callback`;
+    const authorizeUrl =
+      `${hub}/_agent-native/identity/authorize` +
+      `?app=${encodeURIComponent(resolveAppId(event))}` +
+      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+      `&state=${encodeURIComponent(state)}`;
+    return redirect(authorizeUrl);
+  }
+
+  // ---- GET /callback → verify token, JIT-link, mint session ------------
+  if (sub === "/callback") {
+    if (method !== "GET" && method !== "HEAD") {
+      return new Response("Method not allowed", { status: 405 });
+    }
+
+    let token = "";
+    let stateParam = "";
+    try {
+      const u = new URL(
+        (event as any).node?.req?.url ?? event.path ?? "/",
+        "http://an.invalid",
+      );
+      token =
+        u.searchParams.get("token") || u.searchParams.get("id_token") || "";
+      stateParam = u.searchParams.get("state") || "";
+    } catch {
+      return errorPage("Malformed sign-in response.", loginPath);
+    }
+
+    // CSRF: the state must be one we minted, unexpired, and never consumed.
+    // Consume it FIRST (single-use) so a replayed callback can't pass even
+    // with a still-valid token.
+    const stateResult = await consumeSsoState(stateParam);
+    if (!stateResult.ok) {
+      return errorPage(
+        "Your sign-in session expired or was already used. Please try again.",
+        loginPath,
+      );
+    }
+
+    // Identity comes ONLY from the signature-verified token. The query
+    // `email` (if any) is never trusted.
+    const identity = await verifyIdentityToken(token);
+    if (!identity) {
+      return errorPage(
+        "We could not verify the sign-in response. Please try again.",
+        loginPath,
+      );
+    }
+
+    // Replay guard (best-effort, defence in depth on top of single-use
+    // state): reject a token whose jti we've already accepted.
+    if (await isJtiReplayed(identity.jti)) {
+      return errorPage(
+        "This sign-in link was already used. Please try again.",
+        loginPath,
+      );
+    }
+
+    // JIT link STRICTLY by verified email — additive only. Existing users
+    // are never mutated; new users are created via the app's own signup
+    // path; an inert federated `account` link is added via Better Auth's
+    // own adapter API. A failure here must not leave the user signed out
+    // mid-flow, so surface a retryable error rather than a half state.
+    try {
+      await jitLinkIdentity(identity);
+    } catch {
+      return errorPage(
+        "Could not finish linking your account. Please try again.",
+        loginPath,
+      );
+    }
+
+    // Mint a normal framework session EXACTLY the way the Google OAuth
+    // callback does (`createOAuthSession` → addSession + framework cookie).
+    // `hasProductionSession: false` so a fresh session cookie is always set.
+    try {
+      await createOAuthSession(event, identity.email, {
+        hasProductionSession: false,
+      });
+    } catch {
+      return errorPage(
+        "Signed in, but could not start your session. Please try again.",
+        loginPath,
+      );
+    }
+
+    // Land the user back where they started (validated same-origin path).
+    const dest = safeReturnPath(stateResult.returnPath);
+    return redirect(dest);
+  }
+
+  return new Response("Not found", { status: 404 });
+}
+
+/**
+ * Whether the given (already base-path-stripped) request path is one of the
+ * SSO routes that must bypass the blanket auth guard. Both routes resolve /
+ * mint the browser session themselves: `/login` is the unauthenticated entry
+ * point, and `/callback` is hit by a user who is (by definition) not yet
+ * signed in to THIS app. Returns false when the feature is disabled, so the
+ * guard's behaviour is unchanged with the env unset.
+ */
+export function isIdentitySsoBypassPath(p: string): boolean {
+  if (!isIdentitySsoEnabled()) return false;
+  return (
+    p === "/_agent-native/identity/login" ||
+    p === "/_agent-native/identity/callback"
+  );
+}

--- a/packages/core/src/server/identity-sso.ts
+++ b/packages/core/src/server/identity-sso.ts
@@ -267,6 +267,8 @@ interface VerifiedIdentity {
  * `jose.jwtVerify(token, A2A_SECRET)`. `jwtVerify` enforces `exp`
  * automatically. We additionally require:
  *   - `scope === "identity"` (so an A2A delegation token can't be replayed)
+ *   - `aud` is THIS app's callback URL (so a token minted for one app cannot
+ *     be replayed against another app's callback with a fresh state)
  *   - a non-empty `email` claim (the join key — comes ONLY from the verified
  *     token, never a query param)
  *   - issued no more than `MAX_TOKEN_AGE_SECONDS` ago (belt-and-braces on top
@@ -278,6 +280,7 @@ interface VerifiedIdentity {
  */
 async function verifyIdentityToken(
   token: string,
+  expectedAudience: string,
 ): Promise<VerifiedIdentity | null> {
   const secret = process.env.A2A_SECRET;
   if (!secret || !token) return null;
@@ -287,6 +290,17 @@ async function verifyIdentityToken(
       new TextEncoder().encode(secret),
     );
     if (payload.scope !== IDENTITY_SSO_SCOPE) return null;
+    const aud = payload.aud;
+    const audienceMatches = Array.isArray(aud)
+      ? aud.includes(expectedAudience)
+      : aud === expectedAudience;
+    if (!audienceMatches) return null;
+    if (
+      typeof payload.redirect_uri === "string" &&
+      payload.redirect_uri !== expectedAudience
+    ) {
+      return null;
+    }
     const email =
       typeof payload.email === "string" && payload.email.includes("@")
         ? payload.email.trim().toLowerCase()
@@ -427,7 +441,8 @@ export async function handleIdentitySso(
 
     // Identity comes ONLY from the signature-verified token. The query
     // `email` (if any) is never trusted.
-    const identity = await verifyIdentityToken(token);
+    const expectedAudience = `${origin}/_agent-native/identity/callback`;
+    const identity = await verifyIdentityToken(token, expectedAudience);
     if (!identity) {
       return errorPage(
         "We could not verify the sign-in response. Please try again.",

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -31,6 +31,15 @@ export {
   type AuthSession,
   type AuthOptions,
 } from "./auth.js";
+export {
+  handleIdentitySso,
+  getIdentityHubUrl,
+  isIdentitySsoEnabled,
+  isIdentitySsoBypassPath,
+  identitySsoLoginButtonHtml,
+  IDENTITY_SSO_PROVIDER_ID,
+  IDENTITY_SSO_SCOPE,
+} from "./identity-sso.js";
 export { requireEnvKey, type MissingKeyResponse } from "./missing-key.js";
 export { verifyCaptcha, type CaptchaVerifyResult } from "./captcha.js";
 export {

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -14,6 +14,40 @@ describe("getOnboardingHtml", () => {
     expect(html).toContain('id="upgrade-note"');
   });
 
+  describe("federated SSO button (AGENT_NATIVE_IDENTITY_HUB_URL)", () => {
+    it("env unset → login HTML is byte-for-byte identical (no SSO button, no residue)", () => {
+      // Capture baseline with the env unequivocally absent.
+      delete process.env.AGENT_NATIVE_IDENTITY_HUB_URL;
+      const baseline = getOnboardingHtml();
+      expect(baseline).not.toContain("identity-sso-btn");
+      expect(baseline).not.toContain("/_agent-native/identity/login");
+      expect(baseline).not.toContain("Sign in with Agent-Native");
+
+      // Re-render with the env still unset → must be the exact same string.
+      const again = getOnboardingHtml();
+      expect(again).toBe(baseline);
+    });
+
+    it("env set → injects exactly one conditional SSO entry pointing at /identity/login", () => {
+      vi.stubEnv(
+        "AGENT_NATIVE_IDENTITY_HUB_URL",
+        "https://dispatch.agent-native.com",
+      );
+      const html = getOnboardingHtml();
+      expect(html).toContain('id="identity-sso-btn"');
+      expect(html).toContain('href="/_agent-native/identity/login"');
+      expect(html).toContain("Sign in with Agent-Native");
+      // Exactly one occurrence — not duplicated across layout branches.
+      expect(html.split("identity-sso-btn").length - 1).toBe(1);
+    });
+
+    it("malformed env value is treated as OFF (no button, no throw)", () => {
+      vi.stubEnv("AGENT_NATIVE_IDENTITY_HUB_URL", "not a url");
+      const html = getOnboardingHtml();
+      expect(html).not.toContain("identity-sso-btn");
+    });
+  });
+
   it("reveals the upgrade note only from explicit upgrade markers", () => {
     const html = getOnboardingHtml();
 

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -13,6 +13,7 @@ import {
   type GoogleAuthMode,
 } from "./google-auth-mode.js";
 import { getWorkspaceGatewayReturnOrigin } from "./oauth-return-url.js";
+import { identitySsoLoginButtonHtml } from "./identity-sso-store.js";
 
 function hasGoogleOAuth(): boolean {
   return !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
@@ -810,7 +811,7 @@ ${marketingPanelHtml}
     id="upgrade-note"
     data-upgrade-copy="Continue signing in to attach this app to your account and migrate local data."
   ></p>
-
+${identitySsoLoginButtonHtml()}
 ${
   showGoogle
     ? `

--- a/packages/desktop-app/electron.vite.config.ts
+++ b/packages/desktop-app/electron.vite.config.ts
@@ -6,6 +6,7 @@ const workspaceRendererPackages = [
   "@agent-native/code-agents-ui",
   "@agent-native/code-agents-ui/code-agents",
   "@agent-native/core",
+  "@agent-native/core/code-agents/transcript-normalizer",
   "@agent-native/core/client",
   "@agent-native/shared-app-config",
 ];

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -206,18 +206,35 @@ function isDeepLinkArg(arg: string): boolean {
   return arg.startsWith(`${DEEP_LINK_PROTOCOL}:`);
 }
 
-const singleInstanceLock = app.requestSingleInstanceLock();
-if (!singleInstanceLock) {
-  app.quit();
+function handleSecondInstance(_event: Electron.Event, argv: string[]): void {
+  const deepLink = argv.find(isDeepLinkArg);
+  if (deepLink) {
+    void handleDeepLink(deepLink);
+  } else {
+    focusMainWindow();
+  }
+}
+
+if (IS_DEV) {
+  // electron-vite kills the main process and relaunches it on every rebuild
+  // (e.g. when the concurrent `@agent-native/core` tsc --watch under
+  // dev:lazy:desktop rewrites bundled output). A single-instance lock would
+  // make the relaunched instance race the still-dying one for the lock, lose,
+  // and app.quit() — leaving the killed instance's dead Dock tile behind.
+  // Skip the lock in dev; keep the deep-link handler for parity.
+  app.on("second-instance", handleSecondInstance);
+  // Quit immediately when electron-vite SIGTERMs us so the old process and its
+  // Dock tile vanish at once, before the relaunched instance paints its window.
+  const exitNow = () => app.exit(0);
+  process.on("SIGTERM", exitNow);
+  process.on("SIGINT", exitNow);
 } else {
-  app.on("second-instance", (_event, argv) => {
-    const deepLink = argv.find(isDeepLinkArg);
-    if (deepLink) {
-      void handleDeepLink(deepLink);
-    } else {
-      focusMainWindow();
-    }
-  });
+  const singleInstanceLock = app.requestSingleInstanceLock();
+  if (!singleInstanceLock) {
+    app.quit();
+  } else {
+    app.on("second-instance", handleSecondInstance);
+  }
 }
 
 interface OAuthInjectionTarget {
@@ -1493,6 +1510,36 @@ function firstTextValue(...values: unknown[]): string | undefined {
   return undefined;
 }
 
+function transcriptTextFromUnknown(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value.trim() ? value : undefined;
+  }
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((item) => {
+        if (typeof item === "string") return item;
+        if (!isObject(item)) return "";
+        return (
+          firstTranscriptTextValue(item.text, item.content, item.message) ?? ""
+        );
+      })
+      .filter((part) => part.trim());
+    return parts.length > 0 ? parts.join("\n") : undefined;
+  }
+  if (isObject(value)) {
+    return firstTranscriptTextValue(value.text, value.content, value.message);
+  }
+  return undefined;
+}
+
+function firstTranscriptTextValue(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const text = transcriptTextFromUnknown(value);
+    if (text) return text;
+  }
+  return undefined;
+}
+
 function getRecordString(
   record: Record<string, unknown> | null | undefined,
   key: string,
@@ -1692,7 +1739,7 @@ function normalizeCodeAgentTranscriptEvent(
     type === "artifact" ? "Artifact" : undefined,
   );
   const text =
-    firstTextValue(
+    firstTranscriptTextValue(
       row.text,
       row.content,
       row.message,

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -135,6 +135,11 @@ const CODE_AGENT_PROVIDER_SETTING_KEYS: CodeAgentProviderCredentialKey[] = [
   "BUILDER_PUBLIC_KEY",
 ];
 const DESKTOP_BUILDER_CONNECT_TIMEOUT_MS = 5 * 60 * 1000;
+const CODE_AGENTS_SUBSCRIBE_TRANSCRIPT_CHANNEL =
+  "code-agents:subscribe-transcript";
+const CODE_AGENTS_UNSUBSCRIBE_TRANSCRIPT_CHANNEL =
+  "code-agents:unsubscribe-transcript";
+const CODE_AGENTS_TRANSCRIPT_EVENTS_CHANNEL = "code-agents:transcript-events";
 
 type DesktopBackgroundAgentControlCommand =
   | "approve"
@@ -175,6 +180,26 @@ interface DesktopBackgroundAgentController {
   control(
     input: DesktopBackgroundAgentControlInput,
   ): Promise<DesktopBackgroundAgentControlResult>;
+}
+
+interface CodeAgentTranscriptSubscriptionBatch {
+  subscriptionId: string;
+  status: CodeAgentTranscriptResult["status"];
+  runId: string;
+  events: CodeAgentTranscriptEvent[];
+  eventFile?: string;
+  reason?: string;
+  error?: string;
+}
+
+interface CodeAgentTranscriptSubscription {
+  id: string;
+  runId: string;
+  senderId: number;
+  knownEventKeys: Set<string>;
+  watcher?: fs.FSWatcher;
+  flushTimer?: NodeJS.Timeout;
+  reason?: string;
 }
 
 function isDeepLinkArg(arg: string): boolean {
@@ -1828,6 +1853,160 @@ function readCodeAgentTranscript(input: unknown): CodeAgentTranscriptResult {
   };
 }
 
+const codeAgentTranscriptSubscriptions = new Map<
+  string,
+  CodeAgentTranscriptSubscription
+>();
+const codeAgentAssistantDeltaSeq = new Map<string, number>();
+
+function codeAgentTranscriptEventKey(event: CodeAgentTranscriptEvent): string {
+  return `${event.id}\u0000${event.createdAt}\u0000${event.text}`;
+}
+
+function readCodeAgentTranscriptSeq(event: CodeAgentTranscriptEvent): number {
+  const seq = event.metadata?.seq;
+  return typeof seq === "number" && Number.isFinite(seq) ? seq : 0;
+}
+
+function nextCodeAgentAssistantDeltaSeq(runId: string): number {
+  const current = codeAgentAssistantDeltaSeq.get(runId);
+  if (current !== undefined) {
+    const next = current + 1;
+    codeAgentAssistantDeltaSeq.set(runId, next);
+    return next;
+  }
+  const transcript = readCodeAgentTranscript({ runId });
+  const maxSeq = transcript.events.reduce(
+    (max, event) => Math.max(max, readCodeAgentTranscriptSeq(event)),
+    0,
+  );
+  const next = maxSeq + 1;
+  codeAgentAssistantDeltaSeq.set(runId, next);
+  return next;
+}
+
+function appendCodeAgentAssistantDeltaEvent(runId: string, text: string): void {
+  if (!text.trim()) return;
+  const now = new Date().toISOString();
+  const seq = nextCodeAgentAssistantDeltaSeq(runId);
+  appendCodeAgentTranscriptEvent({
+    id: `event-${timestampSlug(now)}-${randomUUID().slice(0, 8)}`,
+    runId,
+    type: "system",
+    title: "Assistant",
+    text,
+    createdAt: now,
+    metadata: {
+      source: "runner-stdout",
+      type: "assistant_delta",
+      seq,
+      stream: "stdout",
+    },
+  });
+}
+
+function initializeCodeAgentTranscriptSubscriptionKeys(
+  subscription: CodeAgentTranscriptSubscription,
+): CodeAgentTranscriptResult {
+  const result = readCodeAgentTranscript({ runId: subscription.runId });
+  subscription.knownEventKeys = new Set(
+    result.events.map(codeAgentTranscriptEventKey),
+  );
+  return result;
+}
+
+function removeCodeAgentTranscriptSubscription(subscriptionId: string): void {
+  const subscription = codeAgentTranscriptSubscriptions.get(subscriptionId);
+  if (!subscription) return;
+  if (subscription.flushTimer) clearTimeout(subscription.flushTimer);
+  subscription.watcher?.close();
+  codeAgentTranscriptSubscriptions.delete(subscriptionId);
+}
+
+function sendCodeAgentTranscriptSubscriptionBatch(
+  subscription: CodeAgentTranscriptSubscription,
+  batch: Omit<CodeAgentTranscriptSubscriptionBatch, "subscriptionId">,
+): void {
+  const target = webContents.fromId(subscription.senderId);
+  if (!target || target.isDestroyed()) {
+    removeCodeAgentTranscriptSubscription(subscription.id);
+    return;
+  }
+  target.send(CODE_AGENTS_TRANSCRIPT_EVENTS_CHANNEL, {
+    subscriptionId: subscription.id,
+    ...batch,
+  } satisfies CodeAgentTranscriptSubscriptionBatch);
+}
+
+function flushCodeAgentTranscriptSubscription(
+  subscription: CodeAgentTranscriptSubscription,
+  reason: string,
+): void {
+  subscription.flushTimer = undefined;
+  const result = readCodeAgentTranscript({ runId: subscription.runId });
+  const nextKnownEventKeys = new Set<string>();
+  const events: CodeAgentTranscriptEvent[] = [];
+
+  for (const event of result.events) {
+    const key = codeAgentTranscriptEventKey(event);
+    nextKnownEventKeys.add(key);
+    if (!subscription.knownEventKeys.has(key)) events.push(event);
+  }
+
+  subscription.knownEventKeys = nextKnownEventKeys;
+  if (events.length === 0 && result.status === "ok" && !result.error) return;
+
+  sendCodeAgentTranscriptSubscriptionBatch(subscription, {
+    status: result.status,
+    runId: result.runId ?? subscription.runId,
+    events,
+    eventFile: result.eventFile,
+    reason,
+    error: result.error,
+  });
+}
+
+function scheduleCodeAgentTranscriptSubscriptionFlush(
+  subscription: CodeAgentTranscriptSubscription,
+  reason: string,
+): void {
+  subscription.reason = reason;
+  if (subscription.flushTimer) return;
+  subscription.flushTimer = setTimeout(() => {
+    flushCodeAgentTranscriptSubscription(
+      subscription,
+      subscription.reason ?? reason,
+    );
+  }, 40);
+}
+
+function notifyCodeAgentTranscriptChanged(runId: string, reason: string): void {
+  for (const subscription of codeAgentTranscriptSubscriptions.values()) {
+    if (subscription.runId !== runId) continue;
+    scheduleCodeAgentTranscriptSubscriptionFlush(subscription, reason);
+  }
+}
+
+function watchCodeAgentTranscriptSubscription(
+  subscription: CodeAgentTranscriptSubscription,
+): void {
+  const eventFile = codeAgentEventFilePath(subscription.runId);
+  if (!eventFile) return;
+  const dir = path.dirname(eventFile);
+  const fileName = path.basename(eventFile);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    subscription.watcher = fs.watch(dir, (_eventType, changedFile) => {
+      const changedName = changedFile ? String(changedFile) : "";
+      if (changedName && changedName !== fileName) return;
+      scheduleCodeAgentTranscriptSubscriptionFlush(subscription, "file-watch");
+    });
+  } catch {
+    // readTranscript remains the compatibility fallback when file watching
+    // is unavailable for this filesystem.
+  }
+}
+
 function readLatestCodeAgentUserPrompt(runId: string): string | undefined {
   const transcript = readCodeAgentTranscript({ runId });
   for (let index = transcript.events.length - 1; index >= 0; index -= 1) {
@@ -1879,6 +2058,7 @@ function appendCodeAgentTranscriptEvent(
       message: event.text,
     })}\n`,
   );
+  notifyCodeAgentTranscriptChanged(event.runId, "append");
   return eventFile;
 }
 
@@ -1976,9 +2156,7 @@ function spawnCodeAgentRunner(
       },
     });
     child.stdout?.on("data", (chunk) => {
-      appendCodeAgentStatusEvent(runId, chunk.toString().trim(), {
-        source: "runner-stdout",
-      });
+      appendCodeAgentAssistantDeltaEvent(runId, chunk.toString());
     });
     child.stderr?.on("data", (chunk) => {
       appendCodeAgentStatusEvent(runId, chunk.toString().trim(), {
@@ -1987,6 +2165,7 @@ function spawnCodeAgentRunner(
     });
     child.on("exit", (code, signal) => {
       activeCodeAgentProcesses.delete(runId);
+      codeAgentAssistantDeltaSeq.delete(runId);
       appendCodeAgentStatusEvent(
         runId,
         code === 0
@@ -3777,6 +3956,62 @@ ipcMain.handle(
   IPC.CODE_AGENTS_READ_TRANSCRIPT,
   (_event: IpcMainInvokeEvent, input: unknown): CodeAgentTranscriptResult =>
     readCodeAgentTranscript(input),
+);
+
+ipcMain.on(
+  CODE_AGENTS_SUBSCRIBE_TRANSCRIPT_CHANNEL,
+  (event: IpcMainEvent, input: unknown) => {
+    const payload = isObject(input) ? input : {};
+    const subscriptionId =
+      firstStringValue(payload.subscriptionId) ??
+      `subscription-${timestampSlug(new Date().toISOString())}-${randomUUID().slice(0, 8)}`;
+    const request = isObject(payload.request) ? payload.request : payload;
+    const runId = normalizeCodeAgentRunId(request.runId);
+    if (!runId) {
+      event.sender.send(CODE_AGENTS_TRANSCRIPT_EVENTS_CHANNEL, {
+        subscriptionId,
+        status: "unavailable",
+        runId: "",
+        events: [],
+        error: "Missing or invalid run id.",
+      } satisfies CodeAgentTranscriptSubscriptionBatch);
+      return;
+    }
+
+    removeCodeAgentTranscriptSubscription(subscriptionId);
+    const subscription: CodeAgentTranscriptSubscription = {
+      id: subscriptionId,
+      runId,
+      senderId: event.sender.id,
+      knownEventKeys: new Set(),
+    };
+    const result = initializeCodeAgentTranscriptSubscriptionKeys(subscription);
+    codeAgentTranscriptSubscriptions.set(subscriptionId, subscription);
+    watchCodeAgentTranscriptSubscription(subscription);
+    event.sender.once("destroyed", () => {
+      removeCodeAgentTranscriptSubscription(subscriptionId);
+    });
+    if (result.status !== "ok" || result.error) {
+      sendCodeAgentTranscriptSubscriptionBatch(subscription, {
+        status: result.status,
+        runId: result.runId ?? runId,
+        events: [],
+        eventFile: result.eventFile,
+        reason: "subscribe",
+        error: result.error,
+      });
+    }
+  },
+);
+
+ipcMain.on(
+  CODE_AGENTS_UNSUBSCRIBE_TRANSCRIPT_CHANNEL,
+  (_event: IpcMainEvent, input: unknown) => {
+    const subscriptionId = isObject(input)
+      ? firstStringValue(input.subscriptionId)
+      : firstStringValue(input);
+    if (subscriptionId) removeCodeAgentTranscriptSubscription(subscriptionId);
+  },
 );
 
 ipcMain.handle(

--- a/packages/desktop-app/src/preload/index.ts
+++ b/packages/desktop-app/src/preload/index.ts
@@ -37,6 +37,17 @@ import {
 } from "@shared/ipc-channels";
 import type { CodeAgentPermissionMode } from "@shared/code-agents";
 
+const CODE_AGENTS_SUBSCRIBE_TRANSCRIPT_CHANNEL =
+  "code-agents:subscribe-transcript";
+const CODE_AGENTS_UNSUBSCRIBE_TRANSCRIPT_CHANNEL =
+  "code-agents:unsubscribe-transcript";
+const CODE_AGENTS_TRANSCRIPT_EVENTS_CHANNEL = "code-agents:transcript-events";
+
+type CodeAgentTranscriptSubscriptionBatch = CodeAgentTranscriptResult & {
+  subscriptionId?: string;
+  reason?: string;
+};
+
 /** The API surface exposed to the renderer via window.electronAPI */
 const electronAPI = {
   /** Current OS platform — used by renderer to adapt UI (e.g. traffic lights vs custom controls) */
@@ -143,6 +154,35 @@ const electronAPI = {
       request: CodeAgentTranscriptRequest,
     ): Promise<CodeAgentTranscriptResult> =>
       ipcRenderer.invoke(IPC.CODE_AGENTS_READ_TRANSCRIPT, request),
+    subscribeTranscript: (
+      request: CodeAgentTranscriptRequest,
+      cb: (batch: CodeAgentTranscriptSubscriptionBatch) => void,
+    ): (() => void) => {
+      const subscriptionId = `subscription-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`;
+      const handler = (
+        _: Electron.IpcRendererEvent,
+        batch: CodeAgentTranscriptSubscriptionBatch,
+      ) => {
+        if (batch?.subscriptionId !== subscriptionId) return;
+        cb(batch);
+      };
+      ipcRenderer.on(CODE_AGENTS_TRANSCRIPT_EVENTS_CHANNEL, handler);
+      ipcRenderer.send(CODE_AGENTS_SUBSCRIBE_TRANSCRIPT_CHANNEL, {
+        subscriptionId,
+        request,
+      });
+      return () => {
+        ipcRenderer.removeListener(
+          CODE_AGENTS_TRANSCRIPT_EVENTS_CHANNEL,
+          handler,
+        );
+        ipcRenderer.send(CODE_AGENTS_UNSUBSCRIBE_TRANSCRIPT_CHANNEL, {
+          subscriptionId,
+        });
+      };
+    },
     appendFollowUp: (
       request: CodeAgentFollowUpRequest,
     ): Promise<CodeAgentFollowUpResult> =>

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
 import {
   CodeAgentsApp,
+  type CodeAgentTranscriptEvent,
+  type CodeAgentTranscriptRequest,
   type CodeAgentsHost,
 } from "@agent-native/code-agents-ui";
 import { toAppDefinition, type AppConfig } from "@shared/app-registry";
@@ -18,13 +20,30 @@ interface CodeAgentsHubProps {
   onOpenSettings?: () => void;
 }
 
+type CodeAgentTranscriptSubscriptionBatch = {
+  status: "ok" | "unavailable";
+  runId?: string;
+  events: CodeAgentTranscriptEvent[];
+  eventFile?: string;
+  error?: string;
+  subscriptionId?: string;
+  reason?: string;
+};
+
+interface CodeAgentsHostWithTranscriptSubscription extends CodeAgentsHost {
+  subscribeTranscript?(
+    request: CodeAgentTranscriptRequest,
+    cb: (batch: CodeAgentTranscriptSubscriptionBatch) => void,
+  ): () => void;
+}
+
 export default function CodeAgentsHub({
   apps,
   openRequest,
   refreshKey = 0,
   onOpenSettings,
 }: CodeAgentsHubProps) {
-  const host = useMemo<CodeAgentsHost>(
+  const host = useMemo<CodeAgentsHostWithTranscriptSubscription>(
     () => ({
       async listRuns(goalId?: string) {
         const api = window.electronAPI?.codeAgents;
@@ -114,6 +133,11 @@ export default function CodeAgentsHub({
           };
         }
         return api.readTranscript(request);
+      },
+      subscribeTranscript(request, callback) {
+        const api = window.electronAPI?.codeAgents;
+        if (!api?.subscribeTranscript) return () => {};
+        return api.subscribeTranscript(request, callback);
       },
       async appendFollowUp(request) {
         const api = window.electronAPI?.codeAgents;

--- a/packages/desktop-app/src/renderer/global.d.ts
+++ b/packages/desktop-app/src/renderer/global.d.ts
@@ -287,6 +287,11 @@ type CodeAgentTranscriptResult = {
   error?: string;
 };
 
+type CodeAgentTranscriptSubscriptionBatch = CodeAgentTranscriptResult & {
+  subscriptionId?: string;
+  reason?: string;
+};
+
 type CodeAgentCreateRunRequest = {
   goalId?: string;
   prompt: string;
@@ -511,6 +516,10 @@ interface ElectronAPI {
     readTranscript(
       request: CodeAgentTranscriptRequest,
     ): Promise<CodeAgentTranscriptResult>;
+    subscribeTranscript(
+      request: CodeAgentTranscriptRequest,
+      cb: (batch: CodeAgentTranscriptSubscriptionBatch) => void,
+    ): () => void;
     appendFollowUp(
       request: CodeAgentFollowUpRequest,
     ): Promise<CodeAgentFollowUpResult>;

--- a/packages/docs/app/components/docsNavItems.ts
+++ b/packages/docs/app/components/docsNavItems.ts
@@ -57,6 +57,7 @@ export const NAV_SECTIONS: NavSection[] = [
       { label: "MCP Clients", to: "/docs/mcp-clients" as const },
       { label: "MCP Protocol", to: "/docs/mcp-protocol" as const },
       { label: "External Agents", to: "/docs/external-agents" as const },
+      { label: "Cross-App SSO", to: "/docs/cross-app-sso" as const },
       { label: "Notifications", to: "/docs/notifications" as const },
       {
         label: "Workspace Connections",

--- a/templates/dispatch/package.json
+++ b/templates/dispatch/package.json
@@ -8,7 +8,7 @@
     "build": "agent-native build",
     "start": "agent-native start",
     "typecheck": "agent-native typecheck",
-    "test": "echo 'skipping dispatch tests (no test files)'",
+    "test": "vitest --run --passWithNoTests",
     "action": "agent-native action",
     "script": "agent-native script"
   },

--- a/templates/dispatch/server/lib/identity-sso.spec.ts
+++ b/templates/dispatch/server/lib/identity-sso.spec.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_ALLOWED_HOST_SUFFIXES,
+  IDENTITY_SCOPE,
+  IDENTITY_TOKEN_TTL,
+  IDENTITY_TOKEN_TTL_SECONDS,
+  buildIdentityClaims,
+  buildRedirectLocation,
+  getConfiguredHostSuffixes,
+  isAllowedRedirectUri,
+} from "./identity-sso.js";
+
+describe("isAllowedRedirectUri — the critical open-redirect guard", () => {
+  describe("accepts first-party + localhost", () => {
+    it("accepts https first-party subdomains", () => {
+      expect(isAllowedRedirectUri("https://mail.agent-native.com/cb")).toBe(
+        true,
+      );
+      expect(
+        isAllowedRedirectUri("https://calendar.agent-native.com/auth/callback"),
+      ).toBe(true);
+      expect(
+        isAllowedRedirectUri("https://analytics.agent-native.com/x?a=1#frag"),
+      ).toBe(true);
+    });
+
+    it("accepts deep first-party subdomains", () => {
+      expect(isAllowedRedirectUri("https://a.b.c.agent-native.com/cb")).toBe(
+        true,
+      );
+    });
+
+    it("accepts localhost over http and https (dev)", () => {
+      expect(isAllowedRedirectUri("http://localhost:3000/cb")).toBe(true);
+      expect(isAllowedRedirectUri("https://localhost:3000/cb")).toBe(true);
+      expect(isAllowedRedirectUri("http://127.0.0.1:5173/auth")).toBe(true);
+      expect(isAllowedRedirectUri("http://[::1]:8080/cb")).toBe(true);
+    });
+
+    it("accepts an extra host suffix passed explicitly", () => {
+      expect(
+        isAllowedRedirectUri("https://app.staging.example.com/cb", {
+          allowedHostSuffixes: [".staging.example.com"],
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("REJECTS everything else", () => {
+    it("rejects a plain evil host", () => {
+      expect(isAllowedRedirectUri("https://evil.com/cb")).toBe(false);
+      expect(isAllowedRedirectUri("https://evil.com/")).toBe(false);
+    });
+
+    it("rejects suffix-spoof: agent-native.com.evil.com", () => {
+      expect(isAllowedRedirectUri("https://agent-native.com.evil.com/cb")).toBe(
+        false,
+      );
+    });
+
+    it("rejects prefix/substring-spoof hosts", () => {
+      expect(isAllowedRedirectUri("https://evil-agent-native.com/cb")).toBe(
+        false,
+      );
+      expect(isAllowedRedirectUri("https://notagent-native.com/cb")).toBe(
+        false,
+      );
+      // bare apex is intentionally NOT allowed (apps are subdomains)
+      expect(isAllowedRedirectUri("https://agent-native.com/cb")).toBe(false);
+    });
+
+    it("rejects non-https for non-loopback hosts", () => {
+      expect(isAllowedRedirectUri("http://mail.agent-native.com/cb")).toBe(
+        false,
+      );
+    });
+
+    it("rejects non-http(s) schemes", () => {
+      expect(isAllowedRedirectUri("javascript:alert(document.cookie)")).toBe(
+        false,
+      );
+      expect(isAllowedRedirectUri("data:text/html;base64,PHNjcmlwdD4=")).toBe(
+        false,
+      );
+      expect(isAllowedRedirectUri("ftp://mail.agent-native.com/cb")).toBe(
+        false,
+      );
+    });
+
+    it("rejects embedded credentials (open-redirect obfuscation)", () => {
+      // userinfo host is good, but the URL parser host is good too — the
+      // credential form is still an exfil/obfuscation vector, reject it.
+      expect(
+        isAllowedRedirectUri("https://attacker@mail.agent-native.com/cb"),
+      ).toBe(false);
+      expect(isAllowedRedirectUri("https://u:p@mail.agent-native.com/cb")).toBe(
+        false,
+      );
+      // Classic trick: real host in userinfo, evil host is the real host.
+      expect(
+        isAllowedRedirectUri("https://mail.agent-native.com@evil.com/cb"),
+      ).toBe(false);
+    });
+
+    it("rejects relative / non-absolute / empty / non-string", () => {
+      expect(isAllowedRedirectUri("/relative/path")).toBe(false);
+      expect(isAllowedRedirectUri("mail.agent-native.com/cb")).toBe(false);
+      expect(isAllowedRedirectUri("")).toBe(false);
+      expect(isAllowedRedirectUri(undefined)).toBe(false);
+      expect(isAllowedRedirectUri(null)).toBe(false);
+      expect(isAllowedRedirectUri(42)).toBe(false);
+      expect(isAllowedRedirectUri({})).toBe(false);
+    });
+
+    it("rejects scheme-relative //evil.com", () => {
+      expect(isAllowedRedirectUri("//evil.com/cb")).toBe(false);
+    });
+
+    it("rejects control chars (CRLF header injection / NUL / DEL)", () => {
+      expect(
+        isAllowedRedirectUri(
+          "https://mail.agent-native.com/cb\r\nSet-Cookie: x=1",
+        ),
+      ).toBe(false);
+      // NUL and DEL bytes via escapes so this source stays plain ASCII.
+      expect(
+        isAllowedRedirectUri(
+          "https://mail.agent-native.com/cb" + String.fromCharCode(0),
+        ),
+      ).toBe(false);
+      expect(
+        isAllowedRedirectUri(
+          "https://mail.agent-native.com/cb" + String.fromCharCode(127),
+        ),
+      ).toBe(false);
+    });
+
+    it("does not allow the configured env suffix to be empty/wildcard", () => {
+      expect(getConfiguredHostSuffixes({} as NodeJS.ProcessEnv)).toEqual([]);
+      expect(
+        getConfiguredHostSuffixes({
+          IDENTITY_SSO_ALLOWED_HOST_SUFFIXES: " , . , ",
+        } as unknown as NodeJS.ProcessEnv),
+      ).toEqual([]);
+      expect(
+        getConfiguredHostSuffixes({
+          IDENTITY_SSO_ALLOWED_HOST_SUFFIXES:
+            "staging.example.com, .preview.example.com",
+        } as unknown as NodeJS.ProcessEnv),
+      ).toEqual([".staging.example.com", ".preview.example.com"]);
+    });
+  });
+
+  it("default allowlist is exactly .agent-native.com", () => {
+    expect(DEFAULT_ALLOWED_HOST_SUFFIXES).toEqual([".agent-native.com"]);
+  });
+});
+
+describe("buildIdentityClaims — exact claim set, no secrets", () => {
+  it("produces sub/email/scope/jti and omits empty optionals", () => {
+    const c = buildIdentityClaims({ email: "user@acme.com" });
+    expect(c.sub).toBe("user@acme.com");
+    expect(c.email).toBe("user@acme.com");
+    expect(c.scope).toBe(IDENTITY_SCOPE);
+    expect(c.scope).toBe("identity");
+    expect(typeof c.jti).toBe("string");
+    expect(c.jti.length).toBeGreaterThan(10);
+    expect("name" in c).toBe(false);
+    expect("org_domain" in c).toBe(false);
+  });
+
+  it("includes name + org_domain when present", () => {
+    const c = buildIdentityClaims({
+      email: "u@acme.com",
+      name: "  Ada Lovelace ",
+      orgDomain: " acme.com ",
+    });
+    expect(c.name).toBe("Ada Lovelace");
+    expect(c.org_domain).toBe("acme.com");
+  });
+
+  it("omits blank name / org_domain", () => {
+    const c = buildIdentityClaims({
+      email: "u@acme.com",
+      name: "   ",
+      orgDomain: "",
+    });
+    expect("name" in c).toBe(false);
+    expect("org_domain" in c).toBe(false);
+  });
+
+  it("never carries a password/secret-like field", () => {
+    const c = buildIdentityClaims({ email: "u@acme.com", name: "U" });
+    const keys = Object.keys(c).sort();
+    expect(keys).toEqual(["email", "jti", "name", "scope", "sub"]);
+  });
+
+  it("jti is unique per call", () => {
+    const a = buildIdentityClaims({ email: "u@acme.com" });
+    const b = buildIdentityClaims({ email: "u@acme.com" });
+    expect(a.jti).not.toBe(b.jti);
+  });
+});
+
+describe("token TTL", () => {
+  it("is short (<= 5 min) and the jose duration string matches the seconds", () => {
+    expect(IDENTITY_TOKEN_TTL_SECONDS).toBeLessThanOrEqual(300);
+    expect(IDENTITY_TOKEN_TTL_SECONDS).toBeGreaterThan(0);
+    // "2m" duration string must equal the documented seconds value.
+    expect(IDENTITY_TOKEN_TTL).toBe("2m");
+    expect(IDENTITY_TOKEN_TTL_SECONDS).toBe(120);
+  });
+});
+
+describe("buildRedirectLocation — token + state placement", () => {
+  it("appends token and state as query params, preserving existing query", () => {
+    const loc = buildRedirectLocation(
+      "https://mail.agent-native.com/cb?keep=1",
+      "JWT.HERE.SIG",
+      "opaque-state-123",
+    );
+    const u = new URL(loc);
+    expect(u.origin).toBe("https://mail.agent-native.com");
+    expect(u.pathname).toBe("/cb");
+    expect(u.searchParams.get("keep")).toBe("1");
+    expect(u.searchParams.get("token")).toBe("JWT.HERE.SIG");
+    expect(u.searchParams.get("state")).toBe("opaque-state-123");
+  });
+
+  it("omits state when not provided but always includes token", () => {
+    const loc = buildRedirectLocation(
+      "https://calendar.agent-native.com/auth",
+      "TKN",
+      null,
+    );
+    const u = new URL(loc);
+    expect(u.searchParams.get("token")).toBe("TKN");
+    expect(u.searchParams.has("state")).toBe(false);
+  });
+
+  it("does not mutate / re-encode an opaque state value's identity", () => {
+    const state = "a+b/c=d&e";
+    const loc = buildRedirectLocation(
+      "https://mail.agent-native.com/cb",
+      "TKN",
+      state,
+    );
+    // URL round-trips it; the parsed value must equal the original.
+    expect(new URL(loc).searchParams.get("state")).toBe(state);
+  });
+});

--- a/templates/dispatch/server/lib/identity-sso.ts
+++ b/templates/dispatch/server/lib/identity-sso.ts
@@ -1,0 +1,222 @@
+/**
+ * Identity-authority logic for "Sign in with Agent-Native".
+ *
+ * Dispatch is the canonical identity authority. A first-party client app
+ * (mail, calendar, analytics, …) bounces an unauthenticated visitor to
+ * Dispatch's `/_agent-native/identity/authorize`. Dispatch reuses its EXISTING
+ * Better Auth session + login flow, then mints a short-lived signed identity
+ * JWT (the existing A2A signer) and 302s back to the client's `redirect_uri`
+ * with the token + the caller's untouched `state`.
+ *
+ * This module holds the pure, side-effect-free pieces so they can be unit
+ * tested in isolation:
+ *   - `isAllowedRedirectUri`  — the single most important security control.
+ *   - `buildIdentityClaims`   — the exact JWT claim set + TTL.
+ *   - `buildRedirectLocation` — where the token + state land on the redirect.
+ *
+ * The HTTP wiring (session resolution, login bounce, signing) lives in
+ * `server/plugins/identity-sso.ts` so this file stays trivially testable with
+ * no Nitro / crypto / DB dependencies.
+ */
+
+import { randomUUID } from "node:crypto";
+
+// Control-char guard (NUL..US + DEL). Defined via codepoints so this source
+// file stays plain ASCII (mirrors packages/core/src/server/open-route.ts).
+const CONTROL_CHARS = new RegExp("[\\u0000-\\u001f\\u007f]");
+
+/**
+ * Identity tokens are auth codes, NOT API tokens. They are exchanged
+ * immediately by the client for its own session, so a tight TTL is correct.
+ * 5 minutes is the documented upper bound from the build spec; we use 2.
+ *
+ * NOTE on the type: `signA2AToken` forwards `expiresIn` to
+ * `jose.SignJWT.setExpirationTime`. In jose, a NUMBER is interpreted as an
+ * ABSOLUTE Unix timestamp (seconds), while a STRING like `"2m"` is parsed
+ * as a duration from now. We MUST pass the duration string form, so the
+ * canonical constant is the jose duration string; the seconds value is
+ * exported alongside it for tests/assertions only.
+ */
+export const IDENTITY_TOKEN_TTL_SECONDS = 120;
+export const IDENTITY_TOKEN_TTL = "2m";
+
+/** JWT `scope` claim marking this as an identity (login) token, not A2A/MCP. */
+export const IDENTITY_SCOPE = "identity";
+
+/**
+ * Host suffixes that a `redirect_uri` may belong to. This is the core
+ * open-redirect / token-theft guard: an attacker-supplied `redirect_uri`
+ * pointing anywhere else would exfiltrate the identity token.
+ *
+ * `.agent-native.com` covers every first-party hosted app
+ * (mail.agent-native.com, calendar.agent-native.com, …) — the shared
+ * first-party prod-URL registry is exactly the `*.agent-native.com`
+ * subdomain space, so a suffix check is both sufficient and the least
+ * footgun-prone (no per-app list to keep in sync).
+ *
+ * These are matched as DOT-prefixed suffixes against the parsed URL
+ * hostname, so `agent-native.com.evil.com` does NOT match
+ * `.agent-native.com` (it ends in `.evil.com`), and a bare
+ * `agent-native.com` apex is intentionally NOT matched (all first-party
+ * apps are subdomains; the apex is the marketing site).
+ */
+export const DEFAULT_ALLOWED_HOST_SUFFIXES: readonly string[] = [
+  ".agent-native.com",
+];
+
+/** Loopback hosts allowed for local development of the client side. */
+const LOCALHOST_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+/**
+ * Read an optional comma-separated extra-host-suffix allowlist from the
+ * environment. Used for staging/preview client hosts that are not on
+ * `*.agent-native.com`. Each entry is normalised to a lower-case,
+ * dot-prefixed suffix so it can only ever broaden by whole-host suffix,
+ * never by substring.
+ *
+ * Deploy-level configuration (not a user credential), so reading it from
+ * the environment here is correct and outside the credentials-guard paths.
+ */
+export function getConfiguredHostSuffixes(
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  const raw = env.IDENTITY_SSO_ALLOWED_HOST_SUFFIXES;
+  if (!raw || typeof raw !== "string") return [];
+  return (
+    raw
+      .split(",")
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean)
+      .map((s) => (s.startsWith(".") ? s : `.${s}`))
+      // Guard against a misconfigured "" / "." that would match everything.
+      .filter((s) => s.length > 1 && s !== ".")
+  );
+}
+
+/**
+ * The redirect-URI allowlist. THE critical control on this endpoint.
+ *
+ * A `redirect_uri` is accepted ONLY when ALL of the following hold:
+ *   1. It parses as an absolute URL.
+ *   2. Its scheme is exactly `https:`  — EXCEPT loopback dev hosts, where
+ *      `http:` is also allowed (TLS is not available on localhost).
+ *   3. It has no embedded credentials (`user:pass@host`) — those are an
+ *      open-redirect obfuscation vector.
+ *   4. Its hostname is either a loopback host, OR ends in one of the
+ *      allowed host suffixes (default `.agent-native.com`, plus any
+ *      configured via env). The suffix is matched against the FULL parsed
+ *      hostname with a leading dot, so `agent-native.com.evil.com` is
+ *      rejected (ends in `.evil.com`) and substring spoofs cannot pass.
+ *
+ * Everything else is rejected. Fragments/queries on the URI are allowed
+ * (the client may have its own) — we append our params safely.
+ */
+export function isAllowedRedirectUri(
+  rawRedirectUri: unknown,
+  options: { allowedHostSuffixes?: readonly string[] } = {},
+): boolean {
+  if (typeof rawRedirectUri !== "string" || rawRedirectUri.length === 0) {
+    return false;
+  }
+  // Reject control chars up front (CR/LF header-injection, NUL, etc.).
+  if (CONTROL_CHARS.test(rawRedirectUri)) return false;
+
+  let url: URL;
+  try {
+    url = new URL(rawRedirectUri);
+  } catch {
+    return false;
+  }
+
+  // No embedded credentials — `https://evil@good.agent-native.com` style.
+  if (url.username || url.password) return false;
+
+  const hostname = url.hostname.toLowerCase();
+  const isLoopback = LOCALHOST_HOSTS.has(hostname);
+
+  // Scheme: https everywhere, http only for loopback dev.
+  if (url.protocol === "https:") {
+    // ok
+  } else if (url.protocol === "http:" && isLoopback) {
+    // ok — local dev
+  } else {
+    return false;
+  }
+
+  if (isLoopback) return true;
+
+  const suffixes = [
+    ...DEFAULT_ALLOWED_HOST_SUFFIXES,
+    ...(options.allowedHostSuffixes ?? getConfiguredHostSuffixes()),
+  ];
+
+  // Suffix match against the full hostname, leading-dot anchored so a
+  // sibling/parent host can never satisfy a child's suffix:
+  //   "mail.agent-native.com".endsWith(".agent-native.com")        -> true
+  //   "agent-native.com.evil.com".endsWith(".agent-native.com")    -> false
+  //   "evil-agent-native.com".endsWith(".agent-native.com")        -> false
+  return suffixes.some((suffix) => hostname.endsWith(suffix));
+}
+
+export interface IdentityClaims {
+  /** Stable user identifier — the Dispatch account email. */
+  sub: string;
+  email: string;
+  /** Display name when the auth provider supplied one. */
+  name?: string;
+  /** Resolved org domain when the user has an active org; omitted otherwise. */
+  org_domain?: string;
+  /** Marks this token as an identity (login) token. */
+  scope: typeof IDENTITY_SCOPE;
+  /** Random per-token id for replay/debugging. */
+  jti: string;
+}
+
+/**
+ * Build the EXACT claim set for the identity token. No secrets/passwords
+ * ever go in here. `sub` and `email` are the same value (the account email)
+ * so a verifier can key on either. `org_domain` is included only when known.
+ */
+export function buildIdentityClaims(input: {
+  email: string;
+  name?: string | null;
+  orgDomain?: string | null;
+}): IdentityClaims {
+  const claims: IdentityClaims = {
+    sub: input.email,
+    email: input.email,
+    scope: IDENTITY_SCOPE,
+    jti: randomUUID(),
+  };
+  if (input.name && input.name.trim()) claims.name = input.name.trim();
+  if (input.orgDomain && input.orgDomain.trim()) {
+    claims.org_domain = input.orgDomain.trim();
+  }
+  return claims;
+}
+
+/**
+ * Construct the final redirect `Location`: the validated `redirect_uri`
+ * with `token` and the caller's untouched `state` appended as QUERY
+ * parameters (not the fragment) so a server-side client callback can read
+ * them. Preserves any pre-existing query the client put on its
+ * `redirect_uri`.
+ *
+ * The token is placed in `?token=<jwt>` and the opaque caller value in
+ * `?state=<state>` — the client MUST echo-check `state` against what it
+ * generated before trusting the token.
+ *
+ * `rawRedirectUri` MUST already have passed `isAllowedRedirectUri`.
+ */
+export function buildRedirectLocation(
+  rawRedirectUri: string,
+  token: string,
+  state: string | null | undefined,
+): string {
+  const url = new URL(rawRedirectUri);
+  url.searchParams.set("token", token);
+  if (typeof state === "string" && state.length > 0) {
+    url.searchParams.set("state", state);
+  }
+  return url.toString();
+}

--- a/templates/dispatch/server/plugins/identity-sso.ts
+++ b/templates/dispatch/server/plugins/identity-sso.ts
@@ -1,0 +1,235 @@
+/**
+ * `/_agent-native/identity/authorize` — Dispatch as the cross-app identity
+ * AUTHORITY ("Sign in with Agent-Native").
+ *
+ * Flow (single-endpoint, no code-exchange — see "Why no /token" below):
+ *
+ *   1. A first-party client app (mail, calendar, …) redirects an
+ *      unauthenticated visitor here with:
+ *        ?app=<id>&redirect_uri=<https url>&state=<opaque>
+ *
+ *   2. We validate `redirect_uri` against the strict allowlist
+ *      (`isAllowedRedirectUri`). An invalid/forbidden value is rejected
+ *      with 400 BEFORE any session work — an attacker-controlled
+ *      `redirect_uri` must never receive a token. This is the single most
+ *      important control on this endpoint.
+ *
+ *   3. We resolve the EXISTING Dispatch Better Auth session (`getSession`).
+ *      - Not logged in -> 302 to the framework's existing sign-in
+ *        entrypoint `/_agent-native/sign-in?return=<this authorize URL>`.
+ *        The framework serves Dispatch's normal login form, and on success
+ *        its post-login reload re-hits `/_agent-native/sign-in`, which 302s
+ *        back to `return` (validated same-origin by the framework's
+ *        `safeReturnPath`). That re-enters THIS handler authenticated. No
+ *        new login UI; we reuse Dispatch's exact existing auth flow.
+ *      - Logged in  -> mint + redirect (step 4).
+ *
+ *   4. Mint a SHORT-LIVED signed identity JWT using the EXISTING A2A signer
+ *      (`signA2AToken`, HS256 over the shared `A2A_SECRET`). Claims are
+ *      exactly: sub=email, email, name?, org_domain?, scope:"identity",
+ *      jti, short exp (<= 5 min). 302 to `redirect_uri` with the token and
+ *      the caller's UNTOUCHED `state` appended as query params.
+ *
+ * Why no `/token` code-exchange endpoint:
+ *   The token is already (a) short-lived (<=2 min exp), (b) signature-
+ *   verified against the shared A2A secret, and (c) only ever delivered to
+ *   an allowlisted first-party https host. Adding a code + exchange
+ *   endpoint would add surface (a second unauthenticated route, a code
+ *   store) without changing the trust model, since the redirect target is
+ *   already constrained. We therefore sign directly and return via the
+ *   redirect query — the simplest secure flow.
+ *
+ * Replay protection:
+ *   The short `exp` (<=2 min) + random `jti` + the caller's `state`
+ *   echo-check (the client MUST verify `state` it generated) bound the
+ *   replay window. We intentionally do NOT add a Dispatch-side jti store:
+ *   the core MCP connect-store jti helpers are not importable from a public
+ *   `@agent-native/core` subpath, and a bespoke store would be net-new
+ *   surface for a token whose window is already <=2 min and single-origin.
+ *   This is documented as the chosen trade-off.
+ *
+ * Auth-guard reachability:
+ *   `/_agent-native/*` is 401'd by the core auth guard when there is no
+ *   session, which would break the logged-OUT bounce. So this plugin
+ *   registers the exact path `/_agent-native/identity/authorize` as a
+ *   `publicPath` via a second `createAuthPlugin({ publicPaths })` call.
+ *   When two `createAuthPlugin` calls run in the same server boot on the
+ *   same Nitro app, the framework APPENDS publicPaths to the live guard
+ *   config (it does not clobber Dispatch's googleOnly/marketing/onboarding
+ *   — verified in packages/core/src/server/auth.ts). The path is matched
+ *   exactly (or as a `/`-segment prefix), so ONLY the authorize endpoint
+ *   becomes public; any future `/_agent-native/identity/*` route stays
+ *   protected. The handler then resolves the session ITSELF (exactly the
+ *   `/_agent-native/open` pattern) — public-path only means "guard does not
+ *   pre-empt", not "no auth": logged-out users are still bounced to login,
+ *   and a token is only minted for a real session.
+ */
+
+import {
+  createAuthPlugin,
+  getH3App,
+  getSession,
+} from "@agent-native/core/server";
+import { signA2AToken } from "@agent-native/core/a2a";
+import { getOrgDomain } from "@agent-native/core/org";
+import { defineEventHandler, getMethod } from "h3";
+import type { H3Event } from "h3";
+import {
+  IDENTITY_TOKEN_TTL,
+  buildIdentityClaims,
+  buildRedirectLocation,
+  isAllowedRedirectUri,
+} from "../lib/identity-sso.js";
+
+/** Exact path. Registered as a publicPath so the guard does not 401 it. */
+const AUTHORIZE_PATH = "/_agent-native/identity/authorize";
+
+function getRequestUrl(event: H3Event): string {
+  return (event as any).node?.req?.url ?? (event as any).path ?? "/";
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function redirect(location: string): Response {
+  // Native web Response — matches the redirect style used by the core
+  // /open + auth routes (avoids h3 v2 sendRedirect behavior differences).
+  return new Response("", { status: 302, headers: { Location: location } });
+}
+
+/**
+ * Resolve the org domain for the active org, best-effort. A missing org
+ * just yields a token with no `org_domain` claim (still a valid identity).
+ */
+async function resolveOrgDomain(
+  orgId: string | undefined,
+): Promise<string | undefined> {
+  if (!orgId) return undefined;
+  try {
+    return (await getOrgDomain(orgId)) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+const authorizeHandler = defineEventHandler(
+  async (event: H3Event): Promise<Response> => {
+    const method = getMethod(event);
+    if (method !== "GET" && method !== "HEAD") {
+      return jsonResponse({ error: "Method not allowed" }, 405);
+    }
+
+    const rawUrl = getRequestUrl(event);
+    let search: URLSearchParams;
+    try {
+      search = new URL(rawUrl, "http://an.invalid").searchParams;
+    } catch {
+      search = new URLSearchParams();
+    }
+
+    const redirectUri = search.get("redirect_uri");
+    const state = search.get("state");
+
+    // ---- Control 1: redirect_uri allowlist (BEFORE any session work) ----
+    // An attacker-supplied redirect_uri must never reach the mint path.
+    if (!isAllowedRedirectUri(redirectUri)) {
+      return jsonResponse(
+        {
+          error: "invalid_redirect_uri",
+          error_description:
+            "redirect_uri must be an absolute https URL on an allowed " +
+            "first-party host (a localhost http URL is allowed for " +
+            "local development).",
+        },
+        400,
+      );
+    }
+    // Narrowed to string by isAllowedRedirectUri.
+    const safeRedirectUri = redirectUri as string;
+
+    // ---- Resolve the EXISTING Dispatch session --------------------------
+    const session = await getSession(event).catch(() => null);
+
+    if (!session?.email) {
+      // Logged out: bounce through the framework's existing sign-in
+      // entrypoint, preserving the FULL authorize URL as the return target
+      // so we re-enter here authenticated. `safeReturnPath` (framework
+      // side) validates `return` is same-origin, so this cannot be turned
+      // into an open redirect.
+      const queryStart = rawUrl.indexOf("?");
+      const authorizePathWithQuery =
+        AUTHORIZE_PATH + (queryStart >= 0 ? rawUrl.slice(queryStart) : "");
+      const loc =
+        "/_agent-native/sign-in?return=" +
+        encodeURIComponent(authorizePathWithQuery);
+      return redirect(loc);
+    }
+
+    // ---- Mint the short-lived identity token ----------------------------
+    if (!process.env.A2A_SECRET) {
+      // Without a shared secret, no first-party app could verify the token.
+      return jsonResponse(
+        {
+          error: "identity_unavailable",
+          error_description:
+            "This Dispatch deployment has no A2A_SECRET configured, so " +
+            "identity tokens cannot be signed.",
+        },
+        503,
+      );
+    }
+
+    const orgDomain = await resolveOrgDomain(session.orgId);
+    const claims = buildIdentityClaims({
+      email: session.email,
+      name: session.name,
+      orgDomain,
+    });
+
+    let token: string;
+    try {
+      // Reuse the EXISTING signer. `sub`/`org_domain` are set by the
+      // signer from (email, orgDomain) and CANNOT be overridden via
+      // extraClaims (the signer spreads them last), so the extra
+      // identity claims here can never spoof identity.
+      token = await signA2AToken(session.email, orgDomain, undefined, {
+        preferGlobalSecret: true,
+        // jose treats a number as an absolute Unix ts; pass the duration
+        // string ("2m") so exp is `now + 2m`.
+        expiresIn: IDENTITY_TOKEN_TTL,
+        extraClaims: {
+          email: claims.email,
+          ...(claims.name ? { name: claims.name } : {}),
+          scope: claims.scope,
+          jti: claims.jti,
+        },
+      });
+    } catch {
+      return jsonResponse(
+        {
+          error: "sign_failed",
+          error_description: "Failed to mint identity token.",
+        },
+        500,
+      );
+    }
+
+    return redirect(buildRedirectLocation(safeRedirectUri, token, state));
+  },
+);
+
+/**
+ * Dispatch identity-SSO plugin. Mounts the authorize route and registers
+ * its exact path as a public path so the core auth guard does not 401 the
+ * logged-out bounce. The `createAuthPlugin({ publicPaths })` call is
+ * additive — it appends to the live guard config without disturbing the
+ * primary Dispatch auth plugin's googleOnly/marketing/onboarding config.
+ */
+export default async (nitroApp: any) => {
+  getH3App(nitroApp).use(AUTHORIZE_PATH, authorizeHandler);
+  return createAuthPlugin({ publicPaths: [AUTHORIZE_PATH] })(nitroApp);
+};

--- a/templates/dispatch/server/plugins/identity-sso.ts
+++ b/templates/dispatch/server/plugins/identity-sso.ts
@@ -27,8 +27,9 @@
  *   4. Mint a SHORT-LIVED signed identity JWT using the EXISTING A2A signer
  *      (`signA2AToken`, HS256 over the shared `A2A_SECRET`). Claims are
  *      exactly: sub=email, email, name?, org_domain?, scope:"identity",
- *      jti, short exp (<= 5 min). 302 to `redirect_uri` with the token and
- *      the caller's UNTOUCHED `state` appended as query params.
+ *      aud=redirect_uri, redirect_uri, jti, short exp (<= 5 min). 302 to
+ *      `redirect_uri` with the token and the caller's UNTOUCHED `state`
+ *      appended as query params.
  *
  * Why no `/token` code-exchange endpoint:
  *   The token is already (a) short-lived (<=2 min exp), (b) signature-
@@ -205,6 +206,8 @@ const authorizeHandler = defineEventHandler(
           email: claims.email,
           ...(claims.name ? { name: claims.name } : {}),
           scope: claims.scope,
+          aud: safeRedirectUri,
+          redirect_uri: safeRedirectUri,
           jti: claims.jti,
         },
       });

--- a/templates/dispatch/vitest.config.ts
+++ b/templates/dispatch/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Minimal node test runner for the Dispatch template's server-side unit
+ * tests (currently the identity-SSO redirect-allowlist + claim logic).
+ * Scoped to `server/**` so it never tries to bundle the React app.
+ */
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["server/**/*.spec.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

- Improve the Desktop Code tab chat UX with shared conversation primitives, ordered transcript parts, better markdown rendering, clickable external links, compact tool calls, hidden runner diagnostics, and fixed stuck tool states.
- Add a browser-safe Code transcript normalizer export and Electron transcript handling fixes for streamed token whitespace.
- Include the concurrent identity SSO / dev auto sign-in cookie work and documentation changes that were present in the local branch, per request to push the full branch.

## Notes

The Code tab now uses the new shared `AgentConversation` primitives from core, but the main agent sidebar is not fully migrated onto that same renderer yet. The sidebar still uses its existing `AssistantChat` / assistant-ui rendering path. The next UX consolidation step should be making the shared conversation renderer canonical for both surfaces so markdown/tool-call improvements land everywhere by default.

## Validation

- `pnpm prep`
- `pnpm --filter @agent-native/core typecheck`
- `pnpm --filter @agent-native/core build`
- `pnpm --filter @agent-native/code-agents-ui typecheck`
- `pnpm --filter @agent-native/desktop-app typecheck`
- `pnpm --filter @agent-native/desktop-app build`
- Focused Vitest coverage for Code transcript normalization and shared conversation rendering
- Electron smoke test against the Desktop Code tab test session: no runner diagnostics, markdown structure present, `list_files` renders once as finished, and tool calls render in transcript order
