### PR TITLE
[wip] fix orgId missing from session

### DIFF
--- a/.changeset/full-seals-shout.md
+++ b/.changeset/full-seals-shout.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix session.orgId always being undefined

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1380,9 +1380,14 @@ describe("server/auth", () => {
         token: "fresh-token",
       });
       const selectedTokens = mockExecute.mock.calls
-        .map(([query]) =>
-          typeof query === "string" ? undefined : query.args?.[0],
-        )
+        .map(([query]) => {
+          if (typeof query === "string") return undefined;
+          const sql = String(query?.sql ?? "");
+          // Only count the legacy `sessions` token lookups; the org-backfill
+          // queries (`org_members`, `settings`) are noise for this assertion.
+          if (!/FROM\s+sessions\b/i.test(sql)) return undefined;
+          return query.args?.[0];
+        })
         .filter(Boolean);
       expect(selectedTokens).toEqual(["stale-token", "fresh-token"]);
     });
@@ -1494,6 +1499,88 @@ describe("server/auth", () => {
       const session = await authModule.getSession(event);
 
       expect(session).toEqual({ email: "custom@auth.com" });
+    });
+
+    it("backfills orgId from org_members for a single-membership user", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+
+      const mockExecute = vi.fn().mockImplementation((query: any) => {
+        const sql = String(query?.sql ?? "");
+        const args = query?.args ?? [];
+        if (/FROM\s+sessions\b/i.test(sql) && args[0] === "token-abc") {
+          return {
+            rows: [{ email: "user@gmail.com", created_at: Date.now() }],
+          };
+        }
+        if (/FROM\s+org_members\b/i.test(sql) && args[0] === "user@gmail.com") {
+          return { rows: [{ org_id: "org-solo" }] };
+        }
+        return { rows: [] };
+      });
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => true,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+
+      const { getSession } = await import("./auth.js");
+      const event = createMockEvent({
+        headers: { authorization: "Bearer token-abc" },
+      });
+
+      expect(await getSession(event)).toEqual({
+        email: "user@gmail.com",
+        token: "token-abc",
+        orgId: "org-solo",
+      });
+    });
+
+    it("honors active-org-id user setting for a multi-membership user", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+
+      const mockExecute = vi.fn().mockImplementation((query: any) => {
+        const sql = String(query?.sql ?? "");
+        const args = query?.args ?? [];
+        if (/FROM\s+sessions\b/i.test(sql) && args[0] === "token-multi") {
+          return {
+            rows: [{ email: "user@gmail.com", created_at: Date.now() }],
+          };
+        }
+        if (/FROM\s+org_members\b/i.test(sql) && args[0] === "user@gmail.com") {
+          return { rows: [{ org_id: "org-a" }, { org_id: "org-b" }] };
+        }
+        if (
+          /FROM\s+settings\b/i.test(sql) &&
+          args[0] === "u:user@gmail.com:active-org-id"
+        ) {
+          return { rows: [{ value: JSON.stringify({ orgId: "org-b" }) }] };
+        }
+        return { rows: [] };
+      });
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => true,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+
+      const { getSession } = await import("./auth.js");
+      const event = createMockEvent({
+        headers: { authorization: "Bearer token-multi" },
+      });
+
+      expect(await getSession(event)).toEqual({
+        email: "user@gmail.com",
+        token: "token-multi",
+        orgId: "org-b",
+      });
     });
   });
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1644,6 +1644,7 @@ function mapBetterAuthSession(baSession: {
     email: baSession.user.email,
     userId: baSession.user.id,
     name: baSession.user.name,
+    token: baSession.session?.token,
   };
 }
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1638,15 +1638,27 @@ async function maybeAutoCreateDevSession(
  */
 function mapBetterAuthSession(baSession: {
   user: { id: string; email: string; name?: string };
-  session: { token: string; activeOrganizationId?: string };
+  session: { token: string };
 }): AuthSession {
   return {
     email: baSession.user.email,
     userId: baSession.user.id,
     name: baSession.user.name,
-    token: baSession.session?.token,
-    orgId: baSession.session?.activeOrganizationId ?? undefined,
   };
+}
+
+/**
+ * Backfill `orgId` onto a resolved session using the canonical
+ * `resolveOrgIdForEmail` (org_members + active-org-id user setting), so
+ * every consumer of `session.orgId` agrees with `getOrgContext` on which
+ * org is active.
+ *
+ */
+async function backfillSessionOrg(session: AuthSession): Promise<AuthSession> {
+  if (session.orgId) return session;
+  const { resolveOrgIdForEmail } = await import("../org/context.js");
+  const orgId = await resolveOrgIdForEmail(session.email).catch(() => null);
+  return orgId ? { ...session, orgId } : session;
 }
 
 /**
@@ -1667,6 +1679,22 @@ function mapBetterAuthSession(baSession: {
  * page load.
  */
 export async function getSession(event: H3Event): Promise<AuthSession | null> {
+  // Per-request memoization. The wider codebase calls `getSession` many
+  // times per request (auth guard, action wrapper, route handler, plus the
+  // org-backfill query inside `backfillSessionOrg`). Cache the resolved
+  // session on `event.context` so the chain runs once per request.
+  const ctx = event.context as {
+    __anSessionCache?: Promise<AuthSession | null>;
+  };
+  return (ctx.__anSessionCache ??= (async () => {
+    const session = await resolveSessionUncached(event);
+    return session?.email ? backfillSessionOrg(session) : session;
+  })());
+}
+
+async function resolveSessionUncached(
+  event: H3Event,
+): Promise<AuthSession | null> {
   // 1. ACCESS_TOKEN check (programmatic/agent access)
   const accessTokens = getAccessTokens();
   if (accessTokens.length > 0) {

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -425,6 +425,7 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
               aria-label="Document title"
               placeholder="Title"
               readOnly={!canEdit}
+              style={{ fieldSizing: "content" } as any}
               className="block w-full resize-none overflow-hidden break-words border-none bg-transparent p-0 text-3xl font-bold leading-tight text-foreground outline-none placeholder:text-muted-foreground/40 md:text-4xl"
             />
           </div>

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -527,7 +527,7 @@ export function DocumentSidebar({
       )}
 
       <ScrollArea className="min-h-0 flex-1">
-        <div className="min-w-full w-max py-2 pr-2">
+        <div className="w-full py-2 pr-2">
           {/* IconSearch results */}
           {filteredDocuments ? (
             <>


### PR DESCRIPTION
`session.orgId` was undefined on every request even for users with an active org.

**Root cause:** `getSession` populated `orgId` only via Better Auth's `activeOrganizationId`, but the Better Auth org plugin is no longer enabled, even before it was not working correctly as the `activeOrganizationId` was not being stored. So the `orgId` on session is always null.

**Fix:** Set `orgId` in `getSession` using `resolveOrgIdForEmail` (reads `org_members` + `active-org-id` user setting). Runs for every auth path. Results cached per-request so the SQL fires once regardless of how many times `getSession` is called. This way other auths besides Better Auth will also have an orgId set on the session

No callsite changes needed.

## Risks

- +1 indexed SQL per request. Cache absorbs repeat calls within a request.
