### PR TITLE
fix(clips/desktop): multi-monitor overlay placement

### DIFF
--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -16,9 +16,9 @@ use crate::state::{
     DictationActive, LastTranscript, RecordingActive, TrayAnchor, VoiceWakePopover,
 };
 use crate::util::{
-    build_overlay_url, hide_voice_wake_popover, is_recording_active, mark_popover_shown,
-    primary_monitor_physical_size, set_capture_excluded, set_capture_excluded_always,
-    set_capture_included, set_dictation_active,
+    build_overlay_url, configure_overlay_behavior, hide_voice_wake_popover, is_recording_active,
+    mark_popover_shown, set_capture_excluded, set_capture_excluded_always, set_capture_included,
+    set_dictation_active, tray_monitor_physical_rect,
 };
 
 /// Native overlay windows for the recording experience. These render the same
@@ -184,8 +184,14 @@ pub async fn show_countdown(app: AppHandle) -> Result<(), String> {
         let _ = app.emit("clips:countdown-shortcuts-active", false);
         let _ = existing.close();
     }
-    let (mw, mh) = primary_monitor_physical_size(&app).unwrap_or((2880, 1800));
-    dlog!("[clips-tray] countdown target size {}x{} physical", mw, mh);
+    let (mx, my, mw, mh) = tray_monitor_physical_rect(&app);
+    dlog!(
+        "[clips-tray] countdown target {}x{} at ({},{}) physical",
+        mw,
+        mh,
+        mx,
+        my
+    );
     let win = WebviewWindowBuilder::new(&app, COUNTDOWN_LABEL, build_overlay_url("countdown"))
         .title("Countdown")
         .decorations(false)
@@ -205,9 +211,10 @@ pub async fn show_countdown(app: AppHandle) -> Result<(), String> {
             e.to_string()
         })?;
     let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(mw, mh)));
-    let _ = win.set_position(PhysicalPosition::new(0, 0));
+    let _ = win.set_position(PhysicalPosition::new(mx, my));
     let _ = win.set_ignore_cursor_events(true);
     set_capture_excluded(&win);
+    configure_overlay_behavior(&win);
     let _ = win.show();
     let _ = app.emit("clips:countdown-shortcuts-active", true);
     dlog!("[clips-tray] countdown shown");
@@ -227,7 +234,7 @@ pub async fn show_finalizing(app: AppHandle) -> Result<(), String> {
     if let Some(existing) = app.get_webview_window(FINALIZING_LABEL) {
         let _ = existing.close();
     }
-    let (mw, mh) = primary_monitor_physical_size(&app).unwrap_or((2880, 1800));
+    let (mx, my, mw, mh) = tray_monitor_physical_rect(&app);
     dlog!("[clips-tray] finalizing target size {}x{} physical", mw, mh);
     let win = WebviewWindowBuilder::new(&app, FINALIZING_LABEL, build_overlay_url("finalizing"))
         .title("Finalizing")
@@ -245,9 +252,10 @@ pub async fn show_finalizing(app: AppHandle) -> Result<(), String> {
             e.to_string()
         })?;
     let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(mw, mh)));
-    let _ = win.set_position(PhysicalPosition::new(0, 0));
+    let _ = win.set_position(PhysicalPosition::new(mx, my));
     let _ = win.set_ignore_cursor_events(true);
     set_capture_excluded(&win);
+    configure_overlay_behavior(&win);
     let _ = win.show();
     dlog!("[clips-tray] finalizing shown");
     Ok(())
@@ -281,7 +289,7 @@ pub async fn show_region_guides(app: AppHandle) -> Result<(), String> {
         return Ok(());
     }
 
-    let (mw, mh) = primary_monitor_physical_size(&app).unwrap_or((2880, 1800));
+    let (mx, my, mw, mh) = tray_monitor_physical_rect(&app);
     let win = WebviewWindowBuilder::new(
         &app,
         REGION_GUIDES_LABEL,
@@ -302,9 +310,10 @@ pub async fn show_region_guides(app: AppHandle) -> Result<(), String> {
         e.to_string()
     })?;
     let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(mw, mh)));
-    let _ = win.set_position(PhysicalPosition::new(0, 0));
+    let _ = win.set_position(PhysicalPosition::new(mx, my));
     let _ = win.set_ignore_cursor_events(true);
     set_capture_excluded_always(&win);
+    configure_overlay_behavior(&win);
     crate::util::show_without_activation(&win);
     Ok(())
 }
@@ -347,7 +356,7 @@ pub async fn show_region_guide_editor(app: AppHandle) -> Result<(), String> {
         let _ = existing.close();
     }
 
-    let (mw, mh) = primary_monitor_physical_size(&app).unwrap_or((2880, 1800));
+    let (mx, my, mw, mh) = tray_monitor_physical_rect(&app);
     #[allow(unused_mut)]
     let mut builder = WebviewWindowBuilder::new(
         &app,
@@ -372,8 +381,9 @@ pub async fn show_region_guide_editor(app: AppHandle) -> Result<(), String> {
         e.to_string()
     })?;
     let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(mw, mh)));
-    let _ = win.set_position(PhysicalPosition::new(0, 0));
+    let _ = win.set_position(PhysicalPosition::new(mx, my));
     set_capture_excluded_always(&win);
+    configure_overlay_behavior(&win);
     let _ = win.show();
     let _ = win.set_focus();
     Ok(())
@@ -392,7 +402,7 @@ pub async fn show_toolbar(app: AppHandle) -> Result<(), String> {
         let _ = existing.set_focus();
         return Ok(());
     }
-    let (_mw, mh) = primary_monitor_physical_size(&app).unwrap_or((2880, 1800));
+    let (mx, my, _mw, mh) = tray_monitor_physical_rect(&app);
     // Tighter pill: buttons are 30px, padding is 10px, gap is 10px. The
     // window is sized so the pill fills it with only ~4-6 px of slack per
     // side for the CSS drop shadow to bleed into. Values are physical px,
@@ -400,8 +410,8 @@ pub async fn show_toolbar(app: AppHandle) -> Result<(), String> {
     let w: u32 = 110;
     let h: u32 = 260;
     // Flush-left with a small margin; vertically centered on the screen.
-    let x: i32 = 48;
-    let y: i32 = (mh as i32 - h as i32) / 2;
+    let x: i32 = mx + 48;
+    let y: i32 = my + (mh as i32 - h as i32) / 2;
     dlog!("[clips-tray] toolbar pos=({},{}) size={}x{}", x, y, w, h);
     #[allow(unused_mut)]
     let mut builder = WebviewWindowBuilder::new(&app, TOOLBAR_LABEL, build_overlay_url("toolbar"))
@@ -436,6 +446,7 @@ pub async fn show_toolbar(app: AppHandle) -> Result<(), String> {
     let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(w, h)));
     let _ = win.set_position(PhysicalPosition::new(x, y));
     set_capture_excluded(&win);
+    configure_overlay_behavior(&win);
     let _ = win.show();
     dlog!("[clips-tray] toolbar shown");
 
@@ -455,7 +466,6 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
         dlog!("[clips-tray] bubble reused");
         return Ok(());
     }
-    let (mw, mh) = primary_monitor_physical_size(&app).unwrap_or((2880, 1800));
     // Honor the user's last-chosen size. Default is "small" (192 physical =
     // 96 logical) so new users get a quiet PiP rather than a giant circle.
     let size_name = load_bubble_size_name(&app);
@@ -463,21 +473,25 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
     // The actual window is TALLER than the circle — see
     // `BUBBLE_CONTROLS_BUDGET_PX` — to give the hover controls pill room.
     let win_h: u32 = bubble_window_height_for(size);
+
+    let (mon_x, mon_y, mon_w, mon_h) = tray_monitor_physical_rect(&app);
+
     // Default Loom-style anchor: flush-left with a small margin, a hair
-    // above the bottom edge of the primary display. On Retina the 60
-    // physical-px offset maps to ~30 logical px. Account for the extra
-    // height below the circle so the circle (not the controls strip) sits
-    // at the same visual position as before.
-    let default_x: i32 = 48;
-    let default_y: i32 = mh as i32 - win_h as i32 - 60;
-    // Prefer the last-known position, clamped to the primary monitor so a
-    // position saved on a now-disconnected external display can't leave
-    // the bubble off-screen.
-    let max_x = (mw as i32 - size as i32).max(0);
-    let max_y = (mh as i32 - win_h as i32).max(0);
+    // above the bottom edge of the target monitor. On Retina the 60
+    // physical-px offset maps to ~30 logical px.
+    let default_x: i32 = mon_x + 48;
+    let default_y: i32 = mon_y + mon_h as i32 - win_h as i32 - 60;
+    // Clamp bounds within the target monitor.
+    let max_x = (mon_x + mon_w as i32 - size as i32).max(mon_x);
+    let max_y = (mon_y + mon_h as i32 - win_h as i32).max(mon_y);
+    // Use the saved position only if it already falls on the target monitor.
+    // A position from a previous session on a different display would strand
+    // the bubble off-screen, so fall back to the default anchor instead.
     let (x, y, source) = match load_bubble_position(&app) {
-        Some((sx, sy)) => (sx.clamp(0, max_x), sy.clamp(0, max_y), "saved"),
-        None => (default_x, default_y, "default"),
+        Some((sx, sy)) if sx >= mon_x && sx <= max_x && sy >= mon_y && sy <= max_y => {
+            (sx, sy, "saved")
+        }
+        _ => (default_x, default_y, "default"),
     };
     dlog!(
         "[clips-tray] bubble pos=({},{}) source={} size={}x{} monitor={}x{}",
@@ -486,8 +500,8 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
         source,
         size,
         win_h,
-        mw,
-        mh
+        mon_w,
+        mon_h
     );
     #[allow(unused_mut)]
     let mut builder = WebviewWindowBuilder::new(&app, BUBBLE_LABEL, build_overlay_url("bubble"))
@@ -516,6 +530,7 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
     // the bubble). NSWindowSharingNone would make macOS exclude it from
     // `getDisplayMedia`, which matches the other Clips chrome (popover,
     // toolbar, countdown) but NOT what users want for the camera bubble.
+    configure_overlay_behavior(&win);
     let _ = win.show();
     dlog!("[clips-tray] bubble shown at ({},{}) size {}", x, y, size);
     Ok(())
@@ -797,6 +812,7 @@ pub async fn show_signin(app: AppHandle, url: String) -> Result<(), String> {
         .build()
         .map_err(|e| e.to_string())?;
     set_capture_excluded(&win);
+    configure_overlay_behavior(&win);
     let _ = win.show();
     let _ = win.set_focus();
     Ok(())
@@ -821,15 +837,15 @@ pub async fn close_signin(app: AppHandle) -> Result<(), String> {
 pub async fn show_flow_bar(app: AppHandle) -> Result<(), String> {
     dlog!("[clips-tray] show_flow_bar invoked");
 
-    let (mw, mh) = primary_monitor_physical_size(&app).unwrap_or((2880, 1800));
+    let (mx, my, mw, mh) = tray_monitor_physical_rect(&app);
     // Wider + taller than the pill alone so the live transcript chip
     // can stack above it. Height accommodates: bottom-anchored 32px pill
     // + 6px gap + ~28px transcript chip + drop-shadow margin.
     let w: u32 = 420;
     let h: u32 = 120;
-    let x: i32 = ((mw as i32 - w as i32) / 2).max(0);
+    let x: i32 = (mx + (mw as i32 - w as i32) / 2).max(mx);
     // Bottom margin: ~14 logical px ≈ 28 physical px.
-    let y: i32 = (mh as i32 - h as i32 - 28).max(0);
+    let y: i32 = (my + mh as i32 - h as i32 - 28).max(my);
 
     if let Some(existing) = app.get_webview_window(FLOW_BAR_LABEL) {
         // Reposition (in case the user changed display geometry between
@@ -865,6 +881,7 @@ pub async fn show_flow_bar(app: AppHandle) -> Result<(), String> {
     // click-through rectangle that strands the X button.
     let _ = win.set_ignore_cursor_events(false);
     set_capture_excluded(&win);
+    configure_overlay_behavior(&win);
     crate::util::show_without_activation(&win);
     let app_for_timeout = app.clone();
     thread::spawn(move || {
@@ -1184,6 +1201,7 @@ pub async fn reset_state(app: AppHandle) -> Result<(), String> {
     if let Some(window) = app.get_webview_window("popover") {
         // Restore normal size in case the window was shrunk to a pinhole
         // during recording — otherwise it would reappear as a 2×2 dot.
+        configure_overlay_behavior(&window);
         let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(360.0, 520.0)));
         position_popover(&app, &window);
         mark_popover_shown(&app);
@@ -1271,6 +1289,9 @@ pub async fn save_bubble_position(app: AppHandle, x: i32, y: i32) -> Result<(), 
 pub async fn show_popover(app: AppHandle) -> Result<(), String> {
     if let Some(window) = app.get_webview_window("popover") {
         set_capture_included(&window);
+        // Re-apply Space behavior — `orderOut:` resets it, so without this
+        // the popover sticks to whichever Space it was first shown on.
+        configure_overlay_behavior(&window);
         // Restore the popover's normal size — it may have been shrunk to 2×2
         // during recording by `park_popover_offscreen` (kept the JS alive
         // while keeping the window out of the way). The content's
@@ -1363,6 +1384,10 @@ pub fn toggle_popover(app: &AppHandle) {
     // during recording / voice-wake — otherwise it would reappear as a
     // 2x2 dot.
     set_capture_included(&window);
+    // Re-apply Space behavior — `orderOut:` resets it on every `hide()`,
+    // so without this the popover sticks to whichever Space it was first
+    // shown on.
+    configure_overlay_behavior(&window);
     let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(360.0, 520.0)));
     position_popover(app, &window);
     mark_popover_shown(app);
@@ -1426,12 +1451,32 @@ pub fn position_popover(app: &AppHandle, window: &WebviewWindow) {
         let gap = 6_i32;
         let mut y = icon_y + icon_h + gap;
 
+        // Find the monitor that actually contains the tray icon. The popover
+        // is parked at (2,2) on the primary display, so current_monitor()
+        // always resolves to the primary monitor — wrong when the user clicked
+        // the icon on a secondary display.
+        let icon_cx = icon_x + icon_w / 2;
+        let icon_cy = icon_y + icon_h / 2;
+        let tray_monitor = window.available_monitors().ok().and_then(|monitors| {
+            monitors.into_iter().find(|m| {
+                let mp = m.position();
+                let ms = m.size();
+                icon_cx >= mp.x
+                    && icon_cx < mp.x + ms.width as i32
+                    && icon_cy >= mp.y
+                    && icon_cy < mp.y + ms.height as i32
+            })
+        });
+        let (clamp_pos, clamp_size) = tray_monitor
+            .map(|m| (*m.position(), *m.size()))
+            .unwrap_or((*mon_pos, *mon_size));
+
         // Clamp so settings and long error states don't run off the edge of
         // shorter displays or get stranded in a corner after a resize.
-        let min_x = mon_pos.x + 8;
-        let max_x = mon_pos.x + mon_size.width as i32 - win_size.width as i32 - 8;
-        let min_y = mon_pos.y + 8;
-        let max_y = mon_pos.y + mon_size.height as i32 - win_size.height as i32 - 8;
+        let min_x = clamp_pos.x + 8;
+        let max_x = clamp_pos.x + clamp_size.width as i32 - win_size.width as i32 - 8;
+        let min_y = clamp_pos.y + 8;
+        let max_y = clamp_pos.y + clamp_size.height as i32 - win_size.height as i32 - 8;
         if x < min_x {
             x = min_x;
         }

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -1454,7 +1454,7 @@ pub fn position_popover(app: &AppHandle, window: &WebviewWindow) {
         // Find the monitor that actually contains the tray icon. The popover
         // is parked at (2,2) on the primary display, so current_monitor()
         // always resolves to the primary monitor — wrong when the user clicked
-        // the icon on a secondary display.
+        // the icon on a secondary display
         let icon_cx = icon_x + icon_w / 2;
         let icon_cy = icon_y + icon_h / 2;
         let tray_monitor = window.available_monitors().ok().and_then(|monitors| {

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -29,7 +29,7 @@ use state::{
     DictationActive, DictationEnabled, LastTranscript, MeetingActive, PopoverShownAt,
     RecordingActive, TrayAnchor, TrayMeetings, VoiceWakePopover,
 };
-use util::{is_recording_active, set_capture_included};
+use util::{configure_overlay_behavior, is_recording_active, set_capture_included};
 
 // Embedded fallback icon — a tiny 16x16 solid purple PNG so the binary always
 // has *something* to display even if `icons/tray.png` is missing on disk. The
@@ -46,6 +46,7 @@ pub fn run() {
             // over focus and neither popover shows.
             if let Some(window) = app.get_webview_window("popover") {
                 set_capture_included(&window);
+                configure_overlay_behavior(&window);
                 position_popover(app, &window);
                 let _ = window.show();
                 let _ = window.set_focus();
@@ -161,15 +162,17 @@ pub fn run() {
         .manage(notifications::MeetingNotificationState::default())
         .manage(silence_detector::DetectorState::default())
         .setup(|app| {
-            // NOTE: we intentionally do NOT call set_activation_policy(Accessory)
-            // in dev here. In unbundled dev runs, Accessory mode sometimes
-            // prevents the tray icon from registering in the macOS menu bar at
-            // all. Production builds (.app bundle) ship with LSUIElement=1 in
-            // Info.plist, which is the proper way to get pure menu-bar behavior.
-            #[cfg(all(target_os = "macos", not(debug_assertions)))]
+            // Keeps the app from yanking the user out of fullscreen when the
+            // popover appears. Production bundles reinforce this with LSUIElement=1.
+            #[cfg(target_os = "macos")]
             {
                 app.set_activation_policy(tauri::ActivationPolicy::Accessory);
             }
+
+            util::build_popover_window(app).map_err(|err| {
+                eprintln!("[clips-tray] popover build failed: {err}");
+                err
+            })?;
 
             tray::build_tray(app)?;
             config::sync_launch_at_login(app.handle());

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -9,6 +9,8 @@ use std::time::{Duration, Instant};
 use tauri::{AppHandle, Manager, State};
 
 #[cfg(target_os = "macos")]
+use core_graphics::display::{CGDisplay, CGPoint};
+#[cfg(target_os = "macos")]
 use screencapturekit::audio_devices::AudioInputDevice;
 #[cfg(target_os = "macos")]
 use screencapturekit::recording_output::{
@@ -80,6 +82,8 @@ struct RestartInfo {
     mic_device_label: Option<String>,
     /// Monotonic counter feeding the per-segment filename suffix.
     segment_counter: u32,
+    /// CGDirectDisplayID of the display to record. None = first available.
+    target_display_id: Option<u32>,
 }
 
 enum NativeFullscreenBackend {
@@ -558,6 +562,7 @@ pub async fn native_fullscreen_recording_resume(
         restart.mic_device_id.as_deref(),
         restart.mic_device_label.as_deref(),
         &segment_path,
+        restart.target_display_id,
     )?;
     session.backend = Some(backend);
     session.segments.push(segment_path);
@@ -674,6 +679,7 @@ fn start_segment_backend(
     mic_device_id: Option<&str>,
     mic_device_label: Option<&str>,
     segment_path: &Path,
+    target_display_id: Option<u32>,
 ) -> Result<(NativeFullscreenBackend, Option<u32>, Option<u32>), String> {
     #[cfg(target_os = "macos")]
     {
@@ -686,6 +692,7 @@ fn start_segment_backend(
             include_audio,
             mic_device_id,
             mic_device_label,
+            target_display_id,
         ) {
             Ok((backend, w, h)) => return Ok((backend, w, h)),
             Err(sck_err) => {
@@ -695,7 +702,7 @@ fn start_segment_backend(
             }
         }
         let (backend, w, h) =
-            start_screencapture_backend_at(segment_path, include_audio).map_err(|fallback_err| {
+            start_screencapture_backend_at(segment_path, include_audio, target_display_id).map_err(|fallback_err| {
                 format!("ScreenCaptureKit resume failed; screencapture fallback failed ({fallback_err})")
             })?;
         Ok((backend, w, h))
@@ -722,12 +729,14 @@ fn start_screencapturekit_backend_at(
     include_audio: bool,
     mic_device_id: Option<&str>,
     mic_device_label: Option<&str>,
+    target_display_id: Option<u32>,
 ) -> Result<(NativeFullscreenBackend, Option<u32>, Option<u32>), String> {
     let content =
         SCShareableContent::get().map_err(|e| format!("shareable content lookup failed: {e:?}"))?;
     let displays = content.displays();
-    let display = displays
-        .first()
+    let display = target_display_id
+        .and_then(|id| displays.iter().find(|d| d.display_id() == id))
+        .or_else(|| displays.first())
         .ok_or_else(|| "No displays available for ScreenCaptureKit recording.".to_string())?;
 
     let width = display.width();
@@ -805,16 +814,25 @@ fn start_screencapturekit_backend_at(
 fn start_screencapture_backend_at(
     output_path: &Path,
     include_audio: bool,
+    target_display_id: Option<u32>,
 ) -> Result<(NativeFullscreenBackend, Option<u32>, Option<u32>), String> {
     if !std::path::Path::new("/usr/sbin/screencapture").exists() {
         return Err("macOS screencapture is unavailable on this machine.".into());
     }
+    // screencapture -D<N> uses 1-based position in CGGetActiveDisplayList.
+    let display_flag = target_display_id
+        .and_then(|id| {
+            CGDisplay::active_displays().ok().and_then(|ids| {
+                ids.iter().position(|&aid| aid == id).map(|p| format!("-D{}", p + 1))
+            })
+        })
+        .unwrap_or_else(|| "-D1".to_string());
     let mut command = Command::new("/usr/sbin/screencapture");
     command
         .arg("-v")
         .arg("-x")
         .arg("-C")
-        .arg("-D1")
+        .arg(display_flag)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
@@ -1234,11 +1252,18 @@ fn capture_thumbnail_bytes(app: &AppHandle, recording_id: &str) -> Result<Vec<u8
 
         let path = thumbnail_path(app, recording_id)?;
         let _ = std::fs::remove_file(&path);
+        let thumb_display_flag = tray_display_id(app)
+            .and_then(|id| {
+                CGDisplay::active_displays().ok().and_then(|ids| {
+                    ids.iter().position(|&aid| aid == id).map(|p| format!("-D{}", p + 1))
+                })
+            })
+            .unwrap_or_else(|| "-D1".to_string());
         let status = Command::new("/usr/sbin/screencapture")
             .arg("-x")
             .arg("-t")
             .arg("jpg")
-            .arg("-D1")
+            .arg(thumb_display_flag)
             .arg(&path)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
@@ -1337,6 +1362,61 @@ fn persist_saved_recording_error(app: &AppHandle, saved: &mut SavedNativeRecordi
 }
 
 #[cfg(target_os = "macos")]
+/// Return the `CGDirectDisplayID` of the display containing the centre of
+/// the last-clicked tray icon. Uses the Tauri monitor list to locate the
+/// right monitor and converts from physical pixels to the logical-point
+/// coordinate space that `CGDisplay::displays_with_point` requires.
+/// Returns `None` when the tray anchor hasn't been set yet or any lookup
+/// fails — callers fall back to the first available display.
+#[cfg(target_os = "macos")]
+fn tray_display_id(app: &AppHandle) -> Option<u32> {
+    let tray_rect = app
+        .try_state::<crate::state::TrayAnchor>()
+        .and_then(|a| a.0.lock().ok().and_then(|g| *g))?;
+
+    let icon_x = match tray_rect.position {
+        tauri::Position::Physical(p) => p.x as f64,
+        tauri::Position::Logical(p) => p.x,
+    };
+    let icon_y = match tray_rect.position {
+        tauri::Position::Physical(p) => p.y as f64,
+        tauri::Position::Logical(p) => p.y,
+    };
+    let icon_w = match tray_rect.size {
+        tauri::Size::Physical(s) => s.width as f64,
+        tauri::Size::Logical(s) => s.width,
+    };
+    let icon_h = match tray_rect.size {
+        tauri::Size::Physical(s) => s.height as f64,
+        tauri::Size::Logical(s) => s.height,
+    };
+
+    let cx_phys = icon_x + icon_w / 2.0;
+    let cy_phys = icon_y + icon_h / 2.0;
+
+    // CGDisplay uses logical (point) coordinates; Tauri gives physical pixels.
+    // Divide by the monitor's scale factor to convert.
+    let scale = app
+        .get_webview_window("popover")
+        .and_then(|w| w.available_monitors().ok())
+        .and_then(|monitors| {
+            monitors.into_iter().find(|m| {
+                let mp = m.position();
+                let ms = m.size();
+                cx_phys as i32 >= mp.x
+                    && (cx_phys as i32) < mp.x + ms.width as i32
+                    && cy_phys as i32 >= mp.y
+                    && (cy_phys as i32) < mp.y + ms.height as i32
+            })
+        })
+        .map(|m| m.scale_factor())
+        .unwrap_or(2.0);
+
+    let point = CGPoint::new(cx_phys / scale, cy_phys / scale);
+    let (ids, _) = CGDisplay::displays_with_point(point, 4).ok()?;
+    ids.into_iter().next()
+}
+
 fn start_screencapturekit_recording(
     app: &AppHandle,
     safe_id: &str,
@@ -1344,6 +1424,7 @@ fn start_screencapturekit_recording(
     mic_device_id: Option<&str>,
     mic_device_label: Option<&str>,
 ) -> Result<NativeFullscreenSession, String> {
+    let target_display_id = tray_display_id(app);
     let path = pending_recording_path(app, safe_id, "mp4")?;
     let _ = std::fs::remove_file(&path);
     let (backend, width, height) = start_screencapturekit_backend_at(
@@ -1351,6 +1432,7 @@ fn start_screencapturekit_recording(
         include_audio,
         mic_device_id,
         mic_device_label,
+        target_display_id,
     )?;
     let (fallback_width, fallback_height) = primary_monitor_size(app);
     Ok(new_fullscreen_session(
@@ -1365,6 +1447,7 @@ fn start_screencapturekit_recording(
             mic_device_id: mic_device_id.map(str::to_string),
             mic_device_label: mic_device_label.map(str::to_string),
             segment_counter: 0,
+            target_display_id,
         },
     ))
 }
@@ -1375,9 +1458,10 @@ fn start_screencapture_recording(
     safe_id: &str,
     include_audio: bool,
 ) -> Result<NativeFullscreenSession, String> {
+    let target_display_id = tray_display_id(app);
     let path = pending_recording_path(app, safe_id, "mov")?;
     let _ = std::fs::remove_file(&path);
-    let (backend, _w, _h) = start_screencapture_backend_at(&path, include_audio)?;
+    let (backend, _w, _h) = start_screencapture_backend_at(&path, include_audio, target_display_id)?;
     let (width, height) = primary_monitor_size(app);
     Ok(new_fullscreen_session(
         backend,
@@ -1391,6 +1475,7 @@ fn start_screencapture_recording(
             mic_device_id: None,
             mic_device_label: None,
             segment_counter: 0,
+            target_display_id,
         },
     ))
 }

--- a/templates/clips/desktop/src-tauri/src/recording_indicator.rs
+++ b/templates/clips/desktop/src-tauri/src/recording_indicator.rs
@@ -33,7 +33,8 @@ use tauri::{AppHandle, Manager, PhysicalPosition, PhysicalSize, WebviewWindowBui
 
 use crate::dlog;
 use crate::util::{
-    build_overlay_url, primary_monitor_physical_size, set_capture_excluded, show_without_activation,
+    configure_overlay_behavior, build_overlay_url, set_capture_excluded, show_without_activation,
+    tray_monitor_physical_rect,
 };
 
 const PILL_LABEL: &str = "recording-pill";
@@ -188,18 +189,18 @@ fn save_pill_position_to_disk(app: &AppHandle, x: i32, y: i32) {
 fn default_bottom_center(app: &AppHandle, w: u32, h: u32) -> (i32, i32) {
     let scale = scale_factor(app);
     let bottom_margin = (PILL_BOTTOM_MARGIN_LOGICAL as f64 * scale) as i32;
-    let (mw, mh) = primary_monitor_physical_size(app).unwrap_or((2880, 1800));
-    let x = ((mw as i32 - w as i32) / 2).max(0);
-    let y = (mh as i32 - h as i32 - bottom_margin).max(0);
+    let (mx, my, mw, mh) = tray_monitor_physical_rect(app);
+    let x = (mx + (mw as i32 - w as i32) / 2).max(mx);
+    let y = (my + mh as i32 - h as i32 - bottom_margin).max(my);
     (x, y)
 }
 
 fn default_center_right(app: &AppHandle, w: u32, h: u32) -> (i32, i32) {
     let scale = scale_factor(app);
     let right_margin = (PILL_RIGHT_MARGIN_LOGICAL as f64 * scale) as i32;
-    let (mw, mh) = primary_monitor_physical_size(app).unwrap_or((2880, 1800));
-    let x = (mw as i32 - w as i32 - right_margin).max(0);
-    let y = ((mh as i32 - h as i32) / 2).max(0);
+    let (mx, my, mw, mh) = tray_monitor_physical_rect(app);
+    let x = (mx + mw as i32 - w as i32 - right_margin).max(mx);
+    let y = (my + (mh as i32 - h as i32) / 2).max(my);
     (x, y)
 }
 
@@ -226,9 +227,9 @@ fn default_top_right(app: &AppHandle, w: u32, _h: u32) -> (i32, i32) {
     let scale = scale_factor(app);
     let top_margin = (PILL_DETACHED_TOP_MARGIN_LOGICAL as f64 * scale) as i32;
     let right_margin = (PILL_DETACHED_RIGHT_MARGIN_LOGICAL as f64 * scale) as i32;
-    let (mw, _mh) = primary_monitor_physical_size(app).unwrap_or((2880, 1800));
-    let x = (mw as i32 - w as i32 - right_margin).max(0);
-    let y = top_margin.max(0);
+    let (mx, my, mw, _mh) = tray_monitor_physical_rect(app);
+    let x = (mx + mw as i32 - w as i32 - right_margin).max(mx);
+    let y = (my + top_margin).max(my);
     (x, y)
 }
 
@@ -243,9 +244,9 @@ fn anchored_rect(
     previous_position: Option<(i32, i32, u32, u32)>,
 ) -> (u32, u32, i32, i32) {
     let (w, h) = pill_size_physical(app, expanded);
-    let (mw, mh) = primary_monitor_physical_size(app).unwrap_or((2880, 1800));
-    let max_x = (mw as i32 - w as i32).max(0);
-    let max_y = (mh as i32 - h as i32).max(0);
+    let (mx, my, mw, mh) = tray_monitor_physical_rect(app);
+    let max_x = (mx + mw as i32 - w as i32).max(mx);
+    let max_y = (my + mh as i32 - h as i32).max(my);
 
     // Detached mode has its own persisted position file so the user can
     // drag the floating pill anywhere on the right edge / corner without
@@ -253,7 +254,7 @@ fn anchored_rect(
     // main app is in front.
     if PILL_DETACHED.load(Ordering::Relaxed) {
         let (x, y) = match load_detached_position(app) {
-            Some((sx, sy)) => (sx.clamp(0, max_x), sy.clamp(0, max_y)),
+            Some((sx, sy)) => (sx.clamp(mx, max_x), sy.clamp(my, max_y)),
             None => default_top_right(app, w, h),
         };
         return (w, h, x, y);
@@ -263,12 +264,12 @@ fn anchored_rect(
         if let Some((px, py, prev_w, prev_h)) = previous_position {
             let prev_right = px + prev_w as i32;
             let prev_center_y = py + prev_h as i32 / 2;
-            let x = (prev_right - w as i32).clamp(0, max_x);
-            let y = (prev_center_y - h as i32 / 2).clamp(0, max_y);
+            let x = (prev_right - w as i32).clamp(mx, max_x);
+            let y = (prev_center_y - h as i32 / 2).clamp(my, max_y);
             return (w, h, x, y);
         }
         let (x, y) = match load_meeting_position(app) {
-            Some((sx, sy)) => (sx.clamp(0, max_x), sy.clamp(0, max_y)),
+            Some((sx, sy)) => (sx.clamp(mx, max_x), sy.clamp(my, max_y)),
             None => default_center_right(app, w, h),
         };
         return (w, h, x, y);
@@ -279,15 +280,15 @@ fn anchored_rect(
         // pinned. New top-left = (prev_center_x - new_w/2, prev_bottom - new_h).
         let prev_center_x = px + prev_w as i32 / 2;
         let prev_bottom = py + prev_h as i32;
-        let x = (prev_center_x - w as i32 / 2).clamp(0, max_x);
-        let y = (prev_bottom - h as i32).clamp(0, max_y);
+        let x = (prev_center_x - w as i32 / 2).clamp(mx, max_x);
+        let y = (prev_bottom - h as i32).clamp(my, max_y);
         return (w, h, x, y);
     }
 
     // First show — prefer the user's last persisted position, otherwise
     // default bottom-center.
     let (x, y) = match load_pill_position(app) {
-        Some((sx, sy)) => (sx.clamp(0, max_x), sy.clamp(0, max_y)),
+        Some((sx, sy)) => (sx.clamp(mx, max_x), sy.clamp(my, max_y)),
         None => default_bottom_center(app, w, h),
     };
     (w, h, x, y)
@@ -356,6 +357,7 @@ pub async fn recording_pill_show(
     let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(w, h)));
     let _ = win.set_position(PhysicalPosition::new(x, y));
     set_capture_excluded(&win);
+    configure_overlay_behavior(&win);
     show_without_activation(&win);
 
     // Tell the freshly-mounted React side which mode + meeting_id to render.

--- a/templates/clips/desktop/src-tauri/src/tray_meetings.rs
+++ b/templates/clips/desktop/src-tauri/src/tray_meetings.rs
@@ -71,6 +71,7 @@ pub fn handle_meeting_menu_click(app: &AppHandle, menu_id: &str) -> bool {
     }
     use tauri::Emitter;
     if let Some(window) = app.get_webview_window("popover") {
+        crate::util::configure_overlay_behavior(&window);
         let _ = window.show();
         let _ = window.set_focus();
     }

--- a/templates/clips/desktop/src-tauri/src/util.rs
+++ b/templates/clips/desktop/src-tauri/src/util.rs
@@ -1,7 +1,9 @@
-use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindow};
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
 
 use crate::dlog;
-use crate::state::{DictationActive, PopoverShownAt, RecordingActive, VoiceWakePopover};
+use crate::state::{
+    DictationActive, PopoverShownAt, RecordingActive, TrayAnchor, VoiceWakePopover,
+};
 
 // ---------------------------------------------------------------------------
 // Capture-sharing helpers (macOS only)
@@ -92,6 +94,64 @@ pub fn set_capture_excluded_always(window: &WebviewWindow) {
 #[cfg(target_os = "macos")]
 pub fn set_capture_included(window: &WebviewWindow) {
     set_window_capture_excluded(window, false);
+}
+
+pub fn build_popover_window(app: &mut tauri::App) -> Result<WebviewWindow, tauri::Error> {
+    WebviewWindowBuilder::new(app, "popover", WebviewUrl::App("index.html".into()))
+        .title("Clips")
+        .inner_size(360.0, 520.0)
+        .position(2.0, 2.0)
+        .resizable(false)
+        .decorations(false)
+        .transparent(true)
+        .always_on_top(true)
+        .visible_on_all_workspaces(true)
+        .skip_taskbar(true)
+        .visible(false)
+        .focused(true)
+        .shadow(false)
+        .accept_first_mouse(true)
+        .build()
+}
+
+// Sets NSWindowCollectionBehaviorCanJoinAllSpaces (bit 0) and
+// NSWindowCollectionBehaviorFullScreenAuxiliary (bit 8). Bit 0 keeps the
+// window visible when the user switches Spaces; bit 8 keeps it visible over
+// fullscreen apps. Tauri exposes bit 0 via set_visible_on_all_workspaces but
+// not bit 8. Must be called before every show — orderOut: resets these bits.
+#[cfg(target_os = "macos")]
+pub fn configure_overlay_behavior(window: &WebviewWindow) {
+    let win = window.clone();
+    // AppKit calls must run on the main thread.
+    if let Err(err) = win.clone().run_on_main_thread(move || {
+        let label = win.label().to_string();
+        let ns_window_ptr = match win.ns_window() {
+            Ok(p) => p,
+            Err(err) => {
+                eprintln!("[clips-tray] configure_overlay_behavior({label}): ns_window() failed: {err}");
+                return;
+            }
+        };
+        if ns_window_ptr.is_null() {
+            eprintln!("[clips-tray] configure_overlay_behavior({label}): ns_window is null");
+            return;
+        }
+        // SAFETY: ns_window() returns a live NSWindow*; called on main thread.
+        unsafe {
+            let obj = ns_window_ptr as *mut objc2::runtime::AnyObject;
+            let current: usize = objc2::msg_send![&*obj, collectionBehavior];
+            let next = current | (1usize << 0) | (1usize << 8); // CanJoinAllSpaces | FullScreenAuxiliary
+            let _: () = objc2::msg_send![&*obj, setCollectionBehavior: next];
+        }
+        dlog!("[clips-tray] configure_overlay_behavior({label}): CanJoinAllSpaces|FullScreenAuxiliary");
+    }) {
+        eprintln!("[clips-tray] configure_overlay_behavior: run_on_main_thread failed: {err}");
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn configure_overlay_behavior(_window: &WebviewWindow) {
+    // No-op on non-macOS platforms. Spaces are a macOS concept.
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -196,6 +256,63 @@ pub fn show_without_activation(window: &WebviewWindow) {
     // is a macOS-flavored complaint; if it shows up on Windows / Linux
     // we'll add a per-platform fix.
     let _ = window.show();
+}
+
+/// Returns `(x, y, width, height)` of the monitor where the tray icon was last
+/// clicked, in physical pixels. Falls back to the primary monitor. Use this
+/// instead of `primary_monitor_physical_size` for any overlay that should appear
+/// on the same screen as the recording.
+pub fn tray_monitor_physical_rect(app: &AppHandle) -> (i32, i32, u32, u32) {
+    let tray_rect = app
+        .try_state::<TrayAnchor>()
+        .and_then(|a| a.0.lock().ok().and_then(|g| *g));
+
+    let (icon_cx, icon_cy) = tray_rect
+        .map(|rect| {
+            let x = match rect.position {
+                tauri::Position::Physical(p) => p.x,
+                tauri::Position::Logical(p) => p.x as i32,
+            };
+            let y = match rect.position {
+                tauri::Position::Physical(p) => p.y,
+                tauri::Position::Logical(p) => p.y as i32,
+            };
+            let w = match rect.size {
+                tauri::Size::Physical(s) => s.width as i32,
+                tauri::Size::Logical(s) => s.width as i32,
+            };
+            let h = match rect.size {
+                tauri::Size::Physical(s) => s.height as i32,
+                tauri::Size::Logical(s) => s.height as i32,
+            };
+            (x + w / 2, y + h / 2)
+        })
+        .unwrap_or((0, 0));
+
+    let window = app.get_webview_window("popover");
+    let monitor = window
+        .as_ref()
+        .and_then(|w| w.available_monitors().ok())
+        .and_then(|monitors| {
+            monitors.into_iter().find(|m| {
+                let mp = m.position();
+                let ms = m.size();
+                icon_cx >= mp.x
+                    && icon_cx < mp.x + ms.width as i32
+                    && icon_cy >= mp.y
+                    && icon_cy < mp.y + ms.height as i32
+            })
+        })
+        .or_else(|| window.and_then(|w| w.primary_monitor().ok().flatten()));
+
+    match monitor {
+        Some(m) => {
+            let p = m.position();
+            let s = m.size();
+            (p.x, p.y, s.width, s.height)
+        }
+        None => (0, 0, 2880, 1800),
+    }
 }
 
 pub fn primary_monitor_physical_size(app: &AppHandle) -> Option<(u32, u32)> {

--- a/templates/clips/desktop/src-tauri/tauri.conf.json
+++ b/templates/clips/desktop/src-tauri/tauri.conf.json
@@ -11,26 +11,7 @@
   },
   "app": {
     "macOSPrivateApi": true,
-    "windows": [
-      {
-        "label": "popover",
-        "title": "Clips",
-        "width": 360,
-        "height": 520,
-        "resizable": false,
-        "decorations": false,
-        "transparent": true,
-        "alwaysOnTop": true,
-        "skipTaskbar": true,
-        "visible": false,
-        "focus": true,
-        "shadow": false,
-        "center": false,
-        "acceptFirstMouse": true,
-        "x": 2,
-        "y": 2
-      }
-    ],
+    "windows": [],
     "security": {
       "csp": null
     }

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -2176,7 +2176,6 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.45);
   user-select: none;
   -webkit-user-select: none;
   cursor: grab;
@@ -2312,9 +2311,6 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   border-radius: 50%;
   overflow: hidden;
   background: #000;
-  /* Drop shadow only — no brand ring. The bubble is the user's face;
-     a bright purple halo competes with what matters visually. */
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
   /* Position context for absolute children (close X, canvas). */
   position: relative;
   /* Cursor hint — the drag region is here. */
@@ -2407,7 +2403,6 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   z-index: 3;
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
 }
 
 .bubble-close:hover {
@@ -2433,7 +2428,6 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
   z-index: 3;
   /* Cursor over the pill should not be a grab cursor (we're not dragging
      the bubble when clicking its controls). */


### PR DESCRIPTION
https://www.loom.com/share/f8883e775064432c8ca27bb1664a397c

All Clips overlays now appear on the monitor where the user clicked the tray icon, instead of always defaulting to the primary display.

## What changed

**App opens on the clicked monitor**

The popover is parked at `(2, 2)` during recordings, so `current_monitor()` always resolved to the primary display. `position_popover()` now walks `available_monitors()` to find which monitor actually contains the tray icon center, and clamps the popover within that monitor's bounds.

**Camera bubble follows the same screen**

The bubble used to read `primary_monitor_physical_size()` for its default anchor and position clamping. It now calls `tray_monitor_physical_rect()` instead, so it opens on the same display the user is working on. A saved bubble position is only reused if it falls within the current tray monitor — positions from a previous session on a different display fall back to the default anchor rather than stranding the bubble off-screen.

**All other overlays follow the tray monitor**

Countdown, recording toolbar, recording pill, finalizing spinner, flow bar, and region guides all use `tray_monitor_physical_rect()` for both size and origin. A new `apply_join_all_spaces()` helper also sets `NSWindowCollectionBehaviorFullScreenAuxiliary` (bit 8) on every overlay window so they stay visible when recording inside a fullscreen app — Tauri doesn't expose this flag. The helper re-applies before every `show()` because `orderOut:` resets these bits.

**Recording captures the right display**

`native_screen.rs` picks the display to record based on the tray icon position:
- ScreenCaptureKit: matches `CGDirectDisplayID` directly
- `screencapture` fallback: computes the correct `-D<N>` index from `CGGetActiveDisplayList`
- Pause/resume preserves the original display via a new `target_display_id` field on `RestartInfo`

**Box shadows removed**

Removed `box-shadow` from `.bubble-root`, `.bubble-close`, `.bubble-controls`, and `.toolbar-v`.
