### PR TITLE
Fix MCP app embeds and trim tool output

### DIFF
--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -151,6 +151,16 @@ agent has a predictable surface without guessing per-app action names:
 A same-named template action overrides a builtin (template-over-core
 precedence). Disable the set with `MCPConfig.builtinCrossAppTools: false`.
 
+For OAuth callers that request `mcp:apps`, the advertised `tools/list` catalog
+is intentionally compact so ChatGPT/Claude app hosts do not ingest every
+internal action schema. The model sees app-facing builtins (`list_apps`,
+`open_app`, app-only `create_embed_session`), actions with `mcpApp`, and
+actions explicitly marked `publicAgent.expose`. Stdio/static-token developer
+clients still get the full connected action surface. If a host should be able
+to call a new action from an MCP App conversation, mark it with `mcpApp` (for
+UI-producing work) or `publicAgent` (for safe read/ingest work) instead of
+relying on incidental full-surface discovery.
+
 ### 2. Add a `link` builder to an action
 
 `defineAction` accepts an optional `link` builder. When set, every MCP/A2A
@@ -247,10 +257,12 @@ export default defineAction({
 
 The MCP server advertises extension `io.modelcontextprotocol/ui`, adds
 `_meta.ui.resourceUri` plus the legacy-compatible `_meta["ui/resourceUri"]` to
-`tools/list`, and exposes the HTML through `resources/list` + `resources/read`
-using MIME `text/html;profile=mcp-app`. The stdio proxy forwards those
-resource handlers from the live app, so local desktop/CLI clients see the same
-resources as HTTP clients.
+`tools/list`, and also emits ChatGPT Apps SDK compatibility metadata
+(`openai/outputTemplate`, widget CSP/description/accessibility). It exposes the
+HTML through `resources/list`, `resources/templates/list`, and `resources/read`
+using MIME `text/html;profile=mcp-app`. The stdio proxy forwards those resource
+handlers from the live app, so local desktop/CLI clients see the same resources
+as HTTP clients.
 
 Keep the existing `link` builder even when adding `mcpApp`. CLI-only clients,
 older hosts, and any host that does not render MCP Apps will ignore the UI

--- a/.changeset/compact-mcp-app-catalog.md
+++ b/.changeset/compact-mcp-app-catalog.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Emit compact MCP Apps tool catalogs for OAuth app hosts and include ChatGPT-compatible widget metadata for real app embeds.

--- a/packages/core/docs/content/actions.md
+++ b/packages/core/docs/content/actions.md
@@ -152,7 +152,7 @@ If your app is an [A2A](/docs/a2a-protocol) peer, other agent-native apps discov
 
 ## Exposing it over MCP {#mcp}
 
-With MCP enabled, your actions show up in the framework's MCP server at `/_agent-native/mcp`. Any MCP client — Claude, ChatGPT custom MCP apps, Claude Desktop/Code, Cursor, Codex, etc. — can connect and see them as tools. See [MCP Protocol](/docs/mcp-protocol).
+With MCP enabled, your actions show up in the framework's MCP server at `/_agent-native/mcp`. Stdio/static-token developer clients see the full connected action surface. OAuth app hosts that request `mcp:apps` get a compact catalog containing app-facing builtins, actions with `mcpApp`, and actions explicitly marked `publicAgent.expose`, so ChatGPT/Claude discovery stays small. See [MCP Protocol](/docs/mcp-protocol).
 
 For UI-capable MCP hosts, actions can also attach an optional MCP Apps resource.
 Use the shared full-app embed helper when the action needs an inline experience.
@@ -188,7 +188,7 @@ export default defineAction({
 });
 ```
 
-This advertises the MCP Apps extension (`io.modelcontextprotocol/ui`), exposes the HTML via MCP resources, and includes both current and legacy UI resource metadata for compatible hosts. Keep `link` as the fallback for CLI and non-UI MCP clients; see [External Agents](/docs/external-agents#mcp-apps).
+This advertises the MCP Apps extension (`io.modelcontextprotocol/ui`), exposes the HTML via MCP resources/templates, and includes standard MCP Apps plus ChatGPT Apps SDK widget metadata for compatible hosts. Keep `link` as the fallback for CLI and non-UI MCP clients; see [External Agents](/docs/external-agents#mcp-apps).
 
 The helper launches the action's `link` target through `/_agent-native/embed/start` with a short-lived browser session, so routes such as full dashboards, filtered inboxes, drafts, and extension pages can reuse the app's React components directly.
 

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -229,6 +229,8 @@ On top of the per-action tools the MCP server exposes a stable verb set, so an e
 
 `create_workspace_app` rejects any non-allow-listed template — the public template allow-list in `packages/shared-app-config/templates.ts` is authoritative and CI-guarded; an external agent cannot widen it. A same-named template action overrides a builtin (template-over-core precedence). Disable the whole set with `MCPConfig.builtinCrossAppTools: false`.
 
+For OAuth callers that request `mcp:apps`, the server intentionally advertises a compact `tools/list` catalog so app hosts do not ingest every internal action schema. The model sees app-facing builtins (`list_apps`, `open_app`, app-only `create_embed_session`), actions with `mcpApp`, and actions explicitly marked `publicAgent.expose`. Stdio/static-token developer clients still get the full connected action surface. If a host should be able to call a new action from an MCP App conversation, mark it with `mcpApp` for UI-producing work or `publicAgent` for safe read/ingest work.
+
 ### Per-app tour {#tour}
 
 Every allow-listed template that produces or lists a navigable resource ships a `link` builder, and the ingest-heavy ones ship a GET + `publicAgent` action so a connected agent can pull live state:
@@ -306,7 +308,7 @@ export default defineAction({
 });
 ```
 
-The MCP server advertises extension `io.modelcontextprotocol/ui`, adds `_meta.ui.resourceUri` plus `_meta["ui/resourceUri"]` to `tools/list`, and exposes the HTML through `resources/list` + `resources/read` using MIME `text/html;profile=mcp-app`. The stdio proxy forwards those resource handlers from the live app, so desktop and CLI clients see the same resources as HTTP clients.
+The MCP server advertises extension `io.modelcontextprotocol/ui`, adds `_meta.ui.resourceUri` plus `_meta["ui/resourceUri"]` to `tools/list`, and also emits ChatGPT Apps SDK compatibility metadata (`openai/outputTemplate`, widget CSP/description/accessibility). It exposes the HTML through `resources/list`, `resources/templates/list`, and `resources/read` using MIME `text/html;profile=mcp-app`. The stdio proxy forwards those resource handlers from the live app, so desktop and CLI clients see the same resources as HTTP clients.
 
 Keep the existing `link` builder even when adding `mcpApp`. CLI-only clients, older hosts, and any host that does not render MCP Apps will ignore the UI metadata and still need the `"Open in … →"` link. `embedApp()` uses that link as its launch target, calls the app-only `create_embed_session` helper, exchanges a one-time SQL ticket at `/_agent-native/embed/start`, and loads the target route in an iframe with a short-lived browser session plus a bearer fallback for same-origin fetches. `open_app({ app, path, embed: true })` is the generic escape hatch for routes such as full dashboards, filtered inboxes, calendar draft views, analyses, and extension pages, and should be used liberally when the full app is the clearest review/edit surface.
 

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -72,11 +72,13 @@ POST https://your-app.example.com/_agent-native/mcp
 
 The server supports the standard MCP handshake: `initialize` → `initialized` → `tools/list` → `tools/call`.
 
-If an action declares `mcpApp`, the server also advertises the official MCP Apps extension (`io.modelcontextprotocol/ui`) and supports `resources/list`, `resources/templates/list`, and `resources/read` for the app resource. Hosts that render MCP Apps can show the UI inline; hosts that do not can still call the tool and use the deep-link fallback. Product UIs should use `embedApp()` so the inline surface is the real React app route, or a focused route that renders a shared React component such as an Analytics chart, not a separate plain HTML implementation. The current official extension matrix includes Claude, Claude Desktop, VS Code GitHub Copilot, Goose, Postman, MCPJam, ChatGPT, and Cursor; host support varies by version and plan, so use the [External Agents MCP Apps notes](/docs/external-agents#mcp-apps-compatibility) for the user-facing guidance.
+If an action declares `mcpApp`, the server also advertises the official MCP Apps extension (`io.modelcontextprotocol/ui`) and supports `resources/list`, `resources/templates/list`, and `resources/read` for the app resource. Hosts that render MCP Apps can show the UI inline; hosts that do not can still call the tool and use the deep-link fallback. Product UIs should use `embedApp()` so the inline surface is the real React app route, or a focused route that renders a shared React component such as an Analytics chart, not a separate plain HTML implementation. The server emits both standard MCP Apps metadata and ChatGPT Apps SDK compatibility metadata so app-capable hosts can find the same `ui://` resource. The current official extension matrix includes Claude, Claude Desktop, VS Code GitHub Copilot, Goose, Postman, MCPJam, ChatGPT, and Cursor; host support varies by version and plan, so use the [External Agents MCP Apps notes](/docs/external-agents#mcp-apps-compatibility) for the user-facing guidance.
 
 ## Tools {#tools}
 
-All actions registered in your app are exposed as MCP tools. The mapping is direct:
+Stdio/static-token developer clients see all connected app actions as MCP tools. OAuth callers that request `mcp:apps` get a compact app-host catalog: app-facing builtins, actions with `mcpApp`, and actions explicitly marked `publicAgent.expose`. This keeps ChatGPT/Claude app-host discovery small while preserving the full developer surface for local agents.
+
+The mapping is direct:
 
 | Action property    | MCP tool property |
 | ------------------ | ----------------- |
@@ -84,7 +86,7 @@ All actions registered in your app are exposed as MCP tools. The mapping is dire
 | `tool.parameters`  | `inputSchema`     |
 | Action name        | Tool name         |
 
-When `mcpApp` is present, the tool entry also includes `_meta.ui.resourceUri` and `_meta["ui/resourceUri"]`, and the corresponding `ui://` resource is returned as `text/html;profile=mcp-app`.
+When `mcpApp` is present, the tool entry also includes `_meta.ui.resourceUri`, `_meta["ui/resourceUri"]`, and `_meta["openai/outputTemplate"]`, and the corresponding `ui://` resource is returned as `text/html;profile=mcp-app`.
 
 ### The `ask-agent` tool {#ask-agent}
 

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -131,6 +131,29 @@ function isActionVisibleForOAuthScope(
   return hasMcpOAuthScope(scopes, required);
 }
 
+const COMPACT_MCP_APP_CATALOG_BUILTINS = new Set([
+  "list_apps",
+  "open_app",
+  "create_embed_session",
+]);
+
+function isDispatchConfig(config: MCPConfig): boolean {
+  const id = (config.appId ?? "").toLowerCase();
+  const name = (config.name ?? "").toLowerCase();
+  return id === "dispatch" || name.includes("dispatch");
+}
+
+function isActionAdvertisedInCompactMcpAppCatalog(
+  config: MCPConfig,
+  name: string,
+  entry: ActionEntry,
+): boolean {
+  if (COMPACT_MCP_APP_CATALOG_BUILTINS.has(name)) return true;
+  if (name === "ask_app" && isDispatchConfig(config)) return true;
+  if (entry.mcpApp?.resource) return true;
+  return entry.publicAgent?.expose === true;
+}
+
 interface ResolvedMcpAppResource {
   uri: string;
   name: string;
@@ -234,9 +257,34 @@ function expandRequestOriginSources(
   );
 }
 
+function openAiWidgetCsp(
+  resource: ActionMcpAppResourceConfig,
+  requestMeta?: MCPRequestMeta,
+): Record<string, string[]> | undefined {
+  if (!resource.csp) return undefined;
+  const csp: Record<string, string[]> = {};
+  const connectDomains = expandRequestOriginSources(
+    resource.csp.connectDomains,
+    requestMeta,
+  );
+  const resourceDomains = expandRequestOriginSources(
+    resource.csp.resourceDomains,
+    requestMeta,
+  );
+  const frameDomains = expandRequestOriginSources(
+    resource.csp.frameDomains,
+    requestMeta,
+  );
+  if (connectDomains?.length) csp.connect_domains = connectDomains;
+  if (resourceDomains?.length) csp.resource_domains = resourceDomains;
+  if (frameDomains?.length) csp.frame_domains = frameDomains;
+  return Object.keys(csp).length > 0 ? csp : undefined;
+}
+
 function mcpAppUiMeta(
   resource: ActionMcpAppResourceConfig,
   requestMeta?: MCPRequestMeta,
+  description?: string,
 ): Record<string, unknown> | undefined {
   const base =
     resource._meta && typeof resource._meta === "object"
@@ -274,6 +322,19 @@ function mcpAppUiMeta(
     ui.prefersBorder = resource.prefersBorder;
   }
   if (Object.keys(ui).length > 0) base.ui = ui;
+  if (description && base["openai/widgetDescription"] == null) {
+    base["openai/widgetDescription"] = description;
+  }
+  if (
+    typeof resource.prefersBorder === "boolean" &&
+    base["openai/widgetPrefersBorder"] == null
+  ) {
+    base["openai/widgetPrefersBorder"] = resource.prefersBorder;
+  }
+  const openAiCsp = openAiWidgetCsp(resource, requestMeta);
+  if (openAiCsp && base["openai/widgetCSP"] == null) {
+    base["openai/widgetCSP"] = openAiCsp;
+  }
   return Object.keys(base).length > 0 ? base : undefined;
 }
 
@@ -287,14 +348,13 @@ function resolveMcpAppResource(
   if (!resource) return null;
   const uri = resource.uri?.trim() || defaultMcpAppUri(config, actionName);
   if (!uri.startsWith("ui://")) return null;
-  const resourceMeta = mcpAppUiMeta(resource, requestMeta);
+  const description = resource.description ?? entry.tool.description;
+  const resourceMeta = mcpAppUiMeta(resource, requestMeta, description);
   return {
     uri,
     name: resource.name?.trim() || actionName,
     ...(resource.title ? { title: resource.title } : {}),
-    ...((resource.description ?? entry.tool.description)
-      ? { description: resource.description ?? entry.tool.description }
-      : {}),
+    ...(description ? { description } : {}),
     html: resource.html,
     mimeType: resource.mimeType ?? MCP_APP_MIME_TYPE,
     ...(resourceMeta ? { _meta: resourceMeta } : {}),
@@ -326,6 +386,127 @@ function renderMcpAppHtml(
     });
   }
   return resource.html;
+}
+
+function openAiToolDescriptorMeta(
+  resource: ResolvedMcpAppResource,
+): Record<string, unknown> {
+  const label = resource.title ?? resource.name;
+  return {
+    "openai/outputTemplate": resource.uri,
+    "openai/toolInvocation/invoking": `Opening ${label}`,
+    "openai/toolInvocation/invoked": `${label} ready`,
+    "openai/widgetAccessible": true,
+  };
+}
+
+function openAiToolResultMeta(
+  resource: ResolvedMcpAppResource,
+): Record<string, unknown> {
+  const label = resource.title ?? resource.name;
+  return {
+    "openai/outputTemplate": resource.uri,
+    "openai/toolInvocation/invoking": `Opening ${label}`,
+    "openai/toolInvocation/invoked": `${label} ready`,
+    "openai/widgetAccessible": true,
+  };
+}
+
+function primitiveValue(value: unknown): value is string | number | boolean {
+  return (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+function compactRecord(
+  value: unknown,
+  keys: string[],
+): Record<string, string | number | boolean> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const out: Record<string, string | number | boolean> = {};
+  const record = value as Record<string, unknown>;
+  for (const key of keys) {
+    const v = record[key];
+    if (primitiveValue(v)) out[key] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function compactMcpAppStructuredContent(
+  result: unknown,
+  meta: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const root = compactRecord(result, [
+    "id",
+    "message",
+    "status",
+    "app",
+    "view",
+    "path",
+    "url",
+    "deepLink",
+    "openUrl",
+    "label",
+    "title",
+    "name",
+    "embed",
+    "created",
+    "updated",
+    "reused",
+  ]);
+  if (root) Object.assign(out, root);
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    const draft = compactRecord((result as Record<string, unknown>).draft, [
+      "id",
+      "to",
+      "cc",
+      "bcc",
+      "subject",
+      "mode",
+      "accountEmail",
+    ]);
+    if (draft) out.draft = draft;
+  } else if (primitiveValue(result)) {
+    out.result = result;
+  }
+  const openLink = meta?.["agent-native/openLink"];
+  if (openLink && typeof openLink === "object" && !Array.isArray(openLink)) {
+    out.openLink = openLink;
+    const webUrl = (openLink as Record<string, unknown>).webUrl;
+    if (typeof webUrl === "string" && !out.url) out.url = webUrl;
+  }
+  return Object.keys(out).length > 0 ? out : { status: "ok" };
+}
+
+function truncateToolText(value: string, max = 2000): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 1)}…`;
+}
+
+function conciseMcpAppToolText(
+  name: string,
+  result: unknown,
+  structuredContent: Record<string, unknown>,
+): string {
+  if (typeof result === "string") return truncateToolText(result);
+  const message = structuredContent.message;
+  if (typeof message === "string" && message.trim()) {
+    return truncateToolText(message.trim());
+  }
+  const title = structuredContent.title ?? structuredContent.name;
+  if (typeof title === "string" && title.trim()) {
+    return `${title.trim()} is ready.`;
+  }
+  const id = structuredContent.id;
+  if (typeof id === "string" && id.trim()) {
+    return `${name} completed for ${id.trim()}.`;
+  }
+  return `${name} completed.`;
 }
 
 // ---------------------------------------------------------------------------
@@ -388,11 +569,22 @@ export async function createMCPServerForRequest(
       isActionVisibleForOAuthScope(entry, effectiveIdentity?.oauthScopes),
     ),
   );
+  const compactMcpAppCatalog = hasMcpOAuthScope(
+    effectiveIdentity?.oauthScopes,
+    "mcp:apps",
+  );
+  const advertisedActions = compactMcpAppCatalog
+    ? Object.fromEntries(
+        Object.entries(visibleActions).filter(([name, entry]) =>
+          isActionAdvertisedInCompactMcpAppCatalog(config, name, entry),
+        ),
+      )
+    : visibleActions;
   const mcpAppResources = hasMcpOAuthScope(
     effectiveIdentity?.oauthScopes,
     "mcp:apps",
   )
-    ? getMcpAppResources(config, visibleActions, requestMeta)
+    ? getMcpAppResources(config, advertisedActions, requestMeta)
     : [];
   const supportsMcpApps = mcpAppResources.length > 0;
   const server = new Server(
@@ -449,7 +641,7 @@ export async function createMCPServerForRequest(
   // applies to the listing too.
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return withCallerContext(async () => {
-      const tools = Object.entries(visibleActions).map(([name, entry]) => {
+      const tools = Object.entries(advertisedActions).map(([name, entry]) => {
         const hasLink = typeof entry.link === "function";
         const mcpAppResource = resolveMcpAppResource(
           config,
@@ -467,6 +659,7 @@ export async function createMCPServerForRequest(
           ...rawToolMeta,
           ...(mcpAppResource
             ? {
+                ...openAiToolDescriptorMeta(mcpAppResource),
                 [MCP_APP_RESOURCE_URI_META_KEY]: mcpAppResource.uri,
                 ui: {
                   ...(((rawToolMeta.ui as any) &&
@@ -483,6 +676,8 @@ export async function createMCPServerForRequest(
         const baseDescription = entry.tool.description ?? name;
         const annotations: Record<string, unknown> = {
           readOnlyHint: entry.readOnly === true,
+          destructiveHint: entry.publicAgent?.isConsequential === true,
+          openWorldHint: false,
         };
         if (hasLink) annotations["agent-native/producesOpenLink"] = true;
         return {
@@ -500,6 +695,7 @@ export async function createMCPServerForRequest(
       });
 
       if (
+        !compactMcpAppCatalog &&
         config.askAgent &&
         hasMcpOAuthScope(effectiveIdentity?.oauthScopes, "mcp:write")
       ) {
@@ -519,7 +715,11 @@ export async function createMCPServerForRequest(
             },
             required: ["message"],
           },
-          annotations: { readOnlyHint: false },
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: false,
+            openWorldHint: false,
+          },
         });
       }
 
@@ -584,19 +784,42 @@ export async function createMCPServerForRequest(
         const resultForClient = isMcpActionResult(result)
           ? result.text
           : result;
-        const text =
-          typeof resultForClient === "string"
-            ? resultForClient
-            : JSON.stringify(resultForClient);
-        const content: any[] = [{ type: "text", text }];
+        const mcpAppResource = resolveMcpAppResource(
+          config,
+          name,
+          entry,
+          requestMeta,
+        );
         const { block, _meta } = buildLinkArtifacts(
           entry,
           (args as Record<string, any>) ?? {},
           isMcpActionResult(result) ? result.raw : result,
           requestMeta,
         );
+        const responseMeta: Record<string, unknown> = {
+          ...(_meta ?? {}),
+          ...(mcpAppResource ? openAiToolResultMeta(mcpAppResource) : {}),
+        };
+        const structuredContent = mcpAppResource
+          ? compactMcpAppStructuredContent(
+              isMcpActionResult(result) ? result.raw : result,
+              responseMeta,
+            )
+          : undefined;
+        const text = mcpAppResource
+          ? conciseMcpAppToolText(name, resultForClient, structuredContent!)
+          : typeof resultForClient === "string"
+            ? resultForClient
+            : JSON.stringify(resultForClient);
+        const content: any[] = [{ type: "text", text }];
         if (block) content.push(block);
-        return { content, ...(_meta ? { _meta } : {}) };
+        return {
+          content,
+          ...(structuredContent ? { structuredContent } : {}),
+          ...(Object.keys(responseMeta).length > 0
+            ? { _meta: responseMeta }
+            : {}),
+        };
       } catch (err: any) {
         return {
           content: [{ type: "text", text: `Error: ${err.message}` }],
@@ -623,7 +846,18 @@ export async function createMCPServerForRequest(
     });
 
     server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
-      return { resourceTemplates: [] };
+      return {
+        resourceTemplates: mcpAppResources.map((resource) => ({
+          uriTemplate: resource.uri,
+          name: resource.name,
+          ...(resource.title ? { title: resource.title } : {}),
+          ...(resource.description
+            ? { description: resource.description }
+            : {}),
+          mimeType: resource.mimeType,
+          ...(resource._meta ? { _meta: resource._meta } : {}),
+        })),
+      };
     });
 
     server.setRequestHandler(
@@ -631,7 +865,7 @@ export async function createMCPServerForRequest(
       async (request: any) => {
         return withCallerContext(async () => {
           const uri = request.params?.uri;
-          const found = Object.entries(visibleActions)
+          const found = Object.entries(advertisedActions)
             .map(([name, entry]) => ({
               actionName: name,
               resource: resolveMcpAppResource(config, name, entry, requestMeta),

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -420,60 +420,16 @@ function primitiveValue(value: unknown): value is string | number | boolean {
   );
 }
 
-function compactRecord(
-  value: unknown,
-  keys: string[],
-): Record<string, string | number | boolean> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
-  }
-  const out: Record<string, string | number | boolean> = {};
-  const record = value as Record<string, unknown>;
-  for (const key of keys) {
-    const v = record[key];
-    if (primitiveValue(v)) out[key] = v;
-  }
-  return Object.keys(out).length > 0 ? out : undefined;
-}
-
-function compactMcpAppStructuredContent(
+function mcpAppStructuredContent(
   result: unknown,
   meta: Record<string, unknown> | undefined,
 ): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  const root = compactRecord(result, [
-    "id",
-    "message",
-    "status",
-    "app",
-    "view",
-    "path",
-    "url",
-    "deepLink",
-    "openUrl",
-    "label",
-    "title",
-    "name",
-    "embed",
-    "created",
-    "updated",
-    "reused",
-  ]);
-  if (root) Object.assign(out, root);
-  if (result && typeof result === "object" && !Array.isArray(result)) {
-    const draft = compactRecord((result as Record<string, unknown>).draft, [
-      "id",
-      "to",
-      "cc",
-      "bcc",
-      "subject",
-      "mode",
-      "accountEmail",
-    ]);
-    if (draft) out.draft = draft;
-  } else if (primitiveValue(result)) {
-    out.result = result;
-  }
+  const out: Record<string, unknown> =
+    result && typeof result === "object" && !Array.isArray(result)
+      ? { ...(result as Record<string, unknown>) }
+      : primitiveValue(result)
+        ? { result }
+        : {};
   const openLink = meta?.["agent-native/openLink"];
   if (openLink && typeof openLink === "object" && !Array.isArray(openLink)) {
     out.openLink = openLink;
@@ -569,10 +525,9 @@ export async function createMCPServerForRequest(
       isActionVisibleForOAuthScope(entry, effectiveIdentity?.oauthScopes),
     ),
   );
-  const compactMcpAppCatalog = hasMcpOAuthScope(
-    effectiveIdentity?.oauthScopes,
-    "mcp:apps",
-  );
+  const compactMcpAppCatalog =
+    Array.isArray(effectiveIdentity?.oauthScopes) &&
+    hasMcpOAuthScope(effectiveIdentity.oauthScopes, "mcp:apps");
   const advertisedActions = compactMcpAppCatalog
     ? Object.fromEntries(
         Object.entries(visibleActions).filter(([name, entry]) =>
@@ -580,10 +535,7 @@ export async function createMCPServerForRequest(
         ),
       )
     : visibleActions;
-  const mcpAppResources = hasMcpOAuthScope(
-    effectiveIdentity?.oauthScopes,
-    "mcp:apps",
-  )
+  const mcpAppResources = compactMcpAppCatalog
     ? getMcpAppResources(config, advertisedActions, requestMeta)
     : [];
   const supportsMcpApps = mcpAppResources.length > 0;
@@ -801,7 +753,7 @@ export async function createMCPServerForRequest(
           ...(mcpAppResource ? openAiToolResultMeta(mcpAppResource) : {}),
         };
         const structuredContent = mcpAppResource
-          ? compactMcpAppStructuredContent(
+          ? mcpAppStructuredContent(
               isMcpActionResult(result) ? result.raw : result,
               responseMeta,
             )

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -252,6 +252,19 @@ async function callWeb(
   return JSON.parse(text);
 }
 
+async function mcpAppsAuthHeaders() {
+  process.env.BETTER_AUTH_SECRET = "oauth-secret";
+  const { signMcpOAuthAccessToken } = await import("./oauth-token.js");
+  const token = await signMcpOAuthAccessToken({
+    ownerEmail: "oauth@example.com",
+    clientId: "client-123",
+    scope: "mcp:read mcp:write mcp:apps",
+    resource: "https://mail.agent-native.com/_agent-native/mcp",
+    issuer: "https://mail.agent-native.com",
+  });
+  return { authorization: `Bearer ${token}` };
+}
+
 describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)", () => {
   beforeEach(() => {
     // A deployed app has a real token; the default makeWebEvent bearer
@@ -269,16 +282,19 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
   });
 
   it("handles `initialize` without a 501", async () => {
-    const out = await callWeb({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "initialize",
-      params: {
-        protocolVersion: "2025-06-18",
-        capabilities: {},
-        clientInfo: { name: "agent-native-connect", version: "1.0.0" },
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "agent-native-connect", version: "1.0.0" },
+        },
       },
-    });
+      { headers: await mcpAppsAuthHeaders() },
+    );
     expect(out.jsonrpc).toBe("2.0");
     expect(out.id).toBe(1);
     expect(out.error).toBeUndefined();
@@ -318,17 +334,6 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
   });
 
   it("uses a compact tool catalog for OAuth MCP Apps callers", async () => {
-    process.env.BETTER_AUTH_SECRET = "oauth-secret";
-    const { signMcpOAuthAccessToken } = await import("./oauth-token.js");
-    const resource = "https://mail.agent-native.com/_agent-native/mcp";
-    const token = await signMcpOAuthAccessToken({
-      ownerEmail: "oauth@example.com",
-      clientId: "client-123",
-      scope: "mcp:read mcp:write mcp:apps",
-      resource,
-      issuer: "https://mail.agent-native.com",
-    });
-
     const out = await callWeb(
       {
         jsonrpc: "2.0",
@@ -337,7 +342,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         params: {},
       },
       {
-        headers: { authorization: `Bearer ${token}` },
+        headers: await mcpAppsAuthHeaders(),
         config: compactSurfaceConfig,
       },
     );
@@ -351,13 +356,34 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(names).not.toContain("ask-agent");
   });
 
+  it("keeps the full tool catalog for non-OAuth callers without mcp:apps", async () => {
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 21,
+        method: "tools/list",
+        params: {},
+      },
+      { config: compactSurfaceConfig },
+    );
+
+    expect(out.error).toBeUndefined();
+    const names = out.result.tools.map((t: any) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["echo-thing", "internal-heavy", "ask-agent"]),
+    );
+  });
+
   it("handles `resources/list` and advertises MCP App resources", async () => {
-    const out = await callWeb({
-      jsonrpc: "2.0",
-      id: 4,
-      method: "resources/list",
-      params: {},
-    });
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 4,
+        method: "resources/list",
+        params: {},
+      },
+      { headers: await mcpAppsAuthHeaders() },
+    );
     expect(out.error).toBeUndefined();
     expect(out.result.resources).toEqual([
       expect.objectContaining({
@@ -385,12 +411,15 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
   });
 
   it("handles `resources/templates/list` with MCP App templates", async () => {
-    const out = await callWeb({
-      jsonrpc: "2.0",
-      id: 5,
-      method: "resources/templates/list",
-      params: {},
-    });
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 5,
+        method: "resources/templates/list",
+        params: {},
+      },
+      { headers: await mcpAppsAuthHeaders() },
+    );
     expect(out.error).toBeUndefined();
     expect(out.result.resourceTemplates).toEqual([
       expect.objectContaining({
@@ -404,12 +433,15 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
   });
 
   it("handles `resources/read` and returns MCP App HTML", async () => {
-    const out = await callWeb({
-      jsonrpc: "2.0",
-      id: 6,
-      method: "resources/read",
-      params: { uri: "ui://mail/echo-thing" },
-    });
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 6,
+        method: "resources/read",
+        params: { uri: "ui://mail/echo-thing" },
+      },
+      { headers: await mcpAppsAuthHeaders() },
+    );
     expect(out.error).toBeUndefined();
     expect(out.result.contents).toEqual([
       expect.objectContaining({
@@ -463,6 +495,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       "ui://mail/echo-thing",
     );
     expect(out.result.structuredContent).toMatchObject({
+      echoed: "hello",
       id: "thing-42",
       openLink: {
         label: "Open in Mail",

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -178,14 +178,60 @@ const config = {
   },
 };
 
+const compactSurfaceConfig = {
+  ...config,
+  askAgent: async () => "agent answer",
+  actions: {
+    ...config.actions,
+    "internal-heavy": {
+      tool: {
+        description: "Internal verbose tool that should not be advertised",
+      },
+      readOnly: true,
+      run: async () => ({ ok: true }),
+    },
+    "public-search": {
+      tool: {
+        description: "Search public mail data",
+      },
+      readOnly: true,
+      publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+      run: async () => ({ results: [] }),
+    },
+    "review-draft": {
+      tool: {
+        description: "Review a draft in the real app",
+      },
+      run: async () => ({ id: "draft-1", message: "Draft ready" }),
+      mcpApp: {
+        resource: {
+          title: "Draft review",
+          description: "Open the draft in Mail.",
+          html: "<!doctype html><html><body>Draft</body></html>",
+        },
+      },
+    },
+  },
+};
+
 /**
  * Drive a single JSON-RPC call through the web fallback and return the parsed
  * JSON-RPC response object. Proves the web `Response` path works with no Node
  * runtime present.
  */
-async function callWeb(rpc: Record<string, unknown>): Promise<any> {
-  const event = makeWebEvent({ method: "POST", body: rpc });
-  const res = await handleMcpRequest(event, config as any);
+async function callWeb(
+  rpc: Record<string, unknown>,
+  opts: {
+    headers?: Record<string, string>;
+    config?: Record<string, unknown>;
+  } = {},
+): Promise<any> {
+  const event = makeWebEvent({
+    method: "POST",
+    body: rpc,
+    ...(opts.headers ? { headers: opts.headers } : {}),
+  });
+  const res = await handleMcpRequest(event, (opts.config ?? config) as any);
   expect(res).toBeInstanceOf(Response);
   const response = res as Response;
   // The SDK web transport returns application/json for request/response when
@@ -214,9 +260,11 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     process.env.ACCESS_TOKEN = "test-access-token";
     delete process.env.ACCESS_TOKENS;
     delete process.env.A2A_SECRET;
+    delete process.env.BETTER_AUTH_SECRET;
   });
   afterEach(() => {
     delete process.env.ACCESS_TOKEN;
+    delete process.env.BETTER_AUTH_SECRET;
     vi.clearAllMocks();
   });
 
@@ -261,10 +309,46 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(echo.annotations?.["agent-native/producesOpenLink"]).toBe(true);
     expect(echo.description).toContain("Open in");
     expect(echo._meta?.["ui/resourceUri"]).toBe("ui://mail/echo-thing");
+    expect(echo._meta?.["openai/outputTemplate"]).toBe("ui://mail/echo-thing");
+    expect(echo._meta?.["openai/widgetAccessible"]).toBe(true);
     expect(echo._meta?.ui).toEqual({
       resourceUri: "ui://mail/echo-thing",
       visibility: ["model", "app"],
     });
+  });
+
+  it("uses a compact tool catalog for OAuth MCP Apps callers", async () => {
+    process.env.BETTER_AUTH_SECRET = "oauth-secret";
+    const { signMcpOAuthAccessToken } = await import("./oauth-token.js");
+    const resource = "https://mail.agent-native.com/_agent-native/mcp";
+    const token = await signMcpOAuthAccessToken({
+      ownerEmail: "oauth@example.com",
+      clientId: "client-123",
+      scope: "mcp:read mcp:write mcp:apps",
+      resource,
+      issuer: "https://mail.agent-native.com",
+    });
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 20,
+        method: "tools/list",
+        params: {},
+      },
+      {
+        headers: { authorization: `Bearer ${token}` },
+        config: compactSurfaceConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    const names = out.result.tools.map((t: any) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["echo-thing", "public-search", "review-draft"]),
+    );
+    expect(names).not.toContain("internal-heavy");
+    expect(names).not.toContain("ask-agent");
   });
 
   it("handles `resources/list` and advertises MCP App resources", async () => {
@@ -282,19 +366,25 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
         mimeType: "text/html;profile=mcp-app",
-        _meta: {
+        _meta: expect.objectContaining({
           ui: {
             csp: {
               connectDomains: ["https://mail.agent-native.com"],
             },
             prefersBorder: true,
           },
-        },
+          "openai/widgetDescription":
+            "Review the echoed thing in an inline MCP App.",
+          "openai/widgetPrefersBorder": true,
+          "openai/widgetCSP": {
+            connect_domains: ["https://mail.agent-native.com"],
+          },
+        }),
       }),
     ]);
   });
 
-  it("handles `resources/templates/list` with an empty template list", async () => {
+  it("handles `resources/templates/list` with MCP App templates", async () => {
     const out = await callWeb({
       jsonrpc: "2.0",
       id: 5,
@@ -302,7 +392,15 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       params: {},
     });
     expect(out.error).toBeUndefined();
-    expect(out.result.resourceTemplates).toEqual([]);
+    expect(out.result.resourceTemplates).toEqual([
+      expect.objectContaining({
+        uriTemplate: "ui://mail/echo-thing",
+        name: "echo-thing",
+        title: "Mail Review",
+        description: "Review the echoed thing in an inline MCP App.",
+        mimeType: "text/html;profile=mcp-app",
+      }),
+    ]);
   });
 
   it("handles `resources/read` and returns MCP App HTML", async () => {
@@ -318,14 +416,17 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         uri: "ui://mail/echo-thing",
         mimeType: "text/html;profile=mcp-app",
         text: expect.stringContaining('data-action="echo-thing"'),
-        _meta: {
+        _meta: expect.objectContaining({
           ui: {
             csp: {
               connectDomains: ["https://mail.agent-native.com"],
             },
             prefersBorder: true,
           },
-        },
+          "openai/widgetDescription":
+            "Review the echoed thing in an inline MCP App.",
+          "openai/widgetPrefersBorder": true,
+        }),
       }),
     ]);
     expect(out.result.contents[0].text).toContain(
@@ -342,12 +443,10 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     });
     expect(out.error).toBeUndefined();
     const content = out.result.content;
-    // First block: the JSON result.
+    // First block: concise model-visible status; the full app opens through
+    // metadata/structuredContent instead of dumping app data into chat.
     expect(content[0].type).toBe("text");
-    expect(JSON.parse(content[0].text)).toEqual({
-      echoed: "hello",
-      id: "thing-42",
-    });
+    expect(content[0].text).toBe("echo-thing completed for thing-42.");
     // Second block: the appended markdown deep link, absolutized to the
     // request origin derived from the inbound Host header.
     expect(content[1].text).toContain(
@@ -359,6 +458,15 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       view: "thing",
       webUrl:
         "https://mail.agent-native.com/_agent-native/open?view=thing&id=thing-42&agentSidebar=closed",
+    });
+    expect(out.result._meta["openai/outputTemplate"]).toBe(
+      "ui://mail/echo-thing",
+    );
+    expect(out.result.structuredContent).toMatchObject({
+      id: "thing-42",
+      openLink: {
+        label: "Open in Mail",
+      },
     });
     expect(out.result._meta["agent-native/openLink"].desktopUrl).toContain(
       "view=thing&id=thing-42",
@@ -415,9 +523,11 @@ describe("handleMcpRequest — Node fast-path still taken when event.node presen
     process.env.ACCESS_TOKEN = "test-access-token";
     delete process.env.ACCESS_TOKENS;
     delete process.env.A2A_SECRET;
+    delete process.env.BETTER_AUTH_SECRET;
   });
   afterEach(() => {
     delete process.env.ACCESS_TOKEN;
+    delete process.env.BETTER_AUTH_SECRET;
     vi.clearAllMocks();
     vi.restoreAllMocks();
   });

--- a/templates/content/app/components/editor/VisualEditor.readonly.test.ts
+++ b/templates/content/app/components/editor/VisualEditor.readonly.test.ts
@@ -20,9 +20,17 @@ describe("VisualEditor read-only mode", () => {
 
     expect(source).toContain("const editor = this.editor");
     expect(source).toContain("el.draggable = false");
-    expect(source).toContain("if (!editor.isEditable) return");
-    expect(source).toContain("e.preventDefault();");
+    expect(source).toMatch(
+      /handle\.addEventListener\("mousedown", \(e\) => \{\s*e\.stopPropagation\(\);\s*if \(!editor\.isEditable\) \{\s*e\.preventDefault\(\);/,
+    );
+    expect(source).not.toMatch(
+      /handle\.addEventListener\("mousedown", \(e\) => \{\s*e\.preventDefault\(\);\s*if \(!editor\.isEditable\)/,
+    );
     expect(source).toContain("handle.draggable = false");
     expect(source).toContain("handle.draggable = true");
+    expect(source).toContain(
+      'e.dataTransfer.setData("text/plain", getDragText());',
+    );
+    expect(source).toContain("node: sel");
   });
 });

--- a/templates/content/app/components/editor/extensions/DragHandle.tsx
+++ b/templates/content/app/components/editor/extensions/DragHandle.tsx
@@ -28,6 +28,21 @@ export const DragHandle = Extension.create({
     let currentBlock: HTMLElement | null = null;
     let dragStartPos: number | null = null;
 
+    const selectCurrentBlock = (editorView: EditorView) => {
+      if (dragStartPos === null) return null;
+
+      try {
+        const sel = NodeSelection.create(editorView.state.doc, dragStartPos);
+        editorView.dispatch(editorView.state.tr.setSelection(sel));
+        editorView.focus();
+        return sel;
+      } catch {
+        return null;
+      }
+    };
+
+    const getDragText = () => currentBlock?.textContent?.trim() || " ";
+
     const createHandle = () => {
       const el = document.createElement("div");
       el.className = "drag-handle";
@@ -59,37 +74,65 @@ export const DragHandle = Extension.create({
 
           // On mousedown, select the block node
           handle.addEventListener("mousedown", (e) => {
-            e.preventDefault();
-            if (!editor.isEditable) return;
-            if (dragStartPos === null) return;
-            const sel = NodeSelection.create(
-              editorView.state.doc,
-              dragStartPos,
-            );
-            editorView.dispatch(editorView.state.tr.setSelection(sel));
-            editorView.focus();
-          });
-
-          // On dragstart, set up ProseMirror's drag state
-          handle.addEventListener("dragstart", (e) => {
+            e.stopPropagation();
             if (!editor.isEditable) {
               e.preventDefault();
               return;
             }
-            if (dragStartPos === null || !e.dataTransfer) return;
 
-            const sel = NodeSelection.create(
-              editorView.state.doc,
-              dragStartPos,
-            );
-            editorView.dispatch(editorView.state.tr.setSelection(sel));
+            selectCurrentBlock(editorView);
+          });
+
+          // On dragstart, set up ProseMirror's drag state
+          handle.addEventListener("dragstart", (e) => {
+            e.stopPropagation();
+            if (!editor.isEditable) {
+              e.preventDefault();
+              return;
+            }
+            if (!e.dataTransfer) {
+              e.preventDefault();
+              return;
+            }
+
+            const sel = selectCurrentBlock(editorView);
+            if (!sel) {
+              e.preventDefault();
+              return;
+            }
 
             const slice = sel.content();
             e.dataTransfer.effectAllowed = "move";
-            e.dataTransfer.setData("text/plain", "");
+            e.dataTransfer.setData("text/plain", getDragText());
+            e.dataTransfer.setData(
+              "text/html",
+              currentBlock?.outerHTML ?? getDragText(),
+            );
 
-            // Tell ProseMirror this is an internal drag
-            (editorView as any).dragging = { slice, move: true };
+            // Tell ProseMirror this is an internal move, including the source
+            // node so the drop handler deletes the original block reliably.
+            (editorView as any).dragging = { slice, move: true, node: sel };
+          });
+
+          handle.addEventListener("dragend", () => {
+            const dragging = (editorView as any).dragging;
+            window.setTimeout(() => {
+              if ((editorView as any).dragging === dragging) {
+                (editorView as any).dragging = null;
+              }
+            }, 50);
+            hideHandle();
+          });
+
+          handle.addEventListener("mouseleave", () => {
+            window.setTimeout(() => {
+              if (
+                !handle?.matches(":hover") &&
+                !editorView.dom.matches(":hover")
+              ) {
+                hideHandle();
+              }
+            }, 100);
           });
 
           return {
@@ -136,11 +179,18 @@ export const DragHandle = Extension.create({
               handle.style.display = "flex";
               handle.draggable = true;
               handle.style.top = `${blockRect.top - wrapperRect.top + 2}px`;
-              handle.style.left = "-28px";
+              handle.style.left = "-24px";
 
               return false;
             },
-            mouseleave() {
+            mouseleave(_view, event) {
+              if (
+                event.relatedTarget instanceof Node &&
+                handle?.contains(event.relatedTarget)
+              ) {
+                return false;
+              }
+
               setTimeout(() => {
                 if (!handle?.matches(":hover")) {
                   hideHandle();

--- a/templates/content/app/global.css
+++ b/templates/content/app/global.css
@@ -271,6 +271,7 @@
 
 .visual-editor-wrapper {
   position: relative;
+  min-height: max(320px, 50vh);
 }
 
 .notion-editor {
@@ -283,6 +284,10 @@
   color: hsl(var(--foreground));
   line-height: 1.7;
   font-size: 1rem;
+}
+
+.visual-editor-wrapper .notion-editor {
+  min-height: max(320px, 50vh);
 }
 
 .notion-editor > *:first-child {
@@ -988,13 +993,14 @@ video.media-block__content {
   display: none;
   align-items: center;
   justify-content: center;
-  width: 20px;
+  width: 24px;
   height: 24px;
   border-radius: 4px;
   cursor: grab;
   color: hsl(var(--muted-foreground) / 0.4);
   z-index: 10;
   user-select: none;
+  touch-action: none;
 }
 .drag-handle:hover {
   color: hsl(var(--muted-foreground));


### PR DESCRIPTION
Summary:
- compact OAuth MCP app-host catalogs so ChatGPT/Claude see only embed/open-app surfaces instead of the full internal action registry
- add ChatGPT Apps-compatible widget metadata and resource templates while keeping real app iframe resources
- return concise structured MCP app tool results to stop massive tool output dumps
- include the existing Content visual-editor drag-handle cleanup that was present in the working tree

Verification:
- pnpm prep