### PR TITLE
Fix scope-flip thread race + content table-cell placeholder

### DIFF
--- a/.changeset/chat-threads-scope-race.md
+++ b/.changeset/chat-threads-scope-race.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix race condition in `useChatThreads` that dropped the active general chat when the user navigated into a scoped resource before `GET /threads` resolved. The scope-flip rehydration effect now defers the decision when thread metadata is unknown (instead of falling through and swapping to the scoped storage key), so the visible conversation is preserved until threads load and a real decision can be made.

--- a/packages/core/src/client/use-chat-threads.ts
+++ b/packages/core/src/client/use-chat-threads.ts
@@ -159,17 +159,25 @@ export function useChatThreads(
   const persistedKeyRef = useRef(activeThreadKey);
   useEffect(() => {
     if (persistedKeyRef.current !== activeThreadKey) {
-      persistedKeyRef.current = activeThreadKey;
       const currentId = activeThreadIdRef.current;
       if (currentId) {
         const currentThreadScope = readKnownThreadScope(currentId);
-        if (
-          currentThreadScope !== undefined &&
-          threadCanStayVisibleInScope(currentThreadScope, scopeRef.current)
-        ) {
+        // Thread metadata not yet loaded from the server — we can't tell
+        // whether the visible chat is general (stays) or scoped-elsewhere
+        // (swaps). Defer until `threads` resolves and this effect re-runs;
+        // we intentionally do NOT update `persistedKeyRef` so the next
+        // render gets another shot. Without this guard, navigating into a
+        // resource before `GET /threads` resolves silently dropped the
+        // active general chat the user was just in.
+        if (currentThreadScope === undefined) {
+          return;
+        }
+        if (threadCanStayVisibleInScope(currentThreadScope, scopeRef.current)) {
+          persistedKeyRef.current = activeThreadKey;
           return;
         }
       }
+      persistedKeyRef.current = activeThreadKey;
       try {
         setActiveThreadId(localStorage.getItem(activeThreadKey));
       } catch {

--- a/templates/content/app/components/editor/VisualEditor.tsx
+++ b/templates/content/app/components/editor/VisualEditor.tsx
@@ -639,6 +639,16 @@ function getVisualEditorPlaceholder({
     return hasAnchor ? "Empty quote" : "";
   }
 
+  // Skip the long "Press 'space' for AI…" hint inside table cells — it wraps
+  // awkwardly in narrow columns and the cell itself is already an affordance.
+  if (
+    node.type.name === "paragraph" &&
+    (hasAncestorType(editor, pos, "tableCell") ||
+      hasAncestorType(editor, pos, "tableHeader"))
+  ) {
+    return "";
+  }
+
   return hasAnchor ? DEFAULT_EMPTY_BLOCK_PLACEHOLDER : "";
 }
 


### PR DESCRIPTION
Sweep of unaddressed feedback flagged on PRs merged earlier today plus a small content editor polish.

## Changes

### `@agent-native/core` — `useChatThreads` scope-flip race condition (patch)
Builder bot flagged this on [#871](https://github.com/BuilderIO/agent-native/pull/871) seven minutes after merge and it was never addressed.

When the user navigated into a scoped resource (deck / design / form) **before** the initial `GET /threads` fetch resolved, `readKnownThreadScope(currentId)` returned `undefined`, the guard fell through, and `setActiveThreadId(localStorage.getItem(scopedKey))` swapped the visible chat to whatever the scoped storage key held — silently dropping the active general chat the user was just in. This contradicts #871's stated goal of "keep general chats visible across navigation."

Fix: when scope is unknown, return early **without updating `persistedKeyRef`**, so the effect re-runs once `threads` populates and can make a real decision.

### `templates/content` — table-cell placeholder hint
Skip the long `Press 'space' for AI…` placeholder inside table cells / headers. It wraps awkwardly in narrow columns and the cell itself is already an affordance.

## Verification
- `pnpm run prep` clean (typecheck, format, all guards)
- No existing tests for the hook; race is timing-dependent and verifiable from the diff
- Changeset added for `@agent-native/core` (patch)
