### PR TITLE
Fix auth cookie realms and workspace secrets

### DIFF
--- a/.changeset/auth-cookie-realms.md
+++ b/.changeset/auth-cookie-realms.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Isolate local dev auth cookies per app and stop first-party hosted apps from sharing incompatible agent-native.com session cookies.

--- a/.changeset/workspace-a2a-auth-secret.md
+++ b/.changeset/workspace-a2a-auth-secret.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Derive production workspace auth and OAuth signing secrets from A2A_SECRET when explicit auth secrets are not configured.

--- a/packages/core/docs/content/authentication.md
+++ b/packages/core/docs/content/authentication.md
@@ -49,9 +49,12 @@ subdomain deployments can opt into shared cookies with `COOKIE_DOMAIN`.
 First-party hosted apps at `*.agent-native.com` are different: each app has its
 own auth database, so `COOKIE_DOMAIN=.agent-native.com` is ignored by default
 and the app uses an isolated cookie namespace instead. Cross-app sign-in for
-those apps should go through [Cross-App SSO](/docs/cross-app-sso). If a
-first-party deployment intentionally shares one auth database across subdomains,
-set `AGENT_NATIVE_SHARE_COOKIE_DOMAIN=1` alongside `COOKIE_DOMAIN`.
+those apps should go through [Cross-App SSO](/docs/cross-app-sso). First-party
+deploys must provide `APP_NAME` or a derivable app URL (`APP_URL`, `URL`,
+`DEPLOY_PRIME_URL`, or `DEPLOY_URL`); otherwise startup fails instead of
+falling back to the shared `an_session` name. If a first-party deployment
+intentionally shares one auth database across subdomains, set
+`AGENT_NATIVE_SHARE_COOKIE_DOMAIN=1` alongside `COOKIE_DOMAIN`.
 
 ## QA Accounts {#qa-accounts}
 

--- a/packages/core/docs/content/authentication.md
+++ b/packages/core/docs/content/authentication.md
@@ -35,6 +35,24 @@ Better Auth routes are mounted at `/_agent-native/auth/ba/*`. The framework also
 - `POST /_agent-native/auth/register` — create account
 - `POST /_agent-native/auth/logout` — sign out
 
+## Cookie Realms {#cookie-realms}
+
+Standalone apps keep their framework session cookie isolated by app when an
+app slug is available (`APP_NAME`, or the package name in local dev). Better
+Auth keeps its production standalone cookie prefix stable as `an` so existing
+sessions are not renamed casually.
+
+Workspace mode (`AGENT_NATIVE_WORKSPACE=1`) uses one shared session realm
+because workspace apps share an origin and database. Custom same-database
+subdomain deployments can opt into shared cookies with `COOKIE_DOMAIN`.
+
+First-party hosted apps at `*.agent-native.com` are different: each app has its
+own auth database, so `COOKIE_DOMAIN=.agent-native.com` is ignored by default
+and the app uses an isolated cookie namespace instead. Cross-app sign-in for
+those apps should go through [Cross-App SSO](/docs/cross-app-sso). If a
+first-party deployment intentionally shares one auth database across subdomains,
+set `AGENT_NATIVE_SHARE_COOKIE_DOMAIN=1` alongside `COOKIE_DOMAIN`.
+
 ## QA Accounts {#qa-accounts}
 
 Local development and tests skip signup email verification by default, so you

--- a/packages/core/docs/content/security.md
+++ b/packages/core/docs/content/security.md
@@ -157,7 +157,7 @@ OAuth flows (Google, Atlassian, Zoom) sign their state envelope with a dedicated
 OAUTH_STATE_SECRET=$(openssl rand -hex 32)
 ```
 
-This used to fall back to `GOOGLE_CLIENT_SECRET` (a credential shared with Google) — a leak of the Google secret would have let attackers forge OAuth state envelopes. The dedicated key is independent of any third-party secret. If `OAUTH_STATE_SECRET` is unset, the framework falls back to `BETTER_AUTH_SECRET`; if both are unset, the OAuth flows fail in production.
+This used to fall back to `GOOGLE_CLIENT_SECRET` (a credential shared with Google) — a leak of the Google secret would have let attackers forge OAuth state envelopes. The dedicated key is independent of any third-party secret. If `OAUTH_STATE_SECRET` is unset, the framework falls back to `BETTER_AUTH_SECRET`; hosted workspace deploys can also derive a per-purpose OAuth key from the already-required `A2A_SECRET`. If none of those server secrets are available, OAuth flows fail in production.
 
 `redirect_uri` query parameters are also validated against an allowlist (same-origin + framework `/_agent-native/...` paths). Custom OAuth flows in templates should use the framework's `isAllowedOAuthRedirectUri()` helper before signing state.
 
@@ -177,8 +177,8 @@ Workspace-scope secret writes still require org owner/admin role regardless of t
 
 ### Auth & secrets
 
-- [ ] `BETTER_AUTH_SECRET` set to a random 32+ char string (`openssl rand -hex 32`)
-- [ ] `OAUTH_STATE_SECRET` set to a separate random 32+ char string (don't reuse `BETTER_AUTH_SECRET`)
+- [ ] `BETTER_AUTH_SECRET` set to a random 32+ char string (`openssl rand -hex 32`), unless this is a hosted workspace deploy deriving it from `A2A_SECRET`
+- [ ] `OAUTH_STATE_SECRET` set to a separate random 32+ char string (don't reuse `BETTER_AUTH_SECRET`), unless this is a hosted workspace deploy deriving it from `A2A_SECRET`
 - [ ] `A2A_SECRET` set on every app that calls or receives A2A traffic
 - [ ] `SECRETS_ENCRYPTION_KEY` set (or rely on the `BETTER_AUTH_SECRET` fallback)
 - [ ] `AUTH_SKIP_EMAIL_VERIFICATION` is **not** set in production (or set only on QA preview deploys)

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1455,6 +1455,54 @@ describe("server/auth", () => {
       expect(selectedTokens).toEqual(["stale-token", "fresh-token"]);
     });
 
+    it("migrates a legacy shared framework cookie into the isolated cookie name", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("COOKIE_DOMAIN", ".agent-native.com");
+      vi.stubEnv("APP_NAME", "slides");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+
+      const mockExecute = vi.fn().mockImplementation((query: any) => {
+        const sql = typeof query === "string" ? query : query.sql;
+        const args = typeof query === "string" ? undefined : query.args;
+        if (
+          typeof sql === "string" &&
+          sql.includes("SELECT") &&
+          args?.[0] === "legacy-token"
+        ) {
+          return {
+            rows: [{ email: "user@gmail.com", created_at: Date.now() }],
+          };
+        }
+        return { rows: [] };
+      });
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => true,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+
+      const { getSession } = await import("./auth.js");
+      const event = createMockEvent({
+        headers: {
+          cookie: "an_session=legacy-token",
+          "x-forwarded-proto": "https",
+        },
+      });
+
+      expect(await getSession(event)).toEqual({
+        email: "user@gmail.com",
+        token: "legacy-token",
+      });
+      const setCookie = event.res.headers.get("set-cookie") ?? "";
+      expect(setCookie).toContain("an_session=");
+      expect(setCookie).toContain("Max-Age=0");
+      expect(setCookie).toContain("Domain=.agent-native.com");
+      expect(setCookie).toContain("an_session_slides=legacy-token");
+    });
+
     it("marks promoted cross-site session cookies secure on forwarded HTTPS requests", async () => {
       vi.stubEnv("NODE_ENV", "production");
       delete process.env.APP_URL;

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -307,6 +307,69 @@ describe("server/auth", () => {
       expect(rejectedState.returnUrl).toBeUndefined();
     });
 
+    it("uses a derived A2A secret for Google OAuth state in production workspaces", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
+      vi.stubEnv("GOOGLE_CLIENT_ID", "google-client");
+      vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-secret");
+      vi.stubEnv("A2A_SECRET", "workspace-root-secret");
+      vi.stubEnv("APP_URL", "https://agent-workspace.builder.io");
+      delete process.env.OAUTH_STATE_SECRET;
+      delete process.env.BETTER_AUTH_SECRET;
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+
+      vi.doMock("./better-auth-instance.js", () => ({
+        getBetterAuth: vi.fn(async () => ({
+          handler: vi.fn(async () => new Response("{}")),
+          api: {
+            getSession: vi.fn(async () => null),
+            signInEmail: vi.fn(),
+            signUpEmail: vi.fn(),
+            signOut: vi.fn(),
+            listOrganizations: vi.fn(),
+          },
+        })),
+        getBetterAuthSync: vi.fn(() => undefined),
+      }));
+
+      const { autoMountAuth } = await import("./auth.js");
+      const { decodeOAuthState } = await import("./google-oauth.js");
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const authUrlHandler = app.use.mock.calls.find(
+        (call: any[]) => call[0] === "/_agent-native/google/auth-url",
+      )?.[1];
+      const result = await authUrlHandler(
+        createMockEvent({
+          path: "/_agent-native/google/auth-url",
+          headers: {
+            host: "agent-workspace.builder.io",
+            "x-forwarded-proto": "https",
+          },
+        }),
+      );
+      const stateParam = new URL(result.url).searchParams.get("state");
+
+      expect(
+        decodeOAuthState(
+          stateParam || undefined,
+          "https://agent-workspace.builder.io/_agent-native/google/callback",
+        ).redirectUri,
+      ).toBe(
+        "https://agent-workspace.builder.io/_agent-native/google/callback",
+      );
+
+      vi.stubEnv("A2A_SECRET", "different-root-secret");
+      expect(
+        decodeOAuthState(
+          stateParam || undefined,
+          "https://fallback.example/_agent-native/google/callback",
+        ).redirectUri,
+      ).toBe("https://fallback.example/_agent-native/google/callback");
+    });
+
     it("mounts auth when ACCESS_TOKEN is set in production", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("ACCESS_TOKEN", "my-secret");
@@ -2160,7 +2223,41 @@ describe("server/auth", () => {
       expect(setCookie).toContain("Secure");
     });
 
-    it("clears stale host-only cookies before setting a domain shared session", async () => {
+    it("clears stale host-only cookies before setting a custom-domain shared session", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("COOKIE_DOMAIN", ".example.com");
+      vi.stubEnv("APP_NAME", "slides");
+
+      const mockExecute = vi.fn(async () => ({ rows: [] }));
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => false,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+
+      const { createOAuthSession } = await import("./google-oauth.js");
+      const event = createMockEvent({
+        headers: {
+          "x-forwarded-proto": "https",
+          host: "slides.example.com",
+        },
+      });
+
+      const result = await createOAuthSession(event, "user@gmail.com", {
+        hasProductionSession: false,
+      });
+
+      const setCookie = event.res.headers.get("set-cookie") ?? "";
+      expect(setCookie).toContain("an_session=");
+      expect(setCookie).toContain("Max-Age=0");
+      expect(setCookie).toContain("Domain=.example.com");
+      expect(setCookie).toContain(result.sessionToken);
+      expect(setCookie).toContain("an_session_slides=");
+    });
+
+    it("ignores first-party shared cookie domains and sets an isolated app session", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("COOKIE_DOMAIN", ".agent-native.com");
       vi.stubEnv("APP_NAME", "slides");
@@ -2190,8 +2287,15 @@ describe("server/auth", () => {
       expect(setCookie).toContain("an_session=");
       expect(setCookie).toContain("Max-Age=0");
       expect(setCookie).toContain("Domain=.agent-native.com");
-      expect(setCookie).toContain(result.sessionToken);
-      expect(setCookie).toContain("an_session_slides=");
+      expect(setCookie).toContain(`an_session_slides=${result.sessionToken}`);
+      const sessionCookie = setCookie
+        .split(/,(?=\s*[^=]+=)/)
+        .map((value) => value.trim())
+        .find((value) =>
+          value.startsWith(`an_session_slides=${result.sessionToken}`),
+        );
+      expect(sessionCookie).toBeTruthy();
+      expect(sessionCookie).not.toContain("Domain=.agent-native.com");
     });
   });
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -339,7 +339,24 @@ function getCookieValues(event: H3Event, name: string): string[] {
 }
 
 export function getFrameworkSessionCookieValues(event: H3Event): string[] {
-  return getCookieValues(event, COOKIE_NAME);
+  return getFrameworkSessionCookieEntries(event).map((entry) => entry.value);
+}
+
+function getFrameworkSessionCookieEntries(
+  event: H3Event,
+): Array<{ name: string; value: string }> {
+  const entries: Array<{ name: string; value: string }> = [];
+  const seenValues = new Set<string>();
+
+  for (const name of frameworkSessionCookieNamesToClear()) {
+    for (const value of getCookieValues(event, name)) {
+      if (seenValues.has(value)) continue;
+      seenValues.add(value);
+      entries.push({ name, value });
+    }
+  }
+
+  return entries;
 }
 
 function frameworkSessionCookieNamesToClear(): string[] {
@@ -364,9 +381,12 @@ export function clearFrameworkSessionCookies(event: H3Event): void {
 async function getLegacyCookieSession(
   event: H3Event,
 ): Promise<AuthSession | null> {
-  for (const cookie of getFrameworkSessionCookieValues(event)) {
-    const email = await getSessionEmail(cookie);
-    if (email) return { email, token: cookie };
+  for (const { name, value } of getFrameworkSessionCookieEntries(event)) {
+    const email = await getSessionEmail(value);
+    if (email) {
+      if (name !== COOKIE_NAME) setFrameworkSessionCookie(event, value);
+      return { email, token: value };
+    }
   }
   return null;
 }
@@ -1200,7 +1220,7 @@ function shouldBypassAuthForBuilderConnect(event: H3Event, p: string): boolean {
     // session-lost popup case) — when a session IS present, the normal
     // guard runs and the callback handler cross-checks the state owner
     // against the session.
-    const hasSession = Boolean(getCookie(event, COOKIE_NAME));
+    const hasSession = getFrameworkSessionCookieValues(event).length > 0;
     if (hasSession) return false;
     return Boolean(
       verifyBuilderCallbackStateAndGetOwner(state) ||

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -94,6 +94,7 @@ import {
   workspaceAppRouteAccessFromEnv,
   type WorkspaceAppAudience,
 } from "../shared/workspace-app-audience.js";
+import { resolveAuthCookieNamespace } from "./cookie-namespace.js";
 import {
   BUILDER_CONNECT_OWNER_COOKIE,
   BUILDER_CONNECT_PARAM,
@@ -260,7 +261,8 @@ export interface AuthOptions {
  * deploys on a shared domain), they would otherwise stomp on each other's
  * `an_session` cookie and ping-pong each other into a logged-out state.
  *
- * When `APP_NAME` is set, suffix the cookie so each app gets its own slot.
+ * When an isolated app slug is resolved, suffix the cookie so each app gets
+ * its own slot.
  *
  * Workspace exception: in workspace mode (`AGENT_NATIVE_WORKSPACE=1`),
  * every app shares the same origin AND the same DB, and cross-app SSO is
@@ -271,41 +273,27 @@ export interface AuthOptions {
  * exchange relies on — see `desktop-exchange` and `oauthCallbackResponse`)
  * is recognised by every app in the workspace.
  *
- * Cross-subdomain exception: when `COOKIE_DOMAIN` is set (e.g.
- * `.agent-native.com` for first-party deploys where each app is its own
- * subdomain — mail.agent-native.com, calendar.agent-native.com, …),
- * use the unsuffixed `an_session` and emit `Domain=<COOKIE_DOMAIN>` so
- * the cookie is shared across every subdomain. Signing into one app
- * signs the user into all of them. Per-app suffixes would defeat the
- * shared cookie since each subdomain reads a different name.
+ * Cross-subdomain exception: when `COOKIE_DOMAIN` is set for a custom domain,
+ * use the unsuffixed `an_session` and emit `Domain=<COOKIE_DOMAIN>` so the
+ * cookie is shared across every subdomain. First-party `*.agent-native.com`
+ * apps are deliberately excluded from that behavior by default because each
+ * hosted app has its own auth database; they use Dispatch identity federation
+ * instead of a shared browser cookie.
  */
-const APP_NAME_SLUG = (process.env.APP_NAME || "")
-  .toLowerCase()
-  .replace(/[^a-z0-9]+/g, "_")
-  .replace(/^_+|_+$/g, "");
-const IS_WORKSPACE_MODE = process.env.AGENT_NATIVE_WORKSPACE === "1";
+const AUTH_COOKIE_NAMESPACE = resolveAuthCookieNamespace();
 
 /**
  * When set, the framework session cookie is shared across every subdomain
- * matching this domain (e.g. `.agent-native.com`). Reads `COOKIE_DOMAIN`.
- * Returns undefined when unset so cookies stay scoped to the origin host.
+ * matching this domain. Returns undefined when unset or deliberately ignored
+ * for first-party hosted apps, so cookies stay scoped to the origin host.
  */
 export function getCookieDomain(): string | undefined {
-  const raw = process.env.COOKIE_DOMAIN;
-  if (!raw) return undefined;
-  const trimmed = raw.trim();
-  return trimmed || undefined;
+  return AUTH_COOKIE_NAMESPACE.frameworkCookieDomain;
 }
 
-const HAS_COOKIE_DOMAIN = !!getCookieDomain();
-
-export const COOKIE_NAME = HAS_COOKIE_DOMAIN
-  ? "an_session"
-  : IS_WORKSPACE_MODE
-    ? "an_session_workspace"
-    : APP_NAME_SLUG
-      ? `an_session_${APP_NAME_SLUG}`
-      : "an_session";
+export const COOKIE_NAME = AUTH_COOKIE_NAMESPACE.frameworkCookieName;
+export const BETTER_AUTH_COOKIE_PREFIX =
+  AUTH_COOKIE_NAMESPACE.betterAuthCookiePrefix;
 
 /**
  * Cookie domain attribute spread into every `setCookie`/`deleteCookie`.
@@ -355,19 +343,15 @@ export function getFrameworkSessionCookieValues(event: H3Event): string[] {
 }
 
 function frameworkSessionCookieNamesToClear(): string[] {
-  const names = new Set([COOKIE_NAME]);
-  if (APP_NAME_SLUG) names.add(`an_session_${APP_NAME_SLUG}`);
-  return [...names];
+  return AUTH_COOKIE_NAMESPACE.frameworkCookieNamesToClear;
 }
 
 function deleteCookieFromEveryScope(event: H3Event, name: string): void {
-  // Clear host-only cookies first. When COOKIE_DOMAIN was introduced, stale
-  // host-only `an_session` cookies could shadow the new domain cookie because
-  // browsers send older same-path duplicates first.
+  // Clear host-only cookies first. Then clear any configured domain scope so
+  // stale shared cookies stop shadowing isolated app sessions.
   deleteCookie(event, name, { path: "/" });
-  const domainAttrs = cookieDomainAttrs();
-  if (domainAttrs.domain) {
-    deleteCookie(event, name, { path: "/", ...domainAttrs });
+  for (const domain of AUTH_COOKIE_NAMESPACE.frameworkCookieDomainsToClear) {
+    deleteCookie(event, name, { path: "/", domain });
   }
 }
 

--- a/packages/core/src/server/better-auth-instance.spec.ts
+++ b/packages/core/src/server/better-auth-instance.spec.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { getAuthSecret } from "./better-auth-instance.js";
+import { deriveServerSecret } from "./derived-secret.js";
 
 describe("resolveAuthSecret", () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
     delete process.env.BETTER_AUTH_SECRET;
+    delete process.env.A2A_SECRET;
+    delete process.env.AGENT_NATIVE_WORKSPACE;
+    delete process.env.VITE_AGENT_NATIVE_WORKSPACE;
     delete process.env.NODE_ENV;
   });
 
@@ -24,6 +28,17 @@ describe("resolveAuthSecret", () => {
   it("throws in production when BETTER_AUTH_SECRET is missing", () => {
     process.env.NODE_ENV = "production";
     expect(() => getAuthSecret()).toThrow(/BETTER_AUTH_SECRET is not set/);
+  });
+
+  it("derives a production workspace auth secret from A2A_SECRET", () => {
+    process.env.NODE_ENV = "production";
+    process.env.AGENT_NATIVE_WORKSPACE = "1";
+    process.env.A2A_SECRET = "workspace-root-secret";
+
+    expect(getAuthSecret()).toBe(
+      deriveServerSecret("workspace-root-secret", "better-auth"),
+    );
+    expect(getAuthSecret()).not.toBe("workspace-root-secret");
   });
 
   it("includes a sample value and openssl command in the prod error", () => {

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -23,6 +23,8 @@ import { acceptPendingInvitationsForEmail } from "../org/accept-pending.js";
 import { autoJoinDomainMatchingOrgs } from "../org/auto-join-domain.js";
 import { saveOAuthTokens } from "../oauth-tokens/store.js";
 import { identify, track } from "../tracking/index.js";
+import { resolveAuthCookieNamespace } from "./cookie-namespace.js";
+import { getWorkspaceA2ADerivedSecret } from "./derived-secret.js";
 import {
   getDialect,
   getDatabaseUrl,
@@ -51,11 +53,14 @@ import {
  *
  * Resolution order:
  *   1. `BETTER_AUTH_SECRET` env var — explicit, recommended for prod.
- *   2. `.env.local` in the template cwd — a per-workspace persistent secret
+ *   2. Hosted workspace deploys can derive a per-purpose secret from the
+ *      already-required `A2A_SECRET` root. This keeps fresh workspace branches
+ *      bootable without reusing the raw A2A key as a cookie-signing key.
+ *   3. `.env.local` in the template cwd — a per-workspace persistent secret
  *      that the framework writes once on first boot when no secret is set.
  *      Gitignored by convention (`.env*` in template .gitignore files), so
  *      it's safe to persist credentials here.
- *   3. Generate a new random 32-byte hex, write it to `.env.local`, and use
+ *   4. Generate a new random 32-byte hex, write it to `.env.local`, and use
  *      it. Subsequent restarts re-read the same file — so session cookies
  *      signed by a previous boot remain valid across dev-server restarts.
  *
@@ -70,12 +75,15 @@ import {
  */
 function resolveAuthSecret(): string {
   if (process.env.BETTER_AUTH_SECRET) return process.env.BETTER_AUTH_SECRET;
+  const workspaceDerivedSecret = getWorkspaceA2ADerivedSecret("better-auth");
+  if (workspaceDerivedSecret) return workspaceDerivedSecret;
 
-  // In production, never auto-generate or fall back. A regenerated/derived
-  // secret invalidates every signed session cookie on the next cold start
-  // (serverless filesystems aren't persistent), and the legacy hardcoded
-  // fallback is identical across every deploy that hits it — both are
-  // serious enough to fail the boot loudly so the deployer notices.
+  // In production, beyond the workspace A2A-derived fallback above, never
+  // auto-generate or use legacy fallbacks. A generated secret invalidates every
+  // signed session cookie on the next cold start (serverless filesystems
+  // aren't persistent), and the legacy hardcoded fallback is identical across
+  // every deploy that hits it — both are serious enough to fail the boot loudly
+  // so the deployer notices.
   if (process.env.NODE_ENV === "production") {
     const sample = crypto.randomBytes(32).toString("hex");
     throw new Error(
@@ -86,7 +94,9 @@ function resolveAuthSecret(): string {
         "Generate your own with `openssl rand -hex 32`. If you already have a " +
         "running deploy on the legacy hardcoded fallback and need to preserve " +
         "existing sessions, set BETTER_AUTH_SECRET=agent-native-local-dev-secret-k9x2m7q4w8 " +
-        "first, then rotate to a real value.",
+        "first, then rotate to a real value. Hosted workspace deploys may also " +
+        "set A2A_SECRET; agent-native derives a per-purpose Better Auth secret " +
+        "from that workspace root secret.",
     );
   }
 
@@ -680,6 +690,7 @@ async function createBetterAuthInstance(
   const secret = resolveAuthSecret();
 
   const appUrl = getAppProductionUrl();
+  const cookieNamespace = resolveAuthCookieNamespace();
   const requireEmailVerification =
     isEmailConfigured() && !shouldSkipEmailVerification();
 
@@ -845,7 +856,7 @@ async function createBetterAuthInstance(
       },
     },
     advanced: {
-      cookiePrefix: "an",
+      cookiePrefix: cookieNamespace.betterAuthCookiePrefix,
       // Emit `SameSite=None; Secure` when the app is served over HTTPS so
       // session cookies are delivered inside third-party iframes (e.g. the
       // Builder.io editor). Plain-HTTP dev keeps the default (Lax) because
@@ -859,16 +870,15 @@ async function createBetterAuthInstance(
             },
           }
         : {}),
-      // When `COOKIE_DOMAIN` is set, share Better Auth's session cookie
-      // across every subdomain matching that domain. Pairs with the legacy
-      // framework cookie's matching `Domain=` attribute (auth.ts) so that
-      // signing into one first-party app (e.g. mail.agent-native.com)
-      // signs the user into all sibling apps without re-authenticating.
-      ...(process.env.COOKIE_DOMAIN
+      // When an effective shared cookie domain is set, share Better Auth's
+      // session cookie across that domain. First-party `*.agent-native.com`
+      // apps intentionally do not use this path because their auth DBs are
+      // separate; Dispatch identity federation handles cross-app sign-in.
+      ...(cookieNamespace.betterAuthCookieDomain
         ? {
             crossSubDomainCookies: {
               enabled: true,
-              domain: process.env.COOKIE_DOMAIN,
+              domain: cookieNamespace.betterAuthCookieDomain,
             },
           }
         : {}),

--- a/packages/core/src/server/cookie-namespace.spec.ts
+++ b/packages/core/src/server/cookie-namespace.spec.ts
@@ -107,11 +107,19 @@ describe("resolveAuthCookieNamespace", () => {
     });
   });
 
+  it("fails closed when a first-party isolated app has no identifier", () => {
+    expect(() =>
+      resolveAuthCookieNamespace({
+        NODE_ENV: "production",
+        COOKIE_DOMAIN: ".agent-native.com",
+      }),
+    ).toThrow(/requires an app identifier/);
+  });
+
   it("allows first-party shared cookies only with an explicit opt-in", () => {
     expect(
       resolveAuthCookieNamespace({
         NODE_ENV: "production",
-        APP_NAME: "dispatch",
         COOKIE_DOMAIN: ".agent-native.com",
         AGENT_NATIVE_SHARE_COOKIE_DOMAIN: "1",
       }),

--- a/packages/core/src/server/cookie-namespace.spec.ts
+++ b/packages/core/src/server/cookie-namespace.spec.ts
@@ -107,6 +107,22 @@ describe("resolveAuthCookieNamespace", () => {
     });
   });
 
+  it.each(["BETTER_AUTH_URL", "VITE_BETTER_AUTH_URL"])(
+    "can derive the first-party slug from %s when APP_NAME is missing",
+    (key) => {
+      expect(
+        resolveAuthCookieNamespace({
+          NODE_ENV: "production",
+          COOKIE_DOMAIN: ".agent-native.com",
+          [key]: "https://mail.agent-native.com",
+        }),
+      ).toMatchObject({
+        frameworkCookieName: "an_session_mail",
+        betterAuthCookiePrefix: "an_mail",
+      });
+    },
+  );
+
   it("fails closed when a first-party isolated app has no identifier", () => {
     expect(() =>
       resolveAuthCookieNamespace({

--- a/packages/core/src/server/cookie-namespace.spec.ts
+++ b/packages/core/src/server/cookie-namespace.spec.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveAuthCookieNamespace } from "./cookie-namespace.js";
+
+describe("resolveAuthCookieNamespace", () => {
+  it("isolates standalone local dev cookies with npm_package_name", () => {
+    expect(
+      resolveAuthCookieNamespace({
+        NODE_ENV: "development",
+        npm_package_name: "calendar",
+      }),
+    ).toMatchObject({
+      frameworkCookieName: "an_session_calendar",
+      betterAuthCookiePrefix: "an_calendar",
+      betterAuthCookieDomain: undefined,
+    });
+  });
+
+  it("falls back to package.json name for standalone local dev", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "an-cookie-test-"));
+    fs.writeFileSync(
+      path.join(dir, "package.json"),
+      JSON.stringify({ name: "@acme/mail-app" }),
+    );
+
+    expect(
+      resolveAuthCookieNamespace({ NODE_ENV: "development" }, dir),
+    ).toMatchObject({
+      frameworkCookieName: "an_session_acme_mail_app",
+      betterAuthCookiePrefix: "an_acme_mail_app",
+    });
+  });
+
+  it("keeps Better Auth's production standalone prefix stable", () => {
+    expect(
+      resolveAuthCookieNamespace({
+        NODE_ENV: "production",
+        APP_NAME: "mail",
+      }),
+    ).toMatchObject({
+      frameworkCookieName: "an_session_mail",
+      betterAuthCookiePrefix: "an",
+      betterAuthCookieDomain: undefined,
+    });
+  });
+
+  it("keeps workspace mode in one shared auth realm", () => {
+    expect(
+      resolveAuthCookieNamespace({
+        NODE_ENV: "production",
+        APP_NAME: "mail",
+        AGENT_NATIVE_WORKSPACE: "1",
+      }),
+    ).toMatchObject({
+      frameworkCookieName: "an_session_workspace",
+      betterAuthCookiePrefix: "an",
+      betterAuthCookieDomain: undefined,
+    });
+  });
+
+  it("preserves explicit shared cookie domains for custom same-DB deploys", () => {
+    expect(
+      resolveAuthCookieNamespace({
+        NODE_ENV: "production",
+        APP_NAME: "mail",
+        COOKIE_DOMAIN: ".example.com",
+      }),
+    ).toMatchObject({
+      frameworkCookieName: "an_session",
+      frameworkCookieDomain: ".example.com",
+      betterAuthCookiePrefix: "an",
+      betterAuthCookieDomain: ".example.com",
+    });
+  });
+
+  it("isolates first-party agent-native.com apps even when COOKIE_DOMAIN is configured", () => {
+    const namespace = resolveAuthCookieNamespace({
+      NODE_ENV: "production",
+      APP_NAME: "mail",
+      COOKIE_DOMAIN: ".agent-native.com",
+    });
+
+    expect(namespace).toMatchObject({
+      frameworkCookieName: "an_session_mail",
+      frameworkCookieDomain: undefined,
+      betterAuthCookiePrefix: "an_mail",
+      betterAuthCookieDomain: undefined,
+    });
+    expect(namespace.frameworkCookieNamesToClear).toContain("an_session");
+    expect(namespace.frameworkCookieDomainsToClear).toContain(
+      ".agent-native.com",
+    );
+  });
+
+  it("can derive the first-party slug from APP_URL when APP_NAME is missing", () => {
+    expect(
+      resolveAuthCookieNamespace({
+        NODE_ENV: "production",
+        COOKIE_DOMAIN: ".agent-native.com",
+        APP_URL: "https://slides.agent-native.com",
+      }),
+    ).toMatchObject({
+      frameworkCookieName: "an_session_slides",
+      betterAuthCookiePrefix: "an_slides",
+    });
+  });
+
+  it("allows first-party shared cookies only with an explicit opt-in", () => {
+    expect(
+      resolveAuthCookieNamespace({
+        NODE_ENV: "production",
+        APP_NAME: "dispatch",
+        COOKIE_DOMAIN: ".agent-native.com",
+        AGENT_NATIVE_SHARE_COOKIE_DOMAIN: "1",
+      }),
+    ).toMatchObject({
+      frameworkCookieName: "an_session",
+      frameworkCookieDomain: ".agent-native.com",
+      betterAuthCookiePrefix: "an",
+      betterAuthCookieDomain: ".agent-native.com",
+    });
+  });
+});

--- a/packages/core/src/server/cookie-namespace.ts
+++ b/packages/core/src/server/cookie-namespace.ts
@@ -30,9 +30,13 @@ export function resolveAuthCookieNamespace(
   const shareFirstPartyCookieDomain = isTruthy(
     env.AGENT_NATIVE_SHARE_COOKIE_DOMAIN,
   );
+  const firstPartyIsolatedRealm =
+    isFirstPartyCookieDomain &&
+    !shareFirstPartyCookieDomain &&
+    !isWorkspaceMode;
   const frameworkCookieDomain =
     configuredCookieDomain && !isWorkspaceMode
-      ? isFirstPartyCookieDomain && !shareFirstPartyCookieDomain
+      ? firstPartyIsolatedRealm
         ? undefined
         : configuredCookieDomain
       : undefined;
@@ -43,11 +47,19 @@ export function resolveAuthCookieNamespace(
   const localAppSlug = localIsolatedRealm
     ? slugifyAppName(env.npm_package_name || readPackageJsonName(cwd))
     : "";
-  const firstPartyAppSlug =
-    isFirstPartyCookieDomain && !frameworkCookieDomain
-      ? explicitAppSlug || readFirstPartyAppSlugFromUrl(env)
-      : "";
-  const appSlug = explicitAppSlug || firstPartyAppSlug || localAppSlug;
+  const firstPartyUrlAppSlug = firstPartyIsolatedRealm
+    ? readFirstPartyAppSlugFromUrl(env)
+    : "";
+  const appSlug = explicitAppSlug || firstPartyUrlAppSlug || localAppSlug;
+
+  if (firstPartyIsolatedRealm && !appSlug) {
+    throw new Error(
+      "[agent-native] COOKIE_DOMAIN=.agent-native.com requires an app identifier " +
+        "so first-party auth cookies stay isolated. Set APP_NAME, APP_URL, URL, " +
+        "DEPLOY_PRIME_URL, or DEPLOY_URL; only set AGENT_NATIVE_SHARE_COOKIE_DOMAIN=1 " +
+        "when every subdomain intentionally shares one auth database.",
+    );
+  }
 
   const frameworkCookieName = frameworkCookieDomain
     ? "an_session"
@@ -58,9 +70,7 @@ export function resolveAuthCookieNamespace(
         : "an_session";
 
   const isolatedBetterAuthPrefix =
-    !!appSlug &&
-    (localIsolatedRealm ||
-      (isFirstPartyCookieDomain && !frameworkCookieDomain && !isWorkspaceMode));
+    !!appSlug && (localIsolatedRealm || firstPartyIsolatedRealm);
 
   const frameworkCookieNamesToClear = new Set<string>([
     frameworkCookieName,

--- a/packages/core/src/server/cookie-namespace.ts
+++ b/packages/core/src/server/cookie-namespace.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const FIRST_PARTY_COOKIE_DOMAIN = "agent-native.com";
+
+export interface AuthCookieNamespace {
+  appSlug: string;
+  configuredCookieDomain?: string;
+  frameworkCookieDomain?: string;
+  frameworkCookieName: string;
+  frameworkCookieNamesToClear: string[];
+  frameworkCookieDomainsToClear: string[];
+  betterAuthCookiePrefix: string;
+  betterAuthCookieDomain?: string;
+  isWorkspaceMode: boolean;
+  isFirstPartyCookieDomain: boolean;
+}
+
+export function resolveAuthCookieNamespace(
+  env: Record<string, string | undefined> = process.env,
+  cwd = process.cwd(),
+): AuthCookieNamespace {
+  const isWorkspaceMode =
+    env.AGENT_NATIVE_WORKSPACE === "1" ||
+    env.VITE_AGENT_NATIVE_WORKSPACE === "1";
+  const configuredCookieDomain = normalizeCookieDomain(env.COOKIE_DOMAIN);
+  const isFirstPartyCookieDomain =
+    normalizeDomainForCompare(configuredCookieDomain) ===
+    FIRST_PARTY_COOKIE_DOMAIN;
+  const shareFirstPartyCookieDomain = isTruthy(
+    env.AGENT_NATIVE_SHARE_COOKIE_DOMAIN,
+  );
+  const frameworkCookieDomain =
+    configuredCookieDomain && !isWorkspaceMode
+      ? isFirstPartyCookieDomain && !shareFirstPartyCookieDomain
+        ? undefined
+        : configuredCookieDomain
+      : undefined;
+  const localIsolatedRealm =
+    env.NODE_ENV !== "production" && !isWorkspaceMode && !frameworkCookieDomain;
+
+  const explicitAppSlug = slugifyAppName(env.APP_NAME || "");
+  const localAppSlug = localIsolatedRealm
+    ? slugifyAppName(env.npm_package_name || readPackageJsonName(cwd))
+    : "";
+  const firstPartyAppSlug =
+    isFirstPartyCookieDomain && !frameworkCookieDomain
+      ? explicitAppSlug || readFirstPartyAppSlugFromUrl(env)
+      : "";
+  const appSlug = explicitAppSlug || firstPartyAppSlug || localAppSlug;
+
+  const frameworkCookieName = frameworkCookieDomain
+    ? "an_session"
+    : isWorkspaceMode
+      ? "an_session_workspace"
+      : appSlug
+        ? `an_session_${appSlug}`
+        : "an_session";
+
+  const isolatedBetterAuthPrefix =
+    !!appSlug &&
+    (localIsolatedRealm ||
+      (isFirstPartyCookieDomain && !frameworkCookieDomain && !isWorkspaceMode));
+
+  const frameworkCookieNamesToClear = new Set<string>([
+    frameworkCookieName,
+    "an_session",
+  ]);
+  if (appSlug) frameworkCookieNamesToClear.add(`an_session_${appSlug}`);
+  if (isWorkspaceMode) frameworkCookieNamesToClear.add("an_session_workspace");
+
+  const frameworkCookieDomainsToClear = configuredCookieDomain
+    ? [configuredCookieDomain]
+    : [];
+
+  return {
+    appSlug,
+    configuredCookieDomain,
+    frameworkCookieDomain,
+    frameworkCookieName,
+    frameworkCookieNamesToClear: [...frameworkCookieNamesToClear],
+    frameworkCookieDomainsToClear,
+    betterAuthCookiePrefix: isolatedBetterAuthPrefix ? `an_${appSlug}` : "an",
+    betterAuthCookieDomain: frameworkCookieDomain,
+    isWorkspaceMode,
+    isFirstPartyCookieDomain,
+  };
+}
+
+function readPackageJsonName(cwd: string): string {
+  try {
+    const raw = fs.readFileSync(path.join(cwd, "package.json"), "utf8");
+    const parsed = JSON.parse(raw) as { name?: unknown };
+    return typeof parsed.name === "string" ? parsed.name : "";
+  } catch {
+    return "";
+  }
+}
+
+function readFirstPartyAppSlugFromUrl(
+  env: Record<string, string | undefined>,
+): string {
+  for (const key of ["APP_URL", "URL", "DEPLOY_PRIME_URL", "DEPLOY_URL"]) {
+    const raw = env[key];
+    if (!raw) continue;
+    try {
+      const hostname = new URL(raw).hostname.toLowerCase();
+      if (
+        hostname.endsWith(`.${FIRST_PARTY_COOKIE_DOMAIN}`) &&
+        hostname !== `www.${FIRST_PARTY_COOKIE_DOMAIN}`
+      ) {
+        return slugifyAppName(
+          hostname.slice(0, -`.${FIRST_PARTY_COOKIE_DOMAIN}`.length),
+        );
+      }
+    } catch {
+      // Ignore malformed platform URLs.
+    }
+  }
+  return "";
+}
+
+function normalizeCookieDomain(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function normalizeDomainForCompare(value: string | undefined): string {
+  return (value || "").trim().toLowerCase().replace(/^\./, "");
+}
+
+function slugifyAppName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function isTruthy(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return !!normalized && !["0", "false", "no", "off"].includes(normalized);
+}

--- a/packages/core/src/server/cookie-namespace.ts
+++ b/packages/core/src/server/cookie-namespace.ts
@@ -110,7 +110,14 @@ function readPackageJsonName(cwd: string): string {
 function readFirstPartyAppSlugFromUrl(
   env: Record<string, string | undefined>,
 ): string {
-  for (const key of ["APP_URL", "URL", "DEPLOY_PRIME_URL", "DEPLOY_URL"]) {
+  for (const key of [
+    "APP_URL",
+    "BETTER_AUTH_URL",
+    "VITE_BETTER_AUTH_URL",
+    "URL",
+    "DEPLOY_PRIME_URL",
+    "DEPLOY_URL",
+  ]) {
     const raw = env[key];
     if (!raw) continue;
     try {

--- a/packages/core/src/server/derived-secret.ts
+++ b/packages/core/src/server/derived-secret.ts
@@ -1,0 +1,28 @@
+import crypto from "node:crypto";
+
+const DERIVED_SECRET_PREFIX = "agent-native:derived-secret:v1";
+
+function isWorkspaceRuntime(): boolean {
+  return (
+    process.env.AGENT_NATIVE_WORKSPACE === "1" ||
+    process.env.VITE_AGENT_NATIVE_WORKSPACE === "1"
+  );
+}
+
+export function deriveServerSecret(
+  rootSecret: string,
+  purpose: string,
+): string {
+  return crypto
+    .createHmac("sha256", rootSecret)
+    .update(`${DERIVED_SECRET_PREFIX}:${purpose}`)
+    .digest("hex");
+}
+
+export function getWorkspaceA2ADerivedSecret(
+  purpose: "better-auth" | "oauth-state" | "short-lived-token",
+): string | undefined {
+  if (!isWorkspaceRuntime()) return undefined;
+  const rootSecret = process.env.A2A_SECRET?.trim();
+  return rootSecret ? deriveServerSecret(rootSecret, purpose) : undefined;
+}

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -22,6 +22,7 @@ import {
   setFrameworkSessionCookie,
 } from "./auth.js";
 import { getAppName } from "./app-name.js";
+import { getWorkspaceA2ADerivedSecret } from "./derived-secret.js";
 import { writeDesktopSso } from "./desktop-sso.js";
 import { appendSessionToOAuthReturnUrl } from "./oauth-return-url.js";
 
@@ -479,20 +480,23 @@ let _devStateSigningKey: string | undefined;
  * Resolution order:
  *   1. OAUTH_STATE_SECRET (preferred — dedicated to this purpose)
  *   2. BETTER_AUTH_SECRET (already used by Better Auth as a server secret)
- *   3. In dev only, an ephemeral random key (per-process)
+ *   3. Hosted workspace deploys derive a per-purpose key from A2A_SECRET
+ *   4. In dev only, an ephemeral random key (per-process)
  *
- * In production, throws if neither secret is set.
+ * In production, throws if no usable server secret is set.
  */
 function getStateSigningKey(): string {
   const secret =
-    process.env.OAUTH_STATE_SECRET || process.env.BETTER_AUTH_SECRET;
+    process.env.OAUTH_STATE_SECRET ||
+    process.env.BETTER_AUTH_SECRET ||
+    getWorkspaceA2ADerivedSecret("oauth-state");
   if (secret) return secret;
 
   const isProd = process.env.NODE_ENV === "production";
   if (isProd) {
     throw new Error(
       "OAuth state signing requires a server secret. " +
-        "Set OAUTH_STATE_SECRET or BETTER_AUTH_SECRET in production.",
+        "Set OAUTH_STATE_SECRET, BETTER_AUTH_SECRET, or A2A_SECRET in production workspace deploys.",
     );
   }
 

--- a/packages/core/src/server/short-lived-token.spec.ts
+++ b/packages/core/src/server/short-lived-token.spec.ts
@@ -5,18 +5,21 @@ import {
 } from "./short-lived-token.js";
 
 describe("short-lived-token", () => {
-  const ORIGINAL_ENV = process.env.OAUTH_STATE_SECRET;
+  const originalEnv = { ...process.env };
 
   beforeEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, originalEnv);
     process.env.OAUTH_STATE_SECRET = "test-secret-do-not-use-in-prod";
   });
 
   afterEach(() => {
-    if (ORIGINAL_ENV === undefined) {
-      delete process.env.OAUTH_STATE_SECRET;
-    } else {
-      process.env.OAUTH_STATE_SECRET = ORIGINAL_ENV;
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) delete process.env[key];
     }
+    Object.assign(process.env, originalEnv);
     vi.useRealTimers();
   });
 
@@ -83,5 +86,22 @@ describe("short-lived-token", () => {
     expect(verifyShortLivedToken("nodot", "rec_abc").ok).toBe(false);
     expect(verifyShortLivedToken("a.", "rec_abc").ok).toBe(false);
     expect(verifyShortLivedToken(".b", "rec_abc").ok).toBe(false);
+  });
+
+  it("uses derived A2A signing in production workspace deploys", () => {
+    delete process.env.OAUTH_STATE_SECRET;
+    delete process.env.BETTER_AUTH_SECRET;
+    process.env.NODE_ENV = "production";
+    process.env.AGENT_NATIVE_WORKSPACE = "1";
+    process.env.A2A_SECRET = "workspace-root-secret";
+
+    const token = signShortLivedToken({ resourceId: "rec_abc" });
+    expect(verifyShortLivedToken(token, "rec_abc").ok).toBe(true);
+
+    process.env.A2A_SECRET = "different-root-secret";
+    expect(verifyShortLivedToken(token, "rec_abc")).toEqual({
+      ok: false,
+      reason: "bad_signature",
+    });
   });
 });

--- a/packages/core/src/server/short-lived-token.ts
+++ b/packages/core/src/server/short-lived-token.ts
@@ -13,12 +13,14 @@
  * Key resolution mirrors `google-oauth.ts:getStateSigningKey`:
  *   1. OAUTH_STATE_SECRET (preferred — dedicated to short-lived signing)
  *   2. BETTER_AUTH_SECRET (already used as a server secret)
- *   3. In dev only, an ephemeral random key (per-process)
+ *   3. Hosted workspace deploys derive a per-purpose key from A2A_SECRET
+ *   4. In dev only, an ephemeral random key (per-process)
  *
- * In production, throws if neither secret is set.
+ * In production, throws if no usable server secret is set.
  */
 
 import crypto from "node:crypto";
+import { getWorkspaceA2ADerivedSecret } from "./derived-secret.js";
 
 /** Default token TTL, in seconds. 10 minutes covers a typical video session. */
 const DEFAULT_TTL_SECONDS = 600;
@@ -53,13 +55,15 @@ let _devSigningKey: string | undefined;
 
 function getSigningKey(): string {
   const secret =
-    process.env.OAUTH_STATE_SECRET || process.env.BETTER_AUTH_SECRET;
+    process.env.OAUTH_STATE_SECRET ||
+    process.env.BETTER_AUTH_SECRET ||
+    getWorkspaceA2ADerivedSecret("short-lived-token");
   if (secret) return secret;
 
   if (process.env.NODE_ENV === "production") {
     throw new Error(
       "Short-lived token signing requires a server secret. " +
-        "Set OAUTH_STATE_SECRET or BETTER_AUTH_SECRET in production.",
+        "Set OAUTH_STATE_SECRET, BETTER_AUTH_SECRET, or A2A_SECRET in production workspace deploys.",
     );
   }
 

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -103,6 +103,7 @@ export const meta = () => [
 const CANONICAL_ALIASES: Record<string, string> = {
   "/docs/getting-started": "/docs",
 };
+const SCROLL_MANAGER_MARKER = "docs-scroll-manager-marker";
 
 function CanonicalLink() {
   const location = useLocation();
@@ -149,14 +150,43 @@ function scrollElementIntoContainerView(target: HTMLElement) {
   });
 }
 
+function getManagedScrollTop(): number | null {
+  if (typeof document === "undefined") return null;
+  const marker = document.querySelector<HTMLElement>(
+    `[data-${SCROLL_MANAGER_MARKER}]`,
+  );
+  if (!marker) return null;
+  const scrollContainer = findScrollContainerFrom(marker);
+  if (scrollContainer === window) return window.scrollY;
+  return (scrollContainer as HTMLElement).scrollTop;
+}
+
+function setManagedScrollTop(top: number) {
+  if (typeof document === "undefined") return;
+  const marker = document.querySelector<HTMLElement>(
+    `[data-${SCROLL_MANAGER_MARKER}]`,
+  );
+  if (!marker) return;
+  const scrollContainer = findScrollContainerFrom(marker);
+  if (scrollContainer === window) {
+    window.scrollTo(0, top);
+  } else {
+    (scrollContainer as HTMLElement).scrollTop = top;
+  }
+}
+
 // AgentSidebar wraps content in an overflow-auto div, so the window usually
 // does not scroll. Keep both normal route changes and hash links pointed at
 // that real scroll container.
-function ScrollManager({ mounted }: { mounted: boolean }) {
+function ScrollManager() {
   const { pathname, hash } = useLocation();
   const ref = useRef<HTMLSpanElement>(null);
+  const isInitialEffectRef = useRef(true);
 
   useEffect(() => {
+    const isInitialEffect = isInitialEffectRef.current;
+    isInitialEffectRef.current = false;
+
     if (hash) {
       const id = decodeURIComponent(hash.slice(1));
       let raf = 0;
@@ -177,6 +207,8 @@ function ScrollManager({ mounted }: { mounted: boolean }) {
       };
     }
 
+    if (isInitialEffect) return;
+
     let parent: HTMLElement | null = ref.current?.parentElement ?? null;
     while (parent) {
       const overflowY = getComputedStyle(parent).overflowY;
@@ -187,8 +219,15 @@ function ScrollManager({ mounted }: { mounted: boolean }) {
       parent = parent.parentElement;
     }
     window.scrollTo(0, 0);
-  }, [pathname, hash, mounted]);
-  return <span ref={ref} aria-hidden style={{ display: "none" }} />;
+  }, [pathname, hash]);
+  return (
+    <span
+      ref={ref}
+      data-docs-scroll-manager-marker
+      aria-hidden
+      style={{ display: "none" }}
+    />
+  );
 }
 
 export function Layout({ children }: { children: React.ReactNode }) {
@@ -228,11 +267,39 @@ export default function Root() {
       }),
   );
   const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  const pendingHydrationScrollTopRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    pendingHydrationScrollTopRef.current = window.location.hash
+      ? null
+      : getManagedScrollTop();
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    const top = pendingHydrationScrollTopRef.current;
+    pendingHydrationScrollTopRef.current = null;
+    if (!top || top <= 0) return;
+
+    let raf = 0;
+    let secondRaf = 0;
+    const timer = window.setTimeout(() => setManagedScrollTop(top), 100);
+    raf = window.requestAnimationFrame(() => {
+      setManagedScrollTop(top);
+      secondRaf = window.requestAnimationFrame(() => setManagedScrollTop(top));
+    });
+
+    return () => {
+      window.cancelAnimationFrame(raf);
+      window.cancelAnimationFrame(secondRaf);
+      window.clearTimeout(timer);
+    };
+  }, [mounted]);
 
   const content = (
     <>
-      <ScrollManager mounted={mounted} />
+      <ScrollManager />
       <Header />
       <Outlet />
       <Footer />


### PR DESCRIPTION
## Summary
- isolate framework and Better Auth cookies by deployment realm, while preventing first-party agent-native.com apps with separate auth DBs from sharing incompatible session cookies
- derive per-purpose Better Auth, OAuth state, and short-lived token signing secrets from A2A_SECRET in hosted workspace deploys when explicit secrets are not configured
- preserve docs scroll position across hydration and document the auth cookie realm behavior

## Verification
- pnpm prep