### PR TITLE
Fix Claude MCP app route embeds

### DIFF
--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -301,16 +301,13 @@ older hosts, and any host that does not render MCP Apps will ignore the UI
 metadata and still need the "Open in … →" link. `embedApp()` uses that link as
 its launch target, calls the app-only `create_embed_session` helper, exchanges
 a one-time SQL ticket at `/_agent-native/embed/start`, then launches the real
-app route with a short-lived browser session. ChatGPT uses a controlled route
-iframe to avoid web-sandbox auto-height feedback loops. Standard hosts that can
-hydrate the route directly navigate the MCP App frame itself. Claude web
-currently proxies MCP App content through `claudemcpcontent.com`; direct route
-navigation can fetch app HTML there without reliably running the framework
-bootstrap, and a second nested iframe is easy for the host to block. For
-Claude, `embedApp()` fetches the signed route HTML and mounts the real app
-document into the existing MCP resource frame, with app-origin requests routed
-back to the app using the embed token. You can force the nested diagnostic
-iframe with `embedMode: "iframe"` /
+app route with a short-lived browser session. ChatGPT and Claude web use a
+controlled route iframe to avoid web-sandbox auto-height feedback loops and
+proxied-origin module loading. Standard hosts that can hydrate the route
+directly navigate the MCP App frame itself. You can force the single-frame
+transplant diagnostic path with `embedMode: "transplant"` or
+`frame: "transplant"` when debugging host module loading, or force the nested
+diagnostic iframe with `embedMode: "iframe"` /
 `renderMode: "iframe"` / `nested: true` when debugging host behavior. Pass
 additional `frameDomains` only for a custom MCP App that truly embeds a
 third-party frame. `open_app({ app, path, embed: true })` is the generic
@@ -449,8 +446,8 @@ connect or present a token rather than assuming the action is missing.
 - Don't replace deep links with MCP Apps; non-UI clients still need the link.
 - Don't hand-write product UI in `mcpApp.resource.html`; use a real React
   route/component and embed it with `embedApp()`.
-- Don't use nested iframes for Claude web as the normal route; use the
-  single-frame mounted route path and reserve nested iframes for diagnostics.
+- Don't use the single-frame transplant path as the normal Claude route; it is
+  a diagnostic escape hatch for host module-loading investigations.
 - Don't scope the `navigate` write to the agent token, or pass privileged
   state through the deep link — it's a pure pointer.
 - Don't invent a new navigation mechanism; bridge to the existing

--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -301,11 +301,13 @@ older hosts, and any host that does not render MCP Apps will ignore the UI
 metadata and still need the "Open in … →" link. `embedApp()` uses that link as
 its launch target, calls the app-only `create_embed_session` helper, exchanges
 a one-time SQL ticket at `/_agent-native/embed/start`, then launches the real
-app route with a short-lived browser session. ChatGPT and Claude web use a
-controlled route iframe to avoid web-sandbox auto-height feedback loops and
-proxied-origin module loading. Standard hosts that can hydrate the route
-directly navigate the MCP App frame itself. You can force the single-frame
-transplant diagnostic path with `embedMode: "transplant"` or
+app route with a short-lived browser session. Standard hosts navigate the MCP
+App frame directly. Claude web uses a single-frame transplant path that fetches
+the signed app HTML and hydrates it inside Claude's MCP App iframe because
+Claude does not reliably allow app-owned child iframes or external frame
+navigation. ChatGPT web uses a controlled route iframe for stable
+`window.openai` host APIs and bounded height control. You can force the
+single-frame transplant path in other hosts with `embedMode: "transplant"` or
 `frame: "transplant"` when debugging host module loading, or force the nested
 diagnostic iframe with `embedMode: "iframe"` /
 `renderMode: "iframe"` / `nested: true` when debugging host behavior. Pass
@@ -321,6 +323,12 @@ for full-app route embeds; Claude and ChatGPT can otherwise measure the whole
 document and create a huge chat iframe. After changing the shell or `ui://`
 resource version, verify with a fresh tool call because old conversation frames
 keep the behavior they were rendered with.
+
+When testing Claude through ngrok, use a production build (`agent-native build`
+then `agent-native start`) or a deployed preview/production URL. Claude's
+transplant path works with production asset chunks; raw Vite dev modules such
+as `/app/root.tsx` can be app-auth protected and fail dynamic imports from the
+Claude resource origin.
 
 For known first-party handoffs, prefer a direct action with `mcpApp` over
 letting the model hunt through screens. Examples: Mail `manage-draft` for email
@@ -446,8 +454,8 @@ connect or present a token rather than assuming the action is missing.
 - Don't replace deep links with MCP Apps; non-UI clients still need the link.
 - Don't hand-write product UI in `mcpApp.resource.html`; use a real React
   route/component and embed it with `embedApp()`.
-- Don't use the single-frame transplant path as the normal Claude route; it is
-  a diagnostic escape hatch for host module-loading investigations.
+- Don't test Claude full-app embeds against raw Vite dev modules and conclude
+  production is broken; use `agent-native start`, a preview deploy, or prod.
 - Don't scope the `navigate` write to the agent token, or pass privileged
   state through the deep link — it's a pure pointer.
 - Don't invent a new navigation mechanism; bridge to the existing

--- a/.changeset/controlled-claude-embeds.md
+++ b/.changeset/controlled-claude-embeds.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Use a controlled route iframe for Claude MCP App embeds and keep the single-frame transplant path diagnostic-only.
+Use Claude single-frame transplant rendering and ChatGPT controlled route frames for MCP App embeds.

--- a/.changeset/controlled-claude-embeds.md
+++ b/.changeset/controlled-claude-embeds.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Use a controlled route iframe for Claude MCP App embeds and keep the single-frame transplant path diagnostic-only.

--- a/packages/core/docs/content/actions.md
+++ b/packages/core/docs/content/actions.md
@@ -199,14 +199,18 @@ export default defineAction({
 This advertises the MCP Apps extension (`io.modelcontextprotocol/ui`), exposes the HTML via MCP resources/templates, and includes standard MCP Apps plus ChatGPT Apps SDK widget metadata for compatible hosts. Keep `link` as the fallback for CLI and non-UI MCP clients; see [External Agents](/docs/external-agents#mcp-apps).
 
 The helper launches the action's `link` target through `/_agent-native/embed/start` with a short-lived browser session, so routes such as full dashboards, filtered inboxes, drafts, and extension pages can reuse the app's React components directly.
-ChatGPT and Claude web use a controlled route iframe to avoid web-sandbox
-auto-height feedback loops and proxied-origin module loading.
+Standard hosts navigate the MCP App frame directly to that signed route.
+Claude web uses a single-frame transplant path that hydrates the signed app
+HTML inside Claude's MCP App iframe because Claude does not reliably allow
+app-owned child iframes or external frame navigation. ChatGPT web uses a
+controlled route iframe for stable `window.openai` host APIs and bounded height
+control.
 
 Embedded routes can use the exported client helpers for the MCP App host
-bridge. Direct route embeds post standard `ui/*` JSON-RPC
-messages to the host, while the ChatGPT/Claude controlled-frame path and
-explicit diagnostic iframe path proxy `agentNative.mcpHost.*` messages through
-the launch wrapper.
+bridge. Direct route embeds and Claude's transplanted route post standard
+`ui/*` JSON-RPC messages to the host, while the ChatGPT controlled-frame path
+and explicit diagnostic iframe path proxy `agentNative.mcpHost.*` messages
+through the launch wrapper.
 When a submitted app prompt should continue the host chat, call
 `sendToAgentChat()` from the embedded route; it sends hidden model context and
 then posts a visible user message through the host bridge where supported.

--- a/packages/core/docs/content/actions.md
+++ b/packages/core/docs/content/actions.md
@@ -199,16 +199,13 @@ export default defineAction({
 This advertises the MCP Apps extension (`io.modelcontextprotocol/ui`), exposes the HTML via MCP resources/templates, and includes standard MCP Apps plus ChatGPT Apps SDK widget metadata for compatible hosts. Keep `link` as the fallback for CLI and non-UI MCP clients; see [External Agents](/docs/external-agents#mcp-apps).
 
 The helper launches the action's `link` target through `/_agent-native/embed/start` with a short-lived browser session, so routes such as full dashboards, filtered inboxes, drafts, and extension pages can reuse the app's React components directly.
-ChatGPT uses a controlled route iframe to avoid web-sandbox auto-height
-feedback loops. Claude web uses a single-frame mount path automatically: the
-launcher fetches the signed route HTML inside Claude's MCP resource frame,
-mounts the real app document there, and rewrites app-origin network calls back
-to the original app with the embed token.
+ChatGPT and Claude web use a controlled route iframe to avoid web-sandbox
+auto-height feedback loops and proxied-origin module loading.
 
 Embedded routes can use the exported client helpers for the MCP App host
-bridge. Direct and Claude-mounted route embeds post standard `ui/*` JSON-RPC
-messages to the host, while the ChatGPT controlled-frame path and explicit
-nested-iframe diagnostic path proxy `agentNative.mcpHost.*` messages through
+bridge. Direct route embeds post standard `ui/*` JSON-RPC
+messages to the host, while the ChatGPT/Claude controlled-frame path and
+explicit diagnostic iframe path proxy `agentNative.mcpHost.*` messages through
 the launch wrapper.
 When a submitted app prompt should continue the host chat, call
 `sendToAgentChat()` from the embedded route; it sends hidden model context and

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -220,25 +220,21 @@ Claude Code and other CLI-first clients still receive the same resources and met
 MCP App embeds are route embeds, not separate mini-products. `embedApp()`
 starts from the action's `link` target, creates a short-lived embed session,
 and launches that signed app route. Standard MCP Apps hosts can navigate the
-MCP App frame itself. ChatGPT gets a controlled route iframe because its web
-sandbox can otherwise auto-size a full app route into a feedback loop. Claude
-web currently proxies MCP App content through `claudemcpcontent.com`; direct
-route navigation can fetch the app HTML there without reliably running the
-framework bootstrap, and a second nested iframe is easy for the host to block.
-For Claude, the launcher fetches the signed app HTML and mounts that document
-into the existing MCP resource frame, then rewrites app-origin
-fetch/XHR/EventSource calls back to the app with the embed token. The app still
-renders the normal route and React components. Design embedded routes so a
-reload with the same signed URL reconstructs the same view.
+MCP App frame itself when the host can hydrate the route directly. ChatGPT and
+Claude web get a controlled route iframe because their web sandboxes can
+otherwise auto-size a full app route into a feedback loop or run app modules
+from a proxied origin. The iframe points at the same signed app route and the
+app still renders the normal route and React components. Design embedded
+routes so a reload with the same signed URL reconstructs the same view.
 
 ChatGPT gets a dedicated compatibility path through `window.openai`: the launch
 document reads `toolInput`, `toolOutput`, and `toolResponseMetadata` directly,
 then calls `create_embed_session` via `window.openai.callTool(...)`. Standard
-MCP Apps hosts use the `ui/*` JSON-RPC bridge. Direct and Claude-mounted routes
-can call `ui/update-model-context`, `ui/message`, `ui/open-link`, and
-`ui/request-display-mode` through the host bridge helpers. When the ChatGPT or
-explicit diagnostic iframe path is used, the wrapper relays the same host
-actions over `agentNative.mcpHost.*` postMessage requests. Keep the result
+MCP Apps hosts use the `ui/*` JSON-RPC bridge. Directly hydrated routes can
+call `ui/update-model-context`, `ui/message`, `ui/open-link`, and
+`ui/request-display-mode` through the host bridge helpers. When the ChatGPT,
+Claude, or explicit diagnostic iframe path is used, the wrapper relays the
+same host actions over `agentNative.mcpHost.*` postMessage requests. Keep the result
 shape identical for both paths: return a focused `link` and concise structured
 content.
 
@@ -250,24 +246,26 @@ new MCP App resources and new tool calls. Old ChatGPT/Claude conversation
 frames can keep the previous resource behavior, so verify sizing with a fresh
 inline render before judging a fix.
 
-You can force the nested diagnostic iframe with `embedMode: "iframe"`,
-`renderMode: "iframe"`, `nested: true`, or `frame: "iframe"` when debugging
-host behavior. If the iframe is blocked, `embedApp()` replaces it with an
+You can force the single-frame transplant diagnostic path with
+`embedMode: "transplant"` or `frame: "transplant"` when debugging host
+module-loading behavior. You can also force the nested diagnostic iframe with
+`embedMode: "iframe"`, `renderMode: "iframe"`, `nested: true`, or
+`frame: "iframe"`. If the iframe is blocked, `embedApp()` replaces it with an
 open-app fallback: the user can retry inline, open a freshly minted embed
 session through the host, or use the visible route URL. Keep the action's
 `link` target useful on its own because it is still the universal escape hatch.
 
 The host bridge is deliberately small:
 
-| Mode                     | Message type                          | Use it for                               |
-| ------------------------ | ------------------------------------- | ---------------------------------------- |
-| direct / Claude          | `ui/update-model-context`             | Hidden context for the host model        |
-| direct / Claude          | `ui/message`                          | Post a visible user turn into the host   |
-| direct / Claude          | `ui/open-link`                        | Open an external or app URL via the host |
-| direct / Claude          | `ui/request-display-mode`             | Request `inline`, `fullscreen`, or `pip` |
-| ChatGPT / iframe wrapper | `agentNative.mcpHostContext`          | Theme, locale, host platform, dimensions |
-| ChatGPT / iframe wrapper | `agentNative.embeddedAppReady`        | Confirm the route iframe loaded          |
-| ChatGPT / iframe wrapper | `agentNative.mcpHost.*` / `.response` | Wrapper relay for host requests          |
+| Mode                          | Message type                          | Use it for                               |
+| ----------------------------- | ------------------------------------- | ---------------------------------------- |
+| direct host route             | `ui/update-model-context`             | Hidden context for the host model        |
+| direct host route             | `ui/message`                          | Post a visible user turn into the host   |
+| direct host route             | `ui/open-link`                        | Open an external or app URL via the host |
+| direct host route             | `ui/request-display-mode`             | Request `inline`, `fullscreen`, or `pip` |
+| ChatGPT / Claude iframe route | `agentNative.mcpHostContext`          | Theme, locale, host platform, dimensions |
+| ChatGPT / Claude iframe route | `agentNative.embeddedAppReady`        | Confirm the route iframe loaded          |
+| ChatGPT / Claude iframe route | `agentNative.mcpHost.*` / `.response` | Wrapper relay for host requests          |
 
 Embedded routes can use `updateMcpAppModelContext()`,
 `openMcpAppHostLink()`, `requestMcpAppDisplayMode()`,

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -220,23 +220,27 @@ Claude Code and other CLI-first clients still receive the same resources and met
 MCP App embeds are route embeds, not separate mini-products. `embedApp()`
 starts from the action's `link` target, creates a short-lived embed session,
 and launches that signed app route. Standard MCP Apps hosts can navigate the
-MCP App frame itself when the host can hydrate the route directly. ChatGPT and
-Claude web get a controlled route iframe because their web sandboxes can
-otherwise auto-size a full app route into a feedback loop or run app modules
-from a proxied origin. The iframe points at the same signed app route and the
-app still renders the normal route and React components. Design embedded
-routes so a reload with the same signed URL reconstructs the same view.
+MCP App frame itself when the host can hydrate the route directly. Claude web
+uses a single-frame transplant path: the resource document fetches the signed
+app HTML and hydrates it inside Claude's MCP App iframe because Claude does not
+reliably allow app-owned child iframes or external frame navigation. ChatGPT
+web gets a controlled route iframe because its Apps bridge gives us stable
+`window.openai` host APIs and bounded height control. All paths point at the
+same signed app route and render the normal route and React components. Design
+embedded routes so a reload with the same signed URL reconstructs the same
+view.
 
 ChatGPT gets a dedicated compatibility path through `window.openai`: the launch
 document reads `toolInput`, `toolOutput`, and `toolResponseMetadata` directly,
 then calls `create_embed_session` via `window.openai.callTool(...)`. Standard
 MCP Apps hosts use the `ui/*` JSON-RPC bridge. Directly hydrated routes can
 call `ui/update-model-context`, `ui/message`, `ui/open-link`, and
-`ui/request-display-mode` through the host bridge helpers. When the ChatGPT,
-Claude, or explicit diagnostic iframe path is used, the wrapper relays the
-same host actions over `agentNative.mcpHost.*` postMessage requests. Keep the result
-shape identical for both paths: return a focused `link` and concise structured
-content.
+`ui/request-display-mode` through the host bridge helpers. Claude's
+transplanted route uses the same direct `ui/*` host bridge after hydration.
+When the ChatGPT or explicit diagnostic iframe path is used, the wrapper
+relays the same host actions over `agentNative.mcpHost.*` postMessage
+requests. Keep the result shape identical for both paths: return a focused
+`link` and concise structured content.
 
 The resource shell owns the outer host size. Keep embedded app routes
 internally scrollable and let the launcher report a bounded intrinsic height
@@ -246,26 +250,33 @@ new MCP App resources and new tool calls. Old ChatGPT/Claude conversation
 frames can keep the previous resource behavior, so verify sizing with a fresh
 inline render before judging a fix.
 
-You can force the single-frame transplant diagnostic path with
-`embedMode: "transplant"` or `frame: "transplant"` when debugging host
-module-loading behavior. You can also force the nested diagnostic iframe with
+Claude uses the single-frame transplant path by default. You can also force it
+in other hosts with `embedMode: "transplant"` or `frame: "transplant"` when
+debugging host module-loading behavior. You can force the nested diagnostic iframe with
 `embedMode: "iframe"`, `renderMode: "iframe"`, `nested: true`, or
 `frame: "iframe"`. If the iframe is blocked, `embedApp()` replaces it with an
 open-app fallback: the user can retry inline, open a freshly minted embed
 session through the host, or use the visible route URL. Keep the action's
 `link` target useful on its own because it is still the universal escape hatch.
 
+When testing Claude through ngrok, use a production build (`agent-native build`
+then `agent-native start`) or a deployed preview/production URL. Claude's
+single-frame transplant path works with production asset chunks; raw Vite dev
+modules such as `/app/root.tsx` can be protected by app auth and fail dynamic
+imports from the Claude resource origin.
+
 The host bridge is deliberately small:
 
-| Mode                          | Message type                          | Use it for                               |
-| ----------------------------- | ------------------------------------- | ---------------------------------------- |
-| direct host route             | `ui/update-model-context`             | Hidden context for the host model        |
-| direct host route             | `ui/message`                          | Post a visible user turn into the host   |
-| direct host route             | `ui/open-link`                        | Open an external or app URL via the host |
-| direct host route             | `ui/request-display-mode`             | Request `inline`, `fullscreen`, or `pip` |
-| ChatGPT / Claude iframe route | `agentNative.mcpHostContext`          | Theme, locale, host platform, dimensions |
-| ChatGPT / Claude iframe route | `agentNative.embeddedAppReady`        | Confirm the route iframe loaded          |
-| ChatGPT / Claude iframe route | `agentNative.mcpHost.*` / `.response` | Wrapper relay for host requests          |
+| Mode                   | Message type                          | Use it for                               |
+| ---------------------- | ------------------------------------- | ---------------------------------------- |
+| direct host route      | `ui/update-model-context`             | Hidden context for the host model        |
+| direct host route      | `ui/message`                          | Post a visible user turn into the host   |
+| direct host route      | `ui/open-link`                        | Open an external or app URL via the host |
+| direct host route      | `ui/request-display-mode`             | Request `inline`, `fullscreen`, or `pip` |
+| Claude transplant      | `ui/*`                                | Same direct host bridge after hydration  |
+| ChatGPT / iframe route | `agentNative.mcpHostContext`          | Theme, locale, host platform, dimensions |
+| ChatGPT / iframe route | `agentNative.embeddedAppReady`        | Confirm the route iframe loaded          |
+| ChatGPT / iframe route | `agentNative.mcpHost.*` / `.response` | Wrapper relay for host requests          |
 
 Embedded routes can use `updateMcpAppModelContext()`,
 `openMcpAppHostLink()`, `requestMcpAppDisplayMode()`,

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -78,15 +78,10 @@ If an action declares `mcpApp`, the server also advertises the official MCP Apps
 
 `embedApp()` is the low-level URL-first MCP App helper. It reads the action
 result's open link, asks the app-only `create_embed_session` tool to mint a
-route-scoped session, then launches the resulting app route. ChatGPT and hosts
-that allow direct route hydration launch the same signed app URL, but ChatGPT
-keeps it in a controlled route iframe to avoid a web-sandbox auto-height
-feedback loop. Claude web currently proxies MCP App content under
-`claudemcpcontent.com`; direct route navigation can fetch app HTML there
-without reliably running the framework bootstrap, and a second nested iframe is
-easy for the host to block. For Claude, `embedApp()` fetches the signed app
-HTML and mounts the real route document into the existing MCP resource frame,
-with app-origin requests routed back to the original app using the embed token.
+route-scoped session, then launches the resulting app route. ChatGPT and Claude
+web keep the signed app URL in a controlled route iframe to avoid web-sandbox
+auto-height feedback loops and proxied-origin module loading. Hosts that can
+hydrate the route directly can still navigate the MCP App frame itself.
 For normal action authoring, use `embedRoute()` when the action's
 `link` and `mcpApp` should come from the same pure route builder. The route
 itself should derive state from the URL and normal app data fetching.

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -78,10 +78,13 @@ If an action declares `mcpApp`, the server also advertises the official MCP Apps
 
 `embedApp()` is the low-level URL-first MCP App helper. It reads the action
 result's open link, asks the app-only `create_embed_session` tool to mint a
-route-scoped session, then launches the resulting app route. ChatGPT and Claude
-web keep the signed app URL in a controlled route iframe to avoid web-sandbox
-auto-height feedback loops and proxied-origin module loading. Hosts that can
-hydrate the route directly can still navigate the MCP App frame itself.
+route-scoped session, then launches the resulting app route. Standard hosts
+hydrate the signed route by navigating the MCP App frame itself. Claude web
+uses a single-frame transplant path that fetches the signed app HTML and
+hydrates it inside Claude's MCP App iframe because Claude does not reliably
+allow app-owned child iframes or external frame navigation. ChatGPT web keeps
+the signed app URL in a controlled route iframe for stable `window.openai`
+host APIs and bounded height control.
 For normal action authoring, use `embedRoute()` when the action's
 `link` and `mcpApp` should come from the same pure route builder. The route
 itself should derive state from the URL and normal app data fetching.
@@ -102,6 +105,11 @@ JSON-RPC messages:
 | `ui/message`              | `{ role: "user", content }`        |
 | `ui/open-link`            | `{ url }`                          |
 | `ui/request-display-mode` | `{ mode }`                         |
+
+Claude's transplanted route uses the same `ui/*` bridge after hydration. Test
+Claude against deployed/preview URLs or a local production build served with
+`agent-native start`; raw Vite dev modules can be app-auth protected and fail
+dynamic imports from Claude's resource origin.
 
 The ChatGPT controlled-frame path and any explicit `embedMode: "iframe"` /
 `renderMode: "iframe"` diagnostic path use the wrapper-to-route postMessage

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -351,7 +351,7 @@ function safeUiSegment(value: string | undefined, fallback: string): string {
 
 // ChatGPT and Claude cache MCP App resource HTML by `ui://` URI. Bump this
 // when the shared shell changes in a way that must invalidate host caches.
-const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v22";
+const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v23";
 
 function legacyDefaultMcpAppUri(config: MCPConfig, actionName: string): string {
   const app = safeUiSegment(config.appId ?? config.name, "agent-native");

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -4,7 +4,7 @@ import type { AgentMcpAppPayload } from "../mcp-client/app-result.js";
 import { embedApp, MCP_APP_REQUEST_ORIGIN_CSP_SOURCE } from "./embed-app.js";
 
 describe("embedApp", () => {
-  it("defaults to direct navigation except inside Claude's proxied MCP content frame", () => {
+  it("renders a controlled app frame inside ChatGPT and Claude app hosts", () => {
     const resource = embedApp({
       title: "Dashboard",
       openLabel: "Open dashboard",
@@ -34,6 +34,10 @@ describe("embedApp", () => {
     expect(html).toContain("shouldRenderControlledAppFrame");
     expect(html).toContain("} else if (shouldRenderControlledAppFrame())");
     expect(html).toContain("window.location.replace(src)");
+    expect(html).toContain(
+      "isChatGptSandboxHost() || isClaudeMcpContentHost()",
+    );
+    expect(html).toContain("shouldTransplantAppDocument");
     expect(html).toContain("isClaudeMcpContentHost");
     expect(html).toContain("transplantAppDocument");
     expect(html).toContain("__agentNativeExternalEmbedRuntimeInstalled");
@@ -44,6 +48,8 @@ describe("embedApp", () => {
     expect(html).toContain("moduleCodeToClassicAsync");
     expect(html).toContain("await import($1)");
     expect(html).toContain("claudemcpcontent");
+    expect(html).toContain('mode === "transplant"');
+    expect(html).toContain('toolInput.frame === "transplant"');
     expect(html).toContain("const embedUrl = withChatBridgeParam(openUrl)");
     expect(html).toContain("!selfNavigate && isEmbedStartUrl(embedUrl)");
     expect(html).toContain('typeof data.startUrl !== "string"');

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -4,7 +4,7 @@ import type { AgentMcpAppPayload } from "../mcp-client/app-result.js";
 import { embedApp, MCP_APP_REQUEST_ORIGIN_CSP_SOURCE } from "./embed-app.js";
 
 describe("embedApp", () => {
-  it("renders a controlled app frame inside ChatGPT and Claude app hosts", () => {
+  it("renders a controlled app frame for ChatGPT and direct/transplant paths for Claude", () => {
     const resource = embedApp({
       title: "Dashboard",
       openLabel: "Open dashboard",
@@ -27,6 +27,9 @@ describe("embedApp", () => {
     expect(html).toContain("openAiBridge.openExternal");
     expect(html).toContain("openAiBridge.setOpenInAppUrl");
     expect(html).toContain("openAiBridge.sendFollowUpMessage");
+    expect(html).toContain(
+      'const record = data && typeof data === "object" ? data : {}',
+    );
     expect(html).toContain("shouldSelfNavigateToApp");
     expect(html).toContain("isChatGptSandboxHost");
     expect(html).toContain("oaiusercontent");
@@ -34,9 +37,7 @@ describe("embedApp", () => {
     expect(html).toContain("shouldRenderControlledAppFrame");
     expect(html).toContain("} else if (shouldRenderControlledAppFrame())");
     expect(html).toContain("window.location.replace(src)");
-    expect(html).toContain(
-      "isChatGptSandboxHost() || isClaudeMcpContentHost()",
-    );
+    expect(html).toContain("return !!openAiBridge || isChatGptSandboxHost();");
     expect(html).toContain("shouldTransplantAppDocument");
     expect(html).toContain("isClaudeMcpContentHost");
     expect(html).toContain("transplantAppDocument");
@@ -50,6 +51,7 @@ describe("embedApp", () => {
     expect(html).toContain("claudemcpcontent");
     expect(html).toContain('mode === "transplant"');
     expect(html).toContain('toolInput.frame === "transplant"');
+    expect(html).toContain("isClaudeMcpContentHost()");
     expect(html).toContain("const embedUrl = withChatBridgeParam(openUrl)");
     expect(html).toContain("!selfNavigate && isEmbedStartUrl(embedUrl)");
     expect(html).toContain('typeof data.startUrl !== "string"');
@@ -115,7 +117,18 @@ describe("embedApp", () => {
     expect(html).toContain("let url = withChatBridgeParam(openUrl)");
     expect(html).toContain("appFrameLoadTimer");
     expect(html).toContain("startFrameReadyTimer(frame)");
-    expect(html).toContain("}, 30000)");
+    expect(html).toContain("function embedSessionArgsFor(value)");
+    expect(html).toContain("? { path: value, chrome }");
+    expect(html).toContain(
+      "callEmbedSessionTool(embedSessionArgsFor(embedUrl))",
+    );
+    expect(html).toContain("callEmbedSessionTool(embedSessionArgsFor(url))");
+    expect(html).toContain("frameReadyMessageDelays");
+    expect(html).toContain("[0, 200, 500, 1500, 3000, 7000, 15000, 30000]");
+    expect(html).toContain("const frameReadyTimeoutMs = 45000");
+    expect(html).toContain("const frameLoadTimeoutMs = 45000");
+    expect(html).toContain("}, frameReadyTimeoutMs)");
+    expect(html).toContain("}, frameLoadTimeoutMs)");
     expect(html).toContain('mode === "iframe" || mode === "nested"');
     expect(html).toContain('toolInput.frame === "iframe"');
     expect(html).toContain('"agentNative.frameOrigin"');

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -663,6 +663,15 @@ export function embedApp(
       return true;
     }
 
+    function shouldTransplantAppDocument() {
+      const mode = typeof toolInput.embedMode === "string"
+        ? toolInput.embedMode
+        : typeof toolInput.renderMode === "string"
+          ? toolInput.renderMode
+          : "";
+      return mode === "transplant" || toolInput.frame === "transplant";
+    }
+
     function isClaudeMcpContentHost() {
       try {
         return /(^|\\.)claudemcpcontent\\.com$/i.test(window.location.hostname || "");
@@ -682,7 +691,7 @@ export function embedApp(
     }
 
     function shouldRenderControlledAppFrame() {
-      return !!openAiBridge || isChatGptSandboxHost();
+      return !!openAiBridge || isChatGptSandboxHost() || isClaudeMcpContentHost();
     }
 
     function navigateToAppFrame(src) {
@@ -871,7 +880,7 @@ export function embedApp(
         const selfNavigate = shouldSelfNavigateToApp();
         const embedUrl = withChatBridgeParam(openUrl);
         if (selfNavigate && isEmbedStartUrl(embedUrl)) {
-          if (isClaudeMcpContentHost()) {
+          if (isClaudeMcpContentHost() && shouldTransplantAppDocument()) {
             await transplantAppDocument(embedUrl);
           } else if (shouldRenderControlledAppFrame()) {
             renderFrame(embedUrl);
@@ -895,7 +904,7 @@ export function embedApp(
           return;
         }
         if (selfNavigate) {
-          if (isClaudeMcpContentHost()) {
+          if (isClaudeMcpContentHost() && shouldTransplantAppDocument()) {
             await transplantAppDocument(data.startUrl);
           } else if (shouldRenderControlledAppFrame()) {
             renderFrame(data.startUrl);

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -105,6 +105,9 @@ export function embedApp(
     const chatBridgeParam = ${JSON.stringify(MCP_APP_CHAT_BRIDGE_QUERY_PARAM)};
     const defaultIntrinsicHeight = ${height};
     const chromeHeight = ${MCP_APP_WRAPPER_CHROME_HEIGHT};
+    const frameReadyMessageDelays = [0, 200, 500, 1500, 3000, 7000, 15000, 30000];
+    const frameReadyTimeoutMs = 45000;
+    const frameLoadTimeoutMs = 45000;
     let app = null;
     let openAiBridge = null;
     let toolInput = {};
@@ -191,7 +194,8 @@ export function embedApp(
       const metaUrl = openLink && typeof openLink === "object" && typeof openLink.webUrl === "string"
         ? openLink.webUrl
         : "";
-      return metaUrl || data.url || data.deepLink || data.openUrl || "";
+      const record = data && typeof data === "object" ? data : {};
+      return metaUrl || record.url || record.deepLink || record.openUrl || "";
     }
 
     function hostState() {
@@ -229,7 +233,7 @@ export function embedApp(
 
     function sendFrameReadyMessages(frame) {
       const originPayload = { type: "agentNative.frameOrigin", origin: window.location.origin };
-      [0, 200, 500, 1500].forEach((delay) => {
+      frameReadyMessageDelays.forEach((delay) => {
         setTimeout(() => {
           try { frame.contentWindow && frame.contentWindow.postMessage(originPayload, "*"); } catch {}
           sendHostContext();
@@ -249,6 +253,13 @@ export function embedApp(
       } catch {
         return value;
       }
+    }
+
+    function embedSessionArgsFor(value) {
+      const chrome = typeof toolInput.chrome === "string" ? toolInput.chrome : "full";
+      return typeof value === "string" && value.startsWith("/")
+        ? { path: value, chrome }
+        : { url: value, chrome };
     }
 
     function isEmbedStartUrl(value) {
@@ -579,7 +590,7 @@ export function embedApp(
       clearFrameReadyTimer();
       appFrameReadyTimer = setTimeout(() => {
         if (!appFrameReady && appFrame === frame) renderFrameFallback();
-      }, 7000);
+      }, frameReadyTimeoutMs);
     }
 
     function renderFrameFallback() {
@@ -615,10 +626,7 @@ export function embedApp(
     async function openFallbackExternal() {
       let url = withChatBridgeParam(openUrl);
       try {
-        const result = await callEmbedSessionTool({
-          url,
-          chrome: typeof toolInput.chrome === "string" ? toolInput.chrome : "full"
-        });
+        const result = await callEmbedSessionTool(embedSessionArgsFor(url));
         const data = parseToolResult(result);
         if (typeof data.startUrl === "string" && data.startUrl) {
           url = data.startUrl;
@@ -649,7 +657,7 @@ export function embedApp(
       notifyHostHeight();
       appFrameLoadTimer = setTimeout(() => {
         if (!appFrameReady && appFrame === frame) renderFrameFallback();
-      }, 30000);
+      }, frameLoadTimeoutMs);
     }
 
     function shouldSelfNavigateToApp() {
@@ -669,7 +677,11 @@ export function embedApp(
         : typeof toolInput.renderMode === "string"
           ? toolInput.renderMode
           : "";
-      return mode === "transplant" || toolInput.frame === "transplant";
+      return (
+        mode === "transplant" ||
+        toolInput.frame === "transplant" ||
+        isClaudeMcpContentHost()
+      );
     }
 
     function isClaudeMcpContentHost() {
@@ -691,7 +703,7 @@ export function embedApp(
     }
 
     function shouldRenderControlledAppFrame() {
-      return !!openAiBridge || isChatGptSandboxHost() || isClaudeMcpContentHost();
+      return !!openAiBridge || isChatGptSandboxHost();
     }
 
     function navigateToAppFrame(src) {
@@ -893,10 +905,7 @@ export function embedApp(
           renderFrame(embedUrl);
           return;
         }
-        const result = await callEmbedSessionTool({
-          url: embedUrl,
-          chrome: typeof toolInput.chrome === "string" ? toolInput.chrome : "full"
-        });
+        const result = await callEmbedSessionTool(embedSessionArgsFor(embedUrl));
         const data = parseToolResult(result);
         if (typeof data.startUrl !== "string" || !data.startUrl) {
           startedFor = "";

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -354,10 +354,10 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(echo.annotations?.["agent-native/producesOpenLink"]).toBe(true);
     expect(echo.description).toContain("Open in");
     expect(echo._meta?.["ui/resourceUri"]).toBe(
-      "ui://mail/echo-thing/shell-v22",
+      "ui://mail/echo-thing/shell-v23",
     );
     expect(echo._meta?.["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v22",
+      "ui://mail/echo-thing/shell-v23",
     );
     expect(echo._meta?.["openai/widgetAccessible"]).toBe(true);
     expect(echo._meta?.["openai/widgetCSP"]).toEqual({
@@ -368,7 +368,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         connectDomains: ["https://mail.agent-native.com"],
       },
       prefersBorder: true,
-      resourceUri: "ui://mail/echo-thing/shell-v22",
+      resourceUri: "ui://mail/echo-thing/shell-v23",
       visibility: ["model", "app"],
     });
   });
@@ -482,8 +482,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources.map((r: any) => r.uri)).toEqual(
       expect.arrayContaining([
-        "ui://mail/echo-thing/shell-v22",
-        "ui://mail/review-draft/shell-v22",
+        "ui://mail/echo-thing/shell-v23",
+        "ui://mail/review-draft/shell-v23",
       ]),
     );
   });
@@ -611,7 +611,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v22",
+        uri: "ui://mail/echo-thing/shell-v23",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -647,7 +647,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resourceTemplates).toEqual([
       expect.objectContaining({
-        uriTemplate: "ui://mail/echo-thing/shell-v22",
+        uriTemplate: "ui://mail/echo-thing/shell-v23",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -662,14 +662,14 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 6,
         method: "resources/read",
-        params: { uri: "ui://mail/echo-thing/shell-v22" },
+        params: { uri: "ui://mail/echo-thing/shell-v23" },
       },
       { headers: await mcpAppsAuthHeaders() },
     );
     expect(out.error).toBeUndefined();
     expect(out.result.contents).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v22",
+        uri: "ui://mail/echo-thing/shell-v23",
         mimeType: "text/html;profile=mcp-app",
         text: expect.stringContaining('data-action="echo-thing"'),
         _meta: expect.objectContaining({
@@ -744,7 +744,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v22",
+        uri: "ui://mail/custom-review/shell-v23",
         name: "custom-review",
       }),
     ]);
@@ -801,7 +801,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v22",
+        uri: "ui://mail/custom-review/shell-v23",
         name: "custom-review",
       }),
     ]);
@@ -858,7 +858,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v22?mode=compact#preview",
+        uri: "ui://mail/custom-review/shell-v23?mode=compact#preview",
         name: "custom-review",
       }),
     ]);
@@ -908,7 +908,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         "https://mail.agent-native.com/_agent-native/open?view=thing&id=thing-42&agentSidebar=closed",
     });
     expect(out.result._meta["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v22",
+      "ui://mail/echo-thing/shell-v23",
     );
     expect(out.result._meta["openai/widgetCSP"]).toEqual({
       connect_domains: ["https://mail.agent-native.com"],


### PR DESCRIPTION
## Summary
- use the controlled route iframe path for Claude web MCP Apps now that embed frame headers/CORS are in place
- keep the single-frame transplant mount as an explicit diagnostic mode
- update MCP Apps docs and external-agent skill guidance

## Verification
- pnpm --filter @agent-native/core exec vitest --run src/mcp/embed-app.spec.ts src/mcp/server.spec.ts src/mcp/builtin-cross-app.spec.ts src/server/security-headers.spec.ts src/server/embed-route.spec.ts src/client/mcp-apps/McpAppRenderer.spec.ts src/client/embed-auth.spec.ts
- pnpm run prep