### PR TITLE
Make MCP app embeds reliable

### DIFF
--- a/.changeset/quiet-db-disconnects.md
+++ b/.changeset/quiet-db-disconnects.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Harden serverless database pool cleanup and chat thread conflict retries.

--- a/.changeset/steady-mcp-app-embeds.md
+++ b/.changeset/steady-mcp-app-embeds.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Make MCP App embeds launch real app routes reliably and keep web-host discovery compact.

--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -22,6 +22,8 @@ let _initPromise: Promise<void> | undefined;
  * remerges message history before retrying.
  */
 const _threadDataLocks = new Map<string, Promise<unknown>>();
+const DEFAULT_THREAD_DATA_UPDATE_ATTEMPTS = 12;
+const THREAD_DATA_CONFLICT_BACKOFF_MS = 25;
 
 export function withThreadDataLock<T>(
   threadId: string,
@@ -483,7 +485,8 @@ export async function updateThreadData(
 ): Promise<void> {
   await ensureTable();
   const client = getDbExec();
-  const maxAttempts = options.maxAttempts ?? 5;
+  const maxAttempts =
+    options.maxAttempts ?? DEFAULT_THREAD_DATA_UPDATE_ATTEMPTS;
   let lastConflict = false;
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -531,7 +534,14 @@ export async function updateThreadData(
     }
 
     lastConflict = true;
-    await new Promise((resolve) => setTimeout(resolve, 10 * (attempt + 1)));
+    if (attempt < maxAttempts - 1) {
+      await new Promise((resolve) =>
+        setTimeout(
+          resolve,
+          Math.min(250, THREAD_DATA_CONFLICT_BACKOFF_MS * (attempt + 1)),
+        ),
+      );
+    }
   }
 
   if (lastConflict) {

--- a/packages/core/src/db/client.spec.ts
+++ b/packages/core/src/db/client.spec.ts
@@ -107,6 +107,33 @@ describe("dbOpTimeoutMs", () => {
   });
 });
 
+describe("attachNeonPoolErrorLogger", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("attaches one error listener and logs pool errors without throwing", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const on = vi.fn();
+    const pool = { on };
+    const { attachNeonPoolErrorLogger } = await import("./client.js");
+
+    attachNeonPoolErrorLogger(pool, "db/neon-auth");
+    attachNeonPoolErrorLogger(pool, "db/neon-auth");
+
+    expect(on).toHaveBeenCalledTimes(1);
+    expect(on).toHaveBeenCalledWith("error", expect.any(Function));
+
+    const listener = on.mock.calls[0]![1] as (err: unknown) => void;
+    expect(() => listener(new Error("connection dropped"))).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      "[db/neon-auth] pool error (will reconnect on next query):",
+      "connection dropped",
+    );
+  });
+});
+
 describe("withDbTimeout", () => {
   afterEach(() => {
     vi.unstubAllEnvs();

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -11,6 +11,7 @@
 import path from "path";
 
 const recyclingPostgresPools = new WeakSet<object>();
+const loggedNeonPools = new WeakSet<object>();
 
 // ---------------------------------------------------------------------------
 // Types
@@ -497,6 +498,41 @@ export function neonPoolMax(): number {
   return isServerlessRuntime() ? 2 : 10;
 }
 
+export function attachNeonPoolErrorLogger(
+  pool: unknown,
+  label = "db/neon",
+): void {
+  if (!pool || typeof pool !== "object") return;
+  if (loggedNeonPools.has(pool)) return;
+  const withEvents = pool as {
+    on?: (event: "error", listener: (err: unknown) => void) => unknown;
+  };
+  if (typeof withEvents.on !== "function") return;
+
+  loggedNeonPools.add(pool);
+  withEvents.on("error", (err: unknown) => {
+    console.warn(
+      `[${label}] pool error (will reconnect on next query):`,
+      err instanceof Error ? err.message : err,
+    );
+  });
+}
+
+function disposePostgresPoolEventually(
+  pool: { end: () => Promise<unknown> },
+  label: string,
+): void {
+  if (!pool || typeof pool !== "object") return;
+  if (recyclingPostgresPools.has(pool)) return;
+  recyclingPostgresPools.add(pool);
+  void pool.end().catch((err: unknown) => {
+    console.warn(
+      `[db/postgres] ${label} cleanup failed:`,
+      err instanceof Error ? err.message : err,
+    );
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Singleton client — lazy-initialized on first execute() call
 // ---------------------------------------------------------------------------
@@ -553,18 +589,7 @@ async function createDbExecInternal(
     if (isNeonUrl(url)) {
       const { Pool } = await import("@neondatabase/serverless");
       const pool = new Pool({ connectionString: url, max: neonPoolMax() });
-      // Neon's serverless Pool extends EventEmitter and emits 'error'
-      // when its WebSocket connection drops (idle timeout, Lambda
-      // suspend, network blip). Without a listener, Node 24 surfaces
-      // these as fatal `Unhandled error` / `Connection terminated
-      // unexpectedly` uncaught exceptions, even though the next query
-      // would have transparently re-connected. Log and swallow.
-      pool.on("error", (err: unknown) => {
-        console.warn(
-          "[db/neon] pool error (will reconnect on next query):",
-          err instanceof Error ? err.message : err,
-        );
-      });
+      attachNeonPoolErrorLogger(pool);
       if (trackSingletonResources) _neonPool = pool;
       return {
         async execute(sql) {
@@ -640,7 +665,7 @@ async function createDbExecInternal(
               dbOpTimeoutMs(),
               () => {
                 timedOut = true;
-                return conn.end({ timeout: 1 });
+                disposePostgresPoolEventually(conn, "timed-out worker query");
               },
             );
             return {
@@ -648,7 +673,14 @@ async function createDbExecInternal(
               rowsAffected: result.count ?? 0,
             };
           } finally {
-            if (!timedOut) await conn.end();
+            if (!timedOut) {
+              await conn.end().catch((err: unknown) => {
+                console.warn(
+                  "[db/postgres] worker query cleanup failed:",
+                  err instanceof Error ? err.message : err,
+                );
+              });
+            }
           }
         },
       };
@@ -662,14 +694,12 @@ async function createDbExecInternal(
       type PostgresPool = ReturnType<typeof createPool>;
       let pool = createPool();
       if (trackSingletonResources) _pgPool = pool;
-      const recyclePool = async (timedOutPool: PostgresPool) => {
-        if (recyclingPostgresPools.has(timedOutPool)) return;
-        recyclingPostgresPools.add(timedOutPool);
+      const recyclePool = (timedOutPool: PostgresPool) => {
         if (pool === timedOutPool) {
           pool = createPool();
           if (trackSingletonResources) _pgPool = pool;
         }
-        await timedOutPool.end({ timeout: 1 });
+        disposePostgresPoolEventually(timedOutPool, "timed-out pooled query");
       };
 
       return {

--- a/packages/core/src/db/create-get-db.ts
+++ b/packages/core/src/db/create-get-db.ts
@@ -9,6 +9,7 @@ import {
   sqliteFilenameFromUrl,
   pgPoolOptions,
   neonPoolMax,
+  attachNeonPoolErrorLogger,
 } from "./client.js";
 
 // Lazy driver loaders — cached promises so dynamic import only runs once.
@@ -105,16 +106,7 @@ export function createGetDb<T extends Record<string, unknown>>(schema: T) {
       if (isNeonUrl(url)) {
         _dbReady = getNeonServerlessDrizzle().then(({ drizzle, Pool }) => {
           const pool = new Pool({ connectionString: url, max: neonPoolMax() });
-          // Neon Pool emits 'error' on WebSocket drops (idle, Lambda
-          // suspend, network). Without a listener Node 24 throws
-          // `Unhandled error` as a fatal uncaught exception. The next
-          // query reconnects transparently, so just log and swallow.
-          pool.on("error", (err: unknown) => {
-            console.warn(
-              "[db/neon] pool error (will reconnect on next query):",
-              err instanceof Error ? err.message : err,
-            );
-          });
+          attachNeonPoolErrorLogger(pool);
           _db = drizzle(pool, { schema });
         });
       } else {

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -97,6 +97,8 @@ export interface MCPCallerIdentity {
   orgDomain: string | undefined;
   /** Present only for standard remote MCP OAuth access tokens. */
   oauthScopes?: string[];
+  /** Present only for standard remote MCP OAuth access tokens. */
+  oauthClientId?: string;
 }
 
 /** Per-request context used to turn an action's relative deep link into the
@@ -151,6 +153,74 @@ function isActionAdvertisedInCompactMcpAppCatalog(
   if (COMPACT_MCP_APP_CATALOG_BUILTINS.has(name)) return true;
   if (name === "ask_app" && isDispatchConfig(config)) return true;
   return Boolean(entry.mcpApp?.resource);
+}
+
+const MCP_APP_OAUTH_CLIENT_RE = /\b(chatgpt|openai|claude|anthropic)\b/i;
+const NON_APP_OAUTH_CLIENT_RE =
+  /\b(code|desktop|cli|cursor|codex|goose|postman|mcpjam|inspector)\b/i;
+const MCP_APP_OAUTH_REDIRECT_HOST_RE =
+  /(^|\.)((chatgpt|openai)\.com|claude\.ai|anthropic\.com)$/i;
+
+async function isKnownMcpAppOAuthClient(
+  identity: MCPCallerIdentity | undefined,
+): Promise<boolean> {
+  const clientId = identity?.oauthClientId?.trim();
+  if (!clientId) return false;
+
+  function isKnownAppClientName(value: string | undefined | null): boolean {
+    if (!value) return false;
+    return (
+      MCP_APP_OAUTH_CLIENT_RE.test(value) &&
+      !NON_APP_OAUTH_CLIENT_RE.test(value)
+    );
+  }
+
+  function isKnownNonAppClientName(value: string | undefined | null): boolean {
+    return Boolean(value && NON_APP_OAUTH_CLIENT_RE.test(value));
+  }
+
+  function isLoopbackHost(hostname: string): boolean {
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname === "[::1]" ||
+      hostname.startsWith("127.")
+    );
+  }
+
+  function isRemoteRedirectUri(uri: string): boolean {
+    try {
+      const url = new URL(uri);
+      return url.protocol === "https:" && !isLoopbackHost(url.hostname);
+    } catch {
+      return false;
+    }
+  }
+
+  if (isKnownAppClientName(clientId)) return true;
+  if (isKnownNonAppClientName(clientId)) return false;
+
+  try {
+    const { getOAuthClient } = await import("./oauth-store.js");
+    const client = await getOAuthClient(clientId);
+    if (!client) return true;
+    if (isKnownAppClientName(client.clientName)) return true;
+    if (isKnownNonAppClientName(client.clientName)) return false;
+    return client.redirectUris.some((uri) => {
+      try {
+        const hostname = new URL(uri).hostname;
+        return (
+          MCP_APP_OAUTH_REDIRECT_HOST_RE.test(hostname) ||
+          isRemoteRedirectUri(uri)
+        );
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return true;
+  }
 }
 
 interface ResolvedMcpAppResource {
@@ -525,8 +595,9 @@ export async function createMCPServerForRequest(
     ),
   );
   const compactMcpAppCatalog =
-    Array.isArray(effectiveIdentity?.oauthScopes) &&
-    hasMcpOAuthScope(effectiveIdentity.oauthScopes, "mcp:apps");
+    (Array.isArray(effectiveIdentity?.oauthScopes) &&
+      hasMcpOAuthScope(effectiveIdentity.oauthScopes, "mcp:apps")) ||
+    (await isKnownMcpAppOAuthClient(effectiveIdentity));
   const advertisedActions = compactMcpAppCatalog
     ? Object.fromEntries(
         Object.entries(visibleActions).filter(([name, entry]) =>
@@ -686,6 +757,12 @@ export async function createMCPServerForRequest(
       const { name, arguments: args } = request.params;
 
       if (name === "ask-agent" && config.askAgent) {
+        if (compactMcpAppCatalog) {
+          return {
+            content: [{ type: "text", text: `Unknown tool: ${name}` }],
+            isError: true,
+          };
+        }
         if (!hasMcpOAuthScope(effectiveIdentity?.oauthScopes, "mcp:write")) {
           return {
             content: [
@@ -709,7 +786,10 @@ export async function createMCPServerForRequest(
         }
       }
 
-      const entry = actions[name];
+      const callableActions = compactMcpAppCatalog
+        ? advertisedActions
+        : actions;
+      const entry = callableActions[name];
       if (!entry) {
         return {
           content: [{ type: "text", text: `Unknown tool: ${name}` }],
@@ -966,6 +1046,7 @@ export async function verifyAuth(
           userEmail: oauthIdentity.userEmail,
           orgDomain: oauthIdentity.orgDomain,
           oauthScopes: oauthIdentity.scopes,
+          oauthClientId: oauthIdentity.clientId,
         },
         fullSurface: true,
       };

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -179,20 +179,13 @@ async function isKnownMcpAppOAuthClient(
     return Boolean(value && NON_APP_OAUTH_CLIENT_RE.test(value));
   }
 
-  function isLoopbackHost(hostname: string): boolean {
-    return (
-      hostname === "localhost" ||
-      hostname === "127.0.0.1" ||
-      hostname === "::1" ||
-      hostname === "[::1]" ||
-      hostname.startsWith("127.")
-    );
-  }
-
-  function isRemoteRedirectUri(uri: string): boolean {
+  function isKnownMcpAppRedirectUri(uri: string): boolean {
     try {
       const url = new URL(uri);
-      return url.protocol === "https:" && !isLoopbackHost(url.hostname);
+      return (
+        url.protocol === "https:" &&
+        MCP_APP_OAUTH_REDIRECT_HOST_RE.test(url.hostname)
+      );
     } catch {
       return false;
     }
@@ -204,22 +197,12 @@ async function isKnownMcpAppOAuthClient(
   try {
     const { getOAuthClient } = await import("./oauth-store.js");
     const client = await getOAuthClient(clientId);
-    if (!client) return true;
+    if (!client) return false;
     if (isKnownAppClientName(client.clientName)) return true;
     if (isKnownNonAppClientName(client.clientName)) return false;
-    return client.redirectUris.some((uri) => {
-      try {
-        const hostname = new URL(uri).hostname;
-        return (
-          MCP_APP_OAUTH_REDIRECT_HOST_RE.test(hostname) ||
-          isRemoteRedirectUri(uri)
-        );
-      } catch {
-        return false;
-      }
-    });
+    return client.redirectUris.some(isKnownMcpAppRedirectUri);
   } catch {
-    return true;
+    return false;
   }
 }
 

--- a/packages/core/src/mcp/build-server.verify-auth.spec.ts
+++ b/packages/core/src/mcp/build-server.verify-auth.spec.ts
@@ -110,6 +110,7 @@ describe("verifyAuth — connect-token revoke check", () => {
       userEmail: "oauth@example.com",
       orgDomain: "builder.io",
       oauthScopes: ["mcp:read", "mcp:apps"],
+      oauthClientId: "client-123",
     });
     expect(isJtiRevokedMock).not.toHaveBeenCalled();
   });

--- a/packages/core/src/mcp/builtin-tools.ts
+++ b/packages/core/src/mcp/builtin-tools.ts
@@ -255,8 +255,7 @@ function openAppTool(config: MCPConfig): ActionEntry {
         "focused route/component. No side " +
         "effects — returns a URL the user can click to land in the running UI. " +
         "Set embed:true when a UI-capable MCP host should render the live app " +
-        "or focused route/component inline. After calling, surface the returned " +
-        '"Open in … →" link to the user.',
+        "or focused route/component inline.",
       {
         app: { type: "string", description: "App id, e.g. 'mail'" },
         view: {
@@ -610,8 +609,7 @@ function createWorkspaceAppTool(): ActionEntry {
     tool: tool(
       "Scaffold a new app into the current workspace from an allow-listed " +
         "template, then return a deep link to open it. Idempotent: if an app " +
-        "with that name already exists it is reused. After calling, surface " +
-        'the returned "Open … →" link to the user.',
+        "with that name already exists it is reused.",
       {
         name: {
           type: "string",

--- a/packages/core/src/mcp/connect-route.ts
+++ b/packages/core/src/mcp/connect-route.ts
@@ -95,6 +95,21 @@ function deriveOrigin(event: H3Event): string {
   return host ? `${proto}://${host}` : "";
 }
 
+function isLoopbackOrigin(origin: string): boolean {
+  try {
+    const hostname = new URL(origin).hostname;
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname === "[::1]" ||
+      hostname.startsWith("127.")
+    );
+  } catch {
+    return false;
+  }
+}
+
 function normalizeBasePath(raw: string | undefined): string {
   const trimmed = (raw ?? "").trim();
   if (!trimmed || trimmed === "/") return "";
@@ -136,6 +151,7 @@ function canUseDevOpenConnect(event: H3Event): boolean {
   // by spoofing `Host: localhost`.
   return (
     isLoopbackRequest(event) &&
+    isLoopbackOrigin(deriveOrigin(event)) &&
     !process.env.A2A_SECRET?.trim() &&
     !process.env.ACCESS_TOKEN?.trim() &&
     !process.env.ACCESS_TOKENS?.trim()

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -23,6 +23,15 @@ vi.mock("../org/context.js", () => ({
   resolveOrgByDomain: vi.fn(async () => null),
 }));
 
+const mockOAuthClients = vi.hoisted(() => new Map<string, any>());
+
+vi.mock("./oauth-store.js", () => ({
+  MCP_OAUTH_ACCESS_TOKEN_TTL: "1h",
+  getOAuthClient: vi.fn(async (clientId: string) => {
+    return mockOAuthClients.get(clientId) ?? null;
+  }),
+}));
+
 const { handleMcpRequest } = await import("./server.js");
 
 // --- minimal h3 event doubles -------------------------------------------------
@@ -178,6 +187,10 @@ const config = {
   },
 };
 
+const veryLongInternalDescription = "INTERNAL_TOOL_BLOAT_SENTINEL ".repeat(
+  1_000,
+);
+
 const compactSurfaceConfig = {
   ...config,
   askAgent: async () => "agent answer",
@@ -185,7 +198,16 @@ const compactSurfaceConfig = {
     ...config.actions,
     "internal-heavy": {
       tool: {
-        description: "Internal verbose tool that should not be advertised",
+        description: veryLongInternalDescription,
+        parameters: {
+          type: "object" as const,
+          properties: {
+            hugePayload: {
+              type: "string",
+              description: veryLongInternalDescription,
+            },
+          },
+        },
       },
       readOnly: true,
       run: async () => ({ ok: true }),
@@ -252,13 +274,18 @@ async function callWeb(
   return JSON.parse(text);
 }
 
-async function mcpAppsAuthHeaders() {
+async function mcpAppsAuthHeaders(
+  options: {
+    clientId?: string;
+    scope?: string;
+  } = {},
+) {
   process.env.BETTER_AUTH_SECRET = "oauth-secret";
   const { signMcpOAuthAccessToken } = await import("./oauth-token.js");
   const token = await signMcpOAuthAccessToken({
     ownerEmail: "oauth@example.com",
-    clientId: "client-123",
-    scope: "mcp:read mcp:write mcp:apps",
+    clientId: options.clientId ?? "client-123",
+    scope: options.scope ?? "mcp:read mcp:write mcp:apps",
     resource: "https://mail.agent-native.com/_agent-native/mcp",
     issuer: "https://mail.agent-native.com",
   });
@@ -274,10 +301,12 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     delete process.env.ACCESS_TOKENS;
     delete process.env.A2A_SECRET;
     delete process.env.BETTER_AUTH_SECRET;
+    mockOAuthClients.clear();
   });
   afterEach(() => {
     delete process.env.ACCESS_TOKEN;
     delete process.env.BETTER_AUTH_SECRET;
+    mockOAuthClients.clear();
     vi.clearAllMocks();
   });
 
@@ -355,6 +384,190 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(names).not.toContain("internal-heavy");
     expect(names).not.toContain("public-search");
     expect(names).not.toContain("ask-agent");
+    expect(JSON.stringify(out)).not.toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
+    expect(JSON.stringify(out).length).toBeLessThan(12_000);
+  });
+
+  it("blocks compact MCP Apps callers from invoking hidden tools by name", async () => {
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 26,
+        method: "tools/call",
+        params: {
+          name: "internal-heavy",
+          arguments: {},
+        },
+      },
+      {
+        headers: await mcpAppsAuthHeaders(),
+        config: compactSurfaceConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.result.isError).toBe(true);
+    expect(out.result.content[0].text).toContain("Unknown tool");
+  });
+
+  it("uses the compact catalog for known ChatGPT/Claude OAuth registrations even when an older token lacks mcp:apps", async () => {
+    mockOAuthClients.set("agent-native-oauth-client-generated-chatgpt", {
+      clientId: "agent-native-oauth-client-generated-chatgpt",
+      clientName: "ChatGPT",
+      redirectUris: ["https://chatgpt.com/aip/mcp/oauth/callback"],
+    });
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 22,
+        method: "tools/list",
+        params: {},
+      },
+      {
+        headers: await mcpAppsAuthHeaders({
+          clientId: "agent-native-oauth-client-generated-chatgpt",
+          scope: "mcp:read mcp:write",
+        }),
+        config: compactSurfaceConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    const names = out.result.tools.map((t: any) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["echo-thing", "review-draft"]),
+    );
+    expect(names).not.toContain("internal-heavy");
+    expect(names).not.toContain("public-search");
+    expect(names).not.toContain("ask-agent");
+    expect(JSON.stringify(out)).not.toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
+    expect(JSON.stringify(out).length).toBeLessThan(12_000);
+  });
+
+  it("advertises MCP App resources for known ChatGPT/Claude OAuth registrations even when an older token lacks mcp:apps", async () => {
+    mockOAuthClients.set("agent-native-oauth-client-generated-claude", {
+      clientId: "agent-native-oauth-client-generated-claude",
+      clientName: "Anthropic Claude",
+      redirectUris: ["https://claude.ai/api/mcp/auth_callback"],
+    });
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 23,
+        method: "resources/list",
+        params: {},
+      },
+      {
+        headers: await mcpAppsAuthHeaders({
+          clientId: "agent-native-oauth-client-generated-claude",
+          scope: "mcp:read mcp:write",
+        }),
+        config: compactSurfaceConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.result.resources.map((r: any) => r.uri)).toEqual(
+      expect.arrayContaining([
+        "ui://mail/echo-thing",
+        "ui://mail/review-draft",
+      ]),
+    );
+  });
+
+  it("defaults remote web OAuth clients to the compact MCP App catalog", async () => {
+    mockOAuthClients.set("agent-native-oauth-client-generated-web-host", {
+      clientId: "agent-native-oauth-client-generated-web-host",
+      clientName: "Acme Web MCP Host",
+      redirectUris: ["https://mcp.example.com/oauth/callback"],
+    });
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 25,
+        method: "tools/list",
+        params: {},
+      },
+      {
+        headers: await mcpAppsAuthHeaders({
+          clientId: "agent-native-oauth-client-generated-web-host",
+          scope: "mcp:read mcp:write",
+        }),
+        config: compactSurfaceConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    const names = out.result.tools.map((t: any) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["echo-thing", "review-draft"]),
+    );
+    expect(names).not.toContain("internal-heavy");
+    expect(names).not.toContain("public-search");
+    expect(names).not.toContain("ask-agent");
+    expect(JSON.stringify(out)).not.toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
+    expect(JSON.stringify(out).length).toBeLessThan(12_000);
+  });
+
+  it("defaults unknown standard OAuth clients without mcp:apps to the compact catalog", async () => {
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 27,
+        method: "tools/list",
+        params: {},
+      },
+      {
+        headers: await mcpAppsAuthHeaders({
+          clientId: "agent-native-oauth-client-generated-random",
+          scope: "mcp:read mcp:write",
+        }),
+        config: compactSurfaceConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    const names = out.result.tools.map((t: any) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["echo-thing", "review-draft"]),
+    );
+    expect(names).not.toContain("internal-heavy");
+    expect(names).not.toContain("public-search");
+    expect(JSON.stringify(out)).not.toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
+    expect(JSON.stringify(out).length).toBeLessThan(12_000);
+  });
+
+  it("keeps the full catalog for code-oriented OAuth clients without mcp:apps", async () => {
+    mockOAuthClients.set("agent-native-oauth-client-generated-claude-code", {
+      clientId: "agent-native-oauth-client-generated-claude-code",
+      clientName: "Claude Code",
+      redirectUris: ["http://127.0.0.1:49152/oauth/callback"],
+    });
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 24,
+        method: "tools/list",
+        params: {},
+      },
+      {
+        headers: await mcpAppsAuthHeaders({
+          clientId: "agent-native-oauth-client-generated-claude-code",
+          scope: "mcp:read mcp:write",
+        }),
+        config: compactSurfaceConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    const names = out.result.tools.map((t: any) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["echo-thing", "internal-heavy", "ask-agent"]),
+    );
   });
 
   it("keeps the full tool catalog for non-OAuth callers without mcp:apps", async () => {

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -362,7 +362,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     });
   });
 
-  it("uses a compact tool catalog for OAuth MCP Apps callers", async () => {
+  it("uses a compact tool catalog when the OAuth token has mcp:apps", async () => {
     const out = await callWeb(
       {
         jsonrpc: "2.0",
@@ -410,10 +410,10 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.result.content[0].text).toContain("Unknown tool");
   });
 
-  it("uses the compact catalog for known ChatGPT/Claude OAuth registrations even when an older token lacks mcp:apps", async () => {
-    mockOAuthClients.set("agent-native-oauth-client-generated-chatgpt", {
-      clientId: "agent-native-oauth-client-generated-chatgpt",
-      clientName: "ChatGPT",
+  it("uses the compact catalog for known ChatGPT redirect registrations even when an older token lacks mcp:apps", async () => {
+    mockOAuthClients.set("agent-native-oauth-client-generated-hosted-app", {
+      clientId: "agent-native-oauth-client-generated-hosted-app",
+      clientName: "MCP Apps Host",
       redirectUris: ["https://chatgpt.com/aip/mcp/oauth/callback"],
     });
 
@@ -426,7 +426,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       },
       {
         headers: await mcpAppsAuthHeaders({
-          clientId: "agent-native-oauth-client-generated-chatgpt",
+          clientId: "agent-native-oauth-client-generated-hosted-app",
           scope: "mcp:read mcp:write",
         }),
         config: compactSurfaceConfig,
@@ -477,7 +477,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     );
   });
 
-  it("defaults remote web OAuth clients to the compact MCP App catalog", async () => {
+  it("keeps the full catalog for generic remote web OAuth clients without mcp:apps", async () => {
     mockOAuthClients.set("agent-native-oauth-client-generated-web-host", {
       clientId: "agent-native-oauth-client-generated-web-host",
       clientName: "Acme Web MCP Host",
@@ -503,16 +503,12 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     const names = out.result.tools.map((t: any) => t.name);
     expect(names).toEqual(
-      expect.arrayContaining(["echo-thing", "review-draft"]),
+      expect.arrayContaining(["echo-thing", "internal-heavy", "ask-agent"]),
     );
-    expect(names).not.toContain("internal-heavy");
-    expect(names).not.toContain("public-search");
-    expect(names).not.toContain("ask-agent");
-    expect(JSON.stringify(out)).not.toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
-    expect(JSON.stringify(out).length).toBeLessThan(12_000);
+    expect(JSON.stringify(out)).toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
   });
 
-  it("defaults unknown standard OAuth clients without mcp:apps to the compact catalog", async () => {
+  it("keeps the full catalog for unknown standard OAuth clients without mcp:apps", async () => {
     const out = await callWeb(
       {
         jsonrpc: "2.0",
@@ -532,12 +528,9 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     const names = out.result.tools.map((t: any) => t.name);
     expect(names).toEqual(
-      expect.arrayContaining(["echo-thing", "review-draft"]),
+      expect.arrayContaining(["echo-thing", "internal-heavy", "ask-agent"]),
     );
-    expect(names).not.toContain("internal-heavy");
-    expect(names).not.toContain("public-search");
-    expect(JSON.stringify(out)).not.toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
-    expect(JSON.stringify(out).length).toBeLessThan(12_000);
+    expect(JSON.stringify(out)).toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
   });
 
   it("keeps the full catalog for code-oriented OAuth clients without mcp:apps", async () => {

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -80,6 +80,22 @@ function deriveRequestMeta(event: H3Event): MCPRequestMeta {
   return { origin, target };
 }
 
+function isLoopbackOrigin(origin: string | undefined): boolean {
+  if (!origin) return false;
+  try {
+    const hostname = new URL(origin).hostname;
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname === "[::1]" ||
+      hostname.startsWith("127.")
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Reconstruct a Web Standard `Request` for the web-standard MCP transport.
  *
@@ -198,7 +214,8 @@ export async function handleMcpRequest(
   // `fullSurface` would otherwise escalate to the full mutating surface.
   const requestMeta = deriveRequestMeta(event);
   const authResult = await verifyAuth(authHeader, ownerEmailHeader, {
-    allowDevOpen: isLoopbackRequest(event),
+    allowDevOpen:
+      isLoopbackRequest(event) && isLoopbackOrigin(requestMeta.origin),
     resourceUrl: getMcpOAuthResource(event),
   });
   if (!authResult.authed) {

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -31,6 +31,7 @@ import {
   getDatabaseAuthToken,
   pgPoolOptions,
   neonPoolMax,
+  attachNeonPoolErrorLogger,
 } from "../db/client.js";
 import {
   pgTable,
@@ -920,6 +921,7 @@ async function buildDatabaseConfig(
         connectionString: url,
         max: neonPoolMax(),
       });
+      attachNeonPoolErrorLogger(_neonAuthPool, "db/neon-auth");
       const { drizzle } = await import("drizzle-orm/neon-serverless");
       const db = drizzle(_neonAuthPool, { schema: pgAuthSchema });
       const { drizzleAdapter } = await import("better-auth/adapters/drizzle");

--- a/packages/core/src/server/embed-session.spec.ts
+++ b/packages/core/src/server/embed-session.spec.ts
@@ -192,6 +192,46 @@ describe("requestMatchesEmbedTarget", () => {
     ).toBe(true);
   });
 
+  it("allows known dashboard alias redirects used by app embeds", () => {
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent(
+          "/adhoc/agent-native-templates-first-party?embedded=1&__an_embed_token=tok",
+        ),
+        "/dashboards",
+      ),
+    ).toBe(true);
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent(
+          "/adhoc/agent-native-templates-first-party?embedded=1&__an_embed_token=tok",
+        ),
+        "/traffic-dashboard",
+      ),
+    ).toBe(true);
+  });
+
+  it("allows app runtime requests from the embedded target referrer", () => {
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/_agent-native/application-state/compose", {
+          host: "mail.agent-native.com",
+          referer: "https://mail.agent-native.com/inbox?embedded=1",
+        }),
+        "/_agent-native/open?app=mail&view=inbox&composeDraftId=d1",
+      ),
+    ).toBe(true);
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/api/emails?view=inbox", {
+          host: "mail.agent-native.com",
+          referer: "https://evil.example/inbox?embedded=1",
+        }),
+        "/_agent-native/open?app=mail&view=inbox&composeDraftId=d1",
+      ),
+    ).toBe(false);
+  });
+
   it("does not build thread record paths from unsafe view paths", () => {
     expect(
       requestMatchesEmbedTarget(

--- a/packages/core/src/server/embed-session.ts
+++ b/packages/core/src/server/embed-session.ts
@@ -36,6 +36,12 @@ const OPEN_ROUTE_VIEW_PATHS: Record<string, string> = {
   sources: "/sources",
   settings: "/settings",
 };
+const EMBED_ROUTE_ALIASES: Record<string, string[]> = {
+  "/dashboard": ["/adhoc/agent-native-templates-first-party"],
+  "/dashboards": ["/adhoc/agent-native-templates-first-party"],
+  "/traffic": ["/adhoc/agent-native-templates-first-party"],
+  "/traffic-dashboard": ["/adhoc/agent-native-templates-first-party"],
+};
 
 let _initPromise: Promise<void> | undefined;
 let _devSigningKey: string | undefined;
@@ -304,7 +310,12 @@ function openRouteTargetPathnames(targetPath: string): Set<string> {
 function allowedEmbedTargetPathnames(targetPath: string): Set<string> {
   const allowed = new Set<string>();
   const direct = pathnameFromPath(targetPath);
-  if (direct) allowed.add(direct);
+  if (direct) {
+    allowed.add(direct);
+    for (const aliasTarget of EMBED_ROUTE_ALIASES[direct] ?? []) {
+      allowed.add(aliasTarget);
+    }
+  }
   for (const openTarget of openRouteTargetPathnames(targetPath)) {
     allowed.add(openTarget);
   }
@@ -351,6 +362,44 @@ function headerTargetPathname(event: H3Event): string | null {
   }
 }
 
+function requestHost(event: H3Event): string | null {
+  const direct =
+    (event as any).request?.headers?.get?.("host") ??
+    (event as any).headers?.get?.("host") ??
+    (event as any).node?.req?.headers?.host;
+  if (typeof direct === "string" && direct.trim()) return direct.trim();
+  try {
+    return getHeader(event, "host") ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function referrerTargetPathname(event: H3Event): string | null {
+  let raw: string | null =
+    (event as any).request?.headers?.get?.("referer") ??
+    (event as any).request?.headers?.get?.("referrer") ??
+    (event as any).headers?.get?.("referer") ??
+    (event as any).headers?.get?.("referrer") ??
+    (event as any).node?.req?.headers?.referer ??
+    (event as any).node?.req?.headers?.referrer ??
+    null;
+  try {
+    raw = raw ?? getHeader(event, "referer") ?? getHeader(event, "referrer");
+  } catch {
+    raw = raw ?? null;
+  }
+  if (!raw) return null;
+  try {
+    const referrer = new URL(raw);
+    const host = requestHost(event);
+    if (host && referrer.host !== host) return null;
+    return pathnameFromPath(`${referrer.pathname}${referrer.search}`);
+  } catch {
+    return pathnameFromPath(raw);
+  }
+}
+
 export function requestMatchesEmbedTarget(
   event: H3Event,
   targetPath: string,
@@ -362,7 +411,10 @@ export function requestMatchesEmbedTarget(
   if (current && allowed.has(current)) return true;
 
   const headerTarget = headerTargetPathname(event);
-  return !!headerTarget && allowed.has(headerTarget);
+  if (headerTarget && allowed.has(headerTarget)) return true;
+
+  const referrerTarget = referrerTargetPathname(event);
+  return !!referrerTarget && allowed.has(referrerTarget);
 }
 
 export function normalizeEmbedTargetPath(

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -412,6 +412,8 @@ export interface NitroOptions {
 export interface ClientConfigOptions {
   /** Port for dev server. Default: 8080 */
   port?: number;
+  /** Additional hostnames allowed to access the dev server. */
+  allowedHosts?: NonNullable<NonNullable<UserConfig["server"]>["allowedHosts"]>;
   /** Vite log level. Workspace child apps default to "warn" so only the gateway URL is advertised. */
   logLevel?: UserConfig["logLevel"];
   /** Additional Vite plugins */
@@ -958,6 +960,11 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
     server: {
       host: "::",
       port: options.port ?? 8080,
+      allowedHosts: options.allowedHosts ?? [
+        ".ngrok-free.dev",
+        ".ngrok-free.app",
+        ".ngrok.io",
+      ],
       fs: {
         allow: [
           ".",

--- a/packages/docs/server/routes/api/desktop-latest.json.get.ts
+++ b/packages/docs/server/routes/api/desktop-latest.json.get.ts
@@ -1,4 +1,4 @@
-import { createError, defineEventHandler, setResponseHeaders } from "h3";
+import { defineEventHandler, setResponseHeaders, setResponseStatus } from "h3";
 import {
   type DesktopDownloadManifest,
   getDesktopDownloadManifest,
@@ -11,10 +11,12 @@ export default defineEventHandler(async (event) => {
     manifest = await getDesktopDownloadManifest();
   } catch (error) {
     const e = getDesktopReleaseError(error);
-    throw createError({
-      statusCode: e.statusCode,
-      statusMessage: e.statusMessage,
+    setResponseStatus(event, e.statusCode, e.statusMessage);
+    setResponseHeaders(event, {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "public, max-age=30",
     });
+    return { error: e.statusMessage };
   }
 
   setResponseHeaders(event, {

--- a/templates/analytics/app/routes/dashboard.tsx
+++ b/templates/analytics/app/routes/dashboard.tsx
@@ -1,0 +1,20 @@
+import { redirect, type LoaderFunctionArgs } from "react-router";
+
+const DEFAULT_DASHBOARD_PATH = "/adhoc/agent-native-templates-first-party";
+
+function target(request: Request): string {
+  const url = new URL(request.url);
+  return `${DEFAULT_DASHBOARD_PATH}${url.search}${url.hash}`;
+}
+
+export function loader({ request }: LoaderFunctionArgs) {
+  throw redirect(target(request));
+}
+
+export function clientLoader({ request }: LoaderFunctionArgs) {
+  throw redirect(target(request));
+}
+
+export default function DashboardAliasRoute() {
+  return null;
+}

--- a/templates/analytics/app/routes/dashboards.tsx
+++ b/templates/analytics/app/routes/dashboards.tsx
@@ -1,0 +1,1 @@
+export { clientLoader, default, loader } from "./dashboard";

--- a/templates/analytics/app/routes/traffic-dashboard.tsx
+++ b/templates/analytics/app/routes/traffic-dashboard.tsx
@@ -1,0 +1,1 @@
+export { clientLoader, default, loader } from "./traffic";

--- a/templates/analytics/app/routes/traffic.tsx
+++ b/templates/analytics/app/routes/traffic.tsx
@@ -1,0 +1,20 @@
+import { redirect, type LoaderFunctionArgs } from "react-router";
+
+const TRAFFIC_DASHBOARD_PATH = "/adhoc/agent-native-templates-first-party";
+
+function target(request: Request): string {
+  const url = new URL(request.url);
+  return `${TRAFFIC_DASHBOARD_PATH}${url.search}${url.hash}`;
+}
+
+export function loader({ request }: LoaderFunctionArgs) {
+  throw redirect(target(request));
+}
+
+export function clientLoader({ request }: LoaderFunctionArgs) {
+  throw redirect(target(request));
+}
+
+export default function TrafficDashboardAliasRoute() {
+  return null;
+}

--- a/templates/analytics/server/handlers/sql-dashboards.ts
+++ b/templates/analytics/server/handlers/sql-dashboards.ts
@@ -20,6 +20,7 @@ import { dryRunQuery } from "../lib/bigquery";
 import { interpolate } from "../../app/pages/adhoc/sql-dashboard/interpolate";
 import { validateFirstPartyAnalyticsSql } from "../lib/first-party-analytics";
 import { parsePanelDescriptor as parsePrometheusPanelDescriptor } from "../lib/prometheus";
+import { loadDashboardSeed } from "../lib/dashboard-seeds";
 
 async function ctxFromEvent(event: any) {
   const ctx = await getOrgContext(event);
@@ -92,6 +93,24 @@ function parseArchivedFilter(raw: unknown): DashboardArchiveFilter {
   return "active";
 }
 
+function isEmptyDashboardConfig(config: Record<string, unknown>): boolean {
+  return !Array.isArray(config.panels) || config.panels.length === 0;
+}
+
+function seededSqlDashboardResponse(
+  id: string,
+  seed: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    id,
+    ...seed,
+    ownerEmail: null,
+    orgId: null,
+    visibility: "org",
+    archivedAt: null,
+  };
+}
+
 export const listSqlDashboards = defineEventHandler(async (event) => {
   try {
     const ctx = await ctxFromEvent(event);
@@ -122,12 +141,19 @@ export const getSqlDashboard = defineEventHandler(async (event) => {
     const ctx = await ctxFromEvent(event);
     const dash = await getDashboard(id, ctx);
     if (!dash || dash.kind !== "sql") {
+      const seed = loadDashboardSeed(id);
+      if (seed) return seededSqlDashboardResponse(id, seed);
       setResponseStatus(event, 404);
       return { error: "Dashboard not found" };
     }
+    const config = dash.config as Record<string, unknown>;
+    if (isEmptyDashboardConfig(config)) {
+      const seed = loadDashboardSeed(id);
+      if (seed) return seededSqlDashboardResponse(id, seed);
+    }
     return {
       id,
-      ...(dash.config as Record<string, unknown>),
+      ...config,
       ownerEmail: dash.ownerEmail,
       orgId: dash.orgId,
       visibility: dash.visibility,

--- a/templates/calendar/actions/get-event.ts
+++ b/templates/calendar/actions/get-event.ts
@@ -85,6 +85,7 @@ export default defineAction({
             email: a.email,
             displayName: a.displayName || undefined,
             photoUrl: a.photoUrl || undefined,
+            comment: a.comment || undefined,
             responseStatus: a.responseStatus || undefined,
             organizer: a.organizer || undefined,
             self: a.self || undefined,

--- a/templates/calendar/actions/manage-event-draft.ts
+++ b/templates/calendar/actions/manage-event-draft.ts
@@ -1,4 +1,4 @@
-import { defineAction } from "@agent-native/core";
+import { defineAction, embedApp } from "@agent-native/core";
 import {
   readAppState,
   writeAppState,
@@ -180,6 +180,17 @@ export default defineAction({
       .optional()
       .describe("Account email to create the event on"),
   }),
+  mcpApp: {
+    resource: embedApp({
+      title: "Review calendar invite",
+      description:
+        "Open the draft in the real Calendar event editor so the user can review attendees, time, location, conferencing, and reminders.",
+      iframeTitle: "Agent-Native Calendar",
+      openLabel: "Open in Calendar",
+      frameDomains: ["https:", "http://localhost:*", "http://127.0.0.1:*"],
+      height: 900,
+    }),
+  },
   run: async (args) => {
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("no authenticated user");

--- a/templates/calendar/app/components/calendar/CreateEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/CreateEventDialog.tsx
@@ -193,7 +193,11 @@ export function CreateEventPopover({
   const today = defaultDate || new Date();
   const defaultDateStr = format(today, "yyyy-MM-dd");
   const { data: settings } = useSettings();
-  const defaultDurationMinutes = settings?.defaultEventDuration ?? 60;
+  const rawDefaultDuration = settings?.defaultEventDuration ?? 30;
+  const defaultDurationMinutes = Number.isFinite(rawDefaultDuration)
+    ? Math.max(5, rawDefaultDuration)
+    : 30;
+  const defaultTimezone = settings?.timezone || getLocalTimezone();
   const fallbackStart = "09:00";
   const fallbackEnd = addMinutesToTimeString(
     fallbackStart,
@@ -211,7 +215,7 @@ export function CreateEventPopover({
   const [eventType, setEventType] = useState<EventType>("default");
   const [availability, setAvailability] = useState<Availability>("opaque");
   const [visibility, setVisibility] = useState<Visibility>("default");
-  const [timezone, setTimezone] = useState(getLocalTimezone());
+  const [timezone, setTimezone] = useState(defaultTimezone);
   const [colorId, setColorId] = useState<string | undefined>();
   const [reminderMode, setReminderMode] = useState<ReminderMode>("default");
   const [reminders, setReminders] = useState<ReminderDraft[]>(() => [
@@ -250,7 +254,7 @@ export function CreateEventPopover({
 
     if (draft) {
       const draftTimezone =
-        draft.startTimeZone || draft.endTimeZone || getLocalTimezone();
+        draft.startTimeZone || draft.endTimeZone || defaultTimezone;
       const startParts = draft.start
         ? dateTimePartsInTimezone(draft.start, draftTimezone)
         : null;
@@ -309,7 +313,7 @@ export function CreateEventPopover({
     setEventType("default");
     setAvailability("opaque");
     setVisibility("default");
-    setTimezone(getLocalTimezone());
+    setTimezone(defaultTimezone);
     setColorId(undefined);
     setReminderMode("default");
     setReminders([createReminderDraft()]);
@@ -325,6 +329,7 @@ export function CreateEventPopover({
     defaultEnd,
     fallbackStart,
     fallbackEnd,
+    defaultTimezone,
   ]);
 
   useEffect(() => {

--- a/templates/calendar/app/components/calendar/CreateEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/CreateEventDialog.tsx
@@ -246,15 +246,15 @@ export function CreateEventPopover({
     }
 
     const nextDate = format(defaultDate || new Date(), "yyyy-MM-dd");
+    const draftTimezone =
+      draft?.startTimeZone || draft?.endTimeZone || defaultTimezone;
     const initKey = draft?.id
-      ? `draft:${draft.id}`
-      : `new:${nextDate}:${defaultStart || fallbackStart}:${defaultEnd || fallbackEnd}`;
+      ? `draft:${draft.id}:${draftTimezone}`
+      : `new:${nextDate}:${defaultStart || fallbackStart}:${defaultEnd || fallbackEnd}:${defaultTimezone}`;
     if (initializedKeyRef.current === initKey) return;
     initializedKeyRef.current = initKey;
 
     if (draft) {
-      const draftTimezone =
-        draft.startTimeZone || draft.endTimeZone || defaultTimezone;
       const startParts = draft.start
         ? dateTimePartsInTimezone(draft.start, draftTimezone)
         : null;

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -14,6 +14,7 @@ import {
 } from "date-fns";
 import { cn } from "@/lib/utils";
 import { shouldSuppressAfterPopoverClose } from "@/lib/popover-click-guard";
+import { RsvpStatusIcon } from "@/lib/rsvp-status";
 import { getEventDisplayColor, allOtherDeclined } from "@/lib/event-colors";
 import { IconAlertTriangleFilled } from "@tabler/icons-react";
 import { EventDetailPopover } from "./EventDetailPopover";
@@ -280,6 +281,10 @@ export function DayView({
                         className="shrink-0 text-current opacity-70"
                       />
                     )}
+                    <RsvpStatusIcon
+                      status={event.responseStatus}
+                      className="shrink-0"
+                    />
                     <span className="truncate">{event.title}</span>
                   </button>
                 </EventDetailPopover>
@@ -489,6 +494,10 @@ export function DayView({
                           className="shrink-0 text-current opacity-70 relative top-[1px]"
                         />
                       )}
+                      <RsvpStatusIcon
+                        status={event.responseStatus}
+                        className="relative top-[1px] shrink-0"
+                      />
                       <span
                         className={cn(
                           "truncate leading-tight",
@@ -535,6 +544,10 @@ export function DayView({
                             className="shrink-0 text-current opacity-70"
                           />
                         )}
+                        <RsvpStatusIcon
+                          status={event.responseStatus}
+                          className="shrink-0"
+                        />
                         <span className="truncate">{event.title}</span>
                       </div>
                       {isStart && (

--- a/templates/calendar/app/components/calendar/EventAttendeesSection.tsx
+++ b/templates/calendar/app/components/calendar/EventAttendeesSection.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import {
-  IconCheck,
-  IconCircleX,
-  IconHelpCircle,
-  IconUser,
-} from "@tabler/icons-react";
+import { IconMessageCircle, IconUser } from "@tabler/icons-react";
 import type { CalendarEvent } from "@shared/api";
 import { AttendeeApolloPopover } from "@/components/calendar/ApolloPanel";
 import { Button } from "@/components/ui/button";
@@ -16,30 +11,21 @@ import {
 import { useAttendeePhotos } from "@/hooks/use-attendee-photos";
 import { useRsvpEvent } from "@/hooks/use-events";
 import { cn } from "@/lib/utils";
+import {
+  getRsvpStatusLabel,
+  RsvpStatusIcon,
+  type RsvpStatus,
+} from "@/lib/rsvp-status";
 
 type RecurringScope = "single" | "all" | "thisAndFollowing";
 
 type Attendee = NonNullable<CalendarEvent["attendees"]>[number];
-type RsvpStatus = "accepted" | "declined" | "tentative" | "needsAction";
 
 const ATTENDEE_TRUNCATE_THRESHOLD = 5;
 const ATTENDEE_INITIAL_SHOW = 3;
 
 function getAvatarUrl(email: string): string {
   return `https://unavatar.io/${encodeURIComponent(email.trim().toLowerCase())}?fallback=false`;
-}
-
-function ResponseStatusIcon({ status }: { status?: string }) {
-  switch (status) {
-    case "accepted":
-      return <IconCheck className="h-3 w-3 text-green-500" />;
-    case "declined":
-      return <IconCircleX className="h-3 w-3 text-red-400" />;
-    case "tentative":
-      return <IconHelpCircle className="h-3 w-3 text-yellow-500" />;
-    default:
-      return <IconHelpCircle className="h-3 w-3 text-muted-foreground/40" />;
-  }
 }
 
 function AttendeeAvatar({
@@ -247,6 +233,10 @@ function AttendeeRow({
   onStatusChange?: (status: Exclude<RsvpStatus, "needsAction">) => void;
   isRecurring?: boolean;
 }) {
+  const displayStatus = inlineRsvp ? currentStatus : attendee.responseStatus;
+  const statusLabel = getRsvpStatusLabel(displayStatus) ?? "Awaiting";
+  const comment = attendee.comment?.trim();
+
   return (
     <AttendeeApolloPopover attendee={attendee}>
       <div className="rounded-xl px-1 py-1 transition-colors hover:bg-muted/40">
@@ -254,9 +244,7 @@ function AttendeeRow({
           <div className="relative shrink-0">
             <AttendeeAvatar attendee={attendee} resolvedPhotoUrl={photoUrl} />
             <div className="absolute -bottom-0.5 -right-0.5">
-              <ResponseStatusIcon
-                status={inlineRsvp ? currentStatus : attendee.responseStatus}
-              />
+              <RsvpStatusIcon status={displayStatus ?? "needsAction"} />
             </div>
           </div>
           <div className="min-w-0 flex-1">
@@ -275,8 +263,17 @@ function AttendeeRow({
                 {attendee.email}
               </div>
             )}
+            <div className="mt-0.5 text-[11px] text-muted-foreground/70">
+              {inlineRsvp ? `Your response: ${statusLabel}` : statusLabel}
+            </div>
           </div>
         </div>
+        {comment && (
+          <div className="ml-10 mt-1 flex items-start gap-1.5 rounded-md bg-muted/40 px-2 py-1 text-[11px] leading-relaxed text-muted-foreground">
+            <IconMessageCircle className="mt-0.5 h-3 w-3 shrink-0" />
+            <span className="min-w-0 break-words">{comment}</span>
+          </div>
+        )}
         {inlineRsvp && currentStatus && onStatusChange && (
           <RsvpControls
             eventId={event.id}

--- a/templates/calendar/app/components/calendar/EventCard.tsx
+++ b/templates/calendar/app/components/calendar/EventCard.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { RsvpStatusIcon } from "@/lib/rsvp-status";
 import {
   getEventDisplayColor,
   allOtherDeclined,
@@ -65,6 +66,7 @@ export function EventCard({
             style={{ backgroundColor: accentColor }}
           />
         )}
+        <RsvpStatusIcon status={event.responseStatus} />
         <span className="truncate font-medium">{event.title}</span>
       </button>
     );
@@ -93,6 +95,7 @@ export function EventCard({
             className="shrink-0 text-current opacity-70"
           />
         )}
+        <RsvpStatusIcon status={event.responseStatus} />
         <span className="truncate font-medium">{event.title}</span>
       </div>
       {!event.allDay && (

--- a/templates/calendar/app/components/calendar/EventDetailPanel.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPanel.tsx
@@ -418,6 +418,23 @@ export function EventDetailPanel({
                     <IconTrash className="mr-1.5 h-3.5 w-3.5" />
                     Delete
                   </Button>
+                  {event.htmlLink && (
+                    <Button
+                      asChild
+                      variant="outline"
+                      size="sm"
+                      className="ml-auto"
+                    >
+                      <a
+                        href={safeUrl(event.htmlLink)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <IconExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                        Google Calendar
+                      </a>
+                    </Button>
+                  )}
                 </div>
               )}
             </>

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -1886,6 +1886,23 @@ Write a short, useful meeting description. If I ask you to apply it, update this
               >
                 {isDraft ? "Discard" : "Delete"}
               </Button>
+              {event.htmlLink && !isDraft && (
+                <Button
+                  asChild
+                  variant="outline"
+                  size="sm"
+                  className="ml-auto gap-1.5 text-xs"
+                >
+                  <a
+                    href={event.htmlLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <IconExternalLink className="h-3.5 w-3.5" />
+                    Google Calendar
+                  </a>
+                </Button>
+              )}
               {isDraft && (
                 <Button
                   size="sm"

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -17,6 +17,7 @@ import {
 } from "date-fns";
 import { cn } from "@/lib/utils";
 import { shouldSuppressAfterPopoverClose } from "@/lib/popover-click-guard";
+import { RsvpStatusIcon } from "@/lib/rsvp-status";
 import { getEventDisplayColor, allOtherDeclined } from "@/lib/event-colors";
 import { IconAlertTriangleFilled } from "@tabler/icons-react";
 import { EventDetailPopover } from "./EventDetailPopover";
@@ -610,6 +611,10 @@ export function WeekView({
                           className="shrink-0 text-current opacity-70"
                         />
                       )}
+                      <RsvpStatusIcon
+                        status={event.responseStatus}
+                        className="shrink-0"
+                      />
                       <span className="truncate">{event.title}</span>
                     </button>
                   </EventDetailPopover>
@@ -889,6 +894,10 @@ export function WeekView({
                                 className="shrink-0 text-current opacity-70 relative top-[1px]"
                               />
                             )}
+                            <RsvpStatusIcon
+                              status={event.responseStatus}
+                              className="relative top-[1px] shrink-0"
+                            />
                             <span
                               className={cn(
                                 "truncate leading-tight",
@@ -937,6 +946,10 @@ export function WeekView({
                                   className="shrink-0 text-current opacity-70"
                                 />
                               )}
+                              <RsvpStatusIcon
+                                status={event.responseStatus}
+                                className="shrink-0"
+                              />
                               <span className="truncate">{event.title}</span>
                             </div>
                             {isStart && (

--- a/templates/calendar/app/components/layout/AppLayout.tsx
+++ b/templates/calendar/app/components/layout/AppLayout.tsx
@@ -290,6 +290,7 @@ export function AppLayout({ children }: AppLayoutProps) {
               {!googleStatus.isLoading &&
               !googleStatus.isError &&
               !hasAccounts &&
+              !eventDraft &&
               isCalendarPage &&
               !isSettingsPage ? (
                 <main className="flex-1 overflow-y-auto">

--- a/templates/calendar/app/lib/rsvp-status.tsx
+++ b/templates/calendar/app/lib/rsvp-status.tsx
@@ -1,0 +1,57 @@
+import { IconCheck, IconCircleX, IconHelpCircle } from "@tabler/icons-react";
+import { cn } from "@/lib/utils";
+
+export type RsvpStatus = "accepted" | "declined" | "tentative" | "needsAction";
+
+export function getRsvpStatusLabel(status?: string) {
+  switch (status) {
+    case "accepted":
+      return "Yes";
+    case "declined":
+      return "No";
+    case "tentative":
+      return "Maybe";
+    case "needsAction":
+      return "Awaiting";
+    default:
+      return undefined;
+  }
+}
+
+export function RsvpStatusIcon({
+  status,
+  className,
+}: {
+  status?: string;
+  className?: string;
+}) {
+  const label = getRsvpStatusLabel(status);
+  if (!label) return null;
+
+  const iconClassName = cn("h-3 w-3", className);
+  if (status === "accepted") {
+    return (
+      <IconCheck
+        className={cn(iconClassName, "text-emerald-500")}
+        aria-label={`RSVP: ${label}`}
+      />
+    );
+  }
+  if (status === "declined") {
+    return (
+      <IconCircleX
+        className={cn(iconClassName, "text-red-400")}
+        aria-label={`RSVP: ${label}`}
+      />
+    );
+  }
+  return (
+    <IconHelpCircle
+      className={cn(
+        iconClassName,
+        status === "tentative" ? "text-yellow-500" : "text-muted-foreground/60",
+      )}
+      aria-label={`RSVP: ${label}`}
+    />
+  );
+}

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -61,6 +61,7 @@ import {
 } from "@/hooks/use-events";
 import { useOverlayPeople } from "@/hooks/use-overlay-people";
 import { useGoogleAuthStatus } from "@/hooks/use-google-auth";
+import { useSettings } from "@/hooks/use-settings";
 import { useViewPreferences } from "@/hooks/use-view-preferences";
 import { useMeetingStartNotifications } from "@/hooks/use-meeting-start-notifications";
 import { useQueryClient } from "@tanstack/react-query";
@@ -122,6 +123,28 @@ function fallbackDraftRange(fallbackDate: Date) {
   const end = new Date(start);
   end.setHours(10, 0, 0, 0);
   return { start, end };
+}
+
+function addMinutesToDateTimeParts(
+  date: string,
+  time: string,
+  minutes: number,
+) {
+  const [hour, minute] = time.split(":").map(Number);
+  const safeHour = Number.isFinite(hour) ? hour : 9;
+  const safeMinute = Number.isFinite(minute) ? minute : 0;
+  const totalMinutes = safeHour * 60 + safeMinute + minutes;
+  const dayOffset = Math.floor(totalMinutes / (24 * 60));
+  const minuteOfDay = ((totalMinutes % (24 * 60)) + 24 * 60) % (24 * 60);
+  const endDate = new Date(`${date}T00:00:00`);
+  endDate.setDate(endDate.getDate() + dayOffset);
+  const endHour = Math.floor(minuteOfDay / 60);
+  const endMinute = minuteOfDay % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return {
+    date: format(endDate, "yyyy-MM-dd"),
+    time: `${pad(endHour)}:${pad(endMinute)}`,
+  };
 }
 
 function draftRange(draft: CalendarEventDraft, fallbackDate: Date) {
@@ -279,6 +302,7 @@ export default function CalendarView() {
 
   const queryClient = useQueryClient();
   const googleStatus = useGoogleAuthStatus();
+  const { data: settings } = useSettings();
   const { data: rawOverlayPeople } = useOverlayPeople();
   const overlayPeople = Array.isArray(rawOverlayPeople) ? rawOverlayPeople : [];
   const overlayEmails = useMemo(
@@ -840,12 +864,13 @@ export default function CalendarView() {
     if (!event) return;
 
     if (calendarDraftIdFromEventId(eventId)) {
+      const timezone = settings?.timezone || getLocalTimezone();
       updateDraftEvent(eventId, {
         start: newStart.toISOString(),
         end: newEnd.toISOString(),
         allDay: false,
-        startTimeZone: getLocalTimezone(),
-        endTimeZone: getLocalTimezone(),
+        startTimeZone: timezone,
+        endTimeZone: timezone,
       });
       return;
     }
@@ -898,18 +923,20 @@ export default function CalendarView() {
   function handleClickTimeSlot(
     clickedDate: Date,
     startTime: string,
-    endTime: string,
+    _endTime: string,
   ) {
     setSelectedDate(clickedDate);
     setEventDraft(null);
+    const defaultDuration = Math.max(5, settings?.defaultEventDuration ?? 30);
+    const timezone = settings?.timezone || getLocalTimezone();
     setCreateDefaultStart(startTime);
-    setCreateDefaultEnd(endTime);
     setCreateDialogOpen(false);
 
     const dateStr = format(clickedDate, "yyyy-MM-dd");
-    const timezone = getLocalTimezone();
+    const end = addMinutesToDateTimeParts(dateStr, startTime, defaultDuration);
+    setCreateDefaultEnd(end.time);
     const startISO = dateTimeInTimezoneToIso(dateStr, startTime, timezone);
-    const endISO = dateTimeInTimezoneToIso(dateStr, endTime, timezone);
+    const endISO = dateTimeInTimezoneToIso(end.date, end.time, timezone);
     const tempId = `temp-${Date.now()}`;
 
     createEvent.mutate(

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -302,7 +302,8 @@ export default function CalendarView() {
 
   const queryClient = useQueryClient();
   const googleStatus = useGoogleAuthStatus();
-  const { data: settings } = useSettings();
+  const settingsQuery = useSettings();
+  const { data: settings } = settingsQuery;
   const { data: rawOverlayPeople } = useOverlayPeople();
   const overlayPeople = Array.isArray(rawOverlayPeople) ? rawOverlayPeople : [];
   const overlayEmails = useMemo(
@@ -920,15 +921,30 @@ export default function CalendarView() {
     );
   }
 
-  function handleClickTimeSlot(
+  async function handleClickTimeSlot(
     clickedDate: Date,
     startTime: string,
     _endTime: string,
   ) {
+    let activeSettings = settings;
+    if (!activeSettings) {
+      const result = await settingsQuery.refetch();
+      activeSettings = result.data;
+    }
+    if (!activeSettings?.timezone) {
+      toast.error(
+        "Calendar settings are still loading. Try again in a moment.",
+      );
+      return;
+    }
+
     setSelectedDate(clickedDate);
     setEventDraft(null);
-    const defaultDuration = Math.max(5, settings?.defaultEventDuration ?? 30);
-    const timezone = settings?.timezone || getLocalTimezone();
+    const defaultDuration = Math.max(
+      5,
+      activeSettings.defaultEventDuration ?? 30,
+    );
+    const timezone = activeSettings.timezone;
     setCreateDefaultStart(startTime);
     setCreateDialogOpen(false);
 

--- a/templates/calendar/app/pages/Settings.tsx
+++ b/templates/calendar/app/pages/Settings.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from "react";
+import { Link } from "react-router";
 import {
   IconBrandZoom,
   IconExternalLink,
+  IconLink,
   IconUnlink,
   IconCircleCheck,
   IconCircleX,
@@ -278,7 +280,9 @@ export default function Settings() {
       <Card>
         <CardHeader>
           <CardTitle className="text-lg">General</CardTitle>
-          <CardDescription>Calendar and booking page settings.</CardDescription>
+          <CardDescription>
+            Calendar defaults and fallback booking copy.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
@@ -287,7 +291,7 @@ export default function Settings() {
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="booking-title">Booking page title</Label>
+            <Label htmlFor="booking-title">Fallback booking page title</Label>
             <Input
               id="booking-title"
               value={bookingTitle}
@@ -295,13 +299,15 @@ export default function Settings() {
               placeholder="Book a Meeting"
             />
             <p className="text-xs text-muted-foreground">
-              Heading shown on your default public booking page. Individual
-              booking links use their own title when set.
+              Used only when a booking link has no title. Create, open, and copy
+              public URLs from Booking links.
             </p>
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="booking-desc">Booking page description</Label>
+            <Label htmlFor="booking-desc">
+              Fallback booking page description
+            </Label>
             <Textarea
               id="booking-desc"
               value={bookingDescription}
@@ -310,8 +316,7 @@ export default function Settings() {
               rows={2}
             />
             <p className="text-xs text-muted-foreground">
-              Subtitle shown on your default public booking page when a booking
-              link has no description of its own.
+              Used only when a booking link has no description of its own.
             </p>
           </div>
 
@@ -333,9 +338,17 @@ export default function Settings() {
             </p>
           </div>
 
-          <Button onClick={handleSave} disabled={updateSettings.isPending}>
-            {updateSettings.isPending ? "Saving..." : "Save Settings"}
-          </Button>
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={handleSave} disabled={updateSettings.isPending}>
+              {updateSettings.isPending ? "Saving..." : "Save Settings"}
+            </Button>
+            <Button asChild variant="outline">
+              <Link to="/booking-links">
+                <IconLink className="mr-1.5 h-3.5 w-3.5" />
+                Booking links
+              </Link>
+            </Button>
+          </div>
         </CardContent>
       </Card>
 

--- a/templates/calendar/server/handlers/events.ts
+++ b/templates/calendar/server/handlers/events.ts
@@ -176,6 +176,7 @@ export const getEvent = defineEventHandler(async (event: H3Event) => {
           attendees: evt.attendees?.map((a: any) => ({
             email: a.email,
             displayName: a.displayName || undefined,
+            comment: a.comment || undefined,
             responseStatus: a.responseStatus || undefined,
             organizer: a.organizer || undefined,
             self: a.self || undefined,

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -596,6 +596,7 @@ export async function listEvents(
               email: a.email,
               displayName: a.displayName || undefined,
               photoUrl: a.photoUrl || undefined,
+              comment: a.comment || undefined,
               responseStatus: a.responseStatus || undefined,
               organizer: a.organizer || undefined,
               self: a.self || undefined,
@@ -759,6 +760,7 @@ export async function getEvent(
       email: a.email,
       displayName: a.displayName || undefined,
       photoUrl: a.photoUrl || undefined,
+      comment: a.comment || undefined,
       responseStatus: a.responseStatus || undefined,
       organizer: a.organizer || undefined,
       self: a.self || undefined,
@@ -822,6 +824,7 @@ export async function createEvent(
     body.attendees = event.attendees.map((a) => ({
       email: a.email,
       ...(a.displayName ? { displayName: a.displayName } : {}),
+      ...(a.comment ? { comment: a.comment } : {}),
     }));
   }
 
@@ -929,6 +932,7 @@ export async function updateEvent(
     requestBody.attendees = eventPatch.attendees.map((a) => ({
       email: a.email,
       ...(a.displayName ? { displayName: a.displayName } : {}),
+      ...(a.comment ? { comment: a.comment } : {}),
       ...(a.responseStatus ? { responseStatus: a.responseStatus } : {}),
     }));
   }

--- a/templates/calendar/server/routes/_agent-native/zoom/auth-url.get.ts
+++ b/templates/calendar/server/routes/_agent-native/zoom/auth-url.get.ts
@@ -8,7 +8,6 @@
 import {
   defineEventHandler,
   getQuery,
-  sendRedirect,
   setResponseStatus,
   type H3Event,
 } from "h3";
@@ -21,6 +20,15 @@ import {
 import { getZoomAuthUrl, isZoomConfigured } from "../../../lib/zoom.js";
 
 const OAUTH_STATE_APP_ID = process.env.APP_NAME || "calendar";
+
+function oauthRedirectResponse(url: string) {
+  // h3 v2 sendRedirect returns an object that can render as "[object Object]"
+  // in production auth popups. Native Response stays a real 302.
+  return new Response(null, {
+    status: 302,
+    headers: { Location: url },
+  });
+}
 
 export default defineEventHandler(async (event: H3Event) => {
   if (!isZoomConfigured()) {
@@ -53,7 +61,7 @@ export default defineEventHandler(async (event: H3Event) => {
   });
   const url = getZoomAuthUrl(redirectUri, state);
   if (getQuery(event).redirect === "1") {
-    return sendRedirect(event, url, 302);
+    return oauthRedirectResponse(url);
   }
   return { url };
 });

--- a/templates/calendar/shared/api.ts
+++ b/templates/calendar/shared/api.ts
@@ -36,6 +36,8 @@ export interface CalendarEvent {
     email: string;
     displayName?: string;
     photoUrl?: string;
+    /** Google Calendar RSVP note/comment from the attendee */
+    comment?: string;
     responseStatus?: "accepted" | "declined" | "tentative" | "needsAction";
     organizer?: boolean;
     self?: boolean;

--- a/templates/clips/actions/get-recording-player-data.ts
+++ b/templates/clips/actions/get-recording-player-data.ts
@@ -17,7 +17,8 @@
  *   pnpm action get-recording-player-data --recordingId=<id>
  */
 
-import { defineAction } from "@agent-native/core";
+import { defineAction, embedApp } from "@agent-native/core";
+import { buildDeepLink } from "@agent-native/core/server";
 import { z } from "zod";
 import { asc, eq } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
@@ -29,12 +30,37 @@ import {
   parseTranscriptSegments,
 } from "../shared/transcript-segments.js";
 
+const MCP_APP_FRAME_DOMAINS = [
+  "https:",
+  "http://localhost:*",
+  "http://127.0.0.1:*",
+];
+
+function recordingDeepLink(recordingId: string): string {
+  return buildDeepLink({
+    app: "clips",
+    view: "recording",
+    params: { recordingId },
+    to: `/r/${encodeURIComponent(recordingId)}`,
+  });
+}
+
 export default defineAction({
   description:
     "Fetch everything the player page needs for a recording: metadata, transcript, comments, reactions, chapters, CTAs, and the caller's effective role.",
   schema: z.object({
     recordingId: z.string().describe("Recording ID"),
   }),
+  mcpApp: {
+    resource: embedApp({
+      title: "Clip player",
+      description: "Open this recording in the real Clips player.",
+      iframeTitle: "Agent-Native Clips",
+      openLabel: "Open clip",
+      frameDomains: MCP_APP_FRAME_DOMAINS,
+      height: 680,
+    }),
+  },
   http: { method: "GET" },
   run: async (args) => {
     const access = await resolveAccess("recording", args.recordingId);
@@ -250,6 +276,13 @@ export default defineAction({
         placement: c.placement,
       })),
       meeting,
+    };
+  },
+  link: ({ args }) => {
+    return {
+      url: recordingDeepLink(args.recordingId),
+      label: "Open clip in Clips",
+      view: "recording",
     };
   },
 });

--- a/templates/clips/actions/search-recordings.ts
+++ b/templates/clips/actions/search-recordings.ts
@@ -1,10 +1,50 @@
-import { defineAction } from "@agent-native/core";
+import { defineAction, embedApp } from "@agent-native/core";
+import { buildDeepLink } from "@agent-native/core/server";
 import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { accessFilter } from "@agent-native/core/sharing";
 
 const SNIPPET_RADIUS = 80;
+const MCP_APP_FRAME_DOMAINS = [
+  "https:",
+  "http://localhost:*",
+  "http://127.0.0.1:*",
+];
+
+type RecordingMatchPanel = "transcript" | "comments" | null;
+
+function playerPath(
+  recordingId: string,
+  options: { matchMs?: number | null; matchPanel?: RecordingMatchPanel } = {},
+): string {
+  const params = new URLSearchParams();
+  if (typeof options.matchMs === "number" && Number.isFinite(options.matchMs)) {
+    params.set("t", Math.max(0, Math.floor(options.matchMs / 1000)).toString());
+  }
+  if (options.matchPanel) params.set("panel", options.matchPanel);
+  const query = params.toString();
+  return `/r/${encodeURIComponent(recordingId)}${query ? `?${query}` : ""}`;
+}
+
+function recordingDeepLink(
+  recordingId: string,
+  options: { matchMs?: number | null; matchPanel?: RecordingMatchPanel } = {},
+): string {
+  return buildDeepLink({
+    app: "clips",
+    view: "recording",
+    params: {
+      recordingId,
+      ...(typeof options.matchMs === "number" &&
+      Number.isFinite(options.matchMs)
+        ? { t: Math.max(0, Math.floor(options.matchMs / 1000)) }
+        : {}),
+      ...(options.matchPanel ? { panel: options.matchPanel } : {}),
+    },
+    to: playerPath(recordingId, options),
+  });
+}
 
 function escapeLike(s: string): string {
   return s.replace(/([\\%_])/g, "\\$1");
@@ -64,6 +104,16 @@ export default defineAction({
     query: z.string().min(1).describe("Search text"),
     limit: z.coerce.number().int().min(1).max(100).default(30),
   }),
+  mcpApp: {
+    resource: embedApp({
+      title: "Clip search",
+      description: "Open the best matching recording in the real Clips player.",
+      iframeTitle: "Agent-Native Clips",
+      openLabel: "Open clip",
+      frameDomains: MCP_APP_FRAME_DOMAINS,
+      height: 680,
+    }),
+  },
   http: { method: "GET" },
   run: async (args) => {
     const db = getDb();
@@ -260,6 +310,25 @@ export default defineAction({
     return {
       query: args.query,
       results: results.slice(0, args.limit),
+    };
+  },
+  link: ({ result }) => {
+    if (!result || typeof result !== "object") return null;
+    const results = (result as { results?: unknown }).results;
+    if (!Array.isArray(results) || results.length === 0) return null;
+    const first = results[0] as {
+      id?: string;
+      matchMs?: number | null;
+      matchPanel?: RecordingMatchPanel;
+    };
+    if (!first.id) return null;
+    return {
+      url: recordingDeepLink(first.id, {
+        matchMs: first.matchMs,
+        matchPanel: first.matchPanel ?? null,
+      }),
+      label: "Open clip in Clips",
+      view: "recording",
     };
   },
 });

--- a/templates/content/actions/create-document.ts
+++ b/templates/content/actions/create-document.ts
@@ -1,4 +1,4 @@
-import { defineAction } from "@agent-native/core";
+import { defineAction, embedApp } from "@agent-native/core";
 import { and, eq, sql } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
 import { parseDocumentFavorite } from "../server/lib/documents.js";
@@ -32,6 +32,17 @@ export default defineAction({
     parentId: z.string().nullish().describe("Parent document ID for nesting"),
     icon: z.string().optional().describe("Emoji icon"),
   }),
+  mcpApp: {
+    resource: embedApp({
+      title: "Edit document",
+      description:
+        "Open the generated draft in the real Content editor so the user can revise, format, organize, and publish it.",
+      iframeTitle: "Agent-Native Content",
+      openLabel: "Open in Content",
+      frameDomains: ["https:", "http://localhost:*", "http://127.0.0.1:*"],
+      height: 900,
+    }),
+  },
   run: async (args) => {
     const title = args.title;
 

--- a/templates/design/actions/create-design.ts
+++ b/templates/design/actions/create-design.ts
@@ -1,4 +1,5 @@
-import { defineAction } from "@agent-native/core";
+import { defineAction, embedApp } from "@agent-native/core";
+import { buildDeepLink } from "@agent-native/core/server";
 import { z } from "zod";
 import { nanoid } from "nanoid";
 import { getDb, schema } from "../server/db/index.js";
@@ -7,6 +8,22 @@ import {
   getRequestOrgId,
 } from "@agent-native/core/server/request-context";
 import { assertAccess } from "@agent-native/core/sharing";
+
+const MCP_APP_FRAME_DOMAINS = [
+  "https:",
+  "http://localhost:*",
+  "http://127.0.0.1:*",
+];
+
+/** Editor deep link so external agents can surface "Open design". */
+function designDeepLink(designId: string): string {
+  return buildDeepLink({
+    app: "design",
+    view: "editor",
+    params: { designId },
+    to: `/design/${encodeURIComponent(designId)}`,
+  });
+}
 
 export default defineAction({
   description:
@@ -33,6 +50,16 @@ export default defineAction({
       .optional()
       .describe("Design system ID to link to this design"),
   }),
+  mcpApp: {
+    resource: embedApp({
+      title: "Design project",
+      description: "Open the new design project in the real Design editor.",
+      iframeTitle: "Agent-Native Design",
+      openLabel: "Open design",
+      frameDomains: MCP_APP_FRAME_DOMAINS,
+      height: 680,
+    }),
+  },
   run: async ({
     id: providedId,
     title,
@@ -70,6 +97,16 @@ export default defineAction({
       projectType,
       renderable: false,
       nextRequiredAction: "generate-design",
+    };
+  },
+  link: ({ result }) => {
+    if (!result || typeof result !== "object") return null;
+    const designId = (result as { id?: string }).id;
+    if (!designId) return null;
+    return {
+      url: designDeepLink(designId),
+      label: "Open design",
+      view: "editor",
     };
   },
 });

--- a/templates/forms/actions/create-form.ts
+++ b/templates/forms/actions/create-form.ts
@@ -1,4 +1,5 @@
-import { defineAction } from "@agent-native/core";
+import { defineAction, embedApp } from "@agent-native/core";
+import { buildDeepLink } from "@agent-native/core/server";
 import {
   getRequestUserEmail,
   getRequestOrgId,
@@ -20,6 +21,15 @@ function slugify(text: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "")
     .slice(0, 60);
+}
+
+function formDeepLink(formId: string): string {
+  return buildDeepLink({
+    app: "forms",
+    view: "form",
+    to: `/forms/${encodeURIComponent(formId)}`,
+    params: { formId },
+  });
 }
 
 export default defineAction({
@@ -44,6 +54,17 @@ export default defineAction({
       .optional()
       .describe("Form status"),
   }),
+  mcpApp: {
+    resource: embedApp({
+      title: "Edit form",
+      description:
+        "Open the generated form in the real Forms editor so the user can edit fields, settings, publishing, and integrations.",
+      iframeTitle: "Agent-Native Forms",
+      openLabel: "Open in Forms",
+      frameDomains: ["https:", "http://localhost:*", "http://127.0.0.1:*"],
+      height: 900,
+    }),
+  },
   run: async (args) => {
     const id = nanoid(10);
     const now = new Date().toISOString();
@@ -127,6 +148,15 @@ export default defineAction({
       responseCount: 0,
       createdAt: now,
       updatedAt: now,
+    };
+  },
+  link: ({ result }) => {
+    const id = (result as { id?: string } | null)?.id;
+    if (!id) return null;
+    return {
+      url: formDeepLink(id),
+      label: "Open form in Forms",
+      view: "form",
     };
   },
 });

--- a/templates/forms/app/pages/FormBuilderPage.tsx
+++ b/templates/forms/app/pages/FormBuilderPage.tsx
@@ -238,7 +238,7 @@ export function FormBuilderPage() {
     [],
   );
 
-  if (isLoading) {
+  if (isLoading || (!form && !error)) {
     return (
       <div className="flex flex-col h-full">
         {/* Top bar */}

--- a/templates/slides/actions/add-slide.ts
+++ b/templates/slides/actions/add-slide.ts
@@ -1,4 +1,4 @@
-import { defineAction } from "@agent-native/core";
+import { defineAction, embedApp } from "@agent-native/core";
 import { buildDeepLink } from "@agent-native/core/server";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
@@ -23,6 +23,12 @@ function deckDeepLink(deckId: string): string {
     params: { deckId },
   });
 }
+
+const MCP_APP_FRAME_DOMAINS = [
+  "https:",
+  "http://localhost:*",
+  "http://127.0.0.1:*",
+];
 
 // In-process serialization per deckId. `add-slide` is intentionally advertised
 // as a sequential write, but the lock still protects against accidental
@@ -81,6 +87,16 @@ export default defineAction({
         "Optional 0-based index to insert at. If not provided, appends to the end of the deck.",
       ),
   }),
+  mcpApp: {
+    resource: embedApp({
+      title: "Deck editor",
+      description: "Open the updated deck in the real Slides editor.",
+      iframeTitle: "Agent-Native Slides",
+      openLabel: "Open deck",
+      frameDomains: MCP_APP_FRAME_DOMAINS,
+      height: 680,
+    }),
+  },
   http: false,
   run: async ({ deckId, content, slideId, layout, notes, position }) =>
     withDeckLock(deckId, async () => {

--- a/templates/slides/actions/create-deck.ts
+++ b/templates/slides/actions/create-deck.ts
@@ -56,9 +56,9 @@ function deckDeepLink(deckId: string): string {
 
 export default defineAction({
   description:
-    "Create an empty deck, or atomically replace all slides in an existing deck. " +
-    "For AI-generated decks, create the deck with slides: [] and then use add-slide so progress appears live. " +
-    "Use non-empty slides here only for imports or intentional bulk replacement. " +
+    "Create a new deck, optionally already populated with slides, or atomically replace all slides in an existing deck. " +
+    "For short AI-generated decks in MCP app hosts, pass all generated slides in this call so the real deck editor opens inline already populated. " +
+    "For longer decks or live in-app generation, create the deck with slides: [] and then use add-slide sequentially so progress appears live. " +
     "Pass deckId to replace an existing deck. " +
     "Returns the deck id, title, and slide count.",
   schema: z.object({

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -9,7 +9,11 @@ import {
   ReactNode,
 } from "react";
 import { nanoid } from "nanoid";
-import { appBasePath, appPath } from "@agent-native/core/client";
+import {
+  appBasePath,
+  appPath,
+  isEmbedAuthActive,
+} from "@agent-native/core/client";
 import type { AspectRatio } from "@/lib/aspect-ratios";
 
 export type SlideLayout =
@@ -579,6 +583,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
 
   // Listen for file changes via SSE (so agent edits show up in real-time)
   useEffect(() => {
+    if (isEmbedAuthActive()) return;
     const evtSource = new EventSource(`${appBasePath()}/api/decks/events`);
     evtSource.onmessage = async (event) => {
       try {


### PR DESCRIPTION
## Summary
- keep ChatGPT/Claude-style OAuth MCP hosts on a compact MCP Apps catalog by default, including old tokens without `mcp:apps`
- block compact hosts from invoking hidden full-catalog tools and avoid huge discovery payloads
- make embedded sessions work through ngrok/full app routes, including app runtime fetches from embedded pages
- add real app-route MCP embeds for Mail, Analytics, Calendar, Forms, Content, Clips, Slides, and Design flows
- include the remaining local DB cleanup, chat-thread retry, desktop latest-route, and calendar RSVP/Zoom updates that were already in the worktree

## Verification
- `pnpm prep`
- `pnpm --dir packages/core exec vitest --run src/mcp/server.spec.ts src/mcp/build-server.verify-auth.spec.ts src/server/embed-session.spec.ts`
- `pnpm --dir packages/core build`
- template typechecks for Analytics, Mail, Calendar, Forms, Content, Slides, Clips, and Design
- ngrok direct MCP checks for Mail and Analytics old-scope OAuth tokens, with compact tool/resource discovery under 12 KB and hidden full-catalog tools blocked
- Chrome proof: Mail draft opened in the real Mail compose UI with contact autocomplete
- Chrome proof: Analytics traffic dashboard opened as the real dashboard route
- mobile Playwright proof for Mail and Analytics embeds
- parallel QA passes for Calendar, Forms, Content, Slides, Clips, and Design MCP embed routes
