### PR TITLE
Include chat debug context in feedback

### DIFF
--- a/.changeset/chat-feedback-debug-context.md
+++ b/.changeset/chat-feedback-debug-context.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Include chat session context in feedback submissions and harden chat debug clipboard actions.

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -697,7 +697,8 @@ function AgentPanelInner({
   // Hide the CLI tab when embedded in the Builder.io frame — code editing
   // there happens via Builder, and the CLI panel only offers a Download
   // Desktop CTA, which adds clutter without value.
-  const showCliMode = (isDevMode || !codeAccessEnabled) && isDevFrameChatSurface;
+  const showCliMode =
+    (isDevMode || !codeAccessEnabled) && isDevFrameChatSurface;
   useEffect(() => {
     if (mode === "cli" && !showCliMode) switchMode("chat");
   }, [mode, showCliMode, switchMode]);

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -82,7 +82,7 @@ import { cn } from "./utils.js";
 import { agentNativePath } from "./api-path.js";
 import { trackEvent } from "./analytics.js";
 import { withBuilderConnectTrackingParams } from "./settings/useBuilderStatus.js";
-import { getFrameOrigin, isInFrame, isTrustedFrameMessage } from "./frame.js";
+import { getFrameOrigin, isTrustedFrameMessage } from "./frame.js";
 import { shouldParentFrameOwnAgentPanel } from "./builder-frame.js";
 import {
   consumeAgentSidebarUrlOpenOverride,
@@ -104,11 +104,6 @@ const AGENT_CHAT_RUNNING_EVENT = "agentNative.chatRunning";
 
 function parentFrameTargetOrigin(): string {
   return getFrameOrigin() ?? window.location.origin;
-}
-
-function isAgentNativeDesktop() {
-  if (typeof navigator === "undefined") return false;
-  return /AgentNativeDesktop/i.test(navigator.userAgent);
 }
 
 // Lazy-load ResourcesPanel to avoid bundling when not needed
@@ -680,8 +675,9 @@ function AgentPanelInner({
   const selectedLabel =
     availableClis.find((c) => c.command === selectedCli)?.label || selectedCli;
   const { isDevMode, canToggle, setDevMode } = useDevMode(apiUrl);
-  const inferredCodeAccessEnabled =
-    !isDevMode || isAgentNativeDesktop() || isInFrame();
+  const isDevFrameChatSurface =
+    assistantChatProps.agentChatSurface === "dev-frame";
+  const inferredCodeAccessEnabled = !isDevMode || isDevFrameChatSurface;
   const codeAccessEnabled = codeAccess?.enabled ?? inferredCodeAccessEnabled;
   const codeUnavailableTitle =
     codeAccess?.unavailableTitle ?? "Open Desktop to edit code";
@@ -696,11 +692,12 @@ function AgentPanelInner({
     codeAccess?.unavailableSecondaryCtaLabel ?? "Use Builder";
   const codeUnavailableSecondaryCtaHref =
     codeAccess?.unavailableSecondaryCtaHref;
-  const canUseCodeTools = isDevMode && codeAccessEnabled;
+  const canUseCodeTools =
+    isDevMode && codeAccessEnabled && isDevFrameChatSurface;
   // Hide the CLI tab when embedded in the Builder.io frame — code editing
   // there happens via Builder, and the CLI panel only offers a Download
   // Desktop CTA, which adds clutter without value.
-  const showCliMode = (isDevMode || !codeAccessEnabled) && !isInFrame();
+  const showCliMode = (isDevMode || !codeAccessEnabled) && isDevFrameChatSurface;
   useEffect(() => {
     if (mode === "cli" && !showCliMode) switchMode("chat");
   }, [mode, showCliMode, switchMode]);
@@ -733,7 +730,7 @@ function AgentPanelInner({
     (window.location.hostname === "localhost" ||
       window.location.hostname === "127.0.0.1" ||
       window.location.hostname === "::1");
-  const showDevToggle = canToggle && isLocalhost;
+  const showDevToggle = canToggle && isLocalhost && isDevFrameChatSurface;
 
   const renderModeButtons = useCallback(
     (activeMode: PanelMode) => (
@@ -840,6 +837,7 @@ function AgentPanelInner({
           side="bottom"
           align="end"
           chatSessionId={activeChatSessionId}
+          chatStorageKey={storageKey}
         />
         {onToggleFullscreen && (
           <IconTooltip

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -828,14 +828,19 @@ function AgentPanelInner({
   );
 
   const renderHeaderActions = useCallback(
-    () => (
+    (activeChatSessionId?: string) => (
       <div className="flex shrink-0 items-center gap-1.5">
         {SHOW_ONBOARDING && canUseCodeTools && (
           <Suspense fallback={null}>
             <SetupButton />
           </Suspense>
         )}
-        <FeedbackButton variant="icon" side="bottom" align="end" />
+        <FeedbackButton
+          variant="icon"
+          side="bottom"
+          align="end"
+          chatSessionId={activeChatSessionId}
+        />
         {onToggleFullscreen && (
           <IconTooltip
             content={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
@@ -912,7 +917,7 @@ function AgentPanelInner({
             {renderModeButtons(mode)}
           </div>
           <div className="flex items-center gap-0.5">
-            {renderHeaderActions()}
+            {renderHeaderActions(activeTabId)}
           </div>
         </div>
         {mode === "chat" && chatNotice ? (

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -34,7 +34,7 @@ import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
   createAgentChatAdapter,
-  type AgentChatSurface,
+  type AgentChatSurfaceKind,
 } from "./agent-chat-adapter.js";
 import {
   useAgentDynamicSuggestions,
@@ -3198,7 +3198,7 @@ export interface AssistantChatAdapterContext {
   execModeRef: { current: "build" | "plan" | undefined };
   browserTabId?: string;
   scopeRef: { current: ChatThreadScope | null | undefined };
-  surface: AgentChatSurface;
+  surface: AgentChatSurfaceKind;
 }
 
 export interface AssistantChatProps {
@@ -3216,7 +3216,7 @@ export interface AssistantChatProps {
    * Identifies which surface hosts this chat. Defaults to "app", which keeps
    * dev filesystem/bash code-editing tools out of in-product sidebars.
    */
-  agentChatSurface?: AgentChatSurface;
+  agentChatSurface?: AgentChatSurfaceKind;
   /** Placeholder text for empty state */
   emptyStateText?: string;
   /** Suggestion prompts shown when no messages */

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -51,6 +51,7 @@ import {
 } from "./sse-event-processor.js";
 import { captureError, trackEvent } from "./analytics.js";
 import { cn } from "./utils.js";
+import { writeClipboardText } from "./clipboard.js";
 import { useNearBottomAutoscroll } from "./conversation/index.js";
 import { TextAttachmentAdapter } from "./composer/attachment-accept.js";
 import { AgentTaskCard } from "./AgentTaskCard.js";
@@ -536,6 +537,18 @@ function shouldImportServerThreadData(currentRepo: any, incomingRepo: any) {
   }
 
   return true;
+}
+
+function cloneContentParts(content: ContentPart[]): ContentPart[] {
+  return content.map((part) =>
+    part.type === "text"
+      ? { ...part }
+      : {
+          ...part,
+          args: { ...part.args },
+          ...(part.mcpApp ? { mcpApp: { ...part.mcpApp } } : {}),
+        },
+  );
 }
 
 function clearPendingSelection() {
@@ -1301,10 +1314,11 @@ function ToolDetailViewer({ payload }: { payload: ToolDetailPayload }) {
 
   const copyValue = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(payload.copyText);
-      setCopied(true);
-      if (copyResetRef.current) clearTimeout(copyResetRef.current);
-      copyResetRef.current = setTimeout(() => setCopied(false), 1200);
+      if (await writeClipboardText(payload.copyText)) {
+        setCopied(true);
+        if (copyResetRef.current) clearTimeout(copyResetRef.current);
+        copyResetRef.current = setTimeout(() => setCopied(false), 1200);
+      }
     } catch {
       // Clipboard failures should not interrupt chat rendering.
     }
@@ -2105,12 +2119,14 @@ function MessageActionsMenu({
       .filter((p) => p.type === "text")
       .map((p) => (p as { text: string }).text)
       .join("\n");
-    navigator.clipboard.writeText(text);
-    setCopied("message");
-    setTimeout(() => {
-      setCopied(null);
-      setOpen(false);
-    }, 1000);
+    void writeClipboardText(text).then((ok) => {
+      if (!ok) return;
+      setCopied("message");
+      setTimeout(() => {
+        setCopied(null);
+        setOpen(false);
+      }, 1000);
+    });
   }, [messageRuntime]);
 
   const handleCopyRequestId = useCallback(() => {
@@ -2132,12 +2148,14 @@ function MessageActionsMenu({
       (typeof window !== "undefined" ? getActiveRun()?.runId : null) ||
       m.id ||
       "";
-    navigator.clipboard.writeText(runId);
-    setCopied("id");
-    setTimeout(() => {
-      setCopied(null);
-      setOpen(false);
-    }, 1000);
+    void writeClipboardText(runId).then((ok) => {
+      if (!ok) return;
+      setCopied("id");
+      setTimeout(() => {
+        setCopied(null);
+        setOpen(false);
+      }, 1000);
+    });
   }, [messageRuntime]);
 
   const handleForkChat = useCallback(() => {
@@ -2740,9 +2758,11 @@ function RunErrorRecoveryCard({
     ]
       .filter(Boolean)
       .join("\n\n");
-    navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1200);
+    void writeClipboardText(text).then((ok) => {
+      if (!ok) return;
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    });
   }, [info]);
   const startNewChat = useCallback(() => {
     window.dispatchEvent(new CustomEvent("agent-chat:new-chat"));
@@ -4398,6 +4418,68 @@ const AssistantChatInner = forwardRef<
     }
   }, [isReconnecting, forceStopped]);
 
+  const materializeFrozenReconnectContent = useCallback(() => {
+    if (!reconnectFrozen || reconnectContent.length === 0) return;
+    try {
+      const repo = normalizeThreadRepository(threadRuntime.export());
+      const messages = getRepoMessages(repo);
+      const lastEntry = messages[messages.length - 1];
+      const lastMessage = getRepoMessage(lastEntry);
+      const parentId =
+        typeof repo.headId === "string"
+          ? repo.headId
+          : typeof lastMessage?.id === "string"
+            ? lastMessage.id
+            : null;
+      const runId = runErrorInfo?.runId ?? reconnectRunIdRef.current;
+      const id = `reconnect-${runId ?? Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+      repo.messages = [
+        ...messages,
+        {
+          parentId,
+          message: {
+            id,
+            role: "assistant",
+            createdAt: new Date(),
+            content: cloneContentParts(reconnectContent),
+            status: { type: "complete", reason: "stop" },
+            metadata: {
+              custom: {
+                reconnectFrozen: true,
+                ...(runId ? { runId } : {}),
+              },
+            },
+          },
+        },
+      ];
+      repo.headId = id;
+
+      threadRuntime.import(ensureMessageMetadata(repo));
+      setReconnectFrozen(false);
+      setReconnectContent([]);
+    } catch (err) {
+      captureError(err, {
+        tags: {
+          source: "agent-chat-client",
+          phase: "materialize-reconnect-content",
+        },
+        extra: {
+          threadId: threadId ?? null,
+          tabId: tabId ?? null,
+          reconnectParts: reconnectContent.length,
+        },
+      });
+    }
+  }, [
+    reconnectFrozen,
+    reconnectContent,
+    runErrorInfo?.runId,
+    tabId,
+    threadId,
+    threadRuntime,
+  ]);
+
   const addToQueue = useCallback(
     async (
       text: string,
@@ -4407,6 +4489,7 @@ const AssistantChatInner = forwardRef<
       requestMode?: AgentRequestMode,
       intent: ComposerSubmitIntent = "queued",
     ) => {
+      materializeFrozenReconnectContent();
       setShowContinue(false);
       setLoopLimitInfo(null);
       setRunErrorInfo(null);
@@ -4469,7 +4552,7 @@ const AssistantChatInner = forwardRef<
         } as Parameters<typeof threadRuntime.append>[0]);
       }
     },
-    [execMode, isRunning, threadRuntime],
+    [execMode, isRunning, materializeFrozenReconnectContent, threadRuntime],
   );
 
   // Expose imperative handle

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -32,7 +32,10 @@ import { CompositeAttachmentAdapter } from "@assistant-ui/react";
 import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { createAgentChatAdapter } from "./agent-chat-adapter.js";
+import {
+  createAgentChatAdapter,
+  type AgentChatSurface,
+} from "./agent-chat-adapter.js";
 import {
   useAgentDynamicSuggestions,
   type AgentDynamicSuggestionsOption,
@@ -3195,6 +3198,7 @@ export interface AssistantChatAdapterContext {
   execModeRef: { current: "build" | "plan" | undefined };
   browserTabId?: string;
   scopeRef: { current: ChatThreadScope | null | undefined };
+  surface: AgentChatSurface;
 }
 
 export interface AssistantChatProps {
@@ -3208,6 +3212,11 @@ export interface AssistantChatProps {
   threadId?: string;
   /** Resource scope to include with chat requests for server-side context. */
   contextScope?: ChatThreadScope | null;
+  /**
+   * Identifies which surface hosts this chat. Defaults to "app", which keeps
+   * dev filesystem/bash code-editing tools out of in-product sidebars.
+   */
+  agentChatSurface?: AgentChatSurface;
   /** Placeholder text for empty state */
   emptyStateText?: string;
   /** Suggestion prompts shown when no messages */
@@ -5172,6 +5181,7 @@ export const AssistantChat = forwardRef<
   execModeRef.current = props.execMode;
   const scopeRef = useRef<ChatThreadScope | null | undefined>(contextScope);
   scopeRef.current = contextScope;
+  const surface = props.agentChatSurface ?? "app";
   const createAdapterRef = useRef(props.createAdapter);
   createAdapterRef.current = props.createAdapter;
 
@@ -5187,6 +5197,7 @@ export const AssistantChat = forwardRef<
         execModeRef,
         browserTabId,
         scopeRef,
+        surface,
       };
       const createAdapter = createAdapterRef.current;
       return createAdapter
@@ -5196,7 +5207,7 @@ export const AssistantChat = forwardRef<
     // Adapter factories must be memoized and use refs for changing values.
     // `adapterReloadKey` is an explicit opt-in for embedded hosts whose
     // transport identity can change without changing tab/thread ids.
-    [apiUrl, tabId, threadId, browserTabId, props.adapterReloadKey],
+    [apiUrl, tabId, threadId, browserTabId, surface, props.adapterReloadKey],
   );
   const attachmentAdapter = useMemo(
     () =>

--- a/packages/core/src/client/FeedbackButton.tsx
+++ b/packages/core/src/client/FeedbackButton.tsx
@@ -11,6 +11,7 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { IconMessage2, IconCheck } from "@tabler/icons-react";
 import { cn } from "./utils.js";
 import { useSession } from "./use-session.js";
+import { getFeedbackClientContext } from "./feedback-context.js";
 
 const DEFAULT_FEEDBACK_URL =
   "https://forms.agent-native.com/f/agent-native-feedback/_16ewV";
@@ -86,6 +87,8 @@ export interface FeedbackButtonProps {
   align?: "start" | "center" | "end";
   /** Placeholder text for the textarea. */
   placeholder?: string;
+  /** Current chat session/thread id, when the host already knows it. */
+  chatSessionId?: string | null;
 }
 
 const surfaceStyle: CSSProperties = {
@@ -109,6 +112,7 @@ export function FeedbackButton({
   side,
   align = "end",
   placeholder,
+  chatSessionId,
 }: FeedbackButtonProps) {
   const target = parseTarget(url);
   const { session } = useSession();
@@ -169,6 +173,7 @@ export function FeedbackButton({
         const resolvedSchema = schema ?? (await loadSchema(target));
         if (!schema) setSchema(resolvedSchema);
         const submitterEmail = session?.email;
+        const feedbackContext = getFeedbackClientContext(chatSessionId);
         const res = await fetch(
           `${target.endpoint}/api/submit/${encodeURIComponent(resolvedSchema.formId)}`,
           {
@@ -178,7 +183,10 @@ export function FeedbackButton({
               data: { [resolvedSchema.fieldId]: trimmed },
               _t: openedAtRef.current,
               _hp: honeypot,
-              ...(submitterEmail ? { _meta: { submitterEmail } } : {}),
+              _meta: {
+                ...(submitterEmail ? { submitterEmail } : {}),
+                ...feedbackContext,
+              },
             }),
           },
         );
@@ -195,7 +203,15 @@ export function FeedbackButton({
         setError(err instanceof Error ? err.message : "Couldn't send feedback");
       }
     },
-    [target, schema, value, honeypot, submitting, session?.email],
+    [
+      target,
+      schema,
+      value,
+      honeypot,
+      submitting,
+      session?.email,
+      chatSessionId,
+    ],
   );
 
   let trigger;

--- a/packages/core/src/client/FeedbackButton.tsx
+++ b/packages/core/src/client/FeedbackButton.tsx
@@ -89,6 +89,8 @@ export interface FeedbackButtonProps {
   placeholder?: string;
   /** Current chat session/thread id, when the host already knows it. */
   chatSessionId?: string | null;
+  /** Chat localStorage namespace, when the host uses per-app chat storage. */
+  chatStorageKey?: string | null;
 }
 
 const surfaceStyle: CSSProperties = {
@@ -113,6 +115,7 @@ export function FeedbackButton({
   align = "end",
   placeholder,
   chatSessionId,
+  chatStorageKey,
 }: FeedbackButtonProps) {
   const target = parseTarget(url);
   const { session } = useSession();
@@ -173,7 +176,10 @@ export function FeedbackButton({
         const resolvedSchema = schema ?? (await loadSchema(target));
         if (!schema) setSchema(resolvedSchema);
         const submitterEmail = session?.email;
-        const feedbackContext = getFeedbackClientContext(chatSessionId);
+        const feedbackContext = getFeedbackClientContext({
+          chatSessionId,
+          storageKey: chatStorageKey,
+        });
         const res = await fetch(
           `${target.endpoint}/api/submit/${encodeURIComponent(resolvedSchema.formId)}`,
           {
@@ -211,6 +217,7 @@ export function FeedbackButton({
       submitting,
       session?.email,
       chatSessionId,
+      chatStorageKey,
     ],
   );
 

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -196,6 +196,7 @@ describe("createAgentChatAdapter", () => {
     const [url, init] = fetchSpy.mock.calls[0];
     expect(url).toBe("/_agent-native/agent-chat");
     expect(init.method).toBe("POST");
+    expect(init.headers["x-agent-native-surface"]).toBe("app");
 
     const body = JSON.parse(init.body);
     expect(body).toMatchObject({
@@ -477,6 +478,31 @@ describe("createAgentChatAdapter", () => {
         },
       ],
     });
+  });
+
+  it("sends the explicit dev-frame surface for outer frame-hosted chat", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(sseResponse([{ type: "done" }]));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      surface: "dev-frame",
+    });
+
+    await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Add a feature" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.headers["x-agent-native-surface"]).toBe("dev-frame");
   });
 
   it("truncates large outbound text attachments before posting", async () => {

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -20,7 +20,7 @@ import type {
 } from "../agent/types.js";
 import type { ChatThreadScope } from "./use-chat-threads.js";
 
-export type AgentChatSurface =
+export type AgentChatSurfaceKind =
   /**
    * Chat rendered by the app itself, including the normal AgentSidebar. This
    * surface must not receive code-editing dev tools because source edits can
@@ -786,7 +786,7 @@ export function createAgentChatAdapter(options?: {
   execModeRef?: { current: "build" | "plan" | undefined };
   browserTabId?: string;
   scopeRef?: { current: ChatThreadScope | null | undefined };
-  surface?: AgentChatSurface;
+  surface?: AgentChatSurfaceKind;
 }): ChatModelAdapter {
   const apiUrl =
     options?.apiUrl ?? agentNativePath("/_agent-native/agent-chat");

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -20,6 +20,16 @@ import type {
 } from "../agent/types.js";
 import type { ChatThreadScope } from "./use-chat-threads.js";
 
+export type AgentChatSurface =
+  /**
+   * Chat rendered by the app itself, including the normal AgentSidebar. This
+   * surface must not receive code-editing dev tools because source edits can
+   * reload the same React tree that is hosting the chat.
+   */
+  | "app"
+  /** Chat rendered by the outer local dev frame, outside the app iframe. */
+  | "dev-frame";
+
 type AdapterHistoryMessage = {
   role: "user" | "assistant";
   content: string;
@@ -776,6 +786,7 @@ export function createAgentChatAdapter(options?: {
   execModeRef?: { current: "build" | "plan" | undefined };
   browserTabId?: string;
   scopeRef?: { current: ChatThreadScope | null | undefined };
+  surface?: AgentChatSurface;
 }): ChatModelAdapter {
   const apiUrl =
     options?.apiUrl ?? agentNativePath("/_agent-native/agent-chat");
@@ -787,6 +798,7 @@ export function createAgentChatAdapter(options?: {
   const execModeRef = options?.execModeRef;
   const browserTabId = options?.browserTabId;
   const scopeRef = options?.scopeRef;
+  const surface = options?.surface ?? "app";
 
   return {
     async *run({ messages, abortSignal, runConfig }) {
@@ -1019,26 +1031,11 @@ export function createAgentChatAdapter(options?: {
         } catch {
           // Non-browser or Intl unavailable — tool calls will fall back to UTC.
         }
-        // Surface hint — the server uses this to gate code-editing dev tools
-        // when the chat is running in a plain browser tab on localhost. Editing
-        // source files there would trigger HMR/page reloads and kill the chat
-        // session, so the agent must redirect users to Desktop / Claude Code /
-        // Codex / Builder.io instead of attempting code work.
-        try {
-          const ua =
-            typeof navigator !== "undefined" ? navigator.userAgent || "" : "";
-          const inIframe =
-            typeof window !== "undefined" && window.parent !== window;
-          const surface = /AgentNativeDesktop/i.test(ua)
-            ? "desktop"
-            : inIframe
-              ? "frame"
-              : "browser";
-          headers["x-agent-native-surface"] = surface;
-        } catch {
-          // Non-browser environment — leave the header off and let the server
-          // fall back to its own UA/host detection.
-        }
+        // Surface hint — the server uses this to keep code-editing dev tools
+        // out of the app-rendered sidebar. The outer dev frame passes
+        // "dev-frame" explicitly; the reusable in-product chat defaults to
+        // "app" even when it is running in Desktop or inside a preview iframe.
+        headers["x-agent-native-surface"] = surface;
 
         const reconnectCurrentRun = async function* (): AsyncGenerator<
           ChatModelRunResult,

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -5,6 +5,8 @@ import {
   llmConnectionTrackingProperties,
   type LlmConnectionStatus,
 } from "../shared/llm-connection.js";
+import { scrubUrl } from "./url-scrub.js";
+export { scrubUrl } from "./url-scrub.js";
 
 declare global {
   interface Window {
@@ -232,45 +234,6 @@ function ensureAmplitude(): boolean {
   amplitude.init(key, { autocapture: true });
   _amplitudeInitialized = true;
   return true;
-}
-
-/**
- * Query parameters that may carry sensitive values in the URL bar. Browser
- * Sentry collects `event.request.url` automatically; without scrubbing,
- * share tokens, password params (F-07), email-confirm tokens, etc. land in
- * Sentry events and become a recon vector for anyone with project access.
- */
-const SENSITIVE_QUERY_PARAMS = new Set([
-  "password",
-  "p",
-  "token",
-  "state",
-  "code",
-  "share",
-  "share_token",
-]);
-
-function scrubUrl(url: string | undefined): string | undefined {
-  if (!url || typeof url !== "string") return url;
-  try {
-    // Parse using a base origin so relative URLs still work.
-    const u = new URL(url, "http://placeholder.local");
-    let mutated = false;
-    for (const key of Array.from(u.searchParams.keys())) {
-      if (SENSITIVE_QUERY_PARAMS.has(key.toLowerCase())) {
-        u.searchParams.set(key, "<redacted>");
-        mutated = true;
-      }
-    }
-    if (!mutated) return url;
-    // If the original URL was relative, return only the path/query/fragment.
-    if (u.origin === "http://placeholder.local") {
-      return `${u.pathname}${u.search}${u.hash}`;
-    }
-    return u.toString();
-  } catch {
-    return url;
-  }
 }
 
 function shouldDropBrowserSentryNoise(event: Sentry.Event): boolean {

--- a/packages/core/src/client/clipboard.ts
+++ b/packages/core/src/client/clipboard.ts
@@ -1,0 +1,58 @@
+type ElectronClipboardApi = {
+  clipboard?: {
+    writeText?: (text: string) => boolean | Promise<boolean>;
+  };
+};
+
+function getElectronClipboard(): ElectronClipboardApi["clipboard"] | null {
+  const api = (
+    globalThis as typeof globalThis & {
+      electronAPI?: ElectronClipboardApi;
+    }
+  ).electronAPI;
+  return api?.clipboard ?? null;
+}
+
+function writeWithExecCommand(text: string): boolean {
+  if (typeof document === "undefined") return false;
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "0";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, text.length);
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+export async function writeClipboardText(text: string): Promise<boolean> {
+  const electronClipboard = getElectronClipboard();
+  if (electronClipboard?.writeText) {
+    try {
+      const result = await electronClipboard.writeText(text);
+      if (result !== false) return true;
+    } catch {
+      // Fall through to browser clipboard options.
+    }
+  }
+
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Embedded surfaces can deny async clipboard even with clipboard-write.
+    }
+  }
+
+  return writeWithExecCommand(text);
+}

--- a/packages/core/src/client/feedback-context.spec.ts
+++ b/packages/core/src/client/feedback-context.spec.ts
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { getFeedbackClientContext } from "./feedback-context.js";
+
+describe("getFeedbackClientContext", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("returns explicit, active-run, and recently open chat session ids", () => {
+    sessionStorage.setItem(
+      "agent-chat-active-run",
+      JSON.stringify({
+        threadId: "running-thread",
+        runId: "run-1",
+        lastSeq: 3,
+      }),
+    );
+    localStorage.setItem("agent-chat-active-thread", "general-thread");
+    localStorage.setItem("agent-chat-active-thread:seen", "100");
+    localStorage.setItem(
+      "agent-chat-active-thread:app:scope:deck:deck-1",
+      "scoped-thread",
+    );
+    localStorage.setItem(
+      "agent-chat-active-thread:app:scope:deck:deck-1:seen",
+      "200",
+    );
+
+    const context = getFeedbackClientContext("explicit-thread");
+
+    expect(context.chatSessionIds).toEqual([
+      "explicit-thread",
+      "running-thread",
+      "scoped-thread",
+      "general-thread",
+    ]);
+    expect(context.activeRunId).toBe("run-1");
+    expect(context.pageUrl).toBe(window.location.href);
+  });
+
+  it("dedupes chat session ids", () => {
+    sessionStorage.setItem(
+      "agent-chat-active-run",
+      JSON.stringify({
+        threadId: "same-thread",
+        runId: "run-1",
+        lastSeq: 3,
+      }),
+    );
+    localStorage.setItem("agent-chat-active-thread", "same-thread");
+
+    const context = getFeedbackClientContext("same-thread");
+
+    expect(context.chatSessionIds).toEqual(["same-thread"]);
+  });
+});

--- a/packages/core/src/client/feedback-context.spec.ts
+++ b/packages/core/src/client/feedback-context.spec.ts
@@ -7,9 +7,11 @@ describe("getFeedbackClientContext", () => {
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
+    window.history.replaceState(null, "", "/");
   });
 
-  it("returns explicit, active-run, and recently open chat session ids", () => {
+  it("returns explicit, active-run, and recently open namespaced chat session ids", () => {
+    window.history.replaceState(null, "", "/inbox?token=secret&utm=ok#section");
     sessionStorage.setItem(
       "agent-chat-active-run",
       JSON.stringify({
@@ -28,17 +30,29 @@ describe("getFeedbackClientContext", () => {
       "agent-chat-active-thread:app:scope:deck:deck-1:seen",
       "200",
     );
+    localStorage.setItem(
+      "agent-chat-active-thread:other:scope:deck:deck-2",
+      "other-app-thread",
+    );
+    localStorage.setItem(
+      "agent-chat-active-thread:other:scope:deck:deck-2:seen",
+      "300",
+    );
 
-    const context = getFeedbackClientContext("explicit-thread");
+    const context = getFeedbackClientContext({
+      chatSessionId: "explicit-thread",
+      storageKey: "app",
+    });
 
     expect(context.chatSessionIds).toEqual([
       "explicit-thread",
       "running-thread",
       "scoped-thread",
-      "general-thread",
     ]);
     expect(context.activeRunId).toBe("run-1");
-    expect(context.pageUrl).toBe(window.location.href);
+    expect(context.pageUrl).toBe(
+      "http://localhost:3000/inbox?token=%3Credacted%3E&utm=ok#section",
+    );
   });
 
   it("dedupes chat session ids", () => {
@@ -52,7 +66,7 @@ describe("getFeedbackClientContext", () => {
     );
     localStorage.setItem("agent-chat-active-thread", "same-thread");
 
-    const context = getFeedbackClientContext("same-thread");
+    const context = getFeedbackClientContext({ chatSessionId: "same-thread" });
 
     expect(context.chatSessionIds).toEqual(["same-thread"]);
   });

--- a/packages/core/src/client/feedback-context.ts
+++ b/packages/core/src/client/feedback-context.ts
@@ -1,0 +1,73 @@
+import { getActiveRun } from "./active-run-state.js";
+
+export interface FeedbackClientContext {
+  chatSessionIds: string[];
+  activeRunId?: string;
+  pageUrl?: string;
+}
+
+const ACTIVE_THREAD_KEY_PREFIX = "agent-chat-active-thread";
+const MAX_CHAT_SESSION_IDS = 5;
+
+function isThreadStorageKey(key: string): boolean {
+  return (
+    key === ACTIVE_THREAD_KEY_PREFIX ||
+    (key.startsWith(`${ACTIVE_THREAD_KEY_PREFIX}:`) && !key.endsWith(":seen"))
+  );
+}
+
+function readSeenAt(key: string): number {
+  try {
+    const raw = localStorage.getItem(`${key}:seen`);
+    const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+    return Number.isFinite(parsed) ? parsed : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function addId(ids: Set<string>, value: unknown): void {
+  if (typeof value !== "string") return;
+  const trimmed = value.trim();
+  if (trimmed) ids.add(trimmed);
+}
+
+function recentStoredThreadIds(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const candidates: Array<{ id: string; seenAt: number }> = [];
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (!key || !isThreadStorageKey(key)) continue;
+      const id = localStorage.getItem(key)?.trim();
+      if (!id) continue;
+      candidates.push({ id, seenAt: readSeenAt(key) });
+    }
+    candidates.sort((a, b) => b.seenAt - a.seenAt);
+    return candidates.map((candidate) => candidate.id);
+  } catch {
+    return [];
+  }
+}
+
+export function getFeedbackClientContext(
+  chatSessionId?: string | null,
+): FeedbackClientContext {
+  const ids = new Set<string>();
+  addId(ids, chatSessionId);
+
+  const activeRun = typeof window !== "undefined" ? getActiveRun() : null;
+  addId(ids, activeRun?.threadId);
+
+  for (const id of recentStoredThreadIds()) {
+    addId(ids, id);
+    if (ids.size >= MAX_CHAT_SESSION_IDS) break;
+  }
+
+  const context: FeedbackClientContext = {
+    chatSessionIds: [...ids].slice(0, MAX_CHAT_SESSION_IDS),
+  };
+  if (activeRun?.runId) context.activeRunId = activeRun.runId;
+  if (typeof window !== "undefined") context.pageUrl = window.location.href;
+  return context;
+}

--- a/packages/core/src/client/feedback-context.ts
+++ b/packages/core/src/client/feedback-context.ts
@@ -1,4 +1,5 @@
 import { getActiveRun } from "./active-run-state.js";
+import { scrubUrl } from "./url-scrub.js";
 
 export interface FeedbackClientContext {
   chatSessionIds: string[];
@@ -6,13 +7,23 @@ export interface FeedbackClientContext {
   pageUrl?: string;
 }
 
+export interface FeedbackClientContextOptions {
+  chatSessionId?: string | null;
+  storageKey?: string | null;
+}
+
 const ACTIVE_THREAD_KEY_PREFIX = "agent-chat-active-thread";
 const MAX_CHAT_SESSION_IDS = 5;
 
-function isThreadStorageKey(key: string): boolean {
+function isThreadStorageKey(key: string, storageKey?: string | null): boolean {
+  if (key.endsWith(":seen")) return false;
+  if (storageKey) {
+    const namespaced = `${ACTIVE_THREAD_KEY_PREFIX}:${storageKey}`;
+    return key === namespaced || key.startsWith(`${namespaced}:scope:`);
+  }
   return (
     key === ACTIVE_THREAD_KEY_PREFIX ||
-    (key.startsWith(`${ACTIVE_THREAD_KEY_PREFIX}:`) && !key.endsWith(":seen"))
+    key.startsWith(`${ACTIVE_THREAD_KEY_PREFIX}:scope:`)
   );
 }
 
@@ -32,13 +43,13 @@ function addId(ids: Set<string>, value: unknown): void {
   if (trimmed) ids.add(trimmed);
 }
 
-function recentStoredThreadIds(): string[] {
+function recentStoredThreadIds(storageKey?: string | null): string[] {
   if (typeof window === "undefined") return [];
   try {
     const candidates: Array<{ id: string; seenAt: number }> = [];
     for (let i = 0; i < localStorage.length; i += 1) {
       const key = localStorage.key(i);
-      if (!key || !isThreadStorageKey(key)) continue;
+      if (!key || !isThreadStorageKey(key, storageKey)) continue;
       const id = localStorage.getItem(key)?.trim();
       if (!id) continue;
       candidates.push({ id, seenAt: readSeenAt(key) });
@@ -51,15 +62,15 @@ function recentStoredThreadIds(): string[] {
 }
 
 export function getFeedbackClientContext(
-  chatSessionId?: string | null,
+  options: FeedbackClientContextOptions = {},
 ): FeedbackClientContext {
   const ids = new Set<string>();
-  addId(ids, chatSessionId);
+  addId(ids, options.chatSessionId);
 
   const activeRun = typeof window !== "undefined" ? getActiveRun() : null;
   addId(ids, activeRun?.threadId);
 
-  for (const id of recentStoredThreadIds()) {
+  for (const id of recentStoredThreadIds(options.storageKey)) {
     addId(ids, id);
     if (ids.size >= MAX_CHAT_SESSION_IDS) break;
   }
@@ -68,6 +79,8 @@ export function getFeedbackClientContext(
     chatSessionIds: [...ids].slice(0, MAX_CHAT_SESSION_IDS),
   };
   if (activeRun?.runId) context.activeRunId = activeRun.runId;
-  if (typeof window !== "undefined") context.pageUrl = window.location.href;
+  if (typeof window !== "undefined") {
+    context.pageUrl = scrubUrl(window.location.href);
+  }
   return context;
 }

--- a/packages/core/src/client/url-scrub.ts
+++ b/packages/core/src/client/url-scrub.ts
@@ -1,0 +1,38 @@
+/**
+ * Query parameters that may carry sensitive values in the URL bar. Browser
+ * telemetry and feedback integrations must not copy OAuth codes, share tokens,
+ * password params, email-confirm tokens, or similar secrets into downstream
+ * systems.
+ */
+const SENSITIVE_QUERY_PARAMS = new Set([
+  "password",
+  "p",
+  "token",
+  "state",
+  "code",
+  "share",
+  "share_token",
+]);
+
+export function scrubUrl(url: string | undefined): string | undefined {
+  if (!url || typeof url !== "string") return url;
+  try {
+    // Parse using a base origin so relative URLs still work.
+    const u = new URL(url, "http://placeholder.local");
+    let mutated = false;
+    for (const key of Array.from(u.searchParams.keys())) {
+      if (SENSITIVE_QUERY_PARAMS.has(key.toLowerCase())) {
+        u.searchParams.set(key, "<redacted>");
+        mutated = true;
+      }
+    }
+    if (!mutated) return url;
+    // If the original URL was relative, return only the path/query/fragment.
+    if (u.origin === "http://placeholder.local") {
+      return `${u.pathname}${u.search}${u.hash}`;
+    }
+    return u.toString();
+  } catch {
+    return url;
+  }
+}

--- a/packages/core/src/server/agent-chat-plugin.surface.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.surface.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { shouldBlockInProductCodeEditingSurface } from "./agent-chat-plugin.js";
+
+describe("shouldBlockInProductCodeEditingSurface", () => {
+  it("blocks app-rendered chat surfaces, including legacy iframe labels", () => {
+    expect(
+      shouldBlockInProductCodeEditingSurface({
+        surface: "app",
+        userAgent: "Mozilla/5.0",
+        host: "preview.builder.io",
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockInProductCodeEditingSurface({
+        surface: "frame",
+        userAgent: "Mozilla/5.0",
+        host: "preview.builder.io",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows explicit dev-frame and desktop host surfaces", () => {
+    expect(
+      shouldBlockInProductCodeEditingSurface({
+        surface: "dev-frame",
+        userAgent: "Mozilla/5.0",
+        host: "localhost:3334",
+      }),
+    ).toBe(false);
+    expect(
+      shouldBlockInProductCodeEditingSurface({
+        surface: "desktop",
+        userAgent: "AgentNativeDesktop/0.1.7",
+        host: "localhost:8080",
+      }),
+    ).toBe(false);
+  });
+
+  it("treats missing browser headers as app-rendered but preserves non-browser callers", () => {
+    expect(
+      shouldBlockInProductCodeEditingSurface({
+        userAgent: "Mozilla/5.0 Chrome/124",
+        host: "preview.builder.io",
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockInProductCodeEditingSurface({
+        userAgent: "agent-native-cli",
+        host: "agent.example.com",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2947,6 +2947,59 @@ function isLocalhost(event: any): boolean {
   }
 }
 
+type AgentChatRequestSurface = "app" | "dev-frame" | "desktop";
+
+function normalizeAgentChatRequestSurface(
+  value: string | null | undefined,
+): AgentChatRequestSurface | null {
+  const normalized = (value ?? "").trim().toLowerCase();
+  if (
+    normalized === "app" ||
+    normalized === "dev-frame" ||
+    normalized === "desktop"
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+function isBrowserUserAgent(userAgent: string | null | undefined): boolean {
+  return /Mozilla\/|Chrome\/|Safari\/|Firefox\/|Edg\//i.test(userAgent ?? "");
+}
+
+export function shouldBlockInProductCodeEditingSurface(input: {
+  surface?: string | null;
+  userAgent?: string | null;
+  host?: string | null;
+}): boolean {
+  const surface = normalizeAgentChatRequestSurface(input.surface);
+  if (surface === "dev-frame") return false;
+  if (surface === "desktop") return false;
+  if (surface === "app") return true;
+
+  // Legacy clients used to send `frame` for any iframe, which includes the
+  // app-rendered sidebar inside preview frames. Treat unknown explicit surface
+  // values as app-owned so they cannot accidentally receive dev code tools.
+  if (input.surface && input.surface.trim()) return true;
+
+  const userAgent = input.userAgent ?? "";
+  if (/AgentNativeDesktop/i.test(userAgent)) return false;
+
+  // Missing header from an older browser client. Be conservative for browser
+  // UAs on any host, because preview URLs can be non-local while still running
+  // a dev-mode app whose in-product chat would be reloaded by source edits.
+  if (isBrowserUserAgent(userAgent)) return true;
+
+  const host = (input.host ?? "").toLowerCase();
+  const hostname = host.split(":")[0] ?? "";
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "[::1]"
+  );
+}
+
 export function createAgentChatPlugin(
   options?: AgentChatPluginOptions,
 ): NitroPluginDef {
@@ -4455,72 +4508,48 @@ export function createAgentChatPlugin(
         return buildRuntimeContextPrompt({ timezone });
       };
 
-      // Chat-in-browser-on-localdev is the one surface where the agent must
-      // not edit code: source-file edits trigger Vite HMR / page reloads and
-      // kill the chat session mid-run. The client sends an
-      // `x-agent-native-surface` header (desktop | frame | browser); we fall
-      // back to UA + Host inspection when the header is missing (older clients,
-      // server-to-server callers, etc.). Returning true forces the prod
-      // handler (no shell / no fs) AND injects a redirect-prompt block telling
-      // the agent to point users at Desktop / Claude Code / Codex / Builder.io.
-      const isChatInBrowserOnLocalDev = (event: any): boolean => {
-        const surface = (
-          getHeader(event, "x-agent-native-surface") || ""
-        ).toLowerCase();
-        const ua = getHeader(event, "user-agent") || "";
-        const isDesktop =
-          surface === "desktop" || /AgentNativeDesktop/i.test(ua);
-        if (isDesktop) return false;
-        if (surface === "frame") return false;
-        const host = (getHeader(event, "host") || "").toLowerCase();
-        const hostname = host.split(":")[0] ?? "";
-        const isLocal =
-          hostname === "localhost" ||
-          hostname === "127.0.0.1" ||
-          hostname === "::1" ||
-          hostname === "[::1]";
-        if (!isLocal) return false;
-        // No header from an older client + non-desktop UA: be conservative and
-        // only trip on plain browser UAs. Treat unknown clients as safe (frame
-        // / desktop / scripting) so we don't break their tool access.
-        if (!surface) {
-          return /Mozilla\/|Chrome\/|Safari\/|Firefox\/|Edg\//i.test(ua);
-        }
-        return surface === "browser";
-      };
+      // The app-rendered sidebar must never edit the app's source code
+      // directly. Source-file edits can trigger HMR or full reloads of the
+      // same React tree that is hosting the chat, interrupting the run and
+      // losing in-progress UI state. Code edits are allowed only from the
+      // outer dev frame (x-agent-native-surface: dev-frame) or from separate
+      // agent surfaces such as Builder/A2A/MCP handoffs.
+      const shouldBlockInProductCodeEditing = (event: any): boolean =>
+        shouldBlockInProductCodeEditingSurface({
+          surface: getHeader(event, "x-agent-native-surface"),
+          userAgent: getHeader(event, "user-agent"),
+          host: getHeader(event, "host"),
+        });
 
-      const CHAT_IN_BROWSER_LOCAL_DEV_PROMPT = `
+      const APP_RENDERED_CHAT_NO_DIRECT_CODE_PROMPT = `
 
-<chat-in-browser-on-localdev>
-This chat is running in a plain browser tab on localhost. Source-code edits would trigger Vite HMR or a full page reload, which kills the chat session mid-run, so source-code work cannot happen on this surface.
+<app-rendered-chat-no-direct-code-edits>
+This chat is rendered by the app itself. It must never edit this app's source files directly, because source edits can hot-reload or replace the same UI that is hosting the chat.
 
-When the user asks for ANY of the following — add a feature, edit a component, fix a bug in the app itself, change styles, add a route, scaffold a new app, run shell commands that modify code, or anything else that requires touching source files:
+When the user asks to add a feature, edit a component, fix a bug in the app itself, change styles, add a route, scaffold a new app, run shell commands that modify code, or do anything else that requires touching source files:
 
-1. Do NOT call \`connect-builder\`, \`scaffold-workspace-app\`, \`start-workspace-app-creation\`, or any other tool that creates or edits source.
-2. Do NOT write code, list files, propose patches, or describe what you would change.
-3. Reply with one short message saying chat-in-browser on localhost can't edit code (page reloads kill the session). If — and only if — the request is specifically to **add or scaffold a new workspace app**, lead with the CLI option since it runs in the same terminal the user is already using:
-   - **Agent Native CLI** — \`npx @agent-native/core add-app\` in this workspace directory (best for template apps like Mail/Calendar/Slides; the workspace gateway picks them up automatically)
+1. Do NOT use dev shell/filesystem tools, write code inline, list source files, propose patches, or describe file-level implementation steps from this chat.
+2. For host-app source changes in Act mode, call \`connect-builder\` when that tool is available so a separate Builder/cloud agent can do the work. If Builder is unavailable, give a short handoff to the outer dev frame, Agent Native Desktop, Claude Code, or Codex in the project directory.
+3. If the request is specifically to add or scaffold a new workspace app and no Builder handoff is available, mention \`npx @agent-native/core add-app\` in this workspace directory as the CLI path.
 
-   Then offer these alternatives for general source-editing work, in this order:
-   - **Agent Native Desktop** — https://www.agent-native.com/download (recommended; same chat, no reload risk)
-   - **Claude Code** — \`claude\` in the project directory
-   - **Codex** — \`codex\` in the project directory
-   - **Builder.io** — open the project in Builder for cloud-based code changes
-
-Non-code requests are still fine on this surface — read data, navigate the UI, summarize, search, create/update extensions (sandboxed Alpine.js mini-apps stored in SQL), and call template actions. The restriction is specifically about editing the app's own source files.
-</chat-in-browser-on-localdev>`;
+Non-code requests are still fine on this surface: read data, navigate the UI, summarize, search, create/update extensions (sandboxed Alpine.js mini-apps stored in SQL), and call template actions. The restriction is specifically about direct edits to the host app's own source files.
+</app-rendered-chat-no-direct-code-edits>`;
 
       const prodHandler = createProductionAgentHandler({
         actions: leanPrompt ? leanActions : prodActions,
         systemPrompt: async (event: any) => {
           const { owner, extra } = await prepareRun(event);
           const runtimeContext = runtimeContextForEvent(event);
-          const browserLocalDev = isChatInBrowserOnLocalDev(event)
-            ? CHAT_IN_BROWSER_LOCAL_DEV_PROMPT
-            : "";
+          const codeEditingSurfaceRestriction =
+            shouldBlockInProductCodeEditing(event)
+              ? APP_RENDERED_CHAT_NO_DIRECT_CODE_PROMPT
+              : "";
           if (leanPrompt) {
             return setSystemPromptOnContext(
-              leanBasePrompt + runtimeContext + browserLocalDev + extra,
+              leanBasePrompt +
+                runtimeContext +
+                codeEditingSurfaceRestriction +
+                extra,
             );
           }
           const resources = await loadResourcesForPrompt(
@@ -4538,7 +4567,7 @@ Non-code requests are still fine on this surface — read data, navigate the UI,
               runtimeContext +
               resources +
               schemaBlock +
-              browserLocalDev +
+              codeEditingSurfaceRestriction +
               extra,
           );
         },
@@ -6145,16 +6174,17 @@ Non-code requests are still fine on this surface — read data, navigate the UI,
               timezone,
             },
             () => {
-              // Chat-in-browser on localhost can't host code edits — Vite HMR
-              // and full reloads would kill the chat mid-run. Force the prod
-              // handler (no shell / no fs); the prompt block injected by
-              // `prodHandler.systemPrompt` then steers the agent to suggest
-              // Desktop / Claude Code / Codex / Builder.io instead.
-              const browserLocalDev = isChatInBrowserOnLocalDev(event);
+              // App-rendered chat can't host direct code edits — HMR/full
+              // reloads would kill the same chat surface mid-run. Force the
+              // prod handler (no shell / no fs); the prompt block injected by
+              // `prodHandler.systemPrompt` then steers source changes to a
+              // separate agent surface such as Builder or the dev frame.
+              const blockInProductCodeEditing =
+                shouldBlockInProductCodeEditing(event);
               const handler =
                 ownerContext.anonymous && anonymousHandler
                   ? anonymousHandler
-                  : !browserLocalDev && currentDevMode && devHandler
+                  : !blockInProductCodeEditing && currentDevMode && devHandler
                     ? devHandler
                     : prodHandler;
               return handler(event);

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -4540,10 +4540,11 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
         systemPrompt: async (event: any) => {
           const { owner, extra } = await prepareRun(event);
           const runtimeContext = runtimeContextForEvent(event);
-          const codeEditingSurfaceRestriction =
-            shouldBlockInProductCodeEditing(event)
-              ? APP_RENDERED_CHAT_NO_DIRECT_CODE_PROMPT
-              : "";
+          const codeEditingSurfaceRestriction = shouldBlockInProductCodeEditing(
+            event,
+          )
+            ? APP_RENDERED_CHAT_NO_DIRECT_CODE_PROMPT
+            : "";
           if (leanPrompt) {
             return setSystemPromptOnContext(
               leanBasePrompt +

--- a/packages/frame/client/App.tsx
+++ b/packages/frame/client/App.tsx
@@ -464,6 +464,7 @@ export function App() {
                 onToggleFullscreen={() => setSidebarFullscreen((prev) => !prev)}
                 devAppUrl={appUrl}
                 storageKey={appId}
+                agentChatSurface="dev-frame"
                 codeAccess={{
                   enabled: isDesktop,
                   unavailableTitle: "Open Desktop to use CLI",

--- a/templates/forms/server/handlers/submissions.ts
+++ b/templates/forms/server/handlers/submissions.ts
@@ -57,19 +57,18 @@ function cleanMetaText(value: unknown): string | null {
 }
 
 function cleanChatSessionIds(value: unknown): string[] {
-  const values = Array.isArray(value) ? [...value] : [value];
   const ids: string[] = [];
-  for (let i = 0; i < values.length; i += 1) {
-    const item = values[i];
+  const visit = (item: unknown) => {
+    if (ids.length >= MAX_CHAT_SESSION_IDS) return;
     if (Array.isArray(item)) {
-      values.push(...item);
-      continue;
+      for (const nested of item) visit(nested);
+      return;
     }
     const cleaned = cleanMetaText(item);
-    if (!cleaned || ids.includes(cleaned)) continue;
+    if (!cleaned || ids.includes(cleaned)) return;
     ids.push(cleaned);
-    if (ids.length >= MAX_CHAT_SESSION_IDS) break;
-  }
+  };
+  visit(value);
   return ids;
 }
 
@@ -266,7 +265,9 @@ export const submitForm = defineEventHandler(async (event: H3Event) => {
     // Non-critical — don't fail the submission
   }
 
-  // Fire integrations (non-blocking, never fails the submission)
+  // Fire integrations (non-blocking, never fails the submission). Feedback
+  // debug context is intentionally integration-only: it helps triage Slack
+  // submissions without retaining page URLs or debug breadcrumbs in SQL.
   try {
     const integrations: FormIntegration[] = settings.integrations ?? [];
     if (integrations.length > 0) {

--- a/templates/forms/server/handlers/submissions.ts
+++ b/templates/forms/server/handlers/submissions.ts
@@ -46,6 +46,32 @@ const MAX_FIELD_LENGTH: Record<string, number> = {
 
 const MAX_PAYLOAD_BYTES = 100 * 1024; // 100KB
 const MIN_FILL_TIME_MS = 500; // reject submits faster than this
+const MAX_META_TEXT_LENGTH = 500;
+const MAX_CHAT_SESSION_IDS = 5;
+
+function cleanMetaText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, MAX_META_TEXT_LENGTH);
+}
+
+function cleanChatSessionIds(value: unknown): string[] {
+  const values = Array.isArray(value) ? [...value] : [value];
+  const ids: string[] = [];
+  for (let i = 0; i < values.length; i += 1) {
+    const item = values[i];
+    if (Array.isArray(item)) {
+      values.push(...item);
+      continue;
+    }
+    const cleaned = cleanMetaText(item);
+    if (!cleaned || ids.includes(cleaned)) continue;
+    ids.push(cleaned);
+    if (ids.length >= MAX_CHAT_SESSION_IDS) break;
+  }
+  return ids;
+}
 
 export const submitForm = defineEventHandler(async (event: H3Event) => {
   const db = getDb();
@@ -193,10 +219,17 @@ export const submitForm = defineEventHandler(async (event: H3Event) => {
   // FeedbackButton, which forwards the logged-in user's email so we can see
   // who sent feedback in Slack). Never required, never trusted as identity —
   // anyone can claim any email — but useful as a hint when the client is ours.
-  const rawSubmitter =
+  const meta =
     typeof body._meta === "object" && body._meta !== null
-      ? (body._meta as { submitterEmail?: unknown }).submitterEmail
-      : undefined;
+      ? (body._meta as {
+          submitterEmail?: unknown;
+          chatSessionId?: unknown;
+          chatSessionIds?: unknown;
+          activeRunId?: unknown;
+          pageUrl?: unknown;
+        })
+      : null;
+  const rawSubmitter = meta?.submitterEmail;
   const submitterEmail =
     typeof rawSubmitter === "string" &&
     rawSubmitter.length > 0 &&
@@ -204,6 +237,12 @@ export const submitForm = defineEventHandler(async (event: H3Event) => {
     rawSubmitter.includes("@")
       ? rawSubmitter
       : null;
+  const chatSessionIds = cleanChatSessionIds([
+    meta?.chatSessionId,
+    meta?.chatSessionIds,
+  ]);
+  const activeRunId = cleanMetaText(meta?.activeRunId);
+  const pageUrl = cleanMetaText(meta?.pageUrl);
 
   await db.insert(schema.responses).values({
     id: responseId,
@@ -240,6 +279,9 @@ export const submitForm = defineEventHandler(async (event: H3Event) => {
         data,
         submittedAt: now,
         submitterEmail,
+        chatSessionIds,
+        activeRunId,
+        pageUrl,
       }).catch(() => {});
     }
   } catch {

--- a/templates/forms/server/lib/integrations.ts
+++ b/templates/forms/server/lib/integrations.ts
@@ -39,6 +39,12 @@ interface SubmissionPayload {
   submittedAt: string;
   /** Email of the submitter, when known (claimed by the client, not verified). */
   submitterEmail?: string | null;
+  /** Agent chat thread/session ids claimed by the client, when available. */
+  chatSessionIds?: string[];
+  /** Active agent run id claimed by the client, when available. */
+  activeRunId?: string | null;
+  /** Page URL where the feedback was submitted, when available. */
+  pageUrl?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -59,6 +65,25 @@ function formatFields(
   return out;
 }
 
+function formatDebugContext(submission: SubmissionPayload): string[] {
+  const lines: string[] = [];
+  const chatSessionIds = submission.chatSessionIds ?? [];
+  if (chatSessionIds.length === 1) {
+    lines.push(`Chat session: \`${chatSessionIds[0]}\``);
+  } else if (chatSessionIds.length > 1) {
+    lines.push(
+      `Chat sessions: ${chatSessionIds.map((id) => `\`${id}\``).join(", ")}`,
+    );
+  }
+  if (submission.activeRunId) {
+    lines.push(`Run: \`${submission.activeRunId}\``);
+  }
+  if (submission.pageUrl) {
+    lines.push(`Page: <${submission.pageUrl}|open>`);
+  }
+  return lines;
+}
+
 /** Slack Block Kit message */
 function buildSlackPayload(submission: SubmissionPayload) {
   const fieldLines = submission.fields
@@ -73,6 +98,7 @@ function buildSlackPayload(submission: SubmissionPayload) {
   const contextText = submission.submitterEmail
     ? `${tsContext} by *${submission.submitterEmail}*`
     : tsContext;
+  const debugContext = formatDebugContext(submission);
 
   return {
     blocks: [
@@ -96,7 +122,7 @@ function buildSlackPayload(submission: SubmissionPayload) {
         elements: [
           {
             type: "mrkdwn",
-            text: contextText,
+            text: [contextText, ...debugContext].join("\n"),
           },
         ],
       },
@@ -120,6 +146,27 @@ function buildDiscordPayload(submission: SubmissionPayload) {
       inline: true,
     });
   }
+  if (submission.chatSessionIds?.length) {
+    discordFields.push({
+      name: "Chat session",
+      value: submission.chatSessionIds.join(", "),
+      inline: false,
+    });
+  }
+  if (submission.activeRunId) {
+    discordFields.push({
+      name: "Run",
+      value: submission.activeRunId,
+      inline: true,
+    });
+  }
+  if (submission.pageUrl) {
+    discordFields.push({
+      name: "Page",
+      value: submission.pageUrl,
+      inline: false,
+    });
+  }
 
   return {
     embeds: [
@@ -139,6 +186,9 @@ function buildGoogleSheetsPayload(submission: SubmissionPayload) {
     formTitle: submission.formTitle,
     submittedAt: submission.submittedAt,
     submitterEmail: submission.submitterEmail ?? "",
+    chatSessionIds: (submission.chatSessionIds ?? []).join(", "),
+    activeRunId: submission.activeRunId ?? "",
+    pageUrl: submission.pageUrl ?? "",
     ...formatFields(submission.fields, submission.data),
   };
 }
@@ -152,6 +202,9 @@ function buildWebhookPayload(submission: SubmissionPayload) {
     responseId: submission.responseId,
     submittedAt: submission.submittedAt,
     submitterEmail: submission.submitterEmail ?? null,
+    chatSessionIds: submission.chatSessionIds ?? [],
+    activeRunId: submission.activeRunId ?? null,
+    pageUrl: submission.pageUrl ?? null,
     data: formatFields(submission.fields, submission.data),
     rawData: submission.data,
   };


### PR DESCRIPTION
## Summary

- Include current chat session IDs, active run ID, and scrubbed page URL in in-app feedback submissions when available.
- Render that debug context in Forms Slack/Discord/Sheets/webhook integrations.
- Keep feedback debug context integration-only; it is intentionally not persisted to the responses table so page URLs and debug breadcrumbs are not retained in ordinary Forms response SQL.
- Harden chat clipboard actions across browser and desktop surfaces.
- Preserve frozen reconnect output as a real assistant message before a user continues a stopped run.

## Validation

- pnpm run prep
- pnpm --filter @agent-native/core test -- src/client/feedback-context.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter forms typecheck
- git diff --check
