### PR TITLE
Add MCP app previews for hosted artifact actions

### DIFF
--- a/.changeset/mcp-app-action-metadata.md
+++ b/.changeset/mcp-app-action-metadata.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve MCP Apps metadata during static action discovery and write hosted Codex MCP installs as HTTP server entries.

--- a/packages/core/src/cli/mcp.ts
+++ b/packages/core/src/cli/mcp.ts
@@ -322,8 +322,28 @@ function tomlQuote(s: string): string {
   return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
+function codexMcpHeader(name: string): string {
+  return `[mcp_servers.${tomlQuote(name)}]`;
+}
+
+function legacyCodexMcpHeader(name: string): string | null {
+  return /^[A-Za-z0-9_-]+$/.test(name) ? `[mcp_servers.${name}]` : null;
+}
+
 function buildCodexBlock(name: string, i: ServerEntryInputs): string {
-  const lines: string[] = [`[mcp_servers.${name}]`];
+  const lines: string[] = [codexMcpHeader(name)];
+  if (i.hostedUrl) {
+    lines.push(`url = ${tomlQuote(i.hostedUrl)}`);
+    if (i.token) {
+      lines.push(
+        `http_headers = { "Authorization" = ${tomlQuote(
+          `Bearer ${i.token}`,
+        )} }`,
+      );
+    }
+    return lines.join("\n") + "\n";
+  }
+
   const args = ["mcp", "serve"];
   if (i.appId) args.push("--app", i.appId);
   if (i.standalone) args.push("--standalone");
@@ -358,14 +378,18 @@ function writeCodexBlock(
     content = "";
   }
 
-  const header = `[mcp_servers.${name}]`;
+  const headers = new Set(
+    [codexMcpHeader(name), legacyCodexMcpHeader(name)].filter(
+      Boolean,
+    ) as string[],
+  );
   const lines = content.split(/\r?\n/);
   const out: string[] = [];
   let i = 0;
   let removed = false;
   while (i < lines.length) {
     const line = lines[i];
-    if (line.trim() === header) {
+    if (headers.has(line.trim())) {
       // Skip this block entirely (header + body until next table header).
       removed = true;
       i++;
@@ -394,9 +418,12 @@ function writeCodexBlock(
 function codexHasBlock(file: string, name: string): boolean {
   try {
     const content = fs.readFileSync(file, "utf-8");
-    return new RegExp(`^\\s*\\[mcp_servers\\.${name}\\]\\s*$`, "m").test(
-      content,
+    const headers = new Set(
+      [codexMcpHeader(name), legacyCodexMcpHeader(name)].filter(
+        Boolean,
+      ) as string[],
     );
+    return content.split(/\r?\n/).some((line) => headers.has(line.trim()));
   } catch {
     return false;
   }

--- a/packages/core/src/server/action-discovery.spec.ts
+++ b/packages/core/src/server/action-discovery.spec.ts
@@ -67,4 +67,26 @@ describe("action discovery", () => {
       isConsequential: false,
     });
   });
+
+  it("preserves MCP Apps metadata from static defineAction entries", () => {
+    const mcpApp = {
+      resource: {
+        title: "Preview",
+        html: "<!doctype html><p>Preview</p>",
+        csp: { connectDomains: ["https://example.com"] },
+      },
+      visibility: ["model", "app"],
+    };
+    const registry = loadActionsFromStaticRegistry({
+      "preview-thing": {
+        default: {
+          tool: { description: "Preview thing", parameters: {} },
+          mcpApp,
+          run: async () => ({ ok: true }),
+        },
+      },
+    });
+
+    expect(registry["preview-thing"].mcpApp).toBe(mcpApp);
+  });
 });

--- a/packages/core/src/server/action-discovery.ts
+++ b/packages/core/src/server/action-discovery.ts
@@ -190,6 +190,13 @@ function preserveActionFlags(entry: Record<string, any>): Partial<ActionEntry> {
   if (typeof entry.link === "function") {
     out.link = entry.link;
   }
+  if (
+    entry.mcpApp &&
+    typeof entry.mcpApp === "object" &&
+    !Array.isArray(entry.mcpApp)
+  ) {
+    out.mcpApp = entry.mcpApp;
+  }
   return out;
 }
 

--- a/templates/analytics/actions/_mcp-apps.ts
+++ b/templates/analytics/actions/_mcp-apps.ts
@@ -1,0 +1,245 @@
+const MCP_APP_IMPORT =
+  "https://esm.sh/@modelcontextprotocol/ext-apps@1.7.2/app-with-deps";
+const ANALYTICS_ORIGIN = "https://analytics.agent-native.com";
+
+export const analyticsMcpAppResourceMeta = {
+  csp: {
+    connectDomains: [ANALYTICS_ORIGIN, "https://esm.sh"],
+    resourceDomains: [ANALYTICS_ORIGIN, "https://esm.sh"],
+  },
+  prefersBorder: true,
+};
+
+function attr(value: string | undefined): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;");
+}
+
+function analyticsAppHtml({
+  title,
+  kind,
+  requestOrigin,
+}: {
+  title: string;
+  kind: "chart" | "analysis" | "dashboard";
+  requestOrigin?: string;
+}): string {
+  const origin = requestOrigin || ANALYTICS_ORIGIN;
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: Canvas; color: CanvasText; }
+    body { margin: 0; }
+    .shell { display: grid; gap: 12px; padding: 14px; }
+    .top { display: flex; align-items: start; justify-content: space-between; gap: 12px; }
+    h1 { margin: 0; font-size: 15px; line-height: 1.25; font-weight: 750; }
+    h2 { margin: 0 0 6px; font-size: 13px; line-height: 1.3; }
+    .muted { color: color-mix(in srgb, CanvasText 58%, Canvas); font-size: 12px; line-height: 1.45; }
+    .actions { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+    button { border: 1px solid color-mix(in srgb, CanvasText 14%, Canvas); border-radius: 7px; background: Canvas; color: CanvasText; cursor: pointer; font: inherit; font-size: 12px; font-weight: 700; min-height: 32px; padding: 0 10px; }
+    .card { border: 1px solid color-mix(in srgb, CanvasText 12%, Canvas); border-radius: 8px; padding: 12px; background: color-mix(in srgb, Canvas 96%, CanvasText); }
+    .grid { display: grid; gap: 10px; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+    .chart { width: 100%; min-height: 240px; }
+    .chart img, .chart svg { display: block; width: 100%; height: auto; border-radius: 7px; }
+    .markdown { max-height: 280px; overflow: auto; white-space: pre-wrap; font-size: 13px; line-height: 1.5; }
+    table { border-collapse: collapse; width: 100%; font-size: 12px; }
+    th, td { border-bottom: 1px solid color-mix(in srgb, CanvasText 12%, Canvas); padding: 7px 6px; text-align: left; vertical-align: top; }
+    th { color: color-mix(in srgb, CanvasText 62%, Canvas); font-weight: 700; }
+    .panel { display: grid; gap: 4px; min-height: 74px; }
+    .panel-kind { color: color-mix(in srgb, CanvasText 55%, Canvas); font-size: 11px; text-transform: uppercase; }
+    .empty { border: 1px dashed color-mix(in srgb, CanvasText 22%, Canvas); border-radius: 8px; padding: 16px; }
+    @media (max-width: 560px) { .top, .actions { align-items: stretch; flex-direction: column; } button { width: 100%; } }
+  </style>
+</head>
+<body data-kind="${attr(kind)}" data-origin="${attr(origin)}">
+  <main id="app" class="shell">
+    <div class="empty muted">Loading ${attr(title)}</div>
+  </main>
+  <script type="module">
+    import { App } from "${MCP_APP_IMPORT}";
+
+    const root = document.getElementById("app");
+    const kind = document.body.dataset.kind;
+    const origin = document.body.dataset.origin || "${ANALYTICS_ORIGIN}";
+    const app = new App({ name: "Agent Native Analytics", version: "1.0.0" }, {});
+    let toolInput = {};
+    let toolResult = {};
+    let openUrl = "";
+
+    function esc(value) {
+      return String(value ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+    }
+
+    function parseJson(value, fallback) {
+      if (value && typeof value === "object") return value;
+      if (typeof value !== "string" || !value.trim()) return fallback;
+      try { return JSON.parse(value); } catch { return fallback; }
+    }
+
+    function parseResult(params) {
+      if (!params) return {};
+      if (params.structuredContent && typeof params.structuredContent === "object") return params.structuredContent;
+      const parts = Array.isArray(params.content) ? params.content : [];
+      const textPart = parts.find((part) => part && part.type === "text" && typeof part.text === "string");
+      return parseJson(textPart ? textPart.text : "", {});
+    }
+
+    function absolutize(url) {
+      if (!url) return "";
+      try { return new URL(url, origin).toString(); } catch { return ""; }
+    }
+
+    function openLinkFrom(params, data) {
+      const metaUrl = params && params._meta && params._meta["agent-native/openLink"]
+        ? params._meta["agent-native/openLink"].webUrl
+        : "";
+      return absolutize(metaUrl || data.deepLink || data.url || "");
+    }
+
+    function datasetsFromInput() {
+      const labels = parseJson(toolInput.labels, []);
+      const parsed = parseJson(toolInput.data, []);
+      if (Array.isArray(parsed) && parsed[0] && typeof parsed[0] === "object" && Array.isArray(parsed[0].data)) {
+        return { labels, datasets: parsed };
+      }
+      return { labels, datasets: [{ label: toolInput.title || "Series", data: Array.isArray(parsed) ? parsed : [] }] };
+    }
+
+    function chartSvg() {
+      const parsed = datasetsFromInput();
+      const labels = Array.isArray(parsed.labels) ? parsed.labels : [];
+      const series = parsed.datasets[0] || { data: [] };
+      const values = Array.isArray(series.data) ? series.data.map((v) => Number(v) || 0) : [];
+      if (!labels.length || !values.length) return '<div class="empty muted">Chart data was not available.</div>';
+      const max = Math.max(...values, 1);
+      const width = 720;
+      const height = 260;
+      const pad = 38;
+      const slot = (width - pad * 2) / values.length;
+      const bars = values.map((value, i) => {
+        const barHeight = Math.max(2, (height - pad * 2) * (value / max));
+        const x = pad + i * slot + slot * 0.18;
+        const y = height - pad - barHeight;
+        return '<rect x="' + x + '" y="' + y + '" width="' + Math.max(8, slot * 0.64) + '" height="' + barHeight + '" rx="4" fill="#2563eb"></rect>' +
+          '<text x="' + (pad + i * slot + slot / 2) + '" y="' + (height - 12) + '" text-anchor="middle" font-size="10" fill="currentColor">' + esc(String(labels[i] ?? "")) + '</text>';
+      }).join("");
+      return '<svg viewBox="0 0 ' + width + ' ' + height + '" role="img" aria-label="Chart preview">' +
+        '<rect width="' + width + '" height="' + height + '" rx="8" fill="color-mix(in srgb, Canvas 98%, CanvasText)"></rect>' +
+        '<line x1="' + pad + '" x2="' + (width - pad) + '" y1="' + (height - pad) + '" y2="' + (height - pad) + '" stroke="color-mix(in srgb, CanvasText 18%, Canvas)"></line>' +
+        bars +
+        '</svg>';
+    }
+
+    function resultRows() {
+      const data = toolResult.resultData || toolResult.data || toolInput.resultData || {};
+      const arrays = Object.values(data).filter(Array.isArray);
+      const rows = arrays.find((items) => items.some((item) => item && typeof item === "object" && !Array.isArray(item))) || [];
+      return rows.slice(0, 8);
+    }
+
+    function renderTable(rows) {
+      if (!rows.length) return "";
+      const columns = Object.keys(rows[0]).slice(0, 6);
+      return '<div class="card"><h2>Data</h2><table><thead><tr>' +
+        columns.map((c) => '<th>' + esc(c) + '</th>').join("") +
+        '</tr></thead><tbody>' +
+        rows.map((row) => '<tr>' + columns.map((c) => '<td>' + esc(row[c]) + '</td>').join("") + '</tr>').join("") +
+        '</tbody></table></div>';
+    }
+
+    function renderShell(title, subtitle, body) {
+      const openButton = openUrl ? '<button type="button" data-open>Open in Analytics</button>' : "";
+      root.innerHTML = '<section class="top"><div><h1>' + esc(title) + '</h1>' +
+        (subtitle ? '<div class="muted">' + esc(subtitle) + '</div>' : "") +
+        '</div><div class="actions">' + openButton + '</div></section>' + body;
+      root.querySelector("[data-open]")?.addEventListener("click", () => {
+        if (openUrl) void app.openLink({ url: openUrl });
+      });
+    }
+
+    function renderDashboard() {
+      const config = toolResult.config || parseJson(toolInput.config, {}) || {};
+      const panels = Array.isArray(config.panels) ? config.panels : [];
+      const cards = panels.map((panel) =>
+        '<section class="card panel"><div class="panel-kind">' + esc(panel.chartType || "panel") + '</div><h2>' + esc(panel.title || panel.id || "Untitled panel") + '</h2><div class="muted">' + esc(panel.source || "layout") + '</div></section>'
+      ).join("");
+      renderShell(config.name || toolResult.name || toolInput.dashboardId || "Dashboard", panels.length + " panel" + (panels.length === 1 ? "" : "s"),
+        '<div class="grid">' + (cards || '<div class="empty muted">Dashboard panels were not available.</div>') + '</div>');
+    }
+
+    function renderAnalysis() {
+      const rows = resultRows();
+      renderShell(toolResult.name || toolInput.name || "Analysis", toolResult.description || toolInput.description || "",
+        '<section class="card markdown">' + esc(toolResult.resultMarkdown || toolInput.resultMarkdown || "Analysis content was not available.") + '</section>' + renderTable(rows));
+    }
+
+    function renderChart() {
+      const image = toolResult.url ? '<img src="' + esc(absolutize(toolResult.url)) + '" alt="Generated chart">' : chartSvg();
+      renderShell(toolInput.title || toolResult.filename || "Chart", toolInput.subtitle || "", '<section class="card chart">' + image + '</section>');
+    }
+
+    function render() {
+      if (kind === "dashboard") return renderDashboard();
+      if (kind === "analysis") return renderAnalysis();
+      return renderChart();
+    }
+
+    app.ontoolinput = (params) => {
+      toolInput = params.arguments || {};
+      render();
+    };
+    app.ontoolresult = (params) => {
+      toolResult = parseResult(params);
+      openUrl = openLinkFrom(params, toolResult);
+      render();
+    };
+    await app.connect();
+  </script>
+</body>
+</html>`;
+}
+
+export function analyticsChartMcpAppHtml({
+  requestOrigin,
+}: {
+  requestOrigin?: string;
+}): string {
+  return analyticsAppHtml({
+    title: "chart",
+    kind: "chart",
+    requestOrigin,
+  });
+}
+
+export function analyticsAnalysisMcpAppHtml({
+  requestOrigin,
+}: {
+  requestOrigin?: string;
+}): string {
+  return analyticsAppHtml({
+    title: "analysis",
+    kind: "analysis",
+    requestOrigin,
+  });
+}
+
+export function analyticsDashboardMcpAppHtml({
+  requestOrigin,
+}: {
+  requestOrigin?: string;
+}): string {
+  return analyticsAppHtml({
+    title: "dashboard",
+    kind: "dashboard",
+    requestOrigin,
+  });
+}

--- a/templates/analytics/actions/_mcp-apps.ts
+++ b/templates/analytics/actions/_mcp-apps.ts
@@ -14,7 +14,8 @@ function attr(value: string | undefined): string {
   return String(value ?? "")
     .replace(/&/g, "&amp;")
     .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;");
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 function analyticsAppHtml({

--- a/templates/analytics/actions/generate-chart.ts
+++ b/templates/analytics/actions/generate-chart.ts
@@ -2,18 +2,13 @@ import { defineAction } from "@agent-native/core";
 import { z } from "zod";
 import type { ChartJSNodeCanvas as ChartJSNodeCanvasType } from "chartjs-node-canvas";
 import type { ChartConfiguration, ChartType } from "chart.js";
-import { writeFileSync, readFileSync, existsSync, mkdirSync } from "fs";
+import { writeFileSync, readFileSync, existsSync } from "node:fs";
 import { join } from "path";
-
-function getMediaDir(): string {
-  const base = import.meta.dirname ?? process.cwd?.();
-  if (!base) {
-    throw new Error(
-      "generate-chart: cannot resolve media directory (no dirname or cwd available in this runtime)",
-    );
-  }
-  return join(base, import.meta.dirname ? "../media" : "media");
-}
+import {
+  analyticsChartMcpAppHtml,
+  analyticsMcpAppResourceMeta,
+} from "./_mcp-apps.js";
+import { getAnalyticsMediaDir } from "../server/lib/media-dir.js";
 
 const THEMES = {
   dark: {
@@ -57,7 +52,7 @@ const PALETTES = {
 
 function getTheme(): "dark" | "light" {
   try {
-    const themeFile = join(getMediaDir(), "theme.json");
+    const themeFile = join(getAnalyticsMediaDir(), "theme.json");
     if (existsSync(themeFile)) {
       const data = JSON.parse(readFileSync(themeFile, "utf8"));
       if (data.theme === "light") return "light";
@@ -125,6 +120,14 @@ export default defineAction({
     filename: z.string().optional().describe("Output filename (without .png)"),
   }),
   http: false,
+  mcpApp: {
+    resource: {
+      title: "Chart preview",
+      description: "Preview the generated Analytics chart inline.",
+      html: analyticsChartMcpAppHtml,
+      ...analyticsMcpAppResourceMeta,
+    },
+  },
   run: async (args) => {
     if (!args.title) {
       return { error: "--title is required", fallback: CHART_FALLBACK_HINT };
@@ -284,10 +287,7 @@ export default defineAction({
       ],
     };
 
-    const mediaDir = getMediaDir();
-    if (!existsSync(mediaDir)) {
-      mkdirSync(mediaDir, { recursive: true });
-    }
+    const mediaDir = getAnalyticsMediaDir();
 
     const filename =
       (args.filename || `${slugify(title)}-${Date.now()}`) + ".png";

--- a/templates/analytics/actions/get-analysis.ts
+++ b/templates/analytics/actions/get-analysis.ts
@@ -6,6 +6,10 @@ import {
 } from "@agent-native/core/server";
 import { z } from "zod";
 import { getAnalysis } from "../server/lib/dashboards-store";
+import {
+  analyticsAnalysisMcpAppHtml,
+  analyticsMcpAppResourceMeta,
+} from "./_mcp-apps.js";
 
 export default defineAction({
   description: "Get a saved ad-hoc analysis by ID, including its full results.",
@@ -15,6 +19,14 @@ export default defineAction({
   http: { method: "GET" },
   readOnly: true,
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  mcpApp: {
+    resource: {
+      title: "Analysis preview",
+      description: "Read the saved Analytics analysis inline.",
+      html: analyticsAnalysisMcpAppHtml,
+      ...analyticsMcpAppResourceMeta,
+    },
+  },
   link: ({ result }) => {
     if (!result || typeof result !== "object") return null;
     const a = result as { id?: string; error?: string };

--- a/templates/analytics/actions/save-analysis.ts
+++ b/templates/analytics/actions/save-analysis.ts
@@ -8,6 +8,10 @@ import {
 import { z } from "zod";
 import { upsertAnalysis } from "../server/lib/dashboards-store";
 import { hasDataQueryAttempt } from "../server/lib/real-data-actions";
+import {
+  analyticsAnalysisMcpAppHtml,
+  analyticsMcpAppResourceMeta,
+} from "./_mcp-apps.js";
 
 function parseJsonArg(value: unknown, label: string): unknown {
   if (typeof value !== "string") return value;
@@ -100,6 +104,14 @@ export default defineAction({
       ),
   }),
   http: false,
+  mcpApp: {
+    resource: {
+      title: "Saved analysis",
+      description: "Preview the saved Analytics analysis inline.",
+      html: analyticsAnalysisMcpAppHtml,
+      ...analyticsMcpAppResourceMeta,
+    },
+  },
   run: async (args) => {
     const runCtx = getRequestRunContext();
     if (
@@ -127,6 +139,9 @@ export default defineAction({
       id: args.id,
       analysisId: args.id,
       name: args.name,
+      description: args.description,
+      resultMarkdown: args.resultMarkdown,
+      resultData: args.resultData,
       urlPath: `/analyses/${args.id}`,
       deepLink: buildDeepLink({
         app: "analytics",

--- a/templates/analytics/actions/update-dashboard.ts
+++ b/templates/analytics/actions/update-dashboard.ts
@@ -14,6 +14,10 @@ import {
   applyText,
   seedFromText,
 } from "@agent-native/core/collab";
+import {
+  analyticsDashboardMcpAppHtml,
+  analyticsMcpAppResourceMeta,
+} from "./_mcp-apps.js";
 
 /**
  * Same shape as the server-side validator in `server/handlers/sql-dashboards.ts`.
@@ -431,6 +435,14 @@ export default defineAction({
       .describe("Replace the whole dashboard config (or a JSON string)."),
   }),
   http: false,
+  mcpApp: {
+    resource: {
+      title: "Dashboard preview",
+      description: "Preview the updated Analytics dashboard inline.",
+      html: analyticsDashboardMcpAppHtml,
+      ...analyticsMcpAppResourceMeta,
+    },
+  },
   run: async (args) => {
     if (!args.ops && !args.config) {
       return "Error: provide either `ops` (for surgical edits) or `config` (for full replace).";
@@ -456,6 +468,7 @@ export default defineAction({
           typeof args.config.name === "string"
             ? args.config.name
             : args.dashboardId,
+        config: args.config,
         urlPath: `/adhoc/${args.dashboardId}`,
         deepLink: buildDeepLink({
           app: "analytics",
@@ -496,6 +509,7 @@ export default defineAction({
       id: args.dashboardId,
       dashboardId: args.dashboardId,
       name: typeof root.name === "string" ? root.name : args.dashboardId,
+      config: root,
       urlPath: `/adhoc/${args.dashboardId}`,
       deepLink: buildDeepLink({
         app: "analytics",

--- a/templates/analytics/server/lib/media-dir.ts
+++ b/templates/analytics/server/lib/media-dir.ts
@@ -1,0 +1,31 @@
+import { accessSync, constants, mkdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+function writableDir(candidate: string): string | null {
+  try {
+    mkdirSync(candidate, { recursive: true });
+    accessSync(candidate, constants.R_OK | constants.W_OK);
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+export function getAnalyticsMediaDir(): string {
+  const candidates = [
+    process.env.AGENT_NATIVE_MEDIA_DIR,
+    import.meta.dirname
+      ? path.resolve(import.meta.dirname, "..", "..", "media")
+      : undefined,
+    path.resolve(process.cwd(), "media"),
+    path.join(os.tmpdir(), "agent-native-analytics-media"),
+  ].filter(Boolean) as string[];
+
+  for (const candidate of candidates) {
+    const dir = writableDir(candidate);
+    if (dir) return dir;
+  }
+
+  throw new Error("No writable media directory is available");
+}

--- a/templates/analytics/server/routes/api/media/[...].get.ts
+++ b/templates/analytics/server/routes/api/media/[...].get.ts
@@ -3,14 +3,12 @@ import { createReadStream } from "fs";
 import { stat } from "fs/promises";
 import { defineEventHandler, setResponseStatus } from "h3";
 import { streamFile } from "@agent-native/core/server";
+import { getAnalyticsMediaDir } from "../../../lib/media-dir.js";
 
 export default defineEventHandler(async (event) => {
   let mediaDir: string;
   try {
-    mediaDir = path.resolve(
-      import.meta.dirname ?? process.cwd(),
-      import.meta.dirname ? "../../../../media" : "media",
-    );
+    mediaDir = getAnalyticsMediaDir();
   } catch {
     setResponseStatus(event, 501);
     return { error: "Media serving not available in this environment" };

--- a/templates/design/actions/_mcp-apps.ts
+++ b/templates/design/actions/_mcp-apps.ts
@@ -1,0 +1,163 @@
+const MCP_APP_IMPORT =
+  "https://esm.sh/@modelcontextprotocol/ext-apps@1.7.2/app-with-deps";
+const DESIGN_ORIGIN = "https://design.agent-native.com";
+
+export const designMcpAppResourceMeta = {
+  csp: {
+    connectDomains: [DESIGN_ORIGIN, "https://esm.sh"],
+    resourceDomains: [DESIGN_ORIGIN, "https://esm.sh"],
+  },
+  prefersBorder: true,
+};
+
+function attr(value: string | undefined): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;");
+}
+
+export function designPreviewMcpAppHtml({
+  requestOrigin,
+}: {
+  requestOrigin?: string;
+}): string {
+  const origin = requestOrigin || DESIGN_ORIGIN;
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: Canvas; color: CanvasText; }
+    body { margin: 0; }
+    .shell { display: grid; gap: 12px; padding: 14px; }
+    .top { display: flex; align-items: start; justify-content: space-between; gap: 12px; }
+    h1 { margin: 0; font-size: 15px; line-height: 1.25; font-weight: 750; }
+    .muted { color: color-mix(in srgb, CanvasText 58%, Canvas); font-size: 12px; line-height: 1.45; }
+    .tabs, .actions { display: flex; gap: 8px; flex-wrap: wrap; }
+    .actions { justify-content: flex-end; }
+    button { border: 1px solid color-mix(in srgb, CanvasText 14%, Canvas); border-radius: 7px; background: Canvas; color: CanvasText; cursor: pointer; font: inherit; font-size: 12px; font-weight: 700; min-height: 32px; padding: 0 10px; }
+    button[aria-pressed="true"] { border-color: #2563eb; background: #2563eb; color: white; }
+    .preview { min-height: 280px; border: 1px solid color-mix(in srgb, CanvasText 12%, Canvas); border-radius: 8px; overflow: auto; background: white; color: #111827; }
+    .empty { border: 1px dashed color-mix(in srgb, CanvasText 22%, Canvas); border-radius: 8px; padding: 16px; }
+    @media (max-width: 560px) { .top, .actions { align-items: stretch; flex-direction: column; } button { width: 100%; } }
+  </style>
+</head>
+<body data-origin="${attr(origin)}">
+  <main id="app" class="shell">
+    <div class="empty muted">Loading design</div>
+  </main>
+  <script type="module">
+    import { App } from "${MCP_APP_IMPORT}";
+
+    const root = document.getElementById("app");
+    const origin = document.body.dataset.origin || "${DESIGN_ORIGIN}";
+    const app = new App({ name: "Agent Native Design Preview", version: "1.0.0" }, {});
+    let toolInput = {};
+    let toolResult = {};
+    let files = [];
+    let selected = 0;
+    let openUrl = "";
+
+    function esc(value) {
+      return String(value ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+    }
+
+    function parseJson(value, fallback) {
+      if (Array.isArray(value) || (value && typeof value === "object")) return value;
+      if (typeof value !== "string" || !value.trim()) return fallback;
+      try { return JSON.parse(value); } catch { return fallback; }
+    }
+
+    function parseResult(params) {
+      if (!params) return {};
+      if (params.structuredContent && typeof params.structuredContent === "object") return params.structuredContent;
+      const parts = Array.isArray(params.content) ? params.content : [];
+      const textPart = parts.find((part) => part && part.type === "text" && typeof part.text === "string");
+      return parseJson(textPart ? textPart.text : "", {});
+    }
+
+    function absolutize(url) {
+      if (!url) return "";
+      try { return new URL(url, origin).toString(); } catch { return ""; }
+    }
+
+    function openLinkFrom(params, data) {
+      const metaUrl = params && params._meta && params._meta["agent-native/openLink"]
+        ? params._meta["agent-native/openLink"].webUrl
+        : "";
+      return absolutize(metaUrl || data.deepLink || "");
+    }
+
+    function collectFiles() {
+      const fromInput = parseJson(toolInput.files, []);
+      const fromResult = Array.isArray(toolResult.files) ? toolResult.files : [];
+      files = (fromResult.some((f) => f && f.content) ? fromResult : fromInput)
+        .filter((f) => f && typeof f.content === "string");
+      if (selected >= files.length) selected = 0;
+    }
+
+    function safePreviewHtml(raw) {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(String(raw || ""), "text/html");
+      doc.querySelectorAll("script").forEach((node) => node.remove());
+      doc.querySelectorAll("*").forEach((node) => {
+        for (const attr of [...node.attributes]) {
+          if (/^on/i.test(attr.name)) node.removeAttribute(attr.name);
+        }
+      });
+      const styles = [...doc.querySelectorAll("style")].map((style) => style.textContent || "").join("\\n");
+      const body = doc.body ? doc.body.innerHTML : doc.documentElement.innerHTML;
+      return '<style>:host{display:block;min-height:280px;background:white;color:#111827;font-family:ui-sans-serif,system-ui;}*,*:before,*:after{box-sizing:border-box;} ' + styles + '</style>' + body;
+    }
+
+    function mountPreview() {
+      const host = root.querySelector("[data-preview]");
+      if (!host || !files.length) return;
+      const shadow = host.shadowRoot || host.attachShadow({ mode: "open" });
+      shadow.innerHTML = safePreviewHtml(files[selected].content);
+    }
+
+    function render() {
+      collectFiles();
+      if (!files.length) {
+        root.innerHTML = '<div class="empty muted">Design files were not available.</div>';
+        return;
+      }
+      const title = toolInput.prompt || toolResult.title || toolResult.designId || "Generated design";
+      root.innerHTML =
+        '<section class="top"><div><h1>' + esc(title) + '</h1><div class="muted">' + files.length + ' file' + (files.length === 1 ? '' : 's') + '</div></div>' +
+        '<div class="actions">' + (openUrl ? '<button type="button" data-open>Open in Design</button>' : '') + '</div></section>' +
+        '<nav class="tabs">' + files.map((file, index) => '<button type="button" data-tab="' + index + '" aria-pressed="' + (index === selected ? 'true' : 'false') + '">' + esc(file.filename || "file") + '</button>').join("") + '</nav>' +
+        '<section class="preview" data-preview></section>';
+      root.querySelectorAll("[data-tab]").forEach((button) => {
+        button.addEventListener("click", () => {
+          selected = Number(button.dataset.tab) || 0;
+          render();
+        });
+      });
+      root.querySelector("[data-open]")?.addEventListener("click", () => {
+        if (openUrl) void app.openLink({ url: openUrl });
+      });
+      mountPreview();
+    }
+
+    app.ontoolinput = (params) => {
+      toolInput = params.arguments || {};
+      render();
+    };
+    app.ontoolresult = (params) => {
+      toolResult = parseResult(params);
+      openUrl = openLinkFrom(params, toolResult);
+      render();
+    };
+    await app.connect();
+  </script>
+</body>
+</html>`;
+}

--- a/templates/design/actions/_mcp-apps.ts
+++ b/templates/design/actions/_mcp-apps.ts
@@ -14,7 +14,8 @@ function attr(value: string | undefined): string {
   return String(value ?? "")
     .replace(/&/g, "&amp;")
     .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;");
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 export function designPreviewMcpAppHtml({
@@ -102,18 +103,156 @@ export function designPreviewMcpAppHtml({
       if (selected >= files.length) selected = 0;
     }
 
-    function safePreviewHtml(raw) {
+    const ALLOWED_TAGS = new Set([
+      "a", "article", "aside", "b", "blockquote", "br", "caption", "code", "col", "colgroup",
+      "dd", "div", "dl", "dt", "em", "figcaption", "figure", "footer", "h1", "h2", "h3", "h4",
+      "h5", "h6", "header", "hr", "i", "img", "li", "main", "ol", "p", "pre", "section", "small",
+      "span", "strong", "style", "sub", "sup", "table", "tbody", "td", "tfoot", "th", "thead",
+      "tr", "u", "ul",
+    ]);
+    const DROP_TAGS = new Set([
+      "base", "button", "embed", "form", "iframe", "input", "link", "math", "meta", "object",
+      "script", "select", "svg", "textarea",
+    ]);
+    const ALLOWED_ATTRS = new Set([
+      "align", "alt", "aria-label", "aria-hidden", "border", "cellpadding", "cellspacing", "class",
+      "colspan", "height", "href", "id", "role", "rowspan", "src", "style", "target", "title",
+      "valign", "width",
+    ]);
+    const URL_ATTRS = new Set(["href", "src", "poster", "xlink:href"]);
+
+    function decodeEntities(value) {
+      const textarea = document.createElement("textarea");
+      let decoded = String(value || "");
+      for (let i = 0; i < 3; i++) {
+        textarea.innerHTML = decoded;
+        const next = textarea.value;
+        if (next === decoded) break;
+        decoded = next;
+      }
+      return decoded;
+    }
+
+    function sanitizeUrl(rawUrl, kind = "link") {
+      const value = String(rawUrl || "").trim();
+      if (!value) return "";
+      const decoded = decodeEntities(value);
+      const lower = decoded.replace(/[\\s\\u0000-\\u001f\\u007f]+/g, "").toLowerCase();
+      if (lower.startsWith("javascript:") || lower.startsWith("vbscript:") || lower.startsWith("file:") || lower.startsWith("//")) return "";
+      if (lower.startsWith("data:")) {
+        return kind === "image" && /^data:image\\/(?:gif|png|jpe?g|webp|avif);base64,/i.test(decoded) ? value : "";
+      }
+      if (value.startsWith("/") || value.startsWith("#") || value.startsWith("./") || value.startsWith("../")) return value;
+      try {
+        const url = new URL(decoded, origin);
+        return kind === "image"
+          ? (url.protocol === "http:" || url.protocol === "https:" ? value : "")
+          : (["http:", "https:", "mailto:", "tel:"].includes(url.protocol) ? value : "");
+      } catch {
+        return /^[a-z][a-z\\d+.-]*:/i.test(lower) ? "" : value;
+      }
+    }
+
+    function sanitizeCssValue(value) {
+      const decoded = decodeEntities(value);
+      if (/(?:^|[^\\w-])expression\\s*\\(/i.test(decoded) || /(?:java|vb)script\\s*:/i.test(decoded) || /(?:^|[^\\w-])url\\s*\\(/i.test(decoded) || /@import/i.test(decoded) || /-moz-binding/i.test(decoded) || /behavior\\s*:/i.test(decoded)) return "";
+      return String(value || "").trim();
+    }
+
+    function sanitizeStyle(style) {
+      return String(style || "")
+        .split(";")
+        .map((declaration) => {
+          const index = declaration.indexOf(":");
+          if (index <= 0) return "";
+          const property = declaration.slice(0, index).trim();
+          const value = declaration.slice(index + 1).trim();
+          if (!/^(?:--)?[a-zA-Z][\\w-]*$/.test(property) || !value) return "";
+          const safeValue = sanitizeCssValue(value);
+          return safeValue ? property + ": " + safeValue : "";
+        })
+        .filter(Boolean)
+        .join("; ");
+    }
+
+    function sanitizeStyleSheet(css) {
+      return String(css || "")
+        .replace(/@import[^;]+;?/gi, "")
+        .replace(/([^{}]+)\\{([^{}]*)\\}/g, (_match, selector, body) => {
+          const safeBody = sanitizeStyle(String(body));
+          return safeBody ? String(selector).trim() + " { " + safeBody + "; }" : "";
+        });
+    }
+
+    function cleanNode(node, doc) {
+      if (node.nodeType === Node.TEXT_NODE) return doc.createTextNode(node.textContent || "");
+      if (node.nodeType !== Node.ELEMENT_NODE) return null;
+      const tag = node.tagName.toLowerCase();
+      if (DROP_TAGS.has(tag)) return null;
+      if (tag === "style") {
+        const safeCss = sanitizeStyleSheet(node.textContent || "");
+        if (!safeCss.trim()) return null;
+        const out = doc.createElement("style");
+        out.textContent = safeCss;
+        return out;
+      }
+      if (!ALLOWED_TAGS.has(tag)) {
+        const fragment = doc.createDocumentFragment();
+        node.childNodes.forEach((child) => {
+          const cleaned = cleanNode(child, doc);
+          if (cleaned) fragment.appendChild(cleaned);
+        });
+        return fragment;
+      }
+      const out = doc.createElement(tag);
+      [...node.attributes].forEach((attribute) => {
+        const name = attribute.name.toLowerCase();
+        const value = attribute.value;
+        if (name.startsWith("on") || name === "srcdoc" || name === "srcset") return;
+        if (!ALLOWED_ATTRS.has(name) && !name.startsWith("data-") && !name.startsWith("aria-")) return;
+        if (URL_ATTRS.has(name)) {
+          const safeUrl = sanitizeUrl(value, tag === "img" ? "image" : "link");
+          if (safeUrl) out.setAttribute(name, safeUrl);
+          return;
+        }
+        if (name === "style") {
+          const safeStyle = sanitizeStyle(value);
+          if (safeStyle) out.setAttribute("style", safeStyle);
+          return;
+        }
+        if (name === "target" && value !== "_blank") return;
+        out.setAttribute(name, value);
+      });
+      if (tag === "a") {
+        out.setAttribute("target", "_blank");
+        out.setAttribute("rel", "noopener noreferrer");
+      }
+      node.childNodes.forEach((child) => {
+        const cleaned = cleanNode(child, doc);
+        if (cleaned) out.appendChild(cleaned);
+      });
+      return out;
+    }
+
+    function sanitizeHtml(raw) {
       const parser = new DOMParser();
       const doc = parser.parseFromString(String(raw || ""), "text/html");
-      doc.querySelectorAll("script").forEach((node) => node.remove());
-      doc.querySelectorAll("*").forEach((node) => {
-        for (const attr of [...node.attributes]) {
-          if (/^on/i.test(attr.name)) node.removeAttribute(attr.name);
-        }
+      const fragment = doc.createDocumentFragment();
+      doc.head.querySelectorAll("style").forEach((style) => {
+        const cleaned = cleanNode(style, doc);
+        if (cleaned) fragment.appendChild(cleaned);
       });
-      const styles = [...doc.querySelectorAll("style")].map((style) => style.textContent || "").join("\\n");
-      const body = doc.body ? doc.body.innerHTML : doc.documentElement.innerHTML;
-      return '<style>:host{display:block;min-height:280px;background:white;color:#111827;font-family:ui-sans-serif,system-ui;}*,*:before,*:after{box-sizing:border-box;} ' + styles + '</style>' + body;
+      doc.body.childNodes.forEach((child) => {
+        const cleaned = cleanNode(child, doc);
+        if (cleaned) fragment.appendChild(cleaned);
+      });
+      const wrapper = doc.createElement("div");
+      wrapper.appendChild(fragment);
+      return wrapper.innerHTML;
+    }
+
+    function safePreviewHtml(raw) {
+      return '<style>:host{display:block;min-height:280px;background:white;color:#111827;font-family:ui-sans-serif,system-ui;}*,*:before,*:after{box-sizing:border-box;}</style>' + sanitizeHtml(raw);
     }
 
     function mountPreview() {

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -10,6 +10,10 @@ import {
   applyText,
   seedFromText,
 } from "@agent-native/core/collab";
+import {
+  designMcpAppResourceMeta,
+  designPreviewMcpAppHtml,
+} from "./_mcp-apps.js";
 
 /** Editor deep link so external agents can surface "Open design". */
 function designDeepLink(designId: string): string {
@@ -98,6 +102,14 @@ export default defineAction({
           "the design's `:root` block actually uses.",
       ),
   }),
+  mcpApp: {
+    resource: {
+      title: "Design preview",
+      description: "Preview generated Design files inline.",
+      html: designPreviewMcpAppHtml,
+      ...designMcpAppResourceMeta,
+    },
+  },
   run: async ({
     designId,
     prompt,

--- a/templates/design/actions/get-design-snapshot.ts
+++ b/templates/design/actions/get-design-snapshot.ts
@@ -5,6 +5,10 @@ import { z } from "zod";
 import { schema } from "../server/db/index.js";
 import { buildDesignSnapshot } from "../server/lib/design-snapshot.js";
 import "../server/db/index.js"; // ensure registerShareableResource runs
+import {
+  designMcpAppResourceMeta,
+  designPreviewMcpAppHtml,
+} from "./_mcp-apps.js";
 
 /** Editor deep link so external agents can surface "Open design". */
 function designDeepLink(designId: string): string {
@@ -29,6 +33,14 @@ export default defineAction({
   readOnly: true,
   http: { method: "GET" },
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  mcpApp: {
+    resource: {
+      title: "Design snapshot",
+      description: "Preview the current Design snapshot inline.",
+      html: designPreviewMcpAppHtml,
+      ...designMcpAppResourceMeta,
+    },
+  },
   run: async ({ designId }) => {
     const access = await resolveAccess("design", designId);
     if (!access) {

--- a/templates/mail/actions/_mcp-apps.ts
+++ b/templates/mail/actions/_mcp-apps.ts
@@ -14,7 +14,8 @@ function attr(value: string | undefined): string {
   return String(value ?? "")
     .replace(/&/g, "&amp;")
     .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;");
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 export function mailDraftMcpAppHtml({

--- a/templates/mail/actions/_mcp-apps.ts
+++ b/templates/mail/actions/_mcp-apps.ts
@@ -1,0 +1,193 @@
+const MCP_APP_IMPORT =
+  "https://esm.sh/@modelcontextprotocol/ext-apps@1.7.2/app-with-deps";
+const MAIL_ORIGIN = "https://mail.agent-native.com";
+
+export const mailMcpAppResourceMeta = {
+  csp: {
+    connectDomains: [MAIL_ORIGIN, "https://esm.sh"],
+    resourceDomains: [MAIL_ORIGIN, "https://esm.sh"],
+  },
+  prefersBorder: true,
+};
+
+function attr(value: string | undefined): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;");
+}
+
+export function mailDraftMcpAppHtml({
+  actionName,
+  requestOrigin,
+}: {
+  actionName: string;
+  requestOrigin?: string;
+}): string {
+  const origin = requestOrigin || MAIL_ORIGIN;
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: Canvas; color: CanvasText; }
+    body { margin: 0; }
+    .shell { display: grid; gap: 12px; padding: 14px; }
+    .top { display: flex; align-items: start; justify-content: space-between; gap: 12px; }
+    h1 { margin: 0; font-size: 15px; line-height: 1.25; font-weight: 700; }
+    .muted { color: color-mix(in srgb, CanvasText 58%, Canvas); font-size: 12px; line-height: 1.45; }
+    .grid { display: grid; gap: 8px; grid-template-columns: 1fr 1fr; }
+    label { display: grid; gap: 4px; color: color-mix(in srgb, CanvasText 68%, Canvas); font-size: 11px; font-weight: 650; letter-spacing: .02em; text-transform: uppercase; }
+    input, textarea { box-sizing: border-box; width: 100%; border: 1px solid color-mix(in srgb, CanvasText 16%, Canvas); border-radius: 7px; background: color-mix(in srgb, Canvas 96%, CanvasText); color: CanvasText; font: inherit; font-size: 13px; padding: 8px 9px; outline: none; }
+    textarea { min-height: 150px; resize: vertical; line-height: 1.45; }
+    input:focus, textarea:focus { border-color: #2563eb; box-shadow: 0 0 0 3px color-mix(in srgb, #2563eb 18%, transparent); }
+    .wide { grid-column: 1 / -1; }
+    .actions { display: flex; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }
+    button { border: 1px solid color-mix(in srgb, CanvasText 14%, Canvas); border-radius: 7px; background: Canvas; color: CanvasText; font: inherit; font-size: 12px; font-weight: 700; min-height: 32px; padding: 0 10px; cursor: pointer; }
+    button.primary { border-color: #2563eb; background: #2563eb; color: white; }
+    button:disabled { opacity: .55; cursor: default; }
+    .status { min-height: 18px; font-size: 12px; color: color-mix(in srgb, CanvasText 58%, Canvas); }
+    .empty { border: 1px dashed color-mix(in srgb, CanvasText 22%, Canvas); border-radius: 8px; padding: 16px; }
+    @media (max-width: 560px) { .grid { grid-template-columns: 1fr; } .top, .actions { align-items: stretch; flex-direction: column; } button { width: 100%; } }
+  </style>
+</head>
+<body data-action="${attr(actionName)}" data-origin="${attr(origin)}">
+  <main id="app" class="shell">
+    <div class="empty muted">Loading draft</div>
+  </main>
+  <script type="module">
+    import { App } from "${MCP_APP_IMPORT}";
+
+    const actionName = document.body.dataset.action;
+    const origin = document.body.dataset.origin || "${MAIL_ORIGIN}";
+    const root = document.getElementById("app");
+    const app = new App({ name: "Agent Native Mail Draft", version: "1.0.0" }, {});
+    let toolInput = {};
+    let state = {};
+    let openUrl = "";
+
+    function esc(value) {
+      return String(value ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+    }
+
+    function parseJsonText(text) {
+      try { return JSON.parse(text); } catch { return { message: text || "" }; }
+    }
+
+    function parseToolResult(params) {
+      if (!params) return {};
+      if (params.structuredContent && typeof params.structuredContent === "object") {
+        return params.structuredContent;
+      }
+      const parts = Array.isArray(params.content) ? params.content : [];
+      const textPart = parts.find((part) => part && part.type === "text" && typeof part.text === "string");
+      return parseJsonText(textPart ? textPart.text : "");
+    }
+
+    function absolutize(url) {
+      if (!url) return "";
+      try { return new URL(url, origin).toString(); } catch { return ""; }
+    }
+
+    function openLinkFrom(params, data) {
+      const metaUrl = params && params._meta && params._meta["agent-native/openLink"]
+        ? params._meta["agent-native/openLink"].webUrl
+        : "";
+      return absolutize(metaUrl || data.deepLink || "");
+    }
+
+    function normalizeDraft(data) {
+      const draft = data && typeof data === "object" && data.draft ? data.draft : data;
+      return {
+        id: draft.id || toolInput.id || "",
+        to: draft.to || toolInput.to || "",
+        cc: draft.cc || toolInput.cc || "",
+        bcc: draft.bcc || toolInput.bcc || "",
+        subject: draft.subject || toolInput.subject || "",
+        body: draft.body || toolInput.body || "",
+        mode: draft.mode || toolInput.mode || "compose",
+        accountEmail: draft.accountEmail || toolInput.accountEmail || ""
+      };
+    }
+
+    function render(status) {
+      if (!state.id) {
+        root.innerHTML = '<div class="empty muted">Draft data was not available.</div>';
+        return;
+      }
+      root.innerHTML =
+        '<section class="top">' +
+          '<div><h1>' + esc(state.subject || "Untitled draft") + '</h1>' +
+          '<div class="muted">' + esc(state.mode || "compose") + (state.accountEmail ? " from " + esc(state.accountEmail) : "") + '</div></div>' +
+          '<div class="actions">' +
+            '<button type="button" data-open' + (openUrl ? "" : " disabled") + '>Open in Mail</button>' +
+            '<button class="primary" type="button" data-save>Update draft</button>' +
+          '</div>' +
+        '</section>' +
+        '<form class="grid">' +
+          '<label>To<input name="to" value="' + esc(state.to) + '"></label>' +
+          '<label>Subject<input name="subject" value="' + esc(state.subject) + '"></label>' +
+          '<label>CC<input name="cc" value="' + esc(state.cc) + '"></label>' +
+          '<label>BCC<input name="bcc" value="' + esc(state.bcc) + '"></label>' +
+          '<label class="wide">Body<textarea name="body">' + esc(state.body) + '</textarea></label>' +
+        '</form>' +
+        '<div class="status" data-status>' + esc(status || "") + '</div>';
+      root.querySelector("[data-open]")?.addEventListener("click", () => {
+        if (openUrl) void app.openLink({ url: openUrl });
+      });
+      root.querySelector("[data-save]")?.addEventListener("click", updateDraft);
+    }
+
+    async function updateDraft() {
+      const form = root.querySelector("form");
+      const status = root.querySelector("[data-status]");
+      const button = root.querySelector("[data-save]");
+      if (!form || !state.id) return;
+      button.disabled = true;
+      status.textContent = "Updating";
+      const payload = {
+        action: "update",
+        id: state.id,
+        to: form.elements.to.value,
+        cc: form.elements.cc.value,
+        bcc: form.elements.bcc.value,
+        subject: form.elements.subject.value,
+        body: form.elements.body.value,
+        mode: state.mode,
+        accountEmail: state.accountEmail
+      };
+      try {
+        const result = await app.callServerTool({ name: actionName, arguments: payload });
+        const data = parseToolResult(result);
+        state = normalizeDraft(data);
+        openUrl = openLinkFrom(result, data) || openUrl;
+        render("Updated");
+      } catch (err) {
+        status.textContent = err && err.message ? err.message : "Update failed";
+        button.disabled = false;
+      }
+    }
+
+    app.ontoolinput = (params) => {
+      toolInput = params.arguments || {};
+      if (!state.id) {
+        state = normalizeDraft(toolInput);
+        render();
+      }
+    };
+    app.ontoolresult = (params) => {
+      const data = parseToolResult(params);
+      state = normalizeDraft(data);
+      openUrl = openLinkFrom(params, data);
+      render(data.message || "");
+    };
+    await app.connect();
+  </script>
+</body>
+</html>`;
+}

--- a/templates/mail/actions/manage-draft.ts
+++ b/templates/mail/actions/manage-draft.ts
@@ -9,6 +9,7 @@ import { getUserSetting } from "@agent-native/core/settings";
 import { getRequestUserEmail, buildDeepLink } from "@agent-native/core/server";
 import { z } from "zod";
 import { appendSignatureToBody } from "../shared/signature.js";
+import { mailDraftMcpAppHtml, mailMcpAppResourceMeta } from "./_mcp-apps.js";
 
 /**
  * Cap for the base64url `compose=` query param. A full draft (recipients +
@@ -109,6 +110,14 @@ export default defineAction({
       .optional()
       .describe("The 'from' account email address to send from"),
   }),
+  mcpApp: {
+    resource: {
+      title: "Review email draft",
+      description: "Review and edit a generated Mail draft inline.",
+      html: mailDraftMcpAppHtml,
+      ...mailMcpAppResourceMeta,
+    },
+  },
   run: async (args) => {
     const action = args.action;
     if (!action)

--- a/templates/slides/actions/_mcp-apps.ts
+++ b/templates/slides/actions/_mcp-apps.ts
@@ -1,0 +1,167 @@
+const MCP_APP_IMPORT =
+  "https://esm.sh/@modelcontextprotocol/ext-apps@1.7.2/app-with-deps";
+const SLIDES_ORIGIN = "https://slides.agent-native.com";
+
+export const slidesMcpAppResourceMeta = {
+  csp: {
+    connectDomains: [SLIDES_ORIGIN, "https://esm.sh"],
+    resourceDomains: [SLIDES_ORIGIN, "https://esm.sh"],
+  },
+  prefersBorder: true,
+};
+
+function attr(value: string | undefined): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;");
+}
+
+export function slidesDeckMcpAppHtml({
+  requestOrigin,
+}: {
+  requestOrigin?: string;
+}): string {
+  const origin = requestOrigin || SLIDES_ORIGIN;
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: Canvas; color: CanvasText; }
+    body { margin: 0; }
+    .shell { display: grid; gap: 12px; padding: 14px; }
+    .top { display: flex; align-items: start; justify-content: space-between; gap: 12px; }
+    h1 { margin: 0; font-size: 15px; line-height: 1.25; font-weight: 750; }
+    .muted { color: color-mix(in srgb, CanvasText 58%, Canvas); font-size: 12px; line-height: 1.45; }
+    .actions { display: flex; gap: 8px; justify-content: flex-end; flex-wrap: wrap; }
+    button { border: 1px solid color-mix(in srgb, CanvasText 14%, Canvas); border-radius: 7px; background: Canvas; color: CanvasText; cursor: pointer; font: inherit; font-size: 12px; font-weight: 700; min-height: 32px; padding: 0 10px; }
+    button:disabled { opacity: .5; cursor: default; }
+    .stage { aspect-ratio: 16 / 9; overflow: hidden; border: 1px solid color-mix(in srgb, CanvasText 12%, Canvas); border-radius: 8px; background: white; color: #111827; }
+    .empty { border: 1px dashed color-mix(in srgb, CanvasText 22%, Canvas); border-radius: 8px; padding: 16px; }
+    @media (max-width: 560px) { .top, .actions { align-items: stretch; flex-direction: column; } button { width: 100%; } }
+  </style>
+</head>
+<body data-origin="${attr(origin)}">
+  <main id="app" class="shell">
+    <div class="empty muted">Loading deck</div>
+  </main>
+  <script type="module">
+    import { App } from "${MCP_APP_IMPORT}";
+
+    const root = document.getElementById("app");
+    const origin = document.body.dataset.origin || "${SLIDES_ORIGIN}";
+    const app = new App({ name: "Agent Native Slides Deck", version: "1.0.0" }, {});
+    let toolInput = {};
+    let toolResult = {};
+    let slides = [];
+    let selected = 0;
+    let openUrl = "";
+
+    function esc(value) {
+      return String(value ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+    }
+
+    function parseJson(value, fallback) {
+      if (Array.isArray(value) || (value && typeof value === "object")) return value;
+      if (typeof value !== "string" || !value.trim()) return fallback;
+      try { return JSON.parse(value); } catch { return fallback; }
+    }
+
+    function parseResult(params) {
+      if (!params) return {};
+      if (params.structuredContent && typeof params.structuredContent === "object") return params.structuredContent;
+      const parts = Array.isArray(params.content) ? params.content : [];
+      const textPart = parts.find((part) => part && part.type === "text" && typeof part.text === "string");
+      return parseJson(textPart ? textPart.text : "", {});
+    }
+
+    function absolutize(url) {
+      if (!url) return "";
+      try { return new URL(url, origin).toString(); } catch { return ""; }
+    }
+
+    function openLinkFrom(params, data) {
+      const metaUrl = params && params._meta && params._meta["agent-native/openLink"]
+        ? params._meta["agent-native/openLink"].webUrl
+        : "";
+      return absolutize(metaUrl || data.deepLink || data.url || "");
+    }
+
+    function collectSlides() {
+      const fromResult = Array.isArray(toolResult.slides) ? toolResult.slides : [];
+      const fromInput = parseJson(toolInput.slides, []);
+      slides = (fromResult.length ? fromResult : fromInput)
+        .filter((slide) => slide && typeof slide.content === "string");
+      if (selected >= slides.length) selected = 0;
+    }
+
+    function safeSlideHtml(raw) {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(String(raw || ""), "text/html");
+      doc.querySelectorAll("script").forEach((node) => node.remove());
+      doc.querySelectorAll("*").forEach((node) => {
+        for (const attr of [...node.attributes]) {
+          if (/^on/i.test(attr.name)) node.removeAttribute(attr.name);
+        }
+      });
+      const styles = [...doc.querySelectorAll("style")].map((style) => style.textContent || "").join("\\n");
+      const body = doc.body ? doc.body.innerHTML : doc.documentElement.innerHTML;
+      return '<style>:host{display:block;width:100%;height:100%;background:white;color:#111827;font-family:ui-sans-serif,system-ui;overflow:hidden;}*,*:before,*:after{box-sizing:border-box;} ' + styles + '</style>' + body;
+    }
+
+    function mountSlide() {
+      const host = root.querySelector("[data-stage]");
+      if (!host || !slides.length) return;
+      const shadow = host.shadowRoot || host.attachShadow({ mode: "open" });
+      shadow.innerHTML = safeSlideHtml(slides[selected].content);
+    }
+
+    function render() {
+      collectSlides();
+      if (!slides.length) {
+        root.innerHTML = '<div class="empty muted">Deck slides were not available.</div>';
+        return;
+      }
+      const title = toolResult.title || toolInput.title || "Deck";
+      root.innerHTML =
+        '<section class="top"><div><h1>' + esc(title) + '</h1><div class="muted">Slide ' + (selected + 1) + ' of ' + slides.length + '</div></div>' +
+        '<div class="actions">' +
+          '<button type="button" data-prev' + (selected === 0 ? ' disabled' : '') + '>Previous</button>' +
+          '<button type="button" data-next' + (selected >= slides.length - 1 ? ' disabled' : '') + '>Next</button>' +
+          (openUrl ? '<button type="button" data-open>Open in Slides</button>' : '') +
+        '</div></section>' +
+        '<section class="stage" data-stage></section>';
+      root.querySelector("[data-prev]")?.addEventListener("click", () => {
+        selected = Math.max(0, selected - 1);
+        render();
+      });
+      root.querySelector("[data-next]")?.addEventListener("click", () => {
+        selected = Math.min(slides.length - 1, selected + 1);
+        render();
+      });
+      root.querySelector("[data-open]")?.addEventListener("click", () => {
+        if (openUrl) void app.openLink({ url: openUrl });
+      });
+      mountSlide();
+    }
+
+    app.ontoolinput = (params) => {
+      toolInput = params.arguments || {};
+      render();
+    };
+    app.ontoolresult = (params) => {
+      toolResult = parseResult(params);
+      openUrl = openLinkFrom(params, toolResult);
+      render();
+    };
+    await app.connect();
+  </script>
+</body>
+</html>`;
+}

--- a/templates/slides/actions/_mcp-apps.ts
+++ b/templates/slides/actions/_mcp-apps.ts
@@ -14,7 +14,8 @@ function attr(value: string | undefined): string {
   return String(value ?? "")
     .replace(/&/g, "&amp;")
     .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;");
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 export function slidesDeckMcpAppHtml({
@@ -101,18 +102,156 @@ export function slidesDeckMcpAppHtml({
       if (selected >= slides.length) selected = 0;
     }
 
-    function safeSlideHtml(raw) {
+    const ALLOWED_TAGS = new Set([
+      "a", "article", "aside", "b", "blockquote", "br", "caption", "code", "col", "colgroup",
+      "dd", "div", "dl", "dt", "em", "figcaption", "figure", "footer", "h1", "h2", "h3", "h4",
+      "h5", "h6", "header", "hr", "i", "img", "li", "main", "ol", "p", "pre", "section", "small",
+      "span", "strong", "style", "sub", "sup", "table", "tbody", "td", "tfoot", "th", "thead",
+      "tr", "u", "ul",
+    ]);
+    const DROP_TAGS = new Set([
+      "base", "button", "embed", "form", "iframe", "input", "link", "math", "meta", "object",
+      "script", "select", "svg", "textarea",
+    ]);
+    const ALLOWED_ATTRS = new Set([
+      "align", "alt", "aria-label", "aria-hidden", "border", "cellpadding", "cellspacing", "class",
+      "colspan", "height", "href", "id", "role", "rowspan", "src", "style", "target", "title",
+      "valign", "width",
+    ]);
+    const URL_ATTRS = new Set(["href", "src", "poster", "xlink:href"]);
+
+    function decodeEntities(value) {
+      const textarea = document.createElement("textarea");
+      let decoded = String(value || "");
+      for (let i = 0; i < 3; i++) {
+        textarea.innerHTML = decoded;
+        const next = textarea.value;
+        if (next === decoded) break;
+        decoded = next;
+      }
+      return decoded;
+    }
+
+    function sanitizeUrl(rawUrl, kind = "link") {
+      const value = String(rawUrl || "").trim();
+      if (!value) return "";
+      const decoded = decodeEntities(value);
+      const lower = decoded.replace(/[\\s\\u0000-\\u001f\\u007f]+/g, "").toLowerCase();
+      if (lower.startsWith("javascript:") || lower.startsWith("vbscript:") || lower.startsWith("file:") || lower.startsWith("//")) return "";
+      if (lower.startsWith("data:")) {
+        return kind === "image" && /^data:image\\/(?:gif|png|jpe?g|webp|avif);base64,/i.test(decoded) ? value : "";
+      }
+      if (value.startsWith("/") || value.startsWith("#") || value.startsWith("./") || value.startsWith("../")) return value;
+      try {
+        const url = new URL(decoded, origin);
+        return kind === "image"
+          ? (url.protocol === "http:" || url.protocol === "https:" ? value : "")
+          : (["http:", "https:", "mailto:", "tel:"].includes(url.protocol) ? value : "");
+      } catch {
+        return /^[a-z][a-z\\d+.-]*:/i.test(lower) ? "" : value;
+      }
+    }
+
+    function sanitizeCssValue(value) {
+      const decoded = decodeEntities(value);
+      if (/(?:^|[^\\w-])expression\\s*\\(/i.test(decoded) || /(?:java|vb)script\\s*:/i.test(decoded) || /(?:^|[^\\w-])url\\s*\\(/i.test(decoded) || /@import/i.test(decoded) || /-moz-binding/i.test(decoded) || /behavior\\s*:/i.test(decoded)) return "";
+      return String(value || "").trim();
+    }
+
+    function sanitizeStyle(style) {
+      return String(style || "")
+        .split(";")
+        .map((declaration) => {
+          const index = declaration.indexOf(":");
+          if (index <= 0) return "";
+          const property = declaration.slice(0, index).trim();
+          const value = declaration.slice(index + 1).trim();
+          if (!/^(?:--)?[a-zA-Z][\\w-]*$/.test(property) || !value) return "";
+          const safeValue = sanitizeCssValue(value);
+          return safeValue ? property + ": " + safeValue : "";
+        })
+        .filter(Boolean)
+        .join("; ");
+    }
+
+    function sanitizeStyleSheet(css) {
+      return String(css || "")
+        .replace(/@import[^;]+;?/gi, "")
+        .replace(/([^{}]+)\\{([^{}]*)\\}/g, (_match, selector, body) => {
+          const safeBody = sanitizeStyle(String(body));
+          return safeBody ? String(selector).trim() + " { " + safeBody + "; }" : "";
+        });
+    }
+
+    function cleanNode(node, doc) {
+      if (node.nodeType === Node.TEXT_NODE) return doc.createTextNode(node.textContent || "");
+      if (node.nodeType !== Node.ELEMENT_NODE) return null;
+      const tag = node.tagName.toLowerCase();
+      if (DROP_TAGS.has(tag)) return null;
+      if (tag === "style") {
+        const safeCss = sanitizeStyleSheet(node.textContent || "");
+        if (!safeCss.trim()) return null;
+        const out = doc.createElement("style");
+        out.textContent = safeCss;
+        return out;
+      }
+      if (!ALLOWED_TAGS.has(tag)) {
+        const fragment = doc.createDocumentFragment();
+        node.childNodes.forEach((child) => {
+          const cleaned = cleanNode(child, doc);
+          if (cleaned) fragment.appendChild(cleaned);
+        });
+        return fragment;
+      }
+      const out = doc.createElement(tag);
+      [...node.attributes].forEach((attribute) => {
+        const name = attribute.name.toLowerCase();
+        const value = attribute.value;
+        if (name.startsWith("on") || name === "srcdoc" || name === "srcset") return;
+        if (!ALLOWED_ATTRS.has(name) && !name.startsWith("data-") && !name.startsWith("aria-")) return;
+        if (URL_ATTRS.has(name)) {
+          const safeUrl = sanitizeUrl(value, tag === "img" ? "image" : "link");
+          if (safeUrl) out.setAttribute(name, safeUrl);
+          return;
+        }
+        if (name === "style") {
+          const safeStyle = sanitizeStyle(value);
+          if (safeStyle) out.setAttribute("style", safeStyle);
+          return;
+        }
+        if (name === "target" && value !== "_blank") return;
+        out.setAttribute(name, value);
+      });
+      if (tag === "a") {
+        out.setAttribute("target", "_blank");
+        out.setAttribute("rel", "noopener noreferrer");
+      }
+      node.childNodes.forEach((child) => {
+        const cleaned = cleanNode(child, doc);
+        if (cleaned) out.appendChild(cleaned);
+      });
+      return out;
+    }
+
+    function sanitizeHtml(raw) {
       const parser = new DOMParser();
       const doc = parser.parseFromString(String(raw || ""), "text/html");
-      doc.querySelectorAll("script").forEach((node) => node.remove());
-      doc.querySelectorAll("*").forEach((node) => {
-        for (const attr of [...node.attributes]) {
-          if (/^on/i.test(attr.name)) node.removeAttribute(attr.name);
-        }
+      const fragment = doc.createDocumentFragment();
+      doc.head.querySelectorAll("style").forEach((style) => {
+        const cleaned = cleanNode(style, doc);
+        if (cleaned) fragment.appendChild(cleaned);
       });
-      const styles = [...doc.querySelectorAll("style")].map((style) => style.textContent || "").join("\\n");
-      const body = doc.body ? doc.body.innerHTML : doc.documentElement.innerHTML;
-      return '<style>:host{display:block;width:100%;height:100%;background:white;color:#111827;font-family:ui-sans-serif,system-ui;overflow:hidden;}*,*:before,*:after{box-sizing:border-box;} ' + styles + '</style>' + body;
+      doc.body.childNodes.forEach((child) => {
+        const cleaned = cleanNode(child, doc);
+        if (cleaned) fragment.appendChild(cleaned);
+      });
+      const wrapper = doc.createElement("div");
+      wrapper.appendChild(fragment);
+      return wrapper.innerHTML;
+    }
+
+    function safeSlideHtml(raw) {
+      return '<style>:host{display:block;width:100%;height:100%;background:white;color:#111827;font-family:ui-sans-serif,system-ui;overflow:hidden;}*,*:before,*:after{box-sizing:border-box;}</style>' + sanitizeHtml(raw);
     }
 
     function mountSlide() {

--- a/templates/slides/actions/add-slide.ts
+++ b/templates/slides/actions/add-slide.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core";
+import { buildDeepLink } from "@agent-native/core/server";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
@@ -14,6 +15,14 @@ import {
   readAppStateForCurrentTab,
   writeAppStateForCurrentTab,
 } from "./_tab-state.js";
+
+function deckDeepLink(deckId: string): string {
+  return buildDeepLink({
+    app: "slides",
+    view: "editor",
+    params: { deckId },
+  });
+}
 
 // In-process serialization per deckId. `add-slide` is intentionally advertised
 // as a sequential write, but the lock still protects against accidental
@@ -168,6 +177,7 @@ export default defineAction({
         slideNumber: insertIndex + 1,
         position: insertIndex,
         slideCount: slides.length,
+        deepLink: deckDeepLink(deckId),
       };
 
       if (fit.status === "overflows") {
@@ -184,4 +194,19 @@ export default defineAction({
 
       return base;
     }),
+  link: ({ result, args }) => {
+    const deckId =
+      result && typeof result === "object"
+        ? ((result as { deckId?: string }).deckId ??
+          (typeof args.deckId === "string" ? args.deckId : undefined))
+        : typeof args.deckId === "string"
+          ? args.deckId
+          : undefined;
+    if (!deckId) return null;
+    return {
+      url: deckDeepLink(deckId),
+      label: "Open deck in Slides",
+      view: "editor",
+    };
+  },
 });

--- a/templates/slides/actions/create-deck.ts
+++ b/templates/slides/actions/create-deck.ts
@@ -4,6 +4,7 @@ import { and, eq } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
 import { writeAppState } from "@agent-native/core/application-state";
 import { assertAccess } from "@agent-native/core/sharing";
+import { buildDeepLink } from "@agent-native/core/server";
 import {
   getRequestUserEmail,
   getRequestOrgId,
@@ -13,6 +14,7 @@ import { ASPECT_RATIO_VALUES } from "../shared/aspect-ratios.js";
 import { getDeckUrl } from "./_app-url.js";
 import { normalizeSlidePadding } from "../app/lib/normalize-slide-padding.js";
 import { createDeckVersionSnapshot } from "../server/lib/deck-versions.js";
+import { slidesDeckMcpAppHtml, slidesMcpAppResourceMeta } from "./_mcp-apps.js";
 
 const SlideSchema = z.object({
   id: z.string().describe("Unique slide ID, e.g. 'slide-1'"),
@@ -38,6 +40,14 @@ const SlidesSchema = z.preprocess(
   (v) => (typeof v === "string" ? JSON.parse(v) : v),
   z.array(SlideSchema),
 );
+
+function deckDeepLink(deckId: string): string {
+  return buildDeepLink({
+    app: "slides",
+    view: "editor",
+    params: { deckId },
+  });
+}
 
 export default defineAction({
   description:
@@ -68,6 +78,14 @@ export default defineAction({
       .optional()
       .describe("Optional design system ID to link to the deck"),
   }),
+  mcpApp: {
+    resource: {
+      title: "Deck preview",
+      description: "Preview a generated slide deck inline.",
+      html: slidesDeckMcpAppHtml,
+      ...slidesMcpAppResourceMeta,
+    },
+  },
   http: false,
   run: async ({
     title,
@@ -133,6 +151,8 @@ export default defineAction({
         title,
         slideCount: slides.length,
         url: getDeckUrl(deckId),
+        deepLink: deckDeepLink(deckId),
+        slides,
       };
     }
 
@@ -183,6 +203,20 @@ export default defineAction({
       title,
       slideCount: slides.length,
       url: getDeckUrl(id),
+      deepLink: deckDeepLink(id),
+      slides,
+    };
+  },
+  link: ({ result }) => {
+    const id =
+      result && typeof result === "object"
+        ? (result as { id?: string }).id
+        : undefined;
+    if (!id) return null;
+    return {
+      url: deckDeepLink(id),
+      label: "Open deck in Slides",
+      view: "editor",
     };
   },
 });

--- a/templates/slides/actions/get-deck.ts
+++ b/templates/slides/actions/get-deck.ts
@@ -1,7 +1,9 @@
 import { defineAction } from "@agent-native/core";
+import { buildDeepLink } from "@agent-native/core/server";
 import { resolveAccess } from "@agent-native/core/sharing";
 import { z } from "zod";
 import "../server/db/index.js"; // ensure registerShareableResource runs
+import { slidesDeckMcpAppHtml, slidesMcpAppResourceMeta } from "./_mcp-apps.js";
 
 function stripHtml(html: string): string {
   return html
@@ -11,6 +13,14 @@ function stripHtml(html: string): string {
     .replace(/&#x[0-9a-f]+;/gi, "")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function deckDeepLink(deckId: string): string {
+  return buildDeepLink({
+    app: "slides",
+    view: "editor",
+    params: { deckId },
+  });
 }
 
 export default defineAction({
@@ -24,6 +34,14 @@ export default defineAction({
       .describe("Set to 'true' for compact output (slide summaries only)"),
   }),
   http: { method: "GET" },
+  mcpApp: {
+    resource: {
+      title: "Deck preview",
+      description: "Preview a Slides deck inline.",
+      html: slidesDeckMcpAppHtml,
+      ...slidesMcpAppResourceMeta,
+    },
+  },
   run: async (args) => {
     if (!args.id) {
       return "Error: --id is required.";
@@ -47,6 +65,7 @@ export default defineAction({
         slideCount: slides.length,
         slideNumbering:
           'User-visible slide numbers are 1-based and match the UI. "Slide 1" means slideNumber 1 / zeroBasedIndex 0. Use slideId for edits.',
+        deepLink: deckDeepLink(row.id),
         slides: slides.map((s: any, i: number) => ({
           slideNumber: i + 1,
           zeroBasedIndex: i,
@@ -67,6 +86,7 @@ export default defineAction({
         'User-visible slide numbers are 1-based and match the UI. "Slide 1" means slideNumber 1 / zeroBasedIndex 0. Use slideId for edits.',
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
+      deepLink: deckDeepLink(row.id),
       slides: slides.map((s: any, i: number) => ({
         slideNumber: i + 1,
         zeroBasedIndex: i,
@@ -75,6 +95,20 @@ export default defineAction({
         content: s.content,
         notes: s.notes ?? null,
       })),
+    };
+  },
+  link: ({ result, args }) => {
+    const id =
+      result && typeof result === "object"
+        ? (result as { id?: string }).id
+        : typeof args.id === "string"
+          ? args.id
+          : undefined;
+    if (!id) return null;
+    return {
+      url: deckDeepLink(id),
+      label: "Open deck in Slides",
+      view: "editor",
     };
   },
 });

--- a/templates/slides/actions/list-decks.ts
+++ b/templates/slides/actions/list-decks.ts
@@ -1,10 +1,15 @@
 import { defineAction } from "@agent-native/core";
+import { buildDeepLink } from "@agent-native/core/server";
 import { and, desc, eq } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
 import { accessFilter } from "@agent-native/core/sharing";
 import { z } from "zod";
 import { getDeckUrl } from "./_app-url.js";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
+
+function slidesDeepLink(): string {
+  return buildDeepLink({ app: "slides", view: "list" });
+}
 
 export default defineAction({
   description: "List all decks from the database with metadata.",
@@ -19,6 +24,11 @@ export default defineAction({
       .describe("Set to 'me' to list only decks created by the current user"),
   }),
   http: { method: "GET" },
+  link: () => ({
+    url: slidesDeepLink(),
+    label: "Open decks in Slides",
+    view: "list",
+  }),
   run: async (args) => {
     const db = getDb();
     const ownerEmail = getRequestUserEmail();

--- a/templates/slides/actions/update-slide.ts
+++ b/templates/slides/actions/update-slide.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core";
+import { buildDeepLink } from "@agent-native/core/server";
 import { getDbExec } from "@agent-native/core/db";
 import {
   hasCollabState,
@@ -16,6 +17,14 @@ import {
   awaitLayoutFitCheck,
   formatOverflowForTool,
 } from "./_await-fit-check.js";
+
+function deckDeepLink(deckId: string): string {
+  return buildDeepLink({
+    app: "slides",
+    view: "editor",
+    params: { deckId },
+  });
+}
 
 async function findCollabOrigin(): Promise<string | null> {
   const tryOrigins = [
@@ -209,6 +218,7 @@ export default defineAction({
       slideId,
       applied: applied || yjsAccepted,
       collabSynced: yjsAccepted,
+      deepLink: deckDeepLink(deckId),
     };
 
     if (fit.status === "overflows") {
@@ -224,5 +234,20 @@ export default defineAction({
     }
 
     return base;
+  },
+  link: ({ result, args }) => {
+    const deckId =
+      result && typeof result === "object"
+        ? ((result as { deckId?: string }).deckId ??
+          (typeof args.deckId === "string" ? args.deckId : undefined))
+        : typeof args.deckId === "string"
+          ? args.deckId
+          : undefined;
+    if (!deckId) return null;
+    return {
+      url: deckDeepLink(deckId),
+      label: "Open deck in Slides",
+      view: "editor",
+    };
   },
 });

--- a/templates/slides/server/plugins/core-routes.ts
+++ b/templates/slides/server/plugins/core-routes.ts
@@ -17,7 +17,7 @@ export default createCoreRoutesPlugin({
       return `/deck/${params.deckId}${suffix}${query}`;
     }
     if (view === "settings") return "/settings";
-    if (view === "editor" || view === "present") return "/";
+    if (view === "editor" || view === "present" || view === "list") return "/";
     return null;
   },
 });

--- a/templates/slides/server/plugins/core-routes.ts
+++ b/templates/slides/server/plugins/core-routes.ts
@@ -1,4 +1,23 @@
 import { createCoreRoutesPlugin } from "@agent-native/core/server";
 import { envKeys } from "../lib/env-config.js";
 
-export default createCoreRoutesPlugin({ envKeys });
+export default createCoreRoutesPlugin({
+  envKeys,
+  resolveOpenPath: ({ view, params }) => {
+    if (params.deckId) {
+      const slideNumber =
+        params.slideNumber ??
+        (params.slideIndex && Number.isFinite(Number(params.slideIndex))
+          ? String(Number(params.slideIndex) + 1)
+          : undefined);
+      const suffix = view === "present" ? "/present" : "";
+      const query = slideNumber
+        ? `?slide=${encodeURIComponent(slideNumber)}`
+        : "";
+      return `/deck/${params.deckId}${suffix}${query}`;
+    }
+    if (view === "settings") return "/settings";
+    if (view === "editor" || view === "present") return "/";
+    return null;
+  },
+});


### PR DESCRIPTION
## Summary
- preserve `mcpApp` metadata from static action discovery and fix hosted Codex MCP config generation for bearer-auth HTTP servers
- add inline MCP app renderers for Mail drafts, Analytics charts/analyses/dashboards, Design artifacts, and Slides decks/actions
- make Analytics chart media writes portable outside `/var/media`

## Validation
- `pnpm --filter @agent-native/core exec vitest --run src/server/action-discovery.spec.ts src/mcp/server.spec.ts src/mcp-client/index.spec.ts src/mcp-client/routes.spec.ts src/client/mcp-apps/McpAppRenderer.spec.ts src/cli/connect.spec.ts`
- `pnpm --filter @agent-native/core exec vitest --run src/mcp/connect-store.spec.ts src/mcp/connect-route.spec.ts src/mcp/build-server.verify-auth.spec.ts src/mcp/deep-link.spec.ts src/mcp/oauth-route.spec.ts`
- `pnpm --filter @agent-native/core typecheck`
- `pnpm --dir templates/mail typecheck`
- `pnpm --dir templates/mail exec vitest --run server/handlers/google-auth.spec.ts server/lib/google-auth.spec.ts server/lib/google-api.spec.ts`
- `pnpm --dir templates/analytics typecheck`
- Analytics local chart smoke generated media successfully with `AGENT_NATIVE_MEDIA_DIR=/tmp/agent-native-analytics-smoke`
- `pnpm --dir templates/design typecheck`
- `pnpm --dir templates/slides typecheck`
- `pnpm --dir templates/slides exec vitest --run actions/create-deck.test.ts actions/get-deck.test.ts actions/list-decks.test.ts actions/add-slide.test.ts actions/update-slide.test.ts`
- `pnpm prep` guard/format portions passed; two core Vitest files that timed out during the full concurrent run passed when rerun in isolation, and local `packages/desktop-app` typecheck still reports missing `@tailwindcss/vite` in this machine's install

## Live MCP/OAuth notes
- Verified hosted Analytics and Mail MCP tools are reachable as `steve@builder.io`
- Verified a fresh Analytics MCP OAuth flow reaches Google sign-in, returns to the Agent Native authorization screen with `mcp:read`, `mcp:write`, and `mcp:apps`, and redirects with an authorization code
- Found and fixed hosted Analytics chart generation failing on unwritable `/var/media`
