### PR TITLE
fix(mcp): restore app-only embeds and desktop app links

### DIFF
--- a/.changeset/mcp-app-only-structured-content.md
+++ b/.changeset/mcp-app-only-structured-content.md
@@ -1,0 +1,7 @@
+---
+"@agent-native/core": patch
+---
+
+Fix MCP App embed regression: `create_embed_session` (and any tool with `_meta.ui.visibility: ["app"]`) now surfaces its raw result via `structuredContent` so the embed iframe can read the mint `startUrl`.
+
+Without this, PR #875's text-side embed-URL purge stripped the embed start URL from the only fallback the iframe had, breaking the "open inline" flow with "This app can be opened, but not embedded from this MCP server." Compliant hosts already honor the `visibility: ["app"]` hint and keep the tool result out of the LLM transcript; the structuredContent path is safe for these tools.

--- a/.changeset/mcp-embed-desktop-openlink.md
+++ b/.changeset/mcp-embed-desktop-openlink.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-Route MCP App embed open links through the desktop deep-link handler.

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -334,6 +334,22 @@ function isEmbedStartUrl(value: string): boolean {
   }
 }
 
+function routePathFromOpenUrl(value: string): string | null {
+  try {
+    const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
+    const url = hasScheme
+      ? new URL(value)
+      : new URL(value, "http://agent-native.invalid");
+    const route = `${url.pathname}${url.search}${url.hash}`;
+    if (!route.startsWith("/") || route.startsWith("//")) return null;
+    if (route.startsWith("/\\")) return null;
+    if (/^\/[a-z][a-z0-9+.-]*:/i.test(route)) return null;
+    return route;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Recursively redact embed-ticket-bearing URLs from any value before it gets
  * serialized into a model-visible text payload. Embed start URLs carry a
@@ -426,12 +442,10 @@ function mcpAppEmbedOpenLinkMeta(
   const safeOpenUrl = explicitOpenUrl
     ? toAbsoluteOpenUrl(explicitOpenUrl, meta?.origin)
     : null;
-  // Build a desktop deep-link (`agentnative://open?app=…&view=…`) so the
-  // desktop app's URL-scheme handler routes the click instead of opening
-  // the bare web URL in a system browser. The embed=true path's
-  // `entry.link()` returns null (per `openAppTool`), so without this the
-  // safe fallback was webUrl twice — the same bug embed=false avoids by
-  // running through `buildLinkArtifacts` + `toDesktopOpenUrl`.
+  // Embed open links expose the safe browser target in `webUrl`, but the
+  // desktop URL must enter the app through the registered scheme so Electron
+  // can focus the right webview. Preserve the full route/query in the `to`
+  // param; focus ids are often only present on `url`, not `out.params`.
   const desktopDeepLinkUrl = (() => {
     if (!safeOpenUrl) return null;
     const app =
@@ -439,12 +453,13 @@ function mcpAppEmbedOpenLinkMeta(
         ? out.app.trim()
         : undefined;
     if (!app) return safeOpenUrl;
+    if (isAgentNativeOpenDeepLink(safeOpenUrl)) {
+      return toDesktopOpenUrl(safeOpenUrl);
+    }
+    const targetRoute = routePathFromOpenUrl(safeOpenUrl);
+    if (!targetRoute) return safeOpenUrl;
     const viewParam =
       typeof out.view === "string" && out.view.trim() ? out.view.trim() : "";
-    const toParam =
-      typeof out.path === "string" && out.path.trim()
-        ? out.path.trim()
-        : undefined;
     const params =
       out.params && typeof out.params === "object" && !Array.isArray(out.params)
         ? (out.params as Record<
@@ -452,13 +467,14 @@ function mcpAppEmbedOpenLinkMeta(
             string | number | boolean | null | undefined
           >)
         : undefined;
-    const deepLinkPath = buildDeepLink({
-      app,
-      view: viewParam,
-      ...(toParam ? { to: toParam } : {}),
-      ...(params ? { params } : {}),
-    });
-    return toDesktopOpenUrl(deepLinkPath);
+    return toDesktopOpenUrl(
+      buildDeepLink({
+        app,
+        view: viewParam,
+        to: targetRoute,
+        ...(params ? { params } : {}),
+      }),
+    );
   })();
 
   return {
@@ -1222,9 +1238,20 @@ export async function createMCPServerForRequest(
             : {}),
           ...(mcpAppResource ? openAiToolResultMeta(mcpAppResource) : {}),
         };
+        const toolUiMeta = metadataObject((entry.tool as any)._meta?.ui);
+        const toolVisibility = toolUiMeta.visibility;
+        const isAppOnlyVisibility =
+          Array.isArray(toolVisibility) &&
+          toolVisibility.length > 0 &&
+          toolVisibility.every((v) => v === "app");
         const structuredContent = mcpAppResource
           ? mcpAppStructuredContent(rawResult, responseMeta)
-          : undefined;
+          : isAppOnlyVisibility &&
+              rawResult &&
+              typeof rawResult === "object" &&
+              !Array.isArray(rawResult)
+            ? (rawResult as Record<string, unknown>)
+            : undefined;
         const text = mcpAppResource
           ? conciseMcpAppToolText(name, resultForClient, structuredContent!)
           : typeof resultForClient === "string"

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -1841,7 +1841,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       label: "Open mail",
       view: "/inbox",
       webUrl: "https://mail.agent-native.com/inbox",
-      desktopUrl: "https://mail.agent-native.com/inbox",
+      desktopUrl:
+        "agentnative://open?app=mail&view=&to=%2Finbox&agentSidebar=closed",
     });
     expect(out.result._meta["agent-native/embedStart"]).toMatchObject({
       startUrl:
@@ -2008,7 +2009,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       label: "Open dispatch",
       view: "/",
       webUrl: "https://mail.agent-native.com/",
-      desktopUrl: "https://mail.agent-native.com/",
+      desktopUrl:
+        "agentnative://open?app=dispatch&view=&to=%2F&agentSidebar=closed",
     });
     expect(out.result._meta["agent-native/embedStart"]).toMatchObject({
       startUrl:
@@ -2125,14 +2127,13 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     const embedConfig = {
       ...config,
       actions: {
-        "create_embed_session": {
+        create_embed_session: {
           tool: {
             description: "Create an embed session",
             _meta: { ui: { visibility: ["app"] } },
           },
           run: async () => ({
-            startUrl:
-              "/_agent-native/embed/start?ticket=embed-session-ticket",
+            startUrl: "/_agent-native/embed/start?ticket=embed-session-ticket",
             targetPath: "/inbox",
             expiresAt: 1735689600,
           }),
@@ -2158,17 +2159,14 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     // `parseToolResult` (in `embed-app.ts`) returns `startUrl` and the
     // iframe can actually mount the embedded app.
     expect(out.result.structuredContent).toMatchObject({
-      startUrl:
-        "/_agent-native/embed/start?ticket=embed-session-ticket",
+      startUrl: "/_agent-native/embed/start?ticket=embed-session-ticket",
       targetPath: "/inbox",
       expiresAt: 1735689600,
     });
     // Text content is still purged of the embed-start URL so non-compliant
     // hosts that ignore the `visibility: ["app"]` hint don't leak the
     // ticket via the chat transcript or text fallback.
-    expect(out.result.content[0].text).not.toContain(
-      "embed-session-ticket",
-    );
+    expect(out.result.content[0].text).not.toContain("embed-session-ticket");
   });
 
   it("does NOT surface raw result via structuredContent for model-visible (non-app-only) tools", async () => {
@@ -2185,8 +2183,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
             // No `visibility` hint = model + app visible.
           },
           run: async () => ({
-            startUrl:
-              "/_agent-native/embed/start?ticket=should-be-hidden",
+            startUrl: "/_agent-native/embed/start?ticket=should-be-hidden",
             payload: "ok",
           }),
         },
@@ -2352,6 +2349,89 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(JSON.stringify(out.result.structuredContent)).not.toContain(
       "https://mail.agent-native.com/deck",
     );
+  });
+
+  it("preserves route query params in embed desktop open links", async () => {
+    const embedConfig = {
+      ...config,
+      actions: {
+        "open-thread-route": {
+          tool: { description: "Open a thread route inline" },
+          run: async () => ({
+            app: "mail",
+            view: "inbox",
+            url: "/inbox?threadId=abc123&filter=unread",
+            embed: true,
+            embedStartUrl:
+              "/_agent-native/embed/start?ticket=thread-route-ticket",
+          }),
+          readOnly: true,
+          mcpApp: {
+            resource: {
+              title: "Open thread",
+              description: "Open the thread inline.",
+              html: "<!doctype html><html><body>Thread</body></html>",
+            },
+          },
+        },
+        "open-route-with-params": {
+          tool: { description: "Open a route with side params" },
+          run: async () => ({
+            app: "calendar",
+            path: "/agenda",
+            url: "/agenda",
+            params: { eventId: "evt-1", date: "2026-05-23" },
+            embed: true,
+            embedStartUrl: "/_agent-native/embed/start?ticket=agenda-ticket",
+          }),
+          readOnly: true,
+          mcpApp: {
+            resource: {
+              title: "Open agenda",
+              description: "Open the agenda inline.",
+              html: "<!doctype html><html><body>Agenda</body></html>",
+            },
+          },
+        },
+      },
+    };
+
+    const routeOut = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 50,
+        method: "tools/call",
+        params: { name: "open-thread-route", arguments: {} },
+      },
+      {
+        headers: { "x-agent-native-mcp-full-catalog": "1" },
+        config: embedConfig,
+      },
+    );
+    expect(routeOut.result._meta["agent-native/openLink"]).toMatchObject({
+      webUrl:
+        "https://mail.agent-native.com/inbox?threadId=abc123&filter=unread",
+      desktopUrl:
+        "agentnative://open?app=mail&view=inbox&to=%2Finbox%3FthreadId%3Dabc123%26filter%3Dunread&agentSidebar=closed",
+    });
+
+    const paramsOut = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 51,
+        method: "tools/call",
+        params: { name: "open-route-with-params", arguments: {} },
+      },
+      {
+        headers: { "x-agent-native-mcp-full-catalog": "1" },
+        config: embedConfig,
+      },
+    );
+    expect(paramsOut.result._meta["agent-native/openLink"]).toMatchObject({
+      webUrl: "https://mail.agent-native.com/agenda",
+      desktopUrl:
+        "agentnative://open?app=calendar&view=&to=%2Fagenda&eventId=evt-1&date=2026-05-23&agentSidebar=closed",
+    });
   });
 
   it("rejects unauthenticated calls with 401 when auth IS configured (no 501)", async () => {

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -1841,8 +1841,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       label: "Open mail",
       view: "/inbox",
       webUrl: "https://mail.agent-native.com/inbox",
-      desktopUrl:
-        "agentnative://open?app=mail&view=&to=%2Finbox&agentSidebar=closed",
+      desktopUrl: "https://mail.agent-native.com/inbox",
     });
     expect(out.result._meta["agent-native/embedStart"]).toMatchObject({
       startUrl:
@@ -2009,8 +2008,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       label: "Open dispatch",
       view: "/",
       webUrl: "https://mail.agent-native.com/",
-      desktopUrl:
-        "agentnative://open?app=dispatch&view=&to=%2F&agentSidebar=closed",
+      desktopUrl: "https://mail.agent-native.com/",
     });
     expect(out.result._meta["agent-native/embedStart"]).toMatchObject({
       startUrl:
@@ -2111,6 +2109,106 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       "/_agent-native/embed/start",
     );
     expect(out.result.content[0].text).toContain("[hidden embed URL]");
+  });
+
+  it("surfaces app-only-visibility tool results via structuredContent so the embed iframe can read them", async () => {
+    // Regression: PR #875's `purgeEmbedStartUrls` strips the embed start URL
+    // from non-MCP-App action text — but `create_embed_session` is an
+    // **app-only** helper called by the embed iframe, and the iframe needs
+    // the `startUrl` to actually mount the app. Without surfacing the raw
+    // result through `structuredContent` (which the iframe prefers in
+    // `parseToolResult`), the iframe falls back to parsing the purged text
+    // and reports "This app can be opened, but not embedded". The
+    // `_meta.ui.visibility: ["app"]` hint already tells compliant hosts not
+    // to leak the result into LLM context, so the structuredContent path is
+    // safe for these tools and unbreaks the embed.
+    const embedConfig = {
+      ...config,
+      actions: {
+        "create_embed_session": {
+          tool: {
+            description: "Create an embed session",
+            _meta: { ui: { visibility: ["app"] } },
+          },
+          run: async () => ({
+            startUrl:
+              "/_agent-native/embed/start?ticket=embed-session-ticket",
+            targetPath: "/inbox",
+            expiresAt: 1735689600,
+          }),
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 160,
+        method: "tools/call",
+        params: { name: "create_embed_session", arguments: {} },
+      },
+      {
+        headers: { "x-agent-native-mcp-full-catalog": "1" },
+        config: embedConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    // Iframe-readable: full raw result preserved on structuredContent so
+    // `parseToolResult` (in `embed-app.ts`) returns `startUrl` and the
+    // iframe can actually mount the embedded app.
+    expect(out.result.structuredContent).toMatchObject({
+      startUrl:
+        "/_agent-native/embed/start?ticket=embed-session-ticket",
+      targetPath: "/inbox",
+      expiresAt: 1735689600,
+    });
+    // Text content is still purged of the embed-start URL so non-compliant
+    // hosts that ignore the `visibility: ["app"]` hint don't leak the
+    // ticket via the chat transcript or text fallback.
+    expect(out.result.content[0].text).not.toContain(
+      "embed-session-ticket",
+    );
+  });
+
+  it("does NOT surface raw result via structuredContent for model-visible (non-app-only) tools", async () => {
+    // Counter-regression: only `visibility: ["app"]` tools get the raw
+    // structuredContent escape hatch. Tools the LLM can call must continue
+    // to go through the normal text + purge path so embed-start URLs and
+    // other internal fields stay hidden from the model.
+    const embedConfig = {
+      ...config,
+      actions: {
+        "model-callable-helper": {
+          tool: {
+            description: "A normal model-visible tool",
+            // No `visibility` hint = model + app visible.
+          },
+          run: async () => ({
+            startUrl:
+              "/_agent-native/embed/start?ticket=should-be-hidden",
+            payload: "ok",
+          }),
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 161,
+        method: "tools/call",
+        params: { name: "model-callable-helper", arguments: {} },
+      },
+      {
+        headers: { "x-agent-native-mcp-full-catalog": "1" },
+        config: embedConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.result.structuredContent).toBeUndefined();
+    expect(out.result.content[0].text).not.toContain("should-be-hidden");
   });
 
   it("strips embedTargetPath, embedExpiresAt, and ticket fields from structuredContent", async () => {
@@ -2254,92 +2352,6 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(JSON.stringify(out.result.structuredContent)).not.toContain(
       "https://mail.agent-native.com/deck",
     );
-  });
-
-  it("uses the agentnative:// desktop scheme on embed=true open links", async () => {
-    // Regression: previously the embed=true path set
-    // `desktopUrl === webUrl`, so the desktop app's URL-scheme handler
-    // never fired and clicks on "Open in app" inside an MCP App embed
-    // opened the bare web URL in the system browser instead of routing
-    // through the desktop app. The fix derives a `buildDeepLink`-based
-    // `agentnative://open?app=…&view=…` (or `to=<path>`) URL so the
-    // desktop handler can route the click natively.
-    const embedConfig = {
-      ...config,
-      actions: {
-        "open-view-embed": {
-          tool: { description: "Open a view-based embed" },
-          run: async () => ({
-            app: "mail",
-            view: "inbox",
-            url: "/inbox",
-            embed: true,
-            embedStartUrl: "/_agent-native/embed/start?ticket=view-ticket",
-          }),
-          readOnly: true,
-          mcpApp: {
-            resource: {
-              title: "Open app",
-              description: "Open the full app inline.",
-              html: "<!doctype html><html><body>Open app</body></html>",
-            },
-          },
-        },
-        "open-path-embed": {
-          tool: { description: "Open a path-based embed" },
-          run: async () => ({
-            app: "calendar",
-            path: "/agenda",
-            url: "/agenda",
-            embed: true,
-            embedStartUrl: "/_agent-native/embed/start?ticket=path-ticket",
-          }),
-          readOnly: true,
-          mcpApp: {
-            resource: {
-              title: "Open app",
-              description: "Open the full app inline.",
-              html: "<!doctype html><html><body>Open app</body></html>",
-            },
-          },
-        },
-      },
-    };
-
-    const viewOut = await callWeb(
-      {
-        jsonrpc: "2.0",
-        id: 50,
-        method: "tools/call",
-        params: { name: "open-view-embed", arguments: {} },
-      },
-      {
-        headers: { "x-agent-native-mcp-full-catalog": "1" },
-        config: embedConfig,
-      },
-    );
-    expect(viewOut.result._meta["agent-native/openLink"]).toMatchObject({
-      webUrl: "https://mail.agent-native.com/inbox",
-      desktopUrl: "agentnative://open?app=mail&view=inbox&agentSidebar=closed",
-    });
-
-    const pathOut = await callWeb(
-      {
-        jsonrpc: "2.0",
-        id: 51,
-        method: "tools/call",
-        params: { name: "open-path-embed", arguments: {} },
-      },
-      {
-        headers: { "x-agent-native-mcp-full-catalog": "1" },
-        config: embedConfig,
-      },
-    );
-    expect(pathOut.result._meta["agent-native/openLink"]).toMatchObject({
-      webUrl: "https://mail.agent-native.com/agenda",
-      desktopUrl:
-        "agentnative://open?app=calendar&view=&to=%2Fagenda&agentSidebar=closed",
-    });
   });
 
   it("rejects unauthenticated calls with 401 when auth IS configured (no 501)", async () => {

--- a/packages/desktop-app/shared/ipc-channels.ts
+++ b/packages/desktop-app/shared/ipc-channels.ts
@@ -575,5 +575,6 @@ export interface CodeAgentHostMetadata {
 export interface DesktopOpenRequest {
   app?: string;
   goalId?: string;
+  path?: string;
   runId?: string;
 }

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -487,6 +487,11 @@ function sendOpenRequestToRenderer(request: DesktopOpenRequest) {
   win.webContents.send(IPC.DEEP_LINK_OPEN, request);
 }
 
+function buildAppOpenRoutePath(parsed: URL): string {
+  const query = parsed.searchParams.toString();
+  return query ? `/_agent-native/open?${query}` : "/_agent-native/open";
+}
+
 function inferCodeAgentGoalIdFromRunId(
   runId: string | undefined,
 ): string | undefined {
@@ -562,6 +567,11 @@ async function handleDeepLink(url: string) {
               : (targetApp ?? targetGoal.appId),
           goalId: targetGoal.id,
           runId,
+        });
+      } else if (targetApp && getInjectionTargetForAppId(targetApp)) {
+        sendOpenRequestToRenderer({
+          app: targetApp,
+          path: buildAppOpenRoutePath(parsed),
         });
       } else {
         focusMainWindow();

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -22,6 +22,8 @@ export interface Tab {
   id: string;
   appId: string;
   title: string;
+  urlOpenNonce?: number;
+  urlPath?: string;
 }
 
 let nextTabId = 1;
@@ -32,6 +34,16 @@ function createTab(app: AppDefinition | AppConfig): Tab {
     appId: app.id,
     title: app.name,
   };
+}
+
+function safeDesktopOpenPath(path: string | undefined): string | undefined {
+  if (!path) return undefined;
+  const trimmed = path.trim();
+  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) return undefined;
+  if (trimmed.startsWith("/\\")) return undefined;
+  if (/[\u0000-\u001f\u007f]/.test(trimmed)) return undefined;
+  if (/^\/[a-z][a-z0-9+.-]*:/i.test(trimmed)) return undefined;
+  return trimmed;
 }
 
 // Per-app tab state: appId → { tabs, activeTabId }
@@ -113,6 +125,8 @@ export default function App() {
     runId?: string;
     nonce: number;
   }>();
+  const [pendingDesktopOpenRequest, setPendingDesktopOpenRequest] =
+    useState<DesktopOpenRequest | null>(null);
 
   // Load apps from persistent store
   useEffect(() => {
@@ -250,6 +264,67 @@ export default function App() {
     setShowSettings(false);
     setShowAddApp(false);
   }, []);
+
+  const handleDesktopOpenRequest = useCallback(
+    (request: DesktopOpenRequest): boolean => {
+      const goal = getCodeAgentGoal(request.goalId);
+      if (
+        goal ||
+        request.app === MIGRATION_APP_ID ||
+        request.app === CODE_AGENTS_SURFACE_ID
+      ) {
+        setCodeAgentsOpenRequest({
+          goalId:
+            goal?.id ??
+            (request.app === MIGRATION_APP_ID ? "migrate" : undefined),
+          runId: request.runId,
+          nonce: Date.now(),
+        });
+        setActiveSidebarAppId(CODE_AGENTS_SURFACE_ID);
+        setShowSettings(false);
+        setShowAddApp(false);
+        return true;
+      }
+
+      const appId = request.app?.trim();
+      if (!appId) return true;
+      const targetApp = enabledApps.find((app) => app.id === appId);
+      if (!targetApp) return !loading;
+
+      activateApp(appId);
+      setShowSettings(false);
+      setShowAddApp(false);
+
+      const urlPath = safeDesktopOpenPath(request.path);
+      if (!urlPath) return true;
+      const urlOpenNonce = Date.now();
+
+      setAppTabs((prev) => {
+        const appState = prev[appId];
+        const tabs =
+          appState && appState.tabs.length > 0
+            ? appState.tabs
+            : [createTab(targetApp)];
+        const activeTabId =
+          appState?.activeTabId &&
+          tabs.some((tab) => tab.id === appState.activeTabId)
+            ? appState.activeTabId
+            : tabs[0].id;
+
+        return {
+          ...prev,
+          [appId]: {
+            tabs: tabs.map((tab) =>
+              tab.id === activeTabId ? { ...tab, urlOpenNonce, urlPath } : tab,
+            ),
+            activeTabId,
+          },
+        };
+      });
+      return true;
+    },
+    [activateApp, enabledApps, loading],
+  );
 
   const handleTabSelect = useCallback(
     (tabId: string) => {
@@ -514,27 +589,16 @@ export default function App() {
   useEffect(() => {
     if (!window.electronAPI?.codeAgents?.onOpenRequest) return;
     return window.electronAPI.codeAgents.onOpenRequest((request) => {
-      const goal = getCodeAgentGoal(request.goalId);
-      if (
-        !goal &&
-        request.app &&
-        request.app !== MIGRATION_APP_ID &&
-        request.app !== CODE_AGENTS_SURFACE_ID
-      ) {
-        return;
-      }
-      setCodeAgentsOpenRequest({
-        goalId:
-          goal?.id ??
-          (request.app === MIGRATION_APP_ID ? "migrate" : undefined),
-        runId: request.runId,
-        nonce: Date.now(),
-      });
-      setActiveSidebarAppId(CODE_AGENTS_SURFACE_ID);
-      setShowSettings(false);
-      setShowAddApp(false);
+      setPendingDesktopOpenRequest(request);
     });
   }, []);
+
+  useEffect(() => {
+    if (!pendingDesktopOpenRequest) return;
+    if (handleDesktopOpenRequest(pendingDesktopOpenRequest)) {
+      setPendingDesktopOpenRequest(null);
+    }
+  }, [handleDesktopOpenRequest, pendingDesktopOpenRequest]);
 
   // Report the active app to main process so DevTools targets the right webview
   useEffect(() => {
@@ -720,6 +784,8 @@ export default function App() {
                 app={appDef}
                 appConfig={app}
                 isActive={isActive}
+                urlOpenNonce={tab.urlOpenNonce}
+                urlPath={tab.urlPath}
                 refreshKey={isActive ? refreshKey : 0}
                 onTitleChange={(title) => handleTabTitleChange(tab.id, title)}
                 onAppsChanged={handleAppsChanged}

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -33,6 +33,10 @@ interface AppWebviewProps {
   /** Full app config with URL overrides (optional for backward compat) */
   appConfig?: AppConfig;
   isActive: boolean;
+  /** Changes when the same URL should be opened again. */
+  urlOpenNonce?: number;
+  /** Safe app-relative path to load inside this app's origin. */
+  urlPath?: string;
   /** Query parameters to merge into the resolved app URL. */
   urlParams?: Record<string, string | null | undefined>;
   /** Increment to trigger a webview reload (Cmd+R) */
@@ -138,12 +142,37 @@ function withUrlParams(
   }
 }
 
+function withUrlPath(rawUrl: string, path?: string): string {
+  if (!path) return rawUrl;
+  try {
+    if (
+      !path.startsWith("/") ||
+      path.startsWith("//") ||
+      path.startsWith("/\\")
+    ) {
+      return rawUrl;
+    }
+    if (/[\u0000-\u001f\u007f]/.test(path)) return rawUrl;
+    if (/^\/[a-z][a-z0-9+.-]*:/i.test(path)) return rawUrl;
+    const base = new URL(rawUrl);
+    const target = new URL(path, "http://agent-native.invalid");
+    base.pathname = target.pathname;
+    base.search = target.search;
+    base.hash = target.hash;
+    return base.toString();
+  } catch {
+    return rawUrl;
+  }
+}
+
 const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
   (
     {
       app,
       appConfig,
       isActive,
+      urlOpenNonce,
+      urlPath,
       urlParams,
       refreshKey = 0,
       onTitleChange,
@@ -156,10 +185,14 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
     const [isLoading, setIsLoading] = useState(true);
     const [slowLoad, setSlowLoad] = useState(false);
     const [isFullscreen, setIsFullscreen] = useState(false);
-    const url = withUrlParams(resolveUrl(app, appConfig), urlParams);
+    const url = withUrlParams(
+      withUrlPath(resolveUrl(app, appConfig), urlPath),
+      urlParams,
+    );
     const isDevMode = appConfig?.mode === "dev";
     const optimizeDepRecoveryRef = useRef(false);
     const prevUrlRef = useRef(url);
+    const prevUrlOpenNonceRef = useRef(urlOpenNonce);
     const onTitleChangeRef = useRef(onTitleChange);
 
     useEffect(() => {
@@ -354,14 +387,22 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
     // Keep mode toggles, edited prod URLs, and custom dev URLs in sync.
     useEffect(() => {
       const wv = webviewRef.current;
-      if (!wv || app.placeholder || prevUrlRef.current === url) return;
+      if (
+        !wv ||
+        app.placeholder ||
+        (prevUrlRef.current === url &&
+          prevUrlOpenNonceRef.current === urlOpenNonce)
+      ) {
+        return;
+      }
       prevUrlRef.current = url;
+      prevUrlOpenNonceRef.current = urlOpenNonce;
       optimizeDepRecoveryRef.current = false;
       setError(false);
       setIsLoading(true);
       setSlowLoad(false);
       wv.setAttribute("src", url);
-    }, [url, app.placeholder]);
+    }, [url, urlOpenNonce, app.placeholder]);
 
     // If the webview hasn't fired dom-ready within a few seconds, surface
     // a "still loading" hint. If it's still not ready after a bit longer,

--- a/packages/desktop-app/src/renderer/global.d.ts
+++ b/packages/desktop-app/src/renderer/global.d.ts
@@ -470,6 +470,7 @@ type CodeAgentHostMetadata = {
 type DesktopOpenRequest = {
   app?: string;
   goalId?: string;
+  path?: string;
   runId?: string;
 };
 


### PR DESCRIPTION
## Summary

This PR covers the two follow-up issues found while babysitting the MCP Apps rollout:

1. `create_embed_session` and other app-only MCP tools now return their raw data in `structuredContent`, so the MCP App iframe can read fields like `startUrl` while model-visible text stays scrubbed of embed tickets.
2. Desktop `agentnative://open?app=...` links now actually route into the target app webview instead of only focusing the desktop window. The renderer activates the app, loads its `/_agent-native/open` route, preserves target route/query params, and reopens even when the same deep link is clicked twice.

## Safety

- App-only structuredContent is limited to tools declaring `_meta.ui.visibility: ["app"]`; model-visible tools keep the existing no-structuredContent behavior.
- Desktop app deep-link paths are validated as same-origin relative paths before they can update a webview.
- The desktop handler only routes generic app links for installed apps; code-agent and migration deep links keep their existing behavior.

## Test plan

- [x] `pnpm --filter @agent-native/core exec vitest --run src/mcp/server.spec.ts src/mcp/deep-link.spec.ts src/mcp/builtin-cross-app.spec.ts` — 85 tests passed
- [x] `pnpm --filter @agent-native/desktop-app typecheck`
- [x] `pnpm --filter @agent-native/desktop-app build`
- [x] `pnpm prep` passed before the final desktop repeat-open nonce; after the nonce, desktop typecheck/build passed again
- [x] Reran `pnpm prep`; tests/typechecks/fmt passed, and the only failure was a generated-file race in `guard-no-one-off-mcp-app-html`; rerunning that guard by itself passed