### PR TITLE
Fix multi-day event overflow in calendar views

### DIFF
--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -173,9 +173,8 @@ export function DayView({
   function getEventStyle(event: CalendarEvent) {
     const start = parseISO(event.start);
     const end = parseISO(event.end);
-    const midnight = startOfDay(start);
-    const dayStart = set(midnight, { hours: START_HOUR });
-    const dayEnd = addDays(midnight, 1);
+    const dayStart = set(startOfDay(date), { hours: START_HOUR });
+    const dayEnd = addDays(startOfDay(date), 1);
     const cappedEnd = min([end, dayEnd]);
     const topMinutes = Math.max(0, differenceInMinutes(start, dayStart));
     const durationMinutes = Math.max(15, differenceInMinutes(cappedEnd, start));
@@ -396,8 +395,10 @@ export function DayView({
                 : getEventStyle(event);
               const color = getEventDisplayColor(event, prefs);
               const evStart = parseISO(event.start);
-              const evEndRaw = parseISO(event.end);
-              const evEnd = min([evEndRaw, addDays(startOfDay(evStart), 1)]);
+              const evEnd = min([
+                parseISO(event.end),
+                addDays(startOfDay(date), 1),
+              ]);
               const durationMin = overrides
                 ? (overrides.height / HOUR_HEIGHT) * 60
                 : differenceInMinutes(evEnd, evStart);
@@ -411,9 +412,11 @@ export function DayView({
                     }),
                     (overrides.top / HOUR_HEIGHT) * 60,
                   )
-                : evStart;
-              const displayEnd = overrides ? addMinutes(displayStart, durationMin) : evEndRaw;
-              const isPast = evEndRaw < now;
+                : parseISO(event.start);
+              const displayEnd = overrides
+                ? addMinutes(displayStart, durationMin)
+                : parseISO(event.end);
+              const isPast = parseISO(event.end) < now;
               const isDeclined = event.responseStatus === "declined";
               const allOthersOut = allOtherDeclined(event);
               const canDrag = !!onEventTimeChange;

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -173,8 +173,9 @@ export function DayView({
   function getEventStyle(event: CalendarEvent) {
     const start = parseISO(event.start);
     const end = parseISO(event.end);
-    const dayStart = set(startOfDay(start), { hours: START_HOUR });
-    const dayEnd = addDays(startOfDay(start), 1);
+    const midnight = startOfDay(start);
+    const dayStart = set(midnight, { hours: START_HOUR });
+    const dayEnd = addDays(midnight, 1);
     const cappedEnd = min([end, dayEnd]);
     const topMinutes = Math.max(0, differenceInMinutes(start, dayStart));
     const durationMinutes = Math.max(15, differenceInMinutes(cappedEnd, start));
@@ -395,7 +396,8 @@ export function DayView({
                 : getEventStyle(event);
               const color = getEventDisplayColor(event, prefs);
               const evStart = parseISO(event.start);
-              const evEnd = min([parseISO(event.end), addDays(startOfDay(evStart), 1)]);
+              const evEndRaw = parseISO(event.end);
+              const evEnd = min([evEndRaw, addDays(startOfDay(evStart), 1)]);
               const durationMin = overrides
                 ? (overrides.height / HOUR_HEIGHT) * 60
                 : differenceInMinutes(evEnd, evStart);
@@ -409,11 +411,9 @@ export function DayView({
                     }),
                     (overrides.top / HOUR_HEIGHT) * 60,
                   )
-                : parseISO(event.start);
-              const displayEnd = overrides
-                ? addMinutes(displayStart, durationMin)
-                : parseISO(event.end);
-              const isPast = parseISO(event.end) < now;
+                : evStart;
+              const displayEnd = overrides ? addMinutes(displayStart, durationMin) : evEndRaw;
+              const isPast = evEndRaw < now;
               const isDeclined = event.responseStatus === "declined";
               const allOthersOut = allOtherDeclined(event);
               const canDrag = !!onEventTimeChange;

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -8,6 +8,8 @@ import {
   set,
   isToday,
   addMinutes,
+  addDays,
+  min,
 } from "date-fns";
 import { cn } from "@/lib/utils";
 import { shouldSuppressAfterPopoverClose } from "@/lib/popover-click-guard";
@@ -172,8 +174,10 @@ export function DayView({
     const start = parseISO(event.start);
     const end = parseISO(event.end);
     const dayStart = set(startOfDay(start), { hours: START_HOUR });
+    const dayEnd = addDays(startOfDay(start), 1);
+    const cappedEnd = min([end, dayEnd]);
     const topMinutes = Math.max(0, differenceInMinutes(start, dayStart));
-    const durationMinutes = Math.max(15, differenceInMinutes(end, start));
+    const durationMinutes = Math.max(15, differenceInMinutes(cappedEnd, start));
     return {
       top: `${(topMinutes / 60) * HOUR_HEIGHT}px`,
       height: `${(durationMinutes / 60) * HOUR_HEIGHT}px`,
@@ -390,12 +394,11 @@ export function DayView({
                   }
                 : getEventStyle(event);
               const color = getEventDisplayColor(event, prefs);
+              const evStart = parseISO(event.start);
+              const evEnd = min([parseISO(event.end), addDays(startOfDay(evStart), 1)]);
               const durationMin = overrides
                 ? (overrides.height / HOUR_HEIGHT) * 60
-                : differenceInMinutes(
-                    parseISO(event.end),
-                    parseISO(event.start),
-                  );
+                : differenceInMinutes(evEnd, evStart);
               // Compute display times (use drag overrides if active)
               const displayStart = overrides
                 ? addMinutes(

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -176,8 +176,12 @@ export function DayView({
     const dayStart = set(startOfDay(date), { hours: START_HOUR });
     const dayEnd = addDays(startOfDay(date), 1);
     const cappedEnd = min([end, dayEnd]);
-    const topMinutes = Math.max(0, differenceInMinutes(start, dayStart));
-    const durationMinutes = Math.max(15, differenceInMinutes(cappedEnd, start));
+    const segStart = start > dayStart ? start : dayStart;
+    const topMinutes = Math.max(0, differenceInMinutes(segStart, dayStart));
+    const durationMinutes = Math.max(
+      15,
+      differenceInMinutes(cappedEnd, segStart),
+    );
     return {
       top: `${(topMinutes / 60) * HOUR_HEIGHT}px`,
       height: `${(durationMinutes / 60) * HOUR_HEIGHT}px`,

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -395,10 +395,10 @@ export function DayView({
                 : getEventStyle(event);
               const color = getEventDisplayColor(event, prefs);
               const evStart = parseISO(event.start);
-              const evEnd = min([
-                parseISO(event.end),
-                addDays(startOfDay(date), 1),
-              ]);
+              const rawEnd = parseISO(event.end);
+              const midnight = addDays(startOfDay(date), 1);
+              const evEnd = min([rawEnd, midnight]);
+              const isOvernightCapped = rawEnd > midnight;
               const durationMin = overrides
                 ? (overrides.height / HOUR_HEIGHT) * 60
                 : differenceInMinutes(evEnd, evStart);
@@ -553,8 +553,8 @@ export function DayView({
                       style={{ touchAction: "none" }}
                     />
                   )}
-                  {/* Bottom resize handle */}
-                  {canDrag && (
+                  {/* Bottom resize handle — hidden on overnight events capped at midnight; drag math uses uncapped duration and would truncate the true end */}
+                  {canDrag && !isOvernightCapped && (
                     <div
                       data-resize-handle="true"
                       onPointerDown={(e) => {

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -13,6 +13,7 @@ import {
   set,
   addDays,
   addMinutes,
+  min,
 } from "date-fns";
 import { cn } from "@/lib/utils";
 import { shouldSuppressAfterPopoverClose } from "@/lib/popover-click-guard";
@@ -289,8 +290,10 @@ export function WeekView({
     const start = parseISO(event.start);
     const end = parseISO(event.end);
     const dayStart = set(startOfDay(start), { hours: START_HOUR });
+    const dayEnd = addDays(startOfDay(start), 1);
+    const cappedEnd = min([end, dayEnd]);
     const topMinutes = Math.max(0, differenceInMinutes(start, dayStart));
-    const durationMinutes = Math.max(15, differenceInMinutes(end, start));
+    const durationMinutes = Math.max(15, differenceInMinutes(cappedEnd, start));
 
     return {
       top: `${(topMinutes / 60) * HOUR_HEIGHT}px`,
@@ -773,9 +776,11 @@ export function WeekView({
                     const color = getEventDisplayColor(event, prefs);
                     const start = parseISO(event.start);
                     const end = parseISO(event.end);
+                    const dayEnd = addDays(startOfDay(start), 1);
+                    const cappedEnd = min([end, dayEnd]);
                     const durationMin = overrides
                       ? (overrides.height / HOUR_HEIGHT) * 60
-                      : differenceInMinutes(end, start);
+                      : differenceInMinutes(cappedEnd, start);
                     // Compute display times (use drag overrides if active)
                     const displayStart = overrides
                       ? addMinutes(

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -122,12 +122,15 @@ interface LayoutInfo {
  * indent per nesting depth and stack on top with opaque backgrounds.
  * Text at the top stays readable; the card beneath is covered.
  */
-function computeLayout(dayEvents: CalendarEvent[], day: Date): Map<string, LayoutInfo> {
+function computeLayout(
+  dayEvents: CalendarEvent[],
+  day: Date,
+): Map<string, LayoutInfo> {
   const result = new Map<string, LayoutInfo>();
   if (dayEvents.length === 0) return result;
 
   const dayStartMs = startOfDay(day).getTime();
-  const dayEndMs = dayStartMs + 24 * 60 * 60 * 1000;
+  const dayEndMs = addDays(startOfDay(day), 1).getTime();
 
   // Cap each event's times to this day's boundaries once, reuse in sort + overlap
   const times = new Map(
@@ -962,8 +965,8 @@ export function WeekView({
                             style={{ touchAction: "none" }}
                           />
                         )}
-                        {/* Bottom resize handle */}
-                        {canDrag && isEnd && (
+                        {/* Bottom resize handle — only on single-day segments; multi-day end segments need segment-aware drag math */}
+                        {canDrag && isEnd && isStart && (
                           <div
                             data-resize-handle="true"
                             onPointerDown={(e) => {

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -122,29 +122,32 @@ interface LayoutInfo {
  * indent per nesting depth and stack on top with opaque backgrounds.
  * Text at the top stays readable; the card beneath is covered.
  */
-function computeLayout(dayEvents: CalendarEvent[]): Map<string, LayoutInfo> {
+function computeLayout(dayEvents: CalendarEvent[], day: Date): Map<string, LayoutInfo> {
   const result = new Map<string, LayoutInfo>();
   if (dayEvents.length === 0) return result;
 
-  // Sort: earliest start first, then longest duration first (background)
+  const dayStartMs = startOfDay(day).getTime();
+  const dayEndMs = addDays(startOfDay(day), 1).getTime();
+
+  // Sort using segment-capped times so continuation events sort correctly
   const sorted = [...dayEvents].sort((a, b) => {
-    const aStart = parseISO(a.start).getTime();
-    const bStart = parseISO(b.start).getTime();
+    const aStart = Math.max(parseISO(a.start).getTime(), dayStartMs);
+    const bStart = Math.max(parseISO(b.start).getTime(), dayStartMs);
     if (aStart !== bStart) return aStart - bStart;
-    return parseISO(b.end).getTime() - parseISO(a.end).getTime();
+    const aEnd = Math.min(parseISO(a.end).getTime(), dayEndMs);
+    const bEnd = Math.min(parseISO(b.end).getTime(), dayEndMs);
+    return bEnd - aEnd;
   });
 
   const times = new Map<string, { start: number; end: number }>();
   for (const ev of sorted) {
     times.set(ev.id, {
-      start: parseISO(ev.start).getTime(),
-      end: parseISO(ev.end).getTime(),
+      start: Math.max(parseISO(ev.start).getTime(), dayStartMs),
+      end: Math.min(parseISO(ev.end).getTime(), dayEndMs),
     });
   }
 
-  // Each event is full-width minus a small indent per overlap depth.
-  // Depth = how many earlier events in the sorted list overlap with this one.
-  const INDENT_PX = 16; // pixels per nesting level
+  const INDENT_PX = 16;
 
   for (const ev of sorted) {
     let depth = 0;
@@ -156,8 +159,8 @@ function computeLayout(dayEvents: CalendarEvent[]): Map<string, LayoutInfo> {
     }
 
     result.set(ev.id, {
-      left: depth * INDENT_PX, // pixels, not percentage
-      width: 0, // signal to use calc(100% - left)
+      left: depth * INDENT_PX,
+      width: 0,
       col: depth,
       totalCols: depth + 1,
     });
@@ -275,26 +278,30 @@ export function WeekView({
     return spans;
   }, [allDayEvents, days]);
 
-  // Pre-compute timed events per day with layout
+  // Pre-compute timed events per day with layout — include events spanning into this day
   const dayData = useMemo(() => {
     return days.map((day) => {
-      const dayEvents = timedEvents.filter((e) =>
-        isSameDay(parseISO(e.start), day),
-      );
-      const layout = computeLayout(dayEvents);
+      const dayStart = startOfDay(day);
+      const dayEnd = addDays(dayStart, 1);
+      const dayEvents = timedEvents.filter((e) => {
+        const evStart = parseISO(e.start);
+        const evEnd = parseISO(e.end);
+        return evStart < dayEnd && evEnd > dayStart;
+      });
+      const layout = computeLayout(dayEvents, day);
       return { day, events: dayEvents, layout };
     });
   }, [days, timedEvents]);
 
-  function getEventStyle(event: CalendarEvent) {
-    const start = parseISO(event.start);
-    const end = parseISO(event.end);
-    const dayStart = set(startOfDay(start), { hours: START_HOUR });
-    const dayEnd = addDays(startOfDay(start), 1);
-    const cappedEnd = min([end, dayEnd]);
-    const topMinutes = Math.max(0, differenceInMinutes(start, dayStart));
-    const durationMinutes = Math.max(15, differenceInMinutes(cappedEnd, start));
-
+  function getSegmentStyle(event: CalendarEvent, day: Date) {
+    const evStart = parseISO(event.start);
+    const evEnd = parseISO(event.end);
+    const dayBase = set(startOfDay(day), { hours: START_HOUR });
+    const dayEnd = addDays(startOfDay(day), 1);
+    const segStart = evStart > dayBase ? evStart : dayBase;
+    const segEnd = min([evEnd, dayEnd]);
+    const topMinutes = Math.max(0, differenceInMinutes(segStart, dayBase));
+    const durationMinutes = Math.max(15, differenceInMinutes(segEnd, segStart));
     return {
       top: `${(topMinutes / 60) * HOUR_HEIGHT}px`,
       height: `${(durationMinutes / 60) * HOUR_HEIGHT}px`,
@@ -756,6 +763,9 @@ export function WeekView({
                     };
                     const overrides = getDragOverrides(event.id);
                     const isBeingDragged = dragEventId === event.id;
+                    const isStart = isSameDay(parseISO(event.start), day);
+                    const isEnd =
+                      parseISO(event.end) <= addDays(startOfDay(day), 1);
 
                     // Hide from original column if dragged to a different day
                     if (
@@ -766,21 +776,26 @@ export function WeekView({
                     ) {
                       return null;
                     }
+                    // Hide continuation segments during active drag to avoid ghost overlap
+                    if (isBeingDragged && isDragging && !isStart) {
+                      return null;
+                    }
 
                     const style = overrides
                       ? {
                           top: `${overrides.top}px`,
                           height: `${overrides.height}px`,
                         }
-                      : getEventStyle(event);
+                      : getSegmentStyle(event, day);
                     const color = getEventDisplayColor(event, prefs);
                     const start = parseISO(event.start);
                     const end = parseISO(event.end);
-                    const dayEnd = addDays(startOfDay(start), 1);
-                    const cappedEnd = min([end, dayEnd]);
+                    const segDayEnd = addDays(startOfDay(day), 1);
+                    const segStart = isStart ? start : startOfDay(day);
+                    const segEnd = min([end, segDayEnd]);
                     const durationMin = overrides
                       ? (overrides.height / HOUR_HEIGHT) * 60
-                      : differenceInMinutes(cappedEnd, start);
+                      : differenceInMinutes(segEnd, segStart);
                     // Compute display times (use drag overrides if active)
                     const displayStart = overrides
                       ? addMinutes(
@@ -806,6 +821,7 @@ export function WeekView({
                           setFocusedEventId(event.id);
                           setFocusedEvent(event);
                           if (
+                            isStart &&
                             canDrag &&
                             !(e.target as HTMLElement).dataset.resizeHandle
                           ) {
@@ -819,7 +835,9 @@ export function WeekView({
                           }
                         }}
                         className={cn(
-                          "absolute overflow-hidden rounded-md px-1.5 py-0.5 text-left text-[11px] flex flex-col hover:brightness-110 hover:shadow-md group",
+                          "absolute overflow-hidden px-1.5 py-0.5 text-left text-[11px] flex flex-col hover:brightness-110 hover:shadow-md group",
+                          isStart ? "rounded-t-md" : "rounded-t-none",
+                          isEnd ? "rounded-b-md" : "rounded-b-none",
                           durationMin <= 30
                             ? "justify-center"
                             : "justify-start",
@@ -828,7 +846,7 @@ export function WeekView({
                           isBeingDragged &&
                             isDragging &&
                             "ring-2 ring-primary/40",
-                          canDrag && "cursor-grab",
+                          canDrag && isStart && "cursor-grab",
                           isBeingDragged && isDragging && "cursor-grabbing",
                         )}
                         style={{
@@ -849,6 +867,13 @@ export function WeekView({
                               ? `color-mix(in srgb, ${color ?? "hsl(var(--primary))"} 30%, transparent)`
                               : (color ?? "hsl(var(--primary))")
                           }`,
+                          borderTop: !isStart
+                            ? `2px dashed ${
+                                isPast || isDeclined
+                                  ? `color-mix(in srgb, ${color ?? "hsl(var(--primary))"} 30%, transparent)`
+                                  : `color-mix(in srgb, ${color ?? "hsl(var(--primary))"} 60%, transparent)`
+                              }`
+                            : undefined,
                           opacity:
                             isBeingDragged && isDragging ? 0.9 : undefined,
                         }}
@@ -873,21 +898,23 @@ export function WeekView({
                             >
                               {event.title}
                             </span>
-                            <span
-                              className={cn(
-                                "shrink-0 text-[10px] leading-tight",
-                                isPast || isDeclined
-                                  ? "text-muted-foreground/50"
-                                  : "text-foreground/60",
-                              )}
-                            >
-                              {format(
-                                displayStart,
-                                displayStart.getMinutes() === 0
-                                  ? "h a"
-                                  : "h:mm a",
-                              )}
-                            </span>
+                            {isStart && (
+                              <span
+                                className={cn(
+                                  "shrink-0 text-[10px] leading-tight",
+                                  isPast || isDeclined
+                                    ? "text-muted-foreground/50"
+                                    : "text-foreground/60",
+                                )}
+                              >
+                                {format(
+                                  displayStart,
+                                  displayStart.getMinutes() === 0
+                                    ? "h a"
+                                    : "h:mm a",
+                                )}
+                              </span>
+                            )}
                           </div>
                         ) : (
                           <>
@@ -909,20 +936,22 @@ export function WeekView({
                               )}
                               <span className="truncate">{event.title}</span>
                             </div>
-                            <div
-                              className={cn(
-                                "mt-0.5 truncate text-[9px] leading-tight",
-                                isPast || isDeclined
-                                  ? "text-muted-foreground/50"
-                                  : "text-foreground/60",
-                              )}
-                            >
-                              {formatEventTime(displayStart, displayEnd)}
-                            </div>
+                            {isStart && (
+                              <div
+                                className={cn(
+                                  "mt-0.5 truncate text-[9px] leading-tight",
+                                  isPast || isDeclined
+                                    ? "text-muted-foreground/50"
+                                    : "text-foreground/60",
+                                )}
+                              >
+                                {formatEventTime(displayStart, displayEnd)}
+                              </div>
+                            )}
                           </>
                         )}
                         {/* Top resize handle */}
-                        {canDrag && (
+                        {canDrag && isStart && (
                           <div
                             data-resize-handle="true"
                             onPointerDown={(e) => {
@@ -934,7 +963,7 @@ export function WeekView({
                           />
                         )}
                         {/* Bottom resize handle */}
-                        {canDrag && (
+                        {canDrag && isEnd && (
                           <div
                             data-resize-handle="true"
                             onPointerDown={(e) => {

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -127,25 +127,25 @@ function computeLayout(dayEvents: CalendarEvent[], day: Date): Map<string, Layou
   if (dayEvents.length === 0) return result;
 
   const dayStartMs = startOfDay(day).getTime();
-  const dayEndMs = addDays(startOfDay(day), 1).getTime();
+  const dayEndMs = dayStartMs + 24 * 60 * 60 * 1000;
 
-  // Sort using segment-capped times so continuation events sort correctly
+  // Cap each event's times to this day's boundaries once, reuse in sort + overlap
+  const times = new Map(
+    dayEvents.map((ev) => [
+      ev.id,
+      {
+        start: Math.max(parseISO(ev.start).getTime(), dayStartMs),
+        end: Math.min(parseISO(ev.end).getTime(), dayEndMs),
+      },
+    ]),
+  );
+
   const sorted = [...dayEvents].sort((a, b) => {
-    const aStart = Math.max(parseISO(a.start).getTime(), dayStartMs);
-    const bStart = Math.max(parseISO(b.start).getTime(), dayStartMs);
-    if (aStart !== bStart) return aStart - bStart;
-    const aEnd = Math.min(parseISO(a.end).getTime(), dayEndMs);
-    const bEnd = Math.min(parseISO(b.end).getTime(), dayEndMs);
-    return bEnd - aEnd;
+    const ta = times.get(a.id)!;
+    const tb = times.get(b.id)!;
+    if (ta.start !== tb.start) return ta.start - tb.start;
+    return tb.end - ta.end; // later end first when starts are equal
   });
-
-  const times = new Map<string, { start: number; end: number }>();
-  for (const ev of sorted) {
-    times.set(ev.id, {
-      start: Math.max(parseISO(ev.start).getTime(), dayStartMs),
-      end: Math.min(parseISO(ev.end).getTime(), dayEndMs),
-    });
-  }
 
   const INDENT_PX = 16;
 
@@ -297,7 +297,7 @@ export function WeekView({
     const evStart = parseISO(event.start);
     const evEnd = parseISO(event.end);
     const dayBase = set(startOfDay(day), { hours: START_HOUR });
-    const dayEnd = addDays(startOfDay(day), 1);
+    const dayEnd = addDays(dayBase, 1);
     const segStart = evStart > dayBase ? evStart : dayBase;
     const segEnd = min([evEnd, dayEnd]);
     const topMinutes = Math.max(0, differenceInMinutes(segStart, dayBase));
@@ -763,9 +763,12 @@ export function WeekView({
                     };
                     const overrides = getDragOverrides(event.id);
                     const isBeingDragged = dragEventId === event.id;
-                    const isStart = isSameDay(parseISO(event.start), day);
-                    const isEnd =
-                      parseISO(event.end) <= addDays(startOfDay(day), 1);
+                    const start = parseISO(event.start);
+                    const end = parseISO(event.end);
+                    const dayBase = startOfDay(day);
+                    const segDayEnd = addDays(dayBase, 1);
+                    const isStart = isSameDay(start, day);
+                    const isEnd = end <= segDayEnd;
 
                     // Hide from original column if dragged to a different day
                     if (
@@ -788,10 +791,7 @@ export function WeekView({
                         }
                       : getSegmentStyle(event, day);
                     const color = getEventDisplayColor(event, prefs);
-                    const start = parseISO(event.start);
-                    const end = parseISO(event.end);
-                    const segDayEnd = addDays(startOfDay(day), 1);
-                    const segStart = isStart ? start : startOfDay(day);
+                    const segStart = isStart ? start : dayBase;
                     const segEnd = min([end, segDayEnd]);
                     const durationMin = overrides
                       ? (overrides.height / HOUR_HEIGHT) * 60


### PR DESCRIPTION
### Summary
Fixes a bug where events spanning past midnight caused the event card to grow abnormally large within the same day column. Events now render as segmented cards that continue across subsequent days.

### Problem
When a calendar event crossed midnight into the next day, the event card in the Day and Week views would stretch to fill the full duration (including time beyond midnight), causing an oversized card that overflowed the visible day column.

<img width="921" height="819" alt="image" src="https://github.com/user-attachments/assets/7bac06de-1b20-478e-a79e-f3eff88857ff" />

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/vibe-volt-owi2ixim"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-vibe-volt-owi2ixim_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 782`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>vibe-volt-owi2ixim</branchName>-->