### PR TITLE
Fix Clips recorder source selection

### DIFF
--- a/.changeset/chatgpt-widget-domain.md
+++ b/.changeset/chatgpt-widget-domain.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Emit MCP App widget domain metadata so ChatGPT can render submitted app templates.

--- a/packages/core/docs/content/client.md
+++ b/packages/core/docs/content/client.md
@@ -81,6 +81,10 @@ message, so it stays model-visible without being posted as user-facing chat.
 `submit: false` keeps the local prefill/review behavior because MCP Apps do not
 define a standard draft-prefill API.
 
+Internally this is the submitted-chat path sometimes surfaced as
+`agentNative.submitChat`; app code should call `sendToAgentChat()` rather than
+posting that event directly.
+
 ```ts
 import { sendToAgentChat } from "@agent-native/core";
 

--- a/packages/core/docs/content/dispatch.md
+++ b/packages/core/docs/content/dispatch.md
@@ -56,6 +56,11 @@ selected app grants, so external agents can route work to Mail, Calendar,
 Analytics, Brain, and workspace apps without a separate authorization for every
 app.
 
+When a host supports MCP Apps, that same Dispatch connector can render granted
+app routes inline too: email drafts, calendar invites, decks, forms, docs,
+designs, dashboards, clips, and other app routes can preview in chat without
+adding per-app connectors.
+
 Direct per-app MCP URLs such as
 `https://mail.agent-native.com/_agent-native/mcp` still exist when you
 intentionally want one isolated app surface. For most workspace use, the

--- a/packages/core/docs/content/drop-in-agent.md
+++ b/packages/core/docs/content/drop-in-agent.md
@@ -122,6 +122,10 @@ import { sendToAgentChat } from "@agent-native/core/client";
 
 `sendToAgentChat` returns a stable `tabId` you can use to track the chat run.
 
+When the same route is embedded as an MCP App, submitted
+`sendToAgentChat()` calls are forwarded to the host chat where supported; see
+[Client](/docs/client#sendtoagentchat) for the MCP App bridge behavior.
+
 If you want a loading state, use the `useSendToAgentChat()` hook — it returns both `send` and `isGenerating`:
 
 ```ts

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -571,5 +571,3 @@ The fallback hosted `connect` flow never copies the deployment's shared secret. 
 - [A2A Protocol](/docs/a2a-protocol) — the `ask-agent` meta-tool and JSON-RPC peer calls.
 - [Actions](/docs/actions) — defining actions, `publicAgent`, GET / `readOnly`.
 - [Context Awareness](/docs/context-awareness) — the `navigate` / `application_state` contract the open route bridges to.
-  </content>
-  </invoke>

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -245,6 +245,15 @@ function metadataObject(value: unknown): Record<string, unknown> {
     : {};
 }
 
+function originString(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return undefined;
+  }
+}
+
 function withMcpChatBridgeParam(urlOrPath: string): string {
   try {
     const base = "http://agent-native.invalid";
@@ -499,7 +508,11 @@ function mcpAppUiMeta(
     };
   }
   if (resource.permissions) ui.permissions = resource.permissions;
-  if (resource.domain) ui.domain = resource.domain;
+  const widgetDomain =
+    originString(resource.domain) ??
+    originString(ui.domain) ??
+    originString(requestMeta?.origin);
+  if (widgetDomain) ui.domain = widgetDomain;
   if (typeof resource.prefersBorder === "boolean") {
     ui.prefersBorder = resource.prefersBorder;
   }
@@ -516,6 +529,9 @@ function mcpAppUiMeta(
   const openAiCsp = openAiWidgetCsp(resolvedCsp, requestMeta);
   if (openAiCsp && base["openai/widgetCSP"] == null) {
     base["openai/widgetCSP"] = openAiCsp;
+  }
+  if (widgetDomain && base["openai/widgetDomain"] == null) {
+    base["openai/widgetDomain"] = widgetDomain;
   }
   return Object.keys(base).length > 0 ? base : undefined;
 }

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -619,10 +619,12 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
             csp: {
               connectDomains: ["https://mail.agent-native.com"],
             },
+            domain: "https://mail.agent-native.com",
             prefersBorder: true,
           },
           "openai/widgetDescription":
             "Review the echoed thing in an inline MCP App.",
+          "openai/widgetDomain": "https://mail.agent-native.com",
           "openai/widgetPrefersBorder": true,
           "openai/widgetCSP": {
             connect_domains: ["https://mail.agent-native.com"],
@@ -675,6 +677,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
             csp: {
               connectDomains: ["https://mail.agent-native.com"],
             },
+            domain: "https://mail.agent-native.com",
             prefersBorder: true,
           },
           "openai/widgetCSP": {
@@ -682,6 +685,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
           },
           "openai/widgetDescription":
             "Review the echoed thing in an inline MCP App.",
+          "openai/widgetDomain": "https://mail.agent-native.com",
           "openai/widgetPrefersBorder": true,
         }),
       }),

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -5199,17 +5199,19 @@ ipcMain.on(IPC.INTER_APP_SEND, (event: IpcMainEvent, msg: InterAppMessage) => {
 // ---------- OAuth handling ----------
 // OAuth providers we recognize and keep out of app webviews. Depending on the
 // provider and flow, the URL is opened in an Electron BrowserWindow or the
-// system browser. App-webview Builder connect stays in an Electron popup so the
-// callback shares the app session; the desktop Code provider has its own
-// loopback browser flow. Each provider specifies:
+// system browser. Signed Builder app-webview connects can use the system
+// browser because the callback carries email-bound state; older unsigned
+// connect URLs still use the Electron popup so the callback shares the app
+// session. The desktop Code provider has its own loopback browser flow. Each
+// provider specifies:
 //   - a `matches` predicate on the initial URL (from window.open)
 //   - a `callbackPathFragment` used to detect when the OAuth callback has
 //     been reached so we can auto-close the popup
 //
 // Builder is matched on two URL shapes: (1) the localhost 302 starter at
 // `/_agent-native/builder/connect`, which is what the in-app button opens,
-// and (2) the resolved `builder.io/cli-auth` URL, so both shapes route
-// through the same popup. Private keys delivered by the callback are
+// and (2) the resolved `builder.io/cli-auth` URL, so both shapes can be
+// routed out of the app webview. Private keys delivered by the callback are
 // written server-side (template `.env` + SQL `persisted-env-vars`) — they
 // never touch the webview/renderer. See credential-provider.ts.
 interface OAuthProvider {
@@ -5545,9 +5547,35 @@ function builderOAuthUsesDesktopProvider(url: URL): boolean {
   }
 }
 
+function builderOAuthUsesSignedBrowserProvider(url: URL): boolean {
+  if (!url.pathname.startsWith("/cli-auth")) return false;
+  const redirectUrl = url.searchParams.get("redirect_url");
+  if (!redirectUrl) return false;
+  try {
+    const callbackUrl = new URL(redirectUrl);
+    return (
+      callbackUrl.pathname.endsWith("/_agent-native/builder/callback") &&
+      callbackUrl.searchParams.has("_an_state")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function builderConnectUsesSignedBrowserProvider(url: URL): boolean {
+  return (
+    url.pathname.endsWith("/_agent-native/builder/connect") &&
+    url.searchParams.has("_an_connect")
+  );
+}
+
 function shouldOpenOAuthInSystemBrowser(provider: OAuthProvider, url: URL) {
   if (provider.name === "builder") {
-    return builderOAuthUsesDesktopProvider(url);
+    return (
+      builderOAuthUsesDesktopProvider(url) ||
+      builderOAuthUsesSignedBrowserProvider(url) ||
+      builderConnectUsesSignedBrowserProvider(url)
+    );
   }
   // Google blocks embedded/Electron OAuth surfaces. Framework pages that pass
   // a flow id poll /desktop-exchange, so the system browser can complete the

--- a/templates/clips/app/components/recorder/pre-record-panel.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.tsx
@@ -125,7 +125,7 @@ const SURFACE_OPTIONS: Array<{
     value: "browser",
     label: "Browser tab",
     icon: IconBrowser,
-    sub: "Best for web demos",
+    sub: "Choose an open tab",
   },
   {
     value: "monitor",

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -806,17 +806,6 @@ export class RecorderEngine {
       await finalDataAvailable;
     }
 
-    // Drain in-flight chunk uploads queued by the start()-time listener
-    // (including the final dataavailable that just fired) before we either
-    // compress + re-upload or send the isFinal sentinel.
-    await this.chunkQueue;
-    if (this.uploadFailure) {
-      this.cleanupTracks();
-      this.localChunks = [];
-      this.transition("error", { message: this.uploadFailure.message });
-      throw this.uploadFailure;
-    }
-
     const dimensions = this.readDimensions();
     const durationMs = Math.round(this.getElapsedMs());
     const hasAudio = this.hasAudioTrack();
@@ -828,6 +817,18 @@ export class RecorderEngine {
       hasCamera,
     };
     this.lastFinalizeMeta = finalizeMeta;
+
+    // Drain in-flight chunk uploads queued by the start()-time listener
+    // (including the final dataavailable that just fired) before we either
+    // compress + re-upload or send the isFinal sentinel. If a streamed upload
+    // already failed, keep `localChunks` + `lastFinalizeMeta` so retryUpload()
+    // can re-send the complete local buffer without a new recording.
+    await this.chunkQueue;
+    if (this.uploadFailure) {
+      this.cleanupTracks();
+      this.transition("error", { message: this.uploadFailure.message });
+      throw this.uploadFailure;
+    }
 
     let result: Record<string, unknown> | undefined;
     let completed = false;

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -111,7 +111,26 @@ export interface RecorderFinalizeResult {
   hasCamera: boolean;
 }
 
+interface RecordingFinalizeMeta {
+  durationMs: number;
+  dimensions: { width: number; height: number };
+  hasAudio: boolean;
+  hasCamera: boolean;
+}
+
+interface CompressionUploadMeta {
+  originalBytes?: number;
+  compressedBytes?: number;
+  ratio?: number;
+  elapsedMs?: number;
+  outputMimeType?: string;
+}
+
 const DEFAULT_CHUNK_MS = 2000;
+const CHUNK_UPLOAD_MAX_ATTEMPTS = 3;
+const RETRYABLE_CHUNK_UPLOAD_STATUSES = new Set([
+  408, 425, 429, 500, 502, 503, 504,
+]);
 type CaptureSource = "screen" | "camera" | "microphone" | "unknown";
 
 const VOICE_FOCUSED_AUDIO_CONSTRAINTS: MediaTrackConstraints = {
@@ -256,6 +275,47 @@ function canStreamMediaRecorderChunks(mimeType: string): boolean {
   return /^video\/webm(?:;|$)/i.test(mimeType);
 }
 
+function isRetryableChunkUploadStatus(status: number): boolean {
+  return RETRYABLE_CHUNK_UPLOAD_STATUSES.has(status);
+}
+
+function retryDelayMs(attempt: number): number {
+  return attempt === 1 ? 500 : 1500;
+}
+
+function waitForRetry(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(
+      signal.reason instanceof Error
+        ? signal.reason
+        : new Error("Upload aborted"),
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    let timer: number;
+    let onAbort: () => void;
+    const cleanup = () => {
+      window.clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const onResolve = () => {
+      cleanup();
+      resolve();
+    };
+    onAbort = () => {
+      cleanup();
+      reject(
+        signal?.reason instanceof Error
+          ? signal.reason
+          : new Error("Upload aborted"),
+      );
+    };
+    timer = window.setTimeout(onResolve, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 export class RecorderEngine {
   readonly opts: Required<
     Pick<RecorderEngineOptions, "chunkIntervalMs" | "uploadUrl" | "abortUrl">
@@ -292,6 +352,7 @@ export class RecorderEngine {
    */
   private localChunks: Blob[] = [];
   private totalRecordedBytes = 0;
+  private lastFinalizeMeta: RecordingFinalizeMeta | null = null;
   /**
    * Owns the abort signal threaded into the compression pass so a `cancel()`
    * during a multi-minute ffmpeg.wasm encode actually terminates the worker
@@ -344,6 +405,14 @@ export class RecorderEngine {
     const pausedNow =
       this.pausedStartedMs !== null ? now - this.pausedStartedMs : 0;
     return Math.max(0, now - this.startedAtMs - this.pausedAccumMs - pausedNow);
+  }
+
+  canRetryUpload(): boolean {
+    return (
+      this.state === "error" &&
+      this.lastFinalizeMeta !== null &&
+      this.localChunks.length > 0
+    );
   }
 
   // -------------------------------------------------------------------------
@@ -411,7 +480,8 @@ export class RecorderEngine {
       const displayOptions: ExtendedDisplayMediaOptions = {
         video: { frameRate: { ideal: 30 }, displaySurface },
         audio: wantsMic,
-        preferCurrentTab: displaySurface === "browser",
+        // Let "Browser tab" open the tab picker. preferCurrentTab turns it
+        // into a current-tab shortcut, which makes choosing another tab harder.
         selfBrowserSurface:
           displaySurface === "browser" ? "include" : "exclude",
         surfaceSwitching: "include",
@@ -578,6 +648,7 @@ export class RecorderEngine {
     this.uploadFailure = null;
     this.localChunks = [];
     this.totalRecordedBytes = 0;
+    this.lastFinalizeMeta = null;
     this.uploadAbort = new AbortController();
     this.streamChunksDuringRecording = canStreamMediaRecorderChunks(
       this.mimeType,
@@ -750,31 +821,29 @@ export class RecorderEngine {
     const durationMs = Math.round(this.getElapsedMs());
     const hasAudio = this.hasAudioTrack();
     const hasCamera = !!this.cameraStream;
+    const finalizeMeta: RecordingFinalizeMeta = {
+      durationMs,
+      dimensions,
+      hasAudio,
+      hasCamera,
+    };
+    this.lastFinalizeMeta = finalizeMeta;
 
     let result: Record<string, unknown> | undefined;
+    let completed = false;
     try {
       if (this.totalRecordedBytes > COMPRESS_THRESHOLD_BYTES) {
         // Discard everything that streamed up during recording — it's
         // about to be replaced by the compressed assembly below — and
         // re-upload from index 0.
-        result = await this.compressAndReupload({
-          durationMs,
-          dimensions,
-          hasAudio,
-          hasCamera,
-        });
+        result = await this.compressAndReupload(finalizeMeta);
       } else if (!this.streamChunksDuringRecording) {
         this.transition("uploading", { progress: 0 });
         const assembled = new Blob(this.localChunks, { type: this.mimeType });
         result = await this.uploadBlobInSlices(
           assembled,
           this.mimeType,
-          {
-            durationMs,
-            dimensions,
-            hasAudio,
-            hasCamera,
-          },
+          finalizeMeta,
           this.uploadAbort?.signal,
         );
       } else {
@@ -800,6 +869,7 @@ export class RecorderEngine {
         );
       }
       this.transition("complete");
+      completed = true;
     } catch (err) {
       // Reachable from compressAndReupload (compression failure, OOM,
       // reset-chunks failure, hard-cap exceeded, abort) and from the
@@ -812,25 +882,117 @@ export class RecorderEngine {
     } finally {
       // Always release hardware resources, even if the final upload failed.
       this.cleanupTracks();
-      // Drop the in-memory chunks now that they're either uploaded or no
-      // longer needed by this engine. If storage was missing, the server keeps
-      // its uploaded chunk scratch-space and the player page resumes finalize
-      // after the user connects Builder.io/S3.
-      this.localChunks = [];
+      // Keep the in-memory chunks after an upload failure so the error screen
+      // can retry the upload without making the user re-record. They are
+      // dropped on success or when cancel/restart runs.
+      if (completed) {
+        this.localChunks = [];
+        this.lastFinalizeMeta = null;
+      }
     }
 
+    return this.toFinalizeResult(result, finalizeMeta);
+  }
+
+  async retryUpload(): Promise<RecorderFinalizeResult> {
+    const meta = this.lastFinalizeMeta;
+    if (!meta || this.localChunks.length === 0) {
+      throw new Error(
+        "This recording no longer has local upload data to retry.",
+      );
+    }
+
+    this.uploadFailure = null;
+    this.chunkIndex = 0;
+    this.uploadAbort = new AbortController();
+
+    let result: Record<string, unknown> | undefined;
+    let completed = false;
+    try {
+      result = await this.uploadBufferedChunks(meta, this.uploadAbort.signal);
+      this.transition("complete");
+      completed = true;
+      return this.toFinalizeResult(result, meta);
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      this.transition("error", { message: e.message });
+      throw e;
+    } finally {
+      if (completed) {
+        this.localChunks = [];
+        this.lastFinalizeMeta = null;
+      }
+    }
+  }
+
+  private toFinalizeResult(
+    result: Record<string, unknown> | undefined,
+    meta: RecordingFinalizeMeta,
+  ): RecorderFinalizeResult {
     return {
       videoUrl: (result?.videoUrl as string | undefined) ?? null,
       status: result?.status as string | undefined,
       waitingForStorage:
         result?.waitingForStorage === true ||
         result?.status === "waiting_storage",
-      durationMs,
-      width: dimensions.width,
-      height: dimensions.height,
-      hasAudio,
-      hasCamera,
+      durationMs: meta.durationMs,
+      width: meta.dimensions.width,
+      height: meta.dimensions.height,
+      hasAudio: meta.hasAudio,
+      hasCamera: meta.hasCamera,
     };
+  }
+
+  private async uploadBufferedChunks(
+    meta: RecordingFinalizeMeta,
+    signal?: AbortSignal,
+  ): Promise<Record<string, unknown> | undefined> {
+    if (this.totalRecordedBytes > COMPRESS_THRESHOLD_BYTES) {
+      return this.compressAndReupload(meta);
+    }
+
+    await this.resetUploadedChunks(null, signal);
+    this.transition("uploading", { progress: 0 });
+    const assembled = new Blob(this.localChunks, { type: this.mimeType });
+    return this.uploadBlobInSlices(assembled, this.mimeType, meta, signal);
+  }
+
+  private async resetUploadedChunks(
+    compression: CompressionUploadMeta | null,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const resetUrl = `${appBasePath()}/api/uploads/${
+      this.opts.recordingId
+    }/reset-chunks`;
+    let resetRes: Response;
+    try {
+      resetRes = await fetch(resetUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ compression }),
+        signal,
+      });
+    } catch (err) {
+      // The user clicking Cancel mid-fetch makes the AbortController abort and
+      // `fetch` rejects with an AbortError. Preserve that identity so the UI
+      // treats it as cancellation, not as a failed upload.
+      if ((err as { name?: string } | null)?.name === "AbortError") {
+        throw err;
+      }
+      throw new Error(
+        `Couldn't prepare the recording for re-upload (network error contacting reset-chunks). ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+    if (!resetRes.ok) {
+      const text = await resetRes.text().catch(() => "");
+      throw new Error(
+        `Couldn't prepare the recording for re-upload (reset-chunks ${
+          resetRes.status
+        }). ${text || resetRes.statusText}`,
+      );
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -849,12 +1011,9 @@ export class RecorderEngine {
    * than `MAX_UPLOAD_BYTES`, so the UI can suggest "shorter recording / lower
    * resolution" rather than letting the upload fail with a 500.
    */
-  private async compressAndReupload(meta: {
-    durationMs: number;
-    dimensions: { width: number; height: number };
-    hasAudio: boolean;
-    hasCamera: boolean;
-  }): Promise<Record<string, unknown> | undefined> {
+  private async compressAndReupload(
+    meta: RecordingFinalizeMeta,
+  ): Promise<Record<string, unknown> | undefined> {
     this.transition("compressing");
 
     // Owned for the lifetime of this single call so `cancel()` can abort
@@ -914,9 +1073,6 @@ export class RecorderEngine {
       // concatenate them into a corrupted blob that decodes to a
       // mid-clip glitch followed by garbage. Better a clean error than a
       // silently-broken recording.
-      const resetUrl = `${appBasePath()}/api/uploads/${
-        this.opts.recordingId
-      }/reset-chunks`;
       const compressionPayload = compression.compressed
         ? {
             originalBytes,
@@ -926,39 +1082,7 @@ export class RecorderEngine {
             outputMimeType: compression.outputMimeType,
           }
         : null;
-      let resetRes: Response;
-      try {
-        resetRes = await fetch(resetUrl, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ compression: compressionPayload }),
-          signal: abort.signal,
-        });
-      } catch (err) {
-        // The user clicking Cancel mid-fetch makes the AbortController
-        // abort and `fetch` rejects with a DOMException whose
-        // `name === "AbortError"`. Wrapping that into a generic network
-        // error would lose the AbortError identity, so doStop()'s catch
-        // would surface a misleading "Upload failed (network error)"
-        // toast for what is actually an intentional cancel. Re-throw the
-        // abort untouched; only wrap genuine non-abort failures.
-        if ((err as { name?: string } | null)?.name === "AbortError") {
-          throw err;
-        }
-        throw new Error(
-          `Couldn't prepare the recording for re-upload (network error contacting reset-chunks). ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-      }
-      if (!resetRes.ok) {
-        const text = await resetRes.text().catch(() => "");
-        throw new Error(
-          `Couldn't prepare the recording for re-upload (reset-chunks ${
-            resetRes.status
-          }). ${text || resetRes.statusText}`,
-        );
-      }
+      await this.resetUploadedChunks(compressionPayload, abort.signal);
 
       if (compressionError) {
         // Compression itself failed — we still hold the original assembled
@@ -1045,6 +1169,7 @@ export class RecorderEngine {
     this.pausedStartedMs = null;
     this.localChunks = [];
     this.totalRecordedBytes = 0;
+    this.lastFinalizeMeta = null;
     this.transition("idle");
 
     if (this.opts.abortUrl) {
@@ -1275,15 +1400,47 @@ export class RecorderEngine {
     const url = `${this.opts.uploadUrl}?${params.toString()}`;
 
     const body = await blob.arrayBuffer();
-    const res = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type":
-          blob.type || this.mimeType || "application/octet-stream",
-      },
-      body,
-      signal: extra.signal,
-    });
+    let res: Response | null = null;
+    for (let attempt = 1; attempt <= CHUNK_UPLOAD_MAX_ATTEMPTS; attempt++) {
+      try {
+        res = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type":
+              blob.type || this.mimeType || "application/octet-stream",
+          },
+          body,
+          signal: extra.signal,
+        });
+      } catch (err) {
+        if (
+          extra.isFinal ||
+          attempt >= CHUNK_UPLOAD_MAX_ATTEMPTS ||
+          (err as { name?: string } | null)?.name === "AbortError"
+        ) {
+          throw err;
+        }
+        await waitForRetry(retryDelayMs(attempt), extra.signal);
+        continue;
+      }
+
+      if (
+        !res.ok &&
+        !extra.isFinal &&
+        attempt < CHUNK_UPLOAD_MAX_ATTEMPTS &&
+        isRetryableChunkUploadStatus(res.status)
+      ) {
+        await res.text().catch(() => "");
+        await waitForRetry(retryDelayMs(attempt), extra.signal);
+        continue;
+      }
+
+      break;
+    }
+
+    if (!res) {
+      throw new Error(`Chunk ${index} upload failed: no response`);
+    }
 
     if (!res.ok) {
       const text = await res.text().catch(() => "");

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -85,6 +85,7 @@ import {
   RecorderEngine,
   NO_MIC_DEVICE_ID,
   type DisplaySurface,
+  type RecorderFinalizeResult,
   type RecordingMode,
 } from "@/components/recorder/recorder-engine";
 import type { CameraBubbleSize } from "@/components/recorder/camera-bubble";
@@ -368,11 +369,15 @@ function getDisplaySurfaceParam(value: string | null): DisplaySurface | null {
 }
 
 function getRecordingErrorTitle(error: string): string {
-  if (/upload failed|chunk/i.test(error)) return "Upload failed";
+  if (isUploadFailureError(error)) return "Upload failed";
   if (isScreenPermissionError(error)) return "Screen recording needs access";
   if (isCameraPermissionError(error)) return "Camera needs access";
   if (isMicrophonePermissionError(error)) return "Microphone needs access";
   return "Couldn't start recording";
+}
+
+function isUploadFailureError(error: string): boolean {
+  return /upload failed|chunk|reset-chunks|re-upload/i.test(error);
 }
 
 function friendlyRecordingErrorMessage(error: string): string {
@@ -391,8 +396,8 @@ function friendlyRecordingErrorMessage(error: string): string {
   if (isMicrophonePermissionError(error)) {
     return "Clips could not start the microphone. Allow microphone access, then try again.";
   }
-  if (/upload failed|chunk/i.test(error)) {
-    return "The recording could not finish uploading. Check video storage, then try again.";
+  if (isUploadFailureError(error)) {
+    return "The recording could not finish uploading. Retry the upload before starting over.";
   }
   if (error.length > 220) {
     return "Something blocked the recorder before it could start.";
@@ -482,11 +487,13 @@ function RecordingErrorCard({
   error,
   mode,
   micDeviceId,
+  canRetryUpload,
   onTryAgain,
 }: {
   error: string;
   mode: RecordingMode;
   micDeviceId: string | null;
+  canRetryUpload: boolean;
   onTryAgain: () => void;
 }) {
   const guidance = permissionGuidance(error, { mode, micDeviceId });
@@ -537,7 +544,7 @@ function RecordingErrorCard({
       <div className="space-y-3 p-6">
         <Button variant="outline" onClick={onTryAgain} className="w-full gap-2">
           <IconRefresh className="h-4 w-4" />
-          Try again
+          {canRetryUpload ? "Retry upload" : "Try again"}
         </Button>
         {(policyError || embeddedScreenError) && (
           <Button
@@ -1329,6 +1336,37 @@ export default function RecordRoute() {
   // -------------------------------------------------------------------------
   // Stop / upload / navigate.
   // -------------------------------------------------------------------------
+  const finishSavedRecording = useCallback(
+    async (recordingId: string, result: RecorderFinalizeResult) => {
+      // Recording is fully saved — clear refs so that if anything below throws
+      // and the user clicks "Try again", doCancel() won't trash a good recording.
+      pendingRef.current = null;
+      engineRef.current = null;
+      setCameraStream(null);
+      setPreviewStream(null);
+      setCompressionProgress(null);
+      setUiState("complete");
+      if (result.waitingForStorage) {
+        toast.info("Recording is ready to upload", {
+          description:
+            "Connect Builder.io or S3 storage on the next screen and Clips will finish saving it.",
+          duration: 12_000,
+        });
+      } else {
+        toast.success("Recording saved");
+      }
+
+      await writeAppState("navigate", {
+        view: "recording",
+        recordingId,
+      }).catch(() => {});
+      setTimeout(() => {
+        navigate(`/r/${recordingId}`);
+      }, 50);
+    },
+    [navigate],
+  );
+
   const doStop = useCallback(async () => {
     const engine = engineRef.current;
     const pending = pendingRef.current;
@@ -1380,30 +1418,7 @@ export default function RecordRoute() {
       }
 
       const stopResult = await engine.stop();
-      // Recording is fully saved — clear refs so that if anything below throws
-      // and the user clicks "Try again", doCancel() won't trash a good recording.
-      pendingRef.current = null;
-      engineRef.current = null;
-      setCameraStream(null);
-      setPreviewStream(null);
-      setUiState("complete");
-      if (stopResult.waitingForStorage) {
-        toast.info("Recording is ready to upload", {
-          description:
-            "Connect Builder.io or S3 storage on the next screen and Clips will finish saving it.",
-          duration: 12_000,
-        });
-      } else {
-        toast.success("Recording saved");
-      }
-
-      await writeAppState("navigate", {
-        view: "recording",
-        recordingId: pending.id,
-      });
-      setTimeout(() => {
-        navigate(`/r/${pending.id}`);
-      }, 50);
+      await finishSavedRecording(pending.id, stopResult);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Upload failed";
       // Distinguish user-initiated cancel from real failure. When the user
@@ -1438,10 +1453,41 @@ export default function RecordRoute() {
         duration: 12_000,
       });
     }
-  }, [navigate, liveTranscription]);
+  }, [finishSavedRecording, liveTranscription]);
 
   // Keep the ref current so engine callbacks always invoke the latest doStop.
   doStopRef.current = doStop;
+
+  const retryFailedUpload = useCallback(async () => {
+    const engine = engineRef.current;
+    const pending = pendingRef.current;
+    if (!engine || !pending || !engine.canRetryUpload()) return;
+
+    setError(null);
+    setCompressionProgress(null);
+    setUiState("uploading");
+    try {
+      const retryResult = await engine.retryUpload();
+      await finishSavedRecording(pending.id, retryResult);
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") {
+        return;
+      }
+      const message = err instanceof Error ? err.message : "Upload failed";
+      fetch(pending.abortUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reason: message }),
+      }).catch(() => {});
+      setCompressionProgress(null);
+      setError(message);
+      setUiState("error");
+      toast.error("Upload failed", {
+        description: message,
+        duration: 12_000,
+      });
+    }
+  }, [finishSavedRecording]);
 
   const requestStop = useCallback(() => {
     const engine = engineRef.current;
@@ -1645,6 +1691,7 @@ export default function RecordRoute() {
     uiState === "compressing";
   const showCameraBubble =
     cameraStream !== null && recordingMode !== "screen" && uiState !== "idle";
+  const rememberedRecorderOptions = pendingStartOptsRef.current;
 
   // `/record` is a fullscreen route outside the `_app` shell, so it has no
   // sidebar back-affordance. Surface a back arrow whenever there's nothing in
@@ -1700,8 +1747,14 @@ export default function RecordRoute() {
                 ) : storageConfigured ? (
                   <PreRecordPanel
                     onStart={startFlow}
-                    initialMode={initialRecorderOptions.mode}
-                    initialDisplaySurface={initialRecorderOptions.surface}
+                    initialMode={
+                      rememberedRecorderOptions?.mode ??
+                      initialRecorderOptions.mode
+                    }
+                    initialDisplaySurface={
+                      rememberedRecorderOptions?.displaySurface ??
+                      initialRecorderOptions.surface
+                    }
                     onUpload={uploadFile}
                     cameraSize={cameraSize}
                     onCameraSizeChange={setCameraSize}
@@ -1877,10 +1930,15 @@ export default function RecordRoute() {
               error={error}
               mode={recordingMode}
               micDeviceId={pendingStartOptsRef.current?.micDeviceId ?? null}
+              canRetryUpload={!!engineRef.current?.canRetryUpload()}
               onTryAgain={() => {
-                // Re-run the same flow with the current mode/surface — users
-                // expect "Try again" to retry, not to wipe their selections.
-                void restart();
+                if (engineRef.current?.canRetryUpload()) {
+                  void retryFailedUpload();
+                } else {
+                  // Re-run the same flow with the current mode/surface — users
+                  // expect "Try again" to retry, not to wipe their selections.
+                  void restart();
+                }
               }}
             />
           )}


### PR DESCRIPTION
## Summary
- Make the Clips Browser tab capture source use Chrome's full tab picker instead of the current-tab shortcut, and clarify the source copy.
- Preserve the selected recorder mode/source when the native capture picker is cancelled.
- Keep recorder upload data available for retry after upload failures, with retryable chunk uploads and a retry action in the error UI.
- Route signed Builder connect/OAuth flows to the system browser in the desktop app, and refresh MCP app bridge docs.

## Verification
- `pnpm --filter clips typecheck`
- `pnpm --filter @agent-native/desktop-app typecheck`
- `git diff --check`

## Notes
- Local browser smoke reached the auth gate on `/record`; I did not create a throwaway account in-browser.