### PR TITLE
Route bespoke Analytics artifacts to extensions

### DIFF
--- a/.changeset/clean-auth-redirect-param.md
+++ b/.changeset/clean-auth-redirect-param.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Clean the temporary auth redirect cache-busting query parameter from browser history after client boot.

--- a/.github/workflows/cancel-stale-netlify-previews.yml
+++ b/.github/workflows/cancel-stale-netlify-previews.yml
@@ -43,7 +43,10 @@ jobs:
             ];
 
             const token = process.env.NETLIFY_TOKEN;
-            if (!token) { core.setFailed('NETLIFY_AUTH_TOKEN secret not set'); return; }
+            if (!token) {
+              core.info('NETLIFY_AUTH_TOKEN secret not set; skipping stale preview cleanup.');
+              return;
+            }
 
             const branch = process.env.BRANCH;
             const latestSha = process.env.LATEST_SHA;

--- a/packages/core/src/client/auth-redirect-url.spec.ts
+++ b/packages/core/src/client/auth-redirect-url.spec.ts
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { AUTH_REDIRECT_QUERY_PARAM } from "../shared/auth-redirect-url.js";
+import { stripAuthRedirectParamFromUrl } from "./auth-redirect-url.js";
+
+describe("stripAuthRedirectParamFromUrl", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("removes the auth redirect cache-buster while preserving the app URL", () => {
+    window.history.replaceState(
+      { state: "kept" },
+      "",
+      `/assets?view=grid&${AUTH_REDIRECT_QUERY_PARAM}=mpsk10xv&library=brand#top`,
+    );
+
+    stripAuthRedirectParamFromUrl();
+
+    expect(window.history.state).toEqual({ state: "kept" });
+    expect(window.location.pathname).toBe("/assets");
+    expect(window.location.search).toBe("?view=grid&library=brand");
+    expect(window.location.hash).toBe("#top");
+  });
+
+  it("removes the query separator when it was the only param", () => {
+    window.history.replaceState(
+      null,
+      "",
+      `/assets?${AUTH_REDIRECT_QUERY_PARAM}=mpsk10xv#top`,
+    );
+
+    stripAuthRedirectParamFromUrl();
+
+    expect(window.location.pathname).toBe("/assets");
+    expect(window.location.search).toBe("");
+    expect(window.location.hash).toBe("#top");
+  });
+
+  it("leaves unrelated URLs unchanged", () => {
+    window.history.replaceState(null, "", "/assets?view=grid#top");
+
+    stripAuthRedirectParamFromUrl();
+
+    expect(window.location.pathname).toBe("/assets");
+    expect(window.location.search).toBe("?view=grid");
+    expect(window.location.hash).toBe("#top");
+  });
+});

--- a/packages/core/src/client/auth-redirect-url.ts
+++ b/packages/core/src/client/auth-redirect-url.ts
@@ -1,0 +1,23 @@
+import { AUTH_REDIRECT_QUERY_PARAM } from "../shared/auth-redirect-url.js";
+
+function browserWindow(): Window | null {
+  return typeof window === "undefined" ? null : window;
+}
+
+export function stripAuthRedirectParamFromUrl(win = browserWindow()): void {
+  if (!win) return;
+
+  try {
+    const url = new URL(win.location.href);
+    if (!url.searchParams.has(AUTH_REDIRECT_QUERY_PARAM)) return;
+
+    url.searchParams.delete(AUTH_REDIRECT_QUERY_PARAM);
+    win.history.replaceState(
+      win.history.state,
+      "",
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+  } catch {
+    // Cosmetic cleanup only; never block app boot if history/location is odd.
+  }
+}

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -1,6 +1,8 @@
 import { installRouteChunkRecovery } from "./route-chunk-recovery.js";
+import { stripAuthRedirectParamFromUrl } from "./auth-redirect-url.js";
 
 installRouteChunkRecovery();
+stripAuthRedirectParamFromUrl();
 
 export {
   sendToAgentChat,

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -18,6 +18,7 @@ import {
   resolveBuiltInAuthMarketing,
   type AuthMarketingContent,
 } from "./auth-marketing.js";
+import { AUTH_REDIRECT_QUERY_PARAM } from "../shared/auth-redirect-url.js";
 
 function hasGoogleOAuth(): boolean {
   return !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
@@ -1097,7 +1098,7 @@ ${
     function __anWithAuthCacheBypass(ret) {
       try {
         var url = new URL(ret || __anPath('/'), window.location.origin);
-        url.searchParams.set('__an_auth_redirect', Date.now().toString(36));
+        url.searchParams.set('${AUTH_REDIRECT_QUERY_PARAM}', Date.now().toString(36));
         return url.pathname + url.search + url.hash;
       } catch(e) {
         var fallback = ret || __anPath('/');
@@ -1105,7 +1106,7 @@ ${
         var beforeHash = hashIndex === -1 ? fallback : fallback.slice(0, hashIndex);
         var hash = hashIndex === -1 ? '' : fallback.slice(hashIndex);
         var sep = beforeHash.indexOf('?') === -1 ? '?' : '&';
-        return beforeHash + sep + '__an_auth_redirect=' + Date.now().toString(36) + hash;
+        return beforeHash + sep + '${AUTH_REDIRECT_QUERY_PARAM}=' + Date.now().toString(36) + hash;
       }
     }
     function __anRedirectToSignedInApp(ret) {

--- a/packages/core/src/shared/auth-redirect-url.ts
+++ b/packages/core/src/shared/auth-redirect-url.ts
@@ -1,0 +1,1 @@
+export const AUTH_REDIRECT_QUERY_PARAM = "__an_auth_redirect";

--- a/templates/analytics/.agents/skills/adhoc-analysis/SKILL.md
+++ b/templates/analytics/.agents/skills/adhoc-analysis/SKILL.md
@@ -20,6 +20,14 @@ Use the ad-hoc analysis workflow when:
 
 For simple one-off questions (e.g., "how many signups last week?"), just query the data and answer in chat — no need to save an analysis.
 
+If the user asks for an analysis output that needs a bespoke interactive
+surface, custom visualization, multi-step workflow, or UI that cannot be
+faithfully represented as saved-analysis Markdown, generated chart images, and
+structured `resultData`, create an extension instead of forcing the request into
+the saved-analysis format. In production mode, call `create-extension`
+automatically and tell the user the requested analysis needed bespoke UI/code, so
+you built it as an extension.
+
 ## Workflow
 
 ### Step 1: Understand the Question

--- a/templates/analytics/.agents/skills/dashboard-management/SKILL.md
+++ b/templates/analytics/.agents/skills/dashboard-management/SKILL.md
@@ -58,6 +58,22 @@ pnpm action navigate --view=adhoc --dashboardId=weekly-metrics
 
 The save path dry-runs BigQuery panels before persisting. If validation returns a provider error, fix the query and retry. Never work around validation by writing directly to a table.
 
+## When To Use An Extension Instead
+
+Native Analytics dashboards are JSON configs rendered by the built-in dashboard
+components. Use `update-dashboard` only when the request fits that model:
+standard panels, supported chart types, filters, variables, sections, and grid
+layout.
+
+If the user asks for a dashboard or analytical surface that needs bespoke UI or
+code beyond the dashboard JSON/component model, create an extension instead.
+Examples include custom interaction flows, non-standard visualizations, complex
+multi-step workflows, highly custom layouts, custom client-side state, or a
+dashboard-like app that needs behavior the built-in renderer cannot express. In
+production mode, call `create-extension` automatically and then tell the user
+that the request needed a bespoke surface, so you built it as an extension
+rather than forcing it into a native dashboard config.
+
 ## Config Shape
 
 ```jsonc

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -21,6 +21,11 @@ details live in `.agents/skills/`.
   and existing credential/integration flow.
 - Dashboards and charts should be useful, explainable, and scoped to the user's
   question. Avoid decorative metrics.
+- Native dashboards and saved analyses are constrained artifacts. If a requested
+  dashboard, analysis surface, visualization, interaction model, custom layout,
+  or bespoke workflow cannot be done faithfully with the built-in dashboard JSON
+  config/components or saved-analysis markdown/chart format, automatically build
+  it as an extension instead and tell the user why.
 - Use framework sharing and access helpers for dashboards, analyses, and saved
   resources.
 

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -72,19 +72,27 @@ export default createAgentChatPlugin({
       "For schema questions, prefer data-dictionary entries and configured warehouse schemas over assumptions; use `search-bigquery-schema` for BigQuery metadata before inventing datasets, tables, or columns. " +
       "Never substitute fabricated numbers for a failed query or unavailable provider. It is fine to ask a clarifying question, provide a plan, or say exactly which source is unavailable as long as you do not present metrics or source-record conclusions without evidence.\n" +
       "</data-source-guidance>";
+    const artifactGuidance =
+      "<analytics-artifact-guidance>\n" +
+      "Native Analytics dashboards and saved analyses are constrained artifacts: dashboards are JSON configs rendered by the built-in dashboard components, and analyses are Markdown reports with generated chart images plus structured resultData. " +
+      "If the user's requested dashboard, analysis surface, visualization, interaction model, custom layout, or bespoke workflow cannot be faithfully represented within those native components/config fields, do not hand-wave, force an approximate JSON dashboard, or route to source-code changes. In production mode, automatically create a sandboxed extension with `create-extension` instead, using Alpine.js HTML and the available app/data helpers. " +
+      "After creating the extension, briefly tell the user that the request needed bespoke UI/code beyond the native Analytics dashboard or analysis format, so you built it as an extension.\n" +
+      "</analytics-artifact-guidance>";
 
     try {
       const scope = await resolveSettingsScope(event);
       const all = await listScopedSettingRecords(scope, DATA_DICT_PREFIX);
       const entries = Object.values(all) as Array<Record<string, unknown>>;
       const dict = renderDataDictionary(entries);
-      return dict ? `${sourceGuidance}\n\n${dict}` : sourceGuidance;
+      return dict
+        ? `${sourceGuidance}\n\n${artifactGuidance}\n\n${dict}`
+        : `${sourceGuidance}\n\n${artifactGuidance}`;
     } catch (err) {
       console.warn(
         "[analytics] data dictionary context failed:",
         err instanceof Error ? err.message : err,
       );
-      return sourceGuidance;
+      return `${sourceGuidance}\n\n${artifactGuidance}`;
     }
   },
   mentionProviders: {

--- a/templates/assets/app/routes/_index.tsx
+++ b/templates/assets/app/routes/_index.tsx
@@ -45,7 +45,6 @@ import {
   SelectItem,
   SelectSeparator,
   SelectTrigger,
-  SelectValue,
 } from "@/components/ui/select";
 import { CreateLibraryDialog } from "@/components/library/CreateLibraryDialog";
 import { LibraryCard } from "@/components/library/LibraryCard";
@@ -85,6 +84,8 @@ const CUSTOM_RATIOS_KEY = "assets.customAspectRatios";
 const MAX_TEXT_CONTEXT_FILE_CHARS = 12_000;
 const MAX_TEXT_CONTEXT_TOTAL_CHARS = 24_000;
 const MAX_TEXT_CONTEXT_READ_BYTES_PER_CHAR = 4;
+const COMPOSER_SELECT_TRIGGER_CLASS =
+  "h-7 w-auto min-w-0 max-w-full rounded-md border-0 bg-transparent px-1.5 py-1 text-xs font-medium text-muted-foreground shadow-none ring-offset-transparent transition hover:bg-accent/50 hover:text-foreground focus:ring-0 focus:ring-offset-0 sm:px-2 data-[placeholder]:text-muted-foreground [&>svg]:ml-1 [&>svg]:size-3.5 [&>svg]:opacity-60";
 
 type ImageGenerationConfig = {
   builderEnabled?: boolean;
@@ -216,10 +217,10 @@ function GenerationSetupNotice({ config }: { config: ImageGenerationConfig }) {
         ? "Add an OpenAI or Gemini key for image generation."
         : "Add S3-compatible storage for originals, thumbnails, and exports.";
   const title = builderAvailable
-    ? "Connect Builder to create assets"
+    ? "Connect generation models"
     : "Finish asset setup";
   const description = builderAvailable
-    ? "One click enables image generation and asset storage. No provider keys needed."
+    ? "Connect to enable image generation, video generation, LLMs, and asset storage. Free credits and no keys needed."
     : "This deployment uses manual provider setup. Add the missing pieces in Settings.";
   const showContent = !!issueMessage || !!flow.error || builderAvailable;
 
@@ -463,6 +464,13 @@ function HomeGeneratePanel({
       return;
     }
     chooseLibrary(value);
+  };
+
+  const handleMediaTypeChange = (value: "image" | "video") => {
+    setMediaType(value);
+    if (value === "video" && aspectRatio !== "16:9" && aspectRatio !== "9:16") {
+      setAspectRatio("16:9");
+    }
   };
 
   const createPresetLibrary = (presetId: string) => {
@@ -778,6 +786,7 @@ function HomeGeneratePanel({
             ) : null}
 
             <PromptComposer
+              className="[&_[data-agent-composer-slot=toolbar-spacer]]:hidden"
               placeholder={
                 selectedLibrary
                   ? mediaType === "video"
@@ -792,144 +801,22 @@ function HomeGeneratePanel({
               showModelSelector={false}
               voiceEnabled={false}
               draftScope="assets-create"
+              toolbarSlot={
+                <AssetComposerToolbar
+                  mediaType={mediaType}
+                  onMediaTypeChange={handleMediaTypeChange}
+                  selectValue={selectValue}
+                  selectedLibraryLabel={selectedLibrary?.title ?? "Generic"}
+                  libraries={sortedLibraries}
+                  onLibraryChange={handleLibraryChange}
+                  aspectRatio={aspectRatio}
+                  onAspectChange={handleAspectChange}
+                  customRatios={customRatios}
+                  count={count}
+                  onCountChange={setCount}
+                />
+              }
             />
-
-            <div className="mt-5 rounded-lg border border-border/80 bg-card/50 p-3 text-sm">
-              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-[minmax(0,0.8fr)_minmax(12rem,1.6fr)_minmax(0,1fr)_minmax(0,0.85fr)]">
-                <div className="grid gap-1.5">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    Type
-                  </span>
-                  <Select
-                    value={mediaType}
-                    onValueChange={(value) => {
-                      const next = value as "image" | "video";
-                      setMediaType(next);
-                      if (
-                        next === "video" &&
-                        aspectRatio !== "16:9" &&
-                        aspectRatio !== "9:16"
-                      ) {
-                        setAspectRatio("16:9");
-                      }
-                    }}
-                  >
-                    <SelectTrigger className="h-9 w-full text-sm">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectItem value="image">Image</SelectItem>
-                        <SelectItem value="video">Video</SelectItem>
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="grid gap-1.5">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    Library
-                  </span>
-                  <Select
-                    value={selectValue}
-                    onValueChange={handleLibraryChange}
-                  >
-                    <SelectTrigger className="h-9 w-full text-sm">
-                      <SelectValue placeholder="Choose a library" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        {sortedLibraries.map((library) => (
-                          <SelectItem key={library.id} value={library.id}>
-                            {library.title}
-                          </SelectItem>
-                        ))}
-                        <SelectItem value="generic">
-                          No library - generic
-                        </SelectItem>
-                      </SelectGroup>
-                      <SelectSeparator />
-                      <SelectGroup>
-                        <SelectItem value="__new__">
-                          <span className="flex items-center gap-2">
-                            <IconPhotoPlus className="size-3.5" />
-                            New library...
-                          </span>
-                        </SelectItem>
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="grid gap-1.5">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    Aspect
-                  </span>
-                  <Select
-                    value={aspectRatio}
-                    onValueChange={handleAspectChange}
-                  >
-                    <SelectTrigger className="h-9 w-full text-sm">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        {ASPECT_RATIOS.filter(
-                          (ratio) =>
-                            mediaType === "image" ||
-                            ratio.value === "16:9" ||
-                            ratio.value === "9:16",
-                        ).map((ratio) => (
-                          <SelectItem key={ratio.value} value={ratio.value}>
-                            {ratio.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                      {customRatios.length > 0 ? (
-                        <>
-                          <SelectSeparator />
-                          <SelectGroup>
-                            {customRatios.map((ratio) => (
-                              <SelectItem key={ratio} value={ratio}>
-                                {ratio} - saved
-                              </SelectItem>
-                            ))}
-                          </SelectGroup>
-                        </>
-                      ) : null}
-                      <SelectSeparator />
-                      <SelectGroup>
-                        <SelectItem value="__custom__">
-                          Custom size...
-                        </SelectItem>
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </div>
-                {mediaType === "image" && (
-                  <div className="grid gap-1.5">
-                    <span className="text-xs font-medium text-muted-foreground">
-                      Count
-                    </span>
-                    <Select
-                      value={String(count)}
-                      onValueChange={(value) => setCount(Number(value))}
-                    >
-                      <SelectTrigger className="h-9 w-full text-sm">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          {[1, 2, 3, 4].map((n) => (
-                            <SelectItem key={n} value={String(n)}>
-                              {n} variants
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                )}
-              </div>
-            </div>
           </div>
 
           <div className="flex flex-wrap justify-center gap-2">
@@ -1082,5 +969,145 @@ function HomeGeneratePanel({
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+function AssetComposerToolbar({
+  mediaType,
+  onMediaTypeChange,
+  selectValue,
+  selectedLibraryLabel,
+  libraries,
+  onLibraryChange,
+  aspectRatio,
+  onAspectChange,
+  customRatios,
+  count,
+  onCountChange,
+}: {
+  mediaType: "image" | "video";
+  onMediaTypeChange: (value: "image" | "video") => void;
+  selectValue: string;
+  selectedLibraryLabel: string;
+  libraries: ImageLibrarySummary[];
+  onLibraryChange: (value: string) => void;
+  aspectRatio: string;
+  onAspectChange: (value: string) => void;
+  customRatios: string[];
+  count: number;
+  onCountChange: (value: number) => void;
+}) {
+  const aspectOptions = ASPECT_RATIOS.filter(
+    (ratio) =>
+      mediaType === "image" || ratio.value === "16:9" || ratio.value === "9:16",
+  );
+
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-1">
+      <Select
+        value={mediaType}
+        onValueChange={(value) => onMediaTypeChange(value as "image" | "video")}
+      >
+        <SelectTrigger
+          aria-label="Asset type"
+          className={`${COMPOSER_SELECT_TRIGGER_CLASS} max-w-[5.5rem] shrink-0`}
+        >
+          <span className="truncate capitalize">{mediaType}</span>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectItem value="image">Image</SelectItem>
+            <SelectItem value="video">Video</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+
+      <div className="flex min-w-0 flex-1 items-center justify-end gap-0.5 sm:gap-1">
+        <Select value={selectValue} onValueChange={onLibraryChange}>
+          <SelectTrigger
+            aria-label="Library"
+            className={`${COMPOSER_SELECT_TRIGGER_CLASS} max-w-[6rem] sm:max-w-[12rem]`}
+          >
+            <span className="truncate">{selectedLibraryLabel}</span>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {libraries.map((library) => (
+                <SelectItem key={library.id} value={library.id}>
+                  {library.title}
+                </SelectItem>
+              ))}
+              <SelectItem value="generic">No library - generic</SelectItem>
+            </SelectGroup>
+            <SelectSeparator />
+            <SelectGroup>
+              <SelectItem value="__new__">
+                <span className="flex items-center gap-2">
+                  <IconPhotoPlus className="size-3.5" />
+                  New library...
+                </span>
+              </SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+
+        <Select value={aspectRatio} onValueChange={onAspectChange}>
+          <SelectTrigger
+            aria-label="Aspect ratio"
+            className={`${COMPOSER_SELECT_TRIGGER_CLASS} max-w-[5rem] shrink-0`}
+          >
+            <span className="truncate">{aspectRatio}</span>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {aspectOptions.map((ratio) => (
+                <SelectItem key={ratio.value} value={ratio.value}>
+                  {ratio.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+            {customRatios.length > 0 ? (
+              <>
+                <SelectSeparator />
+                <SelectGroup>
+                  {customRatios.map((ratio) => (
+                    <SelectItem key={ratio} value={ratio}>
+                      {ratio} - saved
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </>
+            ) : null}
+            <SelectSeparator />
+            <SelectGroup>
+              <SelectItem value="__custom__">Custom size...</SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+
+        {mediaType === "image" ? (
+          <Select
+            value={String(count)}
+            onValueChange={(value) => onCountChange(Number(value))}
+          >
+            <SelectTrigger
+              aria-label="Variant count"
+              className={`${COMPOSER_SELECT_TRIGGER_CLASS} max-w-[4rem] shrink-0`}
+            >
+              <span>{count}x</span>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {[1, 2, 3, 4].map((n) => (
+                  <SelectItem key={n} value={String(n)}>
+                    {n}x
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        ) : null}
+      </div>
+    </div>
   );
 }

--- a/templates/assets/app/routes/_index.tsx
+++ b/templates/assets/app/routes/_index.tsx
@@ -220,7 +220,7 @@ function GenerationSetupNotice({ config }: { config: ImageGenerationConfig }) {
     ? "Connect generation models"
     : "Finish asset setup";
   const description = builderAvailable
-    ? "Connect to enable image generation, video generation, LLMs, and asset storage. Free credits and no keys needed."
+    ? "Connect to enable image generation, video generation, LLMs, and asset storage. Free credits and no keys needed"
     : "This deployment uses manual provider setup. Add the missing pieces in Settings.";
   const showContent = !!issueMessage || !!flow.error || builderAvailable;
 


### PR DESCRIPTION
## Summary
- Add production Analytics agent guidance to create extensions when native dashboard/analysis artifacts cannot faithfully represent the requested surface
- Document the fallback in Analytics AGENTS.md plus dashboard and ad-hoc analysis skills
- Keep stale Netlify preview cleanup from failing when the token is absent
- Clean the temporary auth redirect cache-busting query parameter after client boot
- Move Assets creation controls into the composer toolbar

## Verification
- pnpm run prep