### PR TITLE
Fix Dispatch MCP org-signed embeds

### DIFF
--- a/.changeset/sharp-mcp-org-embeds.md
+++ b/.changeset/sharp-mcp-org-embeds.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Allow Dispatch-routed MCP app embeds to authenticate target apps with synced org A2A secrets.

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -1097,6 +1097,60 @@ function deriveStaticTokenIdentity(
   return { userEmail: owner, orgDomain: undefined };
 }
 
+function addSecretCandidate(
+  candidates: string[],
+  secret: string | null | undefined,
+): void {
+  const trimmed = secret?.trim();
+  if (!trimmed || candidates.includes(trimmed)) return;
+  candidates.push(trimmed);
+}
+
+async function verifyA2AJwtForMcp(
+  token: string,
+): Promise<Record<string, unknown> | null> {
+  const jose = await import("jose");
+  let unverifiedPayload: Record<string, unknown> | null = null;
+  try {
+    unverifiedPayload = jose.decodeJwt(token) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const candidateSecrets: string[] = [];
+  addSecretCandidate(candidateSecrets, process.env.A2A_SECRET);
+
+  const orgDomain =
+    typeof unverifiedPayload.org_domain === "string"
+      ? unverifiedPayload.org_domain
+      : undefined;
+  if (orgDomain) {
+    try {
+      const { getA2ASecretByDomain } = await import("../org/context.js");
+      addSecretCandidate(
+        candidateSecrets,
+        await getA2ASecretByDomain(orgDomain),
+      );
+    } catch {
+      // DB not ready or org lookup unavailable — fall back to other candidates.
+    }
+  }
+
+  for (const secret of candidateSecrets) {
+    try {
+      const { payload } = await jose.jwtVerify(
+        token,
+        new TextEncoder().encode(secret),
+      );
+      return payload as Record<string, unknown>;
+    } catch {
+      // Try the next candidate without exposing which secret matched.
+    }
+  }
+
+  return null;
+}
+
 /**
  * Verify the inbound auth header. Returns:
  *   - { authed: true, identity } when verified — `identity` is derived from
@@ -1159,7 +1213,7 @@ export async function verifyAuth(
       };
     }
   }
-  if (accessTokens.length === 0 && !hasA2ASecret) {
+  if (accessTokens.length === 0 && !hasA2ASecret && !token) {
     if (options.allowDevOpen === false) {
       return { authed: false };
     }
@@ -1176,62 +1230,63 @@ export async function verifyAuth(
 
   if (!token) return { authed: false };
 
-  // Try JWT via A2A_SECRET
-  if (hasA2ASecret) {
-    try {
-      const jose = await import("jose");
-      const { payload } = await jose.jwtVerify(
-        token,
-        new TextEncoder().encode(process.env.A2A_SECRET!),
-      );
+  // Try an A2A JWT via the shared A2A_SECRET first, then the caller org's
+  // synced A2A secret when the token carries org_domain.
+  const payload = await verifyA2AJwtForMcp(token);
+  if (payload) {
+    const tokenScope =
+      typeof payload.scope === "string" ? payload.scope : undefined;
+    if (tokenScope && tokenScope !== MCP_CONNECT_SCOPE) {
+      return { authed: false };
+    }
 
-      const tokenScope =
-        typeof payload.scope === "string" ? payload.scope : undefined;
-      if (tokenScope && tokenScope !== MCP_CONNECT_SCOPE) {
+    // Connect-minted tokens (scope === "mcp-connect") carry a random `jti`
+    // and are individually revocable. Only these tokens hit the revoke
+    // store — ordinary A2A delegation JWTs skip the DB lookup entirely so
+    // the hot path is unchanged. The signature was already
+    // cryptographically verified, so failing open here only widens the
+    // explicit-revoke gate, never the trust boundary.
+    if (tokenScope === MCP_CONNECT_SCOPE) {
+      if (typeof payload.jti !== "string" || !payload.jti) {
         return { authed: false };
       }
-
-      // Connect-minted tokens (scope === "mcp-connect") carry a random `jti`
-      // and are individually revocable. Only these tokens hit the revoke
-      // store — ordinary A2A delegation JWTs skip the DB lookup entirely so
-      // the hot path is unchanged. The revoke check FAILS OPEN on any
-      // store/DB error: a transient Neon WS drop must never lock every
-      // connected agent out. The signature was already cryptographically
-      // verified above, so failing open here only widens the explicit-revoke
-      // gate, never the trust boundary.
-      if (tokenScope === MCP_CONNECT_SCOPE) {
-        if (typeof payload.jti !== "string" || !payload.jti) {
+      const jti = payload.jti;
+      try {
+        const { isJtiRevoked, touchTokenUsed } =
+          await import("./connect-store.js");
+        if (await isJtiRevoked(jti)) {
           return { authed: false };
         }
-        const jti = payload.jti;
-        try {
-          const { isJtiRevoked, touchTokenUsed } =
-            await import("./connect-store.js");
-          if (await isJtiRevoked(jti)) {
-            return { authed: false };
-          }
-          // Best-effort usage telemetry — never blocks / throws.
-          void touchTokenUsed(jti);
-        } catch {
-          // Store import / lookup failed — fail open (see comment above).
-        }
+        // Best-effort usage telemetry — never blocks / throws.
+        void touchTokenUsed(jti);
+      } catch {
+        // Store import / lookup failed — fail open (see comment above).
       }
-
-      return {
-        authed: true,
-        identity: {
-          userEmail: typeof payload.sub === "string" ? payload.sub : undefined,
-          orgDomain:
-            typeof payload.org_domain === "string"
-              ? (payload.org_domain as string)
-              : undefined,
-        },
-        // Verified JWT (connect-minted or A2A delegation) — a real caller.
-        fullSurface: true,
-      };
-    } catch {
-      // Not a valid JWT — fall through to token check
     }
+
+    return {
+      authed: true,
+      identity: {
+        userEmail: typeof payload.sub === "string" ? payload.sub : undefined,
+        orgDomain:
+          typeof payload.org_domain === "string"
+            ? (payload.org_domain as string)
+            : undefined,
+      },
+      // Verified JWT (connect-minted or A2A delegation) — a real caller.
+      fullSurface: true,
+    };
+  }
+
+  if (accessTokens.length === 0 && !hasA2ASecret) {
+    if (options.allowDevOpen === false) {
+      return { authed: false };
+    }
+    return {
+      authed: true,
+      identity: deriveStaticTokenIdentity(ownerEmailHeader),
+      fullSurface: !!(ownerEmailHeader && ownerEmailHeader.trim()),
+    };
   }
 
   // Try ACCESS_TOKEN / ACCESS_TOKENS exact match. Static tokens carry no

--- a/packages/core/src/mcp/build-server.verify-auth.spec.ts
+++ b/packages/core/src/mcp/build-server.verify-auth.spec.ts
@@ -7,29 +7,37 @@ vi.mock("./builtin-tools.js", () => ({ getBuiltinCrossAppTools: () => ({}) }));
 
 const isJtiRevokedMock = vi.fn();
 const touchTokenUsedMock = vi.fn(async () => {});
+const getA2ASecretByDomainMock = vi.fn();
 vi.mock("./connect-store.js", () => ({
   MCP_CONNECT_SCOPE: "mcp-connect",
   isJtiRevoked: (...a: any[]) => isJtiRevokedMock(...a),
   touchTokenUsed: (...a: any[]) => touchTokenUsedMock(...a),
+}));
+vi.mock("../org/context.js", () => ({
+  getA2ASecretByDomain: (...a: any[]) => getA2ASecretByDomainMock(...a),
+  resolveOrgByDomain: vi.fn(async () => null),
 }));
 
 const { verifyAuth } = await import("./build-server.js");
 const { signMcpOAuthAccessToken } = await import("./oauth-token.js");
 
 const SECRET = "verify-auth-secret";
-const enc = new TextEncoder().encode(SECRET);
 
-async function sign(claims: Record<string, unknown>): Promise<string> {
+async function sign(
+  claims: Record<string, unknown>,
+  secret = SECRET,
+): Promise<string> {
   return new jose.SignJWT(claims)
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
     .setExpirationTime("1h")
-    .sign(enc);
+    .sign(new TextEncoder().encode(secret));
 }
 
 describe("verifyAuth — connect-token revoke check", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getA2ASecretByDomainMock.mockResolvedValue(null);
     process.env.A2A_SECRET = SECRET;
     delete process.env.BETTER_AUTH_SECRET;
     delete process.env.ACCESS_TOKEN;
@@ -47,6 +55,28 @@ describe("verifyAuth — connect-token revoke check", () => {
     expect(res.identity?.userEmail).toBe("a@example.com");
     expect(isJtiRevokedMock).not.toHaveBeenCalled();
     expect(touchTokenUsedMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts an ordinary A2A JWT signed with the caller org secret", async () => {
+    process.env.A2A_SECRET = "different-global-secret";
+    getA2ASecretByDomainMock.mockResolvedValue("org-a2a-secret");
+    const token = await sign(
+      { sub: "a@example.com", org_domain: "builder.io" },
+      "org-a2a-secret",
+    );
+
+    const res = await verifyAuth(`Bearer ${token}`, undefined, {
+      allowDevOpen: false,
+    });
+
+    expect(res.authed).toBe(true);
+    expect(res.identity).toEqual({
+      userEmail: "a@example.com",
+      orgDomain: "builder.io",
+    });
+    expect(res.fullSurface).toBe(true);
+    expect(getA2ASecretByDomainMock).toHaveBeenCalledWith("builder.io");
+    expect(isJtiRevokedMock).not.toHaveBeenCalled();
   });
 
   it("rejects identity-scoped SSO JWTs on the MCP endpoint", async () => {

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -368,7 +368,7 @@ describe("createGrantedDispatchMcpEmbedSession", () => {
     });
   });
 
-  it("prefers the shared A2A secret when minting cross-app MCP embed tokens", async () => {
+  it("uses the org A2A secret when minting cross-app MCP embed tokens", async () => {
     mocks.getOrgDomain.mockResolvedValue("builder.io");
     mocks.getOrgA2ASecret.mockResolvedValue("org-specific-secret");
 
@@ -389,6 +389,34 @@ describe("createGrantedDispatchMcpEmbedSession", () => {
       "owner@example.test",
       "builder.io",
       "org-specific-secret",
+      {
+        expiresIn: "5m",
+        preferGlobalSecret: false,
+      },
+    );
+  });
+
+  it("falls back to the shared A2A secret when no org secret is available", async () => {
+    mocks.getOrgDomain.mockResolvedValue("builder.io");
+    mocks.getOrgA2ASecret.mockResolvedValue(null);
+
+    await runWithRequestContext(
+      {
+        userEmail: "owner@example.test",
+        orgId: "org-1",
+        requestOrigin: "http://localhost:8092",
+      },
+      () =>
+        createGrantedDispatchMcpEmbedSession({
+          app: "analytics",
+          path: "/dashboards",
+        }),
+    );
+
+    expect(mocks.signA2AToken).toHaveBeenCalledWith(
+      "owner@example.test",
+      "builder.io",
+      undefined,
       {
         expiresIn: "5m",
         preferGlobalSecret: true,

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -545,10 +545,10 @@ export async function createGrantedDispatchMcpEmbedSession(input: {
     orgSecret ?? undefined,
     {
       expiresIn: "5m",
-      // Target MCP endpoints verify A2A JWTs with the deployment-wide
-      // A2A_SECRET. Prefer it for hosted cross-app embeds even when Dispatch
-      // also has an org-level secret available.
-      preferGlobalSecret: true,
+      // Prefer the synced org A2A secret when present because first-party
+      // production apps do not have to share the same deployment env secret.
+      // Fall back to the global A2A_SECRET for orgs that have not synced yet.
+      preferGlobalSecret: !orgSecret,
     },
   );
 


### PR DESCRIPTION
## Summary
- let MCP auth verify ordinary A2A JWTs with a synced org A2A secret, matching the A2A endpoint fallback
- have Dispatch sign cross-app MCP embed sessions with the org secret when available, falling back to global A2A_SECRET
- add regression coverage for org-signed MCP auth and Dispatch fallback signing

## Tests
- pnpm --filter @agent-native/core exec vitest --run src/mcp/build-server.verify-auth.spec.ts
- pnpm --filter @agent-native/dispatch exec vitest --run src/server/lib/mcp-gateway.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/dispatch typecheck
- pnpm --filter @agent-native/dispatch test
- pnpm --filter @agent-native/core test (first run hit Vitest teardown flake after all tests passed; rerun passed)
- pnpm prep