### PR TITLE
Harden MCP app picker and design flows

### DIFF
--- a/.changeset/mcp-app-bridge-assets-design.md
+++ b/.changeset/mcp-app-bridge-assets-design.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Improve MCP app embedding for external hosts by keeping local embed origins usable, avoiding embed params on dev runtime modules, compacting cached app shells, and acknowledging nested chat handoffs so picked assets can round-trip back to the host.

--- a/packages/core/src/client/mcp-app-host.spec.ts
+++ b/packages/core/src/client/mcp-app-host.spec.ts
@@ -15,6 +15,8 @@ import {
 } from "./mcp-app-host.js";
 import { _resetEmbedAuthForTests } from "./embed-auth.js";
 
+const REQUEST_TIMEOUT_MS = 5000;
+
 function setTestUrl(url: string): void {
   const happyDom = (window as unknown as { happyDOM?: { setURL?: unknown } })
     .happyDOM;
@@ -498,11 +500,13 @@ describe("MCP app host client helpers", () => {
       ],
     });
 
-    await expect(result).resolves.toBe(true);
+    await flushMicrotasks();
+
     expect(parent.postMessage).toHaveBeenCalledWith(
       {
         type: "agentNative.submitChat",
         data: {
+          requestId: expect.any(String),
           context: "Hidden selected asset context",
           message: "Use the selected Assets image",
           content: [
@@ -515,6 +519,29 @@ describe("MCP app host client helpers", () => {
       "*",
     );
     expect(getJsonRpcCalls(parent)).toEqual([]);
+
+    const message = vi.mocked(parent.postMessage).mock.calls[0]?.[0] as {
+      data?: { requestId?: string };
+    };
+    dispatchHostMessage({
+      type: AGENT_NATIVE_MCP_APP_HOST_MESSAGE_TYPES.RESPONSE,
+      data: { requestId: message.data?.requestId, ok: true },
+    });
+    await expect(result).resolves.toBe(true);
+  });
+
+  it("reports wrapper bridge chat failure when the host does not acknowledge", async () => {
+    vi.useFakeTimers();
+    const parent = parentWindow();
+    setNestedParent(parent);
+
+    const result = sendMcpAppHostMessage({
+      message: "Use the selected Assets image",
+    });
+    await flushMicrotasks();
+
+    vi.advanceTimersByTime(REQUEST_TIMEOUT_MS);
+    await expect(result).resolves.toBe(false);
   });
 
   it("uses direct MCP Apps chat messages in Claude transplanted frames", async () => {

--- a/packages/core/src/client/mcp-app-host.ts
+++ b/packages/core/src/client/mcp-app-host.ts
@@ -330,23 +330,35 @@ function postHostRequest(
 }
 
 function postWrapperHostChat(chat: McpAppHostChatMessage): Promise<boolean> {
-  try {
-    window.parent.postMessage(
-      {
-        type: "agentNative.submitChat",
-        data: {
-          message: chat.message,
-          context: chat.context?.trim() || "",
-          submit: true,
-          ...(chat.content?.length ? { content: chat.content } : {}),
+  ensureListener();
+  const id = requestId();
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      pending.delete(id);
+      resolve(false);
+    }, REQUEST_TIMEOUT_MS);
+    pending.set(id, { resolve, timeout });
+
+    try {
+      window.parent.postMessage(
+        {
+          type: "agentNative.submitChat",
+          data: {
+            requestId: id,
+            message: chat.message,
+            context: chat.context?.trim() || "",
+            submit: true,
+            ...(chat.content?.length ? { content: chat.content } : {}),
+          },
         },
-      },
-      "*",
-    );
-    return Promise.resolve(true);
-  } catch {
-    return Promise.resolve(false);
-  }
+        "*",
+      );
+    } catch {
+      pending.delete(id);
+      clearTimeout(timeout);
+      resolve(false);
+    }
+  });
 }
 
 interface OpenAiAppBridge {

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -704,7 +704,7 @@ function safeUiSegment(value: string | undefined, fallback: string): string {
 
 // ChatGPT and Claude cache MCP App resource HTML by `ui://` URI. Bump this
 // when the shared shell changes in a way that must invalidate host caches.
-const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v42";
+const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v43";
 
 function legacyDefaultMcpAppUri(config: MCPConfig, actionName: string): string {
   const app = safeUiSegment(config.appId ?? config.name, "agent-native");

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -165,6 +165,27 @@ describe("embedApp", () => {
     ]);
   });
 
+  it("leaves dev runtime module URLs untokenized in transplanted app documents", () => {
+    const resource = embedApp({ title: "Assets" });
+    const html =
+      typeof resource.html === "function"
+        ? resource.html({ actionName: "open-asset-picker", appId: "assets" })
+        : resource.html;
+
+    expect(html).toContain("function isEmbedRuntimeModulePath(pathname)");
+    expect(html).toContain(
+      "@(?:id|vite|fs|react-refresh)|app|node_modules|packages|src",
+    );
+    expect(html).toContain("function appendEmbedParamsToAppUrl(url, config)");
+    expect(html).toContain(
+      "if (isEmbedRuntimeModulePath(url.pathname)) return url;",
+    );
+    expect(html).toContain(
+      "return appendEmbedParamsToAppUrl(url, config).toString();",
+    );
+    expect(html).toContain("appendEmbedParamsToAppUrl(url, config);");
+  });
+
   it("retains nested iframe mode as an explicit diagnostic fallback", () => {
     const resource = embedApp({
       title: "Dashboard",

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -117,8 +117,11 @@ export function embedApp(
     const openAiBridgePollMs = 50;
     const nativeBridgeInitializeTimeoutMs = 5000;
     const nativeBridgeRequestTimeoutMs = 30000;
+    const wrapperRequestTimeoutMs = 5000;
     let app = null;
     let openAiBridge = null;
+    let wrapperRequestId = 0;
+    const wrapperRequests = new Map();
     let toolInput = {};
     let toolResultData = {};
     let openUrl = "";
@@ -317,6 +320,59 @@ export function embedApp(
     function sendToAppFrame(message) {
       if (!appFrame || !appFrame.contentWindow) return;
       try { appFrame.contentWindow.postMessage(message, "*"); } catch {}
+    }
+
+    function nextWrapperRequestId() {
+      wrapperRequestId += 1;
+      return "mcp-wrapper-" + Date.now() + "-" + wrapperRequestId;
+    }
+
+    function respondToWrapperRequest(requestId, result) {
+      if (!requestId) return;
+      sendToAppFrame({
+        type: "agentNative.mcpHost.response",
+        data: {
+          requestId,
+          ok: !!(result && result.ok),
+          result: result || {}
+        }
+      });
+    }
+
+    function wrapperRpcRequest(method, params, timeoutMs) {
+      return new Promise((resolve) => {
+        const id = nextWrapperRequestId();
+        const timer = window.setTimeout(() => {
+          wrapperRequests.delete(id);
+          resolve({ ok: false, error: "MCP host bridge request timed out." });
+        }, timeoutMs || wrapperRequestTimeoutMs);
+        wrapperRequests.set(id, { resolve, timer });
+        try {
+          window.parent.postMessage(
+            { jsonrpc: "2.0", id, method, params: params || {} },
+            "*"
+          );
+        } catch (err) {
+          wrapperRequests.delete(id);
+          clearTimeout(timer);
+          resolve({ ok: false, error: err && err.message ? err.message : String(err) });
+        }
+      });
+    }
+
+    function settleWrapperRpcResponse(message) {
+      const id = typeof (message && message.id) === "string" ? message.id : "";
+      if (!id) return false;
+      const pending = wrapperRequests.get(id);
+      if (!pending) return false;
+      wrapperRequests.delete(id);
+      clearTimeout(pending.timer);
+      if (message.error) {
+        pending.resolve({ ok: false, error: message.error });
+      } else {
+        pending.resolve({ ok: true, result: message.result });
+      }
+      return true;
     }
 
     function sendHostContext() {
@@ -563,15 +619,27 @@ export function embedApp(
       next.remove();
     }
 
+    function isEmbedRuntimeModulePath(pathname) {
+      if (typeof pathname !== "string" || !pathname) return false;
+      return /(?:^|\\/)(?:@(?:id|vite|fs|react-refresh)|app|node_modules|packages|src)(?:\\/|$)/.test(pathname) ||
+        /(?:^|\\/)__x00__virtual:/.test(pathname) ||
+        pathname.includes("virtual:react-router");
+    }
+
+    function appendEmbedParamsToAppUrl(url, config) {
+      if (isEmbedRuntimeModulePath(url.pathname)) return url;
+      if (config.token) url.searchParams.set(config.embedTokenParam, config.token);
+      if (config.chatBridgeActive) url.searchParams.set(config.chatBridgeParam, "1");
+      return url;
+    }
+
     function rootRelativeSpecifierToAppUrl(specifier, config) {
       if (typeof specifier !== "string" || !specifier.startsWith("/") || specifier.startsWith("//")) {
         return specifier;
       }
       try {
         const url = new URL(specifier, config.origin);
-        if (config.token) url.searchParams.set(config.embedTokenParam, config.token);
-        if (config.chatBridgeActive) url.searchParams.set(config.chatBridgeParam, "1");
-        return url.toString();
+        return appendEmbedParamsToAppUrl(url, config).toString();
       } catch (_err) {
         return specifier;
       }
@@ -590,8 +658,7 @@ export function embedApp(
       try {
         const url = new URL(specifier, baseUrl || config.baseHref);
         if (url.origin === config.origin) {
-          if (config.token) url.searchParams.set(config.embedTokenParam, config.token);
-          if (config.chatBridgeActive) url.searchParams.set(config.chatBridgeParam, "1");
+          appendEmbedParamsToAppUrl(url, config);
         }
         return url.toString();
       } catch (_err) {
@@ -677,8 +744,7 @@ export function embedApp(
       try {
         const url = new URL(raw, config.baseHref);
         if (url.origin === config.origin) {
-          if (config.token) url.searchParams.set(config.embedTokenParam, config.token);
-          if (config.chatBridgeActive) url.searchParams.set(config.chatBridgeParam, "1");
+          appendEmbedParamsToAppUrl(url, config);
         }
         return url.toString();
       } catch (_err) {
@@ -1104,6 +1170,7 @@ export function embedApp(
     }
 
     async function sendHostChat(chat) {
+      const requestId = typeof (chat && chat.requestId) === "string" ? chat.requestId : "";
       if (!chat || chat.submit === false) return;
       const message = typeof chat.message === "string" ? chat.message : "";
       if (!message.trim()) return;
@@ -1137,20 +1204,44 @@ export function embedApp(
             prompt: message,
             scrollToBottom: true
           });
+          respondToWrapperRequest(requestId, { ok: true });
           return;
         }
-        if (!app || typeof app.sendMessage !== "function") return;
-        const result = await app.sendMessage({
-          role: "user",
-          content
-        });
+        let result = null;
+        if (app && typeof app.sendMessage === "function") {
+          result = await app.sendMessage({
+            role: "user",
+            content
+          });
+        } else {
+          result = await wrapperRpcRequest("ui/message", {
+            role: "user",
+            content
+          });
+        }
         if (result && result.isError) {
           console.warn("[agent-native] MCP host rejected chat message", result);
+          respondToWrapperRequest(requestId, { ok: false, result });
+          return;
         }
+        if (result && result.ok === false) {
+          console.warn("[agent-native] MCP host chat bridge failed", result);
+          respondToWrapperRequest(requestId, { ok: false, result });
+          return;
+        }
+        respondToWrapperRequest(requestId, { ok: true, result });
       } catch (err) {
         console.warn("[agent-native] MCP host chat bridge failed", err);
+        respondToWrapperRequest(requestId, { ok: false, error: err && err.message ? err.message : String(err) });
       }
     }
+
+    window.addEventListener("message", (event) => {
+      if (event.source !== window.parent) return;
+      const message = event.data;
+      if (!message || message.jsonrpc !== "2.0") return;
+      settleWrapperRpcResponse(message);
+    });
 
     window.addEventListener("message", (event) => {
       if (!appFrame || event.source !== appFrame.contentWindow) return;

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -557,17 +557,17 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(echo.annotations?.["agent-native/producesOpenLink"]).toBe(true);
     expect(echo.description).toContain("Open in");
     expect(echo._meta?.["ui/resourceUri"]).toBe(
-      "ui://mail/echo-thing/shell-v42",
+      "ui://mail/echo-thing/shell-v43",
     );
     expect(echo._meta?.["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v42",
+      "ui://mail/echo-thing/shell-v43",
     );
     expect(echo._meta?.["openai/widgetAccessible"]).toBe(true);
     expect(echo._meta?.["openai/widgetCSP"]).toEqual({
       connect_domains: ["https://mail.agent-native.com"],
     });
     expect(echo._meta?.ui).toEqual({
-      resourceUri: "ui://mail/echo-thing/shell-v42",
+      resourceUri: "ui://mail/echo-thing/shell-v43",
       visibility: ["model", "app"],
     });
     expect(echo._meta?.ui?.csp).toBeUndefined();
@@ -649,7 +649,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
 
     expect(resourcesOut.error).toBeUndefined();
     expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
-      "ui://mail/open_app/shell-v42",
+      "ui://mail/open_app/shell-v43",
     ]);
     expect(JSON.stringify(resourcesOut)).not.toContain(
       "INTERNAL_TOOL_BLOAT_SENTINEL",
@@ -675,7 +675,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(templatesOut.error).toBeUndefined();
     expect(
       templatesOut.result.resourceTemplates.map((r: any) => r.uriTemplate),
-    ).toEqual(["ui://mail/open_app/shell-v42"]);
+    ).toEqual(["ui://mail/open_app/shell-v43"]);
     expect(JSON.stringify(templatesOut)).not.toContain(
       "INTERNAL_TOOL_BLOAT_SENTINEL",
     );
@@ -689,7 +689,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 123,
         method: "resources/read",
-        params: { uri: "ui://mail/review-draft/shell-v42" },
+        params: { uri: "ui://mail/review-draft/shell-v43" },
       },
       {
         headers: await mcpAppsAuthHeaders(),
@@ -704,7 +704,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 126,
         method: "resources/read",
-        params: { uri: "ui://mail/bloated-widget/shell-v42" },
+        params: { uri: "ui://mail/bloated-widget/shell-v43" },
       },
       {
         headers: await mcpAppsAuthHeaders(),
@@ -775,8 +775,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
 
     expect(resourcesOut.error).toBeUndefined();
     expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
-      "ui://mail/open_app/shell-v42",
-      "ui://mail/status-panel/shell-v42",
+      "ui://mail/open_app/shell-v43",
+      "ui://mail/status-panel/shell-v43",
     ]);
   });
 
@@ -868,7 +868,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
 
     expect(resourcesOut.error).toBeUndefined();
     expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
-      "ui://mail/open_app/shell-v42",
+      "ui://mail/open_app/shell-v43",
     ]);
     expect(JSON.stringify(resourcesOut)).not.toContain(
       "MCP_APP_RESOURCE_BLOAT_SENTINEL",
@@ -933,9 +933,9 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
 
     expect(resourcesOut.error).toBeUndefined();
     expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
-      "ui://mail/echo-thing/shell-v42",
-      "ui://mail/review-draft/shell-v42",
-      "ui://mail/private-widget/shell-v42",
+      "ui://mail/echo-thing/shell-v43",
+      "ui://mail/review-draft/shell-v43",
+      "ui://mail/private-widget/shell-v43",
     ]);
 
     const templatesOut = await callWeb(
@@ -955,9 +955,9 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(
       templatesOut.result.resourceTemplates.map((r: any) => r.uriTemplate),
     ).toEqual([
-      "ui://mail/echo-thing/shell-v42",
-      "ui://mail/review-draft/shell-v42",
-      "ui://mail/private-widget/shell-v42",
+      "ui://mail/echo-thing/shell-v43",
+      "ui://mail/review-draft/shell-v43",
+      "ui://mail/private-widget/shell-v43",
     ]);
 
     const readOut = await callWeb(
@@ -965,7 +965,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 132,
         method: "resources/read",
-        params: { uri: "ui://mail/private-widget/shell-v42" },
+        params: { uri: "ui://mail/private-widget/shell-v43" },
       },
       {
         headers: await mcpAppsAuthHeaders(),
@@ -976,7 +976,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(readOut.error).toBeUndefined();
     expect(readOut.result.contents).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/private-widget/shell-v42",
+        uri: "ui://mail/private-widget/shell-v43",
         text: expect.stringContaining("Private"),
       }),
     ]);
@@ -1062,8 +1062,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
 
     expect(out.error).toBeUndefined();
     expect(out.result.resources.map((r: any) => r.uri)).toEqual([
-      "ui://mail/echo-thing/shell-v42",
-      "ui://mail/review-draft/shell-v42",
+      "ui://mail/echo-thing/shell-v43",
+      "ui://mail/review-draft/shell-v43",
     ]);
   });
 
@@ -1226,7 +1226,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
 
     expect(resourcesOut.error).toBeUndefined();
     expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
-      "ui://mail/open_app/shell-v42",
+      "ui://mail/open_app/shell-v43",
     ]);
     expect(JSON.stringify(resourcesOut)).not.toContain(
       "MCP_APP_RESOURCE_BLOAT_SENTINEL",
@@ -1272,7 +1272,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v42",
+        uri: "ui://mail/echo-thing/shell-v43",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -1310,7 +1310,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resourceTemplates).toEqual([
       expect.objectContaining({
-        uriTemplate: "ui://mail/echo-thing/shell-v42",
+        uriTemplate: "ui://mail/echo-thing/shell-v43",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -1325,14 +1325,14 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 6,
         method: "resources/read",
-        params: { uri: "ui://mail/echo-thing/shell-v42" },
+        params: { uri: "ui://mail/echo-thing/shell-v43" },
       },
       { headers: await mcpAppsFullCatalogHeaders() },
     );
     expect(out.error).toBeUndefined();
     expect(out.result.contents).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v42",
+        uri: "ui://mail/echo-thing/shell-v43",
         mimeType: "text/html;profile=mcp-app",
         text: expect.stringContaining('data-action="echo-thing"'),
         _meta: expect.objectContaining({
@@ -1445,7 +1445,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 37,
         method: "resources/read",
-        params: { uri: "ui://mail/dynamic-review/shell-v42" },
+        params: { uri: "ui://mail/dynamic-review/shell-v43" },
       },
       { headers: await mcpAppsFullCatalogHeaders(), config: dynamicCspConfig },
     );
@@ -1537,7 +1537,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       );
       expect(brokenTool._meta?.["openai/outputTemplate"]).toBeUndefined();
       expect(healthyTool._meta["openai/outputTemplate"]).toBe(
-        "ui://mail/healthy-review/shell-v42",
+        "ui://mail/healthy-review/shell-v43",
       );
 
       const brokenCall = await callWeb(
@@ -1573,7 +1573,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       expect(resources.error).toBeUndefined();
       expect(
         resources.result.resources.map((resource: any) => resource.uri),
-      ).toEqual(["ui://mail/healthy-review/shell-v42"]);
+      ).toEqual(["ui://mail/healthy-review/shell-v43"]);
 
       const templates = await callWeb(
         {
@@ -1592,7 +1592,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         templates.result.resourceTemplates.map(
           (template: any) => template.uriTemplate,
         ),
-      ).toEqual(["ui://mail/healthy-review/shell-v42"]);
+      ).toEqual(["ui://mail/healthy-review/shell-v43"]);
 
       const warnCallsBeforeRead = warn.mock.calls.length;
       const read = await callWeb(
@@ -1600,7 +1600,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
           jsonrpc: "2.0",
           id: 43,
           method: "resources/read",
-          params: { uri: "ui://mail/healthy-review/shell-v42" },
+          params: { uri: "ui://mail/healthy-review/shell-v43" },
         },
         {
           headers: await mcpAppsFullCatalogHeaders(),
@@ -1610,7 +1610,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       expect(read.error).toBeUndefined();
       expect(read.result.contents[0]).toEqual(
         expect.objectContaining({
-          uri: "ui://mail/healthy-review/shell-v42",
+          uri: "ui://mail/healthy-review/shell-v43",
           text: expect.stringContaining("Healthy"),
         }),
       );
@@ -1702,7 +1702,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v42",
+        uri: "ui://mail/custom-review/shell-v43",
         name: "custom-review",
       }),
     ]);
@@ -1765,7 +1765,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v42",
+        uri: "ui://mail/custom-review/shell-v43",
         name: "custom-review",
       }),
     ]);
@@ -1828,7 +1828,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v42?mode=compact#preview",
+        uri: "ui://mail/custom-review/shell-v43?mode=compact#preview",
         name: "custom-review",
       }),
     ]);
@@ -1884,7 +1884,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         "https://mail.agent-native.com/_agent-native/open?view=thing&id=thing-42&agentSidebar=closed",
     });
     expect(out.result._meta["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v42",
+      "ui://mail/echo-thing/shell-v43",
     );
     expect(out.result._meta["openai/widgetCSP"]).toEqual({
       connect_domains: ["https://mail.agent-native.com"],

--- a/packages/core/src/shared/mcp-embed-headers.spec.ts
+++ b/packages/core/src/shared/mcp-embed-headers.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isChatGptMcpSandboxOrigin,
+  isLocalMcpEmbedOrigin,
   isMcpEmbedCorsOrigin,
 } from "./mcp-embed-headers.js";
 
@@ -13,12 +14,25 @@ describe("MCP embed headers", () => {
     expect(isMcpEmbedCorsOrigin(origin)).toBe(true);
   });
 
+  it("allows localhost origins for local MCP app QA", () => {
+    for (const origin of [
+      "http://localhost:9310",
+      "http://127.0.0.1:9310",
+      "http://[::1]:9310",
+    ]) {
+      expect(isLocalMcpEmbedOrigin(origin)).toBe(true);
+      expect(isMcpEmbedCorsOrigin(origin)).toBe(true);
+    }
+  });
+
   it("rejects non-sandbox oaiusercontent origins", () => {
     for (const origin of [
       "https://files.oaiusercontent.com",
       "https://example.oaiusercontent.com",
       "https://web-sandbox.oaiusercontent.com",
       "https://web-sandbox.oaiusercontent.com.evil.example",
+      "https://localhost:9310",
+      "http://example.com",
     ]) {
       expect(isChatGptMcpSandboxOrigin(origin)).toBe(false);
       expect(isMcpEmbedCorsOrigin(origin)).toBe(false);

--- a/packages/core/src/shared/mcp-embed-headers.ts
+++ b/packages/core/src/shared/mcp-embed-headers.ts
@@ -6,6 +6,21 @@ const CLAUDE_MCP_CONTENT_HOST_RE = /^[a-f0-9]{32}\.claudemcpcontent\.com$/i;
 const CHATGPT_MCP_SANDBOX_HOST_RE =
   /^[^.]+\.web-sandbox\.oaiusercontent\.com$/i;
 
+export function isLocalMcpEmbedOrigin(
+  origin: string | null | undefined,
+): boolean {
+  if (!origin) return false;
+  try {
+    const url = new URL(origin);
+    return (
+      url.protocol === "http:" &&
+      ["localhost", "127.0.0.1", "::1", "[::1]"].includes(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function isClaudeMcpContentOrigin(
   origin: string | null | undefined,
 ): boolean {
@@ -40,6 +55,7 @@ export function isMcpEmbedCorsOrigin(
 ): boolean {
   return (
     origin === "null" ||
+    isLocalMcpEmbedOrigin(origin) ||
     isClaudeMcpContentOrigin(origin) ||
     isChatGptMcpSandboxOrigin(origin)
   );

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -114,6 +114,69 @@ describe("dev server mounted path helpers", () => {
     );
   });
 
+  it("serves absolute React Router browser manifests to external MCP embeds", async () => {
+    const plugin = findPlugin("agent-native-base-redirect-guard");
+    let middleware: Function | null = null;
+    const server = {
+      config: { base: "/", publicDir: "/tmp/no-public" },
+      middlewares: {
+        use: vi.fn((fn: Function) => {
+          middleware = fn;
+        }),
+      },
+      pluginContainer: {
+        load: vi.fn(async () => ({
+          code:
+            "window.__reactRouterManifest={" +
+            "'url':'/@id/__x00__virtual:react-router/browser-manifest'," +
+            "'entry':{'module':'/app/entry.client.tsx'}," +
+            "'hmr':{'runtime':'/@id/__x00__virtual:react-router/inject-hmr-runtime'}," +
+            "'routes':{'root':{'module':'/app/root.tsx'}}" +
+            "};",
+        })),
+      },
+      transformRequest: vi.fn(),
+    };
+
+    plugin.configureServer(server);
+    const req = {
+      method: "GET",
+      url: "/@id/__x00__virtual:react-router/browser-manifest",
+      headers: {
+        origin: "http://127.0.0.1:9310",
+        host: "assets-local.trycloudflare.com",
+        "x-forwarded-proto": "https",
+      },
+    };
+    const res = {
+      headersSent: false,
+      statusCode: 0,
+      setHeader: vi.fn(),
+      end: vi.fn(() => {
+        res.headersSent = true;
+      }),
+    };
+    const next = vi.fn();
+
+    middleware!(req, res, next);
+    await vi.waitFor(() => expect(res.end).toHaveBeenCalledOnce());
+
+    expect(next).not.toHaveBeenCalled();
+    expect(server.pluginContainer.load).toHaveBeenCalledWith(
+      "\0virtual:react-router/browser-manifest",
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "content-type",
+      "text/javascript",
+    );
+    expect(String(res.end.mock.calls[0][0])).toContain(
+      '"https://assets-local.trycloudflare.com/app/entry.client.tsx"',
+    );
+    expect(String(res.end.mock.calls[0][0])).toContain(
+      '"https://assets-local.trycloudflare.com/@id/__x00__virtual:react-router/browser-manifest"',
+    );
+  });
+
   it("does not serve base-prefixed Vite modules without embed auth", () => {
     const plugin = findPlugin("agent-native-base-redirect-guard");
     let middleware: Function | null = null;

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -614,6 +614,9 @@ function baseRedirectGuard(): Plugin {
             // original path so the normal dev-server error handling applies.
           }
         }
+        if (serveExternalEmbedBrowserManifest(server, req, res)) {
+          return;
+        }
         if (serveMountedEmbedRuntimeModule(server, req, res, base)) {
           return;
         }
@@ -758,6 +761,92 @@ function serveMountedEmbedRuntimeModule(
         return;
       }
       res.end(code);
+    })
+    .catch((err: unknown) => {
+      if (res.headersSent) return;
+      res.statusCode = 500;
+      res.setHeader("content-type", "text/plain");
+      res.end(err instanceof Error ? err.message : String(err));
+    });
+  return true;
+}
+
+function publicOriginFromDevRequest(req: IncomingMessage): string | null {
+  const forwardedHost = String(req.headers["x-forwarded-host"] ?? "")
+    .split(",")[0]
+    ?.trim();
+  const host =
+    forwardedHost ||
+    String(req.headers.host ?? "")
+      .split(",")[0]
+      ?.trim();
+  if (!host) return null;
+  const forwardedProto = String(req.headers["x-forwarded-proto"] ?? "")
+    .split(",")[0]
+    ?.trim();
+  const proto =
+    forwardedProto ||
+    (/^(localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/i.test(host)
+      ? "http"
+      : "https");
+  return `${proto}://${host}`;
+}
+
+function isReactRouterBrowserManifestUrl(reqUrl: string | undefined): boolean {
+  if (!reqUrl) return false;
+  try {
+    const url = new URL(reqUrl, "http://agent-native.local");
+    return (
+      virtualModuleIdFromRuntimeUrl(url.pathname) ===
+      "\0virtual:react-router/browser-manifest"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function rewriteRootRelativeManifestUrls(
+  code: string,
+  publicOrigin: string,
+): string {
+  return code.replace(/'\/(?!\/)([^']*)'/g, (match, rest: string) => {
+    try {
+      return JSON.stringify(new URL(`/${rest}`, publicOrigin).toString());
+    } catch {
+      return match;
+    }
+  });
+}
+
+function serveExternalEmbedBrowserManifest(
+  server: any,
+  req: IncomingMessage,
+  res: ServerResponse,
+): boolean {
+  if (req.method !== "GET" && req.method !== "HEAD") return false;
+  if (!isMcpEmbedCorsOrigin(String(req.headers.origin ?? ""))) return false;
+  if (!isReactRouterBrowserManifestUrl(req.url)) return false;
+  const publicOrigin = publicOriginFromDevRequest(req);
+  if (!publicOrigin) return false;
+  const runtimeUrl = mountedEmbedRuntimeModuleUrl(req.url, "/") ?? req.url;
+  if (!runtimeUrl) return false;
+
+  void loadMountedEmbedRuntimeModule(server, runtimeUrl)
+    .then((code: string | null) => {
+      if (!code) {
+        if (!res.headersSent) {
+          res.statusCode = 404;
+          res.end();
+        }
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader("content-type", "text/javascript");
+      if (req.method === "HEAD") {
+        res.end();
+        return;
+      }
+      res.end(rewriteRootRelativeManifestUrls(code, publicOrigin));
     })
     .catch((err: unknown) => {
       if (res.headersSent) return;

--- a/templates/assets/app/components/layout/Layout.tsx
+++ b/templates/assets/app/components/layout/Layout.tsx
@@ -4,7 +4,7 @@ import { IconMenu2 } from "@tabler/icons-react";
 import { Sidebar } from "./Sidebar";
 import { Header } from "./Header";
 import { HeaderActionsProvider } from "./HeaderActions";
-import { AgentSidebar } from "@agent-native/core/client";
+import { AgentSidebar, isEmbedAuthActive } from "@agent-native/core/client";
 import { InvitationBanner } from "@agent-native/core/client/org";
 import { useNavigationState } from "@/hooks/use-navigation-state";
 import { cn } from "@/lib/utils";
@@ -37,7 +37,8 @@ export function Layout({ children }: LayoutProps) {
     location.pathname === "/extensions" ||
     location.pathname.startsWith("/extensions/");
   const chromeless =
-    (isPicker && isEmbeddedWindow()) || location.pathname.endsWith("/embed");
+    (isPicker && (isEmbeddedWindow() || isEmbedAuthActive())) ||
+    location.pathname.endsWith("/embed");
 
   if (chromeless) {
     return (

--- a/templates/assets/app/routes/picker.tsx
+++ b/templates/assets/app/routes/picker.tsx
@@ -8,6 +8,7 @@ import {
   agentNativePath,
   appPath,
   getEmbedAuthToken,
+  isEmbedAuthActive,
   sendMcpAppHostMessage,
   updateMcpAppModelContext,
   useActionMutation,
@@ -487,7 +488,7 @@ export default function AssetPicker() {
     } satisfies HostConfig;
   }, [searchParamsKey]);
   const bridgeRef = useRef<EmbeddedAppBridge | null>(null);
-  const embedded = useMemo(() => isEmbeddedWindow(), []);
+  const embedded = useMemo(() => isEmbeddedWindow() || isEmbedAuthActive(), []);
   const [hostConfig, setHostConfig] = useState<HostConfig>(() => urlHostConfig);
   const [mediaType, setMediaType] = useState<PickerMediaType>(
     () => hostConfig.mediaType ?? "image",

--- a/templates/design/actions/present-design-variants.spec.ts
+++ b/templates/design/actions/present-design-variants.spec.ts
@@ -70,6 +70,28 @@ describe("present-design-variants", () => {
     });
     expect(action.mcpApp?.compactCatalog).toBe(true);
     expect(action.mcpApp?.resource.title).toBe("Design directions");
+    expect(action.mcpApp?.resource.html()).toContain(
+      "--agent-native-shell-height: 720px",
+    );
+  });
+
+  it("requires exactly three variants for the MCP picker flow", () => {
+    const base = {
+      designId: "design_123",
+      variants: [
+        { id: "one", label: "One", content: "<html>One</html>" },
+        { id: "two", label: "Two", content: "<html>Two</html>" },
+        { id: "three", label: "Three", content: "<html>Three</html>" },
+      ],
+    };
+
+    expect(action.schema.safeParse(base).success).toBe(true);
+    expect(
+      action.schema.safeParse({
+        ...base,
+        variants: base.variants.slice(0, 2),
+      }).success,
+    ).toBe(false);
   });
 
   it("returns an editor deep link for external hosts", async () => {

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -23,12 +23,14 @@ const variantSchema = z.object({
   content: z
     .string()
     .min(1)
-    .describe("Complete self-contained HTML document for this variant"),
+    .describe(
+      "Complete self-contained HTML document for this variant. Inline the CSS needed for the preview; avoid relying on external CSS/script CDNs because MCP app sandboxes may block them.",
+    ),
 });
 
 export default defineAction({
   description:
-    "Present 2-5 generated design directions in the Design editor so the " +
+    "Present exactly 3 generated design directions in the Design editor so the " +
     "user can visually compare options and pick one. Use this for design " +
     "exploration before calling generate-design. The user's choice is " +
     "persisted automatically by the app.",
@@ -40,9 +42,10 @@ export default defineAction({
       .describe("Caption shown above the variant grid"),
     variants: z
       .array(variantSchema)
-      .min(2)
-      .max(5)
-      .describe("Generated design options to preview side by side"),
+      .length(3)
+      .describe(
+        "Exactly 3 concise, visually distinct generated design options to preview side by side. Inline CSS so all options render in the MCP app preview.",
+      ),
   }),
   mcpApp: {
     compactCatalog: true,
@@ -52,7 +55,7 @@ export default defineAction({
         "Open the Design editor with a visual picker for generated variants.",
       iframeTitle: "Agent-Native Design",
       openLabel: "Open design directions",
-      height: 680,
+      height: 720,
     }),
   },
   run: async ({ designId, prompt, variants }) => {

--- a/templates/design/app/components/design/VariantGrid.tsx
+++ b/templates/design/app/components/design/VariantGrid.tsx
@@ -25,6 +25,8 @@ export function VariantGrid({
   compact = false,
 }: VariantGridProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const previewScale = compact ? 0.36 : 0.5;
+  const previewSize = `${100 / previewScale}%`;
 
   // The same grid renders both in the full editor and in compact MCP App
   // embeds, so it needs to wrap instead of squeezing previews into slivers.
@@ -34,8 +36,8 @@ export function VariantGrid({
       : variants.length === 2
         ? "grid-cols-1 min-[520px]:grid-cols-2"
         : variants.length === 3
-          ? "grid-cols-1 min-[520px]:grid-cols-2"
-          : "grid-cols-1 min-[520px]:grid-cols-2"
+          ? "grid-cols-1 min-[520px]:grid-cols-2 min-[820px]:grid-cols-3"
+          : "grid-cols-1 min-[520px]:grid-cols-2 min-[880px]:grid-cols-3"
     : variants.length <= 1
       ? "grid-cols-1"
       : variants.length === 2
@@ -55,7 +57,7 @@ export function VariantGrid({
         className={cn(
           "grid min-h-0 flex-1 gap-3 sm:gap-4",
           compact
-            ? "auto-rows-[minmax(210px,1fr)]"
+            ? "auto-rows-[minmax(190px,1fr)]"
             : "auto-rows-[minmax(260px,1fr)]",
           gridClass,
         )}
@@ -74,8 +76,16 @@ export function VariantGrid({
               {/* Preview frame */}
               <div
                 onClick={() => onSelect(variant.id)}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter" && event.key !== " ") return;
+                  event.preventDefault();
+                  onSelect(variant.id);
+                }}
+                role="button"
+                tabIndex={0}
+                aria-label={`Use ${variant.label}`}
                 className={cn(
-                  "relative flex-1 cursor-pointer overflow-hidden rounded-lg border-2 bg-muted/10",
+                  "relative flex-1 cursor-pointer overflow-hidden rounded-lg border-2 bg-muted/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                   isSelected
                     ? "border-primary"
                     : "border-transparent hover:border-muted-foreground/30",
@@ -86,9 +96,9 @@ export function VariantGrid({
                   srcDoc={wrapContent(variant.content)}
                   className="pointer-events-none h-full w-full origin-top-left"
                   style={{
-                    width: "200%",
-                    height: "200%",
-                    transform: "scale(0.5)",
+                    width: previewSize,
+                    height: previewSize,
+                    transform: `scale(${previewScale})`,
                   }}
                   sandbox="allow-scripts"
                   title={variant.label}
@@ -141,7 +151,7 @@ function wrapContent(content: string): string {
   const previewStyle = `<style data-agent-native-preview>
     *, *::before, *::after { box-sizing: border-box; }
     html, body { width: 100%; height: 100%; overflow: hidden; }
-    body { background: #0a0a0a; }
+    body { margin: 0; background: #fff; }
   </style>`;
   const trimmed = content.trim();
 

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -38,6 +38,7 @@ import {
   NotificationsBell,
   ShareButton,
   isEmbedAuthActive,
+  sendToAgentChat,
   type CollabUser,
   type PromptComposerSubmitOptions,
 } from "@agent-native/core/client";
@@ -339,6 +340,27 @@ export default function DesignEditor() {
     useVariant: handleUseVariant,
     dismiss: handleVariantsDismiss,
   } = useVariantFlow(id);
+  const handleVariantChoice = useCallback(
+    async (variantId: string) => {
+      const chosen = pendingVariants?.variants.find(
+        (variant) => variant.id === variantId,
+      );
+      await handleUseVariant(variantId);
+
+      if (!embedded || !chosen || !id) return;
+      sendToAgentChat({
+        message: `I picked "${chosen.label}".`,
+        context: [
+          `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${id} inside the embedded Design MCP app.`,
+          "Continue from the chosen direction when the user asks for refinements.",
+          'If the user asks for another iteration, use get-design-snapshot and generate-design against the current index.html; do not present new variants unless they ask for "more options" or "alternatives".',
+        ].join("\n"),
+        submit: true,
+        openSidebar: false,
+      });
+    },
+    [embedded, handleUseVariant, id, pendingVariants],
+  );
 
   const { session } = useSession();
 
@@ -1880,8 +1902,8 @@ ${serializedHtml}
             <div className="flex-1 overflow-hidden">
               <VariantGrid
                 variants={pendingVariants.variants}
-                onSelect={handleUseVariant}
-                onUse={handleUseVariant}
+                onSelect={handleVariantChoice}
+                onUse={handleVariantChoice}
                 compact={embedded}
               />
             </div>
@@ -1889,93 +1911,94 @@ ${serializedHtml}
         )}
 
         {/* Canvas */}
-        {activeFile ? (
-          viewMode === "overview" ? (
-            <MultiScreenCanvas
-              screens={files.map((f) => ({
-                id: f.id,
-                filename: f.filename,
-                content: f.content,
-              }))}
-              zoom={zoom}
-              activeId={activeFileId}
-              onPick={(id) => {
-                setActiveFileId(id);
-                setViewMode("single");
-              }}
-            />
+        {!pendingVariants &&
+          (activeFile ? (
+            viewMode === "overview" ? (
+              <MultiScreenCanvas
+                screens={files.map((f) => ({
+                  id: f.id,
+                  filename: f.filename,
+                  content: f.content,
+                }))}
+                zoom={zoom}
+                activeId={activeFileId}
+                onPick={(id) => {
+                  setActiveFileId(id);
+                  setViewMode("single");
+                }}
+              />
+            ) : (
+              <DesignCanvas
+                content={activeContent}
+                zoom={zoom}
+                onZoomChange={setZoom}
+                deviceFrame={deviceFrame}
+                editMode={mode === "edit"}
+                onElementSelect={handleElementSelect}
+                onElementHover={handleElementHover}
+                tweakValues={cssVarValues}
+                drawMode={drawMode}
+                onExitDrawMode={() => {
+                  setDrawMode(false);
+                  setMode("comment");
+                }}
+                pinMode={pinMode}
+                onExitPinMode={() => setPinMode(false)}
+                designId={id}
+                designTitle={design?.title}
+              />
+            )
           ) : (
-            <DesignCanvas
-              content={activeContent}
-              zoom={zoom}
-              onZoomChange={setZoom}
-              deviceFrame={deviceFrame}
-              editMode={mode === "edit"}
-              onElementSelect={handleElementSelect}
-              onElementHover={handleElementHover}
-              tweakValues={cssVarValues}
-              drawMode={drawMode}
-              onExitDrawMode={() => {
-                setDrawMode(false);
-                setMode("comment");
-              }}
-              pinMode={pinMode}
-              onExitPinMode={() => setPinMode(false)}
-              designId={id}
-              designTitle={design?.title}
-            />
-          )
-        ) : (
-          <div className="flex-1 flex items-center justify-center">
-            <div className="text-center">
-              {generating || pendingGenerationActive ? (
-                <>
-                  <Spinner className="mx-auto mb-3 size-6 text-foreground/30" />
-                  <p className="text-sm text-muted-foreground">
-                    Generating design...
-                  </p>
-                </>
-              ) : (
-                <>
-                  <p className="text-sm text-muted-foreground mb-3">
-                    {generationIssue ??
-                      "No files yet. Ask the agent to generate a design."}
-                  </p>
-                  {retryablePrompt ? (
-                    <p className="text-xs text-muted-foreground/70 mb-4 max-w-sm mx-auto italic">
-                      "{retryablePrompt.prompt}"
+            <div className="flex-1 flex items-center justify-center">
+              <div className="text-center">
+                {generating || pendingGenerationActive ? (
+                  <>
+                    <Spinner className="mx-auto mb-3 size-6 text-foreground/30" />
+                    <p className="text-sm text-muted-foreground">
+                      Generating design...
                     </p>
-                  ) : null}
-                  <div className="flex items-center justify-center gap-2">
+                  </>
+                ) : (
+                  <>
+                    <p className="text-sm text-muted-foreground mb-3">
+                      {generationIssue ??
+                        "No files yet. Ask the agent to generate a design."}
+                    </p>
                     {retryablePrompt ? (
+                      <p className="text-xs text-muted-foreground/70 mb-4 max-w-sm mx-auto italic">
+                        "{retryablePrompt.prompt}"
+                      </p>
+                    ) : null}
+                    <div className="flex items-center justify-center gap-2">
+                      {retryablePrompt ? (
+                        <Button
+                          size="sm"
+                          className="cursor-pointer"
+                          onClick={handleRetryGeneration}
+                        >
+                          <IconRefresh className="w-3.5 h-3.5" />
+                          Try again
+                        </Button>
+                      ) : null}
                       <Button
+                        ref={generateBtnRef}
+                        variant={retryablePrompt ? "ghost" : "outline"}
                         size="sm"
                         className="cursor-pointer"
-                        onClick={handleRetryGeneration}
+                        onClick={() => {
+                          setRetryablePrompt(null);
+                          setShowPrompt(true);
+                        }}
                       >
-                        <IconRefresh className="w-3.5 h-3.5" />
-                        Try again
+                        <IconPlus className="w-3.5 h-3.5" />
+                        {retryablePrompt ? "New prompt" : "Generate Design"}
                       </Button>
-                    ) : null}
-                    <Button
-                      ref={generateBtnRef}
-                      variant={retryablePrompt ? "ghost" : "outline"}
-                      size="sm"
-                      className="cursor-pointer"
-                      onClick={() => {
-                        setRetryablePrompt(null);
-                        setShowPrompt(true);
-                      }}
-                    >
-                      <IconPlus className="w-3.5 h-3.5" />
-                      {retryablePrompt ? "New prompt" : "Generate Design"}
-                    </Button>
-                  </div>
-                </>
-              )}
+                    </div>
+                  </>
+                )}
+              </div>
             </div>
-          </div>
-        )}
+          ))}
 
         {/* Edit panel (right side) */}
         {mode === "edit" && (


### PR DESCRIPTION
## Summary\n- harden MCP app embed/chat bridge handoff so nested pickers get an acknowledgement and fall back to standard MCP app messaging\n- keep local external MCP embed origins working and avoid leaking embed params onto Vite/runtime module requests\n- improve Assets embedded detection plus Design's exactly-three-variant MCP picker flow and compact preview layout\n\n## Testing\n- pnpm --filter @agent-native/core exec vitest --run src/client/mcp-app-host.spec.ts src/mcp/embed-app.spec.ts src/mcp/server.spec.ts src/mcp/embed-app.spec.ts src/shared/mcp-embed-headers.spec.ts src/vite/client.spec.ts --reporter=dot\n- pnpm --dir templates/assets exec vitest --run actions/open-asset-picker.spec.ts actions/generate-image-batch.spec.ts --reporter=dot\n- pnpm --dir templates/design exec vitest --run actions/present-design-variants.spec.ts --reporter=dot\n- pnpm run prep (fmt/typecheck/guards passed; full core test leg hit two 5s timeout flakes)\n- pnpm --filter @agent-native/core exec vitest --run src/checkpoints/service.spec.ts src/workspace-connections/store.spec.ts --reporter=dot\n\n## E2E notes\n- Verified real ChatGPT custom connector can open the inline Assets picker via the MCP app, auto-generate 3 images, and render/select generated candidates.\n- Found the host round-trip was falsely reporting success when ChatGPT did not continue; this PR makes that handoff acknowledged and adds the standard MCP ui/message fallback.\n- Verified local Design embedded variant grid fits the MCP-sized frame at desktop and narrow widths, and selection clears the variant overlay.