### PR TITLE
Pre-mint Dispatch MCP app embeds

### DIFF
--- a/.changeset/dispatch-premint-mcp-embeds.md
+++ b/.changeset/dispatch-premint-mcp-embeds.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Pre-mint Dispatch MCP app embed sessions from open_app results so hosts can render inline apps without a follow-up helper call.

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -170,6 +170,43 @@ describe("openGrantedDispatchMcpApp", () => {
       url: "http://localhost:8092/extensions/ext-1/github-stars-over-time",
       embed: true,
       chrome: "minimal",
+      embedStartUrl:
+        "http://localhost:8092/_agent-native/embed/start?ticket=ticket-123",
+      embedTargetPath: "/extensions/ext-1/github-stars-over-time",
+      embedExpiresAt: 12345,
+    });
+  });
+
+  it("pre-mints cross-app embed sessions for MCP app hosts", async () => {
+    const result = await runWithRequestContext(
+      {
+        userEmail: "owner@example.test",
+        requestOrigin: "http://localhost:8092",
+      },
+      () =>
+        openGrantedDispatchMcpApp({
+          app: "analytics",
+          path: "/dashboards?range=30d",
+          embed: true,
+          chrome: "minimal",
+        }),
+    );
+
+    expect(mocks.managerCallTool).toHaveBeenCalledWith(
+      "mcp__target__create_embed_session",
+      {
+        url: "http://localhost:8086/dashboards?range=30d",
+        chrome: "minimal",
+      },
+    );
+    expect(result).toEqual({
+      app: "analytics",
+      path: "/dashboards?range=30d",
+      url: "http://localhost:8086/dashboards?range=30d",
+      embed: true,
+      chrome: "minimal",
+      embedStartUrl:
+        "http://localhost:8086/_agent-native/embed/start?ticket=remote",
     });
   });
 

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -300,6 +300,9 @@ export async function openGrantedDispatchMcpApp(input: {
   url: string;
   embed?: boolean;
   chrome?: "full" | "minimal";
+  embedStartUrl?: string;
+  embedTargetPath?: string;
+  embedExpiresAt?: number;
 }> {
   const view = input.view?.trim() ?? "";
   const hasPathInput = input.path != null;
@@ -317,13 +320,28 @@ export async function openGrantedDispatchMcpApp(input: {
         view,
         params: input.params,
       });
+  const url = `${appBaseUrl(target)}${relUrl}`;
+  const embedSession = input.embed
+    ? await createGrantedDispatchMcpEmbedSession({
+        app: target.id,
+        url,
+        chrome: input.chrome,
+      })
+    : null;
   return {
     app: target.id,
     ...(view ? { view } : {}),
     ...(path ? { path } : {}),
-    url: `${appBaseUrl(target)}${relUrl}`,
+    url,
     ...(input.embed === true ? { embed: true } : {}),
     ...(input.chrome ? { chrome: input.chrome } : {}),
+    ...(embedSession?.startUrl ? { embedStartUrl: embedSession.startUrl } : {}),
+    ...(embedSession?.targetPath
+      ? { embedTargetPath: embedSession.targetPath }
+      : {}),
+    ...(typeof embedSession?.expiresAt === "number"
+      ? { embedExpiresAt: embedSession.expiresAt }
+      : {}),
   };
 }
 


### PR DESCRIPTION
## Summary\n- Pre-mint Dispatch cross-app MCP embed sessions in open_app results so MCP app hosts can render inline apps without an extra iframe helper call\n- Cover Dispatch self embeds and cross-app pre-minted embeds with gateway tests\n- Add a dispatch patch changeset\n\n## Tests\n- pnpm --filter @agent-native/dispatch exec vitest --run src/server/lib/mcp-gateway.spec.ts src/actions/index.spec.ts\n- pnpm --filter @agent-native/dispatch typecheck\n- pnpm --filter @agent-native/dispatch build\n- pnpm --filter @agent-native/core exec vitest --run src/mcp/embed-app.spec.ts src/client/mcp-app-host.spec.ts