### PR TITLE
Improve desktop updates and composer drops

### DIFF
--- a/.changeset/single-screenshot-drop.md
+++ b/.changeset/single-screenshot-drop.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prevent dropped screenshots in the agent composer from attaching twice.

--- a/packages/code-agents-ui/src/CodeAgentsApp.tsx
+++ b/packages/code-agents-ui/src/CodeAgentsApp.tsx
@@ -1182,7 +1182,6 @@ export default function CodeAgentsApp({
       setSearchPanelOpen(false);
       setMobilePanelOpen(false);
       if (result.event) setTranscriptEvents([result.event]);
-      toast(result.message, { duration: 2200 });
       if (typedGoal.id === selectedGoal.id) {
         await loadRuns(true);
       } else {
@@ -1353,6 +1352,12 @@ export default function CodeAgentsApp({
     }
   }
 
+  const showingSelectedRunDetail =
+    !workbenchOpen &&
+    !mobilePanelOpen &&
+    !searchPanelOpen &&
+    Boolean(selectedRun);
+
   return (
     <section className="code-agents-surface" aria-label="Agent-Native Code">
       <aside
@@ -1494,7 +1499,11 @@ export default function CodeAgentsApp({
             </div>
           </div>
         ) : (
-          <div className="code-agents-overview">
+          <div
+            className={`code-agents-overview${
+              showingSelectedRunDetail ? " code-agents-overview--chat" : ""
+            }`}
+          >
             {mobilePanelOpen ? (
               <MobileConnectorPanel
                 status={remoteConnectorStatus}
@@ -1907,7 +1916,9 @@ function CodeAgentComposer({
           ? "agent-native-code:new-session"
           : "agent-native-code:follow-up"
       }
-      initialText={promptSeed !== undefined ? prompt : undefined}
+      initialText={
+        promptSeed !== undefined && Number(promptSeed) > 0 ? prompt : undefined
+      }
       initialTextKey={promptSeed}
       toolbarSlot={modeControl}
       actionButton={stopButton}

--- a/packages/code-agents-ui/src/styles.css
+++ b/packages/code-agents-ui/src/styles.css
@@ -524,6 +524,17 @@
   padding: 16px 28px;
 }
 
+.code-agents-overview--chat {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.code-agents-overview--chat .code-agents-detail--chat {
+  flex: 1 1 auto;
+  height: auto;
+}
+
 .code-agents-start {
   min-height: calc(100vh - 150px);
   display: flex;

--- a/packages/core/src/cli/connect.spec.ts
+++ b/packages/core/src/cli/connect.spec.ts
@@ -633,8 +633,10 @@ describe("runConnect", () => {
     const root = tmpDir();
     const home = tmpDir();
     const oldHome = process.env.HOME;
+    const oldCi = process.env.CI;
     const preferencesFile = path.join(root, "prefs", "connect.json");
     process.env.HOME = home;
+    process.env.CI = "true";
     process.chdir(root);
 
     const promptClients = vi.fn(async (context) => {
@@ -671,6 +673,11 @@ describe("runConnect", () => {
       expect(codexToml).toContain('[mcp_servers."agent-native-mail"]');
     } finally {
       process.env.HOME = oldHome;
+      if (oldCi === undefined) {
+        delete process.env.CI;
+      } else {
+        process.env.CI = oldCi;
+      }
     }
   });
 

--- a/packages/core/src/cli/connect.ts
+++ b/packages/core/src/cli/connect.ts
@@ -235,9 +235,9 @@ function clientPromptOptions(): ConnectClientPromptContext["options"] {
 }
 
 function shouldPromptForClients(deps: ConnectDeps): boolean {
+  if (deps.isInteractive) return deps.isInteractive();
   if (process.env.AGENT_NATIVE_NO_PROMPT === "1") return false;
   if (process.env.CI === "true") return false;
-  if (deps.isInteractive) return deps.isInteractive();
   return !!process.stdin.isTTY && !!process.stdout.isTTY;
 }
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -3426,6 +3426,7 @@ const AssistantChatInner = forwardRef<
   }, []);
   const handleChatDrop = useCallback(
     (e: React.DragEvent) => {
+      if (e.defaultPrevented) return;
       const files = Array.from(e.dataTransfer?.files ?? []);
       if (files.length === 0) return;
       e.preventDefault();

--- a/packages/core/src/client/composer/TiptapComposer.spec.ts
+++ b/packages/core/src/client/composer/TiptapComposer.spec.ts
@@ -7,6 +7,7 @@ import {
   createTiptapComposerExtensions,
   displayableComposerModeMessage,
   getComposerSubmitIntentForEnterKey,
+  handleComposerFileDrop,
 } from "./TiptapComposer.js";
 
 describe("createTiptapComposerExtensions", () => {
@@ -98,5 +99,32 @@ describe("createTiptapComposerExtensions", () => {
     expect(
       getComposerSubmitIntentForEnterKey({ ...enter, metaKey: true }, false),
     ).toBeNull();
+  });
+
+  it("consumes composer file drops so parent drop targets do not attach duplicates", () => {
+    const file = new File(["fake"], "image.png", { type: "image/png" });
+    const added: File[] = [];
+    let prevented = false;
+    let stopped = false;
+    const handled = handleComposerFileDrop({
+      event: {
+        dataTransfer: { files: [file] },
+        preventDefault: () => {
+          prevented = true;
+        },
+        stopPropagation: () => {
+          stopped = true;
+        },
+      } as unknown as DragEvent,
+      addAttachment: async (attachment) => {
+        added.push(attachment);
+      },
+    });
+
+    expect(handled).toBe(true);
+    expect(prevented).toBe(true);
+    expect(stopped).toBe(true);
+    expect(added).toHaveLength(1);
+    expect(added[0]?.name).toMatch(/^\d+-[a-z0-9]+-image\.png$/);
   });
 });

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -116,6 +116,31 @@ export function displayableComposerModeMessage(options: {
   return `${options.messagePrefix}${modePrompt}`;
 }
 
+function uniquifyComposerImageFile(file: File): File {
+  if (!file.type.startsWith("image/")) return file;
+  const uniqueName = `${Date.now()}-${Math.random().toString(36).slice(2)}-${file.name}`;
+  return new File([file], uniqueName, { type: file.type });
+}
+
+export function handleComposerFileDrop(options: {
+  event: Pick<DragEvent, "dataTransfer" | "preventDefault" | "stopPropagation">;
+  addAttachment: (file: File) => Promise<unknown>;
+  onError?: (error: unknown) => void;
+}): boolean {
+  const droppedFiles = Array.from(options.event.dataTransfer?.files ?? []);
+  if (droppedFiles.length === 0) return false;
+
+  options.event.preventDefault();
+  options.event.stopPropagation();
+  const attachments = droppedFiles.map(uniquifyComposerImageFile);
+  void Promise.all(
+    attachments.map((file) => options.addAttachment(file)),
+  ).catch((error) => {
+    options.onError?.(error);
+  });
+  return true;
+}
+
 const BUILT_IN_COMMANDS: SlashCommand[] = [
   { name: "clear", description: "Start a new chat", icon: "clear" },
   { name: "new", description: "Start a new chat", icon: "new" },
@@ -1139,27 +1164,15 @@ export function TiptapComposer({
       },
       handleDrop: (_view, event) => {
         // Drag-and-drop files (decks, images, PDFs, etc.) into the composer.
-        // Without this, the browser navigates to the dropped file, which is
-        // surprising — users expect drop to attach the file like the "+" menu.
-        const dataTransfer = (event as DragEvent).dataTransfer;
-        const droppedFiles = Array.from(dataTransfer?.files ?? []);
-        if (droppedFiles.length === 0) return false;
-
-        event.preventDefault();
-        // Make image filenames unique so consecutive screenshots (all named
-        // `image.png`) don't collide on the attachment id, mirroring the
-        // paste handler's behavior.
-        const attachments = droppedFiles.map((file) => {
-          if (!file.type.startsWith("image/")) return file;
-          const uniqueName = `${Date.now()}-${Math.random().toString(36).slice(2)}-${file.name}`;
-          return new File([file], uniqueName, { type: file.type });
+        // Mark handled drops as consumed so the chat-wide drop target does not
+        // add the same file a second time.
+        return handleComposerFileDrop({
+          event: event as DragEvent,
+          addAttachment: (file) => composerRuntime.addAttachment(file),
+          onError: (error) => {
+            console.error("Error adding dropped attachment:", error);
+          },
         });
-        void Promise.all(
-          attachments.map((file) => composerRuntime.addAttachment(file)),
-        ).catch((error) => {
-          console.error("Error adding dropped attachment:", error);
-        });
-        return true;
       },
       handleKeyDown: (view, event) => {
         const pop = popoverStateRef.current;

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -5,6 +5,7 @@ import {
   dialog,
   ipcMain,
   Menu,
+  Notification,
   session,
   shell,
   webContents,
@@ -666,17 +667,72 @@ app.on("open-url", (event, url) => {
 // In dev, autoUpdater is unsupported (no app signature, no dev-app-update.yml),
 // so we report an "unsupported" status and skip all autoUpdater calls.
 
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+const UPDATE_FOCUS_CHECK_MIN_INTERVAL_MS = 15 * 60 * 1000;
+
 let currentUpdateStatus: UpdateStatus = IS_DEV
   ? { state: "unsupported", reason: "Auto-update is disabled in development" }
   : { state: "idle" };
+let updateCheckInFlight: Promise<unknown> | null = null;
+let lastUpdateCheckStartedAt = 0;
+let notifiedUpdateVersion: string | null = null;
 
 function broadcastUpdateStatus(status: UpdateStatus) {
   currentUpdateStatus = status;
+  refreshApplicationMenu();
   for (const win of BrowserWindow.getAllWindows()) {
     if (!win.isDestroyed()) {
       win.webContents.send(IPC.UPDATE_STATUS_CHANGED, status);
     }
   }
+}
+
+async function checkForAppUpdates(): Promise<UpdateStatus> {
+  if (IS_DEV) return currentUpdateStatus;
+  if (currentUpdateStatus.state === "downloaded") return currentUpdateStatus;
+
+  if (!updateCheckInFlight) {
+    lastUpdateCheckStartedAt = Date.now();
+    updateCheckInFlight = autoUpdater
+      .checkForUpdates()
+      .catch((err) => {
+        broadcastUpdateStatus({
+          state: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        updateCheckInFlight = null;
+      });
+  }
+
+  await updateCheckInFlight;
+  return currentUpdateStatus;
+}
+
+function maybeCheckForAppUpdates() {
+  if (IS_DEV) return;
+  if (currentUpdateStatus.state === "downloaded") return;
+  if (
+    updateCheckInFlight ||
+    Date.now() - lastUpdateCheckStartedAt < UPDATE_FOCUS_CHECK_MIN_INTERVAL_MS
+  ) {
+    return;
+  }
+  void checkForAppUpdates();
+}
+
+function showUpdateReadyNotification(version: string) {
+  if (!Notification.isSupported()) return;
+  if (notifiedUpdateVersion === version) return;
+  notifiedUpdateVersion = version;
+
+  const notification = new Notification({
+    title: "Agent Native update ready",
+    body: `Version ${version} is downloaded. Open Agent Native to relaunch and install it.`,
+  });
+  notification.on("click", focusMainWindow);
+  notification.show();
 }
 
 if (!IS_DEV) {
@@ -720,6 +776,7 @@ if (!IS_DEV) {
       releaseNotes:
         typeof info.releaseNotes === "string" ? info.releaseNotes : undefined,
     });
+    showUpdateReadyNotification(info.version);
   });
 
   autoUpdater.on("error", (err) => {
@@ -730,33 +787,18 @@ if (!IS_DEV) {
   });
 
   app.whenReady().then(() => {
-    autoUpdater.checkForUpdates().catch(() => {
-      // Errors are surfaced via the 'error' event above; swallow the
-      // promise rejection so it doesn't become an unhandled rejection.
-    });
-    // Re-check every 4 hours
-    setInterval(
-      () => {
-        autoUpdater.checkForUpdates().catch(() => {});
-      },
-      4 * 60 * 60 * 1000,
-    );
+    void checkForAppUpdates();
+    setInterval(() => void checkForAppUpdates(), UPDATE_CHECK_INTERVAL_MS);
   });
+
+  app.on("browser-window-focus", maybeCheckForAppUpdates);
+  app.on("activate", maybeCheckForAppUpdates);
 }
 
 ipcMain.handle(IPC.UPDATE_GET_STATUS, (): UpdateStatus => currentUpdateStatus);
 
 ipcMain.handle(IPC.UPDATE_CHECK, async (): Promise<UpdateStatus> => {
-  if (IS_DEV) return currentUpdateStatus;
-  try {
-    await autoUpdater.checkForUpdates();
-  } catch (err) {
-    broadcastUpdateStatus({
-      state: "error",
-      message: err instanceof Error ? err.message : String(err),
-    });
-  }
-  return currentUpdateStatus;
+  return checkForAppUpdates();
 });
 
 ipcMain.handle(IPC.UPDATE_DOWNLOAD, async (): Promise<UpdateStatus> => {
@@ -4951,8 +4993,9 @@ ipcMain.on(IPC.INTER_APP_SEND, (event: IpcMainEvent, msg: InterAppMessage) => {
 // ---------- OAuth handling ----------
 // OAuth providers we recognize and keep out of app webviews. Depending on the
 // provider and flow, the URL is opened in an Electron BrowserWindow or the
-// system browser. Builder opens in the system browser so users keep their
-// normal logged-in session and browser controls. Each provider specifies:
+// system browser. App-webview Builder connect stays in an Electron popup so the
+// callback shares the app session; the desktop Code provider has its own
+// loopback browser flow. Each provider specifies:
 //   - a `matches` predicate on the initial URL (from window.open)
 //   - a `callbackPathFragment` used to detect when the OAuth callback has
 //     been reached so we can auto-close the popup
@@ -5008,6 +5051,15 @@ function isTrustedGoogleOAuthStarter(
   return getUrlOrigin(context?.sourceUrl) === url.origin;
 }
 
+function isBuilderAppHost(host: string): boolean {
+  return (
+    host === "builder.io" ||
+    host.endsWith(".builder.io") ||
+    host === "builder.my" ||
+    host.endsWith(".builder.my")
+  );
+}
+
 const OAUTH_PROVIDERS: OAuthProvider[] = [
   {
     name: "google",
@@ -5034,9 +5086,7 @@ const OAUTH_PROVIDERS: OAuthProvider[] = [
       // webview don't get hijacked into the OAuth popup — they'd load
       // fine but never hit the callback and the popup would just sit
       // open on a docs page.
-      const isBuilderDomain =
-        host === "builder.io" || host.endsWith(".builder.io");
-      return isBuilderDomain && u.pathname.startsWith("/cli-auth");
+      return isBuilderAppHost(host) && u.pathname.startsWith("/cli-auth");
     },
     callbackPathFragments: ["/_agent-native/builder/callback"],
   },
@@ -5275,8 +5325,24 @@ function googleOAuthUsesDesktopExchange(url: URL): boolean {
   return !!extractFlowFromOAuthState(url.searchParams.get("state"));
 }
 
+function builderOAuthUsesDesktopProvider(url: URL): boolean {
+  if (!url.pathname.startsWith("/cli-auth")) return false;
+  if (url.searchParams.get("host") === "agent-native-desktop") return true;
+  const redirectUrl = url.searchParams.get("redirect_url");
+  if (!redirectUrl) return false;
+  try {
+    return new URL(redirectUrl).pathname.endsWith(
+      "/_agent-native/desktop-builder/callback",
+    );
+  } catch {
+    return false;
+  }
+}
+
 function shouldOpenOAuthInSystemBrowser(provider: OAuthProvider, url: URL) {
-  if (provider.name === "builder") return true;
+  if (provider.name === "builder") {
+    return builderOAuthUsesDesktopProvider(url);
+  }
   // Google blocks embedded/Electron OAuth surfaces. Framework pages that pass
   // a flow id poll /desktop-exchange, so the system browser can complete the
   // OAuth callback and the app webview can claim the resulting session token.
@@ -5690,6 +5756,144 @@ app.on("web-contents-created", (_event, contents) => {
 
 // ---------- App lifecycle ----------
 
+function buildUpdateMenuItem(): Electron.MenuItemConstructorOptions {
+  if (IS_DEV) {
+    return {
+      label: "Check for Updates...",
+      enabled: false,
+    };
+  }
+
+  if (currentUpdateStatus.state === "downloaded") {
+    return {
+      label: currentUpdateStatus.version
+        ? `Relaunch to Install Update ${currentUpdateStatus.version}`
+        : "Relaunch to Install Update",
+      click: () => autoUpdater.quitAndInstall(false, true),
+    };
+  }
+
+  if (currentUpdateStatus.state === "downloading") {
+    return {
+      label: `Downloading Update (${currentUpdateStatus.percent}%)`,
+      enabled: false,
+    };
+  }
+
+  if (currentUpdateStatus.state === "available") {
+    return {
+      label: currentUpdateStatus.version
+        ? `Downloading Update ${currentUpdateStatus.version}`
+        : "Downloading Update",
+      enabled: false,
+    };
+  }
+
+  if (currentUpdateStatus.state === "checking") {
+    return {
+      label: "Checking for Updates...",
+      enabled: false,
+    };
+  }
+
+  return {
+    label:
+      currentUpdateStatus.state === "error"
+        ? "Retry Update Check"
+        : "Check for Updates...",
+    click: () => void checkForAppUpdates(),
+  };
+}
+
+function buildCurrentVersionMenuItem(): Electron.MenuItemConstructorOptions {
+  return {
+    label: `Current Version ${app.getVersion()}`,
+    enabled: false,
+  };
+}
+
+function installApplicationMenu() {
+  const isMac = process.platform === "darwin";
+  const appMenu: Electron.MenuItemConstructorOptions = {
+    label: app.getName(),
+    submenu: [
+      { role: "about" as const },
+      { type: "separator" as const },
+      buildUpdateMenuItem(),
+      buildCurrentVersionMenuItem(),
+      { type: "separator" as const },
+      { role: "services" as const },
+      { type: "separator" as const },
+      { role: "hide" as const },
+      { role: "hideOthers" as const },
+      { role: "unhide" as const },
+      { type: "separator" as const },
+      { role: "quit" as const },
+    ],
+  };
+
+  const helpMenu: Electron.MenuItemConstructorOptions = {
+    role: "help" as const,
+    submenu: isMac
+      ? [buildCurrentVersionMenuItem()]
+      : [
+          buildUpdateMenuItem(),
+          buildCurrentVersionMenuItem(),
+          { type: "separator" as const },
+          {
+            label: "Learn More",
+            click: () => void shell.openExternal("https://agent-native.com"),
+          },
+        ],
+  };
+
+  // Replace the default app menu so Cmd+Option+I doesn't open shell DevTools.
+  // We handle this shortcut ourselves via before-input-event → toggleWebviewDevTools().
+  const template: Electron.MenuItemConstructorOptions[] = [
+    ...(isMac ? [appMenu] : []),
+    { role: "fileMenu" as const },
+    { role: "editMenu" as const },
+    {
+      label: "View",
+      submenu: [
+        { role: "reload" as const },
+        { role: "forceReload" as const },
+        {
+          label: "Toggle Developer Tools",
+          accelerator: "CmdOrCtrl+Option+I",
+          click: () => toggleWebviewDevTools(),
+        },
+        { type: "separator" as const },
+        {
+          label: "Actual Size",
+          accelerator: "CmdOrCtrl+0",
+          click: () => resetActiveWebviewZoom(),
+        },
+        {
+          label: "Zoom In",
+          accelerator: "CmdOrCtrl+Plus",
+          click: () => zoomActiveWebview(ZOOM_STEP),
+        },
+        {
+          label: "Zoom Out",
+          accelerator: "CmdOrCtrl+-",
+          click: () => zoomActiveWebview(-ZOOM_STEP),
+        },
+        { type: "separator" as const },
+        { role: "togglefullscreen" as const },
+      ],
+    },
+    { role: "windowMenu" as const },
+    helpMenu,
+  ];
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
+function refreshApplicationMenu() {
+  if (!app.isReady()) return;
+  installApplicationMenu();
+}
+
 app.whenReady().then(() => {
   // Process any deep link that arrived before the app was ready
   if (pendingDeepLink) {
@@ -5789,52 +5993,7 @@ app.whenReady().then(() => {
     configureWebviewSession(wc.session, id);
   });
 
-  // Replace the default app menu so Cmd+Option+I doesn't open shell DevTools.
-  // We handle this shortcut ourselves via before-input-event → toggleWebviewDevTools().
-  const isMac = process.platform === "darwin";
-  const template: Electron.MenuItemConstructorOptions[] = [
-    ...(isMac
-      ? [
-          {
-            role: "appMenu" as const,
-          },
-        ]
-      : []),
-    { role: "fileMenu" as const },
-    { role: "editMenu" as const },
-    {
-      label: "View",
-      submenu: [
-        { role: "reload" as const },
-        { role: "forceReload" as const },
-        {
-          label: "Toggle Developer Tools",
-          accelerator: "CmdOrCtrl+Option+I",
-          click: () => toggleWebviewDevTools(),
-        },
-        { type: "separator" as const },
-        {
-          label: "Actual Size",
-          accelerator: "CmdOrCtrl+0",
-          click: () => resetActiveWebviewZoom(),
-        },
-        {
-          label: "Zoom In",
-          accelerator: "CmdOrCtrl+Plus",
-          click: () => zoomActiveWebview(ZOOM_STEP),
-        },
-        {
-          label: "Zoom Out",
-          accelerator: "CmdOrCtrl+-",
-          click: () => zoomActiveWebview(-ZOOM_STEP),
-        },
-        { type: "separator" as const },
-        { role: "togglefullscreen" as const },
-      ],
-    },
-    { role: "windowMenu" as const },
-  ];
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+  installApplicationMenu();
 
   reconcileInterruptedCodeAgentRuns("startup");
 

--- a/packages/desktop-app/src/renderer/components/AppSettings.tsx
+++ b/packages/desktop-app/src/renderer/components/AppSettings.tsx
@@ -8,12 +8,17 @@ import {
   IconCheck,
   IconChevronRight,
   IconChevronDown,
+  IconDownload,
+  IconLoader2,
+  IconRefresh,
   IconWorld,
   IconTerminal2,
 } from "@tabler/icons-react";
 import type { AppConfig } from "@shared/app-registry";
+import type { UpdateStatus } from "@shared/ipc-channels";
 import { generateAppId } from "@shared/app-registry";
 import { CodeProviderSettings } from "./CodeProviderSettings";
+import { useUpdateStatus } from "./UpdateIndicator.js";
 
 interface FrameSettings {
   enabled: boolean;
@@ -30,6 +35,7 @@ interface AppSettingsProps {
 }
 
 type RemoteStatusTone = "ok" | "pending" | "offline" | "error";
+type UpdateStatusTone = "ok" | "pending" | "ready" | "offline" | "error";
 
 function inferPortFromUrl(url: string): number {
   try {
@@ -122,6 +128,197 @@ function remoteStatusCopy(status: CodeAgentRemoteConnectorStatus | null): {
     description: "Remote control is not currently polling.",
     tone: "offline",
   };
+}
+
+function updateStatusCopy(status: UpdateStatus | null): {
+  label: string;
+  description: string;
+  tone: UpdateStatusTone;
+} {
+  if (!status) {
+    return {
+      label: "Checking",
+      description: "Reading software update status.",
+      tone: "pending",
+    };
+  }
+
+  if (status.state === "unsupported") {
+    return {
+      label: "Unavailable",
+      description: status.reason,
+      tone: "offline",
+    };
+  }
+
+  if (status.state === "checking") {
+    return {
+      label: "Checking",
+      description: "Looking for the newest Agent Native release.",
+      tone: "pending",
+    };
+  }
+
+  if (status.state === "available") {
+    return {
+      label: "Downloading",
+      description: `Version ${status.version} is available and will install after download.`,
+      tone: "pending",
+    };
+  }
+
+  if (status.state === "downloading") {
+    return {
+      label: "Downloading",
+      description: `Update download is ${status.percent}% complete.`,
+      tone: "pending",
+    };
+  }
+
+  if (status.state === "downloaded") {
+    return {
+      label: "Ready",
+      description: `Version ${status.version} is downloaded. Relaunch to install it.`,
+      tone: "ready",
+    };
+  }
+
+  if (status.state === "not-available") {
+    return {
+      label: "Up to date",
+      description: `Agent Native ${status.currentVersion} is the latest available version.`,
+      tone: "ok",
+    };
+  }
+
+  if (status.state === "error") {
+    return {
+      label: "Needs retry",
+      description: status.message,
+      tone: "error",
+    };
+  }
+
+  return {
+    label: "Automatic",
+    description: "Agent Native checks for updates in the background.",
+    tone: "ok",
+  };
+}
+
+function SoftwareUpdateCard() {
+  const status = useUpdateStatus();
+  const copy = updateStatusCopy(status);
+  const [working, setWorking] = useState<"check" | "download" | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const updater = window.electronAPI?.updater;
+  const isBusy =
+    working !== null ||
+    status?.state === "checking" ||
+    status?.state === "downloading" ||
+    status?.state === "available";
+  const canCheck =
+    Boolean(updater) &&
+    !isBusy &&
+    status?.state !== "downloaded" &&
+    status?.state !== "unsupported";
+  const canDownload = Boolean(updater) && status?.state === "available";
+  const canInstall = Boolean(updater) && status?.state === "downloaded";
+
+  const handleCheck = useCallback(async () => {
+    if (!updater || !canCheck) return;
+    setWorking("check");
+    setMessage(null);
+    try {
+      await updater.check();
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : String(err));
+    } finally {
+      setWorking(null);
+    }
+  }, [canCheck, updater]);
+
+  const handleDownload = useCallback(async () => {
+    if (!updater || !canDownload) return;
+    setWorking("download");
+    setMessage(null);
+    try {
+      await updater.download();
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : String(err));
+    } finally {
+      setWorking(null);
+    }
+  }, [canDownload, updater]);
+
+  const handleInstall = useCallback(() => {
+    if (!updater || !canInstall) return;
+    updater.install();
+  }, [canInstall, updater]);
+
+  return (
+    <div className={`settings-update-card settings-update-card--${copy.tone}`}>
+      <div className="settings-update-row">
+        <div className="settings-update-title">
+          <span
+            className={`settings-update-dot settings-update-dot--${copy.tone}`}
+          />
+          <div>
+            <span className="settings-mode-card-title">Software Updates</span>
+            <span className="settings-mode-card-status">
+              {copy.label} · {copy.description}
+            </span>
+          </div>
+        </div>
+        <div className="settings-update-actions">
+          {canInstall ? (
+            <button
+              type="button"
+              className="settings-btn settings-btn--primary settings-update-btn"
+              onClick={handleInstall}
+            >
+              <IconRefresh size={14} />
+              Relaunch
+            </button>
+          ) : canDownload ? (
+            <button
+              type="button"
+              className="settings-btn settings-btn--primary settings-update-btn"
+              onClick={handleDownload}
+              disabled={working === "download"}
+            >
+              {working === "download" ? (
+                <IconLoader2 size={14} className="settings-update-spin" />
+              ) : (
+                <IconDownload size={14} />
+              )}
+              Download
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="settings-btn settings-btn--ghost settings-update-btn"
+              onClick={handleCheck}
+              disabled={!canCheck}
+            >
+              {working === "check" || status?.state === "checking" ? (
+                <IconLoader2 size={14} className="settings-update-spin" />
+              ) : (
+                <IconRefresh size={14} />
+              )}
+              Check
+            </button>
+          )}
+        </div>
+      </div>
+      {status?.state === "downloading" && (
+        <div className="settings-update-progress" aria-hidden="true">
+          <span style={{ width: `${Math.min(100, status.percent)}%` }} />
+        </div>
+      )}
+      {message && <div className="settings-update-message">{message}</div>}
+    </div>
+  );
 }
 
 export default function AppSettings({
@@ -361,6 +558,8 @@ export default function AppSettings({
               </div>
             </div>
           )}
+
+          <SoftwareUpdateCard />
 
           {providerSettings && (
             <CodeProviderSettings

--- a/packages/desktop-app/src/renderer/components/UpdateIndicator.tsx
+++ b/packages/desktop-app/src/renderer/components/UpdateIndicator.tsx
@@ -11,7 +11,10 @@ export function useUpdateStatus(): UpdateStatus | null {
   useEffect(() => {
     const updater = window.electronAPI?.updater;
     if (!updater) return;
-    updater.getStatus().then(setStatus);
+    updater
+      .getStatus()
+      .then(setStatus)
+      .catch(() => {});
     return updater.onStatusChange(setStatus);
   }, []);
 
@@ -89,7 +92,7 @@ export function UpdateIndicator() {
       <span className="icon-wrapper">
         <IconRefresh size={18} strokeWidth={1.75} />
       </span>
-      <span className="item-label">Restart</span>
+      <span className="item-label">Relaunch</span>
     </button>
   );
 }

--- a/packages/desktop-app/src/renderer/components/UpdatePrompt.tsx
+++ b/packages/desktop-app/src/renderer/components/UpdatePrompt.tsx
@@ -42,7 +42,7 @@ export default function UpdatePrompt() {
           Update ready
         </div>
         <div className="update-prompt-subtitle">
-          Version {status.version} has been downloaded. Restart Agent Native to
+          Version {status.version} has been downloaded. Relaunch Agent Native to
           finish installing.
         </div>
       </div>
@@ -62,7 +62,7 @@ export default function UpdatePrompt() {
           onClick={installNow}
         >
           <IconRefresh size={14} strokeWidth={2} />
-          Restart now
+          Relaunch now
         </button>
       </div>
       <button

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -1235,6 +1235,119 @@ body {
   word-break: break-word;
 }
 
+.settings-update-card {
+  display: grid;
+  gap: 10px;
+  padding: 12px 14px;
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  margin-bottom: 12px;
+}
+
+.settings-update-card--ready {
+  border-color: rgba(34, 197, 94, 0.22);
+  background: rgba(34, 197, 94, 0.055);
+}
+
+.settings-update-card--error {
+  border-color: rgba(239, 68, 68, 0.18);
+}
+
+.settings-update-row,
+.settings-update-title,
+.settings-update-actions {
+  display: flex;
+  align-items: center;
+}
+
+.settings-update-row {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.settings-update-title {
+  min-width: 0;
+  gap: 9px;
+}
+
+.settings-update-title > div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.settings-update-actions {
+  flex: 0 0 auto;
+}
+
+.settings-update-btn {
+  width: auto;
+  min-width: 86px;
+  height: 32px;
+  margin-bottom: 0;
+  padding: 0 11px;
+  white-space: nowrap;
+}
+
+.settings-update-dot {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #555;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.035);
+}
+
+.settings-update-dot--ok,
+.settings-update-dot--ready {
+  background: #22c55e;
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.12);
+}
+
+.settings-update-dot--pending {
+  background: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
+}
+
+.settings-update-dot--offline {
+  background: #6b7280;
+}
+
+.settings-update-dot--error {
+  background: #ef4444;
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.12);
+}
+
+.settings-update-progress {
+  height: 3px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.settings-update-progress span {
+  display: block;
+  height: 100%;
+  min-width: 8px;
+  border-radius: inherit;
+  background: #60a5fa;
+  transition: width var(--ease);
+}
+
+.settings-update-message {
+  color: #fca5a5;
+  font-size: 11px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.settings-update-spin {
+  animation: spin 0.8s linear infinite;
+}
+
 .settings-remote-card {
   display: grid;
   gap: 10px;

--- a/scripts/qa-composer-geometry-smoke.ts
+++ b/scripts/qa-composer-geometry-smoke.ts
@@ -122,6 +122,16 @@ function assertSourceContract(): void {
     /\.code-agents-standard-composer \[data-agent-composer-slot="model-button"\][\s\S]*font-size:\s*11px !important/,
     "Code model picker should match the compact composer font size",
   );
+  assert.match(
+    codeAgentsApp,
+    /showingSelectedRunDetail[\s\S]*code-agents-overview--chat/,
+    "Agent-Native Code should mark selected transcript views with a chat layout class",
+  );
+  assert.match(
+    codeStyles,
+    /\.code-agents-overview--chat\s*\{[\s\S]*overflow:\s*hidden/,
+    "Selected Agent-Native Code transcripts should keep scrolling inside the chat, not the outer overview",
+  );
 }
 
 function fixtureHtml(): string {
@@ -263,6 +273,73 @@ function fixtureHtml(): string {
           </div>
         </div>
       </div>
+    </section>
+    <section
+      data-smoke="code-chat-layout"
+      class="code-agents-surface"
+      style="height: 420px; width: 900px; margin: 32px auto;"
+      aria-label="Agent-Native Code chat layout"
+    >
+      <aside class="code-agents-rail" aria-label="Agent-Native Code goals and sessions"></aside>
+      <main class="code-agents-main">
+        <div data-smoke="code-chat-overview" class="code-agents-overview code-agents-overview--chat">
+          <div class="code-agents-detail code-agents-detail--chat">
+            <div class="code-agents-chat-header">
+              <div>
+                <h3>Review transcript scroll behavior</h3>
+                <p>Updated just now</p>
+              </div>
+            </div>
+            <div class="code-agents-transcript">
+              <div
+                class="code-agents-transcript__assistant"
+                style="display: flex; flex-direction: column; height: 100%; min-height: 0; flex: 1 1 auto;"
+              >
+                <div
+                  data-smoke="code-chat-scroll"
+                  style="flex: 1 1 auto; min-height: 0; overflow-y: auto; overflow-x: hidden;"
+                >
+                  <div
+                    class="agent-thread-content"
+                    style="display: flex; flex-direction: column; gap: 16px; padding: 16px;"
+                  >
+                    <p>First transcript block with enough text to establish the scroll container.</p>
+                    <p>Second transcript block with enough text to establish the scroll container.</p>
+                    <p>Third transcript block with enough text to establish the scroll container.</p>
+                    <p>Fourth transcript block with enough text to establish the scroll container.</p>
+                    <p>Fifth transcript block with enough text to establish the scroll container.</p>
+                    <p>Sixth transcript block with enough text to establish the scroll container.</p>
+                    <p>Seventh transcript block with enough text to establish the scroll container.</p>
+                    <p>Eighth transcript block with enough text to establish the scroll container.</p>
+                    <p>Ninth transcript block with enough text to establish the scroll container.</p>
+                    <p data-smoke="code-chat-last">Final transcript line must remain above the composer after scrolling to the bottom.</p>
+                  </div>
+                </div>
+                <div
+                  data-smoke="code-chat-composer"
+                  data-agent-composer-variant="default"
+                  data-agent-composer-slot="area"
+                  class="agent-composer-area shrink-0 px-3 py-2 text-left code-agents-standard-composer code-agents-composer-shell"
+                >
+                  <div data-agent-composer-slot="root" class="agent-composer-root flex flex-col rounded-lg border border-input bg-background">
+                    <div data-agent-composer-slot="editor-wrap" class="agent-composer-editor-wrap px-2 pt-2 pb-1">
+                      <div data-agent-composer-slot="editor" class="agent-composer-editor aui-composer flex-1 min-w-0 px-0.5">
+                        <div data-agent-composer-slot="editor-input" class="ProseMirror agent-composer-prosemirror" contenteditable="true">Send a follow-up...</div>
+                      </div>
+                    </div>
+                    <div data-agent-composer-slot="toolbar" class="agent-composer-toolbar flex items-center gap-1 px-2 py-1.5">
+                      <button class="code-composer-plus" aria-label="Add attachment" type="button">+</button>
+                      <div data-agent-composer-slot="toolbar-spacer" class="flex-1"></div>
+                      <button data-agent-composer-slot="model-button" class="agent-composer-model-button" aria-label="Model" type="button"><span>Auto</span></button>
+                      <button data-agent-composer-slot="send-button" class="agent-composer-send-button shrink-0" aria-label="Send message" type="button">↑</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
     </section>
   </body>
 </html>`;
@@ -476,6 +553,54 @@ async function main(): Promise<void> {
     assertComposerGeometry(sidebarSnapshot, "Shared sidebar composer", {
       hasFolder: false,
     });
+
+    const chatLayout = await page.evaluate(() => {
+      const overview = document.querySelector<HTMLElement>(
+        '[data-smoke="code-chat-overview"]',
+      );
+      const scroll = document.querySelector<HTMLElement>(
+        '[data-smoke="code-chat-scroll"]',
+      );
+      const composer = document.querySelector<HTMLElement>(
+        '[data-smoke="code-chat-composer"]',
+      );
+      const last = document.querySelector<HTMLElement>(
+        '[data-smoke="code-chat-last"]',
+      );
+      if (!overview || !scroll || !composer || !last) {
+        throw new Error("Missing code chat layout smoke element");
+      }
+      scroll.scrollTop = scroll.scrollHeight;
+      const scrollRect = scroll.getBoundingClientRect();
+      const composerRect = composer.getBoundingClientRect();
+      const lastRect = last.getBoundingClientRect();
+
+      return {
+        overviewOverflowY: getComputedStyle(overview).overflowY,
+        innerCanScroll: scroll.scrollHeight > scroll.clientHeight + 1,
+        scrollBottom: scrollRect.bottom,
+        composerTop: composerRect.top,
+        lastBottom: lastRect.bottom,
+      };
+    });
+
+    assert.equal(
+      chatLayout.overviewOverflowY,
+      "hidden",
+      "Agent-Native Code selected chat view should not create an outer scroll layer",
+    );
+    assert.ok(
+      chatLayout.innerCanScroll,
+      "Agent-Native Code selected chat view should keep transcript scrolling inside the chat",
+    );
+    assert.ok(
+      chatLayout.scrollBottom <= chatLayout.composerTop + 1,
+      "Agent-Native Code selected chat scroll area should end before the composer",
+    );
+    assert.ok(
+      chatLayout.lastBottom <= chatLayout.composerTop + 1,
+      "Agent-Native Code selected chat content should not sit under the composer",
+    );
   } finally {
     await browser.close();
   }


### PR DESCRIPTION
## Summary
- Add desktop update status controls in settings, menu items, foreground-triggered update checks, and downloaded-update notifications.
- Keep Builder app-webview OAuth in an Electron popup unless it is the desktop Code provider flow.
- Prevent composer file drops from bubbling into parent chat drop targets and double-attaching screenshots.
- Tighten Agent-Native Code selected transcript layout so scrolling stays inside the chat view.

## Validation
- npx prettier --write .changeset/single-screenshot-drop.md packages/code-agents-ui/src/CodeAgentsApp.tsx packages/code-agents-ui/src/styles.css packages/core/src/client/AssistantChat.tsx packages/core/src/client/composer/TiptapComposer.spec.ts packages/core/src/client/composer/TiptapComposer.tsx packages/desktop-app/src/main/index.ts packages/desktop-app/src/renderer/components/AppSettings.tsx packages/desktop-app/src/renderer/components/UpdateIndicator.tsx packages/desktop-app/src/renderer/components/UpdatePrompt.tsx packages/desktop-app/src/renderer/shell.css scripts/qa-composer-geometry-smoke.ts
- pnpm --filter @agent-native/core exec vitest run src/client/composer/TiptapComposer.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/code-agents-ui typecheck
- pnpm --filter @agent-native/desktop-app typecheck
- pnpm exec tsx scripts/qa-composer-geometry-smoke.ts

## Follow-up Monitoring
I will babysit this PR for CI and review feedback.
