### PR TITLE
Accept nested MCP open app embed options

### DIFF
--- a/.changeset/open-app-nested-embed-options.md
+++ b/.changeset/open-app-nested-embed-options.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Accept nested `params.embed` and `params.chrome` values in MCP `open_app` calls.

--- a/packages/core/src/mcp/builtin-cross-app.spec.ts
+++ b/packages/core/src/mcp/builtin-cross-app.spec.ts
@@ -228,6 +228,45 @@ describe("open_app — same-app / standalone keeps a relative deep link", () => 
     expect(result.embed).toBe(true);
   });
 
+  it("promotes embed and chrome from params for hosts that nest open options", async () => {
+    const createTicket = vi
+      .spyOn(embedSession, "createEmbedSessionTicket")
+      .mockResolvedValue({
+        ticket: "ticket-params",
+        ticketHash: "hash-params",
+        expiresAt: 987654,
+      });
+    const tools = getBuiltinCrossAppTools(baseConfig(), {
+      origin: "https://mail.example.com",
+    });
+
+    const result: any = await runWithRequestContext(
+      { userEmail: "owner@example.com", orgId: "org-123" },
+      () =>
+        tools.open_app.run({
+          app: "mail",
+          view: "inbox",
+          params: {
+            embed: true,
+            chrome: "minimal",
+            threadId: "abc",
+          },
+        }),
+    );
+
+    expect(result.url).toBe("/inbox?threadId=abc");
+    expect(result.embed).toBe(true);
+    expect(result.embedStartUrl).toBe(
+      "https://mail.example.com/_agent-native/embed/start?ticket=ticket-params",
+    );
+    expect(createTicket).toHaveBeenCalledWith({
+      ownerEmail: "owner@example.com",
+      orgId: "org-123",
+      targetPath: "/inbox?threadId=abc&__an_mcp_chat_bridge=1",
+      scope: "minimal",
+    });
+  });
+
   it("prefixes direct same-app paths with the configured app base path", async () => {
     process.env.APP_BASE_PATH = "/mail";
     const tools = getBuiltinCrossAppTools(baseConfig());

--- a/packages/core/src/mcp/builtin-tools.ts
+++ b/packages/core/src/mcp/builtin-tools.ts
@@ -321,7 +321,40 @@ function openAppTool(
           params = undefined;
         }
       }
-      const embed = args.embed === true || args.embed === "true";
+      const embeddedParam = params?.embed;
+      const chromeParam = params?.chrome;
+      let embed = args.embed === true || args.embed === "true";
+      if (
+        args.embed == null &&
+        (embeddedParam === true || embeddedParam === "true")
+      ) {
+        embed = true;
+      } else if (
+        args.embed == null &&
+        (embeddedParam === false || embeddedParam === "false")
+      ) {
+        embed = false;
+      }
+      if (
+        embeddedParam === true ||
+        embeddedParam === false ||
+        embeddedParam === "true" ||
+        embeddedParam === "false"
+      ) {
+        delete params?.embed;
+      }
+
+      const chrome =
+        typeof args.chrome === "string"
+          ? args.chrome
+          : chromeParam === "full" || chromeParam === "minimal"
+            ? chromeParam
+            : undefined;
+      if (chromeParam === "full" || chromeParam === "minimal") {
+        delete params?.chrome;
+      }
+      if (params && Object.keys(params).length === 0) params = undefined;
+
       const directViewPath = embed && view ? viewToAppPath(view) : null;
       const relUrl = path
         ? appendParamsToPath(path, params)
@@ -364,7 +397,7 @@ function openAppTool(
               ownerEmail,
               orgId: ctx?.orgId,
               targetPath,
-              scope: typeof args.chrome === "string" ? args.chrome : null,
+              scope: chrome ?? null,
             });
             const startPath = buildEmbedStartPath(ticket.ticket);
             embedStartUrl = requestMeta?.origin

--- a/packages/dispatch/src/actions/open_app.spec.ts
+++ b/packages/dispatch/src/actions/open_app.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   listGrantedDispatchMcpAppOrigins: vi.fn(),
@@ -13,6 +13,10 @@ vi.mock("../server/lib/mcp-gateway.js", () => ({
 import openAppAction from "./open_app.js";
 
 describe("open_app MCP App metadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("uses exact granted app origins instead of broad HTTPS CSP", async () => {
     mocks.listGrantedDispatchMcpAppOrigins.mockResolvedValue([
       "https://dispatch.agent-native.com",
@@ -47,5 +51,35 @@ describe("open_app MCP App metadata", () => {
     ]);
     expect(csp.baseUriDomains).toEqual(csp.frameDomains);
     expect(JSON.stringify(csp)).not.toContain('"https:"');
+  });
+
+  it("promotes embed and chrome from params for hosts that nest open options", async () => {
+    mocks.openGrantedDispatchMcpApp.mockResolvedValue({
+      app: "mail",
+      view: "inbox",
+      url: "https://mail.agent-native.com/inbox",
+      embed: true,
+      chrome: "minimal",
+      embedStartUrl:
+        "https://mail.agent-native.com/_agent-native/embed/start?ticket=test",
+    });
+
+    await openAppAction.run({
+      app: "mail",
+      view: "inbox",
+      params: {
+        embed: true,
+        chrome: "minimal",
+        threadId: "abc",
+      },
+    });
+
+    expect(mocks.openGrantedDispatchMcpApp).toHaveBeenCalledWith({
+      app: "mail",
+      view: "inbox",
+      params: { threadId: "abc" },
+      embed: true,
+      chrome: "minimal",
+    });
   });
 });

--- a/packages/dispatch/src/actions/open_app.ts
+++ b/packages/dispatch/src/actions/open_app.ts
@@ -46,6 +46,55 @@ const openAppSchema = z
     path: ["view"],
   });
 
+type OpenAppArgs = z.infer<typeof openAppSchema>;
+
+function normalizeOpenAppArgs(args: OpenAppArgs): OpenAppArgs {
+  if (!args.params) return args;
+
+  const params = { ...args.params };
+  const embedded = params.embed;
+  const chrome = params.chrome;
+  let changed = false;
+
+  let normalizedEmbed = args.embed;
+  if (normalizedEmbed == null) {
+    if (embedded === true || embedded === "true") {
+      normalizedEmbed = true;
+      changed = true;
+    } else if (embedded === false || embedded === "false") {
+      normalizedEmbed = false;
+      changed = true;
+    }
+  }
+  if (
+    embedded === true ||
+    embedded === false ||
+    embedded === "true" ||
+    embedded === "false"
+  ) {
+    delete params.embed;
+    changed = true;
+  }
+
+  let normalizedChrome = args.chrome;
+  if (normalizedChrome == null && (chrome === "full" || chrome === "minimal")) {
+    normalizedChrome = chrome;
+    changed = true;
+  }
+  if (chrome === "full" || chrome === "minimal") {
+    delete params.chrome;
+    changed = true;
+  }
+
+  if (!changed) return args;
+  return {
+    ...args,
+    params: Object.keys(params).length ? params : undefined,
+    ...(normalizedEmbed == null ? {} : { embed: normalizedEmbed }),
+    ...(normalizedChrome == null ? {} : { chrome: normalizedChrome }),
+  };
+}
+
 const localDevFrameSources = ["http://localhost:*", "http://127.0.0.1:*"];
 
 const dispatchOpenAppCsp: ActionMcpAppCspBuilder = async (
@@ -81,7 +130,7 @@ export default defineAction({
   http: { method: "GET" },
   readOnly: true,
   parallelSafe: true,
-  run: async (args) => openGrantedDispatchMcpApp(args),
+  run: async (args) => openGrantedDispatchMcpApp(normalizeOpenAppArgs(args)),
   link: ({ result }) => {
     if (!result || typeof result !== "object") return null;
     const r = result as { url?: string; app?: string; view?: string };


### PR DESCRIPTION
## Summary
- Accept `params.embed` / `params.chrome` in MCP `open_app` calls and promote them to the real embed options
- Strip those host/model-only options out of route params so generated URLs stay clean
- Add focused core + Dispatch regressions for the ChatGPT-style nested argument shape

## Tests
- `pnpm --filter @agent-native/core exec vitest --run src/mcp/builtin-cross-app.spec.ts src/mcp/embed-app.spec.ts src/mcp/build-server.spec.ts`
- `pnpm --filter @agent-native/dispatch exec vitest --run src/actions/open_app.spec.ts src/server/lib/mcp-gateway.spec.ts`
