### PR TITLE
Improve template picker and recording UX

### DIFF
--- a/.changeset/auth-signup-open-source-copy.md
+++ b/.changeset/auth-signup-open-source-copy.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Update signup marketing copy to say Agent Native is 100% free and open source.

--- a/packages/core/src/client/PoweredByBadge.tsx
+++ b/packages/core/src/client/PoweredByBadge.tsx
@@ -183,6 +183,9 @@ export function OpenSourceBadge({
           border-color: transparent !important;
           backdrop-filter: none !important;
           -webkit-backdrop-filter: none !important;
+          color: #00B5FF !important;
+          font-weight: 600 !important;
+          opacity: 0.95 !important;
         }
         @media (max-width: 640px) {
           .an-open-source-badge {
@@ -193,30 +196,30 @@ export function OpenSourceBadge({
           }
         }
         .dark .an-open-source-badge {
-          color: rgba(215, 215, 215, 0.94) !important;
+          color: #00B5FF !important;
         }
         @media ${darkQuery} {
           .an-open-source-badge {
-            color: rgba(215, 215, 215, 0.94) !important;
+            color: #00B5FF !important;
           }
         }
         .light .an-open-source-badge {
-          color: rgba(95, 95, 95, 0.95) !important;
+          color: #00B5FF !important;
         }
         .an-open-source-badge:hover {
           opacity: 1 !important;
-          color: rgba(70, 70, 70, 1) !important;
+          color: #33C4FF !important;
         }
         @media ${darkQuery} {
           .an-open-source-badge:hover {
-            color: rgba(238, 238, 238, 1) !important;
+            color: #33C4FF !important;
           }
         }
         .dark .an-open-source-badge:hover {
-          color: rgba(238, 238, 238, 1) !important;
+          color: #33C4FF !important;
         }
         .light .an-open-source-badge:hover {
-          color: rgba(70, 70, 70, 1) !important;
+          color: #33C4FF !important;
         }
       `}</style>
       <a

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -86,6 +86,7 @@ describe("getOnboardingHtml", () => {
     expect(html).toContain(
       "Your AI agent manages secrets, orchestrates other agents",
     );
+    expect(html).toContain("100% free and open source");
   });
 
   it("has branded auth marketing for every core built-in template host", () => {

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -243,10 +243,12 @@ ${googleNoticeBodyHtml}
     align-items: center;
     gap: 0.375rem;
     font-size: 0.8125rem;
-    color: #71717a;
+    font-weight: 600;
+    color: #00B5FF;
     text-decoration: none;
+    transition: color 0.15s ease;
   }
-  .oss-link:hover { color: #a1a1aa; }
+  .oss-link:hover { color: #33C4FF; }
   .oss-link svg { width: 15px; height: 15px; flex-shrink: 0; }
   .marketing-actions {
     display: flex;
@@ -344,7 +346,7 @@ ${marketing!.description ? `      <p class="app-desc">${esc(marketing!.descripti
       }      <div class="marketing-actions">
 ${runLocalCommand ? `        <button type="button" class="run-local-button" id="run-local-button" aria-expanded="false" aria-controls="run-local-panel" onclick="__anToggleRunLocalCommand()">Run Locally</button>\n` : ""}        <a class="oss-link" href="https://github.com/BuilderIO/agent-native" target="_blank" rel="noreferrer">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-4.3 1.4-4.3-2.5-6-3m12 5v-3.5c0-1 .1-1.4-.5-2 2.8-.3 5.5-1.4 5.5-6a4.6 4.6 0 00-1.3-3.2 4.2 4.2 0 00-.1-3.2s-1.1-.3-3.5 1.3a12.3 12.3 0 00-6.2 0C6.5 2.8 5.4 3.1 5.4 3.1a4.2 4.2 0 00-.1 3.2A4.6 4.6 0 004 9.5c0 4.6 2.7 5.7 5.5 6-.6.6-.6 1.2-.5 2V21"/></svg>
-        Open source
+        100% free and open source
       </a>
       </div>
 ${

--- a/templates/assets/AGENTS.md
+++ b/templates/assets/AGENTS.md
@@ -16,7 +16,7 @@ Detailed library, generation, image, embed, and engine rules live in
   ad hoc provider calls when the app has an action/engine abstraction.
 - Preserve provenance and metadata for generated or imported assets.
 - Use `view-screen` when the active library, selected asset, picker, generation,
-  or embed target is unclear.
+  or embed target is unclear. The picker is also available from the left nav.
 - Keep inline previews and picker outputs lightweight; fetch full asset details
   through actions when needed.
 - Use framework sharing/collaboration primitives for ownable assets.
@@ -24,8 +24,10 @@ Detailed library, generation, image, embed, and engine rules live in
 ## Application State
 
 - `navigation` exposes library, asset, generation, picker, embed, and selection
-  context.
-- `navigate` moves the UI to library, generation, asset, and settings surfaces.
+  context. Picker state includes media type, selected library, query, prompt, and
+  aspect ratio when available.
+- `navigate` moves the UI to picker, library, generation, asset, and settings
+  surfaces.
 
 ## Skills
 

--- a/templates/assets/actions/_helpers.test.ts
+++ b/templates/assets/actions/_helpers.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { assetUrls } from "./_helpers.js";
+import {
+  assetUrls,
+  buildAssetLineage,
+  serializeGenerationSessionItems,
+} from "./_helpers.js";
 
 const ORIGINAL_ENV = {
   APP_BASE_PATH: process.env.APP_BASE_PATH,
@@ -71,5 +75,98 @@ describe("assetUrls", () => {
     expect(urls.thumbnailUrl).toBe(
       "/assets/api/assets/asset-1/content?variant=thumb",
     );
+  });
+});
+
+describe("asset lineage labels", () => {
+  const rows = [
+    {
+      id: "asset-a",
+      role: "generated",
+      generationRunId: "run-a",
+      metadata: JSON.stringify({ generated: true }),
+      createdAt: "2026-05-28T00:00:00.000Z",
+    },
+    {
+      id: "asset-b",
+      role: "generated",
+      generationRunId: "run-b",
+      metadata: JSON.stringify({ generated: true }),
+      createdAt: "2026-05-28T00:01:00.000Z",
+    },
+    {
+      id: "asset-b1",
+      role: "generated",
+      generationRunId: "run-b1",
+      metadata: JSON.stringify({
+        generated: true,
+        sourceAssetId: "asset-b",
+      }),
+      createdAt: "2026-05-28T00:02:00.000Z",
+    },
+    {
+      id: "asset-b2",
+      role: "generated",
+      generationRunId: "run-b2",
+      metadata: JSON.stringify({
+        generated: true,
+        sourceAssetId: "asset-b",
+      }),
+      createdAt: "2026-05-28T00:03:00.000Z",
+    },
+  ];
+
+  it("labels originals and variations with stable serials", () => {
+    const lineage = buildAssetLineage(rows);
+
+    expect(lineage.get("asset-a")).toMatchObject({
+      kind: "original",
+      label: "Original 1",
+      serial: 1,
+    });
+    expect(lineage.get("asset-b")).toMatchObject({
+      kind: "original",
+      label: "Original 2",
+      serial: 2,
+    });
+    expect(lineage.get("asset-b2")).toMatchObject({
+      kind: "variation",
+      label: "Variation 2",
+      serial: 2,
+      sourceAssetId: "asset-b",
+      sourceLabel: "Original 2",
+    });
+  });
+
+  it("uses lineage labels in ordered session summaries", () => {
+    const lineage = buildAssetLineage(rows);
+    const items = serializeGenerationSessionItems(
+      [
+        {
+          id: "item-b2",
+          sessionId: "session-1",
+          assetId: "asset-b2",
+          generationRunId: "run-b2",
+          role: "candidate",
+          sortOrder: 100,
+          createdAt: "2026-05-28T00:03:00.000Z",
+        },
+        {
+          id: "item-b",
+          sessionId: "session-1",
+          assetId: "asset-b",
+          generationRunId: "run-b",
+          role: "active",
+          sortOrder: 0,
+          createdAt: "2026-05-28T00:01:00.000Z",
+        },
+      ],
+      lineage,
+    );
+
+    expect(items.map((item) => item.label)).toEqual([
+      "Original 2",
+      "Variation 2",
+    ]);
   });
 });

--- a/templates/assets/actions/_helpers.ts
+++ b/templates/assets/actions/_helpers.ts
@@ -3,6 +3,8 @@ import { getDb, schema } from "../server/db/index.js";
 import { resolveAccess } from "@agent-native/core/sharing";
 import { absoluteUrl, parseJson } from "../server/lib/json.js";
 import type {
+  AssetLineageSummary,
+  GenerationSessionItemSummary,
   GenerationPresetSummary,
   GenerationSessionSummary,
   ImageAssetMetadata,
@@ -161,6 +163,12 @@ export function serializeGenerationPreset(row: any): GenerationPresetSummary {
 }
 
 export function serializeGenerationSession(row: any): GenerationSessionSummary {
+  const items = Array.isArray(row.items)
+    ? (row.items as GenerationSessionItemSummary[])
+    : undefined;
+  const variationCount =
+    items?.filter((item) => item.lineage?.kind === "variation").length ?? 0;
+  const assetCount = items?.filter((item) => item.assetId).length ?? 0;
   return {
     id: row.id,
     libraryId: row.libraryId,
@@ -175,10 +183,159 @@ export function serializeGenerationSession(row: any): GenerationSessionSummary {
     createdBy: row.createdBy ?? null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+    ...(items
+      ? {
+          items,
+          itemCount: items.length,
+          assetCount,
+          variationCount,
+        }
+      : {}),
   };
 }
 
-export function serializeAsset(row: any) {
+type AssetRowForLineage = {
+  id: string;
+  role?: string | null;
+  generationRunId?: string | null;
+  metadata?: string | null;
+  createdAt?: string | null;
+};
+
+function assetSourceId(metadata: ImageAssetMetadata): string | null {
+  if (typeof metadata.sourceAssetId === "string" && metadata.sourceAssetId) {
+    return metadata.sourceAssetId;
+  }
+  return typeof metadata.subjectAssetId === "string" && metadata.subjectAssetId
+    ? metadata.subjectAssetId
+    : null;
+}
+
+function assetCreatedAtMs(row: AssetRowForLineage): number {
+  if (!row.createdAt) return 0;
+  const time = Date.parse(row.createdAt);
+  return Number.isNaN(time) ? 0 : time;
+}
+
+function compareAssetsByCreation(
+  left: { row: AssetRowForLineage },
+  right: { row: AssetRowForLineage },
+): number {
+  return (
+    assetCreatedAtMs(left.row) - assetCreatedAtMs(right.row) ||
+    String(left.row.generationRunId ?? "").localeCompare(
+      String(right.row.generationRunId ?? ""),
+    ) ||
+    left.row.id.localeCompare(right.row.id)
+  );
+}
+
+function compactAssetId(id: string): string {
+  return id.length > 8 ? `${id.slice(0, 4)}...${id.slice(-4)}` : id;
+}
+
+export function buildAssetLineage(
+  rows: AssetRowForLineage[],
+): Map<string, AssetLineageSummary> {
+  const generatedAssets = rows
+    .map((row) => ({
+      row,
+      metadata: parseJson<ImageAssetMetadata>(row.metadata, {}),
+    }))
+    .filter(
+      ({ row, metadata }) =>
+        row.role === "generated" ||
+        metadata.generated === true ||
+        Boolean(row.generationRunId),
+    )
+    .sort(compareAssetsByCreation);
+  const lineageByAssetId = new Map<string, AssetLineageSummary>();
+  const variationCountsBySource = new Map<string, number>();
+  let originalCount = 0;
+
+  for (const item of generatedAssets) {
+    const sourceAssetId = assetSourceId(item.metadata);
+    if (sourceAssetId) {
+      const serial = (variationCountsBySource.get(sourceAssetId) ?? 0) + 1;
+      variationCountsBySource.set(sourceAssetId, serial);
+      lineageByAssetId.set(item.row.id, {
+        kind: "variation",
+        serial,
+        label: `Variation ${serial}`,
+        sourceAssetId,
+        sourceLabel:
+          lineageByAssetId.get(sourceAssetId)?.label ??
+          compactAssetId(sourceAssetId),
+      });
+      continue;
+    }
+
+    originalCount += 1;
+    lineageByAssetId.set(item.row.id, {
+      kind: "original",
+      serial: originalCount,
+      label: `Original ${originalCount}`,
+      sourceAssetId: null,
+      sourceLabel: null,
+    });
+  }
+
+  return lineageByAssetId;
+}
+
+export function serializeAssets(rows: any[]) {
+  const lineageByAssetId = buildAssetLineage(rows);
+  return rows.map((row) =>
+    serializeAsset(row, lineageByAssetId.get(row.id) ?? null),
+  );
+}
+
+export function serializeGenerationSessionItems(
+  items: any[],
+  lineageByAssetId = new Map<string, AssetLineageSummary>(),
+): GenerationSessionItemSummary[] {
+  let assetCount = 0;
+  let runCount = 0;
+  return [...items]
+    .sort(
+      (left, right) =>
+        Number(left.sortOrder ?? 0) - Number(right.sortOrder ?? 0) ||
+        String(left.createdAt ?? "").localeCompare(
+          String(right.createdAt ?? ""),
+        ) ||
+        String(left.id ?? "").localeCompare(String(right.id ?? "")),
+    )
+    .map((item) => {
+      const lineage = item.assetId
+        ? (lineageByAssetId.get(item.assetId) ?? null)
+        : null;
+      if (item.assetId) assetCount += 1;
+      if (!item.assetId && item.generationRunId) runCount += 1;
+      return {
+        id: item.id,
+        assetId: item.assetId ?? null,
+        generationRunId: item.generationRunId ?? null,
+        role: item.role ?? "candidate",
+        sortOrder: Number(item.sortOrder ?? 0),
+        createdAt: item.createdAt,
+        label:
+          lineage?.label ??
+          (item.assetId
+            ? item.role === "active" && assetCount === 1
+              ? "Original"
+              : `Candidate ${assetCount}`
+            : `Run ${runCount}`),
+        lineage,
+      };
+    });
+}
+
+export function serializeAsset(
+  row: any,
+  lineageOrIndex: AssetLineageSummary | null | number = null,
+) {
+  const lineage =
+    typeof lineageOrIndex === "number" ? null : (lineageOrIndex ?? null);
   const metadata = parseJson<ImageAssetMetadata>(row.metadata, {});
   return {
     id: row.id,
@@ -204,6 +361,7 @@ export function serializeAsset(row: any) {
     sourceUrl: row.sourceUrl,
     generationRunId: row.generationRunId,
     metadata,
+    lineage,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     ...assetUrls(row),

--- a/templates/assets/actions/get-asset.ts
+++ b/templates/assets/actions/get-asset.ts
@@ -1,6 +1,12 @@
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
-import { getAssetOrThrow, serializeAsset } from "./_helpers.js";
+import { eq } from "drizzle-orm";
+import { getDb, schema } from "../server/db/index.js";
+import {
+  buildAssetLineage,
+  getAssetOrThrow,
+  serializeAsset,
+} from "./_helpers.js";
 
 export default defineAction({
   description:
@@ -8,5 +14,13 @@ export default defineAction({
   schema: z.object({ id: z.string() }),
   http: { method: "GET" },
   readOnly: true,
-  run: async ({ id }) => serializeAsset(await getAssetOrThrow(id)),
+  run: async ({ id }) => {
+    const asset = await getAssetOrThrow(id);
+    const libraryAssets = await getDb()
+      .select()
+      .from(schema.assets)
+      .where(eq(schema.assets.libraryId, asset.libraryId));
+    const lineageById = buildAssetLineage(libraryAssets);
+    return serializeAsset(asset, lineageById.get(asset.id) ?? null);
+  },
 });

--- a/templates/assets/actions/get-generation-session.ts
+++ b/templates/assets/actions/get-generation-session.ts
@@ -1,6 +1,6 @@
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
-import { eq, inArray } from "drizzle-orm";
+import { asc, eq, inArray } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
 import {
   requireLibrary,
@@ -29,7 +29,11 @@ export default defineAction({
     const items = await db
       .select()
       .from(schema.assetGenerationSessionItems)
-      .where(eq(schema.assetGenerationSessionItems.sessionId, id));
+      .where(eq(schema.assetGenerationSessionItems.sessionId, id))
+      .orderBy(
+        asc(schema.assetGenerationSessionItems.sortOrder),
+        asc(schema.assetGenerationSessionItems.createdAt),
+      );
     const assetIds = [
       ...new Set(
         items

--- a/templates/assets/actions/get-library.ts
+++ b/templates/assets/actions/get-library.ts
@@ -4,7 +4,7 @@ import { desc, eq } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
 import {
   requireLibrary,
-  serializeAsset,
+  serializeAssets,
   serializeGenerationRun,
   serializeLibrary,
 } from "./_helpers.js";
@@ -44,7 +44,7 @@ export default defineAction({
       library: serializeLibrary(library),
       collections,
       folders,
-      assets: assets.map(serializeAsset),
+      assets: serializeAssets(assets),
       runs: runs.map(serializeGenerationRun),
     };
   },

--- a/templates/assets/actions/list-assets.ts
+++ b/templates/assets/actions/list-assets.ts
@@ -2,7 +2,11 @@ import { defineAction } from "@agent-native/core";
 import { z } from "zod";
 import { and, desc, eq, isNull } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
-import { requireLibrary, serializeAsset } from "./_helpers.js";
+import {
+  buildAssetLineage,
+  requireLibrary,
+  serializeAsset,
+} from "./_helpers.js";
 import { ASSET_MEDIA_TYPES, IMAGE_CATEGORIES } from "../shared/api.js";
 import { parseJson } from "../server/lib/json.js";
 
@@ -46,11 +50,19 @@ export default defineAction({
     if (status) filters.push(eq(schema.assets.status, status));
     if (role) filters.push(eq(schema.assets.role, role));
     const normalizedQuery = query?.trim().toLowerCase();
-    const rows = await getDb()
-      .select()
-      .from(schema.assets)
-      .where(and(...filters))
-      .orderBy(desc(schema.assets.createdAt));
+    const db = getDb();
+    const [rows, lineageRows] = await Promise.all([
+      db
+        .select()
+        .from(schema.assets)
+        .where(and(...filters))
+        .orderBy(desc(schema.assets.createdAt)),
+      db
+        .select()
+        .from(schema.assets)
+        .where(eq(schema.assets.libraryId, libraryId)),
+    ]);
+    const lineageById = buildAssetLineage(lineageRows);
     const assets = rows
       .filter((asset) => {
         const metadata = parseJson<Record<string, unknown>>(asset.metadata, {});
@@ -75,7 +87,7 @@ export default defineAction({
           .toLowerCase();
         return searchable.includes(normalizedQuery);
       })
-      .map(serializeAsset);
+      .map((asset) => serializeAsset(asset, lineageById.get(asset.id) ?? null));
     return { count: assets.length, assets };
   },
 });

--- a/templates/assets/actions/list-generation-sessions.ts
+++ b/templates/assets/actions/list-generation-sessions.ts
@@ -1,8 +1,13 @@
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
-import { and, desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
-import { requireLibrary, serializeGenerationSession } from "./_helpers.js";
+import {
+  buildAssetLineage,
+  requireLibrary,
+  serializeGenerationSession,
+  serializeGenerationSessionItems,
+} from "./_helpers.js";
 import { GENERATION_SESSION_STATUSES } from "../shared/api.js";
 
 export default defineAction({
@@ -19,15 +24,57 @@ export default defineAction({
     await requireLibrary(libraryId);
     const filters = [eq(schema.assetGenerationSessions.libraryId, libraryId)];
     if (status) filters.push(eq(schema.assetGenerationSessions.status, status));
-    const sessions = await getDb()
+    const db = getDb();
+    const sessions = await db
       .select()
       .from(schema.assetGenerationSessions)
       .where(and(...filters))
       .orderBy(desc(schema.assetGenerationSessions.updatedAt))
       .limit(Math.min(Math.max(limit, 1), 100));
+    const sessionIds = sessions.map((session) => session.id);
+    const items = sessionIds.length
+      ? await db
+          .select()
+          .from(schema.assetGenerationSessionItems)
+          .where(
+            inArray(schema.assetGenerationSessionItems.sessionId, sessionIds),
+          )
+          .orderBy(
+            asc(schema.assetGenerationSessionItems.sortOrder),
+            asc(schema.assetGenerationSessionItems.createdAt),
+          )
+      : [];
+    const itemAssetIds = [
+      ...new Set(
+        items
+          .map((item) => item.assetId)
+          .filter((assetId): assetId is string => Boolean(assetId)),
+      ),
+    ];
+    const assetRows = itemAssetIds.length
+      ? await db
+          .select()
+          .from(schema.assets)
+          .where(inArray(schema.assets.id, itemAssetIds))
+      : [];
+    const lineageById = buildAssetLineage(assetRows);
+    const itemsBySessionId = new Map<string, typeof items>();
+    for (const item of items) {
+      const sessionItems = itemsBySessionId.get(item.sessionId) ?? [];
+      sessionItems.push(item);
+      itemsBySessionId.set(item.sessionId, sessionItems);
+    }
     return {
       count: sessions.length,
-      sessions: sessions.map(serializeGenerationSession),
+      sessions: sessions.map((session) =>
+        serializeGenerationSession({
+          ...session,
+          items: serializeGenerationSessionItems(
+            itemsBySessionId.get(session.id) ?? [],
+            lineageById,
+          ),
+        }),
+      ),
     };
   },
 });

--- a/templates/assets/actions/navigate.ts
+++ b/templates/assets/actions/navigate.ts
@@ -4,11 +4,12 @@ import { z } from "zod";
 
 export default defineAction({
   description:
-    "Navigate the Assets UI. Views: create, libraries, library, asset, generation-session, generation-run, extensions, audit, settings. Use libraryId, assetId, sessionId, runId, or extensionId where appropriate.",
+    "Navigate the Assets UI. Views: create, picker, libraries, library, asset, generation-session, generation-run, extensions, audit, settings. Use libraryId, assetId, sessionId, runId, or extensionId where appropriate.",
   schema: z.object({
     view: z
       .enum([
         "create",
+        "picker",
         "libraries",
         "library",
         "asset",
@@ -25,6 +26,10 @@ export default defineAction({
     sessionId: z.string().optional(),
     runId: z.string().optional(),
     presetId: z.string().optional(),
+    mediaType: z.enum(["image", "video"]).optional(),
+    query: z.string().optional(),
+    prompt: z.string().optional(),
+    aspectRatio: z.string().optional(),
     activeTab: z
       .enum(["references", "generated", "runs", "settings"])
       .optional(),

--- a/templates/assets/actions/search-assets.ts
+++ b/templates/assets/actions/search-assets.ts
@@ -4,7 +4,11 @@ import { and, desc, eq, inArray } from "drizzle-orm";
 import { accessFilter } from "@agent-native/core/sharing";
 import { getDb, schema } from "../server/db/index.js";
 import { parseJson } from "../server/lib/json.js";
-import { requireLibrary, serializeAsset } from "./_helpers.js";
+import {
+  buildAssetLineage,
+  requireLibrary,
+  serializeAsset,
+} from "./_helpers.js";
 import { ASSET_MEDIA_TYPES, IMAGE_CATEGORIES } from "../shared/api.js";
 
 export default defineAction({
@@ -37,11 +41,18 @@ export default defineAction({
     const filters = [inArray(schema.assets.libraryId, libraryIds)];
     if (mediaType) filters.push(eq(schema.assets.mediaType, mediaType));
     const normalizedQuery = query.trim().toLowerCase();
-    const rows = await db
-      .select()
-      .from(schema.assets)
-      .where(and(...filters))
-      .orderBy(desc(schema.assets.updatedAt));
+    const [rows, lineageRows] = await Promise.all([
+      db
+        .select()
+        .from(schema.assets)
+        .where(and(...filters))
+        .orderBy(desc(schema.assets.updatedAt)),
+      db
+        .select()
+        .from(schema.assets)
+        .where(inArray(schema.assets.libraryId, libraryIds)),
+    ]);
+    const lineageById = buildAssetLineage(lineageRows);
 
     const assets = rows
       .filter((asset) => {
@@ -67,7 +78,7 @@ export default defineAction({
         return searchable.includes(normalizedQuery);
       })
       .slice(0, limit)
-      .map(serializeAsset);
+      .map((asset) => serializeAsset(asset, lineageById.get(asset.id) ?? null));
 
     return { count: assets.length, assets };
   },

--- a/templates/assets/actions/view-screen.ts
+++ b/templates/assets/actions/view-screen.ts
@@ -5,9 +5,11 @@ import getLibrary from "./get-library.js";
 import getAsset from "./get-asset.js";
 import getGenerationSession from "./get-generation-session.js";
 import getGenerationRun from "./get-generation-run.js";
+import listAssets from "./list-assets.js";
 import listGenerationPresets from "./list-generation-presets.js";
 import listGenerationSessions from "./list-generation-sessions.js";
 import listAuditRuns from "./list-audit-runs.js";
+import listLibraries from "./list-libraries.js";
 
 export default defineAction({
   description:
@@ -48,6 +50,22 @@ export default defineAction({
       screen.generationRun = await getGenerationRun.run({
         runId: nav.runId,
       });
+    }
+    if (nav?.view === "picker") {
+      screen.libraries = await listLibraries.run({ compact: true });
+      if (nav.libraryId) {
+        screen.assets = await listAssets.run({
+          libraryId: nav.libraryId,
+          mediaType:
+            nav.mediaType === "image" || nav.mediaType === "video"
+              ? nav.mediaType
+              : undefined,
+          query:
+            typeof nav.query === "string" && nav.query.trim()
+              ? nav.query
+              : undefined,
+        });
+      }
     }
     if (nav?.view === "audit") {
       screen.audit = await listAuditRuns.run({ limit: 20 });

--- a/templates/assets/app/components/layout/Header.tsx
+++ b/templates/assets/app/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import { AgentToggleButton } from "@agent-native/core/client";
 
 const pageTitles: Record<string, string> = {
   "/": "Create",
+  "/picker": "Picker",
   "/libraries": "Libraries",
   "/extensions": "Extensions",
   "/settings": "Settings",

--- a/templates/assets/app/components/layout/Layout.tsx
+++ b/templates/assets/app/components/layout/Layout.tsx
@@ -13,6 +13,15 @@ interface LayoutProps {
   children: React.ReactNode;
 }
 
+function isEmbeddedWindow() {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.self !== window.top;
+  } catch {
+    return true;
+  }
+}
+
 export function Layout({ children }: LayoutProps) {
   useNavigationState();
   const location = useLocation();
@@ -22,12 +31,13 @@ export function Layout({ children }: LayoutProps) {
     setMobileSidebarOpen(false);
   }, [location.pathname]);
 
+  const isPicker = location.pathname === "/picker";
   const hideHeader =
     location.pathname === "/picker" ||
     location.pathname === "/extensions" ||
     location.pathname.startsWith("/extensions/");
   const chromeless =
-    location.pathname === "/picker" || location.pathname.endsWith("/embed");
+    (isPicker && isEmbeddedWindow()) || location.pathname.endsWith("/embed");
 
   if (chromeless) {
     return (
@@ -81,7 +91,7 @@ export function Layout({ children }: LayoutProps) {
             </div>
             {!hideHeader && <Header />}
             <InvitationBanner />
-            <main className="flex-1 overflow-y-auto">{children}</main>
+            <main className="min-h-0 flex-1 overflow-y-auto">{children}</main>
           </div>
         </div>
       </AgentSidebar>

--- a/templates/assets/app/components/layout/Sidebar.tsx
+++ b/templates/assets/app/components/layout/Sidebar.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from "react-router";
 import {
   IconPhoto,
   IconLibraryPhoto,
+  IconPhotoSearch,
   IconSettings,
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
@@ -24,6 +25,7 @@ import {
 
 const baseNavItems = [
   { icon: IconPhoto, label: "Create", href: "/" },
+  { icon: IconPhotoSearch, label: "Picker", href: "/picker" },
   { icon: IconLibraryPhoto, label: "Libraries", href: "/libraries" },
   { icon: IconSettings, label: "Settings", href: "/settings" },
 ];

--- a/templates/assets/app/hooks/use-navigation-state.ts
+++ b/templates/assets/app/hooks/use-navigation-state.ts
@@ -3,7 +3,12 @@ import { useLocation, useNavigate } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { agentNativePath } from "@agent-native/core/client";
 
-function navigationFromPath(pathname: string) {
+function optionalParam(params: URLSearchParams, key: string) {
+  const value = params.get(key)?.trim();
+  return value ? value : undefined;
+}
+
+function navigationFromPath(pathname: string, search = "") {
   const library = pathname.match(/^\/library\/([^/]+)/);
   if (library) return { view: "library", libraryId: library[1] };
   const asset = pathname.match(/^\/asset\/([^/]+)/);
@@ -11,6 +16,22 @@ function navigationFromPath(pathname: string) {
   const image = pathname.match(/^\/image\/([^/]+)/);
   if (image) return { view: "asset", assetId: image[1] };
   if (pathname === "/") return { view: "create" };
+  if (pathname === "/picker") {
+    const params = new URLSearchParams(search);
+    return {
+      view: "picker",
+      mediaType:
+        params.get("mediaType") === "video"
+          ? "video"
+          : params.get("mediaType") === "image"
+            ? "image"
+            : undefined,
+      libraryId: optionalParam(params, "libraryId"),
+      query: optionalParam(params, "q"),
+      prompt: optionalParam(params, "prompt"),
+      aspectRatio: optionalParam(params, "aspectRatio"),
+    };
+  }
   if (pathname === "/libraries") return { view: "libraries" };
   if (pathname === "/extensions") return { view: "extensions" };
   const extension = pathname.match(/^\/extensions\/([^/]+)/);
@@ -42,6 +63,26 @@ function pathFromCommand(command: any): string | null {
   if (command.view === "audit") return "/audit";
   if (command.view === "settings") return "/settings";
   if (command.view === "create") return "/";
+  if (command.view === "picker") {
+    const params = new URLSearchParams();
+    if (command.mediaType === "image" || command.mediaType === "video") {
+      params.set("mediaType", command.mediaType);
+    }
+    if (typeof command.libraryId === "string" && command.libraryId.trim()) {
+      params.set("libraryId", command.libraryId.trim());
+    }
+    if (typeof command.query === "string" && command.query.trim()) {
+      params.set("q", command.query.trim());
+    }
+    if (typeof command.prompt === "string" && command.prompt.trim()) {
+      params.set("prompt", command.prompt.trim());
+    }
+    if (typeof command.aspectRatio === "string" && command.aspectRatio.trim()) {
+      params.set("aspectRatio", command.aspectRatio.trim());
+    }
+    const query = params.toString();
+    return query ? `/picker?${query}` : "/picker";
+  }
   if (command.view === "libraries") return "/libraries";
   if (command.view === "extensions" && command.extensionId) {
     return `/extensions/${command.extensionId}`;
@@ -61,9 +102,11 @@ export function useNavigationState() {
         "content-type": "application/json",
         "x-request-source": "assets-ui",
       },
-      body: JSON.stringify(navigationFromPath(location.pathname)),
+      body: JSON.stringify(
+        navigationFromPath(location.pathname, location.search),
+      ),
     }).catch(() => {});
-  }, [location.pathname]);
+  }, [location.pathname, location.search]);
 
   const { data: command } = useQuery({
     queryKey: ["app-state", "navigate"],

--- a/templates/assets/app/routes/library.$id.tsx
+++ b/templates/assets/app/routes/library.$id.tsx
@@ -576,6 +576,7 @@ export default function LibraryPage() {
       </div>
     );
   }
+  const assetById = new Map(assets.map((asset) => [asset.id, asset]));
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -891,6 +892,7 @@ export default function LibraryPage() {
                   <RunCard
                     key={run.id}
                     run={run}
+                    outputAssets={assetById}
                     rerunning={
                       rerunGeneration.isPending || refreshGeneration.isPending
                     }
@@ -1149,11 +1151,13 @@ function formatBrandAnalysisTime(value: unknown): string {
 
 function RunCard({
   run,
+  outputAssets,
   onRerun,
   onCreateHandoff,
   rerunning,
 }: {
   run: any;
+  outputAssets?: Map<string, any>;
   onRerun: () => void;
   onCreateHandoff: () => void;
   rerunning?: boolean;
@@ -1276,17 +1280,22 @@ function RunCard({
           </div>
           {outputIds.length ? (
             <div className="mt-2 flex flex-wrap gap-2">
-              {outputIds.map((assetId) => (
-                <Button
-                  key={assetId}
-                  asChild
-                  size="sm"
-                  variant="outline"
-                  className="h-7 px-2 text-xs"
-                >
-                  <Link to={`/asset/${assetId}`}>{shortId(assetId)}</Link>
-                </Button>
-              ))}
+              {outputIds.map((assetId) => {
+                const outputAsset = outputAssets?.get(assetId);
+                return (
+                  <Button
+                    key={assetId}
+                    asChild
+                    size="sm"
+                    variant="outline"
+                    className="h-7 px-2 text-xs"
+                  >
+                    <Link to={`/asset/${assetId}`}>
+                      {assetLineageLabel(outputAsset) ?? shortId(assetId)}
+                    </Link>
+                  </Button>
+                );
+              })}
             </div>
           ) : (
             <p className="mt-2 text-xs text-muted-foreground">
@@ -1337,6 +1346,29 @@ function RunFact({ label, value }: { label: string; value: string }) {
   );
 }
 
+function assetLineageLabel(asset: any): string | null {
+  return typeof asset?.lineage?.label === "string" && asset.lineage.label
+    ? asset.lineage.label
+    : null;
+}
+
+function assetDisplayTitle(asset: any): string {
+  return (
+    assetLineageLabel(asset) ||
+    asset.title ||
+    asset.metadata?.category ||
+    asset.status ||
+    "Asset"
+  );
+}
+
+function assetLineageSourceText(asset: any): string | null {
+  const lineage = asset?.lineage;
+  return lineage?.kind === "variation" && lineage.sourceLabel
+    ? `from ${lineage.sourceLabel}`
+    : null;
+}
+
 function shortId(id: string) {
   return id.length > 12 ? `${id.slice(0, 6)}...${id.slice(-4)}` : id;
 }
@@ -1362,6 +1394,8 @@ function SessionCard({
   onContinue: () => void;
 }) {
   const preset = presets.find((item) => item.id === session.presetId);
+  const sessionItems = Array.isArray(session.items) ? session.items : [];
+  const assetItems = sessionItems.filter((item: any) => item.assetId);
   return (
     <article className="rounded-lg border border-border bg-background p-3">
       <div className="flex items-start justify-between gap-3">
@@ -1390,7 +1424,22 @@ function SessionCard({
       </div>
       <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
         {preset ? <Badge variant="secondary">{preset.title}</Badge> : null}
-        {session.activeAssetId ? (
+        {assetItems.slice(0, 4).map((item: any) => (
+          <Badge
+            key={item.id}
+            variant={
+              item.assetId === session.activeAssetId ? "secondary" : "outline"
+            }
+          >
+            {item.assetId === session.activeAssetId
+              ? `${item.label} active`
+              : item.label}
+          </Badge>
+        ))}
+        {assetItems.length > 4 ? (
+          <Badge variant="outline">+{assetItems.length - 4}</Badge>
+        ) : null}
+        {!assetItems.length && session.activeAssetId ? (
           <Badge variant="outline">
             active {shortId(session.activeAssetId)}
           </Badge>
@@ -2303,108 +2352,122 @@ function AssetGrid({
           {pendingUploads.map((upload) => (
             <PendingUploadCard key={upload.id} upload={upload} />
           ))}
-          {assets.map((asset) => (
-            <div
-              key={asset.id}
-              className={[
-                "group relative overflow-hidden rounded-lg border bg-card transition",
-                selectedIds.has(asset.id)
-                  ? "border-primary ring-2 ring-primary/25"
-                  : "border-border",
-              ].join(" ")}
-            >
-              <div className="absolute left-2 top-2 z-10">
-                <Checkbox
-                  checked={selectedIds.has(asset.id)}
-                  onCheckedChange={(checked) =>
-                    toggleAsset(asset.id, checked === true)
-                  }
-                  aria-label={`Select ${asset.title || asset.metadata?.category || "asset"}`}
-                  className={[
-                    "border-background bg-background/90 shadow-sm opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100",
-                    selectedIds.has(asset.id) ? "sm:opacity-100" : "",
-                  ].join(" ")}
-                />
-              </div>
-              <div className="absolute right-2 top-2 z-10">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      size="icon"
-                      className="h-8 w-8 shadow-sm opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100 data-[state=open]:opacity-100"
-                      aria-label="Asset actions"
-                    >
-                      <IconDotsVertical className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem asChild>
-                      <Link to={`/asset/${asset.id}`}>View details</Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuSub>
-                      <DropdownMenuSubTrigger>
-                        <IconFolder className="mr-2 h-4 w-4 shrink-0" />
-                        Move to
-                      </DropdownMenuSubTrigger>
-                      <DropdownMenuSubContent>
-                        <DropdownMenuItem
-                          onSelect={() =>
-                            updateAsset.mutate({ id: asset.id, folderId: null })
-                          }
-                        >
-                          Unfiled
-                        </DropdownMenuItem>
-                        {folders.map((folder) => (
+          {assets.map((asset) => {
+            const displayTitle = assetDisplayTitle(asset);
+            const sourceText = assetLineageSourceText(asset);
+            return (
+              <div
+                key={asset.id}
+                className={[
+                  "group relative overflow-hidden rounded-lg border bg-card transition",
+                  selectedIds.has(asset.id)
+                    ? "border-primary ring-2 ring-primary/25"
+                    : "border-border",
+                ].join(" ")}
+              >
+                <div className="absolute left-2 top-2 z-10">
+                  <Checkbox
+                    checked={selectedIds.has(asset.id)}
+                    onCheckedChange={(checked) =>
+                      toggleAsset(asset.id, checked === true)
+                    }
+                    aria-label={`Select ${displayTitle}`}
+                    className={[
+                      "border-background bg-background/90 shadow-sm opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100",
+                      selectedIds.has(asset.id) ? "sm:opacity-100" : "",
+                    ].join(" ")}
+                  />
+                </div>
+                <div className="absolute right-2 top-2 z-10">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="icon"
+                        className="h-8 w-8 shadow-sm opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100 data-[state=open]:opacity-100"
+                        aria-label="Asset actions"
+                      >
+                        <IconDotsVertical className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem asChild>
+                        <Link to={`/asset/${asset.id}`}>View details</Link>
+                      </DropdownMenuItem>
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger>
+                          <IconFolder className="mr-2 h-4 w-4 shrink-0" />
+                          Move to
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuSubContent>
                           <DropdownMenuItem
-                            key={folder.id}
                             onSelect={() =>
                               updateAsset.mutate({
                                 id: asset.id,
-                                folderId: folder.id,
+                                folderId: null,
                               })
                             }
                           >
-                            {folder.title}
+                            Unfiled
                           </DropdownMenuItem>
-                        ))}
-                      </DropdownMenuSubContent>
-                    </DropdownMenuSub>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      className="text-destructive focus:bg-destructive/10 focus:text-destructive"
-                      onSelect={() => confirmDelete([asset.id])}
-                    >
-                      <IconTrash className="mr-2 h-4 w-4 shrink-0" />
-                      Delete
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                          {folders.map((folder) => (
+                            <DropdownMenuItem
+                              key={folder.id}
+                              onSelect={() =>
+                                updateAsset.mutate({
+                                  id: asset.id,
+                                  folderId: folder.id,
+                                })
+                              }
+                            >
+                              {folder.title}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuSubContent>
+                      </DropdownMenuSub>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        className="text-destructive focus:bg-destructive/10 focus:text-destructive"
+                        onSelect={() => confirmDelete([asset.id])}
+                      >
+                        <IconTrash className="mr-2 h-4 w-4 shrink-0" />
+                        Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+                <Link to={`/asset/${asset.id}`} className="block outline-none">
+                  <div className="aspect-[4/3] bg-muted">
+                    <AssetPreview asset={asset} />
+                  </div>
+                  <div className="space-y-2 p-3">
+                    <div className="flex items-center gap-2 truncate text-xs font-medium">
+                      {asset.mediaType === "video" ? (
+                        <IconVideo className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      ) : (
+                        <IconPhoto className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      )}
+                      <span className="truncate">{displayTitle}</span>
+                    </div>
+                    {sourceText ? (
+                      <div className="truncate text-[11px] text-muted-foreground">
+                        {sourceText}
+                      </div>
+                    ) : null}
+                    <div className="flex items-center gap-2">
+                      <Badge variant="secondary">{asset.status}</Badge>
+                      {asset.metadata?.category && (
+                        <Badge variant="outline">
+                          {asset.metadata.category}
+                        </Badge>
+                      )}
+                    </div>
+                  </div>
+                </Link>
               </div>
-              <Link to={`/asset/${asset.id}`} className="block outline-none">
-                <div className="aspect-[4/3] bg-muted">
-                  <AssetPreview asset={asset} />
-                </div>
-                <div className="space-y-2 p-3">
-                  <div className="flex items-center gap-2 truncate text-xs font-medium">
-                    {asset.mediaType === "video" ? (
-                      <IconVideo className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                    ) : (
-                      <IconPhoto className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                    )}
-                    {asset.title || asset.metadata?.category || asset.status}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Badge variant="secondary">{asset.status}</Badge>
-                    {asset.metadata?.category && (
-                      <Badge variant="outline">{asset.metadata.category}</Badge>
-                    )}
-                  </div>
-                </div>
-              </Link>
-            </div>
-          ))}
+            );
+          })}
         </div>
       ) : (
         <div className="flex min-h-[320px] w-full flex-col items-center justify-center rounded-lg border border-dashed border-border bg-muted/20 p-8 text-center">

--- a/templates/assets/app/routes/picker.tsx
+++ b/templates/assets/app/routes/picker.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Link, useSearchParams } from "react-router";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import {
   createEmbeddedAppBridge,
   type EmbeddedAppBridge,
 } from "@agent-native/embedding/bridge";
 import {
+  agentNativePath,
   sendMcpAppHostMessage,
   updateMcpAppModelContext,
   useActionMutation,
@@ -22,6 +23,7 @@ import {
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 import {
   Select,
   SelectContent,
@@ -51,6 +53,11 @@ type Asset = {
   downloadUrl?: string;
   embedUrl?: string;
   embedPath?: string;
+  lineage?: {
+    label?: string | null;
+    kind?: string | null;
+    sourceLabel?: string | null;
+  } | null;
 };
 
 type Library = {
@@ -74,6 +81,15 @@ type HostConfig = {
   libraryId?: string;
   aspectRatio?: string;
 };
+
+function isEmbeddedWindow() {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.self !== window.top;
+  } catch {
+    return true;
+  }
+}
 
 function normalizeMediaType(value: unknown): PickerMediaType {
   return value === "video" ? "video" : "image";
@@ -148,9 +164,24 @@ function dimensions(asset: Asset) {
   return `${asset.width} x ${asset.height}`;
 }
 
+function assetDisplayTitle(asset: Asset) {
+  return (
+    asset.lineage?.label || asset.title || asset.prompt || "Untitled asset"
+  );
+}
+
+function assetContextLabel(asset: Asset) {
+  if (asset.lineage?.kind === "variation" && asset.lineage.sourceLabel) {
+    return `from ${asset.lineage.sourceLabel}`;
+  }
+  return dimensions(asset);
+}
+
 export default function AssetPicker() {
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const bridgeRef = useRef<EmbeddedAppBridge | null>(null);
+  const embedded = useMemo(() => isEmbeddedWindow(), []);
   const [hostConfig, setHostConfig] = useState<HostConfig>(() => ({
     mediaType: normalizeMediaType(searchParams.get("mediaType")),
     prompt: searchParams.get("prompt") ?? undefined,
@@ -209,11 +240,14 @@ export default function AssetPicker() {
 
   const chooseAsset = (asset: Asset) => {
     const payload = assetPayload(asset, mediaType);
-    bridgeRef.current?.postMessage("chooseAsset", payload);
+    const posted = bridgeRef.current?.postMessage("chooseAsset", payload);
     if (payload.mediaType === "image") {
       bridgeRef.current?.postMessage("chooseImage", payload);
     }
     notifyMcpHost(payload);
+    if (!embedded && !posted) {
+      navigate(`/asset/${asset.id}`);
+    }
   };
 
   const generate = useActionMutation(
@@ -250,6 +284,24 @@ export default function AssetPicker() {
     };
   }, []);
 
+  useEffect(() => {
+    fetch(agentNativePath("/_agent-native/application-state/navigation"), {
+      method: "PUT",
+      headers: {
+        "content-type": "application/json",
+        "x-request-source": "assets-picker-ui",
+      },
+      body: JSON.stringify({
+        view: "picker",
+        mediaType,
+        libraryId: selectedLibraryId || null,
+        query,
+        prompt,
+        aspectRatio,
+      }),
+    }).catch(() => {});
+  }, [aspectRatio, mediaType, prompt, query, selectedLibraryId]);
+
   const canGenerate =
     mediaType === "image" &&
     Boolean(selectedLibraryId) &&
@@ -264,7 +316,12 @@ export default function AssetPicker() {
         : "Connect Builder.io or add a Gemini key in Settings to generate image assets.";
 
   return (
-    <div className="flex h-screen w-screen flex-col overflow-hidden bg-background text-foreground">
+    <div
+      className={cn(
+        "flex flex-col overflow-hidden bg-background text-foreground",
+        embedded ? "h-screen w-screen" : "h-full w-full",
+      )}
+    >
       <header className="flex h-12 shrink-0 items-center justify-between gap-3 border-b border-border px-3">
         <div className="flex min-w-0 items-center gap-2">
           <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
@@ -275,7 +332,9 @@ export default function AssetPicker() {
             )}
           </div>
           <div className="min-w-0">
-            <div className="truncate text-sm font-semibold">Assets</div>
+            <div className="truncate text-sm font-semibold">
+              {embedded ? "Assets" : "Picker"}
+            </div>
             {selectedLibrary && (
               <div className="truncate text-xs text-muted-foreground">
                 {selectedLibrary.title} - {mediaLabel}
@@ -283,21 +342,23 @@ export default function AssetPicker() {
             )}
           </div>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <Button asChild variant="ghost" size="icon" title="Open Assets">
-            <Link to="/" target="_blank" rel="noreferrer">
-              <IconArrowUpRight className="h-4 w-4" />
-            </Link>
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            title="Close"
-            onClick={() => bridgeRef.current?.close()}
-          >
-            <IconX className="h-4 w-4" />
-          </Button>
-        </div>
+        {embedded && (
+          <div className="flex shrink-0 items-center gap-2">
+            <Button asChild variant="ghost" size="icon" title="Open Assets">
+              <Link to="/" target="_blank" rel="noreferrer">
+                <IconArrowUpRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              title="Close"
+              onClick={() => bridgeRef.current?.close()}
+            >
+              <IconX className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
       </header>
 
       <section className="shrink-0 border-b border-border px-3 py-3">
@@ -450,11 +511,11 @@ export default function AssetPicker() {
                 </div>
                 <div className="space-y-1 p-2">
                   <div className="truncate text-xs font-medium">
-                    {asset.title || asset.prompt || "Untitled asset"}
+                    {assetDisplayTitle(asset)}
                   </div>
-                  {dimensions(asset) && (
+                  {assetContextLabel(asset) && (
                     <div className="text-[11px] text-muted-foreground">
-                      {dimensions(asset)}
+                      {assetContextLabel(asset)}
                     </div>
                   )}
                 </div>

--- a/templates/assets/shared/api.ts
+++ b/templates/assets/shared/api.ts
@@ -167,7 +167,16 @@ export interface ImageAssetMetadata {
   description?: string;
   downloadUrl?: string;
   downloadUrlExpiresAt?: string;
+  subjectAssetId?: string;
   [key: string]: unknown;
+}
+
+export interface AssetLineageSummary {
+  kind: "original" | "variation";
+  serial: number;
+  label: string;
+  sourceAssetId?: string | null;
+  sourceLabel?: string | null;
 }
 
 export interface SkippedAssetUploadDuplicate {
@@ -236,4 +245,19 @@ export interface GenerationSessionSummary {
   createdBy?: string | null;
   createdAt?: string;
   updatedAt?: string;
+  items?: GenerationSessionItemSummary[];
+  itemCount?: number;
+  assetCount?: number;
+  variationCount?: number;
+}
+
+export interface GenerationSessionItemSummary {
+  id: string;
+  assetId?: string | null;
+  generationRunId?: string | null;
+  role: string;
+  sortOrder: number;
+  createdAt?: string;
+  label: string;
+  lineage?: AssetLineageSummary | null;
 }

--- a/templates/calendar/app/components/booking/BookingConfirmation.tsx
+++ b/templates/calendar/app/components/booking/BookingConfirmation.tsx
@@ -10,6 +10,8 @@ interface BookingConfirmationProps {
   onReset: () => void;
 }
 
+const BRAND_LINK_CLASS = "font-semibold text-[#00B5FF] hover:text-[#33C4FF]";
+
 export function BookingConfirmation({
   booking,
   customFields = [],
@@ -63,7 +65,7 @@ export function BookingConfirmation({
               href={booking.meetingLink}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-1.5 font-medium text-primary hover:underline"
+              className={`flex items-center gap-1.5 hover:underline ${BRAND_LINK_CLASS}`}
             >
               <IconVideo className="h-4 w-4" />
               Join Meeting
@@ -89,7 +91,7 @@ export function BookingConfirmation({
           Need to make changes?{" "}
           <Link
             to={`/booking/manage/${booking.cancelToken}`}
-            className="text-primary hover:underline"
+            className={`hover:underline ${BRAND_LINK_CLASS}`}
           >
             Cancel or reschedule
           </Link>

--- a/templates/calendar/app/pages/BookingLinksPage.tsx
+++ b/templates/calendar/app/pages/BookingLinksPage.tsx
@@ -124,6 +124,11 @@ function slugify(value: string) {
 
 const PRODUCTION_DOMAIN = "calendar.agent-native.com";
 const PREVIEW_COLLAPSED_STORAGE_KEY = "calendar.bookingLinks.previewCollapsed";
+const BRAND_LINK_CLASS = "font-semibold text-[#00B5FF] hover:text-[#33C4FF]";
+const BRAND_ICON_LINK_CLASS =
+  "text-[#00B5FF] hover:bg-[#00B5FF]/10 hover:text-[#33C4FF]";
+const BRAND_PILL_LINK_CLASS =
+  "border-[#00B5FF]/35 bg-[#00B5FF]/10 font-semibold text-[#00B5FF] hover:border-[#00B5FF]/55 hover:bg-[#00B5FF]/15 hover:text-[#33C4FF]";
 
 type DraftLink = {
   id?: string;
@@ -817,7 +822,7 @@ export default function BookingLinksPage({
                   variant="ghost"
                   size="icon"
                   onClick={() => void copyPreviewUrl(draft.slug)}
-                  className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                  className={cn("h-8 w-8", BRAND_ICON_LINK_CLASS)}
                   aria-label="Copy booking link"
                 >
                   <IconCopy className="h-4 w-4" />
@@ -832,7 +837,7 @@ export default function BookingLinksPage({
                   variant="ghost"
                   size="icon"
                   onClick={() => openPreview(draft.slug)}
-                  className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                  className={cn("h-8 w-8", BRAND_ICON_LINK_CLASS)}
                   aria-label="Open booking link"
                 >
                   <IconExternalLink className="h-4 w-4" />
@@ -1099,7 +1104,7 @@ export default function BookingLinksPage({
                           variant="ghost"
                           size="icon"
                           onClick={() => openPreview(draft.slug)}
-                          className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                          className={cn("h-8 w-8", BRAND_ICON_LINK_CLASS)}
                           aria-label="Open booking page in new tab"
                         >
                           <IconExternalLink className="h-4 w-4" />
@@ -1379,7 +1384,10 @@ export default function BookingLinksPage({
                                   e.stopPropagation();
                                   void copyPreviewUrl(link.slug);
                                 }}
-                                className="flex items-center gap-1.5 rounded-full border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent/60 sm:px-4 sm:text-sm"
+                                className={cn(
+                                  "flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs sm:px-4 sm:text-sm",
+                                  BRAND_PILL_LINK_CLASS,
+                                )}
                               >
                                 <IconLink className="h-3.5 w-3.5" />
                                 Copy link
@@ -1390,7 +1398,10 @@ export default function BookingLinksPage({
                                   e.stopPropagation();
                                   openPreview(link.slug);
                                 }}
-                                className="flex h-9 w-9 items-center justify-center rounded-full border border-border text-muted-foreground hover:text-foreground hover:bg-accent/60"
+                                className={cn(
+                                  "flex h-9 w-9 items-center justify-center rounded-full border",
+                                  BRAND_PILL_LINK_CLASS,
+                                )}
                               >
                                 <IconExternalLink className="h-4 w-4" />
                               </button>
@@ -1830,7 +1841,10 @@ function BookingPreview({
                   <button
                     type="button"
                     onClick={onCopy}
-                    className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/60"
+                    className={cn(
+                      "flex h-6 w-6 items-center justify-center rounded",
+                      BRAND_ICON_LINK_CLASS,
+                    )}
                   >
                     <IconCopy className="h-3.5 w-3.5" />
                   </button>
@@ -1844,7 +1858,10 @@ function BookingPreview({
                   <button
                     type="button"
                     onClick={onOpen}
-                    className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/60"
+                    className={cn(
+                      "flex h-6 w-6 items-center justify-center rounded",
+                      BRAND_ICON_LINK_CLASS,
+                    )}
                   >
                     <IconExternalLink className="h-3.5 w-3.5" />
                   </button>
@@ -1855,7 +1872,7 @@ function BookingPreview({
           </div>
         </div>
         {bookingUrl && (
-          <p className="text-[11px] font-mono text-muted-foreground truncate">
+          <p className="text-[11px] font-mono font-semibold text-[#00B5FF] truncate">
             {bookingUrl.replace(/^https?:\/\//, "")}
           </p>
         )}
@@ -2043,7 +2060,10 @@ function BookingPreview({
                     setSelectedSlot(null);
                     setForcedStep(null);
                   }}
-                  className="text-[11px] text-primary hover:underline"
+                  className={cn(
+                    "text-[11px] hover:underline",
+                    BRAND_LINK_CLASS,
+                  )}
                 >
                   Change date
                 </button>
@@ -2097,7 +2117,10 @@ function BookingPreview({
                     setSelectedSlot(null);
                     setForcedStep(null);
                   }}
-                  className="text-[11px] text-primary hover:underline"
+                  className={cn(
+                    "text-[11px] hover:underline",
+                    BRAND_LINK_CLASS,
+                  )}
                 >
                   Change time
                 </button>

--- a/templates/calendar/app/pages/BookingPage.tsx
+++ b/templates/calendar/app/pages/BookingPage.tsx
@@ -39,6 +39,8 @@ import { cn } from "@/lib/utils";
 
 type Step = "duration" | "date" | "time" | "info" | "confirmed";
 
+const BRAND_LINK_CLASS = "font-semibold text-[#00B5FF] hover:text-[#33C4FF]";
+
 function BookingPageShell({
   children,
   className,
@@ -400,6 +402,7 @@ export default function BookingPage() {
                 <Button
                   variant="link"
                   size="sm"
+                  className={BRAND_LINK_CLASS}
                   onClick={() => setStep("date")}
                 >
                   Change date
@@ -426,6 +429,7 @@ export default function BookingPage() {
                 <Button
                   variant="link"
                   size="sm"
+                  className={BRAND_LINK_CLASS}
                   onClick={() => setStep("time")}
                 >
                   Change time

--- a/templates/clips/app/components/recorder/pre-record-panel.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.tsx
@@ -178,35 +178,49 @@ export function PreRecordPanel({
     if (initialDisplaySurface) setDisplaySurface(initialDisplaySurface);
   }, [initialDisplaySurface]);
 
+  const enumerateDevices = useCallback(async () => {
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      setEnumError(null);
+      setMics(
+        devices.filter(
+          (d) =>
+            d.kind === "audioinput" && d.deviceId && d.deviceId !== "default",
+        ),
+      );
+      setCameras(
+        devices.filter(
+          (d) =>
+            d.kind === "videoinput" && d.deviceId && d.deviceId !== "default",
+        ),
+      );
+    } catch (err) {
+      setEnumError(
+        err instanceof Error ? err.message : "Could not enumerate devices",
+      );
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
-    async function enumerate() {
-      try {
-        const devices = await navigator.mediaDevices.enumerateDevices();
-        if (cancelled) return;
-        setMics(
-          devices.filter(
-            (d) =>
-              d.kind === "audioinput" && d.deviceId && d.deviceId !== "default",
-          ),
-        );
-        setCameras(
-          devices.filter(
-            (d) =>
-              d.kind === "videoinput" && d.deviceId && d.deviceId !== "default",
-          ),
-        );
-      } catch (err) {
-        setEnumError(
-          err instanceof Error ? err.message : "Could not enumerate devices",
-        );
-      }
+    enumerateDevices().catch(() => {});
+    if (!navigator.mediaDevices?.addEventListener) {
+      return () => {
+        cancelled = true;
+      };
     }
-    void enumerate();
+    const handleDeviceChange = () => {
+      if (!cancelled) enumerateDevices().catch(() => {});
+    };
+    navigator.mediaDevices.addEventListener("devicechange", handleDeviceChange);
     return () => {
       cancelled = true;
+      navigator.mediaDevices.removeEventListener(
+        "devicechange",
+        handleDeviceChange,
+      );
     };
-  }, []);
+  }, [enumerateDevices]);
 
   const supportsCameraToggle = mode === "screen+camera";
   const needsCamera =
@@ -260,8 +274,11 @@ export function PreRecordPanel({
         error: detail?.error ?? null,
         hasSignal: false,
       });
+      if (status === "live") {
+        enumerateDevices().catch(() => {});
+      }
     },
-    [],
+    [enumerateDevices],
   );
 
   const handleMicSignalChange = useCallback((hasSignal: boolean) => {
@@ -275,8 +292,11 @@ export function PreRecordPanel({
         error: detail?.error ?? null,
         hasPreview: false,
       });
+      if (status === "live") {
+        enumerateDevices().catch(() => {});
+      }
     },
-    [],
+    [enumerateDevices],
   );
 
   const handleCameraPreviewChange = useCallback((hasPreview: boolean) => {

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -13,7 +13,8 @@ use tauri::{
 
 use crate::dlog;
 use crate::state::{
-    DictationActive, LastTranscript, RecordingActive, TrayAnchor, VoiceWakePopover,
+    DictationActive, LastTranscript, RecordingActive, TrayAnchor, VoiceTargetBundle,
+    VoiceWakePopover,
 };
 use crate::util::{
     build_overlay_url, configure_overlay_behavior, hide_voice_wake_popover, is_recording_active,
@@ -877,17 +878,18 @@ pub async fn show_flow_bar(app: AppHandle) -> Result<(), String> {
     dlog!("[clips-tray] show_flow_bar invoked");
 
     let (mx, my, mw, mh) = tray_monitor_physical_rect(&app);
+    let scale = overlay_scale_factor(&app);
     // Wider + taller than the pill alone so the live transcript chip
     // can stack above it. Height accommodates: bottom-anchored 32px pill
     // + 6px gap + ~28px transcript chip + drop-shadow margin.
-    let content_w: u32 = 420;
-    let content_h: u32 = 120;
+    let content_w: u32 = (420.0 * scale).round() as u32;
+    let content_h: u32 = (120.0 * scale).round() as u32;
+    let bottom_margin: i32 = (14.0 * scale).round() as i32;
     let gutter = overlay_shadow_gutter_physical(&app);
     let w: u32 = content_w + gutter * 2;
     let h: u32 = content_h + gutter * 2;
     let x: i32 = (mx + (mw as i32 - content_w as i32) / 2 - gutter as i32).max(mx);
-    // Bottom margin: ~14 logical px ≈ 28 physical px.
-    let y: i32 = (my + mh as i32 - content_h as i32 - 28 - gutter as i32).max(my);
+    let y: i32 = (my + mh as i32 - h as i32 - bottom_margin).max(my);
 
     if let Some(existing) = app.get_webview_window(FLOW_BAR_LABEL) {
         // Reposition (in case the user changed display geometry between
@@ -972,6 +974,8 @@ pub async fn complete_voice_dictation(app: AppHandle, text: String) -> Result<()
     #[cfg(target_os = "macos")]
     let frontmost_bundle_id = frontmost_bundle_identifier();
     #[cfg(target_os = "macos")]
+    let voice_target_bundle_id = remembered_voice_target_bundle(&app);
+    #[cfg(target_os = "macos")]
     let strategy = text_insertion_strategy(frontmost_bundle_id.as_deref());
     #[cfg(target_os = "macos")]
     eprintln!(
@@ -999,8 +1003,8 @@ pub async fn complete_voice_dictation(app: AppHandle, text: String) -> Result<()
     write_clipboard(&trimmed)?;
     #[cfg(target_os = "macos")]
     match strategy {
-        TextInsertionStrategy::ClipboardPaste => paste_clipboard(),
-        TextInsertionStrategy::UnicodeType => type_text_unicode(&trimmed),
+        TextInsertionStrategy::ClipboardPaste => paste_clipboard(voice_target_bundle_id),
+        TextInsertionStrategy::UnicodeType => type_text_unicode(&trimmed, voice_target_bundle_id),
     }
     #[cfg(not(target_os = "macos"))]
     type_text_unicode(&trimmed);
@@ -1030,6 +1034,28 @@ fn is_terminal_bundle(bundle_id: &str) -> bool {
             | "net.kovidgoyal.kitty"
             | "co.zeit.hyper"
     )
+}
+
+pub fn remember_voice_target(app: &AppHandle) {
+    #[cfg(target_os = "macos")]
+    {
+        let target = frontmost_bundle_identifier();
+        if let Some(state) = app.try_state::<VoiceTargetBundle>() {
+            if let Ok(mut g) = state.0.lock() {
+                *g = target;
+            }
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn remembered_voice_target_bundle(app: &AppHandle) -> Option<String> {
+    app.try_state::<VoiceTargetBundle>()
+        .and_then(|state| state.0.lock().ok().and_then(|g| g.clone()))
 }
 
 #[cfg(test)]
@@ -1123,12 +1149,13 @@ unsafe fn ns_string_to_owned(ptr: *mut objc2::runtime::AnyObject) -> Option<Stri
 }
 
 #[cfg(target_os = "macos")]
-fn paste_clipboard() {
+fn paste_clipboard(target_bundle_id: Option<String>) {
     use core_graphics::event::{CGEvent, CGEventFlags, CGEventTapLocation};
     use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 
     thread::spawn(move || {
-        thread::sleep(Duration::from_millis(40));
+        reactivate_voice_target(target_bundle_id.as_deref());
+        thread::sleep(Duration::from_millis(90));
         let Ok(source) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
             eprintln!("[clips-tray] paste failed: no CGEventSource");
             return;
@@ -1152,15 +1179,30 @@ fn paste_clipboard() {
 }
 
 #[cfg(target_os = "macos")]
-fn type_text_unicode(text: &str) {
+fn reactivate_voice_target(target_bundle_id: Option<&str>) {
+    let Some(bundle_id) = target_bundle_id else {
+        return;
+    };
+    if bundle_id.trim().is_empty() || bundle_id == "com.clips.tray" {
+        return;
+    }
+    if frontmost_bundle_identifier().as_deref() == Some(bundle_id) {
+        return;
+    }
+    if let Err(err) = Command::new("open").arg("-b").arg(bundle_id).status() {
+        eprintln!("[clips-tray] could not reactivate voice target {bundle_id}: {err}");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn type_text_unicode(text: &str, target_bundle_id: Option<String>) {
     use core_graphics::event::{CGEvent, CGEventTapLocation};
     use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 
     let owned = text.to_string();
     thread::spawn(move || {
-        // Brief delay so the focused-app context is ready (mirrors the
-        // delay the previous Cmd+V path used).
-        thread::sleep(Duration::from_millis(40));
+        reactivate_voice_target(target_bundle_id.as_deref());
+        thread::sleep(Duration::from_millis(90));
         let Ok(source) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
             eprintln!("[clips-tray] type failed: no CGEventSource");
             return;

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -27,7 +27,7 @@ use tauri::{Emitter, Manager};
 use clips::{position_popover, toggle_popover};
 use state::{
     DictationActive, DictationEnabled, LastTranscript, MeetingActive, PopoverShownAt,
-    RecordingActive, TrayAnchor, TrayMeetings, VoiceWakePopover,
+    RecordingActive, TrayAnchor, TrayMeetings, VoiceTargetBundle, VoiceWakePopover,
 };
 use util::{configure_overlay_behavior, is_recording_active, set_capture_included};
 
@@ -157,6 +157,7 @@ pub fn run() {
         .manage(DictationEnabled::default())
         .manage(DictationActive::default())
         .manage(VoiceWakePopover::default())
+        .manage(VoiceTargetBundle::default())
         .manage(LastTranscript::default())
         .manage(native_screen::NativeFullscreenRecordingState::default())
         .manage(meetings_watcher::MeetingsWatcherState::default())

--- a/templates/clips/desktop/src-tauri/src/shortcuts.rs
+++ b/templates/clips/desktop/src-tauri/src/shortcuts.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter, Listener, Manager, PhysicalPosition, PhysicalSize};
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
 
-use crate::clips::toggle_popover;
+use crate::clips::{remember_voice_target, toggle_popover};
 use crate::dlog;
 use crate::state::{DictationActive, VoiceWakePopover};
 use crate::util::{
@@ -368,6 +368,7 @@ fn emit_voice_shortcut(
     wake: bool,
 ) {
     if wake {
+        remember_voice_target(app);
         wake_popover_for_voice(app);
         let app = app.clone();
         thread::spawn(move || {

--- a/templates/clips/desktop/src-tauri/src/state.rs
+++ b/templates/clips/desktop/src-tauri/src/state.rs
@@ -47,6 +47,12 @@ pub struct DictationActive(pub Mutex<bool>);
 #[derive(Default)]
 pub struct VoiceWakePopover(pub Mutex<bool>);
 
+/// Bundle identifier of the app that was focused when voice dictation started.
+/// Used to return focus before posting the paste event if a Clips overlay
+/// briefly became active while showing the dictation HUD.
+#[derive(Default)]
+pub struct VoiceTargetBundle(pub Mutex<Option<String>>);
+
 #[allow(dead_code)]
 /// Last dictation result for "paste last".
 #[derive(Default)]

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -1293,6 +1293,14 @@ export function App() {
     }
   }, []);
 
+  useEffect(() => {
+    if (!navigator.mediaDevices?.addEventListener) return;
+    navigator.mediaDevices.addEventListener("devicechange", loadDevices);
+    return () => {
+      navigator.mediaDevices.removeEventListener("devicechange", loadDevices);
+    };
+  }, [loadDevices]);
+
   const unlockDeviceLabels = useCallback(async () => {
     // Audio-only probe to unlock mic labels. We INTENTIONALLY skip video —
     // the on-screen camera bubble window owns the camera, and probing
@@ -1321,6 +1329,42 @@ export function App() {
     }
     await loadDevices();
   }, [loadDevices, selectedMicId]);
+
+  const requestDeviceAccess = useCallback(
+    async (kind: "camera" | "mic") => {
+      try {
+        if (!navigator.mediaDevices?.getUserMedia) {
+          throw new Error("Device selection is not available in this WebView.");
+        }
+        const stream = await navigator.mediaDevices.getUserMedia(
+          kind === "camera"
+            ? { video: true, audio: false }
+            : { audio: true, video: false },
+        );
+        stream.getTracks().forEach((track) => track.stop());
+        await loadDevices();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (kind === "camera") {
+          setCameraError(
+            isHardCapturePermissionError(message) ||
+              /notallowed|permission|denied/i.test(message)
+              ? MACOS_CAPTURE_PERMISSION_MESSAGE
+              : `Camera unavailable: ${message}`,
+          );
+        } else {
+          setRecError(
+            isHardCapturePermissionError(message) ||
+              /notallowed|permission|denied/i.test(message)
+              ? "Microphone access is blocked. Open System Settings → Privacy & Security → Microphone, allow Clips, then try again."
+              : `Microphone unavailable: ${message}`,
+          );
+        }
+        await loadDevices();
+      }
+    },
+    [loadDevices],
+  );
 
   // ---- Esc closes the popover --------------------------------------------
   useEffect(() => {
@@ -1638,6 +1682,7 @@ export function App() {
           s.getTracks().forEach((t) => t.stop());
           return;
         }
+        await loadDevices();
         stream = s;
         bubbleStreamRef.current = s;
         // Open the bubble window. It's a pure renderer — the bubble
@@ -2413,6 +2458,7 @@ export function App() {
             devices={cameras}
             selectedId={cameraId}
             onSelect={setCameraId}
+            onRefresh={() => requestDeviceAccess("camera")}
             on={cameraOn}
             onToggle={setCameraOn}
           />
@@ -2423,6 +2469,7 @@ export function App() {
           devices={mics}
           selectedId={selectedMicId}
           onSelect={setMicId}
+          onRefresh={() => requestDeviceAccess("mic")}
           on={micOn}
           onToggle={setMicOn}
         />
@@ -2432,6 +2479,7 @@ export function App() {
         mode={mode}
         cameraOn={cameraOn}
         micOn={micOn}
+        includeVoicePaste={voiceDictationEnabled}
         includeFnMonitoring={fnShortcutEnabled}
         open={readinessOpen}
         onOpenChange={updateReadinessOpen}
@@ -2571,11 +2619,13 @@ function readinessItems({
   cameraOn,
   micOn,
   includeFnMonitoring,
+  includeVoicePaste,
 }: {
   mode: CaptureMode;
   cameraOn: boolean;
   micOn: boolean;
   includeFnMonitoring: boolean;
+  includeVoicePaste: boolean;
 }): ReadinessItem[] {
   const items: ReadinessItem[] = [
     {
@@ -2603,6 +2653,12 @@ function readinessItems({
       active: mode !== "screen" && cameraOn,
     },
     {
+      label: "Accessibility",
+      detail: "Needed to paste dictated text into other apps.",
+      pane: "accessibility",
+      active: includeVoicePaste,
+    },
+    {
       label: "Input Monitoring",
       detail: "Only needed for the Fn dictation shortcut.",
       pane: "input-monitoring",
@@ -2618,6 +2674,7 @@ function ReadinessPanel({
   cameraOn,
   micOn,
   includeFnMonitoring,
+  includeVoicePaste,
   open,
   onOpenChange,
   onOpenPermission,
@@ -2626,6 +2683,7 @@ function ReadinessPanel({
   cameraOn: boolean;
   micOn: boolean;
   includeFnMonitoring: boolean;
+  includeVoicePaste: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onOpenPermission: (pane: MacosPrivacyPane) => void;
@@ -2635,6 +2693,7 @@ function ReadinessPanel({
     cameraOn,
     micOn,
     includeFnMonitoring,
+    includeVoicePaste,
   });
 
   return (
@@ -3181,6 +3240,7 @@ function DeviceRow({
   devices,
   selectedId,
   onSelect,
+  onRefresh,
   on,
   onToggle,
 }: {
@@ -3188,6 +3248,7 @@ function DeviceRow({
   devices: MediaDeviceInfo[];
   selectedId: string;
   onSelect: (id: string) => void;
+  onRefresh: () => void;
   on: boolean;
   onToggle: (v: boolean) => void;
 }) {
@@ -3231,7 +3292,13 @@ function DeviceRow({
     };
   }, [open]);
 
-  const disabled = !on || devices.length === 0;
+  const disabled = !on;
+  const defaultLabel = kind === "camera" ? "Default camera" : "Default mic";
+  const accessLabel =
+    kind === "camera" ? "Allow camera access" : "Allow microphone access";
+  const refreshLabel =
+    kind === "camera" ? "Refresh cameras" : "Refresh microphones";
+
   return (
     <div className={`row ${on ? "row-on" : "row-off"}`} ref={rowRef}>
       <span className="row-icon">
@@ -3259,34 +3326,72 @@ function DeviceRow({
       {kind === "mic" && on ? <MicWave /> : null}
       {open ? (
         <div className="row-menu" role="menu">
+          <button
+            type="button"
+            className={`row-menu-item ${!selectedId ? "selected" : ""}`}
+            role="menuitemradio"
+            aria-checked={!selectedId}
+            onClick={() => {
+              onSelect("");
+              setOpen(false);
+            }}
+          >
+            <span className="row-menu-check" aria-hidden>
+              {!selectedId ? <CheckIcon /> : null}
+            </span>
+            <span className="row-menu-label">{defaultLabel}</span>
+          </button>
           {devices.length === 0 ? (
-            <div className="row-menu-empty">
-              {kind === "camera" ? "No cameras found" : "No microphones found"}
-            </div>
+            <button
+              type="button"
+              className="row-menu-item row-menu-action"
+              role="menuitem"
+              onClick={() => {
+                onRefresh();
+                setOpen(false);
+              }}
+            >
+              <span className="row-menu-check" aria-hidden />
+              <span className="row-menu-label">{accessLabel}</span>
+            </button>
           ) : (
-            devices.map((d) => {
-              const isSelected = !!selectedId && d.deviceId === selectedId;
-              return (
-                <button
-                  key={d.deviceId}
-                  type="button"
-                  className={`row-menu-item ${isSelected ? "selected" : ""}`}
-                  role="menuitemradio"
-                  aria-checked={isSelected}
-                  onClick={() => {
-                    onSelect(d.deviceId);
-                    setOpen(false);
-                  }}
-                >
-                  <span className="row-menu-check" aria-hidden>
-                    {isSelected ? <CheckIcon /> : null}
-                  </span>
-                  <span className="row-menu-label">
-                    {d.label || (kind === "camera" ? "Camera" : "Microphone")}
-                  </span>
-                </button>
-              );
-            })
+            <>
+              {devices.map((d) => {
+                const isSelected = !!selectedId && d.deviceId === selectedId;
+                return (
+                  <button
+                    key={d.deviceId}
+                    type="button"
+                    className={`row-menu-item ${isSelected ? "selected" : ""}`}
+                    role="menuitemradio"
+                    aria-checked={isSelected}
+                    onClick={() => {
+                      onSelect(d.deviceId);
+                      setOpen(false);
+                    }}
+                  >
+                    <span className="row-menu-check" aria-hidden>
+                      {isSelected ? <CheckIcon /> : null}
+                    </span>
+                    <span className="row-menu-label">
+                      {d.label || (kind === "camera" ? "Camera" : "Microphone")}
+                    </span>
+                  </button>
+                );
+              })}
+              <button
+                type="button"
+                className="row-menu-item row-menu-action"
+                role="menuitem"
+                onClick={() => {
+                  onRefresh();
+                  setOpen(false);
+                }}
+              >
+                <span className="row-menu-check" aria-hidden />
+                <span className="row-menu-label">{refreshLabel}</span>
+              </button>
+            </>
           )}
         </div>
       ) : null}

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -1156,6 +1156,32 @@ async function abortRecordingUpload(
   }
 }
 
+async function trashRecording(
+  serverUrl: string,
+  recordingId: string,
+): Promise<void> {
+  try {
+    const res = await fetch(
+      `${serverUrl.replace(/\/+$/, "")}/_agent-native/actions/trash-recording`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ id: recordingId }),
+      },
+    );
+    if (!res.ok) {
+      console.warn(
+        "[clips-recorder] trash recording failed:",
+        res.status,
+        await res.text().catch(() => ""),
+      );
+    }
+  } catch (err) {
+    console.warn("[clips-recorder] trash recording failed:", err);
+  }
+}
+
 class CountdownCancelledError extends Error {
   constructor() {
     super("Recording cancelled during countdown");
@@ -1681,6 +1707,7 @@ async function startNativeFullscreenRecording(
             id,
             "Recording cancelled by user",
           );
+          await trashRecording(params.serverUrl, id);
         }
       })();
       return cancelPromise;
@@ -2889,10 +2916,12 @@ async function startNativeRecordingInner(
       // forget with a short-circuit on failure — we don't want to keep the
       // user waiting on a network call to a dev server that may be down.
       try {
-        await fetch(
-          `${params.serverUrl.replace(/\/+$/, "")}/api/uploads/${id}/abort`,
-          { method: "POST", credentials: "include" },
+        await abortRecordingUpload(
+          params.serverUrl,
+          id,
+          "Recording cancelled by user",
         );
+        await trashRecording(params.serverUrl, id);
       } catch (err) {
         console.warn("[clips-recorder] abort failed (non-fatal):", err);
       }

--- a/templates/clips/desktop/src/overlays/toolbar.tsx
+++ b/templates/clips/desktop/src/overlays/toolbar.tsx
@@ -5,6 +5,7 @@ import {
   IconLoader2,
   IconPlayerPauseFilled,
   IconPlayerPlayFilled,
+  IconX,
 } from "@tabler/icons-react";
 
 /**
@@ -121,6 +122,25 @@ export function Toolbar() {
     );
   }
 
+  function cancel() {
+    if (stopping || !enabled) return;
+    setStopping(true);
+    console.log(
+      "[clips-toolbar] cancel clicked — emitting clips:recorder-cancel",
+    );
+    emit("clips:recorder-cancel").catch((err) => {
+      console.error("[clips-toolbar] emit clips:recorder-cancel failed:", err);
+    });
+    fallbackTimer.current = setTimeout(() => {
+      console.warn(
+        "[clips-toolbar] recorder did not close toolbar within 3s after cancel — self-closing",
+      );
+      getCurrentWindow()
+        .close()
+        .catch(() => {});
+    }, 3_000);
+  }
+
   // Same explicit-drag pattern the bubble uses — `data-tauri-drag-region`
   // has been unreliable across iterations so we call `startDragging()`
   // directly on mousedown. Interactive controls are marked `data-no-drag`
@@ -183,6 +203,22 @@ export function Toolbar() {
         ) : (
           <IconPlayerPauseFilled size={18} />
         )}
+      </button>
+      <button
+        className="toolbar-v-cancel"
+        onClick={cancel}
+        disabled={!enabled || stopping}
+        aria-label="Cancel recording"
+        title={
+          stopping
+            ? "Stopping..."
+            : enabled
+              ? "Cancel recording"
+              : "Recording not started yet"
+        }
+        data-no-drag
+      >
+        <IconX size={17} stroke={2.5} />
       </button>
     </div>
   );

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -2357,6 +2357,24 @@ body[data-clips-route="recording-pill"] #root {
   color: white;
 }
 
+.toolbar-v-cancel {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.72);
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.toolbar-v-cancel:hover {
+  background: rgba(239, 68, 68, 0.18);
+  color: #fecaca;
+}
+
 .toolbar-v-paused {
   border-color: rgba(245, 158, 11, 0.35);
 }
@@ -2366,19 +2384,22 @@ body[data-clips-route="recording-pill"] #root {
    (no recorder to drive yet). Greyed out + not-allowed cursor makes the
    "not yet" affordance obvious. */
 .toolbar-v-disabled .toolbar-v-stop,
-.toolbar-v-disabled .toolbar-v-pause {
+.toolbar-v-disabled .toolbar-v-pause,
+.toolbar-v-disabled .toolbar-v-cancel {
   background: rgba(255, 255, 255, 0.06);
   color: rgba(255, 255, 255, 0.35);
   cursor: not-allowed;
   pointer-events: auto;
 }
 .toolbar-v-disabled .toolbar-v-stop:hover,
-.toolbar-v-disabled .toolbar-v-pause:hover {
+.toolbar-v-disabled .toolbar-v-pause:hover,
+.toolbar-v-disabled .toolbar-v-cancel:hover {
   background: rgba(255, 255, 255, 0.06);
   color: rgba(255, 255, 255, 0.35);
 }
 .toolbar-v-stop:disabled,
-.toolbar-v-pause:disabled {
+.toolbar-v-pause:disabled,
+.toolbar-v-cancel:disabled {
   cursor: not-allowed;
 }
 


### PR DESCRIPTION
## Summary
- surface the assets picker as a first-class template route with navigation state and lineage-aware labels
- polish open-source and booking-link affordances with the Agent Native brand link color
- improve Clips recorder/device handling, cancellation cleanup, and voice dictation target focus

## Testing
- Not run locally before publishing; GitHub Actions will validate and I am babysitting the PR.