### PR TITLE
Bust MCP app shell cache

### DIFF
--- a/.changeset/mcp-app-shell-cache-bust.md
+++ b/.changeset/mcp-app-shell-cache-bust.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Bust MCP App shell resource caches so host CSP metadata refreshes after embed changes.

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -370,7 +370,7 @@ function safeUiSegment(value: string | undefined, fallback: string): string {
 
 // ChatGPT and Claude cache MCP App resource HTML by `ui://` URI. Bump this
 // when the shared shell changes in a way that must invalidate host caches.
-const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v23";
+const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v24";
 
 function legacyDefaultMcpAppUri(config: MCPConfig, actionName: string): string {
   const app = safeUiSegment(config.appId ?? config.name, "agent-native");

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -354,10 +354,10 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(echo.annotations?.["agent-native/producesOpenLink"]).toBe(true);
     expect(echo.description).toContain("Open in");
     expect(echo._meta?.["ui/resourceUri"]).toBe(
-      "ui://mail/echo-thing/shell-v23",
+      "ui://mail/echo-thing/shell-v24",
     );
     expect(echo._meta?.["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v23",
+      "ui://mail/echo-thing/shell-v24",
     );
     expect(echo._meta?.["openai/widgetAccessible"]).toBe(true);
     expect(echo._meta?.["openai/widgetCSP"]).toEqual({
@@ -368,7 +368,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         connectDomains: ["https://mail.agent-native.com"],
       },
       prefersBorder: true,
-      resourceUri: "ui://mail/echo-thing/shell-v23",
+      resourceUri: "ui://mail/echo-thing/shell-v24",
       visibility: ["model", "app"],
     });
   });
@@ -482,8 +482,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources.map((r: any) => r.uri)).toEqual(
       expect.arrayContaining([
-        "ui://mail/echo-thing/shell-v23",
-        "ui://mail/review-draft/shell-v23",
+        "ui://mail/echo-thing/shell-v24",
+        "ui://mail/review-draft/shell-v24",
       ]),
     );
   });
@@ -611,7 +611,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v23",
+        uri: "ui://mail/echo-thing/shell-v24",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -647,7 +647,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resourceTemplates).toEqual([
       expect.objectContaining({
-        uriTemplate: "ui://mail/echo-thing/shell-v23",
+        uriTemplate: "ui://mail/echo-thing/shell-v24",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -662,14 +662,14 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 6,
         method: "resources/read",
-        params: { uri: "ui://mail/echo-thing/shell-v23" },
+        params: { uri: "ui://mail/echo-thing/shell-v24" },
       },
       { headers: await mcpAppsAuthHeaders() },
     );
     expect(out.error).toBeUndefined();
     expect(out.result.contents).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v23",
+        uri: "ui://mail/echo-thing/shell-v24",
         mimeType: "text/html;profile=mcp-app",
         text: expect.stringContaining('data-action="echo-thing"'),
         _meta: expect.objectContaining({
@@ -678,6 +678,9 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
               connectDomains: ["https://mail.agent-native.com"],
             },
             prefersBorder: true,
+          },
+          "openai/widgetCSP": {
+            connect_domains: ["https://mail.agent-native.com"],
           },
           "openai/widgetDescription":
             "Review the echoed thing in an inline MCP App.",
@@ -744,7 +747,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v23",
+        uri: "ui://mail/custom-review/shell-v24",
         name: "custom-review",
       }),
     ]);
@@ -801,7 +804,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v23",
+        uri: "ui://mail/custom-review/shell-v24",
         name: "custom-review",
       }),
     ]);
@@ -858,7 +861,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v23?mode=compact#preview",
+        uri: "ui://mail/custom-review/shell-v24?mode=compact#preview",
         name: "custom-review",
       }),
     ]);
@@ -908,7 +911,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         "https://mail.agent-native.com/_agent-native/open?view=thing&id=thing-42&agentSidebar=closed",
     });
     expect(out.result._meta["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v23",
+      "ui://mail/echo-thing/shell-v24",
     );
     expect(out.result._meta["openai/widgetCSP"]).toEqual({
       connect_domains: ["https://mail.agent-native.com"],


### PR DESCRIPTION
## Summary
- bump the shared MCP App shell resource URI from shell-v23 to shell-v24 so Claude/ChatGPT refetch cached widget metadata
- strengthen MCP server tests to assert OpenAI widget CSP metadata is present on resource reads
- add a core patch changeset

## Tests
- pnpm --filter @agent-native/core exec vitest --run src/mcp/server.spec.ts src/mcp/embed-app.spec.ts src/mcp/build-server.spec.ts
- pnpm prep