### PR TITLE
prevent shared engine settings from selecting unavailable packages

### DIFF
--- a/.changeset/gentle-engines-listen.md
+++ b/.changeset/gentle-engines-listen.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prevent unavailable optional agent engines from being selected by chat model pickers or explicit runtime overrides.

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -95,6 +95,76 @@ describe("AgentEngine registry", () => {
     expect(resolved).toBe(fakeEngine);
   });
 
+  it("resolveEngine rejects explicit string engines whose optional runtime packages are missing", async () => {
+    const { registerAgentEngine, resolveEngine } =
+      await import("./registry.js");
+    const create = vi.fn();
+
+    registerAgentEngine({
+      name: "ai-sdk:openai",
+      label: "OpenAI",
+      description: "",
+      installPackage: "@agent-native/definitely-missing-ai-provider",
+      capabilities: {} as any,
+      defaultModel: "gpt-5.4",
+      supportedModels: [],
+      requiredEnvVars: [],
+      create,
+    });
+
+    await expect(
+      resolveEngine({ engineOption: "ai-sdk:openai" }),
+    ).rejects.toThrow(/requires optional packages/);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("resolveEngine rejects explicit object engines whose optional runtime packages are missing", async () => {
+    const { registerAgentEngine, resolveEngine } =
+      await import("./registry.js");
+    const create = vi.fn();
+
+    registerAgentEngine({
+      name: "ai-sdk:openai",
+      label: "OpenAI",
+      description: "",
+      installPackage: "@agent-native/definitely-missing-ai-provider",
+      capabilities: {} as any,
+      defaultModel: "gpt-5.4",
+      supportedModels: [],
+      requiredEnvVars: [],
+      create,
+    });
+
+    await expect(
+      resolveEngine({ engineOption: { name: "ai-sdk:openai", config: {} } }),
+    ).rejects.toThrow(/requires optional packages/);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("resolveEngine rejects AGENT_ENGINE when optional runtime packages are missing", async () => {
+    process.env.AGENT_ENGINE = "ai-sdk:openai";
+    const { registerAgentEngine, resolveEngine } =
+      await import("./registry.js");
+    const create = vi.fn();
+
+    registerAgentEngine({
+      name: "ai-sdk:openai",
+      label: "OpenAI",
+      description: "",
+      installPackage: "@agent-native/definitely-missing-ai-provider",
+      capabilities: {} as any,
+      defaultModel: "gpt-5.4",
+      supportedModels: [],
+      requiredEnvVars: [],
+      create,
+    });
+
+    await expect(resolveEngine({})).rejects.toThrow(
+      /requires optional packages/,
+    );
+    expect(create).not.toHaveBeenCalled();
+  });
+
   it("resolveEngine falls back to default anthropic when nothing configured", async () => {
     const { registerAgentEngine, resolveEngine } =
       await import("./registry.js");

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -119,6 +119,16 @@ export function isAgentEnginePackageInstalled(
   return packageNames.every(canResolvePackage);
 }
 
+function assertAgentEnginePackageInstalled(entry: AgentEngineEntry): void {
+  if (isAgentEnginePackageInstalled(entry)) return;
+  const installHint = entry.installPackage
+    ? ` Run: pnpm add ${entry.installPackage}`
+    : "";
+  throw new Error(
+    `[agent-engine] Engine "${entry.name}" requires optional packages that are not installed in this app.${installHint}`,
+  );
+}
+
 /**
  * First registered engine whose requiredEnvVars are all set. Registration
  * order controls priority — the Builder gateway is registered first so it
@@ -408,6 +418,7 @@ export async function resolveEngine(
       throw new Error(
         `[agent-engine] Unknown engine: "${name}". Registered: ${[..._registry.keys()].join(", ")}`,
       );
+    assertAgentEnginePackageInstalled(entry);
     return entry.create(engineCreateConfig(apiKey, engineConfig));
   }
 
@@ -418,6 +429,7 @@ export async function resolveEngine(
       throw new Error(
         `[agent-engine] Unknown engine: "${engineOption}". Registered: ${[..._registry.keys()].join(", ")}`,
       );
+    assertAgentEnginePackageInstalled(entry);
     return entry.create(engineCreateConfig(apiKey));
   }
 
@@ -425,7 +437,10 @@ export async function resolveEngine(
   const envEngine = process.env.AGENT_ENGINE;
   if (envEngine) {
     const entry = _registry.get(envEngine);
-    if (entry) return entry.create(engineCreateConfig(apiKey));
+    if (entry) {
+      assertAgentEnginePackageInstalled(entry);
+      return entry.create(engineCreateConfig(apiKey));
+    }
   }
 
   const appDefault = await getAgentAppModelDefaultForCurrentRequest(appId);

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -931,14 +931,17 @@ export function MultiTabAssistantChat({
             if (firstGroup) firstGroup.models.unshift(currentModel);
           }
         } else {
-          // No Builder connection — show SDK engines that have API keys.
+          // No Builder connection — show SDK engines this app can run.
           const allowedEngines = new Set([
             "anthropic",
             "ai-sdk:openai",
             "ai-sdk:google",
           ]);
           groups = enginesData.engines
-            .filter((e: any) => allowedEngines.has(e.name))
+            .filter(
+              (e: any) =>
+                allowedEngines.has(e.name) && e.packageInstalled !== false,
+            )
             .map((e: any) => {
               const models = [...e.supportedModels];
               if (
@@ -953,12 +956,11 @@ export function MultiTabAssistantChat({
                 label: e.label,
                 models,
                 configured:
-                  e.packageInstalled !== false &&
-                  (e.requiredEnvVars.length === 0 ||
-                    e.requiredEnvVars.some((v: string) =>
-                      configuredKeys.has(v),
-                    ) ||
-                    e.name === currentEngineName),
+                  e.requiredEnvVars.length === 0 ||
+                  e.requiredEnvVars.some((v: string) =>
+                    configuredKeys.has(v),
+                  ) ||
+                  e.name === currentEngineName,
               };
             });
         }

--- a/packages/core/src/client/use-chat-models.ts
+++ b/packages/core/src/client/use-chat-models.ts
@@ -237,7 +237,10 @@ export function useChatModels({
             "ai-sdk:google",
           ]);
           groups = enginesData.engines
-            .filter((e: any) => allowedEngines.has(e.name))
+            .filter(
+              (e: any) =>
+                allowedEngines.has(e.name) && e.packageInstalled !== false,
+            )
             .map((e: any) => {
               const models = [...e.supportedModels];
               if (
@@ -252,12 +255,11 @@ export function useChatModels({
                 label: e.label,
                 models,
                 configured:
-                  e.packageInstalled !== false &&
-                  (e.requiredEnvVars.length === 0 ||
-                    e.requiredEnvVars.some((v: string) =>
-                      configuredKeys.has(v),
-                    ) ||
-                    e.name === currentEngineName),
+                  e.requiredEnvVars.length === 0 ||
+                  e.requiredEnvVars.some((v: string) =>
+                    configuredKeys.has(v),
+                  ) ||
+                  e.name === currentEngineName,
               };
             });
         }

--- a/packages/core/src/scripts/agent-engines/list-agent-engines.spec.ts
+++ b/packages/core/src/scripts/agent-engines/list-agent-engines.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+describe("list-agent-engines", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    delete process.env.AGENT_ENGINE;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+    delete process.env.BUILDER_PRIVATE_KEY;
+    delete process.env.BUILDER_PUBLIC_KEY;
+    vi.doMock("../../settings/index.js", () => ({
+      getSetting: vi.fn().mockResolvedValue(null),
+    }));
+    vi.doMock("../../agent/app-model-defaults.js", () => ({
+      getAgentAppModelDefaultForCurrentRequest: vi.fn().mockResolvedValue(null),
+    }));
+  });
+
+  it("does not report AGENT_ENGINE as current when its optional package is missing", async () => {
+    process.env.AGENT_ENGINE = "ai-sdk:missing-provider";
+    const { registerAgentEngine } = await import("../../agent/engine/index.js");
+    const { run } = await import("./list-agent-engines.js");
+
+    registerAgentEngine({
+      name: "ai-sdk:missing-provider",
+      label: "Missing Provider",
+      description: "",
+      installPackage: "@agent-native/definitely-missing-ai-provider",
+      capabilities: {} as any,
+      defaultModel: "missing-model",
+      supportedModels: ["missing-model"],
+      requiredEnvVars: [],
+      create: vi.fn() as any,
+    });
+
+    const result = JSON.parse(await run());
+
+    expect(result.current).toBeNull();
+    expect(
+      result.engines.find(
+        (engine: any) => engine.name === "ai-sdk:missing-provider",
+      )?.packageInstalled,
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/scripts/agent-engines/list-agent-engines.ts
+++ b/packages/core/src/scripts/agent-engines/list-agent-engines.ts
@@ -56,17 +56,20 @@ export async function run(args: Record<string, string> = {}): Promise<string> {
     !!appDefaultEntry &&
     (await isStoredEngineUsableForRequest(appDefault, appDefaultEntry));
   const detectedFromUser = await detectEngineFromUserSecrets();
+  const envEntry = process.env.AGENT_ENGINE
+    ? getAgentEngineEntry(process.env.AGENT_ENGINE)
+    : undefined;
+  const envUnavailable = !!envEntry && !isAgentEnginePackageInstalled(envEntry);
 
-  const currentEntry =
-    (process.env.AGENT_ENGINE
-      ? getAgentEngineEntry(process.env.AGENT_ENGINE)
-      : undefined) ??
-    (appDefaultUsable ? appDefaultEntry : undefined) ??
-    (detectedFromUser?.name === "builder" ? detectedFromUser : undefined) ??
-    (storedUsable ? storedEntry : undefined) ??
-    detectedFromUser ??
-    detectEngineFromEnv() ??
-    undefined;
+  const currentEntry = envUnavailable
+    ? undefined
+    : (envEntry ??
+      (appDefaultUsable ? appDefaultEntry : undefined) ??
+      (detectedFromUser?.name === "builder" ? detectedFromUser : undefined) ??
+      (storedUsable ? storedEntry : undefined) ??
+      detectedFromUser ??
+      detectEngineFromEnv() ??
+      undefined);
   const currentModel =
     appDefaultUsable && currentEntry?.name === appDefault?.engine
       ? appDefault?.model
@@ -87,10 +90,12 @@ export async function run(args: Record<string, string> = {}): Promise<string> {
       installPackage: e.installPackage,
       packageInstalled: isAgentEnginePackageInstalled(e),
     })),
-    current: {
-      engine: currentEngineName,
-      model: currentModel ?? currentEntry?.defaultModel ?? DEFAULT_MODEL,
-    },
+    current: envUnavailable
+      ? null
+      : {
+          engine: currentEngineName,
+          model: currentModel ?? currentEntry?.defaultModel ?? DEFAULT_MODEL,
+        },
   };
 
   return JSON.stringify(result, null, 2);

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -117,6 +117,7 @@ import {
   getAgentEngineEntry,
   detectEngineFromEnv,
   detectEngineFromUserSecrets,
+  isAgentEnginePackageInstalled,
   isStoredEngineUsableForRequest,
 } from "../agent/engine/registry.js";
 import { registerBuiltinEngines } from "../agent/engine/builtin.js";
@@ -158,6 +159,13 @@ async function detectUsageEngineName(
         /* org module not present in this template */
       }
     }
+    const envEntry = process.env.AGENT_ENGINE
+      ? getAgentEngineEntry(process.env.AGENT_ENGINE)
+      : undefined;
+    if (envEntry) {
+      return isAgentEnginePackageInstalled(envEntry) ? envEntry.name : null;
+    }
+
     const detectedFromUser = await runWithRequestContext(
       { userEmail, orgId },
       () => detectEngineFromUserSecrets(),
@@ -1870,6 +1878,21 @@ export function createCoreRoutesPlugin(
               engine,
               model: stored.model ?? entry?.defaultModel ?? DEFAULT_MODEL,
               source: "settings" as const,
+            };
+          }
+          const envEntry = process.env.AGENT_ENGINE
+            ? getAgentEngineEntry(process.env.AGENT_ENGINE)
+            : undefined;
+          if (envEntry) {
+            if (!isAgentEnginePackageInstalled(envEntry)) {
+              return { configured: false };
+            }
+            return {
+              configured: true,
+              engine: envEntry.name,
+              model: envEntry.defaultModel ?? DEFAULT_MODEL,
+              source: "env" as const,
+              envVar: "AGENT_ENGINE",
             };
           }
           // Per-user app_secrets — a user who connected Builder (or pasted


### PR DESCRIPTION
## Summary
Prevent optional AI SDK engines from being selected when the current app/container cannot run them.
- Reject explicit runtime engine overrides when required optional packages are missing
- Apply the same guard to 'AGENT_ENGINE'
- Hide uninstalled optional engines from chat model pickers
- Add regression tests for explicit missing-package engine selection
- Add a patch changeset for '@agent-native/core
## Testing
- pnpm --filter @agent-native/core exec vitest --run src/agent/engine/registry.spec.ts
- pnpm --filter @agent-native/core typecheck
- git diff --check