### PR TITLE
Fix vault cleanup and DB timeout teardown

### DIFF
--- a/.changeset/vault-db-cleanup.md
+++ b/.changeset/vault-db-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Clean up synced Dispatch vault secrets on delete and make DB timeout cleanup awaitable.

--- a/packages/core/src/db/client.spec.ts
+++ b/packages/core/src/db/client.spec.ts
@@ -143,6 +143,25 @@ describe("withDbTimeout", () => {
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
+  it("waits for async timeout cleanup before rejecting", async () => {
+    const { withDbTimeout } = await import("./client.js");
+    const events: string[] = [];
+
+    await expect(
+      withDbTimeout(
+        "query",
+        () => new Promise(() => {}),
+        10,
+        async () => {
+          await new Promise((r) => setTimeout(r, 10));
+          events.push("cleanup");
+        },
+      ),
+    ).rejects.toMatchObject({ code: "CONNECT_TIMEOUT" });
+
+    expect(events).toEqual(["cleanup"]);
+  });
+
   it("can retry when timeout is inside the retry attempt", async () => {
     const { retryOnConnectionError, withDbTimeout } =
       await import("./client.js");

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -390,18 +390,10 @@ export async function withDbTimeout<T>(
   let timer: ReturnType<typeof setTimeout> | undefined;
   let settled = false;
 
-  const runCleanup = () => {
+  const runCleanup = async () => {
     if (!onTimeout) return;
     try {
-      const result = onTimeout();
-      if (result && typeof (result as Promise<void>).catch === "function") {
-        void (result as Promise<void>).catch((err) => {
-          console.warn(
-            `[db] timeout cleanup for ${op} failed:`,
-            err instanceof Error ? err.message : err,
-          );
-        });
-      }
+      await onTimeout();
     } catch (err) {
       console.warn(
         `[db] timeout cleanup for ${op} failed:`,
@@ -428,8 +420,12 @@ export async function withDbTimeout<T>(
     };
 
     timer = setTimeout(() => {
-      runCleanup();
-      fail(new DbTimeoutError(op, ms));
+      if (settled) return;
+      settled = true;
+      void (async () => {
+        await runCleanup();
+        reject(new DbTimeoutError(op, ms));
+      })();
     }, ms);
 
     let promise: Promise<T>;
@@ -627,7 +623,6 @@ async function createDbExecInternal(
             onnotice: () => {},
           });
           let timedOut = false;
-          let query: ReturnType<typeof conn.unsafe> | undefined;
           try {
             const rawSql = typeof sql === "string" ? sql : sql.sql;
             const args = typeof sql === "string" ? [] : sql.args || [];
@@ -636,16 +631,14 @@ async function createDbExecInternal(
               ArrayLike<unknown> & { count?: number }
             >(
               "query",
-              () => {
-                query = conn.unsafe(pgSql, args as any[]);
-                return query as Promise<
+              () =>
+                conn.unsafe(pgSql, args as any[]) as Promise<
                   ArrayLike<unknown> & { count?: number }
-                >;
-              },
+                >,
               dbOpTimeoutMs(),
               () => {
                 timedOut = true;
-                query?.cancel?.();
+                return conn.end({ timeout: 1 });
               },
             );
             return {
@@ -653,8 +646,7 @@ async function createDbExecInternal(
               rowsAffected: result.count ?? 0,
             };
           } finally {
-            if (timedOut) await conn.end({ timeout: 1 });
-            else await conn.end();
+            if (!timedOut) await conn.end();
           }
         },
       };
@@ -664,8 +656,15 @@ async function createDbExecInternal(
       // frozen instances don't exhaust Neon/Postgres' connection limit;
       // idle_timeout also closes idle connections before Neon's ~5min
       // server-side timeout, avoiding ECONNRESET when the server hangs up.
-      const pool = postgres(url, pgPoolOptions(url));
+      const createPool = () => postgres(url, pgPoolOptions(url));
+      let pool = createPool();
       if (trackSingletonResources) _pgPool = pool;
+      const recyclePool = async () => {
+        const oldPool = pool;
+        pool = createPool();
+        if (trackSingletonResources) _pgPool = pool;
+        await oldPool.end({ timeout: 1 });
+      };
 
       return {
         async execute(sql) {
@@ -680,7 +679,7 @@ async function createDbExecInternal(
               "query",
               () => query,
               dbOpTimeoutMs(),
-              () => query.cancel(),
+              recyclePool,
             );
           });
           return {

--- a/packages/dispatch/src/server/lib/vault-store.spec.ts
+++ b/packages/dispatch/src/server/lib/vault-store.spec.ts
@@ -2,15 +2,27 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   deleteAppSecret: vi.fn(),
+  getDb: vi.fn(),
+  listAppSecretsForScope: vi.fn(),
   writeAppSecret: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/secrets", () => ({
   deleteAppSecret: mocks.deleteAppSecret,
+  listAppSecretsForScope: mocks.listAppSecretsForScope,
   writeAppSecret: mocks.writeAppSecret,
 }));
 
+vi.mock("../../db/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../db/index.js")>();
+  return {
+    ...actual,
+    getDb: mocks.getDb,
+  };
+});
+
 import {
+  cleanupSyncedCredentialKeysIfUnused,
   credentialStoreScopeForVaultCtx,
   syncSecretsToCredentialStore,
 } from "./vault-store.js";
@@ -66,6 +78,72 @@ describe("syncSecretsToCredentialStore", () => {
       scope: "org",
       scopeId: "org_123",
       keys: ["OPENAI_API_KEY"],
+    });
+  });
+});
+
+describe("cleanupSyncedCredentialKeysIfUnused", () => {
+  function mockVaultSecretLookup(rows: Array<{ id: string }> = []) {
+    const query = {
+      select: vi.fn(() => query),
+      from: vi.fn(() => query),
+      where: vi.fn(() => query),
+      limit: vi.fn(async () => rows),
+    };
+    mocks.getDb.mockReturnValue(query);
+    return query;
+  }
+
+  it("deletes a candidate synced credential when no vault secret still uses it", async () => {
+    mockVaultSecretLookup([]);
+
+    await cleanupSyncedCredentialKeysIfUnused(
+      { ownerEmail: "admin@example.test", orgId: "org_123" },
+      ["OLD_API_KEY"],
+    );
+
+    expect(mocks.deleteAppSecret).toHaveBeenCalledWith({
+      key: "OLD_API_KEY",
+      scope: "org",
+      scopeId: "org_123",
+    });
+  });
+
+  it("keeps a candidate synced credential when another vault secret still uses it", async () => {
+    mockVaultSecretLookup([{ id: "secret_1" }]);
+
+    await cleanupSyncedCredentialKeysIfUnused(
+      { ownerEmail: "admin@example.test", orgId: "org_123" },
+      ["SHARED_API_KEY"],
+    );
+
+    expect(mocks.deleteAppSecret).not.toHaveBeenCalled();
+  });
+
+  it("can scan synced app secrets to recover stale keys after a retry", async () => {
+    mockVaultSecretLookup([]);
+    mocks.listAppSecretsForScope.mockResolvedValue([
+      {
+        key: "STALE_KEY",
+        description: "Synced from Dispatch vault: Old key",
+      },
+      {
+        key: "HAND_WRITTEN_KEY",
+        description: "Created manually",
+      },
+    ]);
+
+    await cleanupSyncedCredentialKeysIfUnused({
+      ownerEmail: "admin@example.test",
+      orgId: "org_123",
+    });
+
+    expect(mocks.listAppSecretsForScope).toHaveBeenCalledWith("org", "org_123");
+    expect(mocks.deleteAppSecret).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteAppSecret).toHaveBeenCalledWith({
+      key: "STALE_KEY",
+      scope: "org",
+      scopeId: "org_123",
     });
   });
 });

--- a/packages/dispatch/src/server/lib/vault-store.ts
+++ b/packages/dispatch/src/server/lib/vault-store.ts
@@ -3,6 +3,7 @@ import { and, desc, eq, isNull, or } from "drizzle-orm";
 import { discoverAgents } from "@agent-native/core/server/agent-discovery";
 import {
   deleteAppSecret,
+  listAppSecretsForScope,
   writeAppSecret,
   type SecretScope,
 } from "@agent-native/core/secrets";
@@ -20,6 +21,7 @@ import {
 } from "./dispatch-store.js";
 
 const VAULT_ACCESS_SETTINGS_KEY = "dispatch-vault-access-settings";
+const VAULT_SYNC_DESCRIPTION_PREFIX = "Synced from Dispatch vault:";
 
 export type VaultAccessMode = "all-apps" | "manual";
 
@@ -403,24 +405,9 @@ export async function updateSecret(
   const updated = await getSecret(secretId, ctx);
   if (updated) await syncSecretsToCredentialStore([updated], ctx);
   if (updated && credentialKey !== existing.credentialKey) {
-    const stillUsesOldKey = await db
-      .select({ id: schema.vaultSecrets.id })
-      .from(schema.vaultSecrets)
-      .where(
-        and(
-          eq(schema.vaultSecrets.credentialKey, existing.credentialKey),
-          ctxScope(schema.vaultSecrets, ctx),
-        ),
-      )
-      .limit(1);
-    if (!stillUsesOldKey[0]) {
-      const target = credentialStoreScopeForVaultCtx(ctx);
-      await deleteAppSecret({
-        key: existing.credentialKey,
-        scope: target.scope,
-        scopeId: target.scopeId,
-      });
-    }
+    await cleanupSyncedCredentialKeysIfUnused(ctx, [existing.credentialKey]);
+  } else if (patch.credentialKey !== undefined) {
+    await cleanupSyncedCredentialKeysIfUnused(ctx);
   }
   return updated;
 }
@@ -449,6 +436,7 @@ export async function deleteSecret(
         ctxScope(schema.vaultSecrets, ctx),
       ),
     );
+  await cleanupSyncedCredentialKeysIfUnused(ctx, [existing.credentialKey]);
 
   await recordVaultAudit({
     action: "secret.deleted",
@@ -652,12 +640,47 @@ export async function syncSecretsToCredentialStore(
       value: secret.value,
       scope: target.scope,
       scopeId: target.scopeId,
-      description: `Synced from Dispatch vault: ${secret.name}`,
+      description: `${VAULT_SYNC_DESCRIPTION_PREFIX} ${secret.name}`,
     });
     syncedKeys.push(secret.credentialKey);
   }
 
   return { ...target, keys: syncedKeys };
+}
+
+export async function cleanupSyncedCredentialKeysIfUnused(
+  ctx: VaultCtx,
+  candidateKeys?: string[],
+) {
+  const db = getDb();
+  const target = credentialStoreScopeForVaultCtx(ctx);
+  const keys = candidateKeys
+    ? candidateKeys
+    : (await listAppSecretsForScope(target.scope, target.scopeId))
+        .filter((secret) =>
+          secret.description?.startsWith(VAULT_SYNC_DESCRIPTION_PREFIX),
+        )
+        .map((secret) => secret.key);
+
+  for (const key of new Set(keys.filter(Boolean))) {
+    const stillUsesKey = await db
+      .select({ id: schema.vaultSecrets.id })
+      .from(schema.vaultSecrets)
+      .where(
+        and(
+          eq(schema.vaultSecrets.credentialKey, key),
+          ctxScope(schema.vaultSecrets, ctx),
+        ),
+      )
+      .limit(1);
+    if (!stillUsesKey[0]) {
+      await deleteAppSecret({
+        key,
+        scope: target.scope,
+        scopeId: target.scopeId,
+      });
+    }
+  }
 }
 
 // ─── Sync ──────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to post-merge review feedback from #760.

Summary:
- Delete synced Dispatch app_secrets entries when vault secrets are deleted.
- Add retry-safe cleanup for stale synced vault keys after credential-key edits.
- Await DB timeout cleanup and recycle postgres.js pools instead of firing cancel without observable error handling.

Validation:
- pnpm --filter @agent-native/core exec vitest --run src/db/client.spec.ts
- pnpm --filter @agent-native/dispatch test -- vault-store.spec.ts
- pnpm --filter @agent-native/dispatch typecheck
- pnpm --filter @agent-native/core typecheck
- pnpm prep passed locally per Steve

Note: unrelated concurrent-agent WIP remains unstaged in the local worktree and is intentionally not part of this PR.