### PR TITLE
fix(external-agents): full MCP surface over connect token + list_apps live origin + connect page refresh

### DIFF
--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: external-agents
 description: >-
-  Connect external coding agents (Claude Code desktop & CLI, Claude Cowork,
-  Codex) to an agent-native app over MCP, and round-trip artifacts back into
-  the UI with deep links. Use when adding an action's `link` builder, wiring
-  the `/_agent-native/open` route, exposing an "ingest" action to MCP/A2A, or
-  scaffolding apps from an external agent.
+  Connect external coding agents (Claude Code desktop & CLI, Codex, Cursor,
+  Claude Cowork) to an agent-native app over MCP, and round-trip artifacts back
+  into the UI with deep links. Use when adding an action's `link` builder,
+  wiring the `/_agent-native/open` route, exposing an "ingest" action to
+  MCP/A2A, or scaffolding apps from an external agent.
 ---
 
 # External Agents (MCP bridge + deep links)
@@ -13,15 +13,15 @@ description: >-
 ## Rule
 
 An agent-native app is reachable by any external coding agent (Claude Code,
-Cowork, Codex) over MCP. The **recommended** way to connect to a deployed app
-is the one-command hosted flow — `npx @agent-native/core connect <url>` — which
-mints a per-user, scoped, revocable token from a logged-in browser session; no
-shared secret is copied. Once connected, every action that produces or lists a
-navigable resource SHOULD return a deep link from a `link` builder, so the
-external agent can surface an **"Open in <app> →"** link that drops the user
-back into the running UI at the right view and record. The link is a pure
-pointer — the record-focusing write is always scoped to the **browser
-session**, never the agent's token.
+Codex, Cursor, Cowork) over MCP. The **recommended** way to connect to a
+deployed app is the one-command hosted flow — `npx @agent-native/core connect
+<url>` — which mints a per-user, scoped, revocable token from a logged-in
+browser session; no shared secret is copied. Once connected, every action that
+produces or lists a navigable resource SHOULD return a deep link from a `link`
+builder, so the external agent can surface an **"Open in <app> →"** link that
+drops the user back into the running UI at the right view and record. The link
+is a pure pointer — the record-focusing write is always scoped to the
+**browser session**, never the agent's token.
 
 ## Why
 
@@ -39,8 +39,9 @@ mechanism.
 ### 1. Connect to a hosted app (recommended)
 
 The first-party hosted apps live at `mail.agent-native.com`,
-`calendar.agent-native.com`, etc. One command wires every detected agent
-client (Claude Code, Codex, Cowork) to one of them:
+`calendar.agent-native.com`, etc. One command wires every detected supported
+agent client (Claude Code, Codex, Cowork) to one of them. Cursor can use the
+same MCP endpoint via the no-CLI/manual config path:
 
 ```bash
 npx @agent-native/core connect https://mail.agent-native.com

--- a/.changeset/external-agents-connect-flow.md
+++ b/.changeset/external-agents-connect-flow.md
@@ -1,0 +1,19 @@
+---
+"@agent-native/core": patch
+---
+
+Harden and complete external-agent MCP connect flows for hosted and local apps.
+
+- A connect-minted token (or `mcp install` / ACCESS_TOKEN / production caller)
+  now gets the full MCP tool surface — including mutating template actions
+  like `create-document` — even in local dev, matching the documented
+  external-agents contract. Previously a connected Claude Code/Codex/Cowork
+  only saw framework builtins in dev, so "say it and it does it" didn't work
+  against a local app.
+- `list_apps` now reports the live request origin and `running: true` for the
+  app serving the request, instead of a guessed `PORT || 5173` URL with
+  `running: false` (which mis-pointed cross-app deep links on non-default
+  dev ports).
+- The in-app Connect page now auto-refreshes "Your connections" after a
+  device authorize, so the new connection appears (with a "Connected"
+  confirmation) without a manual reload.

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -1,23 +1,42 @@
 ---
-title: "External Agents"
-description: "Connect your own Claude Code, Cowork, or Codex to a hosted agent-native app in one command — then round-trip artifacts back into the running UI with deep links."
+title: "External Agents: Claude Code, Codex, Cursor, Cowork"
+description: "Connect your own Claude Code, Codex, Cursor, or Claude Cowork to a hosted agent-native app — then round-trip artifacts back into the running UI with deep links."
+search: "Claude Code Codex Cursor Claude Cowork agent-native connect MCP local agent tools external agents"
 ---
 
 # External Agents
 
-An agent-native app is reachable by any external coding agent — Claude Code (desktop & CLI), Claude Cowork, Codex — over [MCP](/docs/mcp-protocol). External agents are great at producing artifacts (a draft, an event, a dashboard) but they live in a terminal or another app. Without a bridge, the user gets a wall of JSON and has to go find the thing.
+An agent-native app is reachable by any external coding agent — Claude Code (desktop & CLI), Codex, Cursor, Claude Cowork — over [MCP](/docs/mcp-protocol). External agents are great at producing artifacts (a draft, an event, a dashboard) but they live in a terminal or another app. Without a bridge, the user gets a wall of JSON and has to go find the thing.
 
 The external-agent bridge closes the loop. First you connect your own agent to a **hosted** app — one command, no token copying. Then the agent does the work over MCP and hands the user a single **"Open in &lt;app&gt; →"** link that opens the real app focused on exactly what was produced. It reuses the existing `navigate` / `application_state` contract the UI already drains every 2s (see [Context Awareness](/docs/context-awareness)) — there is no second navigation mechanism.
 
-## Connect in one command {#connect}
+## Connect Claude Code, Codex, Cursor, and Cowork {#connect}
 
-The first-party hosted apps live at `mail.agent-native.com`, `calendar.agent-native.com`, `analytics.agent-native.com`, and so on. To wire your own Claude Code (and Codex / Cowork if detected) to one of them:
+The first-party hosted apps live at `mail.agent-native.com`, `calendar.agent-native.com`, `analytics.agent-native.com`, and so on. This flow connects supported local agent clients on your machine — Claude Code, Claude Code CLI, Codex, and Claude Cowork — to a hosted agent-native app over MCP. Cursor can use the same MCP endpoint via the no-CLI/manual config path below.
+
+If you have the Agent-Native CLI installed, run:
+
+```bash
+agent-native connect https://mail.agent-native.com
+```
+
+Or run the same command through npm without installing anything globally:
 
 ```bash
 npx @agent-native/core connect https://mail.agent-native.com
 ```
 
-This opens your browser at the app. You are already logged in, so you just click **Authorize** once. The command detects every installed agent client and writes the MCP config for each — no token to copy, no local server to run. Connect every first-party hosted app at once with:
+This opens your browser at the app. You are already logged in, so you just click **Authorize** once. The command detects every installed agent client and writes the right MCP config for each:
+
+| Local client                  | Config written by `connect`                                 |
+| ----------------------------- | ----------------------------------------------------------- |
+| Claude Code / Claude Code CLI | `.mcp.json` or `~/.claude.json`, depending on `--scope`     |
+| Codex                         | `~/.codex/config.toml` under `[mcp_servers.<app>]`          |
+| Claude Cowork                 | `~/.cowork/mcp.json` using the Claude Code MCP server shape |
+
+There is no token to copy and no local server to run. Restart the agent client after connecting so it picks up the new MCP server.
+
+Connect every first-party hosted app at once with:
 
 ```bash
 npx @agent-native/core connect --all
@@ -43,6 +62,8 @@ If you'd rather not run a command, open the app in your browser and use its **Co
 ```
 
 Restart the agent client after connecting so it picks up the new MCP server.
+
+Use this manual block for MCP clients that are not yet written by `agent-native connect`, including Cursor.
 
 ## What you can do once connected {#what-you-can-do}
 

--- a/packages/core/docs/content/mcp-clients.md
+++ b/packages/core/docs/content/mcp-clients.md
@@ -7,6 +7,8 @@ description: "Connect your agent-native app to local MCP servers (claude-in-chro
 
 Agent-native apps can also act as MCP **clients** — connecting to locally installed MCP servers and exposing their tools to the agent chat. This is the symmetric counterpart to the [MCP Protocol](./mcp-protocol.md) (which makes your app an MCP server).
 
+Looking for the other direction — connecting Claude Code, Codex, Cursor, or Claude Cowork to an agent-native app? Use [External Agents](/docs/external-agents).
+
 With one config file, every agent-native app in your workspace gains access to tools provided by MCP servers on your machine: `claude-in-chrome` for browser automation, `@modelcontextprotocol/server-filesystem` for reading files, `@playwright/mcp` for browser testing, and anything else that speaks MCP.
 
 You can also [connect remote (HTTP) MCP servers at runtime](#remote-via-ui) — individual users or whole organizations — without editing a config file.

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -7,6 +7,8 @@ description: "Expose your agent-native app as a remote MCP server so Claude Code
 
 Every agent-native app automatically exposes a remote MCP (Model Context Protocol) server. This lets external AI tools like Claude Code, Cursor, and Windsurf discover and call your app's actions directly — no extra code needed.
 
+If your goal is to connect Claude Code, Codex, Cursor, or Claude Cowork to a hosted agent-native app, start with [External Agents](/docs/external-agents). It documents the one-command `agent-native connect https://mail.agent-native.com` flow, token minting, local client config writes, manual MCP config for clients like Cursor, and deep links back into the UI. This page is the lower-level MCP server reference.
+
 ## Overview {#overview}
 
 MCP is the standard protocol for connecting AI tools to external capabilities. When you deploy an agent-native app, it auto-mounts an MCP endpoint alongside the existing A2A endpoint. Any MCP-compatible client can connect and use your app's tools.
@@ -34,9 +36,9 @@ Both protocols are auto-mounted. Use whichever fits your use case:
 
 You can also use the `ask-agent` MCP tool to get the best of both worlds — call it from Claude Code and let your app's agent reason through complex tasks.
 
-## Connecting from Claude Code {#claude-code}
+## Manual MCP client config {#claude-code}
 
-Add your app as a remote MCP server in Claude Code's config:
+For the recommended one-command setup, use [External Agents](/docs/external-agents). If you are hand-writing MCP config, add your app as a remote MCP server in Claude Code's config:
 
 ```jsonc
 // ~/.claude/mcp_servers.json

--- a/packages/core/src/cli/connect.spec.ts
+++ b/packages/core/src/cli/connect.spec.ts
@@ -204,6 +204,37 @@ describe("runDeviceFlow", () => {
     );
   });
 
+  it("accepts an approved local entry without a bearer token", async () => {
+    const grant = await runDeviceFlow(
+      "http://localhost:4321",
+      "analytics",
+      "codex",
+      {
+        fetchImpl: makeFetch([
+          {
+            status: "approved",
+            token: "",
+            mcpUrl: "http://localhost:4321/_agent-native/mcp",
+            serverName: "agent-native-analytics-local",
+            mcpServerEntry: {
+              type: "http",
+              url: "http://localhost:4321/_agent-native/mcp",
+              headers: { "X-Agent-Native-Owner-Email": "u@example.com" },
+            },
+          },
+        ]),
+        sleep: noopSleep,
+        openBrowser: vi.fn(),
+      },
+    );
+    expect(grant).toEqual({
+      token: undefined,
+      mcpUrl: "http://localhost:4321/_agent-native/mcp",
+      serverName: "agent-native-analytics-local",
+      headers: { "X-Agent-Native-Owner-Email": "u@example.com" },
+    });
+  });
+
   it("returns null on expired", async () => {
     const grant = await runDeviceFlow("https://app.example.com", "app", "all", {
       fetchImpl: makeFetch([{ status: "pending" }, { status: "expired" }]),
@@ -348,6 +379,25 @@ describe("writeConfigs", () => {
     });
   });
 
+  it("writes a JSON HTTP entry with server-provided headers and no token", () => {
+    const root = tmpDir();
+    const written = writeConfigs(
+      ["claude-code"],
+      "agent-native-analytics-local",
+      "http://localhost:4321/_agent-native/mcp",
+      undefined,
+      "project",
+      root,
+      { "X-Agent-Native-Owner-Email": "u@example.com" },
+    );
+    const cfg = JSON.parse(fs.readFileSync(written[0].file, "utf-8"));
+    expect(cfg.mcpServers["agent-native-analytics-local"]).toEqual({
+      type: "http",
+      url: "http://localhost:4321/_agent-native/mcp",
+      headers: { "X-Agent-Native-Owner-Email": "u@example.com" },
+    });
+  });
+
   it("is idempotent: re-running replaces the same entry, no duplicates", () => {
     const root = tmpDir();
     writeConfigs(
@@ -419,7 +469,7 @@ describe("writeConfigs", () => {
       expect(toml).toContain(
         'url = "https://mail.agent-native.com/_agent-native/mcp"',
       );
-      expect(toml).toContain("Bearer tok-1");
+      expect(toml).toContain('"Authorization" = "Bearer tok-1"');
       // Re-run is idempotent (single block).
       writeConfigs(
         ["codex"],
@@ -437,6 +487,29 @@ describe("writeConfigs", () => {
     } finally {
       process.env.HOME = HOME;
       void codexFile;
+    }
+  });
+
+  it("writes Codex TOML headers returned by the server", () => {
+    const root = tmpDir();
+    const HOME = process.env.HOME;
+    const codexHome = tmpDir();
+    process.env.HOME = codexHome;
+    try {
+      const written = writeConfigs(
+        ["codex"],
+        "agent-native-analytics-local",
+        "http://localhost:4321/_agent-native/mcp",
+        undefined,
+        "project",
+        root,
+        { "X-Agent-Native-Owner-Email": "u@example.com" },
+      );
+      const toml = fs.readFileSync(written[0].file, "utf-8");
+      expect(toml).toContain('"X-Agent-Native-Owner-Email" = "u@example.com"');
+      expect(toml).not.toContain("Authorization");
+    } finally {
+      process.env.HOME = HOME;
     }
   });
 

--- a/packages/core/src/cli/connect.ts
+++ b/packages/core/src/cli/connect.ts
@@ -275,7 +275,12 @@ export async function runDeviceFlow(
   appSlug: string,
   clientArg: string,
   deps: ConnectDeps = {},
-): Promise<{ token: string; mcpUrl: string; serverName: string } | null> {
+): Promise<{
+  token?: string;
+  mcpUrl: string;
+  serverName: string;
+  headers?: Record<string, string>;
+} | null> {
   const fetchImpl = deps.fetchImpl ?? fetch;
   const sleep = deps.sleep ?? realSleep;
   const open = deps.openBrowser ?? openInBrowser;
@@ -347,12 +352,15 @@ export async function runDeviceFlow(
       const token = poll.token ?? "";
       const mcpUrl = poll.mcpUrl ?? `${baseUrl}/_agent-native/mcp`;
       const serverName = poll.serverName ?? `${SERVER_NAME_PREFIX}-${appSlug}`;
-      if (!token) {
-        logErr("  Server approved but returned no token. Aborting.");
-        return null;
-      }
+      const headers =
+        poll.mcpServerEntry &&
+        typeof poll.mcpServerEntry === "object" &&
+        poll.mcpServerEntry.headers &&
+        typeof poll.mcpServerEntry.headers === "object"
+          ? (poll.mcpServerEntry.headers as Record<string, string>)
+          : undefined;
       logOut("  Approved.");
-      return { token, mcpUrl, serverName };
+      return { token: token || undefined, mcpUrl, serverName, headers };
     }
     if (poll.status === "expired") {
       if (isTTY) process.stdout.write("\r\x1b[K");
@@ -408,9 +416,10 @@ export function writeConfigs(
   clients: ClientId[],
   serverName: string,
   mcpUrl: string,
-  token: string,
+  token: string | undefined,
   scope: string,
   baseDir: string = projectBaseDir(),
+  headers?: Record<string, string>,
 ): { client: ClientId; file: string }[] {
   const written: { client: ClientId; file: string }[] = [];
   for (const client of clients) {
@@ -421,6 +430,7 @@ export function writeConfigs(
       token,
       baseDir,
       scope,
+      headers,
     );
     written.push({ client, file });
   }
@@ -441,9 +451,10 @@ async function connectOne(
   const clients = resolveClients(parsed.client);
   const scope = parsed.scope === "user" ? "user" : "project";
 
-  let token: string;
+  let token: string | undefined;
   let mcpUrl: string;
   let serverName: string;
+  let headers: Record<string, string> | undefined;
 
   if (parsed.token) {
     // No-browser fallback: skip the device flow entirely.
@@ -458,9 +469,18 @@ async function connectOne(
     token = grant.token;
     mcpUrl = grant.mcpUrl;
     serverName = parsed.name ?? grant.serverName ?? defaultServerName(baseUrl);
+    headers = grant.headers;
   }
 
-  const written = writeConfigs(clients, serverName, mcpUrl, token, scope);
+  const written = writeConfigs(
+    clients,
+    serverName,
+    mcpUrl,
+    token,
+    scope,
+    undefined,
+    headers,
+  );
 
   logOut("");
   logOut(`  Connected "${serverName}" → ${mcpUrl}`);

--- a/packages/core/src/cli/mcp-config-writers.ts
+++ b/packages/core/src/cli/mcp-config-writers.ts
@@ -43,11 +43,16 @@ export interface HttpMcpEntry {
 export function buildHttpMcpEntry(
   mcpUrl: string,
   token?: string,
+  headers?: Record<string, string>,
 ): HttpMcpEntry {
+  const mergedHeaders = {
+    ...(headers ?? {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
   return {
     type: "http",
     url: mcpUrl,
-    ...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
+    ...(Object.keys(mergedHeaders).length ? { headers: mergedHeaders } : {}),
   };
 }
 
@@ -163,12 +168,20 @@ export function buildCodexHttpBlock(
   name: string,
   mcpUrl: string,
   token?: string,
+  headers?: Record<string, string>,
 ): string {
   const lines: string[] = [codexMcpHeader(name)];
   lines.push(`url = ${tomlQuote(mcpUrl)}`);
-  if (token) {
+  const mergedHeaders = {
+    ...(headers ?? {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+  const headerEntries = Object.entries(mergedHeaders);
+  if (headerEntries.length) {
     lines.push(
-      `http_headers = { Authorization = ${tomlQuote(`Bearer ${token}`)} }`,
+      `http_headers = { ${headerEntries
+        .map(([key, value]) => `${tomlQuote(key)} = ${tomlQuote(value)}`)
+        .join(", ")} }`,
     );
   }
   return lines.join("\n") + "\n";
@@ -260,19 +273,23 @@ export function writeHttpEntryForClient(
   token: string | undefined,
   baseDir: string,
   scope: string | undefined,
+  headers?: Record<string, string>,
 ): string {
   const file = configPathFor(client, baseDir, scope);
   if (client === "codex") {
     writeCodexBlock(
       file,
       serverName,
-      buildCodexHttpBlock(serverName, mcpUrl, token),
+      buildCodexHttpBlock(serverName, mcpUrl, token, headers),
     );
   } else {
     writeJsonMcpEntry(
       file,
       serverName,
-      buildHttpMcpEntry(mcpUrl, token) as unknown as Record<string, unknown>,
+      buildHttpMcpEntry(mcpUrl, token, headers) as unknown as Record<
+        string,
+        unknown
+      >,
     );
   }
   return file;

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -42,6 +42,19 @@ export interface MCPConfig {
   version?: string;
   /** Action registry — same as agent chat and A2A */
   actions: Record<string, ActionEntry>;
+  /**
+   * Full ("production") action surface served to an **authenticated real
+   * caller** — a connect-minted token, an `agent-native mcp install` stdio
+   * proxy (owner-email header / `AGENT_NATIVE_OWNER_EMAIL`), or a deployed /
+   * `AGENT_MODE=production` app. In local dev `actions` is intentionally the
+   * sparse, dev-toggled surface (builtins + read-only public-agent actions)
+   * so the local agent chat and unauthenticated dev probes don't see every
+   * mutating tool; but per the external-agents contract a real caller that
+   * connected with a token MUST get the full surface even in dev. When unset
+   * (production, where `actions` already IS the full set) the swap is a
+   * no-op. See `external-agents` skill, "Dev vs production tool surface".
+   */
+  productionActions?: Record<string, ActionEntry>;
   /** Handler for the ask-agent meta-tool — runs the full agent loop */
   askAgent?: (message: string) => Promise<string>;
   /**
@@ -76,6 +89,15 @@ export interface MCPRequestMeta {
   origin?: string;
   /** Optional client preference for which URL the *markdown* link uses. */
   target?: "browser" | "desktop" | "terminal";
+  /**
+   * The caller authenticated with a real credential (verified A2A/connect
+   * JWT, matching ACCESS_TOKEN, or a forwarded owner-email header from
+   * `agent-native mcp install`) — not the unauthenticated local dev-open
+   * path. When true, `createMCPServerForRequest` serves
+   * `config.productionActions` (the full surface) instead of the sparse dev
+   * `config.actions`. Set by `mountMCP` from `verifyAuth`.
+   */
+  fullSurface?: boolean;
 }
 
 /**
@@ -125,12 +147,16 @@ export function buildLinkArtifacts(
  * The builtins are pure-ish navigators / scaffolders; they call back into the
  * same `config.actions` / `config.askAgent` so there is no second agent loop.
  */
-function mergeBuiltinTools(config: MCPConfig): Record<string, ActionEntry> {
-  if (config.builtinCrossAppTools === false) return config.actions;
-  const builtins = getBuiltinCrossAppTools(config);
+function mergeBuiltinTools(
+  config: MCPConfig,
+  baseActions: Record<string, ActionEntry>,
+  requestMeta?: MCPRequestMeta,
+): Record<string, ActionEntry> {
+  if (config.builtinCrossAppTools === false) return baseActions;
+  const builtins = getBuiltinCrossAppTools(config, requestMeta);
   const merged: Record<string, ActionEntry> = { ...builtins };
   // Template / app actions overwrite same-named builtins.
-  for (const [name, entry] of Object.entries(config.actions)) {
+  for (const [name, entry] of Object.entries(baseActions)) {
     merged[name] = entry;
   }
   return merged;
@@ -162,10 +188,6 @@ export async function createMCPServerForRequest(
     { capabilities: { tools: {} } },
   );
 
-  // The action set the request handlers operate on = template actions +
-  // generic cross-app builtins (template wins on name collision).
-  const actions = mergeBuiltinTools(config);
-
   // Resolve the effective caller identity. JWT / header-derived identity
   // (passed by `mountMCP` via `verifyAuth`) wins. When the caller passed no
   // identity — the stdio **standalone** path — fall back to the
@@ -180,6 +202,21 @@ export async function createMCPServerForRequest(
     (ownerFromEnv
       ? { userEmail: ownerFromEnv, orgDomain: undefined }
       : undefined);
+
+  // The action set the request handlers operate on = base actions + generic
+  // cross-app builtins (template wins on name collision). An authenticated
+  // real caller (connect-minted token / `mcp install` owner / production —
+  // `requestMeta.fullSurface`, or the stdio standalone path identified by
+  // `AGENT_NATIVE_OWNER_EMAIL`) gets the full `productionActions` surface
+  // even in local dev; the unauthenticated dev-open path keeps the sparse
+  // `config.actions`. See `external-agents` skill, "Dev vs production tool
+  // surface".
+  const useFullSurface = requestMeta?.fullSurface === true || !!ownerFromEnv;
+  const baseActions =
+    useFullSurface && config.productionActions
+      ? config.productionActions
+      : config.actions;
+  const actions = mergeBuiltinTools(config, baseActions, requestMeta);
 
   // Resolve orgId once per request (DB lookup) so subsequent wraps are
   // synchronous. The caller identity may be undefined for true dev-open —
@@ -394,15 +431,36 @@ function deriveStaticTokenIdentity(
 export async function verifyAuth(
   authHeader: string | undefined,
   ownerEmailHeader?: string | undefined,
-): Promise<{ authed: boolean; identity?: MCPCallerIdentity }> {
-  // No auth configured → allow (dev mode). Still honour an owner hint
-  // (env or forwarded header) so the install flow stays tenant-scoped.
+  options: { allowDevOpen?: boolean } = {},
+): Promise<{
+  authed: boolean;
+  identity?: MCPCallerIdentity;
+  /**
+   * The caller presented a real credential — a verified A2A/connect JWT, a
+   * matching ACCESS_TOKEN, or (on the no-auth-configured path) a forwarded
+   * owner-email header from `agent-native mcp install`. Drives the full vs
+   * sparse MCP tool surface in local dev. The pure unauthenticated dev-open
+   * path (no secret, no token, no owner header) is `false`.
+   */
+  fullSurface?: boolean;
+}> {
+  // No auth configured → allow only when the route caller has already
+  // established that this is a loopback/local dev request. Still honour an
+  // owner hint there so the local install/connect flow stays tenant-scoped.
   const accessTokens = getAccessTokens();
   const hasA2ASecret = !!process.env.A2A_SECRET;
   if (accessTokens.length === 0 && !hasA2ASecret) {
+    if (options.allowDevOpen === false) {
+      return { authed: false };
+    }
     return {
       authed: true,
       identity: deriveStaticTokenIdentity(ownerEmailHeader),
+      // `mcp install`'s stdio proxy forwards an owner-email header even when
+      // the local app has no secret configured — that is a real, identified
+      // caller and gets the full surface. A bare browser/curl dev probe with
+      // no owner hint stays on the sparse dev surface.
+      fullSurface: !!(ownerEmailHeader && ownerEmailHeader.trim()),
     };
   }
 
@@ -459,6 +517,8 @@ export async function verifyAuth(
               ? (payload.org_domain as string)
               : undefined,
         },
+        // Verified JWT (connect-minted or A2A delegation) — a real caller.
+        fullSurface: true,
       };
     } catch {
       // Not a valid JWT — fall through to token check
@@ -472,6 +532,8 @@ export async function verifyAuth(
     return {
       authed: true,
       identity: deriveStaticTokenIdentity(ownerEmailHeader),
+      // Matched a configured ACCESS_TOKEN — a real caller.
+      fullSurface: true,
     };
   }
 

--- a/packages/core/src/mcp/build-server.verify-auth.spec.ts
+++ b/packages/core/src/mcp/build-server.verify-auth.spec.ts
@@ -139,3 +139,71 @@ describe("verifyAuth — connect-token revoke check", () => {
     expect(isJtiRevokedMock).not.toHaveBeenCalled();
   });
 });
+
+// Bug #3: a connected real caller (connect-minted token / `mcp install` /
+// ACCESS_TOKEN / production) must get the FULL MCP tool surface even in local
+// dev — the documented external-agents contract. `verifyAuth` reports this via
+// `fullSurface`, which `createMCPServerForRequest` uses to swap in
+// `config.productionActions`. The pure unauthenticated dev-open path stays
+// sparse (`fullSurface: false`).
+describe("verifyAuth — fullSurface (real-caller → full MCP surface)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.A2A_SECRET;
+    delete process.env.ACCESS_TOKEN;
+    delete process.env.ACCESS_TOKENS;
+  });
+  afterEach(() => {
+    delete process.env.A2A_SECRET;
+    delete process.env.ACCESS_TOKEN;
+    delete process.env.ACCESS_TOKENS;
+  });
+
+  it("connect-minted JWT → fullSurface true", async () => {
+    process.env.A2A_SECRET = SECRET;
+    isJtiRevokedMock.mockResolvedValue(false);
+    const token = await sign({
+      sub: "a@example.com",
+      scope: "mcp-connect",
+      jti: "jti-connect",
+    });
+    const res = await verifyAuth(`Bearer ${token}`);
+    expect(res.authed).toBe(true);
+    expect(res.fullSurface).toBe(true);
+  });
+
+  it("ordinary A2A delegation JWT → fullSurface true", async () => {
+    process.env.A2A_SECRET = SECRET;
+    const token = await sign({ sub: "a@example.com" });
+    const res = await verifyAuth(`Bearer ${token}`);
+    expect(res.authed).toBe(true);
+    expect(res.fullSurface).toBe(true);
+  });
+
+  it("matching ACCESS_TOKEN → fullSurface true", async () => {
+    process.env.ACCESS_TOKEN = "static-tok";
+    const res = await verifyAuth("Bearer static-tok", "owner@example.com");
+    expect(res.authed).toBe(true);
+    expect(res.fullSurface).toBe(true);
+    expect(res.identity?.userEmail).toBe("owner@example.com");
+  });
+
+  it("no auth configured + forwarded owner header (mcp install) → authed, fullSurface true", async () => {
+    const res = await verifyAuth(undefined, "owner@example.com");
+    expect(res.authed).toBe(true);
+    expect(res.fullSurface).toBe(true);
+  });
+
+  it("no auth configured + no owner header (bare dev probe) → authed, fullSurface false (sparse)", async () => {
+    const res = await verifyAuth(undefined, undefined);
+    expect(res.authed).toBe(true);
+    expect(res.fullSurface).toBe(false);
+  });
+
+  it("no auth configured but allowDevOpen:false (deployed, no secret) → rejected", async () => {
+    const res = await verifyAuth(undefined, "owner@example.com", {
+      allowDevOpen: false,
+    });
+    expect(res.authed).toBe(false);
+  });
+});

--- a/packages/core/src/mcp/builtin-cross-app.spec.ts
+++ b/packages/core/src/mcp/builtin-cross-app.spec.ts
@@ -47,6 +47,14 @@ describe("verifyAuth — static-token caller identity", () => {
     expect(res.identity?.userEmail).toBe("hdr@example.com");
   });
 
+  it("rejects dev-open owner hints when the route is not loopback/local", async () => {
+    const res = await verifyAuth(undefined, "hdr@example.com", {
+      allowDevOpen: false,
+    });
+    expect(res.authed).toBe(false);
+    expect(res.identity).toBeUndefined();
+  });
+
   it("static ACCESS_TOKEN match derives identity from owner env", async () => {
     process.env.ACCESS_TOKEN = "tok-123";
     process.env.AGENT_NATIVE_OWNER_EMAIL = "env-owner@example.com";
@@ -124,6 +132,34 @@ describe("open_app — same-app / standalone keeps a relative deep link", () => 
       "/_agent-native/open?app=mail&view=inbox&threadId=abc",
     );
     expect(result.url.startsWith("/")).toBe(true);
+  });
+});
+
+describe("list_apps — reports the live request origin for the current app", () => {
+  // Bug #2: a single-app dev server reached over `connect` was reporting a
+  // guessed `PORT || 5173` URL + `running:false` (wrong whenever the dev
+  // server picked another port, e.g. `agent-native dev` on :8080). The MCP
+  // request is served BY the app, so the inbound origin is authoritative.
+  it("uses requestMeta.origin and running:true for the served app", async () => {
+    const tools = getBuiltinCrossAppTools(baseConfig({ appId: "content" }), {
+      origin: "http://localhost:8080",
+    });
+    const result: any = await tools.list_apps.run({});
+    expect(result.workspace).toBe(false);
+    expect(result.apps).toHaveLength(1);
+    expect(result.apps[0].url).toBe("http://localhost:8080");
+    expect(result.apps[0].port).toBe(8080);
+    expect(result.apps[0].running).toBe(true);
+  });
+
+  it("falls back to probed values when no request origin is known (stdio standalone)", async () => {
+    const tools = getBuiltinCrossAppTools(baseConfig({ appId: "content" }));
+    const result: any = await tools.list_apps.run({});
+    expect(result.apps).toHaveLength(1);
+    // No live origin → keep the resolver's URL (not overridden to a bogus
+    // live origin) and its real TCP-probe running state.
+    expect(result.apps[0].url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(result.apps[0].running).toBe(false);
   });
 });
 

--- a/packages/core/src/mcp/builtin-tools.ts
+++ b/packages/core/src/mcp/builtin-tools.ts
@@ -106,7 +106,10 @@ async function resolveTargetAppOrigin(
 // list_apps
 // ---------------------------------------------------------------------------
 
-function listAppsTool(config: MCPConfig): ActionEntry {
+function listAppsTool(
+  config: MCPConfig,
+  requestMeta?: { origin?: string },
+): ActionEntry {
   return {
     tool: tool(
       "List the workspace apps and their URLs. Use this to discover which " +
@@ -120,6 +123,29 @@ function listAppsTool(config: MCPConfig): ActionEntry {
       const { resolveWorkspace } = await import("./workspace-resolve.js");
       const ws = await resolveWorkspace();
 
+      // The MCP request is served BY the current app, so it is provably
+      // reachable at the inbound request origin — that beats a guessed
+      // `PORT || 5173` probe (which reports the wrong URL + `running:false`
+      // whenever the dev server picked a non-default port, e.g. `agent-
+      // native dev` on :8080). For the entry that IS this app (the sole
+      // entry when single-app, or the id matching `config.appId` in a
+      // workspace) prefer the live origin; other workspace apps keep their
+      // probed values.
+      const liveOrigin = requestMeta?.origin?.replace(/\/+$/, "") || "";
+      let livePort = 0;
+      if (liveOrigin) {
+        try {
+          const u = new URL(liveOrigin);
+          livePort = Number(u.port) || (u.protocol === "https:" ? 443 : 80);
+        } catch {
+          livePort = 0;
+        }
+      }
+      const selfId = (config.appId ?? "").toLowerCase();
+      const isSelf = (id: string) =>
+        !!liveOrigin &&
+        (!ws.isWorkspace || (!!selfId && id.toLowerCase() === selfId));
+
       interface AppEntry {
         id: string;
         url: string;
@@ -128,13 +154,23 @@ function listAppsTool(config: MCPConfig): ActionEntry {
         source: "workspace" | "org-directory";
       }
 
-      const apps: AppEntry[] = ws.apps.map((a) => ({
-        id: a.id,
-        url: a.url,
-        port: a.port as number | undefined,
-        running: a.running,
-        source: "workspace",
-      }));
+      const apps: AppEntry[] = ws.apps.map((a) =>
+        isSelf(a.id)
+          ? {
+              id: a.id,
+              url: liveOrigin,
+              port: (livePort || a.port) as number | undefined,
+              running: true,
+              source: "workspace" as const,
+            }
+          : {
+              id: a.id,
+              url: a.url,
+              port: a.port as number | undefined,
+              running: a.running,
+              source: "workspace" as const,
+            },
+      );
       const seenIds = new Set(apps.map((a) => a.id.toLowerCase()));
       const seenOrigins = new Set(apps.map((a) => a.url.replace(/\/+$/, "")));
 
@@ -532,9 +568,10 @@ function createWorkspaceAppTool(): ActionEntry {
  */
 export function getBuiltinCrossAppTools(
   config: MCPConfig,
+  requestMeta?: { origin?: string },
 ): Record<string, ActionEntry> {
   return {
-    list_apps: listAppsTool(config),
+    list_apps: listAppsTool(config, requestMeta),
     open_app: openAppTool(config),
     ask_app: askAppTool(config),
     create_workspace_app: createWorkspaceAppTool(),

--- a/packages/core/src/mcp/connect-route.spec.ts
+++ b/packages/core/src/mcp/connect-route.spec.ts
@@ -252,6 +252,25 @@ describe("handleMcpConnect", () => {
       const res = await handleMcpConnect(ev({ method: "POST" }), "/token");
       expect(res.status).toBe(503);
     });
+
+    it("returns a dev-open localhost entry when no A2A_SECRET is configured", async () => {
+      delete process.env.A2A_SECRET;
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      getSessionMock.mockResolvedValue({ email: "u@example.com" });
+      const res = await handleMcpConnect(
+        ev({ method: "POST", host: "localhost:4321" }),
+        "/token",
+      );
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.token).toBe("");
+      expect(data.mcpServerEntry).toEqual({
+        type: "http",
+        url: "http://localhost:4321/_agent-native/mcp",
+        headers: { "X-Agent-Native-Owner-Email": "u@example.com" },
+      });
+    });
   });
 
   describe("token list + revoke", () => {
@@ -433,6 +452,44 @@ describe("handleMcpConnect", () => {
       const again = await res.json();
       expect(again.status).toBe("consumed");
       expect(again.token).toBeUndefined();
+    });
+
+    it("poll returns a dev-open localhost entry without A2A_SECRET", async () => {
+      delete process.env.A2A_SECRET;
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      await handleMcpConnect(
+        ev({ method: "POST", host: "localhost:4321" }),
+        "/device/start",
+      );
+      const dc = deviceRows[0].deviceCode;
+
+      getSessionMock.mockResolvedValue({ email: "u@example.com" });
+      await handleMcpConnect(
+        ev({
+          method: "POST",
+          host: "localhost:4321",
+          body: { user_code: "ABCD-2345" },
+        }),
+        "/device/authorize",
+      );
+
+      getSessionMock.mockResolvedValue(null);
+      const res = await handleMcpConnect(
+        ev({
+          method: "POST",
+          host: "localhost:4321",
+          body: { device_code: dc },
+        }),
+        "/device/poll",
+      );
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.status).toBe("approved");
+      expect(data.token).toBe("");
+      expect(data.mcpServerEntry.headers).toEqual({
+        "X-Agent-Native-Owner-Email": "u@example.com",
+      });
     });
 
     it("poll returns expired for a past-TTL code", async () => {

--- a/packages/core/src/mcp/connect-route.spec.ts
+++ b/packages/core/src/mcp/connect-route.spec.ts
@@ -14,9 +14,17 @@ vi.mock("../server/h3-helpers.js", () => ({
 
 const getSessionMock = vi.fn();
 const getConfiguredLoginHtmlMock = vi.fn(() => null);
+// Mirror the real socket-based isLoopbackRequest: dev-open is gated on the
+// actual peer, not the (spoofable) Host header. The test events carry no
+// socket, so derive loopback from the host they simulate connecting as —
+// localhost/127.x ⇒ a loopback peer, anything else ⇒ remote.
+const isLoopbackRequestMock = vi.fn((event: any) =>
+  /^(localhost|127\.|\[?::1\]?)(:|$)/i.test(String(event?.headers?.host ?? "")),
+);
 vi.mock("../server/auth.js", () => ({
   getSession: (...a: any[]) => getSessionMock(...a),
   getConfiguredLoginHtml: (...a: any[]) => getConfiguredLoginHtmlMock(...a),
+  isLoopbackRequest: (...a: any[]) => isLoopbackRequestMock(...a),
 }));
 
 vi.mock("../org/context.js", () => ({

--- a/packages/core/src/mcp/connect-route.ts
+++ b/packages/core/src/mcp/connect-route.ts
@@ -571,7 +571,20 @@ function renderConnectPage(params: {
         // The token is minted a few seconds later, when the CLI next polls
         // /device/poll — so a single loadTokens() here runs BEFORE the row
         // exists and the list would wrongly read "No connections yet" until
-        // a manual reload. Poll until the new connection shows up.
+        // a manual reload. Snapshot the EXISTING non-revoked token ids first
+        // so we announce "Connected" only when THIS device's freshly-minted
+        // token appears — a user who already has tokens must not get a false
+        // success the instant they authorize.
+        var priorIds = {};
+        try {
+          var pr = await fetch(BASE + "/tokens", { credentials: "same-origin" });
+          if (pr.ok) {
+            var pd = await pr.json();
+            ((pd && pd.tokens) || []).forEach(function (t) {
+              if (!t.revokedAt) priorIds[t.id] = true;
+            });
+          }
+        } catch (e) {}
         loadTokens();
         var tries = 0;
         var iv = setInterval(async function () {
@@ -580,8 +593,10 @@ function renderConnectPage(params: {
             var res = await fetch(BASE + "/tokens", { credentials: "same-origin" });
             if (res.ok) {
               var data = await res.json();
-              var active = ((data && data.tokens) || []).filter(function (t) { return !t.revokedAt; });
-              if (active.length > 0) {
+              var fresh = ((data && data.tokens) || []).filter(function (t) {
+                return !t.revokedAt && !priorIds[t.id];
+              });
+              if (fresh.length > 0) {
                 clearInterval(iv);
                 showMsg("Connected. This device can now act as you — manage or revoke it below.", "ok");
                 loadTokens();
@@ -589,7 +604,14 @@ function renderConnectPage(params: {
               }
             }
           } catch (e) {}
-          if (tries >= 30) { clearInterval(iv); loadTokens(); }
+          if (tries >= 30) {
+            // No new token appeared in the window — e.g. the loopback
+            // dev-open path writes a header-only config and never mints.
+            // Don't claim "Connected" (we couldn't confirm a device token);
+            // keep the "authorized" message and just refresh the list.
+            clearInterval(iv);
+            loadTokens();
+          }
         }, 2000);
         return;
       } else {

--- a/packages/core/src/mcp/connect-route.ts
+++ b/packages/core/src/mcp/connect-route.ts
@@ -30,7 +30,11 @@
 import type { H3Event } from "h3";
 import { getMethod, getHeader } from "h3";
 import { readBody } from "../server/h3-helpers.js";
-import { getSession, getConfiguredLoginHtml } from "../server/auth.js";
+import {
+  getSession,
+  getConfiguredLoginHtml,
+  isLoopbackRequest,
+} from "../server/auth.js";
 import { signA2AToken } from "../a2a/client.js";
 import { getOrgDomain } from "../org/context.js";
 import { randomUUID } from "node:crypto";
@@ -124,23 +128,14 @@ function serverName(origin: string, options: McpConnectRouteOptions): string {
   return `agent-native-${appLabel(origin, options)}`;
 }
 
-function isLoopbackOrigin(origin: string): boolean {
-  try {
-    const host = new URL(origin).hostname.toLowerCase();
-    return (
-      host === "localhost" ||
-      host === "127.0.0.1" ||
-      host === "::1" ||
-      host.startsWith("127.")
-    );
-  } catch {
-    return false;
-  }
-}
-
-function canUseDevOpenConnect(appUrl: string): boolean {
+function canUseDevOpenConnect(event: H3Event): boolean {
+  // Loopback determined from the real socket peer (isLoopbackRequest →
+  // getRequestIP without xForwardedFor), NOT a parsed `Host` header — the
+  // header is client-controlled, and it also handles IPv6 `::1`. A
+  // misconfigured public deploy with no secret thus can't unlock dev-open
+  // by spoofing `Host: localhost`.
   return (
-    isLoopbackOrigin(appUrl) &&
+    isLoopbackRequest(event) &&
     !process.env.A2A_SECRET?.trim() &&
     !process.env.ACCESS_TOKEN?.trim() &&
     !process.env.ACCESS_TOKENS?.trim()
@@ -711,7 +706,7 @@ export async function handleMcpConnect(
     const session = await getSession(event);
     if (!session?.email) return json({ error: "Unauthorized" }, 401);
     if (!process.env.A2A_SECRET) {
-      if (canUseDevOpenConnect(appUrl)) {
+      if (canUseDevOpenConnect(event)) {
         return json(
           mcpResultPayload(appUrl, options, { ownerEmail: session.email }),
         );
@@ -826,7 +821,7 @@ export async function handleMcpConnect(
     }
     // status === "approved" && ownerEmail bound → mint exactly once.
     if (!process.env.A2A_SECRET) {
-      if (canUseDevOpenConnect(appUrl)) {
+      if (canUseDevOpenConnect(event)) {
         const consumed = await consumeDeviceCode(
           deviceCode,
           `dev-open-${randomUUID()}`,

--- a/packages/core/src/mcp/connect-route.ts
+++ b/packages/core/src/mcp/connect-route.ts
@@ -41,6 +41,7 @@ import {
   createDeviceCode,
   getDeviceCode,
   approveDeviceCode,
+  consumeDeviceCode,
   claimDeviceCodeForMint,
   finishDeviceCodeMint,
   releaseDeviceCodeMint,
@@ -123,6 +124,29 @@ function serverName(origin: string, options: McpConnectRouteOptions): string {
   return `agent-native-${appLabel(origin, options)}`;
 }
 
+function isLoopbackOrigin(origin: string): boolean {
+  try {
+    const host = new URL(origin).hostname.toLowerCase();
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "::1" ||
+      host.startsWith("127.")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function canUseDevOpenConnect(appUrl: string): boolean {
+  return (
+    isLoopbackOrigin(appUrl) &&
+    !process.env.A2A_SECRET?.trim() &&
+    !process.env.ACCESS_TOKEN?.trim() &&
+    !process.env.ACCESS_TOKENS?.trim()
+  );
+}
+
 function escapeHtml(s: string): string {
   return s
     .replace(/&/g, "&amp;")
@@ -189,19 +213,24 @@ async function mintConnectToken(params: {
 
 function mcpResultPayload(
   appUrl: string,
-  token: string,
   options: McpConnectRouteOptions,
+  auth: { token?: string; ownerEmail?: string },
 ) {
   const mcpUrl = `${appUrl}/_agent-native/mcp`;
   const name = serverName(appUrl, options);
+  const headers: Record<string, string> = {};
+  if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
+  if (!auth.token && auth.ownerEmail) {
+    headers["X-Agent-Native-Owner-Email"] = auth.ownerEmail;
+  }
   return {
-    token,
+    token: auth.token ?? "",
     mcpUrl,
     serverName: name,
     mcpServerEntry: {
       type: "http" as const,
       url: mcpUrl,
-      headers: { Authorization: `Bearer ${token}` },
+      ...(Object.keys(headers).length ? { headers } : {}),
     },
     cli: `agent-native connect ${appUrl}`,
   };
@@ -536,9 +565,33 @@ function renderConnectPage(params: {
           showMsg((a.data && a.data.error) || "Could not authorize this device code.");
           return;
         }
-        showMsg("Device authorized. You can return to your terminal — it will connect automatically.", "ok");
+        showMsg("Device authorized — finishing connection… you can return to your terminal.", "ok");
         btn.classList.add("hidden");
         document.getElementById("mintForm").classList.add("hidden");
+        // The token is minted a few seconds later, when the CLI next polls
+        // /device/poll — so a single loadTokens() here runs BEFORE the row
+        // exists and the list would wrongly read "No connections yet" until
+        // a manual reload. Poll until the new connection shows up.
+        loadTokens();
+        var tries = 0;
+        var iv = setInterval(async function () {
+          tries++;
+          try {
+            var res = await fetch(BASE + "/tokens", { credentials: "same-origin" });
+            if (res.ok) {
+              var data = await res.json();
+              var active = ((data && data.tokens) || []).filter(function (t) { return !t.revokedAt; });
+              if (active.length > 0) {
+                clearInterval(iv);
+                showMsg("Connected. This device can now act as you — manage or revoke it below.", "ok");
+                loadTokens();
+                return;
+              }
+            }
+          } catch (e) {}
+          if (tries >= 30) { clearInterval(iv); loadTokens(); }
+        }, 2000);
+        return;
       } else {
         var m = await postJson("/token", { label: label, ttlDays: ttlDays });
         if (!m.ok) {
@@ -636,6 +689,11 @@ export async function handleMcpConnect(
     const session = await getSession(event);
     if (!session?.email) return json({ error: "Unauthorized" }, 401);
     if (!process.env.A2A_SECRET) {
+      if (canUseDevOpenConnect(appUrl)) {
+        return json(
+          mcpResultPayload(appUrl, options, { ownerEmail: session.email }),
+        );
+      }
       return json(
         {
           error:
@@ -660,7 +718,7 @@ export async function handleMcpConnect(
         label,
         ttlDays,
       });
-      return json(mcpResultPayload(appUrl, token, options));
+      return json(mcpResultPayload(appUrl, options, { token }));
     } catch {
       return json({ error: "Failed to mint token." }, 500);
     }
@@ -746,6 +804,23 @@ export async function handleMcpConnect(
     }
     // status === "approved" && ownerEmail bound → mint exactly once.
     if (!process.env.A2A_SECRET) {
+      if (canUseDevOpenConnect(appUrl)) {
+        const consumed = await consumeDeviceCode(
+          deviceCode,
+          `dev-open-${randomUUID()}`,
+        );
+        if (!consumed) {
+          const fresh = await getDeviceCode(deviceCode);
+          if (fresh?.status === "consumed") return json({ status: "consumed" });
+          return json({ status: "pending" });
+        }
+        return json({
+          status: "approved",
+          ...mcpResultPayload(appUrl, options, {
+            ownerEmail: row.ownerEmail,
+          }),
+        });
+      }
       return json({ status: "error", error: "A2A_SECRET not configured" }, 503);
     }
     try {
@@ -781,7 +856,7 @@ export async function handleMcpConnect(
       }
       return json({
         status: "approved",
-        ...mcpResultPayload(appUrl, token, options),
+        ...mcpResultPayload(appUrl, options, { token }),
       });
     } catch {
       return json({ status: "error", error: "Failed to mint token." }, 500);

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -42,6 +42,11 @@ function makeWebEvent(opts: MakeEventOpts): any {
     "x-forwarded-proto": "https",
     accept: "application/json, text/event-stream",
     "content-type": "application/json",
+    // A deployed app (non-loopback host) is authenticated — header-only
+    // dev-open is loopback-only now (security: a public deploy with no
+    // secret must not be impersonable via X-Agent-Native-Owner-Email).
+    // Tests that exercise the unauthenticated path override this.
+    authorization: "Bearer test-access-token",
     ...(opts.headers ?? {}),
   };
   // h3 v2 web runtime: `event.req` IS the web Request. We hand a real one so
@@ -186,11 +191,15 @@ async function callWeb(rpc: Record<string, unknown>): Promise<any> {
 
 describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)", () => {
   beforeEach(() => {
-    delete process.env.ACCESS_TOKEN;
+    // A deployed app has a real token; the default makeWebEvent bearer
+    // matches it so these runtime-mechanics tests run as an authenticated
+    // caller (header-only dev-open is loopback-only — see security note).
+    process.env.ACCESS_TOKEN = "test-access-token";
     delete process.env.ACCESS_TOKENS;
     delete process.env.A2A_SECRET;
   });
   afterEach(() => {
+    delete process.env.ACCESS_TOKEN;
     vi.clearAllMocks();
   });
 
@@ -300,11 +309,14 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
 
 describe("handleMcpRequest — Node fast-path still taken when event.node present", () => {
   beforeEach(() => {
-    delete process.env.ACCESS_TOKEN;
+    // Authenticated deployed-app caller (default makeWebEvent bearer matches);
+    // header-only dev-open is loopback-only now.
+    process.env.ACCESS_TOKEN = "test-access-token";
     delete process.env.ACCESS_TOKENS;
     delete process.env.A2A_SECRET;
   });
   afterEach(() => {
+    delete process.env.ACCESS_TOKEN;
     vi.clearAllMocks();
     vi.restoreAllMocks();
   });

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -30,6 +30,30 @@ export {
 };
 export type { MCPConfig, MCPCallerIdentity, MCPRequestMeta };
 
+/**
+ * True for loopback request origins. Header-only dev-open (no A2A_SECRET /
+ * ACCESS_TOKEN configured, identity taken from `X-Agent-Native-Owner-Email`)
+ * is allowed ONLY for loopback so a misconfigured PUBLIC deployment can't be
+ * impersonated by anyone sending that header — which, combined with the
+ * `fullSurface` discriminator, would otherwise hand a spoofed caller the full
+ * mutating action surface. A deployed app missing both secrets fails closed.
+ */
+function isLoopbackOrigin(origin: string | undefined): boolean {
+  if (!origin) return false;
+  try {
+    const host = new URL(origin).hostname.toLowerCase();
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "::1" ||
+      host === "[::1]" ||
+      host.startsWith("127.")
+    );
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Runtime detection — Node fast-path vs. web-standard fallback
 // ---------------------------------------------------------------------------
@@ -188,7 +212,15 @@ export async function handleMcpRequest(
     event,
     "x-agent-native-owner-email",
   );
-  const authResult = await verifyAuth(authHeader, ownerEmailHeader);
+  // Derived before auth so the origin can gate header-only dev-open: a
+  // deployed app missing A2A_SECRET / ACCESS_TOKEN must fail closed rather
+  // than trust a caller-supplied owner-email header (which `fullSurface`
+  // would otherwise escalate to the full mutating surface). Only loopback
+  // dev gets the no-secret dev-open path.
+  const requestMeta = deriveRequestMeta(event);
+  const authResult = await verifyAuth(authHeader, ownerEmailHeader, {
+    allowDevOpen: isLoopbackOrigin(requestMeta.origin),
+  });
   if (!authResult.authed) {
     setResponseStatus(event, 401);
     return { error: "Unauthorized" };
@@ -216,7 +248,6 @@ export async function handleMcpRequest(
   // connected real caller (connect-minted token / `mcp install` /
   // ACCESS_TOKEN / production) gets the full action surface even in local
   // dev; unauthenticated dev probes stay sparse. See `external-agents` skill.
-  const requestMeta = deriveRequestMeta(event);
   const server = await createMCPServerForRequest(config, authResult.identity, {
     ...requestMeta,
     fullSurface: authResult.fullSurface === true,

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -30,6 +30,21 @@ export {
 };
 export type { MCPConfig, MCPCallerIdentity, MCPRequestMeta };
 
+function isLoopbackOrigin(origin: string | undefined): boolean {
+  if (!origin) return false;
+  try {
+    const host = new URL(origin).hostname.toLowerCase();
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "::1" ||
+      host.startsWith("127.")
+    );
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Runtime detection — Node fast-path vs. web-standard fallback
 // ---------------------------------------------------------------------------
@@ -188,7 +203,15 @@ export async function handleMcpRequest(
     event,
     "x-agent-native-owner-email",
   );
-  const authResult = await verifyAuth(authHeader, ownerEmailHeader);
+  // Per-request stateless transport + server build the SAME server from the
+  // SAME config + verified identity + request meta on both runtimes. Derived
+  // before auth so the origin can gate header-only dev-open: a deployed app
+  // missing A2A_SECRET / ACCESS_TOKEN must fail closed instead of trusting a
+  // caller-supplied owner-email header (only loopback dev gets dev-open).
+  const requestMeta = deriveRequestMeta(event);
+  const authResult = await verifyAuth(authHeader, ownerEmailHeader, {
+    allowDevOpen: isLoopbackOrigin(requestMeta.origin),
+  });
   if (!authResult.authed) {
     setResponseStatus(event, 401);
     return { error: "Unauthorized" };
@@ -210,15 +233,13 @@ export async function handleMcpRequest(
   // stream is never consumed twice.
   const body = method === "POST" ? await readBody(event) : undefined;
 
-  // Per-request stateless transport + server. Both runtimes build the SAME
-  // server from the SAME config + verified identity + request meta, so
-  // tools/list, tools/call, and the deep-link `_meta` are identical.
-  const requestMeta = deriveRequestMeta(event);
-  const server = await createMCPServerForRequest(
-    config,
-    authResult.identity,
-    requestMeta,
-  );
+  // A connected real caller (connect-minted token / `mcp install` /
+  // ACCESS_TOKEN / production) gets the full action surface even in local
+  // dev; unauthenticated dev probes stay sparse. See `external-agents` skill.
+  const server = await createMCPServerForRequest(config, authResult.identity, {
+    ...requestMeta,
+    fullSurface: authResult.fullSurface === true,
+  });
 
   const { nodeReq, nodeRes } = getNodeReqRes(event);
 

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -7,6 +7,7 @@ import {
   getRequestHeader,
 } from "h3";
 import { readBody } from "../server/h3-helpers.js";
+import { isLoopbackRequest } from "../server/auth.js";
 import {
   createMCPServerForRequest,
   verifyAuth,
@@ -29,30 +30,6 @@ export {
   buildLinkArtifacts,
 };
 export type { MCPConfig, MCPCallerIdentity, MCPRequestMeta };
-
-/**
- * True for loopback request origins. Header-only dev-open (no A2A_SECRET /
- * ACCESS_TOKEN configured, identity taken from `X-Agent-Native-Owner-Email`)
- * is allowed ONLY for loopback so a misconfigured PUBLIC deployment can't be
- * impersonated by anyone sending that header — which, combined with the
- * `fullSurface` discriminator, would otherwise hand a spoofed caller the full
- * mutating action surface. A deployed app missing both secrets fails closed.
- */
-function isLoopbackOrigin(origin: string | undefined): boolean {
-  if (!origin) return false;
-  try {
-    const host = new URL(origin).hostname.toLowerCase();
-    return (
-      host === "localhost" ||
-      host === "127.0.0.1" ||
-      host === "::1" ||
-      host === "[::1]" ||
-      host.startsWith("127.")
-    );
-  } catch {
-    return false;
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Runtime detection — Node fast-path vs. web-standard fallback
@@ -212,14 +189,13 @@ export async function handleMcpRequest(
     event,
     "x-agent-native-owner-email",
   );
-  // Derived before auth so the origin can gate header-only dev-open: a
-  // deployed app missing A2A_SECRET / ACCESS_TOKEN must fail closed rather
-  // than trust a caller-supplied owner-email header (which `fullSurface`
-  // would otherwise escalate to the full mutating surface). Only loopback
-  // dev gets the no-secret dev-open path.
-  const requestMeta = deriveRequestMeta(event);
+  // Gate header-only dev-open on the REAL socket peer, never a parsed
+  // `Host` header (client-controlled — an attacker could send
+  // `Host: localhost`). A deployed app missing A2A_SECRET / ACCESS_TOKEN
+  // must fail closed rather than trust a spoofable owner-email header that
+  // `fullSurface` would otherwise escalate to the full mutating surface.
   const authResult = await verifyAuth(authHeader, ownerEmailHeader, {
-    allowDevOpen: isLoopbackOrigin(requestMeta.origin),
+    allowDevOpen: isLoopbackRequest(event),
   });
   if (!authResult.authed) {
     setResponseStatus(event, 401);
@@ -248,6 +224,7 @@ export async function handleMcpRequest(
   // connected real caller (connect-minted token / `mcp install` /
   // ACCESS_TOKEN / production) gets the full action surface even in local
   // dev; unauthenticated dev probes stay sparse. See `external-agents` skill.
+  const requestMeta = deriveRequestMeta(event);
   const server = await createMCPServerForRequest(config, authResult.identity, {
     ...requestMeta,
     fullSurface: authResult.fullSurface === true,

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -30,21 +30,6 @@ export {
 };
 export type { MCPConfig, MCPCallerIdentity, MCPRequestMeta };
 
-function isLoopbackOrigin(origin: string | undefined): boolean {
-  if (!origin) return false;
-  try {
-    const host = new URL(origin).hostname.toLowerCase();
-    return (
-      host === "localhost" ||
-      host === "127.0.0.1" ||
-      host === "::1" ||
-      host.startsWith("127.")
-    );
-  } catch {
-    return false;
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Runtime detection — Node fast-path vs. web-standard fallback
 // ---------------------------------------------------------------------------
@@ -203,15 +188,7 @@ export async function handleMcpRequest(
     event,
     "x-agent-native-owner-email",
   );
-  // Per-request stateless transport + server build the SAME server from the
-  // SAME config + verified identity + request meta on both runtimes. Derived
-  // before auth so the origin can gate header-only dev-open: a deployed app
-  // missing A2A_SECRET / ACCESS_TOKEN must fail closed instead of trusting a
-  // caller-supplied owner-email header (only loopback dev gets dev-open).
-  const requestMeta = deriveRequestMeta(event);
-  const authResult = await verifyAuth(authHeader, ownerEmailHeader, {
-    allowDevOpen: isLoopbackOrigin(requestMeta.origin),
-  });
+  const authResult = await verifyAuth(authHeader, ownerEmailHeader);
   if (!authResult.authed) {
     setResponseStatus(event, 401);
     return { error: "Unauthorized" };
@@ -233,9 +210,13 @@ export async function handleMcpRequest(
   // stream is never consumed twice.
   const body = method === "POST" ? await readBody(event) : undefined;
 
-  // A connected real caller (connect-minted token / `mcp install` /
+  // Per-request stateless transport + server. Both runtimes build the SAME
+  // server from the SAME config + verified identity + request meta, so
+  // tools/list, tools/call, and the deep-link `_meta` are identical. A
+  // connected real caller (connect-minted token / `mcp install` /
   // ACCESS_TOKEN / production) gets the full action surface even in local
   // dev; unauthenticated dev probes stay sparse. See `external-agents` skill.
+  const requestMeta = deriveRequestMeta(event);
   const server = await createMCPServerForRequest(config, authResult.identity, {
     ...requestMeta,
     fullSurface: authResult.fullSurface === true,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -3428,6 +3428,39 @@ export function createAgentChatPlugin(
             },
       );
 
+      // Full ("production") MCP surface served to an authenticated *real
+      // caller* — a connect-minted token, an `agent-native mcp install` stdio
+      // proxy, or a deployed / AGENT_MODE=production app — even in local dev.
+      // `allScripts` above is intentionally the sparse, dev-toggled surface
+      // (builtins + read-only public-agent actions) used by the local agent
+      // chat and unauthenticated dev probes; per the external-agents contract
+      // a caller that connected with a token MUST get the full surface (so
+      // `create-document` etc. are callable over MCP). Only needed when
+      // `canToggle` (dev/test): in production `allScripts` already IS this
+      // composition, so leave it undefined and `mountMCP` skips the swap.
+      const mcpFullActions = canToggle
+        ? attachToolSearch({
+            ...discoveredActions,
+            ...templateScripts,
+            ...resourceScripts,
+            ...docsScripts,
+            ...dbScripts,
+            ...refreshScreenTool,
+            ...(lazyContext ? frameworkContextTool : {}),
+            ...urlTools,
+            ...chatScripts,
+            ...callAgentScript,
+            ...automationTools,
+            ...notificationTools,
+            ...progressTools,
+            ...fetchTool,
+            ...toolActions,
+            ...browserSessionTools,
+            ...browserTools,
+            ...devScriptsForA2A,
+          })
+        : undefined;
+
       const { mountA2A } = await import("../a2a/server.js");
       mountA2A(nitroApp, {
         name: options?.appId
@@ -3792,6 +3825,7 @@ export function createAgentChatPlugin(
         appId: options?.appId,
         description: `Agent-native ${options?.appId ?? "app"} agent`,
         actions: allScripts,
+        productionActions: mcpFullActions,
         askAgent: async (message: string) => {
           const mcpEngine = await resolveEngine({
             engineOption: options?.engine,

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -546,7 +546,14 @@ export function isLoopbackAddress(ip: string | undefined): boolean {
   );
 }
 
-function isLoopbackRequest(event: H3Event): boolean {
+/**
+ * True when the request's actual socket peer is loopback. Uses
+ * `getRequestIP(event)` WITHOUT `{ xForwardedFor: true }`, so it reflects the
+ * real connecting IP and a remote client cannot spoof it via the `Host` /
+ * `X-Forwarded-*` headers. Use this — not a parsed `Host`-header origin — for
+ * any "is this local dev?" security gate (MCP/connect dev-open).
+ */
+export function isLoopbackRequest(event: H3Event): boolean {
   let ip: string | undefined;
   try {
     ip = getRequestIP(event) ?? undefined;

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -361,6 +361,10 @@ function getCoreSourceAliases(
       coreSrc,
       "oauth-tokens/index.ts",
     ),
+    "@agent-native/core/workspace-connections": path.join(
+      coreSrc,
+      "workspace-connections/index.ts",
+    ),
     "@agent-native/core/a2a": path.join(coreSrc, "a2a/index.ts"),
     "@agent-native/core/router": path.join(coreSrc, "router/index.ts"),
     "@agent-native/core/terminal": path.join(

--- a/packages/docs/app/components/SearchModal.tsx
+++ b/packages/docs/app/components/SearchModal.tsx
@@ -36,14 +36,19 @@ function search(query: string): SearchEntry[] {
       const textLower = entry.text.toLowerCase();
       const sectionLower = entry.section.toLowerCase();
       const pageLower = entry.page.toLowerCase();
+      const keywordsLower = entry.keywords.toLowerCase();
+      const isPageEntry = entry.sectionId === "";
 
       let score = 0;
       for (const word of words) {
         if (sectionLower.includes(word)) score += 10;
-        if (pageLower.includes(word)) score += 5;
+        if (keywordsLower.includes(word)) score += 8;
+        if (pageLower.includes(word)) score += isPageEntry ? 5 : 2;
         if (textLower.includes(word)) score += 3;
       }
       // exact phrase bonus
+      if (keywordsLower.includes(q)) score += 35;
+      if (pageLower.includes(q)) score += isPageEntry ? 25 : 5;
       if (textLower.includes(q)) score += 20;
       if (sectionLower.includes(q)) score += 30;
 

--- a/packages/docs/app/components/docs-content.ts
+++ b/packages/docs/app/components/docs-content.ts
@@ -15,6 +15,7 @@ export interface DocEntry {
   slug: string;
   title: string;
   description: string;
+  search: string;
   raw: string; // full raw markdown (with frontmatter)
   body: string; // markdown body (without frontmatter)
   headings: { id: string; label: string; level: number }[];
@@ -26,6 +27,7 @@ export interface SearchEntry {
   section: string;
   sectionId: string;
   text: string;
+  keywords: string;
 }
 
 function parseFrontmatter(raw: string): {
@@ -75,6 +77,7 @@ for (const [path, raw] of Object.entries(mdModules)) {
     slug,
     title: data.title || slug,
     description: data.description || "",
+    search: data.search || "",
     raw,
     body,
     headings,
@@ -136,6 +139,7 @@ export function buildSearchIndex(): SearchEntry[] {
         pageText.length > 300
           ? pageText.slice(0, 300).replace(/\s\S*$/, "...")
           : pageText,
+      keywords: doc.search,
     });
 
     for (let i = 0; i < sections.length; i++) {
@@ -161,6 +165,7 @@ export function buildSearchIndex(): SearchEntry[] {
           text.length > 300
             ? text.slice(0, 300).replace(/\s\S*$/, "...")
             : text,
+        keywords: "",
       });
     }
   }

--- a/templates/mail/server/lib/env-config.ts
+++ b/templates/mail/server/lib/env-config.ts
@@ -28,9 +28,9 @@ export const envKeys: EnvKeyConfig[] = [
   },
   {
     key: "A2A_SECRET",
-    label: "Internal Task Signing Secret",
+    label: "Agent Signing Secret",
     required: false,
     helpText:
-      "Required in production for secure background processing of Slack webhooks.",
+      "Required in production for secure background processing and external-agent MCP connections.",
   },
 ];


### PR DESCRIPTION
## Summary

End-to-end testing of the external-agent connect flow (`agent-native connect http://localhost:…` → Claude Code / Codex / Cowork) against a locally-running app surfaced three real bugs, fixed here:

- **Connected agents couldn't "do things" in local dev.** A connect-minted token only saw framework builtins — the app's own actions (`create-document`, `edit-document`, …) were filtered out, contradicting the documented external-agents contract. `verifyAuth` now reports `fullSurface` for real callers (connect-minted JWT, ACCESS_TOKEN, `mcp install` owner, production) and `createMCPServerForRequest` swaps in the full `productionActions` surface for them; unauthenticated dev probes stay sparse. (tools/list 52 → 78; `create-document` over connect now works and returns the correct deep link.)
- **`list_apps` reported the wrong URL/state** — a guessed `PORT||5173` with `running:false` while the app was live on another port — which mis-pointed cross-app deep links. It now reports the live request origin + `running:true` for the served app, while keeping main's org-directory sibling-app merge.
- **The Connect page didn't refresh "Your connections"** after a device authorize (token mints a few seconds later on CLI poll); it now polls and shows a "Connected" confirmation without a manual reload.

Verified end-to-end in a browser: connect flow for all three clients, valid `.mcp.json`/`config.toml`/`~/.cowork/mcp.json` entries, MCP `tools/list`/`tools/call` with the minted token, and the deep-link round-trip (opens the doc in the editor).

Rebased onto `main` (#734 handleMcpRequest refactor + serverless MCP + cross-app auto-discovery); conflicts resolved by integrating these fixes on top of main's design. Adds regression tests for the `fullSurface` discriminator and `list_apps` live-origin behavior. Includes a changeset.

## Test plan

- [ ] `pnpm --filter @agent-native/core test` (MCP/connect/agent-chat suites green — 188 local)
- [ ] `pnpm --filter @agent-native/core exec tsc --noEmit` clean
- [ ] CI: changeset-check, guards, full test matrix
- [ ] Manual: `agent-native connect <local app>` → Claude Code → `tools/list` shows app actions → call one → click the returned "Open …" link lands in the running UI