### PR TITLE
fix(core): prevent agent chat context overflow + trim oversized template prompts

### DIFF
--- a/.changeset/cap-screen-context.md
+++ b/.changeset/cap-screen-context.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Cap the per-message `<current-screen>` context so a large `view-screen` snapshot (e.g. a recording/meeting page returning a full transcript + every segment) can no longer overflow the model context window and hard-error the chat with `context_length_exceeded`. The screen snapshot injected into every user message is now bounded to ~24K chars with a note pointing the agent at `view-screen` / data actions for full detail. This fixes brand-new chats failing on the first message and the very high time-to-first-token caused by an oversized ambient context.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -655,6 +655,26 @@ function maxRetriesForError(err: unknown): number {
 const TOOL_INPUT_ACTIVITY_INTERVAL_MS = 1500;
 const MAX_TEXT_ATTACHMENT_CHARS = 60_000;
 
+/**
+ * Hard cap on the `<current-screen>` block injected into EVERY user message.
+ *
+ * The screen snapshot comes from the template's `view-screen` action, which can
+ * be unbounded — e.g. a recording/meeting page returns the full transcript +
+ * every segment. Injected on every turn with no cap, that single block can blow
+ * past the model's context window and hard-error the chat with
+ * `context_length_exceeded` (observed: a brand-new "hi" message failing because
+ * an open recording's transcript shipped in `<current-screen>`). ~24K chars
+ * (~6K tokens) keeps the ambient snapshot useful while leaving the window for
+ * history and the response; the agent can call `view-screen` (or a data action
+ * like `get-recording-player-data`) for the full detail on demand.
+ */
+const MAX_SCREEN_CONTEXT_CHARS = 24_000;
+
+function capScreenContext(text: string): string {
+  if (text.length <= MAX_SCREEN_CONTEXT_CHARS) return text;
+  return `${text.slice(0, MAX_SCREEN_CONTEXT_CHARS)}\n\n…[current-screen snapshot truncated after ${MAX_SCREEN_CONTEXT_CHARS.toLocaleString()} chars to protect the context window. Call the view-screen action for the full snapshot, or a data action (e.g. get-recording-player-data) for full transcripts.]`;
+}
+
 function generateRunId(): string {
   return `run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -2179,7 +2199,7 @@ export function createProductionAgentHandler(
               typeof result === "string"
                 ? result
                 : JSON.stringify(result, null, 2);
-            return `\n\n<current-screen>\n${screenText}\n</current-screen>`;
+            return `\n\n<current-screen>\n${capScreenContext(screenText)}\n</current-screen>`;
           }
         } else {
           const navigation = await readAppStateForBrowserTab(
@@ -2187,7 +2207,7 @@ export function createProductionAgentHandler(
             requestBrowserTabId,
           );
           if (navigation) {
-            return `\n\n<current-screen>\n${JSON.stringify(navigation, null, 2)}\n</current-screen>`;
+            return `\n\n<current-screen>\n${capScreenContext(JSON.stringify(navigation, null, 2))}\n</current-screen>`;
           }
         }
       } catch {

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -221,15 +221,7 @@ Example:
 
 ## Architecture
 
-```
-Frontend (React)  <-->  Backend (Nitro)  <-->  Data Sources (BigQuery, HubSpot, etc.)
-     |                       |
-     v                       v
-Agent Chat  ------>  Actions (pnpm action)
-     |                       |
-     v                       v
-         SQL Database (shared state)
-```
+React frontend and Nitro backend share one SQL database for all app/UI state; the backend reaches external data sources (BigQuery, HubSpot, etc.). The agent runs the same actions (`pnpm action`) the frontend calls, keeping agent and UI in parity.
 
 ### Data Storage
 

--- a/templates/brain/AGENTS.md
+++ b/templates/brain/AGENTS.md
@@ -316,14 +316,11 @@ secrets. It does not fall back to deploy-level environment variables for source
 credentials. Never include resolved credential values in action responses,
 stats, errors, or logs.
 
-For "ask across everything" requests, do not treat Brain as the owner of every
-workspace system. Use Brain search for reviewed knowledge and accessible captures.
-If the user asks for live metrics, dashboard numbers, CRM pipeline analysis,
-mailbox state, calendar availability, Dispatch policy, or another app-owned
-surface, call the specialized app agent/action through A2A when available and
-ground the answer in that result. Brain may summarize and cite the handoff, but
-it should not fabricate live data or bypass the owning app's permissions and
-domain rules.
+For "ask across everything" requests, follow the `ask-across-everything` skill:
+search Brain for reviewed knowledge and accessible captures, delegate live
+app-owned questions (metrics, mailbox state, calendar, Dispatch policy, etc.) to
+the owning specialist agent via A2A, and never fabricate live data or bypass the
+owning app's permissions.
 
 ## A2A Retrieval
 

--- a/templates/calendar/AGENTS.md
+++ b/templates/calendar/AGENTS.md
@@ -42,14 +42,7 @@ For code editing and development guidance, read `DEVELOPING.md`.
 
 ## Architecture
 
-This is an agent-native calendar app with Google Calendar integration and a public booking page. Events come from Google Calendar API directly (not synced to local files). Bookings are stored in SQL via Drizzle ORM (SQLite, Postgres, Turso, etc. via `DATABASE_URL`). Settings and availability are stored in SQL via the settings API.
-
-### How it works
-
-1. **Frontend** (React + Vite) reads state via API routes
-2. **Server** (Nitro) reads events from Google Calendar API, reads/writes bookings in SQL, reads/writes settings via settings API
-3. **Agent** reads/writes settings via scripts, uses scripts for DB operations — changes propagate to UI via SSE
-4. **Google Calendar** queried via pull-based approach (no webhooks)
+This is an agent-native calendar app with Google Calendar integration and a public booking page. The React + Vite frontend reads state via API routes; the Nitro server reads events from the Google Calendar API (pull-based, no webhooks), and reads/writes bookings in SQL (Drizzle ORM over `DATABASE_URL` — SQLite, Postgres, Turso, etc.) plus settings/availability via the settings API. The agent runs the same operations through scripts; changes propagate to the UI via SSE.
 
 ### Events
 

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -28,38 +28,7 @@ Resources are SQL-backed persistent files for notes, learnings, and context.
 
 ## Architecture
 
-```
-┌──────────────────────┐     ┌──────────────────────┐
-│  Frontend            │     │  Agent Chat          │
-│  (React + Vite)      │◄───►│  (AI agent)          │
-│                      │     │                      │
-│  - MediaRecorder     │     │  - calls actions     │
-│    chunked upload    │     │  - edits metadata    │
-│  - player + editor   │     │  - delegates AI      │
-│  - writes app-state  │     │    via sendToAgent   │
-└──────────┬───────────┘     └──────────┬───────────┘
-           │                            │
-           └──────────────┬─────────────┘
-                          ▼
-                  ┌───────────────┐
-                  │  Nitro server │
-                  │               │
-                  │  actions/     │  ←  auto-mounted at
-                  │  /api/*       │     /_agent-native/actions/:name
-                  └───────┬───────┘
-                          │
-                          ▼
-                  ┌───────────────┐
-                  │  SQL Database │
-                  │  (Neon/PG/SQL)│
-                  └───────────────┘
-                          │
-                          ▼
-                  ┌───────────────┐
-                  │  Video storage│
-                  │  (disk/R2/S3) │
-                  └───────────────┘
-```
+React + Vite frontend (MediaRecorder chunked upload, player + editor, writes app-state) and the agent chat both drive a Nitro server. `actions/` auto-mount at `/_agent-native/actions/:name`; `/api/*` covers uploads/streaming/webhooks. Everything persists to SQL (Neon/PG/SQLite) via Drizzle; video bytes go to disk/R2/S3.
 
 ## Data Sources
 
@@ -324,34 +293,7 @@ All standard CRUD (list, get, create, update) goes through `/_agent-native/actio
 
 ## Keyboard Shortcuts
 
-| Key                   | Action                                       |
-| --------------------- | -------------------------------------------- |
-| `Cmd+Shift+L`         | Start a new recording (global)               |
-| `Space`               | Play / pause                                 |
-| `J`                   | Skip back 10s                                |
-| `K`                   | Play / pause                                 |
-| `L`                   | Skip forward 10s                             |
-| `←` / `→`             | Skip back / forward 5s                       |
-| `Shift+←` / `Shift+→` | Previous / next chapter                      |
-| `↑` / `↓`             | Volume up / down                             |
-| `F`                   | Fullscreen                                   |
-| `M`                   | Mute / unmute                                |
-| `,` / `.`             | Step one frame back / forward (while paused) |
-| `-` / `+`             | Slower / faster playback                     |
-| `C`                   | Toggle captions                              |
-| `I`                   | Mark In-point (editor)                       |
-| `O`                   | Mark Out-point (editor)                      |
-| `X`                   | Cut selection (editor)                       |
-| `S`                   | Split at playhead (editor)                   |
-| `/`                   | Focus library search                         |
-| `⌘K`                  | Command menu                                 |
-| `Esc`                 | Close player / clear selection               |
-| `G then L`            | Go to Library                                |
-| `G then S`            | Go to Spaces                                 |
-| `G then A`            | Go to Archive                                |
-| `G then T`            | Go to Trash                                  |
-| `G then M`            | Go to Meetings                               |
-| `G then D`            | Go to Dictate                                |
+These are human player/editor shortcuts (Space play/pause, J/K/L, `[`/`]` trim, `G then L/S/A/T/M/D` to navigate, `⌘K` command menu, etc.). The agent drives the app through actions, not the keyboard — see the `recording` and `video-editing` skills if you need the full key map for documentation.
 
 ## UI Components
 

--- a/templates/clips/actions/view-screen.ts
+++ b/templates/clips/actions/view-screen.ts
@@ -445,8 +445,27 @@ export default defineAction({
               fetchComments(nav.recordingId),
             ]);
             screen.recording = recording;
-            if (transcript) screen.transcript = transcript;
-            screen.comments = comments;
+            if (transcript) {
+              // Ambient snapshot only — embed a short fullText snippet and the
+              // segment count, NOT the entire transcript + every word-level
+              // segment. The full transcript can be tens of thousands of tokens
+              // and is injected into <current-screen> on EVERY message, which
+              // can blow the model's context window. The agent calls
+              // get-recording-player-data for the complete transcript/segments.
+              const segmentCount = Array.isArray(transcript.segments)
+                ? transcript.segments.length
+                : 0;
+              screen.transcript = {
+                recordingId: transcript.recordingId,
+                language: transcript.language,
+                status: transcript.status,
+                fullTextSnippet: (transcript.fullText ?? "").slice(0, 2000),
+                fullTextLength: (transcript.fullText ?? "").length,
+                segmentCount,
+                note: "Snippet only. Call get-recording-player-data for the full transcript and segments.",
+              };
+            }
+            screen.comments = comments.slice(0, 50);
           }
         }
         break;

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -110,20 +110,14 @@ cd templates/content && pnpm action <name> [args]
 
 **`pull-document` is the collab-aware "ingest the final" read** — prefer it over
 `get-document` for external ingest (another app, an external coding agent over
-MCP/A2A, an A2A peer). `get-document` returns whatever is in the
-`documents.content` SQL column, which can lag behind a live editing session: the
-open editor holds the authoritative Y.Doc in memory and only debounces it back
-to SQL. `pull-document` closes that gap with a flush handshake — if a live Yjs
-collab session exists for the document it writes a one-shot `flush-request-<id>`
-application-state key (scoped to the browser session, just like `navigate`); the
-open editor sees that key, serializes its current document to markdown through
-its own existing serializer, calls `update-document`, and deletes the key;
-`pull-document` waits for the key to clear and then returns the now-fresh row.
-When no editor is open the SQL column is authoritative and the handshake is
-skipped. It is GET + read-only + public-agent exposed (`requiresAuth: true`),
-returns `{ id, title, content, format, deepLink }`, and surfaces an
-"Open document" deep link for external agents. Use `--format text` for a
-plain-text strip of the markdown.
+MCP/A2A, an A2A peer). `get-document` returns the `documents.content` SQL column,
+which can lag behind a live editing session (the open editor holds the
+authoritative Y.Doc in memory and only debounces it back to SQL). `pull-document`
+flushes the open editor first via a one-shot handshake so it returns the fresh
+row. It is GET + read-only + public-agent exposed (`requiresAuth: true`), returns
+`{ id, title, content, format, deepLink }`, and surfaces an "Open document" deep
+link for external agents. Use `--format text` for a plain-text strip of the
+markdown.
 
 **`export-document` is the page export action.** The UI exposes it from the
 page toolbar export menu. Use `--format pdf` when the user wants a PDF; the

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -1910,28 +1910,7 @@ When a user asks to download a design, export a design, or get the generated HTM
 
 ### Claude Code Handoff
 
-When the user wants to convert a prototype into production code, generate a handoff prompt:
-
-```
-Convert this Alpine.js + Tailwind prototype into a production React/Next.js application.
-
-Key design tokens:
-- Primary: #0F172A
-- Accent: #0EA5E9
-- Font: Space Grotesk (headings), DM Sans (body)
-- Border radius: 12px
-
-Interactive states to preserve:
-- Mobile navigation toggle
-- Tab switching
-- Filter controls
-
-Responsive breakpoints:
-- Mobile: 375px
-- Tablet: 768px
-- Desktop: 1280px
-- Wide: 1920px
-```
+To convert a prototype into production code, prefer the canonical `export-coding-handoff --id <id>` action (above), which builds the tweak-aware prompt and raw-code bundle for you. For a hand-written prompt template (design tokens, interactive states, responsive breakpoints), see the `export-handoff` skill.
 
 ---
 

--- a/templates/dispatch/AGENTS.md
+++ b/templates/dispatch/AGENTS.md
@@ -34,16 +34,7 @@ bridge.
 
 ## Integration Webhooks (Slack, Telegram, WhatsApp, Email)
 
-Inbound platform webhooks follow a cross-platform queue pattern so they work on every serverless host (Netlify, Vercel, Cloudflare, etc.) without relying on platform-specific background-execution APIs:
-
-1. `POST /_agent-native/integrations/:platform/webhook` verifies the signature, parses the message into `IncomingMessage`, and **inserts a row into `integration_pending_tasks`** with `status='pending'`.
-2. The handler fires a fire-and-forget `POST /_agent-native/integrations/process-task` and returns `200` immediately so the platform doesn't retry.
-3. The processor endpoint runs in a **fresh function execution** with its own full timeout. It atomically claims the task (`pending` → `processing` via `claimPendingTask`), runs the agent loop, sends the reply via the adapter, and marks the task `completed`.
-4. A recurring retry job (`startPendingTasksRetryJob`, every 60s) sweeps tasks stuck in `pending` >90s or `processing` >5min and re-fires the processor. Capped at 3 attempts, then `failed`.
-
-Never run the agent loop inside the webhook handler itself, and never rely on a fire-and-forget `Promise` outliving the response — serverless freezes the function the moment the response is sent. The SQL queue + self-webhook is what makes the pattern portable.
-
-Adapters (`packages/core/src/integrations/adapters/*.ts`) are platform-specific only for verification, parsing, formatting, and delivery. The queue, processor, and retry are shared infrastructure. See the `integration-webhooks` skill for adding a new platform.
+Inbound platform webhooks use the portable SQL-queue pattern (verify + enqueue to `integration_pending_tasks` → return 200 → run the agent loop in a fresh `process-task` execution → 60s retry job sweeps stuck tasks). Never run the agent loop inside the webhook handler or rely on a fire-and-forget `Promise` outliving the response — serverless freezes the function the moment the response is sent. Adapters (`packages/core/src/integrations/adapters/*.ts`) are platform-specific only for verify/parse/format/deliver; the queue, processor, and retry are shared. See the `integration-webhooks` skill for the full flow and adding a new platform.
 
 ## Resources To Use
 
@@ -70,50 +61,14 @@ The UI writes:
 - `navigation.path`: current route path
 - Dreams may also include filters such as `sourceId`, `ownerEmail`, `status`, or `dreamId`
 
-The agent can navigate with:
-
-- `navigate(view="chat")`
-- `navigate(view="overview")`
-- `navigate(view="apps")`
-- `navigate(view="new-app")`
-- `navigate(view="vault")`
-- `navigate(view="integrations")`
-- `navigate(view="messaging")`
-- `navigate(view="workspace")`
-- `navigate(view="destinations")`
-- `navigate(view="identities")`
-- `navigate(view="approvals")`
-- `navigate(view="audit")`
-- `navigate(view="thread-debug")`
-- `navigate(view="dreams")`
-- `navigate(view="team")`
+The agent navigates with `navigate(view="<id>")` using any of the `navigation.view` ids above (e.g. `navigate(view="vault")`, `navigate(view="dreams")`), or `navigate(path="/your-route")`.
 
 Custom workspace-owned Dispatch tabs can be added without forking the Dispatch
 package. Edit `app/dispatch-extensions.tsx` to add a `navItems` entry, then add
 the matching local route file under `app/routes/`. Use `DispatchShell` from
 `@agent-native/dispatch/components` in the route so the packaged header keeps
 working. The nav item `id` becomes `navigation.view`, and the agent can navigate
-to it with `navigate(view="<id>")` or `navigate(path="/your-route")`.
-
-Example:
-
-```tsx
-import { IconChartBar } from "@tabler/icons-react";
-import type { DispatchExtensionConfig } from "@agent-native/dispatch/components";
-
-export const dispatchExtensions = {
-  navItems: [
-    {
-      id: "reports",
-      to: "/reports",
-      label: "Reports",
-      icon: IconChartBar,
-      section: "operations",
-    },
-  ],
-  queryKeys: ["list-reports"],
-} satisfies DispatchExtensionConfig;
-```
+to it with `navigate(view="<id>")` or `navigate(path="/your-route")`. Export a `dispatchExtensions` object satisfying `DispatchExtensionConfig` with a `navItems` array (each entry has `id`, `to`, `label`, `icon`, `section`) and a `queryKeys` array.
 
 ## Dispatch Actions
 

--- a/templates/mail/AGENTS.md
+++ b/templates/mail/AGENTS.md
@@ -105,34 +105,7 @@ Resources support **personal** scope (per-user) and **shared** scope (visible to
 
 ## Architecture
 
-```
-┌────────────────────┐     ┌────────────────────┐
-│  Frontend          │     │  Agent Chat        │
-│  (React + Vite)    │◄───►│  (AI agent)        │
-│                    │     │                    │
-│  - reads emails    │     │  - reads/writes    │
-│    via API         │     │    SQL via scripts │
-│  - sends actions   │     │  - runs scripts    │
-│    via API PATCH   │     │    via pnpm action │
-└────────┬───────────┘     └──────────┬─────────┘
-         │                            │
-         └──────────┬─────────────────┘
-                    ▼
-            ┌───────────────┐
-            │  Backend      │
-            │  (Nitro)      │
-            │               │
-            │  /api/emails  │
-            │  /api/labels  │
-            │  /api/settings│
-            └───────┬───────┘
-                    │
-                    ▼
-            ┌───────────────┐
-            │  SQL Database │
-            │  (via DB_URL) │
-            └───────────────┘
-```
+The React + Vite frontend and the agent both read and write the same data. The frontend reads emails via the API and sends actions via API PATCH; the agent reads/writes SQL and runs scripts via `pnpm action`. Both go through the Nitro backend (`/api/emails`, `/api/labels`, `/api/settings`), which talks to the SQL database (via `DATABASE_URL`).
 
 ## Data Sources
 
@@ -540,26 +513,7 @@ Scripts use `readAppState()` / `writeAppState()` from `@agent-native/core/applic
 
 ## Keyboard Shortcuts
 
-| Key        | Action                       |
-| ---------- | ---------------------------- |
-| `J`        | Next email                   |
-| `K`        | Previous email               |
-| `↑` / `↓`  | Same as J/K                  |
-| `Enter`    | Open focused email           |
-| `E`        | Archive email/thread         |
-| `D`        | Trash email/thread           |
-| `S`        | Star/unstar (in thread view) |
-| `R`        | Reply                        |
-| `U`        | Toggle read/unread           |
-| `C`        | Compose new email            |
-| `/`        | Focus search bar             |
-| `⌘K`       | Open command palette         |
-| `G then I` | Go to Inbox                  |
-| `G then S` | Go to Starred                |
-| `G then T` | Go to Sent                   |
-| `G then D` | Go to Drafts                 |
-| `G then A` | Go to Archive                |
-| `Esc`      | Close thread / clear search  |
+These are human shortcuts for navigating the mail UI (J/K to move, E to archive, R to reply, C to compose, `/` to search, `G then <key>` to jump views, etc.). The agent drives the app through actions, not the keyboard — see the Actions section above for the full operation set.
 
 ## UI Components
 

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -727,18 +727,7 @@ When generating outbound content (deck slides, marketing copy), use only the aud
 
 ## Skills (for code editing only)
 
-These skills are **only** needed when modifying source code, styles, or architecture. They are **not** needed for creating slides — the slide HTML templates above have everything you need for slide generation.
-
-The framework auto-injects a `<skills>` block in your system prompt listing every available skill with its directory path and description. Skills are folders at `.agents/skills/<name>/` containing `SKILL.md` plus any supporting files.
-
-Read a skill via shell (dev mode):
-
-```
-shell(command="cat .agents/skills/actions/SKILL.md")
-shell(command="ls .agents/skills/actions/")
-```
-
-In production mode (no shell): critical content should be inlined in this AGENTS.md. For this template, all slide HTML templates are already inlined above — skills are only needed for code modification, which happens in dev.
+These skills are **only** needed when modifying source code, styles, or architecture — **not** for creating slides (the slide HTML templates above have everything you need). The framework auto-injects a `<skills>` block listing every skill with its `.agents/skills/<name>/` path and description; read one via shell in dev mode (`cat .agents/skills/<name>/SKILL.md`). In production there is no shell, so all slide-generation content is already inlined above; skills cover code modification, which happens in dev.
 
 ## Inline Previews in Chat
 
@@ -828,61 +817,17 @@ title: Slide 2 — Key Metrics
 
 ## Design Philosophy Reference
 
-When the user's request is vague about visual direction, recommend from these schools:
-
-### Information Architecture School
-
-- **Pentagram**: Grid-first, black/white/red, structured information hierarchy
-- **Stamen Design**: Data-driven, cartographic precision, clear visual encoding
-
-### Motion Poetics School
-
-- **Locomotive**: Smooth scroll, parallax depth, cinematic pacing
-- **Active Theory**: WebGL experiments, particle systems, immersive 3D
-- **Field.io**: Generative art, algorithmic beauty, mathematical precision
-
-### Minimalism School
-
-- **Experimental Jetset**: Swiss typography, geometric forms, pure structure
-- **Muller-Brockmann**: Grid systems, objective communication, typographic hierarchy
-- **Build**: Reduction to essence, mono-font, pure whitespace
-
-### Eastern Philosophy School
-
-- **Kenya Hara**: Ma (negative space), simplicity as depth, emptiness as design
-- **Takram**: Craft meets technology, material honesty, subtle animation
-
-**Key insight**: Describe mood, not layout. Short emotional prompts outperform detailed layout specifications.
+When the user's request is vague about visual direction, describe a mood rather than a layout — short emotional prompts outperform detailed layout specs. For a fuller catalog of design schools (information-architecture, motion, minimalism, Eastern) and named studios to draw from, see the `frontend-design` skill.
 
 ---
 
 ## Slide Design Patterns
 
-### Batch Production Strategy
+**Batch production:** make 2 showcase slides first (title + key content), get user approval on the visual grammar, then produce the rest following the established grammar.
 
-Always make 2 showcase slides first to lock the visual grammar before scaling:
+**Layout types:** title, data/charts, comparison (side-by-side / before-after / pros-cons), timeline/process, quote, image gallery, annotated code.
 
-1. Generate 2 hero slides (title + key content)
-2. Get user approval on the visual language
-3. Then produce remaining slides following the established grammar
-
-### Slide Layout Types
-
-- **Title**: Large heading, minimal text, strong visual impact
-- **Data**: Charts, numbers, clear data visualization
-- **Comparison**: Side-by-side, before/after, pros/cons
-- **Timeline**: Sequential events, process flows
-- **Quote**: Large pull quote with attribution
-- **Gallery**: Image grid with captions
-- **Code**: Syntax-highlighted code with annotations
-
-### Typography on Slides
-
-- Heading: 48-72px on the 960x540 native slide canvas
-- Body: 22-32px minimum
-- Caption: 18-20px
-- Use `font-variation-settings` for weight morphing (if variable font available)
-- Two-tier shadow: 1px tight shadow + 8px ambient shadow (never single shadow)
+**Typography on the 960x540 native canvas:** headings 48-72px, body 22-32px minimum, captions 18-20px. Use `font-variation-settings` for weight morphing when a variable font is available, and a two-tier shadow (1px tight + 8px ambient, never a single shadow).
 
 ---
 

--- a/templates/videos/AGENTS.md
+++ b/templates/videos/AGENTS.md
@@ -286,162 +286,16 @@ This project is a **Remotion-based animation studio** — a web UI for composing
 
 ---
 
-### Core Data Types (`app/types.ts`)
+### Core Data Types, Registry, and Helpers
 
-#### `AnimationTrack`
+The `AnimationTrack` / `AnimatedProp` types (`app/types.ts`), the `CompositionEntry` registry shape (`app/remotion/registry.ts`), the `findTrack` / `trackProgress` / `getPropValue` helpers (`app/remotion/trackAnimation.ts`), the composition component pattern (props + `FALLBACK_TRACKS`), and the steps to add a new composition are all documented in the **`animation-tracks`** and **`composition-management`** skills. Read those before editing animations or compositions.
 
-```typescript
-interface AnimationTrack {
-  id: string; // Unique, stable — e.g. "lr-ring". Used by findTrack().
-  label: string; // Display name in the timeline
-  startFrame: number;
-  endFrame: number;
-  easing: EasingKey; // "linear" | "ease-in" | "ease-out" | "ease-in-out" | "spring"
-  animatedProps?: AnimatedProp[];
-}
-```
+Template-specific notes not in the skills:
 
-#### `AnimatedProp`
-
-```typescript
-interface AnimatedProp {
-  property: string; // Property name — e.g. "opacity", "translateY", "radius"
-  from: string; // Numeric start value as string — e.g. "0"
-  to: string; // Numeric end value as string — e.g. "1"
-  unit: string; // CSS unit appended on output — e.g. "px", "deg", "" (none)
-
-  // Optional transparency / documentation fields:
-  description?: string; // Plain-English explanation shown in the Properties panel
-  codeSnippet?: string; // Read-only source shown in the Properties panel code viewer
-  programmatic?: boolean; // true → no editable from/to; only description + code shown
-  isCustom?: boolean; // true → from/to are raw CSS value strings, not plain numbers
-
-  // Adjustable parameters for programmatic animations:
-  parameters?: Array<{
-    name: string; // Key for accessing value (e.g., "avgCharWidth")
-    label: string; // UI label (e.g., "Character Width")
-    default: number; // Default value
-    min?: number; // Minimum allowed value
-    max?: number; // Maximum allowed value
-    step?: number; // Increment step (e.g., 0.05)
-  }>;
-  parameterValues?: Record<string, number>; // User-adjusted parameter values
-}
-```
-
-**Rule:** Every `animatedProps` entry that has a `codeSnippet` or `programmatic: true` will render as an **expression** (`fx`) in the timeline and Properties panel. Always provide a `description` alongside a `codeSnippet` so users understand what the code does.
-
-**Note:** For programmatic animations, expose internal values as `parameters` to give users control without code editing. See "Exposing Adjustable Parameters" section below for details.
-
----
-
-### The Registry (`app/remotion/registry.ts`)
-
-`compositions` is the authoritative array of `CompositionEntry` objects. Each entry has:
-
-```typescript
-type CompositionEntry = {
-  id: string; // URL slug — e.g. "logo-reveal" → /c/logo-reveal
-  title: string;
-  description: string;
-  component: React.FC<any>; // The Remotion composition component
-  durationInFrames: number; // Default duration (overrideable per-user in localStorage)
-  fps: number; // Default fps (overrideable per-user in localStorage)
-  width: number;
-  height: number;
-  defaultProps: Record<string, any>; // Passed as inputProps to <Player>
-  tracks: AnimationTrack[]; // Default track data (overrideable per-user in localStorage)
-};
-```
-
-**Important:** `defaultProps` is shown in `PropsEditor` as editable fields. Do **not** include `tracks` in `defaultProps` — tracks are passed separately and merged in `CompositionView`.
-
-#### Adding a new composition
-
-1. Create `app/remotion/compositions/MyComp.tsx` — the Remotion component
-2. Export it from `app/remotion/compositions/index.ts`
-3. Add a `CompositionEntry` to the `compositions` array in `app/remotion/registry.ts`
-4. Define `tracks` with meaningful IDs, labels, frame ranges, and `animatedProps`
-
----
-
-### Composition Components (`app/remotion/compositions/*.tsx`)
-
-Each composition:
-
-- Receives `tracks?: AnimationTrack[]` as a prop alongside its own visual props
-- Declares `FALLBACK_TRACKS` — a local copy of the default tracks used when the prop is absent (prevents crashes during development or if the registry changes)
-- Uses `findTrack(tracks, "track-id", FALLBACK_TRACKS[n])` to locate each track
-- Uses `trackProgress(frame, fps, track)` to get a 0→1 progress value
-- Uses `getPropValue(progress, track, "property", defaultFrom, defaultTo)` to read interpolated numeric values from `animatedProps`
-
-#### Template pattern for a new composition
-
-```tsx
-import { AbsoluteFill, useCurrentFrame, useVideoConfig } from "remotion";
-import type { AnimationTrack } from "@/types";
-import { trackProgress, getPropValue, findTrack } from "../trackAnimation";
-
-export type MyCompProps = {
-  title: string;
-  // ... other visual props
-  tracks?: AnimationTrack[];
-};
-
-const FALLBACK_TRACKS: AnimationTrack[] = [
-  {
-    id: "mc-intro",
-    label: "Intro",
-    startFrame: 0,
-    endFrame: 30,
-    easing: "spring",
-    animatedProps: [
-      { property: "opacity", from: "0", to: "1", unit: "" },
-      { property: "translateY", from: "40", to: "0", unit: "px" },
-    ],
-  },
-];
-
-export const MyComp: React.FC<MyCompProps> = ({
-  title,
-  tracks = FALLBACK_TRACKS,
-}) => {
-  const frame = useCurrentFrame();
-  const { fps } = useVideoConfig();
-
-  const introTrack = findTrack(tracks, "mc-intro", FALLBACK_TRACKS[0]);
-  const p = trackProgress(frame, fps, introTrack);
-  const opacity = getPropValue(p, introTrack, "opacity", 0, 1);
-  const transY = getPropValue(p, introTrack, "translateY", 40, 0);
-
-  return (
-    <AbsoluteFill>
-      <div style={{ opacity, transform: `translateY(${transY}px)` }}>
-        {title}
-      </div>
-    </AbsoluteFill>
-  );
-};
-```
-
----
-
-### `trackAnimation.ts` — Helper Reference
-
-```typescript
-// Returns 0→1 progress for the track at the given frame.
-// Handles spring (Remotion spring()) and polynomial easings.
-trackProgress(frame, fps, track): number
-
-// Looks up track.animatedProps by property name and interpolates from→to.
-// Falls back to defaultFrom/defaultTo if the property isn't defined.
-getPropValue(progress, track, property, defaultFrom, defaultTo): number
-
-// Finds a track by id; returns fallback if not found.
-findTrack(tracks, id, fallback): AnimationTrack
-```
-
-**Never** hard-code animation values in a composition when those values should be user-editable via the timeline. Use `getPropValue()` instead.
+- `AnimatedProp.isCustom?: boolean` — when `true`, `from`/`to` are raw CSS value strings, not plain numbers.
+- **Rule:** Any `animatedProps` entry with a `codeSnippet` or `programmatic: true` renders as an expression (`fx`) in the timeline and Properties panel. Always pair a `codeSnippet` with a plain-English `description`.
+- **Important:** `defaultProps` is shown in `PropsEditor` as editable fields — do **not** include `tracks` in `defaultProps`; tracks are passed separately and merged in `CompositionView`.
+- **Never** hard-code animation values that should be user-editable via the timeline — read them through `getPropValue()` instead.
 
 ---
 
@@ -551,14 +405,7 @@ In `Timeline.tsx`, keyframe-style tracks (where `startFrame === endFrame`) are a
 
 This is **automatic** - no special code needed in compositions. Just set `startFrame === endFrame` in the registry.
 
-#### Benefits of Track-Based Animation
-
-✅ **User Control** — Every timing can be adjusted in the timeline UI
-✅ **Visibility** — Users see what animations exist and when they happen
-✅ **Consistency** — All animations follow the same pattern
-✅ **No Mysteries** — No hidden hardcoded behaviors
-
-**See:** `BlankComposition.tsx` for an example of track-based composition setup
+Track-based animation gives users full timing control in the timeline UI and keeps every animation visible (no hidden hardcoded behaviors). **See:** `BlankComposition.tsx` for an example of track-based composition setup.
 
 ---
 
@@ -913,38 +760,7 @@ const driftX = startOffset * (1 - easedProgress);
 - Changes are **auto-saved to localStorage**
 - Click **Save button** to persist to the registry file
 
-**Visual hierarchy:**
-
-```
-┌─────────────────────────────────────┐
-│ fx  typing reveal         [CODE] [X]│
-├─────────────────────────────────────┤
-│ PARAMETERS                          │
-│ Character Width  [0.6    ]          │
-│ Drift Distance   [0.125  ]          │
-└─────────────────────────────────────┘
-```
-
-Expanded (after clicking CODE):
-
-```
-┌─────────────────────────────────────┐
-│ fx  typing reveal         [HIDE] [X]│
-├─────────────────────────────────────┤
-│ PARAMETERS                          │
-│ Character Width  [0.6    ]          │
-│ Drift Distance   [0.125  ]          │
-├─────────────────────────────────────┤
-│ ✨ HOW IT WORKS                     │
-│ Letters appear one by one...        │
-├─────────────────────────────────────┤
-│ EXPRESSION (read-only)              │
-│ ┌─────────────────────────────────┐ │
-│ │ const charsToShow = Math.floor…│ │
-│ │ ...                            │ │
-│ └─────────────────────────────────┘ │
-└─────────────────────────────────────┘
-```
+**Visual hierarchy:** the card header shows the `fx` badge, prop name, and a CODE/HIDE toggle. The PARAMETERS section (a number input per parameter) is always visible below it. Clicking CODE expands a "How it works" description followed by the read-only EXPRESSION code block.
 
 #### Best Practices
 
@@ -1407,8 +1223,6 @@ export const MyComp = createInteractiveComposition<MyCompProps>({
 
 ### Architecture
 
-### Architecture
-
 **Storage** (`CurrentElementContext`)
 
 - `getCursorType(compositionId, elementType)` — Reads from localStorage
@@ -1431,19 +1245,7 @@ export const MyComp = createInteractiveComposition<MyCompProps>({
 
 ### Legacy Manual Pattern (Removed)
 
-**⚠️ The legacy manual pattern has been completely removed from the codebase.**
-
-The old manual registration pattern required:
-
-- 6-8 imports per composition
-- Manual `getCursorType()` calls for reactive cursor types
-- Manual `useHoverAnimationSmooth()` + `useRegisterInteractiveElement()` for each element
-- Manual cursor type aggregation with `useCursorTypeFromHover()`
-- Manual `<CameraHost>` wrapper
-
-This resulted in 729 lines for a 6-card interactive composition.
-
-**For all new code:** Use `createInteractiveComposition()` (145 lines) or `useInteractiveComponent()` (177 lines) patterns instead.
+The old manual registration pattern has been removed from the codebase. For all new code use `createInteractiveComposition()` or `useInteractiveComponent()` (see the Recommended Patterns above).
 
 ### User Workflow
 
@@ -1641,8 +1443,6 @@ All code in this project must be TypeScript (`.ts`). Never create `.js`, `.cjs`,
 ### Icons
 
 - **Never use the Sparkles icon** — it is reserved and must not be used anywhere in the UI.
-
-### Agent Chat Integration
 
 ---
 


### PR DESCRIPTION
## Why

Follow-on to the agent-run reliability work already merged to main (lossless continuation via `turnId` fold, 40s soft-timeout headroom + clamp, errored-run capture). Browser testing surfaced a separate, severe issue: the agent chat could hard-error with `context_length_exceeded` on even a one-word "hi" message, and had very high time-to-first-token.

## Root cause

The `<current-screen>` block — the template's `view-screen` output — is rebuilt and appended to **every** user message, **uncapped**. On a recording/meeting page it embeds the full transcript + every word-level segment (pretty-printed), which can exceed the model context window by itself and is re-sent on every turn. (Confirmed by audit: the static system prompt was only ~25K tokens; the overflow came entirely from this uncapped per-message injection. The 1.3GB of base64 video in `application_state` is a separate issue and is *not* injected.)

## Changes

- **Cap per-message screen context** (`production-agent.ts`): `<current-screen>` is bounded to ~24K chars with a note pointing the agent at `view-screen` / data actions for full detail. Framework-level, so it protects every template.
- **Lean clips `view-screen`**: returns a transcript *snippet* + segment count instead of the entire transcript + all segments (mirrors the existing `meeting` view). The agent calls `get-recording-player-data` for the full transcript on demand.
- **Trim oversized template AGENTS.md** (part of the system prompt every message): conservatively removed agent-irrelevant keyboard-shortcut tables, condensed ASCII architecture diagrams to prose, and replaced skill-duplicative narrative with skill pointers. Action/API tables, schemas, application-state tables, rules, and template-specific gotchas kept intact.

## Testing

- `pnpm prep` green (typecheck + full test suite + guards).
- Browser-verified in clips: chat answers fast with **no** `context_length_exceeded` and still has useful screen context from the now-lean snapshot.

## Follow-ups (not in this PR)

- Builder gateway prompt caching: `builder-engine.ts` has `promptCaching: false` (cache_control not forwarded to the gateway), so the static system prompt is re-processed every message on the hosted default path. Direct-Anthropic / AI-SDK paths already cache. Enabling gateway caching needs gateway-side coordination.
- Deeper AGENTS.md restructuring for `design`/`analytics` (move inline templates / exhaustive action tables into skills).
- Move recording video blobs/chunks out of `application_state` into object storage.