### PR TITLE
Fix Slides prompt deck persistence

### DIFF
--- a/templates/slides/app/components/editor/PromptDialog.tsx
+++ b/templates/slides/app/components/editor/PromptDialog.tsx
@@ -28,6 +28,7 @@ interface PromptPopoverProps {
   draftScope?: string;
   initialText?: string;
   initialTextKey?: string | number;
+  onBeforeUpload?: (prompt: string, files: File[]) => boolean | void;
   children?: React.ReactNode;
 }
 
@@ -45,6 +46,7 @@ export default function PromptPopover({
   draftScope,
   initialText,
   initialTextKey,
+  onBeforeUpload,
   children,
 }: PromptPopoverProps) {
   const [uploading, setUploading] = useState(false);
@@ -136,11 +138,14 @@ export default function PromptPopover({
 
   const handleSubmit = useCallback(
     async (text: string, files: File[]) => {
+      const enrichedText = [text.trim(), googleDocContext]
+        .filter(Boolean)
+        .join("\n\n");
+      if (files.length > 0 && onBeforeUpload?.(enrichedText, files) === false) {
+        return;
+      }
       try {
         const uploaded = await uploadFiles(files);
-        const enrichedText = [text.trim(), googleDocContext]
-          .filter(Boolean)
-          .join("\n\n");
         onSubmit(enrichedText, uploaded);
       } catch (error) {
         toast({
@@ -153,7 +158,7 @@ export default function PromptPopover({
         });
       }
     },
-    [googleDocContext, onSubmit, uploadFiles],
+    [googleDocContext, onBeforeUpload, onSubmit, uploadFiles],
   );
 
   useEffect(() => {

--- a/templates/slides/app/components/editor/PromptDialog.tsx
+++ b/templates/slides/app/components/editor/PromptDialog.tsx
@@ -26,6 +26,8 @@ interface PromptPopoverProps {
   centered?: boolean;
   /** Forwarded to PromptComposer/TipTap for draft persistence in localStorage. */
   draftScope?: string;
+  initialText?: string;
+  initialTextKey?: string | number;
   children?: React.ReactNode;
 }
 
@@ -41,6 +43,8 @@ export default function PromptPopover({
   anchorRef,
   centered = false,
   draftScope,
+  initialText,
+  initialTextKey,
   children,
 }: PromptPopoverProps) {
   const [uploading, setUploading] = useState(false);
@@ -189,6 +193,8 @@ export default function PromptPopover({
             onSubmit={handleSubmit}
             onTextChange={setPromptText}
             draftScope={draftScope}
+            initialText={initialText}
+            initialTextKey={initialTextKey}
           />
         </div>
 

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment happy-dom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DeckProvider, useDecks } from "./DeckContext";
+
+class MockEventSource {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  close = vi.fn();
+
+  constructor(public url: string) {}
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(DeckProvider, null, children);
+}
+
+function setupFetch() {
+  let resolveCreate: (response: Response) => void = () => {};
+  const fetchMock = vi.fn((url: string | URL | Request, init?: RequestInit) => {
+    const href =
+      typeof url === "string"
+        ? url
+        : url instanceof URL
+          ? url.toString()
+          : url.url;
+
+    if (init?.method === "POST" && href.endsWith("/api/decks")) {
+      return new Promise<Response>((resolve) => {
+        resolveCreate = resolve;
+      });
+    }
+
+    if (href.endsWith("/api/decks")) {
+      return Promise.resolve(new Response("[]", { status: 200 }));
+    }
+
+    if (href.includes("/api/decks/")) {
+      return Promise.resolve(new Response("", { status: 404 }));
+    }
+
+    return Promise.resolve(new Response("", { status: 200 }));
+  });
+
+  vi.stubGlobal("fetch", fetchMock);
+  return {
+    fetchMock,
+    resolveCreate: (response: Response) => resolveCreate(response),
+  };
+}
+
+function deckFetchCalls(fetchMock: ReturnType<typeof setupFetch>["fetchMock"]) {
+  return fetchMock.mock.calls.filter(([url]) =>
+    String(url).includes("/api/decks/"),
+  );
+}
+
+describe("DeckContext deck creation persistence", () => {
+  beforeEach(() => {
+    vi.stubGlobal("EventSource", MockEventSource);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("awaits the in-flight create request instead of polling for the new deck", async () => {
+    const { fetchMock, resolveCreate } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let deckId = "";
+    act(() => {
+      deckId = result.current.createDeck(undefined, {
+        noDefaultSlides: true,
+      }).id;
+    });
+
+    let settled = false;
+    const persisted = result.current
+      .ensureDeckPersisted(deckId)
+      .then((value) => {
+        settled = true;
+        return value;
+      });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(deckFetchCalls(fetchMock)).toEqual([]);
+
+    resolveCreate(new Response("", { status: 200 }));
+
+    await expect(persisted).resolves.toBe(true);
+    expect(deckFetchCalls(fetchMock)).toEqual([]);
+  });
+
+  it("reports a failed create request without polling for the optimistic deck", async () => {
+    const { fetchMock, resolveCreate } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let deckId = "";
+    act(() => {
+      deckId = result.current.createDeck(undefined, {
+        noDefaultSlides: true,
+      }).id;
+    });
+
+    const persisted = result.current.ensureDeckPersisted(deckId);
+    resolveCreate(
+      new Response(JSON.stringify({ error: "Sign in to create a deck" }), {
+        status: 403,
+      }),
+    );
+
+    await expect(persisted).resolves.toBe(false);
+    expect(deckFetchCalls(fetchMock)).toEqual([]);
+  });
+});

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -88,6 +88,7 @@ interface DeckContextType {
     title?: string,
     options?: { noDefaultSlides?: boolean; designSystemId?: string | null },
   ) => Deck;
+  ensureDeckPersisted: (id: string) => Promise<boolean>;
   /**
    * Optimistically duplicate a deck. Inserts a copy into local state with the
    * supplied `newId` immediately so the UI can navigate without awaiting the
@@ -364,6 +365,9 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   // Track client-created decks that haven't been confirmed on the server yet.
   // Prevents the poll from wiping optimistic decks before their POST lands.
   const pendingCreateIdsRef = useRef<Set<string>>(new Set());
+  const pendingCreatePromisesRef = useRef<Map<string, Promise<void>>>(
+    new Map(),
+  );
   const pendingDuplicateSourceIdsRef = useRef<Set<string>>(new Set());
   const dirtyDeckIdsRef = useRef<Set<string>>(new Set());
 
@@ -749,18 +753,39 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       // Save to API immediately (not debounced). Track as pending so the
       // poll doesn't wipe the optimistic deck before the POST completes.
       pendingCreateIdsRef.current.add(newDeck.id);
-      createDeckOnAPI(newDeck)
+      const createPromise = createDeckOnAPI(newDeck);
+      pendingCreatePromisesRef.current.set(newDeck.id, createPromise);
+      createPromise
         .catch((err) => {
           console.error(`Failed to create deck ${newDeck.id}:`, err);
         })
         .finally(() => {
           pendingCreateIdsRef.current.delete(newDeck.id);
+          if (
+            pendingCreatePromisesRef.current.get(newDeck.id) === createPromise
+          ) {
+            pendingCreatePromisesRef.current.delete(newDeck.id);
+          }
         });
       setDecksWithHistory("Create deck", (prev) => [...prev, newDeck]);
       return newDeck;
     },
     [setDecksWithHistory],
   );
+
+  const ensureDeckPersisted = useCallback(async (id: string) => {
+    const pendingCreate = pendingCreatePromisesRef.current.get(id);
+    if (pendingCreate) {
+      try {
+        await pendingCreate;
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    return (await fetchDeckFromAPI(id)) !== null;
+  }, []);
 
   const duplicateDeck = useCallback(
     (sourceDeckId: string, newId: string, title?: string): Deck | null => {
@@ -981,6 +1006,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         decks,
         loading,
         createDeck,
+        ensureDeckPersisted,
         duplicateDeck,
         deleteDeck,
         updateDeck,

--- a/templates/slides/app/lib/composer-draft.test.ts
+++ b/templates/slides/app/lib/composer-draft.test.ts
@@ -12,6 +12,10 @@ describe("composer draft helpers", () => {
     );
   });
 
+  it("keeps empty prompts as empty drafts", () => {
+    expect(promptToComposerDraftHtml(" \n ")).toBe("");
+  });
+
   it("stores prompts under the encoded draft scope", () => {
     const storage = { setItem: vi.fn() } as unknown as Storage;
 
@@ -22,5 +26,17 @@ describe("composer draft helpers", () => {
       composerDraftStorageKey("slides new/deck"),
       "<p>Try again</p>",
     );
+  });
+
+  it("reports storage failures", () => {
+    const storage = {
+      setItem: vi.fn(() => {
+        throw new Error("quota exceeded");
+      }),
+    } as unknown as Storage;
+
+    expect(
+      savePromptToComposerDraft("slides-new-deck", "Try again", storage),
+    ).toBe(false);
   });
 });

--- a/templates/slides/app/lib/composer-draft.test.ts
+++ b/templates/slides/app/lib/composer-draft.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  composerDraftStorageKey,
+  promptToComposerDraftHtml,
+  savePromptToComposerDraft,
+} from "./composer-draft";
+
+describe("composer draft helpers", () => {
+  it("formats prompts as the composer draft html", () => {
+    expect(promptToComposerDraftHtml("Title\n\nUse <b>bold</b> & data")).toBe(
+      "<p>Title</p><p>Use &lt;b&gt;bold&lt;/b&gt; &amp; data</p>",
+    );
+  });
+
+  it("stores prompts under the encoded draft scope", () => {
+    const storage = { setItem: vi.fn() } as unknown as Storage;
+
+    expect(
+      savePromptToComposerDraft("slides new/deck", "Try again", storage),
+    ).toBe(true);
+    expect(storage.setItem).toHaveBeenCalledWith(
+      composerDraftStorageKey("slides new/deck"),
+      "<p>Try again</p>",
+    );
+  });
+});

--- a/templates/slides/app/lib/composer-draft.ts
+++ b/templates/slides/app/lib/composer-draft.ts
@@ -1,0 +1,31 @@
+export function composerDraftStorageKey(draftScope: string): string {
+  return `an-composer-draft:${encodeURIComponent(draftScope)}`;
+}
+
+export function promptToComposerDraftHtml(prompt: string): string {
+  const escaped = prompt
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+  return escaped
+    .split(/\n+/)
+    .map((line) => `<p>${line || "<br/>"}</p>`)
+    .join("");
+}
+
+export function savePromptToComposerDraft(
+  draftScope: string,
+  prompt: string,
+  storage: Storage = localStorage,
+): boolean {
+  try {
+    storage.setItem(
+      composerDraftStorageKey(draftScope),
+      promptToComposerDraftHtml(prompt),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/templates/slides/app/lib/composer-draft.ts
+++ b/templates/slides/app/lib/composer-draft.ts
@@ -3,6 +3,8 @@ export function composerDraftStorageKey(draftScope: string): string {
 }
 
 export function promptToComposerDraftHtml(prompt: string): string {
+  if (!prompt.trim()) return "";
+
   const escaped = prompt
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -8,6 +8,7 @@ import PromptPopover from "@/components/editor/PromptDialog";
 import type { UploadedFile } from "@/components/editor/PromptDialog";
 import { useAgentGenerating } from "@/hooks/use-agent-generating";
 import { useDesignSystems } from "@/hooks/use-design-systems";
+import { savePromptToComposerDraft } from "@/lib/composer-draft";
 import {
   useSetHeaderActions,
   useSetPageTitle,
@@ -39,6 +40,13 @@ import { toast } from "@/hooks/use-toast";
 const MAX_SOURCE_CONTEXT_CHARS = 60_000;
 const NEW_DECK_DRAFT_SCOPE = "slides-new-deck";
 const PENDING_PROMPT_KEY = "slides:pending-deck-prompt";
+
+function savePendingPromptForRetry(prompt: string) {
+  try {
+    sessionStorage.setItem(PENDING_PROMPT_KEY, prompt);
+  } catch {}
+  savePromptToComposerDraft(NEW_DECK_DRAFT_SCOPE, prompt);
+}
 
 function summarizePromptForChat(prompt: string): string {
   const singleLine = prompt.trim().replace(/\s+/g, " ");
@@ -178,19 +186,8 @@ export default function Index() {
       saved = sessionStorage.getItem(PENDING_PROMPT_KEY);
     } catch {}
     if (!saved) return;
+    savePromptToComposerDraft(NEW_DECK_DRAFT_SCOPE, saved);
     try {
-      const escaped = saved
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;");
-      const paragraphs = escaped
-        .split(/\n+/)
-        .map((line) => `<p>${line || "<br/>"}</p>`)
-        .join("");
-      localStorage.setItem(
-        `an-composer-draft:${encodeURIComponent(NEW_DECK_DRAFT_SCOPE)}`,
-        paragraphs,
-      );
       sessionStorage.removeItem(PENDING_PROMPT_KEY);
     } catch {}
     setSelectedDesignSystemId(defaultSystem?.id ?? "none");
@@ -222,9 +219,7 @@ export default function Index() {
     // sidebar. Catch it here so the user sees a clear sign-in prompt
     // and the typed prompt isn't lost when they come back.
     if (!session) {
-      try {
-        sessionStorage.setItem(PENDING_PROMPT_KEY, prompt);
-      } catch {}
+      savePendingPromptForRetry(prompt);
       setNewDeckPromptOpen(false);
       setShowSignInDialog(true);
       return;
@@ -302,9 +297,7 @@ export default function Index() {
 
     const persisted = await ensureDeckPersisted(deck.id);
     if (!persisted) {
-      try {
-        sessionStorage.setItem(PENDING_PROMPT_KEY, prompt);
-      } catch {}
+      savePendingPromptForRetry(prompt);
       deleteDeck(deck.id);
       toast({
         title: "Couldn't start deck generation",

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -45,7 +45,7 @@ function savePendingPromptForRetry(prompt: string) {
   try {
     sessionStorage.setItem(PENDING_PROMPT_KEY, prompt);
   } catch {}
-  savePromptToComposerDraft(NEW_DECK_DRAFT_SCOPE, prompt);
+  return savePromptToComposerDraft(NEW_DECK_DRAFT_SCOPE, prompt);
 }
 
 function summarizePromptForChat(prompt: string): string {
@@ -108,6 +108,10 @@ export default function Index() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [deckToDelete, setDeckToDelete] = useState<string | null>(null);
   const [showNewDeckPrompt, setShowNewDeckPrompt] = useState(false);
+  const [newDeckInitialPrompt, setNewDeckInitialPrompt] = useState<{
+    text: string;
+    key: number;
+  } | null>(null);
   const [selectedDesignSystemId, setSelectedDesignSystemId] = useState("");
   const [showSignInDialog, setShowSignInDialog] = useState(false);
   const [duplicating, setDuplicating] = useState<string | null>(null);
@@ -149,6 +153,7 @@ export default function Index() {
   const openNewDeck = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
       anchorElRef.current = e.currentTarget;
+      setNewDeckInitialPrompt(null);
       setSelectedDesignSystemId(defaultSystem?.id ?? "");
       setShowNewDeckPrompt(true);
     },
@@ -157,7 +162,10 @@ export default function Index() {
 
   const setNewDeckPromptOpen = useCallback((open: boolean) => {
     setShowNewDeckPrompt(open);
-    if (!open) setSelectedDesignSystemId("");
+    if (!open) {
+      setSelectedDesignSystemId("");
+      setNewDeckInitialPrompt(null);
+    }
   }, []);
 
   useEffect(() => {
@@ -190,6 +198,9 @@ export default function Index() {
       try {
         sessionStorage.removeItem(PENDING_PROMPT_KEY);
       } catch {}
+      setNewDeckInitialPrompt(null);
+    } else {
+      setNewDeckInitialPrompt({ text: saved, key: Date.now() });
     }
     setSelectedDesignSystemId(defaultSystem?.id ?? "none");
     setShowNewDeckPrompt(true);
@@ -220,7 +231,9 @@ export default function Index() {
     // sidebar. Catch it here so the user sees a clear sign-in prompt
     // and the typed prompt isn't lost when they come back.
     if (!session) {
-      savePendingPromptForRetry(prompt);
+      if (!savePendingPromptForRetry(prompt)) {
+        setNewDeckInitialPrompt({ text: prompt, key: Date.now() });
+      }
       setNewDeckPromptOpen(false);
       setShowSignInDialog(true);
       return;
@@ -298,7 +311,9 @@ export default function Index() {
 
     const persisted = await ensureDeckPersisted(deck.id);
     if (!persisted) {
-      savePendingPromptForRetry(prompt);
+      if (!savePendingPromptForRetry(prompt)) {
+        setNewDeckInitialPrompt({ text: prompt, key: Date.now() });
+      }
       deleteDeck(deck.id);
       toast({
         title: "Couldn't start deck generation",
@@ -514,6 +529,8 @@ export default function Index() {
         loading={generating}
         anchorRef={anchorRef}
         draftScope={NEW_DECK_DRAFT_SCOPE}
+        initialText={newDeckInitialPrompt?.text}
+        initialTextKey={newDeckInitialPrompt?.key}
       >
         {designSystems.length > 0 && (
           <div className="border-t border-border px-3.5 py-2">

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -12,11 +12,7 @@ import {
   useSetHeaderActions,
   useSetPageTitle,
 } from "@/components/layout/HeaderActions";
-import {
-  agentNativePath,
-  appBasePath,
-  useSession,
-} from "@agent-native/core/client";
+import { agentNativePath, useSession } from "@agent-native/core/client";
 import { extractGoogleDocUrls } from "@shared/google-docs";
 import {
   AlertDialog,
@@ -89,23 +85,15 @@ function describeUploadedFilesForAgent(
   ].join("\n");
 }
 
-async function waitForDeckServerRow(deckId: string): Promise<boolean> {
-  const deadline = Date.now() + 5_000;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(`${appBasePath()}/api/decks/${deckId}`);
-      if (res.ok) return true;
-      if (res.status !== 404) return false;
-    } catch {
-      // keep polling until the optimistic create either lands or times out
-    }
-    await new Promise((resolve) => setTimeout(resolve, 150));
-  }
-  return false;
-}
-
 export default function Index() {
-  const { decks, createDeck, deleteDeck, updateDeck, loading } = useDecks();
+  const {
+    decks,
+    createDeck,
+    ensureDeckPersisted,
+    deleteDeck,
+    updateDeck,
+    loading,
+  } = useDecks();
   const { designSystems, defaultSystem } = useDesignSystems();
   const { session } = useSession();
   const navigate = useNavigate();
@@ -312,7 +300,7 @@ export default function Index() {
       "Do NOT use create-deck (the deck already exists). Do NOT call db-schema, resource-read, or search-files.",
     ].join("\n");
 
-    const persisted = await waitForDeckServerRow(deck.id);
+    const persisted = await ensureDeckPersisted(deck.id);
     if (!persisted) {
       try {
         sessionStorage.setItem(PENDING_PROMPT_KEY, prompt);
@@ -327,11 +315,11 @@ export default function Index() {
       return;
     }
 
-    navigate(`/deck/${deck.id}?generating=1`);
     agentSubmit(
       `Create deck: ${summarizePromptForChat(trimmedPrompt)}`,
       context,
     );
+    navigate(`/deck/${deck.id}?generating=1`);
   };
 
   const handleConfirmDelete = () => {

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -167,7 +167,6 @@ export default function Index() {
   const openNewDeck = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
       anchorElRef.current = e.currentTarget;
-      setNewDeckInitialPrompt(null);
       setSelectedDesignSystemId(defaultSystem?.id ?? "");
       setShowNewDeckPrompt(true);
     },

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -45,12 +45,15 @@ function savePromptForRetry(
   prompt: string,
   options: { persistAcrossSignIn?: boolean } = {},
 ) {
+  let signInHandoffSaved = !options.persistAcrossSignIn;
   if (options.persistAcrossSignIn) {
     try {
       sessionStorage.setItem(PENDING_PROMPT_KEY, prompt);
+      signInHandoffSaved = true;
     } catch {}
   }
-  return savePromptToComposerDraft(NEW_DECK_DRAFT_SCOPE, prompt);
+  const draftSaved = savePromptToComposerDraft(NEW_DECK_DRAFT_SCOPE, prompt);
+  return signInHandoffSaved && draftSaved;
 }
 
 function clearPendingPromptForRetry() {
@@ -214,6 +217,7 @@ export default function Index() {
       clearPendingPromptForRetry();
       setNewDeckInitialPrompt(null);
     } else {
+      clearPendingPromptForRetry();
       setNewDeckInitialPrompt({ text: saved, key: Date.now() });
     }
     setSelectedDesignSystemId(defaultSystem?.id ?? "none");

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -41,11 +41,22 @@ const MAX_SOURCE_CONTEXT_CHARS = 60_000;
 const NEW_DECK_DRAFT_SCOPE = "slides-new-deck";
 const PENDING_PROMPT_KEY = "slides:pending-deck-prompt";
 
-function savePendingPromptForRetry(prompt: string) {
-  try {
-    sessionStorage.setItem(PENDING_PROMPT_KEY, prompt);
-  } catch {}
+function savePromptForRetry(
+  prompt: string,
+  options: { persistAcrossSignIn?: boolean } = {},
+) {
+  if (options.persistAcrossSignIn) {
+    try {
+      sessionStorage.setItem(PENDING_PROMPT_KEY, prompt);
+    } catch {}
+  }
   return savePromptToComposerDraft(NEW_DECK_DRAFT_SCOPE, prompt);
+}
+
+function clearPendingPromptForRetry() {
+  try {
+    sessionStorage.removeItem(PENDING_PROMPT_KEY);
+  } catch {}
 }
 
 function summarizePromptForChat(prompt: string): string {
@@ -160,13 +171,18 @@ export default function Index() {
     [defaultSystem?.id],
   );
 
-  const setNewDeckPromptOpen = useCallback((open: boolean) => {
-    setShowNewDeckPrompt(open);
-    if (!open) {
-      setSelectedDesignSystemId("");
-      setNewDeckInitialPrompt(null);
-    }
-  }, []);
+  const setNewDeckPromptOpen = useCallback(
+    (open: boolean, options: { clearInitialPrompt?: boolean } = {}) => {
+      setShowNewDeckPrompt(open);
+      if (!open) {
+        setSelectedDesignSystemId("");
+        if (options.clearInitialPrompt !== false) {
+          setNewDeckInitialPrompt(null);
+        }
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!showNewDeckPrompt || selectedDesignSystemId) return;
@@ -195,9 +211,7 @@ export default function Index() {
     } catch {}
     if (!saved) return;
     if (savePromptToComposerDraft(NEW_DECK_DRAFT_SCOPE, saved)) {
-      try {
-        sessionStorage.removeItem(PENDING_PROMPT_KEY);
-      } catch {}
+      clearPendingPromptForRetry();
       setNewDeckInitialPrompt(null);
     } else {
       setNewDeckInitialPrompt({ text: saved, key: Date.now() });
@@ -231,10 +245,10 @@ export default function Index() {
     // sidebar. Catch it here so the user sees a clear sign-in prompt
     // and the typed prompt isn't lost when they come back.
     if (!session) {
-      if (!savePendingPromptForRetry(prompt)) {
+      if (!savePromptForRetry(prompt, { persistAcrossSignIn: true })) {
         setNewDeckInitialPrompt({ text: prompt, key: Date.now() });
       }
-      setNewDeckPromptOpen(false);
+      setNewDeckPromptOpen(false, { clearInitialPrompt: false });
       setShowSignInDialog(true);
       return;
     }
@@ -311,7 +325,7 @@ export default function Index() {
 
     const persisted = await ensureDeckPersisted(deck.id);
     if (!persisted) {
-      if (!savePendingPromptForRetry(prompt)) {
+      if (!savePromptForRetry(prompt)) {
         setNewDeckInitialPrompt({ text: prompt, key: Date.now() });
       }
       deleteDeck(deck.id);
@@ -324,6 +338,8 @@ export default function Index() {
       return;
     }
 
+    clearPendingPromptForRetry();
+    setNewDeckInitialPrompt(null);
     agentSubmit(
       `Create deck: ${summarizePromptForChat(trimmedPrompt)}`,
       context,

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -186,10 +186,11 @@ export default function Index() {
       saved = sessionStorage.getItem(PENDING_PROMPT_KEY);
     } catch {}
     if (!saved) return;
-    savePromptToComposerDraft(NEW_DECK_DRAFT_SCOPE, saved);
-    try {
-      sessionStorage.removeItem(PENDING_PROMPT_KEY);
-    } catch {}
+    if (savePromptToComposerDraft(NEW_DECK_DRAFT_SCOPE, saved)) {
+      try {
+        sessionStorage.removeItem(PENDING_PROMPT_KEY);
+      } catch {}
+    }
     setSelectedDesignSystemId(defaultSystem?.id ?? "none");
     setShowNewDeckPrompt(true);
   }, [defaultSystem?.id, session]);

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -62,6 +62,19 @@ function clearPendingPromptForRetry() {
   } catch {}
 }
 
+function mergeUploadedFilesForRetry(
+  savedFiles: UploadedFile[],
+  newFiles: UploadedFile[],
+): UploadedFile[] {
+  const seen = new Set<string>();
+  return [...savedFiles, ...newFiles].filter((file) => {
+    const key = file.path || file.url || file.filename;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 function summarizePromptForChat(prompt: string): string {
   const singleLine = prompt.trim().replace(/\s+/g, " ");
   if (!singleLine) return "new deck";
@@ -126,6 +139,10 @@ export default function Index() {
     text: string;
     key: number;
   } | null>(null);
+  const [newDeckRetryFiles, setNewDeckRetryFiles] = useState<UploadedFile[]>(
+    [],
+  );
+  const [signInPromptHadFiles, setSignInPromptHadFiles] = useState(false);
   const [selectedDesignSystemId, setSelectedDesignSystemId] = useState("");
   const [showSignInDialog, setShowSignInDialog] = useState(false);
   const [duplicating, setDuplicating] = useState<string | null>(null);
@@ -180,11 +197,32 @@ export default function Index() {
         setSelectedDesignSystemId("");
         if (options.clearInitialPrompt !== false) {
           setNewDeckInitialPrompt(null);
+          setNewDeckRetryFiles([]);
         }
       }
     },
     [],
   );
+
+  const preservePromptForSignIn = useCallback(
+    (prompt: string, options: { hadFiles?: boolean } = {}) => {
+      if (!savePromptForRetry(prompt, { persistAcrossSignIn: true })) {
+        setNewDeckInitialPrompt({ text: prompt, key: Date.now() });
+      }
+      setNewDeckRetryFiles([]);
+      setSignInPromptHadFiles(Boolean(options.hadFiles));
+      setNewDeckPromptOpen(false, { clearInitialPrompt: false });
+      setShowSignInDialog(true);
+    },
+    [setNewDeckPromptOpen],
+  );
+
+  const setSignInDialogOpen = useCallback((open: boolean) => {
+    setShowSignInDialog(open);
+    if (!open) {
+      setSignInPromptHadFiles(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (!showNewDeckPrompt || selectedDesignSystemId) return;
@@ -248,14 +286,14 @@ export default function Index() {
     // sidebar. Catch it here so the user sees a clear sign-in prompt
     // and the typed prompt isn't lost when they come back.
     if (!session) {
-      if (!savePromptForRetry(prompt, { persistAcrossSignIn: true })) {
-        setNewDeckInitialPrompt({ text: prompt, key: Date.now() });
-      }
-      setNewDeckPromptOpen(false, { clearInitialPrompt: false });
-      setShowSignInDialog(true);
+      preservePromptForSignIn(prompt, { hadFiles: files.length > 0 });
       return;
     }
 
+    const filesForGeneration = mergeUploadedFilesForRetry(
+      newDeckRetryFiles,
+      files,
+    );
     const selectedDesignSystem =
       selectedDesignSystemId && selectedDesignSystemId !== "none"
         ? designSystems.find((ds) => ds.id === selectedDesignSystemId)
@@ -276,7 +314,10 @@ export default function Index() {
     const googleDocUrls = hasImportedGoogleDocContext
       ? []
       : extractGoogleDocUrls(trimmedPrompt);
-    const fileContext = describeUploadedFilesForAgent(files, deck.id);
+    const fileContext = describeUploadedFilesForAgent(
+      filesForGeneration,
+      deck.id,
+    );
     const googleDocContext =
       googleDocUrls.length > 0
         ? [
@@ -331,6 +372,7 @@ export default function Index() {
       if (!savePromptForRetry(prompt)) {
         setNewDeckInitialPrompt({ text: prompt, key: Date.now() });
       }
+      setNewDeckRetryFiles(filesForGeneration);
       deleteDeck(deck.id);
       toast({
         title: "Couldn't start deck generation",
@@ -343,6 +385,7 @@ export default function Index() {
 
     clearPendingPromptForRetry();
     setNewDeckInitialPrompt(null);
+    setNewDeckRetryFiles([]);
     agentSubmit(
       `Create deck: ${summarizePromptForChat(trimmedPrompt)}`,
       context,
@@ -545,6 +588,11 @@ export default function Index() {
         onSkip={handleCreateDeckBlank}
         skipLabel="Skip prompt"
         onSubmit={handleCreateDeckWithPrompt}
+        onBeforeUpload={(prompt, files) => {
+          if (session) return true;
+          preservePromptForSignIn(prompt, { hadFiles: files.length > 0 });
+          return false;
+        }}
         loading={generating}
         anchorRef={anchorRef}
         draftScope={NEW_DECK_DRAFT_SCOPE}
@@ -580,13 +628,14 @@ export default function Index() {
       {/* Sign-in required to create a deck. Shown when an unauthenticated
           user submits a prompt — the typed prompt is preserved in
           sessionStorage and replayed into the composer after sign-in. */}
-      <AlertDialog open={showSignInDialog} onOpenChange={setShowSignInDialog}>
+      <AlertDialog open={showSignInDialog} onOpenChange={setSignInDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Sign in to create a deck</AlertDialogTitle>
             <AlertDialogDescription>
-              You need to sign in before generating a deck. We've saved your
-              prompt — once you're back, it'll be ready to go.
+              {signInPromptHadFiles
+                ? "You need to sign in before generating a deck. We've saved your prompt; reattach any files once you're back."
+                : "You need to sign in before generating a deck. We've saved your prompt — once you're back, it'll be ready to go."}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>


### PR DESCRIPTION
## Summary
- track in-flight optimistic deck create requests in DeckContext
- wait for the pending create before submitting prompt generation
- add regression coverage for successful and failed create persistence

## Tests
- npx prettier --write templates/slides/app/context/DeckContext.tsx templates/slides/app/pages/Index.tsx templates/slides/app/context/DeckContext.persistence.test.ts
- pnpm --filter slides test -- templates/slides/app/context/DeckContext.persistence.test.ts