### PR TITLE
fix(external-agents): deep links open the record for analytics + design

### DIFF
--- a/templates/analytics/server/plugins/core-routes.ts
+++ b/templates/analytics/server/plugins/core-routes.ts
@@ -1,0 +1,20 @@
+import { createCoreRoutesPlugin } from "@agent-native/core/server";
+
+// Land external-agent deep links straight on the real SPA route. Without
+// this, `/_agent-native/open?app=analytics&view=adhoc&dashboardId=…` falls
+// back to `/<view>` = `/adhoc`, which has no matching route (the dashboard
+// route is `adhoc.$id.tsx` → `/adhoc/:id`) and 404s — so an "Open in
+// Analytics" link produced by `update-dashboard` / `save-analysis` for a
+// connected Claude Code / Codex / Cowork never opened the record.
+export default createCoreRoutesPlugin({
+  resolveOpenPath: ({ view, params }) => {
+    if (params.dashboardId) return `/adhoc/${params.dashboardId}`;
+    if (params.analysisId) return `/analyses/${params.analysisId}`;
+    if (view === "analyses") return "/analyses";
+    // `adhoc`/unknown with no id: there is no bare `/adhoc` route — send to
+    // the app root rather than 404 (the polled `navigate` command still
+    // applies any record focus once the SPA is loaded).
+    if (view === "adhoc") return "/";
+    return null;
+  },
+});

--- a/templates/design/server/plugins/core-routes.ts
+++ b/templates/design/server/plugins/core-routes.ts
@@ -1,0 +1,20 @@
+import { createCoreRoutesPlugin } from "@agent-native/core/server";
+
+// Land external-agent deep links straight on the real SPA route. Every
+// design `link` builder (generate-design, apply-tweaks, get-design-snapshot,
+// export-coding-handoff) emits `view: "editor"` + `params.designId`. Without
+// a resolveOpenPath, `/_agent-native/open?app=design&view=editor&designId=…`
+// falls back to `/<view>` = `/editor`, which has no matching route (the
+// editor route is `design.$id.tsx` → `/design/:id`) and 404s — so an
+// "Open in Design" link for a connected Claude Code / Codex / Cowork never
+// opened the design.
+export default createCoreRoutesPlugin({
+  resolveOpenPath: ({ view, params }) => {
+    if (params.designId) return `/design/${params.designId}`;
+    // `editor`/unknown with no id: there is no bare `/editor` route — send to
+    // the app root rather than 404 (the polled `navigate` command still
+    // applies any record focus once the SPA is loaded).
+    if (view === "editor") return "/";
+    return null;
+  },
+});


### PR DESCRIPTION
## Summary

Follow-up to #737. While testing the external-agent connect flow with the **real Claude Code and Codex CLIs** (typed prompts → MCP tool → "Open in …" deep link → open it), the deep link **404'd for analytics and design**:

- **analytics** — `update-dashboard` / `save-analysis` / `get-analysis` emit `view: adhoc|analyses` + `dashboardId`/`analysisId`, but analytics had **no** core-routes plugin, so `/_agent-native/open` fell back to `/<view>` (`/adhoc`, `/analyses`). The real routes are `adhoc.$id.tsx` / `analyses.$id.tsx` (`/adhoc/:id`, `/analyses/:id`) → bare `/adhoc` 404s.
- **design** — `generate-design` / `apply-tweaks` / `get-design-snapshot` / `export-coding-handoff` emit `view: editor` + `designId` with no core-routes plugin → `/editor` 404 (route is `design.$id.tsx` → `/design/:id`).

Adds a `server/plugins/core-routes.ts` to each with a `resolveOpenPath` mapping the ids to the real SPA routes — the same proven pattern content/brain/calendar already use.

`forms`, `slides`, `videos`, `issues` were audited and emit **no** action deep links, so they need no change (no no-op plugins added). `mail` already has a working `manage-draft` deep link.

## Verification

Real Claude Code CLI, connected over `agent-native connect` (project-scoped `.mcp.json`):
- analytics: "create a dashboard" → MCP `update-dashboard` → returned `…/open?app=analytics&view=adhoc&dashboardId=…` → **before:** `/adhoc` 404 · **after:** opens `/adhoc/<id>` showing the dashboard. Re-verified with a fresh run.
- design: `…/open?app=design&view=editor&designId=…` → **after:** opens `/design/<id>` ("Design Editor").
- `pnpm prep` green (fmt + typecheck + test + guards). Template-only change (no changeset needed).

## Test plan

- [ ] CI green (lint, test, typecheck, build, guards)
- [ ] Manual: connect Claude Code/Codex to a deployed analytics or design app, ask it to create a dashboard/design, click the returned "Open in …" link → lands on the record (not 404)