### PR TITLE
Fix: Builder connect flow fails when user has no active session

### DIFF
--- a/.changeset/grumpy-eggs-fix.md
+++ b/.changeset/grumpy-eggs-fix.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+fix builder connect 401 for unauthenticated users with a valid connect token

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -16,6 +16,7 @@ import {
   getCookie,
   setCookie,
   deleteCookie,
+  getRequestURL,
 } from "h3";
 import type { H3Event } from "h3";
 import path from "node:path";
@@ -665,21 +666,18 @@ export function createCoreRoutesPlugin(
 
     const resolveBuilderOwnerContext = async (
       event: H3Event,
+      mode?: "connect" | "callback",
     ): Promise<BuilderOwnerContext> => {
       const session = await getSession(event).catch(() => null);
       if (session?.email) {
         return { email: session.email, session, anonymous: false };
       }
 
-      const rawUrl = event.node?.req?.url ?? event.path ?? "/";
-      const queryStart = rawUrl.indexOf("?");
-      const rawPath = queryStart >= 0 ? rawUrl.slice(0, queryStart) : rawUrl;
-      const search = queryStart >= 0 ? rawUrl.slice(queryStart + 1) : "";
-      const path = stripAppBasePath(rawPath);
+      const searchParams = getRequestURL(event).searchParams;
 
-      if (path === `${P}/builder/connect`) {
+      if (mode === "connect") {
         const ownerFromConnectToken = verifyBuilderConnectTokenAndGetOwner(
-          new URLSearchParams(search).get(BUILDER_CONNECT_PARAM),
+          searchParams.get(BUILDER_CONNECT_PARAM),
         );
         if (ownerFromConnectToken) {
           return {
@@ -690,7 +688,7 @@ export function createCoreRoutesPlugin(
         }
       }
 
-      if (path === `${P}/builder/callback`) {
+      if (mode === "callback") {
         // Prefer the signed _an_state owner over the legacy
         // an_builder_connect_owner cookie. The cookie can be stale on a
         // shared browser — user A signed in earlier, user B starts a fresh
@@ -699,7 +697,7 @@ export function createCoreRoutesPlugin(
         // state is per-flow and TTL-bounded, so it's authoritative when
         // both are present.
         const ownerFromCallbackState = verifyBuilderCallbackStateAndGetOwner(
-          new URLSearchParams(search).get(BUILDER_STATE_PARAM),
+          searchParams.get(BUILDER_STATE_PARAM),
         );
         if (ownerFromCallbackState) {
           return {
@@ -967,7 +965,7 @@ export function createCoreRoutesPlugin(
     getH3App(nitroApp).use(
       `${P}/builder/connect`,
       defineEventHandler(async (event) => {
-        const ownerContext = await resolveBuilderOwnerContext(event);
+        const ownerContext = await resolveBuilderOwnerContext(event, "connect");
         const ownerEmail = ownerContext.email;
         if (!ownerEmail) {
           setResponseStatus(event, 401);
@@ -1224,7 +1222,10 @@ export function createCoreRoutesPlugin(
         // A real session or a template-approved anonymous owner is required;
         // the pending-row check below (combined with the same-origin gate on
         // /builder/connect) blocks CSRF and callback replay.
-        const ownerContext = await resolveBuilderOwnerContext(event);
+        const ownerContext = await resolveBuilderOwnerContext(
+          event,
+          "callback",
+        );
         const ownerEmail = ownerContext.email;
         // Diagnostic: log the resolver's inputs for debugging "No active
         // connect flow found" reports. Reveals session-vs-state owner


### PR DESCRIPTION
## What was broken

When a user without an active session hits `/_agent-native/builder/connect?_an_connect=<token>`, the server was returning a 401 even though the request carried a valid signed connect token.

The root cause is a subtle behavior of h3's `.use(path, handler)`: it strips the matched path prefix from `req.url` before invoking the handler. So inside the `/builder/connect` handler, `req.url` is `/?_an_connect=...` instead of `/_agent-native/builder/connect?_an_connect=...`.

`resolveBuilderOwnerContext` was reconstructing the path from `req.url` and checking it against the expected route strings. Because the path was always stripped to `/`, neither the `builder/connect` check nor the `builder/callback` check ever matched — the signed token in the query string was never verified, and the function returned `email: undefined`, causing a 401.

## What changed

**`resolveBuilderOwnerContext` now accepts an optional `mode` parameter** (`"connect"` or `"callback"`) instead of trying to infer the route from the request URL.