### PR TITLE
Converge Code chat on shared agent runtime

### DIFF
--- a/.changeset/bright-vault-stars.md
+++ b/.changeset/bright-vault-stars.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Allow extensions to resolve vault-backed keys from the active workspace and mirror Dispatch vault saves into the shared credential store.

--- a/.changeset/calm-model-menus.md
+++ b/.changeset/calm-model-menus.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Respect externally supplied Builder-backed model availability in the shared composer model picker.

--- a/.changeset/gentle-transcript-spaces.md
+++ b/.changeset/gentle-transcript-spaces.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve spaces between streamed Agent-Native Code transcript chunks.

--- a/.changeset/quiet-open-links.md
+++ b/.changeset/quiet-open-links.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Collapse the agent sidebar by default when opening external-agent deep links.

--- a/.changeset/shared-code-chat.md
+++ b/.changeset/shared-code-chat.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": minor
+---
+
+Add shared Code chat transcript replay, prompt attachment helpers, and injectable AssistantChat runtime adapters.

--- a/.changeset/slow-chat-startup.md
+++ b/.changeset/slow-chat-startup.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Bound agent chat startup/history size and surface stalled or quota-capped runs instead of retrying forever.

--- a/packages/code-agents-ui/src/CodeAgentsApp.tsx
+++ b/packages/code-agents-ui/src/CodeAgentsApp.tsx
@@ -3516,13 +3516,15 @@ function TranscriptPanel({
           adapterReloadKey={controller}
           loadHistoryRepository={loadHistoryRepository}
           historyReloadKey={historyReloadKey}
-          composerSlot={
+          composerAreaClassName="code-agents-standard-composer"
+          composerToolbarSlot={
             <CodeAgentChatComposerSlot
-              runIsActive={runIsActive}
               permissionMode={permissionMode}
               onPermissionModeChange={onPermissionModeChange}
-              onStop={onStop}
             />
+          }
+          composerExtraActionButton={
+            runIsActive ? <CodeAgentStopButton onStop={onStop} /> : undefined
           }
           selectedModel={selectedModel}
           selectedEngine={selectedEngine}
@@ -3549,15 +3551,11 @@ function TranscriptPanel({
 }
 
 function CodeAgentChatComposerSlot({
-  runIsActive,
   permissionMode,
   onPermissionModeChange,
-  onStop,
 }: {
-  runIsActive: boolean;
   permissionMode: CodeAgentPermissionMode;
   onPermissionModeChange: (value: CodeAgentPermissionMode) => void;
-  onStop: () => void;
 }) {
   return (
     <div className="code-agents-chat-composer-slot">
@@ -3566,18 +3564,21 @@ function CodeAgentChatComposerSlot({
         onChange={onPermissionModeChange}
         compact
       />
-      {runIsActive && (
-        <button
-          type="button"
-          onClick={onStop}
-          className="code-agents-composer-stop-button"
-          aria-label="Stop session"
-          title="Stop session (Esc)"
-        >
-          <IconPlayerStop size={14} strokeWidth={1.9} />
-        </button>
-      )}
     </div>
+  );
+}
+
+function CodeAgentStopButton({ onStop }: { onStop: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onStop}
+      className="code-agents-composer-stop-button"
+      aria-label="Stop session"
+      title="Stop session (Esc)"
+    >
+      <IconPlayerStop size={14} strokeWidth={1.9} />
+    </button>
   );
 }
 

--- a/packages/code-agents-ui/src/CodeAgentsApp.tsx
+++ b/packages/code-agents-ui/src/CodeAgentsApp.tsx
@@ -18,6 +18,7 @@ import {
   IconFolder,
   IconFolderPlus,
   IconLink,
+  IconPencil,
   IconPinned,
   IconPinnedOff,
   IconPlus,
@@ -32,16 +33,19 @@ import {
 } from "@tabler/icons-react";
 import { QRCodeSVG } from "qrcode.react";
 import {
-  AgentConversation,
+  AssistantChat,
   PromptComposer,
-  type AgentConversationMessage,
+  buildRepositoryFromCodeAgentTranscript,
+  createCodeAgentChatAdapter,
+  isCodeAgentRunActive,
+  mergeCodeAgentTranscriptEvents,
+  readAgentPromptAttachment,
+  type CodeAgentChatController,
   type PromptComposerFile,
   type SlashCommand,
   type TiptapComposerHandle,
 } from "@agent-native/core/client";
 import { toast } from "sonner";
-import { readCodeAgentPromptAttachment } from "./composer-primitives.js";
-import { normalizeCodeAgentTranscriptForConversation } from "./transcript-conversation.js";
 import {
   CODE_AGENT_GOALS,
   DEFAULT_CODE_AGENT_PERMISSION_MODE,
@@ -236,6 +240,7 @@ const DEFAULT_CODE_AGENT_MODEL_OPTIONS: CodeAgentModelOption[] = [
 ];
 
 const CODE_AGENT_MODEL_SELECTION_KEY = "agent-native-code:model-selection";
+const CODE_AGENT_VIEWED_RUN_IDS_KEY = "agent-native-code:viewed-run-ids";
 const CODE_AGENT_PINNED_AT_METADATA_KEY = "pinnedAt";
 const DEFAULT_REMOTE_RELAY_URL = "https://dispatch.agent-native.com";
 
@@ -310,8 +315,6 @@ export default function CodeAgentsApp({
   >([]);
   const [transcriptLoading, setTranscriptLoading] = useState(false);
   const [transcriptError, setTranscriptError] = useState<string | null>(null);
-  const [followUpPrompt, setFollowUpPrompt] = useState("");
-  const [submittingFollowUp, setSubmittingFollowUp] = useState(false);
   const [newRunPermissionMode, setNewRunPermissionMode] =
     useState<CodeAgentPermissionMode>(DEFAULT_CODE_AGENT_PERMISSION_MODE);
   const [selectedPermissionMode, setSelectedPermissionMode] =
@@ -364,6 +367,30 @@ export default function CodeAgentsApp({
   const searchTranscriptCacheRef = useRef(
     new Map<string, CodeAgentTranscriptEvent[]>(),
   );
+  const initialViewedRunIdsRef = useRef<{
+    initialized: boolean;
+    ids: Set<string>;
+  } | null>(null);
+  if (initialViewedRunIdsRef.current === null) {
+    initialViewedRunIdsRef.current = readStoredViewedRunIds();
+  }
+  const viewedRunIdsInitializedRef = useRef(
+    initialViewedRunIdsRef.current.initialized,
+  );
+  const [viewedRunIds, setViewedRunIds] = useState<Set<string>>(
+    () => new Set(initialViewedRunIdsRef.current!.ids),
+  );
+
+  const markRunsViewed = useCallback((runIds: string[]) => {
+    const ids = runIds.filter(Boolean);
+    setViewedRunIds((current) => {
+      const next = new Set(current);
+      for (const id of ids) next.add(id);
+      if (next.size === current.size) return current;
+      writeStoredViewedRunIds(next);
+      return next;
+    });
+  }, []);
 
   const seedNewPrompt = useCallback((value: string) => {
     setNewPrompt(value);
@@ -380,6 +407,12 @@ export default function CodeAgentsApp({
         setStatus(result.status);
         setError(result.error ?? null);
         setRuns(result.runs);
+        if (result.status === "ok" && !viewedRunIdsInitializedRef.current) {
+          const initialIds = result.runs.map((run) => run.id);
+          viewedRunIdsInitializedRef.current = true;
+          setViewedRunIds(new Set(initialIds));
+          writeStoredViewedRunIds(new Set(initialIds));
+        }
       } catch (err) {
         setStatus("unavailable");
         setError(err instanceof Error ? err.message : String(err));
@@ -535,6 +568,13 @@ export default function CodeAgentsApp({
         });
       }
       await loadHostMetadata();
+      const modelResult = await host.listModels?.();
+      if (modelResult?.status === "ok" && modelResult.models.length > 0) {
+        setModelOptions(modelResult.models);
+        if (!modelSelection.model && modelResult.selected) {
+          setModelSelection(modelResult.selected);
+        }
+      }
       await loadRuns(true);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -543,7 +583,7 @@ export default function CodeAgentsApp({
     } finally {
       setBuilderConnecting(false);
     }
-  }, [host, loadHostMetadata, loadRuns, onOpenSettings]);
+  }, [host, loadHostMetadata, loadRuns, modelSelection.model, onOpenSettings]);
 
   useEffect(() => {
     if (!host.getRemoteConnectorStatus) return;
@@ -601,6 +641,10 @@ export default function CodeAgentsApp({
   useEffect(() => {
     setSelectedPermissionMode(selectedRunStoredPermissionMode);
   }, [selectedRunId, selectedRunStoredPermissionMode]);
+
+  useEffect(() => {
+    if (selectedRunId) markRunsViewed([selectedRunId]);
+  }, [markRunsViewed, selectedRunId]);
 
   useEffect(() => {
     if (!searchPanelOpen) return;
@@ -673,7 +717,7 @@ export default function CodeAgentsApp({
     return () => {
       cancelled = true;
     };
-  }, [host, modelSelection.model]);
+  }, [host, modelSelection.model, refreshKey]);
 
   useEffect(() => {
     void loadProjects();
@@ -742,6 +786,21 @@ export default function CodeAgentsApp({
     selectedRunId,
     selectedRunIsActive,
   ]);
+
+  // Cmd+N / Ctrl+N — start a new chat from anywhere in the Code tab.
+  // Use a ref so the effect is stable and doesn't re-register on every render.
+  const openSelectedGoalRef = useRef(openSelectedGoal);
+  openSelectedGoalRef.current = openSelectedGoal;
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== "n") return;
+      if (e.altKey || e.shiftKey) return;
+      e.preventDefault();
+      openSelectedGoalRef.current();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
 
   async function selectProjectFolder(pathValue: string) {
     if (!pathValue) return;
@@ -965,7 +1024,6 @@ export default function CodeAgentsApp({
     setWorkbenchOpen(false);
     setSearchPanelOpen(false);
     setMobilePanelOpen(false);
-    setFollowUpPrompt("");
     setTranscriptEvents([]);
     setTranscriptError(null);
     seedNewPrompt("");
@@ -1144,82 +1202,6 @@ export default function CodeAgentsApp({
     }
   }
 
-  async function submitFollowUp(
-    preparedPrompt: string,
-    attachments: CodeAgentPromptAttachment[],
-    deliveryMode: CodeAgentFollowUpMode = "immediate",
-  ) {
-    if (providerGate.blocked && !selectedRunIsActive) {
-      toast("Connect a model provider first", {
-        description: providerGate.description,
-        duration: 3600,
-      });
-      return;
-    }
-    if (!selectedRun) {
-      toast("Select a session first", { duration: 1800 });
-      return;
-    }
-    const prompt = preparedPrompt.trim();
-    if (!prompt) {
-      toast("Enter a follow-up prompt", { duration: 1800 });
-      return;
-    }
-    const optimisticEvent: CodeAgentTranscriptEvent = {
-      id: `pending-${Date.now()}`,
-      runId: selectedRun.id,
-      type: "user",
-      title: "User prompt",
-      text: prompt,
-      createdAt: new Date().toISOString(),
-      metadata: {
-        source: "desktop",
-        queued: true,
-        pending: true,
-        followUpMode: selectedRunIsActive ? deliveryMode : "immediate",
-      },
-    };
-    setFollowUpPrompt("");
-    setTranscriptEvents((current) => [...current, optimisticEvent]);
-    setSubmittingFollowUp(true);
-    try {
-      const result = await host.appendFollowUp({
-        goalId: selectedGoal.id,
-        runId: selectedRun.id,
-        prompt,
-        followUpMode: selectedRunIsActive ? deliveryMode : "immediate",
-        permissionMode: selectedPermissionMode,
-        engine: selectedModelSelection.engine,
-        model: selectedModelSelection.model,
-        effort: selectedModelSelection.effort,
-        attachments,
-      });
-      if (!result.ok) {
-        setTranscriptEvents((current) =>
-          current.filter((item) => item.id !== optimisticEvent.id),
-        );
-        toast(result.message, {
-          description: result.error,
-          duration: 3600,
-        });
-        return;
-      }
-      toast(result.message, { duration: 1800 });
-      await loadRuns(true);
-      await loadTranscript(selectedRun.id, true);
-    } catch (err) {
-      setTranscriptEvents((current) =>
-        current.filter((item) => item.id !== optimisticEvent.id),
-      );
-      toast("Could not record the follow-up", {
-        description: err instanceof Error ? err.message : String(err),
-        duration: 3600,
-      });
-    } finally {
-      setSubmittingFollowUp(false);
-    }
-  }
-
   async function changeSelectedPermissionMode(
     nextMode: CodeAgentPermissionMode,
   ) {
@@ -1332,6 +1314,45 @@ export default function CodeAgentsApp({
     }
   }
 
+  async function renameRun(run: CodeAgentRun, newTitle: string) {
+    const trimmed = newTitle.trim();
+    if (!trimmed || trimmed === getRunTitle(run)) return;
+    const optimisticRun: CodeAgentRun = { ...run, title: trimmed };
+    setRuns((current) =>
+      current.map((item) => (item.id === run.id ? optimisticRun : item)),
+    );
+    try {
+      const result = await host.updateRun({
+        goalId: selectedGoal.id,
+        runId: run.id,
+        title: trimmed,
+      });
+      if (!result.ok) {
+        setRuns((current) =>
+          current.map((item) => (item.id === run.id ? run : item)),
+        );
+        toast(result.message, { description: result.error, duration: 3200 });
+        return;
+      }
+      if (result.run) {
+        setRuns((current) =>
+          current.map((item) =>
+            item.id === result.run!.id ? result.run! : item,
+          ),
+        );
+      }
+      toast("Session renamed", { duration: 1600 });
+    } catch (err) {
+      setRuns((current) =>
+        current.map((item) => (item.id === run.id ? run : item)),
+      );
+      toast("Could not rename session", {
+        description: err instanceof Error ? err.message : String(err),
+        duration: 3200,
+      });
+    }
+  }
+
   return (
     <section className="code-agents-surface" aria-label="Agent-Native Code">
       <aside
@@ -1402,18 +1423,22 @@ export default function CodeAgentsApp({
             <GroupedRunList
               runs={runs}
               selectedRunId={selectedRunId}
+              viewedRunIds={viewedRunIds}
               onSelect={(run) => {
+                markRunsViewed([run.id]);
                 setSelectedRunId(run.id);
                 setSearchPanelOpen(false);
                 setMobilePanelOpen(false);
               }}
               onOpen={(run) => {
+                markRunsViewed([run.id]);
                 setSelectedRunId(run.id);
                 setWorkbenchOpen(true);
                 setSearchPanelOpen(false);
                 setMobilePanelOpen(false);
               }}
               onTogglePin={toggleRunPinned}
+              onRename={renameRun}
             />
           )}
         </div>
@@ -1518,22 +1543,19 @@ export default function CodeAgentsApp({
 
                 {selectedRun ? (
                   <RunDetailCard
+                    host={host}
                     run={selectedRun}
                     selectedRunId={selectedRunId}
                     goal={selectedGoal}
                     transcriptEvents={transcriptEvents}
                     transcriptLoading={transcriptLoading}
                     transcriptError={transcriptError}
-                    followUpPrompt={followUpPrompt}
-                    submittingFollowUp={submittingFollowUp}
                     permissionMode={selectedPermissionMode}
                     modelSelection={selectedModelSelection}
                     modelOptions={modelOptions}
                     updatingPermissionMode={updatingPermissionMode}
-                    onFollowUpPromptChange={setFollowUpPrompt}
                     onPermissionModeChange={changeSelectedPermissionMode}
                     onModelSelectionChange={setModelSelection}
-                    onSubmitFollowUp={submitFollowUp}
                     onOpenWorkbench={() => setWorkbenchOpen(true)}
                     onOpenTerminal={canOpenTerminal ? openTerminal : undefined}
                     onResume={() => controlRun("resume")}
@@ -1545,6 +1567,7 @@ export default function CodeAgentsApp({
                     builderConnectMessage={builderConnectMessage}
                     onConnectBuilder={connectBuilderProvider}
                     onOpenSettings={onOpenSettings}
+                    onConnectProvider={connectBuilderProvider}
                   />
                 ) : (
                   <div className="code-agents-start">
@@ -1573,6 +1596,7 @@ export default function CodeAgentsApp({
                       onModelSelectionChange={setModelSelection}
                       onSlashCommand={handleSlashCommand}
                       onSubmit={createRunFromPrompt}
+                      onConnectProvider={connectBuilderProvider}
                     />
                     {(projects.length > 0 || canChooseProjectFolder) && (
                       <ProjectFolderPicker
@@ -1642,7 +1666,7 @@ function ProjectFolderPicker({
       <p className="code-agents-rail-label">Folder</p>
       <div className="code-agents-project-picker__row">
         <Select
-          value={selectedPath || undefined}
+          value={selectedPath || ""}
           disabled={loading || projects.length === 0}
           onValueChange={(value) => {
             if (value === "__choose__") {
@@ -1715,6 +1739,7 @@ function NewSessionComposer({
   onModelSelectionChange,
   onSlashCommand,
   onSubmit,
+  onConnectProvider,
 }: {
   prompt: string;
   promptSeed: number;
@@ -1733,6 +1758,7 @@ function NewSessionComposer({
     preparedPrompt: string,
     attachments: CodeAgentPromptAttachment[],
   ) => void;
+  onConnectProvider?: () => void;
 }) {
   return (
     <CodeAgentComposer
@@ -1752,6 +1778,7 @@ function NewSessionComposer({
       onModelSelectionChange={onModelSelectionChange}
       onSlashCommand={onSlashCommand}
       onSubmit={onSubmit}
+      onConnectProvider={onConnectProvider}
     />
   );
 }
@@ -1775,6 +1802,7 @@ function CodeAgentComposer({
   onSlashCommand,
   onSubmit,
   onStop,
+  onConnectProvider,
 }: {
   prompt: string;
   promptSeed?: string | number;
@@ -1798,6 +1826,7 @@ function CodeAgentComposer({
     followUpMode?: CodeAgentFollowUpMode,
   ) => void;
   onStop?: () => void;
+  onConnectProvider?: () => void;
 }) {
   const composerModelGroups = useMemo(
     () => modelOptionsToComposerGroups(modelOptions),
@@ -1837,7 +1866,7 @@ function CodeAgentComposer({
 
   const readPromptFiles = useCallback(
     async (files: PromptComposerFile[]) =>
-      Promise.all(files.map((file) => readCodeAgentPromptAttachment(file))),
+      Promise.all(files.map((file) => readAgentPromptAttachment(file))),
     [],
   );
 
@@ -1888,6 +1917,7 @@ function CodeAgentComposer({
       selectedEffort={selectedEffort}
       onModelChange={handleModelChange}
       onEffortChange={handleEffortChange}
+      modelStatusChecksEnabled={false}
       onTextChange={onPromptChange}
       slashCommands={slashCommands}
       includeDefaultSlashSkills={false}
@@ -1903,6 +1933,7 @@ function CodeAgentComposer({
       attachmentsEnabled
       voiceEnabled
       preserveDraftOnSubmit={false}
+      onConnectProvider={onConnectProvider}
     />
   );
 }
@@ -1926,15 +1957,17 @@ function modelOptionsToComposerGroups(models: CodeAgentModelOption[]): Array<{
   for (const option of models) {
     const label = providerLabelForModel(option);
     const key = `${option.engine}:${label}`;
+    const configured = option.configured !== false;
     const group = groups.get(key) ?? {
       engine: option.engine,
       label,
       models: [],
-      configured: true,
+      configured,
     };
     if (!group.models.includes(option.model)) {
       group.models.push(option.model);
     }
+    group.configured = group.configured || configured;
     groups.set(key, group);
   }
 
@@ -2130,6 +2163,45 @@ function writeStoredModelSelection(value: CodeAgentModelSelection): void {
   }
 }
 
+function readStoredViewedRunIds(): {
+  initialized: boolean;
+  ids: Set<string>;
+} {
+  if (typeof window === "undefined") {
+    return { initialized: true, ids: new Set() };
+  }
+  try {
+    const raw = window.localStorage.getItem(CODE_AGENT_VIEWED_RUN_IDS_KEY);
+    if (!raw) return { initialized: false, ids: new Set() };
+    const parsed = JSON.parse(raw) as unknown;
+    const ids = Array.isArray(parsed)
+      ? parsed
+      : parsed &&
+          typeof parsed === "object" &&
+          Array.isArray((parsed as { ids?: unknown }).ids)
+        ? (parsed as { ids: unknown[] }).ids
+        : [];
+    return {
+      initialized: true,
+      ids: new Set(ids.filter((id): id is string => typeof id === "string")),
+    };
+  } catch {
+    return { initialized: false, ids: new Set() };
+  }
+}
+
+function writeStoredViewedRunIds(ids: Set<string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      CODE_AGENT_VIEWED_RUN_IDS_KEY,
+      JSON.stringify({ version: 1, ids: [...ids].slice(-1000) }),
+    );
+  } catch {
+    // Ignore private-mode storage failures.
+  }
+}
+
 function RunModeSelect({
   value,
   onChange,
@@ -2258,30 +2330,25 @@ function normalizePromptForSelectedGoal(
 }
 
 function isRunActive(run: CodeAgentRun): boolean {
-  return !(
-    run.status === "completed" ||
-    run.status === "errored" ||
-    run.status === "paused" ||
-    run.phase === "complete" ||
-    run.phase === "error" ||
-    run.phase === "paused" ||
-    run.phase === "missing-credentials" ||
-    run.phase === "stopped"
-  );
+  return isCodeAgentRunActive(run);
 }
 
 function GroupedRunList({
   runs,
   selectedRunId,
+  viewedRunIds,
   onSelect,
   onOpen,
   onTogglePin,
+  onRename,
 }: {
   runs: CodeAgentRun[];
   selectedRunId: string | null;
+  viewedRunIds: Set<string>;
   onSelect: (run: CodeAgentRun) => void;
   onOpen: (run: CodeAgentRun) => void;
   onTogglePin: (run: CodeAgentRun) => void;
+  onRename: (run: CodeAgentRun, newTitle: string) => void;
 }) {
   const sortedRuns = sortRunsForRail(runs);
   return (
@@ -2291,9 +2358,11 @@ function GroupedRunList({
           key={run.id}
           run={run}
           selected={run.id === selectedRunId}
+          unread={!viewedRunIds.has(run.id) && !isRunActive(run)}
           onSelect={() => onSelect(run)}
           onOpen={() => onOpen(run)}
           onTogglePin={() => onTogglePin(run)}
+          onRename={(newTitle) => onRename(run, newTitle)}
         />
       ))}
     </div>
@@ -2405,27 +2474,7 @@ function mergeTranscriptEvents(
   current: CodeAgentTranscriptEvent[],
   incoming: CodeAgentTranscriptEvent[],
 ): CodeAgentTranscriptEvent[] {
-  if (incoming.length === 0) return current;
-  const byId = new Map(current.map((event) => [event.id, event]));
-  for (const event of incoming) byId.set(event.id, event);
-  return [...byId.values()].sort(compareTranscriptEvents);
-}
-
-function compareTranscriptEvents(
-  a: CodeAgentTranscriptEvent,
-  b: CodeAgentTranscriptEvent,
-): number {
-  const seqA = getTranscriptSeq(a);
-  const seqB = getTranscriptSeq(b);
-  if (seqA !== null && seqB !== null && seqA !== seqB) return seqA - seqB;
-  const created = a.createdAt.localeCompare(b.createdAt);
-  if (created !== 0) return created;
-  return a.id.localeCompare(b.id);
-}
-
-function getTranscriptSeq(event: CodeAgentTranscriptEvent): number | null {
-  const value = event.metadata?.seq;
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
+  return mergeCodeAgentTranscriptEvents(current, incoming);
 }
 
 function getSearchMatchSnippet(text: string, tokens: string[]): string {
@@ -2554,65 +2603,137 @@ function renderControlButton(button: {
 function RunRailItem({
   run,
   selected,
+  unread,
   onSelect,
   onOpen,
   onTogglePin,
+  onRename,
 }: {
   run: CodeAgentRun;
   selected: boolean;
+  unread: boolean;
   onSelect: () => void;
   onOpen: () => void;
   onTogglePin: () => void;
+  onRename: (newTitle: string) => void;
 }) {
   const pinned = isRunPinned(run);
+  const active = isRunActive(run);
+  const [renaming, setRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
+  const renameInputRef = useRef<HTMLInputElement | null>(null);
+
+  function startRename() {
+    setRenameValue(getRunTitle(run) ?? "");
+    setRenaming(true);
+    window.requestAnimationFrame(() => {
+      renameInputRef.current?.select();
+    });
+  }
+
+  function commitRename() {
+    const trimmed = renameValue.trim();
+    setRenaming(false);
+    if (trimmed && trimmed !== getRunTitle(run)) {
+      onRename(trimmed);
+    }
+  }
+
+  function handleRenameKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commitRename();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setRenaming(false);
+    }
+  }
+
   return (
     <div
       className={`code-agents-run-row${
         selected ? " code-agents-run-row--active" : ""
-      }${pinned ? " code-agents-run-row--pinned" : ""}`}
+      }${pinned ? " code-agents-run-row--pinned" : ""}${
+        renaming ? " code-agents-run-row--renaming" : ""
+      }`}
     >
-      <button
-        type="button"
-        className="code-agents-run"
-        onClick={onSelect}
-        onDoubleClick={onOpen}
-        title={getRunTitle(run) ?? undefined}
-      >
-        <div className="code-agents-run__topline">
-          <span className="code-agents-run__name">{getRunTitle(run)}</span>
-          <span className="code-agents-run__time">
-            {formatRelativeTime(run.updatedAt)}
-          </span>
+      {renaming ? (
+        <div className="code-agents-run code-agents-run--rename">
+          <input
+            ref={renameInputRef}
+            className="code-agents-run__rename-input"
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={handleRenameKeyDown}
+            onBlur={commitRename}
+            autoFocus
+            aria-label="Rename session"
+          />
         </div>
-      </button>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            className={`code-agents-run-menu${
-              pinned ? " code-agents-run-menu--pinned" : ""
-            }`}
-            aria-label={pinned ? "Unpin session" : "Pin session"}
-            title={pinned ? "Unpin session" : "Pin session"}
-          >
-            {pinned ? (
-              <IconPinned size={13} strokeWidth={1.8} />
-            ) : (
-              <IconDots size={14} strokeWidth={1.8} />
-            )}
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" side="right" sideOffset={8}>
-          <DropdownMenuItem onSelect={onTogglePin}>
-            {pinned ? (
-              <IconPinnedOff size={14} strokeWidth={1.8} />
-            ) : (
-              <IconPinned size={14} strokeWidth={1.8} />
-            )}
-            <span>{pinned ? "Unpin from top" : "Pin to top"}</span>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      ) : (
+        <button
+          type="button"
+          className="code-agents-run"
+          onClick={onSelect}
+          onDoubleClick={onOpen}
+          title={getRunTitle(run) ?? undefined}
+        >
+          <div className="code-agents-run__topline">
+            <span className="code-agents-run__name">{getRunTitle(run)}</span>
+            <span className="code-agents-run__time">
+              {active ? (
+                <span
+                  className="code-agents-run-status-spinner"
+                  aria-label="Running"
+                  title="Running"
+                />
+              ) : unread ? (
+                <span
+                  className="code-agents-run-status-dot"
+                  aria-label="Done — unread"
+                  title="Done"
+                />
+              ) : (
+                formatRelativeTime(run.updatedAt)
+              )}
+            </span>
+          </div>
+        </button>
+      )}
+      {!renaming && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className={`code-agents-run-menu${
+                pinned ? " code-agents-run-menu--pinned" : ""
+              }`}
+              aria-label="Session options"
+              title="Session options"
+            >
+              {pinned ? (
+                <IconPinned size={13} strokeWidth={1.8} />
+              ) : (
+                <IconDots size={14} strokeWidth={1.8} />
+              )}
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" side="right" sideOffset={8}>
+            <DropdownMenuItem onSelect={startRename}>
+              <IconPencil size={14} strokeWidth={1.8} />
+              <span>Rename</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onTogglePin}>
+              {pinned ? (
+                <IconPinnedOff size={14} strokeWidth={1.8} />
+              ) : (
+                <IconPinned size={14} strokeWidth={1.8} />
+              )}
+              <span>{pinned ? "Unpin from top" : "Pin to top"}</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </div>
   );
 }
@@ -3040,22 +3161,19 @@ function MobileConnectorPanel({
 }
 
 function RunDetailCard({
+  host,
   run,
   selectedRunId,
   goal,
   transcriptEvents,
   transcriptLoading,
   transcriptError,
-  followUpPrompt,
-  submittingFollowUp,
   permissionMode,
   modelSelection,
   modelOptions,
   updatingPermissionMode,
-  onFollowUpPromptChange,
   onPermissionModeChange,
   onModelSelectionChange,
-  onSubmitFollowUp,
   onOpenWorkbench,
   onOpenTerminal,
   onResume,
@@ -3067,27 +3185,21 @@ function RunDetailCard({
   builderConnectMessage,
   onConnectBuilder,
   onOpenSettings,
+  onConnectProvider,
 }: {
+  host: CodeAgentsHost;
   run: CodeAgentRun | null;
   selectedRunId: string | null;
   goal: CodeAgentGoalDefinition;
   transcriptEvents: CodeAgentTranscriptEvent[];
   transcriptLoading: boolean;
   transcriptError: string | null;
-  followUpPrompt: string;
-  submittingFollowUp: boolean;
   permissionMode: CodeAgentPermissionMode;
   modelSelection: CodeAgentModelSelection;
   modelOptions: CodeAgentModelOption[];
   updatingPermissionMode: boolean;
-  onFollowUpPromptChange: (value: string) => void;
   onPermissionModeChange: (value: CodeAgentPermissionMode) => void;
   onModelSelectionChange: (value: CodeAgentModelSelection) => void;
-  onSubmitFollowUp: (
-    preparedPrompt: string,
-    attachments: CodeAgentPromptAttachment[],
-    followUpMode?: CodeAgentFollowUpMode,
-  ) => void;
   onOpenWorkbench: () => void;
   onOpenTerminal?: () => void;
   onResume: () => void;
@@ -3099,6 +3211,7 @@ function RunDetailCard({
   builderConnectMessage: string | null;
   onConnectBuilder: () => void;
   onOpenSettings?: () => void;
+  onConnectProvider?: () => void;
 }) {
   const runIsActive = run ? isRunActive(run) : false;
 
@@ -3256,98 +3369,275 @@ function RunDetailCard({
         )}
 
       <TranscriptPanel
+        host={host}
+        goal={goal}
+        run={run}
         events={transcriptEvents}
         loading={transcriptLoading}
         error={transcriptError}
-        followUpPrompt={followUpPrompt}
         runIsActive={runIsActive}
-        submitting={submittingFollowUp}
         permissionMode={permissionMode}
         modelSelection={modelSelection}
         modelOptions={modelOptions}
         hideCredentialMessages={hasCredentialGap}
-        onFollowUpPromptChange={onFollowUpPromptChange}
         onPermissionModeChange={onPermissionModeChange}
         onModelSelectionChange={onModelSelectionChange}
-        onSubmitFollowUp={onSubmitFollowUp}
         onStop={onStop}
+        onConnectProvider={onConnectProvider}
       />
     </div>
   );
 }
 
 function TranscriptPanel({
+  host,
+  goal,
+  run,
   events,
   loading,
   error,
-  followUpPrompt,
   runIsActive,
-  submitting,
   permissionMode,
   modelSelection,
   modelOptions,
   hideCredentialMessages = false,
-  onFollowUpPromptChange,
   onPermissionModeChange,
   onModelSelectionChange,
-  onSubmitFollowUp,
   onStop,
+  onConnectProvider,
 }: {
+  host: CodeAgentsHost;
+  goal: CodeAgentGoalDefinition;
+  run: CodeAgentRun;
   events: CodeAgentTranscriptEvent[];
   loading: boolean;
   error: string | null;
-  followUpPrompt: string;
   runIsActive: boolean;
-  submitting: boolean;
   permissionMode: CodeAgentPermissionMode;
   modelSelection: CodeAgentModelSelection;
   modelOptions: CodeAgentModelOption[];
   hideCredentialMessages?: boolean;
-  onFollowUpPromptChange: (value: string) => void;
   onPermissionModeChange: (value: CodeAgentPermissionMode) => void;
   onModelSelectionChange: (value: CodeAgentModelSelection) => void;
-  onSubmitFollowUp: (
-    preparedPrompt: string,
-    attachments: CodeAgentPromptAttachment[],
-    followUpMode?: CodeAgentFollowUpMode,
-  ) => void;
   onStop: () => void;
+  onConnectProvider?: () => void;
 }) {
-  const messages = useMemo<AgentConversationMessage[]>(
+  const normalizedModel = normalizeModelSelection(modelSelection, modelOptions);
+  const selectedModel = normalizedModel.model ?? "auto";
+  const selectedEngine = normalizedModel.engine ?? "auto";
+  const selectedEffort = normalizeReasoningEffort(
+    normalizedModel.effort ?? "auto",
+  );
+  const eventsRef = useRef(events);
+  eventsRef.current = events;
+  const hideCredentialMessagesRef = useRef(hideCredentialMessages);
+  hideCredentialMessagesRef.current = hideCredentialMessages;
+  const runIdRef = useRef<string | null>(run.id);
+  runIdRef.current = run.id;
+  const permissionModeRef = useRef<string | undefined>(permissionMode);
+  permissionModeRef.current = permissionMode;
+  const modelRef = useRef<string | undefined>(selectedModel);
+  modelRef.current = selectedModel === "auto" ? undefined : selectedModel;
+  const engineRef = useRef<string | undefined>(selectedEngine);
+  engineRef.current = selectedEngine === "auto" ? undefined : selectedEngine;
+  const effortRef = useRef<CodeAgentReasoningEffort | undefined>(
+    selectedEffort,
+  );
+  effortRef.current = selectedEffort;
+  const followUpModeRef = useRef<CodeAgentFollowUpMode | undefined>(undefined);
+  const attachOnlyRef = useRef(false);
+  attachOnlyRef.current = false;
+
+  const controller = useMemo(
+    () => createHostCodeAgentChatController(host, goal.id),
+    [goal.id, host],
+  );
+  const createAdapter = useCallback(
     () =>
-      normalizeCodeAgentTranscriptForConversation(events, {
-        hideCredentialMessages,
+      createCodeAgentChatAdapter({
+        controller,
+        runIdRef,
+        permissionModeRef,
+        modelRef,
+        engineRef,
+        effortRef,
+        followUpModeRef,
+        attachOnlyRef,
+        tabId: `code-agent:${run.id}`,
       }),
-    [events, hideCredentialMessages],
+    [controller, run.id],
+  );
+  const loadHistoryRepository = useCallback(
+    async () =>
+      buildRepositoryFromCodeAgentTranscript(eventsRef.current, {
+        hideCredentialMessages: hideCredentialMessagesRef.current,
+      }),
+    [],
+  );
+  const historyReloadKey = useMemo(() => {
+    const lastEvent = events.length > 0 ? events[events.length - 1] : undefined;
+    return [
+      run.id,
+      events.length,
+      lastEvent?.id ?? "",
+      lastEvent?.createdAt ?? "",
+      hideCredentialMessages ? "hide" : "show",
+    ].join(":");
+  }, [events, hideCredentialMessages, run.id]);
+  const composerGroups = useMemo(
+    () => modelOptionsToComposerGroups(modelOptions),
+    [modelOptions],
   );
 
   return (
-    <AgentConversation
-      className="code-agents-transcript"
-      timelineClassName="code-agents-transcript__timeline"
-      messages={messages}
-      loading={loading}
-      error={error}
-      streaming={runIsActive}
-      emptyTitle="No messages yet."
-      composer={
-        <CodeAgentComposer
-          prompt={followUpPrompt}
-          submitting={submitting}
-          permissionMode={permissionMode}
-          modelSelection={modelSelection}
-          modelOptions={modelOptions}
-          placeholder="Ask for follow-up changes"
-          onPromptChange={onFollowUpPromptChange}
-          onPermissionModeChange={onPermissionModeChange}
-          onModelSelectionChange={onModelSelectionChange}
-          onSubmit={onSubmitFollowUp}
-          stopActive={runIsActive}
-          onStop={onStop}
+    <div className="code-agents-transcript">
+      {error && (
+        <div className="code-agents-transcript__error">
+          <IconAlertCircle size={15} strokeWidth={1.8} />
+          <span>{error}</span>
+        </div>
+      )}
+      {loading && events.length === 0 ? (
+        <div className="code-agents-transcript__empty">
+          Loading transcript...
+        </div>
+      ) : (
+        <AssistantChat
+          key={run.id}
+          className="code-agents-transcript__assistant"
+          tabId={`code-agent:${run.id}`}
+          showHeader={false}
+          emptyStateText="No messages yet."
+          suggestions={[]}
+          dynamicSuggestions={false}
+          plusMenuMode="upload-only"
+          providerStatusChecksEnabled={false}
+          createAdapter={createAdapter}
+          adapterReloadKey={controller}
+          loadHistoryRepository={loadHistoryRepository}
+          historyReloadKey={historyReloadKey}
+          composerSlot={
+            <CodeAgentChatComposerSlot
+              runIsActive={runIsActive}
+              permissionMode={permissionMode}
+              onPermissionModeChange={onPermissionModeChange}
+              onStop={onStop}
+            />
+          }
+          selectedModel={selectedModel}
+          selectedEngine={selectedEngine}
+          selectedEffort={selectedEffort}
+          availableModels={composerGroups}
+          onModelChange={(model, engine) => {
+            if (engine === "auto" && model === "auto") {
+              onModelSelectionChange({ effort: selectedEffort });
+              return;
+            }
+            onModelSelectionChange({ engine, model, effort: selectedEffort });
+          }}
+          onEffortChange={(effort) => {
+            onModelSelectionChange({
+              ...normalizedModel,
+              effort: normalizeReasoningEffort(effort),
+            });
+          }}
+          onConnectProvider={onConnectProvider}
         />
-      }
-    />
+      )}
+    </div>
   );
+}
+
+function CodeAgentChatComposerSlot({
+  runIsActive,
+  permissionMode,
+  onPermissionModeChange,
+  onStop,
+}: {
+  runIsActive: boolean;
+  permissionMode: CodeAgentPermissionMode;
+  onPermissionModeChange: (value: CodeAgentPermissionMode) => void;
+  onStop: () => void;
+}) {
+  return (
+    <div className="code-agents-chat-composer-slot">
+      <RunModeSelect
+        value={permissionMode}
+        onChange={onPermissionModeChange}
+        compact
+      />
+      {runIsActive && (
+        <button
+          type="button"
+          onClick={onStop}
+          className="code-agents-composer-stop-button"
+          aria-label="Stop session"
+          title="Stop session (Esc)"
+        >
+          <IconPlayerStop size={14} strokeWidth={1.9} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+function createHostCodeAgentChatController(
+  host: CodeAgentsHost,
+  goalId: string,
+): CodeAgentChatController {
+  return {
+    async get(runId) {
+      const result = await host.listRuns(goalId);
+      return result.runs.find((run) => run.id === runId) ?? null;
+    },
+    async transcript(runId) {
+      const result = await host.readTranscript({ goalId, runId });
+      return result.status === "ok" ? result.events : [];
+    },
+    async sendFollowUp(input) {
+      const result = await host.appendFollowUp({
+        goalId,
+        runId: input.runId,
+        prompt: input.prompt,
+        followUpMode: input.mode,
+        permissionMode: input.permissionMode as
+          | CodeAgentPermissionMode
+          | undefined,
+        engine: input.engine,
+        model: input.model,
+        effort: input.reasoningEffort as CodeAgentReasoningEffort | undefined,
+        attachments: normalizePromptAttachmentsForHost(input.metadata),
+      });
+      return {
+        ok: result.ok,
+        message: result.message,
+        error: result.error,
+      };
+    },
+    async control(input) {
+      const result = await host.controlRun(goalId, input.runId, "stop");
+      return {
+        ok: result.ok,
+        run: result.run ?? null,
+        message: result.message,
+        error: result.error,
+      };
+    },
+  };
+}
+
+function normalizePromptAttachmentsForHost(
+  metadata: Record<string, unknown> | undefined,
+): CodeAgentPromptAttachment[] | undefined {
+  const raw = metadata?.attachments;
+  if (!Array.isArray(raw)) return undefined;
+  return raw.filter((item): item is CodeAgentPromptAttachment => {
+    return Boolean(
+      item &&
+      typeof item === "object" &&
+      typeof (item as CodeAgentPromptAttachment).name === "string",
+    );
+  });
 }
 
 function Field({ label, value }: { label: string; value: string }) {

--- a/packages/code-agents-ui/src/composer-primitives.ts
+++ b/packages/code-agents-ui/src/composer-primitives.ts
@@ -1,55 +1,8 @@
-import type { CodeAgentPromptAttachment } from "./types.js";
-
-export const CODE_AGENT_MAX_INLINE_TEXT_CHARS = 60_000;
-
-export async function readCodeAgentPromptAttachment(
-  file: File,
-): Promise<CodeAgentPromptAttachment> {
-  const attachment: CodeAgentPromptAttachment = {
-    name: file.name,
-    type: file.type || undefined,
-    size: file.size,
-  };
-  if (
-    isInlineableCodeAgentFile(file) &&
-    file.size <= CODE_AGENT_MAX_INLINE_TEXT_CHARS
-  ) {
-    try {
-      attachment.text = await file.text();
-    } catch {
-      // Keep the filename-only attachment if the browser cannot read it.
-    }
-  }
-  return attachment;
-}
-
-export function isInlineableCodeAgentFile(file: File): boolean {
-  if (file.type.startsWith("text/")) return true;
-  return /\.(cjs|css|csv|html|js|json|jsx|md|mdx|mjs|sql|tsx?|txt|xml|yaml|yml)$/i.test(
-    file.name,
-  );
-}
-
-export function formatCodeAgentPromptWithAttachments(
-  prompt: string,
-  attachments: CodeAgentPromptAttachment[],
-): string {
-  if (attachments.length === 0) return prompt;
-  const attachmentText = attachments
-    .map((attachment) => {
-      const size = attachment.size ? ` size="${attachment.size}"` : "";
-      const type = attachment.type
-        ? ` type="${escapeCodeAgentXmlAttribute(attachment.type)}"`
-        : "";
-      const body =
-        attachment.text?.trim() ||
-        "Selected in the UI. If this file is needed, inspect it from the workspace or ask for a readable copy.";
-      return `<attached-file name="${escapeCodeAgentXmlAttribute(attachment.name)}"${type}${size}>\n${body}\n</attached-file>`;
-    })
-    .join("\n\n");
-  return `${prompt.trimEnd()}\n\nAttached context:\n${attachmentText}`;
-}
-
-export function escapeCodeAgentXmlAttribute(value: string): string {
-  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
-}
+export {
+  AGENT_PROMPT_MAX_INLINE_IMAGE_BYTES as CODE_AGENT_MAX_INLINE_IMAGE_BYTES,
+  AGENT_PROMPT_MAX_INLINE_TEXT_CHARS as CODE_AGENT_MAX_INLINE_TEXT_CHARS,
+  escapePromptAttachmentAttribute as escapeCodeAgentXmlAttribute,
+  formatPromptWithAttachments as formatCodeAgentPromptWithAttachments,
+  isInlineableAgentPromptFile as isInlineableCodeAgentFile,
+  readAgentPromptAttachment as readCodeAgentPromptAttachment,
+} from "@agent-native/core/client";

--- a/packages/code-agents-ui/src/styles.css
+++ b/packages/code-agents-ui/src/styles.css
@@ -2161,9 +2161,11 @@
 }
 
 .code-agents-chat-composer-slot {
-  display: flex;
+  min-width: 0;
+  flex: 0 0 auto;
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 8px;
 }
 

--- a/packages/code-agents-ui/src/styles.css
+++ b/packages/code-agents-ui/src/styles.css
@@ -1,3 +1,5 @@
+@import "../../core/src/styles/agent-conversation.css";
+
 /* ─── Agent-Native Code shadcn/template alignment ─────────────── */
 .code-agents-surface {
   --background: 220 6% 6%;
@@ -25,6 +27,7 @@
   --sidebar-accent: 220 4% 10%;
   --sidebar-accent-foreground: 0 0% 90%;
   --sidebar-border: 220 4% 10%;
+  --ease: 120ms cubic-bezier(0.16, 1, 0.3, 1);
   --code-agents-chat-max: 700px;
   --code-agents-rail-gutter: 8px;
   --code-agents-rail-row-inset: 8px;
@@ -122,6 +125,9 @@
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
+  transition:
+    background var(--ease),
+    color var(--ease);
 }
 
 .code-agents-nav-link:disabled {
@@ -322,6 +328,7 @@
   position: relative;
   border-radius: calc(var(--radius) - 2px);
   color: hsl(var(--muted-foreground));
+  transition: background var(--ease);
 }
 
 .code-agents-run-row--active .code-agents-run__name,
@@ -348,6 +355,33 @@
   cursor: pointer;
 }
 
+.code-agents-run--rename {
+  display: flex;
+  align-items: center;
+  padding: 4px var(--code-agents-rail-row-inset);
+  cursor: default;
+}
+
+.code-agents-run__rename-input {
+  width: 100%;
+  min-width: 0;
+  padding: 2px 6px;
+  border: 1px solid hsl(var(--ring));
+  border-radius: calc(var(--radius) - 3px);
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  outline: none;
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.25);
+}
+
+.code-agents-run__rename-input:focus {
+  border-color: hsl(var(--ring));
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.35);
+}
+
 .code-agents-run-menu {
   position: absolute;
   top: 4px;
@@ -363,6 +397,10 @@
   color: hsl(var(--muted-foreground) / 0.72);
   opacity: 0;
   cursor: pointer;
+  transition:
+    background var(--ease),
+    color var(--ease),
+    opacity 100ms ease;
 }
 
 .code-agents-run-menu:hover,
@@ -415,6 +453,37 @@
 
 .code-agents-run__time {
   justify-self: end;
+}
+
+/* ── Session status indicators in the rail ─────────────────────── */
+.code-agents-run-status-spinner,
+.code-agents-run-status-dot {
+  display: inline-block;
+  flex: 0 0 auto;
+  border-radius: 50%;
+}
+
+/* Spinning arc for actively-running sessions */
+.code-agents-run-status-spinner {
+  width: 9px;
+  height: 9px;
+  border: 1.5px solid hsl(var(--muted-foreground) / 0.28);
+  border-top-color: hsl(var(--muted-foreground) / 0.82);
+  animation: code-agents-spin 0.75s linear infinite;
+}
+
+@keyframes code-agents-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Blue dot for completed sessions the user hasn't opened yet */
+.code-agents-run-status-dot {
+  width: 7px;
+  height: 7px;
+  background: #3b82f6;
+  box-shadow: 0 0 0 2.5px rgba(59, 130, 246, 0.18);
 }
 
 .code-agents-source-label {
@@ -556,6 +625,7 @@
   color: hsl(var(--foreground));
   text-align: left;
   cursor: pointer;
+  transition: background var(--ease);
 }
 
 .code-agents-search-result:hover {
@@ -1384,6 +1454,11 @@
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
+  transition:
+    background var(--ease),
+    color var(--ease),
+    border-color var(--ease),
+    opacity var(--ease);
 }
 
 .code-agents-button--primary {
@@ -1815,6 +1890,20 @@
   box-shadow:
     0 18px 44px rgba(0, 0, 0, 0.42),
     inset 0 1px 0 hsl(var(--foreground, 0 0% 90%) / 0.04);
+  /* shadcn-style enter/exit animations */
+  transform-origin: var(--radix-select-content-transform-origin);
+  animation-duration: 140ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.desktop-select-content[data-state="open"] {
+  animation-name: desktop-dropdown-in;
+}
+
+.desktop-select-content[data-state="closed"] {
+  animation-name: desktop-dropdown-out;
+  animation-timing-function: cubic-bezier(0.4, 0, 1, 1);
+  animation-duration: 100ms;
 }
 
 .desktop-select-viewport {
@@ -1844,6 +1933,9 @@
   padding: 8px 9px 8px 30px;
   color: hsl(var(--foreground, 0 0% 90%) / 0.88);
   outline: none;
+  transition:
+    background 80ms ease,
+    color 80ms ease;
 }
 
 .desktop-select-item[data-highlighted] {
@@ -1896,6 +1988,42 @@
   box-shadow:
     0 18px 44px rgba(0, 0, 0, 0.42),
     inset 0 1px 0 hsl(var(--foreground, 0 0% 90%) / 0.04);
+  /* shadcn-style enter/exit animations via Radix data-state */
+  transform-origin: var(--radix-dropdown-menu-content-transform-origin);
+  animation-duration: 140ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.desktop-dropdown-content[data-state="open"] {
+  animation-name: desktop-dropdown-in;
+}
+
+.desktop-dropdown-content[data-state="closed"] {
+  animation-name: desktop-dropdown-out;
+  animation-timing-function: cubic-bezier(0.4, 0, 1, 1);
+  animation-duration: 100ms;
+}
+
+@keyframes desktop-dropdown-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes desktop-dropdown-out {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.95);
+  }
 }
 
 .desktop-dropdown-label {
@@ -1918,6 +2046,10 @@
   font-size: 12px;
   outline: none;
   user-select: none;
+  cursor: default;
+  transition:
+    background 80ms ease,
+    color 80ms ease;
 }
 
 .desktop-dropdown-item > svg {
@@ -2023,6 +2155,18 @@
   border-top: 0;
 }
 
+.code-agents-transcript__assistant {
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.code-agents-chat-composer-slot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .code-agents-detail__footer,
 .code-agents-follow-up__actions,
 .code-agents-toolbar-actions {
@@ -2071,298 +2215,6 @@
   gap: 14px;
   overflow-y: auto;
   padding: 4px 2px 8px;
-}
-
-.agent-conversation {
-  position: relative;
-}
-
-.agent-conversation__error {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
-  border: 1px solid hsl(var(--destructive) / 0.24);
-  border-radius: var(--radius);
-  background: hsl(var(--destructive) / 0.08);
-  color: hsl(var(--destructive-foreground));
-  font-size: 12px;
-}
-
-.agent-conversation__empty {
-  min-height: 180px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  color: hsl(var(--muted-foreground));
-  font-size: 12px;
-}
-
-.agent-conversation__empty span {
-  color: hsl(var(--muted-foreground));
-}
-
-.agent-conversation__scroll-bottom {
-  position: absolute;
-  right: 18px;
-  bottom: 92px;
-  z-index: 2;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: 1px solid hsl(var(--border));
-  border-radius: 999px;
-  background: hsl(var(--popover));
-  color: hsl(var(--foreground));
-  box-shadow: 0 10px 30px hsl(var(--background) / 0.28);
-  cursor: pointer;
-}
-
-.agent-conversation-message {
-  display: flex;
-  width: 100%;
-}
-
-.agent-conversation-message--user {
-  justify-content: flex-end;
-}
-
-.agent-conversation-message--assistant,
-.agent-conversation-message--system {
-  justify-content: flex-start;
-}
-
-.agent-conversation-message__body {
-  min-width: 0;
-  max-width: min(100%, 880px);
-}
-
-.agent-conversation-message--user .agent-conversation-message__body {
-  max-width: min(78%, 720px);
-  padding: 9px 11px;
-  border-radius: calc(var(--radius) + 4px);
-  background: hsl(var(--muted));
-}
-
-.agent-conversation-message--pending .agent-conversation-message__body {
-  opacity: 0.72;
-}
-
-.agent-conversation-message__part + .agent-conversation-message__part {
-  margin-top: 10px;
-}
-
-.agent-conversation-message__part--tool,
-.agent-conversation-message__part--notice,
-.agent-conversation-message__part--artifact {
-  display: block;
-}
-
-.agent-conversation-markdown {
-  color: hsl(var(--foreground) / 0.82);
-  font-size: 13px;
-  line-height: 1.6;
-  overflow-wrap: anywhere;
-}
-
-.agent-conversation-message--user .agent-conversation-markdown {
-  color: hsl(var(--foreground) / 0.92);
-}
-
-.agent-conversation-markdown > :first-child {
-  margin-top: 0;
-}
-
-.agent-conversation-markdown > :last-child {
-  margin-bottom: 0;
-}
-
-.agent-conversation-markdown p,
-.agent-conversation-markdown ul,
-.agent-conversation-markdown ol,
-.agent-conversation-markdown pre {
-  margin: 0 0 10px;
-}
-
-.agent-conversation-markdown ul,
-.agent-conversation-markdown ol {
-  padding-left: 20px;
-}
-
-.agent-conversation-markdown li {
-  margin: 3px 0;
-  padding-left: 2px;
-}
-
-.agent-conversation-markdown li > p {
-  margin: 0;
-}
-
-.agent-conversation-markdown strong {
-  color: hsl(var(--foreground) / 0.92);
-  font-weight: 650;
-}
-
-.agent-conversation-markdown a {
-  color: #60a5fa;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  cursor: pointer;
-}
-
-.agent-conversation-markdown a:hover {
-  color: #93c5fd;
-}
-
-.agent-conversation-markdown code {
-  border-radius: 4px;
-  background: hsl(var(--muted));
-  padding: 1px 4px;
-  font-size: 12px;
-}
-
-.agent-conversation-markdown pre {
-  max-width: 100%;
-  overflow: auto;
-  padding: 10px;
-  border-radius: var(--radius);
-  background: hsl(var(--muted) / 0.72);
-}
-
-.agent-conversation-markdown pre code {
-  display: block;
-  padding: 0;
-  background: transparent;
-  white-space: pre;
-}
-
-.agent-conversation-tool {
-  max-width: min(100%, 760px);
-  border: 1px solid hsl(var(--border) / 0.9);
-  border-radius: var(--radius);
-  background: hsl(var(--card) / 0.58);
-  color: hsl(var(--muted-foreground));
-  font-size: 12px;
-}
-
-.agent-conversation-tool summary,
-.agent-conversation-tool:not(details) {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 32px;
-  padding: 0 10px;
-}
-
-.agent-conversation-tool summary {
-  cursor: pointer;
-}
-
-.agent-conversation-tool__icon {
-  display: inline-flex;
-  color: hsl(var(--foreground) / 0.7);
-}
-
-.agent-conversation-tool__name {
-  color: hsl(var(--foreground) / 0.82);
-  font-weight: 500;
-}
-
-.agent-conversation-tool__summary {
-  margin-left: auto;
-  font-size: 11px;
-}
-
-.agent-conversation-tool__chevron {
-  transition: transform 140ms ease;
-}
-
-.agent-conversation-tool[open] .agent-conversation-tool__chevron {
-  transform: rotate(180deg);
-}
-
-.agent-conversation-tool__details {
-  display: grid;
-  gap: 8px;
-  padding: 0 10px 10px;
-}
-
-.agent-conversation-tool__details pre {
-  max-height: 220px;
-  overflow: auto;
-  margin: 0;
-  padding: 8px;
-  border-radius: calc(var(--radius) - 2px);
-  background: hsl(var(--muted));
-  color: hsl(var(--foreground) / 0.72);
-  font-size: 11px;
-  line-height: 1.45;
-  white-space: pre-wrap;
-}
-
-.agent-conversation-tool__details strong {
-  display: block;
-  margin-bottom: 5px;
-  color: hsl(var(--foreground) / 0.86);
-  font-size: 10px;
-}
-
-.agent-conversation-notice,
-.agent-conversation-artifact {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  max-width: min(100%, 760px);
-  padding: 9px 10px;
-  border-radius: var(--radius);
-  font-size: 12px;
-}
-
-.agent-conversation-notice {
-  border: 1px solid hsl(var(--border));
-  background: hsl(var(--muted) / 0.55);
-  color: hsl(var(--foreground) / 0.78);
-}
-
-.agent-conversation-notice--warning {
-  border-color: hsl(45 90% 50% / 0.22);
-  background: hsl(45 90% 50% / 0.07);
-}
-
-.agent-conversation-notice--error {
-  border-color: hsl(var(--destructive) / 0.24);
-  background: hsl(var(--destructive) / 0.08);
-}
-
-.agent-conversation-notice strong {
-  display: block;
-  margin-bottom: 2px;
-  color: hsl(var(--foreground) / 0.88);
-}
-
-.agent-conversation-artifact {
-  border: 1px solid hsl(var(--border));
-  background: hsl(var(--card) / 0.58);
-  color: hsl(var(--muted-foreground));
-}
-
-.agent-conversation-artifact code {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.agent-conversation-artifact a {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  margin-left: auto;
-  color: hsl(var(--muted-foreground));
-  text-decoration: none;
 }
 
 .code-agents-composer-stop-button {
@@ -2602,9 +2454,8 @@
   );
 }
 
-.code-agents-spin,
-.agent-conversation-spin {
-  animation: spin 1s linear infinite;
+.code-agents-spin {
+  animation: code-agents-spin 1s linear infinite;
 }
 
 @media (max-width: 980px) {

--- a/packages/code-agents-ui/src/types.ts
+++ b/packages/code-agents-ui/src/types.ts
@@ -1,3 +1,4 @@
+import type { AgentPromptAttachment } from "@agent-native/core/client";
 import type { CodeAgentPermissionMode } from "./code-agents.js";
 
 export type CodeAgentReasoningEffort =
@@ -22,6 +23,7 @@ export interface CodeAgentModelOption {
   model: string;
   label: string;
   description?: string;
+  configured?: boolean;
 }
 
 export interface CodeAgentModelListResult {
@@ -31,12 +33,7 @@ export interface CodeAgentModelListResult {
   error?: string;
 }
 
-export interface CodeAgentPromptAttachment {
-  name: string;
-  type?: string;
-  size?: number;
-  text?: string;
-}
+export type CodeAgentPromptAttachment = AgentPromptAttachment;
 
 export type CodeAgentFollowUpMode = "immediate" | "queued";
 
@@ -240,6 +237,7 @@ export interface CodeAgentFollowUpResult {
 export interface CodeAgentUpdateRunRequest {
   goalId?: string;
   runId: string;
+  title?: string;
   permissionMode?: CodeAgentPermissionMode;
   engine?: string;
   model?: string;

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -498,6 +498,29 @@ describe("createBuilderEngine", () => {
     expect(stop?.error?.toLowerCase()).toContain("too many requests");
   });
 
+  it("maps daily gateway caps to a non-retryable error message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonErrorResponse(429, {
+          code: "rate_limit_exceeded",
+          message:
+            "Daily gateway request cap reached (cap: 5000). Please try again tomorrow.",
+        }),
+      ),
+    );
+
+    const engine = createBuilderEngine();
+    const events = await collectEvents(engine.stream(BASE_OPTS));
+
+    const stop = events.find((e) => e.type === "stop");
+    expect(stop?.reason).toBe("error");
+    expect(stop?.errorCode).toBe("rate_limit_exceeded");
+    expect(stop?.error).toBe(
+      "Daily gateway request cap reached (cap: 5000). Please try again tomorrow.",
+    );
+  });
+
   it("aborts hung gateway requests before the host function timeout", async () => {
     vi.stubEnv("AGENT_NATIVE_BUILDER_GATEWAY_TIMEOUT_MS", "1");
     const fetchSpy = vi.fn(

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -349,9 +349,20 @@ async function* emitHttpError(response: Response): AsyncIterable<EngineEvent> {
     };
     return;
   }
+  if (code === "rate_limit_exceeded") {
+    yield {
+      type: "stop",
+      reason: "error",
+      error: message,
+      errorCode: code,
+    };
+    return;
+  }
   if (status === 429 || code === "too_many_concurrent_requests") {
     // Include "too many requests" in the message so production-agent's
-    // isRetryableError picks it up and retries the turn.
+    // isRetryableError picks up transient concurrency throttles and retries
+    // the turn. Daily gateway caps use `rate_limit_exceeded` above and must
+    // not loop.
     yield {
       type: "stop",
       reason: "error",

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -678,6 +678,11 @@ function isRetryableError(err: unknown): boolean {
   const code =
     err instanceof EngineError ? (err.errorCode ?? "").toLowerCase() : "";
   if (code === "builder_gateway_timeout") return false;
+  if (
+    code === "rate_limit_exceeded" ||
+    msg.includes("daily gateway request cap")
+  )
+    return false;
   return (
     code === "builder_gateway_error" ||
     code === "builder_gateway_network_error" ||
@@ -2356,6 +2361,8 @@ export function createProductionAgentHandler(
       runId,
       threadId ?? runId,
       async (send, signal) => {
+        send({ type: "activity", label: "Starting agent" });
+
         // Notify listeners that a run has started (used by agent teams)
         if (options.onRunStart) {
           await options.onRunStart(send, threadId ?? runId);
@@ -2645,6 +2652,8 @@ export function createProductionAgentHandler(
           maxIterations: loopSettings.maxIterations,
           finalResponseGuard: options.finalResponseGuard,
         };
+
+        send({ type: "activity", label: "Contacting model" });
 
         let loopUsage: AgentLoopUsage;
         let instrumented = false;

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildAssistantMessage,
+  buildRepositoryFromCodeAgentTranscript,
   buildUserMessage,
   mergeThreadDataForClientSave,
   normalizeThreadRepository,
@@ -604,6 +605,88 @@ describe("normalizeThreadRepository", () => {
         message: expect.objectContaining({ id: "assistant-1" }),
       }),
     ]);
+  });
+});
+
+describe("buildRepositoryFromCodeAgentTranscript", () => {
+  it("builds assistant-ui repository entries from Code transcript turns", () => {
+    const repo = buildRepositoryFromCodeAgentTranscript([
+      {
+        id: "evt-user",
+        runId: "run-code",
+        kind: "user",
+        message: "Fix the bug",
+        createdAt: "2026-05-17T12:00:00.000Z",
+        metadata: {
+          attachments: [
+            {
+              name: "notes.txt",
+              type: "text/plain",
+              text: "stack trace",
+            },
+          ],
+        },
+      },
+      {
+        id: "evt-assistant",
+        runId: "run-code",
+        kind: "system",
+        message: "I found the issue.",
+        createdAt: "2026-05-17T12:00:01.000Z",
+        metadata: { role: "assistant" },
+      },
+      {
+        id: "evt-tool-start",
+        runId: "run-code",
+        kind: "status",
+        message: "Running tests.",
+        createdAt: "2026-05-17T12:00:02.000Z",
+        metadata: { type: "tool_start", tool: "test", input: { file: "x" } },
+      },
+      {
+        id: "evt-tool-done",
+        runId: "run-code",
+        kind: "status",
+        message: "Finished tests.",
+        createdAt: "2026-05-17T12:00:03.000Z",
+        metadata: { type: "tool_done", tool: "test", result: "ok" },
+      },
+    ]);
+
+    expect(repo.messages).toHaveLength(2);
+    expect(repo.messages[0]?.message.role).toBe("user");
+    expect(repo.messages[0]?.message.attachments?.[0]?.name).toBe("notes.txt");
+    expect(repo.messages[1]?.message.role).toBe("assistant");
+    expect(repo.messages[1]?.message.content).toEqual([
+      { type: "text", text: "I found the issue." },
+      {
+        type: "tool-call",
+        toolCallId: "code-tool-evt-tool-start",
+        toolName: "test",
+        argsText: '{\n  "file": "x"\n}',
+        args: { file: "x" },
+        result: "ok",
+      },
+    ]);
+    expect(repo.headId).toBe(repo.messages[1]?.message.id);
+  });
+
+  it("can hide credential status messages from imported Code history", () => {
+    const repo = buildRepositoryFromCodeAgentTranscript(
+      [
+        {
+          id: "evt-status",
+          runId: "run-code",
+          kind: "status",
+          message: "Missing credentials for a provider.",
+          createdAt: "2026-05-17T12:00:00.000Z",
+          metadata: { type: "error" },
+        },
+      ],
+      { hideCredentialMessages: true },
+    );
+
+    expect(repo.messages).toEqual([]);
   });
 });
 

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -1,4 +1,11 @@
 import type { AgentChatAttachment, RunEvent } from "./types.js";
+import {
+  normalizeCodeAgentTranscript,
+  type CodeAgentTranscriptEvent as CoreCodeAgentTranscriptEvent,
+  type NormalizedCodeAgentStatusEvent,
+  type NormalizedCodeAgentToolEvent,
+  type NormalizedCodeAgentTranscriptItem,
+} from "../code-agents/transcript-normalizer.js";
 
 interface ContentPart {
   type: string;
@@ -382,6 +389,136 @@ export function normalizeThreadRepository(repo: any): any {
   return normalized;
 }
 
+export interface CodeAgentThreadTranscriptEvent {
+  id: string;
+  runId: string;
+  kind?: CoreCodeAgentTranscriptEvent["kind"];
+  type?: CoreCodeAgentTranscriptEvent["kind"] | "note";
+  message?: string;
+  text?: string;
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+  artifactPath?: string;
+  artifactUrl?: string;
+}
+
+export interface BuildRepositoryFromCodeAgentTranscriptOptions {
+  hideCredentialMessages?: boolean;
+}
+
+export function buildRepositoryFromCodeAgentTranscript(
+  events: readonly CodeAgentThreadTranscriptEvent[],
+  options: BuildRepositoryFromCodeAgentTranscriptOptions = {},
+): any {
+  const normalized = normalizeCodeAgentTranscript(
+    events.map(toCoreCodeAgentTranscriptEvent),
+  );
+  const repo: {
+    headId: string | null;
+    messages: Array<{ message: any; parentId: string | null }>;
+  } = {
+    headId: null,
+    messages: [],
+  };
+
+  let headId: string | null = null;
+  let assistantTurn: {
+    turnIndex: number;
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    runId?: string;
+    content: ContentPart[];
+    eventIds: string[];
+  } | null = null;
+
+  const flushAssistant = () => {
+    if (!assistantTurn || assistantTurn.content.length === 0) {
+      assistantTurn = null;
+      return;
+    }
+    const message = {
+      id: assistantTurn.id,
+      createdAt: new Date(assistantTurn.createdAt),
+      role: "assistant" as const,
+      content: assistantTurn.content,
+      status: { type: "complete" as const, reason: "stop" as const },
+      metadata: {
+        ...(assistantTurn.runId ? { runId: assistantTurn.runId } : {}),
+        custom: {
+          codeAgentTranscriptEventIds: assistantTurn.eventIds,
+        },
+      },
+    };
+    repo.messages.push({ message, parentId: headId });
+    headId = message.id;
+    repo.headId = headId;
+    assistantTurn = null;
+  };
+
+  for (const item of normalized.items) {
+    if (item.type === "user") {
+      flushAssistant();
+      const runId = item.events[0]?.runId;
+      const userMessage = buildUserMessage({
+        text: item.text,
+        attachments: codeAgentAttachmentsFromEvents(item.events),
+        runId: runId ? `${runId}-${item.id}` : item.id,
+        createdAt: new Date(item.createdAt),
+      });
+      userMessage.id = `code-user-${item.id}`;
+      const existingCustom =
+        userMessage.metadata.custom &&
+        typeof userMessage.metadata.custom === "object"
+          ? (userMessage.metadata.custom as Record<string, unknown>)
+          : {};
+      userMessage.metadata = {
+        ...userMessage.metadata,
+        custom: {
+          ...existingCustom,
+          submittedRunId: runId,
+          codeAgentTranscriptEventIds: item.eventIds,
+        },
+      };
+      repo.messages.push({ message: userMessage, parentId: headId });
+      headId = userMessage.id;
+      repo.headId = headId;
+      continue;
+    }
+
+    const content = contentPartForCodeAgentTranscriptItem(item, options);
+    if (!content) continue;
+
+    if (!assistantTurn || assistantTurn.turnIndex !== item.turnIndex) {
+      flushAssistant();
+      assistantTurn = {
+        turnIndex: item.turnIndex,
+        id: `code-assistant-${item.turnIndex}-${item.id}`,
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+        runId: item.events[0]?.runId,
+        content: [],
+        eventIds: [],
+      };
+    }
+    assistantTurn.updatedAt = item.updatedAt;
+    assistantTurn.eventIds.push(...item.eventIds);
+    if (content.type === "text") {
+      const last = assistantTurn.content.at(-1);
+      if (last?.type === "text") {
+        last.text = `${last.text}${last.text ? "\n\n" : ""}${content.text}`;
+      } else {
+        assistantTurn.content.push(content);
+      }
+    } else {
+      assistantTurn.content.push(content);
+    }
+  }
+
+  flushAssistant();
+  return normalizeThreadRepository(repo);
+}
+
 function rewriteEntryParentId(
   entry: any,
   idRewrites: Map<string, string>,
@@ -603,6 +740,141 @@ export function buildUserMessage(opts: {
       },
     },
   };
+}
+
+function toCoreCodeAgentTranscriptEvent(
+  event: CodeAgentThreadTranscriptEvent,
+): CoreCodeAgentTranscriptEvent {
+  return {
+    schemaVersion: 1,
+    id: event.id,
+    runId: event.runId,
+    kind: (event.kind ??
+      event.type ??
+      "status") as CoreCodeAgentTranscriptEvent["kind"],
+    message: event.message ?? event.text ?? "",
+    createdAt: event.createdAt,
+    metadata: {
+      ...(event.metadata ?? {}),
+      ...(event.artifactPath ? { artifactPath: event.artifactPath } : {}),
+      ...(event.artifactUrl ? { artifactUrl: event.artifactUrl } : {}),
+    },
+  };
+}
+
+function contentPartForCodeAgentTranscriptItem(
+  item: NormalizedCodeAgentTranscriptItem,
+  options: BuildRepositoryFromCodeAgentTranscriptOptions,
+): ContentPart | null {
+  if (item.type === "assistant") {
+    return item.text.trim() ? { type: "text", text: item.text } : null;
+  }
+  if (item.type === "tool") {
+    return toolContentPartForCodeAgentTranscriptItem(item);
+  }
+  if (item.type === "status") {
+    const text = statusTextForCodeAgentTranscriptItem(item, options);
+    return text ? { type: "text", text } : null;
+  }
+  return null;
+}
+
+function toolContentPartForCodeAgentTranscriptItem(
+  item: NormalizedCodeAgentToolEvent,
+): ContentPart {
+  return {
+    type: "tool-call",
+    toolCallId: `code-tool-${item.id}`,
+    toolName: item.tool ?? item.label ?? "code-agent",
+    argsText: previewCodeAgentTranscriptValue(item.input) ?? "",
+    args: recordArgsForCodeAgentTool(item.input),
+    ...(item.result !== undefined
+      ? { result: previewCodeAgentTranscriptValue(item.result) ?? "" }
+      : {}),
+  };
+}
+
+function statusTextForCodeAgentTranscriptItem(
+  item: NormalizedCodeAgentStatusEvent,
+  options: BuildRepositoryFromCodeAgentTranscriptOptions,
+): string | null {
+  if (options.hideCredentialMessages && isCredentialCodeAgentText(item.text)) {
+    return null;
+  }
+  if (item.statusKind === "artifact") {
+    const event = item.events[0];
+    const path =
+      stringRecordValue(event?.metadata, "artifactPath") ??
+      stringRecordValue(event?.metadata, "path");
+    const url = stringRecordValue(event?.metadata, "artifactUrl");
+    const target = url ?? path;
+    return target
+      ? `Artifact: ${item.text}\n${target}`
+      : `Artifact: ${item.text}`;
+  }
+  if (item.level === "info" && item.statusKind !== "note") return null;
+  return item.text;
+}
+
+function codeAgentAttachmentsFromEvents(
+  events: readonly CoreCodeAgentTranscriptEvent[],
+): AgentChatAttachment[] {
+  for (const event of events) {
+    const raw = event.metadata?.attachments;
+    if (!Array.isArray(raw) || raw.length === 0) continue;
+    const attachments: AgentChatAttachment[] = [];
+    for (const item of raw) {
+      if (!item || typeof item !== "object") continue;
+      const record = item as Record<string, unknown>;
+      const name = stringRecordValue(record, "name");
+      if (!name) continue;
+      const contentType = stringRecordValue(record, "type");
+      const text = stringRecordValue(record, "text");
+      const dataUrl = stringRecordValue(record, "dataUrl");
+      attachments.push({
+        type: dataUrl ? "image" : "file",
+        name,
+        ...(contentType ? { contentType } : {}),
+        ...(text ? { text } : {}),
+        ...(dataUrl ? { data: dataUrl } : {}),
+      });
+    }
+    if (attachments.length > 0) return attachments;
+  }
+  return [];
+}
+
+function recordArgsForCodeAgentTool(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const result: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    result[key] =
+      typeof entry === "string"
+        ? entry
+        : (previewCodeAgentTranscriptValue(entry) ?? "");
+  }
+  return result;
+}
+
+function previewCodeAgentTranscriptValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const text =
+    typeof value === "string" ? value : (JSON.stringify(value, null, 2) ?? "");
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > 4000 ? `${trimmed.slice(0, 4000)}\n...` : trimmed;
+}
+
+function stringRecordValue(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isCredentialCodeAgentText(value: string): boolean {
+  return /No LLM provider key was found|Missing credentials/i.test(value);
 }
 
 export function upsertUserMessage(repo: any, userMsg: UserMessage): any {

--- a/packages/core/src/cli/code-agent-executor.ts
+++ b/packages/core/src/cli/code-agent-executor.ts
@@ -38,6 +38,10 @@ import {
   type ReasoningEffort,
 } from "../shared/reasoning-effort.js";
 import {
+  formatPromptWithAttachments,
+  type AgentPromptAttachment,
+} from "../code-agents/prompt-attachments.js";
+import {
   appendCodeAgentTranscriptEvent,
   dequeueCodeAgentFollowUp,
   getCodeAgentRunRecord,
@@ -54,6 +58,7 @@ export interface ExecuteCodeAgentRunOptions {
   engine?: AgentEngine;
   model?: string;
   reasoningEffort?: ReasoningEffort;
+  attachments?: AgentPromptAttachment[];
   stdout?: NodeJS.WritableStream;
   signal?: AbortSignal;
 }
@@ -78,6 +83,10 @@ export async function executeCodeAgentRun(
   if (!existing) return null;
 
   const prompt = options.prompt ?? latestUserPrompt(existing.id);
+  const executionPrompt = formatPromptWithAttachments(
+    prompt,
+    options.attachments ?? latestUserPromptAttachments(existing.id, prompt),
+  );
   if (!prompt) {
     appendCodeAgentTranscriptEvent({
       runId: existing.id,
@@ -170,7 +179,7 @@ export async function executeCodeAgentRun(
   }
   actions[TOOL_SEARCH_ACTION_NAME] = createToolSearchEntry(() => actions);
   const tools = actionsToEngineTools(actions);
-  const messages = buildCodeAgentMessages(existing, prompt);
+  const messages = buildCodeAgentMessages(existing, executionPrompt);
   const controller = new AbortController();
   const abortFromParent = () => controller.abort();
   if (options.signal) {
@@ -309,6 +318,9 @@ export async function executeCodeAgentRun(
         ...options,
         runId: existing.id,
         prompt: pendingFollowUp.prompt,
+        attachments:
+          pendingFollowUp.attachments ??
+          userPromptAttachmentsForEvent(existing.id, pendingFollowUp.eventId),
         appendUserEvent: false,
       });
     }
@@ -477,6 +489,54 @@ function latestUserPrompt(runId: string): string {
     if (event.kind === "user" && event.message.trim()) return event.message;
   }
   return "";
+}
+
+function latestUserPromptAttachments(
+  runId: string,
+  prompt: string,
+): AgentPromptAttachment[] {
+  const events = listCodeAgentTranscriptEvents(runId);
+  const normalizedPrompt = prompt.trim();
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (event.kind !== "user" || !event.message.trim()) continue;
+    if (
+      !normalizedPrompt ||
+      event.message.trim() === normalizedPrompt ||
+      i === events.length - 1
+    ) {
+      return promptAttachmentsFromMetadata(event.metadata?.attachments);
+    }
+  }
+  return [];
+}
+
+function userPromptAttachmentsForEvent(
+  runId: string,
+  eventId: string | undefined,
+): AgentPromptAttachment[] {
+  if (!eventId) return [];
+  const event = listCodeAgentTranscriptEvents(runId).find(
+    (item) => item.id === eventId && item.kind === "user",
+  );
+  return promptAttachmentsFromMetadata(event?.metadata?.attachments);
+}
+
+function promptAttachmentsFromMetadata(
+  value: unknown,
+): AgentPromptAttachment[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is Record<string, unknown> =>
+      Boolean(item && typeof item === "object" && !Array.isArray(item)),
+    )
+    .map((item) => ({
+      name: typeof item.name === "string" && item.name ? item.name : "file",
+      ...(typeof item.type === "string" ? { type: item.type } : {}),
+      ...(typeof item.size === "number" ? { size: item.size } : {}),
+      ...(typeof item.text === "string" ? { text: item.text } : {}),
+      ...(typeof item.dataUrl === "string" ? { dataUrl: item.dataUrl } : {}),
+    }));
 }
 
 function metadataString(

--- a/packages/core/src/cli/code-agent-runs.ts
+++ b/packages/core/src/cli/code-agent-runs.ts
@@ -2,6 +2,7 @@ import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import type { AgentPromptAttachment } from "../code-agents/prompt-attachments.js";
 
 export type CodeAgentRunStatus =
   | "queued"
@@ -45,6 +46,7 @@ export interface CodeAgentPendingFollowUp {
   eventId?: string;
   permissionMode?: CodeAgentPermissionMode;
   source?: string;
+  attachments?: AgentPromptAttachment[];
 }
 
 export interface CodeAgentRunRecord {
@@ -116,6 +118,7 @@ export interface QueueCodeAgentFollowUpInput {
   permissionMode?: CodeAgentPermissionMode;
   source?: string;
   createdAt?: string;
+  attachments?: AgentPromptAttachment[];
 }
 
 const STORE_ENV = "AGENT_NATIVE_CODE_AGENTS_HOME";
@@ -286,6 +289,9 @@ export function queueCodeAgentFollowUp(
     eventId: input.eventId,
     permissionMode: input.permissionMode,
     source: input.source,
+    ...(input.attachments && input.attachments.length > 0
+      ? { attachments: input.attachments }
+      : {}),
   };
   const updated = updateCodeAgentRunRecord(input.runId, (record) => ({
     metadata: {

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -85,6 +85,7 @@ import { withBuilderConnectTrackingParams } from "./settings/useBuilderStatus.js
 import { getFrameOrigin, isInFrame, isTrustedFrameMessage } from "./frame.js";
 import { shouldParentFrameOwnAgentPanel } from "./builder-frame.js";
 import {
+  consumeAgentSidebarUrlOpenOverride,
   dispatchAgentSidebarStateChange,
   getInitialAgentSidebarOpen,
   SIDEBAR_OPEN_KEY,
@@ -491,6 +492,7 @@ function AgentPanelInner({
   browserTabId,
   chatNotice,
   codeAccess,
+  ...assistantChatProps
 }: AgentPanelProps) {
   const mounted = useClientOnly();
   const keyPrefix = storageKey ? `:${storageKey}` : "";
@@ -1345,6 +1347,7 @@ function AgentPanelInner({
       >
         {mounted && (
           <MultiTabAssistantChat
+            {...assistantChatProps}
             apiUrl={apiUrl}
             showHeader={false}
             renderHeader={showHeader ? renderChatHeader : undefined}
@@ -2060,6 +2063,11 @@ export function AgentSidebar({
     },
     [],
   );
+
+  useEffect(() => {
+    const override = consumeAgentSidebarUrlOpenOverride();
+    if (override !== null) setOpenPersisted(override);
+  }, [setOpenPersisted]);
 
   const toggleFullscreen = useCallback(() => {
     setFullscreen((prev) => {

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1556,7 +1556,7 @@ function ToolCallDisplay({
   const isExpanded = isAgentCall ? hasStreamText && expanded : expanded;
 
   return (
-    <div className="my-1 overflow-hidden">
+    <div className="my-2 overflow-hidden">
       <button
         onClick={() => canExpand && setExpanded(!isExpanded)}
         aria-expanded={canExpand ? isExpanded : undefined}

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -21,7 +21,9 @@ import {
 } from "@assistant-ui/react";
 import type {
   AttachmentAdapter,
+  ChatModelAdapter,
   CompleteAttachment,
+  ExportedMessageRepository,
   PendingAttachment,
   ToolCallMessagePartProps,
   Attachment,
@@ -3153,6 +3155,18 @@ export interface AssistantChatHandle {
   exportThreadSnapshot(): ChatThreadSnapshot | null;
 }
 
+export interface AssistantChatAdapterContext {
+  apiUrl: string;
+  tabId?: string;
+  threadId?: string;
+  modelRef: { current: string | undefined };
+  engineRef: { current: string | undefined };
+  effortRef: { current: ReasoningEffort | undefined };
+  execModeRef: { current: "build" | "plan" | undefined };
+  browserTabId?: string;
+  scopeRef: { current: ChatThreadScope | null | undefined };
+}
+
 export interface AssistantChatProps {
   /** API endpoint URL. Default: "/_agent-native/agent-chat" */
   apiUrl?: string;
@@ -3233,6 +3247,36 @@ export interface AssistantChatProps {
   onEffortChange?: (effort: ReasoningEffort) => void;
   /** Callback when user clicks "Fork Chat" in the message actions menu */
   onForkChat?: () => void | boolean | Promise<void | boolean>;
+  /** Override Builder/provider connect routing for embedded hosts. */
+  onConnectProvider?: () => void;
+  /**
+   * Controls the shared composer + menu. Sidebar keeps the full menu by default;
+   * hosts without the sidebar provider stack can use upload-only.
+   */
+  plusMenuMode?: "full" | "upload-only" | "hidden";
+  /**
+   * Enable framework provider/env status checks. Embedded hosts that provide
+   * model/provider state through another transport can disable these probes.
+   */
+  providerStatusChecksEnabled?: boolean;
+  /**
+   * Advanced host override for non-HTTP transports. Defaults to the production
+   * sidebar SSE adapter when omitted.
+   */
+  createAdapter?: (context: AssistantChatAdapterContext) => ChatModelAdapter;
+  /**
+   * Explicitly recreate an injected adapter when the host transport identity
+   * changes. Omit for the production sidebar so parent rerenders do not reset
+   * active chats.
+   */
+  adapterReloadKey?: unknown;
+  /**
+   * Advanced host override for thread replay. Defaults to SQL thread fetch when
+   * `threadId` is set, or sessionStorage for legacy tab chats.
+   */
+  loadHistoryRepository?: () => Promise<ExportedMessageRepository | null>;
+  /** Re-run `loadHistoryRepository` when the host's external transcript changes. */
+  historyReloadKey?: string | number | null;
 }
 
 export const CHAT_STORAGE_PREFIX = "agent-chat:";
@@ -3322,6 +3366,11 @@ const AssistantChatInner = forwardRef<
     onModelChange,
     onEffortChange,
     onForkChat,
+    onConnectProvider,
+    plusMenuMode = "full",
+    providerStatusChecksEnabled = true,
+    loadHistoryRepository,
+    historyReloadKey,
   },
   ref,
 ) {
@@ -3499,7 +3548,9 @@ const AssistantChatInner = forwardRef<
 
   // ─── Chat persistence ──────────────────────────────────────────────
   const hasRestoredRef = useRef(false);
-  const [isRestoring, setIsRestoring] = useState(!!threadId && !isNewThread);
+  const [isRestoring, setIsRestoring] = useState(
+    !!(threadId || loadHistoryRepository) && !isNewThread,
+  );
   const onSaveThreadRef = useRef(onSaveThread);
   onSaveThreadRef.current = onSaveThread;
   const onGenerateTitleRef = useRef(onGenerateTitle);
@@ -3538,6 +3589,15 @@ const AssistantChatInner = forwardRef<
   );
 
   const refreshThreadFromServer = useCallback(async (): Promise<any | null> => {
+    if (loadHistoryRepository) {
+      try {
+        const repo = await loadHistoryRepository();
+        if (!repo) return null;
+        return importThreadData(repo);
+      } catch {
+        return null;
+      }
+    }
     if (!threadId) return null;
     try {
       const refreshRes = await fetch(
@@ -3550,7 +3610,7 @@ const AssistantChatInner = forwardRef<
     } catch {
       return null;
     }
-  }, [apiUrl, importThreadData, threadId]);
+  }, [apiUrl, importThreadData, loadHistoryRepository, threadId]);
 
   const wasRecentlyStoppedRun = useCallback((runId?: string): boolean => {
     const stopped = userStoppedRunRef.current;
@@ -3772,7 +3832,21 @@ const AssistantChatInner = forwardRef<
     if (hasRestoredRef.current) return;
     hasRestoredRef.current = true;
 
-    if (threadId) {
+    if (loadHistoryRepository) {
+      (async () => {
+        try {
+          const repo = await loadHistoryRepository();
+          if (repo) {
+            importThreadData(repo, { markTitleGenerated: true });
+          }
+          titleGeneratedRef.current = true;
+        } catch {
+          // Start fresh
+        } finally {
+          setIsRestoring(false);
+        }
+      })();
+    } else if (threadId) {
       (async () => {
         try {
           const res = await fetch(
@@ -3818,6 +3892,34 @@ const AssistantChatInner = forwardRef<
     threadRuntime,
     importThreadData,
     reconnectActiveRunForThread,
+    loadHistoryRepository,
+  ]);
+
+  useEffect(() => {
+    if (
+      !loadHistoryRepository ||
+      !hasRestoredRef.current ||
+      isRestoring ||
+      isRunning
+    ) {
+      return;
+    }
+    let cancelled = false;
+    void loadHistoryRepository()
+      .then((repo) => {
+        if (cancelled || !repo) return;
+        importThreadData(repo, { markTitleGenerated: true });
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    historyReloadKey,
+    importThreadData,
+    isRestoring,
+    isRunning,
+    loadHistoryRepository,
   ]);
 
   // If assistant-ui stops the local runtime while the background server run is
@@ -3990,6 +4092,10 @@ const AssistantChatInner = forwardRef<
   // Check on mount and whenever SettingsPanel dispatches
   // `agent-engine:configured-changed` so the gate flips live without reload.
   useEffect(() => {
+    if (!providerStatusChecksEnabled) {
+      setMissingApiKey(false);
+      return;
+    }
     let cancelled = false;
     const check = async () => {
       const [envKeys, builderStatus, engineStatus] = await Promise.all([
@@ -4026,7 +4132,7 @@ const AssistantChatInner = forwardRef<
       cancelled = true;
       window.removeEventListener("agent-engine:configured-changed", check);
     };
-  }, []);
+  }, [providerStatusChecksEnabled]);
 
   // Listen for auth error events from the adapter
   const checkAuthSession = useCallback(async () => {
@@ -4853,6 +4959,9 @@ const AssistantChatInner = forwardRef<
                 availableModels={availableModels}
                 onModelChange={onModelChange}
                 onEffortChange={onEffortChange}
+                onConnectProvider={onConnectProvider}
+                plusMenuMode={plusMenuMode}
+                providerConnectStatusEnabled={providerStatusChecksEnabled}
                 draftScope={threadId || tabId}
                 interceptBuildRequestsForBuilder
                 extraActionButton={
@@ -4943,10 +5052,12 @@ export const AssistantChat = forwardRef<
   execModeRef.current = props.execMode;
   const scopeRef = useRef<ChatThreadScope | null | undefined>(contextScope);
   scopeRef.current = contextScope;
+  const createAdapterRef = useRef(props.createAdapter);
+  createAdapterRef.current = props.createAdapter;
 
   const adapter = useMemo(
-    () =>
-      createAgentChatAdapter({
+    () => {
+      const context: AssistantChatAdapterContext = {
         apiUrl,
         tabId,
         threadId,
@@ -4956,8 +5067,16 @@ export const AssistantChat = forwardRef<
         execModeRef,
         browserTabId,
         scopeRef,
-      }),
-    [apiUrl, tabId, threadId, browserTabId],
+      };
+      const createAdapter = createAdapterRef.current;
+      return createAdapter
+        ? createAdapter(context)
+        : createAgentChatAdapter(context);
+    },
+    // Adapter factories must be memoized and use refs for changing values.
+    // `adapterReloadKey` is an explicit opt-in for embedded hosts whose
+    // transport identity can change without changing tab/thread ids.
+    [apiUrl, tabId, threadId, browserTabId, props.adapterReloadKey],
   );
   const attachmentAdapter = useMemo(
     () =>
@@ -4974,22 +5093,24 @@ export const AssistantChat = forwardRef<
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
-      <ThreadPrimitive.Root className="flex flex-1 flex-col h-full min-h-0 overflow-x-hidden">
-        <AssistantUiStaleIndexErrorBoundary
-          resetKey={`${tabId ?? ""}:${threadId ?? ""}`}
-          componentName="AssistantChat"
-        >
-          <AssistantChatInner
-            ref={ref}
-            {...props}
-            browserTabId={browserTabId}
-            contextScope={contextScope}
-            apiUrl={apiUrl}
-            tabId={tabId}
-            threadId={threadId}
-          />
-        </AssistantUiStaleIndexErrorBoundary>
-      </ThreadPrimitive.Root>
+      <TooltipProvider delayDuration={200}>
+        <ThreadPrimitive.Root className="flex flex-1 flex-col h-full min-h-0 overflow-x-hidden">
+          <AssistantUiStaleIndexErrorBoundary
+            resetKey={`${tabId ?? ""}:${threadId ?? ""}`}
+            componentName="AssistantChat"
+          >
+            <AssistantChatInner
+              ref={ref}
+              {...props}
+              browserTabId={browserTabId}
+              contextScope={contextScope}
+              apiUrl={apiUrl}
+              tabId={tabId}
+              threadId={threadId}
+            />
+          </AssistantUiStaleIndexErrorBoundary>
+        </ThreadPrimitive.Root>
+      </TooltipProvider>
     </AssistantRuntimeProvider>
   );
 });

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -426,7 +426,7 @@ const markdownStyles = `
 .agent-tool-code .agent-markdown-shiki pre span { background: transparent; }
 .agent-tool-code pre { margin: 0; min-width: max-content; padding: 0.75rem; background: transparent; color: inherit; }
 .agent-tool-code mark { border-radius: 0.1875rem; background: rgba(245, 158, 11, 0.25); color: inherit; }
-.agent-markdown hr { border: none; border-top: 1px solid hsl(var(--border, 0 0% 20%)); margin: 0.75em 0; }
+.agent-markdown hr { border: none; border-top: 1px solid hsl(var(--border, 0 0% 20%)); margin: 0.75em 0 1em; }
 .agent-markdown a { text-decoration: underline; text-underline-offset: 2px; }
 .agent-markdown a.agent-markdown-cta { text-decoration: none; }
 .agent-markdown blockquote { border-left: 2px solid hsl(var(--border, 0 0% 20%)); padding-left: 0.75em; margin: 0.5em 0; opacity: 0.8; }
@@ -1556,7 +1556,7 @@ function ToolCallDisplay({
   const isExpanded = isAgentCall ? hasStreamText && expanded : expanded;
 
   return (
-    <div className="my-2 overflow-hidden">
+    <div className="my-1 overflow-hidden">
       <button
         onClick={() => canExpand && setExpanded(!isExpanded)}
         aria-expanded={canExpand ? isExpanded : undefined}

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -3210,6 +3210,12 @@ export interface AssistantChatProps {
   onGenerateTitle?: (threadId: string, message: string) => void;
   /** Optional content rendered just above the composer input */
   composerSlot?: React.ReactNode;
+  /** Class applied to the shared composer area for host-specific sizing/skin. */
+  composerAreaClassName?: string;
+  /** Optional content rendered inside the composer toolbar after the attach button. */
+  composerToolbarSlot?: React.ReactNode;
+  /** Optional action rendered beside the voice/send controls. */
+  composerExtraActionButton?: React.ReactNode;
   /** Disable the composer for capability-gated surfaces while still showing history. */
   composerDisabled?: boolean;
   /** Placeholder to show while the composer is disabled by the host surface. */
@@ -3350,6 +3356,9 @@ const AssistantChatInner = forwardRef<
     onSaveThread,
     onGenerateTitle,
     composerSlot,
+    composerAreaClassName,
+    composerToolbarSlot,
+    composerExtraActionButton,
     composerDisabled = false,
     composerDisabledPlaceholder,
     isNewThread,
@@ -4911,6 +4920,7 @@ const AssistantChatInner = forwardRef<
             {/* Input area */}
             <AgentComposerFrame
               className={cn(
+                composerAreaClassName,
                 missingApiKey && "cursor-pointer",
                 isComposerDisabled && "opacity-70",
               )}
@@ -4960,63 +4970,73 @@ const AssistantChatInner = forwardRef<
                 onModelChange={onModelChange}
                 onEffortChange={onEffortChange}
                 onConnectProvider={onConnectProvider}
+                toolbarSlot={composerToolbarSlot}
                 plusMenuMode={plusMenuMode}
                 providerConnectStatusEnabled={providerStatusChecksEnabled}
                 draftScope={threadId || tabId}
                 interceptBuildRequestsForBuilder
                 extraActionButton={
-                  showRunningInUI ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            // Nuclear stop: flip forceStopped so isRunning is false
-                            // immediately. This unblocks submission even if the
-                            // runtime or reconnect state is stuck.
-                            setForceStopped(true);
-                            const activeRun = getActiveRun();
-                            const runIdToAbort =
-                              reconnectRunIdRef.current ?? activeRun?.runId;
-                            userStoppedRunRef.current = {
-                              at: Date.now(),
-                              ...(runIdToAbort ? { runId: runIdToAbort } : {}),
-                            };
-                            setRunErrorInfo(null);
-                            setDismissedRunErrorKey(null);
-                            if (runIdToAbort) {
-                              fetch(
-                                `${apiUrl}/runs/${encodeURIComponent(runIdToAbort)}/abort`,
-                                { method: "POST" },
-                              ).catch(() => {});
-                            }
+                  composerExtraActionButton || showRunningInUI ? (
+                    <>
+                      {composerExtraActionButton}
+                      {showRunningInUI && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                // Nuclear stop: flip forceStopped so isRunning is false
+                                // immediately. This unblocks submission even if the
+                                // runtime or reconnect state is stuck.
+                                setForceStopped(true);
+                                const activeRun = getActiveRun();
+                                const runIdToAbort =
+                                  reconnectRunIdRef.current ?? activeRun?.runId;
+                                userStoppedRunRef.current = {
+                                  at: Date.now(),
+                                  ...(runIdToAbort
+                                    ? { runId: runIdToAbort }
+                                    : {}),
+                                };
+                                setRunErrorInfo(null);
+                                setDismissedRunErrorKey(null);
+                                if (runIdToAbort) {
+                                  fetch(
+                                    `${apiUrl}/runs/${encodeURIComponent(runIdToAbort)}/abort`,
+                                    { method: "POST" },
+                                  ).catch(() => {});
+                                }
 
-                            if (isReconnecting) {
-                              reconnectAbortRef.current?.abort();
-                              reconnectAbortRef.current = null;
-                              reconnectRunIdRef.current = null;
-                              setIsReconnecting(false);
-                              setReconnectFrozen(reconnectContent.length > 0);
-                            }
+                                if (isReconnecting) {
+                                  reconnectAbortRef.current?.abort();
+                                  reconnectAbortRef.current = null;
+                                  reconnectRunIdRef.current = null;
+                                  setIsReconnecting(false);
+                                  setReconnectFrozen(
+                                    reconnectContent.length > 0,
+                                  );
+                                }
 
-                            threadRuntime.cancelRun();
+                                threadRuntime.cancelRun();
 
-                            window.dispatchEvent(
-                              new CustomEvent("agentNative.chatRunning", {
-                                detail: {
-                                  isRunning: false,
-                                  tabId: tabId || threadId,
-                                },
-                              }),
-                            );
-                          }}
-                          className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md bg-muted text-foreground hover:bg-muted/80"
-                        >
-                          <IconPlayerStop className="h-3.5 w-3.5" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent>Stop generating</TooltipContent>
-                    </Tooltip>
+                                window.dispatchEvent(
+                                  new CustomEvent("agentNative.chatRunning", {
+                                    detail: {
+                                      isRunning: false,
+                                      tabId: tabId || threadId,
+                                    },
+                                  }),
+                                );
+                              }}
+                              className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md bg-muted text-foreground hover:bg-muted/80"
+                            >
+                              <IconPlayerStop className="h-3.5 w-3.5" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>Stop generating</TooltipContent>
+                        </Tooltip>
+                      )}
+                    </>
                   ) : undefined
                 }
               />

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -1245,6 +1245,140 @@ describe("createAgentChatAdapter", () => {
     expect(last.content.at(-1).text).toBe("finished after idle recovery");
   });
 
+  it("stops silent run timeouts without retrying the same no-progress request", async () => {
+    vi.useFakeTimers();
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        postCount += 1;
+        return sseResponse([{ type: "auto_continue", reason: "run_timeout" }]);
+      }
+      if (url.includes("/runs/")) {
+        return jsonResponse({ active: false, status: "idle" });
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-no-progress",
+      threadId: "thread-no-progress",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "large extension edit" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const results = await promise;
+
+    expect(postCount).toBe(1);
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent-chat:run-error",
+        detail: expect.objectContaining({
+          errorCode: "connection_error",
+          message: expect.stringContaining(
+            "did not produce any visible progress",
+          ),
+        }),
+      }),
+    );
+    const last = results.at(-1) as any;
+    expect(last.status).toEqual({ type: "incomplete", reason: "error" });
+    expect(last.content.at(-1).text).toContain(
+      "did not produce any visible progress",
+    );
+  });
+
+  it("surfaces a startup timeout when the POST never becomes an SSE stream", async () => {
+    vi.useFakeTimers();
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    const fetchSpy = vi.fn((url: string, init?: RequestInit) => {
+      if (url.includes("/runs/active")) {
+        return Promise.resolve(jsonResponse({ active: false, status: "idle" }));
+      }
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        return new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            reject(new Error("aborted"));
+          });
+        });
+      }
+      return Promise.resolve(jsonResponse({ error: "unexpected" }, 500));
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-startup-timeout",
+      threadId: "thread-startup-timeout",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "please respond" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(45_001);
+    const results = await promise;
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent-chat:run-error",
+        detail: expect.objectContaining({
+          errorCode: "startup_timeout",
+          message: expect.stringContaining("did not start streaming"),
+        }),
+      }),
+    );
+    const last = results.at(-1) as any;
+    expect(last.status).toEqual({ type: "incomplete", reason: "error" });
+    expect(last.content.at(-1).text).toContain("did not start streaming");
+  });
+
   it("uses partial stream-ended text as history without keeping it visible", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("window", { dispatchEvent: vi.fn() });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -58,9 +58,16 @@ const MAX_STARTUP_RECOVERY_ATTEMPTS = 8;
 const MAX_STALE_RUN_CONTINUATIONS = 3;
 const MAX_STALLED_TRANSIENT_CONTINUATIONS = 8;
 const MAX_TOTAL_TRANSIENT_CONTINUATIONS = 32;
+const MAX_EMPTY_TRANSIENT_CONTINUATIONS = 1;
 const RETRY_BASE_DELAY_MS = 500;
 const RETRY_MAX_DELAY_MS = 8_000;
 const MAX_HISTORY_ATTACHMENT_CHARS = 60_000;
+const MAX_HISTORY_MESSAGES = 24;
+const MAX_HISTORY_TOTAL_CHARS = 64_000;
+const MAX_HISTORY_MESSAGE_CHARS = 12_000;
+const MAX_HISTORY_TOOL_ARGS_CHARS = 8_000;
+const MAX_HISTORY_TOOL_RESULT_CHARS = 12_000;
+const STARTUP_RESPONSE_TIMEOUT_MS = 45_000;
 
 function normalizeMentions(text: string): string {
   return text.replace(/@\[([^\]|]+)\|[^\]]+\]/g, "@$1");
@@ -69,6 +76,16 @@ function normalizeMentions(text: string): string {
 function truncateForContinuation(value: string, maxChars: number): string {
   if (value.length <= maxChars) return value;
   return `${value.slice(0, maxChars)}\n\n...[truncated ${value.length - maxChars} chars from prior partial output]`;
+}
+
+function truncateForHistory(
+  value: string,
+  maxChars: number,
+  label: string,
+): string {
+  if (value.length <= maxChars) return value;
+  const omitted = value.length - maxChars;
+  return `${value.slice(0, maxChars)}\n\n[${label} truncated after ${maxChars.toLocaleString()} characters; ${omitted.toLocaleString()} characters omitted from prior chat history. Read the current app/resource state with tools if exact content is needed.]`;
 }
 
 function contentToContinuationHistory(content: ContentPart[]): string {
@@ -93,6 +110,43 @@ function contentToContinuationHistory(content: ContentPart[]): string {
 }
 
 function messageTextFromContent(
+  content: readonly { type: string; text?: string }[],
+): string {
+  return truncateForHistory(
+    content
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => normalizeMentions(p.text))
+      .join("\n"),
+    MAX_HISTORY_MESSAGE_CHARS,
+    "Message",
+  );
+}
+
+function truncateToolArgsForHistory(args: unknown): Record<string, unknown> {
+  if (!args || typeof args !== "object" || Array.isArray(args)) return {};
+  try {
+    const json = JSON.stringify(args);
+    if (json.length <= MAX_HISTORY_TOOL_ARGS_CHARS) {
+      return args as Record<string, unknown>;
+    }
+    return {
+      __agentNativeTruncated: true,
+      note: "Tool input was too large to resend in chat history. Use the current app/resource state as the source of truth if exact content is needed.",
+      preview: truncateForHistory(
+        json,
+        MAX_HISTORY_TOOL_ARGS_CHARS,
+        "Tool input",
+      ),
+    };
+  } catch {
+    return {
+      __agentNativeTruncated: true,
+      note: "Tool input could not be serialized for prior chat history.",
+    };
+  }
+}
+
+function messageTextFromContentRaw(
   content: readonly { type: string; text?: string }[],
 ): string {
   return content
@@ -225,11 +279,15 @@ function messageTextForHistory(message: {
   content: readonly { type: string; text?: string }[];
   attachments?: readonly AssistantUiAttachment[];
 }): string {
-  const text = messageTextFromContent(message.content);
+  const text = messageTextFromContentRaw(message.content);
   const attachments = extractAttachmentsFromMessage(message)
     .map(attachmentHistoryText)
     .filter((part): part is string => !!part && part.trim().length > 0);
-  return [text, ...attachments].filter((part) => part.trim()).join("\n\n");
+  return truncateForHistory(
+    [text, ...attachments].filter((part) => part.trim()).join("\n\n"),
+    MAX_HISTORY_MESSAGE_CHARS,
+    "Message",
+  );
 }
 
 function isToolCallContentPart(
@@ -252,10 +310,12 @@ function toolResultContent(result: unknown): string {
 function contentToStructuredMessages(
   content: readonly ContentPart[],
   nextToolCallId: () => string,
+  options?: { truncateForHistory?: boolean },
 ): AgentChatStructuredMessage[] {
   const messages: AgentChatStructuredMessage[] = [];
   let assistantParts: AgentChatStructuredContentPart[] = [];
   let pendingToolResults: AgentChatStructuredContentPart[] = [];
+  const truncate = options?.truncateForHistory === true;
 
   const flushToolTurn = () => {
     if (pendingToolResults.length === 0) return;
@@ -271,7 +331,16 @@ function contentToStructuredMessages(
     if (part.type === "text") {
       if (pendingToolResults.length > 0) flushToolTurn();
       if (part.text.trim()) {
-        assistantParts.push({ type: "text", text: part.text });
+        assistantParts.push({
+          type: "text",
+          text: truncate
+            ? truncateForHistory(
+                part.text,
+                MAX_HISTORY_MESSAGE_CHARS,
+                "Assistant text",
+              )
+            : part.text,
+        });
       }
       continue;
     }
@@ -282,14 +351,22 @@ function contentToStructuredMessages(
         type: "tool-call",
         toolCallId,
         toolName: part.toolName,
-        args: part.args ?? {},
+        args: truncate
+          ? truncateToolArgsForHistory(part.args ?? {})
+          : (part.args ?? {}),
       });
       if (part.result !== undefined) {
         pendingToolResults.push({
           type: "tool-result",
           toolCallId,
           toolName: part.toolName,
-          content: toolResultContent(part.result),
+          content: truncate
+            ? truncateForHistory(
+                toolResultContent(part.result),
+                MAX_HISTORY_TOOL_RESULT_CHARS,
+                "Tool result",
+              )
+            : toolResultContent(part.result),
         });
       }
     }
@@ -359,10 +436,50 @@ function assistantUiMessagesToStructuredHistory(
         });
       }
     }
-    structured.push(...contentToStructuredMessages(content, nextToolCallId));
+    structured.push(
+      ...contentToStructuredMessages(content, nextToolCallId, {
+        truncateForHistory: true,
+      }),
+    );
   }
 
   return structured;
+}
+
+function estimateHistoryMessageCost(message: {
+  content: readonly { type: string; text?: string }[];
+  attachments?: readonly AssistantUiAttachment[];
+}): number {
+  return Math.max(1, messageTextForHistory(message).length);
+}
+
+function limitPriorMessagesForRequest<
+  T extends {
+    role: string;
+    content: readonly { type: string; text?: string }[];
+    attachments?: readonly AssistantUiAttachment[];
+  },
+>(messages: readonly T[]): T[] {
+  const recent = messages.slice(-MAX_HISTORY_MESSAGES);
+  const kept: T[] = [];
+  let totalChars = 0;
+
+  for (let i = recent.length - 1; i >= 0; i--) {
+    const message = recent[i];
+    if (message.role !== "user" && message.role !== "assistant") continue;
+    const cost = estimateHistoryMessageCost(message);
+    if (kept.length > 0 && totalChars + cost > MAX_HISTORY_TOTAL_CHARS) {
+      break;
+    }
+    kept.push(message);
+    totalChars += cost;
+  }
+
+  kept.reverse();
+  while (kept.length > 0 && kept[0].role !== "user") {
+    kept.shift();
+  }
+  return kept;
 }
 
 function combineContinuationHistory(fragments: string[]): string {
@@ -421,6 +538,50 @@ function delay(ms: number, abortSignal: AbortSignal): Promise<void> {
       { once: true },
     );
   });
+}
+
+class AgentStartupTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(
+      `Agent chat did not start streaming within ${Math.round(timeoutMs / 1000)}s.`,
+    );
+    this.name = "AgentStartupTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+async function fetchWithStartupTimeout(
+  input: RequestInfo | URL,
+  init: RequestInit,
+  timeoutMs: number,
+  abortSignal: AbortSignal,
+): Promise<Response> {
+  if (abortSignal.aborted) {
+    throw new DOMException("The operation was aborted.", "AbortError");
+  }
+
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+  const abort = () => controller.abort();
+  abortSignal.addEventListener("abort", abort, { once: true });
+
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (timedOut) {
+      throw new AgentStartupTimeoutError(timeoutMs);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    abortSignal.removeEventListener("abort", abort);
+  }
 }
 
 function retryDelay(attempt: number, abortSignal: AbortSignal): Promise<void> {
@@ -674,7 +835,9 @@ export function createAgentChatAdapter(options?: {
           ? rawMessageText
           : "Use the attached context.";
 
-      const priorMessages = messages.slice(0, -1); // exclude latest user message
+      const priorMessages = limitPriorMessagesForRequest(
+        messages.slice(0, -1) as any,
+      ); // exclude latest user message and cap resend size
       const history = priorMessages
         .filter((m) => m.role === "user" || m.role === "assistant")
         .map((m) => ({
@@ -736,6 +899,18 @@ export function createAgentChatAdapter(options?: {
         ]
           .filter(Boolean)
           .join("\n");
+      };
+
+      const exhaustedRecoveryMessage = (reason?: string): string => {
+        if (
+          content.length === 0 &&
+          (reason === "run_timeout" ||
+            reason === "no_progress" ||
+            reason === "stream_ended")
+        ) {
+          return "The agent request started but did not produce any visible progress before timing out. I stopped the automatic retries so this chat would not stay stuck on Thinking.";
+        }
+        return "The agent connection kept failing after several automatic recovery attempts.";
       };
 
       const dispatchAuthError = (
@@ -1018,11 +1193,22 @@ export function createAgentChatAdapter(options?: {
           const currentPartialHistory =
             contentToContinuationHistory(visibleContent);
           const madeProgress = hasContinuationProgress(visibleContent);
+          const madeVisibleProgress = visibleContent.length > 0;
 
           if (signal.reason === "loop_limit") {
             stalledTransientContinuationAttempts = 0;
           } else {
             totalTransientContinuationAttempts += 1;
+            if (!madeVisibleProgress && signal.reason === "run_timeout") {
+              return { ok: false, resetVisibleContent: false };
+            }
+            if (
+              !madeVisibleProgress &&
+              totalTransientContinuationAttempts >
+                MAX_EMPTY_TRANSIENT_CONTINUATIONS
+            ) {
+              return { ok: false, resetVisibleContent: false };
+            }
             if (signal.reason === "stale_run") {
               staleRunContinuationAttempts += 1;
               if (staleRunContinuationAttempts > MAX_STALE_RUN_CONTINUATIONS) {
@@ -1101,31 +1287,35 @@ export function createAgentChatAdapter(options?: {
           try {
             runId = null;
             lastSeq = -1;
-            const res = await fetch(apiUrl, {
-              method: "POST",
-              headers,
-              body: JSON.stringify({
-                message: currentMessageText,
-                displayMessage: userMessageText,
-                history: currentHistory,
-                structuredHistory: currentStructuredHistory,
-                ...(threadId ? { threadId } : {}),
-                ...(internalContinuationRequest
-                  ? { internalContinuation: true }
-                  : {}),
-                ...(requestMode ? { mode: requestMode } : {}),
-                ...(modelRef?.current ? { model: modelRef.current } : {}),
-                ...(engineRef?.current ? { engine: engineRef.current } : {}),
-                ...(effortRef?.current ? { effort: effortRef.current } : {}),
-                ...(browserTabId ? { browserTabId } : {}),
-                ...(scopeRef?.current ? { scope: scopeRef.current } : {}),
-                ...(includeAttachments ? { attachments } : {}),
-                ...(includeReferences && runConfig?.custom?.references
-                  ? { references: runConfig.custom.references }
-                  : {}),
-              }),
-              signal: abortSignal,
-            });
+            const res = await fetchWithStartupTimeout(
+              apiUrl,
+              {
+                method: "POST",
+                headers,
+                body: JSON.stringify({
+                  message: currentMessageText,
+                  displayMessage: userMessageText,
+                  history: currentHistory,
+                  structuredHistory: currentStructuredHistory,
+                  ...(threadId ? { threadId } : {}),
+                  ...(internalContinuationRequest
+                    ? { internalContinuation: true }
+                    : {}),
+                  ...(requestMode ? { mode: requestMode } : {}),
+                  ...(modelRef?.current ? { model: modelRef.current } : {}),
+                  ...(engineRef?.current ? { engine: engineRef.current } : {}),
+                  ...(effortRef?.current ? { effort: effortRef.current } : {}),
+                  ...(browserTabId ? { browserTabId } : {}),
+                  ...(scopeRef?.current ? { scope: scopeRef.current } : {}),
+                  ...(includeAttachments ? { attachments } : {}),
+                  ...(includeReferences && runConfig?.custom?.references
+                    ? { references: runConfig.custom.references }
+                    : {}),
+                }),
+              },
+              STARTUP_RESPONSE_TIMEOUT_MS,
+              abortSignal,
+            );
 
             // Check for auth errors returned as 200 with JSON (common with middleware issues)
             const contentType = res.headers.get("content-type") || "";
@@ -1319,8 +1509,7 @@ export function createAgentChatAdapter(options?: {
               }
               const continuation = prepareAutoContinuation(err);
               if (!continuation.ok) {
-                const message =
-                  "The agent connection kept failing after several automatic recovery attempts.";
+                const message = exhaustedRecoveryMessage(err.reason);
                 captureChatClientError(err, "auto-continuation-exhausted", {
                   autoContinueReason: err.reason,
                 });
@@ -1416,6 +1605,42 @@ export function createAgentChatAdapter(options?: {
             const activeReconnected = yield* reconnectActiveRunForThread();
             if (activeReconnected) return;
 
+            if (err instanceof AgentStartupTimeoutError) {
+              const message =
+                "The agent chat endpoint accepted the request but did not start streaming in time. This usually means prompt setup, the LLM gateway, or the provider is stalled.";
+              captureChatClientError(err, "startup-timeout", {
+                timeoutMs: err.timeoutMs,
+              });
+              const runError = {
+                message,
+                details: connectionRecoveryDetails(),
+                errorCode: "startup_timeout",
+                recoverable: true,
+                ...(runId ? { runId } : {}),
+              };
+              if (typeof window !== "undefined") {
+                window.dispatchEvent(
+                  new CustomEvent("agent-chat:run-error", {
+                    detail: { ...runError, tabId },
+                  }),
+                );
+              }
+              content.push({
+                type: "text",
+                text: `Something went wrong: ${message}`,
+              });
+              yield {
+                content: [...content],
+                status: {
+                  type: "incomplete" as const,
+                  reason: "error" as const,
+                },
+                metadata: { custom: { ...(runId ? { runId } : {}), runError } },
+              };
+              clearActiveRun();
+              return;
+            }
+
             // Reconnect failed or not possible — keep going from the partial
             // streamed content instead of surfacing a transient transport error.
             if (content.length > 0) {
@@ -1423,8 +1648,7 @@ export function createAgentChatAdapter(options?: {
                 new AgentAutoContinueSignal({ reason: "stream_ended" }),
               );
               if (!continuation.ok) {
-                const message =
-                  "The agent connection kept failing after several automatic recovery attempts.";
+                const message = exhaustedRecoveryMessage("stream_ended");
                 captureChatClientError(err, "recovery-exhausted");
                 const runError = {
                   message,

--- a/packages/core/src/client/agent-sidebar-state.spec.ts
+++ b/packages/core/src/client/agent-sidebar-state.spec.ts
@@ -8,6 +8,7 @@ vi.mock("./builder-frame.js", () => ({
 }));
 
 const {
+  consumeAgentSidebarUrlOpenOverride,
   dispatchAgentSidebarStateChange,
   getInitialAgentSidebarOpen,
   SIDEBAR_OPEN_KEY,
@@ -34,6 +35,7 @@ describe("getInitialAgentSidebarOpen", () => {
   beforeEach(() => {
     frameState.inBuilderFrame = false;
     window.localStorage.clear();
+    window.history.replaceState(null, "", "/");
     stubMatchMedia(false);
   });
 
@@ -63,11 +65,38 @@ describe("getInitialAgentSidebarOpen", () => {
 
     expect(getInitialAgentSidebarOpen(true)).toBe(false);
   });
+
+  it("starts closed from an external-agent deep-link hint even with a saved open preference", () => {
+    window.localStorage.setItem(SIDEBAR_OPEN_KEY, "true");
+    window.history.replaceState(
+      null,
+      "",
+      "/inbox?threadId=t1&agentSidebar=closed",
+    );
+
+    expect(getInitialAgentSidebarOpen(true)).toBe(false);
+  });
+
+  it("consumes the external-agent deep-link hint and persists the closed state", () => {
+    window.localStorage.setItem(SIDEBAR_OPEN_KEY, "true");
+    window.history.replaceState(
+      null,
+      "",
+      "/inbox?threadId=t1&agentSidebar=closed#message",
+    );
+
+    expect(consumeAgentSidebarUrlOpenOverride()).toBe(false);
+    expect(window.localStorage.getItem(SIDEBAR_OPEN_KEY)).toBe("false");
+    expect(window.location.pathname).toBe("/inbox");
+    expect(window.location.search).toBe("?threadId=t1");
+    expect(window.location.hash).toBe("#message");
+  });
 });
 
 describe("dispatchAgentSidebarStateChange", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    window.history.replaceState(null, "", "/");
     stubMatchMedia(false);
   });
 

--- a/packages/core/src/client/agent-sidebar-state.ts
+++ b/packages/core/src/client/agent-sidebar-state.ts
@@ -1,4 +1,8 @@
 import { isInBuilderFrame } from "./builder-frame.js";
+import {
+  AGENT_SIDEBAR_QUERY_PARAM,
+  AGENT_SIDEBAR_QUERY_VALUE_CLOSED,
+} from "../shared/agent-sidebar-url.js";
 
 export const SIDEBAR_OPEN_KEY = "agent-native-sidebar-open";
 export const SIDEBAR_STATE_CHANGE_EVENT = "agent-panel:state-change";
@@ -26,7 +30,41 @@ export function dispatchAgentSidebarStateChange(
   );
 }
 
+export function getAgentSidebarUrlOpenOverride(): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const url = new URL(window.location.href);
+    const value = url.searchParams.get(AGENT_SIDEBAR_QUERY_PARAM);
+    if (value === AGENT_SIDEBAR_QUERY_VALUE_CLOSED) return false;
+  } catch {}
+  return null;
+}
+
+export function consumeAgentSidebarUrlOpenOverride(): boolean | null {
+  const override = getAgentSidebarUrlOpenOverride();
+  if (override === null || typeof window === "undefined") return override;
+
+  try {
+    localStorage.setItem(SIDEBAR_OPEN_KEY, String(override));
+  } catch {}
+
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.delete(AGENT_SIDEBAR_QUERY_PARAM);
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+  } catch {}
+
+  return override;
+}
+
 export function getInitialAgentSidebarOpen(defaultOpen: boolean): boolean {
+  const urlOverride = getAgentSidebarUrlOpenOverride();
+  if (urlOverride !== null) return urlOverride;
+
   // On mobile viewports the sidebar would cover most of the screen, so
   // always start closed regardless of any persisted desktop preference.
   if (

--- a/packages/core/src/client/code-agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/code-agent-chat-adapter.spec.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  codeAgentTranscriptEventsToContent,
+  createCodeAgentChatAdapter,
+  type CodeAgentChatController,
+  type CodeAgentChatTranscriptEvent,
+} from "./code-agent-chat-adapter.js";
+
+async function drain(iterable: AsyncIterable<unknown>) {
+  const results: unknown[] = [];
+  for await (const result of iterable) results.push(result);
+  return results;
+}
+
+function runOptions(message: any, abortSignal = new AbortController().signal) {
+  return {
+    messages: [message],
+    abortSignal,
+    runConfig: {},
+    context: {},
+    config: {},
+    unstable_getMessage: () => message,
+  } as any;
+}
+
+describe("codeAgentTranscriptEventsToContent", () => {
+  it("maps Code transcript text and tool events into assistant-ui content", () => {
+    const content = codeAgentTranscriptEventsToContent([
+      event("assistant", "system", "Checking it now", {
+        role: "assistant",
+      }),
+      event("tool-start", "status", "Running tests.", {
+        type: "tool_start",
+        tool: "test",
+        input: { file: "app.tsx" },
+      }),
+      event("tool-done", "status", "Finished tests.", {
+        type: "tool_done",
+        tool: "test",
+        result: "ok",
+      }),
+    ]);
+
+    expect(content).toEqual([
+      { type: "text", text: "Checking it now" },
+      {
+        type: "tool-call",
+        toolCallId: "code-tool-tool-start",
+        toolName: "test",
+        argsText: '{\n  "file": "app.tsx"\n}',
+        args: { file: "app.tsx" },
+        result: "ok",
+      },
+    ]);
+  });
+});
+
+describe("createCodeAgentChatAdapter", () => {
+  it("sends the latest user prompt and attachments through the Code controller", async () => {
+    const events: CodeAgentChatTranscriptEvent[] = [];
+    const sendFollowUp = vi.fn(async () => {
+      events.push(event("assistant", "system", "Done", { role: "assistant" }));
+      return { ok: true };
+    });
+    const controller: CodeAgentChatController = {
+      get: vi.fn(async () => ({ status: "completed" })),
+      transcript: vi.fn(async () => events),
+      sendFollowUp,
+      control: vi.fn(async () => ({ ok: true })),
+    };
+    const adapter = createCodeAgentChatAdapter({
+      controller,
+      runIdRef: { current: "run-1" },
+      permissionModeRef: { current: "full-auto" },
+      modelRef: { current: "claude-sonnet-4-6" },
+      engineRef: { current: "builder" },
+      effortRef: { current: "high" },
+      pollIntervalMs: 1,
+      idlePollIntervalMs: 1,
+      terminalIdlePolls: 1,
+    });
+
+    const results = await drain(
+      adapter.run(
+        runOptions({
+          role: "user",
+          content: [{ type: "text", text: "Fix it" }],
+          attachments: [
+            {
+              name: "screen.png",
+              contentType: "image/png",
+              content: [{ type: "image", image: "data:image/png;base64,abc" }],
+            },
+          ],
+        }),
+      ) as AsyncIterable<unknown>,
+    );
+
+    expect(sendFollowUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        prompt: "Fix it",
+        permissionMode: "full-auto",
+        model: "claude-sonnet-4-6",
+        engine: "builder",
+        reasoningEffort: "high",
+        metadata: {
+          attachments: [
+            {
+              name: "screen.png",
+              type: "image/png",
+              dataUrl: "data:image/png;base64,abc",
+            },
+          ],
+        },
+      }),
+    );
+    expect(results.at(-1)).toMatchObject({
+      content: [{ type: "text", text: "Done" }],
+      metadata: { custom: { runId: "run-1" } },
+    });
+  });
+
+  it("does not stop the Code run for lifecycle aborts by default", async () => {
+    const abortController = new AbortController();
+    const control = vi.fn(async () => ({ ok: true }));
+    const controller: CodeAgentChatController = {
+      get: vi.fn(async () => ({ status: "running" })),
+      transcript: vi.fn(async () => []),
+      sendFollowUp: vi.fn(async () => ({ ok: true })),
+      control,
+    };
+    const adapter = createCodeAgentChatAdapter({
+      controller,
+      runIdRef: { current: "run-1" },
+      pollIntervalMs: 5,
+      idlePollIntervalMs: 5,
+    });
+
+    setTimeout(() => abortController.abort(), 0);
+    await drain(
+      adapter.run(
+        runOptions(
+          {
+            role: "user",
+            content: [{ type: "text", text: "Stop soon" }],
+          },
+          abortController.signal,
+        ),
+      ) as AsyncIterable<unknown>,
+    );
+
+    expect(control).not.toHaveBeenCalled();
+  });
+
+  it("can map assistant-ui aborts to Code stop when explicitly requested", async () => {
+    const abortController = new AbortController();
+    const control = vi.fn(async () => ({ ok: true }));
+    const controller: CodeAgentChatController = {
+      get: vi.fn(async () => ({ status: "running" })),
+      transcript: vi.fn(async () => []),
+      sendFollowUp: vi.fn(async () => ({ ok: true })),
+      control,
+    };
+    const adapter = createCodeAgentChatAdapter({
+      controller,
+      runIdRef: { current: "run-1" },
+      pollIntervalMs: 5,
+      idlePollIntervalMs: 5,
+      stopOnAbort: true,
+    });
+
+    setTimeout(() => abortController.abort(), 0);
+    await drain(
+      adapter.run(
+        runOptions(
+          {
+            role: "user",
+            content: [{ type: "text", text: "Stop soon" }],
+          },
+          abortController.signal,
+        ),
+      ) as AsyncIterable<unknown>,
+    );
+
+    expect(control).toHaveBeenCalledWith({ runId: "run-1", command: "stop" });
+  });
+});
+
+function event(
+  id: string,
+  kind: CodeAgentChatTranscriptEvent["kind"],
+  message: string,
+  metadata?: Record<string, unknown>,
+): CodeAgentChatTranscriptEvent {
+  return {
+    id,
+    runId: "run-1",
+    kind,
+    message,
+    createdAt: `2026-05-17T12:00:0${id.length % 10}.000Z`,
+    metadata,
+  };
+}

--- a/packages/core/src/client/code-agent-chat-adapter.ts
+++ b/packages/core/src/client/code-agent-chat-adapter.ts
@@ -1,0 +1,445 @@
+import type {
+  ChatModelAdapter,
+  ChatModelRunOptions,
+  ChatModelRunResult,
+} from "@assistant-ui/react";
+import { unwrapAttachmentEnvelope } from "./composer/pasted-text.js";
+import type { AgentPromptAttachment } from "./composer/prompt-attachments.js";
+import type { ReasoningEffort } from "../shared/reasoning-effort.js";
+import {
+  compareCodeAgentTranscriptEvents,
+  isCodeAgentRunActive,
+  type CodeAgentRunStateLike,
+} from "../code-agents/transcript-order.js";
+import {
+  normalizeCodeAgentTranscript,
+  type CodeAgentTranscriptEvent as CoreCodeAgentTranscriptEvent,
+  type NormalizedCodeAgentStatusEvent,
+  type NormalizedCodeAgentToolEvent,
+  type NormalizedCodeAgentTranscriptItem,
+} from "../code-agents/transcript-normalizer.js";
+import type { ContentPart } from "./sse-event-processor.js";
+
+export type CodeAgentChatFollowUpMode = "immediate" | "queued";
+
+export interface CodeAgentChatTranscriptEvent {
+  id: string;
+  runId: string;
+  kind?: CoreCodeAgentTranscriptEvent["kind"];
+  type?: CoreCodeAgentTranscriptEvent["kind"] | "note";
+  message?: string;
+  text?: string;
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+  artifactPath?: string;
+  artifactUrl?: string;
+}
+
+export interface CodeAgentChatControlResult {
+  ok: boolean;
+  run?: CodeAgentRunStateLike | null;
+  queued?: boolean;
+  message?: string;
+  error?: string;
+}
+
+export interface CodeAgentChatController {
+  get(runId: string): Promise<CodeAgentRunStateLike | null>;
+  transcript(runId: string): Promise<CodeAgentChatTranscriptEvent[]>;
+  sendFollowUp(input: {
+    runId: string;
+    prompt: string;
+    mode?: CodeAgentChatFollowUpMode;
+    permissionMode?: string;
+    engine?: string;
+    model?: string;
+    reasoningEffort?: ReasoningEffort;
+    source?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<CodeAgentChatControlResult>;
+  control(input: {
+    runId: string;
+    command: "stop";
+  }): Promise<CodeAgentChatControlResult>;
+}
+
+export interface CreateCodeAgentChatAdapterOptions {
+  controller: CodeAgentChatController;
+  runIdRef: { current: string | null };
+  permissionModeRef?: { current: string | undefined };
+  modelRef?: { current: string | undefined };
+  engineRef?: { current: string | undefined };
+  effortRef?: { current: ReasoningEffort | undefined };
+  followUpModeRef?: { current: CodeAgentChatFollowUpMode | undefined };
+  attachOnlyRef?: { current: boolean };
+  tabId?: string;
+  pollIntervalMs?: number;
+  idlePollIntervalMs?: number;
+  terminalIdlePolls?: number;
+  /**
+   * Assistant-ui may abort a run for UI lifecycle reasons, such as switching
+   * selected sessions. Code sessions keep running unless the host sends an
+   * explicit stop command.
+   */
+  stopOnAbort?: boolean;
+}
+
+type AssistantUiAttachment = {
+  name?: string;
+  contentType?: string;
+  content?: readonly Record<string, unknown>[];
+};
+
+export function createCodeAgentChatAdapter(
+  options: CreateCodeAgentChatAdapterOptions,
+): ChatModelAdapter {
+  const pollIntervalMs = options.pollIntervalMs ?? 1000;
+  const idlePollIntervalMs = options.idlePollIntervalMs ?? 5000;
+  const terminalIdlePolls = options.terminalIdlePolls ?? 3;
+  const stopOnAbort = options.stopOnAbort === true;
+
+  return {
+    async *run({ messages, abortSignal }: ChatModelRunOptions) {
+      const runId = options.runIdRef.current;
+      if (!runId) {
+        yield errorResult("Select an Agent-Native Code session first.");
+        return;
+      }
+
+      const lastUserMessage = latestUserMessage(messages);
+      const attachments = lastUserMessage
+        ? extractPromptAttachmentsFromAssistantMessage(lastUserMessage)
+        : [];
+      const prompt =
+        latestUserText(messages).trim() ||
+        (attachments.length > 0 ? "Use the attached context." : "");
+      if (!prompt.trim()) {
+        yield errorResult("Enter a follow-up prompt.");
+        return;
+      }
+
+      let stoppedFromAbort = false;
+      const stopForAbort = () => {
+        stoppedFromAbort = true;
+        if (stopOnAbort) {
+          void options.controller.control({ runId, command: "stop" });
+        }
+      };
+      if (abortSignal.aborted) {
+        stopForAbort();
+        return;
+      }
+      abortSignal.addEventListener("abort", stopForAbort, { once: true });
+
+      try {
+        const initialEvents = await options.controller.transcript(runId);
+        const seenEventIds = new Set(initialEvents.map((event) => event.id));
+        const tailedEvents: CodeAgentChatTranscriptEvent[] = [];
+
+        if (!options.attachOnlyRef?.current) {
+          const beforeSendRun = await options.controller.get(runId);
+          const response = await options.controller.sendFollowUp({
+            runId,
+            prompt,
+            mode:
+              options.followUpModeRef?.current ??
+              (beforeSendRun && isCodeAgentRunActive(beforeSendRun)
+                ? "queued"
+                : "immediate"),
+            permissionMode: options.permissionModeRef?.current,
+            engine: options.engineRef?.current,
+            model: options.modelRef?.current,
+            reasoningEffort: options.effortRef?.current,
+            source: "code-agent-chat",
+            metadata: attachments.length > 0 ? { attachments } : undefined,
+          });
+          if (!response.ok) {
+            yield errorResult(
+              response.error ?? response.message ?? "Could not send follow-up.",
+              runId,
+            );
+            return;
+          }
+        }
+
+        let lastYieldKey = "";
+        let idleTerminalPolls = 0;
+        while (!abortSignal.aborted) {
+          const [events, run] = await Promise.all([
+            options.controller.transcript(runId),
+            options.controller.get(runId),
+          ]);
+          const nextEvents = events
+            .filter((event) => !seenEventIds.has(event.id))
+            .sort(compareCodeAgentTranscriptEvents);
+          for (const event of nextEvents) {
+            seenEventIds.add(event.id);
+            tailedEvents.push(event);
+          }
+
+          const content = codeAgentTranscriptEventsToContent(tailedEvents);
+          const nextYieldKey = JSON.stringify(content);
+          if (content.length > 0 && nextYieldKey !== lastYieldKey) {
+            lastYieldKey = nextYieldKey;
+            yield withRunMetadata({ content: [...content] }, runId);
+          }
+
+          if (run && isCodeAgentRunActive(run)) {
+            idleTerminalPolls = 0;
+          } else if (nextEvents.length === 0) {
+            idleTerminalPolls += 1;
+          } else {
+            idleTerminalPolls = 0;
+          }
+
+          if (idleTerminalPolls >= terminalIdlePolls) {
+            if (content.length > 0) {
+              yield withRunMetadata({ content: [...content] }, runId);
+            }
+            return;
+          }
+
+          await sleep(
+            run && isCodeAgentRunActive(run)
+              ? pollIntervalMs
+              : idlePollIntervalMs,
+            abortSignal,
+          );
+        }
+      } finally {
+        abortSignal.removeEventListener("abort", stopForAbort);
+        if (stoppedFromAbort) {
+          return;
+        }
+      }
+    },
+  };
+}
+
+export function codeAgentTranscriptEventsToContent(
+  events: readonly CodeAgentChatTranscriptEvent[],
+): ContentPart[] {
+  const normalized = normalizeCodeAgentTranscript(
+    events.map(toCoreCodeAgentTranscriptEvent),
+  );
+  const content: ContentPart[] = [];
+
+  const appendText = (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    const last = content.at(-1);
+    if (last?.type === "text") {
+      last.text = `${last.text}${last.text ? "\n\n" : ""}${trimmed}`;
+    } else {
+      content.push({ type: "text", text: trimmed });
+    }
+  };
+
+  for (const item of normalized.items) {
+    const part = contentPartForCodeAgentTranscriptItem(item);
+    if (!part) continue;
+    if (part.type === "text") {
+      appendText(part.text);
+    } else {
+      content.push(part);
+    }
+  }
+
+  return content;
+}
+
+function latestUserMessage(
+  messages: ChatModelRunOptions["messages"],
+): ChatModelRunOptions["messages"][number] | undefined {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message.role === "user") return message;
+  }
+  return undefined;
+}
+
+function latestUserText(messages: ChatModelRunOptions["messages"]): string {
+  const message = latestUserMessage(messages);
+  return (
+    message?.content
+      .filter(
+        (part): part is { type: "text"; text: string } => part.type === "text",
+      )
+      .map((part) => part.text)
+      .join("\n") ?? ""
+  );
+}
+
+function extractPromptAttachmentsFromAssistantMessage(message: {
+  attachments?: readonly AssistantUiAttachment[];
+}): AgentPromptAttachment[] {
+  const attachments: AgentPromptAttachment[] = [];
+  for (const att of message.attachments ?? []) {
+    const name = att.name ?? "attachment";
+    for (const part of att.content ?? []) {
+      if (part.type === "image" && typeof part.image === "string") {
+        attachments.push({
+          name,
+          type: att.contentType,
+          dataUrl: part.image,
+        });
+      } else if (part.type === "file" && typeof part.data === "string") {
+        attachments.push({
+          name,
+          type:
+            att.contentType ??
+            (typeof part.mimeType === "string" ? part.mimeType : undefined),
+          ...(part.data.startsWith("data:")
+            ? { dataUrl: part.data }
+            : { text: part.data }),
+        });
+      } else if (part.type === "text" && typeof part.text === "string") {
+        attachments.push({
+          name,
+          type: att.contentType,
+          text: unwrapAttachmentEnvelope(part.text),
+        });
+      }
+    }
+  }
+  return attachments;
+}
+
+function toCoreCodeAgentTranscriptEvent(
+  event: CodeAgentChatTranscriptEvent,
+): CoreCodeAgentTranscriptEvent {
+  return {
+    schemaVersion: 1,
+    id: event.id,
+    runId: event.runId,
+    kind: (event.kind ??
+      event.type ??
+      "status") as CoreCodeAgentTranscriptEvent["kind"],
+    message: event.message ?? event.text ?? "",
+    createdAt: event.createdAt,
+    metadata: {
+      ...(event.metadata ?? {}),
+      ...(event.artifactPath ? { artifactPath: event.artifactPath } : {}),
+      ...(event.artifactUrl ? { artifactUrl: event.artifactUrl } : {}),
+    },
+  };
+}
+
+function contentPartForCodeAgentTranscriptItem(
+  item: NormalizedCodeAgentTranscriptItem,
+): ContentPart | null {
+  if (item.type === "assistant") {
+    return item.text.trim() ? { type: "text", text: item.text.trim() } : null;
+  }
+  if (item.type === "tool") {
+    return toolContentPartForCodeAgentTranscriptItem(item);
+  }
+  if (item.type === "status") {
+    const text = statusTextForCodeAgentTranscriptItem(item);
+    return text ? { type: "text", text } : null;
+  }
+  return null;
+}
+
+function toolContentPartForCodeAgentTranscriptItem(
+  item: NormalizedCodeAgentToolEvent,
+): ContentPart {
+  return {
+    type: "tool-call",
+    toolCallId: `code-tool-${item.id}`,
+    toolName: item.tool ?? item.label ?? "code-agent",
+    argsText: previewValue(item.input) ?? "",
+    args: recordArgs(item.input),
+    ...(item.result !== undefined
+      ? { result: previewValue(item.result) ?? "" }
+      : {}),
+  };
+}
+
+function statusTextForCodeAgentTranscriptItem(
+  item: NormalizedCodeAgentStatusEvent,
+): string | null {
+  if (item.statusKind === "artifact") {
+    const event = item.events[0];
+    const path =
+      stringMetadata(event?.metadata, "artifactPath") ??
+      stringMetadata(event?.metadata, "path");
+    const url = stringMetadata(event?.metadata, "artifactUrl");
+    const target = url ?? path;
+    return target
+      ? `Artifact: ${item.text}\n${target}`
+      : `Artifact: ${item.text}`;
+  }
+  if (item.level === "info" && item.statusKind !== "note") return null;
+  return item.text;
+}
+
+function recordArgs(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const result: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    result[key] =
+      typeof entry === "string" ? entry : (previewValue(entry) ?? "");
+  }
+  return result;
+}
+
+function previewValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const text =
+    typeof value === "string" ? value : (JSON.stringify(value, null, 2) ?? "");
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > 4000 ? `${trimmed.slice(0, 4000)}\n...` : trimmed;
+}
+
+function stringMetadata(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function withRunMetadata(
+  result: ChatModelRunResult,
+  runId: string,
+): ChatModelRunResult {
+  const metadata = (result.metadata ?? {}) as Record<string, unknown>;
+  const custom =
+    metadata.custom && typeof metadata.custom === "object"
+      ? (metadata.custom as Record<string, unknown>)
+      : {};
+  return {
+    ...result,
+    metadata: {
+      ...metadata,
+      custom: { ...custom, runId },
+    },
+  };
+}
+
+function errorResult(message: string, runId?: string): ChatModelRunResult {
+  return withRunMetadata(
+    {
+      content: [{ type: "text", text: message }],
+      status: { type: "incomplete", reason: "error" },
+    } as ChatModelRunResult,
+    runId ?? "code-agent",
+  );
+}
+
+function sleep(ms: number, abortSignal: AbortSignal): Promise<void> {
+  if (abortSignal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timeout = setTimeout(resolve, ms);
+    abortSignal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}

--- a/packages/core/src/client/code-agent-chat-adapter.ts
+++ b/packages/core/src/client/code-agent-chat-adapter.ts
@@ -162,7 +162,7 @@ export function createCodeAgentChatAdapter(
           }
         }
 
-        let lastYieldKey = "";
+        let yieldedContent = false;
         let idleTerminalPolls = 0;
         while (!abortSignal.aborted) {
           const [events, run] = await Promise.all([
@@ -178,9 +178,8 @@ export function createCodeAgentChatAdapter(
           }
 
           const content = codeAgentTranscriptEventsToContent(tailedEvents);
-          const nextYieldKey = JSON.stringify(content);
-          if (content.length > 0 && nextYieldKey !== lastYieldKey) {
-            lastYieldKey = nextYieldKey;
+          if (content.length > 0 && nextEvents.length > 0) {
+            yieldedContent = true;
             yield withRunMetadata({ content: [...content] }, runId);
           }
 
@@ -193,7 +192,7 @@ export function createCodeAgentChatAdapter(
           }
 
           if (idleTerminalPolls >= terminalIdlePolls) {
-            if (content.length > 0) {
+            if (content.length > 0 && !yieldedContent) {
               yield withRunMetadata({ content: [...content] }, runId);
             }
             return;

--- a/packages/core/src/client/composer/PromptComposer.tsx
+++ b/packages/core/src/client/composer/PromptComposer.tsx
@@ -128,8 +128,19 @@ export interface PromptComposerProps {
   selectedEffort?: ReasoningEffort;
   onModelChange?: (model: string, engine: string) => void;
   onEffortChange?: (effort: ReasoningEffort) => void;
+  /**
+   * Enable server-backed model/provider status checks. Defaults off when the
+   * host supplies model state and callbacks, otherwise on.
+   */
+  modelStatusChecksEnabled?: boolean;
   /** Called whenever the plain editor text changes. */
   onTextChange?: (text: string) => void;
+  /**
+   * Override the Builder.io connect action in the model picker. When provided,
+   * clicking "Connect Builder.io" calls this instead of opening a browser popup.
+   * Used by the Electron desktop app to route through the native IPC handler.
+   */
+  onConnectProvider?: () => void;
   /** Imperative handle for focusing the composer. */
   composerRef?: Ref<TiptapComposerHandle>;
 }
@@ -471,12 +482,21 @@ function PromptComposerInner({
   selectedEffort,
   onModelChange,
   onEffortChange,
+  modelStatusChecksEnabled,
   onTextChange,
+  onConnectProvider,
   composerRef,
 }: PromptComposerProps) {
   const localRef = useRef<TiptapComposerHandle>(null);
   const handleRef = composerRef ?? localRef;
-  const models = useChatModels();
+  const hostManagedModels = Boolean(
+    availableModels && selectedModel && onModelChange,
+  );
+  const resolvedModelStatusChecksEnabled =
+    modelStatusChecksEnabled ?? !hostManagedModels;
+  const models = useChatModels({
+    enabled: showModelSelector && resolvedModelStatusChecksEnabled,
+  });
   const composerModel = showModelSelector
     ? (selectedModel ?? models.selectedModel)
     : undefined;
@@ -573,6 +593,8 @@ function PromptComposerInner({
         availableModels={composerModelGroups}
         onModelChange={handleModelChange}
         onEffortChange={handleEffortChange}
+        providerConnectStatusEnabled={resolvedModelStatusChecksEnabled}
+        onConnectProvider={onConnectProvider}
       />
     </AgentComposerFrame>
   );

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -335,6 +335,17 @@ interface TiptapComposerProps {
   onModelChange?: (model: string, engine: string) => void;
   /** Callback when user picks a reasoning effort */
   onEffortChange?: (effort: ReasoningEffort) => void;
+  /**
+   * Disable Builder/provider status polling for hosts that supply provider
+   * state through another channel, such as Electron IPC.
+   */
+  providerConnectStatusEnabled?: boolean;
+  /**
+   * Override the Builder.io connect action in the model picker. When provided,
+   * clicking "Connect Builder.io" calls this instead of opening a browser popup.
+   * Used by the Electron desktop app to route through the native IPC handler.
+   */
+  onConnectProvider?: () => void;
   /** Stable scope for persisted drafts, usually the active thread or tab id. */
   draftScope?: string;
   /**
@@ -585,6 +596,8 @@ function ModelSelector({
   engines,
   onChange,
   onEffortChange,
+  providerConnectStatusEnabled = true,
+  onConnectProvider,
 }: {
   model: string;
   effort?: ReasoningEffort;
@@ -596,6 +609,8 @@ function ModelSelector({
   }>;
   onChange: (model: string, engine: string) => void;
   onEffortChange?: (effort: ReasoningEffort) => void;
+  providerConnectStatusEnabled?: boolean;
+  onConnectProvider?: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const autoModelGroup = engines.find((group) => group.models.includes("auto"));
@@ -654,12 +669,18 @@ function ModelSelector({
   // it unlocks every model family (Claude, OpenAI, Gemini) without the
   // user having to paste individual API keys.
   const builderFlow = useBuilderConnectFlow({
+    enabled: providerConnectStatusEnabled,
     trackingSource: "composer_builder_cta",
   });
+  const hasConfiguredBuilderModels = providerGroups.some(
+    (group) => group.engine === "builder" && group.configured,
+  );
   const showBuilderCta =
-    builderFlow.hasFetchedStatus &&
+    (builderFlow.hasFetchedStatus ||
+      (!providerConnectStatusEnabled && !!onConnectProvider)) &&
     !builderFlow.configured &&
-    !builderFlow.envManaged;
+    !builderFlow.envManaged &&
+    !hasConfiguredBuilderModels;
   const openLlmSettings = useCallback(() => {
     try {
       window.location.hash = "llm";
@@ -699,15 +720,19 @@ function ModelSelector({
               <button
                 type="button"
                 onClick={() => {
-                  builderFlow.start();
+                  if (onConnectProvider) {
+                    onConnectProvider();
+                  } else {
+                    builderFlow.start();
+                  }
                 }}
-                disabled={builderFlow.connecting}
+                disabled={!onConnectProvider && builderFlow.connecting}
                 className="flex w-full items-start gap-2 px-3 py-2 text-left hover:bg-accent/50 disabled:opacity-60"
               >
                 <IconPlugConnected className="h-4 w-4 shrink-0 mt-0.5 text-blue-500" />
                 <span className="flex-1 min-w-0">
                   <span className="block text-[12px] font-medium text-foreground">
-                    {builderFlow.connecting
+                    {!onConnectProvider && builderFlow.connecting
                       ? "Connecting Builder.io…"
                       : "Connect Builder.io"}
                   </span>
@@ -880,6 +905,8 @@ export function TiptapComposer({
   availableModels,
   onModelChange,
   onEffortChange,
+  providerConnectStatusEnabled,
+  onConnectProvider,
   draftScope,
   plusMenuMode = "full",
   interceptBuildRequestsForBuilder = false,
@@ -1884,6 +1911,8 @@ export function TiptapComposer({
             engines={availableModels}
             onChange={onModelChange}
             onEffortChange={onEffortChange}
+            providerConnectStatusEnabled={providerConnectStatusEnabled}
+            onConnectProvider={onConnectProvider}
           />
         )}
         {execMode && onExecModeChange && (

--- a/packages/core/src/client/composer/index.ts
+++ b/packages/core/src/client/composer/index.ts
@@ -12,6 +12,16 @@ export {
   type PromptComposerFile,
   type PromptComposerSubmitOptions,
 } from "./PromptComposer.js";
+export {
+  AGENT_PROMPT_MAX_INLINE_IMAGE_BYTES,
+  AGENT_PROMPT_MAX_INLINE_TEXT_CHARS,
+  escapePromptAttachmentAttribute,
+  formatPromptWithAttachments,
+  isInlineableAgentPromptFile,
+  readAgentPromptAttachment,
+  type AgentPromptAttachment,
+  type ReadAgentPromptAttachmentOptions,
+} from "./prompt-attachments.js";
 export { MentionPopover } from "./MentionPopover.js";
 export { useMentionSearch } from "./use-mention-search.js";
 export type {

--- a/packages/core/src/client/composer/prompt-attachments.spec.ts
+++ b/packages/core/src/client/composer/prompt-attachments.spec.ts
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from "vitest";
+import {
+  escapePromptAttachmentAttribute,
+  formatPromptWithAttachments,
+  isInlineableAgentPromptFile,
+  readAgentPromptAttachment,
+} from "./prompt-attachments.js";
+
+describe("prompt attachment helpers", () => {
+  it("inlines readable text files up to the configured limit", async () => {
+    const file = new File(["hello"], "notes.md", {
+      type: "text/markdown",
+    });
+
+    const attachment = await readAgentPromptAttachment(file);
+
+    expect(isInlineableAgentPromptFile(file)).toBe(true);
+    expect(attachment).toEqual({
+      name: "notes.md",
+      type: "text/markdown",
+      size: 5,
+      text: "hello",
+    });
+  });
+
+  it("falls back to filename metadata for oversized text files", async () => {
+    const file = new File(["hello"], "notes.md", {
+      type: "text/markdown",
+    });
+
+    const attachment = await readAgentPromptAttachment(file, {
+      maxInlineTextChars: 2,
+    });
+
+    expect(attachment).toEqual({
+      name: "notes.md",
+      type: "text/markdown",
+      size: 5,
+    });
+  });
+
+  it("inlines small image files as data URLs", async () => {
+    const file = new File(["fake image"], "screenshot.png", {
+      type: "image/png",
+    });
+
+    const attachment = await readAgentPromptAttachment(file);
+
+    expect(attachment.name).toBe("screenshot.png");
+    expect(attachment.type).toBe("image/png");
+    expect(attachment.dataUrl).toContain("data:image/png;base64,");
+  });
+
+  it("formats attachments with escaped XML attributes", () => {
+    const formatted = formatPromptWithAttachments("Review this", [
+      {
+        name: 'bad"name&.ts',
+        type: "text/plain",
+        size: 12,
+        text: "const x = 1;",
+      },
+      {
+        name: "shot.png",
+        type: "image/png",
+        size: 3,
+        dataUrl: "data:image/png;base64,abc",
+      },
+    ]);
+
+    expect(escapePromptAttachmentAttribute('a&"b')).toBe("a&amp;&quot;b");
+    expect(formatted).toContain("Attached context:");
+    expect(formatted).toContain('name="bad&quot;name&amp;.ts"');
+    expect(formatted).toContain("<attached-file");
+    expect(formatted).toContain("<attached-image");
+    expect(formatted).toContain("data:image/png;base64,abc");
+  });
+});

--- a/packages/core/src/client/composer/prompt-attachments.ts
+++ b/packages/core/src/client/composer/prompt-attachments.ts
@@ -1,14 +1,17 @@
+import {
+  formatPromptWithAttachments,
+  escapePromptAttachmentAttribute,
+  type AgentPromptAttachment,
+} from "../../code-agents/prompt-attachments.js";
+
+export {
+  formatPromptWithAttachments,
+  escapePromptAttachmentAttribute,
+  type AgentPromptAttachment,
+};
+
 export const AGENT_PROMPT_MAX_INLINE_TEXT_CHARS = 60_000;
 export const AGENT_PROMPT_MAX_INLINE_IMAGE_BYTES = 2 * 1024 * 1024;
-
-export interface AgentPromptAttachment {
-  name: string;
-  type?: string;
-  size?: number;
-  text?: string;
-  /** Base64 data URL for image attachments (e.g. "data:image/png;base64,..."). */
-  dataUrl?: string;
-}
 
 export interface ReadAgentPromptAttachmentOptions {
   maxInlineTextChars?: number;
@@ -54,37 +57,6 @@ export function isInlineableAgentPromptFile(file: File): boolean {
   return /\.(cjs|css|csv|html|js|json|jsx|md|mdx|mjs|sql|tsx?|txt|xml|yaml|yml)$/i.test(
     file.name,
   );
-}
-
-export function formatPromptWithAttachments(
-  prompt: string,
-  attachments: readonly AgentPromptAttachment[],
-): string {
-  if (attachments.length === 0) return prompt;
-  const attachmentText = attachments
-    .map((attachment) => {
-      const size = attachment.size ? ` size="${attachment.size}"` : "";
-      const type = attachment.type
-        ? ` type="${escapePromptAttachmentAttribute(attachment.type)}"`
-        : "";
-      if (attachment.dataUrl) {
-        return `<attached-image name="${escapePromptAttachmentAttribute(
-          attachment.name,
-        )}"${type}${size}>\n${attachment.dataUrl}\n</attached-image>`;
-      }
-      const body =
-        attachment.text?.trim() ||
-        "Selected in the UI. If this file is needed, inspect it from the workspace or ask for a readable copy.";
-      return `<attached-file name="${escapePromptAttachmentAttribute(
-        attachment.name,
-      )}"${type}${size}>\n${body}\n</attached-file>`;
-    })
-    .join("\n\n");
-  return `${prompt.trimEnd()}\n\nAttached context:\n${attachmentText}`;
-}
-
-export function escapePromptAttachmentAttribute(value: string): string {
-  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
 }
 
 function readFileAsDataUrl(file: File): Promise<string> {

--- a/packages/core/src/client/composer/prompt-attachments.ts
+++ b/packages/core/src/client/composer/prompt-attachments.ts
@@ -1,0 +1,98 @@
+export const AGENT_PROMPT_MAX_INLINE_TEXT_CHARS = 60_000;
+export const AGENT_PROMPT_MAX_INLINE_IMAGE_BYTES = 2 * 1024 * 1024;
+
+export interface AgentPromptAttachment {
+  name: string;
+  type?: string;
+  size?: number;
+  text?: string;
+  /** Base64 data URL for image attachments (e.g. "data:image/png;base64,..."). */
+  dataUrl?: string;
+}
+
+export interface ReadAgentPromptAttachmentOptions {
+  maxInlineTextChars?: number;
+  maxInlineImageBytes?: number;
+}
+
+export async function readAgentPromptAttachment(
+  file: File,
+  options: ReadAgentPromptAttachmentOptions = {},
+): Promise<AgentPromptAttachment> {
+  const maxInlineTextChars =
+    options.maxInlineTextChars ?? AGENT_PROMPT_MAX_INLINE_TEXT_CHARS;
+  const maxInlineImageBytes =
+    options.maxInlineImageBytes ?? AGENT_PROMPT_MAX_INLINE_IMAGE_BYTES;
+  const attachment: AgentPromptAttachment = {
+    name: file.name,
+    type: file.type || undefined,
+    size: file.size,
+  };
+
+  if (isInlineableAgentPromptFile(file) && file.size <= maxInlineTextChars) {
+    try {
+      attachment.text = await file.text();
+    } catch {
+      // Keep the filename-only attachment if the browser cannot read it.
+    }
+  } else if (
+    file.type.startsWith("image/") &&
+    file.size <= maxInlineImageBytes
+  ) {
+    try {
+      attachment.dataUrl = await readFileAsDataUrl(file);
+    } catch {
+      // Keep the filename-only attachment if the browser cannot read it.
+    }
+  }
+
+  return attachment;
+}
+
+export function isInlineableAgentPromptFile(file: File): boolean {
+  if (file.type.startsWith("text/")) return true;
+  return /\.(cjs|css|csv|html|js|json|jsx|md|mdx|mjs|sql|tsx?|txt|xml|yaml|yml)$/i.test(
+    file.name,
+  );
+}
+
+export function formatPromptWithAttachments(
+  prompt: string,
+  attachments: readonly AgentPromptAttachment[],
+): string {
+  if (attachments.length === 0) return prompt;
+  const attachmentText = attachments
+    .map((attachment) => {
+      const size = attachment.size ? ` size="${attachment.size}"` : "";
+      const type = attachment.type
+        ? ` type="${escapePromptAttachmentAttribute(attachment.type)}"`
+        : "";
+      if (attachment.dataUrl) {
+        return `<attached-image name="${escapePromptAttachmentAttribute(
+          attachment.name,
+        )}"${type}${size}>\n${attachment.dataUrl}\n</attached-image>`;
+      }
+      const body =
+        attachment.text?.trim() ||
+        "Selected in the UI. If this file is needed, inspect it from the workspace or ask for a readable copy.";
+      return `<attached-file name="${escapePromptAttachmentAttribute(
+        attachment.name,
+      )}"${type}${size}>\n${body}\n</attached-file>`;
+    })
+    .join("\n\n");
+  return `${prompt.trimEnd()}\n\nAttached context:\n${attachmentText}`;
+}
+
+export function escapePromptAttachmentAttribute(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ""));
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("Could not read file"));
+    reader.readAsDataURL(file);
+  });
+}

--- a/packages/core/src/client/conversation/AgentConversation.tsx
+++ b/packages/core/src/client/conversation/AgentConversation.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
@@ -15,6 +15,7 @@ import {
 import { cn } from "../utils.js";
 import { useNearBottomAutoscroll } from "./use-near-bottom-autoscroll.js";
 import type {
+  AgentConversationAttachment,
   AgentConversationArtifact,
   AgentConversationMessage,
   AgentConversationMessagePart,
@@ -131,6 +132,16 @@ export function AgentConversationMessageView({
         message.pending && "agent-conversation-message--pending",
       )}
     >
+      {message.attachments && message.attachments.length > 0 && (
+        <div className="agent-conversation-message__attachments">
+          {message.attachments.map((attachment, i) => (
+            <ConversationAttachmentChip
+              key={`${attachment.name}-${i}`}
+              attachment={attachment}
+            />
+          ))}
+        </div>
+      )}
       <div className="agent-conversation-message__body">
         {parts.map((part) => (
           <ConversationMessagePartView key={part.id} part={part} />
@@ -196,6 +207,117 @@ function ConversationMessagePartView({
   );
 }
 
+// ─── Shiki syntax highlighter (lazy-loaded) ──────────────────────────────────
+type ShikiHighlighter = {
+  codeToHtml: (
+    code: string,
+    options: {
+      lang: string;
+      themes: { light: string; dark: string };
+      defaultColor?: false | "light" | "dark";
+    },
+  ) => string | Promise<string>;
+  getLoadedLanguages: () => string[];
+};
+
+let _highlighterLoader: Promise<ShikiHighlighter> | null = null;
+function loadConversationHighlighter(): Promise<ShikiHighlighter> {
+  if (!_highlighterLoader) {
+    _highlighterLoader = (async () => {
+      const [{ createHighlighterCore }, { createOnigurumaEngine }] =
+        await Promise.all([
+          import("shiki/core"),
+          import("shiki/engine/oniguruma"),
+        ]);
+      return createHighlighterCore({
+        themes: [
+          import("shiki/themes/github-light-default.mjs"),
+          import("shiki/themes/github-dark-default.mjs"),
+        ],
+        langs: [
+          import("shiki/langs/javascript.mjs"),
+          import("shiki/langs/typescript.mjs"),
+          import("shiki/langs/jsx.mjs"),
+          import("shiki/langs/tsx.mjs"),
+          import("shiki/langs/json.mjs"),
+          import("shiki/langs/css.mjs"),
+          import("shiki/langs/html.mjs"),
+          import("shiki/langs/markdown.mjs"),
+          import("shiki/langs/bash.mjs"),
+          import("shiki/langs/shellscript.mjs"),
+          import("shiki/langs/python.mjs"),
+          import("shiki/langs/yaml.mjs"),
+          import("shiki/langs/sql.mjs"),
+        ],
+        engine: createOnigurumaEngine(import("shiki/wasm")),
+      }) as unknown as Promise<ShikiHighlighter>;
+    })().catch((err) => {
+      _highlighterLoader = null;
+      throw err;
+    });
+  }
+  return _highlighterLoader;
+}
+
+const LANG_ALIASES: Record<string, string> = {
+  js: "javascript",
+  ts: "typescript",
+  sh: "bash",
+  shell: "bash",
+  zsh: "bash",
+  py: "python",
+  yml: "yaml",
+  md: "markdown",
+  bq: "sql",
+  bigquery: "sql",
+};
+
+function HighlightedCodeBlock({ code, lang }: { code: string; lang: string }) {
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadConversationHighlighter()
+      .then((highlighter) => {
+        const requested = (lang || "text").toLowerCase();
+        const resolved = LANG_ALIASES[requested] ?? requested;
+        const loaded = highlighter.getLoadedLanguages();
+        const finalLang = loaded.includes(resolved) ? resolved : "text";
+        return highlighter.codeToHtml(code, {
+          lang: finalLang,
+          themes: {
+            light: "github-light-default",
+            dark: "github-dark-default",
+          },
+          defaultColor: false,
+        });
+      })
+      .then((out) => {
+        if (!cancelled) setHtml(out as string);
+      })
+      .catch(() => {
+        if (!cancelled) setHtml(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [code, lang]);
+
+  if (html) {
+    return (
+      <div
+        className="agent-conversation-shiki"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    );
+  }
+  return (
+    <pre>
+      <code className={lang ? `language-${lang}` : undefined}>{code}</code>
+    </pre>
+  );
+}
+
 function ConversationMarkdown({ text }: { text: string }) {
   return (
     <div className="agent-conversation-markdown">
@@ -218,12 +340,44 @@ function ConversationMarkdown({ text }: { text: string }) {
               </a>
             );
           },
+          pre(props: React.HTMLAttributes<HTMLPreElement>) {
+            const { children, ...rest } = props;
+            if (React.isValidElement(children)) {
+              const childProps = children.props as {
+                className?: string;
+                children?: React.ReactNode;
+              };
+              const langMatch = (childProps.className ?? "").match(
+                /\blanguage-([\w+-]+)\b/,
+              );
+              if (langMatch) {
+                const code = extractCodeText(childProps.children).replace(
+                  /\n$/,
+                  "",
+                );
+                return <HighlightedCodeBlock code={code} lang={langMatch[1]} />;
+              }
+            }
+            return <pre {...rest}>{children}</pre>;
+          },
         }}
       >
         {text}
       </ReactMarkdown>
     </div>
   );
+}
+
+function extractCodeText(node: React.ReactNode): string {
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(extractCodeText).join("");
+  if (React.isValidElement(node)) {
+    return extractCodeText(
+      (node.props as { children?: React.ReactNode }).children,
+    );
+  }
+  return "";
 }
 
 function openMarkdownLink(
@@ -335,4 +489,43 @@ function ConversationArtifact({
       )}
     </div>
   );
+}
+
+function ConversationAttachmentChip({
+  attachment,
+}: {
+  attachment: AgentConversationAttachment;
+}) {
+  if (attachment.dataUrl) {
+    return (
+      <div className="agent-conversation-attachment agent-conversation-attachment--image">
+        <img
+          src={attachment.dataUrl}
+          alt={attachment.name}
+          className="agent-conversation-attachment__image"
+        />
+        <span className="agent-conversation-attachment__name">
+          {attachment.name}
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div className="agent-conversation-attachment agent-conversation-attachment--file">
+      <span className="agent-conversation-attachment__name">
+        {attachment.name}
+      </span>
+      {attachment.size !== undefined && (
+        <span className="agent-conversation-attachment__size">
+          {formatBytes(attachment.size)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/packages/core/src/client/conversation/code-agent-transcript.spec.ts
+++ b/packages/core/src/client/conversation/code-agent-transcript.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCodeAgentTranscriptForConversation } from "./code-agent-transcript.js";
+import type { CodeAgentConversationTranscriptEvent } from "./code-agent-transcript.js";
+
+describe("normalizeCodeAgentTranscriptForConversation", () => {
+  it("groups Code transcript events into shared conversation messages", () => {
+    const events: CodeAgentConversationTranscriptEvent[] = [
+      {
+        id: "user-1",
+        runId: "run-1",
+        type: "user",
+        text: "Fix the chat",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        metadata: {
+          attachments: [
+            {
+              name: "screenshot.png",
+              type: "image/png",
+              size: 42,
+              dataUrl: "data:image/png;base64,abc",
+            },
+          ],
+        },
+      },
+      {
+        id: "assistant-1",
+        runId: "run-1",
+        kind: "system",
+        message: "I will inspect the code.",
+        createdAt: "2026-01-01T00:00:01.000Z",
+        metadata: { role: "assistant" },
+      },
+      {
+        id: "tool-start-1",
+        runId: "run-1",
+        type: "status",
+        text: "Reading files",
+        createdAt: "2026-01-01T00:00:02.000Z",
+        metadata: {
+          type: "tool_start",
+          tool: "read_file",
+          input: { path: "chat.tsx" },
+        },
+      },
+      {
+        id: "tool-done-1",
+        runId: "run-1",
+        type: "status",
+        text: "Read files",
+        createdAt: "2026-01-01T00:00:03.000Z",
+        metadata: {
+          type: "tool_done",
+          tool: "read_file",
+          result: "ok",
+        },
+      },
+      {
+        id: "artifact-1",
+        runId: "run-1",
+        type: "artifact",
+        text: "Patch",
+        artifactPath: "/tmp/patch.diff",
+        artifactUrl: "file:///tmp/patch.diff",
+        createdAt: "2026-01-01T00:00:04.000Z",
+      },
+    ];
+
+    const messages = normalizeCodeAgentTranscriptForConversation(events);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({
+      id: "user-1",
+      role: "user",
+      text: "Fix the chat",
+      attachments: [
+        {
+          name: "screenshot.png",
+          type: "image/png",
+          size: 42,
+          dataUrl: "data:image/png;base64,abc",
+        },
+      ],
+    });
+    expect(messages[1]?.parts?.map((part) => part.type)).toEqual([
+      "text",
+      "tool",
+      "artifact",
+    ]);
+    expect(messages[1]?.tools?.[0]).toMatchObject({
+      name: "read_file",
+      state: "completed",
+      summary: "finished",
+    });
+    expect(messages[1]?.artifacts?.[0]).toMatchObject({
+      label: "Patch",
+      path: "/tmp/patch.diff",
+      url: "file:///tmp/patch.diff",
+    });
+  });
+
+  it("marks pending user turns and can hide credential notices", () => {
+    const events: CodeAgentConversationTranscriptEvent[] = [
+      {
+        id: "user-1",
+        runId: "run-1",
+        type: "user",
+        text: "Continue",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        metadata: { pending: true },
+      },
+      {
+        id: "credentials-1",
+        runId: "run-1",
+        type: "status",
+        text: "No LLM provider key was found.",
+        createdAt: "2026-01-01T00:00:01.000Z",
+        metadata: { phase: "missing-credentials" },
+      },
+    ];
+
+    const visible = normalizeCodeAgentTranscriptForConversation(events);
+    const hidden = normalizeCodeAgentTranscriptForConversation(events, {
+      hideCredentialMessages: true,
+    });
+
+    expect(visible[0]?.pending).toBe(true);
+    expect(visible[1]?.notices?.[0]?.tone).toBe("warning");
+    expect(hidden).toHaveLength(1);
+  });
+});

--- a/packages/core/src/client/conversation/code-agent-transcript.ts
+++ b/packages/core/src/client/conversation/code-agent-transcript.ts
@@ -1,25 +1,51 @@
-import type {
-  AgentConversationArtifact,
-  AgentConversationMessage,
-  AgentConversationMessagePart,
-  AgentConversationNotice,
-  AgentConversationToolCall,
-} from "@agent-native/core/client";
 import {
   normalizeCodeAgentTranscript,
   type CodeAgentTranscriptEvent as CoreCodeAgentTranscriptEvent,
   type NormalizedCodeAgentStatusEvent,
   type NormalizedCodeAgentToolEvent,
   type NormalizedCodeAgentTranscriptItem,
-} from "@agent-native/core/code-agents/transcript-normalizer";
-import type { CodeAgentTranscriptEvent } from "./types.js";
+} from "../../code-agents/transcript-normalizer.js";
+import type {
+  AgentConversationAttachment,
+  AgentConversationArtifact,
+  AgentConversationMessage,
+  AgentConversationMessagePart,
+  AgentConversationNotice,
+  AgentConversationToolCall,
+} from "./types.js";
+
+export type CodeAgentConversationTranscriptEventType =
+  | "user"
+  | "system"
+  | "artifact"
+  | "status"
+  | "note";
+
+/**
+ * Browser/UI transcript event shape used by Code-style hosts. It accepts both
+ * the local Code UI field names (`type`, `text`) and the core transcript-store
+ * field names (`kind`, `message`) so hosts can pass through either shape.
+ */
+export interface CodeAgentConversationTranscriptEvent {
+  id: string;
+  runId: string;
+  type?: CodeAgentConversationTranscriptEventType;
+  kind?: CodeAgentConversationTranscriptEventType;
+  title?: string;
+  text?: string;
+  message?: string;
+  createdAt: string;
+  artifactPath?: string;
+  artifactUrl?: string;
+  metadata?: Record<string, unknown>;
+}
 
 export interface NormalizeCodeAgentTranscriptOptions {
   hideCredentialMessages?: boolean;
 }
 
 export function normalizeCodeAgentTranscriptForConversation(
-  events: CodeAgentTranscriptEvent[],
+  events: readonly CodeAgentConversationTranscriptEvent[],
   options: NormalizeCodeAgentTranscriptOptions = {},
 ): AgentConversationMessage[] {
   const normalized = normalizeCodeAgentTranscript(
@@ -48,12 +74,14 @@ export function normalizeCodeAgentTranscriptForConversation(
 
   for (const item of normalized.items) {
     if (item.type === "user") {
+      const attachments = extractAttachments(item.events);
       messages.push({
         id: item.id,
         role: "user",
         text: item.text,
         createdAt: item.createdAt,
         pending: item.events.some((event) => event.metadata?.pending === true),
+        ...(attachments.length > 0 ? { attachments } : {}),
       });
       continue;
     }
@@ -115,14 +143,16 @@ function appendPart(
 }
 
 function toCoreTranscriptEvent(
-  event: CodeAgentTranscriptEvent,
+  event: CodeAgentConversationTranscriptEvent,
 ): CoreCodeAgentTranscriptEvent {
   return {
     schemaVersion: 1,
     id: event.id,
     runId: event.runId,
-    kind: event.type as CoreCodeAgentTranscriptEvent["kind"],
-    message: event.text,
+    kind: (event.kind ??
+      event.type ??
+      "status") as CoreCodeAgentTranscriptEvent["kind"],
+    message: event.message ?? event.text ?? "",
     createdAt: event.createdAt,
     metadata: {
       ...(event.metadata ?? {}),
@@ -217,4 +247,28 @@ function stringMetadata(
 
 function isCredentialText(value: string): boolean {
   return /No LLM provider key was found|Missing credentials/i.test(value);
+}
+
+function extractAttachments(
+  events: CoreCodeAgentTranscriptEvent[],
+): AgentConversationAttachment[] {
+  for (const event of events) {
+    const raw = event.metadata?.attachments;
+    if (!Array.isArray(raw) || raw.length === 0) continue;
+    const result: AgentConversationAttachment[] = [];
+    for (const item of raw) {
+      if (!item || typeof item !== "object") continue;
+      const record = item as Record<string, unknown>;
+      const name = typeof record.name === "string" ? record.name : undefined;
+      if (!name) continue;
+      const attachment: AgentConversationAttachment = { name };
+      if (typeof record.type === "string") attachment.type = record.type;
+      if (typeof record.size === "number") attachment.size = record.size;
+      if (typeof record.dataUrl === "string")
+        attachment.dataUrl = record.dataUrl;
+      result.push(attachment);
+    }
+    if (result.length > 0) return result;
+  }
+  return [];
 }

--- a/packages/core/src/client/conversation/index.ts
+++ b/packages/core/src/client/conversation/index.ts
@@ -3,7 +3,14 @@ export {
   AgentConversationMessageView,
 } from "./AgentConversation.js";
 export { useNearBottomAutoscroll } from "./use-near-bottom-autoscroll.js";
+export {
+  normalizeCodeAgentTranscriptForConversation,
+  type CodeAgentConversationTranscriptEvent,
+  type CodeAgentConversationTranscriptEventType,
+  type NormalizeCodeAgentTranscriptOptions,
+} from "./code-agent-transcript.js";
 export type {
+  AgentConversationAttachment,
   AgentConversationArtifact,
   AgentConversationMessage,
   AgentConversationMessagePart,

--- a/packages/core/src/client/conversation/types.ts
+++ b/packages/core/src/client/conversation/types.ts
@@ -1,5 +1,13 @@
 import type { ReactNode } from "react";
 
+export interface AgentConversationAttachment {
+  name: string;
+  type?: string;
+  size?: number;
+  /** Base64 data URL for image attachments (e.g. "data:image/png;base64,..."). */
+  dataUrl?: string;
+}
+
 export type AgentConversationMessageRole = "user" | "assistant" | "system";
 
 export type AgentConversationToolState =
@@ -66,4 +74,5 @@ export interface AgentConversationMessage {
   tools?: AgentConversationToolCall[];
   notices?: AgentConversationNotice[];
   artifacts?: AgentConversationArtifact[];
+  attachments?: AgentConversationAttachment[];
 }

--- a/packages/core/src/client/conversation/use-near-bottom-autoscroll.ts
+++ b/packages/core/src/client/conversation/use-near-bottom-autoscroll.ts
@@ -26,15 +26,6 @@ export function useNearBottomAutoscroll<TElement extends HTMLElement>({
     setShowScrollToBottom(!nearBottom);
   }, [threshold]);
 
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el || !enabled) return;
-    const onScroll = () => updateNearBottom();
-    el.addEventListener("scroll", onScroll, { passive: true });
-    updateNearBottom();
-    return () => el.removeEventListener("scroll", onScroll);
-  }, [enabled, updateNearBottom]);
-
   const scrollToBottom = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -42,6 +33,31 @@ export function useNearBottomAutoscroll<TElement extends HTMLElement>({
     isNearBottomRef.current = true;
     setShowScrollToBottom(false);
   }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !enabled) return;
+    const onScroll = () => updateNearBottom();
+    el.addEventListener("scroll", onScroll, { passive: true });
+    updateNearBottom();
+
+    // Re-check near-bottom whenever the scroll container's content grows
+    // (e.g. new messages appended, images loaded, tool-call details expanded).
+    // Without this the "near bottom" flag can get stuck as `false` even though
+    // the user never scrolled away — the container just grew taller.
+    const ro = new ResizeObserver(() => {
+      if (isNearBottomRef.current) scrollToBottom();
+      else updateNearBottom();
+    });
+    ro.observe(el);
+    // Also watch direct children so inline content changes are caught.
+    for (const child of Array.from(el.children)) ro.observe(child);
+
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+      ro.disconnect();
+    };
+  }, [enabled, updateNearBottom, scrollToBottom]);
 
   const scrollToBottomAfterPaint = useCallback(() => {
     scrollToBottom();

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -15,6 +15,28 @@ export {
   appBasePath,
   appPath,
 } from "./api-path.js";
+export {
+  codeAgentTranscriptEventsToContent,
+  createCodeAgentChatAdapter,
+  type CodeAgentChatController,
+  type CodeAgentChatControlResult,
+  type CodeAgentChatFollowUpMode,
+  type CodeAgentChatTranscriptEvent,
+  type CreateCodeAgentChatAdapterOptions,
+} from "./code-agent-chat-adapter.js";
+export {
+  buildRepositoryFromCodeAgentTranscript,
+  type BuildRepositoryFromCodeAgentTranscriptOptions,
+  type CodeAgentThreadTranscriptEvent,
+} from "../agent/thread-data-builder.js";
+export {
+  compareCodeAgentTranscriptEvents,
+  getCodeAgentTranscriptSeq,
+  isCodeAgentRunActive,
+  mergeCodeAgentTranscriptEvents,
+  type CodeAgentRunStateLike,
+  type CodeAgentTranscriptOrderEvent,
+} from "../code-agents/transcript-order.js";
 export { useSendToAgentChat } from "./use-send-to-agent-chat.js";
 export {
   useChatModels,
@@ -28,8 +50,13 @@ export {
 export {
   AgentConversation,
   AgentConversationMessageView,
+  normalizeCodeAgentTranscriptForConversation,
   useNearBottomAutoscroll,
+  type CodeAgentConversationTranscriptEvent,
+  type CodeAgentConversationTranscriptEventType,
+  type NormalizeCodeAgentTranscriptOptions,
   type AgentConversationArtifact,
+  type AgentConversationAttachment,
   type AgentConversationMessage,
   type AgentConversationMessagePart,
   type AgentConversationMessageRole,
@@ -234,9 +261,17 @@ export {
   AgentComposerFrame,
   type AgentComposerFrameProps,
   PromptComposer,
+  AGENT_PROMPT_MAX_INLINE_IMAGE_BYTES,
+  AGENT_PROMPT_MAX_INLINE_TEXT_CHARS,
+  escapePromptAttachmentAttribute,
+  formatPromptWithAttachments,
+  isInlineableAgentPromptFile,
+  readAgentPromptAttachment,
   type PromptComposerProps,
   type PromptComposerFile,
   type PromptComposerSubmitOptions,
+  type AgentPromptAttachment,
+  type ReadAgentPromptAttachmentOptions,
   type AgentComposerLayoutVariant,
   type SlashCommand,
   type SkillResult,

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -20,8 +20,14 @@ function setUserAgent(userAgent: string) {
   });
 }
 
-function BuilderConnectProbe({ popupUrl }: { popupUrl?: string }) {
-  const flow = useBuilderConnectFlow({ popupUrl });
+function BuilderConnectProbe({
+  enabled = true,
+  popupUrl,
+}: {
+  enabled?: boolean;
+  popupUrl?: string;
+}) {
+  const flow = useBuilderConnectFlow({ enabled, popupUrl });
   return (
     <div>
       <button type="button" onClick={() => flow.start()}>
@@ -129,6 +135,24 @@ describe("useBuilderConnectFlow", () => {
     );
     expect(popup.location.href).toBe(expectedConnectUrl(signedCliAuthUrl));
     expect(container.textContent).not.toContain("Popup blocked");
+  });
+
+  it("does not probe Builder status when disabled", async () => {
+    await act(async () => {
+      root.render(<BuilderConnectProbe enabled={false} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      container.querySelector("button")?.click();
+      await Promise.resolve();
+    });
+
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("refreshes an un-timestamped signed prop URL before navigating web popups", async () => {

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -105,6 +105,8 @@ export function useBuilderStatus() {
 // caller already has it in hand.
 
 export interface BuilderConnectFlowOptions {
+  /** Skip server status polling for hosts that own provider routing. */
+  enabled?: boolean;
   /** URL to synchronously open on start(). Defaults to the 302 shortcut. */
   popupUrl?: string;
   /** Low-cardinality label for the UI surface that opened Builder connect. */
@@ -430,6 +432,7 @@ export function useBuilderConnectFlow(
   opts: BuilderConnectFlowOptions = {},
 ): BuilderConnectFlow {
   const {
+    enabled = true,
     popupUrl,
     trackingSource = "builder_connect_flow",
     trackingFlow,
@@ -466,6 +469,7 @@ export function useBuilderConnectFlow(
   }, []);
 
   const fetchStatus = useCallback(async () => {
+    if (!enabled) return null;
     const origin = getCallbackOrigin() || window.location.origin;
     try {
       const r = await fetch(
@@ -486,7 +490,7 @@ export function useBuilderConnectFlow(
     } catch {
       return null;
     }
-  }, []);
+  }, [enabled]);
 
   // Initial fetch + focus/visibility refresh so if the user completed the
   // flow in another tab (or a downgraded same-tab nav) we notice it. Also
@@ -494,6 +498,19 @@ export function useBuilderConnectFlow(
   // Settings propagates to any connect-CTA cards rendered elsewhere in
   // the app without waiting for the next focus event.
   useEffect(() => {
+    if (!enabled) {
+      setConfigured(false);
+      setEnvManaged(false);
+      setBuilderEnabled(false);
+      setOrgName(null);
+      setConnecting(false);
+      setError(null);
+      setHasFetchedStatus(false);
+      setStatusConnectUrl(null);
+      statusConnectUrlAtRef.current = null;
+      stopPoll();
+      return;
+    }
     mountedRef.current = true;
     let cancelled = false;
     const refresh = async () => {
@@ -553,10 +570,11 @@ export function useBuilderConnectFlow(
       window.removeEventListener("agent-engine:configured-changed", refresh);
       stopPoll();
     };
-  }, [fetchStatus, stopPoll]);
+  }, [enabled, fetchStatus, stopPoll]);
 
   const start = useCallback(
     (startOptions?: BuilderConnectStartOptions) => {
+      if (!enabled) return;
       stopPoll();
       const started = Date.now();
       const clickTrackingSource =
@@ -744,6 +762,7 @@ export function useBuilderConnectFlow(
       }, POLL_INTERVAL_MS);
     },
     [
+      enabled,
       fetchStatus,
       popupUrl,
       statusConnectUrl,

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -573,6 +573,31 @@ describe("SSE event processor error classification", () => {
     expect(second.done).toBe(true);
   });
 
+  it("surfaces daily gateway caps instead of looping auto-continuation", async () => {
+    const iter = readSSEStream(
+      eventStream([
+        {
+          type: "error",
+          error:
+            "Daily gateway request cap reached (cap: 5000). Please try again tomorrow.",
+          errorCode: "rate_limit_exceeded",
+        },
+      ]),
+      [],
+      { value: 0 },
+      "tab-gateway-cap",
+    )[Symbol.asyncIterator]();
+
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+    expect(first.value?.status).toEqual({
+      type: "incomplete",
+      reason: "error",
+    });
+    const second = await iter.next();
+    expect(second.done).toBe(true);
+  });
+
   it("auto-continues Builder gateway network errors", async () => {
     const err = await readSSEStream(
       eventStream([

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -121,6 +121,7 @@ function isAutoRecoverableError(ev: SSEEvent, errMsg: string): boolean {
     code === "permission_error" ||
     code === "http_401" ||
     code === "http_403" ||
+    code === "rate_limit_exceeded" ||
     code === "gateway_not_enabled" ||
     code === "missing_api_key" ||
     code === "missing_credentials" ||
@@ -163,6 +164,8 @@ function isAutoRecoverableError(ev: SSEEvent, errMsg: string): boolean {
   }
 
   if (ev.recoverable === true) return true;
+
+  if (msg.includes("daily gateway request cap")) return false;
 
   // "gateway error" intentionally absent — that's the no-detail Builder
   // gateway fallback and the production-agent already retries it

--- a/packages/core/src/client/use-chat-models.spec.tsx
+++ b/packages/core/src/client/use-chat-models.spec.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatModels } from "./use-chat-models.js";
+
+function ChatModelsProbe({ enabled }: { enabled: boolean }) {
+  const models = useChatModels({ enabled, storageKey: null });
+  return (
+    <button type="button" onClick={models.refreshEngines}>
+      {models.selectedModel}:{models.availableModels.length}
+    </button>
+  );
+}
+
+describe("useChatModels", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}")),
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not probe framework model endpoints when disabled", async () => {
+    await act(async () => {
+      root.render(<ChatModelsProbe enabled={false} />);
+      await Promise.resolve();
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      container.querySelector("button")?.click();
+      await Promise.resolve();
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/client/use-chat-models.ts
+++ b/packages/core/src/client/use-chat-models.ts
@@ -30,6 +30,11 @@ interface Options {
    * page loads. Pass `null` to disable persistence.
    */
   storageKey?: string | null;
+  /**
+   * Disable server-backed model discovery for hosts that provide their own
+   * model list/state, such as Electron Code.
+   */
+  enabled?: boolean;
 }
 
 const DEFAULT_STORAGE_KEY = "agent-native:chat-models:selection";
@@ -65,6 +70,7 @@ function writePersisted(key: string | null, value: PersistedSelection) {
  */
 export function useChatModels({
   storageKey = DEFAULT_STORAGE_KEY,
+  enabled = true,
 }: Options = {}): UseChatModelsResult {
   const [availableModels, setAvailableModels] = useState<EngineModelGroup[]>(
     [],
@@ -128,6 +134,7 @@ export function useChatModels({
   );
 
   const refreshEngines = useCallback(() => {
+    if (!enabled) return;
     Promise.all([
       fetch(agentNativePath("/_agent-native/actions/manage-agent-engine"), {
         method: "POST",
@@ -311,11 +318,12 @@ export function useChatModels({
         }
       })
       .catch(() => {});
-  }, [storageKey]);
+  }, [enabled, storageKey]);
 
   useEffect(() => {
+    if (!enabled) return;
     refreshEngines();
-  }, [refreshEngines]);
+  }, [enabled, refreshEngines]);
 
   return {
     availableModels,

--- a/packages/core/src/code-agents/background-controller.ts
+++ b/packages/core/src/code-agents/background-controller.ts
@@ -2,6 +2,7 @@ import {
   executeExistingCodeAgentRun,
   executePendingCodeAgentApproval,
 } from "../cli/code-agent-executor.js";
+import type { AgentPromptAttachment } from "./prompt-attachments.js";
 import {
   appendCodeAgentTranscriptEvent,
   getCodeAgentRunRecord,
@@ -174,6 +175,9 @@ async function sendLocalCodeBackgroundAgentFollowUp(
       delivery: shouldQueue ? mode : "run-now",
     },
   });
+  const attachments = promptAttachmentsFromMetadata(
+    input.metadata?.attachments,
+  );
 
   if (shouldQueue) {
     queueCodeAgentFollowUp({
@@ -184,6 +188,7 @@ async function sendLocalCodeBackgroundAgentFollowUp(
       permissionMode: input.permissionMode,
       source: input.source ?? "background-agent-controller",
       createdAt: event.createdAt,
+      attachments,
     });
     return {
       ok: true,
@@ -199,6 +204,7 @@ async function sendLocalCodeBackgroundAgentFollowUp(
     appendUserEvent: false,
     model: input.model,
     reasoningEffort: input.reasoningEffort,
+    attachments,
     stdout: input.stdout,
   });
   return {
@@ -340,6 +346,23 @@ function stopLocalCodeBackgroundAgentRun(
       : undefined,
     error: updated ? undefined : `Run not found: ${runId}`,
   };
+}
+
+function promptAttachmentsFromMetadata(
+  value: unknown,
+): AgentPromptAttachment[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is Record<string, unknown> =>
+      Boolean(item && typeof item === "object" && !Array.isArray(item)),
+    )
+    .map((item) => ({
+      name: typeof item.name === "string" && item.name ? item.name : "file",
+      ...(typeof item.type === "string" ? { type: item.type } : {}),
+      ...(typeof item.size === "number" ? { size: item.size } : {}),
+      ...(typeof item.text === "string" ? { text: item.text } : {}),
+      ...(typeof item.dataUrl === "string" ? { dataUrl: item.dataUrl } : {}),
+    }));
 }
 
 function currentBackgroundRun(runId: string): BackgroundAgentRun | null {

--- a/packages/core/src/code-agents/index.ts
+++ b/packages/core/src/code-agents/index.ts
@@ -33,6 +33,14 @@ export {
   type NormalizedCodeAgentUserTurn,
 } from "./transcript-normalizer.js";
 export {
+  compareCodeAgentTranscriptEvents,
+  getCodeAgentTranscriptSeq,
+  isCodeAgentRunActive,
+  mergeCodeAgentTranscriptEvents,
+  type CodeAgentRunStateLike,
+  type CodeAgentTranscriptOrderEvent,
+} from "./transcript-order.js";
+export {
   CODE_AGENT_PERMISSION_MODES,
   appendCodeAgentTranscriptEvent,
   codeAgentRunArtifactsDir,

--- a/packages/core/src/code-agents/index.ts
+++ b/packages/core/src/code-agents/index.ts
@@ -41,6 +41,11 @@ export {
   type CodeAgentTranscriptOrderEvent,
 } from "./transcript-order.js";
 export {
+  escapePromptAttachmentAttribute,
+  formatPromptWithAttachments,
+  type AgentPromptAttachment,
+} from "./prompt-attachments.js";
+export {
   CODE_AGENT_PERMISSION_MODES,
   appendCodeAgentTranscriptEvent,
   codeAgentRunArtifactsDir,

--- a/packages/core/src/code-agents/prompt-attachments.ts
+++ b/packages/core/src/code-agents/prompt-attachments.ts
@@ -1,0 +1,39 @@
+export interface AgentPromptAttachment {
+  name: string;
+  type?: string;
+  size?: number;
+  text?: string;
+  /** Base64 data URL for image attachments (e.g. "data:image/png;base64,..."). */
+  dataUrl?: string;
+}
+
+export function formatPromptWithAttachments(
+  prompt: string,
+  attachments: readonly AgentPromptAttachment[],
+): string {
+  if (attachments.length === 0) return prompt;
+  const attachmentText = attachments
+    .map((attachment) => {
+      const size = attachment.size ? ` size="${attachment.size}"` : "";
+      const type = attachment.type
+        ? ` type="${escapePromptAttachmentAttribute(attachment.type)}"`
+        : "";
+      if (attachment.dataUrl) {
+        return `<attached-image name="${escapePromptAttachmentAttribute(
+          attachment.name,
+        )}"${type}${size}>\n${attachment.dataUrl}\n</attached-image>`;
+      }
+      const body =
+        attachment.text?.trim() ||
+        "Selected in the UI. If this file is needed, inspect it from the workspace or ask for a readable copy.";
+      return `<attached-file name="${escapePromptAttachmentAttribute(
+        attachment.name,
+      )}"${type}${size}>\n${body}\n</attached-file>`;
+    })
+    .join("\n\n");
+  return `${prompt.trimEnd()}\n\nAttached context:\n${attachmentText}`;
+}
+
+export function escapePromptAttachmentAttribute(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}

--- a/packages/core/src/code-agents/transcript-normalizer.spec.ts
+++ b/packages/core/src/code-agents/transcript-normalizer.spec.ts
@@ -96,6 +96,51 @@ describe("normalizeCodeAgentTranscript", () => {
     ]);
   });
 
+  it("preserves streaming assistant_delta spaces before a final duplicate arrives", () => {
+    const events = [
+      event("evt-user", "user", "Check the diff."),
+      event("evt-delta-1", "system", "Now let", {
+        type: "assistant_delta",
+        seq: 1,
+      }),
+      event("evt-delta-2", "system", " me check", {
+        type: "assistant_delta",
+        seq: 2,
+      }),
+      event("evt-delta-3", "system", " the remaining", {
+        type: "assistant_delta",
+        seq: 3,
+      }),
+      event("evt-delta-4", "system", " diffs to", {
+        type: "assistant_delta",
+        seq: 4,
+      }),
+      event("evt-delta-5", "system", " ", {
+        type: "assistant_delta",
+        seq: 5,
+      }),
+      event("evt-delta-6", "system", "make", {
+        type: "assistant_delta",
+        seq: 6,
+      }),
+      event("evt-delta-7", "system", " sure everything is clean.", {
+        type: "assistant_delta",
+        seq: 7,
+      }),
+    ];
+
+    const transcript = normalizeCodeAgentTranscript(events);
+
+    expect(transcript.items).toEqual([
+      expect.objectContaining({ type: "user" }),
+      expect.objectContaining({
+        type: "assistant",
+        source: "runner-stdout",
+        text: "Now let me check the remaining diffs to make sure everything is clean.",
+      }),
+    ]);
+  });
+
   it("keeps regular assistant system messages when they are not stdout duplicates", () => {
     const events = [
       event("evt-user", "user", "Summarize the changes."),

--- a/packages/core/src/code-agents/transcript-normalizer.ts
+++ b/packages/core/src/code-agents/transcript-normalizer.ts
@@ -455,19 +455,33 @@ function assistantTextForEvent(
   event: CodeAgentTranscriptEvent,
   source: NormalizedCodeAgentAssistantTurn["source"],
 ): string {
-  if (source === "runner-stdout") return stripRunnerDiagnostics(event.message);
+  if (source === "runner-stdout") {
+    return stripRunnerDiagnostics(event.message, {
+      trim: !isAssistantDeltaEvent(event),
+    });
+  }
   return event.message;
 }
 
-function stripRunnerDiagnostics(value: string): string {
-  return value
+function stripRunnerDiagnostics(
+  value: string,
+  options: { trim?: boolean } = {},
+): string {
+  const stripped = value
     .replace(RUNNER_DIAGNOSTIC_LINE_PATTERNS.engineDetect, "")
-    .replace(RUNNER_DIAGNOSTIC_LINE_PATTERNS.builderEngine, "");
+    .replace(RUNNER_DIAGNOSTIC_LINE_PATTERNS.builderEngine, "")
+    .replace(RUNNER_DIAGNOSTIC_LINE_PATTERNS.sessionStartedBanner, "");
+  return options.trim === false ? stripped : stripped.trim();
 }
 
 const RUNNER_DIAGNOSTIC_LINE_PATTERNS = {
   engineDetect: /^\[engine-detect\][^\r\n]*(?:\r?\n|$)/gm,
   builderEngine: /^\[builder-engine\]\s*[←→][^\r\n]*(?:\r?\n|$)/gm,
+  // Strip the "Agent-Native Code session started." banner block that the CLI
+  // prints to stdout at the start of every run. It is informational for
+  // terminal users but clutters the chat transcript.
+  sessionStartedBanner:
+    /\n?Agent-Native Code session started\.[\s\S]*?Streaming output below\. The transcript is saved with this run\.\n?/,
 };
 
 function toolEventType(

--- a/packages/core/src/code-agents/transcript-order.spec.ts
+++ b/packages/core/src/code-agents/transcript-order.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareCodeAgentTranscriptEvents,
+  isCodeAgentRunActive,
+  mergeCodeAgentTranscriptEvents,
+} from "./transcript-order.js";
+
+describe("code agent transcript order", () => {
+  it("orders by seq before timestamp and id", () => {
+    const events = [
+      {
+        id: "later",
+        createdAt: "2026-05-17T12:00:00.000Z",
+        metadata: { seq: 2 },
+      },
+      {
+        id: "earlier",
+        createdAt: "2026-05-17T12:05:00.000Z",
+        metadata: { seq: 1 },
+      },
+    ];
+
+    expect([...events].sort(compareCodeAgentTranscriptEvents)).toEqual([
+      events[1],
+      events[0],
+    ]);
+  });
+
+  it("merges duplicate event ids with the newest copy", () => {
+    const merged = mergeCodeAgentTranscriptEvents(
+      [
+        {
+          id: "evt-1",
+          createdAt: "2026-05-17T12:00:00.000Z",
+          metadata: { seq: 1, text: "old" },
+        },
+      ],
+      [
+        {
+          id: "evt-1",
+          createdAt: "2026-05-17T12:00:00.000Z",
+          metadata: { seq: 1, text: "new" },
+        },
+        {
+          id: "evt-2",
+          createdAt: "2026-05-17T12:01:00.000Z",
+          metadata: { seq: 2 },
+        },
+      ],
+    );
+
+    expect(merged.map((event) => event.id)).toEqual(["evt-1", "evt-2"]);
+    expect(merged[0]?.metadata?.text).toBe("new");
+  });
+});
+
+describe("isCodeAgentRunActive", () => {
+  it("treats running and queued phases as active", () => {
+    expect(isCodeAgentRunActive({ status: "running" })).toBe(true);
+    expect(isCodeAgentRunActive({ status: "queued" })).toBe(true);
+  });
+
+  it("treats terminal and approval states as inactive", () => {
+    expect(isCodeAgentRunActive({ status: "completed" })).toBe(false);
+    expect(isCodeAgentRunActive({ phase: "missing-credentials" })).toBe(false);
+    expect(isCodeAgentRunActive({ needsApproval: true })).toBe(false);
+    expect(
+      isCodeAgentRunActive({
+        status: "running",
+        metadata: { runnerState: "stopped" },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/code-agents/transcript-order.ts
+++ b/packages/core/src/code-agents/transcript-order.ts
@@ -1,0 +1,73 @@
+export interface CodeAgentTranscriptOrderEvent {
+  id: string;
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CodeAgentRunStateLike {
+  status?: string;
+  phase?: string;
+  needsApproval?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export function getCodeAgentTranscriptSeq(
+  event: CodeAgentTranscriptOrderEvent,
+): number | null {
+  const value = event.metadata?.seq;
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function compareCodeAgentTranscriptEvents<
+  TEvent extends CodeAgentTranscriptOrderEvent,
+>(a: TEvent, b: TEvent): number {
+  const seqA = getCodeAgentTranscriptSeq(a);
+  const seqB = getCodeAgentTranscriptSeq(b);
+  if (seqA !== null && seqB !== null && seqA !== seqB) return seqA - seqB;
+  const created = a.createdAt.localeCompare(b.createdAt);
+  if (created !== 0) return created;
+  return a.id.localeCompare(b.id);
+}
+
+export function mergeCodeAgentTranscriptEvents<
+  TEvent extends CodeAgentTranscriptOrderEvent,
+>(current: readonly TEvent[], incoming: readonly TEvent[]): TEvent[] {
+  if (incoming.length === 0) return [...current];
+  const byId = new Map(current.map((event) => [event.id, event]));
+  for (const event of incoming) byId.set(event.id, event);
+  return [...byId.values()].sort(compareCodeAgentTranscriptEvents);
+}
+
+export function isCodeAgentRunActive(run: CodeAgentRunStateLike): boolean {
+  const runnerState = stringMetadata(run.metadata, "runnerState");
+  if (
+    runnerState === "exited" ||
+    runnerState === "failed" ||
+    runnerState === "interrupted" ||
+    runnerState === "stopped"
+  ) {
+    return false;
+  }
+
+  return !(
+    run.needsApproval ||
+    run.status === "completed" ||
+    run.status === "errored" ||
+    run.status === "needs-approval" ||
+    run.status === "paused" ||
+    run.phase === "complete" ||
+    run.phase === "error" ||
+    run.phase === "approval-required" ||
+    run.phase === "paused" ||
+    run.phase === "missing-credentials" ||
+    run.phase === "stopped"
+  );
+}
+
+function stringMetadata(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = metadata?.[key];
+  return typeof value === "string" ? value : undefined;
+}

--- a/packages/core/src/extensions/routes.ts
+++ b/packages/core/src/extensions/routes.ts
@@ -29,9 +29,10 @@ import {
 import { buildExtensionHtml, EXTENSION_IFRAME_CSP } from "./html-shell.js";
 import { getThemeVars } from "./theme.js";
 import {
-  resolveKeyReferences,
+  resolveKeyReferencesWithRequestScopes,
   validateUrlAllowlist,
-  getKeyAllowlist,
+  getResolvedKeyAllowlist,
+  type ResolvedKeyReference,
 } from "../secrets/substitution.js";
 import {
   collectSecretValues,
@@ -488,33 +489,34 @@ async function handleProxy(
   let resolvedUrl = rawUrl;
   let resolvedHeaders = JSON.stringify(rawHeaders);
   let resolvedBody = rawBody;
-  const allUsedKeys: string[] = [];
   const allSecretValues: string[] = [];
+  const allResolvedKeys: ResolvedKeyReference[] = [];
 
   try {
-    const urlResult = await resolveKeyReferences(rawUrl, "user", userEmail);
+    const urlResult = await resolveKeyReferencesWithRequestScopes(
+      rawUrl,
+      userEmail,
+    );
     resolvedUrl = urlResult.resolved;
-    allUsedKeys.push(...urlResult.usedKeys);
     allSecretValues.push(...urlResult.secretValues);
+    allResolvedKeys.push(...(urlResult.resolvedKeys ?? []));
 
-    const headerResult = await resolveKeyReferences(
+    const headerResult = await resolveKeyReferencesWithRequestScopes(
       resolvedHeaders,
-      "user",
       userEmail,
     );
     resolvedHeaders = headerResult.resolved;
-    allUsedKeys.push(...headerResult.usedKeys);
     allSecretValues.push(...headerResult.secretValues);
+    allResolvedKeys.push(...(headerResult.resolvedKeys ?? []));
 
     if (rawBody) {
-      const bodyResult = await resolveKeyReferences(
+      const bodyResult = await resolveKeyReferencesWithRequestScopes(
         typeof rawBody === "string" ? rawBody : JSON.stringify(rawBody),
-        "user",
         userEmail,
       );
       resolvedBody = bodyResult.resolved;
-      allUsedKeys.push(...bodyResult.usedKeys);
       allSecretValues.push(...bodyResult.secretValues);
+      allResolvedKeys.push(...(bodyResult.resolvedKeys ?? []));
     }
   } catch (err: any) {
     setResponseStatus(event, 400);
@@ -527,12 +529,18 @@ async function handleProxy(
     return { error: "Requests to private/internal addresses are not allowed" };
   }
 
-  for (const keyName of new Set(allUsedKeys)) {
-    const allowlist = await getKeyAllowlist(keyName, "user", userEmail);
+  const uniqueResolvedKeys = new Map(
+    allResolvedKeys.map((ref) => [
+      `${ref.name}:${ref.scope}:${ref.scopeId}`,
+      ref,
+    ]),
+  );
+  for (const keyRef of uniqueResolvedKeys.values()) {
+    const allowlist = await getResolvedKeyAllowlist(keyRef);
     if (!validateUrlAllowlist(resolvedUrl, allowlist)) {
       setResponseStatus(event, 403);
       return {
-        error: `Key "${keyName}" is not allowed for this URL origin`,
+        error: `Key "${keyRef.name}" is not allowed for this URL origin`,
       };
     }
   }
@@ -595,12 +603,12 @@ async function handleProxy(
         return { error: "Redirect to private/internal address blocked" };
       }
       if (redirectUrl) {
-        for (const keyName of new Set(allUsedKeys)) {
-          const allowlist = await getKeyAllowlist(keyName, "user", userEmail);
+        for (const keyRef of uniqueResolvedKeys.values()) {
+          const allowlist = await getResolvedKeyAllowlist(keyRef);
           if (!validateUrlAllowlist(redirectUrl, allowlist)) {
             setResponseStatus(event, 403);
             return {
-              error: `Redirect URL is not allowed for key "${keyName}"`,
+              error: `Redirect URL is not allowed for key "${keyRef.name}"`,
             };
           }
         }

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -21,6 +21,10 @@
 import type { ActionEntry } from "../agent/production-agent.js";
 import { runWithRequestContext } from "../server/request-context.js";
 import { toAbsoluteOpenUrl, toDesktopOpenUrl } from "../server/deep-link.js";
+import {
+  isAgentNativeOpenDeepLink,
+  withCollapsedAgentSidebarParam,
+} from "../shared/agent-sidebar-url.js";
 import { getBuiltinCrossAppTools } from "./builtin-tools.js";
 import { MCP_CONNECT_SCOPE } from "./connect-store.js";
 
@@ -118,8 +122,11 @@ export function buildLinkArtifacts(
   try {
     const lk = entry.link({ args: args ?? {}, result });
     if (!lk?.url) return {};
-    const webUrl = toAbsoluteOpenUrl(lk.url, meta?.origin);
-    const desktopUrl = toDesktopOpenUrl(lk.url);
+    const linkUrl = isAgentNativeOpenDeepLink(lk.url)
+      ? withCollapsedAgentSidebarParam(lk.url)
+      : lk.url;
+    const webUrl = toAbsoluteOpenUrl(linkUrl, meta?.origin);
+    const desktopUrl = toDesktopOpenUrl(linkUrl);
     const markdownUrl = meta?.target === "desktop" ? desktopUrl : webUrl;
     return {
       block: { type: "text", text: `\n\n[${lk.label} →](${markdownUrl})` },

--- a/packages/core/src/mcp/builtin-cross-app.spec.ts
+++ b/packages/core/src/mcp/builtin-cross-app.spec.ts
@@ -129,7 +129,7 @@ describe("open_app — same-app / standalone keeps a relative deep link", () => 
       params: { threadId: "abc" },
     });
     expect(result.url).toBe(
-      "/_agent-native/open?app=mail&view=inbox&threadId=abc",
+      "/_agent-native/open?app=mail&view=inbox&threadId=abc&agentSidebar=closed",
     );
     expect(result.url.startsWith("/")).toBe(true);
   });

--- a/packages/core/src/mcp/deep-link.spec.ts
+++ b/packages/core/src/mcp/deep-link.spec.ts
@@ -11,10 +11,10 @@ describe("buildDeepLink", () => {
   it("always starts with the open-route path and emits view", () => {
     const url = buildDeepLink({ view: "inbox" });
     expect(url.startsWith(`/_agent-native${OPEN_ROUTE_SUBPATH}?`)).toBe(true);
-    expect(url).toBe("/_agent-native/open?view=inbox");
+    expect(url).toBe("/_agent-native/open?view=inbox&agentSidebar=closed");
   });
 
-  it("orders app, view, to, compose before params", () => {
+  it("orders app, view, to, compose before params and the sidebar hint", () => {
     const url = buildDeepLink({
       app: "mail",
       view: "inbox",
@@ -23,7 +23,7 @@ describe("buildDeepLink", () => {
       params: { threadId: "abc123" },
     });
     expect(url).toBe(
-      "/_agent-native/open?app=mail&view=inbox&to=%2Finbox%2Fabc&compose=Zm9v&threadId=abc123",
+      "/_agent-native/open?app=mail&view=inbox&to=%2Finbox%2Fabc&compose=Zm9v&threadId=abc123&agentSidebar=closed",
     );
   });
 
@@ -50,7 +50,9 @@ describe("buildDeepLink", () => {
 
   it("omits optional app/to/compose when not provided", () => {
     const url = buildDeepLink({ view: "calendar", params: { eventId: "e1" } });
-    expect(url).toBe("/_agent-native/open?view=calendar&eventId=e1");
+    expect(url).toBe(
+      "/_agent-native/open?view=calendar&eventId=e1&agentSidebar=closed",
+    );
   });
 
   it("url-encodes param values", () => {

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -256,14 +256,14 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     // Second block: the appended markdown deep link, absolutized to the
     // request origin derived from the inbound Host header.
     expect(content[1].text).toContain(
-      "[Open in Mail →](https://mail.agent-native.com/_agent-native/open?view=thing&id=thing-42)",
+      "[Open in Mail →](https://mail.agent-native.com/_agent-native/open?view=thing&id=thing-42&agentSidebar=closed)",
     );
     // Structured `_meta` so a desktop client can open it natively.
     expect(out.result._meta["agent-native/openLink"]).toMatchObject({
       label: "Open in Mail",
       view: "thing",
       webUrl:
-        "https://mail.agent-native.com/_agent-native/open?view=thing&id=thing-42",
+        "https://mail.agent-native.com/_agent-native/open?view=thing&id=thing-42&agentSidebar=closed",
     });
     expect(out.result._meta["agent-native/openLink"].desktopUrl).toContain(
       "view=thing&id=thing-42",

--- a/packages/core/src/secrets/substitution.spec.ts
+++ b/packages/core/src/secrets/substitution.spec.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockReadAppSecret = vi.fn();
+const mockReadAppSecretMeta = vi.fn();
+const mockGetRequestOrgId = vi.fn();
+const mockGetRequestUserEmail = vi.fn();
+
+vi.mock("./storage.js", () => ({
+  readAppSecret: (...args: any[]) => mockReadAppSecret(...args),
+  readAppSecretMeta: (...args: any[]) => mockReadAppSecretMeta(...args),
+}));
+
+vi.mock("../server/request-context.js", () => ({
+  getRequestOrgId: (...args: any[]) => mockGetRequestOrgId(...args),
+  getRequestUserEmail: (...args: any[]) => mockGetRequestUserEmail(...args),
+}));
+
+import {
+  getResolvedKeyAllowlist,
+  resolveKeyReferencesWithRequestScopes,
+} from "./substitution.js";
+
+describe("resolveKeyReferencesWithRequestScopes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRequestOrgId.mockReturnValue("org_123");
+    mockGetRequestUserEmail.mockReturnValue("alice@example.test");
+    mockReadAppSecret.mockResolvedValue(null);
+    mockReadAppSecretMeta.mockResolvedValue(null);
+  });
+
+  it("falls back from user scope to active org scope", async () => {
+    mockReadAppSecret.mockImplementation(async ({ scope }) =>
+      scope === "org" ? { value: "org-token" } : null,
+    );
+
+    const result = await resolveKeyReferencesWithRequestScopes(
+      "Bearer ${keys.GITHUB_TOKEN}",
+      "alice@example.test",
+    );
+
+    expect(result.resolved).toBe("Bearer org-token");
+    expect(result.usedKeys).toEqual(["GITHUB_TOKEN"]);
+    expect(result.secretValues).toEqual(["org-token"]);
+    expect(result.resolvedKeys).toEqual([
+      {
+        name: "GITHUB_TOKEN",
+        scope: "org",
+        scopeId: "org_123",
+      },
+    ]);
+    expect(mockReadAppSecret).toHaveBeenCalledWith({
+      key: "GITHUB_TOKEN",
+      scope: "user",
+      scopeId: "alice@example.test",
+    });
+    expect(mockReadAppSecret).toHaveBeenCalledWith({
+      key: "GITHUB_TOKEN",
+      scope: "org",
+      scopeId: "org_123",
+    });
+  });
+
+  it("uses solo workspace scope when no org is active", async () => {
+    mockGetRequestOrgId.mockReturnValue(null);
+    mockReadAppSecret.mockImplementation(async ({ scope, scopeId }) =>
+      scope === "workspace" && scopeId === "solo:alice@example.test"
+        ? { value: "solo-token" }
+        : null,
+    );
+
+    const result = await resolveKeyReferencesWithRequestScopes(
+      "token=${keys.API_TOKEN}",
+      "alice@example.test",
+    );
+
+    expect(result.resolved).toBe("token=solo-token");
+    expect(result.resolvedKeys).toEqual([
+      {
+        name: "API_TOKEN",
+        scope: "workspace",
+        scopeId: "solo:alice@example.test",
+      },
+    ]);
+  });
+
+  it("reads allowlists from the resolved scope", async () => {
+    mockReadAppSecretMeta.mockResolvedValue({
+      urlAllowlist: ["https://api.github.com"],
+    });
+
+    await expect(
+      getResolvedKeyAllowlist({
+        name: "GITHUB_TOKEN",
+        scope: "org",
+        scopeId: "org_123",
+      }),
+    ).resolves.toEqual(["https://api.github.com"]);
+
+    expect(mockReadAppSecretMeta).toHaveBeenCalledWith({
+      key: "GITHUB_TOKEN",
+      scope: "org",
+      scopeId: "org_123",
+    });
+  });
+});

--- a/packages/core/src/secrets/substitution.ts
+++ b/packages/core/src/secrets/substitution.ts
@@ -50,6 +50,13 @@ export interface ResolveKeyReferencesResult {
   resolved: string;
   usedKeys: string[];
   secretValues: string[];
+  resolvedKeys?: ResolvedKeyReference[];
+}
+
+export interface ResolvedKeyReference {
+  name: string;
+  scope: SecretScope;
+  scopeId: string;
 }
 
 /**
@@ -110,6 +117,87 @@ export async function resolveKeyReferences(
 }
 
 /**
+ * Resolve `${keys.NAME}` for browser extension fetches and other request-bound
+ * code paths that should honor the active workspace's shared credential store.
+ *
+ * Lookup order:
+ * 1. user scope for personal overrides
+ * 2. active org scope (Dispatch vault sync writes here for org workspaces)
+ * 3. active org workspace scope (legacy shared rows)
+ * 4. solo workspace scope when no org is active
+ */
+export async function resolveKeyReferencesWithRequestScopes(
+  text: string,
+  userScopeId: string,
+): Promise<ResolveKeyReferencesResult> {
+  const usedKeys: string[] = [];
+  const matches = Array.from(text.matchAll(KEY_REFERENCE_REGEX));
+  if (matches.length === 0) {
+    return { resolved: text, usedKeys, secretValues: [], resolvedKeys: [] };
+  }
+
+  const resolutions = new Map<string, string>();
+  const resolvedKeys: ResolvedKeyReference[] = [];
+  const secretValues: string[] = [];
+  for (const match of matches) {
+    const name = match[1];
+    if (resolutions.has(name)) continue;
+
+    const result = await readRequestScopedSecret(name, userScopeId);
+    if (!result) {
+      throw new Error(
+        `Referenced key "${name}" is not defined for this user or active workspace. Create it in Settings or the Dispatch vault before using this extension.`,
+      );
+    }
+    resolutions.set(name, result.value);
+    usedKeys.push(name);
+    resolvedKeys.push(result.ref);
+    if (result.value) secretValues.push(result.value);
+  }
+
+  const resolved = text.replace(KEY_REFERENCE_REGEX, (_, name: string) => {
+    const value = resolutions.get(name);
+    if (value === undefined) {
+      throw new Error(`Referenced key "${name}" was not resolved`);
+    }
+    return value;
+  });
+
+  return { resolved, usedKeys, secretValues, resolvedKeys };
+}
+
+async function readRequestScopedSecret(
+  name: string,
+  userScopeId: string,
+): Promise<{ value: string; ref: ResolvedKeyReference } | null> {
+  const candidates = requestSecretCandidates(userScopeId);
+  for (const ref of candidates) {
+    const result = await readAppSecret({ key: name, ...ref });
+    if (result) return { value: result.value, ref: { name, ...ref } };
+  }
+  return null;
+}
+
+function requestSecretCandidates(
+  userScopeId: string,
+): Array<{ scope: SecretScope; scopeId: string }> {
+  const orgId = getRequestOrgId();
+  if (orgId) {
+    return [
+      { scope: "user", scopeId: userScopeId },
+      { scope: "org", scopeId: orgId },
+      { scope: "workspace", scopeId: orgId },
+    ];
+  }
+
+  const email = getRequestUserEmail() || userScopeId;
+  return [
+    { scope: "user", scopeId: userScopeId },
+    { scope: "workspace", scopeId: `solo:${email}` },
+  ];
+}
+
+/**
  * Check if a URL is allowed by a key's URL allowlist. Returns true when no
  * allowlist is configured (permissive default — the allowlist is opt-in).
  *
@@ -160,6 +248,17 @@ export async function getKeyAllowlist(
       scopeId: getWorkspaceScopeId(scopeId),
     });
   }
+  return meta?.urlAllowlist ?? null;
+}
+
+export async function getResolvedKeyAllowlist(
+  ref: ResolvedKeyReference,
+): Promise<string[] | null> {
+  const meta = await readAppSecretMeta({
+    key: ref.name,
+    scope: ref.scope,
+    scopeId: ref.scopeId,
+  });
   return meta?.urlAllowlist ?? null;
 }
 

--- a/packages/core/src/server/deep-link.ts
+++ b/packages/core/src/server/deep-link.ts
@@ -16,6 +16,7 @@
  * bridges external surfaces to the `navigate`/`application_state` contract the
  * UI already drains every 2s.
  */
+import { withCollapsedAgentSidebarParam } from "../shared/agent-sidebar-url.js";
 
 /** Path of the framework deep-link route, relative to the route prefix. */
 export const OPEN_ROUTE_SUBPATH = "/open";
@@ -57,7 +58,9 @@ function buildQuery(input: DeepLinkInput): string {
  * Per-app `link` builders call this; never hand-format the URL.
  */
 export function buildDeepLink(input: DeepLinkInput): string {
-  return `/_agent-native${OPEN_ROUTE_SUBPATH}?${buildQuery(input)}`;
+  return withCollapsedAgentSidebarParam(
+    `/_agent-native${OPEN_ROUTE_SUBPATH}?${buildQuery(input)}`,
+  );
 }
 
 /**

--- a/packages/core/src/server/open-route.spec.ts
+++ b/packages/core/src/server/open-route.spec.ts
@@ -16,9 +16,11 @@ vi.mock("./auth.js", () => ({
 }));
 
 const appStatePut = vi.hoisted(() => vi.fn());
+const appStateGet = vi.hoisted(() => vi.fn());
 
 vi.mock("../application-state/store.js", () => ({
   appStatePut: (...a: any[]) => appStatePut(...a),
+  appStateGet: (...a: any[]) => appStateGet(...a),
 }));
 
 import { createOpenRouteHandler } from "./open-route.js";
@@ -34,6 +36,8 @@ describe("createOpenRouteHandler", () => {
     getConfiguredLoginHtml.mockReset();
     appStatePut.mockReset();
     appStatePut.mockResolvedValue(undefined);
+    appStateGet.mockReset();
+    appStateGet.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -45,7 +49,9 @@ describe("createOpenRouteHandler", () => {
     const handler = createOpenRouteHandler();
 
     const res: Response = await handler(
-      fakeEvent("/_agent-native/open?app=mail&view=inbox&threadId=abc123"),
+      fakeEvent(
+        "/_agent-native/open?app=mail&view=inbox&threadId=abc123&agentSidebar=closed",
+      ),
     );
 
     expect(appStatePut).toHaveBeenCalledTimes(1);
@@ -56,7 +62,7 @@ describe("createOpenRouteHandler", () => {
     expect(options).toEqual({ requestSource: "deep-link" });
 
     expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toBe("/inbox");
+    expect(res.headers.get("Location")).toBe("/inbox?agentSidebar=closed");
   });
 
   it("unauthenticated returns the configured login HTML with status 200 and no app-state write", async () => {
@@ -95,7 +101,7 @@ describe("createOpenRouteHandler", () => {
     );
 
     expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toBe("/inbox");
+    expect(res.headers.get("Location")).toBe("/inbox?agentSidebar=closed");
   });
 
   it("open-redirect guard rejects an absolute `to` URL and falls back to /<view>", async () => {
@@ -109,7 +115,7 @@ describe("createOpenRouteHandler", () => {
     );
 
     expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toBe("/dashboard");
+    expect(res.headers.get("Location")).toBe("/dashboard?agentSidebar=closed");
   });
 
   it("open-redirect guard rejects a control-char `to` and, with no view, falls back to /", async () => {
@@ -122,7 +128,7 @@ describe("createOpenRouteHandler", () => {
     );
 
     expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toBe("/");
+    expect(res.headers.get("Location")).toBe("/?agentSidebar=closed");
   });
 
   it("forwards f_* filter params onto the redirect Location", async () => {
@@ -141,6 +147,7 @@ describe("createOpenRouteHandler", () => {
     const sp = new URL(loc, "http://x.invalid").searchParams;
     expect(sp.get("f_range")).toBe("30d");
     expect(sp.get("f_team")).toBe("growth");
+    expect(sp.get("agentSidebar")).toBe("closed");
     // Non-filter record ids are NOT forwarded onto the URL (they ride the
     // navigate app-state command instead).
     expect(sp.has("dashboardId")).toBe(false);
@@ -164,7 +171,9 @@ describe("createOpenRouteHandler", () => {
     );
 
     expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toBe("/inbox/abc123");
+    expect(res.headers.get("Location")).toBe(
+      "/inbox/abc123?agentSidebar=closed",
+    );
   });
 
   it("uses resolveOpenPath when provided and `to` is absent", async () => {
@@ -179,6 +188,6 @@ describe("createOpenRouteHandler", () => {
     );
 
     expect(res.status).toBe(302);
-    expect(res.headers.get("Location")).toBe("/email/t9");
+    expect(res.headers.get("Location")).toBe("/email/t9?agentSidebar=closed");
   });
 });

--- a/packages/core/src/server/open-route.ts
+++ b/packages/core/src/server/open-route.ts
@@ -25,9 +25,19 @@ import type { H3Event } from "h3";
 import { defineEventHandler, getMethod } from "h3";
 import { getSession, getConfiguredLoginHtml } from "./auth.js";
 import { appStatePut, appStateGet } from "../application-state/store.js";
+import {
+  AGENT_SIDEBAR_QUERY_PARAM,
+  withCollapsedAgentSidebarParam,
+} from "../shared/agent-sidebar-url.js";
 
 /** Query keys that are route control, not navigation payload. */
-const RESERVED = new Set(["app", "view", "to", "compose"]);
+const RESERVED = new Set([
+  "app",
+  "view",
+  "to",
+  "compose",
+  AGENT_SIDEBAR_QUERY_PARAM,
+]);
 
 // Control-char guard (NUL..US + DEL). Defined via codepoints so the source
 // file stays plain ASCII.
@@ -77,6 +87,17 @@ function redirect(location: string): Response {
   // Native web Response (not h3 v2's reworked sendRedirect) — matches the
   // redirect pattern used elsewhere in auth.ts.
   return new Response("", { status: 302, headers: { Location: location } });
+}
+
+function appendSearchParams(target: string, params: URLSearchParams): string {
+  if (!params.toString()) return target;
+  try {
+    const url = new URL(target, "http://an.invalid");
+    for (const [k, v] of params.entries()) url.searchParams.set(k, v);
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return target;
+  }
 }
 
 export function createOpenRouteHandler(options: OpenRouteOptions = {}) {
@@ -195,8 +216,8 @@ export function createOpenRouteHandler(options: OpenRouteOptions = {}) {
     for (const [k, v] of search.entries()) {
       if (k.startsWith("f_")) filters.set(k, v);
     }
-    const fq = filters.toString();
-    if (fq) target += (target.includes("?") ? "&" : "?") + fq;
+    target = appendSearchParams(target, filters);
+    target = withCollapsedAgentSidebarParam(target);
 
     return redirect(target);
   });

--- a/packages/core/src/shared/agent-sidebar-url.ts
+++ b/packages/core/src/shared/agent-sidebar-url.ts
@@ -1,0 +1,39 @@
+export const AGENT_NATIVE_OPEN_PATH = "/_agent-native/open";
+export const AGENT_SIDEBAR_QUERY_PARAM = "agentSidebar";
+export const AGENT_SIDEBAR_QUERY_VALUE_CLOSED = "closed";
+
+const RELATIVE_URL_BASE = "http://agent-native.invalid";
+
+function hasUrlScheme(urlOrPath: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(urlOrPath);
+}
+
+export function isAgentNativeOpenDeepLink(urlOrPath: string): boolean {
+  try {
+    const absolute = hasUrlScheme(urlOrPath);
+    const url = absolute
+      ? new URL(urlOrPath)
+      : new URL(urlOrPath, RELATIVE_URL_BASE);
+    if (url.protocol === "agentnative:" && url.host === "open") return true;
+    return url.pathname === AGENT_NATIVE_OPEN_PATH;
+  } catch {
+    return false;
+  }
+}
+
+export function withCollapsedAgentSidebarParam(urlOrPath: string): string {
+  try {
+    const absolute = hasUrlScheme(urlOrPath);
+    const url = absolute
+      ? new URL(urlOrPath)
+      : new URL(urlOrPath, RELATIVE_URL_BASE);
+    url.searchParams.set(
+      AGENT_SIDEBAR_QUERY_PARAM,
+      AGENT_SIDEBAR_QUERY_VALUE_CLOSED,
+    );
+    if (absolute) return url.toString();
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return urlOrPath;
+  }
+}

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -32,3 +32,10 @@ export {
   type WorkspaceAppRouteAccessFromConfig,
   type WorkspaceAppAudience,
 } from "./workspace-app-audience.js";
+export {
+  AGENT_NATIVE_OPEN_PATH,
+  AGENT_SIDEBAR_QUERY_PARAM,
+  AGENT_SIDEBAR_QUERY_VALUE_CLOSED,
+  isAgentNativeOpenDeepLink,
+  withCollapsedAgentSidebarParam,
+} from "./agent-sidebar-url.js";

--- a/packages/core/src/styles/agent-conversation.css
+++ b/packages/core/src/styles/agent-conversation.css
@@ -1,0 +1,403 @@
+/* Shared conversation surface used by Code chat and other host-owned chats. */
+.agent-conversation {
+  position: relative;
+}
+
+.agent-conversation__error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid hsl(var(--destructive) / 0.24);
+  border-radius: var(--radius);
+  background: hsl(var(--destructive) / 0.08);
+  color: hsl(var(--destructive-foreground));
+  font-size: 12px;
+}
+
+.agent-conversation__empty {
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  color: hsl(var(--muted-foreground));
+  font-size: 12px;
+}
+
+.agent-conversation__empty span {
+  color: hsl(var(--muted-foreground));
+}
+
+.agent-conversation__scroll-bottom {
+  position: absolute;
+  right: 18px;
+  bottom: 92px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 999px;
+  background: hsl(var(--popover));
+  color: hsl(var(--foreground));
+  box-shadow: 0 10px 30px hsl(var(--background) / 0.28);
+  cursor: pointer;
+}
+
+.agent-conversation-message {
+  display: flex;
+  width: 100%;
+}
+
+.agent-conversation-message--user {
+  justify-content: flex-end;
+}
+
+.agent-conversation-message--assistant,
+.agent-conversation-message--system {
+  justify-content: flex-start;
+}
+
+.agent-conversation-message__body {
+  min-width: 0;
+  max-width: min(100%, 880px);
+}
+
+.agent-conversation-message--user .agent-conversation-message__body {
+  max-width: min(78%, 720px);
+  padding: 9px 11px;
+  border-radius: calc(var(--radius) + 4px);
+  background: hsl(var(--muted));
+}
+
+.agent-conversation-message--pending .agent-conversation-message__body {
+  opacity: 0.72;
+}
+
+.agent-conversation-message__part + .agent-conversation-message__part {
+  margin-top: 10px;
+}
+
+.agent-conversation-message__part--tool,
+.agent-conversation-message__part--notice,
+.agent-conversation-message__part--artifact {
+  display: block;
+}
+
+.agent-conversation-markdown {
+  color: hsl(var(--foreground) / 0.82);
+  font-size: 13px;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.agent-conversation-message--user .agent-conversation-markdown {
+  color: hsl(var(--foreground) / 0.92);
+}
+
+.agent-conversation-markdown > :first-child {
+  margin-top: 0;
+}
+
+.agent-conversation-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.agent-conversation-markdown p,
+.agent-conversation-markdown ul,
+.agent-conversation-markdown ol,
+.agent-conversation-markdown pre {
+  margin: 0 0 10px;
+}
+
+.agent-conversation-markdown ul,
+.agent-conversation-markdown ol {
+  padding-left: 20px;
+}
+
+.agent-conversation-markdown li {
+  margin: 3px 0;
+  padding-left: 2px;
+}
+
+.agent-conversation-markdown li > p {
+  margin: 0;
+}
+
+.agent-conversation-markdown strong {
+  color: hsl(var(--foreground) / 0.92);
+  font-weight: 650;
+}
+
+.agent-conversation-markdown a {
+  color: #60a5fa;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.agent-conversation-markdown a:hover {
+  color: #93c5fd;
+}
+
+.agent-conversation-markdown code {
+  border-radius: 4px;
+  background: hsl(var(--muted));
+  padding: 1px 4px;
+  font-size: 12px;
+}
+
+.agent-conversation-markdown pre {
+  max-width: 100%;
+  overflow: auto;
+  padding: 10px;
+  border-radius: var(--radius);
+  background: hsl(var(--muted) / 0.72);
+}
+
+.agent-conversation-markdown pre code {
+  display: block;
+  padding: 0;
+  background: transparent;
+  white-space: pre;
+}
+
+.agent-conversation-shiki {
+  margin: 0 0 10px;
+  border-radius: var(--radius);
+  overflow: hidden;
+  font-size: 12px;
+}
+
+.agent-conversation-shiki pre {
+  margin: 0;
+  padding: 10px 12px;
+  overflow-x: auto;
+  background: var(--shiki-light-bg, hsl(var(--muted) / 0.72));
+  color: var(--shiki-light, hsl(var(--foreground)));
+}
+
+.agent-conversation-shiki pre code {
+  background: transparent;
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+  white-space: pre;
+}
+
+.agent-conversation-shiki pre span {
+  color: var(--shiki-light);
+  background: var(--shiki-light-bg);
+}
+
+.dark .agent-conversation-shiki pre {
+  background: var(--shiki-dark-bg, hsl(var(--muted) / 0.72));
+  color: var(--shiki-dark, hsl(var(--foreground)));
+}
+
+.dark .agent-conversation-shiki pre span {
+  color: var(--shiki-dark);
+  background: var(--shiki-dark-bg);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not(.light) .agent-conversation-shiki pre {
+    background: var(--shiki-dark-bg, hsl(var(--muted) / 0.72));
+    color: var(--shiki-dark, hsl(var(--foreground)));
+  }
+  :root:not(.light) .agent-conversation-shiki pre span {
+    color: var(--shiki-dark);
+    background: var(--shiki-dark-bg);
+  }
+}
+
+.agent-conversation-tool {
+  width: 100%;
+  border: 1px solid hsl(var(--border) / 0.9);
+  border-radius: var(--radius);
+  background: hsl(var(--card) / 0.58);
+  color: hsl(var(--muted-foreground));
+  font-size: 12px;
+  box-sizing: border-box;
+}
+
+.agent-conversation-tool summary,
+.agent-conversation-tool:not(details) {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 32px;
+  padding: 0 10px;
+}
+
+.agent-conversation-tool summary {
+  cursor: pointer;
+}
+
+.agent-conversation-tool__icon {
+  display: inline-flex;
+  color: hsl(var(--foreground) / 0.7);
+}
+
+.agent-conversation-tool__name {
+  color: hsl(var(--foreground) / 0.82);
+  font-weight: 500;
+}
+
+.agent-conversation-tool__summary {
+  margin-left: auto;
+  font-size: 11px;
+}
+
+.agent-conversation-tool__chevron {
+  transition: transform 140ms ease;
+}
+
+.agent-conversation-tool[open] .agent-conversation-tool__chevron {
+  transform: rotate(180deg);
+}
+
+.agent-conversation-tool__details {
+  display: grid;
+  gap: 8px;
+  padding: 0 10px 10px;
+}
+
+.agent-conversation-tool__details pre {
+  max-height: 220px;
+  overflow: auto;
+  margin: 0;
+  padding: 8px;
+  border-radius: calc(var(--radius) - 2px);
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground) / 0.72);
+  font-size: 11px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.agent-conversation-tool__details strong {
+  display: block;
+  margin-bottom: 5px;
+  color: hsl(var(--foreground) / 0.86);
+  font-size: 10px;
+}
+
+.agent-conversation-notice,
+.agent-conversation-artifact {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  max-width: min(100%, 760px);
+  padding: 9px 10px;
+  border-radius: var(--radius);
+  font-size: 12px;
+}
+
+.agent-conversation-notice {
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--muted) / 0.55);
+  color: hsl(var(--foreground) / 0.78);
+}
+
+.agent-conversation-notice--warning {
+  border-color: hsl(45 90% 50% / 0.22);
+  background: hsl(45 90% 50% / 0.07);
+}
+
+.agent-conversation-notice--error {
+  border-color: hsl(var(--destructive) / 0.24);
+  background: hsl(var(--destructive) / 0.08);
+}
+
+.agent-conversation-notice strong {
+  display: block;
+  margin-bottom: 2px;
+  color: hsl(var(--foreground) / 0.88);
+}
+
+.agent-conversation-artifact {
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card) / 0.58);
+  color: hsl(var(--muted-foreground));
+}
+
+.agent-conversation-artifact code {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-conversation-artifact a {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: auto;
+  color: hsl(var(--muted-foreground));
+  text-decoration: none;
+}
+
+.agent-conversation-message__attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.agent-conversation-attachment {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: calc(var(--radius) - 2px);
+  background: hsl(var(--muted));
+  font-size: 11px;
+  color: hsl(var(--muted-foreground));
+  max-width: 220px;
+  overflow: hidden;
+}
+
+.agent-conversation-attachment--image {
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 4px;
+  gap: 4px;
+}
+
+.agent-conversation-attachment__image {
+  display: block;
+  max-width: 200px;
+  max-height: 140px;
+  border-radius: calc(var(--radius) - 4px);
+  object-fit: contain;
+}
+
+.agent-conversation-attachment__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+.agent-conversation-attachment--image .agent-conversation-attachment__name {
+  padding: 0 4px 2px;
+}
+
+.agent-conversation-attachment__size {
+  flex-shrink: 0;
+  color: hsl(var(--muted-foreground) / 0.7);
+}
+
+.agent-conversation-spin {
+  animation: agent-conversation-spin 1s linear infinite;
+}
+
+@keyframes agent-conversation-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/core/src/styles/agent-conversation.css
+++ b/packages/core/src/styles/agent-conversation.css
@@ -81,20 +81,6 @@
   margin-top: 10px;
 }
 
-.agent-conversation-message__part:not(.agent-conversation-message__part--tool)
-  + .agent-conversation-message__part--tool,
-.agent-conversation-message__part--tool
-  + .agent-conversation-message__part:not(
-    .agent-conversation-message__part--tool
-  ) {
-  margin-top: 16px;
-}
-
-.agent-conversation-message__part--tool
-  + .agent-conversation-message__part--tool {
-  margin-top: 5px;
-}
-
 .agent-conversation-message__part--tool,
 .agent-conversation-message__part--notice,
 .agent-conversation-message__part--artifact {

--- a/packages/core/src/styles/agent-conversation.css
+++ b/packages/core/src/styles/agent-conversation.css
@@ -81,6 +81,20 @@
   margin-top: 10px;
 }
 
+.agent-conversation-message__part:not(.agent-conversation-message__part--tool)
+  + .agent-conversation-message__part--tool,
+.agent-conversation-message__part--tool
+  + .agent-conversation-message__part:not(
+    .agent-conversation-message__part--tool
+  ) {
+  margin-top: 16px;
+}
+
+.agent-conversation-message__part--tool
+  + .agent-conversation-message__part--tool {
+  margin-top: 5px;
+}
+
 .agent-conversation-message__part--tool,
 .agent-conversation-message__part--notice,
 .agent-conversation-message__part--artifact {

--- a/packages/core/src/styles/agent-native.css
+++ b/packages/core/src/styles/agent-native.css
@@ -22,6 +22,8 @@
  * file maps those to Tailwind utilities like `bg-background`, `text-foreground`.
  */
 
+@import "./agent-conversation.css";
+
 /* Scan @agent-native/core's compiled client output for Tailwind classes.
    Path is resolved relative to THIS file. After build, this CSS lives at
    dist/styles/agent-native.css, so `../client/**` resolves to dist/client/**. */

--- a/packages/desktop-app/electron.vite.config.ts
+++ b/packages/desktop-app/electron.vite.config.ts
@@ -1,6 +1,7 @@
 import { resolve } from "path";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 import react from "@vitejs/plugin-react-swc";
+import tailwindcss from "@tailwindcss/vite";
 
 const workspaceRendererPackages = [
   "@agent-native/code-agents-ui",
@@ -62,6 +63,6 @@ export default defineConfig({
       },
       dedupe: ["react", "react-dom"],
     },
-    plugins: [react()],
+    plugins: [react(), tailwindcss({ optimize: false })],
   },
 });

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -37,6 +37,7 @@
     "@types/node": "^24.2.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@tailwindcss/vite": "^4.3.0",
     "@vitejs/plugin-react-swc": "^4.0.0",
     "electron": "^41.2.2",
     "electron-builder": "^26.8.1",
@@ -44,6 +45,7 @@
     "lucide-react": "^1.8.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.9"
   }

--- a/packages/desktop-app/shared/ipc-channels.ts
+++ b/packages/desktop-app/shared/ipc-channels.ts
@@ -49,6 +49,7 @@ export const IPC = {
   /** Agent-Native Code hub (renderer ↔ main) */
   CODE_AGENTS_LIST_RUNS: "code-agents:list-runs",
   CODE_AGENTS_CREATE_RUN: "code-agents:create-run",
+  CODE_AGENTS_LIST_MODELS: "code-agents:list-models",
   CODE_AGENTS_READ_TRANSCRIPT: "code-agents:read-transcript",
   CODE_AGENTS_APPEND_FOLLOW_UP: "code-agents:append-follow-up",
   CODE_AGENTS_UPDATE_RUN: "code-agents:update-run",
@@ -136,11 +137,35 @@ export type CodeAgentReasoningEffort =
   | "xhigh"
   | "max";
 
+export interface CodeAgentModelSelection {
+  engine?: string;
+  model?: string;
+  effort?: CodeAgentReasoningEffort | string;
+}
+
+export interface CodeAgentModelOption {
+  engine: string;
+  engineLabel: string;
+  model: string;
+  label: string;
+  description?: string;
+  configured?: boolean;
+}
+
+export interface CodeAgentModelListResult {
+  status: "ok" | "unavailable";
+  models: CodeAgentModelOption[];
+  selected?: CodeAgentModelSelection;
+  error?: string;
+}
+
 export interface CodeAgentPromptAttachment {
   name: string;
   type?: string;
   size?: number;
   text?: string;
+  /** Base64 data URL for image attachments (e.g. "data:image/png;base64,..."). */
+  dataUrl?: string;
 }
 
 export interface CodeAgentProjectCommand {

--- a/packages/desktop-app/src/main/app-store.ts
+++ b/packages/desktop-app/src/main/app-store.ts
@@ -28,6 +28,14 @@ interface CodeAgentProviderStore {
   credentials: Partial<Record<CodeAgentProviderCredentialKey, StoredSecret>>;
 }
 
+export interface CodeAgentProviderCredentialApplyResult {
+  ok: boolean;
+  settings: CodeAgentProviderSettings;
+  appliedKeys: CodeAgentProviderCredentialKey[];
+  failedKeys: CodeAgentProviderCredentialKey[];
+  error?: string;
+}
+
 const CODE_AGENT_PROVIDER_DEFINITIONS: Array<{
   id: CodeAgentProviderStatus["id"];
   label: string;
@@ -216,6 +224,10 @@ function decryptProviderSecret(
   }
 }
 
+function hasStoredProviderSecret(secret: StoredSecret | undefined): boolean {
+  return Boolean(secret?.value);
+}
+
 export function loadCodeAgentProviderCredentials(): Partial<
   Record<CodeAgentProviderCredentialKey, string>
 > {
@@ -247,31 +259,49 @@ export function saveCodeAgentProviderCredentials(
   return getCodeAgentProviderSettingsStatus();
 }
 
-export function applyCodeAgentProviderCredentialsToEnv(): void {
+export function applyCodeAgentProviderCredentialsToEnv(): CodeAgentProviderCredentialApplyResult {
+  const store = loadCodeAgentProviderStore();
   const credentials = loadCodeAgentProviderCredentials();
+  const appliedKeys: CodeAgentProviderCredentialKey[] = [];
+  const failedKeys: CodeAgentProviderCredentialKey[] = [];
   for (const key of CODE_AGENT_PROVIDER_KEYS) {
     const value = credentials[key] ?? INITIAL_CODE_AGENT_PROVIDER_ENV.get(key);
     if (value) {
       process.env[key] = value;
+      if (credentials[key]) appliedKeys.push(key);
     } else {
       delete process.env[key];
+      if (hasStoredProviderSecret(store.credentials[key])) failedKeys.push(key);
     }
   }
+  return {
+    ok: failedKeys.length === 0,
+    settings: getCodeAgentProviderSettingsStatus(),
+    appliedKeys,
+    failedKeys,
+    error:
+      failedKeys.length > 0
+        ? "Could not unlock one or more saved code provider keys."
+        : undefined,
+  };
 }
 
 export function getCodeAgentProviderSettingsStatus(): CodeAgentProviderSettings {
-  const savedCredentials = loadCodeAgentProviderCredentials();
+  const store = loadCodeAgentProviderStore();
   const providers = CODE_AGENT_PROVIDER_DEFINITIONS.map((provider) => {
-    const configuredKeys = provider.keys.filter((key) =>
-      Boolean(process.env[key]),
-    );
     const savedKeys = provider.keys.filter((key) =>
-      Boolean(savedCredentials[key]),
+      hasStoredProviderSecret(store.credentials[key]),
     );
-    const missingKeys = provider.keys.filter((key) => !process.env[key]);
+    const envKeys = provider.keys.filter((key) => Boolean(process.env[key]));
+    const configuredKeys = provider.keys.filter(
+      (key) => Boolean(process.env[key]) || savedKeys.includes(key),
+    );
+    const missingKeys = provider.keys.filter(
+      (key) => !process.env[key] && !savedKeys.includes(key),
+    );
     const configured = missingKeys.length === 0;
     const hasSaved = savedKeys.length > 0;
-    const hasEnv = configuredKeys.some((key) => !savedCredentials[key]);
+    const hasEnv = envKeys.some((key) => !savedKeys.includes(key));
     const source: CodeAgentProviderStatus["source"] | undefined = configured
       ? hasSaved && hasEnv
         ? "mixed"

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -13,7 +13,12 @@ import {
 } from "electron";
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { createServer, type Server as HttpServer } from "node:http";
+import {
+  createServer,
+  type IncomingMessage,
+  type Server as HttpServer,
+  type ServerResponse,
+} from "node:http";
 import type { AddressInfo } from "node:net";
 import fs from "fs";
 import os from "os";
@@ -1466,13 +1471,27 @@ function reconcileInterruptedCodeAgentRun(
   reason: "startup" | "list" | "read" | "follow-up" | "shutdown",
   record = readCodeAgentRunRecord(runId),
 ): void {
-  if (!record || (reason !== "shutdown" && activeCodeAgentProcesses.has(runId)))
+  let currentRecord = record;
+  if (
+    !currentRecord ||
+    (reason !== "shutdown" && activeCodeAgentProcesses.has(runId))
+  )
     return;
-  if (!isDesktopCodeAgentRunInterruptible(record)) return;
-  if (reason !== "shutdown" && hasLivePersistedCodeAgentRunner(record)) return;
+  if (!isDesktopCodeAgentRunInterruptible(currentRecord)) return;
+  if (reason !== "shutdown" && hasLivePersistedCodeAgentRunner(currentRecord))
+    return;
+
+  currentRecord = readCodeAgentRunRecord(runId) ?? currentRecord;
+  if (
+    reason !== "shutdown" &&
+    (activeCodeAgentProcesses.has(runId) ||
+      hasLivePersistedCodeAgentRunner(currentRecord))
+  )
+    return;
+  if (!isDesktopCodeAgentRunInterruptible(currentRecord)) return;
 
   const now = new Date().toISOString();
-  const approvalInterrupted = isDesktopCodeAgentApprovalRunner(record);
+  const approvalInterrupted = isDesktopCodeAgentApprovalRunner(currentRecord);
   appendCodeAgentStatusEvent(
     runId,
     approvalInterrupted
@@ -1509,7 +1528,7 @@ function reconcileInterruptedCodeAgentRun(
       runnerState: "interrupted",
       runnerInterruptedAt: now,
       runnerInterruptReason: reason,
-      staleRunnerPid: readPersistedCodeAgentRunnerPid(record),
+      staleRunnerPid: readPersistedCodeAgentRunnerPid(currentRecord),
       pendingFollowUps: undefined,
     },
   });
@@ -2679,6 +2698,9 @@ async function sendDesktopCodeBackgroundAgentFollowUp(
             eventId: event.id,
             permissionMode: input.permissionMode,
             source: input.source ?? "desktop-background-agent-controller",
+            ...(Array.isArray(input.metadata?.attachments)
+              ? { attachments: input.metadata.attachments }
+              : {}),
           },
         ],
       },
@@ -2949,53 +2971,56 @@ function titleFromPrompt(prompt: string): string {
   return normalized.length > 72 ? `${normalized.slice(0, 69)}...` : normalized;
 }
 
-/**
- * Fire-and-forget: calls the Anthropic API with a cheap haiku model to
- * generate a short session title, then patches the run record on disk.
- * Falls back silently — the prompt-truncation title is already written.
- */
-function generateAndPatchRunTitle(runId: string, prompt: string): void {
+async function generateAndPatchRunTitle(
+  runId: string,
+  prompt: string,
+): Promise<string | null> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
 
-  if (!apiKey) return;
+  if (!apiKey) return null;
 
   const cleanPrompt = prompt.replace(/\s+/g, " ").trim().slice(0, 500);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 6_000);
 
-  fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": apiKey,
-      "anthropic-version": "2023-06-01",
-    },
-    body: JSON.stringify({
-      model: "claude-haiku-4-5-20251001",
-      max_tokens: 20,
-      messages: [
-        {
-          role: "user",
-          content: `Generate a very short title (3-6 words, no quotes, no punctuation at end) for a coding session that starts with this request:\n\n${cleanPrompt}`,
-        },
-      ],
-    }),
-  })
-    .then(async (res) => {
-      if (!res.ok) return;
-      const data = (await res.json()) as {
-        content?: Array<{ type: string; text: string }>;
-      };
-      const text = data?.content?.find((c) => c.type === "text")?.text?.trim();
-      if (!text) return;
-      // Strip surrounding quotes the model sometimes adds
-      const title = text
-        .replace(/^["']|["']$/g, "")
-        .trim()
-        .slice(0, 72);
-      if (title) touchCodeAgentRunRecord(runId, { title });
-    })
-    .catch(() => {
-      // Silently ignore — the truncated prompt title is already in place.
+  try {
+    const res = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: "claude-haiku-4-5-20251001",
+        max_tokens: 20,
+        messages: [
+          {
+            role: "user",
+            content: `Generate a very short title (3-6 words, no quotes, no punctuation at end) for a coding session that starts with this request:\n\n${cleanPrompt}`,
+          },
+        ],
+      }),
     });
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      content?: Array<{ type: string; text: string }>;
+    };
+    const text = data?.content?.find((c) => c.type === "text")?.text?.trim();
+    if (!text) return null;
+    const title = text
+      .replace(/^["']|["']$/g, "")
+      .trim()
+      .slice(0, 72);
+    if (!title) return null;
+    touchCodeAgentRunRecord(runId, { title });
+    return title;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 function formatCodeAgentModel(model: string, effort?: string): string {
@@ -3009,7 +3034,9 @@ function formatCodeAgentModel(model: string, effort?: string): string {
   return `${label} / ${effort}`;
 }
 
-function createCodeAgentRun(input: unknown): CodeAgentCreateRunResult {
+async function createCodeAgentRun(
+  input: unknown,
+): Promise<CodeAgentCreateRunResult> {
   const payload = isObject(input) ? input : {};
   const prompt = firstStringValue(payload.prompt) ?? "";
   if (!prompt) {
@@ -3138,11 +3165,10 @@ function createCodeAgentRun(input: unknown): CodeAgentCreateRunResult {
     if (goal.surfaceKind === "native") {
       spawnCodeAgentRunner(runId, cwd, permissionMode);
     }
-    // Async: generate a better title via LLM and patch the run record.
-    generateAndPatchRunTitle(runId, prompt);
+    const generatedTitle = await generateAndPatchRunTitle(runId, prompt);
     return {
       ok: true,
-      run,
+      run: generatedTitle ? { ...run, title: generatedTitle } : run,
       event,
       eventFile,
       message: "Coding session recorded.",
@@ -3156,7 +3182,9 @@ function createCodeAgentRun(input: unknown): CodeAgentCreateRunResult {
   }
 }
 
-function rerunCodeAgentRun(input: unknown): CodeAgentRerunResult {
+async function rerunCodeAgentRun(
+  input: unknown,
+): Promise<CodeAgentRerunResult> {
   const payload = isObject(input) ? input : {};
   const sourceRunId = normalizeCodeAgentRunId(payload.runId);
   if (!sourceRunId) {
@@ -3223,7 +3251,7 @@ function rerunCodeAgentRun(input: unknown): CodeAgentRerunResult {
     sourceMetadata.attachments,
   );
   const userMetadata = isObject(payload.metadata) ? payload.metadata : {};
-  const result = createCodeAgentRun({
+  const result = await createCodeAgentRun({
     goalId: goal.id,
     prompt,
     cwd:
@@ -4437,8 +4465,10 @@ ipcMain.handle(
 
 ipcMain.handle(
   IPC.CODE_AGENTS_CREATE_RUN,
-  (_event: IpcMainInvokeEvent, input: unknown): CodeAgentCreateRunResult =>
-    createCodeAgentRun(input),
+  (
+    _event: IpcMainInvokeEvent,
+    input: unknown,
+  ): Promise<CodeAgentCreateRunResult> => createCodeAgentRun(input),
 );
 
 ipcMain.handle(
@@ -4530,7 +4560,7 @@ ipcMain.handle(
 
 ipcMain.handle(
   IPC.CODE_AGENTS_RERUN_RUN,
-  (_event: IpcMainInvokeEvent, input: unknown): CodeAgentRerunResult =>
+  (_event: IpcMainInvokeEvent, input: unknown): Promise<CodeAgentRerunResult> =>
     rerunCodeAgentRun(input),
 );
 
@@ -5072,13 +5102,19 @@ function connectDesktopBuilderProvider(): Promise<CodeAgentProviderSettingsUpdat
       resolve(result);
     };
 
-    callbackServer = createServer((req, res) => {
+    const handleCallbackRequest = (
+      req: IncomingMessage,
+      res: ServerResponse,
+    ) => {
+      const origin = callbackOrigin;
+      if (!origin) {
+        res.writeHead(503, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Callback server is not ready");
+        return;
+      }
       let requestUrl: URL;
       try {
-        requestUrl = new URL(
-          req.url ?? "/",
-          callbackOrigin ?? "http://127.0.0.1",
-        );
+        requestUrl = new URL(req.url ?? "/", origin);
       } catch {
         res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
         res.end("Bad request");
@@ -5122,7 +5158,9 @@ function connectDesktopBuilderProvider(): Promise<CodeAgentProviderSettingsUpdat
         settings,
         message: "Builder.io connected for Code.",
       });
-    });
+    };
+
+    callbackServer = createServer();
 
     callbackServer.once("error", (err) => {
       finish({
@@ -5134,7 +5172,17 @@ function connectDesktopBuilderProvider(): Promise<CodeAgentProviderSettingsUpdat
     });
 
     callbackServer.listen(0, "127.0.0.1", () => {
-      const address = callbackServer?.address() as AddressInfo | null;
+      const server = callbackServer;
+      if (!server) {
+        finish({
+          ok: false,
+          settings: AppStore.getCodeAgentProviderSettingsStatus(),
+          message: "Could not start Builder.io connect flow.",
+          error: "No callback server was available.",
+        });
+        return;
+      }
+      const address = server.address() as AddressInfo | null;
       if (!address) {
         finish({
           ok: false,
@@ -5146,6 +5194,7 @@ function connectDesktopBuilderProvider(): Promise<CodeAgentProviderSettingsUpdat
       }
 
       callbackOrigin = `http://127.0.0.1:${address.port}`;
+      server.on("request", handleCallbackRequest);
       const callbackUrl = `http://127.0.0.1:${address.port}/_agent-native/desktop-builder/callback`;
       const authUrl = buildDesktopBuilderCliAuthUrl(callbackUrl);
       if (!canOpenExternalUrl(authUrl)) {

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -27,6 +27,8 @@ import {
   type CodeAgentCreateRunResult,
   type CodeAgentFollowUpResult,
   type CodeAgentHostMetadata,
+  type CodeAgentModelListResult,
+  type CodeAgentModelOption,
   type CodeAgentProjectFolder,
   type CodeAgentProjectListResult,
   type CodeAgentProjectSelectResult,
@@ -66,6 +68,11 @@ import {
   type BackgroundAgentRun,
   type BackgroundAgentTranscriptEvent,
 } from "../../../core/src/code-agents/background-run.js";
+import {
+  AI_SDK_MODEL_CONFIG,
+  ANTHROPIC_MODEL_CONFIG,
+  BUILDER_MODEL_CONFIG,
+} from "../../../core/src/agent/model-config.js";
 import {
   CODE_AGENTS_SURFACE_ID,
   CODE_AGENT_GOALS,
@@ -1405,6 +1412,7 @@ function codeAgentEventFilePath(runId: string): string | null {
 }
 
 function listDesktopCodeAgentRuns(goalId?: string): CodeAgentRun[] {
+  reconcileInterruptedCodeAgentRuns("list", goalId);
   const runs = desktopCodeBackgroundAgentController.list({
     goalId,
   }) as BackgroundAgentRun[];
@@ -1412,10 +1420,158 @@ function listDesktopCodeAgentRuns(goalId?: string): CodeAgentRun[] {
 }
 
 function readDesktopCodeAgentRun(runId: string): CodeAgentRun | null {
+  reconcileInterruptedCodeAgentRun(runId, "read");
   const run = desktopCodeBackgroundAgentController.get(
     runId,
   ) as BackgroundAgentRun | null;
   return run ? backgroundRunToDesktopRun(run) : null;
+}
+
+function listRawCodeAgentRunRecords(
+  goalId?: string,
+): Array<{ runId: string; record: Record<string, unknown> }> {
+  const dir = codeAgentRunsDir();
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => {
+      const record = readJsonObjectFile(path.join(dir, file));
+      const runId = normalizeCodeAgentRunId(record?.id);
+      if (!record || !runId) return null;
+      if (goalId && getRecordString(record, "goalId") !== goalId) return null;
+      return { runId, record };
+    })
+    .filter(
+      (
+        item,
+      ): item is {
+        runId: string;
+        record: Record<string, unknown>;
+      } => Boolean(item),
+    );
+}
+
+function reconcileInterruptedCodeAgentRuns(
+  reason: "startup" | "list" | "read" | "follow-up" | "shutdown",
+  goalId?: string,
+): void {
+  for (const { runId, record } of listRawCodeAgentRunRecords(goalId)) {
+    reconcileInterruptedCodeAgentRun(runId, reason, record);
+  }
+}
+
+function reconcileInterruptedCodeAgentRun(
+  runId: string,
+  reason: "startup" | "list" | "read" | "follow-up" | "shutdown",
+  record = readCodeAgentRunRecord(runId),
+): void {
+  if (!record || (reason !== "shutdown" && activeCodeAgentProcesses.has(runId)))
+    return;
+  if (!isDesktopCodeAgentRunInterruptible(record)) return;
+  if (reason !== "shutdown" && hasLivePersistedCodeAgentRunner(record)) return;
+
+  const now = new Date().toISOString();
+  const approvalInterrupted = isDesktopCodeAgentApprovalRunner(record);
+  appendCodeAgentStatusEvent(
+    runId,
+    approvalInterrupted
+      ? "Agent-Native Code approval was interrupted before it finished."
+      : reason === "shutdown"
+        ? "Agent-Native Code paused because Desktop closed."
+        : "Agent-Native Code was interrupted because Desktop restarted before this run finished.",
+    {
+      source: "desktop-runner",
+      status: approvalInterrupted ? "needs-approval" : "paused",
+      phase: approvalInterrupted ? "approval-required" : "stopped",
+      reason,
+    },
+  );
+  touchCodeAgentRunRecord(runId, {
+    updatedAt: now,
+    status: approvalInterrupted ? "needs-approval" : "paused",
+    phase: approvalInterrupted ? "approval-required" : "stopped",
+    needsApproval: approvalInterrupted ? true : false,
+    progress: approvalInterrupted
+      ? {
+          label: "Approval required",
+          completed: 0,
+          total: 1,
+          percent: 50,
+        }
+      : {
+          label: "Paused",
+          completed: 0,
+          total: 1,
+          percent: 0,
+        },
+    metadata: {
+      runnerState: "interrupted",
+      runnerInterruptedAt: now,
+      runnerInterruptReason: reason,
+      staleRunnerPid: readPersistedCodeAgentRunnerPid(record),
+      pendingFollowUps: undefined,
+    },
+  });
+}
+
+function isDesktopCodeAgentRunInterruptible(
+  record: Record<string, unknown>,
+): boolean {
+  const status = getRecordString(record, "status");
+  const phase = getRecordString(record, "phase");
+  return Boolean(
+    status === "queued" ||
+    status === "running" ||
+    phase === "queued" ||
+    phase === "retry-queued" ||
+    phase === "executing" ||
+    phase === "follow-up" ||
+    phase === "approval-running",
+  );
+}
+
+function isDesktopCodeAgentApprovalRunner(
+  record: Record<string, unknown>,
+): boolean {
+  const metadata = isObject(record.metadata) ? record.metadata : undefined;
+  return Boolean(
+    getRecordString(record, "phase") === "approval-running" ||
+    isObject(metadata?.pendingApproval) ||
+    record.needsApproval === true,
+  );
+}
+
+function hasLivePersistedCodeAgentRunner(
+  record: Record<string, unknown>,
+): boolean {
+  const pid = readPersistedCodeAgentRunnerPid(record);
+  if (!pid || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readPersistedCodeAgentRunnerPid(
+  record: Record<string, unknown>,
+): number | undefined {
+  const metadata = isObject(record.metadata) ? record.metadata : undefined;
+  return (
+    readRecordNumber(metadata, "runnerPid") ??
+    readRecordNumber(record, "runnerPid")
+  );
+}
+
+function readRecordNumber(
+  record: Record<string, unknown> | null | undefined,
+  key: string,
+): number | undefined {
+  if (!record) return undefined;
+  const value = Number(record[key]);
+  return Number.isFinite(value) ? value : undefined;
 }
 
 function backgroundRunToDesktopRun(record: BackgroundAgentRun): CodeAgentRun {
@@ -1571,9 +1727,11 @@ function normalizeCodeAgentPromptAttachments(
       const attachment: CodeAgentPromptAttachment = { name };
       const type = firstStringValue(item.type);
       const text = firstStringValue(item.text);
+      const dataUrl = firstStringValue(item.dataUrl);
       if (type) attachment.type = type;
       if (Number.isFinite(size) && size >= 0) attachment.size = size;
       if (text) attachment.text = text;
+      if (dataUrl) attachment.dataUrl = dataUrl;
       return attachment;
     })
     .filter((item): item is CodeAgentPromptAttachment => item !== null);
@@ -1596,6 +1754,16 @@ function readCodeAgentAttempt(
 function isActiveDesktopCodeAgentRun(
   record: Record<string, unknown> | null | undefined,
 ): boolean {
+  const metadata = isObject(record?.metadata) ? record.metadata : undefined;
+  const runnerState = getRecordString(metadata, "runnerState");
+  if (
+    runnerState === "exited" ||
+    runnerState === "failed" ||
+    runnerState === "interrupted" ||
+    runnerState === "stopped"
+  ) {
+    return false;
+  }
   const status = getRecordString(record, "status");
   const phase = getRecordString(record, "phase");
   return Boolean(
@@ -2120,6 +2288,32 @@ const activeCodeAgentProcesses = new Map<
   }
 >();
 
+function signalCodeAgentProcess(pid: number, signal: NodeJS.Signals): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  if (process.platform !== "win32") {
+    try {
+      process.kill(-pid, signal);
+      return true;
+    } catch {
+      // Fall back to the child process itself when process groups are unavailable.
+    }
+  }
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pauseActiveCodeAgentProcessesForShutdown(): void {
+  for (const [runId, active] of activeCodeAgentProcesses) {
+    if (active.pid) signalCodeAgentProcess(active.pid, "SIGTERM");
+    reconcileInterruptedCodeAgentRun(runId, "shutdown");
+    activeCodeAgentProcesses.delete(runId);
+  }
+}
+
 const desktopCodeBackgroundAgentController: DesktopBackgroundAgentController = {
   list: listBackgroundAgentRuns,
   get: getBackgroundAgentRun,
@@ -2150,6 +2344,26 @@ function spawnCodeAgentRunner(
   permissionMode?: CodeAgentPermissionMode,
 ): void {
   if (activeCodeAgentProcesses.has(runId)) return;
+  const provider = ensureCodeAgentLlmProvider();
+  if (!provider.ok) {
+    appendCodeAgentStatusEvent(
+      runId,
+      "Could not start Agent-Native Code process.",
+      {
+        source: "desktop-runner",
+        error: provider.error,
+      },
+    );
+    touchCodeAgentRunRecord(runId, {
+      status: "errored",
+      phase: "missing-credentials",
+      metadata: {
+        runnerState: "failed",
+        runnerError: provider.error,
+      },
+    });
+    return;
+  }
   const repoRoot = resolveRepositoryRoot(cwd);
   const runRecord = readCodeAgentRunRecord(runId);
   const normalizedPermissionMode =
@@ -2261,6 +2475,28 @@ function spawnCodeAgentApprovalRunner(
       command: "approve",
       action: "refresh",
       message: "This Agent-Native Code run already has an active process.",
+    };
+  }
+  const provider = ensureCodeAgentLlmProvider();
+  if (!provider.ok) {
+    appendCodeAgentStatusEvent(runId, "Could not start the approval command.", {
+      source: "desktop-approval-runner",
+      error: provider.error,
+    });
+    touchCodeAgentRunRecord(runId, {
+      status: "needs-approval",
+      phase: "missing-credentials",
+      needsApproval: true,
+      metadata: {
+        approvalRunnerError: provider.error,
+      },
+    });
+    return {
+      ok: false,
+      command: "approve",
+      action: "refresh",
+      message: "Connect a model provider before approving this run.",
+      error: provider.error,
     };
   }
   const repoRoot = resolveRepositoryRoot(cwd);
@@ -2402,9 +2638,11 @@ async function sendDesktopCodeBackgroundAgentFollowUp(
     };
   }
 
+  reconcileInterruptedCodeAgentRun(input.runId, "follow-up", runRecord);
+  const currentRunRecord = readCodeAgentRunRecord(input.runId) ?? runRecord;
   const runIsActive =
     activeCodeAgentProcesses.has(input.runId) ||
-    isActiveDesktopCodeAgentRun(runRecord);
+    isActiveDesktopCodeAgentRun(currentRunRecord);
   const mode = input.mode ?? "immediate";
   const event = createDesktopUserTranscriptEvent(
     input.runId,
@@ -2422,7 +2660,9 @@ async function sendDesktopCodeBackgroundAgentFollowUp(
   appendCodeAgentTranscriptEvent(event);
 
   if (runIsActive) {
-    const metadata = isObject(runRecord.metadata) ? runRecord.metadata : {};
+    const metadata = isObject(currentRunRecord.metadata)
+      ? currentRunRecord.metadata
+      : {};
     touchCodeAgentRunRecord(input.runId, {
       ...(input.permissionMode ? { permissionMode: input.permissionMode } : {}),
       metadata: {
@@ -2453,9 +2693,10 @@ async function sendDesktopCodeBackgroundAgentFollowUp(
   }
 
   const cwd =
-    getRecordString(runRecord, "cwd") ?? resolveCodeAgentsTerminalCwd({});
+    getRecordString(currentRunRecord, "cwd") ??
+    resolveCodeAgentsTerminalCwd({});
   const goal =
-    getCodeAgentGoal(getRecordString(runRecord, "goalId")) ??
+    getCodeAgentGoal(getRecordString(currentRunRecord, "goalId")) ??
     CODE_AGENT_GOALS[0];
   if (goal.surfaceKind === "native") {
     spawnCodeAgentRunner(input.runId, cwd, input.permissionMode);
@@ -2542,8 +2783,7 @@ async function controlDesktopCodeBackgroundAgentRun(
     }
 
     if (active?.pid) {
-      try {
-        process.kill(active.pid, "SIGTERM");
+      if (signalCodeAgentProcess(active.pid, "SIGTERM")) {
         activeCodeAgentProcesses.delete(input.runId);
         appendCodeAgentStatusEvent(
           input.runId,
@@ -2568,17 +2808,16 @@ async function controlDesktopCodeBackgroundAgentRun(
           ) as BackgroundAgentRun | null,
           message: "Stop requested for this Agent-Native Code run.",
         };
-      } catch (err) {
-        return {
-          ok: false,
-          runId: input.runId,
-          run: desktopCodeBackgroundAgentController.get(
-            input.runId,
-          ) as BackgroundAgentRun | null,
-          message: "Could not stop this Agent-Native Code process.",
-          error: err instanceof Error ? err.message : String(err),
-        };
       }
+      return {
+        ok: false,
+        runId: input.runId,
+        run: desktopCodeBackgroundAgentController.get(
+          input.runId,
+        ) as BackgroundAgentRun | null,
+        message: "Could not stop this Agent-Native Code process.",
+        error: `No process accepted SIGTERM for pid ${active.pid}.`,
+      };
     }
 
     return stopDesktopCodeBackgroundAgentRunWithoutSignal(input.runId);
@@ -2710,6 +2949,55 @@ function titleFromPrompt(prompt: string): string {
   return normalized.length > 72 ? `${normalized.slice(0, 69)}...` : normalized;
 }
 
+/**
+ * Fire-and-forget: calls the Anthropic API with a cheap haiku model to
+ * generate a short session title, then patches the run record on disk.
+ * Falls back silently — the prompt-truncation title is already written.
+ */
+function generateAndPatchRunTitle(runId: string, prompt: string): void {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+
+  if (!apiKey) return;
+
+  const cleanPrompt = prompt.replace(/\s+/g, " ").trim().slice(0, 500);
+
+  fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 20,
+      messages: [
+        {
+          role: "user",
+          content: `Generate a very short title (3-6 words, no quotes, no punctuation at end) for a coding session that starts with this request:\n\n${cleanPrompt}`,
+        },
+      ],
+    }),
+  })
+    .then(async (res) => {
+      if (!res.ok) return;
+      const data = (await res.json()) as {
+        content?: Array<{ type: string; text: string }>;
+      };
+      const text = data?.content?.find((c) => c.type === "text")?.text?.trim();
+      if (!text) return;
+      // Strip surrounding quotes the model sometimes adds
+      const title = text
+        .replace(/^["']|["']$/g, "")
+        .trim()
+        .slice(0, 72);
+      if (title) touchCodeAgentRunRecord(runId, { title });
+    })
+    .catch(() => {
+      // Silently ignore — the truncated prompt title is already in place.
+    });
+}
+
 function formatCodeAgentModel(model: string, effort?: string): string {
   const label = model
     .replace(/^ai-sdk:/, "")
@@ -2731,12 +3019,12 @@ function createCodeAgentRun(input: unknown): CodeAgentCreateRunResult {
       error: "Missing prompt.",
     };
   }
-  if (!hasCodeAgentLlmProvider()) {
+  const provider = ensureCodeAgentLlmProvider();
+  if (!provider.ok) {
     return {
       ok: false,
       message: "Connect a model provider before starting a coding chat.",
-      error:
-        "Set ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, or Builder credentials, then restart Agent Native Desktop.",
+      error: provider.error,
     };
   }
 
@@ -2850,6 +3138,8 @@ function createCodeAgentRun(input: unknown): CodeAgentCreateRunResult {
     if (goal.surfaceKind === "native") {
       spawnCodeAgentRunner(runId, cwd, permissionMode);
     }
+    // Async: generate a better title via LLM and patch the run record.
+    generateAndPatchRunTitle(runId, prompt);
     return {
       ok: true,
       run,
@@ -3001,12 +3291,12 @@ async function appendCodeAgentFollowUp(
       error: "Missing prompt.",
     };
   }
-  if (!hasCodeAgentLlmProvider()) {
+  const provider = ensureCodeAgentLlmProvider();
+  if (!provider.ok) {
     return {
       ok: false,
       message: "Connect a model provider before chatting.",
-      error:
-        "Set ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, or Builder credentials, then restart Agent Native Desktop.",
+      error: provider.error,
     };
   }
   if (requestedPermissionMode && !permissionMode) {
@@ -3020,14 +3310,19 @@ async function appendCodeAgentFollowUp(
   try {
     const goalId = firstStringValue(payload.goalId);
     const runRecord = readCodeAgentRunRecord(runId);
+    if (runRecord)
+      reconcileInterruptedCodeAgentRun(runId, "follow-up", runRecord);
+    const currentRunRecord = readCodeAgentRunRecord(runId) ?? runRecord;
     const runIsActive =
       activeCodeAgentProcesses.has(runId) ||
-      isActiveDesktopCodeAgentRun(runRecord);
+      isActiveDesktopCodeAgentRun(currentRunRecord);
     const cwd =
-      getRecordString(runRecord, "cwd") ?? resolveCodeAgentsTerminalCwd({});
+      getRecordString(currentRunRecord, "cwd") ??
+      resolveCodeAgentsTerminalCwd({});
     const steering = buildCodeAgentSteeringMetadata({
       cwd,
-      permissionMode: permissionMode ?? readCodeAgentPermissionMode(runRecord),
+      permissionMode:
+        permissionMode ?? readCodeAgentPermissionMode(currentRunRecord),
       engine,
       model,
       effort,
@@ -3117,6 +3412,8 @@ function updateCodeAgentRun(input: unknown): CodeAgentUpdateRunResult {
   const model = firstStringValue(payload.model);
   const effort = firstStringValue(payload.effort);
   const userMetadata = isObject(payload.metadata) ? payload.metadata : {};
+  const newTitle =
+    typeof payload.title === "string" ? payload.title.trim() : undefined;
   if (requestedPermissionMode && !permissionMode) {
     return {
       ok: false,
@@ -3138,6 +3435,7 @@ function updateCodeAgentRun(input: unknown): CodeAgentUpdateRunResult {
       ),
     });
     touchCodeAgentRunRecord(runId, {
+      ...(newTitle ? { title: newTitle } : {}),
       permissionMode,
       steering,
       metadata: {
@@ -3162,6 +3460,7 @@ function updateCodeAgentRun(input: unknown): CodeAgentUpdateRunResult {
       ),
     });
     touchCodeAgentRunRecord(runId, {
+      ...(newTitle ? { title: newTitle } : {}),
       steering,
       metadata: {
         ...userMetadata,
@@ -3171,9 +3470,12 @@ function updateCodeAgentRun(input: unknown): CodeAgentUpdateRunResult {
         steering,
       },
     });
-  } else if (Object.keys(userMetadata).length > 0) {
+  } else if (newTitle || Object.keys(userMetadata).length > 0) {
     touchCodeAgentRunRecord(runId, {
-      metadata: userMetadata,
+      ...(newTitle ? { title: newTitle } : {}),
+      ...(Object.keys(userMetadata).length > 0
+        ? { metadata: userMetadata }
+        : {}),
     });
   }
 
@@ -3644,8 +3946,39 @@ function getCodeAgentLlmProviderStatus(): NonNullable<
   };
 }
 
-function hasCodeAgentLlmProvider(): boolean {
-  return getCodeAgentLlmProviderStatus().configured;
+function hasRuntimeCodeAgentLlmProvider(): boolean {
+  if (process.env.AGENT_ENGINE) return true;
+  if (process.env.ANTHROPIC_API_KEY) return true;
+  if (process.env.OPENAI_API_KEY) return true;
+  if (process.env.GOOGLE_GENERATIVE_AI_API_KEY) return true;
+  return Boolean(
+    process.env.BUILDER_PRIVATE_KEY && process.env.BUILDER_PUBLIC_KEY,
+  );
+}
+
+function ensureCodeAgentLlmProvider(): {
+  ok: boolean;
+  error?: string;
+} {
+  if (process.env.AGENT_NATIVE_CODE_AGENT_FAKE_RESPONSE !== undefined) {
+    return { ok: true };
+  }
+  if (hasRuntimeCodeAgentLlmProvider()) return { ok: true };
+
+  const applyResult = AppStore.applyCodeAgentProviderCredentialsToEnv();
+  if (hasRuntimeCodeAgentLlmProvider()) return { ok: true };
+  if (applyResult.failedKeys.length > 0) {
+    return {
+      ok: false,
+      error:
+        "Agent Native could not unlock the saved code provider keys. Allow Keychain access when starting a Code run, or reconnect the provider in Settings.",
+    };
+  }
+  return {
+    ok: false,
+    error:
+      "Set ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, or Builder credentials.",
+  };
 }
 
 function getCodeAgentProviderSettings(): CodeAgentProviderSettings {
@@ -3680,6 +4013,115 @@ function updateCodeAgentProviderSettings(
       ok: false,
       settings: AppStore.getCodeAgentProviderSettingsStatus(),
       message: "Could not save code provider settings.",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function providerStatusById(settings: CodeAgentProviderSettings, id: string) {
+  return settings.providers.find((provider) => provider.id === id);
+}
+
+function pushCodeAgentModelOptions(
+  models: CodeAgentModelOption[],
+  options: {
+    engine: string;
+    engineLabel: string;
+    supportedModels: readonly string[];
+    configured: boolean;
+  },
+): void {
+  for (const model of options.supportedModels) {
+    models.push({
+      engine: options.engine,
+      engineLabel: options.engineLabel,
+      model,
+      label: model,
+      configured: options.configured,
+    });
+  }
+}
+
+function getCodeAgentModelList(): CodeAgentModelListResult {
+  try {
+    const settings = AppStore.getCodeAgentProviderSettingsStatus();
+    const models: CodeAgentModelOption[] = [
+      {
+        engine: "auto",
+        engineLabel: "Auto",
+        model: "auto",
+        label: "Default model",
+        description: "Use the connected provider and saved default.",
+        configured: true,
+      },
+    ];
+    const builderConfigured = Boolean(
+      providerStatusById(settings, "builder")?.configured,
+    );
+    const customEngine = process.env.AGENT_ENGINE?.trim();
+    const customModel = process.env.AGENT_MODEL?.trim();
+
+    if (customEngine) {
+      models.push({
+        engine: customEngine,
+        engineLabel: "Custom",
+        model: customModel || BUILDER_MODEL_CONFIG.defaultModel,
+        label: customModel || BUILDER_MODEL_CONFIG.defaultModel,
+        configured: true,
+      });
+    }
+
+    if (builderConfigured) {
+      pushCodeAgentModelOptions(models, {
+        engine: "builder",
+        engineLabel: "Builder.io",
+        supportedModels: BUILDER_MODEL_CONFIG.supportedModels,
+        configured: true,
+      });
+    } else {
+      pushCodeAgentModelOptions(models, {
+        engine: "anthropic",
+        engineLabel: "Anthropic",
+        supportedModels: ANTHROPIC_MODEL_CONFIG.supportedModels,
+        configured: Boolean(
+          providerStatusById(settings, "anthropic")?.configured,
+        ),
+      });
+      pushCodeAgentModelOptions(models, {
+        engine: "ai-sdk:openai",
+        engineLabel: "OpenAI",
+        supportedModels: AI_SDK_MODEL_CONFIG.openai.supportedModels,
+        configured: Boolean(providerStatusById(settings, "openai")?.configured),
+      });
+      pushCodeAgentModelOptions(models, {
+        engine: "ai-sdk:google",
+        engineLabel: "Gemini",
+        supportedModels: AI_SDK_MODEL_CONFIG.google.supportedModels,
+        configured: Boolean(providerStatusById(settings, "google")?.configured),
+      });
+    }
+
+    const selected = customEngine
+      ? {
+          engine: customEngine,
+          model: customModel || BUILDER_MODEL_CONFIG.defaultModel,
+        }
+      : builderConfigured
+        ? {
+            engine: "builder",
+            model: BUILDER_MODEL_CONFIG.defaultModel,
+          }
+        : { engine: "auto", model: "auto" };
+
+    return {
+      status: "ok",
+      models,
+      selected,
+    };
+  } catch (err) {
+    return {
+      status: "unavailable",
+      models: [],
       error: err instanceof Error ? err.message : String(err),
     };
   }
@@ -3997,6 +4439,11 @@ ipcMain.handle(
   IPC.CODE_AGENTS_CREATE_RUN,
   (_event: IpcMainInvokeEvent, input: unknown): CodeAgentCreateRunResult =>
     createCodeAgentRun(input),
+);
+
+ipcMain.handle(
+  IPC.CODE_AGENTS_LIST_MODELS,
+  (): CodeAgentModelListResult => getCodeAgentModelList(),
 );
 
 ipcMain.handle(
@@ -4612,6 +5059,7 @@ function connectDesktopBuilderProvider(): Promise<CodeAgentProviderSettingsUpdat
   return new Promise((resolve) => {
     let settled = false;
     let callbackServer: HttpServer | null = null;
+    let callbackOrigin: string | null = null;
     let timeout: NodeJS.Timeout | null = null;
 
     const finish = (result: CodeAgentProviderSettingsUpdateResult) => {
@@ -4625,9 +5073,18 @@ function connectDesktopBuilderProvider(): Promise<CodeAgentProviderSettingsUpdat
     };
 
     callbackServer = createServer((req, res) => {
-      const address = callbackServer?.address() as AddressInfo | null;
-      const origin = address ? `http://127.0.0.1:${address.port}` : "";
-      const requestUrl = new URL(req.url ?? "/", origin);
+      let requestUrl: URL;
+      try {
+        requestUrl = new URL(
+          req.url ?? "/",
+          callbackOrigin ?? "http://127.0.0.1",
+        );
+      } catch {
+        res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Bad request");
+        return;
+      }
+
       if (requestUrl.pathname !== "/_agent-native/desktop-builder/callback") {
         res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
         res.end("Not found");
@@ -4688,6 +5145,7 @@ function connectDesktopBuilderProvider(): Promise<CodeAgentProviderSettingsUpdat
         return;
       }
 
+      callbackOrigin = `http://127.0.0.1:${address.port}`;
       const callbackUrl = `http://127.0.0.1:${address.port}/_agent-native/desktop-builder/callback`;
       const authUrl = buildDesktopBuilderCliAuthUrl(callbackUrl);
       if (!canOpenExternalUrl(authUrl)) {
@@ -5324,7 +5782,7 @@ app.whenReady().then(() => {
   ];
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 
-  AppStore.applyCodeAgentProviderCredentialsToEnv();
+  reconcileInterruptedCodeAgentRuns("startup");
 
   const win = createWindow();
   remoteConnectorEnabled = AppStore.loadRemoteConnectorSettings().enabled;
@@ -5420,6 +5878,7 @@ app.on("window-all-closed", () => {
 
 app.on("before-quit", () => {
   appIsQuitting = true;
+  pauseActiveCodeAgentProcessesForShutdown();
   if (remoteConnectorRestartTimer) {
     clearTimeout(remoteConnectorRestartTimer);
     remoteConnectorRestartTimer = null;

--- a/packages/desktop-app/src/preload/index.ts
+++ b/packages/desktop-app/src/preload/index.ts
@@ -8,6 +8,7 @@ import {
   type CodeAgentFollowUpRequest,
   type CodeAgentFollowUpResult,
   type CodeAgentHostMetadata,
+  type CodeAgentModelListResult,
   type CodeAgentProjectListResult,
   type CodeAgentProjectSelectResult,
   type CodeAgentRetryRunRequest,
@@ -146,6 +147,8 @@ const electronAPI = {
   codeAgents: {
     listRuns: (goalId?: string): Promise<CodeAgentRunListResult> =>
       ipcRenderer.invoke(IPC.CODE_AGENTS_LIST_RUNS, goalId),
+    listModels: (): Promise<CodeAgentModelListResult> =>
+      ipcRenderer.invoke(IPC.CODE_AGENTS_LIST_MODELS),
     createRun: (
       request: CodeAgentCreateRunRequest,
     ): Promise<CodeAgentCreateRunResult> =>

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import {
   CodeAgentsApp,
+  type CodeAgentModelListResult,
   type CodeAgentTranscriptEvent,
   type CodeAgentTranscriptRequest,
   type CodeAgentsHost,
@@ -67,6 +68,17 @@ export default function CodeAgentsHub({
           };
         }
         return api.createRun(request);
+      },
+      async listModels() {
+        const api = window.electronAPI?.codeAgents;
+        if (!api?.listModels) {
+          return {
+            status: "unavailable",
+            models: [],
+            error: "Desktop bridge is not available.",
+          };
+        }
+        return api.listModels() as Promise<CodeAgentModelListResult>;
       },
       async getHostMetadata() {
         const api = window.electronAPI?.codeAgents;

--- a/packages/desktop-app/src/renderer/global.d.ts
+++ b/packages/desktop-app/src/renderer/global.d.ts
@@ -55,6 +55,28 @@ type CodeAgentReasoningEffort =
   | "xhigh"
   | "max";
 
+type CodeAgentModelSelection = {
+  engine?: string;
+  model?: string;
+  effort?: CodeAgentReasoningEffort | string;
+};
+
+type CodeAgentModelOption = {
+  engine: string;
+  engineLabel: string;
+  model: string;
+  label: string;
+  description?: string;
+  configured?: boolean;
+};
+
+type CodeAgentModelListResult = {
+  status: "ok" | "unavailable";
+  models: CodeAgentModelOption[];
+  selected?: CodeAgentModelSelection;
+  error?: string;
+};
+
 type CodeAgentRemoteConnectorState =
   | "disabled"
   | "unconfigured"
@@ -510,6 +532,7 @@ interface ElectronAPI {
 
   codeAgents: {
     listRuns(goalId?: string): Promise<CodeAgentRunListResult>;
+    listModels(): Promise<CodeAgentModelListResult>;
     createRun(
       request: CodeAgentCreateRunRequest,
     ): Promise<CodeAgentCreateRunResult>;

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -1,3 +1,9 @@
+@import "tailwindcss";
+@import "@agent-native/core/styles/agent-native.css";
+
+@source "./**/*.{ts,tsx}";
+@source "../../../code-agents-ui/src/**/*.{ts,tsx}";
+
 /* ─── Reset ─────────────────────────────────────────────────── */
 *,
 *::before,

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -2,7 +2,6 @@
 @import "@agent-native/core/styles/agent-native.css";
 
 @source "./**/*.{ts,tsx}";
-@source "../../../core/src/client/**/*.{ts,tsx}";
 @source "../../../code-agents-ui/src/**/*.{ts,tsx}";
 
 /* ─── Reset ─────────────────────────────────────────────────── */

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -2,6 +2,7 @@
 @import "@agent-native/core/styles/agent-native.css";
 
 @source "./**/*.{ts,tsx}";
+@source "../../../core/src/client/**/*.{ts,tsx}";
 @source "../../../code-agents-ui/src/**/*.{ts,tsx}";
 
 /* ─── Reset ─────────────────────────────────────────────────── */

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -4,15 +4,6 @@
 @source "./**/*.{ts,tsx}";
 @source "../../../code-agents-ui/src/**/*.{ts,tsx}";
 
-/* ─── Reset ─────────────────────────────────────────────────── */
-*,
-*::before,
-*::after {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
 /* ─── Design tokens ──────────────────────────────────────────── */
 :root {
   --sidebar-width: 56px;

--- a/packages/dispatch/src/server/lib/vault-store.ts
+++ b/packages/dispatch/src/server/lib/vault-store.ts
@@ -257,7 +257,9 @@ export async function createSecret(
       summary: `Updated vault secret "${input.name}" (${credentialKey})`,
     });
 
-    return getSecret(existing[0].id, ctx);
+    const updated = await getSecret(existing[0].id, ctx);
+    if (updated) await syncSecretsToCredentialStore([updated], ctx);
+    return updated;
   }
 
   const secretId = id();
@@ -291,7 +293,9 @@ export async function createSecret(
     summary: `Created vault secret "${input.name}" (${credentialKey})`,
   });
 
-  return getSecret(secretId, ctx);
+  const created = await getSecret(secretId, ctx);
+  if (created) await syncSecretsToCredentialStore([created], ctx);
+  return created;
 }
 
 export async function updateSecret(
@@ -319,7 +323,9 @@ export async function updateSecret(
     summary: `Updated value for secret "${existing.name}" (${existing.credentialKey})`,
   });
 
-  return getSecret(secretId, ctx);
+  const updated = await getSecret(secretId, ctx);
+  if (updated) await syncSecretsToCredentialStore([updated], ctx);
+  return updated;
 }
 
 export async function deleteSecret(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,9 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@types/node':
         specifier: ^24.2.1
         version: 24.12.2
@@ -446,6 +449,9 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -17278,10 +17284,6 @@ packages:
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
-  tapable@2.3.2:
-    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
-    engines: {node: '>=6'}
-
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
@@ -19285,6 +19287,7 @@ snapshots:
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
+    optional: true
 
   '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0)':
     dependencies:
@@ -20817,6 +20820,7 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
+    optional: true
 
   '@expo/code-signing-certificates@0.0.6':
     dependencies:
@@ -20878,6 +20882,7 @@ snapshots:
     optionalDependencies:
       react: 19.2.5
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)
+    optional: true
 
   '@expo/dom-webview@55.0.5(expo@55.0.17)(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -20890,6 +20895,7 @@ snapshots:
       expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@5.0.5(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)))(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.5))(react-native-webview@13.16.1(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       react: 19.2.5
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)
+    optional: true
 
   '@expo/env@2.1.1':
     dependencies:
@@ -20979,6 +20985,7 @@ snapshots:
       react: 19.2.5
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)
       stacktrace-parser: 0.1.11
+    optional: true
 
   '@expo/metro-config@55.0.17(expo@55.0.17)(typescript@6.0.3)':
     dependencies:
@@ -21002,7 +21009,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@5.0.5(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)))(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.5))(react-native-webview@13.16.1(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@5.0.5(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)))(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.5))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -21067,7 +21074,7 @@ snapshots:
       '@expo/json-file': 10.0.13
       '@react-native/normalize-colors': 0.83.6
       debug: 4.4.3
-      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@5.0.5(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)))(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.5))(react-native-webview@13.16.1(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@5.0.5(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)))(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.5))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       resolve-from: 5.0.0
       semver: 7.8.0
       xml2js: 0.6.0
@@ -21124,6 +21131,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@expo/schema-utils@55.0.3': {}
 
@@ -21146,6 +21154,7 @@ snapshots:
       expo-font: 55.0.6(expo@55.0.17)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)
+    optional: true
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -23863,7 +23872,8 @@ snapshots:
 
   '@react-native/assets-registry@0.83.9': {}
 
-  '@react-native/assets-registry@0.85.2': {}
+  '@react-native/assets-registry@0.85.2':
+    optional: true
 
   '@react-native/babel-plugin-codegen@0.83.6(@babel/core@7.29.0)':
     dependencies:
@@ -23952,6 +23962,7 @@ snapshots:
       nullthrows: 1.1.1
       tinyglobby: 0.2.16
       yargs: 17.7.2
+    optional: true
 
   '@react-native/community-cli-plugin@0.83.9':
     dependencies:
@@ -23980,12 +23991,14 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   '@react-native/debugger-frontend@0.83.6': {}
 
   '@react-native/debugger-frontend@0.83.9': {}
 
-  '@react-native/debugger-frontend@0.85.2': {}
+  '@react-native/debugger-frontend@0.85.2':
+    optional: true
 
   '@react-native/debugger-shell@0.83.6':
     dependencies:
@@ -24004,6 +24017,7 @@ snapshots:
       fb-dotslash: 0.5.8
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@react-native/dev-middleware@0.83.6':
     dependencies:
@@ -24061,20 +24075,24 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   '@react-native/gradle-plugin@0.83.9': {}
 
-  '@react-native/gradle-plugin@0.85.2': {}
+  '@react-native/gradle-plugin@0.85.2':
+    optional: true
 
   '@react-native/js-polyfills@0.83.9': {}
 
-  '@react-native/js-polyfills@0.85.2': {}
+  '@react-native/js-polyfills@0.85.2':
+    optional: true
 
   '@react-native/normalize-colors@0.83.6': {}
 
   '@react-native/normalize-colors@0.83.9': {}
 
-  '@react-native/normalize-colors@0.85.2': {}
+  '@react-native/normalize-colors@0.85.2':
+    optional: true
 
   '@react-native/virtualized-lists@0.83.9(@types/react@19.2.14)(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -24093,6 +24111,7 @@ snapshots:
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
+    optional: true
 
   '@react-navigation/bottom-tabs@7.15.9(@react-navigation/native@7.2.2(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native-safe-area-context@5.7.0(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native-screens@4.24.0(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -25614,6 +25633,13 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 8.0.13(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@tailwindcss/vite@4.3.0(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@tanstack/query-core@5.100.10': {}
 
   '@tanstack/query-core@5.99.2': {}
@@ -26860,6 +26886,7 @@ snapshots:
   babel-plugin-syntax-hermes-parser@0.33.3:
     dependencies:
       hermes-parser: 0.33.3
+    optional: true
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.0):
     dependencies:
@@ -26914,7 +26941,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@5.0.5(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)))(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.5))(react-native-webview@13.16.1(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@5.0.5(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)))(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.5))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -27312,6 +27339,7 @@ snapshots:
       mkdirp: 1.0.4
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   chromium-pickle-js@0.2.0: {}
 
@@ -28110,7 +28138,7 @@ snapshots:
   enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.2
+      tapable: 2.3.3
 
   enhanced-resolve@5.21.3:
     dependencies:
@@ -28390,6 +28418,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    optional: true
 
   expo-constants@55.0.15(expo@55.0.17)(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)):
     dependencies:
@@ -28406,6 +28435,7 @@ snapshots:
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   expo-constants@55.0.16(expo@55.0.17)(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)):
     dependencies:
@@ -28458,6 +28488,7 @@ snapshots:
     dependencies:
       expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@5.0.5(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)))(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.5))(react-native-webview@13.16.1(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)
+    optional: true
 
   expo-font@55.0.6(expo@55.0.17)(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -28472,6 +28503,7 @@ snapshots:
       fontfaceobserver: 2.3.0
       react: 19.2.5
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)
+    optional: true
 
   expo-glass-effect@55.0.10(expo@55.0.17)(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -28505,7 +28537,7 @@ snapshots:
 
   expo-keep-awake@55.0.6(expo@55.0.17)(react@19.2.5):
     dependencies:
-      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@5.0.5(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)))(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.5))(react-native-webview@13.16.1(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@5.0.5(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)))(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.5))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       react: 19.2.5
 
   expo-linking@55.0.14(expo@55.0.17)(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5):
@@ -28555,6 +28587,7 @@ snapshots:
       invariant: 2.2.4
       react: 19.2.5
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)
+    optional: true
 
   expo-notifications@55.0.23(expo@55.0.17)(react-native@0.83.9(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@6.0.3):
     dependencies:
@@ -28782,6 +28815,7 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
+    optional: true
 
   exponential-backoff@3.1.3: {}
 
@@ -29457,13 +29491,15 @@ snapshots:
 
   hermes-compiler@0.14.1: {}
 
-  hermes-compiler@250829098.0.10: {}
+  hermes-compiler@250829098.0.10:
+    optional: true
 
   hermes-estree@0.32.0: {}
 
   hermes-estree@0.32.1: {}
 
-  hermes-estree@0.33.3: {}
+  hermes-estree@0.33.3:
+    optional: true
 
   hermes-estree@0.35.0: {}
 
@@ -29478,6 +29514,7 @@ snapshots:
   hermes-parser@0.33.3:
     dependencies:
       hermes-estree: 0.33.3
+    optional: true
 
   hermes-parser@0.35.0:
     dependencies:
@@ -30638,6 +30675,7 @@ snapshots:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   metro-cache-key@0.83.6:
     dependencies:
@@ -30646,6 +30684,7 @@ snapshots:
   metro-cache-key@0.84.4:
     dependencies:
       flow-enums-runtime: 0.0.6
+    optional: true
 
   metro-cache@0.83.6:
     dependencies:
@@ -30664,6 +30703,7 @@ snapshots:
       metro-core: 0.84.4
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   metro-config@0.83.6:
     dependencies:
@@ -30694,6 +30734,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro-core@0.83.6:
     dependencies:
@@ -30706,6 +30747,7 @@ snapshots:
       flow-enums-runtime: 0.0.6
       lodash.throttle: 4.1.1
       metro-resolver: 0.84.4
+    optional: true
 
   metro-file-map@0.83.6:
     dependencies:
@@ -30734,6 +30776,7 @@ snapshots:
       walker: 1.0.8
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   metro-minify-terser@0.83.6:
     dependencies:
@@ -30744,6 +30787,7 @@ snapshots:
     dependencies:
       flow-enums-runtime: 0.0.6
       terser: 5.46.1
+    optional: true
 
   metro-resolver@0.83.6:
     dependencies:
@@ -30752,6 +30796,7 @@ snapshots:
   metro-resolver@0.84.4:
     dependencies:
       flow-enums-runtime: 0.0.6
+    optional: true
 
   metro-runtime@0.83.6:
     dependencies:
@@ -30762,6 +30807,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
       flow-enums-runtime: 0.0.6
+    optional: true
 
   metro-source-map@0.83.6:
     dependencies:
@@ -30790,6 +30836,7 @@ snapshots:
       vlq: 1.0.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   metro-symbolicate@0.83.6:
     dependencies:
@@ -30812,6 +30859,7 @@ snapshots:
       vlq: 1.0.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   metro-transform-plugins@0.83.6:
     dependencies:
@@ -30834,6 +30882,7 @@ snapshots:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   metro-transform-worker@0.83.6:
     dependencies:
@@ -30874,6 +30923,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro@0.83.6:
     dependencies:
@@ -30967,6 +31017,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   micromark-core-commonmark@1.1.0:
     dependencies:
@@ -31607,6 +31658,7 @@ snapshots:
   ob1@0.84.4:
     dependencies:
       flow-enums-runtime: 0.0.6
+    optional: true
 
   object-assign@4.1.1: {}
 
@@ -32539,6 +32591,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1):
     dependencies:
@@ -33540,8 +33593,6 @@ snapshots:
   tailwindcss@4.2.4: {}
 
   tailwindcss@4.3.0: {}
-
-  tapable@2.3.2: {}
 
   tapable@2.3.3: {}
 

--- a/templates/code/actions/_code-agent-ui.ts
+++ b/templates/code/actions/_code-agent-ui.ts
@@ -95,6 +95,7 @@ export function runCodeAgentInBackground(input: {
   appendUserEvent?: boolean;
   model?: string;
   reasoningEffort?: CodeAgentReasoningEffort;
+  attachments?: CodeAgentPromptAttachment[];
 }): void {
   setTimeout(() => {
     void executeCodeAgentRun({
@@ -104,6 +105,7 @@ export function runCodeAgentInBackground(input: {
       model: input.model,
       reasoningEffort:
         input.reasoningEffort === "auto" ? undefined : input.reasoningEffort,
+      attachments: input.attachments,
     });
   }, 0);
 }
@@ -140,7 +142,12 @@ export async function appendFollowUpAndRun(input: {
           : {}),
       },
     });
-  } else if (input.engine || input.model || input.effort) {
+  } else if (
+    input.engine ||
+    input.model ||
+    input.effort ||
+    (input.attachments && input.attachments.length > 0)
+  ) {
     updateCodeAgentRunRecord(input.runId, {
       metadata: {
         ...(input.engine ? { engine: input.engine } : {}),

--- a/templates/code/actions/_code-agent-ui.ts
+++ b/templates/code/actions/_code-agent-ui.ts
@@ -14,6 +14,7 @@ import {
   type CodeAgentTranscriptEvent as StoredTranscriptEvent,
 } from "@agent-native/core/code-agents";
 import type {
+  CodeAgentPromptAttachment,
   CodeAgentReasoningEffort,
   CodeAgentRun,
   CodeAgentTranscriptEvent,
@@ -121,6 +122,7 @@ export async function appendFollowUpAndRun(input: {
   model?: string;
   effort?: CodeAgentReasoningEffort;
   followUpMode?: CodeAgentFollowUpMode;
+  attachments?: CodeAgentPromptAttachment[];
 }): Promise<CodeAgentTranscriptEvent> {
   const record = getCodeAgentRunRecord(input.runId);
   if (!record)
@@ -133,6 +135,9 @@ export async function appendFollowUpAndRun(input: {
         ...(input.engine ? { engine: input.engine } : {}),
         ...(input.model ? { model: input.model } : {}),
         ...(input.effort ? { effort: input.effort } : {}),
+        ...(input.attachments && input.attachments.length > 0
+          ? { attachments: input.attachments }
+          : {}),
       },
     });
   } else if (input.engine || input.model || input.effort) {
@@ -141,6 +146,9 @@ export async function appendFollowUpAndRun(input: {
         ...(input.engine ? { engine: input.engine } : {}),
         ...(input.model ? { model: input.model } : {}),
         ...(input.effort ? { effort: input.effort } : {}),
+        ...(input.attachments && input.attachments.length > 0
+          ? { attachments: input.attachments }
+          : {}),
       },
     });
   }
@@ -156,6 +164,7 @@ export async function appendFollowUpAndRun(input: {
       engine: input.engine,
       model: input.model,
       effort: input.effort,
+      attachments: input.attachments,
     },
   });
   if (!result.ok) throw new Error(result.error ?? "Follow-up failed.");

--- a/templates/code/actions/append-code-agent-follow-up.ts
+++ b/templates/code/actions/append-code-agent-follow-up.ts
@@ -4,6 +4,14 @@ import type { CodeAgentReasoningEffort } from "@agent-native/code-agents-ui/type
 import { z } from "zod";
 import { appendFollowUpAndRun } from "./_code-agent-ui.js";
 
+const promptAttachmentSchema = z.object({
+  name: z.string().min(1),
+  type: z.string().optional(),
+  size: z.number().optional(),
+  text: z.string().optional(),
+  dataUrl: z.string().optional(),
+});
+
 export default defineAction({
   description:
     "Append a follow-up prompt to an existing local Agent-Native Code run and resume execution.",
@@ -16,6 +24,7 @@ export default defineAction({
     model: z.string().optional(),
     effort: z.string().optional(),
     followUpMode: z.enum(["immediate", "queued"]).optional(),
+    attachments: z.array(promptAttachmentSchema).optional(),
   }),
   run: async (args) => {
     const permissionMode = normalizeCodeAgentPermissionMode(
@@ -33,6 +42,7 @@ export default defineAction({
       model: args.model,
       effort,
       followUpMode: args.followUpMode,
+      attachments: args.attachments,
     });
     return {
       ok: true,

--- a/templates/code/actions/create-code-agent-run.ts
+++ b/templates/code/actions/create-code-agent-run.ts
@@ -113,6 +113,7 @@ export default defineAction({
       appendUserEvent: false,
       model: args.model,
       reasoningEffort: effort,
+      attachments,
     });
     return {
       ok: true,

--- a/templates/code/actions/create-code-agent-run.ts
+++ b/templates/code/actions/create-code-agent-run.ts
@@ -14,6 +14,14 @@ import {
 } from "./_code-agent-ui.js";
 import type { CodeAgentReasoningEffort } from "@agent-native/code-agents-ui/types";
 
+const promptAttachmentSchema = z.object({
+  name: z.string().min(1),
+  type: z.string().optional(),
+  size: z.number().optional(),
+  text: z.string().optional(),
+  dataUrl: z.string().optional(),
+});
+
 export default defineAction({
   description:
     "Create and start a local Agent-Native Code run. The run store is shared with the CLI and Desktop.",
@@ -25,6 +33,7 @@ export default defineAction({
     model: z.string().optional(),
     effort: z.string().optional(),
     cwd: z.string().optional(),
+    attachments: z.array(promptAttachmentSchema).optional(),
   }),
   run: async (args) => {
     const permissionMode =
@@ -32,6 +41,10 @@ export default defineAction({
     const prompt = args.prompt.trim();
     const goalId = args.goalId || "task";
     const cwd = args.cwd || process.cwd();
+    const attachments =
+      args.attachments && args.attachments.length > 0
+        ? args.attachments
+        : undefined;
     const effort =
       args.effort === "auto"
         ? undefined
@@ -75,6 +88,7 @@ export default defineAction({
         engine: args.engine,
         model: args.model,
         effort: args.effort,
+        attachments,
         cwd,
       },
     });
@@ -82,7 +96,7 @@ export default defineAction({
       runId: run.id,
       kind: "user",
       message: prompt,
-      metadata: { source: "initial-prompt" },
+      metadata: { source: "initial-prompt", attachments },
     });
     appendCodeAgentTranscriptEvent({
       runId: run.id,

--- a/templates/code/actions/update-code-agent-run.ts
+++ b/templates/code/actions/update-code-agent-run.ts
@@ -12,6 +12,7 @@ export default defineAction({
   schema: z.object({
     goalId: z.string().optional(),
     runId: z.string().min(1),
+    title: z.string().optional(),
     permissionMode: z.string().optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
   }),
@@ -27,14 +28,16 @@ export default defineAction({
       };
     }
     const metadata = args.metadata ?? {};
-    if (!permissionMode && Object.keys(metadata).length === 0) {
+    const title = args.title?.trim();
+    if (!permissionMode && !title && Object.keys(metadata).length === 0) {
       return {
         ok: false,
         message: "Nothing to update",
-        error: "Provide permissionMode or metadata.",
+        error: "Provide title, permissionMode, or metadata.",
       };
     }
     const run = updateCodeAgentRunRecord(args.runId, {
+      ...(title ? { title } : {}),
       ...(permissionMode ? { permissionMode } : {}),
       metadata: {
         ...metadata,


### PR DESCRIPTION
## Summary
- Reuse the shared agent chat runtime/composer/conversation primitives for the Electron Code dev-tab chat
- Move Code transcript normalization, transcript ordering, prompt attachments, and conversation styling into core shared modules
- Add Desktop Tailwind compilation coverage for core and code-agents-ui class sources so shared chat UI styles render in Electron

## Validation
- pnpm --filter @agent-native/core test
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/code-agents-ui typecheck
- pnpm --filter @agent-native/desktop-app typecheck
- pnpm --filter @agent-native/desktop-app build
- pnpm --filter code typecheck
- pnpm qa:composer-geometry
- git diff --check