### PR TITLE
Fix same-app MCP app embeds for Claude

### DIFF
--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -299,9 +299,13 @@ as HTTP clients.
 Keep the existing `link` builder even when adding `mcpApp`. CLI-only clients,
 older hosts, and any host that does not render MCP Apps will ignore the UI
 metadata and still need the "Open in … →" link. `embedApp()` uses that link as
-its launch target, calls the app-only `create_embed_session` helper, exchanges
-a one-time SQL ticket at `/_agent-native/embed/start`, then launches the real
-app route with a short-lived browser session. Standard hosts navigate the MCP
+its launch target. Same-app `open_app({ embed: true })` mints the
+`/_agent-native/embed/start` ticket during the original tool call so production
+hosts do not need the iframe to make a second app-only helper call; custom
+actions can return `embedStartUrl` for the same fast path. Otherwise the
+resource falls back to the app-only `create_embed_session` helper. The embed
+start route exchanges a one-time SQL ticket, then launches the real app route
+with a short-lived browser session. Standard hosts navigate the MCP
 App frame directly. Claude web uses a single-frame transplant path that fetches
 the signed app HTML and hydrates it inside Claude's MCP App iframe because
 Claude does not reliably allow app-owned child iframes or external frame

--- a/.changeset/server-minted-embed-sessions.md
+++ b/.changeset/server-minted-embed-sessions.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Mint same-app MCP embed sessions during app launches so Claude can render embedded apps without iframe-originated tool calls.

--- a/packages/core/docs/content/actions.md
+++ b/packages/core/docs/content/actions.md
@@ -199,6 +199,10 @@ export default defineAction({
 This advertises the MCP Apps extension (`io.modelcontextprotocol/ui`), exposes the HTML via MCP resources/templates, and includes standard MCP Apps plus ChatGPT Apps SDK widget metadata for compatible hosts. Keep `link` as the fallback for CLI and non-UI MCP clients; see [External Agents](/docs/external-agents#mcp-apps).
 
 The helper launches the action's `link` target through `/_agent-native/embed/start` with a short-lived browser session, so routes such as full dashboards, filtered inboxes, drafts, and extension pages can reuse the app's React components directly.
+Same-app `open_app({ embed: true })` mints that embed-start ticket during the
+original tool call, and custom actions can return `embedStartUrl` for the same
+fast path; otherwise the resource falls back to the app-only
+`create_embed_session` helper.
 Standard hosts navigate the MCP App frame directly to that signed route.
 Claude web uses a single-frame transplant path that hydrates the signed app
 HTML inside Claude's MCP App iframe because Claude does not reliably allow

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -230,6 +230,13 @@ same signed app route and render the normal route and React components. Design
 embedded routes so a reload with the same signed URL reconstructs the same
 view.
 
+For same-app `open_app({ embed: true })`, the framework mints the embed-start
+ticket during the original tool call and returns `embedStartUrl` in the hidden
+structured payload. Custom actions can do the same. When no `embedStartUrl` is
+present, the resource falls back to the app-only `create_embed_session` helper.
+This keeps production hosts that restrict iframe-initiated tool calls on the
+direct route.
+
 ChatGPT gets a dedicated compatibility path through `window.openai`: the launch
 document reads `toolInput`, `toolOutput`, and `toolResponseMetadata` directly,
 then calls `create_embed_session` via `window.openai.callTool(...)`. Standard

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -88,6 +88,10 @@ host APIs and bounded height control.
 For normal action authoring, use `embedRoute()` when the action's
 `link` and `mcpApp` should come from the same pure route builder. The route
 itself should derive state from the URL and normal app data fetching.
+Same-app `open_app({ embed: true })` returns a server-minted `embedStartUrl`
+so the resource can launch without a second iframe-originated tool call;
+custom actions can return the same field when they already know the target
+route.
 
 The outer MCP resource reports a bounded inline height to the host and the app
 route scrolls internally. Do not rely on host auto-resize measuring the full

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -33,6 +33,7 @@ import {
   isAgentNativeOpenDeepLink,
   withCollapsedAgentSidebarParam,
 } from "../shared/agent-sidebar-url.js";
+import { MCP_APP_CHAT_BRIDGE_QUERY_PARAM } from "../shared/embed-auth.js";
 import { getBuiltinCrossAppTools } from "./builtin-tools.js";
 import { MCP_CONNECT_SCOPE } from "./connect-store.js";
 import {
@@ -232,6 +233,21 @@ function metadataObject(value: unknown): Record<string, unknown> {
     : {};
 }
 
+function withMcpChatBridgeParam(urlOrPath: string): string {
+  try {
+    const base = "http://agent-native.invalid";
+    const url = urlOrPath.startsWith("/")
+      ? new URL(urlOrPath, base)
+      : new URL(urlOrPath);
+    url.searchParams.set(MCP_APP_CHAT_BRIDGE_QUERY_PARAM, "1");
+    return urlOrPath.startsWith("/")
+      ? `${url.pathname}${url.search}${url.hash}`
+      : url.toString();
+  } catch {
+    return urlOrPath;
+  }
+}
+
 function mcpAppEmbedOpenLinkMeta(
   result: unknown,
   resource: ResolvedMcpAppResource,
@@ -248,7 +264,10 @@ function mcpAppEmbedOpenLinkMeta(
         : null;
   if (!embedStartUrl) return {};
 
-  const webUrl = toAbsoluteOpenUrl(embedStartUrl, meta?.origin);
+  const webUrl = toAbsoluteOpenUrl(
+    withMcpChatBridgeParam(embedStartUrl),
+    meta?.origin,
+  );
   const deepLinkUrl =
     typeof out.deepLinkUrl === "string" ? out.deepLinkUrl : null;
   const fallbackLabel = resource.title ?? resource.name ?? "app";

--- a/packages/core/src/mcp/builtin-cross-app.spec.ts
+++ b/packages/core/src/mcp/builtin-cross-app.spec.ts
@@ -5,6 +5,8 @@ import type { MCPConfig } from "./build-server.js";
 import * as orgDirectory from "./org-directory.js";
 import * as a2aClient from "../a2a/client.js";
 import * as callerAuth from "../a2a/caller-auth.js";
+import * as embedSession from "../server/embed-session.js";
+import { runWithRequestContext } from "../server/request-context.js";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -160,6 +162,46 @@ describe("open_app — same-app / standalone keeps a relative deep link", () => 
     expect(result.embedStartUrl).toBeUndefined();
     expect(result.deepLinkUrl).toBeUndefined();
     expect(result.embed).toBe(true);
+  });
+
+  it("mints a same-app embed start URL for authenticated MCP app callers", async () => {
+    const createTicket = vi
+      .spyOn(embedSession, "createEmbedSessionTicket")
+      .mockResolvedValue({
+        ticket: "ticket-123",
+        ticketHash: "hash-123",
+        expiresAt: 123456,
+      });
+    const tools = getBuiltinCrossAppTools(baseConfig(), {
+      origin: "https://mail.example.com",
+    });
+
+    const result: any = await runWithRequestContext(
+      { userEmail: "owner@example.com", orgId: "org-123" },
+      () =>
+        tools.open_app.run({
+          app: "mail",
+          view: "inbox",
+          params: { threadId: "abc" },
+          embed: true,
+          chrome: "minimal",
+        }),
+    );
+
+    expect(result.url).toBe("/inbox?threadId=abc");
+    expect(result.embedStartUrl).toBe(
+      "https://mail.example.com/_agent-native/embed/start?ticket=ticket-123",
+    );
+    expect(result.embedTargetPath).toBe(
+      "/inbox?threadId=abc&__an_mcp_chat_bridge=1",
+    );
+    expect(result.embedExpiresAt).toBe(123456);
+    expect(createTicket).toHaveBeenCalledWith({
+      ownerEmail: "owner@example.com",
+      orgId: "org-123",
+      targetPath: "/inbox?threadId=abc&__an_mcp_chat_bridge=1",
+      scope: "minimal",
+    });
   });
 
   it("requests the default app viewport for full-app MCP App embeds", () => {

--- a/packages/core/src/mcp/builtin-tools.ts
+++ b/packages/core/src/mcp/builtin-tools.ts
@@ -33,6 +33,7 @@
 import type { ActionEntry } from "../agent/production-agent.js";
 import { buildDeepLink } from "../server/deep-link.js";
 import { getConfiguredAppBasePath } from "../server/app-base-path.js";
+import { MCP_APP_CHAT_BRIDGE_QUERY_PARAM } from "../shared/embed-auth.js";
 import type { MCPConfig } from "./build-server.js";
 import { fetchOrgApps, type OrgApp } from "./org-directory.js";
 import { embedApp } from "./embed-app.js";
@@ -110,6 +111,16 @@ function withConfiguredBasePath(path: string): string {
   const base = getConfiguredAppBasePath();
   if (!base || path === base || path.startsWith(`${base}/`)) return path;
   return `${base}${path}`;
+}
+
+function withMcpChatBridgeParam(path: string): string {
+  try {
+    const url = new URL(path, "http://agent-native.invalid");
+    url.searchParams.set(MCP_APP_CHAT_BRIDGE_QUERY_PARAM, "1");
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return path;
+  }
 }
 
 /**
@@ -250,7 +261,7 @@ function listAppsTool(
 
 function openAppTool(
   config: MCPConfig,
-  _requestMeta?: { origin?: string },
+  requestMeta?: { origin?: string },
 ): ActionEntry {
   return {
     tool: tool(
@@ -330,12 +341,49 @@ function openAppTool(
         ? `${targetApp.origin.replace(/\/+$/, "")}${relUrl}`
         : sameAppUrl;
       const url = appUrl;
+      let embedStartUrl: string | undefined;
+      let embedTargetPath: string | undefined;
+      let embedExpiresAt: number | undefined;
+
+      if (embed && !targetApp) {
+        const { getRequestContext } =
+          await import("../server/request-context.js");
+        const ctx = getRequestContext();
+        const ownerEmail = ctx?.userEmail?.trim();
+        if (ownerEmail) {
+          const { normalizeEmbedTargetPath, createEmbedSessionTicket } =
+            await import("../server/embed-session.js");
+          const { buildEmbedStartPath } =
+            await import("../server/embed-route.js");
+          const targetPath = normalizeEmbedTargetPath(
+            withMcpChatBridgeParam(url),
+            requestMeta?.origin,
+          );
+          if (targetPath) {
+            const ticket = await createEmbedSessionTicket({
+              ownerEmail,
+              orgId: ctx?.orgId,
+              targetPath,
+              scope: typeof args.chrome === "string" ? args.chrome : null,
+            });
+            const startPath = buildEmbedStartPath(ticket.ticket);
+            embedStartUrl = requestMeta?.origin
+              ? new URL(startPath, requestMeta.origin).toString()
+              : startPath;
+            embedTargetPath = targetPath;
+            embedExpiresAt = ticket.expiresAt;
+          }
+        }
+      }
 
       return {
         app,
         ...(view ? { view } : {}),
         ...(path ? { path } : {}),
         url,
+        ...(embedStartUrl ? { embedStartUrl } : {}),
+        ...(embedTargetPath ? { embedTargetPath } : {}),
+        ...(embedExpiresAt ? { embedExpiresAt } : {}),
         embed,
       };
     },

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -70,6 +70,7 @@ describe("embedApp", () => {
     expect(html).toContain('"agentNative.mcpHost.response"');
     expect(html).toContain("app.requestDisplayMode");
     expect(html).toContain("function openLinkRecordFrom(value)");
+    expect(html).toContain("return withChatBridgeParam(value)");
     expect(html).not.toContain("shouldDirectRenderEmbed");
     expect(html).toContain("claudemcpcontent\\.com");
     expect(html).toContain("isClaudeMcpContentHost()");

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -30,6 +30,8 @@ describe("embedApp", () => {
     expect(html).toContain(
       'const record = data && typeof data === "object" ? data : {}',
     );
+    expect(html).toContain("function embedStartUrlFrom(data)");
+    expect(html).toContain("openStartUrl = embedStartUrlFrom(data)");
     expect(html).toContain("shouldSelfNavigateToApp");
     expect(html).toContain("isChatGptSandboxHost");
     expect(html).toContain("oaiusercontent");
@@ -52,7 +54,9 @@ describe("embedApp", () => {
     expect(html).toContain('mode === "transplant"');
     expect(html).toContain('toolInput.frame === "transplant"');
     expect(html).toContain("isClaudeMcpContentHost()");
-    expect(html).toContain("const embedUrl = withChatBridgeParam(openUrl)");
+    expect(html).toContain(
+      "const embedUrl = openStartUrl || withChatBridgeParam(openUrl)",
+    );
     expect(html).toContain("!selfNavigate && isEmbedStartUrl(embedUrl)");
     expect(html).toContain('typeof data.startUrl !== "string"');
     expect(html).toContain("if (selfNavigate)");
@@ -114,13 +118,18 @@ describe("embedApp", () => {
     expect(html).toContain('document.createElement("iframe")');
     expect(html).toContain("renderFrameFallback");
     expect(html).toContain("openFallbackExternal");
-    expect(html).toContain("let url = withChatBridgeParam(openUrl)");
+    expect(html).toContain(
+      "let url = openStartUrl || withChatBridgeParam(openUrl)",
+    );
     expect(html).toContain("appFrameLoadTimer");
     expect(html).toContain("startFrameReadyTimer(frame)");
     expect(html).toContain("function embedSessionArgsFor(value)");
     expect(html).toContain("? { path: value, chrome }");
     expect(html).toContain(
       "callEmbedSessionTool(embedSessionArgsFor(embedUrl))",
+    );
+    expect(html).toContain(
+      "const embedUrl = openStartUrl || withChatBridgeParam(openUrl)",
     );
     expect(html).toContain("callEmbedSessionTool(embedSessionArgsFor(url))");
     expect(html).toContain("frameReadyMessageDelays");

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -30,8 +30,12 @@ describe("embedApp", () => {
     expect(html).toContain(
       'const record = data && typeof data === "object" ? data : {}',
     );
-    expect(html).toContain("function embedStartUrlFrom(data)");
-    expect(html).toContain("openStartUrl = embedStartUrlFrom(data)");
+    expect(html).toContain("function embedStartUrlFrom(params, data)");
+    expect(html).toContain("openStartUrl = embedStartUrlFrom(params, data)");
+    expect(html).toContain("record.embedTargetPath");
+    expect(html).toContain("record.deepLinkUrl");
+    expect(html).toContain("const launchUrl = openStartUrl || openUrl");
+    expect(html).toContain("if (openUrl || openStartUrl)");
     expect(html).toContain("shouldSelfNavigateToApp");
     expect(html).toContain("isChatGptSandboxHost");
     expect(html).toContain("oaiusercontent");
@@ -54,9 +58,7 @@ describe("embedApp", () => {
     expect(html).toContain('mode === "transplant"');
     expect(html).toContain('toolInput.frame === "transplant"');
     expect(html).toContain("isClaudeMcpContentHost()");
-    expect(html).toContain(
-      "const embedUrl = withChatBridgeParam(openStartUrl || openUrl)",
-    );
+    expect(html).toContain("const embedUrl = withChatBridgeParam(launchUrl)");
     expect(html).toContain("!selfNavigate && isEmbedStartUrl(embedUrl)");
     expect(html).toContain('typeof data.startUrl !== "string"');
     expect(html).toContain("if (selfNavigate)");
@@ -67,7 +69,7 @@ describe("embedApp", () => {
     expect(html).toContain('"agentNative.mcpHost.requestDisplayMode"');
     expect(html).toContain('"agentNative.mcpHost.response"');
     expect(html).toContain("app.requestDisplayMode");
-    expect(html).toContain('typeof openLink === "object"');
+    expect(html).toContain("function openLinkRecordFrom(value)");
     expect(html).not.toContain("shouldDirectRenderEmbed");
     expect(html).toContain("claudemcpcontent\\.com");
     expect(html).toContain("isClaudeMcpContentHost()");
@@ -119,6 +121,7 @@ describe("embedApp", () => {
     expect(html).toContain("renderFrameFallback");
     expect(html).toContain("openFallbackExternal");
     expect(html).toContain("let url = withChatBridgeParam(openUrl)");
+    expect(html).toContain("if (!url) url = withChatBridgeParam(openStartUrl)");
     expect(html).toContain("appFrameLoadTimer");
     expect(html).toContain("startFrameReadyTimer(frame)");
     expect(html).toContain("function embedSessionArgsFor(value)");
@@ -126,9 +129,7 @@ describe("embedApp", () => {
     expect(html).toContain(
       "callEmbedSessionTool(embedSessionArgsFor(embedUrl))",
     );
-    expect(html).toContain(
-      "const embedUrl = withChatBridgeParam(openStartUrl || openUrl)",
-    );
+    expect(html).toContain("const embedUrl = withChatBridgeParam(launchUrl)");
     expect(html).toContain(
       'url.pathname.endsWith("/_agent-native/embed/start")',
     );

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -61,6 +61,9 @@ describe("embedApp", () => {
     expect(html).toContain("const embedUrl = withChatBridgeParam(launchUrl)");
     expect(html).toContain("!selfNavigate && isEmbedStartUrl(embedUrl)");
     expect(html).toContain('typeof data.startUrl !== "string"');
+    expect(html).toContain(
+      "const startUrl = withChatBridgeParam(data.startUrl)",
+    );
     expect(html).toContain("if (selfNavigate)");
     expect(html).toContain('"agentNative.submitChat"');
     expect(html).toContain('"agentNative.mcpHostContext"');

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -55,7 +55,7 @@ describe("embedApp", () => {
     expect(html).toContain('toolInput.frame === "transplant"');
     expect(html).toContain("isClaudeMcpContentHost()");
     expect(html).toContain(
-      "const embedUrl = openStartUrl || withChatBridgeParam(openUrl)",
+      "const embedUrl = withChatBridgeParam(openStartUrl || openUrl)",
     );
     expect(html).toContain("!selfNavigate && isEmbedStartUrl(embedUrl)");
     expect(html).toContain('typeof data.startUrl !== "string"');
@@ -118,9 +118,7 @@ describe("embedApp", () => {
     expect(html).toContain('document.createElement("iframe")');
     expect(html).toContain("renderFrameFallback");
     expect(html).toContain("openFallbackExternal");
-    expect(html).toContain(
-      "let url = openStartUrl || withChatBridgeParam(openUrl)",
-    );
+    expect(html).toContain("let url = withChatBridgeParam(openUrl)");
     expect(html).toContain("appFrameLoadTimer");
     expect(html).toContain("startFrameReadyTimer(frame)");
     expect(html).toContain("function embedSessionArgsFor(value)");
@@ -129,7 +127,10 @@ describe("embedApp", () => {
       "callEmbedSessionTool(embedSessionArgsFor(embedUrl))",
     );
     expect(html).toContain(
-      "const embedUrl = openStartUrl || withChatBridgeParam(openUrl)",
+      "const embedUrl = withChatBridgeParam(openStartUrl || openUrl)",
+    );
+    expect(html).toContain(
+      'url.pathname.endsWith("/_agent-native/embed/start")',
     );
     expect(html).toContain("callEmbedSessionTool(embedSessionArgsFor(url))");
     expect(html).toContain("frameReadyMessageDelays");

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -190,22 +190,58 @@ export function embedApp(
       return parseJson(textPart ? textPart.text : "", {});
     }
 
-    function openLinkFrom(params, data) {
-      const openLink = params && params._meta && params._meta["agent-native/openLink"];
-      const metaUrl = openLink && typeof openLink === "object" && typeof openLink.webUrl === "string"
-        ? openLink.webUrl
-        : "";
-      const record = data && typeof data === "object" ? data : {};
-      return metaUrl || record.url || record.deepLink || record.openUrl || "";
+    function openLinkRecordFrom(value) {
+      return value && typeof value === "object" && !Array.isArray(value)
+        ? value
+        : {};
     }
 
-    function embedStartUrlFrom(data) {
+    function openLinkWebUrlFrom(value) {
+      const record = openLinkRecordFrom(value);
+      return typeof record.webUrl === "string" ? record.webUrl : "";
+    }
+
+    function firstNonEmbedStartUrl(values) {
+      for (const value of values) {
+        if (typeof value === "string" && value && !isEmbedStartUrl(value)) return value;
+      }
+      return "";
+    }
+
+    function firstEmbedStartUrl(values) {
+      for (const value of values) {
+        if (typeof value === "string" && value && isEmbedStartUrl(value)) return value;
+      }
+      return "";
+    }
+
+    function openLinkFrom(params, data) {
+      const openLink = params && params._meta && params._meta["agent-native/openLink"];
+      const metaUrl = openLinkWebUrlFrom(openLink);
       const record = data && typeof data === "object" ? data : {};
-      return typeof record.embedStartUrl === "string"
-        ? record.embedStartUrl
-        : typeof record.startUrl === "string"
-          ? record.startUrl
-          : "";
+      const structuredOpenLinkUrl = openLinkWebUrlFrom(record.openLink);
+      return firstNonEmbedStartUrl([
+        record.embedTargetPath,
+        record.deepLinkUrl,
+        record.deepLink,
+        record.openUrl,
+        record.url,
+        structuredOpenLinkUrl,
+        metaUrl
+      ]);
+    }
+
+    function embedStartUrlFrom(params, data) {
+      const openLink = params && params._meta && params._meta["agent-native/openLink"];
+      const metaUrl = openLinkWebUrlFrom(openLink);
+      const record = data && typeof data === "object" ? data : {};
+      return firstEmbedStartUrl([
+        record.embedStartUrl,
+        record.startUrl,
+        record.url,
+        openLinkWebUrlFrom(record.openLink),
+        metaUrl
+      ]);
     }
 
     function hostState() {
@@ -615,14 +651,14 @@ export function embedApp(
             '<button type="button" data-fallback-open>Open app</button>' +
             '<button type="button" data-fallback-retry>Try inline again</button>' +
           '</div>' +
-          (openUrl ? '<a class="fallback-url" href="' + esc(openUrl) + '" target="_blank" rel="noreferrer">' + esc(openUrl) + '</a>' : '') +
+          (openUrl || openStartUrl ? '<a class="fallback-url" href="' + esc(openUrl || openStartUrl) + '" target="_blank" rel="noreferrer">' + esc(openUrl || openStartUrl) + '</a>' : '') +
         '</div>';
       const fallbackOpen = stage.querySelector("[data-fallback-open]");
       const fallbackRetry = stage.querySelector("[data-fallback-retry]");
       if (fallbackOpen) {
-        fallbackOpen.disabled = !openUrl;
+        fallbackOpen.disabled = !(openUrl || openStartUrl);
         fallbackOpen.onclick = () => {
-          if (openUrl) void openFallbackExternal();
+          if (openUrl || openStartUrl) void openFallbackExternal();
         };
       }
       if (fallbackRetry) {
@@ -636,14 +672,17 @@ export function embedApp(
     async function openFallbackExternal() {
       let url = withChatBridgeParam(openUrl);
       try {
-        const result = await callEmbedSessionTool(embedSessionArgsFor(url));
-        const data = parseToolResult(result);
-        if (typeof data.startUrl === "string" && data.startUrl) {
-          url = withChatBridgeParam(data.startUrl);
+        if (url) {
+          const result = await callEmbedSessionTool(embedSessionArgsFor(url));
+          const data = parseToolResult(result);
+          if (typeof data.startUrl === "string" && data.startUrl) {
+            url = withChatBridgeParam(data.startUrl);
+          }
         }
       } catch (err) {
         console.warn("[agent-native] MCP fallback could not mint a fresh app session", err);
       }
+      if (!url) url = withChatBridgeParam(openStartUrl);
       await openHostLink({ url });
     }
 
@@ -887,7 +926,8 @@ export function embedApp(
     }
 
     async function launchEmbed() {
-      if (!openUrl) {
+      const launchUrl = openStartUrl || openUrl;
+      if (!launchUrl) {
         setMessage("Open link was not available.");
         return;
       }
@@ -895,12 +935,12 @@ export function embedApp(
         setMessage("Ready to open.");
         return;
       }
-      if (startedFor === openUrl) return;
-      startedFor = openUrl;
+      if (startedFor === launchUrl) return;
+      startedFor = launchUrl;
       setMessage("Loading app");
       try {
         const selfNavigate = shouldSelfNavigateToApp();
-        const embedUrl = withChatBridgeParam(openStartUrl || openUrl);
+        const embedUrl = withChatBridgeParam(launchUrl);
         if (selfNavigate && isEmbedStartUrl(embedUrl)) {
           if (isClaudeMcpContentHost() && shouldTransplantAppDocument()) {
             await transplantAppDocument(embedUrl);
@@ -961,9 +1001,10 @@ export function embedApp(
     }
 
     function updateOpenButton() {
-      openButton.disabled = !openUrl;
+      const buttonUrl = openUrl || openStartUrl;
+      openButton.disabled = !buttonUrl;
       openButton.onclick = () => {
-        if (openUrl) void openHostLink({ url: openUrl });
+        if (buttonUrl) void openHostLink({ url: buttonUrl });
       };
       updateHostOpenInAppUrl();
     }
@@ -1001,13 +1042,13 @@ export function embedApp(
       const params = openAiToolResultParams(bridge);
       const data = parseToolResult(params);
       openUrl = openLinkFrom(params, data);
-      openStartUrl = embedStartUrlFrom(data);
+      openStartUrl = embedStartUrlFrom(params, data);
       updateTitle(data);
       updateOpenButton();
       updateDisplayButton();
       notifyHostHeight();
       sendHostContext();
-      if (openUrl) {
+      if (openUrl || openStartUrl) {
         void launchEmbed();
       } else if (!appFrame) {
         setMessage("Waiting for app result");
@@ -1051,7 +1092,7 @@ export function embedApp(
       app.ontoolresult = (params) => {
         const data = parseToolResult(params);
         openUrl = openLinkFrom(params, data);
-        openStartUrl = embedStartUrlFrom(data);
+        openStartUrl = embedStartUrlFrom(params, data);
         updateTitle(data);
         updateOpenButton();
         void launchEmbed();

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -112,6 +112,7 @@ export function embedApp(
     let openAiBridge = null;
     let toolInput = {};
     let openUrl = "";
+    let openStartUrl = "";
     let startedFor = "";
     let appFrame = null;
     let appFrameReady = false;
@@ -196,6 +197,15 @@ export function embedApp(
         : "";
       const record = data && typeof data === "object" ? data : {};
       return metaUrl || record.url || record.deepLink || record.openUrl || "";
+    }
+
+    function embedStartUrlFrom(data) {
+      const record = data && typeof data === "object" ? data : {};
+      return typeof record.embedStartUrl === "string"
+        ? record.embedStartUrl
+        : typeof record.startUrl === "string"
+          ? record.startUrl
+          : "";
     }
 
     function hostState() {
@@ -624,12 +634,14 @@ export function embedApp(
     }
 
     async function openFallbackExternal() {
-      let url = withChatBridgeParam(openUrl);
+      let url = openStartUrl || withChatBridgeParam(openUrl);
       try {
-        const result = await callEmbedSessionTool(embedSessionArgsFor(url));
-        const data = parseToolResult(result);
-        if (typeof data.startUrl === "string" && data.startUrl) {
-          url = data.startUrl;
+        if (!isEmbedStartUrl(url)) {
+          const result = await callEmbedSessionTool(embedSessionArgsFor(url));
+          const data = parseToolResult(result);
+          if (typeof data.startUrl === "string" && data.startUrl) {
+            url = data.startUrl;
+          }
         }
       } catch (err) {
         console.warn("[agent-native] MCP fallback could not mint a fresh app session", err);
@@ -890,7 +902,7 @@ export function embedApp(
       setMessage("Loading app");
       try {
         const selfNavigate = shouldSelfNavigateToApp();
-        const embedUrl = withChatBridgeParam(openUrl);
+        const embedUrl = openStartUrl || withChatBridgeParam(openUrl);
         if (selfNavigate && isEmbedStartUrl(embedUrl)) {
           if (isClaudeMcpContentHost() && shouldTransplantAppDocument()) {
             await transplantAppDocument(embedUrl);
@@ -991,6 +1003,7 @@ export function embedApp(
       const params = openAiToolResultParams(bridge);
       const data = parseToolResult(params);
       openUrl = openLinkFrom(params, data);
+      openStartUrl = embedStartUrlFrom(data);
       updateTitle(data);
       updateOpenButton();
       updateDisplayButton();
@@ -1040,6 +1053,7 @@ export function embedApp(
       app.ontoolresult = (params) => {
         const data = parseToolResult(params);
         openUrl = openLinkFrom(params, data);
+        openStartUrl = embedStartUrlFrom(data);
         updateTitle(data);
         updateOpenButton();
         void launchEmbed();

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -964,16 +964,17 @@ export function embedApp(
           setMessage(data.error || "This app can be opened, but not embedded from this MCP server.");
           return;
         }
+        const startUrl = withChatBridgeParam(data.startUrl);
         if (selfNavigate) {
           if (isClaudeMcpContentHost() && shouldTransplantAppDocument()) {
-            await transplantAppDocument(data.startUrl);
+            await transplantAppDocument(startUrl);
           } else if (shouldRenderControlledAppFrame()) {
-            renderFrame(data.startUrl);
+            renderFrame(startUrl);
           } else {
-            navigateToAppFrame(data.startUrl);
+            navigateToAppFrame(startUrl);
           }
         } else {
-          renderFrame(data.startUrl);
+          renderFrame(startUrl);
         }
       } catch (err) {
         startedFor = "";

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -210,7 +210,9 @@ export function embedApp(
 
     function firstEmbedStartUrl(values) {
       for (const value of values) {
-        if (typeof value === "string" && value && isEmbedStartUrl(value)) return value;
+        if (typeof value === "string" && value && isEmbedStartUrl(value)) {
+          return withChatBridgeParam(value);
+        }
       }
       return "";
     }

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -276,7 +276,7 @@ export function embedApp(
       if (typeof value !== "string" || !value) return false;
       try {
         const url = new URL(value, window.location.href);
-        return /\\/_agent-native\\/embed\\/start$/.test(url.pathname);
+        return url.pathname.endsWith("/_agent-native/embed/start");
       } catch {
         return false;
       }
@@ -634,14 +634,12 @@ export function embedApp(
     }
 
     async function openFallbackExternal() {
-      let url = openStartUrl || withChatBridgeParam(openUrl);
+      let url = withChatBridgeParam(openUrl);
       try {
-        if (!isEmbedStartUrl(url)) {
-          const result = await callEmbedSessionTool(embedSessionArgsFor(url));
-          const data = parseToolResult(result);
-          if (typeof data.startUrl === "string" && data.startUrl) {
-            url = data.startUrl;
-          }
+        const result = await callEmbedSessionTool(embedSessionArgsFor(url));
+        const data = parseToolResult(result);
+        if (typeof data.startUrl === "string" && data.startUrl) {
+          url = withChatBridgeParam(data.startUrl);
         }
       } catch (err) {
         console.warn("[agent-native] MCP fallback could not mint a fresh app session", err);
@@ -902,7 +900,7 @@ export function embedApp(
       setMessage("Loading app");
       try {
         const selfNavigate = shouldSelfNavigateToApp();
-        const embedUrl = openStartUrl || withChatBridgeParam(openUrl);
+        const embedUrl = withChatBridgeParam(openStartUrl || openUrl);
         if (selfNavigate && isEmbedStartUrl(embedUrl)) {
           if (isClaudeMcpContentHost() && shouldTransplantAppDocument()) {
             await transplantAppDocument(embedUrl);

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -978,14 +978,14 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       label: "Open mail",
       view: "/inbox",
       webUrl:
-        "https://mail.agent-native.com/_agent-native/embed/start?ticket=test-ticket",
+        "https://mail.agent-native.com/_agent-native/embed/start?ticket=test-ticket&__an_mcp_chat_bridge=1",
       desktopUrl: "https://mail.agent-native.com/inbox",
     });
     expect(out.result.structuredContent).toMatchObject({
       url: "/_agent-native/embed/start?ticket=test-ticket",
       openLink: {
         webUrl:
-          "https://mail.agent-native.com/_agent-native/embed/start?ticket=test-ticket",
+          "https://mail.agent-native.com/_agent-native/embed/start?ticket=test-ticket&__an_mcp_chat_bridge=1",
       },
     });
   });


### PR DESCRIPTION
## Summary
- Mint same-app MCP embed start URLs during open_app({ embed: true }) tool calls when the MCP request is authenticated
- Teach the shared MCP app wrapper to use returned embedStartUrl/startUrl before falling back to iframe-originated helper calls
- Document the portable embed behavior and add coverage for the server-minted Claude path

## Verification
- pnpm run prep
- Local ngrok Claude smoke verified the Mail MCP app renders inline without the iframe-originated helper call 404