### PR TITLE
Compact MCP Apps catalog output

### DIFF
--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -137,16 +137,18 @@ agent has a predictable surface without guessing per-app action names:
 A same-named template action overrides a builtin (template-over-core
 precedence). Disable the set with `MCPConfig.builtinCrossAppTools: false`.
 
-For OAuth callers that request `mcp:apps`, the advertised `tools/list` catalog
-is intentionally compact so ChatGPT/Claude app hosts do not ingest every
-internal action schema. The model sees app-facing builtins (`list_apps`,
-`open_app`, app-only `create_embed_session`) and actions with `mcpApp`.
-Stdio/static-token developer clients still get the full connected action
-surface, and `publicAgent.expose` remains the opt-in for safe read/ingest tools
-outside the compact MCP Apps catalog. If a UI-capable host should be able to
-call a new action from an MCP App conversation, mark it with `mcpApp`; use
-`publicAgent` for non-UI read/ingest handoff tools instead of relying on
-incidental full-surface discovery.
+For OAuth callers that request `mcp:apps`, the advertised `tools/list` and
+`resources/list` catalogs are intentionally tiny so ChatGPT/Claude app hosts do
+not ingest every internal action schema or every action-specific UI resource.
+The model sees the generic app-facing verbs (`list_apps`, `open_app`,
+`ask_app`, and app-only `create_embed_session`) and routes UI through
+`open_app({ embed: true })`. Stdio/static-token developer clients still get
+the full connected action surface, and `publicAgent.expose` remains the opt-in
+for safe read/ingest tools outside the compact MCP Apps catalog. Do not rely on
+action-specific `mcpApp` resources appearing in ChatGPT/Claude discovery by
+default; use `open_app` for the first-class app embed path. If a specific
+action truly must remain visible in that compact app-host catalog, set
+`mcpApp.compactCatalog: true` as a rare escape hatch.
 
 ### 1b. Fast-path expectations for MCP Apps hosts
 

--- a/.changeset/compact-mcp-app-catalogs.md
+++ b/.changeset/compact-mcp-app-catalogs.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Default MCP Apps hosts to the compact generic app catalog instead of listing every action-specific UI resource.

--- a/.changeset/quiet-session-owners.md
+++ b/.changeset/quiet-session-owners.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Refuse to auto-bind CLI actions when multiple dev session owners exist.

--- a/packages/core/docs/content/actions.md
+++ b/packages/core/docs/content/actions.md
@@ -152,7 +152,7 @@ If your app is an [A2A](/docs/a2a-protocol) peer, other agent-native apps discov
 
 ## Exposing it over MCP {#mcp}
 
-With MCP enabled, your actions show up in the framework's MCP server at `/_agent-native/mcp`. Stdio/static-token developer clients see the full connected action surface. OAuth app hosts that request `mcp:apps` get a compact catalog containing app-facing builtins and actions with `mcpApp`; `publicAgent.expose` is still the opt-in for safe read/ingest tools outside that compact app catalog. See [MCP Protocol](/docs/mcp-protocol).
+With MCP enabled, your actions show up in the framework's MCP server at `/_agent-native/mcp`. Stdio/static-token developer clients see the full connected action surface. OAuth app hosts that request `mcp:apps` get a compact catalog containing app-facing builtins (`open_app`, `list_apps`, `ask_app`, and app-only embed helpers); action-specific MCP App resources stay out of that catalog unless an action explicitly sets `mcpApp.compactCatalog: true`. `publicAgent.expose` is still the opt-in for safe read/ingest tools outside that compact app catalog. See [MCP Protocol](/docs/mcp-protocol).
 
 For UI-capable MCP hosts, actions can also attach an optional MCP Apps resource.
 Use the shared full-app embed helper when the action needs an inline experience.

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -177,10 +177,9 @@ host. Developer clients and bearer/static-token clients get the app's full
 action surface plus the `ask-agent` meta-tool that runs the full agent loop
 (the same entry point [A2A](/docs/a2a-protocol) uses). OAuth chat hosts that
 request `mcp:apps`, including Claude and ChatGPT, get a compact app-facing
-catalog instead: cross-app verbs such as `list_apps` and `open_app`, app-only
-embed helpers, and actions that explicitly declare `mcpApp`. In both cases,
-ask the agent to do real work and it hands back a link straight into the
-running app:
+catalog instead: cross-app verbs such as `list_apps`, `open_app`, and
+`ask_app`, plus the app-only embed helper. In both cases, ask the agent to do
+real work and it hands back a link straight into the running app:
 
 ```
 > draft an email to John about the Q3 report
@@ -200,6 +199,14 @@ declares `mcpApp`, the server advertises
 `resources/list` + `resources/read` as `text/html;profile=mcp-app`. Resource
 security metadata such as CSP and sandbox permissions lives on the resource
 entries and `resources/read` content, not on the tool descriptor.
+
+For ChatGPT/Claude-style OAuth app hosts, that discovery surface is compact by
+default: `tools/list` and `resources/list` advertise the generic `open_app`
+embed path instead of every action-specific MCP App resource. Use
+`open_app({ path, embed: true })` for first-class inline app previews. Keep
+action-specific MCP App resources for direct app connectors that disable the
+generic builtins, or mark an individual action with `mcpApp.compactCatalog: true`
+only when it truly needs to stay visible in chat-host discovery.
 
 That makes the same app surface available to every compatible host rather than building per-client shims. The current official MCP Apps client list includes Claude, Claude Desktop, VS Code GitHub Copilot, Goose, Postman, MCPJam, ChatGPT, and Cursor; host support still varies by plan, release channel, and client version, so check the [MCP extension support matrix](https://modelcontextprotocol.io/extensions/client-matrix). ChatGPT custom MCP apps are available through developer mode for Business and Enterprise/Edu workspaces on ChatGPT web; see OpenAI's [developer mode and MCP apps](https://help.openai.com/en/articles/12584461-developer-mode-and-full-mcp-apps-in-chatgpt-beta) notes.
 
@@ -310,7 +317,16 @@ On top of the per-action tools the MCP server exposes a stable verb set, so an e
 
 `create_workspace_app` rejects any non-allow-listed template — the public template allow-list in `packages/shared-app-config/templates.ts` is authoritative and CI-guarded; an external agent cannot widen it. A same-named template action overrides a builtin (template-over-core precedence). Disable the whole set with `MCPConfig.builtinCrossAppTools: false`.
 
-For OAuth callers that request `mcp:apps`, the server intentionally advertises a compact `tools/list` catalog so app hosts do not ingest every internal action schema. The model sees app-facing builtins (`list_apps`, `open_app`, app-only `create_embed_session`) and actions with `mcpApp`. Stdio/static-token developer clients still get the full connected action surface, and `publicAgent.expose` remains the opt-in for safe read/ingest tools outside the compact app catalog. If a UI-capable host should be able to call a new action from an MCP App conversation, mark it with `mcpApp`; use `publicAgent` for non-UI read/ingest handoff tools.
+For OAuth callers that request `mcp:apps`, the server intentionally advertises
+tiny `tools/list` and `resources/list` catalogs so app hosts do not ingest
+every internal action schema or every action-specific UI resource. The model
+sees app-facing builtins (`list_apps`, `open_app`, `ask_app`, and app-only
+`create_embed_session`) and routes inline UI through
+`open_app({ embed: true })`. Stdio/static-token developer clients still get
+the full connected action surface, and `publicAgent.expose` remains the opt-in
+for safe read/ingest tools outside the compact app catalog. If an individual
+UI action must remain visible to ChatGPT/Claude discovery, set
+`mcpApp.compactCatalog: true`, but treat that as a rare exception.
 
 For fast ChatGPT/Claude handoffs, the ideal path is direct: call the action that creates or opens the artifact, then let the MCP App launch the route. A Mail request should call `manage_draft` and render the real compose route. A dashboard request should call `open_app({ path, embed: true })` or a dashboard action with `mcpApp` and render the full Analytics route. Calendar, Forms, Content, Slides, Design, and Clips should follow the same pattern with their draft/create/search actions. `list_apps` is useful when the model must choose among granted apps; broad `resources/list`, full-catalog discovery, or `ask_app` delegation should not be the normal route for an obvious UI handoff.
 

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -148,7 +148,7 @@ request. Embedded routes must remain functional in the default inline mode.
 
 ## Tools {#tools}
 
-Stdio/static-token developer clients see all connected app actions as MCP tools. OAuth callers that request `mcp:apps` get a compact app-host catalog: app-facing builtins and actions with `mcpApp`. `publicAgent.expose` remains the opt-in for safe read/ingest tools outside that compact app catalog. This keeps ChatGPT/Claude app-host discovery small while preserving the full developer surface for local agents.
+Stdio/static-token developer clients see all connected app actions as MCP tools. OAuth callers that request `mcp:apps` get a compact app-host catalog: app-facing builtins (`list_apps`, `open_app`, `ask_app`, and app-only `create_embed_session`) plus rare actions marked `mcpApp.compactCatalog: true`. Their `resources/list` is compact too, normally advertising only the generic `open_app` embed resource. `publicAgent.expose` remains the opt-in for safe read/ingest tools outside that compact app catalog. This keeps ChatGPT/Claude app-host discovery small while preserving the full developer surface for local agents.
 
 The mapping is direct:
 

--- a/packages/core/src/a2a/handlers.spec.ts
+++ b/packages/core/src/a2a/handlers.spec.ts
@@ -173,6 +173,10 @@ describe("handleJsonRpc", () => {
   beforeEach(() => {
     resolveOrgByDomainMock.mockReset();
     resolveOrgIdForEmailMock.mockReset();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("ok")),
+    );
   });
 
   afterEach(() => {

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -145,6 +145,13 @@ export interface ActionMcpAppConfig {
    * action and the app iframe can call it back through the host bridge.
    */
   visibility?: Array<"model" | "app">;
+  /**
+   * Rare escape hatch for MCP Apps chat hosts. By default OAuth callers with
+   * `mcp:apps` see the generic app tools (`open_app`, `list_apps`, etc.) so
+   * hosts do not ingest every action-specific UI resource. Set this only when
+   * this specific action must stay visible in that compact catalog.
+   */
+  compactCatalog?: boolean;
 }
 
 /** Schema definition for a single action parameter (legacy JSON schema style). */

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -138,14 +138,9 @@ function isActionVisibleForOAuthScope(
 const COMPACT_MCP_APP_CATALOG_BUILTINS = new Set([
   "list_apps",
   "open_app",
+  "ask_app",
   "create_embed_session",
 ]);
-
-function isDispatchConfig(config: MCPConfig): boolean {
-  const id = (config.appId ?? "").toLowerCase();
-  const name = (config.name ?? "").toLowerCase();
-  return id === "dispatch" || name.includes("dispatch");
-}
 
 function isActionAdvertisedInCompactMcpAppCatalog(
   config: MCPConfig,
@@ -153,8 +148,20 @@ function isActionAdvertisedInCompactMcpAppCatalog(
   entry: ActionEntry,
 ): boolean {
   if (COMPACT_MCP_APP_CATALOG_BUILTINS.has(name)) return true;
-  if (name === "ask_app" && isDispatchConfig(config)) return true;
-  return Boolean(entry.mcpApp?.resource);
+  if (
+    (entry.mcpApp as { compactCatalog?: unknown } | undefined)
+      ?.compactCatalog === true
+  ) {
+    return true;
+  }
+  // If an app deliberately disables the generic open_app builtin, fall back to
+  // its action-specific MCP App tools so it still has a UI surface. The normal
+  // default is the opposite: keep chat-host catalogs tiny and route UI via
+  // open_app instead of listing every app action/template.
+  if (config.builtinCrossAppTools === false) {
+    return Boolean(entry.mcpApp?.resource);
+  }
+  return false;
 }
 
 const MCP_APP_OAUTH_CLIENT_RE = /\b(chatgpt|openai|claude|anthropic)\b/i;

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -17,7 +17,72 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Heavy/irrelevant deps mocked so importing build-server.ts is cheap. The
 // MCP SDK itself is REAL — that's the whole point of these tests.
 vi.mock("./builtin-tools.js", () => ({
-  getBuiltinCrossAppTools: () => ({}),
+  getBuiltinCrossAppTools: () => ({
+    list_apps: {
+      tool: {
+        description: "List workspace apps",
+      },
+      readOnly: true,
+      run: async () => ({ apps: [] }),
+    },
+    open_app: {
+      tool: {
+        description: "Open a workspace app",
+        parameters: {
+          type: "object",
+          properties: {
+            app: { type: "string" },
+            path: { type: "string" },
+            embed: { type: "boolean" },
+          },
+        },
+      },
+      readOnly: true,
+      run: async () => ({ app: "mail", url: "/inbox", embed: true }),
+      mcpApp: {
+        resource: {
+          uri: "ui://mail/open_app",
+          title: "Open app",
+          description: "Open the app inline.",
+          html: "<!doctype html><html><body>Open app</body></html>",
+        },
+      },
+    },
+    ask_app: {
+      tool: {
+        description: "Ask a workspace app",
+        parameters: {
+          type: "object",
+          properties: {
+            app: { type: "string" },
+            message: { type: "string" },
+          },
+          required: ["app", "message"],
+        },
+      },
+      run: async () => ({ response: "agent answer" }),
+    },
+    create_embed_session: {
+      tool: {
+        description: "Create an embed session",
+        _meta: { ui: { visibility: ["app"] } },
+      },
+      run: async () => ({ startUrl: "/_agent-native/embed/start/mock" }),
+    },
+    create_workspace_app: {
+      tool: {
+        description: "Scaffold a workspace app",
+      },
+      run: async () => ({ url: "/new-app" }),
+    },
+    list_templates: {
+      tool: {
+        description: "List app templates",
+      },
+      readOnly: true,
+      run: async () => ({ templates: [] }),
+    },
+  }),
 }));
 vi.mock("../org/context.js", () => ({
   resolveOrgByDomain: vi.fn(async () => null),
@@ -190,6 +255,9 @@ const config = {
 const veryLongInternalDescription = "INTERNAL_TOOL_BLOAT_SENTINEL ".repeat(
   1_000,
 );
+const veryLongMcpAppDescription = "MCP_APP_RESOURCE_BLOAT_SENTINEL ".repeat(
+  1_000,
+);
 
 const compactSurfaceConfig = {
   ...config,
@@ -230,6 +298,36 @@ const compactSurfaceConfig = {
           title: "Draft review",
           description: "Open the draft in Mail.",
           html: "<!doctype html><html><body>Draft</body></html>",
+        },
+      },
+    },
+  },
+};
+
+const compactSurfaceDefaultConfig = {
+  ...compactSurfaceConfig,
+  builtinCrossAppTools: true as const,
+  actions: {
+    ...compactSurfaceConfig.actions,
+    "bloated-widget": {
+      tool: {
+        description: veryLongMcpAppDescription,
+        parameters: {
+          type: "object" as const,
+          properties: {
+            hugeWidgetPayload: {
+              type: "string",
+              description: veryLongMcpAppDescription,
+            },
+          },
+        },
+      },
+      run: async () => ({ id: "widget-1", message: "Widget ready" }),
+      mcpApp: {
+        resource: {
+          title: "Bloated widget",
+          description: veryLongMcpAppDescription,
+          html: `<!doctype html><html><body>${veryLongMcpAppDescription}</body></html>`,
         },
       },
     },
@@ -395,6 +493,188 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(names).not.toContain("ask-agent");
     expect(JSON.stringify(out)).not.toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
     expect(JSON.stringify(out).length).toBeLessThan(12_000);
+  });
+
+  it("defaults MCP Apps hosts to a tiny generic catalog instead of browser-freezing action/resource dumps", async () => {
+    const toolsOut = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 120,
+        method: "tools/list",
+        params: {},
+      },
+      {
+        headers: await mcpAppsAuthHeaders(),
+        config: compactSurfaceDefaultConfig,
+      },
+    );
+
+    expect(toolsOut.error).toBeUndefined();
+    const names = toolsOut.result.tools.map((t: any) => t.name);
+    expect(names).toEqual([
+      "list_apps",
+      "open_app",
+      "ask_app",
+      "create_embed_session",
+    ]);
+    expect(names).not.toContain("echo-thing");
+    expect(names).not.toContain("review-draft");
+    expect(names).not.toContain("bloated-widget");
+    expect(names).not.toContain("internal-heavy");
+    expect(names).not.toContain("create_workspace_app");
+    expect(names).not.toContain("list_templates");
+    expect(JSON.stringify(toolsOut)).not.toContain(
+      "INTERNAL_TOOL_BLOAT_SENTINEL",
+    );
+    expect(JSON.stringify(toolsOut)).not.toContain(
+      "MCP_APP_RESOURCE_BLOAT_SENTINEL",
+    );
+    expect(JSON.stringify(toolsOut).length).toBeLessThan(12_000);
+
+    const resourcesOut = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 121,
+        method: "resources/list",
+        params: {},
+      },
+      {
+        headers: await mcpAppsAuthHeaders(),
+        config: compactSurfaceDefaultConfig,
+      },
+    );
+
+    expect(resourcesOut.error).toBeUndefined();
+    expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
+      "ui://mail/open_app/shell-v25",
+    ]);
+    expect(JSON.stringify(resourcesOut)).not.toContain(
+      "INTERNAL_TOOL_BLOAT_SENTINEL",
+    );
+    expect(JSON.stringify(resourcesOut)).not.toContain(
+      "MCP_APP_RESOURCE_BLOAT_SENTINEL",
+    );
+    expect(JSON.stringify(resourcesOut).length).toBeLessThan(8_000);
+
+    const templatesOut = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 122,
+        method: "resources/templates/list",
+        params: {},
+      },
+      {
+        headers: await mcpAppsAuthHeaders(),
+        config: compactSurfaceDefaultConfig,
+      },
+    );
+
+    expect(templatesOut.error).toBeUndefined();
+    expect(
+      templatesOut.result.resourceTemplates.map((r: any) => r.uriTemplate),
+    ).toEqual(["ui://mail/open_app/shell-v25"]);
+    expect(JSON.stringify(templatesOut)).not.toContain(
+      "INTERNAL_TOOL_BLOAT_SENTINEL",
+    );
+    expect(JSON.stringify(templatesOut)).not.toContain(
+      "MCP_APP_RESOURCE_BLOAT_SENTINEL",
+    );
+    expect(JSON.stringify(templatesOut).length).toBeLessThan(8_000);
+
+    const hiddenRead = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 123,
+        method: "resources/read",
+        params: { uri: "ui://mail/review-draft/shell-v25" },
+      },
+      {
+        headers: await mcpAppsAuthHeaders(),
+        config: compactSurfaceDefaultConfig,
+      },
+    );
+
+    expect(hiddenRead.error?.message).toContain("MCP App resource not found");
+
+    const bloatedResourceRead = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 126,
+        method: "resources/read",
+        params: { uri: "ui://mail/bloated-widget/shell-v25" },
+      },
+      {
+        headers: await mcpAppsAuthHeaders(),
+        config: compactSurfaceDefaultConfig,
+      },
+    );
+
+    expect(bloatedResourceRead.error?.message).toContain(
+      "MCP App resource not found",
+    );
+    expect(JSON.stringify(bloatedResourceRead)).not.toContain(
+      "MCP_APP_RESOURCE_BLOAT_SENTINEL",
+    );
+  });
+
+  it("keeps explicitly opted-in actions in the compact MCP Apps catalog", async () => {
+    const optInConfig = {
+      ...compactSurfaceDefaultConfig,
+      actions: {
+        ...compactSurfaceDefaultConfig.actions,
+        "status-panel": {
+          tool: {
+            description: "Open a small status panel",
+          },
+          readOnly: true,
+          run: async () => ({ status: "ok" }),
+          mcpApp: {
+            compactCatalog: true,
+            resource: {
+              title: "Status panel",
+              html: "<!doctype html><html><body>Status</body></html>",
+            },
+          },
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 124,
+        method: "tools/list",
+        params: {},
+      },
+      {
+        headers: await mcpAppsAuthHeaders(),
+        config: optInConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    const names = out.result.tools.map((t: any) => t.name);
+    expect(names).toContain("status-panel");
+    expect(names).not.toContain("review-draft");
+
+    const resourcesOut = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 125,
+        method: "resources/list",
+        params: {},
+      },
+      {
+        headers: await mcpAppsAuthHeaders(),
+        config: optInConfig,
+      },
+    );
+
+    expect(resourcesOut.error).toBeUndefined();
+    expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
+      "ui://mail/open_app/shell-v25",
+      "ui://mail/status-panel/shell-v25",
+    ]);
   });
 
   it("blocks compact MCP Apps callers from invoking hidden tools by name", async () => {

--- a/packages/core/src/scripts/dev-session.spec.ts
+++ b/packages/core/src/scripts/dev-session.spec.ts
@@ -46,7 +46,7 @@ describe("resolveDevUserEmail", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
-  it("returns the latest sessions.email row in dev with AUTH_MODE unset", async () => {
+  it("returns the sole sessions.email owner in dev with AUTH_MODE unset", async () => {
     vi.stubEnv("AGENT_USER_EMAIL", "");
     vi.stubEnv("NODE_ENV", "development");
     const execute = vi.fn().mockResolvedValue({
@@ -61,12 +61,13 @@ describe("resolveDevUserEmail", () => {
     expect(execute).toHaveBeenCalledOnce();
     const call = execute.mock.calls[0][0];
     expect(call.sql).toContain("FROM sessions");
-    expect(call.sql).toContain("ORDER BY created_at DESC");
+    expect(call.sql).toContain("GROUP BY TRIM(email)");
+    expect(call.sql).toContain("LIMIT 2");
     // Sentinel must be excluded from the result set
     expect(call.args).toEqual(["local@localhost"]);
   });
 
-  it("returns the latest sessions.email row when AUTH_MODE === 'local'", async () => {
+  it("returns the sole sessions.email owner when AUTH_MODE === 'local'", async () => {
     vi.stubEnv("AGENT_USER_EMAIL", "");
     vi.stubEnv("NODE_ENV", "development");
     vi.stubEnv("AUTH_MODE", "local");
@@ -79,6 +80,24 @@ describe("resolveDevUserEmail", () => {
 
     const { resolveDevUserEmail } = await import("./dev-session.js");
     expect(await resolveDevUserEmail()).toBe("alice@local");
+  });
+
+  it("refuses to guess when multiple session owners exist", async () => {
+    vi.stubEnv("AGENT_USER_EMAIL", "");
+    vi.stubEnv("NODE_ENV", "development");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const execute = vi.fn().mockResolvedValue({
+      rows: [{ email: "emma@builder.io" }, { email: "tim@builder.io" }],
+    });
+    vi.doMock("../db/client.js", () => ({
+      getDbExec: () => ({ execute }),
+    }));
+
+    const { resolveDevUserEmail } = await import("./dev-session.js");
+    expect(await resolveDevUserEmail()).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      "[dev-session] multiple session owners found (emma@builder.io, tim@builder.io); set AGENT_USER_EMAIL=<email> to choose one",
+    );
   });
 
   it("returns undefined when sessions table is empty", async () => {

--- a/packages/core/src/scripts/dev-session.ts
+++ b/packages/core/src/scripts/dev-session.ts
@@ -9,20 +9,16 @@
  * this helper every db-* CLI run hands the user a stack trace.
  *
  * What this does: when the runner is about to dispatch, resolve a real
- * email by reading the most-recent row from the legacy `sessions` table
- * (the same table that `addSession()` writes from google-oauth.ts and the
- * A2A receiver fallback already consults). The runner then wraps dispatch
- * in `runWithRequestContext({ userEmail })` so the action sees a real
- * identity.
+ * email from the legacy `sessions` table (the same table that
+ * `addSession()` writes from google-oauth.ts and the A2A receiver fallback
+ * already consults). The runner then wraps dispatch in
+ * `runWithRequestContext({ userEmail })` so the action sees a real identity.
  *
- * SHARED-DEV-BOX CAVEAT: the `SELECT email FROM sessions ORDER BY
- * created_at DESC LIMIT 1` query is unscoped — on a machine where
- * multiple developers have signed in (or after a `pnpm action …` run
- * from another team's app), this will bind to whoever signed in most
- * recently across *all* sessions in the DB. If that is wrong, set
- * `AGENT_USER_EMAIL=<your-email>` in your shell or `.env`; explicit env
- * always wins. A `[dev-session]` log line is emitted so wrong-binding
- * is easy to spot.
+ * SHARED-DEV-BOX CAVEAT: this table is unscoped. To avoid silently binding
+ * to another developer, auto-binding only happens when the table contains
+ * exactly one distinct real email. If multiple developers have signed in,
+ * set `AGENT_USER_EMAIL=<your-email>` in your shell or `.env`; explicit env
+ * always wins.
  *
  * Strict gating mirrors the A2A precedent in
  * `server/agent-chat-plugin.ts` (search for "latest session"):
@@ -61,13 +57,31 @@ export async function resolveDevUserEmail(): Promise<string | undefined> {
   try {
     const { getDbExec } = await import("../db/client.js");
     const { rows } = await getDbExec().execute({
-      sql: `SELECT email FROM sessions
-            WHERE email IS NOT NULL AND email <> ?
-            ORDER BY created_at DESC LIMIT 1`,
+      sql: `SELECT email
+            FROM (
+              SELECT TRIM(email) AS email, MAX(created_at) AS last_seen
+              FROM sessions
+              WHERE email IS NOT NULL AND TRIM(email) <> ?
+              GROUP BY TRIM(email)
+            ) AS session_owners
+            WHERE email <> ''
+            ORDER BY last_seen DESC
+            LIMIT 2`,
       args: [DEV_FALLBACK_EMAIL],
     });
-    const email = rows[0]?.email as string | undefined;
-    if (!email || email.trim().length === 0) return undefined;
+    const emails = rows
+      .map((row) => (typeof row.email === "string" ? row.email.trim() : ""))
+      .filter((email) => email.length > 0);
+    if (emails.length === 0) return undefined;
+    if (emails.length > 1) {
+      console.warn(
+        `[dev-session] multiple session owners found (${emails.join(
+          ", ",
+        )}); set AGENT_USER_EMAIL=<email> to choose one`,
+      );
+      return undefined;
+    }
+    const email = emails[0];
     console.log(
       `[dev-session] auto-bound to ${email} (set AGENT_USER_EMAIL to override)`,
     );

--- a/packages/core/src/scripts/runner.ts
+++ b/packages/core/src/scripts/runner.ts
@@ -107,7 +107,7 @@ export async function runScript(options: RunScriptOptions = {}): Promise<void> {
   // it, db-exec / db-query / db-patch and any action that calls
   // `getRequestUserEmail()` see no identity and refuse to run. The
   // resolver picks up `AGENT_USER_EMAIL` if explicitly set, otherwise
-  // reads the most-recent signed-in session from the DB (dev-only,
+  // reads the DB session owner only when it is unambiguous (dev-only,
   // narrowly gated — see dev-session.ts).
   //
   // This wrap is intentionally a single point of injection: it covers


### PR DESCRIPTION
## Summary
- default MCP Apps OAuth hosts to the generic app catalog instead of action-specific MCP App resources
- add a rare mcpApp.compactCatalog escape hatch for intentionally visible action-specific resources
- document the compact ChatGPT/Claude path and add regression coverage for browser-freezing catalog payloads
- stabilize the A2A handlers spec by stubbing async self-dispatch fetches

## Tests
- pnpm --filter @agent-native/core exec vitest --run src/mcp/server.spec.ts src/mcp/builtin-cross-app.spec.ts src/mcp/embed-app.spec.ts src/mcp/embed-route.spec.ts src/mcp/oauth-route.spec.ts src/mcp/connect-route.spec.ts src/mcp/build-server.verify-auth.spec.ts
- pnpm --filter @agent-native/core exec vitest --run src/a2a/handlers.spec.ts
- pnpm prep