### PR TITLE
Remove browser token gate

### DIFF
--- a/.agents/skills/authentication/SKILL.md
+++ b/.agents/skills/authentication/SKILL.md
@@ -20,7 +20,7 @@ Auth is powered by **Better Auth** with account-first design. Every new user cre
 | **Production (default)**  | Better Auth with email/password + social providers (Google, GitHub). Organizations built in.                                             |
 | **`AUTH_MODE=local`**     | Explicit escape hatch. `getSession()` always returns `{ email: "local@localhost" }`. Set via `.env` or the onboarding page's "Use locally" button. |
 | **`AUTH_SKIP_EMAIL_VERIFICATION=1`** | QA/preview escape hatch for real email/password accounts. Signup skips email verification and does not send the signup verification email. Local dev/test skips verification by default; set `AUTH_SKIP_EMAIL_VERIFICATION=0` only when testing verification itself. Use `+qa` emails for test accounts. |
-| **`ACCESS_TOKEN` / `ACCESS_TOKENS`** | Simple token-based auth for production deployments.                                                                           |
+| **`ACCESS_TOKEN` / `ACCESS_TOKENS`** | Static bearer fallback for MCP/connect clients that cannot use OAuth. Not browser auth and never a token login page.         |
 | **`AUTH_DISABLED=true`**  | Skip auth entirely (for apps behind infrastructure-level auth like Cloudflare Access).                                                   |
 | **Custom**                | Pass your own `getSession` to `autoMountAuth(app, { getSession })`.                                                                     |
 
@@ -35,7 +35,7 @@ client, and complete authorization-code + PKCE at
 Access tokens are audience-bound to the exact MCP URL and carry user/org
 identity plus `mcp:read`, `mcp:write`, and/or `mcp:apps`; refresh tokens are
 stored hashed and rotate. Keep `ACCESS_TOKEN` and `agent-native connect` for
-local stdio proxying, fallback clients, and simple private deployments. The CLI
+local stdio proxying and fallback clients. The CLI
 uses the OAuth-native URL-only entry for Claude Code/Claude Code CLI by
 default; use the Connect page or `agent-native connect --token <token>` when a
 client needs explicit bearer headers.

--- a/.changeset/remove-token-gate.md
+++ b/.changeset/remove-token-gate.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Remove browser-facing ACCESS_TOKEN auth gates and keep static bearer tokens limited to MCP/connect fallback clients.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -75,13 +75,13 @@ pnpm typecheck    # type-check
 
 Templates read from `.env` in their own directory. Key variables:
 
-| Variable               | Purpose                                                       |
-| ---------------------- | ------------------------------------------------------------- |
-| `DATABASE_URL`         | Database connection string (see below)                        |
-| `ANTHROPIC_API_KEY`    | API key for Claude (required for agent chat)                  |
-| `ACCESS_TOKEN`         | Enables auth in production mode; without it, auth is bypassed |
-| `GOOGLE_CLIENT_ID`     | Google OAuth client ID (for Gmail, Calendar integrations)     |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret                                    |
+| Variable               | Purpose                                                          |
+| ---------------------- | ---------------------------------------------------------------- |
+| `DATABASE_URL`         | Database connection string (see below)                           |
+| `ANTHROPIC_API_KEY`    | API key for Claude (required for agent chat)                     |
+| `ACCESS_TOKEN`         | Static bearer fallback for MCP/connect clients; not browser auth |
+| `GOOGLE_CLIENT_ID`     | Google OAuth client ID (for Gmail, Calendar integrations)        |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret                                       |
 
 ### Database options
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -18,7 +18,7 @@ Auth modes:
 | ------------------- | ----------------------------------------------------------------------- |
 | Better Auth         | Default. Email/password + Google / GitHub social + organizations.       |
 | `AUTH_MODE=local`   | Solo local dev. Forces `getSession()` → `{ email: "local@localhost" }`. |
-| `ACCESS_TOKEN(S)`   | Simple shared-token deploys. No per-user identity.                      |
+| `ACCESS_TOKEN(S)`   | Static MCP/connect bearer fallback only; not browser auth.              |
 | `AUTH_DISABLED=1`   | Apps behind infrastructure auth (Cloudflare Access, VPN, etc.).         |
 | Custom `getSession` | BYOA — Auth.js, Clerk, Lucia, WorkOS, etc.                              |
 

--- a/packages/core/docs/content/authentication.md
+++ b/packages/core/docs/content/authentication.md
@@ -1,6 +1,6 @@
 ---
 title: "Authentication"
-description: "Better Auth integration with email/password, social providers, organizations, and access tokens."
+description: "Better Auth integration with email/password, social providers, organizations, and MCP bearer credentials."
 ---
 
 # Authentication
@@ -12,7 +12,6 @@ Agent-native apps use [Better Auth](https://better-auth.com) for authentication 
 Auth is configured automatically via `autoMountAuth(app)` in the auth server plugin. The behavior depends on your environment:
 
 - **Default:** Better Auth with email/password + social providers. Onboarding page shown on first visit.
-- **`ACCESS_TOKEN`:** Simple shared token for production.
 - **Remote MCP OAuth:** Standard OAuth 2.1 for MCP hosts such as Claude Code and ChatGPT connectors.
 - **Custom:** Bring your own auth via `getSession` callback.
 
@@ -20,7 +19,7 @@ Local development uses the same Better Auth flow as production — there is no d
 
 ## Better Auth (Default) {#better-auth}
 
-When no `ACCESS_TOKEN` is set, Better Auth powers authentication. It provides:
+By default, Better Auth powers authentication. It provides:
 
 - Email/password registration and login
 - Social providers (Google, GitHub, and 35+ others)
@@ -31,7 +30,7 @@ When no `ACCESS_TOKEN` is set, Better Auth powers authentication. It provides:
 Better Auth routes are mounted at `/_agent-native/auth/ba/*`. The framework also provides backward-compatible endpoints:
 
 - `GET /_agent-native/auth/session` — get current session
-- `POST /_agent-native/auth/login` — email/password or token login
+- `POST /_agent-native/auth/login` — email/password login
 - `POST /_agent-native/auth/register` — create account
 - `POST /_agent-native/auth/logout` — sign out
 
@@ -113,9 +112,9 @@ Better Auth's organization plugin is built into the framework. Every app support
 
 The active organization flows automatically through the system: `session.orgId` → `AGENT_ORG_ID` → SQL scoping. See the [Security & Data Scoping](/docs/security) docs for details.
 
-## Access Tokens {#access-tokens}
+## Static MCP Bearer Tokens {#access-tokens}
 
-For simple deployments, set `ACCESS_TOKEN` (single) or `ACCESS_TOKENS` (comma-separated) as environment variables:
+`ACCESS_TOKEN` and `ACCESS_TOKENS` are not browser auth and do not make an app private. They remain only as static bearer credentials for MCP/connect clients that cannot use the OAuth flow.
 
 ```bash
 # Single token
@@ -125,7 +124,7 @@ ACCESS_TOKEN=my-secret-token
 ACCESS_TOKENS=token1,token2,token3
 ```
 
-When access tokens are configured, users see a token login page. Sessions are cookie-based with 30-day expiry.
+Configuring these variables never renders a token login page for visitors. Web sign-in stays on Better Auth or your custom `getSession` provider.
 
 ## Remote MCP OAuth {#remote-mcp-oauth}
 
@@ -284,7 +283,7 @@ The default `/_agent-native/google/auth-url` route does this automatically — o
 | `GOOGLE_CLIENT_SECRET`         | Google OAuth secret                                                                                                               |
 | `GITHUB_CLIENT_ID`             | Enable GitHub OAuth                                                                                                               |
 | `GITHUB_CLIENT_SECRET`         | GitHub OAuth secret                                                                                                               |
-| `ACCESS_TOKEN`                 | Simple shared token auth                                                                                                          |
-| `ACCESS_TOKENS`                | Comma-separated shared tokens                                                                                                     |
+| `ACCESS_TOKEN`                 | Static bearer fallback for MCP/connect clients; not browser auth                                                                  |
+| `ACCESS_TOKENS`                | Comma-separated static bearer fallbacks for MCP/connect clients; not browser auth                                                 |
 | `A2A_SECRET`                   | Shared secret for JWT-signed A2A cross-app identity verification and, when present, MCP OAuth access-token signing                |
 | `AUTH_DISABLED`                | Set to `true` to skip auth (infrastructure-level auth)                                                                            |

--- a/packages/core/docs/content/deployment.md
+++ b/packages/core/docs/content/deployment.md
@@ -233,8 +233,8 @@ These must be set before promoting an app to a real prod deploy. Missing values 
 
 | Variable                       | Description                                                                                                                                                                                   |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ACCESS_TOKEN`                 | Single shared token for simple production deploys (alternative to Better Auth).                                                                                                               |
-| `ACCESS_TOKENS`                | Comma-separated list of access tokens.                                                                                                                                                        |
+| `ACCESS_TOKEN`                 | Static bearer fallback for MCP/connect clients that cannot use OAuth. Does not enable browser auth or make the app private.                                                                   |
+| `ACCESS_TOKENS`                | Comma-separated static bearer fallbacks for MCP/connect clients. Does not enable browser auth or make the app private.                                                                        |
 | `AUTH_SKIP_EMAIL_VERIFICATION` | Skip email verification for QA accounts. Local dev/test skips by default; hosted deploys must set this explicitly. **Disables a real security control** — only use on hosted QA environments. |
 | `GOOGLE_CLIENT_ID`             | Google OAuth client ID. Auto-enables "Sign in with Google" in Better Auth.                                                                                                                    |
 | `GOOGLE_CLIENT_SECRET`         | Google OAuth client secret.                                                                                                                                                                   |

--- a/packages/core/src/onboarding/default-steps.ts
+++ b/packages/core/src/onboarding/default-steps.ts
@@ -212,23 +212,6 @@ const authStep: OnboardingStep = {
         ],
       },
     },
-    {
-      id: "access-token",
-      kind: "form",
-      label: "Shared access token",
-      description: "Use a simple token gate for private deployments.",
-      payload: {
-        writeScope: "workspace",
-        fields: [
-          {
-            key: "ACCESS_TOKEN",
-            label: "ACCESS_TOKEN",
-            placeholder: "Paste a strong shared token",
-            secret: true,
-          },
-        ],
-      },
-    },
   ],
   isComplete: () => true,
 };

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -370,10 +370,22 @@ describe("server/auth", () => {
       ).toBe("https://fallback.example/_agent-native/google/callback");
     });
 
-    it("mounts auth when ACCESS_TOKEN is set in production", async () => {
+    it("uses Better Auth, not token-only browser auth, when ACCESS_TOKEN is set", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("ACCESS_TOKEN", "my-secret");
       vi.stubEnv("DEBUG", "1");
+      vi.doMock("./better-auth-instance.js", () => ({
+        getBetterAuth: vi.fn(async () => ({
+          handler: vi.fn(async () => new Response("{}")),
+          api: {
+            getSession: vi.fn(async () => null),
+            signInEmail: vi.fn(),
+            signUpEmail: vi.fn(),
+            signOut: vi.fn(),
+          },
+        })),
+        getBetterAuthSync: vi.fn(() => undefined),
+      }));
       const { autoMountAuth } = await import("./auth.js");
 
       const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -381,16 +393,32 @@ describe("server/auth", () => {
       const result = await autoMountAuth(app);
 
       expect(result).toBe(true);
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining("1 access token(s)"),
-      );
+      const paths = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .filter((path: unknown): path is string => typeof path === "string");
+      expect(paths).toContain("/_agent-native/auth/ba");
+      const allLogs = logSpy.mock.calls.map((c) => c[0]).join(" ");
+      expect(allLogs).toContain("Better Auth");
+      expect(allLogs).not.toContain("access token");
       logSpy.mockRestore();
     });
 
-    it("renders a clearer access-token login page with mounted auth paths", async () => {
+    it("does not render an access-token login page when ACCESS_TOKEN is set", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("ACCESS_TOKEN", "my-secret");
       vi.stubEnv("APP_BASE_PATH", "/demo");
+      vi.doMock("./better-auth-instance.js", () => ({
+        getBetterAuth: vi.fn(async () => ({
+          handler: vi.fn(async () => new Response("{}")),
+          api: {
+            getSession: vi.fn(async () => null),
+            signInEmail: vi.fn(),
+            signUpEmail: vi.fn(),
+            signOut: vi.fn(),
+          },
+        })),
+        getBetterAuthSync: vi.fn(() => undefined),
+      }));
       const { autoMountAuth } = await import("./auth.js");
 
       const app = createMockApp();
@@ -406,23 +434,20 @@ describe("server/auth", () => {
       expect((result as Response).status).toBe(401);
 
       const html = await (result as Response).text();
-      expect(html).toContain("This app is private");
-      expect(html).toContain("not your deploy provider account token");
-      expect(html).toContain('var configuredBasePath = "/demo";');
-      expect(html).toContain("__anPath('/_agent-native/auth/login')");
-      expect(html).toContain("__anPath('/_agent-native/auth/session')");
-      expect(html).toContain("The token was accepted, but the browser");
+      expect(html).toContain("Create account");
+      expect(html).not.toContain("This app is private");
+      expect(html).not.toContain("Private deployment");
+      expect(html).not.toContain("ACCESS_TOKEN");
     });
 
-    it("infers mounted workspace auth paths when APP_BASE_PATH is absent", async () => {
+    it("custom auth without loginHtml does not render an access-token page", async () => {
       vi.stubEnv("NODE_ENV", "production");
-      vi.stubEnv("ACCESS_TOKEN", "my-secret");
-      vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
-      delete process.env.APP_BASE_PATH;
       const { autoMountAuth } = await import("./auth.js");
 
       const app = createMockApp();
-      await autoMountAuth(app);
+      await autoMountAuth(app, {
+        getSession: async () => null,
+      });
 
       const guard = app.use.mock.calls
         .map((call: any[]) => call[0])
@@ -433,8 +458,10 @@ describe("server/auth", () => {
       expect(result).toBeInstanceOf(Response);
 
       const html = await (result as Response).text();
-      expect(html).toContain('var configuredBasePath = "/starter";');
-      expect(html).toContain("__anPath('/_agent-native/auth/login')");
+      expect(html).toContain("Sign in is not configured");
+      expect(html).not.toContain("This app is private");
+      expect(html).not.toContain("Private deployment");
+      expect(html).not.toContain("ACCESS_TOKEN");
     });
 
     it("recognizes auth routes under APP_BASE_PATH in the global guard", async () => {
@@ -1396,11 +1423,23 @@ describe("server/auth", () => {
       });
     });
 
-    it("supports multiple ACCESS_TOKENS", async () => {
+    it("does not enable token-only browser auth when ACCESS_TOKENS is set", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("ACCESS_TOKENS", "token1, token2, token3");
       vi.stubEnv("DEBUG", "1");
       delete process.env.ACCESS_TOKEN;
+      vi.doMock("./better-auth-instance.js", () => ({
+        getBetterAuth: vi.fn(async () => ({
+          handler: vi.fn(async () => new Response("{}")),
+          api: {
+            getSession: vi.fn(async () => null),
+            signInEmail: vi.fn(),
+            signUpEmail: vi.fn(),
+            signOut: vi.fn(),
+          },
+        })),
+        getBetterAuthSync: vi.fn(() => undefined),
+      }));
       const { autoMountAuth } = await import("./auth.js");
 
       const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -1408,26 +1447,9 @@ describe("server/auth", () => {
       const result = await autoMountAuth(app);
 
       expect(result).toBe(true);
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining("3 access token(s)"),
-      );
-      logSpy.mockRestore();
-    });
-
-    it("deduplicates tokens across ACCESS_TOKEN and ACCESS_TOKENS", async () => {
-      vi.stubEnv("NODE_ENV", "production");
-      vi.stubEnv("ACCESS_TOKEN", "shared");
-      vi.stubEnv("ACCESS_TOKENS", "shared,unique1,unique2");
-      vi.stubEnv("DEBUG", "1");
-      const { autoMountAuth } = await import("./auth.js");
-
-      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-      const app = createMockApp();
-      await autoMountAuth(app);
-
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining("3 access token(s)"),
-      );
+      const allLogs = logSpy.mock.calls.map((c) => c[0]).join(" ");
+      expect(allLogs).toContain("Better Auth");
+      expect(allLogs).not.toContain("access token");
       logSpy.mockRestore();
     });
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -653,20 +653,6 @@ function getAccessTokens(): string[] {
   return tokens;
 }
 
-function safeTokenMatch(input: string, tokens: string[]): boolean {
-  const inputBuf = Buffer.from(input);
-  for (const token of tokens) {
-    const tokenBuf = Buffer.from(token);
-    if (
-      inputBuf.length === tokenBuf.length &&
-      crypto.timingSafeEqual(inputBuf, tokenBuf)
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
 function getBearerSessionToken(event: H3Event): string | undefined {
   const auth = getHeader(event, "authorization");
   if (!auth) return undefined;
@@ -2000,44 +1986,16 @@ function stripAppBasePath(pathname: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Login page HTML (ACCESS_TOKEN mode)
+// Fallback login page HTML (custom auth with no login page configured)
 // ---------------------------------------------------------------------------
 
-function inferWorkspaceBasePathFromRequest(requestPath?: string): string {
-  if (
-    process.env.AGENT_NATIVE_WORKSPACE !== "1" &&
-    process.env.VITE_AGENT_NATIVE_WORKSPACE !== "1"
-  ) {
-    return "";
-  }
-  if (!requestPath || !requestPath.startsWith("/")) return "";
-  const firstSegment = requestPath.split(/[/?#]/)[1];
-  if (!firstSegment) return "";
-  const reservedRootPaths = new Set([
-    "_agent-native",
-    ".well-known",
-    "api",
-    "login",
-    "signup",
-    "apps",
-    "new-app",
-    "approval",
-    "extensions",
-  ]);
-  if (reservedRootPaths.has(firstSegment)) return "";
-  if (!isValidWorkspaceAppIdFormat(firstSegment)) return "";
-  return `/${firstSegment}`;
-}
-
-function getTokenLoginHtml(options: { requestPath?: string } = {}): string {
-  const configuredBasePath =
-    getAppBasePath() || inferWorkspaceBasePathFromRequest(options.requestPath);
+function getCustomAuthRequiredHtml(): string {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<title>Private app</title>
+<title>Authentication required</title>
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   :root {
@@ -2050,18 +2008,10 @@ function getTokenLoginHtml(options: { requestPath?: string } = {}): string {
     --text: #f4f4f5;
     --muted: #a1a1aa;
     --subtle: #71717a;
-    --error: #fca5a5;
-    --error-bg: rgba(127,29,29,0.18);
-    --success: #86efac;
-    --success-bg: rgba(20,83,45,0.2);
-    --info: #c4b5fd;
-    --info-bg: rgba(76,29,149,0.18);
   }
   body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    background:
-      radial-gradient(circle at top left, rgba(63,63,70,0.24), transparent 32rem),
-      linear-gradient(180deg, #111114 0%, var(--bg) 58%);
+    background: linear-gradient(180deg, #111114 0%, var(--bg) 58%);
     color: var(--text);
     display: flex;
     align-items: center;
@@ -2105,107 +2055,11 @@ function getTokenLoginHtml(options: { requestPath?: string } = {}): string {
     font-size: 0.9375rem;
     line-height: 1.55;
   }
-  label {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 0.75rem;
-    font-size: 0.8125rem;
-    color: var(--muted);
-    margin-bottom: 0.375rem;
-  }
-  label span:last-child {
-    color: var(--subtle);
-    font-size: 0.75rem;
-  }
-  .input-wrap { position: relative; }
-  input {
-    width: 100%;
-    min-height: 2.75rem;
-    padding: 0.625rem 0.75rem;
-    background: #0f0f12;
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    color: var(--text);
-    font-size: 0.9375rem;
-    outline: none;
-  }
-  input:focus {
-    border-color: var(--border-strong);
-    box-shadow: 0 0 0 3px rgba(255,255,255,0.08);
-  }
-  input::placeholder { color: #52525b; }
-  button {
-    width: 100%;
-    min-height: 2.75rem;
-    margin-top: 1rem;
-    padding: 0.625rem 0.875rem;
-    background: var(--text);
-    color: #000;
-    border: none;
-    border-radius: 8px;
-    font-size: 0.9375rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: transform 120ms ease, opacity 120ms ease, background 120ms ease;
-  }
-  button:hover:not(:disabled) { background: #e4e4e7; transform: translateY(-1px); }
-  button:disabled { opacity: 0.55; cursor: wait; }
   .hint {
-    margin-top: 0.75rem;
-    color: var(--subtle);
-    font-size: 0.8125rem;
-    line-height: 1.45;
-  }
-  .msg {
-    display: none;
-    margin-top: 0.875rem;
-    padding: 0.75rem;
-    border-radius: 8px;
-    font-size: 0.8125rem;
-    line-height: 1.45;
-  }
-  .msg.show { display: block; }
-  .msg.error {
-    color: var(--error);
-    background: var(--error-bg);
-    border: 1px solid rgba(248,113,113,0.22);
-  }
-  .msg.success {
-    color: var(--success);
-    background: var(--success-bg);
-    border: 1px solid rgba(74,222,128,0.18);
-  }
-  .msg.info {
-    color: var(--info);
-    background: var(--info-bg);
-    border: 1px solid rgba(167,139,250,0.2);
-  }
-  details {
     margin-top: 1rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--border);
-  }
-  summary {
-    cursor: pointer;
-    color: var(--muted);
-    font-size: 0.8125rem;
-    font-weight: 600;
-  }
-  details p {
-    margin-top: 0.75rem;
     color: var(--subtle);
     font-size: 0.8125rem;
-    line-height: 1.5;
-  }
-  code {
-    color: #e4e4e7;
-    background: var(--panel-soft);
-    border: 1px solid var(--border);
-    border-radius: 5px;
-    padding: 0.075rem 0.25rem;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    font-size: 0.78rem;
+    line-height: 1.45;
   }
   @media (max-width: 480px) {
     .card { padding: 1.5rem; }
@@ -2215,118 +2069,11 @@ function getTokenLoginHtml(options: { requestPath?: string } = {}): string {
 </head>
 <body>
 <div class="card">
-  <div class="eyebrow">Private deployment</div>
-  <h1>This app is private</h1>
-  <p class="intro">Enter the shared app access token to continue. This is the value configured for this app, not your deploy provider account token.</p>
-  <form id="form">
-    <label for="token"><span>App ACCESS_TOKEN</span><span>Required</span></label>
-    <div class="input-wrap">
-      <input id="token" type="password" autocomplete="current-password" autofocus placeholder="Paste the shared app token" />
-    </div>
-    <button id="submit" type="submit">Continue</button>
-    <p class="hint">If someone sent you this app, ask them for the shared app token. If you own the deploy, use the exact value saved as <code>ACCESS_TOKEN</code> or one of <code>ACCESS_TOKENS</code>.</p>
-    <p class="msg error" id="msg" role="alert"></p>
-  </form>
-  <details>
-    <summary>Where do I find this?</summary>
-    <p>Create or copy the app's shared token from your deployment environment variables. The key should be <code>ACCESS_TOKEN</code> for one token or <code>ACCESS_TOKENS</code> for a comma-separated list. Redeploy after changing it.</p>
-  </details>
+  <div class="eyebrow">Authentication required</div>
+  <h1>Sign in is not configured</h1>
+  <p class="intro">This route requires an authenticated session, but this app's custom auth plugin did not provide a sign-in page.</p>
+  <p class="hint">If this route should be public, add it to the auth plugin's public route configuration. Otherwise configure a custom sign-in page for this app.</p>
 </div>
-<script>
-  var configuredBasePath = ${JSON.stringify(configuredBasePath)};
-  function __anBasePath() {
-    if (
-      configuredBasePath &&
-      (window.location.pathname === configuredBasePath ||
-        window.location.pathname.indexOf(configuredBasePath + '/') === 0)
-    ) {
-      return configuredBasePath;
-    }
-    var marker = '/_agent-native';
-    var idx = window.location.pathname.indexOf(marker);
-    return idx > 0 ? window.location.pathname.slice(0, idx) : '';
-  }
-  function __anPath(path) {
-    return __anBasePath() + path;
-  }
-  function setMessage(kind, text) {
-    var msg = document.getElementById('msg');
-    msg.textContent = text;
-    msg.className = 'msg ' + kind + ' show';
-  }
-  function clearMessage() {
-    var msg = document.getElementById('msg');
-    msg.textContent = '';
-    msg.className = 'msg error';
-  }
-  function setBusy(isBusy) {
-    var button = document.getElementById('submit');
-    var input = document.getElementById('token');
-    button.disabled = isBusy;
-    input.disabled = isBusy;
-    button.textContent = isBusy ? 'Checking...' : 'Continue';
-  }
-  async function readJsonSafely(res) {
-    try {
-      return await res.json();
-    } catch (_err) {
-      return null;
-    }
-  }
-  async function verifySession() {
-    var res = await fetch(__anPath('/_agent-native/auth/session'), {
-      method: 'GET',
-      credentials: 'same-origin',
-      cache: 'no-store',
-      headers: { 'Accept': 'application/json' },
-    });
-    if (!res.ok) return false;
-    var data = await readJsonSafely(res);
-    return !!data && !data.error;
-  }
-  document.getElementById('form').addEventListener('submit', async (e) => {
-    e.preventDefault();
-    var token = document.getElementById('token').value.trim();
-    if (!token) {
-      setMessage('error', 'Paste the shared app token to continue.');
-      return;
-    }
-    clearMessage();
-    setBusy(true);
-    setMessage('info', 'Checking the app token...');
-    try {
-      var res = await fetch(__anPath('/_agent-native/auth/login'), {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json',
-        },
-        credentials: 'same-origin',
-        body: JSON.stringify({ token: token }),
-      });
-      if (!res.ok) {
-        var badTokenMessage = 'That token was not accepted. Use this app\\'s shared ACCESS_TOKEN, not your deploy provider account token.';
-        if (res.status === 404) {
-          badTokenMessage = 'Could not reach this app\\'s auth endpoint. If this app is mounted under a path, confirm APP_BASE_PATH and VITE_APP_BASE_PATH match the deploy path.';
-        }
-        setMessage('error', badTokenMessage);
-        setBusy(false);
-        return;
-      }
-      var hasSession = await verifySession();
-      if (!hasSession) {
-        setMessage('error', 'The token was accepted, but the browser did not keep the session cookie. Try opening the app in a new tab, or check cookie restrictions for this domain.');
-        setBusy(false);
-        return;
-      }
-      setMessage('success', 'Signed in. Opening the app...');
-      window.location.replace(window.location.href);
-    } catch (_err) {
-      setMessage('error', 'Could not contact the auth endpoint. Check the deploy status, then try again.');
-      setBusy(false);
-    }
-  });
-</script>
 </body>
 </html>`;
 }
@@ -2689,8 +2436,6 @@ async function mountBetterAuthRoutes(
     }),
   );
 
-  const accessTokens = getAccessTokens();
-
   // Initialize Better Auth. Forward `googleScopes` into the BetterAuthConfig
   // so the social provider requests the broader product scopes (Gmail,
   // Calendar, etc.) up front during the primary sign-in — eliminating the
@@ -2909,22 +2654,6 @@ async function mountBetterAuthRoutes(
       }
 
       const body = await readBody(event);
-
-      // Legacy ACCESS_TOKEN login
-      if (
-        body?.token &&
-        typeof body.token === "string" &&
-        accessTokens.length > 0
-      ) {
-        if (!safeTokenMatch(body.token, accessTokens)) {
-          setResponseStatus(event, 401);
-          return { error: "Invalid token" };
-        }
-        const sessionToken = crypto.randomBytes(32).toString("hex");
-        await addSession(sessionToken, "user");
-        setFrameworkSessionCookie(event, sessionToken);
-        return authLoginResponse(event, sessionToken, "user");
-      }
 
       // Email/password login via Better Auth
       const email = body?.email?.trim?.()?.toLowerCase?.();
@@ -3147,81 +2876,6 @@ async function mountBetterAuthRoutes(
 }
 
 // ---------------------------------------------------------------------------
-// mountTokenOnlyRoutes — ACCESS_TOKEN-only auth (no Better Auth)
-// ---------------------------------------------------------------------------
-
-function mountTokenOnlyRoutes(
-  app: H3App,
-  accessTokens: string[],
-  publicPaths: string[] = [],
-  workspaceAppAudience = resolveWorkspaceAppAudience(),
-  workspaceAppRouteAccess = resolveWorkspaceAppRouteAccess(),
-): void {
-  app.use(
-    "/_agent-native/auth/login",
-    defineEventHandler(async (event) => {
-      if (getMethod(event) !== "POST") {
-        setResponseStatus(event, 405);
-        return { error: "Method not allowed" };
-      }
-
-      const body = await readBody(event);
-      if (
-        !body?.token ||
-        typeof body.token !== "string" ||
-        !safeTokenMatch(body.token, accessTokens)
-      ) {
-        setResponseStatus(event, 401);
-        return { error: "Invalid token" };
-      }
-      const sessionToken = crypto.randomBytes(32).toString("hex");
-      await addSession(sessionToken, "user");
-      setFrameworkSessionCookie(event, sessionToken);
-      return authLoginResponse(event, sessionToken, "user");
-    }),
-  );
-
-  app.use(
-    "/_agent-native/auth/logout",
-    defineEventHandler(async (event) => {
-      for (const cookie of getFrameworkSessionCookieValues(event)) {
-        await removeSession(cookie);
-      }
-      const bearerToken = getBearerSessionToken(event);
-      if (bearerToken) await removeSession(bearerToken);
-      clearFrameworkSessionCookies(event);
-      if (isElectronRequest(event)) await clearDesktopSso();
-      return { ok: true };
-    }),
-  );
-
-  app.use(
-    "/_agent-native/auth/session",
-    defineEventHandler(async (event) => {
-      if (!isReadMethod(event)) {
-        setResponseStatus(event, 405);
-        return { error: "Method not allowed" };
-      }
-      const session = await getSession(event);
-      return session ?? { error: "Not authenticated" };
-    }),
-  );
-
-  _authGuardConfig = {
-    loginHtml: getTokenLoginHtml(),
-    getLoginHtml: (_event, rawPath) =>
-      getTokenLoginHtml({ requestPath: rawPath }),
-    publicPaths,
-    workspaceAppAudience,
-    workspaceAppPublicPaths: workspaceAppRouteAccess.publicPaths,
-    workspaceAppProtectedPaths: workspaceAppRouteAccess.protectedPaths,
-  };
-  const guardFn = createAuthGuardFn();
-  _authGuardFn = guardFn;
-  app.use(defineEventHandler(guardFn));
-}
-
-// ---------------------------------------------------------------------------
 // mountAuthFallbackRoutes — minimal auth endpoints when Better Auth init fails
 // ---------------------------------------------------------------------------
 
@@ -3356,7 +3010,6 @@ function mountAuthFallbackRoutes(app: H3App): void {
  * Automatically configure auth based on environment and configuration:
  *
  * - **BYOA (custom getSession)**: Template-provided auth callback handles everything.
- * - **ACCESS_TOKEN/ACCESS_TOKENS**: Simple token-based auth.
  * - **Default**: Better Auth with email/password, social providers, organizations, and JWT.
  *   Users see an onboarding page to create an account on first visit.
  *
@@ -3484,14 +3137,13 @@ export async function autoMountAuth(
       }),
     );
 
-    const byoaLoginHtml = options.loginHtml ?? getTokenLoginHtml();
+    const byoaLoginHtml = options.loginHtml ?? getCustomAuthRequiredHtml();
     _authGuardConfig = {
       loginHtml: byoaLoginHtml,
       ...(options.loginHtml
         ? {}
         : {
-            getLoginHtml: (_event, rawPath) =>
-              getTokenLoginHtml({ requestPath: rawPath }),
+            getLoginHtml: () => getCustomAuthRequiredHtml(),
           }),
       publicPaths,
       workspaceAppAudience,
@@ -3504,23 +3156,6 @@ export async function autoMountAuth(
 
     if (process.env.DEBUG)
       console.log("[agent-native] Auth enabled — custom getSession provider.");
-    return true;
-  }
-
-  // ACCESS_TOKEN-only mode
-  const tokens = getAccessTokens();
-  if (tokens.length > 0) {
-    mountTokenOnlyRoutes(
-      app,
-      tokens,
-      publicPaths,
-      workspaceAppAudience,
-      workspaceAppRouteAccess,
-    );
-    if (process.env.DEBUG)
-      console.log(
-        `[agent-native] Auth enabled — ${tokens.length} access token(s) configured.`,
-      );
     return true;
   }
 
@@ -3563,5 +3198,9 @@ export async function autoMountAuth(
  * @deprecated Use `autoMountAuth(app, options?)` instead.
  */
 export function mountAuthMiddleware(app: H3App, accessToken: string): void {
-  mountTokenOnlyRoutes(app, [accessToken]);
+  void app;
+  void accessToken;
+  throw new Error(
+    "mountAuthMiddleware(accessToken) has been removed. Use createAuthPlugin() or autoMountAuth() with Better Auth, or a custom getSession provider.",
+  );
 }

--- a/packages/docs/netlify.toml
+++ b/packages/docs/netlify.toml
@@ -11,6 +11,8 @@
 
 [build.environment]
   NITRO_PRESET = "netlify"
+  AGENT_NATIVE_WORKSPACE_APP_AUDIENCE = "public"
+  VITE_AGENT_NATIVE_WORKSPACE_APP_AUDIENCE = "public"
 
 # SSR pages: keep browsers fresh, let the CDN serve stale while revalidating.
 [[headers]]

--- a/packages/docs/server/plugins/auth.ts
+++ b/packages/docs/server/plugins/auth.ts
@@ -1,4 +1,8 @@
-import { createAuthPlugin, getAppBasePath } from "@agent-native/core/server";
+import {
+  createAuthPlugin,
+  getAppBasePath,
+  type AuthOptions,
+} from "@agent-native/core/server";
 import { getCookie, getRequestURL, setCookie, type H3Event } from "h3";
 import { randomUUID } from "crypto";
 
@@ -21,7 +25,8 @@ function shouldCreateDocsSession(event: H3Event): boolean {
   return shouldCreateDocsSessionForPath(pathname);
 }
 
-export default createAuthPlugin({
+export const docsAuthOptions: AuthOptions = {
+  workspaceAppAudience: "public",
   getSession: async (event) => {
     const cookieName = "an_docs_session";
     let sessionId = getCookie(event, cookieName);
@@ -44,4 +49,6 @@ export default createAuthPlugin({
       userId: sessionId,
     };
   },
-});
+};
+
+export default createAuthPlugin(docsAuthOptions);

--- a/packages/docs/tests/auth.spec.ts
+++ b/packages/docs/tests/auth.spec.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { shouldCreateDocsSessionForPath } from "../server/plugins/auth.js";
+import {
+  docsAuthOptions,
+  shouldCreateDocsSessionForPath,
+} from "../server/plugins/auth.js";
 
 describe("docs auth session scoping", () => {
+  it("marks docs pages as public in runtime auth config", () => {
+    expect(docsAuthOptions.workspaceAppAudience).toBe("public");
+  });
+
   it("creates anonymous sessions for framework and API routes under a mount path", () => {
     expect(
       shouldCreateDocsSessionForPath(


### PR DESCRIPTION
## Summary
- remove browser-facing ACCESS_TOKEN / ACCESS_TOKENS auth gates and token login handling
- mark the docs app public at runtime and in Netlify build env
- update docs, onboarding, and auth guidance so ACCESS_TOKEN is only an MCP/connect bearer fallback

## Verification
- pnpm prep