### PR TITLE
Cache immutable client assets long-term

### DIFF
--- a/.changeset/immutable-client-assets-cache.md
+++ b/.changeset/immutable-client-assets-cache.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Set year-long immutable cache headers for content-hashed client assets in framework deploy outputs.

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -3,11 +3,13 @@ import path from "path";
 import { pathToFileURL } from "url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  addImmutableAssetRouteRulesForClientBuild,
   generateWorkerEntry,
   getNodeBuiltinNames,
   runNitroBuildPipeline,
 } from "./build.js";
 import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
+import { IMMUTABLE_ASSET_CACHE_CONTROL } from "./immutable-assets.js";
 
 const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
@@ -209,6 +211,41 @@ export default (event) =>
     );
   });
 
+  it("adds immutable cache headers to Cloudflare Pages hashed assets only", async () => {
+    const worker = await importGeneratedWorker(generateWorkerEntry([], []));
+    const env = {
+      APP_BASE_PATH: "/docs",
+      ASSETS: {
+        fetch: async () =>
+          new Response("asset", {
+            headers: { "content-type": "application/javascript" },
+          }),
+      },
+    };
+
+    const hashed = await worker.fetch(
+      new Request("https://app.test/docs/assets/entry.client-aB12_cdE.js"),
+      env,
+      {},
+    );
+    expect(await hashed.text()).toBe("asset");
+    expect(hashed.headers.get("cache-control")).toBe(
+      IMMUTABLE_ASSET_CACHE_CONTROL,
+    );
+    expect(hashed.headers.get("cdn-cache-control")).toBe(
+      IMMUTABLE_ASSET_CACHE_CONTROL,
+    );
+
+    const unhashed = await worker.fetch(
+      new Request("https://app.test/docs/assets/logo.png"),
+      env,
+      {},
+    );
+    expect(await unhashed.text()).toBe("asset");
+    expect(unhashed.headers.get("cache-control")).toBeNull();
+    expect(unhashed.headers.get("cdn-cache-control")).toBeNull();
+  });
+
   it("injects runtime browser Sentry config into generated worker SSR HTML", async () => {
     const worker = await importGeneratedWorker(generateWorkerEntry([], []));
 
@@ -326,6 +363,11 @@ describe("runNitroBuildPipeline", () => {
       path.join(clientDir, "assets", "entry.client-abc.js"),
       "console.log('rr-client')",
     );
+    fs.writeFileSync(
+      path.join(clientDir, "assets", "entry.client-aB12_cdE.js"),
+      "console.log('hashed-client')",
+    );
+    fs.writeFileSync(path.join(clientDir, "assets", "logo.png"), "png");
 
     // Simulate the cleared publicDir Nitro would set up in `prepare`.
     const publicOutputDir = path.join(cwd, ".output", "public");
@@ -397,6 +439,60 @@ describe("runNitroBuildPipeline", () => {
         path.join(publicOutputDir, "docs", "assets", "entry.client-abc.js"),
       ),
     ).toBe(true);
+  });
+
+  it("adds exact immutable route rules for copied hashed client assets", async () => {
+    const { cwd, clientDir, publicOutputDir } = setupFixture();
+    const nitro: any = {
+      options: { output: { publicDir: publicOutputDir } },
+    };
+
+    await runNitroBuildPipeline({
+      nitro,
+      hooks: {
+        prepare: async () => {},
+        copyPublicAssets: async () => {},
+        nitroBuild: async () => {},
+      },
+      clientDir,
+      publicOutputDir,
+      appBasePath: "/docs",
+      cwd,
+    });
+
+    expect(
+      nitro.options.routeRules["/assets/entry.client-aB12_cdE.js"].headers[
+        "cache-control"
+      ],
+    ).toBe(IMMUTABLE_ASSET_CACHE_CONTROL);
+    expect(
+      nitro.options.routeRules["/docs/assets/entry.client-aB12_cdE.js"].headers[
+        "cdn-cache-control"
+      ],
+    ).toBe(IMMUTABLE_ASSET_CACHE_CONTROL);
+    expect(nitro.options.routeRules["/assets/logo.png"]).toBeUndefined();
+    expect(
+      nitro.options.routeRules["/assets/entry.client-abc.js"],
+    ).toBeUndefined();
+  });
+
+  it("merges immutable headers into existing route rules", () => {
+    const routeRules: Record<string, { headers?: Record<string, string> }> = {
+      "/assets/entry.client-aB12_cdE.js": {
+        headers: { "cross-origin-resource-policy": "cross-origin" },
+      },
+    };
+    const { clientDir } = setupFixture();
+
+    addImmutableAssetRouteRulesForClientBuild(routeRules, clientDir);
+
+    expect(
+      routeRules["/assets/entry.client-aB12_cdE.js"].headers,
+    ).toMatchObject({
+      "cross-origin-resource-policy": "cross-origin",
+      "cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
+      "cdn-cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
+    });
   });
 
   it("skips the client copy when the React Router build is absent", async () => {

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -212,7 +212,11 @@ export default (event) =>
   });
 
   it("adds immutable cache headers to Cloudflare Pages hashed assets only", async () => {
-    const worker = await importGeneratedWorker(generateWorkerEntry([], []));
+    const worker = await importGeneratedWorker(
+      generateWorkerEntry([], [], [], [], null, [
+        "/assets/entry.client-aB12_cdE.js",
+      ]),
+    );
     const env = {
       APP_BASE_PATH: "/docs",
       ASSETS: {
@@ -244,6 +248,15 @@ export default (event) =>
     expect(await unhashed.text()).toBe("asset");
     expect(unhashed.headers.get("cache-control")).toBeNull();
     expect(unhashed.headers.get("cdn-cache-control")).toBeNull();
+
+    const manuallyVersioned = await worker.fetch(
+      new Request("https://app.test/docs/assets/logo-20240501.png"),
+      env,
+      {},
+    );
+    expect(await manuallyVersioned.text()).toBe("asset");
+    expect(manuallyVersioned.headers.get("cache-control")).toBeNull();
+    expect(manuallyVersioned.headers.get("cdn-cache-control")).toBeNull();
   });
 
   it("injects runtime browser Sentry config into generated worker SSR HTML", async () => {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -35,6 +35,13 @@ import {
 import { generateActionRegistryForProject } from "../vite/action-types-plugin.js";
 import { mcpEmbedStaticAssetRouteRules } from "../shared/mcp-embed-headers.js";
 import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
+import {
+  collectImmutableAssetPaths,
+  IMMUTABLE_ASSET_CACHE_CONTROL,
+  IMMUTABLE_ASSET_CACHE_HEADERS,
+  IMMUTABLE_ASSET_PATH_PATTERN,
+  prefixAssetPath,
+} from "./immutable-assets.js";
 
 const cwd = process.cwd();
 const preset = process.env.NITRO_PRESET || "node";
@@ -63,6 +70,36 @@ const NODE_ONLY_PLUGINS = new Set([
 function isNodeOnlyPlugin(filePath: string): boolean {
   const basename = path.basename(filePath, path.extname(filePath));
   return NODE_ONLY_PLUGINS.has(basename);
+}
+
+type RouteRules = Record<string, { headers?: Record<string, string> }>;
+
+function addImmutableAssetRouteRule(
+  routeRules: RouteRules,
+  pathname: string,
+): void {
+  const existing = routeRules[pathname] ?? {};
+  routeRules[pathname] = {
+    ...existing,
+    headers: {
+      ...(existing.headers ?? {}),
+      ...IMMUTABLE_ASSET_CACHE_HEADERS,
+    },
+  };
+}
+
+export function addImmutableAssetRouteRulesForClientBuild(
+  routeRules: RouteRules,
+  clientDir: string,
+  appBasePath = "",
+): void {
+  for (const assetPath of collectImmutableAssetPaths(clientDir)) {
+    addImmutableAssetRouteRule(routeRules, assetPath);
+    const mountedPath = prefixAssetPath(assetPath, appBasePath);
+    if (mountedPath !== assetPath) {
+      addImmutableAssetRouteRule(routeRules, mountedPath);
+    }
+  }
 }
 
 /**
@@ -307,6 +344,8 @@ function injectHeadScript(html, script) {
 }
 
 const DEFAULT_SSR_CACHE_CONTROL = ${JSON.stringify(DEFAULT_SSR_CACHE_CONTROL)};
+const IMMUTABLE_ASSET_CACHE_CONTROL = ${JSON.stringify(IMMUTABLE_ASSET_CACHE_CONTROL)};
+const IMMUTABLE_ASSET_PATH_RE = new RegExp(${JSON.stringify(IMMUTABLE_ASSET_PATH_PATTERN)});
 const AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE = ${JSON.stringify(
     AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE,
   )};
@@ -344,6 +383,26 @@ function applyDefaultSsrCacheHeader(headers, status) {
   if (!contentType.includes("text/html")) return;
 
   headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
+}
+
+function isImmutableAssetRequest(request) {
+  const pathname = stripAppBasePath(new URL(request.url).pathname);
+  return IMMUTABLE_ASSET_PATH_RE.test(pathname);
+}
+
+function applyImmutableAssetCacheHeaders(response, request) {
+  if (!isImmutableAssetRequest(request)) return response;
+  if (!((response.status >= 200 && response.status < 300) || response.status === 304)) {
+    return response;
+  }
+  const headers = new Headers(response.headers);
+  headers.set("Cache-Control", IMMUTABLE_ASSET_CACHE_CONTROL);
+  headers.set("CDN-Cache-Control", IMMUTABLE_ASSET_CACHE_CONTROL);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 async function rewriteMountedResponse(response, basePath) {
@@ -504,7 +563,7 @@ export default {
       try {
         const assetResponse = await env.ASSETS.fetch(request);
         if (assetResponse.status !== 404) {
-          return assetResponse;
+          return applyImmutableAssetCacheHeaders(assetResponse, request);
         }
       } catch {
         // Asset fetch failed — fall through to SSR
@@ -1247,6 +1306,12 @@ export async function runNitroBuildPipeline(
     if (appBasePath) {
       copyDir(clientDir, path.join(publicOutputDir, appBasePath.slice(1)));
     }
+    nitro.options.routeRules ??= {};
+    addImmutableAssetRouteRulesForClientBuild(
+      nitro.options.routeRules,
+      clientDir,
+      appBasePath,
+    );
     console.log(
       `[deploy] Copied client assets to ${path.relative(cwd, publicOutputDir)}`,
     );

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -39,7 +39,6 @@ import {
   collectImmutableAssetPaths,
   IMMUTABLE_ASSET_CACHE_CONTROL,
   IMMUTABLE_ASSET_CACHE_HEADERS,
-  IMMUTABLE_ASSET_PATH_PATTERN,
   prefixAssetPath,
 } from "./immutable-assets.js";
 
@@ -117,6 +116,7 @@ export function generateWorkerEntry(
   defaultPluginStems: string[] = [],
   actions: DiscoveredAction[] = [],
   workspaceCore: WorkspaceCoreExports | null = null,
+  immutableAssetPaths: string[] = [],
 ): string {
   const routeImports: string[] = [];
   const routeRegistrations: string[] = [];
@@ -345,7 +345,9 @@ function injectHeadScript(html, script) {
 
 const DEFAULT_SSR_CACHE_CONTROL = ${JSON.stringify(DEFAULT_SSR_CACHE_CONTROL)};
 const IMMUTABLE_ASSET_CACHE_CONTROL = ${JSON.stringify(IMMUTABLE_ASSET_CACHE_CONTROL)};
-const IMMUTABLE_ASSET_PATH_RE = new RegExp(${JSON.stringify(IMMUTABLE_ASSET_PATH_PATTERN)});
+const IMMUTABLE_ASSET_PATHS = new Set(${JSON.stringify(
+    [...new Set(immutableAssetPaths)].sort(),
+  )});
 const AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE = ${JSON.stringify(
     AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE,
   )};
@@ -387,7 +389,7 @@ function applyDefaultSsrCacheHeader(headers, status) {
 
 function isImmutableAssetRequest(request) {
   const pathname = stripAppBasePath(new URL(request.url).pathname);
-  return IMMUTABLE_ASSET_PATH_RE.test(pathname);
+  return IMMUTABLE_ASSET_PATHS.has(pathname);
 }
 
 function applyImmutableAssetCacheHeaders(response, request) {
@@ -643,12 +645,14 @@ async function buildCloudflarePages() {
   );
 
   // Generate the worker entry
+  const immutableAssetPaths = collectImmutableAssetPaths(clientDir);
   const entrySource = generateWorkerEntry(
     routes,
     plugins,
     missingDefaults,
     actions,
     workspaceCore,
+    immutableAssetPaths,
   );
 
   // Create _worker.js output directory

--- a/packages/core/src/deploy/immutable-assets.ts
+++ b/packages/core/src/deploy/immutable-assets.ts
@@ -1,0 +1,59 @@
+import fs from "fs";
+import path from "path";
+
+export const IMMUTABLE_ASSET_CACHE_CONTROL =
+  "public, max-age=31536000, immutable";
+
+export const IMMUTABLE_ASSET_CACHE_HEADERS = {
+  "cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
+  "cdn-cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
+} as const;
+
+export const IMMUTABLE_ASSET_PATH_PATTERN =
+  "^/assets/[^/]+-[A-Za-z0-9_-]{8}\\.[a-z0-9]+$";
+
+const IMMUTABLE_ASSET_PATH_RE = new RegExp(IMMUTABLE_ASSET_PATH_PATTERN);
+
+export function isImmutableAssetPath(pathname: string): boolean {
+  return IMMUTABLE_ASSET_PATH_RE.test(pathname);
+}
+
+export function normalizeBasePath(basePath: string | undefined): string {
+  const raw = String(basePath ?? "").trim();
+  if (!raw || raw === "/") return "";
+  const normalized = raw.replace(/^\/+/, "").replace(/\/+$/, "");
+  return normalized ? `/${normalized}` : "";
+}
+
+export function prefixAssetPath(
+  pathname: string,
+  basePath: string | undefined,
+): string {
+  const base = normalizeBasePath(basePath);
+  if (!base) return pathname;
+  return `${base}${pathname}`;
+}
+
+export function collectImmutableAssetPaths(rootDir: string): string[] {
+  const assetsDir = path.join(rootDir, "assets");
+  if (!fs.existsSync(assetsDir)) return [];
+
+  const paths: string[] = [];
+  const scan = (dir: string, relDir = "") => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const relPath = relDir ? `${relDir}/${entry.name}` : entry.name;
+      const absPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        scan(absPath, relPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+
+      const assetPath = `/assets/${relPath}`;
+      if (isImmutableAssetPath(assetPath)) paths.push(assetPath);
+    }
+  };
+
+  scan(assetsDir);
+  return paths.sort();
+}

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { pathToFileURL } from "url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runWorkspaceDeploy } from "./workspace-deploy.js";
+import { IMMUTABLE_ASSET_CACHE_CONTROL } from "./immutable-assets.js";
 
 let tmpDir: string;
 let previousAppBasePath: string | undefined;
@@ -506,6 +507,22 @@ describe("workspace deploy", () => {
     expect(redirects).not.toContain(
       "/unknown /.netlify/functions/dispatch-server",
     );
+    const headers = fs.readFileSync(
+      path.join(tmpDir, "dist", "_headers"),
+      "utf-8",
+    );
+    expect(headers).toContain("/dispatch/assets/app-aB12_cdE.js");
+    expect(headers).toContain(
+      "/_workspace_static/dispatch/assets/app-aB12_cdE.js",
+    );
+    expect(headers).toContain("/starter/assets/app-aB12_cdE.js");
+    expect(headers).toContain(
+      `cache-control: ${IMMUTABLE_ASSET_CACHE_CONTROL}`,
+    );
+    expect(headers).toContain(
+      `cdn-cache-control: ${IMMUTABLE_ASSET_CACHE_CONTROL}`,
+    );
+    expect(headers).not.toContain("/dispatch/assets/app.js\n");
     expect(fs.existsSync(path.join(tmpDir, "dist", "_routes.json"))).toBe(
       false,
     );
@@ -707,6 +724,25 @@ describe("workspace deploy", () => {
     );
     expect(config.version).toBe(3);
     expect(config.routes).toContainEqual({ handle: "filesystem" });
+    expect(config.routes).toContainEqual({
+      src: "/dispatch/assets/app-aB12_cdE\\.js",
+      headers: {
+        "cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
+        "cdn-cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
+      },
+      continue: true,
+    });
+    expect(config.routes).toContainEqual({
+      src: "/starter/assets/app-aB12_cdE\\.js",
+      headers: {
+        "cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
+        "cdn-cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
+      },
+      continue: true,
+    });
+    expect(config.routes).not.toContainEqual(
+      expect.objectContaining({ src: "/dispatch/assets/app\\.js" }),
+    );
     expect(config.routes).toContainEqual({
       src: "/_agent-native/(.*)",
       dest: "/dispatch-server",
@@ -1124,6 +1160,10 @@ function writeAppBuildOutput(workspaceRoot: string, app: string): void {
     "export {};",
   );
   fs.writeFileSync(
+    path.join(appDir, "dist", app, "assets", "app-aB12_cdE.js"),
+    "export {};",
+  );
+  fs.writeFileSync(
     path.join(appDir, "dist", app, "favicon.svg"),
     "<svg></svg>",
   );
@@ -1172,6 +1212,10 @@ function writeVercelAppBuildOutput(workspaceRoot: string, app: string): void {
   fs.mkdirSync(path.join(staticDir, "assets"), { recursive: true });
   fs.mkdirSync(functionDir, { recursive: true });
   fs.writeFileSync(path.join(staticDir, "assets", "app.js"), "export {};");
+  fs.writeFileSync(
+    path.join(staticDir, "assets", "app-aB12_cdE.js"),
+    "export {};",
+  );
   fs.writeFileSync(path.join(staticDir, "favicon.ico"), "");
   fs.writeFileSync(path.join(staticDir, "favicon.svg"), "<svg></svg>");
   fs.writeFileSync(path.join(staticDir, "manifest.json"), "{}");

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -28,6 +28,10 @@ import {
   type WorkspaceAppRouteAccess,
   type WorkspaceAppAudience,
 } from "../shared/workspace-app-audience.js";
+import {
+  collectImmutableAssetPaths,
+  IMMUTABLE_ASSET_CACHE_HEADERS,
+} from "./immutable-assets.js";
 
 export type WorkspaceDeployPreset = "cloudflare_pages" | "netlify" | "vercel";
 
@@ -168,6 +172,7 @@ export async function runWorkspaceDeploy(
 
   if (preset === "netlify") {
     writeNetlifyRedirects(distDir, apps);
+    writeNetlifyHeaders(distDir, apps);
   } else if (preset === "vercel") {
     writeVercelBuildConfig(vercelOutputDir, apps);
   } else {
@@ -483,8 +488,33 @@ function writeNetlifyRedirects(distDir: string, apps: string[]): void {
   fs.writeFileSync(path.join(distDir, "_redirects"), lines.join("\n") + "\n");
 }
 
+function writeNetlifyHeaders(distDir: string, apps: string[]): void {
+  const blocks = apps.flatMap((app) => {
+    const staticDir = path.join(distDir, NETLIFY_WORKSPACE_STATIC_DIR, app);
+    return collectImmutableAssetPaths(staticDir).flatMap((assetPath) => [
+      netlifyHeaderBlock(`/${app}${assetPath}`),
+      netlifyHeaderBlock(`/${NETLIFY_WORKSPACE_STATIC_DIR}/${app}${assetPath}`),
+    ]);
+  });
+
+  if (blocks.length === 0) return;
+  fs.writeFileSync(path.join(distDir, "_headers"), blocks.join("\n\n") + "\n");
+}
+
+function netlifyHeaderBlock(pathname: string): string {
+  return [
+    pathname,
+    ...Object.entries(IMMUTABLE_ASSET_CACHE_HEADERS).map(
+      ([name, value]) => `  ${name}: ${value}`,
+    ),
+  ].join("\n");
+}
+
 function writeVercelBuildConfig(outputDir: string, apps: string[]): void {
-  const routes: Array<Record<string, any>> = [{ handle: "filesystem" }];
+  const routes: Array<Record<string, any>> = [
+    ...vercelImmutableAssetHeaderRoutes(outputDir, apps),
+    { handle: "filesystem" },
+  ];
 
   if (apps.includes("dispatch")) {
     routes.push(
@@ -529,6 +559,24 @@ function writeVercelBuildConfig(outputDir: string, apps: string[]): void {
     path.join(outputDir, "config.json"),
     JSON.stringify(config, null, 2) + "\n",
   );
+}
+
+function vercelImmutableAssetHeaderRoutes(
+  outputDir: string,
+  apps: string[],
+): Array<Record<string, any>> {
+  return apps.flatMap((app) => {
+    const staticDir = path.join(outputDir, "static", app);
+    return collectImmutableAssetPaths(staticDir).map((assetPath) => ({
+      src: vercelRouteSrc(`/${app}${assetPath}`),
+      headers: IMMUTABLE_ASSET_CACHE_HEADERS,
+      continue: true,
+    }));
+  });
+}
+
+function vercelRouteSrc(pathname: string): string {
+  return pathname.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function vercelRedirect(src: string, location: string): Record<string, any> {

--- a/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
@@ -49,6 +49,7 @@ import {
   emailToColor,
   emailToName,
   useSession,
+  useChangeVersions,
   agentNativePath,
   appApiPath,
   type CollabUser,
@@ -243,28 +244,60 @@ export default function ExplorerDashboardPage() {
     staleTime: 30_000,
   });
 
+  // Refetch the dashboard whenever the `dashboards` source bumps OR any agent
+  // action runs — the same "agent writes show up without a manual refresh"
+  // pattern the SQL dashboard page uses. We depend on both because:
+  // - `dashboards` covers same-process writes from upsertDashboard
+  // - `action` covers every successful agent action and is emitted by the
+  //   agent runner unconditionally, which makes the refresh resilient even if
+  //   the dashboards-store emit is missed (different process, etc.).
+  // Without this, an agent edit to an explorer dashboard only reached the open
+  // page through the collab Y.Text channel, which is silent on the first edit
+  // (seedFromText doesn't emit) — so the title/charts could go stale.
+  const sync = useChangeVersions(["dashboards", "action"]);
+  const dashboardQuery = useQuery({
+    // dashboardId is part of the key, so React Query keeps a separate cache
+    // entry per dashboard — no `placeholderData` (it would carry the previous
+    // dashboard's data across an id switch and flash the wrong dashboard).
+    // The skeleton shows until fresh data for the current id arrives, exactly
+    // like the original one-shot load. Same-key refetches (agent writes) keep
+    // the rendered `dashboard` state until the new data lands, so there's no
+    // flicker on those.
+    queryKey: ["data", "explorer-dashboard", dashboardId, sync],
+    enabled: !!dashboardId,
+    queryFn: async () => {
+      if (!dashboardId) return null;
+      return fetchDashboard(dashboardId);
+    },
+    staleTime: 30_000,
+  });
+
   useEffect(() => {
     if (!dashboardId) return;
     setLoaded(false);
+    setDashboard(null);
     setResourceAccess(null);
     setEditingName(false);
-    fetchDashboard(dashboardId).then((d) => {
-      if (d) {
-        setDashboard(d.data);
-        setArchivedAt(d.archivedAt);
-        setResourceAccess({
-          role: d.role,
-          canEdit: d.canEdit,
-          canManage: d.canManage,
-        });
-      } else {
-        setDashboard({ name: "Untitled Dashboard", charts: [] });
-        setArchivedAt(null);
-        setResourceAccess(null);
-      }
-      setLoaded(true);
-    });
   }, [dashboardId]);
+
+  useEffect(() => {
+    if (!dashboardId || !dashboardQuery.isSuccess) return;
+    const d = dashboardQuery.data;
+    if (d) {
+      setDashboard(d.data);
+      setArchivedAt(d.archivedAt);
+      setResourceAccess({
+        role: d.role,
+        canEdit: d.canEdit,
+        canManage: d.canManage,
+      });
+    } else {
+      setDashboard({ name: "Untitled Dashboard", charts: [] });
+      setArchivedAt(null);
+      setResourceAccess(null);
+    }
+    setLoaded(true);
+  }, [dashboardId, dashboardQuery.data, dashboardQuery.isSuccess]);
 
   const handleArchive = useCallback(async () => {
     if (!dashboardId || !canEdit) return;
@@ -308,6 +341,13 @@ export default function ExplorerDashboardPage() {
       }
       setDashboard(updated);
       pushToCollab(updated);
+      // Keep the cached dashboard query in sync with the optimistic write so a
+      // `sync` bump from our own save doesn't briefly flash stale data before
+      // the refetch lands.
+      queryClient.setQueriesData<FetchedExplorerDashboard | null>(
+        { queryKey: ["data", "explorer-dashboard", dashboardId] },
+        (prev) => (prev ? { ...prev, data: updated } : prev),
+      );
       saveDashboard(dashboardId, updated).then(() => {
         queryClient.invalidateQueries({
           queryKey: ["explorer-dashboards-palette"],

--- a/templates/content/actions/transcribe-media.ts
+++ b/templates/content/actions/transcribe-media.ts
@@ -1,10 +1,4 @@
 import { defineAction } from "@agent-native/core";
-import { writeAppState } from "@agent-native/core/application-state";
-import {
-  hasCollabState,
-  agentEnterDocument,
-  agentLeaveDocument,
-} from "@agent-native/core/collab";
 import { resolveCredential } from "@agent-native/core/credentials";
 import { readAppSecret } from "@agent-native/core/secrets";
 import {
@@ -266,65 +260,6 @@ function insertTranscriptAfterMedia({
   return `${content.slice(0, insertAt)}\n\n${transcriptToggleMarkdown(transcript)}${content.slice(insertAt)}`;
 }
 
-async function findCollabOrigin(): Promise<string | null> {
-  const tryOrigins = [
-    process.env.ORIGIN,
-    process.env.PORT ? `http://localhost:${process.env.PORT}` : null,
-    "http://localhost:8080",
-    "http://localhost:8081",
-    "http://localhost:8082",
-    "http://localhost:8083",
-  ].filter(Boolean) as string[];
-  for (const origin of tryOrigins) {
-    try {
-      const res = await fetch(`${origin}/_agent-native/ping`, {
-        signal: AbortSignal.timeout(500),
-      });
-      if (res.ok) return origin;
-    } catch {
-      // Try next origin.
-    }
-  }
-  return null;
-}
-
-async function replaceInCollab({
-  documentId,
-  find,
-  replace,
-}: {
-  documentId: string;
-  find: string;
-  replace: string;
-}): Promise<boolean> {
-  if (!(await hasCollabState(documentId))) return false;
-  const origin = await findCollabOrigin();
-  if (!origin) return false;
-
-  agentEnterDocument(documentId);
-  try {
-    const response = await fetch(
-      `${origin}/_agent-native/collab/${documentId}/search-replace`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          find,
-          replace,
-          requestSource: "agent",
-        }),
-      },
-    ).catch(() => null);
-    if (!response?.ok) return false;
-    const body = (await response.json().catch(() => null)) as {
-      found?: boolean;
-    } | null;
-    return body?.found === true;
-  } finally {
-    agentLeaveDocument(documentId);
-  }
-}
-
 async function resolveKey(key: string): Promise<string | undefined> {
   const userEmail = getRequestUserEmail();
   if (userEmail) {
@@ -436,9 +371,14 @@ async function applyTranscriptToDocument({
   const content = freshDoc.content ?? "";
   let nextContent: string | null = null;
 
+  // Replace the placeholder if present; otherwise insert after the media block.
+  // The transcript reaches the live editor through the normal change-sync:
+  // update-document bumps updatedAt and the open editor reconciles the newer
+  // content into the Y.Doc (see the `real-time-collab` skill). No localhost
+  // collab push — that silently no-oped on serverless.
   if (placeholderText && content.includes(placeholderText)) {
     nextContent = content.replace(placeholderText, transcript);
-  } else if (!placeholderText) {
+  } else {
     nextContent = insertTranscriptAfterMedia({
       content,
       mediaUrl,
@@ -447,29 +387,16 @@ async function applyTranscriptToDocument({
     });
   }
 
-  const collabUpdated = placeholderText
-    ? await replaceInCollab({
-        documentId,
-        find: placeholderText,
-        replace: transcript,
-      })
-    : false;
-
   if (nextContent && nextContent !== content) {
     await updateDocument.run({ id: documentId, content: nextContent });
-    return { sqlUpdated: true, collabUpdated };
+    return { sqlUpdated: true, collabUpdated: false };
   }
 
-  if (!collabUpdated) {
-    throw new Error(
-      placeholderText
-        ? "Could not find the transcript placeholder in the document."
-        : "Could not find the media block in the document.",
-    );
-  }
-
-  await writeAppState("refresh-signal", { ts: Date.now() });
-  return { sqlUpdated: false, collabUpdated };
+  throw new Error(
+    placeholderText
+      ? "Could not find the transcript placeholder in the document."
+      : "Could not find the media block in the document.",
+  );
 }
 
 export default defineAction({

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -29,6 +29,7 @@ import {
   useActionMutation,
   useSession,
   useCollaborativeDoc,
+  isReconcileLeadClient,
   generateTabId,
   emailToColor,
   emailToName,
@@ -641,12 +642,46 @@ export default function DesignEditor() {
   // instead of the DB-fetched content so live remote edits appear instantly.
   const [collabContent, setCollabContent] = useState<string | null>(null);
   const prevActiveFileIdRef = useRef<string | null>(null);
+  // `updatedAt` of the DB content this preview currently reflects. A poll that
+  // returns an older-or-equal value is a stale snapshot and is ignored; a newer
+  // one is a genuine external edit (agent / peer-via-SQL) and is reconciled in.
+  // Mirrors the content template's VisualEditor `lastAppliedUpdatedAt` gate.
+  const lastAppliedFileUpdatedAtRef = useRef<string | null>(null);
+  // The last content this client itself wrote into the Y.Doc (inline-style
+  // edits) — so the reconcile/observe doesn't treat our own echo as external.
+  const lastLocalContentRef = useRef<string | null>(null);
+  // Freshest known DB `updatedAt` for the active file, kept in a ref so the
+  // Yjs observe handler can advance the reconcile watermark without re-subscribing.
+  const documentFileUpdatedAtRef = useRef<string | null>(null);
 
-  // Reset collab content when switching files
+  // Whether this client applies authoritative external snapshots into the
+  // shared Y.Doc. Exactly one client (the lead) does, so an agent/peer edit
+  // that arrives via the get-design refetch isn't diffed into the CRDT by every
+  // open client and duplicated. Re-elected on awareness / visibility changes.
+  const [isLeadClient, setIsLeadClient] = useState(true);
+  useEffect(() => {
+    if (!awareness || !ydoc) {
+      setIsLeadClient(true);
+      return;
+    }
+    const update = () =>
+      setIsLeadClient(isReconcileLeadClient(awareness, ydoc.clientID));
+    update();
+    awareness.on("change", update);
+    document.addEventListener("visibilitychange", update);
+    return () => {
+      awareness.off("change", update);
+      document.removeEventListener("visibilitychange", update);
+    };
+  }, [awareness, ydoc]);
+
+  // Reset per-file reconcile state when switching files
   useEffect(() => {
     if (activeFileId !== prevActiveFileIdRef.current) {
       prevActiveFileIdRef.current = activeFileId;
       setCollabContent(null);
+      lastAppliedFileUpdatedAtRef.current = null;
+      lastLocalContentRef.current = null;
     }
   }, [activeFileId]);
 
@@ -657,21 +692,86 @@ export default function DesignEditor() {
     const text = ytext.toString();
     if (text.length > 0) {
       setCollabContent(text);
+      // Adopt the loaded file's watermark so a later equal-or-older poll can't
+      // revert it, and a genuinely newer agent edit is still recognized.
+      lastAppliedFileUpdatedAtRef.current = activeFile?.updatedAt ?? null;
     }
-  }, [ydoc, isSynced, activeFileId]);
+  }, [ydoc, isSynced, activeFileId, activeFile?.updatedAt]);
 
-  // Observe Y.Text changes for live updates from remote editors
+  // Keep the freshest DB `updatedAt` in a ref the observe handler can read.
+  useEffect(() => {
+    documentFileUpdatedAtRef.current = activeFile?.updatedAt ?? null;
+  }, [activeFile?.updatedAt]);
+
+  // Observe Y.Text changes for live updates from remote editors (peers + the
+  // agent's in-process applyText). This is the instant peer-to-peer path.
   useEffect(() => {
     if (!ydoc || !isSynced) return;
     const ytext = ydoc.getText("content");
     const handler = () => {
-      setCollabContent(ytext.toString());
+      const next = ytext.toString();
+      setCollabContent(next);
+      lastLocalContentRef.current = next;
+      // A Yjs update means the live doc now matches whatever DB write produced
+      // it; advance the watermark so the get-design reconcile below no-ops.
+      lastAppliedFileUpdatedAtRef.current =
+        documentFileUpdatedAtRef.current ?? lastAppliedFileUpdatedAtRef.current;
     };
     ytext.observe(handler);
     return () => {
       ytext.unobserve(handler);
     };
   }, [ydoc, isSynced]);
+
+  // Reconcile authoritative external DB content (agent edit / peer-via-SQL) into
+  // the live preview. This is the robustness fallback the Yjs observe path can't
+  // guarantee on its own: a collab poll can be missed or paused (e.g. the tab
+  // was backgrounded, or refetchInterval is off for a normal agent edit), but
+  // get-design still refetches via the action-change invalidate. Driven by
+  // `updatedAt`: only content genuinely newer than what the preview reflects is
+  // adopted, so a lagging poll can never revert live edits. The lead client also
+  // writes it into the Y.Doc so peers receive it and it persists.
+  useEffect(() => {
+    if (!activeFile || !isSynced) return;
+    const dbContent = activeFile.content ?? "";
+    const dbUpdatedAt = activeFile.updatedAt ?? null;
+
+    // Already reflecting this exact content (our own echo or Yjs already
+    // delivered it) — just advance the watermark and stop.
+    if (
+      collabContent === dbContent ||
+      lastLocalContentRef.current === dbContent
+    ) {
+      if (dbUpdatedAt) lastAppliedFileUpdatedAtRef.current = dbUpdatedAt;
+      return;
+    }
+
+    // Only adopt genuinely newer content. No baseline yet (fresh file load)
+    // always adopts so a stale persisted Y.Doc can't shadow newer SQL.
+    const applied = lastAppliedFileUpdatedAtRef.current;
+    const externalNewer = !applied || (!!dbUpdatedAt && dbUpdatedAt > applied);
+    if (!externalNewer) return;
+
+    // Render the newer content immediately so the preview is never stale.
+    setCollabContent(dbContent);
+    lastLocalContentRef.current = dbContent;
+    if (dbUpdatedAt) lastAppliedFileUpdatedAtRef.current = dbUpdatedAt;
+
+    // Lead client mirrors it into the shared Y.Doc so other open clients
+    // receive it through Yjs and the durable collab state stays in step. The
+    // agent's update-file/generate-design already wrote the Y.Doc in-process,
+    // so in the common case this is a no-op diff; it only does real work when
+    // the Yjs update was missed (the failure this fallback exists to cover).
+    if (isLeadClient && ydoc) {
+      const ytext = ydoc.getText("content");
+      if (ytext.toString() !== dbContent) {
+        ydoc.transact(() => {
+          ytext.delete(0, ytext.length);
+          ytext.insert(0, dbContent);
+        }, TAB_ID);
+      }
+    }
+  }, [activeFile, collabContent, isSynced, isLeadClient, ydoc]);
 
   // Set awareness local state to include which file the user is viewing
   useEffect(() => {
@@ -795,6 +895,20 @@ export default function DesignEditor() {
       if (!nextContent) return;
 
       setCollabContent(nextContent);
+      // Mark as our own write so the get-design reconcile + Yjs observe don't
+      // treat the echo as an external edit and fight the live value.
+      lastLocalContentRef.current = nextContent;
+      // Write the edit into the shared Y.Doc so other open clients see it live
+      // through Yjs (not only via the slower update-file → applyText round-trip).
+      if (ydoc && isSynced) {
+        const ytext = ydoc.getText("content");
+        if (ytext.toString() !== nextContent) {
+          ydoc.transact(() => {
+            ytext.delete(0, ytext.length);
+            ytext.insert(0, nextContent);
+          }, TAB_ID);
+        }
+      }
       queueFileContentSave(activeFile.id, nextContent);
       setSelectedElement((prev) =>
         prev
@@ -805,7 +919,14 @@ export default function DesignEditor() {
           : prev,
       );
     },
-    [activeContent, activeFile, queueFileContentSave, selectedElement],
+    [
+      activeContent,
+      activeFile,
+      queueFileContentSave,
+      selectedElement,
+      ydoc,
+      isSynced,
+    ],
   );
 
   const handleZoomIn = useCallback(() => {

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -691,12 +691,12 @@ export default function DesignEditor() {
     const ytext = ydoc.getText("content");
     const text = ytext.toString();
     if (text.length > 0) {
+      // Y.Doc snapshots are a render seed, not the SQL source of truth; the
+      // reconcile effect below advances the updatedAt watermark only after it
+      // confirms or applies the current DB content.
       setCollabContent(text);
-      // Adopt the loaded file's watermark so a later equal-or-older poll can't
-      // revert it, and a genuinely newer agent edit is still recognized.
-      lastAppliedFileUpdatedAtRef.current = activeFile?.updatedAt ?? null;
     }
-  }, [ydoc, isSynced, activeFileId, activeFile?.updatedAt]);
+  }, [ydoc, isSynced, activeFileId]);
 
   // Keep the freshest DB `updatedAt` in a ref the observe handler can read.
   useEffect(() => {

--- a/templates/mail/app/components/email/ComposeEditor.tsx
+++ b/templates/mail/app/components/email/ComposeEditor.tsx
@@ -81,6 +81,7 @@ export const ComposeEditor = forwardRef<
   // external/agent edit reconcile in even while the editor is focused but idle,
   // without yanking text out from under in-progress keystrokes.
   const lastTypedAtRef = useRef(0);
+  const pendingComposeContentRef = useRef<string | null>(null);
   const onChangeRef = useRef(onChange);
   const onSendRef = useRef(onSend);
   const onCloseRef = useRef(onClose);
@@ -170,9 +171,23 @@ export const ComposeEditor = forwardRef<
       const currentMd = (editor.storage as any).markdown.getMarkdown();
 
       if (
+        content !== currentMd &&
+        content !== pendingComposeContentRef.current
+      ) {
+        pendingComposeContentRef.current = content;
+      }
+
+      const nextContent = pendingComposeContentRef.current;
+      if (nextContent == null) return;
+      if (currentMd === nextContent) {
+        pendingComposeContentRef.current = null;
+        return;
+      }
+
+      if (
         !shouldApplyComposeContent({
           currentMarkdown: currentMd,
-          nextContent: content,
+          nextContent,
           editorFocused: editor.isFocused,
           lastTypedAt: lastTypedAtRef.current,
           now: Date.now(),
@@ -180,14 +195,13 @@ export const ComposeEditor = forwardRef<
       ) {
         // Differs but the user is mid-keystroke — re-check once they pause so
         // the agent edit still appears without clobbering their typing.
-        if (currentMd !== content) {
-          retryTimer = setTimeout(run, COMPOSE_TYPING_GRACE_MS);
-        }
+        retryTimer = setTimeout(run, COMPOSE_TYPING_GRACE_MS);
         return;
       }
 
+      pendingComposeContentRef.current = null;
       isSettingContent.current = true;
-      editor.commands.setContent(content);
+      editor.commands.setContent(nextContent);
       isSettingContent.current = false;
     };
 

--- a/templates/mail/app/components/email/ComposeEditor.tsx
+++ b/templates/mail/app/components/email/ComposeEditor.tsx
@@ -17,6 +17,10 @@ import { ComposeSlashMenu } from "./ComposeSlashMenu";
 import { ComposeBubbleToolbar } from "./ComposeBubbleToolbar";
 import { CodeBlockLangPicker } from "./CodeBlockLangPicker";
 import {
+  shouldApplyComposeContent,
+  COMPOSE_TYPING_GRACE_MS,
+} from "./compose-draft-context";
+import {
   Dialog,
   DialogContent,
   DialogHeader,
@@ -73,6 +77,10 @@ export const ComposeEditor = forwardRef<
   ref,
 ) {
   const isSettingContent = useRef(false);
+  // Last time the user actually typed (not merely had focus). Used to let an
+  // external/agent edit reconcile in even while the editor is focused but idle,
+  // without yanking text out from under in-progress keystrokes.
+  const lastTypedAtRef = useRef(0);
   const onChangeRef = useRef(onChange);
   const onSendRef = useRef(onSend);
   const onCloseRef = useRef(onClose);
@@ -132,7 +140,11 @@ export const ComposeEditor = forwardRef<
       },
     },
     onUpdate: ({ editor }) => {
+      // Only a genuine local keystroke marks the user as "actively typing".
+      // setContent (external/agent reconcile) sets isSettingContent first, so
+      // those updates don't extend the typing grace window.
       if (isSettingContent.current) return;
+      lastTypedAtRef.current = Date.now();
       try {
         const md = (editor.storage as any).markdown.getMarkdown();
         onChangeRef.current(md);
@@ -142,18 +154,49 @@ export const ComposeEditor = forwardRef<
     },
   });
 
-  // Sync content from outside (when the agent updates compose-{id} app-state)
+  // Reconcile external content into the editor when the agent (or another
+  // surface) updates compose-{id} app-state — the `compose-drafts` query
+  // refetches and feeds the new body in via `content`. We adopt it live even
+  // while the editor is focused, EXCEPT when the user is actively typing right
+  // now; in that case we retry shortly so the edit still lands once they pause.
   useEffect(() => {
     if (!editor || editor.isDestroyed) return;
-    const currentMd = (editor.storage as any).markdown.getMarkdown();
-    if (currentMd !== content) {
-      if (editor.isFocused) {
+
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const run = () => {
+      if (cancelled || !editor || editor.isDestroyed) return;
+      const currentMd = (editor.storage as any).markdown.getMarkdown();
+
+      if (
+        !shouldApplyComposeContent({
+          currentMarkdown: currentMd,
+          nextContent: content,
+          editorFocused: editor.isFocused,
+          lastTypedAt: lastTypedAtRef.current,
+          now: Date.now(),
+        })
+      ) {
+        // Differs but the user is mid-keystroke — re-check once they pause so
+        // the agent edit still appears without clobbering their typing.
+        if (currentMd !== content) {
+          retryTimer = setTimeout(run, COMPOSE_TYPING_GRACE_MS);
+        }
         return;
       }
+
       isSettingContent.current = true;
       editor.commands.setContent(content);
       isSettingContent.current = false;
-    }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+    };
   }, [content, editor]);
 
   const [showLinkDialog, setShowLinkDialog] = useState(false);

--- a/templates/mail/app/components/email/compose-content-sync.spec.ts
+++ b/templates/mail/app/components/email/compose-content-sync.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldApplyComposeContent,
+  COMPOSE_TYPING_GRACE_MS,
+} from "./compose-draft-context";
+
+const NOW = 1_000_000;
+
+describe("shouldApplyComposeContent", () => {
+  it("does not re-apply content the editor already shows", () => {
+    expect(
+      shouldApplyComposeContent({
+        currentMarkdown: "Hello",
+        nextContent: "Hello",
+        editorFocused: true,
+        lastTypedAt: NOW,
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it("applies an external (agent) edit when the editor is blurred", () => {
+    expect(
+      shouldApplyComposeContent({
+        currentMarkdown: "Old body",
+        nextContent: "Agent-rewritten body",
+        editorFocused: false,
+        lastTypedAt: NOW - 10_000,
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it("applies an external edit while focused but idle (not actively typing)", () => {
+    expect(
+      shouldApplyComposeContent({
+        currentMarkdown: "Old body",
+        nextContent: "Agent-rewritten body",
+        editorFocused: true,
+        lastTypedAt: NOW - (COMPOSE_TYPING_GRACE_MS + 1),
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it("defers an external edit while the user is actively typing", () => {
+    expect(
+      shouldApplyComposeContent({
+        currentMarkdown: "User is typing thi",
+        nextContent: "Agent-rewritten body",
+        editorFocused: true,
+        lastTypedAt: NOW - 100,
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it("applies once the typing grace window elapses (boundary)", () => {
+    expect(
+      shouldApplyComposeContent({
+        currentMarkdown: "Old body",
+        nextContent: "New body",
+        editorFocused: true,
+        lastTypedAt: NOW - COMPOSE_TYPING_GRACE_MS,
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores recent typing when the editor is not focused", () => {
+    // A blurred editor can't be "typing right now" even if lastTypedAt is recent
+    expect(
+      shouldApplyComposeContent({
+        currentMarkdown: "Old body",
+        nextContent: "New body",
+        editorFocused: false,
+        lastTypedAt: NOW - 50,
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+});

--- a/templates/mail/app/components/email/compose-draft-context.ts
+++ b/templates/mail/app/components/email/compose-draft-context.ts
@@ -14,6 +14,42 @@ type MarkdownEditor = {
   };
 };
 
+/** How long after the user's last keystroke we treat the body as "actively
+ *  being typed" and defer an incoming external (agent) edit. Mirrors the
+ *  content editor's typing guard so an agent draft update lands the moment the
+ *  user pauses, instead of waiting for them to blur the field. */
+export const COMPOSE_TYPING_GRACE_MS = 1500;
+
+/**
+ * Decide whether an external `content` value (e.g. an agent-written draft body
+ * reconciled in via the `compose-drafts` query) should replace what the editor
+ * currently shows.
+ *
+ * - Never re-apply content the editor already reflects (no-op / our own echo).
+ * - Adopt external content even while the editor is focused, as long as the
+ *   user isn't typing *right now* — so an agent edit appears live.
+ * - Only defer while the user is actively typing, so we never yank text out
+ *   from under in-progress keystrokes (the caller retries once they pause).
+ */
+export function shouldApplyComposeContent({
+  currentMarkdown,
+  nextContent,
+  editorFocused,
+  lastTypedAt,
+  now,
+}: {
+  currentMarkdown: string;
+  nextContent: string;
+  editorFocused: boolean;
+  lastTypedAt: number;
+  now: number;
+}): boolean {
+  if (currentMarkdown === nextContent) return false;
+  const typingRightNow =
+    editorFocused && now - lastTypedAt < COMPOSE_TYPING_GRACE_MS;
+  return !typingRightNow;
+}
+
 export function splitQuotedContent(body: string): [string, string] {
   const replyMatch = body.match(/\n*— On .+? wrote:\n/);
   const fwdMatch = body.match(/\n*— Forwarded message —\n/);

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -11,6 +11,8 @@ import {
   agentNativePath,
   sendToAgentChat,
   usePinchZoom,
+  useAvatarUrl,
+  type CollabUser,
 } from "@agent-native/core/client";
 import { createPortal } from "react-dom";
 import { enterSelectionMode } from "@/root";
@@ -248,6 +250,74 @@ interface SlideEditorProps {
    *  `_await-fit-check` can build correct `update-slide --deckId=<id>`
    *  agent retry commands. */
   deckId?: string;
+  /** Other users (besides the current user) currently viewing/editing THIS
+   *  slide. Drives the soft same-slide-edit indicator on the canvas so a user
+   *  knows before they clobber someone else's last-writer-wins text edit. */
+  presentUsers?: CollabUser[];
+}
+
+/**
+ * Soft same-slide presence indicator. Renders a small stacked-avatar chip on
+ * the canvas when another user is on the SAME slide the current user is
+ * editing — a non-blocking heads-up so people don't unknowingly clobber each
+ * other's edits (sync is last-writer-wins at deck granularity). No hard lock:
+ * it only warns. Reuses the avatar + tooltip pattern from the sidebar.
+ */
+function SamePresenceAvatar({ user }: { user: CollabUser }) {
+  const avatarUrl = useAvatarUrl(user.email);
+  const initial = (user.name || user.email).slice(0, 1).toUpperCase();
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className="-ml-1.5 flex h-5 w-5 flex-shrink-0 items-center justify-center overflow-hidden rounded-full font-bold text-white ring-2 ring-popover first:ml-0"
+          style={{
+            backgroundColor: avatarUrl ? undefined : user.color,
+            fontSize: 9,
+          }}
+          aria-label={`${user.name} is on this slide`}
+        >
+          {avatarUrl ? (
+            <img
+              src={avatarUrl}
+              alt={user.name}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            initial
+          )}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        {user.name} ({user.email}) is on this slide
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function SameSlidePresenceIndicator({ users }: { users: CollabUser[] }) {
+  if (users.length === 0) return null;
+  const visible = users.slice(0, 3);
+  const overflow = users.length - visible.length;
+  const label =
+    users.length === 1
+      ? `${users[0].name} is here`
+      : `${users.length} others here`;
+  return (
+    <div className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border bg-popover/95 py-1 pl-1 pr-2.5 text-xs text-popover-foreground shadow-lg backdrop-blur">
+      <div className="flex items-center">
+        {visible.map((u) => (
+          <SamePresenceAvatar key={u.email} user={u} />
+        ))}
+        {overflow > 0 && (
+          <span className="-ml-1.5 flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1 text-[9px] font-medium leading-none text-muted-foreground ring-2 ring-popover">
+            +{overflow}
+          </span>
+        )}
+      </div>
+      <span className="font-medium leading-none">{label}</span>
+    </div>
+  );
 }
 
 /** Selection outline rendered over a selected image */
@@ -434,6 +504,7 @@ export default function SlideEditor({
   slideId,
   slideTitle,
   deckId,
+  presentUsers = [],
 }: SlideEditorProps) {
   const content = typeof slide.content === "string" ? slide.content : "";
   const isHtmlSlide =
@@ -1410,6 +1481,15 @@ export default function SlideEditor({
                       {agentActive && (
                         <div className="absolute top-2 right-2 z-10 pointer-events-none">
                           <AgentPresenceChip active={agentActive} />
+                        </div>
+                      )}
+                      {presentUsers.length > 0 && (
+                        <div
+                          className={`absolute right-2 z-10 ${
+                            agentActive ? "top-11" : "top-2"
+                          }`}
+                        >
+                          <SameSlidePresenceIndicator users={presentUsers} />
                         </div>
                       )}
                       {overflowInfo && !readOnly && !agentActive && (

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -992,6 +992,7 @@ export default function DeckEditor() {
                   `Slide ${(currentIndex >= 0 ? currentIndex : 0) + 1}`
                 );
               })()}
+              presentUsers={slidePresence.get(currentSlide.id) ?? []}
             />
           )}
 

--- a/templates/videos/app/hooks/use-composition-collab.ts
+++ b/templates/videos/app/hooks/use-composition-collab.ts
@@ -37,6 +37,61 @@ export interface CompositionCollabData {
   updatedAt?: string;
 }
 
+/**
+ * Normalize a parsed composition JSON blob into the canonical collab shape the
+ * contexts consume (`tracks`, `props`, `settings`).
+ *
+ * Two writers feed `Y.Text("content")` and historically disagreed on the field
+ * names, which is why agent edits used to never reach the editor's props/settings:
+ *
+ *  - The agent actions (`update-composition`, `save-composition`) and the SQL
+ *    source of truth (`compositions.data`, see `databaseRowToComposition`) use
+ *    the FLAT, DB-canonical shape:
+ *    `{ tracks, defaultProps, durationInFrames, fps, width, height }`.
+ *  - The UI's own `pushToCollab` historically used a NESTED shape:
+ *    `{ tracks, props, settings: { durationInFrames, fps, width, height } }`.
+ *
+ * `tracks` was the only field both shapes shared, so timeline edits synced but
+ * prop/setting edits silently dropped. We now normalize on read so BOTH shapes
+ * are understood, and `pushToCollab` writes the DB-canonical shape so every
+ * writer (agent, SQL, and all clients) agrees.
+ */
+function normalizeCompositionCollab(raw: any): CompositionCollabData | null {
+  if (!raw || typeof raw !== "object") return null;
+
+  const tracks = Array.isArray(raw.tracks) ? raw.tracks : undefined;
+
+  // props: prefer the DB-canonical `defaultProps`, fall back to nested `props`.
+  const props =
+    raw.defaultProps && typeof raw.defaultProps === "object"
+      ? raw.defaultProps
+      : raw.props && typeof raw.props === "object"
+        ? raw.props
+        : undefined;
+
+  // settings: prefer the nested `settings` object, otherwise lift the flat
+  // DB-canonical fields into a settings object.
+  let settings: CompositionCollabData["settings"];
+  if (raw.settings && typeof raw.settings === "object") {
+    settings = raw.settings;
+  } else {
+    const flat: CompositionCollabData["settings"] = {};
+    if (typeof raw.durationInFrames === "number")
+      flat.durationInFrames = raw.durationInFrames;
+    if (typeof raw.fps === "number") flat.fps = raw.fps;
+    if (typeof raw.width === "number") flat.width = raw.width;
+    if (typeof raw.height === "number") flat.height = raw.height;
+    if (Object.keys(flat).length > 0) settings = flat;
+  }
+
+  return {
+    tracks,
+    props,
+    settings,
+    updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : undefined,
+  };
+}
+
 export interface UseCompositionCollabResult {
   /** The parsed composition data from the collab layer, or null if not synced yet. */
   compositionData: CompositionCollabData | null;
@@ -111,20 +166,21 @@ export function useCompositionCollab(
 
     if (text) {
       try {
-        const parsed = JSON.parse(text) as CompositionCollabData;
-        setCompositionData(parsed);
+        const parsed = normalizeCompositionCollab(JSON.parse(text));
+        if (parsed) setCompositionData(parsed);
       } catch {
         // Not valid JSON yet — initial state may be empty
       }
     }
 
-    // Observe Y.Text changes from remote edits
+    // Observe Y.Text changes from remote edits (other users AND the agent —
+    // the agent writes the DB-canonical JSON in-process via applyText).
     const observer = () => {
       const updated = ytext.toString();
       if (updated) {
         try {
-          const parsed = JSON.parse(updated) as CompositionCollabData;
-          setCompositionData(parsed);
+          const parsed = normalizeCompositionCollab(JSON.parse(updated));
+          if (parsed) setCompositionData(parsed);
         } catch {
           // Ignore parse errors during partial updates
         }
@@ -140,17 +196,43 @@ export function useCompositionCollab(
   // Track whether we're currently pushing to avoid feedback loops
   const isPushingRef = useRef(false);
 
-  // Push local state to collab endpoint, merging with existing state
+  // Hold the latest parsed state so pushToCollab can merge against it without
+  // depending on `compositionData` (which would change its identity on every
+  // remote edit and re-trigger the contexts' push effects).
+  const compositionDataRef = useRef<CompositionCollabData | null>(null);
+  compositionDataRef.current = compositionData;
+
+  // Push local state to collab endpoint, merging with existing state and
+  // writing the DB-canonical shape so every writer (the agent's in-process
+  // `applyText`, the SQL `compositions.data` column, and all clients) agree on
+  // field names. `update-composition`/`save-composition` read `defaultProps`
+  // and flat `durationInFrames`/`fps`/`width`/`height`, so we serialize the
+  // same way here instead of the old nested `{ props, settings }` shape.
   const pushToCollab = useCallback(
     (data: CompositionCollabData) => {
       if (!docId || isPushingRef.current) return;
       isPushingRef.current = true;
 
-      const merged = { ...compositionData, ...data };
-      const dataStr = JSON.stringify({
-        ...merged,
+      const current = compositionDataRef.current ?? {};
+      const tracks = data.tracks ?? current.tracks;
+      const props = data.props ?? current.props;
+      const settings = data.settings ?? current.settings;
+
+      const payload: Record<string, any> = {
         updatedAt: new Date().toISOString(),
-      });
+      };
+      if (tracks !== undefined) payload.tracks = tracks;
+      if (props !== undefined) payload.defaultProps = props;
+      if (settings) {
+        if (typeof settings.durationInFrames === "number")
+          payload.durationInFrames = settings.durationInFrames;
+        if (typeof settings.fps === "number") payload.fps = settings.fps;
+        if (typeof settings.width === "number") payload.width = settings.width;
+        if (typeof settings.height === "number")
+          payload.height = settings.height;
+      }
+
+      const dataStr = JSON.stringify(payload);
 
       fetch(agentNativePath(`/_agent-native/collab/${docId}/text`), {
         method: "POST",


### PR DESCRIPTION
## Summary
- Add shared detection for flat Vite/Rollup content-hashed client assets.
- Apply `Cache-Control` and `CDN-Cache-Control` immutable one-year headers in standalone Nitro deploys, including mounted base paths and Cloudflare Pages `env.ASSETS` responses.
- Generate equivalent workspace deploy asset headers for Netlify and Vercel outputs.

## Test plan
- `pnpm --filter @agent-native/core exec vitest --run src/deploy/build.spec.ts src/deploy/workspace-deploy.spec.ts`
- `pnpm --filter @agent-native/core typecheck`