### PR TITLE
Make MCP connect setup easier for chat hosts

### DIFF
--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -90,9 +90,13 @@ For OAuth-native Claude clients, restart Claude Code after the config write,
 run `/mcp`, and choose Authenticate. For fallback clients, the command opens
 the browser at the app; the user is already logged in and clicks **Authorize**
 once. No token to copy, no local server. The fallback connection is **per-user,
-scoped, and revocable**. The no-CLI equivalent is the in-app **Connect**
-affordance served at `https://<app>/_agent-native/mcp/connect`, which hands
-back a one-click deep link or a ready-to-paste `.mcp.json` block.
+scoped, and revocable**. The no-CLI equivalent is the in-app **Connect** page
+served at `https://<app>/_agent-native/mcp/connect`: it shows the remote MCP
+URL with a copy button and a tab strip — **Claude · ChatGPT · Cursor · Claude
+Code · Codex · Other** — with the exact paste-URL steps or copy-able
+`claude mcp add` / `npx @agent-native/core connect` snippet for each host, plus
+a collapsible static-token mint for clients without remote-OAuth support.
+Point non-developer teammates there instead of telling them to install a CLI.
 
 Re-running `agent-native connect <url> --client claude-code` over an older
 Claude bearer-token entry is the migration path: the CLI replaces

--- a/.changeset/connect-page-non-dev-flow.md
+++ b/.changeset/connect-page-non-dev-flow.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+`/_agent-native/mcp/connect` now leads with the no-CLI path: the remote MCP URL is shown with a copy button, and a Claude/ChatGPT/Cursor/Claude Code/Codex/Other tab strip walks users through each host (paste-the-URL for OAuth hosts, one-line `claude mcp add` / `npx @agent-native/core connect` snippets for CLI hosts) so non-developers can connect a chat host without ever opening a terminal. The static-token mint flow and connections list keep their existing endpoints; tests cover the new sections.

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -8,11 +8,74 @@ search: "Claude ChatGPT Claude Code Codex Cursor Claude Cowork MCP Apps agent-na
 
 An agent-native app is reachable by any MCP-compatible host — Claude, Claude Desktop, Claude Code, ChatGPT custom MCP apps, Codex, Cursor, Claude Cowork, VS Code GitHub Copilot, Goose, Postman, MCPJam, and future clients that implement the standard. External agents are great at producing artifacts (a draft, an event, a dashboard) but they often live in a terminal or another app. Without a bridge, the user gets a wall of JSON and has to go find the thing.
 
-The external-agent bridge closes the loop. First you connect your own agent to a **hosted** app — one command writes the local client config, using standard remote MCP OAuth for clients that support it and a browser-authorized bearer fallback for older clients. Then the agent does the work over MCP and hands the user either an inline **MCP App** UI in compatible hosts or a single **"Open in &lt;app&gt; →"** link that opens the real app focused on exactly what was produced. It reuses the existing `navigate` / `application_state` contract the UI already drains every 2s (see [Context Awareness](/docs/context-awareness)) — there is no second navigation mechanism.
+The external-agent bridge closes the loop. First you connect your own agent to a **hosted** app — either by pasting the app's remote MCP URL into a chat host like Claude or ChatGPT, or by running the developer CLI flow for local coding agents. Then the agent does the work over MCP and hands the user either an inline **MCP App** UI in compatible hosts or a single **"Open in &lt;app&gt; →"** link that opens the real app focused on exactly what was produced. It reuses the existing `navigate` / `application_state` contract the UI already drains every 2s (see [Context Awareness](/docs/context-awareness)) — there is no second navigation mechanism.
 
-## Connect Claude Code, Codex, Cursor, and Cowork {#connect}
+## Easy setup {#easy-setup}
 
-The first-party hosted apps live at `mail.agent-native.com`, `calendar.agent-native.com`, `analytics.agent-native.com`, and so on. This flow connects supported local agent clients on your machine — Claude Code, Claude Code CLI, Codex, and Claude Cowork — to a hosted agent-native app over MCP. Cursor can use the same MCP endpoint via the no-CLI/manual config path below.
+Add the hosted app as a remote MCP connector in your chat host, sign in, and enable it in a chat.
+
+Use the hosted app's MCP URL:
+
+| App       | Remote MCP URL                                         |
+| --------- | ------------------------------------------------------ |
+| Mail      | `https://mail.agent-native.com/_agent-native/mcp`      |
+| Analytics | `https://analytics.agent-native.com/_agent-native/mcp` |
+| Any app   | `https://<app-host>/_agent-native/mcp`                 |
+
+When the chat host asks you to authorize Agent-Native, sign in with your workspace account and approve the MCP scopes:
+
+| Scope       | What it enables                                      |
+| ----------- | ---------------------------------------------------- |
+| `mcp:read`  | Read-only tools and tool/resource discovery          |
+| `mcp:write` | Drafting, updating, and other mutating actions       |
+| `mcp:apps`  | Inline MCP Apps, charts, dashboards, drafts, and UIs |
+
+Each chat host stores its own authorization, so connect Claude, ChatGPT, and other hosts separately.
+
+### Claude and Claude Desktop {#claude-chat}
+
+1. Open Claude.
+2. Go to **Customize → Connectors**.
+3. Choose **Add custom connector**.
+4. Paste the remote MCP URL for the app.
+5. Click **Connect**.
+6. Sign in with your Agent-Native account, then approve `mcp:read`, `mcp:write`, and `mcp:apps`.
+7. Start a chat and enable the connector from the connector/tools menu.
+
+For Team or Enterprise workspaces, an owner or admin may need to add the connector under organization settings first. Each user still connects their own account once, so tool calls run as the signed-in user.
+
+### ChatGPT web {#chatgpt}
+
+ChatGPT's full MCP connector flow is currently workspace/admin gated. Use ChatGPT web in a workspace where custom MCP connectors are enabled.
+
+1. In ChatGPT, open **Workspace settings**.
+2. Enable the setting that allows custom MCP connectors or developer-mode connectors.
+3. Go to **Apps** or **Connectors**, then choose **Create** or **Add custom connector**.
+4. Paste the remote MCP URL for the app.
+5. Choose OAuth authentication.
+6. Scan or discover tools.
+7. Sign in with your Agent-Native account and approve the MCP scopes.
+8. Create the connector, then select it from a new chat's tools/apps menu.
+
+If the ChatGPT workspace does not expose custom MCP connectors, ask a workspace admin to enable them first.
+
+### Quick test prompt {#quick-test}
+
+After connecting, try one of these:
+
+```text
+Use Agent-Native Analytics to generate a weekly conversion-rate bar chart and show it inline.
+```
+
+```text
+Use Agent-Native Mail to draft a short follow-up email to me, but do not send it.
+```
+
+In hosts that support MCP Apps, Analytics can render charts and dashboards inline, and Mail can render draft-review UI inline. In hosts that do not render MCP Apps, the same tool call still returns a deep link such as **Open draft in Mail →** or **Open chart in Analytics →**.
+
+## Advanced setup: local agents {#connect}
+
+Use this flow for local agent clients on your machine — Claude Code, Claude Code CLI, Codex, and Claude Cowork. Cursor can use the same MCP endpoint via the manual config path below.
 
 If you have the Agent-Native CLI installed, run:
 
@@ -38,7 +101,7 @@ If you previously connected Claude Code through the old bearer-token flow, just 
 | Codex                         | `~/.codex/config.toml` under `[mcp_servers.<app>]`      | Browser-authorized bearer fallback              |
 | Claude Cowork                 | `~/.cowork/mcp.json` using the Claude Code MCP shape    | Browser-authorized bearer fallback              |
 
-There is no token to copy and no local server to run. Restart the agent client after connecting so it picks up the new MCP server; OAuth-native clients may then prompt you to authenticate from their MCP UI.
+Restart the agent client after connecting so it picks up the new MCP server; OAuth-native clients may then prompt you to authenticate from their MCP UI.
 
 Use `--client codex` (or `--client claude-code`, `--client claude-code-cli`, `--client cowork`, `--client all`) to skip the picker for scripts or one-off installs.
 
@@ -52,9 +115,9 @@ The client picker appears once and the same selection is used for every hosted a
 
 The connection is **per-user, scoped, and revocable**. In the OAuth path, the host stores the tokens after `/mcp` authentication; in the fallback path, the browser session you authorized with is the identity the agent acts as. Nothing exposes the deployment's shared secret.
 
-### No-CLI alternative {#no-cli}
+### Connect page fallback {#connect-page-fallback}
 
-If you'd rather not run a command, open the app in your browser and use its **Connect** affordance (served at `https://<app>/_agent-native/mcp/connect`). While logged in, click **Connect / Authorize**. The page hands you either a one-click deep link that configures a detected agent, or a ready-to-paste `.mcp.json` block:
+For MCP clients that cannot add a remote OAuth URL directly, open the app in your browser and use its **Connect** affordance (served at `https://<app>/_agent-native/mcp/connect`). While logged in, click **Connect / Authorize**. The page hands you either a one-click deep link that configures a detected agent, or a ready-to-paste `.mcp.json` block:
 
 ```jsonc
 // .mcp.json

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -14,6 +14,8 @@ The external-agent bridge closes the loop. First you connect your own agent to a
 
 Add the hosted app as a remote MCP connector in your chat host, sign in, and enable it in a chat.
 
+**Shortcut:** every hosted agent-native app serves a one-page connect helper at `https://<app>/_agent-native/mcp/connect` (for example [mail.agent-native.com/\_agent-native/mcp/connect](https://mail.agent-native.com/_agent-native/mcp/connect), [analytics.agent-native.com/\_agent-native/mcp/connect](https://analytics.agent-native.com/_agent-native/mcp/connect)). It shows the MCP URL with a one-click copy button and a tab strip — Claude · ChatGPT · Cursor · Claude Code · Codex · Other — each with the exact steps or copy-able command for that host. Bookmark it and share with non-developer teammates; everything below is also reachable from that page.
+
 Use the hosted app's MCP URL:
 
 | App       | Remote MCP URL                                         |
@@ -58,6 +60,15 @@ ChatGPT's full MCP connector flow is currently workspace/admin gated. Use ChatGP
 8. Create the connector, then select it from a new chat's tools/apps menu.
 
 If the ChatGPT workspace does not expose custom MCP connectors, ask a workspace admin to enable them first.
+
+### Cursor {#cursor}
+
+1. Open Cursor → **Settings → MCP**.
+2. Click **Add MCP Server**.
+3. Paste the remote MCP URL for the app and save.
+4. When Cursor prompts, sign in with your Agent-Native account and approve `mcp:read`, `mcp:write`, and `mcp:apps`.
+
+Cursor supports remote-OAuth MCP servers, so the paste-URL flow works the same as Claude — no terminal involved. Goose, Postman, MCPJam, and VS Code GitHub Copilot accept the same URL through their own MCP-server UIs once OAuth support is enabled in your build.
 
 ### Quick test prompt {#quick-test}
 

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -86,7 +86,7 @@ In hosts that support MCP Apps, Analytics can render charts and dashboards inlin
 
 ## Advanced setup: local agents {#connect}
 
-Use this flow for local agent clients on your machine — Claude Code, Claude Code CLI, Codex, and Claude Cowork. Cursor can use the same MCP endpoint via the manual config path below.
+Use this flow for local agent clients on your machine — Claude Code, Claude Code CLI, Codex, and Claude Cowork. (Cursor uses the paste-URL flow above; it does not need this CLI path.)
 
 If you have the Agent-Native CLI installed, run:
 

--- a/packages/core/src/mcp/connect-route.spec.ts
+++ b/packages/core/src/mcp/connect-route.spec.ts
@@ -176,11 +176,26 @@ describe("handleMcpConnect", () => {
       expect(body).toContain("Connect an external agent");
       expect(body).toContain("u@example.com");
       expect(body).not.toContain("Allow Claude Code, Codex, or Cowork");
-      expect(body).not.toContain("https://mail.agent-native.com");
       expect(body).toContain('<details id="connections" class="connections">');
       expect(body).not.toContain("connectionsEl.open = true");
       // The page never embeds a token.
       expect(body).not.toContain("Bearer ey");
+      // The new non-dev flow surfaces the remote MCP URL + a per-host picker
+      // (Claude / ChatGPT / Cursor / Claude Code / Codex / Other) so users can
+      // connect without copying a token. Display the live host MCP URL rather
+      // than a hardcoded one.
+      expect(body).toContain("https://mail.agent-native.com/_agent-native/mcp");
+      expect(body).toContain('data-tab="claude"');
+      expect(body).toContain('data-tab="chatgpt"');
+      expect(body).toContain('data-tab="claude-code"');
+      expect(body).toContain('data-tab="codex"');
+      expect(body).toContain("Your MCP URL");
+      expect(body).toContain(
+        "claude mcp add --transport http agent-native-mail",
+      );
+      expect(body).toContain(
+        "npx @agent-native/core connect https://mail.agent-native.com",
+      );
     });
 
     it("shows the device user_code when present and well-formed", async () => {

--- a/packages/core/src/mcp/connect-route.ts
+++ b/packages/core/src/mcp/connect-route.ts
@@ -252,11 +252,24 @@ function renderConnectPage(params: {
   connectBasePath: string;
   email: string;
   appName: string;
+  appUrl: string;
+  serverId: string;
   userCode: string | null;
 }): string {
-  const { connectBasePath, email, appName, userCode } = params;
+  const { connectBasePath, email, appName, appUrl, serverId, userCode } =
+    params;
   const safeEmail = escapeHtml(email);
   const safeApp = escapeHtml(appName);
+  const mcpUrl = `${appUrl}/_agent-native/mcp`;
+  const safeMcpUrl = escapeHtml(mcpUrl);
+  const safeServerId = escapeHtml(serverId);
+  const safeClaudeCodeCmd = escapeHtml(
+    `claude mcp add --transport http ${serverId} ${mcpUrl}`,
+  );
+  const safeCodexCmd = escapeHtml(`npx @agent-native/core connect ${appUrl}`);
+  const safeGenericConfig = escapeHtml(
+    `{\n  "mcpServers": {\n    "${serverId}": {\n      "type": "http",\n      "url": "${mcpUrl}"\n    }\n  }\n}`,
+  );
   const brandMarkSvg = agentNativeMarkSvg(
     "brand-mark",
     "agent-native-connect-brand-gradient",
@@ -487,6 +500,69 @@ function renderConnectPage(params: {
     .app-pill { max-width: 46%; }
     pre { font-size: 0.72rem; }
   }
+  /* MCP URL display + per-host tabs (the non-dev path). */
+  .mcp-url-block { margin: 0 0 1rem; }
+  .url-row {
+    display: flex; align-items: center; gap: 0.5rem;
+    background: var(--panel-2); border: 1px solid var(--border-strong);
+    border-radius: 8px; padding: 0.45rem 0.5rem 0.45rem 0.75rem;
+  }
+  .url-row code {
+    flex: 1 1 auto; min-width: 0; overflow-x: auto; white-space: nowrap;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.78rem; color: var(--text);
+  }
+  .url-row .ghost { flex: 0 0 auto; }
+  .hosts { margin: 0 0 1rem; }
+  .tabs {
+    display: flex; flex-wrap: wrap; gap: 0.25rem;
+    border-bottom: 1px solid var(--border); margin-bottom: 0.75rem;
+    padding-bottom: 0.4rem;
+  }
+  .tab {
+    background: transparent; color: var(--subtle);
+    border: 1px solid transparent;
+    padding: 0.35rem 0.65rem; font-size: 0.8rem; font-weight: 600;
+    border-radius: 6px;
+  }
+  .tab:hover { color: var(--muted); background: var(--panel-soft); }
+  .tab.is-active {
+    color: var(--text); background: var(--panel-2);
+    border-color: var(--border-strong);
+  }
+  .tab-panel { display: none; }
+  .tab-panel.is-active { display: block; }
+  .tab-panel ol { margin: 0 0 0.6rem 1.1rem; padding: 0; }
+  .tab-panel li {
+    margin-bottom: 0.3rem; font-size: 0.86rem; line-height: 1.5;
+    color: var(--muted);
+  }
+  .tab-panel li strong { color: var(--text); font-weight: 650; }
+  .tab-panel a {
+    color: var(--text); text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .tab-panel p {
+    font-size: 0.84rem; color: var(--muted); margin: 0.4rem 0;
+    line-height: 1.5;
+  }
+  .tab-panel .hint {
+    font-size: 0.78rem; color: var(--subtle); margin-top: 0.5rem;
+  }
+  .tab-panel code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.78rem; color: var(--text);
+    background: var(--panel-2); padding: 0.05rem 0.3rem;
+    border-radius: 4px;
+  }
+  .tab-panel pre { margin: 0.4rem 0 0.5rem; }
+  .copy-flash {
+    color: var(--ok) !important;
+    border-color: var(--ok-border) !important;
+  }
+  @media (min-width: 560px) {
+    .card { max-width: 580px; }
+  }
   .hidden { display: none !important; }
 </style>
 </head>
@@ -522,6 +598,67 @@ function renderConnectPage(params: {
   <div id="codeCallout" class="device-strip ${safeUserCode ? "" : "hidden"}">
     <span class="label">Device code</span>
     <span class="value" id="userCodeValue">${safeUserCode}</span>
+  </div>
+
+  <div class="mcp-url-block">
+    <div class="section-label">Your MCP URL</div>
+    <div class="url-row">
+      <code id="mcpUrlValue">${safeMcpUrl}</code>
+      <button type="button" class="ghost" data-copy="mcpUrlValue" aria-label="Copy MCP URL">Copy</button>
+    </div>
+  </div>
+
+  <div class="hosts">
+    <div class="section-label">Pick your AI assistant</div>
+    <div class="tabs" role="tablist" aria-label="Choose your AI assistant">
+      <button type="button" class="tab is-active" role="tab" data-tab="claude" aria-selected="true">Claude</button>
+      <button type="button" class="tab" role="tab" data-tab="chatgpt" aria-selected="false">ChatGPT</button>
+      <button type="button" class="tab" role="tab" data-tab="cursor" aria-selected="false">Cursor</button>
+      <button type="button" class="tab" role="tab" data-tab="claude-code" aria-selected="false">Claude Code</button>
+      <button type="button" class="tab" role="tab" data-tab="codex" aria-selected="false">Codex</button>
+      <button type="button" class="tab" role="tab" data-tab="other" aria-selected="false">Other</button>
+    </div>
+    <div class="tab-panel is-active" role="tabpanel" data-panel="claude">
+      <ol>
+        <li>Open <a href="https://claude.ai/customize/connectors" target="_blank" rel="noopener noreferrer">claude.ai → Customize → Connectors</a> (or Settings → Connectors in Claude Desktop).</li>
+        <li>Click the <strong>+</strong> button → <strong>Add custom connector</strong>.</li>
+        <li>Paste the MCP URL above, name it <strong>${safeApp}</strong>, click <strong>Connect</strong>.</li>
+        <li>On the consent page, click <strong>Authorize</strong> to approve <code>mcp:read</code>, <code>mcp:write</code>, <code>mcp:apps</code>.</li>
+      </ol>
+      <p class="hint">Inline MCP Apps (charts, dashboards, drafts) render automatically inside Claude chats.</p>
+    </div>
+    <div class="tab-panel" role="tabpanel" data-panel="chatgpt">
+      <ol>
+        <li>In ChatGPT, open <strong>Settings → Connectors → Add</strong> (Business/Enterprise/Edu workspaces with developer mode enabled).</li>
+        <li>Paste the MCP URL above, name it <strong>${safeApp}</strong>, click <strong>Connect</strong>.</li>
+        <li>Sign in with your Agent-Native account and approve <code>mcp:read</code>, <code>mcp:write</code>, <code>mcp:apps</code>.</li>
+      </ol>
+      <p class="hint">Workspace admins may need to add the connector under organization settings first; each member still authorizes their own account.</p>
+    </div>
+    <div class="tab-panel" role="tabpanel" data-panel="cursor">
+      <ol>
+        <li>Open Cursor → <strong>Settings → MCP</strong>.</li>
+        <li>Click <strong>Add MCP Server</strong>, paste the MCP URL above, save.</li>
+        <li>When prompted, sign in with your Agent-Native account.</li>
+      </ol>
+    </div>
+    <div class="tab-panel" role="tabpanel" data-panel="claude-code">
+      <p>In your terminal, run:</p>
+      <pre id="claudeCodeCmd">${safeClaudeCodeCmd}</pre>
+      <button type="button" class="ghost" data-copy="claudeCodeCmd">Copy command</button>
+      <p>Then inside Claude Code, type <code>/mcp</code>, choose <strong>${safeServerId}</strong>, and click <strong>Authenticate</strong>.</p>
+    </div>
+    <div class="tab-panel" role="tabpanel" data-panel="codex">
+      <p>For Codex (and other CLI agents), run:</p>
+      <pre id="codexCmd">${safeCodexCmd}</pre>
+      <button type="button" class="ghost" data-copy="codexCmd">Copy command</button>
+      <p class="hint">Mints a per-user token (revocable under <strong>Existing connections</strong> below) and writes the right config file for Codex automatically. For Cowork or Goose, the same command writes the right config.</p>
+    </div>
+    <div class="tab-panel" role="tabpanel" data-panel="other">
+      <p>For any MCP-compatible client with remote-OAuth support, paste the MCP URL above. For clients without OAuth, this generic HTTP config snippet works once paired with a static token (generated below):</p>
+      <pre id="genericConfig">${safeGenericConfig}</pre>
+      <button type="button" class="ghost" data-copy="genericConfig">Copy config</button>
+    </div>
   </div>
 
   <div id="msg" class="msg"></div>
@@ -578,6 +715,44 @@ function renderConnectPage(params: {
   var msgEl = document.getElementById("msg");
   var connectionsEl = document.getElementById("connections");
   var connectionsStateEl = document.getElementById("connectionsState");
+
+  // Tab switching for the per-host instructions block.
+  var tabBtns = document.querySelectorAll(".tabs .tab");
+  var tabPanels = document.querySelectorAll(".tab-panel");
+  for (var i = 0; i < tabBtns.length; i++) {
+    tabBtns[i].addEventListener("click", function (ev) {
+      var btn = ev.currentTarget;
+      var name = btn.getAttribute("data-tab");
+      for (var j = 0; j < tabBtns.length; j++) {
+        var active = tabBtns[j] === btn;
+        tabBtns[j].classList.toggle("is-active", active);
+        tabBtns[j].setAttribute("aria-selected", active ? "true" : "false");
+      }
+      for (var k = 0; k < tabPanels.length; k++) {
+        tabPanels[k].classList.toggle(
+          "is-active",
+          tabPanels[k].getAttribute("data-panel") === name,
+        );
+      }
+    });
+  }
+
+  // Copy buttons — any element with data-copy="<id>" copies that node's text.
+  document.addEventListener("click", function (ev) {
+    var btn = ev.target && ev.target.closest && ev.target.closest("[data-copy]");
+    if (!btn) return;
+    var node = document.getElementById(btn.getAttribute("data-copy"));
+    if (!node || !navigator.clipboard) return;
+    navigator.clipboard.writeText(node.textContent || "").then(function () {
+      var prev = btn.textContent;
+      btn.textContent = "Copied";
+      btn.classList.add("copy-flash");
+      setTimeout(function () {
+        btn.textContent = prev;
+        btn.classList.remove("copy-flash");
+      }, 1400);
+    });
+  });
   function showMsg(text, kind) {
     msgEl.textContent = text;
     msgEl.className = "msg " + (kind || "err");
@@ -788,6 +963,8 @@ export async function handleMcpConnect(
           connectBasePath: basePath,
           email: "(no auth configured)",
           appName: options.appName || appLabel(appUrl, options),
+          appUrl,
+          serverId: serverName(appUrl, options),
           userCode: null,
         }),
       );
@@ -808,6 +985,8 @@ export async function handleMcpConnect(
         connectBasePath: basePath,
         email: session.email,
         appName: options.appName || appLabel(appUrl, options),
+        appUrl,
+        serverId: serverName(appUrl, options),
         userCode,
       }),
     );


### PR DESCRIPTION
## Summary
- Lead `/_agent-native/mcp/connect` with a copyable remote MCP URL and host-specific setup tabs for Claude, ChatGPT, Cursor, Claude Code, Codex, and generic MCP clients.
- Update external-agent docs to start with the no-CLI remote MCP setup path, then keep the local agent setup as advanced guidance.
- Add a patch changeset for `@agent-native/core` and tests for the new connect-page sections.

## Validation
- `npx prettier --write packages/core/docs/content/external-agents.md packages/core/src/mcp/connect-route.spec.ts packages/core/src/mcp/connect-route.ts .changeset/connect-page-non-dev-flow.md`
- `pnpm --filter @agent-native/core typecheck`
- `PATH=/Users/stephensewell/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm --filter @agent-native/core test -- src/mcp/connect-route.spec.ts` (the package script ran the full core suite: 224 files, 2195 tests passed)

Note: the first local Vitest attempt under `/usr/local/bin/node` v18.15.0 failed before tests ran because rolldown imports `node:util.styleText`. Rerunning with bundled Node v24.14.0 passed.