### PR TITLE
Fix MCP app embed bridges and fallback behavior

### DIFF
--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -307,6 +307,17 @@ embed: true })` is the generic escape hatch for routes like full dashboards,
 filtered inboxes, calendar drafts, analyses, or extension pages, and should be
 used liberally when the full app is the clearest review/edit surface.
 
+Some hosts, especially Claude web/desktop, may render the MCP App resource in a
+host-owned sandbox and block nested app iframes even when frame domains are
+declared. Keep `embedApp()`'s ready-handshake fallback intact: it retries inline
+or opens a freshly minted embed session via `ui/open-link`. Do not special-case
+Claude by assigning `window.location` to `/_agent-native/embed/start`; Claude's
+initial iframe is the returned `ui://` resource HTML on a
+`*.claudemcpcontent.com` origin, not our app URL, and redirecting that document
+can bypass the fallback. If true nested-frame-free Claude support is needed,
+build a distinct MCP resource shell that bootstraps the app route inside the
+resource document with declared CSP/CORS/auth.
+
 Compatibility target: build to the standard once, not per-client shims. MCP
 Apps-capable hosts should include Claude/Claude Desktop/Claude Code, ChatGPT
 custom MCP apps, VS Code GitHub Copilot, Goose, Postman, MCPJam, Cursor, and

--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -244,6 +244,13 @@ Expose the operation as a normal action/tool, return a focused deep link with
 `link`, and add `mcpApp.resource = embedApp(...)` so capable hosts load that
 same route inline instead of opening a new tab.
 
+`embedApp()` supports both host bridges. Standard MCP Apps hosts use the
+`ui/*` bridge; ChatGPT uses the `window.openai` compatibility bridge, reading
+`toolInput` / `toolOutput` / `toolResponseMetadata` and calling
+`create_embed_session` through `window.openai.callTool(...)`. Do not build a
+ChatGPT-only HTML surface. Keep the action result and `link` target focused so
+both bridges land on the same real app route.
+
 That means full-app embeds can do anything the route can do once opened:
 review or edit an email draft, show a filtered inbox/search, open a calendar
 event or event draft, load an extension page, inspect a full analytics

--- a/.changeset/claude-mcp-app-csp-metadata.md
+++ b/.changeset/claude-mcp-app-csp-metadata.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Expose MCP App CSP metadata, compact unknown OAuth app hosts, support ChatGPT's window.openai bridge, and show a Claude-safe fallback when nested app frames are blocked.

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -222,11 +222,25 @@ starts from the action's `link` target, creates a short-lived embed session,
 and loads that URL in an iframe. Design embedded routes so a reload with the
 same URL reconstructs the same view.
 
+ChatGPT gets a dedicated compatibility path through `window.openai`: the
+wrapper reads `toolInput`, `toolOutput`, and `toolResponseMetadata` directly,
+then calls `create_embed_session` via `window.openai.callTool(...)`. Other MCP
+Apps hosts use the standard `ui/*` bridge. Keep the result shape identical for
+both paths: return a focused `link` and concise structured content.
+
+Some hosts support MCP Apps but still block nested iframes for a returned UI
+resource. `embedApp()` detects that case with a route-ready handshake and
+replaces the broken frame with an open-app fallback: the user can retry inline,
+open a freshly minted embed session through the host, or use the visible route
+URL. Keep the action's `link` target useful on its own because it is still the
+universal escape hatch.
+
 The host bridge is deliberately small:
 
 | Direction       | Message type                             | Use it for                               |
 | --------------- | ---------------------------------------- | ---------------------------------------- |
 | wrapper → route | `agentNative.mcpHostContext`             | Theme, locale, host platform, dimensions |
+| route → wrapper | `agentNative.embeddedAppReady`           | Confirm the nested route iframe loaded   |
 | route → wrapper | `agentNative.mcpHost.updateModelContext` | Hidden context for the host model        |
 | route → wrapper | `agentNative.mcpHost.openLink`           | Open an external or app URL via the host |
 | route → wrapper | `agentNative.mcpHost.requestDisplayMode` | Request `inline`, `fullscreen`, or `pip` |

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -235,6 +235,16 @@ open a freshly minted embed session through the host, or use the visible route
 URL. Keep the action's `link` target useful on its own because it is still the
 universal escape hatch.
 
+Do not try to make Claude render full app routes inline by redirecting the MCP
+App resource document to `/_agent-native/embed/start`. Claude first renders the
+`ui://` resource HTML on a `*.claudemcpcontent.com` sandbox origin; our app URL
+is only reached later by wrapper code. The `/embed/start` 302 works for the
+nested app iframe and for `ui/open-link` external opens, but it is not a
+portable substitute for the MCP resource document itself. True nested-frame-free
+Claude support would need a separate resource-shell mode that bootstraps the
+route inside the returned MCP App HTML document, with explicit asset/API CSP,
+CORS, and embed-session auth.
+
 The host bridge is deliberately small:
 
 | Direction       | Message type                             | Use it for                               |

--- a/packages/core/src/client/frame.ts
+++ b/packages/core/src/client/frame.ts
@@ -82,6 +82,10 @@ if (typeof window !== "undefined") {
       event.source === window.parent
     ) {
       _frameOrigin = origin;
+      window.parent.postMessage(
+        { type: "agentNative.embeddedAppReady" },
+        origin,
+      );
     }
   });
 }

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -197,12 +197,21 @@ async function isKnownMcpAppOAuthClient(
   try {
     const { getOAuthClient } = await import("./oauth-store.js");
     const client = await getOAuthClient(clientId);
-    if (!client) return false;
+    // If the token carries an OAuth client id but its registration is missing,
+    // keep the model on the compact MCP Apps surface instead of exposing every
+    // private action/schema.
+    if (!client) return true;
     if (isKnownAppClientName(client.clientName)) return true;
     if (isKnownNonAppClientName(client.clientName)) return false;
-    return client.redirectUris.some(isKnownMcpAppRedirectUri);
+    if (client.redirectUris.some(isKnownMcpAppRedirectUri)) return true;
+    // Most OAuth hosts are UI-oriented MCP clients. Preserve the full catalog
+    // only for known code/CLI clients so unknown browser hosts cannot trigger
+    // massive resources/list payloads.
+    return true;
   } catch {
-    return false;
+    // On metadata lookup errors, fail compact instead of falling back to the
+    // full action surface; ChatGPT/Claude old tokens otherwise get huge lists.
+    return true;
   }
 }
 
@@ -214,6 +223,12 @@ interface ResolvedMcpAppResource {
   html: ActionMcpAppResourceConfig["html"];
   mimeType: typeof MCP_APP_MIME_TYPE;
   _meta?: Record<string, unknown>;
+}
+
+function metadataObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
 }
 
 /**
@@ -444,11 +459,15 @@ function openAiToolDescriptorMeta(
   resource: ResolvedMcpAppResource,
 ): Record<string, unknown> {
   const label = resource.title ?? resource.name;
+  const widgetCsp = metadataObject(resource._meta?.["openai/widgetCSP"]);
   return {
     "openai/outputTemplate": resource.uri,
     "openai/toolInvocation/invoking": `Opening ${label}`,
     "openai/toolInvocation/invoked": `${label} ready`,
     "openai/widgetAccessible": true,
+    ...(Object.keys(widgetCsp).length > 0
+      ? { "openai/widgetCSP": widgetCsp }
+      : {}),
   };
 }
 
@@ -456,11 +475,17 @@ function openAiToolResultMeta(
   resource: ResolvedMcpAppResource,
 ): Record<string, unknown> {
   const label = resource.title ?? resource.name;
+  const ui = metadataObject(resource._meta?.ui);
+  const widgetCsp = metadataObject(resource._meta?.["openai/widgetCSP"]);
   return {
     "openai/outputTemplate": resource.uri,
     "openai/toolInvocation/invoking": `Opening ${label}`,
     "openai/toolInvocation/invoked": `${label} ready`,
     "openai/widgetAccessible": true,
+    ...(Object.keys(ui).length > 0 ? { ui } : {}),
+    ...(Object.keys(widgetCsp).length > 0
+      ? { "openai/widgetCSP": widgetCsp }
+      : {}),
   };
 }
 
@@ -667,6 +692,7 @@ export async function createMCPServerForRequest(
                 ...openAiToolDescriptorMeta(mcpAppResource),
                 [MCP_APP_RESOURCE_URI_META_KEY]: mcpAppResource.uri,
                 ui: {
+                  ...metadataObject(mcpAppResource._meta?.ui),
                   ...(((rawToolMeta.ui as any) &&
                   typeof rawToolMeta.ui === "object" &&
                   !Array.isArray(rawToolMeta.ui)

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -18,15 +18,27 @@ describe("embedApp", () => {
     expect(html).toContain("app.callServerTool");
     expect(html).toContain("app.updateModelContext");
     expect(html).toContain("app.sendMessage");
+    expect(html).toContain("window.openai");
+    expect(html).toContain('"openai:set_globals"');
+    expect(html).toContain("bridge.toolInput");
+    expect(html).toContain("bridge.toolOutput");
+    expect(html).toContain("bridge.toolResponseMetadata");
+    expect(html).toContain("openAiBridge.callTool(startTool, args)");
+    expect(html).toContain("openAiBridge.openExternal");
+    expect(html).toContain("openAiBridge.setOpenInAppUrl");
+    expect(html).toContain("openAiBridge.sendFollowUpMessage");
     expect(html).toContain('document.createElement("iframe")');
     expect(html).toContain('"agentNative.submitChat"');
     expect(html).toContain('"agentNative.frameOrigin"');
+    expect(html).toContain('"agentNative.embeddedAppReady"');
     expect(html).toContain('"agentNative.mcpHostContext"');
     expect(html).toContain('"agentNative.mcpHost.updateModelContext"');
     expect(html).toContain('"agentNative.mcpHost.openLink"');
     expect(html).toContain('"agentNative.mcpHost.requestDisplayMode"');
     expect(html).toContain('"agentNative.mcpHost.response"');
     expect(html).toContain("app.requestDisplayMode");
+    expect(html).toContain("renderFrameFallback");
+    expect(html).toContain("openFallbackExternal");
     expect(html).toContain("__an_mcp_chat_bridge");
     expect(html).toContain('data-app-title="Dashboard"');
     expect(html).toContain("data-title-label>Dashboard");
@@ -44,6 +56,21 @@ describe("embedApp", () => {
       MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
     );
     expect(resource.csp?.resourceDomains).toContain("https://esm.sh");
+  });
+
+  it("checks for ChatGPT's window.openai bridge before loading the standard bridge module", () => {
+    const resource = embedApp({ title: "Mail" });
+    const html =
+      typeof resource.html === "function"
+        ? resource.html({ actionName: "manage-draft", appId: "mail" })
+        : resource.html;
+
+    const openAiIndex = html.indexOf("window.openai");
+    const dynamicImportIndex = html.indexOf("await import");
+
+    expect(openAiIndex).toBeGreaterThanOrEqual(0);
+    expect(dynamicImportIndex).toBeGreaterThan(openAiIndex);
+    expect(html).not.toContain('import { App } from "https://esm.sh');
   });
 
   it("allows full-app embeds to request a 900px canvas", () => {
@@ -119,7 +146,14 @@ describe("embedApp", () => {
     expect(fixture.html).toContain("app.updateModelContext");
     expect(fixture.html).toContain("app.requestDisplayMode");
     expect(fixture.html).toContain("app.sendMessage");
+    expect(fixture.html).toContain("window.openai");
+    expect(fixture.html).toContain('"openai:set_globals"');
+    expect(fixture.html).toContain("openAiBridge.callTool(startTool, args)");
+    expect(fixture.html).toContain("openAiBridge.openExternal");
+    expect(fixture.html).toContain("openAiBridge.setOpenInAppUrl");
+    expect(fixture.html).toContain("openAiBridge.sendFollowUpMessage");
     expect(fixture.html).toContain('"agentNative.frameOrigin"');
+    expect(fixture.html).toContain('"agentNative.embeddedAppReady"');
     expect(fixture.html).toContain('"agentNative.submitChat"');
     expect(fixture.html).toContain('"agentNative.mcpHostContext"');
     expect(fixture.html).toContain('"agentNative.mcpHost.updateModelContext"');
@@ -130,8 +164,10 @@ describe("embedApp", () => {
     expect(fixture.html).toContain(
       'url.searchParams.set(chatBridgeParam, "1")',
     );
+    expect(fixture.html).toContain("Open this app in its own tab");
+    expect(fixture.html).toContain("use the URL below");
     expect(fixture.html).toContain("name: startTool");
-    expect(fixture.html).toContain("arguments: {");
+    expect(fixture.html).toContain("arguments: args");
   });
 });
 

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -39,9 +39,12 @@ describe("embedApp", () => {
     expect(html).toContain("app.requestDisplayMode");
     expect(html).toContain("renderFrameFallback");
     expect(html).toContain("openFallbackExternal");
-    expect(html).toContain("shouldDirectRenderEmbed");
-    expect(html).toContain("claudemcpcontent.com");
-    expect(html).toContain("window.location.href = data.startUrl");
+    expect(html).toContain("appFrameLoadTimer");
+    expect(html).toContain("startFrameReadyTimer(frame)");
+    expect(html).toContain("}, 30000)");
+    expect(html).not.toContain("shouldDirectRenderEmbed");
+    expect(html).not.toContain("claudemcpcontent.com");
+    expect(html).not.toContain("window.location.href = data.startUrl");
     expect(html).toContain("__an_mcp_chat_bridge");
     expect(html).toContain('data-app-title="Dashboard"');
     expect(html).toContain("data-title-label>Dashboard");

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -39,6 +39,9 @@ describe("embedApp", () => {
     expect(html).toContain("app.requestDisplayMode");
     expect(html).toContain("renderFrameFallback");
     expect(html).toContain("openFallbackExternal");
+    expect(html).toContain("shouldDirectRenderEmbed");
+    expect(html).toContain("claudemcpcontent.com");
+    expect(html).toContain("window.location.href = data.startUrl");
     expect(html).toContain("__an_mcp_chat_bridge");
     expect(html).toContain('data-app-title="Dashboard"');
     expect(html).toContain("data-title-label>Dashboard");

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -258,6 +258,11 @@ export function embedApp(
       stage.innerHTML = '<div class="message">' + esc(message) + '</div>';
     }
 
+    function shouldDirectRenderEmbed() {
+      const host = window.location.hostname.toLowerCase();
+      return host === "claudemcpcontent.com" || host.endsWith(".claudemcpcontent.com");
+    }
+
     function clearFrameReadyTimer() {
       if (!appFrameReadyTimer) return;
       clearTimeout(appFrameReadyTimer);
@@ -481,6 +486,10 @@ export function embedApp(
         if (!data.startUrl) {
           startedFor = "";
           setMessage(data.error || "This app can be opened, but not embedded from this MCP server.");
+          return;
+        }
+        if (shouldDirectRenderEmbed()) {
+          window.location.href = data.startUrl;
           return;
         }
         renderFrame(data.startUrl);

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -64,6 +64,11 @@ export function embedApp(
     .stage { position: relative; min-height: ${viewportHeight}px; }
     iframe { display: block; width: 100%; height: ${viewportHeight}px; border: 0; background: Canvas; }
     .message { display: grid; place-items: center; min-height: ${viewportHeight}px; padding: 18px; color: color-mix(in srgb, CanvasText 62%, Canvas); font-size: 13px; line-height: 1.45; text-align: center; }
+    .fallback { display: grid; align-content: center; justify-items: center; gap: 12px; min-height: ${viewportHeight}px; padding: 24px; background: Canvas; color: CanvasText; text-align: center; }
+    .fallback-title { max-width: 440px; font-size: 14px; font-weight: 700; }
+    .fallback-copy { max-width: 520px; color: color-mix(in srgb, CanvasText 64%, Canvas); font-size: 13px; line-height: 1.45; }
+    .fallback-actions { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 8px; }
+    .fallback-url { max-width: min(560px, 100%); overflow-wrap: anywhere; color: color-mix(in srgb, CanvasText 76%, Canvas); font-size: 12px; }
   </style>
 </head>
 <body
@@ -86,9 +91,6 @@ export function embedApp(
     </section>
   </main>
   <script type="module">
-    import { App } from "${MCP_APP_IMPORT}";
-
-    const app = new App({ name: "Agent Native Embed", version: "1.0.0" }, {});
     const body = document.body;
     const stage = document.querySelector("[data-stage]");
     const titleEl = document.querySelector("[data-title-label]");
@@ -97,10 +99,16 @@ export function embedApp(
     const startTool = body.dataset.startTool || "create_embed_session";
     const embedByDefault = body.dataset.embedDefault !== "0";
     const chatBridgeParam = ${JSON.stringify(MCP_APP_CHAT_BRIDGE_QUERY_PARAM)};
+    const intrinsicHeight = ${height};
+    let app = null;
+    let openAiBridge = null;
     let toolInput = {};
     let openUrl = "";
     let startedFor = "";
     let appFrame = null;
+    let appFrameReady = false;
+    let appFrameReadyTimer = null;
+    let lastFrameSrc = "";
 
     function esc(value) {
       return String(value ?? "")
@@ -116,8 +124,20 @@ export function embedApp(
       try { return JSON.parse(value); } catch { return fallback; }
     }
 
+    function objectValue(value) {
+      return value && typeof value === "object" && !Array.isArray(value)
+        ? value
+        : {};
+    }
+
     function parseToolResult(params) {
       if (!params) return {};
+      if (params.result && typeof params.result === "object") {
+        return parseToolResult(params.result);
+      }
+      if (params.toolResult && typeof params.toolResult === "object") {
+        return parseToolResult(params.toolResult);
+      }
       if (params.structuredContent && typeof params.structuredContent === "object") {
         return params.structuredContent;
       }
@@ -134,10 +154,26 @@ export function embedApp(
     }
 
     function hostState() {
+      if (openAiBridge) {
+        return {
+          context: {
+            displayMode: openAiBridge.displayMode,
+            availableDisplayModes: typeof openAiBridge.requestDisplayMode === "function"
+              ? ["inline", "fullscreen", "pip"]
+              : [],
+            maxHeight: openAiBridge.maxHeight,
+            locale: openAiBridge.locale,
+            theme: openAiBridge.theme,
+            view: openAiBridge.view
+          },
+          capabilities: { openai: true },
+          version: openAiBridge.userAgent
+        };
+      }
       return {
-        context: app.getHostContext ? app.getHostContext() : undefined,
-        capabilities: app.getHostCapabilities ? app.getHostCapabilities() : undefined,
-        version: app.getHostVersion ? app.getHostVersion() : undefined
+        context: app && app.getHostContext ? app.getHostContext() : undefined,
+        capabilities: app && app.getHostCapabilities ? app.getHostCapabilities() : undefined,
+        version: app && app.getHostVersion ? app.getHostVersion() : undefined
       };
     }
 
@@ -181,12 +217,23 @@ export function embedApp(
     }
 
     function supportedDisplayMode(mode) {
+      if (openAiBridge && typeof openAiBridge.requestDisplayMode === "function") {
+        return mode === "inline" || mode === "fullscreen" || mode === "pip";
+      }
       const modes = hostState().context && hostState().context.availableDisplayModes;
       return Array.isArray(modes) && modes.includes(mode);
     }
 
     async function requestHostDisplayMode(mode) {
-      const result = await app.requestDisplayMode({ mode });
+      let result;
+      if (openAiBridge && typeof openAiBridge.requestDisplayMode === "function") {
+        result = await openAiBridge.requestDisplayMode({ mode });
+      } else {
+        if (!app || typeof app.requestDisplayMode !== "function") {
+          throw new Error("Display mode changes are not available in this host.");
+        }
+        result = await app.requestDisplayMode({ mode });
+      }
       updateDisplayButton();
       sendHostContext();
       return result;
@@ -211,14 +258,74 @@ export function embedApp(
       stage.innerHTML = '<div class="message">' + esc(message) + '</div>';
     }
 
+    function clearFrameReadyTimer() {
+      if (!appFrameReadyTimer) return;
+      clearTimeout(appFrameReadyTimer);
+      appFrameReadyTimer = null;
+    }
+
+    function renderFrameFallback() {
+      clearFrameReadyTimer();
+      appFrame = null;
+      stage.innerHTML =
+        '<div class="fallback">' +
+          '<div class="fallback-title">Open this app in its own tab</div>' +
+          '<div class="fallback-copy">This chat host did not allow the embedded app frame to load inline. You can still open the same app route through the host or use the URL below.</div>' +
+          '<div class="fallback-actions">' +
+            '<button type="button" data-fallback-open>Open app</button>' +
+            '<button type="button" data-fallback-retry>Try inline again</button>' +
+          '</div>' +
+          (openUrl ? '<a class="fallback-url" href="' + esc(openUrl) + '" target="_blank" rel="noreferrer">' + esc(openUrl) + '</a>' : '') +
+        '</div>';
+      const fallbackOpen = stage.querySelector("[data-fallback-open]");
+      const fallbackRetry = stage.querySelector("[data-fallback-retry]");
+      if (fallbackOpen) {
+        fallbackOpen.disabled = !openUrl;
+        fallbackOpen.onclick = () => {
+          if (openUrl) void openFallbackExternal();
+        };
+      }
+      if (fallbackRetry) {
+        fallbackRetry.disabled = !lastFrameSrc;
+        fallbackRetry.onclick = () => {
+          if (lastFrameSrc) renderFrame(lastFrameSrc);
+        };
+      }
+    }
+
+    async function openFallbackExternal() {
+      let url = openUrl;
+      try {
+        const embedUrl = withChatBridgeParam(openUrl);
+        const result = await callEmbedSessionTool({
+          url: embedUrl,
+          chrome: typeof toolInput.chrome === "string" ? toolInput.chrome : "full"
+        });
+        const data = parseToolResult(result);
+        if (typeof data.startUrl === "string" && data.startUrl) {
+          url = data.startUrl;
+        }
+      } catch (err) {
+        console.warn("[agent-native] MCP fallback could not mint a fresh app session", err);
+      }
+      await openHostLink({ url });
+    }
+
     function renderFrame(src) {
+      clearFrameReadyTimer();
       const frame = document.createElement("iframe");
       frame.title = body.dataset.iframeTitle || "Agent Native app";
       frame.src = src;
       frame.allow = "clipboard-read; clipboard-write";
       appFrame = frame;
+      appFrameReady = false;
+      lastFrameSrc = src;
       frame.addEventListener("load", () => sendFrameReadyMessages(frame));
       stage.replaceChildren(frame);
+      notifyHostHeight();
+      appFrameReadyTimer = setTimeout(() => {
+        if (!appFrameReady && appFrame === frame) renderFrameFallback();
+      }, 7000);
     }
 
     async function updateHostModelContext(data) {
@@ -227,13 +334,40 @@ export function embedApp(
       if (data && data.structuredContent && typeof data.structuredContent === "object") {
         params.structuredContent = data.structuredContent;
       }
+      if (openAiBridge && typeof openAiBridge.setWidgetState === "function") {
+        openAiBridge.setWidgetState({
+          ...objectValue(openAiBridge.widgetState),
+          agentNativeModelContext: params
+        });
+        return { ok: true };
+      }
+      if (!app || typeof app.updateModelContext !== "function") return { ok: false };
       await app.updateModelContext(params);
+      return { ok: true };
     }
 
     async function openHostLink(data) {
       const url = typeof (data && data.url) === "string" ? data.url : "";
       if (!url) return { isError: true };
-      return await app.openLink({ url });
+      if (openAiBridge && typeof openAiBridge.openExternal === "function") {
+        return await openAiBridge.openExternal({ href: url, redirectUrl: false });
+      }
+      if (app && typeof app.openLink === "function") {
+        return await app.openLink({ url });
+      }
+      window.open(url, "_blank", "noopener,noreferrer");
+      return { ok: true };
+    }
+
+    function notifyHostHeight() {
+      if (!openAiBridge || typeof openAiBridge.notifyIntrinsicHeight !== "function") {
+        return;
+      }
+      try {
+        openAiBridge.notifyIntrinsicHeight({ height: intrinsicHeight });
+      } catch (err) {
+        console.warn("[agent-native] ChatGPT rejected intrinsic height update", err);
+      }
     }
 
     function respondToAppFrame(requestId, work) {
@@ -264,14 +398,29 @@ export function embedApp(
       const context = typeof chat.context === "string" ? chat.context : "";
       if (context.trim()) {
         try {
-          await app.updateModelContext({
-            content: [{ type: "text", text: context }]
-          });
+          if (openAiBridge && typeof openAiBridge.setWidgetState === "function") {
+            openAiBridge.setWidgetState({
+              ...objectValue(openAiBridge.widgetState),
+              agentNativeChatContext: context
+            });
+          } else if (app && typeof app.updateModelContext === "function") {
+            await app.updateModelContext({
+              content: [{ type: "text", text: context }]
+            });
+          }
         } catch (err) {
           console.warn("[agent-native] MCP host rejected model context update", err);
         }
       }
       try {
+        if (openAiBridge && typeof openAiBridge.sendFollowUpMessage === "function") {
+          await openAiBridge.sendFollowUpMessage({
+            prompt: context.trim() ? context.trim() + "\\n\\n" + message : message,
+            scrollToBottom: true
+          });
+          return;
+        }
+        if (!app || typeof app.sendMessage !== "function") return;
         const result = await app.sendMessage({
           role: "user",
           content: [{ type: "text", text: message }]
@@ -288,6 +437,11 @@ export function embedApp(
       if (!appFrame || event.source !== appFrame.contentWindow) return;
       if (!event.data) return;
       const data = event.data.data || {};
+      if (event.data.type === "agentNative.embeddedAppReady") {
+        appFrameReady = true;
+        clearFrameReadyTimer();
+        return;
+      }
       if (event.data.type === "agentNative.submitChat") {
         void sendHostChat(data);
         return;
@@ -319,12 +473,9 @@ export function embedApp(
       setMessage("Loading app");
       try {
         const embedUrl = withChatBridgeParam(openUrl);
-        const result = await app.callServerTool({
-          name: startTool,
-          arguments: {
-            url: embedUrl,
-            chrome: typeof toolInput.chrome === "string" ? toolInput.chrome : "full"
-          }
+        const result = await callEmbedSessionTool({
+          url: embedUrl,
+          chrome: typeof toolInput.chrome === "string" ? toolInput.chrome : "full"
         });
         const data = parseToolResult(result);
         if (!data.startUrl) {
@@ -339,11 +490,33 @@ export function embedApp(
       }
     }
 
+    async function callEmbedSessionTool(args) {
+      if (openAiBridge && typeof openAiBridge.callTool === "function") {
+        return await openAiBridge.callTool(startTool, args);
+      }
+      if (!app || typeof app.callServerTool !== "function") {
+        throw new Error("Host tool calls are not available.");
+      }
+      return await app.callServerTool({ name: startTool, arguments: args });
+    }
+
+    function updateHostOpenInAppUrl() {
+      if (!openAiBridge || !openUrl || typeof openAiBridge.setOpenInAppUrl !== "function") {
+        return;
+      }
+      try {
+        openAiBridge.setOpenInAppUrl({ href: openUrl });
+      } catch (err) {
+        console.warn("[agent-native] ChatGPT rejected open-in-app URL", err);
+      }
+    }
+
     function updateOpenButton() {
       openButton.disabled = !openUrl;
       openButton.onclick = () => {
-        if (openUrl) void app.openLink({ url: openUrl });
+        if (openUrl) void openHostLink({ url: openUrl });
       };
+      updateHostOpenInAppUrl();
     }
 
     function updateTitle(data) {
@@ -351,23 +524,96 @@ export function embedApp(
       titleEl.textContent = String(label);
     }
 
-    app.ontoolinput = (params) => {
-      toolInput = params.arguments || {};
-    };
-    app.ontoolresult = (params) => {
+    function readOpenAiBridge() {
+      return window.openai && typeof window.openai === "object"
+        ? window.openai
+        : null;
+    }
+
+    function openAiToolResultParams(bridge) {
+      const params = {};
+      if (bridge && bridge.toolOutput !== undefined) {
+        if (bridge.toolOutput && typeof bridge.toolOutput === "object") {
+          params.structuredContent = bridge.toolOutput;
+        } else {
+          params.content = [{ type: "text", text: String(bridge.toolOutput) }];
+        }
+      }
+      if (bridge && bridge.toolResponseMetadata && typeof bridge.toolResponseMetadata === "object") {
+        params._meta = bridge.toolResponseMetadata;
+      }
+      return params;
+    }
+
+    function syncOpenAiBridge(bridge) {
+      if (!bridge) return false;
+      openAiBridge = bridge;
+      toolInput = objectValue(bridge.toolInput);
+      const params = openAiToolResultParams(bridge);
       const data = parseToolResult(params);
       openUrl = openLinkFrom(params, data);
       updateTitle(data);
       updateOpenButton();
-      void launchEmbed();
-    };
-    app.onhostcontextchanged = () => {
+      updateDisplayButton();
+      notifyHostHeight();
+      sendHostContext();
+      if (openUrl) {
+        void launchEmbed();
+      } else if (!appFrame) {
+        setMessage("Waiting for app result");
+      }
+      return true;
+    }
+
+    function waitForOpenAiBridge() {
+      const existing = readOpenAiBridge();
+      if (existing) return Promise.resolve(existing);
+      return new Promise((resolve) => {
+        let settled = false;
+        const finish = (bridge) => {
+          if (settled) return;
+          settled = true;
+          window.removeEventListener("openai:set_globals", onGlobals);
+          clearTimeout(timer);
+          resolve(bridge || readOpenAiBridge());
+        };
+        const onGlobals = () => finish(readOpenAiBridge());
+        const timer = setTimeout(() => finish(null), 200);
+        window.addEventListener("openai:set_globals", onGlobals, { passive: true });
+      });
+    }
+
+    window.addEventListener("openai:set_globals", () => {
+      const bridge = readOpenAiBridge();
+      if (bridge && (!appFrame || openAiBridge)) syncOpenAiBridge(bridge);
+    }, { passive: true });
+
+    async function startMcpAppsBridge() {
+      const { App } = await import("${MCP_APP_IMPORT}");
+      app = new App({ name: "Agent Native Embed", version: "1.0.0" }, {});
+      app.ontoolinput = (params) => {
+        toolInput = params.arguments || {};
+      };
+      app.ontoolresult = (params) => {
+        const data = parseToolResult(params);
+        openUrl = openLinkFrom(params, data);
+        updateTitle(data);
+        updateOpenButton();
+        void launchEmbed();
+      };
+      app.onhostcontextchanged = () => {
+        updateDisplayButton();
+        sendHostContext();
+      };
+      await app.connect();
       updateDisplayButton();
       sendHostContext();
-    };
-    await app.connect();
-    updateDisplayButton();
-    sendHostContext();
+    }
+
+    const initialOpenAiBridge = await waitForOpenAiBridge();
+    if (!syncOpenAiBridge(initialOpenAiBridge)) {
+      await startMcpAppsBridge();
+    }
   </script>
 </body>
 </html>`,

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -108,6 +108,7 @@ export function embedApp(
     let appFrame = null;
     let appFrameReady = false;
     let appFrameReadyTimer = null;
+    let appFrameLoadTimer = null;
     let lastFrameSrc = "";
 
     function esc(value) {
@@ -258,19 +259,28 @@ export function embedApp(
       stage.innerHTML = '<div class="message">' + esc(message) + '</div>';
     }
 
-    function shouldDirectRenderEmbed() {
-      const host = window.location.hostname.toLowerCase();
-      return host === "claudemcpcontent.com" || host.endsWith(".claudemcpcontent.com");
-    }
-
     function clearFrameReadyTimer() {
       if (!appFrameReadyTimer) return;
       clearTimeout(appFrameReadyTimer);
       appFrameReadyTimer = null;
     }
 
+    function clearFrameLoadTimer() {
+      if (!appFrameLoadTimer) return;
+      clearTimeout(appFrameLoadTimer);
+      appFrameLoadTimer = null;
+    }
+
+    function startFrameReadyTimer(frame) {
+      clearFrameReadyTimer();
+      appFrameReadyTimer = setTimeout(() => {
+        if (!appFrameReady && appFrame === frame) renderFrameFallback();
+      }, 7000);
+    }
+
     function renderFrameFallback() {
       clearFrameReadyTimer();
+      clearFrameLoadTimer();
       appFrame = null;
       stage.innerHTML =
         '<div class="fallback">' +
@@ -318,6 +328,7 @@ export function embedApp(
 
     function renderFrame(src) {
       clearFrameReadyTimer();
+      clearFrameLoadTimer();
       const frame = document.createElement("iframe");
       frame.title = body.dataset.iframeTitle || "Agent Native app";
       frame.src = src;
@@ -325,12 +336,17 @@ export function embedApp(
       appFrame = frame;
       appFrameReady = false;
       lastFrameSrc = src;
-      frame.addEventListener("load", () => sendFrameReadyMessages(frame));
+      frame.addEventListener("load", () => {
+        if (appFrame !== frame) return;
+        clearFrameLoadTimer();
+        sendFrameReadyMessages(frame);
+        startFrameReadyTimer(frame);
+      });
       stage.replaceChildren(frame);
       notifyHostHeight();
-      appFrameReadyTimer = setTimeout(() => {
+      appFrameLoadTimer = setTimeout(() => {
         if (!appFrameReady && appFrame === frame) renderFrameFallback();
-      }, 7000);
+      }, 30000);
     }
 
     async function updateHostModelContext(data) {
@@ -444,6 +460,7 @@ export function embedApp(
       const data = event.data.data || {};
       if (event.data.type === "agentNative.embeddedAppReady") {
         appFrameReady = true;
+        clearFrameLoadTimer();
         clearFrameReadyTimer();
         return;
       }
@@ -486,10 +503,6 @@ export function embedApp(
         if (!data.startUrl) {
           startedFor = "";
           setMessage(data.error || "This app can be opened, but not embedded from this MCP server.");
-          return;
-        }
-        if (shouldDirectRenderEmbed()) {
-          window.location.href = data.startUrl;
           return;
         }
         renderFrame(data.startUrl);

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -356,7 +356,14 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(echo._meta?.["ui/resourceUri"]).toBe("ui://mail/echo-thing");
     expect(echo._meta?.["openai/outputTemplate"]).toBe("ui://mail/echo-thing");
     expect(echo._meta?.["openai/widgetAccessible"]).toBe(true);
+    expect(echo._meta?.["openai/widgetCSP"]).toEqual({
+      connect_domains: ["https://mail.agent-native.com"],
+    });
     expect(echo._meta?.ui).toEqual({
+      csp: {
+        connectDomains: ["https://mail.agent-native.com"],
+      },
+      prefersBorder: true,
       resourceUri: "ui://mail/echo-thing",
       visibility: ["model", "app"],
     });
@@ -477,7 +484,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     );
   });
 
-  it("keeps the full catalog for generic remote web OAuth clients without mcp:apps", async () => {
+  it("uses the compact catalog for generic remote web OAuth clients without mcp:apps", async () => {
     mockOAuthClients.set("agent-native-oauth-client-generated-web-host", {
       clientId: "agent-native-oauth-client-generated-web-host",
       clientName: "Acme Web MCP Host",
@@ -503,12 +510,15 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     const names = out.result.tools.map((t: any) => t.name);
     expect(names).toEqual(
-      expect.arrayContaining(["echo-thing", "internal-heavy", "ask-agent"]),
+      expect.arrayContaining(["echo-thing", "review-draft"]),
     );
-    expect(JSON.stringify(out)).toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
+    expect(names).not.toContain("internal-heavy");
+    expect(names).not.toContain("ask-agent");
+    expect(JSON.stringify(out)).not.toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
+    expect(JSON.stringify(out).length).toBeLessThan(12_000);
   });
 
-  it("keeps the full catalog for unknown standard OAuth clients without mcp:apps", async () => {
+  it("uses the compact catalog for unknown standard OAuth clients without mcp:apps", async () => {
     const out = await callWeb(
       {
         jsonrpc: "2.0",
@@ -528,9 +538,12 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     const names = out.result.tools.map((t: any) => t.name);
     expect(names).toEqual(
-      expect.arrayContaining(["echo-thing", "internal-heavy", "ask-agent"]),
+      expect.arrayContaining(["echo-thing", "review-draft"]),
     );
-    expect(JSON.stringify(out)).toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
+    expect(names).not.toContain("internal-heavy");
+    expect(names).not.toContain("ask-agent");
+    expect(JSON.stringify(out)).not.toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
+    expect(JSON.stringify(out).length).toBeLessThan(12_000);
   });
 
   it("keeps the full catalog for code-oriented OAuth clients without mcp:apps", async () => {
@@ -701,6 +714,15 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.result._meta["openai/outputTemplate"]).toBe(
       "ui://mail/echo-thing",
     );
+    expect(out.result._meta["openai/widgetCSP"]).toEqual({
+      connect_domains: ["https://mail.agent-native.com"],
+    });
+    expect(out.result._meta.ui).toMatchObject({
+      csp: {
+        connectDomains: ["https://mail.agent-native.com"],
+      },
+      prefersBorder: true,
+    });
     expect(out.result.structuredContent).toMatchObject({
       echoed: "hello",
       id: "thing-42",


### PR DESCRIPTION
## Summary
- add a ChatGPT `window.openai` bridge path to the shared `embedApp()` wrapper so full-app MCP embeds can launch without waiting on the standard module bridge
- keep the standard MCP Apps `ui/*` bridge for Claude/other hosts and add a route-ready fallback when nested frames are blocked
- compact unknown OAuth app hosts by default so MCP Apps hosts do not receive giant hidden tool/resource catalogs
- update external-agent docs and skills for the real-app embed pattern

## Verification
- pnpm --dir packages/core exec vitest --run src/mcp/embed-app.spec.ts src/mcp/server.spec.ts src/mcp/build-server.verify-auth.spec.ts
- pnpm --dir packages/core typecheck
- pnpm prep

## Notes
Production still needs this deploy before the ChatGPT card can be retested end-to-end with the new bridge.