### PR TITLE
Persist action refreshes and sidebar preferences

### DIFF
--- a/.agents/skills/actions/SKILL.md
+++ b/.agents/skills/actions/SKILL.md
@@ -68,7 +68,7 @@ Controls how the action is exposed as an HTTP endpoint:
 
 ### Screen Refresh (automatic)
 
-The framework auto-refreshes the UI after any successful mutating action. On completion of a non-`GET` action, the server emits a change event that the client's `useDbSync` picks up and uses to invalidate `["action"]` React Query keys — so `list-*` / `get-*` hooks refetch without a full page reload.
+The framework auto-refreshes the UI after any successful mutating action. On completion of a non-`GET` action, the framework emits a change event with `source: "action"` that the client's `useDbSync` picks up and uses to invalidate `["action"]` React Query keys — so `list-*` / `get-*` hooks refetch without a full page reload. In-process calls emit directly; dev-mode `pnpm action ...` calls also write a durable marker so the web server sees child-process action changes.
 
 Rules:
 

--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -250,7 +250,7 @@ external agent's MCP token. See **context-awareness** for the
 An action an external agent reads to pull live app state into its own context
 must be: `http: { method: "GET" }` + `readOnly: true` +
 `publicAgent: { expose: true, readOnly: true, requiresAuth: true }`. GET +
-`readOnly` keeps it side-effect-free and out of the screen-refresh poll;
+`readOnly` keeps it side-effect-free and out of the screen-refresh change event;
 `publicAgent` is the explicit opt-in (public web routes never imply public
 MCP/A2A exposure). Design/content ingest actions MUST read **live** state
 (e.g. the Yjs document) — not the stale DB snapshot column — so the external

--- a/.changeset/builder-chat-preference.md
+++ b/.changeset/builder-chat-preference.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Respect the persisted agent chat sidebar state inside Builder frames.

--- a/.changeset/durable-action-pings.md
+++ b/.changeset/durable-action-pings.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Persist mutating action change markers so child-process actions refresh custom app UIs.

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -247,7 +247,7 @@ export default defineAction({
 });
 ```
 
-`GET` + `readOnly` keeps the action side-effect-free and out of the screen-refresh poll. `publicAgent` is the **explicit opt-in** — a public web route never implies public MCP/A2A exposure; see [Actions](/docs/actions). Design/content ingest actions MUST read **live** state (the Yjs collaborative document, not the stale DB snapshot column) so the external agent sees what the user actually has on screen. Content's `pull-document` flushes any open live collab session to SQL first; design's `get-design-snapshot` returns the live Yjs file contents plus the user's resolved tweak values.
+`GET` + `readOnly` keeps the action side-effect-free and out of the screen-refresh change event. `publicAgent` is the **explicit opt-in** — a public web route never implies public MCP/A2A exposure; see [Actions](/docs/actions). Design/content ingest actions MUST read **live** state (the Yjs collaborative document, not the stale DB snapshot column) so the external agent sees what the user actually has on screen. Content's `pull-document` flushes any open live collab session to SQL first; design's `get-design-snapshot` returns the live Yjs file contents plus the user's resolved tweak values.
 
 ## Advanced: local development & manual setup {#advanced}
 

--- a/packages/core/docs/content/what-is-agent-native.md
+++ b/packages/core/docs/content/what-is-agent-native.md
@@ -53,7 +53,7 @@ It also explains why agent-native can support so many protocols without making e
 
 ## Why every agent needs a UI {#why-every-agent-needs-a-ui}
 
-The hot take in 2026 is "apps are dead, agents will replace UIs, everyone will just text an agent in Telegram." That's wrong.
+The hot take in 2026 is "apps are dead, agents will replace UIs, everyone will just text an agent in Telegram." Eh.
 
 Even when the agent does all the heavy lifting, humans still need to:
 

--- a/packages/core/src/action-change-marker.ts
+++ b/packages/core/src/action-change-marker.ts
@@ -1,0 +1,67 @@
+export const ACTION_CHANGE_MARKER_KEY = "__action_change__";
+export const ACTION_CHANGE_MARKER_ORG_PREFIX = "__org__:";
+
+export interface ActionChangeTarget {
+  actionName?: string;
+  owner?: string;
+  orgId?: string;
+}
+
+export function actionChangeMarkerSession(
+  target: ActionChangeTarget,
+): string | null {
+  if (target.owner) return target.owner;
+  if (target.orgId) return `${ACTION_CHANGE_MARKER_ORG_PREFIX}${target.orgId}`;
+  return null;
+}
+
+export function actionChangeMarkerValue(
+  target: ActionChangeTarget,
+): Record<string, string> {
+  return {
+    source: "action",
+    ...(target.actionName ? { actionName: target.actionName } : {}),
+    ...(target.owner ? { owner: target.owner } : {}),
+    ...(target.orgId ? { orgId: target.orgId } : {}),
+  };
+}
+
+export function parseActionChangeMarker(
+  sessionId: unknown,
+  value: unknown,
+): ActionChangeTarget | null {
+  let parsed: unknown = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      parsed = null;
+    }
+  }
+
+  let actionName: string | undefined;
+  let owner: string | undefined;
+  let orgId: string | undefined;
+
+  if (parsed && typeof parsed === "object") {
+    const record = parsed as Record<string, unknown>;
+    actionName =
+      typeof record.actionName === "string" ? record.actionName : undefined;
+    owner = typeof record.owner === "string" ? record.owner : undefined;
+    orgId = typeof record.orgId === "string" ? record.orgId : undefined;
+  }
+
+  if (!owner && !orgId && typeof sessionId === "string" && sessionId) {
+    if (sessionId.startsWith(ACTION_CHANGE_MARKER_ORG_PREFIX)) {
+      const parsedOrgId = sessionId.slice(
+        ACTION_CHANGE_MARKER_ORG_PREFIX.length,
+      );
+      if (parsedOrgId) orgId = parsedOrgId;
+    } else {
+      owner = sessionId;
+    }
+  }
+
+  if (!actionName && !owner && !orgId) return null;
+  return { actionName, owner, orgId };
+}

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -173,7 +173,7 @@ interface DefineActionWithSchema<
     args: StandardSchemaV1.InferOutput<TSchema>,
   ) => Promise<TReturn> | TReturn;
   http?: ActionHttpConfig | false;
-  /** If true, the framework will NOT emit a screen-refresh poll event after a
+  /** If true, the framework will NOT emit a screen-refresh change event after a
    *  successful call. Auto-inferred as `true` when `http.method === "GET"`.
    *  Only set this manually when you need to override the inference — e.g. a
    *  POST action that only reads data but can't use GET for a protocol reason. */
@@ -228,7 +228,7 @@ interface DefineActionWithParams<
   schema?: never;
   run: (args: InferParams<TParams>) => Promise<TReturn> | TReturn;
   http?: ActionHttpConfig | false;
-  /** If true, the framework will NOT emit a screen-refresh poll event after a
+  /** If true, the framework will NOT emit a screen-refresh change event after a
    *  successful call. Auto-inferred as `true` when `http.method === "GET"`. */
   readOnly?: boolean;
   /** If true, the agent may execute this action concurrently with other
@@ -319,7 +319,7 @@ export function defineAction(options: any) {
   // Auto-infer readOnly from http.method === "GET" unless explicitly set.
   // GET actions are idempotent reads; their completion should NOT trigger a
   // screen refresh. Everything else is assumed to mutate — the dispatcher
-  // emits a poll event on success so the UI auto-refetches its queries.
+  // emits a change event on success so the UI auto-refetches its queries.
   const httpConfig = options.http as ActionHttpConfig | false | undefined;
   const inferredReadOnly =
     httpConfig !== false &&

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -263,7 +263,7 @@ export interface ActionEntry {
   /** Explicit opt-in metadata for public agent protocols. Public routes never
    *  imply public tool exposure; MCP/A2A/OpenAPI surfaces must filter for this. */
   publicAgent?: import("../action.js").PublicAgentActionConfig;
-  /** If true, completion does NOT trigger a screen-refresh poll event.
+  /** If true, completion does NOT trigger a screen-refresh change event.
    *  Set automatically by `defineAction` when `http.method === "GET"`. */
   readOnly?: boolean;
   /** If true, this action can run concurrently with other same-turn
@@ -1755,19 +1755,18 @@ export async function runAgentLoop(opts: {
 
       // Auto-refresh the UI after a successful mutating tool call. Any action
       // that isn't explicitly read-only is assumed to mutate. The client's
-      // useDbSync listener sees a poll event with source:"action" and
+      // useDbSync listener sees a change event with source:"action" and
       // invalidates ["action"] queries so list-* / get-* refetch. This makes
       // refresh after agent writes reliable without the model needing to
       // remember to call `refresh-screen` itself.
       if (!isError && actionEntry.readOnly !== true) {
         try {
-          const { recordChange } = await import("../server/poll.js");
+          const { notifyActionChange } =
+            await import("../server/action-change.js");
           const owner = opts.ownerEmail ?? getRequestUserEmail() ?? undefined;
           const orgId = opts.orgId ?? getRequestOrgId() ?? undefined;
-          recordChange({
-            source: "action",
-            type: "change",
-            key: toolCall.name,
+          await notifyActionChange({
+            actionName: toolCall.name,
             ...(owner ? { owner } : {}),
             ...(orgId ? { orgId } : {}),
           });

--- a/packages/core/src/client/agent-sidebar-state.spec.ts
+++ b/packages/core/src/client/agent-sidebar-state.spec.ts
@@ -1,12 +1,6 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const frameState = vi.hoisted(() => ({ inBuilderFrame: false }));
-
-vi.mock("./builder-frame.js", () => ({
-  isInBuilderFrame: () => frameState.inBuilderFrame,
-}));
-
 const {
   consumeAgentSidebarUrlOpenOverride,
   dispatchAgentSidebarStateChange,
@@ -34,7 +28,6 @@ function stubMatchMedia(matches: boolean) {
 
 describe("getInitialAgentSidebarOpen", () => {
   beforeEach(() => {
-    frameState.inBuilderFrame = false;
     window.localStorage.clear();
     window.history.replaceState(null, "", "/");
     stubMatchMedia(false);
@@ -56,13 +49,6 @@ describe("getInitialAgentSidebarOpen", () => {
   it("starts closed on mobile even with a saved open preference", () => {
     window.localStorage.setItem(SIDEBAR_OPEN_KEY, "true");
     stubMatchMedia(true);
-
-    expect(getInitialAgentSidebarOpen(true)).toBe(false);
-  });
-
-  it("starts closed in Builder even with a saved open preference", () => {
-    window.localStorage.setItem(SIDEBAR_OPEN_KEY, "true");
-    frameState.inBuilderFrame = true;
 
     expect(getInitialAgentSidebarOpen(true)).toBe(false);
   });

--- a/packages/core/src/client/agent-sidebar-state.ts
+++ b/packages/core/src/client/agent-sidebar-state.ts
@@ -1,4 +1,3 @@
-import { isInBuilderFrame } from "./builder-frame.js";
 import {
   AGENT_SIDEBAR_QUERY_PARAM,
   AGENT_SIDEBAR_QUERY_VALUE_CLOSED,
@@ -119,13 +118,6 @@ export function getInitialAgentSidebarOpen(defaultOpen: boolean): boolean {
     typeof window !== "undefined" &&
     window.matchMedia("(max-width: 767px)").matches
   ) {
-    return false;
-  }
-
-  // Builder owns the code/chat surface around embedded apps. Start the
-  // app-native chat collapsed there even if a previous standalone session
-  // persisted it as open.
-  if (isInBuilderFrame()) {
     return false;
   }
 

--- a/packages/core/src/scripts/runner.ts
+++ b/packages/core/src/scripts/runner.ts
@@ -18,6 +18,7 @@ import { closeDbExec } from "../db/client.js";
 import { loadEnv } from "./utils.js";
 import { runWithRequestContext } from "../server/request-context.js";
 import { resolveDevUserEmail } from "./dev-session.js";
+import { notifyActionChange } from "../server/action-change.js";
 import type { ActionEntry } from "../agent/production-agent.js";
 
 // Load .env from cwd so DATABASE_URL and other vars are available to all actions.
@@ -212,6 +213,9 @@ async function dispatchAction(
       ) {
         const parsed = parseActionArgs(args, { coerceBooleans: true });
         const result = await handler.run(parsed);
+        if (handler.readOnly !== true) {
+          await notifyActionChange({ actionName }).catch(() => {});
+        }
         if (result) console.log(result);
       } else if (typeof handler === "function") {
         await handler(args);
@@ -237,6 +241,9 @@ async function dispatchAction(
       await runAppDbPluginIfPresent();
       const parsed = parseActionArgs(args, { coerceBooleans: true });
       const result = await packageAction.run(parsed as Record<string, string>);
+      if (packageAction.readOnly !== true) {
+        await notifyActionChange({ actionName }).catch(() => {});
+      }
       if (result) console.log(result);
       await closeDbExec().catch(() => {});
       process.exit(0);

--- a/packages/core/src/server/action-change.spec.ts
+++ b/packages/core/src/server/action-change.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAppStatePut = vi.hoisted(() => vi.fn());
+const mockRecordChange = vi.hoisted(() => vi.fn());
+const mockGetRequestOrgId = vi.hoisted(() => vi.fn());
+const mockGetRequestUserEmail = vi.hoisted(() => vi.fn());
+
+vi.mock("../application-state/store.js", () => ({
+  appStatePut: (...args: unknown[]) => mockAppStatePut(...args),
+}));
+
+vi.mock("./poll.js", () => ({
+  recordChange: (...args: unknown[]) => mockRecordChange(...args),
+}));
+
+vi.mock("./request-context.js", () => ({
+  getRequestOrgId: () => mockGetRequestOrgId(),
+  getRequestUserEmail: () => mockGetRequestUserEmail(),
+}));
+
+describe("notifyActionChange", () => {
+  beforeEach(() => {
+    mockAppStatePut.mockReset();
+    mockRecordChange.mockReset();
+    mockGetRequestOrgId.mockReset();
+    mockGetRequestUserEmail.mockReset();
+  });
+
+  it("records in-memory and durable action changes for an owner", async () => {
+    const { notifyActionChange } = await import("./action-change.js");
+
+    await notifyActionChange({
+      actionName: "create-project",
+      owner: "owner@example.com",
+    });
+
+    expect(mockRecordChange).toHaveBeenCalledWith({
+      source: "action",
+      type: "change",
+      key: "create-project",
+      owner: "owner@example.com",
+    });
+    expect(mockAppStatePut).toHaveBeenCalledWith(
+      "owner@example.com",
+      "__action_change__",
+      expect.objectContaining({
+        source: "action",
+        actionName: "create-project",
+        owner: "owner@example.com",
+      }),
+      { requestSource: "agent" },
+    );
+  });
+
+  it("does not broaden owner-scoped action markers to the current org", async () => {
+    mockGetRequestUserEmail.mockReturnValue("owner@example.com");
+    mockGetRequestOrgId.mockReturnValue("org-1");
+    const { notifyActionChange } = await import("./action-change.js");
+
+    await notifyActionChange({ actionName: "update-project" });
+
+    expect(mockRecordChange).toHaveBeenCalledWith({
+      source: "action",
+      type: "change",
+      key: "update-project",
+      owner: "owner@example.com",
+    });
+    expect(mockAppStatePut.mock.calls[0][2]).not.toHaveProperty("orgId");
+  });
+});

--- a/packages/core/src/server/action-change.spec.ts
+++ b/packages/core/src/server/action-change.spec.ts
@@ -67,4 +67,33 @@ describe("notifyActionChange", () => {
     });
     expect(mockAppStatePut.mock.calls[0][2]).not.toHaveProperty("orgId");
   });
+
+  it("keeps explicit owner-scoped action changes out of explicit org scope", async () => {
+    const { notifyActionChange } = await import("./action-change.js");
+
+    await notifyActionChange({
+      actionName: "publish-project",
+      owner: "owner@example.com",
+      orgId: "org-1",
+    });
+
+    expect(mockRecordChange).toHaveBeenCalledWith({
+      source: "action",
+      type: "change",
+      key: "publish-project",
+      owner: "owner@example.com",
+    });
+    expect(mockRecordChange.mock.calls[0][0]).not.toHaveProperty("orgId");
+    expect(mockAppStatePut).toHaveBeenCalledWith(
+      "owner@example.com",
+      "__action_change__",
+      expect.objectContaining({
+        source: "action",
+        actionName: "publish-project",
+        owner: "owner@example.com",
+      }),
+      { requestSource: "agent" },
+    );
+    expect(mockAppStatePut.mock.calls[0][2]).not.toHaveProperty("orgId");
+  });
 });

--- a/packages/core/src/server/action-change.ts
+++ b/packages/core/src/server/action-change.ts
@@ -1,0 +1,62 @@
+import {
+  ACTION_CHANGE_MARKER_KEY,
+  actionChangeMarkerSession,
+  actionChangeMarkerValue,
+  type ActionChangeTarget,
+} from "../action-change-marker.js";
+import { appStatePut } from "../application-state/store.js";
+import { getRequestOrgId, getRequestUserEmail } from "./request-context.js";
+import { recordChange } from "./poll.js";
+
+export interface NotifyActionChangeOptions {
+  actionName: string;
+  owner?: string;
+  orgId?: string;
+}
+
+function actionChangeTarget(
+  options: NotifyActionChangeOptions,
+): ActionChangeTarget {
+  const owner = options.owner ?? getRequestUserEmail() ?? undefined;
+  return {
+    actionName: options.actionName,
+    owner,
+    orgId: options.orgId ?? (owner ? undefined : getRequestOrgId()),
+  };
+}
+
+export async function writeActionChangeMarker(
+  options: NotifyActionChangeOptions,
+): Promise<void> {
+  const target = actionChangeTarget(options);
+  const sessionId = actionChangeMarkerSession(target);
+  if (!sessionId) return;
+  await appStatePut(
+    sessionId,
+    ACTION_CHANGE_MARKER_KEY,
+    {
+      ...actionChangeMarkerValue(target),
+      nonce: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    },
+    { requestSource: "agent" },
+  );
+}
+
+export async function notifyActionChange(
+  options: NotifyActionChangeOptions,
+): Promise<void> {
+  const target = actionChangeTarget(options);
+  recordChange({
+    source: "action",
+    type: "change",
+    key: options.actionName,
+    ...(target.owner ? { owner: target.owner } : {}),
+    ...(target.orgId ? { orgId: target.orgId } : {}),
+  });
+
+  await writeActionChangeMarker({
+    actionName: options.actionName,
+    ...(target.owner ? { owner: target.owner } : {}),
+    ...(target.orgId ? { orgId: target.orgId } : {}),
+  });
+}

--- a/packages/core/src/server/action-change.ts
+++ b/packages/core/src/server/action-change.ts
@@ -21,7 +21,7 @@ function actionChangeTarget(
   return {
     actionName: options.actionName,
     owner,
-    orgId: options.orgId ?? (owner ? undefined : getRequestOrgId()),
+    orgId: owner ? undefined : (options.orgId ?? getRequestOrgId()),
   };
 }
 

--- a/packages/core/src/server/action-routes.spec.ts
+++ b/packages/core/src/server/action-routes.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ActionEntry } from "../agent/production-agent.js";
 
-const mockRecordChange = vi.hoisted(() => vi.fn());
+const mockNotifyActionChange = vi.hoisted(() => vi.fn());
 
 vi.mock("h3", () => ({
   defineEventHandler: (handler: any) => handler,
@@ -23,8 +23,8 @@ vi.mock("./framework-request-handler.js", () => ({
   getH3App: (app: any) => app,
 }));
 
-vi.mock("./poll.js", () => ({
-  recordChange: (...args: unknown[]) => mockRecordChange(...args),
+vi.mock("./action-change.js", () => ({
+  notifyActionChange: (...args: unknown[]) => mockNotifyActionChange(...args),
 }));
 
 describe("mountActionRoutes", () => {
@@ -32,7 +32,7 @@ describe("mountActionRoutes", () => {
     delete process.env.AGENT_USER_EMAIL;
     delete process.env.AGENT_ORG_ID;
     delete process.env.AGENT_USER_TIMEZONE;
-    mockRecordChange.mockReset();
+    mockNotifyActionChange.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -152,7 +152,7 @@ describe("mountActionRoutes", () => {
 
     expect(result).toEqual({ ok: true, params: { q: "hello" } });
     expect(actions["list-things"].run).toHaveBeenCalledWith({ q: "hello" });
-    expect(mockRecordChange).not.toHaveBeenCalled();
+    expect(mockNotifyActionChange).not.toHaveBeenCalled();
   });
 
   it("short-circuits OPTIONS without resolving auth context", async () => {
@@ -233,10 +233,8 @@ describe("mountActionRoutes", () => {
       req: { url: "http://app.test/_agent-native/actions/mutating-read" },
     });
 
-    expect(mockRecordChange).toHaveBeenCalledWith({
-      source: "action",
-      type: "change",
-      key: "mutating-read",
+    expect(mockNotifyActionChange).toHaveBeenCalledWith({
+      actionName: "mutating-read",
     });
   });
 

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -16,7 +16,7 @@ import {
 import type { ActionEntry } from "../agent/production-agent.js";
 import { readBody } from "../server/h3-helpers.js";
 import { runWithRequestContext } from "./request-context.js";
-import { recordChange } from "./poll.js";
+import { notifyActionChange } from "./action-change.js";
 import {
   getAllowedCorsOrigin as resolveAllowedCorsOrigin,
   readCorsAllowedOrigins,
@@ -214,11 +214,9 @@ export function mountActionRoutes(
                   : method === "GET";
               if (!isReadOnly) {
                 try {
-                  recordChange({
-                    source: "action",
-                    type: "change",
-                    key: name,
-                    owner: userEmail,
+                  await notifyActionChange({
+                    actionName: name,
+                    ...(userEmail ? { owner: userEmail } : {}),
                   });
                 } catch {
                   // ignore

--- a/packages/core/src/server/poll-handler.spec.ts
+++ b/packages/core/src/server/poll-handler.spec.ts
@@ -34,6 +34,7 @@ describe("poll handler", () => {
     let settingsTs = 900;
     let extensionsTs = 800;
     let extensionMarkerTs = 0;
+    let actionMarkerTs = 0;
     let refreshTs = 500;
     let refreshValue = JSON.stringify({ scope: "initial" });
     let appStateRows = [
@@ -51,7 +52,17 @@ describe("poll handler", () => {
         sql.includes("application_state") &&
         sql.includes("WHERE key = ?")
       ) {
-        return { rows: [{ max_ts: extensionMarkerTs }] };
+        const key = query.args?.[0];
+        return {
+          rows: [
+            {
+              max_ts:
+                key === "__action_change__"
+                  ? actionMarkerTs
+                  : extensionMarkerTs,
+            },
+          ],
+        };
       }
       if (
         sql.includes("MAX(updated_at)") &&
@@ -70,6 +81,9 @@ describe("poll handler", () => {
         sql.includes("key = ?") &&
         sql.includes("SELECT session_id, value, updated_at")
       ) {
+        if (query.args?.[0] === "__action_change__") {
+          return { rows: [] };
+        }
         return { rows: [] };
       }
       if (
@@ -104,6 +118,7 @@ describe("poll handler", () => {
     settingsTs = 900;
     extensionsTs = 800;
     extensionMarkerTs = 0;
+    actionMarkerTs = 0;
     refreshTs = 2_000;
     refreshValue = JSON.stringify({ scope: "documents" });
     appStateRows = [
@@ -140,6 +155,7 @@ describe("poll handler", () => {
     let settingsTs = 900;
     let extensionsTs = "2026-05-15T12:00:00.000Z";
     let extensionMarkerTs = 700;
+    let actionMarkerTs = 0;
     let extensionRows: Array<Record<string, unknown>> = [];
 
     mockExecute.mockImplementation(async (query: any) => {
@@ -149,7 +165,17 @@ describe("poll handler", () => {
         sql.includes("application_state") &&
         sql.includes("WHERE key = ?")
       ) {
-        return { rows: [{ max_ts: extensionMarkerTs }] };
+        const key = query.args?.[0];
+        return {
+          rows: [
+            {
+              max_ts:
+                key === "__action_change__"
+                  ? actionMarkerTs
+                  : extensionMarkerTs,
+            },
+          ],
+        };
       }
       if (
         sql.includes("MAX(updated_at)") &&
@@ -241,12 +267,13 @@ describe("poll handler", () => {
     );
   });
 
-  it("emits extension changes from durable markers for delete and hide fallback", async () => {
+  it("emits action changes from durable markers for child-process actions", async () => {
     let appStateTs = 1_000;
     let settingsTs = 900;
     let extensionsTs = 800;
-    let extensionMarkerTs = 700;
-    let extensionMarkerRows: Array<Record<string, unknown>> = [];
+    let extensionMarkerTs = 0;
+    let actionMarkerTs = 700;
+    let actionMarkerRows: Array<Record<string, unknown>> = [];
 
     mockExecute.mockImplementation(async (query: any) => {
       const sql = typeof query === "string" ? query : query.sql;
@@ -255,7 +282,17 @@ describe("poll handler", () => {
         sql.includes("application_state") &&
         sql.includes("WHERE key = ?")
       ) {
-        return { rows: [{ max_ts: extensionMarkerTs }] };
+        const key = query.args?.[0];
+        return {
+          rows: [
+            {
+              max_ts:
+                key === "__action_change__"
+                  ? actionMarkerTs
+                  : extensionMarkerTs,
+            },
+          ],
+        };
       }
       if (
         sql.includes("MAX(updated_at)") &&
@@ -274,6 +311,127 @@ describe("poll handler", () => {
         sql.includes("key = ?") &&
         sql.includes("SELECT session_id, value, updated_at")
       ) {
+        if (query.args?.[0] === "__action_change__") {
+          return { rows: actionMarkerRows };
+        }
+        return { rows: [] };
+      }
+      if (
+        sql.includes("SELECT session_id, key, updated_at") &&
+        sql.includes("application_state")
+      ) {
+        const since = Number(query.args?.[0]) || 0;
+        return {
+          rows: actionMarkerRows
+            .filter((row) => Number(row.updated_at) > since)
+            .map((row) => ({
+              session_id: row.session_id,
+              key: "__action_change__",
+              updated_at: row.updated_at,
+            })),
+        };
+      }
+      if (sql.includes("WHERE key = ?")) {
+        return { rows: [] };
+      }
+      if (
+        sql.includes("SELECT id, owner_email") &&
+        sql.includes("FROM tools")
+      ) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+
+    const { createPollHandler } = await import("./poll.js");
+    const handler = createPollHandler() as any;
+
+    const baseline = await handler({ query: { since: "0" } });
+    expect(baseline.events).toEqual([]);
+
+    vi.setSystemTime(101_500);
+    appStateTs = 2_000;
+    actionMarkerTs = 2_000;
+    actionMarkerRows = [
+      {
+        session_id: "test@example.com",
+        value: JSON.stringify({
+          source: "action",
+          actionName: "create-project",
+          owner: "test@example.com",
+        }),
+        updated_at: 2_000,
+      },
+    ];
+
+    const next = await handler({ query: { since: String(baseline.version) } });
+
+    expect(next.events).toEqual([
+      expect.objectContaining({
+        source: "action",
+        type: "change",
+        key: "create-project",
+        owner: "test@example.com",
+      }),
+    ]);
+    expect(next.events).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "app-state",
+          key: "__action_change__",
+        }),
+      ]),
+    );
+  });
+
+  it("emits extension changes from durable markers for delete and hide fallback", async () => {
+    let appStateTs = 1_000;
+    let settingsTs = 900;
+    let extensionsTs = 800;
+    let extensionMarkerTs = 700;
+    let actionMarkerTs = 0;
+    let extensionMarkerRows: Array<Record<string, unknown>> = [];
+    let actionMarkerRows: Array<Record<string, unknown>> = [];
+
+    mockExecute.mockImplementation(async (query: any) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      if (
+        sql.includes("MAX(updated_at)") &&
+        sql.includes("application_state") &&
+        sql.includes("WHERE key = ?")
+      ) {
+        const key = query.args?.[0];
+        return {
+          rows: [
+            {
+              max_ts:
+                key === "__action_change__"
+                  ? actionMarkerTs
+                  : extensionMarkerTs,
+            },
+          ],
+        };
+      }
+      if (
+        sql.includes("MAX(updated_at)") &&
+        sql.includes("application_state")
+      ) {
+        return { rows: [{ max_ts: appStateTs }] };
+      }
+      if (sql.includes("MAX(updated_at)") && sql.includes("settings")) {
+        return { rows: [{ max_ts: settingsTs }] };
+      }
+      if (sql.includes("MAX(updated_at)") && sql.includes("tools")) {
+        return { rows: [{ max_ts: extensionsTs }] };
+      }
+      if (
+        sql.includes("FROM application_state") &&
+        sql.includes("key = ?") &&
+        sql.includes("SELECT session_id, value, updated_at")
+      ) {
+        if (query.args?.[0] === "__action_change__") {
+          return { rows: actionMarkerRows };
+        }
         return { rows: extensionMarkerRows };
       }
       if (
@@ -312,6 +470,8 @@ describe("poll handler", () => {
     vi.setSystemTime(101_500);
     appStateTs = 2_000;
     extensionMarkerTs = 2_000;
+    actionMarkerTs = 0;
+    actionMarkerRows = [];
     extensionMarkerRows = [
       {
         session_id: "test@example.com",

--- a/packages/core/src/server/poll-handler.spec.ts
+++ b/packages/core/src/server/poll-handler.spec.ts
@@ -384,6 +384,106 @@ describe("poll handler", () => {
     );
   });
 
+  it("emits existing action markers on cold start instead of baselining past them", async () => {
+    const appStateTs = 1_000;
+    const settingsTs = 900;
+    const extensionsTs = 800;
+    const extensionMarkerTs = 0;
+    const actionMarkerTs = 1_000;
+    const actionMarkerRows: Array<Record<string, unknown>> = [
+      {
+        session_id: "test@example.com",
+        value: JSON.stringify({
+          source: "action",
+          actionName: "create-project",
+          owner: "test@example.com",
+        }),
+        updated_at: 1_000,
+      },
+    ];
+
+    mockExecute.mockImplementation(async (query: any) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      if (
+        sql.includes("MAX(updated_at)") &&
+        sql.includes("application_state") &&
+        sql.includes("WHERE key = ?")
+      ) {
+        const key = query.args?.[0];
+        return {
+          rows: [
+            {
+              max_ts:
+                key === "__action_change__"
+                  ? actionMarkerTs
+                  : extensionMarkerTs,
+            },
+          ],
+        };
+      }
+      if (
+        sql.includes("MAX(updated_at)") &&
+        sql.includes("application_state")
+      ) {
+        return { rows: [{ max_ts: appStateTs }] };
+      }
+      if (sql.includes("MAX(updated_at)") && sql.includes("settings")) {
+        return { rows: [{ max_ts: settingsTs }] };
+      }
+      if (sql.includes("MAX(updated_at)") && sql.includes("tools")) {
+        return { rows: [{ max_ts: extensionsTs }] };
+      }
+      if (
+        sql.includes("FROM application_state") &&
+        sql.includes("key = ?") &&
+        sql.includes("SELECT session_id, value, updated_at")
+      ) {
+        if (query.args?.[0] === "__action_change__") {
+          return { rows: actionMarkerRows };
+        }
+        return { rows: [] };
+      }
+      if (
+        sql.includes("SELECT session_id, key, updated_at") &&
+        sql.includes("application_state")
+      ) {
+        return { rows: [] };
+      }
+      if (sql.includes("WHERE key = ?")) {
+        return { rows: [] };
+      }
+      if (
+        sql.includes("SELECT id, owner_email") &&
+        sql.includes("FROM tools")
+      ) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+
+    const { createPollHandler } = await import("./poll.js");
+    const handler = createPollHandler() as any;
+
+    const baseline = await handler({ query: { since: "0" } });
+
+    expect(baseline.events).toEqual([
+      expect.objectContaining({
+        source: "action",
+        type: "change",
+        key: "create-project",
+        owner: "test@example.com",
+      }),
+    ]);
+    expect(baseline.events).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "app-state",
+          key: "__action_change__",
+        }),
+      ]),
+    );
+  });
+
   it("emits extension changes from durable markers for delete and hide fallback", async () => {
     let appStateTs = 1_000;
     let settingsTs = 900;

--- a/packages/core/src/server/poll.ts
+++ b/packages/core/src/server/poll.ts
@@ -420,7 +420,10 @@ async function seedVersionFromDb(): Promise<void> {
     _lastExtensionsTs = extensionsTs;
     _lastExtensionsUpdatedAt = sqlWatermarkValue(extensionsMaxUpdatedAt);
     _lastExtensionMarkerTs = extensionMarkerTs;
-    _lastActionMarkerTs = actionMarkerTs;
+    // Action markers are durable specifically so a web server can observe work
+    // performed by a separate action process. Do not baseline past an existing
+    // marker on cold start, or the first poll after the action will miss it.
+    _lastActionMarkerTs = 0;
     _lastScreenRefreshTs = refreshTs;
     _screenRefreshInitialized = true;
   } catch {
@@ -488,13 +491,11 @@ async function checkExternalDbChanges(): Promise<void> {
       const changedActionMarkers = actionMarkerResult.rows.filter(
         (row) => timestampValue(row.updated_at) > _lastActionMarkerTs,
       );
-      if (_lastActionMarkerTs > 0) {
-        recordActionChanges(
-          changedActionMarkers
-            .map((row) => parseActionChangeMarker(row.session_id, row.value))
-            .filter((target): target is ActionChangeTarget => !!target),
-        );
-      }
+      recordActionChanges(
+        changedActionMarkers
+          .map((row) => parseActionChangeMarker(row.session_id, row.value))
+          .filter((target): target is ActionChangeTarget => !!target),
+      );
       _lastActionMarkerTs = actionMarkerTs;
     }
 

--- a/packages/core/src/server/poll.ts
+++ b/packages/core/src/server/poll.ts
@@ -15,6 +15,11 @@
 
 import { EventEmitter } from "node:events";
 import { defineEventHandler, getQuery, setResponseStatus } from "h3";
+import {
+  ACTION_CHANGE_MARKER_KEY,
+  parseActionChangeMarker,
+  type ActionChangeTarget,
+} from "../action-change-marker.js";
 import { getAppStateEmitter } from "../application-state/emitter.js";
 import { getDbExec } from "../db/client.js";
 import {
@@ -67,6 +72,7 @@ let _lastSettingsTs = 0;
 let _lastExtensionsTs = 0;
 let _lastExtensionsUpdatedAt: string | number | undefined;
 let _lastExtensionMarkerTs = 0;
+let _lastActionMarkerTs = 0;
 
 /**
  * Tracks the latest updated_at seen on the `__screen_refresh__` key in
@@ -87,6 +93,12 @@ function wireLocalEmitters(): void {
   if (_localEmittersWired) return;
   _localEmittersWired = true;
   getAppStateEmitter().on("app-state", (event) => {
+    if (
+      event.key === EXTENSION_CHANGE_MARKER_KEY ||
+      event.key === ACTION_CHANGE_MARKER_KEY
+    ) {
+      return;
+    }
     recordChange(event);
   });
   getSettingsEmitter().on("settings", (event) => {
@@ -148,6 +160,22 @@ async function readExtensionMarkerMaxUpdatedAt(db: {
     const result = await db.execute({
       sql: "SELECT MAX(updated_at) as max_ts FROM application_state WHERE key = ?",
       args: [EXTENSION_CHANGE_MARKER_KEY],
+    });
+    return timestampValue(result.rows[0]?.max_ts);
+  } catch {
+    return 0;
+  }
+}
+
+async function readActionMarkerMaxUpdatedAt(db: {
+  execute: (
+    query: string | { sql: string; args?: unknown[] },
+  ) => Promise<{ rows: Array<Record<string, unknown>> }>;
+}): Promise<number> {
+  try {
+    const result = await db.execute({
+      sql: "SELECT MAX(updated_at) as max_ts FROM application_state WHERE key = ?",
+      args: [ACTION_CHANGE_MARKER_KEY],
     });
     return timestampValue(result.rows[0]?.max_ts);
   } catch {
@@ -217,6 +245,18 @@ function recordExtensionChanges(targets: ExtensionChangeTarget[]): void {
       source: "extensions",
       type: "change",
       key: "*",
+      ...(target.owner ? { owner: target.owner } : {}),
+      ...(target.orgId ? { orgId: target.orgId } : {}),
+    });
+  }
+}
+
+function recordActionChanges(targets: ActionChangeTarget[]): void {
+  for (const target of targets) {
+    recordChange({
+      source: "action",
+      type: "change",
+      key: target.actionName ?? "*",
       ...(target.owner ? { owner: target.owner } : {}),
       ...(target.orgId ? { orgId: target.orgId } : {}),
     });
@@ -345,12 +385,14 @@ async function seedVersionFromDb(): Promise<void> {
       settingsTs,
       extensionsMaxUpdatedAt,
       extensionMarkerTs,
+      actionMarkerTs,
       refreshResult,
     ] = await Promise.all([
       readMaxUpdatedAt(db, "application_state"),
       readMaxUpdatedAt(db, "settings"),
       readMaxUpdatedAtRaw(db, "tools"),
       readExtensionMarkerMaxUpdatedAt(db),
+      readActionMarkerMaxUpdatedAt(db),
       db
         .execute({
           sql: "SELECT updated_at FROM application_state WHERE key = ?",
@@ -369,6 +411,7 @@ async function seedVersionFromDb(): Promise<void> {
       settingsTs,
       extensionsTs,
       extensionMarkerTs,
+      actionMarkerTs,
     );
 
     // Set baselines so checkExternalDbChanges detects future writes
@@ -377,6 +420,7 @@ async function seedVersionFromDb(): Promise<void> {
     _lastExtensionsTs = extensionsTs;
     _lastExtensionsUpdatedAt = sqlWatermarkValue(extensionsMaxUpdatedAt);
     _lastExtensionMarkerTs = extensionMarkerTs;
+    _lastActionMarkerTs = actionMarkerTs;
     _lastScreenRefreshTs = refreshTs;
     _screenRefreshInitialized = true;
   } catch {
@@ -412,7 +456,12 @@ async function checkExternalDbChanges(): Promise<void> {
       if (_lastAppStateTs > 0) {
         for (const row of appResult.rows) {
           const key = typeof row.key === "string" ? row.key : "*";
-          if (key === EXTENSION_CHANGE_MARKER_KEY) continue;
+          if (
+            key === EXTENSION_CHANGE_MARKER_KEY ||
+            key === ACTION_CHANGE_MARKER_KEY
+          ) {
+            continue;
+          }
           const owner =
             typeof row.session_id === "string" ? row.session_id : undefined;
           recordChange({
@@ -424,6 +473,29 @@ async function checkExternalDbChanges(): Promise<void> {
         }
       }
       _lastAppStateTs = appTs;
+    }
+
+    // Mutating actions write a durable marker in addition to the in-process
+    // event. This lets dev-mode `pnpm action ...` child processes and
+    // serverless action invocations wake the web server's SSE/poll loop as a
+    // first-class source:"action" event rather than a generic app-state bump.
+    const actionMarkerTs = await readActionMarkerMaxUpdatedAt(db);
+    if (actionMarkerTs > _lastActionMarkerTs) {
+      const actionMarkerResult = await db.execute({
+        sql: "SELECT session_id, value, updated_at FROM application_state WHERE key = ? ORDER BY updated_at ASC",
+        args: [ACTION_CHANGE_MARKER_KEY],
+      });
+      const changedActionMarkers = actionMarkerResult.rows.filter(
+        (row) => timestampValue(row.updated_at) > _lastActionMarkerTs,
+      );
+      if (_lastActionMarkerTs > 0) {
+        recordActionChanges(
+          changedActionMarkers
+            .map((row) => parseActionChangeMarker(row.session_id, row.value))
+            .filter((target): target is ActionChangeTarget => !!target),
+        );
+      }
+      _lastActionMarkerTs = actionMarkerTs;
     }
 
     // Check for screen-refresh requests from the agent. The `refresh-screen`

--- a/packages/core/src/templates/default/.agents/skills/actions/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/actions/SKILL.md
@@ -68,7 +68,7 @@ Controls how the action is exposed as an HTTP endpoint:
 
 ### Screen Refresh (automatic)
 
-The framework auto-refreshes the UI after any successful mutating action. On completion of a non-`GET` action, the server emits a poll event that the client's `useDbSync` picks up and uses to invalidate `["action"]` React Query keys — so `list-*` / `get-*` hooks refetch without a full page reload.
+The framework auto-refreshes the UI after any successful mutating action. On completion of a non-`GET` action, the framework emits a change event with `source: "action"` that the client's `useDbSync` picks up and uses to invalidate `["action"]` React Query keys — so `list-*` / `get-*` hooks refetch without a full page reload. In-process calls emit directly; dev-mode `pnpm action ...` calls also write a durable marker so the web server sees child-process action changes.
 
 Rules:
 

--- a/packages/core/src/templates/workspace-core/.agents/skills/actions/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/actions/SKILL.md
@@ -68,7 +68,7 @@ Controls how the action is exposed as an HTTP endpoint:
 
 ### Screen Refresh (automatic)
 
-The framework auto-refreshes the UI after any successful mutating action. On completion of a non-`GET` action, the server emits a poll event that the client's `useDbSync` picks up and uses to invalidate `["action"]` React Query keys — so `list-*` / `get-*` hooks refetch without a full page reload.
+The framework auto-refreshes the UI after any successful mutating action. On completion of a non-`GET` action, the framework emits a change event with `source: "action"` that the client's `useDbSync` picks up and uses to invalidate `["action"]` React Query keys — so `list-*` / `get-*` hooks refetch without a full page reload. In-process calls emit directly; dev-mode `pnpm action ...` calls also write a durable marker so the web server sees child-process action changes.
 
 Rules:
 

--- a/templates/starter/.agents/skills/actions/SKILL.md
+++ b/templates/starter/.agents/skills/actions/SKILL.md
@@ -68,7 +68,7 @@ Controls how the action is exposed as an HTTP endpoint:
 
 ### Screen Refresh (automatic)
 
-The framework auto-refreshes the UI after any successful mutating action. On completion of a non-`GET` action, the server emits a poll event that the client's `useDbSync` picks up and uses to invalidate `["action"]` React Query keys — so `list-*` / `get-*` hooks refetch without a full page reload.
+The framework auto-refreshes the UI after any successful mutating action. On completion of a non-`GET` action, the framework emits a change event with `source: "action"` that the client's `useDbSync` picks up and uses to invalidate `["action"]` React Query keys — so `list-*` / `get-*` hooks refetch without a full page reload. In-process calls emit directly; dev-mode `pnpm action ...` calls also write a durable marker so the web server sees child-process action changes.
 
 Rules:
 


### PR DESCRIPTION
## Summary
- persist mutating action change markers so child-process actions refresh app UIs
- preserve Builder-frame agent sidebar preference behavior
- include concurrent docs wording update

## Tests
- pnpm prep