### PR TITLE
Allow MCP app embed connections

### DIFF
--- a/.changeset/mcp-embed-connect-domains.md
+++ b/.changeset/mcp-embed-connect-domains.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow MCP app embed wrappers to connect to configured frame domains so Claude can transplant cross-app embeds.

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -152,6 +152,9 @@ describe("embedApp", () => {
     expect(html).toContain('toolInput.frame === "iframe"');
     expect(html).toContain('"agentNative.frameOrigin"');
     expect(html).toContain('"agentNative.embeddedAppReady"');
+    expect(resource.csp?.connectDomains).toContain(
+      "https://analytics.example.com",
+    );
     expect(resource.csp?.frameDomains).toEqual([
       MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
       "https://analytics.example.com",

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -1123,7 +1123,11 @@ export function embedApp(
 </body>
 </html>`,
     csp: {
-      connectDomains: ["https://esm.sh", MCP_APP_REQUEST_ORIGIN_CSP_SOURCE],
+      connectDomains: [
+        "https://esm.sh",
+        MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
+        ...(options.frameDomains ?? []),
+      ],
       resourceDomains: [
         "https://esm.sh",
         MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,


### PR DESCRIPTION
## Summary\n- Include configured MCP app frame domains in wrapper connect CSP so Claude can fetch/transplant cross-app embed start URLs\n- Cover the CSP expansion in embed-app tests\n- Add a core patch changeset\n\n## Tests\n- pnpm --filter @agent-native/core exec vitest --run src/mcp/embed-app.spec.ts src/client/mcp-app-host.spec.ts src/mcp/build-server.spec.ts src/mcp/server.spec.ts\n- pnpm --filter @agent-native/core typecheck\n- pnpm --filter @agent-native/core build\n- pnpm --filter @agent-native/dispatch exec vitest --run src/server/lib/mcp-gateway.spec.ts src/actions/index.spec.ts