### PR TITLE
Fix Clips Windows: Setup Open buttons not working (Screen Recording, Microphone, Speech Recognition)

### DIFF
--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -355,6 +355,8 @@ const MACOS_PRIVACY_URLS: Record<MacosPrivacyPane, string> = {
 const WINDOWS_PRIVACY_URLS: Partial<Record<MacosPrivacyPane, string>> = {
   camera: "ms-settings:privacy-webcam",
   microphone: "ms-settings:privacy-microphone",
+  // No dedicated screen-capture privacy page that works on all Windows
+  // versions, so open the top-level Privacy settings page.
   screen: "ms-settings:privacy",
   speech: "ms-settings:privacy-speechtyping",
   accessibility: "ms-settings:easeofaccess",

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -352,22 +352,59 @@ const MACOS_PRIVACY_URLS: Record<MacosPrivacyPane, string> = {
     "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent",
 };
 
+const WINDOWS_PRIVACY_URLS: Partial<Record<MacosPrivacyPane, string>> = {
+  camera: "ms-settings:privacy-webcam",
+  microphone: "ms-settings:privacy-microphone",
+  screen: "ms-settings:privacy",
+  speech: "ms-settings:privacy-speechtyping",
+  accessibility: "ms-settings:easeofaccess",
+  "input-monitoring": "ms-settings:privacy",
+};
+
 function isMacPlatform(): boolean {
   return typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 }
 
-function openMacosPrivacySettings(pane: MacosPrivacyPane): void {
-  if (!isMacPlatform()) return;
-  invoke("open_macos_privacy_settings", { pane }).catch((nativeErr) => {
-    console.warn(
-      "[clips-tray] native macOS privacy settings open failed; falling back:",
-      nativeErr,
-    );
-    openExternal(MACOS_PRIVACY_URLS[pane]).catch((err) => {
-      console.error("[clips-tray] open macOS privacy settings failed:", err);
-    });
-  });
+function isWindowsPlatform(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    (/Win/i.test(navigator.platform) ||
+      /Win/i.test(
+        (navigator as { userAgentData?: { platform?: string } }).userAgentData
+          ?.platform ?? "",
+      ))
+  );
 }
+
+function openPrivacySettings(pane: MacosPrivacyPane): void {
+  if (isMacPlatform()) {
+    invoke("open_macos_privacy_settings", { pane }).catch((nativeErr) => {
+      console.warn(
+        "[clips-tray] native macOS privacy settings open failed; falling back:",
+        nativeErr,
+      );
+      openExternal(MACOS_PRIVACY_URLS[pane]).catch((err) => {
+        console.error("[clips-tray] open macOS privacy settings failed:", err);
+      });
+    });
+    return;
+  }
+  if (isWindowsPlatform()) {
+    const url = WINDOWS_PRIVACY_URLS[pane];
+    if (url) {
+      openExternal(url).catch((err) => {
+        console.error(
+          "[clips-tray] open Windows privacy settings failed:",
+          err,
+        );
+      });
+    }
+    return;
+  }
+}
+
+// Keep backward-compatible alias so all existing call-sites continue to work.
+const openMacosPrivacySettings = openPrivacySettings;
 
 function nativeVoiceProvider(): VoiceProvider {
   return isMacPlatform() ? "macos-native" : "browser";
@@ -1997,13 +2034,21 @@ export function App() {
         localRecordingMode,
         preAcquiredCameraStream,
       });
-      // Park the popover to its 2×2 pinhole IMMEDIATELY — we want the
-      // popover to vanish the instant the user clicks Start, before the
-      // screen picker has a chance to enumerate windows. Fire-and-forget;
-      // the recording promise was already dispatched above so
-      // getDisplayMedia has already captured the user gesture.
-      invoke("park_popover_offscreen").catch(() => {});
-      emit("clips:popover-visible", false).catch(() => {});
+      // macOS: park the popover to its 2×2 pinhole IMMEDIATELY so it
+      // doesn't appear in the screen picker window list. The native
+      // Rust recorder used for full-screen doesn't need getDisplayMedia
+      // at all, so parking is always safe on macOS.
+      //
+      // Windows: do NOT park before getDisplayMedia resolves. On Windows,
+      // the WebView2 screen picker UI renders within the popover webview —
+      // shrinking the window to 2×2 makes the picker invisible and the
+      // user can never select a screen. The recorder.ts code parks the
+      // popover itself (line ~2165) AFTER the streams are acquired, which
+      // is the correct time on Windows.
+      if (isMacPlatform()) {
+        invoke("park_popover_offscreen").catch(() => {});
+        emit("clips:popover-visible", false).catch(() => {});
+      }
 
       // No watchdog — the macOS screen picker can stay open indefinitely
       // (a user deciding which window to capture may take 20, 60, 180
@@ -2655,7 +2700,7 @@ function PermissionRecoveryBanner({
         <div className="permission-title">{title}</div>
         <div>{message}</div>
       </div>
-      <div className="permission-actions" aria-label="Open macOS permissions">
+      <div className="permission-actions" aria-label="Open privacy settings">
         {uniquePanes.map((pane) => (
           <button
             type="button"

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -919,6 +919,9 @@ body[data-clips-route="recording-pill"] #root {
   flex-direction: column;
   gap: 2px;
   padding: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .readiness-item {


### PR DESCRIPTION
### Summary
This PR fixes the Clips recording feature on Windows, where the app would get stuck when attempting to start a recording and privacy settings buttons were non-functional.

### Problem
On Windows, clicking "Start Recording" in Clips caused the app to freeze. The root cause was that the popover window was immediately shrunk to a 2×2 pixel pinhole before `getDisplayMedia` resolved — on Windows, the screen picker UI renders inside the popover WebView2 window, so shrinking it made the picker invisible and unselectable. Additionally, privacy settings buttons (screen recording, microphone, speech recognition, etc.) did nothing on Windows because only macOS URLs were defined, and the permission actions list had no scroll support.

### Solution
- Gate the early popover-parking logic behind `isMacPlatform()` so Windows users see the screen picker correctly. On Windows, the popover is parked after streams are acquired (handled in `recorder.ts`).
- Add a `WINDOWS_PRIVACY_URLS` map with `ms-settings:` deep links for each privacy pane, and a cross-platform `openPrivacySettings` function that dispatches to the correct OS handler.
- Add scroll support to the permission actions list via CSS so it doesn't overflow on smaller windows.

### Key Changes
- **`app.tsx`**: Added `isWindowsPlatform()` helper and `WINDOWS_PRIVACY_URLS` map with `ms-settings:` deep links for camera, microphone, screen, speech, accessibility, and input monitoring.
- **`app.tsx`**: Replaced `openMacosPrivacySettings` with a unified `openPrivacySettings` function that branches on macOS vs. Windows; kept `openMacosPrivacySettings` as a backward-compatible alias.
- **`app.tsx`**: Wrapped `invoke("park_popover_offscreen")` and `emit("clips:popover-visible", false)` in an `isMacPlatform()` guard to prevent the screen picker from being hidden on Windows.
- **`app.tsx`**: Updated `aria-label` from "Open macOS permissions" to "Open privacy settings" to be platform-agnostic.
- **`styles.css`**: Added `max-height: 240px`, `overflow-y: auto`, and `overscroll-behavior: contain` to the permission actions container for proper scrollability.

---

<a href="https://builder.io/app/projects/ae8cb7b8045d4c21b2a343e11036d454/story-cipher-1323zk5v"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://ae8cb7b8045d4c21b2a343e11036d454-story-cipher-1323zk5v_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=ae8cb7b8045d4c21b2a343e11036d454&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 911`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ae8cb7b8045d4c21b2a343e11036d454</projectId>-->
<!--<branchName>story-cipher-1323zk5v</branchName>-->