### PR TITLE
Harden Assets and Design MCP app flows

### DIFF
--- a/templates/assets/app/routes/picker.tsx
+++ b/templates/assets/app/routes/picker.tsx
@@ -518,9 +518,13 @@ export default function AssetPicker() {
     setCount(urlHostConfig.count ?? 3);
   }, [urlHostConfig]);
 
-  const { data: libraryData } = useActionQuery("list-libraries", {
+  const librariesQuery = useActionQuery("list-libraries", {
     compact: true,
-  } as any) as { data?: { libraries?: Library[] } };
+  } as any) as {
+    data?: { libraries?: Library[] };
+  };
+  const libraryData = librariesQuery.data;
+  const libraryListReady = Array.isArray(libraryData?.libraries);
   const libraries = libraryData?.libraries ?? [];
   const starterLibrary: Library = useMemo(
     () => ({
@@ -537,10 +541,20 @@ export default function AssetPicker() {
       : [starterLibrary];
 
   useEffect(() => {
-    if (!selectedLibraryId && displayLibraries[0]) {
-      setSelectedLibraryId(displayLibraries[0].id);
+    const firstLibraryId = displayLibraries[0]?.id;
+    if (!firstLibraryId) return;
+    if (!selectedLibraryId) {
+      setSelectedLibraryId(firstLibraryId);
+      return;
     }
-  }, [displayLibraries, selectedLibraryId]);
+    if (!libraryListReady) return;
+    const selectedLibraryExists = displayLibraries.some(
+      (library) => library.id === selectedLibraryId,
+    );
+    if (!selectedLibraryExists) {
+      setSelectedLibraryId(firstLibraryId);
+    }
+  }, [displayLibraries, libraryListReady, selectedLibraryId]);
 
   const { data: config } = useActionQuery(
     "get-image-generation-config",
@@ -783,6 +797,7 @@ export default function AssetPicker() {
         : "Connect Builder.io or add a Gemini key in Settings to generate image assets.";
   const needsGenerationLibrary =
     mediaType === "image" &&
+    libraryListReady &&
     !libraries.length &&
     !createdPickerLibrary &&
     usingStarterLibrary;

--- a/templates/design/actions/present-design-variants.spec.ts
+++ b/templates/design/actions/present-design-variants.spec.ts
@@ -11,6 +11,7 @@ vi.mock("@agent-native/core/application-state", () => ({
 
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: mocks.assertAccess,
+  registerShareableResource: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/server", () => ({

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -3,6 +3,7 @@ import { buildDeepLink } from "@agent-native/core/server";
 import { writeAppState } from "@agent-native/core/application-state";
 import { assertAccess } from "@agent-native/core/sharing";
 import { z } from "zod";
+import "../server/db/index.js"; // ensure registerShareableResource runs
 
 function designDeepLink(designId: string): string {
   return buildDeepLink({

--- a/templates/design/app/components/design/VariantGrid.tsx
+++ b/templates/design/app/components/design/VariantGrid.tsx
@@ -14,6 +14,7 @@ interface VariantGridProps {
   selectedId?: string;
   onSelect: (id: string) => void;
   onUse: (id: string) => void;
+  compact?: boolean;
 }
 
 export function VariantGrid({
@@ -21,13 +22,21 @@ export function VariantGrid({
   selectedId,
   onSelect,
   onUse,
+  compact = false,
 }: VariantGridProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null);
 
   // The same grid renders both in the full editor and in compact MCP App
   // embeds, so it needs to wrap instead of squeezing previews into slivers.
-  const gridClass =
-    variants.length <= 1
+  const gridClass = compact
+    ? variants.length <= 1
+      ? "grid-cols-1"
+      : variants.length === 2
+        ? "grid-cols-1 min-[520px]:grid-cols-2"
+        : variants.length === 3
+          ? "grid-cols-1 min-[520px]:grid-cols-2"
+          : "grid-cols-1 min-[520px]:grid-cols-2"
+    : variants.length <= 1
       ? "grid-cols-1"
       : variants.length === 2
         ? "grid-cols-1 sm:grid-cols-2"
@@ -36,10 +45,18 @@ export function VariantGrid({
           : "grid-cols-1 sm:grid-cols-2";
 
   return (
-    <div className="flex h-full w-full flex-col overflow-y-auto bg-background p-3 sm:p-4 lg:p-6">
+    <div
+      className={cn(
+        "flex h-full w-full flex-col overflow-y-auto bg-background",
+        compact ? "p-3" : "p-3 sm:p-4 lg:p-6",
+      )}
+    >
       <div
         className={cn(
-          "grid min-h-0 flex-1 auto-rows-[minmax(260px,1fr)] gap-3 sm:gap-4",
+          "grid min-h-0 flex-1 gap-3 sm:gap-4",
+          compact
+            ? "auto-rows-[minmax(210px,1fr)]"
+            : "auto-rows-[minmax(260px,1fr)]",
           gridClass,
         )}
       >

--- a/templates/design/app/hooks/use-variant-flow.ts
+++ b/templates/design/app/hooks/use-variant-flow.ts
@@ -2,6 +2,8 @@ import { useEffect, useCallback, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { sendToAgentChat, agentNativePath } from "@agent-native/core/client";
 
+export const DESIGN_VARIANT_PICKED_EVENT = "agent-native-design-variant-picked";
+
 export interface VariantCandidate {
   id: string;
   label: string;
@@ -76,6 +78,7 @@ export function useVariantFlow(designId: string | undefined) {
       // Persist the chosen variant as the design's primary file via the
       // agent's own action endpoint. We keep the agent informed via chat so
       // subsequent edits target the picked direction.
+      let persisted = false;
       try {
         const res = await fetch(
           agentNativePath("/_agent-native/actions/generate-design"),
@@ -95,7 +98,23 @@ export function useVariantFlow(designId: string | undefined) {
             }),
           },
         );
-        if (!res.ok) {
+        if (res.ok) {
+          await Promise.all([
+            qc.invalidateQueries({
+              queryKey: ["action", "get-design", { id: designId }],
+            }),
+            qc.invalidateQueries({ queryKey: ["action", "get-design"] }),
+            qc.invalidateQueries({ queryKey: ["action", "list-designs"] }),
+          ]);
+          persisted = true;
+          if (typeof window !== "undefined") {
+            window.dispatchEvent(
+              new CustomEvent(DESIGN_VARIANT_PICKED_EVENT, {
+                detail: { designId, content: chosen.content },
+              }),
+            );
+          }
+        } else {
           // Surface the failure rather than telling the agent the variant was
           // saved when the server actually rejected it. The picker still
           // clears so the user isn't stuck — they can re-pick after retrying.
@@ -112,15 +131,19 @@ export function useVariantFlow(designId: string | undefined) {
         message: `I picked "${chosen.label}".`,
         context: [
           `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${designId}.`,
-          `Its content has been saved as index.html. Continue refining from there if the user asks.`,
-          `Do not show further variants unless the user explicitly asks for "more options" or "alternatives".`,
+          persisted
+            ? `Its content has been saved as index.html. Continue refining from there if the user asks.`
+            : `Saving the chosen variant did not complete. Ask the user whether to retry before refining it.`,
+          persisted
+            ? `Do not show further variants unless the user explicitly asks for "more options" or "alternatives".`
+            : `Do not claim the design file was updated until generate-design succeeds.`,
         ].join("\n"),
         submit: false,
       });
 
       clear();
     },
-    [state, designId, clear],
+    [state, designId, qc, clear],
   );
 
   const dismiss = useCallback(() => {

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -65,7 +65,10 @@ import PromptPopover from "@/components/editor/PromptDialog";
 import type { UploadedFile } from "@/components/editor/PromptDialog";
 import { useAgentGenerating } from "@/hooks/use-agent-generating";
 import { useQuestionFlow } from "@/hooks/use-question-flow";
-import { useVariantFlow } from "@/hooks/use-variant-flow";
+import {
+  DESIGN_VARIANT_PICKED_EVENT,
+  useVariantFlow,
+} from "@/hooks/use-variant-flow";
 import { useOpenMobileSidebar } from "@/components/layout/Layout";
 import type {
   ElementInfo,
@@ -92,6 +95,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 
 const TAB_ID = generateTabId();
@@ -655,6 +659,7 @@ export default function DesignEditor() {
   // Freshest known DB `updatedAt` for the active file, kept in a ref so the
   // Yjs observe handler can advance the reconcile watermark without re-subscribing.
   const documentFileUpdatedAtRef = useRef<string | null>(null);
+  const documentFileContentRef = useRef<string | null>(null);
 
   // Whether this client applies authoritative external snapshots into the
   // shared Y.Doc. Exactly one client (the lead) does, so an agent/peer edit
@@ -703,7 +708,8 @@ export default function DesignEditor() {
   // Keep the freshest DB `updatedAt` in a ref the observe handler can read.
   useEffect(() => {
     documentFileUpdatedAtRef.current = activeFile?.updatedAt ?? null;
-  }, [activeFile?.updatedAt]);
+    documentFileContentRef.current = activeFile?.content ?? null;
+  }, [activeFile?.content, activeFile?.updatedAt]);
 
   // Observe Y.Text changes for live updates from remote editors (peers + the
   // agent's in-process applyText). This is the instant peer-to-peer path.
@@ -714,10 +720,14 @@ export default function DesignEditor() {
       const next = ytext.toString();
       setCollabContent(next);
       lastLocalContentRef.current = next;
-      // A Yjs update means the live doc now matches whatever DB write produced
-      // it; advance the watermark so the get-design reconcile below no-ops.
-      lastAppliedFileUpdatedAtRef.current =
-        documentFileUpdatedAtRef.current ?? lastAppliedFileUpdatedAtRef.current;
+      // Only advance the DB reconcile watermark when the live CRDT text
+      // actually matches the current SQL snapshot. Otherwise an intermediate
+      // or malformed Yjs update can shadow valid saved HTML until reload.
+      if (next === documentFileContentRef.current) {
+        lastAppliedFileUpdatedAtRef.current =
+          documentFileUpdatedAtRef.current ??
+          lastAppliedFileUpdatedAtRef.current;
+      }
     };
     ytext.observe(handler);
     return () => {
@@ -774,6 +784,26 @@ export default function DesignEditor() {
       }
     }
   }, [activeFile, collabContent, isSynced, isLeadClient, ydoc]);
+
+  useEffect(() => {
+    const handleVariantPicked = (event: Event) => {
+      const detail = (
+        event as CustomEvent<{ designId?: string; content?: string }>
+      ).detail;
+      if (detail?.designId !== id || typeof detail.content !== "string") {
+        return;
+      }
+      setCollabContent(detail.content);
+      lastLocalContentRef.current = detail.content;
+    };
+    window.addEventListener(DESIGN_VARIANT_PICKED_EVENT, handleVariantPicked);
+    return () => {
+      window.removeEventListener(
+        DESIGN_VARIANT_PICKED_EVENT,
+        handleVariantPicked,
+      );
+    };
+  }, [id]);
 
   // Set awareness local state to include which file the user is viewing
   useEffect(() => {
@@ -1393,6 +1423,7 @@ ${serializedHtml}
     id: f.id,
     filename: f.filename,
   }));
+  const hideEmbeddedVariantToolbar = embedded && !!pendingVariants;
 
   return (
     // h-full not flex-1: the parent <main> uses overflow-y-auto, not flex,
@@ -1402,9 +1433,11 @@ ${serializedHtml}
     <div className="h-full flex flex-col overflow-hidden bg-background">
       {/* Toolbar */}
       <header
-        className={`shrink-0 overflow-x-auto overflow-y-hidden overscroll-x-contain border-b border-border [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${
-          embedded ? "h-10" : "h-12"
-        }`}
+        className={cn(
+          "shrink-0 overflow-x-auto overflow-y-hidden overscroll-x-contain border-b border-border [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+          embedded ? "h-10" : "h-12",
+          hideEmbeddedVariantToolbar && "hidden",
+        )}
       >
         <div className="flex h-full min-w-max w-full items-center gap-2 px-3">
           {openMobileSidebar && (
@@ -1849,6 +1882,7 @@ ${serializedHtml}
                 variants={pendingVariants.variants}
                 onSelect={handleUseVariant}
                 onUse={handleUseVariant}
+                compact={embedded}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- prevent the Assets MCP picker from creating duplicate fallback libraries before real library data loads
- register Design shareable resources for `present-design-variants` action calls
- make embedded Design variant picking fit better in MCP app frames and settle immediately into the chosen preview

## Testing
- pnpm --dir templates/assets test actions/open-asset-picker.spec.ts actions/generate-image-batch.spec.ts
- pnpm --dir templates/design test actions/present-design-variants.spec.ts app/lib/pending-generation.test.ts app/components/design/bridge-security.test.ts
- pnpm --dir templates/assets typecheck
- pnpm --dir templates/design typecheck
- pnpm --dir packages/core test src/mcp/server.spec.ts src/cli/skills.spec.ts src/client/mcp-app-host.spec.ts (ran full core suite: 245 files / 2521 tests)
- pnpm --dir packages/core exec tsx src/cli/index.ts skills add agent-native-images --scope project --client codex --dry-run
- pnpm --dir packages/core exec tsx src/cli/index.ts skills add agent-native-design-exploration --scope project --client codex --dry-run
- pnpm run prep

## Manual QA
- generated 3 Assets images through the local picker and verified the embedded host bridge returns absolute selected image URLs plus image context
- verified no duplicate `MCP image picks` library creation on auto-generate load
- exercised Design `present-design-variants` inside a 760x680 MCP-style iframe, selected a variant, and verified the embedded editor immediately renders the chosen design without reload or overflow