### PR TITLE
Fix calendar booking availability for tentative meetings

### DIFF
--- a/.changeset/embed-dev-frame-headers.md
+++ b/.changeset/embed-dev-frame-headers.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add COEP-compatible dev headers for MCP embed page loads.

--- a/.changeset/embed-security-coep.md
+++ b/.changeset/embed-security-coep.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Emit Cross-Origin-Embedder-Policy for validated MCP embed-session page loads.

--- a/.changeset/embed-security-corp.md
+++ b/.changeset/embed-security-corp.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Relax Cross-Origin-Resource-Policy for validated MCP embed-session page loads.

--- a/.changeset/embed-session-runtime-cookie.md
+++ b/.changeset/embed-session-runtime-cookie.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow MCP app runtime requests to resolve validated embed-session cookies.

--- a/.changeset/mcp-app-embed-host-csp.md
+++ b/.changeset/mcp-app-embed-host-csp.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow MCP App full-app embeds to load in hosted chat clients with stricter iframe and resource policies.

--- a/.changeset/mcp-app-open-height.md
+++ b/.changeset/mcp-app-open-height.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Lower default full-app MCP App embeds to a 720px app viewport.

--- a/.changeset/mcp-app-resource-origin.md
+++ b/.changeset/mcp-app-resource-origin.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow MCP app embeds to load resources from the request origin.

--- a/.changeset/prevent-auth-retry-storms.md
+++ b/.changeset/prevent-auth-retry-storms.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prevent same-origin 401/403 responses from causing client retry storms.

--- a/packages/core/src/client/embed-auth.spec.ts
+++ b/packages/core/src/client/embed-auth.spec.ts
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+async function loadEmbedAuth() {
+  vi.resetModules();
+  return import("./embed-auth.js");
+}
+
+function installFetchMock(
+  response: () => Response | Promise<Response>,
+): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async () => response());
+  vi.stubGlobal("fetch", fetchMock);
+  Object.defineProperty(window, "fetch", {
+    configurable: true,
+    writable: true,
+    value: fetchMock,
+  });
+  return fetchMock;
+}
+
+describe("embed auth fetch interceptor", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("serves repeated embedded auth failures locally during cooldown", async () => {
+    const fetchMock = installFetchMock(
+      () =>
+        new Response(JSON.stringify({ error: "Unauthorized" }), {
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    window.history.replaceState({}, "", "/mail?__an_embed_token=embed-token");
+
+    const { ensureEmbedAuthFetchInterceptor } = await loadEmbedAuth();
+    ensureEmbedAuthFetchInterceptor();
+
+    const first = await window.fetch("/api/emails?view=inbox&limit=25");
+    expect(first.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(window.location.search).not.toContain("__an_embed_token");
+
+    const firstInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    const firstHeaders = new Headers(firstInit?.headers);
+    expect(firstHeaders.get("authorization")).toBe("Bearer embed-token");
+
+    const second = await window.fetch("/api/emails?view=inbox&limit=25");
+    expect(second.status).toBe(401);
+    expect(second.headers.get("x-agent-native-auth-circuit-breaker")).toBe("1");
+    await expect(second.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const otherEndpoint = await window.fetch("/api/labels");
+    expect(otherEndpoint.status).toBe(401);
+    expect(
+      otherEndpoint.headers.get("x-agent-native-auth-circuit-breaker"),
+    ).toBe("1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes ordinary same-origin auth failures by request URL", async () => {
+    const fetchMock = installFetchMock(
+      () =>
+        new Response("Nope", {
+          status: 401,
+          statusText: "Unauthorized",
+        }),
+    );
+
+    const { ensureEmbedAuthFetchInterceptor } = await loadEmbedAuth();
+    ensureEmbedAuthFetchInterceptor();
+
+    await window.fetch("/api/emails?view=inbox");
+    const cached = await window.fetch("/api/emails?view=inbox");
+    expect(cached.status).toBe(401);
+    expect(cached.headers.get("x-agent-native-auth-circuit-breaker")).toBe("1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await window.fetch("/api/labels");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/client/embed-auth.spec.ts
+++ b/packages/core/src/client/embed-auth.spec.ts
@@ -1,87 +1,90 @@
 // @vitest-environment happy-dom
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  EMBED_TARGET_HEADER,
+  EMBED_TOKEN_QUERY_PARAM,
+} from "../shared/embed-auth.js";
+
+const STORAGE_KEY = "agent-native:embed-auth-token";
 
 async function loadEmbedAuth() {
   vi.resetModules();
   return import("./embed-auth.js");
 }
 
-function installFetchMock(
-  response: () => Response | Promise<Response>,
-): ReturnType<typeof vi.fn> {
-  const fetchMock = vi.fn(async () => response());
-  vi.stubGlobal("fetch", fetchMock);
-  Object.defineProperty(window, "fetch", {
-    configurable: true,
-    writable: true,
-    value: fetchMock,
-  });
-  return fetchMock;
-}
-
-describe("embed auth fetch interceptor", () => {
+describe("embed auth client", () => {
   beforeEach(() => {
-    vi.unstubAllGlobals();
-    window.history.replaceState({}, "", "/");
+    sessionStorage.clear();
+    window.history.replaceState(null, "", "/");
+    Object.defineProperty(window, "fetch", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(async () => new Response("ok")),
+    });
   });
 
-  it("serves repeated embedded auth failures locally during cooldown", async () => {
-    const fetchMock = installFetchMock(
-      () =>
-        new Response(JSON.stringify({ error: "Unauthorized" }), {
-          status: 401,
-          statusText: "Unauthorized",
-          headers: { "content-type": "application/json" },
-        }),
+  it("persists the URL token before stripping it from browser-visible history", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      `/inbox?embedded=1&${EMBED_TOKEN_QUERY_PARAM}=signed-token#message`,
     );
-    window.history.replaceState({}, "", "/mail?__an_embed_token=embed-token");
+
+    const first = await loadEmbedAuth();
+    first.ensureEmbedAuthFetchInterceptor();
+
+    expect(window.location.search).toBe("?embedded=1");
+    expect(window.location.hash).toBe("#message");
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe("signed-token");
+
+    const reloadedModule = await loadEmbedAuth();
+    expect(reloadedModule.getEmbedAuthToken()).toBe("signed-token");
+  });
+
+  it("adds the stored embed bearer token and target header to same-origin fetches", async () => {
+    window.history.replaceState(null, "", "/inbox?embedded=1");
+    sessionStorage.setItem(STORAGE_KEY, "stored-token");
+    const originalFetch = vi.fn(async () => new Response("ok"));
+    Object.defineProperty(window, "fetch", {
+      configurable: true,
+      writable: true,
+      value: originalFetch,
+    });
 
     const { ensureEmbedAuthFetchInterceptor } = await loadEmbedAuth();
     ensureEmbedAuthFetchInterceptor();
 
-    const first = await window.fetch("/api/emails?view=inbox&limit=25");
-    expect(first.status).toBe(401);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(window.location.search).not.toContain("__an_embed_token");
+    await window.fetch("/api/emails?view=inbox", {
+      headers: { "Content-Type": "application/json" },
+    });
 
-    const firstInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
-    const firstHeaders = new Headers(firstInit?.headers);
-    expect(firstHeaders.get("authorization")).toBe("Bearer embed-token");
-
-    const second = await window.fetch("/api/emails?view=inbox&limit=25");
-    expect(second.status).toBe(401);
-    expect(second.headers.get("x-agent-native-auth-circuit-breaker")).toBe("1");
-    await expect(second.json()).resolves.toEqual({ error: "Unauthorized" });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-
-    const otherEndpoint = await window.fetch("/api/labels");
-    expect(otherEndpoint.status).toBe(401);
-    expect(
-      otherEndpoint.headers.get("x-agent-native-auth-circuit-breaker"),
-    ).toBe("1");
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(originalFetch).toHaveBeenCalledTimes(1);
+    const [, init] = originalFetch.mock.calls[0]!;
+    const headers = new Headers(init?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer stored-token");
+    expect(headers.get(EMBED_TARGET_HEADER)).toBe("/inbox?embedded=1");
   });
 
-  it("dedupes ordinary same-origin auth failures by request URL", async () => {
-    const fetchMock = installFetchMock(
-      () =>
-        new Response("Nope", {
-          status: 401,
-          statusText: "Unauthorized",
-        }),
-    );
+  it("does not add embed credentials to cross-origin fetches", async () => {
+    window.history.replaceState(null, "", "/inbox?embedded=1");
+    sessionStorage.setItem(STORAGE_KEY, "stored-token");
+    const originalFetch = vi.fn(async () => new Response("ok"));
+    Object.defineProperty(window, "fetch", {
+      configurable: true,
+      writable: true,
+      value: originalFetch,
+    });
 
     const { ensureEmbedAuthFetchInterceptor } = await loadEmbedAuth();
     ensureEmbedAuthFetchInterceptor();
 
-    await window.fetch("/api/emails?view=inbox");
-    const cached = await window.fetch("/api/emails?view=inbox");
-    expect(cached.status).toBe(401);
-    expect(cached.headers.get("x-agent-native-auth-circuit-breaker")).toBe("1");
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await window.fetch("https://example.com/api/emails");
 
-    await window.fetch("/api/labels");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(originalFetch).toHaveBeenCalledTimes(1);
+    const [, init] = originalFetch.mock.calls[0]!;
+    const headers = new Headers(init?.headers);
+    expect(headers.has("Authorization")).toBe(false);
+    expect(headers.has(EMBED_TARGET_HEADER)).toBe(false);
   });
 });

--- a/packages/core/src/client/embed-auth.ts
+++ b/packages/core/src/client/embed-auth.ts
@@ -7,6 +7,7 @@ import {
 
 let installed = false;
 let memoryToken: string | null = null;
+const EMBED_TOKEN_STORAGE_KEY = "agent-native:embed-auth-token";
 
 const AUTH_FAILURE_COOLDOWN_MS = 60_000;
 const GUARDED_METHODS = new Set(["GET", "HEAD"]);
@@ -36,16 +37,33 @@ function readTokenFromUrl(win: Window): string | null {
   }
 }
 
-function storeToken(token: string): void {
+function storedToken(win: Window): string | null {
+  try {
+    return win.sessionStorage?.getItem(EMBED_TOKEN_STORAGE_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function storeToken(token: string, win: Window): void {
   memoryToken = token;
+  try {
+    win.sessionStorage?.setItem(EMBED_TOKEN_STORAGE_KEY, token);
+  } catch {
+    // Session storage may be unavailable in some sandboxed hosts. The
+    // in-memory fallback still covers the normal single-page boot path.
+  }
 }
 
 export function getEmbedAuthToken(): string | null {
   const win = browserWindow();
   if (!win) return null;
   const fromUrl = readTokenFromUrl(win);
-  if (fromUrl) return fromUrl;
-  return memoryToken;
+  if (fromUrl) {
+    storeToken(fromUrl, win);
+    return fromUrl;
+  }
+  return memoryToken ?? storedToken(win);
 }
 
 export function isEmbedAuthActive(): boolean {
@@ -245,7 +263,7 @@ export function ensureEmbedAuthFetchInterceptor(): void {
 
   const urlToken = readTokenFromUrl(win);
   if (urlToken) {
-    storeToken(urlToken);
+    storeToken(urlToken, win);
     stripTokenFromUrl(win);
   }
 

--- a/packages/core/src/client/embed-auth.ts
+++ b/packages/core/src/client/embed-auth.ts
@@ -1,11 +1,27 @@
 import {
   EMBED_MODE_QUERY_PARAM,
+  EMBED_START_PATH,
   EMBED_TARGET_HEADER,
   EMBED_TOKEN_QUERY_PARAM,
 } from "../shared/embed-auth.js";
 
 let installed = false;
 let memoryToken: string | null = null;
+
+const AUTH_FAILURE_COOLDOWN_MS = 60_000;
+const GUARDED_METHODS = new Set(["GET", "HEAD"]);
+const AUTH_FAILURE_HEADER = "x-agent-native-auth-circuit-breaker";
+
+type AuthFailureRecord = {
+  status: number;
+  statusText: string;
+  headers: [string, string][];
+  body: string | null;
+  expiresAt: number;
+};
+
+const authFailureCache = new Map<string, AuthFailureRecord>();
+let embedAuthFailure: AuthFailureRecord | null = null;
 
 function browserWindow(): Window | null {
   return typeof window === "undefined" ? null : window;
@@ -64,16 +80,163 @@ function currentEmbedTarget(win: Window): string {
   return `${win.location.pathname}${win.location.search}`;
 }
 
-function sameOrigin(input: RequestInfo | URL, win: Window): boolean {
+function inputUrl(input: RequestInfo | URL, win: Window): URL | null {
   try {
-    const url =
-      input instanceof Request
-        ? new URL(input.url)
-        : new URL(String(input), win.location.origin);
-    return url.origin === win.location.origin;
+    return input instanceof Request
+      ? new URL(input.url)
+      : new URL(String(input), win.location.origin);
   } catch {
-    return false;
+    return null;
   }
+}
+
+function sameOrigin(input: RequestInfo | URL, win: Window): boolean {
+  const url = inputUrl(input, win);
+  return !!url && url.origin === win.location.origin;
+}
+
+function requestMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  return (
+    init?.method ??
+    (input instanceof Request ? input.method : undefined) ??
+    "GET"
+  ).toUpperCase();
+}
+
+function authFailureKey(method: string, url: URL): string {
+  return `${method} ${url.href}`;
+}
+
+function isAuthFailureStatus(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
+function shouldGuardAuthFailure(method: string, url: URL): boolean {
+  if (!GUARDED_METHODS.has(method)) return false;
+  if (url.pathname === EMBED_START_PATH) return false;
+  if (url.pathname === "/_agent-native/sign-in") return false;
+  return true;
+}
+
+function activeAuthFailure(
+  record: AuthFailureRecord | null | undefined,
+): AuthFailureRecord | null {
+  if (!record) return null;
+  if (record.expiresAt > Date.now()) return record;
+  return null;
+}
+
+function getCachedAuthFailure(
+  key: string,
+  useEmbedWideFailure: boolean,
+): AuthFailureRecord | null {
+  const cached = activeAuthFailure(authFailureCache.get(key));
+  if (cached) return cached;
+  authFailureCache.delete(key);
+
+  if (!useEmbedWideFailure) return null;
+  const embedCached = activeAuthFailure(embedAuthFailure);
+  if (embedCached) return embedCached;
+  embedAuthFailure = null;
+  return null;
+}
+
+function authFailureResponse(record: AuthFailureRecord): Response {
+  const headers = new Headers(record.headers);
+  headers.set(AUTH_FAILURE_HEADER, "1");
+  if (!headers.has("retry-after")) {
+    headers.set(
+      "retry-after",
+      String(Math.max(1, Math.ceil((record.expiresAt - Date.now()) / 1000))),
+    );
+  }
+  return new Response(record.body, {
+    status: record.status,
+    statusText: record.statusText,
+    headers,
+  });
+}
+
+async function recordAuthFailure(
+  key: string,
+  response: Response,
+  useEmbedWideFailure: boolean,
+): Promise<void> {
+  let body: string | null = null;
+  try {
+    body = await response.clone().text();
+  } catch {
+    body = null;
+  }
+
+  const headers: [string, string][] = [];
+  response.headers.forEach((value, name) => {
+    const lower = name.toLowerCase();
+    if (
+      lower === "content-encoding" ||
+      lower === "content-length" ||
+      lower === "transfer-encoding"
+    ) {
+      return;
+    }
+    headers.push([name, value]);
+  });
+
+  const record: AuthFailureRecord = {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+    body,
+    expiresAt: Date.now() + AUTH_FAILURE_COOLDOWN_MS,
+  };
+  authFailureCache.set(key, record);
+  if (useEmbedWideFailure) embedAuthFailure = record;
+}
+
+function clearAuthFailure(key: string, useEmbedWideFailure: boolean): void {
+  authFailureCache.delete(key);
+  if (useEmbedWideFailure) embedAuthFailure = null;
+}
+
+function withEmbedAuthHeaders(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  token: string,
+  win: Window,
+): [RequestInfo | URL, RequestInit | undefined] {
+  const headers = new Headers(
+    init?.headers ?? (input instanceof Request ? input.headers : undefined),
+  );
+  if (!headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  if (!headers.has(EMBED_TARGET_HEADER)) {
+    headers.set(EMBED_TARGET_HEADER, currentEmbedTarget(win));
+  }
+
+  if (input instanceof Request) {
+    return [new Request(input, { ...init, headers }), undefined];
+  }
+  return [input, { ...init, headers }];
+}
+
+function requestUrlAndKey(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  win: Window,
+):
+  | {
+      key: string;
+      shouldGuard: boolean;
+    }
+  | undefined {
+  const url = inputUrl(input, win);
+  if (!url || url.origin !== win.location.origin) return undefined;
+  const method = requestMethod(input, init);
+  return {
+    key: authFailureKey(method, url),
+    shouldGuard: shouldGuardAuthFailure(method, url),
+  };
 }
 
 export function ensureEmbedAuthFetchInterceptor(): void {
@@ -91,25 +254,27 @@ export function ensureEmbedAuthFetchInterceptor(): void {
   installed = true;
 
   const originalFetch = win.fetch.bind(win);
-  win.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+  win.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = requestUrlAndKey(input, init, win);
+    const embedMode = isEmbedAuthActive();
+    if (request?.shouldGuard) {
+      const cached = getCachedAuthFailure(request.key, embedMode);
+      if (cached) return authFailureResponse(cached);
+    }
+
     const token = getEmbedAuthToken();
-    if (!token || !sameOrigin(input, win)) {
-      return originalFetch(input as any, init as any);
+    let fetchInput = input;
+    let fetchInit = init;
+    if (token && sameOrigin(input, win)) {
+      [fetchInput, fetchInit] = withEmbedAuthHeaders(input, init, token, win);
     }
 
-    const headers = new Headers(
-      init?.headers ?? (input instanceof Request ? input.headers : undefined),
-    );
-    if (!headers.has("Authorization")) {
-      headers.set("Authorization", `Bearer ${token}`);
+    const response = await originalFetch(fetchInput as any, fetchInit as any);
+    if (request?.shouldGuard && isAuthFailureStatus(response.status)) {
+      await recordAuthFailure(request.key, response, embedMode || !!token);
+    } else if (request?.shouldGuard && response.ok) {
+      clearAuthFailure(request.key, embedMode || !!token);
     }
-    if (!headers.has(EMBED_TARGET_HEADER)) {
-      headers.set(EMBED_TARGET_HEADER, currentEmbedTarget(win));
-    }
-
-    if (input instanceof Request) {
-      return originalFetch(new Request(input, { ...init, headers }));
-    }
-    return originalFetch(input as any, { ...init, headers });
+    return response;
   }) as typeof fetch;
 }

--- a/packages/core/src/client/use-action.ts
+++ b/packages/core/src/client/use-action.ts
@@ -29,6 +29,24 @@ import { ensureEmbedAuthFetchInterceptor } from "./embed-auth.js";
 
 const ACTION_PREFIX = agentNativePath("/_agent-native/actions");
 
+function isAuthFailure(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    "status" in error &&
+    ((error as { status?: unknown }).status === 401 ||
+      (error as { status?: unknown }).status === 403)
+  );
+}
+
+function defaultActionQueryRetry(
+  failureCount: number,
+  error: unknown,
+): boolean {
+  if (isAuthFailure(error)) return false;
+  return failureCount < 3;
+}
+
 // ---------------------------------------------------------------------------
 // Action type registry — augmented by generated code
 // ---------------------------------------------------------------------------
@@ -224,6 +242,7 @@ export function useActionQuery<
   return useQuery<R>({
     queryKey: ["action", actionName, params],
     queryFn: () => actionFetch<R>(actionName, "GET", params),
+    retry: defaultActionQueryRetry,
     ...options,
   });
 }

--- a/packages/core/src/client/use-db-sync.spec.tsx
+++ b/packages/core/src/client/use-db-sync.spec.tsx
@@ -64,6 +64,7 @@ describe("useDbSync", () => {
     roots = [];
     containers = [];
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it("broadly invalidates active queries for action events", async () => {
@@ -94,5 +95,40 @@ describe("useDbSync", () => {
     expect(result.fetchMock).toHaveBeenCalled();
     expect(result.queryClient.calls).not.toContainEqual(undefined);
     expect(result.queryClient.calls).toContainEqual({ queryKey: ["action"] });
+  });
+
+  it("backs off polling after an auth failure", async () => {
+    vi.useFakeTimers();
+    const queryClient = new QueryClientProbe();
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("Unauthorized", {
+          status: 401,
+          statusText: "Unauthorized",
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    roots.push(root);
+    containers.push(container);
+
+    await act(async () => {
+      root.render(<SyncProbe queryClient={queryClient} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/client/use-db-sync.ts
+++ b/packages/core/src/client/use-db-sync.ts
@@ -13,6 +13,16 @@ interface QueryClient {
 
 const POLL_ABORT_MIN_MS = 10_000;
 const SSE_FALLBACK_INTERVAL_MS = 15_000;
+const POLL_AUTH_FAILURE_COOLDOWN_MS = 60_000;
+
+class HttpStatusError extends Error {
+  status: number;
+
+  constructor(status: number) {
+    super("HTTP " + status);
+    this.status = status;
+  }
+}
 
 type SyncEvent = {
   version?: number;
@@ -74,6 +84,16 @@ function hasAppStateEvent(events: SyncEvent[], key: string): boolean {
   );
 }
 
+function isAuthFailure(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    "status" in error &&
+    ((error as { status?: unknown }).status === 401 ||
+      (error as { status?: unknown }).status === 403)
+  );
+}
+
 async function fetchPollJson<T>(
   pollUrl: string,
   since: number,
@@ -90,7 +110,7 @@ async function fetchPollJson<T>(
       `${pollUrl}?since=${since}`,
       controller ? { signal: controller.signal } : undefined,
     );
-    if (!res.ok) throw new Error("HTTP " + res.status);
+    if (!res.ok) throw new HttpStatusError(res.status);
     // Await the json before the finally so a body-stream abort doesn't
     // produce a dangling promise that escapes as an unhandled rejection.
     return await res.json();
@@ -172,11 +192,24 @@ export function useDbSync(
     let inFlight = false;
     let eventSource: EventSource | null = null;
     let sseConnected = false;
+    let authFailureUntil = 0;
+
+    function authFailureDelayMs(): number {
+      return Math.max(0, authFailureUntil - Date.now());
+    }
 
     function schedulePoll() {
       if (stopped) return;
       if (pauseWhenHidden && isDocumentHidden()) return;
       if (timer) clearTimeout(timer);
+      const authDelay = authFailureDelayMs();
+      if (authDelay > 0) {
+        timer = setTimeout(() => {
+          timer = null;
+          void poll();
+        }, authDelay);
+        return;
+      }
       timer = setTimeout(
         () => {
           timer = null;
@@ -316,7 +349,11 @@ export function useDbSync(
           interval,
         );
         applyEvents(data.events ?? [], data.version);
-      } catch {
+      } catch (err) {
+        if (isAuthFailure(err)) {
+          authFailureUntil = Date.now() + POLL_AUTH_FAILURE_COOLDOWN_MS;
+          closeEvents();
+        }
         // Network error — will retry on next interval
       } finally {
         inFlight = false;
@@ -326,6 +363,10 @@ export function useDbSync(
 
     function pollNow() {
       if (pauseWhenHidden && isDocumentHidden()) {
+        return;
+      }
+      if (authFailureDelayMs() > 0) {
+        schedulePoll();
         return;
       }
       if (timer) {
@@ -424,11 +465,24 @@ export function useScreenRefreshKey(
     let inFlight = false;
     let eventSource: EventSource | null = null;
     let sseConnected = false;
+    let authFailureUntil = 0;
+
+    function authFailureDelayMs(): number {
+      return Math.max(0, authFailureUntil - Date.now());
+    }
 
     function schedulePoll() {
       if (stopped) return;
       if (pauseWhenHidden && isDocumentHidden()) return;
       if (timer) clearTimeout(timer);
+      const authDelay = authFailureDelayMs();
+      if (authDelay > 0) {
+        timer = setTimeout(() => {
+          timer = null;
+          void poll();
+        }, authDelay);
+        return;
+      }
       timer = setTimeout(
         () => {
           timer = null;
@@ -504,7 +558,11 @@ export function useScreenRefreshKey(
           interval,
         );
         applyEvents(data.events ?? [], data.version);
-      } catch {
+      } catch (err) {
+        if (isAuthFailure(err)) {
+          authFailureUntil = Date.now() + POLL_AUTH_FAILURE_COOLDOWN_MS;
+          closeEvents();
+        }
         // Network error — retry on next interval.
       } finally {
         inFlight = false;
@@ -514,6 +572,10 @@ export function useScreenRefreshKey(
 
     function pollNow() {
       if (pauseWhenHidden && isDocumentHidden()) {
+        return;
+      }
+      if (authFailureDelayMs() > 0) {
+        schedulePoll();
         return;
       }
       if (timer) {

--- a/packages/core/src/mcp/builtin-cross-app.spec.ts
+++ b/packages/core/src/mcp/builtin-cross-app.spec.ts
@@ -160,7 +160,7 @@ describe("open_app — same-app / standalone keeps a relative deep link", () => 
     expect(result.embed).toBe(true);
   });
 
-  it("requests the largest full-app MCP App height we support", () => {
+  it("requests a 720px app viewport for full-app MCP App embeds", () => {
     const tools = getBuiltinCrossAppTools(baseConfig());
     const resource = tools.open_app.mcpApp?.resource;
     const html =
@@ -168,7 +168,8 @@ describe("open_app — same-app / standalone keeps a relative deep link", () => 
         ? resource.html({ actionName: "open_app", appId: "mail" })
         : resource?.html;
 
-    expect(html).toContain("min-height: 900px");
+    expect(html).toContain("min-height: 764px");
+    expect(html).toContain("height: 720px");
   });
 
   it("accepts string embed:true from MCP clients that stringify arguments", async () => {

--- a/packages/core/src/mcp/builtin-tools.ts
+++ b/packages/core/src/mcp/builtin-tools.ts
@@ -351,7 +351,6 @@ function openAppTool(config: MCPConfig): ActionEntry {
         description: "Render the requested app route inline.",
         iframeTitle: "Agent Native app",
         openLabel: "Open app",
-        height: 900,
       }),
     },
   };

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -35,7 +35,8 @@ describe("embedApp", () => {
     expect(html).toContain(
       'toolInput.embed === false || toolInput.embed === "false"',
     );
-    expect(html).toContain("min-height: 900px");
+    expect(html).toContain("min-height: 764px");
+    expect(html).toContain("height: 720px");
     expect(resource.csp?.frameDomains).toContain(
       MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
     );

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -40,6 +40,9 @@ describe("embedApp", () => {
     expect(resource.csp?.frameDomains).toContain(
       MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
     );
+    expect(resource.csp?.resourceDomains).toContain(
+      MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
+    );
     expect(resource.csp?.resourceDomains).toContain("https://esm.sh");
   });
 
@@ -76,6 +79,10 @@ describe("embedApp", () => {
             prefersBorder: false,
             csp: {
               frameDomains: [MCP_APP_REQUEST_ORIGIN_CSP_SOURCE],
+              resourceDomains: [
+                "https://esm.sh",
+                MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
+              ],
             },
           },
         },

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -373,7 +373,11 @@ export function embedApp(
 </html>`,
     csp: {
       connectDomains: ["https://esm.sh"],
-      resourceDomains: ["https://esm.sh"],
+      resourceDomains: [
+        "https://esm.sh",
+        MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
+        ...(options.frameDomains ?? []),
+      ],
       frameDomains: [
         MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
         ...(options.frameDomains ?? []),

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -5,6 +5,10 @@ const MCP_APP_IMPORT =
   "https://esm.sh/@modelcontextprotocol/ext-apps@1.7.2/app-with-deps";
 
 export const MCP_APP_REQUEST_ORIGIN_CSP_SOURCE = "$requestOrigin";
+const MCP_APP_WRAPPER_CHROME_HEIGHT = 44;
+export const DEFAULT_MCP_APP_VIEWPORT_HEIGHT = 720;
+export const DEFAULT_MCP_APP_SHELL_HEIGHT =
+  DEFAULT_MCP_APP_VIEWPORT_HEIGHT + MCP_APP_WRAPPER_CHROME_HEIGHT;
 
 export interface EmbedAppOptions {
   title?: string;
@@ -33,7 +37,11 @@ export function embedApp(
   const openLabel = options.openLabel ?? "Open in app";
   const startToolName = options.startToolName ?? "create_embed_session";
   const embedByDefault = options.embedByDefault !== false;
-  const height = Math.max(320, Math.min(900, options.height ?? 900));
+  const height = Math.max(
+    320,
+    Math.min(900, options.height ?? DEFAULT_MCP_APP_SHELL_HEIGHT),
+  );
+  const viewportHeight = height - MCP_APP_WRAPPER_CHROME_HEIGHT;
 
   return {
     title,
@@ -53,9 +61,9 @@ export function embedApp(
     .actions { display: flex; align-items: center; gap: 6px; }
     button { min-height: 28px; border: 1px solid color-mix(in srgb, CanvasText 14%, Canvas); border-radius: 7px; background: Canvas; color: CanvasText; cursor: pointer; font: inherit; font-size: 12px; font-weight: 700; padding: 0 9px; }
     button:disabled { opacity: .55; cursor: default; }
-    .stage { position: relative; min-height: ${height - 44}px; }
-    iframe { display: block; width: 100%; height: ${height - 44}px; border: 0; background: Canvas; }
-    .message { display: grid; place-items: center; min-height: ${height - 44}px; padding: 18px; color: color-mix(in srgb, CanvasText 62%, Canvas); font-size: 13px; line-height: 1.45; text-align: center; }
+    .stage { position: relative; min-height: ${viewportHeight}px; }
+    iframe { display: block; width: 100%; height: ${viewportHeight}px; border: 0; background: Canvas; }
+    .message { display: grid; place-items: center; min-height: ${viewportHeight}px; padding: 18px; color: color-mix(in srgb, CanvasText 62%, Canvas); font-size: 13px; line-height: 1.45; text-align: center; }
   </style>
 </head>
 <body

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -14,6 +14,7 @@ import {
 import type { H3Event } from "h3";
 import type { H3AppShim } from "./framework-request-handler.js";
 import { EMBED_START_PATH } from "../shared/embed-auth.js";
+import { EMBED_TARGET_HEADER } from "../shared/embed-auth.js";
 import { resolveEmbedSessionFromRequest } from "./embed-session.js";
 
 // In h3 v2, `event.req` IS the web Request — but in Nitro's dev server (srvx
@@ -1100,7 +1101,14 @@ function applyCorsHeaders(event: H3Event): {
   setResponseHeader(
     event,
     "Access-Control-Allow-Headers",
-    "Content-Type,Authorization,X-Requested-With,X-Request-Source,X-Agent-Native-CSRF",
+    [
+      "Content-Type",
+      "Authorization",
+      "X-Requested-With",
+      "X-Request-Source",
+      "X-Agent-Native-CSRF",
+      EMBED_TARGET_HEADER,
+    ].join(","),
   );
   return { hasOrigin: true, allowed: true };
 }

--- a/packages/core/src/server/embed-route.spec.ts
+++ b/packages/core/src/server/embed-route.spec.ts
@@ -46,6 +46,9 @@ describe("createEmbedStartRouteHandler", () => {
 
     expect(res.status).toBe(204);
     expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe(
+      "cross-origin",
+    );
     expect(consumeEmbedSessionTicket).not.toHaveBeenCalled();
     expect(setEmbedSessionCookie).not.toHaveBeenCalled();
   });
@@ -72,6 +75,9 @@ describe("createEmbedStartRouteHandler", () => {
     expect(res.status).toBe(302);
     expect(res.headers.get("Location")).toBe(
       "/inbox?embedded=1&__an_embed_token=signed-token&agentSidebar=closed",
+    );
+    expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe(
+      "cross-origin",
     );
   });
 });

--- a/packages/core/src/server/embed-route.spec.ts
+++ b/packages/core/src/server/embed-route.spec.ts
@@ -52,6 +52,7 @@ describe("createEmbedStartRouteHandler", () => {
     expect(res.headers.get("Cross-Origin-Embedder-Policy")).toBe(
       "require-corp",
     );
+    expect(res.headers.get("Cross-Origin-Opener-Policy")).toBe("same-origin");
     expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe(
       "cross-origin",
     );
@@ -59,6 +60,11 @@ describe("createEmbedStartRouteHandler", () => {
       expect.anything(),
       "Cross-Origin-Embedder-Policy",
       "require-corp",
+    );
+    expect(setResponseHeader).toHaveBeenCalledWith(
+      expect.anything(),
+      "Cross-Origin-Opener-Policy",
+      "same-origin",
     );
     expect(setResponseHeader).toHaveBeenCalledWith(
       expect.anything(),
@@ -95,6 +101,7 @@ describe("createEmbedStartRouteHandler", () => {
     expect(res.headers.get("Cross-Origin-Embedder-Policy")).toBe(
       "require-corp",
     );
+    expect(res.headers.get("Cross-Origin-Opener-Policy")).toBe("same-origin");
     expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe(
       "cross-origin",
     );
@@ -102,6 +109,11 @@ describe("createEmbedStartRouteHandler", () => {
       expect.anything(),
       "Cross-Origin-Embedder-Policy",
       "require-corp",
+    );
+    expect(setResponseHeader).toHaveBeenCalledWith(
+      expect.anything(),
+      "Cross-Origin-Opener-Policy",
+      "same-origin",
     );
     expect(setResponseHeader).toHaveBeenCalledWith(
       expect.anything(),

--- a/packages/core/src/server/embed-route.spec.ts
+++ b/packages/core/src/server/embed-route.spec.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const setResponseHeader = vi.hoisted(() => vi.fn());
+
 vi.mock("h3", () => ({
   defineEventHandler: (handler: any) => handler,
   getMethod: (event: any) => event.method ?? "GET",
   getQuery: (event: any) => event.query ?? {},
-  setResponseHeader: vi.fn(),
+  setResponseHeader: (...a: any[]) => setResponseHeader(...a),
 }));
 
 const consumeEmbedSessionTicket = vi.hoisted(() => vi.fn());
@@ -35,6 +37,7 @@ describe("createEmbedStartRouteHandler", () => {
   beforeEach(() => {
     consumeEmbedSessionTicket.mockReset();
     setEmbedSessionCookie.mockReset();
+    setResponseHeader.mockReset();
   });
 
   it("does not consume one-time embed tickets for HEAD probes", async () => {
@@ -50,6 +53,16 @@ describe("createEmbedStartRouteHandler", () => {
       "require-corp",
     );
     expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe(
+      "cross-origin",
+    );
+    expect(setResponseHeader).toHaveBeenCalledWith(
+      expect.anything(),
+      "Cross-Origin-Embedder-Policy",
+      "require-corp",
+    );
+    expect(setResponseHeader).toHaveBeenCalledWith(
+      expect.anything(),
+      "Cross-Origin-Resource-Policy",
       "cross-origin",
     );
     expect(consumeEmbedSessionTicket).not.toHaveBeenCalled();
@@ -83,6 +96,16 @@ describe("createEmbedStartRouteHandler", () => {
       "require-corp",
     );
     expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe(
+      "cross-origin",
+    );
+    expect(setResponseHeader).toHaveBeenCalledWith(
+      expect.anything(),
+      "Cross-Origin-Embedder-Policy",
+      "require-corp",
+    );
+    expect(setResponseHeader).toHaveBeenCalledWith(
+      expect.anything(),
+      "Cross-Origin-Resource-Policy",
       "cross-origin",
     );
   });

--- a/packages/core/src/server/embed-route.spec.ts
+++ b/packages/core/src/server/embed-route.spec.ts
@@ -46,6 +46,9 @@ describe("createEmbedStartRouteHandler", () => {
 
     expect(res.status).toBe(204);
     expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Cross-Origin-Embedder-Policy")).toBe(
+      "require-corp",
+    );
     expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe(
       "cross-origin",
     );
@@ -75,6 +78,9 @@ describe("createEmbedStartRouteHandler", () => {
     expect(res.status).toBe(302);
     expect(res.headers.get("Location")).toBe(
       "/inbox?embedded=1&__an_embed_token=signed-token&agentSidebar=closed",
+    );
+    expect(res.headers.get("Cross-Origin-Embedder-Policy")).toBe(
+      "require-corp",
     );
     expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe(
       "cross-origin",

--- a/packages/core/src/server/embed-route.ts
+++ b/packages/core/src/server/embed-route.ts
@@ -34,7 +34,10 @@ function redirectWithStagedCookies(
   location: string,
   status = 302,
 ): Response {
-  const headers = new Headers({ Location: location });
+  const headers = new Headers({
+    "Cross-Origin-Resource-Policy": "cross-origin",
+    Location: location,
+  });
   const staged = event.res?.headers?.getSetCookie?.() ?? [];
   for (const cookie of staged) headers.append("set-cookie", cookie);
   headers.set("Referrer-Policy", "no-referrer");
@@ -44,7 +47,10 @@ function redirectWithStagedCookies(
 function textResponse(message: string, status: number): Response {
   return new Response(message, {
     status,
-    headers: { "Content-Type": "text/plain; charset=utf-8" },
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cross-Origin-Resource-Policy": "cross-origin",
+    },
   });
 }
 
@@ -65,7 +71,10 @@ export function createEmbedStartRouteHandler(
     if (method === "HEAD") {
       return new Response(null, {
         status: 204,
-        headers: { "Cache-Control": "no-store" },
+        headers: {
+          "Cache-Control": "no-store",
+          "Cross-Origin-Resource-Policy": "cross-origin",
+        },
       });
     }
 

--- a/packages/core/src/server/embed-route.ts
+++ b/packages/core/src/server/embed-route.ts
@@ -34,6 +34,7 @@ function redirectWithStagedCookies(
   location: string,
   status = 302,
 ): Response {
+  setEmbedStartResponseHeaders(event);
   const headers = new Headers({
     "Cross-Origin-Embedder-Policy": "require-corp",
     "Cross-Origin-Resource-Policy": "cross-origin",
@@ -45,7 +46,17 @@ function redirectWithStagedCookies(
   return new Response("", { status, headers });
 }
 
-function textResponse(message: string, status: number): Response {
+function setEmbedStartResponseHeaders(event: H3Event): void {
+  setResponseHeader(event, "Cross-Origin-Embedder-Policy", "require-corp");
+  setResponseHeader(event, "Cross-Origin-Resource-Policy", "cross-origin");
+}
+
+function textResponse(
+  event: H3Event,
+  message: string,
+  status: number,
+): Response {
+  setEmbedStartResponseHeaders(event);
   return new Response(message, {
     status,
     headers: {
@@ -71,6 +82,7 @@ export function createEmbedStartRouteHandler(
   return defineEventHandler(async (event: H3Event) => {
     const method = getMethod(event);
     if (method === "HEAD") {
+      setEmbedStartResponseHeaders(event);
       return new Response(null, {
         status: 204,
         headers: {
@@ -82,7 +94,7 @@ export function createEmbedStartRouteHandler(
     }
 
     if (method !== "GET") {
-      return textResponse("Method not allowed", 405);
+      return textResponse(event, "Method not allowed", 405);
     }
 
     const rawTicket = getQuery(event)?.ticket;
@@ -94,12 +106,12 @@ export function createEmbedStartRouteHandler(
       expectedOrgId: existingSession?.orgId ?? null,
     });
     if (!consumed) {
-      return textResponse("Invalid or expired embed session.", 401);
+      return textResponse(event, "Invalid or expired embed session.", 401);
     }
 
     const target = normalizeEmbedTargetPath(consumed.targetPath);
     if (!target) {
-      return textResponse("Invalid embed target.", 400);
+      return textResponse(event, "Invalid embed target.", 400);
     }
 
     const token = signEmbedSessionToken({

--- a/packages/core/src/server/embed-route.ts
+++ b/packages/core/src/server/embed-route.ts
@@ -35,6 +35,7 @@ function redirectWithStagedCookies(
   status = 302,
 ): Response {
   const headers = new Headers({
+    "Cross-Origin-Embedder-Policy": "require-corp",
     "Cross-Origin-Resource-Policy": "cross-origin",
     Location: location,
   });
@@ -49,6 +50,7 @@ function textResponse(message: string, status: number): Response {
     status,
     headers: {
       "Content-Type": "text/plain; charset=utf-8",
+      "Cross-Origin-Embedder-Policy": "require-corp",
       "Cross-Origin-Resource-Policy": "cross-origin",
     },
   });
@@ -73,6 +75,7 @@ export function createEmbedStartRouteHandler(
         status: 204,
         headers: {
           "Cache-Control": "no-store",
+          "Cross-Origin-Embedder-Policy": "require-corp",
           "Cross-Origin-Resource-Policy": "cross-origin",
         },
       });

--- a/packages/core/src/server/embed-route.ts
+++ b/packages/core/src/server/embed-route.ts
@@ -37,6 +37,7 @@ function redirectWithStagedCookies(
   setEmbedStartResponseHeaders(event);
   const headers = new Headers({
     "Cross-Origin-Embedder-Policy": "require-corp",
+    "Cross-Origin-Opener-Policy": "same-origin",
     "Cross-Origin-Resource-Policy": "cross-origin",
     Location: location,
   });
@@ -48,6 +49,7 @@ function redirectWithStagedCookies(
 
 function setEmbedStartResponseHeaders(event: H3Event): void {
   setResponseHeader(event, "Cross-Origin-Embedder-Policy", "require-corp");
+  setResponseHeader(event, "Cross-Origin-Opener-Policy", "same-origin");
   setResponseHeader(event, "Cross-Origin-Resource-Policy", "cross-origin");
 }
 
@@ -62,6 +64,7 @@ function textResponse(
     headers: {
       "Content-Type": "text/plain; charset=utf-8",
       "Cross-Origin-Embedder-Policy": "require-corp",
+      "Cross-Origin-Opener-Policy": "same-origin",
       "Cross-Origin-Resource-Policy": "cross-origin",
     },
   });
@@ -88,6 +91,7 @@ export function createEmbedStartRouteHandler(
         headers: {
           "Cache-Control": "no-store",
           "Cross-Origin-Embedder-Policy": "require-corp",
+          "Cross-Origin-Opener-Policy": "same-origin",
           "Cross-Origin-Resource-Policy": "cross-origin",
         },
       });

--- a/packages/core/src/server/embed-session.spec.ts
+++ b/packages/core/src/server/embed-session.spec.ts
@@ -283,6 +283,14 @@ describe("requestMatchesEmbedTarget", () => {
         "/_agent-native/open?app=mail&view=inbox",
       ),
     ).toBe(true);
+    expect(
+      requestMatchesEmbedTarget(
+        fakeEvent("/api/emails?view=inbox&limit=25", {
+          [EMBED_TARGET_HEADER]: "/inbox?embedded=1",
+        }),
+        "/_agent-native/open?app=mail&view=inbox",
+      ),
+    ).toBe(true);
 
     expect(
       requestMatchesEmbedTarget(

--- a/packages/core/src/server/embed-session.spec.ts
+++ b/packages/core/src/server/embed-session.spec.ts
@@ -2,10 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   requestMatchesEmbedTarget,
   normalizeEmbedTargetPath,
+  resolveEmbedSessionFromRequest,
   signEmbedSessionToken,
   verifyEmbedSessionToken,
 } from "./embed-session.js";
-import { EMBED_TARGET_HEADER } from "../shared/embed-auth.js";
+import {
+  EMBED_SESSION_COOKIE,
+  EMBED_TARGET_HEADER,
+} from "../shared/embed-auth.js";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -109,6 +113,7 @@ describe("requestMatchesEmbedTarget", () => {
   function fakeEvent(path: string, headers: Record<string, string> = {}) {
     return {
       path,
+      req: { url: `http://mail.test${path}`, headers: new Headers(headers) },
       request: { headers: new Headers(headers) },
       headers: new Headers(headers),
       node: { req: { url: path, headers } },
@@ -300,5 +305,35 @@ describe("requestMatchesEmbedTarget", () => {
         "/_agent-native/open?app=mail&view=inbox",
       ),
     ).toBe(false);
+  });
+
+  it("allows app runtime requests with the embed cookie when referrer headers are unavailable", async () => {
+    process.env.OAUTH_STATE_SECRET = "embed-test-secret";
+    const token = signEmbedSessionToken({
+      ownerEmail: "owner@example.com",
+      orgId: "org_123",
+      targetPath: "/inbox?__an_mcp_chat_bridge=1",
+      ttlSeconds: 60,
+    });
+
+    const runtimeSession = await resolveEmbedSessionFromRequest(
+      fakeEvent("/api/emails?view=inbox&limit=25", {
+        cookie: `${EMBED_SESSION_COOKIE}=${token}`,
+      }),
+    );
+
+    expect(runtimeSession).toMatchObject({
+      email: "owner@example.com",
+      orgId: "org_123",
+      targetPath: "/inbox?__an_mcp_chat_bridge=1",
+    });
+
+    await expect(
+      resolveEmbedSessionFromRequest(
+        fakeEvent("/settings", {
+          cookie: `${EMBED_SESSION_COOKIE}=${token}`,
+        }),
+      ),
+    ).resolves.toBeNull();
   });
 });

--- a/packages/core/src/server/embed-session.ts
+++ b/packages/core/src/server/embed-session.ts
@@ -417,6 +417,17 @@ export function requestMatchesEmbedTarget(
   return !!referrerTarget && allowed.has(referrerTarget);
 }
 
+function isEmbedRuntimeRequest(event: H3Event): boolean {
+  const pathname = requestPathname(event);
+  return (
+    !!pathname &&
+    (pathname === "/api" ||
+      pathname.startsWith("/api/") ||
+      pathname === "/_agent-native" ||
+      pathname.startsWith("/_agent-native/"))
+  );
+}
+
 export function normalizeEmbedTargetPath(
   raw: string | undefined | null,
   requestOrigin?: string,
@@ -676,7 +687,13 @@ export async function resolveEmbedSessionFromRequest(
   for (const candidate of candidates) {
     const verified = verifyEmbedSessionToken(candidate.token);
     if (!verified.ok) continue;
-    if (!requestMatchesEmbedTarget(event, verified.claims.targetPath)) {
+    const matchesTarget = requestMatchesEmbedTarget(
+      event,
+      verified.claims.targetPath,
+    );
+    const isRuntimeCookieRequest =
+      candidate.source === "cookie" && isEmbedRuntimeRequest(event);
+    if (!matchesTarget && !isRuntimeCookieRequest) {
       continue;
     }
     if (candidate.source === "query" && candidate.token) {

--- a/packages/core/src/server/security-headers.spec.ts
+++ b/packages/core/src/server/security-headers.spec.ts
@@ -24,6 +24,7 @@ describe("security headers middleware", () => {
     expect(headers.get("Permissions-Policy")).toBe(
       "camera=(), microphone=(self), geolocation=(), screen-wake-lock=()",
     );
+    expect(headers.get("Cross-Origin-Embedder-Policy")).toBeUndefined();
     expect(headers.get("Cross-Origin-Resource-Policy")).toBe("same-site");
   });
 
@@ -47,6 +48,7 @@ describe("security headers middleware", () => {
 
     expect(headers.get("X-Frame-Options")).toBeUndefined();
     expect(headers.get("Referrer-Policy")).toBe("no-referrer");
+    expect(headers.get("Cross-Origin-Embedder-Policy")).toBe("require-corp");
     expect(headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
     vi.unstubAllEnvs();
   });

--- a/packages/core/src/server/security-headers.spec.ts
+++ b/packages/core/src/server/security-headers.spec.ts
@@ -24,9 +24,10 @@ describe("security headers middleware", () => {
     expect(headers.get("Permissions-Policy")).toBe(
       "camera=(), microphone=(self), geolocation=(), screen-wake-lock=()",
     );
+    expect(headers.get("Cross-Origin-Resource-Policy")).toBe("same-site");
   });
 
-  it("omits X-Frame-Options for embed-token page loads in production", () => {
+  it("relaxes frame headers for embed-token page loads in production", () => {
     headers.clear();
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("OAUTH_STATE_SECRET", "embed-test-secret");
@@ -46,6 +47,7 @@ describe("security headers middleware", () => {
 
     expect(headers.get("X-Frame-Options")).toBeUndefined();
     expect(headers.get("Referrer-Policy")).toBe("no-referrer");
+    expect(headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
     vi.unstubAllEnvs();
   });
 });

--- a/packages/core/src/server/security-headers.ts
+++ b/packages/core/src/server/security-headers.ts
@@ -35,6 +35,9 @@
  *     override this on their own routes.
  *   - `Cross-Origin-Opener-Policy: same-origin` — isolates window.opener so
  *     a popup-window opener reference can't read or modify our document.
+ *   - `Cross-Origin-Embedder-Policy: require-corp` — emitted only for
+ *     validated MCP embed-session page loads. COEP hosts such as Claude's MCP
+ *     Apps proxy require framed cross-origin documents to opt in explicitly.
  *   - `Cross-Origin-Resource-Policy: same-site` — prevents other origins from
  *     embedding our endpoints as `<img>` / `<script>` / `<audio>`, blocking
  *     the simplest data-leak chain when combined with auth cookies. Validated
@@ -97,6 +100,9 @@ export function createSecurityHeadersMiddleware() {
     );
     setResponseHeader(event, "Permissions-Policy", PERMISSIONS_POLICY);
     setResponseHeader(event, "Cross-Origin-Opener-Policy", "same-origin");
+    if (embedFrameRequest) {
+      setResponseHeader(event, "Cross-Origin-Embedder-Policy", "require-corp");
+    }
     setResponseHeader(
       event,
       "Cross-Origin-Resource-Policy",

--- a/packages/core/src/server/security-headers.ts
+++ b/packages/core/src/server/security-headers.ts
@@ -37,7 +37,9 @@
  *     a popup-window opener reference can't read or modify our document.
  *   - `Cross-Origin-Resource-Policy: same-site` — prevents other origins from
  *     embedding our endpoints as `<img>` / `<script>` / `<audio>`, blocking
- *     the simplest data-leak chain when combined with auth cookies.
+ *     the simplest data-leak chain when combined with auth cookies. Validated
+ *     MCP embed-session page loads use `cross-origin` so COEP hosts such as
+ *     Claude's MCP Apps proxy can frame the short-lived app document.
  *
  * NOTE: We don't set `Cross-Origin-Embedder-Policy` because it requires every
  * embedded subresource to opt in via CORP/CORS, which would break Builder's
@@ -95,7 +97,11 @@ export function createSecurityHeadersMiddleware() {
     );
     setResponseHeader(event, "Permissions-Policy", PERMISSIONS_POLICY);
     setResponseHeader(event, "Cross-Origin-Opener-Policy", "same-origin");
-    setResponseHeader(event, "Cross-Origin-Resource-Policy", "same-site");
+    setResponseHeader(
+      event,
+      "Cross-Origin-Resource-Policy",
+      embedFrameRequest ? "cross-origin" : "same-site",
+    );
     if (isHttpsRequest(event)) {
       setResponseHeader(event, "Strict-Transport-Security", HSTS);
     }

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -90,6 +90,70 @@ describe("Vite optimized dependency recovery", () => {
   });
 });
 
+describe("Vite MCP embed headers", () => {
+  it("adds COEP-compatible headers to embed-token page loads in dev", () => {
+    const plugin = findPlugin("agent-native-embed-dev-frame-headers");
+    let middleware: Function | null = null;
+    const server = {
+      middlewares: {
+        use: vi.fn((fn: Function) => {
+          middleware = fn;
+        }),
+      },
+    };
+
+    plugin.configureServer(server);
+    expect(middleware).toBeTypeOf("function");
+
+    const setHeader = vi.fn();
+    middleware!(
+      { url: "/inbox?embedded=1&__an_embed_token=tok", headers: {} },
+      { setHeader },
+      vi.fn(),
+    );
+
+    expect(setHeader).toHaveBeenCalledWith(
+      "Cross-Origin-Embedder-Policy",
+      "require-corp",
+    );
+    expect(setHeader).toHaveBeenCalledWith(
+      "Cross-Origin-Resource-Policy",
+      "cross-origin",
+    );
+    expect(setHeader).toHaveBeenCalledWith("Referrer-Policy", "no-referrer");
+  });
+
+  it("adds the same headers when an embed session cookie is present", () => {
+    const plugin = findPlugin("agent-native-embed-dev-frame-headers");
+    let middleware: Function | null = null;
+    const server = {
+      middlewares: {
+        use: vi.fn((fn: Function) => {
+          middleware = fn;
+        }),
+      },
+    };
+
+    plugin.configureServer(server);
+
+    const setHeader = vi.fn();
+    middleware!(
+      { url: "/inbox", headers: { cookie: "an_embed_session=tok" } },
+      { setHeader },
+      vi.fn(),
+    );
+
+    expect(setHeader).toHaveBeenCalledWith(
+      "Cross-Origin-Embedder-Policy",
+      "require-corp",
+    );
+    expect(setHeader).toHaveBeenCalledWith(
+      "Cross-Origin-Resource-Policy",
+      "cross-origin",
+    );
+  });
+});
+
 describe("Vite connection reset noise", () => {
   it("suppresses benign reset errors before they reach the browser overlay", () => {
     const plugin = findPlugin("agent-native-silence-connection-resets");

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -117,6 +117,10 @@ describe("Vite MCP embed headers", () => {
       "require-corp",
     );
     expect(setHeader).toHaveBeenCalledWith(
+      "Cross-Origin-Opener-Policy",
+      "same-origin",
+    );
+    expect(setHeader).toHaveBeenCalledWith(
       "Cross-Origin-Resource-Policy",
       "cross-origin",
     );
@@ -146,6 +150,10 @@ describe("Vite MCP embed headers", () => {
     expect(setHeader).toHaveBeenCalledWith(
       "Cross-Origin-Embedder-Policy",
       "require-corp",
+    );
+    expect(setHeader).toHaveBeenCalledWith(
+      "Cross-Origin-Opener-Policy",
+      "same-origin",
     );
     expect(setHeader).toHaveBeenCalledWith(
       "Cross-Origin-Resource-Policy",

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -640,6 +640,7 @@ function embedDevFrameHeaders(): Plugin {
         }
         if (hasEmbedMarker) {
           res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+          res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
           res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
           res.setHeader("Referrer-Policy", "no-referrer");
         }

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -623,6 +623,32 @@ function baseRedirectGuard(): Plugin {
   };
 }
 
+function embedDevFrameHeaders(): Plugin {
+  return {
+    name: "agent-native-embed-dev-frame-headers",
+    apply: "serve",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const cookieHeader = String(req.headers.cookie ?? "");
+        let hasEmbedMarker = /\ban_embed_session=/.test(cookieHeader);
+        try {
+          const url = new URL(req.url ?? "/", "http://agent-native.local");
+          hasEmbedMarker =
+            hasEmbedMarker || url.searchParams.has("__an_embed_token");
+        } catch {
+          // Malformed URLs should continue through Vite's normal handling.
+        }
+        if (hasEmbedMarker) {
+          res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+          res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
+          res.setHeader("Referrer-Policy", "no-referrer");
+        }
+        next();
+      });
+    },
+  };
+}
+
 function contentTypeForPublicFile(filePath: string): string | null {
   switch (path.extname(filePath).toLowerCase()) {
     case ".css":
@@ -1058,6 +1084,7 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
       agentsBundlePlugin(),
       autoReloadOnOptimizeDep(),
       fullReloadOnOptimizeDep504(),
+      embedDevFrameHeaders(),
       baseRedirectGuard(),
       portExposer(),
       silenceConnectionResets(),

--- a/packages/dispatch/src/actions/open_app.ts
+++ b/packages/dispatch/src/actions/open_app.ts
@@ -62,7 +62,6 @@ export default defineAction({
       iframeTitle: "Dispatch MCP app",
       openLabel: "Open app",
       frameDomains: ["https:", "http://localhost:*", "http://127.0.0.1:*"],
-      height: 900,
     }),
   },
 });

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -136,6 +136,7 @@ type AvailabilityContext = {
 
 type ConflictItem = { start: string; end: string };
 type BookingLinkRow = typeof schema.bookingLinks.$inferSelect;
+type ConflictDb = Pick<ReturnType<typeof getDb>, "select">;
 
 type LocalDateTimeParts = {
   year: number;
@@ -393,11 +394,13 @@ async function resolveAvailabilityContext(
 }
 
 async function getConflictItems({
+  db = getDb(),
   ownerEmail,
   conflictSlugs,
   rangeStartIso,
   rangeEndIso,
 }: {
+  db?: ConflictDb;
   ownerEmail?: string;
   conflictSlugs: string[];
   rangeStartIso: string;
@@ -423,7 +426,7 @@ async function getConflictItems({
     }
   }
 
-  const bookings = await getDb()
+  const bookings = await db
     .select()
     .from(schema.bookings)
     .where(
@@ -552,11 +555,13 @@ function generateAvailableSlotsForDate({
 }
 
 async function requestedSlotIsCurrentlyAvailable({
+  db,
   slug,
   start,
   end,
   duration,
 }: {
+  db?: ConflictDb;
   slug: string;
   start: Date;
   end: Date;
@@ -568,6 +573,7 @@ async function requestedSlotIsCurrentlyAvailable({
   const timezone = context.effectiveConfig.timezone || "UTC";
   const date = formatLocalDateInTimezone(start, timezone);
   const conflictItems = await getConflictItems({
+    db,
     ownerEmail: context.ownerEmail,
     conflictSlugs: context.conflictSlugs,
     rangeStartIso: dateStartIso(date, timezone),
@@ -783,6 +789,7 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
 
       if (
         !(await requestedSlotIsCurrentlyAvailable({
+          db: tx,
           slug: requestedSlug,
           start: requestedRange.start,
           end: requestedRange.end,

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -57,8 +57,9 @@ async function requireRequestContext<T>(
 
 async function getBookingLinkSlugsForOwner(
   ownerEmail: string,
+  db: ConflictDb = getDb(),
 ): Promise<string[]> {
-  const rows = await getDb()
+  const rows = await db
     .select({ slug: schema.bookingLinks.slug })
     .from(schema.bookingLinks)
     .where(eq(schema.bookingLinks.ownerEmail, ownerEmail));
@@ -348,14 +349,18 @@ function dateEndIso(date: string, timezone: string): string {
   ).toISOString();
 }
 
-async function resolveAvailabilityContext(
-  slug: string,
-): Promise<AvailabilityContext> {
+async function resolveAvailabilityContext({
+  slug,
+  db = getDb(),
+}: {
+  slug: string;
+  db?: ConflictDb;
+}): Promise<AvailabilityContext> {
   const config = (await getSetting(
     "calendar-availability",
   )) as unknown as AvailabilityConfig | null;
   const bookingLink = slug
-    ? await getDb()
+    ? await db
         .select()
         .from(schema.bookingLinks)
         .where(eq(schema.bookingLinks.slug, slug))
@@ -374,7 +379,7 @@ async function resolveAvailabilityContext(
       } | null)
     : null;
   const conflictSlugs = ownerEmail
-    ? await getBookingLinkSlugsForOwner(ownerEmail)
+    ? await getBookingLinkSlugsForOwner(ownerEmail, db)
     : slug
       ? [slug]
       : [];
@@ -567,7 +572,7 @@ async function requestedSlotIsCurrentlyAvailable({
   end: Date;
   duration: number;
 }): Promise<boolean> {
-  const context = await resolveAvailabilityContext(slug);
+  const context = await resolveAvailabilityContext({ slug, db });
   if (!context.effectiveConfig) return false;
 
   const timezone = context.effectiveConfig.timezone || "UTC";
@@ -774,11 +779,6 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
 
     // Check for conflicts + insert atomically in a transaction
     const db = getDb();
-    const conflictSlugs = bookingLink?.ownerEmail
-      ? await getBookingLinkSlugsForOwner(bookingLink.ownerEmail)
-      : requestedSlug
-        ? [requestedSlug]
-        : [];
     const insertResult = await db.transaction(async (tx) => {
       // Serialize booking creation per host. The no-op write takes a row lock
       // on all of the host's booking links without changing user-visible data.
@@ -786,6 +786,12 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
         .update(schema.bookingLinks)
         .set({ ownerEmail: hostEmail })
         .where(eq(schema.bookingLinks.ownerEmail, hostEmail));
+
+      const conflictSlugs = bookingLink?.ownerEmail
+        ? await getBookingLinkSlugsForOwner(bookingLink.ownerEmail, tx)
+        : requestedSlug
+          ? [requestedSlug]
+          : [];
 
       if (
         !(await requestedSlotIsCurrentlyAvailable({
@@ -1061,7 +1067,7 @@ export const getAvailableSlots = defineEventHandler(async (event: H3Event) => {
       return { error: "date query parameter is required" };
     }
 
-    const context = await resolveAvailabilityContext(slug);
+    const context = await resolveAvailabilityContext({ slug });
     if (!context.effectiveConfig) {
       return hasRangeQuery ? { dates: [] } : { slots: [] };
     }

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -8,7 +8,7 @@ import {
   type H3Event,
 } from "h3";
 import { nanoid } from "nanoid";
-import { eq, and, gte, lte, ne, inArray } from "drizzle-orm";
+import { eq, and, gt, gte, lt, lte, ne, inArray } from "drizzle-orm";
 import {
   getSession,
   recordChange,
@@ -766,18 +766,6 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
       }
     }
 
-    if (
-      !(await requestedSlotIsCurrentlyAvailable({
-        slug: requestedSlug,
-        start: requestedRange.start,
-        end: requestedRange.end,
-        duration: requestedRange.duration,
-      }))
-    ) {
-      setResponseStatus(event, 409);
-      return { error: "This time slot is no longer available" };
-    }
-
     // Check for conflicts + insert atomically in a transaction
     const db = getDb();
     const conflictSlugs = bookingLink?.ownerEmail
@@ -786,14 +774,32 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
         ? [requestedSlug]
         : [];
     const insertResult = await db.transaction(async (tx) => {
+      // Serialize booking creation per host. The no-op write takes a row lock
+      // on all of the host's booking links without changing user-visible data.
+      await tx
+        .update(schema.bookingLinks)
+        .set({ ownerEmail: hostEmail })
+        .where(eq(schema.bookingLinks.ownerEmail, hostEmail));
+
+      if (
+        !(await requestedSlotIsCurrentlyAvailable({
+          slug: requestedSlug,
+          start: requestedRange.start,
+          end: requestedRange.end,
+          duration: requestedRange.duration,
+        }))
+      ) {
+        return { conflict: true } as const;
+      }
+
       const conflicting = await tx
         .select()
         .from(schema.bookings)
         .where(
           and(
             ne(schema.bookings.status, "cancelled"),
-            lte(schema.bookings.start, requestedRange.end.toISOString()),
-            gte(schema.bookings.end, requestedRange.start.toISOString()),
+            lt(schema.bookings.start, requestedRange.end.toISOString()),
+            gt(schema.bookings.end, requestedRange.start.toISOString()),
             conflictSlugs.length > 0
               ? inArray(schema.bookings.slug, conflictSlugs)
               : undefined,

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -135,6 +135,7 @@ type AvailabilityContext = {
 };
 
 type ConflictItem = { start: string; end: string };
+type BookingLinkRow = typeof schema.bookingLinks.$inferSelect;
 
 type LocalDateTimeParts = {
   year: number;
@@ -264,6 +265,61 @@ function addDateString(date: string, days: number): string {
   const next = new Date(`${date}T00:00:00Z`);
   next.setUTCDate(next.getUTCDate() + days);
   return next.toISOString().slice(0, 10);
+}
+
+function parseRequestDate(value: unknown): Date | null {
+  if (typeof value !== "string" || value.trim().length === 0) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function uniqueDurations(values: number[]): number[] {
+  return [...new Set(values.filter((value) => Number.isInteger(value)))];
+}
+
+function parseBookingLinkDurations(
+  bookingLink: Pick<BookingLinkRow, "duration" | "durations">,
+): number[] {
+  if (bookingLink.durations) {
+    try {
+      const parsed = JSON.parse(bookingLink.durations);
+      if (Array.isArray(parsed)) {
+        const durations = uniqueDurations(
+          parsed
+            .map((value) =>
+              typeof value === "number"
+                ? value
+                : typeof value === "string"
+                  ? Number(value)
+                  : NaN,
+            )
+            .filter((value) => value > 0 && value <= 24 * 60),
+        );
+        if (durations.length > 0) return durations;
+      }
+    } catch {
+      // Fall through to the primary duration below.
+    }
+  }
+  return [bookingLink.duration].filter(
+    (value) => Number.isInteger(value) && value > 0 && value <= 24 * 60,
+  );
+}
+
+function requestedBookingRange(
+  startValue: unknown,
+  endValue: unknown,
+): { start: Date; end: Date; duration: number } | null {
+  const start = parseRequestDate(startValue);
+  const end = parseRequestDate(endValue);
+  if (!start || !end || end <= start) return null;
+
+  const duration = (end.getTime() - start.getTime()) / (60 * 1000);
+  if (!Number.isInteger(duration) || duration <= 0 || duration > 24 * 60) {
+    return null;
+  }
+
+  return { start, end, duration };
 }
 
 function countDaysInclusive(start: Date, end: Date): number {
@@ -495,6 +551,43 @@ function generateAvailableSlotsForDate({
   return availableSlots;
 }
 
+async function requestedSlotIsCurrentlyAvailable({
+  slug,
+  start,
+  end,
+  duration,
+}: {
+  slug: string;
+  start: Date;
+  end: Date;
+  duration: number;
+}): Promise<boolean> {
+  const context = await resolveAvailabilityContext(slug);
+  if (!context.effectiveConfig) return false;
+
+  const timezone = context.effectiveConfig.timezone || "UTC";
+  const date = formatLocalDateInTimezone(start, timezone);
+  const conflictItems = await getConflictItems({
+    ownerEmail: context.ownerEmail,
+    conflictSlugs: context.conflictSlugs,
+    rangeStartIso: dateStartIso(date, timezone),
+    rangeEndIso: dateEndIso(date, timezone),
+  });
+  const slots = generateAvailableSlotsForDate({
+    date,
+    duration,
+    config: context.effectiveConfig,
+    conflictItems,
+  });
+  const startMs = start.getTime();
+  const endMs = end.getTime();
+  return slots.some(
+    (slot) =>
+      new Date(slot.start).getTime() === startMs &&
+      new Date(slot.end).getTime() === endMs,
+  );
+}
+
 export const listBookings = defineEventHandler(async (_event: H3Event) => {
   return requireRequestContext(_event, async () => {
     try {
@@ -545,17 +638,18 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
       setResponseStatus(event, 400);
       return { error: "Enter a valid email address" };
     }
+    const requestedSlug = stripCrlf(body.slug);
 
     const bookingLink =
-      body.slug &&
+      requestedSlug &&
       (
         await getDb()
           .select()
           .from(schema.bookingLinks)
-          .where(eq(schema.bookingLinks.slug, body.slug))
+          .where(eq(schema.bookingLinks.slug, requestedSlug))
       )[0];
 
-    if (body.slug && (!bookingLink || !bookingLink.isActive)) {
+    if (requestedSlug && (!bookingLink || !bookingLink.isActive)) {
       setResponseStatus(event, 404);
       return { error: "Booking link not found" };
     }
@@ -566,6 +660,23 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
       setResponseStatus(event, 500);
       return { error: "Booking link has no host email" };
     }
+    const requestedRange = requestedBookingRange(body.start, body.end);
+    if (!requestedRange) {
+      setResponseStatus(event, 400);
+      return { error: "start and end must be valid ISO times" };
+    }
+
+    const allowedDurations = bookingLink
+      ? parseBookingLinkDurations(bookingLink)
+      : [];
+    if (
+      allowedDurations.length > 0 &&
+      !allowedDurations.includes(requestedRange.duration)
+    ) {
+      setResponseStatus(event, 400);
+      return { error: "Requested duration is not available for this link" };
+    }
+
     const bookingTimeZone = await getOwnerBookingTimeZone(hostEmail);
 
     const eventTitle = buildBookingEventTitle({
@@ -655,12 +766,24 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
       }
     }
 
+    if (
+      !(await requestedSlotIsCurrentlyAvailable({
+        slug: requestedSlug,
+        start: requestedRange.start,
+        end: requestedRange.end,
+        duration: requestedRange.duration,
+      }))
+    ) {
+      setResponseStatus(event, 409);
+      return { error: "This time slot is no longer available" };
+    }
+
     // Check for conflicts + insert atomically in a transaction
     const db = getDb();
     const conflictSlugs = bookingLink?.ownerEmail
       ? await getBookingLinkSlugsForOwner(bookingLink.ownerEmail)
-      : body.slug
-        ? [String(body.slug)]
+      : requestedSlug
+        ? [requestedSlug]
         : [];
     const insertResult = await db.transaction(async (tx) => {
       const conflicting = await tx
@@ -669,8 +792,8 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
         .where(
           and(
             ne(schema.bookings.status, "cancelled"),
-            lte(schema.bookings.start, body.end),
-            gte(schema.bookings.end, body.start),
+            lte(schema.bookings.start, requestedRange.end.toISOString()),
+            gte(schema.bookings.end, requestedRange.start.toISOString()),
             conflictSlugs.length > 0
               ? inArray(schema.bookings.slug, conflictSlugs)
               : undefined,
@@ -685,9 +808,9 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
         id,
         name: attendeeName,
         email: attendeeEmail,
-        start: body.start,
-        end: body.end,
-        slug: body.slug || "",
+        start: requestedRange.start.toISOString(),
+        end: requestedRange.end.toISOString(),
+        slug: requestedSlug,
         eventTitle,
         notes: notes || null,
         fieldResponses:
@@ -738,8 +861,8 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
         const zoomResult = await createZoomMeeting({
           hostEmail,
           title: eventTitle,
-          startTime: body.start,
-          endTime: body.end,
+          startTime: requestedRange.start.toISOString(),
+          endTime: requestedRange.end.toISOString(),
           timezone: bookingTimeZone,
         });
         if (zoomResult?.meetingUrl) {
@@ -787,8 +910,8 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
           id: nanoid(),
           title: eventTitle,
           description: descParts.join("\n\n"),
-          start: body.start,
-          end: body.end,
+          start: requestedRange.start.toISOString(),
+          end: requestedRange.end.toISOString(),
           location: meetingLink || "",
           allDay: false,
           source: "google",
@@ -836,9 +959,9 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
       id,
       name: attendeeName,
       email: attendeeEmail,
-      start: body.start,
-      end: body.end,
-      slug: body.slug || "",
+      start: requestedRange.start.toISOString(),
+      end: requestedRange.end.toISOString(),
+      slug: requestedSlug,
       eventTitle,
       notes: notes || undefined,
       fieldResponses:
@@ -862,11 +985,11 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
         "calendar.booking.created",
         {
           bookingId: id,
-          schedulingLinkSlug: body.slug || "",
+          schedulingLinkSlug: requestedSlug,
           attendeeName,
           attendeeEmail,
-          startTime: body.start,
-          endTime: body.end,
+          startTime: requestedRange.start.toISOString(),
+          endTime: requestedRange.end.toISOString(),
           eventTitle: booking.eventTitle || "",
         },
         { owner: hostEmail },

--- a/templates/calendar/server/lib/calendar-availability.spec.ts
+++ b/templates/calendar/server/lib/calendar-availability.spec.ts
@@ -44,7 +44,29 @@ describe("eventBlocksAvailability", () => {
     ).toBe(false);
   });
 
-  it("does not block time for attendee events where the host is not attending", () => {
+  it("blocks time when the host tentatively accepted the event", () => {
+    expect(
+      eventBlocksAvailability(event({ responseStatus: "tentative" })),
+    ).toBe(true);
+  });
+
+  it("blocks time when the host has not responded to the event", () => {
+    expect(
+      eventBlocksAvailability(
+        event({
+          attendees: [
+            {
+              email: "host@example.com",
+              responseStatus: "needsAction",
+              self: true,
+            },
+          ],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("blocks time when the host response cannot be identified", () => {
     expect(
       eventBlocksAvailability(
         event({
@@ -54,7 +76,7 @@ describe("eventBlocksAvailability", () => {
           organizer: { email: "organizer@example.com" },
         }),
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("blocks time for accepted self attendee events", () => {

--- a/templates/calendar/server/lib/calendar-availability.ts
+++ b/templates/calendar/server/lib/calendar-availability.ts
@@ -5,7 +5,6 @@ type AvailabilityEvent = Pick<
   | "accountEmail"
   | "attendees"
   | "end"
-  | "organizer"
   | "responseStatus"
   | "start"
   | "status"
@@ -31,13 +30,6 @@ export function eventBlocksAvailability(event: AvailabilityEvent): boolean {
   const selfAttendee = findSelfAttendee(event);
   const selfStatus = event.responseStatus ?? selfAttendee?.responseStatus;
   if (selfStatus === "declined") return false;
-
-  if (event.attendees && event.attendees.length > 0) {
-    const organizerIsSelf =
-      event.organizer?.self === true ||
-      sameEmail(event.organizer?.email, event.accountEmail);
-    if (!selfAttendee && !organizerIsSelf) return false;
-  }
 
   return true;
 }

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -35,6 +35,12 @@ function isAuthFailure(error: unknown): boolean {
   );
 }
 
+function toError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  if (typeof error === "string") return new Error(error);
+  return new Error("Request failed");
+}
+
 // ─── API helpers ─────────────────────────────────────────────────────────────
 
 async function apiFetch<T>(url: string, options?: RequestInit): Promise<T> {
@@ -507,7 +513,7 @@ export function useEmails(
     // quota cooldown). Showing the full error state while data exists makes
     // the inbox appear to flash/reload even though the old page is usable.
     isError: q.isError && !q.data,
-    error: q.isError && !q.data ? q.error : null,
+    error: q.isError && !q.data ? toError(q.error) : null,
     refetch: q.refetch,
     hasNextPage: q.hasNextPage,
     fetchNextPage: q.fetchNextPage,

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -25,6 +25,16 @@ import {
 
 const EMAIL_PAGE_SIZE = 25;
 
+function isAuthFailure(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    "status" in error &&
+    ((error as { status?: unknown }).status === 401 ||
+      (error as { status?: unknown }).status === 403)
+  );
+}
+
 // ─── API helpers ─────────────────────────────────────────────────────────────
 
 async function apiFetch<T>(url: string, options?: RequestInit): Promise<T> {
@@ -37,7 +47,9 @@ async function apiFetch<T>(url: string, options?: RequestInit): Promise<T> {
   });
   if (!res.ok) {
     const body = await res.json().catch(() => null);
-    throw new Error(body?.error || `Request failed (${res.status})`);
+    const error = new Error(body?.error || `Request failed (${res.status})`);
+    (error as Error & { status?: number }).status = res.status;
+    throw error;
   }
   return res.json();
 }
@@ -464,9 +476,10 @@ export function useEmails(
     // the interval based on consecutive failures, capped at 5 minutes, so the
     // UI keeps trying without hammering Gmail.
     refetchInterval: (query: {
-      state: { status: string; fetchFailureCount: number };
+      state: { status: string; fetchFailureCount: number; error: unknown };
     }) => {
       if (search) return false;
+      if (isAuthFailure(query.state.error)) return false;
       const base = 2 * 60_000;
       if (query.state.status === "error") {
         return Math.min(base * (1 + query.state.fetchFailureCount), 5 * 60_000);
@@ -507,6 +520,7 @@ export function useEmail(id: string | undefined) {
     queryKey: ["email", id],
     queryFn: () => apiFetch(`/api/emails/${id}`),
     enabled: !!id,
+    retry: (failureCount, error) => !isAuthFailure(error) && failureCount < 1,
   });
 }
 

--- a/templates/mail/app/lib/thread-cache.ts
+++ b/templates/mail/app/lib/thread-cache.ts
@@ -21,6 +21,7 @@ const STORAGE_TTL = 60 * 60 * 1000; // 1 hour
 const STORAGE_MAX_ENTRIES = 50;
 const STORAGE_MAX_BYTES = 3 * 1024 * 1024; // ~3MB, well under the 5MB cap
 const BACKGROUND_RATE_LIMIT_COOLDOWN_MS = 90 * 1000;
+const BACKGROUND_AUTH_FAILURE_COOLDOWN_MS = 5 * 60 * 1000;
 const WARM_BATCH_LIMIT = 4;
 
 // Park state on globalThis so Vite HMR module reloads don't wipe the cache.
@@ -63,6 +64,10 @@ function isRateLimitMessage(message: string): boolean {
   return /\b(?:429|quota|rate limit)\b/i.test(message);
 }
 
+function isAuthFailureStatus(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
 function retryDelayFromMessage(message: string): number {
   const match = message.match(/retry in\s+(\d+)s/i);
   if (!match) return BACKGROUND_RATE_LIMIT_COOLDOWN_MS;
@@ -73,12 +78,20 @@ function retryDelayFromMessage(message: string): number {
   return Math.min(Math.max(seconds * 1000, 15_000), 5 * 60_000);
 }
 
-function noteFetchError(message: string) {
-  if (!isRateLimitMessage(message)) return;
-  backgroundCooldownUntil = Math.max(
-    backgroundCooldownUntil,
-    Date.now() + retryDelayFromMessage(message),
-  );
+function noteFetchError(message: string, status?: number) {
+  if (status !== undefined && isAuthFailureStatus(status)) {
+    backgroundCooldownUntil = Math.max(
+      backgroundCooldownUntil,
+      Date.now() + BACKGROUND_AUTH_FAILURE_COOLDOWN_MS,
+    );
+    return;
+  }
+  if (isRateLimitMessage(message)) {
+    backgroundCooldownUntil = Math.max(
+      backgroundCooldownUntil,
+      Date.now() + retryDelayFromMessage(message),
+    );
+  }
 }
 
 function canRunBackgroundFetch() {
@@ -104,8 +117,10 @@ async function fetchThread(
   if (!res.ok) {
     const body = await res.json().catch(() => null);
     const message = body?.error || `Request failed (${res.status})`;
-    noteFetchError(message);
-    throw new Error(message);
+    noteFetchError(message, res.status);
+    const error = new Error(message);
+    (error as Error & { status?: number }).status = res.status;
+    throw error;
   }
   return res.json();
 }

--- a/templates/mail/app/root.tsx
+++ b/templates/mail/app/root.tsx
@@ -52,6 +52,16 @@ function getHydrationStableThemeInitScript() {
 
 const THEME_INIT_SCRIPT = getHydrationStableThemeInitScript();
 
+function isAuthFailure(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    "status" in error &&
+    ((error as { status?: unknown }).status === 401 ||
+      (error as { status?: unknown }).status === 403)
+  );
+}
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -246,7 +256,8 @@ export default function Root() {
         defaultOptions: {
           queries: {
             staleTime: 30_000,
-            retry: 1,
+            retry: (failureCount, error) =>
+              !isAuthFailure(error) && failureCount < 1,
             refetchOnWindowFocus: true,
           },
         },


### PR DESCRIPTION
## Summary
- Treat only explicitly declined Google events as non-blocking for calendar booking availability
- Revalidate the exact requested booking slot against current availability before inserting a booking
- Add coverage for tentative, unresponded, and unknown-response calendar events

## Tests
- pnpm --dir templates/calendar exec vitest --run server/lib/calendar-availability.spec.ts
- pnpm --filter calendar typecheck
- git diff --check