### PR TITLE
Fix MCP app host chat fallback

### DIFF
--- a/.changeset/quiet-mcp-mail-generate.md
+++ b/.changeset/quiet-mcp-mail-generate.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Clear MCP app host generate loading state after direct host sends and fall back to the wrapper relay when direct sends fail.

--- a/packages/core/src/client/agent-chat.spec.ts
+++ b/packages/core/src/client/agent-chat.spec.ts
@@ -32,6 +32,11 @@ vi.stubGlobal("window", {
 const { sendToAgentChat, generateTabId } = await import("./agent-chat.js");
 const { _resetEmbedAuthForTests } = await import("./embed-auth.js");
 
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe("sendToAgentChat", () => {
   beforeEach(() => {
     frameState.inBuilderFrame = false;
@@ -208,7 +213,7 @@ describe("sendToAgentChat", () => {
     expect(parentPostMessageSpy).not.toHaveBeenCalled();
   });
 
-  it("lets direct MCP App frames handle auto-submitted prompts via JSON-RPC", () => {
+  it("lets direct MCP App frames handle auto-submitted prompts via JSON-RPC", async () => {
     window.location.search =
       "?embedded=1&__an_embed_token=signed-token&__an_mcp_chat_bridge=1";
     sendMcpAppHostMessageMock.mockReturnValue(Promise.resolve(true));
@@ -225,6 +230,46 @@ describe("sendToAgentChat", () => {
     });
     expect(parentPostMessageSpy).not.toHaveBeenCalled();
     expect(dispatchEventSpy).not.toHaveBeenCalled();
+
+    await flushMicrotasks();
+
+    expect(parentPostMessageSpy).not.toHaveBeenCalled();
+    expect(dispatchEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agentNative.chatRunning",
+        detail: { isRunning: false },
+      }),
+    );
+  });
+
+  it("falls back to the wrapper relay if direct MCP App host messaging rejects the send", async () => {
+    window.location.search =
+      "?embedded=1&__an_embed_token=signed-token&__an_mcp_chat_bridge=1";
+    sendMcpAppHostMessageMock.mockReturnValue(Promise.resolve(false));
+
+    const tabId = sendToAgentChat({
+      message: "continue with this selection",
+      context: "Selected item ids: a, b",
+      submit: true,
+    });
+
+    expect(parentPostMessageSpy).not.toHaveBeenCalled();
+
+    await flushMicrotasks();
+
+    expect(parentPostMessageSpy).toHaveBeenCalledOnce();
+    const [payload, targetOrigin] = parentPostMessageSpy.mock.calls[0];
+    expect(targetOrigin).toBe("*");
+    expect(payload.type).toBe("agentNative.submitChat");
+    expect(payload.data.tabId).toBe(tabId);
+    expect(payload.data.message).toBe("continue with this selection");
+    expect(payload.data.context).toBe("Selected item ids: a, b");
+    expect(dispatchEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agentNative.chatRunning",
+        detail: { isRunning: false },
+      }),
+    );
   });
 
   it("keeps direct MCP App embed sessions on the local app chat path", () => {

--- a/packages/core/src/client/agent-chat.ts
+++ b/packages/core/src/client/agent-chat.ts
@@ -119,6 +119,15 @@ function isDirectMcpAppEmbedSession(): boolean {
   return isEmbedAuthActive() && !isEmbedMcpChatBridgeActive();
 }
 
+function dispatchAgentChatRunning(isRunning: boolean): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent("agentNative.chatRunning", {
+      detail: { isRunning },
+    }),
+  );
+}
+
 /**
  * Send a message to the agent chat via postMessage.
  */
@@ -148,7 +157,16 @@ export function sendToAgentChat(opts: AgentChatMessage): string {
       message: opts.message,
       context: opts.context,
     });
-    if (directHostMessage) return tabId;
+    if (directHostMessage) {
+      void Promise.resolve(directHostMessage)
+        .then((ok) => {
+          if (!ok) window.parent.postMessage(payload, getFrameOrigin() || "*");
+        })
+        .finally(() => {
+          dispatchAgentChatRunning(false);
+        });
+      return tabId;
+    }
     window.parent.postMessage(payload, getFrameOrigin() || "*");
     return tabId;
   }

--- a/packages/core/src/client/mcp-app-host.spec.ts
+++ b/packages/core/src/client/mcp-app-host.spec.ts
@@ -408,19 +408,24 @@ describe("MCP app host client helpers", () => {
     });
 
     const result = sendMcpAppHostMessage({
-      context: "Hidden draft context",
+      context:
+        "Hidden draft context. Do not ask to read application-state/compose.json.",
       message: "Rewrite the selected sentence",
     });
 
     await expect(result).resolves.toBe(true);
     expect(setWidgetState).toHaveBeenCalledWith({
       existing: true,
-      agentNativeChatContext: "Hidden draft context",
+      agentNativeChatContext:
+        "Hidden draft context. Do not ask to read application-state/compose.json.",
     });
     expect(sendFollowUpMessage).toHaveBeenCalledWith({
       prompt: "Rewrite the selected sentence",
       scrollToBottom: true,
     });
+    expect(JSON.stringify(sendFollowUpMessage.mock.calls)).not.toContain(
+      "application-state/compose.json",
+    );
   });
 
   it("clears ChatGPT hidden context when a follow-up has no context", async () => {
@@ -479,5 +484,108 @@ describe("MCP app host client helpers", () => {
     )!;
     dispatchHostMessage({ jsonrpc: "2.0", id: linkCall.id, result: {} });
     await expect(result).resolves.toBe(true);
+  });
+
+  it("clears direct MCP Apps hidden context between turns in the same session", async () => {
+    const parent = parentWindow();
+    setDirectParent(parent);
+
+    const firstResult = sendMcpAppHostMessage({
+      context:
+        "Hidden draft context. Do not ask to read application-state/compose.json.",
+      message: "Rewrite the selected sentence",
+    });
+    await flushMicrotasks();
+
+    let calls = getJsonRpcCalls(parent);
+    const initCall = calls.find((call) => call.method === "ui/initialize")!;
+    dispatchHostMessage({
+      jsonrpc: "2.0",
+      id: initCall.id,
+      result: { protocolVersion: "2026-01-26" },
+    });
+    await flushMicrotasks();
+
+    calls = getJsonRpcCalls(parent);
+    const firstContextCall = calls.find(
+      (call) => call.method === "ui/update-model-context",
+    )!;
+    expect(firstContextCall).toMatchObject({
+      params: {
+        content: [
+          {
+            type: "text",
+            text: "Hidden draft context. Do not ask to read application-state/compose.json.",
+          },
+        ],
+      },
+    });
+    dispatchHostMessage({
+      jsonrpc: "2.0",
+      id: firstContextCall.id,
+      result: {},
+    });
+    await flushMicrotasks();
+
+    calls = getJsonRpcCalls(parent);
+    const firstMessageCall = calls.find(
+      (call) => call.method === "ui/message",
+    )!;
+    expect(firstMessageCall).toMatchObject({
+      params: {
+        role: "user",
+        content: { type: "text", text: "Rewrite the selected sentence" },
+      },
+    });
+    expect(JSON.stringify(firstMessageCall)).not.toContain(
+      "application-state/compose.json",
+    );
+    dispatchHostMessage({
+      jsonrpc: "2.0",
+      id: firstMessageCall.id,
+      result: {},
+    });
+    await expect(firstResult).resolves.toBe(true);
+
+    vi.mocked(parent.postMessage).mockClear();
+
+    const secondResult = sendMcpAppHostMessage({
+      message: "Continue without selection",
+    });
+    await flushMicrotasks();
+
+    calls = getJsonRpcCalls(parent);
+    const secondContextCall = calls.find(
+      (call) => call.method === "ui/update-model-context",
+    )!;
+    expect(secondContextCall).toMatchObject({
+      params: { content: [] },
+    });
+    dispatchHostMessage({
+      jsonrpc: "2.0",
+      id: secondContextCall.id,
+      result: {},
+    });
+    await flushMicrotasks();
+
+    const secondMessageCall = getJsonRpcCalls(parent).find(
+      (call) => call.method === "ui/message",
+    )!;
+    expect(secondMessageCall).toMatchObject({
+      params: {
+        role: "user",
+        content: { type: "text", text: "Continue without selection" },
+      },
+    });
+    expect(JSON.stringify(secondMessageCall)).not.toContain(
+      "application-state/compose.json",
+    );
+    dispatchHostMessage({
+      jsonrpc: "2.0",
+      id: secondMessageCall.id,
+      result: {},
+    });
+
+    await expect(secondResult).resolves.toBe(true);
   });
 });

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -847,6 +847,49 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       "ui://mail/review-draft/shell-v26",
       "ui://mail/private-widget/shell-v26",
     ]);
+
+    const templatesOut = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 131,
+        method: "resources/templates/list",
+        params: {},
+      },
+      {
+        headers: await mcpAppsAuthHeaders(),
+        config: fallbackConfig,
+      },
+    );
+
+    expect(templatesOut.error).toBeUndefined();
+    expect(
+      templatesOut.result.resourceTemplates.map((r: any) => r.uriTemplate),
+    ).toEqual([
+      "ui://mail/echo-thing/shell-v26",
+      "ui://mail/review-draft/shell-v26",
+      "ui://mail/private-widget/shell-v26",
+    ]);
+
+    const readOut = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 132,
+        method: "resources/read",
+        params: { uri: "ui://mail/private-widget/shell-v26" },
+      },
+      {
+        headers: await mcpAppsAuthHeaders(),
+        config: fallbackConfig,
+      },
+    );
+
+    expect(readOut.error).toBeUndefined();
+    expect(readOut.result.contents).toEqual([
+      expect.objectContaining({
+        uri: "ui://mail/private-widget/shell-v26",
+        text: expect.stringContaining("Private"),
+      }),
+    ]);
   });
 
   it("blocks compact MCP Apps callers from invoking hidden tools by name", async () => {
@@ -1867,6 +1910,58 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       "only-ticket",
     );
     expect(out.result.structuredContent.openLink).toBeUndefined();
+  });
+
+  it("keeps url-only embed start URLs hidden without exposing them as open links", async () => {
+    const embedConfig = {
+      ...config,
+      actions: {
+        "open-url-only-embed": {
+          tool: {
+            description: "Open an embed-only app through url",
+          },
+          run: async () => ({
+            app: "mail",
+            embed: true,
+            url: "/_agent-native/embed/start?ticket=url-only-ticket",
+          }),
+          readOnly: true,
+          mcpApp: {
+            resource: {
+              title: "Open url-only embed app",
+              description: "Open the full app inline.",
+              html: "<!doctype html><html><body>Open app</body></html>",
+            },
+          },
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 135,
+        method: "tools/call",
+        params: { name: "open-url-only-embed", arguments: {} },
+      },
+      {
+        headers: { "x-agent-native-mcp-full-catalog": "1" },
+        config: embedConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.result._meta["agent-native/openLink"]).toBeUndefined();
+    expect(out.result._meta["agent-native/embedStart"]).toMatchObject({
+      startUrl:
+        "https://mail.agent-native.com/_agent-native/embed/start?ticket=url-only-ticket&__an_mcp_chat_bridge=1",
+    });
+    expect(JSON.stringify(out.result.content)).not.toContain("url-only-ticket");
+    expect(JSON.stringify(out.result.structuredContent)).not.toContain(
+      "url-only-ticket",
+    );
+    expect(out.result.structuredContent.openLink).toBeUndefined();
+    expect(out.result.structuredContent.url).toBeUndefined();
   });
 
   it("uses a durable root open link for root-path embed starts", async () => {

--- a/packages/core/src/scripts/runner.spec.ts
+++ b/packages/core/src/scripts/runner.spec.ts
@@ -51,6 +51,7 @@ const tsxCli = resolveTsxCli();
 const tsxIsBinShim = !tsxCli.endsWith(".mjs") && !tsxCli.endsWith(".js");
 const tsxCommand = tsxIsBinShim ? tsxCli : process.execPath;
 const tsxLeadingArgs = tsxIsBinShim ? [] : [tsxCli];
+const spawnTimeoutMs = 15_000;
 
 describe("runScript package actions", () => {
   let tmpDir: string;
@@ -98,13 +99,14 @@ describe("runScript package actions", () => {
           ...process.env,
           AGENT_USER_EMAIL: "owner@example.test",
         },
+        timeout: spawnTimeoutMs,
       },
     );
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("Fixture package actions:");
     expect(result.stdout).toContain("package-action");
-  });
+  }, 20_000);
 
   it("runs a package action when no local action exists", () => {
     const result = spawnSync(
@@ -129,6 +131,7 @@ describe("runScript package actions", () => {
           ...process.env,
           AGENT_USER_EMAIL: "owner@example.test",
         },
+        timeout: spawnTimeoutMs,
       },
     );
 
@@ -144,5 +147,5 @@ describe("runScript package actions", () => {
       sourceIds: ["mail", "calendar"],
       limit: "8",
     });
-  });
+  }, 20_000);
 });

--- a/templates/mail/app/lib/agent-generate.spec.ts
+++ b/templates/mail/app/lib/agent-generate.spec.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const bridgeState = vi.hoisted(() => ({ active: false }));
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/client", () => ({
+  agentNativePath: (path: string) => path,
+}));
+
+vi.mock("./mcp-chat-bridge", () => ({
+  isMcpChatBridgeActive: () => bridgeState.active,
+}));
+
+const { canUseAgentGenerate } = await import("./agent-generate");
+
+function statusResponse(configured: boolean) {
+  return {
+    ok: true,
+    json: async () => ({ configured }),
+  };
+}
+
+describe("canUseAgentGenerate", () => {
+  beforeEach(() => {
+    bridgeState.active = false;
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("allows MCP host bridge generate even when local engine status is unavailable", async () => {
+    bridgeState.active = true;
+
+    await expect(canUseAgentGenerate()).resolves.toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("requires a configured local agent engine outside MCP host bridge mode", async () => {
+    fetchMock
+      .mockResolvedValueOnce(statusResponse(false))
+      .mockResolvedValueOnce(statusResponse(false));
+
+    await expect(canUseAgentGenerate()).resolves.toBe(false);
+  });
+
+  it("allows local generate when Builder or an agent engine is configured", async () => {
+    fetchMock
+      .mockResolvedValueOnce(statusResponse(false))
+      .mockResolvedValueOnce(statusResponse(true));
+
+    await expect(canUseAgentGenerate()).resolves.toBe(true);
+  });
+});

--- a/templates/mail/app/lib/agent-generate.ts
+++ b/templates/mail/app/lib/agent-generate.ts
@@ -1,4 +1,5 @@
 import { agentNativePath } from "@agent-native/core/client";
+import { isMcpChatBridgeActive } from "./mcp-chat-bridge";
 
 async function readStatus(path: string): Promise<any | null> {
   return fetch(agentNativePath(path))
@@ -7,6 +8,8 @@ async function readStatus(path: string): Promise<any | null> {
 }
 
 export async function canUseAgentGenerate(): Promise<boolean> {
+  if (isMcpChatBridgeActive()) return true;
+
   const [builderStatus, engineStatus] = await Promise.all([
     readStatus("/_agent-native/builder/status"),
     readStatus("/_agent-native/agent-engine/status"),


### PR DESCRIPTION
## Summary
- keep ChatGPT/Claude MCP app hidden context isolated and cleared across turns
- prevent stale Mail generate loading state when direct MCP host sends succeed or fall back to wrapper relay
- allow Mail generate in MCP bridge mode without requiring local agent engine setup
- add compact-catalog/embed-ticket regression coverage and harden a flaky runner help spec timeout

## Verification
- pnpm --filter @agent-native/core exec vitest --run src/client/agent-chat.spec.ts src/client/mcp-app-host.spec.ts src/mcp/server.spec.ts src/mcp/embed-app.spec.ts src/client/embed-auth.spec.ts src/client/mcp-apps/McpAppRenderer.spec.ts
- pnpm --filter @agent-native/core exec vitest --run src/mcp src/client/agent-chat.spec.ts src/client/mcp-app-host.spec.ts src/client/embed-auth.spec.ts src/client/mcp-apps/McpAppRenderer.spec.ts
- pnpm --filter @agent-native/core exec vitest --run src/scripts/runner.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter mail typecheck
- pnpm --filter mail exec vitest --run app/lib/agent-generate.spec.ts app/components/email/mcp-compose-prompts.spec.ts
- local authenticated MCP smoke for Dispatch and Mail tools/resources/embed ticket privacy
- headless Chrome MCP app host smoke with mocked window.openai submitChat bridge
- pnpm prep