### PR TITLE
[wip] Fix: glitchy screen+camera recordings when switching tabs

### DIFF
--- a/templates/clips/app/lib/camera-composite.ts
+++ b/templates/clips/app/lib/camera-composite.ts
@@ -233,9 +233,6 @@ export function createCameraCompositeStream(
 
   resizeCanvasToDisplay(canvas, display.video, options.displayStream);
   const stream = canvas.captureStream(frameRate);
-  let raf: number | null = null;
-  let stopped = false;
-  let lastFrameAt = 0;
   const minFrameMs = 1000 / frameRate;
 
   const drawFrame = () => {
@@ -250,22 +247,51 @@ export function createCameraCompositeStream(
     drawCameraBubble(ctx, camera.video, canvas, drawOptions);
   };
 
-  const tick = (now: number) => {
-    if (stopped) return;
-    if (now - lastFrameAt >= minFrameMs) {
-      lastFrameAt = now;
-      drawFrame();
-    }
+  // Use a Worker-based timer so the draw loop keeps running at the target
+  // frame rate even when the user switches to a different tab. rAF is
+  // throttled to ~1fps in background tabs, which causes glitchy recordings.
+  // Falls back to rAF if Worker creation fails (e.g. strict CSP blocking blob: workers).
+  let worker: Worker | null = null;
+  let raf: number | null = null;
+
+  try {
+    const workerBlob = new Blob(
+      [
+        `let t=null;onmessage=e=>{if(e.data==='start'){clearInterval(t);t=setInterval(()=>postMessage('tick'),${minFrameMs});}else if(e.data==='stop'){clearInterval(t);}};`,
+      ],
+      { type: "application/javascript" },
+    );
+    const workerUrl = URL.createObjectURL(workerBlob);
+    worker = new Worker(workerUrl);
+    URL.revokeObjectURL(workerUrl);
+    worker.onmessage = () => drawFrame();
+    worker.postMessage("start");
+  } catch (err) {
+    console.warn(
+      "[camera-composite] Worker timer unavailable, falling back to rAF — recording may glitch on hidden tabs:",
+      err,
+    );
+    let lastFrameAt = 0;
+    const tick = (now: number) => {
+      if (raf === null) return;
+      if (now - lastFrameAt >= minFrameMs) {
+        lastFrameAt = now;
+        drawFrame();
+      }
+      raf = window.requestAnimationFrame(tick);
+    };
     raf = window.requestAnimationFrame(tick);
-  };
+  }
 
   drawFrame();
-  raf = window.requestAnimationFrame(tick);
 
   return {
     stream,
     cleanup() {
-      stopped = true;
+      if (worker) {
+        worker.postMessage("stop");
+        worker.terminate();
+      }
       if (raf !== null) {
         window.cancelAnimationFrame(raf);
         raf = null;


### PR DESCRIPTION
## What was broken

When recording screen + camera and switching to a different browser tab, the output video would become glitchy or frozen during the time the Clips tab was in the background.

## Why it happened

The canvas compositor (which merges the screen capture and camera bubble into a single video stream) was driven by `requestAnimationFrame`. Browsers throttle `requestAnimationFrame` to ~1fps in background tabs, so the canvas would stop updating, causing choppy or frozen frames in the recording.

## The fix

Replaced the `requestAnimationFrame` loop with a **Web Worker timer**. The worker runs `setInterval` on a separate thread, which is not subject to background-tab throttling. Every tick, the worker sends a message to the main thread, which draws the next frame.

The canvas now keeps updating at the target frame rate (30fps) regardless of which tab is active.

A fallback to `requestAnimationFrame` is included in case Worker creation fails (e.g. a future strict CSP), so recording still works - just with the original limitation.