### PR TITLE
Improve command search and credential fallback

### DIFF
--- a/.changeset/legacy-credential-key-fallback.md
+++ b/.changeset/legacy-credential-key-fallback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow extension key resolution to fall back to scoped app credentials after vault secrets miss.

--- a/packages/core/src/secrets/substitution.spec.ts
+++ b/packages/core/src/secrets/substitution.spec.ts
@@ -4,6 +4,7 @@ const mockReadAppSecret = vi.fn();
 const mockReadAppSecretMeta = vi.fn();
 const mockGetRequestOrgId = vi.fn();
 const mockGetRequestUserEmail = vi.fn();
+const mockResolveCredentialForScope = vi.fn();
 
 vi.mock("./storage.js", () => ({
   readAppSecret: (...args: any[]) => mockReadAppSecret(...args),
@@ -13,6 +14,11 @@ vi.mock("./storage.js", () => ({
 vi.mock("../server/request-context.js", () => ({
   getRequestOrgId: (...args: any[]) => mockGetRequestOrgId(...args),
   getRequestUserEmail: (...args: any[]) => mockGetRequestUserEmail(...args),
+}));
+
+vi.mock("../credentials/index.js", () => ({
+  resolveCredentialForScope: (...args: any[]) =>
+    mockResolveCredentialForScope(...args),
 }));
 
 import {
@@ -27,6 +33,7 @@ describe("resolveKeyReferencesWithRequestScopes", () => {
     mockGetRequestUserEmail.mockReturnValue("alice@example.test");
     mockReadAppSecret.mockResolvedValue(null);
     mockReadAppSecretMeta.mockResolvedValue(null);
+    mockResolveCredentialForScope.mockResolvedValue(undefined);
   });
 
   it("falls back from user scope to active org scope", async () => {
@@ -82,6 +89,58 @@ describe("resolveKeyReferencesWithRequestScopes", () => {
         scopeId: "solo:alice@example.test",
       },
     ]);
+  });
+
+  it("falls back to a legacy user credential after scoped secrets miss", async () => {
+    mockResolveCredentialForScope.mockImplementation(async (_key, { scope }) =>
+      scope === "user" ? "legacy-user-token" : undefined,
+    );
+
+    const result = await resolveKeyReferencesWithRequestScopes(
+      "Bearer ${keys.GITHUB_TOKEN}",
+      "alice@example.test",
+    );
+
+    expect(result.resolved).toBe("Bearer legacy-user-token");
+    expect(result.secretValues).toEqual(["legacy-user-token"]);
+    expect(result.resolvedKeys).toEqual([
+      {
+        name: "GITHUB_TOKEN",
+        scope: "user",
+        scopeId: "alice@example.test",
+      },
+    ]);
+    expect(mockResolveCredentialForScope).toHaveBeenCalledWith("GITHUB_TOKEN", {
+      userEmail: "alice@example.test",
+      orgId: "org_123",
+      scope: "user",
+    });
+  });
+
+  it("falls back to a legacy org credential after user credential misses", async () => {
+    mockResolveCredentialForScope.mockImplementation(async (_key, { scope }) =>
+      scope === "org" ? "legacy-org-token" : undefined,
+    );
+
+    const result = await resolveKeyReferencesWithRequestScopes(
+      "Bearer ${keys.GITHUB_TOKEN}",
+      "alice@example.test",
+    );
+
+    expect(result.resolved).toBe("Bearer legacy-org-token");
+    expect(result.secretValues).toEqual(["legacy-org-token"]);
+    expect(result.resolvedKeys).toEqual([
+      {
+        name: "GITHUB_TOKEN",
+        scope: "org",
+        scopeId: "org_123",
+      },
+    ]);
+    expect(mockResolveCredentialForScope).toHaveBeenCalledWith("GITHUB_TOKEN", {
+      userEmail: "alice@example.test",
+      orgId: "org_123",
+      scope: "org",
+    });
   });
 
   it("reads allowlists from the resolved scope", async () => {

--- a/packages/core/src/secrets/substitution.ts
+++ b/packages/core/src/secrets/substitution.ts
@@ -27,6 +27,7 @@
 
 import { readAppSecret, readAppSecretMeta } from "./storage.js";
 import type { SecretScope } from "./register.js";
+import { resolveCredentialForScope } from "../credentials/index.js";
 import {
   getRequestOrgId,
   getRequestUserEmail,
@@ -125,6 +126,7 @@ export async function resolveKeyReferences(
  * 2. active org scope (Dispatch vault sync writes here for org workspaces)
  * 3. active org workspace scope (legacy shared rows)
  * 4. solo workspace scope when no org is active
+ * 5. legacy app credential store user/org scopes
  */
 export async function resolveKeyReferencesWithRequestScopes(
   text: string,
@@ -175,7 +177,40 @@ async function readRequestScopedSecret(
     const result = await readAppSecret({ key: name, ...ref });
     if (result) return { value: result.value, ref: { name, ...ref } };
   }
+  const legacyCredential = await readLegacyCredential(name, userScopeId);
+  if (legacyCredential) return legacyCredential;
   return null;
+}
+
+async function readLegacyCredential(
+  name: string,
+  userScopeId: string,
+): Promise<{ value: string; ref: ResolvedKeyReference } | null> {
+  const orgId = getRequestOrgId();
+  const userValue = await resolveCredentialForScope(name, {
+    userEmail: userScopeId,
+    orgId,
+    scope: "user",
+  }).catch(() => undefined);
+  if (userValue) {
+    return {
+      value: userValue,
+      ref: { name, scope: "user", scopeId: userScopeId },
+    };
+  }
+
+  if (!orgId) return null;
+  const orgValue = await resolveCredentialForScope(name, {
+    userEmail: userScopeId,
+    orgId,
+    scope: "org",
+  }).catch(() => undefined);
+  if (!orgValue) return null;
+
+  return {
+    value: orgValue,
+    ref: { name, scope: "org", scopeId: orgId },
+  };
 }
 
 function requestSecretCandidates(

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -1128,12 +1128,14 @@ function handleDesktopShortcutBinding(binding: DesktopShortcutBinding) {
     mainWindow && !mainWindow.isDestroyed()
       ? mainWindow
       : BrowserWindow.getAllWindows()[0];
-  const isTargetAlreadyFrontmost =
-    Boolean(win && !win.isDestroyed() && win.isVisible() && win.isFocused()) &&
-    activeAppId === binding.app;
+  const isWindowFrontmost = Boolean(
+    win && !win.isDestroyed() && win.isVisible() && win.isFocused(),
+  );
+  const isTargetActive = activeAppId === binding.app;
 
-  if (binding.behavior === "toggle" && isTargetAlreadyFrontmost) {
-    hideMainWindowForShortcut();
+  if (binding.behavior === "toggle" && isTargetActive) {
+    if (isWindowFrontmost) hideMainWindowForShortcut();
+    else focusMainWindow();
     return;
   }
 

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -195,7 +195,7 @@ function canSoftOpenWebview(
 }
 
 function buildSoftOpenScript(path: string): string {
-  return `(() => fetch(${JSON.stringify(path)}, { credentials: "same-origin", redirect: "manual", cache: "no-store" }).then((response) => response.ok && response.type !== "opaqueredirect", () => false))()`;
+  return `(() => fetch(${JSON.stringify(path)}, { credentials: "same-origin", redirect: "manual", cache: "no-store" }).then(() => true, () => false))()`;
 }
 
 const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -271,6 +271,17 @@ body {
   display: none;
 }
 
+.sidebar:focus,
+.sidebar:focus-visible,
+.sidebar-nav:focus,
+.sidebar-nav:focus-visible,
+.sidebar-footer:focus,
+.sidebar-footer:focus-visible,
+.sidebar-item:focus,
+.sidebar-item:focus-visible {
+  outline: none;
+}
+
 .sidebar-footer {
   width: 100%;
   display: flex;

--- a/templates/analytics/app/components/layout/CommandPalette.tsx
+++ b/templates/analytics/app/components/layout/CommandPalette.tsx
@@ -20,7 +20,14 @@ import {
 import { useTheme } from "next-themes";
 import { dashboards } from "@/pages/adhoc/registry";
 import { getIdToken } from "@/lib/auth";
-import { appApiPath, useChangeVersions } from "@agent-native/core/client";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  agentNativePath,
+  appApiPath,
+  useChangeVersions,
+} from "@agent-native/core/client";
+import { extensionPath } from "@agent-native/core/client/extensions";
+import { commandPaletteKeywords } from "./command-palette-search";
 
 interface SavedConfig {
   id: string;
@@ -32,6 +39,12 @@ interface ExplorerDashboard {
   name: string;
 }
 
+interface ExtensionSearchItem {
+  id: string;
+  name: string;
+  description?: string;
+}
+
 const defaultTools = [
   { id: "explorer", name: "Explorer", href: "/adhoc/explorer" },
   {
@@ -40,6 +53,36 @@ const defaultTools = [
     href: "/adhoc/customer-health",
   },
 ];
+
+const loadingRowWidths = ["w-[58%]", "w-[71%]", "w-[84%]"] as const;
+
+function CommandLoadingGroup({
+  heading,
+  rows = 3,
+}: {
+  heading: string;
+  rows?: number;
+}) {
+  return (
+    <CommandGroup heading={heading} forceMount>
+      {Array.from({ length: rows }).map((_, index) => (
+        <CommandItem
+          key={`${heading}-loading-${index}`}
+          disabled
+          forceMount
+          value={`${heading} loading ${index + 1}`}
+        >
+          <Skeleton className="mr-2 h-4 w-4 shrink-0 rounded-sm" />
+          <Skeleton
+            className={`h-4 rounded ${
+              loadingRowWidths[index % loadingRowWidths.length]
+            }`}
+          />
+        </CommandItem>
+      ))}
+    </CommandGroup>
+  );
+}
 
 async function fetchSavedConfigs(): Promise<SavedConfig[]> {
   const token = await getIdToken();
@@ -73,8 +116,38 @@ async function fetchSqlDashboards(): Promise<{ id: string; name: string }[]> {
   if (!res.ok) return [];
   const data = await res.json();
   return (data.dashboards ?? [])
-    .filter((d: any) => d.name)
-    .map((d: any) => ({ id: d.id, name: d.name }));
+    .filter((d: any) => d && typeof d.id === "string" && d.id.length > 0)
+    .map((d: any) => ({
+      id: d.id,
+      name:
+        typeof d.name === "string" && d.name.trim().length > 0
+          ? d.name
+          : "Untitled dashboard",
+    }));
+}
+
+async function fetchExtensions(): Promise<ExtensionSearchItem[]> {
+  const res = await fetch(agentNativePath("/_agent-native/extensions"));
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (Array.isArray(data) ? data : [])
+    .filter((extension: any) => {
+      return (
+        extension &&
+        typeof extension.id === "string" &&
+        extension.id.length > 0 &&
+        typeof extension.name === "string" &&
+        extension.name.trim().length > 0
+      );
+    })
+    .map((extension: any) => ({
+      id: extension.id,
+      name: extension.name,
+      description:
+        typeof extension.description === "string"
+          ? extension.description
+          : undefined,
+    }));
 }
 
 function persistThemePreference(theme: "light" | "dark") {
@@ -91,7 +164,7 @@ export function CommandPalette() {
   const { resolvedTheme, setTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
 
-  const { data: savedCharts = [] } = useQuery({
+  const { data: savedCharts = [], isFetching: savedChartsFetching } = useQuery({
     queryKey: ["explorer-configs-palette"],
     queryFn: fetchSavedConfigs,
     staleTime: 30_000,
@@ -100,7 +173,10 @@ export function CommandPalette() {
 
   const dashboardsSync = useChangeVersions(["dashboards", "action"]);
 
-  const { data: explorerDashboards = [] } = useQuery({
+  const {
+    data: explorerDashboards = [],
+    isFetching: explorerDashboardsFetching,
+  } = useQuery({
     queryKey: ["explorer-dashboards-palette", dashboardsSync],
     queryFn: fetchExplorerDashboards,
     staleTime: 30_000,
@@ -108,9 +184,20 @@ export function CommandPalette() {
     placeholderData: (prev) => prev,
   });
 
-  const { data: sqlDashboards = [] } = useQuery({
-    queryKey: ["sql-dashboards-palette", dashboardsSync],
-    queryFn: fetchSqlDashboards,
+  const { data: sqlDashboards = [], isFetching: sqlDashboardsFetching } =
+    useQuery({
+      queryKey: ["sql-dashboards-palette", dashboardsSync],
+      queryFn: fetchSqlDashboards,
+      staleTime: 30_000,
+      enabled: open,
+      placeholderData: (prev) => prev,
+    });
+
+  const { data: extensions = [], isFetching: extensionsFetching } = useQuery<
+    ExtensionSearchItem[]
+  >({
+    queryKey: ["extensions"],
+    queryFn: fetchExtensions,
     staleTime: 30_000,
     enabled: open,
     placeholderData: (prev) => prev,
@@ -140,11 +227,21 @@ export function CommandPalette() {
     [navigate],
   );
 
+  const asyncGroupsLoading =
+    (explorerDashboardsFetching && explorerDashboards.length === 0) ||
+    (sqlDashboardsFetching && sqlDashboards.length === 0) ||
+    (extensionsFetching && extensions.length === 0) ||
+    (savedChartsFetching && savedCharts.length === 0);
+
   return (
     <CommandDialog open={open} onOpenChange={setOpen}>
-      <CommandInput placeholder="Search dashboards, tools, charts..." />
+      <CommandInput placeholder="Search dashboards, extensions, charts..." />
       <CommandList>
-        <CommandEmpty>No results found.</CommandEmpty>
+        {!asyncGroupsLoading && <CommandEmpty>No results found.</CommandEmpty>}
+
+        {explorerDashboardsFetching && explorerDashboards.length === 0 && (
+          <CommandLoadingGroup heading="Explorer Dashboards" rows={2} />
+        )}
 
         {explorerDashboards.length > 0 && (
           <CommandGroup heading="Explorer Dashboards">
@@ -152,6 +249,11 @@ export function CommandPalette() {
               <CommandItem
                 key={`ed-${d.id}`}
                 onSelect={() => go(`/adhoc/explorer-dashboard?id=${d.id}`)}
+                keywords={commandPaletteKeywords(
+                  d.name,
+                  "explorer dashboard",
+                  "dashboard",
+                )}
               >
                 <IconLayoutDashboard className="mr-2 h-4 w-4 text-muted-foreground" />
                 {d.name}
@@ -160,15 +262,48 @@ export function CommandPalette() {
           </CommandGroup>
         )}
 
+        {sqlDashboardsFetching && sqlDashboards.length === 0 && (
+          <CommandLoadingGroup heading="SQL Dashboards" rows={3} />
+        )}
+
         {sqlDashboards.length > 0 && (
           <CommandGroup heading="SQL Dashboards">
             {sqlDashboards.map((d) => (
               <CommandItem
                 key={`sql-${d.id}`}
                 onSelect={() => go(`/adhoc/${d.id}`)}
+                keywords={commandPaletteKeywords(
+                  d.name,
+                  "sql dashboard",
+                  "dashboard",
+                )}
               >
                 <IconLayoutDashboard className="mr-2 h-4 w-4 text-muted-foreground" />
                 {d.name}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {extensionsFetching && extensions.length === 0 && (
+          <CommandLoadingGroup heading="Extensions" rows={3} />
+        )}
+
+        {extensions.length > 0 && (
+          <CommandGroup heading="Extensions">
+            {extensions.map((extension) => (
+              <CommandItem
+                key={`extension-${extension.id}`}
+                onSelect={() => go(extensionPath(extension.id, extension.name))}
+                keywords={commandPaletteKeywords(
+                  extension.name,
+                  extension.description,
+                  "extension",
+                  "tool",
+                )}
+              >
+                <IconTool className="mr-2 h-4 w-4 text-muted-foreground" />
+                {extension.name}
               </CommandItem>
             ))}
           </CommandGroup>
@@ -179,6 +314,7 @@ export function CommandPalette() {
             <CommandItem
               key={`dash-${d.id}`}
               onSelect={() => go(`/adhoc/${d.id}`)}
+              keywords={commandPaletteKeywords(d.name, "dashboard")}
             >
               <IconFlask className="mr-2 h-4 w-4 text-muted-foreground" />
               {d.name}
@@ -188,7 +324,11 @@ export function CommandPalette() {
 
         <CommandGroup heading="Tools">
           {defaultTools.map((t) => (
-            <CommandItem key={`tool-${t.id}`} onSelect={() => go(t.href)}>
+            <CommandItem
+              key={`tool-${t.id}`}
+              onSelect={() => go(t.href)}
+              keywords={commandPaletteKeywords(t.name, "tool")}
+            >
               <IconTool className="mr-2 h-4 w-4 text-muted-foreground" />
               {t.name}
             </CommandItem>
@@ -213,12 +353,21 @@ export function CommandPalette() {
           </CommandItem>
         </CommandGroup>
 
+        {savedChartsFetching && savedCharts.length === 0 && (
+          <CommandLoadingGroup heading="Saved Charts" rows={2} />
+        )}
+
         {savedCharts.length > 0 && (
           <CommandGroup heading="Saved Charts">
             {savedCharts.map((c) => (
               <CommandItem
                 key={`chart-${c.id}`}
                 onSelect={() => go(`/adhoc/explorer?config=${c.id}`)}
+                keywords={commandPaletteKeywords(
+                  c.name,
+                  "saved chart",
+                  "chart",
+                )}
               >
                 <IconChartBar className="mr-2 h-4 w-4 text-muted-foreground" />
                 {c.name}

--- a/templates/analytics/app/components/layout/command-palette-search.spec.ts
+++ b/templates/analytics/app/components/layout/command-palette-search.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { commandPaletteKeywords } from "./command-palette-search";
+
+describe("commandPaletteKeywords", () => {
+  it("adds hyphen and space variants for resource names", () => {
+    const keywords = commandPaletteKeywords("Agent Native");
+
+    expect(keywords).toContain("Agent Native");
+    expect(keywords).toContain("Agent-Native");
+    expect(keywords).toContain("agent-native");
+    expect(keywords).toContain("AgentNative");
+  });
+
+  it("adds space variants for hyphenated extension names", () => {
+    const keywords = commandPaletteKeywords("Agent-Native stars");
+
+    expect(keywords).toContain("Agent Native stars");
+    expect(keywords).toContain("agent native stars");
+    expect(keywords).toContain("Agent-Native-stars");
+  });
+
+  it("skips empty values", () => {
+    expect(commandPaletteKeywords("", undefined, null)).toEqual([]);
+  });
+});

--- a/templates/analytics/app/components/layout/command-palette-search.ts
+++ b/templates/analytics/app/components/layout/command-palette-search.ts
@@ -1,0 +1,28 @@
+export function commandPaletteKeywords(
+  ...parts: Array<string | null | undefined>
+): string[] {
+  const variants = new Set<string>();
+
+  const add = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    variants.add(trimmed);
+    variants.add(trimmed.toLowerCase());
+  };
+
+  for (const part of parts) {
+    if (!part) continue;
+
+    add(part);
+
+    const spaced = part.replace(/[-_/]+/g, " ").replace(/\s+/g, " ");
+    const hyphenated = spaced.trim().replace(/\s+/g, "-");
+    const compact = spaced.trim().replace(/\s+/g, "");
+
+    add(spaced);
+    add(hyphenated);
+    add(compact);
+  }
+
+  return Array.from(variants);
+}


### PR DESCRIPTION
## Summary
- Index Analytics extensions in Cmd+K alongside dashboards, with non-blocking skeleton rows for async result groups.
- Add command search keyword variants so hyphenated and spaced resource names both match.
- Fall back from scoped vault secrets to legacy user/org credentials after scoped secret misses, with coverage and a core changeset.
- Adjust desktop shortcut toggling, soft-open probing behavior, and sidebar focus styling.

## Validation
- pnpm --filter @agent-native/core test -- src/secrets/substitution.spec.ts
- pnpm --filter @agent-native/desktop-app typecheck
- pnpm --filter analytics test -- app/components/layout/command-palette-search.spec.ts
- pnpm --filter analytics typecheck
- pnpm prep