### PR TITLE
fix windows desktop build

### DIFF
--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -1417,6 +1417,7 @@ fn tray_display_id(app: &AppHandle) -> Option<u32> {
     ids.into_iter().next()
 }
 
+#[cfg(target_os = "macos")]
 fn start_screencapturekit_recording(
     app: &AppHandle,
     safe_id: &str,


### PR DESCRIPTION
The desktop build has failed after the following PR was merged https://github.com/BuilderIO/agent-native/pull/892

This PR will add `#[cfg(target_os = "macos")]` to `start_screencapturekit_recording` in native_screen.rs. Function calls two macOS-only helpers (tray_display_id, start_screencapturekit_backend_at) but was missing the platform gate, causing E0425 compile errors on Windows.