### PR TITLE
Fix Clips desktop overlay shadow clipping

### DIFF
--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -38,6 +38,10 @@ const REGION_GUIDE_EDITOR_LABEL: &str = "region-guide-editor";
 /// launch — this matches Loom's out-of-the-box behavior.
 const BUBBLE_SIZE_SMALL: u32 = 360;
 const BUBBLE_SIZE_MEDIUM: u32 = 504;
+const POPOVER_SHADOW_GUTTER_LOGICAL: f64 = 12.0;
+const POPOVER_DEFAULT_WIDTH_LOGICAL: f64 = 360.0;
+const POPOVER_DEFAULT_HEIGHT_LOGICAL: f64 = 520.0;
+const OVERLAY_SHADOW_GUTTER_LOGICAL: f64 = 18.0;
 
 #[cfg(target_os = "macos")]
 #[link(name = "AppKit", kind = "framework")]
@@ -67,6 +71,28 @@ enum TextInsertionStrategy {
 /// an 8px gap from the circle, with a small cushion so the pill's drop-shadow
 /// doesn't clip at the window bottom.
 const BUBBLE_CONTROLS_BUDGET_PX: u32 = 80;
+
+fn overlay_scale_factor(app: &AppHandle) -> f64 {
+    app.get_webview_window("popover")
+        .and_then(|w| w.scale_factor().ok())
+        .or_else(|| {
+            app.primary_monitor()
+                .ok()
+                .flatten()
+                .map(|monitor| monitor.scale_factor())
+        })
+        .unwrap_or(2.0)
+        .max(1.0)
+}
+
+fn overlay_shadow_gutter_physical(app: &AppHandle) -> u32 {
+    (OVERLAY_SHADOW_GUTTER_LOGICAL * overlay_scale_factor(app)).round() as u32
+}
+
+fn popover_window_size_logical(content_width: f64, content_height: f64) -> (f64, f64) {
+    let gutter = POPOVER_SHADOW_GUTTER_LOGICAL * 2.0;
+    (content_width + gutter, content_height + gutter)
+}
 
 fn bubble_size_for_name(name: &str) -> u32 {
     match name {
@@ -397,22 +423,27 @@ pub async fn show_toolbar(app: AppHandle) -> Result<(), String> {
     // Reset the blur guard — spawning an overlay can briefly steal focus
     // from the popover on some macOS versions even with .focused(false).
     mark_popover_shown(&app);
+    let (mx, my, _mw, mh) = tray_monitor_physical_rect(&app);
+    let gutter = overlay_shadow_gutter_physical(&app);
+    // Tighter pill: buttons are 30px, padding is 10px, gap is 10px. The
+    // visible pill keeps its original footprint, while the native window is
+    // expanded by a transparent gutter so the CSS shadow is not chopped at
+    // the rectangular WebView edge.
+    let content_w: u32 = 110;
+    let content_h: u32 = 260;
+    let w: u32 = content_w + gutter * 2;
+    let h: u32 = content_h + gutter * 2;
+    // Flush-left with a small margin; vertically centered on the screen.
+    let x: i32 = mx + 48 - gutter as i32;
+    let y: i32 = my + (mh as i32 - content_h as i32) / 2 - gutter as i32;
+    dlog!("[clips-tray] toolbar pos=({},{}) size={}x{}", x, y, w, h);
     if let Some(existing) = app.get_webview_window(TOOLBAR_LABEL) {
+        let _ = existing.set_size(tauri::Size::Physical(PhysicalSize::new(w, h)));
+        let _ = existing.set_position(PhysicalPosition::new(x, y));
         let _ = existing.show();
         let _ = existing.set_focus();
         return Ok(());
     }
-    let (mx, my, _mw, mh) = tray_monitor_physical_rect(&app);
-    // Tighter pill: buttons are 30px, padding is 10px, gap is 10px. The
-    // window is sized so the pill fills it with only ~4-6 px of slack per
-    // side for the CSS drop shadow to bleed into. Values are physical px,
-    // so ~2x the logical pill dimensions on retina.
-    let w: u32 = 110;
-    let h: u32 = 260;
-    // Flush-left with a small margin; vertically centered on the screen.
-    let x: i32 = mx + 48;
-    let y: i32 = my + (mh as i32 - h as i32) / 2;
-    dlog!("[clips-tray] toolbar pos=({},{}) size={}x{}", x, y, w, h);
     #[allow(unused_mut)]
     let mut builder = WebviewWindowBuilder::new(&app, TOOLBAR_LABEL, build_overlay_url("toolbar"))
         .title("Clips Recorder")
@@ -472,17 +503,20 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
     let size: u32 = bubble_size_for_name(&size_name);
     // The actual window is TALLER than the circle — see
     // `BUBBLE_CONTROLS_BUDGET_PX` — to give the hover controls pill room.
-    let win_h: u32 = bubble_window_height_for(size);
+    let content_h: u32 = bubble_window_height_for(size);
+    let gutter = overlay_shadow_gutter_physical(&app);
+    let win_w: u32 = size + gutter * 2;
+    let win_h: u32 = content_h + gutter * 2;
 
     let (mon_x, mon_y, mon_w, mon_h) = tray_monitor_physical_rect(&app);
 
     // Default Loom-style anchor: flush-left with a small margin, a hair
     // above the bottom edge of the target monitor. On Retina the 60
     // physical-px offset maps to ~30 logical px.
-    let default_x: i32 = mon_x + 48;
-    let default_y: i32 = mon_y + mon_h as i32 - win_h as i32 - 60;
+    let default_x: i32 = mon_x + 48 - gutter as i32;
+    let default_y: i32 = mon_y + mon_h as i32 - content_h as i32 - 60 - gutter as i32;
     // Clamp bounds within the target monitor.
-    let max_x = (mon_x + mon_w as i32 - size as i32).max(mon_x);
+    let max_x = (mon_x + mon_w as i32 - win_w as i32).max(mon_x);
     let max_y = (mon_y + mon_h as i32 - win_h as i32).max(mon_y);
     // Use the saved position only if it already falls on the target monitor.
     // A position from a previous session on a different display would strand
@@ -498,7 +532,7 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
         x,
         y,
         source,
-        size,
+        win_w,
         win_h,
         mon_w,
         mon_h
@@ -522,7 +556,7 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
         eprintln!("[clips-tray] bubble build failed: {}", e);
         e.to_string()
     })?;
-    let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(size, win_h)));
+    let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(win_w, win_h)));
     let _ = win.set_position(PhysicalPosition::new(x, y));
     // NOTE: intentionally NOT calling `set_capture_excluded` on the bubble.
     // The bubble is the user's face — Loom's behavior is that the camera
@@ -532,7 +566,7 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
     // toolbar, countdown) but NOT what users want for the camera bubble.
     configure_overlay_behavior(&win);
     let _ = win.show();
-    dlog!("[clips-tray] bubble shown at ({},{}) size {}", x, y, size);
+    dlog!("[clips-tray] bubble shown at ({},{}) size {}", x, y, win_w);
     Ok(())
 }
 
@@ -659,13 +693,18 @@ pub async fn resize_popover(app: AppHandle, height: f64, width: Option<f64>) -> 
             .or_else(|| w.primary_monitor().ok().flatten())
             .map(|monitor| {
                 let scale = monitor.scale_factor().max(1.0);
-                ((monitor.size().height as f64) / scale - 24.0).clamp(260.0, 820.0)
+                ((monitor.size().height as f64) / scale
+                    - 24.0
+                    - POPOVER_SHADOW_GUTTER_LOGICAL * 2.0)
+                    .clamp(260.0, 820.0)
             })
             .unwrap_or(820.0);
         let clamped = height.clamp(200.0, max_logical_height);
         let width = width.unwrap_or(360.0).clamp(320.0, 480.0);
+        let (window_width, window_height) = popover_window_size_logical(width, clamped);
         let _ = w.set_size(tauri::Size::Logical(tauri::LogicalSize::new(
-            width, clamped,
+            window_width,
+            window_height,
         )));
         // Re-anchor to the tray icon so the window doesn't drift below the
         // bottom of the monitor after a growth.
@@ -841,11 +880,14 @@ pub async fn show_flow_bar(app: AppHandle) -> Result<(), String> {
     // Wider + taller than the pill alone so the live transcript chip
     // can stack above it. Height accommodates: bottom-anchored 32px pill
     // + 6px gap + ~28px transcript chip + drop-shadow margin.
-    let w: u32 = 420;
-    let h: u32 = 120;
-    let x: i32 = (mx + (mw as i32 - w as i32) / 2).max(mx);
+    let content_w: u32 = 420;
+    let content_h: u32 = 120;
+    let gutter = overlay_shadow_gutter_physical(&app);
+    let w: u32 = content_w + gutter * 2;
+    let h: u32 = content_h + gutter * 2;
+    let x: i32 = (mx + (mw as i32 - content_w as i32) / 2 - gutter as i32).max(mx);
     // Bottom margin: ~14 logical px ≈ 28 physical px.
-    let y: i32 = (my + mh as i32 - h as i32 - 28).max(my);
+    let y: i32 = (my + mh as i32 - content_h as i32 - 28 - gutter as i32).max(my);
 
     if let Some(existing) = app.get_webview_window(FLOW_BAR_LABEL) {
         // Reposition (in case the user changed display geometry between
@@ -1202,7 +1244,11 @@ pub async fn reset_state(app: AppHandle) -> Result<(), String> {
         // Restore normal size in case the window was shrunk to a pinhole
         // during recording — otherwise it would reappear as a 2×2 dot.
         configure_overlay_behavior(&window);
-        let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(360.0, 520.0)));
+        let (w, h) = popover_window_size_logical(
+            POPOVER_DEFAULT_WIDTH_LOGICAL,
+            POPOVER_DEFAULT_HEIGHT_LOGICAL,
+        );
+        let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(w, h)));
         position_popover(&app, &window);
         mark_popover_shown(&app);
         let _ = window.show();
@@ -1229,7 +1275,9 @@ pub async fn set_bubble_size(app: AppHandle, size: String) -> Result<(), String>
         _ => "small",
     };
     let px = bubble_size_for_name(name);
-    let win_h = bubble_window_height_for(px);
+    let gutter = overlay_shadow_gutter_physical(&app);
+    let win_w = px + gutter * 2;
+    let win_h = bubble_window_height_for(px) + gutter * 2;
     if let Some(win) = app.get_webview_window(BUBBLE_LABEL) {
         // Re-center the resize around the current circle's center so the
         // bubble visually grows / shrinks around its current spot instead of
@@ -1246,12 +1294,13 @@ pub async fn set_bubble_size(app: AppHandle, size: String) -> Result<(), String>
             .outer_size()
             .ok()
             .map(|s| s.width as i32)
-            .unwrap_or(BUBBLE_SIZE_SMALL as i32);
+            .unwrap_or((BUBBLE_SIZE_SMALL + gutter * 2) as i32);
         let new_px = px as i32;
-        let delta = (current_size - new_px) / 2;
+        let current_circle_size = current_size - (gutter * 2) as i32;
+        let delta = (current_circle_size - new_px) / 2;
         let new_x = current_pos.0 + delta;
         let new_y = current_pos.1 + delta;
-        let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(px, win_h)));
+        let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(win_w, win_h)));
         let _ = win.set_position(PhysicalPosition::new(new_x, new_y));
     }
     save_bubble_size_name(&app, name);
@@ -1298,7 +1347,11 @@ pub async fn show_popover(app: AppHandle) -> Result<(), String> {
         // ResizeObserver will call `resize_popover` on the next render to
         // fine-tune the height, but we need a sensible starting size so
         // `position_popover` can anchor correctly.
-        let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(360.0, 520.0)));
+        let (w, h) = popover_window_size_logical(
+            POPOVER_DEFAULT_WIDTH_LOGICAL,
+            POPOVER_DEFAULT_HEIGHT_LOGICAL,
+        );
+        let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(w, h)));
         position_popover(&app, &window);
         mark_popover_shown(&app);
         let _ = window.show();
@@ -1388,7 +1441,11 @@ pub fn toggle_popover(app: &AppHandle) {
     // so without this the popover sticks to whichever Space it was first
     // shown on.
     configure_overlay_behavior(&window);
-    let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(360.0, 520.0)));
+    let (w, h) = popover_window_size_logical(
+        POPOVER_DEFAULT_WIDTH_LOGICAL,
+        POPOVER_DEFAULT_HEIGHT_LOGICAL,
+    );
+    let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(w, h)));
     position_popover(app, &window);
     mark_popover_shown(app);
     let _ = window.show();
@@ -1447,7 +1504,9 @@ pub fn position_popover(app: &AppHandle, window: &WebviewWindow) {
 
         // Center the popover horizontally on the icon.
         let mut x = icon_x + icon_w / 2 - (win_size.width as i32) / 2;
-        // Drop below the icon with a tiny gap.
+        // Drop the visible panel below the icon with a tiny gap. The native
+        // window itself starts a shadow-gutter earlier so the top shadow has
+        // real transparent pixels to paint into without moving the panel down.
         let gap = 6_i32;
         let mut y = icon_y + icon_h + gap;
 
@@ -1467,6 +1526,15 @@ pub fn position_popover(app: &AppHandle, window: &WebviewWindow) {
                     && icon_cy < mp.y + ms.height as i32
             })
         });
+        let popover_gutter = (POPOVER_SHADOW_GUTTER_LOGICAL
+            * tray_monitor
+                .as_ref()
+                .map(|m| m.scale_factor())
+                .unwrap_or_else(|| monitor.scale_factor())
+                .max(1.0))
+        .round() as i32;
+        y -= popover_gutter;
+
         let (clamp_pos, clamp_size) = tray_monitor
             .map(|m| (*m.position(), *m.size()))
             .unwrap_or((*mon_pos, *mon_size));
@@ -1498,12 +1566,13 @@ pub fn position_popover(app: &AppHandle, window: &WebviewWindow) {
     let scale = monitor.scale_factor();
     let margin_right = (12.0 * scale) as i32;
     let margin_top = (36.0 * scale) as i32;
+    let popover_gutter = (POPOVER_SHADOW_GUTTER_LOGICAL * scale.max(1.0)).round() as i32;
     let min_x = mon_pos.x + 8;
     let max_x = mon_pos.x + mon_size.width as i32 - win_size.width as i32 - 8;
     let min_y = mon_pos.y + 8;
     let max_y = mon_pos.y + mon_size.height as i32 - win_size.height as i32 - 8;
     let x = (mon_pos.x + mon_size.width as i32 - win_size.width as i32 - margin_right)
         .clamp(min_x, max_x.max(min_x));
-    let y = (mon_pos.y + margin_top).clamp(min_y, max_y.max(min_y));
+    let y = (mon_pos.y + margin_top - popover_gutter).clamp(min_y, max_y.max(min_y));
     let _ = window.set_position(PhysicalPosition::new(x, y));
 }

--- a/templates/clips/desktop/src-tauri/src/recording_indicator.rs
+++ b/templates/clips/desktop/src-tauri/src/recording_indicator.rs
@@ -33,7 +33,7 @@ use tauri::{AppHandle, Manager, PhysicalPosition, PhysicalSize, WebviewWindowBui
 
 use crate::dlog;
 use crate::util::{
-    configure_overlay_behavior, build_overlay_url, set_capture_excluded, show_without_activation,
+    build_overlay_url, configure_overlay_behavior, set_capture_excluded, show_without_activation,
     tray_monitor_physical_rect,
 };
 
@@ -64,6 +64,7 @@ const PILL_DETACHED_H_LOGICAL: u32 = 40;
 const PILL_DETACHED_TOP_MARGIN_LOGICAL: u32 = 24;
 const PILL_DETACHED_RIGHT_MARGIN_LOGICAL: u32 = 24;
 const PILL_RIGHT_MARGIN_LOGICAL: u32 = 24;
+const OVERLAY_SHADOW_GUTTER_LOGICAL: f64 = 18.0;
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -77,6 +78,10 @@ fn scale_factor(app: &AppHandle) -> f64 {
     app.get_webview_window("popover")
         .and_then(|w| w.scale_factor().ok())
         .unwrap_or(2.0)
+}
+
+fn overlay_shadow_gutter_physical(app: &AppHandle) -> u32 {
+    (OVERLAY_SHADOW_GUTTER_LOGICAL * scale_factor(app).max(1.0)).round() as u32
 }
 
 /// Persist the last-known pill position so the next `show` re-opens at the
@@ -204,7 +209,7 @@ fn default_center_right(app: &AppHandle, w: u32, h: u32) -> (i32, i32) {
     (x, y)
 }
 
-fn pill_size_physical(app: &AppHandle, expanded: bool) -> (u32, u32) {
+fn pill_content_size_physical(app: &AppHandle, expanded: bool) -> (u32, u32) {
     let scale = scale_factor(app);
     let detached = PILL_DETACHED.load(Ordering::Relaxed);
     // Detached mode ignores the `expanded` flag — the floating pill is a
@@ -220,6 +225,12 @@ fn pill_size_physical(app: &AppHandle, expanded: bool) -> (u32, u32) {
     let w = (w_log as f64 * scale) as u32;
     let h = (h_log as f64 * scale) as u32;
     (w, h)
+}
+
+fn pill_size_physical(app: &AppHandle, expanded: bool) -> (u32, u32) {
+    let (content_w, content_h) = pill_content_size_physical(app, expanded);
+    let gutter = overlay_shadow_gutter_physical(app);
+    (content_w + gutter * 2, content_h + gutter * 2)
 }
 
 /// Default top-right anchor (physical px) for detached mode.

--- a/templates/clips/desktop/src-tauri/src/util.rs
+++ b/templates/clips/desktop/src-tauri/src/util.rs
@@ -5,6 +5,10 @@ use crate::state::{
     DictationActive, PopoverShownAt, RecordingActive, TrayAnchor, VoiceWakePopover,
 };
 
+const POPOVER_SHADOW_GUTTER_LOGICAL: f64 = 12.0;
+const POPOVER_DEFAULT_WIDTH_LOGICAL: f64 = 360.0;
+const POPOVER_DEFAULT_HEIGHT_LOGICAL: f64 = 520.0;
+
 // ---------------------------------------------------------------------------
 // Capture-sharing helpers (macOS only)
 // ---------------------------------------------------------------------------
@@ -97,9 +101,13 @@ pub fn set_capture_included(window: &WebviewWindow) {
 }
 
 pub fn build_popover_window(app: &mut tauri::App) -> Result<WebviewWindow, tauri::Error> {
+    let gutter = POPOVER_SHADOW_GUTTER_LOGICAL * 2.0;
     WebviewWindowBuilder::new(app, "popover", WebviewUrl::App("index.html".into()))
         .title("Clips")
-        .inner_size(360.0, 520.0)
+        .inner_size(
+            POPOVER_DEFAULT_WIDTH_LOGICAL + gutter,
+            POPOVER_DEFAULT_HEIGHT_LOGICAL + gutter,
+        )
         .position(2.0, 2.0)
         .resizable(false)
         .decorations(false)

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -631,8 +631,17 @@ interface NativeTranscriptCapture {
 }
 
 interface RecordingStartCue {
-  play(): void;
+  play(): Promise<void>;
   cleanup(): void;
+}
+
+const COUNTDOWN_EVENT_TIMEOUT_MS = 5000;
+const COUNTDOWN_OVERLAY_SETTLE_MS = 120;
+const RECORDING_START_CUE_TIMEOUT_MS = 450;
+const RECORDING_START_CUE_SETTLE_MS = 80;
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
 interface NativeFullscreenUploadResult {
@@ -1224,7 +1233,7 @@ async function showRegionGuidesForRecording(wantsScreen: boolean) {
 }
 
 async function runRecordingCountdown(wantsScreen: boolean) {
-  const countdownEvent = waitForCountdownEvent(4000);
+  const countdownEvent = waitForCountdownEvent(COUNTDOWN_EVENT_TIMEOUT_MS);
   await showRegionGuidesForRecording(wantsScreen);
   try {
     await invoke("show_countdown");
@@ -1239,7 +1248,37 @@ async function runRecordingCountdown(wantsScreen: boolean) {
       throw err;
     }
     console.warn("[clips-recorder] countdown timed out — proceeding");
+    return;
   }
+  // The countdown webview emits before it finishes closing. Give macOS a
+  // brief beat to remove the overlay and any shortcut handling before capture
+  // starts, so the first frame/audio sample is the real recording.
+  await wait(COUNTDOWN_OVERLAY_SETTLE_MS);
+}
+
+async function playRecordingStartCueBeforeCapture(
+  recordingStartCue: RecordingStartCue,
+) {
+  let timedOut = false;
+  await Promise.race([
+    recordingStartCue.play(),
+    wait(RECORDING_START_CUE_TIMEOUT_MS).then(() => {
+      timedOut = true;
+    }),
+  ]).catch((err) => {
+    console.warn("[clips-recorder] start cue unavailable:", err);
+  });
+  if (timedOut) {
+    recordingStartCue.cleanup();
+    return;
+  }
+  await wait(RECORDING_START_CUE_SETTLE_MS);
+}
+
+function showFinalizingFeedback() {
+  invoke("show_finalizing").catch((err) =>
+    console.error("[clips-recorder] show_finalizing failed:", err),
+  );
 }
 
 function abortCreatedRecordingOnCountdownCancel(
@@ -1360,6 +1399,7 @@ async function startNativeFullscreenRecording(
       id = createRes.id;
     }
 
+    await playRecordingStartCueBeforeCapture(recordingStartCue);
     await invoke("native_fullscreen_recording_start", {
       recordingId: id,
       includeAudio: wantsAudio,
@@ -1437,6 +1477,7 @@ async function startNativeFullscreenRecording(
       stopPromise = (async () => {
         stopped = true;
         console.log("[clips-recorder] native full-screen stop requested");
+        if (!localOnly) showFinalizingFeedback();
         if (tickHandle) {
           clearInterval(tickHandle);
           tickHandle = null;
@@ -1534,10 +1575,6 @@ async function startNativeFullscreenRecording(
               err,
             );
           });
-
-          invoke("show_finalizing").catch((err) =>
-            console.error("[clips-recorder] show_finalizing failed:", err),
-          );
 
           const viewUrl = `/r/${id}`;
           try {
@@ -1680,7 +1717,6 @@ async function startNativeFullscreenRecording(
   ]);
   stateUnlistens = toolbarUnlistens;
   tickHandle = setInterval(emitState, 500);
-  recordingStartCue.play();
   emit("clips:toolbar-enabled", true).catch(() => {});
   emitState();
 
@@ -1768,7 +1804,7 @@ function createSyntheticAudioStream(): {
 }
 
 const noopRecordingStartCue: RecordingStartCue = {
-  play() {},
+  async play() {},
   cleanup() {},
 };
 
@@ -1796,43 +1832,69 @@ function createRecordingStartCue(): RecordingStartCue {
       ctx.close().catch(() => {});
     };
 
-    const play = () => {
-      if (played || closed) return;
-      played = true;
-
-      const startedAt = ctx.currentTime + 0.005;
-      const oscillator = ctx.createOscillator();
-      const gain = ctx.createGain();
-
-      oscillator.type = "sine";
-      oscillator.frequency.setValueAtTime(880, startedAt);
-      oscillator.frequency.exponentialRampToValueAtTime(660, startedAt + 0.14);
-
-      gain.gain.setValueAtTime(0.0001, startedAt);
-      gain.gain.exponentialRampToValueAtTime(0.07, startedAt + 0.018);
-      gain.gain.exponentialRampToValueAtTime(0.0001, startedAt + 0.18);
-
-      oscillator.connect(gain);
-      gain.connect(ctx.destination);
-
-      oscillator.addEventListener("ended", close, { once: true });
-      oscillator.start(startedAt);
-      oscillator.stop(startedAt + 0.2);
-    };
-
-    const cue: RecordingStartCue = {
-      play() {
-        if (ctx.state === "running") {
-          play();
+    const play = () =>
+      new Promise<void>((resolve) => {
+        if (played || closed) {
+          resolve();
           return;
         }
-        ctx
-          .resume()
-          .then(play)
-          .catch((err) => {
-            console.warn("[clips-recorder] start cue unavailable:", err);
+        played = true;
+
+        const startedAt = ctx.currentTime + 0.005;
+        const oscillator = ctx.createOscillator();
+        const gain = ctx.createGain();
+        let resolved = false;
+        let timeout: ReturnType<typeof window.setTimeout> | null =
+          window.setTimeout(() => {
+            timeout = null;
+            if (resolved) return;
+            resolved = true;
             close();
-          });
+            resolve();
+          }, 500);
+        const finish = () => {
+          if (resolved) return;
+          resolved = true;
+          if (timeout) {
+            window.clearTimeout(timeout);
+            timeout = null;
+          }
+          close();
+          resolve();
+        };
+
+        oscillator.type = "sine";
+        oscillator.frequency.setValueAtTime(880, startedAt);
+        oscillator.frequency.exponentialRampToValueAtTime(
+          660,
+          startedAt + 0.14,
+        );
+
+        gain.gain.setValueAtTime(0.0001, startedAt);
+        gain.gain.exponentialRampToValueAtTime(0.07, startedAt + 0.018);
+        gain.gain.exponentialRampToValueAtTime(0.0001, startedAt + 0.18);
+
+        oscillator.connect(gain);
+        gain.connect(ctx.destination);
+
+        oscillator.addEventListener("ended", finish, { once: true });
+        oscillator.start(startedAt);
+        oscillator.stop(startedAt + 0.2);
+      });
+
+    const cue: RecordingStartCue = {
+      async play() {
+        if (ctx.state === "running") {
+          await play();
+          return;
+        }
+        try {
+          await ctx.resume();
+          await play();
+        } catch (err) {
+          console.warn("[clips-recorder] start cue unavailable:", err);
+          close();
+        }
       },
       cleanup: close,
     };
@@ -2173,7 +2235,7 @@ async function startNativeRecordingInner(
     }
 
     const id = `local-${Date.now().toString(36)}`;
-    const startedAt = Date.now();
+    let startedAt = Date.now();
     let pausedAt: number | null = null;
     let accumulatedPauseMs = 0;
     let stopped = false;
@@ -2218,8 +2280,9 @@ async function startNativeRecordingInner(
     stateUnlistens = toolbarUnlistens;
 
     await showRegionGuidesForRecording(wantsScreen);
+    await playRecordingStartCueBeforeCapture(recordingStartCue);
     localExport.start(2_000);
-    recordingStartCue.play();
+    startedAt = Date.now();
     emit("clips:toolbar-enabled", true).catch(() => {});
     emitState(false);
 
@@ -2449,7 +2512,7 @@ async function startNativeRecordingInner(
     inflight.add(p);
   };
 
-  const startedAt = Date.now();
+  let startedAt = Date.now();
   let pausedAt: number | null = null;
   let accumulatedPauseMs = 0;
   let stopped = false;
@@ -2518,8 +2581,9 @@ async function startNativeRecordingInner(
     );
   }
   await showRegionGuidesForRecording(wantsScreen);
+  await playRecordingStartCueBeforeCapture(recordingStartCue);
   recorder.start(2_000);
-  recordingStartCue.play();
+  startedAt = Date.now();
   // The toolbar is already open (the popover's bubble-session effect
   // spawns it alongside the bubble in its pre-record, disabled state).
   // Now that MediaRecorder is actually ticking, flip the toolbar's
@@ -2540,6 +2604,7 @@ async function startNativeRecordingInner(
       if (stopped) return { recordingId: id, viewUrl: `/r/${id}` };
       stopped = true;
       console.log("[clips-recorder] stop requested");
+      showFinalizingFeedback();
       clearInterval(tickHandle);
       stateUnlistens.forEach((u) => u());
       stateUnlistens = [];
@@ -2677,18 +2742,6 @@ async function startNativeRecordingInner(
         : "hide_overlays";
       await invoke(chromeCmd).catch((err) =>
         console.error(`[clips-recorder] ${chromeCmd} failed:`, err),
-      );
-
-      // Show the full-screen "Finishing up your clip…" spinner overlay so
-      // the user gets immediate feedback while we flush the recorder
-      // buffer, wait for in-flight chunk uploads to settle, and POST the
-      // finalize. Without this the screen goes blank between the toolbar
-      // disappearing and the browser opening — several seconds of nothing
-      // on a longer recording. The overlay ignores cursor events and is
-      // closed right after openExternal below. Fired-and-forgotten (no
-      // await) so we don't add latency to the finalize path.
-      invoke("show_finalizing").catch((err) =>
-        console.error("[clips-recorder] show_finalizing failed:", err),
       );
 
       // Wait for any in-flight chunk uploads to settle before sending the

--- a/templates/clips/desktop/src/overlays/countdown.tsx
+++ b/templates/clips/desktop/src/overlays/countdown.tsx
@@ -2,10 +2,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { emit } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
+const COUNTDOWN_STEP_MS = 1000;
+
 /**
- * Full-screen transparent countdown overlay. Runs 3 → 2 → 1, then emits
- * `clips:countdown-done` and closes its own window. The recorder waits for
- * that event before it starts capturing.
+ * Full-screen transparent countdown overlay. Runs 3 → 2 → 1 on full-second
+ * beats, then emits `clips:countdown-done` and closes its own window. The
+ * recorder waits for that event before it starts capturing.
  */
 export function Countdown() {
   const [n, setN] = useState(3);
@@ -48,7 +50,7 @@ export function Countdown() {
       closeWithEvent("clips:countdown-done");
       return;
     }
-    const t = setTimeout(() => setN((v) => v - 1), 850);
+    const t = setTimeout(() => setN((v) => v - 1), COUNTDOWN_STEP_MS);
     return () => clearTimeout(t);
   }, [closeWithEvent, n]);
 

--- a/templates/clips/desktop/src/overlays/recording-pill.tsx
+++ b/templates/clips/desktop/src/overlays/recording-pill.tsx
@@ -4,6 +4,7 @@ import { emit, listen } from "@tauri-apps/api/event";
 import {
   IconChevronDown,
   IconChevronUp,
+  IconLoader2,
   IconPlayerPauseFilled,
   IconPlayerPlayFilled,
   IconPlayerStopFilled,
@@ -316,10 +317,14 @@ export function RecordingPill() {
             disabled={stopping}
             data-no-drag
             className="ml-1 inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-full bg-red-500 text-white hover:bg-red-400 disabled:cursor-not-allowed disabled:opacity-60"
-            aria-label={stopLabel}
-            title={stopLabel}
+            aria-label={stopping ? "Stopping" : stopLabel}
+            title={stopping ? "Stopping..." : stopLabel}
           >
-            <IconPlayerStopFilled size={14} />
+            {stopping ? (
+              <IconLoader2 className="animate-spin" size={14} />
+            ) : (
+              <IconPlayerStopFilled size={14} />
+            )}
           </button>
           <button
             type="button"
@@ -375,10 +380,15 @@ export function RecordingPill() {
                 disabled={stopping}
                 data-no-drag
                 className="ml-auto inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-full bg-red-500 px-3 text-[12px] font-medium text-white hover:bg-red-400 disabled:cursor-not-allowed disabled:opacity-60"
-                aria-label={stopLabel}
+                aria-label={stopping ? "Stopping" : stopLabel}
+                title={stopping ? "Stopping..." : stopLabel}
               >
-                <IconPlayerStopFilled size={14} />
-                Stop
+                {stopping ? (
+                  <IconLoader2 className="animate-spin" size={14} />
+                ) : (
+                  <IconPlayerStopFilled size={14} />
+                )}
+                {stopping ? "Stopping" : "Stop"}
               </button>
             </div>
           </>

--- a/templates/clips/desktop/src/overlays/toolbar.tsx
+++ b/templates/clips/desktop/src/overlays/toolbar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
+  IconLoader2,
   IconPlayerPauseFilled,
   IconPlayerPlayFilled,
 } from "@tabler/icons-react";
@@ -144,20 +145,36 @@ export function Toolbar() {
         className="toolbar-v-stop"
         onClick={stop}
         disabled={stopping || !enabled}
-        aria-label="Stop recording"
-        title={enabled ? "Stop recording" : "Recording not started yet"}
+        aria-label={stopping ? "Stopping recording" : "Stop recording"}
+        title={
+          stopping
+            ? "Stopping..."
+            : enabled
+              ? "Stop recording"
+              : "Recording not started yet"
+        }
         data-no-drag
       >
-        <span className="toolbar-v-stop-square" />
+        {stopping ? (
+          <IconLoader2 className="toolbar-v-spinner" size={18} />
+        ) : (
+          <span className="toolbar-v-stop-square" />
+        )}
       </button>
       <div className="toolbar-v-time">{formatTime(elapsed)}</div>
       <button
         className="toolbar-v-pause"
         onClick={togglePause}
-        disabled={!enabled}
+        disabled={!enabled || stopping}
         aria-label={paused ? "Resume" : "Pause"}
         title={
-          enabled ? (paused ? "Resume" : "Pause") : "Recording not started yet"
+          stopping
+            ? "Stopping..."
+            : enabled
+              ? paused
+                ? "Resume"
+                : "Pause"
+              : "Recording not started yet"
         }
         data-no-drag
       >

--- a/templates/clips/desktop/src/overlays/toolbar.tsx
+++ b/templates/clips/desktop/src/overlays/toolbar.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import {
+  IconPlayerPauseFilled,
+  IconPlayerPlayFilled,
+} from "@tabler/icons-react";
 
 /**
  * Floating recording toolbar — vertical pill anchored to the LEFT edge of
@@ -157,7 +161,11 @@ export function Toolbar() {
         }
         data-no-drag
       >
-        {paused ? <PlayGlyph /> : <PauseGlyph />}
+        {paused ? (
+          <IconPlayerPlayFilled size={18} />
+        ) : (
+          <IconPlayerPauseFilled size={18} />
+        )}
       </button>
     </div>
   );
@@ -168,27 +176,4 @@ function formatTime(ms: number): string {
   const m = Math.floor(total / 60);
   const s = total % 60;
   return `${m}:${s.toString().padStart(2, "0")}`;
-}
-
-function PauseGlyph() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-      <rect x="7" y="5" width="3.5" height="14" rx="1.5" fill="currentColor" />
-      <rect
-        x="13.5"
-        y="5"
-        width="3.5"
-        height="14"
-        rx="1.5"
-        fill="currentColor"
-      />
-    </svg>
-  );
-}
-function PlayGlyph() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-      <path d="M7 5l13 7-13 7z" fill="currentColor" />
-    </svg>
-  );
 }

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1897,10 +1897,12 @@ body[data-clips-route="recording-pill"] #root {
   font-weight: 800;
   font-variant-numeric: tabular-nums;
   color: #ffffff;
-  /* No glow — the bare white numeral is crisper on camera than a
-     haloed one, which tends to bloom and lose edge detail in the
-     recorded output. */
-  animation: cd-pop 0.85s ease-out forwards;
+  -webkit-text-stroke: 1px rgba(17, 24, 39, 0.22);
+  text-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.48),
+    0 12px 34px rgba(0, 0, 0, 0.36),
+    0 0 2px rgba(0, 0, 0, 0.72);
+  animation: cd-pop 1s ease-out forwards;
   line-height: 1;
 }
 
@@ -1915,6 +1917,7 @@ body[data-clips-route="recording-pill"] #root {
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: var(--radius-pill);
   background: rgba(10, 12, 16, 0.28);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.24);
   color: rgba(255, 255, 255, 0.58);
   font-size: 11px;
   font-weight: 500;
@@ -2233,6 +2236,16 @@ body[data-clips-route="recording-pill"] #root {
   background: currentColor;
   border-radius: 2px;
   display: inline-block;
+}
+
+.toolbar-v-spinner {
+  animation: toolbar-v-spin 0.8s linear infinite;
+}
+
+@keyframes toolbar-v-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .toolbar-v-time {

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -22,6 +22,8 @@
   --radius: 12px;
   --radius-sm: 8px;
   --radius-pill: 999px;
+  --popover-shadow-gutter: 12px;
+  --overlay-shadow-gutter: 18px;
 
   --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
   --shadow-md:
@@ -75,6 +77,10 @@ body {
   overflow: visible;
 }
 
+body[data-clips-route="popover"] {
+  overflow: hidden;
+}
+
 html[data-clips-route]:not([data-clips-route="popover"]),
 body[data-clips-route]:not([data-clips-route="popover"]) {
   width: 100vw;
@@ -93,9 +99,18 @@ button {
   background: transparent;
 }
 
+body[data-clips-route="popover"] #root {
+  min-height: 100vh;
+  padding: var(--popover-shadow-gutter);
+}
+
 body[data-clips-route]:not([data-clips-route="popover"]) #root {
   height: 100vh;
   overflow: hidden;
+}
+
+body[data-clips-route="recording-pill"] #root {
+  padding: var(--overlay-shadow-gutter);
 }
 
 /* ------------------------------------------------------------------------- */
@@ -115,7 +130,9 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   box-shadow: var(--shadow-md);
   /* No fixed height — the Tauri window is resized to match the rendered
      content via resize_popover, so the shell just flows naturally. */
-  max-height: 100vh;
+  max-height: calc(
+    100vh - var(--popover-shadow-gutter) - var(--popover-shadow-gutter)
+  );
   overflow-y: auto;
   overscroll-behavior: contain;
 }
@@ -2163,7 +2180,7 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
 
 .toolbar-v {
   position: fixed;
-  inset: 0;
+  inset: var(--overlay-shadow-gutter);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -2176,6 +2193,9 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow:
+    0 18px 42px rgba(0, 0, 0, 0.42),
+    0 4px 12px rgba(0, 0, 0, 0.34);
   user-select: none;
   -webkit-user-select: none;
   cursor: grab;
@@ -2288,7 +2308,7 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
  */
 .bubble-wrapper {
   position: fixed;
-  inset: 0;
+  inset: var(--overlay-shadow-gutter);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -2311,6 +2331,9 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   border-radius: 50%;
   overflow: hidden;
   background: #000;
+  box-shadow:
+    0 22px 54px rgba(0, 0, 0, 0.28),
+    0 4px 14px rgba(0, 0, 0, 0.18);
   /* Position context for absolute children (close X, canvas). */
   position: relative;
   /* Cursor hint — the drag region is here. */
@@ -3078,7 +3101,7 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
    the words being recognized in real time. */
 .flow-bar-root {
   position: fixed;
-  inset: 0;
+  inset: var(--overlay-shadow-gutter);
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
- add transparent shadow gutters around Clips desktop popover and recording overlays so CSS shadows are not clipped by native WebView bounds
- keep the visible bubble, toolbar, flow bar, and popover anchored at their previous visual positions while expanding only the transparent window area
- make the countdown easier to read on light backgrounds, run it on full-second beats, and keep the start cue out of captured recordings
- show immediate stop feedback with busy stop controls and an earlier finalizing overlay while recording flushes
- replace the toolbar pause/play inline SVGs with Tabler icons

## Verification
- npx prettier --write templates/clips/desktop/src/lib/recorder.ts templates/clips/desktop/src/overlays/countdown.tsx templates/clips/desktop/src/overlays/toolbar.tsx templates/clips/desktop/src/overlays/recording-pill.tsx templates/clips/desktop/src/styles.css
- pnpm --dir templates/clips/desktop build
- pnpm --dir templates/clips/desktop exec tsc --noEmit
- cargo check --manifest-path templates/clips/desktop/src-tauri/Cargo.toml
- git diff --check

Note: browser preview of the desktop routes was limited because the overlay views call Tauri APIs that are only available in the Tauri WebView runtime.
