### PR TITLE
Address MCP app feedback and design system details

### DIFF
--- a/.changeset/mcp-csp-resilience.md
+++ b/.changeset/mcp-csp-resilience.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Keep MCP App resource listing resilient to CSP metadata failures and invalid Dispatch app URLs.

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -209,6 +209,9 @@ Claude and ChatGPT can cache tool and resource metadata for an existing custom
 connector. After changing MCP App metadata, verify with a fresh tool call; if
 the host still uses the old descriptor, reconnect the Claude connector or
 rescan/review the ChatGPT connector so it refreshes the catalog.
+If Claude logs a warning about `_meta.ui.csp` or `_meta.ui.permissions` living
+on the tool descriptor after a deploy, that connector is using stale metadata:
+delete/reconnect the Claude connector and start a fresh chat.
 
 ### First-class MCP App bridge {#mcp-app-bridge}
 

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -988,7 +988,7 @@ export async function createMCPServerForRequest(
         const resultForClient = isMcpActionResult(result)
           ? result.text
           : result;
-        const mcpAppResource = await resolveMcpAppResource(
+        const mcpAppResource = await resolveMcpAppResourceSafely(
           config,
           name,
           entry,
@@ -1096,7 +1096,7 @@ export async function createMCPServerForRequest(
             ) {
               continue;
             }
-            const resource = await resolveMcpAppResource(
+            const resource = await resolveMcpAppResourceSafely(
               config,
               name,
               entry,

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -234,6 +234,11 @@ interface McpAppResourceContext {
   requestOrigin?: string;
 }
 
+interface VersionedMcpAppResourceUri {
+  uri: string;
+  legacyUris?: string[];
+}
+
 function metadataObject(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -387,7 +392,7 @@ function legacyDefaultMcpAppUri(config: MCPConfig, actionName: string): string {
 
 function versionMcpAppResourceUri(
   rawUri: string,
-): { uri: string; legacyUris?: string[] } | null {
+): VersionedMcpAppResourceUri | null {
   const uri = rawUri.trim();
   if (!uri.startsWith("ui://")) return null;
   const versionSuffix = `/${MCP_APP_RESOURCE_SHELL_VERSION}`;
@@ -406,6 +411,18 @@ function versionMcpAppResourceUri(
     uri: versionedUri,
     ...(versionedUri !== uri ? { legacyUris: [uri] } : {}),
   };
+}
+
+function getMcpAppResourceUri(
+  config: MCPConfig,
+  actionName: string,
+  entry: ActionEntry,
+): VersionedMcpAppResourceUri | null {
+  const resource = entry.mcpApp?.resource;
+  if (!resource) return null;
+  const baseUri =
+    resource.uri?.trim() || legacyDefaultMcpAppUri(config, actionName);
+  return versionMcpAppResourceUri(baseUri);
 }
 
 function expandRequestOriginSources(
@@ -521,9 +538,7 @@ async function resolveMcpAppResource(
 ): Promise<ResolvedMcpAppResource | null> {
   const resource = entry.mcpApp?.resource;
   if (!resource) return null;
-  const baseUri =
-    resource.uri?.trim() || legacyDefaultMcpAppUri(config, actionName);
-  const resolvedUri = versionMcpAppResourceUri(baseUri);
+  const resolvedUri = getMcpAppResourceUri(config, actionName, entry);
   if (!resolvedUri) return null;
   const description = resource.description ?? entry.tool.description;
   const resolvedCsp = await resolveMcpAppCsp(resource, {
@@ -549,6 +564,23 @@ async function resolveMcpAppResource(
   };
 }
 
+async function resolveMcpAppResourceSafely(
+  config: MCPConfig,
+  actionName: string,
+  entry: ActionEntry,
+  requestMeta?: MCPRequestMeta,
+): Promise<ResolvedMcpAppResource | null> {
+  try {
+    return await resolveMcpAppResource(config, actionName, entry, requestMeta);
+  } catch (error) {
+    console.warn(
+      `[mcp] Skipping MCP App resource for action "${actionName}" because its metadata could not be resolved.`,
+      error,
+    );
+    return null;
+  }
+}
+
 async function getMcpAppResources(
   config: MCPConfig,
   actions: Record<string, ActionEntry>,
@@ -556,7 +588,7 @@ async function getMcpAppResources(
 ): Promise<ResolvedMcpAppResource[]> {
   const resources = await Promise.all(
     Object.entries(actions).map(([name, entry]) =>
-      resolveMcpAppResource(config, name, entry, requestMeta),
+      resolveMcpAppResourceSafely(config, name, entry, requestMeta),
     ),
   );
   return resources.filter((resource): resource is ResolvedMcpAppResource =>
@@ -808,7 +840,7 @@ export async function createMCPServerForRequest(
       const tools = await Promise.all(
         Object.entries(advertisedActions).map(async ([name, entry]) => {
           const hasLink = typeof entry.link === "function";
-          const mcpAppResource = await resolveMcpAppResource(
+          const mcpAppResource = await resolveMcpAppResourceSafely(
             config,
             name,
             entry,
@@ -1051,23 +1083,31 @@ export async function createMCPServerForRequest(
       async (request: any) => {
         return withCallerContext(async () => {
           const uri = request.params?.uri;
-          const candidates = await Promise.all(
-            Object.entries(advertisedActions).map(async ([name, entry]) => ({
-              actionName: name,
-              resource: await resolveMcpAppResource(
-                config,
-                name,
-                entry,
-                requestMeta,
-              ),
-            })),
-          );
-          const found = candidates.find(
-            (candidate) =>
-              candidate.resource?.uri === uri ||
-              candidate.resource?.legacyUris?.includes(uri),
-          );
-          if (!found?.resource) {
+          let found: {
+            actionName: string;
+            resource: ResolvedMcpAppResource;
+          } | null = null;
+          for (const [name, entry] of Object.entries(advertisedActions)) {
+            const resourceUri = getMcpAppResourceUri(config, name, entry);
+            if (
+              !resourceUri ||
+              (resourceUri.uri !== uri &&
+                !resourceUri.legacyUris?.includes(uri))
+            ) {
+              continue;
+            }
+            const resource = await resolveMcpAppResource(
+              config,
+              name,
+              entry,
+              requestMeta,
+            );
+            if (resource) {
+              found = { actionName: name, resource };
+            }
+            break;
+          }
+          if (!found) {
             throw new Error(`MCP App resource not found: ${uri}`);
           }
           return {

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -367,6 +367,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       resourceUri: "ui://mail/echo-thing/shell-v25",
       visibility: ["model", "app"],
     });
+    expect(echo._meta?.ui?.csp).toBeUndefined();
+    expect(echo._meta?.ui?.permissions).toBeUndefined();
   });
 
   it("uses a compact tool catalog when the OAuth token has mcp:apps", async () => {

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -807,6 +807,124 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     );
   });
 
+  it("isolates MCP App CSP builder failures to the affected resource", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const resourceFailure = new Error("csp store offline");
+    const failingCspConfig = {
+      ...config,
+      actions: {
+        "broken-review": {
+          tool: {
+            description: "Broken review",
+          },
+          run: async () => ({ ok: true }),
+          mcpApp: {
+            resource: {
+              title: "Broken review",
+              html: "<!doctype html><html><body>Broken</body></html>",
+              csp: async () => {
+                throw resourceFailure;
+              },
+            },
+          },
+        },
+        "healthy-review": {
+          tool: {
+            description: "Healthy review",
+          },
+          run: async () => ({ ok: true }),
+          mcpApp: {
+            resource: {
+              title: "Healthy review",
+              html: "<!doctype html><html><body>Healthy</body></html>",
+              csp: {
+                connectDomains: ["https://healthy.example.com"],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    try {
+      const tools = await callWeb(
+        {
+          jsonrpc: "2.0",
+          id: 39,
+          method: "tools/list",
+          params: {},
+        },
+        { headers: await mcpAppsAuthHeaders(), config: failingCspConfig },
+      );
+      expect(tools.error).toBeUndefined();
+      const brokenTool = tools.result.tools.find(
+        (tool: any) => tool.name === "broken-review",
+      );
+      const healthyTool = tools.result.tools.find(
+        (tool: any) => tool.name === "healthy-review",
+      );
+      expect(brokenTool._meta?.["openai/outputTemplate"]).toBeUndefined();
+      expect(healthyTool._meta["openai/outputTemplate"]).toBe(
+        "ui://mail/healthy-review/shell-v25",
+      );
+
+      const resources = await callWeb(
+        {
+          jsonrpc: "2.0",
+          id: 40,
+          method: "resources/list",
+          params: {},
+        },
+        { headers: await mcpAppsAuthHeaders(), config: failingCspConfig },
+      );
+      expect(resources.error).toBeUndefined();
+      expect(
+        resources.result.resources.map((resource: any) => resource.uri),
+      ).toEqual(["ui://mail/healthy-review/shell-v25"]);
+
+      const templates = await callWeb(
+        {
+          jsonrpc: "2.0",
+          id: 41,
+          method: "resources/templates/list",
+          params: {},
+        },
+        { headers: await mcpAppsAuthHeaders(), config: failingCspConfig },
+      );
+      expect(templates.error).toBeUndefined();
+      expect(
+        templates.result.resourceTemplates.map(
+          (template: any) => template.uriTemplate,
+        ),
+      ).toEqual(["ui://mail/healthy-review/shell-v25"]);
+
+      const warnCallsBeforeRead = warn.mock.calls.length;
+      const read = await callWeb(
+        {
+          jsonrpc: "2.0",
+          id: 42,
+          method: "resources/read",
+          params: { uri: "ui://mail/healthy-review/shell-v25" },
+        },
+        { headers: await mcpAppsAuthHeaders(), config: failingCspConfig },
+      );
+      expect(read.error).toBeUndefined();
+      expect(read.result.contents[0]).toEqual(
+        expect.objectContaining({
+          uri: "ui://mail/healthy-review/shell-v25",
+          text: expect.stringContaining("Healthy"),
+        }),
+      );
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('"broken-review"'),
+        resourceFailure,
+      );
+      expect(warn).toHaveBeenCalledTimes(warnCallsBeforeRead);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("keeps legacy unversioned MCP App resource reads working", async () => {
     const out = await callWeb(
       {

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -868,10 +868,25 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         "ui://mail/healthy-review/shell-v25",
       );
 
-      const resources = await callWeb(
+      const brokenCall = await callWeb(
         {
           jsonrpc: "2.0",
           id: 40,
+          method: "tools/call",
+          params: { name: "broken-review", arguments: {} },
+        },
+        { headers: await mcpAppsAuthHeaders(), config: failingCspConfig },
+      );
+      expect(brokenCall.error).toBeUndefined();
+      expect(brokenCall.result.content[0].text).toBe('{"ok":true}');
+      expect(
+        brokenCall.result._meta?.["openai/outputTemplate"],
+      ).toBeUndefined();
+
+      const resources = await callWeb(
+        {
+          jsonrpc: "2.0",
+          id: 41,
           method: "resources/list",
           params: {},
         },
@@ -885,7 +900,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       const templates = await callWeb(
         {
           jsonrpc: "2.0",
-          id: 41,
+          id: 42,
           method: "resources/templates/list",
           params: {},
         },
@@ -902,7 +917,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       const read = await callWeb(
         {
           jsonrpc: "2.0",
-          id: 42,
+          id: 43,
           method: "resources/read",
           params: { uri: "ui://mail/healthy-review/shell-v25" },
         },

--- a/packages/dispatch/src/actions/open_app.spec.ts
+++ b/packages/dispatch/src/actions/open_app.spec.ts
@@ -53,6 +53,27 @@ describe("open_app MCP App metadata", () => {
     expect(JSON.stringify(csp)).not.toContain('"https:"');
   });
 
+  it("keeps exact granted origins when request origin is unavailable", async () => {
+    mocks.listGrantedDispatchMcpAppOrigins.mockResolvedValue([
+      "https://mail.agent-native.com",
+      "https://calendar.agent-native.com",
+    ]);
+
+    const cspBuilder = openAppAction.mcpApp?.resource.csp;
+    const csp = await (cspBuilder as any)({
+      actionName: "open_app",
+      appId: "dispatch",
+    });
+
+    expect(csp.frameDomains).toEqual([
+      "$requestOrigin",
+      "https://mail.agent-native.com",
+      "https://calendar.agent-native.com",
+      "http://localhost:*",
+      "http://127.0.0.1:*",
+    ]);
+  });
+
   it("promotes embed and chrome from params for hosts that nest open options", async () => {
     mocks.openGrantedDispatchMcpApp.mockResolvedValue({
       app: "mail",

--- a/packages/dispatch/src/actions/open_app.ts
+++ b/packages/dispatch/src/actions/open_app.ts
@@ -101,7 +101,7 @@ const dispatchOpenAppCsp: ActionMcpAppCspBuilder = async (
   ctx,
 ): Promise<ActionMcpAppCsp> => {
   const appOrigins = (await listGrantedDispatchMcpAppOrigins()).filter(
-    (origin) => origin !== ctx.requestOrigin,
+    (origin) => !ctx.requestOrigin || origin !== ctx.requestOrigin,
   );
   const routeSources = [
     MCP_APP_REQUEST_ORIGIN_CSP_SOURCE,

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -163,10 +163,24 @@ describe("Dispatch MCP gateway app discovery", () => {
         url: "https://mail.agent-native.com/inbox",
         color: "#2563EB",
       },
+      {
+        id: "bad-url",
+        name: "Bad URL",
+        description: "Invalid manifest URL",
+        url: "mail.agent-native.com",
+        color: "#111827",
+      },
+      {
+        id: "file-url",
+        name: "File URL",
+        description: "Unsupported manifest URL scheme",
+        url: "file:///tmp/app",
+        color: "#111827",
+      },
     ]);
     mocks.getUserSetting.mockResolvedValue({
       mode: "selected-apps",
-      selectedAppIds: ["dispatch", "analytics", "mail"],
+      selectedAppIds: ["dispatch", "analytics", "mail", "bad-url", "file-url"],
     });
 
     const origins = await runWithRequestContext(

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -452,6 +452,48 @@ describe("createGrantedDispatchMcpEmbedSession", () => {
     });
   });
 
+  it("skips malformed granted app URLs when matching embed URLs", async () => {
+    mocks.discoverAgents.mockResolvedValue([
+      {
+        id: "bad-url",
+        name: "Bad URL",
+        description: "Invalid manifest URL",
+        url: "mail.agent-native.com",
+        color: "#111827",
+      },
+      {
+        id: "mail",
+        name: "Mail",
+        description: "Mail",
+        url: "https://mail.agent-native.com",
+        color: "#2563EB",
+      },
+    ]);
+
+    const result = await runWithRequestContext(
+      {
+        userEmail: "owner@example.test",
+        requestOrigin: "http://localhost:8092",
+      },
+      () =>
+        createGrantedDispatchMcpEmbedSession({
+          url: "https://mail.agent-native.com/inbox",
+        }),
+    );
+
+    expect(mocks.managerConstructor).toHaveBeenCalledWith({
+      servers: {
+        target: expect.objectContaining({
+          url: "https://mail.agent-native.com/_agent-native/mcp",
+        }),
+      },
+    });
+    expect(result).toEqual({
+      app: "mail",
+      startUrl: "http://localhost:8086/_agent-native/embed/start?ticket=remote",
+    });
+  });
+
   it("uses the org A2A secret when minting cross-app MCP embed tokens", async () => {
     mocks.getOrgDomain.mockResolvedValue("builder.io");
     mocks.getOrgA2ASecret.mockResolvedValue("org-specific-secret");

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -75,6 +75,7 @@ import {
   listGrantedDispatchMcpApps,
   listGrantedDispatchMcpAppOrigins,
   openGrantedDispatchMcpApp,
+  resolveGrantedDispatchMcpApp,
 } from "./mcp-gateway.js";
 import { runWithRequestContext } from "@agent-native/core/server";
 
@@ -190,12 +191,46 @@ describe("Dispatch MCP gateway app discovery", () => {
       },
       () => listGrantedDispatchMcpAppOrigins(),
     );
+    const apps = await runWithRequestContext(
+      {
+        userEmail: "owner@example.test",
+        requestOrigin: "http://localhost:8092",
+      },
+      () => listGrantedDispatchMcpApps(),
+    );
 
     expect(origins).toEqual([
       "http://localhost:8092",
       "http://localhost:8086",
       "https://mail.agent-native.com",
     ]);
+    expect(apps.map((app) => app.id)).toEqual([
+      "dispatch",
+      "analytics",
+      "mail",
+    ]);
+  });
+
+  it("rejects malformed granted app URLs before routing MCP actions", async () => {
+    mocks.discoverAgents.mockResolvedValue([
+      {
+        id: "bad-url",
+        name: "Bad URL",
+        description: "Invalid manifest URL",
+        url: "mail.agent-native.com",
+        color: "#111827",
+      },
+    ]);
+
+    await expect(
+      runWithRequestContext(
+        {
+          userEmail: "owner@example.test",
+          requestOrigin: "http://localhost:8092",
+        },
+        () => resolveGrantedDispatchMcpApp("bad-url"),
+      ),
+    ).rejects.toThrow(/invalid URL/);
   });
 });
 

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -145,8 +145,21 @@ function appendParamsToPath(
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
+function safeAppOrigin(app: DispatchMcpAccessibleApp): string | null {
+  try {
+    const url = new URL(app.url);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.origin
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 function appOrigin(app: DispatchMcpAccessibleApp): string {
-  return new URL(app.url).origin;
+  const origin = safeAppOrigin(app);
+  if (!origin) throw new Error(`Invalid app URL for "${app.id}": ${app.url}`);
+  return origin;
 }
 
 function appBaseUrl(app: DispatchMcpAccessibleApp): string {
@@ -240,7 +253,7 @@ export async function listGrantedDispatchMcpApps(): Promise<
 
 export async function listGrantedDispatchMcpAppOrigins(): Promise<string[]> {
   const apps = await listGrantedDispatchMcpApps();
-  return Array.from(new Set(apps.map((app) => appOrigin(app))));
+  return Array.from(new Set(apps.flatMap((app) => safeAppOrigin(app) ?? [])));
 }
 
 export async function resolveGrantedDispatchMcpApp(

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -172,7 +172,8 @@ function appBasePath(app: DispatchMcpAccessibleApp): string {
 }
 
 function appMatchesUrlPath(app: DispatchMcpAccessibleApp, url: URL): boolean {
-  if (url.origin !== appOrigin(app)) return false;
+  const origin = safeAppOrigin(app);
+  if (!origin || url.origin !== origin) return false;
   const basePath = appBasePath(app);
   if (!basePath) return true;
   return url.pathname === basePath || url.pathname.startsWith(`${basePath}/`);

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -249,7 +249,7 @@ export async function listGrantedDispatchMcpApps(): Promise<
   DispatchMcpAccessibleApp[]
 > {
   const { apps } = await listDispatchMcpApps();
-  return apps.filter((app) => app.granted);
+  return apps.filter((app) => app.granted && safeAppOrigin(app));
 }
 
 export async function listGrantedDispatchMcpAppOrigins(): Promise<string[]> {
@@ -275,6 +275,11 @@ export async function resolveGrantedDispatchMcpApp(
   if (!match.granted) {
     throw new Error(
       `Dispatch MCP access to "${match.id}" is not granted. Open Dispatch > Agents to change MCP app access.`,
+    );
+  }
+  if (!safeAppOrigin(match)) {
+    throw new Error(
+      `Dispatch MCP app "${match.id}" has an invalid URL and cannot be opened through MCP.`,
     );
   }
   return match;

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -181,6 +181,7 @@ Write to `navigate` to move the user. The UI reads it, navigates, and auto-delet
 { "view": "editor", "designId": "abc123" }
 { "view": "list" }
 { "view": "design-systems" }
+{ "view": "design-systems", "designSystemId": "ds123" }
 { "path": "/present/abc123" }
 ```
 
@@ -296,14 +297,15 @@ If your cwd is the monorepo root instead (e.g., running from the Frame wrapper),
 
 ### Navigation
 
-| Action     | Args                             | Purpose                    |
-| ---------- | -------------------------------- | -------------------------- |
-| `navigate` | `--view list`                    | Navigate to design list    |
-| `navigate` | `--view editor --designId <id>`  | Navigate to design editor  |
-| `navigate` | `--view design-systems`          | Navigate to design systems |
-| `navigate` | `--view present --designId <id>` | Navigate to presentation   |
-| `navigate` | `--view templates`               | Navigate to templates      |
-| `navigate` | `--view settings`                | Navigate to settings       |
+| Action     | Args                                          | Purpose                           |
+| ---------- | --------------------------------------------- | --------------------------------- |
+| `navigate` | `--view list`                                 | Navigate to design list           |
+| `navigate` | `--view editor --designId <id>`               | Navigate to design editor         |
+| `navigate` | `--view design-systems`                       | Navigate to design systems        |
+| `navigate` | `--view design-systems --designSystemId <id>` | Open a design system detail sheet |
+| `navigate` | `--view present --designId <id>`              | Navigate to presentation          |
+| `navigate` | `--view templates`                            | Navigate to templates             |
+| `navigate` | `--view settings`                             | Navigate to settings              |
 
 ### Creating & Editing Designs
 

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -360,6 +360,7 @@ If your cwd is the monorepo root instead (e.g., running from the Frame wrapper),
 | ----------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `export-html`           | `--id <designId>`                                                  | Export as standalone HTML with CDN scripts                                                                                                        |
 | `export-zip`            | `--id <designId>`                                                  | Export as ZIP with all files + README                                                                                                             |
+| `export-svg`            | `--id <designId> [--width <px>] [--height <px>]`                   | Export as SVG with the design embedded in a foreignObject wrapper                                                                                 |
 | `export-pdf`            | `--id <designId>`                                                  | Prepare data for client-side PDF rendering                                                                                                        |
 | `export-coding-handoff` | `--id <designId> [--origin <appOrigin>] [--format markdown\|json]` | **Turn design into code.** Copy-ready prompt + tokenized raw-code URL; bundle reflects live (collab) content and the user's applied visual tweaks |
 
@@ -856,6 +857,7 @@ If Builder is not connected, fall back to `import-from-url --url "https://exampl
 | "Add a navigation bar"          | `get-design --id <id>`, add nav HTML to `index.html`, save                                                 |
 | "Export as HTML"                | `export-html --id <id>`                                                                                    |
 | "Export as ZIP"                 | `export-zip --id <id>`                                                                                     |
+| "Export as SVG"                 | `export-svg --id <id>`                                                                                     |
 | "Duplicate this design"         | `duplicate-design --id <id>`                                                                               |
 | "Set up brand identity for X"   | `analyze-brand-assets --websiteUrl "..."` then `create-design-system`                                      |
 | "Apply my brand to this design" | `get-design-system --id <id>` then regenerate with tokens                                                  |
@@ -1882,7 +1884,11 @@ All three return an editor deep link ("Open design") so external surfaces
 
 `export-html --id <id>` bundles all files into a single standalone HTML file with Tailwind CDN and Alpine.js included. The output works when double-clicked in a browser.
 
-When a user asks to download a design, export a design, or get the generated HTML, use `export-html --id <id>` or tell them to use the editor's Download menu. Do not send them to external HTML screenshot services. The editor Download menu supports direct HTML, PNG, ZIP, and coding-handoff downloads.
+When a user asks to download a design, export a design, or get the generated HTML, use `export-html --id <id>` or tell them to use the editor's Download menu. Do not send them to external HTML screenshot services. The editor Download menu supports direct HTML, PNG, SVG, ZIP, and coding-handoff downloads.
+
+### SVG Export
+
+`export-svg --id <id>` creates an SVG document with the standalone HTML embedded inside a `foreignObject`. In the editor, Download SVG uses the live iframe DOM for a more faithful visual snapshot of the current screen.
 
 ### ZIP Export
 

--- a/templates/design/actions/export-html.ts
+++ b/templates/design/actions/export-html.ts
@@ -3,29 +3,12 @@ import { z } from "zod";
 import { eq } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
 import { resolveAccess } from "@agent-native/core/sharing";
+import {
+  buildStandaloneHtml,
+  exportFilename,
+  trySaveExportFile,
+} from "../server/lib/design-export.js";
 import "../server/db/index.js"; // ensure registerShareableResource runs
-
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
-function getExportDir(path: typeof import("path")): string {
-  if (process.env.NODE_ENV === "production") {
-    return path.join(process.cwd(), "data", "exports");
-  }
-
-  return path.join(
-    process.cwd(),
-    "node_modules",
-    ".cache",
-    "agent-native-design",
-    "exports",
-  );
-}
 
 export default defineAction({
   description:
@@ -48,88 +31,11 @@ export default defineAction({
       .from(schema.designFiles)
       .where(eq(schema.designFiles.designId, id));
 
-    const cssFiles = files.filter((f) => f.fileType === "css");
-    const htmlFiles = files.filter((f) => f.fileType === "html");
-    const jsxFiles = files.filter((f) => f.fileType === "jsx");
-    const indexHtml =
-      files.find((f) => f.filename === "index.html") ?? htmlFiles[0];
-    const combinedCss = cssFiles.map((f) => f.content).join("\n\n");
+    const html = buildStandaloneHtml({ title: row.title, files });
 
-    let html: string;
-    if (
-      indexHtml?.content &&
-      /<!doctype html|<html[\s>]/i.test(indexHtml.content)
-    ) {
-      html = indexHtml.content;
-      // Merge non-index HTML/JSX files into the body of the standalone
-      // document so multi-file designs (components.html, page-*.html, etc.)
-      // still ship in one bundle. Drop the file we already used as the
-      // shell so we don't double-include it.
-      const extraBody = [...htmlFiles, ...jsxFiles]
-        .filter((f) => f !== indexHtml)
-        .map((f) => f.content)
-        .join("\n\n");
-      if (extraBody.trim()) {
-        // Find the last closing body tag. Inline JS / template literals
-        // can contain `</body>` strings, so a naive replace can mishit —
-        // use lastIndexOf which favors the real document boundary.
-        const closeBody = html.lastIndexOf("</body>");
-        if (closeBody !== -1) {
-          html = `${html.slice(0, closeBody)}${extraBody}\n${html.slice(closeBody)}`;
-        } else {
-          html = `${html}\n${extraBody}`;
-        }
-      }
-      // Idempotency: if a prior export already injected this CSS block,
-      // skip re-injection so repeated exports don't duplicate the style
-      // tag. The `data-agent-native-export` marker is our sentinel.
-      if (
-        combinedCss.trim() &&
-        !/<style[^>]*data-agent-native-export\b/i.test(html)
-      ) {
-        const styleBlock = `<style data-agent-native-export>\n${combinedCss}\n</style>`;
-        // Match the LAST `</head>` (not the first appearance inside an
-        // inline script / comment) to avoid injecting before content
-        // that depends on the document's own styles.
-        const closeHead = html.lastIndexOf("</head>");
-        if (closeHead !== -1) {
-          html = `${html.slice(0, closeHead)}${styleBlock}\n${html.slice(closeHead)}`;
-        } else {
-          html = `${styleBlock}\n${html}`;
-        }
-      }
-    } else {
-      const combinedBody = [...htmlFiles, ...jsxFiles]
-        .map((f) => f.content)
-        .join("\n\n");
+    const filename = exportFilename(row.title, "html");
+    const saveResult = await trySaveExportFile(filename, html);
 
-      html = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${escapeHtml(row.title)}</title>
-  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.11/dist/cdn.min.js"></script>
-  <style>
-    ${combinedCss}
-  </style>
-</head>
-<body>
-  ${combinedBody}
-</body>
-</html>`;
-    }
-
-    // Save to exports directory
-    const fs = await import("fs");
-    const path = await import("path");
-    const exportDir = getExportDir(path);
-    fs.mkdirSync(exportDir, { recursive: true });
-    const filename = `${row.title.replace(/[^a-zA-Z0-9]/g, "-")}-${Date.now()}.html`;
-    const filePath = path.join(exportDir, filename);
-    fs.writeFileSync(filePath, html);
-
-    return { html, filename, filePath, fileCount: files.length };
+    return { html, filename, ...saveResult, fileCount: files.length };
   },
 });

--- a/templates/design/actions/export-svg.ts
+++ b/templates/design/actions/export-svg.ts
@@ -17,14 +17,14 @@ export default defineAction({
     "The editor's Download SVG command uses the live browser DOM for the most faithful snapshot; this action provides agent parity for source-based SVG export.",
   schema: z.object({
     id: z.string().describe("Design ID to export"),
-    width: z
+    width: z.coerce
       .number()
       .int()
       .positive()
       .optional()
       .default(1440)
       .describe("SVG viewport width in pixels"),
-    height: z
+    height: z.coerce
       .number()
       .int()
       .positive()

--- a/templates/design/actions/export-svg.ts
+++ b/templates/design/actions/export-svg.ts
@@ -1,0 +1,60 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { getDb, schema } from "../server/db/index.js";
+import { resolveAccess } from "@agent-native/core/sharing";
+import {
+  buildStandaloneHtml,
+  buildSvgForeignObject,
+  exportFilename,
+  trySaveExportFile,
+} from "../server/lib/design-export.js";
+import "../server/db/index.js"; // ensure registerShareableResource runs
+
+export default defineAction({
+  description:
+    "Export a design project as an SVG document using a foreignObject wrapper around the standalone HTML. " +
+    "The editor's Download SVG command uses the live browser DOM for the most faithful snapshot; this action provides agent parity for source-based SVG export.",
+  schema: z.object({
+    id: z.string().describe("Design ID to export"),
+    width: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .default(1440)
+      .describe("SVG viewport width in pixels"),
+    height: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .default(1200)
+      .describe("SVG viewport height in pixels"),
+  }),
+  readOnly: true,
+  run: async ({ id, width, height }) => {
+    const access = await resolveAccess("design", id);
+    if (!access) throw new Error(`Design not found: ${id}`);
+
+    const row = access.resource;
+    const db = getDb();
+
+    const files = await db
+      .select()
+      .from(schema.designFiles)
+      .where(eq(schema.designFiles.designId, id));
+
+    const html = buildStandaloneHtml({ title: row.title, files });
+    const svg = buildSvgForeignObject({
+      html,
+      width,
+      height,
+      title: row.title,
+    });
+    const filename = exportFilename(row.title, "svg");
+    const saveResult = await trySaveExportFile(filename, svg);
+
+    return { svg, filename, ...saveResult, fileCount: files.length };
+  },
+});

--- a/templates/design/actions/export-zip.ts
+++ b/templates/design/actions/export-zip.ts
@@ -3,21 +3,11 @@ import { z } from "zod";
 import { eq } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
 import { resolveAccess } from "@agent-native/core/sharing";
+import {
+  exportFilename,
+  trySaveExportFile,
+} from "../server/lib/design-export.js";
 import "../server/db/index.js"; // ensure registerShareableResource runs
-
-function getExportDir(path: typeof import("path")): string {
-  if (process.env.NODE_ENV === "production") {
-    return path.join(process.cwd(), "data", "exports");
-  }
-
-  return path.join(
-    process.cwd(),
-    "node_modules",
-    ".cache",
-    "agent-native-design",
-    "exports",
-  );
-}
 
 export default defineAction({
   description:
@@ -75,15 +65,9 @@ export default defineAction({
     const zipBuffer = await zip.generateAsync({ type: "nodebuffer" });
     const zipBase64 = zipBuffer.toString("base64");
 
-    // Save to exports directory
-    const fs = await import("fs");
-    const path = await import("path");
-    const exportDir = getExportDir(path);
-    fs.mkdirSync(exportDir, { recursive: true });
-    const filename = `${row.title.replace(/[^a-zA-Z0-9]/g, "-")}-${Date.now()}.zip`;
-    const filePath = path.join(exportDir, filename);
-    fs.writeFileSync(filePath, zipBuffer);
+    const filename = exportFilename(row.title, "zip");
+    const saveResult = await trySaveExportFile(filename, zipBuffer);
 
-    return { zipBase64, filename, filePath, fileCount: files.length };
+    return { zipBase64, filename, ...saveResult, fileCount: files.length };
   },
 });

--- a/templates/design/actions/list-design-systems.ts
+++ b/templates/design/actions/list-design-systems.ts
@@ -67,6 +67,7 @@ export default defineAction({
         title: row.title,
         description: row.description,
         data: row.data,
+        assets: row.assets,
         customInstructions: row.customInstructions ?? "",
         isDefault: row.isDefault,
         visibility: row.visibility,

--- a/templates/design/actions/navigate.ts
+++ b/templates/design/actions/navigate.ts
@@ -7,6 +7,7 @@
  *   pnpm action navigate --view=list
  *   pnpm action navigate --view=editor --designId=abc123
  *   pnpm action navigate --view=design-systems
+ *   pnpm action navigate --view=design-systems --designSystemId=abc123
  *   pnpm action navigate --view=templates
  *   pnpm action navigate --view=settings
  *   pnpm action navigate --path=/some/route
@@ -14,6 +15,7 @@
  * Options:
  *   --view       View name (list, editor, design-systems, present, templates, settings)
  *   --designId   Design ID (for editor/present views)
+ *   --designSystemId Design system ID (for design-systems view)
  *   --path       URL path to navigate to
  */
 
@@ -23,7 +25,7 @@ import { writeAppState } from "@agent-native/core/application-state";
 
 export default defineAction({
   description:
-    "Navigate the UI to a specific view or path. Views: list, editor, design-systems, present, templates, settings. Use --designId with editor/present views.",
+    "Navigate the UI to a specific view or path. Views: list, editor, design-systems, present, templates, settings. Use --designId with editor/present views and --designSystemId with design-systems.",
   schema: z.object({
     view: z
       .enum([
@@ -38,6 +40,10 @@ export default defineAction({
       .optional()
       .describe("View name to navigate to"),
     designId: z.string().optional().describe("Design ID for editor/present"),
+    designSystemId: z
+      .string()
+      .optional()
+      .describe("Design system ID for design-systems view"),
     path: z.string().optional().describe("URL path to navigate to"),
   }),
   http: false,
@@ -48,8 +54,11 @@ export default defineAction({
     const nav: Record<string, string> = {};
     if (args.view) nav.view = args.view;
     if (args.designId) nav.designId = args.designId;
+    if (args.designSystemId) nav.designSystemId = args.designSystemId;
     if (args.path) nav.path = args.path;
     await writeAppState("navigate", nav);
-    return `Navigating to ${args.view || args.path}${args.designId ? ` (design: ${args.designId})` : ""}`;
+    return `Navigating to ${args.view || args.path}${
+      args.designId ? ` (design: ${args.designId})` : ""
+    }${args.designSystemId ? ` (design system: ${args.designSystemId})` : ""}`;
   },
 });

--- a/templates/design/app/components/design/DesignToolbar.tsx
+++ b/templates/design/app/components/design/DesignToolbar.tsx
@@ -110,6 +110,7 @@ export function DesignToolbar({
 }: DesignToolbarProps) {
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState(title);
+  const zoomLabel = `${Math.round(zoom)}%`;
 
   const commitTitle = () => {
     setEditingTitle(false);
@@ -280,8 +281,8 @@ export function DesignToolbar({
         >
           <IconMinus className="h-3 w-3" />
         </Button>
-        <span className="min-w-[3rem] text-center text-xs text-muted-foreground">
-          {zoom}%
+        <span className="min-w-12 text-center text-xs tabular-nums text-muted-foreground">
+          {zoomLabel}
         </span>
         <Button
           variant="ghost"

--- a/templates/design/app/components/design/DesignToolbar.tsx
+++ b/templates/design/app/components/design/DesignToolbar.tsx
@@ -74,6 +74,7 @@ const MODE_ITEMS: {
 
 const EXPORT_FORMATS = [
   { value: "zip", label: "Download ZIP" },
+  { value: "svg", label: "Download SVG" },
   { value: "pdf", label: "Export PDF" },
   { value: "html", label: "Export HTML" },
   { value: "coding-handoff", label: "Copy coding handoff" },

--- a/templates/design/app/components/design/ZoomControls.tsx
+++ b/templates/design/app/components/design/ZoomControls.tsx
@@ -28,6 +28,8 @@ export function ZoomControls({ zoom, onZoomChange }: ZoomControlsProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
+  const roundedZoom = Math.round(zoom);
+  const zoomLabel = `${roundedZoom}%`;
 
   const handleZoomIn = useCallback(() => {
     const next = ZOOM_PRESETS.find((p) => p > zoom);
@@ -44,9 +46,9 @@ export function ZoomControls({ zoom, onZoomChange }: ZoomControlsProps) {
   }, [onZoomChange]);
 
   const handleStartEdit = useCallback(() => {
-    setEditValue(String(zoom));
+    setEditValue(String(roundedZoom));
     setIsEditing(true);
-  }, [zoom]);
+  }, [roundedZoom]);
 
   const handleCommitEdit = useCallback(() => {
     const parsed = parseInt(editValue, 10);
@@ -103,7 +105,7 @@ export function ZoomControls({ zoom, onZoomChange }: ZoomControlsProps) {
               onClick={handleStartEdit}
               className="flex items-center gap-0.5 px-1.5 h-6 text-xs text-foreground tabular-nums hover:bg-accent rounded"
             >
-              {zoom}%
+              {zoomLabel}
               <IconChevronDown className="w-3 h-3 opacity-50" />
             </button>
           </DropdownMenuTrigger>

--- a/templates/design/app/hooks/use-navigation-state.ts
+++ b/templates/design/app/hooks/use-navigation-state.ts
@@ -6,6 +6,7 @@ import { agentNativePath } from "@agent-native/core/client";
 export interface NavigationState {
   view: string;
   designId?: string;
+  designSystemId?: string;
   path?: string;
 }
 
@@ -24,6 +25,10 @@ export function useNavigationState() {
       state.designId = params.id;
     } else if (location.pathname.startsWith("/design-systems")) {
       state.view = "design-systems";
+      const designSystemId = new URLSearchParams(location.search).get(
+        "designSystemId",
+      );
+      if (designSystemId) state.designSystemId = designSystemId;
     } else if (location.pathname.startsWith("/present/")) {
       state.view = "present";
       state.designId = params.id;
@@ -42,7 +47,7 @@ export function useNavigationState() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(state),
     }).catch(() => {});
-  }, [location.pathname, params.id]);
+  }, [location.pathname, location.search, params.id]);
 
   // Listen for navigate commands from agent
   const { data: navCommand } = useQuery({
@@ -74,14 +79,21 @@ export function useNavigationState() {
       method: "DELETE",
       headers: { "X-Agent-Native-CSRF": "1" },
     }).catch(() => {});
-    const cmd = navCommand as NavigationState & { designId?: string };
+    const cmd = navCommand as NavigationState & {
+      designId?: string;
+      designSystemId?: string;
+    };
 
     let path = cmd.path;
     if (!path) {
       if (cmd.view === "editor" && cmd.designId) {
         path = `/design/${cmd.designId}`;
       } else if (cmd.view === "design-systems") {
-        path = "/design-systems";
+        path = cmd.designSystemId
+          ? `/design-systems?designSystemId=${encodeURIComponent(
+              cmd.designSystemId,
+            )}`
+          : "/design-systems";
       } else if (cmd.view === "present" && cmd.designId) {
         path = `/present/${cmd.designId}`;
       } else if (cmd.view === "templates" || cmd.view === "examples") {

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -1156,6 +1156,39 @@ export default function DesignEditor() {
       );
       const clone = doc.documentElement.cloneNode(true) as HTMLElement;
       clone.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+      const stylesheetLinks = Array.from(
+        doc.querySelectorAll<HTMLLinkElement>('link[rel~="stylesheet"]'),
+      );
+      const clonedStylesheetLinks = Array.from(
+        clone.querySelectorAll<HTMLLinkElement>('link[rel~="stylesheet"]'),
+      );
+      const stylesheets = Array.from(doc.styleSheets);
+
+      stylesheetLinks.forEach((link, index) => {
+        const sheet = stylesheets.find(
+          (candidate) =>
+            (candidate as StyleSheet & { ownerNode?: Node | null })
+              .ownerNode === link,
+        ) as CSSStyleSheet | undefined;
+        let cssText = "";
+        try {
+          cssText = Array.from(sheet?.cssRules ?? [])
+            .map((rule) => rule.cssText)
+            .join("\n");
+        } catch {
+          // Cross-origin stylesheets cannot be read. Leave the original link in
+          // place instead of failing the whole export.
+          return;
+        }
+        if (!cssText.trim()) return;
+        const style = doc.createElement("style");
+        style.setAttribute(
+          "data-agent-native-inlined-stylesheet",
+          link.getAttribute("href") ?? "",
+        );
+        style.textContent = cssText;
+        clonedStylesheetLinks[index]?.replaceWith(style);
+      });
       clone.querySelectorAll("script").forEach((node) => node.remove());
       clone.style.width = `${width}px`;
       clone.style.minHeight = `${height}px`;

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -221,6 +221,7 @@ export default function DesignEditor() {
   const [drawMode, setDrawMode] = useState(false);
   const [pinMode, setPinMode] = useState(false);
   const [showPrompt, setShowPrompt] = useState(false);
+  const [svgExporting, setSvgExporting] = useState(false);
   const generateBtnRef = useRef<HTMLButtonElement | null>(null);
   const promptAnchorRef = useRef<HTMLElement | null>(null);
   promptAnchorRef.current = generateBtnRef.current;
@@ -1131,10 +1132,76 @@ export default function DesignEditor() {
     }
   }, [fallbackExportName, triggerBlobDownload]);
 
+  const handleDownloadSvg = useCallback(async () => {
+    const iframe = document.querySelector<HTMLIFrameElement>(
+      'iframe[title="Design Preview"]',
+    );
+    const doc = iframe?.contentDocument;
+    if (!doc?.documentElement) {
+      toast.error("Open a screen before exporting SVG");
+      return;
+    }
+
+    setSvgExporting(true);
+    try {
+      const width = Math.max(
+        doc.documentElement.scrollWidth,
+        doc.body?.scrollWidth ?? 0,
+        iframe?.clientWidth ?? 0,
+      );
+      const height = Math.max(
+        doc.documentElement.scrollHeight,
+        doc.body?.scrollHeight ?? 0,
+        iframe?.clientHeight ?? 0,
+      );
+      const clone = doc.documentElement.cloneNode(true) as HTMLElement;
+      clone.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+      clone.querySelectorAll("script").forEach((node) => node.remove());
+      clone.style.width = `${width}px`;
+      clone.style.minHeight = `${height}px`;
+
+      const body = clone.querySelector("body") as HTMLElement | null;
+      if (body) {
+        body.style.margin = body.style.margin || "0";
+        body.style.width = `${width}px`;
+        body.style.minHeight = `${height}px`;
+      }
+
+      const serializedHtml = new XMLSerializer().serializeToString(clone);
+      const safeTitle =
+        design?.title
+          ?.replace(/&/g, "&amp;")
+          .replace(/"/g, "&quot;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;") || "Design export";
+      const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${safeTitle}">
+  <title>${safeTitle}</title>
+  <foreignObject width="${width}" height="${height}">
+${serializedHtml}
+  </foreignObject>
+</svg>`;
+
+      triggerBlobDownload(
+        new Blob([svg], { type: "image/svg+xml;charset=utf-8" }),
+        fallbackExportName("svg"),
+      );
+      toast.success("SVG downloaded");
+    } catch (error) {
+      console.error("SVG export failed:", error);
+      toast.error(
+        error instanceof Error ? error.message : "Could not export SVG",
+      );
+    } finally {
+      setSvgExporting(false);
+    }
+  }, [design?.title, fallbackExportName, triggerBlobDownload]);
+
   const exportPending =
     exportHtmlMutation.isPending ||
     exportZipMutation.isPending ||
-    createCodingHandoffMutation.isPending;
+    createCodingHandoffMutation.isPending ||
+    svgExporting;
 
   if (!id) {
     navigate("/");
@@ -1472,6 +1539,13 @@ export default function DesignEditor() {
                 >
                   <IconPhoto className="mr-2 h-4 w-4" />
                   Download PNG
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={handleDownloadSvg}
+                  disabled={!activeFile || svgExporting}
+                >
+                  <IconCode className="mr-2 h-4 w-4" />
+                  Download SVG
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={handleDownloadZip}

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -1202,6 +1202,7 @@ ${serializedHtml}
     exportZipMutation.isPending ||
     createCodingHandoffMutation.isPending ||
     svgExporting;
+  const zoomLabel = `${Math.round(zoom)}%`;
 
   if (!id) {
     navigate("/");
@@ -1421,8 +1422,8 @@ ${serializedHtml}
               >
                 <IconZoomOut className="w-3.5 h-3.5" />
               </Button>
-              <span className="text-xs text-muted-foreground w-10 text-center tabular-nums">
-                {zoom}%
+              <span className="w-10 text-center text-xs tabular-nums text-muted-foreground">
+                {zoomLabel}
               </span>
               <Button
                 variant="ghost"

--- a/templates/design/app/pages/DesignSystems.tsx
+++ b/templates/design/app/pages/DesignSystems.tsx
@@ -716,7 +716,10 @@ function DesignSystemDetailsSheet({
     setTitle(designSystem.title);
     setDescription(designSystem.description ?? "");
     setCustomInstructions(designSystem.customInstructions ?? "");
-  }, [designSystem]);
+    // Only rehydrate when the user opens a different design system. Query
+    // refetches can replace this object while the user is editing the sheet.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [designSystem?.id]);
 
   const parsed = useMemo(
     () => (designSystem ? parseDesignSystemData(designSystem.data) : null),

--- a/templates/design/app/pages/DesignSystems.tsx
+++ b/templates/design/app/pages/DesignSystems.tsx
@@ -734,7 +734,10 @@ function DesignSystemDetailsSheet({
     return null;
   }
 
-  const canEdit = Boolean(designSystem.canManage);
+  const canEdit =
+    designSystem.accessRole === "owner" ||
+    designSystem.accessRole === "admin" ||
+    designSystem.accessRole === "editor";
   const trimmedTitle = title.trim();
   const hasChanges =
     trimmedTitle !== designSystem.title ||

--- a/templates/design/app/pages/DesignSystems.tsx
+++ b/templates/design/app/pages/DesignSystems.tsx
@@ -1,5 +1,11 @@
-import { useCallback, useState } from "react";
-import { Link, useNavigate } from "react-router";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import {
   IconCheckbox,
   IconChecks,
@@ -20,6 +26,8 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -37,6 +45,15 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Textarea } from "@/components/ui/textarea";
+import {
   useSetHeaderActions,
   useSetPageTitle,
 } from "@/components/layout/HeaderActions";
@@ -52,11 +69,14 @@ interface DesignSystem {
   title: string;
   description?: string | null;
   data: string;
+  assets?: string | null;
+  customInstructions?: string | null;
   isDefault: boolean;
   visibility?: "private" | "org" | "public" | null;
   accessRole?: "owner" | "viewer" | "editor" | "admin";
   canManage?: boolean;
   createdAt: string;
+  updatedAt?: string;
 }
 
 interface DesignSystemData {
@@ -65,15 +85,26 @@ interface DesignSystemData {
     secondary?: string;
     accent?: string;
     background?: string;
+    surface?: string;
+    text?: string;
+    textMuted?: string;
   };
   typography?: {
     headingFont?: string;
     bodyFont?: string;
+    headingWeight?: string;
+    bodyWeight?: string;
   };
+  spacing?: Record<string, string | undefined>;
+  borders?: Record<string, string | undefined>;
+  logos?: Array<{ url?: string; name?: string; variant?: string }>;
+  defaults?: Record<string, string | undefined>;
+  notes?: string;
 }
 
 export default function DesignSystems() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
@@ -88,13 +119,33 @@ export default function DesignSystems() {
 
   const setDefaultMutation = useActionMutation("set-default-design-system");
   const deleteMutation = useActionMutation("delete-design-system");
+  const updateMutation = useActionMutation("update-design-system");
 
   const designSystems = data?.designSystems ?? [];
+  const selectedDesignSystemId = searchParams.get("designSystemId");
+  const selectedDesignSystem = useMemo(
+    () =>
+      selectedDesignSystemId
+        ? (designSystems.find((ds) => ds.id === selectedDesignSystemId) ?? null)
+        : null,
+    [designSystems, selectedDesignSystemId],
+  );
   const manageableDesignSystems = designSystems.filter((ds) => ds.canManage);
   const selectedSystemCount = selectedSystemIds.size;
   const allSystemsSelected =
     manageableDesignSystems.length > 0 &&
     manageableDesignSystems.every((ds) => selectedSystemIds.has(ds.id));
+
+  const openDesignSystemDetails = useCallback(
+    (id: string) => {
+      navigate(`/design-systems?designSystemId=${encodeURIComponent(id)}`);
+    },
+    [navigate],
+  );
+
+  const closeDesignSystemDetails = useCallback(() => {
+    navigate("/design-systems", { replace: true });
+  }, [navigate]);
 
   const openSetupFromDesignSystem = useCallback(
     (id: string) => {
@@ -211,6 +262,53 @@ export default function DesignSystems() {
       },
     });
   }, [deleteId, queryClient, deleteMutation]);
+
+  const handleUpdateDetails = useCallback(
+    (
+      id: string,
+      updates: {
+        title: string;
+        description: string;
+        customInstructions: string;
+      },
+    ) => {
+      const previous = queryClient.getQueryData([
+        "action",
+        "list-design-systems",
+        undefined,
+      ]);
+
+      queryClient.setQueryData(
+        ["action", "list-design-systems", undefined],
+        (old: any) => {
+          const systems = old?.designSystems ?? [];
+          return {
+            ...old,
+            designSystems: systems.map((ds: DesignSystem) =>
+              ds.id === id ? { ...ds, ...updates } : ds,
+            ),
+          };
+        },
+      );
+
+      updateMutation.mutate({ id, ...updates } as any, {
+        onSuccess: () => {
+          toast.success("Design system updated");
+        },
+        onError: (error) => {
+          queryClient.setQueryData(
+            ["action", "list-design-systems", undefined],
+            previous,
+          );
+          toast.error("Could not update design system", {
+            description:
+              error instanceof Error ? error.message : "Something went wrong",
+          });
+        },
+      });
+    },
+    [queryClient, updateMutation],
+  );
 
   const handleBulkDelete = useCallback(() => {
     const ids = Array.from(selectedSystemIds);
@@ -386,7 +484,7 @@ export default function DesignSystems() {
                             if (ds.canManage) toggleSystemSelection(ds.id);
                             return;
                           }
-                          openSetupFromDesignSystem(ds.id);
+                          openDesignSystemDetails(ds.id);
                         }}
                         aria-pressed={isSelectionMode ? isSelected : undefined}
                         className="block w-full text-left cursor-pointer"
@@ -572,8 +670,367 @@ export default function DesignSystems() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <DesignSystemDetailsSheet
+        designSystem={selectedDesignSystem}
+        open={Boolean(selectedDesignSystem)}
+        isSaving={updateMutation.isPending}
+        onOpenChange={(open) => {
+          if (!open) closeDesignSystemDetails();
+        }}
+        onUseAsSource={openSetupFromDesignSystem}
+        onSave={handleUpdateDetails}
+      />
     </>
   );
+}
+
+function DesignSystemDetailsSheet({
+  designSystem,
+  open,
+  isSaving,
+  onOpenChange,
+  onUseAsSource,
+  onSave,
+}: {
+  designSystem: DesignSystem | null;
+  open: boolean;
+  isSaving?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUseAsSource: (id: string) => void;
+  onSave: (
+    id: string,
+    updates: {
+      title: string;
+      description: string;
+      customInstructions: string;
+    },
+  ) => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [customInstructions, setCustomInstructions] = useState("");
+
+  useEffect(() => {
+    if (!designSystem) return;
+    setTitle(designSystem.title);
+    setDescription(designSystem.description ?? "");
+    setCustomInstructions(designSystem.customInstructions ?? "");
+  }, [designSystem]);
+
+  const parsed = useMemo(
+    () => (designSystem ? parseDesignSystemData(designSystem.data) : null),
+    [designSystem],
+  );
+  const assets = useMemo(
+    () => parseDesignSystemAssets(designSystem?.assets),
+    [designSystem?.assets],
+  );
+
+  if (!designSystem) {
+    return null;
+  }
+
+  const canEdit = Boolean(designSystem.canManage);
+  const trimmedTitle = title.trim();
+  const hasChanges =
+    trimmedTitle !== designSystem.title ||
+    description.trim() !== (designSystem.description ?? "") ||
+    customInstructions.trim() !== (designSystem.customInstructions ?? "");
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="flex w-full flex-col overflow-y-auto sm:max-w-xl">
+        <SheetHeader className="pr-8">
+          <SheetTitle>{designSystem.title}</SheetTitle>
+          <SheetDescription>
+            Review the saved tokens and update the details agents use when they
+            apply this design system.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 space-y-7 py-6">
+          <section className="space-y-3">
+            <div className="grid gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="design-system-title">Title</Label>
+                <Input
+                  id="design-system-title"
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  readOnly={!canEdit}
+                  className="bg-accent/50"
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="design-system-description">Description</Label>
+                <Textarea
+                  id="design-system-description"
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  readOnly={!canEdit}
+                  rows={3}
+                  className="bg-accent/50"
+                />
+              </div>
+            </div>
+          </section>
+
+          <TokenPreview data={parsed} assets={assets} />
+
+          <section className="space-y-3 border-t border-border pt-6">
+            <div>
+              <h3 className="text-sm font-medium text-foreground">
+                Custom instructions
+              </h3>
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                Durable guidance the agent reuses whenever this system is linked
+                to a design.
+              </p>
+            </div>
+            <Textarea
+              value={customInstructions}
+              onChange={(event) => setCustomInstructions(event.target.value)}
+              readOnly={!canEdit}
+              rows={5}
+              placeholder="No custom instructions saved yet."
+              className="bg-accent/50"
+            />
+          </section>
+        </div>
+
+        <SheetFooter className="gap-2 border-t border-border pt-4 sm:space-x-0">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onUseAsSource(designSystem.id)}
+            className="cursor-pointer"
+          >
+            Use as starting point
+          </Button>
+          {canEdit ? (
+            <Button
+              type="button"
+              onClick={() =>
+                onSave(designSystem.id, {
+                  title: trimmedTitle,
+                  description: description.trim(),
+                  customInstructions: customInstructions.trim(),
+                })
+              }
+              disabled={!trimmedTitle || !hasChanges || isSaving}
+              className="cursor-pointer"
+            >
+              {isSaving ? "Saving..." : "Save changes"}
+            </Button>
+          ) : null}
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function TokenPreview({
+  data,
+  assets,
+}: {
+  data: DesignSystemData | null;
+  assets: Array<{ name?: string; url?: string; variant?: string }>;
+}) {
+  const colors = getColorTokens(data);
+  const typeTokens = getTypographyTokens(data);
+  const detailTokens = getDetailTokens(data, assets);
+
+  return (
+    <section className="space-y-6 border-t border-border pt-6">
+      <div>
+        <h3 className="text-sm font-medium text-foreground">Token preview</h3>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+          A snapshot of the colors, type, spacing, and assets currently stored.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <h4 className="text-xs font-medium uppercase text-muted-foreground">
+          Colors
+        </h4>
+        {colors.length > 0 ? (
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {colors.map((color) => (
+              <div
+                key={color.label}
+                className="flex min-w-0 items-center gap-3 rounded-lg border border-border bg-muted/30 p-2"
+              >
+                <div
+                  className="h-9 w-9 shrink-0 rounded-md border border-border"
+                  style={{ backgroundColor: color.value }}
+                />
+                <div className="min-w-0">
+                  <div className="text-xs font-medium text-foreground">
+                    {color.label}
+                  </div>
+                  <div className="truncate font-mono text-[11px] text-muted-foreground">
+                    {color.value}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <EmptyPreviewLine icon={<IconPalette className="h-4 w-4" />}>
+            No color tokens saved.
+          </EmptyPreviewLine>
+        )}
+      </div>
+
+      {typeTokens.length > 0 ? (
+        <PreviewList title="Typography" items={typeTokens} />
+      ) : null}
+      {detailTokens.length > 0 ? (
+        <PreviewList title="Details" items={detailTokens} />
+      ) : null}
+    </section>
+  );
+}
+
+function PreviewList({
+  title,
+  items,
+}: {
+  title: string;
+  items: Array<{ label: string; value: string }>;
+}) {
+  return (
+    <div className="space-y-3">
+      <h4 className="text-xs font-medium uppercase text-muted-foreground">
+        {title}
+      </h4>
+      <dl className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {items.map((item) => (
+          <div
+            key={`${item.label}:${item.value}`}
+            className="min-w-0 rounded-lg border border-border bg-muted/30 p-3"
+          >
+            <dt className="text-xs font-medium text-foreground">
+              {item.label}
+            </dt>
+            <dd className="mt-1 truncate text-xs text-muted-foreground">
+              {item.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function EmptyPreviewLine({
+  icon,
+  children,
+}: {
+  icon: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+      {icon}
+      {children}
+    </div>
+  );
+}
+
+function parseDesignSystemData(dataStr: string): DesignSystemData | null {
+  try {
+    const parsed = JSON.parse(dataStr);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as DesignSystemData;
+  } catch {
+    return null;
+  }
+}
+
+function parseDesignSystemAssets(
+  assetsStr?: string | null,
+): Array<{ name?: string; url?: string; variant?: string }> {
+  if (!assetsStr) return [];
+  try {
+    const parsed = JSON.parse(assetsStr);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function getColorTokens(data: DesignSystemData | null) {
+  const colors = data?.colors;
+  if (!colors) return [];
+  return [
+    { label: "Primary", value: colors.primary },
+    { label: "Secondary", value: colors.secondary },
+    { label: "Accent", value: colors.accent },
+    { label: "Background", value: colors.background },
+    { label: "Surface", value: colors.surface },
+    { label: "Text", value: colors.text },
+    { label: "Muted text", value: colors.textMuted },
+  ].filter((item): item is { label: string; value: string } =>
+    Boolean(item.value),
+  );
+}
+
+function getTypographyTokens(data: DesignSystemData | null) {
+  const typography = data?.typography;
+  if (!typography) return [];
+  return [
+    { label: "Heading font", value: typography.headingFont },
+    { label: "Body font", value: typography.bodyFont },
+    { label: "Heading weight", value: typography.headingWeight },
+    { label: "Body weight", value: typography.bodyWeight },
+  ].filter((item): item is { label: string; value: string } =>
+    Boolean(item.value),
+  );
+}
+
+function getDetailTokens(
+  data: DesignSystemData | null,
+  assets: Array<{ name?: string; url?: string; variant?: string }>,
+) {
+  const spacing = data?.spacing ?? {};
+  const borders = data?.borders ?? {};
+  const defaults = data?.defaults ?? {};
+  const logos = data?.logos ?? [];
+  return [
+    ...objectPreviewItems("Spacing", spacing),
+    ...objectPreviewItems("Borders", borders),
+    ...objectPreviewItems("Defaults", defaults),
+    logos.length > 0
+      ? { label: "Logos", value: `${logos.length} saved` }
+      : null,
+    assets.length > 0
+      ? { label: "Assets", value: `${assets.length} saved` }
+      : null,
+  ].filter((item): item is { label: string; value: string } => Boolean(item));
+}
+
+function objectPreviewItems(
+  prefix: string,
+  values: Record<string, string | undefined>,
+) {
+  return Object.entries(values)
+    .filter((entry): entry is [string, string] => Boolean(entry[1]))
+    .slice(0, 4)
+    .map(([key, value]) => ({
+      label: `${prefix}: ${labelizeKey(key)}`,
+      value,
+    }));
+}
+
+function labelizeKey(key: string) {
+  return key
+    .replace(/([A-Z])/g, " $1")
+    .replace(/[-_]/g, " ")
+    .replace(/^./, (char) => char.toUpperCase());
 }
 
 function LoadingSkeleton() {

--- a/templates/design/server/lib/design-export.ts
+++ b/templates/design/server/lib/design-export.ts
@@ -116,11 +116,7 @@ function escapeXmlAttribute(value: string): string {
 
 function normalizeHtmlForSvg(html: string): string {
   const withoutDoctype = html.replace(/<!doctype[^>]*>/i, "").trim();
-  const withoutScripts = withoutDoctype.replace(
-    /<script\b[\s\S]*?<\/script>/gi,
-    "",
-  );
-  const withClosedVoidElements = withoutScripts.replace(
+  const withClosedVoidElements = withoutDoctype.replace(
     /<(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)\b([^>]*)>/gi,
     (match, tag: string, attrs: string) => {
       if (/\/\s*>$/.test(match)) return match;

--- a/templates/design/server/lib/design-export.ts
+++ b/templates/design/server/lib/design-export.ts
@@ -1,0 +1,203 @@
+export interface DesignExportFile {
+  filename: string;
+  fileType: string | null;
+  content: string | null;
+}
+
+export interface DesignExportSaveResult {
+  filePath?: string;
+  saveWarning?: string;
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export function safeExportBaseName(title: string | null | undefined): string {
+  const safe = (title || "design")
+    .replace(/[^a-zA-Z0-9_-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return safe || "design";
+}
+
+export function exportFilename(
+  title: string | null | undefined,
+  extension: string,
+): string {
+  return `${safeExportBaseName(title)}-${Date.now()}.${extension}`;
+}
+
+export function buildStandaloneHtml(args: {
+  title: string;
+  files: DesignExportFile[];
+}): string {
+  const { title, files } = args;
+  const cssFiles = files.filter((f) => f.fileType === "css");
+  const htmlFiles = files.filter((f) => f.fileType === "html");
+  const jsxFiles = files.filter((f) => f.fileType === "jsx");
+  const indexHtml =
+    files.find((f) => f.filename === "index.html") ?? htmlFiles[0];
+  const combinedCss = cssFiles.map((f) => f.content ?? "").join("\n\n");
+
+  if (
+    indexHtml?.content &&
+    /<!doctype html|<html[\s>]/i.test(indexHtml.content)
+  ) {
+    let html = indexHtml.content;
+    // Merge non-index HTML/JSX files into the body of the standalone document
+    // so multi-file designs still ship in one bundle.
+    const extraBody = [...htmlFiles, ...jsxFiles]
+      .filter((f) => f !== indexHtml)
+      .map((f) => f.content ?? "")
+      .join("\n\n");
+    if (extraBody.trim()) {
+      // Inline JS / template literals can contain `</body>` strings, so favor
+      // the final document boundary.
+      const closeBody = html.lastIndexOf("</body>");
+      if (closeBody !== -1) {
+        html = `${html.slice(0, closeBody)}${extraBody}\n${html.slice(closeBody)}`;
+      } else {
+        html = `${html}\n${extraBody}`;
+      }
+    }
+
+    // Idempotency: if a prior export already injected this CSS block, skip
+    // re-injection so repeated exports don't duplicate the style tag.
+    if (
+      combinedCss.trim() &&
+      !/<style[^>]*data-agent-native-export\b/i.test(html)
+    ) {
+      const styleBlock = `<style data-agent-native-export>\n${combinedCss}\n</style>`;
+      const closeHead = html.lastIndexOf("</head>");
+      if (closeHead !== -1) {
+        html = `${html.slice(0, closeHead)}${styleBlock}\n${html.slice(closeHead)}`;
+      } else {
+        html = `${styleBlock}\n${html}`;
+      }
+    }
+
+    return html;
+  }
+
+  const combinedBody = [...htmlFiles, ...jsxFiles]
+    .map((f) => f.content ?? "")
+    .join("\n\n");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(title)}</title>
+  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.11/dist/cdn.min.js"></script>
+  <style>
+    ${combinedCss}
+  </style>
+</head>
+<body>
+  ${combinedBody}
+</body>
+</html>`;
+}
+
+function escapeXmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function normalizeHtmlForSvg(html: string): string {
+  const withoutDoctype = html.replace(/<!doctype[^>]*>/i, "").trim();
+  const withoutScripts = withoutDoctype.replace(
+    /<script\b[\s\S]*?<\/script>/gi,
+    "",
+  );
+  const withClosedVoidElements = withoutScripts.replace(
+    /<(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)\b([^>]*)>/gi,
+    (match, tag: string, attrs: string) => {
+      if (/\/\s*>$/.test(match)) return match;
+      return `<${tag}${attrs} />`;
+    },
+  );
+  const withEscapedBareAmpersands = withClosedVoidElements.replace(
+    /&(?!#?[a-zA-Z0-9]+;)/g,
+    "&amp;",
+  );
+
+  if (/<html\b[^>]*\bxmlns=/i.test(withEscapedBareAmpersands)) {
+    return withEscapedBareAmpersands;
+  }
+
+  if (/<html\b/i.test(withEscapedBareAmpersands)) {
+    return withEscapedBareAmpersands.replace(
+      /<html\b/i,
+      '<html xmlns="http://www.w3.org/1999/xhtml"',
+    );
+  }
+
+  return `<html xmlns="http://www.w3.org/1999/xhtml"><body>${withEscapedBareAmpersands}</body></html>`;
+}
+
+export function buildSvgForeignObject(args: {
+  html: string;
+  width: number;
+  height: number;
+  title?: string | null;
+}): string {
+  const width = Math.max(1, Math.round(args.width));
+  const height = Math.max(1, Math.round(args.height));
+  const title = args.title ? escapeXmlAttribute(args.title) : "Design export";
+  const html = normalizeHtmlForSvg(args.html);
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${title}">
+  <title>${title}</title>
+  <foreignObject width="${width}" height="${height}">
+${html}
+  </foreignObject>
+</svg>`;
+}
+
+function getExportDir(path: typeof import("path")): string {
+  if (process.env.NODE_ENV === "production") {
+    return path.join(process.cwd(), "data", "exports");
+  }
+
+  return path.join(
+    process.cwd(),
+    "node_modules",
+    ".cache",
+    "agent-native-design",
+    "exports",
+  );
+}
+
+export async function trySaveExportFile(
+  filename: string,
+  contents: string | Uint8Array,
+): Promise<DesignExportSaveResult> {
+  const fs = await import("fs");
+  const path = await import("path");
+  const exportDir = getExportDir(path);
+  const filePath = path.join(exportDir, filename);
+
+  try {
+    fs.mkdirSync(exportDir, { recursive: true });
+    fs.writeFileSync(filePath, contents);
+    return { filePath };
+  } catch (error) {
+    console.warn("Design export server-side save skipped:", error);
+    return {
+      saveWarning:
+        "Could not save a server-side copy, but the download payload was created.",
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Make MCP App resource/tool listing resilient when an async CSP builder fails, and avoid resolving unrelated resources during resources/read.
- Ignore malformed/non-HTTP Dispatch app URLs when building granted app CSP origins, and keep open_app CSP origin handling explicit when request origin is unavailable.
- Carry forward the local design-system detail sheet/navigation updates that were present on the branch, including agent navigation docs and a required changeset for core/dispatch.

## Feedback audit
- #839: premint hard-failure/read-only concern is already addressed on main by best-effort embed session creation.
- #846: retry dead code, classifier, stop masking, and backoff feedback is already addressed on main.
- #848: org-secret signing fallback is already addressed on main.
- #850: design cleanup and text attachment forwarding are already addressed on main.
- #853: addressed the post-merge Builder Review Agent findings around CSP failure isolation, resources/read resolution order, malformed Dispatch URLs, and request-origin handling.

## Tests
- pnpm --filter @agent-native/core exec vitest run src/mcp/server.spec.ts
- pnpm --filter @agent-native/dispatch exec vitest run src/actions/open_app.spec.ts src/server/lib/mcp-gateway.spec.ts
- pnpm run prep