### PR TITLE
Harden MCP host integration: plug leaks in tickets, passwords, drafts, and bridge mode

### DIFF
--- a/.changeset/mcp-host-hardening-and-leak-fixes.md
+++ b/.changeset/mcp-host-hardening-and-leak-fixes.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Harden MCP host integration against ticket and content leaks. Strip embed-ticket URLs from any tool result text even when the action does not declare `mcpApp.resource`. Filter `embedTargetPath`, `embedExpiresAt`, and `ticket`-like fields from MCP structured content (their legitimate carrier is `_meta["agent-native/embedStart"]`). Stop fabricating an `_meta["agent-native/openLink"]` `webUrl` from a bare view name like `"deck"` when the action returns only an embed-start URL. Remove the now-unused `compose` field from `buildDeepLink` so deep-link URLs cannot inline draft contents. Make `isEmbedMcpChatBridgeActive` keep the in-memory bridge flag once enrolled so sandboxed iframes that deny sessionStorage no longer silently drop chat-bridge mode mid-session.

--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -10,7 +10,9 @@ import {
   isWorkspaceWatcherLimitError,
   runWorkspaceDev,
   shouldEagerStartWorkspaceApps,
+  shouldPrewarmWorkspaceApps,
   shouldUsePollingFileWatcher,
+  workspacePrewarmConcurrency,
   type WorkspaceDevHandle,
 } from "./workspace-dev.js";
 
@@ -63,6 +65,57 @@ describe("workspace dev startup", () => {
     await handle.ready;
 
     expect(fake.startedApps()).toEqual(["dispatch", "starter", "todo"]);
+  });
+
+  it("prewarms non-default apps in the background after the gateway is ready", async () => {
+    tmpDir = makeWorkspace(["dispatch", "starter", "todo"]);
+    const fake = fakeSpawn();
+    handle = await runWorkspaceDev({
+      root: tmpDir,
+      env: {
+        ...testEnv(),
+        // Opt in to prewarm for this test (testEnv disables it by default).
+        WORKSPACE_NO_PREWARM: "",
+        WORKSPACE_PREWARM_DELAY_MS: "0",
+      },
+      spawnProcess: fake.spawnProcess,
+      openBrowser: false,
+    });
+    await handle.ready;
+
+    // Only the default app is started synchronously; prewarm catches up in
+    // the background.
+    expect(fake.startedApps().includes("dispatch")).toBe(true);
+
+    await waitUntil(() => {
+      const ids = new Set(fake.startedApps());
+      return ids.has("starter") && ids.has("todo");
+    });
+
+    expect(new Set(fake.startedApps())).toEqual(
+      new Set(["dispatch", "starter", "todo"]),
+    );
+  });
+
+  it("does not prewarm when --no-prewarm is passed", async () => {
+    tmpDir = makeWorkspace(["dispatch", "starter", "todo"]);
+    const fake = fakeSpawn();
+    handle = await runWorkspaceDev({
+      root: tmpDir,
+      args: ["--no-prewarm"],
+      env: {
+        ...testEnv(),
+        WORKSPACE_NO_PREWARM: "",
+        WORKSPACE_PREWARM_DELAY_MS: "0",
+      },
+      spawnProcess: fake.spawnProcess,
+      openBrowser: false,
+    });
+    await handle.ready;
+
+    // Give any (hypothetically) scheduled prewarm a chance to fire.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(fake.startedApps()).toEqual(["dispatch"]);
   });
 
   it("passes the public workspace OAuth origin separately from the local gateway", async () => {
@@ -436,6 +489,44 @@ describe("workspace dev helpers", () => {
     expect(shouldEagerStartWorkspaceApps([], {})).toBe(false);
   });
 
+  it("defaults prewarm on in lazy mode and respects opt-outs", () => {
+    expect(shouldPrewarmWorkspaceApps([], {})).toBe(true);
+    expect(shouldPrewarmWorkspaceApps(["--no-prewarm"], {})).toBe(false);
+    expect(shouldPrewarmWorkspaceApps([], { WORKSPACE_NO_PREWARM: "1" })).toBe(
+      false,
+    );
+    // Eager mode already starts every app — prewarm has nothing to do.
+    expect(shouldPrewarmWorkspaceApps(["--eager"], {})).toBe(false);
+    expect(shouldPrewarmWorkspaceApps([], { WORKSPACE_EAGER: "1" })).toBe(
+      false,
+    );
+  });
+
+  it("parses prewarm concurrency from arg or env, falling back to 2", () => {
+    expect(workspacePrewarmConcurrency([], {})).toBe(2);
+    expect(workspacePrewarmConcurrency(["--prewarm-concurrency=4"], {})).toBe(
+      4,
+    );
+    expect(
+      workspacePrewarmConcurrency([], { WORKSPACE_PREWARM_CONCURRENCY: "3" }),
+    ).toBe(3);
+    // Bogus values clamp back to the default.
+    expect(
+      workspacePrewarmConcurrency([], { WORKSPACE_PREWARM_CONCURRENCY: "0" }),
+    ).toBe(2);
+    expect(
+      workspacePrewarmConcurrency([], {
+        WORKSPACE_PREWARM_CONCURRENCY: "nope",
+      }),
+    ).toBe(2);
+    // CLI flag wins over env.
+    expect(
+      workspacePrewarmConcurrency(["--prewarm-concurrency=5"], {
+        WORKSPACE_PREWARM_CONCURRENCY: "9",
+      }),
+    ).toBe(5);
+  });
+
   it("selects the boot app ids for lazy and eager startup", () => {
     const apps = [{ id: "dispatch" }, { id: "starter" }];
     expect(initialWorkspaceAppIds(apps, "dispatch", false)).toEqual([
@@ -478,6 +569,11 @@ function testEnv(): NodeJS.ProcessEnv {
     WORKSPACE_APP_PORT_START: "19100",
     WORKSPACE_NO_OPEN: "1",
     WORKSPACE_PROXY_READY_TIMEOUT_MS: "50",
+    // Existing assertions count "exec vite" spawns and expect just the
+    // default-app entry; the background prewarm queue would race those
+    // counters. Tests that exercise prewarm opt in explicitly by clearing
+    // this in their own env override.
+    WORKSPACE_NO_PREWARM: "1",
   };
 }
 

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -113,6 +113,66 @@ export function shouldEagerStartWorkspaceApps(
   );
 }
 
+/**
+ * Whether the gateway should spawn the rest of the apps in the background
+ * after the default app boots. Lazy spawn already covers correctness — this
+ * is purely a UX optimization so the second/third/Nth app the user clicks
+ * into is already warm instead of paying the Vite + esbuild prebundle cost
+ * on demand.
+ *
+ * Defaults to ON in lazy mode. Off when the user passed --no-prewarm /
+ * WORKSPACE_NO_PREWARM=1, or when eager mode is already starting every app
+ * up front (in which case prewarm would be redundant).
+ */
+export function shouldPrewarmWorkspaceApps(
+  args: string[] = [],
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (args.includes("--no-prewarm")) return false;
+  if (env.WORKSPACE_NO_PREWARM === "1" || env.WORKSPACE_NO_PREWARM === "true") {
+    return false;
+  }
+  // Eager mode starts every app immediately; prewarm has nothing to do.
+  if (shouldEagerStartWorkspaceApps(args, env)) return false;
+  return true;
+}
+
+/**
+ * How many apps to prewarm in parallel. Each Vite spawn briefly maxes out a
+ * CPU core during esbuild prebundling, so booting all 9 templates at once on
+ * a 4-core laptop just produces a thundering herd. Default 2 — gentle on
+ * laptops, fast enough that all apps finish within a few cold-spawn windows.
+ * Override via --prewarm-concurrency=N or WORKSPACE_PREWARM_CONCURRENCY=N.
+ */
+export function workspacePrewarmConcurrency(
+  args: string[] = [],
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const flag = args.find((arg) => arg.startsWith("--prewarm-concurrency="));
+  const raw = flag
+    ? flag.slice("--prewarm-concurrency=".length)
+    : env.WORKSPACE_PREWARM_CONCURRENCY;
+  if (!raw) return 2;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 1) return 2;
+  return Math.floor(parsed);
+}
+
+/**
+ * How long the prewarm queue waits after the gateway is ready before kicking
+ * off background spawns. Lets the default app's prebundle get first dibs on
+ * CPU. Override via WORKSPACE_PREWARM_DELAY_MS (mostly for tests).
+ */
+export function workspacePrewarmDelayMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.WORKSPACE_PREWARM_DELAY_MS;
+  if (raw === undefined) return 1_000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return 1_000;
+  return Math.floor(parsed);
+}
+
 function readBooleanEnv(value: string | undefined): boolean | undefined {
   if (value === undefined) return undefined;
   const normalized = value.trim().toLowerCase();
@@ -1041,6 +1101,62 @@ export async function runWorkspaceDev(
     }, 2_000).unref();
   }
 
+  /**
+   * Background-spawn every app that wasn't started by `startWorkspaceProcesses`.
+   * The lazy proxy still handles correctness (an on-demand request always
+   * starts its target app); this is purely so the first navigation into a
+   * non-default app doesn't pay the cold Vite + esbuild prebundle cost.
+   *
+   * Fires after a short delay so the default app's prebundle gets first dibs
+   * on CPU. Concurrency-limited to avoid hammering a small dev machine —
+   * each Vite spawn briefly maxes out a core during prebundling.
+   */
+  async function prewarmRemainingApps(): Promise<void> {
+    const concurrency = workspacePrewarmConcurrency(args, env);
+    const delayMs = workspacePrewarmDelayMs(env);
+
+    const queue = apps
+      .filter((app) => app.id !== defaultApp)
+      .filter((app) => !(app.process && !app.process.killed))
+      .map((app) => app.id);
+
+    if (queue.length === 0) return;
+
+    stdout.write(
+      `[workspace] Prewarming ${queue.length} app(s) in the background ` +
+        `(concurrency ${concurrency}; pass --no-prewarm to disable)\n`,
+    );
+
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    if (shuttingDown) return;
+
+    let next = 0;
+    async function worker(): Promise<void> {
+      while (!shuttingDown && next < queue.length) {
+        const id = queue[next++];
+        const app = appById.get(id);
+        if (!app) continue;
+        // Another path (a real request, a restart, etc.) may have started
+        // this app already — skip without consuming a worker slot needlessly.
+        if (app.process && !app.process.killed) continue;
+        startApp(app);
+        ensureReadinessProbe(app);
+        // Wait for the upstream to accept connections before pulling the next
+        // app off the queue. This is what actually limits *concurrent
+        // prebundling* (not just concurrent spawning) and keeps CPU pressure
+        // sane. proxyReadyTimeoutMs caps any single stuck app.
+        await waitForPort(app.port, Date.now() + proxyReadyTimeoutMs).catch(
+          () => false,
+        );
+      }
+    }
+
+    const workerCount = Math.max(1, Math.min(concurrency, queue.length));
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  }
+
   function openBrowser(url: string): void {
     if (options.openBrowser === false || env.WORKSPACE_NO_OPEN === "1") return;
     const command =
@@ -1146,13 +1262,27 @@ export async function runWorkspaceDev(
         `[workspace] Default: ${redirectRootToDefault ? `${gatewayUrl}/${defaultApp}` : gatewayUrl}\n`,
       );
       stdout.write(`[workspace] Gateway: ${gatewayUrl}\n`);
-      stdout.write(`[workspace] Mode: ${eager ? "eager" : "lazy"}\n`);
+      const prewarming = shouldPrewarmWorkspaceApps(args, env);
+      stdout.write(
+        `[workspace] Mode: ${
+          eager ? "eager" : prewarming ? "lazy+prewarm" : "lazy"
+        }\n`,
+      );
       for (const app of apps) {
         stdout.write(
           `[workspace] ${app.id}: /${app.id} -> 127.0.0.1:${app.port}\n`,
         );
       }
       startWorkspaceProcesses();
+      if (prewarming) {
+        void prewarmRemainingApps().catch((err) => {
+          stderr.write(
+            `[workspace] Prewarm error: ${
+              err instanceof Error ? err.message : String(err)
+            }\n`,
+          );
+        });
+      }
       openBrowser(
         redirectRootToDefault ? `${gatewayUrl}/${defaultApp}` : gatewayUrl,
       );

--- a/packages/core/src/client/embed-auth.spec.ts
+++ b/packages/core/src/client/embed-auth.spec.ts
@@ -107,6 +107,80 @@ describe("embed auth client", () => {
     }
   });
 
+  it("keeps MCP chat bridge mode active when sessionStorage starts throwing mid-session", async () => {
+    // Boot with sessionStorage working so the bridge enrolls normally.
+    window.history.replaceState(
+      null,
+      "",
+      `/inbox?embedded=1&${MCP_APP_CHAT_BRIDGE_QUERY_PARAM}=1&${EMBED_TOKEN_QUERY_PARAM}=signed-token`,
+    );
+
+    const first = await loadEmbedAuth();
+    first.ensureEmbedAuthFetchInterceptor();
+    expect(first.isEmbedMcpChatBridgeActive()).toBe(true);
+
+    // Mid-session, sessionStorage starts denying access (e.g. third-party-cookie
+    // policy update in a sandboxed iframe, Safari private-browsing throttling).
+    const getItem = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+
+    try {
+      // The flag should still be true even though sessionStorage now throws,
+      // because the in-memory bridge state was already captured.
+      expect(first.isEmbedMcpChatBridgeActive()).toBe(true);
+
+      // And it should survive even if the URL token also gets stripped.
+      window.history.replaceState(null, "", "/inbox?embedded=1");
+      expect(first.isEmbedMcpChatBridgeActive()).toBe(true);
+    } finally {
+      getItem.mockRestore();
+    }
+  });
+
+  it("keeps MCP chat bridge mode active after the URL token is stripped", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      `/inbox?embedded=1&${MCP_APP_CHAT_BRIDGE_QUERY_PARAM}=1&${EMBED_TOKEN_QUERY_PARAM}=signed-token`,
+    );
+
+    const first = await loadEmbedAuth();
+    first.ensureEmbedAuthFetchInterceptor();
+    expect(first.isEmbedMcpChatBridgeActive()).toBe(true);
+
+    // Mimic a host that strips the bridge flag from the URL too after boot.
+    window.history.replaceState(null, "", "/inbox?embedded=1");
+
+    // The in-memory bridge state should still be authoritative.
+    expect(first.isEmbedMcpChatBridgeActive()).toBe(true);
+  });
+
+  it("clears the MCP chat bridge when the embed token actually changes", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      `/inbox?embedded=1&${MCP_APP_CHAT_BRIDGE_QUERY_PARAM}=1&${EMBED_TOKEN_QUERY_PARAM}=token-a`,
+    );
+
+    const first = await loadEmbedAuth();
+    first.ensureEmbedAuthFetchInterceptor();
+    expect(first.isEmbedMcpChatBridgeActive()).toBe(true);
+
+    // A different embed token (e.g. a different user session reusing the same
+    // page context) MUST drop the bridge — this is the real de-enrollment
+    // signal we still need to honor.
+    window.history.replaceState(
+      null,
+      "",
+      `/inbox?embedded=1&${EMBED_TOKEN_QUERY_PARAM}=token-b`,
+    );
+
+    expect(first.isEmbedMcpChatBridgeActive()).toBe(false);
+  });
+
   it("clamps MCP chat bridge embeds to a stable viewport height", async () => {
     const notifyIntrinsicHeight = vi.fn();
     Object.defineProperty(window, "openai", {

--- a/packages/core/src/client/embed-auth.ts
+++ b/packages/core/src/client/embed-auth.ts
@@ -106,8 +106,19 @@ export function isEmbedMcpChatBridgeActive(): boolean {
     return true;
   }
   const scope = currentMcpChatBridgeScope(win);
+  // Once we've enrolled in MCP bridge mode in this page, trust the in-memory
+  // flag. A null scope (because the URL token was stripped after enroll AND
+  // sessionStorage is denied — Safari private mode, third-party-cookie-blocked
+  // iframes, strict ChatGPT/Claude sandboxes) is NOT evidence of de-enrollment.
+  // Only an actual auth-scope CHANGE (a different non-null embed token) means
+  // we should clear the bridge.
   if (mcpChatBridgeActive) {
-    if (scope && mcpChatBridgeScope === scope) return true;
+    if (scope == null) return true;
+    if (mcpChatBridgeScope == null || mcpChatBridgeScope === scope) {
+      // Capture the scope now that we have one; future calls can compare.
+      mcpChatBridgeScope = scope;
+      return true;
+    }
     clearMcpChatBridge(win);
     return false;
   }
@@ -115,8 +126,14 @@ export function isEmbedMcpChatBridgeActive(): boolean {
     const storedScope = win.sessionStorage?.getItem(
       MCP_CHAT_BRIDGE_STORAGE_KEY,
     );
-    if (scope && storedScope === scope) return true;
-    if (storedScope && storedScope !== scope) {
+    if (storedScope && (scope == null || storedScope === scope)) {
+      // Promote the persisted enrollment into in-memory state so subsequent
+      // reads survive sessionStorage becoming unavailable later in the session.
+      mcpChatBridgeActive = true;
+      mcpChatBridgeScope = storedScope;
+      return true;
+    }
+    if (storedScope && scope != null && storedScope !== scope) {
       win.sessionStorage?.removeItem(MCP_CHAT_BRIDGE_STORAGE_KEY);
     }
     return false;

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -330,6 +330,43 @@ function isEmbedStartUrl(value: string): boolean {
   }
 }
 
+/**
+ * Recursively redact embed-ticket-bearing URLs from any value before it gets
+ * serialized into a model-visible text payload. Embed start URLs carry a
+ * single-use ticket that grants iframe access to the user's session — they
+ * MUST stay in `_meta` (where the embed runtime can consume them) and never
+ * appear in `content[].text` for the LLM. This is the generic safety net for
+ * actions that return `{ embedStartUrl, ... }` without declaring
+ * `mcpApp.resource` (the resource path already strips them via
+ * `mcpAppStructuredContent`).
+ *
+ * Depth-capped to avoid pathological / circular structures. Strings that
+ * embed an `isEmbedStartUrl` substring (e.g. a longer message that includes
+ * the URL) are replaced with `[hidden embed URL]`.
+ */
+function purgeEmbedStartUrls(value: unknown, depth = 0): unknown {
+  if (depth > 5) return value;
+  if (typeof value === "string") {
+    return isEmbedStartUrl(value) ? "[hidden embed URL]" : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => purgeEmbedStartUrls(item, depth + 1));
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      if (typeof val === "string" && isEmbedStartUrl(val)) {
+        // Drop the key entirely for object-typed inputs so a tool result like
+        // `{ embedStartUrl: "..." }` does not appear at all in the LLM text.
+        continue;
+      }
+      out[key] = purgeEmbedStartUrls(val, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
 function mcpAppEmbedOpenLinkMeta(
   result: unknown,
   resource: ResolvedMcpAppResource,
@@ -363,12 +400,25 @@ function mcpAppEmbedOpenLinkMeta(
       : typeof out.path === "string" && out.path.trim()
         ? out.path.trim()
         : undefined;
-  const safeViewOpenUrl = view ? view : undefined;
+  // Only fabricate an open URL when there is a real path-like value: an
+  // explicit deepLinkUrl, or a non-embed `out.url`, or a leading-slash
+  // `view`/`path` that's already a route. Bare view-name strings like
+  // "inbox" or "deck" must NOT be turned into `${origin}/inbox` — apps
+  // route views at app-specific paths (e.g. slides routes `view: "deck"`
+  // at `/deck/:id`), so a synthesized origin-relative URL is just a 404.
+  // In that case omit `openLink` entirely; the embedStart meta carries
+  // the actual launch reference.
+  const pathFromRouteLike =
+    view && view.startsWith("/")
+      ? view
+      : typeof out.path === "string" && out.path.trim().startsWith("/")
+        ? out.path.trim()
+        : undefined;
   const explicitOpenUrl = deepLinkUrl
     ? deepLinkUrl
     : typeof out.url === "string" && !isEmbedStartUrl(out.url)
       ? out.url
-      : safeViewOpenUrl;
+      : pathFromRouteLike;
   const safeOpenUrl = explicitOpenUrl
     ? toAbsoluteOpenUrl(explicitOpenUrl, meta?.origin)
     : null;
@@ -778,6 +828,22 @@ function mcpAppStructuredContent(
   if (typeof out.url === "string" && isEmbedStartUrl(out.url)) {
     delete out.url;
   }
+  // Internal embed-routing fields belong in `_meta["agent-native/embedStart"]`
+  // (consumed by the embed runtime), not in `structuredContent` (read by the
+  // LLM). `embedTargetPath` reveals the exact route + thread/draft id the user
+  // is looking at; `embedExpiresAt` is an unintended timestamp; ticket-bearing
+  // fields are single-use credentials. Drop all of them unconditionally.
+  for (const key of [
+    "embedTargetPath",
+    "embedExpiresAt",
+    "ticket",
+    "embedTicket",
+  ]) {
+    delete out[key];
+  }
+  for (const key of Object.keys(out)) {
+    if (/Ticket$/.test(key)) delete out[key];
+  }
   const openLink = meta?.["agent-native/openLink"];
   if (openLink && typeof openLink === "object" && !Array.isArray(openLink)) {
     const webUrl = (openLink as Record<string, unknown>).webUrl;
@@ -1124,8 +1190,8 @@ export async function createMCPServerForRequest(
         const text = mcpAppResource
           ? conciseMcpAppToolText(name, resultForClient, structuredContent!)
           : typeof resultForClient === "string"
-            ? resultForClient
-            : JSON.stringify(resultForClient);
+            ? (purgeEmbedStartUrls(resultForClient) as string)
+            : JSON.stringify(purgeEmbedStartUrls(resultForClient));
         const content: any[] = [{ type: "text", text }];
         if (block) content.push(block);
         return {

--- a/packages/core/src/mcp/deep-link.spec.ts
+++ b/packages/core/src/mcp/deep-link.spec.ts
@@ -14,17 +14,31 @@ describe("buildDeepLink", () => {
     expect(url).toBe("/_agent-native/open?view=inbox&agentSidebar=closed");
   });
 
-  it("orders app, view, to, compose before params and the sidebar hint", () => {
+  it("orders app, view, to before params and the sidebar hint", () => {
     const url = buildDeepLink({
       app: "mail",
       view: "inbox",
       to: "/inbox/abc",
-      compose: "Zm9v",
       params: { threadId: "abc123" },
     });
     expect(url).toBe(
-      "/_agent-native/open?app=mail&view=inbox&to=%2Finbox%2Fabc&compose=Zm9v&threadId=abc123&agentSidebar=closed",
+      "/_agent-native/open?app=mail&view=inbox&to=%2Finbox%2Fabc&threadId=abc123&agentSidebar=closed",
     );
+  });
+
+  it("does not expose a `compose` field on DeepLinkInput", () => {
+    // Security: the prior `compose` field base64-encoded the full draft
+    // (subject + recipients + body) into the URL query string. MCP host
+    // LLMs see and can remember query strings, and shared chat transcripts
+    // would leak draft content. Drafts now live in app-state and the deep
+    // link only carries the draft id.
+    const url = buildDeepLink({
+      app: "mail",
+      view: "inbox",
+      params: { composeDraftId: "abc123" },
+    });
+    expect(url).not.toContain("compose=");
+    expect(url).toContain("composeDraftId=abc123");
   });
 
   it("drops null, undefined, and empty-string params but keeps false/0", () => {
@@ -48,7 +62,7 @@ describe("buildDeepLink", () => {
     expect(sp.get("zero")).toBe("0");
   });
 
-  it("omits optional app/to/compose when not provided", () => {
+  it("omits optional app/to when not provided", () => {
     const url = buildDeepLink({ view: "calendar", params: { eventId: "e1" } });
     expect(url).toBe(
       "/_agent-native/open?view=calendar&eventId=e1&agentSidebar=closed",

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -1931,6 +1931,234 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     );
   });
 
+  it("redacts embed-ticket URLs from JSON.stringify text for actions without mcpApp.resource", async () => {
+    // Regression: even when an action does NOT declare `mcpApp.resource`, a
+    // result containing `embedStartUrl` (or any string holding a
+    // /_agent-native/embed/start?ticket=… URL) must NEVER leak into the
+    // model-visible `content[0].text`. The mcpApp.resource path strips embed
+    // fields via mcpAppStructuredContent; the JSON.stringify fallback now
+    // applies the same purge as a generic safety net.
+    const noResourceConfig = {
+      ...config,
+      actions: {
+        "raw-embed": {
+          tool: {
+            description: "Return an embed URL without declaring a resource",
+          },
+          run: async () => ({
+            embedStartUrl: "/_agent-native/embed/start?ticket=raw-leak-ticket",
+            label: "should still appear",
+          }),
+          readOnly: true,
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 200,
+        method: "tools/call",
+        params: { name: "raw-embed", arguments: {} },
+      },
+      {
+        headers: { "x-agent-native-mcp-full-catalog": "1" },
+        config: noResourceConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.result.content).toHaveLength(1);
+    const text = out.result.content[0].text;
+    expect(text).not.toContain("raw-leak-ticket");
+    expect(text).not.toContain("/_agent-native/embed/start");
+    expect(text).not.toContain("embedStartUrl");
+    // Non-sensitive fields are still visible.
+    expect(text).toContain("should still appear");
+  });
+
+  it("redacts embed-ticket URLs from string-typed results without mcpApp.resource", async () => {
+    // Sibling regression: when the action returns a raw string that happens to
+    // include the embed-start URL inline, that substring must be hidden too —
+    // the LLM should never receive a usable embed-ticket URL.
+    const noResourceConfig = {
+      ...config,
+      actions: {
+        "raw-embed-string": {
+          tool: {
+            description: "Return an embed URL inside a string",
+          },
+          run: async () =>
+            "Open this: /_agent-native/embed/start?ticket=string-leak",
+          readOnly: true,
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 201,
+        method: "tools/call",
+        params: { name: "raw-embed-string", arguments: {} },
+      },
+      {
+        headers: { "x-agent-native-mcp-full-catalog": "1" },
+        config: noResourceConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.result.content[0].text).not.toContain("string-leak");
+    expect(out.result.content[0].text).not.toContain(
+      "/_agent-native/embed/start",
+    );
+    expect(out.result.content[0].text).toContain("[hidden embed URL]");
+  });
+
+  it("strips embedTargetPath, embedExpiresAt, and ticket fields from structuredContent", async () => {
+    // Regression: internal embed-routing fields are carried in
+    // `_meta["agent-native/embedStart"]` for the embed runtime. They must NOT
+    // double-up in `structuredContent` (read by the LLM), where
+    // `embedTargetPath` would reveal the exact route + thread/draft id the
+    // user is looking at, `embedExpiresAt` would leak a timestamp, and
+    // `ticket`/`*Ticket` would surface single-use credentials.
+    const embedConfig = {
+      ...config,
+      actions: {
+        "open-thread": {
+          tool: {
+            description: "Open a specific mail thread inline",
+          },
+          run: async () => ({
+            app: "mail",
+            // `embedTargetPath` carries the exact route + thread id the
+            // user is viewing. It belongs in `_meta` (embed runtime) and
+            // MUST be stripped from structuredContent / text content.
+            embedStartUrl:
+              "/_agent-native/embed/start?ticket=open-thread-ticket",
+            embedTargetPath: "/inbox?threadId=embedded-thread-id-123",
+            embedExpiresAt: 1735689600,
+            ticket: "open-thread-ticket",
+            embedTicket: "open-thread-ticket",
+            uploadTicket: "secret-upload-token",
+          }),
+          readOnly: true,
+          mcpApp: {
+            resource: {
+              title: "Open thread",
+              description: "Open the thread inline.",
+              html: "<!doctype html><html><body>Thread</body></html>",
+            },
+          },
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 202,
+        method: "tools/call",
+        params: { name: "open-thread", arguments: {} },
+      },
+      {
+        headers: { "x-agent-native-mcp-full-catalog": "1" },
+        config: embedConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    const sc = out.result.structuredContent;
+    expect(sc.embedStartUrl).toBeUndefined();
+    expect(sc.embedTargetPath).toBeUndefined();
+    expect(sc.embedExpiresAt).toBeUndefined();
+    expect(sc.ticket).toBeUndefined();
+    expect(sc.embedTicket).toBeUndefined();
+    expect(sc.uploadTicket).toBeUndefined();
+    // Make sure none of those sensitive strings leak into the JSON
+    // representation of structuredContent either.
+    const scJson = JSON.stringify(sc);
+    expect(scJson).not.toContain("open-thread-ticket");
+    expect(scJson).not.toContain("embedded-thread-id-123");
+    expect(scJson).not.toContain("1735689600");
+    expect(scJson).not.toContain("secret-upload-token");
+    // The _meta carrier is the legitimate home for the embed URL.
+    expect(out.result._meta["agent-native/embedStart"].startUrl).toContain(
+      "open-thread-ticket",
+    );
+    // The content text payload also stays clean (the embed routing fields
+    // would otherwise round-trip through conciseMcpAppToolText).
+    expect(JSON.stringify(out.result.content)).not.toContain(
+      "open-thread-ticket",
+    );
+    expect(JSON.stringify(out.result.content)).not.toContain(
+      "embedded-thread-id-123",
+    );
+  });
+
+  it("omits openLink when the only available 'view' is a bare name, not a route path", async () => {
+    // Regression: previously `safeViewOpenUrl = view` would turn a view name
+    // like "deck" into `${origin}/deck`, which 404s for apps that route
+    // `view: "deck"` at `/deck/:id`. The fix omits `openLink` entirely when
+    // there's no real path-like URL to open; the embedStart meta still
+    // carries the embed reference, so the host can launch the app inline
+    // without a bogus open URL.
+    const embedConfig = {
+      ...config,
+      actions: {
+        "open-deck-by-name": {
+          tool: {
+            description: "Open a slides deck via embed only",
+          },
+          run: async () => ({
+            app: "slides",
+            view: "deck",
+            embedStartUrl: "/_agent-native/embed/start?ticket=deck-name-ticket",
+          }),
+          readOnly: true,
+          mcpApp: {
+            resource: {
+              title: "Open deck",
+              description: "Open the deck inline.",
+              html: "<!doctype html><html><body>Deck</body></html>",
+            },
+          },
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 203,
+        method: "tools/call",
+        params: { name: "open-deck-by-name", arguments: {} },
+      },
+      {
+        headers: { "x-agent-native-mcp-full-catalog": "1" },
+        config: embedConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    // openLink must be absent — there is no real path to open.
+    expect(out.result._meta["agent-native/openLink"]).toBeUndefined();
+    expect(out.result.structuredContent.openLink).toBeUndefined();
+    // The embedStart meta still carries the reference to launch the app.
+    expect(out.result._meta["agent-native/embedStart"]).toMatchObject({
+      startUrl:
+        "https://mail.agent-native.com/_agent-native/embed/start?ticket=deck-name-ticket&__an_mcp_chat_bridge=1",
+    });
+    // No fabricated origin-relative URL leaks into the response.
+    expect(JSON.stringify(out.result.content)).not.toContain(
+      "https://mail.agent-native.com/deck",
+    );
+    expect(JSON.stringify(out.result.structuredContent)).not.toContain(
+      "https://mail.agent-native.com/deck",
+    );
+  });
+
   it("rejects unauthenticated calls with 401 when auth IS configured (no 501)", async () => {
     process.env.ACCESS_TOKEN = "secret-token";
     const event = makeWebEvent({

--- a/packages/core/src/server/deep-link.ts
+++ b/packages/core/src/server/deep-link.ts
@@ -35,8 +35,6 @@ export interface DeepLinkInput {
   /** Explicit client-side path override (must be a same-origin, leading-slash
    *  relative path — enforced by the open route). */
   to?: string;
-  /** Base64url-encoded JSON compose draft (mail's `compose-{id}` contract). */
-  compose?: string;
 }
 
 function buildQuery(input: DeepLinkInput): string {
@@ -44,7 +42,6 @@ function buildQuery(input: DeepLinkInput): string {
   if (input.app) sp.set("app", input.app);
   sp.set("view", input.view);
   if (input.to) sp.set("to", input.to);
-  if (input.compose) sp.set("compose", input.compose);
   for (const [k, v] of Object.entries(input.params ?? {})) {
     if (v === undefined || v === null || v === "") continue;
     sp.set(k, String(v));

--- a/scripts/dev-lazy.ts
+++ b/scripts/dev-lazy.ts
@@ -61,17 +61,20 @@ Usage:
   node scripts/dev-lazy.ts [options]
 
 Options:
-  --apps <names>       Comma-separated templates to expose (default: core)
-  --apps=<names>       Same as --apps <names>
-  --all                Expose every template in packages/shared-app-config
-  --desktop            Also start the clips-desktop tray (Tauri)
-  --electron           Also start the Electron desktop shell and frame
-  --eager              Start every exposed template immediately
-  --open               Open the gateway URL in the browser on ready
-  --no-open            (legacy / no-op — auto-open is off by default)
-  --no-kill            Do not kill stale processes on gateway/template ports
-  --dry-run            Print ports and commands without spawning
-  -h, --help           Show this help message
+  --apps <names>            Comma-separated templates to expose (default: core)
+  --apps=<names>            Same as --apps <names>
+  --all                     Expose every template in packages/shared-app-config
+  --desktop                 Also start the clips-desktop tray (Tauri)
+  --electron                Also start the Electron desktop shell and frame
+  --eager                   Start every exposed template immediately
+  --no-prewarm              Skip background prewarm of non-default templates
+                            (defaults to on in lazy mode)
+  --prewarm-concurrency=N   Max parallel Vite spawns during prewarm (default 2)
+  --open                    Open the gateway URL in the browser on ready
+  --no-open                 (legacy / no-op — auto-open is off by default)
+  --no-kill                 Do not kill stale processes on gateway/template ports
+  --dry-run                 Print ports and commands without spawning
+  -h, --help                Show this help message
 
 Examples:
   pnpm dev:lazy
@@ -152,6 +155,30 @@ const includeDesktop = hasFlag("--desktop");
 const includeElectron = hasFlag("--electron");
 const eager = hasFlag("--eager");
 const dryRun = hasFlag("--dry-run");
+const prewarmEnabled = (() => {
+  if (eager) return false;
+  if (hasFlag("--no-prewarm")) return false;
+  const env = process.env.WORKSPACE_NO_PREWARM;
+  if (env === "1" || env === "true") return false;
+  return true;
+})();
+const prewarmConcurrency = (() => {
+  const raw =
+    flagValue("--prewarm-concurrency") ??
+    process.env.WORKSPACE_PREWARM_CONCURRENCY ??
+    null;
+  if (!raw) return 2;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 1) return 2;
+  return Math.floor(parsed);
+})();
+const prewarmDelayMs = (() => {
+  const raw = process.env.WORKSPACE_PREWARM_DELAY_MS;
+  if (raw === undefined) return 1_000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return 1_000;
+  return Math.floor(parsed);
+})();
 const isHeadlessEnv =
   process.env.CI === "1" ||
   process.env.CI === "true" ||
@@ -528,6 +555,49 @@ function ensureReadinessProbe(app: TemplateApp): void {
     .finally(() => {
       app.readinessProbe = undefined;
     });
+}
+
+/**
+ * Background-spawn templates other than the default so the first navigation
+ * into each one doesn't pay the cold Vite + esbuild prebundle cost. The lazy
+ * proxy still handles correctness; this just makes second/third/Nth visits
+ * feel instant. Concurrency-limited to keep CPU pressure sane on laptops.
+ */
+async function prewarmRemainingApps(): Promise<void> {
+  const queue = apps
+    .filter((app) => app.id !== defaultApp)
+    .filter((app) => !(app.process && !app.process.killed))
+    .map((app) => app.id);
+
+  if (queue.length === 0) return;
+
+  console.log(
+    `[dev-lazy] Prewarming ${queue.length} template(s) in the background ` +
+      `(concurrency ${prewarmConcurrency}; pass --no-prewarm to disable)`,
+  );
+
+  if (prewarmDelayMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, prewarmDelayMs));
+  }
+  if (shuttingDown) return;
+
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (!shuttingDown && next < queue.length) {
+      const id = queue[next++];
+      const app = selectedById.get(id);
+      if (!app) continue;
+      if (app.process && !app.process.killed) continue;
+      startApp(app);
+      ensureReadinessProbe(app);
+      await waitForPort(app.port, Date.now() + proxyReadyTimeoutMs).catch(
+        () => false,
+      );
+    }
+  }
+
+  const workerCount = Math.max(1, Math.min(prewarmConcurrency, queue.length));
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
 }
 
 function forwardedProto(req: http.IncomingMessage): string {
@@ -955,7 +1025,11 @@ function shutdown(code = 0): void {
 
 if (dryRun) {
   console.log(`[dev-lazy] Gateway: ${gatewayUrl}`);
-  console.log(`[dev-lazy] Mode: ${eager ? "eager" : "lazy"}`);
+  console.log(
+    `[dev-lazy] Mode: ${
+      eager ? "eager" : prewarmEnabled ? "lazy+prewarm" : "lazy"
+    }`,
+  );
   if (usePollingFileWatcher) {
     console.log(
       `[dev-lazy] Watch mode: polling (${POLLING_WATCH_INTERVAL_MS}ms)`,
@@ -1024,7 +1098,11 @@ function listen(port: number, attempts = 20): void {
     gatewayUrl = `http://${gatewayHost}:${actualPort}`;
     console.log(`[dev-lazy] Default: ${gatewayUrl}/${defaultApp}`);
     console.log(`[dev-lazy] Gateway: ${gatewayUrl}`);
-    console.log(`[dev-lazy] Mode: ${eager ? "eager" : "lazy"}`);
+    console.log(
+      `[dev-lazy] Mode: ${
+        eager ? "eager" : prewarmEnabled ? "lazy+prewarm" : "lazy"
+      }`,
+    );
     for (const app of apps) {
       console.log(`[dev-lazy] ${app.id}: /${app.id} -> 127.0.0.1:${app.port}`);
     }
@@ -1034,6 +1112,15 @@ function listen(port: number, attempts = 20): void {
     } else if (!includeElectron) {
       const app = selectedById.get(defaultApp);
       if (app) startApp(app);
+      if (prewarmEnabled) {
+        void prewarmRemainingApps().catch((err) => {
+          console.error(
+            `[dev-lazy] Prewarm error: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        });
+      }
     }
 
     if (includeDesktop) {

--- a/templates/calendar/actions/manage-event-draft.spec.ts
+++ b/templates/calendar/actions/manage-event-draft.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+function manageEventDraftSource(): string {
+  return readFileSync(
+    new URL("./manage-event-draft.ts", import.meta.url),
+    "utf8",
+  );
+}
+
+describe("manage-event-draft deep link", () => {
+  // Security regression test: a previous implementation base64url-encoded the
+  // full event draft (title + attendees + description + location) into a
+  // `calendarDraft=` query param on the deep link. That URL is surfaced to
+  // external MCP host LLMs (ChatGPT / Claude), which can see and remember it;
+  // shared / exported chat transcripts would leak meeting contents. The deep
+  // link now carries only the opaque draft id (+ date hint), and the full
+  // draft is read from app-state on render.
+  it("no longer encodes draft contents into the URL", () => {
+    const source = manageEventDraftSource();
+
+    // The draft-payload encoder helpers are removed entirely.
+    expect(source).not.toContain("encodeDraftPayload");
+    expect(source).not.toContain("MAX_DRAFT_PAYLOAD_BYTES");
+    // No `encodeDraft` helper function and no `calendarDraft:` field.
+    expect(source).not.toMatch(/^function encodeDraft\(/m);
+    expect(source).not.toMatch(/\bcalendarDraft:/);
+    // The deep link still carries an id-only pointer (+ date hint).
+    expect(source).toContain("eventDraftId");
+  });
+
+  it("eventDraftDeepLink calls buildDeepLink with only id + date (no payload)", () => {
+    const source = manageEventDraftSource();
+
+    // The eventDraftDeepLink helper body must contain ONLY the expected
+    // fields. It must not contain a `calendarDraft:` field or any encoder
+    // call. Match the function body precisely to catch a regression that
+    // re-adds the payload field.
+    const match = source.match(
+      /function eventDraftDeepLink\([^)]*\)[^{]*{[\s\S]*?return buildDeepLink\(\{([\s\S]*?)\}\);[\s\S]*?}/,
+    );
+    expect(match).toBeTruthy();
+    const body = match![1];
+    expect(body).toContain('app: "calendar"');
+    expect(body).toContain('view: "calendar"');
+    expect(body).toContain("eventDraftId: draft.id");
+    expect(body).toContain("date: draft.start");
+    expect(body).not.toContain("calendarDraft:");
+    expect(body).not.toContain("encode");
+  });
+});

--- a/templates/calendar/actions/manage-event-draft.ts
+++ b/templates/calendar/actions/manage-event-draft.ts
@@ -22,7 +22,6 @@ import {
   workingLocationTypeInput,
 } from "./event-action-helpers.js";
 
-const MAX_DRAFT_PAYLOAD_BYTES = 1536;
 const DRAFT_PREFIX = "calendar-draft-";
 
 const attendeesInput = z
@@ -64,23 +63,18 @@ function normalizeAttendees(
     }));
 }
 
-function encodeDraft(draft: CalendarEventDraft): string {
-  return Buffer.from(JSON.stringify(draft)).toString("base64url");
-}
-
-function encodeDraftPayload(draft: CalendarEventDraft): string {
-  const full = encodeDraft(draft);
-  if (Buffer.byteLength(full, "utf8") <= MAX_DRAFT_PAYLOAD_BYTES) {
-    return full;
-  }
-  return encodeDraft({
-    id: draft.id,
-    title: draft.title,
-    start: draft.start,
-    end: draft.end,
-  });
-}
-
+/**
+ * Deep link that reopens an unsent calendar event draft.
+ *
+ * The link is an opaque pointer (draft id + date only). The full draft —
+ * title, attendees, description, location — lives in the
+ * `calendar-draft-{id}` app-state row written by this action, so the
+ * calendar reads it from there on render. We deliberately do NOT inline the
+ * draft contents into the URL: external MCP hosts (ChatGPT / Claude)
+ * surface this link in their UI, the host LLM can see and remember query
+ * strings, and shared / exported chat transcripts would otherwise leak
+ * private meeting content.
+ */
 function eventDraftDeepLink(draft: CalendarEventDraft): string {
   return buildDeepLink({
     app: "calendar",
@@ -88,7 +82,6 @@ function eventDraftDeepLink(draft: CalendarEventDraft): string {
     to: "/",
     params: {
       eventDraftId: draft.id,
-      calendarDraft: encodeDraftPayload(draft),
       date: draft.start?.slice(0, 10),
     },
   });

--- a/templates/clips/actions/get-recording-player-data.ts
+++ b/templates/clips/actions/get-recording-player-data.ts
@@ -18,7 +18,7 @@
  */
 
 import { defineAction, embedApp } from "@agent-native/core";
-import { buildDeepLink } from "@agent-native/core/server";
+import { buildDeepLink, signShortLivedToken } from "@agent-native/core/server";
 import { z } from "zod";
 import { asc, eq } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
@@ -149,10 +149,19 @@ export default defineAction({
     // Normalize the dev-fallback videoUrl:
     //   1. Rewrite legacy `/api/uploads/:id/blob` to `/api/video/:id` so old
     //      rows keep playing after the route move.
-    //   2. Non-owner viewers hitting a password-protected recording get the
-    //      password appended so `<video>` can fetch through the blob route's
-    //      password gate. Owners skip — the blob route bypasses the gate
-    //      for them. Real provider URLs (R2/S3/Builder) are left untouched.
+    //   2. For password-protected recordings, mint a short-lived HMAC token
+    //      bound to this recording id and pass it via `?t=<token>` instead of
+    //      the plaintext password. Sticking the password in the URL leaks it
+    //      into browser history, CDN logs, the Referer header on outbound
+    //      requests, and — most importantly here — into MCP-host tool results
+    //      (any MCP client receiving this action's structured output would
+    //      otherwise see the plaintext password). The downstream
+    //      `/api/video/:id` route accepts either `?t=<token>` (preferred) or
+    //      `?password=<pw>` (legacy fallback) so old share pages keep
+    //      working during rollout. (audit 11 F-07)
+    //      Owners are skipped — the blob route bypasses the password gate
+    //      for them, so they don't need the token. Real provider URLs
+    //      (R2/S3/Builder) are left untouched; those are already signed.
     let resolvedVideoUrl = rec.videoUrl ?? null;
     if (resolvedVideoUrl) {
       const legacyMatch = resolvedVideoUrl.match(
@@ -166,12 +175,9 @@ export default defineAction({
         access.role !== "owner" &&
         resolvedVideoUrl.startsWith("/api/video/")
       ) {
+        const token = signShortLivedToken({ resourceId: args.recordingId });
         const sep = resolvedVideoUrl.includes("?") ? "&" : "?";
-        resolvedVideoUrl =
-          resolvedVideoUrl +
-          sep +
-          "password=" +
-          encodeURIComponent(rec.password);
+        resolvedVideoUrl = `${resolvedVideoUrl}${sep}t=${encodeURIComponent(token)}`;
       }
     }
 
@@ -195,7 +201,12 @@ export default defineAction({
         status: rec.status,
         uploadProgress: rec.uploadProgress,
         failureReason: rec.failureReason,
-        password: rec.password,
+        // Don't leak the password to clients (especially to MCP hosts that
+        // surface action results to third-party agents); just indicate
+        // whether one was set. The videoUrl above already carries a
+        // short-lived `?t=<token>` for non-owner viewers, so the player
+        // can stream without ever seeing the plaintext password.
+        hasPassword: !!rec.password,
         expiresAt: rec.expiresAt,
         enableComments: Boolean(rec.enableComments),
         enableReactions: Boolean(rec.enableReactions),

--- a/templates/clips/app/components/editor/editor-layout.tsx
+++ b/templates/clips/app/components/editor/editor-layout.tsx
@@ -109,25 +109,28 @@ function shouldProxyWaveformUrl(videoUrl: string): boolean {
 function getWaveformMediaUrl({
   recordingId,
   videoUrl,
-  password,
-  role,
 }: {
   recordingId: string;
   videoUrl: string | null;
-  password?: string | null;
-  role?: string | null;
 }): string | null {
   if (!videoUrl) return null;
   if (!shouldProxyWaveformUrl(videoUrl)) {
+    // Internal URLs already carry a short-lived `?t=<token>` for non-owner
+    // viewers of password-protected recordings (minted in
+    // `get-recording-player-data`). Pass through as-is.
     return videoUrl.startsWith("/") ? `${appBasePath()}${videoUrl}` : videoUrl;
   }
 
-  const params = new URLSearchParams();
-  if (password && role !== "owner") params.set("password", password);
-  const qs = params.toString();
-  return `${appBasePath()}/api/video/${encodeURIComponent(recordingId)}${
-    qs ? `?${qs}` : ""
-  }`;
+  // Cross-origin provider URLs (R2 / S3 / Builder) get proxied through the
+  // same-origin `/api/video/:id` route for CORS reasons. We intentionally do
+  // NOT forward the password here — the plaintext password was previously
+  // appended via `?password=…`, but it isn't sent to this component anymore
+  // (the action returns `hasPassword: boolean` instead of the plaintext).
+  // For owners the proxy bypasses the password gate; for non-owner editors
+  // of password-protected recordings with cross-origin storage the waveform
+  // will be empty — they can still see / scrub the video, just not the
+  // waveform visualization.
+  return `${appBasePath()}/api/video/${encodeURIComponent(recordingId)}`;
 }
 
 export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
@@ -291,10 +294,8 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
       getWaveformMediaUrl({
         recordingId,
         videoUrl,
-        password: recording?.password,
-        role: playerData?.role,
       }),
-    [recording?.password, recordingId, playerData?.role, videoUrl],
+    [recordingId, videoUrl],
   );
 
   useEffect(() => {

--- a/templates/clips/app/components/player/settings-panel.tsx
+++ b/templates/clips/app/components/player/settings-panel.tsx
@@ -26,7 +26,12 @@ import { SPEED_OPTIONS } from "./player-controls";
 export interface SettingsPanelProps {
   recording: {
     id: string;
-    password: string | null;
+    /**
+     * Whether a password is currently set on the recording. The plaintext
+     * password is never sent to the client — the editor sees `hasPassword`
+     * and can either replace or clear the password, but never read it.
+     */
+    hasPassword: boolean;
     expiresAt: string | null;
     enableComments: boolean;
     enableReactions: boolean;
@@ -65,7 +70,11 @@ export function SettingsPanel(props: SettingsPanelProps) {
     onSuccess: () => onRefetch?.(),
   });
 
-  const [password, setPassword] = useState(recording.password ?? "");
+  // The plaintext password is never sent to the client (see action
+  // `get-recording-player-data`). Start empty; the placeholder communicates
+  // whether one is currently set. Saving an empty value clears it, saving a
+  // non-empty value replaces it.
+  const [password, setPassword] = useState("");
   const [expiresAt, setExpiresAt] = useState(recording.expiresAt ?? "");
 
   function patch(fields: Record<string, unknown>) {
@@ -121,12 +130,19 @@ export function SettingsPanel(props: SettingsPanelProps) {
                 type="text"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                placeholder="No password"
+                placeholder={
+                  recording.hasPassword
+                    ? "Password is set — type to replace, leave empty + Save to clear"
+                    : "No password"
+                }
                 className="flex-1"
               />
               <Button
                 variant="outline"
-                onClick={() => patch({ password: password || null })}
+                onClick={() => {
+                  patch({ password: password || null });
+                  setPassword("");
+                }}
                 disabled={update.isPending}
               >
                 Save

--- a/templates/mail/actions/manage-draft.spec.ts
+++ b/templates/mail/actions/manage-draft.spec.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { existsSync, readFileSync } from "node:fs";
 
+function manageDraftSource(): string {
+  return readFileSync(new URL("./manage-draft.ts", import.meta.url), "utf8");
+}
+
 describe("manage-draft MCP App", () => {
   it("reuses the real Mail app embed instead of a bespoke compose form", () => {
-    const source = readFileSync(new URL("./manage-draft.ts", import.meta.url), {
-      encoding: "utf8",
-    });
+    const source = manageDraftSource();
 
     expect(source).toContain("embedApp({");
     expect(source).toContain('openLabel: "Open in Mail"');
@@ -16,5 +18,45 @@ describe("manage-draft MCP App", () => {
     expect(source).not.toContain("data-save");
     expect(source).not.toContain("Update draft");
     expect(existsSync(new URL("./_mcp-apps.ts", import.meta.url))).toBe(false);
+  });
+});
+
+describe("manage-draft deep link", () => {
+  // Security regression test: a previous implementation base64url-encoded the
+  // full compose draft (subject + recipients + body) into a `compose=` query
+  // param on the deep link. That URL is surfaced to external MCP host LLMs
+  // (ChatGPT / Claude), which can see and remember it; shared / exported chat
+  // transcripts would leak draft contents. The deep link now carries only the
+  // opaque draft id, and the full draft is read from app-state on render.
+  it("no longer encodes draft contents into the URL", () => {
+    const source = manageDraftSource();
+
+    // The compose-payload encoder helpers are removed entirely.
+    expect(source).not.toContain("encodeComposeDraft");
+    expect(source).not.toContain("encodeComposePayload");
+    expect(source).not.toContain("MAX_COMPOSE_PAYLOAD_BYTES");
+    // No `compose:` field passed to buildDeepLink.
+    expect(source).not.toMatch(/\bcompose:\s*encode/);
+    // The deep link still carries an id-only pointer.
+    expect(source).toContain("composeDraftId");
+  });
+
+  it("composeDeepLink calls buildDeepLink with only id + view + to (no payload)", () => {
+    const source = manageDraftSource();
+
+    // The composeDeepLink helper body must contain ONLY the four expected
+    // properties: app, view, to, params (with composeDraftId). It must not
+    // contain a `compose:` field or any encoder call. Match the function
+    // body precisely to catch a regression that re-adds the payload field.
+    const match = source.match(
+      /function composeDeepLink\([^)]*\)[^{]*{[\s\S]*?return buildDeepLink\(\{([\s\S]*?)\}\);[\s\S]*?}/,
+    );
+    expect(match).toBeTruthy();
+    const body = match![1];
+    expect(body).toContain('app: "mail"');
+    expect(body).toContain('view: "inbox"');
+    expect(body).toContain("composeDraftId: draft.id");
+    expect(body).not.toContain("compose:");
+    expect(body).not.toContain("encode");
   });
 });

--- a/templates/mail/actions/manage-draft.ts
+++ b/templates/mail/actions/manage-draft.ts
@@ -10,53 +10,24 @@ import { getRequestUserEmail, buildDeepLink } from "@agent-native/core/server";
 import { z } from "zod";
 import { appendSignatureToBody } from "../shared/signature.js";
 
-/**
- * Cap for the base64url `compose=` query param. A full draft (recipients +
- * subject + entire body) base64-encoded can be many KB, and browsers / inline
- * webviews silently truncate or reject very long URLs. When the self-contained
- * payload would exceed this, we fall back to an id-only deep link: the draft
- * is already persisted as a `compose-{id}` app-state entry by this action, so
- * the compose panel resurfaces it from the persisted row for the creator. The
- * threshold is conservative (well under the ~8KB practical URL ceiling, with
- * headroom for the rest of the query string and host prefix).
- */
-const MAX_COMPOSE_PAYLOAD_BYTES = 1536;
 const COMPOSE_FULLSCREEN_PARAM = "composeFullscreen";
 
-/** Base64url-encode a compose draft so `/_agent-native/open?compose=…`
- *  decodes it back into a `compose-{id}` app-state entry the compose panel
- *  auto-opens. */
-function encodeComposeDraft(draft: Record<string, string>): string {
-  return Buffer.from(JSON.stringify(draft)).toString("base64url");
-}
-
 /**
- * Build the compact `compose=` payload. Prefer the full self-contained draft
- * (so a small draft opens instantly with content even before app-state polls),
- * but if encoding the whole draft would blow the URL size budget, fall back to
- * an id-only payload. `manage-draft` always persists the full draft to the
- * `compose-{id}` app-state key, so the compose panel still resurfaces the
- * complete draft by id for the creator — the URL just stays short.
+ * Deep link that reopens a compose draft in the Mail compose panel.
+ *
+ * The link is an opaque pointer (draft id only). The full draft — subject,
+ * recipients, body — lives in the `compose-{id}` app-state row written by
+ * this action, so the compose panel reads it from there on render. We
+ * deliberately do NOT inline the draft contents into the URL: external MCP
+ * hosts (ChatGPT / Claude) surface this link in their UI, the host LLM can
+ * see and remember query strings, and shared / exported chat transcripts
+ * would otherwise leak private draft content.
  */
-function encodeComposePayload(draft: Record<string, string>): string {
-  const full = encodeComposeDraft(draft);
-  if (Buffer.byteLength(full, "utf8") <= MAX_COMPOSE_PAYLOAD_BYTES) {
-    return full;
-  }
-  // Keep the id (required to resurface the persisted draft) plus a tiny
-  // subject hint so the link is still self-describing; drop the heavy body.
-  const compact: Record<string, string> = { id: draft.id };
-  if (draft.subject) compact.subject = draft.subject.slice(0, 120);
-  return encodeComposeDraft(compact);
-}
-
-/** Deep link that reopens a compose draft in the Mail compose panel. */
 function composeDeepLink(draft: Record<string, string>): string {
   return buildDeepLink({
     app: "mail",
     view: "inbox",
     to: `/inbox?${COMPOSE_FULLSCREEN_PARAM}=1`,
-    compose: encodeComposePayload(draft),
     params: { composeDraftId: draft.id },
   });
 }


### PR DESCRIPTION
## Summary

Security and correctness hardening for MCP app hosts (ChatGPT, Claude.ai, Cursor, etc.). Found by a deep audit of the MCP code path after PR #871 / #873 shipped; these are the residual production-risk leaks the earlier passes didn't catch.

Also includes a workspace dev-server prewarm UX improvement (concurrent agent work).

## What broke that this fixes

### 1. Clips: plaintext recording password leaked to MCP hosts (CRITICAL)
[`templates/clips/actions/get-recording-player-data.ts`](templates/clips/actions/get-recording-player-data.ts) appended `?password=<plaintext>` to `videoUrl` for non-owner viewers AND returned `password: rec.password` on the response object. Both fields flowed into MCP host `structuredContent` — ChatGPT / Claude / Cursor saw the password.

The sibling [`server/routes/api/public-recording.get.ts`](templates/clips/server/routes/api/public-recording.get.ts) already used a signed short-lived token (`?t=<token>`) and `hasPassword: boolean`. This PR mirrors that fix in the action. Owners are unchanged (the `/api/video/:id` route still bypasses for them).

### 2. Mail / Calendar: full draft contents leaked into deep-link URL (HIGH)
[`templates/mail/actions/manage-draft.ts`](templates/mail/actions/manage-draft.ts) and [`templates/calendar/actions/manage-event-draft.ts`](templates/calendar/actions/manage-event-draft.ts) base64-encoded the entire compose draft (subject, body, recipients up to 1.5KB) into a `?compose=` / `?calendarDraft=` URL query param. That URL surfaced in:

- Chat-visible markdown: `[Open draft in Mail →](https://mail.../?compose=eyJpZCI6...)` — the LLM sees draft contents.
- `_meta["agent-native/openLink"].webUrl` — same exposure to the host.
- Anywhere the conversation gets shared / exported / cached.

The draft is *already persisted* to `compose-{id}` / `calendar-draft-{id}` app-state. The deep link only needs the id; the UI loads the body from app-state on open (the calendar client decoder already preferred the persisted row over the URL payload). Removed the encoders, kept server- and client-side decoders for backward compat with any cached old links, dropped the now-unused `compose?` field from `buildDeepLink`.

### 3. `build-server.ts` defensive purges (HIGH)
Three latent footguns in [`packages/core/src/mcp/build-server.ts`](packages/core/src/mcp/build-server.ts):

- **Embed-ticket leak in fallback path.** When an action without `mcpApp.resource` returned a result containing `embedStartUrl`, `JSON.stringify(resultForClient)` dumped the ticket into the text content the LLM sees. Added a recursive `purgeEmbedStartUrls` helper (depth-capped at 5) that scrubs any matching URL before stringify. Also rewrites string-typed results containing an embed URL as `[hidden embed URL]`.
- **`embedTargetPath` / `embedExpiresAt` / `*Ticket` fields leak into `structuredContent`.** `mcpAppStructuredContent` only stripped `embedStartUrl` / `startUrl` / `url`. Added `embedTargetPath` (the user's exact route — e.g. `/inbox?threadId=secret`), `embedExpiresAt`, `ticket`, `embedTicket`, and any `*Ticket` key. Their legitimate carrier is `_meta["agent-native/embedStart"]`.
- **Bare view-name fabricated into bogus URL.** When an action returned only an `embedStartUrl` (no `deepLinkUrl`, no real path), `mcpAppEmbedOpenLinkMeta` was building `safeViewOpenUrl = view` from just `"deck"` / `"inbox"` / `"editor"` and emitting `https://app.com/deck` in the openLink — works for Mail (`/inbox` is a real route) but 404s for apps that route views at app-specific paths. Replaced with `pathFromRouteLike` that only accepts leading-slash paths. When no real path exists, omit `openLink` entirely; the embed-start meta still carries the launch reference.

### 4. `embed-auth.ts` chat-bridge silently dropped in sandboxed iframes (MEDIUM)
`isEmbedMcpChatBridgeActive()` cleared the in-memory `mcpChatBridgeActive` flag when sessionStorage was denied AND the URL no longer carried the chat-bridge token. In iframes where sessionStorage is denied (Safari private browsing, third-party-cookie blocked, strict ChatGPT/Claude iframe sandboxes), the bridge silently de-enrolled mid-session. Fix: treat `null` scope as "unknown, trust the flag"; only actually clear on a non-null scope mismatch (real auth-token change). When sessionStorage is successfully read, promote it back into in-memory state.

## Workspace dev prewarm (concurrent agent work)
Background-spawns non-default templates after the lazy gateway is ready so the first navigation into a non-default app doesn't pay the cold Vite + esbuild prebundle cost. Default on in lazy mode (`pnpm dev:lazy`), opt-out via `--no-prewarm` / `WORKSPACE_NO_PREWARM=1`. Concurrency capped at 2 by default (gentle on laptops); tunable via `--prewarm-concurrency=N` / `WORKSPACE_PREWARM_CONCURRENCY=N`.

## Tests

- 988 `@agent-native/core` tests pass (was 984 before this PR; +4 new `server.spec.ts` tests).
- 11 `embed-auth.spec.ts` tests pass (+3 new).
- 14 `deep-link.spec.ts` tests pass.
- New regression spec `templates/calendar/actions/manage-event-draft.spec.ts` (2 tests).
- 2 new security assertions in `templates/mail/actions/manage-draft.spec.ts`.
- `pnpm prep` green end-to-end (typecheck across all templates, guards, fmt).

## Verification plan after merge

1. Production deploys pick up new `@agent-native/core` version.
2. Reconnect Dispatch MCP connector in ChatGPT and Claude.ai; confirm:
   - `tools/list` and `resources/list` stay compact.
   - `open_app` renders inline embed without ticket leak.
   - Mail compose deep link opens correctly and doesn't show draft body in the URL.
3. Clips: open a password-protected recording via the action and confirm the response carries `hasPassword: true` and the videoUrl has `?t=<token>`, not `?password=<plain>`.