### PR TITLE
Address provider credential and OAuth followups

### DIFF
--- a/.changeset/oauth-provider-followups.md
+++ b/.changeset/oauth-provider-followups.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep Builder iframe Google sign-in on the popup path when redirects cannot work.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1741,9 +1741,15 @@ describe("server/auth", () => {
         "function __anStartRedirectOAuth(ret, btn, err, flowId, reason)",
       );
       expect(html).toContain(
+        "function __anHandlePopupOAuthFailure(ret, btn, err, flowId, redirectReason, builderFrameMessage)",
+      );
+      expect(html).toContain(
         "Google popup was blocked; falling back to redirect",
       );
-      expect(html).not.toContain("Allow popups for this site");
+      expect(html).toContain("Allow popups for this site and try again");
+      expect(html).toContain(
+        "Opening Google sign-in redirect from Builder preview",
+      );
       expect(html).toContain(
         "never reached this app. Check the Google OAuth redirect URI",
       );
@@ -1887,9 +1893,15 @@ describe("server/auth", () => {
         "function __anStartRedirectOAuth(ret, btn, err, flowId, reason)",
       );
       expect(loginHtml).toContain(
+        "function __anHandlePopupOAuthFailure(ret, btn, err, flowId, redirectReason, builderFrameMessage)",
+      );
+      expect(loginHtml).toContain(
         "Google popup was blocked; falling back to redirect",
       );
-      expect(loginHtml).not.toContain("Allow popups for this site");
+      expect(loginHtml).toContain("Allow popups for this site and try again");
+      expect(loginHtml).toContain(
+        "Opening Google sign-in redirect from Builder preview",
+      );
       expect(loginHtml).toContain(
         "never reached this app. Check the Google OAuth redirect URI",
       );

--- a/packages/core/src/server/google-auth-plugin.ts
+++ b/packages/core/src/server/google-auth-plugin.ts
@@ -318,6 +318,13 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
     err.classList.add('show');
     btn.disabled = false;
   }
+  function __anHandlePopupOAuthFailure(ret, btn, err, flowId, redirectReason, builderFrameMessage) {
+    if (__anIsBuilderPreview() && __anIsInFrame()) {
+      __anShowOAuthError(err, btn, builderFrameMessage + ' Allow popups for this site and try again (flow ' + __anFlowDebugId(flowId) + ').');
+      return;
+    }
+    __anStartRedirectOAuth(ret, btn, err, flowId, redirectReason);
+  }
   function __anStartRedirectOAuth(ret, btn, err, flowId, reason) {
     var params = new URLSearchParams();
     var oauthReturn = __anIsBuilderPreview() ? __anOAuthReturnTarget(ret) : ret;
@@ -380,7 +387,7 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
     try {
       var popup = window.open('', '_blank', 'width=640,height=760');
       if (!popup) {
-        __anStartRedirectOAuth(ret, btn, err, flowId, 'Google popup was blocked; falling back to redirect');
+        __anHandlePopupOAuthFailure(ret, btn, err, flowId, 'Google popup was blocked; falling back to redirect', 'Google popup was blocked.');
         return;
       }
       try { popup.opener = null; } catch(e) {}
@@ -388,12 +395,12 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
         popup.location.href = url;
       } catch(e) {
         try { popup.close(); } catch(closeErr) {}
-        __anStartRedirectOAuth(ret, btn, err, flowId, 'Could not navigate Google popup; falling back to redirect');
+        __anHandlePopupOAuthFailure(ret, btn, err, flowId, 'Could not navigate Google popup; falling back to redirect', 'Could not navigate Google popup.');
         return;
       }
       __anSetOAuthDebug('Google popup opened; waiting for callback', flowId);
     } catch(e) {
-      __anStartRedirectOAuth(ret, btn, err, flowId, 'Could not open Google popup; falling back to redirect');
+      __anHandlePopupOAuthFailure(ret, btn, err, flowId, 'Could not open Google popup; falling back to redirect', 'Could not open Google popup.');
       return;
     }
     __anWaitForOAuthExchange(flowId, ret, btn, err);
@@ -429,7 +436,8 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
       return;
     }
     if (__anIsBuilderPreview()) {
-      __anStartRedirectOAuth(ret, btn, err);
+      var flowId = __anNewOAuthFlowId();
+      __anStartRedirectOAuth(ret, btn, err, flowId, 'Opening Google sign-in redirect from Builder preview');
       return;
     }
     try {

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -90,6 +90,13 @@ describe("getOnboardingHtml", () => {
       "__anSetOAuthDebug(reason || 'Opening Google sign-in redirect', flowId)",
     );
     expect(html).toContain(
+      "function __anHandlePopupOAuthFailure(ret, btn, err, flowId, redirectReason, builderFrameMessage)",
+    );
+    expect(html).toContain("Allow popups for this site and try again");
+    expect(html).toContain(
+      "Opening Google sign-in redirect from Builder preview",
+    );
+    expect(html).toContain(
       "__anSetOAuthDebug('Opening Google sign-in in system browser', flowId)",
     );
     expect(html).toContain("function __anBuilderPreviewReturnOrigin()");

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1140,6 +1140,13 @@ ${
       err.classList.add('show');
       btn.disabled = false;
     }
+    function __anHandlePopupOAuthFailure(ret, btn, err, flowId, redirectReason, builderFrameMessage) {
+      if (__anIsBuilderPreview() && __anIsInFrame()) {
+        __anShowOAuthError(err, btn, builderFrameMessage + ' Allow popups for this site and try again (flow ' + __anFlowDebugId(flowId) + ').');
+        return;
+      }
+      __anStartRedirectOAuth(ret, btn, err, flowId, redirectReason);
+    }
     function __anStartRedirectOAuth(ret, btn, err, flowId, reason) {
       var params = new URLSearchParams();
       var oauthReturn = __anIsBuilderPreview() ? __anOAuthReturnTarget(ret) : ret;
@@ -1202,7 +1209,7 @@ ${
       try {
         var popup = window.open('', '_blank', 'width=640,height=760');
         if (!popup) {
-          __anStartRedirectOAuth(ret, btn, err, flowId, 'Google popup was blocked; falling back to redirect');
+          __anHandlePopupOAuthFailure(ret, btn, err, flowId, 'Google popup was blocked; falling back to redirect', 'Google popup was blocked.');
           return;
         }
         try { popup.opener = null; } catch(e) {}
@@ -1210,12 +1217,12 @@ ${
           popup.location.href = url;
         } catch(e) {
           try { popup.close(); } catch(closeErr) {}
-          __anStartRedirectOAuth(ret, btn, err, flowId, 'Could not navigate Google popup; falling back to redirect');
+          __anHandlePopupOAuthFailure(ret, btn, err, flowId, 'Could not navigate Google popup; falling back to redirect', 'Could not navigate Google popup.');
           return;
         }
         __anSetOAuthDebug('Google popup opened; waiting for callback', flowId);
       } catch(e) {
-        __anStartRedirectOAuth(ret, btn, err, flowId, 'Could not open Google popup; falling back to redirect');
+        __anHandlePopupOAuthFailure(ret, btn, err, flowId, 'Could not open Google popup; falling back to redirect', 'Could not open Google popup.');
         return;
       }
       __anWaitForOAuthExchange(flowId, ret, btn, err);
@@ -1719,7 +1726,8 @@ ${
       return;
     }
     if (__anIsBuilderPreview()) {
-      __anStartRedirectOAuth(ret, btn, err);
+      var flowId = __anNewOAuthFlowId();
+      __anStartRedirectOAuth(ret, btn, err, flowId, 'Opening Google sign-in redirect from Builder preview');
       return;
     }
     try {

--- a/packages/desktop-app/src/main/app-store.ts
+++ b/packages/desktop-app/src/main/app-store.ts
@@ -257,9 +257,17 @@ function migrateDecryptableProviderSecrets(
 }
 
 function hasStoredProviderSecret(secret: StoredSecret | undefined): boolean {
-  // Status reads should not decrypt safeStorage entries; that can trigger OS
-  // prompts on macOS. Credential application performs the actual decrypt.
   return Boolean(secret?.value);
+}
+
+function canReadStoredProviderSecret(
+  secret: StoredSecret | undefined,
+): boolean {
+  if (!secret?.value) return false;
+  if (secret.encoding === "local-file-v1" || secret.encoding === "plain") {
+    return true;
+  }
+  return Boolean(decryptProviderSecret(secret));
 }
 
 export function loadCodeAgentProviderCredentials(): Partial<
@@ -325,7 +333,7 @@ export function getCodeAgentProviderSettingsStatus(): CodeAgentProviderSettings 
   const store = loadCodeAgentProviderStore();
   const providers = CODE_AGENT_PROVIDER_DEFINITIONS.map((provider) => {
     const savedKeys = provider.keys.filter((key) =>
-      hasStoredProviderSecret(store.credentials[key]),
+      canReadStoredProviderSecret(store.credentials[key]),
     );
     const envKeys = provider.keys.filter((key) => Boolean(process.env[key]));
     const configuredKeys = provider.keys.filter(

--- a/packages/desktop-app/src/main/app-store.ts
+++ b/packages/desktop-app/src/main/app-store.ts
@@ -1,4 +1,4 @@
-import { app } from "electron";
+import { app, safeStorage } from "electron";
 import fs from "fs";
 import path from "path";
 import {
@@ -197,12 +197,29 @@ function saveCodeAgentProviderStore(store: CodeAgentProviderStore): void {
   }
 }
 
+function canUseSafeStorage(): boolean {
+  try {
+    return safeStorage.isEncryptionAvailable();
+  } catch {
+    return false;
+  }
+}
+
 function encodeProviderSecret(value: string): StoredSecret {
-  // Electron safeStorage uses macOS Keychain and can show a blocking
-  // permission prompt during settings/status reads. Keep desktop provider keys
-  // in the existing 0600 app data file instead.
+  if (canUseSafeStorage()) {
+    try {
+      return {
+        encoding: "safeStorage-v1",
+        value: safeStorage.encryptString(value).toString("base64"),
+        updatedAt: new Date().toISOString(),
+      };
+    } catch {
+      // Fall through to the plain fallback below.
+    }
+  }
+
   return {
-    encoding: "local-file-v1",
+    encoding: "plain",
     value,
     updatedAt: new Date().toISOString(),
   };
@@ -215,11 +232,34 @@ function decryptProviderSecret(
   if (secret.encoding === "local-file-v1" || secret.encoding === "plain") {
     return secret.value;
   }
-  return null;
+  if (!canUseSafeStorage()) return null;
+  try {
+    return safeStorage.decryptString(Buffer.from(secret.value, "base64"));
+  } catch {
+    return null;
+  }
+}
+
+function migrateDecryptableProviderSecrets(
+  store: CodeAgentProviderStore,
+  credentials: Partial<Record<CodeAgentProviderCredentialKey, string>>,
+): void {
+  if (!canUseSafeStorage()) return;
+  let changed = false;
+  for (const key of CODE_AGENT_PROVIDER_KEYS) {
+    const secret = store.credentials[key];
+    const value = credentials[key];
+    if (!value || !secret || secret.encoding === "safeStorage-v1") continue;
+    store.credentials[key] = encodeProviderSecret(value);
+    changed = true;
+  }
+  if (changed) saveCodeAgentProviderStore(store);
 }
 
 function hasStoredProviderSecret(secret: StoredSecret | undefined): boolean {
-  return Boolean(decryptProviderSecret(secret));
+  // Status reads should not decrypt safeStorage entries; that can trigger OS
+  // prompts on macOS. Credential application performs the actual decrypt.
+  return Boolean(secret?.value);
 }
 
 export function loadCodeAgentProviderCredentials(): Partial<
@@ -232,6 +272,7 @@ export function loadCodeAgentProviderCredentials(): Partial<
     const value = decryptProviderSecret(store.credentials[key]);
     if (value) credentials[key] = value;
   }
+  migrateDecryptableProviderSecrets(store, credentials);
   return credentials;
 }
 

--- a/packages/desktop-app/src/main/app-store.ts
+++ b/packages/desktop-app/src/main/app-store.ts
@@ -256,7 +256,9 @@ function migrateDecryptableProviderSecrets(
   if (changed) saveCodeAgentProviderStore(store);
 }
 
-function hasStoredProviderSecret(secret: StoredSecret | undefined): boolean {
+function hasStoredProviderSecretBlob(
+  secret: StoredSecret | undefined,
+): boolean {
   return Boolean(secret?.value);
 }
 
@@ -314,7 +316,9 @@ export function applyCodeAgentProviderCredentialsToEnv(): CodeAgentProviderCrede
       if (credentials[key]) appliedKeys.push(key);
     } else {
       delete process.env[key];
-      if (hasStoredProviderSecret(store.credentials[key])) failedKeys.push(key);
+      if (hasStoredProviderSecretBlob(store.credentials[key])) {
+        failedKeys.push(key);
+      }
     }
   }
   return {

--- a/packages/docs/app/components/docsNavItems.ts
+++ b/packages/docs/app/components/docsNavItems.ts
@@ -75,17 +75,22 @@ export const NAV_SECTIONS: NavSection[] = [
     // flag in that file. The CI guard `scripts/guard-template-list.mjs`
     // enforces this — adding a slug here that isn't in the allow-list will
     // fail the build.
+    //
+    // Important: this is the docs sidebar, so these links must point to the
+    // markdown docs under `/docs/template-<slug>`, never the marketing/demo
+    // landing pages under `/templates/<slug>`. The tests and guard script
+    // intentionally enforce this because this list has regressed before.
     items: [
-      { label: "Calendar", to: "/templates/calendar" as const },
-      { label: "Content", to: "/templates/content" as const },
-      { label: "Slides", to: "/templates/slides" as const },
-      { label: "Analytics", to: "/templates/analytics" as const },
-      { label: "Mail", to: "/templates/mail" as const },
-      { label: "Clips", to: "/templates/clips" as const },
-      { label: "Brain", to: "/templates/brain" as const },
-      { label: "Design", to: "/templates/design" as const },
-      { label: "Dispatch", to: "/templates/dispatch" as const },
-      { label: "Forms", to: "/templates/forms" as const },
+      { label: "Calendar", to: "/docs/template-calendar" as const },
+      { label: "Content", to: "/docs/template-content" as const },
+      { label: "Slides", to: "/docs/template-slides" as const },
+      { label: "Analytics", to: "/docs/template-analytics" as const },
+      { label: "Mail", to: "/docs/template-mail" as const },
+      { label: "Clips", to: "/docs/template-clips" as const },
+      { label: "Brain", to: "/docs/template-brain" as const },
+      { label: "Design", to: "/docs/template-design" as const },
+      { label: "Dispatch", to: "/docs/template-dispatch" as const },
+      { label: "Forms", to: "/docs/template-forms" as const },
     ],
   },
   {

--- a/packages/docs/tests/templates-routes.test.ts
+++ b/packages/docs/tests/templates-routes.test.ts
@@ -45,7 +45,7 @@ describe("template routes", () => {
       (item) => item.to,
     );
     const catalogTemplatePaths = featuredTemplates.map(
-      (template) => `/templates/${template.slug}`,
+      (template) => `/docs/template-${template.slug}`,
     );
 
     // Every featured catalog template must be reachable from the sidebar.
@@ -55,13 +55,15 @@ describe("template routes", () => {
       expect(sidebarTemplatePaths).toContain(catalogPath);
     }
 
+    const docsDir = path.resolve(docsRoot, "../core/docs/content");
     for (const sidebarPath of sidebarTemplatePaths) {
-      const slug = sidebarPath.replace("/templates/", "");
-      expect(() =>
-        loader({
-          params: { slug },
-        } as unknown as Parameters<typeof loader>[0]),
-      ).not.toThrow();
+      expect(sidebarPath).toMatch(/^\/docs\/template-[a-z0-9-]+$/);
+      expect(sidebarPath).not.toMatch(/^\/templates\//);
+
+      const slug = sidebarPath.replace("/docs/template-", "");
+      expect(fs.existsSync(path.join(docsDir, `template-${slug}.md`))).toBe(
+        true,
+      );
     }
   });
 

--- a/scripts/guard-template-list.mjs
+++ b/scripts/guard-template-list.mjs
@@ -124,7 +124,8 @@ const TEMPLATE_CARD_PATH = "packages/docs/app/components/TemplateCard.tsx";
   }
 }
 
-// ── 3. Docs sidebar (docsNavItems.ts) must only contain allowed slugs.
+// ── 3. Docs sidebar (docsNavItems.ts) must only contain allowed slugs and
+// must point at docs pages, not the public template landing pages.
 const DOCS_NAV_PATH = "packages/docs/app/components/docsNavItems.ts";
 {
   const src = fs.readFileSync(path.join(repoRoot, DOCS_NAV_PATH), "utf-8");
@@ -132,13 +133,22 @@ const DOCS_NAV_PATH = "packages/docs/app/components/docsNavItems.ts";
     .split(/title:\s*"Templates"/)[1]
     ?.split(/title:\s*"/)[0];
   if (inTemplatesSection) {
-    const slugRe = /\/templates\/([a-z][a-z0-9-]*)\b/g;
+    const landingSlugRe = /\/templates\/([a-z][a-z0-9-]*)\b/g;
     let match;
-    while ((match = slugRe.exec(inTemplatesSection)) !== null) {
+    while ((match = landingSlugRe.exec(inTemplatesSection)) !== null) {
+      const slug = match[1];
+      errors.push(
+        `${DOCS_NAV_PATH}: "/templates/${slug}" is a landing page link. ` +
+          `Docs sidebar template entries must link to "/docs/template-${slug}".`,
+      );
+    }
+
+    const docsSlugRe = /\/docs\/template-([a-z][a-z0-9-]*)\b/g;
+    while ((match = docsSlugRe.exec(inTemplatesSection)) !== null) {
       const slug = match[1];
       if (!allowed.has(slug)) {
         errors.push(
-          `${DOCS_NAV_PATH}: "/templates/${slug}" is in the sidebar but not in the public allow-list. ` +
+          `${DOCS_NAV_PATH}: "/docs/template-${slug}" is in the sidebar but not in the public allow-list. ` +
             `Either remove the entry, or flip hidden:false in ${SOURCE_OF_TRUTH} (and ${CLI_DUPLICATE}).`,
         );
       }

--- a/templates/calendar/app/pages/BookingLinksPage.tsx
+++ b/templates/calendar/app/pages/BookingLinksPage.tsx
@@ -6,6 +6,7 @@ import {
   IconCalendar,
   IconChevronLeft,
   IconChevronRight,
+  IconCircleCheck,
   IconCopy,
   IconExternalLink,
   IconLink,
@@ -41,6 +42,7 @@ import {
   getDay,
 } from "date-fns";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
@@ -138,6 +140,15 @@ type DraftLink = {
 };
 
 type DayName = keyof AvailabilityConfig["weeklySchedule"];
+
+type BookingPreviewStep = "duration" | "date" | "time" | "info" | "confirmed";
+
+type BookingPreviewFormValue = {
+  name: string;
+  email: string;
+  notes: string;
+  fieldResponses: Record<string, string | boolean>;
+};
 
 const DAYS: { key: DayName; label: string; short: string }[] = [
   { key: "monday", label: "Monday", short: "Mon" },
@@ -1677,12 +1688,24 @@ function BookingPreview({
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [selectedDuration, setSelectedDuration] = useState<number | null>(null);
   const [selectedSlot, setSelectedSlot] = useState<string | null>(null);
+  const [previewConfirmed, setPreviewConfirmed] = useState(false);
+  const [previewForm, setPreviewForm] = useState<BookingPreviewFormValue>({
+    name: "Preview Guest",
+    email: "preview@example.com",
+    notes: "",
+    fieldResponses: {},
+  });
 
   // Reset selections when durations change
   useEffect(() => {
     setSelectedDuration(null);
     setSelectedSlot(null);
+    setPreviewConfirmed(false);
   }, [durations.join(",")]);
+
+  useEffect(() => {
+    setPreviewConfirmed(false);
+  }, [selectedDate, selectedDuration, selectedSlot]);
 
   // Calendar data for viewed month
   const monthStart = startOfMonth(viewMonth);
@@ -1729,20 +1752,48 @@ function BookingPreview({
   }, [selectedDate, selectedDuration, primaryDuration, availability]);
 
   // Determine which step to show
-  type Step = "duration" | "date" | "time" | "info";
-  const [forcedStep, setForcedStep] = useState<Step | null>(null);
+  const [forcedStep, setForcedStep] = useState<BookingPreviewStep | null>(null);
 
-  let naturalStep: Step = "date";
+  let naturalStep: BookingPreviewStep = "date";
   if (hasDurationChoice && selectedDuration === null) naturalStep = "duration";
   else if (!selectedDate) naturalStep = "date";
   else if (!selectedSlot) naturalStep = "time";
   else naturalStep = "info";
 
-  const step = forcedStep ?? naturalStep;
+  const step: BookingPreviewStep = previewConfirmed
+    ? "confirmed"
+    : (forcedStep ?? naturalStep);
 
-  const steps: Step[] = hasDurationChoice
+  const steps: BookingPreviewStep[] = hasDurationChoice
     ? ["duration", "date", "time", "info"]
     : ["date", "time", "info"];
+
+  const confirmedDuration = selectedDuration ?? primaryDuration;
+
+  function updatePreviewForm(patch: Partial<BookingPreviewFormValue>) {
+    setPreviewForm((prev) => ({ ...prev, ...patch }));
+  }
+
+  function setPreviewFieldValue(id: string, value: string | boolean) {
+    setPreviewForm((prev) => ({
+      ...prev,
+      fieldResponses: { ...prev.fieldResponses, [id]: value },
+    }));
+  }
+
+  function handlePreviewSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setPreviewConfirmed(true);
+    setForcedStep(null);
+  }
+
+  function resetPreviewFlow() {
+    setSelectedDuration(null);
+    setSelectedDate(null);
+    setSelectedSlot(null);
+    setPreviewConfirmed(false);
+    setForcedStep(null);
+  }
 
   return (
     <div className="rounded-2xl border border-border overflow-hidden bg-card">
@@ -1750,7 +1801,7 @@ function BookingPreview({
       <div className="border-b border-border/60 bg-muted/30 px-4 py-2 space-y-2">
         <div className="flex items-center justify-between">
           <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-            Read-only preview
+            Preview
           </span>
           <div className="flex items-center gap-1">
             {!isActive && (
@@ -1809,14 +1860,8 @@ function BookingPreview({
         )}
       </div>
 
-      {/* Read-only booking page preview */}
-      <div
-        inert={true}
-        className={cn(
-          "pointer-events-none select-none space-y-5 p-6",
-          !isActive && "opacity-50",
-        )}
-      >
+      {/* Booking page preview */}
+      <div className={cn("space-y-5 p-6", !isActive && "opacity-60")}>
         {/* Header */}
         <div className="text-center space-y-2">
           <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
@@ -1838,46 +1883,47 @@ function BookingPreview({
         </div>
 
         {/* Step indicators */}
-        <div className="flex items-center justify-center gap-2">
-          {steps.map((s, i) => (
-            <div key={s} className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => {
-                  if (s === step) return;
-                  // Navigate back: clear state so natural step resets
-                  if (s === "duration") {
-                    setSelectedDuration(null);
-                    setSelectedDate(null);
-                    setSelectedSlot(null);
-                    setForcedStep(null);
-                  } else if (s === "date") {
-                    setSelectedDate(null);
-                    setSelectedSlot(null);
-                    setForcedStep(null);
-                  } else if (s === "time") {
-                    setSelectedSlot(null);
-                    setForcedStep(null);
-                  } else {
-                    // Navigate forward: force the step
-                    setForcedStep(s);
-                  }
-                }}
-                className={cn(
-                  "flex h-6 w-6 items-center justify-center rounded-full text-[10px] font-medium cursor-pointer",
-                  step === s
-                    ? "bg-primary text-primary-foreground"
-                    : steps.indexOf(step) > i
-                      ? "bg-primary/20 text-primary hover:bg-primary/30"
-                      : "bg-muted text-muted-foreground hover:bg-muted/80",
-                )}
-              >
-                {i + 1}
-              </button>
-              {i < steps.length - 1 && <div className="h-px w-6 bg-border" />}
-            </div>
-          ))}
-        </div>
+        {step !== "confirmed" && (
+          <div className="flex items-center justify-center gap-2">
+            {steps.map((s, i) => (
+              <div key={s} className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (s === step) return;
+                    if (s === "duration") {
+                      setSelectedDuration(null);
+                      setSelectedDate(null);
+                      setSelectedSlot(null);
+                      setForcedStep(null);
+                    } else if (s === "date") {
+                      setSelectedDate(null);
+                      setSelectedSlot(null);
+                      setForcedStep(null);
+                    } else if (s === "time") {
+                      setSelectedSlot(null);
+                      setForcedStep(null);
+                    } else {
+                      setForcedStep(s);
+                    }
+                  }}
+                  className={cn(
+                    "flex h-6 w-6 items-center justify-center rounded-full text-[10px] font-medium cursor-pointer transition-colors",
+                    step === s
+                      ? "bg-primary text-primary-foreground"
+                      : steps.indexOf(step) > i
+                        ? "bg-primary/20 text-primary hover:bg-primary/30"
+                        : "bg-muted text-muted-foreground hover:bg-muted/80",
+                  )}
+                  aria-label={`Go to preview step ${i + 1}`}
+                >
+                  {i + 1}
+                </button>
+                {i < steps.length - 1 && <div className="h-px w-6 bg-border" />}
+              </div>
+            ))}
+          </div>
+        )}
 
         {/* Duration step */}
         {step === "duration" && (
@@ -2036,9 +2082,9 @@ function BookingPreview({
           </div>
         )}
 
-        {/* Info step (preview only — just shows the form shape) */}
+        {/* Info step */}
         {step === "info" && (
-          <div className="space-y-3">
+          <form className="space-y-3" onSubmit={handlePreviewSubmit}>
             {selectedDate && selectedSlot ? (
               <div className="flex items-center justify-between">
                 <p className="text-xs font-medium text-muted-foreground">
@@ -2061,43 +2107,214 @@ function BookingPreview({
               </p>
             )}
             <div className="space-y-2">
-              <div className="rounded-md border border-border/60 px-3 py-2 text-[11px] text-muted-foreground/50">
-                Name
+              <div className="space-y-1.5">
+                <Label htmlFor="preview-booking-name" className="text-[11px]">
+                  Name
+                </Label>
+                <Input
+                  id="preview-booking-name"
+                  value={previewForm.name}
+                  onChange={(event) =>
+                    updatePreviewForm({ name: event.target.value })
+                  }
+                  className="h-8 text-xs"
+                  required
+                />
               </div>
-              <div className="rounded-md border border-border/60 px-3 py-2 text-[11px] text-muted-foreground/50">
-                Email
+              <div className="space-y-1.5">
+                <Label htmlFor="preview-booking-email" className="text-[11px]">
+                  Email
+                </Label>
+                <Input
+                  id="preview-booking-email"
+                  type="email"
+                  value={previewForm.email}
+                  onChange={(event) =>
+                    updatePreviewForm({ email: event.target.value })
+                  }
+                  className="h-8 text-xs"
+                  required
+                />
               </div>
               {customFields.map((field) => (
-                <div
+                <PreviewCustomFieldInput
                   key={field.id}
-                  className={cn(
-                    "rounded-md border border-border/60 px-3 py-2 text-[11px] text-muted-foreground/50",
-                    field.type === "textarea" && "h-14",
-                    field.type === "checkbox" && "flex items-center gap-1.5",
-                  )}
-                >
-                  {field.type === "checkbox" && (
-                    <div className="h-3 w-3 rounded-sm border border-border/60 shrink-0" />
-                  )}
-                  <span>
-                    {field.label}
-                    {!field.required && " (optional)"}
-                  </span>
-                  {field.required && (
-                    <span className="text-destructive/50">*</span>
-                  )}
-                </div>
+                  field={field}
+                  value={previewForm.fieldResponses[field.id]}
+                  onChange={(value) => setPreviewFieldValue(field.id, value)}
+                />
               ))}
-              <div className="rounded-md border border-border/60 px-3 py-2 text-[11px] text-muted-foreground/50 h-14">
-                Notes (optional)
+              <div className="space-y-1.5">
+                <Label htmlFor="preview-booking-notes" className="text-[11px]">
+                  Notes (optional)
+                </Label>
+                <Textarea
+                  id="preview-booking-notes"
+                  value={previewForm.notes}
+                  onChange={(event) =>
+                    updatePreviewForm({ notes: event.target.value })
+                  }
+                  className="min-h-16 text-xs"
+                  placeholder="Anything you'd like to share"
+                />
               </div>
             </div>
-            <div className="rounded-md bg-primary/10 border border-primary/20 px-3 py-2 text-center text-[11px] font-medium text-primary">
+            <Button type="submit" className="h-8 w-full text-xs">
               Confirm Booking
+            </Button>
+          </form>
+        )}
+
+        {step === "confirmed" && (
+          <div className="flex flex-col items-center py-3 text-center">
+            <IconCircleCheck className="h-12 w-12 text-emerald-600 dark:text-emerald-400" />
+            <div className="mt-3 space-y-1">
+              <h4 className="text-base font-semibold">Preview Confirmed</h4>
+              <p className="text-xs text-muted-foreground">
+                No booking was created.
+              </p>
             </div>
+            <div className="mt-4 w-full rounded-lg border border-border bg-muted/20 p-3 text-left text-xs">
+              <div>
+                <span className="text-muted-foreground">Event</span>
+                <p className="font-medium text-foreground">{displayTitle}</p>
+              </div>
+              {selectedDate && (
+                <div className="mt-2">
+                  <span className="text-muted-foreground">Date</span>
+                  <p className="font-medium text-foreground">
+                    {format(selectedDate, "EEEE, MMMM d, yyyy")}
+                  </p>
+                </div>
+              )}
+              {selectedSlot && (
+                <div className="mt-2">
+                  <span className="text-muted-foreground">Time</span>
+                  <p className="font-medium text-foreground">
+                    {selectedSlot} · {confirmedDuration} minutes
+                  </p>
+                </div>
+              )}
+              <div className="mt-2">
+                <span className="text-muted-foreground">Name</span>
+                <p className="font-medium text-foreground">
+                  {previewForm.name.trim() || "Preview Guest"}
+                </p>
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-4 h-8 text-xs"
+              onClick={resetPreviewFlow}
+            >
+              Try Again
+            </Button>
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+function PreviewCustomFieldInput({
+  field,
+  value,
+  onChange,
+}: {
+  field: CustomField;
+  value: string | boolean | undefined;
+  onChange: (value: string | boolean) => void;
+}) {
+  const id = `preview-custom-field-${field.id}`;
+  const strValue = typeof value === "string" ? value : "";
+  const boolValue = typeof value === "boolean" ? value : false;
+  const optionalLabel = field.required ? "" : " (optional)";
+
+  if (field.type === "checkbox") {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-border/60 px-3 py-2">
+        <Checkbox
+          id={id}
+          checked={boolValue}
+          onCheckedChange={(checked) => onChange(checked === true)}
+        />
+        <Label htmlFor={id} className="text-[11px] font-normal">
+          {field.label}
+          {optionalLabel}
+        </Label>
+      </div>
+    );
+  }
+
+  if (field.type === "select" && field.options?.length) {
+    return (
+      <div className="space-y-1.5">
+        <Label htmlFor={id} className="text-[11px]">
+          {field.label}
+          {optionalLabel}
+        </Label>
+        <Select value={strValue} onValueChange={onChange}>
+          <SelectTrigger id={id} className="h-8 text-xs">
+            <span
+              className={cn("truncate", !strValue && "text-muted-foreground")}
+            >
+              {strValue || field.placeholder || "Select..."}
+            </span>
+          </SelectTrigger>
+          <SelectContent>
+            {field.options.map((option) => (
+              <SelectItem key={option} value={option}>
+                {option}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    );
+  }
+
+  if (field.type === "textarea") {
+    return (
+      <div className="space-y-1.5">
+        <Label htmlFor={id} className="text-[11px]">
+          {field.label}
+          {optionalLabel}
+        </Label>
+        <Textarea
+          id={id}
+          value={strValue}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={field.placeholder}
+          className="min-h-16 text-xs"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id} className="text-[11px]">
+        {field.label}
+        {optionalLabel}
+      </Label>
+      <Input
+        id={id}
+        type={
+          field.type === "url"
+            ? "url"
+            : field.type === "tel"
+              ? "tel"
+              : field.type === "email"
+                ? "email"
+                : "text"
+        }
+        value={strValue}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={field.placeholder}
+        className="h-8 text-xs"
+      />
     </div>
   );
 }

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -36,6 +36,10 @@ import {
   sendBookingConfirmationEmails,
 } from "../lib/booking-emails.js";
 import { getOwnerBookingTimeZone } from "../lib/booking-timezone.js";
+import {
+  buildBookingEventAttendees,
+  buildBookingEventTitle,
+} from "../lib/booking-event-details.js";
 
 async function requireRequestContext<T>(
   event: H3Event,
@@ -79,45 +83,8 @@ function stripCrlf(value: unknown): string {
     .trim();
 }
 
-function titleCaseToken(value: string): string {
-  if (!value) return value;
-  return value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
-}
-
-function displayNameFromEmail(email: string): string {
-  const localPart = email.split("@")[0]?.split("+")[0] ?? "";
-  const parts = localPart
-    .split(/[._-]+/)
-    .map((part) => part.replace(/[^a-zA-Z0-9]/g, ""))
-    .filter(Boolean);
-
-  if (parts.length === 0) return email;
-  return parts.map(titleCaseToken).join(" ");
-}
-
 function isValidEmail(value: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-}
-
-function buildBookingEventTitle({
-  explicitTitle,
-  bookingTitle,
-  hostEmail,
-  attendeeName,
-}: {
-  explicitTitle?: unknown;
-  bookingTitle?: unknown;
-  hostEmail: string;
-  attendeeName: unknown;
-}) {
-  const explicit = stripCrlf(explicitTitle);
-  if (explicit) return explicit;
-  const meetingType = stripCrlf(bookingTitle);
-  if (meetingType) return meetingType;
-
-  const hostName = displayNameFromEmail(hostEmail);
-  const guestName = stripCrlf(attendeeName) || "Guest";
-  return `${hostName} + ${guestName}`;
 }
 
 async function deleteGoogleEventForBooking({
@@ -603,7 +570,6 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
 
     const eventTitle = buildBookingEventTitle({
       explicitTitle: body.eventTitle,
-      bookingTitle: bookingLink?.title,
       hostEmail,
       attendeeName,
     });
@@ -827,11 +793,16 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
           allDay: false,
           source: "google",
           accountEmail: hostEmail,
+          attendees: buildBookingEventAttendees({
+            attendeeEmail,
+            attendeeName,
+          }),
           createdAt: now,
           updatedAt: now,
         };
         const result = await googleCalendar.createEvent(calEvent, {
           addGoogleMeet: conferencing?.type === "google_meet",
+          sendUpdates: "all",
         });
         // Google Meet link is returned by the API when created
         googleEventId = result.id;

--- a/templates/calendar/server/lib/booking-event-details.spec.ts
+++ b/templates/calendar/server/lib/booking-event-details.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBookingEventAttendees,
+  buildBookingEventTitle,
+} from "./booking-event-details";
+
+describe("booking event details", () => {
+  it("generates host plus guest event titles instead of reusing the meeting type", () => {
+    expect(
+      buildBookingEventTitle({
+        hostEmail: "steve@example.com",
+        attendeeName: "Rakesh Rachamalla",
+      }),
+    ).toBe("Steve + Rakesh");
+  });
+
+  it("still honors an explicit event title override", () => {
+    expect(
+      buildBookingEventTitle({
+        explicitTitle: "Intro call",
+        hostEmail: "steve@example.com",
+        attendeeName: "Rakesh Rachamalla",
+      }),
+    ).toBe("Intro call");
+  });
+
+  it("builds a Google Calendar attendee for the booker", () => {
+    expect(
+      buildBookingEventAttendees({
+        attendeeEmail: "rakesh.rachamalla@walmart.com",
+        attendeeName: "Rakesh Rachamalla",
+      }),
+    ).toEqual([
+      {
+        email: "rakesh.rachamalla@walmart.com",
+        displayName: "Rakesh Rachamalla",
+      },
+    ]);
+  });
+});

--- a/templates/calendar/server/lib/booking-event-details.ts
+++ b/templates/calendar/server/lib/booking-event-details.ts
@@ -1,0 +1,57 @@
+function stripCrlf(value: unknown): string {
+  return String(value ?? "")
+    .replace(/[\r\n]+/g, " ")
+    .trim();
+}
+
+function titleCaseToken(value: string): string {
+  if (!value) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+}
+
+function displayNameFromEmail(email: string): string {
+  const localPart = email.split("@")[0]?.split("+")[0] ?? "";
+  const parts = localPart
+    .split(/[._-]+/)
+    .map((part) => part.replace(/[^a-zA-Z0-9]/g, ""))
+    .filter(Boolean);
+
+  if (parts.length === 0) return email;
+  return parts.map(titleCaseToken).join(" ");
+}
+
+function firstNameForTitle(value: string): string {
+  return value.trim().split(/\s+/)[0] ?? value.trim();
+}
+
+export function buildBookingEventTitle({
+  explicitTitle,
+  hostEmail,
+  attendeeName,
+}: {
+  explicitTitle?: unknown;
+  hostEmail: string;
+  attendeeName: unknown;
+}) {
+  const explicit = stripCrlf(explicitTitle);
+  if (explicit) return explicit;
+
+  const hostName = firstNameForTitle(displayNameFromEmail(hostEmail));
+  const guestName = firstNameForTitle(stripCrlf(attendeeName)) || "Guest";
+  return `${hostName} + ${guestName}`;
+}
+
+export function buildBookingEventAttendees({
+  attendeeEmail,
+  attendeeName,
+}: {
+  attendeeEmail: string;
+  attendeeName: string;
+}) {
+  return [
+    {
+      email: attendeeEmail,
+      displayName: attendeeName,
+    },
+  ];
+}

--- a/templates/clips/app/root.tsx
+++ b/templates/clips/app/root.tsx
@@ -1,4 +1,11 @@
-import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
+import {
+  Links,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+  useLocation,
+} from "react-router";
 import { useCallback, useState } from "react";
 import { useNavigationState } from "@/hooks/use-navigation-state";
 import {
@@ -108,21 +115,37 @@ function ThemeToggleItem() {
   );
 }
 
-export default function Root() {
+function isStandalonePublicPath(pathname: string): boolean {
+  const path = pathname.replace(/\/+$/, "") || "/";
+  return (
+    path === "/download" ||
+    path.startsWith("/share/") ||
+    path.startsWith("/embed/")
+  );
+}
+
+function RootContent() {
+  const location = useLocation();
+  const standalonePublic = isStandalonePublicPath(location.pathname);
   const [queryClient] = useState(() => new QueryClient());
   const [cmdkOpen, setCmdkOpen] = useState(false);
-  useCommandMenuShortcut(useCallback(() => setCmdkOpen(true), []));
+  useCommandMenuShortcut(
+    useCallback(() => {
+      if (!standalonePublic) setCmdkOpen(true);
+    }, [standalonePublic]),
+  );
+
   return (
-    <ClientOnly fallback={<DefaultSpinner />}>
-      <ThemeProvider
-        attribute="class"
-        defaultTheme="system"
-        enableSystem
-        disableTransitionOnChange
-      >
-        <QueryClientProvider client={queryClient}>
-          <TooltipProvider>
-            <DbSyncSetup />
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          {standalonePublic ? null : <DbSyncSetup />}
+          {standalonePublic ? null : (
             <CommandMenu open={cmdkOpen} onOpenChange={setCmdkOpen}>
               <CommandMenu.Group heading="Actions">
                 <CommandMenu.Item onSelect={() => {}}>Search</CommandMenu.Item>
@@ -131,12 +154,20 @@ export default function Root() {
                 <ThemeToggleItem />
               </CommandMenu.Group>
             </CommandMenu>
-            <DevOverlay />
-            <Outlet />
-            <Toaster richColors position="bottom-left" />
-          </TooltipProvider>
-        </QueryClientProvider>
-      </ThemeProvider>
+          )}
+          {standalonePublic ? null : <DevOverlay />}
+          <Outlet />
+          <Toaster richColors position="bottom-left" />
+        </TooltipProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
+  );
+}
+
+export default function Root() {
+  return (
+    <ClientOnly fallback={<DefaultSpinner />}>
+      <RootContent />
     </ClientOnly>
   );
 }

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
 import { useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
@@ -190,7 +196,7 @@ export default function ShareRoute() {
   });
   const [pwError, setPwError] = useState<string | null>(null);
   const [currentMs, setCurrentMs] = useState(0);
-  const { session } = useSession();
+  const { session, isLoading: sessionLoading } = useSession();
   const [signInIntent, setSignInIntent] = useState<"comment" | "react" | null>(
     null,
   );
@@ -465,6 +471,13 @@ export default function ShareRoute() {
                 Sign in to finish
               </a>
             </Button>
+          ) : !session && !sessionLoading && !isFailure ? (
+            <Button asChild variant="ghost" size="sm">
+              <a href={signInHref} className="gap-1.5">
+                <IconLogin2 className="h-4 w-4" />
+                Sign in if this is yours
+              </a>
+            </Button>
           ) : canManageStorage && isFailure ? (
             <Button asChild size="sm">
               <a href={appPath(`/r/${recording.id}`)}>Open dashboard</a>
@@ -707,7 +720,7 @@ function EndState({
 }: {
   title: string;
   message: string;
-  action?: React.ReactNode;
+  action?: ReactNode;
 }) {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-background text-foreground px-6">

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
 import { useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
-import { IconExternalLink, IconShare3 } from "@tabler/icons-react";
+import {
+  IconAlertTriangle,
+  IconExternalLink,
+  IconLogin2,
+  IconShare3,
+} from "@tabler/icons-react";
 import { eq } from "drizzle-orm";
 import {
   agentNativePath,
@@ -59,6 +64,26 @@ function pageTitle(title: string | null | undefined): string {
 
 function displayRecordingTitle(title: string | null | undefined): string {
   return hasGeneratedTitle(title) ? (title ?? "").trim() : "Untitled Clip";
+}
+
+function isStorageSetupFailureReason(
+  reason: string | null | undefined,
+): boolean {
+  return /video storage is not connected|file upload provider|storage provider|connect builder|s3-compatible/i.test(
+    reason ?? "",
+  );
+}
+
+function failureDetail(reason: string | null | undefined): string | null {
+  const trimmed = reason?.trim();
+  if (!trimmed) return null;
+  return trimmed.length > 800 ? `${trimmed.slice(0, 800)}...` : trimmed;
+}
+
+function buildSignInHref(returnTo: string): string {
+  return agentNativePath(
+    `/_agent-native/sign-in?return=${encodeURIComponent(returnTo)}`,
+  );
 }
 
 function shouldShowGeneratedTitleSkeleton(
@@ -169,6 +194,7 @@ export default function ShareRoute() {
   const [signInIntent, setSignInIntent] = useState<"comment" | "react" | null>(
     null,
   );
+  const [processingTimeout, setProcessingTimeout] = useState(false);
   const requireSignIn = useCallback(
     (intent: "comment" | "react") => setSignInIntent(intent),
     [],
@@ -216,6 +242,32 @@ export default function ShareRoute() {
     if (!recording) return;
     document.title = pageTitle(recording.title);
   }, [recording?.title]);
+
+  useEffect(() => {
+    if (!recording) {
+      setProcessingTimeout(false);
+      return;
+    }
+    if (recording.status === "ready" && recording.videoUrl) {
+      setProcessingTimeout(false);
+      return;
+    }
+    if (recording.status === "failed") {
+      setProcessingTimeout(false);
+      return;
+    }
+
+    const progress = Number(recording.uploadProgress ?? 0);
+    const timeoutMs =
+      recording.status === "processing" || progress >= 95 ? 12_000 : 30_000;
+    const handle = setTimeout(() => setProcessingTimeout(true), timeoutMs);
+    return () => clearTimeout(handle);
+  }, [
+    recording?.id,
+    recording?.status,
+    recording?.videoUrl,
+    recording?.uploadProgress,
+  ]);
 
   usePlayerShortcuts({ playerRef });
 
@@ -306,7 +358,17 @@ export default function ShareRoute() {
     return (
       <EndState
         title="Clip unavailable"
-        message="This recording isn't public, or the link is invalid."
+        message="This recording isn't public, or the link is invalid. If it's your clip, sign in to check access."
+        action={
+          shareId ? (
+            <Button asChild size="sm">
+              <a href={buildSignInHref(`/r/${shareId}`)} className="gap-1.5">
+                <IconLogin2 className="h-4 w-4" />
+                Sign in
+              </a>
+            </Button>
+          ) : null
+        }
       />
     );
   }
@@ -323,28 +385,59 @@ export default function ShareRoute() {
   if (recording.status !== "ready" || !recording.videoUrl) {
     const progress = Number(recording.uploadProgress ?? 0);
     const explicitFailure = recording.status === "failed";
-    const label = explicitFailure
-      ? "Something went wrong while saving this clip."
-      : "Finishing up this clip...";
-    const message = explicitFailure
-      ? ((recording as any).failureReason ?? "The creator may need to retry.")
-      : "Uploading and assembling the video. This page will update automatically.";
-    const storageSetupFailure =
-      explicitFailure &&
-      /file upload provider|storage provider|connect builder|s3-compatible/i.test(
-        message,
-      );
+    const rawFailureReason =
+      ((recording as any).failureReason as string | null | undefined) ?? null;
+    const storageSetupFailure = isStorageSetupFailureReason(rawFailureReason);
+    const stuckFailure = !explicitFailure && processingTimeout;
+    const isFailure = explicitFailure || storageSetupFailure || stuckFailure;
+    const canManageStorage = viewerCanEdit;
+    const signInHref = buildSignInHref(`/r/${recording.id}`);
+    const detail = failureDetail(rawFailureReason);
+    const label = storageSetupFailure
+      ? "Connect storage to finish this clip."
+      : stuckFailure
+        ? "This clip needs attention to finish."
+        : explicitFailure
+          ? "Something went wrong while saving this clip."
+          : "Finishing up this clip...";
+    const message = storageSetupFailure
+      ? canManageStorage
+        ? "The video is preserved. Connect Builder.io or S3 storage and Clips will finish uploading it."
+        : session
+          ? "The creator needs to connect Builder.io or S3 storage before this clip can finish."
+          : "If this is your clip, sign in here to connect Builder.io or S3 storage and finish the upload."
+      : stuckFailure
+        ? session
+          ? "The upload has not completed yet. Open the dashboard for this clip or ask the creator to check storage."
+          : "The upload has not completed yet. If this is your clip, sign in to open the owner controls and check storage."
+        : explicitFailure
+          ? (rawFailureReason ?? "The creator may need to retry.")
+          : "Uploading and assembling the video. This page will update automatically.";
 
     return (
       <div className="flex flex-col items-center justify-center min-h-screen bg-background text-foreground px-6">
-        {!explicitFailure ? (
+        {!isFailure ? (
           <Spinner className="h-8 w-8 mb-4 text-muted-foreground" />
-        ) : null}
-        <h1 className="text-lg font-semibold mb-1">{label}</h1>
-        <p className="text-sm text-muted-foreground mb-4 max-w-md text-center">
+        ) : (
+          <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-full border border-destructive/30 bg-destructive/10 text-destructive">
+            <IconAlertTriangle className="h-5 w-5" />
+          </div>
+        )}
+        <h1 className="mb-1 text-center text-lg font-semibold">{label}</h1>
+        <p className="mb-4 max-w-md text-center text-sm text-muted-foreground">
           {message}
         </p>
-        {!explicitFailure && progress > 0 ? (
+        {isFailure && detail && canManageStorage ? (
+          <div className="mb-4 w-full max-w-xl rounded-md border border-border bg-card p-4 text-left shadow-sm">
+            <div className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Details
+            </div>
+            <pre className="max-h-36 overflow-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-muted-foreground">
+              {detail}
+            </pre>
+          </div>
+        ) : null}
+        {!isFailure && progress > 0 ? (
           <div className="w-64 h-1.5 rounded-full bg-accent overflow-hidden mb-4">
             <div
               className="h-full bg-foreground"
@@ -352,20 +445,36 @@ export default function ShareRoute() {
             />
           </div>
         ) : null}
-        {storageSetupFailure ? (
+        {storageSetupFailure && canManageStorage ? (
           <div className="mb-4 w-full">
             <StorageSetupCard
               title="Connect storage to finish saving"
-              description="If this is your clip, connect Builder.io here and this page will check again."
+              description="Choose where Clips should store videos. After it connects, this page will check again."
+              connectedDescription="Storage connected. Checking this clip..."
               onConfigured={() => {
                 void dataQ.refetch();
               }}
             />
           </div>
         ) : null}
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          {!session && isFailure ? (
+            <Button asChild size="sm">
+              <a href={signInHref} className="gap-1.5">
+                <IconLogin2 className="h-4 w-4" />
+                Sign in to finish
+              </a>
+            </Button>
+          ) : canManageStorage && isFailure ? (
+            <Button asChild size="sm">
+              <a href={appPath(`/r/${recording.id}`)}>Open dashboard</a>
+            </Button>
+          ) : null}
           <Button
-            onClick={() => dataQ.refetch()}
+            onClick={() => {
+              setProcessingTimeout(false);
+              void dataQ.refetch();
+            }}
             variant="outline"
             size="sm"
             className="border-foreground/20 bg-muted/50 hover:bg-accent text-foreground"
@@ -591,14 +700,27 @@ function sanitizeFilename(name: string): string {
   );
 }
 
-function EndState({ title, message }: { title: string; message: string }) {
+function EndState({
+  title,
+  message,
+  action,
+}: {
+  title: string;
+  message: string;
+  action?: React.ReactNode;
+}) {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-background text-foreground px-6">
       <h1 className="text-2xl font-semibold mb-2">{title}</h1>
-      <p className="text-sm text-muted-foreground mb-6">{message}</p>
-      <a href={appPath("/")} className="text-sm text-primary hover:underline">
-        Go home
-      </a>
+      <p className="mb-6 max-w-md text-center text-sm text-muted-foreground">
+        {message}
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {action}
+        <Button asChild variant="ghost" size="sm">
+          <a href={appPath("/")}>Go home</a>
+        </Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Restore safeStorage support for desktop provider credentials while preserving readable local-file/plain fallback migration
- Keep Builder iframe Google sign-in on the popup path when redirects cannot work
- Pass OAuth flow context through Builder preview redirect sign-in

## Testing
- pnpm --filter @agent-native/core test -- auth.spec.ts onboarding-html.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/desktop-app typecheck