### PR TITLE
[wip] Fix bubble shadows, multi-screen, and overlay visibility

### DIFF
--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -517,6 +517,9 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
     // `getDisplayMedia`, which matches the other Clips chrome (popover,
     // toolbar, countdown) but NOT what users want for the camera bubble.
     let _ = win.show();
+    // canJoinAllSpaces: bubble follows the user across every Mission Control
+    // space and every monitor — not just the one where the session started.
+    crate::util::set_window_can_join_all_spaces(&win);
     dlog!("[clips-tray] bubble shown at ({},{}) size {}", x, y, size);
     Ok(())
 }

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -29,7 +29,7 @@ use state::{
     DictationActive, DictationEnabled, LastTranscript, MeetingActive, PopoverShownAt,
     RecordingActive, TrayAnchor, TrayMeetings, VoiceWakePopover,
 };
-use util::{is_recording_active, set_capture_included};
+use util::{is_recording_active, set_capture_included, set_window_can_join_all_spaces};
 
 // Embedded fallback icon — a tiny 16x16 solid purple PNG so the binary always
 // has *something* to display even if `icons/tray.png` is missing on disk. The
@@ -184,6 +184,12 @@ pub fn run() {
             // server URL via `meetings_watcher_set_server_url` once the
             // popover boots.
             meetings_watcher::spawn_watcher(app.handle().clone());
+
+            // Ensure the popover appears above every app on every Mission
+            // Control space so it's reachable before the user starts recording.
+            if let Some(window) = app.get_webview_window("popover") {
+                set_window_can_join_all_spaces(&window);
+            }
 
             // Hide the popover on blur so it feels like a real menu-bar popover.
             // The 250ms guard is the important bit — during the tray-click

--- a/templates/clips/desktop/src-tauri/src/util.rs
+++ b/templates/clips/desktop/src-tauri/src/util.rs
@@ -190,6 +190,42 @@ pub fn show_without_activation(window: &WebviewWindow) {
     }
 }
 
+/// Set `NSWindowCollectionBehaviorCanJoinAllSpaces` so the window follows the
+/// user across every Mission Control space and appears on any monitor — not
+/// just the one where it was first shown.
+#[cfg(target_os = "macos")]
+pub fn set_window_can_join_all_spaces(window: &WebviewWindow) {
+    let win = window.clone();
+    if let Err(err) = win.clone().run_on_main_thread(move || {
+        let label = win.label().to_string();
+        let ns_window_ptr = match win.ns_window() {
+            Ok(p) => p,
+            Err(err) => {
+                eprintln!(
+                    "[clips-tray] set_window_can_join_all_spaces({label}): ns_window() failed: {err}"
+                );
+                return;
+            }
+        };
+        if ns_window_ptr.is_null() {
+            return;
+        }
+        unsafe {
+            let obj = ns_window_ptr as *mut objc2::runtime::AnyObject;
+            // NSWindowCollectionBehaviorCanJoinAllSpaces = 1 << 0 = 1
+            let _: () = objc2::msg_send![&*obj, setCollectionBehavior: 1usize];
+        }
+        dlog!("[clips-tray] set_window_can_join_all_spaces({label}): applied");
+    }) {
+        eprintln!(
+            "[clips-tray] set_window_can_join_all_spaces: run_on_main_thread failed: {err}"
+        );
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn set_window_can_join_all_spaces(_window: &WebviewWindow) {}
+
 #[cfg(not(target_os = "macos"))]
 pub fn show_without_activation(window: &WebviewWindow) {
     // On non-macOS we just fall back to the standard show. Focus stealing

--- a/templates/clips/desktop/src-tauri/src/util.rs
+++ b/templates/clips/desktop/src-tauri/src/util.rs
@@ -212,8 +212,11 @@ pub fn set_window_can_join_all_spaces(window: &WebviewWindow) {
         }
         unsafe {
             let obj = ns_window_ptr as *mut objc2::runtime::AnyObject;
-            // NSWindowCollectionBehaviorCanJoinAllSpaces = 1 << 0 = 1
-            let _: () = objc2::msg_send![&*obj, setCollectionBehavior: 1usize];
+            // Read the current behavior so we don't discard flags Tauri
+            // already set (e.g. NSWindowCollectionBehaviorManaged = 4).
+            // NSWindowCollectionBehaviorCanJoinAllSpaces = 1 << 0 = 1.
+            let current: usize = objc2::msg_send![&*obj, collectionBehavior];
+            let _: () = objc2::msg_send![&*obj, setCollectionBehavior: current | 1usize];
         }
         dlog!("[clips-tray] set_window_can_join_all_spaces({label}): applied");
     }) {

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -2312,9 +2312,6 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   border-radius: 50%;
   overflow: hidden;
   background: #000;
-  /* Drop shadow only — no brand ring. The bubble is the user's face;
-     a bright purple halo competes with what matters visually. */
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
   /* Position context for absolute children (close X, canvas). */
   position: relative;
   /* Cursor hint — the drag region is here. */
@@ -2407,7 +2404,6 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   z-index: 3;
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
 }
 
 .bubble-close:hover {
@@ -2433,7 +2429,6 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
   z-index: 3;
   /* Cursor over the pill should not be a grab cursor (we're not dragging
      the bubble when clicking its controls). */

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -2049,9 +2049,6 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow:
-    0 10px 30px rgba(0, 0, 0, 0.35),
-    0 2px 6px rgba(0, 0, 0, 0.3);
   color: white;
   cursor: grab;
 }
@@ -2176,7 +2173,6 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.45);
   user-select: none;
   -webkit-user-select: none;
   cursor: grab;


### PR DESCRIPTION
### Summary
This PR improves the Clips desktop app's camera bubble and overlay behavior by removing drop shadows, enabling the camera bubble and popover to follow the user across all Mission Control spaces and monitors, and ensuring the overlay is visible above other apps before recording starts.

### Problem
Three issues existed in the Clips desktop app:
1. The camera bubble and pill UI elements had drop shadows that were visually distracting.
2. The camera bubble only appeared on the screen/space where the app was initially started, and did not follow the user to other monitors or Mission Control spaces.
3. The app overlay (popover) was only shown on the desktop window and was not visible above other apps before recording began.

### Solution
- Removed `box-shadow` CSS rules from the camera bubble, pill, and close button elements.
- Introduced a new `set_window_can_join_all_spaces` utility that sets `NSWindowCollectionBehaviorCanJoinAllSpaces` on macOS windows via the Objective-C runtime, making them follow the user across all spaces and monitors.
- Applied this utility to both the camera bubble (on show) and the popover window (on app startup) so both are reachable regardless of the active space or monitor.

### Key Changes
- **`src/styles.css`**: Removed `box-shadow` from the camera bubble container, the bubble close button, and the pill control bar.
- **`src-tauri/src/util.rs`**: Added `set_window_can_join_all_spaces` utility function (macOS-only) that uses `objc2` to set `NSWindowCollectionBehaviorCanJoinAllSpaces` (bit flag `1`) on the underlying `NSWindow`; no-op stub provided for non-macOS targets.
- **`src-tauri/src/clips/mod.rs`**: Called `set_window_can_join_all_spaces` on the camera bubble window when it is shown.
- **`src-tauri/src/lib.rs`**: Called `set_window_can_join_all_spaces` on the popover window at app startup so the overlay appears above all apps on every space before recording starts.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/magic-opening-1pssrzso"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-magic-opening-1pssrzso_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 813`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>magic-opening-1pssrzso</branchName>-->