### PR TITLE
fix(clips): audio recording bugs

### DIFF
--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -402,6 +402,11 @@ export class RecorderEngine {
         systemAudio: wantsMic ? "include" : "exclude",
       };
 
+      if (wantsMic || wantsDisplay) {
+        this.audioMixCtx?.close().catch(() => {});
+        this.audioMixCtx = new AudioContext();
+      }
+
       if (wantsDisplay) {
         try {
           this.displayStream =
@@ -460,11 +465,6 @@ export class RecorderEngine {
 
       this.previewStream =
         this.opts.mode === "camera" ? this.cameraStream! : this.displayStream!;
-
-      if (wantsMic || wantsDisplay) {
-        this.audioMixCtx?.close().catch(() => {});
-        this.audioMixCtx = new AudioContext();
-      }
 
       return {
         previewStream: this.previewStream,
@@ -1066,6 +1066,9 @@ export class RecorderEngine {
 
     const ctx = this.audioMixCtx ?? new AudioContext();
     this.audioMixCtx = ctx;
+    if (ctx.state === "suspended") {
+      ctx.resume().catch(() => {});
+    }
     this.audioMixSources = [];
     const dest = ctx.createMediaStreamDestination();
     for (const track of audioTracks) {

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -253,6 +253,7 @@ export class RecorderEngine {
   private previewStream: MediaStream | null = null;
   private cameraComposite: CameraCompositeHandle | null = null;
   private audioMixCtx: AudioContext | null = null;
+  private audioMixSources: MediaStreamAudioSourceNode[] = [];
   private recorder: MediaRecorder | null = null;
   private mimeType: string = "video/webm";
 
@@ -459,6 +460,11 @@ export class RecorderEngine {
 
       this.previewStream =
         this.opts.mode === "camera" ? this.cameraStream! : this.displayStream!;
+
+      if (wantsMic || wantsDisplay) {
+        this.audioMixCtx?.close().catch(() => {});
+        this.audioMixCtx = new AudioContext();
+      }
 
       return {
         previewStream: this.previewStream,
@@ -1058,16 +1064,15 @@ export class RecorderEngine {
     if (audioTracks.length === 0) return null;
     if (audioTracks.length === 1) return audioTracks[0];
 
-    this.audioMixCtx?.close().catch(() => {});
-    const ctx = new AudioContext();
-    if (ctx.state === "suspended") {
-      ctx.resume().catch(() => {});
-    }
+    const ctx = this.audioMixCtx ?? new AudioContext();
+    this.audioMixCtx = ctx;
+    this.audioMixSources = [];
     const dest = ctx.createMediaStreamDestination();
     for (const track of audioTracks) {
-      ctx.createMediaStreamSource(new MediaStream([track])).connect(dest);
+      const source = ctx.createMediaStreamSource(new MediaStream([track]));
+      source.connect(dest);
+      this.audioMixSources.push(source);
     }
-    this.audioMixCtx = ctx;
     return dest.stream.getAudioTracks()[0];
   }
 
@@ -1343,6 +1348,7 @@ export class RecorderEngine {
   }
 
   private cleanupTracks(): void {
+    this.audioMixSources = [];
     this.audioMixCtx?.close().catch(() => {});
     this.audioMixCtx = null;
     this.cameraComposite?.cleanup();

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -1081,7 +1081,7 @@ export class RecorderEngine {
       return combined;
     }
 
-    // Camera-only: camera video + mic (no display stream to mix).
+    // Camera-only: camera video + mic.
     if (this.opts.mode === "camera") {
       const combined = new MediaStream();
       for (const t of this.cameraStream!.getVideoTracks()) combined.addTrack(t);

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -1040,15 +1040,18 @@ export class RecorderEngine {
   // -------------------------------------------------------------------------
 
   private buildCombinedStream(): MediaStream {
-    // Screen-only: just add mic audio if we have it.
+    // Screen-only: prefer mic audio; fall back to display (system) audio only
+    // when no mic is present. MediaRecorder in Chromium-based browsers records
+    // only the first audio track in the stream, so mic must come first.
     if (this.opts.mode === "screen") {
       const combined = new MediaStream();
       for (const t of this.displayStream!.getVideoTracks())
         combined.addTrack(t);
-      for (const t of this.displayStream!.getAudioTracks())
-        combined.addTrack(t);
       if (this.micStream) {
         for (const t of this.micStream.getAudioTracks()) combined.addTrack(t);
+      } else {
+        for (const t of this.displayStream!.getAudioTracks())
+          combined.addTrack(t);
       }
       return combined;
     }
@@ -1075,9 +1078,11 @@ export class RecorderEngine {
     const combined = new MediaStream();
     for (const t of this.cameraComposite.stream.getVideoTracks())
       combined.addTrack(t);
-    for (const t of this.displayStream!.getAudioTracks()) combined.addTrack(t);
+    // Prefer mic audio; fall back to display (system) audio only when no mic.
     if (this.micStream) {
       for (const t of this.micStream.getAudioTracks()) combined.addTrack(t);
+    } else {
+      for (const t of this.displayStream!.getAudioTracks()) combined.addTrack(t);
     }
     return combined;
   }

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -252,6 +252,7 @@ export class RecorderEngine {
   private combinedStream: MediaStream | null = null;
   private previewStream: MediaStream | null = null;
   private cameraComposite: CameraCompositeHandle | null = null;
+  private audioMixCtx: AudioContext | null = null;
   private recorder: MediaRecorder | null = null;
   private mimeType: string = "video/webm";
 
@@ -1039,30 +1040,53 @@ export class RecorderEngine {
   // Internals
   // -------------------------------------------------------------------------
 
+  /**
+   * Mix audio tracks from multiple streams into a single track via Web Audio
+   * API. A single mixed track avoids the Chromium behaviour where only the
+   * first audio track in a MediaStream is reliably encoded by MediaRecorder,
+   * while still capturing both mic and system audio when both are present.
+   *
+   * Returns null when no audio tracks exist. Returns the single raw track
+   * directly when only one exists (avoids unnecessary AudioContext overhead).
+   */
+  private buildMixedAudioTrack(
+    streams: (MediaStream | null | undefined)[],
+  ): MediaStreamTrack | null {
+    const audioTracks = streams
+      .filter((s): s is MediaStream => s != null)
+      .flatMap((s) => s.getAudioTracks());
+    if (audioTracks.length === 0) return null;
+    if (audioTracks.length === 1) return audioTracks[0];
+
+    this.audioMixCtx?.close().catch(() => {});
+    const ctx = new AudioContext();
+    const dest = ctx.createMediaStreamDestination();
+    for (const track of audioTracks) {
+      ctx.createMediaStreamSource(new MediaStream([track])).connect(dest);
+    }
+    this.audioMixCtx = ctx;
+    return dest.stream.getAudioTracks()[0];
+  }
+
   private buildCombinedStream(): MediaStream {
-    // Screen-only: prefer mic audio; fall back to display (system) audio only
-    // when no mic is present. MediaRecorder in Chromium-based browsers records
-    // only the first audio track in the stream, so mic must come first.
     if (this.opts.mode === "screen") {
       const combined = new MediaStream();
       for (const t of this.displayStream!.getVideoTracks())
         combined.addTrack(t);
-      if (this.micStream) {
-        for (const t of this.micStream.getAudioTracks()) combined.addTrack(t);
-      } else {
-        for (const t of this.displayStream!.getAudioTracks())
-          combined.addTrack(t);
-      }
+      const audio = this.buildMixedAudioTrack([
+        this.micStream,
+        this.displayStream,
+      ]);
+      if (audio) combined.addTrack(audio);
       return combined;
     }
 
-    // Camera-only: camera video + mic.
+    // Camera-only: camera video + mic (no display stream to mix).
     if (this.opts.mode === "camera") {
       const combined = new MediaStream();
       for (const t of this.cameraStream!.getVideoTracks()) combined.addTrack(t);
-      if (this.micStream) {
-        for (const t of this.micStream.getAudioTracks()) combined.addTrack(t);
-      }
+      const audio = this.buildMixedAudioTrack([this.micStream]);
+      if (audio) combined.addTrack(audio);
       return combined;
     }
 
@@ -1078,12 +1102,11 @@ export class RecorderEngine {
     const combined = new MediaStream();
     for (const t of this.cameraComposite.stream.getVideoTracks())
       combined.addTrack(t);
-    // Prefer mic audio; fall back to display (system) audio only when no mic.
-    if (this.micStream) {
-      for (const t of this.micStream.getAudioTracks()) combined.addTrack(t);
-    } else {
-      for (const t of this.displayStream!.getAudioTracks()) combined.addTrack(t);
-    }
+    const audio = this.buildMixedAudioTrack([
+      this.micStream,
+      this.displayStream,
+    ]);
+    if (audio) combined.addTrack(audio);
     return combined;
   }
 
@@ -1317,6 +1340,8 @@ export class RecorderEngine {
   }
 
   private cleanupTracks(): void {
+    this.audioMixCtx?.close().catch(() => {});
+    this.audioMixCtx = null;
     this.cameraComposite?.cleanup();
     this.cameraComposite = null;
     for (const s of [

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -1060,6 +1060,9 @@ export class RecorderEngine {
 
     this.audioMixCtx?.close().catch(() => {});
     const ctx = new AudioContext();
+    if (ctx.state === "suspended") {
+      ctx.resume().catch(() => {});
+    }
     const dest = ctx.createMediaStreamDestination();
     for (const track of audioTracks) {
       ctx.createMediaStreamSource(new MediaStream([track])).connect(dest);

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -1319,7 +1319,7 @@ export default function RecordRoute() {
       setUiState("error");
       showRecordingErrorToast(message);
     }
-  }, [liveTranscription, showRecordingErrorToast]);
+  }, [showRecordingErrorToast]);
 
   // -------------------------------------------------------------------------
   // Stop / upload / navigate.


### PR DESCRIPTION
### Mic audio silently dropped in recordings
Chromium's MediaRecorder only encodes the **first audio track** in a stream. The recorder was adding system/display audio before mic audio, so mic was never recorded — even though the microphone tester showed a working waveform.

Fixed by merging mic and system audio into a single track via `AudioContext + createMediaStreamDestination()` before handing the stream to MediaRecorder. Both sources are now captured together, and the single-track approach sidesteps the first-track-only limitation entirely.