### PR TITLE
Polish asset generation and calendar drafts

### DIFF
--- a/.changeset/builder-image-credentials.md
+++ b/.changeset/builder-image-credentials.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+---
+
+Validate Builder private keys before storing them and send the matching public
+key with managed image-generation requests.

--- a/.changeset/cache-auth-html.md
+++ b/.changeset/cache-auth-html.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Serve unauthenticated app HTML as cacheable 200 responses and let the sign-in page perform client-side session redirects.

--- a/.changeset/quiet-data-cache.md
+++ b/.changeset/quiet-data-cache.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+---
+
+Apply the default public SSR cache policy to React Router `.data` responses
+that only carry React Router's default `no-cache` header.

--- a/.changeset/scaffold-better-auth-pin.md
+++ b/.changeset/scaffold-better-auth-pin.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Pin Better Auth in scaffolded workspace roots until the latest Kysely adapter build is compatible.

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -328,6 +328,12 @@ describe("workspace scaffold — required packages", { timeout: 60000 }, () => {
     expect(wsYaml).toContain("tailwindcss");
   });
 
+  it("pins Better Auth in workspace roots until the latest Kysely adapter build is compatible", async () => {
+    const wsDir = await scaffoldWorkspace("my-ws", ["calendar"]);
+    const rootPkg = readPkg(wsDir);
+    expect(rootPkg.pnpm?.overrides?.["better-auth"]).toBe("1.6.0");
+  });
+
   it("keeps the default workspace starter app branded as a blank app", async () => {
     await createApp("my-ws", { template: "starter,dispatch" });
     const wsDir = path.join(tmpDir, "my-ws");

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -225,6 +225,20 @@ export default (event) =>
     );
   });
 
+  it("preserves React Router's default no-cache policy on authenticated Cloudflare worker data responses", async () => {
+    const worker = await importGeneratedWorker(generateWorkerEntry([], []));
+
+    const response = await worker.fetch(
+      new Request("https://app.test/docs/inbox.data", {
+        headers: { cookie: "an_session=active" },
+      }),
+      { APP_BASE_PATH: "/docs" },
+      {},
+    );
+
+    expect(response.headers.get("cache-control")).toBe("no-cache");
+  });
+
   it("preserves explicit private cache policies on Cloudflare worker data responses", async () => {
     const worker = await importGeneratedWorker(generateWorkerEntry([], []));
 

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -37,6 +37,14 @@ export function createRequestHandler() {
   return async (request) => {
     const url = new URL(request.url);
     if (url.pathname.endsWith(".data")) {
+      if (url.pathname === "/custom.data") {
+        return new Response('{"ok":true}', {
+          headers: {
+            "cache-control": "no-cache",
+            "content-type": "application/json",
+          },
+        });
+      }
       return new Response('["data"]', {
         headers: {
           "cache-control": url.pathname === "/private.data" ? "private, no-store" : "no-cache",
@@ -227,6 +235,18 @@ export default (event) =>
     );
 
     expect(response.headers.get("cache-control")).toBe("private, no-store");
+  });
+
+  it("does not replace no-cache on non-React Router Cloudflare worker data responses", async () => {
+    const worker = await importGeneratedWorker(generateWorkerEntry([], []));
+
+    const response = await worker.fetch(
+      new Request("https://app.test/custom.data"),
+      {},
+      {},
+    );
+
+    expect(response.headers.get("cache-control")).toBe("no-cache");
   });
 
   it("keeps public SSR cache headers for anonymous Cloudflare worker preference cookies", async () => {

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -36,6 +36,15 @@ async function importGeneratedWorker(entrySource: string) {
 export function createRequestHandler() {
   return async (request) => {
     const url = new URL(request.url);
+    if (url.pathname.endsWith(".data")) {
+      return new Response('["data"]', {
+        headers: {
+          "cache-control": url.pathname === "/private.data" ? "private, no-store" : "no-cache",
+          "content-type": "text/x-script",
+          "x-remix-response": "yes",
+        },
+      });
+    }
     if (url.pathname === "/redirect") {
       return new Response(null, {
         status: 302,
@@ -192,6 +201,32 @@ export default (event) =>
     expect(response.headers.get("cache-control")).toBe(
       DEFAULT_SSR_CACHE_CONTROL,
     );
+  });
+
+  it("replaces React Router's default no-cache policy on Cloudflare worker data responses", async () => {
+    const worker = await importGeneratedWorker(generateWorkerEntry([], []));
+
+    const response = await worker.fetch(
+      new Request("https://app.test/docs/inbox.data"),
+      { APP_BASE_PATH: "/docs" },
+      {},
+    );
+
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
+  });
+
+  it("preserves explicit private cache policies on Cloudflare worker data responses", async () => {
+    const worker = await importGeneratedWorker(generateWorkerEntry([], []));
+
+    const response = await worker.fetch(
+      new Request("https://app.test/private.data"),
+      {},
+      {},
+    );
+
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
   });
 
   it("keeps public SSR cache headers for anonymous Cloudflare worker preference cookies", async () => {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -377,13 +377,22 @@ function injectDefaultSocialImageMeta(html) {
   return html.slice(0, headCloseIdx) + tags.join("") + html.slice(headCloseIdx);
 }
 
-function applyDefaultSsrCacheHeader(headers, status) {
-  if (headers.has("cache-control")) return;
-  if (status < 200 || status >= 400) return;
+function shouldUseDefaultSsrCacheHeader(headers, status, pathname) {
+  if (status < 200 || status >= 400) return false;
 
   const contentType = (headers.get("content-type") || "").toLowerCase();
-  if (!contentType.includes("text/html")) return;
+  if (contentType.includes("text/html")) {
+    return !headers.has("cache-control");
+  }
 
+  if (!pathname.endsWith(".data")) return false;
+
+  const cacheControl = headers.get("cache-control");
+  return !cacheControl || cacheControl.trim().toLowerCase() === "no-cache";
+}
+
+function applyDefaultSsrCacheHeader(headers, status, pathname) {
+  if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname)) return;
   headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
 }
 
@@ -407,10 +416,10 @@ function applyImmutableAssetCacheHeaders(response, request) {
   });
 }
 
-async function rewriteMountedResponse(response, basePath) {
+async function rewriteMountedResponse(response, basePath, pathname) {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
-  applyDefaultSsrCacheHeader(headers, response.status);
+  applyDefaultSsrCacheHeader(headers, response.status, pathname);
 
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {
@@ -531,9 +540,10 @@ ${actionRegistrations.join("\n")}
           headers: response.headers,
         }),
         basePath,
+        p,
       );
     }
-    return rewriteMountedResponse(await rrHandler(request), basePath);
+    return rewriteMountedResponse(await rrHandler(request), basePath, p);
   }));
 
   _handler = app.fetch.bind(app);

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -386,6 +386,7 @@ function shouldUseDefaultSsrCacheHeader(headers, status, pathname) {
   }
 
   if (!pathname.endsWith(".data")) return false;
+  if (!contentType.includes("text/x-script")) return false;
 
   const cacheControl = headers.get("cache-control");
   return !cacheControl || cacheControl.trim().toLowerCase() === "no-cache";

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -377,7 +377,30 @@ function injectDefaultSocialImageMeta(html) {
   return html.slice(0, headCloseIdx) + tags.join("") + html.slice(headCloseIdx);
 }
 
-function shouldUseDefaultSsrCacheHeader(headers, status, pathname) {
+const ANONYMOUS_SESSION_COOKIE_NAMES = new Set(["an_docs_session"]);
+const AUTH_SESSION_COOKIE_RE = /^(?:an_session(?:_[^=;]+)?|an_embed_session|[^=;]+\\.session_(?:token|data))$/;
+
+function requestHasAuthenticatedCookie(cookieHeader) {
+  if (!cookieHeader) return false;
+  return cookieHeader
+    .split(";")
+    .map((cookie) => cookie.trim().split("=", 1)[0]?.trim())
+    .filter(Boolean)
+    .map((name) => name.replace(/^__(?:Secure|Host)-/, ""))
+    .some((name) => !ANONYMOUS_SESSION_COOKIE_NAMES.has(name) && AUTH_SESSION_COOKIE_RE.test(name));
+}
+
+function requestHasAuthSignal(request) {
+  const url = new URL(request.url);
+  return Boolean(
+    request.headers.get("authorization") ||
+    requestHasAuthenticatedCookie(request.headers.get("cookie")) ||
+    url.searchParams.has("__an_embed_token") ||
+    url.searchParams.has("_session")
+  );
+}
+
+function shouldUseDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal) {
   if (status < 200 || status >= 400) return false;
 
   const contentType = (headers.get("content-type") || "").toLowerCase();
@@ -386,14 +409,15 @@ function shouldUseDefaultSsrCacheHeader(headers, status, pathname) {
   }
 
   if (!pathname.endsWith(".data")) return false;
+  if (hasAuthSignal) return false;
   if (!contentType.includes("text/x-script")) return false;
 
   const cacheControl = headers.get("cache-control");
   return !cacheControl || cacheControl.trim().toLowerCase() === "no-cache";
 }
 
-function applyDefaultSsrCacheHeader(headers, status, pathname) {
-  if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname)) return;
+function applyDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal) {
+  if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal)) return;
   headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
 }
 
@@ -417,10 +441,10 @@ function applyImmutableAssetCacheHeaders(response, request) {
   });
 }
 
-async function rewriteMountedResponse(response, basePath, pathname) {
+async function rewriteMountedResponse(response, basePath, pathname, hasAuthSignal) {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
-  applyDefaultSsrCacheHeader(headers, response.status, pathname);
+  applyDefaultSsrCacheHeader(headers, response.status, pathname, hasAuthSignal);
 
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {
@@ -531,6 +555,7 @@ ${actionRegistrations.join("\n")}
       return new Response(null, { status: 404 });
     }
     const request = requestWithPathname(event.req, p);
+    const hasAuthSignal = requestHasAuthSignal(event.req);
     if (event.req.method === "HEAD") {
       const getRequest = requestWithMethod(request, "GET");
       const response = await rrHandler(getRequest);
@@ -542,9 +567,10 @@ ${actionRegistrations.join("\n")}
         }),
         basePath,
         p,
+        hasAuthSignal,
       );
     }
-    return rewriteMountedResponse(await rrHandler(request), basePath, p);
+    return rewriteMountedResponse(await rrHandler(request), basePath, p, hasAuthSignal);
   }));
 
   _handler = app.fetch.bind(app);

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+const DEFAULT_SSR_CACHE_CONTROL =
+  "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+
 describe("server/auth", () => {
   let originalEnv: NodeJS.ProcessEnv;
 
@@ -431,7 +434,10 @@ describe("server/auth", () => {
 
       const result = await guard(createMockEvent({ path: "/demo" }));
       expect(result).toBeInstanceOf(Response);
-      expect((result as Response).status).toBe(401);
+      expect((result as Response).status).toBe(200);
+      expect((result as Response).headers.get("Cache-Control")).toBe(
+        DEFAULT_SSR_CACHE_CONTROL,
+      );
 
       const html = await (result as Response).text();
       expect(html).toContain("Create account");
@@ -513,7 +519,18 @@ describe("server/auth", () => {
         createMockEvent({ path: "/portal/admin/users" }),
       );
       expect(adminResult).toBeInstanceOf(Response);
-      expect((adminResult as Response).status).toBe(401);
+      expect((adminResult as Response).status).toBe(200);
+      expect((adminResult as Response).headers.get("Cache-Control")).toBe(
+        DEFAULT_SSR_CACHE_CONTROL,
+      );
+
+      const adminDataResult = await guard(
+        createMockEvent({
+          path: "/portal/admin/users.data",
+          headers: { accept: "text/x-script" },
+        }),
+      );
+      expect(adminDataResult).toEqual({ error: "Unauthorized" });
 
       const apiResult = await guard(
         createMockEvent({ path: "/portal/api/private" }),
@@ -553,7 +570,10 @@ describe("server/auth", () => {
         createMockEvent({ path: "/docs/admin" }),
       );
       expect(privateResult).toBeInstanceOf(Response);
-      expect((privateResult as Response).status).toBe(401);
+      expect((privateResult as Response).status).toBe(200);
+      expect((privateResult as Response).headers.get("Cache-Control")).toBe(
+        DEFAULT_SSR_CACHE_CONTROL,
+      );
     });
 
     it("relays root workspace OAuth callbacks to the app from state", async () => {
@@ -782,7 +802,7 @@ describe("server/auth", () => {
       }
     });
 
-    it("serves first-party branded auth when the default guard handles a built-in host", async () => {
+    it("serves cacheable first-party branded auth when the default guard handles a built-in host", async () => {
       vi.stubEnv("NODE_ENV", "production");
       delete process.env.ACCESS_TOKEN;
       delete process.env.ACCESS_TOKENS;
@@ -817,9 +837,9 @@ describe("server/auth", () => {
       );
 
       expect(result).toBeInstanceOf(Response);
-      expect((result as Response).status).toBe(401);
+      expect((result as Response).status).toBe(200);
       expect((result as Response).headers.get("Cache-Control")).toBe(
-        "no-store",
+        DEFAULT_SSR_CACHE_CONTROL,
       );
       expect((result as Response).headers.get("X-Robots-Tag")).toBe(
         "noindex, nofollow",
@@ -827,6 +847,34 @@ describe("server/auth", () => {
       const html = await (result as Response).text();
       expect(html).toContain("Agent-Native Dispatch");
       expect(html).toContain('class="marketing-panel"');
+      expect(html).toContain("__anRedirectIfAlreadySignedIn");
+    });
+
+    it("keeps React Router data requests protected instead of serving cached login HTML", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app, {
+        getSession: async () => null,
+        loginHtml: "<!doctype html><title>QA login</title>",
+      });
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      const event = createMockEvent({
+        path: "/inbox.data",
+        headers: { accept: "text/x-script" },
+      });
+      const result = await guard(event);
+
+      expect(result).toEqual({ error: "Unauthorized" });
+      expect(event.res.status).toBe(401);
     });
 
     it("redirects mounted login and signup pages when a session already exists", async () => {

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -101,6 +101,7 @@ import {
   workspaceAppRouteAccessFromEnv,
   type WorkspaceAppAudience,
 } from "../shared/workspace-app-audience.js";
+import { DEFAULT_SSR_CACHE_CONTROL } from "../shared/cache-control.js";
 import { resolveAuthCookieNamespace } from "./cookie-namespace.js";
 import {
   BUILDER_CONNECT_OWNER_COOKIE,
@@ -1275,6 +1276,28 @@ function shouldBypassAuthForBuilderConnect(event: H3Event, p: string): boolean {
   return false;
 }
 
+function loginHtmlResponse(loginHtml: string): Response {
+  return new Response(loginHtml, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": DEFAULT_SSR_CACHE_CONTROL,
+      "X-Robots-Tag": "noindex, nofollow",
+    },
+  });
+}
+
+function isHtmlDocumentRequest(event: H3Event, pathname: string): boolean {
+  if (!isReadMethod(event)) return false;
+  if (pathname.endsWith(".data")) return false;
+
+  const fetchDest = getHeader(event, "sec-fetch-dest")?.toLowerCase();
+  if (fetchDest === "document" || fetchDest === "iframe") return true;
+
+  const accept = getHeader(event, "accept")?.toLowerCase();
+  return !accept || accept.includes("text/html") || accept.includes("*/*");
+}
+
 function createAuthGuardFn(): (
   event: H3Event,
 ) => Promise<Response | object | string | void> {
@@ -1461,10 +1484,7 @@ function createAuthGuardFn(): (
           headers: { Location: safeReturn },
         });
       }
-      return new Response(loginHtml, {
-        status: 200,
-        headers: { "Content-Type": "text/html; charset=utf-8" },
-      });
+      return loginHtmlResponse(loginHtml);
     }
 
     // Auth entry pages are framework-owned pages, not app routes. When a user
@@ -1478,10 +1498,7 @@ function createAuthGuardFn(): (
           headers: { Location: getAppBasePath() || "/" },
         });
       }
-      return new Response(loginHtml, {
-        status: 200,
-        headers: { "Content-Type": "text/html; charset=utf-8" },
-      });
+      return loginHtmlResponse(loginHtml);
     }
 
     // Skip static assets (Vite chunks, fonts, images, etc.)
@@ -1522,6 +1539,11 @@ function createAuthGuardFn(): (
       return { error: "Unauthorized" };
     }
 
+    if (!isHtmlDocumentRequest(event, p)) {
+      setResponseStatus(event, 401);
+      return { error: "Unauthorized" };
+    }
+
     // Local-dev convenience: on the first page GET of a freshly-scaffolded
     // app, transparently create + sign in `dev@local.test` instead of
     // showing the sign-up form. Gated on NODE_ENV=development AND no real users in the
@@ -1532,14 +1554,7 @@ function createAuthGuardFn(): (
       if (autoSession) return autoSession;
     }
 
-    return new Response(loginHtml, {
-      status: 401,
-      headers: {
-        "Content-Type": "text/html; charset=utf-8",
-        "Cache-Control": "no-store",
-        "X-Robots-Tag": "noindex, nofollow",
-      },
-    });
+    return loginHtmlResponse(loginHtml);
   };
 }
 

--- a/packages/core/src/server/core-routes-plugin.spec.ts
+++ b/packages/core/src/server/core-routes-plugin.spec.ts
@@ -1,5 +1,37 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { resolveLegacyToolsRedirect } from "./core-routes-plugin.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { H3Event } from "h3";
+import {
+  resolveBuilderOwnerContextForRequest,
+  resolveLegacyToolsRedirect,
+} from "./core-routes-plugin.js";
+import {
+  BUILDER_CONNECT_PARAM,
+  BUILDER_STATE_PARAM,
+  signBuilderCallbackState,
+  signBuilderConnectToken,
+} from "./builder-browser.js";
+
+function createMockEvent(url: string): H3Event {
+  const parsed = new URL(url);
+  return {
+    req: {
+      method: "GET",
+      url: parsed.href,
+      headers: new Headers({ host: parsed.host }),
+    },
+    url: parsed,
+    node: {
+      req: {
+        headers: { host: parsed.host },
+        method: "GET",
+        url: `${parsed.pathname}${parsed.search}`,
+      },
+    },
+    headers: new Headers({ host: parsed.host }),
+    context: {},
+    path: parsed.pathname,
+  } as unknown as H3Event;
+}
 
 describe("resolveLegacyToolsRedirect", () => {
   afterEach(() => {
@@ -78,5 +110,81 @@ describe("resolveLegacyToolsRedirect", () => {
     expect(resolveLegacyToolsRedirect("/mail/tools/abc", "")).toBe(
       "/mail/extensions/abc",
     );
+  });
+});
+
+describe("resolveBuilderOwnerContextForRequest", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.BETTER_AUTH_SECRET = "builder-owner-context-test-secret";
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("uses signed callback state when docs auth minted a fresh anonymous session", async () => {
+    const originalOwner = "anon-original@agent-native.com";
+    const freshOwner = "anon-fresh@agent-native.com";
+    const state = signBuilderCallbackState(originalOwner);
+    const event = createMockEvent(
+      `https://agent-native.com/_agent-native/builder/callback?${BUILDER_STATE_PARAM}=${encodeURIComponent(state)}`,
+    );
+
+    const context = await resolveBuilderOwnerContextForRequest(
+      event,
+      {
+        getSessionForEvent: async () => ({ email: freshOwner }),
+      },
+      "callback",
+    );
+
+    expect(context.email).toBe(originalOwner);
+    expect(context.session).toBeNull();
+    expect(context.anonymous).toBe(true);
+  });
+
+  it("uses signed connect owner when docs auth minted a fresh anonymous session", async () => {
+    const originalOwner = "anon-original@agent-native.com";
+    const freshOwner = "anon-fresh@agent-native.com";
+    const token = signBuilderConnectToken(originalOwner);
+    const event = createMockEvent(
+      `https://agent-native.com/_agent-native/builder/connect?${BUILDER_CONNECT_PARAM}=${encodeURIComponent(token)}`,
+    );
+
+    const context = await resolveBuilderOwnerContextForRequest(
+      event,
+      {
+        getSessionForEvent: async () => ({ email: freshOwner }),
+      },
+      "connect",
+    );
+
+    expect(context.email).toBe(originalOwner);
+    expect(context.session).toBeNull();
+    expect(context.anonymous).toBe(true);
+  });
+
+  it("does not let signed Builder state override a different real user session", async () => {
+    const state = signBuilderCallbackState("mallory@example.com");
+    const event = createMockEvent(
+      `https://assets.agent-native.com/_agent-native/builder/callback?${BUILDER_STATE_PARAM}=${encodeURIComponent(state)}`,
+    );
+
+    const context = await resolveBuilderOwnerContextForRequest(
+      event,
+      {
+        getSessionForEvent: async () => ({ email: "steve@builder.io" }),
+      },
+      "callback",
+    );
+
+    expect(context.email).toBe("steve@builder.io");
+    expect(context.session).toEqual({ email: "steve@builder.io" });
+    expect(context.anonymous).toBe(false);
   });
 });

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -83,7 +83,7 @@ import {
   putUserSetting,
   deleteUserSetting,
 } from "../settings/user-settings.js";
-import { getSession } from "./auth.js";
+import { getSession, type AuthSession } from "./auth.js";
 import { getAppBasePath, getOrigin } from "./google-oauth.js";
 import { findWorkspaceRoot } from "../scripts/utils.js";
 import { listOnboardingSteps } from "../onboarding/registry.js";
@@ -277,6 +277,83 @@ function clearBuilderConnectOwnerCookie(event: H3Event): void {
   });
 }
 
+function isAgentNativeAnonymousOwner(email: string | undefined): boolean {
+  return /^anon-[^@]+@agent-native\.com$/i.test(email ?? "");
+}
+
+type BuilderAnonymousOwnerResolver = (
+  event: H3Event,
+) => string | null | Promise<string | null>;
+
+export type BuilderOwnerContext = {
+  email: string | undefined;
+  session: AuthSession | null;
+  anonymous: boolean;
+};
+
+export async function resolveBuilderOwnerContextForRequest(
+  event: H3Event,
+  options: {
+    anonymousOwner?: BuilderAnonymousOwnerResolver;
+    getSessionForEvent?: (event: H3Event) => Promise<AuthSession | null>;
+  } = {},
+  mode?: "connect" | "callback",
+): Promise<BuilderOwnerContext> {
+  const searchParams = getRequestURL(event).searchParams;
+  const signedOwner =
+    mode === "connect"
+      ? verifyBuilderConnectTokenAndGetOwner(
+          searchParams.get(BUILDER_CONNECT_PARAM),
+        )
+      : mode === "callback"
+        ? verifyBuilderCallbackStateAndGetOwner(
+            searchParams.get(BUILDER_STATE_PARAM),
+          )
+        : null;
+  const cookieOwner =
+    mode === "callback" ? readBuilderConnectOwnerCookie(event) : null;
+  const session = await (options.getSessionForEvent ?? getSession)(event).catch(
+    () => null,
+  );
+  if (session?.email) {
+    if (
+      signedOwner &&
+      (signedOwner === session.email ||
+        (isAgentNativeAnonymousOwner(signedOwner) &&
+          isAgentNativeAnonymousOwner(session.email)))
+    ) {
+      // Public docs/app surfaces can mint a new anonymous session inside the
+      // popup when cookies do not round-trip. Keep the signed flow owner in
+      // that anonymous-only case, but do not override a real user session.
+      return {
+        email: signedOwner,
+        session: signedOwner === session.email ? session : null,
+        anonymous: isAgentNativeAnonymousOwner(signedOwner),
+      };
+    }
+    return { email: session.email, session, anonymous: false };
+  }
+
+  if (signedOwner) {
+    return {
+      email: signedOwner,
+      session: null,
+      anonymous: isAgentNativeAnonymousOwner(signedOwner),
+    };
+  }
+
+  if (cookieOwner) {
+    return { email: cookieOwner, session: null, anonymous: false };
+  }
+
+  const anonymousOwner = await options.anonymousOwner?.(event);
+  if (anonymousOwner) {
+    return { email: anonymousOwner, session: null, anonymous: true };
+  }
+
+  return { email: undefined, session: null, anonymous: false };
+}
+
 /**
  * Resolves the page-level legacy `/tools` → `/extensions` redirect target.
  *
@@ -353,7 +430,7 @@ export interface CoreRoutesPluginOptions {
    * pages that let anonymous viewers connect Builder credentials for their
    * own browser-scoped agent session.
    */
-  anonymousOwner?: (event: H3Event) => string | null | Promise<string | null>;
+  anonymousOwner?: BuilderAnonymousOwnerResolver;
 }
 
 /**
@@ -658,67 +735,15 @@ export function createCoreRoutesPlugin(
 
     mountBrowserSessionRoutes(nitroApp, { routePrefix: P });
 
-    type BuilderOwnerContext = {
-      email: string | undefined;
-      session: Awaited<ReturnType<typeof getSession>> | null;
-      anonymous: boolean;
-    };
-
     const resolveBuilderOwnerContext = async (
       event: H3Event,
       mode?: "connect" | "callback",
-    ): Promise<BuilderOwnerContext> => {
-      const session = await getSession(event).catch(() => null);
-      if (session?.email) {
-        return { email: session.email, session, anonymous: false };
-      }
-
-      const searchParams = getRequestURL(event).searchParams;
-
-      if (mode === "connect") {
-        const ownerFromConnectToken = verifyBuilderConnectTokenAndGetOwner(
-          searchParams.get(BUILDER_CONNECT_PARAM),
-        );
-        if (ownerFromConnectToken) {
-          return {
-            email: ownerFromConnectToken,
-            session: null,
-            anonymous: false,
-          };
-        }
-      }
-
-      if (mode === "callback") {
-        // Prefer the signed _an_state owner over the legacy
-        // an_builder_connect_owner cookie. The cookie can be stale on a
-        // shared browser — user A signed in earlier, user B starts a fresh
-        // callback with a signed state for B — and using the cookie first
-        // would mis-attribute B's Builder credentials to A. The signed
-        // state is per-flow and TTL-bounded, so it's authoritative when
-        // both are present.
-        const ownerFromCallbackState = verifyBuilderCallbackStateAndGetOwner(
-          searchParams.get(BUILDER_STATE_PARAM),
-        );
-        if (ownerFromCallbackState) {
-          return {
-            email: ownerFromCallbackState,
-            session: null,
-            anonymous: false,
-          };
-        }
-        const ownerFromCookie = readBuilderConnectOwnerCookie(event);
-        if (ownerFromCookie) {
-          return { email: ownerFromCookie, session: null, anonymous: false };
-        }
-      }
-
-      const anonymousOwner = await options.anonymousOwner?.(event);
-      if (anonymousOwner) {
-        return { email: anonymousOwner, session: null, anonymous: true };
-      }
-
-      return { email: undefined, session: null, anonymous: false };
-    };
+    ): Promise<BuilderOwnerContext> =>
+      resolveBuilderOwnerContextForRequest(
+        event,
+        { anonymousOwner: options.anonymousOwner },
+        mode,
+      );
 
     getH3App(nitroApp).use(
       `${P}/builder/status`,

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -272,6 +272,19 @@ describe("writeBuilderCredentials", () => {
     expect(mockWriteAppSecret).not.toHaveBeenCalled();
   });
 
+  it("rejects blank public keys after trimming before clearing existing rows", async () => {
+    await expect(
+      writeBuilderCredentials(
+        "owner@b.com",
+        { privateKey: "bpk-test-private", publicKey: "   " },
+        { orgId: "builder_io", role: "owner" },
+      ),
+    ).rejects.toThrow("public API key");
+
+    expect(mockDeleteAppSecret).not.toHaveBeenCalled();
+    expect(mockWriteAppSecret).not.toHaveBeenCalled();
+  });
+
   it("trims the returned Builder keys before storing them", async () => {
     await writeBuilderCredentials("owner@b.com", {
       privateKey: "  bpk-trimmed-private  ",

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -111,7 +111,7 @@ describe("resolveCredentialWriteScope", () => {
 describe("writeBuilderCredentials", () => {
   it("writes at user scope without options (legacy callers)", async () => {
     const target = await writeBuilderCredentials("a@b.com", {
-      privateKey: "pk",
+      privateKey: "bpk-test-private",
       publicKey: "pub",
     });
     expect(target).toEqual({ scope: "user", scopeId: "a@b.com" });
@@ -122,7 +122,7 @@ describe("writeBuilderCredentials", () => {
   it("writes at org scope for an owner of an active org", async () => {
     const target = await writeBuilderCredentials(
       "owner@b.com",
-      { privateKey: "pk", publicKey: "pub" },
+      { privateKey: "bpk-test-private", publicKey: "pub" },
       { orgId: "builder_io", role: "owner" },
     );
     expect(target).toEqual({ scope: "org", scopeId: "builder_io" });
@@ -136,7 +136,7 @@ describe("writeBuilderCredentials", () => {
   it("writes at user scope for a plain member of an org", async () => {
     const target = await writeBuilderCredentials(
       "member@b.com",
-      { privateKey: "pk", publicKey: "pub" },
+      { privateKey: "bpk-test-private", publicKey: "pub" },
       { orgId: "builder_io", role: "member" },
     );
     expect(target).toEqual({ scope: "user", scopeId: "member@b.com" });
@@ -146,7 +146,7 @@ describe("writeBuilderCredentials", () => {
     await writeBuilderCredentials(
       "owner@b.com",
       {
-        privateKey: "pk",
+        privateKey: "bpk-test-private",
         publicKey: "pub",
         userId: "u1",
         orgName: "Builder.io",
@@ -169,7 +169,7 @@ describe("writeBuilderCredentials", () => {
     // must not leave the previous connection's metadata in place.
     await writeBuilderCredentials(
       "owner@b.com",
-      { privateKey: "pk2", publicKey: "pub2" },
+      { privateKey: "bpk-second-private", publicKey: "pub2" },
       { orgId: "builder_io", role: "owner" },
     );
     const deleteCalls = mockDeleteAppSecret.mock.calls.map((c) => c[0]);
@@ -193,7 +193,7 @@ describe("writeBuilderCredentials", () => {
     // scope before org scope by design.
     await writeBuilderCredentials(
       "owner@b.com",
-      { privateKey: "pk-new", publicKey: "pub-new" },
+      { privateKey: "bpk-new-private", publicKey: "pub-new" },
       { orgId: "builder_io", role: "owner" },
     );
     const userDeletes = mockDeleteAppSecret.mock.calls
@@ -211,7 +211,7 @@ describe("writeBuilderCredentials", () => {
   it("does NOT touch the org-scope row when writing at user scope (other org members still need it)", async () => {
     await writeBuilderCredentials(
       "member@b.com",
-      { privateKey: "pk", publicKey: "pub" },
+      { privateKey: "bpk-test-private", publicKey: "pub" },
       { orgId: "builder_io", role: "member" },
     );
     const orgDeletes = mockDeleteAppSecret.mock.calls
@@ -234,7 +234,7 @@ describe("writeBuilderCredentials", () => {
     });
     await writeBuilderCredentials(
       "owner@b.com",
-      { privateKey: "pk", publicKey: "pub" },
+      { privateKey: "bpk-test-private", publicKey: "pub" },
       { orgId: "builder_io", role: "owner" },
     );
     const firstWrite = order.indexOf("write");
@@ -247,12 +247,48 @@ describe("writeBuilderCredentials", () => {
   it("clears the auth-failure marker for the new key pair", async () => {
     await writeBuilderCredentials(
       "owner@b.com",
-      { privateKey: "pk-new", publicKey: "pub-new" },
+      { privateKey: "bpk-new-private", publicKey: "pub-new" },
       { orgId: "builder_io", role: "owner" },
     );
-    const fingerprint = builderCredentialFingerprint("pk-new", "pub-new");
+    const fingerprint = builderCredentialFingerprint(
+      "bpk-new-private",
+      "pub-new",
+    );
     expect(mockDeleteSetting).toHaveBeenCalledWith(
       `builder-auth-failure:${fingerprint}`,
+    );
+  });
+
+  it("rejects non-private-key credentials before clearing existing rows", async () => {
+    await expect(
+      writeBuilderCredentials(
+        "owner@b.com",
+        { privateKey: "btk-personal-access-token", publicKey: "pub" },
+        { orgId: "builder_io", role: "owner" },
+      ),
+    ).rejects.toThrow("expected bpk-");
+
+    expect(mockDeleteAppSecret).not.toHaveBeenCalled();
+    expect(mockWriteAppSecret).not.toHaveBeenCalled();
+  });
+
+  it("trims the returned Builder keys before storing them", async () => {
+    await writeBuilderCredentials("owner@b.com", {
+      privateKey: "  bpk-trimmed-private  ",
+      publicKey: "  pub-trimmed  ",
+    });
+
+    expect(mockWriteAppSecret).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "BUILDER_PRIVATE_KEY",
+        value: "bpk-trimmed-private",
+      }),
+    );
+    expect(mockWriteAppSecret).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "BUILDER_PUBLIC_KEY",
+        value: "pub-trimmed",
+      }),
     );
   });
 });

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -161,6 +161,10 @@ function isCompleteBuilderConnection(creds: BuilderResolvedCredentials) {
   return Boolean(creds.privateKey && creds.publicKey);
 }
 
+export function isBuilderPrivateKey(value: string | null | undefined): boolean {
+  return typeof value === "string" && value.trim().startsWith("bpk-");
+}
+
 async function readBuilderCredentialScope(
   readAppSecret: typeof import("../secrets/storage.js").readAppSecret,
   scope: "user" | "org" | "workspace",
@@ -595,6 +599,19 @@ export async function writeBuilderCredentials(
   },
   options?: { orgId?: string | null; role?: string | null },
 ): Promise<{ scope: "user" | "org"; scopeId: string }> {
+  const privateKey = creds.privateKey.trim();
+  const publicKey = creds.publicKey.trim();
+  if (!isBuilderPrivateKey(privateKey)) {
+    throw new Error(
+      "Builder returned a credential that is not a Builder private key (expected bpk-...). Restart the Builder connect flow and choose a space that can issue a private key.",
+    );
+  }
+  if (!publicKey) {
+    throw new Error(
+      "Builder did not return a public API key. Restart the Builder connect flow.",
+    );
+  }
+
   const { writeAppSecret, deleteAppSecret } =
     await import("../secrets/storage.js");
   const target = resolveCredentialWriteScope(
@@ -622,8 +639,8 @@ export async function writeBuilderCredentials(
   await Promise.all(cleanups);
 
   const entries: Array<{ key: string; value: string }> = [
-    { key: "BUILDER_PRIVATE_KEY", value: creds.privateKey },
-    { key: "BUILDER_PUBLIC_KEY", value: creds.publicKey },
+    { key: "BUILDER_PRIVATE_KEY", value: privateKey },
+    { key: "BUILDER_PUBLIC_KEY", value: publicKey },
   ];
   if (creds.userId) {
     entries.push({ key: "BUILDER_USER_ID", value: creds.userId });
@@ -645,8 +662,8 @@ export async function writeBuilderCredentials(
     ),
   );
   await clearBuilderCredentialAuthFailure({
-    privateKey: creds.privateKey,
-    publicKey: creds.publicKey,
+    privateKey,
+    publicKey,
   });
   return target;
 }

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1067,7 +1067,7 @@ ${
         return;
       }
       __anSetOAuthDebug('OAuth exchange redeemed; returning to the app', flowId);
-      window.location.href = ret || '/';
+      __anRedirectToSignedInApp(ret);
     }
     function __anGetReturnPath() {
       try {
@@ -1076,6 +1076,53 @@ ${
       } catch(e) {}
       return window.location.pathname + window.location.search;
     }
+    function __anMountedPathname(pathname) {
+      var base = __anBasePath();
+      if (base && pathname.indexOf(base + '/') === 0) return pathname.slice(base.length);
+      if (base && pathname === base) return '/';
+      return pathname || '/';
+    }
+    function __anIsAuthEntryPath(pathname) {
+      var p = __anMountedPathname(pathname);
+      return p === '/login' || p === '/signup' || p === '/_agent-native/sign-in';
+    }
+    function __anGetSignedInReturnPath() {
+      try {
+        var inner = new URLSearchParams(window.location.search).get('return');
+        if (inner) return inner;
+      } catch(e) {}
+      if (__anIsAuthEntryPath(window.location.pathname)) return __anPath('/');
+      return window.location.pathname + window.location.search + window.location.hash;
+    }
+    function __anWithAuthCacheBypass(ret) {
+      try {
+        var url = new URL(ret || __anPath('/'), window.location.origin);
+        url.searchParams.set('__an_auth_redirect', Date.now().toString(36));
+        return url.pathname + url.search + url.hash;
+      } catch(e) {
+        var fallback = ret || __anPath('/');
+        var hashIndex = fallback.indexOf('#');
+        var beforeHash = hashIndex === -1 ? fallback : fallback.slice(0, hashIndex);
+        var hash = hashIndex === -1 ? '' : fallback.slice(hashIndex);
+        var sep = beforeHash.indexOf('?') === -1 ? '?' : '&';
+        return beforeHash + sep + '__an_auth_redirect=' + Date.now().toString(36) + hash;
+      }
+    }
+    function __anRedirectToSignedInApp(ret) {
+      window.location.replace(__anWithAuthCacheBypass(ret || __anGetSignedInReturnPath()));
+    }
+    (function __anRedirectIfAlreadySignedIn() {
+      fetch(__anPath('/_agent-native/auth/session'), {
+        headers: { 'Accept': 'application/json' },
+        credentials: 'include',
+        cache: 'no-store',
+      }).then(function(res) {
+        if (!res.ok) return null;
+        return res.json().catch(function() { return null; });
+      }).then(function(data) {
+        if (data && data.email && !data.error) __anRedirectToSignedInApp();
+      }).catch(function() {});
+    })();
     var __anBuilderPreviewSeen = false;
     function __anRememberBuilderPreview() {
       __anBuilderPreviewSeen = true;
@@ -1418,7 +1465,7 @@ ${
         body: JSON.stringify({ email: email, password: password }),
       });
       if (res.ok) {
-        window.location.reload();
+        __anRedirectToSignedInApp();
         return { ok: true };
       }
       var data = await res.json().catch(function() { return {}; });
@@ -1450,7 +1497,7 @@ ${
         });
         var data = await res.json().catch(function() { return {}; });
         if (res.ok && data && data.email && !data.error) {
-          window.location.reload();
+          __anRedirectToSignedInApp();
           return;
         }
         var loginResult = await signInWithPendingSignup();
@@ -1617,7 +1664,7 @@ ${
         if (loginRes.ok) {
           msg.textContent = 'Account created — signing you in…';
           msg.classList.add('show', 'success');
-          window.location.reload();
+          __anRedirectToSignedInApp();
           return;
         }
           btn.disabled = false;
@@ -1739,7 +1786,7 @@ ${
         }),
       });
       if (res.ok) {
-        window.location.reload();
+        __anRedirectToSignedInApp();
         return;
       }
       var data = await res.json().catch(function() { return {}; });

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -141,6 +141,27 @@ describe("createH3SSRHandler", () => {
     );
   });
 
+  it("preserves React Router's default no-cache policy on authenticated .data responses", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response('[{"_1":2},"routes/account"]', {
+        headers: {
+          "cache-control": "no-cache",
+          "content-type": "text/x-script",
+          "x-remix-response": "yes",
+        },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(
+      createEvent("/account.data", "GET", {
+        headers: { cookie: "an_session=active" },
+      }),
+    );
+
+    expect(response.headers.get("cache-control")).toBe("no-cache");
+  });
+
   it("preserves explicit private cache policies on .data responses", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response('[{"_1":2},"routes/private"]', {

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -158,6 +158,22 @@ describe("createH3SSRHandler", () => {
     expect(response.headers.get("cache-control")).toBe("private, no-store");
   });
 
+  it("does not replace no-cache on non-React Router .data responses", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response('{"ok":true}', {
+        headers: {
+          "cache-control": "no-cache",
+          "content-type": "application/json",
+        },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(createEvent("/custom.data"));
+
+    expect(response.headers.get("cache-control")).toBe("no-cache");
+  });
+
   it("injects the default social image into SSR HTML without one", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response(

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -122,6 +122,42 @@ describe("createH3SSRHandler", () => {
     );
   });
 
+  it("replaces React Router's default no-cache policy on .data responses", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response('[{"_1":2},"routes/docs.$slug"]', {
+        headers: {
+          "cache-control": "no-cache",
+          "content-type": "text/x-script",
+          "x-remix-response": "yes",
+        },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(createEvent("/docs/template-calendar.data"));
+
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
+  });
+
+  it("preserves explicit private cache policies on .data responses", async () => {
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response('[{"_1":2},"routes/private"]', {
+        headers: {
+          "cache-control": "private, no-store",
+          "content-type": "text/x-script",
+          "x-remix-response": "yes",
+        },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(createEvent("/private.data"));
+
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+  });
+
   it("injects the default social image into SSR HTML without one", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response(

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -217,6 +217,7 @@ function shouldUseDefaultSsrCacheHeader(
   headers: Headers,
   status: number,
   pathname: string,
+  hasAuthSignal: boolean,
 ): boolean {
   if (status < 200 || status >= 400) return false;
 
@@ -226,6 +227,7 @@ function shouldUseDefaultSsrCacheHeader(
   }
 
   if (!pathname.endsWith(".data")) return false;
+  if (hasAuthSignal) return false;
   if (!contentType.includes("text/x-script")) return false;
 
   const cacheControl = headers.get("cache-control");
@@ -236,8 +238,13 @@ function applyDefaultSsrCacheHeader(
   headers: Headers,
   status: number,
   pathname: string,
+  hasAuthSignal: boolean,
 ) {
-  if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname)) return;
+  if (
+    !shouldUseDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal)
+  ) {
+    return;
+  }
   headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
 }
 
@@ -263,10 +270,11 @@ async function rewriteMountedResponse(
   response: Response,
   basePath: string,
   pathname: string,
+  hasAuthSignal: boolean,
 ): Promise<Response> {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
-  applyDefaultSsrCacheHeader(headers, response.status, pathname);
+  applyDefaultSsrCacheHeader(headers, response.status, pathname, hasAuthSignal);
 
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {
@@ -347,12 +355,14 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
           }),
           basePath,
           p,
+          hasAuthSignal,
         );
       }
       return await rewriteMountedResponse(
         await runWithRequestContext(ctx, () => handler(request)),
         basePath,
         p,
+        hasAuthSignal,
       );
     } catch (err) {
       // Log the full stack server-side, but never leak it to the client.

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -213,13 +213,30 @@ function isAuthenticatedCookieName(name: string): boolean {
   );
 }
 
-function applyDefaultSsrCacheHeader(headers: Headers, status: number) {
-  if (headers.has("cache-control")) return;
-  if (status < 200 || status >= 400) return;
+function shouldUseDefaultSsrCacheHeader(
+  headers: Headers,
+  status: number,
+  pathname: string,
+): boolean {
+  if (status < 200 || status >= 400) return false;
 
   const contentType = headers.get("content-type")?.toLowerCase() ?? "";
-  if (!contentType.includes("text/html")) return;
+  if (contentType.includes("text/html")) {
+    return !headers.has("cache-control");
+  }
 
+  if (!pathname.endsWith(".data")) return false;
+
+  const cacheControl = headers.get("cache-control");
+  return !cacheControl || cacheControl.trim().toLowerCase() === "no-cache";
+}
+
+function applyDefaultSsrCacheHeader(
+  headers: Headers,
+  status: number,
+  pathname: string,
+) {
+  if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname)) return;
   headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
 }
 
@@ -244,10 +261,11 @@ function isFrameworkOrAssetPath(pathname: string): boolean {
 async function rewriteMountedResponse(
   response: Response,
   basePath: string,
+  pathname: string,
 ): Promise<Response> {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
-  applyDefaultSsrCacheHeader(headers, response.status);
+  applyDefaultSsrCacheHeader(headers, response.status, pathname);
 
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {
@@ -327,11 +345,13 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
             headers: response.headers,
           }),
           basePath,
+          p,
         );
       }
       return await rewriteMountedResponse(
         await runWithRequestContext(ctx, () => handler(request)),
         basePath,
+        p,
       );
     } catch (err) {
       // Log the full stack server-side, but never leak it to the client.

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -226,6 +226,7 @@ function shouldUseDefaultSsrCacheHeader(
   }
 
   if (!pathname.endsWith(".data")) return false;
+  if (!contentType.includes("text/x-script")) return false;
 
   const cacheControl = headers.get("cache-control");
   return !cacheControl || cacheControl.trim().toLowerCase() === "no-cache";

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -26,9 +26,9 @@ import {
   EMBED_TOKEN_QUERY_PARAM,
 } from "../shared/embed-auth.js";
 import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
+import { DEFAULT_SSR_CACHE_CONTROL } from "../shared/cache-control.js";
 
-export const DEFAULT_SSR_CACHE_CONTROL =
-  "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+export { DEFAULT_SSR_CACHE_CONTROL } from "../shared/cache-control.js";
 const ANONYMOUS_SESSION_COOKIE_NAMES = new Set(["an_docs_session"]);
 const BETTER_AUTH_SESSION_COOKIE_RE = /\.session_(?:token|data)$/;
 

--- a/packages/core/src/shared/cache-control.ts
+++ b/packages/core/src/shared/cache-control.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_SSR_CACHE_CONTROL =
+  "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";

--- a/packages/core/src/templates/workspace-root/package.json
+++ b/packages/core/src/templates/workspace-root/package.json
@@ -23,5 +23,10 @@
     "tsx": "catalog:",
     "typescript": "^6.0.3"
   },
+  "pnpm": {
+    "overrides": {
+      "better-auth": "1.6.0"
+    }
+  },
   "packageManager": "pnpm@10.14.0"
 }

--- a/templates/assets/actions/list-libraries.ts
+++ b/templates/assets/actions/list-libraries.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { and, desc, inArray, isNull } from "drizzle-orm";
 import { accessFilter } from "@agent-native/core/sharing";
 import { getDb, schema } from "../server/db/index.js";
+import { parseJson } from "../server/lib/json.js";
 import { serializeAsset, serializeLibrary } from "./_helpers.js";
 
 function isImageAsset(asset: typeof schema.assets.$inferSelect): boolean {
@@ -12,8 +13,22 @@ function isImageAsset(asset: typeof schema.assets.$inferSelect): boolean {
   );
 }
 
+function isContentOnlyReference(
+  asset: typeof schema.assets.$inferSelect,
+): boolean {
+  if (asset.role === "subject_reference") return true;
+  const metadata = parseJson<Record<string, unknown>>(asset.metadata, {});
+  return metadata.intent === "subject";
+}
+
+function isReusableReference(
+  asset: typeof schema.assets.$inferSelect,
+): boolean {
+  return asset.status === "reference" && !isContentOnlyReference(asset);
+}
+
 function previewPriority(asset: typeof schema.assets.$inferSelect): number {
-  if (asset.status === "reference") return 0;
+  if (isReusableReference(asset)) return 0;
   if (asset.status === "saved") return 1;
   if (asset.role === "generated") return 2;
   return 3;
@@ -89,8 +104,8 @@ export default defineAction({
         ? { id: base.id, title: base.title, description: base.description }
         : {
             ...base,
-            referenceCount: libAssets.filter(
-              (asset) => asset.status === "reference",
+            referenceCount: libAssets.filter((asset) =>
+              isReusableReference(asset),
             ).length,
             generatedCount: libAssets.filter(
               (asset) => asset.role === "generated",

--- a/templates/assets/app/routes/_index.tsx
+++ b/templates/assets/app/routes/_index.tsx
@@ -603,6 +603,7 @@ function HomeGeneratePanel({
     let uploadedAssets: { id: string; title: string }[] = [];
     if (imageFiles.length > 0 && selectedLibrary) {
       const uploadChunks = chunkAssetUploads(imageFiles);
+      const attachedAssetIds = new Set<string>();
       const uploadingToast = toast.loading(
         `Uploading ${imageFiles.length} content image${imageFiles.length === 1 ? "" : "s"}...`,
         {
@@ -632,12 +633,27 @@ function HomeGeneratePanel({
           const data = (await res.json()) as AssetUploadResult;
           skippedCount += getSkippedDuplicateCount(data);
           failedCount += getFailedUploadCount(data);
-          uploadedAssets.push(
-            ...(data.assets ?? []).map((a: any) => ({
-              id: a.id,
-              title: a.title || "Content image",
+          const attachedAssets = [
+            ...(data.assets ?? []).map((asset) => ({
+              id: asset.id,
+              title: asset.title || "Content image",
             })),
-          );
+            ...(data.skippedDuplicates ?? [])
+              .filter(
+                (duplicate) =>
+                  duplicate.reason === "existing-asset" &&
+                  Boolean(duplicate.assetId),
+              )
+              .map((duplicate) => ({
+                id: duplicate.assetId!,
+                title: duplicate.title || "Content image",
+              })),
+          ];
+          for (const asset of attachedAssets) {
+            if (attachedAssetIds.has(asset.id)) continue;
+            attachedAssetIds.add(asset.id);
+            uploadedAssets.push(asset);
+          }
         }
         const uploadedCount = uploadedAssets.length;
         if (failedCount > 0) {

--- a/templates/assets/app/routes/_index.tsx
+++ b/templates/assets/app/routes/_index.tsx
@@ -590,13 +590,13 @@ function HomeGeneratePanel({
 
     if (unsupportedFiles.length > 0) {
       toast.error(
-        "Attach image files as references, or text files as prompt context.",
+        "Attach image files as content references, or text files as prompt context.",
       );
       return;
     }
 
     if (imageFiles.length > 0 && !selectedLibrary) {
-      toast.error("Pick a library to attach reference images.");
+      toast.error("Pick a library to attach content images.");
       return;
     }
 
@@ -604,7 +604,7 @@ function HomeGeneratePanel({
     if (imageFiles.length > 0 && selectedLibrary) {
       const uploadChunks = chunkAssetUploads(imageFiles);
       const uploadingToast = toast.loading(
-        `Uploading ${imageFiles.length} reference${imageFiles.length === 1 ? "" : "s"}...`,
+        `Uploading ${imageFiles.length} content image${imageFiles.length === 1 ? "" : "s"}...`,
         {
           description:
             uploadChunks.length > 1
@@ -618,7 +618,8 @@ function HomeGeneratePanel({
         for (const chunk of uploadChunks) {
           const form = new FormData();
           form.append("libraryId", selectedLibrary.id);
-          form.append("category", "style-only");
+          form.append("category", "other");
+          form.append("intent", "subject");
           for (const file of chunk) form.append("files", file);
           const res = await fetch(`${appBasePath()}/api/assets/upload`, {
             method: "POST",
@@ -634,14 +635,14 @@ function HomeGeneratePanel({
           uploadedAssets.push(
             ...(data.assets ?? []).map((a: any) => ({
               id: a.id,
-              title: a.title || "Reference image",
+              title: a.title || "Content image",
             })),
           );
         }
         const uploadedCount = uploadedAssets.length;
         if (failedCount > 0) {
           toast.warning(
-            `Added ${uploadedCount} reference${
+            `Attached ${uploadedCount} content image${
               uploadedCount === 1 ? "" : "s"
             }; ${failedCount} failed.`,
             {
@@ -654,7 +655,7 @@ function HomeGeneratePanel({
           );
         } else if (uploadedCount > 0 && skippedCount > 0) {
           toast.success(
-            `Added ${uploadedCount} reference${
+            `Attached ${uploadedCount} content image${
               uploadedCount === 1 ? "" : "s"
             }; skipped ${skippedCount} duplicate${
               skippedCount === 1 ? "" : "s"
@@ -663,14 +664,14 @@ function HomeGeneratePanel({
           );
         } else if (uploadedCount > 0) {
           toast.success(
-            `Added ${uploadedCount} reference${
+            `Attached ${uploadedCount} content image${
               uploadedCount === 1 ? "" : "s"
-            } to ${selectedLibrary.title}`,
+            } for this request`,
             { id: uploadingToast, description: null },
           );
         } else if (skippedCount > 0) {
           toast.warning(
-            `Skipped ${skippedCount} duplicate reference${
+            `Skipped ${skippedCount} duplicate content image${
               skippedCount === 1 ? "" : "s"
             }.`,
             {
@@ -679,13 +680,13 @@ function HomeGeneratePanel({
             },
           );
         } else {
-          toast.warning("No new references were added.", {
+          toast.warning("No new content images were attached.", {
             id: uploadingToast,
             description: null,
           });
         }
       } catch (err: any) {
-        toast.error(err?.message || "Couldn't upload references.", {
+        toast.error(err?.message || "Couldn't upload content images.", {
           id: uploadingToast,
           description: null,
         });
@@ -707,30 +708,40 @@ function HomeGeneratePanel({
       }
     }
 
-    const messageLines = [
+    const chatMessage =
+      trimmed ||
+      (uploadedAssets.length > 0
+        ? "Generate from the attached content images."
+        : "Generate from the attached context.");
+    const requestLines = [
       requestedMediaType === "video"
-        ? "Generate 1 video candidate."
-        : `Generate ${count} image candidate${count === 1 ? "" : "s"}.`,
-      `Prompt: ${trimmed}`,
+        ? "Requested output: 1 video candidate"
+        : `Requested output: ${count} image candidate${count === 1 ? "" : "s"}`,
+      `User prompt: ${trimmed || "(no text prompt provided)"}`,
       `Aspect ratio: ${aspectRatio}`,
       selectedLibrary
         ? `Use library: ${selectedLibrary.title} (${selectedLibrary.id})`
         : "No library selected; match-library if you find a strong fit, otherwise generate generic.",
     ];
     if (uploadedAssets.length > 0) {
-      messageLines.push(
-        `Just uploaded ${uploadedAssets.length} new reference${
+      requestLines.push(
+        `Attached ${uploadedAssets.length} content image${
           uploadedAssets.length === 1 ? "" : "s"
-        } to the library - prioritize them: ${uploadedAssets
+        } for this request - use as source/content context, not reusable style inspiration: ${uploadedAssets
           .map((a) => a.id)
           .join(", ")}`,
+        uploadedAssets.length === 1
+          ? `If the user wants the attached image preserved or restyled, pass subjectAssetId: ${uploadedAssets[0].id}.`
+          : "Pass these IDs explicitly as referenceAssetIds or subjectAssetId values when the content needs to influence generation.",
       );
     }
 
-    const contextLines = ["## Assets create composer"];
+    const contextLines = ["## Assets create composer", ...requestLines];
     if (selectedLibrary) {
       const customInstructions = getLibraryCustomInstructions(selectedLibrary);
       contextLines.push(
+        "",
+        "## Selected library",
         `Library: ${selectedLibrary.title} (${selectedLibrary.id})`,
         `Description: ${selectedLibrary.description || ""}`,
         `References: ${selectedLibrary.referenceCount ?? 0}`,
@@ -746,22 +757,20 @@ function HomeGeneratePanel({
     if (uploadedAssets.length > 0) {
       contextLines.push(
         "",
-        "## Newly uploaded references (this turn)",
+        "## Attached content images (this turn)",
         ...uploadedAssets.map((a) => `- ${a.id} - ${a.title}`),
         "",
-        "These were just added to the library. Treat them as the highest-weight style references for this generation.",
+        "These are content-only source images for this request. Use them for subject, product, composition, or source-image context; do not treat them as style-guide inspiration or reusable style anchors.",
       );
     }
     if (textContextSnippets.length > 0) {
       contextLines.push(
         "",
-        "## Attached text context (this turn)",
-        ...textContextSnippets,
-      );
-      messageLines.push(
         `Use ${textContextSnippets.length} attached text context file${
           textContextSnippets.length === 1 ? "" : "s"
         } from the request context.`,
+        "## Attached text context (this turn)",
+        ...textContextSnippets,
       );
     }
     contextLines.push(
@@ -772,7 +781,7 @@ function HomeGeneratePanel({
     );
 
     sendToAgentChat({
-      message: messageLines.join("\n"),
+      message: chatMessage,
       context: contextLines.join("\n"),
       submit: true,
       newTab: true,
@@ -803,8 +812,8 @@ function HomeGeneratePanel({
               placeholder={
                 selectedLibrary
                   ? mediaType === "video"
-                    ? "Describe the video - attach image references or text context with +"
-                    : "Describe the asset - attach references or text context with +"
+                    ? "Describe the video - attach content images or text context with +"
+                    : "Describe the asset - attach content images or text context with +"
                   : mediaType === "video"
                     ? "Describe the video you want to generate"
                     : "Describe the asset you want to generate"

--- a/templates/assets/app/routes/asset.$id.tsx
+++ b/templates/assets/app/routes/asset.$id.tsx
@@ -51,6 +51,7 @@ export default function AssetDetailPage() {
   const isVideo =
     asset.mediaType === "video" || asset.mimeType?.startsWith("video/");
   const previewUrl = assetMediaUrl(asset.previewUrl);
+  const categoryLabel = assetCategoryLabel(asset);
 
   function refine() {
     sendToAgentChat({
@@ -119,9 +120,7 @@ export default function AssetDetailPage() {
           <Badge variant="secondary">{asset.status}</Badge>
           <Badge variant="outline">{asset.role}</Badge>
           <Badge variant="outline">{isVideo ? "video" : "image"}</Badge>
-          {asset.metadata?.category && (
-            <Badge variant="outline">{asset.metadata.category}</Badge>
-          )}
+          {categoryLabel && <Badge variant="outline">{categoryLabel}</Badge>}
         </div>
         <Separator className="my-5" />
         <div className="space-y-4 text-sm">
@@ -244,6 +243,19 @@ export default function AssetDetailPage() {
       </div>
     </div>
   );
+}
+
+function assetCategoryLabel(asset: any): string | null {
+  if (
+    asset?.metadata?.intent === "subject" ||
+    asset?.role === "subject_reference"
+  ) {
+    return "content only";
+  }
+  const category = asset?.metadata?.category;
+  if (typeof category !== "string") return null;
+  if (category === "style-only") return "style reference";
+  return category.replace(/-/g, " ");
 }
 
 function AssetImagePreview({

--- a/templates/assets/app/routes/library.$id.tsx
+++ b/templates/assets/app/routes/library.$id.tsx
@@ -184,7 +184,8 @@ export default function LibraryPage() {
       asset.mimeType,
       asset.status,
       asset.role,
-      asset.metadata?.category,
+      assetCategoryLabel(asset),
+      asset.metadata?.intent,
       asset.metadata?.originalName,
     ]
       .filter((value): value is string => typeof value === "string")
@@ -478,8 +479,31 @@ export default function LibraryPage() {
     const selectedPreset = options.presetId
       ? generationPresets.find((preset) => preset.id === options.presetId)
       : null;
+    const trimmedPrompt = prompt.trim();
+    const chatMessage =
+      trimmedPrompt ||
+      (options.mediaType === "video"
+        ? "Generate a video for this library."
+        : "Generate images for this library.");
     const context = [
       "## Assets library context",
+      options.mediaType === "video"
+        ? "Requested output: 1 video candidate for this library"
+        : `Requested output: ${options.count} image candidate${options.count === 1 ? "" : "s"} for this library`,
+      `User prompt: ${trimmedPrompt || "(no text prompt provided)"}`,
+      options.presetId ? `Preset ID: ${options.presetId}` : "Preset ID: none",
+      `Aspect ratio: ${options.aspectRatio}`,
+      options.mediaType === "video"
+        ? `Duration: ${options.durationSeconds}s\nResolution: ${options.resolution}`
+        : `Image size: ${options.imageSize}`,
+      `Model: ${options.model}`,
+      activeFolderId && activeFolderId !== "all"
+        ? `Folder ID: ${activeFolderId}`
+        : "Folder ID: none",
+      `Reference categories: ${options.category}`,
+      `Include canonical logo: ${options.includeLogo ? "yes" : "no"}`,
+      "",
+      "## Selected library",
       `Library: ${library.title} (${library.id})`,
       `Description: ${library.description || ""}`,
       `Folder: ${activeFolderId && activeFolderId !== "all" ? folders.find((folder) => folder.id === activeFolderId)?.title : "All assets"}`,
@@ -498,23 +522,7 @@ export default function LibraryPage() {
         : "Use the asset generation actions. If a generation preset ID is present, pass presetId to generate-image or generate-image-batch. Generate candidates, show previews, ask for feedback, and refine by assetId until the user is happy.",
     ].join("\n");
     sendToAgentChat({
-      message: [
-        options.mediaType === "video"
-          ? "Generate 1 video candidate for this library."
-          : `Generate ${options.count} image candidate${options.count === 1 ? "" : "s"} for this library.`,
-        `Prompt: ${prompt}`,
-        options.presetId ? `Preset ID: ${options.presetId}` : "Preset ID: none",
-        `Aspect ratio: ${options.aspectRatio}`,
-        options.mediaType === "video"
-          ? `Duration: ${options.durationSeconds}s\nResolution: ${options.resolution}`
-          : `Image size: ${options.imageSize}`,
-        `Model: ${options.model}`,
-        activeFolderId && activeFolderId !== "all"
-          ? `Folder ID: ${activeFolderId}`
-          : "Folder ID: none",
-        `Reference categories: ${options.category}`,
-        `Include canonical logo: ${options.includeLogo ? "yes" : "no"}`,
-      ].join("\n"),
+      message: chatMessage,
       context,
       submit: true,
       newTab: true,
@@ -603,7 +611,7 @@ export default function LibraryPage() {
                 "Upload, generate, describe, and organize reusable assets across agents."}
             </p>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:flex-nowrap lg:shrink-0">
             <ShareButton
               resourceType="asset-library"
               resourceId={library.id}
@@ -624,7 +632,7 @@ export default function LibraryPage() {
             </Button>
             <Button
               variant="outline"
-              className="gap-2"
+              className="hidden gap-2 xl:inline-flex"
               onClick={() => setFolderOpen(true)}
             >
               <IconFolderPlus className="h-4 w-4" />
@@ -649,6 +657,17 @@ export default function LibraryPage() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  className="xl:hidden"
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    setFolderOpen(true);
+                  }}
+                >
+                  <IconFolderPlus className="mr-2 h-4 w-4 shrink-0" />
+                  New folder
+                </DropdownMenuItem>
+                <DropdownMenuSeparator className="xl:hidden" />
                 <DropdownMenuItem
                   onSelect={(event) => {
                     event.preventDefault();
@@ -721,13 +740,6 @@ export default function LibraryPage() {
       ) : null}
 
       <div className="flex-1 overflow-y-auto px-6 py-5">
-        <BrandSummaryCard
-          library={library}
-          assets={assets}
-          referencesCount={references.length}
-          onGenerate={() => setGenerateOpen(true)}
-        />
-
         <section className="mb-5 space-y-3">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
             <div className="flex min-w-0 flex-wrap items-center gap-2">
@@ -1020,135 +1032,6 @@ type PendingUpload = {
 
 type LibraryTab = "references" | "generated" | "runs" | "settings";
 
-function BrandSummaryCard({
-  library,
-  assets,
-  referencesCount,
-  onGenerate,
-}: {
-  library: any;
-  assets: any[];
-  referencesCount: number;
-  onGenerate: () => void;
-}) {
-  const style = library.styleBrief ?? {};
-  const settings = library.settings ?? {};
-  const analysis = settings.brandAnalysis ?? {};
-  const canonicalIds = Array.isArray(settings.canonicalStyleAssetIds)
-    ? settings.canonicalStyleAssetIds.filter(
-        (id: unknown): id is string => typeof id === "string",
-      )
-    : [];
-  const anchors = assets
-    .filter(
-      (asset) =>
-        asset.metadata?.isStyleAnchor === true ||
-        canonicalIds.includes(asset.id),
-    )
-    .slice(0, 4);
-  const palette = Array.isArray(style.palette) ? style.palette.slice(0, 6) : [];
-  const constraints = Array.isArray(style.doNot) ? style.doNot.slice(0, 2) : [];
-  const traits = [style.medium, style.mood, style.texture]
-    .filter((item): item is string => typeof item === "string" && !!item.trim())
-    .slice(0, 3);
-  const analyzedCount =
-    typeof analysis.analyzedImageCount === "number"
-      ? analysis.analyzedImageCount
-      : typeof analysis.referenceCount === "number"
-        ? analysis.referenceCount
-        : referencesCount;
-
-  return (
-    <section className="mb-5 rounded-lg border border-border bg-card p-4">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="min-w-0 space-y-3">
-          <div className="flex flex-wrap items-center gap-2">
-            <h3 className="text-sm font-semibold">Brand summary</h3>
-            <Badge variant={analysis.analyzedAt ? "secondary" : "outline"}>
-              {analysis.analyzedAt ? "Learned" : "Needs analysis"}
-            </Badge>
-            <span className="text-xs text-muted-foreground">
-              {analyzedCount} reference{analyzedCount === 1 ? "" : "s"}
-              {analysis.analyzedAt
-                ? ` · Last analyzed ${formatBrandAnalysisTime(
-                    analysis.analyzedAt,
-                  )}`
-                : ""}
-            </span>
-          </div>
-          <p className="line-clamp-2 max-w-4xl text-sm leading-relaxed text-foreground">
-            {style.description ||
-              "Upload example assets, analyze the brand in Settings, then generate from a prompt with the library look applied."}
-          </p>
-          <div className="flex flex-wrap items-center gap-3">
-            {palette.length ? (
-              <div className="flex items-center gap-1.5">
-                {palette.map((color: string) => (
-                  <span
-                    key={color}
-                    className="h-5 w-5 rounded border border-border"
-                    style={{ backgroundColor: color }}
-                    title={color}
-                  />
-                ))}
-              </div>
-            ) : null}
-            {traits.map((trait) => (
-              <Badge
-                key={trait}
-                variant="outline"
-                className="max-w-52 truncate"
-              >
-                {trait}
-              </Badge>
-            ))}
-            {constraints.map((constraint: string) => (
-              <Badge
-                key={constraint}
-                variant="outline"
-                className="max-w-64 truncate text-muted-foreground"
-              >
-                Avoid {constraint}
-              </Badge>
-            ))}
-          </div>
-          {anchors.length ? (
-            <div className="flex items-center gap-2">
-              <span className="text-xs font-medium text-muted-foreground">
-                Anchors
-              </span>
-              <div className="flex -space-x-2">
-                {anchors.map((asset) => (
-                  <img
-                    key={asset.id}
-                    src={assetMediaUrl(asset.thumbnailUrl || asset.previewUrl)}
-                    alt=""
-                    className="h-8 w-8 rounded-md border border-background object-cover"
-                  />
-                ))}
-              </div>
-            </div>
-          ) : null}
-        </div>
-        <Button className="shrink-0 gap-2" onClick={onGenerate}>
-          <IconMessageCircle className="h-4 w-4" />
-          Generate
-        </Button>
-      </div>
-    </section>
-  );
-}
-
-function formatBrandAnalysisTime(value: unknown): string {
-  if (typeof value !== "string" || !value) return "unknown";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "unknown";
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(date);
-}
-
 function RunCard({
   run,
   outputAssets,
@@ -1356,10 +1239,23 @@ function assetDisplayTitle(asset: any): string {
   return (
     assetLineageLabel(asset) ||
     asset.title ||
-    asset.metadata?.category ||
+    assetCategoryLabel(asset) ||
     asset.status ||
     "Asset"
   );
+}
+
+function assetCategoryLabel(asset: any): string | null {
+  if (
+    asset?.metadata?.intent === "subject" ||
+    asset?.role === "subject_reference"
+  ) {
+    return "content only";
+  }
+  const category = asset?.metadata?.category;
+  if (typeof category !== "string") return null;
+  if (category === "style-only") return "style reference";
+  return category.replace(/-/g, " ");
 }
 
 function assetLineageSourceText(asset: any): string | null {
@@ -2457,9 +2353,9 @@ function AssetGrid({
                     ) : null}
                     <div className="flex items-center gap-2">
                       <Badge variant="secondary">{asset.status}</Badge>
-                      {asset.metadata?.category && (
+                      {assetCategoryLabel(asset) && (
                         <Badge variant="outline">
-                          {asset.metadata.category}
+                          {assetCategoryLabel(asset)}
                         </Badge>
                       )}
                     </div>

--- a/templates/assets/server/handlers/assets.ts
+++ b/templates/assets/server/handlers/assets.ts
@@ -195,6 +195,7 @@ export const uploadAssets = defineEventHandler(async (event) =>
     const intent = intentFromForm(readField(parts, "intent"));
     const category =
       intent === "subject" ? "other" : categoryFromForm(rawCategory);
+    const role = roleFromUpload(category, intent);
     const title = readField(parts, "title") || null;
     const files =
       parts?.filter((part) => part.name === "files" && part.data) ?? [];
@@ -263,6 +264,7 @@ export const uploadAssets = defineEventHandler(async (event) =>
         and(
           eq(schema.assets.libraryId, libraryId),
           eq(schema.assets.status, "reference"),
+          eq(schema.assets.role, role),
         ),
       );
     const deduped = await filterDuplicateAssetUploads({
@@ -291,7 +293,7 @@ export const uploadAssets = defineEventHandler(async (event) =>
             buffer: file.buffer,
             mimeType: file.mimeType,
             mediaType: file.mediaType,
-            role: roleFromUpload(category, intent),
+            role,
             status: "reference",
             title: file.title,
             altText: file.altText,

--- a/templates/assets/server/handlers/assets.ts
+++ b/templates/assets/server/handlers/assets.ts
@@ -89,12 +89,30 @@ function categoryFromForm(value: unknown): ImageCategory {
     : "style-only";
 }
 
-function roleFromCategory(category: ImageCategory): ImageRole {
+function intentFromForm(value: unknown): "subject" | null {
+  return value === "subject" ? "subject" : null;
+}
+
+function roleFromUpload(
+  category: ImageCategory,
+  intent: "subject" | null,
+): ImageRole {
+  if (intent === "subject") return "subject_reference";
   if (category === "logo") return "logo_reference";
   if (category === "product") return "product_reference";
   if (category === "diagram") return "diagram_reference";
   if (category === "video") return "video_reference";
   return "style_reference";
+}
+
+function defaultUploadTitle(
+  mediaType: "image" | "video",
+  intent: "subject" | null,
+): string {
+  if (intent === "subject") {
+    return mediaType === "video" ? "Content video" : "Content image";
+  }
+  return mediaType === "video" ? "Reference video" : "Reference image";
 }
 
 function hasAllowedSignature(mimeType: string, data: Uint8Array): boolean {
@@ -173,8 +191,12 @@ export const uploadAssets = defineEventHandler(async (event) =>
     if (folderId) {
       await assertFolderBelongsToLibrary(folderId, libraryId);
     }
-    const category = categoryFromForm(readField(parts, "category"));
-    const intent = readField(parts, "intent");
+    const rawCategory = readField(parts, "category");
+    const intent = intentFromForm(readField(parts, "intent"));
+    const category =
+      intent === "subject" && (!rawCategory || rawCategory === "style-only")
+        ? "other"
+        : categoryFromForm(rawCategory);
     const title = readField(parts, "title") || null;
     const files =
       parts?.filter((part) => part.name === "files" && part.data) ?? [];
@@ -218,10 +240,7 @@ export const uploadAssets = defineEventHandler(async (event) =>
         filename,
         mimeType,
         mediaType,
-        title:
-          title ||
-          filename ||
-          (mediaType === "video" ? "Reference video" : "Reference image"),
+        title: title || filename || defaultUploadTitle(mediaType, intent),
         metadata: {
           contentHash,
           ...(intent === "subject" ? { intent: "subject" } : {}),
@@ -274,7 +293,7 @@ export const uploadAssets = defineEventHandler(async (event) =>
             buffer: file.buffer,
             mimeType: file.mimeType,
             mediaType: file.mediaType,
-            role: roleFromCategory(category),
+            role: roleFromUpload(category, intent),
             status: "reference",
             title: file.title,
             altText: file.altText,

--- a/templates/assets/server/handlers/assets.ts
+++ b/templates/assets/server/handlers/assets.ts
@@ -194,9 +194,7 @@ export const uploadAssets = defineEventHandler(async (event) =>
     const rawCategory = readField(parts, "category");
     const intent = intentFromForm(readField(parts, "intent"));
     const category =
-      intent === "subject" && (!rawCategory || rawCategory === "style-only")
-        ? "other"
-        : categoryFromForm(rawCategory);
+      intent === "subject" ? "other" : categoryFromForm(rawCategory);
     const title = readField(parts, "title") || null;
     const files =
       parts?.filter((part) => part.name === "files" && part.data) ?? [];

--- a/templates/assets/server/lib/generation.test.ts
+++ b/templates/assets/server/lib/generation.test.ts
@@ -122,6 +122,27 @@ describe("generateWithManagedImageProvider", () => {
     );
   });
 
+  it("fails before calling Builder when the public key is missing", async () => {
+    resolveBuilderCredentialsMock.mockResolvedValue({
+      privateKey: "bpk-builder-key",
+      publicKey: null,
+      userId: null,
+      orgName: null,
+      orgKind: null,
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(generateWithManagedImageProvider(baseInput)).rejects.toEqual(
+      expect.objectContaining({
+        name: "FeatureNotConfiguredError",
+        requiredCredential: "BUILDER_PRIVATE_KEY",
+        message: expect.stringContaining("Builder public key is missing"),
+      }),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("uses OpenAI as a manual image fallback when Builder is unavailable", async () => {
     resolveBuilderCredentialsMock.mockResolvedValue({
       privateKey: null,

--- a/templates/assets/server/lib/generation.test.ts
+++ b/templates/assets/server/lib/generation.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./generation.js";
 import type { GenerateProviderInput } from "./generation.js";
 
-const resolveBuilderAuthHeaderMock = vi.hoisted(() => vi.fn());
+const resolveBuilderCredentialsMock = vi.hoisted(() => vi.fn());
 const resolveSecretMock = vi.hoisted(() => vi.fn());
 const resolveHasBuilderPrivateKeyMock = vi.hoisted(() => vi.fn());
 
@@ -35,7 +35,7 @@ vi.mock("@agent-native/core/server", () => {
     getBuilderImageGenerationBaseUrl: vi.fn(
       () => "https://builder.test/agent-native/images/v1",
     ),
-    resolveBuilderAuthHeader: resolveBuilderAuthHeaderMock,
+    resolveBuilderCredentials: resolveBuilderCredentialsMock,
     resolveHasBuilderPrivateKey: resolveHasBuilderPrivateKeyMock,
     resolveSecret: resolveSecretMock,
   };
@@ -66,7 +66,13 @@ describe("generateWithManagedImageProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv("BUILDER_IMAGE_GENERATION_ENABLED", "true");
-    resolveBuilderAuthHeaderMock.mockResolvedValue("Bearer builder-key");
+    resolveBuilderCredentialsMock.mockResolvedValue({
+      privateKey: "bpk-builder-key",
+      publicKey: "space-test",
+      userId: null,
+      orgName: null,
+      orgKind: null,
+    });
     resolveHasBuilderPrivateKeyMock.mockResolvedValue(true);
     resolveSecretMock.mockResolvedValue(null);
   });
@@ -99,7 +105,13 @@ describe("generateWithManagedImageProvider", () => {
   });
 
   it("keeps missing Builder credentials on reconnect guidance", async () => {
-    resolveBuilderAuthHeaderMock.mockResolvedValue(null);
+    resolveBuilderCredentialsMock.mockResolvedValue({
+      privateKey: null,
+      publicKey: null,
+      userId: null,
+      orgName: null,
+      orgKind: null,
+    });
 
     await expect(generateWithManagedImageProvider(baseInput)).rejects.toEqual(
       expect.objectContaining({
@@ -111,7 +123,13 @@ describe("generateWithManagedImageProvider", () => {
   });
 
   it("uses OpenAI as a manual image fallback when Builder is unavailable", async () => {
-    resolveBuilderAuthHeaderMock.mockResolvedValue(null);
+    resolveBuilderCredentialsMock.mockResolvedValue({
+      privateKey: null,
+      publicKey: null,
+      userId: null,
+      orgName: null,
+      orgKind: null,
+    });
     resolveSecretMock.mockImplementation(async (key: string) =>
       key === "OPENAI_API_KEY" ? "sk-openai-test" : null,
     );
@@ -145,7 +163,13 @@ describe("generateWithManagedImageProvider", () => {
   });
 
   it("guards restyle and edit runs when only OpenAI fallback is available", async () => {
-    resolveBuilderAuthHeaderMock.mockResolvedValue(null);
+    resolveBuilderCredentialsMock.mockResolvedValue({
+      privateKey: null,
+      publicKey: null,
+      userId: null,
+      orgName: null,
+      orgKind: null,
+    });
     resolveSecretMock.mockImplementation(async (key: string) =>
       key === "OPENAI_API_KEY" ? "sk-openai-test" : null,
     );
@@ -236,6 +260,15 @@ describe("generateWithManagedImageProvider", () => {
       }),
     );
     expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock.mock.calls[2]).toEqual([
+      "https://builder.test/agent-native/images/v1/generations",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer bpk-builder-key",
+          "x-builder-api-key": "space-test",
+        }),
+      }),
+    ]);
   });
 });
 

--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -885,7 +885,8 @@ export async function selectReferences(input: {
         item.isSubject ||
         item.isSource ||
         item.isAnchor ||
-        item.metadata.intent !== "subject",
+        (item.metadata.intent !== "subject" &&
+          item.asset.role !== "subject_reference"),
     );
 
   const byId = new Map(candidates.map((item) => [item.asset.id, item]));

--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -2,7 +2,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import {
   FeatureNotConfiguredError,
   getBuilderImageGenerationBaseUrl,
-  resolveBuilderAuthHeader,
+  resolveBuilderCredentials,
   resolveSecret,
 } from "@agent-native/core/server";
 import { getDb, schema } from "../db/index.js";
@@ -176,8 +176,8 @@ interface BuilderImageGenerationResponse {
 export async function generateWithBuilderImageApi(
   input: GenerateProviderInput,
 ): Promise<GenerateProviderOutput> {
-  const authHeader = await resolveBuilderAuthHeader();
-  if (!authHeader) {
+  const builderCredentials = await resolveBuilderCredentials();
+  if (!builderCredentials.privateKey) {
     throw new BuilderImageGenerationError(
       "Builder.io is not connected for managed image generation.",
       401,
@@ -188,7 +188,10 @@ export async function generateWithBuilderImageApi(
   const response = await fetch(`${baseUrl}/generations`, {
     method: "POST",
     headers: {
-      Authorization: authHeader,
+      Authorization: `Bearer ${builderCredentials.privateKey}`,
+      ...(builderCredentials.publicKey
+        ? { "x-builder-api-key": builderCredentials.publicKey }
+        : {}),
       "Content-Type": "application/json",
     },
     body: JSON.stringify({

--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -177,10 +177,17 @@ export async function generateWithBuilderImageApi(
   input: GenerateProviderInput,
 ): Promise<GenerateProviderOutput> {
   const builderCredentials = await resolveBuilderCredentials();
-  if (!builderCredentials.privateKey) {
+  if (!builderCredentials.privateKey || !builderCredentials.publicKey) {
+    const detail =
+      !builderCredentials.privateKey && !builderCredentials.publicKey
+        ? "Builder private and public keys are missing"
+        : !builderCredentials.privateKey
+          ? "Builder private key is missing"
+          : "Builder public key is missing";
     throw new BuilderImageGenerationError(
-      "Builder.io is not connected for managed image generation.",
+      "Builder.io is not fully connected for managed image generation. Reconnect Builder.io so both Builder private and public keys are available.",
       401,
+      detail,
     );
   }
 
@@ -189,9 +196,7 @@ export async function generateWithBuilderImageApi(
     method: "POST",
     headers: {
       Authorization: `Bearer ${builderCredentials.privateKey}`,
-      ...(builderCredentials.publicKey
-        ? { "x-builder-api-key": builderCredentials.publicKey }
-        : {}),
+      "x-builder-api-key": builderCredentials.publicKey,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
@@ -358,7 +363,7 @@ function builderImageGenerationFallbackMessage(
   const detail = err.detail ? `: ${err.detail}` : ".";
   switch (err.status) {
     case 401:
-      return "Image generation needs Builder.io connected or reconnected. Open Settings and click Connect Builder.io, or expand the Asset generation setup step and add an OpenAI or Gemini API key as the manual fallback.";
+      return `Image generation needs Builder.io connected or reconnected${err.detail ? ` (${err.detail})` : ""}. Open Settings and click Connect Builder.io, or expand the Asset generation setup step and add an OpenAI or Gemini API key as the manual fallback.`;
     case 402:
       return `Builder.io is connected, but this Builder space cannot use managed image generation credits${detail} Open Builder space settings or reconnect to a space with image-generation credits, or add an OpenAI or Gemini API key as the manual fallback.`;
     case 403:

--- a/templates/assets/server/lib/select-references.spec.ts
+++ b/templates/assets/server/lib/select-references.spec.ts
@@ -137,6 +137,15 @@ describe("selectReferences", () => {
         objectKey: "unused-subject-bytes",
         metadata: JSON.stringify({ intent: "subject" }),
       },
+      {
+        id: "subject-role-not-selected",
+        role: "subject_reference",
+        mimeType: "image/png",
+        status: "reference",
+        createdAt: "2026-05-26T00:00:00.000Z",
+        objectKey: "unused-subject-role-bytes",
+        metadata: "{}",
+      },
     ];
     getDbMock.mockReturnValue(
       createDb({ canonicalStyleAssetIds: ["anchor-json"] }, assets),
@@ -179,6 +188,9 @@ describe("selectReferences", () => {
       "scored",
     ]);
     expect(refs.some((ref) => ref.id === "subject-upload-not-selected")).toBe(
+      false,
+    );
+    expect(refs.some((ref) => ref.id === "subject-role-not-selected")).toBe(
       false,
     );
     expect(randomSpy).not.toHaveBeenCalled();

--- a/templates/assets/shared/api.ts
+++ b/templates/assets/shared/api.ts
@@ -160,6 +160,7 @@ export interface ImageAssetMetadata {
   colors?: string[];
   contentHash?: string;
   generated?: boolean;
+  intent?: "subject" | string;
   sourceAssetId?: string;
   referenceAssetIds?: string[];
   prompt?: string;

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -477,11 +477,11 @@ export function EventDetailPopover({
   // Save a field update
   const saveField = useCallback(
     (updates: EventUpdatePatch) => {
-      if (!event.id) return;
+      if (!event.id) return false;
       if (isDraft) {
         const { scope: _scope, ...draftUpdates } = updates;
         onDraftUpdate?.(event.id, draftUpdates);
-        return;
+        return true;
       }
       void (async () => {
         const { scope: _scope, ...notificationUpdates } = updates;
@@ -498,6 +498,7 @@ export function EventDetailPopover({
           ...guestNotification,
         });
       })();
+      return true;
     },
     [event, isDraft, onDraftUpdate, promptGuestNotification, updateEvent],
   );
@@ -534,18 +535,22 @@ export function EventDetailPopover({
   );
 
   const handleSaveReminders = useCallback(() => {
-    saveField(buildReminderPayload(editReminderMode, editReminders));
+    const saved = saveField(
+      buildReminderPayload(editReminderMode, editReminders),
+    );
     setEditingField(null);
+    return saved;
   }, [editReminderMode, editReminders, saveField]);
 
   const handleSaveAttachments = useCallback(() => {
     const result = validateAttachmentDrafts(editAttachments);
     if (result.error) {
       toast.error(result.error);
-      return;
+      return false;
     }
-    saveField({ attachments: result.attachments });
+    const saved = saveField({ attachments: result.attachments });
     setEditingField(null);
+    return saved;
   }, [editAttachments, saveField]);
 
   const handleColorChange = useCallback(
@@ -676,10 +681,12 @@ Write a short, useful meeting description. If I ask you to apply it, update this
 
   const handleSaveDescription = useCallback(() => {
     const trimmed = editDescription.trim();
+    let saved = false;
     if (trimmed !== (event.description || "").trim()) {
-      saveField({ description: trimmed });
+      saved = saveField({ description: trimmed });
     }
     setEditingField(null);
+    return saved;
   }, [editDescription, event.description, saveField]);
 
   const handleSaveLocation = useCallback(() => {
@@ -689,8 +696,9 @@ Write a short, useful meeting description. If I ask you to apply it, update this
     if (locationContainsMeetingLink && !trimmed) {
       setEditLocation(event.location || "");
       setEditingField(null);
-      return;
+      return false;
     }
+    let saved = false;
     if (trimmed !== (event.location || "").trim()) {
       const updates: Partial<CalendarEvent> = { location: trimmed };
       if (
@@ -706,9 +714,10 @@ Write a short, useful meeting description. If I ask you to apply it, update this
           ? `${event.description.trim()}\n\n${label}: ${meetingLink.url}`
           : `${label}: ${meetingLink.url}`;
       }
-      saveField(updates);
+      saved = saveField(updates);
     }
     setEditingField(null);
+    return saved;
   }, [editLocation, event.description, event.location, meetingLink, saveField]);
 
   const handleSaveTime = useCallback(() => {
@@ -730,10 +739,11 @@ Write a short, useful meeting description. If I ask you to apply it, update this
           endTime: editEndTime,
         }),
       );
-      return;
+      return false;
     }
+    let saved = false;
     if (newStart !== event.start || newEnd !== event.end) {
-      saveField({
+      saved = saveField({
         start: newStart,
         end: newEnd,
         allDay: event.allDay,
@@ -744,6 +754,7 @@ Write a short, useful meeting description. If I ask you to apply it, update this
     }
     setEditTimeScope("single");
     setEditingField(null);
+    return saved;
   }, [
     editDate,
     editEndDate,
@@ -845,19 +856,21 @@ Write a short, useful meeting description. If I ask you to apply it, update this
 
   const handleSaveMeetingLink = useCallback(() => {
     const url = editMeetingLink.trim();
+    let saved = false;
     if (url) {
       // Save meeting link as location if no location exists, otherwise as description addendum
       if (!event.location) {
-        saveField({ location: url });
+        saved = saveField({ location: url });
         setEditLocation(url);
       } else {
         const desc = event.description ? `${event.description}\n\n${url}` : url;
-        saveField({ description: desc });
+        saved = saveField({ description: desc });
         setEditDescription(desc);
       }
     }
     setEditMeetingLink("");
     setEditingField(null);
+    return saved;
   }, [editMeetingLink, event.location, event.description, saveField]);
 
   // If in sidebar mode, clicking the trigger opens the sidebar instead of popover
@@ -936,28 +949,39 @@ Write a short, useful meeting description. If I ask you to apply it, update this
     (newOpen: boolean) => {
       if (!newOpen && open) {
         const trimmedTitle = editingTitle.trim();
+        let savedPendingChange = false;
         // Popover is closing — handle saves
         if (isEditingTitle) {
           if (trimmedTitle && trimmedTitle !== "(No title)") {
             onTitleSave?.(event.id, trimmedTitle);
             isNewEventRef.current = false;
+            savedPendingChange = true;
           }
           setIsEditingTitle(false);
         }
+        // Save any pending field edits before deciding whether an untouched
+        // new draft should be discarded.
+        if (editingField === "description") {
+          savedPendingChange = handleSaveDescription() || savedPendingChange;
+        } else if (editingField === "location") {
+          savedPendingChange = handleSaveLocation() || savedPendingChange;
+        } else if (editingField === "time") {
+          savedPendingChange = handleSaveTime() || savedPendingChange;
+        } else if (editingField === "meetingLink") {
+          savedPendingChange = handleSaveMeetingLink() || savedPendingChange;
+        } else if (editingField === "reminders") {
+          savedPendingChange = handleSaveReminders() || savedPendingChange;
+        } else if (editingField === "attachments") {
+          savedPendingChange = handleSaveAttachments() || savedPendingChange;
+        }
         if (
           isNewEventRef.current &&
+          !savedPendingChange &&
           (!trimmedTitle || trimmedTitle === "(No title)") &&
           onDismissNew
         ) {
           onDismissNew(event.id);
         }
-        // Save any pending field edits
-        if (editingField === "description") handleSaveDescription();
-        else if (editingField === "location") handleSaveLocation();
-        else if (editingField === "time") handleSaveTime();
-        else if (editingField === "meetingLink") handleSaveMeetingLink();
-        else if (editingField === "reminders") handleSaveReminders();
-        else if (editingField === "attachments") handleSaveAttachments();
 
         setEditingField(null);
         isNewEventRef.current = false;

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -112,6 +112,10 @@ function calendarDraftIdFromEventId(eventId: string) {
     : null;
 }
 
+function isSlotDraftId(id: string) {
+  return id.startsWith("slot-");
+}
+
 function parseValidDate(value: string | undefined): Date | null {
   if (!value) return null;
   const date = new Date(value);
@@ -297,6 +301,7 @@ export default function CalendarView() {
     Record<string, string>
   >({});
   const openedDraftIdRef = useRef<string | null>(null);
+  const committingDraftIdsRef = useRef<Set<string>>(new Set());
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [deleteDialogEvent, setDeleteDialogEvent] =
     useState<CalendarEvent | null>(null);
@@ -349,6 +354,7 @@ export default function CalendarView() {
     data: rawEventsData,
     error: eventsError,
     isLoading,
+    isPlaceholderData,
   } = useEvents(from, to, overlayEmails);
   const rawEvents = Array.isArray(rawEventsData) ? rawEventsData : [];
   const draftEvent = useMemo(
@@ -407,7 +413,7 @@ export default function CalendarView() {
 
   // Show skeleton only when loading with no cached data (new date range).
   // Tab refocus keeps cached data visible and refetches in background.
-  const eventsLoading = isLoading;
+  const eventsLoading = isLoading || isPlaceholderData;
 
   // Apply overlay colors and filter hidden calendars
   const events = useMemo(() => {
@@ -501,42 +507,11 @@ export default function CalendarView() {
     viewMode,
   ]);
 
-  const updateDraftEvent = useCallback(
-    (eventId: string, patch: DraftEventPatch) => {
-      const draftId = calendarDraftIdFromEventId(eventId);
-      if (!draftId || !eventDraft || eventDraft.id !== draftId) return null;
-      const nextDraft = applyDraftPatch(eventDraft, patch);
-      setEventDraft(nextDraft);
-      persistCalendarDraft(nextDraft);
-      return nextDraft;
-    },
-    [eventDraft, setEventDraft],
-  );
-
-  const discardDraftEvent = useCallback(
-    (eventId: string) => {
-      const draftId = calendarDraftIdFromEventId(eventId);
-      if (!draftId || !eventDraft || eventDraft.id !== draftId) return;
-      deletePersistedCalendarDraft(draftId);
-      setEventDraft(null);
-      setQuickEditEventId(null);
-      if (sidebarEvent?.id === eventId) setSidebarEvent(null);
-      if (focusedEvent?.id === eventId) setFocusedEvent(null);
-    },
-    [
-      eventDraft,
-      focusedEvent,
-      setEventDraft,
-      setFocusedEvent,
-      setSidebarEvent,
-      sidebarEvent,
-    ],
-  );
-
   const createDraftEvent = useCallback(
     (eventId: string, pendingPatch?: DraftEventPatch) => {
       const draftId = calendarDraftIdFromEventId(eventId);
       if (!draftId || !eventDraft || eventDraft.id !== draftId) return;
+      if (committingDraftIdsRef.current.has(draftId)) return;
       const draft = pendingPatch
         ? applyDraftPatch(eventDraft, pendingPatch)
         : eventDraft;
@@ -544,10 +519,18 @@ export default function CalendarView() {
         setEventDraft(draft);
         persistCalendarDraft(draft);
       }
-      const title = draft.title?.trim();
+      const trimmedTitle = draft.title?.trim();
+      const title =
+        trimmedTitle && trimmedTitle !== "(No title)"
+          ? trimmedTitle
+          : isSlotDraftId(draftId)
+            ? "(No title)"
+            : "";
       if (!title || title === "(No title)") {
-        toast.error("Add a title before creating the event");
-        return;
+        if (!isSlotDraftId(draftId)) {
+          toast.error("Add a title before creating the event");
+          return;
+        }
       }
 
       const { start, end } = draftRange(draft, selectedDate);
@@ -573,8 +556,10 @@ export default function CalendarView() {
                   : draft.workingLocationLabel,
             };
 
+      committingDraftIdsRef.current.add(draftId);
       createEvent.mutate(
         {
+          _tempId: eventId,
           title,
           description: draft.description ?? "",
           start: start.toISOString(),
@@ -632,10 +617,53 @@ export default function CalendarView() {
             toast.error(
               error instanceof Error ? error.message : "Failed to create event",
             ),
+          onSettled: () => {
+            committingDraftIdsRef.current.delete(draftId);
+          },
         },
       );
     },
     [createEvent, deleteEvent, eventDraft, selectedDate, setEventDraft],
+  );
+
+  const updateDraftEvent = useCallback(
+    (eventId: string, patch: DraftEventPatch) => {
+      const draftId = calendarDraftIdFromEventId(eventId);
+      if (!draftId || !eventDraft || eventDraft.id !== draftId) return null;
+
+      if (isSlotDraftId(draftId)) {
+        const nextDraft = applyDraftPatch(eventDraft, patch);
+        createDraftEvent(eventId, patch);
+        return nextDraft;
+      }
+
+      const nextDraft = applyDraftPatch(eventDraft, patch);
+      setEventDraft(nextDraft);
+      persistCalendarDraft(nextDraft);
+      return nextDraft;
+    },
+    [createDraftEvent, eventDraft, setEventDraft],
+  );
+
+  const discardDraftEvent = useCallback(
+    (eventId: string) => {
+      const draftId = calendarDraftIdFromEventId(eventId);
+      if (!draftId || !eventDraft || eventDraft.id !== draftId) return;
+      if (committingDraftIdsRef.current.has(draftId)) return;
+      deletePersistedCalendarDraft(draftId);
+      setEventDraft(null);
+      setQuickEditEventId(null);
+      if (sidebarEvent?.id === eventId) setSidebarEvent(null);
+      if (focusedEvent?.id === eventId) setFocusedEvent(null);
+    },
+    [
+      eventDraft,
+      focusedEvent,
+      setEventDraft,
+      setFocusedEvent,
+      setSidebarEvent,
+      sidebarEvent,
+    ],
   );
 
   const selectedEvent = useMemo(() => {

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -302,6 +302,9 @@ export default function CalendarView() {
   >({});
   const openedDraftIdRef = useRef<string | null>(null);
   const committingDraftIdsRef = useRef<Set<string>>(new Set());
+  const discardedCommittingDraftsRef = useRef<Map<string, CalendarEventDraft>>(
+    new Map(),
+  );
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [deleteDialogEvent, setDeleteDialogEvent] =
     useState<CalendarEvent | null>(null);
@@ -516,23 +519,18 @@ export default function CalendarView() {
       const draft = pendingPatch
         ? applyDraftPatch(eventDraft, pendingPatch)
         : eventDraft;
+      discardedCommittingDraftsRef.current.delete(draftId);
       if (pendingPatch) {
         setEventDraft(draft);
         persistCalendarDraft(draft);
       }
       const trimmedTitle = draft.title?.trim();
       const title =
-        trimmedTitle && trimmedTitle !== "(No title)"
-          ? trimmedTitle
-          : isSlotDraftId(draftId)
-            ? "(No title)"
-            : "";
-      if (!title || title === "(No title)") {
-        if (!isSlotDraftId(draftId)) {
-          committingDraftIdsRef.current.delete(draftId);
-          toast.error("Add a title before creating the event");
-          return;
-        }
+        trimmedTitle && trimmedTitle !== "(No title)" ? trimmedTitle : "";
+      if (!title && !isSlotDraftId(draftId)) {
+        committingDraftIdsRef.current.delete(draftId);
+        toast.error("Add a title before creating the event");
+        return;
       }
 
       const { start, end } = draftRange(draft, selectedDate);
@@ -595,6 +593,7 @@ export default function CalendarView() {
         },
         {
           onSuccess: (result) => {
+            discardedCommittingDraftsRef.current.delete(draftId);
             deletePersistedCalendarDraft(draftId);
             setEventDraft(null);
             setQuickEditEventId(null);
@@ -615,10 +614,19 @@ export default function CalendarView() {
             }
             toast("Event created");
           },
-          onError: (error) =>
+          onError: (error) => {
+            const discardedDraft =
+              discardedCommittingDraftsRef.current.get(draftId);
+            if (discardedDraft) {
+              discardedCommittingDraftsRef.current.delete(draftId);
+              persistCalendarDraft(discardedDraft);
+              setEventDraft(discardedDraft);
+              setQuickEditEventId(calendarDraftEventId(draftId));
+            }
             toast.error(
               error instanceof Error ? error.message : "Failed to create event",
-            ),
+            );
+          },
           onSettled: () => {
             committingDraftIdsRef.current.delete(draftId);
           },
@@ -645,6 +653,12 @@ export default function CalendarView() {
     (eventId: string) => {
       const draftId = calendarDraftIdFromEventId(eventId);
       if (!draftId || !eventDraft || eventDraft.id !== draftId) return;
+      if (committingDraftIdsRef.current.has(draftId)) {
+        discardedCommittingDraftsRef.current.set(draftId, eventDraft);
+        committingDraftIdsRef.current.delete(draftId);
+      } else {
+        discardedCommittingDraftsRef.current.delete(draftId);
+      }
       deletePersistedCalendarDraft(draftId);
       setEventDraft(null);
       setQuickEditEventId(null);

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -512,6 +512,7 @@ export default function CalendarView() {
       const draftId = calendarDraftIdFromEventId(eventId);
       if (!draftId || !eventDraft || eventDraft.id !== draftId) return;
       if (committingDraftIdsRef.current.has(draftId)) return;
+      committingDraftIdsRef.current.add(draftId);
       const draft = pendingPatch
         ? applyDraftPatch(eventDraft, pendingPatch)
         : eventDraft;
@@ -528,6 +529,7 @@ export default function CalendarView() {
             : "";
       if (!title || title === "(No title)") {
         if (!isSlotDraftId(draftId)) {
+          committingDraftIdsRef.current.delete(draftId);
           toast.error("Add a title before creating the event");
           return;
         }
@@ -535,6 +537,7 @@ export default function CalendarView() {
 
       const { start, end } = draftRange(draft, selectedDate);
       if (end.getTime() <= start.getTime()) {
+        committingDraftIdsRef.current.delete(draftId);
         toast.error("End time must be after start time");
         return;
       }
@@ -556,7 +559,6 @@ export default function CalendarView() {
                   : draft.workingLocationLabel,
             };
 
-      committingDraftIdsRef.current.add(draftId);
       createEvent.mutate(
         {
           _tempId: eventId,

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -633,25 +633,18 @@ export default function CalendarView() {
       const draftId = calendarDraftIdFromEventId(eventId);
       if (!draftId || !eventDraft || eventDraft.id !== draftId) return null;
 
-      if (isSlotDraftId(draftId)) {
-        const nextDraft = applyDraftPatch(eventDraft, patch);
-        createDraftEvent(eventId, patch);
-        return nextDraft;
-      }
-
       const nextDraft = applyDraftPatch(eventDraft, patch);
       setEventDraft(nextDraft);
       persistCalendarDraft(nextDraft);
       return nextDraft;
     },
-    [createDraftEvent, eventDraft, setEventDraft],
+    [eventDraft, setEventDraft],
   );
 
   const discardDraftEvent = useCallback(
     (eventId: string) => {
       const draftId = calendarDraftIdFromEventId(eventId);
       if (!draftId || !eventDraft || eventDraft.id !== draftId) return;
-      if (committingDraftIdsRef.current.has(draftId)) return;
       deletePersistedCalendarDraft(draftId);
       setEventDraft(null);
       setQuickEditEventId(null);

--- a/templates/mail/server/plugins/auth.ts
+++ b/templates/mail/server/plugins/auth.ts
@@ -50,5 +50,5 @@ export default createAuthPlugin({
   // GMAIL_PUSH_AUDIENCE is configured.
   // Cloud Scheduler POSTs to /api/gmail/watch/renew every 6h for watch
   // lifecycle; same OIDC-verification pattern.
-  publicPaths: ["/api/gmail/push", "/api/gmail/watch/renew"],
+  publicPaths: ["/api/gmail/push", "/api/gmail/watch/renew", "/api/tracking"],
 });


### PR DESCRIPTION
## Summary
- keep generated asset chat prompts user-facing while moving generation settings into hidden context
- treat one-off content uploads separately from reusable style references in Assets
- simplify the library page by removing the duplicate brand summary and tightening header actions
- preserve draft calendar edits while committing new slot events

## Tests
- pnpm exec prettier --write templates/assets/actions/list-libraries.ts templates/assets/app/routes/_index.tsx templates/assets/app/routes/asset.$id.tsx templates/assets/app/routes/library.$id.tsx templates/assets/server/handlers/assets.ts templates/assets/server/lib/generation.ts templates/assets/server/lib/select-references.spec.ts templates/assets/shared/api.ts templates/calendar/app/components/calendar/EventDetailPopover.tsx templates/calendar/app/pages/CalendarView.tsx
- pnpm --filter assets typecheck
- pnpm --filter assets test -- select-references
- pnpm --filter calendar typecheck
- git diff --check

## Notes
- Local browser checked the Assets library header at desktop and 390px mobile.