### PR TITLE
fix(clips): stop title regeneration spam

### DIFF
--- a/templates/clips/actions/list-recordings.ts
+++ b/templates/clips/actions/list-recordings.ts
@@ -9,10 +9,6 @@ import {
   isNotNull,
   sql,
 } from "drizzle-orm";
-
-function escapeLike(s: string): string {
-  return s.replace(/([\\%_])/g, "\\$1");
-}
 import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { accessFilter } from "@agent-native/core/sharing";
@@ -21,6 +17,29 @@ import {
   getActiveOrganizationId,
   parseSpaceIds,
 } from "../server/lib/recordings.js";
+
+function escapeLike(s: string): string {
+  return s.replace(/([\\%_])/g, "\\$1");
+}
+
+function transcriptHasText(
+  fullText: string | null | undefined,
+  segmentsJson: string | null | undefined,
+): boolean {
+  if (fullText?.trim()) return true;
+  if (!segmentsJson) return false;
+  try {
+    const parsed = JSON.parse(segmentsJson);
+    return (
+      Array.isArray(parsed) &&
+      parsed.some(
+        (segment) => typeof segment?.text === "string" && segment.text.trim(),
+      )
+    );
+  } catch {
+    return false;
+  }
+}
 
 export default defineAction({
   description:
@@ -141,14 +160,23 @@ export default defineAction({
           : [desc(schema.recordings.createdAt)];
 
     const rows = await db
-      .select()
+      .select({
+        recording: schema.recordings,
+        transcriptStatus: schema.recordingTranscripts.status,
+        transcriptFullText: schema.recordingTranscripts.fullText,
+        transcriptSegmentsJson: schema.recordingTranscripts.segmentsJson,
+      })
       .from(schema.recordings)
+      .leftJoin(
+        schema.recordingTranscripts,
+        eq(schema.recordingTranscripts.recordingId, schema.recordings.id),
+      )
       .where(and(...whereClauses))
       .orderBy(...orderBy)
       .limit(args.limit)
       .offset(args.offset);
 
-    const ids = rows.map((r) => r.id);
+    const ids = rows.map((r) => r.recording.id);
 
     // Gather tags for the result set in one query
     let tagsByRec: Record<string, string[]> = {};
@@ -184,34 +212,42 @@ export default defineAction({
       }
     }
 
-    const recordings = rows.map((r) => ({
-      id: r.id,
-      title: r.title,
-      titleSource: r.titleSource,
-      sourceAppName: r.sourceAppName,
-      sourceWindowTitle: r.sourceWindowTitle,
-      description: r.description,
-      thumbnailUrl: r.thumbnailUrl,
-      animatedThumbnailUrl: r.animatedThumbnailUrl,
-      durationMs: r.durationMs,
-      status: r.status,
-      uploadProgress: r.uploadProgress,
-      failureReason: r.failureReason,
-      visibility: r.visibility,
-      ownerEmail: r.ownerEmail,
-      folderId: r.folderId,
-      spaceIds: parseSpaceIds(r.spaceIds),
-      tags: tagsByRec[r.id] ?? [],
-      viewCount: viewsByRec[r.id] ?? 0,
-      createdAt: r.createdAt,
-      updatedAt: r.updatedAt,
-      archivedAt: r.archivedAt,
-      trashedAt: r.trashedAt,
-      hasAudio: Boolean(r.hasAudio),
-      hasCamera: Boolean(r.hasCamera),
-      width: r.width,
-      height: r.height,
-    }));
+    const recordings = rows.map((row) => {
+      const r = row.recording;
+      return {
+        id: r.id,
+        title: r.title,
+        titleSource: r.titleSource,
+        sourceAppName: r.sourceAppName,
+        sourceWindowTitle: r.sourceWindowTitle,
+        description: r.description,
+        thumbnailUrl: r.thumbnailUrl,
+        animatedThumbnailUrl: r.animatedThumbnailUrl,
+        durationMs: r.durationMs,
+        status: r.status,
+        uploadProgress: r.uploadProgress,
+        failureReason: r.failureReason,
+        visibility: r.visibility,
+        ownerEmail: r.ownerEmail,
+        folderId: r.folderId,
+        spaceIds: parseSpaceIds(r.spaceIds),
+        tags: tagsByRec[r.id] ?? [],
+        viewCount: viewsByRec[r.id] ?? 0,
+        createdAt: r.createdAt,
+        updatedAt: r.updatedAt,
+        archivedAt: r.archivedAt,
+        trashedAt: r.trashedAt,
+        hasAudio: Boolean(r.hasAudio),
+        hasCamera: Boolean(r.hasCamera),
+        width: r.width,
+        height: r.height,
+        transcriptStatus: row.transcriptStatus ?? null,
+        transcriptHasText: transcriptHasText(
+          row.transcriptFullText,
+          row.transcriptSegmentsJson,
+        ),
+      };
+    });
 
     return { recordings };
   },

--- a/templates/clips/actions/regenerate-title.ts
+++ b/templates/clips/actions/regenerate-title.ts
@@ -210,9 +210,13 @@ export default defineAction({
       (!args.transcriptText && transcript?.status !== "ready") ||
       !transcriptText
     ) {
-      throw new Error(
-        "Transcript is not ready yet. Try again after transcription finishes.",
-      );
+      return {
+        updated: false,
+        skipped: true,
+        reason: "transcript_not_ready",
+        recordingId: args.recordingId,
+        transcriptStatus: transcript?.status ?? "missing",
+      };
     }
 
     const agentsContext = await loadAgentsMdContext({

--- a/templates/clips/app/hooks/use-auto-title.ts
+++ b/templates/clips/app/hooks/use-auto-title.ts
@@ -101,7 +101,10 @@ export function useAutoTitleBridge(): void {
 
   const readyRecordings = recordings.filter((r) => r.status === "ready");
   const readyRecordingsKey = readyRecordings
-    .map((r) => `${r.id}:${r.titleSource ?? ""}:${r.title}:${r.updatedAt}`)
+    .map(
+      (r) =>
+        `${r.id}:${r.titleSource ?? ""}:${r.title}:${r.updatedAt}:${r.transcriptStatus ?? ""}:${r.transcriptHasText ? "1" : "0"}`,
+    )
     .join("|");
 
   useEffect(() => {
@@ -149,6 +152,13 @@ export function useAutoTitleBridge(): void {
             // ample time to write its own clips-ai-request entry. For freshly-
             // finalized clips the server request may still be en route; if we
             // dispatch now we'd block that richer transcript-backed delegation.
+            if (
+              rec.transcriptStatus !== "ready" ||
+              rec.transcriptHasText !== true
+            ) {
+              continue;
+            }
+
             const ageMs = Date.now() - new Date(rec.createdAt).getTime();
             const TWO_MINUTES_MS = 2 * 60 * 1000;
             if (ageMs < TWO_MINUTES_MS) continue;

--- a/templates/clips/app/hooks/use-library.ts
+++ b/templates/clips/app/hooks/use-library.ts
@@ -27,6 +27,8 @@ export interface RecordingSummary {
   hasCamera: boolean;
   width: number;
   height: number;
+  transcriptStatus?: "pending" | "streaming" | "ready" | "failed" | null;
+  transcriptHasText?: boolean;
 }
 
 export interface ListRecordingsArgs {
@@ -42,11 +44,21 @@ export interface ListRecordingsArgs {
 
 function isAwaitingAutoTitle(recording: RecordingSummary): boolean {
   const title = (recording.title ?? "").trim();
-  return (
+  const titleIsReplaceable =
     title === "" ||
     title === "Untitled recording" ||
     recording.titleSource === "default" ||
-    recording.titleSource === "context"
+    recording.titleSource === "context";
+  if (!titleIsReplaceable) return false;
+
+  if (recording.transcriptStatus === "failed") return false;
+  if (recording.transcriptStatus === "ready") {
+    return recording.transcriptHasText === true;
+  }
+
+  return (
+    recording.transcriptStatus === "pending" ||
+    recording.transcriptStatus === "streaming"
   );
 }
 

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -240,10 +240,17 @@ export default function RecordingPage() {
   const handleAiError = (err: Error) =>
     toast.error(err?.message ?? "AI request failed");
   const regenerateTitle = useActionMutation("regenerate-title" as any, {
-    onSuccess: (result: any) =>
-      toast.success(
-        result?.updated ? "Title updated" : "Title generation queued",
-      ),
+    onSuccess: (result: any) => {
+      if (result?.updated) {
+        toast.success("Title updated");
+      } else if (result?.skipped) {
+        toast.message("Transcript is not ready yet", {
+          description: "Try again after transcription finishes.",
+        });
+      } else {
+        toast.success("Title generation queued");
+      }
+    },
     onError: handleAiError,
   });
   const regenerateSummary = useActionMutation("regenerate-summary" as any, {


### PR DESCRIPTION
## Summary

Fixes the Clips auto-title fallback so opening a clip no longer triggers repeated `regenerate-title` calls for recordings whose transcripts are missing, pending, failed, or empty.

## Root cause

The client-side auto-title bridge listed all visible ready recordings and called `regenerate-title` for any old recording with a default/context title. That fallback did not know whether a transcript was actually ready, so stale recordings could repeatedly call the action and hit a server error.

## Changes

- Include transcript status/text availability in `list-recordings` results.
- Gate the auto-title fallback on `transcriptStatus === "ready"` and real transcript text.
- Return a structured skip from `regenerate-title` when transcript content is not ready instead of throwing a 500.
- Show a gentle toast when a manual title regeneration is skipped for transcript readiness.

## Validation

- `pnpm --filter clips typecheck`
