### PR TITLE
Fix MCP app embeds and SSR caching

### DIFF
--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -300,18 +300,23 @@ Keep the existing `link` builder even when adding `mcpApp`. CLI-only clients,
 older hosts, and any host that does not render MCP Apps will ignore the UI
 metadata and still need the "Open in … →" link. `embedApp()` uses that link as
 its launch target, calls the app-only `create_embed_session` helper, exchanges
-a one-time SQL ticket at `/_agent-native/embed/start`, then navigates the MCP
-App resource frame itself to the real app route with a short-lived browser
-session. This avoids the fragile "iframe inside the host's iframe" shape that
-Claude and some ChatGPT surfaces block or paint blank. A nested iframe remains
-available only as an explicit diagnostic fallback (`embedMode: "iframe"` /
-`renderMode: "iframe"` / `nested: true`); pass `frameDomains` only for that
-diagnostic or for a custom MCP App that truly embeds a third-party frame.
-Claude currently restricts third-party `frameDomains`, so normal product UI
-must stay on the direct route-navigation path. `open_app({ app, path, embed:
-true })` is the generic escape hatch for routes like full dashboards, filtered
-inboxes, calendar drafts, analyses, or extension pages, and should be used
-liberally when the full app is the clearest review/edit surface.
+a one-time SQL ticket at `/_agent-native/embed/start`, then launches the real
+app route with a short-lived browser session. ChatGPT uses a controlled route
+iframe to avoid web-sandbox auto-height feedback loops. Standard hosts that can
+hydrate the route directly navigate the MCP App frame itself. Claude web
+currently proxies MCP App content through `claudemcpcontent.com`; direct route
+navigation can fetch app HTML there without reliably running the framework
+bootstrap, and a second nested iframe is easy for the host to block. For
+Claude, `embedApp()` fetches the signed route HTML and mounts the real app
+document into the existing MCP resource frame, with app-origin requests routed
+back to the app using the embed token. You can force the nested diagnostic
+iframe with `embedMode: "iframe"` /
+`renderMode: "iframe"` / `nested: true` when debugging host behavior. Pass
+additional `frameDomains` only for a custom MCP App that truly embeds a
+third-party frame. `open_app({ app, path, embed: true })` is the generic
+escape hatch for routes like full dashboards, filtered inboxes, calendar
+drafts, analyses, or extension pages, and should be used liberally when the
+full app is the clearest review/edit surface.
 
 For known first-party handoffs, prefer a direct action with `mcpApp` over
 letting the model hunt through screens. Examples: Mail `manage-draft` for email

--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -282,7 +282,6 @@ export default defineAction({
       description: "Open the generated draft in the real Mail compose UI.",
       iframeTitle: "Agent-Native Mail",
       openLabel: "Open in Mail",
-      frameDomains: ["https:", "http://localhost:*", "http://127.0.0.1:*"],
     }),
   },
 });
@@ -306,10 +305,13 @@ App resource frame itself to the real app route with a short-lived browser
 session. This avoids the fragile "iframe inside the host's iframe" shape that
 Claude and some ChatGPT surfaces block or paint blank. A nested iframe remains
 available only as an explicit diagnostic fallback (`embedMode: "iframe"` /
-`renderMode: "iframe"` / `nested: true`). `open_app({ app, path, embed: true })`
-is the generic escape hatch for routes like full dashboards, filtered inboxes,
-calendar drafts, analyses, or extension pages, and should be used liberally
-when the full app is the clearest review/edit surface.
+`renderMode: "iframe"` / `nested: true`); pass `frameDomains` only for that
+diagnostic or for a custom MCP App that truly embeds a third-party frame.
+Claude currently restricts third-party `frameDomains`, so normal product UI
+must stay on the direct route-navigation path. `open_app({ app, path, embed:
+true })` is the generic escape hatch for routes like full dashboards, filtered
+inboxes, calendar drafts, analyses, or extension pages, and should be used
+liberally when the full app is the clearest review/edit surface.
 
 For known first-party handoffs, prefer a direct action with `mcpApp` over
 letting the model hunt through screens. Examples: Mail `manage-draft` for email

--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -318,6 +318,13 @@ escape hatch for routes like full dashboards, filtered inboxes, calendar
 drafts, analyses, or extension pages, and should be used liberally when the
 full app is the clearest review/edit surface.
 
+Host sizing rule: the MCP resource shell owns a bounded inline height and the
+embedded route should scroll internally. Do not re-enable host SDK auto-resize
+for full-app route embeds; Claude and ChatGPT can otherwise measure the whole
+document and create a huge chat iframe. After changing the shell or `ui://`
+resource version, verify with a fresh tool call because old conversation frames
+keep the behavior they were rendered with.
+
 For known first-party handoffs, prefer a direct action with `mcpApp` over
 letting the model hunt through screens. Examples: Mail `manage-draft` for email
 drafts, Analytics `open-traffic-dashboard` for the first-party traffic
@@ -418,6 +425,9 @@ connect or present a token rather than assuming the action is missing.
 - Do use `embedApp()` / `open_app({ embed: true })` when the right UI is the
   existing React app at a specific route, including full app routes and focused
   component routes like an Analytics chart embed.
+- Do test real ChatGPT/Claude web behavior with a fresh inline render after any
+  resource-shell or host-bridge change; old frames are not proof that a new
+  shell is still broken.
 - Do build the URL with `buildDeepLink(...)` — it is the single source of truth
   for the open-route format.
 - Do keep `link` pure and synchronous; return `null` when there's nothing to
@@ -439,6 +449,8 @@ connect or present a token rather than assuming the action is missing.
 - Don't replace deep links with MCP Apps; non-UI clients still need the link.
 - Don't hand-write product UI in `mcpApp.resource.html`; use a real React
   route/component and embed it with `embedApp()`.
+- Don't use nested iframes for Claude web as the normal route; use the
+  single-frame mounted route path and reserve nested iframes for diagnostics.
 - Don't scope the `navigate` write to the agent token, or pass privileged
   state through the deep link — it's a pure pointer.
 - Don't invent a new navigation mechanism; bridge to the existing

--- a/.changeset/cacheable-ssr-pages.md
+++ b/.changeset/cacheable-ssr-pages.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Default Agent-Native SSR page responses to public cache headers with short max-age, week-long stale-while-revalidate, and hour-long stale-if-error, without creating sessions for anonymous page hits.

--- a/.changeset/mcp-app-direct-route-embeds.md
+++ b/.changeset/mcp-app-direct-route-embeds.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Improve MCP App route embeds by using signed real app routes across hosts, preserving host chat bridge state, controlling ChatGPT route height, and mounting the real signed app document inside Claude's proxied MCP content frame.

--- a/.changeset/mcp-app-visible-height.md
+++ b/.changeset/mcp-app-visible-height.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Make MCP app embeds default to 560px, shrink toward the host-visible height, and cap dynamic resize reports at the configured embed height.

--- a/.changeset/smooth-mcp-app-embeds.md
+++ b/.changeset/smooth-mcp-app-embeds.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Make MCP App embeds navigate the host frame into the real app route, keep the MCP chat bridge alive after embed-token redirects, and cache-bust the shared MCP App shell resource.
+Make MCP App embeds navigate the host frame into the real app route, keep the MCP chat bridge alive after embed-token redirects, avoid nested-frame CSP by default for Claude compatibility, and cache-bust the shared MCP App shell resource.

--- a/.changeset/smooth-mcp-app-embeds.md
+++ b/.changeset/smooth-mcp-app-embeds.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-Make MCP App embeds navigate the host frame into the real app route, keep the MCP chat bridge alive after embed-token redirects, avoid nested-frame CSP by default for Claude compatibility, and cache-bust the shared MCP App shell resource.

--- a/packages/core/docs/content/actions.md
+++ b/packages/core/docs/content/actions.md
@@ -199,6 +199,9 @@ export default defineAction({
 This advertises the MCP Apps extension (`io.modelcontextprotocol/ui`), exposes the HTML via MCP resources/templates, and includes standard MCP Apps plus ChatGPT Apps SDK widget metadata for compatible hosts. Keep `link` as the fallback for CLI and non-UI MCP clients; see [External Agents](/docs/external-agents#mcp-apps).
 
 The helper launches the action's `link` target through `/_agent-native/embed/start` with a short-lived browser session, so routes such as full dashboards, filtered inboxes, drafts, and extension pages can reuse the app's React components directly.
+It does not request nested `frameDomains` unless you pass them explicitly; keep
+normal product UI on the single-frame route-navigation path for Claude
+compatibility.
 
 Embedded routes can use the exported client helpers for the MCP App host
 bridge. Under the hood, routes receive `agentNative.mcpHostContext` and may

--- a/packages/core/docs/content/actions.md
+++ b/packages/core/docs/content/actions.md
@@ -199,16 +199,17 @@ export default defineAction({
 This advertises the MCP Apps extension (`io.modelcontextprotocol/ui`), exposes the HTML via MCP resources/templates, and includes standard MCP Apps plus ChatGPT Apps SDK widget metadata for compatible hosts. Keep `link` as the fallback for CLI and non-UI MCP clients; see [External Agents](/docs/external-agents#mcp-apps).
 
 The helper launches the action's `link` target through `/_agent-native/embed/start` with a short-lived browser session, so routes such as full dashboards, filtered inboxes, drafts, and extension pages can reuse the app's React components directly.
-It does not request nested `frameDomains` unless you pass them explicitly; keep
-normal product UI on the single-frame route-navigation path for Claude
-compatibility.
+ChatGPT uses a controlled route iframe to avoid web-sandbox auto-height
+feedback loops. Claude web uses a single-frame mount path automatically: the
+launcher fetches the signed route HTML inside Claude's MCP resource frame,
+mounts the real app document there, and rewrites app-origin network calls back
+to the original app with the embed token.
 
 Embedded routes can use the exported client helpers for the MCP App host
-bridge. Under the hood, routes receive `agentNative.mcpHostContext` and may
-post `agentNative.mcpHost.updateModelContext`,
-`agentNative.mcpHost.openLink`, or
-`agentNative.mcpHost.requestDisplayMode`; the wrapper replies with
-`agentNative.mcpHost.response`.
+bridge. Direct and Claude-mounted route embeds post standard `ui/*` JSON-RPC
+messages to the host, while the ChatGPT controlled-frame path and explicit
+nested-iframe diagnostic path proxy `agentNative.mcpHost.*` messages through
+the launch wrapper.
 
 ## Standard actions {#standard-actions}
 

--- a/packages/core/docs/content/actions.md
+++ b/packages/core/docs/content/actions.md
@@ -210,6 +210,12 @@ bridge. Direct and Claude-mounted route embeds post standard `ui/*` JSON-RPC
 messages to the host, while the ChatGPT controlled-frame path and explicit
 nested-iframe diagnostic path proxy `agentNative.mcpHost.*` messages through
 the launch wrapper.
+When a submitted app prompt should continue the host chat, call
+`sendToAgentChat()` from the embedded route; it sends hidden model context and
+then posts a visible user message through the host bridge where supported.
+Design those routes with their own scrolling, because the MCP resource reports
+a bounded inline height rather than asking the host to size itself to the full
+app document.
 
 ## Standard actions {#standard-actions}
 

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -219,41 +219,47 @@ Claude Code and other CLI-first clients still receive the same resources and met
 
 MCP App embeds are route embeds, not separate mini-products. `embedApp()`
 starts from the action's `link` target, creates a short-lived embed session,
-and by default navigates the MCP App frame itself to that app route. That keeps
-Claude and ChatGPT on a single iframe instead of relying on a nested app iframe.
-Design embedded routes so a reload with the same URL reconstructs the same view.
+and launches that signed app route. Standard MCP Apps hosts can navigate the
+MCP App frame itself. ChatGPT gets a controlled route iframe because its web
+sandbox can otherwise auto-size a full app route into a feedback loop. Claude
+web currently proxies MCP App content through `claudemcpcontent.com`; direct
+route navigation can fetch the app HTML there without reliably running the
+framework bootstrap, and a second nested iframe is easy for the host to block.
+For Claude, the launcher fetches the signed app HTML and mounts that document
+into the existing MCP resource frame, then rewrites app-origin
+fetch/XHR/EventSource calls back to the app with the embed token. The app still
+renders the normal route and React components. Design embedded routes so a
+reload with the same signed URL reconstructs the same view.
 
 ChatGPT gets a dedicated compatibility path through `window.openai`: the launch
 document reads `toolInput`, `toolOutput`, and `toolResponseMetadata` directly,
 then calls `create_embed_session` via `window.openai.callTool(...)`. Standard
-MCP Apps hosts use the `ui/*` JSON-RPC bridge. After the direct navigation, the
-loaded app route can still call `ui/update-model-context`, `ui/message`,
-`ui/open-link`, and `ui/request-display-mode` through the host bridge helpers.
-Keep the result shape identical for both paths: return a focused `link` and
-concise structured content.
+MCP Apps hosts use the `ui/*` JSON-RPC bridge. Direct and Claude-mounted routes
+can call `ui/update-model-context`, `ui/message`, `ui/open-link`, and
+`ui/request-display-mode` through the host bridge helpers. When the ChatGPT or
+explicit diagnostic iframe path is used, the wrapper relays the same host
+actions over `agentNative.mcpHost.*` postMessage requests. Keep the result
+shape identical for both paths: return a focused `link` and concise structured
+content.
 
-An explicit nested iframe diagnostic path remains available with
-`embedMode: "iframe"`, `renderMode: "iframe"`, `nested: true`, or
-`frame: "iframe"`. Use it only when debugging host behavior, and pass
-`frameDomains` explicitly if the target host supports nested third-party
-frames. Claude currently restricts `frameDomains`, so the default route is the
-direct frame navigation path. If that diagnostic iframe is blocked,
-`embedApp()` replaces it with an open-app fallback: the user can retry inline,
-open a freshly minted embed session through the host, or use the visible route
-URL. Keep the action's `link` target useful on its own because it is still the
-universal escape hatch.
+You can force the nested diagnostic iframe with `embedMode: "iframe"`,
+`renderMode: "iframe"`, `nested: true`, or `frame: "iframe"` when debugging
+host behavior. If the iframe is blocked, `embedApp()` replaces it with an
+open-app fallback: the user can retry inline, open a freshly minted embed
+session through the host, or use the visible route URL. Keep the action's
+`link` target useful on its own because it is still the universal escape hatch.
 
 The host bridge is deliberately small:
 
-| Mode              | Message type                          | Use it for                               |
-| ----------------- | ------------------------------------- | ---------------------------------------- |
-| direct            | `ui/update-model-context`             | Hidden context for the host model        |
-| direct            | `ui/message`                          | Post a visible user turn into the host   |
-| direct            | `ui/open-link`                        | Open an external or app URL via the host |
-| direct            | `ui/request-display-mode`             | Request `inline`, `fullscreen`, or `pip` |
-| nested diagnostic | `agentNative.mcpHostContext`          | Theme, locale, host platform, dimensions |
-| nested diagnostic | `agentNative.embeddedAppReady`        | Confirm the route iframe loaded          |
-| nested diagnostic | `agentNative.mcpHost.*` / `.response` | Wrapper relay for host requests          |
+| Mode                     | Message type                          | Use it for                               |
+| ------------------------ | ------------------------------------- | ---------------------------------------- |
+| direct / Claude          | `ui/update-model-context`             | Hidden context for the host model        |
+| direct / Claude          | `ui/message`                          | Post a visible user turn into the host   |
+| direct / Claude          | `ui/open-link`                        | Open an external or app URL via the host |
+| direct / Claude          | `ui/request-display-mode`             | Request `inline`, `fullscreen`, or `pip` |
+| ChatGPT / iframe wrapper | `agentNative.mcpHostContext`          | Theme, locale, host platform, dimensions |
+| ChatGPT / iframe wrapper | `agentNative.embeddedAppReady`        | Confirm the route iframe loaded          |
+| ChatGPT / iframe wrapper | `agentNative.mcpHost.*` / `.response` | Wrapper relay for host requests          |
 
 Embedded routes can use `updateMcpAppModelContext()`,
 `openMcpAppHostLink()`, `requestMcpAppDisplayMode()`,
@@ -364,10 +370,10 @@ The MCP server advertises extension `io.modelcontextprotocol/ui`, adds `_meta.ui
 
 Keep the existing `link` builder even when adding `mcpApp`. CLI-only clients, older hosts, and any host that does not render MCP Apps will ignore the UI metadata and still need the `"Open in … →"` link. `embedApp()` uses that link as its launch target, calls the app-only `create_embed_session` helper, exchanges a one-time SQL ticket at `/_agent-native/embed/start`, and navigates the MCP App frame to the target route with a short-lived browser session plus a bearer fallback for same-origin fetches. `open_app({ app, path, embed: true })` is the generic escape hatch for routes such as full dashboards, filtered inboxes, calendar draft views, analyses, and extension pages, and should be used liberally when the full app is the clearest review/edit surface.
 
-`embedApp()` does not request `frameDomains` by default. That keeps Claude and
-other hosts on the supported single-frame path. Only pass `frameDomains` for an
-explicit nested-iframe diagnostic or for a custom MCP App that truly embeds a
-third-party player.
+`embedApp()` includes the MCP request origin in the resource CSP so the launcher
+can fetch and, when explicitly requested, frame the signed first-party app
+route. Only pass additional `frameDomains` for a custom MCP App that truly
+embeds a third-party player.
 
 Inside those `embedApp()` routes, `sendToAgentChat()` is embed-aware.
 Auto-submitted prompts relay to the MCP host as `ui/update-model-context` plus

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -242,6 +242,14 @@ actions over `agentNative.mcpHost.*` postMessage requests. Keep the result
 shape identical for both paths: return a focused `link` and concise structured
 content.
 
+The resource shell owns the outer host size. Keep embedded app routes
+internally scrollable and let the launcher report a bounded intrinsic height
+rather than the full document height; otherwise host auto-resize can turn a
+normal app page into a very tall chat artifact. A changed shell only affects
+new MCP App resources and new tool calls. Old ChatGPT/Claude conversation
+frames can keep the previous resource behavior, so verify sizing with a fresh
+inline render before judging a fix.
+
 You can force the nested diagnostic iframe with `embedMode: "iframe"`,
 `renderMode: "iframe"`, `nested: true`, or `frame: "iframe"` when debugging
 host behavior. If the iframe is blocked, `embedApp()` replaces it with an
@@ -377,7 +385,9 @@ embeds a third-party player.
 
 Inside those `embedApp()` routes, `sendToAgentChat()` is embed-aware.
 Auto-submitted prompts relay to the MCP host as `ui/update-model-context` plus
-`ui/message`; `submit: false` remains local prefill/review behavior.
+`ui/message`, so a button in the embedded app can intentionally continue the
+Claude/ChatGPT conversation from the selected app state. `submit: false`
+remains local prefill/review behavior.
 
 ### The `link` contract {#link-contract}
 
@@ -522,6 +532,9 @@ The fallback hosted `connect` flow never copies the deployment's shared secret. 
 - Test MCP Apps with the lightweight fixtures around `embedApp()` and
   `McpAppRenderer`; they cover CSP, host context, app launch, and bridge
   message behavior without needing a real external host.
+- When validating ChatGPT or Claude web, trigger a fresh tool call after shell
+  changes and measure the visible iframe. Previously rendered frames in the
+  same conversation may still show cached height or launch behavior.
 
 **Don't**
 

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -234,11 +234,14 @@ concise structured content.
 
 An explicit nested iframe diagnostic path remains available with
 `embedMode: "iframe"`, `renderMode: "iframe"`, `nested: true`, or
-`frame: "iframe"`. Use it only when debugging host behavior. If that diagnostic
-iframe is blocked, `embedApp()` replaces it with an open-app fallback: the user
-can retry inline, open a freshly minted embed session through the host, or use
-the visible route URL. Keep the action's `link` target useful on its own because
-it is still the universal escape hatch.
+`frame: "iframe"`. Use it only when debugging host behavior, and pass
+`frameDomains` explicitly if the target host supports nested third-party
+frames. Claude currently restricts `frameDomains`, so the default route is the
+direct frame navigation path. If that diagnostic iframe is blocked,
+`embedApp()` replaces it with an open-app fallback: the user can retry inline,
+open a freshly minted embed session through the host, or use the visible route
+URL. Keep the action's `link` target useful on its own because it is still the
+universal escape hatch.
 
 The host bridge is deliberately small:
 
@@ -352,7 +355,6 @@ export default defineAction({
       description: "Open the generated draft in the real Mail compose UI.",
       iframeTitle: "Agent-Native Mail",
       openLabel: "Open in Mail",
-      frameDomains: ["https:", "http://localhost:*", "http://127.0.0.1:*"],
     }),
   },
 });
@@ -361,6 +363,11 @@ export default defineAction({
 The MCP server advertises extension `io.modelcontextprotocol/ui`, adds `_meta.ui.resourceUri` plus `_meta["ui/resourceUri"]` to `tools/list`, and also emits ChatGPT Apps SDK compatibility metadata (`openai/outputTemplate`, widget CSP/description/accessibility). It exposes the HTML through `resources/list`, `resources/templates/list`, and `resources/read` using MIME `text/html;profile=mcp-app`. The stdio proxy forwards those resource handlers from the live app, so desktop and CLI clients see the same resources as HTTP clients.
 
 Keep the existing `link` builder even when adding `mcpApp`. CLI-only clients, older hosts, and any host that does not render MCP Apps will ignore the UI metadata and still need the `"Open in … →"` link. `embedApp()` uses that link as its launch target, calls the app-only `create_embed_session` helper, exchanges a one-time SQL ticket at `/_agent-native/embed/start`, and navigates the MCP App frame to the target route with a short-lived browser session plus a bearer fallback for same-origin fetches. `open_app({ app, path, embed: true })` is the generic escape hatch for routes such as full dashboards, filtered inboxes, calendar draft views, analyses, and extension pages, and should be used liberally when the full app is the clearest review/edit surface.
+
+`embedApp()` does not request `frameDomains` by default. That keeps Claude and
+other hosts on the supported single-frame path. Only pass `frameDomains` for an
+explicit nested-iframe diagnostic or for a custom MCP App that truly embeds a
+third-party player.
 
 Inside those `embedApp()` routes, `sendToAgentChat()` is embed-aware.
 Auto-submitted prompts relay to the MCP host as `ui/update-model-context` plus

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -104,6 +104,10 @@ keeps the old wrapper-to-route postMessage relay:
 | route → wrapper | `agentNative.mcpHost.requestDisplayMode` | `{ requestId, mode }`                         |
 | wrapper → route | `agentNative.mcpHost.response`           | `{ requestId, ok, result?, error? }`          |
 
+`embedApp()` only includes `frameDomains` when you pass them explicitly.
+Claude currently restricts third-party nested iframe domains, so normal
+full-app embeds should stay on the direct route-navigation path.
+
 Host-mediated open links keep the iframe from choosing its own browser target.
 Model context updates are opt-in and hidden from the user-facing transcript.
 Display mode requests are best-effort: a host can honor, ignore, or reject the

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -91,6 +91,13 @@ For normal action authoring, use `embedRoute()` when the action's
 `link` and `mcpApp` should come from the same pure route builder. The route
 itself should derive state from the URL and normal app data fetching.
 
+The outer MCP resource reports a bounded inline height to the host and the app
+route scrolls internally. Do not rely on host auto-resize measuring the full
+document; in ChatGPT and Claude this can make a normal full-app route appear as
+a huge chat artifact. Host conversations also keep already-rendered iframes, so
+after changing the resource shell or `ui://` version, test a fresh tool call
+rather than re-measuring an old frame.
+
 Default direct embeds talk to the MCP Apps host through standard `ui/*`
 JSON-RPC messages:
 
@@ -119,6 +126,11 @@ route. Pass additional `frameDomains` only for custom third-party frames.
 
 Host-mediated open links keep the iframe from choosing its own browser target.
 Model context updates are opt-in and hidden from the user-facing transcript.
+`ui/message` is the portable way for an embedded app button to ask the host to
+post a visible user message and continue the chat. In agent-native routes,
+`sendToAgentChat()` uses `ui/update-model-context` plus `ui/message` when
+called from a submitted MCP App embed, while `submit: false` remains an
+in-route draft/prefill path.
 Display mode requests are best-effort: a host can honor, ignore, or reject the
 request. Embedded routes must remain functional in the default inline mode.
 

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -78,8 +78,16 @@ If an action declares `mcpApp`, the server also advertises the official MCP Apps
 
 `embedApp()` is the low-level URL-first MCP App helper. It reads the action
 result's open link, asks the app-only `create_embed_session` tool to mint a
-route-scoped session, then navigates the MCP App frame itself to the resulting
-app route. For normal action authoring, use `embedRoute()` when the action's
+route-scoped session, then launches the resulting app route. ChatGPT and hosts
+that allow direct route hydration launch the same signed app URL, but ChatGPT
+keeps it in a controlled route iframe to avoid a web-sandbox auto-height
+feedback loop. Claude web currently proxies MCP App content under
+`claudemcpcontent.com`; direct route navigation can fetch app HTML there
+without reliably running the framework bootstrap, and a second nested iframe is
+easy for the host to block. For Claude, `embedApp()` fetches the signed app
+HTML and mounts the real route document into the existing MCP resource frame,
+with app-origin requests routed back to the original app using the embed token.
+For normal action authoring, use `embedRoute()` when the action's
 `link` and `mcpApp` should come from the same pure route builder. The route
 itself should derive state from the URL and normal app data fetching.
 
@@ -93,8 +101,9 @@ JSON-RPC messages:
 | `ui/open-link`            | `{ url }`                          |
 | `ui/request-display-mode` | `{ mode }`                         |
 
-An explicit `embedMode: "iframe"` / `renderMode: "iframe"` diagnostic path
-keeps the old wrapper-to-route postMessage relay:
+The ChatGPT controlled-frame path and any explicit `embedMode: "iframe"` /
+`renderMode: "iframe"` diagnostic path use the wrapper-to-route postMessage
+relay:
 
 | Direction       | Type                                     | Payload shape                                 |
 | --------------- | ---------------------------------------- | --------------------------------------------- |
@@ -104,9 +113,9 @@ keeps the old wrapper-to-route postMessage relay:
 | route → wrapper | `agentNative.mcpHost.requestDisplayMode` | `{ requestId, mode }`                         |
 | wrapper → route | `agentNative.mcpHost.response`           | `{ requestId, ok, result?, error? }`          |
 
-`embedApp()` only includes `frameDomains` when you pass them explicitly.
-Claude currently restricts third-party nested iframe domains, so normal
-full-app embeds should stay on the direct route-navigation path.
+`embedApp()` includes the MCP request origin in the resource CSP so the
+launcher can fetch and, when explicitly requested, frame the signed first-party
+route. Pass additional `frameDomains` only for custom third-party frames.
 
 Host-mediated open links keep the iframe from choosing its own browser target.
 Model context updates are opt-in and hidden from the user-facing transcript.

--- a/packages/core/src/client/embed-auth.spec.ts
+++ b/packages/core/src/client/embed-auth.spec.ts
@@ -106,6 +106,43 @@ describe("embed auth client", () => {
     expect(headers.get(EMBED_TARGET_HEADER)).toBe("/inbox?embedded=1");
   });
 
+  it("uses location.href as the app origin when the sandbox origin is opaque", async () => {
+    window.history.replaceState(null, "", "/inbox?embedded=1");
+    sessionStorage.setItem(STORAGE_KEY, "stored-token");
+    const originalOrigin = Object.getOwnPropertyDescriptor(
+      window.location,
+      "origin",
+    );
+    Object.defineProperty(window.location, "origin", {
+      configurable: true,
+      get: () => "null",
+    });
+    const originalFetch = vi.fn(async () => new Response("ok"));
+    Object.defineProperty(window, "fetch", {
+      configurable: true,
+      writable: true,
+      value: originalFetch,
+    });
+
+    try {
+      const { ensureEmbedAuthFetchInterceptor } = await loadEmbedAuth();
+      ensureEmbedAuthFetchInterceptor();
+
+      await window.fetch("/api/emails?view=inbox");
+
+      const [, init] = originalFetch.mock.calls[0]!;
+      const headers = new Headers(init?.headers);
+      expect(headers.get("Authorization")).toBe("Bearer stored-token");
+      expect(headers.get(EMBED_TARGET_HEADER)).toBe("/inbox?embedded=1");
+    } finally {
+      if (originalOrigin) {
+        Object.defineProperty(window.location, "origin", originalOrigin);
+      } else {
+        delete (window.location as unknown as { origin?: string }).origin;
+      }
+    }
+  });
+
   it("does not add embed credentials to cross-origin fetches", async () => {
     window.history.replaceState(null, "", "/inbox?embedded=1");
     sessionStorage.setItem(STORAGE_KEY, "stored-token");

--- a/packages/core/src/client/embed-auth.spec.ts
+++ b/packages/core/src/client/embed-auth.spec.ts
@@ -25,6 +25,7 @@ describe("embed auth client", () => {
       writable: true,
       value: vi.fn(async () => new Response("ok")),
     });
+    delete (window as Window & { openai?: unknown }).openai;
   });
 
   it("persists the URL token before stripping it from browser-visible history", async () => {
@@ -63,6 +64,30 @@ describe("embed auth client", () => {
     window.history.replaceState(null, "", "/inbox?embedded=1");
     const reloadedModule = await loadEmbedAuth();
     expect(reloadedModule.isEmbedMcpChatBridgeActive()).toBe(true);
+  });
+
+  it("clamps MCP chat bridge embeds to a stable viewport height", async () => {
+    const notifyIntrinsicHeight = vi.fn();
+    Object.defineProperty(window, "openai", {
+      configurable: true,
+      writable: true,
+      value: { notifyIntrinsicHeight },
+    });
+    window.history.replaceState(
+      null,
+      "",
+      `/inbox?embedded=1&${MCP_APP_CHAT_BRIDGE_QUERY_PARAM}=1&${EMBED_TOKEN_QUERY_PARAM}=signed-token`,
+    );
+
+    const first = await loadEmbedAuth();
+    first.ensureEmbedAuthFetchInterceptor();
+
+    const style = document.getElementById(
+      "agent-native-mcp-chat-bridge-viewport",
+    );
+    expect(style?.textContent).toContain("height: 560px !important");
+    expect(style?.textContent).toContain("overflow: hidden !important");
+    expect(notifyIntrinsicHeight).toHaveBeenCalledWith({ height: 560 });
   });
 
   it("does not leak a stored MCP chat bridge flag to a different embed token", async () => {

--- a/packages/core/src/client/embed-auth.ts
+++ b/packages/core/src/client/embed-auth.ts
@@ -16,6 +16,9 @@ const MCP_CHAT_BRIDGE_STORAGE_KEY = "agent-native:mcp-chat-bridge";
 const AUTH_FAILURE_COOLDOWN_MS = 60_000;
 const GUARDED_METHODS = new Set(["GET", "HEAD"]);
 const AUTH_FAILURE_HEADER = "x-agent-native-auth-circuit-breaker";
+const MCP_CHAT_BRIDGE_VIEWPORT_STYLE_ID =
+  "agent-native-mcp-chat-bridge-viewport";
+const MCP_CHAT_BRIDGE_VIEWPORT_HEIGHT = 560;
 
 type AuthFailureRecord = {
   status: number;
@@ -157,6 +160,79 @@ export function isEmbedAuthActive(): boolean {
   if (getEmbedAuthToken()) return true;
   const mode = currentUrl(win)?.searchParams.get(EMBED_MODE_QUERY_PARAM);
   return mode === "1" || mode === "true";
+}
+
+function ensureMcpChatBridgeViewportClamp(win: Window): void {
+  if (!isEmbedMcpChatBridgeActive()) return;
+  const doc = win.document;
+  if (!doc?.head) return;
+  if (!doc.getElementById(MCP_CHAT_BRIDGE_VIEWPORT_STYLE_ID)) {
+    const style = doc.createElement("style");
+    style.id = MCP_CHAT_BRIDGE_VIEWPORT_STYLE_ID;
+    const height = `${MCP_CHAT_BRIDGE_VIEWPORT_HEIGHT}px`;
+    style.textContent = `
+html,
+body {
+  min-height: 0 !important;
+  height: ${height} !important;
+  max-height: ${height} !important;
+  overflow: hidden !important;
+}
+
+#root,
+#__next,
+[data-agent-native-app-root] {
+  min-height: 0 !important;
+  height: ${height} !important;
+  max-height: ${height} !important;
+  overflow: hidden !important;
+}
+`;
+    doc.head.appendChild(style);
+  }
+  notifyMcpChatBridgeViewportHeight(win);
+}
+
+function notifyMcpChatBridgeViewportHeight(win: Window): void {
+  const height = MCP_CHAT_BRIDGE_VIEWPORT_HEIGHT;
+  const notify = () => {
+    try {
+      const openai = (
+        win as Window & {
+          openai?: {
+            notifyIntrinsicHeight?: (payload: { height: number }) => void;
+          };
+        }
+      ).openai;
+      openai?.notifyIntrinsicHeight?.({ height });
+    } catch {
+      // Host bridge availability varies by client; sizing is best-effort.
+    }
+
+    try {
+      if (win.parent && win.parent !== win) {
+        win.parent.postMessage(
+          {
+            jsonrpc: "2.0",
+            method: "ui/notifications/size-changed",
+            params: { height },
+          },
+          "*",
+        );
+      }
+    } catch {
+      // Cross-host embeds can deny parent messaging in tests or strict sandboxes.
+    }
+  };
+
+  notify();
+  try {
+    win.requestAnimationFrame?.(() => notify());
+    win.setTimeout?.(notify, 250);
+    win.setTimeout?.(notify, 1000);
+  } catch {
+    // Timers are a progressive enhancement for late host bridge initialization.
+  }
 }
 
 /** Internal test helper. Do not use in app code. */
@@ -372,6 +448,7 @@ export function ensureEmbedAuthFetchInterceptor(): void {
     storeToken(urlToken, win);
     stripTokenFromUrl(win);
   }
+  ensureMcpChatBridgeViewportClamp(win);
 
   if (installed) return;
   if (typeof win.fetch !== "function") return;

--- a/packages/core/src/client/embed-auth.ts
+++ b/packages/core/src/client/embed-auth.ts
@@ -189,11 +189,22 @@ function currentEmbedTarget(win: Window): string {
   return `${win.location.pathname}${win.location.search}`;
 }
 
+function currentAppOrigin(win: Window): string | null {
+  const url = currentUrl(win);
+  if (url?.origin && url.origin !== "null") return url.origin;
+  try {
+    const origin = win.location.origin;
+    return origin && origin !== "null" ? origin : null;
+  } catch {
+    return null;
+  }
+}
+
 function inputUrl(input: RequestInfo | URL, win: Window): URL | null {
   try {
     return input instanceof Request
       ? new URL(input.url)
-      : new URL(String(input), win.location.origin);
+      : new URL(String(input), currentUrl(win)?.href ?? win.location.href);
   } catch {
     return null;
   }
@@ -201,7 +212,8 @@ function inputUrl(input: RequestInfo | URL, win: Window): URL | null {
 
 function sameOrigin(input: RequestInfo | URL, win: Window): boolean {
   const url = inputUrl(input, win);
-  return !!url && url.origin === win.location.origin;
+  const origin = currentAppOrigin(win);
+  return !!url && !!origin && url.origin === origin;
 }
 
 function requestMethod(input: RequestInfo | URL, init?: RequestInit): string {
@@ -340,7 +352,8 @@ function requestUrlAndKey(
     }
   | undefined {
   const url = inputUrl(input, win);
-  if (!url || url.origin !== win.location.origin) return undefined;
+  const origin = currentAppOrigin(win);
+  if (!url || !origin || url.origin !== origin) return undefined;
   const method = requestMethod(input, init);
   return {
     key: authFailureKey(method, url),

--- a/packages/core/src/client/mcp-apps/McpAppRenderer.spec.ts
+++ b/packages/core/src/client/mcp-apps/McpAppRenderer.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   buildMcpAppCsp,
+  clampMcpAppHeight,
+  DEFAULT_MCP_APP_IFRAME_HEIGHT,
   supportedMcpAppPermissions,
 } from "./McpAppRenderer.js";
 
@@ -14,6 +16,14 @@ describe("McpAppRenderer security helpers", () => {
         clipboardWrite: {},
       }),
     ).toEqual({ clipboardWrite: {} });
+  });
+
+  it("defaults to 650px and caps reported height to the visible viewport", () => {
+    expect(DEFAULT_MCP_APP_IFRAME_HEIGHT).toBe(650);
+    expect(clampMcpAppHeight(1200, 700)).toBe(700);
+    expect(clampMcpAppHeight(420, 700)).toBe(420);
+    expect(clampMcpAppHeight(120, 700)).toBe(220);
+    expect(clampMcpAppHeight(420, 180)).toBe(180);
   });
 
   it("builds a restrictive CSP and drops invalid source expressions", () => {

--- a/packages/core/src/client/mcp-apps/McpAppRenderer.tsx
+++ b/packages/core/src/client/mcp-apps/McpAppRenderer.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   AppBridge,
   PostMessageTransport,
@@ -12,8 +18,9 @@ import type { AgentMcpAppPayload } from "../../mcp-client/app-result.js";
 import { agentNativePath } from "../api-path.js";
 import { cn } from "../utils.js";
 
-const DEFAULT_IFRAME_HEIGHT = 360;
-const MAX_IFRAME_HEIGHT = 900;
+export const DEFAULT_MCP_APP_IFRAME_HEIGHT = 650;
+const MIN_IFRAME_HEIGHT = 220;
+const VIEWPORT_MARGIN = 16;
 const SANDBOX_FLAGS = "allow-scripts allow-forms allow-popups";
 
 export interface McpAppRendererProps {
@@ -29,8 +36,9 @@ type ResourceUiMeta = {
 
 export function McpAppRenderer({ app, className }: McpAppRendererProps) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const desiredHeightRef = useRef(DEFAULT_MCP_APP_IFRAME_HEIGHT);
   const [loadedSrcDoc, setLoadedSrcDoc] = useState<string | null>(null);
-  const [height, setHeight] = useState(DEFAULT_IFRAME_HEIGHT);
+  const [height, setHeight] = useState(DEFAULT_MCP_APP_IFRAME_HEIGHT);
   const [error, setError] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
   const resourceHtml = app.resource ? htmlFromResource(app.resource) : "";
@@ -46,10 +54,67 @@ export function McpAppRenderer({ app, className }: McpAppRendererProps) {
   );
 
   useEffect(() => {
+    desiredHeightRef.current = DEFAULT_MCP_APP_IFRAME_HEIGHT;
+    setHeight(
+      clampMcpAppHeight(
+        DEFAULT_MCP_APP_IFRAME_HEIGHT,
+        availableMcpAppHeight(iframeRef.current),
+      ),
+    );
     setLoadedSrcDoc(null);
     setReady(false);
     setError(null);
   }, [srcDoc]);
+
+  const applyHeight = useCallback((desiredHeight?: number) => {
+    if (
+      typeof desiredHeight === "number" &&
+      Number.isFinite(desiredHeight) &&
+      desiredHeight > 0
+    ) {
+      desiredHeightRef.current = desiredHeight;
+    }
+    setHeight(
+      clampMcpAppHeight(
+        desiredHeightRef.current,
+        availableMcpAppHeight(iframeRef.current),
+      ),
+    );
+  }, []);
+
+  useEffect(() => {
+    let frame = 0;
+    const update = () => {
+      if (frame) cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        applyHeight();
+      });
+    };
+
+    update();
+    window.addEventListener("resize", update, { passive: true });
+    window.visualViewport?.addEventListener("resize", update, {
+      passive: true,
+    });
+    document.addEventListener("scroll", update, true);
+
+    const observer =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : null;
+    if (observer) {
+      observer.observe(document.documentElement);
+      const parent = iframeRef.current?.parentElement;
+      if (parent) observer.observe(parent);
+    }
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      window.removeEventListener("resize", update);
+      window.visualViewport?.removeEventListener("resize", update);
+      document.removeEventListener("scroll", update, true);
+      observer?.disconnect();
+    };
+  }, [applyHeight, srcDoc]);
 
   useEffect(() => {
     const iframe = iframeRef.current;
@@ -70,7 +135,10 @@ export function McpAppRenderer({ app, className }: McpAppRendererProps) {
         },
       },
       {
-        hostContext: buildHostContext(app) as any,
+        hostContext: buildHostContext(
+          app,
+          availableMcpAppHeight(iframe),
+        ) as any,
       },
     );
 
@@ -78,9 +146,7 @@ export function McpAppRenderer({ app, className }: McpAppRendererProps) {
       if (typeof nextHeight !== "number" || !Number.isFinite(nextHeight)) {
         return;
       }
-      setHeight(
-        Math.min(MAX_IFRAME_HEIGHT, Math.max(220, Math.ceil(nextHeight))),
-      );
+      applyHeight(nextHeight);
     });
     bridge.addEventListener("initialized", () => {
       if (closed) return;
@@ -148,7 +214,14 @@ export function McpAppRenderer({ app, className }: McpAppRendererProps) {
           void (bridge as any).close?.().catch?.(() => undefined);
         });
     };
-  }, [app, loadedSrcDoc, srcDoc, supportedPermissions, uiMeta.csp]);
+  }, [
+    app,
+    applyHeight,
+    loadedSrcDoc,
+    srcDoc,
+    supportedPermissions,
+    uiMeta.csp,
+  ]);
 
   if (!resourceHtml) {
     return (
@@ -292,7 +365,7 @@ function escapeAttribute(value: string): string {
     .replace(/</g, "&lt;");
 }
 
-function buildHostContext(app: AgentMcpAppPayload) {
+function buildHostContext(app: AgentMcpAppPayload, maxHeight: number) {
   const root =
     typeof window !== "undefined"
       ? getComputedStyle(document.documentElement)
@@ -326,7 +399,7 @@ function buildHostContext(app: AgentMcpAppPayload) {
     locale: typeof navigator !== "undefined" ? navigator.language : undefined,
     timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     containerDimensions: {
-      maxHeight: MAX_IFRAME_HEIGHT,
+      maxHeight,
       maxWidth: typeof window !== "undefined" ? window.innerWidth : undefined,
     },
     styles: {
@@ -393,6 +466,45 @@ function errorToolResult(message: string): CallToolResult {
     content: [{ type: "text", text: `Error: ${message}` }],
     isError: true,
   };
+}
+
+function finitePositiveNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : null;
+}
+
+export function availableMcpAppHeight(
+  element: HTMLElement | null | undefined,
+): number {
+  if (typeof window === "undefined") return DEFAULT_MCP_APP_IFRAME_HEIGHT;
+
+  const viewportHeight =
+    finitePositiveNumber(window.visualViewport?.height) ??
+    finitePositiveNumber(window.innerHeight) ??
+    DEFAULT_MCP_APP_IFRAME_HEIGHT;
+
+  if (!element) {
+    return Math.max(1, Math.floor(viewportHeight - VIEWPORT_MARGIN * 2));
+  }
+
+  const rect = element.getBoundingClientRect();
+  const top = Number.isFinite(rect.top)
+    ? Math.max(VIEWPORT_MARGIN, rect.top)
+    : VIEWPORT_MARGIN;
+  return Math.max(1, Math.floor(viewportHeight - top - VIEWPORT_MARGIN));
+}
+
+export function clampMcpAppHeight(
+  desiredHeight: number,
+  maxVisibleHeight: number,
+): number {
+  const maxHeight =
+    finitePositiveNumber(maxVisibleHeight) ?? DEFAULT_MCP_APP_IFRAME_HEIGHT;
+  const desired =
+    finitePositiveNumber(desiredHeight) ?? DEFAULT_MCP_APP_IFRAME_HEIGHT;
+  const minimum = Math.min(MIN_IFRAME_HEIGHT, maxHeight);
+  return Math.max(minimum, Math.min(maxHeight, Math.ceil(desired)));
 }
 
 function isSafeExternalUrl(value: string): boolean {

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -8,6 +8,9 @@ import {
   runNitroBuildPipeline,
 } from "./build.js";
 
+const DEFAULT_SSR_CACHE_CONTROL =
+  "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+
 const tempDirs: string[] = [];
 
 function makeTempDir(): string {
@@ -155,6 +158,9 @@ export default (event) =>
     expect(html).toContain('href="/docs/next"');
     expect(html).toContain('action="/docs/api/search"');
     expect(html).toContain('url("/docs/hero.png")');
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
 
     const redirect = await worker.fetch(
       new Request("https://app.test/docs/redirect", { method: "GET" }),

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -10,6 +10,8 @@ import {
 
 const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+const AUTHENTICATED_SSR_CACHE_CONTROL =
+  "private, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 
 const tempDirs: string[] = [];
 
@@ -169,6 +171,40 @@ export default (event) =>
     );
     expect(redirect.status).toBe(302);
     expect(redirect.headers.get("location")).toBe("/docs/login");
+  });
+
+  it("uses private SSR cache headers for authenticated Cloudflare worker SSR", async () => {
+    const worker = await importGeneratedWorker(generateWorkerEntry([], []));
+
+    const response = await worker.fetch(
+      new Request("https://app.test/docs/inbox", {
+        method: "GET",
+        headers: { cookie: "an_session=1" },
+      }),
+      { APP_BASE_PATH: "/docs" },
+      {},
+    );
+
+    expect(response.headers.get("cache-control")).toBe(
+      AUTHENTICATED_SSR_CACHE_CONTROL,
+    );
+  });
+
+  it("keeps public SSR cache headers for anonymous Cloudflare worker preference cookies", async () => {
+    const worker = await importGeneratedWorker(generateWorkerEntry([], []));
+
+    const response = await worker.fetch(
+      new Request("https://app.test/docs/inbox", {
+        method: "GET",
+        headers: { cookie: "sidebar:state=collapsed" },
+      }),
+      { APP_BASE_PATH: "/docs" },
+      {},
+    );
+
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
   });
 
   it("injects runtime browser Sentry config into generated worker SSR HTML", async () => {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -33,9 +33,12 @@ import {
   type WorkspaceCoreExports,
 } from "./workspace-core.js";
 import { generateActionRegistryForProject } from "../vite/action-types-plugin.js";
+import { mcpEmbedStaticAssetRouteRules } from "../shared/mcp-embed-headers.js";
 
 const cwd = process.cwd();
 const preset = process.env.NITRO_PRESET || "node";
+const DEFAULT_SSR_CACHE_CONTROL =
+  "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 
 function normalizeConfiguredAppBasePath(): string {
   const raw = process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH;
@@ -302,14 +305,34 @@ function injectHeadScript(html, script) {
   return html.slice(0, headCloseIdx) + script + html.slice(headCloseIdx);
 }
 
+const DEFAULT_SSR_CACHE_CONTROL = ${JSON.stringify(DEFAULT_SSR_CACHE_CONTROL)};
+
+function applyDefaultSsrCacheHeader(headers, status) {
+  if (headers.has("cache-control")) return;
+  if (status < 200 || status >= 400) return;
+
+  const contentType = (headers.get("content-type") || "").toLowerCase();
+  if (!contentType.includes("text/html")) return;
+
+  headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
+}
+
 async function rewriteMountedResponse(response, basePath) {
   const sentryClientConfigScript = getSentryClientConfigScript();
-  if (!basePath && !sentryClientConfigScript) return response;
-
   const headers = new Headers(response.headers);
+  applyDefaultSsrCacheHeader(headers, response.status);
+
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {
     headers.set("location", prefixMountedPath(location, basePath));
+  }
+
+  if (!basePath && !sentryClientConfigScript) {
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
   }
 
   const contentType = headers.get("content-type") || "";
@@ -381,7 +404,7 @@ async function getHandler() {
         headers: {
           "Access-Control-Allow-Origin": "*",
           "Access-Control-Allow-Methods": "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS",
-          "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Requested-With,X-Request-Source",
+          "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Requested-With,X-Request-Source,X-Agent-Native-CSRF,X-Agent-Native-Embed-Target",
         },
       });
     }
@@ -1296,6 +1319,7 @@ export default bundle;
     virtual: {
       "virtual:agents-bundle": agentsBundleModuleSource,
     },
+    routeRules: mcpEmbedStaticAssetRouteRules(appBasePath),
     // For edge presets (cloudflare, deno), bundle all deps — node_modules
     // aren't available at runtime. Netlify/Vercel/Node have node_modules.
     ...(preset.startsWith("cloudflare") || preset.startsWith("deno")

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -34,11 +34,17 @@ import {
 } from "./workspace-core.js";
 import { generateActionRegistryForProject } from "../vite/action-types-plugin.js";
 import { mcpEmbedStaticAssetRouteRules } from "../shared/mcp-embed-headers.js";
+import {
+  EMBED_SESSION_COOKIE,
+  EMBED_TOKEN_QUERY_PARAM,
+} from "../shared/embed-auth.js";
 
 const cwd = process.cwd();
 const preset = process.env.NITRO_PRESET || "node";
 const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+const AUTHENTICATED_SSR_CACHE_CONTROL =
+  "private, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 
 function normalizeConfiguredAppBasePath(): string {
   const raw = process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH;
@@ -306,21 +312,62 @@ function injectHeadScript(html, script) {
 }
 
 const DEFAULT_SSR_CACHE_CONTROL = ${JSON.stringify(DEFAULT_SSR_CACHE_CONTROL)};
+const AUTHENTICATED_SSR_CACHE_CONTROL = ${JSON.stringify(AUTHENTICATED_SSR_CACHE_CONTROL)};
+const EMBED_SESSION_COOKIE = ${JSON.stringify(EMBED_SESSION_COOKIE)};
+const EMBED_TOKEN_QUERY_PARAM = ${JSON.stringify(EMBED_TOKEN_QUERY_PARAM)};
+const ANONYMOUS_SESSION_COOKIE_NAMES = new Set(["an_docs_session"]);
+const BETTER_AUTH_SESSION_COOKIE_RE = /\\.session_(?:token|data)$/;
 
-function applyDefaultSsrCacheHeader(headers, status) {
+function isAuthenticatedCookieName(name) {
+  if (ANONYMOUS_SESSION_COOKIE_NAMES.has(name)) return false;
+  const bareName = String(name || "").replace(/^__(?:Secure|Host)-/, "");
+  return (
+    bareName === EMBED_SESSION_COOKIE ||
+    bareName === "an_session" ||
+    bareName === "an_session_workspace" ||
+    bareName.startsWith("an_session_") ||
+    bareName === "an.session_token" ||
+    bareName === "an.session_data" ||
+    BETTER_AUTH_SESSION_COOKIE_RE.test(bareName)
+  );
+}
+
+function requestHasAuthenticatedCookie(cookieHeader) {
+  if (!cookieHeader) return false;
+  return String(cookieHeader)
+    .split(";")
+    .map((cookie) => cookie.trim().split("=", 1)[0]?.trim())
+    .filter(Boolean)
+    .some(isAuthenticatedCookieName);
+}
+
+function requestHasAuthSignal(request) {
+  const url = new URL(request.url);
+  return Boolean(
+    request.headers.get("authorization") ||
+    requestHasAuthenticatedCookie(request.headers.get("cookie")) ||
+    url.searchParams.has(EMBED_TOKEN_QUERY_PARAM) ||
+    url.searchParams.has("_session")
+  );
+}
+
+function applyDefaultSsrCacheHeader(headers, status, hasAuthSignal) {
   if (headers.has("cache-control")) return;
   if (status < 200 || status >= 400) return;
 
   const contentType = (headers.get("content-type") || "").toLowerCase();
   if (!contentType.includes("text/html")) return;
 
-  headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
+  headers.set(
+    "cache-control",
+    hasAuthSignal ? AUTHENTICATED_SSR_CACHE_CONTROL : DEFAULT_SSR_CACHE_CONTROL,
+  );
 }
 
-async function rewriteMountedResponse(response, basePath) {
+async function rewriteMountedResponse(response, basePath, hasAuthSignal) {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
-  applyDefaultSsrCacheHeader(headers, response.status);
+  applyDefaultSsrCacheHeader(headers, response.status, hasAuthSignal);
 
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {
@@ -436,6 +483,7 @@ ${actionRegistrations.join("\n")}
       return new Response(null, { status: 404 });
     }
     const request = requestWithPathname(event.req, p);
+    const hasAuthSignal = requestHasAuthSignal(event.req);
     if (event.req.method === "HEAD") {
       const getRequest = requestWithMethod(request, "GET");
       const response = await rrHandler(getRequest);
@@ -446,9 +494,10 @@ ${actionRegistrations.join("\n")}
           headers: response.headers,
         }),
         basePath,
+        hasAuthSignal,
       );
     }
-    return rewriteMountedResponse(await rrHandler(request), basePath);
+    return rewriteMountedResponse(await rrHandler(request), basePath, hasAuthSignal);
   }));
 
   _handler = app.fetch.bind(app);

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -308,7 +308,7 @@ function safeUiSegment(value: string | undefined, fallback: string): string {
 
 // ChatGPT and Claude cache MCP App resource HTML by `ui://` URI. Bump this
 // when the shared shell changes in a way that must invalidate host caches.
-const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v4";
+const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v5";
 
 function legacyDefaultMcpAppUri(config: MCPConfig, actionName: string): string {
   const app = safeUiSegment(config.appId ?? config.name, "agent-native");

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -232,6 +232,49 @@ function metadataObject(value: unknown): Record<string, unknown> {
     : {};
 }
 
+function mcpAppEmbedOpenLinkMeta(
+  result: unknown,
+  resource: ResolvedMcpAppResource,
+  meta: MCPRequestMeta | undefined,
+): Record<string, unknown> {
+  const out = metadataObject(result);
+  const embedStartUrl =
+    typeof out.embedStartUrl === "string"
+      ? out.embedStartUrl
+      : out.embed === true &&
+          typeof out.url === "string" &&
+          out.url.includes("/_agent-native/embed/start")
+        ? out.url
+        : null;
+  if (!embedStartUrl) return {};
+
+  const webUrl = toAbsoluteOpenUrl(embedStartUrl, meta?.origin);
+  const deepLinkUrl =
+    typeof out.deepLinkUrl === "string" ? out.deepLinkUrl : null;
+  const fallbackLabel = resource.title ?? resource.name ?? "app";
+  const label =
+    typeof out.app === "string" && out.app.trim()
+      ? `Open ${out.app.trim()}`
+      : fallbackLabel;
+  const view =
+    typeof out.view === "string" && out.view.trim()
+      ? out.view.trim()
+      : typeof out.path === "string" && out.path.trim()
+        ? out.path.trim()
+        : undefined;
+
+  return {
+    "agent-native/openLink": {
+      label,
+      ...(view ? { view } : {}),
+      webUrl,
+      desktopUrl: deepLinkUrl
+        ? toAbsoluteOpenUrl(deepLinkUrl, meta?.origin)
+        : webUrl,
+    },
+  };
+}
+
 /**
  * Build the deep-link content block + structured `_meta` for a tool result.
  * Best-effort: any throw / nullish link is swallowed so a bad `link` builder
@@ -308,7 +351,7 @@ function safeUiSegment(value: string | undefined, fallback: string): string {
 
 // ChatGPT and Claude cache MCP App resource HTML by `ui://` URI. Bump this
 // when the shared shell changes in a way that must invalidate host caches.
-const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v5";
+const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v22";
 
 function legacyDefaultMcpAppUri(config: MCPConfig, actionName: string): string {
   const app = safeUiSegment(config.appId ?? config.name, "agent-native");
@@ -852,6 +895,7 @@ export async function createMCPServerForRequest(
 
       try {
         const result = await entry.run((args as Record<string, string>) ?? {});
+        const rawResult = isMcpActionResult(result) ? result.raw : result;
         const resultForClient = isMcpActionResult(result)
           ? result.text
           : result;
@@ -864,18 +908,18 @@ export async function createMCPServerForRequest(
         const { block, _meta } = buildLinkArtifacts(
           entry,
           (args as Record<string, any>) ?? {},
-          isMcpActionResult(result) ? result.raw : result,
+          rawResult,
           requestMeta,
         );
         const responseMeta: Record<string, unknown> = {
           ...(_meta ?? {}),
+          ...(mcpAppResource
+            ? mcpAppEmbedOpenLinkMeta(rawResult, mcpAppResource, requestMeta)
+            : {}),
           ...(mcpAppResource ? openAiToolResultMeta(mcpAppResource) : {}),
         };
         const structuredContent = mcpAppResource
-          ? mcpAppStructuredContent(
-              isMcpActionResult(result) ? result.raw : result,
-              responseMeta,
-            )
+          ? mcpAppStructuredContent(rawResult, responseMeta)
           : undefined;
         const text = mcpAppResource
           ? conciseMcpAppToolText(name, resultForClient, structuredContent!)

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -308,7 +308,7 @@ function safeUiSegment(value: string | undefined, fallback: string): string {
 
 // ChatGPT and Claude cache MCP App resource HTML by `ui://` URI. Bump this
 // when the shared shell changes in a way that must invalidate host caches.
-const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v3";
+const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v4";
 
 function legacyDefaultMcpAppUri(config: MCPConfig, actionName: string): string {
   const app = safeUiSegment(config.appId ?? config.name, "agent-native");

--- a/packages/core/src/mcp/builtin-cross-app.spec.ts
+++ b/packages/core/src/mcp/builtin-cross-app.spec.ts
@@ -160,7 +160,7 @@ describe("open_app — same-app / standalone keeps a relative deep link", () => 
     expect(result.embed).toBe(true);
   });
 
-  it("requests a 720px app viewport for full-app MCP App embeds", () => {
+  it("requests the default app viewport for full-app MCP App embeds", () => {
     const tools = getBuiltinCrossAppTools(baseConfig());
     const resource = tools.open_app.mcpApp?.resource;
     const html =
@@ -168,8 +168,8 @@ describe("open_app — same-app / standalone keeps a relative deep link", () => 
         ? resource.html({ actionName: "open_app", appId: "mail" })
         : resource?.html;
 
-    expect(html).toContain("min-height: 764px");
-    expect(html).toContain("height: 720px");
+    expect(html).toContain("--agent-native-shell-height: 560px");
+    expect(html).toContain("--agent-native-viewport-height: 516px");
   });
 
   it("accepts string embed:true from MCP clients that stringify arguments", async () => {

--- a/packages/core/src/mcp/builtin-cross-app.spec.ts
+++ b/packages/core/src/mcp/builtin-cross-app.spec.ts
@@ -157,6 +157,8 @@ describe("open_app — same-app / standalone keeps a relative deep link", () => 
       embed: true,
     });
     expect(result.url).toBe("/inbox?threadId=abc");
+    expect(result.embedStartUrl).toBeUndefined();
+    expect(result.deepLinkUrl).toBeUndefined();
     expect(result.embed).toBe(true);
   });
 

--- a/packages/core/src/mcp/builtin-tools.ts
+++ b/packages/core/src/mcp/builtin-tools.ts
@@ -248,47 +248,9 @@ function listAppsTool(
 // open_app
 // ---------------------------------------------------------------------------
 
-function absolutizeMaybe(pathOrUrl: string, origin?: string): string {
-  if (!origin) return pathOrUrl;
-  try {
-    return new URL(pathOrUrl, origin).toString();
-  } catch {
-    return pathOrUrl;
-  }
-}
-
-async function tryCreateSameAppEmbedStartUrl(
-  targetPath: string,
-  requestMeta?: { origin?: string },
-  chrome?: unknown,
-): Promise<string | null> {
-  try {
-    const { getRequestContext } = await import("../server/request-context.js");
-    const ctx = getRequestContext();
-    const ownerEmail = ctx?.userEmail?.trim();
-    if (!ownerEmail) return null;
-
-    const { createEmbedSessionTicket } =
-      await import("../server/embed-session.js");
-    const { buildEmbedStartPath } = await import("../server/embed-route.js");
-    const ticket = await createEmbedSessionTicket({
-      ownerEmail,
-      orgId: ctx?.orgId,
-      targetPath,
-      scope: typeof chrome === "string" ? chrome : null,
-    });
-    return absolutizeMaybe(
-      buildEmbedStartPath(ticket.ticket),
-      requestMeta?.origin,
-    );
-  } catch {
-    return null;
-  }
-}
-
 function openAppTool(
   config: MCPConfig,
-  requestMeta?: { origin?: string },
+  _requestMeta?: { origin?: string },
 ): ActionEntry {
   return {
     tool: tool(
@@ -367,22 +329,13 @@ function openAppTool(
       const appUrl = targetApp
         ? `${targetApp.origin.replace(/\/+$/, "")}${relUrl}`
         : sameAppUrl;
-      const embedStartUrl =
-        embed && !targetApp
-          ? await tryCreateSameAppEmbedStartUrl(
-              sameAppUrl,
-              requestMeta,
-              args.chrome,
-            )
-          : null;
-      const url = embedStartUrl ?? appUrl;
+      const url = appUrl;
 
       return {
         app,
         ...(view ? { view } : {}),
         ...(path ? { path } : {}),
         url,
-        ...(embedStartUrl ? { embedStartUrl, deepLinkUrl: appUrl } : {}),
         embed,
       };
     },

--- a/packages/core/src/mcp/builtin-tools.ts
+++ b/packages/core/src/mcp/builtin-tools.ts
@@ -248,7 +248,48 @@ function listAppsTool(
 // open_app
 // ---------------------------------------------------------------------------
 
-function openAppTool(config: MCPConfig): ActionEntry {
+function absolutizeMaybe(pathOrUrl: string, origin?: string): string {
+  if (!origin) return pathOrUrl;
+  try {
+    return new URL(pathOrUrl, origin).toString();
+  } catch {
+    return pathOrUrl;
+  }
+}
+
+async function tryCreateSameAppEmbedStartUrl(
+  targetPath: string,
+  requestMeta?: { origin?: string },
+  chrome?: unknown,
+): Promise<string | null> {
+  try {
+    const { getRequestContext } = await import("../server/request-context.js");
+    const ctx = getRequestContext();
+    const ownerEmail = ctx?.userEmail?.trim();
+    if (!ownerEmail) return null;
+
+    const { createEmbedSessionTicket } =
+      await import("../server/embed-session.js");
+    const { buildEmbedStartPath } = await import("../server/embed-route.js");
+    const ticket = await createEmbedSessionTicket({
+      ownerEmail,
+      orgId: ctx?.orgId,
+      targetPath,
+      scope: typeof chrome === "string" ? chrome : null,
+    });
+    return absolutizeMaybe(
+      buildEmbedStartPath(ticket.ticket),
+      requestMeta?.origin,
+    );
+  } catch {
+    return null;
+  }
+}
+
+function openAppTool(
+  config: MCPConfig,
+  requestMeta?: { origin?: string },
+): ActionEntry {
   return {
     tool: tool(
       "Build a deep link that opens an app at a specific view/record or " +
@@ -323,21 +364,37 @@ function openAppTool(config: MCPConfig): ActionEntry {
       // the wrong app (e.g. open_app({app:"calendar"}) served from Mail).
       // Same-app / standalone keeps the relative path (current behavior).
       const targetApp = await resolveTargetAppOrigin(config, app);
-      const url = targetApp
+      const appUrl = targetApp
         ? `${targetApp.origin.replace(/\/+$/, "")}${relUrl}`
         : sameAppUrl;
+      const embedStartUrl =
+        embed && !targetApp
+          ? await tryCreateSameAppEmbedStartUrl(
+              sameAppUrl,
+              requestMeta,
+              args.chrome,
+            )
+          : null;
+      const url = embedStartUrl ?? appUrl;
 
       return {
         app,
         ...(view ? { view } : {}),
         ...(path ? { path } : {}),
         url,
+        ...(embedStartUrl ? { embedStartUrl, deepLinkUrl: appUrl } : {}),
         embed,
       };
     },
     link: ({ result }) => {
       if (!result || typeof result !== "object") return null;
-      const r = result as { url?: string; app?: string; view?: string };
+      const r = result as {
+        url?: string;
+        app?: string;
+        view?: string;
+        embed?: boolean;
+      };
+      if (r.embed) return null;
       if (!r.url) return null;
       return {
         url: r.url,
@@ -735,7 +792,7 @@ export function getBuiltinCrossAppTools(
 ): Record<string, ActionEntry> {
   return {
     list_apps: listAppsTool(config, requestMeta),
-    open_app: openAppTool(config),
+    open_app: openAppTool(config, requestMeta),
     create_embed_session: createEmbedSessionTool(requestMeta),
     ask_app: askAppTool(config),
     create_workspace_app: createWorkspaceAppTool(),

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -29,6 +29,11 @@ describe("embedApp", () => {
     expect(html).toContain("openAiBridge.sendFollowUpMessage");
     expect(html).toContain("shouldSelfNavigateToApp");
     expect(html).toContain("window.location.replace(src)");
+    expect(html).toContain("isClaudeMcpContentHost");
+    expect(html).toContain("transplantAppDocument");
+    expect(html).toContain("document.write(prepared)");
+    expect(html).toContain("__AGENT_NATIVE_EXTERNAL_EMBED");
+    expect(html).toContain("claudemcpcontent");
     expect(html).toContain("const embedUrl = withChatBridgeParam(openUrl)");
     expect(html).toContain('typeof data.startUrl !== "string"');
     expect(html).toContain("if (selfNavigate)");
@@ -53,17 +58,24 @@ describe("embedApp", () => {
     );
     expect(html).toContain("min-height: 764px");
     expect(html).toContain("height: 720px");
-    expect(resource.csp?.frameDomains).toContain(
-      MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
-    );
+    expect(resource.csp?.frameDomains).toBeUndefined();
     expect(resource.csp?.resourceDomains).toContain(
       MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
     );
     expect(resource.csp?.resourceDomains).toContain("https://esm.sh");
+    expect(resource.csp?.connectDomains).toContain(
+      MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
+    );
+    expect(resource.csp?.baseUriDomains).toEqual([
+      MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
+    ]);
   });
 
   it("retains nested iframe mode as an explicit diagnostic fallback", () => {
-    const resource = embedApp({ title: "Dashboard" });
+    const resource = embedApp({
+      title: "Dashboard",
+      frameDomains: ["https://analytics.example.com"],
+    });
     const html =
       typeof resource.html === "function"
         ? resource.html({ actionName: "open_app", appId: "analytics" })
@@ -80,6 +92,10 @@ describe("embedApp", () => {
     expect(html).toContain('toolInput.frame === "iframe"');
     expect(html).toContain('"agentNative.frameOrigin"');
     expect(html).toContain('"agentNative.embeddedAppReady"');
+    expect(resource.csp?.frameDomains).toEqual([
+      MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
+      "https://analytics.example.com",
+    ]);
   });
 
   it("checks for ChatGPT's window.openai bridge before loading the standard bridge module", () => {
@@ -129,11 +145,15 @@ describe("embedApp", () => {
           ui: {
             prefersBorder: false,
             csp: {
-              frameDomains: [MCP_APP_REQUEST_ORIGIN_CSP_SOURCE],
               resourceDomains: [
                 "https://esm.sh",
                 MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
               ],
+              connectDomains: [
+                "https://esm.sh",
+                MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
+              ],
+              baseUriDomains: [MCP_APP_REQUEST_ORIGIN_CSP_SOURCE],
             },
           },
         },

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -4,7 +4,7 @@ import type { AgentMcpAppPayload } from "../mcp-client/app-result.js";
 import { embedApp, MCP_APP_REQUEST_ORIGIN_CSP_SOURCE } from "./embed-app.js";
 
 describe("embedApp", () => {
-  it("defaults to direct no-nested-frame navigation after minting an embed session", () => {
+  it("defaults to direct navigation except inside Claude's proxied MCP content frame", () => {
     const resource = embedApp({
       title: "Dashboard",
       openLabel: "Open dashboard",
@@ -28,13 +28,24 @@ describe("embedApp", () => {
     expect(html).toContain("openAiBridge.setOpenInAppUrl");
     expect(html).toContain("openAiBridge.sendFollowUpMessage");
     expect(html).toContain("shouldSelfNavigateToApp");
+    expect(html).toContain("isChatGptSandboxHost");
+    expect(html).toContain("oaiusercontent");
+    expect(html).toContain('appParam === "chatgpt"');
+    expect(html).toContain("shouldRenderControlledAppFrame");
+    expect(html).toContain("} else if (shouldRenderControlledAppFrame())");
     expect(html).toContain("window.location.replace(src)");
     expect(html).toContain("isClaudeMcpContentHost");
     expect(html).toContain("transplantAppDocument");
-    expect(html).toContain("document.write(prepared)");
+    expect(html).toContain("__agentNativeExternalEmbedRuntimeInstalled");
+    expect(html).not.toContain("/_agent-native/embed/runtime.js");
     expect(html).toContain("__AGENT_NATIVE_EXTERNAL_EMBED");
+    expect(html).toContain("window.history.replaceState");
+    expect(html).toContain("mountTransplantedHtml");
+    expect(html).toContain("moduleCodeToClassicAsync");
+    expect(html).toContain("await import($1)");
     expect(html).toContain("claudemcpcontent");
     expect(html).toContain("const embedUrl = withChatBridgeParam(openUrl)");
+    expect(html).toContain("!selfNavigate && isEmbedStartUrl(embedUrl)");
     expect(html).toContain('typeof data.startUrl !== "string"');
     expect(html).toContain("if (selfNavigate)");
     expect(html).toContain('"agentNative.submitChat"');
@@ -46,7 +57,8 @@ describe("embedApp", () => {
     expect(html).toContain("app.requestDisplayMode");
     expect(html).toContain('typeof openLink === "object"');
     expect(html).not.toContain("shouldDirectRenderEmbed");
-    expect(html).not.toContain("claudemcpcontent.com");
+    expect(html).toContain("claudemcpcontent\\.com");
+    expect(html).toContain("isClaudeMcpContentHost()");
     expect(html).not.toContain("window.location.href = data.startUrl");
     expect(html).toContain("__an_mcp_chat_bridge");
     expect(html).toContain('data-app-title="Dashboard"');
@@ -56,9 +68,19 @@ describe("embedApp", () => {
     expect(html).toContain(
       'toolInput.embed === false || toolInput.embed === "false"',
     );
-    expect(html).toContain("min-height: 764px");
-    expect(html).toContain("height: 720px");
-    expect(resource.csp?.frameDomains).toBeUndefined();
+    expect(html).toContain("--agent-native-shell-height: 560px");
+    expect(html).toContain("--agent-native-viewport-height: 516px");
+    expect(html).toContain("min-height: var(--agent-native-viewport-height)");
+    expect(html).toContain("Math.min(");
+    expect(html).toContain("defaultIntrinsicHeight");
+    expect(html).toContain("Math.floor(nextHeight || defaultIntrinsicHeight)");
+    expect(html).toContain("notifyHostHeightRepeatedly");
+    expect(html).toContain("{ autoResize: false }");
+    expect(html).toContain("openAiBridge.notifyIntrinsicHeight({ height })");
+    expect(html).toContain("app.sendSizeChanged({ height })");
+    expect(resource.csp?.frameDomains).toEqual([
+      MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
+    ]);
     expect(resource.csp?.resourceDomains).toContain(
       MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
     );
@@ -106,7 +128,9 @@ describe("embedApp", () => {
         : resource.html;
 
     const openAiIndex = html.indexOf("window.openai");
-    const dynamicImportIndex = html.indexOf("await import");
+    const dynamicImportIndex = html.indexOf(
+      'await import("https://esm.sh/@modelcontextprotocol',
+    );
 
     expect(openAiIndex).toBeGreaterThanOrEqual(0);
     expect(dynamicImportIndex).toBeGreaterThan(openAiIndex);
@@ -120,8 +144,8 @@ describe("embedApp", () => {
         ? resource.html({ actionName: "open_app", appId: "analytics" })
         : resource.html;
 
-    expect(html).toContain("min-height: 900px");
-    expect(html).toContain("height: 856px");
+    expect(html).toContain("--agent-native-shell-height: 900px");
+    expect(html).toContain("--agent-native-viewport-height: 856px");
   });
 
   it("provides a local MCP App payload fixture for renderer tests", () => {

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -6,9 +6,9 @@ const MCP_APP_IMPORT =
 
 export const MCP_APP_REQUEST_ORIGIN_CSP_SOURCE = "$requestOrigin";
 const MCP_APP_WRAPPER_CHROME_HEIGHT = 44;
-export const DEFAULT_MCP_APP_VIEWPORT_HEIGHT = 720;
-export const DEFAULT_MCP_APP_SHELL_HEIGHT =
-  DEFAULT_MCP_APP_VIEWPORT_HEIGHT + MCP_APP_WRAPPER_CHROME_HEIGHT;
+export const DEFAULT_MCP_APP_SHELL_HEIGHT = 560;
+export const DEFAULT_MCP_APP_VIEWPORT_HEIGHT =
+  DEFAULT_MCP_APP_SHELL_HEIGHT - MCP_APP_WRAPPER_CHROME_HEIGHT;
 
 export interface EmbedAppOptions {
   title?: string;
@@ -42,10 +42,10 @@ export function embedApp(
     Math.min(900, options.height ?? DEFAULT_MCP_APP_SHELL_HEIGHT),
   );
   const viewportHeight = height - MCP_APP_WRAPPER_CHROME_HEIGHT;
-  const frameDomains =
-    options.frameDomains && options.frameDomains.length > 0
-      ? [MCP_APP_REQUEST_ORIGIN_CSP_SOURCE, ...options.frameDomains]
-      : undefined;
+  const frameDomains = [
+    MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
+    ...(options.frameDomains ?? []),
+  ];
 
   return {
     title,
@@ -56,19 +56,19 @@ export function embedApp(
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
-    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: Canvas; color: CanvasText; }
+    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: Canvas; color: CanvasText; --agent-native-shell-height: ${height}px; --agent-native-viewport-height: ${viewportHeight}px; }
     * { box-sizing: border-box; }
     body { margin: 0; }
-    .shell { display: grid; gap: 8px; min-height: ${height}px; padding: 0; }
+    .shell { display: grid; gap: 8px; min-height: var(--agent-native-shell-height); padding: 0; }
     .bar { display: flex; align-items: center; justify-content: space-between; gap: 8px; min-height: 36px; padding: 6px 8px; border-bottom: 1px solid color-mix(in srgb, CanvasText 12%, Canvas); }
     .title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; font-weight: 700; color: color-mix(in srgb, CanvasText 72%, Canvas); }
     .actions { display: flex; align-items: center; gap: 6px; }
     button { min-height: 28px; border: 1px solid color-mix(in srgb, CanvasText 14%, Canvas); border-radius: 7px; background: Canvas; color: CanvasText; cursor: pointer; font: inherit; font-size: 12px; font-weight: 700; padding: 0 9px; }
     button:disabled { opacity: .55; cursor: default; }
-    .stage { position: relative; min-height: ${viewportHeight}px; }
-    iframe { display: block; width: 100%; height: ${viewportHeight}px; border: 0; background: Canvas; }
-    .message { display: grid; place-items: center; min-height: ${viewportHeight}px; padding: 18px; color: color-mix(in srgb, CanvasText 62%, Canvas); font-size: 13px; line-height: 1.45; text-align: center; }
-    .fallback { display: grid; align-content: center; justify-items: center; gap: 12px; min-height: ${viewportHeight}px; padding: 24px; background: Canvas; color: CanvasText; text-align: center; }
+    .stage { position: relative; min-height: var(--agent-native-viewport-height); }
+    iframe { display: block; width: 100%; height: var(--agent-native-viewport-height); border: 0; background: Canvas; }
+    .message { display: grid; place-items: center; min-height: var(--agent-native-viewport-height); padding: 18px; color: color-mix(in srgb, CanvasText 62%, Canvas); font-size: 13px; line-height: 1.45; text-align: center; }
+    .fallback { display: grid; align-content: center; justify-items: center; gap: 12px; min-height: var(--agent-native-viewport-height); padding: 24px; background: Canvas; color: CanvasText; text-align: center; }
     .fallback-title { max-width: 440px; font-size: 14px; font-weight: 700; }
     .fallback-copy { max-width: 520px; color: color-mix(in srgb, CanvasText 64%, Canvas); font-size: 13px; line-height: 1.45; }
     .fallback-actions { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 8px; }
@@ -103,7 +103,8 @@ export function embedApp(
     const startTool = body.dataset.startTool || "create_embed_session";
     const embedByDefault = body.dataset.embedDefault !== "0";
     const chatBridgeParam = ${JSON.stringify(MCP_APP_CHAT_BRIDGE_QUERY_PARAM)};
-    const intrinsicHeight = ${height};
+    const defaultIntrinsicHeight = ${height};
+    const chromeHeight = ${MCP_APP_WRAPPER_CHROME_HEIGHT};
     let app = null;
     let openAiBridge = null;
     let toolInput = {};
@@ -133,6 +134,40 @@ export function embedApp(
       return value && typeof value === "object" && !Array.isArray(value)
         ? value
         : {};
+    }
+
+    function finiteNumber(value) {
+      return typeof value === "number" && Number.isFinite(value) && value > 0
+        ? value
+        : null;
+    }
+
+    function contextMaxHeight(context) {
+      if (!context || typeof context !== "object") return null;
+      return finiteNumber(context.maxHeight) ||
+        finiteNumber(context.containerDimensions && context.containerDimensions.maxHeight);
+    }
+
+    function visibleIntrinsicHeight() {
+      const context = hostState().context || {};
+      const hostMaxHeight = contextMaxHeight(context);
+      if (hostMaxHeight) return Math.floor(hostMaxHeight);
+      const viewportHeight = finiteNumber(window.visualViewport && window.visualViewport.height) ||
+        finiteNumber(window.innerHeight);
+      return Math.floor(viewportHeight || defaultIntrinsicHeight);
+    }
+
+    function applyIntrinsicHeight(nextHeight) {
+      const boundedHeight = Math.min(
+        defaultIntrinsicHeight,
+        Math.floor(nextHeight || defaultIntrinsicHeight)
+      );
+      const height = Math.max(320, boundedHeight);
+      const viewportHeight = Math.max(0, height - chromeHeight);
+      document.documentElement.style.setProperty("--agent-native-shell-height", height + "px");
+      document.documentElement.style.setProperty("--agent-native-viewport-height", viewportHeight + "px");
+      if (appFrame) appFrame.style.height = viewportHeight + "px";
+      return height;
     }
 
     function parseToolResult(params) {
@@ -216,10 +251,6 @@ export function embedApp(
       }
     }
 
-    function isClaudeMcpContentHost() {
-      return /^[a-f0-9]{32}\\.claudemcpcontent\\.com$/i.test(window.location.hostname);
-    }
-
     function isEmbedStartUrl(value) {
       if (typeof value !== "string" || !value) return false;
       try {
@@ -250,36 +281,9 @@ export function embedApp(
       );
     }
 
-    function safeJsonForInlineScript(value) {
-      return JSON.stringify(value).replace(/</g, "\\\\u003c");
-    }
-
-    function externalEmbedBootstrapMarkup(config) {
-      const json = safeJsonForInlineScript(config);
-      const script =
-        '<script>' +
-        '(function(){' +
-        'var config=' + json + ';' +
-        'window.__AGENT_NATIVE_EXTERNAL_EMBED=config;' +
-        'try{' +
-        'if(config.token){sessionStorage.setItem("agent-native:embed-auth-token",config.token);}' +
-        'if(config.chatBridgeActive&&config.token){sessionStorage.setItem("agent-native:mcp-chat-bridge",config.token);}' +
-        '}catch(_err){}' +
-        'function appOrigin(){try{return new URL(config.origin).origin;}catch(_err){return "";}}' +
-        'function targetPath(){return config.target||location.pathname+location.search;}' +
-        'function rewrittenUrl(value,appendToken){var origin=appOrigin();if(!origin)return null;var url;try{url=new URL(value,location.href);}catch(_err){return null;}if(url.origin!==location.origin&&url.origin!==origin)return null;if(url.origin!==origin){var app=new URL(origin);url.protocol=app.protocol;url.host=app.host;}if(appendToken&&config.token&&url.pathname==="/_agent-native/events"){url.searchParams.set(config.embedTokenParam,config.token);}return url.toString();}' +
-        'function authHeaders(input,init){var headers=new Headers(init&&init.headers?init.headers:(input instanceof Request?input.headers:undefined));if(config.token&&!headers.has("Authorization"))headers.set("Authorization","Bearer "+config.token);if(!headers.has(config.embedTargetHeader))headers.set(config.embedTargetHeader,targetPath());return headers;}' +
-        'if(typeof fetch==="function"){var originalFetch=fetch.bind(window);window.fetch=function(input,init){var raw=input instanceof Request?input.url:String(input);var url=rewrittenUrl(raw,false);if(!url)return originalFetch(input,init);var nextInit=Object.assign({},init||{},{headers:authHeaders(input,init),credentials:"omit"});if(input instanceof Request){return originalFetch(new Request(url,input),nextInit);}return originalFetch(url,nextInit);};}' +
-        'if(typeof XMLHttpRequest!=="undefined"){var originalOpen=XMLHttpRequest.prototype.open;var originalSend=XMLHttpRequest.prototype.send;XMLHttpRequest.prototype.open=function(method,url){var rewritten=rewrittenUrl(url,false);this.__agentNativeExternalEmbed=!!rewritten;return originalOpen.call(this,method,rewritten||url,arguments.length>2?arguments[2]:true,arguments[3],arguments[4]);};XMLHttpRequest.prototype.send=function(body){if(this.__agentNativeExternalEmbed){try{if(config.token)this.setRequestHeader("Authorization","Bearer "+config.token);this.setRequestHeader(config.embedTargetHeader,targetPath());}catch(_err){}}return originalSend.call(this,body);};}' +
-        'if(typeof EventSource!=="undefined"){var OriginalEventSource=EventSource;window.EventSource=function(url,options){return new OriginalEventSource(rewrittenUrl(url,true)||url,options);};window.EventSource.prototype=OriginalEventSource.prototype;}' +
-        '})();' +
-        '<\\/script>';
-      return script + '<base href="' + esc(config.baseHref) + '">';
-    }
-
-    function prepareTransplantedHtml(html, appUrl) {
+    function embedConfigForAppUrl(appUrl) {
       const sanitizedTarget = localPathFromUrl(appUrl, false);
-      const config = {
+      return {
         origin: appUrl.origin,
         href: appUrl.href,
         baseHref: appUrl.origin + appUrl.pathname,
@@ -290,12 +294,202 @@ export function embedApp(
         embedTokenParam: "__an_embed_token",
         embedTargetHeader: "x-agent-native-embed-target"
       };
-      const bootstrap = externalEmbedBootstrapMarkup(config);
-      const rewritten = rewriteRootRelativeHtmlUrls(removeHtmlCspMeta(html), appUrl.origin);
-      if (/<head[\\s>]/i.test(rewritten)) {
-        return rewritten.replace(/<head([^>]*)>/i, "<head$1>" + bootstrap);
+    }
+
+    function installExternalEmbedRuntime(config) {
+      window.__AGENT_NATIVE_EXTERNAL_EMBED = config;
+      try {
+        if (config.target) {
+          window.history.replaceState(window.history.state, "", config.target);
+        }
+      } catch (_err) {}
+      try {
+        if (config.token) {
+          sessionStorage.setItem("agent-native:embed-auth-token", config.token);
+        }
+        if (config.chatBridgeActive && config.token) {
+          sessionStorage.setItem("agent-native:mcp-chat-bridge", config.token);
+        }
+      } catch (_err) {}
+      if (window.__agentNativeExternalEmbedRuntimeInstalled) return;
+      window.__agentNativeExternalEmbedRuntimeInstalled = true;
+      function appOrigin() {
+        try {
+          return new URL(config.origin).origin;
+        } catch (_err) {
+          return "";
+        }
       }
-      return bootstrap + rewritten;
+      function targetPath() {
+        return config.target || location.pathname + location.search;
+      }
+      function rewrittenUrl(value, appendToken) {
+        const origin = appOrigin();
+        if (!origin) return null;
+        let url;
+        try {
+          url = new URL(value, location.href);
+        } catch (_err) {
+          return null;
+        }
+        if (url.origin !== location.origin && url.origin !== origin) return null;
+        if (url.origin !== origin) {
+          const app = new URL(origin);
+          url.protocol = app.protocol;
+          url.host = app.host;
+        }
+        if (appendToken && config.token && url.pathname === "/_agent-native/events") {
+          url.searchParams.set(config.embedTokenParam, config.token);
+        }
+        return url.toString();
+      }
+      function authHeaders(input, init) {
+        const headers = new Headers(
+          init && init.headers ? init.headers : input instanceof Request ? input.headers : undefined
+        );
+        if (config.token && !headers.has("Authorization")) {
+          headers.set("Authorization", "Bearer " + config.token);
+        }
+        if (!headers.has(config.embedTargetHeader)) {
+          headers.set(config.embedTargetHeader, targetPath());
+        }
+        return headers;
+      }
+      if (typeof fetch === "function") {
+        const originalFetch = fetch.bind(window);
+        window.fetch = function(input, init) {
+          const raw = input instanceof Request ? input.url : String(input);
+          const url = rewrittenUrl(raw, false);
+          if (!url) return originalFetch(input, init);
+          const nextInit = Object.assign({}, init || {}, {
+            headers: authHeaders(input, init),
+            credentials: "omit"
+          });
+          if (input instanceof Request) {
+            return originalFetch(new Request(url, input), nextInit);
+          }
+          return originalFetch(url, nextInit);
+        };
+      }
+      if (typeof XMLHttpRequest !== "undefined") {
+        const originalOpen = XMLHttpRequest.prototype.open;
+        const originalSend = XMLHttpRequest.prototype.send;
+        XMLHttpRequest.prototype.open = function(method, url) {
+          const rewritten = rewrittenUrl(url, false);
+          this.__agentNativeExternalEmbed = !!rewritten;
+          return originalOpen.call(
+            this,
+            method,
+            rewritten || url,
+            arguments.length > 2 ? arguments[2] : true,
+            arguments[3],
+            arguments[4]
+          );
+        };
+        XMLHttpRequest.prototype.send = function(body) {
+          if (this.__agentNativeExternalEmbed) {
+            try {
+              if (config.token) this.setRequestHeader("Authorization", "Bearer " + config.token);
+              this.setRequestHeader(config.embedTargetHeader, targetPath());
+            } catch (_err) {}
+          }
+          return originalSend.call(this, body);
+        };
+      }
+      if (typeof EventSource !== "undefined") {
+        const OriginalEventSource = EventSource;
+        window.EventSource = function(url, options) {
+          return new OriginalEventSource(rewrittenUrl(url, true) || url, options);
+        };
+        window.EventSource.prototype = OriginalEventSource.prototype;
+      }
+    }
+
+    function copyDocumentElementAttributes(source) {
+      const target = document.documentElement;
+      for (const attr of Array.from(target.attributes)) {
+        target.removeAttribute(attr.name);
+      }
+      for (const attr of Array.from(source.attributes)) {
+        target.setAttribute(attr.name, attr.value);
+      }
+    }
+
+    function importChildren(source, target) {
+      target.replaceChildren(
+        ...Array.from(source.childNodes).map((node) => document.importNode(node, true))
+      );
+    }
+
+    function isModuleScript(script) {
+      return (script.getAttribute("type") || "").trim().toLowerCase() === "module";
+    }
+
+    function isRunnableClassicScript(script) {
+      const type = (script.getAttribute("type") || "").trim().toLowerCase();
+      return !type || type === "text/javascript" || type === "application/javascript";
+    }
+
+    function runClassicScript(script) {
+      const next = document.createElement("script");
+      for (const attr of Array.from(script.attributes)) {
+        if (attr.name === "type") continue;
+        next.setAttribute(attr.name, attr.value);
+      }
+      if (script.src) {
+        next.src = script.src;
+      } else {
+        next.textContent = script.textContent || "";
+      }
+      document.body.appendChild(next);
+      next.remove();
+    }
+
+    function rootRelativeSpecifiersToAbsolute(code, appOrigin) {
+      return String(code).replace(/(["'])\\/(?!\\/)/g, "$1" + appOrigin + "/");
+    }
+
+    function moduleCodeToClassicAsync(code, appOrigin) {
+      return rootRelativeSpecifiersToAbsolute(code, appOrigin)
+        .replace(
+          /\\bimport\\s+\\*\\s+as\\s+([A-Za-z_$][\\w$]*)\\s+from\\s+(["'][^"']+["'])\\s*;?/g,
+          "const $1 = await import($2);"
+        )
+        .replace(/\\bimport\\s+(["'][^"']+["'])\\s*;?/g, "await import($1);")
+        .replace(/\\bimport\\((["'][^"']+["'])\\)\\s*;?/g, "await import($1);");
+    }
+
+    function runModuleScriptAsClassic(script, appOrigin) {
+      const code = moduleCodeToClassicAsync(script.textContent || "", appOrigin);
+      const runner = document.createElement("script");
+      runner.textContent =
+        "(async()=>{" +
+        code +
+        "})().catch((err)=>{console.error('[agent-native] transplanted app module failed',err);document.body.setAttribute('data-agent-native-hydration-error',String(err&&err.message||err));});";
+      document.body.appendChild(runner);
+      runner.remove();
+    }
+
+    function mountTransplantedHtml(html, appUrl) {
+      const config = embedConfigForAppUrl(appUrl);
+      installExternalEmbedRuntime(config);
+      const parsed = new DOMParser().parseFromString(
+        rewriteRootRelativeHtmlUrls(removeHtmlCspMeta(html), appUrl.origin),
+        "text/html"
+      );
+      const scripts = Array.from(parsed.querySelectorAll("script"));
+      copyDocumentElementAttributes(parsed.documentElement);
+      importChildren(parsed.head, document.head);
+      const base = document.createElement("base");
+      base.href = config.baseHref;
+      document.head.prepend(base);
+      importChildren(parsed.body, document.body);
+      for (const script of scripts) {
+        if (isRunnableClassicScript(script)) runClassicScript(script);
+      }
+      for (const script of scripts) {
+        if (isModuleScript(script)) runModuleScriptAsClassic(script, appUrl.origin);
+      }
     }
 
     async function transplantAppDocument(src) {
@@ -317,10 +511,8 @@ export function embedApp(
       try {
         window.history.replaceState(window.history.state, "", localPathFromUrl(appUrl, false));
       } catch {}
-      const prepared = prepareTransplantedHtml(html, appUrl);
-      document.open();
-      document.write(prepared);
-      document.close();
+      mountTransplantedHtml(html, appUrl);
+      notifyHostHeightRepeatedly();
     }
 
     function wantsEmbed() {
@@ -471,6 +663,28 @@ export function embedApp(
       return true;
     }
 
+    function isClaudeMcpContentHost() {
+      try {
+        return /(^|\\.)claudemcpcontent\\.com$/i.test(window.location.hostname || "");
+      } catch {
+        return false;
+      }
+    }
+
+    function isChatGptSandboxHost() {
+      try {
+        const host = window.location.hostname || "";
+        const appParam = new URL(window.location.href).searchParams.get("app");
+        return /(^|\\.)oaiusercontent\\.com$/i.test(host) || appParam === "chatgpt";
+      } catch {
+        return false;
+      }
+    }
+
+    function shouldRenderControlledAppFrame() {
+      return !!openAiBridge || isChatGptSandboxHost();
+    }
+
     function navigateToAppFrame(src) {
       clearFrameReadyTimer();
       clearFrameLoadTimer();
@@ -517,11 +731,19 @@ export function embedApp(
     }
 
     function notifyHostHeight() {
+      const height = applyIntrinsicHeight(visibleIntrinsicHeight());
       if (!openAiBridge || typeof openAiBridge.notifyIntrinsicHeight !== "function") {
+        if (app && typeof app.sendSizeChanged === "function") {
+          try {
+            app.sendSizeChanged({ height });
+          } catch (err) {
+            console.warn("[agent-native] MCP host rejected size update", err);
+          }
+        }
         return;
       }
       try {
-        openAiBridge.notifyIntrinsicHeight({ height: intrinsicHeight });
+        openAiBridge.notifyIntrinsicHeight({ height });
       } catch (err) {
         console.warn("[agent-native] ChatGPT rejected intrinsic height update", err);
       }
@@ -617,6 +839,22 @@ export function embedApp(
       }
     });
 
+    function notifyHostHeightSoon() {
+      requestAnimationFrame(() => notifyHostHeight());
+    }
+
+    function notifyHostHeightRepeatedly() {
+      notifyHostHeight();
+      [0, 250, 1000, 2500].forEach((delay) => {
+        setTimeout(() => notifyHostHeight(), delay);
+      });
+    }
+
+    window.addEventListener("resize", notifyHostHeightSoon, { passive: true });
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener("resize", notifyHostHeightSoon, { passive: true });
+    }
+
     async function launchEmbed() {
       if (!openUrl) {
         setMessage("Open link was not available.");
@@ -635,9 +873,15 @@ export function embedApp(
         if (selfNavigate && isEmbedStartUrl(embedUrl)) {
           if (isClaudeMcpContentHost()) {
             await transplantAppDocument(embedUrl);
+          } else if (shouldRenderControlledAppFrame()) {
+            renderFrame(embedUrl);
           } else {
             navigateToAppFrame(embedUrl);
           }
+          return;
+        }
+        if (!selfNavigate && isEmbedStartUrl(embedUrl)) {
+          renderFrame(embedUrl);
           return;
         }
         const result = await callEmbedSessionTool({
@@ -653,6 +897,8 @@ export function embedApp(
         if (selfNavigate) {
           if (isClaudeMcpContentHost()) {
             await transplantAppDocument(data.startUrl);
+          } else if (shouldRenderControlledAppFrame()) {
+            renderFrame(data.startUrl);
           } else {
             navigateToAppFrame(data.startUrl);
           }
@@ -765,7 +1011,11 @@ export function embedApp(
 
     async function startMcpAppsBridge() {
       const { App } = await import("${MCP_APP_IMPORT}");
-      app = new App({ name: "Agent Native Embed", version: "1.0.0" }, {});
+      app = new App(
+        { name: "Agent Native Embed", version: "1.0.0" },
+        {},
+        { autoResize: false }
+      );
       app.ontoolinput = (params) => {
         toolInput = params.arguments || {};
       };
@@ -778,10 +1028,12 @@ export function embedApp(
       };
       app.onhostcontextchanged = () => {
         updateDisplayButton();
+        notifyHostHeight();
         sendHostContext();
       };
       await app.connect();
       updateDisplayButton();
+      notifyHostHeight();
       sendHostContext();
     }
 
@@ -800,7 +1052,7 @@ export function embedApp(
         ...(options.frameDomains ?? []),
       ],
       baseUriDomains: [MCP_APP_REQUEST_ORIGIN_CSP_SOURCE],
-      ...(frameDomains ? { frameDomains } : {}),
+      frameDomains,
     },
     prefersBorder: false,
   };

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -42,6 +42,10 @@ export function embedApp(
     Math.min(900, options.height ?? DEFAULT_MCP_APP_SHELL_HEIGHT),
   );
   const viewportHeight = height - MCP_APP_WRAPPER_CHROME_HEIGHT;
+  const frameDomains =
+    options.frameDomains && options.frameDomains.length > 0
+      ? [MCP_APP_REQUEST_ORIGIN_CSP_SOURCE, ...options.frameDomains]
+      : undefined;
 
   return {
     title,
@@ -210,6 +214,103 @@ export function embedApp(
       } catch {
         return value;
       }
+    }
+
+    function isClaudeMcpContentHost() {
+      return /^[a-f0-9]{32}\\.claudemcpcontent\\.com$/i.test(window.location.hostname);
+    }
+
+    function localPathFromUrl(url, includeToken) {
+      const next = new URL(url.href);
+      if (!includeToken) next.searchParams.delete("__an_embed_token");
+      return next.pathname + next.search + next.hash;
+    }
+
+    function rewriteRootRelativeHtmlUrls(html, appOrigin) {
+      return String(html).replace(
+        /\\b(src|href|poster|action)\\s*=\\s*(["'])\\/(?!\\/)/gi,
+        (_match, name, quote) => String(name) + "=" + quote + appOrigin + "/"
+      );
+    }
+
+    function removeHtmlCspMeta(html) {
+      return String(html).replace(
+        /<meta\\s+[^>]*http-equiv\\s*=\\s*(["'])?content-security-policy\\1?[^>]*>/gi,
+        ""
+      );
+    }
+
+    function safeJsonForInlineScript(value) {
+      return JSON.stringify(value).replace(/</g, "\\\\u003c");
+    }
+
+    function externalEmbedBootstrapMarkup(config) {
+      const json = safeJsonForInlineScript(config);
+      const script =
+        '<script>' +
+        '(function(){' +
+        'var config=' + json + ';' +
+        'window.__AGENT_NATIVE_EXTERNAL_EMBED=config;' +
+        'try{' +
+        'if(config.token){sessionStorage.setItem("agent-native:embed-auth-token",config.token);}' +
+        'if(config.chatBridgeActive&&config.token){sessionStorage.setItem("agent-native:mcp-chat-bridge",config.token);}' +
+        '}catch(_err){}' +
+        'function appOrigin(){try{return new URL(config.origin).origin;}catch(_err){return "";}}' +
+        'function targetPath(){return config.target||location.pathname+location.search;}' +
+        'function rewrittenUrl(value,appendToken){var origin=appOrigin();if(!origin)return null;var url;try{url=new URL(value,location.href);}catch(_err){return null;}if(url.origin!==location.origin&&url.origin!==origin)return null;if(url.origin!==origin){var app=new URL(origin);url.protocol=app.protocol;url.host=app.host;}if(appendToken&&config.token&&url.pathname==="/_agent-native/events"){url.searchParams.set(config.embedTokenParam,config.token);}return url.toString();}' +
+        'function authHeaders(input,init){var headers=new Headers(init&&init.headers?init.headers:(input instanceof Request?input.headers:undefined));if(config.token&&!headers.has("Authorization"))headers.set("Authorization","Bearer "+config.token);if(!headers.has(config.embedTargetHeader))headers.set(config.embedTargetHeader,targetPath());return headers;}' +
+        'if(typeof fetch==="function"){var originalFetch=fetch.bind(window);window.fetch=function(input,init){var raw=input instanceof Request?input.url:String(input);var url=rewrittenUrl(raw,false);if(!url)return originalFetch(input,init);var nextInit=Object.assign({},init||{},{headers:authHeaders(input,init),credentials:"omit"});if(input instanceof Request){return originalFetch(new Request(url,input),nextInit);}return originalFetch(url,nextInit);};}' +
+        'if(typeof XMLHttpRequest!=="undefined"){var originalOpen=XMLHttpRequest.prototype.open;var originalSend=XMLHttpRequest.prototype.send;XMLHttpRequest.prototype.open=function(method,url){var rewritten=rewrittenUrl(url,false);this.__agentNativeExternalEmbed=!!rewritten;return originalOpen.call(this,method,rewritten||url,arguments.length>2?arguments[2]:true,arguments[3],arguments[4]);};XMLHttpRequest.prototype.send=function(body){if(this.__agentNativeExternalEmbed){try{if(config.token)this.setRequestHeader("Authorization","Bearer "+config.token);this.setRequestHeader(config.embedTargetHeader,targetPath());}catch(_err){}}return originalSend.call(this,body);};}' +
+        'if(typeof EventSource!=="undefined"){var OriginalEventSource=EventSource;window.EventSource=function(url,options){return new OriginalEventSource(rewrittenUrl(url,true)||url,options);};window.EventSource.prototype=OriginalEventSource.prototype;}' +
+        '})();' +
+        '<\\/script>';
+      return script + '<base href="' + esc(config.baseHref) + '">';
+    }
+
+    function prepareTransplantedHtml(html, appUrl) {
+      const sanitizedTarget = localPathFromUrl(appUrl, false);
+      const config = {
+        origin: appUrl.origin,
+        href: appUrl.href,
+        baseHref: appUrl.origin + appUrl.pathname,
+        target: sanitizedTarget,
+        token: appUrl.searchParams.get("__an_embed_token") || "",
+        chatBridgeActive: appUrl.searchParams.get(chatBridgeParam) === "1",
+        chatBridgeParam,
+        embedTokenParam: "__an_embed_token",
+        embedTargetHeader: "x-agent-native-embed-target"
+      };
+      const bootstrap = externalEmbedBootstrapMarkup(config);
+      const rewritten = rewriteRootRelativeHtmlUrls(removeHtmlCspMeta(html), appUrl.origin);
+      if (/<head[\\s>]/i.test(rewritten)) {
+        return rewritten.replace(/<head([^>]*)>/i, "<head$1>" + bootstrap);
+      }
+      return bootstrap + rewritten;
+    }
+
+    async function transplantAppDocument(src) {
+      clearFrameReadyTimer();
+      clearFrameLoadTimer();
+      appFrame = null;
+      lastFrameSrc = src;
+      setMessage("Loading app");
+      const response = await fetch(src, {
+        credentials: "omit",
+        redirect: "follow",
+        headers: { Accept: "text/html" }
+      });
+      if (!response.ok) {
+        throw new Error("Embedded app returned HTTP " + response.status + ".");
+      }
+      const html = await response.text();
+      const appUrl = new URL(response.url || src);
+      try {
+        window.history.replaceState(window.history.state, "", localPathFromUrl(appUrl, false));
+      } catch {}
+      const prepared = prepareTransplantedHtml(html, appUrl);
+      document.open();
+      document.write(prepared);
+      document.close();
     }
 
     function wantsEmbed() {
@@ -532,7 +633,11 @@ export function embedApp(
           return;
         }
         if (selfNavigate) {
-          navigateToAppFrame(data.startUrl);
+          if (isClaudeMcpContentHost()) {
+            await transplantAppDocument(data.startUrl);
+          } else {
+            navigateToAppFrame(data.startUrl);
+          }
         } else {
           renderFrame(data.startUrl);
         }
@@ -670,16 +775,14 @@ export function embedApp(
 </body>
 </html>`,
     csp: {
-      connectDomains: ["https://esm.sh"],
+      connectDomains: ["https://esm.sh", MCP_APP_REQUEST_ORIGIN_CSP_SOURCE],
       resourceDomains: [
         "https://esm.sh",
         MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
         ...(options.frameDomains ?? []),
       ],
-      frameDomains: [
-        MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
-        ...(options.frameDomains ?? []),
-      ],
+      baseUriDomains: [MCP_APP_REQUEST_ORIGIN_CSP_SOURCE],
+      ...(frameDomains ? { frameDomains } : {}),
     },
     prefersBorder: false,
   };

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -220,6 +220,16 @@ export function embedApp(
       return /^[a-f0-9]{32}\\.claudemcpcontent\\.com$/i.test(window.location.hostname);
     }
 
+    function isEmbedStartUrl(value) {
+      if (typeof value !== "string" || !value) return false;
+      try {
+        const url = new URL(value, window.location.href);
+        return /\\/_agent-native\\/embed\\/start$/.test(url.pathname);
+      } catch {
+        return false;
+      }
+    }
+
     function localPathFromUrl(url, includeToken) {
       const next = new URL(url.href);
       if (!includeToken) next.searchParams.delete("__an_embed_token");
@@ -622,6 +632,14 @@ export function embedApp(
       try {
         const selfNavigate = shouldSelfNavigateToApp();
         const embedUrl = withChatBridgeParam(openUrl);
+        if (selfNavigate && isEmbedStartUrl(embedUrl)) {
+          if (isClaudeMcpContentHost()) {
+            await transplantAppDocument(embedUrl);
+          } else {
+            navigateToAppFrame(embedUrl);
+          }
+          return;
+        }
         const result = await callEmbedSessionTool({
           url: embedUrl,
           chrome: typeof toolInput.chrome === "string" ? toolInput.chrome : "full"

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -354,10 +354,10 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(echo.annotations?.["agent-native/producesOpenLink"]).toBe(true);
     expect(echo.description).toContain("Open in");
     expect(echo._meta?.["ui/resourceUri"]).toBe(
-      "ui://mail/echo-thing/shell-v5",
+      "ui://mail/echo-thing/shell-v22",
     );
     expect(echo._meta?.["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v5",
+      "ui://mail/echo-thing/shell-v22",
     );
     expect(echo._meta?.["openai/widgetAccessible"]).toBe(true);
     expect(echo._meta?.["openai/widgetCSP"]).toEqual({
@@ -368,7 +368,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         connectDomains: ["https://mail.agent-native.com"],
       },
       prefersBorder: true,
-      resourceUri: "ui://mail/echo-thing/shell-v5",
+      resourceUri: "ui://mail/echo-thing/shell-v22",
       visibility: ["model", "app"],
     });
   });
@@ -482,8 +482,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources.map((r: any) => r.uri)).toEqual(
       expect.arrayContaining([
-        "ui://mail/echo-thing/shell-v5",
-        "ui://mail/review-draft/shell-v5",
+        "ui://mail/echo-thing/shell-v22",
+        "ui://mail/review-draft/shell-v22",
       ]),
     );
   });
@@ -611,7 +611,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v5",
+        uri: "ui://mail/echo-thing/shell-v22",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -647,7 +647,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resourceTemplates).toEqual([
       expect.objectContaining({
-        uriTemplate: "ui://mail/echo-thing/shell-v5",
+        uriTemplate: "ui://mail/echo-thing/shell-v22",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -662,14 +662,14 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 6,
         method: "resources/read",
-        params: { uri: "ui://mail/echo-thing/shell-v5" },
+        params: { uri: "ui://mail/echo-thing/shell-v22" },
       },
       { headers: await mcpAppsAuthHeaders() },
     );
     expect(out.error).toBeUndefined();
     expect(out.result.contents).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v5",
+        uri: "ui://mail/echo-thing/shell-v22",
         mimeType: "text/html;profile=mcp-app",
         text: expect.stringContaining('data-action="echo-thing"'),
         _meta: expect.objectContaining({
@@ -744,7 +744,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v5",
+        uri: "ui://mail/custom-review/shell-v22",
         name: "custom-review",
       }),
     ]);
@@ -801,7 +801,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v5",
+        uri: "ui://mail/custom-review/shell-v22",
         name: "custom-review",
       }),
     ]);
@@ -858,7 +858,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v5?mode=compact#preview",
+        uri: "ui://mail/custom-review/shell-v22?mode=compact#preview",
         name: "custom-review",
       }),
     ]);
@@ -908,7 +908,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         "https://mail.agent-native.com/_agent-native/open?view=thing&id=thing-42&agentSidebar=closed",
     });
     expect(out.result._meta["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v5",
+      "ui://mail/echo-thing/shell-v22",
     );
     expect(out.result._meta["openai/widgetCSP"]).toEqual({
       connect_domains: ["https://mail.agent-native.com"],
@@ -929,6 +929,65 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.result._meta["agent-native/openLink"].desktopUrl).toContain(
       "view=thing&id=thing-42",
     );
+  });
+
+  it("adds hidden open-link metadata for MCP App embed start URLs", async () => {
+    const embedConfig = {
+      ...config,
+      actions: {
+        "open-app-embed": {
+          tool: {
+            description: "Open a full app embed",
+          },
+          run: async () => ({
+            app: "mail",
+            path: "/inbox",
+            url: "/_agent-native/embed/start?ticket=test-ticket",
+            embedStartUrl: "/_agent-native/embed/start?ticket=test-ticket",
+            deepLinkUrl: "/inbox",
+            embed: true,
+          }),
+          readOnly: true,
+          mcpApp: {
+            resource: {
+              title: "Open app",
+              description: "Open the full app inline.",
+              html: "<!doctype html><html><body>Open app</body></html>",
+            },
+          },
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 34,
+        method: "tools/call",
+        params: { name: "open-app-embed", arguments: {} },
+      },
+      { config: embedConfig },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.result.content).toEqual([
+      { type: "text", text: "open-app-embed completed." },
+    ]);
+    expect(JSON.stringify(out.result.content)).not.toContain("test-ticket");
+    expect(out.result._meta["agent-native/openLink"]).toMatchObject({
+      label: "Open mail",
+      view: "/inbox",
+      webUrl:
+        "https://mail.agent-native.com/_agent-native/embed/start?ticket=test-ticket",
+      desktopUrl: "https://mail.agent-native.com/inbox",
+    });
+    expect(out.result.structuredContent).toMatchObject({
+      url: "/_agent-native/embed/start?ticket=test-ticket",
+      openLink: {
+        webUrl:
+          "https://mail.agent-native.com/_agent-native/embed/start?ticket=test-ticket",
+      },
+    });
   });
 
   it("rejects unauthenticated calls with 401 when auth IS configured (no 501)", async () => {

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -354,10 +354,10 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(echo.annotations?.["agent-native/producesOpenLink"]).toBe(true);
     expect(echo.description).toContain("Open in");
     expect(echo._meta?.["ui/resourceUri"]).toBe(
-      "ui://mail/echo-thing/shell-v4",
+      "ui://mail/echo-thing/shell-v5",
     );
     expect(echo._meta?.["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v4",
+      "ui://mail/echo-thing/shell-v5",
     );
     expect(echo._meta?.["openai/widgetAccessible"]).toBe(true);
     expect(echo._meta?.["openai/widgetCSP"]).toEqual({
@@ -368,7 +368,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         connectDomains: ["https://mail.agent-native.com"],
       },
       prefersBorder: true,
-      resourceUri: "ui://mail/echo-thing/shell-v4",
+      resourceUri: "ui://mail/echo-thing/shell-v5",
       visibility: ["model", "app"],
     });
   });
@@ -482,8 +482,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources.map((r: any) => r.uri)).toEqual(
       expect.arrayContaining([
-        "ui://mail/echo-thing/shell-v4",
-        "ui://mail/review-draft/shell-v4",
+        "ui://mail/echo-thing/shell-v5",
+        "ui://mail/review-draft/shell-v5",
       ]),
     );
   });
@@ -611,7 +611,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v4",
+        uri: "ui://mail/echo-thing/shell-v5",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -647,7 +647,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resourceTemplates).toEqual([
       expect.objectContaining({
-        uriTemplate: "ui://mail/echo-thing/shell-v4",
+        uriTemplate: "ui://mail/echo-thing/shell-v5",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -662,14 +662,14 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 6,
         method: "resources/read",
-        params: { uri: "ui://mail/echo-thing/shell-v4" },
+        params: { uri: "ui://mail/echo-thing/shell-v5" },
       },
       { headers: await mcpAppsAuthHeaders() },
     );
     expect(out.error).toBeUndefined();
     expect(out.result.contents).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v4",
+        uri: "ui://mail/echo-thing/shell-v5",
         mimeType: "text/html;profile=mcp-app",
         text: expect.stringContaining('data-action="echo-thing"'),
         _meta: expect.objectContaining({
@@ -744,7 +744,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v4",
+        uri: "ui://mail/custom-review/shell-v5",
         name: "custom-review",
       }),
     ]);
@@ -779,7 +779,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
           run: async () => ({ ok: true }),
           mcpApp: {
             resource: {
-              uri: "ui://mail/custom-review/shell-v3",
+              uri: "ui://mail/custom-review/shell-v4",
               title: "Custom review",
               html: "<!doctype html><html><body>Custom review</body></html>",
             },
@@ -801,7 +801,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v4",
+        uri: "ui://mail/custom-review/shell-v5",
         name: "custom-review",
       }),
     ]);
@@ -811,7 +811,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 31,
         method: "resources/read",
-        params: { uri: "ui://mail/custom-review/shell-v3" },
+        params: { uri: "ui://mail/custom-review/shell-v4" },
       },
       { headers: await mcpAppsAuthHeaders(), config: customResourceConfig },
     );
@@ -819,7 +819,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(legacyRead.error).toBeUndefined();
     expect(legacyRead.result.contents).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v3",
+        uri: "ui://mail/custom-review/shell-v4",
         text: expect.stringContaining("Custom review"),
       }),
     ]);
@@ -858,7 +858,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v4?mode=compact#preview",
+        uri: "ui://mail/custom-review/shell-v5?mode=compact#preview",
         name: "custom-review",
       }),
     ]);
@@ -908,7 +908,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         "https://mail.agent-native.com/_agent-native/open?view=thing&id=thing-42&agentSidebar=closed",
     });
     expect(out.result._meta["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v4",
+      "ui://mail/echo-thing/shell-v5",
     );
     expect(out.result._meta["openai/widgetCSP"]).toEqual({
       connect_domains: ["https://mail.agent-native.com"],

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -354,10 +354,10 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(echo.annotations?.["agent-native/producesOpenLink"]).toBe(true);
     expect(echo.description).toContain("Open in");
     expect(echo._meta?.["ui/resourceUri"]).toBe(
-      "ui://mail/echo-thing/shell-v3",
+      "ui://mail/echo-thing/shell-v4",
     );
     expect(echo._meta?.["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v3",
+      "ui://mail/echo-thing/shell-v4",
     );
     expect(echo._meta?.["openai/widgetAccessible"]).toBe(true);
     expect(echo._meta?.["openai/widgetCSP"]).toEqual({
@@ -368,7 +368,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         connectDomains: ["https://mail.agent-native.com"],
       },
       prefersBorder: true,
-      resourceUri: "ui://mail/echo-thing/shell-v3",
+      resourceUri: "ui://mail/echo-thing/shell-v4",
       visibility: ["model", "app"],
     });
   });
@@ -482,8 +482,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources.map((r: any) => r.uri)).toEqual(
       expect.arrayContaining([
-        "ui://mail/echo-thing/shell-v3",
-        "ui://mail/review-draft/shell-v3",
+        "ui://mail/echo-thing/shell-v4",
+        "ui://mail/review-draft/shell-v4",
       ]),
     );
   });
@@ -611,7 +611,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v3",
+        uri: "ui://mail/echo-thing/shell-v4",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -647,7 +647,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resourceTemplates).toEqual([
       expect.objectContaining({
-        uriTemplate: "ui://mail/echo-thing/shell-v3",
+        uriTemplate: "ui://mail/echo-thing/shell-v4",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -662,14 +662,14 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 6,
         method: "resources/read",
-        params: { uri: "ui://mail/echo-thing/shell-v3" },
+        params: { uri: "ui://mail/echo-thing/shell-v4" },
       },
       { headers: await mcpAppsAuthHeaders() },
     );
     expect(out.error).toBeUndefined();
     expect(out.result.contents).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v3",
+        uri: "ui://mail/echo-thing/shell-v4",
         mimeType: "text/html;profile=mcp-app",
         text: expect.stringContaining('data-action="echo-thing"'),
         _meta: expect.objectContaining({
@@ -744,7 +744,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v3",
+        uri: "ui://mail/custom-review/shell-v4",
         name: "custom-review",
       }),
     ]);
@@ -779,7 +779,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
           run: async () => ({ ok: true }),
           mcpApp: {
             resource: {
-              uri: "ui://mail/custom-review/shell-v2",
+              uri: "ui://mail/custom-review/shell-v3",
               title: "Custom review",
               html: "<!doctype html><html><body>Custom review</body></html>",
             },
@@ -801,7 +801,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v3",
+        uri: "ui://mail/custom-review/shell-v4",
         name: "custom-review",
       }),
     ]);
@@ -811,7 +811,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 31,
         method: "resources/read",
-        params: { uri: "ui://mail/custom-review/shell-v2" },
+        params: { uri: "ui://mail/custom-review/shell-v3" },
       },
       { headers: await mcpAppsAuthHeaders(), config: customResourceConfig },
     );
@@ -819,7 +819,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(legacyRead.error).toBeUndefined();
     expect(legacyRead.result.contents).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v2",
+        uri: "ui://mail/custom-review/shell-v3",
         text: expect.stringContaining("Custom review"),
       }),
     ]);
@@ -858,7 +858,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v3?mode=compact#preview",
+        uri: "ui://mail/custom-review/shell-v4?mode=compact#preview",
         name: "custom-review",
       }),
     ]);
@@ -908,7 +908,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         "https://mail.agent-native.com/_agent-native/open?view=thing&id=thing-42&agentSidebar=closed",
     });
     expect(out.result._meta["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v3",
+      "ui://mail/echo-thing/shell-v4",
     );
     expect(out.result._meta["openai/widgetCSP"]).toEqual({
       connect_domains: ["https://mail.agent-native.com"],

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -23,6 +23,12 @@ import { createPollHandler } from "./poll.js";
 import { createPollEventsHandler } from "./poll-events.js";
 import { createOpenRouteHandler } from "./open-route.js";
 import { createEmbedStartRouteHandler } from "./embed-route.js";
+import { EMBED_TARGET_HEADER } from "../shared/embed-auth.js";
+import {
+  isMcpEmbedCorsOrigin,
+  MCP_EMBED_CORS_ALLOW_HEADERS,
+  shouldAllowMcpEmbedCredentials,
+} from "../shared/mcp-embed-headers.js";
 import { handleMcpConnect } from "../mcp/connect-route.js";
 import {
   handleMcpOAuth,
@@ -496,18 +502,41 @@ export function createCoreRoutesPlugin(
             String(event.node?.req?.url ?? event.path ?? "/").split("?")[0],
         );
         if (!pathname.startsWith(P) && !pathname.startsWith("/api/")) return;
-        const origin = getHeader(event, "origin");
+        const readRequestHeader = (name: string): string | undefined => {
+          const lower = name.toLowerCase();
+          const raw =
+            (event as any).node?.req?.headers?.[lower] ??
+            (event as any).node?.req?.headers?.[name];
+          if (Array.isArray(raw)) return raw[0];
+          if (typeof raw === "string") return raw;
+          return getHeader(event, name) ?? undefined;
+        };
+        const origin = readRequestHeader("origin");
         const method = getMethod(event);
+        const requestedHeaders = readRequestHeader(
+          "access-control-request-headers",
+        );
+        const requestedHeaderNames = String(requestedHeaders ?? "")
+          .toLowerCase()
+          .split(",")
+          .map((header) => header.trim());
+        const mcpEmbedCorsRequest =
+          isMcpEmbedCorsOrigin(origin) &&
+          (requestedHeaderNames.includes(EMBED_TARGET_HEADER.toLowerCase()) ||
+            Boolean(readRequestHeader(EMBED_TARGET_HEADER)) ||
+            Boolean(readRequestHeader("authorization")));
 
         // Decide whether this origin is allowed. We never fall back to the
         // first allowlist entry — that previously echoed `Access-Control-
         // Allow-Origin: <unrelated-allowed-origin>` for disallowed callers,
         // which is permissive enough that some clients followed through.
-        const allowedOrigin = getAllowedCorsOrigin(origin, {
-          allowedOrigins: allowlist,
-          allowAnyOriginWhenNoAllowlist: false,
-          allowLocalhostWhenNoAllowlist: true,
-        });
+        const allowedOrigin = mcpEmbedCorsRequest
+          ? origin
+          : getAllowedCorsOrigin(origin, {
+              allowedOrigins: allowlist,
+              allowAnyOriginWhenNoAllowlist: false,
+              allowLocalhostWhenNoAllowlist: true,
+            });
 
         // Reject preflights from disallowed cross-origin callers BEFORE
         // returning 204. Previously the OPTIONS short-circuit returned 204
@@ -526,11 +555,13 @@ export function createCoreRoutesPlugin(
               allowedOrigin,
             );
             setResponseHeader(event, "Vary", "Origin");
-            setResponseHeader(
-              event,
-              "Access-Control-Allow-Credentials",
-              "true",
-            );
+            if (shouldAllowMcpEmbedCredentials(allowedOrigin)) {
+              setResponseHeader(
+                event,
+                "Access-Control-Allow-Credentials",
+                "true",
+              );
+            }
             setResponseHeader(
               event,
               "Access-Control-Allow-Methods",
@@ -539,7 +570,7 @@ export function createCoreRoutesPlugin(
             setResponseHeader(
               event,
               "Access-Control-Allow-Headers",
-              "Content-Type,Authorization,X-Requested-With,X-Request-Source,X-Agent-Native-CSRF",
+              MCP_EMBED_CORS_ALLOW_HEADERS,
             );
           }
           setResponseStatus(event, 204);
@@ -553,7 +584,9 @@ export function createCoreRoutesPlugin(
         if (!allowedOrigin) return;
         setResponseHeader(event, "Access-Control-Allow-Origin", allowedOrigin);
         setResponseHeader(event, "Vary", "Origin");
-        setResponseHeader(event, "Access-Control-Allow-Credentials", "true");
+        if (shouldAllowMcpEmbedCredentials(allowedOrigin)) {
+          setResponseHeader(event, "Access-Control-Allow-Credentials", "true");
+        }
         setResponseHeader(
           event,
           "Access-Control-Allow-Methods",
@@ -562,7 +595,7 @@ export function createCoreRoutesPlugin(
         setResponseHeader(
           event,
           "Access-Control-Allow-Headers",
-          "Content-Type,Authorization,X-Requested-With,X-Request-Source,X-Agent-Native-CSRF",
+          MCP_EMBED_CORS_ALLOW_HEADERS,
         );
       }),
     );

--- a/packages/core/src/server/create-server.ts
+++ b/packages/core/src/server/create-server.ts
@@ -16,6 +16,12 @@ import {
   readCorsAllowedOrigins,
 } from "./cors-origins.js";
 import { isEnvVarWriteAllowed } from "./env-var-writes.js";
+import { EMBED_TARGET_HEADER } from "../shared/embed-auth.js";
+import {
+  isMcpEmbedCorsOrigin,
+  MCP_EMBED_CORS_ALLOW_HEADERS,
+  shouldAllowMcpEmbedCredentials,
+} from "../shared/mcp-embed-headers.js";
 
 export interface EnvKeyConfig {
   /** Environment variable name (e.g. "HUBSPOT_ACCESS_TOKEN") */
@@ -169,6 +175,17 @@ export function createServer(
       defineEventHandler((event) => {
         const requestOrigin = getRequestHeader(event, "origin");
         const method = getMethod(event);
+        const requestedHeaders = String(
+          getRequestHeader(event, "access-control-request-headers") ?? "",
+        )
+          .toLowerCase()
+          .split(",")
+          .map((header) => header.trim());
+        const embedCorsRequest =
+          isMcpEmbedCorsOrigin(requestOrigin) &&
+          (requestedHeaders.includes(EMBED_TARGET_HEADER.toLowerCase()) ||
+            Boolean(getRequestHeader(event, EMBED_TARGET_HEADER)) ||
+            Boolean(getRequestHeader(event, "authorization")));
 
         /**
          * Decide whether the requesting origin is allowed. We never fall back
@@ -178,11 +195,13 @@ export function createServer(
          * permissive enough that some clients followed through with the
          * credentialed request.
          */
-        const allowedOrigin = getAllowedCorsOrigin(requestOrigin, {
-          allowedOrigins,
-          allowAnyOriginWhenNoAllowlist: !isProduction,
-          allowLocalhostWhenNoAllowlist: true,
-        });
+        const allowedOrigin = embedCorsRequest
+          ? requestOrigin
+          : getAllowedCorsOrigin(requestOrigin, {
+              allowedOrigins,
+              allowAnyOriginWhenNoAllowlist: !isProduction,
+              allowLocalhostWhenNoAllowlist: true,
+            });
         // No origin header at all (same-origin fetch, server-to-server) and
         // no allowlist → fall through with `*`-equivalent behaviour: omit
         // ACAO entirely and let the browser apply its same-origin default.
@@ -199,7 +218,13 @@ export function createServer(
           // apps that share a same-site cookie with the web app). The
           // wildcard `*` is spec-incompatible with credentials, so only
           // set this when we're echoing a concrete origin.
-          setResponseHeader(event, "Access-Control-Allow-Credentials", "true");
+          if (shouldAllowMcpEmbedCredentials(allowedOrigin)) {
+            setResponseHeader(
+              event,
+              "Access-Control-Allow-Credentials",
+              "true",
+            );
+          }
         } else if (!requestOrigin) {
           // No origin header — preserve the legacy permissive behaviour for
           // tools/scripts that hit the API directly (no credentialed CORS
@@ -215,7 +240,7 @@ export function createServer(
         setResponseHeader(
           event,
           "Access-Control-Allow-Headers",
-          "Content-Type,Authorization,X-Requested-With,X-Request-Source,X-Agent-Native-CSRF",
+          MCP_EMBED_CORS_ALLOW_HEADERS,
         );
 
         if (method === "OPTIONS") {

--- a/packages/core/src/server/embed-route.spec.ts
+++ b/packages/core/src/server/embed-route.spec.ts
@@ -4,6 +4,8 @@ const setResponseHeader = vi.hoisted(() => vi.fn());
 
 vi.mock("h3", () => ({
   defineEventHandler: (handler: any) => handler,
+  getHeader: (event: any, name: string) =>
+    event.headers?.[name] ?? event.headers?.[name.toLowerCase()],
   getMethod: (event: any) => event.method ?? "GET",
   getQuery: (event: any) => event.query ?? {},
   setResponseHeader: (...a: any[]) => setResponseHeader(...a),
@@ -21,10 +23,15 @@ vi.mock("./embed-session.js", () => ({
 
 import { createEmbedStartRouteHandler } from "./embed-route.js";
 
-function fakeEvent(method: string, query: Record<string, string> = {}) {
+function fakeEvent(
+  method: string,
+  query: Record<string, string> = {},
+  headers: Record<string, string> = {},
+) {
   return {
     method,
     query,
+    headers,
     res: {
       headers: {
         getSetCookie: () => [],
@@ -120,5 +127,35 @@ describe("createEmbedStartRouteHandler", () => {
       "Cross-Origin-Resource-Policy",
       "cross-origin",
     );
+  });
+
+  it("allows Claude MCP content frames to fetch embed start redirects", async () => {
+    consumeEmbedSessionTicket.mockResolvedValue({
+      ownerEmail: "steve@example.com",
+      orgId: "builder",
+      targetPath: "/inbox",
+      scope: "full",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const handler = createEmbedStartRouteHandler();
+
+    const res: Response = await handler(
+      fakeEvent(
+        "GET",
+        { ticket: "ticket-123" },
+        {
+          origin:
+            "https://520ba469ac5783c72c33d79bea940871.claudemcpcontent.com",
+        },
+      ),
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://520ba469ac5783c72c33d79bea940871.claudemcpcontent.com",
+    );
+    expect(res.headers.get("Access-Control-Expose-Headers")).toBe("Location");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
   });
 });

--- a/packages/core/src/server/embed-route.spec.ts
+++ b/packages/core/src/server/embed-route.spec.ts
@@ -158,4 +158,28 @@ describe("createEmbedStartRouteHandler", () => {
     expect(res.headers.get("Access-Control-Expose-Headers")).toBe("Location");
     expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
   });
+
+  it("preserves the MCP chat bridge flag on the signed app route", async () => {
+    consumeEmbedSessionTicket.mockResolvedValue({
+      ownerEmail: "steve@example.com",
+      orgId: "builder",
+      targetPath: "/inbox",
+      scope: "full",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const handler = createEmbedStartRouteHandler();
+
+    const res: Response = await handler(
+      fakeEvent("GET", {
+        ticket: "ticket-123",
+        __an_mcp_chat_bridge: "1",
+      }),
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(
+      "/inbox?embedded=1&__an_embed_token=signed-token&__an_mcp_chat_bridge=1&agentSidebar=closed",
+    );
+  });
 });

--- a/packages/core/src/server/embed-route.ts
+++ b/packages/core/src/server/embed-route.ts
@@ -1,5 +1,11 @@
 import type { H3Event } from "h3";
-import { defineEventHandler, getMethod, getQuery, setResponseHeader } from "h3";
+import {
+  defineEventHandler,
+  getHeader,
+  getMethod,
+  getQuery,
+  setResponseHeader,
+} from "h3";
 import {
   consumeEmbedSessionTicket,
   normalizeEmbedTargetPath,
@@ -13,6 +19,10 @@ import {
   EMBED_START_PATH,
   EMBED_TOKEN_QUERY_PARAM,
 } from "../shared/embed-auth.js";
+import {
+  isClaudeMcpContentOrigin,
+  MCP_EMBED_CORS_ALLOW_HEADERS,
+} from "../shared/mcp-embed-headers.js";
 import { withCollapsedAgentSidebarParam } from "../shared/agent-sidebar-url.js";
 
 function withConfiguredBasePath(path: string): string {
@@ -35,12 +45,7 @@ function redirectWithStagedCookies(
   status = 302,
 ): Response {
   setEmbedStartResponseHeaders(event);
-  const headers = new Headers({
-    "Cross-Origin-Embedder-Policy": "require-corp",
-    "Cross-Origin-Opener-Policy": "same-origin",
-    "Cross-Origin-Resource-Policy": "cross-origin",
-    Location: location,
-  });
+  const headers = embedStartResponseHeaders(event, { Location: location });
   const staged = event.res?.headers?.getSetCookie?.() ?? [];
   for (const cookie of staged) headers.append("set-cookie", cookie);
   headers.set("Referrer-Policy", "no-referrer");
@@ -51,6 +56,48 @@ function setEmbedStartResponseHeaders(event: H3Event): void {
   setResponseHeader(event, "Cross-Origin-Embedder-Policy", "require-corp");
   setResponseHeader(event, "Cross-Origin-Opener-Policy", "same-origin");
   setResponseHeader(event, "Cross-Origin-Resource-Policy", "cross-origin");
+  const origin = embedStartCorsOrigin(event);
+  if (origin) {
+    setResponseHeader(event, "Access-Control-Allow-Origin", origin);
+    setResponseHeader(event, "Vary", "Origin");
+    setResponseHeader(
+      event,
+      "Access-Control-Allow-Methods",
+      "GET,HEAD,OPTIONS",
+    );
+    setResponseHeader(
+      event,
+      "Access-Control-Allow-Headers",
+      MCP_EMBED_CORS_ALLOW_HEADERS,
+    );
+    setResponseHeader(event, "Access-Control-Expose-Headers", "Location");
+  }
+}
+
+function embedStartCorsOrigin(event: H3Event): string | null {
+  const origin = getHeader(event, "origin");
+  return isClaudeMcpContentOrigin(origin) ? origin : null;
+}
+
+function embedStartResponseHeaders(
+  event: H3Event,
+  init: Record<string, string> = {},
+): Headers {
+  const headers = new Headers({
+    "Cross-Origin-Embedder-Policy": "require-corp",
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "Cross-Origin-Resource-Policy": "cross-origin",
+    ...init,
+  });
+  const origin = embedStartCorsOrigin(event);
+  if (origin) {
+    headers.set("Access-Control-Allow-Origin", origin);
+    headers.set("Vary", "Origin");
+    headers.set("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS");
+    headers.set("Access-Control-Allow-Headers", MCP_EMBED_CORS_ALLOW_HEADERS);
+    headers.set("Access-Control-Expose-Headers", "Location");
+  }
+  return headers;
 }
 
 function textResponse(
@@ -61,12 +108,9 @@ function textResponse(
   setEmbedStartResponseHeaders(event);
   return new Response(message, {
     status,
-    headers: {
+    headers: embedStartResponseHeaders(event, {
       "Content-Type": "text/plain; charset=utf-8",
-      "Cross-Origin-Embedder-Policy": "require-corp",
-      "Cross-Origin-Opener-Policy": "same-origin",
-      "Cross-Origin-Resource-Policy": "cross-origin",
-    },
+    }),
   });
 }
 
@@ -84,16 +128,23 @@ export function createEmbedStartRouteHandler(
 ) {
   return defineEventHandler(async (event: H3Event) => {
     const method = getMethod(event);
+    if (method === "OPTIONS") {
+      setEmbedStartResponseHeaders(event);
+      return new Response(null, {
+        status: 204,
+        headers: embedStartResponseHeaders(event, {
+          "Cache-Control": "no-store",
+        }),
+      });
+    }
+
     if (method === "HEAD") {
       setEmbedStartResponseHeaders(event);
       return new Response(null, {
         status: 204,
-        headers: {
+        headers: embedStartResponseHeaders(event, {
           "Cache-Control": "no-store",
-          "Cross-Origin-Embedder-Policy": "require-corp",
-          "Cross-Origin-Opener-Policy": "same-origin",
-          "Cross-Origin-Resource-Policy": "cross-origin",
-        },
+        }),
       });
     }
 

--- a/packages/core/src/server/embed-route.ts
+++ b/packages/core/src/server/embed-route.ts
@@ -18,6 +18,7 @@ import {
   EMBED_MODE_QUERY_PARAM,
   EMBED_START_PATH,
   EMBED_TOKEN_QUERY_PARAM,
+  MCP_APP_CHAT_BRIDGE_QUERY_PARAM,
 } from "../shared/embed-auth.js";
 import {
   isClaudeMcpContentOrigin,
@@ -32,10 +33,17 @@ function withConfiguredBasePath(path: string): string {
   return `${base}${path}`;
 }
 
-function appendEmbedParams(target: string, token: string): string {
+function appendEmbedParams(
+  target: string,
+  token: string,
+  chatBridgeActive = false,
+): string {
   const url = new URL(target, "http://agent-native.invalid");
   url.searchParams.set(EMBED_MODE_QUERY_PARAM, "1");
   url.searchParams.set(EMBED_TOKEN_QUERY_PARAM, token);
+  if (chatBridgeActive) {
+    url.searchParams.set(MCP_APP_CHAT_BRIDGE_QUERY_PARAM, "1");
+  }
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
@@ -119,6 +127,14 @@ export function buildEmbedStartPath(ticket: string): string {
   return `${getConfiguredAppBasePath()}${EMBED_START_PATH}?${qs}`;
 }
 
+function firstQueryValue(value: unknown): string {
+  return typeof value === "string"
+    ? value
+    : Array.isArray(value) && typeof value[0] === "string"
+      ? value[0]
+      : "";
+}
+
 export interface EmbedStartRouteOptions {
   getExistingSession?: (event: H3Event) => Promise<AuthSession | null>;
 }
@@ -152,7 +168,8 @@ export function createEmbedStartRouteHandler(
       return textResponse(event, "Method not allowed", 405);
     }
 
-    const rawTicket = getQuery(event)?.ticket;
+    const query = getQuery(event) ?? {};
+    const rawTicket = query.ticket;
     const ticket = Array.isArray(rawTicket) ? rawTicket[0] : rawTicket;
     const existingSession = await options
       .getExistingSession?.(event)
@@ -178,8 +195,13 @@ export function createEmbedStartRouteHandler(
     setEmbedSessionCookie(event, token);
     setResponseHeader(event, "Referrer-Policy", "no-referrer");
 
+    const chatBridgeActive =
+      firstQueryValue(query[MCP_APP_CHAT_BRIDGE_QUERY_PARAM]) === "1" ||
+      firstQueryValue(query[MCP_APP_CHAT_BRIDGE_QUERY_PARAM]) === "true";
     const location = withConfiguredBasePath(
-      withCollapsedAgentSidebarParam(appendEmbedParams(target, token)),
+      withCollapsedAgentSidebarParam(
+        appendEmbedParams(target, token, chatBridgeActive),
+      ),
     );
     return redirectWithStagedCookies(event, location);
   });

--- a/packages/core/src/server/security-headers.spec.ts
+++ b/packages/core/src/server/security-headers.spec.ts
@@ -5,6 +5,12 @@ const headers = new Map<string, string>();
 vi.mock("h3", () => ({
   defineEventHandler: (handler: any) => handler,
   getCookie: (event: any, name: string) => event.cookies?.[name],
+  getHeader: (event: any, name: string) =>
+    event.headers?.get?.(name) ??
+    event.headers?.[name] ??
+    event.headers?.[name.toLowerCase()] ??
+    event.node?.req?.headers?.[name] ??
+    event.node?.req?.headers?.[name.toLowerCase()],
   getQuery: (event: any) => event.query ?? {},
   setResponseHeader: (_event: any, name: string, value: string) => {
     headers.set(name, value);
@@ -92,6 +98,35 @@ describe("security headers middleware", () => {
     expect(headers.get("Referrer-Policy")).toBe("no-referrer");
     expect(headers.get("Cross-Origin-Embedder-Policy")).toBe("require-corp");
     expect(headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+    vi.unstubAllEnvs();
+  });
+
+  it("allows Claude MCP content frames to fetch embed-token page HTML", () => {
+    headers.clear();
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("OAUTH_STATE_SECRET", "embed-test-secret");
+    const token = signEmbedSessionToken({
+      ownerEmail: "user@example.test",
+      targetPath: "/inbox",
+      ttlSeconds: 60,
+    });
+
+    const handler = createSecurityHeadersMiddleware();
+    handler({
+      path: "/inbox",
+      query: { __an_embed_token: token },
+      url: { protocol: "https:" },
+      headers: new Headers({
+        origin: "https://520ba469ac5783c72c33d79bea940871.claudemcpcontent.com",
+      }),
+      node: { req: { headers: {} } },
+    });
+
+    expect(headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://520ba469ac5783c72c33d79bea940871.claudemcpcontent.com",
+    );
+    expect(headers.get("Access-Control-Allow-Credentials")).toBeUndefined();
+    expect(headers.get("Vary")).toBe("Origin");
     vi.unstubAllEnvs();
   });
 });

--- a/packages/core/src/server/security-headers.ts
+++ b/packages/core/src/server/security-headers.ts
@@ -50,8 +50,12 @@
  * us most of the protection.
  */
 
-import { defineEventHandler, setResponseHeader } from "h3";
+import { defineEventHandler, getHeader, setResponseHeader } from "h3";
 import { requestHasEmbedAuthMarker } from "./embed-session.js";
+import {
+  isClaudeMcpContentOrigin,
+  MCP_EMBED_CORS_ALLOW_HEADERS,
+} from "../shared/mcp-embed-headers.js";
 
 const HSTS = "max-age=31536000; includeSubDomains; preload";
 const PERMISSIONS_POLICY =
@@ -89,6 +93,7 @@ export function createSecurityHeadersMiddleware() {
   const isProduction = process.env.NODE_ENV === "production";
   return defineEventHandler((event) => {
     const embedFrameRequest = requestHasEmbedAuthMarker(event);
+    const requestOrigin = getHeader(event, "origin");
     setResponseHeader(event, "X-Content-Type-Options", "nosniff");
     if (isProduction && !embedFrameRequest) {
       setResponseHeader(event, "X-Frame-Options", "DENY");
@@ -108,6 +113,20 @@ export function createSecurityHeadersMiddleware() {
       "Cross-Origin-Resource-Policy",
       embedFrameRequest ? "cross-origin" : "same-site",
     );
+    if (embedFrameRequest && isClaudeMcpContentOrigin(requestOrigin)) {
+      setResponseHeader(event, "Access-Control-Allow-Origin", requestOrigin);
+      setResponseHeader(event, "Vary", "Origin");
+      setResponseHeader(
+        event,
+        "Access-Control-Allow-Methods",
+        "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS",
+      );
+      setResponseHeader(
+        event,
+        "Access-Control-Allow-Headers",
+        MCP_EMBED_CORS_ALLOW_HEADERS,
+      );
+    }
     if (isHttpsRequest(event)) {
       setResponseHeader(event, "Strict-Transport-Security", HSTS);
     }

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createH3SSRHandler } from "./ssr-handler.js";
+import {
+  createH3SSRHandler,
+  DEFAULT_SSR_CACHE_CONTROL,
+} from "./ssr-handler.js";
 
 const mocks = vi.hoisted(() => {
   const requestHandler = vi.fn(async (request: Request) => {
@@ -8,11 +11,16 @@ const mocks = vi.hoisted(() => {
       headers: { "x-rr-path": url.pathname },
     });
   });
-  return { requestHandler };
+  const getSession = vi.fn(async () => null);
+  return { getSession, requestHandler };
 });
 
 vi.mock("react-router", () => ({
   createRequestHandler: vi.fn(() => mocks.requestHandler),
+}));
+
+vi.mock("./auth.js", () => ({
+  getSession: mocks.getSession,
 }));
 
 function createEvent(pathname: string, method = "GET", init: RequestInit = {}) {
@@ -31,6 +39,7 @@ describe("createH3SSRHandler", () => {
     delete process.env.SENTRY_DSN;
     delete process.env.SENTRY_ENVIRONMENT;
     mocks.requestHandler.mockClear();
+    mocks.getSession.mockClear();
   });
 
   it("strips APP_BASE_PATH before handing requests to React Router", async () => {
@@ -86,6 +95,63 @@ describe("createH3SSRHandler", () => {
     expect(response.headers.get("x-rr-path")).toBe("/settings");
     await expect(response.text()).resolves.toBe("");
     expect(mocks.requestHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the default public SSR cache policy to HTML responses", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response("<html><head></head><body>ok</body></html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(createEvent("/"));
+
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
+  });
+
+  it("preserves explicit SSR cache policies from routes", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response("<html><head></head><body>ok</body></html>", {
+        headers: {
+          "cache-control": "private, no-store",
+          "content-type": "text/html; charset=utf-8",
+        },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(createEvent("/"));
+
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+  });
+
+  it("does not resolve auth for anonymous SSR page requests", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response("<html><head></head><body>ok</body></html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    await handler(createEvent("/"));
+
+    expect(mocks.getSession).not.toHaveBeenCalled();
+  });
+
+  it("resolves auth context when an SSR page request carries credentials", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response("<html><head></head><body>ok</body></html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    await handler(createEvent("/", "GET", { headers: { cookie: "sid=1" } }));
+
+    expect(mocks.getSession).toHaveBeenCalledTimes(1);
   });
 
   it("does not SSR framework routes under APP_BASE_PATH", async () => {

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  AUTHENTICATED_SSR_CACHE_CONTROL,
   createH3SSRHandler,
   DEFAULT_SSR_CACHE_CONTROL,
 } from "./ssr-handler.js";
@@ -116,6 +117,25 @@ describe("createH3SSRHandler", () => {
 
     expect(response.headers.get("cache-control")).toBe(
       DEFAULT_SSR_CACHE_CONTROL,
+    );
+  });
+
+  it("uses private SSR caching when a page request carries auth signals", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response("<html><head></head><body>ok</body></html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(
+      createEvent("/slides/private", "GET", {
+        headers: { cookie: "sid=1" },
+      }),
+    );
+
+    expect(response.headers.get("cache-control")).toBe(
+      AUTHENTICATED_SSR_CACHE_CONTROL,
     );
   });
 

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -139,6 +139,46 @@ describe("createH3SSRHandler", () => {
     );
   });
 
+  it("keeps public SSR caching for docs anonymous session cookies", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response("<html><head></head><body>ok</body></html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(
+      createEvent("/docs", "GET", {
+        headers: { cookie: "an_docs_session=anonymous-session" },
+      }),
+    );
+
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
+    expect(mocks.getSession).not.toHaveBeenCalled();
+  });
+
+  it("uses private SSR caching when anonymous and authenticated cookies coexist", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response("<html><head></head><body>ok</body></html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(
+      createEvent("/docs", "GET", {
+        headers: { cookie: "an_docs_session=anon; sid=1" },
+      }),
+    );
+
+    expect(response.headers.get("cache-control")).toBe(
+      AUTHENTICATED_SSR_CACHE_CONTROL,
+    );
+    expect(mocks.getSession).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves explicit SSR cache policies from routes", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response("<html><head></head><body>ok</body></html>", {

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -22,6 +22,8 @@ vi.mock("react-router", () => ({
 }));
 
 vi.mock("./auth.js", () => ({
+  BETTER_AUTH_COOKIE_PREFIX: "an",
+  COOKIE_NAME: "an_session",
   getSession: mocks.getSession,
 }));
 
@@ -120,7 +122,7 @@ describe("createH3SSRHandler", () => {
     );
   });
 
-  it("uses private SSR caching when a page request carries auth signals", async () => {
+  it("uses private SSR caching when a page request carries a framework session cookie", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response("<html><head></head><body>ok</body></html>", {
         headers: { "content-type": "text/html; charset=utf-8" },
@@ -130,7 +132,7 @@ describe("createH3SSRHandler", () => {
 
     const response = await handler(
       createEvent("/slides/private", "GET", {
-        headers: { cookie: "sid=1" },
+        headers: { cookie: "an_session=1" },
       }),
     );
 
@@ -159,6 +161,26 @@ describe("createH3SSRHandler", () => {
     expect(mocks.getSession).not.toHaveBeenCalled();
   });
 
+  it("keeps public SSR caching for anonymous preference cookies", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response("<html><head></head><body>ok</body></html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(
+      createEvent("/docs", "GET", {
+        headers: { cookie: "sidebar:state=collapsed" },
+      }),
+    );
+
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
+    expect(mocks.getSession).not.toHaveBeenCalled();
+  });
+
   it("uses private SSR caching when anonymous and authenticated cookies coexist", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response("<html><head></head><body>ok</body></html>", {
@@ -169,7 +191,7 @@ describe("createH3SSRHandler", () => {
 
     const response = await handler(
       createEvent("/docs", "GET", {
-        headers: { cookie: "an_docs_session=anon; sid=1" },
+        headers: { cookie: "an_docs_session=anon; an_session=1" },
       }),
     );
 
@@ -216,7 +238,9 @@ describe("createH3SSRHandler", () => {
     );
     const handler = createH3SSRHandler(() => ({})) as any;
 
-    await handler(createEvent("/", "GET", { headers: { cookie: "sid=1" } }));
+    await handler(
+      createEvent("/", "GET", { headers: { cookie: "an_session=1" } }),
+    );
 
     expect(mocks.getSession).toHaveBeenCalledTimes(1);
   });

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -12,7 +12,8 @@ const mocks = vi.hoisted(() => {
     });
   });
   const getSession = vi.fn(async () => null);
-  return { getSession, requestHandler };
+  const requestHasEmbedAuthMarker = vi.fn(() => false);
+  return { getSession, requestHandler, requestHasEmbedAuthMarker };
 });
 
 vi.mock("react-router", () => ({
@@ -21,6 +22,10 @@ vi.mock("react-router", () => ({
 
 vi.mock("./auth.js", () => ({
   getSession: mocks.getSession,
+}));
+
+vi.mock("./embed-session.js", () => ({
+  requestHasEmbedAuthMarker: mocks.requestHasEmbedAuthMarker,
 }));
 
 function createEvent(pathname: string, method = "GET", init: RequestInit = {}) {
@@ -40,6 +45,8 @@ describe("createH3SSRHandler", () => {
     delete process.env.SENTRY_ENVIRONMENT;
     mocks.requestHandler.mockClear();
     mocks.getSession.mockClear();
+    mocks.requestHasEmbedAuthMarker.mockClear();
+    mocks.requestHasEmbedAuthMarker.mockReturnValue(false);
   });
 
   it("strips APP_BASE_PATH before handing requests to React Router", async () => {
@@ -150,6 +157,46 @@ describe("createH3SSRHandler", () => {
     const handler = createH3SSRHandler(() => ({})) as any;
 
     await handler(createEvent("/", "GET", { headers: { cookie: "sid=1" } }));
+
+    expect(mocks.getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves auth context when an SSR page request carries an embed token", async () => {
+    mocks.requestHasEmbedAuthMarker.mockReturnValue(true);
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response("<html><head></head><body>ok</body></html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    await handler(createEvent("/inbox?embedded=1&__an_embed_token=signed"));
+
+    expect(mocks.getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves auth context when an SSR page request carries embed token auth", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response("<html><head></head><body>ok</body></html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    await handler(createEvent("/inbox?__an_embed_token=signed-token"));
+
+    expect(mocks.getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves auth context when an SSR page request carries mobile session auth", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response("<html><head></head><body>ok</body></html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    await handler(createEvent("/inbox?_session=mobile-token"));
 
     expect(mocks.getSession).toHaveBeenCalledTimes(1);
   });

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -25,6 +25,8 @@ import { EMBED_TOKEN_QUERY_PARAM } from "../shared/embed-auth.js";
 
 export const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+export const AUTHENTICATED_SSR_CACHE_CONTROL =
+  "private, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 
 /**
  * Read the active org for a request without forcing every template to bundle
@@ -151,14 +153,21 @@ function requestHasAuthSignal(event: H3Event): boolean {
   );
 }
 
-function applyDefaultSsrCacheHeader(headers: Headers, status: number) {
+function applyDefaultSsrCacheHeader(
+  headers: Headers,
+  status: number,
+  hasAuthSignal: boolean,
+) {
   if (headers.has("cache-control")) return;
   if (status < 200 || status >= 400) return;
 
   const contentType = headers.get("content-type")?.toLowerCase() ?? "";
   if (!contentType.includes("text/html")) return;
 
-  headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
+  headers.set(
+    "cache-control",
+    hasAuthSignal ? AUTHENTICATED_SSR_CACHE_CONTROL : DEFAULT_SSR_CACHE_CONTROL,
+  );
 }
 
 function isFrameworkOrAssetPath(pathname: string): boolean {
@@ -182,10 +191,11 @@ function isFrameworkOrAssetPath(pathname: string): boolean {
 async function rewriteMountedResponse(
   response: Response,
   basePath: string,
+  hasAuthSignal: boolean,
 ): Promise<Response> {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
-  applyDefaultSsrCacheHeader(headers, response.status);
+  applyDefaultSsrCacheHeader(headers, response.status, hasAuthSignal);
 
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {
@@ -244,7 +254,8 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
       // unauthenticated branch even when the user is logged in — which broke
       // shared-deck "Presentation link" access for non-public decks.
       let session: Awaited<ReturnType<typeof getSession>> | null = null;
-      if (requestHasAuthSignal(event)) {
+      const hasAuthSignal = requestHasAuthSignal(event);
+      if (hasAuthSignal) {
         try {
           session = await getSession(event);
         } catch {
@@ -272,11 +283,13 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
             headers: response.headers,
           }),
           basePath,
+          hasAuthSignal,
         );
       }
       return await rewriteMountedResponse(
         await runWithRequestContext(ctx, () => handler(request)),
         basePath,
+        hasAuthSignal,
       );
     } catch (err) {
       // Log the full stack server-side, but never leak it to the client.

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -27,6 +27,7 @@ export const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 export const AUTHENTICATED_SSR_CACHE_CONTROL =
   "private, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+const ANONYMOUS_SESSION_COOKIE_NAMES = new Set(["an_docs_session"]);
 
 /**
  * Read the active org for a request without forcing every template to bundle
@@ -146,11 +147,20 @@ function requestHasAuthSignal(event: H3Event): boolean {
   const headers = event.req.headers;
   return Boolean(
     headers.get("authorization") ||
-    headers.get("cookie") ||
+    requestHasAuthenticatedCookie(headers.get("cookie")) ||
     event.url.searchParams.has(EMBED_TOKEN_QUERY_PARAM) ||
     event.url.searchParams.has("_session") ||
     requestHasEmbedAuthMarker(event),
   );
+}
+
+function requestHasAuthenticatedCookie(cookieHeader: string | null): boolean {
+  if (!cookieHeader) return false;
+  return cookieHeader
+    .split(";")
+    .map((cookie) => cookie.trim().split("=", 1)[0]?.trim())
+    .filter((name): name is string => Boolean(name))
+    .some((name) => !ANONYMOUS_SESSION_COOKIE_NAMES.has(name));
 }
 
 function applyDefaultSsrCacheHeader(

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -18,16 +18,20 @@
 import { createRequestHandler } from "react-router";
 import { defineEventHandler, type H3Event } from "h3";
 import { getSentryClientConfigScript } from "./sentry-config.js";
-import { getSession } from "./auth.js";
+import { BETTER_AUTH_COOKIE_PREFIX, COOKIE_NAME, getSession } from "./auth.js";
 import { runWithRequestContext } from "./request-context.js";
 import { requestHasEmbedAuthMarker } from "./embed-session.js";
-import { EMBED_TOKEN_QUERY_PARAM } from "../shared/embed-auth.js";
+import {
+  EMBED_SESSION_COOKIE,
+  EMBED_TOKEN_QUERY_PARAM,
+} from "../shared/embed-auth.js";
 
 export const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 export const AUTHENTICATED_SSR_CACHE_CONTROL =
   "private, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 const ANONYMOUS_SESSION_COOKIE_NAMES = new Set(["an_docs_session"]);
+const BETTER_AUTH_SESSION_COOKIE_RE = /\.session_(?:token|data)$/;
 
 /**
  * Read the active org for a request without forcing every template to bundle
@@ -160,7 +164,22 @@ function requestHasAuthenticatedCookie(cookieHeader: string | null): boolean {
     .split(";")
     .map((cookie) => cookie.trim().split("=", 1)[0]?.trim())
     .filter((name): name is string => Boolean(name))
-    .some((name) => !ANONYMOUS_SESSION_COOKIE_NAMES.has(name));
+    .some(isAuthenticatedCookieName);
+}
+
+function isAuthenticatedCookieName(name: string): boolean {
+  if (ANONYMOUS_SESSION_COOKIE_NAMES.has(name)) return false;
+  const bareName = name.replace(/^__(?:Secure|Host)-/, "");
+  return (
+    bareName === COOKIE_NAME ||
+    bareName === EMBED_SESSION_COOKIE ||
+    bareName === "an_session" ||
+    bareName === "an_session_workspace" ||
+    bareName.startsWith("an_session_") ||
+    bareName === `${BETTER_AUTH_COOKIE_PREFIX}.session_token` ||
+    bareName === `${BETTER_AUTH_COOKIE_PREFIX}.session_data` ||
+    BETTER_AUTH_SESSION_COOKIE_RE.test(bareName)
+  );
 }
 
 function applyDefaultSsrCacheHeader(

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -21,6 +21,9 @@ import { getSentryClientConfigScript } from "./sentry-config.js";
 import { getSession } from "./auth.js";
 import { runWithRequestContext } from "./request-context.js";
 
+export const DEFAULT_SSR_CACHE_CONTROL =
+  "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+
 /**
  * Read the active org for a request without forcing every template to bundle
  * the org module. Mirrors what `core-routes-plugin` does for action handlers.
@@ -135,6 +138,21 @@ function injectHeadScript(html: string, script: string | null): string {
   return html.slice(0, headCloseIdx) + script + html.slice(headCloseIdx);
 }
 
+function requestHasAuthSignal(event: H3Event): boolean {
+  const headers = event.req.headers;
+  return Boolean(headers.get("authorization") || headers.get("cookie"));
+}
+
+function applyDefaultSsrCacheHeader(headers: Headers, status: number) {
+  if (headers.has("cache-control")) return;
+  if (status < 200 || status >= 400) return;
+
+  const contentType = headers.get("content-type")?.toLowerCase() ?? "";
+  if (!contentType.includes("text/html")) return;
+
+  headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
+}
+
 function isFrameworkOrAssetPath(pathname: string): boolean {
   return (
     pathname.startsWith("/.well-known/") ||
@@ -158,12 +176,20 @@ async function rewriteMountedResponse(
   basePath: string,
 ): Promise<Response> {
   const sentryClientConfigScript = getSentryClientConfigScript();
-  if (!basePath && !sentryClientConfigScript) return response;
-
   const headers = new Headers(response.headers);
+  applyDefaultSsrCacheHeader(headers, response.status);
+
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {
     headers.set("location", prefixMountedPath(location, basePath));
+  }
+
+  if (!basePath && !sentryClientConfigScript) {
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
   }
 
   const contentType = headers.get("content-type") ?? "";
@@ -210,10 +236,12 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
       // unauthenticated branch even when the user is logged in — which broke
       // shared-deck "Presentation link" access for non-public decks.
       let session: Awaited<ReturnType<typeof getSession>> | null = null;
-      try {
-        session = await getSession(event);
-      } catch {
-        // Auth lookup failures must not break SSR; treat as unauthenticated.
+      if (requestHasAuthSignal(event)) {
+        try {
+          session = await getSession(event);
+        } catch {
+          // Auth lookup failures must not break SSR; treat as unauthenticated.
+        }
       }
       const orgId = session?.email ? await readOrgIdForEvent(event) : undefined;
       const ctx = {

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -20,6 +20,8 @@ import { defineEventHandler, type H3Event } from "h3";
 import { getSentryClientConfigScript } from "./sentry-config.js";
 import { getSession } from "./auth.js";
 import { runWithRequestContext } from "./request-context.js";
+import { requestHasEmbedAuthMarker } from "./embed-session.js";
+import { EMBED_TOKEN_QUERY_PARAM } from "../shared/embed-auth.js";
 
 export const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
@@ -140,7 +142,13 @@ function injectHeadScript(html: string, script: string | null): string {
 
 function requestHasAuthSignal(event: H3Event): boolean {
   const headers = event.req.headers;
-  return Boolean(headers.get("authorization") || headers.get("cookie"));
+  return Boolean(
+    headers.get("authorization") ||
+    headers.get("cookie") ||
+    event.url.searchParams.has(EMBED_TOKEN_QUERY_PARAM) ||
+    event.url.searchParams.has("_session") ||
+    requestHasEmbedAuthMarker(event),
+  );
 }
 
 function applyDefaultSsrCacheHeader(headers: Headers, status: number) {

--- a/packages/core/src/shared/mcp-embed-headers.ts
+++ b/packages/core/src/shared/mcp-embed-headers.ts
@@ -1,0 +1,69 @@
+export const MCP_EMBED_CORS_ALLOW_HEADERS =
+  "Content-Type,Authorization,X-Requested-With,X-Request-Source,X-Agent-Native-CSRF,X-Agent-Native-Embed-Target";
+
+const CLAUDE_MCP_CONTENT_HOST_RE = /^[a-f0-9]{32}\.claudemcpcontent\.com$/i;
+
+export function isClaudeMcpContentOrigin(
+  origin: string | null | undefined,
+): boolean {
+  if (!origin) return false;
+  try {
+    const url = new URL(origin);
+    return (
+      url.protocol === "https:" && CLAUDE_MCP_CONTENT_HOST_RE.test(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isMcpEmbedCorsOrigin(
+  origin: string | null | undefined,
+): boolean {
+  return origin === "null" || isClaudeMcpContentOrigin(origin);
+}
+
+export function shouldAllowMcpEmbedCredentials(
+  origin: string | null | undefined,
+): boolean {
+  return origin !== "null" && !isClaudeMcpContentOrigin(origin);
+}
+
+export const MCP_EMBED_STATIC_ASSET_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Cross-Origin-Resource-Policy": "cross-origin",
+} as const;
+
+const STATIC_ASSET_PATTERNS = [
+  "/assets/**",
+  "/favicon.ico",
+  "/favicon.svg",
+  "/manifest.json",
+  "/icon-*.svg",
+  "/agent-native-*.svg",
+];
+
+function normalizeBasePath(basePath: string | undefined): string {
+  const base = (basePath ?? "").trim();
+  if (!base || base === "/") return "";
+  return base.startsWith("/")
+    ? base.replace(/\/+$/g, "")
+    : `/${base.replace(/\/+$/g, "")}`;
+}
+
+export function mcpEmbedStaticAssetRouteRules(
+  basePath?: string,
+): Record<string, { headers: typeof MCP_EMBED_STATIC_ASSET_HEADERS }> {
+  const base = normalizeBasePath(basePath);
+  const rules: Record<
+    string,
+    { headers: typeof MCP_EMBED_STATIC_ASSET_HEADERS }
+  > = {};
+  for (const pattern of STATIC_ASSET_PATTERNS) {
+    rules[pattern] = { headers: MCP_EMBED_STATIC_ASSET_HEADERS };
+    if (base) {
+      rules[`${base}${pattern}`] = { headers: MCP_EMBED_STATIC_ASSET_HEADERS };
+    }
+  }
+  return rules;
+}

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -160,6 +160,71 @@ describe("Vite MCP embed headers", () => {
       "cross-origin",
     );
   });
+
+  it("adds CORS/CORP headers to null-origin sandbox subresources in dev", () => {
+    const plugin = findPlugin("agent-native-embed-dev-frame-headers");
+    let middleware: Function | null = null;
+    const server = {
+      middlewares: {
+        use: vi.fn((fn: Function) => {
+          middleware = fn;
+        }),
+      },
+    };
+
+    plugin.configureServer(server);
+
+    const setHeader = vi.fn();
+    middleware!(
+      { url: "/app/entry.client.tsx", headers: { origin: "null" } },
+      { setHeader },
+      vi.fn(),
+    );
+
+    expect(setHeader).toHaveBeenCalledWith(
+      "Access-Control-Allow-Origin",
+      "null",
+    );
+    expect(setHeader).toHaveBeenCalledWith("Vary", "Origin");
+    expect(setHeader).toHaveBeenCalledWith(
+      "Access-Control-Allow-Headers",
+      expect.stringContaining("X-Agent-Native-Embed-Target"),
+    );
+    expect(setHeader).toHaveBeenCalledWith(
+      "Cross-Origin-Resource-Policy",
+      "cross-origin",
+    );
+  });
+
+  it("answers null-origin sandbox preflights before Nitro dev middleware", () => {
+    const plugin = findPlugin("agent-native-embed-dev-frame-headers");
+    let middleware: Function | null = null;
+    const server = {
+      middlewares: {
+        use: vi.fn((fn: Function) => {
+          middleware = fn;
+        }),
+      },
+    };
+
+    plugin.configureServer(server);
+
+    const res = { setHeader: vi.fn(), end: vi.fn(), statusCode: 200 };
+    const next = vi.fn();
+    middleware!(
+      {
+        method: "OPTIONS",
+        url: "/_agent-native/poll",
+        headers: { origin: "null" },
+      },
+      res,
+      next,
+    );
+
+    expect(res.statusCode).toBe(204);
+    expect(res.end).toHaveBeenCalledOnce();
+    expect(next).not.toHaveBeenCalled();
+  });
 });
 
 describe("Vite connection reset noise", () => {

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -7,6 +7,12 @@ import { actionTypesPlugin } from "./action-types-plugin.js";
 import { agentsBundlePlugin } from "./agents-bundle-plugin.js";
 import { findWorkspaceRoot } from "../scripts/utils.js";
 import { getViteDevRecoveryScript } from "../client/vite-dev-recovery-script.js";
+import {
+  isMcpEmbedCorsOrigin,
+  MCP_EMBED_CORS_ALLOW_HEADERS,
+  MCP_EMBED_STATIC_ASSET_HEADERS,
+  mcpEmbedStaticAssetRouteRules,
+} from "../shared/mcp-embed-headers.js";
 
 import { fileURLToPath } from "url";
 
@@ -629,6 +635,31 @@ function embedDevFrameHeaders(): Plugin {
     apply: "serve",
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
+        const origin = String(req.headers.origin ?? "");
+        if (isMcpEmbedCorsOrigin(origin)) {
+          res.setHeader("Access-Control-Allow-Origin", origin);
+          res.setHeader("Vary", "Origin");
+          res.setHeader(
+            "Access-Control-Allow-Methods",
+            "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS",
+          );
+          res.setHeader(
+            "Access-Control-Allow-Headers",
+            MCP_EMBED_CORS_ALLOW_HEADERS,
+          );
+          for (const [name, value] of Object.entries(
+            MCP_EMBED_STATIC_ASSET_HEADERS,
+          )) {
+            if (name === "Access-Control-Allow-Origin") continue;
+            res.setHeader(name, value);
+          }
+          if (req.method === "OPTIONS") {
+            res.statusCode = 204;
+            res.end();
+            return;
+          }
+        }
+
         const cookieHeader = String(req.headers.cookie ?? "");
         let hasEmbedMarker = /\ban_embed_session=/.test(cookieHeader);
         try {
@@ -1098,6 +1129,11 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
             nitroVitePlugin({
               serverDir: "./server",
               ...(options.nitro ?? {}),
+              routeRules: {
+                ...mcpEmbedStaticAssetRouteRules(appBasePath),
+                ...((options.nitro as { routeRules?: Record<string, any> })
+                  ?.routeRules ?? {}),
+              },
             } as any),
           ]),
       reactPluginInstance,

--- a/packages/docs/netlify.toml
+++ b/packages/docs/netlify.toml
@@ -12,11 +12,11 @@
 [build.environment]
   NITRO_PRESET = "netlify"
 
-# SSR pages: cache 1h, serve stale for 24h while revalidating
+# SSR pages: keep browsers fresh, let the CDN serve stale while revalidating.
 [[headers]]
   for = "/*"
   [headers.values]
-    Cache-Control = "public, max-age=3600, stale-while-revalidate=86400"
+    Cache-Control = "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600"
 
 # Static assets: immutable long cache
 [[headers]]

--- a/packages/docs/server/plugins/auth.spec.ts
+++ b/packages/docs/server/plugins/auth.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { shouldCreateDocsSessionForPath } from "./auth.js";
+
+describe("docs auth session scoping", () => {
+  it("creates anonymous sessions for framework and API routes under a mount path", () => {
+    expect(
+      shouldCreateDocsSessionForPath(
+        "/docs/_agent-native/auth/session",
+        "/docs",
+      ),
+    ).toBe(true);
+    expect(shouldCreateDocsSessionForPath("/docs/api/search", "/docs")).toBe(
+      true,
+    );
+  });
+
+  it("does not create anonymous sessions for public page routes under a mount path", () => {
+    expect(shouldCreateDocsSessionForPath("/docs", "/docs")).toBe(false);
+    expect(
+      shouldCreateDocsSessionForPath("/docs/getting-started", "/docs"),
+    ).toBe(false);
+  });
+});

--- a/packages/docs/server/plugins/auth.ts
+++ b/packages/docs/server/plugins/auth.ts
@@ -1,15 +1,22 @@
 import { createAuthPlugin } from "@agent-native/core/server";
-import { getCookie, setCookie } from "h3";
+import { getCookie, getRequestURL, setCookie, type H3Event } from "h3";
 import { randomUUID } from "crypto";
+
+function shouldCreateDocsSession(event: H3Event): boolean {
+  const pathname = getRequestURL(event).pathname;
+  return pathname.startsWith("/_agent-native/") || pathname.startsWith("/api/");
+}
 
 export default createAuthPlugin({
   getSession: async (event) => {
     const cookieName = "an_docs_session";
-    let sessionId = getCookie(event as any, cookieName);
+    let sessionId = getCookie(event, cookieName);
 
     if (!sessionId) {
+      if (!shouldCreateDocsSession(event)) return null;
+
       sessionId = randomUUID();
-      setCookie(event as any, cookieName, sessionId, {
+      setCookie(event, cookieName, sessionId, {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",
         sameSite: "lax",

--- a/packages/docs/server/plugins/auth.ts
+++ b/packages/docs/server/plugins/auth.ts
@@ -1,10 +1,24 @@
-import { createAuthPlugin } from "@agent-native/core/server";
+import { createAuthPlugin, getAppBasePath } from "@agent-native/core/server";
 import { getCookie, getRequestURL, setCookie, type H3Event } from "h3";
 import { randomUUID } from "crypto";
 
+export function shouldCreateDocsSessionForPath(
+  pathname: string,
+  basePath = getAppBasePath(),
+): boolean {
+  const pathWithoutBase =
+    basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+      ? pathname.slice(basePath.length) || "/"
+      : pathname;
+  return (
+    pathWithoutBase.startsWith("/_agent-native/") ||
+    pathWithoutBase.startsWith("/api/")
+  );
+}
+
 function shouldCreateDocsSession(event: H3Event): boolean {
   const pathname = getRequestURL(event).pathname;
-  return pathname.startsWith("/_agent-native/") || pathname.startsWith("/api/");
+  return shouldCreateDocsSessionForPath(pathname);
 }
 
 export default createAuthPlugin({

--- a/packages/docs/server/routes/[...page].get.ts
+++ b/packages/docs/server/routes/[...page].get.ts
@@ -1,4 +1,7 @@
-import { createH3SSRHandler } from "@agent-native/core/server/ssr-handler";
+import {
+  createH3SSRHandler,
+  DEFAULT_SSR_CACHE_CONTROL,
+} from "@agent-native/core/server/ssr-handler";
 import { buildMarkdownResponseHeaders } from "../../../core/src/agent-web/index";
 import fs from "fs";
 import path from "path";
@@ -22,6 +25,7 @@ export default async function docsPageHandler(event: H3Event) {
   const agentWebAsset = readAgentWebAssetForRequest(event);
   if (agentWebAsset) {
     setHeader(event, "content-type", agentWebAsset.contentType);
+    setHeader(event, "cache-control", DEFAULT_SSR_CACHE_CONTROL);
     setHeader(event, "link", `<${SITE_URL}/llms.txt>; rel="llms-txt"`);
     return agentWebAsset.content;
   }
@@ -38,6 +42,7 @@ export default async function docsPageHandler(event: H3Event) {
     )) {
       setHeader(event, name, value);
     }
+    setHeader(event, "cache-control", DEFAULT_SSR_CACHE_CONTROL);
     return markdown.content;
   }
 

--- a/packages/docs/server/routes/[...page].head.ts
+++ b/packages/docs/server/routes/[...page].head.ts
@@ -1,4 +1,7 @@
-import { createH3SSRHandler } from "@agent-native/core/server/ssr-handler";
+import {
+  createH3SSRHandler,
+  DEFAULT_SSR_CACHE_CONTROL,
+} from "@agent-native/core/server/ssr-handler";
 import { estimateMarkdownTokens } from "../../../core/src/agent-web/index";
 import fs from "fs";
 import path from "path";
@@ -21,6 +24,7 @@ export default async function docsHeadHandler(event: H3Event) {
       "content-length",
       String(Buffer.byteLength(asset.content)),
     );
+    setHeader(event, "cache-control", DEFAULT_SSR_CACHE_CONTROL);
     setHeader(event, "link", `<${SITE_URL}/llms.txt>; rel="llms-txt"`);
     if (asset.contentType.startsWith("text/markdown")) {
       setHeader(

--- a/packages/docs/tests/auth.spec.ts
+++ b/packages/docs/tests/auth.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { shouldCreateDocsSessionForPath } from "./auth.js";
+import { shouldCreateDocsSessionForPath } from "../server/plugins/auth.js";
 
 describe("docs auth session scoping", () => {
   it("creates anonymous sessions for framework and API routes under a mount path", () => {

--- a/templates/analytics/actions/get-analysis.ts
+++ b/templates/analytics/actions/get-analysis.ts
@@ -7,12 +7,6 @@ import {
 import { z } from "zod";
 import { getAnalysis } from "../server/lib/dashboards-store";
 
-const MCP_APP_FRAME_DOMAINS = [
-  "https:",
-  "http://localhost:*",
-  "http://127.0.0.1:*",
-];
-
 export default defineAction({
   description: "Get a saved ad-hoc analysis by ID, including its full results.",
   schema: z.object({
@@ -27,7 +21,6 @@ export default defineAction({
       description: "Open the saved analysis in the real Analytics UI.",
       iframeTitle: "Agent-Native Analytics",
       openLabel: "Open analysis",
-      frameDomains: MCP_APP_FRAME_DOMAINS,
       height: 680,
     }),
   },

--- a/templates/analytics/actions/open-traffic-dashboard.ts
+++ b/templates/analytics/actions/open-traffic-dashboard.ts
@@ -4,11 +4,6 @@ import { z } from "zod";
 
 const TRAFFIC_DASHBOARD_PATH = "/adhoc/agent-native-templates-first-party";
 const TRAFFIC_DASHBOARD_ID = "agent-native-templates-first-party";
-const MCP_APP_FRAME_DOMAINS = [
-  "https:",
-  "http://localhost:*",
-  "http://127.0.0.1:*",
-];
 
 function trafficDashboardDeepLink(): string {
   return buildDeepLink({
@@ -33,7 +28,6 @@ export default defineAction({
         "Open the first-party traffic dashboard in the real Analytics app.",
       iframeTitle: "Agent-Native Analytics",
       openLabel: "Open traffic dashboard",
-      frameDomains: MCP_APP_FRAME_DOMAINS,
       height: 900,
     }),
   },

--- a/templates/analytics/actions/save-analysis.ts
+++ b/templates/analytics/actions/save-analysis.ts
@@ -13,12 +13,6 @@ import { z } from "zod";
 import { upsertAnalysis } from "../server/lib/dashboards-store";
 import { hasDataQueryAttempt } from "../server/lib/real-data-actions";
 
-const MCP_APP_FRAME_DOMAINS = [
-  "https:",
-  "http://localhost:*",
-  "http://127.0.0.1:*",
-];
-
 function parseJsonArg(value: unknown, label: string): unknown {
   if (typeof value !== "string") return value;
   try {
@@ -116,7 +110,6 @@ export default defineAction({
       description: "Open the saved analysis in the real Analytics UI.",
       iframeTitle: "Agent-Native Analytics",
       openLabel: "Open analysis",
-      frameDomains: MCP_APP_FRAME_DOMAINS,
       height: 680,
     }),
   },

--- a/templates/analytics/actions/update-dashboard.ts
+++ b/templates/analytics/actions/update-dashboard.ts
@@ -15,12 +15,6 @@ import {
   seedFromText,
 } from "@agent-native/core/collab";
 
-const MCP_APP_FRAME_DOMAINS = [
-  "https:",
-  "http://localhost:*",
-  "http://127.0.0.1:*",
-];
-
 /**
  * Same shape as the server-side validator in `server/handlers/sql-dashboards.ts`.
  * Variables declared on the dashboard take priority; filter `default` values
@@ -449,7 +443,6 @@ export default defineAction({
       description: "Open the updated dashboard in the real Analytics UI.",
       iframeTitle: "Agent-Native Analytics",
       openLabel: "Open dashboard",
-      frameDomains: MCP_APP_FRAME_DOMAINS,
       height: 680,
     }),
   },

--- a/templates/calendar/actions/manage-event-draft.ts
+++ b/templates/calendar/actions/manage-event-draft.ts
@@ -187,7 +187,6 @@ export default defineAction({
         "Open the draft in the real Calendar event editor so the user can review attendees, time, location, conferencing, and reminders.",
       iframeTitle: "Agent-Native Calendar",
       openLabel: "Open in Calendar",
-      frameDomains: ["https:", "http://localhost:*", "http://127.0.0.1:*"],
       height: 900,
     }),
   },

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -14,7 +14,7 @@ import {
 } from "date-fns";
 import { cn } from "@/lib/utils";
 import { shouldSuppressAfterPopoverClose } from "@/lib/popover-click-guard";
-import { RsvpStatusIcon } from "@/lib/rsvp-status";
+import { EventStatusIcon } from "@/lib/rsvp-status";
 import { getEventDisplayColor, allOtherDeclined } from "@/lib/event-colors";
 import { IconAlertTriangleFilled } from "@tabler/icons-react";
 import { EventDetailPopover } from "./EventDetailPopover";
@@ -281,10 +281,7 @@ export function DayView({
                         className="shrink-0 text-current opacity-70"
                       />
                     )}
-                    <RsvpStatusIcon
-                      status={event.responseStatus}
-                      className="shrink-0"
-                    />
+                    <EventStatusIcon event={event} className="shrink-0" />
                     <span className="truncate">{event.title}</span>
                   </button>
                 </EventDetailPopover>
@@ -494,8 +491,8 @@ export function DayView({
                           className="shrink-0 text-current opacity-70 relative top-[1px]"
                         />
                       )}
-                      <RsvpStatusIcon
-                        status={event.responseStatus}
+                      <EventStatusIcon
+                        event={event}
                         className="relative top-[1px] shrink-0"
                       />
                       <span
@@ -510,21 +507,6 @@ export function DayView({
                       >
                         {event.title}
                       </span>
-                      {isStart && (
-                        <span
-                          className={cn(
-                            "shrink-0 text-[11px] leading-tight",
-                            isPast || isDeclined
-                              ? "text-muted-foreground/50"
-                              : "text-foreground/60",
-                          )}
-                        >
-                          {format(
-                            displayStart,
-                            displayStart.getMinutes() === 0 ? "h a" : "h:mm a",
-                          )}
-                        </span>
-                      )}
                     </div>
                   ) : (
                     <>
@@ -544,10 +526,7 @@ export function DayView({
                             className="shrink-0 text-current opacity-70"
                           />
                         )}
-                        <RsvpStatusIcon
-                          status={event.responseStatus}
-                          className="shrink-0"
-                        />
+                        <EventStatusIcon event={event} className="shrink-0" />
                         <span className="truncate">{event.title}</span>
                       </div>
                       {isStart && (

--- a/templates/calendar/app/components/calendar/EventCard.tsx
+++ b/templates/calendar/app/components/calendar/EventCard.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import { RsvpStatusIcon } from "@/lib/rsvp-status";
+import { EventStatusIcon } from "@/lib/rsvp-status";
 import {
   getEventDisplayColor,
   allOtherDeclined,
@@ -66,7 +66,7 @@ export function EventCard({
             style={{ backgroundColor: accentColor }}
           />
         )}
-        <RsvpStatusIcon status={event.responseStatus} />
+        <EventStatusIcon event={event} />
         <span className="truncate font-medium">{event.title}</span>
       </button>
     );
@@ -95,7 +95,7 @@ export function EventCard({
             className="shrink-0 text-current opacity-70"
           />
         )}
-        <RsvpStatusIcon status={event.responseStatus} />
+        <EventStatusIcon event={event} />
         <span className="truncate font-medium">{event.title}</span>
       </div>
       {!event.allDay && (

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -17,7 +17,7 @@ import {
 } from "date-fns";
 import { cn } from "@/lib/utils";
 import { shouldSuppressAfterPopoverClose } from "@/lib/popover-click-guard";
-import { RsvpStatusIcon } from "@/lib/rsvp-status";
+import { EventStatusIcon } from "@/lib/rsvp-status";
 import { getEventDisplayColor, allOtherDeclined } from "@/lib/event-colors";
 import { IconAlertTriangleFilled } from "@tabler/icons-react";
 import { EventDetailPopover } from "./EventDetailPopover";
@@ -611,10 +611,7 @@ export function WeekView({
                           className="shrink-0 text-current opacity-70"
                         />
                       )}
-                      <RsvpStatusIcon
-                        status={event.responseStatus}
-                        className="shrink-0"
-                      />
+                      <EventStatusIcon event={event} className="shrink-0" />
                       <span className="truncate">{event.title}</span>
                     </button>
                   </EventDetailPopover>
@@ -894,8 +891,8 @@ export function WeekView({
                                 className="shrink-0 text-current opacity-70 relative top-[1px]"
                               />
                             )}
-                            <RsvpStatusIcon
-                              status={event.responseStatus}
+                            <EventStatusIcon
+                              event={event}
                               className="relative top-[1px] shrink-0"
                             />
                             <span
@@ -910,23 +907,6 @@ export function WeekView({
                             >
                               {event.title}
                             </span>
-                            {isStart && (
-                              <span
-                                className={cn(
-                                  "shrink-0 text-[10px] leading-tight",
-                                  isPast || isDeclined
-                                    ? "text-muted-foreground/50"
-                                    : "text-foreground/60",
-                                )}
-                              >
-                                {format(
-                                  displayStart,
-                                  displayStart.getMinutes() === 0
-                                    ? "h a"
-                                    : "h:mm a",
-                                )}
-                              </span>
-                            )}
                           </div>
                         ) : (
                           <>
@@ -946,8 +926,8 @@ export function WeekView({
                                   className="shrink-0 text-current opacity-70"
                                 />
                               )}
-                              <RsvpStatusIcon
-                                status={event.responseStatus}
+                              <EventStatusIcon
+                                event={event}
                                 className="shrink-0"
                               />
                               <span className="truncate">{event.title}</span>

--- a/templates/calendar/app/lib/rsvp-status.tsx
+++ b/templates/calendar/app/lib/rsvp-status.tsx
@@ -1,7 +1,16 @@
-import { IconCheck, IconCircleX, IconHelpCircle } from "@tabler/icons-react";
+import {
+  IconCheck,
+  IconCircleX,
+  IconClock,
+  IconHelpCircle,
+} from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
+import type { CalendarEvent } from "@shared/api";
 
 export type RsvpStatus = "accepted" | "declined" | "tentative" | "needsAction";
+
+const TIME_PROPOSAL_COMMENT_RE =
+  /\b(propos(?:e|ed|ing)|new time|different time|another time|reschedul|move (?:it|this)|can we (?:do|move)|could we (?:do|move))\b/i;
 
 export function getRsvpStatusLabel(status?: string) {
   switch (status) {
@@ -54,4 +63,51 @@ export function RsvpStatusIcon({
       aria-label={`RSVP: ${label}`}
     />
   );
+}
+
+export function hasTimeProposal(event: CalendarEvent): boolean {
+  const attendees = event.attendees ?? [];
+  const otherAttendees = attendees.filter((attendee) => !attendee.self);
+
+  if (
+    otherAttendees.some((attendee) => {
+      const comment = attendee.comment?.trim();
+      return !!comment && TIME_PROPOSAL_COMMENT_RE.test(comment);
+    })
+  ) {
+    return true;
+  }
+
+  const userIsOrganizer = Boolean(
+    event.organizer?.self ||
+    attendees.some((attendee) => attendee.self && attendee.organizer),
+  );
+
+  return (
+    userIsOrganizer &&
+    otherAttendees.some((attendee) => attendee.responseStatus === "tentative")
+  );
+}
+
+export function EventStatusIcon({
+  event,
+  className,
+}: {
+  event: CalendarEvent;
+  className?: string;
+}) {
+  const iconClassName = cn("h-3 w-3", className);
+
+  if (hasTimeProposal(event)) {
+    return (
+      <IconClock
+        className={cn(iconClassName, "text-yellow-500")}
+        aria-label="Time change proposed"
+      />
+    );
+  }
+
+  if (event.responseStatus === "accepted") return null;
+
+  return <RsvpStatusIcon status={event.responseStatus} className={className} />;
 }

--- a/templates/clips/actions/get-recording-player-data.ts
+++ b/templates/clips/actions/get-recording-player-data.ts
@@ -30,12 +30,6 @@ import {
   parseTranscriptSegments,
 } from "../shared/transcript-segments.js";
 
-const MCP_APP_FRAME_DOMAINS = [
-  "https:",
-  "http://localhost:*",
-  "http://127.0.0.1:*",
-];
-
 function recordingDeepLink(recordingId: string): string {
   return buildDeepLink({
     app: "clips",
@@ -57,7 +51,6 @@ export default defineAction({
       description: "Open this recording in the real Clips player.",
       iframeTitle: "Agent-Native Clips",
       openLabel: "Open clip",
-      frameDomains: MCP_APP_FRAME_DOMAINS,
       height: 680,
     }),
   },

--- a/templates/clips/actions/search-recordings.ts
+++ b/templates/clips/actions/search-recordings.ts
@@ -6,11 +6,6 @@ import { getDb, schema } from "../server/db/index.js";
 import { accessFilter } from "@agent-native/core/sharing";
 
 const SNIPPET_RADIUS = 80;
-const MCP_APP_FRAME_DOMAINS = [
-  "https:",
-  "http://localhost:*",
-  "http://127.0.0.1:*",
-];
 
 type RecordingMatchPanel = "transcript" | "comments" | null;
 
@@ -110,7 +105,6 @@ export default defineAction({
       description: "Open the best matching recording in the real Clips player.",
       iframeTitle: "Agent-Native Clips",
       openLabel: "Open clip",
-      frameDomains: MCP_APP_FRAME_DOMAINS,
       height: 680,
     }),
   },

--- a/templates/content/actions/create-document.ts
+++ b/templates/content/actions/create-document.ts
@@ -42,7 +42,6 @@ export default defineAction({
         "Open the generated draft in the real Content editor so the user can revise, format, organize, and publish it.",
       iframeTitle: "Agent-Native Content",
       openLabel: "Open in Content",
-      frameDomains: ["https:", "http://localhost:*", "http://127.0.0.1:*"],
       height: 900,
     }),
   },

--- a/templates/design/actions/create-design.ts
+++ b/templates/design/actions/create-design.ts
@@ -9,12 +9,6 @@ import {
 } from "@agent-native/core/server/request-context";
 import { assertAccess } from "@agent-native/core/sharing";
 
-const MCP_APP_FRAME_DOMAINS = [
-  "https:",
-  "http://localhost:*",
-  "http://127.0.0.1:*",
-];
-
 /** Editor deep link so external agents can surface "Open design". */
 function designDeepLink(designId: string): string {
   return buildDeepLink({
@@ -56,7 +50,6 @@ export default defineAction({
       description: "Open the new design project in the real Design editor.",
       iframeTitle: "Agent-Native Design",
       openLabel: "Open design",
-      frameDomains: MCP_APP_FRAME_DOMAINS,
       height: 680,
     }),
   },

--- a/templates/design/actions/generate-design.ts
+++ b/templates/design/actions/generate-design.ts
@@ -11,12 +11,6 @@ import {
   seedFromText,
 } from "@agent-native/core/collab";
 
-const MCP_APP_FRAME_DOMAINS = [
-  "https:",
-  "http://localhost:*",
-  "http://127.0.0.1:*",
-];
-
 /** Editor deep link so external agents can surface "Open design". */
 function designDeepLink(designId: string): string {
   return buildDeepLink({
@@ -110,7 +104,6 @@ export default defineAction({
       description: "Open the generated design in the real Design editor.",
       iframeTitle: "Agent-Native Design",
       openLabel: "Open design",
-      frameDomains: MCP_APP_FRAME_DOMAINS,
       height: 680,
     }),
   },

--- a/templates/design/actions/get-design-snapshot.ts
+++ b/templates/design/actions/get-design-snapshot.ts
@@ -6,12 +6,6 @@ import { schema } from "../server/db/index.js";
 import { buildDesignSnapshot } from "../server/lib/design-snapshot.js";
 import "../server/db/index.js"; // ensure registerShareableResource runs
 
-const MCP_APP_FRAME_DOMAINS = [
-  "https:",
-  "http://localhost:*",
-  "http://127.0.0.1:*",
-];
-
 /** Editor deep link so external agents can surface "Open design". */
 function designDeepLink(designId: string): string {
   return buildDeepLink({
@@ -41,7 +35,6 @@ export default defineAction({
       description: "Open the current design in the real Design editor.",
       iframeTitle: "Agent-Native Design",
       openLabel: "Open design",
-      frameDomains: MCP_APP_FRAME_DOMAINS,
       height: 680,
     }),
   },

--- a/templates/forms/actions/create-form.ts
+++ b/templates/forms/actions/create-form.ts
@@ -61,7 +61,6 @@ export default defineAction({
         "Open the generated form in the real Forms editor so the user can edit fields, settings, publishing, and integrations.",
       iframeTitle: "Agent-Native Forms",
       openLabel: "Open in Forms",
-      frameDomains: ["https:", "http://localhost:*", "http://127.0.0.1:*"],
       height: 900,
     }),
   },

--- a/templates/forms/server/lib/public-form-ssr.ts
+++ b/templates/forms/server/lib/public-form-ssr.ts
@@ -1,6 +1,7 @@
 import { getMethod, getRequestURL, type H3Event } from "h3";
 import { eq } from "drizzle-orm";
 import { getAppBasePath } from "@agent-native/core/server";
+import { DEFAULT_SSR_CACHE_CONTROL } from "@agent-native/core/server/ssr-handler";
 import { getDb, schema } from "../db/index.js";
 import type { FormField, FormSettings } from "../../shared/types.js";
 
@@ -244,8 +245,7 @@ export async function renderPublicForm(event: H3Event) {
     "Content-Security-Policy": "frame-ancestors *",
   };
   if (status === 200) {
-    headers["Cache-Control"] =
-      "public, s-maxage=60, stale-while-revalidate=300";
+    headers["Cache-Control"] = DEFAULT_SSR_CACHE_CONTROL;
   }
   return new Response(getMethod(event) === "HEAD" ? null : html, {
     status,

--- a/templates/mail/actions/manage-draft.ts
+++ b/templates/mail/actions/manage-draft.ts
@@ -116,7 +116,6 @@ export default defineAction({
         "Open the generated draft in the real Mail compose UI with contact autocomplete, aliases, formatting, attachments, and sending controls.",
       iframeTitle: "Agent-Native Mail",
       openLabel: "Open in Mail",
-      frameDomains: ["https:", "http://localhost:*", "http://127.0.0.1:*"],
       height: 900,
     }),
   },

--- a/templates/slides/actions/add-slide.ts
+++ b/templates/slides/actions/add-slide.ts
@@ -24,12 +24,6 @@ function deckDeepLink(deckId: string): string {
   });
 }
 
-const MCP_APP_FRAME_DOMAINS = [
-  "https:",
-  "http://localhost:*",
-  "http://127.0.0.1:*",
-];
-
 // In-process serialization per deckId. `add-slide` is intentionally advertised
 // as a sequential write, but the lock still protects against accidental
 // concurrent calls and any direct integrations that bypass agent guidance.
@@ -93,7 +87,6 @@ export default defineAction({
       description: "Open the updated deck in the real Slides editor.",
       iframeTitle: "Agent-Native Slides",
       openLabel: "Open deck",
-      frameDomains: MCP_APP_FRAME_DOMAINS,
       height: 680,
     }),
   },

--- a/templates/slides/actions/create-deck.ts
+++ b/templates/slides/actions/create-deck.ts
@@ -15,12 +15,6 @@ import { getDeckUrl } from "./_app-url.js";
 import { normalizeSlidePadding } from "../app/lib/normalize-slide-padding.js";
 import { createDeckVersionSnapshot } from "../server/lib/deck-versions.js";
 
-const MCP_APP_FRAME_DOMAINS = [
-  "https:",
-  "http://localhost:*",
-  "http://127.0.0.1:*",
-];
-
 const SlideSchema = z.object({
   id: z.string().describe("Unique slide ID, e.g. 'slide-1'"),
   content: z.string().describe("Full HTML content of the slide"),
@@ -89,7 +83,6 @@ export default defineAction({
       description: "Open the generated deck in the real Slides editor.",
       iframeTitle: "Agent-Native Slides",
       openLabel: "Open deck",
-      frameDomains: MCP_APP_FRAME_DOMAINS,
       height: 680,
     }),
   },

--- a/templates/slides/actions/get-deck.ts
+++ b/templates/slides/actions/get-deck.ts
@@ -4,12 +4,6 @@ import { resolveAccess } from "@agent-native/core/sharing";
 import { z } from "zod";
 import "../server/db/index.js"; // ensure registerShareableResource runs
 
-const MCP_APP_FRAME_DOMAINS = [
-  "https:",
-  "http://localhost:*",
-  "http://127.0.0.1:*",
-];
-
 function stripHtml(html: string): string {
   return html
     .replace(/<br\s*\/?>/gi, "\n")
@@ -45,7 +39,6 @@ export default defineAction({
       description: "Open the deck in the real Slides editor.",
       iframeTitle: "Agent-Native Slides",
       openLabel: "Open deck",
-      frameDomains: MCP_APP_FRAME_DOMAINS,
       height: 680,
     }),
   },


### PR DESCRIPTION
## Summary
- improve MCP app embed handling for Claude-hosted content with route transplanting, CORS/static asset headers, and safer nested-frame defaults
- remove first-party action frameDomains now that full-app embeds use the single-frame route path by default
- default Agent-Native SSR HTML to public caching with max-age=5, stale-while-revalidate=604800, stale-if-error=3600, and avoid docs session cookies on public page hits

## Tests
- pnpm --filter @agent-native/core test
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/docs typecheck
- pnpm --filter forms typecheck
- git diff --check