### PR TITLE
Pinned chat activity + Code-mode rename (+ db-admin/docs polish)

### DIFF
--- a/.changeset/code-mode-rename.md
+++ b/.changeset/code-mode-rename.md
@@ -1,0 +1,18 @@
+---
+"@agent-native/core": minor
+---
+
+Rename the agent-capability "dev mode" to "Code mode" for clarity. This is the
+toggle that lets the agent run shell/file/raw-DB tools and edit the app's own
+source code — now named distinctly from environment dev mode (`NODE_ENV` /
+Vite).
+
+- `useCodeMode()` is now the primary client hook, returning `{ isCodeMode,
+canToggle, isLoading, setCodeMode }`.
+- `useDevMode()` is kept as a `@deprecated` alias that returns the old
+  `{ isDevMode, canToggle, isLoading, setDevMode }` shape, delegating to the
+  same shared internal state so existing callers keep working.
+- Back-compat is fully preserved: the `AGENT_MODE` env var, the
+  `/_agent-native/agent-chat/mode` endpoint (its payload still uses `devMode`),
+  and the `agent-chat.mode` settings key are unchanged. The `/mode` GET response
+  now additively includes a `codeMode` field mirroring `devMode`.

--- a/.changeset/pinned-chat-activity.md
+++ b/.changeset/pinned-chat-activity.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep live agent activity steps pinned above the composer while a chat run is in progress, leaving completed activity trails collapsed in the transcript.

--- a/packages/core/docs/content/frames.md
+++ b/packages/core/docs/content/frames.md
@@ -33,14 +33,14 @@ component in dev and prod.
 - Reads `application_state.navigation` every turn, so it already knows which
   view you're in and what's selected — you don't have to re-explain "this".
 
-### Dev vs prod tool modes {#tool-modes}
+### App vs Code tool modes {#tool-modes}
 
 The panel runs in one of two tool modes:
 
-- **Production mode** — the agent only has your app's own tools: the actions you
+- **App mode** — the agent only has your app's own tools: the actions you
   defined with `defineAction`, plus navigation and context. No filesystem or
   shell access. This is what end users get.
-- **Development mode** — adds the shared coding tools (`bash`, `read`, `edit`,
+- **Code mode** — adds the shared coding tools (`bash`, `read`, `edit`,
   `write`) and database access on top of the app tools, so the agent can change
   the app's own source. Code requests are gated: when a message requires code
   (`type: "code"`) and no code-capable frame is connected, the panel shows a
@@ -48,9 +48,15 @@ The panel runs in one of two tool modes:
   when a frame is connected, the request is routed to it and a code-agent
   indicator shows while it works (`useSendToAgentChat`).
 
+"Code mode" is the agent-capability toggle — distinct from environment dev mode
+(`NODE_ENV` / Vite). For back-compat the underlying `AGENT_MODE` env var, the
+`/_agent-native/agent-chat/mode` endpoint (whose payload still uses `devMode`),
+and the `agent-chat.mode` settings key are unchanged. The client hook is
+`useCodeMode()` (the older `useDevMode()` remains as a deprecated alias).
+
 In the local dev frame, the settings cog toggles between these modes. Switching
-to prod hides the frame's own sidebar and shows the app's in-app agent sidebar
-inside the iframe instead, so you can preview exactly what end users see.
+off Code mode hides the frame's own sidebar and shows the app's in-app agent
+sidebar inside the iframe instead, so you can preview exactly what end users see.
 
 ## Integrated terminal and CLI switching {#cli-terminal}
 

--- a/packages/core/docs/content/workspace.md
+++ b/packages/core/docs/content/workspace.md
@@ -139,7 +139,7 @@ Change how the agent behaves, in 60 seconds.
 
 ## How the Agent Uses Resources {#how-the-agent-uses-resources}
 
-The agent has built-in tools for managing resources: `resource-list`, `resource-read`, `resource-effective`, `resource-write`, and `resource-delete`. These are available in both dev and production modes.
+The agent has built-in tools for managing resources: `resource-list`, `resource-read`, `resource-effective`, `resource-write`, and `resource-delete`. These are available in both Code mode and App mode.
 
 At the start of every conversation, the agent automatically reads:
 
@@ -337,8 +337,8 @@ When the agent encounters a task that matches a skill, it reads the skill file a
 
 There are two ways to add skills:
 
-1. **Via Workspace tab** — Create a new resource with a path like `skills/my-skill/SKILL.md`. This works in both dev and production.
-2. **Via code (dev only)** — Add a Markdown file to `.agents/skills/` in your project. These are available when the app runs in dev mode.
+1. **Via Workspace tab** — Create a new resource with a path like `skills/my-skill/SKILL.md`. This works in both Code mode and App mode.
+2. **Via code (Code mode only)** — Add a Markdown file to `.agents/skills/` in your project. These are available when the app runs in Code mode.
 
 ## Custom Agents {#custom-agents}
 
@@ -435,8 +435,8 @@ When you send a message:
 
 What shows up depends on the mode:
 
-- **Dev mode** — Codebase files, workspace resources, custom agents, and connected agents
-- **Production mode** — Workspace resources, custom agents, and connected agents
+- **Code mode** — Codebase files, workspace resources, custom agents, and connected agents
+- **App mode** — Workspace resources, custom agents, and connected agents
 
 ## / Slash Commands {#slash-commands}
 
@@ -444,16 +444,16 @@ Type `/` at the start of a line to invoke a skill. A dropdown shows available sk
 
 What shows up depends on the mode:
 
-- **Dev mode** — Skills from `.agents/skills/` (codebase) and skills from resources
-- **Production mode** — Skills from resources only
+- **Code mode** — Skills from `.agents/skills/` (codebase) and skills from resources
+- **App mode** — Skills from resources only
 
 If no skills are configured, the dropdown shows a hint with a link to these docs.
 
-## Dev vs Production Mode {#dev-vs-prod}
+## Code vs App Mode {#dev-vs-prod}
 
 The resource system works identically in both modes. The difference is what additional sources are available for `@` tagging and `/` commands:
 
-| Feature            | Dev Mode                                                                | Production                                             |
+| Feature            | Code Mode                                                               | App Mode                                               |
 | ------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------ |
 | @ tagging          | Codebase files + workspace resources + custom agents + connected agents | Workspace resources + custom agents + connected agents |
 | / slash commands   | .agents/skills/ + resource skills                                       | Resource skills only                                   |

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1343,6 +1343,7 @@ function AgentPanelInner({
             ".agent-tabs-scroll{scrollbar-width:none;-ms-overflow-style:none;}" +
             ".agent-tabs-scroll::-webkit-scrollbar{display:none;}" +
             `[data-agent-fullscreen='true'] .agent-thread-content,` +
+            `[data-agent-fullscreen='true'] .agent-running-activity,` +
             `[data-agent-fullscreen='true'] .agent-composer-area{` +
             `max-width:${FULLSCREEN_CONTENT_MAX_PX}px;` +
             `margin-left:auto;margin-right:auto;width:100%;}`,

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2442,12 +2442,21 @@ interface ActivityStep {
   tool?: string;
 }
 
-function ActivitySteps({ steps }: { steps: ActivityStep[] }) {
+function ActivitySteps({
+  steps,
+  className,
+}: {
+  steps: ActivityStep[];
+  className?: string;
+}) {
   if (steps.length === 0) return null;
   const visibleSteps = steps.slice(-4);
   return (
     <div
-      className="max-w-[85%] rounded-md border border-border/60 bg-muted/30 px-2.5 py-2 text-xs text-muted-foreground"
+      className={cn(
+        "max-w-[85%] rounded-md border border-border/60 bg-muted/30 px-2.5 py-2 text-xs text-muted-foreground",
+        className,
+      )}
       aria-live="polite"
     >
       <div className="space-y-1">
@@ -2464,6 +2473,23 @@ function ActivitySteps({ steps }: { steps: ActivityStep[] }) {
             </div>
           );
         })}
+      </div>
+    </div>
+  );
+}
+
+function RunningActivityStatus({
+  steps,
+  label,
+}: {
+  steps: ActivityStep[];
+  label: string;
+}) {
+  return (
+    <div className="agent-running-activity shrink-0 px-4 pb-2">
+      <div className="flex flex-col gap-2">
+        <ActivitySteps steps={steps} className="max-w-full" />
+        <ThinkingIndicator label={label} />
       </div>
     </div>
   );
@@ -5104,24 +5130,6 @@ const AssistantChatInner = forwardRef<
                     reconnectContent.length > 0 && (
                       <ReconnectStreamMessage content={reconnectContent} />
                     )}
-                  {/* Always show the thinking indicator while the agent is working,
-                including during reconnect. The indicator sits BELOW any
-                already-streamed reconnect content so the user sees both
-                "what it did so far" and "it's still working". Swap the label
-                to "Reconnecting" during reconnect so the user knows the
-                system is actively recovering, not just stuck. */}
-                  {showRunningInUI && (
-                    <>
-                      <ActivitySteps steps={activitySteps} />
-                      <ThinkingIndicator
-                        label={
-                          isReconnecting
-                            ? "Reconnecting"
-                            : (activityLabel ?? "Thinking")
-                        }
-                      />
-                    </>
-                  )}
                   {queuedMessages.map((msg) => {
                     const displayText = msg.text
                       .replace(/<context>[\s\S]*?<\/context>\n?/g, "")
@@ -5189,6 +5197,18 @@ const AssistantChatInner = forwardRef<
               />
             )}
             <SelectionAttachedPill />
+            {/* Keep live run progress pinned in the composer footer while the
+                completed/collapsed trail remains attached to the transcript. */}
+            {showRunningInUI && (
+              <RunningActivityStatus
+                steps={activitySteps}
+                label={
+                  isReconnecting
+                    ? "Reconnecting"
+                    : (activityLabel ?? "Thinking")
+                }
+              />
+            )}
             {/* Input area */}
             <AgentComposerFrame
               layoutVariant={composerLayoutVariant}

--- a/packages/core/src/client/db-admin/DbAdminPage.tsx
+++ b/packages/core/src/client/db-admin/DbAdminPage.tsx
@@ -1,15 +1,15 @@
 /**
- * Dev-mode database admin page — the shell that hosts the table browser, the
+ * Code-mode database admin page — the shell that hosts the table browser, the
  * table editor, and the SQL editor.
  *
- * Gated to development mode: when the app is not running in a dev environment
+ * Gated to Code mode: when the app cannot toggle into Code mode
  * (`canToggle` is false) we render a clean notice instead of the tool. The
  * backend also enforces this with a 403, so this is purely a friendlier UX.
  */
 import { useEffect, useMemo, useState } from "react";
 import { IconDatabase, IconLoader2 } from "@tabler/icons-react";
 import { cn } from "../utils.js";
-import { useDevMode } from "../use-dev-mode.js";
+import { useCodeMode } from "../use-dev-mode.js";
 import type { DbAdminFilter, DbAdminColumn } from "../../db-admin/types.js";
 import { useOverview } from "./useDbAdmin.js";
 import { TableBrowser } from "./TableBrowser.js";
@@ -24,7 +24,7 @@ const DIALECT_LABEL: Record<string, string> = {
 };
 
 export function DbAdminPage() {
-  const { canToggle, isLoading: devLoading } = useDevMode();
+  const { canToggle, isLoading: devLoading } = useCodeMode();
   const { data: overview, isLoading: overviewLoading } = useOverview();
 
   const [selectedTable, setSelectedTable] = useState<string | null>(null);
@@ -56,7 +56,7 @@ export function DbAdminPage() {
   // (Table-name autocomplete still works; column autocomplete fills in lazily.)
   const columnsByTable = useMemo<Record<string, string[]>>(() => ({}), []);
 
-  // ─── Dev gate ──────────────────────────────────────────────────────────
+  // ─── Code mode gate ──────────────────────────────────────────────────────
   if (!devLoading && !canToggle) {
     return (
       <div className="flex h-full w-full items-center justify-center bg-background p-6">
@@ -68,10 +68,10 @@ export function DbAdminPage() {
             />
           </div>
           <h2 className="text-base font-semibold text-foreground">
-            Development mode only
+            Code mode only
           </h2>
           <p className="mt-1.5 text-sm text-muted-foreground">
-            Database admin is available in development mode only.
+            Database admin is available in Code mode only.
           </p>
         </div>
       </div>

--- a/packages/core/src/client/db-admin/DevDatabaseLink.tsx
+++ b/packages/core/src/client/db-admin/DevDatabaseLink.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router";
 import { IconDatabase } from "@tabler/icons-react";
-import { useDevMode } from "../use-dev-mode.js";
+import { useCodeMode } from "../use-dev-mode.js";
 import { appPath } from "../api-path.js";
 import { cn } from "../utils.js";
 
@@ -11,27 +11,27 @@ export interface DevDatabaseLinkProps {
 }
 
 /**
- * Development-only entry point to the database admin.
+ * Code-mode-only entry point to the database admin.
  *
  * Renders a compact footer link (designed to sit next to `FeedbackButton` /
- * `OrgSwitcher` in a template's sidebar footer) ONLY when the app is running in
- * a development environment (`useDevMode().canToggle`). In production it renders
+ * `OrgSwitcher` in a template's sidebar footer) ONLY when the app can toggle
+ * into Code mode (`useCodeMode().canToggle`). When it can't, it renders
  * nothing, so it is safe to drop into every template's chrome unconditionally.
  *
  * The page it links to (`/database`) and its backing routes are independently
- * gated to `NODE_ENV === "development"` on the server, so this is purely a
- * convenience affordance — never a security boundary.
+ * gated on the server, so this is purely a convenience affordance — never a
+ * security boundary.
  */
 export function DevDatabaseLink({
   className,
   to = "/database",
 }: DevDatabaseLinkProps) {
-  const { canToggle } = useDevMode();
+  const { canToggle } = useCodeMode();
   if (!canToggle) return null;
   return (
     <Link
       to={appPath(to)}
-      title="Database admin — development only"
+      title="Database admin — Code mode only"
       className={cn(
         "flex w-full items-center gap-2 rounded-md border border-border/50 px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         className,
@@ -40,7 +40,7 @@ export function DevDatabaseLink({
       <IconDatabase className="h-3.5 w-3.5 shrink-0" />
       <span className="flex-1 truncate text-left">Database</span>
       <span className="rounded bg-muted px-1 py-0.5 text-[9px] uppercase tracking-wide text-muted-foreground">
-        dev
+        code
       </span>
     </Link>
   );

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -8,7 +8,7 @@ export {
   type AgentChatMessage,
 } from "./agent-chat.js";
 export { useAgentChatGenerating } from "./use-agent-chat.js";
-export { useDevMode } from "./use-dev-mode.js";
+export { useCodeMode, useDevMode } from "./use-dev-mode.js";
 export {
   agentNativePath,
   appApiPath,

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -1930,16 +1930,20 @@ function initialOpenSection(): SettingsSectionId {
   return normalizeSettingsSection(window.location.hash) ?? "llm";
 }
 
-const environmentOptions: SettingsSelectOption[] = [
+// Agent capability modes. The internal values ("production"/"development") are
+// kept for back-compat with the AGENT_MODE wiring; only the visible labels
+// changed to "App mode" / "Code mode" so this control reads as the agent
+// capability it is — not the deployment environment (NODE_ENV).
+const agentModeOptions: SettingsSelectOption[] = [
   {
     value: "production",
-    label: "Production",
+    label: "App mode",
     description:
       "App tools only; code, bash, and files require Builder or a local clone.",
   },
   {
     value: "development",
-    label: "Development",
+    label: "Code mode",
     description: "Full access to code editing, bash, and files.",
   },
 ];
@@ -2209,12 +2213,12 @@ export function SettingsPanel({
       className="flex-1 min-h-0 overflow-y-auto p-3 space-y-2"
       style={{ overflowY: "auto" }}
     >
-      {/* Environment toggle + dev app link */}
+      {/* Agent capability mode (App vs Code) + app link */}
       {(showDevToggle || devAppUrl) && (
         <div className="space-y-2 pb-2 border-b border-border mb-2">
           {showDevToggle && (
             <SettingsSelect
-              label="Environment"
+              label="Agent mode"
               labelAdornment={
                 devAppUrl ? (
                   <Tooltip>
@@ -2234,7 +2238,7 @@ export function SettingsPanel({
                 ) : undefined
               }
               value={isDevMode ? "development" : "production"}
-              options={environmentOptions}
+              options={agentModeOptions}
               onValueChange={(next) => {
                 const nextIsDev = next === "development";
                 if (nextIsDev !== isDevMode) onToggleDevMode();

--- a/packages/core/src/client/use-dev-mode.ts
+++ b/packages/core/src/client/use-dev-mode.ts
@@ -1,16 +1,16 @@
 import { useState, useEffect, useCallback } from "react";
 import { agentNativePath } from "./api-path.js";
 
-interface DevModeState {
+interface CodeModeState {
   devMode: boolean;
   canToggle: boolean;
 }
 
-let cached: DevModeState | null = null;
-let fetchPromise: Promise<DevModeState> | null = null;
-let listeners: Set<(state: DevModeState) => void> = new Set();
+let cached: CodeModeState | null = null;
+let fetchPromise: Promise<CodeModeState> | null = null;
+let listeners: Set<(state: CodeModeState) => void> = new Set();
 
-function notifyListeners(state: DevModeState) {
+function notifyListeners(state: CodeModeState) {
   cached = state;
   listeners.forEach((fn) => fn(state));
 }
@@ -21,22 +21,22 @@ function isLocalhostHostname(): boolean {
   return h === "localhost" || h === "127.0.0.1" || h === "::1";
 }
 
-function fetchDevMode(apiBase: string): Promise<DevModeState> {
+function fetchCodeMode(apiBase: string): Promise<CodeModeState> {
   if (!fetchPromise) {
     fetchPromise = fetch(`${apiBase}/mode`)
       .then((res) => {
         if (!res.ok) throw new Error(`${res.status}`);
         return res.json();
       })
-      .then((data: DevModeState) => {
+      .then((data: CodeModeState) => {
         cached = data;
         return cached;
       })
       .catch(() => {
         // If the server isn't reachable (503 during boot, connection refused,
-        // etc.) but we're clearly on localhost, assume dev mode so the CLI
-        // tab and dev toggle still work. Without this, a transient server
-        // error permanently disables dev features in the sidebar.
+        // etc.) but we're clearly on localhost, assume Code mode is on so the
+        // CLI tab and Code mode toggle still work. Without this, a transient
+        // server error permanently disables code features in the sidebar.
         cached = isLocalhostHostname()
           ? { devMode: true, canToggle: true }
           : { devMode: false, canToggle: false };
@@ -50,18 +50,21 @@ function fetchDevMode(apiBase: string): Promise<DevModeState> {
 }
 
 /**
- * Returns whether the app is running in dev mode and whether mode can be toggled.
- * Fetches /_agent-native/agent-chat/mode on first call, then stays in sync via setDevMode.
+ * Shared internal state machine backing both `useCodeMode` (primary) and the
+ * deprecated `useDevMode` alias. Returns the raw `{ codeMode, canToggle,
+ * isLoading, setCodeMode }` shape; the public hooks adapt the field names.
+ *
+ * The `/mode` endpoint and its `devMode` payload key are unchanged for
+ * back-compat — only the user-facing concept name moved from "dev mode" to
+ * "Code mode".
  */
-export function useDevMode(
-  apiBase = agentNativePath("/_agent-native/agent-chat"),
-): {
-  isDevMode: boolean;
+function useCodeModeInternal(apiBase: string): {
+  codeMode: boolean;
   canToggle: boolean;
   isLoading: boolean;
-  setDevMode: (devMode: boolean) => Promise<void>;
+  setCodeMode: (codeMode: boolean) => Promise<void>;
 } {
-  const [state, setState] = useState<DevModeState>(
+  const [state, setState] = useState<CodeModeState>(
     cached ?? { devMode: false, canToggle: false },
   );
   const [isLoading, setIsLoading] = useState(cached === null);
@@ -80,23 +83,24 @@ export function useDevMode(
       setIsLoading(false);
       return;
     }
-    fetchDevMode(apiBase).then((val) => {
+    fetchCodeMode(apiBase).then((val) => {
       setState(val);
       setIsLoading(false);
     });
   }, [apiBase]);
 
-  const setDevMode = useCallback(
-    async (devMode: boolean) => {
-      // Optimistic update — apply immediately, then confirm with server
-      notifyListeners({ devMode, canToggle: true });
+  const setCodeMode = useCallback(
+    async (codeMode: boolean) => {
+      // Optimistic update — apply immediately, then confirm with server.
+      // The endpoint still speaks `devMode` for back-compat.
+      notifyListeners({ devMode: codeMode, canToggle: true });
       const res = await fetch(`${apiBase}/mode`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ devMode }),
+        body: JSON.stringify({ devMode: codeMode }),
       });
       if (res.ok) {
-        const data: DevModeState = await res.json();
+        const data: CodeModeState = await res.json();
         notifyListeners(data);
       }
     },
@@ -104,9 +108,56 @@ export function useDevMode(
   );
 
   return {
-    isDevMode: state.devMode,
+    codeMode: state.devMode,
     canToggle: state.canToggle,
     isLoading,
-    setDevMode,
+    setCodeMode,
+  };
+}
+
+/**
+ * Whether the agent is in "Code mode" — the capability toggle that lets the
+ * agent run shell/file/raw-DB tools and edit the app's own source code. This is
+ * distinct from environment dev mode (NODE_ENV / Vite).
+ *
+ * Fetches `/_agent-native/agent-chat/mode` on first call, then stays in sync via
+ * `setCodeMode`. The endpoint, its `devMode` payload key, the `AGENT_MODE` env
+ * var, and the `agent-chat.mode` settings key are unchanged for back-compat.
+ */
+export function useCodeMode(
+  apiBase = agentNativePath("/_agent-native/agent-chat"),
+): {
+  isCodeMode: boolean;
+  canToggle: boolean;
+  isLoading: boolean;
+  setCodeMode: (codeMode: boolean) => Promise<void>;
+} {
+  const { codeMode, canToggle, isLoading, setCodeMode } =
+    useCodeModeInternal(apiBase);
+  return { isCodeMode: codeMode, canToggle, isLoading, setCodeMode };
+}
+
+/**
+ * @deprecated Use {@link useCodeMode} instead. The agent-capability "dev mode"
+ * was renamed to "Code mode" to disambiguate it from environment/NODE_ENV dev
+ * mode. This alias preserves the old `{ isDevMode, canToggle, isLoading,
+ * setDevMode }` shape so existing callers keep working; it delegates to the same
+ * shared internal state as `useCodeMode`.
+ */
+export function useDevMode(
+  apiBase = agentNativePath("/_agent-native/agent-chat"),
+): {
+  isDevMode: boolean;
+  canToggle: boolean;
+  isLoading: boolean;
+  setDevMode: (devMode: boolean) => Promise<void>;
+} {
+  const { codeMode, canToggle, isLoading, setCodeMode } =
+    useCodeModeInternal(apiBase);
+  return {
+    isDevMode: codeMode,
+    canToggle,
+    isLoading,
+    setDevMode: setCodeMode,
   };
 }

--- a/packages/core/src/db-admin/agent-tools.ts
+++ b/packages/core/src/db-admin/agent-tools.ts
@@ -107,7 +107,7 @@ export function createDbAdminAgentTools(): Record<string, ActionEntry> {
     "db-admin-mutate": {
       tool: {
         description:
-          'DEV ONLY. Insert, update, and/or delete rows in one table (unscoped). Pass `dryRun: "true"` to get the SQL without executing. Each update/delete must include a where clause.',
+          'DEV ONLY. Insert, update, and/or delete rows in one table (unscoped — full database access). PREFER THIS over db-exec/db-patch for any database-admin edit, and ALWAYS use it (not db-exec) for tables without owner_email/org_id columns — db-exec auto-scopes to the current user and will match 0 rows on unscoped tables. Pass `dryRun: "true"` to get the SQL without executing. Each update/delete must include a where clause.',
         parameters: {
           type: "object",
           properties: {
@@ -158,7 +158,7 @@ export function createDbAdminAgentTools(): Record<string, ActionEntry> {
     "db-admin-query": {
       tool: {
         description:
-          'DEV ONLY. Run arbitrary SQL against the full database (unscoped). Bare SELECTs are auto-limited to 100 rows. Destructive statements (DROP / TRUNCATE / unscoped DELETE or UPDATE) require confirmDestructive: "true".',
+          'DEV ONLY. Run arbitrary SQL against the full database (unscoped). PREFER THIS over db-query/db-exec for database-admin work and for any table without owner_email/org_id scoping (the scoped tools match 0 rows on those). Bare SELECTs are auto-limited to 100 rows. Destructive statements (DROP / TRUNCATE / unscoped DELETE or UPDATE) require confirmDestructive: "true".',
         parameters: {
           type: "object",
           properties: {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -4916,9 +4916,17 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
               // Persistence is best-effort — in-memory flag still applies for
               // the lifetime of this process even if the settings write fails.
             }
-            return { devMode: currentDevMode, canToggle };
+            return {
+              devMode: currentDevMode,
+              codeMode: currentDevMode,
+              canToggle,
+            };
           }
-          return { devMode: currentDevMode, canToggle };
+          return {
+            devMode: currentDevMode,
+            codeMode: currentDevMode,
+            canToggle,
+          };
         }),
       );
 

--- a/templates/assets/app/routes/settings.tsx
+++ b/templates/assets/app/routes/settings.tsx
@@ -1,21 +1,53 @@
 import {
+  agentNativePath,
   useActionQuery,
-  useBuilderStatus,
   useBuilderConnectFlow,
+  useBuilderStatus,
 } from "@agent-native/core/client";
-import { OnboardingPanel } from "@agent-native/core/client/onboarding";
+import {
+  useOnboarding,
+  type OnboardingMethod,
+  type OnboardingStepStatus,
+} from "@agent-native/core/client/onboarding";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   IconAlertCircle,
   IconCheck,
+  IconChevronDown,
   IconCloudUpload,
   IconExternalLink,
   IconKey,
+  IconLibraryPhoto,
   IconLoader2,
   IconPhoto,
 } from "@tabler/icons-react";
-import type { ReactNode } from "react";
-import { Badge } from "@/components/ui/badge";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from "react";
 import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { PageShell } from "@/components/layout/PageShell";
+import { cn } from "@/lib/utils";
 
 type ImageGenerationConfig = {
   builderEnabled?: boolean;
@@ -30,187 +62,531 @@ type ImageGenerationConfig = {
   } | null;
 };
 
+type FormOnboardingMethod = Extract<OnboardingMethod, { kind: "form" }>;
+
 export default function SettingsPage() {
-  const { data } = useActionQuery("list-libraries", { compact: true }) as any;
+  const { data } = useActionQuery("list-libraries", { compact: true }) as {
+    data?: { count?: number };
+  };
+
   return (
-    <div className="mx-auto max-w-4xl space-y-5 px-6 py-6">
-      <div>
-        <h2 className="text-2xl font-semibold tracking-tight">Settings</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Connect Builder-managed image generation, manual provider keys, video
-          generation, and object storage to start creating brand assets.
+    <PageShell
+      title="Settings"
+      description="Asset generation, storage, and library access."
+      className="max-w-4xl space-y-6"
+    >
+      <div className="max-w-2xl">
+        <h2 className="text-lg font-semibold tracking-tight">Connections</h2>
+        <p className="mt-1 text-sm leading-6 text-muted-foreground">
+          Keep Assets ready to generate, save, and share brand-safe media.
+          Builder is the simplest path; manual keys stay available when you need
+          them.
         </p>
       </div>
 
       <section id="asset-generation-setup" className="scroll-mt-4">
-        <OnboardingPanel title="Setup" />
+        <AssetsSetupCard libraryCount={data?.count ?? 0} />
       </section>
-
-      <div className="grid gap-4 md:grid-cols-3">
-        <InfoTile
-          icon={<IconKey className="h-5 w-5" />}
-          title="Asset generation"
-          body="Builder uses managed credits; OpenAI or Gemini keys can power manual image runs. Gemini also powers video."
-        />
-        <InfoTile
-          icon={<IconCloudUpload className="h-5 w-5" />}
-          title="Object storage"
-          body="Required in production for originals, videos, thumbnails, and exports."
-        />
-        <InfoTile
-          icon={<IconPhoto className="h-5 w-5" />}
-          title="Libraries"
-          body={`${(data as any)?.count ?? 0} accessible libraries`}
-        />
-      </div>
-
-      <div className="rounded-lg border border-border p-4">
-        <div className="flex items-center justify-between gap-4">
-          <div>
-            <h3 className="text-sm font-semibold">Cross-agent access</h3>
-            <p className="mt-1 text-sm text-muted-foreground">
-              This app is discoverable over A2A as the Assets agent. Slides,
-              Design, Content, and Mail should call Assets instead of media
-              providers directly when brand libraries matter.
-            </p>
-          </div>
-          <Badge variant="secondary">A2A ready</Badge>
-        </div>
-      </div>
-
-      <ManageCredentialsSection />
-    </div>
+    </PageShell>
   );
 }
 
-function ManageCredentialsSection() {
+function AssetsSetupCard({ libraryCount }: { libraryCount: number }) {
+  const queryClient = useQueryClient();
+  const onboarding = useOnboarding();
   const { status } = useBuilderStatus();
-  const flow = useBuilderConnectFlow({
-    trackingSource: "assets_settings_credentials",
-  });
-  // `BUILDER_IMAGE_GENERATION_ENABLED=false` deployments reject Builder
-  // credentials in `generateWithManagedImageProvider` even when Builder is
-  // connected. Surface that here so the settings UI doesn't send users
-  // down a Connect-Builder path that can't succeed. The onboarding plugin
-  // already marks the corresponding setup step `disabled` in this case;
-  // this card mirrors the gating.
+  const [manualGenerationOpen, setManualGenerationOpen] = useState(false);
+  const [manualStorageOpen, setManualStorageOpen] = useState(false);
   const { data: configData } = useActionQuery(
     "get-image-generation-config",
     {},
   ) as { data?: ImageGenerationConfig };
-  // While the flag query is loading, assume Builder is enabled (the
-  // production default) so the connect button doesn't briefly flash as
-  // disabled on first render.
+
+  const refreshSetup = async () => {
+    await Promise.all([
+      onboarding.refresh(),
+      queryClient.invalidateQueries({
+        queryKey: ["action", "get-image-generation-config"],
+      }),
+    ]);
+  };
+
+  const flow = useBuilderConnectFlow({
+    trackingSource: "assets_settings_connections",
+    trackingFlow: "image_generation",
+    onConnected: refreshSetup,
+  });
+
+  const generationStep = onboarding.steps.find(
+    (step) => step.id === "image-generation",
+  );
+  const storageStep = onboarding.steps.find(
+    (step) => step.id === "image-storage",
+  );
+
   const builderEnabled = configData?.builderEnabled ?? true;
-  const setupIssue =
-    typeof configData?.lastIssue?.message === "string"
-      ? configData.lastIssue.message
-      : null;
-  const configured = flow.hasFetchedStatus
+  const builderConfigured = flow.hasFetchedStatus
     ? flow.configured
     : !!status?.configured;
+  const builderConnected =
+    builderEnabled &&
+    (!!configData?.builderConnected || builderConfigured || !!flow.configured);
+  const generationReady =
+    builderConnected ||
+    configData?.configured === true ||
+    !!configData?.openaiConfigured ||
+    !!configData?.geminiConfigured ||
+    !!generationStep?.complete;
+  const storageReady =
+    builderConnected ||
+    !!configData?.objectStorageConfigured ||
+    !!storageStep?.complete;
+  const setupIssue =
+    flow.error ??
+    (typeof configData?.lastIssue?.message === "string"
+      ? configData.lastIssue.message
+      : null);
   const orgName = flow.orgName ?? status?.orgName ?? null;
-
-  if (!builderEnabled) {
-    return (
-      <div className="rounded-lg border border-border p-4">
-        <h3 className="text-sm font-semibold">Manage credentials</h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Builder-managed image generation is disabled for this deployment by
-          the <code className="text-xs">BUILDER_IMAGE_GENERATION_ENABLED</code>{" "}
-          environment variable. Add an OpenAI or Gemini API key from the Setup
-          checklist above; manual keys are the only path that will succeed until
-          the flag is re-enabled.
-        </p>
-        {setupIssue ? <SetupIssueCallout message={setupIssue} /> : null}
-      </div>
-    );
-  }
+  const readyCount = [generationReady, storageReady].filter(Boolean).length;
 
   return (
-    <div className="rounded-lg border border-border p-4">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <h3 className="text-sm font-semibold">Manage credentials</h3>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {configured
-              ? "Builder.io is connected for managed image generation and storage. Add Gemini for video generation, or add OpenAI/Gemini keys as manual fallbacks."
-              : "Connect Builder.io for one-click managed image generation and storage, or add OpenAI/Gemini keys plus object storage from the Setup checklist above."}
-          </p>
-          {configured && orgName ? (
-            <p className="mt-1 text-xs text-muted-foreground">
-              Connected as{" "}
-              <span className="font-medium text-foreground">{orgName}</span>.
-            </p>
-          ) : null}
-          {flow.error ? (
-            <p className="mt-2 text-xs text-destructive">{flow.error}</p>
-          ) : null}
-          {setupIssue ? <SetupIssueCallout message={setupIssue} /> : null}
+    <Card className="overflow-hidden border-border/80 bg-card/80 shadow-sm">
+      <CardHeader className="border-b border-border/70 p-5">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <CardTitle className="text-base">Assets setup</CardTitle>
+            <CardDescription className="mt-1 leading-6">
+              Two essentials: generation and durable storage.
+            </CardDescription>
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">{readyCount}/2</span>
+            ready
+          </div>
         </div>
-        {configured ? (
-          <span className="inline-flex shrink-0 items-center gap-1 rounded-md bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
-            <IconCheck className="h-3 w-3" />
-            Connected
-          </span>
+      </CardHeader>
+
+      <CardContent className="p-0">
+        <SettingsRow
+          icon={<IconKey className="size-4" />}
+          title="Builder"
+          description={
+            builderConnected
+              ? orgName
+                ? `Connected to ${orgName}.`
+                : "Connected for managed generation."
+              : builderEnabled
+                ? "Managed image generation and storage, no provider keys."
+                : "Disabled for this deployment."
+          }
+          status={
+            <StatusPill tone={builderConnected ? "ready" : "neutral"}>
+              {builderConnected ? "Connected" : "Optional"}
+            </StatusPill>
+          }
+          action={
+            builderEnabled ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => flow.start()}
+                disabled={flow.connecting}
+                className="shrink-0"
+              >
+                {flow.connecting ? (
+                  <>
+                    <IconLoader2 className="size-3.5 animate-spin" />
+                    Connecting
+                  </>
+                ) : builderConnected ? (
+                  <>
+                    Reconnect
+                    <IconExternalLink className="size-3.5" />
+                  </>
+                ) : (
+                  <>
+                    Connect
+                    <IconExternalLink className="size-3.5" />
+                  </>
+                )}
+              </Button>
+            ) : null
+          }
+        />
+
+        {setupIssue ? <SetupIssueCallout message={setupIssue} /> : null}
+
+        <SettingsRow
+          icon={<IconPhoto className="size-4" />}
+          title="Generation"
+          description={generationSummary(configData, builderConnected)}
+          status={
+            <StatusPill tone={generationReady ? "ready" : "attention"}>
+              {generationReady ? "Ready" : "Needs setup"}
+            </StatusPill>
+          }
+          action={
+            generationStep ? (
+              <DisclosureButton
+                open={manualGenerationOpen}
+                onClick={() => setManualGenerationOpen((open) => !open)}
+              >
+                Manual keys
+              </DisclosureButton>
+            ) : null
+          }
+        />
+        {manualGenerationOpen && generationStep ? (
+          <ManualMethodPanel
+            step={generationStep}
+            title="Manual generation keys"
+            description="Add Gemini for video generation, or OpenAI/Gemini as image fallbacks."
+            onSaved={refreshSetup}
+          />
         ) : null}
+
+        <SettingsRow
+          icon={<IconCloudUpload className="size-4" />}
+          title="Storage"
+          description={
+            storageReady
+              ? "Originals, thumbnails, videos, and exports have a durable home."
+              : "Add S3-compatible storage for production assets and exports."
+          }
+          status={
+            <StatusPill tone={storageReady ? "ready" : "attention"}>
+              {storageReady ? "Ready" : "Needs setup"}
+            </StatusPill>
+          }
+          action={
+            storageStep ? (
+              <DisclosureButton
+                open={manualStorageOpen}
+                onClick={() => setManualStorageOpen((open) => !open)}
+              >
+                Configure
+              </DisclosureButton>
+            ) : null
+          }
+        />
+        {manualStorageOpen && storageStep ? (
+          <ManualMethodPanel
+            step={storageStep}
+            title="Object storage"
+            description="Use S3, R2, Spaces, Tigris, MinIO, or another compatible provider."
+            onSaved={refreshSetup}
+          />
+        ) : null}
+
+        <SettingsRow
+          icon={<IconLibraryPhoto className="size-4" />}
+          title="Libraries"
+          description={`${libraryCount} accessible ${
+            libraryCount === 1 ? "library" : "libraries"
+          }.`}
+          status={<StatusPill tone="neutral">Available</StatusPill>}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function SettingsRow({
+  icon,
+  title,
+  description,
+  status,
+  action,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  status: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3 border-b border-border/70 px-5 py-4 last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex min-w-0 gap-3">
+        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground">
+          {icon}
+        </div>
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-sm font-medium">{title}</h3>
+            {status}
+          </div>
+          <p className="mt-1 max-w-xl text-sm leading-6 text-muted-foreground">
+            {description}
+          </p>
+        </div>
       </div>
-      <div className="mt-3 flex flex-wrap gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => flow.start()}
-          disabled={flow.connecting}
-          className="cursor-pointer"
-        >
-          {flow.connecting ? (
-            <>
-              <IconLoader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
-              Waiting for Builder…
-            </>
-          ) : configured ? (
-            <>
-              Reconnect Builder.io
-              <IconExternalLink className="ml-1 h-3.5 w-3.5" />
-            </>
-          ) : (
-            <>
-              Connect Builder.io
-              <IconExternalLink className="ml-1 h-3.5 w-3.5" />
-            </>
-          )}
-        </Button>
+      {action ? <div className="shrink-0 sm:ml-4">{action}</div> : null}
+    </div>
+  );
+}
+
+function StatusPill({
+  children,
+  tone,
+}: {
+  children: ReactNode;
+  tone: "ready" | "attention" | "neutral";
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex h-6 items-center gap-1.5 rounded-full border px-2 text-xs font-medium",
+        tone === "ready" &&
+          "border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+        tone === "attention" &&
+          "border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+        tone === "neutral" && "border-border bg-muted/40 text-muted-foreground",
+      )}
+    >
+      {tone === "ready" ? <IconCheck className="size-3" /> : null}
+      {children}
+    </span>
+  );
+}
+
+function DisclosureButton({
+  children,
+  open,
+  onClick,
+}: {
+  children: ReactNode;
+  open: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={onClick}
+      className="text-muted-foreground hover:text-foreground"
+      aria-expanded={open}
+    >
+      {children}
+      <IconChevronDown
+        className={cn("size-3.5 transition-transform", open && "rotate-180")}
+      />
+    </Button>
+  );
+}
+
+function ManualMethodPanel({
+  step,
+  title,
+  description,
+  onSaved,
+}: {
+  step: OnboardingStepStatus;
+  title: string;
+  description: string;
+  onSaved: () => Promise<void>;
+}) {
+  const methods = useMemo(() => step.methods.filter(isFormMethod), [step]);
+  const [selectedId, setSelectedId] = useState(methods[0]?.id ?? "");
+
+  useEffect(() => {
+    if (!methods.some((method) => method.id === selectedId)) {
+      setSelectedId(methods[0]?.id ?? "");
+    }
+  }, [methods, selectedId]);
+
+  const selected = methods.find((method) => method.id === selectedId);
+
+  return (
+    <div className="border-b border-border/70 bg-muted/20 px-5 py-4">
+      <div className="mx-auto max-w-2xl space-y-4">
+        <div>
+          <h3 className="text-sm font-medium">{title}</h3>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            {description}
+          </p>
+        </div>
+
+        {methods.length > 1 ? (
+          <div className="max-w-xs">
+            <Label className="text-xs text-muted-foreground">Provider</Label>
+            <Select value={selectedId} onValueChange={setSelectedId}>
+              <SelectTrigger className="mt-2">
+                <SelectValue placeholder="Choose a provider" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {methods.map((method) => (
+                    <SelectItem key={method.id} value={method.id}>
+                      {method.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        ) : null}
+
+        {selected ? (
+          <CredentialForm method={selected} onSaved={onSaved} />
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No manual setup options are available for this item.
+          </p>
+        )}
       </div>
     </div>
+  );
+}
+
+function CredentialForm({
+  method,
+  onSaved,
+}: {
+  method: FormOnboardingMethod;
+  onSaved: () => Promise<void>;
+}) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fields = method.payload.fields;
+  const submitLabel = fields.length > 1 ? "Save settings" : "Save key";
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const vars = fields
+        .map((field) => ({
+          key: field.key,
+          value: (values[field.key] ?? "").trim(),
+        }))
+        .filter((item) => item.value !== "");
+
+      if (!vars.length) {
+        setError("Enter a value first.");
+        return;
+      }
+
+      const response = await fetch(agentNativePath("/_agent-native/env-vars"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          vars,
+          scope: method.payload.writeScope ?? "workspace",
+        }),
+      });
+
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new Error(data.error ?? `Save failed: ${response.status}`);
+      }
+
+      setValues({});
+      await onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {method.description ? (
+        <p className="text-sm leading-6 text-muted-foreground">
+          {method.description}
+        </p>
+      ) : null}
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {fields.map((field) => {
+          const id = `${method.id}-${field.key}`;
+          return (
+            <div
+              key={field.key}
+              className={cn(fields.length === 1 && "sm:col-span-2")}
+            >
+              <Label htmlFor={id} className="text-xs text-muted-foreground">
+                {field.label}
+              </Label>
+              <Input
+                id={id}
+                type={field.secret ? "password" : "text"}
+                value={values[field.key] ?? ""}
+                placeholder={field.placeholder}
+                onChange={(event) =>
+                  setValues((current) => ({
+                    ...current,
+                    [field.key]: event.target.value,
+                  }))
+                }
+                className="mt-2"
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {error ? (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+
+      <Button type="submit" size="sm" disabled={saving}>
+        {saving ? (
+          <>
+            <IconLoader2 className="size-3.5 animate-spin" />
+            Saving
+          </>
+        ) : (
+          submitLabel
+        )}
+      </Button>
+    </form>
   );
 }
 
 function SetupIssueCallout({ message }: { message: string }) {
   return (
-    <div className="mt-3 flex gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-muted-foreground">
-      <IconAlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
-      <p className="leading-relaxed">{message}</p>
+    <div
+      role="alert"
+      className="border-b border-border/70 bg-amber-500/5 px-5 py-3"
+    >
+      <div className="flex gap-2 text-sm leading-6 text-amber-700 dark:text-amber-300">
+        <IconAlertCircle className="mt-1 size-4 shrink-0" />
+        <p>{message}</p>
+      </div>
     </div>
   );
 }
 
-function InfoTile({
-  icon,
-  title,
-  body,
-}: {
-  icon: ReactNode;
-  title: string;
-  body: string;
-}) {
-  return (
-    <div className="rounded-lg border border-border p-4">
-      <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-md bg-muted text-muted-foreground">
-        {icon}
-      </div>
-      <div className="text-sm font-medium">{title}</div>
-      <p className="mt-1 text-sm text-muted-foreground">{body}</p>
-    </div>
-  );
+function isFormMethod(
+  method: OnboardingMethod,
+): method is FormOnboardingMethod {
+  return method.kind === "form";
+}
+
+function generationSummary(
+  config: ImageGenerationConfig | undefined,
+  builderConnected: boolean,
+) {
+  if (builderConnected) return "Builder is handling managed image generation.";
+  const providers = [
+    config?.geminiConfigured ? "Gemini" : null,
+    config?.openaiConfigured ? "OpenAI" : null,
+  ].filter(Boolean);
+  if (providers.length) return `${providers.join(" and ")} configured.`;
+  if (config?.builderEnabled === false) {
+    return "Add Gemini or OpenAI before generating new assets.";
+  }
+  return "Add Builder, Gemini, or OpenAI before generating new assets.";
 }


### PR DESCRIPTION
## Pinned chat activity + Code-mode rename (+ db-admin/docs polish)

Follow-up updates landed on this branch after the #950 beta-readiness merge.

### Changes
- **Agent chat — pinned running activity:** the live activity steps + thinking indicator now stay pinned above the composer while a run is in progress (new `RunningActivityStatus`, `ActivitySteps` gains a `className`, fullscreen CSS in `AgentPanel`), so "what it did so far" and "still working / reconnecting" stay visible. Completed activity collapses into the transcript. *(changeset: `pinned-chat-activity`, patch)*
- **Code-mode rename:** renames the agent-capability "dev mode" → "Code mode" for clarity across `use-dev-mode`, `SettingsPanel`, and `agent-chat-plugin`. *(changeset: `code-mode-rename`, minor)*
- **db-admin polish:** `DbAdminPage` / `DevDatabaseLink` tweaks + an `agent-tools` adjustment.
- **Docs:** `frames.md` / `workspace.md` updates.
- **Cleanup:** removed a dead `assets` settings route (−216 lines).

### Verification
`pnpm prep` green locally (fmt + typecheck + full test suite + all 13 guards); changeset coverage confirmed for `@agent-native/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
