### PR TITLE
Fix shared deck team-join deep links

### DIFF
--- a/.changeset/calm-anthropic-timeouts.md
+++ b/.changeset/calm-anthropic-timeouts.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Clamp hosted run soft timeouts below upstream hard walls and surface Anthropic tool input progress.

--- a/.changeset/default-social-meta.md
+++ b/.changeset/default-social-meta.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add shared default social image metadata helpers and SSR injection.

--- a/.changeset/free-open-source-badge.md
+++ b/.changeset/free-open-source-badge.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Update the open source badge copy to mention Agent Native is 100% free and open source.

--- a/.changeset/fresh-composer-line-breaks.md
+++ b/.changeset/fresh-composer-line-breaks.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the chat composer scrolled to the caret when inserting Shift+Enter line breaks.

--- a/.changeset/fresh-diagrams-walk.md
+++ b/.changeset/fresh-diagrams-walk.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Recover client API paths from the live workspace mount when a stale app base path points at another workspace app.

--- a/.changeset/lossless-agent-continuation.md
+++ b/.changeset/lossless-agent-continuation.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stop losing agent chat turns that span a serverless timeout. A turn that is cut off mid-stream (the Builder gateway's 45s wall or the function/heartbeat limit) and resumed via auto-continuation now folds every continuation run onto a single durable assistant message keyed by a stable `turnId`, instead of each run persisting only its own events and dropping the earlier text. This fixes the "the agent stopped, then the last paragraphs disappear and it says it's just getting started" failure: the streamed text and completed tool calls are preserved in `thread_data` (monotonic, never-shrinking) so reloads and follow-up turns keep full context. Errored/cut-off runs are also now classified (`error_code`/`error_detail`) and retained longer than completed runs so failure patterns can be analyzed.

--- a/.changeset/narrow-dispatch-glance.md
+++ b/.changeset/narrow-dispatch-glance.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Improve Dispatch overview stat card wrapping in narrow embedded windows.

--- a/.changeset/social-image-defaults.md
+++ b/.changeset/social-image-defaults.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Inject the default Agent-Native social image into SSR HTML when templates do not provide an OG image.

--- a/.changeset/sturdy-scaffold-cleanup.md
+++ b/.changeset/sturdy-scaffold-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Harden workspace scaffold test cleanup against transient filesystem races.

--- a/packages/core/src/agent/engine/anthropic-engine.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.ts
@@ -19,6 +19,7 @@ import {
   engineMessagesToAnthropic,
   anthropicContentToEngine,
   anthropicChunkToEngineEvents,
+  createAnthropicChunkStreamState,
 } from "./translate-anthropic.js";
 import { readDeployCredentialEnv } from "../../server/credential-provider.js";
 import { normalizeReasoningEffortForModel } from "../../shared/reasoning-effort.js";
@@ -126,9 +127,15 @@ class AnthropicEngine implements AgentEngine {
     let thinkingText = "";
     let thinkingSignature = "";
 
+    // Per-stream state lets the translator carry each tool-call's id/name from
+    // its `content_block_start` onto the streamed `input_json_delta` chunks, so
+    // long tool-input generation emits countable `tool-input-start` /
+    // `tool-input-delta` progress events (mirroring the Builder engine).
+    const chunkState = createAnthropicChunkStreamState();
+
     try {
       for await (const chunk of apiStream) {
-        const events = anthropicChunkToEngineEvents(chunk);
+        const events = anthropicChunkToEngineEvents(chunk, chunkState);
         for (const event of events) {
           if (event.type === "thinking-delta") {
             thinkingText += event.text;

--- a/packages/core/src/agent/engine/translate-anthropic.spec.ts
+++ b/packages/core/src/agent/engine/translate-anthropic.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
+  anthropicChunkToEngineEvents,
+  createAnthropicChunkStreamState,
   engineToolsToAnthropic,
   engineMessagesToAnthropic,
   engineMessagesToBuilderGatewayAnthropic,
@@ -308,5 +310,53 @@ describe("anthropicContentToEngine", () => {
       name: "my-tool",
       input: { x: 1 },
     });
+  });
+});
+
+describe("anthropicChunkToEngineEvents", () => {
+  it("emits tool input progress with id and name across streamed chunks", () => {
+    const state = createAnthropicChunkStreamState();
+
+    expect(
+      anthropicChunkToEngineEvents(
+        {
+          type: "content_block_start",
+          index: 1,
+          content_block: {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "create-extension",
+          },
+        },
+        state,
+      ),
+    ).toEqual([
+      {
+        type: "tool-input-start",
+        id: "toolu_1",
+        name: "create-extension",
+      },
+    ]);
+
+    expect(
+      anthropicChunkToEngineEvents(
+        {
+          type: "content_block_delta",
+          index: 1,
+          delta: {
+            type: "input_json_delta",
+            partial_json: '{"html":"<div',
+          },
+        },
+        state,
+      ),
+    ).toEqual([
+      {
+        type: "tool-input-delta",
+        id: "toolu_1",
+        name: "create-extension",
+        text: '{"html":"<div',
+      },
+    ]);
   });
 });

--- a/packages/core/src/agent/engine/translate-anthropic.ts
+++ b/packages/core/src/agent/engine/translate-anthropic.ts
@@ -400,13 +400,53 @@ export function anthropicContentToEngine(
 // ---------------------------------------------------------------------------
 
 /**
+ * Mutable state threaded across `anthropicChunkToEngineEvents` calls within a
+ * single stream. Anthropic's `content_block_delta` chunks carry only the block
+ * `index`, not the tool-call id/name — those arrive once on the matching
+ * `content_block_start`. We remember `index → { id, name }` here so each
+ * `input_json_delta` can be surfaced as a `tool-input-delta` carrying the same
+ * id/name the consumer expects (mirroring the Builder gateway shape).
+ */
+export interface AnthropicChunkStreamState {
+  toolUseByIndex: Map<number, { id: string; name: string }>;
+}
+
+export function createAnthropicChunkStreamState(): AnthropicChunkStreamState {
+  return { toolUseByIndex: new Map() };
+}
+
+/**
  * Translate an Anthropic stream chunk into zero or more EngineEvents.
  * Called in a loop as chunks arrive from client.messages.stream().
+ *
+ * Pass a per-stream `state` (from `createAnthropicChunkStreamState`) to also
+ * emit `tool-input-start` / `tool-input-delta` progress events while a tool
+ * call's JSON input streams in. These are progress-only signals: the
+ * authoritative `tool-call` blocks are still emitted from `finalMessage()` by
+ * the engine, so omitting `state` simply drops the progress events without
+ * changing tool dispatch.
  */
-export function anthropicChunkToEngineEvents(chunk: any): EngineEvent[] {
+export function anthropicChunkToEngineEvents(
+  chunk: any,
+  state?: AnthropicChunkStreamState,
+): EngineEvent[] {
   const events: EngineEvent[] = [];
 
-  if (chunk.type === "content_block_delta") {
+  if (chunk.type === "content_block_start") {
+    const block = chunk.content_block;
+    if (block?.type === "tool_use") {
+      const id = typeof block.id === "string" ? block.id : undefined;
+      const name = typeof block.name === "string" ? block.name : undefined;
+      if (state && typeof chunk.index === "number" && id && name) {
+        state.toolUseByIndex.set(chunk.index, { id, name });
+      }
+      events.push({
+        type: "tool-input-start",
+        ...(id ? { id } : {}),
+        ...(name ? { name } : {}),
+      });
+    }
+  } else if (chunk.type === "content_block_delta") {
     if (chunk.delta?.type === "text_delta") {
       events.push({ type: "text-delta", text: chunk.delta.text });
     } else if (chunk.delta?.type === "thinking_delta") {
@@ -418,6 +458,23 @@ export function anthropicChunkToEngineEvents(chunk: any): EngineEvent[] {
         type: "thinking-delta",
         text: "",
         signature: chunk.delta.signature,
+      });
+    } else if (chunk.delta?.type === "input_json_delta") {
+      // Partial JSON for a streaming tool-call input. Surface as countable
+      // progress so long tool inputs (e.g. large extension HTML) don't look
+      // hung to the agent loop's tool-input activity heartbeat.
+      const active =
+        state && typeof chunk.index === "number"
+          ? state.toolUseByIndex.get(chunk.index)
+          : undefined;
+      events.push({
+        type: "tool-input-delta",
+        ...(active?.id ? { id: active.id } : {}),
+        ...(active?.name ? { name: active.name } : {}),
+        text:
+          typeof chunk.delta.partial_json === "string"
+            ? chunk.delta.partial_json
+            : "",
       });
     }
   }

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1972,6 +1972,7 @@ export function createProductionAgentHandler(
       attachments,
       displayMessage,
       internalContinuation,
+      turnId: requestTurnId,
       model: requestModel,
       engine: requestEngine,
       effort: requestEffort,
@@ -2824,6 +2825,13 @@ export function createProductionAgentHandler(
       {
         softTimeoutMs: options.runSoftTimeoutMs,
         useHostedSoftTimeoutDefault: true,
+        // Fold continuation runs of one logical turn onto a single durable
+        // assistant message. Falls back to the runId (turn == run) when the
+        // client doesn't supply a turnId.
+        turnId:
+          typeof requestTurnId === "string" && requestTurnId.trim()
+            ? requestTurnId.trim()
+            : runId,
       },
     );
 

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -31,6 +31,7 @@ import {
   abortRun,
   DEFAULT_COMPLETED_RUN_RETENTION_MS,
   DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS,
+  HOSTED_SOFT_TIMEOUT_CEILING_MS,
   getActiveRunForThreadAsync,
   resolveCompletedRunRetentionMs,
   resolveRunSoftTimeoutMs,
@@ -211,6 +212,23 @@ describe("run manager soft timeout", () => {
 
     expect(resolveRunSoftTimeoutMs(undefined, { useHostedDefault: true })).toBe(
       0,
+    );
+  });
+
+  it("clamps hosted soft timeout overrides under the gateway hard wall", () => {
+    process.env.NETLIFY = "true";
+
+    expect(resolveRunSoftTimeoutMs(240_000)).toBe(
+      HOSTED_SOFT_TIMEOUT_CEILING_MS,
+    );
+  });
+
+  it("clamps hosted soft timeout env values under the gateway hard wall", () => {
+    process.env.NETLIFY = "true";
+    process.env.AGENT_RUN_SOFT_TIMEOUT_MS = "240000";
+
+    expect(resolveRunSoftTimeoutMs(undefined, { useHostedDefault: true })).toBe(
+      HOSTED_SOFT_TIMEOUT_CEILING_MS,
     );
   });
 

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -244,6 +244,24 @@ describe("run manager soft timeout", () => {
     expect(resolveCompletedRunRetentionMs()).toBe(60000);
   });
 
+  it("persists the logical turn id for continuation runs", async () => {
+    startRun(
+      "run-continuation-chunk",
+      "thread-continuation-chunk",
+      async () => {},
+      undefined,
+      { softTimeoutMs: 0, turnId: "turn-original" },
+    );
+
+    await vi.waitFor(() => {
+      expect(insertRun).toHaveBeenCalledWith(
+        "run-continuation-chunk",
+        "thread-continuation-chunk",
+        "turn-original",
+      );
+    });
+  });
+
   it("persists terminal error events before marking errored runs complete", async () => {
     let releaseTerminalEvent!: () => void;
     const terminalEventPersisted = new Promise<void>((resolve) => {

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -16,6 +16,7 @@ vi.mock("./run-store.js", () => ({
   bumpRunProgress: vi.fn(() => Promise.resolve()),
   reapIfStale: vi.fn(() => Promise.resolve(null)),
   ensureTerminalRunEvent: vi.fn(() => Promise.resolve()),
+  setRunError: vi.fn(() => Promise.resolve()),
   STALE_RUN_ERROR_EVENT: {
     type: "error",
     error:
@@ -30,10 +31,12 @@ vi.mock("./run-store.js", () => ({
 import {
   abortRun,
   DEFAULT_COMPLETED_RUN_RETENTION_MS,
+  DEFAULT_ERRORED_RUN_RETENTION_MS,
   DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS,
   HOSTED_SOFT_TIMEOUT_CEILING_MS,
   getActiveRunForThreadAsync,
   resolveCompletedRunRetentionMs,
+  resolveErroredRunRetentionMs,
   resolveRunSoftTimeoutMs,
   startRun,
   subscribeToRun,
@@ -49,11 +52,14 @@ import {
   markRunAborted,
   updateRunStatus,
   ensureTerminalRunEvent,
+  cleanupOldRuns,
+  setRunError,
 } from "./run-store.js";
 import { registerErrorCaptureProvider } from "../server/capture-error.js";
 
 const originalTimeoutEnv = process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
 const originalRetentionEnv = process.env.AGENT_RUN_RETENTION_MS;
+const originalErroredRetentionEnv = process.env.AGENT_ERRORED_RUN_RETENTION_MS;
 const originalNetlify = process.env.NETLIFY;
 const originalNetlifyLocal = process.env.NETLIFY_LOCAL;
 const originalCfPages = process.env.CF_PAGES;
@@ -67,6 +73,7 @@ const originalAwsLambdaFunctionName = process.env.AWS_LAMBDA_FUNCTION_NAME;
 function clearHostedEnvForTest() {
   delete process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
   delete process.env.AGENT_RUN_RETENTION_MS;
+  delete process.env.AGENT_ERRORED_RUN_RETENTION_MS;
   delete process.env.NETLIFY;
   delete process.env.NETLIFY_LOCAL;
   delete process.env.CF_PAGES;
@@ -85,6 +92,9 @@ function restoreHostedEnvAfterTest() {
   if (originalRetentionEnv === undefined)
     delete process.env.AGENT_RUN_RETENTION_MS;
   else process.env.AGENT_RUN_RETENTION_MS = originalRetentionEnv;
+  if (originalErroredRetentionEnv === undefined)
+    delete process.env.AGENT_ERRORED_RUN_RETENTION_MS;
+  else process.env.AGENT_ERRORED_RUN_RETENTION_MS = originalErroredRetentionEnv;
   if (originalNetlify === undefined) delete process.env.NETLIFY;
   else process.env.NETLIFY = originalNetlify;
   if (originalNetlifyLocal === undefined) delete process.env.NETLIFY_LOCAL;
@@ -118,6 +128,8 @@ describe("run manager soft timeout", () => {
     vi.mocked(markRunAborted).mockClear();
     vi.mocked(insertRunEvent).mockClear();
     vi.mocked(updateRunStatus).mockClear();
+    vi.mocked(cleanupOldRuns).mockClear();
+    vi.mocked(setRunError).mockClear();
   });
 
   afterEach(() => {
@@ -244,6 +256,35 @@ describe("run manager soft timeout", () => {
     expect(resolveCompletedRunRetentionMs()).toBe(60000);
   });
 
+  it("keeps errored run events for seven days by default", () => {
+    expect(resolveErroredRunRetentionMs()).toBe(
+      DEFAULT_ERRORED_RUN_RETENTION_MS,
+    );
+  });
+
+  it("allows errored run event retention to be configured by environment", () => {
+    process.env.AGENT_ERRORED_RUN_RETENTION_MS = "120000";
+
+    expect(resolveErroredRunRetentionMs()).toBe(120000);
+  });
+
+  it("prunes completed and errored run events with separate retention windows", async () => {
+    process.env.AGENT_RUN_RETENTION_MS = "60000";
+    process.env.AGENT_ERRORED_RUN_RETENTION_MS = "120000";
+
+    startRun(
+      "run-retention-cleanup",
+      "thread-retention-cleanup",
+      async () => {},
+      undefined,
+      { softTimeoutMs: 0 },
+    );
+
+    await vi.waitFor(() => {
+      expect(cleanupOldRuns).toHaveBeenCalledWith(60000, 120000);
+    });
+  });
+
   it("persists the logical turn id for continuation runs", async () => {
     startRun(
       "run-continuation-chunk",
@@ -301,6 +342,26 @@ describe("run manager soft timeout", () => {
       expect(updateRunStatus).toHaveBeenCalledWith(
         "run-terminal-event-order",
         "errored",
+      );
+    });
+  });
+
+  it("records terminal error diagnostics for errored runs", async () => {
+    startRun(
+      "run-error-diagnostics",
+      "thread-error-diagnostics",
+      async () => {
+        throw new Error("boom");
+      },
+      undefined,
+      { softTimeoutMs: 0 },
+    );
+
+    await vi.waitFor(() => {
+      expect(setRunError).toHaveBeenCalledWith(
+        "run-error-diagnostics",
+        "unknown",
+        "boom",
       );
     });
   });

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -22,6 +22,8 @@ import {
 export interface ActiveRun {
   runId: string;
   threadId: string;
+  /** Logical-turn identity (see StartRunOptions.turnId). Defaults to runId. */
+  turnId: string;
   events: RunEvent[];
   status: RunStatus;
   subscribers: Set<(event: RunEvent) => void>;
@@ -64,8 +66,16 @@ export const DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS = 40_000;
  */
 export const HOSTED_SOFT_TIMEOUT_CEILING_MS = 40_000;
 
-/** Default SQL retention for completed/errored run event logs (24 hours). */
+/** Default SQL retention for completed run event logs (24 hours). */
 export const DEFAULT_COMPLETED_RUN_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Default SQL retention for errored/aborted run event logs (7 days). Kept
+ * longer than completed runs so cut-off / failed chats survive for pattern
+ * analysis (listErroredRuns) — these are rare and small, and they are exactly
+ * the runs we need to study to keep hardening reliability.
+ */
+export const DEFAULT_ERRORED_RUN_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * How recently a terminal run must have started for `/runs/active` to surface
@@ -155,6 +165,15 @@ export function resolveCompletedRunRetentionMs(): number {
   return DEFAULT_COMPLETED_RUN_RETENTION_MS;
 }
 
+export function resolveErroredRunRetentionMs(): number {
+  const envValue = process.env.AGENT_ERRORED_RUN_RETENTION_MS;
+  if (envValue !== undefined) {
+    const raw = Number(envValue);
+    if (Number.isFinite(raw) && raw >= 0) return raw;
+  }
+  return DEFAULT_ERRORED_RUN_RETENTION_MS;
+}
+
 function isTerminalRunEvent(event: AgentChatEvent): boolean {
   return (
     event.type === "done" ||
@@ -210,6 +229,7 @@ export function startRun(
   const run: ActiveRun = {
     runId,
     threadId,
+    turnId: options?.turnId ?? runId,
     events: [],
     status: "running",
     subscribers: new Set(),
@@ -487,6 +507,38 @@ export function startRun(
         // the heartbeat-stale path.
       }
 
+      // 5b. Record terminal failure classification for errored runs so
+      //     cut-off / failed chats are queryable for pattern analysis. Read
+      //     the actual error event the run emitted (errorCode + message) so
+      //     diagnostics reflect the real cause (builder_gateway_timeout,
+      //     stale_run, context_length_exceeded, completion_error, …).
+      if (finalStatus === "errored") {
+        let errorCode: string | undefined;
+        let errorDetail: string | undefined;
+        for (let i = run.events.length - 1; i >= 0; i--) {
+          const ev = run.events[i].event as {
+            type: string;
+            error?: string;
+            errorCode?: string;
+            details?: string;
+          };
+          if (ev.type === "error") {
+            errorCode = ev.errorCode;
+            errorDetail = ev.error ?? ev.details;
+            break;
+          }
+        }
+        if (completionError && !errorCode) {
+          errorCode = "completion_error";
+          errorDetail =
+            errorDetail ??
+            (completionError instanceof Error
+              ? completionError.message
+              : String(completionError));
+        }
+        await setRunError(runId, errorCode ?? "unknown", errorDetail);
+      }
+
       // 6. Schedule in-memory cleanup + opportunistic old-run pruning.
       setTimeout(() => {
         activeRuns.delete(runId);
@@ -494,7 +546,10 @@ export function startRun(
           threadToRun.delete(threadId);
         }
       }, CLEANUP_DELAY_MS);
-      cleanupOldRuns(resolveCompletedRunRetentionMs()).catch(() => {});
+      cleanupOldRuns(
+        resolveCompletedRunRetentionMs(),
+        resolveErroredRunRetentionMs(),
+      ).catch(() => {});
     });
 
   // On Cloudflare Workers, keep the isolate alive for this run

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -38,12 +38,30 @@ const CLEANUP_DELAY_MS = 5 * 60 * 1000;
 /**
  * Default run chunk budget for hosted/serverless deploys.
  *
- * Netlify's synchronous Functions limit is currently 60s, so keep enough
- * headroom for abort propagation, thread_data persistence, terminal event
- * writes, and reconnect bookkeeping before the platform hard-kills the
- * invocation.
+ * This MUST fire before the two upstream hard walls that otherwise kill a run
+ * mid-turn with no chance to hand off:
+ *   1. The Builder model gateway hard-caps a single model call at 45s
+ *      (builder-engine.ts MAX_BUILDER_GATEWAY_TIMEOUT_MS) — not raisable.
+ *   2. Serverless functions are hard-killed around 60-65s (the heartbeat then
+ *      reaps the row as a stale_run).
+ * Production data showed every cutoff landing in the 44-70s window with ZERO
+ * auto_continue events ever emitted — i.e. the old 45s default raced the 45s
+ * gateway and lost, and per-template overrides (e.g. 240_000) pushed it past
+ * BOTH walls so it could never fire. 40s leaves ~5s of headroom under the
+ * gateway wall to abort, persist the partial turn, write the terminal event,
+ * and emit a clean auto_continue so the client resumes seamlessly.
  */
-export const DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS = 45_000;
+export const DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS = 40_000;
+
+/**
+ * Hard ceiling for the hosted soft timeout. On a hosted runtime the
+ * auto_continue soft timeout can never usefully exceed this — the gateway
+ * (45s) / function (~60s) walls kill the run first, so a larger configured or
+ * env value just guarantees the cutoff is a hard error instead of a graceful
+ * hand-off. Any resolved value above this is clamped down when hosted. Local
+ * dev (non-hosted) is left alone so long-running local turns aren't chunked.
+ */
+export const HOSTED_SOFT_TIMEOUT_CEILING_MS = 40_000;
 
 /** Default SQL retention for completed/errored run event logs (24 hours). */
 export const DEFAULT_COMPLETED_RUN_RETENTION_MS = 24 * 60 * 60 * 1000;
@@ -98,15 +116,26 @@ export function resolveRunSoftTimeoutMs(
   overrideMs?: number,
   options?: ResolveRunSoftTimeoutOptions,
 ): number {
+  const hosted = isHostedRuntime();
+  // A configured/env soft timeout that exceeds the upstream walls can never
+  // actually fire (the gateway/function kills the run first), so clamp it down
+  // on hosted runtimes. This is what makes auto_continue reach the client
+  // instead of the run dying as builder_gateway_timeout / stale_run. `0` means
+  // "disabled" and is never clamped up.
+  const clampHosted = (ms: number): number =>
+    hosted && ms > HOSTED_SOFT_TIMEOUT_CEILING_MS
+      ? HOSTED_SOFT_TIMEOUT_CEILING_MS
+      : ms;
+
   if (typeof overrideMs === "number" && Number.isFinite(overrideMs)) {
-    return Math.max(0, overrideMs);
+    return clampHosted(Math.max(0, overrideMs));
   }
   const envValue = process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
   if (envValue !== undefined) {
     const raw = Number(envValue);
-    if (Number.isFinite(raw) && raw >= 0) return raw;
+    if (Number.isFinite(raw) && raw >= 0) return clampHosted(raw);
   }
-  return options?.useHostedDefault && isHostedRuntime()
+  return options?.useHostedDefault && hosted
     ? DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS
     : 0;
 }

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -15,6 +15,7 @@ import {
   bumpRunProgress,
   reapIfStale,
   ensureTerminalRunEvent,
+  setRunError,
   STALE_RUN_ERROR_EVENT,
 } from "./run-store.js";
 
@@ -82,6 +83,11 @@ export interface StartRunOptions {
   /** Opt into the hosted/serverless default chunk budget. Only callers with
    * automatic continuation support should enable this. */
   useHostedSoftTimeoutDefault?: boolean;
+  /** Stable identity for the logical assistant turn this run belongs to. A
+   * turn may span several continuation runs (each chunk is its own run); they
+   * share one `turnId` so the durable assistant message can be folded across
+   * them instead of dropped per-run. Defaults to the runId (turn == run). */
+  turnId?: string;
 }
 
 export interface ResolveRunSoftTimeoutOptions {
@@ -217,7 +223,9 @@ export function startRun(
   // Persist run to SQL without blocking the response. Keep the promise so
   // final status cannot race ahead of a slow initial INSERT and then get
   // overwritten by a late row stuck at status='running'.
-  const insertRunPromise = insertRun(runId, threadId).catch(() => {});
+  const insertRunPromise = insertRun(runId, threadId, options?.turnId).catch(
+    () => {},
+  );
 
   // Throttle the durable progress timestamp to at most once per second so
   // a chatty token-by-token stream doesn't translate into one DB write per

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -153,4 +153,26 @@ describe("run store", () => {
     expect(insert?.args[0]).toBe("old-but-heartbeating-run");
     expect(insert?.args[2] as string).toContain('"errorCode":"stale_run"');
   });
+
+  it("keeps errored runs longer than completed runs during cleanup", async () => {
+    await cleanupOldRuns(24 * 60 * 60 * 1000, 7 * 24 * 60 * 60 * 1000);
+
+    const deleteEvents = execCalls.find((call) =>
+      /DELETE FROM agent_run_events/i.test(call.sql),
+    );
+    expect(deleteEvents?.sql).toContain("status = 'completed'");
+    expect(deleteEvents?.sql).toContain("status IN ('errored', 'aborted')");
+    expect(Number(deleteEvents?.args[1])).toBeLessThan(
+      Number(deleteEvents?.args[0]),
+    );
+
+    const deleteRuns = execCalls.find((call) =>
+      /DELETE FROM agent_runs/i.test(call.sql),
+    );
+    expect(deleteRuns?.sql).toContain("status = 'completed'");
+    expect(deleteRuns?.sql).toContain("status IN ('errored', 'aborted')");
+    expect(Number(deleteRuns?.args[1])).toBeLessThan(
+      Number(deleteRuns?.args[0]),
+    );
+  });
 });

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -405,13 +405,20 @@ export async function reapAllStaleRuns(): Promise<number> {
   return rowsAffected ?? 0;
 }
 
-/** Delete completed/errored runs older than the given threshold,
- *  and expire stale "running" rows that haven't had activity
- *  (e.g. worker crashed before updating status). */
-export async function cleanupOldRuns(olderThanMs: number): Promise<void> {
+/** Delete old runs and expire stale "running" rows that haven't had activity
+ *  (e.g. worker crashed before updating status). Completed runs are pruned at
+ *  `olderThanMs`; errored/aborted runs are kept until `erroredOlderThanMs` (a
+ *  longer window, falling back to `olderThanMs`) so their event log survives
+ *  for cut-off pattern analysis via listErroredRuns. */
+export async function cleanupOldRuns(
+  olderThanMs: number,
+  erroredOlderThanMs?: number,
+): Promise<void> {
   await ensureRunTables();
   const client = getDbExec();
   const cutoff = Date.now() - olderThanMs;
+  const erroredCutoff =
+    Date.now() - Math.max(erroredOlderThanMs ?? 0, olderThanMs);
   // Expire stale running rows on the absolute-age threshold — safety net
   // for runs that never received a heartbeat (very old deployments). The
   // SELECT covers BOTH UPDATE conditions so the terminal-event-append loop
@@ -449,16 +456,85 @@ export async function cleanupOldRuns(olderThanMs: number): Promise<void> {
       );
     }
   }
-  // Delete events for old non-running runs
+  // Delete events for old terminal runs. Completed runs prune at `cutoff`;
+  // errored/aborted runs are retained until the (longer) `erroredCutoff`.
   await client.execute({
     sql: `DELETE FROM agent_run_events WHERE run_id IN (
-      SELECT id FROM agent_runs WHERE status != 'running' AND completed_at < ?
+      SELECT id FROM agent_runs
+      WHERE (status = 'completed' AND completed_at < ?)
+         OR (status IN ('errored', 'aborted') AND completed_at < ?)
     )`,
-    args: [cutoff],
+    args: [cutoff, erroredCutoff],
   });
   await client.execute({
-    sql: `DELETE FROM agent_runs WHERE status != 'running' AND completed_at < ?`,
-    args: [cutoff],
+    sql: `DELETE FROM agent_runs
+          WHERE (status = 'completed' AND completed_at < ?)
+             OR (status IN ('errored', 'aborted') AND completed_at < ?)`,
+    args: [cutoff, erroredCutoff],
+  });
+}
+
+/**
+ * List recent errored/aborted runs for cut-off pattern analysis. Read-only,
+ * bounded, and ordered newest-first. Surfaced via the list-errored-runs action
+ * so the team can see why chats are failing (terminal error code, duration,
+ * turn linkage) instead of discovering it ad hoc.
+ */
+export async function listErroredRuns(options?: {
+  limit?: number;
+  sinceMs?: number;
+}): Promise<
+  Array<{
+    id: string;
+    threadId: string;
+    turnId: string | null;
+    status: string;
+    errorCode: string | null;
+    errorDetail: string | null;
+    startedAt: number;
+    completedAt: number | null;
+    durationMs: number | null;
+  }>
+> {
+  await ensureRunTables();
+  const client = getDbExec();
+  const limit = Math.min(Math.max(Math.floor(options?.limit ?? 100), 1), 1000);
+  const since =
+    options?.sinceMs && options.sinceMs > 0 ? Date.now() - options.sinceMs : 0;
+  const { rows } = await client.execute({
+    sql: `SELECT id, thread_id, turn_id, status, error_code, error_detail, started_at, completed_at
+          FROM agent_runs
+          WHERE status IN ('errored', 'aborted')
+            AND COALESCE(completed_at, started_at) >= ?
+          ORDER BY COALESCE(completed_at, started_at) DESC
+          LIMIT ${limit}`,
+    args: [since],
+  });
+  return rows.map((r) => {
+    const row = r as {
+      id: string;
+      thread_id: string;
+      turn_id: string | null;
+      status: string;
+      error_code: string | null;
+      error_detail: string | null;
+      started_at: number | string;
+      completed_at: number | string | null;
+    };
+    const startedAt = Number(row.started_at);
+    const completedAt =
+      row.completed_at == null ? null : Number(row.completed_at);
+    return {
+      id: row.id,
+      threadId: row.thread_id,
+      turnId: row.turn_id ?? null,
+      status: row.status,
+      errorCode: row.error_code ?? null,
+      errorDetail: row.error_detail ?? null,
+      startedAt,
+      completedAt,
+      durationMs: completedAt == null ? null : completedAt - startedAt,
+    };
   });
 }
 

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -39,7 +39,10 @@ async function ensureRunTables(): Promise<void> {
           started_at ${intType()} NOT NULL,
           completed_at ${intType()},
           heartbeat_at ${intType()},
-          last_progress_at ${intType()}
+          last_progress_at ${intType()},
+          turn_id TEXT,
+          error_code TEXT,
+          error_detail TEXT
         )
       `);
       // Backfill heartbeat_at on older deployments.
@@ -85,6 +88,28 @@ async function ensureRunTables(): Promise<void> {
       } catch {
         // Column already exists — ignore
       }
+      // Backfill turn_id / error_code / error_detail.
+      //   turn_id    = stable identity for one logical assistant turn that may
+      //                span several continuation runs, so the durable record
+      //                can be folded across runs instead of dropped per-run.
+      //   error_code / error_detail = terminal failure classification captured
+      //                at completion so errored/cut-off runs are queryable for
+      //                pattern analysis (see listErroredRuns).
+      for (const col of ["turn_id", "error_code", "error_detail"] as const) {
+        try {
+          if (isPostgres()) {
+            await client.execute(
+              `ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS ${col} TEXT`,
+            );
+          } else {
+            await client.execute(
+              `ALTER TABLE agent_runs ADD COLUMN ${col} TEXT`,
+            );
+          }
+        } catch {
+          // Column already exists — ignore
+        }
+      }
       await client.execute(`
         CREATE TABLE IF NOT EXISTS agent_run_events (
           run_id TEXT NOT NULL,
@@ -98,14 +123,45 @@ async function ensureRunTables(): Promise<void> {
   return _initPromise;
 }
 
-export async function insertRun(id: string, threadId: string): Promise<void> {
+export async function insertRun(
+  id: string,
+  threadId: string,
+  turnId?: string,
+): Promise<void> {
   await ensureRunTables();
   const client = getDbExec();
   const now = Date.now();
   await client.execute({
-    sql: `INSERT INTO agent_runs (id, thread_id, status, started_at, heartbeat_at, last_progress_at) VALUES (?, ?, 'running', ?, ?, ?)`,
-    args: [id, threadId, now, now, now],
+    sql: `INSERT INTO agent_runs (id, thread_id, status, started_at, heartbeat_at, last_progress_at, turn_id) VALUES (?, ?, 'running', ?, ?, ?, ?)`,
+    args: [id, threadId, now, now, now, turnId ?? id],
   });
+}
+
+/**
+ * Record terminal failure classification for a run so cut-off / errored runs
+ * can be surfaced for pattern analysis (see listErroredRuns). Best-effort —
+ * never throws, since it runs on the completion path that must not fail the run.
+ */
+export async function setRunError(
+  runId: string,
+  errorCode: string | undefined,
+  errorDetail: string | undefined,
+): Promise<void> {
+  if (!errorCode && !errorDetail) return;
+  try {
+    await ensureRunTables();
+    const client = getDbExec();
+    await client.execute({
+      sql: `UPDATE agent_runs SET error_code = ?, error_detail = ? WHERE id = ?`,
+      args: [
+        errorCode ?? null,
+        errorDetail ? errorDetail.slice(0, 2000) : null,
+        runId,
+      ],
+    });
+  } catch {
+    // Diagnostics are best-effort; never let them break completion.
+  }
 }
 
 /** Update the run's liveness heartbeat. Called periodically by run-manager. */

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -4,6 +4,7 @@ import {
   buildRepositoryFromCodeAgentTranscript,
   buildUserMessage,
   extractThreadMeta,
+  foldAssistantTurn,
   mergeThreadDataForClientSave,
   normalizeThreadRepository,
   upsertAssistantMessage,
@@ -33,33 +34,54 @@ describe("extractThreadMeta", () => {
 });
 
 describe("buildAssistantMessage", () => {
-  it("does not persist partial output from internal continuation boundaries", () => {
+  it("persists partial output from internal continuation boundaries", () => {
     const events: RunEvent[] = [
       { seq: 0, event: { type: "text", text: "partial answer" } },
       { seq: 1, event: { type: "auto_continue", reason: "run_timeout" } },
     ];
 
-    expect(
-      buildAssistantMessage(events, "run-timeout", {
-        suppressInternalContinuation: true,
-      }),
-    ).toBeNull();
+    const message = buildAssistantMessage(events, "run-timeout", {
+      suppressInternalContinuation: true,
+      turnId: "turn-timeout",
+    });
+
+    expect(message?.content).toEqual([
+      { type: "text", text: "partial answer" },
+    ]);
+    expect(message?.metadata).toMatchObject({
+      runId: "run-timeout",
+      custom: {
+        turnId: "turn-timeout",
+        foldedRunIds: ["run-timeout"],
+        continued: true,
+      },
+    });
   });
 
-  it("does not persist partial output from suppressed loop-limit boundaries", () => {
+  it("persists partial output from suppressed loop-limit boundaries", () => {
     const events: RunEvent[] = [
       { seq: 0, event: { type: "text", text: "partial answer" } },
       { seq: 1, event: { type: "loop_limit", maxIterations: 50 } },
     ];
 
-    expect(
-      buildAssistantMessage(events, "run-loop-limit", {
-        suppressInternalContinuation: true,
-      }),
-    ).toBeNull();
+    const message = buildAssistantMessage(events, "run-loop-limit", {
+      suppressInternalContinuation: true,
+      turnId: "turn-loop-limit",
+    });
+
+    expect(message?.content).toEqual([
+      { type: "text", text: "partial answer" },
+    ]);
+    expect(message?.metadata).toMatchObject({
+      custom: {
+        turnId: "turn-loop-limit",
+        foldedRunIds: ["run-loop-limit"],
+        continued: true,
+      },
+    });
   });
 
-  it("does not persist partial output from recoverable gateway errors when suppressed", () => {
+  it("persists partial output from recoverable gateway errors when suppressed", () => {
     const events: RunEvent[] = [
       { seq: 0, event: { type: "text", text: "checking..." } },
       {
@@ -72,11 +94,19 @@ describe("buildAssistantMessage", () => {
       },
     ];
 
-    expect(
-      buildAssistantMessage(events, "run-gateway-timeout", {
-        suppressInternalContinuation: true,
-      }),
-    ).toBeNull();
+    const message = buildAssistantMessage(events, "run-gateway-timeout", {
+      suppressInternalContinuation: true,
+      turnId: "turn-gateway-timeout",
+    });
+
+    expect(message?.content).toEqual([{ type: "text", text: "checking..." }]);
+    expect(message?.metadata).toMatchObject({
+      custom: {
+        turnId: "turn-gateway-timeout",
+        foldedRunIds: ["run-gateway-timeout"],
+        continued: true,
+      },
+    });
   });
 
   it("persists bare gateway stop errors when continuation errors are suppressed", () => {
@@ -319,6 +349,61 @@ describe("buildAssistantMessage", () => {
         },
       ],
     });
+  });
+
+  it("folds continuation chunks for one logical turn into one durable assistant message", () => {
+    const firstChunk = buildAssistantMessage(
+      [
+        { seq: 0, event: { type: "text", text: "First chunk. " } },
+        { seq: 1, event: { type: "auto_continue", reason: "run_timeout" } },
+      ],
+      "run-fold-1",
+      { suppressInternalContinuation: true, turnId: "turn-fold" },
+    );
+    const secondChunk = buildAssistantMessage(
+      [
+        { seq: 0, event: { type: "text", text: "Second chunk." } },
+        { seq: 1, event: { type: "done" } },
+      ],
+      "run-fold-2",
+      { suppressInternalContinuation: true, turnId: "turn-fold" },
+    );
+    expect(firstChunk).not.toBeNull();
+    expect(secondChunk).not.toBeNull();
+
+    let repo = foldAssistantTurn(
+      {
+        messages: [
+          {
+            message: {
+              id: "user-1",
+              role: "user",
+              content: [{ type: "text", text: "finish this" }],
+            },
+            parentId: null,
+          },
+        ],
+      },
+      firstChunk!,
+      { turnId: "turn-fold", runId: "run-fold-1" },
+    );
+    repo = foldAssistantTurn(repo, secondChunk!, {
+      turnId: "turn-fold",
+      runId: "run-fold-2",
+    });
+
+    expect(repo.messages).toHaveLength(2);
+    expect(repo.messages[1].message.content).toEqual([
+      { type: "text", text: "First chunk. Second chunk." },
+    ]);
+    expect(repo.messages[1].message.metadata).toMatchObject({
+      runId: "run-fold-2",
+      custom: {
+        turnId: "turn-fold",
+        foldedRunIds: ["run-fold-1", "run-fold-2"],
+      },
+    });
+    expect(repo.messages[1].message.metadata.custom.continued).toBeUndefined();
   });
 });
 

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -19,6 +19,13 @@ interface ContentPart {
 
 interface BuildAssistantMessageOptions {
   suppressInternalContinuation?: boolean;
+  /**
+   * Logical-turn identity. When set it is stamped onto the message metadata so
+   * continuation runs of the same turn can be folded onto a single durable
+   * assistant message (see foldAssistantTurn) instead of each run dropping or
+   * overwriting the others.
+   */
+  turnId?: string;
 }
 
 type AssistantMessage = NonNullable<ReturnType<typeof buildAssistantMessage>>;
@@ -180,18 +187,29 @@ export function buildAssistantMessage(
     // done, missing_api_key — terminal signals, not content
   }
 
-  if (content.length === 0 || endedAtInternalContinuationBoundary) return null;
+  // Only a truly empty turn produces nothing to persist. A turn that ended at
+  // an internal continuation boundary (soft-timeout auto_continue, a
+  // recoverable gateway error, suppressed loop_limit) DID stream real content
+  // — persist it as a partial so the continuation run can fold the next chunk
+  // onto it (foldAssistantTurn) instead of the earlier text being dropped.
+  if (content.length === 0) return null;
+
+  const continued = endedAtInternalContinuationBoundary;
+
+  const custom: Record<string, unknown> = {};
+  if (options.turnId) custom.turnId = options.turnId;
+  if (runId) custom.foldedRunIds = [runId];
+  if (continued) custom.continued = true;
+  if (runError) {
+    custom.runError = {
+      ...runError,
+      ...(runId ? { runId } : {}),
+    };
+  }
 
   const metadata: Record<string, unknown> = {};
   if (runId) metadata.runId = runId;
-  if (runError) {
-    metadata.custom = {
-      runError: {
-        ...runError,
-        ...(runId ? { runId } : {}),
-      },
-    };
-  }
+  if (Object.keys(custom).length > 0) metadata.custom = custom;
 
   return {
     id: `server-${runId ?? Date.now()}`,
@@ -273,6 +291,11 @@ function messageIdentityKeys(message: any): string[] {
   }
   const runId = getMessageRunId(message);
   if (runId) keys.push(`run:${runId}`);
+  // A logical turn is ONE durable assistant message even though it may span
+  // several continuation runs, so two messages sharing a turnId (e.g. the
+  // client export and the server fold of the same answer) must dedupe to one.
+  const turnId = turnIdOf(message);
+  if (turnId) keys.push(`turn:${turnId}`);
 
   // Normalize attachments through `normalizeAttachmentIdentity` so an
   // explicit empty `[]` (assistant-ui's default for messages with no
@@ -320,6 +343,27 @@ function messagesMatch(a: any, b: any): boolean {
 function chooseMergedMessageEntry(existingEntry: any, incomingEntry: any): any {
   const existing = getStoredMessage(existingEntry);
   const incoming = getStoredMessage(incomingEntry);
+  // Same logical turn (client export vs server fold of one accumulating
+  // answer): never shrink — keep whichever side accumulated more content, so a
+  // stale/lossy export can't overwrite the richer folded turn. Ties prefer the
+  // terminal copy.
+  const existingTurn = turnIdOf(existing);
+  const incomingTurn = turnIdOf(incoming);
+  if (
+    existing?.role === "assistant" &&
+    incoming?.role === "assistant" &&
+    existingTurn &&
+    existingTurn === incomingTurn
+  ) {
+    const existingWeight = assistantContentWeight(existing.content);
+    const incomingWeight = assistantContentWeight(incoming.content);
+    if (existingWeight > incomingWeight) return existingEntry;
+    if (incomingWeight > existingWeight) return incomingEntry;
+    return isTerminalAssistantStatus(existing?.status) &&
+      !isTerminalAssistantStatus(incoming?.status)
+      ? existingEntry
+      : incomingEntry;
+  }
   if (
     existing?.role === "assistant" &&
     incoming?.role === "assistant" &&
@@ -961,6 +1005,158 @@ export function upsertAssistantMessage(
       : null;
   nextRepo.messages.push({ message: assistantMsg, parentId });
   nextRepo.headId = assistantMsg.id;
+  return nextRepo;
+}
+
+function turnIdOf(message: any): string | undefined {
+  const t = message?.metadata?.custom?.turnId;
+  return typeof t === "string" && t ? t : undefined;
+}
+
+function foldedRunIdsOf(message: any): string[] {
+  const ids = message?.metadata?.custom?.foldedRunIds;
+  return Array.isArray(ids)
+    ? ids.filter((x: unknown): x is string => typeof x === "string")
+    : [];
+}
+
+/** Rough size of an assistant message's content, used only to pick the larger
+ *  of two representations of the same chunk so a fold can never shrink. */
+function assistantContentWeight(content: unknown): number {
+  if (!Array.isArray(content)) return 0;
+  let weight = 0;
+  for (const part of content) {
+    if (part?.type === "text" && typeof part.text === "string") {
+      weight += part.text.length;
+    } else {
+      weight += 1;
+    }
+  }
+  return weight;
+}
+
+/** Concatenate continuation content onto the accumulated turn, merging a
+ *  trailing+leading text run so the resumed answer reads as one flowing
+ *  message rather than two stacked fragments. */
+function appendFoldedContent(existing: any[], incoming: any[]): any[] {
+  const merged = existing.map((p) => ({ ...p }));
+  for (const part of incoming) {
+    const last = merged[merged.length - 1];
+    if (
+      part?.type === "text" &&
+      typeof part.text === "string" &&
+      last?.type === "text" &&
+      typeof last.text === "string"
+    ) {
+      last.text = `${last.text}${part.text}`;
+    } else {
+      merged.push({ ...part });
+    }
+  }
+  return merged;
+}
+
+/**
+ * Fold a continuation run's assistant message onto the single durable message
+ * for its logical turn (identified by `turnId`), so a turn that spans several
+ * continuation runs accumulates into ONE message that only ever grows. This is
+ * the server-side analog of an append-only rollout: the durable transcript is
+ * a monotonic fold over every run in the turn, never a per-run snapshot that
+ * drops the earlier chunks.
+ *
+ * Idempotent and never-shrinking, so it is safe to run alongside the client's
+ * full-thread export (which may write the same turn from the other side):
+ *   - First chunk of a turn → appended as a fresh message.
+ *   - A run whose content is already represented (already folded, or the client
+ *     saved it) → kept as-is, choosing whichever copy has more content.
+ *   - A new chunk → appended onto the accumulated turn.
+ * Falls back to per-run upsert when no `turnId` is available (turn == run).
+ */
+export function foldAssistantTurn(
+  repo: any,
+  assistantMsg: AssistantMessage,
+  options: { turnId?: string; runId?: string },
+): any {
+  const turnId = options.turnId;
+  const runId = options.runId;
+  if (!turnId) return upsertAssistantMessage(repo, assistantMsg);
+
+  const nextRepo = normalizeThreadRepository(repo);
+  const lastIndex = nextRepo.messages.length - 1;
+  const lastEntry = lastIndex >= 0 ? nextRepo.messages[lastIndex] : undefined;
+  const lastMsg = getStoredMessage(lastEntry);
+
+  const sameTurn =
+    lastMsg?.role === "assistant" &&
+    (turnIdOf(lastMsg) === turnId ||
+      // A message the client wrote for one of this turn's runs before it
+      // carried a turnId stamp.
+      (!!runId && getMessageRunId(lastMsg) === runId));
+
+  if (!sameTurn) {
+    // First chunk of this turn (or the previous assistant belongs to an
+    // earlier turn) — append as a fresh message; buildAssistantMessage already
+    // stamped turnId + foldedRunIds onto it.
+    return upsertAssistantMessage(repo, assistantMsg);
+  }
+
+  const existingContent = Array.isArray(lastMsg.content) ? lastMsg.content : [];
+  const incomingContent = Array.isArray(assistantMsg.content)
+    ? assistantMsg.content
+    : [];
+  const existingFolded = foldedRunIdsOf(lastMsg);
+  const runAlreadyFolded =
+    !!runId &&
+    (existingFolded.includes(runId) || getMessageRunId(lastMsg) === runId);
+
+  // If this run's chunk is already represented in the turn (the client saved
+  // it, or we already folded it), do not re-append — keep the larger copy so
+  // the turn never shrinks. Otherwise fold this chunk onto the accumulated turn.
+  const mergedContent = runAlreadyFolded
+    ? assistantContentWeight(incomingContent) >
+      assistantContentWeight(existingContent)
+      ? incomingContent
+      : existingContent
+    : appendFoldedContent(existingContent, incomingContent);
+
+  const mergedFolded = Array.from(
+    new Set([...existingFolded, ...(runId ? [runId] : [])]),
+  );
+
+  const existingCustom =
+    lastMsg.metadata?.custom && typeof lastMsg.metadata.custom === "object"
+      ? (lastMsg.metadata.custom as Record<string, unknown>)
+      : {};
+  const incomingCustom =
+    assistantMsg.metadata?.custom &&
+    typeof assistantMsg.metadata.custom === "object"
+      ? (assistantMsg.metadata.custom as Record<string, unknown>)
+      : {};
+
+  const mergedCustom: Record<string, unknown> = {
+    ...existingCustom,
+    ...incomingCustom,
+    turnId,
+    foldedRunIds: mergedFolded,
+  };
+  // Only the freshest chunk decides whether the turn is still continuing.
+  if (incomingCustom.continued !== true) delete mergedCustom.continued;
+
+  const mergedMessage = {
+    ...lastMsg,
+    content: mergedContent,
+    // The freshest chunk's status wins: a clean done supersedes a prior
+    // partial; a real error supersedes a partial.
+    status: assistantMsg.status ?? lastMsg.status,
+    metadata: {
+      ...lastMsg.metadata,
+      runId: runId ?? lastMsg.metadata?.runId,
+      custom: mergedCustom,
+    },
+  };
+
+  nextRepo.messages[lastIndex] = { ...lastEntry, message: mergedMessage };
+  nextRepo.headId = mergedMessage.id ?? nextRepo.headId;
   return nextRepo;
 }
 

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -113,6 +113,14 @@ export interface AgentChatRequest {
   attachments?: AgentChatAttachment[];
   /** Internal retry/continuation requests should not create visible user turns. */
   internalContinuation?: boolean;
+  /**
+   * Stable identity for the logical assistant turn this request belongs to.
+   * The client sends the SAME turnId for the initial POST and every
+   * auto-continuation re-POST of one turn, so the server can fold each
+   * continuation run's output onto a single durable assistant message instead
+   * of dropping the earlier chunks. Defaults to the run id when absent.
+   */
+  turnId?: string;
   /** Execution mode for this turn. Plan mode is read-only and proposes before acting. */
   mode?: "act" | "plan";
   /** Per-request model override (ephemeral, from the composer model picker). */

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -45,7 +45,12 @@ beforeEach(() => {
 
 afterEach(() => {
   process.chdir(origCwd);
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 100,
+  });
 });
 
 function readPkg(dir: string): Record<string, any> {

--- a/packages/core/src/client/PoweredByBadge.tsx
+++ b/packages/core/src/client/PoweredByBadge.tsx
@@ -157,7 +157,7 @@ export function PoweredByBadge({
 }
 
 /**
- * Small GitHub badge: "Open source"
+ * Small GitHub badge: "100% free and open source"
  *
  * Intended to pair with PoweredByBadge on public pages.
  */
@@ -227,7 +227,7 @@ export function OpenSourceBadge({
         style={containerStyle(position)}
       >
         <IconBrandGithub aria-hidden="true" stroke={1.8} />
-        <span>Open source</span>
+        <span>100% free and open source</span>
       </a>
     </>
   );

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -574,6 +574,17 @@ function combineContinuationHistory(fragments: string[]): string {
 function visibleTransientContinuationContent(
   content: ContentPart[],
 ): ContentPart[] {
+  // NOTE: this intentionally keeps ONLY completed tool calls, dropping
+  // already-streamed text, on a transient continuation. Preserving the text
+  // here is desirable (it's the live "paragraphs disappear" flicker) BUT it
+  // breaks visibleContentForContinuation's part-count prefix slicing: the
+  // resumed run's text concatenates into the preserved trailing text part, so
+  // the "new chunk" reads as empty and the empty-continuation cap gives up
+  // prematurely on text-heavy multi-continuation turns. The durable fix
+  // (server-side foldAssistantTurn) already preserves the text in thread_data,
+  // so no data is lost — only the live render flickers. Fixing the flicker
+  // safely requires reworking the prefix/new-chunk detection to diff by text
+  // length rather than part count; see the agent-run reliability follow-up.
   return content.filter(
     (part) => part.type === "tool-call" && part.result !== undefined,
   );

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -691,6 +691,16 @@ function retryDelay(attempt: number, abortSignal: AbortSignal): Promise<void> {
   return delay(ms, abortSignal);
 }
 
+function generateTurnId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return `turn-${crypto.randomUUID()}`;
+  }
+  return `turn-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 function isRetryableStartupError(message: string): boolean {
   const msg = message.toLowerCase();
   if (
@@ -983,6 +993,7 @@ export function createAgentChatAdapter(options?: {
 
       const content: ContentPart[] = [];
       const toolCallCounter = { value: 0 };
+      const turnId = generateTurnId();
       let runId: string | null = null;
       let lastSeq = -1;
       let currentMessageText = normalizeMentions(
@@ -1426,6 +1437,7 @@ export function createAgentChatAdapter(options?: {
                   displayMessage: userMessageText,
                   history: currentHistory,
                   structuredHistory: currentStructuredHistory,
+                  turnId,
                   ...(threadId ? { threadId } : {}),
                   ...(internalContinuationRequest
                     ? { internalContinuation: true }

--- a/packages/core/src/client/api-path.spec.ts
+++ b/packages/core/src/client/api-path.spec.ts
@@ -40,6 +40,37 @@ describe("agentNativePath", () => {
       "/_agent-native/org/members",
     );
   });
+
+  it("uses the live workspace mount when a configured base belongs to another app", () => {
+    vi.stubEnv("VITE_AGENT_NATIVE_WORKSPACE", "1");
+    vi.stubEnv("VITE_APP_BASE_PATH", "/dispatch");
+    vi.stubGlobal("window", { location: { pathname: "/diagrams" } });
+
+    expect(appBasePath()).toBe("/diagrams");
+    expect(agentNativePath("/_agent-native/poll")).toBe(
+      "/diagrams/_agent-native/poll",
+    );
+  });
+
+  it("uses the live workspace route segment for app API paths under nested routes", () => {
+    vi.stubEnv("VITE_AGENT_NATIVE_WORKSPACE", "1");
+    vi.stubEnv("VITE_APP_BASE_PATH", "/dispatch");
+    vi.stubGlobal("window", { location: { pathname: "/diagrams/editor" } });
+
+    expect(appBasePath()).toBe("/diagrams");
+    expect(appApiPath("local-migration")).toBe("/diagrams/api/local-migration");
+  });
+
+  it("keeps a configured workspace base when the current path matches it", () => {
+    vi.stubEnv("VITE_AGENT_NATIVE_WORKSPACE", "1");
+    vi.stubEnv("VITE_APP_BASE_PATH", "/dispatch");
+    vi.stubGlobal("window", { location: { pathname: "/dispatch/overview" } });
+
+    expect(appBasePath()).toBe("/dispatch");
+    expect(agentNativePath("/_agent-native/notifications/count")).toBe(
+      "/dispatch/_agent-native/notifications/count",
+    );
+  });
 });
 
 describe("oauthRedirectUri", () => {
@@ -118,6 +149,7 @@ describe("oauthRedirectUri", () => {
 describe("appPath", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("prefixes app-local root paths from the current mounted pathname", () => {
@@ -151,6 +183,7 @@ describe("appPath", () => {
 describe("appApiPath", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("normalizes app-local API paths and applies the app base path", () => {

--- a/packages/core/src/client/api-path.ts
+++ b/packages/core/src/client/api-path.ts
@@ -10,13 +10,25 @@ function normalizeBasePath(value: string | undefined): string {
 }
 
 function configuredBasePath(): string {
-  const env = (
+  const env = clientEnv();
+  const value = env?.VITE_APP_BASE_PATH ?? env?.APP_BASE_PATH ?? env?.BASE_URL;
+  return typeof value === "string" ? normalizeBasePath(value) : "";
+}
+
+function clientEnv(): Record<string, string | boolean | undefined> | undefined {
+  const importMetaEnv = (
     import.meta as unknown as {
       env?: Record<string, string | boolean | undefined>;
     }
   ).env;
-  const value = env?.VITE_APP_BASE_PATH ?? env?.APP_BASE_PATH ?? env?.BASE_URL;
-  return typeof value === "string" ? normalizeBasePath(value) : "";
+  const processEnv = (
+    globalThis as typeof globalThis & {
+      process?: { env?: Record<string, string | boolean | undefined> };
+    }
+  ).process?.env;
+
+  if (importMetaEnv && processEnv) return { ...processEnv, ...importMetaEnv };
+  return importMetaEnv ?? processEnv;
 }
 
 function pathDerivedBasePath(): string {
@@ -27,9 +39,39 @@ function pathDerivedBasePath(): string {
   return normalizeBasePath(pathname.slice(0, markerIndex));
 }
 
+function pathMatchesBasePath(pathname: string, basePath: string): boolean {
+  return pathname === basePath || pathname.startsWith(`${basePath}/`);
+}
+
+function isWorkspaceRuntime(): boolean {
+  const env = clientEnv();
+  return (
+    env?.VITE_AGENT_NATIVE_WORKSPACE === "1" ||
+    env?.AGENT_NATIVE_WORKSPACE === "1" ||
+    typeof env?.VITE_AGENT_NATIVE_WORKSPACE_APPS_JSON === "string"
+  );
+}
+
+function workspacePathBasePath(): string {
+  if (typeof window === "undefined" || !isWorkspaceRuntime()) return "";
+  const segment = window.location.pathname.split("/").find(Boolean);
+  if (!segment || segment === "_agent-native" || segment === "api") return "";
+  return normalizeBasePath(segment);
+}
+
 export function appBasePath(): string {
   ensureEmbedAuthFetchInterceptor();
-  return configuredBasePath() || pathDerivedBasePath();
+  const configured = configuredBasePath();
+  const derived = pathDerivedBasePath();
+  if (!configured) return derived;
+  if (typeof window === "undefined") return configured;
+
+  const pathname = window.location.pathname;
+  if (pathMatchesBasePath(pathname, configured)) return configured;
+
+  // In a multi-app workspace, a globally configured base can bleed from one
+  // app build into another. Prefer the live mount path when they disagree.
+  return derived || workspacePathBasePath() || configured;
 }
 
 export function appPath(path: string): string {

--- a/packages/core/src/client/composer/TiptapComposer.spec.ts
+++ b/packages/core/src/client/composer/TiptapComposer.spec.ts
@@ -8,6 +8,7 @@ import {
   displayableComposerModeMessage,
   getComposerSubmitIntentForEnterKey,
   handleComposerFileDrop,
+  insertComposerHardBreakAndScrollIntoView,
 } from "./TiptapComposer.js";
 
 describe("createTiptapComposerExtensions", () => {
@@ -99,6 +100,29 @@ describe("createTiptapComposerExtensions", () => {
     expect(
       getComposerSubmitIntentForEnterKey({ ...enter, metaKey: true }, false),
     ).toBeNull();
+  });
+
+  it("scrolls the composer caret into view for Shift+Enter line breaks", () => {
+    const editor = new Editor({
+      element: document.createElement("div"),
+      extensions: createTiptapComposerExtensions(() => "Message agent..."),
+      content: "<p>Hello</p>",
+    });
+    editor.commands.setTextSelection(editor.state.doc.content.size);
+
+    const view = editor.view;
+    const scrolledTransactions: boolean[] = [];
+    const dispatch = view.dispatch.bind(view);
+    view.dispatch = (transaction) => {
+      scrolledTransactions.push(transaction.scrolledIntoView);
+      dispatch(transaction);
+    };
+
+    expect(insertComposerHardBreakAndScrollIntoView(view)).toBe(true);
+    expect(scrolledTransactions).toEqual([true]);
+    expect(editor.getText()).toBe("Hello\n");
+
+    editor.destroy();
   });
 
   it("consumes composer file drops so parent drop targets do not attach duplicates", () => {

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -12,6 +12,7 @@ import {
   useComposerRuntime,
 } from "@assistant-ui/react";
 import { useEditor, EditorContent } from "@tiptap/react";
+import type { EditorView } from "@tiptap/pm/view";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import { FileReference } from "./extensions/FileReference.js";
@@ -103,6 +104,18 @@ export function getComposerSubmitIntentForEnterKey(
   if (!event.metaKey && !event.ctrlKey) return "immediate";
 
   return null;
+}
+
+export function insertComposerHardBreakAndScrollIntoView(
+  view: Pick<EditorView, "state" | "dispatch">,
+): boolean {
+  const hardBreak = view.state.schema.nodes.hardBreak;
+  if (!hardBreak) return false;
+
+  view.dispatch(
+    view.state.tr.replaceSelectionWith(hardBreak.create()).scrollIntoView(),
+  );
+  return true;
 }
 
 export function displayableComposerModeMessage(options: {
@@ -1251,8 +1264,14 @@ export function TiptapComposer({
           return true;
         }
 
-        // Submit on Enter. Shift+Enter falls through to Tiptap for a newline;
+        // Submit on Enter. Shift+Enter inserts a newline and keeps the
+        // composer scrolled to the caret.
         // Cmd+Enter on macOS / Ctrl+Enter elsewhere marks the submit queued.
+        if (event.key === "Enter" && event.shiftKey) {
+          event.preventDefault();
+          return insertComposerHardBreakAndScrollIntoView(view);
+        }
+
         const submitIntent = getComposerSubmitIntentForEnterKey(event, isMac);
         if (submitIntent) {
           event.preventDefault();

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -7,6 +7,7 @@ import {
   getNodeBuiltinNames,
   runNitroBuildPipeline,
 } from "./build.js";
+import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
 
 const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
@@ -158,6 +159,9 @@ export default (event) =>
     expect(html).toContain('href="/docs/next"');
     expect(html).toContain('action="/docs/api/search"');
     expect(html).toContain('url("/docs/hero.png")');
+    expect(html).toContain(
+      `<meta property="og:image" content="${AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE}">`,
+    );
     expect(response.headers.get("cache-control")).toBe(
       DEFAULT_SSR_CACHE_CONTROL,
     );

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -308,8 +308,8 @@ function injectHeadScript(html, script) {
 
 const DEFAULT_SSR_CACHE_CONTROL = ${JSON.stringify(DEFAULT_SSR_CACHE_CONTROL)};
 const AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE = ${JSON.stringify(
-  AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE,
-)};
+    AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE,
+  )};
 const OG_IMAGE_META_RE = /<meta\\b(?=[^>]*\\bproperty=(["'])og:image\\1)[^>]*>/i;
 const TWITTER_CARD_META_RE = /<meta\\b(?=[^>]*\\bname=(["'])twitter:card\\1)[^>]*>/i;
 const TWITTER_IMAGE_META_RE = /<meta\\b(?=[^>]*\\bname=(["'])twitter:image\\1)[^>]*>/i;

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -34,6 +34,7 @@ import {
 } from "./workspace-core.js";
 import { generateActionRegistryForProject } from "../vite/action-types-plugin.js";
 import { mcpEmbedStaticAssetRouteRules } from "../shared/mcp-embed-headers.js";
+import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
 
 const cwd = process.cwd();
 const preset = process.env.NITRO_PRESET || "node";
@@ -306,6 +307,34 @@ function injectHeadScript(html, script) {
 }
 
 const DEFAULT_SSR_CACHE_CONTROL = ${JSON.stringify(DEFAULT_SSR_CACHE_CONTROL)};
+const AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE = ${JSON.stringify(
+  AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE,
+)};
+const OG_IMAGE_META_RE = /<meta\\b(?=[^>]*\\bproperty=(["'])og:image\\1)[^>]*>/i;
+const TWITTER_CARD_META_RE = /<meta\\b(?=[^>]*\\bname=(["'])twitter:card\\1)[^>]*>/i;
+const TWITTER_IMAGE_META_RE = /<meta\\b(?=[^>]*\\bname=(["'])twitter:image\\1)[^>]*>/i;
+
+function injectDefaultSocialImageMeta(html) {
+  const headCloseIdx = html.indexOf("</head>");
+  if (headCloseIdx === -1) return html;
+
+  const hasAnySocialImage =
+    OG_IMAGE_META_RE.test(html) || TWITTER_IMAGE_META_RE.test(html);
+  const tags = [];
+
+  if (!hasAnySocialImage) {
+    tags.push('<meta property="og:image" content="' + AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE + '">');
+  }
+  if (!TWITTER_CARD_META_RE.test(html)) {
+    tags.push('<meta name="twitter:card" content="summary_large_image">');
+  }
+  if (!hasAnySocialImage) {
+    tags.push('<meta name="twitter:image" content="' + AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE + '">');
+  }
+
+  if (tags.length === 0) return html;
+  return html.slice(0, headCloseIdx) + tags.join("") + html.slice(headCloseIdx);
+}
 
 function applyDefaultSsrCacheHeader(headers, status) {
   if (headers.has("cache-control")) return;
@@ -327,14 +356,6 @@ async function rewriteMountedResponse(response, basePath) {
     headers.set("location", prefixMountedPath(location, basePath));
   }
 
-  if (!basePath && !sentryClientConfigScript) {
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers,
-    });
-  }
-
   const contentType = headers.get("content-type") || "";
   if (!contentType.toLowerCase().includes("text/html") || !response.body) {
     return new Response(response.body, {
@@ -347,7 +368,10 @@ async function rewriteMountedResponse(response, basePath) {
   const html = await response.text();
   headers.delete("content-length");
   return new Response(
-    injectHeadScript(prefixMountedHtml(html, basePath), sentryClientConfigScript),
+    injectHeadScript(
+      injectDefaultSocialImageMeta(prefixMountedHtml(html, basePath)),
+      sentryClientConfigScript,
+    ),
     {
       status: response.status,
       statusText: response.statusText,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -73,8 +73,8 @@ import {
   buildAssistantMessage,
   buildUserMessage,
   extractThreadMeta,
+  foldAssistantTurn,
   mergeThreadDataForClientSave,
-  upsertAssistantMessage,
   upsertUserMessage,
 } from "../agent/thread-data-builder.js";
 import {
@@ -4168,7 +4168,13 @@ export function createAgentChatPlugin(
             const assistantMsg = buildAssistantMessage(
               run.events ?? [],
               run.runId,
-              { suppressInternalContinuation: true },
+              {
+                suppressInternalContinuation: true,
+                turnId:
+                  typeof run.turnId === "string" && run.turnId
+                    ? run.turnId
+                    : undefined,
+              },
             );
             if (!assistantMsg) {
               // No content produced — just bump timestamp
@@ -4193,7 +4199,13 @@ export function createAgentChatPlugin(
             }
             if (!Array.isArray(repo.messages)) repo.messages = [];
 
-            repo = upsertAssistantMessage(repo, assistantMsg);
+            repo = foldAssistantTurn(repo, assistantMsg, {
+              runId: run.runId,
+              turnId:
+                typeof run.turnId === "string" && run.turnId
+                  ? run.turnId
+                  : undefined,
+            });
 
             // Store debug metadata so we can inspect what the LLM actually
             // received (system prompt, model, engine) when diagnosing issues.

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -125,7 +125,7 @@ describe("createH3SSRHandler", () => {
   it("injects the default social image into SSR HTML without one", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response(
-        '<html><head><title>Calendar</title></head><body>ok</body></html>',
+        "<html><head><title>Calendar</title></head><body>ok</body></html>",
         {
           headers: { "content-type": "text/html; charset=utf-8" },
         },

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -3,6 +3,7 @@ import {
   createH3SSRHandler,
   DEFAULT_SSR_CACHE_CONTROL,
 } from "./ssr-handler.js";
+import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
 
 const mocks = vi.hoisted(() => {
   const requestHandler = vi.fn(async (request: Request) => {
@@ -118,6 +119,52 @@ describe("createH3SSRHandler", () => {
 
     expect(response.headers.get("cache-control")).toBe(
       DEFAULT_SSR_CACHE_CONTROL,
+    );
+  });
+
+  it("injects the default social image into SSR HTML without one", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response(
+        '<html><head><title>Calendar</title></head><body>ok</body></html>',
+        {
+          headers: { "content-type": "text/html; charset=utf-8" },
+        },
+      ),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(createEvent("/"));
+    const html = await response.text();
+
+    expect(html).toContain(
+      `<meta property="og:image" content="${AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE}">`,
+    );
+    expect(html).toContain(
+      `<meta name="twitter:image" content="${AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE}">`,
+    );
+    expect(html).toContain(
+      '<meta name="twitter:card" content="summary_large_image">',
+    );
+  });
+
+  it("does not inject the default social image when a route provides one", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response(
+        '<html><head><meta property="og:image" content="https://example.test/custom.png"></head><body>ok</body></html>',
+        {
+          headers: { "content-type": "text/html; charset=utf-8" },
+        },
+      ),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(createEvent("/book/steve/meeting"));
+    const html = await response.text();
+
+    expect(html).toContain("https://example.test/custom.png");
+    expect(html).not.toContain(AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE);
+    expect(html).toContain(
+      '<meta name="twitter:card" content="summary_large_image">',
     );
   });
 

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -25,6 +25,7 @@ import {
   EMBED_SESSION_COOKIE,
   EMBED_TOKEN_QUERY_PARAM,
 } from "../shared/embed-auth.js";
+import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
 
 export const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
@@ -145,6 +146,39 @@ function injectHeadScript(html: string, script: string | null): string {
   return html.slice(0, headCloseIdx) + script + html.slice(headCloseIdx);
 }
 
+const OG_IMAGE_META_RE =
+  /<meta\b(?=[^>]*\bproperty=(["'])og:image\1)[^>]*>/i;
+const TWITTER_CARD_META_RE =
+  /<meta\b(?=[^>]*\bname=(["'])twitter:card\1)[^>]*>/i;
+const TWITTER_IMAGE_META_RE =
+  /<meta\b(?=[^>]*\bname=(["'])twitter:image\1)[^>]*>/i;
+
+function injectDefaultSocialImageMeta(html: string): string {
+  const headCloseIdx = html.indexOf("</head>");
+  if (headCloseIdx === -1) return html;
+
+  const hasAnySocialImage =
+    OG_IMAGE_META_RE.test(html) || TWITTER_IMAGE_META_RE.test(html);
+  const tags: string[] = [];
+
+  if (!hasAnySocialImage) {
+    tags.push(
+      `<meta property="og:image" content="${AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE}">`,
+    );
+  }
+  if (!TWITTER_CARD_META_RE.test(html)) {
+    tags.push(`<meta name="twitter:card" content="summary_large_image">`);
+  }
+  if (!hasAnySocialImage) {
+    tags.push(
+      `<meta name="twitter:image" content="${AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE}">`,
+    );
+  }
+
+  if (tags.length === 0) return html;
+  return html.slice(0, headCloseIdx) + tags.join("") + html.slice(headCloseIdx);
+}
+
 function requestHasAuthSignal(event: H3Event): boolean {
   const headers = event.req.headers;
   return Boolean(
@@ -221,14 +255,6 @@ async function rewriteMountedResponse(
     headers.set("location", prefixMountedPath(location, basePath));
   }
 
-  if (!basePath && !sentryClientConfigScript) {
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers,
-    });
-  }
-
   const contentType = headers.get("content-type") ?? "";
   if (!contentType.toLowerCase().includes("text/html") || !response.body) {
     return new Response(response.body, {
@@ -242,7 +268,7 @@ async function rewriteMountedResponse(
   headers.delete("content-length");
   return new Response(
     injectHeadScript(
-      prefixMountedHtml(html, basePath),
+      injectDefaultSocialImageMeta(prefixMountedHtml(html, basePath)),
       sentryClientConfigScript,
     ),
     {

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -146,8 +146,7 @@ function injectHeadScript(html: string, script: string | null): string {
   return html.slice(0, headCloseIdx) + script + html.slice(headCloseIdx);
 }
 
-const OG_IMAGE_META_RE =
-  /<meta\b(?=[^>]*\bproperty=(["'])og:image\1)[^>]*>/i;
+const OG_IMAGE_META_RE = /<meta\b(?=[^>]*\bproperty=(["'])og:image\1)[^>]*>/i;
 const TWITTER_CARD_META_RE =
   /<meta\b(?=[^>]*\bname=(["'])twitter:card\1)[^>]*>/i;
 const TWITTER_IMAGE_META_RE =

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -40,6 +40,12 @@ export {
   withCollapsedAgentSidebarParam,
 } from "./agent-sidebar-url.js";
 export {
+  AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE,
+  defaultSocialImageMeta,
+  withDefaultSocialImage,
+  type SocialMetaDescriptor,
+} from "./social-meta.js";
+export {
   EMBED_MODE_QUERY_PARAM,
   EMBED_SESSION_COOKIE,
   EMBED_START_PATH,

--- a/packages/core/src/shared/social-meta.ts
+++ b/packages/core/src/shared/social-meta.ts
@@ -1,0 +1,42 @@
+export type SocialMetaDescriptor =
+  | { title: string }
+  | { property: string; content: string }
+  | { name: string; content: string };
+
+export const AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE =
+  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9c533fed169648069bffaed652ec0897";
+
+function hasMetaProperty(meta: SocialMetaDescriptor[], property: string) {
+  return meta.some((item) => "property" in item && item.property === property);
+}
+
+function hasMetaName(meta: SocialMetaDescriptor[], name: string) {
+  return meta.some((item) => "name" in item && item.name === name);
+}
+
+export function defaultSocialImageMeta(
+  image = AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE,
+): SocialMetaDescriptor[] {
+  return [
+    { property: "og:image", content: image },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:image", content: image },
+  ];
+}
+
+export function withDefaultSocialImage<T extends SocialMetaDescriptor>(
+  meta: T[],
+  image = AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE,
+): Array<T | SocialMetaDescriptor> {
+  const hasAnySocialImage =
+    hasMetaProperty(meta, "og:image") || hasMetaName(meta, "twitter:image");
+
+  return [
+    ...meta,
+    ...(hasAnySocialImage ? [] : [{ property: "og:image", content: image }]),
+    ...(hasMetaName(meta, "twitter:card")
+      ? []
+      : [{ name: "twitter:card", content: "summary_large_image" }]),
+    ...(hasAnySocialImage ? [] : [{ name: "twitter:image", content: image }]),
+  ];
+}

--- a/packages/dispatch/src/routes/pages/overview.tsx
+++ b/packages/dispatch/src/routes/pages/overview.tsx
@@ -399,18 +399,18 @@ function StatCard({
   cta?: React.ReactNode;
 }) {
   return (
-    <div className="rounded-2xl border bg-card p-5">
+    <div className="min-w-0 rounded-2xl border bg-card p-5">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-            <span>{label}</span>
+          <div className="flex items-center gap-1.5 text-sm font-medium leading-snug text-foreground">
+            <span className="min-w-0">{label}</span>
             <HelpTooltip content={help} />
           </div>
           <div className="mt-3 text-3xl font-semibold text-foreground">
             {value}
           </div>
         </div>
-        <div className="rounded-xl border bg-muted/30 p-3 text-muted-foreground">
+        <div className="shrink-0 rounded-xl border bg-muted/30 p-3 text-muted-foreground">
           <Icon size={18} />
         </div>
       </div>
@@ -649,7 +649,7 @@ export default function OverviewRoute() {
           <IconActivity size={16} className="text-muted-foreground" />
           <h2 className="text-sm font-semibold text-foreground">At a glance</h2>
         </div>
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <div className="grid grid-cols-[repeat(auto-fit,minmax(min(100%,13rem),1fr))] gap-4">
           <StatCard
             label="Vault secrets"
             help="Credentials stored in the workspace vault."

--- a/packages/docs/app/seo.ts
+++ b/packages/docs/app/seo.ts
@@ -1,46 +1,18 @@
 import type { MetaDescriptor } from "react-router";
+import {
+  AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE,
+  defaultSocialImageMeta as coreDefaultSocialImageMeta,
+  withDefaultSocialImage as coreWithDefaultSocialImage,
+} from "@agent-native/core/shared";
 
-export const DEFAULT_SOCIAL_IMAGE =
-  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9c533fed169648069bffaed652ec0897";
-
-function hasMetaProperty(meta: MetaDescriptor[], property: string) {
-  return meta.some(
-    (item) =>
-      item &&
-      typeof item === "object" &&
-      "property" in item &&
-      item.property === property,
-  );
-}
-
-function hasMetaName(meta: MetaDescriptor[], name: string) {
-  return meta.some(
-    (item) =>
-      item && typeof item === "object" && "name" in item && item.name === name,
-  );
-}
+export const DEFAULT_SOCIAL_IMAGE = AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE;
 
 export function defaultSocialImageMeta(): MetaDescriptor[] {
-  return [
-    { property: "og:image", content: DEFAULT_SOCIAL_IMAGE },
-    { name: "twitter:card", content: "summary_large_image" },
-    { name: "twitter:image", content: DEFAULT_SOCIAL_IMAGE },
-  ];
+  return coreDefaultSocialImageMeta() as MetaDescriptor[];
 }
 
 export function withDefaultSocialImage(
   meta: MetaDescriptor[],
 ): MetaDescriptor[] {
-  return [
-    ...meta,
-    ...(hasMetaProperty(meta, "og:image")
-      ? []
-      : [{ property: "og:image", content: DEFAULT_SOCIAL_IMAGE }]),
-    ...(hasMetaName(meta, "twitter:card")
-      ? []
-      : [{ name: "twitter:card", content: "summary_large_image" }]),
-    ...(hasMetaName(meta, "twitter:image")
-      ? []
-      : [{ name: "twitter:image", content: DEFAULT_SOCIAL_IMAGE }]),
-  ];
+  return coreWithDefaultSocialImage(meta as any) as MetaDescriptor[];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1545,6 +1545,9 @@ importers:
       '@libsql/client':
         specifier: ^0.15.0
         version: 0.15.15
+      '@resvg/resvg-js':
+        specifier: ^2.6.2
+        version: 2.6.2
       '@tabler/icons-react':
         specifier: ^3.40.0
         version: 3.41.1(react@19.2.5)
@@ -10122,6 +10125,86 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    resolution: {integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    resolution: {integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    resolution: {integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    resolution: {integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    resolution: {integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    resolution: {integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    resolution: {integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@resvg/resvg-js@2.6.2':
+    resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
+    engines: {node: '>= 10'}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
@@ -25330,6 +25413,57 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       remotion: 4.0.443(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js@2.6.2':
+    optionalDependencies:
+      '@resvg/resvg-js-android-arm-eabi': 2.6.2
+      '@resvg/resvg-js-android-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-x64': 2.6.2
+      '@resvg/resvg-js-linux-arm-gnueabihf': 2.6.2
+      '@resvg/resvg-js-linux-arm64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-arm64-musl': 2.6.2
+      '@resvg/resvg-js-linux-x64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-x64-musl': 2.6.2
+      '@resvg/resvg-js-win32-arm64-msvc': 2.6.2
+      '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
+      '@resvg/resvg-js-win32-x64-msvc': 2.6.2
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true

--- a/templates/calendar/app/routes/book.$slug.tsx
+++ b/templates/calendar/app/routes/book.$slug.tsx
@@ -1,9 +1,10 @@
 import BookingPage from "@/pages/BookingPage";
 import { Spinner } from "@/components/ui/spinner";
+import { bookingOgLoader, bookingOgMeta } from "./booking-og-meta";
 
-export function meta() {
-  return [{ title: "Book a Meeting" }];
-}
+export const loader = bookingOgLoader;
+
+export const meta = bookingOgMeta;
 
 export function HydrateFallback() {
   return (
@@ -14,7 +15,6 @@ export function HydrateFallback() {
 }
 
 // Public booking page — no AppLayout wrapper.
-// Future: add a server loader here for og tags/SEO when needed.
 export default function BookingRoute() {
   return <BookingPage />;
 }

--- a/templates/calendar/app/routes/book.$username.$slug.tsx
+++ b/templates/calendar/app/routes/book.$username.$slug.tsx
@@ -1,9 +1,10 @@
 import BookingPage from "@/pages/BookingPage";
 import { Spinner } from "@/components/ui/spinner";
+import { bookingOgLoader, bookingOgMeta } from "./booking-og-meta";
 
-export function meta() {
-  return [{ title: "Book a Meeting" }];
-}
+export const loader = bookingOgLoader;
+
+export const meta = bookingOgMeta;
 
 export function HydrateFallback() {
   return (

--- a/templates/calendar/app/routes/booking-og-meta.ts
+++ b/templates/calendar/app/routes/booking-og-meta.ts
@@ -1,0 +1,62 @@
+import type {
+  LoaderFunctionArgs,
+  MetaArgs,
+  MetaDescriptor,
+} from "react-router";
+
+export interface BookingOgLoaderData {
+  ogImageUrl: string;
+}
+
+function normalizeAppBasePath(value: string | undefined): string {
+  if (!value || value === "/") return "";
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === "/") return "";
+  return `/${trimmed.replace(/^\/+/, "").replace(/\/+$/, "")}`;
+}
+
+function appBasePath(): string {
+  const metaEnv = (
+    import.meta as unknown as {
+      env?: Record<string, string | undefined>;
+    }
+  ).env;
+  return normalizeAppBasePath(
+    process.env.VITE_APP_BASE_PATH ||
+      process.env.APP_BASE_PATH ||
+      metaEnv?.VITE_APP_BASE_PATH ||
+      metaEnv?.APP_BASE_PATH ||
+      metaEnv?.BASE_URL,
+  );
+}
+
+export function bookingOgLoader({
+  params,
+  request,
+}: LoaderFunctionArgs): BookingOgLoaderData {
+  const slug = params.slug ?? "";
+  const imageUrl = new URL(
+    `${appBasePath()}/api/public/booking-links/${encodeURIComponent(slug)}/og.png`,
+    request.url,
+  );
+  if (params.username) imageUrl.searchParams.set("username", params.username);
+  return { ogImageUrl: imageUrl.toString() };
+}
+
+export function bookingOgMeta({
+  data,
+}: MetaArgs<typeof bookingOgLoader>): MetaDescriptor[] {
+  const image = data?.ogImageUrl;
+  return [
+    { title: "Book a Meeting" },
+    { property: "og:title", content: "Book a Meeting" },
+    { property: "og:type", content: "website" },
+    ...(image
+      ? [
+          { property: "og:image", content: image },
+          { name: "twitter:card", content: "summary_large_image" },
+          { name: "twitter:image", content: image },
+        ]
+      : []),
+  ];
+}

--- a/templates/calendar/app/routes/meet.$username.$slug.tsx
+++ b/templates/calendar/app/routes/meet.$username.$slug.tsx
@@ -1,9 +1,10 @@
 import BookingPage from "@/pages/BookingPage";
 import { Spinner } from "@/components/ui/spinner";
+import { bookingOgLoader, bookingOgMeta } from "./booking-og-meta";
 
-export function meta() {
-  return [{ title: "Book a Meeting" }];
-}
+export const loader = bookingOgLoader;
+
+export const meta = bookingOgMeta;
 
 export function HydrateFallback() {
   return (

--- a/templates/calendar/package.json
+++ b/templates/calendar/package.json
@@ -19,6 +19,7 @@
     "@agent-native/core": "workspace:*",
     "@agent-native/scheduling": "workspace:*",
     "@libsql/client": "^0.15.0",
+    "@resvg/resvg-js": "^2.6.2",
     "@tabler/icons-react": "^3.40.0",
     "dotenv": "^17.2.1",
     "drizzle-orm": "^0.45.2",

--- a/templates/calendar/server/lib/booking-og-image.spec.ts
+++ b/templates/calendar/server/lib/booking-og-image.spec.ts
@@ -15,7 +15,7 @@ describe("booking OG image", () => {
 
     expect(svg).toContain("Agent-Native");
     expect(svg).toContain("Calendar");
-    expect(svg).toContain("Meet Steve Sewell");
+    expect(svg).toContain("Meet with Steve Sewell");
     expect(svg).toContain("30 min meeting");
     expect(svg).toContain('fill="#000000"');
     expect(svg).not.toContain("Pick a time");
@@ -33,6 +33,18 @@ describe("booking OG image", () => {
     expect(Array.from(png.slice(0, 8))).toEqual([
       0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
     ]);
+  });
+
+  it("uses custom booking link titles in place of the generated title", () => {
+    const svg = renderBookingOgImageSvg({
+      title: "Product strategy sync",
+      duration: 45,
+      username: "steve",
+      bookingPageTitle: "Meet Steve Sewell",
+    });
+
+    expect(svg).toContain("Product strategy sync");
+    expect(svg).not.toContain("Meet with Steve Sewell");
   });
 
   it("renders a profile image when provided", () => {

--- a/templates/calendar/server/lib/booking-og-image.spec.ts
+++ b/templates/calendar/server/lib/booking-og-image.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderBookingOgImagePng,
+  renderBookingOgImageSvg,
+} from "./booking-og-image";
+
+describe("booking OG image", () => {
+  it("renders branded SVG content for a booking link", () => {
+    const svg = renderBookingOgImageSvg({
+      title: "Meeting",
+      duration: 30,
+      username: "steve",
+      bookingPageTitle: "Meet Steve Sewell",
+    });
+
+    expect(svg).toContain("Agent-Native");
+    expect(svg).toContain("Calendar");
+    expect(svg).toContain("Meet Steve Sewell");
+    expect(svg).toContain("30 min meeting");
+  });
+
+  it("renders a PNG image", () => {
+    const png = renderBookingOgImagePng({
+      title: "Meeting",
+      duration: 30,
+      username: "steve",
+      bookingPageTitle: "Meet Steve Sewell",
+    });
+
+    expect(png.byteLength).toBeGreaterThan(1000);
+    expect(Array.from(png.slice(0, 8))).toEqual([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+  });
+});

--- a/templates/calendar/server/lib/booking-og-image.spec.ts
+++ b/templates/calendar/server/lib/booking-og-image.spec.ts
@@ -17,6 +17,8 @@ describe("booking OG image", () => {
     expect(svg).toContain("Calendar");
     expect(svg).toContain("Meet Steve Sewell");
     expect(svg).toContain("30 min meeting");
+    expect(svg).toContain('fill="#000000"');
+    expect(svg).not.toContain("Pick a time");
   });
 
   it("renders a PNG image", () => {
@@ -31,5 +33,19 @@ describe("booking OG image", () => {
     expect(Array.from(png.slice(0, 8))).toEqual([
       0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
     ]);
+  });
+
+  it("renders a profile image when provided", () => {
+    const svg = renderBookingOgImageSvg({
+      title: "Meeting",
+      duration: 30,
+      username: "steve",
+      bookingPageTitle: "Meet Steve Sewell",
+      profileImageDataUrl:
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+    });
+
+    expect(svg).toContain("<image");
+    expect(svg).toContain('mask="url(#avatarMask)"');
   });
 });

--- a/templates/calendar/server/lib/booking-og-image.ts
+++ b/templates/calendar/server/lib/booking-og-image.ts
@@ -8,10 +8,23 @@ export interface BookingOgImageInput {
   username?: string | null;
   ownerEmail?: string | null;
   bookingPageTitle?: string | null;
+  profileImageDataUrl?: string | null;
 }
 
 const WIDTH = 1200;
 const HEIGHT = 630;
+const BRAND_BLUE = "#00B5FF";
+const BRAND_MINT = "#48FFE4";
+const BG = "#000000";
+const SURFACE = "#0a0a0a";
+const BORDER = "#1f1f1f";
+const FG = "#ededed";
+const MUTED = "#a0a0a0";
+
+const LOGO_MARK = `
+  <path d="M24.5537 65.7695H0L15.0859 39.4619L37.708 0L60.4912 39.4619H39.6396L24.5537 65.7695Z" fill="white"/>
+  <path d="M89.446 0H114L76.2921 65.7704H51.7383L89.446 0Z" fill="url(#brand)"/>
+`;
 
 function escapeSvg(value: string): string {
   return value
@@ -86,6 +99,11 @@ function initialsFor(name: string): string {
   return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
 }
 
+function validProfileImageDataUrl(value: string | null | undefined): string {
+  const dataUrl = cleanText(value);
+  return /^data:image\/[a-z0-9.+-]+;base64,/i.test(dataUrl) ? dataUrl : "";
+}
+
 function wrapText(value: string, maxChars: number, maxLines: number): string[] {
   const words = value.split(/\s+/).filter(Boolean);
   const lines: string[] = [];
@@ -146,66 +164,64 @@ export function renderBookingOgImageSvg(input: BookingOgImageInput): string {
     displayNameFromIdentifier(input.username, input.ownerEmail);
   const title = displayTitle(input, inferredHost);
   const titleLines = wrapText(title, title.length > 34 ? 23 : 28, 2);
-  const description = cleanText(input.description);
-  const descriptionLines = description
-    ? wrapText(description, 52, 2)
-    : [`Pick a time with ${inferredHost}`];
   const duration = durationLabel(input);
   const initials = initialsFor(inferredHost);
+  const profileImageDataUrl = validProfileImageDataUrl(
+    input.profileImageDataUrl,
+  );
+  const titleFontSize = titleLines.length > 1 ? 66 : 82;
+  const titleLineHeight = titleLines.length > 1 ? 76 : 92;
+  const durationY = titleLines.length > 1 ? 214 : 150;
+  const avatarContent = profileImageDataUrl
+    ? `<image x="910" y="106" width="172" height="172" href="${escapeSvg(profileImageDataUrl)}" preserveAspectRatio="xMidYMid slice" mask="url(#avatarMask)"/>`
+    : `<circle cx="996" cy="192" r="72" fill="url(#brand)" fill-opacity="0.2"/>
+       <text x="996" y="212" text-anchor="middle" font-family="Inter, Arial, system-ui, sans-serif" font-size="56" font-weight="800" fill="${FG}">${escapeSvg(initials)}</text>`;
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">
+  <title>Agent-Native Calendar booking link</title>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#050505"/>
-      <stop offset="0.56" stop-color="#0a0d0f"/>
-      <stop offset="1" stop-color="#020202"/>
-    </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#00d1ff"/>
-      <stop offset="1" stop-color="#7cffc4"/>
+    <linearGradient id="brand" x1="101.702" y1="67.4791" x2="113.672" y2="-37.4275" gradientUnits="userSpaceOnUse">
+      <stop stop-color="${BRAND_BLUE}"/>
+      <stop offset="1" stop-color="${BRAND_MINT}"/>
     </linearGradient>
     <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
-      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#ffffff" stroke-opacity="0.055" stroke-width="1"/>
+      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#ffffff" stroke-opacity="0.07" stroke-width="1"/>
     </pattern>
+    <mask id="avatarMask">
+      <rect width="${WIDTH}" height="${HEIGHT}" fill="black"/>
+      <circle cx="996" cy="192" r="78" fill="white"/>
+    </mask>
   </defs>
-  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#bg)"/>
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="${BG}"/>
   <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#grid)"/>
-  <path d="M0 518 C190 456 294 460 482 506 C702 560 866 546 1200 438 L1200 630 L0 630 Z" fill="#ffffff" fill-opacity="0.035"/>
-  <path d="M80 78 H1120" stroke="#ffffff" stroke-opacity="0.11"/>
-  <g transform="translate(80 112)">
-    <rect x="0" y="0" width="58" height="58" rx="16" fill="url(#accent)"/>
-    <text x="29" y="38" text-anchor="middle" font-family="Inter, Arial, system-ui, sans-serif" font-size="22" font-weight="800" fill="#020202">AN</text>
-    <text x="78" y="25" font-family="Inter, Arial, system-ui, sans-serif" font-size="28" font-weight="800" fill="#ffffff">Agent-Native</text>
-    <text x="78" y="51" font-family="Inter, Arial, system-ui, sans-serif" font-size="20" font-weight="600" fill="#94a3b8">Calendar</text>
+  <rect x="64" y="64" width="1072" height="502" rx="28" fill="${BG}" fill-opacity="0.72" stroke="${BORDER}" stroke-width="1"/>
+  <path d="M80 154 H1120" stroke="${BORDER}"/>
+  <g transform="translate(80 86)">
+    <g transform="scale(0.62)">
+      ${LOGO_MARK}
+    </g>
+    <text x="90" y="31" font-family="Inter, Arial, system-ui, sans-serif" font-size="28" font-weight="800" fill="${FG}">Agent-Native</text>
+    <text x="91" y="58" font-family="Inter, Arial, system-ui, sans-serif" font-size="18" font-weight="600" fill="${MUTED}">Calendar</text>
   </g>
-  <g transform="translate(904 112)">
-    <circle cx="92" cy="92" r="86" fill="#0e1113" stroke="#ffffff" stroke-opacity="0.14" stroke-width="2"/>
-    <circle cx="92" cy="92" r="64" fill="url(#accent)" fill-opacity="0.18"/>
-    <text x="92" y="112" text-anchor="middle" font-family="Inter, Arial, system-ui, sans-serif" font-size="54" font-weight="800" fill="#ffffff">${escapeSvg(initials)}</text>
+  <g>
+    <circle cx="996" cy="192" r="86" fill="${SURFACE}" stroke="${BORDER}" stroke-width="2"/>
+    ${avatarContent}
+    <circle cx="996" cy="192" r="78" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
   </g>
-  <g transform="translate(80 342)">
+  <g transform="translate(80 348)">
     ${textBlock({
       lines: titleLines,
       x: 0,
       y: 0,
-      fontSize: titleLines.length > 1 ? 66 : 78,
-      lineHeight: titleLines.length > 1 ? 76 : 88,
+      fontSize: titleFontSize,
+      lineHeight: titleLineHeight,
       weight: 800,
-      fill: "#f8fafc",
+      fill: FG,
     })}
-    ${textBlock({
-      lines: descriptionLines,
-      x: 2,
-      y: titleLines.length > 1 ? 174 : 116,
-      fontSize: 29,
-      lineHeight: 40,
-      weight: 500,
-      fill: "#94a3b8",
-    })}
-    <g transform="translate(0 ${titleLines.length > 1 ? 250 : 192})">
-      <rect x="0" y="-34" width="${Math.max(246, duration.length * 17 + 54)}" height="58" rx="29" fill="#ffffff" fill-opacity="0.09" stroke="#ffffff" stroke-opacity="0.16"/>
-      <circle cx="31" cy="-5" r="8" fill="#7cffc4"/>
-      <text x="54" y="4" font-family="Inter, Arial, system-ui, sans-serif" font-size="27" font-weight="700" fill="#ffffff">${escapeSvg(duration)}</text>
+    <g transform="translate(0 ${durationY})">
+      <rect x="0" y="-34" width="${Math.max(246, duration.length * 17 + 54)}" height="58" rx="29" fill="${SURFACE}" stroke="${BORDER}"/>
+      <circle cx="31" cy="-5" r="8" fill="${BRAND_MINT}"/>
+      <text x="54" y="4" font-family="Inter, Arial, system-ui, sans-serif" font-size="27" font-weight="700" fill="${FG}">${escapeSvg(duration)}</text>
     </g>
   </g>
 </svg>`;

--- a/templates/calendar/server/lib/booking-og-image.ts
+++ b/templates/calendar/server/lib/booking-og-image.ts
@@ -1,0 +1,219 @@
+import { Resvg } from "@resvg/resvg-js";
+
+export interface BookingOgImageInput {
+  title?: string | null;
+  description?: string | null;
+  duration?: number | null;
+  durations?: number[] | null;
+  username?: string | null;
+  ownerEmail?: string | null;
+  bookingPageTitle?: string | null;
+}
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+function escapeSvg(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function cleanText(value: string | null | undefined): string {
+  return String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(/[\s._-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function displayNameFromIdentifier(
+  username?: string | null,
+  ownerEmail?: string | null,
+): string {
+  const source = cleanText(username) || cleanText(ownerEmail).split("@")[0];
+  return titleCase(source || "Host");
+}
+
+function hostNameFromBookingPageTitle(title?: string | null): string | null {
+  const clean = cleanText(title);
+  const match = clean.match(/^book(?:\s+a)?\s+meeting\s+with\s+(.+)$/i);
+  if (match?.[1]) return cleanText(match[1]);
+  const meetMatch = clean.match(/^meet\s+(.+)$/i);
+  if (meetMatch?.[1]) return cleanText(meetMatch[1]);
+  return null;
+}
+
+function isGenericMeetingTitle(title: string): boolean {
+  return /^(book\s+a\s+meeting|meeting)$/i.test(title);
+}
+
+function displayTitle(input: BookingOgImageInput, hostName: string): string {
+  const title = cleanText(input.title);
+  const pageTitle = cleanText(input.bookingPageTitle);
+  if (title && !isGenericMeetingTitle(title)) return title;
+  if (pageTitle && !isGenericMeetingTitle(pageTitle)) return pageTitle;
+  return hostName ? `Meet ${hostName}` : title || pageTitle || "Book a meeting";
+}
+
+function durationLabel(input: BookingOgImageInput): string {
+  const durations = Array.isArray(input.durations)
+    ? input.durations.filter((value) => Number.isFinite(value) && value > 0)
+    : [];
+  if (durations.length > 1) {
+    return `${durations.slice(0, 3).join(" / ")} min options`;
+  }
+  const duration = durations[0] ?? input.duration ?? 30;
+  return `${duration} min meeting`;
+}
+
+function initialsFor(name: string): string {
+  const parts = name.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "AN";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+}
+
+function wrapText(value: string, maxChars: number, maxLines: number): string[] {
+  const words = value.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length <= maxChars) {
+      current = next;
+      continue;
+    }
+    if (current) lines.push(current);
+    current = word;
+    if (lines.length === maxLines) break;
+  }
+  if (current && lines.length < maxLines) lines.push(current);
+
+  if (lines.length > maxLines) return lines.slice(0, maxLines);
+  const last = lines[lines.length - 1];
+  const remainingWords = words.slice(lines.join(" ").split(/\s+/).length);
+  if (remainingWords.length > 0 && last) {
+    lines[lines.length - 1] =
+      last.length > maxChars - 1
+        ? `${last.slice(0, Math.max(0, maxChars - 1)).trim()}...`
+        : `${last}...`;
+  }
+  return lines.length ? lines : [value.slice(0, maxChars)];
+}
+
+function textBlock({
+  lines,
+  x,
+  y,
+  fontSize,
+  lineHeight,
+  weight,
+  fill,
+}: {
+  lines: string[];
+  x: number;
+  y: number;
+  fontSize: number;
+  lineHeight: number;
+  weight: number;
+  fill: string;
+}): string {
+  return `<text x="${x}" y="${y}" font-family="Inter, Arial, system-ui, sans-serif" font-size="${fontSize}" font-weight="${weight}" fill="${fill}">${lines
+    .map(
+      (line, index) =>
+        `<tspan x="${x}" dy="${index === 0 ? 0 : lineHeight}">${escapeSvg(line)}</tspan>`,
+    )
+    .join("")}</text>`;
+}
+
+export function renderBookingOgImageSvg(input: BookingOgImageInput): string {
+  const inferredHost =
+    hostNameFromBookingPageTitle(input.bookingPageTitle) ??
+    displayNameFromIdentifier(input.username, input.ownerEmail);
+  const title = displayTitle(input, inferredHost);
+  const titleLines = wrapText(title, title.length > 34 ? 23 : 28, 2);
+  const description = cleanText(input.description);
+  const descriptionLines = description
+    ? wrapText(description, 52, 2)
+    : [`Pick a time with ${inferredHost}`];
+  const duration = durationLabel(input);
+  const initials = initialsFor(inferredHost);
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#050505"/>
+      <stop offset="0.56" stop-color="#0a0d0f"/>
+      <stop offset="1" stop-color="#020202"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00d1ff"/>
+      <stop offset="1" stop-color="#7cffc4"/>
+    </linearGradient>
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#ffffff" stroke-opacity="0.055" stroke-width="1"/>
+    </pattern>
+  </defs>
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#bg)"/>
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#grid)"/>
+  <path d="M0 518 C190 456 294 460 482 506 C702 560 866 546 1200 438 L1200 630 L0 630 Z" fill="#ffffff" fill-opacity="0.035"/>
+  <path d="M80 78 H1120" stroke="#ffffff" stroke-opacity="0.11"/>
+  <g transform="translate(80 112)">
+    <rect x="0" y="0" width="58" height="58" rx="16" fill="url(#accent)"/>
+    <text x="29" y="38" text-anchor="middle" font-family="Inter, Arial, system-ui, sans-serif" font-size="22" font-weight="800" fill="#020202">AN</text>
+    <text x="78" y="25" font-family="Inter, Arial, system-ui, sans-serif" font-size="28" font-weight="800" fill="#ffffff">Agent-Native</text>
+    <text x="78" y="51" font-family="Inter, Arial, system-ui, sans-serif" font-size="20" font-weight="600" fill="#94a3b8">Calendar</text>
+  </g>
+  <g transform="translate(904 112)">
+    <circle cx="92" cy="92" r="86" fill="#0e1113" stroke="#ffffff" stroke-opacity="0.14" stroke-width="2"/>
+    <circle cx="92" cy="92" r="64" fill="url(#accent)" fill-opacity="0.18"/>
+    <text x="92" y="112" text-anchor="middle" font-family="Inter, Arial, system-ui, sans-serif" font-size="54" font-weight="800" fill="#ffffff">${escapeSvg(initials)}</text>
+  </g>
+  <g transform="translate(80 342)">
+    ${textBlock({
+      lines: titleLines,
+      x: 0,
+      y: 0,
+      fontSize: titleLines.length > 1 ? 66 : 78,
+      lineHeight: titleLines.length > 1 ? 76 : 88,
+      weight: 800,
+      fill: "#f8fafc",
+    })}
+    ${textBlock({
+      lines: descriptionLines,
+      x: 2,
+      y: titleLines.length > 1 ? 174 : 116,
+      fontSize: 29,
+      lineHeight: 40,
+      weight: 500,
+      fill: "#94a3b8",
+    })}
+    <g transform="translate(0 ${titleLines.length > 1 ? 250 : 192})">
+      <rect x="0" y="-34" width="${Math.max(246, duration.length * 17 + 54)}" height="58" rx="29" fill="#ffffff" fill-opacity="0.09" stroke="#ffffff" stroke-opacity="0.16"/>
+      <circle cx="31" cy="-5" r="8" fill="#7cffc4"/>
+      <text x="54" y="4" font-family="Inter, Arial, system-ui, sans-serif" font-size="27" font-weight="700" fill="#ffffff">${escapeSvg(duration)}</text>
+    </g>
+  </g>
+</svg>`;
+}
+
+export function renderBookingOgImagePng(
+  input: BookingOgImageInput,
+): Uint8Array {
+  return new Resvg(renderBookingOgImageSvg(input), {
+    fitTo: { mode: "width", value: WIDTH },
+    font: { loadSystemFonts: true },
+  })
+    .render()
+    .asPng();
+}

--- a/templates/calendar/server/lib/booking-og-image.ts
+++ b/templates/calendar/server/lib/booking-og-image.ts
@@ -77,8 +77,9 @@ function displayTitle(input: BookingOgImageInput, hostName: string): string {
   const title = cleanText(input.title);
   const pageTitle = cleanText(input.bookingPageTitle);
   if (title && !isGenericMeetingTitle(title)) return title;
-  if (pageTitle && !isGenericMeetingTitle(pageTitle)) return pageTitle;
-  return hostName ? `Meet ${hostName}` : title || pageTitle || "Book a meeting";
+  return hostName
+    ? `Meet with ${hostName}`
+    : pageTitle || title || "Book a meeting";
 }
 
 function durationLabel(input: BookingOgImageInput): string {

--- a/templates/calendar/server/lib/booking-og-image.ts
+++ b/templates/calendar/server/lib/booking-og-image.ts
@@ -20,6 +20,9 @@ const SURFACE = "#0a0a0a";
 const BORDER = "#1f1f1f";
 const FG = "#ededed";
 const MUTED = "#a0a0a0";
+const AVATAR_CX = 996;
+const AVATAR_CY = 170;
+const AVATAR_SIZE = 172;
 
 const LOGO_MARK = `
   <path d="M24.5537 65.7695H0L15.0859 39.4619L37.708 0L60.4912 39.4619H39.6396L24.5537 65.7695Z" fill="white"/>
@@ -172,11 +175,12 @@ export function renderBookingOgImageSvg(input: BookingOgImageInput): string {
   );
   const titleFontSize = titleLines.length > 1 ? 66 : 82;
   const titleLineHeight = titleLines.length > 1 ? 76 : 92;
-  const durationY = titleLines.length > 1 ? 214 : 150;
+  const titleGroupY = titleLines.length > 1 ? 350 : 382;
+  const durationY = titleLines.length > 1 ? 186 : 150;
   const avatarContent = profileImageDataUrl
-    ? `<image x="910" y="106" width="172" height="172" href="${escapeSvg(profileImageDataUrl)}" preserveAspectRatio="xMidYMid slice" mask="url(#avatarMask)"/>`
-    : `<circle cx="996" cy="192" r="72" fill="url(#brand)" fill-opacity="0.2"/>
-       <text x="996" y="212" text-anchor="middle" font-family="Inter, Arial, system-ui, sans-serif" font-size="56" font-weight="800" fill="${FG}">${escapeSvg(initials)}</text>`;
+    ? `<image x="${AVATAR_CX - AVATAR_SIZE / 2}" y="${AVATAR_CY - AVATAR_SIZE / 2}" width="${AVATAR_SIZE}" height="${AVATAR_SIZE}" href="${escapeSvg(profileImageDataUrl)}" preserveAspectRatio="xMidYMid slice" mask="url(#avatarMask)"/>`
+    : `<circle cx="${AVATAR_CX}" cy="${AVATAR_CY}" r="72" fill="url(#brand)" fill-opacity="0.2"/>
+       <text x="${AVATAR_CX}" y="${AVATAR_CY + 20}" text-anchor="middle" font-family="Inter, Arial, system-ui, sans-serif" font-size="56" font-weight="800" fill="${FG}">${escapeSvg(initials)}</text>`;
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">
   <title>Agent-Native Calendar booking link</title>
@@ -190,7 +194,7 @@ export function renderBookingOgImageSvg(input: BookingOgImageInput): string {
     </pattern>
     <mask id="avatarMask">
       <rect width="${WIDTH}" height="${HEIGHT}" fill="black"/>
-      <circle cx="996" cy="192" r="78" fill="white"/>
+      <circle cx="${AVATAR_CX}" cy="${AVATAR_CY}" r="78" fill="white"/>
     </mask>
   </defs>
   <rect width="${WIDTH}" height="${HEIGHT}" fill="${BG}"/>
@@ -205,11 +209,11 @@ export function renderBookingOgImageSvg(input: BookingOgImageInput): string {
     <text x="91" y="58" font-family="Inter, Arial, system-ui, sans-serif" font-size="18" font-weight="600" fill="${MUTED}">Calendar</text>
   </g>
   <g>
-    <circle cx="996" cy="192" r="86" fill="${SURFACE}" stroke="${BORDER}" stroke-width="2"/>
+    <circle cx="${AVATAR_CX}" cy="${AVATAR_CY}" r="86" fill="${SURFACE}" stroke="${BORDER}" stroke-width="2"/>
     ${avatarContent}
-    <circle cx="996" cy="192" r="78" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
+    <circle cx="${AVATAR_CX}" cy="${AVATAR_CY}" r="78" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
   </g>
-  <g transform="translate(80 348)">
+  <g transform="translate(80 ${titleGroupY})">
     ${textBlock({
       lines: titleLines,
       x: 0,

--- a/templates/calendar/server/lib/booking-og-image.ts
+++ b/templates/calendar/server/lib/booking-og-image.ts
@@ -39,8 +39,12 @@ function displayNameFromIdentifier(
   username?: string | null,
   ownerEmail?: string | null,
 ): string {
-  const source = cleanText(username) || cleanText(ownerEmail).split("@")[0];
-  return titleCase(source || "Host");
+  const usernameName = titleCase(cleanText(username));
+  const emailName = titleCase(cleanText(ownerEmail).split("@")[0]);
+  if (emailName.split(/\s+/).length > usernameName.split(/\s+/).length) {
+    return emailName;
+  }
+  return usernameName || emailName || "Host";
 }
 
 function hostNameFromBookingPageTitle(title?: string | null): string | null {

--- a/templates/calendar/server/lib/google-calendar.spec.ts
+++ b/templates/calendar/server/lib/google-calendar.spec.ts
@@ -10,6 +10,7 @@ const peopleGetProfileMock = vi.hoisted(() => vi.fn());
 const calendarGetEventMock = vi.hoisted(() => vi.fn());
 const calendarFreeBusyMock = vi.hoisted(() => vi.fn());
 const calendarPatchEventMock = vi.hoisted(() => vi.fn());
+const dbExecuteMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core/server", () => ({
   getOAuthAccounts: getOAuthAccountsMock,
@@ -22,6 +23,10 @@ vi.mock("@agent-native/core/oauth-tokens", () => ({
   deleteOAuthTokens: deleteOAuthTokensMock,
   listOAuthAccountsByOwner: listOAuthAccountsByOwnerMock,
   hasOAuthTokens: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/db", () => ({
+  getDbExec: () => ({ execute: dbExecuteMock }),
 }));
 
 vi.mock("./google-api.js", () => ({
@@ -40,6 +45,7 @@ import {
   exchangeCode,
   getAuthStatus,
   getFreeBusy,
+  getPrimaryAccountPhotoUrl,
   updateEvent,
 } from "./google-calendar";
 
@@ -57,6 +63,7 @@ describe("calendar Google auth status", () => {
         },
       },
     ]);
+    dbExecuteMock.mockResolvedValue({ rows: [] });
   });
 
   it("uses the OAuth userinfo picture for account avatars", async () => {
@@ -118,6 +125,34 @@ describe("calendar Google auth status", () => {
       "secondary@example.com",
       expect.objectContaining({ access_token: "new-token" }),
       "owner@example.com",
+    );
+  });
+
+  it("returns the primary Google account photo for booking OG images", async () => {
+    listOAuthAccountsByOwnerMock.mockResolvedValue([
+      {
+        accountId: "steve@example.com",
+        tokens: {
+          access_token: "access-token",
+          expiry_date: Date.now() + 10 * 60_000,
+          photoUrl: "https://lh3.googleusercontent.com/a/photo",
+        },
+      },
+    ]);
+
+    await expect(getPrimaryAccountPhotoUrl("steve@example.com")).resolves.toBe(
+      "https://lh3.googleusercontent.com/a/photo",
+    );
+  });
+
+  it("falls back to Better Auth user image for booking OG images", async () => {
+    listOAuthAccountsByOwnerMock.mockResolvedValue([]);
+    dbExecuteMock.mockResolvedValue({
+      rows: [{ image: "https://lh3.googleusercontent.com/a/auth-photo" }],
+    });
+
+    await expect(getPrimaryAccountPhotoUrl("steve@example.com")).resolves.toBe(
+      "https://lh3.googleusercontent.com/a/auth-photo",
     );
   });
 });

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -12,6 +12,7 @@ import {
   hasOAuthTokens,
 } from "@agent-native/core/oauth-tokens";
 import { isOAuthConnected, getOAuthAccounts } from "@agent-native/core/server";
+import { getDbExec } from "@agent-native/core/db";
 import {
   createOAuth2Client,
   oauth2GetUserInfo,
@@ -398,6 +399,21 @@ async function resolveAccountPhotoUrl(
   }
 }
 
+async function getBetterAuthUserImage(
+  email: string | undefined,
+): Promise<string | undefined> {
+  if (!email) return undefined;
+  try {
+    const { rows } = await getDbExec().execute({
+      sql: 'SELECT image FROM "user" WHERE email = ? LIMIT 1',
+      args: [email],
+    });
+    return optionalString(rows[0]?.image);
+  } catch {
+    return undefined;
+  }
+}
+
 export async function getClient(
   email: string | undefined,
 ): Promise<{ accessToken: string } | null> {
@@ -493,9 +509,10 @@ export async function getPrimaryAccountPhotoUrl(
   forEmail?: string,
 ): Promise<string | undefined> {
   if (!forEmail) return undefined;
+  const fallbackUserImage = await getBetterAuthUserImage(forEmail);
   const accounts = await listOAuthAccountsByOwner("google", forEmail);
   const account = accounts.find((a) => a.accountId === forEmail) ?? accounts[0];
-  if (!account) return undefined;
+  if (!account) return fallbackUserImage;
 
   const tokens = account.tokens as unknown as GoogleTokens;
   const cachedPhotoUrl = optionalString(tokens.photoUrl);
@@ -507,9 +524,9 @@ export async function getPrimaryAccountPhotoUrl(
       tokens,
       forEmail,
     );
-    return resolveAccountPhotoUrl(accessToken);
+    return (await resolveAccountPhotoUrl(accessToken)) ?? fallbackUserImage;
   } catch {
-    return undefined;
+    return fallbackUserImage;
   }
 }
 

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -489,6 +489,30 @@ export async function getConnectedAccounts(
   return accounts.map((a) => a.accountId);
 }
 
+export async function getPrimaryAccountPhotoUrl(
+  forEmail?: string,
+): Promise<string | undefined> {
+  if (!forEmail) return undefined;
+  const accounts = await listOAuthAccountsByOwner("google", forEmail);
+  const account = accounts.find((a) => a.accountId === forEmail) ?? accounts[0];
+  if (!account) return undefined;
+
+  const tokens = account.tokens as unknown as GoogleTokens;
+  const cachedPhotoUrl = optionalString(tokens.photoUrl);
+  if (cachedPhotoUrl) return cachedPhotoUrl;
+
+  try {
+    const accessToken = await getValidAccessToken(
+      account.accountId,
+      tokens,
+      forEmail,
+    );
+    return resolveAccountPhotoUrl(accessToken);
+  } catch {
+    return undefined;
+  }
+}
+
 export async function getAuthStatus(
   forEmail?: string,
 ): Promise<GoogleAuthStatus> {

--- a/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
+++ b/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
@@ -1,0 +1,79 @@
+import {
+  defineEventHandler,
+  getQuery,
+  getRouterParam,
+  setResponseHeader,
+  setResponseStatus,
+  type H3Event,
+} from "h3";
+import { eq } from "drizzle-orm";
+import { getUserSetting } from "@agent-native/core/settings";
+import { getDb, schema } from "../../../../../db/index.js";
+import { getBookingUsername } from "../../../../../handlers/booking-usernames.js";
+import {
+  renderBookingOgImagePng,
+  type BookingOgImageInput,
+} from "../../../../../lib/booking-og-image.js";
+import type { Settings } from "../../../../../../shared/api.js";
+
+function parseDurations(value: string | null): number[] | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return undefined;
+    return parsed
+      .map((item) => Number(item))
+      .filter((item) => Number.isFinite(item) && item > 0);
+  } catch {
+    return undefined;
+  }
+}
+
+export default defineEventHandler(async (event: H3Event) => {
+  const slug = getRouterParam(event, "slug");
+  if (!slug) {
+    setResponseStatus(event, 400);
+    return { error: "slug is required" };
+  }
+
+  const [bookingLink] = await getDb()
+    .select()
+    .from(schema.bookingLinks)
+    .where(eq(schema.bookingLinks.slug, slug))
+    .limit(1);
+
+  if (!bookingLink?.isActive) {
+    setResponseStatus(event, 404);
+    return { error: "Booking link not found" };
+  }
+
+  const query = getQuery(event);
+  const queryUsername =
+    typeof query.username === "string" ? query.username : undefined;
+  const [ownerSettings, reservedUsername] = await Promise.all([
+    getUserSetting(
+      bookingLink.ownerEmail,
+      "calendar-settings",
+    ) as Promise<Settings | null>,
+    getBookingUsername(bookingLink.ownerEmail),
+  ]);
+  const imageInput: BookingOgImageInput = {
+    title: bookingLink.title,
+    description: bookingLink.description,
+    duration: bookingLink.duration,
+    durations: parseDurations(bookingLink.durations),
+    username: queryUsername || reservedUsername,
+    ownerEmail: bookingLink.ownerEmail,
+    bookingPageTitle: ownerSettings?.bookingPageTitle,
+  };
+  const png = renderBookingOgImagePng(imageInput);
+
+  setResponseHeader(event, "Content-Type", "image/png");
+  setResponseHeader(event, "Content-Length", String(png.byteLength));
+  setResponseHeader(
+    event,
+    "Cache-Control",
+    "public, max-age=300, stale-while-revalidate=86400",
+  );
+  return Buffer.from(png);
+});

--- a/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
+++ b/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
@@ -9,6 +9,7 @@ import { eq } from "drizzle-orm";
 import { getUserSetting } from "@agent-native/core/settings";
 import { getDb, schema } from "../../../../../db/index.js";
 import { getBookingUsername } from "../../../../../handlers/booking-usernames.js";
+import { getPrimaryAccountPhotoUrl } from "../../../../../lib/google-calendar.js";
 import {
   renderBookingOgImagePng,
   type BookingOgImageInput,
@@ -23,6 +24,48 @@ function parseDurations(value: string | null): number[] | undefined {
     return parsed
       .map((item) => Number(item))
       .filter((item) => Number.isFinite(item) && item > 0);
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeGoogleProfilePhotoUrl(value: string | undefined): string {
+  if (!value) return "";
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:") return "";
+    if (!/(^|\.)googleusercontent\.com$/i.test(url.hostname)) return "";
+    return url.toString().replace(/=s\d+(-c)?$/i, "=s256-c");
+  } catch {
+    return "";
+  }
+}
+
+async function fetchProfileImageDataUrl(
+  photoUrl: string | undefined,
+): Promise<string | undefined> {
+  const url = normalizeGoogleProfilePhotoUrl(photoUrl);
+  if (!url) return undefined;
+
+  try {
+    const response = await fetch(url, {
+      headers: { "User-Agent": "Agent-Native Calendar OG Image" },
+    });
+    if (!response.ok) return undefined;
+
+    const contentType =
+      response.headers.get("content-type")?.split(";")[0]?.trim() ||
+      "image/jpeg";
+    if (!contentType.startsWith("image/")) return undefined;
+
+    const contentLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(contentLength) && contentLength > 2_000_000) {
+      return undefined;
+    }
+
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > 2_000_000) return undefined;
+    return `data:${contentType};base64,${Buffer.from(bytes).toString("base64")}`;
   } catch {
     return undefined;
   }
@@ -50,12 +93,14 @@ export default defineEventHandler(async (event: H3Event) => {
   const query = getQuery(event);
   const queryUsername =
     typeof query.username === "string" ? query.username : undefined;
-  const [ownerSettings, reservedUsername] = await Promise.all([
+  const [ownerSettings, reservedUsername, profilePhotoUrl] = await Promise.all([
     getUserSetting(bookingLink.ownerEmail, "calendar-settings").then(
       (settings) => settings as unknown as Settings | null,
     ),
     getBookingUsername(bookingLink.ownerEmail),
+    getPrimaryAccountPhotoUrl(bookingLink.ownerEmail),
   ]);
+  const profileImageDataUrl = await fetchProfileImageDataUrl(profilePhotoUrl);
   const imageInput: BookingOgImageInput = {
     title: bookingLink.title,
     description: bookingLink.description,
@@ -64,6 +109,7 @@ export default defineEventHandler(async (event: H3Event) => {
     username: queryUsername || reservedUsername,
     ownerEmail: bookingLink.ownerEmail,
     bookingPageTitle: ownerSettings?.bookingPageTitle,
+    profileImageDataUrl,
   };
   const png = renderBookingOgImagePng(imageInput);
   const body = png.buffer.slice(

--- a/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
+++ b/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
@@ -51,10 +51,9 @@ export default defineEventHandler(async (event: H3Event) => {
   const queryUsername =
     typeof query.username === "string" ? query.username : undefined;
   const [ownerSettings, reservedUsername] = await Promise.all([
-    getUserSetting(
-      bookingLink.ownerEmail,
-      "calendar-settings",
-    ) as Promise<Settings | null>,
+    getUserSetting(bookingLink.ownerEmail, "calendar-settings").then(
+      (settings) => settings as unknown as Settings | null,
+    ),
     getBookingUsername(bookingLink.ownerEmail),
   ]);
   const imageInput: BookingOgImageInput = {
@@ -67,8 +66,12 @@ export default defineEventHandler(async (event: H3Event) => {
     bookingPageTitle: ownerSettings?.bookingPageTitle,
   };
   const png = renderBookingOgImagePng(imageInput);
+  const body = png.buffer.slice(
+    png.byteOffset,
+    png.byteOffset + png.byteLength,
+  ) as ArrayBuffer;
 
-  return new Response(png, {
+  return new Response(body, {
     headers: {
       "Content-Type": "image/png",
       "Content-Length": String(png.byteLength),

--- a/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
+++ b/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
@@ -2,7 +2,6 @@ import {
   defineEventHandler,
   getQuery,
   getRouterParam,
-  setResponseHeader,
   setResponseStatus,
   type H3Event,
 } from "h3";
@@ -36,6 +35,7 @@ export default defineEventHandler(async (event: H3Event) => {
     return { error: "slug is required" };
   }
 
+  // guard:allow-unscoped — public booking OG image, gated by active booking slug
   const [bookingLink] = await getDb()
     .select()
     .from(schema.bookingLinks)
@@ -68,12 +68,11 @@ export default defineEventHandler(async (event: H3Event) => {
   };
   const png = renderBookingOgImagePng(imageInput);
 
-  setResponseHeader(event, "Content-Type", "image/png");
-  setResponseHeader(event, "Content-Length", String(png.byteLength));
-  setResponseHeader(
-    event,
-    "Cache-Control",
-    "public, max-age=300, stale-while-revalidate=86400",
-  );
-  return Buffer.from(png);
+  return new Response(png, {
+    headers: {
+      "Content-Type": "image/png",
+      "Content-Length": String(png.byteLength),
+      "Cache-Control": "public, max-age=300, stale-while-revalidate=86400",
+    },
+  });
 });

--- a/templates/mail/actions/send-email.ts
+++ b/templates/mail/actions/send-email.ts
@@ -2,16 +2,18 @@ import { defineAction } from "@agent-native/core";
 import { getAccessTokens } from "./helpers.js";
 import { z } from "zod";
 import { nanoid } from "nanoid";
+import { gmailGetMessage, gmailSendMessage } from "../server/lib/google-api.js";
 import {
-  gmailGetMessage,
-  gmailSendMessage,
-  googleFetch,
-} from "../server/lib/google-api.js";
-import { invalidateListCacheForOwner } from "../server/lib/google-auth.js";
+  getAccountDisplayName,
+  invalidateListCacheForOwner,
+  setAccountDisplayName,
+} from "../server/lib/google-auth.js";
+import { setOAuthDisplayName } from "@agent-native/core/oauth-tokens";
 import {
   encodeAddressHeader,
   encodeMimeHeaderValue,
 } from "../server/lib/outgoing-email.js";
+import { resolveGoogleSenderIdentity } from "../server/lib/sender-identity.js";
 import { getRequestUserEmail } from "@agent-native/core/server";
 import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
 import { emit } from "@agent-native/core/event-bus";
@@ -375,48 +377,21 @@ export default defineAction({
       }
     }
 
-    // Fetch sender display name from Gmail send-as settings,
-    // falling back to Google profile name, then settings.name
-    let fromHeader = settings.name
-      ? `${settings.name} <${selectedEmail}>`
-      : selectedEmail;
-    try {
-      const sendAs = await googleFetch(
-        `https://gmail.googleapis.com/gmail/v1/users/me/settings/sendAs`,
-        selectedToken,
-      );
-      const match = sendAs?.sendAs?.find(
-        (s: any) =>
-          s.sendAsEmail?.toLowerCase() === selectedEmail.toLowerCase(),
-      );
-      if (match?.displayName) {
-        fromHeader = `${match.displayName} <${selectedEmail}>`;
-      }
-    } catch {
-      // Fall back to profile name below
-    }
-    // If still no display name, try Google profile
-    if (
-      fromHeader === selectedEmail ||
-      (!fromHeader.includes("<") && !settings.name)
-    ) {
-      try {
-        const profile = await googleFetch(
-          `https://www.googleapis.com/oauth2/v2/userinfo`,
-          selectedToken,
-        );
-        if (profile?.name) {
-          fromHeader = `${profile.name} <${selectedEmail}>`;
-        }
-      } catch {
-        // Fall back to settings.name or email-only
-      }
-    }
+    const senderIdentity = await resolveGoogleSenderIdentity({
+      accessToken: selectedToken,
+      email: selectedEmail,
+      fallbackName: settings.name,
+      cachedName: getAccountDisplayName(selectedEmail),
+      onResolvedDisplayName: (name) => {
+        setAccountDisplayName(selectedEmail, name);
+        void setOAuthDisplayName("google", selectedEmail, name).catch(() => {});
+      },
+    });
 
     const tracking = buildTrackingContext(args.body, settings.tracking);
 
     const raw = buildRawEmail({
-      from: fromHeader,
+      from: senderIdentity.header,
       to: args.to,
       cc: args.cc,
       bcc: args.bcc,

--- a/templates/mail/app/components/email/ComposeModal.tsx
+++ b/templates/mail/app/components/email/ComposeModal.tsx
@@ -42,7 +42,6 @@ import { useUpdateQueuedDraft } from "@/hooks/use-draft-queue";
 import { useScheduleEmail } from "@/hooks/use-scheduled-jobs";
 import { SendLaterButton } from "./SendLaterButton";
 import { expandAliasTokens } from "@/lib/alias-utils";
-import { appApiPath } from "@/lib/api-path";
 import { useAgentChatGenerating } from "@agent-native/core";
 import { toast } from "sonner";
 import type { ComposeState } from "@shared/types";
@@ -224,17 +223,9 @@ export function ComposeModal({
 
     // Snapshot draft data for potential undo
     const draftSnapshot = { ...activeDraft };
-    const { savedDraftId } = activeDraft;
 
     // Close composer immediately
     onDiscard(activeId);
-
-    // Clean up any persistent draft
-    if (savedDraftId) {
-      fetch(appApiPath(`/api/emails/draft/${savedDraftId}`), {
-        method: "DELETE",
-      });
-    }
 
     // Show optimistic reply in the thread immediately (for replies)
     const undoOptimistic = draftSnapshot.replyToId
@@ -327,7 +318,6 @@ export function ComposeModal({
     }
 
     const draftSnapshot = { ...activeDraft };
-    const { savedDraftId } = activeDraft;
 
     try {
       await scheduleEmail.mutateAsync({
@@ -345,11 +335,6 @@ export function ComposeModal({
 
       // Job created successfully — now discard the draft
       onDiscard(activeId);
-      if (savedDraftId) {
-        fetch(appApiPath(`/api/emails/draft/${savedDraftId}`), {
-          method: "DELETE",
-        });
-      }
 
       const scheduledDate = new Date(runAt).toLocaleString("en-US", {
         weekday: "short",

--- a/templates/mail/app/components/email/ComposeModal.tsx
+++ b/templates/mail/app/components/email/ComposeModal.tsx
@@ -67,7 +67,7 @@ function FromAccountSelector({
   value,
   onChange,
 }: {
-  accounts: Array<{ email: string }>;
+  accounts: Array<{ email: string; displayName?: string }>;
   value: string | undefined;
   onChange: (email: string) => void;
 }) {
@@ -106,7 +106,9 @@ function FromAccountSelector({
         <SelectContent>
           {accounts.map((acct) => (
             <SelectItem key={acct.email} value={acct.email}>
-              {acct.email}
+              {acct.displayName
+                ? `${acct.displayName} <${acct.email}>`
+                : acct.email}
             </SelectItem>
           ))}
         </SelectContent>

--- a/templates/mail/app/components/email/EmailThread.tsx
+++ b/templates/mail/app/components/email/EmailThread.tsx
@@ -2538,6 +2538,7 @@ function HtmlEmailBody({
   searchTerm?: string;
   activeLocalIdx?: number | null;
 }) {
+  const frameHostRef = useRef<HTMLDivElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [height, setHeight] = useState(200);
   const { resolvedTheme } = useTheme();
@@ -3133,6 +3134,12 @@ function HtmlEmailBody({
     doc.addEventListener("click", handleLinkClick);
 
     // Forward keyboard events from iframe to parent
+    const focusParentAfterShortcut = () => {
+      window.focus();
+      iframeRef.current?.blur();
+      frameHostRef.current?.focus({ preventScroll: true });
+    };
+
     const forwardKey = (e: KeyboardEvent) => {
       const forwarded = new KeyboardEvent(e.type, {
         key: e.key,
@@ -3146,7 +3153,13 @@ function HtmlEmailBody({
         bubbles: true,
         cancelable: true,
       });
-      window.dispatchEvent(forwarded);
+      const handled = !window.dispatchEvent(forwarded);
+      if (handled || forwarded.defaultPrevented) {
+        e.preventDefault();
+        e.stopPropagation();
+        focusParentAfterShortcut();
+        requestAnimationFrame(focusParentAfterShortcut);
+      }
     };
     doc.addEventListener("keydown", forwardKey);
 
@@ -3265,7 +3278,7 @@ function HtmlEmailBody({
     (isEmbedded || !showImagesForThread);
 
   return (
-    <div>
+    <div ref={frameHostRef} tabIndex={-1} className="outline-none">
       {showBanner && (
         <div className="flex items-center gap-2 px-3 py-1.5 mb-2 rounded-md bg-accent/60 text-[12px] text-muted-foreground">
           <IconPhoto className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />

--- a/templates/mail/app/components/email/InlineReplyComposer.tsx
+++ b/templates/mail/app/components/email/InlineReplyComposer.tsx
@@ -36,7 +36,6 @@ import {
 } from "@/hooks/use-emails";
 import { useAliases } from "@/hooks/use-aliases";
 import { expandAliasTokens } from "@/lib/alias-utils";
-import { appApiPath } from "@/lib/api-path";
 import { useAgentChatGenerating } from "@agent-native/core";
 import { toast } from "sonner";
 import type { ComposeState, EmailMessage } from "@shared/types";
@@ -176,15 +175,8 @@ export const InlineReplyComposer = forwardRef<
     sendingRef.current = true;
 
     const draftSnapshot = { ...draft };
-    const { savedDraftId } = draft;
 
     onDiscard(draft.id);
-
-    if (savedDraftId) {
-      fetch(appApiPath(`/api/emails/draft/${savedDraftId}`), {
-        method: "DELETE",
-      });
-    }
 
     // Show optimistic reply in the thread immediately
     const undoOptimistic = addOptimisticReply({

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -2100,7 +2100,7 @@ function AccountPopover({
   onToggleAccount,
   onRemoveAccount,
 }: {
-  accounts: Array<{ email: string; photoUrl?: string }>;
+  accounts: Array<{ email: string; displayName?: string; photoUrl?: string }>;
   activeAccounts: Set<string>;
   onToggleAccount: (email: string) => void;
   onRemoveAccount: (email: string) => void;
@@ -2173,8 +2173,16 @@ function AccountPopover({
                 imageClassName="h-6 w-6 rounded-full object-cover shrink-0"
                 fallbackClassName="h-6 w-6 rounded-full bg-primary/20 flex items-center justify-center text-[10px] font-semibold text-primary shrink-0"
               />
-              <span className="text-[13px] text-foreground/80 truncate flex-1">
-                {account.email}
+              <span className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate text-[13px] text-foreground/80">
+                  {account.displayName || account.email}
+                </span>
+                {account.displayName &&
+                  account.displayName !== account.email && (
+                    <span className="truncate text-[11px] text-muted-foreground/60">
+                      {account.email}
+                    </span>
+                  )}
               </span>
               <button
                 onClick={() => {

--- a/templates/mail/app/hooks/use-account-filter.ts
+++ b/templates/mail/app/hooks/use-account-filter.ts
@@ -3,7 +3,11 @@ import { createContext, useContext } from "react";
 export type AccountFilterContextType = {
   /** Set of active account emails. Empty = show all (no filtering). */
   activeAccounts: Set<string>;
-  allAccounts: Array<{ email: string; photoUrl?: string }>;
+  allAccounts: Array<{
+    email: string;
+    displayName?: string;
+    photoUrl?: string;
+  }>;
 };
 
 export const AccountFilterContext = createContext<AccountFilterContextType>({

--- a/templates/mail/app/hooks/use-compose-state.spec.ts
+++ b/templates/mail/app/hooks/use-compose-state.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { ComposeState } from "@shared/types";
-import { newestUnseenPopoutDraftId } from "./use-compose-state";
+import {
+  filterRemovedDrafts,
+  newestUnseenPopoutDraftId,
+} from "./use-compose-state";
 
 function draft(id: string, inline = false): ComposeState {
   return {
@@ -30,5 +33,15 @@ describe("newestUnseenPopoutDraftId", () => {
         draft("inline-reply", true),
       ]),
     ).toBeNull();
+  });
+});
+
+describe("filterRemovedDrafts", () => {
+  it("keeps a just-discarded draft from reappearing in stale server results", () => {
+    expect(
+      filterRemovedDrafts([draft("kept"), draft("sent-reply", true)], {
+        "sent-reply": Date.now(),
+      }).map((item) => item.id),
+    ).toEqual(["kept"]);
   });
 });

--- a/templates/mail/app/hooks/use-compose-state.ts
+++ b/templates/mail/app/hooks/use-compose-state.ts
@@ -8,6 +8,7 @@ import { appApiPath } from "@/lib/api-path";
 import { TAB_ID } from "@/lib/tab-id";
 
 export const FOCUS_COMPOSE_DRAFT_EVENT = "mail:focus-compose-draft";
+const REMOVED_DRAFT_TOMBSTONE_TTL = 60_000;
 
 async function apiFetch<T>(url: string, options?: RequestInit): Promise<T> {
   const res = await fetch(
@@ -36,6 +37,23 @@ function hasDraftContent(draft: ComposeState): boolean {
     draft.subject?.trim() ||
     draft.body?.trim()
   );
+}
+
+function pruneRemovedDraftIds(removed: Record<string, number>) {
+  const now = Date.now();
+  for (const [id, removedAt] of Object.entries(removed)) {
+    if (now - removedAt > REMOVED_DRAFT_TOMBSTONE_TTL) {
+      delete removed[id];
+    }
+  }
+}
+
+export function filterRemovedDrafts<T extends { id: string }>(
+  drafts: T[],
+  removed: Record<string, number>,
+): T[] {
+  pruneRemovedDraftIds(removed);
+  return drafts.filter((draft) => removed[draft.id] === undefined);
 }
 
 /** Save a compose draft to persistent storage (emails with isDraft=true).
@@ -71,6 +89,7 @@ export function useComposeState() {
     {},
   );
   const knownDraftIdsRef = useRef<Set<string> | null>(null);
+  const removedDraftIdsRef = useRef<Record<string, number>>({});
 
   // Fetch all drafts — short staleTime so agent-written drafts appear quickly
   const query = useQuery<ComposeState[]>({
@@ -79,9 +98,14 @@ export function useComposeState() {
       const result = await apiFetch<ComposeState[]>(
         "/_agent-native/application-state/compose",
       );
-      const serverDrafts = result ?? [];
-      const localDrafts =
-        qc.getQueryData<ComposeState[]>(["compose-drafts"]) ?? [];
+      const serverDrafts = filterRemovedDrafts(
+        result ?? [],
+        removedDraftIdsRef.current,
+      );
+      const localDrafts = filterRemovedDrafts(
+        qc.getQueryData<ComposeState[]>(["compose-drafts"]) ?? [],
+        removedDraftIdsRef.current,
+      );
       if (!localDrafts.length) return serverDrafts;
 
       const merged = serverDrafts.map((serverDraft) => {
@@ -94,6 +118,7 @@ export function useComposeState() {
       for (const localDraft of localDrafts) {
         if (
           dirtyRef.current[localDraft.id] &&
+          removedDraftIdsRef.current[localDraft.id] === undefined &&
           !merged.some((d) => d.id === localDraft.id)
         ) {
           merged.push(localDraft);
@@ -174,6 +199,7 @@ export function useComposeState() {
           : state.body,
         id,
       };
+      delete removedDraftIdsRef.current[id];
 
       // Optimistically add to cache
       qc.setQueryData<ComposeState[]>(["compose-drafts"], (old) => [
@@ -260,6 +286,8 @@ export function useComposeState() {
   /** Close a single draft tab — auto-saves to Drafts if it has content. */
   const close = useCallback(
     (id: string) => {
+      removedDraftIdsRef.current[id] = Date.now();
+      void qc.cancelQueries({ queryKey: ["compose-drafts"] });
       // Clear debounce timers
       if (debounceRef.current[id]) clearTimeout(debounceRef.current[id]);
       if (gmailSaveRef.current[id]) clearTimeout(gmailSaveRef.current[id]);
@@ -300,6 +328,8 @@ export function useComposeState() {
    *  If a Gmail draft was already created by auto-save, delete it. */
   const discard = useCallback(
     (id: string) => {
+      removedDraftIdsRef.current[id] = Date.now();
+      void qc.cancelQueries({ queryKey: ["compose-drafts"] });
       if (debounceRef.current[id]) clearTimeout(debounceRef.current[id]);
       if (gmailSaveRef.current[id]) clearTimeout(gmailSaveRef.current[id]);
       delete dirtyRef.current[id];
@@ -337,6 +367,11 @@ export function useComposeState() {
   const closeAll = useCallback(() => {
     const currentDrafts =
       qc.getQueryData<ComposeState[]>(["compose-drafts"]) ?? [];
+    const removedAt = Date.now();
+    for (const draft of currentDrafts) {
+      removedDraftIdsRef.current[draft.id] = removedAt;
+    }
+    void qc.cancelQueries({ queryKey: ["compose-drafts"] });
 
     // Save all drafts with content
     for (const draft of currentDrafts) {

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -22,6 +22,7 @@ import {
   getCachedThread,
   setCachedThread,
 } from "@/lib/thread-cache";
+import { useAccountFilter } from "@/hooks/use-account-filter";
 
 const EMAIL_PAGE_SIZE = 25;
 
@@ -86,6 +87,26 @@ function parseRecipients(value?: string): EmailMessage["to"] {
 
 function makeTempId(prefix: string) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function resolveOptimisticSender(
+  settings: UserSettings | undefined,
+  accounts: Array<{ email: string; displayName?: string }>,
+  accountEmail?: string,
+): EmailMessage["from"] {
+  const email =
+    accountEmail ||
+    settings?.email ||
+    (accounts.length === 1 ? accounts[0]?.email : undefined) ||
+    "";
+  const account = accounts.find(
+    (item) => item.email.toLowerCase() === email.toLowerCase(),
+  );
+  const name =
+    account?.displayName ||
+    settings?.name ||
+    (email ? email : settings?.email || "Me");
+  return { name, email };
 }
 
 const RECENT_SENT_DURATION = 2 * 60_000;
@@ -195,6 +216,7 @@ function delayedInvalidate(
 
 export function useAddOptimisticReply() {
   const qc = useQueryClient();
+  const { allAccounts } = useAccountFilter();
 
   return (data: {
     to: string;
@@ -214,10 +236,7 @@ export function useAddOptimisticReply() {
     const optimisticMessage: EmailMessage = {
       id: makeTempId("sent"),
       threadId,
-      from: {
-        name: settings?.name || settings?.email || data.accountEmail || "Me",
-        email: data.accountEmail || settings?.email || "",
-      },
+      from: resolveOptimisticSender(settings, allAccounts, data.accountEmail),
       to: parseRecipients(data.to),
       ...(data.cc ? { cc: parseRecipients(data.cc) } : {}),
       subject: data.subject || "(no subject)",
@@ -898,6 +917,7 @@ export function useDeleteDraft() {
 
 export function useSendEmail() {
   const qc = useQueryClient();
+  const { allAccounts } = useAccountFilter();
   return useMutation({
     mutationFn: (data: {
       to: string;
@@ -910,13 +930,15 @@ export function useSendEmail() {
       accountEmail?: string;
       attachments?: ComposeAttachment[];
     }) =>
-      apiFetch<{ id: string; threadId?: string; labelIds?: string[] }>(
-        "/api/emails/send",
-        {
-          method: "POST",
-          body: JSON.stringify(data),
-        },
-      ),
+      apiFetch<{
+        id: string;
+        threadId?: string;
+        labelIds?: string[];
+        from?: EmailMessage["from"];
+      }>("/api/emails/send", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
     onMutate: async (data) => {
       const settings = qc.getQueryData<UserSettings>(["settings"]);
       const cachedEmails = qc
@@ -948,10 +970,7 @@ export function useSendEmail() {
       const optimisticMessage: EmailMessage = existingOptimistic ?? {
         id: makeTempId("sent"),
         threadId,
-        from: {
-          name: settings?.name || settings?.email || data.accountEmail || "Me",
-          email: data.accountEmail || settings?.email || "",
-        },
+        from: resolveOptimisticSender(settings, allAccounts, data.accountEmail),
         to: parseRecipients(data.to),
         ...(data.cc ? { cc: parseRecipients(data.cc) } : {}),
         ...(data.bcc ? { bcc: parseRecipients(data.bcc) } : {}),
@@ -1030,6 +1049,7 @@ export function useSendEmail() {
         ...context.optimisticMessage,
         id: result.id || context.optimisticMessage.id,
         threadId,
+        ...(result.from ? { from: result.from } : {}),
         labelIds: result.labelIds?.map((id) => id.toLowerCase()) || ["sent"],
       };
       replaceRecentSentEmail(context.optimisticMessage.id, replacement);

--- a/templates/mail/app/hooks/use-google-auth.ts
+++ b/templates/mail/app/hooks/use-google-auth.ts
@@ -4,7 +4,12 @@ import { agentNativePath, oauthRedirectUri } from "@agent-native/core/client";
 
 interface GoogleAuthStatus {
   connected: boolean;
-  accounts: Array<{ email: string; expiresAt?: string; photoUrl?: string }>;
+  accounts: Array<{
+    email: string;
+    displayName?: string;
+    expiresAt?: string;
+    photoUrl?: string;
+  }>;
 }
 
 /**

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -74,6 +74,7 @@ import {
   encodeMimeHeaderValue,
   resolveComposeAttachments,
 } from "../lib/outgoing-email.js";
+import { resolveGoogleSenderIdentity } from "../lib/sender-identity.js";
 import { normalizeSignature } from "../../shared/signature.js";
 import { emailMessageMatchesSearch } from "@shared/search.js";
 import { getAppProductionUrl } from "@agent-native/core/server";
@@ -1448,43 +1449,23 @@ export const sendEmail = defineEventHandler(async (event: H3Event) => {
       }
 
       if (selectedToken) {
-        // Fetch the sender's display name from Gmail send-as settings,
-        // falling back to Google profile name
-        let fromHeader = selectedEmail;
-        try {
-          const sendAs = await googleFetch(
-            `https://gmail.googleapis.com/gmail/v1/users/me/settings/sendAs`,
-            selectedToken,
-          );
-          const match = sendAs?.sendAs?.find(
-            (s: any) =>
-              s.sendAsEmail?.toLowerCase() === selectedEmail.toLowerCase(),
-          );
-          if (match?.displayName) {
-            fromHeader = `${match.displayName} <${selectedEmail}>`;
-          }
-        } catch {
-          // Fall back to profile name below
-        }
-        // If sendAs didn't have a display name, try Google profile
-        if (fromHeader === selectedEmail) {
-          try {
-            const profile = await googleFetch(
-              `https://www.googleapis.com/oauth2/v2/userinfo`,
-              selectedToken,
+        const senderIdentity = await resolveGoogleSenderIdentity({
+          accessToken: selectedToken,
+          email: selectedEmail,
+          fallbackName: settings.name,
+          cachedName: getAccountDisplayName(selectedEmail),
+          onResolvedDisplayName: (name) => {
+            setAccountDisplayName(selectedEmail, name);
+            void setOAuthDisplayName("google", selectedEmail, name).catch(
+              () => {},
             );
-            if (profile?.name) {
-              fromHeader = `${profile.name} <${selectedEmail}>`;
-            }
-          } catch {
-            // Fall back to email-only
-          }
-        }
+          },
+        });
 
         const tracking = buildTrackingContext(event, body || "", settings);
 
         const raw = buildOutgoingRawEmail({
-          from: fromHeader,
+          from: senderIdentity.header,
           to: cleanedTo,
           cc: cleanedCc,
           bcc: cleanedBcc,
@@ -1563,6 +1544,10 @@ export const sendEmail = defineEventHandler(async (event: H3Event) => {
           id: sent.id,
           threadId: sent.threadId,
           labelIds: sent.labelIds || ["SENT"],
+          from: {
+            name: senderIdentity.displayName || senderIdentity.email,
+            email: senderIdentity.email,
+          },
         };
       }
     } catch (error: any) {

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -440,8 +440,10 @@ export async function getAuthStatus(
     if (!tokens) continue;
     const email = account.accountId;
     let photoUrl: string | undefined;
+    const accountDisplayName = (account as { displayName?: string | null })
+      .displayName;
     let displayName =
-      account.displayName ?? getAccountDisplayName(account.accountId);
+      accountDisplayName ?? getAccountDisplayName(account.accountId);
     try {
       const accessToken = await getValidAccessToken(email, tokens);
       const identity = await resolveGoogleSenderIdentity({

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -20,10 +20,12 @@ import {
   listOAuthAccounts,
   listOAuthAccountsByOwner,
   hasOAuthTokens,
+  setOAuthDisplayName,
 } from "@agent-native/core/oauth-tokens";
 import { isOAuthConnected, getOAuthAccounts } from "@agent-native/core/server";
 import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
 import { decodeCommonHtmlEntities } from "@shared/markdown.js";
+import { resolveGoogleSenderIdentity } from "./sender-identity.js";
 
 const SCOPES = [
   "https://www.googleapis.com/auth/gmail.readonly",
@@ -406,7 +408,12 @@ export async function getConnectedAccounts(
 
 export interface GoogleAuthStatus {
   connected: boolean;
-  accounts: Array<{ email: string; expiresAt?: string; photoUrl?: string }>;
+  accounts: Array<{
+    email: string;
+    displayName?: string;
+    expiresAt?: string;
+    photoUrl?: string;
+  }>;
 }
 
 /**
@@ -424,6 +431,7 @@ export async function getAuthStatus(
 
   const accounts: Array<{
     email: string;
+    displayName?: string;
     expiresAt?: string;
     photoUrl?: string;
   }> = [];
@@ -432,13 +440,27 @@ export async function getAuthStatus(
     if (!tokens) continue;
     const email = account.accountId;
     let photoUrl: string | undefined;
+    let displayName =
+      account.displayName ?? getAccountDisplayName(account.accountId);
     try {
       const accessToken = await getValidAccessToken(email, tokens);
+      const identity = await resolveGoogleSenderIdentity({
+        accessToken,
+        email,
+        cachedName: displayName,
+        onResolvedDisplayName: (name) => {
+          displayName = name;
+          setAccountDisplayName(email, name);
+          void setOAuthDisplayName("google", email, name).catch(() => {});
+        },
+      });
+      displayName = identity.displayName;
       const profile = await peopleGetProfile(accessToken, "photos");
       photoUrl = profile.photos?.[0]?.url ?? undefined;
     } catch {}
     accounts.push({
       email,
+      ...(displayName ? { displayName } : {}),
       expiresAt: tokens.expiry_date
         ? new Date(tokens.expiry_date).toISOString()
         : undefined,

--- a/templates/mail/server/lib/jobs.ts
+++ b/templates/mail/server/lib/jobs.ts
@@ -4,13 +4,19 @@ import {
   saveOAuthTokens,
   listOAuthAccounts,
   listOAuthAccountsByOwner,
+  setOAuthDisplayName,
 } from "@agent-native/core/oauth-tokens";
 import { and, eq, inArray, lte } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type { ComposeAttachment, EmailMessage } from "@shared/types.js";
 import { markdownPreviewSnippet } from "@shared/markdown.js";
 import { db, schema } from "../db/index.js";
-import { isConnected, gmailToEmailMessage } from "./google-auth.js";
+import {
+  getAccountDisplayName,
+  isConnected,
+  gmailToEmailMessage,
+  setAccountDisplayName,
+} from "./google-auth.js";
 import {
   createOAuth2Client,
   gmailGetMessage,
@@ -25,6 +31,7 @@ import {
   buildRawEmail as buildOutgoingRawEmail,
   resolveComposeAttachments,
 } from "./outgoing-email.js";
+import { resolveGoogleSenderIdentity } from "./sender-identity.js";
 
 interface StoredTokens {
   access_token: string;
@@ -570,24 +577,19 @@ export async function sendScheduledEmail(
         } catch {}
       }
 
-      // Resolve sender display name
-      let senderFrom = from || account.email || "me";
-      if (!senderFrom.includes("<")) {
-        try {
-          const profile = await googleFetch(
-            `https://www.googleapis.com/oauth2/v2/userinfo`,
-            account.accessToken,
-          );
-          if (profile?.name) {
-            senderFrom = `${profile.name} <${senderFrom}>`;
-          }
-        } catch {
-          // Fall back to email-only
-        }
-      }
+      const senderEmail = account.email || from || "me";
+      const senderIdentity = await resolveGoogleSenderIdentity({
+        accessToken: account.accessToken,
+        email: senderEmail,
+        cachedName: getAccountDisplayName(senderEmail),
+        onResolvedDisplayName: (name) => {
+          setAccountDisplayName(senderEmail, name);
+          void setOAuthDisplayName("google", senderEmail, name).catch(() => {});
+        },
+      });
 
       const raw = buildOutgoingRawEmail({
-        from: senderFrom,
+        from: senderIdentity.header,
         to,
         cc,
         bcc,

--- a/templates/mail/server/lib/sender-identity.spec.ts
+++ b/templates/mail/server/lib/sender-identity.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  formatSenderHeader,
+  resolveGoogleSenderIdentity,
+  usableDisplayName,
+} from "./sender-identity";
+
+describe("sender identity", () => {
+  it("ignores email-as-display-name values", () => {
+    expect(usableDisplayName("steve@builder.io", "steve@builder.io")).toBe(
+      undefined,
+    );
+    expect(formatSenderHeader("steve@builder.io", "steve@builder.io")).toBe(
+      "steve@builder.io",
+    );
+  });
+
+  it("falls back from unusable Gmail send-as name to Google profile name", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sendAs: [
+          {
+            sendAsEmail: "steve@builder.io",
+            displayName: "steve@builder.io",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ name: "Steve Sewell" });
+    const onResolvedDisplayName = vi.fn();
+
+    await expect(
+      resolveGoogleSenderIdentity({
+        accessToken: "token",
+        email: "steve@builder.io",
+        fetcher,
+        onResolvedDisplayName,
+      }),
+    ).resolves.toEqual({
+      email: "steve@builder.io",
+      displayName: "Steve Sewell",
+      header: "Steve Sewell <steve@builder.io>",
+    });
+    expect(onResolvedDisplayName).toHaveBeenCalledWith("Steve Sewell");
+  });
+
+  it("uses a cached display name before falling back to profile", async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce({ sendAs: [] });
+
+    await expect(
+      resolveGoogleSenderIdentity({
+        accessToken: "token",
+        email: "steve@builder.io",
+        cachedName: "Steve Sewell",
+        fetcher,
+      }),
+    ).resolves.toMatchObject({
+      displayName: "Steve Sewell",
+      header: "Steve Sewell <steve@builder.io>",
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+});

--- a/templates/mail/server/lib/sender-identity.ts
+++ b/templates/mail/server/lib/sender-identity.ts
@@ -1,0 +1,85 @@
+import { googleFetch } from "./google-api.js";
+
+const GMAIL_SEND_AS_URL =
+  "https://gmail.googleapis.com/gmail/v1/users/me/settings/sendAs";
+const GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+
+type GoogleFetch = typeof googleFetch;
+
+export type SenderIdentity = {
+  email: string;
+  displayName?: string;
+  header: string;
+};
+
+export function usableDisplayName(
+  name: unknown,
+  email: string,
+): string | undefined {
+  const value = typeof name === "string" ? name.trim() : "";
+  if (!value) return undefined;
+  if (value.toLowerCase() === email.trim().toLowerCase()) return undefined;
+  return value;
+}
+
+export function formatSenderHeader(
+  email: string,
+  displayName?: string,
+): string {
+  const cleanEmail = email.trim();
+  const cleanName = usableDisplayName(displayName, cleanEmail);
+  return cleanName ? `${cleanName} <${cleanEmail}>` : cleanEmail;
+}
+
+export async function resolveGoogleSenderIdentity({
+  accessToken,
+  email,
+  fallbackName,
+  cachedName,
+  fetcher = googleFetch,
+  onResolvedDisplayName,
+}: {
+  accessToken: string;
+  email: string;
+  fallbackName?: string;
+  cachedName?: string | null;
+  fetcher?: GoogleFetch;
+  onResolvedDisplayName?: (displayName: string) => void | Promise<void>;
+}): Promise<SenderIdentity> {
+  const cleanEmail = email.trim();
+  let displayName: string | undefined;
+
+  try {
+    const sendAs = await fetcher(GMAIL_SEND_AS_URL, accessToken);
+    const match = sendAs?.sendAs?.find(
+      (entry: any) =>
+        entry.sendAsEmail?.toLowerCase() === cleanEmail.toLowerCase(),
+    );
+    displayName = usableDisplayName(match?.displayName, cleanEmail);
+  } catch {
+    // Fall back to cached/profile/settings names below.
+  }
+
+  displayName ??= usableDisplayName(cachedName, cleanEmail);
+
+  if (!displayName) {
+    try {
+      const profile = await fetcher(GOOGLE_USERINFO_URL, accessToken);
+      displayName = usableDisplayName(profile?.name, cleanEmail);
+    } catch {
+      // Fall back to settings or bare email below.
+    }
+  }
+
+  displayName ??= usableDisplayName(fallbackName, cleanEmail);
+
+  if (displayName) {
+    await onResolvedDisplayName?.(displayName);
+  }
+
+  return {
+    email: cleanEmail,
+    displayName,
+    header: formatSenderHeader(cleanEmail, displayName),
+  };
+}

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -223,4 +223,78 @@ describe("DeckContext deck creation persistence", () => {
 
     await waitFor(() => expect(result.current.canUndo).toBe(true));
   });
+
+  it("ignores stale reload responses after the route changes", async () => {
+    window.history.pushState({}, "", "/");
+    const firstDeck: Deck = {
+      id: "first-deck",
+      title: "First Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [],
+    };
+    const secondDeck: Deck = {
+      id: "second-deck",
+      title: "Second Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [],
+    };
+    let firstDeckRequestStarted = false;
+    let resolveFirstDeck: (response: Response) => void = () => {};
+    const fetchMock = vi.fn((url: string | URL | Request) => {
+      const href =
+        typeof url === "string"
+          ? url
+          : url instanceof URL
+            ? url.toString()
+            : url.url;
+
+      if (href.endsWith("/api/decks")) {
+        return Promise.resolve(new Response("[]", { status: 200 }));
+      }
+
+      if (href.endsWith("/api/decks/first-deck")) {
+        firstDeckRequestStarted = true;
+        return new Promise<Response>((resolve) => {
+          resolveFirstDeck = resolve;
+        });
+      }
+
+      if (href.endsWith("/api/decks/second-deck")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(secondDeck), { status: 200 }),
+        );
+      }
+
+      return Promise.resolve(new Response("", { status: 404 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() => useDecks(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    window.history.pushState({}, "", "/deck/first-deck");
+    let firstReload = Promise.resolve();
+    act(() => {
+      firstReload = result.current.reloadDecks();
+    });
+    await waitFor(() => expect(firstDeckRequestStarted).toBe(true));
+
+    window.history.pushState({}, "", "/deck/second-deck");
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+    expect(result.current.getDeck("second-deck")?.title).toBe("Second Deck");
+
+    await act(async () => {
+      resolveFirstDeck(
+        new Response(JSON.stringify(firstDeck), { status: 200 }),
+      );
+      await firstReload;
+    });
+
+    expect(result.current.getDeck("second-deck")?.title).toBe("Second Deck");
+    expect(result.current.getDeck("first-deck")).toBeUndefined();
+  });
 });

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -297,4 +297,44 @@ describe("DeckContext deck creation persistence", () => {
     expect(result.current.getDeck("second-deck")?.title).toBe("Second Deck");
     expect(result.current.getDeck("first-deck")).toBeUndefined();
   });
+
+  it("clears loading when the initial response becomes stale after navigation", async () => {
+    window.history.pushState({}, "", "/deck/first-deck");
+    const firstDeck: Deck = {
+      id: "first-deck",
+      title: "First Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [],
+    };
+    let resolveDecks: (response: Response) => void = () => {};
+    const fetchMock = vi.fn((url: string | URL | Request) => {
+      const href =
+        typeof url === "string"
+          ? url
+          : url instanceof URL
+            ? url.toString()
+            : url.url;
+
+      if (href.endsWith("/api/decks")) {
+        return new Promise<Response>((resolve) => {
+          resolveDecks = resolve;
+        });
+      }
+
+      return Promise.resolve(new Response("", { status: 404 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    window.history.pushState({}, "", "/deck/second-deck");
+    await act(async () => {
+      resolveDecks(new Response(JSON.stringify([firstDeck]), { status: 200 }));
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.getDeck("first-deck")).toBeUndefined();
+  });
 });

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -184,4 +184,43 @@ describe("DeckContext deck creation persistence", () => {
 
     expect(result.current.getDeck("shared-deck")?.slides).toEqual([]);
   });
+
+  it("records the first edit after reloading over a pending undo skip", async () => {
+    window.history.pushState({}, "", "/deck/shared-deck");
+    const { setAccessibleDeck } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck({
+      id: "shared-deck",
+      title: "Shared Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [],
+    });
+
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    act(() => {
+      result.current.addSlide("shared-deck");
+    });
+    await waitFor(() => expect(result.current.canUndo).toBe(true));
+
+    act(() => {
+      result.current.undo();
+    });
+
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    act(() => {
+      result.current.addSlide("shared-deck");
+    });
+
+    await waitFor(() => expect(result.current.canUndo).toBe(true));
+  });
 });

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -2,7 +2,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { DeckProvider, useDecks } from "./DeckContext";
+import { DeckProvider, useDecks, type Deck } from "./DeckContext";
 
 class MockEventSource {
   onmessage: ((event: MessageEvent) => void) | null = null;
@@ -17,6 +17,7 @@ function wrapper({ children }: { children: ReactNode }) {
 
 function setupFetch() {
   let resolveCreate: (response: Response) => void = () => {};
+  let accessibleDeck: Deck | null = null;
   const fetchMock = vi.fn((url: string | URL | Request, init?: RequestInit) => {
     const href =
       typeof url === "string"
@@ -36,6 +37,11 @@ function setupFetch() {
     }
 
     if (href.includes("/api/decks/")) {
+      if (accessibleDeck) {
+        return Promise.resolve(
+          new Response(JSON.stringify(accessibleDeck), { status: 200 }),
+        );
+      }
       return Promise.resolve(new Response("", { status: 404 }));
     }
 
@@ -46,6 +52,9 @@ function setupFetch() {
   return {
     fetchMock,
     resolveCreate: (response: Response) => resolveCreate(response),
+    setAccessibleDeck: (deck: Deck) => {
+      accessibleDeck = deck;
+    },
   };
 }
 
@@ -119,5 +128,28 @@ describe("DeckContext deck creation persistence", () => {
 
     await expect(persisted).resolves.toBe(false);
     expect(deckFetchCalls(fetchMock)).toEqual([]);
+  });
+
+  it("can reload the currently open deck after access changes", async () => {
+    window.history.pushState({}, "", "/deck/shared-deck");
+    const { setAccessibleDeck } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.decks).toEqual([]);
+
+    setAccessibleDeck({
+      id: "shared-deck",
+      title: "Shared Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [],
+    });
+
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    expect(result.current.getDeck("shared-deck")?.title).toBe("Shared Deck");
   });
 });

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -152,4 +152,36 @@ describe("DeckContext deck creation persistence", () => {
 
     expect(result.current.getDeck("shared-deck")?.title).toBe("Shared Deck");
   });
+
+  it("resets undo history to the reloaded deck baseline", async () => {
+    window.history.pushState({}, "", "/deck/shared-deck");
+    const { setAccessibleDeck } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck({
+      id: "shared-deck",
+      title: "Shared Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [],
+    });
+
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    act(() => {
+      result.current.addSlide("shared-deck");
+    });
+
+    await waitFor(() => expect(result.current.canUndo).toBe(true));
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.getDeck("shared-deck")?.slides).toEqual([]);
+  });
 });

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -254,6 +254,11 @@ export function deckIdFromPathname(pathname: string): string | null {
   }
 }
 
+function currentOpenDeckIdFromWindow(): string | null {
+  if (typeof window === "undefined") return null;
+  return deckIdFromPathname(window.location.pathname);
+}
+
 export async function includeOpenDeckIfMissing(
   decks: Deck[],
   openDeckId: string | null,
@@ -268,10 +273,7 @@ export async function includeOpenDeckIfMissing(
 }
 
 async function fetchDecksForCurrentRoute(): Promise<Deck[] | null> {
-  const currentOpenDeckId =
-    typeof window === "undefined"
-      ? null
-      : deckIdFromPathname(window.location.pathname);
+  const currentOpenDeckId = currentOpenDeckIdFromWindow();
   const loaded = await fetchDecksFromAPI();
   if (loaded !== null) {
     return includeOpenDeckIfMissing(loaded, currentOpenDeckId);
@@ -400,6 +402,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   );
   const pendingDuplicateSourceIdsRef = useRef<Set<string>>(new Set());
   const dirtyDeckIdsRef = useRef<Set<string>>(new Set());
+  const deckBaselineRequestIdRef = useRef(0);
 
   const markDeckDirty = useCallback((deckId: string) => {
     lastExternalUpdateRef.current = 0;
@@ -431,15 +434,31 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const reloadDecks = useCallback(async () => {
+    const requestId = ++deckBaselineRequestIdRef.current;
+    const requestedOpenDeckId = currentOpenDeckIdFromWindow();
     const loaded = await fetchDecksForCurrentRoute();
-    if (loaded === null) return;
+    if (
+      requestId !== deckBaselineRequestIdRef.current ||
+      requestedOpenDeckId !== currentOpenDeckIdFromWindow() ||
+      loaded === null
+    ) {
+      return;
+    }
     lastExternalUpdateRef.current = Date.now();
     resetDeckBaseline(loaded);
   }, [resetDeckBaseline]);
 
   // Load decks from API on mount
   useEffect(() => {
+    const requestId = ++deckBaselineRequestIdRef.current;
+    const requestedOpenDeckId = currentOpenDeckIdFromWindow();
     fetchDecksForCurrentRoute().then(async (loaded) => {
+      if (
+        requestId !== deckBaselineRequestIdRef.current ||
+        requestedOpenDeckId !== currentOpenDeckIdFromWindow()
+      ) {
+        return;
+      }
       // Initial fetch failed — start empty so the UI can render. The fallback
       // poll will retry shortly; until then `decks` stays empty without
       // triggering the save effect (lastExternalUpdateRef is bumped).

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -457,6 +457,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         requestId !== deckBaselineRequestIdRef.current ||
         requestedOpenDeckId !== currentOpenDeckIdFromWindow()
       ) {
+        setLoading(false);
         return;
       }
       // Initial fetch failed — start empty so the UI can render. The fallback

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -417,12 +417,24 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     decksRef.current = decks;
   }, [decks]);
 
+  const resetDeckBaseline = useCallback((nextDecks: Deck[]) => {
+    setDecks(nextDecks);
+    setHistory([
+      {
+        timestamp: Date.now(),
+        label: "Initial state",
+        decks: JSON.parse(JSON.stringify(nextDecks)),
+      },
+    ]);
+    setHistoryIndex(0);
+  }, []);
+
   const reloadDecks = useCallback(async () => {
     const loaded = await fetchDecksForCurrentRoute();
     if (loaded === null) return;
     lastExternalUpdateRef.current = Date.now();
-    setDecks(loaded);
-  }, []);
+    resetDeckBaseline(loaded);
+  }, [resetDeckBaseline]);
 
   // Load decks from API on mount
   useEffect(() => {
@@ -432,18 +444,10 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       // triggering the save effect (lastExternalUpdateRef is bumped).
       const initial = loaded ?? [];
       lastExternalUpdateRef.current = Date.now(); // Don't save initial load back
-      setDecks(initial);
-      setHistory([
-        {
-          timestamp: Date.now(),
-          label: "Initial state",
-          decks: JSON.parse(JSON.stringify(initial)),
-        },
-      ]);
-      setHistoryIndex(0);
+      resetDeckBaseline(initial);
       setLoading(false);
     });
-  }, []);
+  }, [resetDeckBaseline]);
 
   // Fallback polling for deck list + open-deck changes. SSE is the primary
   // path; this catches agent/db writes that bypass it without hammering idle

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -418,6 +418,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   }, [decks]);
 
   const resetDeckBaseline = useCallback((nextDecks: Deck[]) => {
+    skipHistoryRef.current = false;
     setDecks(nextDecks);
     setHistory([
       {

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -111,6 +111,7 @@ interface DeckContextType {
     id: string,
     updates: Partial<Omit<Deck, "id" | "createdAt">>,
   ) => void;
+  reloadDecks: () => Promise<void>;
   getDeck: (id: string) => Deck | undefined;
   addSlide: (
     deckId: string,
@@ -266,6 +267,20 @@ export async function includeOpenDeckIfMissing(
   return directDeck ? [...decks, directDeck] : decks;
 }
 
+async function fetchDecksForCurrentRoute(): Promise<Deck[] | null> {
+  const currentOpenDeckId =
+    typeof window === "undefined"
+      ? null
+      : deckIdFromPathname(window.location.pathname);
+  const loaded = await fetchDecksFromAPI();
+  if (loaded !== null) {
+    return includeOpenDeckIfMissing(loaded, currentOpenDeckId);
+  }
+  if (!currentOpenDeckId) return null;
+  const directDeck = await fetchDeckFromAPI(currentOpenDeckId);
+  return directDeck ? [directDeck] : null;
+}
+
 async function deleteDeckFromAPI(id: string): Promise<void> {
   try {
     await fetch(`${appBasePath()}/api/decks/${id}`, { method: "DELETE" });
@@ -402,20 +417,20 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     decksRef.current = decks;
   }, [decks]);
 
+  const reloadDecks = useCallback(async () => {
+    const loaded = await fetchDecksForCurrentRoute();
+    if (loaded === null) return;
+    lastExternalUpdateRef.current = Date.now();
+    setDecks(loaded);
+  }, []);
+
   // Load decks from API on mount
   useEffect(() => {
-    fetchDecksFromAPI().then(async (loaded) => {
+    fetchDecksForCurrentRoute().then(async (loaded) => {
       // Initial fetch failed — start empty so the UI can render. The fallback
       // poll will retry shortly; until then `decks` stays empty without
       // triggering the save effect (lastExternalUpdateRef is bumped).
-      const currentOpenDeckId =
-        typeof window === "undefined"
-          ? null
-          : deckIdFromPathname(window.location.pathname);
-      const initial = await includeOpenDeckIfMissing(
-        loaded ?? [],
-        currentOpenDeckId,
-      );
+      const initial = loaded ?? [];
       lastExternalUpdateRef.current = Date.now(); // Don't save initial load back
       setDecks(initial);
       setHistory([
@@ -1025,6 +1040,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         duplicateDeck,
         deleteDeck,
         updateDeck,
+        reloadDecks,
         getDeck,
         addSlide,
         updateSlide,

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -78,6 +78,7 @@ function MissingDeckAccessPane({
   deckId,
   hasTeamJoinOption,
   orgLoading,
+  orgError,
   refreshing,
   onRetry,
   onBack,
@@ -85,21 +86,27 @@ function MissingDeckAccessPane({
   deckId: string | undefined;
   hasTeamJoinOption: boolean;
   orgLoading: boolean;
+  orgError: boolean;
   refreshing: boolean;
   onRetry: () => void;
   onBack: () => void;
 }) {
-  const Icon = hasTeamJoinOption || orgLoading ? IconBuilding : IconLock;
+  const Icon =
+    hasTeamJoinOption || orgLoading || orgError ? IconBuilding : IconLock;
   const title = orgLoading
     ? "Looking for this deck"
-    : hasTeamJoinOption
-      ? "Join your team to open this deck"
-      : "Deck unavailable";
+    : orgError
+      ? "Couldn't check team access"
+      : hasTeamJoinOption
+        ? "Join your team to open this deck"
+        : "Deck unavailable";
   const description = orgLoading
     ? "Checking whether this presentation is shared with your account."
-    : hasTeamJoinOption
-      ? "This link points to a team presentation. Join the team shown above and the deck will open here automatically."
-      : "This deck may have been removed, or your account does not have access to it.";
+    : orgError
+      ? "We couldn't verify whether this presentation is shared with your account. Try again to reload team access and the deck."
+      : hasTeamJoinOption
+        ? "This link points to a team presentation. Join the team shown above and the deck will open here automatically."
+        : "This deck may have been removed, or your account does not have access to it.";
 
   return (
     <div className="flex flex-1 items-center justify-center bg-background px-4 py-10">
@@ -169,7 +176,12 @@ export default function DeckEditor() {
     () => typeof window !== "undefined" && window.innerWidth >= 768,
   );
   const [retryingMissingDeck, setRetryingMissingDeck] = useState(false);
-  const { data: org, isLoading: orgLoading } = useOrg();
+  const {
+    data: org,
+    isLoading: orgLoading,
+    isError: orgError,
+    refetch: refetchOrg,
+  } = useOrg();
 
   // Dialog/popover states
   const [imageGenOpen, setImageGenOpen] = useState(false);
@@ -265,11 +277,12 @@ export default function DeckEditor() {
   const retryOpenDeck = useCallback(async () => {
     setRetryingMissingDeck(true);
     try {
+      await refetchOrg();
       await reloadDecks();
     } finally {
       setRetryingMissingDeck(false);
     }
-  }, [reloadDecks]);
+  }, [refetchOrg, reloadDecks]);
 
   // Clean up the generating URL param/ref when generation completes or when
   // the first slide lands, so partial progress is visible during long decks.
@@ -705,6 +718,7 @@ export default function DeckEditor() {
         deckId={id}
         hasTeamJoinOption={hasTeamJoinOption}
         orgLoading={orgLoading}
+        orgError={orgError}
         refreshing={retryingMissingDeck}
         onRetry={() => void retryOpenDeck()}
         onBack={() => navigate("/")}

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -7,12 +7,7 @@ import {
   lazy,
   Suspense,
 } from "react";
-import {
-  useParams,
-  Navigate,
-  useSearchParams,
-  useNavigate,
-} from "react-router";
+import { useParams, useSearchParams, useNavigate } from "react-router";
 import {
   DndContext,
   closestCenter,
@@ -47,6 +42,13 @@ import {
   appBasePath,
   useGuidedQuestionFlow,
 } from "@agent-native/core/client";
+import { useOrg } from "@agent-native/core/client/org";
+import {
+  IconArrowLeft,
+  IconBuilding,
+  IconLock,
+  IconRefresh,
+} from "@tabler/icons-react";
 import { useDeckPresence } from "@/hooks/use-deck-presence";
 import { useDeckRole } from "@/hooks/use-deck-role";
 import { useSlideComments } from "@/hooks/use-slide-comments";
@@ -63,6 +65,7 @@ import {
 import { replaceImageTargetInSlideHtml } from "@/lib/slide-image-replacement";
 import { toast } from "@/hooks/use-toast";
 import { ToastAction } from "@/components/ui/toast";
+import { Button } from "@/components/ui/button";
 import { nanoid } from "nanoid";
 import { TAB_ID } from "@/lib/tab-id";
 const Pinpoint = lazy(() =>
@@ -71,12 +74,78 @@ const Pinpoint = lazy(() =>
   })),
 );
 
+function MissingDeckAccessPane({
+  deckId,
+  hasTeamJoinOption,
+  orgLoading,
+  refreshing,
+  onRetry,
+  onBack,
+}: {
+  deckId: string | undefined;
+  hasTeamJoinOption: boolean;
+  orgLoading: boolean;
+  refreshing: boolean;
+  onRetry: () => void;
+  onBack: () => void;
+}) {
+  const Icon = hasTeamJoinOption || orgLoading ? IconBuilding : IconLock;
+  const title = orgLoading
+    ? "Looking for this deck"
+    : hasTeamJoinOption
+      ? "Join your team to open this deck"
+      : "Deck unavailable";
+  const description = orgLoading
+    ? "Checking whether this presentation is shared with your account."
+    : hasTeamJoinOption
+      ? "This link points to a team presentation. Join the team shown above and the deck will open here automatically."
+      : "This deck may have been removed, or your account does not have access to it.";
+
+  return (
+    <div className="flex flex-1 items-center justify-center bg-background px-4 py-10">
+      <div className="w-full max-w-md rounded-lg border border-border bg-card p-6 shadow-sm">
+        <div className="mb-4 flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-md border border-border bg-background text-muted-foreground">
+            <Icon className="size-5" />
+          </div>
+          <div className="min-w-0">
+            <h1 className="text-base font-semibold text-foreground">{title}</h1>
+            {deckId && (
+              <p className="truncate text-xs text-muted-foreground">
+                Deck ID: {deckId}
+              </p>
+            )}
+          </div>
+        </div>
+        <p className="text-sm leading-6 text-muted-foreground">{description}</p>
+        <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button type="button" variant="outline" onClick={onBack}>
+            <IconArrowLeft className="size-4" />
+            Back to Decks
+          </Button>
+          <Button
+            type="button"
+            onClick={onRetry}
+            disabled={refreshing || orgLoading}
+          >
+            <IconRefresh
+              className={refreshing ? "size-4 animate-spin" : "size-4"}
+            />
+            Try again
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function DeckEditor() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const {
     getDeck,
+    reloadDecks,
     updateDeck,
     updateSlide,
     deleteSlide,
@@ -99,6 +168,8 @@ export default function DeckEditor() {
   const [sidebarOpen, setSidebarOpen] = useState(
     () => typeof window !== "undefined" && window.innerWidth >= 768,
   );
+  const [retryingMissingDeck, setRetryingMissingDeck] = useState(false);
+  const { data: org, isLoading: orgLoading } = useOrg();
 
   // Dialog/popover states
   const [imageGenOpen, setImageGenOpen] = useState(false);
@@ -138,6 +209,10 @@ export default function DeckEditor() {
   }, []);
 
   const deck = getDeck(id || "");
+  const hasTeamJoinOption =
+    !org?.orgId &&
+    ((org?.pendingInvitations?.length ?? 0) > 0 ||
+      (org?.domainMatches?.length ?? 0) > 0);
   const slideCount = deck?.slides.length ?? 0;
   // Mirror Google Slides: viewers see the editor shell with edit affordances
   // disabled (rather than a separate "viewer" route). Owners/Editors/Admins
@@ -181,6 +256,20 @@ export default function DeckEditor() {
   });
 
   const showQuestionFlow = Boolean(questionFlowQuestions?.length);
+
+  useEffect(() => {
+    if (loading || deck || !id || !org?.orgId) return;
+    void reloadDecks();
+  }, [deck, id, loading, org?.orgId, reloadDecks]);
+
+  const retryOpenDeck = useCallback(async () => {
+    setRetryingMissingDeck(true);
+    try {
+      await reloadDecks();
+    } finally {
+      setRetryingMissingDeck(false);
+    }
+  }, [reloadDecks]);
 
   // Clean up the generating URL param/ref when generation completes or when
   // the first slide lands, so partial progress is visible during long decks.
@@ -610,7 +699,18 @@ export default function DeckEditor() {
   ).length;
 
   if (loading) return <div className="h-screen bg-background" />;
-  if (!deck || !id) return <Navigate to="/" replace />;
+  if (!deck || !id) {
+    return (
+      <MissingDeckAccessPane
+        deckId={id}
+        hasTeamJoinOption={hasTeamJoinOption}
+        orgLoading={orgLoading}
+        refreshing={retryingMissingDeck}
+        onRetry={() => void retryOpenDeck()}
+        onBack={() => navigate("/")}
+      />
+    );
+  }
 
   const currentSlide =
     deck.slides.find((s) => s.id === activeSlideId) || deck.slides[0];


### PR DESCRIPTION
## Summary
- keep shared deck editor links mounted when access is not available yet
- show a contextual access state instead of redirecting to the deck list
- reload the currently open deck after org membership changes

## Verification
- pnpm --filter slides exec vitest --run app/context/DeckContext.test.ts app/context/DeckContext.persistence.test.ts
- pnpm --filter slides typecheck
- browser verified /deck/codex-missing-shared-deck on desktop and mobile