### PR TITLE
Fix MCP app embed launch reliability

### DIFF
--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -154,12 +154,13 @@ precedence). Disable the set with `MCPConfig.builtinCrossAppTools: false`.
 For OAuth callers that request `mcp:apps`, the advertised `tools/list` catalog
 is intentionally compact so ChatGPT/Claude app hosts do not ingest every
 internal action schema. The model sees app-facing builtins (`list_apps`,
-`open_app`, app-only `create_embed_session`), actions with `mcpApp`, and
-actions explicitly marked `publicAgent.expose`. Stdio/static-token developer
-clients still get the full connected action surface. If a host should be able
-to call a new action from an MCP App conversation, mark it with `mcpApp` (for
-UI-producing work) or `publicAgent` (for safe read/ingest work) instead of
-relying on incidental full-surface discovery.
+`open_app`, app-only `create_embed_session`) and actions with `mcpApp`.
+Stdio/static-token developer clients still get the full connected action
+surface, and `publicAgent.expose` remains the opt-in for safe read/ingest tools
+outside the compact MCP Apps catalog. If a UI-capable host should be able to
+call a new action from an MCP App conversation, mark it with `mcpApp`; use
+`publicAgent` for non-UI read/ingest handoff tools instead of relying on
+incidental full-surface discovery.
 
 ### 2. Add a `link` builder to an action
 

--- a/.changeset/steady-mcp-app-embeds.md
+++ b/.changeset/steady-mcp-app-embeds.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix MCP App full-app embed launching through open routes and keep app-host discovery compact.

--- a/packages/core/docs/content/actions.md
+++ b/packages/core/docs/content/actions.md
@@ -152,7 +152,7 @@ If your app is an [A2A](/docs/a2a-protocol) peer, other agent-native apps discov
 
 ## Exposing it over MCP {#mcp}
 
-With MCP enabled, your actions show up in the framework's MCP server at `/_agent-native/mcp`. Stdio/static-token developer clients see the full connected action surface. OAuth app hosts that request `mcp:apps` get a compact catalog containing app-facing builtins, actions with `mcpApp`, and actions explicitly marked `publicAgent.expose`, so ChatGPT/Claude discovery stays small. See [MCP Protocol](/docs/mcp-protocol).
+With MCP enabled, your actions show up in the framework's MCP server at `/_agent-native/mcp`. Stdio/static-token developer clients see the full connected action surface. OAuth app hosts that request `mcp:apps` get a compact catalog containing app-facing builtins and actions with `mcpApp`; `publicAgent.expose` is still the opt-in for safe read/ingest tools outside that compact app catalog. See [MCP Protocol](/docs/mcp-protocol).
 
 For UI-capable MCP hosts, actions can also attach an optional MCP Apps resource.
 Use the shared full-app embed helper when the action needs an inline experience.

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -229,7 +229,7 @@ On top of the per-action tools the MCP server exposes a stable verb set, so an e
 
 `create_workspace_app` rejects any non-allow-listed template — the public template allow-list in `packages/shared-app-config/templates.ts` is authoritative and CI-guarded; an external agent cannot widen it. A same-named template action overrides a builtin (template-over-core precedence). Disable the whole set with `MCPConfig.builtinCrossAppTools: false`.
 
-For OAuth callers that request `mcp:apps`, the server intentionally advertises a compact `tools/list` catalog so app hosts do not ingest every internal action schema. The model sees app-facing builtins (`list_apps`, `open_app`, app-only `create_embed_session`), actions with `mcpApp`, and actions explicitly marked `publicAgent.expose`. Stdio/static-token developer clients still get the full connected action surface. If a host should be able to call a new action from an MCP App conversation, mark it with `mcpApp` for UI-producing work or `publicAgent` for safe read/ingest work.
+For OAuth callers that request `mcp:apps`, the server intentionally advertises a compact `tools/list` catalog so app hosts do not ingest every internal action schema. The model sees app-facing builtins (`list_apps`, `open_app`, app-only `create_embed_session`) and actions with `mcpApp`. Stdio/static-token developer clients still get the full connected action surface, and `publicAgent.expose` remains the opt-in for safe read/ingest tools outside the compact app catalog. If a UI-capable host should be able to call a new action from an MCP App conversation, mark it with `mcpApp`; use `publicAgent` for non-UI read/ingest handoff tools.
 
 ### Per-app tour {#tour}
 

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -76,7 +76,7 @@ If an action declares `mcpApp`, the server also advertises the official MCP Apps
 
 ## Tools {#tools}
 
-Stdio/static-token developer clients see all connected app actions as MCP tools. OAuth callers that request `mcp:apps` get a compact app-host catalog: app-facing builtins, actions with `mcpApp`, and actions explicitly marked `publicAgent.expose`. This keeps ChatGPT/Claude app-host discovery small while preserving the full developer surface for local agents.
+Stdio/static-token developer clients see all connected app actions as MCP tools. OAuth callers that request `mcp:apps` get a compact app-host catalog: app-facing builtins and actions with `mcpApp`. `publicAgent.expose` remains the opt-in for safe read/ingest tools outside that compact app catalog. This keeps ChatGPT/Claude app-host discovery small while preserving the full developer surface for local agents.
 
 The mapping is direct:
 

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -150,8 +150,7 @@ function isActionAdvertisedInCompactMcpAppCatalog(
 ): boolean {
   if (COMPACT_MCP_APP_CATALOG_BUILTINS.has(name)) return true;
   if (name === "ask_app" && isDispatchConfig(config)) return true;
-  if (entry.mcpApp?.resource) return true;
-  return entry.publicAgent?.expose === true;
+  return Boolean(entry.mcpApp?.resource);
 }
 
 interface ResolvedMcpAppResource {

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -15,6 +15,10 @@ describe("embedApp", () => {
     expect(html).toContain("create_embed_session");
     expect(html).toContain("app.callServerTool");
     expect(html).toContain('document.createElement("iframe")');
+    expect(html).toContain('data-app-title="Dashboard"');
+    expect(html).toContain("data-title-label>Dashboard");
+    expect(html).toContain('document.querySelector("[data-title-label]")');
+    expect(html).not.toContain('document.querySelector("[data-title]")');
     expect(html).toContain(
       'toolInput.embed === false || toolInput.embed === "false"',
     );

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -58,7 +58,7 @@ export function embedApp(
   </style>
 </head>
 <body
-  data-title="${attr(title)}"
+  data-app-title="${attr(title)}"
   data-iframe-title="${attr(iframeTitle)}"
   data-open-label="${attr(openLabel)}"
   data-start-tool="${attr(startToolName)}"
@@ -66,7 +66,7 @@ export function embedApp(
 >
   <main class="shell">
     <div class="bar">
-      <div class="title" data-title>${attr(title)}</div>
+      <div class="title" data-title-label>${attr(title)}</div>
       <div class="actions">
         <button type="button" data-open disabled>${attr(openLabel)}</button>
       </div>
@@ -81,7 +81,7 @@ export function embedApp(
     const app = new App({ name: "Agent Native Embed", version: "1.0.0" }, {});
     const body = document.body;
     const stage = document.querySelector("[data-stage]");
-    const titleEl = document.querySelector("[data-title]");
+    const titleEl = document.querySelector("[data-title-label]");
     const openButton = document.querySelector("[data-open]");
     const startTool = body.dataset.startTool || "create_embed_session";
     const embedByDefault = body.dataset.embedDefault !== "0";
@@ -179,7 +179,7 @@ export function embedApp(
     }
 
     function updateTitle(data) {
-      const label = data.label || data.app || data.view || body.dataset.title || "App";
+      const label = data.label || data.app || data.view || body.dataset.appTitle || "App";
       titleEl.textContent = String(label);
     }
 

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -350,9 +350,10 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     const names = out.result.tools.map((t: any) => t.name);
     expect(names).toEqual(
-      expect.arrayContaining(["echo-thing", "public-search", "review-draft"]),
+      expect.arrayContaining(["echo-thing", "review-draft"]),
     );
     expect(names).not.toContain("internal-heavy");
+    expect(names).not.toContain("public-search");
     expect(names).not.toContain("ask-agent");
   });
 

--- a/packages/core/src/server/embed-session.spec.ts
+++ b/packages/core/src/server/embed-session.spec.ts
@@ -163,6 +163,12 @@ describe("requestMatchesEmbedTarget", () => {
     ).toBe(true);
     expect(
       requestMatchesEmbedTarget(
+        fakeEvent("/?embedded=1&__an_embed_token=tok"),
+        "/_agent-native/open?app=slides&view=list",
+      ),
+    ).toBe(true);
+    expect(
+      requestMatchesEmbedTarget(
         fakeEvent("/search?embedded=1&__an_embed_token=tok"),
         "/_agent-native/open?app=brain&view=capture&captureId=capture-1",
       ),
@@ -191,6 +197,15 @@ describe("requestMatchesEmbedTarget", () => {
       requestMatchesEmbedTarget(
         fakeEvent("/evil/t1?embedded=1&__an_embed_token=tok"),
         "/_agent-native/open?app=mail&view=//evil&threadId=t1",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects dot-segment record ids before route matching", () => {
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/deck?embedded=1&__an_embed_token=tok"),
+        "/_agent-native/open?app=slides&view=editor&deckId=..",
       ),
     ).toBe(false);
   });

--- a/packages/core/src/server/embed-session.spec.ts
+++ b/packages/core/src/server/embed-session.spec.ts
@@ -96,6 +96,16 @@ describe("normalizeEmbedTargetPath", () => {
 });
 
 describe("requestMatchesEmbedTarget", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.APP_BASE_PATH;
+    delete process.env.VITE_APP_BASE_PATH;
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
   function fakeEvent(path: string, headers: Record<string, string> = {}) {
     return {
       path,
@@ -127,6 +137,62 @@ describe("requestMatchesEmbedTarget", () => {
         "/_agent-native/open?app=analytics&view=analyses&analysisId=analysis-1",
       ),
     ).toBe(true);
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/design/design-1?embedded=1&__an_embed_token=tok"),
+        "/_agent-native/open?app=design&view=editor&designId=design-1",
+      ),
+    ).toBe(true);
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/page/doc-1?embedded=1&__an_embed_token=tok"),
+        "/_agent-native/open?app=content&view=editor&documentId=doc-1",
+      ),
+    ).toBe(true);
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/deck/deck-1?embedded=1&__an_embed_token=tok"),
+        "/_agent-native/open?app=slides&view=editor&deckId=deck-1",
+      ),
+    ).toBe(true);
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/deck/deck-1/present?embedded=1&__an_embed_token=tok"),
+        "/_agent-native/open?app=slides&view=present&deckId=deck-1",
+      ),
+    ).toBe(true);
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/search?embedded=1&__an_embed_token=tok"),
+        "/_agent-native/open?app=brain&view=capture&captureId=capture-1",
+      ),
+    ).toBe(true);
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/?embedded=1&__an_embed_token=tok"),
+        "/_agent-native/open?app=calendar&view=calendar&eventId=event-1",
+      ),
+    ).toBe(true);
+  });
+
+  it("allows resolved open routes when the app is deployed under APP_BASE_PATH", () => {
+    process.env.APP_BASE_PATH = "/mail";
+
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/mail/inbox?embedded=1&__an_embed_token=tok"),
+        "/mail/_agent-native/open?app=mail&view=inbox",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not build thread record paths from unsafe view paths", () => {
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/evil/t1?embedded=1&__an_embed_token=tok"),
+        "/_agent-native/open?app=mail&view=//evil&threadId=t1",
+      ),
+    ).toBe(false);
   });
 
   it("uses the browser URL, not the mounted handler path, for framework routes", () => {

--- a/packages/core/src/server/embed-session.spec.ts
+++ b/packages/core/src/server/embed-session.spec.ts
@@ -114,6 +114,36 @@ describe("requestMatchesEmbedTarget", () => {
     ).toBe(true);
   });
 
+  it("allows record routes produced by template open-route resolvers", () => {
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/adhoc/q2-traffic?embedded=1&__an_embed_token=tok"),
+        "/_agent-native/open?app=analytics&view=adhoc&dashboardId=q2-traffic",
+      ),
+    ).toBe(true);
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/analyses/analysis-1?embedded=1&__an_embed_token=tok"),
+        "/_agent-native/open?app=analytics&view=analyses&analysisId=analysis-1",
+      ),
+    ).toBe(true);
+  });
+
+  it("uses the browser URL, not the mounted handler path, for framework routes", () => {
+    const event = fakeEvent("/");
+    event.context = { _mountedPathname: "/_agent-native/open" };
+    event.url = {
+      search: "?app=mail&view=inbox&embedded=1&__an_embed_token=tok",
+    };
+
+    expect(
+      requestMatchesEmbedTarget(
+        event,
+        "/_agent-native/open?app=mail&view=inbox",
+      ),
+    ).toBe(true);
+  });
+
   it("rejects unrelated page routes for the same token", () => {
     expect(
       requestMatchesEmbedTarget(

--- a/packages/core/src/server/embed-session.ts
+++ b/packages/core/src/server/embed-session.ts
@@ -27,6 +27,7 @@ const OPEN_ROUTE_VIEW_PATHS: Record<string, string> = {
   calendar: "/",
   capture: "/search",
   knowledge: "/knowledge",
+  list: "/",
   ops: "/ops",
   proposals: "/review",
   review: "/review",
@@ -186,6 +187,7 @@ function pathnameFromPath(path: string): string | null {
 function safePathSegment(value: string | null | undefined): string | null {
   const segment = value?.trim();
   if (!segment || CONTROL_CHARS.test(segment)) return null;
+  if (segment === "." || segment === "..") return null;
   if (
     segment.includes("/") ||
     segment.includes("\\") ||

--- a/packages/core/src/server/embed-session.ts
+++ b/packages/core/src/server/embed-session.ts
@@ -22,6 +22,19 @@ const DEFAULT_TOKEN_TTL_SECONDS = 60 * 60;
 const DEFAULT_TICKET_TTL_SECONDS = 5 * 60;
 const CONTROL_CHARS = new RegExp("[\\u0000-\\u001f\\u007f]");
 const OPEN_ROUTE_PATH = "/_agent-native/open";
+const OPEN_ROUTE_VIEW_PATHS: Record<string, string> = {
+  ask: "/",
+  calendar: "/",
+  capture: "/search",
+  knowledge: "/knowledge",
+  ops: "/ops",
+  proposals: "/review",
+  review: "/review",
+  search: "/search",
+  source: "/sources",
+  sources: "/sources",
+  settings: "/settings",
+};
 
 let _initPromise: Promise<void> | undefined;
 let _devSigningKey: string | undefined;
@@ -184,6 +197,15 @@ function safePathSegment(value: string | null | undefined): string | null {
   return segment;
 }
 
+function addResolvedOpenRoutePath(
+  targets: Set<string>,
+  path: string | null | undefined,
+): void {
+  if (!path) return;
+  const pathname = pathnameFromPath(path);
+  if (pathname) targets.add(pathname);
+}
+
 function openRouteTargetPathnames(targetPath: string): Set<string> {
   const targets = new Set<string>();
   let url: URL;
@@ -192,35 +214,86 @@ function openRouteTargetPathnames(targetPath: string): Set<string> {
   } catch {
     return targets;
   }
-  if (url.pathname !== OPEN_ROUTE_PATH) {
+  if (stripConfiguredBasePath(url.pathname) !== OPEN_ROUTE_PATH) {
     return targets;
   }
 
   const to = normalizeEmbedTargetPath(url.searchParams.get("to"));
-  const toPathname = to ? pathnameFromPath(to) : null;
-  if (toPathname) targets.add(toPathname);
+  addResolvedOpenRoutePath(targets, to);
 
   const view = url.searchParams.get("view")?.trim();
   if (!view || CONTROL_CHARS.test(view)) return targets;
   const viewPath = view.startsWith("/") ? view : `/${view}`;
   const viewPathname = pathnameFromPath(viewPath);
-  if (viewPathname) targets.add(viewPathname);
+  addResolvedOpenRoutePath(targets, viewPathname);
+  addResolvedOpenRoutePath(targets, OPEN_ROUTE_VIEW_PATHS[view]);
 
   const dashboardId = safePathSegment(url.searchParams.get("dashboardId"));
   if (view === "adhoc" && dashboardId) {
-    targets.add(`/adhoc/${encodeURIComponent(dashboardId)}`);
+    addResolvedOpenRoutePath(
+      targets,
+      `/adhoc/${encodeURIComponent(dashboardId)}`,
+    );
   }
   const analysisId = safePathSegment(url.searchParams.get("analysisId"));
   if (view === "analyses" && analysisId) {
-    targets.add(`/analyses/${encodeURIComponent(analysisId)}`);
+    addResolvedOpenRoutePath(
+      targets,
+      `/analyses/${encodeURIComponent(analysisId)}`,
+    );
   }
   const extensionId = safePathSegment(url.searchParams.get("extensionId"));
   if (view === "extensions" && extensionId) {
-    targets.add(`/extensions/${encodeURIComponent(extensionId)}`);
+    addResolvedOpenRoutePath(
+      targets,
+      `/extensions/${encodeURIComponent(extensionId)}`,
+    );
+  }
+  const designId = safePathSegment(url.searchParams.get("designId"));
+  if (designId) {
+    addResolvedOpenRoutePath(
+      targets,
+      view === "present"
+        ? `/present/${encodeURIComponent(designId)}`
+        : `/design/${encodeURIComponent(designId)}`,
+    );
+  }
+  const documentId = safePathSegment(url.searchParams.get("documentId"));
+  if (documentId) {
+    addResolvedOpenRoutePath(
+      targets,
+      `/page/${encodeURIComponent(documentId)}`,
+    );
+  }
+  const deckId = safePathSegment(url.searchParams.get("deckId"));
+  if (deckId) {
+    addResolvedOpenRoutePath(
+      targets,
+      view === "present"
+        ? `/deck/${encodeURIComponent(deckId)}/present`
+        : `/deck/${encodeURIComponent(deckId)}`,
+    );
+  }
+  if (
+    safePathSegment(url.searchParams.get("captureId")) ||
+    safePathSegment(url.searchParams.get("knowledgeId")) ||
+    safePathSegment(url.searchParams.get("sourceId"))
+  ) {
+    addResolvedOpenRoutePath(targets, OPEN_ROUTE_VIEW_PATHS[view]);
+  }
+  if (
+    view === "calendar" &&
+    (safePathSegment(url.searchParams.get("eventId")) ||
+      safePathSegment(url.searchParams.get("eventDraftId")))
+  ) {
+    addResolvedOpenRoutePath(targets, "/");
   }
   const threadId = safePathSegment(url.searchParams.get("threadId"));
-  if (view && threadId) {
-    targets.add(`${viewPathname ?? viewPath}/${encodeURIComponent(threadId)}`);
+  if (viewPathname && threadId) {
+    addResolvedOpenRoutePath(
+      targets,
+      `${viewPathname}/${encodeURIComponent(threadId)}`,
+    );
   }
 
   return targets;

--- a/packages/core/src/server/embed-session.ts
+++ b/packages/core/src/server/embed-session.ts
@@ -170,42 +170,89 @@ function pathnameFromPath(path: string): string | null {
   }
 }
 
-function safeOpenRouteTargetPathname(targetPath: string): string | null {
+function safePathSegment(value: string | null | undefined): string | null {
+  const segment = value?.trim();
+  if (!segment || CONTROL_CHARS.test(segment)) return null;
+  if (
+    segment.includes("/") ||
+    segment.includes("\\") ||
+    segment.includes("?")
+  ) {
+    return null;
+  }
+  if (segment.includes("#")) return null;
+  return segment;
+}
+
+function openRouteTargetPathnames(targetPath: string): Set<string> {
+  const targets = new Set<string>();
   let url: URL;
   try {
     url = new URL(targetPath, "http://agent-native.invalid");
   } catch {
-    return null;
+    return targets;
   }
   if (url.pathname !== OPEN_ROUTE_PATH) {
-    return null;
+    return targets;
   }
 
   const to = normalizeEmbedTargetPath(url.searchParams.get("to"));
-  if (to) return pathnameFromPath(to);
+  const toPathname = to ? pathnameFromPath(to) : null;
+  if (toPathname) targets.add(toPathname);
 
   const view = url.searchParams.get("view")?.trim();
-  if (!view || CONTROL_CHARS.test(view)) return null;
+  if (!view || CONTROL_CHARS.test(view)) return targets;
   const viewPath = view.startsWith("/") ? view : `/${view}`;
-  return pathnameFromPath(viewPath);
+  const viewPathname = pathnameFromPath(viewPath);
+  if (viewPathname) targets.add(viewPathname);
+
+  const dashboardId = safePathSegment(url.searchParams.get("dashboardId"));
+  if (view === "adhoc" && dashboardId) {
+    targets.add(`/adhoc/${encodeURIComponent(dashboardId)}`);
+  }
+  const analysisId = safePathSegment(url.searchParams.get("analysisId"));
+  if (view === "analyses" && analysisId) {
+    targets.add(`/analyses/${encodeURIComponent(analysisId)}`);
+  }
+  const extensionId = safePathSegment(url.searchParams.get("extensionId"));
+  if (view === "extensions" && extensionId) {
+    targets.add(`/extensions/${encodeURIComponent(extensionId)}`);
+  }
+  const threadId = safePathSegment(url.searchParams.get("threadId"));
+  if (view && threadId) {
+    targets.add(`${viewPathname ?? viewPath}/${encodeURIComponent(threadId)}`);
+  }
+
+  return targets;
 }
 
 function allowedEmbedTargetPathnames(targetPath: string): Set<string> {
   const allowed = new Set<string>();
   const direct = pathnameFromPath(targetPath);
   if (direct) allowed.add(direct);
-  const openTarget = safeOpenRouteTargetPathname(targetPath);
-  if (openTarget) allowed.add(openTarget);
+  for (const openTarget of openRouteTargetPathnames(targetPath)) {
+    allowed.add(openTarget);
+  }
   return allowed;
 }
 
-function requestPathname(event: H3Event): string | null {
-  const raw =
-    (event as any).path ??
+function requestUrlFromEvent(event: H3Event): string {
+  const mountedPathname = (event as any).context?._mountedPathname;
+  if (typeof mountedPathname === "string" && mountedPathname) {
+    return `${mountedPathname}${(event as any).url?.search ?? ""}`;
+  }
+  return (
     (event as any).node?.req?.url ??
     ((event as any).req?.url as string | undefined) ??
+    ((event as any).request?.url as string | undefined) ??
+    (event as any).path ??
     (event as any).url?.toString?.() ??
-    "/";
+    "/"
+  );
+}
+
+function requestPathname(event: H3Event): string | null {
+  const raw = requestUrlFromEvent(event);
   try {
     const pathname = new URL(raw, "http://agent-native.invalid").pathname;
     return stripConfiguredBasePath(pathname);
@@ -477,7 +524,18 @@ function bearerToken(event: H3Event): string | undefined {
 
 function queryToken(event: H3Event): string | undefined {
   const raw = getQuery(event)?.[EMBED_TOKEN_QUERY_PARAM];
-  return Array.isArray(raw) ? raw[0] : raw;
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value) return value;
+  try {
+    return (
+      new URL(
+        requestUrlFromEvent(event),
+        "http://agent-native.invalid",
+      ).searchParams.get(EMBED_TOKEN_QUERY_PARAM) ?? undefined
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 export async function resolveEmbedSessionFromRequest(

--- a/packages/core/src/server/open-route.spec.ts
+++ b/packages/core/src/server/open-route.spec.ts
@@ -182,6 +182,29 @@ describe("createOpenRouteHandler", () => {
     expect(payload).toEqual({ threadId: "t1", view: "inbox" });
   });
 
+  it("parses the original browser URL when mounted under the framework route", async () => {
+    getSession.mockResolvedValue({ email: "user@example.com" });
+    const handler = createOpenRouteHandler();
+
+    const res: Response = await handler({
+      method: "GET",
+      path: "/",
+      node: { req: { url: "/" } },
+      context: { _mountedPathname: "/_agent-native/open" },
+      url: {
+        search: "?view=inbox&threadId=t1&embedded=1&__an_embed_token=tok_123",
+      },
+    } as any);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(
+      "/inbox?embedded=1&__an_embed_token=tok_123&agentSidebar=closed",
+    );
+
+    const [, , payload] = appStatePut.mock.calls[0];
+    expect(payload).toEqual({ threadId: "t1", view: "inbox" });
+  });
+
   it("honors a safe same-origin relative `to` override", async () => {
     getSession.mockResolvedValue({ email: "user@example.com" });
     const handler = createOpenRouteHandler();

--- a/packages/core/src/server/open-route.spec.ts
+++ b/packages/core/src/server/open-route.spec.ts
@@ -32,6 +32,8 @@ function fakeEvent(url: string, method = "GET") {
 
 describe("createOpenRouteHandler", () => {
   beforeEach(() => {
+    delete process.env.APP_BASE_PATH;
+    delete process.env.VITE_APP_BASE_PATH;
     getSession.mockReset();
     getConfiguredLoginHtml.mockReset();
     appStatePut.mockReset();
@@ -41,6 +43,8 @@ describe("createOpenRouteHandler", () => {
   });
 
   afterEach(() => {
+    delete process.env.APP_BASE_PATH;
+    delete process.env.VITE_APP_BASE_PATH;
     vi.restoreAllMocks();
   });
 
@@ -203,6 +207,36 @@ describe("createOpenRouteHandler", () => {
 
     const [, , payload] = appStatePut.mock.calls[0];
     expect(payload).toEqual({ threadId: "t1", view: "inbox" });
+  });
+
+  it("preserves APP_BASE_PATH when redirecting mounted app routes", async () => {
+    process.env.APP_BASE_PATH = "/mail";
+    getSession.mockResolvedValue({ email: "user@example.com" });
+    const handler = createOpenRouteHandler();
+
+    const res: Response = await handler(
+      fakeEvent("/mail/_agent-native/open?view=inbox&threadId=t1"),
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/mail/inbox?agentSidebar=closed");
+  });
+
+  it("does not duplicate APP_BASE_PATH when a safe to param is already mounted", async () => {
+    process.env.APP_BASE_PATH = "/mail";
+    getSession.mockResolvedValue({ email: "user@example.com" });
+    const handler = createOpenRouteHandler();
+
+    const res: Response = await handler(
+      fakeEvent(
+        "/mail/_agent-native/open?view=inbox&to=%2Fmail%2Finbox%2Fabc123",
+      ),
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(
+      "/mail/inbox/abc123?agentSidebar=closed",
+    );
   });
 
   it("honors a safe same-origin relative `to` override", async () => {

--- a/packages/core/src/server/open-route.ts
+++ b/packages/core/src/server/open-route.ts
@@ -33,6 +33,7 @@ import {
   EMBED_MODE_QUERY_PARAM,
   EMBED_TOKEN_QUERY_PARAM,
 } from "../shared/embed-auth.js";
+import { getConfiguredAppBasePath } from "./app-base-path.js";
 
 /** Query keys that are route control, not navigation payload. */
 const RESERVED = new Set([
@@ -104,6 +105,21 @@ function appendSearchParams(target: string, params: URLSearchParams): string {
   try {
     const url = new URL(target, "http://an.invalid");
     for (const [k, v] of params.entries()) url.searchParams.set(k, v);
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return target;
+  }
+}
+
+function withConfiguredRedirectBasePath(target: string): string {
+  const base = getConfiguredAppBasePath();
+  if (!base) return target;
+  try {
+    const url = new URL(target, "http://an.invalid");
+    if (url.pathname === base || url.pathname.startsWith(`${base}/`)) {
+      return `${url.pathname}${url.search}${url.hash}`;
+    }
+    url.pathname = url.pathname === "/" ? base : `${base}${url.pathname}`;
     return `${url.pathname}${url.search}${url.hash}`;
   } catch {
     return target;
@@ -234,6 +250,7 @@ export function createOpenRouteHandler(options: OpenRouteOptions = {}) {
     }
     target = appendSearchParams(target, embedParams);
     target = withCollapsedAgentSidebarParam(target);
+    target = withConfiguredRedirectBasePath(target);
 
     return redirect(target);
   });

--- a/packages/core/src/server/open-route.ts
+++ b/packages/core/src/server/open-route.ts
@@ -67,6 +67,10 @@ export interface OpenRouteOptions {
 }
 
 function getRequestUrl(event: H3Event): string {
+  const mountedPathname = (event as any).context?._mountedPathname;
+  if (typeof mountedPathname === "string" && mountedPathname) {
+    return `${mountedPathname}${(event as any).url?.search ?? ""}`;
+  }
   return (event as any).node?.req?.url ?? (event as any).path ?? "/";
 }
 


### PR DESCRIPTION
## Summary
- fix the MCP app wrapper title selector that was replacing the whole app with plain text
- allow embed-session auth through mounted open routes and resolved record routes such as analytics dashboards/analyses
- keep OAuth MCP Apps discovery compact to avoid giant tool catalogs
- update external-agent docs/skills for real React/full-app embeds

## Verification
- pnpm --dir packages/core exec vitest --run src/mcp/embed-app.spec.ts src/mcp/server.spec.ts src/server/embed-session.spec.ts src/server/open-route.spec.ts src/server/security-headers.spec.ts
- pnpm --dir packages/core build
- mobile-sized Playwright MCP wrapper E2E for Mail draft embed
- mobile-sized Playwright MCP wrapper E2E for Analytics dashboard embed
- mobile-sized Playwright MCP wrapper E2E for open_app analytics overview embed
- OAuth mcp:apps compact catalog size checked locally for Mail and Analytics
- pnpm prep