### PR TITLE
Fix collectionId passing undefined in image generation

### DIFF
--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -204,7 +204,7 @@ export async function generateWithBuilderImageApi(
         resourceId: input.libraryId,
       },
       metadata: {
-        collectionId: input.collectionId,
+        collectionId: input.collectionId ?? undefined,
         callerAppId: input.callerAppId,
         source: input.source,
         groundingMode: input.groundingMode,


### PR DESCRIPTION
### Summary
Fixes a bug in the image generation flow where `collectionId` could be passed as `null` to the Builder Image API instead of being omitted from the metadata.

### Problem
In the assets/images template, image generation was failing due to `collectionId` potentially being `null` when not provided. The Builder Image API does not accept `null` for this field, causing generation requests to fail.

### Solution
Apply a nullish coalescing fallback (`?? undefined`) to `collectionId` so that a `null` value is coerced to `undefined`, effectively omitting the field from the metadata payload sent to the API.

### Key Changes
- In `templates/assets/server/lib/generation.ts`, changed `collectionId: input.collectionId` to `collectionId: input.collectionId ?? undefined` to ensure `null` values are not forwarded to the API metadata.


---

<a href="https://builder.io/app/projects/ae8cb7b8045d4c21b2a343e11036d454/thin-divide-jtdnvhaj"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ae8cb7b8045d4c21b2a343e11036d454-thin-divide-jtdnvhaj_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ae8cb7b8045d4c21b2a343e11036d454&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 910`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ae8cb7b8045d4c21b2a343e11036d454</projectId>-->
<!--<branchName>thin-divide-jtdnvhaj</branchName>-->