### PR TITLE
feat(core): reserved-job registry

### DIFF
--- a/.changeset/reserved-jobs.md
+++ b/.changeset/reserved-jobs.md
@@ -1,0 +1,15 @@
+---
+"@agent-native/core": minor
+---
+
+Add `registerReservedJob({ name, reason })` so templates with native cron loops (e.g. `server/plugins/sequencer-jobs.ts`) can reserve job names. Both `manage-jobs.create` and `manage-automations.define` consult the registry and refuse to create matching `jobs/*.md` resources, surfacing `reason` back to the agent. Prevents agents from accidentally duplicating native background loops as agentic automations (each `runAgentLoop` tick costs LLM credits even when the loop has nothing to do).
+
+```ts
+import { registerReservedJob } from "@agent-native/core/jobs";
+
+registerReservedJob({
+  name: /^send-due-steps$|^check-replies$/,
+  reason:
+    "Native cron runs these every 60s in server/plugins/sequencer-jobs.ts.",
+});
+```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -85,6 +85,7 @@
     "./progress": "./dist/progress/index.js",
     "./client/progress": "./dist/client/progress/index.js",
     "./triggers": "./dist/triggers/index.js",
+    "./jobs": "./dist/jobs/index.js",
     "./terminal": "./dist/client/terminal/index.js",
     "./terminal/server": "./dist/terminal/index.js",
     "./tailwind": "./dist/tailwind.preset.js",

--- a/packages/core/src/jobs/index.ts
+++ b/packages/core/src/jobs/index.ts
@@ -7,3 +7,8 @@ export {
   type SchedulerDeps,
 } from "./scheduler.js";
 export { createJobTools } from "./tools.js";
+export {
+  registerReservedJob,
+  findReservedJob,
+  type ReservedJob,
+} from "./reserved.js";

--- a/packages/core/src/jobs/reserved.spec.ts
+++ b/packages/core/src/jobs/reserved.spec.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __clearReservedJobs,
+  findReservedJob,
+  registerReservedJob,
+} from "./reserved.js";
+
+afterEach(() => __clearReservedJobs());
+
+describe("reserved-job registry", () => {
+  it("matches an exact slug", () => {
+    registerReservedJob({ name: "send-due-steps", reason: "native cron" });
+    expect(findReservedJob("send-due-steps")?.reason).toBe("native cron");
+    expect(findReservedJob("send-due-stepss")).toBeUndefined();
+  });
+
+  it("matches a RegExp pattern", () => {
+    registerReservedJob({ name: /^sequencer-/i, reason: "owned by sequencer" });
+    expect(findReservedJob("sequencer-send-due-steps")?.reason).toBe(
+      "owned by sequencer",
+    );
+    expect(findReservedJob("Sequencer-Watchdog")?.reason).toBe(
+      "owned by sequencer",
+    );
+    expect(findReservedJob("daily-digest")).toBeUndefined();
+  });
+
+  it("returns the first match when multiple reservations overlap", () => {
+    registerReservedJob({ name: "send-due-steps", reason: "first" });
+    registerReservedJob({ name: /^send-/, reason: "second" });
+    expect(findReservedJob("send-due-steps")?.reason).toBe("first");
+  });
+});

--- a/packages/core/src/jobs/reserved.ts
+++ b/packages/core/src/jobs/reserved.ts
@@ -1,0 +1,41 @@
+/**
+ * Reserved-job registry.
+ *
+ * Templates that ship their own native background loops (TypeScript cron in
+ * `server/plugins/*.ts`, etc.) call `registerReservedJob()` at server startup
+ * to reserve job names. Both `manage-jobs.create` and `manage-automations.define`
+ * consult this registry and refuse to create matching `jobs/*.md` resources,
+ * surfacing `reason` back to the agent.
+ *
+ * This prevents the agent from accidentally duplicating native cron loops as
+ * agentic automations (each `runAgentLoop` tick burns LLM credits even when
+ * the loop has nothing to do).
+ */
+
+export interface ReservedJob {
+  /** Exact slug name (e.g. "send-due-steps") or RegExp tested against the slug. */
+  name: string | RegExp;
+  /** Shown to the agent when a reservation blocks creation. */
+  reason: string;
+}
+
+const reserved: ReservedJob[] = [];
+
+/** Reserve a job name (or pattern) so agentic creation is refused. */
+export function registerReservedJob(entry: ReservedJob): void {
+  reserved.push(entry);
+}
+
+/** Find the first reservation matching `name`, or undefined. */
+export function findReservedJob(name: string): ReservedJob | undefined {
+  return reserved.find((entry) =>
+    typeof entry.name === "string"
+      ? entry.name === name
+      : entry.name.test(name),
+  );
+}
+
+/** Test-only: clear all reservations. */
+export function __clearReservedJobs(): void {
+  reserved.length = 0;
+}

--- a/packages/core/src/jobs/tools.ts
+++ b/packages/core/src/jobs/tools.ts
@@ -17,6 +17,7 @@ import {
   getRequestOrgId,
 } from "../server/request-context.js";
 import { getDbExec } from "../db/client.js";
+import { findReservedJob } from "./reserved.js";
 
 function getOwner(): string {
   const email = getRequestUserEmail();
@@ -95,6 +96,13 @@ async function runCreate(args: Record<string, any>): Promise<string> {
   if (!isValidCron(schedule)) {
     return JSON.stringify({
       error: `Invalid cron expression: "${schedule}". Use 5 fields: minute hour day-of-month month day-of-week.`,
+    });
+  }
+
+  const reserved = findReservedJob(name);
+  if (reserved) {
+    return JSON.stringify({
+      error: `"${name}" is reserved by a native background loop and cannot be created as a recurring job. ${reserved.reason}`,
     });
   }
 

--- a/packages/core/src/templates/workspace-core/.agents/skills/automations/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/automations/SKILL.md
@@ -14,12 +14,18 @@ Automations are agent-executed tasks that fire in response to events or on a cro
 
 ## The Two Trigger Types
 
-| Type       | Fires when                                      | Key field           |
-| ---------- | ----------------------------------------------- | ------------------- |
-| `schedule` | Cron expression matches (same as recurring jobs) | `schedule` (cron)   |
+| Type       | Fires when                                       | Key field            |
+| ---------- | ------------------------------------------------ | -------------------- |
+| `schedule` | Cron expression matches (same as recurring jobs) | `schedule` (cron)    |
 | `event`    | A matching event is emitted on the event bus     | `event` (event name) |
 
 Event triggers can optionally include a `condition` -- a natural-language string evaluated by Haiku against the event payload before dispatch. If the condition does not match, the automation is skipped.
+
+## Reserved Names
+
+Templates that ship their own native cron loops (TypeScript `setInterval` in `server/plugins/*.ts`) reserve job names via `registerReservedJob({ name, reason })` from `@agent-native/core/jobs`. Both `manage-jobs.create` and `manage-automations.define` refuse matching names with the registered `reason` -- this prevents the agent from accidentally creating an agentic loop that duplicates a native one and burns LLM credits every tick.
+
+If `define` returns `Error: "<name>" is reserved by a native background loop...`, do not retry with a similar name -- the native loop already does this work. Tell the user the equivalent is already running and ask if they want a different behavior.
 
 ## How It Works
 
@@ -52,22 +58,22 @@ Use the web-request tool with ${keys.SLACK_WEBHOOK}.
 
 ### Frontmatter Fields
 
-| Field         | Type                           | Purpose                                                |
-| ------------- | ------------------------------ | ------------------------------------------------------ |
-| `schedule`    | `string`                       | Cron expression (required for schedule triggers)       |
-| `enabled`     | `boolean`                      | Whether the automation is active                       |
-| `triggerType` | `"schedule" \| "event"`        | How the automation fires                               |
-| `event`       | `string?`                      | Event name to subscribe to (event triggers)            |
-| `condition`   | `string?`                      | Natural-language condition evaluated before dispatch   |
-| `mode`        | `"agentic" \| "deterministic"` | Full agent loop vs. fixed action set                   |
-| `model`       | `string?`                      | Override the model for this trigger's agent loop       |
-| `domain`      | `string?`                      | Grouping tag (mail, calendar, clips, etc.)             |
-| `createdBy`   | `string?`                      | Owner email                                            |
-| `orgId`       | `string?`                      | Org scope                                              |
-| `runAs`       | `"creator" \| "shared"`        | Whose API key and permissions to use                   |
-| `lastRun`     | `string?`                      | ISO timestamp of last execution                        |
-| `lastStatus`  | `string?`                      | `success`, `error`, `running`, or `skipped`            |
-| `lastError`   | `string?`                      | Error message from last failed run                     |
+| Field         | Type                           | Purpose                                              |
+| ------------- | ------------------------------ | ---------------------------------------------------- |
+| `schedule`    | `string`                       | Cron expression (required for schedule triggers)     |
+| `enabled`     | `boolean`                      | Whether the automation is active                     |
+| `triggerType` | `"schedule" \| "event"`        | How the automation fires                             |
+| `event`       | `string?`                      | Event name to subscribe to (event triggers)          |
+| `condition`   | `string?`                      | Natural-language condition evaluated before dispatch |
+| `mode`        | `"agentic" \| "deterministic"` | Full agent loop vs. fixed action set                 |
+| `model`       | `string?`                      | Override the model for this trigger's agent loop     |
+| `domain`      | `string?`                      | Grouping tag (mail, calendar, clips, etc.)           |
+| `createdBy`   | `string?`                      | Owner email                                          |
+| `orgId`       | `string?`                      | Org scope                                            |
+| `runAs`       | `"creator" \| "shared"`        | Whose API key and permissions to use                 |
+| `lastRun`     | `string?`                      | ISO timestamp of last execution                      |
+| `lastStatus`  | `string?`                      | `success`, `error`, `running`, or `skipped`          |
+| `lastError`   | `string?`                      | Error message from last failed run                   |
 
 ## Agent Tools
 
@@ -77,7 +83,7 @@ All automation operations are accessed through a single `manage-automations` too
 | ------------- | -------------------------------------------------------------------- |
 | `list-events` | Discover all registered events with descriptions and payload schemas |
 | `list`        | List all automations with status, filter by domain or enabled        |
-| `define`      | Create a new automation (name, trigger type, event, condition, body)  |
+| `define`      | Create a new automation (name, trigger type, event, condition, body) |
 | `update`      | Update an existing automation (enabled, condition, body)             |
 | `delete`      | Delete an automation (always confirm with user first)                |
 | `fire-test`   | Emit a `test.event.fired` event to validate automations              |
@@ -101,36 +107,44 @@ registerEvent({
     attendeeEmail: z.string(),
     startTime: z.string(),
   }),
-  example: { bookingId: "abc", attendeeEmail: "jane@co.com", startTime: "2025-01-15T10:00:00Z" },
+  example: {
+    bookingId: "abc",
+    attendeeEmail: "jane@co.com",
+    startTime: "2025-01-15T10:00:00Z",
+  },
 });
 
 // Emit the event (from an action, webhook handler, etc.)
-emit("calendar.booking.created", {
-  bookingId: "abc",
-  attendeeEmail: "jane@co.com",
-  startTime: "2025-01-15T10:00:00Z",
-}, { owner: "owner@example.com" });
+emit(
+  "calendar.booking.created",
+  {
+    bookingId: "abc",
+    attendeeEmail: "jane@co.com",
+    startTime: "2025-01-15T10:00:00Z",
+  },
+  { owner: "owner@example.com" },
+);
 ```
 
 ### Built-in Events
 
-| Event                     | Source              |
-| ------------------------- | ------------------- |
-| `test.event.fired`        | Manual / manage-automations action=fire-test |
-| `agent.turn.completed`    | Agent chat          |
-| `calendar.*`              | Calendar integration |
-| `clip.*`                  | Clips integration   |
-| `mail.*`                  | Mail integration    |
+| Event                  | Source                                       |
+| ---------------------- | -------------------------------------------- |
+| `test.event.fired`     | Manual / manage-automations action=fire-test |
+| `agent.turn.completed` | Agent chat                                   |
+| `calendar.*`           | Calendar integration                         |
+| `clip.*`               | Clips integration                            |
+| `mail.*`               | Mail integration                             |
 
 ### Event Bus API
 
-| Function         | Purpose                                     |
-| ---------------- | ------------------------------------------- |
-| `registerEvent`  | Declare an event type with schema           |
-| `emit`           | Fire an event (validates payload)           |
-| `subscribe`      | Listen for an event (returns subscription ID) |
-| `unsubscribe`    | Remove a subscription by ID                 |
-| `listEvents`     | List all registered event definitions       |
+| Function        | Purpose                                       |
+| --------------- | --------------------------------------------- |
+| `registerEvent` | Declare an event type with schema             |
+| `emit`          | Fire an event (validates payload)             |
+| `subscribe`     | Listen for an event (returns subscription ID) |
+| `unsubscribe`   | Remove a subscription by ID                   |
+| `listEvents`    | List all registered event definitions         |
 
 ## Condition Evaluator
 
@@ -173,15 +187,15 @@ Agent flow:
 
 ## Key Files
 
-| File                                           | Purpose                                          |
-| ---------------------------------------------- | ------------------------------------------------ |
-| `packages/core/src/triggers/types.ts`          | `TriggerFrontmatter` interface                   |
-| `packages/core/src/triggers/actions.ts`        | Agent tools (define, list, update, delete, test)  |
-| `packages/core/src/triggers/dispatcher.ts`     | Event subscription and agentic dispatch          |
-| `packages/core/src/triggers/condition-evaluator.ts` | Haiku condition classification with caching |
-| `packages/core/src/event-bus/`                 | Event bus (register, emit, subscribe)            |
-| `packages/core/src/tools/fetch-tool.ts`        | `web-request` tool with key substitution         |
-| `packages/core/src/secrets/substitution.ts`    | `resolveKeyReferences()` and `validateUrlAllowlist()` |
+| File                                                | Purpose                                               |
+| --------------------------------------------------- | ----------------------------------------------------- |
+| `packages/core/src/triggers/types.ts`               | `TriggerFrontmatter` interface                        |
+| `packages/core/src/triggers/actions.ts`             | Agent tools (define, list, update, delete, test)      |
+| `packages/core/src/triggers/dispatcher.ts`          | Event subscription and agentic dispatch               |
+| `packages/core/src/triggers/condition-evaluator.ts` | Haiku condition classification with caching           |
+| `packages/core/src/event-bus/`                      | Event bus (register, emit, subscribe)                 |
+| `packages/core/src/tools/fetch-tool.ts`             | `web-request` tool with key substitution              |
+| `packages/core/src/secrets/substitution.ts`         | `resolveKeyReferences()` and `validateUrlAllowlist()` |
 
 ## Related Skills
 

--- a/packages/core/src/triggers/actions.spec.ts
+++ b/packages/core/src/triggers/actions.spec.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAutomationToolEntries } from "./actions.js";
+import { __clearReservedJobs, registerReservedJob } from "../jobs/reserved.js";
 
 const resourceListAllOwnersMock = vi.hoisted(() => vi.fn());
 const resourceGetByPathMock = vi.hoisted(() => vi.fn());
@@ -160,6 +161,26 @@ Record the QA signal.`,
     await tool().run({ action: "delete", name: "qa-alert" });
 
     expect(resourceDeleteMock).toHaveBeenCalledWith("resource-1");
+  });
+
+  it("refuses to define an automation whose name is reserved by a native loop", async () => {
+    registerReservedJob({
+      name: /^send-due-steps$/,
+      reason: "Sequencer runs this as native cron.",
+    });
+
+    const result = await tool().run({
+      action: "define",
+      name: "send-due-steps",
+      trigger_type: "schedule",
+      schedule: "* * * * *",
+      body: "duplicate of native cron",
+    });
+
+    expect(result).toContain("reserved");
+    expect(result).toContain("Sequencer runs this as native cron.");
+    expect(resourcePutMock).not.toHaveBeenCalled();
+    __clearReservedJobs();
   });
 
   it("scopes fire-test events to the current user", async () => {

--- a/packages/core/src/triggers/actions.ts
+++ b/packages/core/src/triggers/actions.ts
@@ -21,6 +21,7 @@ import {
 import { parseTriggerFrontmatter, buildTriggerContent } from "./dispatcher.js";
 import { refreshEventSubscriptions } from "./dispatcher.js";
 import type { TriggerFrontmatter } from "./types.js";
+import { findReservedJob } from "../jobs/reserved.js";
 
 /* ------------------------------------------------------------------ */
 /*  Individual action handlers                                        */
@@ -97,6 +98,11 @@ async function handleDefine(
   if (!name) return "Error: name is required (lowercase, hyphens).";
 
   const path = `jobs/${name}.md`;
+
+  const reserved = findReservedJob(name);
+  if (reserved) {
+    return `Error: "${name}" is reserved by a native background loop and cannot be created as an automation. ${reserved.reason}`;
+  }
 
   // Check if it already exists
   const existing = await resourceGetByPath(owner, path);

--- a/packages/core/src/triggers/index.ts
+++ b/packages/core/src/triggers/index.ts
@@ -11,3 +11,8 @@ export {
   __clearConditionCache,
 } from "./condition-evaluator.js";
 export { createAutomationToolEntries } from "./actions.js";
+export {
+  registerReservedJob,
+  findReservedJob,
+  type ReservedJob,
+} from "../jobs/reserved.js";


### PR DESCRIPTION
## Why

Templates that ship their own native background loops (TypeScript `setInterval` in `server/plugins/*.ts`) had no way to tell the framework "don't let the agent create a `jobs/*.md` automation with this name". Result: an agent in chat could (and did, in `apps/sequencer`) call `manage-automations define` to set up a one-minute agentic version of `send-due-steps` that ran a full `runAgentLoop` every tick — duplicating the native cron and burning Sonnet credits even when idle.

## What

One primitive in `@agent-native/core/jobs`:

```ts
import { registerReservedJob } from "@agent-native/core/jobs";

registerReservedJob({
  name: /^send-due-steps$|^check-replies$/,
  reason: "Native cron runs these every 60s in server/plugins/sequencer-jobs.ts.",
});
```

Both `manage-jobs.create` and `manage-automations.define` consult the registry and refuse to create matching `jobs/*.md` resources, surfacing the registered \`reason\` back to the agent in the error message. Existing jobs are untouched; this only gates new creations.

Templates without reservations behave identically.

## Surface area

- New: \`src/jobs/reserved.ts\` (~40 lines), tests in \`reserved.spec.ts\`
- Re-exported from \`@agent-native/core/jobs\` and \`@agent-native/core/triggers\`
- \`manage-jobs.create\` checks the registry (\`src/jobs/tools.ts\`)
- \`manage-automations.define\` checks the registry (\`src/triggers/actions.ts\`)
- Skill doc updated with the "Reserved Names" section so the agent knows how to react to the error
- Changeset: minor bump

## Test plan

- [x] Unit tests for the registry (exact + regex match, ordering)
- [x] Integration test in \`actions.spec.ts\`: \`define\` refuses a reserved name and does not write
- [x] \`pnpm vitest run src/jobs/reserved.spec.ts src/triggers/actions.spec.ts\` passes
- [ ] Sequencer follow-up: register reservations at startup and drop \`server/lib/purge-redundant-automations.ts\` (separate PR in \`builder-agent-native-workspace\`)

Made with [Cursor](https://cursor.com)