### PR TITLE
Fix public SSR caching and MCP extension embeds

### DIFF
--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -309,6 +309,21 @@ escape hatch for routes like full dashboards, filtered inboxes, calendar
 drafts, analyses, or extension pages, and should be used liberally when the
 full app is the clearest review/edit surface.
 
+Do not set standard `_meta.ui.domain` to an app URL. That field is
+host-specific: Claude validates hash subdomains such as
+`{hash}.claudemcpcontent.com`, while ChatGPT has its own widget-domain
+metadata. Let hosts choose their default sandbox origin unless you are emitting
+a host-specific value on purpose. `embedApp()` may still emit
+`openai/widgetDomain` for ChatGPT compatibility.
+
+Extension pages are a special case inside MCP chat embeds. The normal app uses
+`/_agent-native/extensions/:id/render` as a sandboxed child iframe, but MCP
+chat hosts add another ancestor frame and can block that route via
+`frame-ancestors` / `X-Frame-Options`. In MCP chat bridge mode the framework
+renders the extension document as sandboxed `srcDoc` inside the existing app
+route iframe instead; keep `sandbox="allow-scripts allow-forms"` and do not add
+`allow-same-origin`.
+
 For Dispatch, keep the single connector path first-class: the `open_app`
 resource CSP should include the exact origins of apps granted through Dispatch,
 not broad sources like `https:`. This lets Claude's transplant path fetch the

--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -137,16 +137,17 @@ agent has a predictable surface without guessing per-app action names:
 A same-named template action overrides a builtin (template-over-core
 precedence). Disable the set with `MCPConfig.builtinCrossAppTools: false`.
 
-For OAuth callers that request `mcp:apps`, the advertised `tools/list` and
-`resources/list` catalogs are intentionally tiny so ChatGPT/Claude app hosts do
-not ingest every internal action schema or every action-specific UI resource.
-The model sees the generic app-facing verbs (`list_apps`, `open_app`,
-`ask_app`, and app-only `create_embed_session`) and routes UI through
-`open_app({ embed: true })`. Stdio/static-token developer clients still get
-the full connected action surface, and `publicAgent.expose` remains the opt-in
-for safe read/ingest tools outside the compact MCP Apps catalog. Do not rely on
-action-specific `mcpApp` resources appearing in ChatGPT/Claude discovery by
-default; use `open_app` for the first-class app embed path. If a specific
+The advertised `tools/list` and `resources/list` catalogs are intentionally
+tiny by default for ChatGPT/Claude-style app hosts, including OAuth MCP Apps
+callers and generic authenticated remote HTTP/static-token callers. The model
+sees the generic app-facing verbs (`list_apps`, `open_app`, `ask_app`, and
+app-only `create_embed_session`) and routes UI through
+`open_app({ embed: true })`. Stdio/code clients that explicitly identify as
+developer clients keep the full connected action surface, and
+`publicAgent.expose` remains the opt-in for safe read/ingest tools outside the
+compact MCP Apps catalog. Do not rely on action-specific `mcpApp` resources
+appearing in ChatGPT/Claude discovery by default; use `open_app` for the
+first-class app embed path. If a specific
 action truly must remain visible in that compact app-host catalog, set
 `mcpApp.compactCatalog: true` as a rare escape hatch.
 

--- a/.changeset/auth-marketing-fallback.md
+++ b/.changeset/auth-marketing-fallback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Recover built-in auth marketing copy from hosted app request context.

--- a/.changeset/branded-auth-fallback.md
+++ b/.changeset/branded-auth-fallback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Use branded first-party auth pages when the default auth guard serves before a template plugin.

--- a/.changeset/mcp-app-extension-embeds.md
+++ b/.changeset/mcp-app-extension-embeds.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix MCP Apps metadata and extension-page embeds for Claude and ChatGPT hosts.

--- a/.changeset/public-ssr-cache.md
+++ b/.changeset/public-ssr-cache.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep default SSR HTML cache headers public even when requests include auth cookies.

--- a/packages/core/docs/content/actions.md
+++ b/packages/core/docs/content/actions.md
@@ -152,7 +152,7 @@ If your app is an [A2A](/docs/a2a-protocol) peer, other agent-native apps discov
 
 ## Exposing it over MCP {#mcp}
 
-With MCP enabled, your actions show up in the framework's MCP server at `/_agent-native/mcp`. Stdio/static-token developer clients see the full connected action surface. OAuth app hosts that request `mcp:apps` get a compact catalog containing app-facing builtins (`open_app`, `list_apps`, `ask_app`, and app-only embed helpers); action-specific MCP App resources stay out of that catalog unless an action explicitly sets `mcpApp.compactCatalog: true`. `publicAgent.expose` is still the opt-in for safe read/ingest tools outside that compact app catalog. See [MCP Protocol](/docs/mcp-protocol).
+With MCP enabled, your actions show up in the framework's MCP server at `/_agent-native/mcp`. Stdio/code developer clients can see the full connected action surface. Chat-style app hosts, including OAuth MCP Apps callers and generic authenticated remote HTTP/static-token callers, get a compact catalog containing app-facing builtins (`open_app`, `list_apps`, `ask_app`, and app-only embed helpers); action-specific MCP App resources stay out of that catalog unless an action explicitly sets `mcpApp.compactCatalog: true`. `publicAgent.expose` is still the opt-in for safe read/ingest tools outside that compact app catalog. See [MCP Protocol](/docs/mcp-protocol).
 
 For UI-capable MCP hosts, actions can also attach an optional MCP Apps resource.
 Use the shared full-app embed helper when the action needs an inline experience.

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -254,6 +254,20 @@ relays the same host actions over `agentNative.mcpHost.*` postMessage
 requests. Keep the result shape identical for both paths: return a focused
 `link` and concise structured content.
 
+Do not set standard `_meta.ui.domain` to an app URL. MCP Apps treats that field
+as host-specific: Claude validates `{hash}.claudemcpcontent.com`-style sandbox
+domains, while ChatGPT uses its own `openai/widgetDomain` metadata. Omit
+`ui.domain` unless you are deliberately emitting a host-specific value; the host
+will choose a default sandbox origin.
+
+Extension pages keep their sandbox in MCP chat embeds without navigating a
+second route iframe. Normal app usage renders
+`/_agent-native/extensions/:id/render` as a sandboxed child iframe. In MCP chat
+bridge mode the framework renders the same extension document as sandboxed
+`srcDoc` inside the route iframe, avoiding host `frame-ancestors` /
+`X-Frame-Options` failures while preserving `sandbox="allow-scripts
+allow-forms"`.
+
 The resource shell owns the outer host size. `embedApp({ height })` defaults
 to `560px`, clamps the shell to `320-900px`, and reserves `44px` for the small
 toolbar, so the route viewport is `height - 44px`. Keep embedded app routes

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -173,13 +173,14 @@ When the client requests no explicit scope, the app grants all three so the conn
 ## What you can do once connected {#what-you-can-do}
 
 Once your agent is connected, the available MCP tool surface depends on the
-host. Developer clients and bearer/static-token clients get the app's full
-action surface plus the `ask-agent` meta-tool that runs the full agent loop
-(the same entry point [A2A](/docs/a2a-protocol) uses). OAuth chat hosts that
-request `mcp:apps`, including Claude and ChatGPT, get a compact app-facing
-catalog instead: cross-app verbs such as `list_apps`, `open_app`, and
-`ask_app`, plus the app-only embed helper. In both cases, ask the agent to do
-real work and it hands back a link straight into the running app:
+host. Code/stdio developer clients get the app's full action surface plus the
+`ask-agent` meta-tool that runs the full agent loop (the same entry point
+[A2A](/docs/a2a-protocol) uses). Chat hosts, including Claude and ChatGPT, get
+a compact app-facing catalog by default even when they authenticate through a
+generic bearer/static-token path: cross-app verbs such as `list_apps`,
+`open_app`, and `ask_app`, plus the app-only embed helper. In both cases, ask
+the agent to do real work and it hands back a link straight into the running
+app:
 
 ```
 > draft an email to John about the Q3 report
@@ -331,14 +332,16 @@ On top of the per-action tools the MCP server exposes a stable verb set, so an e
 
 `create_workspace_app` rejects any non-allow-listed template — the public template allow-list in `packages/shared-app-config/templates.ts` is authoritative and CI-guarded; an external agent cannot widen it. A same-named template action overrides a builtin (template-over-core precedence). Disable the whole set with `MCPConfig.builtinCrossAppTools: false`.
 
-For OAuth callers that request `mcp:apps`, the server intentionally advertises
-tiny `tools/list` and `resources/list` catalogs so app hosts do not ingest
+The server intentionally advertises tiny `tools/list` and `resources/list`
+catalogs by default for app hosts, including OAuth MCP Apps callers and
+generic authenticated remote HTTP/static-token callers, so hosts do not ingest
 every internal action schema or every action-specific UI resource. The model
 sees app-facing builtins (`list_apps`, `open_app`, `ask_app`, and app-only
 `create_embed_session`) and routes inline UI through
-`open_app({ embed: true })`. Stdio/static-token developer clients still get
-the full connected action surface, and `publicAgent.expose` remains the opt-in
-for safe read/ingest tools outside the compact app catalog. If an individual
+`open_app({ embed: true })`. Stdio/code developer clients can explicitly opt
+into the full connected action surface, and `publicAgent.expose` remains the
+opt-in for safe read/ingest tools outside the compact app catalog. If an
+individual
 UI action must remain visible to ChatGPT/Claude discovery, set
 `mcpApp.compactCatalog: true`, but treat that as a rare exception.
 
@@ -532,7 +535,7 @@ This is the unmanaged equivalent of what `connect` writes for you. See [MCP Prot
 
 ### Dev vs production tool surface {#dev-vs-prod}
 
-In plain local dev (`NODE_ENV=development` and `AGENT_MODE !== "production"`) the MCP `tools/list` deliberately exposes only the generic builtins plus actions with `publicAgent.requiresAuth === false` — the per-app ingest actions (`requiresAuth: true`) and mutating actions (no `publicAgent`) are filtered out (`filterPublicAgentActions`). The full per-app surface appears when the request is authenticated as a real caller: a deployed / `AGENT_MODE=production` app, or a local app reached through `connect` / `agent-native mcp install` (which provisions a token so the caller has an identity). So if `tools/list` looks sparse, you are hitting an unauthenticated dev endpoint — connect (or present a token) rather than assuming the action is missing.
+In plain local dev (`NODE_ENV=development` and `AGENT_MODE !== "production"`) the MCP `tools/list` deliberately exposes only the generic builtins plus actions with `publicAgent.requiresAuth === false` — the per-app ingest actions (`requiresAuth: true`) and mutating actions (no `publicAgent`) are filtered out (`filterPublicAgentActions`). Stdio/code clients that use the `agent-native` proxy identify themselves and get the full developer catalog after auth. Chat-style remote HTTP callers stay on the compact app-facing catalog by default, even when authenticated, so ChatGPT/Claude cannot dump a huge full action catalog into the conversation.
 
 ### Switching first-party apps between prod and dev {#dev-switch}
 

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -102,6 +102,12 @@ a huge chat artifact. Host conversations also keep already-rendered iframes, so
 after changing the resource shell or `ui://` version, test a fresh tool call
 rather than re-measuring an old frame.
 
+If a user reopens an older chat after a one-time embed start ticket expires,
+the start route returns a small refresh page and posts
+`agentNative.embedSessionExpired` to the wrapper. `embedApp()` clears the stale
+start URL and asks the app-only `create_embed_session` tool for a fresh ticket
+when it still has the original app route.
+
 Default direct embeds talk to the MCP Apps host through standard `ui/*`
 JSON-RPC messages:
 
@@ -159,7 +165,7 @@ request. Embedded routes must remain functional in the default inline mode.
 
 ## Tools {#tools}
 
-Stdio/static-token developer clients see all connected app actions as MCP tools. OAuth callers that request `mcp:apps` get a compact app-host catalog: app-facing builtins (`list_apps`, `open_app`, `ask_app`, and app-only `create_embed_session`) plus rare actions marked `mcpApp.compactCatalog: true`. Their `resources/list` is compact too, normally advertising only the generic `open_app` embed resource. `publicAgent.expose` remains the opt-in for safe read/ingest tools outside that compact app catalog. This keeps ChatGPT/Claude app-host discovery small while preserving the full developer surface for local agents.
+Stdio/code developer clients can see all connected app actions as MCP tools. Chat-style app hosts, including OAuth callers that request `mcp:apps` and generic authenticated remote HTTP/static-token callers, get a compact app-host catalog: app-facing builtins (`list_apps`, `open_app`, `ask_app`, and app-only `create_embed_session`) plus rare actions marked `mcpApp.compactCatalog: true`. Their `resources/list` is compact too, normally advertising only the generic `open_app` embed resource. `publicAgent.expose` remains the opt-in for safe read/ingest tools outside that compact app catalog. This keeps ChatGPT/Claude app-host discovery small while preserving the full developer surface for local agents.
 
 The mapping is direct:
 

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -136,6 +136,17 @@ through Dispatch, which keeps the one-connector path narrow while still letting
 Claude/ChatGPT inline target app routes. Pass additional domains only for
 custom third-party frames or assets.
 
+Leave standard `_meta.ui.domain` unset by default. Its format is host-specific:
+Claude expects Claude content-domain hashes, while ChatGPT reads the separate
+`openai/widgetDomain` compatibility field. App URLs belong in CSP sources and
+open-link targets, not portable `ui.domain` metadata.
+
+Extension detail routes render their extension iframe from `srcDoc` when the
+route is already inside an MCP chat embed. That avoids a second
+`/_agent-native/extensions/:id/render` frame navigation being rejected by chat
+host ancestry checks, while keeping the same sandbox flags and postMessage
+extension bridge.
+
 Host-mediated open links keep the iframe from choosing its own browser target.
 Model context updates are opt-in and hidden from the user-facing transcript.
 `ui/message` is the portable way for an embedded app button to ask the host to

--- a/packages/core/src/client/extensions/ExtensionViewer.spec.tsx
+++ b/packages/core/src/client/extensions/ExtensionViewer.spec.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+import React, { act } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ExtensionViewer } from "./ExtensionViewer.js";
+
+const embedState = vi.hoisted(() => ({ active: false }));
+
+vi.mock("../embed-auth.js", () => ({
+  ensureEmbedAuthFetchInterceptor: vi.fn(),
+  isEmbedMcpChatBridgeActive: () => embedState.active,
+}));
+
+vi.mock("../sharing/ShareButton.js", () => ({
+  ShareButton: () => <button type="button">Share</button>,
+}));
+
+vi.mock("../AgentPanel.js", () => ({
+  AgentToggleButton: () => <button type="button">Agent</button>,
+}));
+
+vi.mock("../notifications/NotificationsBell.js", () => ({
+  NotificationsBell: () => <button type="button">Notifications</button>,
+}));
+
+vi.mock("../composer/PromptComposer.js", () => ({
+  PromptComposer: () => <div />,
+}));
+
+vi.mock("../components/ui/popover.js", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("../components/ui/tooltip.js", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+const extensionResponse = {
+  id: "ext-1",
+  name: "GitHub Stars Over Time",
+  description: "Tracks stars",
+  content: "<section>Star history chart</section>",
+  updatedAt: "2026-05-22T00:00:00.000Z",
+  ownerEmail: "owner@example.test",
+  role: "owner",
+  canDelete: true,
+};
+
+describe("ExtensionViewer MCP embeds", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json(extensionResponse)),
+    );
+    embedState.active = false;
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    container = document.createElement("div");
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    queryClient.clear();
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  async function renderViewer() {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={["/extensions/ext-1/github-stars"]}>
+            <ExtensionViewer extensionId="ext-1" />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+    await vi.waitFor(() => {
+      expect(container.querySelector("iframe")).toBeTruthy();
+    });
+    return container.querySelector("iframe") as HTMLIFrameElement;
+  }
+
+  it("uses the extension render route in the normal app", async () => {
+    const iframe = await renderViewer();
+
+    expect(iframe.getAttribute("src")).toContain(
+      "/_agent-native/extensions/ext-1/render",
+    );
+    expect(iframe.getAttribute("srcdoc")).toBeNull();
+    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts allow-forms");
+  });
+
+  it("uses sandboxed srcdoc inside MCP chat embeds to avoid a blocked nested route frame", async () => {
+    embedState.active = true;
+    const iframe = await renderViewer();
+
+    expect(iframe.getAttribute("src")).toBeNull();
+    expect(iframe.getAttribute("srcdoc")).toContain("Star history chart");
+    expect(iframe.getAttribute("srcdoc")).toContain(
+      "agent-native-extension-binding",
+    );
+    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts allow-forms");
+  });
+});

--- a/packages/core/src/client/extensions/ExtensionViewer.tsx
+++ b/packages/core/src/client/extensions/ExtensionViewer.tsx
@@ -39,6 +39,9 @@ import {
   invalidateExtensionRemoval,
 } from "./delete-extension.js";
 import { extensionPath, isExtensionPathname } from "../../extensions/path.js";
+import { buildExtensionHtml } from "../../extensions/html-shell.js";
+import { getThemeVars } from "../../extensions/theme.js";
+import { isEmbedMcpChatBridgeActive } from "../embed-auth.js";
 
 const THEME_CSS_VARS = [
   "--background",
@@ -87,6 +90,8 @@ interface Extension {
   description?: string;
   content?: string;
   updatedAt?: string;
+  ownerEmail?: string;
+  role?: ExtensionBridgeRole | null;
   canDelete?: boolean;
 }
 
@@ -102,6 +107,34 @@ function readExtensionTitleSuffix(): string | null {
 
 function extensionDocumentTitle(name: string, suffix: string | null): string {
   return suffix ? `${name} \u2014 ${suffix}` : `${name} \u2014 Extensions`;
+}
+
+function extensionRole(value: unknown): ExtensionBridgeRole {
+  return value === "owner" ||
+    value === "admin" ||
+    value === "editor" ||
+    value === "viewer"
+    ? value
+    : "viewer";
+}
+
+function buildExtensionViewerSrcDoc(
+  extension: Extension,
+  isDark: boolean,
+): string {
+  const role = extensionRole(extension.role);
+  return buildExtensionHtml(
+    extension.content ?? "",
+    getThemeVars(isDark),
+    isDark,
+    extension.id,
+    {
+      authorEmail: extension.ownerEmail ?? "",
+      viewerEmail: "",
+      isAuthor: role === "owner",
+      role,
+    },
+  );
 }
 
 function applyCanonicalLink(path: string): () => void {
@@ -550,6 +583,10 @@ export function ExtensionViewer({ extensionId }: ExtensionViewerProps) {
       ),
     [extensionId, extension?.updatedAt, refreshKey],
   );
+  const iframeSrcDoc = useMemo(() => {
+    if (!extension?.content || !isEmbedMcpChatBridgeActive()) return undefined;
+    return buildExtensionViewerSrcDoc(extension, isDark);
+  }, [extension, isDark]);
 
   useEffect(() => {
     setIframeReady(false);
@@ -729,7 +766,8 @@ export function ExtensionViewer({ extensionId }: ExtensionViewerProps) {
           <iframe
             ref={iframeRef}
             key={`${extension.updatedAt}-${refreshKey}`}
-            src={iframeSrc}
+            src={iframeSrcDoc ? undefined : iframeSrc}
+            srcDoc={iframeSrcDoc}
             className="h-full w-full border-0"
             sandbox="allow-scripts allow-forms"
             title={extension.name}

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -10,8 +10,6 @@ import {
 
 const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
-const AUTHENTICATED_SSR_CACHE_CONTROL =
-  "private, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 
 const tempDirs: string[] = [];
 
@@ -173,7 +171,7 @@ export default (event) =>
     expect(redirect.headers.get("location")).toBe("/docs/login");
   });
 
-  it("uses private SSR cache headers for authenticated Cloudflare worker SSR", async () => {
+  it("uses public SSR cache headers for authenticated Cloudflare worker SSR", async () => {
     const worker = await importGeneratedWorker(generateWorkerEntry([], []));
 
     const response = await worker.fetch(
@@ -186,7 +184,7 @@ export default (event) =>
     );
 
     expect(response.headers.get("cache-control")).toBe(
-      AUTHENTICATED_SSR_CACHE_CONTROL,
+      DEFAULT_SSR_CACHE_CONTROL,
     );
   });
 

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -34,17 +34,11 @@ import {
 } from "./workspace-core.js";
 import { generateActionRegistryForProject } from "../vite/action-types-plugin.js";
 import { mcpEmbedStaticAssetRouteRules } from "../shared/mcp-embed-headers.js";
-import {
-  EMBED_SESSION_COOKIE,
-  EMBED_TOKEN_QUERY_PARAM,
-} from "../shared/embed-auth.js";
 
 const cwd = process.cwd();
 const preset = process.env.NITRO_PRESET || "node";
 const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
-const AUTHENTICATED_SSR_CACHE_CONTROL =
-  "private, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 
 function normalizeConfiguredAppBasePath(): string {
   const raw = process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH;
@@ -312,62 +306,21 @@ function injectHeadScript(html, script) {
 }
 
 const DEFAULT_SSR_CACHE_CONTROL = ${JSON.stringify(DEFAULT_SSR_CACHE_CONTROL)};
-const AUTHENTICATED_SSR_CACHE_CONTROL = ${JSON.stringify(AUTHENTICATED_SSR_CACHE_CONTROL)};
-const EMBED_SESSION_COOKIE = ${JSON.stringify(EMBED_SESSION_COOKIE)};
-const EMBED_TOKEN_QUERY_PARAM = ${JSON.stringify(EMBED_TOKEN_QUERY_PARAM)};
-const ANONYMOUS_SESSION_COOKIE_NAMES = new Set(["an_docs_session"]);
-const BETTER_AUTH_SESSION_COOKIE_RE = /\\.session_(?:token|data)$/;
 
-function isAuthenticatedCookieName(name) {
-  if (ANONYMOUS_SESSION_COOKIE_NAMES.has(name)) return false;
-  const bareName = String(name || "").replace(/^__(?:Secure|Host)-/, "");
-  return (
-    bareName === EMBED_SESSION_COOKIE ||
-    bareName === "an_session" ||
-    bareName === "an_session_workspace" ||
-    bareName.startsWith("an_session_") ||
-    bareName === "an.session_token" ||
-    bareName === "an.session_data" ||
-    BETTER_AUTH_SESSION_COOKIE_RE.test(bareName)
-  );
-}
-
-function requestHasAuthenticatedCookie(cookieHeader) {
-  if (!cookieHeader) return false;
-  return String(cookieHeader)
-    .split(";")
-    .map((cookie) => cookie.trim().split("=", 1)[0]?.trim())
-    .filter(Boolean)
-    .some(isAuthenticatedCookieName);
-}
-
-function requestHasAuthSignal(request) {
-  const url = new URL(request.url);
-  return Boolean(
-    request.headers.get("authorization") ||
-    requestHasAuthenticatedCookie(request.headers.get("cookie")) ||
-    url.searchParams.has(EMBED_TOKEN_QUERY_PARAM) ||
-    url.searchParams.has("_session")
-  );
-}
-
-function applyDefaultSsrCacheHeader(headers, status, hasAuthSignal) {
+function applyDefaultSsrCacheHeader(headers, status) {
   if (headers.has("cache-control")) return;
   if (status < 200 || status >= 400) return;
 
   const contentType = (headers.get("content-type") || "").toLowerCase();
   if (!contentType.includes("text/html")) return;
 
-  headers.set(
-    "cache-control",
-    hasAuthSignal ? AUTHENTICATED_SSR_CACHE_CONTROL : DEFAULT_SSR_CACHE_CONTROL,
-  );
+  headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
 }
 
-async function rewriteMountedResponse(response, basePath, hasAuthSignal) {
+async function rewriteMountedResponse(response, basePath) {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
-  applyDefaultSsrCacheHeader(headers, response.status, hasAuthSignal);
+  applyDefaultSsrCacheHeader(headers, response.status);
 
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {
@@ -483,7 +436,6 @@ ${actionRegistrations.join("\n")}
       return new Response(null, { status: 404 });
     }
     const request = requestWithPathname(event.req, p);
-    const hasAuthSignal = requestHasAuthSignal(event.req);
     if (event.req.method === "HEAD") {
       const getRequest = requestWithMethod(request, "GET");
       const response = await rrHandler(getRequest);
@@ -494,10 +446,9 @@ ${actionRegistrations.join("\n")}
           headers: response.headers,
         }),
         basePath,
-        hasAuthSignal,
       );
     }
-    return rewriteMountedResponse(await rrHandler(request), basePath, hasAuthSignal);
+    return rewriteMountedResponse(await rrHandler(request), basePath);
   }));
 
   _handler = app.fetch.bind(app);

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -113,6 +113,14 @@ export interface MCPRequestMeta {
   /** Optional client preference for which URL the *markdown* link uses. */
   target?: "browser" | "desktop" | "terminal";
   /**
+   * Best-effort caller label derived from MCP transport headers. Chat-style
+   * remote hosts should stay on the compact catalog; code/stdio clients can
+   * explicitly identify themselves to keep the full action surface.
+   */
+  clientName?: string;
+  /** Explicit opt-in to the full tool catalog for code/stdio style clients. */
+  fullCatalog?: boolean;
+  /**
    * The caller authenticated with a real credential (verified A2A/connect
    * JWT, matching ACCESS_TOKEN, or a forwarded owner-email header from
    * `agent-native mcp install`) — not the unauthenticated local dev-open
@@ -169,6 +177,8 @@ const NON_APP_OAUTH_CLIENT_RE =
   /\b(code|desktop|cli|cursor|codex|goose|postman|mcpjam|inspector)\b/i;
 const MCP_APP_OAUTH_REDIRECT_HOST_RE =
   /(^|\.)((chatgpt|openai)\.com|claude\.ai|anthropic\.com)$/i;
+const FULL_CATALOG_CLIENT_RE =
+  /\b(agent-native-mcp-(proxy|stdio|standalone)|code|desktop|cli|cursor|codex|goose|postman|mcpjam|inspector)\b/i;
 
 async function isKnownMcpAppOAuthClient(
   identity: MCPCallerIdentity | undefined,
@@ -222,6 +232,28 @@ async function isKnownMcpAppOAuthClient(
     // full action surface; ChatGPT/Claude old tokens otherwise get huge lists.
     return true;
   }
+}
+
+function explicitlyRequestsFullMcpCatalog(
+  requestMeta: MCPRequestMeta | undefined,
+): boolean {
+  if (process.env.AGENT_NATIVE_MCP_FULL_CATALOG === "1") return true;
+  if (requestMeta?.fullCatalog === true) return true;
+  return FULL_CATALOG_CLIENT_RE.test(requestMeta?.clientName ?? "");
+}
+
+function shouldUseCompactMcpCatalogByDefault(
+  identity: MCPCallerIdentity | undefined,
+  requestMeta: MCPRequestMeta | undefined,
+): boolean {
+  if (explicitlyRequestsFullMcpCatalog(requestMeta)) return false;
+  // OAuth callers are classified through `isKnownMcpAppOAuthClient`: unknown
+  // OAuth clients compact by default, while known code/CLI clients stay full.
+  if (identity?.oauthClientId) return false;
+  // A real authenticated remote HTTP caller with no OAuth client metadata is
+  // usually a chat-host static-token connector. Keep it on the app-facing
+  // verbs so a host cannot dump every action schema into a giant tool card.
+  return requestMeta?.fullSurface === true;
 }
 
 interface ResolvedMcpAppResource {
@@ -809,7 +841,8 @@ export async function createMCPServerForRequest(
   const compactMcpAppCatalog =
     (Array.isArray(effectiveIdentity?.oauthScopes) &&
       hasMcpOAuthScope(effectiveIdentity.oauthScopes, "mcp:apps")) ||
-    (await isKnownMcpAppOAuthClient(effectiveIdentity));
+    (await isKnownMcpAppOAuthClient(effectiveIdentity)) ||
+    shouldUseCompactMcpCatalogByDefault(effectiveIdentity, requestMeta);
   const advertisedActions = compactMcpAppCatalog
     ? Object.fromEntries(
         Object.entries(visibleActions).filter(([name, entry]) =>

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -261,6 +261,17 @@ function originString(value: unknown): string | undefined {
   }
 }
 
+function hostSpecificDomainString(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  const trimmed = value.trim();
+  try {
+    new URL(trimmed);
+    return undefined;
+  } catch {
+    return trimmed;
+  }
+}
+
 function withMcpChatBridgeParam(urlOrPath: string): string {
   try {
     const base = "http://agent-native.invalid";
@@ -493,6 +504,7 @@ function mcpAppUiMeta(
       ? (base.ui as Record<string, unknown>)
       : {};
   const ui: Record<string, unknown> = { ...existingUi };
+  delete ui.domain;
   if (resolvedCsp) {
     ui.csp = {
       ...resolvedCsp,
@@ -515,11 +527,15 @@ function mcpAppUiMeta(
     };
   }
   if (resource.permissions) ui.permissions = resource.permissions;
-  const widgetDomain =
+  const hostSpecificDomain =
+    hostSpecificDomainString(resource.domain) ??
+    hostSpecificDomainString(existingUi.domain);
+  if (hostSpecificDomain) ui.domain = hostSpecificDomain;
+  const openAiWidgetDomain =
     originString(resource.domain) ??
     originString(ui.domain) ??
+    originString(existingUi.domain) ??
     originString(requestMeta?.origin);
-  if (widgetDomain) ui.domain = widgetDomain;
   if (typeof resource.prefersBorder === "boolean") {
     ui.prefersBorder = resource.prefersBorder;
   }
@@ -537,8 +553,8 @@ function mcpAppUiMeta(
   if (openAiCsp && base["openai/widgetCSP"] == null) {
     base["openai/widgetCSP"] = openAiCsp;
   }
-  if (widgetDomain && base["openai/widgetDomain"] == null) {
-    base["openai/widgetDomain"] = widgetDomain;
+  if (openAiWidgetDomain && base["openai/widgetDomain"] == null) {
+    base["openai/widgetDomain"] = openAiWidgetDomain;
   }
   return Object.keys(base).length > 0 ? base : undefined;
 }

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -75,6 +75,9 @@ describe("embedApp", () => {
     expect(html).toContain('"agentNative.mcpHost.openLink"');
     expect(html).toContain('"agentNative.mcpHost.requestDisplayMode"');
     expect(html).toContain('"agentNative.mcpHost.response"');
+    expect(html).toContain('"agentNative.embedSessionExpired"');
+    expect(html).toContain("refreshExpiredEmbedSession");
+    expect(html).toContain('openStartUrl = "";');
     expect(html).toContain("app.requestDisplayMode");
     expect(html).toContain("function openLinkRecordFrom(value)");
     expect(html).toContain("return withChatBridgeParam(value)");

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -715,6 +715,21 @@ export function embedApp(
       }, frameLoadTimeoutMs);
     }
 
+    function refreshExpiredEmbedSession() {
+      clearFrameReadyTimer();
+      clearFrameLoadTimer();
+      appFrameReady = false;
+      if (!openUrl) {
+        renderFrameFallback();
+        return;
+      }
+      openStartUrl = "";
+      startedFor = "";
+      lastFrameSrc = "";
+      setMessage("Refreshing app session");
+      void launchEmbed();
+    }
+
     function shouldSelfNavigateToApp() {
       const mode = typeof toolInput.embedMode === "string"
         ? toolInput.embedMode
@@ -896,6 +911,10 @@ export function embedApp(
         appFrameReady = true;
         clearFrameLoadTimer();
         clearFrameReadyTimer();
+        return;
+      }
+      if (event.data.type === "agentNative.embedSessionExpired") {
+        refreshExpiredEmbedSession();
         return;
       }
       if (event.data.type === "agentNative.submitChat") {

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -899,7 +899,6 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
             csp: {
               connectDomains: ["https://mail.agent-native.com"],
             },
-            domain: "https://mail.agent-native.com",
             prefersBorder: true,
           },
           "openai/widgetDescription":
@@ -957,7 +956,6 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
             csp: {
               connectDomains: ["https://mail.agent-native.com"],
             },
-            domain: "https://mail.agent-native.com",
             prefersBorder: true,
           },
           "openai/widgetCSP": {

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -858,15 +858,70 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     );
   });
 
-  it("keeps the full tool catalog for non-OAuth callers without mcp:apps", async () => {
-    const out = await callWeb(
+  it("uses the compact catalog for authenticated non-OAuth callers by default", async () => {
+    const toolsOut = await callWeb(
       {
         jsonrpc: "2.0",
         id: 21,
         method: "tools/list",
         params: {},
       },
-      { config: compactSurfaceConfig },
+      { config: compactSurfaceDefaultConfig },
+    );
+
+    expect(toolsOut.error).toBeUndefined();
+    const names = toolsOut.result.tools.map((t: any) => t.name);
+    expect(names).toEqual([
+      "list_apps",
+      "open_app",
+      "ask_app",
+      "create_embed_session",
+    ]);
+    expect(names).not.toContain("internal-heavy");
+    expect(names).not.toContain("bloated-widget");
+    expect(JSON.stringify(toolsOut)).not.toContain(
+      "INTERNAL_TOOL_BLOAT_SENTINEL",
+    );
+    expect(JSON.stringify(toolsOut)).not.toContain(
+      "MCP_APP_RESOURCE_BLOAT_SENTINEL",
+    );
+    expect(JSON.stringify(toolsOut).length).toBeLessThan(12_000);
+
+    const resourcesOut = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 28,
+        method: "resources/list",
+        params: {},
+      },
+      { config: compactSurfaceDefaultConfig },
+    );
+
+    expect(resourcesOut.error).toBeUndefined();
+    expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
+      "ui://mail/open_app/shell-v25",
+    ]);
+    expect(JSON.stringify(resourcesOut)).not.toContain(
+      "MCP_APP_RESOURCE_BLOAT_SENTINEL",
+    );
+    expect(JSON.stringify(resourcesOut).length).toBeLessThan(8_000);
+  });
+
+  it("keeps the full tool catalog only for explicit code/stdio callers", async () => {
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 29,
+        method: "tools/list",
+        params: {},
+      },
+      {
+        headers: {
+          "x-agent-native-mcp-client": "agent-native-mcp-proxy",
+          "x-agent-native-mcp-full-catalog": "1",
+        },
+        config: compactSurfaceConfig,
+      },
     );
 
     expect(out.error).toBeUndefined();
@@ -874,6 +929,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(names).toEqual(
       expect.arrayContaining(["echo-thing", "internal-heavy", "ask-agent"]),
     );
+    expect(JSON.stringify(out)).toContain("INTERNAL_TOOL_BLOAT_SENTINEL");
   });
 
   it("handles `resources/list` and advertises MCP App resources", async () => {

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -77,7 +77,24 @@ function deriveRequestMeta(event: H3Event): MCPRequestMeta {
     targetHeader === "browser"
       ? (targetHeader as MCPRequestMeta["target"])
       : undefined;
-  return { origin, target };
+  const clientName =
+    getRequestHeader(event, "x-agent-native-mcp-client")?.trim() ||
+    getRequestHeader(event, "user-agent")?.trim() ||
+    undefined;
+  const fullCatalogHeader = getRequestHeader(
+    event,
+    "x-agent-native-mcp-full-catalog",
+  )?.toLowerCase();
+  const fullCatalog =
+    fullCatalogHeader === "1" ||
+    fullCatalogHeader === "true" ||
+    fullCatalogHeader === "yes";
+  return {
+    origin,
+    target,
+    clientName,
+    ...(fullCatalog ? { fullCatalog } : {}),
+  };
 }
 
 function isLoopbackOrigin(origin: string | undefined): boolean {

--- a/packages/core/src/mcp/stdio.ts
+++ b/packages/core/src/mcp/stdio.ts
@@ -56,7 +56,10 @@ function log(msg: string): void {
  * `sub`, so we only add an `X-Agent-Native-Owner-Email` hint header.
  */
 function authHeaders(env: NodeJS.ProcessEnv): Record<string, string> {
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = {
+    "X-Agent-Native-MCP-Client": "agent-native-mcp-proxy",
+    "X-Agent-Native-MCP-Full-Catalog": "1",
+  };
   const token = env.ACCESS_TOKEN || env.AGENT_NATIVE_MCP_TOKEN;
   if (token) headers["Authorization"] = `Bearer ${token}`;
   const owner = env.AGENT_NATIVE_OWNER_EMAIL;
@@ -257,7 +260,11 @@ async function runStandalone(opts: RunMCPStdioOptions): Promise<void> {
     // No verified identity in standalone (no inbound auth header). Runs with
     // platform-default scope, same as a tokenless local HTTP mount.
     undefined,
-    { origin },
+    {
+      origin,
+      clientName: "agent-native-mcp-standalone",
+      fullCatalog: true,
+    },
   );
 
   const transport = new StdioServerTransport();

--- a/packages/core/src/server/auth-marketing.ts
+++ b/packages/core/src/server/auth-marketing.ts
@@ -1,0 +1,305 @@
+export interface AuthMarketingContent {
+  appName: string;
+  tagline: string;
+  description?: string;
+  features?: string[];
+  runLocalCommand?: string;
+}
+
+export interface ResolveBuiltInAuthMarketingOptions {
+  requestHost?: string;
+  requestPath?: string;
+}
+
+export const BUILT_IN_AUTH_MARKETING: Record<string, AuthMarketingContent> = {
+  analytics: {
+    appName: "Agent-Native Analytics",
+    tagline:
+      "Your AI agent queries your data sources, builds dashboards, and answers business questions alongside you.",
+    features: [
+      "Ask any question and get answers from BigQuery, HubSpot, Jira, and more",
+      "Agent-built dashboards that pull live data from all your sources",
+      "Saved analyses the agent can re-run on demand with fresh numbers",
+    ],
+  },
+  brain: {
+    appName: "Agent-Native Brain",
+    tagline:
+      "A company memory layer where raw conversations become reviewed, searchable institutional knowledge.",
+    features: [
+      "Import transcripts, notes, Slack exports, and Granola summaries",
+      "Validate every fact against exact source quotes",
+      "Review company-wide knowledge through proposal workflows",
+    ],
+  },
+  calendar: {
+    appName: "Agent-Native Calendar",
+    tagline:
+      "Your AI agent schedules, reschedules, and manages your calendar so you never have to.",
+    features: [
+      "Finds open slots and books meetings on your behalf",
+      "Manages availability and booking links automatically",
+      "Answers schedule questions and resolves conflicts instantly",
+    ],
+  },
+  calls: {
+    appName: "Agent-Native Calls",
+    tagline:
+      "Your AI agent transcribes, summarizes, and surfaces key moments from every conversation.",
+    features: [
+      "Automatic recaps, action items, and next steps after every call",
+      "Smart trackers that detect competitor mentions, objections, and custom topics",
+      "Shareable snippets for the exact moment that matters",
+    ],
+  },
+  clips: {
+    appName: "Agent-Native Clips",
+    tagline:
+      "Your AI agent transcribes, summarizes, and searches everything you record alongside you.",
+    features: [
+      "One-click screen recording with automatic titles, summaries, and chapters",
+      "Calendar-synced meeting notes with live transcripts and action items",
+      "One searchable library across recordings, meetings, and dictations",
+    ],
+  },
+  code: {
+    appName: "Agent-Native Code",
+    tagline:
+      "A customizable local Agent-Native Code UI for long-running coding sessions, slash commands, and migration goals.",
+    features: [
+      "Start and resume local coding sessions",
+      "Use the same transcript store as the CLI and Desktop",
+      "Customize the UI while reusing the agent-native run harness",
+    ],
+  },
+  content: {
+    appName: "Agent-Native Content",
+    tagline:
+      "Your AI agent creates, edits, and organizes documents alongside you in a Notion-like workspace.",
+    features: [
+      "Create and restructure entire document trees from a single prompt",
+      "Surgical edits that sync live to your editor via real-time collaboration",
+      "Search, summarize, and cross-reference documents instantly",
+    ],
+  },
+  design: {
+    appName: "Agent-Native Design",
+    tagline:
+      "Design and prototype by describing what you want. The AI agent turns your ideas into interactive, fully responsive designs in seconds.",
+    features: [
+      "Create polished prototypes just by describing them",
+      "Build and apply design systems to keep everything on-brand",
+      "Export your work or share it with a link",
+    ],
+  },
+  dispatch: {
+    appName: "Agent-Native Dispatch",
+    tagline:
+      "Your AI agent manages secrets, orchestrates other agents, and routes messages across your workspace.",
+    features: [
+      "Centralized vault for secrets with granular per-app grants",
+      "Cross-agent orchestration and delegation to specialist apps",
+      "Slack and Telegram routing with approval workflows",
+    ],
+  },
+  forms: {
+    appName: "Agent-Native Forms",
+    tagline:
+      "Your AI agent builds, publishes, and analyzes forms alongside you.",
+    features: [
+      "Create complete forms from a single sentence",
+      "Instant publishing with shareable links and captcha",
+      "Response summaries, exports, and trend analysis on demand",
+    ],
+  },
+  images: {
+    appName: "Agent-Native Images",
+    tagline:
+      "Your AI agent creates, refines, and organizes on-brand images alongside you.",
+    features: [
+      "Build reusable brand image libraries from logos, product shots, and references",
+      "Generate heroes, diagrams, slide art, and product visuals from a prompt",
+      "Audit prompts, references, outputs, and refinements across every run",
+    ],
+  },
+  mail: {
+    appName: "Agent-Native Mail",
+    tagline: "Your AI agent reads, drafts, and organizes email alongside you.",
+    features: [
+      "Replies that match your tone and style",
+      "Multi-account Gmail in a single unified inbox",
+      "Autonomous triage, archiving, and follow-ups",
+    ],
+    runLocalCommand:
+      "npx @agent-native/core create my-mail-app --template mail",
+  },
+  "meeting-notes": {
+    appName: "Agent-Native Meeting Notes",
+    tagline:
+      "Your AI agent transcribes, enhances, and organizes your meeting notes while you focus on the conversation.",
+    features: [
+      "AI-enhanced meeting notes that merge raw notes with transcripts",
+      "Smart contact and company tracking from meeting attendees",
+      "Reusable templates for consistent note formatting",
+    ],
+  },
+  migration: {
+    appName: "Migration Workbench",
+    tagline:
+      "Move existing apps to agent-native with assessment, human approval, and deterministic verification.",
+    features: [
+      "Inventory routes, components, behavior, and content before touching output",
+      "Approve plans before generated writes begin",
+      "Verify output with structured migration reports",
+    ],
+  },
+  recruiting: {
+    appName: "Agent-Native Recruiting",
+    tagline:
+      "Your AI agent screens candidates, manages pipelines, and keeps your hiring on track.",
+    features: [
+      "AI resume analysis and candidate comparison",
+      "Pipeline management with automated stage progression",
+      "Scorecard tracking and overdue feedback alerts",
+    ],
+  },
+  scheduling: {
+    appName: "Agent-Native Scheduling",
+    tagline:
+      "Your AI agent manages availability, books meetings, and handles rescheduling alongside you.",
+    features: [
+      "Automatic round-robin and team scheduling across hosts",
+      "Smart availability management with conflict detection",
+      "Autonomous rescheduling, reminders, and follow-ups",
+    ],
+  },
+  slides: {
+    appName: "Agent-Native Slides",
+    tagline:
+      "Your AI agent builds, edits, and refines presentations alongside you.",
+    features: [
+      "Generate entire decks from a single prompt",
+      "Surgical slide edits while you present or review",
+      "Real-time collaboration between you and the agent",
+    ],
+  },
+  starter: {
+    appName: "Blank app",
+    tagline:
+      "Build an agent-native app where the AI agent and UI share state, actions, and context.",
+    features: [
+      "Define once, use everywhere: actions work as agent tools and API endpoints",
+      "The agent always knows what you are looking at and can act on it",
+      "Modify your app's own code, routes, and styles through conversation",
+    ],
+  },
+  videos: {
+    appName: "Agent-Native Videos",
+    tagline:
+      "Your AI agent builds, animates, and refines programmatic videos alongside you.",
+    features: [
+      "Generate animated components and compositions from a description",
+      "Fine-tune tracks, keyframes, and easing without touching code",
+      "Camera moves, interactive elements, and effects the agent wires for you",
+    ],
+  },
+  voice: {
+    appName: "Agent-Native Voice",
+    tagline:
+      "Speak to type anywhere with context-aware formatting, snippets, and custom vocabulary.",
+    features: [
+      "Push-to-talk or hands-free dictation with Whisper transcription",
+      "Context-aware style presets for formal, casual, and excited tones",
+      "Text expansion snippets and custom dictionary for tricky words",
+    ],
+  },
+};
+
+const SLUG_ALIASES: Record<string, string> = {
+  "agent-native": "",
+  "blank-app": "starter",
+  "migration-goal-surface": "migration",
+  video: "videos",
+};
+
+function cloneMarketing(marketing: AuthMarketingContent): AuthMarketingContent {
+  return {
+    ...marketing,
+    features: marketing.features ? [...marketing.features] : undefined,
+  };
+}
+
+function normalizeSlug(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  let slug = value.trim().toLowerCase();
+  if (!slug) return undefined;
+
+  slug = slug.replace(/^@agent-native\//, "");
+  slug = slug
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  slug = slug.replace(/^agent-native-/, "");
+  slug = SLUG_ALIASES[slug] ?? slug;
+  if (!slug) return undefined;
+  return BUILT_IN_AUTH_MARKETING[slug] ? slug : undefined;
+}
+
+function slugFromUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    return slugFromHost(url.host) ?? slugFromPath(url.pathname);
+  } catch {
+    return undefined;
+  }
+}
+
+function slugFromHost(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const host = value.split(",")[0]?.trim().split(":")[0]?.toLowerCase();
+  if (!host) return undefined;
+  if (host.endsWith(".agent-native.com")) {
+    return normalizeSlug(host.slice(0, -".agent-native.com".length));
+  }
+  return undefined;
+}
+
+function slugFromPath(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const firstSegment = value.split("?")[0]?.split("/").filter(Boolean)[0];
+  return normalizeSlug(firstSegment);
+}
+
+function candidateSlugs(
+  opts: ResolveBuiltInAuthMarketingOptions = {},
+): string[] {
+  const env = process.env;
+  const candidates = [
+    opts.requestHost ? slugFromHost(opts.requestHost) : undefined,
+    opts.requestPath ? slugFromPath(opts.requestPath) : undefined,
+    normalizeSlug(env.AGENT_NATIVE_TEMPLATE),
+    normalizeSlug(env.APP_NAME),
+    normalizeSlug(env.npm_package_name),
+    slugFromPath(env.APP_BASE_PATH),
+    slugFromPath(env.VITE_APP_BASE_PATH),
+    slugFromUrl(env.APP_URL),
+    slugFromUrl(env.BETTER_AUTH_URL),
+    slugFromUrl(env.VITE_BETTER_AUTH_URL),
+    slugFromUrl(env.URL),
+    slugFromUrl(env.DEPLOY_URL),
+    slugFromUrl(env.DEPLOY_PRIME_URL),
+  ];
+
+  return candidates.filter((slug): slug is string => !!slug);
+}
+
+export function resolveBuiltInAuthMarketing(
+  opts: ResolveBuiltInAuthMarketingOptions = {},
+): AuthMarketingContent | undefined {
+  for (const slug of candidateSlugs(opts)) {
+    const marketing = BUILT_IN_AUTH_MARKETING[slug];
+    if (marketing) return cloneMarketing(marketing);
+  }
+  return undefined;
+}

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -752,6 +752,46 @@ describe("server/auth", () => {
       }
     });
 
+    it("serves first-party branded auth when the default guard handles a built-in host", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      vi.doMock("./better-auth-instance.js", () => ({
+        getBetterAuth: vi.fn(async () => ({
+          handler: vi.fn(async () => new Response("{}")),
+          api: {
+            getSession: vi.fn(async () => null),
+            signInEmail: vi.fn(),
+            signUpEmail: vi.fn(),
+            signOut: vi.fn(),
+          },
+        })),
+        getBetterAuthSync: vi.fn(() => undefined),
+      }));
+
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      const result = await guard(
+        createMockEvent({
+          path: "/",
+          headers: { host: "dispatch.agent-native.com" },
+        }),
+      );
+
+      expect(result).toBeInstanceOf(Response);
+      const html = await (result as Response).text();
+      expect(html).toContain("Agent-Native Dispatch");
+      expect(html).toContain('class="marketing-panel"');
+    });
+
     it("redirects mounted login and signup pages when a session already exists", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("APP_BASE_PATH", "/dispatch");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -66,7 +66,11 @@ import {
   getAllowedCorsOrigin,
   readCorsAllowedOrigins,
 } from "./cors-origins.js";
-import { getOnboardingHtml, getResetPasswordHtml } from "./onboarding-html.js";
+import {
+  getOnboardingHtml,
+  getResetPasswordHtml,
+  type OnboardingHtmlOptions,
+} from "./onboarding-html.js";
 import type { GoogleAuthMode } from "./google-auth-mode.js";
 import { readBody } from "../server/h3-helpers.js";
 import {
@@ -854,6 +858,48 @@ interface AuthGuardConfig {
 }
 let _authGuardConfig: AuthGuardConfig | null = null;
 const _genericGoogleOAuthRoutesEnabled = new WeakMap<object, boolean>();
+
+function getRequestHost(event: H3Event): string | undefined {
+  return (
+    getHeader(event, "x-forwarded-host") ??
+    getHeader(event, "host") ??
+    undefined
+  );
+}
+
+function getOnboardingHtmlOptions(
+  options: AuthOptions,
+  event?: H3Event,
+  rawPath?: string,
+): OnboardingHtmlOptions {
+  return {
+    googleOnly: options.googleOnly,
+    marketing: options.marketing,
+    googleSignInNotice: options.googleSignInNotice,
+    googleAuthMode: options.googleAuthMode,
+    requestHost: event ? getRequestHost(event) : undefined,
+    requestPath: rawPath,
+  };
+}
+
+function getAuthOnboardingHtml(
+  options: AuthOptions,
+  event?: H3Event,
+  rawPath?: string,
+): string {
+  return getOnboardingHtml(getOnboardingHtmlOptions(options, event, rawPath));
+}
+
+function getOnboardingLoginHtmlConfig(
+  options: AuthOptions,
+): Pick<AuthGuardConfig, "loginHtml" | "getLoginHtml"> {
+  if (options.loginHtml) return { loginHtml: options.loginHtml };
+  return {
+    loginHtml: getAuthOnboardingHtml(options),
+    getLoginHtml: (event, rawPath) =>
+      getAuthOnboardingHtml(options, event, rawPath),
+  };
+}
 
 function resolveWorkspaceAppAudience(
   options: Pick<AuthOptions, "workspaceAppAudience"> = {},
@@ -3083,16 +3129,9 @@ async function mountBetterAuthRoutes(
 
   // Auth guard — stored both in framework middleware registry AND in
   // _authGuardFn so the server middleware can enforce it on ALL routes.
-  const loginHtml =
-    options.loginHtml ??
-    getOnboardingHtml({
-      googleOnly: options.googleOnly,
-      marketing: options.marketing,
-      googleSignInNotice: options.googleSignInNotice,
-      googleAuthMode: options.googleAuthMode,
-    });
+  const loginHtmlConfig = getOnboardingLoginHtmlConfig(options);
   _authGuardConfig = {
-    loginHtml,
+    ...loginHtmlConfig,
     publicPaths,
     workspaceAppAudience,
     workspaceAppPublicPaths: workspaceAppRouteAccess.publicPaths,
@@ -3355,14 +3394,9 @@ export async function autoMountAuth(
         options.marketing ||
         options.googleSignInNotice
       ) {
-        _authGuardConfig.loginHtml =
-          options.loginHtml ??
-          getOnboardingHtml({
-            googleOnly: options.googleOnly,
-            marketing: options.marketing,
-            googleSignInNotice: options.googleSignInNotice,
-            googleAuthMode: options.googleAuthMode,
-          });
+        const loginHtmlConfig = getOnboardingLoginHtmlConfig(options);
+        _authGuardConfig.loginHtml = loginHtmlConfig.loginHtml;
+        _authGuardConfig.getLoginHtml = loginHtmlConfig.getLoginHtml;
       }
       if (options.publicPaths) {
         _authGuardConfig.publicPaths = [
@@ -3499,16 +3533,9 @@ export async function autoMountAuth(
     // CRITICAL: Even if Better Auth fails, register the auth guard so
     // unauthenticated users can't access the app. They'll see the login
     // page but won't be able to sign in until the DB is available.
-    const loginHtml =
-      options.loginHtml ??
-      getOnboardingHtml({
-        googleOnly: options.googleOnly,
-        marketing: options.marketing,
-        googleSignInNotice: options.googleSignInNotice,
-        googleAuthMode: options.googleAuthMode,
-      });
+    const loginHtmlConfig = getOnboardingLoginHtmlConfig(options);
     _authGuardConfig = {
-      loginHtml,
+      ...loginHtmlConfig,
       publicPaths,
       workspaceAppAudience,
       workspaceAppPublicPaths: workspaceAppRouteAccess.publicPaths,

--- a/packages/core/src/server/embed-route.spec.ts
+++ b/packages/core/src/server/embed-route.spec.ts
@@ -129,6 +129,24 @@ describe("createEmbedStartRouteHandler", () => {
     );
   });
 
+  it("returns a refreshable expired-session page for stale embed tickets", async () => {
+    consumeEmbedSessionTicket.mockResolvedValue(null);
+
+    const handler = createEmbedStartRouteHandler();
+
+    const res: Response = await handler(
+      fakeEvent("GET", { ticket: "expired-ticket" }),
+    );
+    const html = await res.text();
+
+    expect(res.status).toBe(401);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(html).toContain("Embedded app session expired");
+    expect(html).toContain("agentNative.embedSessionExpired");
+    expect(html).not.toContain("Invalid or expired embed session");
+  });
+
   it("allows Claude MCP content frames to fetch embed start redirects", async () => {
     consumeEmbedSessionTicket.mockResolvedValue({
       ownerEmail: "steve@example.com",

--- a/packages/core/src/server/embed-route.ts
+++ b/packages/core/src/server/embed-route.ts
@@ -122,6 +122,48 @@ function textResponse(
   });
 }
 
+function expiredEmbedSessionResponse(event: H3Event): Response {
+  setEmbedStartResponseHeaders(event);
+  return new Response(
+    `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Embedded app session expired</title>
+  <style>
+    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: Canvas; color: CanvasText; }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 24px; }
+    main { max-width: 520px; text-align: center; }
+    h1 { margin: 0 0 8px; font-size: 16px; line-height: 1.25; }
+    p { margin: 0; color: color-mix(in srgb, CanvasText 64%, Canvas); font-size: 13px; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Embedded app session expired</h1>
+    <p>This chat preview is refreshing. If it does not reload, ask the chat to open the app again.</p>
+  </main>
+  <script>
+    try {
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({ type: "agentNative.embedSessionExpired" }, "*");
+      }
+    } catch {}
+  </script>
+</body>
+</html>`,
+    {
+      status: 401,
+      headers: embedStartResponseHeaders(event, {
+        "Content-Type": "text/html; charset=utf-8",
+        "Cache-Control": "no-store",
+      }),
+    },
+  );
+}
+
 export function buildEmbedStartPath(ticket: string): string {
   const qs = new URLSearchParams({ ticket });
   return `${getConfiguredAppBasePath()}${EMBED_START_PATH}?${qs}`;
@@ -178,7 +220,7 @@ export function createEmbedStartRouteHandler(
       expectedOrgId: existingSession?.orgId ?? null,
     });
     if (!consumed) {
-      return textResponse(event, "Invalid or expired embed session.", 401);
+      return expiredEmbedSessionResponse(event);
     }
 
     const target = normalizeEmbedTargetPath(consumed.targetPath);

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getOnboardingHtml } from "./onboarding-html.js";
+import { BUILT_IN_AUTH_MARKETING } from "./auth-marketing.js";
 
 describe("getOnboardingHtml", () => {
   afterEach(() => {
@@ -73,6 +74,51 @@ describe("getOnboardingHtml", () => {
       "__anPath('/_agent-native/auth/ba/request-password-reset')",
     );
     expect(html).toContain("__anPath('/_agent-native/google/auth-url')");
+  });
+
+  it("uses branded first-party marketing from the request host", () => {
+    const html = getOnboardingHtml({
+      requestHost: "dispatch.agent-native.com",
+    });
+
+    expect(html).toContain('class="marketing-panel"');
+    expect(html).toContain("Agent-Native Dispatch");
+    expect(html).toContain(
+      "Your AI agent manages secrets, orchestrates other agents",
+    );
+  });
+
+  it("has branded auth marketing for every core built-in template host", () => {
+    const coreSlugs = [
+      "calendar",
+      "content",
+      "slides",
+      "clips",
+      "brain",
+      "analytics",
+      "mail",
+      "dispatch",
+      "forms",
+      "design",
+      "starter",
+    ];
+
+    for (const slug of coreSlugs) {
+      const html = getOnboardingHtml({
+        requestHost: `${slug}.agent-native.com`,
+      });
+
+      expect(html).toContain('class="marketing-panel"');
+      expect(html).toContain(BUILT_IN_AUTH_MARKETING[slug]!.appName);
+    }
+  });
+
+  it("keeps unknown apps on the compact generic auth page", () => {
+    const html = getOnboardingHtml({
+      requestHost: "workspace.example.com",
+    });
+
+    expect(html).not.toContain('class="marketing-panel"');
   });
 
   it("embeds the public OAuth origin for Builder desktop redirects", () => {

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -14,6 +14,10 @@ import {
 } from "./google-auth-mode.js";
 import { getWorkspaceGatewayReturnOrigin } from "./oauth-return-url.js";
 import { identitySsoLoginButtonHtml } from "./identity-sso-store.js";
+import {
+  resolveBuiltInAuthMarketing,
+  type AuthMarketingContent,
+} from "./auth-marketing.js";
 
 function hasGoogleOAuth(): boolean {
   return !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
@@ -67,6 +71,12 @@ export interface OnboardingHtmlOptions {
     runLocalCommand?: string;
   };
   /**
+   * Request context used only to recover branded first-party marketing when a
+   * default auth guard serves before a template-specific auth plugin.
+   */
+  requestHost?: string;
+  requestPath?: string;
+  /**
    * Optional preflight copy shown before redirecting through Google sign-in.
    * Use this when a hosted app needs to warn about provider-specific consent
    * screens while leaving self-hosted deployments untouched.
@@ -96,7 +106,12 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
   const workspaceGatewayReturnOrigin = getWorkspaceGatewayReturnOrigin();
   const googleAuthMode = resolveGoogleAuthMode(opts.googleAuthMode);
 
-  const marketing = opts.marketing;
+  const marketing: AuthMarketingContent | undefined =
+    opts.marketing ??
+    resolveBuiltInAuthMarketing({
+      requestHost: opts.requestHost,
+      requestPath: opts.requestPath,
+    });
   const hasMarketing = !!marketing;
   const runLocalCommand = marketing?.runLocalCommand?.trim();
   const brandMarkSrc = withAppBasePath("/agent-native-icon-dark.svg");

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  AUTHENTICATED_SSR_CACHE_CONTROL,
   createH3SSRHandler,
   DEFAULT_SSR_CACHE_CONTROL,
 } from "./ssr-handler.js";
@@ -122,7 +121,7 @@ describe("createH3SSRHandler", () => {
     );
   });
 
-  it("uses private SSR caching when a page request carries a framework session cookie", async () => {
+  it("keeps public SSR caching when a page request carries a framework session cookie", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response("<html><head></head><body>ok</body></html>", {
         headers: { "content-type": "text/html; charset=utf-8" },
@@ -137,7 +136,7 @@ describe("createH3SSRHandler", () => {
     );
 
     expect(response.headers.get("cache-control")).toBe(
-      AUTHENTICATED_SSR_CACHE_CONTROL,
+      DEFAULT_SSR_CACHE_CONTROL,
     );
   });
 
@@ -181,7 +180,7 @@ describe("createH3SSRHandler", () => {
     expect(mocks.getSession).not.toHaveBeenCalled();
   });
 
-  it("uses private SSR caching when anonymous and authenticated cookies coexist", async () => {
+  it("keeps public SSR caching when anonymous and authenticated cookies coexist", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response("<html><head></head><body>ok</body></html>", {
         headers: { "content-type": "text/html; charset=utf-8" },
@@ -196,7 +195,7 @@ describe("createH3SSRHandler", () => {
     );
 
     expect(response.headers.get("cache-control")).toBe(
-      AUTHENTICATED_SSR_CACHE_CONTROL,
+      DEFAULT_SSR_CACHE_CONTROL,
     );
     expect(mocks.getSession).toHaveBeenCalledTimes(1);
   });

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -28,8 +28,6 @@ import {
 
 export const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
-export const AUTHENTICATED_SSR_CACHE_CONTROL =
-  "private, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 const ANONYMOUS_SESSION_COOKIE_NAMES = new Set(["an_docs_session"]);
 const BETTER_AUTH_SESSION_COOKIE_RE = /\.session_(?:token|data)$/;
 
@@ -182,21 +180,14 @@ function isAuthenticatedCookieName(name: string): boolean {
   );
 }
 
-function applyDefaultSsrCacheHeader(
-  headers: Headers,
-  status: number,
-  hasAuthSignal: boolean,
-) {
+function applyDefaultSsrCacheHeader(headers: Headers, status: number) {
   if (headers.has("cache-control")) return;
   if (status < 200 || status >= 400) return;
 
   const contentType = headers.get("content-type")?.toLowerCase() ?? "";
   if (!contentType.includes("text/html")) return;
 
-  headers.set(
-    "cache-control",
-    hasAuthSignal ? AUTHENTICATED_SSR_CACHE_CONTROL : DEFAULT_SSR_CACHE_CONTROL,
-  );
+  headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
 }
 
 function isFrameworkOrAssetPath(pathname: string): boolean {
@@ -220,11 +211,10 @@ function isFrameworkOrAssetPath(pathname: string): boolean {
 async function rewriteMountedResponse(
   response: Response,
   basePath: string,
-  hasAuthSignal: boolean,
 ): Promise<Response> {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
-  applyDefaultSsrCacheHeader(headers, response.status, hasAuthSignal);
+  applyDefaultSsrCacheHeader(headers, response.status);
 
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {
@@ -312,13 +302,11 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
             headers: response.headers,
           }),
           basePath,
-          hasAuthSignal,
         );
       }
       return await rewriteMountedResponse(
         await runWithRequestContext(ctx, () => handler(request)),
         basePath,
-        hasAuthSignal,
       );
     } catch (err) {
       // Log the full stack server-side, but never leak it to the client.


### PR DESCRIPTION
## Summary
- Keep default successful SSR HTML responses public-cacheable even when auth cookies are present
- Render extension pages via sandboxed srcdoc inside MCP chat embeds to avoid nested frame ancestry failures
- Stop emitting app URLs in standard MCP Apps ui.domain metadata while preserving ChatGPT widgetDomain compatibility
- Document the MCP Apps metadata and extension embed behavior

## Tests
- pnpm --filter @agent-native/core exec vitest --run src/client/extensions/ExtensionViewer.spec.tsx src/mcp/server.spec.ts src/server/ssr-handler.spec.ts src/deploy/build.spec.ts
- pnpm --filter @agent-native/core typecheck