### PR TITLE
fix(forms): correct navigation state for team, extensions, and form-preview routes

### DIFF
--- a/templates/forms/app/hooks/use-navigation-state.ts
+++ b/templates/forms/app/hooks/use-navigation-state.ts
@@ -34,6 +34,12 @@ export function useNavigationState() {
       }
     } else if (path.startsWith("/f/")) {
       state.view = "public-form";
+    } else if (path.startsWith("/team")) {
+      state.view = "team";
+    } else if (path.startsWith("/extensions")) {
+      state.view = "extensions";
+    } else if (path.startsWith("/form-preview")) {
+      state.view = "form-preview";
     }
 
     fetch(agentNativePath("/_agent-native/application-state/navigation"), {
@@ -79,6 +85,12 @@ export function useNavigationState() {
       path = `/forms/${cmd.formId}/responses`;
     } else if (cmd.view === "forms") {
       path = "/forms";
+    } else if (cmd.view === "team") {
+      path = "/team";
+    } else if (cmd.view === "extensions") {
+      path = "/extensions";
+    } else if (cmd.view === "form-preview") {
+      path = "/form-preview";
     }
 
     navigate(path);


### PR DESCRIPTION
## What was broken
`useNavigationState` in `templates/forms/app/hooks/use-navigation-state.ts`
initializes `state` as `{ view: "forms" }` and only overwrites it for known
routes. `/team`, `/extensions`, and `/form-preview` had no branches, so the
hook always wrote `{ view: "forms" }` to `/_agent-native/application-state/navigation`
when the user was on any of those pages. An agent reading navigation state
from those routes received incorrect context.

The navigate command resolution (second `useEffect`) had the same gap:
`cmd.view === "team"`, `"extensions"`, or `"form-preview"` fell through
to the default, causing agent navigate commands for those views to silently
redirect to `/forms`.

## Why it happened
The `if/else if` chain was written for the initial set of routes and never
extended when `/team`, `/extensions`, and `/form-preview` were added.

## The fix
Added `startsWith` branches for all three routes in both `useEffect` blocks.

For `/extensions`: `ExtensionsListPage` and `ExtensionViewerPage` (from
`@agent-native/core/client/extensions`) already self-report `view: "extensions"`
on mount. The hook was still writing `view: "forms"` on every route change,
creating a race — whichever effect fired last won. The fix makes both writers
consistent, eliminating the race.

## Key changes
- `templates/forms/app/hooks/use-navigation-state.ts`: added `else if` branches
  for `/team`, `/extensions`, `/form-preview` in the state write effect (after
  the `/f/` branch) and in the navigate command resolution (after the `"forms"` branch)

## Verification
Confirmed `{"view":"forms"}` payload via DevTools Network tab on `/team` before
fix. After fix:
- `/team` → `{"view":"team"}`
- `/extensions` → `{"view":"extensions"}`
- `/form-preview` → `{"view":"form-preview"}`