### PR TITLE
Fix Claude MCP app open redirects

### DIFF
--- a/.changeset/fix-claude-open-redirect-cors.md
+++ b/.changeset/fix-claude-open-redirect-cors.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow MCP App embed fetches to follow Agent-Native open redirects in Claude.

--- a/packages/core/src/server/open-route.spec.ts
+++ b/packages/core/src/server/open-route.spec.ts
@@ -4,6 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // field we set on the fake event. Mirrors poll-handler.spec's h3 stub.
 vi.mock("h3", () => ({
   defineEventHandler: (handler: any) => handler,
+  getHeader: (event: any, name: string) =>
+    event.headers?.get?.(name) ??
+    event.headers?.[name] ??
+    event.headers?.[name.toLowerCase()] ??
+    event.node?.req?.headers?.[name] ??
+    event.node?.req?.headers?.[name.toLowerCase()],
   getMethod: (event: any) => event.method ?? "GET",
 }));
 
@@ -21,6 +27,12 @@ const appStateGet = vi.hoisted(() => vi.fn());
 vi.mock("../application-state/store.js", () => ({
   appStatePut: (...a: any[]) => appStatePut(...a),
   appStateGet: (...a: any[]) => appStateGet(...a),
+}));
+
+const requestHasEmbedAuthMarker = vi.hoisted(() => vi.fn());
+
+vi.mock("./embed-session.js", () => ({
+  requestHasEmbedAuthMarker: (...a: any[]) => requestHasEmbedAuthMarker(...a),
 }));
 
 import { createOpenRouteHandler } from "./open-route.js";
@@ -45,6 +57,8 @@ describe("createOpenRouteHandler", () => {
     appStatePut.mockResolvedValue(undefined);
     appStateGet.mockReset();
     appStateGet.mockResolvedValue(null);
+    requestHasEmbedAuthMarker.mockReset();
+    requestHasEmbedAuthMarker.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -190,6 +204,32 @@ describe("createOpenRouteHandler", () => {
 
     const [, , payload] = appStatePut.mock.calls[0];
     expect(payload).toEqual({ threadId: "t1", view: "inbox" });
+  });
+
+  it("adds MCP embed CORS headers to embed-auth open redirects", async () => {
+    requestHasEmbedAuthMarker.mockReturnValue(true);
+    getSession.mockResolvedValue({ email: "user@example.com" });
+    const handler = createOpenRouteHandler();
+
+    const res: Response = await handler({
+      ...fakeEvent(
+        `/_agent-native/open?view=inbox&threadId=t1&${EMBED_MODE_QUERY_PARAM}=1&${EMBED_TOKEN_QUERY_PARAM}=tok_123`,
+      ),
+      headers: new Headers({
+        origin: "https://520ba469ac5783c72c33d79bea940871.claudemcpcontent.com",
+      }),
+    } as any);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("/inbox?");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://520ba469ac5783c72c33d79bea940871.claudemcpcontent.com",
+    );
+    expect(res.headers.get("Access-Control-Expose-Headers")).toBe("Location");
+    expect(res.headers.get("Cross-Origin-Resource-Policy")).toBe(
+      "cross-origin",
+    );
+    expect(res.headers.get("Referrer-Policy")).toBe("no-referrer");
   });
 
   it("parses the original browser URL when mounted under the framework route", async () => {

--- a/packages/core/src/server/open-route.ts
+++ b/packages/core/src/server/open-route.ts
@@ -22,9 +22,10 @@
  * no privileged state.
  */
 import type { H3Event } from "h3";
-import { defineEventHandler, getMethod } from "h3";
+import { defineEventHandler, getHeader, getMethod } from "h3";
 import { getSession, getConfiguredLoginHtml } from "./auth.js";
 import { appStatePut, appStateGet } from "../application-state/store.js";
+import { requestHasEmbedAuthMarker } from "./embed-session.js";
 import {
   AGENT_SIDEBAR_QUERY_PARAM,
   withCollapsedAgentSidebarParam,
@@ -35,6 +36,10 @@ import {
   MCP_APP_CHAT_BRIDGE_QUERY_PARAM,
 } from "../shared/embed-auth.js";
 import { getConfiguredAppBasePath } from "./app-base-path.js";
+import {
+  isMcpEmbedCorsOrigin,
+  MCP_EMBED_CORS_ALLOW_HEADERS,
+} from "../shared/mcp-embed-headers.js";
 
 /** Query keys that are route control, not navigation payload. */
 const RESERVED = new Set([
@@ -96,10 +101,32 @@ function safeRelativePath(raw: string | undefined | null): string | null {
   return raw;
 }
 
-function redirect(location: string): Response {
+function addMcpEmbedHeaders(event: H3Event, headers: Headers): Headers {
+  headers.set("Cross-Origin-Embedder-Policy", "require-corp");
+  headers.set("Cross-Origin-Opener-Policy", "same-origin");
+  headers.set("Cross-Origin-Resource-Policy", "cross-origin");
+  headers.set("Referrer-Policy", "no-referrer");
+  const origin = getHeader(event, "origin");
+  if (isMcpEmbedCorsOrigin(origin)) {
+    headers.set("Access-Control-Allow-Origin", origin);
+    headers.set("Vary", "Origin");
+    headers.set("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS");
+    headers.set("Access-Control-Allow-Headers", MCP_EMBED_CORS_ALLOW_HEADERS);
+    headers.set("Access-Control-Expose-Headers", "Location");
+  }
+  return headers;
+}
+
+function redirect(
+  event: H3Event,
+  location: string,
+  embedRedirect: boolean,
+): Response {
   // Native web Response (not h3 v2's reworked sendRedirect) — matches the
   // redirect pattern used elsewhere in auth.ts.
-  return new Response("", { status: 302, headers: { Location: location } });
+  const headers = new Headers({ Location: location });
+  if (embedRedirect) addMcpEmbedHeaders(event, headers);
+  return new Response("", { status: 302, headers });
 }
 
 function appendSearchParams(target: string, params: URLSearchParams): string {
@@ -258,6 +285,6 @@ export function createOpenRouteHandler(options: OpenRouteOptions = {}) {
     target = withCollapsedAgentSidebarParam(target);
     target = withConfiguredRedirectBasePath(target);
 
-    return redirect(target);
+    return redirect(event, target, requestHasEmbedAuthMarker(event));
   });
 }


### PR DESCRIPTION
## Summary
- Add MCP embed CORS/COEP/CORP headers to Agent-Native open-route redirects when the request has a valid embed marker
- Cover the Claude MCP content origin redirect hop in unit tests
- Add a core changeset

## Testing
- pnpm --filter @agent-native/core exec vitest --run src/server/open-route.spec.ts src/server/security-headers.spec.ts src/server/embed-route.spec.ts src/mcp/embed-app.spec.ts
- pnpm prep
