### PR TITLE
Add Design exploration MCP skill

### DIFF
--- a/.changeset/design-exploration-skill.md
+++ b/.changeset/design-exploration-skill.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add the hosted Design exploration app-backed skill so local agents can install Design MCP instructions and connector setup with `agent-native skills add design-exploration`.

--- a/packages/core/docs/content/skills-guide.md
+++ b/packages/core/docs/content/skills-guide.md
@@ -87,7 +87,10 @@ npx @agent-native/core@latest skills add assets
 # Same install, using the image-generation alias for demos and tutorials.
 npx @agent-native/core@latest skills add images
 
-# Register the hosted MCP connector for local agent clients.
+# One-command hosted install for Design exploration plus MCP connector.
+npx @agent-native/core@latest skills add design-exploration
+
+# Register a hosted MCP connector for local agent clients.
 agent-native app-skill ensure --manifest templates/assets/agent-native.app-skill.json
 
 # Materialize and run editable local source.
@@ -111,9 +114,9 @@ settings flow.
 
 The Vercel Labs `skills` adapter is a portable `skills/<name>/SKILL.md` bundle
 for `npx skills add ...`. For first-party hosted apps, prefer
-`agent-native skills add images` or `agent-native skills add assets`; either
-installs the exported Assets instructions and runs the MCP registration step
-together.
+`agent-native skills add images`, `agent-native skills add assets`, or
+`agent-native skills add design-exploration`; each installs the exported
+instructions and runs the MCP registration step together.
 
 The Claude Code marketplace adapter writes
 `adapters/claude-marketplace/.claude-plugin/marketplace.json` plus a nested

--- a/packages/core/docs/content/template-design.md
+++ b/packages/core/docs/content/template-design.md
@@ -22,6 +22,17 @@ Use it when you want a polished landing page concept, product UI direction, bran
 4. **Export when it is useful.** Download HTML, ZIP, or PDF once the prototype
    is ready to hand to another tool or teammate.
 
+For Codex, Claude Code, and other local agent clients, the hosted Design app can
+be installed as an app-backed skill plus MCP connector:
+
+```bash
+npx @agent-native/core@latest skills add design-exploration
+```
+
+That gives the agent instructions to create a design shell, present three visual
+directions in the inline Design MCP app, wait for your pick, and iterate from
+the selected prototype.
+
 ## Useful Prompts
 
 - "Create three landing-page directions for a technical analytics product."

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -734,8 +734,8 @@ Usage:
                                 fallback.
   agent-native app-skill <cmd>  Install, launch, or package app-backed skills.
                                 cmds: ensure | launch | pack
-  agent-native skills add assets
-                                Install Assets skill instructions and MCP in one step
+  agent-native skills add assets|design-exploration
+                                Install app skill instructions and MCP in one step
   agent-native migrate <source> Create an Agent-Native Code /migrate session, or use
                                 --emit for a portable own-agent dossier.
   agent-native add-app [name]   Add one or more apps to the current workspace

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -59,6 +59,44 @@ describe("agent-native skills", () => {
     );
   });
 
+  it("accepts design-exploration aliases for the built-in Design skill", async () => {
+    const root = tmpDir();
+    const commands: { cmd: string; args: string[] }[] = [];
+
+    const result = await addAgentNativeSkill(
+      parseSkillsArgs([
+        "add",
+        "agent-native-design-exploration",
+        "--client",
+        "codex",
+        "--scope",
+        "project",
+      ]),
+      {
+        baseDir: root,
+        runCommand: async (cmd, args) => {
+          commands.push({ cmd, args });
+          return 0;
+        },
+      },
+    );
+
+    expect(result.id).toBe("design");
+    expect(result.skillNames).toEqual(["design-exploration"]);
+    expect(commands[0].args).toEqual(
+      expect.arrayContaining([
+        "--skill",
+        "design-exploration",
+        "-a",
+        "codex",
+        "-y",
+      ]),
+    );
+    expect(result.mcpUrl).toBe(
+      "https://design.agent-native.com/_agent-native/mcp",
+    );
+  });
+
   it("installs built-in Assets instructions and MCP config", async () => {
     const root = tmpDir();
     const commands: { cmd: string; args: string[] }[] = [];

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -24,11 +24,12 @@ const HELP = `agent-native skills
 
 Usage:
   agent-native skills list
-  agent-native skills add assets [--client codex|claude-code|claude-code-cli|cowork|all] [--scope user|project] [--yes] [--dry-run] [--json]
+  agent-native skills add assets|design-exploration [--client codex|claude-code|claude-code-cli|cowork|all] [--scope user|project] [--yes] [--dry-run] [--json]
   agent-native skills add <manifest-or-app-dir> [--client ...] [--yes]
 
 Examples:
   agent-native skills add assets
+  agent-native skills add design-exploration
   agent-native skills add assets --client claude-code
   agent-native skills add ./dist/assets-skill --client codex
 
@@ -86,8 +87,59 @@ or generated image/video assets that another app can reference by ID and URL.
   generation, picker UI, search/list/export, and asset context.
 `;
 
+const DESIGN_EXPLORATION_SKILL_MD = `---
+name: design-exploration
+description: >-
+  Use Design for UI/UX exploration, side-by-side design directions,
+  interactive prototype previews, user selection, iteration, and design-to-code
+  handoff through the hosted Design MCP app.
+metadata:
+  visibility: exported
+---
+
+# Design Exploration
+
+Use the Design app when a workflow needs visual UI exploration, prototype
+iteration, or a human-in-the-loop choice among design directions.
+
+## Choose The Path
+
+- Use \`create-design\` first to create a project shell. Do not report the
+  design as ready until it has renderable HTML.
+- For open-ended UX exploration, generate three distinct, complete HTML
+  directions and call \`present-design-variants\`. The inline Design MCP app
+  shows the options, lets the user pick one, and persists the selected variant.
+- For direct refinements to an already chosen direction, call
+  \`get-design-snapshot\`, edit from the current tuned HTML, then call
+  \`generate-design\`.
+- Use \`export-coding-handoff\` when the user wants to implement the chosen
+  design in a codebase.
+
+## Exploration Defaults
+
+1. Default to three variants unless the user asks for a different count.
+2. Make variants structurally and stylistically distinct, not just color swaps.
+3. Each variant must be a complete standalone HTML document that renders
+   without a build step.
+4. For product UI redesigns, prefer cleaner hierarchy, progressive disclosure,
+   and realistic controls over decorative mockups.
+5. After \`present-design-variants\`, wait for the user's pick before
+   generating the next version. If they say "I like #2 but...", snapshot the
+   chosen design and refine that direction with \`generate-design\`.
+
+## Cross-App Use
+
+- Hosted default: connect \`https://design.agent-native.com/_agent-native/mcp\`.
+  Do not put shared secrets in skill files.
+- Dispatch can expose Design alongside other apps. Use Design for UI/UX design
+  tasks, Assets for image/media selection, Slides for decks, and so on.
+- Keep the loop visual: surface the inline MCP App or the returned "Open
+  design" link instead of pasting large HTML blobs into chat.
+`;
+
 const BUILT_IN_APP_SKILLS = {
   assets: {
+    skillName: "assets",
     manifest: normalizeAppSkillManifest({
       schemaVersion: 1,
       id: "assets",
@@ -132,9 +184,53 @@ const BUILT_IN_APP_SKILLS = {
     }),
     skillMarkdown: ASSETS_SKILL_MD,
   },
+  design: {
+    skillName: "design-exploration",
+    manifest: normalizeAppSkillManifest({
+      schemaVersion: 1,
+      id: "design",
+      displayName: "Design",
+      description:
+        "Explore, compare, iterate, and export interactive UI design prototypes from the Design app.",
+      hosted: {
+        url: "https://design.agent-native.com",
+        mcpUrl: "https://design.agent-native.com/_agent-native/mcp",
+      },
+      mcp: { serverName: "agent-native-design" },
+      auth: {
+        mode: "oauth",
+        setup:
+          "Authenticate with the Design MCP connector in the host app. No shared secrets are stored in skill files.",
+      },
+      surfaces: [
+        {
+          id: "design-exploration",
+          action: "present-design-variants",
+          path: "/design",
+        },
+      ],
+      skills: [
+        {
+          path: "skills/design-exploration",
+          visibility: "exported",
+          exportAs: "design-exploration",
+        },
+      ],
+      hostAdapters: [
+        "codex-plugin",
+        "claude-marketplace",
+        "vercel-skills",
+        "plain-skill",
+        "claude-skill",
+        "chatgpt-mcp",
+        "generic-mcp",
+      ],
+    }),
+    skillMarkdown: DESIGN_EXPLORATION_SKILL_MD,
+  },
 } satisfies Record<
   string,
-  { manifest: AppSkillManifest; skillMarkdown: string }
+  { manifest: AppSkillManifest; skillMarkdown: string; skillName: string }
 >;
 
 type BuiltInAppSkillId = keyof typeof BUILT_IN_APP_SKILLS;
@@ -148,10 +244,22 @@ const BUILT_IN_APP_SKILL_ALIASES = {
   "image-generation": "assets",
   "agent-native-assets": "assets",
   "agent-native-images": "assets",
+  design: "design",
+  "ui-design": "design",
+  "ux-design": "design",
+  "design-exploration": "design",
+  "ux-exploration": "design",
+  "agent-native-design": "design",
+  "agent-native-design-exploration": "design",
 } satisfies Record<string, BuiltInAppSkillId>;
 
 const BUILT_IN_APP_SKILL_DISPLAY_ALIASES = {
   assets: ["images", "image-generation", "agent-native-images"],
+  design: [
+    "design-exploration",
+    "ux-exploration",
+    "agent-native-design-exploration",
+  ],
 } satisfies Record<BuiltInAppSkillId, string[]>;
 
 type SkillsCommand = "list" | "add" | "help";
@@ -281,9 +389,9 @@ function loadSkillTarget(target: string): SkillInstallTarget {
         file: `<built-in:${builtIn.manifest.id}>`,
         dir: process.cwd(),
       },
-      skillNames: ["assets"],
+      skillNames: [builtIn.skillName],
       materializeInstructions(outDir) {
-        const skillDir = path.join(outDir, "skills", "assets");
+        const skillDir = path.join(outDir, "skills", builtIn.skillName);
         fs.mkdirSync(skillDir, { recursive: true });
         fs.writeFileSync(
           path.join(skillDir, "SKILL.md"),

--- a/templates/design/.agents/skills/design-generation/SKILL.md
+++ b/templates/design/.agents/skills/design-generation/SKILL.md
@@ -31,7 +31,8 @@ Then, for any non-trivial first prompt, write `application-state/show-questions`
 
 ### Phase 2 — Generate three side-by-side variations
 
-For new designs, default to **three** variations. Write candidates to `application-state/design-variants`:
+For new designs, default to **three** variations. In normal app-agent flows,
+write candidates to `application-state/design-variants`:
 
 ```json
 {
@@ -48,6 +49,13 @@ For new designs, default to **three** variations. Write candidates to `applicati
 Each `content` is a complete, self-contained document (Alpine.js + Tailwind via CDN, full `<head>`, CSS variables in `:root`). Variations should be **stylistically/structurally distinct** — different typography schools, layout grammars, color moods — never just color swaps. Label them with concrete style names ("Editorial Serif", not "Variant A").
 
 The framework persists the chosen content as `index.html` automatically when the user clicks "Use this one" — do NOT call `generate-design` while the picker is open.
+
+When the caller is an external MCP host (ChatGPT, Claude, Claude Code, Codex,
+Dispatch), call `present-design-variants` instead of writing
+`application-state` directly. Pass the existing `designId`, a concise prompt
+caption, and 2-5 complete HTML variants. The action opens the same editor
+variant picker as the first-party app and keeps the workflow visible inside
+MCP Apps. After that, wait for the user's pick before refining.
 
 ### Phase 3 — Save with `generate-design` (when not using variants)
 

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -24,7 +24,8 @@ patterns live in `.agents/skills/`.
 - Persist useful work early: create/update the design and files as soon as a
   coherent candidate exists, then iterate.
 - For multi-variant work, write candidates incrementally so the UI can preview
-  progress.
+  progress. External MCP hosts should use `present-design-variants` so the same
+  picker opens inline instead of writing `application_state` directly.
 - Use framework sharing actions for design and design-system visibility/grants.
 - When the user asks to download/export, use export actions or point to the
   editor download menu.
@@ -36,6 +37,17 @@ patterns live in `.agents/skills/`.
 - `navigate` moves the UI and is auto-deleted after the client consumes it.
 - `show-questions` opens focused pre-generation questions when needed.
 - `design-variants` contains in-progress candidates for the variant picker.
+
+## App-Backed Skill Distribution
+
+- The preferred hosted install path is
+  `npx @agent-native/core@latest skills add design-exploration` (or `design`).
+  It installs the exported Design exploration instructions and registers the
+  hosted Design MCP connector together.
+- For human-in-the-loop UI exploration, create a design shell, call
+  `present-design-variants` with 2-5 complete HTML directions, wait for the
+  user to pick one, then use `get-design-snapshot` and `generate-design` for
+  follow-up refinements.
 
 ## Skills
 

--- a/templates/design/actions/present-design-variants.spec.ts
+++ b/templates/design/actions/present-design-variants.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  writeAppState: vi.fn(),
+  assertAccess: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/application-state", () => ({
+  writeAppState: mocks.writeAppState,
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  assertAccess: mocks.assertAccess,
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  buildDeepLink: (args: {
+    app: string;
+    view: string;
+    params?: Record<string, string>;
+    to?: string;
+  }) =>
+    `/_agent-native/open?app=${args.app}&view=${args.view}&designId=${args.params?.designId ?? ""}`,
+}));
+
+import action from "./present-design-variants.js";
+
+describe("present-design-variants", () => {
+  it("writes variants to application state and exposes MCP app metadata", async () => {
+    const result = await action.run({
+      designId: "design_123",
+      prompt: "Pick a calmer picker direction",
+      variants: [
+        {
+          id: "one-line-focus",
+          label: "One-Line Focus",
+          content: "<!DOCTYPE html><html><body>One</body></html>",
+        },
+        {
+          id: "progressive-disclosure",
+          label: "Progressive Disclosure",
+          content: "<!DOCTYPE html><html><body>Two</body></html>",
+        },
+        {
+          id: "quiet-studio",
+          label: "Quiet Studio",
+          content: "<!DOCTYPE html><html><body>Three</body></html>",
+        },
+      ],
+    });
+
+    expect(mocks.assertAccess).toHaveBeenCalledWith(
+      "design",
+      "design_123",
+      "editor",
+    );
+    expect(mocks.writeAppState).toHaveBeenCalledWith("design-variants", {
+      designId: "design_123",
+      prompt: "Pick a calmer picker direction",
+      variants: expect.arrayContaining([
+        expect.objectContaining({ id: "one-line-focus" }),
+      ]),
+    });
+    expect(result).toMatchObject({
+      designId: "design_123",
+      count: 3,
+      path: "/design/design_123",
+      embed: true,
+    });
+    expect(action.mcpApp?.compactCatalog).toBe(true);
+    expect(action.mcpApp?.resource.title).toBe("Design directions");
+  });
+
+  it("returns an editor deep link for external hosts", async () => {
+    const link = action.link?.({
+      args: {},
+      result: { designId: "design_123" },
+    });
+
+    expect(link).toEqual({
+      url: "/_agent-native/open?app=design&view=editor&designId=design_123",
+      label: "Open design directions",
+      view: "editor",
+    });
+  });
+});

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -1,0 +1,86 @@
+import { defineAction, embedApp } from "@agent-native/core";
+import { buildDeepLink } from "@agent-native/core/server";
+import { writeAppState } from "@agent-native/core/application-state";
+import { assertAccess } from "@agent-native/core/sharing";
+import { z } from "zod";
+
+function designDeepLink(designId: string): string {
+  return buildDeepLink({
+    app: "design",
+    view: "editor",
+    params: { designId },
+    to: `/design/${encodeURIComponent(designId)}`,
+  });
+}
+
+const variantSchema = z.object({
+  id: z.string().min(1).describe("Stable variant id, e.g. 'minimal-focus'"),
+  label: z
+    .string()
+    .min(1)
+    .describe("Short user-facing variant name, e.g. 'One-Line Focus'"),
+  content: z
+    .string()
+    .min(1)
+    .describe("Complete self-contained HTML document for this variant"),
+});
+
+export default defineAction({
+  description:
+    "Present 2-5 generated design directions in the Design editor so the " +
+    "user can visually compare options and pick one. Use this for design " +
+    "exploration before calling generate-design. The user's choice is " +
+    "persisted automatically by the app.",
+  schema: z.object({
+    designId: z.string().describe("Design project ID to show variants for"),
+    prompt: z
+      .string()
+      .optional()
+      .describe("Caption shown above the variant grid"),
+    variants: z
+      .array(variantSchema)
+      .min(2)
+      .max(5)
+      .describe("Generated design options to preview side by side"),
+  }),
+  mcpApp: {
+    compactCatalog: true,
+    resource: embedApp({
+      title: "Design directions",
+      description:
+        "Open the Design editor with a visual picker for generated variants.",
+      iframeTitle: "Agent-Native Design",
+      openLabel: "Open design directions",
+      height: 680,
+    }),
+  },
+  run: async ({ designId, prompt, variants }) => {
+    await assertAccess("design", designId, "editor");
+
+    await writeAppState("design-variants", {
+      designId,
+      prompt: prompt ?? "Pick a direction",
+      variants,
+    });
+
+    return {
+      designId,
+      prompt: prompt ?? "Pick a direction",
+      count: variants.length,
+      path: `/design/${encodeURIComponent(designId)}`,
+      embed: true,
+      nextRequiredAction:
+        "Wait for the user to pick a variant before refining or calling generate-design.",
+    };
+  },
+  link: ({ result }) => {
+    if (!result || typeof result !== "object") return null;
+    const designId = (result as { designId?: string }).designId;
+    if (!designId) return null;
+    return {
+      url: designDeepLink(designId),
+      label: "Open design directions",
+      view: "editor",
+    };
+  },
+});

--- a/templates/design/agent-native.app-skill.json
+++ b/templates/design/agent-native.app-skill.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": 1,
+  "id": "design",
+  "displayName": "Design",
+  "description": "Explore, compare, iterate, and export interactive UI design prototypes from the Design app.",
+  "hosted": {
+    "url": "https://design.agent-native.com",
+    "mcpUrl": "https://design.agent-native.com/_agent-native/mcp"
+  },
+  "mcp": {
+    "serverName": "agent-native-design"
+  },
+  "local": {
+    "template": "design",
+    "sourcePath": ".",
+    "defaultUrl": "http://127.0.0.1:8101",
+    "commands": {
+      "install": "pnpm install",
+      "dev": "pnpm dev",
+      "start": "pnpm start"
+    }
+  },
+  "auth": {
+    "mode": "oauth",
+    "setup": "Authenticate with the Design MCP connector in the host app or use agent-native app-skill ensure to register the URL-only connector."
+  },
+  "surfaces": [
+    {
+      "id": "design-exploration",
+      "action": "present-design-variants",
+      "path": "/design"
+    }
+  ],
+  "skills": [
+    {
+      "path": ".agents/skills/design-generation",
+      "visibility": "both",
+      "exportAs": "design-exploration"
+    }
+  ],
+  "hostAdapters": [
+    "codex-plugin",
+    "claude-marketplace",
+    "vercel-skills",
+    "plain-skill",
+    "claude-skill",
+    "chatgpt-mcp",
+    "generic-mcp"
+  ]
+}

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -441,7 +441,7 @@ export function DesignCanvas({
       <iframe
         ref={iframeRef}
         srcDoc={srcdoc}
-        sandbox="allow-scripts allow-same-origin"
+        sandbox="allow-scripts"
         className="border-0 bg-white block w-full h-full"
         title="Design Preview"
       />

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -203,7 +203,7 @@ function Screen({
           >
             <iframe
               srcDoc={screen.content}
-              sandbox="allow-scripts allow-same-origin"
+              sandbox="allow-scripts"
               className="pointer-events-none border-0"
               style={{
                 width: 1280,

--- a/templates/design/app/components/design/PresentMode.tsx
+++ b/templates/design/app/components/design/PresentMode.tsx
@@ -57,7 +57,7 @@ export function PresentMode({ content, onExit }: PresentModeProps) {
       <iframe
         ref={iframeRef}
         srcDoc={srcdoc}
-        sandbox="allow-scripts allow-same-origin"
+        sandbox="allow-scripts"
         className="w-full h-full border-0"
         title="Present Mode"
       />

--- a/templates/design/app/components/design/VariantGrid.tsx
+++ b/templates/design/app/components/design/VariantGrid.tsx
@@ -24,19 +24,25 @@ export function VariantGrid({
 }: VariantGridProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null);
 
-  // Determine grid layout based on variant count
+  // The same grid renders both in the full editor and in compact MCP App
+  // embeds, so it needs to wrap instead of squeezing previews into slivers.
   const gridClass =
     variants.length <= 1
       ? "grid-cols-1"
       : variants.length === 2
-        ? "grid-cols-2"
+        ? "grid-cols-1 sm:grid-cols-2"
         : variants.length === 3
-          ? "grid-cols-3"
-          : "grid-cols-2";
+          ? "grid-cols-1 sm:grid-cols-2 xl:grid-cols-3"
+          : "grid-cols-1 sm:grid-cols-2";
 
   return (
-    <div className="flex h-full w-full flex-col bg-background p-6">
-      <div className={cn("grid flex-1 gap-4", gridClass)}>
+    <div className="flex h-full w-full flex-col overflow-y-auto bg-background p-3 sm:p-4 lg:p-6">
+      <div
+        className={cn(
+          "grid min-h-0 flex-1 auto-rows-[minmax(260px,1fr)] gap-3 sm:gap-4",
+          gridClass,
+        )}
+      >
         {variants.map((variant) => {
           const isSelected = selectedId === variant.id;
           const isHovered = hoveredId === variant.id;
@@ -67,7 +73,7 @@ export function VariantGrid({
                     height: "200%",
                     transform: "scale(0.5)",
                   }}
-                  sandbox="allow-same-origin"
+                  sandbox="allow-scripts"
                   title={variant.label}
                 />
 
@@ -113,17 +119,31 @@ export function VariantGrid({
   );
 }
 
-/** Wrap raw HTML content in a minimal document for the iframe */
+/** Prepare generated HTML for the iframe preview without changing full docs. */
 function wrapContent(content: string): string {
+  const previewStyle = `<style data-agent-native-preview>
+    *, *::before, *::after { box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; overflow: hidden; }
+    body { background: #0a0a0a; }
+  </style>`;
+  const trimmed = content.trim();
+
+  if (/<!doctype\s+html|<html[\s>]/i.test(trimmed)) {
+    if (/<\/head>/i.test(trimmed)) {
+      return trimmed.replace(/<\/head>/i, `${previewStyle}</head>`);
+    }
+    return trimmed.replace(
+      /<html([^>]*)>/i,
+      `<html$1><head>${previewStyle}</head>`,
+    );
+  }
+
   return `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8" />
-  <style>
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    body { background: #0a0a0a; overflow: hidden; }
-  </style>
+  ${previewStyle}
 </head>
-<body>${content}</body>
+<body>${trimmed}</body>
 </html>`;
 }

--- a/templates/design/app/components/layout/Layout.tsx
+++ b/templates/design/app/components/layout/Layout.tsx
@@ -11,7 +11,7 @@ import { IconMenu2 } from "@tabler/icons-react";
 import { Sidebar } from "./Sidebar";
 import { Header } from "./Header";
 import { HeaderActionsProvider } from "./HeaderActions";
-import { AgentSidebar } from "@agent-native/core/client";
+import { AgentSidebar, isEmbedAuthActive } from "@agent-native/core/client";
 import { useNavigationState } from "@/hooks/use-navigation-state";
 import { cn } from "@/lib/utils";
 
@@ -68,6 +68,26 @@ export function Layout({ children }: LayoutProps) {
   );
   const isDesignEditor = location.pathname.startsWith("/design/");
   const showMobileTopBar = !isDesignEditor;
+  const embedded = isEmbedAuthActive();
+
+  if (embedded) {
+    return (
+      <HeaderActionsProvider>
+        <MobileSidebarContext.Provider value={null}>
+          <div className="flex h-[100dvh] w-full overflow-hidden bg-background text-foreground">
+            <main
+              className={cn(
+                "min-w-0 flex-1",
+                isDesignEditor ? "overflow-hidden" : "overflow-y-auto",
+              )}
+            >
+              {children}
+            </main>
+          </div>
+        </MobileSidebarContext.Provider>
+      </HeaderActionsProvider>
+    );
+  }
 
   return (
     <HeaderActionsProvider>

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -37,6 +37,7 @@ import {
   AgentToggleButton,
   NotificationsBell,
   ShareButton,
+  isEmbedAuthActive,
   type CollabUser,
   type PromptComposerSubmitOptions,
 } from "@agent-native/core/client";
@@ -195,6 +196,7 @@ export default function DesignEditor() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const openMobileSidebar = useOpenMobileSidebar();
+  const embedded = isEmbedAuthActive();
 
   // Editor state
   const [mode, setMode] = useState<EditorMode>("comment");
@@ -1399,7 +1401,11 @@ ${serializedHtml}
     // flex-col page shell). Without this the canvas collapses to ~150px.
     <div className="h-full flex flex-col overflow-hidden bg-background">
       {/* Toolbar */}
-      <header className="h-12 shrink-0 overflow-x-auto overflow-y-hidden overscroll-x-contain border-b border-border [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <header
+        className={`shrink-0 overflow-x-auto overflow-y-hidden overscroll-x-contain border-b border-border [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${
+          embedded ? "h-10" : "h-12"
+        }`}
+      >
         <div className="flex h-full min-w-max w-full items-center gap-2 px-3">
           {openMobileSidebar && (
             <Button
@@ -1453,36 +1459,43 @@ ${serializedHtml}
           </Badge>
 
           <div className="ml-auto flex shrink-0 items-center gap-1 pl-2">
-            {/* Mode switcher */}
-            <Tabs
-              value={mode}
-              onValueChange={(v) => handleModeChange(v as EditorMode)}
-            >
-              <TabsList className="h-8">
-                <TabsTrigger
-                  value="comment"
-                  className="h-6 px-2 text-xs gap-1"
-                  onClick={handleCommentTabClick}
+            {!embedded && (
+              <>
+                {/* Mode switcher */}
+                <Tabs
+                  value={mode}
+                  onValueChange={(v) => handleModeChange(v as EditorMode)}
                 >
-                  <IconMessage className="w-3 h-3" />
-                  Comment
-                </TabsTrigger>
-                <TabsTrigger value="edit" className="h-6 px-2 text-xs gap-1">
-                  <IconPencil className="w-3 h-3" />
-                  Edit
-                </TabsTrigger>
-                <TabsTrigger
-                  value="draw"
-                  className="h-6 px-2 text-xs gap-1"
-                  disabled={!activeFile || viewMode === "overview"}
-                >
-                  <IconBrush className="w-3 h-3" />
-                  Draw
-                </TabsTrigger>
-              </TabsList>
-            </Tabs>
+                  <TabsList className="h-8">
+                    <TabsTrigger
+                      value="comment"
+                      className="h-6 px-2 text-xs gap-1"
+                      onClick={handleCommentTabClick}
+                    >
+                      <IconMessage className="w-3 h-3" />
+                      Comment
+                    </TabsTrigger>
+                    <TabsTrigger
+                      value="edit"
+                      className="h-6 px-2 text-xs gap-1"
+                    >
+                      <IconPencil className="w-3 h-3" />
+                      Edit
+                    </TabsTrigger>
+                    <TabsTrigger
+                      value="draw"
+                      className="h-6 px-2 text-xs gap-1"
+                      disabled={!activeFile || viewMode === "overview"}
+                    >
+                      <IconBrush className="w-3 h-3" />
+                      Draw
+                    </TabsTrigger>
+                  </TabsList>
+                </Tabs>
 
-            <div className="w-px h-5 bg-accent mx-1" />
+                <div className="w-px h-5 bg-accent mx-1" />
+              </>
+            )}
 
             {/* Overview / single-screen toggle. Clicking Overview shows every
               file in the design as a Figma-style pannable lineup. */}
@@ -1502,94 +1515,104 @@ ${serializedHtml}
               </TooltipContent>
             </Tooltip>
 
-            <div className="w-px h-5 bg-accent mx-1" />
+            {!embedded && (
+              <>
+                <div className="w-px h-5 bg-accent mx-1" />
 
-            {/* Device frame — only meaningful in single-screen mode. */}
-            <div className="flex items-center gap-0.5">
-              <Tooltip>
-                <TooltipTrigger asChild>
+                {/* Device frame — only meaningful in single-screen mode. */}
+                <div className="flex items-center gap-0.5">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant={deviceFrame === "none" ? "secondary" : "ghost"}
+                        size="icon"
+                        className="h-7 w-7 cursor-pointer"
+                        onClick={() => setDeviceFrame("none")}
+                        disabled={viewMode === "overview"}
+                      >
+                        <IconDeviceDesktopOff className="w-3.5 h-3.5" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>No frame</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant={
+                          deviceFrame === "desktop" ? "secondary" : "ghost"
+                        }
+                        size="icon"
+                        className="h-7 w-7 cursor-pointer"
+                        onClick={() => setDeviceFrame("desktop")}
+                        disabled={viewMode === "overview"}
+                      >
+                        <IconDeviceDesktop className="w-3.5 h-3.5" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Desktop</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant={
+                          deviceFrame === "tablet" ? "secondary" : "ghost"
+                        }
+                        size="icon"
+                        className="h-7 w-7 cursor-pointer"
+                        onClick={() => setDeviceFrame("tablet")}
+                        disabled={viewMode === "overview"}
+                      >
+                        <IconDeviceTablet className="w-3.5 h-3.5" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Tablet</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant={
+                          deviceFrame === "mobile" ? "secondary" : "ghost"
+                        }
+                        size="icon"
+                        className="h-7 w-7 cursor-pointer"
+                        onClick={() => setDeviceFrame("mobile")}
+                        disabled={viewMode === "overview"}
+                      >
+                        <IconDeviceMobile className="w-3.5 h-3.5" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Mobile</TooltipContent>
+                  </Tooltip>
+                </div>
+
+                <div className="w-px h-5 bg-accent mx-1" />
+
+                {/* Zoom */}
+                <div className="flex items-center gap-0.5">
                   <Button
-                    variant={deviceFrame === "none" ? "secondary" : "ghost"}
+                    variant="ghost"
                     size="icon"
                     className="h-7 w-7 cursor-pointer"
-                    onClick={() => setDeviceFrame("none")}
-                    disabled={viewMode === "overview"}
+                    onClick={handleZoomOut}
                   >
-                    <IconDeviceDesktopOff className="w-3.5 h-3.5" />
+                    <IconZoomOut className="w-3.5 h-3.5" />
                   </Button>
-                </TooltipTrigger>
-                <TooltipContent>No frame</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
+                  <span className="w-10 text-center text-xs tabular-nums text-muted-foreground">
+                    {zoomLabel}
+                  </span>
                   <Button
-                    variant={deviceFrame === "desktop" ? "secondary" : "ghost"}
+                    variant="ghost"
                     size="icon"
                     className="h-7 w-7 cursor-pointer"
-                    onClick={() => setDeviceFrame("desktop")}
-                    disabled={viewMode === "overview"}
+                    onClick={handleZoomIn}
                   >
-                    <IconDeviceDesktop className="w-3.5 h-3.5" />
+                    <IconZoomIn className="w-3.5 h-3.5" />
                   </Button>
-                </TooltipTrigger>
-                <TooltipContent>Desktop</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant={deviceFrame === "tablet" ? "secondary" : "ghost"}
-                    size="icon"
-                    className="h-7 w-7 cursor-pointer"
-                    onClick={() => setDeviceFrame("tablet")}
-                    disabled={viewMode === "overview"}
-                  >
-                    <IconDeviceTablet className="w-3.5 h-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Tablet</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant={deviceFrame === "mobile" ? "secondary" : "ghost"}
-                    size="icon"
-                    className="h-7 w-7 cursor-pointer"
-                    onClick={() => setDeviceFrame("mobile")}
-                    disabled={viewMode === "overview"}
-                  >
-                    <IconDeviceMobile className="w-3.5 h-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Mobile</TooltipContent>
-              </Tooltip>
-            </div>
+                </div>
 
-            <div className="w-px h-5 bg-accent mx-1" />
-
-            {/* Zoom */}
-            <div className="flex items-center gap-0.5">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 cursor-pointer"
-                onClick={handleZoomOut}
-              >
-                <IconZoomOut className="w-3.5 h-3.5" />
-              </Button>
-              <span className="w-10 text-center text-xs tabular-nums text-muted-foreground">
-                {zoomLabel}
-              </span>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 cursor-pointer"
-                onClick={handleZoomIn}
-              >
-                <IconZoomIn className="w-3.5 h-3.5" />
-              </Button>
-            </div>
-
-            <div className="w-px h-5 bg-accent mx-1" />
+                <div className="w-px h-5 bg-accent mx-1" />
+              </>
+            )}
 
             {/* Actions */}
             <Tooltip>
@@ -1606,51 +1629,55 @@ ${serializedHtml}
               <TooltipContent>Tweaks</TooltipContent>
             </Tooltip>
 
-            {/* Draw on canvas — overlays the iframe with pencil + text. */}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant={drawMode ? "secondary" : "ghost"}
-                  size="icon"
-                  className="h-7 w-7 cursor-pointer"
-                  data-toolbar-draw-button
-                  onClick={handleDrawToolToggle}
-                  disabled={!activeFile || viewMode === "overview"}
-                >
-                  <IconPencilPlus className="w-3.5 h-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {viewMode === "overview"
-                  ? "Open a single screen to draw"
-                  : drawMode
-                    ? "Exit draw mode"
-                    : "Draw on current screen"}
-              </TooltipContent>
-            </Tooltip>
+            {!embedded && (
+              <>
+                {/* Draw on canvas — overlays the iframe with pencil + text. */}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant={drawMode ? "secondary" : "ghost"}
+                      size="icon"
+                      className="h-7 w-7 cursor-pointer"
+                      data-toolbar-draw-button
+                      onClick={handleDrawToolToggle}
+                      disabled={!activeFile || viewMode === "overview"}
+                    >
+                      <IconPencilPlus className="w-3.5 h-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {viewMode === "overview"
+                      ? "Open a single screen to draw"
+                      : drawMode
+                        ? "Exit draw mode"
+                        : "Draw on current screen"}
+                  </TooltipContent>
+                </Tooltip>
 
-            {/* Drop comment pin — overlays the iframe with click-to-comment. */}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant={pinMode ? "secondary" : "ghost"}
-                  size="icon"
-                  className="h-7 w-7 cursor-pointer"
-                  data-toolbar-pin-button
-                  onClick={handlePinToolToggle}
-                  disabled={!activeFile || viewMode === "overview"}
-                >
-                  <IconPin className="w-3.5 h-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {viewMode === "overview"
-                  ? "Open a single screen to comment"
-                  : pinMode
-                    ? "Exit comment pin mode"
-                    : "Drop comment pin"}
-              </TooltipContent>
-            </Tooltip>
+                {/* Drop comment pin — overlays the iframe with click-to-comment. */}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant={pinMode ? "secondary" : "ghost"}
+                      size="icon"
+                      className="h-7 w-7 cursor-pointer"
+                      data-toolbar-pin-button
+                      onClick={handlePinToolToggle}
+                      disabled={!activeFile || viewMode === "overview"}
+                    >
+                      <IconPin className="w-3.5 h-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {viewMode === "overview"
+                      ? "Open a single screen to comment"
+                      : pinMode
+                        ? "Exit comment pin mode"
+                        : "Drop comment pin"}
+                  </TooltipContent>
+                </Tooltip>
+              </>
+            )}
 
             {/* Save state — currently the design template doesn't expose a
               dedicated "save in flight" signal (file edits go through Yjs +
@@ -1658,76 +1685,84 @@ ${serializedHtml}
               slides; flip `saving` off until we wire a real source. */}
             <SaveStatusIndicator saving={false} className="ml-1 mr-1" />
 
-            <ShareButton
-              resourceType="design"
-              resourceId={id}
-              resourceTitle={design.title}
-            />
+            {!embedded && (
+              <ShareButton
+                resourceType="design"
+                resourceId={id}
+                resourceTitle={design.title}
+              />
+            )}
 
-            <DropdownMenu>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7 cursor-pointer"
-                      disabled={!activeFile || exportPending}
-                    >
-                      <IconDownload className="w-3.5 h-3.5" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent>Export</TooltipContent>
-              </Tooltip>
-              <DropdownMenuContent align="end" className="w-56">
-                <DropdownMenuItem
-                  onClick={handleDownloadHtml}
-                  disabled={!activeFile || exportHtmlMutation.isPending}
-                >
-                  <IconCode className="mr-2 h-4 w-4" />
-                  Download HTML
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={handleDownloadPng}
-                  disabled={!activeFile}
-                >
-                  <IconPhoto className="mr-2 h-4 w-4" />
-                  Download PNG
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={handleDownloadSvg}
-                  disabled={!activeFile || svgExporting}
-                >
-                  <IconCode className="mr-2 h-4 w-4" />
-                  Download SVG
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={handleDownloadZip}
-                  disabled={!activeFile || exportZipMutation.isPending}
-                >
-                  <IconArchive className="mr-2 h-4 w-4" />
-                  Download ZIP
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={handleCopyCodingHandoff}
-                  disabled={
-                    !activeFile || createCodingHandoffMutation.isPending
-                  }
-                >
-                  <IconCode className="mr-2 h-4 w-4" />
-                  Copy coding handoff
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            {!embedded && (
+              <DropdownMenu>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 cursor-pointer"
+                        disabled={!activeFile || exportPending}
+                      >
+                        <IconDownload className="w-3.5 h-3.5" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>Export</TooltipContent>
+                </Tooltip>
+                <DropdownMenuContent align="end" className="w-56">
+                  <DropdownMenuItem
+                    onClick={handleDownloadHtml}
+                    disabled={!activeFile || exportHtmlMutation.isPending}
+                  >
+                    <IconCode className="mr-2 h-4 w-4" />
+                    Download HTML
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={handleDownloadPng}
+                    disabled={!activeFile}
+                  >
+                    <IconPhoto className="mr-2 h-4 w-4" />
+                    Download PNG
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={handleDownloadSvg}
+                    disabled={!activeFile || svgExporting}
+                  >
+                    <IconCode className="mr-2 h-4 w-4" />
+                    Download SVG
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={handleDownloadZip}
+                    disabled={!activeFile || exportZipMutation.isPending}
+                  >
+                    <IconArchive className="mr-2 h-4 w-4" />
+                    Download ZIP
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={handleCopyCodingHandoff}
+                    disabled={
+                      !activeFile || createCodingHandoffMutation.isPending
+                    }
+                  >
+                    <IconCode className="mr-2 h-4 w-4" />
+                    Copy coding handoff
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
 
-            <PresenceBar
-              activeUsers={activeUsers}
-              agentActive={agentActive}
-              currentUserEmail={session?.email}
-            />
-            <NotificationsBell />
-            <AgentToggleButton />
+            {!embedded && (
+              <>
+                <PresenceBar
+                  activeUsers={activeUsers}
+                  agentActive={agentActive}
+                  currentUserEmail={session?.email}
+                />
+                <NotificationsBell />
+                <AgentToggleButton />
+              </>
+            )}
           </div>
         </div>
       </header>
@@ -1786,12 +1821,16 @@ ${serializedHtml}
             designs. "Use this one" persists the chosen content as index.html. */}
         {pendingVariants && (
           <div className="absolute inset-0 z-40 flex flex-col bg-background">
-            <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
-              <div>
-                <span className="text-sm font-medium text-foreground/90">
+            <div
+              className={`flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 ${
+                embedded ? "h-10" : "h-12"
+              }`}
+            >
+              <div className="min-w-0">
+                <span className="block truncate text-sm font-medium text-foreground/90">
                   {pendingVariants.prompt ?? "Pick a direction"}
                 </span>
-                <span className="ml-2 text-xs text-muted-foreground">
+                <span className="text-xs text-muted-foreground">
                   {pendingVariants.variants.length} variations
                 </span>
               </div>


### PR DESCRIPTION
## Summary
- add a Design app-backed skill/manifest so agents can install the hosted Design MCP connector with `agent-native skills add design-exploration`
- add `present-design-variants` so external hosts can show 2-5 generated design directions in the real Design editor MCP app and wait for the user pick
- compact the Design editor when embedded in MCP Apps and make generated preview iframes fit/render safely without `allow-same-origin`

## Testing
- `pnpm --dir packages/core exec vitest --run src/cli/skills.spec.ts`
- `pnpm --dir templates/design exec vitest --run actions/present-design-variants.spec.ts`
- `pnpm dev:cli skills add design-exploration --client codex --scope project --dry-run --json`
- `pnpm dev:cli app-skill pack --manifest templates/design/agent-native.app-skill.json --out /tmp/design-skill-test --json`
- Chrome/Playwright local E2E against `http://127.0.0.1:9212/design/assets-picker-minimal-qa-2?embedded=1`: presented three Apple-esque Assets picker directions, verified embedded 760x680 fit, verified no console/page/network errors, verified live full-HTML previews, selected Progressive Focus, verified only selected HTML persisted and variant state cleared
- `pnpm --dir templates/design typecheck`
- `pnpm --filter @agent-native/core typecheck`
- `pnpm --dir templates/design build`
- `pnpm run prep`