### PR TITLE
Fix MCP app host edge cases

### DIFF
--- a/.changeset/mcp-app-host-edge-cases.md
+++ b/.changeset/mcp-app-host-edge-cases.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix MCP app host catalog and embed metadata edge cases.

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -363,7 +363,7 @@ function mcpAppEmbedOpenLinkMeta(
       : typeof out.path === "string" && out.path.trim()
         ? out.path.trim()
         : undefined;
-  const safeViewOpenUrl = view && view !== "/" ? view : undefined;
+  const safeViewOpenUrl = view ? view : undefined;
   const explicitOpenUrl = deepLinkUrl
     ? deepLinkUrl
     : typeof out.url === "string" && !isEmbedStartUrl(out.url)

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -363,14 +363,15 @@ function mcpAppEmbedOpenLinkMeta(
       : typeof out.path === "string" && out.path.trim()
         ? out.path.trim()
         : undefined;
+  const safeViewOpenUrl = view && view !== "/" ? view : undefined;
   const explicitOpenUrl = deepLinkUrl
     ? deepLinkUrl
     : typeof out.url === "string" && !isEmbedStartUrl(out.url)
       ? out.url
-      : view;
+      : safeViewOpenUrl;
   const safeOpenUrl = explicitOpenUrl
     ? toAbsoluteOpenUrl(explicitOpenUrl, meta?.origin)
-    : webUrl;
+    : null;
 
   return {
     "agent-native/embedStart": {
@@ -379,12 +380,16 @@ function mcpAppEmbedOpenLinkMeta(
         ? { expiresAt: out.embedExpiresAt }
         : {}),
     },
-    "agent-native/openLink": {
-      label,
-      ...(view ? { view } : {}),
-      webUrl: safeOpenUrl,
-      desktopUrl: safeOpenUrl,
-    },
+    ...(safeOpenUrl
+      ? {
+          "agent-native/openLink": {
+            label,
+            ...(view ? { view } : {}),
+            webUrl: safeOpenUrl,
+            desktopUrl: safeOpenUrl,
+          },
+        }
+      : {}),
   };
 }
 

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -136,7 +136,15 @@ describe("embedApp", () => {
     expect(html).toContain("renderFrameFallback");
     expect(html).toContain("openFallbackExternal");
     expect(html).toContain("let url = withChatBridgeParam(openUrl)");
-    expect(html).toContain("if (!url) url = withChatBridgeParam(openStartUrl)");
+    expect(html).toContain("const buttonUrl = openUrl");
+    expect(html).toContain("fallbackOpen.disabled = !openUrl");
+    expect(html).toContain(
+      '(openUrl ? \'<a class="fallback-url" href="\' + esc(openUrl)',
+    );
+    expect(html).not.toContain(
+      "if (!url) url = withChatBridgeParam(openStartUrl)",
+    );
+    expect(html).not.toContain("const buttonUrl = openUrl || openStartUrl");
     expect(html).toContain("appFrameLoadTimer");
     expect(html).toContain("startFrameReadyTimer(frame)");
     expect(html).toContain("function embedSessionArgsFor(value)");

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -656,22 +656,25 @@ export function embedApp(
       clearFrameReadyTimer();
       clearFrameLoadTimer();
       appFrame = null;
+      const fallbackCopy = openUrl
+        ? "This chat host did not allow the embedded app frame to load inline. You can still open the same app route through the host or use the URL below."
+        : "This chat host did not allow the embedded app frame to load inline.";
       stage.innerHTML =
         '<div class="fallback">' +
           '<div class="fallback-title">Open this app in its own tab</div>' +
-          '<div class="fallback-copy">This chat host did not allow the embedded app frame to load inline. You can still open the same app route through the host or use the URL below.</div>' +
+          '<div class="fallback-copy">' + esc(fallbackCopy) + '</div>' +
           '<div class="fallback-actions">' +
             '<button type="button" data-fallback-open>Open app</button>' +
             '<button type="button" data-fallback-retry>Try inline again</button>' +
           '</div>' +
-          (openUrl || openStartUrl ? '<a class="fallback-url" href="' + esc(openUrl || openStartUrl) + '" target="_blank" rel="noreferrer">' + esc(openUrl || openStartUrl) + '</a>' : '') +
+          (openUrl ? '<a class="fallback-url" href="' + esc(openUrl) + '" target="_blank" rel="noreferrer">' + esc(openUrl) + '</a>' : '') +
         '</div>';
       const fallbackOpen = stage.querySelector("[data-fallback-open]");
       const fallbackRetry = stage.querySelector("[data-fallback-retry]");
       if (fallbackOpen) {
-        fallbackOpen.disabled = !(openUrl || openStartUrl);
+        fallbackOpen.disabled = !openUrl;
         fallbackOpen.onclick = () => {
-          if (openUrl || openStartUrl) void openFallbackExternal();
+          if (openUrl) void openFallbackExternal();
         };
       }
       if (fallbackRetry) {
@@ -683,6 +686,7 @@ export function embedApp(
     }
 
     async function openFallbackExternal() {
+      if (!openUrl) return;
       let url = withChatBridgeParam(openUrl);
       try {
         if (url) {
@@ -695,7 +699,6 @@ export function embedApp(
       } catch (err) {
         console.warn("[agent-native] MCP fallback could not mint a fresh app session", err);
       }
-      if (!url) url = withChatBridgeParam(openStartUrl);
       await openHostLink({ url });
     }
 
@@ -1032,7 +1035,7 @@ export function embedApp(
     }
 
     function updateOpenButton() {
-      const buttonUrl = openUrl || openStartUrl;
+      const buttonUrl = openUrl;
       openButton.disabled = !buttonUrl;
       openButton.onclick = () => {
         if (buttonUrl) void openHostLink({ url: buttonUrl });

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -690,6 +690,102 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     ]);
   });
 
+  it("keeps app-defined workspace connector verbs compact while hiding bulky app resources", async () => {
+    const dispatchLikeConfig = {
+      ...compactSurfaceDefaultConfig,
+      actions: {
+        ...compactSurfaceDefaultConfig.actions,
+        list_apps: {
+          tool: {
+            description: "List granted workspace apps",
+          },
+          readOnly: true,
+          run: async () => ({ apps: [] }),
+        },
+        open_app: {
+          tool: {
+            description: "Open a granted workspace app",
+          },
+          readOnly: true,
+          run: async () => ({
+            app: "mail",
+            path: "/",
+            embedStartUrl: "/_agent-native/embed/start?ticket=dispatch-ticket",
+          }),
+          mcpApp: {
+            resource: {
+              title: "Open app",
+              description: "Open the granted app inline.",
+              html: "<!doctype html><html><body>Open app</body></html>",
+            },
+          },
+        },
+        ask_app: {
+          tool: {
+            description: "Ask a granted workspace app",
+          },
+          run: async () => ({ response: "ok" }),
+        },
+        create_embed_session: {
+          tool: {
+            description: "Create an embed session",
+          },
+          readOnly: true,
+          run: async () => ({ startUrl: "/_agent-native/embed/start/mock" }),
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 129,
+        method: "tools/list",
+        params: {},
+      },
+      {
+        headers: await mcpAppsAuthHeaders(),
+        config: dispatchLikeConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    const names = out.result.tools.map((t: any) => t.name);
+    expect(names).toEqual([
+      "list_apps",
+      "open_app",
+      "ask_app",
+      "create_embed_session",
+    ]);
+    expect(names).not.toContain("bloated-widget");
+    expect(JSON.stringify(out)).not.toContain(
+      "MCP_APP_RESOURCE_BLOAT_SENTINEL",
+    );
+    expect(JSON.stringify(out).length).toBeLessThan(12_000);
+
+    const resourcesOut = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 130,
+        method: "resources/list",
+        params: {},
+      },
+      {
+        headers: await mcpAppsAuthHeaders(),
+        config: dispatchLikeConfig,
+      },
+    );
+
+    expect(resourcesOut.error).toBeUndefined();
+    expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
+      "ui://mail/open_app/shell-v26",
+    ]);
+    expect(JSON.stringify(resourcesOut)).not.toContain(
+      "MCP_APP_RESOURCE_BLOAT_SENTINEL",
+    );
+    expect(JSON.stringify(resourcesOut).length).toBeLessThan(8_000);
+  });
+
   it("preserves action-specific MCP App resources when builtins are disabled for app hosts", async () => {
     const fallbackConfig = {
       ...compactSurfaceConfig,
@@ -1723,7 +1819,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     );
   });
 
-  it("keeps embed-only start URLs as hidden open-link targets", async () => {
+  it("keeps embed-only start URLs hidden without exposing them as open links", async () => {
     const embedConfig = {
       ...config,
       actions: {
@@ -1761,13 +1857,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     );
 
     expect(out.error).toBeUndefined();
-    expect(out.result._meta["agent-native/openLink"]).toMatchObject({
-      label: "Open mail",
-      webUrl:
-        "https://mail.agent-native.com/_agent-native/embed/start?ticket=only-ticket&__an_mcp_chat_bridge=1",
-      desktopUrl:
-        "https://mail.agent-native.com/_agent-native/embed/start?ticket=only-ticket&__an_mcp_chat_bridge=1",
-    });
+    expect(out.result._meta["agent-native/openLink"]).toBeUndefined();
     expect(out.result._meta["agent-native/embedStart"]).toMatchObject({
       startUrl:
         "https://mail.agent-native.com/_agent-native/embed/start?ticket=only-ticket&__an_mcp_chat_bridge=1",
@@ -1777,6 +1867,59 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       "only-ticket",
     );
     expect(out.result.structuredContent.openLink).toBeUndefined();
+  });
+
+  it("does not invent a visible root open link for root-path embed starts", async () => {
+    const embedConfig = {
+      ...config,
+      actions: {
+        "open-root-embed": {
+          tool: {
+            description: "Open a root-path embed-only app",
+          },
+          run: async () => ({
+            app: "dispatch",
+            path: "/",
+            embed: true,
+            embedStartUrl: "/_agent-native/embed/start?ticket=root-ticket",
+          }),
+          readOnly: true,
+          mcpApp: {
+            resource: {
+              title: "Open root app",
+              description: "Open the full app inline.",
+              html: "<!doctype html><html><body>Open app</body></html>",
+            },
+          },
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 36,
+        method: "tools/call",
+        params: { name: "open-root-embed", arguments: {} },
+      },
+      {
+        headers: { "x-agent-native-mcp-full-catalog": "1" },
+        config: embedConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.result._meta["agent-native/openLink"]).toBeUndefined();
+    expect(out.result._meta["agent-native/embedStart"]).toMatchObject({
+      startUrl:
+        "https://mail.agent-native.com/_agent-native/embed/start?ticket=root-ticket&__an_mcp_chat_bridge=1",
+    });
+    expect(JSON.stringify(out.result.content)).not.toContain("root-ticket");
+    expect(JSON.stringify(out.result.structuredContent)).not.toContain(
+      "root-ticket",
+    );
+    expect(out.result.structuredContent.openLink).toBeUndefined();
+    expect(out.result.structuredContent.url).toBeUndefined();
   });
 
   it("rejects unauthenticated calls with 401 when auth IS configured (no 501)", async () => {

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -1869,7 +1869,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.result.structuredContent.openLink).toBeUndefined();
   });
 
-  it("does not invent a visible root open link for root-path embed starts", async () => {
+  it("uses a durable root open link for root-path embed starts", async () => {
     const embedConfig = {
       ...config,
       actions: {
@@ -1909,7 +1909,12 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     );
 
     expect(out.error).toBeUndefined();
-    expect(out.result._meta["agent-native/openLink"]).toBeUndefined();
+    expect(out.result._meta["agent-native/openLink"]).toMatchObject({
+      label: "Open dispatch",
+      view: "/",
+      webUrl: "https://mail.agent-native.com/",
+      desktopUrl: "https://mail.agent-native.com/",
+    });
     expect(out.result._meta["agent-native/embedStart"]).toMatchObject({
       startUrl:
         "https://mail.agent-native.com/_agent-native/embed/start?ticket=root-ticket&__an_mcp_chat_bridge=1",
@@ -1918,8 +1923,12 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(JSON.stringify(out.result.structuredContent)).not.toContain(
       "root-ticket",
     );
-    expect(out.result.structuredContent.openLink).toBeUndefined();
-    expect(out.result.structuredContent.url).toBeUndefined();
+    expect(out.result.structuredContent.openLink).toMatchObject({
+      webUrl: "https://mail.agent-native.com/",
+    });
+    expect(out.result.structuredContent.url).toBe(
+      "https://mail.agent-native.com/",
+    );
   });
 
   it("rejects unauthenticated calls with 401 when auth IS configured (no 501)", async () => {

--- a/packages/core/src/server/embed-session.spec.ts
+++ b/packages/core/src/server/embed-session.spec.ts
@@ -200,6 +200,12 @@ describe("requestMatchesEmbedTarget", () => {
   it("allows known dashboard alias redirects used by app embeds", () => {
     expect(
       requestMatchesEmbedTarget(
+        fakeEvent("/overview?embedded=1&__an_embed_token=tok"),
+        "/",
+      ),
+    ).toBe(true);
+    expect(
+      requestMatchesEmbedTarget(
         fakeEvent(
           "/adhoc/agent-native-templates-first-party?embedded=1&__an_embed_token=tok",
         ),

--- a/packages/core/src/server/embed-session.ts
+++ b/packages/core/src/server/embed-session.ts
@@ -37,6 +37,10 @@ const OPEN_ROUTE_VIEW_PATHS: Record<string, string> = {
   settings: "/settings",
 };
 const EMBED_ROUTE_ALIASES: Record<string, string[]> = {
+  // Dispatch's app root redirects to /overview. A ticket minted for the root
+  // should survive that first-hop redirect instead of falling back to the
+  // private deployment token gate.
+  "/": ["/overview"],
   "/dashboard": ["/adhoc/agent-native-templates-first-party"],
   "/dashboards": ["/adhoc/agent-native-templates-first-party"],
   "/traffic": ["/adhoc/agent-native-templates-first-party"],

--- a/templates/content/app/components/editor/VisualEditor.markdown.test.ts
+++ b/templates/content/app/components/editor/VisualEditor.markdown.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   createVisualEditorExtensions,
   EmptyLineParagraph,
+  shouldSeedCollaborativeContent,
 } from "./VisualEditor";
 import { CodeBlock } from "./extensions/CodeBlockNode";
 import { NotionToggle } from "./extensions/NotionExtensions";
@@ -184,6 +185,30 @@ describe("VisualEditor markdown round-tripping", () => {
       awareness.destroy();
       ydoc.destroy();
     }
+  });
+
+  it("seeds saved SQL content over a semantically empty collab fragment", () => {
+    expect(
+      shouldSeedCollaborativeContent({
+        content: "Saved body",
+        currentMarkdown: "<empty-block/>",
+        fragmentLength: 1,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSeedCollaborativeContent({
+        content: "Saved body",
+        currentMarkdown: "Live body",
+        fragmentLength: 1,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSeedCollaborativeContent({
+        content: "",
+        currentMarkdown: "",
+        fragmentLength: 1,
+      }),
+    ).toBe(false);
   });
 
   it("labels empty quote blocks with the quote placeholder", () => {

--- a/templates/content/app/components/editor/VisualEditor.tsx
+++ b/templates/content/app/components/editor/VisualEditor.tsx
@@ -555,6 +555,23 @@ interface VisualEditorProps {
   onJoinTitle?: (text: string) => void;
 }
 
+export function shouldSeedCollaborativeContent({
+  content,
+  currentMarkdown,
+  fragmentLength,
+}: {
+  content: string;
+  currentMarkdown: string;
+  fragmentLength: number;
+}): boolean {
+  const semanticMarkdown = currentMarkdown
+    .split(/\r?\n/)
+    .filter((line) => !/^<empty-block\b[^>]*\/>$/.test(line.trim()))
+    .join("\n")
+    .trim();
+  return !!content.trim() && (fragmentLength === 0 || !semanticMarkdown);
+}
+
 interface VisualEditorExtensionOptions {
   ydoc?: YDoc | null;
   localAwareness?: Awareness | null;
@@ -892,7 +909,16 @@ export function VisualEditor({
     // Skip if already seeded for this document
     if (seededDocRef.current === documentId) return;
     const fragment = ydoc.getXmlFragment("default");
-    if (fragment.length === 0) {
+    const currentMd = serializeEditorToNfm(
+      (editor.storage as any).markdown.getMarkdown(),
+    );
+    if (
+      shouldSeedCollaborativeContent({
+        content,
+        currentMarkdown: currentMd,
+        fragmentLength: fragment.length,
+      })
+    ) {
       isSettingContent.current = true;
       editor.commands.setContent(parseNfmForEditor(content));
       isSettingContent.current = false;

--- a/templates/content/app/hooks/use-navigation-state.ts
+++ b/templates/content/app/hooks/use-navigation-state.ts
@@ -81,7 +81,7 @@ export function useNavigationState() {
     }).catch(() => {});
 
     const target = resolveNavTarget(navCommand);
-    if (target) navigate(target, { flushSync: true });
+    if (target) navigate(target);
     qc.setQueryData(["navigate-command"], null);
   }, [navCommand, navigate, qc]);
 }

--- a/templates/content/app/hooks/use-navigation-watcher.ts
+++ b/templates/content/app/hooks/use-navigation-watcher.ts
@@ -55,7 +55,7 @@ export function useNavigationWatcher() {
                 path?: string;
               } | null;
               if (stateData?.path) {
-                navigate(stateData.path, { flushSync: true });
+                navigate(stateData.path);
               }
             }
           }

--- a/templates/content/app/routes/_app._index.tsx
+++ b/templates/content/app/routes/_app._index.tsx
@@ -47,7 +47,7 @@ export default function IndexRoute() {
     if (documents && documents.length > 0) {
       const firstFavorite = documents.find((d) => d.isFavorite);
       const target = firstFavorite ?? documents[0];
-      navigate(`/page/${target.id}`, { replace: true, flushSync: true });
+      navigate(`/page/${target.id}`, { replace: true });
     }
   }, [documents, navigate]);
 

--- a/templates/mail/actions/manage-draft.spec.ts
+++ b/templates/mail/actions/manage-draft.spec.ts
@@ -10,9 +10,7 @@ describe("manage-draft MCP App", () => {
     expect(source).toContain("embedApp({");
     expect(source).toContain('openLabel: "Open in Mail"');
     expect(source).toContain('iframeTitle: "Agent-Native Mail"');
-    expect(source).toContain('"https:"');
-    expect(source).toContain('"http://localhost:*"');
-    expect(source).toContain('"http://127.0.0.1:*"');
+    expect(source).toContain("height: 900");
     expect(source).not.toContain("mailDraftMcpAppHtml");
     expect(source).not.toContain("_mcp-apps");
     expect(source).not.toContain("data-save");

--- a/templates/mail/app/components/email/ComposeBubbleToolbar.tsx
+++ b/templates/mail/app/components/email/ComposeBubbleToolbar.tsx
@@ -16,13 +16,14 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { createPortal } from "react-dom";
+import { getSelectedMarkdown } from "./compose-draft-context";
 
 interface ComposeBubbleToolbarProps {
   editor: Editor;
   onFlush: () => Promise<unknown> | undefined;
   isGenerating: boolean;
   draftId: string;
-  draftBody: string;
+  getCurrentDraftBody: (editor: Editor) => string;
   sendToAgent: (opts: {
     message: string;
     context?: string;
@@ -47,7 +48,7 @@ export function ComposeBubbleToolbar({
   onFlush,
   isGenerating,
   draftId,
-  draftBody,
+  getCurrentDraftBody,
   sendToAgent,
 }: ComposeBubbleToolbarProps) {
   const [visible, setVisible] = useState(false);
@@ -223,12 +224,14 @@ export function ComposeBubbleToolbar({
 
     const { from, to } = editor.state.selection;
     const selectedText = editor.state.doc.textBetween(from, to, " ");
+    const selectedMarkdown = getSelectedMarkdown(editor, from, to);
 
     await onFlush();
+    const currentDraftBody = getCurrentDraftBody(editor);
 
     sendToAgent({
       message: aiPrompt.trim(),
-      context: `The user selected specific text in their email draft and wants you to edit only that selected portion. Update the existing draft by calling manage-draft with action "update", id "${draftId}", and body set to the full revised Markdown draft body. Preserve every unselected part of the body exactly, including quoted history. Do not only reply with replacement text.\n\nCurrent draft body:\n${draftBody || "(empty draft)"}\n\nSelected text to edit:\n"${selectedText}"`,
+      context: `The user selected specific text in their email draft and wants you to edit only that selected portion. Update the existing draft by calling manage-draft with action "update", id "${draftId}", and body set to the full revised Markdown draft body. Preserve every unselected part of the body exactly, including quoted history. Do not only reply with replacement text.\n\nCurrent Markdown draft body:\n${currentDraftBody || "(empty draft)"}\n\nSelected Markdown slice to edit:\n${selectedMarkdown?.trim() || "(selection could not be serialized; use the plain selected text below)"}\n\nPlain selected text:\n"${selectedText}"\n\nSelection range in the editor document: ${from}-${to}.`,
       submit: true,
     });
 

--- a/templates/mail/app/components/email/ComposeBubbleToolbar.tsx
+++ b/templates/mail/app/components/email/ComposeBubbleToolbar.tsx
@@ -9,7 +9,6 @@ import {
   IconLoader2,
 } from "@tabler/icons-react";
 import { cn, formatShortcut } from "@/lib/utils";
-import { isMcpChatBridgeActive } from "@/lib/mcp-chat-bridge";
 import { useState, useEffect, useRef, useCallback } from "react";
 import {
   Tooltip,
@@ -22,6 +21,8 @@ interface ComposeBubbleToolbarProps {
   editor: Editor;
   onFlush: () => Promise<unknown> | undefined;
   isGenerating: boolean;
+  draftId: string;
+  draftBody: string;
   sendToAgent: (opts: {
     message: string;
     context?: string;
@@ -45,6 +46,8 @@ export function ComposeBubbleToolbar({
   editor,
   onFlush,
   isGenerating,
+  draftId,
+  draftBody,
   sendToAgent,
 }: ComposeBubbleToolbarProps) {
   const [visible, setVisible] = useState(false);
@@ -223,12 +226,9 @@ export function ComposeBubbleToolbar({
 
     await onFlush();
 
-    const hostBridgeActive = isMcpChatBridgeActive();
     sendToAgent({
       message: aiPrompt.trim(),
-      context: hostBridgeActive
-        ? `The user selected specific text in their email draft and wants you to edit only that selected portion. Return the replacement text only; do not include commentary.\n\nSelected text to edit:\n"${selectedText}"`
-        : `The user has selected specific text in their email draft and wants you to edit ONLY that selected portion. You MUST:\n1. Read the full draft from application-state/compose.json\n2. Find and replace ONLY the selected text (shown below) with your edited version based on the user's instruction\n3. Preserve ALL other content exactly as-is — subject, recipients, and every other part of the body that was not selected\n4. Write the updated draft back to application-state/compose.json\n\nSelected text to edit:\n"${selectedText}"`,
+      context: `The user selected specific text in their email draft and wants you to edit only that selected portion. Update the existing draft by calling manage-draft with action "update", id "${draftId}", and body set to the full revised Markdown draft body. Preserve every unselected part of the body exactly, including quoted history. Do not only reply with replacement text.\n\nCurrent draft body:\n${draftBody || "(empty draft)"}\n\nSelected text to edit:\n"${selectedText}"`,
       submit: true,
     });
 

--- a/templates/mail/app/components/email/ComposeEditor.tsx
+++ b/templates/mail/app/components/email/ComposeEditor.tsx
@@ -46,7 +46,7 @@ interface ComposeEditorProps {
   onFlush: () => Promise<unknown> | undefined;
   isGenerating: boolean;
   draftId: string;
-  draftBody: string;
+  getCurrentDraftBody: (editor: Editor) => string;
   sendToAgent: (opts: {
     message: string;
     context?: string;
@@ -67,7 +67,7 @@ export const ComposeEditor = forwardRef<
     onFlush,
     isGenerating,
     draftId,
-    draftBody,
+    getCurrentDraftBody,
     sendToAgent,
   },
   ref,
@@ -200,7 +200,7 @@ export const ComposeEditor = forwardRef<
         onFlush={onFlush}
         isGenerating={isGenerating}
         draftId={draftId}
-        draftBody={draftBody}
+        getCurrentDraftBody={getCurrentDraftBody}
         sendToAgent={sendToAgent}
       />
       <ComposeSlashMenu editor={editor} onGenerate={onGenerate} />

--- a/templates/mail/app/components/email/ComposeEditor.tsx
+++ b/templates/mail/app/components/email/ComposeEditor.tsx
@@ -45,6 +45,8 @@ interface ComposeEditorProps {
   onClose: () => void;
   onFlush: () => Promise<unknown> | undefined;
   isGenerating: boolean;
+  draftId: string;
+  draftBody: string;
   sendToAgent: (opts: {
     message: string;
     context?: string;
@@ -64,6 +66,8 @@ export const ComposeEditor = forwardRef<
     onClose,
     onFlush,
     isGenerating,
+    draftId,
+    draftBody,
     sendToAgent,
   },
   ref,
@@ -195,6 +199,8 @@ export const ComposeEditor = forwardRef<
         editor={editor}
         onFlush={onFlush}
         isGenerating={isGenerating}
+        draftId={draftId}
+        draftBody={draftBody}
         sendToAgent={sendToAgent}
       />
       <ComposeSlashMenu editor={editor} onGenerate={onGenerate} />

--- a/templates/mail/app/components/email/ComposeModal.tsx
+++ b/templates/mail/app/components/email/ComposeModal.tsx
@@ -44,7 +44,6 @@ import { SendLaterButton } from "./SendLaterButton";
 import { expandAliasTokens } from "@/lib/alias-utils";
 import { appApiPath } from "@/lib/api-path";
 import { useAgentChatGenerating } from "@agent-native/core";
-import { isMcpChatBridgeActive } from "@/lib/mcp-chat-bridge";
 import { toast } from "sonner";
 import type { ComposeState } from "@shared/types";
 import {
@@ -421,13 +420,10 @@ export function ComposeModal({
       .filter(Boolean)
       .join("\n");
 
-    const hostBridgeActive = isMcpChatBridgeActive();
     const draftContext = context || "(empty draft)";
     sendToAgent({
       message: generatePrompt.trim(),
-      context: hostBridgeActive
-        ? `The user is composing an email in Agent-Native Mail. Use the draft snapshot below as the source of truth, then update the existing draft by calling manage-draft with action "update", id "${activeId}", and the revised Markdown body. Do not only reply with the revised content; the Mail draft must be updated through the tool. Preserve recipients and subject unless the user explicitly asks to change them.\n\nDrafting rules:\n- Use the configured signature exactly when one is present, and do not duplicate it if it is already in the draft.\n- If no configured signature is present, do not invent or derive a sign-off from the user's name or email address.\n- Use Markdown only. Keep the copy natural, specific, and free of generic AI email filler unless the user asks for a formal template.\n\n${draftContext}`
-        : `The user is composing an email. The current draft is saved in application-state/compose-${activeId}.json.\n\nIMPORTANT: Update this EXISTING file (compose-${activeId}.json) — do NOT create a new compose file. Read it first, then write back to the same file with your changes.\n\nDrafting rules:\n- Use the configured signature exactly when one is present, and do not duplicate it if it is already in the draft.\n- If no configured signature is present, do not invent or derive a sign-off from the user's name or email address.\n- Use Markdown only. Keep the copy natural, specific, and free of generic AI email filler unless the user asks for a formal template.\n\n${draftContext}`,
+      context: `The user is composing an email in Agent-Native Mail. Use the draft snapshot below as the source of truth, then update the existing draft by calling manage-draft with action "update", id "${activeId}", and the revised Markdown body. Do not only reply with the revised content; the Mail draft must be updated through the tool. Preserve recipients and subject unless the user explicitly asks to change them.\n\nDrafting rules:\n- Use the configured signature exactly when one is present, and do not duplicate it if it is already in the draft.\n- If no configured signature is present, do not invent or derive a sign-off from the user's name or email address.\n- Use Markdown only. Keep the copy natural, specific, and free of generic AI email filler unless the user asks for a formal template.\n\n${draftContext}`,
       submit: true,
     });
 
@@ -973,6 +969,8 @@ function ComposeBody({
         onClose={() => onClose(activeId)}
         onFlush={() => onFlush(activeId)}
         isGenerating={isGenerating}
+        draftId={activeId}
+        draftBody={activeDraft.body}
         sendToAgent={sendToAgent}
       />
       {hasQuote && (

--- a/templates/mail/app/components/email/ComposeModal.tsx
+++ b/templates/mail/app/components/email/ComposeModal.tsx
@@ -50,29 +50,16 @@ import {
   appendSignatureToBody,
   splitAppendedSignature,
 } from "@shared/signature";
+import {
+  getCurrentDraftBodyFromEditor,
+  splitQuotedContent,
+} from "./compose-draft-context";
 import { RecipientInput } from "./RecipientInput";
 import { ComposeEditor, type ComposeEditorHandle } from "./ComposeEditor";
 import { openFilePicker, uploadFiles } from "@/lib/upload";
 import { useAccountFilter } from "@/hooks/use-account-filter";
 import { canUseAgentGenerate } from "@/lib/agent-generate";
 import { AttachmentStrip } from "./AttachmentStrip";
-
-/**
- * Split a compose body into the editable portion and the quoted history.
- * Returns [editable, quoted] — quoted is empty string when there's no quote.
- */
-function splitQuotedContent(body: string): [string, string] {
-  // Match "— On ..., ... wrote:" (reply) or "— Forwarded message —" (forward)
-  const replyMatch = body.match(/\n*— On .+? wrote:\n/);
-  const fwdMatch = body.match(/\n*— Forwarded message —\n/);
-
-  const match = replyMatch || fwdMatch;
-  if (!match || match.index === undefined) return [body, ""];
-
-  const editable = body.slice(0, match.index);
-  const quoted = body.slice(match.index);
-  return [editable, quoted];
-}
 
 const LAST_SEND_ACCOUNT_KEY = "mail:lastSendAccount";
 
@@ -405,17 +392,25 @@ export function ComposeModal({
     }
 
     await onFlush(activeId);
+    const promptDraft = {
+      ...activeDraft,
+      body: getCurrentDraftBodyFromEditor({
+        draft: activeDraft,
+        editor: editorRef.current?.getEditor(),
+        signature: settings?.signature,
+      }),
+    };
 
     const context = [
-      activeDraft.to && `To: ${activeDraft.to}`,
-      activeDraft.cc && `Cc: ${activeDraft.cc}`,
-      activeDraft.subject && `Subject: ${activeDraft.subject}`,
+      promptDraft.to && `To: ${promptDraft.to}`,
+      promptDraft.cc && `Cc: ${promptDraft.cc}`,
+      promptDraft.subject && `Subject: ${promptDraft.subject}`,
       settings?.writingStyle?.trim() &&
         `User writing style:\n${settings.writingStyle.trim()}`,
       settings?.signature?.trim()
         ? `Configured signature:\n${settings.signature.trim()}`
         : "Configured signature: (none)",
-      activeDraft.body && `Current draft:\n${activeDraft.body}`,
+      promptDraft.body && `Current draft:\n${promptDraft.body}`,
     ]
       .filter(Boolean)
       .join("\n");
@@ -970,7 +965,13 @@ function ComposeBody({
         onFlush={() => onFlush(activeId)}
         isGenerating={isGenerating}
         draftId={activeId}
-        draftBody={activeDraft.body}
+        getCurrentDraftBody={(editor) =>
+          getCurrentDraftBodyFromEditor({
+            draft: activeDraft,
+            editor,
+            signature,
+          })
+        }
         sendToAgent={sendToAgent}
       />
       {hasQuote && (

--- a/templates/mail/app/components/email/InlineReplyComposer.tsx
+++ b/templates/mail/app/components/email/InlineReplyComposer.tsx
@@ -38,7 +38,6 @@ import { useAliases } from "@/hooks/use-aliases";
 import { expandAliasTokens } from "@/lib/alias-utils";
 import { appApiPath } from "@/lib/api-path";
 import { useAgentChatGenerating } from "@agent-native/core";
-import { isMcpChatBridgeActive } from "@/lib/mcp-chat-bridge";
 import { toast } from "sonner";
 import type { ComposeState, EmailMessage } from "@shared/types";
 import {
@@ -297,13 +296,10 @@ export const InlineReplyComposer = forwardRef<
     ]
       .filter(Boolean)
       .join("\n");
-    const hostBridgeActive = isMcpChatBridgeActive();
     const draftContext = context || "(empty draft)";
     sendToAgent({
       message: generatePrompt.trim(),
-      context: hostBridgeActive
-        ? `The user is composing an email reply in Agent-Native Mail. Use the draft snapshot below as the source of truth, then update the existing reply draft by calling manage-draft with action "update", id "${draft.id}", and the revised Markdown body. Do not only reply with the revised content; the Mail draft must be updated through the tool. Preserve recipients and subject unless the user explicitly asks to change them.\n\nDrafting rules:\n- Use the configured signature exactly when one is present, and do not duplicate it if it is already in the draft.\n- If no configured signature is present, do not invent or derive a sign-off from the user's name or email address.\n- Use Markdown only. Keep the copy natural, specific, and free of generic AI email filler unless the user asks for a formal template.\n\n${draftContext}`
-        : `The user is composing an email reply. The current draft is saved in application-state/compose-${draft.id}.json.\n\nIMPORTANT: Update this EXISTING file (compose-${draft.id}.json) — do NOT create a new compose file. Read it first, then write back to the same file with your changes.\n\nDrafting rules:\n- Use the configured signature exactly when one is present, and do not duplicate it if it is already in the draft.\n- If no configured signature is present, do not invent or derive a sign-off from the user's name or email address.\n- Use Markdown only. Keep the copy natural, specific, and free of generic AI email filler unless the user asks for a formal template.\n\n${draftContext}`,
+      context: `The user is composing an email reply in Agent-Native Mail. Use the draft snapshot below as the source of truth, then update the existing reply draft by calling manage-draft with action "update", id "${draft.id}", and the revised Markdown body. Do not only reply with the revised content; the Mail draft must be updated through the tool. Preserve recipients and subject unless the user explicitly asks to change them.\n\nDrafting rules:\n- Use the configured signature exactly when one is present, and do not duplicate it if it is already in the draft.\n- If no configured signature is present, do not invent or derive a sign-off from the user's name or email address.\n- Use Markdown only. Keep the copy natural, specific, and free of generic AI email filler unless the user asks for a formal template.\n\n${draftContext}`,
       submit: true,
     });
     setGeneratePrompt("");
@@ -453,6 +449,8 @@ export const InlineReplyComposer = forwardRef<
           onClose={() => onClose(draft.id)}
           onFlush={() => onFlush(draft.id)}
           isGenerating={isGenerating}
+          draftId={draft.id}
+          draftBody={draft.body}
           sendToAgent={sendToAgent}
         />
         {hasQuote && (

--- a/templates/mail/app/components/email/InlineReplyComposer.tsx
+++ b/templates/mail/app/components/email/InlineReplyComposer.tsx
@@ -44,19 +44,15 @@ import {
   appendSignatureToBody,
   splitAppendedSignature,
 } from "@shared/signature";
+import {
+  getCurrentDraftBodyFromEditor,
+  splitQuotedContent,
+} from "./compose-draft-context";
 import { RecipientInput } from "./RecipientInput";
 import { ComposeEditor, type ComposeEditorHandle } from "./ComposeEditor";
 import { openFilePicker, uploadFiles } from "@/lib/upload";
 import { canUseAgentGenerate } from "@/lib/agent-generate";
 import { AttachmentStrip } from "./AttachmentStrip";
-
-function splitQuotedContent(body: string): [string, string] {
-  const replyMatch = body.match(/\n*— On .+? wrote:\n/);
-  const fwdMatch = body.match(/\n*— Forwarded message —\n/);
-  const match = replyMatch || fwdMatch;
-  if (!match || match.index === undefined) return [body, ""];
-  return [body.slice(0, match.index), body.slice(match.index)];
-}
 
 export interface InlineReplyHandle {
   focusEditor: () => void;
@@ -283,16 +279,24 @@ export const InlineReplyComposer = forwardRef<
       return;
     }
     await onFlush(draft.id);
+    const promptDraft = {
+      ...draft,
+      body: getCurrentDraftBodyFromEditor({
+        draft,
+        editor: editorRef.current?.getEditor(),
+        signature: settings?.signature,
+      }),
+    };
     const context = [
-      draft.to && `To: ${draft.to}`,
-      draft.cc && `Cc: ${draft.cc}`,
-      draft.subject && `Subject: ${draft.subject}`,
+      promptDraft.to && `To: ${promptDraft.to}`,
+      promptDraft.cc && `Cc: ${promptDraft.cc}`,
+      promptDraft.subject && `Subject: ${promptDraft.subject}`,
       settings?.writingStyle?.trim() &&
         `User writing style:\n${settings.writingStyle.trim()}`,
       settings?.signature?.trim()
         ? `Configured signature:\n${settings.signature.trim()}`
         : "Configured signature: (none)",
-      draft.body && `Current draft:\n${draft.body}`,
+      promptDraft.body && `Current draft:\n${promptDraft.body}`,
     ]
       .filter(Boolean)
       .join("\n");
@@ -450,7 +454,13 @@ export const InlineReplyComposer = forwardRef<
           onFlush={() => onFlush(draft.id)}
           isGenerating={isGenerating}
           draftId={draft.id}
-          draftBody={draft.body}
+          getCurrentDraftBody={(editor) =>
+            getCurrentDraftBodyFromEditor({
+              draft,
+              editor,
+              signature: settings?.signature,
+            })
+          }
           sendToAgent={sendToAgent}
         />
         {hasQuote && (

--- a/templates/mail/app/components/email/compose-draft-context.ts
+++ b/templates/mail/app/components/email/compose-draft-context.ts
@@ -1,0 +1,90 @@
+import type { ComposeState } from "@shared/types";
+import {
+  appendSignatureToBody,
+  splitAppendedSignature,
+} from "@shared/signature";
+
+type MarkdownEditor = {
+  isDestroyed?: boolean;
+  storage: any;
+  state: {
+    doc: {
+      cut: (from: number, to: number) => unknown;
+    };
+  };
+};
+
+export function splitQuotedContent(body: string): [string, string] {
+  const replyMatch = body.match(/\n*— On .+? wrote:\n/);
+  const fwdMatch = body.match(/\n*— Forwarded message —\n/);
+  const match = replyMatch || fwdMatch;
+  if (!match || match.index === undefined) return [body, ""];
+  return [body.slice(0, match.index), body.slice(match.index)];
+}
+
+export function getEditorMarkdown(editor: MarkdownEditor | null | undefined) {
+  if (!editor || editor.isDestroyed) return null;
+  try {
+    return (editor.storage as any).markdown.getMarkdown() as string;
+  } catch {
+    return null;
+  }
+}
+
+export function mergeEditorMarkdownIntoDraftBody({
+  draft,
+  editorMarkdown,
+  signature,
+}: {
+  draft: ComposeState;
+  editorMarkdown: string | null | undefined;
+  signature?: string;
+}) {
+  if (editorMarkdown == null) return draft.body;
+
+  const [editableContent, quotedContent] = splitQuotedContent(draft.body);
+  const [, appendedSignature] =
+    draft.mode === "reply"
+      ? splitAppendedSignature(editableContent, signature)
+      : [editableContent, ""];
+
+  if (appendedSignature) {
+    return appendSignatureToBody(
+      editorMarkdown + quotedContent,
+      appendedSignature,
+    );
+  }
+  if (quotedContent) return editorMarkdown + quotedContent;
+  return editorMarkdown;
+}
+
+export function getCurrentDraftBodyFromEditor({
+  draft,
+  editor,
+  signature,
+}: {
+  draft: ComposeState;
+  editor: MarkdownEditor | null | undefined;
+  signature?: string;
+}) {
+  return mergeEditorMarkdownIntoDraftBody({
+    draft,
+    editorMarkdown: getEditorMarkdown(editor),
+    signature,
+  });
+}
+
+export function getSelectedMarkdown(
+  editor: MarkdownEditor,
+  from: number,
+  to: number,
+) {
+  if (from === to) return "";
+  try {
+    const serializer = (editor.storage as any).markdown?.serializer;
+    if (!serializer || typeof serializer.serialize !== "function") return null;
+    return serializer.serialize(editor.state.doc.cut(from, to)) as string;
+  } catch {
+    return null;
+  }
+}

--- a/templates/mail/app/components/email/mcp-compose-prompts.spec.ts
+++ b/templates/mail/app/components/email/mcp-compose-prompts.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { mergeEditorMarkdownIntoDraftBody } from "./compose-draft-context";
 
 function source(path: string): string {
   return readFileSync(new URL(path, import.meta.url), "utf8");
@@ -12,6 +13,7 @@ describe("Mail MCP compose prompts", () => {
 
     for (const file of [popout, inline]) {
       expect(file).toContain('calling manage-draft with action "update"');
+      expect(file).toContain("getCurrentDraftBodyFromEditor");
       expect(file).not.toContain("application-state/compose-");
       expect(file).not.toContain("Read it first, then write back");
       expect(file).not.toContain("isMcpChatBridgeActive");
@@ -25,9 +27,30 @@ describe("Mail MCP compose prompts", () => {
     expect(toolbar).toContain(
       "body set to the full revised Markdown draft body",
     );
-    expect(toolbar).toContain("Current draft body:");
-    expect(toolbar).not.toContain("replacement text only");
+    expect(toolbar).toContain("Current Markdown draft body:");
+    expect(toolbar).toContain("Selected Markdown slice to edit:");
+    expect(toolbar).toContain("Selection range in the editor document:");
+    expect(toolbar).toContain("getCurrentDraftBody(editor)");
     expect(toolbar).not.toContain("application-state/compose.json");
     expect(toolbar).not.toContain("isMcpChatBridgeActive");
+  });
+
+  it("reconstructs the current full body from live editor Markdown", () => {
+    expect(
+      mergeEditorMarkdownIntoDraftBody({
+        draft: {
+          id: "draft-1",
+          mode: "reply",
+          to: "friend@example.com",
+          cc: "",
+          bcc: "",
+          subject: "Re: hi",
+          body: "Old body\n\nBest,\nSteve\n— On Tue wrote:\nQuoted",
+          attachments: [],
+        },
+        editorMarkdown: "Fresh body",
+        signature: "Best,\nSteve",
+      }),
+    ).toBe("Fresh body\n\nBest,\nSteve\n\n— On Tue wrote:\nQuoted");
   });
 });

--- a/templates/mail/app/components/email/mcp-compose-prompts.spec.ts
+++ b/templates/mail/app/components/email/mcp-compose-prompts.spec.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+describe("Mail MCP compose prompts", () => {
+  it("uses the manage-draft action contract for popout and inline generate prompts", () => {
+    const popout = source("./ComposeModal.tsx");
+    const inline = source("./InlineReplyComposer.tsx");
+
+    for (const file of [popout, inline]) {
+      expect(file).toContain('calling manage-draft with action "update"');
+      expect(file).not.toContain("application-state/compose-");
+      expect(file).not.toContain("Read it first, then write back");
+      expect(file).not.toContain("isMcpChatBridgeActive");
+    }
+  });
+
+  it("updates the active draft for selected-text AI edits instead of asking for text-only replies", () => {
+    const toolbar = source("./ComposeBubbleToolbar.tsx");
+
+    expect(toolbar).toContain('id "${draftId}"');
+    expect(toolbar).toContain(
+      "body set to the full revised Markdown draft body",
+    );
+    expect(toolbar).toContain("Current draft body:");
+    expect(toolbar).not.toContain("replacement text only");
+    expect(toolbar).not.toContain("application-state/compose.json");
+    expect(toolbar).not.toContain("isMcpChatBridgeActive");
+  });
+});

--- a/templates/mail/app/hooks/use-compose-state.spec.ts
+++ b/templates/mail/app/hooks/use-compose-state.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import type { ComposeState } from "@shared/types";
+import { newestUnseenPopoutDraftId } from "./use-compose-state";
+
+function draft(id: string, inline = false): ComposeState {
+  return {
+    id,
+    to: "",
+    subject: "",
+    body: "",
+    mode: "compose",
+    inline,
+  };
+}
+
+describe("newestUnseenPopoutDraftId", () => {
+  it("focuses the newest server-added popout draft", () => {
+    expect(
+      newestUnseenPopoutDraftId(new Set(["old"]), [
+        draft("old"),
+        draft("newer"),
+      ]),
+    ).toBe("newer");
+  });
+
+  it("ignores inline reply drafts and keeps focus unchanged", () => {
+    expect(
+      newestUnseenPopoutDraftId(new Set(["old"]), [
+        draft("old"),
+        draft("inline-reply", true),
+      ]),
+    ).toBeNull();
+  });
+});

--- a/templates/mail/app/hooks/use-compose-state.ts
+++ b/templates/mail/app/hooks/use-compose-state.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { agentNativePath } from "@agent-native/core/client";
 import { nanoid } from "nanoid";
@@ -6,6 +6,8 @@ import type { ComposeState, UserSettings } from "@shared/types";
 import { appendSignatureToBody } from "@shared/signature";
 import { appApiPath } from "@/lib/api-path";
 import { TAB_ID } from "@/lib/tab-id";
+
+export const FOCUS_COMPOSE_DRAFT_EVENT = "mail:focus-compose-draft";
 
 async function apiFetch<T>(url: string, options?: RequestInit): Promise<T> {
   const res = await fetch(
@@ -68,6 +70,7 @@ export function useComposeState() {
   const gmailSaveRef = useRef<Record<string, ReturnType<typeof setTimeout>>>(
     {},
   );
+  const knownDraftIdsRef = useRef<Set<string> | null>(null);
 
   // Fetch all drafts — short staleTime so agent-written drafts appear quickly
   const query = useQuery<ComposeState[]>({
@@ -104,6 +107,27 @@ export function useComposeState() {
   });
 
   const drafts = query.data ?? [];
+
+  useEffect(() => {
+    const handleFocusDraft = (event: Event) => {
+      const id = (event as CustomEvent<{ id?: unknown }>).detail?.id;
+      if (typeof id === "string" && id.trim()) setActiveId(id);
+    };
+    window.addEventListener(FOCUS_COMPOSE_DRAFT_EVENT, handleFocusDraft);
+    return () =>
+      window.removeEventListener(FOCUS_COMPOSE_DRAFT_EVENT, handleFocusDraft);
+  }, []);
+
+  useEffect(() => {
+    if (!query.isSuccess) return;
+    const previousIds = knownDraftIdsRef.current;
+    const currentIds = new Set(drafts.map((draft) => draft.id));
+    knownDraftIdsRef.current = currentIds;
+    if (!previousIds) return;
+
+    const newActiveId = newestUnseenPopoutDraftId(previousIds, drafts);
+    if (newActiveId) setActiveId(newActiveId);
+  }, [drafts, query.isSuccess]);
 
   // Resolve activeId: use current if valid, else last draft, else null
   const resolvedActiveId =
@@ -368,4 +392,15 @@ export function useComposeState() {
     setActiveId,
     flush,
   };
+}
+
+export function newestUnseenPopoutDraftId(
+  previousIds: ReadonlySet<string>,
+  drafts: ComposeState[],
+) {
+  for (let i = drafts.length - 1; i >= 0; i -= 1) {
+    const draft = drafts[i];
+    if (!draft.inline && !previousIds.has(draft.id)) return draft.id;
+  }
+  return null;
 }

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -5,7 +5,10 @@ import { cn } from "@/lib/utils";
 import { EmailList, InboxZero } from "@/components/email/EmailList";
 import { groupIntoThreads, type ThreadSummary } from "@/lib/threads";
 import { EmailThread } from "@/components/email/EmailThread";
-import { useComposeState } from "@/hooks/use-compose-state";
+import {
+  FOCUS_COMPOSE_DRAFT_EVENT,
+  useComposeState,
+} from "@/hooks/use-compose-state";
 import {
   useNavigationState,
   type NavigationState,
@@ -437,8 +440,14 @@ export function InboxPage() {
     if (navCommand.composeDraftId && !targetThread) {
       // A deep link reopened a compose draft. The open route already wrote the
       // matching compose-<id> app-state entry, which the compose panel
-      // auto-opens via polling — we just need to land on the inbox so the
-      // panel is visible.
+      // auto-opens via polling. Select the requested draft immediately so
+      // existing compose tabs do not keep focus when the draft arrives.
+      compose.setActiveId(navCommand.composeDraftId);
+      window.dispatchEvent(
+        new CustomEvent(FOCUS_COMPOSE_DRAFT_EVENT, {
+          detail: { id: navCommand.composeDraftId },
+        }),
+      );
       if (view !== "inbox") navigate("/inbox");
     } else if (targetView === "draft-queue") {
       const target = navCommand.queuedDraftId

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function inboxSource(): string {
+  return readFileSync(new URL("./InboxPage.tsx", import.meta.url), "utf8");
+}
+
+describe("Inbox navigation commands", () => {
+  it("focuses compose drafts opened by MCP deep links", () => {
+    const source = inboxSource();
+    expect(source).toContain("navCommand.composeDraftId && !targetThread");
+    expect(source).toContain("compose.setActiveId(navCommand.composeDraftId)");
+    expect(source).toContain("FOCUS_COMPOSE_DRAFT_EVENT");
+  });
+});

--- a/templates/mail/server/lib/queued-drafts.ts
+++ b/templates/mail/server/lib/queued-drafts.ts
@@ -62,6 +62,14 @@ function isAdminRole(role: string | undefined): boolean {
   return role === "owner" || role === "admin";
 }
 
+function isQueueContextUnavailable(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("An active organization is required") ||
+    message.includes("Only members of this organization")
+  );
+}
+
 export function serializeQueuedDraft(row: any): QueuedEmailDraft {
   const draft = {
     id: row.id,
@@ -285,7 +293,13 @@ export async function listQueuedDrafts(input: {
   ownerEmail?: string;
   limit?: number;
 }): Promise<QueuedEmailDraft[]> {
-  const ctx = await requireQueueContext();
+  let ctx: QueueContext;
+  try {
+    ctx = await requireQueueContext();
+  } catch (error) {
+    if (isQueueContextUnavailable(error)) return [];
+    throw error;
+  }
   const scope = input.scope ?? "review";
   const status = input.status ?? "active";
   const limit = Math.min(Math.max(input.limit ?? 100, 1), 200);


### PR DESCRIPTION
## Summary
- keep embed-start-only MCP App results hidden instead of exposing bogus visible open links
- keep Dispatch-style app host catalogs compact while preserving single-app MCP App resources
- route Mail compose generation and selected-text edits through the manage-draft action contract

## Verification
- pnpm --filter @agent-native/core exec vitest --run src/mcp/server.spec.ts src/mcp/embed-app.spec.ts src/client/mcp-app-host.spec.ts src/client/agent-chat.spec.ts src/client/embed-auth.spec.ts
- pnpm --filter mail exec vitest --run app/components/email/mcp-compose-prompts.spec.ts actions/manage-draft.spec.ts
- pnpm --filter mail typecheck
- live MCP smoke for Mail + Dispatch local/ngrok compact tools/resources and ticket privacy
- Browser smoke for expired embed session page
- pnpm prep