### PR TITLE
Harden collab sync and add Content document exports

### DIFF
--- a/.changeset/harden-collab-multiplayer.md
+++ b/.changeset/harden-collab-multiplayer.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Harden collaborative editing against missed updates and concurrent Yjs persistence races.

--- a/packages/core/src/collab/client.ts
+++ b/packages/core/src/collab/client.ts
@@ -268,7 +268,7 @@ export function useCollaborativeDoc(
         if (data?.state) {
           const binary = base64ToUint8Array(data.state);
           if (binary.length > 4) {
-            Y.applyUpdate(ydoc, binary);
+            Y.applyUpdate(ydoc, binary, "remote");
           }
         }
         setIsLoading(false);
@@ -360,6 +360,31 @@ export function useCollaborativeDoc(
         }
 
         pollVersionRef.current = version;
+
+        try {
+          // The poll ring buffer is process-local. Fetching a state-vector diff
+          // makes collaboration durable across serverless invocations, process
+          // restarts, or any missed poll event.
+          const stateVector = uint8ArrayToBase64(Y.encodeStateVector(ydoc));
+          const stateRes = await fetch(
+            `${baseUrl}/${docId}/state?stateVector=${encodeURIComponent(
+              stateVector,
+            )}`,
+          );
+          if (stateRes.ok) {
+            const stateData = (await stateRes.json().catch(() => null)) as {
+              state?: string;
+            } | null;
+            if (stateData?.state) {
+              const binary = base64ToUint8Array(stateData.state);
+              if (binary.length > 2) {
+                Y.applyUpdate(ydoc, binary, "remote");
+              }
+            }
+          }
+        } catch {
+          // The next poll retries; awareness should still sync below.
+        }
 
         // Sync awareness (cursor positions)
         if (awareness) {

--- a/packages/core/src/collab/routes.ts
+++ b/packages/core/src/collab/routes.ts
@@ -4,7 +4,12 @@
  * Mounted under /_agent-native/collab/ by the collab plugin.
  */
 
-import { defineEventHandler, setResponseStatus, getRouterParam } from "h3";
+import {
+  defineEventHandler,
+  setResponseStatus,
+  getRouterParam,
+  getQuery,
+} from "h3";
 import type { H3Event } from "h3";
 import * as manager from "./ydoc-manager.js";
 import { searchAndReplace as doSearchAndReplace } from "./ydoc-manager.js";
@@ -23,7 +28,23 @@ export const getCollabState = defineEventHandler(async (event: H3Event) => {
     return { error: "docId required" };
   }
 
-  const state = await manager.getState(docId);
+  const query = getQuery(event);
+  const encodedStateVector =
+    typeof query.stateVector === "string" ? query.stateVector : null;
+  let state: Uint8Array;
+  if (encodedStateVector) {
+    try {
+      state = await manager.getIncUpdate(
+        docId,
+        base64ToUint8Array(encodedStateVector),
+      );
+    } catch {
+      setResponseStatus(event, 400);
+      return { error: "stateVector must be base64-encoded" };
+    }
+  } else {
+    state = await manager.getState(docId);
+  }
   return {
     docId,
     state: uint8ArrayToBase64(state),

--- a/packages/core/src/collab/storage.spec.ts
+++ b/packages/core/src/collab/storage.spec.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadYDocRecord, saveYDocState, trySaveYDocState } from "./storage.js";
+
+const rows = vi.hoisted(
+  () =>
+    new Map<
+      string,
+      { yjs_state: string; text_snapshot: string; version: number }
+    >(),
+);
+
+function toBase64(arr: Uint8Array): string {
+  return Buffer.from(arr).toString("base64");
+}
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => ({
+    execute: async (query: string | { sql: string; args?: unknown[] }) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      const args = typeof query === "string" ? [] : (query.args ?? []);
+
+      if (/^\s*CREATE TABLE/i.test(sql) || /^\s*ALTER TABLE/i.test(sql)) {
+        return { rows: [], rowsAffected: 0 };
+      }
+
+      if (/^\s*SELECT yjs_state, version FROM _collab_docs/i.test(sql)) {
+        const row = rows.get(String(args[0]));
+        return { rows: row ? [row] : [], rowsAffected: 0 };
+      }
+
+      if (/^\s*UPDATE _collab_docs\b/i.test(sql)) {
+        const hasVersionGuard = /\bAND version = \?/i.test(sql);
+        const docId = String(args[2]);
+        const row = rows.get(docId);
+        if (!row) return { rows: [], rowsAffected: 0 };
+        if (hasVersionGuard && row.version !== Number(args[3])) {
+          return { rows: [], rowsAffected: 0 };
+        }
+        rows.set(docId, {
+          yjs_state: String(args[0]),
+          text_snapshot: String(args[1]),
+          version: row.version + 1,
+        });
+        return { rows: [], rowsAffected: 1 };
+      }
+
+      if (/^\s*INSERT (OR IGNORE )?INTO _collab_docs/i.test(sql)) {
+        const docId = String(args[0]);
+        if (rows.has(docId)) return { rows: [], rowsAffected: 0 };
+        rows.set(docId, {
+          yjs_state: String(args[1]),
+          text_snapshot: String(args[2]),
+          version: 0,
+        });
+        return { rows: [], rowsAffected: 1 };
+      }
+
+      throw new Error(`Unexpected SQL: ${sql}`);
+    },
+  }),
+  isPostgres: () => false,
+}));
+
+describe("collab storage optimistic saves", () => {
+  afterEach(() => {
+    rows.clear();
+  });
+
+  it("rejects stale version writes so callers can merge and retry", async () => {
+    await saveYDocState("doc-1", new Uint8Array([1]), "one");
+    const firstRead = await loadYDocRecord("doc-1");
+
+    expect(firstRead?.version).toBe(0);
+    expect(
+      await trySaveYDocState(
+        "doc-1",
+        new Uint8Array([2]),
+        "two",
+        firstRead!.version,
+      ),
+    ).toBe(true);
+    expect(
+      await trySaveYDocState(
+        "doc-1",
+        new Uint8Array([3]),
+        "three",
+        firstRead!.version,
+      ),
+    ).toBe(false);
+
+    const latest = await loadYDocRecord("doc-1");
+    expect(latest?.version).toBe(1);
+    expect(latest?.state).toEqual(new Uint8Array([2]));
+    expect(rows.get("doc-1")?.yjs_state).toBe(toBase64(new Uint8Array([2])));
+  });
+});

--- a/packages/core/src/collab/storage.ts
+++ b/packages/core/src/collab/storage.ts
@@ -19,24 +19,76 @@ async function ensureTable(): Promise<void> {
           doc_id TEXT PRIMARY KEY,
           yjs_state TEXT NOT NULL,
           text_snapshot TEXT NOT NULL DEFAULT '',
+          version INTEGER NOT NULL DEFAULT 0,
           updated_at TEXT NOT NULL DEFAULT (${nowDefault})
         )
       `);
+      try {
+        await client.execute(
+          `ALTER TABLE _collab_docs ADD COLUMN version INTEGER NOT NULL DEFAULT 0`,
+        );
+      } catch {
+        // Existing deployments already have the column after the first run.
+      }
     })();
   }
   return _initPromise;
 }
 
-/** Load Yjs state as Uint8Array, or null if not found. */
-export async function loadYDocState(docId: string): Promise<Uint8Array | null> {
+export interface YDocStateRecord {
+  state: Uint8Array;
+  version: number;
+}
+
+/** Load Yjs state plus optimistic concurrency version. */
+export async function loadYDocRecord(
+  docId: string,
+): Promise<YDocStateRecord | null> {
   await ensureTable();
   const client = getDbExec();
   const { rows } = await client.execute({
-    sql: `SELECT yjs_state FROM _collab_docs WHERE doc_id = ?`,
+    sql: `SELECT yjs_state, version FROM _collab_docs WHERE doc_id = ?`,
     args: [docId],
   });
   if (rows.length === 0) return null;
-  return base64ToUint8Array(rows[0].yjs_state as string);
+  return {
+    state: base64ToUint8Array(rows[0].yjs_state as string),
+    version: Number(rows[0].version ?? 0),
+  };
+}
+
+/** Load Yjs state as Uint8Array, or null if not found. */
+export async function loadYDocState(docId: string): Promise<Uint8Array | null> {
+  const record = await loadYDocRecord(docId);
+  return record?.state ?? null;
+}
+
+/** Save only if the stored row still has the version the caller merged from. */
+export async function trySaveYDocState(
+  docId: string,
+  state: Uint8Array,
+  textSnapshot: string,
+  expectedVersion: number | null,
+): Promise<boolean> {
+  await ensureTable();
+  const client = getDbExec();
+  const b64 = uint8ArrayToBase64(state);
+  const nowExpr = isPostgres() ? "NOW()::text" : "datetime('now')";
+  if (expectedVersion === null) {
+    const result = await client.execute({
+      sql: isPostgres()
+        ? `INSERT INTO _collab_docs (doc_id, yjs_state, text_snapshot, version, updated_at) VALUES (?, ?, ?, 0, ${nowExpr}) ON CONFLICT (doc_id) DO NOTHING`
+        : `INSERT OR IGNORE INTO _collab_docs (doc_id, yjs_state, text_snapshot, version, updated_at) VALUES (?, ?, ?, 0, ${nowExpr})`,
+      args: [docId, b64, textSnapshot],
+    });
+    return result.rowsAffected > 0;
+  }
+
+  const result = await client.execute({
+    sql: `UPDATE _collab_docs SET yjs_state = ?, text_snapshot = ?, version = version + 1, updated_at = ${nowExpr} WHERE doc_id = ? AND version = ?`,
+    args: [b64, textSnapshot, docId, expectedVersion],
+  });
+  return result.rowsAffected > 0;
 }
 
 /** Save Yjs state (Uint8Array) and a plain-text snapshot. */
@@ -49,11 +101,23 @@ export async function saveYDocState(
   const client = getDbExec();
   const b64 = uint8ArrayToBase64(state);
   const nowExpr = isPostgres() ? "NOW()::text" : "datetime('now')";
-  await client.execute({
+  const updated = await client.execute({
+    sql: `UPDATE _collab_docs SET yjs_state = ?, text_snapshot = ?, version = version + 1, updated_at = ${nowExpr} WHERE doc_id = ?`,
+    args: [b64, textSnapshot, docId],
+  });
+  if (updated.rowsAffected > 0) return;
+
+  const inserted = await client.execute({
     sql: isPostgres()
-      ? `INSERT INTO _collab_docs (doc_id, yjs_state, text_snapshot, updated_at) VALUES (?, ?, ?, ${nowExpr}) ON CONFLICT (doc_id) DO UPDATE SET yjs_state = EXCLUDED.yjs_state, text_snapshot = EXCLUDED.text_snapshot, updated_at = EXCLUDED.updated_at`
-      : `INSERT OR REPLACE INTO _collab_docs (doc_id, yjs_state, text_snapshot, updated_at) VALUES (?, ?, ?, ${nowExpr})`,
+      ? `INSERT INTO _collab_docs (doc_id, yjs_state, text_snapshot, version, updated_at) VALUES (?, ?, ?, 0, ${nowExpr}) ON CONFLICT (doc_id) DO NOTHING`
+      : `INSERT OR IGNORE INTO _collab_docs (doc_id, yjs_state, text_snapshot, version, updated_at) VALUES (?, ?, ?, 0, ${nowExpr})`,
     args: [docId, b64, textSnapshot],
+  });
+  if (inserted.rowsAffected > 0) return;
+
+  await client.execute({
+    sql: `UPDATE _collab_docs SET yjs_state = ?, text_snapshot = ?, version = version + 1, updated_at = ${nowExpr} WHERE doc_id = ?`,
+    args: [b64, textSnapshot, docId],
   });
 }
 

--- a/packages/core/src/collab/ydoc-manager.ts
+++ b/packages/core/src/collab/ydoc-manager.ts
@@ -3,7 +3,12 @@
  */
 
 import * as Y from "yjs";
-import { loadYDocState, saveYDocState } from "./storage.js";
+import {
+  loadYDocRecord,
+  loadYDocState,
+  saveYDocState,
+  trySaveYDocState,
+} from "./storage.js";
 import { applyTextToYDoc, initYDocWithText } from "./text-to-yjs.js";
 import { searchAndReplaceInYXml, extractTextFromYXml } from "./xml-ops.js";
 import {
@@ -25,6 +30,7 @@ interface CacheEntry {
 }
 
 const _cache = new Map<string, CacheEntry>();
+const _writeLocks = new Map<string, Promise<void>>();
 
 function evictIfNeeded(): void {
   if (_cache.size <= MAX_CACHE) return;
@@ -42,6 +48,60 @@ function evictIfNeeded(): void {
     entry?.doc.destroy();
     _cache.delete(oldest);
   }
+}
+
+async function withDocWriteLock<T>(
+  docId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = _writeLocks.get(docId) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const chained = previous.catch(() => {}).then(() => current);
+  _writeLocks.set(docId, chained);
+
+  await previous.catch(() => {});
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (_writeLocks.get(docId) === chained) {
+      _writeLocks.delete(docId);
+    }
+  }
+}
+
+async function applyStoredState(docId: string, doc: Y.Doc): Promise<void> {
+  const stored = await loadYDocState(docId);
+  if (stored && stored.length > 0) {
+    Y.applyUpdate(doc, stored);
+  }
+}
+
+async function persistMergedState(
+  docId: string,
+  doc: Y.Doc,
+  getTextSnapshot: () => string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const latest = await loadYDocRecord(docId);
+    if (latest?.state && latest.state.length > 0) {
+      Y.applyUpdate(doc, latest.state);
+    }
+
+    const saved = await trySaveYDocState(
+      docId,
+      Y.encodeStateAsUpdate(doc),
+      getTextSnapshot(),
+      latest?.version ?? null,
+    );
+    if (saved) return;
+  }
+
+  await applyStoredState(docId, doc);
+  await saveYDocState(docId, Y.encodeStateAsUpdate(doc), getTextSnapshot());
 }
 
 /**
@@ -74,14 +134,17 @@ export async function applyUpdate(
   update: Uint8Array,
   requestSource?: string,
 ): Promise<void> {
-  const doc = await getDoc(docId);
-  Y.applyUpdate(doc, update);
+  return withDocWriteLock(docId, async () => {
+    const doc = await getDoc(docId);
+    await applyStoredState(docId, doc);
+    Y.applyUpdate(doc, update);
 
-  const state = Y.encodeStateAsUpdate(doc);
-  const text = doc.getText(DEFAULT_FIELD).toString();
-  await saveYDocState(docId, state, text);
+    await persistMergedState(docId, doc, () =>
+      doc.getText(DEFAULT_FIELD).toString(),
+    );
 
-  emitCollabUpdate(docId, uint8ArrayToBase64(update), requestSource);
+    emitCollabUpdate(docId, uint8ArrayToBase64(update), requestSource);
+  });
 }
 
 /**
@@ -96,19 +159,22 @@ export async function applyText(
   fieldName: string = DEFAULT_FIELD,
   requestSource?: string,
 ): Promise<string> {
-  const doc = await getDoc(docId);
-  const update = applyTextToYDoc(doc, fieldName, newText, "server");
+  return withDocWriteLock(docId, async () => {
+    const doc = await getDoc(docId);
+    await applyStoredState(docId, doc);
+    const update = applyTextToYDoc(doc, fieldName, newText, "server");
 
-  if (update.length === 0) {
+    if (update.length === 0) {
+      return doc.getText(fieldName).toString();
+    }
+
+    await persistMergedState(docId, doc, () =>
+      doc.getText(fieldName).toString(),
+    );
+
+    emitCollabUpdate(docId, uint8ArrayToBase64(update), requestSource);
     return doc.getText(fieldName).toString();
-  }
-
-  const state = Y.encodeStateAsUpdate(doc);
-  const text = doc.getText(fieldName).toString();
-  await saveYDocState(docId, state, text);
-
-  emitCollabUpdate(docId, uint8ArrayToBase64(update), requestSource);
-  return text;
+  });
 }
 
 /**
@@ -123,34 +189,34 @@ export async function searchAndReplace(
   replace: string,
   requestSource?: string,
 ): Promise<{ found: boolean; update: Uint8Array }> {
-  const doc = await getDoc(docId);
-  const fragment = doc.getXmlFragment("default");
+  return withDocWriteLock(docId, async () => {
+    const doc = await getDoc(docId);
+    await applyStoredState(docId, doc);
+    const fragment = doc.getXmlFragment("default");
 
-  // Capture the update produced by the transaction
-  let update: Uint8Array = new Uint8Array(0);
-  const handler = (u: Uint8Array) => {
-    update = u;
-  };
-  doc.on("update", handler);
+    // Capture the update produced by the transaction
+    let update: Uint8Array = new Uint8Array(0);
+    const handler = (u: Uint8Array) => {
+      update = u;
+    };
+    doc.on("update", handler);
 
-  let found = false;
-  doc.transact(() => {
-    found = searchAndReplaceInYXml(fragment, find, replace);
-  }, "agent");
+    let found = false;
+    doc.transact(() => {
+      found = searchAndReplaceInYXml(fragment, find, replace);
+    }, "agent");
 
-  doc.off("update", handler);
+    doc.off("update", handler);
 
-  if (!found || update.length === 0) {
-    return { found: false, update: new Uint8Array(0) };
-  }
+    if (!found || update.length === 0) {
+      return { found: false, update: new Uint8Array(0) };
+    }
 
-  // Persist and emit
-  const state = Y.encodeStateAsUpdate(doc);
-  const textSnapshot = extractTextFromYXml(fragment);
-  await saveYDocState(docId, state, textSnapshot);
-  emitCollabUpdate(docId, uint8ArrayToBase64(update), requestSource);
+    await persistMergedState(docId, doc, () => extractTextFromYXml(fragment));
+    emitCollabUpdate(docId, uint8ArrayToBase64(update), requestSource);
 
-  return { found: true, update };
+    return { found: true, update };
+  });
 }
 
 /**
@@ -161,6 +227,7 @@ export async function getText(
   fieldName: string = DEFAULT_FIELD,
 ): Promise<string> {
   const doc = await getDoc(docId);
+  await applyStoredState(docId, doc);
   return doc.getText(fieldName).toString();
 }
 
@@ -169,6 +236,7 @@ export async function getText(
  */
 export async function getState(docId: string): Promise<Uint8Array> {
   const doc = await getDoc(docId);
+  await applyStoredState(docId, doc);
   return Y.encodeStateAsUpdate(doc);
 }
 
@@ -180,6 +248,7 @@ export async function getIncUpdate(
   clientStateVector: Uint8Array,
 ): Promise<Uint8Array> {
   const doc = await getDoc(docId);
+  await applyStoredState(docId, doc);
   return Y.encodeStateAsUpdate(doc, clientStateVector);
 }
 
@@ -192,15 +261,17 @@ export async function seedFromText(
   text: string,
   fieldName: string = DEFAULT_FIELD,
 ): Promise<void> {
-  const existing = await loadYDocState(docId);
-  if (existing && existing.length > 0) return; // Already seeded
+  return withDocWriteLock(docId, async () => {
+    const existing = await loadYDocState(docId);
+    if (existing && existing.length > 0) return; // Already seeded
 
-  const { doc, state } = initYDocWithText(fieldName, text);
-  await saveYDocState(docId, state, text);
+    const { doc, state } = initYDocWithText(fieldName, text);
+    await saveYDocState(docId, state, text);
 
-  // Cache the doc
-  evictIfNeeded();
-  _cache.set(docId, { doc, lastAccess: Date.now() });
+    // Cache the doc
+    evictIfNeeded();
+    _cache.set(docId, { doc, lastAccess: Date.now() });
+  });
 }
 
 // ─── Structured JSON Operations ─────────────────────────────────────
@@ -216,15 +287,17 @@ export async function applyJson(
   type: "map" | "array" = "map",
   requestSource?: string,
 ): Promise<void> {
-  const doc = await getDoc(docId);
-  const update = applyJsonDiff(doc, fieldName, newJson, "server");
+  return withDocWriteLock(docId, async () => {
+    const doc = await getDoc(docId);
+    await applyStoredState(docId, doc);
+    const update = applyJsonDiff(doc, fieldName, newJson, "server");
 
-  if (update.length === 0) return;
+    if (update.length === 0) return;
 
-  const state = Y.encodeStateAsUpdate(doc);
-  await saveYDocState(docId, state, JSON.stringify(newJson));
+    await persistMergedState(docId, doc, () => JSON.stringify(newJson));
 
-  emitCollabUpdate(docId, uint8ArrayToBase64(update), requestSource);
+    emitCollabUpdate(docId, uint8ArrayToBase64(update), requestSource);
+  });
 }
 
 /**
@@ -236,16 +309,19 @@ export async function applyPatchOps(
   fieldName: string = "data",
   requestSource?: string,
 ): Promise<void> {
-  const doc = await getDoc(docId);
-  const update = applyJsonPatch(doc, fieldName, ops, "server");
+  return withDocWriteLock(docId, async () => {
+    const doc = await getDoc(docId);
+    await applyStoredState(docId, doc);
+    const update = applyJsonPatch(doc, fieldName, ops, "server");
 
-  if (update.length === 0) return;
+    if (update.length === 0) return;
 
-  const state = Y.encodeStateAsUpdate(doc);
-  const json = yDocToJson(doc, fieldName);
-  await saveYDocState(docId, state, JSON.stringify(json));
+    await persistMergedState(docId, doc, () =>
+      JSON.stringify(yDocToJson(doc, fieldName)),
+    );
 
-  emitCollabUpdate(docId, uint8ArrayToBase64(update), requestSource);
+    emitCollabUpdate(docId, uint8ArrayToBase64(update), requestSource);
+  });
 }
 
 /**
@@ -256,6 +332,7 @@ export async function getJson(
   fieldName: string = "data",
 ): Promise<any> {
   const doc = await getDoc(docId);
+  await applyStoredState(docId, doc);
   return yDocToJson(doc, fieldName);
 }
 
@@ -269,15 +346,17 @@ export async function seedFromJson(
   fieldName: string = "data",
   type: "map" | "array" = "map",
 ): Promise<void> {
-  const existing = await loadYDocState(docId);
-  if (existing && existing.length > 0) return; // Already seeded
+  return withDocWriteLock(docId, async () => {
+    const existing = await loadYDocState(docId);
+    if (existing && existing.length > 0) return; // Already seeded
 
-  const { doc, state } = initYDocWithJson(fieldName, json, type);
-  await saveYDocState(docId, state, JSON.stringify(json));
+    const { doc, state } = initYDocWithJson(fieldName, json, type);
+    await saveYDocState(docId, state, JSON.stringify(json));
 
-  // Cache the doc
-  evictIfNeeded();
-  _cache.set(docId, { doc, lastAccess: Date.now() });
+    // Cache the doc
+    evictIfNeeded();
+    _cache.set(docId, { doc, lastAccess: Date.now() });
+  });
 }
 
 /**

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -91,21 +91,22 @@ cd templates/content && pnpm action <name> [args]
 
 ### Document Operations
 
-| Action                         | Args                                                                                     | Purpose                                                                               |
-| ------------------------------ | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `list-documents`               | `[--format json]`                                                                        | List document metadata/tree; no full bodies                                           |
-| `search-documents`             | `--query <text> [--format json]`                                                         | Search by title/content and return snippets                                           |
-| `get-document`                 | `--id <id> [--format json]`                                                              | Get a single document with content                                                    |
-| `pull-document`                | `--id <id> [--format markdown\|text]`                                                    | Collab-aware "ingest the final" read                                                  |
-| `create-document`              | `--title <text> [--content] [--parentId] [--icon]`                                       | Create a new document                                                                 |
-| `edit-document`                | `--id <id> --find <text> --replace <text>`                                               | Surgical text edit (preferred for modifications)                                      |
-| `edit-document`                | `--id <id> --edits <json>`                                                               | Batch surgical text edits                                                             |
-| `update-document`              | `--id <id> [--title] [--content] [--icon]`                                               | Full rewrite of document fields                                                       |
-| `set-document-discoverability` | `--id <id> --hideFromSearch true\|false [--includeChildren true\|false]`                 | Hide/show an org-accessible document in Organization/search while keeping link access |
-| `move-document`                | `--id <id> [--parentId] [--position]`                                                    | Move or reorder a document in the page tree                                           |
-| `delete-document`              | `--id <id>`                                                                              | Delete with recursive children                                                        |
-| `set-image-alt-text`           | `--documentId <id> --imageUrl <url> --altText <text> [--imageOccurrence <n>]`            | Set generated or edited alt text for a specific image                                 |
-| `transcribe-media`             | `--documentId <id> --mediaUrl <url> --mediaType audio\|video [--placeholderText <text>]` | Transcribe audio/video media into the Transcript toggle beneath the block             |
+| Action                         | Args                                                                                     | Purpose                                                                                                     |
+| ------------------------------ | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `list-documents`               | `[--format json]`                                                                        | List document metadata/tree; no full bodies                                                                 |
+| `search-documents`             | `--query <text> [--format json]`                                                         | Search by title/content and return snippets                                                                 |
+| `get-document`                 | `--id <id> [--format json]`                                                              | Get a single document with content                                                                          |
+| `pull-document`                | `--id <id> [--format markdown\|text]`                                                    | Collab-aware "ingest the final" read                                                                        |
+| `export-document`              | `--id <id> [--format pdf\|markdown\|html]`                                               | Export a page; PDF returns print-ready HTML for Save as PDF, Markdown/HTML return downloadable file content |
+| `create-document`              | `--title <text> [--content] [--parentId] [--icon]`                                       | Create a new document                                                                                       |
+| `edit-document`                | `--id <id> --find <text> --replace <text>`                                               | Surgical text edit (preferred for modifications)                                                            |
+| `edit-document`                | `--id <id> --edits <json>`                                                               | Batch surgical text edits                                                                                   |
+| `update-document`              | `--id <id> [--title] [--content] [--icon]`                                               | Full rewrite of document fields                                                                             |
+| `set-document-discoverability` | `--id <id> --hideFromSearch true\|false [--includeChildren true\|false]`                 | Hide/show an org-accessible document in Organization/search while keeping link access                       |
+| `move-document`                | `--id <id> [--parentId] [--position]`                                                    | Move or reorder a document in the page tree                                                                 |
+| `delete-document`              | `--id <id>`                                                                              | Delete with recursive children                                                                              |
+| `set-image-alt-text`           | `--documentId <id> --imageUrl <url> --altText <text> [--imageOccurrence <n>]`            | Set generated or edited alt text for a specific image                                                       |
+| `transcribe-media`             | `--documentId <id> --mediaUrl <url> --mediaType audio\|video [--placeholderText <text>]` | Transcribe audio/video media into the Transcript toggle beneath the block                                   |
 
 **`pull-document` is the collab-aware "ingest the final" read** — prefer it over
 `get-document` for external ingest (another app, an external coding agent over
@@ -123,6 +124,15 @@ skipped. It is GET + read-only + public-agent exposed (`requiresAuth: true`),
 returns `{ id, title, content, format, deepLink }`, and surfaces an
 "Open document" deep link for external agents. Use `--format text` for a
 plain-text strip of the markdown.
+
+**`export-document` is the page export action.** The UI exposes it from the
+page toolbar export menu. Use `--format pdf` when the user wants a PDF; the
+action returns a print-ready HTML document and the UI opens the print dialog so
+the user can choose Save as PDF. Use `--format markdown` for an exact `.md`
+export that includes the page title as the first H1, or `--format html` for a
+standalone readable HTML file. Word/Google Docs exports are not native in this
+template; use Markdown or HTML unless the user explicitly asks for a heavier
+conversion/integration workflow.
 
 ### Notion Integration
 

--- a/templates/content/actions/export-document.ts
+++ b/templates/content/actions/export-document.ts
@@ -1,0 +1,65 @@
+import { defineAction } from "@agent-native/core";
+import { resolveAccess } from "@agent-native/core/sharing";
+import { buildDeepLink } from "@agent-native/core/server";
+import { z } from "zod";
+import { buildDocumentExport } from "../shared/document-export.js";
+import "../server/db/index.js";
+
+export default defineAction({
+  description:
+    "Export a Content document as PDF-ready HTML, Markdown, or standalone HTML. PDF exports are print-ready HTML intended for the browser print dialog.",
+  schema: z.object({
+    id: z.string().describe("Document ID (required)"),
+    format: z
+      .enum(["pdf", "markdown", "html"])
+      .default("pdf")
+      .describe("Export format: pdf, markdown, or html."),
+    title: z
+      .string()
+      .max(500)
+      .optional()
+      .describe("Optional unsaved editor title to export."),
+    content: z
+      .string()
+      .max(2_000_000)
+      .optional()
+      .describe("Optional unsaved editor markdown content to export."),
+  }),
+  readOnly: true,
+  publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  run: async ({ id, format, title, content }) => {
+    const access = await resolveAccess("document", id);
+    if (!access) throw new Error(`Document "${id}" not found`);
+
+    const doc = access.resource;
+    const payload = buildDocumentExport({
+      id: doc.id,
+      title: title ?? doc.title,
+      content: content ?? doc.content,
+      updatedAt: doc.updatedAt,
+      format,
+    });
+
+    return {
+      ...payload,
+      deepLink: buildDeepLink({
+        app: "content",
+        view: "editor",
+        params: { documentId: doc.id },
+      }),
+    };
+  },
+  link: ({ result }) => {
+    const id = (result as { id?: string } | null)?.id;
+    if (!id) return null;
+    return {
+      url: buildDeepLink({
+        app: "content",
+        view: "editor",
+        params: { documentId: id },
+      }),
+      label: "Open document",
+      view: "editor",
+    };
+  },
+});

--- a/templates/content/actions/transcribe-media.ts
+++ b/templates/content/actions/transcribe-media.ts
@@ -15,11 +15,10 @@ import {
 } from "@agent-native/core/server";
 import { assertAccess } from "@agent-native/core/sharing";
 import { transcribeWithBuilder } from "@agent-native/core/transcription/builder";
-import { eq } from "drizzle-orm";
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
 import { z } from "zod";
-import { getDb, schema } from "../server/db/index.js";
+import "../server/db/index.js";
 import updateDocument from "./update-document.js";
 import {
   assertAudioHasAudibleSignal,
@@ -431,13 +430,8 @@ async function applyTranscriptToDocument({
   placeholderText?: string;
   transcript: string;
 }): Promise<{ sqlUpdated: boolean; collabUpdated: boolean }> {
-  const db = getDb();
-  const [freshDoc] = await db
-    .select({ content: schema.documents.content })
-    .from(schema.documents)
-    .where(eq(schema.documents.id, documentId))
-    .limit(1);
-  if (!freshDoc) throw new Error(`Document "${documentId}" not found`);
+  const freshAccess = await assertAccess("document", documentId, "editor");
+  const freshDoc = freshAccess.resource;
 
   const content = freshDoc.content ?? "";
   let nextContent: string | null = null;

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -421,13 +421,18 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
       scrollContainerRef={scrollContainerRef}
     />
   );
+  const exportTitle = isInitializedRef.current ? localTitle : document.title;
+  const exportContent = isInitializedRef.current
+    ? localContent
+    : document.content;
 
   return (
-    <div className="relative flex-1 flex min-h-0">
+    <div className="relative flex-1 flex min-h-0" data-document-print-root>
       <div className="flex-1 flex flex-col min-h-0">
         <DocumentToolbar
           documentId={documentId}
-          documentTitle={localTitle || document.title}
+          documentTitle={exportTitle}
+          documentContent={exportContent}
           activeUsers={activeUsers}
           agentPresent={agentPresent}
           agentActive={agentActive}
@@ -442,6 +447,7 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
         <div
           ref={scrollContainerRef}
           className="flex-1 min-h-0 overflow-auto flex flex-col"
+          data-document-print-scroll
         >
           <div className="shrink-0 w-full max-w-3xl mx-auto px-4 pt-14 pb-8 sm:px-8 md:px-16 md:pt-16 group/title">
             <div className="mb-1">
@@ -501,6 +507,7 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
               content={document.content}
               onChange={handleContentChange}
               ydoc={canEdit ? ydoc : null}
+              awareness={canEdit ? awareness : null}
               user={currentUser}
               editable={canEdit}
               onComment={canEdit ? handleComment : undefined}

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -3,9 +3,13 @@ import {
   IconArrowBarDown,
   IconArrowBarUp,
   IconAlertTriangle,
+  IconDownload,
   IconExternalLink,
+  IconFileTypeHtml,
+  IconFileTypePdf,
   IconLinkOff,
   IconLoader2,
+  IconMarkdown,
   IconSearch,
   IconFileText,
   IconPlus,
@@ -18,6 +22,13 @@ import {
   PopoverTrigger,
   PopoverContent,
 } from "@/components/ui/popover";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import {
   AgentToggleButton,
@@ -49,6 +60,63 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 
+type ExportFormat = "pdf" | "markdown" | "html";
+
+interface ExportDocumentResult {
+  filename: string;
+  mimeType: string;
+  content: string;
+  format: ExportFormat;
+  print: boolean;
+}
+
+function downloadExportFile(result: ExportDocumentResult) {
+  const blob = new Blob([result.content], { type: result.mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = window.document.createElement("a");
+  link.href = url;
+  link.download = result.filename;
+  window.document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function printExportHtml(result: ExportDocumentResult) {
+  const iframe = window.document.createElement("iframe");
+  iframe.setAttribute("aria-hidden", "true");
+  iframe.style.position = "fixed";
+  iframe.style.right = "0";
+  iframe.style.bottom = "0";
+  iframe.style.width = "0";
+  iframe.style.height = "0";
+  iframe.style.border = "0";
+  window.document.body.appendChild(iframe);
+
+  const frameWindow = iframe.contentWindow;
+  const frameDocument = frameWindow?.document;
+  if (!frameWindow || !frameDocument) {
+    iframe.remove();
+    throw new Error("Could not open the print preview.");
+  }
+
+  const cleanup = () => {
+    setTimeout(() => iframe.remove(), 500);
+  };
+
+  frameWindow.addEventListener("afterprint", cleanup, { once: true });
+  frameDocument.open();
+  frameDocument.write(result.content);
+  frameDocument.close();
+
+  window.setTimeout(() => {
+    frameWindow.focus();
+    frameWindow.print();
+  }, 100);
+
+  window.setTimeout(cleanup, 60_000);
+}
+
 function NotionIcon({ className }: { className?: string }) {
   return (
     <svg viewBox="0 0 100 100" className={cn("notion-logo-icon", className)}>
@@ -69,6 +137,7 @@ function NotionIcon({ className }: { className?: string }) {
 interface DocumentToolbarProps {
   documentId: string;
   documentTitle?: string;
+  documentContent?: string;
   activeUsers?: CollabUser[];
   agentPresent?: boolean;
   agentActive?: boolean;
@@ -81,6 +150,7 @@ interface DocumentToolbarProps {
 export function DocumentToolbar({
   documentId,
   documentTitle,
+  documentContent,
   activeUsers,
   agentPresent,
   agentActive,
@@ -104,6 +174,7 @@ export function DocumentToolbar({
   const setDocumentDiscoverability = useActionMutation(
     "set-document-discoverability",
   );
+  const exportDocument = useActionMutation("export-document");
 
   const createAndLink = useCreateAndLinkNotionPage(documentId);
 
@@ -333,6 +404,38 @@ export function DocumentToolbar({
     setOpen(false);
   };
 
+  const handleExport = useCallback(
+    async (format: ExportFormat) => {
+      try {
+        const result = (await exportDocument.mutateAsync({
+          id: documentId,
+          format,
+          title: documentTitle,
+          content: documentContent,
+        })) as ExportDocumentResult;
+
+        if (result.print) {
+          printExportHtml(result);
+          toast.success("Print dialog opened", {
+            description: "Choose Save as PDF to finish the export.",
+          });
+          return;
+        }
+
+        downloadExportFile(result);
+        toast.success(
+          `Exported ${format === "markdown" ? "Markdown" : "HTML"}`,
+        );
+      } catch (error) {
+        toast.error("Export failed", {
+          description:
+            error instanceof Error ? error.message : "Something went wrong",
+        });
+      }
+    },
+    [documentContent, documentId, documentTitle, exportDocument],
+  );
+
   return (
     <>
       <div
@@ -395,6 +498,52 @@ export function DocumentToolbar({
           onOpenChange={setHistoryOpen}
           canRestore={canEdit}
         />
+
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <button
+                  className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent disabled:opacity-50"
+                  disabled={exportDocument.isPending}
+                  aria-label="Export page"
+                >
+                  {exportDocument.isPending ? (
+                    <IconLoader2 size={16} className="animate-spin" />
+                  ) : (
+                    <IconDownload size={16} />
+                  )}
+                </button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>Export page</TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuGroup>
+              <DropdownMenuItem
+                disabled={exportDocument.isPending}
+                onSelect={() => void handleExport("pdf")}
+              >
+                <IconFileTypePdf className="mr-2 h-4 w-4" />
+                PDF
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={exportDocument.isPending}
+                onSelect={() => void handleExport("markdown")}
+              >
+                <IconMarkdown className="mr-2 h-4 w-4" />
+                Markdown
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={exportDocument.isPending}
+                onSelect={() => void handleExport("html")}
+              >
+                <IconFileTypeHtml className="mr-2 h-4 w-4" />
+                HTML
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
 
         {canEdit ? (
           <Popover open={open} onOpenChange={setOpen}>

--- a/templates/content/app/components/editor/SlashCommandMenu.test.ts
+++ b/templates/content/app/components/editor/SlashCommandMenu.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import {
+  parseSlashCommandQuery,
   parseInlineGeneratePrompt,
   shouldOpenGenerateOnSpace,
 } from "./SlashCommandMenu";
@@ -47,5 +48,19 @@ describe("space generate shortcut", () => {
     } finally {
       editor.destroy();
     }
+  });
+});
+
+describe("slash command menu trigger", () => {
+  it("opens for slash commands at the start of a block", () => {
+    expect(parseSlashCommandQuery("/")).toBe("");
+    expect(parseSlashCommandQuery("/heading")).toBe("heading");
+    expect(parseSlashCommandQuery("  /table")).toBe("table");
+  });
+
+  it("does not open for slashes embedded in normal prose", () => {
+    expect(parseSlashCommandQuery("hello/world")).toBeNull();
+    expect(parseSlashCommandQuery("hello /world")).toBeNull();
+    expect(parseSlashCommandQuery("open https://example.com/path")).toBeNull();
   });
 });

--- a/templates/content/app/components/editor/SlashCommandMenu.tsx
+++ b/templates/content/app/components/editor/SlashCommandMenu.tsx
@@ -78,6 +78,10 @@ export function shouldOpenGenerateOnSpace(editor: Editor) {
   return $from.parent.textContent.trim().length === 0;
 }
 
+export function parseSlashCommandQuery(textBeforeCursor: string) {
+  return textBeforeCursor.match(/^\s*\/([a-zA-Z0-9]*)$/)?.[1] ?? null;
+}
+
 const commands: CommandItem[] = [
   {
     title: "Text",
@@ -599,18 +603,26 @@ export function SlashCommandMenu({
     const handleTransaction = () => {
       const { state } = editor;
       const { from } = state.selection;
-      const textBefore = state.doc.textBetween(
-        Math.max(0, from - 20),
-        from,
-        "\n",
-      );
+      const { $from } = state.selection;
+      if (!$from.parent.isTextblock) {
+        if (isOpen) {
+          setIsOpen(false);
+          setIsTurnInto(false);
+          setQuery("");
+          slashPosRef.current = null;
+        }
+        return;
+      }
 
-      const slashMatch = textBefore.match(/\/([a-zA-Z0-9]*)$/);
+      const blockStart = $from.start();
+      const textBefore = state.doc.textBetween(blockStart, from, "\n");
+      const slashQuery = parseSlashCommandQuery(textBefore);
 
-      if (slashMatch) {
-        const slashStart = from - slashMatch[0].length;
+      if (slashQuery !== null) {
+        const slashIndex = textBefore.lastIndexOf("/");
+        const slashStart = blockStart + slashIndex;
         slashPosRef.current = slashStart;
-        setQuery(slashMatch[1]);
+        setQuery(slashQuery);
         setSelectedIndex(0);
 
         // Detect "turn into" mode: "/" is at start of a non-empty block
@@ -618,7 +630,7 @@ export function SlashCommandMenu({
         const parentNode = resolved.parent;
         const offsetInParent = resolved.parentOffset;
         const blockHasOtherContent =
-          parentNode.textContent.length > slashMatch[0].length;
+          parentNode.textContent.length > textBefore.length - slashIndex;
         const slashAtBlockStart = offsetInParent === 0;
         setIsTurnInto(slashAtBlockStart && blockHasOtherContent);
 

--- a/templates/content/app/components/editor/VisualEditor.markdown.test.ts
+++ b/templates/content/app/components/editor/VisualEditor.markdown.test.ts
@@ -16,6 +16,7 @@ import {
   uploadAndInsertAudioFiles,
   uploadAndInsertImageFiles,
   uploadAndInsertVideoFiles,
+  shouldApplyExternalContentSync,
   shouldSeedCollaborativeContent,
 } from "./VisualEditor";
 import { CodeBlock } from "./extensions/CodeBlockNode";
@@ -445,6 +446,40 @@ describe("VisualEditor markdown round-tripping", () => {
         fragmentLength: 1,
       }),
     ).toBe(false);
+  });
+
+  it("does not apply stale SQL snapshots over live collaborative edits", () => {
+    expect(
+      shouldApplyExternalContentSync({
+        collaborationActive: true,
+        hasLiveCollaborativeEdits: true,
+        docChanged: false,
+        content: "Older collaborator snapshot",
+        lastEmittedMarkdown: "Merged live content",
+        currentMarkdown: "Merged live content",
+        nextMarkdown: "Older collaborator snapshot",
+        editorFocused: false,
+        lastTypedAt: 0,
+        now: 10_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("still applies external content before collaborative edits begin", () => {
+    expect(
+      shouldApplyExternalContentSync({
+        collaborationActive: true,
+        hasLiveCollaborativeEdits: false,
+        docChanged: false,
+        content: "Pulled from Notion",
+        lastEmittedMarkdown: "",
+        currentMarkdown: "Saved body",
+        nextMarkdown: "Pulled from Notion",
+        editorFocused: false,
+        lastTypedAt: 0,
+        now: 10_000,
+      }),
+    ).toBe(true);
   });
 
   it("labels empty quote blocks with the quote placeholder", () => {

--- a/templates/content/app/components/editor/VisualEditor.tsx
+++ b/templates/content/app/components/editor/VisualEditor.tsx
@@ -557,8 +557,10 @@ interface VisualEditorProps {
   onChange: (markdown: string) => void;
   /** Yjs document for collaborative editing. */
   ydoc?: YDoc | null;
+  /** Shared awareness instance for collaborative cursors/presence. */
+  awareness?: Awareness | null;
   /** Current user info for cursor labels. */
-  user?: { name: string; color: string };
+  user?: { name: string; color: string; email?: string };
   editable?: boolean;
   /** Called when user selects text and clicks "Comment" in bubble toolbar. */
   onComment?: (quotedText: string, offsetTop: number) => void;
@@ -582,11 +584,52 @@ export function shouldSeedCollaborativeContent({
   return !!content.trim() && (fragmentLength === 0 || !semanticMarkdown);
 }
 
+export function shouldApplyExternalContentSync({
+  collaborationActive,
+  hasLiveCollaborativeEdits,
+  docChanged,
+  content,
+  lastEmittedMarkdown,
+  currentMarkdown,
+  nextMarkdown,
+  editorFocused,
+  lastTypedAt,
+  now,
+}: {
+  collaborationActive: boolean;
+  hasLiveCollaborativeEdits: boolean;
+  docChanged: boolean;
+  content: string;
+  lastEmittedMarkdown: string;
+  currentMarkdown: string;
+  nextMarkdown: string;
+  editorFocused: boolean;
+  lastTypedAt: number;
+  now: number;
+}): boolean {
+  if (currentMarkdown === nextMarkdown) return false;
+
+  // Own-save echo from SQL polling.
+  if (content === lastEmittedMarkdown) return false;
+
+  // Once Yjs has live edits, ordinary SQL refetches are only snapshots. Applying
+  // them with setContent() would turn a stale whole-document save into a Yjs
+  // replacement and can revert collaborators' newer CRDT updates.
+  if (collaborationActive && hasLiveCollaborativeEdits && !docChanged) {
+    return false;
+  }
+
+  const typedRecently = now - lastTypedAt < 2000;
+  if (editorFocused && typedRecently && !docChanged) return false;
+
+  return true;
+}
+
 interface VisualEditorExtensionOptions {
   documentId?: string;
   ydoc?: YDoc | null;
   localAwareness?: Awareness | null;
-  user?: { name: string; color: string } | null;
+  user?: { name: string; color: string; email?: string } | null;
   onImageComment?: (quotedText: string, offsetTop: number) => void;
   onJoinTitle?: (text: string) => void;
 }
@@ -997,6 +1040,7 @@ export function VisualEditor({
   content,
   onChange,
   ydoc,
+  awareness,
   user,
   editable = true,
   onComment,
@@ -1015,30 +1059,34 @@ export function VisualEditor({
   // agent edit can still apply when the user is idle but happens to have
   // the editor focused — without yanking in-progress typing.
   const lastTypedAtRef = useRef<number>(0);
+  const hasLiveCollaborativeEditsRef = useRef(false);
 
-  // Create Awareness instance locally (same module as CollaborationCursor uses)
-  const localAwareness = useMemo(() => {
+  // Reuse the synced Awareness instance when provided; fall back for tests or
+  // non-template embedders that only pass a Y.Doc.
+  const fallbackAwareness = useMemo(() => {
+    if (awareness) return null;
     if (!ydoc) return null;
     const a = new Awareness(ydoc);
     if (user) {
       a.setLocalStateField("user", user);
     }
     return a;
-  }, [ydoc]);
+  }, [awareness, ydoc]);
+  const localAwareness = awareness ?? fallbackAwareness;
 
   // Update user info when it changes
   useEffect(() => {
     if (localAwareness && user) {
       localAwareness.setLocalStateField("user", user);
     }
-  }, [localAwareness, user?.name, user?.color]);
+  }, [localAwareness, user?.name, user?.email, user?.color]);
 
   // Clean up awareness on unmount
   useEffect(() => {
     return () => {
-      localAwareness?.destroy();
+      fallbackAwareness?.destroy();
     };
-  }, [localAwareness]);
+  }, [fallbackAwareness]);
 
   const extensions = useMemo(
     () =>
@@ -1055,6 +1103,7 @@ export function VisualEditor({
       ydoc,
       localAwareness,
       user?.name,
+      user?.email,
       user?.color,
       onComment,
       onJoinTitle,
@@ -1169,6 +1218,7 @@ export function VisualEditor({
     editable,
     onUpdate: ({ editor }) => {
       if (isSettingContent.current) return;
+      if (ydoc) hasLiveCollaborativeEditsRef.current = true;
       lastTypedAtRef.current = Date.now();
       try {
         const md = (editor.storage as any).markdown.getMarkdown();
@@ -1217,11 +1267,8 @@ export function VisualEditor({
   }, [editor, ydoc, content, documentId]);
 
   // Sync content from outside (e.g. Notion pull, update-document action).
-  // When ydoc is bound, applying content through the editor via setContent
-  // propagates through TipTap's Collaboration extension to Y.XmlFragment,
-  // which then flows to the server and other clients via the collab update
-  // channel. We detect echoes of our own saves via lastEmittedRef to avoid
-  // clobbering user edits in progress.
+  // In collab mode this is only safe before live Yjs edits have started:
+  // after that, SQL content is a lagging snapshot and Yjs owns the document.
   useEffect(() => {
     if (!editor || editor.isDestroyed) return;
     const docChanged = documentId !== prevDocIdRef.current;
@@ -1231,19 +1278,22 @@ export function VisualEditor({
       (editor.storage as any).markdown.getMarkdown(),
     );
     const normalizedNext = serializeEditorToNfm(nextEditorContent);
-    if (currentMd === normalizedNext) return;
-
-    // If the incoming content matches what we just emitted, it's our own
-    // save echoing back via the poll — skip to avoid a needless re-render.
-    if (content === lastEmittedRef.current) return;
-
-    // Skip sync while the user is actively typing (unless the doc switched)
-    // so we don't yank their in-progress edits. We only block if the user
-    // has TYPED in the last 2s — having focus alone isn't enough, otherwise
-    // a Notion pull that happens while the user has the editor focused but
-    // idle would leave them stuck on the pre-pull content.
-    const typedRecently = Date.now() - lastTypedAtRef.current < 2000;
-    if (editor.isFocused && typedRecently && !docChanged) return;
+    if (
+      !shouldApplyExternalContentSync({
+        collaborationActive: !!ydoc,
+        hasLiveCollaborativeEdits: hasLiveCollaborativeEditsRef.current,
+        docChanged,
+        content,
+        lastEmittedMarkdown: lastEmittedRef.current,
+        currentMarkdown: currentMd,
+        nextMarkdown: normalizedNext,
+        editorFocused: editor.isFocused,
+        lastTypedAt: lastTypedAtRef.current,
+        now: Date.now(),
+      })
+    ) {
+      return;
+    }
 
     // Defer to a microtask so we don't trigger flushSync during a React
     // render — TipTap's setContent dispatches PM transactions that may

--- a/templates/content/app/global.css
+++ b/templates/content/app/global.css
@@ -1908,6 +1908,69 @@ audio.media-block__content {
   background: hsl(210 100% 52% / 0.2);
 }
 
+@media print {
+  @page {
+    margin: 0.65in;
+  }
+
+  body:has([data-document-print-root]) {
+    background: #fff !important;
+    color: #111 !important;
+  }
+
+  body:has([data-document-print-root]) * {
+    visibility: hidden !important;
+  }
+
+  body:has([data-document-print-root]) [data-document-print-root],
+  body:has([data-document-print-root]) [data-document-print-root] * {
+    visibility: visible !important;
+  }
+
+  [data-document-print-root] {
+    position: absolute !important;
+    inset: 0 !important;
+    display: block !important;
+    width: 100% !important;
+    min-height: auto !important;
+    background: #fff !important;
+    color: #111 !important;
+  }
+
+  [data-document-print-root] > div,
+  [data-document-print-scroll] {
+    display: block !important;
+    height: auto !important;
+    min-height: auto !important;
+    overflow: visible !important;
+  }
+
+  [data-document-print-root] [class*="absolute"],
+  [data-document-print-root] .media-block__toolbar,
+  [data-document-print-root] .media-block__overlay,
+  [data-document-print-root] .media-block__resize-handle,
+  [data-document-print-root] .media-block__alt-badge,
+  [data-document-print-root] .ProseMirror-selectednode::selection {
+    display: none !important;
+  }
+
+  [data-document-print-root] textarea,
+  [data-document-print-root] .notion-editor {
+    color: #111 !important;
+  }
+
+  [data-document-print-root] .notion-editor {
+    min-height: auto !important;
+  }
+
+  [data-document-print-root] pre,
+  [data-document-print-root] blockquote,
+  [data-document-print-root] img,
+  [data-document-print-root] table {
+    break-inside: avoid;
+  }
+}
+
 /* ===== Bubble Toolbar ===== */
 .bubble-toolbar {
   display: flex;

--- a/templates/content/shared/document-export.spec.ts
+++ b/templates/content/shared/document-export.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDocumentExport,
+  exportFilename,
+  markdownWithTitle,
+} from "./document-export";
+
+describe("document export", () => {
+  it("creates stable filenames from page titles", () => {
+    expect(exportFilename("Q2 Launch / PRD", "markdown")).toBe(
+      "q2-launch-prd.md",
+    );
+    expect(exportFilename("", "pdf")).toBe("untitled.pdf");
+  });
+
+  it("adds the page title to markdown without duplicating an existing H1", () => {
+    expect(markdownWithTitle("Roadmap", "First paragraph")).toBe(
+      "# Roadmap\n\nFirst paragraph\n",
+    );
+    expect(markdownWithTitle("Roadmap", "# Roadmap\n\nFirst paragraph")).toBe(
+      "# Roadmap\n\nFirst paragraph\n",
+    );
+  });
+
+  it("escapes user-authored HTML in portable HTML exports", () => {
+    const exportPayload = buildDocumentExport({
+      id: "doc_123",
+      title: "Launch <Plan>",
+      content: "<script>alert('x')</script>\n\n**Ship it**",
+      format: "html",
+    });
+
+    expect(exportPayload.filename).toBe("launch-plan.html");
+    expect(exportPayload.content).toContain("Launch &lt;Plan&gt;");
+    expect(exportPayload.content).toContain("&lt;script&gt;");
+    expect(exportPayload.content).not.toContain("<script>");
+    expect(exportPayload.content).toContain("<strong>Ship it</strong>");
+  });
+
+  it("strips unsafe link targets from HTML exports", () => {
+    const exportPayload = buildDocumentExport({
+      id: "doc_123",
+      title: "Links",
+      content: "[bad](javascript:alert(1)) ![bad](javascript:alert(1))",
+      format: "html",
+    });
+
+    expect(exportPayload.content).toContain('<a href="#">bad</a>');
+    expect(exportPayload.content).toContain('<img src="#" alt="bad" />');
+    expect(exportPayload.content).not.toContain("javascript:");
+  });
+
+  it("marks PDF exports as print-ready HTML with a PDF filename", () => {
+    const exportPayload = buildDocumentExport({
+      id: "doc_123",
+      title: "Board Notes",
+      content: "Agenda",
+      format: "pdf",
+    });
+
+    expect(exportPayload.filename).toBe("board-notes.pdf");
+    expect(exportPayload.mimeType).toBe("text/html;charset=utf-8");
+    expect(exportPayload.print).toBe(true);
+    expect(exportPayload.content).toContain("@media print");
+  });
+});

--- a/templates/content/shared/document-export.ts
+++ b/templates/content/shared/document-export.ts
@@ -1,0 +1,377 @@
+export type DocumentExportFormat = "pdf" | "markdown" | "html";
+
+export interface DocumentExportInput {
+  id: string;
+  title?: string | null;
+  content?: string | null;
+  updatedAt?: string | null;
+  format: DocumentExportFormat;
+}
+
+export interface DocumentExportPayload {
+  id: string;
+  title: string;
+  format: DocumentExportFormat;
+  filename: string;
+  mimeType: string;
+  content: string;
+  print: boolean;
+}
+
+const EXTENSION_BY_FORMAT: Record<DocumentExportFormat, string> = {
+  pdf: "pdf",
+  markdown: "md",
+  html: "html",
+};
+
+const MIME_BY_FORMAT: Record<DocumentExportFormat, string> = {
+  pdf: "text/html;charset=utf-8",
+  markdown: "text/markdown;charset=utf-8",
+  html: "text/html;charset=utf-8",
+};
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function safeExportUrl(value: string, kind: "link" | "image"): string {
+  const normalized = value.replace(/&amp;/g, "&").trim();
+  const lower = normalized.toLowerCase();
+
+  if (
+    lower.startsWith("#") ||
+    lower.startsWith("/") ||
+    lower.startsWith("./") ||
+    lower.startsWith("../")
+  ) {
+    return value;
+  }
+
+  if (kind === "image" && lower.startsWith("data:image/")) return value;
+
+  try {
+    const url = new URL(normalized);
+    const allowed =
+      kind === "image"
+        ? url.protocol === "http:" || url.protocol === "https:"
+        : ["http:", "https:", "mailto:", "tel:"].includes(url.protocol);
+    return allowed ? value : "#";
+  } catch {
+    return "#";
+  }
+}
+
+function normalizeTitle(title: string | null | undefined): string {
+  const normalized = (title ?? "").replace(/\s+/g, " ").trim();
+  return normalized || "Untitled";
+}
+
+export function exportFilename(
+  title: string | null | undefined,
+  format: DocumentExportFormat,
+): string {
+  const base = normalizeTitle(title)
+    .toLowerCase()
+    .replace(/['"]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+
+  return `${base || "untitled"}.${EXTENSION_BY_FORMAT[format]}`;
+}
+
+export function markdownWithTitle(
+  title: string | null | undefined,
+  content: string | null | undefined,
+): string {
+  const safeTitle = normalizeTitle(title);
+  const body = (content ?? "").trim();
+  const firstHeading = body.match(/^#\s+(.+?)(?:\n|$)/);
+
+  if (firstHeading?.[1]?.trim().toLowerCase() === safeTitle.toLowerCase()) {
+    return `${body}\n`;
+  }
+
+  return `${`# ${safeTitle}`}${body ? `\n\n${body}` : ""}\n`;
+}
+
+function inlineMarkdownToHtml(text: string): string {
+  return escapeHtml(text)
+    .replace(
+      /!\[([^\]]*)\]\(([^)\s]+)(?:\s+&quot;[^&]*&quot;)?\)/g,
+      (_m, alt, src) => {
+        return `<img src="${safeExportUrl(src, "image")}" alt="${alt}" />`;
+      },
+    )
+    .replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (_m, label, href) => {
+      return `<a href="${safeExportUrl(href, "link")}">${label}</a>`;
+    })
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/__([^_]+)__/g, "<strong>$1</strong>")
+    .replace(/~~([^~]+)~~/g, "<s>$1</s>")
+    .replace(/(^|[^\*])\*([^*]+)\*/g, "$1<em>$2</em>")
+    .replace(/(^|[^_])_([^_]+)_/g, "$1<em>$2</em>");
+}
+
+function listItemsToHtml(lines: string[], ordered: boolean): string {
+  const items = lines
+    .map((line) => {
+      const text = ordered
+        ? line.replace(/^\s*\d+[.)]\s+/, "")
+        : line.replace(/^\s*[-*+]\s+/, "");
+      const task = text.match(/^\[( |x|X)\]\s+(.*)$/);
+      if (task) {
+        const checked = task[1].toLowerCase() === "x";
+        return `<li class="task"><input type="checkbox" disabled${
+          checked ? " checked" : ""
+        } /> <span>${inlineMarkdownToHtml(task[2])}</span></li>`;
+      }
+      return `<li>${inlineMarkdownToHtml(text)}</li>`;
+    })
+    .join("\n");
+
+  return ordered ? `<ol>\n${items}\n</ol>` : `<ul>\n${items}\n</ul>`;
+}
+
+function markdownToHtml(markdown: string): string {
+  const lines = markdown.replace(/\r\n?/g, "\n").split("\n");
+  const blocks: string[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index];
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      index++;
+      continue;
+    }
+
+    const codeFence = trimmed.match(/^```(\w+)?/);
+    if (codeFence) {
+      const code: string[] = [];
+      index++;
+      while (index < lines.length && !lines[index].trim().startsWith("```")) {
+        code.push(lines[index]);
+        index++;
+      }
+      index++;
+      const language = codeFence[1]
+        ? ` class="language-${escapeHtml(codeFence[1])}"`
+        : "";
+      blocks.push(
+        `<pre><code${language}>${escapeHtml(code.join("\n"))}</code></pre>`,
+      );
+      continue;
+    }
+
+    const heading = trimmed.match(/^(#{1,6})\s+(.+)$/);
+    if (heading) {
+      const level = heading[1].length;
+      blocks.push(`<h${level}>${inlineMarkdownToHtml(heading[2])}</h${level}>`);
+      index++;
+      continue;
+    }
+
+    if (/^(-{3,}|\*{3,}|_{3,})$/.test(trimmed)) {
+      blocks.push("<hr />");
+      index++;
+      continue;
+    }
+
+    if (/^>\s?/.test(trimmed)) {
+      const quote: string[] = [];
+      while (index < lines.length && /^>\s?/.test(lines[index].trim())) {
+        quote.push(lines[index].trim().replace(/^>\s?/, ""));
+        index++;
+      }
+      blocks.push(
+        `<blockquote>${markdownToHtml(quote.join("\n"))}</blockquote>`,
+      );
+      continue;
+    }
+
+    if (/^\s*[-*+]\s+/.test(line)) {
+      const items: string[] = [];
+      while (index < lines.length && /^\s*[-*+]\s+/.test(lines[index])) {
+        items.push(lines[index]);
+        index++;
+      }
+      blocks.push(listItemsToHtml(items, false));
+      continue;
+    }
+
+    if (/^\s*\d+[.)]\s+/.test(line)) {
+      const items: string[] = [];
+      while (index < lines.length && /^\s*\d+[.)]\s+/.test(lines[index])) {
+        items.push(lines[index]);
+        index++;
+      }
+      blocks.push(listItemsToHtml(items, true));
+      continue;
+    }
+
+    const paragraph: string[] = [line];
+    index++;
+    while (
+      index < lines.length &&
+      lines[index].trim() &&
+      !/^(#{1,6})\s+/.test(lines[index].trim()) &&
+      !/^```/.test(lines[index].trim()) &&
+      !/^>\s?/.test(lines[index].trim()) &&
+      !/^\s*[-*+]\s+/.test(lines[index]) &&
+      !/^\s*\d+[.)]\s+/.test(lines[index])
+    ) {
+      paragraph.push(lines[index]);
+      index++;
+    }
+    blocks.push(`<p>${inlineMarkdownToHtml(paragraph.join("\n"))}</p>`);
+  }
+
+  return blocks.join("\n\n");
+}
+
+function buildHtmlDocument(input: {
+  title: string;
+  content: string;
+  updatedAt?: string | null;
+  print: boolean;
+}): string {
+  const body = markdownToHtml(input.content);
+  const updated = input.updatedAt
+    ? `<p class="meta">Updated ${escapeHtml(
+        new Date(input.updatedAt).toLocaleString("en-US", {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+          hour: "numeric",
+          minute: "2-digit",
+        }),
+      )}</p>`
+    : "";
+
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(input.title)}</title>
+  <style>
+    :root { color-scheme: light; }
+    body {
+      margin: 0;
+      background: #fff;
+      color: #262626;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.68;
+    }
+    main {
+      box-sizing: border-box;
+      max-width: 760px;
+      margin: 0 auto;
+      padding: ${input.print ? "48px 56px" : "56px 32px"};
+    }
+    .meta {
+      color: #737373;
+      font-size: 13px;
+      margin: 0 0 12px;
+    }
+    h1 {
+      font-size: 40px;
+      line-height: 1.15;
+      letter-spacing: 0;
+      margin: 0 0 32px;
+    }
+    h2 { font-size: 26px; margin: 32px 0 8px; }
+    h3 { font-size: 21px; margin: 28px 0 6px; }
+    h4, h5, h6 { font-size: 17px; margin: 22px 0 4px; }
+    p, ul, ol, blockquote, pre { margin: 12px 0; }
+    ul, ol { padding-left: 1.4rem; }
+    li { margin: 4px 0; }
+    li.task { list-style: none; margin-left: -1.4rem; }
+    li.task input { margin-right: 8px; }
+    blockquote {
+      border-left: 3px solid #d4d4d4;
+      color: #525252;
+      padding-left: 14px;
+    }
+    pre {
+      background: #f6f6f6;
+      border: 1px solid #e5e5e5;
+      border-radius: 8px;
+      overflow-x: auto;
+      padding: 14px 16px;
+      white-space: pre-wrap;
+    }
+    code {
+      font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.9em;
+    }
+    p code, li code {
+      background: #f1f1f1;
+      border-radius: 4px;
+      padding: 0.12rem 0.3rem;
+    }
+    a { color: #2563eb; }
+    img {
+      display: block;
+      max-width: 100%;
+      height: auto;
+      border-radius: 8px;
+      margin: 18px 0;
+    }
+    hr {
+      border: 0;
+      border-top: 1px solid #e5e5e5;
+      margin: 28px 0;
+    }
+    @media print {
+      @page { margin: 0.65in; }
+      main { max-width: none; padding: 0; }
+      a { color: inherit; text-decoration: underline; }
+      pre, blockquote, img { break-inside: avoid; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    ${updated}
+    <h1>${escapeHtml(input.title)}</h1>
+    <article>${body}</article>
+  </main>
+</body>
+</html>`;
+}
+
+export function buildDocumentExport(
+  input: DocumentExportInput,
+): DocumentExportPayload {
+  const title = normalizeTitle(input.title);
+  const filename = exportFilename(title, input.format);
+  const markdown = markdownWithTitle(title, input.content);
+  const isHtmlLike = input.format === "html" || input.format === "pdf";
+  const content = isHtmlLike
+    ? buildHtmlDocument({
+        title,
+        content: input.content ?? "",
+        updatedAt: input.updatedAt,
+        print: input.format === "pdf",
+      })
+    : markdown;
+
+  return {
+    id: input.id,
+    title,
+    format: input.format,
+    filename,
+    mimeType: MIME_BY_FORMAT[input.format],
+    content,
+    print: input.format === "pdf",
+  };
+}


### PR DESCRIPTION
## Summary
- harden core Yjs collaboration persistence with versioned saves, per-doc write locks, and state-vector catch-up polling
- add Content document export support for PDF-ready HTML, Markdown, and standalone HTML
- tighten Content editor slash-command and external-content sync behavior
- scope the transcribe-media fresh document read through document access control

## Verification
- pnpm run prep