### PR TITLE
Address MCP embed and generation feedback

### DIFF
--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -34,6 +34,11 @@ can still use `npx @agent-native/core connect <url>`, which mints a per-user,
 scoped, revocable token from a logged-in browser session; no shared secret is
 copied.
 
+Claude and ChatGPT can cache custom connector tool/resource metadata. After
+changing MCP App metadata or the shared `embedApp()` shell, validate with a
+fresh tool call; if the host still behaves like the old descriptor, reconnect
+the Claude connector or rescan/review the ChatGPT connector.
+
 Once connected, every action that produces or lists a navigable resource SHOULD
 return a deep link from a `link` builder, so the external agent can surface an
 **"Open in <app> →"** link that drops the user back into the running UI at the
@@ -301,6 +306,11 @@ third-party frame. `open_app({ app, path, embed: true })` is the generic
 escape hatch for routes like full dashboards, filtered inboxes, calendar
 drafts, analyses, or extension pages, and should be used liberally when the
 full app is the clearest review/edit surface.
+
+For Dispatch, keep the single connector path first-class: the `open_app`
+resource CSP should include the exact origins of apps granted through Dispatch,
+not broad sources like `https:`. This lets Claude's transplant path fetch the
+signed target app HTML while keeping the connector's resource surface narrow.
 
 Host sizing rule: the MCP resource shell owns a bounded inline height and the
 embedded route should scroll internally. `embedApp({ height })` defaults to a

--- a/.changeset/chat-startup-retry.md
+++ b/.changeset/chat-startup-retry.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Retry transient agent-chat route-missing startup responses and harden Dispatch MCP embed fallback behavior.

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -205,6 +205,11 @@ That makes the same app surface available to every compatible host rather than b
 
 Claude Code and other CLI-first clients still receive the same resources and metadata when they support MCP Apps, but the deep link remains the reliable fallback when a host chooses not to render an iframe. In practice, every agent-native app should be authored with both: MCP Apps for inline review/edit in capable hosts, and `link` for universal round-tripping back to the full app.
 
+Claude and ChatGPT can cache tool and resource metadata for an existing custom
+connector. After changing MCP App metadata, verify with a fresh tool call; if
+the host still uses the old descriptor, reconnect the Claude connector or
+rescan/review the ChatGPT connector so it refreshes the catalog.
+
 ### First-class MCP App bridge {#mcp-app-bridge}
 
 MCP App embeds are route embeds, not separate mini-products. `embedApp()`
@@ -388,8 +393,11 @@ Keep the existing `link` builder even when adding `mcpApp`. CLI-only clients, ol
 
 `embedApp()` includes the MCP request origin in the resource CSP so the launcher
 can fetch and, when explicitly requested, frame the signed first-party app
-route. Only pass additional `frameDomains` for a custom MCP App that truly
-embeds a third-party player.
+route. Dispatch adds the exact origins for the granted apps to its `open_app`
+resource so a single Dispatch connector can inline Mail, Calendar, Slides, and
+the rest without allowing every HTTPS origin. Only pass additional frame or
+resource domains for a custom MCP App that truly embeds a third-party player or
+loads third-party assets.
 
 Inside those `embedApp()` routes, `sendToAgentChat()` is embed-aware.
 Auto-submitted prompts relay to the MCP host as `ui/update-model-context` plus

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -131,7 +131,10 @@ relay:
 
 `embedApp()` includes the MCP request origin in the resource CSP so the
 launcher can fetch and, when explicitly requested, frame the signed first-party
-route. Pass additional `frameDomains` only for custom third-party frames.
+route. Dispatch's `open_app` resource adds the exact origins for apps granted
+through Dispatch, which keeps the one-connector path narrow while still letting
+Claude/ChatGPT inline target app routes. Pass additional domains only for
+custom third-party frames or assets.
 
 Host-mediated open links keep the iframe from choosing its own browser target.
 Model context updates are opt-in and hidden from the user-facing transcript.

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -90,6 +90,12 @@ export interface ActionMcpAppCsp {
   baseUriDomains?: string[];
 }
 
+export type ActionMcpAppCspBuilder = (ctx: {
+  actionName: string;
+  appId?: string;
+  requestOrigin?: string;
+}) => ActionMcpAppCsp | Promise<ActionMcpAppCsp>;
+
 export interface ActionMcpAppPermissions {
   camera?: Record<string, never>;
   microphone?: Record<string, never>;
@@ -98,7 +104,7 @@ export interface ActionMcpAppPermissions {
 }
 
 export interface ActionMcpAppResourceMeta {
-  csp?: ActionMcpAppCsp;
+  csp?: ActionMcpAppCsp | ActionMcpAppCspBuilder;
   permissions?: ActionMcpAppPermissions;
   domain?: string;
   prefersBorder?: boolean;

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -132,7 +132,7 @@ export interface ActionMcpAppResourceConfig {
   mimeType?: typeof MCP_APP_MIME_TYPE;
   /** Extra resource/content metadata. `ui` is merged with the fields below. */
   _meta?: Record<string, unknown>;
-  csp?: ActionMcpAppCsp;
+  csp?: ActionMcpAppCsp | ActionMcpAppCspBuilder;
   permissions?: ActionMcpAppPermissions;
   domain?: string;
   prefersBorder?: boolean;

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -1406,6 +1406,74 @@ describe("createAgentChatAdapter", () => {
     expect(last.content.at(-1).text).toContain("did not start streaming");
   });
 
+  it("retries a transient missing agent-chat route on startup", async () => {
+    vi.useFakeTimers();
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const routeMissing = {
+      error: true,
+      status: 404,
+      message:
+        "Cannot find any route matching [POST] https://design.agent-native.com/_agent-native/agent-chat",
+    };
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        postCount += 1;
+        return postCount < 3
+          ? jsonResponse(routeMissing, 404)
+          : sseResponse([
+              { type: "text", text: "ready after route registration" },
+              { type: "done" },
+            ]);
+      }
+      if (url.includes("/runs/active")) {
+        return jsonResponse({ active: false, status: "idle" });
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-route-missing",
+      threadId: "thread-route-missing",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "please respond" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    const results = await promise;
+
+    expect(postCount).toBe(3);
+    expect(dispatchEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "agent-chat:run-error" }),
+    );
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toBe("ready after route registration");
+  });
+
   it("uses partial stream-ended text as history without keeping it visible", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("window", { dispatchEvent: vi.fn() });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -619,6 +619,12 @@ function retryDelay(attempt: number, abortSignal: AbortSignal): Promise<void> {
 function isRetryableStartupError(message: string): boolean {
   const msg = message.toLowerCase();
   if (
+    msg.includes("cannot find any route matching") &&
+    msg.includes("/_agent-native/agent-chat")
+  ) {
+    return true;
+  }
+  if (
     msg.includes("unauthorized") ||
     msg.includes("not authenticated") ||
     msg.includes("401") ||

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -50,6 +50,7 @@ export {
   MCP_APP_RESOURCE_URI_META_KEY,
   type ActionMcpAppConfig,
   type ActionMcpAppCsp,
+  type ActionMcpAppCspBuilder,
   type ActionMcpAppHtmlBuilder,
   type ActionMcpAppPermissions,
   type ActionMcpAppResourceConfig,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export {
   MCP_APP_RESOURCE_URI_META_KEY,
   type ActionMcpAppConfig,
   type ActionMcpAppCsp,
+  type ActionMcpAppCspBuilder,
   type ActionMcpAppHtmlBuilder,
   type ActionMcpAppPermissions,
   type ActionMcpAppResourceConfig,

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -377,7 +377,7 @@ function safeUiSegment(value: string | undefined, fallback: string): string {
 
 // ChatGPT and Claude cache MCP App resource HTML by `ui://` URI. Bump this
 // when the shared shell changes in a way that must invalidate host caches.
-const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v24";
+const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v25";
 
 function legacyDefaultMcpAppUri(config: MCPConfig, actionName: string): string {
   const app = safeUiSegment(config.appId ?? config.name, "agent-native");

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -24,6 +24,7 @@ import {
   MCP_APP_EXTENSION_ID,
   MCP_APP_MIME_TYPE,
   MCP_APP_RESOURCE_URI_META_KEY,
+  type ActionMcpAppCsp,
   type ActionMcpAppResourceConfig,
 } from "../action.js";
 import { MCP_APP_REQUEST_ORIGIN_CSP_SOURCE } from "./embed-app.js";
@@ -227,6 +228,12 @@ interface ResolvedMcpAppResource {
   _meta?: Record<string, unknown>;
 }
 
+interface McpAppResourceContext {
+  actionName: string;
+  appId?: string;
+  requestOrigin?: string;
+}
+
 function metadataObject(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -415,21 +422,21 @@ function expandRequestOriginSources(
 }
 
 function openAiWidgetCsp(
-  resource: ActionMcpAppResourceConfig,
+  cspConfig: ActionMcpAppCsp | undefined,
   requestMeta?: MCPRequestMeta,
 ): Record<string, string[]> | undefined {
-  if (!resource.csp) return undefined;
+  if (!cspConfig) return undefined;
   const csp: Record<string, string[]> = {};
   const connectDomains = expandRequestOriginSources(
-    resource.csp.connectDomains,
+    cspConfig.connectDomains,
     requestMeta,
   );
   const resourceDomains = expandRequestOriginSources(
-    resource.csp.resourceDomains,
+    cspConfig.resourceDomains,
     requestMeta,
   );
   const frameDomains = expandRequestOriginSources(
-    resource.csp.frameDomains,
+    cspConfig.frameDomains,
     requestMeta,
   );
   if (connectDomains?.length) csp.connect_domains = connectDomains;
@@ -440,6 +447,7 @@ function openAiWidgetCsp(
 
 function mcpAppUiMeta(
   resource: ActionMcpAppResourceConfig,
+  resolvedCsp: ActionMcpAppCsp | undefined,
   requestMeta?: MCPRequestMeta,
   description?: string,
 ): Record<string, unknown> | undefined {
@@ -452,23 +460,23 @@ function mcpAppUiMeta(
       ? (base.ui as Record<string, unknown>)
       : {};
   const ui: Record<string, unknown> = { ...existingUi };
-  if (resource.csp) {
+  if (resolvedCsp) {
     ui.csp = {
-      ...resource.csp,
+      ...resolvedCsp,
       connectDomains: expandRequestOriginSources(
-        resource.csp.connectDomains,
+        resolvedCsp.connectDomains,
         requestMeta,
       ),
       resourceDomains: expandRequestOriginSources(
-        resource.csp.resourceDomains,
+        resolvedCsp.resourceDomains,
         requestMeta,
       ),
       frameDomains: expandRequestOriginSources(
-        resource.csp.frameDomains,
+        resolvedCsp.frameDomains,
         requestMeta,
       ),
       baseUriDomains: expandRequestOriginSources(
-        resource.csp.baseUriDomains,
+        resolvedCsp.baseUriDomains,
         requestMeta,
       ),
     };
@@ -488,19 +496,29 @@ function mcpAppUiMeta(
   ) {
     base["openai/widgetPrefersBorder"] = resource.prefersBorder;
   }
-  const openAiCsp = openAiWidgetCsp(resource, requestMeta);
+  const openAiCsp = openAiWidgetCsp(resolvedCsp, requestMeta);
   if (openAiCsp && base["openai/widgetCSP"] == null) {
     base["openai/widgetCSP"] = openAiCsp;
   }
   return Object.keys(base).length > 0 ? base : undefined;
 }
 
-function resolveMcpAppResource(
+async function resolveMcpAppCsp(
+  resource: ActionMcpAppResourceConfig,
+  ctx: McpAppResourceContext,
+): Promise<ActionMcpAppCsp | undefined> {
+  if (!resource.csp) return undefined;
+  return typeof resource.csp === "function"
+    ? await resource.csp(ctx)
+    : resource.csp;
+}
+
+async function resolveMcpAppResource(
   config: MCPConfig,
   actionName: string,
   entry: ActionEntry,
   requestMeta?: MCPRequestMeta,
-): ResolvedMcpAppResource | null {
+): Promise<ResolvedMcpAppResource | null> {
   const resource = entry.mcpApp?.resource;
   if (!resource) return null;
   const baseUri =
@@ -508,7 +526,17 @@ function resolveMcpAppResource(
   const resolvedUri = versionMcpAppResourceUri(baseUri);
   if (!resolvedUri) return null;
   const description = resource.description ?? entry.tool.description;
-  const resourceMeta = mcpAppUiMeta(resource, requestMeta, description);
+  const resolvedCsp = await resolveMcpAppCsp(resource, {
+    actionName,
+    appId: config.appId,
+    requestOrigin: requestMeta?.origin,
+  });
+  const resourceMeta = mcpAppUiMeta(
+    resource,
+    resolvedCsp,
+    requestMeta,
+    description,
+  );
   return {
     uri: resolvedUri.uri,
     ...(resolvedUri.legacyUris ? { legacyUris: resolvedUri.legacyUris } : {}),
@@ -521,15 +549,19 @@ function resolveMcpAppResource(
   };
 }
 
-function getMcpAppResources(
+async function getMcpAppResources(
   config: MCPConfig,
   actions: Record<string, ActionEntry>,
   requestMeta?: MCPRequestMeta,
-): ResolvedMcpAppResource[] {
-  return Object.entries(actions).flatMap(([name, entry]) => {
-    const resource = resolveMcpAppResource(config, name, entry, requestMeta);
-    return resource ? [resource] : [];
-  });
+): Promise<ResolvedMcpAppResource[]> {
+  const resources = await Promise.all(
+    Object.entries(actions).map(([name, entry]) =>
+      resolveMcpAppResource(config, name, entry, requestMeta),
+    ),
+  );
+  return resources.filter((resource): resource is ResolvedMcpAppResource =>
+    Boolean(resource),
+  );
 }
 
 function renderMcpAppHtml(
@@ -714,10 +746,11 @@ export async function createMCPServerForRequest(
         ),
       )
     : visibleActions;
-  const mcpAppResources = compactMcpAppCatalog
-    ? getMcpAppResources(config, advertisedActions, requestMeta)
-    : [];
-  const supportsMcpApps = mcpAppResources.length > 0;
+  const supportsMcpApps =
+    compactMcpAppCatalog &&
+    Object.values(advertisedActions).some((entry) =>
+      Boolean(entry.mcpApp?.resource),
+    );
   const server = new Server(
     { name: config.name, version: config.version ?? "1.0.0" },
     {
@@ -772,54 +805,56 @@ export async function createMCPServerForRequest(
   // applies to the listing too.
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return withCallerContext(async () => {
-      const tools = Object.entries(advertisedActions).map(([name, entry]) => {
-        const hasLink = typeof entry.link === "function";
-        const mcpAppResource = resolveMcpAppResource(
-          config,
-          name,
-          entry,
-          requestMeta,
-        );
-        const rawToolMeta =
-          (entry.tool as any)._meta &&
-          typeof (entry.tool as any)._meta === "object" &&
-          !Array.isArray((entry.tool as any)._meta)
-            ? { ...((entry.tool as any)._meta as Record<string, unknown>) }
-            : {};
-        const toolMeta = {
-          ...rawToolMeta,
-          ...(mcpAppResource
-            ? {
-                ...openAiToolDescriptorMeta(mcpAppResource),
-                [MCP_APP_RESOURCE_URI_META_KEY]: mcpAppResource.uri,
-                ui: mcpAppToolUiMeta(
-                  mcpAppResource,
-                  entry.mcpApp?.visibility ??
-                    metadataObject(rawToolMeta.ui).visibility,
-                ),
-              }
-            : {}),
-        };
-        const baseDescription = entry.tool.description ?? name;
-        const annotations: Record<string, unknown> = {
-          readOnlyHint: entry.readOnly === true,
-          destructiveHint: entry.publicAgent?.isConsequential === true,
-          openWorldHint: false,
-        };
-        if (hasLink) annotations["agent-native/producesOpenLink"] = true;
-        return {
-          name,
-          description: hasLink
-            ? `${baseDescription} After calling, surface the returned "Open in … →" link to the user.`
-            : baseDescription,
-          inputSchema: entry.tool.parameters ?? {
-            type: "object" as const,
-            properties: {},
-          },
-          ...(Object.keys(toolMeta).length > 0 ? { _meta: toolMeta } : {}),
-          annotations,
-        };
-      });
+      const tools = await Promise.all(
+        Object.entries(advertisedActions).map(async ([name, entry]) => {
+          const hasLink = typeof entry.link === "function";
+          const mcpAppResource = await resolveMcpAppResource(
+            config,
+            name,
+            entry,
+            requestMeta,
+          );
+          const rawToolMeta =
+            (entry.tool as any)._meta &&
+            typeof (entry.tool as any)._meta === "object" &&
+            !Array.isArray((entry.tool as any)._meta)
+              ? { ...((entry.tool as any)._meta as Record<string, unknown>) }
+              : {};
+          const toolMeta = {
+            ...rawToolMeta,
+            ...(mcpAppResource
+              ? {
+                  ...openAiToolDescriptorMeta(mcpAppResource),
+                  [MCP_APP_RESOURCE_URI_META_KEY]: mcpAppResource.uri,
+                  ui: mcpAppToolUiMeta(
+                    mcpAppResource,
+                    entry.mcpApp?.visibility ??
+                      metadataObject(rawToolMeta.ui).visibility,
+                  ),
+                }
+              : {}),
+          };
+          const baseDescription = entry.tool.description ?? name;
+          const annotations: Record<string, unknown> = {
+            readOnlyHint: entry.readOnly === true,
+            destructiveHint: entry.publicAgent?.isConsequential === true,
+            openWorldHint: false,
+          };
+          if (hasLink) annotations["agent-native/producesOpenLink"] = true;
+          return {
+            name,
+            description: hasLink
+              ? `${baseDescription} After calling, surface the returned "Open in … →" link to the user.`
+              : baseDescription,
+            inputSchema: entry.tool.parameters ?? {
+              type: "object" as const,
+              properties: {},
+            },
+            ...(Object.keys(toolMeta).length > 0 ? { _meta: toolMeta } : {}),
+            annotations,
+          };
+        }),
+      );
 
       if (
         !compactMcpAppCatalog &&
@@ -921,7 +956,7 @@ export async function createMCPServerForRequest(
         const resultForClient = isMcpActionResult(result)
           ? result.text
           : result;
-        const mcpAppResource = resolveMcpAppResource(
+        const mcpAppResource = await resolveMcpAppResource(
           config,
           name,
           entry,
@@ -968,33 +1003,47 @@ export async function createMCPServerForRequest(
 
   if (supportsMcpApps) {
     server.setRequestHandler(ListResourcesRequestSchema, async () => {
-      return withCallerContext(async () => ({
-        resources: mcpAppResources.map((resource) => ({
-          uri: resource.uri,
-          name: resource.name,
-          ...(resource.title ? { title: resource.title } : {}),
-          ...(resource.description
-            ? { description: resource.description }
-            : {}),
-          mimeType: resource.mimeType,
-          ...(resource._meta ? { _meta: resource._meta } : {}),
-        })),
-      }));
+      return withCallerContext(async () => {
+        const mcpAppResources = await getMcpAppResources(
+          config,
+          advertisedActions,
+          requestMeta,
+        );
+        return {
+          resources: mcpAppResources.map((resource) => ({
+            uri: resource.uri,
+            name: resource.name,
+            ...(resource.title ? { title: resource.title } : {}),
+            ...(resource.description
+              ? { description: resource.description }
+              : {}),
+            mimeType: resource.mimeType,
+            ...(resource._meta ? { _meta: resource._meta } : {}),
+          })),
+        };
+      });
     });
 
     server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
-      return {
-        resourceTemplates: mcpAppResources.map((resource) => ({
-          uriTemplate: resource.uri,
-          name: resource.name,
-          ...(resource.title ? { title: resource.title } : {}),
-          ...(resource.description
-            ? { description: resource.description }
-            : {}),
-          mimeType: resource.mimeType,
-          ...(resource._meta ? { _meta: resource._meta } : {}),
-        })),
-      };
+      return withCallerContext(async () => {
+        const mcpAppResources = await getMcpAppResources(
+          config,
+          advertisedActions,
+          requestMeta,
+        );
+        return {
+          resourceTemplates: mcpAppResources.map((resource) => ({
+            uriTemplate: resource.uri,
+            name: resource.name,
+            ...(resource.title ? { title: resource.title } : {}),
+            ...(resource.description
+              ? { description: resource.description }
+              : {}),
+            mimeType: resource.mimeType,
+            ...(resource._meta ? { _meta: resource._meta } : {}),
+          })),
+        };
+      });
     });
 
     server.setRequestHandler(
@@ -1002,16 +1051,22 @@ export async function createMCPServerForRequest(
       async (request: any) => {
         return withCallerContext(async () => {
           const uri = request.params?.uri;
-          const found = Object.entries(advertisedActions)
-            .map(([name, entry]) => ({
+          const candidates = await Promise.all(
+            Object.entries(advertisedActions).map(async ([name, entry]) => ({
               actionName: name,
-              resource: resolveMcpAppResource(config, name, entry, requestMeta),
-            }))
-            .find(
-              (candidate) =>
-                candidate.resource?.uri === uri ||
-                candidate.resource?.legacyUris?.includes(uri),
-            );
+              resource: await resolveMcpAppResource(
+                config,
+                name,
+                entry,
+                requestMeta,
+              ),
+            })),
+          );
+          const found = candidates.find(
+            (candidate) =>
+              candidate.resource?.uri === uri ||
+              candidate.resource?.legacyUris?.includes(uri),
+          );
           if (!found?.resource) {
             throw new Error(`MCP App resource not found: ${uri}`);
           }

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -354,17 +354,17 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(echo.annotations?.["agent-native/producesOpenLink"]).toBe(true);
     expect(echo.description).toContain("Open in");
     expect(echo._meta?.["ui/resourceUri"]).toBe(
-      "ui://mail/echo-thing/shell-v24",
+      "ui://mail/echo-thing/shell-v25",
     );
     expect(echo._meta?.["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v24",
+      "ui://mail/echo-thing/shell-v25",
     );
     expect(echo._meta?.["openai/widgetAccessible"]).toBe(true);
     expect(echo._meta?.["openai/widgetCSP"]).toEqual({
       connect_domains: ["https://mail.agent-native.com"],
     });
     expect(echo._meta?.ui).toEqual({
-      resourceUri: "ui://mail/echo-thing/shell-v24",
+      resourceUri: "ui://mail/echo-thing/shell-v25",
       visibility: ["model", "app"],
     });
   });
@@ -478,8 +478,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources.map((r: any) => r.uri)).toEqual(
       expect.arrayContaining([
-        "ui://mail/echo-thing/shell-v24",
-        "ui://mail/review-draft/shell-v24",
+        "ui://mail/echo-thing/shell-v25",
+        "ui://mail/review-draft/shell-v25",
       ]),
     );
   });
@@ -607,7 +607,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v24",
+        uri: "ui://mail/echo-thing/shell-v25",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -643,7 +643,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resourceTemplates).toEqual([
       expect.objectContaining({
-        uriTemplate: "ui://mail/echo-thing/shell-v24",
+        uriTemplate: "ui://mail/echo-thing/shell-v25",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -658,14 +658,14 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 6,
         method: "resources/read",
-        params: { uri: "ui://mail/echo-thing/shell-v24" },
+        params: { uri: "ui://mail/echo-thing/shell-v25" },
       },
       { headers: await mcpAppsAuthHeaders() },
     );
     expect(out.error).toBeUndefined();
     expect(out.result.contents).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v24",
+        uri: "ui://mail/echo-thing/shell-v25",
         mimeType: "text/html;profile=mcp-app",
         text: expect.stringContaining('data-action="echo-thing"'),
         _meta: expect.objectContaining({
@@ -776,7 +776,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 37,
         method: "resources/read",
-        params: { uri: "ui://mail/dynamic-review/shell-v24" },
+        params: { uri: "ui://mail/dynamic-review/shell-v25" },
       },
       { headers: await mcpAppsAuthHeaders(), config: dynamicCspConfig },
     );
@@ -861,7 +861,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v24",
+        uri: "ui://mail/custom-review/shell-v25",
         name: "custom-review",
       }),
     ]);
@@ -918,7 +918,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v24",
+        uri: "ui://mail/custom-review/shell-v25",
         name: "custom-review",
       }),
     ]);
@@ -975,7 +975,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v24?mode=compact#preview",
+        uri: "ui://mail/custom-review/shell-v25?mode=compact#preview",
         name: "custom-review",
       }),
     ]);
@@ -1025,7 +1025,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         "https://mail.agent-native.com/_agent-native/open?view=thing&id=thing-42&agentSidebar=closed",
     });
     expect(out.result._meta["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v24",
+      "ui://mail/echo-thing/shell-v25",
     );
     expect(out.result._meta["openai/widgetCSP"]).toEqual({
       connect_domains: ["https://mail.agent-native.com"],

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -689,6 +689,124 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     );
   });
 
+  it("resolves function-valued MCP App CSP across tools and resources", async () => {
+    const dynamicCspCalls: any[] = [];
+    const dynamicCspConfig = {
+      ...config,
+      actions: {
+        "dynamic-review": {
+          tool: {
+            description: "Review with dynamic CSP",
+          },
+          run: async () => ({ ok: true }),
+          mcpApp: {
+            resource: {
+              title: "Dynamic review",
+              html: "<!doctype html><html><body>Dynamic</body></html>",
+              csp: async (ctx: any) => {
+                dynamicCspCalls.push(ctx);
+                return {
+                  connectDomains: ["$requestOrigin", "https://api.example.com"],
+                  resourceDomains: ["https://cdn.example.com"],
+                  frameDomains: ["https://frame.example.com"],
+                  baseUriDomains: ["https://base.example.com"],
+                };
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const tools = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 34,
+        method: "tools/list",
+        params: {},
+      },
+      { headers: await mcpAppsAuthHeaders(), config: dynamicCspConfig },
+    );
+    const tool = tools.result.tools.find(
+      (t: any) => t.name === "dynamic-review",
+    );
+    expect(tool._meta["openai/widgetCSP"]).toEqual({
+      connect_domains: [
+        "https://mail.agent-native.com",
+        "https://api.example.com",
+      ],
+      resource_domains: ["https://cdn.example.com"],
+      frame_domains: ["https://frame.example.com"],
+    });
+
+    const list = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 35,
+        method: "resources/list",
+        params: {},
+      },
+      { headers: await mcpAppsAuthHeaders(), config: dynamicCspConfig },
+    );
+    expect(list.result.resources[0]._meta.ui.csp).toEqual({
+      connectDomains: [
+        "https://mail.agent-native.com",
+        "https://api.example.com",
+      ],
+      resourceDomains: ["https://cdn.example.com"],
+      frameDomains: ["https://frame.example.com"],
+      baseUriDomains: ["https://base.example.com"],
+    });
+
+    const templates = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 36,
+        method: "resources/templates/list",
+        params: {},
+      },
+      { headers: await mcpAppsAuthHeaders(), config: dynamicCspConfig },
+    );
+    expect(templates.result.resourceTemplates[0]._meta.ui.csp).toEqual(
+      list.result.resources[0]._meta.ui.csp,
+    );
+
+    const read = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 37,
+        method: "resources/read",
+        params: { uri: "ui://mail/dynamic-review/shell-v24" },
+      },
+      { headers: await mcpAppsAuthHeaders(), config: dynamicCspConfig },
+    );
+    expect(read.result.contents[0]._meta.ui.csp).toEqual(
+      list.result.resources[0]._meta.ui.csp,
+    );
+
+    const call = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 38,
+        method: "tools/call",
+        params: { name: "dynamic-review", arguments: {} },
+      },
+      { headers: await mcpAppsAuthHeaders(), config: dynamicCspConfig },
+    );
+    expect(call.result._meta["openai/widgetCSP"]).toEqual(
+      tool._meta["openai/widgetCSP"],
+    );
+    expect(dynamicCspCalls).toEqual(
+      expect.arrayContaining([
+        {
+          actionName: "dynamic-review",
+          appId: "mail",
+          requestOrigin: "https://mail.agent-native.com",
+        },
+      ]),
+    );
+  });
+
   it("keeps legacy unversioned MCP App resource reads working", async () => {
     const out = await callWeb(
       {

--- a/packages/core/src/server/embed-route.spec.ts
+++ b/packages/core/src/server/embed-route.spec.ts
@@ -159,6 +159,27 @@ describe("createEmbedStartRouteHandler", () => {
     expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
   });
 
+  it("allows opaque sandboxed MCP app frames to fetch embed start redirects", async () => {
+    consumeEmbedSessionTicket.mockResolvedValue({
+      ownerEmail: "steve@example.com",
+      orgId: "builder",
+      targetPath: "/inbox",
+      scope: "full",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const handler = createEmbedStartRouteHandler();
+
+    const res: Response = await handler(
+      fakeEvent("GET", { ticket: "ticket-123" }, { origin: "null" }),
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("null");
+    expect(res.headers.get("Access-Control-Expose-Headers")).toBe("Location");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+  });
+
   it("preserves the MCP chat bridge flag on the signed app route", async () => {
     consumeEmbedSessionTicket.mockResolvedValue({
       ownerEmail: "steve@example.com",

--- a/packages/core/src/server/embed-route.ts
+++ b/packages/core/src/server/embed-route.ts
@@ -21,7 +21,7 @@ import {
   MCP_APP_CHAT_BRIDGE_QUERY_PARAM,
 } from "../shared/embed-auth.js";
 import {
-  isClaudeMcpContentOrigin,
+  isMcpEmbedCorsOrigin,
   MCP_EMBED_CORS_ALLOW_HEADERS,
 } from "../shared/mcp-embed-headers.js";
 import { withCollapsedAgentSidebarParam } from "../shared/agent-sidebar-url.js";
@@ -84,7 +84,7 @@ function setEmbedStartResponseHeaders(event: H3Event): void {
 
 function embedStartCorsOrigin(event: H3Event): string | null {
   const origin = getHeader(event, "origin");
-  return isClaudeMcpContentOrigin(origin) ? origin : null;
+  return isMcpEmbedCorsOrigin(origin) ? origin : null;
 }
 
 function embedStartResponseHeaders(

--- a/packages/core/src/server/security-headers.spec.ts
+++ b/packages/core/src/server/security-headers.spec.ts
@@ -129,4 +129,29 @@ describe("security headers middleware", () => {
     expect(headers.get("Vary")).toBe("Origin");
     vi.unstubAllEnvs();
   });
+
+  it("allows opaque sandboxed MCP app frames to fetch embed-token page HTML", () => {
+    headers.clear();
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("OAUTH_STATE_SECRET", "embed-test-secret");
+    const token = signEmbedSessionToken({
+      ownerEmail: "user@example.test",
+      targetPath: "/inbox",
+      ttlSeconds: 60,
+    });
+
+    const handler = createSecurityHeadersMiddleware();
+    handler({
+      path: "/inbox",
+      query: { __an_embed_token: token },
+      url: { protocol: "https:" },
+      headers: new Headers({ origin: "null" }),
+      node: { req: { headers: {} } },
+    });
+
+    expect(headers.get("Access-Control-Allow-Origin")).toBe("null");
+    expect(headers.get("Access-Control-Allow-Credentials")).toBeUndefined();
+    expect(headers.get("Vary")).toBe("Origin");
+    vi.unstubAllEnvs();
+  });
 });

--- a/packages/core/src/server/security-headers.ts
+++ b/packages/core/src/server/security-headers.ts
@@ -53,7 +53,7 @@
 import { defineEventHandler, getHeader, setResponseHeader } from "h3";
 import { requestHasEmbedAuthMarker } from "./embed-session.js";
 import {
-  isClaudeMcpContentOrigin,
+  isMcpEmbedCorsOrigin,
   MCP_EMBED_CORS_ALLOW_HEADERS,
 } from "../shared/mcp-embed-headers.js";
 
@@ -113,7 +113,7 @@ export function createSecurityHeadersMiddleware() {
       "Cross-Origin-Resource-Policy",
       embedFrameRequest ? "cross-origin" : "same-site",
     );
-    if (embedFrameRequest && isClaudeMcpContentOrigin(requestOrigin)) {
+    if (embedFrameRequest && isMcpEmbedCorsOrigin(requestOrigin)) {
       setResponseHeader(event, "Access-Control-Allow-Origin", requestOrigin);
       setResponseHeader(event, "Vary", "Origin");
       setResponseHeader(

--- a/packages/dispatch/src/actions/open_app.spec.ts
+++ b/packages/dispatch/src/actions/open_app.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listGrantedDispatchMcpAppOrigins: vi.fn(),
+  openGrantedDispatchMcpApp: vi.fn(),
+}));
+
+vi.mock("../server/lib/mcp-gateway.js", () => ({
+  listGrantedDispatchMcpAppOrigins: mocks.listGrantedDispatchMcpAppOrigins,
+  openGrantedDispatchMcpApp: mocks.openGrantedDispatchMcpApp,
+}));
+
+import openAppAction from "./open_app.js";
+
+describe("open_app MCP App metadata", () => {
+  it("uses exact granted app origins instead of broad HTTPS CSP", async () => {
+    mocks.listGrantedDispatchMcpAppOrigins.mockResolvedValue([
+      "https://dispatch.agent-native.com",
+      "https://mail.agent-native.com",
+      "https://calendar.agent-native.com",
+    ]);
+
+    const cspBuilder = openAppAction.mcpApp?.resource.csp;
+    expect(typeof cspBuilder).toBe("function");
+
+    const csp = await (cspBuilder as any)({
+      actionName: "open_app",
+      appId: "dispatch",
+      requestOrigin: "https://dispatch.agent-native.com",
+    });
+
+    expect(csp.connectDomains).toEqual([
+      "https://esm.sh",
+      "$requestOrigin",
+      "https://mail.agent-native.com",
+      "https://calendar.agent-native.com",
+      "http://localhost:*",
+      "http://127.0.0.1:*",
+    ]);
+    expect(csp.resourceDomains).toEqual(csp.connectDomains);
+    expect(csp.frameDomains).toEqual([
+      "$requestOrigin",
+      "https://mail.agent-native.com",
+      "https://calendar.agent-native.com",
+      "http://localhost:*",
+      "http://127.0.0.1:*",
+    ]);
+    expect(csp.baseUriDomains).toEqual(csp.frameDomains);
+    expect(JSON.stringify(csp)).not.toContain('"https:"');
+  });
+});

--- a/packages/dispatch/src/actions/open_app.ts
+++ b/packages/dispatch/src/actions/open_app.ts
@@ -1,6 +1,15 @@
-import { defineAction, embedApp } from "@agent-native/core";
+import {
+  defineAction,
+  embedApp,
+  MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
+  type ActionMcpAppCsp,
+  type ActionMcpAppCspBuilder,
+} from "@agent-native/core";
 import { z } from "zod";
-import { openGrantedDispatchMcpApp } from "../server/lib/mcp-gateway.js";
+import {
+  listGrantedDispatchMcpAppOrigins,
+  openGrantedDispatchMcpApp,
+} from "../server/lib/mcp-gateway.js";
 
 const deepLinkParam = z.union([z.string(), z.number(), z.boolean()]);
 const openAppSchema = z
@@ -37,6 +46,34 @@ const openAppSchema = z
     path: ["view"],
   });
 
+const localDevFrameSources = ["http://localhost:*", "http://127.0.0.1:*"];
+
+const dispatchOpenAppCsp: ActionMcpAppCspBuilder = async (
+  ctx,
+): Promise<ActionMcpAppCsp> => {
+  const appOrigins = (await listGrantedDispatchMcpAppOrigins()).filter(
+    (origin) => origin !== ctx.requestOrigin,
+  );
+  const routeSources = [
+    MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,
+    ...appOrigins,
+    ...localDevFrameSources,
+  ];
+  return {
+    connectDomains: ["https://esm.sh", ...routeSources],
+    resourceDomains: ["https://esm.sh", ...routeSources],
+    frameDomains: routeSources,
+    baseUriDomains: routeSources,
+  };
+};
+
+const openAppResource = embedApp({
+  title: "Open app",
+  description: "Render the requested granted app route inline.",
+  iframeTitle: "Dispatch MCP app",
+  openLabel: "Open app",
+});
+
 export default defineAction({
   description:
     'Build a deep link or embeddable app route/component route for an app available through Dispatch MCP. Use app "dispatch" for Dispatch extension/tool pages. No side effects; surface the returned Open link to the user.',
@@ -56,12 +93,9 @@ export default defineAction({
     };
   },
   mcpApp: {
-    resource: embedApp({
-      title: "Open app",
-      description: "Render the requested granted app route inline.",
-      iframeTitle: "Dispatch MCP app",
-      openLabel: "Open app",
-      frameDomains: ["https:", "http://localhost:*", "http://127.0.0.1:*"],
-    }),
+    resource: {
+      ...openAppResource,
+      csp: dispatchOpenAppCsp,
+    },
   },
 });

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -211,6 +211,7 @@ describe("openGrantedDispatchMcpApp", () => {
   });
 
   it("retries transient target MCP connection failures while pre-minting embeds", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
     mocks.managerCallTool
       .mockRejectedValueOnce(
         new Error(
@@ -246,6 +247,38 @@ describe("openGrantedDispatchMcpApp", () => {
       embedStartUrl:
         "http://localhost:8086/_agent-native/embed/start?ticket=remote",
     });
+    randomSpy.mockRestore();
+  });
+
+  it("returns the normal open URL when embed preminting fails", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mocks.managerCallTool.mockRejectedValueOnce(
+      new Error("Target app did not return an embed session."),
+    );
+
+    const result = await runWithRequestContext(
+      {
+        userEmail: "owner@example.test",
+        requestOrigin: "http://localhost:8092",
+      },
+      () =>
+        openGrantedDispatchMcpApp({
+          app: "analytics",
+          path: "/dashboards",
+          embed: true,
+          chrome: "minimal",
+        }),
+    );
+
+    expect(result).toEqual({
+      app: "analytics",
+      path: "/dashboards",
+      url: "http://localhost:8086/dashboards",
+      embed: true,
+      chrome: "minimal",
+    });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it("rejects Dispatch-owned extension routes on sibling apps", async () => {
@@ -422,6 +455,85 @@ describe("createGrantedDispatchMcpEmbedSession", () => {
         preferGlobalSecret: true,
       },
     );
+  });
+
+  it("falls back to the shared A2A secret when org signing inputs are incomplete", async () => {
+    mocks.getOrgDomain.mockResolvedValue(null);
+    mocks.getOrgA2ASecret.mockResolvedValue("org-specific-secret");
+
+    await runWithRequestContext(
+      {
+        userEmail: "owner@example.test",
+        orgId: "org-1",
+        requestOrigin: "http://localhost:8092",
+      },
+      () =>
+        createGrantedDispatchMcpEmbedSession({
+          app: "analytics",
+          path: "/dashboards",
+        }),
+    );
+
+    expect(mocks.signA2AToken).toHaveBeenCalledWith(
+      "owner@example.test",
+      undefined,
+      undefined,
+      {
+        expiresIn: "5m",
+        preferGlobalSecret: true,
+      },
+    );
+  });
+
+  it("does not retry permanent target MCP errors", async () => {
+    mocks.managerCallTool.mockRejectedValueOnce(
+      new Error(
+        'MCP server "target" is not connected: The MCP server rejected the request.',
+      ),
+    );
+
+    await expect(
+      runWithRequestContext(
+        {
+          userEmail: "owner@example.test",
+          requestOrigin: "http://localhost:8092",
+        },
+        () =>
+          createGrantedDispatchMcpEmbedSession({
+            app: "analytics",
+            path: "/dashboards",
+          }),
+      ),
+    ).rejects.toThrow(/rejected the request/);
+    expect(mocks.managerConstructor).toHaveBeenCalledTimes(1);
+    expect(mocks.managerCallTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let stop failures mask target MCP errors", async () => {
+    mocks.managerCallTool.mockRejectedValueOnce(
+      new Error("Target app returned a permanent auth error."),
+    );
+    mocks.managerStop.mockRejectedValueOnce(new Error("stop failed"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(
+      runWithRequestContext(
+        {
+          userEmail: "owner@example.test",
+          requestOrigin: "http://localhost:8092",
+        },
+        () =>
+          createGrantedDispatchMcpEmbedSession({
+            app: "analytics",
+            path: "/dashboards",
+          }),
+      ),
+    ).rejects.toThrow(/permanent auth error/);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[dispatch] Failed to stop target MCP client:",
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
   });
 
   it("surfaces target MCP embed-session errors", async () => {

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -73,6 +73,7 @@ vi.mock("@agent-native/core/mcp-client", () => ({
 import {
   createGrantedDispatchMcpEmbedSession,
   listGrantedDispatchMcpApps,
+  listGrantedDispatchMcpAppOrigins,
   openGrantedDispatchMcpApp,
 } from "./mcp-gateway.js";
 import { runWithRequestContext } from "@agent-native/core/server";
@@ -145,6 +146,42 @@ describe("Dispatch MCP gateway app discovery", () => {
     );
 
     expect(apps.map((app) => app.id)).toEqual(["dispatch"]);
+  });
+
+  it("returns deduped origins for granted Dispatch MCP apps only", async () => {
+    mocks.discoverAgents.mockResolvedValue([
+      analyticsAgent,
+      {
+        ...analyticsAgent,
+        id: "analytics-copy",
+        name: "Analytics Copy",
+      },
+      {
+        id: "mail",
+        name: "Mail",
+        description: "Mail",
+        url: "https://mail.agent-native.com/inbox",
+        color: "#2563EB",
+      },
+    ]);
+    mocks.getUserSetting.mockResolvedValue({
+      mode: "selected-apps",
+      selectedAppIds: ["dispatch", "analytics", "mail"],
+    });
+
+    const origins = await runWithRequestContext(
+      {
+        userEmail: "owner@example.test",
+        requestOrigin: "http://localhost:8092",
+      },
+      () => listGrantedDispatchMcpAppOrigins(),
+    );
+
+    expect(origins).toEqual([
+      "http://localhost:8092",
+      "http://localhost:8086",
+      "https://mail.agent-native.com",
+    ]);
   });
 });
 

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -238,6 +238,11 @@ export async function listGrantedDispatchMcpApps(): Promise<
   return apps.filter((app) => app.granted);
 }
 
+export async function listGrantedDispatchMcpAppOrigins(): Promise<string[]> {
+  const apps = await listGrantedDispatchMcpApps();
+  return Array.from(new Set(apps.map((app) => appOrigin(app))));
+}
+
 export async function resolveGrantedDispatchMcpApp(
   app: string,
 ): Promise<DispatchMcpAccessibleApp> {

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -572,9 +572,10 @@ export async function createGrantedDispatchMcpEmbedSession(input: {
   const usableOrgDomain =
     typeof orgDomain === "string" && orgDomain.trim().length > 0;
   const useOrgSigning = usableOrgDomain && usableOrgSecret;
+  const signedOrgDomain = usableOrgDomain ? orgDomain.trim() : undefined;
   const token = await signA2AToken(
     userEmail,
-    useOrgSigning ? orgDomain.trim() : undefined,
+    signedOrgDomain,
     useOrgSigning ? orgSecret.trim() : undefined,
     {
       expiresIn: "5m",

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -30,6 +30,7 @@ const DISPATCH_DESCRIPTION =
   "Workspace control plane for extensions, agents, vault, integrations, approvals, and app routing.";
 const DISPATCH_COLOR = "#14B8A6";
 const TARGET_EMBED_SESSION_ATTEMPTS = 3;
+const TARGET_EMBED_SESSION_RETRY_BASE_MS = 250;
 
 export interface DispatchMcpAccessibleApp {
   id: string;
@@ -322,13 +323,23 @@ export async function openGrantedDispatchMcpApp(input: {
         params: input.params,
       });
   const url = `${appBaseUrl(target)}${relUrl}`;
-  const embedSession = input.embed
-    ? await createGrantedDispatchMcpEmbedSession({
+  let embedSession: Awaited<
+    ReturnType<typeof createGrantedDispatchMcpEmbedSession>
+  > | null = null;
+  if (input.embed) {
+    try {
+      embedSession = await createGrantedDispatchMcpEmbedSession({
         app: target.id,
         url,
         chrome: input.chrome,
-      })
-    : null;
+      });
+    } catch (error) {
+      console.warn(
+        `[dispatch] Could not pre-mint MCP embed session for ${target.id}:`,
+        error,
+      );
+    }
+  }
   return {
     app: target.id,
     ...(view ? { view } : {}),
@@ -376,9 +387,22 @@ function isRetryableTargetMcpError(error: unknown): boolean {
       : typeof error === "string"
         ? error
         : String(error ?? "");
-  return /not connected|streamable http|handshake|failed to fetch|fetch failed|networkerror|econnrefused|enotfound|timed out|timeout|502|503|504/i.test(
+  if (
+    /rejected the request|unauthorized|forbidden|401|403|404|405|html/i.test(
+      message,
+    )
+  ) {
+    return false;
+  }
+  return /streamable http|handshake|failed to fetch|fetch failed|networkerror|econnrefused|enotfound|timed out|timeout|502|503|504/i.test(
     message,
   );
+}
+
+function targetMcpRetryDelay(attempt: number): number {
+  const base =
+    TARGET_EMBED_SESSION_RETRY_BASE_MS * Math.pow(2, Math.max(0, attempt - 1));
+  return base + Math.floor(Math.random() * 100);
 }
 
 async function callTargetCreateEmbedSession(input: {
@@ -388,8 +412,7 @@ async function callTargetCreateEmbedSession(input: {
   chrome?: "full" | "minimal";
 }): Promise<unknown> {
   const serverId = "target";
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= TARGET_EMBED_SESSION_ATTEMPTS; attempt++) {
+  for (let attempt = 1; ; attempt += 1) {
     const manager = new McpClientManager({
       servers: {
         [serverId]: {
@@ -411,19 +434,19 @@ async function callTargetCreateEmbedSession(input: {
         },
       );
     } catch (error) {
-      lastError = error;
       if (
         attempt >= TARGET_EMBED_SESSION_ATTEMPTS ||
         !isRetryableTargetMcpError(error)
       ) {
         throw error;
       }
-      await sleep(250 * attempt);
+      await sleep(targetMcpRetryDelay(attempt));
     } finally {
-      await manager.stop();
+      await manager.stop().catch((stopError) => {
+        console.warn("[dispatch] Failed to stop target MCP client:", stopError);
+      });
     }
   }
-  throw lastError;
 }
 
 async function resolveDispatchEmbedTarget(input: {
@@ -539,16 +562,21 @@ export async function createGrantedDispatchMcpEmbedSession(input: {
         getOrgA2ASecret(orgId).catch(() => null),
       ])
     : [null, null];
+  const usableOrgSecret =
+    typeof orgSecret === "string" && orgSecret.trim().length > 0;
+  const usableOrgDomain =
+    typeof orgDomain === "string" && orgDomain.trim().length > 0;
+  const useOrgSigning = usableOrgDomain && usableOrgSecret;
   const token = await signA2AToken(
     userEmail,
-    orgDomain ?? undefined,
-    orgSecret ?? undefined,
+    useOrgSigning ? orgDomain.trim() : undefined,
+    useOrgSigning ? orgSecret.trim() : undefined,
     {
       expiresIn: "5m",
       // Prefer the synced org A2A secret when present because first-party
       // production apps do not have to share the same deployment env secret.
       // Fall back to the global A2A_SECRET for orgs that have not synced yet.
-      preferGlobalSecret: !orgSecret,
+      preferGlobalSecret: !useOrgSigning,
     },
   );
 

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -290,25 +290,19 @@ export default function Home() {
                   <polyline points="12 5 19 12 12 19" />
                 </svg>
               </a>
-              <a
-                href="https://github.com/BuilderIO/agent-native"
-                target="_blank"
-                rel="noopener noreferrer"
+              <Link
+                prefetch="render"
+                to="/docs"
                 className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
                 onClick={() =>
-                  trackEvent("click cta", { label: "github", location: "hero" })
+                  trackEvent("click cta", {
+                    label: "view_docs",
+                    location: "hero",
+                  })
                 }
               >
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
-                  <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
-                </svg>
-                GitHub
-              </a>
+                View the Docs
+              </Link>
             </div>
 
             <TerminalCommand />

--- a/templates/calendar/app/pages/BookingPage.tsx
+++ b/templates/calendar/app/pages/BookingPage.tsx
@@ -55,7 +55,7 @@ function BookingPageShell({
     >
       <StarfieldBackground className="fixed inset-0 opacity-25 dark:opacity-60" />
       <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(ellipse_at_center,hsl(var(--background)/0.35)_0%,hsl(var(--background)/0.88)_72%)]" />
-      <div className="relative z-10">{children}</div>
+      <div className="relative z-10 flow-root">{children}</div>
     </div>
   );
 }

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -334,8 +334,12 @@ export default function DesignEditor() {
 
   const { session } = useSession();
 
-  useEffect(() => clearGenerationCompleteTimer, [clearGenerationCompleteTimer]);
-  useEffect(() => clearAutoRetryTimer, [clearAutoRetryTimer]);
+  useEffect(() => {
+    return () => clearGenerationCompleteTimer();
+  }, [clearGenerationCompleteTimer]);
+  useEffect(() => {
+    return () => clearAutoRetryTimer();
+  }, [clearAutoRetryTimer]);
 
   // Current user info for collaborative presence
   const currentUser: CollabUser | undefined = session?.email

--- a/templates/images/actions/get-image-generation-config.ts
+++ b/templates/images/actions/get-image-generation-config.ts
@@ -31,12 +31,14 @@ export default defineAction({
       readAppState("image-generation-setup").catch(() => null),
     ]);
 
+    const configured = (builderEnabled && builderConnected) || geminiConfigured;
+
     return {
       builderEnabled,
       builderConnected,
       geminiConfigured,
-      configured: (builderEnabled && builderConnected) || geminiConfigured,
-      lastIssue: geminiConfigured ? null : lastIssue,
+      configured,
+      lastIssue: configured ? null : lastIssue,
     };
   },
 });

--- a/templates/images/app/routes/_index.tsx
+++ b/templates/images/app/routes/_index.tsx
@@ -56,6 +56,8 @@ const HOME_CHAT_SUGGESTIONS = [
 ];
 
 const CUSTOM_RATIOS_KEY = "images.customAspectRatios";
+const MAX_TEXT_CONTEXT_FILE_CHARS = 12_000;
+const MAX_TEXT_CONTEXT_TOTAL_CHARS = 24_000;
 
 type ImageGenerationConfig = {
   builderEnabled?: boolean;
@@ -171,6 +173,27 @@ function isInlineTextContextFile(file: File): boolean {
   );
 }
 
+async function readInlineTextContextFiles(files: File[]) {
+  const snippets: string[] = [];
+  let remaining = MAX_TEXT_CONTEXT_TOTAL_CHARS;
+  for (const file of files) {
+    if (remaining <= 0) break;
+    const raw = await file.text();
+    const maxForFile = Math.min(MAX_TEXT_CONTEXT_FILE_CHARS, remaining);
+    const text = raw.slice(0, maxForFile);
+    remaining -= text.length;
+    snippets.push(
+      [
+        `### ${file.name}`,
+        raw.length > text.length
+          ? `${text}\n\n[Truncated ${raw.length - text.length} characters]`
+          : text,
+      ].join("\n"),
+    );
+  }
+  return snippets;
+}
+
 function HomeGeneratePanel({
   libraries,
   onRequestNewLibrary,
@@ -274,6 +297,7 @@ function HomeGeneratePanel({
     }
 
     const imageFiles = files.filter(isImageReferenceFile);
+    const textFiles = files.filter(isInlineTextContextFile);
     const unsupportedFiles = files.filter(
       (file) => !isImageReferenceFile(file) && !isInlineTextContextFile(file),
     );
@@ -327,6 +351,16 @@ function HomeGeneratePanel({
       }
     }
 
+    let textContextSnippets: string[] = [];
+    if (textFiles.length > 0) {
+      try {
+        textContextSnippets = await readInlineTextContextFiles(textFiles);
+      } catch {
+        toast.error("Couldn't read one of the attached text files.");
+        return;
+      }
+    }
+
     const messageLines = [
       `Generate ${count} image candidate${count === 1 ? "" : "s"}.`,
       `Prompt: ${trimmed}`,
@@ -368,6 +402,18 @@ function HomeGeneratePanel({
         ...uploadedAssets.map((a) => `- ${a.id} - ${a.title}`),
         "",
         "These were just added to the library. Treat them as the highest-weight style references for this generation.",
+      );
+    }
+    if (textContextSnippets.length > 0) {
+      contextLines.push(
+        "",
+        "## Attached text context (this turn)",
+        ...textContextSnippets,
+      );
+      messageLines.push(
+        `Use ${textContextSnippets.length} attached text context file${
+          textContextSnippets.length === 1 ? "" : "s"
+        } from the request context.`,
       );
     }
     contextLines.push(

--- a/templates/images/app/routes/_index.tsx
+++ b/templates/images/app/routes/_index.tsx
@@ -58,6 +58,7 @@ const HOME_CHAT_SUGGESTIONS = [
 const CUSTOM_RATIOS_KEY = "images.customAspectRatios";
 const MAX_TEXT_CONTEXT_FILE_CHARS = 12_000;
 const MAX_TEXT_CONTEXT_TOTAL_CHARS = 24_000;
+const MAX_TEXT_CONTEXT_READ_BYTES_PER_CHAR = 4;
 
 type ImageGenerationConfig = {
   builderEnabled?: boolean;
@@ -178,15 +179,20 @@ async function readInlineTextContextFiles(files: File[]) {
   let remaining = MAX_TEXT_CONTEXT_TOTAL_CHARS;
   for (const file of files) {
     if (remaining <= 0) break;
-    const raw = await file.text();
     const maxForFile = Math.min(MAX_TEXT_CONTEXT_FILE_CHARS, remaining);
+    const maxReadBytes = Math.min(
+      file.size,
+      maxForFile * MAX_TEXT_CONTEXT_READ_BYTES_PER_CHAR,
+    );
+    const raw = await file.slice(0, maxReadBytes).text();
     const text = raw.slice(0, maxForFile);
+    const truncated = raw.length > text.length || file.size > maxReadBytes;
     remaining -= text.length;
     snippets.push(
       [
         `### ${file.name}`,
-        raw.length > text.length
-          ? `${text}\n\n[Truncated ${raw.length - text.length} characters]`
+        truncated
+          ? `${text}\n\n[Truncated after ${text.length} characters]`
           : text,
       ].join("\n"),
     );

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -932,7 +932,10 @@ export function EmailList({
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting && !isFetchingNextPageRef.current) {
-          fetchNextPage();
+          void fetchNextPage().catch(() => {
+            // React Query owns the visible error state; avoid a global
+            // unhandledrejection for transient list-page fetch failures.
+          });
         }
       },
       { rootMargin: "200px" },


### PR DESCRIPTION
## Summary
- retry transient agent-chat route-missing startup responses before surfacing connection errors
- address real feedback from #839, #846, and #848 by making Dispatch MCP embed preminting best-effort, tightening retry classification/backoff/cleanup, and falling back from incomplete org-secret signing inputs
- address real feedback from #850 by forwarding text attachments into image-generation context, clearing stale setup issues once configured, and making DesignEditor timer cleanups explicit
- include small carried-forward UI fixes for docs CTA, booking shell layout, and mail infinite-scroll rejection handling

## Skipped / skeptical notes
- I did not reclassify open_app away from GET/read-only; preminting is now best-effort and failures preserve the normal open URL fallback, which addresses the practical regression without widening the tool contract.
- I did not reply on the merged PR threads because the GitHub comment workflow says not to write replies unless explicitly requested.

## Tests
- pnpm --filter dispatch test -- src/server/lib/mcp-gateway.spec.ts
- pnpm --filter dispatch typecheck
- pnpm --filter @agent-native/core test -- src/client/agent-chat-adapter.spec.ts
- pnpm --filter images typecheck
- pnpm --filter design typecheck
- pnpm run prep