### PR TITLE
Retry Dispatch target MCP embed handshakes

### DIFF
--- a/.changeset/dispatch-mcp-embed-retry.md
+++ b/.changeset/dispatch-mcp-embed-retry.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Retry transient target MCP handshakes when Dispatch pre-mints cross-app embeds.

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -210,6 +210,44 @@ describe("openGrantedDispatchMcpApp", () => {
     });
   });
 
+  it("retries transient target MCP connection failures while pre-minting embeds", async () => {
+    mocks.managerCallTool
+      .mockRejectedValueOnce(
+        new Error(
+          'MCP server "target" is not connected: The server did not complete the Streamable HTTP MCP handshake.',
+        ),
+      )
+      .mockResolvedValueOnce({
+        structuredContent: {
+          startUrl:
+            "http://localhost:8086/_agent-native/embed/start?ticket=remote",
+        },
+      });
+
+    const result = await runWithRequestContext(
+      {
+        userEmail: "owner@example.test",
+        requestOrigin: "http://localhost:8092",
+      },
+      () =>
+        openGrantedDispatchMcpApp({
+          app: "analytics",
+          path: "/dashboards",
+          embed: true,
+        }),
+    );
+
+    expect(mocks.managerConstructor).toHaveBeenCalledTimes(2);
+    expect(mocks.managerStart).toHaveBeenCalledTimes(2);
+    expect(mocks.managerStop).toHaveBeenCalledTimes(2);
+    expect(mocks.managerCallTool).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      app: "analytics",
+      embedStartUrl:
+        "http://localhost:8086/_agent-native/embed/start?ticket=remote",
+    });
+  });
+
   it("rejects Dispatch-owned extension routes on sibling apps", async () => {
     await expect(
       runWithRequestContext(

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -29,6 +29,7 @@ const DISPATCH_NAME = "Agent-Native Dispatch";
 const DISPATCH_DESCRIPTION =
   "Workspace control plane for extensions, agents, vault, integrations, approvals, and app routing.";
 const DISPATCH_COLOR = "#14B8A6";
+const TARGET_EMBED_SESSION_ATTEMPTS = 3;
 
 export interface DispatchMcpAccessibleApp {
   id: string;
@@ -364,6 +365,67 @@ function parseMcpToolTextResult(result: unknown): Record<string, unknown> {
   throw new Error("Target app did not return an embed session.");
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRetryableTargetMcpError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : String(error ?? "");
+  return /not connected|streamable http|handshake|failed to fetch|fetch failed|networkerror|econnrefused|enotfound|timed out|timeout|502|503|504/i.test(
+    message,
+  );
+}
+
+async function callTargetCreateEmbedSession(input: {
+  app: DispatchMcpAccessibleApp;
+  token: string;
+  url: string;
+  chrome?: "full" | "minimal";
+}): Promise<unknown> {
+  const serverId = "target";
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= TARGET_EMBED_SESSION_ATTEMPTS; attempt++) {
+    const manager = new McpClientManager({
+      servers: {
+        [serverId]: {
+          type: "http",
+          url: `${appBaseUrl(input.app)}/_agent-native/mcp`,
+          headers: {
+            Authorization: `Bearer ${input.token}`,
+          },
+        },
+      },
+    });
+    try {
+      await manager.start();
+      return await manager.callTool(
+        buildMcpToolName(serverId, "create_embed_session"),
+        {
+          url: input.url,
+          chrome: input.chrome ?? "full",
+        },
+      );
+    } catch (error) {
+      lastError = error;
+      if (
+        attempt >= TARGET_EMBED_SESSION_ATTEMPTS ||
+        !isRetryableTargetMcpError(error)
+      ) {
+        throw error;
+      }
+      await sleep(250 * attempt);
+    } finally {
+      await manager.stop();
+    }
+  }
+  throw lastError;
+}
+
 async function resolveDispatchEmbedTarget(input: {
   app?: string;
   url?: string;
@@ -490,49 +552,30 @@ export async function createGrantedDispatchMcpEmbedSession(input: {
     },
   );
 
-  const serverId = "target";
-  const manager = new McpClientManager({
-    servers: {
-      [serverId]: {
-        type: "http",
-        url: `${appBaseUrl(target.app)}/_agent-native/mcp`,
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      },
-    },
+  const result = await callTargetCreateEmbedSession({
+    app: target.app,
+    token,
+    url: target.url,
+    chrome: input.chrome,
   });
-  await manager.start();
-  try {
-    const result = await manager.callTool(
-      buildMcpToolName(serverId, "create_embed_session"),
-      {
-        url: target.url,
-        chrome: input.chrome ?? "full",
-      },
-    );
-    const parsed = parseMcpToolTextResult(result) as {
-      startUrl?: string;
-      targetPath?: string;
-      expiresAt?: number;
-    };
-    if (!parsed.startUrl) {
-      throw new Error("Target app did not return an embed start URL.");
-    }
-    const output: {
-      startUrl: string;
-      targetPath?: string;
-      expiresAt?: number;
-      app: string;
-    } = {
-      startUrl: parsed.startUrl,
-      app: target.app.id,
-    };
-    if (parsed.targetPath) output.targetPath = parsed.targetPath;
-    if (typeof parsed.expiresAt === "number")
-      output.expiresAt = parsed.expiresAt;
-    return output;
-  } finally {
-    await manager.stop();
+  const parsed = parseMcpToolTextResult(result) as {
+    startUrl?: string;
+    targetPath?: string;
+    expiresAt?: number;
+  };
+  if (!parsed.startUrl) {
+    throw new Error("Target app did not return an embed start URL.");
   }
+  const output: {
+    startUrl: string;
+    targetPath?: string;
+    expiresAt?: number;
+    app: string;
+  } = {
+    startUrl: parsed.startUrl,
+    app: target.app.id,
+  };
+  if (parsed.targetPath) output.targetPath = parsed.targetPath;
+  if (typeof parsed.expiresAt === "number") output.expiresAt = parsed.expiresAt;
+  return output;
 }


### PR DESCRIPTION
## Summary
- retry transient target MCP connection/handshake failures when Dispatch pre-mints cross-app embed sessions
- keep app-level target errors surfaced without retry masking
- add a Dispatch gateway regression test and changeset

## Tests
- pnpm --filter @agent-native/dispatch exec vitest --run src/server/lib/mcp-gateway.spec.ts src/actions/index.spec.ts
- pnpm --filter @agent-native/core test (rerun after unrelated Vitest teardown flake in full prep)
- pnpm --filter @agent-native/dispatch typecheck
- pnpm guards

Note: full pnpm prep had all tests passing but exited on an unrelated Vitest EnvironmentTeardownError in src/a2a/handlers.spec.ts; rerunning @agent-native/core test passed cleanly.