### PR TITLE
changes-182: release-pipeline fix + core test coverage + assets/analytics/db-admin updates

### DIFF
--- a/.agents/skills/security/SKILL.md
+++ b/.agents/skills/security/SKILL.md
@@ -51,10 +51,24 @@ await client.execute(`SELECT * FROM users WHERE id = '${id}'`);
 - For rich text editing, use TipTap (framework dependency).
 - For rendering markdown, use `react-markdown`.
 
+## SSRF
+
+Any server-side `fetch` of a user- or agent-controlled URL must go through the framework SSRF guard — a bare `fetch()` can be steered at cloud metadata (`169.254.169.254`), `localhost`, or internal services.
+
+```ts
+import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
+// Blocks private/internal targets, re-checks the resolved IP at connect time
+// (DNS rebinding), and re-validates every redirect hop.
+const res = await ssrfSafeFetch(userProvidedUrl, {}, { maxRedirects: 3 });
+```
+
+For a pre-flight-only check (e.g. before a streaming or one-shot fetch), use `isBlockedExtensionUrlWithDns(url)` plus `createSsrfSafeDispatcher()` from the same module, and set `redirect: "manual"`. Never let the default `fetch` follow redirects for an untrusted URL — a public URL can 30x into the private network.
+
 ## Secrets
 
 - OAuth tokens go in the `oauth_tokens` store via `saveOAuthTokens()`.
-- Never store secrets in `settings`, `application_state`, source code, or action responses sent to the client.
+- Per-user / per-org API keys go through `saveCredential` / `resolveCredential` (`@agent-native/core/credentials`) or the `app_secrets` vault. Both encrypt values at rest with AES-256-GCM (keyed by `SECRETS_ENCRYPTION_KEY`, falling back to `BETTER_AUTH_SECRET`; production refuses to start without one).
+- Never hand-roll secrets into `settings`, `application_state`, source code, or action responses sent to the client. The credential / vault APIs above are the only sanctioned stores.
 
 ## User Credentials Are Per-User Data — Never `process.env`
 
@@ -64,6 +78,8 @@ User credentials (API keys, third-party tokens) are per-user (or per-org) data. 
 import { resolveCredential } from "@agent-native/core/credentials";
 const apiKey = await resolveCredential("OPENAI_API_KEY", { userEmail, orgId });
 ```
+
+Values are encrypted at rest (AES-256-GCM, shared `secrets/crypto.ts`): `saveCredential` encrypts on write and `resolveCredential` decrypts on read, with a transparent fallback for legacy plaintext rows. The agent's raw `db-query` / `db-exec` tools also cannot read credential rows — they are excluded from the scoped `settings` view. To encrypt pre-existing rows in place, run `pnpm action db-migrate-encrypt-credentials` (idempotent, non-destructive; needs the same `SECRETS_ENCRYPTION_KEY` / `BETTER_AUTH_SECRET` as the app).
 
 On 2026-04-29 the previous one-arg `resolveCredential(key)` form fell back to `process.env[key]` and an unscoped global `settings` row, so every signed-in user inherited the deployment's credentials. Two guards now block this in CI (`pnpm prep`):
 
@@ -138,6 +154,8 @@ export default defineEventHandler(async (event) => {
 
 In production, the framework automatically restricts all agent SQL queries to the current user's data using temporary views. This is enforced at the SQL level — the agent cannot bypass it.
 
+The `db-query` / `db-exec` tools (and the extension SQL bridge, which shares the same path) reject schema-qualified table references like `public.<table>` or `main.<table>` — a qualified name resolves to the base table and would skip the temp view. Use bare table names; scoping is applied automatically.
+
 ### Per-User Scoping (`owner_email`)
 
 Every template table with user data **must** have an `owner_email` text column:
@@ -180,6 +198,8 @@ Run `pnpm action db-check-scoping` to verify. Use `--require-org` for multi-org 
 - [ ] New action uses `defineAction` with a Zod `schema:`
 - [ ] No SQL string concatenation with user input
 - [ ] No `dangerouslySetInnerHTML` with user content
+- [ ] Server-side fetches of user/agent URLs use `ssrfSafeFetch`, not bare `fetch`
+- [ ] Secrets stored via `saveCredential` / the vault (encrypted), never raw in `settings` or responses
 - [ ] New env vars in `.env` only, not committed
 - [ ] New user-data tables have `owner_email` column
 - [ ] Custom routes call `getSession` and reject unauthenticated requests

--- a/.changeset/clean-auth-redirect-param.md
+++ b/.changeset/clean-auth-redirect-param.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Clean the temporary auth redirect cache-busting query parameter from browser history after client boot.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,11 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@agent-native/desktop-app"],
+  "ignore": [
+    "@agent-native/desktop-app",
+    "@agent-native/code-agents-ui",
+    "@agent-native/shared-app-config"
+  ],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/.changeset/db-admin-agent-parity.md
+++ b/.changeset/db-admin-agent-parity.md
@@ -1,0 +1,10 @@
+---
+"@agent-native/core": patch
+---
+
+Database admin: make the agent's db-admin tools available whenever the DB admin
+itself is (`NODE_ENV === "development"`), instead of only when the agent
+Code-mode toggle is on. This gives true agent/UI parity — the agent can read and
+edit the full database through `db-admin-*` tools in App mode too — and the tool
+descriptions now steer the agent to prefer them over the scoped `db-exec`/
+`db-query` for admin work and for tables without `owner_email`/`org_id` scoping.

--- a/.github/workflows/cancel-stale-netlify-previews.yml
+++ b/.github/workflows/cancel-stale-netlify-previews.yml
@@ -43,7 +43,10 @@ jobs:
             ];
 
             const token = process.env.NETLIFY_TOKEN;
-            if (!token) { core.setFailed('NETLIFY_AUTH_TOKEN secret not set'); return; }
+            if (!token) {
+              core.info('NETLIFY_AUTH_TOKEN secret not set; skipping stale preview cleanup.');
+              return;
+            }
 
             const branch = process.env.BRANCH;
             const latestSha = process.env.LATEST_SHA;

--- a/packages/core/docs/content/security.md
+++ b/packages/core/docs/content/security.md
@@ -11,15 +11,16 @@ Agent-native apps are designed to be secure by default. The framework provides a
 
 The framework architecture prevents common vulnerabilities when you use the standard patterns:
 
-| Vulnerability   | Framework Protection                                            |
-| --------------- | --------------------------------------------------------------- |
-| SQL injection   | Parameterized queries in `db-query`/`db-exec` and Drizzle ORM   |
-| XSS             | React auto-escapes JSX; TipTap sanitizes rich text              |
-| Data leaks      | SQL-level scoping via temporary views (`owner_email`, `org_id`) |
-| Auth bypass     | Auth guard auto-protects all `defineAction` endpoints           |
-| Input injection | Zod schema validation in `defineAction`                         |
-| CSRF            | `SameSite=lax` + `httpOnly` cookies                             |
-| Secret exposure | `.env` files gitignored; OAuth tokens in dedicated store        |
+| Vulnerability   | Framework Protection                                                   |
+| --------------- | ---------------------------------------------------------------------- |
+| SQL injection   | Parameterized queries in `db-query`/`db-exec` and Drizzle ORM          |
+| XSS             | React auto-escapes JSX; TipTap sanitizes rich text                     |
+| Data leaks      | SQL-level scoping via temporary views (`owner_email`, `org_id`)        |
+| Auth bypass     | Auth guard auto-protects all `defineAction` endpoints                  |
+| Input injection | Zod schema validation in `defineAction`                                |
+| CSRF            | `SameSite=lax` + `httpOnly` cookies                                    |
+| Secret exposure | `.env` gitignored; credentials & vault encrypted at rest (AES-256-GCM) |
+| SSRF            | `ssrfSafeFetch` blocks internal/metadata targets + redirect rebinding  |
 
 ## Input Validation {#input-validation}
 
@@ -67,6 +68,18 @@ React auto-escapes all JSX expressions. Additional guidelines:
 - For rich text editing, use TipTap (framework dependency) — it sanitizes through its schema
 - For rendering markdown, use `react-markdown` — it converts to React elements safely
 
+## Server-Side Fetch (SSRF) {#ssrf}
+
+Any server-side `fetch` of a user- or agent-controlled URL must go through the framework SSRF guard, or it can be pointed at cloud metadata (`169.254.169.254`), `localhost`, or internal services:
+
+```typescript
+import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
+
+const res = await ssrfSafeFetch(userProvidedUrl, {}, { maxRedirects: 3 });
+```
+
+`ssrfSafeFetch` blocks private/internal targets, re-checks the resolved IP at connect time (DNS rebinding), and re-validates every redirect hop so a public URL can't redirect into the private network. The extension iframe proxy, `upload-image`, and the design-token importer all route through it. For a pre-flight-only check, use `isBlockedExtensionUrlWithDns(url)` with `redirect: "manual"`.
+
 ## Data Scoping {#data-scoping}
 
 In production, the framework automatically restricts agent SQL queries to the current user's data. This is enforced at the SQL level — agents cannot bypass it. This section is the canonical reference for the scoping pipeline; the [Authentication](/docs/authentication) and [Multi-Tenancy](/docs/multi-tenancy) docs link here for the mechanics.
@@ -106,6 +119,8 @@ CREATE TEMPORARY VIEW "notes" AS
 
 INSERT statements get `owner_email` auto-injected when the column isn't already present.
 
+The `db-query` / `db-exec` tools reject schema-qualified table references (`public.<table>`, `main.<table>`) — a qualified name resolves to the base table and would bypass the temporary view above. Agents use bare table names; scoping is applied automatically.
+
 ### Per-Org Scoping (`org_id`)
 
 For multi-user apps where teams share data, add an `org_id` column. When both columns are present, queries are scoped by both: `WHERE owner_email = ? AND org_id = ?`.
@@ -141,13 +156,17 @@ pnpm action db-check-scoping --require-org  # Also require org_id
 
 ## Secrets Management {#secrets}
 
-| Secret type                     | Where to store                               |
-| ------------------------------- | -------------------------------------------- |
-| API keys (OpenAI, Stripe, etc.) | `.env` file (gitignored, server-side only)   |
-| OAuth tokens (Google, GitHub)   | `oauth_tokens` store via `saveOAuthTokens()` |
-| Session tokens                  | Automatic (Better Auth handles this)         |
+| Secret type                        | Where to store                                             |
+| ---------------------------------- | ---------------------------------------------------------- |
+| Deploy-level keys (one per app)    | `.env` file (gitignored, server-side only)                 |
+| Per-user / per-org API keys        | `saveCredential` / `resolveCredential` (encrypted at rest) |
+| Registered secrets (sidebar vault) | `app_secrets` vault (encrypted at rest)                    |
+| OAuth tokens (Google, GitHub)      | `oauth_tokens` store via `saveOAuthTokens()`               |
+| Session tokens                     | Automatic (Better Auth handles this)                       |
 
-Never store secrets in `settings`, `application_state`, source code, or action responses.
+Per-user/per-org credentials and the vault are encrypted at rest with AES-256-GCM, keyed by `SECRETS_ENCRYPTION_KEY` (falling back to `BETTER_AUTH_SECRET`); production refuses to start without one. To encrypt any pre-existing plaintext credential rows in place, run `pnpm action db-migrate-encrypt-credentials` (idempotent, non-destructive).
+
+Never store secrets in `settings`, `application_state`, source code, or action responses. Use the credential / vault APIs above — they handle both encryption and per-user scoping.
 
 ## Authentication {#auth}
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -296,6 +296,7 @@
     "@types/react": "^19.2.14",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react-swc": "^4.0.0",
+    "@vitest/coverage-v8": "4.1.5",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",

--- a/packages/core/src/a2a/auth-policy.spec.ts
+++ b/packages/core/src/a2a/auth-policy.spec.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  hasConfiguredA2ASecret,
+  isA2AProductionRuntime,
+  shouldAdvertiseJwtA2AAuth,
+} from "./auth-policy.js";
+
+// Env vars these helpers read. Cleared before each test so the host machine's
+// real environment (NODE_ENV, CI provider flags, etc.) can't make a "default"
+// case secretly pass.
+const A2A_ENV_KEYS = [
+  "NODE_ENV",
+  "NETLIFY",
+  "NETLIFY_LOCAL",
+  "AWS_LAMBDA_FUNCTION_NAME",
+  "CF_PAGES",
+  "VERCEL",
+  "VERCEL_ENV",
+  "RENDER",
+  "FLY_APP_NAME",
+  "K_SERVICE",
+  "A2A_SECRET",
+] as const;
+
+describe("a2a auth-policy", () => {
+  const originalEnv = { ...process.env };
+  const hadCfEnv = "__cf_env" in globalThis;
+
+  beforeEach(() => {
+    for (const key of A2A_ENV_KEYS) delete process.env[key];
+    delete (globalThis as Record<string, unknown>).__cf_env;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    if (hadCfEnv) {
+      // restore whatever was there; tests never set a meaningful value
+      (globalThis as Record<string, unknown>).__cf_env ??= {};
+    } else {
+      delete (globalThis as Record<string, unknown>).__cf_env;
+    }
+  });
+
+  describe("isA2AProductionRuntime", () => {
+    it("is false with no production signals", () => {
+      expect(isA2AProductionRuntime()).toBe(false);
+    });
+
+    it("is true when NODE_ENV is production", () => {
+      process.env.NODE_ENV = "production";
+      expect(isA2AProductionRuntime()).toBe(true);
+    });
+
+    it("is false in development/test even with no platform flags", () => {
+      process.env.NODE_ENV = "development";
+      expect(isA2AProductionRuntime()).toBe(false);
+    });
+
+    it("treats deployed Netlify as production", () => {
+      process.env.NETLIFY = "true";
+      expect(isA2AProductionRuntime()).toBe(true);
+    });
+
+    it("does NOT treat local Netlify dev (`netlify dev`) as production", () => {
+      process.env.NETLIFY = "true";
+      process.env.NETLIFY_LOCAL = "true";
+      expect(isA2AProductionRuntime()).toBe(false);
+    });
+
+    it("requires NETLIFY to equal the literal string 'true'", () => {
+      process.env.NETLIFY = "1";
+      expect(isA2AProductionRuntime()).toBe(false);
+    });
+
+    it("treats a deployed Lambda function as production", () => {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = "my-func";
+      expect(isA2AProductionRuntime()).toBe(true);
+    });
+
+    it("does NOT treat a Lambda under local Netlify dev as production", () => {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = "my-func";
+      process.env.NETLIFY_LOCAL = "true";
+      expect(isA2AProductionRuntime()).toBe(false);
+    });
+
+    it("treats Cloudflare Pages as production", () => {
+      process.env.CF_PAGES = "1";
+      expect(isA2AProductionRuntime()).toBe(true);
+    });
+
+    it("requires CF_PAGES to equal the literal string '1'", () => {
+      process.env.CF_PAGES = "true";
+      expect(isA2AProductionRuntime()).toBe(false);
+    });
+
+    it("treats a Cloudflare Workers binding (__cf_env on globalThis) as production", () => {
+      (globalThis as Record<string, unknown>).__cf_env = {};
+      expect(isA2AProductionRuntime()).toBe(true);
+    });
+
+    it("treats Vercel as production (VERCEL flag)", () => {
+      process.env.VERCEL = "1";
+      expect(isA2AProductionRuntime()).toBe(true);
+    });
+
+    it("treats Vercel as production (VERCEL_ENV flag)", () => {
+      process.env.VERCEL_ENV = "preview";
+      expect(isA2AProductionRuntime()).toBe(true);
+    });
+
+    it.each(["RENDER", "FLY_APP_NAME", "K_SERVICE"])(
+      "treats %s as a production host",
+      (key) => {
+        process.env[key] = "set";
+        expect(isA2AProductionRuntime()).toBe(true);
+      },
+    );
+  });
+
+  describe("hasConfiguredA2ASecret", () => {
+    it("is false when A2A_SECRET is unset", () => {
+      expect(hasConfiguredA2ASecret()).toBe(false);
+    });
+
+    it("is false when A2A_SECRET is empty or whitespace-only", () => {
+      process.env.A2A_SECRET = "   ";
+      expect(hasConfiguredA2ASecret()).toBe(false);
+    });
+
+    it("is true when A2A_SECRET holds a real value", () => {
+      process.env.A2A_SECRET = "super-secret";
+      expect(hasConfiguredA2ASecret()).toBe(true);
+    });
+  });
+
+  describe("shouldAdvertiseJwtA2AAuth", () => {
+    it("advertises JWT auth when a secret is configured even in dev", () => {
+      process.env.NODE_ENV = "development";
+      process.env.A2A_SECRET = "super-secret";
+      expect(shouldAdvertiseJwtA2AAuth()).toBe(true);
+    });
+
+    it("advertises JWT auth in production even without a configured secret", () => {
+      process.env.NODE_ENV = "production";
+      expect(shouldAdvertiseJwtA2AAuth()).toBe(true);
+    });
+
+    it("does NOT advertise JWT auth in local dev with no secret", () => {
+      process.env.NODE_ENV = "development";
+      expect(shouldAdvertiseJwtA2AAuth()).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/a2a/task-store-lifecycle.spec.ts
+++ b/packages/core/src/a2a/task-store-lifecycle.spec.ts
@@ -1,0 +1,370 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DbExec } from "../db/client.js";
+import type { Message } from "./types.js";
+
+// Real in-memory SQLite DbExec adapter (mirrors the better-sqlite3 branch of
+// db/client.ts). Using a real engine — instead of a hand-rolled mock that
+// ignores WHERE clauses — is what makes the state-gated transitions
+// (claim / touch / reset-stuck / fail-stuck) and owner scoping meaningful to
+// test: the conditional UPDATEs actually have to match rows.
+let sqlite: Database.Database;
+
+const dbExec: DbExec = {
+  async execute(sql) {
+    const rawSql = typeof sql === "string" ? sql : sql.sql;
+    const args = typeof sql === "string" ? [] : sql.args || [];
+    // libsql/our wrapper convert undefined -> null; mimic that so INSERTs of
+    // optional columns (owner_email, context_id, metadata) behave like prod.
+    const bound = args.map((a) => (a === undefined ? null : a));
+    const stmt = sqlite.prepare(rawSql);
+    if (stmt.reader) {
+      return { rows: stmt.all(...bound), rowsAffected: 0 };
+    }
+    const result = stmt.run(...bound);
+    return { rows: [], rowsAffected: result.changes ?? 0 };
+  },
+};
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => dbExec,
+  isPostgres: () => false,
+  intType: () => "INTEGER",
+}));
+
+function makeMessage(text: string, role: "user" | "agent" = "user"): Message {
+  return { role, parts: [{ type: "text", text }] };
+}
+
+type Store = typeof import("./task-store.js");
+
+async function loadStore(): Promise<Store> {
+  // Re-import after resetModules so the module-level _initPromise re-runs
+  // ensureTable against the fresh in-memory database each test.
+  return import("./task-store.js");
+}
+
+describe("task-store lifecycle (real sqlite)", () => {
+  beforeEach(() => {
+    sqlite = new Database(":memory:");
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  describe("createTask owner scoping", () => {
+    it("records the verified owner email and exposes it via getTaskOwner", async () => {
+      const { createTask, getTaskOwner } = await loadStore();
+      const task = await createTask(
+        makeMessage("hi"),
+        "ctx",
+        { foo: "bar" },
+        "owner@example.com",
+      );
+      expect(await getTaskOwner(task.id)).toBe("owner@example.com");
+    });
+
+    it("treats a null owner (legacy/unauthenticated) as unscoped", async () => {
+      const { createTask, getTaskOwner } = await loadStore();
+      const task = await createTask(makeMessage("hi"));
+      // Legacy rows have NULL owner_email and must read back as null, not "".
+      expect(await getTaskOwner(task.id)).toBeNull();
+    });
+
+    it("coerces an empty-string owner_email to null (no matchable owner)", async () => {
+      // Security: an empty owner must never read back as the empty string,
+      // which an empty/spoofed caller email could otherwise match in the
+      // handleGet/handleCancel IDOR check. ensureTable has run via createTask.
+      const { createTask, getTaskOwner } = await loadStore();
+      const task = await createTask(makeMessage("hi"));
+      await dbExec.execute({
+        sql: `UPDATE a2a_tasks SET owner_email = ? WHERE id = ?`,
+        args: ["", task.id],
+      });
+      expect(await getTaskOwner(task.id)).toBeNull();
+    });
+
+    it("getTaskOwner returns null for a missing task", async () => {
+      const { getTaskOwner } = await loadStore();
+      expect(await getTaskOwner("does-not-exist")).toBeNull();
+    });
+
+    it("round-trips metadata through getTask", async () => {
+      const { createTask, getTask } = await loadStore();
+      const task = await createTask(makeMessage("hi"), undefined, {
+        kind: "demo",
+        n: 7,
+      });
+      const loaded = await getTask(task.id);
+      expect(loaded!.metadata).toEqual({ kind: "demo", n: 7 });
+    });
+  });
+
+  describe("claimA2ATaskForProcessing", () => {
+    it("claims a freshly submitted task and flips it to processing", async () => {
+      const { createTask, claimA2ATaskForProcessing, getTask } =
+        await loadStore();
+      const task = await createTask(makeMessage("go"));
+
+      const claimed = await claimA2ATaskForProcessing(task.id);
+      expect(claimed).not.toBeNull();
+      expect(claimed!.status.state).toBe("processing");
+      expect((await getTask(task.id))!.status.state).toBe("processing");
+    });
+
+    it("claims a task still in 'working' state", async () => {
+      const { createTask, updateTask, claimA2ATaskForProcessing } =
+        await loadStore();
+      const task = await createTask(makeMessage("go"));
+      await updateTask(task.id, { state: "working" });
+
+      const claimed = await claimA2ATaskForProcessing(task.id);
+      expect(claimed!.status.state).toBe("processing");
+    });
+
+    it("returns null on a second claim — prevents duplicate processing (concurrency guard)", async () => {
+      const { createTask, claimA2ATaskForProcessing } = await loadStore();
+      const task = await createTask(makeMessage("go"));
+
+      const first = await claimA2ATaskForProcessing(task.id);
+      const second = await claimA2ATaskForProcessing(task.id);
+      expect(first).not.toBeNull();
+      expect(second).toBeNull();
+    });
+
+    it("refuses to claim a completed task", async () => {
+      const { createTask, updateTask, claimA2ATaskForProcessing } =
+        await loadStore();
+      const task = await createTask(makeMessage("go"));
+      await updateTask(task.id, { state: "completed" });
+
+      expect(await claimA2ATaskForProcessing(task.id)).toBeNull();
+    });
+
+    it("returns null for a missing task", async () => {
+      const { claimA2ATaskForProcessing } = await loadStore();
+      expect(await claimA2ATaskForProcessing("nope")).toBeNull();
+    });
+  });
+
+  describe("getA2ATaskDispatchState", () => {
+    it("returns id/state/metadata/updatedAt for an existing task", async () => {
+      const { createTask, getA2ATaskDispatchState } = await loadStore();
+      const task = await createTask(makeMessage("go"), undefined, {
+        route: "x",
+      });
+
+      const dispatch = await getA2ATaskDispatchState(task.id);
+      expect(dispatch).not.toBeNull();
+      expect(dispatch!.id).toBe(task.id);
+      expect(dispatch!.statusState).toBe("submitted");
+      expect(dispatch!.metadata).toEqual({ route: "x" });
+      expect(typeof dispatch!.updatedAt).toBe("number");
+      expect(dispatch!.updatedAt).toBeGreaterThan(0);
+    });
+
+    it("returns undefined metadata when none was stored", async () => {
+      const { createTask, getA2ATaskDispatchState } = await loadStore();
+      const task = await createTask(makeMessage("go"));
+      const dispatch = await getA2ATaskDispatchState(task.id);
+      expect(dispatch!.metadata).toBeUndefined();
+    });
+
+    it("returns null for a missing task", async () => {
+      const { getA2ATaskDispatchState } = await loadStore();
+      expect(await getA2ATaskDispatchState("missing")).toBeNull();
+    });
+  });
+
+  describe("touchQueuedA2ATaskDispatch", () => {
+    it("touches a queued (submitted/working) task and returns true", async () => {
+      const { createTask, touchQueuedA2ATaskDispatch } = await loadStore();
+      const task = await createTask(makeMessage("go"));
+      expect(await touchQueuedA2ATaskDispatch(task.id)).toBe(true);
+    });
+
+    it("does NOT touch a task already in processing (out of queued set)", async () => {
+      const {
+        createTask,
+        claimA2ATaskForProcessing,
+        touchQueuedA2ATaskDispatch,
+      } = await loadStore();
+      const task = await createTask(makeMessage("go"));
+      await claimA2ATaskForProcessing(task.id);
+      expect(await touchQueuedA2ATaskDispatch(task.id)).toBe(false);
+    });
+
+    it("returns false for a missing task", async () => {
+      const { touchQueuedA2ATaskDispatch } = await loadStore();
+      expect(await touchQueuedA2ATaskDispatch("missing")).toBe(false);
+    });
+  });
+
+  describe("touchProcessingA2ATask", () => {
+    it("touches only tasks in processing state", async () => {
+      const { createTask, claimA2ATaskForProcessing, touchProcessingA2ATask } =
+        await loadStore();
+      const task = await createTask(makeMessage("go"));
+      // Not yet processing.
+      expect(await touchProcessingA2ATask(task.id)).toBe(false);
+      await claimA2ATaskForProcessing(task.id);
+      expect(await touchProcessingA2ATask(task.id)).toBe(true);
+    });
+  });
+
+  describe("resetStuckA2ATaskForRetry", () => {
+    it("resets a processing task back to 'working' when last touch is at/under the cutoff", async () => {
+      const {
+        createTask,
+        claimA2ATaskForProcessing,
+        resetStuckA2ATaskForRetry,
+        getTask,
+      } = await loadStore();
+      const task = await createTask(makeMessage("go"));
+      await claimA2ATaskForProcessing(task.id);
+
+      // Future cutoff => the row's updated_at is <= cutoff => eligible.
+      const ok = await resetStuckA2ATaskForRetry(task.id, Date.now() + 60_000);
+      expect(ok).toBe(true);
+      expect((await getTask(task.id))!.status.state).toBe("working");
+    });
+
+    it("does NOT reset when the task was touched after the cutoff (not stuck)", async () => {
+      const {
+        createTask,
+        claimA2ATaskForProcessing,
+        resetStuckA2ATaskForRetry,
+        getTask,
+      } = await loadStore();
+      const task = await createTask(makeMessage("go"));
+      await claimA2ATaskForProcessing(task.id);
+
+      // Cutoff in the past => updated_at > cutoff => still considered alive.
+      const ok = await resetStuckA2ATaskForRetry(task.id, Date.now() - 60_000);
+      expect(ok).toBe(false);
+      expect((await getTask(task.id))!.status.state).toBe("processing");
+    });
+
+    it("does NOT reset a task that is not in processing state", async () => {
+      const { createTask, resetStuckA2ATaskForRetry } = await loadStore();
+      const task = await createTask(makeMessage("go")); // submitted
+      expect(
+        await resetStuckA2ATaskForRetry(task.id, Date.now() + 60_000),
+      ).toBe(false);
+    });
+  });
+
+  describe("failStuckA2ATask", () => {
+    it("fails a stuck processing task and records the reason message", async () => {
+      const {
+        createTask,
+        claimA2ATaskForProcessing,
+        failStuckA2ATask,
+        getTask,
+      } = await loadStore();
+      const task = await createTask(makeMessage("go"));
+      await claimA2ATaskForProcessing(task.id);
+
+      const ok = await failStuckA2ATask(
+        task.id,
+        Date.now() + 60_000,
+        "processor timed out",
+      );
+      expect(ok).toBe(true);
+      const loaded = await getTask(task.id);
+      expect(loaded!.status.state).toBe("failed");
+      expect(loaded!.status.message).toEqual({
+        role: "agent",
+        parts: [{ type: "text", text: "processor timed out" }],
+      });
+    });
+
+    it("does NOT fail a task touched after the cutoff", async () => {
+      const { createTask, claimA2ATaskForProcessing, failStuckA2ATask } =
+        await loadStore();
+      const task = await createTask(makeMessage("go"));
+      await claimA2ATaskForProcessing(task.id);
+      expect(await failStuckA2ATask(task.id, Date.now() - 60_000, "nope")).toBe(
+        false,
+      );
+    });
+
+    it("does NOT fail a task that is not processing", async () => {
+      const { createTask, failStuckA2ATask } = await loadStore();
+      const task = await createTask(makeMessage("go")); // submitted
+      expect(await failStuckA2ATask(task.id, Date.now() + 60_000, "nope")).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("updateTaskStatusMessage", () => {
+    it("updates the status message while the task is in-flight", async () => {
+      const { createTask, updateTaskStatusMessage, getTask } =
+        await loadStore();
+      const task = await createTask(makeMessage("go"));
+      const progress = makeMessage("halfway", "agent");
+
+      await updateTaskStatusMessage(task.id, progress);
+      const loaded = await getTask(task.id);
+      expect(loaded!.status.message).toEqual(progress);
+      // State itself is untouched — only the message/timestamp move.
+      expect(loaded!.status.state).toBe("submitted");
+    });
+
+    it("is a no-op once the task has reached a terminal state", async () => {
+      const { createTask, updateTask, updateTaskStatusMessage, getTask } =
+        await loadStore();
+      const task = await createTask(makeMessage("go"));
+      await updateTask(task.id, { state: "completed" });
+
+      await updateTaskStatusMessage(task.id, makeMessage("late note", "agent"));
+      const loaded = await getTask(task.id);
+      // Gated by `status_state IN ('submitted','working','processing')`, so a
+      // completed task keeps its original (empty) status message.
+      expect(loaded!.status.message).toBeUndefined();
+    });
+  });
+
+  describe("listTasks ordering", () => {
+    it("orders tasks by created_at descending (newest first)", async () => {
+      const { createTask, listTasks } = await loadStore();
+      const oldest = await createTask(makeMessage("a"));
+      const middle = await createTask(makeMessage("b"));
+      const newest = await createTask(makeMessage("c"));
+
+      // createTask stamps all three with the same Date.now() millisecond, which
+      // would make the DESC ordering untestable. Rewrite created_at to distinct,
+      // out-of-insertion-order values so the ORDER BY clause is actually
+      // exercised rather than incidentally satisfied by insertion order.
+      await dbExec.execute({
+        sql: `UPDATE a2a_tasks SET created_at = ? WHERE id = ?`,
+        args: [1000, oldest.id],
+      });
+      await dbExec.execute({
+        sql: `UPDATE a2a_tasks SET created_at = ? WHERE id = ?`,
+        args: [2000, middle.id],
+      });
+      await dbExec.execute({
+        sql: `UPDATE a2a_tasks SET created_at = ? WHERE id = ?`,
+        args: [3000, newest.id],
+      });
+
+      const ids = (await listTasks()).map((t) => t.id);
+      expect(ids).toEqual([newest.id, middle.id, oldest.id]);
+    });
+
+    it("scopes a context listing to that context only", async () => {
+      const { createTask, listTasks } = await loadStore();
+      await createTask(makeMessage("a"), "ctx-1");
+      await createTask(makeMessage("b"), "ctx-2");
+      await createTask(makeMessage("c"), "ctx-1");
+
+      const scoped = await listTasks("ctx-1");
+      expect(scoped).toHaveLength(2);
+      expect(scoped.every((t) => t.contextId === "ctx-1")).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/action.spec.ts
+++ b/packages/core/src/action.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { defineAction } from "./action.js";
+import { z } from "zod";
+import {
+  defineAction,
+  AgentActionStopError,
+  isAgentActionStopError,
+} from "./action.js";
 
 // Uses the legacy `parameters` mode so we don't need to pull in zod as a test
 // dep — the readOnly inference logic is independent of the schema path.
@@ -105,5 +110,255 @@ describe("defineAction", () => {
       run: async () => "ok",
     } as any);
     expect(action.mcpApp).toBeUndefined();
+  });
+
+  it("drops malformed publicAgent / link / mcpApp config that is wrong-typed", () => {
+    const action = defineAction({
+      description: "wrong-typed metadata",
+      parameters: {},
+      // arrays and non-functions must be rejected, not threaded through
+      publicAgent: ["expose"] as any,
+      link: "not-a-function" as any,
+      mcpApp: { resource: [] } as any,
+      run: async () => "ok",
+    } as any);
+    expect(action.publicAgent).toBeUndefined();
+    expect(action.link).toBeUndefined();
+    expect(action.mcpApp).toBeUndefined();
+  });
+
+  it("threads through a valid link builder, publicAgent, and toolCallable=false", () => {
+    const link = ({ result }: { args: any; result: any }) => ({
+      url: `/_agent-native/open?id=${result.id}`,
+      label: "Open",
+    });
+    const action = defineAction({
+      description: "admin op",
+      parameters: { id: { type: "string" } },
+      toolCallable: false,
+      publicAgent: { expose: true, readOnly: false },
+      link,
+      run: async () => ({ id: "abc" }),
+    });
+    expect(action.toolCallable).toBe(false);
+    expect(action.publicAgent).toEqual({ expose: true, readOnly: false });
+    expect(action.link).toBe(link);
+    expect(action.link({ args: {}, result: { id: "abc" } })).toEqual({
+      url: "/_agent-native/open?id=abc",
+      label: "Open",
+    });
+  });
+
+  it("omits http from the entry when http is not specified", () => {
+    const action = defineAction({
+      description: "no http",
+      parameters: {},
+      run: async () => "ok",
+    });
+    expect("http" in action).toBe(false);
+  });
+
+  it("preserves http:false so the entry stays agent-only", () => {
+    const action = defineAction({
+      description: "agent-only",
+      parameters: {},
+      http: false,
+      run: async () => "ok",
+    });
+    expect(action.http).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema mode — JSON Schema conversion for the Claude API tool definition.
+// ---------------------------------------------------------------------------
+describe("defineAction schema mode — tool parameter JSON Schema", () => {
+  it("converts a zod object into a JSON Schema with required vs optional fields", () => {
+    const action = defineAction({
+      description: "create form",
+      schema: z.object({
+        title: z.string().describe("Form title"),
+        status: z.enum(["draft", "published", "closed"]).default("draft"),
+        maxResponses: z.number().int().optional(),
+      }),
+      run: async () => "ok",
+    });
+
+    const params = action.tool.parameters;
+    expect(params.type).toBe("object");
+    expect(params.properties.title).toMatchObject({ type: "string" });
+    // status has a default → must NOT be required; optional field also not required.
+    expect(params.required).toEqual(["title"]);
+    // enum values surface as a string enum.
+    expect(params.properties.status.enum).toEqual([
+      "draft",
+      "published",
+      "closed",
+    ]);
+    // description from .describe() is carried through.
+    expect(params.properties.title.description).toBe("Form title");
+  });
+
+  it("strips the $schema key so the Claude API (draft 2020-12) does not reject it", () => {
+    const action = defineAction({
+      description: "with schema key",
+      schema: z.object({ x: z.string() }),
+      run: async () => "ok",
+    });
+    expect("$schema" in (action.tool.parameters as any)).toBe(false);
+  });
+
+  it("stores the original schema on the entry for downstream re-validation", () => {
+    const schema = z.object({ x: z.string() });
+    const action = defineAction({
+      description: "keeps schema",
+      schema,
+      run: async () => "ok",
+    });
+    expect(action.schema).toBe(schema);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime validation wrapper — the most important behavior: invalid agent
+// input is rejected with a self-correcting error and never reaches run().
+// ---------------------------------------------------------------------------
+describe("defineAction schema mode — runtime validation wrapper", () => {
+  it("passes validated + coerced args to run() on success", async () => {
+    let received: unknown;
+    const action = defineAction({
+      description: "echo",
+      schema: z.object({
+        title: z.string(),
+        status: z.enum(["a", "b"]).default("a"),
+      }),
+      run: async (args: { title: string; status: string }) => {
+        received = args;
+        return "done";
+      },
+    });
+
+    const out = await action.run({ title: "Hi" });
+    expect(out).toBe("done");
+    // Default applied by the schema before reaching run().
+    expect(received).toEqual({ title: "Hi", status: "a" });
+  });
+
+  it("never invokes run() when validation fails", async () => {
+    let ran = false;
+    const action = defineAction({
+      description: "guarded",
+      schema: z.object({ title: z.string() }),
+      run: async () => {
+        ran = true;
+        return "should not happen";
+      },
+    });
+
+    await expect(action.run({})).rejects.toThrow(/Invalid action parameters/);
+    expect(ran).toBe(false);
+  });
+
+  it("formats missing required fields as a 'Missing required parameter' message", async () => {
+    const action = defineAction({
+      description: "needs two",
+      schema: z.object({ title: z.string(), body: z.string() }),
+      run: async () => "ok",
+    });
+
+    await expect(action.run({})).rejects.toThrow(
+      /Missing required parameters: title, body/,
+    );
+  });
+
+  it("echoes the received args and the expected signature so the agent can self-correct", async () => {
+    const action = defineAction({
+      description: "signature",
+      schema: z.object({
+        deckId: z.string(),
+        slideId: z.string().optional(),
+      }),
+      run: async () => "ok",
+    });
+
+    let message = "";
+    try {
+      await action.run({ slideId: "s1" });
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    // Echoes what was actually passed…
+    expect(message).toContain('Received: {"slideId":"s1"}');
+    // …and the expected signature with required (*) / optional (?) markers.
+    expect(message).toContain("deckId*: string");
+    expect(message).toContain("slideId?: string");
+    expect(message).toContain("* = required, ? = optional");
+  });
+
+  it("reports non-missing validation errors (wrong type) distinctly", async () => {
+    const action = defineAction({
+      description: "typed",
+      schema: z.object({ count: z.number() }),
+      run: async () => "ok",
+    });
+
+    let message = "";
+    try {
+      await action.run({ count: "not-a-number" });
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    // A wrong-type error is NOT classified as "missing".
+    expect(message).not.toMatch(/Missing required parameter/);
+    expect(message).toContain("count");
+  });
+
+  it("truncates an oversized received-args echo to keep tool results compact", async () => {
+    const action = defineAction({
+      description: "big",
+      schema: z.object({ required: z.string() }),
+      run: async () => "ok",
+    });
+
+    const huge = { extra: "x".repeat(2000) };
+    let message = "";
+    try {
+      await action.run(huge as any);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    // The truncation ellipsis is appended; the full 2000-char blob is not echoed.
+    expect(message).toContain("…");
+    expect(message.length).toBeLessThan(1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentActionStopError — the stop-the-turn signal used by actions.
+// ---------------------------------------------------------------------------
+describe("AgentActionStopError", () => {
+  it("carries the stop marker, errorCode, and toolResult", () => {
+    const err = new AgentActionStopError("nothing more to do", {
+      errorCode: "DONE",
+      toolResult: "Stopped.",
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("AgentActionStopError");
+    expect(err.agentNativeStop).toBe(true);
+    expect(err.errorCode).toBe("DONE");
+    expect(err.toolResult).toBe("Stopped.");
+  });
+
+  it("isAgentActionStopError recognizes real instances and duck-typed objects", () => {
+    expect(isAgentActionStopError(new AgentActionStopError("x"))).toBe(true);
+    // Duck-typed (e.g. structured-cloned across a worker boundary).
+    expect(isAgentActionStopError({ agentNativeStop: true })).toBe(true);
+  });
+
+  it("isAgentActionStopError rejects ordinary errors and non-objects", () => {
+    expect(isAgentActionStopError(new Error("boom"))).toBe(false);
+    expect(isAgentActionStopError({ agentNativeStop: false })).toBe(false);
+    expect(isAgentActionStopError(null)).toBe(false);
+    expect(isAgentActionStopError("agentNativeStop")).toBe(false);
   });
 });

--- a/packages/core/src/agent/app-model-defaults.spec.ts
+++ b/packages/core/src/agent/app-model-defaults.spec.ts
@@ -1,0 +1,369 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory settings store so we can assert org/user scoping isolation.
+const orgStore = new Map<string, Record<string, unknown>>();
+const userStore = new Map<string, Record<string, unknown>>();
+
+function orgK(orgId: string, key: string) {
+  return `${orgId}::${key}`;
+}
+function userK(email: string, key: string) {
+  return `${email}::${key}`;
+}
+
+vi.mock("../settings/index.js", () => ({
+  getOrgSetting: vi.fn(async (orgId: string, key: string) =>
+    orgStore.has(orgK(orgId, key)) ? orgStore.get(orgK(orgId, key))! : null,
+  ),
+  putOrgSetting: vi.fn(
+    async (orgId: string, key: string, value: Record<string, unknown>) => {
+      orgStore.set(orgK(orgId, key), value);
+    },
+  ),
+  deleteOrgSetting: vi.fn(async (orgId: string, key: string) =>
+    orgStore.delete(orgK(orgId, key)),
+  ),
+  getUserSetting: vi.fn(async (email: string, key: string) =>
+    userStore.has(userK(email, key)) ? userStore.get(userK(email, key))! : null,
+  ),
+  putUserSetting: vi.fn(
+    async (email: string, key: string, value: Record<string, unknown>) => {
+      userStore.set(userK(email, key), value);
+    },
+  ),
+  deleteUserSetting: vi.fn(async (email: string, key: string) =>
+    userStore.delete(userK(email, key)),
+  ),
+}));
+
+let roleRows: Array<{ role: string }> = [];
+let roleQueryThrows = false;
+const execute = vi.fn(async () => {
+  if (roleQueryThrows) throw new Error("db down");
+  return { rows: roleRows, rowsAffected: 0 };
+});
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => ({ execute }),
+  isPostgres: () => false,
+}));
+
+// Request-context resolver values for getAgentAppModelDefaultForCurrentRequest.
+let requestUserEmail: string | undefined;
+let requestOrgId: string | undefined;
+vi.mock("../server/request-context.js", () => ({
+  getRequestUserEmail: () => requestUserEmail,
+  getRequestOrgId: () => requestOrgId,
+}));
+
+const {
+  AGENT_APP_MODEL_DEFAULT_KEY_PREFIX,
+  normalizeAgentAppModelDefaultAppId,
+  agentAppModelDefaultSettingsKey,
+  readAgentAppModelDefaultSettings,
+  writeAgentAppModelDefaultSettings,
+  resetAgentAppModelDefaultSettings,
+  canUpdateAgentAppModelDefaultSettings,
+  getAgentAppModelDefaultForCurrentRequest,
+} = await import("./app-model-defaults.js");
+
+beforeEach(() => {
+  orgStore.clear();
+  userStore.clear();
+  roleRows = [];
+  roleQueryThrows = false;
+  requestUserEmail = undefined;
+  requestOrgId = undefined;
+  execute.mockClear();
+});
+
+describe("normalizeAgentAppModelDefaultAppId", () => {
+  it("trims and lower-cases valid slugs", () => {
+    expect(normalizeAgentAppModelDefaultAppId("  Mail  ")).toBe("mail");
+    expect(normalizeAgentAppModelDefaultAppId("my-app-2")).toBe("my-app-2");
+  });
+
+  it("rejects empty, nullish, and structurally invalid ids", () => {
+    expect(normalizeAgentAppModelDefaultAppId(null)).toBeNull();
+    expect(normalizeAgentAppModelDefaultAppId(undefined)).toBeNull();
+    expect(normalizeAgentAppModelDefaultAppId("")).toBeNull();
+    expect(normalizeAgentAppModelDefaultAppId("   ")).toBeNull();
+    // Must start with a letter.
+    expect(normalizeAgentAppModelDefaultAppId("2cool")).toBeNull();
+    expect(normalizeAgentAppModelDefaultAppId("-leading")).toBeNull();
+    // No underscores, spaces, dots, or other punctuation.
+    expect(normalizeAgentAppModelDefaultAppId("my_app")).toBeNull();
+    expect(normalizeAgentAppModelDefaultAppId("a b")).toBeNull();
+    expect(normalizeAgentAppModelDefaultAppId("a.b")).toBeNull();
+  });
+
+  it("builds a namespaced settings key", () => {
+    expect(agentAppModelDefaultSettingsKey("mail")).toBe(
+      `${AGENT_APP_MODEL_DEFAULT_KEY_PREFIX}:mail`,
+    );
+  });
+});
+
+describe("readAgentAppModelDefaultSettings", () => {
+  it("throws on an invalid appId", async () => {
+    await expect(
+      readAgentAppModelDefaultSettings({ orgId: "org1" }, "bad id"),
+    ).rejects.toThrow(/valid appId/);
+  });
+
+  it("returns empty default scope when unauthenticated and nothing stored", async () => {
+    const s = await readAgentAppModelDefaultSettings({}, "mail");
+    expect(s).toEqual({
+      appId: "mail",
+      engine: null,
+      model: null,
+      scope: "default",
+      source: "default",
+    });
+  });
+
+  it("reads org scope and ignores a user value for the same app", async () => {
+    orgStore.set(orgK("org1", agentAppModelDefaultSettingsKey("mail")), {
+      engine: "builder",
+      model: "claude-sonnet-4-6",
+      updatedAt: 123,
+      updatedBy: "boss@x.com",
+    });
+    userStore.set(userK("a@b.com", agentAppModelDefaultSettingsKey("mail")), {
+      engine: "anthropic",
+      model: "should-not-win",
+    });
+    const s = await readAgentAppModelDefaultSettings(
+      { orgId: "org1", userEmail: "a@b.com" },
+      "mail",
+    );
+    expect(s.scope).toBe("org");
+    expect(s.source).toBe("org");
+    expect(s.engine).toBe("builder");
+    expect(s.model).toBe("claude-sonnet-4-6");
+    expect(s.updatedAt).toBe(123);
+    expect(s.updatedBy).toBe("boss@x.com");
+  });
+
+  it("reads user scope when no org and normalizes the appId casing for the key", async () => {
+    userStore.set(userK("a@b.com", agentAppModelDefaultSettingsKey("mail")), {
+      engine: "anthropic",
+      model: "claude-opus-4-7",
+    });
+    const s = await readAgentAppModelDefaultSettings(
+      { userEmail: "a@b.com" },
+      "MAIL",
+    );
+    expect(s.scope).toBe("user");
+    expect(s.source).toBe("user");
+    expect(s.engine).toBe("anthropic");
+    expect(s.appId).toBe("mail");
+  });
+
+  it("treats a stored row missing engine or model as empty (parse guard)", async () => {
+    orgStore.set(orgK("org1", agentAppModelDefaultSettingsKey("mail")), {
+      engine: "  ",
+      model: "x",
+    });
+    const s = await readAgentAppModelDefaultSettings({ orgId: "org1" }, "mail");
+    expect(s.engine).toBeNull();
+    expect(s.model).toBeNull();
+    expect(s.source).toBe("default");
+    // Scope still reflects where we looked.
+    expect(s.scope).toBe("org");
+  });
+
+  it("drops a non-finite updatedAt and a non-string updatedBy", async () => {
+    orgStore.set(orgK("org1", agentAppModelDefaultSettingsKey("mail")), {
+      engine: "builder",
+      model: "m",
+      updatedAt: Number.NaN,
+      updatedBy: 42,
+    });
+    const s = await readAgentAppModelDefaultSettings({ orgId: "org1" }, "mail");
+    expect(s.updatedAt).toBeUndefined();
+    expect(s.updatedBy).toBeUndefined();
+  });
+});
+
+describe("writeAgentAppModelDefaultSettings", () => {
+  it("persists org selection with a timestamp and updatedBy", async () => {
+    const before = Date.now();
+    const s = await writeAgentAppModelDefaultSettings(
+      { orgId: "org1" },
+      "mail",
+      {
+        engine: " builder ",
+        model: " claude-sonnet-4-6 ",
+        updatedBy: "u@x.com",
+      },
+    );
+    expect(s.engine).toBe("builder");
+    expect(s.model).toBe("claude-sonnet-4-6");
+    const stored = orgStore.get(
+      orgK("org1", agentAppModelDefaultSettingsKey("mail")),
+    )!;
+    expect(stored.engine).toBe("builder");
+    expect(stored.model).toBe("claude-sonnet-4-6");
+    expect(stored.updatedBy).toBe("u@x.com");
+    expect(typeof stored.updatedAt).toBe("number");
+    expect(stored.updatedAt as number).toBeGreaterThanOrEqual(before);
+  });
+
+  it("omits updatedBy when not supplied", async () => {
+    await writeAgentAppModelDefaultSettings({ userEmail: "a@b.com" }, "mail", {
+      engine: "anthropic",
+      model: "claude-opus-4-7",
+    });
+    const stored = userStore.get(
+      userK("a@b.com", agentAppModelDefaultSettingsKey("mail")),
+    )!;
+    expect("updatedBy" in stored).toBe(false);
+  });
+
+  it("rejects blank engine or model after trimming", async () => {
+    await expect(
+      writeAgentAppModelDefaultSettings({ orgId: "org1" }, "mail", {
+        engine: "   ",
+        model: "m",
+      }),
+    ).rejects.toThrow(/engine is required/);
+    await expect(
+      writeAgentAppModelDefaultSettings({ orgId: "org1" }, "mail", {
+        engine: "builder",
+        model: "  ",
+      }),
+    ).rejects.toThrow(/model is required/);
+    expect(orgStore.size).toBe(0);
+  });
+
+  it("rejects an invalid appId", async () => {
+    await expect(
+      writeAgentAppModelDefaultSettings({ orgId: "org1" }, "bad id", {
+        engine: "builder",
+        model: "m",
+      }),
+    ).rejects.toThrow(/valid appId/);
+  });
+
+  it("requires authentication when neither org nor user is present", async () => {
+    await expect(
+      writeAgentAppModelDefaultSettings({}, "mail", {
+        engine: "builder",
+        model: "m",
+      }),
+    ).rejects.toThrow(/Authentication required/);
+  });
+});
+
+describe("resetAgentAppModelDefaultSettings", () => {
+  it("clears the org selection and returns empty", async () => {
+    orgStore.set(orgK("org1", agentAppModelDefaultSettingsKey("mail")), {
+      engine: "builder",
+      model: "m",
+    });
+    const s = await resetAgentAppModelDefaultSettings(
+      { orgId: "org1" },
+      "mail",
+    );
+    expect(orgStore.size).toBe(0);
+    expect(s.engine).toBeNull();
+    expect(s.model).toBeNull();
+  });
+
+  it("clears the user selection when no org is present", async () => {
+    userStore.set(userK("a@b.com", agentAppModelDefaultSettingsKey("mail")), {
+      engine: "anthropic",
+      model: "m",
+    });
+    await resetAgentAppModelDefaultSettings({ userEmail: "a@b.com" }, "mail");
+    expect(userStore.size).toBe(0);
+  });
+
+  it("requires authentication when unauthenticated", async () => {
+    await expect(resetAgentAppModelDefaultSettings({}, "mail")).rejects.toThrow(
+      /Authentication required/,
+    );
+  });
+});
+
+describe("canUpdateAgentAppModelDefaultSettings", () => {
+  it("denies unauthenticated callers", async () => {
+    expect(await canUpdateAgentAppModelDefaultSettings(null, "org1")).toBe(
+      false,
+    );
+  });
+
+  it("allows any signed-in user with no org (personal scope)", async () => {
+    expect(await canUpdateAgentAppModelDefaultSettings("a@b.com", null)).toBe(
+      true,
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("allows org owners and admins and denies plain members", async () => {
+    roleRows = [{ role: "owner" }];
+    expect(await canUpdateAgentAppModelDefaultSettings("a@b.com", "org1")).toBe(
+      true,
+    );
+    roleRows = [{ role: "admin" }];
+    expect(await canUpdateAgentAppModelDefaultSettings("a@b.com", "org1")).toBe(
+      true,
+    );
+    roleRows = [{ role: "member" }];
+    expect(await canUpdateAgentAppModelDefaultSettings("a@b.com", "org1")).toBe(
+      false,
+    );
+  });
+
+  it("denies when no membership row exists for the org", async () => {
+    roleRows = [];
+    expect(await canUpdateAgentAppModelDefaultSettings("a@b.com", "org1")).toBe(
+      false,
+    );
+  });
+
+  it("scopes the membership lookup to the org and a lower-cased email", async () => {
+    roleRows = [{ role: "owner" }];
+    await canUpdateAgentAppModelDefaultSettings("Mixed@Case.COM", "org1");
+    const call = execute.mock.calls.at(-1)![0] as { args: unknown[] };
+    expect(call.args).toEqual(["org1", "mixed@case.com"]);
+  });
+
+  it("fails closed when the membership query throws", async () => {
+    roleQueryThrows = true;
+    expect(await canUpdateAgentAppModelDefaultSettings("a@b.com", "org1")).toBe(
+      false,
+    );
+  });
+});
+
+describe("getAgentAppModelDefaultForCurrentRequest", () => {
+  it("returns null for an invalid appId without touching settings", async () => {
+    expect(await getAgentAppModelDefaultForCurrentRequest("bad id")).toBeNull();
+  });
+
+  it("resolves the org-scoped selection from request context, ignoring the user value", async () => {
+    requestOrgId = "org1";
+    requestUserEmail = "a@b.com";
+    orgStore.set(orgK("org1", agentAppModelDefaultSettingsKey("mail")), {
+      engine: "builder",
+      model: "claude-sonnet-4-6",
+      updatedAt: 1,
+      updatedBy: "boss@x.com",
+    });
+    // A conflicting user-scoped value must NOT leak when an org is in context.
+    userStore.set(userK("a@b.com", agentAppModelDefaultSettingsKey("mail")), {
+      engine: "anthropic",
+      model: "should-not-win",
+    });
+    const sel = await getAgentAppModelDefaultForCurrentRequest("mail");
+    // Only engine + model are returned (no metadata leakage); org wins.
+    expect(sel).toEqual({ engine: "builder", model: "claude-sonnet-4-6" });
+  });
+
+  it("returns null when nothing is stored for the request scope", async () => {
+    requestUserEmail = "a@b.com";
+    expect(await getAgentAppModelDefaultForCurrentRequest("mail")).toBeNull();
+  });
+});

--- a/packages/core/src/agent/engine/builder-gateway-headers.spec.ts
+++ b/packages/core/src/agent/engine/builder-gateway-headers.spec.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Re-import fresh per test so the module-level version cache does not leak
+// between cases (the SHA suffix is computed at call time, but the npm version
+// is cached on first read).
+async function freshModule() {
+  vi.resetModules();
+  return import("./builder-gateway-headers.js");
+}
+
+describe("builder gateway headers", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns the package version with no SHA when no deploy SHA env is set", async () => {
+    vi.stubEnv("VERCEL_GIT_COMMIT_SHA", "");
+    vi.stubEnv("AGENT_NATIVE_BUILD_SHA", "");
+    const { getBuilderGatewayClientVersion, getAgentNativeCorePackageVersion } =
+      await freshModule();
+
+    const version = getBuilderGatewayClientVersion();
+    expect(version).toBe(getAgentNativeCorePackageVersion());
+    // No "+sha" suffix when there is no SHA.
+    expect(version).not.toContain("+");
+  });
+
+  it("appends a 7-char SHA suffix from VERCEL_GIT_COMMIT_SHA", async () => {
+    vi.stubEnv("VERCEL_GIT_COMMIT_SHA", "abcdef1234567890");
+    vi.stubEnv("AGENT_NATIVE_BUILD_SHA", "");
+    const { getBuilderGatewayClientVersion, getAgentNativeCorePackageVersion } =
+      await freshModule();
+
+    const base = getAgentNativeCorePackageVersion();
+    expect(getBuilderGatewayClientVersion()).toBe(`${base}+abcdef1`);
+  });
+
+  it("prefers VERCEL_GIT_COMMIT_SHA over AGENT_NATIVE_BUILD_SHA", async () => {
+    vi.stubEnv("VERCEL_GIT_COMMIT_SHA", "1111111aaaa");
+    vi.stubEnv("AGENT_NATIVE_BUILD_SHA", "2222222bbbb");
+    const { getBuilderGatewayClientVersion, getAgentNativeCorePackageVersion } =
+      await freshModule();
+
+    const base = getAgentNativeCorePackageVersion();
+    expect(getBuilderGatewayClientVersion()).toBe(`${base}+1111111`);
+  });
+
+  it("falls back to AGENT_NATIVE_BUILD_SHA when Vercel SHA is absent", async () => {
+    vi.stubEnv("VERCEL_GIT_COMMIT_SHA", "");
+    vi.stubEnv("AGENT_NATIVE_BUILD_SHA", "deadbeefcafe");
+    const { getBuilderGatewayClientVersion, getAgentNativeCorePackageVersion } =
+      await freshModule();
+
+    const base = getAgentNativeCorePackageVersion();
+    expect(getBuilderGatewayClientVersion()).toBe(`${base}+deadbee`);
+  });
+
+  it("ignores a too-short SHA (< 7 chars) and emits only the version", async () => {
+    vi.stubEnv("VERCEL_GIT_COMMIT_SHA", "abc123");
+    vi.stubEnv("AGENT_NATIVE_BUILD_SHA", "");
+    const { getBuilderGatewayClientVersion, getAgentNativeCorePackageVersion } =
+      await freshModule();
+
+    expect(getBuilderGatewayClientVersion()).toBe(
+      getAgentNativeCorePackageVersion(),
+    );
+  });
+
+  it("trims whitespace around the SHA before measuring length", async () => {
+    vi.stubEnv("VERCEL_GIT_COMMIT_SHA", "   fedcba9   ");
+    vi.stubEnv("AGENT_NATIVE_BUILD_SHA", "");
+    const { getBuilderGatewayClientVersion, getAgentNativeCorePackageVersion } =
+      await freshModule();
+
+    const base = getAgentNativeCorePackageVersion();
+    expect(getBuilderGatewayClientVersion()).toBe(`${base}+fedcba9`);
+  });
+
+  it("builds stable attribution headers carrying the client version", async () => {
+    vi.stubEnv("VERCEL_GIT_COMMIT_SHA", "");
+    vi.stubEnv("AGENT_NATIVE_BUILD_SHA", "");
+    const { getBuilderGatewayRequestHeaders, getBuilderGatewayClientVersion } =
+      await freshModule();
+
+    const headers = getBuilderGatewayRequestHeaders();
+    expect(headers["x-client-name"]).toBe("@agent-native/core");
+    expect(headers["x-client-version"]).toBe(getBuilderGatewayClientVersion());
+  });
+
+  it("caches the resolved package version across calls", async () => {
+    const { getAgentNativeCorePackageVersion } = await freshModule();
+    const first = getAgentNativeCorePackageVersion();
+    expect(getAgentNativeCorePackageVersion()).toBe(first);
+    expect(typeof first).toBe("string");
+    expect(first.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/agent/engine/provider-env-vars.spec.ts
+++ b/packages/core/src/agent/engine/provider-env-vars.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  PROVIDER_ENV_META,
+  PROVIDER_ENV_PLACEHOLDERS,
+  PROVIDER_ENV_VARS,
+  PROVIDER_TO_ENV,
+} from "./provider-env-vars.js";
+
+describe("provider env var maps", () => {
+  it("derives PROVIDER_TO_ENV from each provider's envVar", () => {
+    expect(PROVIDER_TO_ENV.anthropic).toBe("ANTHROPIC_API_KEY");
+    expect(PROVIDER_TO_ENV.openai).toBe("OPENAI_API_KEY");
+    expect(PROVIDER_TO_ENV.google).toBe("GOOGLE_GENERATIVE_AI_API_KEY");
+
+    // Keys mirror the meta exactly, values mirror each meta's envVar.
+    expect(Object.keys(PROVIDER_TO_ENV).sort()).toEqual(
+      Object.keys(PROVIDER_ENV_META).sort(),
+    );
+    for (const [provider, meta] of Object.entries(PROVIDER_ENV_META)) {
+      expect(PROVIDER_TO_ENV[provider]).toBe(meta.envVar);
+    }
+  });
+
+  it("lists exactly the distinct env var names with no duplicates", () => {
+    const expected = Object.values(PROVIDER_ENV_META).map((m) => m.envVar);
+    expect([...PROVIDER_ENV_VARS]).toEqual(expected);
+    // Each provider has a unique env var so no UI gate collisions occur.
+    expect(new Set(PROVIDER_ENV_VARS).size).toBe(PROVIDER_ENV_VARS.length);
+  });
+
+  it("keys placeholders by env var (not provider name) for the key form", () => {
+    expect(PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_API_KEY).toBe("sk-ant-...");
+    expect(PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY).toBe("sk-...");
+    expect(PROVIDER_ENV_PLACEHOLDERS.OPENROUTER_API_KEY).toBe("sk-or-...");
+
+    // Provider names must NOT be valid keys — only env vars are.
+    expect(PROVIDER_ENV_PLACEHOLDERS.anthropic).toBeUndefined();
+    expect(Object.keys(PROVIDER_ENV_PLACEHOLDERS).sort()).toEqual(
+      [...PROVIDER_ENV_VARS].sort(),
+    );
+  });
+});

--- a/packages/core/src/agent/loop-settings.spec.ts
+++ b/packages/core/src/agent/loop-settings.spec.ts
@@ -1,0 +1,315 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory settings store keyed by the helper + scope id, so we can assert
+// org/user isolation without a real DB.
+const orgStore = new Map<string, Record<string, unknown>>();
+const userStore = new Map<string, Record<string, unknown>>();
+
+function orgK(orgId: string, key: string) {
+  return `${orgId}::${key}`;
+}
+function userK(email: string, key: string) {
+  return `${email}::${key}`;
+}
+
+vi.mock("../settings/index.js", () => ({
+  getOrgSetting: vi.fn(async (orgId: string, key: string) =>
+    orgStore.has(orgK(orgId, key)) ? orgStore.get(orgK(orgId, key))! : null,
+  ),
+  putOrgSetting: vi.fn(
+    async (orgId: string, key: string, value: Record<string, unknown>) => {
+      orgStore.set(orgK(orgId, key), value);
+    },
+  ),
+  deleteOrgSetting: vi.fn(async (orgId: string, key: string) =>
+    orgStore.delete(orgK(orgId, key)),
+  ),
+  getUserSetting: vi.fn(async (email: string, key: string) =>
+    userStore.has(userK(email, key)) ? userStore.get(userK(email, key))! : null,
+  ),
+  putUserSetting: vi.fn(
+    async (email: string, key: string, value: Record<string, unknown>) => {
+      userStore.set(userK(email, key), value);
+    },
+  ),
+  deleteUserSetting: vi.fn(async (email: string, key: string) =>
+    userStore.delete(userK(email, key)),
+  ),
+}));
+
+// Role lookup for canUpdate; tests set the row to return.
+let roleRows: Array<{ role: string }> = [];
+let roleQueryThrows = false;
+const execute = vi.fn(async (_q: { sql: string; args: unknown[] }) => {
+  if (roleQueryThrows) throw new Error("db down");
+  return { rows: roleRows, rowsAffected: 0 };
+});
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => ({ execute }),
+  isPostgres: () => false,
+}));
+
+const {
+  AGENT_LOOP_SETTINGS_KEY,
+  DEFAULT_AGENT_MAX_ITERATIONS,
+  MIN_AGENT_MAX_ITERATIONS,
+  MAX_AGENT_MAX_ITERATIONS,
+  normalizeMaxIterations,
+  validateMaxIterationsInput,
+  getDefaultMaxIterations,
+  readAgentLoopSettings,
+  writeAgentLoopSettings,
+  resetAgentLoopSettings,
+  canUpdateAgentLoopSettings,
+} = await import("./loop-settings.js");
+
+beforeEach(() => {
+  orgStore.clear();
+  userStore.clear();
+  roleRows = [];
+  roleQueryThrows = false;
+  execute.mockClear();
+  vi.unstubAllEnvs();
+});
+
+describe("normalizeMaxIterations", () => {
+  it("clamps below the minimum up and above the maximum down", () => {
+    expect(normalizeMaxIterations(0)).toBe(MIN_AGENT_MAX_ITERATIONS);
+    expect(normalizeMaxIterations(-50)).toBe(MIN_AGENT_MAX_ITERATIONS);
+    expect(normalizeMaxIterations(99999)).toBe(MAX_AGENT_MAX_ITERATIONS);
+  });
+
+  it("returns valid in-range integers unchanged", () => {
+    expect(normalizeMaxIterations(42)).toBe(42);
+    expect(normalizeMaxIterations(MAX_AGENT_MAX_ITERATIONS)).toBe(
+      MAX_AGENT_MAX_ITERATIONS,
+    );
+  });
+
+  it("parses numeric strings", () => {
+    expect(normalizeMaxIterations("7")).toBe(7);
+  });
+
+  it("falls back when the value is not a finite integer", () => {
+    expect(normalizeMaxIterations(undefined)).toBe(
+      DEFAULT_AGENT_MAX_ITERATIONS,
+    );
+    expect(normalizeMaxIterations("")).toBe(DEFAULT_AGENT_MAX_ITERATIONS);
+    expect(normalizeMaxIterations("abc")).toBe(DEFAULT_AGENT_MAX_ITERATIONS);
+    expect(normalizeMaxIterations(3.5)).toBe(DEFAULT_AGENT_MAX_ITERATIONS);
+    expect(normalizeMaxIterations(NaN)).toBe(DEFAULT_AGENT_MAX_ITERATIONS);
+    expect(normalizeMaxIterations(Infinity)).toBe(DEFAULT_AGENT_MAX_ITERATIONS);
+  });
+
+  it("honors a caller-supplied fallback", () => {
+    expect(normalizeMaxIterations(null, 25)).toBe(25);
+  });
+});
+
+describe("validateMaxIterationsInput", () => {
+  it("accepts in-range integers", () => {
+    expect(validateMaxIterationsInput(50)).toEqual({ ok: true, value: 50 });
+    expect(validateMaxIterationsInput("50")).toEqual({ ok: true, value: 50 });
+  });
+
+  it("rejects non-integers with a clear error", () => {
+    expect(validateMaxIterationsInput(2.5)).toEqual({
+      ok: false,
+      error: "maxIterations must be an integer.",
+    });
+    expect(validateMaxIterationsInput("nope").ok).toBe(false);
+  });
+
+  it("rejects values below the minimum and above the maximum", () => {
+    expect(validateMaxIterationsInput(0)).toEqual({
+      ok: false,
+      error: `maxIterations must be at least ${MIN_AGENT_MAX_ITERATIONS}.`,
+    });
+    expect(validateMaxIterationsInput(MAX_AGENT_MAX_ITERATIONS + 1)).toEqual({
+      ok: false,
+      error: `maxIterations must be at most ${MAX_AGENT_MAX_ITERATIONS}.`,
+    });
+  });
+});
+
+describe("getDefaultMaxIterations env override", () => {
+  it("uses the framework default when AGENT_MAX_ITERATIONS is unset", () => {
+    expect(getDefaultMaxIterations()).toBe(DEFAULT_AGENT_MAX_ITERATIONS);
+  });
+
+  it("reads and clamps the env override", () => {
+    vi.stubEnv("AGENT_MAX_ITERATIONS", "5");
+    expect(getDefaultMaxIterations()).toBe(5);
+    vi.stubEnv("AGENT_MAX_ITERATIONS", "100000");
+    expect(getDefaultMaxIterations()).toBe(MAX_AGENT_MAX_ITERATIONS);
+  });
+
+  it("ignores a non-integer env override", () => {
+    vi.stubEnv("AGENT_MAX_ITERATIONS", "not-a-number");
+    expect(getDefaultMaxIterations()).toBe(DEFAULT_AGENT_MAX_ITERATIONS);
+  });
+});
+
+describe("readAgentLoopSettings scope resolution", () => {
+  it("returns default scope/source when unauthenticated", async () => {
+    const s = await readAgentLoopSettings({});
+    expect(s.scope).toBe("default");
+    expect(s.source).toBe("default");
+    expect(s.maxIterations).toBe(DEFAULT_AGENT_MAX_ITERATIONS);
+    expect(s.minMaxIterations).toBe(MIN_AGENT_MAX_ITERATIONS);
+    expect(s.maxMaxIterations).toBe(MAX_AGENT_MAX_ITERATIONS);
+  });
+
+  it("prefers org scope over user scope when both are present", async () => {
+    orgStore.set(orgK("org1", AGENT_LOOP_SETTINGS_KEY), { maxIterations: 7 });
+    userStore.set(userK("a@b.com", AGENT_LOOP_SETTINGS_KEY), {
+      maxIterations: 999,
+    });
+    const s = await readAgentLoopSettings({
+      orgId: "org1",
+      userEmail: "a@b.com",
+    });
+    expect(s.scope).toBe("org");
+    expect(s.source).toBe("org");
+    expect(s.maxIterations).toBe(7);
+  });
+
+  it("falls to user scope when there is no org", async () => {
+    userStore.set(userK("a@b.com", AGENT_LOOP_SETTINGS_KEY), {
+      maxIterations: 33,
+    });
+    const s = await readAgentLoopSettings({ userEmail: "a@b.com" });
+    expect(s.scope).toBe("user");
+    expect(s.source).toBe("user");
+    expect(s.maxIterations).toBe(33);
+  });
+
+  it("clamps an out-of-range stored value on read", async () => {
+    orgStore.set(orgK("org1", AGENT_LOOP_SETTINGS_KEY), {
+      maxIterations: 1000000,
+    });
+    const s = await readAgentLoopSettings({ orgId: "org1" });
+    expect(s.maxIterations).toBe(MAX_AGENT_MAX_ITERATIONS);
+  });
+
+  it("uses the env default and source=env when stored row lacks maxIterations", async () => {
+    vi.stubEnv("AGENT_MAX_ITERATIONS", "12");
+    orgStore.set(orgK("org1", AGENT_LOOP_SETTINGS_KEY), { unrelated: true });
+    const s = await readAgentLoopSettings({ orgId: "org1" });
+    // No stored maxIterations -> defaultMaxIterations and env source.
+    expect(s.maxIterations).toBe(12);
+    expect(s.defaultMaxIterations).toBe(12);
+    expect(s.source).toBe("env");
+    expect(s.scope).toBe("org");
+  });
+
+  it("keeps source=scope (not env) when a row stores maxIterations even with the env set", async () => {
+    // The stored value wins; source must reflect where it came from, not env.
+    vi.stubEnv("AGENT_MAX_ITERATIONS", "12");
+    orgStore.set(orgK("org1", AGENT_LOOP_SETTINGS_KEY), { maxIterations: 42 });
+    const s = await readAgentLoopSettings({ orgId: "org1" });
+    expect(s.maxIterations).toBe(42);
+    expect(s.source).toBe("org");
+    // The env still informs the surfaced default even though it is not used.
+    expect(s.defaultMaxIterations).toBe(12);
+  });
+});
+
+describe("writeAgentLoopSettings", () => {
+  it("writes org settings and echoes the persisted value", async () => {
+    const s = await writeAgentLoopSettings({ orgId: "org1" }, 80);
+    expect(s.maxIterations).toBe(80);
+    expect(s.scope).toBe("org");
+    expect(orgStore.get(orgK("org1", AGENT_LOOP_SETTINGS_KEY))).toEqual({
+      maxIterations: 80,
+    });
+  });
+
+  it("writes user settings when no org is present", async () => {
+    const s = await writeAgentLoopSettings({ userEmail: "a@b.com" }, 60);
+    expect(s.scope).toBe("user");
+    expect(userStore.get(userK("a@b.com", AGENT_LOOP_SETTINGS_KEY))).toEqual({
+      maxIterations: 60,
+    });
+  });
+
+  it("rejects invalid input before any write", async () => {
+    await expect(writeAgentLoopSettings({ orgId: "org1" }, 0)).rejects.toThrow(
+      /at least/,
+    );
+    expect(orgStore.size).toBe(0);
+  });
+
+  it("requires authentication when neither org nor user is set", async () => {
+    await expect(writeAgentLoopSettings({}, 50)).rejects.toThrow(
+      /Authentication required/,
+    );
+  });
+});
+
+describe("resetAgentLoopSettings", () => {
+  it("deletes the org setting and reverts to the env/default", async () => {
+    orgStore.set(orgK("org1", AGENT_LOOP_SETTINGS_KEY), { maxIterations: 7 });
+    const s = await resetAgentLoopSettings({ orgId: "org1" });
+    expect(orgStore.has(orgK("org1", AGENT_LOOP_SETTINGS_KEY))).toBe(false);
+    expect(s.maxIterations).toBe(DEFAULT_AGENT_MAX_ITERATIONS);
+  });
+
+  it("deletes the user setting when no org is present", async () => {
+    userStore.set(userK("a@b.com", AGENT_LOOP_SETTINGS_KEY), {
+      maxIterations: 7,
+    });
+    await resetAgentLoopSettings({ userEmail: "a@b.com" });
+    expect(userStore.has(userK("a@b.com", AGENT_LOOP_SETTINGS_KEY))).toBe(
+      false,
+    );
+  });
+
+  it("requires authentication when unauthenticated", async () => {
+    await expect(resetAgentLoopSettings({})).rejects.toThrow(
+      /Authentication required/,
+    );
+  });
+});
+
+describe("canUpdateAgentLoopSettings", () => {
+  it("denies unauthenticated callers", async () => {
+    expect(await canUpdateAgentLoopSettings(null, "org1")).toBe(false);
+    expect(await canUpdateAgentLoopSettings(undefined, "org1")).toBe(false);
+  });
+
+  it("allows any signed-in user when there is no org (personal scope)", async () => {
+    expect(await canUpdateAgentLoopSettings("a@b.com", null)).toBe(true);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("allows org owners and admins only", async () => {
+    roleRows = [{ role: "owner" }];
+    expect(await canUpdateAgentLoopSettings("a@b.com", "org1")).toBe(true);
+    roleRows = [{ role: "admin" }];
+    expect(await canUpdateAgentLoopSettings("a@b.com", "org1")).toBe(true);
+  });
+
+  it("denies non-admin org members", async () => {
+    roleRows = [{ role: "member" }];
+    expect(await canUpdateAgentLoopSettings("a@b.com", "org1")).toBe(false);
+  });
+
+  it("denies when the member row is missing", async () => {
+    roleRows = [];
+    expect(await canUpdateAgentLoopSettings("a@b.com", "org1")).toBe(false);
+  });
+
+  it("lower-cases the email in the membership lookup", async () => {
+    roleRows = [{ role: "owner" }];
+    await canUpdateAgentLoopSettings("Mixed@Case.COM", "org1");
+    const call = execute.mock.calls.at(-1)![0] as { args: unknown[] };
+    expect(call.args).toEqual(["org1", "mixed@case.com"]);
+  });
+
+  it("denies (fails closed) when the role query throws", async () => {
+    roleQueryThrows = true;
+    expect(await canUpdateAgentLoopSettings("a@b.com", "org1")).toBe(false);
+  });
+});

--- a/packages/core/src/agent/model-config.spec.ts
+++ b/packages/core/src/agent/model-config.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_MODEL_CONFIG,
+  AI_SDK_MODEL_CONFIG,
+  ANTHROPIC_MODEL_CONFIG,
+  BUILDER_MODEL_CONFIG,
+  DEFAULT_ANTHROPIC_MODEL,
+  DEFAULT_MODEL,
+  DEFAULT_OPENAI_MODEL,
+} from "./model-config.js";
+
+describe("agent model config catalog", () => {
+  it("derives the builder gateway OpenAI id by dot->dash from the OpenAI default", () => {
+    // The framework default bump lives in one place (the OpenAI id); the
+    // builder gateway id is mechanically derived by replacing dots with dashes.
+    const dashed = DEFAULT_OPENAI_MODEL.replace(/\./g, "-");
+    expect(BUILDER_MODEL_CONFIG.supportedModels).toContain(dashed);
+    // Sanity: the derivation actually changes a dotted id.
+    expect(dashed).not.toContain(".");
+    if (DEFAULT_OPENAI_MODEL.includes(".")) {
+      expect(dashed).not.toBe(DEFAULT_OPENAI_MODEL);
+    }
+  });
+
+  it("derives the OpenRouter default as openai/<openai-default>", () => {
+    expect(AI_SDK_MODEL_CONFIG.openrouter.defaultModel).toBe(
+      `openai/${DEFAULT_OPENAI_MODEL}`,
+    );
+    expect(AI_SDK_MODEL_CONFIG.openrouter.supportedModels).toContain(
+      `openai/${DEFAULT_OPENAI_MODEL}`,
+    );
+  });
+
+  it("keeps the builder default in sync with the anthropic default", () => {
+    expect(DEFAULT_MODEL).toBe(BUILDER_MODEL_CONFIG.defaultModel);
+    expect(DEFAULT_MODEL).toBe(DEFAULT_ANTHROPIC_MODEL);
+    expect(ANTHROPIC_MODEL_CONFIG.defaultModel).toBe(DEFAULT_ANTHROPIC_MODEL);
+  });
+
+  it("re-exported constants point at the same catalog objects", () => {
+    expect(BUILDER_MODEL_CONFIG).toBe(AGENT_MODEL_CONFIG.builder);
+    expect(ANTHROPIC_MODEL_CONFIG).toBe(AGENT_MODEL_CONFIG.anthropic);
+    expect(AI_SDK_MODEL_CONFIG).toBe(AGENT_MODEL_CONFIG.aiSdk);
+  });
+
+  it("includes every default model in its own supported list", () => {
+    // Top-level engines.
+    expect(BUILDER_MODEL_CONFIG.supportedModels).toContain(
+      BUILDER_MODEL_CONFIG.defaultModel,
+    );
+    expect(ANTHROPIC_MODEL_CONFIG.supportedModels).toContain(
+      ANTHROPIC_MODEL_CONFIG.defaultModel,
+    );
+
+    // Every ai-sdk provider's default must be selectable.
+    for (const [provider, cfg] of Object.entries(AI_SDK_MODEL_CONFIG)) {
+      expect(
+        cfg.supportedModels,
+        `${provider} default not in supportedModels`,
+      ).toContain(cfg.defaultModel);
+    }
+  });
+
+  it("exposes the expected ai-sdk providers each with a non-empty model list", () => {
+    expect(Object.keys(AI_SDK_MODEL_CONFIG).sort()).toEqual(
+      [
+        "anthropic",
+        "cohere",
+        "google",
+        "groq",
+        "mistral",
+        "ollama",
+        "openai",
+        "openrouter",
+      ].sort(),
+    );
+    for (const cfg of Object.values(AI_SDK_MODEL_CONFIG)) {
+      expect(cfg.supportedModels.length).toBeGreaterThan(0);
+      expect(typeof cfg.defaultModel).toBe("string");
+      expect(cfg.defaultModel.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/core/src/client/auth-redirect-url.spec.ts
+++ b/packages/core/src/client/auth-redirect-url.spec.ts
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { AUTH_REDIRECT_QUERY_PARAM } from "../shared/auth-redirect-url.js";
+import { stripAuthRedirectParamFromUrl } from "./auth-redirect-url.js";
+
+describe("stripAuthRedirectParamFromUrl", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("removes the auth redirect cache-buster while preserving the app URL", () => {
+    window.history.replaceState(
+      { state: "kept" },
+      "",
+      `/assets?view=grid&${AUTH_REDIRECT_QUERY_PARAM}=mpsk10xv&library=brand#top`,
+    );
+
+    stripAuthRedirectParamFromUrl();
+
+    expect(window.history.state).toEqual({ state: "kept" });
+    expect(window.location.pathname).toBe("/assets");
+    expect(window.location.search).toBe("?view=grid&library=brand");
+    expect(window.location.hash).toBe("#top");
+  });
+
+  it("removes the query separator when it was the only param", () => {
+    window.history.replaceState(
+      null,
+      "",
+      `/assets?${AUTH_REDIRECT_QUERY_PARAM}=mpsk10xv#top`,
+    );
+
+    stripAuthRedirectParamFromUrl();
+
+    expect(window.location.pathname).toBe("/assets");
+    expect(window.location.search).toBe("");
+    expect(window.location.hash).toBe("#top");
+  });
+
+  it("leaves unrelated URLs unchanged", () => {
+    window.history.replaceState(null, "", "/assets?view=grid#top");
+
+    stripAuthRedirectParamFromUrl();
+
+    expect(window.location.pathname).toBe("/assets");
+    expect(window.location.search).toBe("?view=grid");
+    expect(window.location.hash).toBe("#top");
+  });
+});

--- a/packages/core/src/client/auth-redirect-url.ts
+++ b/packages/core/src/client/auth-redirect-url.ts
@@ -1,0 +1,23 @@
+import { AUTH_REDIRECT_QUERY_PARAM } from "../shared/auth-redirect-url.js";
+
+function browserWindow(): Window | null {
+  return typeof window === "undefined" ? null : window;
+}
+
+export function stripAuthRedirectParamFromUrl(win = browserWindow()): void {
+  if (!win) return;
+
+  try {
+    const url = new URL(win.location.href);
+    if (!url.searchParams.has(AUTH_REDIRECT_QUERY_PARAM)) return;
+
+    url.searchParams.delete(AUTH_REDIRECT_QUERY_PARAM);
+    win.history.replaceState(
+      win.history.state,
+      "",
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+  } catch {
+    // Cosmetic cleanup only; never block app boot if history/location is odd.
+  }
+}

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -1,6 +1,8 @@
 import { installRouteChunkRecovery } from "./route-chunk-recovery.js";
+import { stripAuthRedirectParamFromUrl } from "./auth-redirect-url.js";
 
 installRouteChunkRecovery();
+stripAuthRedirectParamFromUrl();
 
 export {
   sendToAgentChat,

--- a/packages/core/src/collab/agent-presence.spec.ts
+++ b/packages/core/src/collab/agent-presence.spec.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSearchAndReplace = vi.fn();
+const mockApplyPatchOps = vi.fn();
+
+vi.mock("./ydoc-manager.js", () => ({
+  searchAndReplace: (...args: unknown[]) => mockSearchAndReplace(...args),
+  applyPatchOps: (...args: unknown[]) => mockApplyPatchOps(...args),
+}));
+
+import { getDocAwareness } from "./awareness.js";
+import { AGENT_CLIENT_ID, DEFAULT_AGENT_IDENTITY } from "./agent-identity.js";
+import {
+  agentEnterDocument,
+  agentLeaveDocument,
+  agentUpdateSelection,
+  agentApplyEditsIncrementally,
+  agentApplyPatchesIncrementally,
+} from "./agent-presence.js";
+
+function agentState(docId: string): Record<string, any> | undefined {
+  const entry = getDocAwareness(docId).get(AGENT_CLIENT_ID);
+  return entry ? JSON.parse(entry.state) : undefined;
+}
+
+afterEach(() => {
+  mockSearchAndReplace.mockReset();
+  mockApplyPatchOps.mockReset();
+});
+
+describe("agentEnterDocument / agentLeaveDocument", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sets an awareness entry with the agent identity on enter", () => {
+    const docId = "presence-enter";
+    agentEnterDocument(docId);
+
+    const entry = getDocAwareness(docId).get(AGENT_CLIENT_ID);
+    expect(entry?.clientId).toBe(AGENT_CLIENT_ID);
+    expect(agentState(docId)).toEqual({
+      user: {
+        name: DEFAULT_AGENT_IDENTITY.name,
+        email: DEFAULT_AGENT_IDENTITY.email,
+        color: DEFAULT_AGENT_IDENTITY.color,
+      },
+    });
+
+    agentLeaveDocument(docId);
+  });
+
+  it("merges extra metadata into the awareness state", () => {
+    const docId = "presence-meta";
+    agentEnterDocument(docId, { selection: { trackId: "t1" } });
+    expect(agentState(docId)).toMatchObject({
+      user: { name: DEFAULT_AGENT_IDENTITY.name },
+      selection: { trackId: "t1" },
+    });
+    agentLeaveDocument(docId);
+  });
+
+  it("ref-counts: stays present until the last leave drains the count", () => {
+    const docId = "presence-refcount";
+    agentEnterDocument(docId);
+    agentEnterDocument(docId);
+
+    agentLeaveDocument(docId); // count 2 -> 1, still present
+    expect(getDocAwareness(docId).has(AGENT_CLIENT_ID)).toBe(true);
+
+    agentLeaveDocument(docId); // count 1 -> 0, removed
+    expect(getDocAwareness(docId).has(AGENT_CLIENT_ID)).toBe(false);
+  });
+
+  it("reuses a single heartbeat interval across nested enters", () => {
+    const docId = "presence-heartbeat";
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const before = setIntervalSpy.mock.calls.length;
+
+    agentEnterDocument(docId);
+    agentEnterDocument(docId);
+
+    // Only one interval was created despite two enters.
+    expect(setIntervalSpy.mock.calls.length - before).toBe(1);
+
+    agentLeaveDocument(docId);
+    agentLeaveDocument(docId);
+    setIntervalSpy.mockRestore();
+  });
+
+  it("heartbeat refreshes lastSeen while present", () => {
+    const docId = "presence-tick";
+    vi.setSystemTime(0);
+    agentEnterDocument(docId);
+    expect(getDocAwareness(docId).get(AGENT_CLIENT_ID)?.lastSeen).toBe(0);
+
+    // Advancing past the 10s interval fires the heartbeat, which stamps
+    // lastSeen with Date.now() at fire time (the advanced fake clock).
+    vi.advanceTimersByTime(10_000);
+    expect(getDocAwareness(docId).get(AGENT_CLIENT_ID)?.lastSeen).toBe(10_000);
+
+    agentLeaveDocument(docId);
+  });
+
+  it("leave on a never-entered doc does not throw and leaves no entry", () => {
+    const docId = "presence-never-entered";
+    expect(() => agentLeaveDocument(docId)).not.toThrow();
+    expect(getDocAwareness(docId).has(AGENT_CLIENT_ID)).toBe(false);
+  });
+});
+
+describe("agentUpdateSelection", () => {
+  it("merges selection onto the existing state, preserving user identity", () => {
+    const docId = "presence-select";
+    agentEnterDocument(docId);
+    agentUpdateSelection(docId, { selection: { panel: "left" } });
+
+    expect(agentState(docId)).toMatchObject({
+      user: { name: DEFAULT_AGENT_IDENTITY.name },
+      selection: { panel: "left" },
+    });
+
+    agentLeaveDocument(docId);
+    agentLeaveDocument(docId); // drain both refs (enter + leave symmetry)
+  });
+
+  it("falls back to default identity when there is no existing entry", () => {
+    const docId = "presence-select-fresh";
+    agentUpdateSelection(docId, { selection: { panel: "right" } });
+    expect(agentState(docId)).toEqual({
+      user: {
+        name: DEFAULT_AGENT_IDENTITY.name,
+        email: DEFAULT_AGENT_IDENTITY.email,
+        color: DEFAULT_AGENT_IDENTITY.color,
+      },
+      selection: { panel: "right" },
+    });
+    getDocAwareness(docId).clear();
+  });
+
+  it("recovers from a corrupt stored state by using defaults", () => {
+    const docId = "presence-select-corrupt";
+    getDocAwareness(docId).set(AGENT_CLIENT_ID, {
+      clientId: AGENT_CLIENT_ID,
+      state: "{not valid json",
+      lastSeen: Date.now(),
+    });
+
+    agentUpdateSelection(docId, { selection: { focused: true } });
+    expect(agentState(docId)).toEqual({
+      user: {
+        name: DEFAULT_AGENT_IDENTITY.name,
+        email: DEFAULT_AGENT_IDENTITY.email,
+        color: DEFAULT_AGENT_IDENTITY.color,
+      },
+      selection: { focused: true },
+    });
+    getDocAwareness(docId).clear();
+  });
+});
+
+describe("agentApplyEditsIncrementally", () => {
+  it("enters, applies each edit via searchAndReplace, then leaves", async () => {
+    const docId = "presence-edits";
+    mockSearchAndReplace.mockResolvedValue({
+      found: true,
+      update: new Uint8Array(),
+    });
+
+    await agentApplyEditsIncrementally(
+      docId,
+      [
+        { find: "a", replace: "b" },
+        { find: "c", replace: "d" },
+      ],
+      { delayMs: 0 },
+    );
+
+    expect(mockSearchAndReplace).toHaveBeenCalledTimes(2);
+    expect(mockSearchAndReplace).toHaveBeenNthCalledWith(
+      1,
+      docId,
+      "a",
+      "b",
+      "agent",
+    );
+    expect(mockSearchAndReplace).toHaveBeenNthCalledWith(
+      2,
+      docId,
+      "c",
+      "d",
+      "agent",
+    );
+    // Presence cleaned up after completion.
+    expect(getDocAwareness(docId).has(AGENT_CLIENT_ID)).toBe(false);
+  });
+
+  it("leaves the document even if an edit throws", async () => {
+    const docId = "presence-edits-error";
+    mockSearchAndReplace.mockRejectedValue(new Error("boom"));
+
+    await expect(
+      agentApplyEditsIncrementally(docId, [{ find: "x", replace: "y" }], {
+        delayMs: 0,
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(getDocAwareness(docId).has(AGENT_CLIENT_ID)).toBe(false);
+  });
+});
+
+describe("agentApplyPatchesIncrementally", () => {
+  it("applies each patch via applyPatchOps with the field name and agent origin", async () => {
+    const docId = "presence-patches";
+    mockApplyPatchOps.mockResolvedValue(undefined);
+
+    const patches = [
+      { op: "set", path: "a", value: 1 },
+      { op: "delete", path: "b" },
+    ];
+    await agentApplyPatchesIncrementally(docId, "data", patches, {
+      delayMs: 0,
+    });
+
+    expect(mockApplyPatchOps).toHaveBeenCalledTimes(2);
+    expect(mockApplyPatchOps).toHaveBeenNthCalledWith(
+      1,
+      docId,
+      [patches[0]],
+      "data",
+      "agent",
+    );
+    expect(getDocAwareness(docId).has(AGENT_CLIENT_ID)).toBe(false);
+  });
+
+  it("leaves the document even if a patch throws", async () => {
+    const docId = "presence-patches-error";
+    mockApplyPatchOps.mockRejectedValue(new Error("patch failed"));
+
+    await expect(
+      agentApplyPatchesIncrementally(
+        docId,
+        "data",
+        [{ op: "set", path: "a", value: 1 }],
+        { delayMs: 0 },
+      ),
+    ).rejects.toThrow("patch failed");
+
+    expect(getDocAwareness(docId).has(AGENT_CLIENT_ID)).toBe(false);
+  });
+});

--- a/packages/core/src/collab/awareness.spec.ts
+++ b/packages/core/src/collab/awareness.spec.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// h3 in the source is only used for handler plumbing; stub it so we can drive
+// the handlers with plain fake events and inspect the response status.
+vi.mock("h3", () => ({
+  defineEventHandler: (handler: any) => handler,
+  getRouterParam: (event: any, name: string) => event._params?.[name],
+  setResponseStatus: (event: any, status: number) => {
+    event._status = status;
+  },
+}));
+
+const mockReadBody = vi.fn();
+vi.mock("../server/h3-helpers.js", () => ({
+  readBody: (...args: unknown[]) => mockReadBody(...args),
+}));
+
+import {
+  getDocAwareness,
+  cleanExpired,
+  postAwareness,
+  getActiveUsers,
+  type AwarenessEntry,
+} from "./awareness.js";
+
+function event(params: Record<string, string> = {}) {
+  return { _params: params, _status: 200 } as any;
+}
+
+describe("getDocAwareness", () => {
+  it("returns the same Map instance for a docId on repeated calls", () => {
+    const a = getDocAwareness("doc-shared");
+    const b = getDocAwareness("doc-shared");
+    expect(a).toBe(b);
+  });
+
+  it("isolates state between documents", () => {
+    const a = getDocAwareness("doc-iso-a");
+    const b = getDocAwareness("doc-iso-b");
+    a.set(1, { clientId: 1, state: "s", lastSeen: Date.now() });
+    expect(b.has(1)).toBe(false);
+  });
+});
+
+describe("cleanExpired", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("drops entries older than the 30s timeout, keeps fresh ones", () => {
+    const map = new Map<number, AwarenessEntry>();
+    map.set(1, { clientId: 1, state: "stale", lastSeen: 0 });
+    map.set(2, { clientId: 2, state: "fresh", lastSeen: 20_000 });
+
+    vi.setSystemTime(31_000); // 31s after t=0
+    cleanExpired(map);
+
+    expect(map.has(1)).toBe(false); // 31s old > 30s timeout
+    expect(map.has(2)).toBe(true); // 11s old
+  });
+
+  it("keeps an entry exactly at the boundary (not strictly greater)", () => {
+    const map = new Map<number, AwarenessEntry>();
+    map.set(1, { clientId: 1, state: "edge", lastSeen: 0 });
+    vi.setSystemTime(30_000); // exactly 30s — boundary is not expired
+    cleanExpired(map);
+    expect(map.has(1)).toBe(true);
+  });
+});
+
+describe("postAwareness handler", () => {
+  afterEach(() => {
+    mockReadBody.mockReset();
+    // Clear shared maps used by these tests.
+    getDocAwareness("post-doc").clear();
+  });
+
+  it("returns 400 when docId is missing", async () => {
+    const ev = event({});
+    const res = await postAwareness(ev);
+    expect(ev._status).toBe(400);
+    expect(res).toEqual({ error: "docId required" });
+  });
+
+  it("returns 400 when clientId or state is missing", async () => {
+    mockReadBody.mockResolvedValue({ clientId: 5 }); // no state
+    const ev = event({ docId: "post-doc" });
+    const res = await postAwareness(ev);
+    expect(ev._status).toBe(400);
+    expect(res).toEqual({ error: "clientId and state required" });
+  });
+
+  it("stores the sender's state and returns only other clients' states", async () => {
+    const map = getDocAwareness("post-doc");
+    map.set(99, { clientId: 99, state: "other-state", lastSeen: Date.now() });
+
+    mockReadBody.mockResolvedValue({ clientId: 5, state: "my-state" });
+    const ev = event({ docId: "post-doc" });
+    const res = (await postAwareness(ev)) as {
+      states: Array<{ clientId: number; state: string }>;
+    };
+
+    // Sender stored.
+    expect(map.get(5)?.state).toBe("my-state");
+    // Response excludes the sender (5), includes the peer (99).
+    expect(res.states).toEqual([{ clientId: 99, state: "other-state" }]);
+  });
+
+  it("evicts expired peers before responding", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const map = getDocAwareness("post-doc");
+    map.set(7, { clientId: 7, state: "expired", lastSeen: 0 });
+
+    vi.setSystemTime(40_000);
+    mockReadBody.mockResolvedValue({ clientId: 5, state: "fresh" });
+    const res = (await postAwareness(event({ docId: "post-doc" }))) as {
+      states: Array<{ clientId: number }>;
+    };
+    vi.useRealTimers();
+
+    expect(map.has(7)).toBe(false);
+    expect(res.states).toEqual([]); // peer 7 expired, sender 5 excluded
+  });
+});
+
+describe("getActiveUsers handler", () => {
+  afterEach(() => {
+    getDocAwareness("users-doc").clear();
+  });
+
+  it("returns 400 when docId is missing", async () => {
+    const ev = event({});
+    const res = await getActiveUsers(ev);
+    expect(ev._status).toBe(400);
+    expect(res).toEqual({ error: "docId required" });
+  });
+
+  it("lists active client ids and prunes expired ones", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const map = getDocAwareness("users-doc");
+    map.set(1, { clientId: 1, state: "a", lastSeen: 0 });
+    map.set(2, { clientId: 2, state: "b", lastSeen: 25_000 });
+
+    vi.setSystemTime(40_000);
+    const res = (await getActiveUsers(event({ docId: "users-doc" }))) as {
+      users: Array<{ clientId: number; lastSeen: number }>;
+    };
+    vi.useRealTimers();
+
+    // Client 1 (40s old) pruned; client 2 (15s old) survives.
+    expect(res.users).toEqual([{ clientId: 2, lastSeen: 25_000 }]);
+  });
+});

--- a/packages/core/src/collab/client.spec.ts
+++ b/packages/core/src/collab/client.spec.ts
@@ -1,8 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   dedupeCollabUsersByEmail,
   reconcileRemoteAwarenessStates,
+  emailToColor,
+  emailToName,
+  isReconcileLeadClient,
 } from "./client.js";
+import { AGENT_CLIENT_ID } from "./agent-identity.js";
+
+/** Minimal Awareness stand-in: isReconcileLeadClient only calls getStates(). */
+function fakeAwareness(states: Map<number, unknown>): any {
+  return { getStates: () => states };
+}
 
 describe("dedupeCollabUsersByEmail", () => {
   it("keeps one presence entry per email", () => {
@@ -42,6 +51,26 @@ describe("dedupeCollabUsersByEmail", () => {
       },
     ]);
   });
+
+  it("derives name and color from the email when they are blank", () => {
+    const [user] = dedupeCollabUsersByEmail([
+      { name: "", email: "Kat@Example.com", color: "" },
+    ]);
+    // Email is normalized (lowercased/trimmed); name/color are derived from it.
+    expect(user.email).toBe("kat@example.com");
+    expect(user.name).toBe(emailToName("kat@example.com"));
+    expect(user.color).toBe(emailToColor("kat@example.com"));
+  });
+
+  it("drops entries with an empty email entirely", () => {
+    const users = dedupeCollabUsersByEmail([
+      { name: "Ghost", email: "   ", color: "#fff" },
+      { name: "Real", email: "real@example.com", color: "#000" },
+    ]);
+    expect(users).toEqual([
+      { name: "Real", email: "real@example.com", color: "#000" },
+    ]);
+  });
 });
 
 describe("reconcileRemoteAwarenessStates", () => {
@@ -59,5 +88,157 @@ describe("reconcileRemoteAwarenessStates", () => {
 
     expect(changes).toEqual({ added: [4], updated: [3], removed: [2] });
     expect(Array.from(states.keys())).toEqual([1, 3, 4]);
+  });
+
+  it("ignores non-finite client ids and the local client", () => {
+    const states = new Map<number, unknown>();
+    const changes = reconcileRemoteAwarenessStates(states, 1, [
+      { clientId: 1, state: {} }, // self — skipped
+      { clientId: NaN, state: {} }, // invalid — skipped
+      { clientId: 2, state: { ok: true } },
+    ]);
+    expect(changes).toEqual({ added: [2], updated: [], removed: [] });
+    expect(Array.from(states.keys())).toEqual([2]);
+  });
+
+  it("never removes the local client even when absent from the remote set", () => {
+    const states = new Map<number, unknown>([[1, { self: true }]]);
+    const changes = reconcileRemoteAwarenessStates(states, 1, []);
+    expect(changes).toEqual({ added: [], updated: [], removed: [] });
+    expect(states.has(1)).toBe(true);
+  });
+});
+
+describe("emailToName", () => {
+  it("capitalizes the local part of the email", () => {
+    expect(emailToName("steve@example.com")).toBe("Steve");
+  });
+
+  it("falls back to the whole string when there is no @", () => {
+    expect(emailToName("anonymous")).toBe("Anonymous");
+  });
+
+  it("handles a leading-@ email by using the original string", () => {
+    // local part is "" so it falls back to the full email, then capitalizes.
+    expect(emailToName("@host")).toBe("@host");
+  });
+});
+
+describe("emailToColor", () => {
+  it("is deterministic for the same email", () => {
+    expect(emailToColor("kat@example.com")).toBe(
+      emailToColor("kat@example.com"),
+    );
+  });
+
+  it("always returns a color from the fixed palette", () => {
+    const palette = new Set([
+      "#f87171",
+      "#fb923c",
+      "#fbbf24",
+      "#a3e635",
+      "#34d399",
+      "#22d3ee",
+      "#60a5fa",
+      "#14b8a6",
+      "#f472b6",
+      "#e879f9",
+    ]);
+    for (const email of ["a@b.com", "z@y.com", "long.name@corp.io", ""]) {
+      expect(palette.has(emailToColor(email))).toBe(true);
+    }
+  });
+});
+
+describe("isReconcileLeadClient (CRDT snapshot leader election)", () => {
+  it("returns false when the local client id is null", () => {
+    expect(isReconcileLeadClient(fakeAwareness(new Map()), null)).toBe(false);
+    expect(isReconcileLeadClient(fakeAwareness(new Map()), undefined)).toBe(
+      false,
+    );
+  });
+
+  it("acts alone when there is no awareness instance", () => {
+    expect(isReconcileLeadClient(null, 5)).toBe(true);
+  });
+
+  it("is the sole applier when no real peers are present", () => {
+    // Only the agent and stale (no user) entries — not real peers.
+    const states = new Map<number, unknown>([
+      [AGENT_CLIENT_ID, { user: { name: "AI" } }],
+      [9, { user: undefined }],
+    ]);
+    expect(isReconcileLeadClient(fakeAwareness(states), 100)).toBe(true);
+  });
+
+  it("the agent client id can never be the lead even if lowest", () => {
+    // A visible human peer exists; local IS the agent. Agent must yield.
+    const states = new Map<number, unknown>([
+      [AGENT_CLIENT_ID, { user: { name: "AI" } }],
+      [50, { user: { name: "Human" } }],
+    ]);
+    // Local = agent id (max int) and there is a visible peer (50) lower than it.
+    expect(isReconcileLeadClient(fakeAwareness(states), AGENT_CLIENT_ID)).toBe(
+      false,
+    );
+  });
+
+  it("the lowest-id visible client leads when peers are present", () => {
+    const states = new Map<number, unknown>([
+      [3, { user: { name: "A" } }],
+      [7, { user: { name: "B" } }],
+    ]);
+    // Local 3 is lowest among visible → leads.
+    expect(isReconcileLeadClient(fakeAwareness(states), 3)).toBe(true);
+    // Local 7 is not lowest → yields to 3.
+    expect(isReconcileLeadClient(fakeAwareness(states), 7)).toBe(false);
+  });
+
+  it("skips peers that published visible:false when electing", () => {
+    // Peer 2 is backgrounded (visible:false); only peer 8 is visible.
+    const states = new Map<number, unknown>([
+      [2, { user: { name: "Bg" }, visible: false }],
+      [8, { user: { name: "Fg" } }],
+    ]);
+    // Local 5: lower than the only visible peer (8), so it leads despite the
+    // hidden peer 2 having a lower id.
+    expect(isReconcileLeadClient(fakeAwareness(states), 5)).toBe(true);
+  });
+
+  it("treats a peer without a visible field as visible", () => {
+    const states = new Map<number, unknown>([
+      [1, { user: { name: "Peer" } }], // no visible field → visible
+    ]);
+    // Local 4 is higher than visible peer 1 → yields.
+    expect(isReconcileLeadClient(fakeAwareness(states), 4)).toBe(false);
+  });
+
+  describe("when the local tab is hidden", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("yields leadership to a visible peer even though it would otherwise lead", () => {
+      // Node has no `document`; stub a hidden one so the localHidden branch runs.
+      vi.stubGlobal("document", { visibilityState: "hidden" });
+      const states = new Map<number, unknown>([
+        [3, { user: { name: "Peer" } }],
+      ]);
+      // Local 1 is the lowest id and would normally lead, but its tab is hidden
+      // and a visible peer (3) exists — a backgrounded tab pauses its poll and
+      // must not hold the applier role, or the agent edit never reaches the
+      // visible tab. So it yields.
+      expect(isReconcileLeadClient(fakeAwareness(states), 1)).toBe(false);
+    });
+
+    it("still leads as the sole client even when hidden", () => {
+      vi.stubGlobal("document", { visibilityState: "hidden" });
+      // No real peers → the !hasPeer short-circuit fires before the hidden
+      // check, so a single-user hidden tab still applies its own agent edits.
+      const states = new Map<number, unknown>([
+        [AGENT_CLIENT_ID, { user: { name: "AI" } }],
+      ]);
+      expect(isReconcileLeadClient(fakeAwareness(states), 100)).toBe(true);
+    });
   });
 });

--- a/packages/core/src/collab/json-to-yjs.spec.ts
+++ b/packages/core/src/collab/json-to-yjs.spec.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import {
+  seedYDocFromJson,
+  yMapToJson,
+  yArrayToJson,
+  yDocToJson,
+  applyJsonDiff,
+  applyJsonPatch,
+  initYDocWithJson,
+  type PatchOp,
+} from "./json-to-yjs.js";
+
+describe("seedYDocFromJson / yDocToJson round-trips", () => {
+  it("round-trips a deeply nested mixed object through a Y.Map", () => {
+    const json = {
+      title: "Deck",
+      published: true,
+      count: 3,
+      tags: ["a", "b"],
+      meta: { author: "kat", nested: { deep: [1, { x: "y" }] } },
+      empty: {},
+    };
+    const doc = new Y.Doc();
+    seedYDocFromJson(doc, "data", json, "map");
+
+    // Shared types are materialized as real Yjs containers, not stored verbatim.
+    const ymap = doc.getMap("data");
+    expect(ymap.get("meta")).toBeInstanceOf(Y.Map);
+    expect(ymap.get("tags")).toBeInstanceOf(Y.Array);
+
+    expect(yDocToJson(doc, "data")).toEqual(json);
+  });
+
+  it("round-trips an array of objects through a Y.Array", () => {
+    const json = [
+      { id: "t1", label: "one" },
+      { id: "t2", label: "two", children: [{ id: "c1" }] },
+    ];
+    const doc = new Y.Doc();
+    seedYDocFromJson(doc, "data", json, "array");
+
+    expect(doc.getArray("data").get(0)).toBeInstanceOf(Y.Map);
+    expect(yDocToJson(doc, "data")).toEqual(json);
+  });
+
+  it("preserves null and treats it as a primitive, not a container", () => {
+    const json = { a: null, b: 0, c: "" };
+    const doc = new Y.Doc();
+    seedYDocFromJson(doc, "data", json, "map");
+    const ymap = doc.getMap("data");
+    expect(ymap.get("a")).toBeNull();
+    expect(yMapToJson(ymap)).toEqual(json);
+  });
+
+  it("ignores a type mismatch: array json into a map field seeds nothing", () => {
+    const doc = new Y.Doc();
+    seedYDocFromJson(doc, "data", [1, 2, 3], "map");
+    expect(doc.getMap("data").size).toBe(0);
+    expect(yDocToJson(doc, "data")).toEqual({});
+  });
+
+  it("ignores a type mismatch: object json into an array field seeds nothing", () => {
+    const doc = new Y.Doc();
+    seedYDocFromJson(doc, "data", { a: 1 }, "array");
+    expect(doc.getArray("data").length).toBe(0);
+  });
+
+  it("yDocToJson returns {} for an unknown field", () => {
+    const doc = new Y.Doc();
+    expect(yDocToJson(doc, "missing")).toEqual({});
+  });
+});
+
+describe("yArrayToJson", () => {
+  it("serializes nested arrays preserving order", () => {
+    const doc = new Y.Doc();
+    const yarr = doc.getArray("data");
+    const inner = new Y.Array();
+    inner.push([1, 2]);
+    yarr.push(["x", inner]);
+    expect(yArrayToJson(yarr)).toEqual(["x", [1, 2]]);
+  });
+});
+
+describe("applyJsonDiff on Y.Map", () => {
+  it("sets, changes, and deletes keys with a minimal diff", () => {
+    const doc = new Y.Doc();
+    seedYDocFromJson(
+      doc,
+      "data",
+      { keep: 1, change: "old", drop: true },
+      "map",
+    );
+
+    const update = applyJsonDiff(doc, "data", {
+      keep: 1,
+      change: "new",
+      added: [1, 2],
+    });
+
+    // A real update was produced (non-empty).
+    expect(update.length).toBeGreaterThan(0);
+    expect(yDocToJson(doc, "data")).toEqual({
+      keep: 1,
+      change: "new",
+      added: [1, 2],
+    });
+  });
+
+  it("recurses into nested maps without replacing the container", () => {
+    const doc = new Y.Doc();
+    seedYDocFromJson(doc, "data", { nested: { a: 1, b: 2 } }, "map");
+    const nestedBefore = doc.getMap("data").get("nested");
+
+    applyJsonDiff(doc, "data", { nested: { a: 1, b: 99, c: 3 } });
+
+    // Same container object reused (in-place diff, not replaced).
+    expect(doc.getMap("data").get("nested")).toBe(nestedBefore);
+    expect(yDocToJson(doc, "data")).toEqual({ nested: { a: 1, b: 99, c: 3 } });
+  });
+
+  it("returns an empty update when nothing changed", () => {
+    const doc = new Y.Doc();
+    seedYDocFromJson(doc, "data", { a: 1, nested: { b: 2 } }, "map");
+    const update = applyJsonDiff(doc, "data", { a: 1, nested: { b: 2 } });
+    expect(update.length).toBe(0);
+  });
+
+  it("tags the transaction with the given origin", () => {
+    const doc = new Y.Doc();
+    seedYDocFromJson(doc, "data", { a: 1 }, "map");
+    let seenOrigin: unknown = "unset";
+    doc.on("afterTransaction", (txn) => {
+      seenOrigin = txn.origin;
+    });
+    applyJsonDiff(doc, "data", { a: 2 }, "server");
+    expect(seenOrigin).toBe("server");
+  });
+});
+
+describe("applyJsonDiff on Y.Array by index (no ids)", () => {
+  it("updates in place, appends, and truncates", () => {
+    const doc = new Y.Doc();
+    seedYDocFromJson(doc, "data", [1, 2, 3], "array");
+
+    applyJsonDiff(doc, "data", [1, 20, 3, 4]);
+    expect(yDocToJson(doc, "data")).toEqual([1, 20, 3, 4]);
+
+    applyJsonDiff(doc, "data", [1]);
+    expect(yDocToJson(doc, "data")).toEqual([1]);
+  });
+
+  it("diffs nested object items in place by index", () => {
+    const doc = new Y.Doc();
+    seedYDocFromJson(doc, "data", [{ x: 1 }, { x: 2 }], "array");
+    const firstBefore = doc.getArray("data").get(0);
+
+    applyJsonDiff(doc, "data", [{ x: 1, y: 9 }, { x: 2 }]);
+
+    expect(doc.getArray("data").get(0)).toBe(firstBefore);
+    expect(yDocToJson(doc, "data")).toEqual([{ x: 1, y: 9 }, { x: 2 }]);
+  });
+});
+
+describe("applyJsonDiff on Y.Array by id (stable identity)", () => {
+  it("removes items that disappear, keyed by id", () => {
+    const doc = new Y.Doc();
+    seedYDocFromJson(
+      doc,
+      "data",
+      [
+        { id: "a", v: 1 },
+        { id: "b", v: 2 },
+        { id: "c", v: 3 },
+      ],
+      "array",
+    );
+
+    applyJsonDiff(doc, "data", [
+      { id: "a", v: 1 },
+      { id: "c", v: 3 },
+    ]);
+
+    expect(yDocToJson(doc, "data")).toEqual([
+      { id: "a", v: 1 },
+      { id: "c", v: 3 },
+    ]);
+  });
+
+  it("reorders existing items by id, preserving the moved container's identity", () => {
+    const doc = new Y.Doc();
+    seedYDocFromJson(
+      doc,
+      "data",
+      [
+        { id: "a", v: 1 },
+        { id: "b", v: 2 },
+        { id: "c", v: 3 },
+      ],
+      "array",
+    );
+
+    // Move "c" to the front.
+    applyJsonDiff(doc, "data", [
+      { id: "c", v: 3 },
+      { id: "a", v: 1 },
+      { id: "b", v: 2 },
+    ]);
+
+    expect(yDocToJson(doc, "data")).toEqual([
+      { id: "c", v: 3 },
+      { id: "a", v: 1 },
+      { id: "b", v: 2 },
+    ]);
+  });
+
+  it("inserts brand-new items at their target position and diffs matched ones in place", () => {
+    const doc = new Y.Doc();
+    seedYDocFromJson(
+      doc,
+      "data",
+      [
+        { id: "a", v: 1 },
+        { id: "b", v: 2 },
+      ],
+      "array",
+    );
+    const aBefore = doc.getArray("data").get(0);
+
+    applyJsonDiff(doc, "data", [
+      { id: "a", v: 11 },
+      { id: "x", v: 100 },
+      { id: "b", v: 2 },
+    ]);
+
+    // "a" container reused and mutated in place.
+    expect(doc.getArray("data").get(0)).toBe(aBefore);
+    expect(yDocToJson(doc, "data")).toEqual([
+      { id: "a", v: 11 },
+      { id: "x", v: 100 },
+      { id: "b", v: 2 },
+    ]);
+  });
+
+  it("matches ids that differ only by type (numeric vs string)", () => {
+    const doc = new Y.Doc();
+    seedYDocFromJson(doc, "data", [{ id: 1, v: "old" }], "array");
+    const before = doc.getArray("data").get(0);
+
+    // New json uses a string id "1" — should match the numeric id 1.
+    applyJsonDiff(doc, "data", [{ id: "1", v: "new" }]);
+
+    expect(doc.getArray("data").get(0)).toBe(before);
+    expect(yDocToJson(doc, "data")).toEqual([{ id: "1", v: "new" }]);
+  });
+});
+
+describe("applyJsonPatch", () => {
+  function seededDoc(json: any, type: "map" | "array" = "map"): Y.Doc {
+    const doc = new Y.Doc();
+    seedYDocFromJson(doc, "data", json, type);
+    return doc;
+  }
+
+  it("set replaces a nested map value", () => {
+    const doc = seededDoc({ a: { b: 1 } });
+    const ops: PatchOp[] = [{ op: "set", path: "a/b", value: 42 }];
+    applyJsonPatch(doc, "data", ops);
+    expect(yDocToJson(doc, "data")).toEqual({ a: { b: 42 } });
+  });
+
+  it("set replaces an array element by index", () => {
+    const doc = seededDoc({ list: [10, 20, 30] });
+    applyJsonPatch(doc, "data", [{ op: "set", path: "list/1", value: 99 }]);
+    expect(yDocToJson(doc, "data")).toEqual({ list: [10, 99, 30] });
+  });
+
+  it("set with an out-of-range array index is a no-op", () => {
+    const doc = seededDoc({ list: [1, 2] });
+    applyJsonPatch(doc, "data", [{ op: "set", path: "list/5", value: 9 }]);
+    expect(yDocToJson(doc, "data")).toEqual({ list: [1, 2] });
+  });
+
+  it("insert adds into an array, clamping the index", () => {
+    const doc = seededDoc({ list: [1, 2] });
+    applyJsonPatch(doc, "data", [
+      { op: "insert", path: "list", index: 1, value: 9 },
+      { op: "insert", path: "list", index: 99, value: 5 },
+    ]);
+    expect(yDocToJson(doc, "data")).toEqual({ list: [1, 9, 2, 5] });
+  });
+
+  it("delete removes a map key", () => {
+    const doc = seededDoc({ a: 1, b: 2 });
+    applyJsonPatch(doc, "data", [{ op: "delete", path: "b" }]);
+    expect(yDocToJson(doc, "data")).toEqual({ a: 1 });
+  });
+
+  it("delete removes an array element by index", () => {
+    const doc = seededDoc({ list: [1, 2, 3] });
+    applyJsonPatch(doc, "data", [{ op: "delete", path: "list/1" }]);
+    expect(yDocToJson(doc, "data")).toEqual({ list: [1, 3] });
+  });
+
+  it("move reorders an array element and clamps the target", () => {
+    const doc = seededDoc({ list: ["a", "b", "c", "d"] });
+    applyJsonPatch(doc, "data", [{ op: "move", path: "list", from: 0, to: 2 }]);
+    expect(yDocToJson(doc, "data")).toEqual({ list: ["b", "c", "a", "d"] });
+
+    // to beyond the end clamps to the last index.
+    applyJsonPatch(doc, "data", [
+      { op: "move", path: "list", from: 0, to: 99 },
+    ]);
+    expect(yDocToJson(doc, "data")).toEqual({ list: ["c", "a", "d", "b"] });
+  });
+
+  it("move is a no-op for an out-of-range source or a no-op destination", () => {
+    const doc = seededDoc({ list: ["a", "b"] });
+    applyJsonPatch(doc, "data", [{ op: "move", path: "list", from: 5, to: 0 }]);
+    applyJsonPatch(doc, "data", [{ op: "move", path: "list", from: 0, to: 0 }]);
+    expect(yDocToJson(doc, "data")).toEqual({ list: ["a", "b"] });
+  });
+
+  it("set with an empty path is ignored", () => {
+    const doc = seededDoc({ a: 1 });
+    const update = applyJsonPatch(doc, "data", [
+      { op: "set", path: "", value: "ignored" },
+    ]);
+    expect(update.length).toBe(0);
+    expect(yDocToJson(doc, "data")).toEqual({ a: 1 });
+  });
+
+  it("applies multiple ops atomically in one update", () => {
+    const doc = seededDoc({ a: 1, list: [1, 2] });
+    const update = applyJsonPatch(doc, "data", [
+      { op: "set", path: "a", value: 2 },
+      { op: "insert", path: "list", index: 0, value: 0 },
+      { op: "delete", path: "list/2" },
+    ]);
+    expect(update.length).toBeGreaterThan(0);
+    expect(yDocToJson(doc, "data")).toEqual({ a: 2, list: [0, 1] });
+  });
+});
+
+describe("initYDocWithJson", () => {
+  it("returns a doc plus an encoded state that reconstructs the json", () => {
+    const json = { a: 1, b: [{ id: "x" }] };
+    const { doc, state } = initYDocWithJson("data", json, "map");
+    expect(yDocToJson(doc, "data")).toEqual(json);
+
+    // The encoded state replays into a fresh doc. yDocToJson dispatches on
+    // `doc.share.get(field) instanceof Y.Map/Y.Array`, and a replayed root
+    // type is an untyped AbstractType until claimed with the matching typed
+    // accessor — so the consumer must call getMap/getArray first.
+    const replay = new Y.Doc();
+    Y.applyUpdate(replay, state);
+    replay.getMap("data"); // claim the root type, as every real consumer does
+    expect(yDocToJson(replay, "data")).toEqual(json);
+  });
+
+  it("yDocToJson returns {} on a replayed doc whose root type was never claimed", () => {
+    // Documents the typed-accessor requirement: without getMap/getArray the
+    // root share is an AbstractType and the instanceof checks fall through.
+    const { state } = initYDocWithJson("data", { a: 1 }, "map");
+    const replay = new Y.Doc();
+    Y.applyUpdate(replay, state);
+    expect(replay.share.has("data")).toBe(true);
+    expect(yDocToJson(replay, "data")).toEqual({});
+  });
+
+  it("seeds an array field and reconstructs after claiming with getArray", () => {
+    const json = [{ id: "a" }, { id: "b" }];
+    const { state } = initYDocWithJson("data", json, "array");
+    const replay = new Y.Doc();
+    Y.applyUpdate(replay, state);
+    replay.getArray("data");
+    expect(yDocToJson(replay, "data")).toEqual(json);
+  });
+});

--- a/packages/core/src/collab/text-to-yjs.spec.ts
+++ b/packages/core/src/collab/text-to-yjs.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { applyTextToYDoc, initYDocWithText } from "./text-to-yjs.js";
+
+describe("applyTextToYDoc", () => {
+  it("inserts text into an empty field", () => {
+    const doc = new Y.Doc();
+    const update = applyTextToYDoc(doc, "content", "hello world");
+    expect(update.length).toBeGreaterThan(0);
+    expect(doc.getText("content").toString()).toBe("hello world");
+  });
+
+  it("returns an empty update and makes no change when text is identical", () => {
+    const doc = new Y.Doc();
+    doc.getText("content").insert(0, "unchanged");
+    const update = applyTextToYDoc(doc, "content", "unchanged");
+    expect(update.length).toBe(0);
+    expect(doc.getText("content").toString()).toBe("unchanged");
+  });
+
+  it("applies a minimal middle edit preserving the surrounding text", () => {
+    const doc = new Y.Doc();
+    doc.getText("content").insert(0, "the quick brown fox");
+    applyTextToYDoc(doc, "content", "the quick red fox");
+    expect(doc.getText("content").toString()).toBe("the quick red fox");
+  });
+
+  it("handles a pure deletion to empty", () => {
+    const doc = new Y.Doc();
+    doc.getText("content").insert(0, "delete me");
+    applyTextToYDoc(doc, "content", "");
+    expect(doc.getText("content").toString()).toBe("");
+  });
+
+  it("performs a minimal delete that keeps the unchanged tail intact", () => {
+    // Concurrent-edit safety relies on diffs being surgical, not full-replace.
+    // Insert a marker, then delete only the prefix and assert the tail's
+    // identity is untouched by checking the relative position survives.
+    const doc = new Y.Doc();
+    const ytext = doc.getText("content");
+    ytext.insert(0, "PREFIX-KEEP THIS TAIL");
+
+    // A RelativePosition anchored to the tail should still resolve to the
+    // same logical character after a minimal prefix deletion.
+    const tailIndex = "PREFIX-".length; // points at "K" of KEEP
+    const relPos = Y.createRelativePositionFromTypeIndex(ytext, tailIndex);
+
+    applyTextToYDoc(doc, "content", "KEEP THIS TAIL");
+
+    const resolved = Y.createAbsolutePositionFromRelativePosition(relPos, doc);
+    expect(doc.getText("content").toString()).toBe("KEEP THIS TAIL");
+    // The anchored character ("K") stayed at index 0 because only the prefix
+    // was deleted — a full replace would have orphaned the relative position.
+    expect(resolved?.index).toBe(0);
+  });
+
+  it("tags the produced transaction with the supplied origin", () => {
+    const doc = new Y.Doc();
+    let seenOrigin: unknown = "unset";
+    doc.on("afterTransaction", (txn) => {
+      seenOrigin = txn.origin;
+    });
+    applyTextToYDoc(doc, "content", "x", "agent");
+    expect(seenOrigin).toBe("agent");
+  });
+
+  it("update replays into another doc reproducing the same text", () => {
+    const a = new Y.Doc();
+    const b = new Y.Doc();
+    const update = applyTextToYDoc(a, "content", "sync me");
+    Y.applyUpdate(b, update);
+    expect(b.getText("content").toString()).toBe("sync me");
+  });
+});
+
+describe("initYDocWithText", () => {
+  it("seeds a doc and returns a replayable state", () => {
+    const { doc, state } = initYDocWithText("content", "seed text");
+    expect(doc.getText("content").toString()).toBe("seed text");
+
+    const replay = new Y.Doc();
+    Y.applyUpdate(replay, state);
+    expect(replay.getText("content").toString()).toBe("seed text");
+  });
+
+  it("produces a non-empty state for empty seed text (structural metadata only)", () => {
+    const { doc, state } = initYDocWithText("content", "");
+    expect(doc.getText("content").toString()).toBe("");
+    expect(state).toBeInstanceOf(Uint8Array);
+  });
+});

--- a/packages/core/src/collab/xml-ops.spec.ts
+++ b/packages/core/src/collab/xml-ops.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { searchAndReplaceInYXml, extractTextFromYXml } from "./xml-ops.js";
+
+/** Build a <paragraph> element wrapping a single text node. */
+function paragraph(text: string): Y.XmlElement {
+  const el = new Y.XmlElement("paragraph");
+  const t = new Y.XmlText();
+  t.insert(0, text);
+  el.insert(0, [t]);
+  return el;
+}
+
+function buildFragment(doc: Y.Doc, paras: string[]): Y.XmlFragment {
+  const frag = doc.getXmlFragment("default");
+  doc.transact(() => {
+    frag.insert(
+      0,
+      paras.map((p) => paragraph(p)),
+    );
+  });
+  return frag;
+}
+
+describe("searchAndReplaceInYXml", () => {
+  it("replaces the first occurrence inside a nested element and returns true", () => {
+    const doc = new Y.Doc();
+    const frag = buildFragment(doc, ["hello world", "goodbye world"]);
+
+    let result = false;
+    doc.transact(() => {
+      result = searchAndReplaceInYXml(frag, "world", "planet");
+    });
+
+    expect(result).toBe(true);
+    expect(extractTextFromYXml(frag)).toBe("hello planet\ngoodbye world");
+  });
+
+  it("returns false and changes nothing when the text is not found", () => {
+    const doc = new Y.Doc();
+    const frag = buildFragment(doc, ["alpha", "beta"]);
+
+    let result = true;
+    doc.transact(() => {
+      result = searchAndReplaceInYXml(frag, "gamma", "delta");
+    });
+
+    expect(result).toBe(false);
+    expect(extractTextFromYXml(frag)).toBe("alpha\nbeta");
+  });
+
+  it("only replaces the first match across multiple text nodes", () => {
+    const doc = new Y.Doc();
+    const frag = buildFragment(doc, ["target here", "target there"]);
+
+    doc.transact(() => {
+      searchAndReplaceInYXml(frag, "target", "HIT");
+    });
+
+    expect(extractTextFromYXml(frag)).toBe("HIT here\ntarget there");
+  });
+
+  it("recurses into deeply nested elements", () => {
+    const doc = new Y.Doc();
+    const frag = doc.getXmlFragment("default");
+    doc.transact(() => {
+      const outer = new Y.XmlElement("blockquote");
+      outer.insert(0, [paragraph("nested needle")]);
+      frag.insert(0, [outer]);
+    });
+
+    let result = false;
+    doc.transact(() => {
+      result = searchAndReplaceInYXml(frag, "needle", "thread");
+    });
+
+    expect(result).toBe(true);
+    expect(extractTextFromYXml(frag)).toBe("nested thread");
+  });
+
+  it("replaces a longer string with a shorter one using correct offsets", () => {
+    const doc = new Y.Doc();
+    const frag = buildFragment(doc, ["prefix REPLACEME suffix"]);
+
+    doc.transact(() => {
+      searchAndReplaceInYXml(frag, "REPLACEME", "X");
+    });
+
+    expect(extractTextFromYXml(frag)).toBe("prefix X suffix");
+  });
+});
+
+describe("extractTextFromYXml", () => {
+  it("joins block-level elements with newlines", () => {
+    const doc = new Y.Doc();
+    const frag = buildFragment(doc, ["line one", "line two", "line three"]);
+    expect(extractTextFromYXml(frag)).toBe("line one\nline two\nline three");
+  });
+
+  it("returns an empty string for an empty fragment", () => {
+    const doc = new Y.Doc();
+    const frag = doc.getXmlFragment("default");
+    expect(extractTextFromYXml(frag)).toBe("");
+  });
+
+  it("flattens nested containers, joining each container's text", () => {
+    const doc = new Y.Doc();
+    const frag = doc.getXmlFragment("default");
+    doc.transact(() => {
+      const list = new Y.XmlElement("list");
+      list.insert(0, [paragraph("a"), paragraph("b")]);
+      frag.insert(0, [list, paragraph("c")]);
+    });
+    // The list joins its two paragraphs with "\n", then the fragment joins
+    // the list result and "c" with another "\n".
+    expect(extractTextFromYXml(frag)).toBe("a\nb\nc");
+  });
+});

--- a/packages/core/src/db-admin/operations.postgres.spec.ts
+++ b/packages/core/src/db-admin/operations.postgres.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Postgres-dialect verification for the DB-admin introspection path.
+ *
+ * The main `operations.spec.ts` runs against a real local SQLite file. We have
+ * no local Postgres in CI/dev, so this file mocks `../db/client.js` to report
+ * the Postgres dialect and return canned `information_schema` / `pg_*` rows.
+ * That verifies the dialect-specific branch end-to-end — that introspection
+ * issues the Postgres queries (NOT `sqlite_master`/`PRAGMA`) and parses their
+ * results (columns, nullability, PK, FK, indexes, serial autoIncrement)
+ * correctly — without needing a live Postgres.
+ *
+ * A live Postgres run (the full suite against a real `DATABASE_URL`) is the
+ * stronger check and remains the open item; this closes the query-shape +
+ * parsing risk, which is where the SQLite vs Postgres code actually diverges.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let executed: string[] = [];
+
+vi.mock("../db/client.js", () => {
+  const execute = async (sqlOrObj: unknown) => {
+    const sql =
+      typeof sqlOrObj === "string"
+        ? sqlOrObj
+        : (sqlOrObj as { sql: string }).sql;
+    executed.push(sql);
+    const norm = sql.replace(/\s+/g, " ").trim();
+
+    if (
+      /information_schema\.tables/.test(norm) &&
+      /ORDER BY table_name/.test(norm)
+    ) {
+      return {
+        rows: [
+          { name: "orders", type: "BASE TABLE" },
+          { name: "order_summary", type: "VIEW" },
+        ],
+        rowsAffected: 0,
+      };
+    }
+    if (
+      /information_schema\.tables/.test(norm) &&
+      /table_name = \?/.test(norm)
+    ) {
+      return { rows: [{ type: "BASE TABLE" }], rowsAffected: 0 };
+    }
+    if (/information_schema\.columns/.test(norm)) {
+      return {
+        rows: [
+          {
+            name: "id",
+            type: "integer",
+            nullable: 0,
+            dflt: "nextval('orders_id_seq'::regclass)",
+          },
+          { name: "customer_id", type: "integer", nullable: 0, dflt: null },
+          { name: "note", type: "text", nullable: 1, dflt: null },
+        ],
+        rowsAffected: 0,
+      };
+    }
+    if (/constraint_type = 'PRIMARY KEY'/.test(norm)) {
+      return { rows: [{ col: "id" }], rowsAffected: 0 };
+    }
+    if (/constraint_type = 'FOREIGN KEY'/.test(norm)) {
+      return {
+        rows: [{ col: "customer_id", ref_table: "customers", ref_col: "id" }],
+        rowsAffected: 0,
+      };
+    }
+    if (/pg_indexes/.test(norm)) {
+      return {
+        rows: [
+          {
+            name: "orders_pkey",
+            def: "CREATE UNIQUE INDEX orders_pkey ON public.orders USING btree (id)",
+          },
+          {
+            name: "orders_customer_idx",
+            def: "CREATE INDEX orders_customer_idx ON public.orders USING btree (customer_id)",
+          },
+        ],
+        rowsAffected: 0,
+      };
+    }
+    if (/COUNT\(\*\)/.test(norm)) {
+      return { rows: [{ c: 5 }], rowsAffected: 0 };
+    }
+    return { rows: [], rowsAffected: 0 };
+  };
+
+  return {
+    getDbExec: () => ({ execute }),
+    getDialect: () => "postgres",
+    isPostgres: () => true,
+  };
+});
+
+const { listTables, getTableSchema } = await import("./operations.js");
+
+beforeEach(() => {
+  executed = [];
+});
+
+describe("db-admin operations — Postgres dialect (mocked)", () => {
+  it("listTables uses information_schema (never sqlite_master/PRAGMA) and parses tables + views", async () => {
+    const { dialect, tables } = await listTables();
+    expect(dialect).toBe("postgres");
+    expect(tables).toEqual([
+      { name: "orders", type: "table", rowCount: 5 },
+      { name: "order_summary", type: "view", rowCount: null },
+    ]);
+    expect(executed.some((s) => /information_schema\.tables/.test(s))).toBe(
+      true,
+    );
+    expect(executed.some((s) => /sqlite_master|PRAGMA/.test(s))).toBe(false);
+  });
+
+  it("getTableSchema parses columns/PK/FK/indexes + serial autoIncrement from information_schema/pg_*", async () => {
+    const schema = await getTableSchema("orders");
+
+    expect(schema.type).toBe("table");
+    expect(schema.primaryKey).toEqual(["id"]);
+
+    expect(schema.columns.find((c) => c.name === "id")).toMatchObject({
+      type: "integer",
+      nullable: false,
+      pk: true,
+      autoIncrement: true, // nextval(...) → serial
+    });
+    expect(schema.columns.find((c) => c.name === "note")).toMatchObject({
+      nullable: true,
+      pk: false,
+    });
+
+    expect(schema.foreignKeys).toEqual([
+      { column: "customer_id", refTable: "customers", refColumn: "id" },
+    ]);
+    expect(schema.indexes).toEqual([
+      { name: "orders_pkey", unique: true, columns: ["id"] },
+      { name: "orders_customer_idx", unique: false, columns: ["customer_id"] },
+    ]);
+
+    expect(executed.some((s) => /information_schema\.columns/.test(s))).toBe(
+      true,
+    );
+    expect(executed.some((s) => /PRAGMA/.test(s))).toBe(false);
+  });
+});

--- a/packages/core/src/event-bus/bus.spec.ts
+++ b/packages/core/src/event-bus/bus.spec.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import {
+  __resetEventBus,
+  emit,
+  listSubscriptions,
+  subscribe,
+  unsubscribe,
+} from "./bus.js";
+import { __resetEventRegistry, registerEvent, getEvent } from "./registry.js";
+
+describe("event-bus", () => {
+  beforeEach(() => {
+    __resetEventBus();
+    __resetEventRegistry();
+    // Silence the bus's intentional console warnings/errors for negative paths.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    __resetEventBus();
+    __resetEventRegistry();
+    vi.restoreAllMocks();
+  });
+
+  describe("subscribe / emit / unsubscribe", () => {
+    it("delivers the payload and synthesized meta to a subscriber", () => {
+      registerEvent({
+        name: "thing.happened",
+        description: "test",
+        payloadSchema: z.object({ n: z.number() }) as any,
+      });
+      const handler = vi.fn();
+      subscribe("thing.happened", handler);
+
+      emit("thing.happened", { n: 42 }, { owner: "alice@example.com" });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const [payload, meta] = handler.mock.calls[0];
+      expect(payload).toEqual({ n: 42 });
+      expect(meta.owner).toBe("alice@example.com");
+      expect(typeof meta.eventId).toBe("string");
+      expect(meta.eventId.length).toBeGreaterThan(0);
+      expect(typeof meta.emittedAt).toBe("string");
+      // emittedAt is an ISO timestamp.
+      expect(Number.isNaN(Date.parse(meta.emittedAt))).toBe(false);
+    });
+
+    it("returns a distinct id per subscription and tracks them", () => {
+      const id1 = subscribe("e", () => {});
+      const id2 = subscribe("e", () => {});
+      expect(id1).not.toBe(id2);
+      const subs = listSubscriptions("e");
+      expect(subs.map((s) => s.id).sort()).toEqual([id1, id2].sort());
+    });
+
+    it("stops delivering after unsubscribe and returns true once", () => {
+      const handler = vi.fn();
+      const id = subscribe("e", handler);
+
+      unsubscribe(id);
+      emit("e", {});
+
+      expect(handler).not.toHaveBeenCalled();
+      // Second unsubscribe of the same id is a no-op false.
+      expect(unsubscribe(id)).toBe(false);
+      expect(listSubscriptions("e")).toHaveLength(0);
+    });
+
+    it("unsubscribe of an unknown id returns false", () => {
+      expect(unsubscribe("does-not-exist")).toBe(false);
+    });
+
+    it("rejects invalid subscribe arguments", () => {
+      expect(() => subscribe("", () => {})).toThrow(/event name is required/);
+      // @ts-expect-error testing runtime guard
+      expect(() => subscribe("e", null)).toThrow(/handler must be a function/);
+    });
+
+    it("rejects emit with no event name", () => {
+      // @ts-expect-error testing runtime guard
+      expect(() => emit("", {})).toThrow(/event name is required/);
+    });
+
+    it("only delivers to subscribers of the matching event", () => {
+      const a = vi.fn();
+      const b = vi.fn();
+      subscribe("event.a", a);
+      subscribe("event.b", b);
+
+      emit("event.a", {});
+
+      expect(a).toHaveBeenCalledTimes(1);
+      expect(b).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ordering and multiple subscribers", () => {
+    it("invokes handlers in subscription order", () => {
+      const order: number[] = [];
+      subscribe("e", () => order.push(1));
+      subscribe("e", () => order.push(2));
+      subscribe("e", () => order.push(3));
+
+      emit("e", {});
+
+      expect(order).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe("handler error isolation", () => {
+    it("a throwing sync handler does not prevent later handlers", () => {
+      const after = vi.fn();
+      subscribe("e", () => {
+        throw new Error("boom");
+      });
+      subscribe("e", after);
+
+      expect(() => emit("e", {})).not.toThrow();
+      expect(after).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it("a rejected async handler is caught and logged, not unhandled", async () => {
+      subscribe("e", async () => {
+        throw new Error("async boom");
+      });
+      const after = vi.fn();
+      subscribe("e", after);
+
+      expect(() => emit("e", {})).not.toThrow();
+      expect(after).toHaveBeenCalledTimes(1);
+      // Let the rejected microtask settle so the .catch runs.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining("Async handler"),
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe("listener snapshot during dispatch", () => {
+    it("a handler that subscribes mid-dispatch does not run in the same emission", () => {
+      const late = vi.fn();
+      subscribe("e", () => {
+        subscribe("e", late);
+      });
+
+      emit("e", {});
+      expect(late).not.toHaveBeenCalled();
+
+      // But it does run on the next emission.
+      emit("e", {});
+      expect(late).toHaveBeenCalledTimes(1);
+    });
+
+    it("a handler that unsubscribes another mid-dispatch still delivers to the snapshotted listener", () => {
+      const calls: string[] = [];
+      let secondId = "";
+      subscribe("e", () => {
+        calls.push("first");
+        unsubscribe(secondId);
+      });
+      secondId = subscribe("e", () => calls.push("second"));
+
+      emit("e", {});
+      // "second" was in the snapshot taken before dispatch, so it still fires.
+      expect(calls).toEqual(["first", "second"]);
+
+      // On the next emission "second" is gone.
+      calls.length = 0;
+      emit("e", {});
+      expect(calls).toEqual(["first"]);
+    });
+  });
+
+  describe("payload validation against registered schema", () => {
+    it("passes the schema-parsed (coerced) value to handlers", () => {
+      registerEvent({
+        name: "coerce.event",
+        description: "test",
+        payloadSchema: z.object({
+          n: z.coerce.number(),
+        }) as any,
+      });
+      const handler = vi.fn();
+      subscribe("coerce.event", handler);
+
+      emit("coerce.event", { n: "7" });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0]).toEqual({ n: 7 });
+    });
+
+    it("drops the emission when payload validation fails", () => {
+      registerEvent({
+        name: "strict.event",
+        description: "test",
+        payloadSchema: z.object({ n: z.number() }) as any,
+      });
+      const handler = vi.fn();
+      subscribe("strict.event", handler);
+
+      emit("strict.event", { n: "not-a-number" });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Payload validation failed"),
+        expect.anything(),
+      );
+    });
+
+    it("dispatches unvalidated and warns for an unregistered event", () => {
+      const handler = vi.fn();
+      subscribe("unregistered.event", handler);
+
+      emit("unregistered.event", { anything: true });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0]).toEqual({ anything: true });
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("unregistered event"),
+      );
+    });
+
+    it("dispatches unvalidated and warns when a schema validates asynchronously", () => {
+      registerEvent({
+        name: "async.event",
+        description: "test",
+        // A schema whose validate() returns a Promise — unsupported path.
+        payloadSchema: {
+          "~standard": {
+            version: 1,
+            vendor: "test",
+            validate: async () => ({ value: { ok: true } }),
+          },
+        } as any,
+      });
+      const handler = vi.fn();
+      subscribe("async.event", handler);
+
+      emit("async.event", { raw: 1 });
+
+      // Falls through to dispatching the original (unvalidated) payload.
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0]).toEqual({ raw: 1 });
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("async validation is not supported"),
+      );
+    });
+  });
+});
+
+describe("event registry", () => {
+  beforeEach(() => {
+    __resetEventRegistry();
+  });
+  afterEach(() => {
+    __resetEventRegistry();
+  });
+
+  it("seeds the built-in events on reset", () => {
+    expect(getEvent("test.event.fired")?.name).toBe("test.event.fired");
+    expect(getEvent("agent.turn.completed")?.name).toBe("agent.turn.completed");
+  });
+
+  it("registers and looks up a definition", () => {
+    registerEvent({
+      name: "my.event",
+      description: "desc",
+      payloadSchema: z.object({}) as any,
+    });
+    expect(getEvent("my.event")?.description).toBe("desc");
+  });
+
+  it("later registration with the same name replaces the previous one", () => {
+    registerEvent({
+      name: "dup",
+      description: "first",
+      payloadSchema: z.object({}) as any,
+    });
+    registerEvent({
+      name: "dup",
+      description: "second",
+      payloadSchema: z.object({}) as any,
+    });
+    expect(getEvent("dup")?.description).toBe("second");
+  });
+
+  it("validates required fields on registration", () => {
+    expect(() =>
+      registerEvent({ description: "d", payloadSchema: z.object({}) } as any),
+    ).toThrow(/def.name is required/);
+    expect(() =>
+      registerEvent({ name: "x", payloadSchema: z.object({}) } as any),
+    ).toThrow(/def.description is required/);
+    expect(() => registerEvent({ name: "x", description: "d" } as any)).toThrow(
+      /def.payloadSchema is required/,
+    );
+  });
+
+  it("getEvent returns undefined for an unknown name", () => {
+    expect(getEvent("nope.nope")).toBeUndefined();
+  });
+});

--- a/packages/core/src/extensions/slots/store.spec.ts
+++ b/packages/core/src/extensions/slots/store.spec.ts
@@ -1,0 +1,481 @@
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runWithRequestContext } from "../../server/request-context.js";
+import { registerShareableResource } from "../../sharing/registry.js";
+import { ForbiddenError } from "../../sharing/access.js";
+import { extensions, extensionShares } from "../schema.js";
+import {
+  EXTENSION_SLOTS_CREATE_SQL,
+  EXTENSION_SLOTS_BY_SLOT_INDEX_SQL,
+  EXTENSION_SLOTS_BY_EXTENSION_INDEX_SQL,
+  EXTENSION_SLOTS_UNIQUE_INDEX_SQL,
+  EXTENSION_SLOT_INSTALLS_CREATE_SQL,
+  EXTENSION_SLOT_INSTALLS_BY_USER_SLOT_INDEX_SQL,
+  EXTENSION_SLOT_INSTALLS_UNIQUE_INDEX_SQL,
+} from "./schema.js";
+
+// One real in-memory sqlite DB shared between the slot store's drizzle handle
+// (createGetDb is mocked to return it) and the raw getDbExec client used by
+// ensureSlotTables for DDL, plus the registered "extension" shareable resource
+// so access scoping is exercised for real (not mocked away).
+let sqlite: Database.Database;
+let db: ReturnType<typeof drizzle>;
+
+const rawClient = {
+  execute: vi.fn(async (input: string | { sql: string; args?: unknown[] }) => {
+    if (typeof input === "string") {
+      sqlite.exec(input);
+      return { rows: [], rowsAffected: 0 };
+    }
+    const stmt = sqlite.prepare(input.sql);
+    if (/^\s*select/i.test(input.sql)) {
+      const rows = stmt.all(...((input.args ?? []) as unknown[]));
+      return { rows, rowsAffected: 0 };
+    }
+    const info = stmt.run(...((input.args ?? []) as unknown[]));
+    return { rows: [], rowsAffected: info.changes };
+  }),
+};
+
+vi.mock("../../db/client.js", () => ({
+  getDbExec: () => rawClient,
+  isPostgres: () => false,
+  getDialect: () => "sqlite",
+  intType: () => "INTEGER",
+}));
+
+vi.mock("../../db/create-get-db.js", () => ({
+  createGetDb: () => () => db,
+}));
+
+const {
+  addExtensionSlotTarget,
+  removeExtensionSlotTarget,
+  listSlotsForExtension,
+  listExtensionsForSlot,
+  installExtensionSlot,
+  uninstallExtensionSlot,
+  listSlotInstallsForUser,
+  cascadeDeleteExtensionSlots,
+} = await import("./store.js");
+
+const OWNER = "owner@example.com";
+const VIEWER = "viewer@example.com";
+const OUTSIDER = "outsider@example.com";
+const ORG = "org-1";
+
+async function insertExtension(values: {
+  id: string;
+  name?: string;
+  ownerEmail?: string;
+  orgId?: string | null;
+  visibility?: "private" | "org" | "public";
+}) {
+  await db.insert(extensions).values({
+    id: values.id,
+    name: values.name ?? values.id,
+    description: `${values.id} description`,
+    content: "<div></div>",
+    icon: null,
+    ownerEmail: values.ownerEmail ?? OWNER,
+    orgId: values.orgId === undefined ? ORG : values.orgId,
+    visibility: values.visibility ?? "private",
+  });
+}
+
+function shareToUser(resourceId: string, email: string, role = "viewer") {
+  return db.insert(extensionShares).values({
+    id: `${resourceId}:${email}:${role}`,
+    resourceId,
+    principalType: "user",
+    principalId: email,
+    role,
+    createdBy: OWNER,
+    createdAt: "2026-04-30T00:00:00.000Z",
+  });
+}
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  // Mirror the real extensions/extension_shares tables so accessFilter and
+  // resolveAccess run against genuine rows.
+  sqlite.exec(`
+    CREATE TABLE tools (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL DEFAULT '',
+      content TEXT NOT NULL DEFAULT '',
+      icon TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      owner_email TEXT NOT NULL DEFAULT 'local@localhost',
+      org_id TEXT,
+      visibility TEXT NOT NULL DEFAULT 'private'
+    );
+    CREATE TABLE tool_shares (
+      id TEXT PRIMARY KEY,
+      resource_id TEXT NOT NULL,
+      principal_type TEXT NOT NULL,
+      principal_id TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'viewer',
+      created_by TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+  sqlite.exec(EXTENSION_SLOTS_CREATE_SQL);
+  sqlite.exec(EXTENSION_SLOTS_BY_SLOT_INDEX_SQL);
+  sqlite.exec(EXTENSION_SLOTS_BY_EXTENSION_INDEX_SQL);
+  sqlite.exec(EXTENSION_SLOTS_UNIQUE_INDEX_SQL);
+  sqlite.exec(EXTENSION_SLOT_INSTALLS_CREATE_SQL);
+  sqlite.exec(EXTENSION_SLOT_INSTALLS_BY_USER_SLOT_INDEX_SQL);
+  sqlite.exec(EXTENSION_SLOT_INSTALLS_UNIQUE_INDEX_SQL);
+  db = drizzle(sqlite);
+
+  registerShareableResource({
+    type: "extension",
+    resourceTable: extensions,
+    sharesTable: extensionShares,
+    displayName: "Extension",
+    titleColumn: "name",
+    allowPublic: false,
+    requireOrgMemberForUserShares: true,
+    getDb: () => db,
+  });
+});
+
+afterEach(() => {
+  sqlite.close();
+  vi.clearAllMocks();
+});
+
+describe("extension slots: slot-target declarations", () => {
+  it("requires editor access on the extension to declare a slot target", async () => {
+    await insertExtension({ id: "ext-1" });
+    // Viewer-only share — not enough to declare a slot target.
+    await shareToUser("ext-1", VIEWER, "viewer");
+
+    await runWithRequestContext({ userEmail: VIEWER, orgId: ORG }, async () => {
+      await expect(
+        addExtensionSlotTarget("ext-1", "mail.sidebar"),
+      ).rejects.toBeInstanceOf(ForbiddenError);
+    });
+
+    // No declaration row should have been written.
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, async () => {
+      await expect(listSlotsForExtension("ext-1")).resolves.toEqual([]);
+    });
+  });
+
+  it("lets the owner declare a slot target and is idempotent on the unique index", async () => {
+    await insertExtension({ id: "ext-1" });
+
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, async () => {
+      const first = await addExtensionSlotTarget(
+        "ext-1",
+        "mail.sidebar",
+        '{"variant":"compact"}',
+      );
+      expect(first).toMatchObject({
+        extensionId: "ext-1",
+        slotId: "mail.sidebar",
+        config: '{"variant":"compact"}',
+      });
+
+      // Re-declaring the same (extension, slot) pair returns the existing row
+      // instead of throwing on the unique index.
+      const again = await addExtensionSlotTarget("ext-1", "mail.sidebar");
+      expect(again.id).toBe(first.id);
+
+      const rows = await listSlotsForExtension("ext-1");
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  it("requires viewer access to list an extension's slot targets", async () => {
+    await insertExtension({ id: "ext-1" });
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, () =>
+      addExtensionSlotTarget("ext-1", "mail.sidebar"),
+    );
+
+    await runWithRequestContext(
+      { userEmail: OUTSIDER, orgId: ORG },
+      async () => {
+        await expect(listSlotsForExtension("ext-1")).rejects.toBeInstanceOf(
+          ForbiddenError,
+        );
+      },
+    );
+  });
+
+  it("removes a slot target only with editor access", async () => {
+    await insertExtension({ id: "ext-1" });
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, () =>
+      addExtensionSlotTarget("ext-1", "mail.sidebar"),
+    );
+
+    await runWithRequestContext(
+      { userEmail: OUTSIDER, orgId: ORG },
+      async () => {
+        await expect(
+          removeExtensionSlotTarget("ext-1", "mail.sidebar"),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+      },
+    );
+
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, async () => {
+      await expect(
+        removeExtensionSlotTarget("ext-1", "mail.sidebar"),
+      ).resolves.toBe(true);
+      await expect(listSlotsForExtension("ext-1")).resolves.toEqual([]);
+    });
+  });
+});
+
+describe("extension slots: listExtensionsForSlot scoping", () => {
+  it("only returns slot declarations for extensions the caller can access", async () => {
+    await insertExtension({ id: "mine", name: "Mine", ownerEmail: OWNER });
+    await insertExtension({
+      id: "theirs",
+      name: "Theirs",
+      ownerEmail: OUTSIDER,
+      visibility: "private",
+    });
+    await insertExtension({
+      id: "shared",
+      name: "Shared",
+      ownerEmail: OUTSIDER,
+    });
+    await shareToUser("shared", OWNER, "viewer");
+
+    // Declare all three in the same slot (declaration auth is checked when
+    // adding; insert directly to bypass and focus on the read-side scoping).
+    for (const id of ["mine", "theirs", "shared"]) {
+      sqlite
+        .prepare(
+          `INSERT INTO tool_slots (id, tool_id, slot_id, config, created_at)
+           VALUES (?, ?, 'calendar.panel', NULL, '2026-04-30T00:00:00.000Z')`,
+        )
+        .run(`decl-${id}`, id);
+    }
+
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, async () => {
+      const visible = await listExtensionsForSlot("calendar.panel");
+      expect(visible.map((e) => e.extensionId).sort()).toEqual([
+        "mine",
+        "shared",
+      ]);
+      // "theirs" (private, not shared) must never leak.
+      expect(visible.some((e) => e.extensionId === "theirs")).toBe(false);
+    });
+  });
+
+  it("returns an empty list when the caller can see no extensions", async () => {
+    await insertExtension({ id: "theirs", ownerEmail: OUTSIDER });
+    sqlite
+      .prepare(
+        `INSERT INTO tool_slots (id, tool_id, slot_id, config, created_at)
+         VALUES ('d1', 'theirs', 'calendar.panel', NULL, '2026-04-30T00:00:00.000Z')`,
+      )
+      .run();
+
+    await runWithRequestContext(
+      { userEmail: OUTSIDER + ".nope", orgId: "org-x" },
+      async () => {
+        await expect(listExtensionsForSlot("calendar.panel")).resolves.toEqual(
+          [],
+        );
+      },
+    );
+  });
+});
+
+describe("extension slots: install / uninstall", () => {
+  it("requires viewer access on the extension to install it into a slot", async () => {
+    await insertExtension({ id: "ext-1", ownerEmail: OUTSIDER });
+
+    await runWithRequestContext({ userEmail: VIEWER, orgId: ORG }, async () => {
+      await expect(
+        installExtensionSlot("ext-1", "mail.sidebar"),
+      ).rejects.toBeInstanceOf(ForbiddenError);
+    });
+  });
+
+  it("installs an accessible extension and auto-assigns increasing positions per slot", async () => {
+    await insertExtension({ id: "ext-a", ownerEmail: OWNER });
+    await insertExtension({ id: "ext-b", ownerEmail: OWNER });
+
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, async () => {
+      const a = await installExtensionSlot("ext-a", "mail.sidebar");
+      const b = await installExtensionSlot("ext-b", "mail.sidebar");
+      expect(a.position).toBe(0);
+      expect(b.position).toBe(1);
+      expect(a.ownerEmail).toBe(OWNER);
+      expect(a.orgId).toBe(ORG);
+
+      // A different slot starts its own position sequence at 0.
+      const otherSlot = await installExtensionSlot("ext-a", "calendar.panel");
+      expect(otherSlot.position).toBe(0);
+    });
+  });
+
+  it("honors an explicit position and is idempotent on re-install", async () => {
+    await insertExtension({ id: "ext-a", ownerEmail: OWNER });
+
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, async () => {
+      const first = await installExtensionSlot("ext-a", "mail.sidebar", {
+        position: 7,
+        config: '{"x":1}',
+      });
+      expect(first.position).toBe(7);
+
+      // Re-installing returns the existing row (does not create a duplicate or
+      // bump position).
+      const again = await installExtensionSlot("ext-a", "mail.sidebar", {
+        position: 99,
+      });
+      expect(again.id).toBe(first.id);
+      expect(again.position).toBe(7);
+
+      const installs = await listSlotInstallsForUser("mail.sidebar");
+      expect(installs).toHaveLength(1);
+    });
+  });
+
+  it("scopes installs per user — one user's install is invisible to another", async () => {
+    await insertExtension({
+      id: "ext-a",
+      ownerEmail: OWNER,
+      visibility: "org",
+    });
+
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, () =>
+      installExtensionSlot("ext-a", "mail.sidebar"),
+    );
+
+    // VIEWER can see ext-a (org visibility) but has installed nothing.
+    await runWithRequestContext({ userEmail: VIEWER, orgId: ORG }, async () => {
+      await expect(listSlotInstallsForUser("mail.sidebar")).resolves.toEqual(
+        [],
+      );
+      // VIEWER installs for themselves.
+      await installExtensionSlot("ext-a", "mail.sidebar");
+      const mine = await listSlotInstallsForUser("mail.sidebar");
+      expect(mine).toHaveLength(1);
+      expect(mine[0].extensionId).toBe("ext-a");
+    });
+
+    // OWNER still sees only their own single install.
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, async () => {
+      await expect(
+        listSlotInstallsForUser("mail.sidebar"),
+      ).resolves.toHaveLength(1);
+    });
+  });
+
+  it("uninstall only removes the calling user's install row", async () => {
+    await insertExtension({
+      id: "ext-a",
+      ownerEmail: OWNER,
+      visibility: "org",
+    });
+
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, () =>
+      installExtensionSlot("ext-a", "mail.sidebar"),
+    );
+    await runWithRequestContext({ userEmail: VIEWER, orgId: ORG }, () =>
+      installExtensionSlot("ext-a", "mail.sidebar"),
+    );
+
+    // VIEWER uninstalls — OWNER's install must remain.
+    await runWithRequestContext({ userEmail: VIEWER, orgId: ORG }, async () => {
+      await expect(
+        uninstallExtensionSlot("ext-a", "mail.sidebar"),
+      ).resolves.toBe(true);
+      await expect(listSlotInstallsForUser("mail.sidebar")).resolves.toEqual(
+        [],
+      );
+    });
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, async () => {
+      await expect(
+        listSlotInstallsForUser("mail.sidebar"),
+      ).resolves.toHaveLength(1);
+    });
+  });
+
+  it("rejects install/uninstall with no authenticated user", async () => {
+    await insertExtension({ id: "ext-a", ownerEmail: OWNER });
+
+    await runWithRequestContext({ userEmail: undefined }, async () => {
+      // install runs the access check first; with no user it has no access.
+      await expect(
+        installExtensionSlot("ext-a", "mail.sidebar"),
+      ).rejects.toBeInstanceOf(ForbiddenError);
+      // uninstall has no access check — it falls straight to requireUserEmail().
+      await expect(
+        uninstallExtensionSlot("ext-a", "mail.sidebar"),
+      ).rejects.toThrow(/authenticated user/i);
+    });
+  });
+});
+
+describe("extension slots: listSlotInstallsForUser", () => {
+  it("sorts by position and lazily skips installs the user lost access to", async () => {
+    await insertExtension({ id: "ext-a", ownerEmail: OWNER });
+    await insertExtension({ id: "ext-b", ownerEmail: OWNER });
+    // ext-gone: owned by an outsider, never shared — represents an extension
+    // the user installed earlier but has since lost access to.
+    await insertExtension({ id: "ext-gone", ownerEmail: OUTSIDER });
+
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, async () => {
+      await installExtensionSlot("ext-b", "mail.sidebar", { position: 5 });
+      await installExtensionSlot("ext-a", "mail.sidebar", { position: 1 });
+    });
+
+    // Directly insert an install row for ext-gone owned by OWNER (simulating a
+    // stale install), so listSlotInstallsForUser must filter it out because
+    // accessFilter no longer admits ext-gone.
+    sqlite
+      .prepare(
+        `INSERT INTO tool_slot_installs
+          (id, tool_id, slot_id, owner_email, org_id, position, config, created_at, updated_at)
+         VALUES ('stale', 'ext-gone', 'mail.sidebar', ?, ?, 2, NULL, '2026-04-30T00:00:00.000Z', '2026-04-30T00:00:00.000Z')`,
+      )
+      .run(OWNER, ORG);
+
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, async () => {
+      const installs = await listSlotInstallsForUser("mail.sidebar");
+      // ext-gone is silently dropped; the rest are sorted by position asc.
+      expect(installs.map((i) => i.extensionId)).toEqual(["ext-a", "ext-b"]);
+      expect(installs[0]).toMatchObject({ name: "ext-a", position: 1 });
+      // Joined extension metadata is present.
+      expect(installs[0].description).toBe("ext-a description");
+    });
+  });
+});
+
+describe("extension slots: cascadeDeleteExtensionSlots", () => {
+  it("removes every declaration and install row referencing the extension", async () => {
+    await insertExtension({ id: "ext-a", ownerEmail: OWNER });
+
+    await runWithRequestContext({ userEmail: OWNER, orgId: ORG }, async () => {
+      await addExtensionSlotTarget("ext-a", "mail.sidebar");
+      await addExtensionSlotTarget("ext-a", "calendar.panel");
+      await installExtensionSlot("ext-a", "mail.sidebar");
+    });
+
+    await cascadeDeleteExtensionSlots("ext-a");
+
+    const slotRows = sqlite
+      .prepare(`SELECT COUNT(*) AS c FROM tool_slots WHERE tool_id = 'ext-a'`)
+      .get() as { c: number };
+    const installRows = sqlite
+      .prepare(
+        `SELECT COUNT(*) AS c FROM tool_slot_installs WHERE tool_id = 'ext-a'`,
+      )
+      .get() as { c: number };
+    expect(slotRows.c).toBe(0);
+    expect(installRows.c).toBe(0);
+  });
+});

--- a/packages/core/src/file-upload/builder.spec.ts
+++ b/packages/core/src/file-upload/builder.spec.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { builderFileUploadProvider } from "./builder.js";
+
+const resolveBuilderPrivateKeyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../server/credential-provider.js", () => ({
+  resolveBuilderPrivateKey: resolveBuilderPrivateKeyMock,
+}));
+
+function jsonResponse(body: unknown, init?: { status?: number }): Response {
+  return {
+    ok: (init?.status ?? 200) < 400,
+    status: init?.status ?? 200,
+    statusText: "OK",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function errorResponse(status: number, text = ""): Response {
+  return {
+    ok: false,
+    status,
+    statusText: `status ${status}`,
+    json: async () => ({}),
+    text: async () => text,
+  } as unknown as Response;
+}
+
+describe("builderFileUploadProvider", () => {
+  const originalEnv = { ...process.env };
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.BUILDER_APP_HOST;
+    delete process.env.BUILDER_PUBLIC_APP_HOST;
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    resolveBuilderPrivateKeyMock.mockResolvedValue("bpk-secret");
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    process.env = { ...originalEnv };
+  });
+
+  it("identifies as the builder provider and reports config from env", () => {
+    expect(builderFileUploadProvider.id).toBe("builder");
+    delete process.env.BUILDER_PRIVATE_KEY;
+    expect(builderFileUploadProvider.isConfigured()).toBe(false);
+    process.env.BUILDER_PRIVATE_KEY = "x";
+    expect(builderFileUploadProvider.isConfigured()).toBe(true);
+  });
+
+  it("throws when no private key resolves", async () => {
+    resolveBuilderPrivateKeyMock.mockResolvedValue(null);
+    await expect(
+      builderFileUploadProvider.upload({ data: new Uint8Array([1]) }),
+    ).rejects.toThrow(/BUILDER_PRIVATE_KEY is not set/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts to the upload API with auth, name param, and bearer key", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ url: "https://cdn.builder.io/abc", id: "abc" }),
+    );
+
+    const result = await builderFileUploadProvider.upload({
+      data: new Uint8Array([1, 2, 3]),
+      filename: "photo.png",
+      mimeType: "image/png",
+    });
+
+    expect(result).toEqual({
+      url: "https://cdn.builder.io/abc",
+      id: "abc",
+      provider: "builder",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsed = new URL(url.toString());
+    expect(parsed.origin).toBe("https://builder.io");
+    expect(parsed.pathname).toBe("/api/v1/upload");
+    expect(parsed.searchParams.get("name")).toBe("photo.png");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Bearer bpk-secret");
+  });
+
+  it("strips media-type parameters from the Content-Type header", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ url: "https://cdn/x" }));
+
+    await builderFileUploadProvider.upload({
+      data: new Uint8Array([1]),
+      mimeType: "video/webm;codecs=avc1,opus",
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers["Content-Type"]).toBe("video/webm");
+  });
+
+  it("defaults Content-Type to application/octet-stream when no mime given", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ url: "https://cdn/x" }));
+
+    await builderFileUploadProvider.upload({ data: new Uint8Array([1]) });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    // No filename -> no name search param.
+    expect(new URL(url.toString()).searchParams.has("name")).toBe(false);
+    expect(init.headers["Content-Type"]).toBe("application/octet-stream");
+  });
+
+  it("uses BUILDER_APP_HOST when set, preferring it over the public host", async () => {
+    process.env.BUILDER_APP_HOST = "https://app.example.com";
+    process.env.BUILDER_PUBLIC_APP_HOST = "https://public.example.com";
+    fetchMock.mockResolvedValue(jsonResponse({ url: "https://cdn/x" }));
+
+    await builderFileUploadProvider.upload({ data: new Uint8Array([1]) });
+
+    expect(new URL(fetchMock.mock.calls[0][0].toString()).origin).toBe(
+      "https://app.example.com",
+    );
+  });
+
+  it("retries a transient 5xx once then succeeds", async () => {
+    fetchMock
+      .mockResolvedValueOnce(errorResponse(500, "Internal Error"))
+      .mockResolvedValueOnce(jsonResponse({ url: "https://cdn/ok", id: "ok" }));
+
+    const promise = builderFileUploadProvider.upload({
+      data: new Uint8Array([1]),
+    });
+    // Advance past the first backoff delay (600ms) so the retry fires.
+    await vi.advanceTimersByTimeAsync(600);
+    const result = await promise;
+
+    expect(result.url).toBe("https://cdn/ok");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry a 4xx — surfaces it immediately", async () => {
+    fetchMock.mockResolvedValue(errorResponse(400, "No image specified"));
+
+    await expect(
+      builderFileUploadProvider.upload({ data: new Uint8Array([1]) }),
+    ).rejects.toThrow(/Builder.io upload failed \(400\): No image specified/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry a 501 (treated as non-transient)", async () => {
+    fetchMock.mockResolvedValue(errorResponse(501, "Not Implemented"));
+
+    await expect(
+      builderFileUploadProvider.upload({ data: new Uint8Array([1]) }),
+    ).rejects.toThrow(/\(501\)/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after exhausting retries on persistent 5xx", async () => {
+    fetchMock.mockResolvedValue(errorResponse(503, "Unavailable"));
+
+    const promise = builderFileUploadProvider.upload({
+      data: new Uint8Array([1]),
+    });
+    const expectation = expect(promise).rejects.toThrow(/\(503\): Unavailable/);
+    // Two backoff windows: 600ms then 1800ms.
+    await vi.advanceTimersByTimeAsync(600);
+    await vi.advanceTimersByTimeAsync(1800);
+    await expectation;
+    // 1 initial + 2 retries = 3 attempts.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws when the upload response has no url", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: "abc" }));
+
+    await expect(
+      builderFileUploadProvider.upload({ data: new Uint8Array([1]) }),
+    ).rejects.toThrow(/returned no URL/);
+  });
+});

--- a/packages/core/src/file-upload/registry.spec.ts
+++ b/packages/core/src/file-upload/registry.spec.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getActiveFileUploadProvider,
+  listFileUploadProviders,
+  registerFileUploadProvider,
+  unregisterFileUploadProvider,
+  uploadFile,
+} from "./registry.js";
+import { builderFileUploadProvider } from "./builder.js";
+import type { FileUploadProvider } from "./types.js";
+
+const resolveBuilderPrivateKeyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../server/credential-provider.js", () => ({
+  resolveBuilderPrivateKey: resolveBuilderPrivateKeyMock,
+}));
+
+function makeProvider(
+  id: string,
+  configured: boolean,
+  upload?: FileUploadProvider["upload"],
+): FileUploadProvider {
+  return {
+    id,
+    name: id,
+    isConfigured: () => configured,
+    upload:
+      upload ??
+      (async () => ({ url: `https://cdn/${id}`, id: `${id}-1`, provider: id })),
+  };
+}
+
+describe("file-upload registry", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Drop any providers a prior test (or import side effect) left on the
+    // globalThis-pinned map so each case starts clean.
+    for (const p of listFileUploadProviders()) {
+      unregisterFileUploadProvider(p.id);
+    }
+    process.env = { ...originalEnv };
+    delete process.env.BUILDER_PRIVATE_KEY;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    for (const p of listFileUploadProviders()) {
+      unregisterFileUploadProvider(p.id);
+    }
+    process.env = { ...originalEnv };
+  });
+
+  describe("registration and lookup", () => {
+    it("registers, lists, and unregisters providers", () => {
+      const p = makeProvider("s3", true);
+      registerFileUploadProvider(p);
+      expect(listFileUploadProviders()).toContain(p);
+
+      unregisterFileUploadProvider("s3");
+      expect(listFileUploadProviders()).not.toContain(p);
+    });
+
+    it("is idempotent per id — re-registering the same id replaces it", () => {
+      const first = makeProvider("dup", false);
+      const second = makeProvider("dup", true);
+      registerFileUploadProvider(first);
+      registerFileUploadProvider(second);
+
+      const matches = listFileUploadProviders().filter((p) => p.id === "dup");
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toBe(second);
+    });
+  });
+
+  describe("getActiveFileUploadProvider", () => {
+    it("returns the first configured user provider", () => {
+      registerFileUploadProvider(makeProvider("unconfigured", false));
+      const configured = makeProvider("configured", true);
+      registerFileUploadProvider(configured);
+
+      expect(getActiveFileUploadProvider()).toBe(configured);
+    });
+
+    it("falls back to the builder builtin when its env is set", () => {
+      registerFileUploadProvider(makeProvider("unconfigured", false));
+      process.env.BUILDER_PRIVATE_KEY = "bpk-123";
+
+      expect(getActiveFileUploadProvider()).toBe(builderFileUploadProvider);
+    });
+
+    it("returns null when nothing is configured", () => {
+      registerFileUploadProvider(makeProvider("unconfigured", false));
+      expect(getActiveFileUploadProvider()).toBeNull();
+    });
+
+    it("prefers a configured user provider over the builder builtin", () => {
+      process.env.BUILDER_PRIVATE_KEY = "bpk-123";
+      const s3 = makeProvider("s3", true);
+      registerFileUploadProvider(s3);
+      expect(getActiveFileUploadProvider()).toBe(s3);
+    });
+  });
+
+  describe("uploadFile dispatch", () => {
+    it("uses a configured user provider directly without resolving builder creds", async () => {
+      const upload = vi.fn(async () => ({
+        url: "https://cdn/s3/x",
+        provider: "s3",
+      }));
+      registerFileUploadProvider(makeProvider("s3", true, upload));
+
+      const input = { data: new Uint8Array([1, 2, 3]), filename: "x.png" };
+      const result = await uploadFile(input);
+
+      expect(result).toEqual({ url: "https://cdn/s3/x", provider: "s3" });
+      expect(upload).toHaveBeenCalledWith(input);
+      // The builder credential path must not be touched for user providers.
+      expect(resolveBuilderPrivateKeyMock).not.toHaveBeenCalled();
+    });
+
+    it("resolves builder credentials async and uploads via the builtin", async () => {
+      resolveBuilderPrivateKeyMock.mockResolvedValue("bpk-runtime");
+      const uploadSpy = vi
+        .spyOn(builderFileUploadProvider, "upload")
+        .mockResolvedValue({
+          url: "https://cdn.builder.io/abc",
+          id: "abc",
+          provider: "builder",
+        });
+
+      const input = { data: new Uint8Array([9]), mimeType: "image/png" };
+      const result = await uploadFile(input);
+
+      expect(result).toEqual({
+        url: "https://cdn.builder.io/abc",
+        id: "abc",
+        provider: "builder",
+      });
+      expect(uploadSpy).toHaveBeenCalledWith(input);
+      uploadSpy.mockRestore();
+    });
+
+    it("returns null (SQL fallback signal) when no creds resolve", async () => {
+      resolveBuilderPrivateKeyMock.mockResolvedValue(null);
+      const result = await uploadFile({ data: new Uint8Array([1]) });
+      expect(result).toBeNull();
+    });
+
+    it("falls back to null when credential resolution throws (DB unavailable)", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      resolveBuilderPrivateKeyMock.mockRejectedValue(new Error("db down"));
+
+      const result = await uploadFile({ data: new Uint8Array([1]) });
+
+      expect(result).toBeNull();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Builder credential check failed"),
+        expect.stringContaining("db down"),
+      );
+      warn.mockRestore();
+    });
+
+    it("does NOT swallow a real upload failure as a fallback", async () => {
+      // Creds resolve fine, so an upload error must propagate to the caller
+      // rather than being treated as a missing-provider null.
+      resolveBuilderPrivateKeyMock.mockResolvedValue("bpk-runtime");
+      const uploadSpy = vi
+        .spyOn(builderFileUploadProvider, "upload")
+        .mockRejectedValue(new Error("network blip"));
+
+      await expect(uploadFile({ data: new Uint8Array([1]) })).rejects.toThrow(
+        /network blip/,
+      );
+      uploadSpy.mockRestore();
+    });
+  });
+});

--- a/packages/core/src/integrations/adapters/google-docs.spec.ts
+++ b/packages/core/src/integrations/adapters/google-docs.spec.ts
@@ -1,0 +1,449 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Pull in the module fresh inside the token-exchange describe block so the
+// module-level token cache does not leak across tests. The pure helpers
+// (extractFileId, getServiceAccountKey, request builders) are stateless and
+// can use a single static import.
+import {
+  extractFileId,
+  getServiceAccountKey,
+  getServiceAccountEmail,
+  listDocComments,
+  replyToComment,
+  getStartPageToken,
+  listChanges,
+  googleDocsAdapter,
+} from "./google-docs.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  delete process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+});
+
+describe("extractFileId", () => {
+  it("extracts the file id from a /d/<id> document URL", () => {
+    expect(
+      extractFileId(
+        "https://docs.google.com/document/d/1AbC_def-123/edit?usp=sharing",
+      ),
+    ).toBe("1AbC_def-123");
+  });
+
+  it("returns the input unchanged when it is already a bare id", () => {
+    expect(extractFileId("1AbC_def-123")).toBe("1AbC_def-123");
+  });
+
+  it("returns the input when no /d/ segment is present", () => {
+    expect(extractFileId("https://example.com/foo")).toBe(
+      "https://example.com/foo",
+    );
+  });
+});
+
+describe("getServiceAccountKey / getServiceAccountEmail", () => {
+  it("returns null when the env var is unset", () => {
+    expect(getServiceAccountKey()).toBeNull();
+    expect(getServiceAccountEmail()).toBeNull();
+  });
+
+  it("parses an inline JSON key", () => {
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY = JSON.stringify({
+      client_email: "svc@project.iam.gserviceaccount.com",
+      private_key: "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----",
+    });
+
+    const key = getServiceAccountKey();
+    expect(key?.client_email).toBe("svc@project.iam.gserviceaccount.com");
+    expect(getServiceAccountEmail()).toBe(
+      "svc@project.iam.gserviceaccount.com",
+    );
+  });
+
+  it("falls back to reading a file path when the value is not JSON", async () => {
+    const os = await import("node:os");
+    const path = await import("node:path");
+    const fs = await import("node:fs");
+    const file = path.join(
+      os.tmpdir(),
+      `gdocs-key-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+    );
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ client_email: "file@svc.test", private_key: "k" }),
+    );
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY = file;
+
+    try {
+      expect(getServiceAccountKey()?.client_email).toBe("file@svc.test");
+    } finally {
+      fs.unlinkSync(file);
+    }
+  });
+
+  it("returns null when the value is neither valid JSON nor a readable file", () => {
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY = "/no/such/path/at/all.json";
+    expect(getServiceAccountKey()).toBeNull();
+  });
+});
+
+describe("listDocComments", () => {
+  it("requests the comments endpoint with the auth header and returns the array", async () => {
+    let captured: { url: string; headers: any } | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        captured = { url, headers: init?.headers };
+        return Promise.resolve(
+          new Response(JSON.stringify({ comments: [{ id: "c1" }] }), {
+            status: 200,
+          }),
+        );
+      }),
+    );
+
+    const comments = await listDocComments("FILE1", "tok-abc");
+
+    expect(comments).toEqual([{ id: "c1" }]);
+    expect(captured?.url).toContain("/files/FILE1/comments?");
+    expect(captured?.url).toContain("pageSize=100");
+    expect((captured?.headers as any).Authorization).toBe("Bearer tok-abc");
+    // No startModifiedTime filter unless provided.
+    expect(captured?.url).not.toContain("startModifiedTime");
+  });
+
+  it("includes startModifiedTime when provided", async () => {
+    let url = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((u: string) => {
+        url = u;
+        return Promise.resolve(
+          new Response(JSON.stringify({ comments: [] }), { status: 200 }),
+        );
+      }),
+    );
+
+    await listDocComments("FILE1", "tok", "2026-01-01T00:00:00Z");
+    expect(url).toContain("startModifiedTime=");
+  });
+
+  it("defaults to an empty array when the response has no comments field", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(new Response(JSON.stringify({}), { status: 200 })),
+      ),
+    );
+    await expect(listDocComments("F", "tok")).resolves.toEqual([]);
+  });
+
+  it("throws with the error body when the API call fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(new Response("permission denied", { status: 403 })),
+      ),
+    );
+    await expect(listDocComments("F", "tok")).rejects.toThrow(
+      /Failed to list comments: permission denied/,
+    );
+  });
+});
+
+describe("replyToComment", () => {
+  it("POSTs the content to the comment replies endpoint", async () => {
+    let captured: { url: string; init?: RequestInit } | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        captured = { url, init };
+        return Promise.resolve(new Response("{}", { status: 200 }));
+      }),
+    );
+
+    await replyToComment("FILE1", "CMT1", "On it!", "tok");
+
+    expect(captured?.url).toContain("/files/FILE1/comments/CMT1/replies");
+    expect(captured?.init?.method).toBe("POST");
+    expect(JSON.parse(String(captured?.init?.body))).toMatchObject({
+      content: "On it!",
+    });
+    expect((captured?.init?.headers as any).Authorization).toBe("Bearer tok");
+  });
+
+  it("throws when the reply request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response("nope", { status: 500 }))),
+    );
+    await expect(replyToComment("F", "C", "x", "tok")).rejects.toThrow(
+      /Failed to reply to comment: nope/,
+    );
+  });
+});
+
+describe("getStartPageToken", () => {
+  it("returns the start page token", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ startPageToken: "tok-42" }), {
+            status: 200,
+          }),
+        ),
+      ),
+    );
+    await expect(getStartPageToken("auth")).resolves.toBe("tok-42");
+  });
+
+  it("throws on failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response("", { status: 401 }))),
+    );
+    await expect(getStartPageToken("auth")).rejects.toThrow(
+      "Failed to get start page token",
+    );
+  });
+});
+
+describe("listChanges", () => {
+  it("returns changes and prefers nextPageToken from the response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              changes: [{ fileId: "f1", removed: false }],
+              nextPageToken: "next-1",
+            }),
+            { status: 200 },
+          ),
+        ),
+      ),
+    );
+
+    const result = await listChanges("page-0", "tok");
+    expect(result.changes).toEqual([{ fileId: "f1", removed: false }]);
+    expect(result.nextPageToken).toBe("next-1");
+  });
+
+  it("falls back to newStartPageToken, then the input token, when nextPageToken is absent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ newStartPageToken: "fresh-start" }), {
+            status: 200,
+          }),
+        ),
+      ),
+    );
+    const withNewStart = await listChanges("page-0", "tok");
+    expect(withNewStart.changes).toEqual([]);
+    expect(withNewStart.nextPageToken).toBe("fresh-start");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(new Response(JSON.stringify({}), { status: 200 })),
+      ),
+    );
+    const noTokens = await listChanges("page-input", "tok");
+    expect(noTokens.nextPageToken).toBe("page-input");
+  });
+
+  it("throws with the error body on failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response("boom", { status: 500 }))),
+    );
+    await expect(listChanges("p", "tok")).rejects.toThrow(
+      /Failed to list changes: boom/,
+    );
+  });
+});
+
+describe("getServiceAccountAccessToken (with module-level cache)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+  });
+
+  it("returns null when no service account key is configured", async () => {
+    const mod = await import("./google-docs.js");
+    await expect(mod.getServiceAccountAccessToken()).resolves.toBeNull();
+  });
+
+  it("signs a JWT, exchanges it for a token, and caches the result", async () => {
+    // Generate a real RSA key so node:crypto can actually sign the JWT.
+    const crypto = await import("node:crypto");
+    const { privateKey } = crypto.generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      publicKeyEncoding: { type: "spki", format: "pem" },
+    });
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY = JSON.stringify({
+      client_email: "svc@project.iam.gserviceaccount.com",
+      private_key: privateKey,
+    });
+
+    const fetchSpy = vi.fn(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ access_token: "ya29.token", expires_in: 3600 }),
+          { status: 200 },
+        ),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const mod = await import("./google-docs.js");
+    const first = await mod.getServiceAccountAccessToken();
+    expect(first).toBe("ya29.token");
+
+    // The token-exchange POST carries a JWT assertion built from the key.
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const params = String(init.body);
+    expect(params).toContain(
+      "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer",
+    );
+    expect(params).toContain("assertion=");
+
+    // Second call within the validity window is served from cache — no
+    // additional token exchange.
+    const second = await mod.getServiceAccountAccessToken();
+    expect(second).toBe("ya29.token");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null and does not cache when the token exchange fails", async () => {
+    const crypto = await import("node:crypto");
+    const { privateKey } = crypto.generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      publicKeyEncoding: { type: "spki", format: "pem" },
+    });
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY = JSON.stringify({
+      client_email: "svc@project.iam.gserviceaccount.com",
+      private_key: privateKey,
+    });
+
+    const fetchSpy = vi.fn(() =>
+      Promise.resolve(new Response("invalid_grant", { status: 400 })),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const mod = await import("./google-docs.js");
+    await expect(mod.getServiceAccountAccessToken()).resolves.toBeNull();
+    // A retry still hits the network (nothing cached on failure).
+    await mod.getServiceAccountAccessToken();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("googleDocsAdapter", () => {
+  it("is poll-driven: parseIncomingMessage and handleVerification short-circuit", async () => {
+    const adapter = googleDocsAdapter();
+    await expect(adapter.parseIncomingMessage({} as any)).resolves.toBeNull();
+    await expect(adapter.handleVerification({} as any)).resolves.toEqual({
+      handled: false,
+    });
+    // verifyWebhook trusts the poller (no inbound webhook to verify).
+    await expect(adapter.verifyWebhook({} as any)).resolves.toBe(true);
+  });
+
+  it("formatAgentResponse passes text through as plain text", () => {
+    const out = googleDocsAdapter().formatAgentResponse("**hi**");
+    expect(out.text).toBe("**hi**");
+    expect(out.platformContext).toEqual({});
+  });
+
+  it("reports configured status from the service account key", async () => {
+    delete process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+    const unconfigured = await googleDocsAdapter().getStatus();
+    expect(unconfigured.configured).toBe(false);
+    expect(unconfigured.error).toMatch(/GOOGLE_SERVICE_ACCOUNT_KEY/);
+
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY = JSON.stringify({
+      client_email: "svc@x.test",
+      private_key: "k",
+    });
+    const configured = await googleDocsAdapter().getStatus();
+    expect(configured.configured).toBe(true);
+    expect(configured.error).toBeUndefined();
+    expect(configured.details?.serviceAccountEmail).toBe("svc@x.test");
+  });
+
+  it("sendResponse replies to the doc comment using a resolved access token", async () => {
+    // Use a real key so getServiceAccountAccessToken can mint a token via the
+    // mocked token endpoint, then assert the reply hits the comments endpoint.
+    vi.resetModules();
+    const crypto = await import("node:crypto");
+    const { privateKey } = crypto.generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      publicKeyEncoding: { type: "spki", format: "pem" },
+    });
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY = JSON.stringify({
+      client_email: "svc@x.test",
+      private_key: privateKey,
+    });
+
+    const replyUrls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (String(url).includes("oauth2.googleapis.com/token")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ access_token: "ya29.x", expires_in: 3600 }),
+              { status: 200 },
+            ),
+          );
+        }
+        replyUrls.push(String(url));
+        return Promise.resolve(new Response("{}", { status: 200 }));
+      }),
+    );
+
+    const mod = await import("./google-docs.js");
+    await mod.googleDocsAdapter().sendResponse(
+      { text: "reply body", platformContext: {} },
+      {
+        platform: "google-docs",
+        externalThreadId: "FILE9:CMT9",
+        text: "@agent help",
+        timestamp: 1,
+        platformContext: { fileId: "FILE9", commentId: "CMT9" },
+      },
+    );
+
+    expect(replyUrls).toHaveLength(1);
+    expect(replyUrls[0]).toContain("/files/FILE9/comments/CMT9/replies");
+  });
+
+  it("sendResponse does nothing when no access token can be resolved", async () => {
+    vi.resetModules();
+    delete process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const mod = await import("./google-docs.js");
+    await mod.googleDocsAdapter().sendResponse(
+      { text: "reply", platformContext: {} },
+      {
+        platform: "google-docs",
+        externalThreadId: "F:C",
+        text: "x",
+        timestamp: 1,
+        platformContext: { fileId: "F", commentId: "C" },
+      },
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/integrations/adapters/telegram.spec.ts
+++ b/packages/core/src/integrations/adapters/telegram.spec.ts
@@ -1,0 +1,449 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  header: undefined as string | undefined,
+}));
+
+vi.mock("h3", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("h3")>();
+  return {
+    ...actual,
+    // verifyWebhook reads the Telegram secret header through h3.getHeader.
+    getHeader: vi.fn(() => hoisted.header),
+  };
+});
+
+// telegram.ts reads the request body via the core readBody helper; the parser
+// uses the body cached on event.context.__rawBody when present, so tests set
+// that directly and never need the real h3 stream.
+vi.mock("../../server/h3-helpers.js", () => ({
+  readBody: vi.fn(async (event: any) => event.context.__rawBody ?? {}),
+}));
+
+import { telegramAdapter } from "./telegram.js";
+
+/** Event whose pre-cached body is the given Telegram update object. */
+function eventWithBody(body: unknown): any {
+  return { context: { __rawBody: body } };
+}
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  hoisted.header = undefined;
+  process.env.NODE_ENV = originalNodeEnv;
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  delete process.env.TELEGRAM_WEBHOOK_SECRET;
+  delete process.env.AGENT_NATIVE_ALLOW_UNVERIFIED_WEBHOOKS;
+});
+
+describe("telegramAdapter parseIncomingMessage", () => {
+  function update(extra: Record<string, unknown> = {}) {
+    return {
+      message: {
+        message_id: 42,
+        date: 1700000000,
+        chat: { id: 555, type: "private" },
+        from: { id: 777, first_name: "Ada", username: "ada_l" },
+        text: "ship it",
+        ...extra,
+      },
+    };
+  }
+
+  it("normalizes a valid text message", async () => {
+    const msg = await telegramAdapter().parseIncomingMessage(
+      eventWithBody(update()),
+    );
+
+    expect(msg).toMatchObject({
+      platform: "telegram",
+      externalThreadId: "555",
+      text: "ship it",
+      senderName: "Ada",
+      senderId: "777",
+      timestamp: 1700000000 * 1000,
+    });
+    expect(msg?.platformContext).toMatchObject({
+      chatId: 555,
+      chatType: "private",
+      messageId: 42,
+      rawText: "ship it",
+      fromId: 777,
+      fromUsername: "ada_l",
+    });
+  });
+
+  it("joins first and last name for senderName", async () => {
+    const msg = await telegramAdapter().parseIncomingMessage(
+      eventWithBody(
+        update({ from: { id: 1, first_name: "Ada", last_name: "Lovelace" } }),
+      ),
+    );
+    expect(msg?.senderName).toBe("Ada Lovelace");
+  });
+
+  it("handles edited_message updates", async () => {
+    const body = {
+      edited_message: {
+        message_id: 9,
+        date: 1700000001,
+        chat: { id: 1, type: "group" },
+        from: { id: 2, first_name: "Edited" },
+        text: "fixed typo",
+      },
+    };
+    const msg = await telegramAdapter().parseIncomingMessage(
+      eventWithBody(body),
+    );
+    expect(msg?.text).toBe("fixed typo");
+    expect(msg?.platformContext.messageId).toBe(9);
+  });
+
+  it("maps /start to a friendly greeting", async () => {
+    const msg = await telegramAdapter().parseIncomingMessage(
+      eventWithBody(update({ text: "/start" })),
+    );
+    expect(msg?.text).toBe("Hello! I'm ready to chat.");
+    // rawText preserves the original command.
+    expect(msg?.platformContext.rawText).toBe("/start");
+  });
+
+  it("strips a leading bot command prefix", async () => {
+    const msg = await telegramAdapter().parseIncomingMessage(
+      eventWithBody(update({ text: "/ask what's the weather" })),
+    );
+    expect(msg?.text).toBe("what's the weather");
+    expect(msg?.platformContext.rawText).toBe("/ask what's the weather");
+  });
+
+  it("falls back to the raw text when stripping a command leaves nothing", async () => {
+    const msg = await telegramAdapter().parseIncomingMessage(
+      eventWithBody(update({ text: "/help" })),
+    );
+    expect(msg?.text).toBe("/help");
+  });
+
+  it("returns null for a non-message update (no message/edited_message)", async () => {
+    const msg = await telegramAdapter().parseIncomingMessage(
+      eventWithBody({ callback_query: { id: "abc" } }),
+    );
+    expect(msg).toBeNull();
+  });
+
+  it("returns null for a non-text message (e.g. photo only)", async () => {
+    const msg = await telegramAdapter().parseIncomingMessage(
+      eventWithBody(update({ text: undefined, photo: [{ file_id: "x" }] })),
+    );
+    expect(msg).toBeNull();
+  });
+
+  it("returns null for a whitespace-only message", async () => {
+    const msg = await telegramAdapter().parseIncomingMessage(
+      eventWithBody(update({ text: "   \n  " })),
+    );
+    expect(msg).toBeNull();
+  });
+
+  it("returns null when the body is empty", async () => {
+    const msg = await telegramAdapter().parseIncomingMessage(
+      eventWithBody(null),
+    );
+    expect(msg).toBeNull();
+  });
+});
+
+describe("telegramAdapter handleVerification", () => {
+  it("caches the raw body and never short-circuits", async () => {
+    const event: any = { context: {} };
+    const readBody = await import("../../server/h3-helpers.js");
+    (readBody.readBody as any).mockResolvedValueOnce({
+      message: { text: "hi" },
+    });
+
+    const result = await telegramAdapter().handleVerification(event);
+
+    expect(result).toEqual({ handled: false });
+    expect(event.context.__rawBody).toEqual({ message: { text: "hi" } });
+  });
+
+  it("does not re-read a body that is already cached", async () => {
+    const event: any = { context: { __rawBody: { message: { text: "x" } } } };
+    const readBody = await import("../../server/h3-helpers.js");
+    (readBody.readBody as any).mockClear();
+
+    await telegramAdapter().handleVerification(event);
+
+    expect(readBody.readBody as any).not.toHaveBeenCalled();
+  });
+});
+
+describe("telegramAdapter verifyWebhook (security)", () => {
+  it("refuses webhooks in production when no secret is set (fail closed)", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.TELEGRAM_BOT_TOKEN = "123:abc";
+
+    await expect(telegramAdapter().verifyWebhook({} as any)).resolves.toBe(
+      false,
+    );
+  });
+
+  it("accepts unverified webhooks in production when explicitly opted in", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.AGENT_NATIVE_ALLOW_UNVERIFIED_WEBHOOKS = "1";
+    process.env.TELEGRAM_BOT_TOKEN = "123:abc";
+
+    await expect(telegramAdapter().verifyWebhook({} as any)).resolves.toBe(
+      true,
+    );
+  });
+
+  it("in dev without a secret, accepts only when the bot token is configured", async () => {
+    process.env.NODE_ENV = "development";
+
+    await expect(telegramAdapter().verifyWebhook({} as any)).resolves.toBe(
+      false,
+    );
+
+    process.env.TELEGRAM_BOT_TOKEN = "123:abc";
+    await expect(telegramAdapter().verifyWebhook({} as any)).resolves.toBe(
+      true,
+    );
+  });
+
+  it("with a secret set, accepts only a matching header (timing-safe)", async () => {
+    process.env.TELEGRAM_WEBHOOK_SECRET = "s3cr3t-token";
+    hoisted.header = "s3cr3t-token";
+
+    await expect(telegramAdapter().verifyWebhook({} as any)).resolves.toBe(
+      true,
+    );
+  });
+
+  it("with a secret set, rejects a same-length mismatched header (timingSafeEqual returns false)", async () => {
+    process.env.TELEGRAM_WEBHOOK_SECRET = "s3cr3t-token";
+    hoisted.header = "wrong--token"; // same 12-char length, different content
+
+    await expect(telegramAdapter().verifyWebhook({} as any)).resolves.toBe(
+      false,
+    );
+  });
+
+  it("with a secret set, rejects a different-length header (timingSafeEqual throws, caught)", async () => {
+    process.env.TELEGRAM_WEBHOOK_SECRET = "s3cr3t-token";
+    hoisted.header = "wrong-token"; // 11 chars vs 12 — length mismatch path
+
+    await expect(telegramAdapter().verifyWebhook({} as any)).resolves.toBe(
+      false,
+    );
+  });
+
+  it("with a secret set, rejects when no header is present", async () => {
+    process.env.TELEGRAM_WEBHOOK_SECRET = "s3cr3t-token";
+    hoisted.header = undefined;
+
+    await expect(telegramAdapter().verifyWebhook({} as any)).resolves.toBe(
+      false,
+    );
+  });
+});
+
+describe("telegramAdapter formatAgentResponse", () => {
+  it("downconverts **double** asterisk bold to Telegram's *single* bold", () => {
+    const out = telegramAdapter().formatAgentResponse(
+      "**Important** and **also this**",
+    );
+    expect(out.text).toBe("*Important* and *also this*");
+    expect(out.platformContext.parse_mode).toBe("Markdown");
+  });
+
+  it("rewrites bold spanning multiple lines", () => {
+    const out = telegramAdapter().formatAgentResponse("**line one\nline two**");
+    expect(out.text).toBe("*line one\nline two*");
+  });
+});
+
+describe("telegramAdapter sendResponse", () => {
+  it("does nothing without a bot token", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await telegramAdapter().sendResponse(
+      { text: "hi", platformContext: {} },
+      {
+        platform: "telegram",
+        externalThreadId: "555",
+        text: "q",
+        timestamp: 1,
+        platformContext: { chatId: 555 },
+      },
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("posts the message with Markdown parse_mode to the chat", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "123:abc";
+    const calls: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        calls.push({ url, body: JSON.parse(String(init?.body)) });
+        return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+      }),
+    );
+
+    await telegramAdapter().sendResponse(
+      { text: "*hi*", platformContext: {} },
+      {
+        platform: "telegram",
+        externalThreadId: "555",
+        text: "q",
+        timestamp: 1,
+        platformContext: { chatId: 555 },
+      },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain("/bot123:abc/sendMessage");
+    expect(calls[0].body).toMatchObject({
+      chat_id: 555,
+      text: "*hi*",
+      parse_mode: "Markdown",
+    });
+  });
+
+  it("retries without Markdown when Telegram reports a parse error", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "123:abc";
+    const bodies: any[] = [];
+    let call = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        call += 1;
+        const ok = call > 1; // first attempt fails with a parse error
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              ok,
+              description: ok ? undefined : "Bad Request: can't parse entities",
+            }),
+          ),
+        );
+      }),
+    );
+
+    await telegramAdapter().sendResponse(
+      { text: "*broken", platformContext: {} },
+      {
+        platform: "telegram",
+        externalThreadId: "555",
+        text: "q",
+        timestamp: 1,
+        platformContext: { chatId: 555 },
+      },
+    );
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0].parse_mode).toBe("Markdown");
+    // retry strips parse_mode entirely
+    expect(bodies[1].parse_mode).toBeUndefined();
+    expect(bodies[1].text).toBe("*broken");
+  });
+
+  it("splits messages longer than the Telegram length limit", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "123:abc";
+    const bodies: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+      }),
+    );
+
+    const long = `${"a".repeat(4096)} ${"b".repeat(20)}`;
+    await telegramAdapter().sendResponse(
+      { text: long, platformContext: {} },
+      {
+        platform: "telegram",
+        externalThreadId: "555",
+        text: "q",
+        timestamp: 1,
+        platformContext: { chatId: 555 },
+      },
+    );
+
+    expect(bodies.length).toBeGreaterThan(1);
+    expect(bodies.every((b) => b.text.length <= 4096)).toBe(true);
+  });
+});
+
+describe("telegramAdapter sendMessageToTarget", () => {
+  it("posts to the target destination and includes a thread id when given", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "123:abc";
+    const bodies: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+      }),
+    );
+
+    await telegramAdapter().sendMessageToTarget!(
+      { text: "ping", platformContext: {} },
+      { destination: "999", threadRef: "12" },
+    );
+
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toMatchObject({
+      chat_id: "999",
+      text: "ping",
+      message_thread_id: "12",
+    });
+  });
+
+  it("omits message_thread_id when no threadRef is given", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "123:abc";
+    let body: any;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        body = JSON.parse(String(init?.body));
+        return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+      }),
+    );
+
+    await telegramAdapter().sendMessageToTarget!(
+      { text: "ping", platformContext: {} },
+      { destination: "999" },
+    );
+
+    expect(body).not.toHaveProperty("message_thread_id");
+  });
+
+  it("throws when the Telegram API reports failure", async () => {
+    process.env.TELEGRAM_BOT_TOKEN = "123:abc";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({ ok: false, description: "chat not found" }),
+          ),
+        ),
+      ),
+    );
+
+    await expect(
+      telegramAdapter().sendMessageToTarget!(
+        { text: "ping", platformContext: {} },
+        { destination: "999" },
+      ),
+    ).rejects.toThrow("chat not found");
+  });
+});

--- a/packages/core/src/integrations/adapters/whatsapp.spec.ts
+++ b/packages/core/src/integrations/adapters/whatsapp.spec.ts
@@ -1,0 +1,434 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  query: {} as Record<string, unknown>,
+  header: undefined as string | undefined,
+}));
+
+vi.mock("h3", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("h3")>();
+  return {
+    ...actual,
+    // The adapter reads the raw body via h3.readRawBody and caches it on
+    // event.context.__rawBody. Return the cached string (set per test).
+    readRawBody: vi.fn(async (event: any) => event.context.__rawBody),
+    getQuery: vi.fn(() => hoisted.query),
+    getHeader: vi.fn(() => hoisted.header),
+  };
+});
+
+import { whatsappAdapter } from "./whatsapp.js";
+
+/** Event whose raw body is the given JSON string (already stringified). */
+function eventWithRaw(raw: string | undefined, method = "POST"): any {
+  return { context: { __rawBody: raw }, node: { req: { method } } };
+}
+
+/** A well-formed WhatsApp Cloud API text-message webhook payload. */
+function textWebhook(overrides: Record<string, any> = {}) {
+  return {
+    entry: [
+      {
+        changes: [
+          {
+            field: "messages",
+            value: {
+              metadata: {
+                phone_number_id: "PNID",
+                display_phone_number: "+15550000000",
+              },
+              contacts: [{ profile: { name: "Grace" } }],
+              messages: [
+                {
+                  id: "wamid.1",
+                  type: "text",
+                  from: "15551234567",
+                  timestamp: "1700000000",
+                  text: { body: "ship it" },
+                  ...overrides.message,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+    ...overrides.top,
+  };
+}
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  hoisted.query = {};
+  hoisted.header = undefined;
+  process.env.NODE_ENV = originalNodeEnv;
+  delete process.env.WHATSAPP_ACCESS_TOKEN;
+  delete process.env.WHATSAPP_VERIFY_TOKEN;
+  delete process.env.WHATSAPP_PHONE_NUMBER_ID;
+  delete process.env.WHATSAPP_APP_SECRET;
+  delete process.env.AGENT_NATIVE_ALLOW_UNVERIFIED_WEBHOOKS;
+});
+
+describe("whatsappAdapter parseIncomingMessage", () => {
+  it("normalizes a valid text message", async () => {
+    const msg = await whatsappAdapter().parseIncomingMessage(
+      eventWithRaw(JSON.stringify(textWebhook())),
+    );
+
+    expect(msg).toMatchObject({
+      platform: "whatsapp",
+      externalThreadId: "15551234567",
+      text: "ship it",
+      senderName: "Grace",
+      senderId: "15551234567",
+      timestamp: 1700000000 * 1000,
+    });
+    expect(msg?.platformContext).toMatchObject({
+      phoneNumberId: "PNID",
+      displayPhoneNumber: "+15550000000",
+      messageId: "wamid.1",
+      from: "15551234567",
+      timestamp: "1700000000",
+    });
+  });
+
+  it("returns null for malformed JSON", async () => {
+    const msg = await whatsappAdapter().parseIncomingMessage(
+      eventWithRaw("{not json"),
+    );
+    expect(msg).toBeNull();
+  });
+
+  it("returns null when the body is empty", async () => {
+    const msg = await whatsappAdapter().parseIncomingMessage(eventWithRaw(""));
+    expect(msg).toBeNull();
+  });
+
+  it("returns null when the change field is not 'messages' (e.g. statuses)", async () => {
+    const payload = textWebhook();
+    payload.entry[0].changes[0].field = "statuses";
+    const msg = await whatsappAdapter().parseIncomingMessage(
+      eventWithRaw(JSON.stringify(payload)),
+    );
+    expect(msg).toBeNull();
+  });
+
+  it("returns null for non-text message types (e.g. image)", async () => {
+    const msg = await whatsappAdapter().parseIncomingMessage(
+      eventWithRaw(
+        JSON.stringify(
+          textWebhook({ message: { type: "image", text: undefined } }),
+        ),
+      ),
+    );
+    expect(msg).toBeNull();
+  });
+
+  it("returns null when the text body is whitespace only", async () => {
+    const msg = await whatsappAdapter().parseIncomingMessage(
+      eventWithRaw(
+        JSON.stringify(textWebhook({ message: { text: { body: "   " } } })),
+      ),
+    );
+    expect(msg).toBeNull();
+  });
+
+  it("returns null when there is no entry (delivery callback shape)", async () => {
+    const msg = await whatsappAdapter().parseIncomingMessage(
+      eventWithRaw(JSON.stringify({ object: "whatsapp_business_account" })),
+    );
+    expect(msg).toBeNull();
+  });
+
+  it("trims surrounding whitespace from the message text", async () => {
+    const msg = await whatsappAdapter().parseIncomingMessage(
+      eventWithRaw(
+        JSON.stringify(textWebhook({ message: { text: { body: "  hi  " } } })),
+      ),
+    );
+    expect(msg?.text).toBe("hi");
+  });
+});
+
+describe("whatsappAdapter handleVerification (GET challenge handshake)", () => {
+  function getEvent(): any {
+    return { context: {}, node: { req: { method: "GET" } } };
+  }
+
+  it("echoes the challenge when the verify token matches", async () => {
+    process.env.WHATSAPP_VERIFY_TOKEN = "my-verify-token";
+    hoisted.query = {
+      "hub.mode": "subscribe",
+      "hub.verify_token": "my-verify-token",
+      "hub.challenge": "challenge-123",
+    };
+
+    await expect(
+      whatsappAdapter().handleVerification(getEvent()),
+    ).resolves.toEqual({ handled: true, response: "challenge-123" });
+  });
+
+  it("does not handle when the verify token mismatches (same length)", async () => {
+    process.env.WHATSAPP_VERIFY_TOKEN = "my-verify-token";
+    hoisted.query = {
+      "hub.mode": "subscribe",
+      "hub.verify_token": "XX-verify-token",
+      "hub.challenge": "challenge-123",
+    };
+
+    await expect(
+      whatsappAdapter().handleVerification(getEvent()),
+    ).resolves.toEqual({ handled: false });
+  });
+
+  it("does not handle when the verify token length differs", async () => {
+    process.env.WHATSAPP_VERIFY_TOKEN = "my-verify-token";
+    hoisted.query = {
+      "hub.mode": "subscribe",
+      "hub.verify_token": "short",
+      "hub.challenge": "challenge-123",
+    };
+
+    await expect(
+      whatsappAdapter().handleVerification(getEvent()),
+    ).resolves.toEqual({ handled: false });
+  });
+
+  it("does not handle when mode is not 'subscribe'", async () => {
+    process.env.WHATSAPP_VERIFY_TOKEN = "my-verify-token";
+    hoisted.query = {
+      "hub.mode": "unsubscribe",
+      "hub.verify_token": "my-verify-token",
+      "hub.challenge": "challenge-123",
+    };
+
+    await expect(
+      whatsappAdapter().handleVerification(getEvent()),
+    ).resolves.toEqual({ handled: false });
+  });
+
+  it("pre-caches the raw body once on POST so the consume-once stream is not double-read", async () => {
+    // POST must NOT take the GET challenge path even when verify-token query
+    // params are present — it pre-reads the raw body and returns handled:false.
+    process.env.WHATSAPP_VERIFY_TOKEN = "my-verify-token";
+    hoisted.query = {
+      "hub.mode": "subscribe",
+      "hub.verify_token": "my-verify-token",
+      "hub.challenge": "challenge-123",
+    };
+    const h3 = await import("h3");
+    const readRawBody = h3.readRawBody as unknown as ReturnType<typeof vi.fn>;
+    // Event has no cached body yet; the source wrapper reads via h3 once and
+    // caches the bytes on event.context.__rawBody (M3 consume-once guard).
+    const event: any = { context: {}, node: { req: { method: "POST" } } };
+    readRawBody.mockResolvedValueOnce('{"entry":[]}');
+
+    const result = await whatsappAdapter().handleVerification(event);
+
+    expect(result).toEqual({ handled: false });
+    expect(event.context.__rawBody).toBe('{"entry":[]}');
+
+    // A second read (e.g. from verifyWebhook/parseIncomingMessage) is served
+    // from the cache and never re-streams the request.
+    readRawBody.mockClear();
+    await whatsappAdapter().parseIncomingMessage(event);
+    expect(readRawBody).not.toHaveBeenCalled();
+  });
+});
+
+describe("whatsappAdapter verifyWebhook (security)", () => {
+  it("refuses webhooks in production when no app secret is set (fail closed)", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.WHATSAPP_ACCESS_TOKEN = "tok";
+
+    await expect(whatsappAdapter().verifyWebhook({} as any)).resolves.toBe(
+      false,
+    );
+  });
+
+  it("accepts unverified webhooks in production when explicitly opted in", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.AGENT_NATIVE_ALLOW_UNVERIFIED_WEBHOOKS = "1";
+    process.env.WHATSAPP_ACCESS_TOKEN = "tok";
+
+    await expect(whatsappAdapter().verifyWebhook({} as any)).resolves.toBe(
+      true,
+    );
+  });
+
+  it("in dev without a secret, accepts only when the access token is configured", async () => {
+    process.env.NODE_ENV = "development";
+
+    await expect(whatsappAdapter().verifyWebhook({} as any)).resolves.toBe(
+      false,
+    );
+
+    process.env.WHATSAPP_ACCESS_TOKEN = "tok";
+    await expect(whatsappAdapter().verifyWebhook({} as any)).resolves.toBe(
+      true,
+    );
+  });
+
+  it("accepts a request whose HMAC-SHA256 signature matches the app secret", async () => {
+    process.env.WHATSAPP_APP_SECRET = "shh";
+    const raw = JSON.stringify(textWebhook());
+    const crypto = await import("node:crypto");
+    const expected =
+      "sha256=" + crypto.createHmac("sha256", "shh").update(raw).digest("hex");
+    hoisted.header = expected;
+
+    await expect(
+      whatsappAdapter().verifyWebhook(eventWithRaw(raw)),
+    ).resolves.toBe(true);
+  });
+
+  it("rejects a request whose signature does not match", async () => {
+    process.env.WHATSAPP_APP_SECRET = "shh";
+    const raw = JSON.stringify(textWebhook());
+    // signature computed over a DIFFERENT body — must fail
+    const crypto = await import("node:crypto");
+    hoisted.header =
+      "sha256=" +
+      crypto.createHmac("sha256", "shh").update("tampered").digest("hex");
+
+    await expect(
+      whatsappAdapter().verifyWebhook(eventWithRaw(raw)),
+    ).resolves.toBe(false);
+  });
+
+  it("rejects when the signature header is absent", async () => {
+    process.env.WHATSAPP_APP_SECRET = "shh";
+    hoisted.header = undefined;
+
+    await expect(
+      whatsappAdapter().verifyWebhook(eventWithRaw("{}")),
+    ).resolves.toBe(false);
+  });
+
+  it("verifies over the exact raw bytes, not a JSON-equivalent re-serialization (M2)", async () => {
+    // Meta signs the exact bytes it sent. A signature minted over a byte
+    // variant (extra whitespace, same JSON value) must be rejected — the
+    // adapter must NOT re-stringify a parsed body before comparing.
+    process.env.WHATSAPP_APP_SECRET = "shh";
+    const sentBytes = '{"a":1,"b":2}';
+    const reserializedBytes = '{ "a": 1, "b": 2 }'; // same value, different bytes
+    const crypto = await import("node:crypto");
+    hoisted.header =
+      "sha256=" +
+      crypto
+        .createHmac("sha256", "shh")
+        .update(reserializedBytes)
+        .digest("hex");
+
+    await expect(
+      whatsappAdapter().verifyWebhook(eventWithRaw(sentBytes)),
+    ).resolves.toBe(false);
+  });
+});
+
+describe("whatsappAdapter sendResponse", () => {
+  it("does nothing when access token or phone number id is missing", async () => {
+    process.env.WHATSAPP_ACCESS_TOKEN = "tok";
+    // no phone number id
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await whatsappAdapter().sendResponse(
+      { text: "hi", platformContext: {} },
+      {
+        platform: "whatsapp",
+        externalThreadId: "15551234567",
+        text: "q",
+        senderId: "15551234567",
+        timestamp: 1,
+        platformContext: {},
+      },
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("posts a text message to the recipient via the Graph API", async () => {
+    process.env.WHATSAPP_ACCESS_TOKEN = "tok";
+    process.env.WHATSAPP_PHONE_NUMBER_ID = "PNID";
+    const calls: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        calls.push({
+          url,
+          headers: init?.headers,
+          body: JSON.parse(String(init?.body)),
+        });
+        return Promise.resolve(
+          new Response(JSON.stringify({}), { status: 200 }),
+        );
+      }),
+    );
+
+    await whatsappAdapter().sendResponse(
+      { text: "hello there", platformContext: {} },
+      {
+        platform: "whatsapp",
+        externalThreadId: "15551234567",
+        text: "q",
+        senderId: "15551234567",
+        timestamp: 1,
+        platformContext: {},
+      },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain("/v21.0/PNID/messages");
+    expect((calls[0].headers as any).Authorization).toBe("Bearer tok");
+    expect(calls[0].body).toMatchObject({
+      messaging_product: "whatsapp",
+      recipient_type: "individual",
+      to: "15551234567",
+      type: "text",
+      text: { body: "hello there" },
+    });
+  });
+
+  it("splits replies longer than the WhatsApp length limit", async () => {
+    process.env.WHATSAPP_ACCESS_TOKEN = "tok";
+    process.env.WHATSAPP_PHONE_NUMBER_ID = "PNID";
+    const bodies: any[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        return Promise.resolve(
+          new Response(JSON.stringify({}), { status: 200 }),
+        );
+      }),
+    );
+
+    const long = `${"x".repeat(4096)} ${"y".repeat(50)}`;
+    await whatsappAdapter().sendResponse(
+      { text: long, platformContext: {} },
+      {
+        platform: "whatsapp",
+        externalThreadId: "15551234567",
+        text: "q",
+        senderId: "15551234567",
+        timestamp: 1,
+        platformContext: {},
+      },
+    );
+
+    expect(bodies.length).toBeGreaterThan(1);
+    expect(bodies.every((b) => b.text.body.length <= 4096)).toBe(true);
+  });
+});
+
+describe("whatsappAdapter formatAgentResponse", () => {
+  it("passes text through unchanged (WhatsApp uses plain text)", () => {
+    const out = whatsappAdapter().formatAgentResponse("**bold** _italic_");
+    expect(out.text).toBe("**bold** _italic_");
+    expect(out.platformContext).toEqual({});
+  });
+});

--- a/packages/core/src/jobs/cron.spec.ts
+++ b/packages/core/src/jobs/cron.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { describeCron, isValidCron, nextOccurrence } from "./cron.js";
+
+describe("isValidCron", () => {
+  it("accepts standard 5-field expressions", () => {
+    expect(isValidCron("0 9 * * *")).toBe(true);
+    expect(isValidCron("*/30 * * * *")).toBe(true);
+    expect(isValidCron("0 9 * * 1-5")).toBe(true);
+  });
+
+  it("rejects garbage and out-of-range fields", () => {
+    expect(isValidCron("not a cron")).toBe(false);
+    expect(isValidCron("99 99 * * *")).toBe(false);
+    // Whitespace-only parses as a 1-field expr and trips a range constraint.
+    expect(isValidCron("   ")).toBe(false);
+  });
+
+  it("normalizes the @midnight alias that cron-parser v5 mishandles", () => {
+    // The whole reason ALIAS_MAP exists: without normalization cron-parser
+    // would throw on "@midnight". With it, the alias validates.
+    expect(isValidCron("@midnight")).toBe(true);
+    expect(isValidCron("  @MIDNIGHT  ")).toBe(true);
+  });
+});
+
+describe("nextOccurrence", () => {
+  // cron-parser interprets the cron fields in the runtime's local timezone, so
+  // assert with local-time getters to stay timezone-agnostic across CI hosts.
+  it("computes the next matching time strictly after the anchor", () => {
+    // Anchor before today's 09:00 local; expect today at 09:00 local.
+    const after = new Date("2026-01-15T00:00:00");
+    after.setHours(8, 0, 0, 0);
+    const next = nextOccurrence("0 9 * * *", after);
+    expect(next.getTime()).toBeGreaterThan(after.getTime());
+    expect(next.getHours()).toBe(9);
+    expect(next.getMinutes()).toBe(0);
+    expect(next.getDate()).toBe(15);
+  });
+
+  it("rolls to the next day when the anchor is past today's time", () => {
+    const after = new Date("2026-01-15T00:00:00");
+    after.setHours(10, 0, 0, 0);
+    const next = nextOccurrence("0 9 * * *", after);
+    expect(next.getDate()).toBe(16);
+    expect(next.getHours()).toBe(9);
+  });
+
+  it("honors the @midnight alias as 0 0 * * *", () => {
+    const after = new Date("2026-03-10T00:00:00");
+    after.setHours(12, 34, 0, 0);
+    const next = nextOccurrence("@midnight", after);
+    expect(next.getHours()).toBe(0);
+    expect(next.getMinutes()).toBe(0);
+    expect(next.getDate()).toBe(11);
+  });
+
+  it("advances on each successive call when fed its own output", () => {
+    const start = new Date("2026-01-01T00:00:00");
+    const first = nextOccurrence("*/15 * * * *", start);
+    const second = nextOccurrence("*/15 * * * *", first);
+    expect(second.getTime()).toBeGreaterThan(first.getTime());
+    expect(second.getTime() - first.getTime()).toBe(15 * 60_000);
+  });
+});
+
+describe("describeCron", () => {
+  it("describes every-minute and every-N-minutes", () => {
+    expect(describeCron("* * * * *")).toBe("Every minute");
+    expect(describeCron("*/5 * * * *")).toBe("Every 5 minutes");
+    expect(describeCron("*/30 * * * *")).toBe("Every 30 minutes");
+  });
+
+  it("describes hourly schedules with zero-padded minutes", () => {
+    expect(describeCron("0 * * * *")).toBe("Every hour at :00");
+    expect(describeCron("5 * * * *")).toBe("Every hour at :05");
+  });
+
+  it("describes a daily schedule with 12-hour AM/PM time", () => {
+    expect(describeCron("0 9 * * *")).toBe("Every day at 9 AM");
+    expect(describeCron("30 14 * * *")).toBe("Every day at 2:30 PM");
+    // midnight (hour 0) renders as 12 AM, noon as 12 PM.
+    expect(describeCron("0 0 * * *")).toBe("Every day at 12 AM");
+    expect(describeCron("0 12 * * *")).toBe("Every day at 12 PM");
+  });
+
+  it("describes weekday schedules for both 1-5 and MON-FRI", () => {
+    expect(describeCron("0 9 * * 1-5")).toBe("Every weekday at 9 AM");
+    expect(describeCron("0 9 * * MON-FRI")).toBe("Every weekday at 9 AM");
+  });
+
+  it("describes a specific day-of-week with its English name", () => {
+    expect(describeCron("0 9 * * 1")).toBe("Every Monday at 9 AM");
+    // 0 and 7 both mean Sunday.
+    expect(describeCron("0 9 * * 0")).toBe("Every Sunday at 9 AM");
+    expect(describeCron("0 9 * * 7")).toBe("Every Sunday at 9 AM");
+  });
+
+  it("describes a specific day-of-month schedule", () => {
+    expect(describeCron("0 9 15 * *")).toBe("On day 15 of every month at 9 AM");
+  });
+
+  it("joins multiple hours with 'and'", () => {
+    // Exercises the multi-hour formatTime branch (hours.join(" and ")).
+    expect(describeCron("0 9,17 * * *")).toBe("Every day at 9 AM and 5 PM");
+  });
+
+  it("joins multiple days-of-week with commas", () => {
+    // Exercises the comma-separated day-of-week branch (days.join(", ")).
+    expect(describeCron("0 9 * * 1,3,5")).toBe(
+      "Every Monday, Wednesday, Friday at 9 AM",
+    );
+  });
+
+  it("falls back to the raw expression for shapes it can't describe", () => {
+    // Wrong field count returns the raw input verbatim.
+    expect(describeCron("0 9 * *")).toBe("0 9 * *");
+    // A month-constrained expression isn't matched by any branch.
+    expect(describeCron("0 9 1 6 *")).toBe("0 9 1 6 *");
+  });
+
+  it("describes @midnight via the alias map", () => {
+    expect(describeCron("@midnight")).toBe("Every day at 12 AM");
+  });
+});

--- a/packages/core/src/jobs/tools.spec.ts
+++ b/packages/core/src/jobs/tools.spec.ts
@@ -1,0 +1,397 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createJobTools } from "./tools.js";
+import { parseJobFrontmatter } from "./scheduler.js";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+const resourcePutMock = vi.hoisted(() => vi.fn());
+const resourceGetByPathMock = vi.hoisted(() => vi.fn());
+const resourceListMock = vi.hoisted(() => vi.fn());
+const resourceDeleteMock = vi.hoisted(() => vi.fn());
+
+const getRequestUserEmailMock = vi.hoisted(() => vi.fn());
+const getRequestOrgIdMock = vi.hoisted(() => vi.fn());
+
+const dbExecuteMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../resources/store.js", () => ({
+  resourcePut: resourcePutMock,
+  resourceGetByPath: resourceGetByPathMock,
+  resourceList: resourceListMock,
+  resourceDelete: resourceDeleteMock,
+  SHARED_OWNER: "__shared__",
+}));
+
+vi.mock("../server/request-context.js", () => ({
+  getRequestUserEmail: getRequestUserEmailMock,
+  getRequestOrgId: getRequestOrgIdMock,
+}));
+
+// Partial-mock db/client so the org-admin lookup is stubbed while other
+// exports (getDialect, etc.) used transitively by db/schema stay real.
+vi.mock(import("../db/client.js"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getDbExec: () => ({ execute: dbExecuteMock }) as any,
+  };
+});
+
+const SHARED_OWNER = "__shared__";
+
+function run(args: Record<string, unknown>): Promise<string> {
+  const tools = createJobTools();
+  return tools["manage-jobs"].run(args as any, {} as any) as Promise<string>;
+}
+
+function sharedJobContent(opts: {
+  createdBy?: string;
+  orgId?: string;
+  runAs?: string;
+}): string {
+  const lines = ["---", 'schedule: "0 9 * * *"', "enabled: true"];
+  if (opts.createdBy) lines.push(`createdBy: ${opts.createdBy}`);
+  if (opts.orgId) lines.push(`orgId: ${opts.orgId}`);
+  if (opts.runAs) lines.push(`runAs: ${opts.runAs}`);
+  lines.push("---", "", "Summarize the inbox.");
+  return lines.join("\n");
+}
+
+describe("manage-jobs tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getRequestUserEmailMock.mockReturnValue("alice@example.com");
+    getRequestOrgIdMock.mockReturnValue("org-1");
+    resourcePutMock.mockResolvedValue(undefined);
+    resourceDeleteMock.mockResolvedValue(true);
+  });
+
+  describe("create", () => {
+    it("validates required fields", async () => {
+      const out = JSON.parse(await run({ action: "create", name: "x" }));
+      expect(out.error).toMatch(
+        /name, schedule, and instructions are required/,
+      );
+      expect(resourcePutMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects an invalid cron schedule", async () => {
+      const out = JSON.parse(
+        await run({
+          action: "create",
+          name: "x",
+          schedule: "not a cron",
+          instructions: "do it",
+        }),
+      );
+      expect(out.error).toMatch(/Invalid cron expression/);
+      expect(resourcePutMock).not.toHaveBeenCalled();
+    });
+
+    it("creates a shared job by default, owned by SHARED_OWNER, stamped with creator + orgId", async () => {
+      const out = JSON.parse(
+        await run({
+          action: "create",
+          name: "daily-report",
+          schedule: "0 9 * * *",
+          instructions: "Summarize the inbox.",
+        }),
+      );
+
+      expect(out.created).toBe(true);
+      expect(out.path).toBe("jobs/daily-report.md");
+      expect(out.scope).toBe("shared");
+      expect(typeof out.nextRun).toBe("string");
+
+      const [owner, path, content] = resourcePutMock.mock.calls[0];
+      expect(owner).toBe(SHARED_OWNER);
+      expect(path).toBe("jobs/daily-report.md");
+      const { meta } = parseJobFrontmatter(content);
+      expect(meta.createdBy).toBe("alice@example.com");
+      expect(meta.orgId).toBe("org-1");
+      // Default runAs is "creator" unless explicitly "shared".
+      expect(meta.runAs).toBe("creator");
+      expect(meta.nextRun).toBeTruthy();
+    });
+
+    it("creates a personal job owned by the caller", async () => {
+      await run({
+        action: "create",
+        name: "my-job",
+        schedule: "0 9 * * *",
+        instructions: "do it",
+        scope: "personal",
+      });
+      expect(resourcePutMock.mock.calls[0][0]).toBe("alice@example.com");
+    });
+
+    it("honors runAs: shared when requested", async () => {
+      await run({
+        action: "create",
+        name: "j",
+        schedule: "0 9 * * *",
+        instructions: "do it",
+        runAs: "shared",
+      });
+      const { meta } = parseJobFrontmatter(resourcePutMock.mock.calls[0][2]);
+      expect(meta.runAs).toBe("shared");
+    });
+  });
+
+  describe("update authorization (shared-job privilege escalation guard)", () => {
+    it("lets the original creator update their shared job", async () => {
+      resourceGetByPathMock.mockResolvedValueOnce({
+        id: "r1",
+        owner: SHARED_OWNER,
+        path: "jobs/j.md",
+        content: sharedJobContent({ createdBy: "alice@example.com" }),
+      });
+
+      const out = JSON.parse(
+        await run({ action: "update", name: "j", enabled: "false" }),
+      );
+      expect(out.updated).toBe(true);
+      expect(out.enabled).toBe(false);
+      expect(resourcePutMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("BLOCKS a non-creator non-admin from updating another user's shared job", async () => {
+      // Caller is mallory; job was created by alice; mallory is not an admin.
+      getRequestUserEmailMock.mockReturnValue("mallory@example.com");
+      resourceGetByPathMock.mockResolvedValueOnce({
+        id: "r1",
+        owner: SHARED_OWNER,
+        path: "jobs/j.md",
+        content: sharedJobContent({
+          createdBy: "alice@example.com",
+          orgId: "org-1",
+        }),
+      });
+      // org_members lookup returns no membership row -> not admin.
+      dbExecuteMock.mockResolvedValue({ rows: [] });
+
+      const out = JSON.parse(
+        await run({ action: "update", name: "j", instructions: "evil" }),
+      );
+
+      expect(out.error).toMatch(/Only the job's creator \(or an org admin\)/);
+      // The mutation must never reach the store.
+      expect(resourcePutMock).not.toHaveBeenCalled();
+    });
+
+    it("ALLOWS an org admin to update another user's shared job", async () => {
+      getRequestUserEmailMock.mockReturnValue("admin@example.com");
+      resourceGetByPathMock.mockResolvedValueOnce({
+        id: "r1",
+        owner: SHARED_OWNER,
+        path: "jobs/j.md",
+        content: sharedJobContent({
+          createdBy: "alice@example.com",
+          orgId: "org-1",
+        }),
+      });
+      // Membership row with admin role.
+      dbExecuteMock.mockResolvedValue({ rows: [{ role: "owner" }] });
+
+      const out = JSON.parse(
+        await run({ action: "update", name: "j", enabled: "false" }),
+      );
+      expect(out.updated).toBe(true);
+      expect(resourcePutMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("fails closed (denies) when the admin role lookup throws", async () => {
+      getRequestUserEmailMock.mockReturnValue("mallory@example.com");
+      resourceGetByPathMock.mockResolvedValueOnce({
+        id: "r1",
+        owner: SHARED_OWNER,
+        path: "jobs/j.md",
+        content: sharedJobContent({
+          createdBy: "alice@example.com",
+          orgId: "org-1",
+        }),
+      });
+      dbExecuteMock.mockRejectedValue(new Error("db error"));
+
+      const out = JSON.parse(
+        await run({ action: "update", name: "j", enabled: "false" }),
+      );
+      expect(out.error).toMatch(/Only the job's creator/);
+      expect(resourcePutMock).not.toHaveBeenCalled();
+    });
+
+    it("allows a personal-scope job update without an admin check", async () => {
+      // resource owner is the caller, not SHARED_OWNER -> authorizeJobMutation
+      // returns null immediately and never queries org_members.
+      resourceGetByPathMock
+        .mockResolvedValueOnce(null) // shared lookup misses
+        .mockResolvedValueOnce({
+          id: "r2",
+          owner: "alice@example.com",
+          path: "jobs/j.md",
+          content: sharedJobContent({ createdBy: "alice@example.com" }),
+        });
+
+      const out = JSON.parse(
+        await run({ action: "update", name: "j", enabled: "false" }),
+      );
+      expect(out.updated).toBe(true);
+      expect(dbExecuteMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("update behavior", () => {
+    it("returns an error when the job is not found", async () => {
+      resourceGetByPathMock.mockResolvedValue(null);
+      const out = JSON.parse(await run({ action: "update", name: "ghost" }));
+      expect(out.error).toMatch(/Job "ghost" not found/);
+    });
+
+    it("rejects an invalid new schedule and does not persist", async () => {
+      resourceGetByPathMock.mockResolvedValueOnce({
+        id: "r1",
+        owner: SHARED_OWNER,
+        path: "jobs/j.md",
+        content: sharedJobContent({ createdBy: "alice@example.com" }),
+      });
+      const out = JSON.parse(
+        await run({ action: "update", name: "j", schedule: "garbage" }),
+      );
+      expect(out.error).toMatch(/Invalid cron expression/);
+      expect(resourcePutMock).not.toHaveBeenCalled();
+    });
+
+    it("recomputes nextRun when a valid new schedule is supplied", async () => {
+      resourceGetByPathMock.mockResolvedValueOnce({
+        id: "r1",
+        owner: SHARED_OWNER,
+        path: "jobs/j.md",
+        content: sharedJobContent({ createdBy: "alice@example.com" }),
+      });
+      const out = JSON.parse(
+        await run({ action: "update", name: "j", schedule: "*/30 * * * *" }),
+      );
+      expect(out.schedule).toBe("*/30 * * * *");
+      expect(out.nextRun).toBeTruthy();
+      const { meta } = parseJobFrontmatter(resourcePutMock.mock.calls[0][2]);
+      expect(meta.schedule).toBe("*/30 * * * *");
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes a shared job by its creator", async () => {
+      resourceGetByPathMock.mockResolvedValueOnce({
+        id: "r1",
+        owner: SHARED_OWNER,
+        path: "jobs/j.md",
+        content: sharedJobContent({ createdBy: "alice@example.com" }),
+      });
+      const out = JSON.parse(await run({ action: "delete", name: "j" }));
+      expect(out.deleted).toBe(true);
+      expect(resourceDeleteMock).toHaveBeenCalledWith("r1");
+    });
+
+    it("BLOCKS deleting another user's shared job and never calls resourceDelete", async () => {
+      getRequestUserEmailMock.mockReturnValue("mallory@example.com");
+      resourceGetByPathMock.mockResolvedValueOnce({
+        id: "r1",
+        owner: SHARED_OWNER,
+        path: "jobs/j.md",
+        content: sharedJobContent({
+          createdBy: "alice@example.com",
+          orgId: "org-1",
+        }),
+      });
+      dbExecuteMock.mockResolvedValue({ rows: [] });
+
+      const out = JSON.parse(await run({ action: "delete", name: "j" }));
+      expect(out.error).toMatch(/Only the job's creator/);
+      expect(resourceDeleteMock).not.toHaveBeenCalled();
+    });
+
+    it("returns not-found for a missing job", async () => {
+      resourceGetByPathMock.mockResolvedValue(null);
+      const out = JSON.parse(await run({ action: "delete", name: "ghost" }));
+      expect(out.error).toMatch(/not found/);
+    });
+  });
+
+  describe("list", () => {
+    it("merges the caller's personal and shared jobs (org isolation: no other users')", async () => {
+      // resourceList is called for (caller, 'jobs/') and (SHARED_OWNER, 'jobs/').
+      resourceListMock.mockImplementation(async (owner: string) => {
+        if (owner === "alice@example.com") {
+          return [{ owner: "alice@example.com", path: "jobs/personal.md" }];
+        }
+        return [{ owner: SHARED_OWNER, path: "jobs/team.md" }];
+      });
+      resourceGetByPathMock.mockImplementation(
+        async (_owner: string, path: string) => ({
+          id: path,
+          owner: _owner,
+          path,
+          content: sharedJobContent({ createdBy: "alice@example.com" }),
+        }),
+      );
+
+      const jobs = JSON.parse(await run({ action: "list" }));
+      const names = jobs.map((j: any) => j.name).sort();
+      expect(names).toEqual(["personal", "team"]);
+      const scopes = Object.fromEntries(
+        jobs.map((j: any) => [j.name, j.scope]),
+      );
+      expect(scopes.personal).toBe("personal");
+      expect(scopes.team).toBe("shared");
+
+      // The two list queries are scoped to the caller and SHARED_OWNER only —
+      // never an arbitrary other user.
+      const queriedOwners = resourceListMock.mock.calls.map((c) => c[0]).sort();
+      expect(queriedOwners).toEqual([SHARED_OWNER, "alice@example.com"].sort());
+    });
+
+    it("filters to personal scope only", async () => {
+      resourceListMock.mockImplementation(async (owner: string) =>
+        owner === "alice@example.com"
+          ? [{ owner: "alice@example.com", path: "jobs/personal.md" }]
+          : [{ owner: SHARED_OWNER, path: "jobs/team.md" }],
+      );
+      resourceGetByPathMock.mockResolvedValue({
+        content: sharedJobContent({ createdBy: "alice@example.com" }),
+      });
+
+      const jobs = JSON.parse(await run({ action: "list", scope: "personal" }));
+      expect(jobs.map((j: any) => j.name)).toEqual(["personal"]);
+    });
+
+    it("returns the empty-state message when there are no jobs", async () => {
+      resourceListMock.mockResolvedValue([]);
+      const out = await run({ action: "list" });
+      expect(out).toMatch(/No recurring jobs configured/);
+    });
+
+    it("ignores .keep placeholder files", async () => {
+      resourceListMock.mockImplementation(async (owner: string) =>
+        owner === "alice@example.com"
+          ? [{ owner: "alice@example.com", path: "jobs/.keep" }]
+          : [],
+      );
+      const out = await run({ action: "list" });
+      expect(out).toMatch(/No recurring jobs configured/);
+    });
+  });
+
+  describe("unknown action", () => {
+    it("returns an error for an unrecognized action", async () => {
+      const out = JSON.parse(await run({ action: "frobnicate" }));
+      expect(out.error).toMatch(/Unknown action "frobnicate"/);
+    });
+  });
+
+  describe("unauthenticated caller", () => {
+    it("throws when there is no authenticated user (getOwner guard)", async () => {
+      getRequestUserEmailMock.mockReturnValue(undefined);
+      await expect(run({ action: "list" })).rejects.toThrow(
+        /no authenticated user/,
+      );
+    });
+  });
+});

--- a/packages/core/src/mcp/oauth-store.spec.ts
+++ b/packages/core/src/mcp/oauth-store.spec.ts
@@ -1,0 +1,423 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * oauth-store persists OAuth clients, short-lived authorization codes, and
+ * hashed refresh tokens for the standard remote MCP OAuth flow. We back it with
+ * a REAL in-memory sqlite engine (wrapped to the framework's `DbExec` shape, the
+ * same wrapper production uses for sqlite) so expiry filtering, consume-once
+ * atomicity, UNIQUE constraints, and refresh rotation are exercised for real —
+ * not pattern-matched. SQL stays dialect-agnostic; we never assert sqlite-only
+ * behavior.
+ */
+
+let sqlite: Database.Database;
+let connectionErrorNext = false;
+let genericErrorNext = false;
+
+function makeExec() {
+  return {
+    async execute(input: string | { sql: string; args?: unknown[] }) {
+      if (connectionErrorNext) {
+        connectionErrorNext = false;
+        throw new Error("CONNECTION_LOST");
+      }
+      if (genericErrorNext) {
+        genericErrorNext = false;
+        throw new Error("SYNTAX_ERROR");
+      }
+      const rawSql = typeof input === "string" ? input : input.sql;
+      const args = (
+        typeof input === "string" ? [] : (input.args ?? [])
+      ) as any[];
+      const stmt = sqlite.prepare(rawSql);
+      if (stmt.reader) {
+        return { rows: stmt.all(...args) as any[], rowsAffected: 0 };
+      }
+      const result = stmt.run(...args);
+      return { rows: [] as any[], rowsAffected: result.changes ?? 0 };
+    },
+  };
+}
+
+let exec = makeExec();
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => exec,
+  isConnectionError: (err: any) => err?.message === "CONNECTION_LOST",
+  intType: () => "INTEGER",
+}));
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  connectionErrorNext = false;
+  genericErrorNext = false;
+  exec = makeExec();
+});
+
+afterEach(() => {
+  sqlite.close();
+  vi.restoreAllMocks();
+});
+
+// The store memoizes its CREATE TABLE init in a module-scoped `_initPromise`.
+// Re-importing with a reset module graph each test rebinds that init to the
+// current in-memory DB (there is no reset export), so tables are recreated in
+// the fresh sqlite instance the test just opened.
+async function freshStore() {
+  vi.resetModules();
+  return import("./oauth-store.js");
+}
+
+describe("oauth-store hashing & token generation", () => {
+  it("generateOpaqueToken returns high-entropy, url-safe, distinct values", async () => {
+    const s = await freshStore();
+    const a = s.generateOpaqueToken();
+    const b = s.generateOpaqueToken();
+    expect(a).not.toBe(b);
+    // 32 random bytes → 43-char base64url, no padding / non-url-safe chars.
+    expect(a).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(a.length).toBeGreaterThanOrEqual(43);
+  });
+
+  it("hashOAuthToken is deterministic and not the identity of the token", async () => {
+    const s = await freshStore();
+    expect(s.hashOAuthToken("secret")).toBe(s.hashOAuthToken("secret"));
+    expect(s.hashOAuthToken("secret")).not.toBe(s.hashOAuthToken("secret2"));
+    expect(s.hashOAuthToken("secret")).not.toBe("secret");
+    expect(s.hashOAuthToken("secret")).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+});
+
+describe("client registration", () => {
+  it("round-trips a registered client and applies grant/response defaults", async () => {
+    const s = await freshStore();
+    const reg = await s.registerOAuthClient({
+      clientName: "Claude",
+      redirectUris: ["https://claude.ai/cb"],
+    });
+    expect(reg.clientId).toMatch(/^agent-native-oauth-client-/);
+    expect(reg.grantTypes).toEqual(["authorization_code", "refresh_token"]);
+    expect(reg.responseTypes).toEqual(["code"]);
+    expect(reg.tokenEndpointAuthMethod).toBe("none");
+
+    const fetched = await s.getOAuthClient(reg.clientId);
+    expect(fetched).toMatchObject({
+      clientId: reg.clientId,
+      clientName: "Claude",
+      redirectUris: ["https://claude.ai/cb"],
+      grantTypes: ["authorization_code", "refresh_token"],
+      responseTypes: ["code"],
+      tokenEndpointAuthMethod: "none",
+    });
+  });
+
+  it("preserves caller-supplied grant/response types and auth method", async () => {
+    const s = await freshStore();
+    const reg = await s.registerOAuthClient({
+      clientName: null,
+      redirectUris: ["https://app/cb", "https://app/cb2"],
+      grantTypes: ["authorization_code"],
+      responseTypes: ["code", "token"],
+      tokenEndpointAuthMethod: "client_secret_basic",
+    });
+    const fetched = await s.getOAuthClient(reg.clientId);
+    expect(fetched?.grantTypes).toEqual(["authorization_code"]);
+    expect(fetched?.responseTypes).toEqual(["code", "token"]);
+    expect(fetched?.tokenEndpointAuthMethod).toBe("client_secret_basic");
+    expect(fetched?.clientName).toBeNull();
+    expect(fetched?.redirectUris).toEqual([
+      "https://app/cb",
+      "https://app/cb2",
+    ]);
+  });
+
+  it("getOAuthClient returns null for an unknown client", async () => {
+    const s = await freshStore();
+    expect(await s.getOAuthClient("does-not-exist")).toBeNull();
+  });
+
+  it("enforces the registration rate limit inside the window", async () => {
+    const s = await freshStore();
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    for (let i = 0; i < s.MCP_OAUTH_REGISTER_MAX; i++) {
+      await s.registerOAuthClient({ redirectUris: ["https://x/cb"] });
+    }
+    await expect(
+      s.registerOAuthClient({ redirectUris: ["https://x/cb"] }),
+    ).rejects.toThrow("RATE_LIMITED");
+  });
+
+  it("registrations outside the window do not count toward the limit", async () => {
+    const s = await freshStore();
+    // One ancient registration well before the window.
+    vi.spyOn(Date, "now").mockReturnValue(0);
+    await s.registerOAuthClient({ redirectUris: ["https://x/cb"] });
+    // Move far past the window; fill up to MAX-1 fresh registrations.
+    vi.spyOn(Date, "now").mockReturnValue(10_000_000);
+    for (let i = 0; i < s.MCP_OAUTH_REGISTER_MAX - 1; i++) {
+      await s.registerOAuthClient({ redirectUris: ["https://x/cb"] });
+    }
+    // The ancient one is outside the window, so one more must still succeed.
+    await expect(
+      s.registerOAuthClient({ redirectUris: ["https://x/cb"] }),
+    ).resolves.toBeTruthy();
+  });
+
+  it("getOAuthClient swallows connection errors and returns null", async () => {
+    const s = await freshStore();
+    // Make sure the table exists first (so ensureTable in the call doesn't
+    // need the DB), then fail the SELECT with a connection error.
+    await s.registerOAuthClient({ redirectUris: ["https://x/cb"] });
+    connectionErrorNext = true;
+    expect(await s.getOAuthClient("anything")).toBeNull();
+  });
+
+  it("getOAuthClient re-throws non-connection errors (no silent null)", async () => {
+    const s = await freshStore();
+    // Table already initialized, so the next execute is the SELECT. A
+    // non-connection failure must surface rather than be masked as "not found".
+    await s.registerOAuthClient({ redirectUris: ["https://x/cb"] });
+    genericErrorNext = true;
+    await expect(s.getOAuthClient("anything")).rejects.toThrow("SYNTAX_ERROR");
+  });
+
+  it("registration proceeds when the rate-limit count read fails transiently", async () => {
+    const s = await freshStore();
+    // Table already initialized; the next execute is the COUNT(*) rate-limit
+    // read. A transient connection failure there is swallowed (not RATE_LIMITED)
+    // and the INSERT still proceeds, so the client is registered.
+    await s.registerOAuthClient({ redirectUris: ["https://seed/cb"] });
+    connectionErrorNext = true;
+    const reg = await s.registerOAuthClient({
+      redirectUris: ["https://after-failure/cb"],
+    });
+    expect(reg.clientId).toMatch(/^agent-native-oauth-client-/);
+    // It was genuinely persisted, not just returned.
+    expect(await s.getOAuthClient(reg.clientId)).toMatchObject({
+      redirectUris: ["https://after-failure/cb"],
+    });
+  });
+});
+
+describe("authorization codes", () => {
+  const codeParams = {
+    clientId: "client-1",
+    redirectUri: "https://claude.ai/cb",
+    codeChallenge: "challenge",
+    codeChallengeMethod: "S256",
+    ownerEmail: "owner@example.com",
+    orgId: "org-1",
+    orgDomain: "example.com",
+    scope: "mcp:read mcp:write",
+    resource: "https://mail.example.com",
+  };
+
+  it("creates a code with a 10-minute TTL and persists all claims", async () => {
+    const s = await freshStore();
+    vi.spyOn(Date, "now").mockReturnValue(1000);
+    const created = await s.createOAuthCode(codeParams);
+    expect(created.expiresAt).toBe(1000 + s.MCP_OAUTH_CODE_TTL_MS);
+    expect(created.consumedAt).toBeNull();
+
+    const fetched = await s.getOAuthCode(created.code);
+    expect(fetched).toMatchObject({
+      clientId: "client-1",
+      ownerEmail: "owner@example.com",
+      orgId: "org-1",
+      orgDomain: "example.com",
+      scope: "mcp:read mcp:write",
+      resource: "https://mail.example.com",
+      codeChallenge: "challenge",
+      codeChallengeMethod: "S256",
+    });
+  });
+
+  it("getOAuthCode returns null for an expired code", async () => {
+    const s = await freshStore();
+    vi.spyOn(Date, "now").mockReturnValue(1000);
+    const created = await s.createOAuthCode(codeParams);
+    vi.spyOn(Date, "now").mockReturnValue(1000 + s.MCP_OAUTH_CODE_TTL_MS + 1);
+    expect(await s.getOAuthCode(created.code)).toBeNull();
+  });
+
+  it("getOAuthCode returns null for an unknown code", async () => {
+    const s = await freshStore();
+    expect(await s.getOAuthCode("nope")).toBeNull();
+  });
+
+  it("consumeOAuthCode succeeds exactly once (single-use)", async () => {
+    const s = await freshStore();
+    const created = await s.createOAuthCode(codeParams);
+    const first = await s.consumeOAuthCode(created.code);
+    expect(first?.code).toBe(created.code);
+    expect(first?.ownerEmail).toBe("owner@example.com");
+    // A second consume returns null — the code is spent.
+    expect(await s.consumeOAuthCode(created.code)).toBeNull();
+    // And it is no longer readable.
+    expect(await s.getOAuthCode(created.code)).toBeNull();
+  });
+
+  it("consumeOAuthCode returns null for an unknown or expired code", async () => {
+    const s = await freshStore();
+    expect(await s.consumeOAuthCode("missing")).toBeNull();
+
+    vi.spyOn(Date, "now").mockReturnValue(1000);
+    const created = await s.createOAuthCode(codeParams);
+    vi.spyOn(Date, "now").mockReturnValue(1000 + s.MCP_OAUTH_CODE_TTL_MS + 1);
+    expect(await s.consumeOAuthCode(created.code)).toBeNull();
+  });
+
+  it("defaults orgId / orgDomain to null when omitted", async () => {
+    const s = await freshStore();
+    const created = await s.createOAuthCode({
+      ...codeParams,
+      orgId: undefined,
+      orgDomain: undefined,
+    });
+    expect(created.orgId).toBeNull();
+    expect(created.orgDomain).toBeNull();
+    const fetched = await s.getOAuthCode(created.code);
+    expect(fetched?.orgId).toBeNull();
+    expect(fetched?.orgDomain).toBeNull();
+  });
+});
+
+describe("refresh tokens", () => {
+  const refreshParams = {
+    refreshToken: "raw-refresh-token",
+    clientId: "client-1",
+    ownerEmail: "owner@example.com",
+    orgId: "org-1",
+    orgDomain: "example.com",
+    scope: "mcp:read",
+    resource: "https://mail.example.com",
+  };
+
+  it("stores only the HASH of the refresh token, never the raw value", async () => {
+    const s = await freshStore();
+    const row = await s.createOAuthRefreshToken(refreshParams);
+    expect(row.tokenHash).toBe(s.hashOAuthToken("raw-refresh-token"));
+    expect(row.tokenHash).not.toBe("raw-refresh-token");
+    // The raw value must not be retrievable from any stored column.
+    const dump = sqlite
+      .prepare("SELECT * FROM mcp_oauth_refresh_tokens")
+      .all() as any[];
+    const serialized = JSON.stringify(dump);
+    expect(serialized).not.toContain("raw-refresh-token");
+    expect(serialized).toContain(row.tokenHash);
+  });
+
+  it("looks up an active refresh token by its raw value", async () => {
+    const s = await freshStore();
+    await s.createOAuthRefreshToken(refreshParams);
+    const found = await s.getOAuthRefreshToken("raw-refresh-token");
+    expect(found).toMatchObject({
+      clientId: "client-1",
+      ownerEmail: "owner@example.com",
+      orgId: "org-1",
+      scope: "mcp:read",
+      resource: "https://mail.example.com",
+      revokedAt: null,
+    });
+    expect(await s.getOAuthRefreshToken("wrong-token")).toBeNull();
+  });
+
+  it("getOAuthRefreshToken returns null once expired", async () => {
+    const s = await freshStore();
+    vi.spyOn(Date, "now").mockReturnValue(1000);
+    await s.createOAuthRefreshToken(refreshParams);
+    vi.spyOn(Date, "now").mockReturnValue(
+      1000 + s.MCP_OAUTH_REFRESH_TOKEN_TTL_MS + 1,
+    );
+    expect(await s.getOAuthRefreshToken("raw-refresh-token")).toBeNull();
+  });
+
+  it("rotateOAuthRefreshToken revokes the old token and issues a fresh one carrying the same identity", async () => {
+    const s = await freshStore();
+    const original = await s.createOAuthRefreshToken(refreshParams);
+    const rotated = await s.rotateOAuthRefreshToken({
+      oldRefreshToken: "raw-refresh-token",
+      newRefreshToken: "new-refresh-token",
+    });
+    expect(rotated).not.toBeNull();
+    // The new token carries the original's identity/scope/resource.
+    expect(rotated).toMatchObject({
+      clientId: "client-1",
+      ownerEmail: "owner@example.com",
+      orgId: "org-1",
+      orgDomain: "example.com",
+      scope: "mcp:read",
+      resource: "https://mail.example.com",
+      revokedAt: null,
+    });
+    expect(rotated?.tokenHash).toBe(s.hashOAuthToken("new-refresh-token"));
+    expect(rotated?.id).not.toBe(original.id);
+
+    // The old token is revoked and no longer resolvable.
+    expect(await s.getOAuthRefreshToken("raw-refresh-token")).toBeNull();
+    // The new one is active.
+    expect(await s.getOAuthRefreshToken("new-refresh-token")).not.toBeNull();
+  });
+
+  it("records the replacement hash on the revoked old token (rotation chain)", async () => {
+    const s = await freshStore();
+    await s.createOAuthRefreshToken(refreshParams);
+    await s.rotateOAuthRefreshToken({
+      oldRefreshToken: "raw-refresh-token",
+      newRefreshToken: "new-refresh-token",
+    });
+    const oldRow = sqlite
+      .prepare("SELECT * FROM mcp_oauth_refresh_tokens WHERE token_hash = ?")
+      .get(s.hashOAuthToken("raw-refresh-token")) as any;
+    expect(oldRow.revoked_at).not.toBeNull();
+    expect(oldRow.replaced_by_hash).toBe(s.hashOAuthToken("new-refresh-token"));
+  });
+
+  it("rotation is single-use: reusing a spent refresh token yields null (reuse detection)", async () => {
+    const s = await freshStore();
+    await s.createOAuthRefreshToken(refreshParams);
+    const first = await s.rotateOAuthRefreshToken({
+      oldRefreshToken: "raw-refresh-token",
+      newRefreshToken: "rotated-1",
+    });
+    expect(first).not.toBeNull();
+    // Replaying the original (already revoked) token must not mint anything.
+    const replay = await s.rotateOAuthRefreshToken({
+      oldRefreshToken: "raw-refresh-token",
+      newRefreshToken: "rotated-2",
+    });
+    expect(replay).toBeNull();
+  });
+
+  it("rotateOAuthRefreshToken returns null for an unknown token", async () => {
+    const s = await freshStore();
+    expect(
+      await s.rotateOAuthRefreshToken({
+        oldRefreshToken: "never-existed",
+        newRefreshToken: "x",
+      }),
+    ).toBeNull();
+  });
+
+  it("rotateOAuthRefreshToken returns null for an expired token (no new token minted)", async () => {
+    const s = await freshStore();
+    vi.spyOn(Date, "now").mockReturnValue(1000);
+    await s.createOAuthRefreshToken(refreshParams);
+    vi.spyOn(Date, "now").mockReturnValue(
+      1000 + s.MCP_OAUTH_REFRESH_TOKEN_TTL_MS + 1,
+    );
+    const rotated = await s.rotateOAuthRefreshToken({
+      oldRefreshToken: "raw-refresh-token",
+      newRefreshToken: "new-token",
+    });
+    expect(rotated).toBeNull();
+    // No replacement row was inserted.
+    const count = (
+      sqlite
+        .prepare("SELECT COUNT(*) AS n FROM mcp_oauth_refresh_tokens")
+        .get() as any
+    ).n;
+    expect(count).toBe(1);
+  });
+});

--- a/packages/core/src/mcp/oauth-token.spec.ts
+++ b/packages/core/src/mcp/oauth-token.spec.ts
@@ -1,0 +1,282 @@
+import * as jose from "jose";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * oauth-token mints and verifies the signed JWT access tokens for the standard
+ * remote MCP OAuth flow. Tokens are HS256 JWTs keyed on `A2A_SECRET` (falling
+ * back to the better-auth secret). We mock only the secret provider and use the
+ * REAL jose sign/verify so the audience binding, typ guard, scope guard, and
+ * expiry are exercised as in production.
+ */
+
+vi.mock("../server/better-auth-instance.js", () => ({
+  getAuthSecret: () => "fallback-auth-secret",
+}));
+
+import {
+  MCP_OAUTH_DEFAULT_SCOPE,
+  MCP_OAUTH_SCOPES,
+  hasMcpOAuthScope,
+  normalizeOAuthScope,
+  scopeList,
+  signMcpOAuthAccessToken,
+  verifyMcpOAuthAccessToken,
+} from "./oauth-token.js";
+
+const ORIGINAL_ENV = { ...process.env };
+const ISSUER = "https://mail.example.com";
+const RESOURCE = "https://mail.example.com/_agent-native/mcp";
+
+const baseSign = {
+  ownerEmail: "owner@example.com",
+  clientId: "client-abc",
+  scope: "mcp:read mcp:write",
+  resource: RESOURCE,
+  issuer: ISSUER,
+};
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.A2A_SECRET;
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+  vi.restoreAllMocks();
+});
+
+describe("normalizeOAuthScope", () => {
+  it("returns the full default scope for empty / non-string input", () => {
+    expect(normalizeOAuthScope("")).toBe(MCP_OAUTH_DEFAULT_SCOPE);
+    expect(normalizeOAuthScope("   ")).toBe(MCP_OAUTH_DEFAULT_SCOPE);
+    expect(normalizeOAuthScope(undefined)).toBe(MCP_OAUTH_DEFAULT_SCOPE);
+    expect(normalizeOAuthScope(null)).toBe(MCP_OAUTH_DEFAULT_SCOPE);
+    expect(normalizeOAuthScope(123)).toBe(MCP_OAUTH_DEFAULT_SCOPE);
+  });
+
+  it("keeps only allow-listed scopes and dedupes them", () => {
+    expect(normalizeOAuthScope("mcp:read mcp:read mcp:write")).toBe(
+      "mcp:read mcp:write",
+    );
+    expect(normalizeOAuthScope("mcp:apps")).toBe("mcp:apps");
+  });
+
+  it("drops unknown scopes but keeps recognised ones", () => {
+    expect(normalizeOAuthScope("mcp:read openid profile")).toBe("mcp:read");
+  });
+
+  it("returns null when every requested scope is unknown (request rejected)", () => {
+    expect(normalizeOAuthScope("openid profile email")).toBeNull();
+    expect(normalizeOAuthScope("admin:* mcp:admin")).toBeNull();
+  });
+
+  it("default scope contains exactly the three known scopes", () => {
+    expect(MCP_OAUTH_DEFAULT_SCOPE.split(" ").sort()).toEqual(
+      [...MCP_OAUTH_SCOPES].sort(),
+    );
+  });
+});
+
+describe("scopeList", () => {
+  it("splits on arbitrary whitespace and trims, ignoring undefined", () => {
+    expect(scopeList("mcp:read  mcp:write\tmcp:apps")).toEqual([
+      "mcp:read",
+      "mcp:write",
+      "mcp:apps",
+    ]);
+    expect(scopeList(undefined)).toEqual([]);
+    expect(scopeList("")).toEqual([]);
+  });
+});
+
+describe("hasMcpOAuthScope", () => {
+  it("treats an undefined scope set as fully permissive (legacy tokens)", () => {
+    expect(hasMcpOAuthScope(undefined, "mcp:write")).toBe(true);
+  });
+
+  it("grants only when the specific scope is present", () => {
+    expect(hasMcpOAuthScope(["mcp:read"], "mcp:read")).toBe(true);
+    expect(hasMcpOAuthScope(["mcp:read"], "mcp:write")).toBe(false);
+    expect(hasMcpOAuthScope([], "mcp:read")).toBe(false);
+  });
+});
+
+describe("signMcpOAuthAccessToken + verifyMcpOAuthAccessToken round-trip", () => {
+  it("verifies a freshly minted token and returns the bound identity & scopes", async () => {
+    const token = await signMcpOAuthAccessToken({
+      ...baseSign,
+      orgId: "org-1",
+      orgDomain: "example.com",
+    });
+    const result = await verifyMcpOAuthAccessToken(token, RESOURCE);
+    expect(result).toEqual({
+      userEmail: "owner@example.com",
+      orgId: "org-1",
+      orgDomain: "example.com",
+      scopes: ["mcp:read", "mcp:write"],
+      clientId: "client-abc",
+    });
+  });
+
+  it("omits org claims entirely when not provided", async () => {
+    const token = await signMcpOAuthAccessToken(baseSign);
+    const decoded = jose.decodeJwt(token);
+    expect(decoded.org_id).toBeUndefined();
+    expect(decoded.org_domain).toBeUndefined();
+    const result = await verifyMcpOAuthAccessToken(token, RESOURCE);
+    expect(result?.orgId).toBeUndefined();
+    expect(result?.orgDomain).toBeUndefined();
+  });
+
+  it("sets the typ marker, issuer, audience, jti, and an expiry", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const token = await signMcpOAuthAccessToken(baseSign);
+    const decoded = jose.decodeJwt(token) as any;
+    expect(decoded.typ).toBe("agent-native-mcp-oauth");
+    expect(decoded.iss).toBe(ISSUER);
+    expect(decoded.aud).toBe(RESOURCE);
+    expect(typeof decoded.jti).toBe("string");
+    expect(decoded.exp).toBeGreaterThan(decoded.iat);
+  });
+
+  it("prefers A2A_SECRET over the better-auth secret for signing+verify", async () => {
+    process.env.A2A_SECRET = "a2a-strong-secret";
+    const token = await signMcpOAuthAccessToken(baseSign);
+    // Verifies with the same A2A_SECRET active.
+    expect(await verifyMcpOAuthAccessToken(token, RESOURCE)).not.toBeNull();
+    // A token signed under A2A_SECRET must fail once the secret changes.
+    delete process.env.A2A_SECRET;
+    expect(await verifyMcpOAuthAccessToken(token, RESOURCE)).toBeNull();
+  });
+});
+
+describe("verifyMcpOAuthAccessToken rejection branches", () => {
+  it("returns null when no resource is supplied (audience cannot be checked)", async () => {
+    const token = await signMcpOAuthAccessToken(baseSign);
+    expect(await verifyMcpOAuthAccessToken(token, undefined)).toBeNull();
+  });
+
+  it("rejects a token whose audience differs from the requested resource", async () => {
+    const token = await signMcpOAuthAccessToken(baseSign);
+    expect(
+      await verifyMcpOAuthAccessToken(token, "https://other.example.com/mcp"),
+    ).toBeNull();
+  });
+
+  it("rejects a token signed with the wrong secret", async () => {
+    const wrong = await new jose.SignJWT({
+      typ: "agent-native-mcp-oauth",
+      sub: "owner@example.com",
+      scope: "mcp:read",
+      client_id: "client-abc",
+      resource: RESOURCE,
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuer(ISSUER)
+      .setAudience(RESOURCE)
+      .setExpirationTime("1h")
+      .setIssuedAt()
+      .sign(new TextEncoder().encode("attacker-secret"));
+    expect(await verifyMcpOAuthAccessToken(wrong, RESOURCE)).toBeNull();
+  });
+
+  it("rejects a token with the wrong typ marker (not an MCP OAuth token)", async () => {
+    const token = await new jose.SignJWT({
+      typ: "some-other-token",
+      sub: "owner@example.com",
+      scope: "mcp:read",
+      client_id: "client-abc",
+      resource: RESOURCE,
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setAudience(RESOURCE)
+      .setExpirationTime("1h")
+      .setIssuedAt()
+      .sign(new TextEncoder().encode("fallback-auth-secret"));
+    expect(await verifyMcpOAuthAccessToken(token, RESOURCE)).toBeNull();
+  });
+
+  it("rejects a token whose embedded resource claim mismatches the audience", async () => {
+    // aud matches the requested resource (so jose passes), but the inner
+    // `resource` claim was forged to a different value — must be rejected.
+    const token = await new jose.SignJWT({
+      typ: "agent-native-mcp-oauth",
+      sub: "owner@example.com",
+      scope: "mcp:read",
+      client_id: "client-abc",
+      resource: "https://evil.example.com/mcp",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setAudience(RESOURCE)
+      .setExpirationTime("1h")
+      .setIssuedAt()
+      .sign(new TextEncoder().encode("fallback-auth-secret"));
+    expect(await verifyMcpOAuthAccessToken(token, RESOURCE)).toBeNull();
+  });
+
+  it("rejects a token missing a subject", async () => {
+    const token = await new jose.SignJWT({
+      typ: "agent-native-mcp-oauth",
+      scope: "mcp:read",
+      client_id: "client-abc",
+      resource: RESOURCE,
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setAudience(RESOURCE)
+      .setExpirationTime("1h")
+      .setIssuedAt()
+      .sign(new TextEncoder().encode("fallback-auth-secret"));
+    expect(await verifyMcpOAuthAccessToken(token, RESOURCE)).toBeNull();
+  });
+
+  it("rejects a token missing a client_id", async () => {
+    const token = await new jose.SignJWT({
+      typ: "agent-native-mcp-oauth",
+      sub: "owner@example.com",
+      scope: "mcp:read",
+      resource: RESOURCE,
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setAudience(RESOURCE)
+      .setExpirationTime("1h")
+      .setIssuedAt()
+      .sign(new TextEncoder().encode("fallback-auth-secret"));
+    expect(await verifyMcpOAuthAccessToken(token, RESOURCE)).toBeNull();
+  });
+
+  it("rejects a token carrying no recognised MCP scope", async () => {
+    const token = await new jose.SignJWT({
+      typ: "agent-native-mcp-oauth",
+      sub: "owner@example.com",
+      scope: "openid profile",
+      client_id: "client-abc",
+      resource: RESOURCE,
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setAudience(RESOURCE)
+      .setExpirationTime("1h")
+      .setIssuedAt()
+      .sign(new TextEncoder().encode("fallback-auth-secret"));
+    expect(await verifyMcpOAuthAccessToken(token, RESOURCE)).toBeNull();
+  });
+
+  it("rejects an expired token", async () => {
+    const token = await new jose.SignJWT({
+      typ: "agent-native-mcp-oauth",
+      sub: "owner@example.com",
+      scope: "mcp:read",
+      client_id: "client-abc",
+      resource: RESOURCE,
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setAudience(RESOURCE)
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 7200)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 3600)
+      .sign(new TextEncoder().encode("fallback-auth-secret"));
+    expect(await verifyMcpOAuthAccessToken(token, RESOURCE)).toBeNull();
+  });
+
+  it("rejects a structurally invalid token string", async () => {
+    expect(await verifyMcpOAuthAccessToken("not-a-jwt", RESOURCE)).toBeNull();
+  });
+});

--- a/packages/core/src/mcp/workspace-resolve.spec.ts
+++ b/packages/core/src/mcp/workspace-resolve.spec.ts
@@ -1,0 +1,359 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * workspace-resolve maps the MCP stdio CLI to the right local dev origin. It is
+ * a Node-only module that walks the filesystem, optionally queries a gateway,
+ * and TCP-probes ports. We use REAL temp directories for the filesystem walk
+ * and app discovery, a controllable `node:net` mock so port probes are
+ * deterministic, and a stubbed `fetch` for the gateway list.
+ */
+
+// --- controllable port-probe outcome -------------------------------------
+// probePort dynamically imports("node:net") and connects a socket. We make
+// every probe resolve via a single switch so tests stay deterministic.
+let probeOutcome: "connect" | "error" | "timeout" = "error";
+
+vi.mock("node:net", () => {
+  class FakeSocket {
+    private handlers: Record<string, (() => void)[]> = {};
+    setTimeout() {}
+    once(event: string, cb: () => void) {
+      (this.handlers[event] ??= []).push(cb);
+      return this;
+    }
+    destroy() {}
+    connect() {
+      const event =
+        probeOutcome === "connect"
+          ? "connect"
+          : probeOutcome === "timeout"
+            ? "timeout"
+            : "error";
+      // Fire asynchronously like a real socket would.
+      queueMicrotask(() => this.handlers[event]?.forEach((cb) => cb()));
+    }
+  }
+  const net = { Socket: FakeSocket };
+  return { default: net, Socket: FakeSocket };
+});
+
+const { findWorkspaceRoot, resolveWorkspace, resolveLocalAppOrigin } =
+  await import("./workspace-resolve.js");
+
+let tmpRoot: string;
+
+function mkdirp(p: string) {
+  fs.mkdirSync(p, { recursive: true });
+}
+
+function writePkg(dir: string, json: unknown) {
+  mkdirp(dir);
+  fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify(json));
+}
+
+/** Build a workspace root with the given app ids (each gets a package.json). */
+function buildWorkspace(appIds: string[]): string {
+  const root = fs.mkdtempSync(path.join(tmpRoot, "ws-"));
+  writePkg(root, {
+    name: "workspace",
+    "agent-native": { workspaceCore: "@agent-native/core" },
+  });
+  for (const id of appIds) {
+    writePkg(path.join(root, "apps", id), { name: id });
+  }
+  return root;
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wsr-"));
+  probeOutcome = "error";
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("findWorkspaceRoot", () => {
+  it("finds the nearest ancestor with workspaceCore + an apps/ dir", () => {
+    const root = buildWorkspace(["mail"]);
+    const deep = path.join(root, "apps", "mail", "src", "nested");
+    mkdirp(deep);
+    expect(findWorkspaceRoot(deep)).toBe(root);
+  });
+
+  it("returns null when no ancestor declares a workspace", () => {
+    const plain = fs.mkdtempSync(path.join(tmpRoot, "plain-"));
+    writePkg(plain, { name: "just-an-app" });
+    expect(findWorkspaceRoot(plain)).toBeNull();
+  });
+
+  it("ignores a workspaceCore package.json that lacks an apps/ dir", () => {
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "noapps-"));
+    writePkg(dir, {
+      name: "ws",
+      "agent-native": { workspaceCore: "@agent-native/core" },
+    });
+    // No apps/ dir → not a workspace root.
+    expect(findWorkspaceRoot(dir)).toBeNull();
+  });
+
+  it("keeps walking past an unparsable package.json", () => {
+    const root = buildWorkspace(["mail"]);
+    const child = path.join(root, "apps", "mail");
+    fs.writeFileSync(path.join(child, "package.json"), "{ not valid json");
+    // Starting from the app with broken json, it should still find the root.
+    expect(findWorkspaceRoot(child)).toBe(root);
+  });
+});
+
+describe("resolveWorkspace — standalone (no workspace)", () => {
+  it("treats the cwd as the single app and derives a clean id from the pkg name", async () => {
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "solo-"));
+    writePkg(dir, { name: "@agent-native/agent-native-mail" });
+    probeOutcome = "error"; // dev server not up
+    const ws = await resolveWorkspace(dir, { PORT: "4321" });
+    expect(ws.isWorkspace).toBe(false);
+    expect(ws.gatewayUrl).toBeUndefined();
+    expect(ws.apps).toHaveLength(1);
+    expect(ws.apps[0]).toMatchObject({
+      // scope + agent-native- prefix stripped
+      id: "mail",
+      port: 4321,
+      url: "http://127.0.0.1:4321",
+      running: false,
+    });
+  });
+
+  it("falls back to the Vite default port and reports running when the probe connects", async () => {
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "solo-"));
+    writePkg(dir, { name: "design" });
+    probeOutcome = "connect";
+    const ws = await resolveWorkspace(dir, {});
+    expect(ws.apps[0].port).toBe(5173);
+    expect(ws.apps[0].running).toBe(true);
+  });
+
+  it("derives the id from the directory name when package.json is absent", async () => {
+    const dir = path.join(tmpRoot, "my-loose-app");
+    mkdirp(dir);
+    const ws = await resolveWorkspace(dir, {});
+    expect(ws.isWorkspace).toBe(false);
+    expect(ws.apps[0].id).toBe("my-loose-app");
+  });
+});
+
+describe("resolveWorkspace — workspace via filesystem fallback (gateway down)", () => {
+  beforeEach(() => {
+    // Gateway unreachable → fall back to a filesystem scan.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+    );
+  });
+
+  it("discovers apps/* and assigns 8100+index in dispatch-first order", async () => {
+    const root = buildWorkspace(["mail", "calendar", "dispatch"]);
+    const ws = await resolveWorkspace(root, {});
+    expect(ws.isWorkspace).toBe(true);
+    expect(ws.gatewayUrl).toBe("http://127.0.0.1:8080");
+    // dispatch first, then alphabetical: dispatch, calendar, mail.
+    expect(ws.apps.map((a) => [a.id, a.port])).toEqual([
+      ["dispatch", 8100],
+      ["calendar", 8101],
+      ["mail", 8102],
+    ]);
+  });
+
+  it("skips apps/* entries that lack a package.json", async () => {
+    const root = buildWorkspace(["mail"]);
+    // A bare directory with no package.json must be ignored.
+    mkdirp(path.join(root, "apps", "not-an-app"));
+    const ws = await resolveWorkspace(root, {});
+    expect(ws.apps.map((a) => a.id)).toEqual(["mail"]);
+  });
+
+  it("honours WORKSPACE_PORT / WORKSPACE_HOST / app-port-start overrides", async () => {
+    const root = buildWorkspace(["mail"]);
+    const ws = await resolveWorkspace(root, {
+      WORKSPACE_PORT: "9090",
+      WORKSPACE_HOST: "0.0.0.0",
+      WORKSPACE_APP_PORT_START: "9200",
+    });
+    expect(ws.gatewayUrl).toBe("http://0.0.0.0:9090");
+    expect(ws.apps[0].port).toBe(9200);
+  });
+});
+
+describe("resolveWorkspace — workspace via gateway list (authoritative)", () => {
+  it("prefers the gateway's apps + ports over the filesystem scan", async () => {
+    const root = buildWorkspace(["mail", "calendar"]);
+    // Gateway reassigns ports and reports a different set than the FS scan.
+    const fetchSpy = vi.fn(async (url: string) => {
+      expect(url).toBe("http://127.0.0.1:8080/_workspace/apps");
+      return new Response(
+        JSON.stringify([
+          { id: "mail", port: 8155 },
+          { id: "calendar", port: 8156 },
+        ]),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const ws = await resolveWorkspace(root, {});
+    expect(ws.apps.map((a) => [a.id, a.port])).toEqual([
+      ["mail", 8155],
+      ["calendar", 8156],
+    ]);
+    expect(ws.apps.map((a) => a.url)).toEqual([
+      "http://127.0.0.1:8155",
+      "http://127.0.0.1:8156",
+    ]);
+  });
+
+  it("falls back to the filesystem scan when the gateway returns non-2xx", async () => {
+    const root = buildWorkspace(["dispatch", "mail"]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("no", { status: 503 })),
+    );
+    const ws = await resolveWorkspace(root, {});
+    expect(ws.apps.map((a) => a.id)).toEqual(["dispatch", "mail"]);
+  });
+
+  it("falls back to the filesystem scan when the gateway returns a non-array body", async () => {
+    const root = buildWorkspace(["mail"]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ nope: true }), { status: 200 }),
+      ),
+    );
+    const ws = await resolveWorkspace(root, {});
+    expect(ws.apps.map((a) => a.id)).toEqual(["mail"]);
+  });
+
+  it("drops malformed gateway entries (no string id)", async () => {
+    const root = buildWorkspace(["mail"]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify([
+              { id: "mail", port: 8155 },
+              { port: 8156 },
+              { id: 42, port: 8157 },
+            ]),
+            { status: 200 },
+          ),
+      ),
+    );
+    const ws = await resolveWorkspace(root, {});
+    expect(ws.apps.map((a) => a.id)).toEqual(["mail"]);
+  });
+});
+
+describe("resolveLocalAppOrigin precedence", () => {
+  beforeEach(() => {
+    // Default: gateway down → filesystem scan, ports unprobed/down.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+    );
+  });
+
+  it("1. explicit port wins and maps to the matching app id", async () => {
+    const root = buildWorkspace(["dispatch", "mail"]);
+    const res = await resolveLocalAppOrigin({ cwd: root, port: 8101 });
+    // dispatch=8100, mail=8101.
+    expect(res.origin).toBe("http://127.0.0.1:8101");
+    expect(res.appId).toBe("mail");
+  });
+
+  it("1b. explicit port with no matching app still returns that origin", async () => {
+    const root = buildWorkspace(["mail"]);
+    const res = await resolveLocalAppOrigin({ cwd: root, port: 9999 });
+    expect(res.origin).toBe("http://127.0.0.1:9999");
+    // Falls back to provided appId / first app id.
+    expect(res.appId).toBe("mail");
+  });
+
+  it("1c. an explicit port outranks a conflicting appId and adopts the matched app's id", async () => {
+    const root = buildWorkspace(["dispatch", "mail"]);
+    // dispatch=8100, mail=8101. Port 8101 wins over the appId "dispatch".
+    const res = await resolveLocalAppOrigin({
+      cwd: root,
+      port: 8101,
+      appId: "dispatch",
+    });
+    expect(res.origin).toBe("http://127.0.0.1:8101");
+    expect(res.appId).toBe("mail");
+  });
+
+  it("2. explicit appId selects that app's discovered url", async () => {
+    const root = buildWorkspace(["dispatch", "mail", "calendar"]);
+    const res = await resolveLocalAppOrigin({ cwd: root, appId: "calendar" });
+    expect(res.appId).toBe("calendar");
+    // dispatch first (8100), then alphabetical: calendar=8101, mail=8102.
+    expect(res.origin).toBe("http://127.0.0.1:8101");
+  });
+
+  it("2b. an unknown appId throws and lists the available apps", async () => {
+    const root = buildWorkspace(["dispatch", "mail"]);
+    await expect(
+      resolveLocalAppOrigin({ cwd: root, appId: "ghost" }),
+    ).rejects.toThrow(/App "ghost" not found\. Available: dispatch, mail/);
+  });
+
+  it("3. defaults to dispatch when present and no selector is given", async () => {
+    const root = buildWorkspace(["mail", "dispatch", "calendar"]);
+    const res = await resolveLocalAppOrigin({ cwd: root });
+    expect(res.appId).toBe("dispatch");
+    expect(res.origin).toBe("http://127.0.0.1:8100");
+  });
+
+  it("3b. defaults to the first app when dispatch is absent", async () => {
+    const root = buildWorkspace(["mail", "calendar"]);
+    const res = await resolveLocalAppOrigin({ cwd: root });
+    // alphabetical: calendar first.
+    expect(res.appId).toBe("calendar");
+    expect(res.origin).toBe("http://127.0.0.1:8100");
+  });
+
+  it("4. standalone single app resolves to its own origin", async () => {
+    const dir = fs.mkdtempSync(path.join(tmpRoot, "solo-"));
+    writePkg(dir, { name: "@scope/forms" });
+    const res = await resolveLocalAppOrigin({
+      cwd: dir,
+      env: { PORT: "3000" },
+    });
+    expect(res.appId).toBe("forms");
+    expect(res.origin).toBe("http://127.0.0.1:3000");
+    expect(res.ws.isWorkspace).toBe(false);
+  });
+
+  it("throws when a workspace has zero discoverable apps and no selector", async () => {
+    // workspaceCore + apps/ dir present (so it IS a workspace) but apps/ empty
+    // and the gateway is down → no apps resolved → guarded error.
+    const root = fs.mkdtempSync(path.join(tmpRoot, "empty-ws-"));
+    writePkg(root, {
+      name: "ws",
+      "agent-native": { workspaceCore: "@agent-native/core" },
+    });
+    mkdirp(path.join(root, "apps"));
+    await expect(resolveLocalAppOrigin({ cwd: root })).rejects.toThrow(
+      /No apps found/,
+    );
+  });
+});

--- a/packages/core/src/notifications/channels.spec.ts
+++ b/packages/core/src/notifications/channels.spec.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NotificationChannel } from "./types.js";
+
+// Each test imports channels.js fresh (vi.resetModules) so the module-level
+// `_registered` guard re-runs and the channel closure captures the current
+// NOTIFICATIONS_WEBHOOK_URL / _AUTH env. We capture the registered channel,
+// then drive its deliver() directly to exercise the real webhook logic: key-
+// reference resolution, URL allowlist enforcement, auth header, POST body, and
+// non-ok handling.
+
+const resolveKeyReferences = vi.fn();
+const validateUrlAllowlist = vi.fn();
+const getKeyAllowlist = vi.fn();
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function okResponse() {
+  return { ok: true, status: 200, body: null } as unknown as Response;
+}
+
+async function loadWebhookChannel(): Promise<NotificationChannel | undefined> {
+  vi.resetModules();
+  const registered: NotificationChannel[] = [];
+  vi.doMock("./registry.js", () => ({
+    registerNotificationChannel: (channel: NotificationChannel) => {
+      registered.push(channel);
+    },
+  }));
+  vi.doMock("../secrets/substitution.js", () => ({
+    resolveKeyReferences: (...args: unknown[]) => resolveKeyReferences(...args),
+    validateUrlAllowlist: (...args: unknown[]) => validateUrlAllowlist(...args),
+    getKeyAllowlist: (...args: unknown[]) => getKeyAllowlist(...args),
+  }));
+  const { registerBuiltinNotificationChannels } = await import("./channels.js");
+  registerBuiltinNotificationChannels();
+  return registered.find((c) => c.name === "webhook");
+}
+
+beforeEach(() => {
+  process.env.NOTIFICATIONS_WEBHOOK_URL = "https://hooks.example.com/notify";
+  delete process.env.NOTIFICATIONS_WEBHOOK_AUTH;
+  fetchMock = vi.fn(async () => okResponse());
+  vi.stubGlobal("fetch", fetchMock);
+  resolveKeyReferences.mockImplementation(async (text: string) => ({
+    resolved: text,
+    usedKeys: [],
+    secretValues: [],
+  }));
+  validateUrlAllowlist.mockReturnValue(true);
+  getKeyAllowlist.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  vi.resetModules();
+  delete process.env.NOTIFICATIONS_WEBHOOK_URL;
+  delete process.env.NOTIFICATIONS_WEBHOOK_AUTH;
+});
+
+describe("webhook notification channel", () => {
+  it("is not registered when NOTIFICATIONS_WEBHOOK_URL is unset", async () => {
+    delete process.env.NOTIFICATIONS_WEBHOOK_URL;
+    await expect(loadWebhookChannel()).resolves.toBeUndefined();
+  });
+
+  it("POSTs the notification payload as JSON scoped to the owner", async () => {
+    const channel = (await loadWebhookChannel())!;
+    await channel.deliver(
+      {
+        severity: "critical",
+        title: "DB offline",
+        body: "primary down",
+        metadata: { region: "us-east" },
+      },
+      { owner: "alice@example.com" },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://hooks.example.com/notify");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    const payload = JSON.parse(init.body);
+    expect(payload).toMatchObject({
+      severity: "critical",
+      title: "DB offline",
+      body: "primary down",
+      metadata: { region: "us-east" },
+      owner: "alice@example.com",
+    });
+    expect(typeof payload.emittedAt).toBe("string");
+    // No Authorization header when NOTIFICATIONS_WEBHOOK_AUTH is unset.
+    expect(init.headers.Authorization).toBeUndefined();
+  });
+
+  it("resolves an Authorization header from NOTIFICATIONS_WEBHOOK_AUTH", async () => {
+    process.env.NOTIFICATIONS_WEBHOOK_AUTH = "Bearer ${keys.HOOK_TOKEN}";
+    resolveKeyReferences.mockImplementation(async (text: string) => ({
+      resolved: text.includes("HOOK_TOKEN") ? "Bearer secret-xyz" : text,
+      usedKeys: [],
+      secretValues: [],
+    }));
+    const channel = (await loadWebhookChannel())!;
+
+    await channel.deliver(
+      { severity: "info", title: "Hi" },
+      { owner: "alice@example.com" },
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBe("Bearer secret-xyz");
+  });
+
+  it("enforces the per-key URL allowlist and never POSTs a disallowed origin", async () => {
+    process.env.NOTIFICATIONS_WEBHOOK_URL = "${keys.HOOK_URL}";
+    resolveKeyReferences.mockImplementation(async () => ({
+      resolved: "https://evil.example.com/steal",
+      usedKeys: ["HOOK_URL"],
+      secretValues: [],
+    }));
+    getKeyAllowlist.mockResolvedValue(["https://hooks.example.com"]);
+    validateUrlAllowlist.mockReturnValue(false);
+
+    const channel = (await loadWebhookChannel())!;
+
+    await expect(
+      channel.deliver(
+        { severity: "critical", title: "x" },
+        { owner: "alice@example.com" },
+      ),
+    ).rejects.toThrow(/not in the allowlist/i);
+
+    // Critically, the disallowed request must never be sent.
+    expect(fetchMock).not.toHaveBeenCalled();
+    // The allowlist was looked up for the referenced key, scoped to the owner.
+    expect(getKeyAllowlist).toHaveBeenCalledWith(
+      "HOOK_URL",
+      "user",
+      "alice@example.com",
+    );
+  });
+
+  it("delivers when the resolved URL satisfies the allowlist", async () => {
+    process.env.NOTIFICATIONS_WEBHOOK_URL = "${keys.HOOK_URL}";
+    resolveKeyReferences.mockImplementation(async () => ({
+      resolved: "https://hooks.example.com/notify",
+      usedKeys: ["HOOK_URL"],
+      secretValues: [],
+    }));
+    getKeyAllowlist.mockResolvedValue(["https://hooks.example.com"]);
+    validateUrlAllowlist.mockReturnValue(true);
+
+    const channel = (await loadWebhookChannel())!;
+    await channel.deliver(
+      { severity: "info", title: "ok" },
+      { owner: "alice@example.com" },
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws with the status when the webhook responds non-ok", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+      body: null,
+    } as unknown as Response);
+
+    const channel = (await loadWebhookChannel())!;
+    await expect(
+      channel.deliver(
+        { severity: "warning", title: "x" },
+        { owner: "alice@example.com" },
+      ),
+    ).rejects.toThrow(/503/);
+  });
+
+  it("appends a body snippet to the error when the failing response has a body", async () => {
+    let cancelled = false;
+    const chunk = new TextEncoder().encode("upstream rejected: bad token");
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      body: {
+        getReader() {
+          let sent = false;
+          return {
+            async read() {
+              if (sent) return { value: undefined, done: true };
+              sent = true;
+              return { value: chunk, done: false };
+            },
+            async cancel() {
+              cancelled = true;
+            },
+          };
+        },
+      },
+    } as unknown as Response);
+
+    const channel = (await loadWebhookChannel())!;
+    await expect(
+      channel.deliver(
+        { severity: "critical", title: "x" },
+        { owner: "alice@example.com" },
+      ),
+    ).rejects.toThrow(/401: upstream rejected: bad token/);
+    // The reader is drained then released rather than left open.
+    expect(cancelled).toBe(true);
+  });
+});

--- a/packages/core/src/notifications/store.spec.ts
+++ b/packages/core/src/notifications/store.spec.ts
@@ -1,28 +1,37 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-interface ExecCall {
-  sql: string;
-  args: unknown[];
-}
+// Real in-memory sqlite behind the raw getDbExec client. This lets the
+// owner-scoping invariants (you cannot mark/delete another owner's
+// notification) be tested for real rather than by inspecting captured SQL.
+let sqlite: Database.Database;
 
-const execCalls: ExecCall[] = [];
-
-const mockDb = {
-  execute: vi.fn(async (sql: string | { sql: string; args?: unknown[] }) => {
-    const rawSql = typeof sql === "string" ? sql : sql.sql;
-    const args = typeof sql === "string" ? [] : (sql.args ?? []);
-    execCalls.push({ sql: rawSql, args });
-    return { rows: [], rowsAffected: 0 };
+const rawClient = {
+  execute: vi.fn(async (input: string | { sql: string; args?: unknown[] }) => {
+    if (typeof input === "string") {
+      sqlite.exec(input);
+      return { rows: [], rowsAffected: 0 };
+    }
+    const stmt = sqlite.prepare(input.sql);
+    const args = (input.args ?? []) as unknown[];
+    if (/^\s*select/i.test(input.sql)) {
+      return { rows: stmt.all(...args), rowsAffected: 0 };
+    }
+    const info = stmt.run(...args);
+    return { rows: [], rowsAffected: info.changes };
   }),
 };
 
+const recordChange = vi.fn();
+
 vi.mock("../db/client.js", () => ({
-  getDbExec: () => mockDb,
+  getDbExec: () => rawClient,
   intType: () => "INTEGER",
-  retryOnDdlRace: (fn: () => unknown) => fn(),
-  safeJsonParse: (value: string, fallback: unknown) => {
+  retryOnDdlRace: <T>(fn: () => Promise<T>) => fn(),
+  safeJsonParse: (value: unknown, fallback: unknown) => {
+    if (value == null) return fallback;
     try {
-      return JSON.parse(value);
+      return JSON.parse(String(value));
     } catch {
       return fallback;
     }
@@ -30,29 +39,258 @@ vi.mock("../db/client.js", () => ({
 }));
 
 vi.mock("../server/poll.js", () => ({
-  recordChange: vi.fn(),
+  recordChange: (...args: unknown[]) => recordChange(...args),
 }));
 
-const { listNotifications } = await import("./store.js");
+const {
+  insertNotification,
+  listNotifications,
+  countUnread,
+  markNotificationRead,
+  markAllNotificationsRead,
+  deleteNotification,
+  updateDeliveredChannels,
+} = await import("./store.js");
 
-function lastSelect(): ExecCall {
-  const selects = execCalls.filter((c) => /^\s*SELECT\b/i.test(c.sql));
-  if (selects.length === 0) throw new Error("no SELECT was executed");
-  return selects[selects.length - 1];
+const ALICE = "alice@example.com";
+const BOB = "bob@example.com";
+
+// Seed a row with an explicit created_at so ordering/cursor tests are
+// deterministic (the store stamps Date.now() which collides under fast loops).
+function seedRow(opts: {
+  id: string;
+  owner: string;
+  title: string;
+  createdAt: number;
+  readAt?: number | null;
+}) {
+  sqlite
+    .prepare(
+      `INSERT INTO notifications
+        (id, owner, severity, title, body, metadata, delivered_channels, created_at, read_at)
+       VALUES (?, ?, 'info', ?, NULL, NULL, '["inbox"]', ?, ?)`,
+    )
+    .run(opts.id, opts.owner, opts.title, opts.createdAt, opts.readAt ?? null);
 }
 
-describe("notifications store", () => {
-  beforeEach(() => {
-    execCalls.length = 0;
-    vi.clearAllMocks();
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  // The store caches CREATE TABLE in a module-level _initPromise; create the
+  // table per fresh DB ourselves so each test starts clean.
+  sqlite.exec(`CREATE TABLE IF NOT EXISTS notifications (
+    id TEXT PRIMARY KEY,
+    owner TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    title TEXT NOT NULL,
+    body TEXT,
+    metadata TEXT,
+    delivered_channels TEXT NOT NULL DEFAULT '[]',
+    created_at INTEGER NOT NULL,
+    read_at INTEGER
+  )`);
+});
+
+afterEach(() => {
+  sqlite.close();
+  vi.clearAllMocks();
+});
+
+describe("insertNotification", () => {
+  it("returns the shaped notification, persists JSON metadata, and bumps poll", async () => {
+    const n = await insertNotification({
+      owner: ALICE,
+      severity: "warning",
+      title: "Disk low",
+      body: "Only 2% free",
+      metadata: { url: "/settings", code: 42 },
+      deliveredChannels: ["inbox"],
+    });
+
+    expect(n).toMatchObject({
+      owner: ALICE,
+      severity: "warning",
+      title: "Disk low",
+      body: "Only 2% free",
+      metadata: { url: "/settings", code: 42 },
+      deliveredChannels: ["inbox"],
+      readAt: null,
+    });
+    expect(n.id).toBeTruthy();
+    expect(typeof n.createdAt).toBe("string");
+    expect(recordChange).toHaveBeenCalledWith({
+      source: "notifications",
+      type: "change",
+      key: ALICE,
+    });
+
+    // Round-trips through list (metadata deserialized, createdAt ISO).
+    const [listed] = await listNotifications(ALICE);
+    expect(listed.metadata).toEqual({ url: "/settings", code: 42 });
+    expect(listed.body).toBe("Only 2% free");
+    expect(listed.deliveredChannels).toEqual(["inbox"]);
   });
 
-  it("scopes list queries to the owner and clamps invalid limits", async () => {
-    await listNotifications("alice@example.com", { limit: -1 });
+  it("stores null body/metadata cleanly and defaults delivered channels", async () => {
+    const n = await insertNotification({
+      owner: ALICE,
+      severity: "info",
+      title: "No extras",
+    });
+    expect(n.deliveredChannels).toEqual([]);
 
-    const call = lastSelect();
-    expect(call.sql).toMatch(/WHERE owner = \?/);
-    expect(call.sql).toMatch(/LIMIT \?/);
-    expect(call.args).toEqual(["alice@example.com", 50]);
+    const [listed] = await listNotifications(ALICE);
+    expect(listed.body).toBeUndefined();
+    expect(listed.metadata).toBeUndefined();
+    expect(listed.deliveredChannels).toEqual([]);
+  });
+});
+
+describe("listNotifications", () => {
+  const T1 = 1_700_000_000_000;
+  const T2 = T1 + 1000;
+  const T3 = T1 + 2000;
+
+  beforeEach(() => {
+    // Three Alice notifications at distinct timestamps; one Bob notification.
+    seedRow({ id: "a1", owner: ALICE, title: "A1", createdAt: T1 });
+    seedRow({ id: "a2", owner: ALICE, title: "A2", createdAt: T2 });
+    seedRow({ id: "a3", owner: ALICE, title: "A3", createdAt: T3 });
+    seedRow({ id: "b1", owner: BOB, title: "B1", createdAt: T2 });
+  });
+
+  it("scopes to the owner and orders newest-first", async () => {
+    const rows = await listNotifications(ALICE);
+    expect(rows.map((r) => r.title)).toEqual(["A3", "A2", "A1"]);
+    // Bob's notification never appears in Alice's list.
+    expect(rows.some((r) => r.title === "B1")).toBe(false);
+  });
+
+  it("unreadOnly excludes already-read notifications", async () => {
+    await markNotificationRead("a2", ALICE);
+
+    const unread = await listNotifications(ALICE, { unreadOnly: true });
+    expect(unread.map((r) => r.title)).toEqual(["A3", "A1"]);
+  });
+
+  it("before cursor returns only notifications older than the cursor", async () => {
+    const older = await listNotifications(ALICE, {
+      before: new Date(T2).toISOString(),
+    });
+    // Only A1 is strictly older than A2.
+    expect(older.map((r) => r.title)).toEqual(["A1"]);
+  });
+
+  it("clamps an over-large limit to 200 and a non-positive limit to the default", async () => {
+    await listNotifications(ALICE, { limit: 9999 });
+    const big = rawClient.execute.mock.calls.at(-1)![0] as { args: unknown[] };
+    expect(big.args.at(-1)).toBe(200);
+
+    await listNotifications(ALICE, { limit: -3 });
+    const neg = rawClient.execute.mock.calls.at(-1)![0] as { args: unknown[] };
+    expect(neg.args.at(-1)).toBe(50);
+  });
+});
+
+describe("countUnread", () => {
+  it("counts only the owner's unread rows", async () => {
+    await insertNotification({ owner: ALICE, severity: "info", title: "A1" });
+    const a2 = await insertNotification({
+      owner: ALICE,
+      severity: "info",
+      title: "A2",
+    });
+    await insertNotification({ owner: BOB, severity: "info", title: "B1" });
+
+    await expect(countUnread(ALICE)).resolves.toBe(2);
+    await markNotificationRead(a2.id, ALICE);
+    await expect(countUnread(ALICE)).resolves.toBe(1);
+    // Bob's count is independent.
+    await expect(countUnread(BOB)).resolves.toBe(1);
+  });
+});
+
+describe("markNotificationRead — owner scoping", () => {
+  it("marks the owner's notification read once and is a no-op the second time", async () => {
+    const n = await insertNotification({
+      owner: ALICE,
+      severity: "info",
+      title: "A1",
+    });
+    recordChange.mockClear();
+
+    await expect(markNotificationRead(n.id, ALICE)).resolves.toBe(true);
+    expect(recordChange).toHaveBeenCalledTimes(1);
+
+    // Already read → no rows affected, returns false, no extra poll bump.
+    recordChange.mockClear();
+    await expect(markNotificationRead(n.id, ALICE)).resolves.toBe(false);
+    expect(recordChange).not.toHaveBeenCalled();
+  });
+
+  it("refuses to mark another owner's notification read", async () => {
+    const n = await insertNotification({
+      owner: ALICE,
+      severity: "info",
+      title: "A1",
+    });
+
+    await expect(markNotificationRead(n.id, BOB)).resolves.toBe(false);
+    // Alice's notification is still unread.
+    await expect(countUnread(ALICE)).resolves.toBe(1);
+  });
+});
+
+describe("markAllNotificationsRead — owner scoping", () => {
+  it("marks only the caller's unread rows and returns the count", async () => {
+    await insertNotification({ owner: ALICE, severity: "info", title: "A1" });
+    await insertNotification({ owner: ALICE, severity: "info", title: "A2" });
+    await insertNotification({ owner: BOB, severity: "info", title: "B1" });
+
+    await expect(markAllNotificationsRead(ALICE)).resolves.toBe(2);
+    await expect(countUnread(ALICE)).resolves.toBe(0);
+    // Bob is untouched.
+    await expect(countUnread(BOB)).resolves.toBe(1);
+
+    // No unread left → returns 0 and does not bump poll.
+    recordChange.mockClear();
+    await expect(markAllNotificationsRead(ALICE)).resolves.toBe(0);
+    expect(recordChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteNotification — owner scoping", () => {
+  it("deletes the owner's notification and reports success", async () => {
+    const n = await insertNotification({
+      owner: ALICE,
+      severity: "info",
+      title: "A1",
+    });
+    await expect(deleteNotification(n.id, ALICE)).resolves.toBe(true);
+    await expect(listNotifications(ALICE)).resolves.toEqual([]);
+  });
+
+  it("refuses to delete another owner's notification", async () => {
+    const n = await insertNotification({
+      owner: ALICE,
+      severity: "info",
+      title: "A1",
+    });
+    await expect(deleteNotification(n.id, BOB)).resolves.toBe(false);
+    // Still present for Alice.
+    await expect(listNotifications(ALICE)).resolves.toHaveLength(1);
+  });
+});
+
+describe("updateDeliveredChannels", () => {
+  it("overwrites the delivered-channel list as JSON", async () => {
+    const n = await insertNotification({
+      owner: ALICE,
+      severity: "info",
+      title: "A1",
+      deliveredChannels: ["inbox"],
+    });
+    await updateDeliveredChannels(n.id, ["inbox", "webhook", "slack"]);
+    const [listed] = await listNotifications(ALICE);
+    expect(listed.deliveredChannels).toEqual(["inbox", "webhook", "slack"]);
   });
 });

--- a/packages/core/src/observability/cleanup-job.spec.ts
+++ b/packages/core/src/observability/cleanup-job.spec.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// The cleanup job's job is to bound trace storage by purging rows older
+// than a retention horizon. The high-value behavior to lock down is the
+// retention-cutoff math and the "disabled" escape hatch
+// (AGENT_NATIVE_TRACE_RETENTION_DAYS=0), plus the idempotency of the
+// recurring scheduler. We mock the store so no real DB is touched and so
+// we can read back exactly which cutoff timestamp was passed to the
+// delete.
+
+const deleteOldTraceData = vi.hoisted(() => vi.fn());
+
+vi.mock("./store.js", () => ({
+  deleteOldTraceData: (...args: unknown[]) => deleteOldTraceData(...args),
+}));
+
+const { runTraceCleanupOnce, startTraceCleanupJob, stopTraceCleanupJob } =
+  await import("./cleanup-job.js");
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const ENV_KEY = "AGENT_NATIVE_TRACE_RETENTION_DAYS";
+
+describe("trace cleanup retention logic", () => {
+  const originalEnv = process.env[ENV_KEY];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    deleteOldTraceData.mockResolvedValue({ spans: 0, summaries: 0, evals: 0 });
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    stopTraceCleanupJob();
+    vi.useRealTimers();
+    if (originalEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = originalEnv;
+  });
+
+  describe("runTraceCleanupOnce", () => {
+    it("uses the 30-day default cutoff when the env var is unset", async () => {
+      vi.useFakeTimers();
+      const now = 1_000_000_000_000;
+      vi.setSystemTime(now);
+
+      await runTraceCleanupOnce();
+
+      expect(deleteOldTraceData).toHaveBeenCalledTimes(1);
+      const cutoff = deleteOldTraceData.mock.calls[0][0] as number;
+      expect(cutoff).toBe(now - 30 * ONE_DAY_MS);
+    });
+
+    it("honors a custom retention window from the env var", async () => {
+      process.env[ENV_KEY] = "7";
+      vi.useFakeTimers();
+      const now = 2_000_000_000_000;
+      vi.setSystemTime(now);
+
+      await runTraceCleanupOnce();
+
+      const cutoff = deleteOldTraceData.mock.calls[0][0] as number;
+      expect(cutoff).toBe(now - 7 * ONE_DAY_MS);
+    });
+
+    it("returns null and does NOT purge when retention is disabled (=0)", async () => {
+      // 0 is the documented escape hatch for dev/debugging. It must never
+      // issue a delete — otherwise "disabled" would still destroy data.
+      process.env[ENV_KEY] = "0";
+
+      const result = await runTraceCleanupOnce();
+
+      expect(result).toBeNull();
+      expect(deleteOldTraceData).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the default for non-numeric or negative values", async () => {
+      vi.useFakeTimers();
+      const now = 3_000_000_000_000;
+      vi.setSystemTime(now);
+
+      for (const bad of ["abc", "-5", ""]) {
+        deleteOldTraceData.mockClear();
+        process.env[ENV_KEY] = bad;
+        await runTraceCleanupOnce();
+        const cutoff = deleteOldTraceData.mock.calls[0][0] as number;
+        expect(cutoff).toBe(now - 30 * ONE_DAY_MS);
+      }
+    });
+
+    it("propagates the per-table deletion counts from the store", async () => {
+      deleteOldTraceData.mockResolvedValue({
+        spans: 12,
+        summaries: 3,
+        evals: 7,
+      });
+      const result = await runTraceCleanupOnce();
+      expect(result).toEqual({ spans: 12, summaries: 3, evals: 7 });
+    });
+  });
+
+  describe("startTraceCleanupJob scheduler", () => {
+    it("runs the first purge only after the startup delay, then daily", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+
+      startTraceCleanupJob();
+
+      // Nothing fires immediately — the startup delay protects bootstrap.
+      expect(deleteOldTraceData).not.toHaveBeenCalled();
+
+      // After the 5-minute startup delay, the first sweep runs.
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      expect(deleteOldTraceData).toHaveBeenCalledTimes(1);
+
+      // Then a sweep every 24h.
+      await vi.advanceTimersByTimeAsync(ONE_DAY_MS);
+      expect(deleteOldTraceData).toHaveBeenCalledTimes(2);
+    });
+
+    it("is idempotent: a second start does not double-schedule", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+
+      startTraceCleanupJob();
+      startTraceCleanupJob();
+
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      // One scheduler => one sweep, not two.
+      expect(deleteOldTraceData).toHaveBeenCalledTimes(1);
+    });
+
+    it("schedules nothing when retention is disabled", async () => {
+      process.env[ENV_KEY] = "0";
+      vi.useFakeTimers();
+
+      startTraceCleanupJob();
+      await vi.advanceTimersByTimeAsync(10 * ONE_DAY_MS);
+
+      expect(deleteOldTraceData).not.toHaveBeenCalled();
+    });
+
+    it("stopTraceCleanupJob cancels a pending startup purge", async () => {
+      vi.useFakeTimers();
+
+      startTraceCleanupJob();
+      stopTraceCleanupJob();
+
+      await vi.advanceTimersByTimeAsync(10 * ONE_DAY_MS);
+      expect(deleteOldTraceData).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/observability/evals.spec.ts
+++ b/packages/core/src/observability/evals.spec.ts
@@ -1,0 +1,470 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { TraceSummary, EvalCriteria } from "./types.js";
+import type { AgentEngine } from "../agent/engine/types.js";
+
+// evals.ts has three layers:
+//  1. Automated deterministic scorers (tool success, step efficiency,
+//     latency, cost, error recovery) — pure functions of a TraceSummary
+//     plus run status. These are the highest-value: every score must be
+//     clamped to [0,1] and reflect the documented formula.
+//  2. LLM-as-judge — we DON'T hit a model; we inject a fake engine whose
+//     stream yields a canned JSON blob, and assert the parsing +
+//     score-range normalization + null-on-garbage behavior.
+//  3. Dataset eval — aggregates judge results into an avgScore.
+//
+// Store writes (insertEvalResult) are fire-and-forget; we mock them and
+// also capture the persisted rows to check userId scoping.
+
+const store = vi.hoisted(() => ({
+  getTraceSummary: vi.fn(),
+  insertEvalResult: vi.fn(),
+  getEvalDataset: vi.fn(),
+}));
+const runStore = vi.hoisted(() => ({
+  getRunById: vi.fn(),
+  getRunEventsSince: vi.fn(),
+}));
+const engineMod = vi.hoisted(() => ({
+  resolveEngine: vi.fn(),
+  getStoredModelForEngine: vi.fn(),
+}));
+
+vi.mock("./store.js", () => ({
+  getTraceSummary: (...a: unknown[]) => store.getTraceSummary(...a),
+  insertEvalResult: (...a: unknown[]) => store.insertEvalResult(...a),
+  getEvalDataset: (...a: unknown[]) => store.getEvalDataset(...a),
+}));
+vi.mock("../agent/run-store.js", () => ({
+  getRunById: (...a: unknown[]) => runStore.getRunById(...a),
+  getRunEventsSince: (...a: unknown[]) => runStore.getRunEventsSince(...a),
+}));
+vi.mock("../agent/engine/index.js", () => ({
+  resolveEngine: (...a: unknown[]) => engineMod.resolveEngine(...a),
+  getStoredModelForEngine: (...a: unknown[]) =>
+    engineMod.getStoredModelForEngine(...a),
+}));
+
+const { runAutomatedEvals, runLlmJudgeEval, runDatasetEval, evaluateRun } =
+  await import("./evals.js");
+
+function summary(over: Partial<TraceSummary> = {}): TraceSummary {
+  return {
+    runId: "run-1",
+    threadId: "thread-1",
+    userId: "alice",
+    totalSpans: 0,
+    llmCalls: 0,
+    toolCalls: 0,
+    successfulTools: 0,
+    failedTools: 0,
+    totalDurationMs: 0,
+    totalCostCentsX100: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    model: "test-model",
+    createdAt: 0,
+    ...over,
+  };
+}
+
+/** A fake engine whose single stream() call yields the given text as one
+ *  text-delta. Lets us drive judge parsing without a model. */
+function fakeEngine(responseText: string): AgentEngine {
+  return {
+    name: "fake",
+    label: "Fake",
+    defaultModel: "fake-model",
+    supportedModels: ["fake-model"],
+    capabilities: {} as any,
+    async *stream() {
+      yield { type: "text-delta", text: responseText } as any;
+    },
+  } as AgentEngine;
+}
+
+function byCriteria(results: { criteria: string }[]) {
+  return Object.fromEntries(results.map((r) => [r.criteria, r])) as Record<
+    string,
+    any
+  >;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const fn of [
+    ...Object.values(store),
+    ...Object.values(runStore),
+    ...Object.values(engineMod),
+  ])
+    fn.mockReset();
+  store.insertEvalResult.mockResolvedValue(undefined);
+});
+
+describe("runAutomatedEvals deterministic scorers", () => {
+  it("returns [] (and writes nothing) when no trace summary exists", async () => {
+    store.getTraceSummary.mockResolvedValue(null);
+    runStore.getRunById.mockResolvedValue(null);
+
+    const results = await runAutomatedEvals("run-1");
+    expect(results).toEqual([]);
+    expect(store.insertEvalResult).not.toHaveBeenCalled();
+  });
+
+  it("scores a perfect tool run: success rate 1, full efficiency, recovers", async () => {
+    store.getTraceSummary.mockResolvedValue(
+      summary({
+        toolCalls: 3,
+        successfulTools: 3,
+        failedTools: 0,
+        llmCalls: 3,
+        totalDurationMs: 0,
+        totalCostCentsX100: 0,
+      }),
+    );
+    runStore.getRunById.mockResolvedValue({
+      id: "run-1",
+      threadId: "thread-1",
+      status: "completed",
+      startedAt: 0,
+    });
+
+    const r = byCriteria(await runAutomatedEvals("run-1"));
+    expect(r.tool_success_rate.score).toBe(1); // 3/3
+    expect(r.step_efficiency.score).toBe(1); // min(1, 3/3)
+    expect(r.latency_score.score).toBe(1); // 0 duration
+    expect(r.cost_efficiency.score).toBe(1); // 0 cost
+    expect(r.error_recovery.score).toBe(1); // no failures
+  });
+
+  it("tool_success_rate is failedTools-aware and is 1.0 for a no-tool run", async () => {
+    store.getTraceSummary.mockResolvedValue(
+      summary({ toolCalls: 4, successfulTools: 1, failedTools: 3 }),
+    );
+    runStore.getRunById.mockResolvedValue(null);
+    let r = byCriteria(await runAutomatedEvals("run-1"));
+    expect(r.tool_success_rate.score).toBe(0.25); // 1/4
+    expect(r.tool_success_rate.metadata).toMatchObject({
+      totalTools: 4,
+      successfulTools: 1,
+      failedTools: 3,
+    });
+
+    // No tools at all => treated as a clean Q&A, score 1.0.
+    store.getTraceSummary.mockResolvedValue(summary({ toolCalls: 0 }));
+    r = byCriteria(await runAutomatedEvals("run-1"));
+    expect(r.tool_success_rate.score).toBe(1);
+    expect(r.step_efficiency.score).toBe(1);
+  });
+
+  it("step_efficiency penalizes many LLM iterations per tool call", async () => {
+    store.getTraceSummary.mockResolvedValue(
+      summary({ toolCalls: 2, llmCalls: 8 }),
+    );
+    runStore.getRunById.mockResolvedValue(null);
+    const r = byCriteria(await runAutomatedEvals("run-1"));
+    expect(r.step_efficiency.score).toBe(0.25); // min(1, 2/8)
+  });
+
+  it("latency_score clamps to 0 when the run vastly exceeds the baseline", async () => {
+    // baseline = max(10000, toolCalls*10000). With 0 tools => 10000ms.
+    store.getTraceSummary.mockResolvedValue(
+      summary({ toolCalls: 0, totalDurationMs: 50_000 }),
+    );
+    runStore.getRunById.mockResolvedValue(null);
+    const r = byCriteria(await runAutomatedEvals("run-1"));
+    expect(r.latency_score.score).toBe(0); // 1 - 50000/10000 < 0 => clamp
+    expect(r.latency_score.metadata).toMatchObject({
+      actualMs: 50_000,
+      expectedMs: 10_000,
+    });
+  });
+
+  it("cost_efficiency clamps to 0 when cost exceeds the per-tool budget", async () => {
+    // expected = max(50, toolCalls*50) = 50 with 0 tools.
+    store.getTraceSummary.mockResolvedValue(
+      summary({ toolCalls: 0, totalCostCentsX100: 200 }),
+    );
+    runStore.getRunById.mockResolvedValue(null);
+    const r = byCriteria(await runAutomatedEvals("run-1"));
+    expect(r.cost_efficiency.score).toBe(0); // 1 - 200/50 < 0
+  });
+
+  it("error_recovery: failures + a non-completed run scores 0", async () => {
+    store.getTraceSummary.mockResolvedValue(
+      summary({ toolCalls: 2, successfulTools: 1, failedTools: 1 }),
+    );
+    runStore.getRunById.mockResolvedValue({
+      id: "run-1",
+      threadId: "thread-1",
+      status: "failed",
+      startedAt: 0,
+    });
+    const r = byCriteria(await runAutomatedEvals("run-1"));
+    expect(r.error_recovery.score).toBe(0);
+    expect(r.error_recovery.metadata).toMatchObject({
+      hadErrors: true,
+      runStatus: "failed",
+    });
+  });
+
+  it("error_recovery: failures but a completed run still scores 1 (recovered)", async () => {
+    store.getTraceSummary.mockResolvedValue(
+      summary({ toolCalls: 2, successfulTools: 1, failedTools: 1 }),
+    );
+    runStore.getRunById.mockResolvedValue({
+      id: "run-1",
+      threadId: "thread-1",
+      status: "completed",
+      startedAt: 0,
+    });
+    const r = byCriteria(await runAutomatedEvals("run-1"));
+    expect(r.error_recovery.score).toBe(1);
+  });
+
+  it("falls back to 'unknown' run status when the run row is missing", async () => {
+    store.getTraceSummary.mockResolvedValue(
+      summary({ toolCalls: 1, successfulTools: 0, failedTools: 1 }),
+    );
+    runStore.getRunById.mockResolvedValue(null);
+    const r = byCriteria(await runAutomatedEvals("run-1"));
+    // hadErrors true, status not "completed" => 0.
+    expect(r.error_recovery.score).toBe(0);
+    expect(r.error_recovery.metadata).toMatchObject({ runStatus: "unknown" });
+  });
+
+  it("carries the trace summary's userId onto every eval row (scoping)", async () => {
+    store.getTraceSummary.mockResolvedValue(summary({ userId: "carol" }));
+    runStore.getRunById.mockResolvedValue(null);
+    const results = await runAutomatedEvals("run-1");
+    expect(results).toHaveLength(5);
+    expect(results.every((r) => r.userId === "carol")).toBe(true);
+    expect(results.every((r) => r.evalType === "automated")).toBe(true);
+  });
+});
+
+describe("runLlmJudgeEval", () => {
+  const criteria: EvalCriteria = {
+    name: "helpfulness",
+    description: "How helpful the response is",
+  };
+
+  beforeEach(() => {
+    runStore.getRunEventsSince.mockResolvedValue([
+      {
+        seq: 1,
+        eventData: JSON.stringify({ type: "user-message", text: "hi" }),
+      },
+      {
+        seq: 2,
+        eventData: JSON.stringify({ type: "text", text: "hello there" }),
+      },
+    ]);
+    runStore.getRunById.mockResolvedValue({
+      id: "run-1",
+      threadId: "thread-1",
+      status: "completed",
+      startedAt: 0,
+    });
+  });
+
+  it("returns null when the run has no events", async () => {
+    runStore.getRunEventsSince.mockResolvedValue([]);
+    const out = await runLlmJudgeEval("run-1", criteria, {
+      engine: fakeEngine('{"score": 1, "reasoning": "x"}'),
+    });
+    expect(out).toBeNull();
+  });
+
+  it("parses a clean JSON judge response into a [0,1] score", async () => {
+    const out = await runLlmJudgeEval("run-1", criteria, {
+      engine: fakeEngine('{"score": 0.9, "reasoning": "good answer"}'),
+      userId: "alice",
+    });
+    expect(out).not.toBeNull();
+    expect(out!.score).toBe(0.9);
+    expect(out!.reasoning).toBe("good answer");
+    expect(out!.evalType).toBe("llm_judge");
+    expect(out!.userId).toBe("alice");
+    expect(out!.criteria).toBe("helpfulness");
+  });
+
+  it("normalizes a custom score range to [0,1]", async () => {
+    // 7 on a 1..10 scale => (7-1)/(10-1) = 0.666...
+    const out = await runLlmJudgeEval(
+      "run-1",
+      { ...criteria, scoreRange: { min: 1, max: 10 } },
+      { engine: fakeEngine('Here you go: {"score": 7, "reasoning": "ok"}') },
+    );
+    expect(out!.score).toBeCloseTo(6 / 9, 5);
+    expect(out!.metadata).toMatchObject({ rawScore: 7 });
+  });
+
+  it("extracts the JSON object even when wrapped in prose / markdown", async () => {
+    const out = await runLlmJudgeEval("run-1", criteria, {
+      engine: fakeEngine(
+        'Sure!\n```json\n{"score": 0.5, "reasoning": "mid"}\n```\nDone.',
+      ),
+    });
+    expect(out!.score).toBe(0.5);
+  });
+
+  it("returns null when the response contains no JSON object", async () => {
+    const out = await runLlmJudgeEval("run-1", criteria, {
+      engine: fakeEngine("I cannot evaluate this."),
+    });
+    expect(out).toBeNull();
+  });
+
+  it("returns null (does not throw) on malformed JSON", async () => {
+    const out = await runLlmJudgeEval("run-1", criteria, {
+      engine: fakeEngine('{"score": oops not valid}'),
+    });
+    expect(out).toBeNull();
+  });
+
+  it("clamps out-of-range judge scores into [0,1]", async () => {
+    const over = await runLlmJudgeEval("run-1", criteria, {
+      engine: fakeEngine('{"score": 5, "reasoning": "too high"}'),
+    });
+    expect(over!.score).toBe(1);
+    const under = await runLlmJudgeEval("run-1", criteria, {
+      engine: fakeEngine('{"score": -3, "reasoning": "too low"}'),
+    });
+    expect(under!.score).toBe(0);
+  });
+
+  it("resolves engine + stored model when none are supplied", async () => {
+    const eng = fakeEngine('{"score": 0.7, "reasoning": "auto"}');
+    engineMod.resolveEngine.mockResolvedValue(eng);
+    engineMod.getStoredModelForEngine.mockResolvedValue("stored-model");
+
+    const out = await runLlmJudgeEval("run-1", criteria);
+    expect(engineMod.resolveEngine).toHaveBeenCalled();
+    expect(out!.score).toBe(0.7);
+    expect(out!.metadata).toMatchObject({ model: "stored-model" });
+  });
+});
+
+describe("runDatasetEval aggregation", () => {
+  it("returns an empty result when the dataset is missing", async () => {
+    store.getEvalDataset.mockResolvedValue(null);
+    const out = await runDatasetEval("ds-1", {
+      engine: fakeEngine('{"score":1,"reasoning":"x"}'),
+    });
+    expect(out).toEqual({
+      datasetId: "ds-1",
+      totalCases: 0,
+      avgScore: 0,
+      results: [],
+    });
+  });
+
+  it("averages judge scores across every test case (default single criterion)", async () => {
+    store.getEvalDataset.mockResolvedValue({
+      id: "ds-1",
+      name: "n",
+      description: "",
+      entries: [{ input: "case A" }, { input: "case B", expectedOutput: "B!" }],
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    // Each evaluateTestCase call streams the same response => score 0.8.
+    const out = await runDatasetEval("ds-1", {
+      engine: fakeEngine('{"score": 0.8, "reasoning": "fine"}'),
+    });
+
+    expect(out.totalCases).toBe(2);
+    expect(out.results).toHaveLength(2); // 1 criterion x 2 cases
+    expect(out.avgScore).toBeCloseTo(0.8, 5);
+    // Dataset evals are administrative => userId null, synthetic runId.
+    expect(out.results.every((r) => r.userId === null)).toBe(true);
+    expect(out.results.every((r) => r.runId.startsWith("dataset:ds-1:"))).toBe(
+      true,
+    );
+  });
+
+  it("runs each supplied criterion against each case (cross product)", async () => {
+    store.getEvalDataset.mockResolvedValue({
+      id: "ds-1",
+      name: "n",
+      description: "",
+      entries: [{ input: "only case" }],
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    const out = await runDatasetEval("ds-1", {
+      engine: fakeEngine('{"score": 0.5, "reasoning": "ok"}'),
+      criteria: [
+        { name: "accuracy", description: "a" },
+        { name: "tone", description: "t" },
+      ],
+    });
+    expect(out.results).toHaveLength(2);
+    expect(new Set(out.results.map((r) => r.criteria))).toEqual(
+      new Set(["accuracy", "tone"]),
+    );
+  });
+
+  it("skips unparseable judge responses (avgScore ignores them)", async () => {
+    store.getEvalDataset.mockResolvedValue({
+      id: "ds-1",
+      name: "n",
+      description: "",
+      entries: [{ input: "a" }, { input: "b" }],
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    // No JSON => every evaluateTestCase returns null => no results.
+    const out = await runDatasetEval("ds-1", {
+      engine: fakeEngine("nope, no json here"),
+    });
+    expect(out.results).toHaveLength(0);
+    expect(out.avgScore).toBe(0);
+    expect(out.totalCases).toBe(2);
+  });
+});
+
+describe("evaluateRun orchestrator", () => {
+  beforeEach(() => {
+    store.getTraceSummary.mockResolvedValue(
+      summary({ toolCalls: 1, successfulTools: 1, userId: "alice" }),
+    );
+    runStore.getRunById.mockResolvedValue({
+      id: "run-1",
+      threadId: "thread-1",
+      status: "completed",
+      startedAt: 0,
+    });
+  });
+
+  it("runs only the 5 automated evals when sampleRate is 0 (no judge)", async () => {
+    const results = await evaluateRun("run-1", { sampleRate: 0 });
+    expect(results).toHaveLength(5);
+    expect(results.every((r) => r.evalType === "automated")).toBe(true);
+  });
+
+  it("appends judge evals when the sample roll passes", async () => {
+    // sampleRate 1 => always sample. Provide an engine via resolveEngine.
+    engineMod.resolveEngine.mockResolvedValue(
+      fakeEngine('{"score": 0.9, "reasoning": "great"}'),
+    );
+    engineMod.getStoredModelForEngine.mockResolvedValue("m");
+    runStore.getRunEventsSince.mockResolvedValue([
+      {
+        seq: 1,
+        eventData: JSON.stringify({ type: "user-message", text: "hi" }),
+      },
+      { seq: 2, eventData: JSON.stringify({ type: "text", text: "hello" }) },
+    ]);
+
+    const results = await evaluateRun("run-1", { sampleRate: 1 });
+    // 5 automated + 2 default judge criteria.
+    expect(results).toHaveLength(7);
+    const judge = results.filter((r) => r.evalType === "llm_judge");
+    expect(judge).toHaveLength(2);
+    // Judge evals inherit the automated userId.
+    expect(judge.every((r) => r.userId === "alice")).toBe(true);
+  });
+});

--- a/packages/core/src/observability/experiments.spec.ts
+++ b/packages/core/src/observability/experiments.spec.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Experiment, ExperimentVariant } from "./types.js";
+
+// experiments.ts holds the deterministic A/B bucketing logic and the
+// metric aggregation (mean / stddev / 95% CI). Those are the high-value
+// targets: a non-deterministic bucketer would silently reassign users
+// mid-experiment, and broken stats would mislead every readout. We mock
+// the store (assignment lookups, experiment CRUD) and the raw DB client
+// (used by computeExperimentResults) so we can shape inputs precisely and
+// no network/DB is hit.
+
+const store = vi.hoisted(() => ({
+  insertExperiment: vi.fn(),
+  updateExperiment: vi.fn(),
+  listExperiments: vi.fn(),
+  getExperiment: vi.fn(),
+  upsertAssignment: vi.fn(),
+  getAssignment: vi.fn(),
+  insertExperimentResult: vi.fn(),
+  ensureObservabilityTables: vi.fn(),
+}));
+
+const dbExecute = vi.hoisted(() => vi.fn());
+
+vi.mock("./store.js", () => ({
+  insertExperiment: (...a: unknown[]) => store.insertExperiment(...a),
+  updateExperiment: (...a: unknown[]) => store.updateExperiment(...a),
+  listExperiments: (...a: unknown[]) => store.listExperiments(...a),
+  getExperiment: (...a: unknown[]) => store.getExperiment(...a),
+  upsertAssignment: (...a: unknown[]) => store.upsertAssignment(...a),
+  getAssignment: (...a: unknown[]) => store.getAssignment(...a),
+  insertExperimentResult: (...a: unknown[]) =>
+    store.insertExperimentResult(...a),
+  ensureObservabilityTables: (...a: unknown[]) =>
+    store.ensureObservabilityTables(...a),
+}));
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => ({ execute: dbExecute }),
+}));
+
+const {
+  createExperiment,
+  startExperiment,
+  pauseExperiment,
+  completeExperiment,
+  resolveVariant,
+  resolveActiveExperimentConfig,
+  computeExperimentResults,
+} = await import("./experiments.js");
+
+function makeExperiment(over: Partial<Experiment> = {}): Experiment {
+  return {
+    id: "exp-1",
+    name: "test",
+    status: "running",
+    variants: [
+      { id: "control", weight: 50, config: { color: "blue" } },
+      { id: "treatment", weight: 50, config: { color: "green" } },
+    ],
+    metrics: ["avg_cost"],
+    assignmentLevel: "user",
+    startedAt: null,
+    endedAt: null,
+    createdAt: 0,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const fn of Object.values(store)) fn.mockReset();
+  store.insertExperiment.mockResolvedValue(undefined);
+  store.updateExperiment.mockResolvedValue(undefined);
+  store.upsertAssignment.mockResolvedValue(undefined);
+  store.insertExperimentResult.mockResolvedValue(undefined);
+  store.ensureObservabilityTables.mockResolvedValue(undefined);
+  store.getAssignment.mockResolvedValue(null);
+  dbExecute.mockResolvedValue({ rows: [] });
+});
+
+describe("experiment lifecycle", () => {
+  it("createExperiment starts in draft with a user-level default", async () => {
+    const exp = await createExperiment({
+      name: "checkout-test",
+      variants: [{ id: "a", weight: 1, config: {} }],
+      metrics: ["avg_cost"],
+    });
+
+    expect(exp.status).toBe("draft");
+    expect(exp.assignmentLevel).toBe("user");
+    expect(exp.startedAt).toBeNull();
+    expect(exp.endedAt).toBeNull();
+    expect(store.insertExperiment).toHaveBeenCalledWith(exp);
+  });
+
+  it("start / pause / complete transition status (and complete stamps endedAt)", async () => {
+    await startExperiment("exp-1");
+    expect(store.updateExperiment).toHaveBeenCalledWith("exp-1", {
+      status: "running",
+    });
+
+    await pauseExperiment("exp-1");
+    expect(store.updateExperiment).toHaveBeenCalledWith("exp-1", {
+      status: "paused",
+    });
+
+    await completeExperiment("exp-1");
+    const lastCall = store.updateExperiment.mock.calls.at(-1)![1];
+    expect(lastCall.status).toBe("completed");
+    expect(typeof lastCall.endedAt).toBe("number");
+  });
+});
+
+describe("resolveVariant bucketing", () => {
+  it("is deterministic: same (experiment,user) always lands the same variant", async () => {
+    store.getExperiment.mockResolvedValue(makeExperiment());
+
+    const first = await resolveVariant("exp-1", "user-42");
+    // Clear the fire-and-forget assignment so the second call re-buckets
+    // from the hash, not from a stored assignment — proving the hash
+    // itself is stable.
+    store.getAssignment.mockResolvedValue(null);
+    const second = await resolveVariant("exp-1", "user-42");
+
+    expect(first.id).toBe(second.id);
+  });
+
+  it("respects a stored assignment over re-bucketing (sticky)", async () => {
+    store.getExperiment.mockResolvedValue(makeExperiment());
+    store.getAssignment.mockResolvedValue({
+      experimentId: "exp-1",
+      userId: "user-1",
+      variantId: "treatment",
+      assignedAt: 1,
+    });
+
+    const variant = await resolveVariant("exp-1", "user-1");
+    expect(variant.id).toBe("treatment");
+    // No new assignment write when one already exists.
+    expect(store.upsertAssignment).not.toHaveBeenCalled();
+  });
+
+  it("distributes users across variants roughly in proportion to weights", async () => {
+    store.getExperiment.mockResolvedValue(makeExperiment());
+
+    const counts: Record<string, number> = { control: 0, treatment: 0 };
+    for (let i = 0; i < 2000; i++) {
+      const v = await resolveVariant("exp-1", `user-${i}`);
+      counts[v.id]++;
+    }
+    // 50/50 split — allow generous slack but both must get a real share.
+    expect(counts.control).toBeGreaterThan(700);
+    expect(counts.treatment).toBeGreaterThan(700);
+    expect(counts.control + counts.treatment).toBe(2000);
+  });
+
+  it("honors lopsided weights (90/10) directionally", async () => {
+    store.getExperiment.mockResolvedValue(
+      makeExperiment({
+        variants: [
+          { id: "big", weight: 90, config: {} },
+          { id: "small", weight: 10, config: {} },
+        ],
+      }),
+    );
+
+    const counts: Record<string, number> = { big: 0, small: 0 };
+    for (let i = 0; i < 2000; i++) {
+      const v = await resolveVariant("exp-1", `u${i}`);
+      counts[v.id]++;
+    }
+    expect(counts.big).toBeGreaterThan(counts.small * 3);
+  });
+
+  it("persists the chosen assignment on first bucketing", async () => {
+    store.getExperiment.mockResolvedValue(makeExperiment());
+
+    const v = await resolveVariant("exp-1", "user-7");
+    // upsertAssignment is fire-and-forget; await a microtask flush.
+    await Promise.resolve();
+    expect(store.upsertAssignment).toHaveBeenCalledTimes(1);
+    const written = store.upsertAssignment.mock.calls[0][0];
+    expect(written.variantId).toBe(v.id);
+    expect(written.experimentId).toBe("exp-1");
+    expect(written.userId).toBe("user-7");
+  });
+
+  it("throws when the experiment is missing", async () => {
+    store.getExperiment.mockResolvedValue(null);
+    await expect(resolveVariant("nope", "u1")).rejects.toThrow(/not found/);
+  });
+
+  it("throws when there are no variants or zero total weight", async () => {
+    store.getExperiment.mockResolvedValue(makeExperiment({ variants: [] }));
+    await expect(resolveVariant("exp-1", "u1")).rejects.toThrow(/no variants/);
+
+    store.getExperiment.mockResolvedValue(
+      makeExperiment({
+        variants: [{ id: "z", weight: 0, config: {} }],
+      }),
+    );
+    await expect(resolveVariant("exp-1", "u1")).rejects.toThrow(
+      /no valid variant weights/,
+    );
+  });
+
+  it("throws if a stored assignment points at a now-deleted variant", async () => {
+    store.getExperiment.mockResolvedValue(makeExperiment());
+    store.getAssignment.mockResolvedValue({
+      experimentId: "exp-1",
+      userId: "u1",
+      variantId: "ghost",
+      assignedAt: 1,
+    });
+    await expect(resolveVariant("exp-1", "u1")).rejects.toThrow(
+      /Variant ghost not found/,
+    );
+  });
+});
+
+describe("resolveActiveExperimentConfig", () => {
+  it("returns null when no experiments are running", async () => {
+    store.listExperiments.mockResolvedValue([
+      makeExperiment({ status: "draft" }),
+    ]);
+    const out = await resolveActiveExperimentConfig("user-1");
+    expect(out).toBeNull();
+  });
+
+  it("merges configs from all running experiments for the user", async () => {
+    // getActiveExperiments has a 5s in-module TTL cache; the previous test
+    // may have cached an empty active-list. invalidateCache is only reachable
+    // through a lifecycle call, so clear it via pauseExperiment first.
+    await pauseExperiment("exp-x");
+    const expA = makeExperiment({
+      id: "expA",
+      variants: [{ id: "a", weight: 1, config: { theme: "dark" } }],
+    });
+    const expB = makeExperiment({
+      id: "expB",
+      variants: [{ id: "b", weight: 1, config: { layout: "grid" } }],
+    });
+    store.listExperiments.mockResolvedValue([expA, expB]);
+    store.getExperiment.mockImplementation(async (id: string) =>
+      id === "expA" ? expA : expB,
+    );
+
+    const out = await resolveActiveExperimentConfig("user-1");
+    expect(out).not.toBeNull();
+    expect(out!.configs).toEqual({ theme: "dark", layout: "grid" });
+    expect(out!.assignments).toEqual([
+      { experimentId: "expA", variantId: "a" },
+      { experimentId: "expB", variantId: "b" },
+    ]);
+  });
+});
+
+describe("computeExperimentResults stats", () => {
+  it("emits zeroed metrics for a variant with no assignments", async () => {
+    store.getExperiment.mockResolvedValue(makeExperiment());
+    // Both variants: assignment query returns no rows.
+    dbExecute.mockResolvedValue({ rows: [] });
+
+    const results = await computeExperimentResults("exp-1");
+
+    // 6 empty metrics per variant, 2 variants.
+    expect(results).toHaveLength(12);
+    expect(results.every((r) => r.value === 0 && r.sampleSize === 0)).toBe(
+      true,
+    );
+    const metrics = new Set(results.map((r) => r.metric));
+    expect(metrics).toEqual(
+      new Set([
+        "avg_cost",
+        "avg_latency",
+        "avg_eval_score",
+        "tool_success_rate",
+        "satisfaction",
+        "sample_size",
+      ]),
+    );
+  });
+
+  it("computes mean, sample size, and a 95% CI from real trace rows", async () => {
+    store.getExperiment.mockResolvedValue(
+      makeExperiment({
+        variants: [{ id: "control", weight: 1, config: {} }],
+      }),
+    );
+
+    // Queue the sequence of execute() calls for the single variant:
+    //  1) assignment user_ids
+    //  2) trace summaries
+    //  3) eval scores
+    //  4) satisfaction (frustration) scores
+    dbExecute
+      .mockResolvedValueOnce({ rows: [{ user_id: "u1" }, { user_id: "u2" }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            total_cost_cents_x100: 100, // => $1.00
+            total_duration_ms: 1000,
+            successful_tools: 1,
+            tool_calls: 2, // rate 0.5
+            run_id: "r1",
+          },
+          {
+            total_cost_cents_x100: 300, // => $3.00
+            total_duration_ms: 3000,
+            successful_tools: 2,
+            tool_calls: 2, // rate 1.0
+            run_id: "r2",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ score: 0.8 }, { score: 0.6 }] })
+      .mockResolvedValueOnce({ rows: [{ frustration_score: 20 }] });
+
+    const results = await computeExperimentResults("exp-1");
+    const byMetric = Object.fromEntries(results.map((r) => [r.metric, r]));
+
+    expect(byMetric.avg_cost.value).toBeCloseTo(2.0, 5); // mean of 1,3
+    expect(byMetric.avg_latency.value).toBeCloseTo(2000, 5);
+    expect(byMetric.tool_success_rate.value).toBeCloseTo(0.75, 5); // (.5+1)/2
+    expect(byMetric.avg_eval_score.value).toBeCloseTo(0.7, 5); // (.8+.6)/2
+    expect(byMetric.satisfaction.value).toBeCloseTo(0.8, 5); // 1 - 20/100
+    expect(byMetric.sample_size.value).toBe(2);
+
+    // With n=2 the CI must straddle the mean (margin = 1.96*std/sqrt(2)).
+    expect(byMetric.avg_cost.confidenceLow).toBeLessThan(2.0);
+    expect(byMetric.avg_cost.confidenceHigh).toBeGreaterThan(2.0);
+    // sample_size metric has std 0 => CI collapses to the point value.
+    expect(byMetric.sample_size.confidenceLow).toBe(2);
+    expect(byMetric.sample_size.confidenceHigh).toBe(2);
+
+    // Each metric was persisted.
+    expect(store.insertExperimentResult).toHaveBeenCalledTimes(6);
+  });
+
+  it("scopes trace + satisfaction queries to the variant's assigned user_ids", async () => {
+    store.getExperiment.mockResolvedValue(
+      makeExperiment({
+        startedAt: 5000,
+        variants: [{ id: "control", weight: 1, config: {} }],
+      }),
+    );
+    dbExecute
+      .mockResolvedValueOnce({
+        rows: [{ user_id: "alice" }, { user_id: "bob" }],
+      })
+      .mockResolvedValueOnce({ rows: [] }) // no traces -> eval query skipped
+      .mockResolvedValueOnce({ rows: [] }); // satisfaction (3rd call)
+
+    await computeExperimentResults("exp-1");
+
+    // 2nd call = trace summaries; must filter user_id IN (?, ?) and the
+    // startedAt cutoff, with the user ids + cutoff bound in order.
+    const traceCall = dbExecute.mock.calls[1][0];
+    expect(traceCall.sql).toMatch(/s\.user_id IN \(\?, \?\)/);
+    expect(traceCall.sql).toMatch(/s\.created_at >= \?/);
+    expect(traceCall.args).toEqual(["alice", "bob", 5000]);
+
+    // Because no traces matched, runIds is empty and the eval query is
+    // skipped — so the satisfaction read is the very next (3rd) call. It
+    // must likewise scope to the variant's users via the feedback subquery
+    // (f.user_id IN (?, ?)), never leaking another variant's frustration.
+    expect(dbExecute.mock.calls).toHaveLength(3);
+    const satCall = dbExecute.mock.calls[2][0];
+    expect(satCall.sql).toMatch(/f\.user_id IN \(\?, \?\)/);
+    expect(satCall.sql).toMatch(/computed_at >= \?/);
+    expect(satCall.args).toEqual(["alice", "bob", 5000]);
+  });
+
+  it("throws when computing results for a missing experiment", async () => {
+    store.getExperiment.mockResolvedValue(null);
+    await expect(computeExperimentResults("nope")).rejects.toThrow(/not found/);
+  });
+});

--- a/packages/core/src/observability/feedback.spec.ts
+++ b/packages/core/src/observability/feedback.spec.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// feedback.ts has two real surfaces worth testing:
+//  1. submitFeedback — input validation + the persisted entry shape, and
+//     that userId scoping reaches the row.
+//  2. computeSatisfactionScore — a deterministic frustration heuristic
+//     built from several sub-scores (rephrasing, abandonment, sentiment,
+//     length trend, retry). These are pure functions of the thread's
+//     messages, so we drive them by stubbing the thread_data read and
+//     assert on the resulting score breakdown. No LLM, no network.
+//
+// We use the capturing/mock-DB pattern: the only DB read feedback.ts
+// performs is `SELECT thread_data FROM chat_threads`, which we control
+// per-test so we can shape the conversation.
+
+const insertFeedback = vi.hoisted(() => vi.fn());
+const upsertSatisfactionScore = vi.hoisted(() => vi.fn());
+const ensureObservabilityTables = vi.hoisted(() => vi.fn());
+
+// threadData is the JSON string returned for the chat_threads row.
+let threadData: string | null = null;
+
+const mockExecute = vi.hoisted(() => vi.fn());
+
+vi.mock("./store.js", () => ({
+  insertFeedback: (...args: unknown[]) => insertFeedback(...args),
+  upsertSatisfactionScore: (...args: unknown[]) =>
+    upsertSatisfactionScore(...args),
+  ensureObservabilityTables: (...args: unknown[]) =>
+    ensureObservabilityTables(...args),
+}));
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => ({ execute: mockExecute }),
+}));
+
+const { submitFeedback, computeSatisfactionScore } =
+  await import("./feedback.js");
+
+function setThread(messages: unknown[] | null): void {
+  threadData = messages === null ? null : JSON.stringify({ messages });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insertFeedback.mockResolvedValue(undefined);
+  upsertSatisfactionScore.mockResolvedValue(undefined);
+  ensureObservabilityTables.mockResolvedValue(undefined);
+  threadData = null;
+  mockExecute.mockImplementation(async () => ({
+    rows: threadData === null ? [] : [{ thread_data: threadData }],
+  }));
+});
+
+describe("submitFeedback", () => {
+  it("rejects a missing threadId", async () => {
+    await expect(
+      submitFeedback({ threadId: "", feedbackType: "thumbs_up" }),
+    ).rejects.toThrow(/threadId is required/);
+    expect(insertFeedback).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown feedbackType", async () => {
+    await expect(
+      submitFeedback({
+        threadId: "t1",
+        feedbackType: "explosion" as any,
+      }),
+    ).rejects.toThrow(/Invalid feedbackType/);
+    expect(insertFeedback).not.toHaveBeenCalled();
+  });
+
+  it("persists a fully-formed entry with defaults and the owner userId", async () => {
+    const entry = await submitFeedback({
+      threadId: "t1",
+      feedbackType: "thumbs_down",
+      userId: "alice",
+    });
+
+    expect(insertFeedback).toHaveBeenCalledTimes(1);
+    const persisted = insertFeedback.mock.calls[0][0];
+    // Defaults: runId/messageSeq null, value "".
+    expect(persisted).toMatchObject({
+      threadId: "t1",
+      feedbackType: "thumbs_down",
+      userId: "alice",
+      runId: null,
+      messageSeq: null,
+      value: "",
+    });
+    expect(typeof persisted.id).toBe("string");
+    expect(typeof persisted.createdAt).toBe("number");
+    // submitFeedback returns the same entry it stored.
+    expect(entry).toEqual(persisted);
+  });
+
+  it("defaults userId to null when no auth context is supplied", async () => {
+    await submitFeedback({ threadId: "t1", feedbackType: "category" });
+    expect(insertFeedback.mock.calls[0][0].userId).toBeNull();
+  });
+});
+
+describe("computeSatisfactionScore", () => {
+  it("returns an all-zero (content) score for a clean, successful thread", async () => {
+    setThread([
+      { role: "user", content: "Please write a detailed project plan" },
+      {
+        role: "assistant",
+        content: "Sure, here is a thorough plan with milestones...",
+      },
+    ]);
+
+    const score = await computeSatisfactionScore("t1", { userId: "alice" });
+
+    expect(score.rephrasingScore).toBe(0); // <2 user msgs
+    expect(score.abandonmentScore).toBe(0); // ends with assistant
+    expect(score.sentimentScore).toBe(0); // no negative patterns, not terse
+    expect(score.lengthTrendScore).toBe(0); // <3 user msgs
+    expect(score.frustrationScore).toBe(0);
+    expect(score.userId).toBe("alice");
+    expect(score.id).toBe("sat-t1");
+    expect(upsertSatisfactionScore).toHaveBeenCalledTimes(1);
+  });
+
+  it("flags abandonment when the thread ends on an unanswered user message", async () => {
+    setThread([{ role: "user", content: "Can you help me with the report?" }]);
+
+    const score = await computeSatisfactionScore("t1");
+
+    // computeAbandonmentScore => 80 when last message is from the user.
+    expect(score.abandonmentScore).toBe(80);
+    // Composite weights abandonment at 0.2 => 16, but sentiment also
+    // fires here? "Can you help me with the report?" has no negative
+    // pattern and is not terse, so only abandonment contributes.
+    expect(score.frustrationScore).toBe(16);
+    expect(score.userId).toBeNull();
+  });
+
+  it("scores rephrasing high when consecutive user messages are near-identical", async () => {
+    const q = "how do i export the analytics dashboard to a pdf file";
+    setThread([
+      { role: "user", content: q },
+      { role: "assistant", content: "..." },
+      { role: "user", content: q }, // identical => jaccard 1.0
+      { role: "assistant", content: "..." },
+    ]);
+
+    const score = await computeSatisfactionScore("t1");
+
+    // Two identical user messages: peak similarity 1.0, ratio 1/1=1.
+    // rephrasing = (1.0*60 + 1*40) = 100.
+    expect(score.rephrasingScore).toBe(100);
+    expect(score.frustrationScore).toBeGreaterThan(0);
+  });
+
+  it("detects negative sentiment from explicit frustration phrases", async () => {
+    setThread([
+      { role: "user", content: "no that's not what I asked for" },
+      { role: "assistant", content: "..." },
+      { role: "user", content: "still wrong, this is useless" },
+      { role: "assistant", content: "..." },
+    ]);
+
+    const score = await computeSatisfactionScore("t1");
+
+    // BUG: computeSentimentScore double-scales — the formula is
+    //   Math.min(100, (negativeRatio * 70 + terseRatio * 30) * 100)
+    // where negativeRatio/terseRatio are already in [0,1]. The trailing
+    // `* 100` means a single matching message already yields 70*100=7000,
+    // which clamps to 100. So sentiment saturates at 100 the moment ANY
+    // negative phrase appears, making the 70/30 sub-weights meaningless.
+    // Asserting the current (buggy) saturated value; see bugsFound.
+    expect(score.sentimentScore).toBe(100);
+  });
+
+  it("treats short final user replies as mild abandonment", async () => {
+    setThread([
+      { role: "user", content: "Give me a long answer about widgets please" },
+      { role: "assistant", content: "Here is a long answer..." },
+      { role: "user", content: "ok" }, // short (<15 chars)
+      { role: "assistant", content: "Anything else?" },
+    ]);
+
+    const score = await computeSatisfactionScore("t1");
+    // Ends with assistant; second-to-last user msg "ok" is <15 chars => 40.
+    expect(score.abandonmentScore).toBe(40);
+  });
+
+  it("scores a length downtrend (messages getting shorter) as frustration", async () => {
+    setThread([
+      {
+        role: "user",
+        content:
+          "I would like a comprehensive walkthrough of the entire onboarding flow with examples",
+      },
+      { role: "assistant", content: "..." },
+      { role: "user", content: "show me the second step in more detail" },
+      { role: "assistant", content: "..." },
+      { role: "user", content: "next" },
+      { role: "assistant", content: "..." },
+    ]);
+
+    const score = await computeSatisfactionScore("t1");
+    // Lengths strictly decreasing => negative slope => >0.
+    expect(score.lengthTrendScore).toBeGreaterThan(0);
+  });
+
+  it("scores retry phrasing as frustration", async () => {
+    setThread([
+      { role: "user", content: "make me a logo" },
+      { role: "assistant", content: "..." },
+      { role: "user", content: "try again, that's wrong" },
+      { role: "assistant", content: "..." },
+    ]);
+
+    const score = await computeSatisfactionScore("t1");
+    // 1 of 2 user msgs hits a RETRY pattern => ratio .5 * 150 = 75.
+    // retry contributes 0.2 weight => at least 15 toward frustration.
+    expect(score.frustrationScore).toBeGreaterThanOrEqual(15);
+  });
+
+  it("returns all zeros and still upserts when the thread has no messages", async () => {
+    setThread(null); // no chat_threads row at all
+
+    const score = await computeSatisfactionScore("t1");
+
+    expect(score.frustrationScore).toBe(0);
+    expect(score.rephrasingScore).toBe(0);
+    expect(score.abandonmentScore).toBe(0);
+    expect(upsertSatisfactionScore).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates malformed thread_data JSON without throwing", async () => {
+    threadData = "{ this is not valid json";
+
+    const score = await computeSatisfactionScore("t1");
+    expect(score.frustrationScore).toBe(0);
+  });
+
+  it("clamps the composite frustration score at 100", async () => {
+    // Maximize every sub-score: identical negative+retry messages that
+    // also shrink in length and abandon at the end.
+    const long = "no that is wrong, try again, this is completely useless x";
+    setThread([
+      { role: "user", content: long },
+      { role: "assistant", content: "..." },
+      { role: "user", content: long },
+      { role: "assistant", content: "..." },
+      { role: "user", content: "no" },
+    ]);
+
+    const score = await computeSatisfactionScore("t1");
+    expect(score.frustrationScore).toBeLessThanOrEqual(100);
+  });
+
+  it("reads thread_data scoped by threadId (parameterized, no injection)", async () => {
+    setThread([{ role: "user", content: "hi" }]);
+    await computeSatisfactionScore("thread-xyz");
+
+    const call = mockExecute.mock.calls[0][0];
+    expect(call.sql).toMatch(
+      /SELECT thread_data FROM chat_threads WHERE id = \?/,
+    );
+    expect(call.args).toEqual(["thread-xyz"]);
+  });
+
+  it("parses structured (array-of-parts) message content", async () => {
+    setThread([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "first part " },
+          { type: "image", url: "x" },
+          { type: "text", text: "second part" },
+        ],
+      },
+      { role: "assistant", content: "ok" },
+    ]);
+
+    // If the text parts were joined correctly it's a normal sentence,
+    // not terse — sentiment stays 0. This exercises the content mapper.
+    const score = await computeSatisfactionScore("t1");
+    expect(score.sentimentScore).toBe(0);
+  });
+});

--- a/packages/core/src/observability/feedback.spec.ts
+++ b/packages/core/src/observability/feedback.spec.ts
@@ -163,14 +163,14 @@ describe("computeSatisfactionScore", () => {
 
     const score = await computeSatisfactionScore("t1");
 
-    // BUG: computeSentimentScore double-scales — the formula is
-    //   Math.min(100, (negativeRatio * 70 + terseRatio * 30) * 100)
-    // where negativeRatio/terseRatio are already in [0,1]. The trailing
-    // `* 100` means a single matching message already yields 70*100=7000,
-    // which clamps to 100. So sentiment saturates at 100 the moment ANY
-    // negative phrase appears, making the 70/30 sub-weights meaningless.
-    // Asserting the current (buggy) saturated value; see bugsFound.
-    expect(score.sentimentScore).toBe(100);
+    // sentimentScore = min(100, negativeRatio * 70 + terseRatio * 30).
+    // Both user messages match a NEGATIVE_PATTERN ("not what i"/"that's not"
+    // and "still wrong"/"useless") → negativeRatio = 2/2 = 1.0. Neither is
+    // terse (>2 words) → terseRatio = 0. So the score is the graded 70, NOT
+    // the saturated 100 the old double-scaling (`* 100`) produced. This is the
+    // assertion that guards against that regression — the 70/30 sub-weights
+    // must remain meaningful rather than clamping on the first negative phrase.
+    expect(score.sentimentScore).toBe(70);
   });
 
   it("treats short final user replies as mild abandonment", async () => {

--- a/packages/core/src/observability/feedback.ts
+++ b/packages/core/src/observability/feedback.ts
@@ -218,7 +218,10 @@ function computeSentimentScore(userMessages: string[]): number {
   const negativeRatio = negativeCount / userMessages.length;
   const terseRatio = terseCount / userMessages.length;
 
-  return Math.min(100, (negativeRatio * 70 + terseRatio * 30) * 100);
+  // negativeRatio/terseRatio are already in [0,1], so the weighted sum is in
+  // [0,100] — it must NOT be multiplied by another 100 (that would saturate
+  // sentiment to 100 the moment a single message matched any negative pattern).
+  return Math.min(100, negativeRatio * 70 + terseRatio * 30);
 }
 
 function computeLengthTrendScore(userMessages: string[]): number {

--- a/packages/core/src/org/context.spec.ts
+++ b/packages/core/src/org/context.spec.ts
@@ -1,0 +1,528 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockExecute = vi.fn();
+const mockGetSession = vi.fn();
+const mockGetUserSetting = vi.fn();
+const mockPutUserSetting = vi.fn();
+const mockGetSetting = vi.fn();
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => ({ execute: mockExecute }),
+  isPostgres: () => false,
+  isLocalDatabase: () => true,
+}));
+vi.mock("../server/auth.js", () => ({
+  getSession: (...args: any[]) => mockGetSession(...args),
+}));
+vi.mock("../settings/user-settings.js", () => ({
+  getUserSetting: (...args: any[]) => mockGetUserSetting(...args),
+  putUserSetting: (...args: any[]) => mockPutUserSetting(...args),
+}));
+vi.mock("../settings/store.js", () => ({
+  getSetting: (...args: any[]) => mockGetSetting(...args),
+}));
+
+import {
+  getOrgContext,
+  resolveOrgIdForEmail,
+  createOrganization,
+  getOrgDomain,
+  getOrgA2ASecret,
+  getA2ASecretByDomain,
+  resolveOrgByDomain,
+} from "./context.js";
+
+// A throwaway H3-like event; getSession is fully mocked so the shape is unused.
+const EVENT = {} as any;
+
+function queueSelect(...rows: any[][]) {
+  for (const r of rows) {
+    mockExecute.mockResolvedValueOnce({ rows: r });
+  }
+}
+
+describe("getOrgContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecute.mockResolvedValue({ rows: [] });
+    mockGetUserSetting.mockResolvedValue(null);
+    mockGetSetting.mockResolvedValue(null);
+    delete process.env.AUTO_CREATE_DEFAULT_ORG;
+  });
+
+  it("returns the empty context for an unauthenticated request", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const ctx = await getOrgContext(EVENT);
+    expect(ctx).toEqual({ email: "", orgId: null, orgName: null, role: null });
+    // No DB work should happen without an authenticated email.
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("looks up memberships by LOWERCASED email", async () => {
+    mockGetSession.mockResolvedValue({ email: "Alice@Builder.IO" });
+    queueSelect([{ orgId: "org1", role: "member", orgName: "Builder" }]);
+    await getOrgContext(EVENT);
+    const call = mockExecute.mock.calls[0][0];
+    expect(call.sql).toContain("FROM org_members");
+    expect(call.args).toEqual(["alice@builder.io"]);
+  });
+
+  it("falls back to the first membership when session has no orgId", async () => {
+    // Better Auth session.orgId is null until an explicit org switch.
+    mockGetSession.mockResolvedValue({ email: "a@b.com" });
+    queueSelect([
+      { orgId: "first", role: "owner", orgName: "First Co" },
+      { orgId: "second", role: "member", orgName: "Second Co" },
+    ]);
+    const ctx = await getOrgContext(EVENT);
+    expect(ctx).toEqual({
+      email: "a@b.com",
+      orgId: "first",
+      orgName: "First Co",
+      role: "owner",
+    });
+  });
+
+  it("honors a valid session.orgId over the first membership", async () => {
+    mockGetSession.mockResolvedValue({
+      email: "a@b.com",
+      orgId: "second",
+      orgRole: "admin",
+    });
+    queueSelect([
+      { orgId: "first", role: "owner", orgName: "First Co" },
+      { orgId: "second", role: "member", orgName: "Second Co" },
+    ]);
+    const ctx = await getOrgContext(EVENT);
+    // Role/name come from the membership row, not the session claim.
+    expect(ctx).toEqual({
+      email: "a@b.com",
+      orgId: "second",
+      orgName: "Second Co",
+      role: "member",
+    });
+  });
+
+  it("trusts a session.orgId the user is NOT a member of, but with null name and session role", async () => {
+    // Cross-app A2A / impersonation context: the session asserts an org the
+    // local memberships table doesn't have. We surface it but cannot supply a
+    // name and must use the session-claimed role only.
+    mockGetSession.mockResolvedValue({
+      email: "a@b.com",
+      orgId: "ghost-org",
+      orgRole: "owner",
+    });
+    queueSelect([{ orgId: "real", role: "member", orgName: "Real Co" }]);
+    const ctx = await getOrgContext(EVENT);
+    expect(ctx).toEqual({
+      email: "a@b.com",
+      orgId: "ghost-org",
+      orgName: null,
+      role: "owner",
+    });
+  });
+
+  it("normalizes a bogus session.orgRole to null", async () => {
+    mockGetSession.mockResolvedValue({
+      email: "a@b.com",
+      orgId: "ghost-org",
+      orgRole: "superuser", // not a valid OrgRole
+    });
+    queueSelect([]); // no memberships
+    const ctx = await getOrgContext(EVENT);
+    expect(ctx.orgId).toBe("ghost-org");
+    expect(ctx.role).toBeNull();
+  });
+
+  it("ignores a whitespace-only session.orgId", async () => {
+    mockGetSession.mockResolvedValue({ email: "a@b.com", orgId: "   " });
+    queueSelect([{ orgId: "real", role: "member", orgName: "Real Co" }]);
+    const ctx = await getOrgContext(EVENT);
+    expect(ctx.orgId).toBe("real");
+  });
+
+  it("honors active-org-id user setting when in multiple orgs", async () => {
+    mockGetSession.mockResolvedValue({ email: "a@b.com" });
+    queueSelect([
+      { orgId: "first", role: "owner", orgName: "First Co" },
+      { orgId: "second", role: "member", orgName: "Second Co" },
+    ]);
+    mockGetUserSetting.mockResolvedValue({ orgId: "second" });
+    const ctx = await getOrgContext(EVENT);
+    expect(ctx.orgId).toBe("second");
+    expect(ctx.role).toBe("member");
+    expect(mockGetUserSetting).toHaveBeenCalledWith("a@b.com", "active-org-id");
+  });
+
+  it("falls back to first membership when active-org-id points to a non-membership", async () => {
+    mockGetSession.mockResolvedValue({ email: "a@b.com" });
+    queueSelect([
+      { orgId: "first", role: "owner", orgName: "First Co" },
+      { orgId: "second", role: "member", orgName: "Second Co" },
+    ]);
+    mockGetUserSetting.mockResolvedValue({ orgId: "left-this-org" });
+    const ctx = await getOrgContext(EVENT);
+    expect(ctx.orgId).toBe("first");
+  });
+
+  it("does NOT consult active-org-id when in exactly one org", async () => {
+    mockGetSession.mockResolvedValue({ email: "a@b.com" });
+    queueSelect([{ orgId: "only", role: "owner", orgName: "Only Co" }]);
+    const ctx = await getOrgContext(EVENT);
+    expect(ctx.orgId).toBe("only");
+    expect(mockGetUserSetting).not.toHaveBeenCalled();
+  });
+
+  it("returns null org for an authenticated user with zero memberships (no auto-create)", async () => {
+    mockGetSession.mockResolvedValue({ email: "loner@b.com" });
+    queueSelect([]);
+    const ctx = await getOrgContext(EVENT);
+    expect(ctx).toEqual({
+      email: "loner@b.com",
+      orgId: null,
+      orgName: null,
+      role: null,
+    });
+    expect(mockPutUserSetting).not.toHaveBeenCalled();
+  });
+
+  describe("membership-lookup failure (tables missing before migrations)", () => {
+    it("returns the session orgId when present", async () => {
+      mockGetSession.mockResolvedValue({
+        email: "a@b.com",
+        orgId: "sess-org",
+        orgRole: "admin",
+      });
+      mockExecute.mockRejectedValueOnce(
+        new Error("no such table: org_members"),
+      );
+      const ctx = await getOrgContext(EVENT);
+      expect(ctx).toEqual({
+        email: "a@b.com",
+        orgId: "sess-org",
+        orgName: null,
+        role: "admin",
+      });
+    });
+
+    it("returns a null-org context when there is no session orgId", async () => {
+      mockGetSession.mockResolvedValue({ email: "a@b.com" });
+      mockExecute.mockRejectedValueOnce(
+        new Error("no such table: org_members"),
+      );
+      const ctx = await getOrgContext(EVENT);
+      expect(ctx).toEqual({
+        email: "a@b.com",
+        orgId: null,
+        orgName: null,
+        role: null,
+      });
+    });
+  });
+
+  describe("AUTO_CREATE_DEFAULT_ORG", () => {
+    afterEach(() => {
+      delete process.env.AUTO_CREATE_DEFAULT_ORG;
+    });
+
+    it("provisions a default org for a zero-membership user when enabled", async () => {
+      process.env.AUTO_CREATE_DEFAULT_ORG = "1";
+      mockGetSession.mockResolvedValue({
+        email: "jane@startup.dev",
+        name: "Jane Doe",
+      });
+      // 1) memberships lookup -> empty
+      // 2) acquireClaim INSERT into settings -> succeeds (no throw)
+      // 3) hasPendingInvitation -> none
+      // 4) hasDomainMatch -> none
+      // 5) INSERT organizations
+      // 6) INSERT org_members
+      queueSelect(
+        [], // memberships
+        [], // acquireClaim INSERT settings (resolves -> claim acquired)
+        [], // hasPendingInvitation
+        [], // hasDomainMatch
+        [], // INSERT organizations
+        [], // INSERT org_members
+      );
+      const ctx = await getOrgContext(EVENT);
+      expect(ctx.email).toBe("jane@startup.dev");
+      expect(ctx.orgId).toBeTruthy();
+      expect(ctx.role).toBe("owner");
+      expect(ctx.orgName).toBe("Jane Doe's workspace");
+      expect(mockPutUserSetting).toHaveBeenCalledWith(
+        "jane@startup.dev",
+        "active-org-id",
+        { orgId: ctx.orgId },
+      );
+    });
+
+    it("derives the workspace name from the email local-part when session has no name", async () => {
+      process.env.AUTO_CREATE_DEFAULT_ORG = "1";
+      mockGetSession.mockResolvedValue({ email: "john.q-public@startup.dev" });
+      queueSelect([], [], [], [], [], []);
+      const ctx = await getOrgContext(EVENT);
+      expect(ctx.orgName).toBe("John Q Public's workspace");
+    });
+
+    it("does NOT auto-create when the user has a pending invitation", async () => {
+      process.env.AUTO_CREATE_DEFAULT_ORG = "1";
+      mockGetSession.mockResolvedValue({ email: "invited@startup.dev" });
+      queueSelect(
+        [], // memberships
+        [], // acquireClaim INSERT settings
+        [{ "1": 1 }], // hasPendingInvitation -> has one
+      );
+      // releaseClaim DELETE -> resolves
+      mockExecute.mockResolvedValueOnce({ rows: [] });
+      const ctx = await getOrgContext(EVENT);
+      expect(ctx.orgId).toBeNull();
+      // Critically: we must not have written an active-org-id for them.
+      expect(mockPutUserSetting).not.toHaveBeenCalled();
+      // And no organization was inserted.
+      const sqls = mockExecute.mock.calls.map((c) => c[0].sql);
+      expect(sqls.some((s) => s.includes("INSERT INTO organizations"))).toBe(
+        false,
+      );
+    });
+
+    it("does NOT auto-create when the email domain already matches an org", async () => {
+      process.env.AUTO_CREATE_DEFAULT_ORG = "1";
+      mockGetSession.mockResolvedValue({ email: "new@builder.io" });
+      queueSelect(
+        [], // memberships
+        [], // acquireClaim INSERT settings
+        [], // hasPendingInvitation -> none
+        [{ "1": 1 }], // hasDomainMatch -> match
+      );
+      mockExecute.mockResolvedValueOnce({ rows: [] }); // releaseClaim DELETE
+      const ctx = await getOrgContext(EVENT);
+      expect(ctx.orgId).toBeNull();
+      expect(mockPutUserSetting).not.toHaveBeenCalled();
+    });
+
+    it("bails (null org) when the auto-create claim is lost to a concurrent request", async () => {
+      process.env.AUTO_CREATE_DEFAULT_ORG = "1";
+      mockGetSession.mockResolvedValue({ email: "racer@startup.dev" });
+      // memberships empty, then acquireClaim INSERT throws (key exists), then
+      // the stale-takeover UPDATE matches zero rows -> claim NOT acquired.
+      mockExecute.mockResolvedValueOnce({ rows: [] }); // memberships
+      mockExecute.mockRejectedValueOnce(
+        new Error("UNIQUE constraint failed: settings.key"),
+      );
+      mockExecute.mockResolvedValueOnce({ rowsAffected: 0 }); // stale UPDATE, no match
+      const ctx = await getOrgContext(EVENT);
+      expect(ctx.orgId).toBeNull();
+      expect(mockPutUserSetting).not.toHaveBeenCalled();
+    });
+
+    it("reclaims a STALE claim (TTL-expired) and proceeds to create the org", async () => {
+      // Stuck-state recovery: a prior claim's DELETE failed, but the row is
+      // older than CLAIM_TTL_MS. acquireClaim's INSERT conflicts, the
+      // conditional stale-takeover UPDATE matches one row, and creation
+      // proceeds. Without this branch a user could be permanently stranded.
+      process.env.AUTO_CREATE_DEFAULT_ORG = "1";
+      mockGetSession.mockResolvedValue({
+        email: "stuck@startup.dev",
+        name: "Stuck User",
+      });
+      mockExecute.mockResolvedValueOnce({ rows: [] }); // memberships
+      mockExecute.mockRejectedValueOnce(
+        new Error("UNIQUE constraint failed: settings.key"),
+      ); // acquireClaim INSERT conflicts
+      mockExecute.mockResolvedValueOnce({ rowsAffected: 1 }); // stale UPDATE wins
+      mockExecute.mockResolvedValueOnce({ rows: [] }); // hasPendingInvitation -> none
+      mockExecute.mockResolvedValueOnce({ rows: [] }); // hasDomainMatch -> none
+      mockExecute.mockResolvedValueOnce({ rows: [] }); // INSERT organizations
+      mockExecute.mockResolvedValueOnce({ rows: [] }); // INSERT org_members
+      const ctx = await getOrgContext(EVENT);
+      expect(ctx.orgId).toBeTruthy();
+      expect(ctx.role).toBe("owner");
+      expect(ctx.orgName).toBe("Stuck User's workspace");
+      expect(mockPutUserSetting).toHaveBeenCalledWith(
+        "stuck@startup.dev",
+        "active-org-id",
+        { orgId: ctx.orgId },
+      );
+    });
+
+    it("does NOT auto-create when the invitation lookup ERRORS (fail closed)", async () => {
+      // hasPendingInvitation swallows DB errors and returns true so we never
+      // race ahead of an invite we couldn't read. Auto-create must be skipped.
+      process.env.AUTO_CREATE_DEFAULT_ORG = "1";
+      mockGetSession.mockResolvedValue({ email: "maybe-invited@startup.dev" });
+      mockExecute.mockResolvedValueOnce({ rows: [] }); // memberships
+      mockExecute.mockResolvedValueOnce({ rows: [] }); // acquireClaim INSERT
+      mockExecute.mockRejectedValueOnce(
+        new Error("no such table: org_invitations"),
+      ); // hasPendingInvitation throws -> treated as "has invite"
+      mockExecute.mockResolvedValueOnce({ rows: [] }); // releaseClaim DELETE
+      const ctx = await getOrgContext(EVENT);
+      expect(ctx.orgId).toBeNull();
+      expect(mockPutUserSetting).not.toHaveBeenCalled();
+      const sqls = mockExecute.mock.calls.map((c) => c[0].sql);
+      expect(sqls.some((s) => s.includes("INSERT INTO organizations"))).toBe(
+        false,
+      );
+    });
+
+    it("does NOT auto-create when the flag is unset, even for a zero-membership user", async () => {
+      mockGetSession.mockResolvedValue({ email: "loner@startup.dev" });
+      queueSelect([]); // memberships only
+      const ctx = await getOrgContext(EVENT);
+      expect(ctx.orgId).toBeNull();
+      expect(mockGetSetting).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("resolveOrgIdForEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecute.mockResolvedValue({ rows: [] });
+    mockGetUserSetting.mockResolvedValue(null);
+  });
+
+  it("returns null when the user has no memberships", async () => {
+    queueSelect([]);
+    expect(await resolveOrgIdForEmail("nobody@b.com")).toBeNull();
+  });
+
+  it("returns the single membership without consulting active-org-id", async () => {
+    queueSelect([{ org_id: "only" }]);
+    expect(await resolveOrgIdForEmail("a@b.com")).toBe("only");
+    expect(mockGetUserSetting).not.toHaveBeenCalled();
+  });
+
+  it("prefers active-org-id when it is one of multiple memberships", async () => {
+    queueSelect([{ org_id: "first" }, { org_id: "second" }]);
+    mockGetUserSetting.mockResolvedValue({ orgId: "second" });
+    expect(await resolveOrgIdForEmail("a@b.com")).toBe("second");
+  });
+
+  it("falls back to the first membership when active-org-id is not a current membership", async () => {
+    queueSelect([{ org_id: "first" }, { org_id: "second" }]);
+    mockGetUserSetting.mockResolvedValue({ orgId: "left-org" });
+    expect(await resolveOrgIdForEmail("a@b.com")).toBe("first");
+  });
+
+  it("lowercases the email in the lookup", async () => {
+    queueSelect([]);
+    await resolveOrgIdForEmail("Mixed@Case.COM");
+    expect(mockExecute.mock.calls[0][0].args).toEqual(["mixed@case.com"]);
+  });
+
+  it("returns null on a DB error (missing tables) rather than throwing", async () => {
+    mockExecute.mockRejectedValueOnce(new Error("no such table: org_members"));
+    expect(await resolveOrgIdForEmail("a@b.com")).toBeNull();
+  });
+});
+
+describe("createOrganization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecute.mockResolvedValue({ rows: [] });
+  });
+
+  it("inserts the org and an owner membership, trims the name, and sets active-org-id", async () => {
+    const result = await createOrganization("  Acme Inc  ", "founder@acme.com");
+
+    expect(result.name).toBe("Acme Inc");
+    expect(result.role).toBe("owner");
+    expect(result.id).toBeTruthy();
+    // A2A secret must be a non-trivial base64url string for JWT signing.
+    expect(result.a2aSecret).toMatch(/^[A-Za-z0-9_-]{32,}$/);
+
+    const calls = mockExecute.mock.calls.map((c) => c[0]);
+    expect(calls[0].sql).toContain("INSERT INTO organizations");
+    // org row carries id, trimmed name, creator email, createdAt, a2aSecret
+    expect(calls[0].args[0]).toBe(result.id);
+    expect(calls[0].args[1]).toBe("Acme Inc");
+    expect(calls[0].args[2]).toBe("founder@acme.com");
+    expect(calls[0].args[4]).toBe(result.a2aSecret);
+
+    expect(calls[1].sql).toContain("INSERT INTO org_members");
+    expect(calls[1].args[1]).toBe(result.id); // org_id
+    expect(calls[1].args[2]).toBe("founder@acme.com"); // email
+    expect(calls[1].args[3]).toBe("owner"); // role
+
+    expect(mockPutUserSetting).toHaveBeenCalledWith(
+      "founder@acme.com",
+      "active-org-id",
+      { orgId: result.id },
+    );
+  });
+
+  it("honors an explicit non-owner role for the creator", async () => {
+    const result = await createOrganization("Team", "admin@x.com", "admin");
+    expect(result.role).toBe("admin");
+    const memberInsert = mockExecute.mock.calls[1][0];
+    expect(memberInsert.args[3]).toBe("admin");
+  });
+});
+
+describe("domain & A2A secret lookups (A2A receiving-side scoping)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecute.mockResolvedValue({ rows: [] });
+  });
+
+  it("getOrgDomain returns the allowed_domain or null", async () => {
+    queueSelect([{ allowed_domain: "acme.com" }]);
+    expect(await getOrgDomain("org1")).toBe("acme.com");
+  });
+
+  it("getOrgDomain returns null when no row matches", async () => {
+    queueSelect([]);
+    expect(await getOrgDomain("missing")).toBeNull();
+  });
+
+  it("getOrgDomain treats an empty stored domain as null", async () => {
+    queueSelect([{ allowed_domain: "" }]);
+    expect(await getOrgDomain("org1")).toBeNull();
+  });
+
+  it("getOrgDomain returns null on DB error", async () => {
+    mockExecute.mockRejectedValueOnce(new Error("boom"));
+    expect(await getOrgDomain("org1")).toBeNull();
+  });
+
+  it("getOrgA2ASecret returns the secret or null", async () => {
+    queueSelect([{ a2a_secret: "s3cr3t" }]);
+    expect(await getOrgA2ASecret("org1")).toBe("s3cr3t");
+  });
+
+  it("getOrgA2ASecret treats an empty secret as null", async () => {
+    queueSelect([{ a2a_secret: "" }]);
+    expect(await getOrgA2ASecret("org1")).toBeNull();
+  });
+
+  it("getA2ASecretByDomain lowercases the domain in the lookup", async () => {
+    queueSelect([{ a2a_secret: "byDomain" }]);
+    const secret = await getA2ASecretByDomain("ACME.com");
+    expect(secret).toBe("byDomain");
+    expect(mockExecute.mock.calls[0][0].args).toEqual(["acme.com"]);
+  });
+
+  it("getA2ASecretByDomain returns null on DB error", async () => {
+    mockExecute.mockRejectedValueOnce(new Error("boom"));
+    expect(await getA2ASecretByDomain("acme.com")).toBeNull();
+  });
+
+  it("resolveOrgByDomain returns {orgId, orgName} and lowercases the lookup", async () => {
+    queueSelect([{ id: "org1", name: "Acme" }]);
+    const out = await resolveOrgByDomain("Acme.COM");
+    expect(out).toEqual({ orgId: "org1", orgName: "Acme" });
+    expect(mockExecute.mock.calls[0][0].args).toEqual(["acme.com"]);
+  });
+
+  it("resolveOrgByDomain returns null when nothing matches", async () => {
+    queueSelect([]);
+    expect(await resolveOrgByDomain("nope.com")).toBeNull();
+  });
+
+  it("resolveOrgByDomain returns null on DB error", async () => {
+    mockExecute.mockRejectedValueOnce(new Error("boom"));
+    expect(await resolveOrgByDomain("acme.com")).toBeNull();
+  });
+});

--- a/packages/core/src/org/free-email-providers.spec.ts
+++ b/packages/core/src/org/free-email-providers.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import {
+  FREE_EMAIL_PROVIDER_DOMAINS,
+  isFreeEmailProvider,
+} from "./free-email-providers.js";
+
+describe("isFreeEmailProvider", () => {
+  it("flags well-known free/public mailbox providers", () => {
+    // Security invariant: these must never be usable as an org auto-join
+    // domain — anyone in the world can mint a matching address.
+    for (const domain of [
+      "gmail.com",
+      "outlook.com",
+      "yahoo.com",
+      "icloud.com",
+      "proton.me",
+      "qq.com",
+      "mailinator.com",
+    ]) {
+      expect(isFreeEmailProvider(domain)).toBe(true);
+    }
+  });
+
+  it("does NOT flag company-owned domains", () => {
+    for (const domain of [
+      "builder.io",
+      "acme.com",
+      "anthropic.com",
+      "example.org",
+    ]) {
+      expect(isFreeEmailProvider(domain)).toBe(false);
+    }
+  });
+
+  it("is case-insensitive (a domain is just-as-free in any case)", () => {
+    expect(isFreeEmailProvider("Gmail.com")).toBe(true);
+    expect(isFreeEmailProvider("GMAIL.COM")).toBe(true);
+    expect(isFreeEmailProvider("GmAiL.CoM")).toBe(true);
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    expect(isFreeEmailProvider("  gmail.com  ")).toBe(true);
+    expect(isFreeEmailProvider("\tyahoo.com\n")).toBe(true);
+  });
+
+  it("does not treat a subdomain of a free provider as free", () => {
+    // We match the literal domain only; a crafted subdomain is a distinct
+    // string and is (correctly) not in the set.
+    expect(isFreeEmailProvider("mail.gmail.com")).toBe(false);
+    expect(isFreeEmailProvider("corp.outlook.com")).toBe(false);
+  });
+
+  it("returns false for empty / whitespace-only input", () => {
+    expect(isFreeEmailProvider("")).toBe(false);
+    expect(isFreeEmailProvider("   ")).toBe(false);
+  });
+
+  it("covers regional Microsoft/Yahoo variants that share open signup", () => {
+    expect(isFreeEmailProvider("outlook.co.uk")).toBe(true);
+    expect(isFreeEmailProvider("hotmail.fr")).toBe(true);
+    expect(isFreeEmailProvider("yahoo.co.jp")).toBe(true);
+    expect(isFreeEmailProvider("yahoo.com.br")).toBe(true);
+  });
+
+  it("exposes a frozen-by-convention Set with no accidental empty entry", () => {
+    expect(FREE_EMAIL_PROVIDER_DOMAINS.has("")).toBe(false);
+    // Every entry must already be lowercase, or the lowercasing lookup
+    // in isFreeEmailProvider would silently never match it.
+    for (const domain of FREE_EMAIL_PROVIDER_DOMAINS) {
+      expect(domain).toBe(domain.toLowerCase());
+      expect(domain.trim()).toBe(domain);
+    }
+  });
+});

--- a/packages/core/src/scripts/db/check-scoping.spec.ts
+++ b/packages/core/src/scripts/db/check-scoping.spec.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createClient, type Client } from "@libsql/client";
+
+/**
+ * db-check-scoping is the CI/agent guard that flags template tables missing the
+ * owner_email (and optionally org_id) scoping columns. Those unscoped tables
+ * are denied to the raw db-* tools, so the detection logic here is what keeps
+ * a forgotten ownership column from becoming a cross-tenant hole. The `validate`
+ * helper isn't exported, so we drive the real default export against a temp-file
+ * SQLite database and assert on the JSON output and the process exit code.
+ */
+describe("db-check-scoping", () => {
+  let dir: string;
+  let dbFile: string;
+  let prevExitCode: typeof process.exitCode;
+
+  async function withClient<T>(fn: (c: Client) => Promise<T>): Promise<T> {
+    const c = createClient({ url: "file:" + dbFile });
+    try {
+      return await fn(c);
+    } finally {
+      c.close();
+    }
+  }
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), "db-check-"));
+    dbFile = path.join(dir, "app.db");
+    prevExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(async () => {
+    process.exitCode = prevExitCode;
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    vi.restoreAllMocks();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function runCheck(extra: string[]): Promise<string[]> {
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, "log")
+      .mockImplementation((...a: unknown[]) => {
+        logs.push(a.map(String).join(" "));
+      });
+    try {
+      const { default: dbCheckScoping } = await import("./check-scoping.js");
+      await dbCheckScoping(["--db", dbFile, ...extra]);
+    } finally {
+      spy.mockRestore();
+    }
+    return logs;
+  }
+
+  async function runCheckJson(extra: string[]): Promise<any> {
+    const logs = await runCheck(["--format", "json", ...extra]);
+    const joined = logs.join("\n");
+    return JSON.parse(joined.slice(joined.indexOf("{")));
+  }
+
+  it("flags a template table missing owner_email and sets a non-zero exit code", async () => {
+    await withClient(async (c) => {
+      await c.execute(
+        `CREATE TABLE scoped_notes (id TEXT PRIMARY KEY, owner_email TEXT, body TEXT)`,
+      );
+      await c.execute(
+        `CREATE TABLE leaky_table (id TEXT PRIMARY KEY, body TEXT)`,
+      );
+    });
+
+    const out = await runCheckJson([]);
+    const byTable = Object.fromEntries(
+      out.tables.map((t: any) => [t.table, t]),
+    );
+
+    expect(byTable.scoped_notes.hasOwnerEmail).toBe(true);
+    expect(byTable.scoped_notes.issues).toEqual([]);
+
+    expect(byTable.leaky_table.hasOwnerEmail).toBe(false);
+    expect(byTable.leaky_table.issues[0]).toMatch(/missing owner_email/);
+
+    // JSON mode is a pure report and does not set the exit code.
+    expect(process.exitCode).toBeUndefined();
+
+    // The human-readable path fails closed: a missing scoping column must
+    // surface as exit code 1 (so CI guards catch it).
+    const logs = await runCheck([]);
+    expect(logs.join("\n")).toContain("Tables denied to raw DB tools:");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("skips core/framework tables that scope themselves", async () => {
+    await withClient(async (c) => {
+      // settings + sessions + chat_threads are in CORE_TABLES and intentionally
+      // lack owner_email; they must NOT be reported as issues.
+      await c.execute(
+        `CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT, updated_at INTEGER)`,
+      );
+      await c.execute(
+        `CREATE TABLE sessions (token TEXT PRIMARY KEY, email TEXT)`,
+      );
+      await c.execute(
+        `CREATE TABLE chat_threads (id TEXT PRIMARY KEY, title TEXT)`,
+      );
+    });
+
+    const out = await runCheckJson([]);
+    expect(out.tables).toEqual([]);
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it("skips migration helper tables whose name starts with an underscore", async () => {
+    await withClient(async (c) => {
+      await c.execute(
+        `CREATE TABLE _custom_migrations (id INTEGER PRIMARY KEY, name TEXT)`,
+      );
+      await c.execute(
+        `CREATE TABLE good (id TEXT PRIMARY KEY, owner_email TEXT)`,
+      );
+    });
+    const out = await runCheckJson([]);
+    const names = out.tables.map((t: any) => t.table);
+    expect(names).toContain("good");
+    expect(names).not.toContain("_custom_migrations");
+  });
+
+  it("passes when every template table is properly scoped", async () => {
+    await withClient(async (c) => {
+      await c.execute(
+        `CREATE TABLE notes (id TEXT PRIMARY KEY, owner_email TEXT, body TEXT)`,
+      );
+    });
+    const logs = await runCheck([]);
+    expect(logs.join("\n")).toContain(
+      "All template tables have proper scoping columns.",
+    );
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it("with --require-org, a table with owner_email but no org_id is flagged", async () => {
+    await withClient(async (c) => {
+      await c.execute(
+        `CREATE TABLE personal_only (id TEXT PRIMARY KEY, owner_email TEXT)`,
+      );
+      await c.execute(
+        `CREATE TABLE multi_org (id TEXT PRIMARY KEY, owner_email TEXT, org_id TEXT)`,
+      );
+    });
+
+    const out = await runCheckJson(["--require-org"]);
+    const byTable = Object.fromEntries(
+      out.tables.map((t: any) => [t.table, t]),
+    );
+
+    expect(byTable.personal_only.hasOrgId).toBe(false);
+    expect(byTable.personal_only.issues).toEqual([
+      expect.stringMatching(/missing org_id/),
+    ]);
+
+    expect(byTable.multi_org.hasOrgId).toBe(true);
+    expect(byTable.multi_org.issues).toEqual([]);
+
+    // Human-readable run with --require-org must fail closed on the org gap.
+    const logs = await runCheck(["--require-org"]);
+    expect(logs.join("\n")).toContain("missing org_id");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("without --require-org, a table missing org_id is not flagged", async () => {
+    await withClient(async (c) => {
+      await c.execute(
+        `CREATE TABLE personal_only (id TEXT PRIMARY KEY, owner_email TEXT)`,
+      );
+    });
+    const out = await runCheckJson([]);
+    const byTable = Object.fromEntries(
+      out.tables.map((t: any) => [t.table, t]),
+    );
+    expect(byTable.personal_only.issues).toEqual([]);
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it("prints help without inspecting the database", async () => {
+    const logs = await runCheck(["--help"]);
+    expect(logs.join("\n")).toContain("Usage: pnpm action db-check-scoping");
+  });
+});

--- a/packages/core/src/scripts/db/exec-behaviors.spec.ts
+++ b/packages/core/src/scripts/db/exec-behaviors.spec.ts
@@ -140,26 +140,29 @@ describe("db-exec behaviors", () => {
     expect(text).toMatch(/owned by a different user|per-user.*scoping/i);
   });
 
-  it("BUG: INSERT OR IGNORE is not qualified to the base table under SQLite scoping, so it hits the temp view and errors (the qualify regex only matches a bare 'INSERT INTO')", async () => {
+  it("qualifies INSERT OR IGNORE to the base table and skips a duplicate (changes=0) instead of erroring on the scoped view", async () => {
     await withClient((c) =>
       c.execute({
         sql: `INSERT INTO notes VALUES (?, ?, ?)`,
         args: ["dup", "owner@x.com", "first"],
       }),
     );
-    const { default: dbExec } = await import("./exec.js");
-    // A plain `INSERT INTO` is rewritten to main."notes" and works, but the
-    // `OR IGNORE` variant slips past the rewrite and runs against the scoped
-    // view, which SQLite refuses to modify. (Would otherwise have exercised the
-    // INSERT zero-changes UNIQUE-constraint hint.)
-    await expect(
-      dbExec([
-        "--db",
-        dbFile,
-        "--sql",
-        "INSERT OR IGNORE INTO notes (id, title) VALUES ('dup', 'second')",
-      ]),
-    ).rejects.toThrow(/cannot modify notes because it is a view/);
+    // The `INSERT OR <conflict>` conflict forms must be qualified to
+    // main."notes" (like a bare INSERT INTO) so the write reaches the real
+    // table, not the non-updatable scoped temp view. id='dup' already exists,
+    // so OR IGNORE skips the row: 0 changes, no error.
+    const out = await runExecJson([
+      "--sql",
+      "INSERT OR IGNORE INTO notes (id, title) VALUES ('dup', 'second')",
+    ]);
+    expect(out.changes).toBe(0);
+    // The pre-existing row is untouched (IGNORE did not overwrite it).
+    const title = await withClient((c) =>
+      c
+        .execute(`SELECT title FROM notes WHERE id = 'dup'`)
+        .then((r) => (r.rows[0]?.title ?? r.rows[0]?.[0]) as string),
+    );
+    expect(title).toBe("first");
   });
 
   // ── INSERT ownership injection (SQLite) ─────────────────────────────────
@@ -196,7 +199,7 @@ describe("db-exec behaviors", () => {
   });
 
   // ── REPLACE scoping ─────────────────────────────────────────────────────
-  it("BUG: REPLACE INTO is qualified to the base table but does NOT receive owner_email injection, so the row lands unowned and is invisible to the writer under scoping (only INSERT triggers ownership injection)", async () => {
+  it("auto-injects owner_email on REPLACE INTO so the row is visible to the writer under scoping", async () => {
     const out = await runExecJson([
       "--sql",
       "REPLACE INTO notes (id, title) VALUES (?, ?)",
@@ -211,9 +214,10 @@ describe("db-exec behaviors", () => {
           (r) => (r.rows[0]?.owner_email ?? r.rows[0]?.[0]) as string | null,
         ),
     );
-    // Documenting the current (buggy) behavior: owner_email is null, so a
-    // follow-up scoped read by the same user will not see this row.
-    expect(owner).toBeNull();
+    // REPLACE creates a new row under the current user, so ownership injection
+    // must apply (just like INSERT) — otherwise the row lands unowned and a
+    // follow-up scoped read by the same user would not see it.
+    expect(owner).toBe("owner@x.com");
   });
 
   // ── Batch transactional rollback ────────────────────────────────────────

--- a/packages/core/src/scripts/db/exec-behaviors.spec.ts
+++ b/packages/core/src/scripts/db/exec-behaviors.spec.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createClient, type Client } from "@libsql/client";
+
+/**
+ * Behavior tests for db-exec that complement parameterized.spec.ts (which
+ * covers bind-arg plumbing and the security denylists). Here we focus on the
+ * statement-shape guards and the agent-facing result semantics — multi-
+ * statement rejection, SELECT routing, the zero-changes scoping hint, INSERT
+ * ownership injection, and REPLACE scoping — run against a real temp SQLite DB.
+ */
+describe("db-exec behaviors", () => {
+  let dir: string;
+  let dbFile: string;
+  let url: string;
+
+  async function withClient<T>(fn: (c: Client) => Promise<T>): Promise<T> {
+    const c = createClient({ url });
+    try {
+      return await fn(c);
+    } finally {
+      c.close();
+    }
+  }
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), "db-exec-"));
+    dbFile = path.join(dir, "app.db");
+    url = "file:" + dbFile;
+    await withClient(async (c) => {
+      await c.execute(
+        `CREATE TABLE notes (id TEXT PRIMARY KEY, owner_email TEXT, title TEXT)`,
+      );
+    });
+    vi.stubEnv("AGENT_USER_EMAIL", "owner@x.com");
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    vi.restoreAllMocks();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function runExec(extra: string[]): Promise<string[]> {
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, "log")
+      .mockImplementation((...a: unknown[]) => {
+        logs.push(a.map(String).join(" "));
+      });
+    try {
+      const { default: dbExec } = await import("./exec.js");
+      await dbExec(["--db", dbFile, ...extra]);
+    } finally {
+      spy.mockRestore();
+    }
+    return logs;
+  }
+
+  async function runExecJson(extra: string[]): Promise<any> {
+    const logs = await runExec(["--format", "json", ...extra]);
+    const joined = logs.join("\n");
+    return JSON.parse(joined.slice(joined.indexOf("{")));
+  }
+
+  // ── Statement-shape guards ──────────────────────────────────────────────
+  it("rejects a SELECT (routes the agent to db-query)", async () => {
+    const { default: dbExec } = await import("./exec.js");
+    await expect(
+      dbExec(["--db", dbFile, "--sql", "SELECT * FROM notes"]),
+    ).rejects.toThrow(/use db-query for SELECT/);
+  });
+
+  it("rejects two statements packed into one --sql string", async () => {
+    const { default: dbExec } = await import("./exec.js");
+    await expect(
+      dbExec([
+        "--db",
+        dbFile,
+        "--sql",
+        "UPDATE notes SET title = 'x'; DELETE FROM notes",
+      ]),
+    ).rejects.toThrow(/multiple SQL statements/);
+  });
+
+  it("does not treat a semicolon inside a string literal as a second statement", async () => {
+    await withClient((c) =>
+      c.execute({
+        sql: `INSERT INTO notes VALUES (?, ?, ?)`,
+        args: ["n1", "owner@x.com", "old"],
+      }),
+    );
+    const out = await runExecJson([
+      "--sql",
+      "UPDATE notes SET title = 'a; b' WHERE id = 'n1'",
+    ]);
+    expect(out.changes).toBe(1);
+    const title = await withClient((c) =>
+      c
+        .execute(`SELECT title FROM notes WHERE id = 'n1'`)
+        .then((r) => (r.rows[0]?.title ?? r.rows[0]?.[0]) as string),
+    );
+    expect(title).toBe("a; b");
+  });
+
+  it("rejects passing both --sql and --statements", async () => {
+    const { default: dbExec } = await import("./exec.js");
+    await expect(
+      dbExec([
+        "--db",
+        dbFile,
+        "--sql",
+        "DELETE FROM notes",
+        "--statements",
+        JSON.stringify([{ sql: "DELETE FROM notes" }]),
+      ]),
+    ).rejects.toThrow(/either --sql or --statements, not both/i);
+  });
+
+  it("rejects DROP / DDL through db-exec", async () => {
+    const { default: dbExec } = await import("./exec.js");
+    await expect(
+      dbExec(["--db", dbFile, "--sql", "DROP TABLE notes"]),
+    ).rejects.toThrow(/only INSERT, UPDATE, DELETE, REPLACE/);
+  });
+
+  // ── Result semantics ────────────────────────────────────────────────────
+  it("emits a per-user scoping hint when an UPDATE changes zero rows", async () => {
+    // No matching row → 0 changes. The hint must mention scoping so the agent
+    // doesn't report a silent no-op as success.
+    const logs = await runExec([
+      "--sql",
+      "UPDATE notes SET title = 'x' WHERE id = 'missing'",
+    ]);
+    const text = logs.join("\n");
+    expect(text).toContain("Changes: 0");
+    expect(text).toMatch(/owned by a different user|per-user.*scoping/i);
+  });
+
+  it("BUG: INSERT OR IGNORE is not qualified to the base table under SQLite scoping, so it hits the temp view and errors (the qualify regex only matches a bare 'INSERT INTO')", async () => {
+    await withClient((c) =>
+      c.execute({
+        sql: `INSERT INTO notes VALUES (?, ?, ?)`,
+        args: ["dup", "owner@x.com", "first"],
+      }),
+    );
+    const { default: dbExec } = await import("./exec.js");
+    // A plain `INSERT INTO` is rewritten to main."notes" and works, but the
+    // `OR IGNORE` variant slips past the rewrite and runs against the scoped
+    // view, which SQLite refuses to modify. (Would otherwise have exercised the
+    // INSERT zero-changes UNIQUE-constraint hint.)
+    await expect(
+      dbExec([
+        "--db",
+        dbFile,
+        "--sql",
+        "INSERT OR IGNORE INTO notes (id, title) VALUES ('dup', 'second')",
+      ]),
+    ).rejects.toThrow(/cannot modify notes because it is a view/);
+  });
+
+  // ── INSERT ownership injection (SQLite) ─────────────────────────────────
+  it("auto-injects owner_email on INSERT so the row is visible to the writer", async () => {
+    const out = await runExecJson([
+      "--sql",
+      "INSERT INTO notes (id, title) VALUES (?, ?)",
+      "--args",
+      JSON.stringify(["n-inject", "hello"]),
+    ]);
+    expect(out.changes).toBe(1);
+    // The base row must carry the current user's owner_email even though the
+    // INSERT never named the column.
+    const owner = await withClient((c) =>
+      c
+        .execute(`SELECT owner_email FROM notes WHERE id = 'n-inject'`)
+        .then((r) => (r.rows[0]?.owner_email ?? r.rows[0]?.[0]) as string),
+    );
+    expect(owner).toBe("owner@x.com");
+  });
+
+  it("blocks an explicit owner_email in an INSERT column list (access-control column denylist)", async () => {
+    // Writing owner_email directly is treated as an access-control write and is
+    // refused — the agent can't plant a row under an arbitrary owner.
+    const { default: dbExec } = await import("./exec.js");
+    await expect(
+      dbExec([
+        "--db",
+        dbFile,
+        "--sql",
+        "INSERT INTO notes (id, owner_email, title) VALUES ('n-explicit', 'victim@x.com', 't')",
+      ]),
+    ).rejects.toThrow(/identity\/access-control column "owner_email"/);
+  });
+
+  // ── REPLACE scoping ─────────────────────────────────────────────────────
+  it("BUG: REPLACE INTO is qualified to the base table but does NOT receive owner_email injection, so the row lands unowned and is invisible to the writer under scoping (only INSERT triggers ownership injection)", async () => {
+    const out = await runExecJson([
+      "--sql",
+      "REPLACE INTO notes (id, title) VALUES (?, ?)",
+      "--args",
+      JSON.stringify(["n-replace", "v1"]),
+    ]);
+    expect(out.changes).toBe(1);
+    const owner = await withClient((c) =>
+      c
+        .execute(`SELECT owner_email FROM notes WHERE id = 'n-replace'`)
+        .then(
+          (r) => (r.rows[0]?.owner_email ?? r.rows[0]?.[0]) as string | null,
+        ),
+    );
+    // Documenting the current (buggy) behavior: owner_email is null, so a
+    // follow-up scoped read by the same user will not see this row.
+    expect(owner).toBeNull();
+  });
+
+  // ── Batch transactional rollback ────────────────────────────────────────
+  it("rolls back the whole batch when a later statement fails", async () => {
+    await withClient((c) =>
+      c.execute({
+        sql: `INSERT INTO notes VALUES (?, ?, ?)`,
+        args: ["seed", "owner@x.com", "seed-title"],
+      }),
+    );
+    const { default: dbExec } = await import("./exec.js");
+    await expect(
+      dbExec([
+        "--db",
+        dbFile,
+        "--statements",
+        JSON.stringify([
+          { sql: "UPDATE notes SET title = 'changed' WHERE id = 'seed'" },
+          // Second statement references a non-existent column → fails, forcing
+          // a rollback of the first UPDATE.
+          { sql: "UPDATE notes SET nonexistent_col = 'x' WHERE id = 'seed'" },
+        ]),
+      ]),
+    ).rejects.toThrow();
+
+    const title = await withClient((c) =>
+      c
+        .execute(`SELECT title FROM notes WHERE id = 'seed'`)
+        .then((r) => (r.rows[0]?.title ?? r.rows[0]?.[0]) as string),
+    );
+    // The first UPDATE must have been rolled back.
+    expect(title).toBe("seed-title");
+  });
+});

--- a/packages/core/src/scripts/db/exec.ts
+++ b/packages/core/src/scripts/db/exec.ts
@@ -294,8 +294,21 @@ function normalizePostgresSql(sql: string, args: unknown[]): string {
 }
 
 /**
- * For INSERT statements targeting a table with owner_email / org_id columns,
- * auto-inject the current user's email and org ID if not already present.
+ * SQLite/standard SQL forms that create a new row and therefore need
+ * owner_email / org_id auto-injected:
+ *   INSERT INTO …, INSERT OR {ROLLBACK,ABORT,FAIL,IGNORE,REPLACE} INTO …,
+ *   REPLACE INTO … (shorthand for INSERT OR REPLACE INTO).
+ * Used by both injectOwnership and qualifySqliteWrite so the two stay in sync.
+ */
+const INSERT_OR_REPLACE_INTO =
+  "(?:INSERT(?:\\s+OR\\s+(?:ROLLBACK|ABORT|FAIL|IGNORE|REPLACE))?|REPLACE)\\s+INTO";
+
+/**
+ * For INSERT/REPLACE statements targeting a table with owner_email / org_id
+ * columns, auto-inject the current user's email and org ID if not already
+ * present. REPLACE and the `INSERT OR <action>` conflict forms also create a
+ * row under the current user, so they are injected too — otherwise the row
+ * lands unowned and is invisible to the writer under scoping.
  *
  * Handles the explicit column list form:
  *   INSERT INTO table (col1, col2) VALUES (val1, val2)
@@ -308,10 +321,12 @@ function injectOwnership(sql: string, scoping: ScopingContext): string {
     .replace(/\/\*[\s\S]*?\*\//g, "")
     .trim()
     .toUpperCase();
-  if (!upper.startsWith("INSERT")) return sql;
+  if (!upper.startsWith("INSERT") && !upper.startsWith("REPLACE")) return sql;
 
-  // Extract table name: INSERT INTO <table> ...
-  const match = sql.match(/INSERT\s+INTO\s+["']?(\w+)["']?/i);
+  // Extract table name: INSERT [OR ...] INTO <table> / REPLACE INTO <table>
+  const match = sql.match(
+    new RegExp(`${INSERT_OR_REPLACE_INTO}\\s+["']?(\\w+)["']?`, "i"),
+  );
   if (!match) return sql;
 
   const tableName = match[1];
@@ -345,7 +360,10 @@ function injectOwnership(sql: string, scoping: ScopingContext): string {
 
   // Try to inject into explicit column list: INSERT INTO t (cols) VALUES (vals)
   const colListMatch = sql.match(
-    /(INSERT\s+INTO\s+["']?\w+["']?\s*)\(([^)]+)\)(\s*VALUES\s*)\(([^)]+)\)/i,
+    new RegExp(
+      `(${INSERT_OR_REPLACE_INTO}\\s+["']?\\w+["']?\\s*)\\(([^)]+)\\)(\\s*VALUES\\s*)\\(([^)]+)\\)`,
+      "i",
+    ),
   );
   if (colListMatch) {
     const [, prefix, cols, valueKeyword, vals] = colListMatch;

--- a/packages/core/src/scripts/db/exec.ts
+++ b/packages/core/src/scripts/db/exec.ts
@@ -458,7 +458,10 @@ function qualifySqliteWrite(sql: string, scoping: ScopingContext): string {
   }
 
   return sql.replace(
-    /^\s*(INSERT\s+INTO|REPLACE\s+INTO)\s+(?:"([^"]+)"|'([^']+)'|(\w+))/i,
+    new RegExp(
+      `^\\s*(${INSERT_OR_REPLACE_INTO})\\s+(?:"([^"]+)"|'([^']+)'|(\\w+))`,
+      "i",
+    ),
     (match, keyword, quotedDouble, quotedSingle, bare) => {
       const tableName = quotedDouble ?? quotedSingle ?? bare;
       if (

--- a/packages/core/src/scripts/db/migrate-encrypt-credentials.e2e.spec.ts
+++ b/packages/core/src/scripts/db/migrate-encrypt-credentials.e2e.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * End-to-end test for the `db-migrate-encrypt-credentials` script against a
+ * REAL (temp-file) SQLite database. Validates the command we tell operators to
+ * run in production: it encrypts plaintext credential rows in place, leaves
+ * already-encrypted and non-credential rows alone, is idempotent, and refuses
+ * to run without an encryption key.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createClient, type Client } from "@libsql/client";
+import {
+  encryptSecretValue,
+  decryptSecretValue,
+  isEncryptedSecretValue,
+} from "../../secrets/crypto.js";
+
+const KEY = "migrate-encrypt-spec-key";
+
+describe("db-migrate-encrypt-credentials (e2e, real sqlite)", () => {
+  let dir: string;
+  let dbFile: string;
+  let url: string;
+
+  async function withClient<T>(fn: (c: Client) => Promise<T>): Promise<T> {
+    const c = createClient({ url });
+    try {
+      return await fn(c);
+    } finally {
+      c.close();
+    }
+  }
+
+  async function rawValue(key: string): Promise<string> {
+    return withClient(async (c) => {
+      const r = await c.execute({
+        sql: `SELECT value FROM settings WHERE key = ?`,
+        args: [key],
+      });
+      const stored = JSON.parse(r.rows[0].value as string);
+      return stored.value as string;
+    });
+  }
+
+  async function runMigrate(extraArgs: string[] = []): Promise<void> {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { default: migrate } =
+        await import("./migrate-encrypt-credentials.js");
+      await migrate(["--db", dbFile, ...extraArgs]);
+    } finally {
+      vi.restoreAllMocks();
+    }
+  }
+
+  beforeEach(async () => {
+    vi.stubEnv("SECRETS_ENCRYPTION_KEY", KEY);
+    dir = await mkdtemp(path.join(os.tmpdir(), "an-migrate-"));
+    dbFile = path.join(dir, "app.db");
+    url = "file:" + dbFile;
+    await withClient(async (c) => {
+      await c.execute(
+        `CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at INTEGER NOT NULL)`,
+      );
+      const rows: [string, unknown][] = [
+        ["u:a@x.com:credential:OPENAI_API_KEY", { value: "sk-plain-AAA" }],
+        ["o:org1:credential:STRIPE_KEY", { value: "sk_live_plain" }],
+        // Already encrypted — must be left untouched (idempotent).
+        ["u:b@x.com:credential:K", { value: encryptSecretValue("already") }],
+        // Non-credential setting — must never be touched.
+        ["u:a@x.com:pref:theme", { value: "dark" }],
+      ];
+      for (const [key, value] of rows) {
+        await c.execute({
+          sql: `INSERT INTO settings VALUES (?, ?, ?)`,
+          args: [key, JSON.stringify(value), 1],
+        });
+      }
+    });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    vi.restoreAllMocks();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("--dry-run reports rows without writing anything", async () => {
+    await runMigrate(["--dry-run"]);
+    expect(await rawValue("u:a@x.com:credential:OPENAI_API_KEY")).toBe(
+      "sk-plain-AAA",
+    );
+  });
+
+  it("encrypts plaintext credential rows in place (decrypts to the original)", async () => {
+    await runMigrate();
+    const userVal = await rawValue("u:a@x.com:credential:OPENAI_API_KEY");
+    const orgVal = await rawValue("o:org1:credential:STRIPE_KEY");
+    expect(isEncryptedSecretValue(userVal)).toBe(true);
+    expect(isEncryptedSecretValue(orgVal)).toBe(true);
+    expect(decryptSecretValue(userVal)).toBe("sk-plain-AAA");
+    expect(decryptSecretValue(orgVal)).toBe("sk_live_plain");
+  });
+
+  it("leaves already-encrypted and non-credential rows untouched", async () => {
+    const beforeEnc = await rawValue("u:b@x.com:credential:K");
+    await runMigrate();
+    expect(await rawValue("u:b@x.com:credential:K")).toBe(beforeEnc); // byte-identical
+    expect(await rawValue("u:a@x.com:pref:theme")).toBe("dark"); // plaintext pref
+  });
+
+  it("is idempotent — a second run encrypts nothing new", async () => {
+    await runMigrate();
+    const after1 = await rawValue("u:a@x.com:credential:OPENAI_API_KEY");
+    await runMigrate();
+    const after2 = await rawValue("u:a@x.com:credential:OPENAI_API_KEY");
+    expect(after2).toBe(after1); // not double-encrypted
+    expect(decryptSecretValue(after2)).toBe("sk-plain-AAA");
+  });
+
+  it("refuses to run without an encryption key", async () => {
+    vi.stubEnv("SECRETS_ENCRYPTION_KEY", "");
+    vi.stubEnv("BETTER_AUTH_SECRET", "");
+    await expect(runMigrate()).rejects.toThrow(/encryption key/i);
+    // Nothing was modified.
+    expect(await rawValue("u:a@x.com:credential:OPENAI_API_KEY")).toBe(
+      "sk-plain-AAA",
+    );
+  });
+});

--- a/packages/core/src/scripts/db/patch.spec.ts
+++ b/packages/core/src/scripts/db/patch.spec.ts
@@ -1,0 +1,820 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createClient, type Client } from "@libsql/client";
+
+/**
+ * db-patch is the agent's surgical search-and-replace + JSON-op tool. None of
+ * the interesting logic (validateWhere, the JSON-op engine, strict-uniqueness
+ * matching) is exported, so we drive everything through the real default
+ * export.
+ *
+ * For tests that VERIFY THE WRITTEN VALUE, we drive a mocked Postgres backend:
+ *   - In production (Neon Postgres) db-patch's scoped temp views are
+ *     auto-updatable single-table views WITH LOCAL CHECK OPTION, so the UPDATE
+ *     through the view succeeds and the patch engine's output is what lands.
+ *   - The mock records the SELECT result and captures the UPDATE bind value so
+ *     we can assert exactly what applyEdits / the JSON-op engine produced.
+ * (See the SQLite section below for the desktop/local path, which surfaces a
+ * genuine view-write bug.)
+ *
+ * For tests that only check validation / no-write behavior we use a real
+ * temp-file SQLite database since no write is attempted.
+ */
+describe("db-patch", () => {
+  let dir: string;
+  let dbFile: string;
+  let url: string;
+
+  async function withClient<T>(fn: (c: Client) => Promise<T>): Promise<T> {
+    const c = createClient({ url });
+    try {
+      return await fn(c);
+    } finally {
+      c.close();
+    }
+  }
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), "db-patch-"));
+    dbFile = path.join(dir, "app.db");
+    url = "file:" + dbFile;
+    await withClient(async (c) => {
+      await c.execute(
+        `CREATE TABLE documents (id TEXT PRIMARY KEY, owner_email TEXT, content TEXT)`,
+      );
+    });
+    vi.stubEnv("AGENT_USER_EMAIL", "owner@x.com");
+  });
+
+  afterEach(async () => {
+    // doMock registrations are file-scoped and survive resetModules; clear them
+    // so the SQLite tests (which use the real client) don't inherit a partial
+    // Postgres mock of ../../db/client.js from an earlier test.
+    vi.doUnmock("postgres");
+    vi.doUnmock("../../db/client.js");
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    vi.restoreAllMocks();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  // ── Postgres-backed harness (write verification) ────────────────────────
+  //
+  // Mocks `postgres` so db-patch's runPostgres path runs against an in-memory
+  // fake: the SELECT returns `initialValue`, the UPDATE captures the new value.
+  interface PgHarness {
+    /** The value the UPDATE wrote, or undefined if no UPDATE ran. */
+    written: () => string | undefined;
+    /** All UPDATE statements seen. */
+    updateCount: () => number;
+  }
+
+  function mockPg(opts: {
+    table: string;
+    columns: string[];
+    selectRows: Record<string, unknown>[];
+  }): PgHarness {
+    let captured: string | undefined;
+    let updates = 0;
+
+    const introspectRows = opts.columns.map((c) => ({
+      table_name: opts.table,
+      column_name: c,
+    }));
+
+    const unsafe = vi.fn(async (sql: string, args?: unknown[]) => {
+      const lower = sql.toLowerCase();
+      if (lower.includes("temporary view") || lower.startsWith("drop view")) {
+        return [];
+      }
+      if (lower.startsWith("select")) {
+        return opts.selectRows;
+      }
+      if (lower.startsWith("update")) {
+        updates++;
+        captured = (args?.[0] as string) ?? undefined;
+        return Object.assign([], { count: 1 });
+      }
+      return [];
+    });
+
+    // The introspection query is the tagged-template call on tx.
+    const introspect = vi.fn(async () => introspectRows);
+    const tx: any = Object.assign(introspect, { unsafe });
+    const pgSql: any = Object.assign(introspect, {
+      unsafe,
+      end: vi.fn(),
+      begin: async (fn: any) => fn(tx),
+    });
+
+    vi.doMock("postgres", () => ({ default: () => pgSql }));
+    vi.doMock("../../db/client.js", () => ({
+      getDatabaseUrl: () => "postgres://qa.example/db",
+      getDatabaseAuthToken: () => undefined,
+    }));
+
+    return {
+      written: () => captured,
+      updateCount: () => updates,
+    };
+  }
+
+  async function runPatchPg(harness: PgHarness, extra: string[]): Promise<any> {
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, "log")
+      .mockImplementation((...a: unknown[]) => {
+        logs.push(a.map(String).join(" "));
+      });
+    try {
+      const { default: dbPatch } = await import("./patch.js");
+      await dbPatch(["--format", "json", ...extra]);
+    } finally {
+      spy.mockRestore();
+    }
+    const joined = logs.join("\n");
+    const start = joined.indexOf("{");
+    return start >= 0 ? JSON.parse(joined.slice(start)) : null;
+  }
+
+  // ── SQLite harness (validation / no-write paths) ────────────────────────
+  async function seedDoc(id: string, owner: string, content: string) {
+    await withClient((c) =>
+      c.execute({
+        sql: `INSERT INTO documents VALUES (?, ?, ?)`,
+        args: [id, owner, content],
+      }),
+    );
+  }
+
+  // ── Argument validation (no DB touch) ──────────────────────────────────
+  describe("argument validation", () => {
+    it("rejects a non-identifier table name (SQL injection via --table)", async () => {
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents; DROP TABLE documents",
+          "--column",
+          "content",
+          "--where",
+          "id='d1'",
+          "--find",
+          "a",
+          "--replace",
+          "b",
+        ]),
+      ).rejects.toThrow(/Invalid --table/);
+    });
+
+    it("rejects a non-identifier column name", async () => {
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents",
+          "--column",
+          "content = x, owner_email",
+          "--where",
+          "id='d1'",
+          "--find",
+          "a",
+          "--replace",
+          "b",
+        ]),
+      ).rejects.toThrow(/Invalid --column/);
+    });
+
+    it("rejects a WHERE clause that chains statements", async () => {
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id='d1'; DELETE FROM documents",
+          "--find",
+          "a",
+          "--replace",
+          "b",
+        ]),
+      ).rejects.toThrow(/no statement chaining/);
+    });
+
+    it("rejects a WHERE clause containing a blocked DDL keyword", async () => {
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id = 'd1' OR 1=1 DROP TABLE documents",
+          "--find",
+          "a",
+          "--replace",
+          "b",
+        ]),
+      ).rejects.toThrow(/--where must not contain "DROP"/);
+    });
+
+    it("rejects a WHERE clause with a SQL comment", async () => {
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id = 'd1' -- and the rest",
+          "--find",
+          "a",
+          "--replace",
+          "b",
+        ]),
+      ).rejects.toThrow(/--where must not contain "--"/);
+    });
+
+    it("rejects a ';' even when it is inside a quoted string literal (the ';' check runs before string-stripping)", async () => {
+      // validateWhere checks for ';' on the raw clause BEFORE stripping string
+      // literals, so unlike the DDL-keyword denylist there is no carve-out for
+      // a semicolon hidden in a quoted value. This is the conservative-by-design
+      // asymmetry: a stray ';' is always refused, the throw happens before any
+      // DB connection, and the SQLite victim DB is never touched.
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id = 'a;b'",
+          "--find",
+          "a",
+          "--replace",
+          "b",
+        ]),
+      ).rejects.toThrow(/no statement chaining/);
+    });
+
+    it("allows a blocked keyword that only appears inside a quoted string literal", async () => {
+      // "DROP TABLE" lives entirely inside the string literal, so validateWhere
+      // strips it before scanning. With a Postgres backend the patch goes
+      // through and the engine output is written.
+      const h = mockPg({
+        table: "documents",
+        columns: ["id", "owner_email", "content"],
+        selectRows: [{ __val: "needle here" }],
+      });
+      const out = await runPatchPg(h, [
+        "--table",
+        "documents",
+        "--column",
+        "content",
+        "--where",
+        "id = 'd1' AND content != 'DROP TABLE foo'",
+        "--find",
+        "needle",
+        "--replace",
+        "pin",
+      ]);
+      expect(out.applied).toBe(1);
+      expect(h.written()).toBe("pin here");
+    });
+
+    it("requires an edit mode (--find or --edits)", async () => {
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id='d1'",
+        ]),
+      ).rejects.toThrow(/Either --find\/--replace or --edits is required/);
+    });
+
+    it("rejects an empty --find (passed as --find= so parseArgs keeps it empty)", async () => {
+      // `--find ""` would be parsed as a boolean flag; `--find=` preserves the
+      // empty value, which is the case the empty-find guard rejects.
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id='d1'",
+          "--find=",
+        ]),
+      ).rejects.toThrow(/--find cannot be empty/);
+    });
+
+    it("rejects an --edits payload that is not a non-empty array", async () => {
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id='d1'",
+          "--edits",
+          "[]",
+        ]),
+      ).rejects.toThrow(/non-empty JSON array/);
+    });
+  });
+
+  // ── Text edits: strict uniqueness, not-found, replaceAll (Postgres) ─────
+  describe("text edits", () => {
+    function docPg(content: string): PgHarness {
+      return mockPg({
+        table: "documents",
+        columns: ["id", "owner_email", "content"],
+        selectRows: [{ __val: content }],
+      });
+    }
+
+    it("applies a single unambiguous find/replace", async () => {
+      const h = docPg("the quik brown fox");
+      const out = await runPatchPg(h, [
+        "--table",
+        "documents",
+        "--column",
+        "content",
+        "--where",
+        "id = 'd1'",
+        "--find",
+        "quik",
+        "--replace",
+        "quick",
+      ]);
+      expect(out.applied).toBe(1);
+      expect(out.results[0].status).toBe("replaced");
+      expect(h.written()).toBe("the quick brown fox");
+    });
+
+    it("reports not-found, applies nothing, and runs no UPDATE when find is absent", async () => {
+      const h = docPg("hello world");
+      const out = await runPatchPg(h, [
+        "--table",
+        "documents",
+        "--column",
+        "content",
+        "--where",
+        "id = 'd1'",
+        "--find",
+        "absent",
+        "--replace",
+        "x",
+      ]);
+      expect(out.applied).toBe(0);
+      expect(out.results[0].status).toBe("not-found");
+      expect(h.updateCount()).toBe(0);
+    });
+
+    it("refuses an ambiguous match by default (strict uniqueness) and writes nothing", async () => {
+      const h = docPg("foo and foo and foo");
+      const out = await runPatchPg(h, [
+        "--table",
+        "documents",
+        "--column",
+        "content",
+        "--where",
+        "id = 'd1'",
+        "--find",
+        "foo",
+        "--replace",
+        "bar",
+      ]);
+      expect(out.applied).toBe(0);
+      expect(out.results[0].status).toBe("not-found");
+      expect(out.results[0].occurrences).toBe(3);
+      expect(out.results[0].detail).toContain("3 occurrences");
+      expect(h.updateCount()).toBe(0);
+    });
+
+    it("replaces every occurrence with --all", async () => {
+      const h = docPg("foo and foo and foo");
+      const out = await runPatchPg(h, [
+        "--table",
+        "documents",
+        "--column",
+        "content",
+        "--where",
+        "id = 'd1'",
+        "--find",
+        "foo",
+        "--replace",
+        "bar",
+        "--all",
+      ]);
+      expect(out.applied).toBe(1);
+      expect(out.results[0].occurrences).toBe(3);
+      expect(h.written()).toBe("bar and bar and bar");
+    });
+
+    it("treats an empty replace as a deletion", async () => {
+      const h = docPg("keep[DROP]end");
+      const out = await runPatchPg(h, [
+        "--table",
+        "documents",
+        "--column",
+        "content",
+        "--where",
+        "id = 'd1'",
+        "--find",
+        "[DROP]",
+      ]);
+      expect(out.results[0].status).toBe("deleted");
+      expect(h.written()).toBe("keepend");
+    });
+
+    it("applies a batch of --edits sequentially against the evolving content", async () => {
+      // The second edit's `find` only exists after the first edit runs.
+      const h = docPg("alpha");
+      const out = await runPatchPg(h, [
+        "--table",
+        "documents",
+        "--column",
+        "content",
+        "--where",
+        "id = 'd1'",
+        "--edits",
+        JSON.stringify([
+          { find: "alpha", replace: "beta" },
+          { find: "beta", replace: "gamma" },
+        ]),
+      ]);
+      expect(out.applied).toBe(2);
+      expect(h.written()).toBe("gamma");
+    });
+
+    it("reports zero matching rows distinctly from zero text matches", async () => {
+      const h = mockPg({
+        table: "documents",
+        columns: ["id", "owner_email", "content"],
+        selectRows: [],
+      });
+      void h;
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id = 'does-not-exist'",
+          "--find",
+          "a",
+          "--replace",
+          "b",
+        ]),
+      ).rejects.toThrow(/No rows matched/);
+    });
+
+    it("refuses to patch when the WHERE clause matches more than one row", async () => {
+      mockPg({
+        table: "documents",
+        columns: ["id", "owner_email", "content"],
+        selectRows: [{ __val: "one" }, { __val: "two" }],
+      });
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "owner_email = 'owner@x.com'",
+          "--find",
+          "o",
+          "--replace",
+          "0",
+        ]),
+      ).rejects.toThrow(/expects exactly one row/);
+    });
+
+    it("rejects a non-text column value", async () => {
+      mockPg({
+        table: "documents",
+        columns: ["id", "owner_email", "content"],
+        selectRows: [{ __val: 42 }],
+      });
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id = 'd1'",
+          "--find",
+          "a",
+          "--replace",
+          "b",
+        ]),
+      ).rejects.toThrow(/is not a text column/);
+    });
+  });
+
+  // ── JSON ops engine (Postgres) ──────────────────────────────────────────
+  describe("json-ops", () => {
+    function deckPg(data: unknown): PgHarness {
+      return mockPg({
+        table: "decks",
+        columns: ["id", "owner_email", "data"],
+        selectRows: [{ __val: JSON.stringify(data) }],
+      });
+    }
+
+    async function runDeckOps(
+      h: PgHarness,
+      ops: unknown[],
+    ): Promise<{ out: any; result: any }> {
+      const out = await runPatchPg(h, [
+        "--table",
+        "decks",
+        "--column",
+        "data",
+        "--where",
+        "id = 'd1'",
+        "--json-ops",
+        JSON.stringify(ops),
+      ]);
+      const written = h.written();
+      return { out, result: written ? JSON.parse(written) : undefined };
+    }
+
+    it("sets a nested value via JSON Pointer", async () => {
+      const h = deckPg({ panels: [{ title: "Q3" }, { title: "stay" }] });
+      const { out, result } = await runDeckOps(h, [
+        { op: "set", path: "/panels/0/title", value: "Q4" },
+      ]);
+      expect(out.applied).toBe(1);
+      expect(result.panels[0].title).toBe("Q4");
+      expect(result.panels[1].title).toBe("stay");
+    });
+
+    it("removes an object key and splices an array element", async () => {
+      const h = deckPg({ keep: 1, drop: 2, list: ["a", "b", "c"] });
+      const { out, result } = await runDeckOps(h, [
+        { op: "remove", path: "/drop" },
+        { op: "remove", path: "/list/1" },
+      ]);
+      expect(out.applied).toBe(2);
+      expect(result).not.toHaveProperty("drop");
+      expect(result.keep).toBe(1);
+      expect(result.list).toEqual(["a", "c"]);
+    });
+
+    it("inserts into an array at an index and at the '-' append position", async () => {
+      const h = deckPg({ list: ["a", "c"] });
+      const { out, result } = await runDeckOps(h, [
+        { op: "insert", path: "/list/1", value: "b" },
+        { op: "insert", path: "/list/-", value: "d" },
+      ]);
+      expect(out.applied).toBe(2);
+      expect(result.list).toEqual(["a", "b", "c", "d"]);
+    });
+
+    it("move-before reorders an array element so it lands at the requested index", async () => {
+      // Move index 3 to index 1; final order must be a, d, b, c.
+      const h = deckPg({ list: ["a", "b", "c", "d"] });
+      const { out, result } = await runDeckOps(h, [
+        { op: "move-before", from: "/list/3", path: "/list/1" },
+      ]);
+      expect(out.applied).toBe(1);
+      expect(result.list).toEqual(["a", "d", "b", "c"]);
+    });
+
+    it("move forward (to a higher index in the same array) shifts the target down by one after the source splice", async () => {
+      // Move index 0 to index 2 within the same array. The source splice removes
+      // "a" first (→ b, c, d) and because target 2 > source 0 the destination is
+      // decremented to 1, so "a" is reinserted at index 1 → b, a, c, d. This is
+      // the stable-index convention shared with move-before.
+      const h = deckPg({ list: ["a", "b", "c", "d"] });
+      const { out, result } = await runDeckOps(h, [
+        { op: "move", from: "/list/0", path: "/list/2" },
+      ]);
+      expect(out.applied).toBe(1);
+      expect(result.list).toEqual(["b", "a", "c", "d"]);
+    });
+
+    it("records a per-op failure without aborting surviving ops, and writes the partial result", async () => {
+      const h = deckPg({ list: ["a", "b"] });
+      const { out, result } = await runDeckOps(h, [
+        { op: "set", path: "/list/0", value: "Z" },
+        // Out-of-bounds parent walk → this op fails but must not discard op 0.
+        { op: "set", path: "/list/9/deep", value: "x" },
+      ]);
+      expect(out.applied).toBe(1);
+      expect(out.results[0].status).toBe("replaced");
+      expect(out.results[1].status).toBe("not-found");
+      expect(out.results[1].detail).toContain("FAILED");
+      expect(result.list[0]).toBe("Z");
+    });
+
+    it("fails the whole run when the column is not valid JSON", async () => {
+      mockPg({
+        table: "decks",
+        columns: ["id", "owner_email", "data"],
+        selectRows: [{ __val: "not json {" }],
+      });
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--table",
+          "decks",
+          "--column",
+          "data",
+          "--where",
+          "id = 'd1'",
+          "--json-ops",
+          JSON.stringify([{ op: "set", path: "/x", value: 1 }]),
+        ]),
+      ).rejects.toThrow(/requires the column value to be valid JSON/);
+    });
+
+    it("rejects a json-ops payload whose entries are not op objects", async () => {
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id = 'd1'",
+          "--json-ops",
+          JSON.stringify(["not-an-op"]),
+        ]),
+      ).rejects.toThrow(/Each op must be an object with an 'op' field/);
+    });
+
+    it("escapes JSON Pointer ~1 (slash) and ~0 (tilde) in key segments", async () => {
+      const h = deckPg({ "a/b": { "c~d": "old" } });
+      const { out, result } = await runDeckOps(h, [
+        { op: "set", path: "/a~1b/c~0d", value: "new" },
+      ]);
+      expect(out.applied).toBe(1);
+      expect(result["a/b"]["c~d"]).toBe("new");
+    });
+
+    it("rejects a JSON path that does not start with '/'", async () => {
+      const h = deckPg({ x: 1 });
+      const { out } = await runDeckOps(h, [{ op: "set", path: "x", value: 2 }]);
+      // The op fails individually (caught) → recorded as a failed op, nothing
+      // applied, no write.
+      expect(out.applied).toBe(0);
+      expect(out.results[0].detail).toContain("FAILED");
+      expect(h.updateCount()).toBe(0);
+    });
+  });
+
+  // ── Scoping / safety (SQLite, no successful write needed) ───────────────
+  describe("scoping and safety (SQLite)", () => {
+    it("cannot read a row owned by another user (it appears as no-rows)", async () => {
+      await seedDoc("victim", "other@x.com", "victim content");
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id = 'victim'",
+          "--find",
+          "victim",
+          "--replace",
+          "pwned",
+        ]),
+      ).rejects.toThrow(/No rows matched/);
+      // The victim's row is byte-for-byte intact.
+      const stillThere = await withClient((c) =>
+        c
+          .execute({
+            sql: `SELECT content FROM documents WHERE id = ?`,
+            args: ["victim"],
+          })
+          .then((r) => (r.rows[0]?.content ?? r.rows[0]?.[0]) as string),
+      );
+      expect(stillThere).toBe("victim content");
+    });
+
+    it("refuses to run when there is no authenticated user identity", async () => {
+      vi.stubEnv("AGENT_USER_EMAIL", "");
+      await seedDoc("d1", "owner@x.com", "x");
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id = 'd1'",
+          "--find",
+          "x",
+          "--replace",
+          "y",
+        ]),
+      ).rejects.toThrow(/require an authenticated user identity/);
+    });
+
+    it("rejects the dev sentinel identity (local@localhost)", async () => {
+      vi.stubEnv("AGENT_USER_EMAIL", "local@localhost");
+      await seedDoc("d1", "owner@x.com", "x");
+      const { default: dbPatch } = await import("./patch.js");
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id = 'd1'",
+          "--find",
+          "x",
+          "--replace",
+          "y",
+        ]),
+      ).rejects.toThrow(/require an authenticated user identity/);
+    });
+
+    it('BUG: under SQLite scoping a successful patch fails because the UPDATE hits the scoped temp view, which SQLite/libSQL cannot modify (desktop/local path). db-exec avoids this by qualifying writes to main."table"; db-patch does not.', async () => {
+      await seedDoc("d1", "owner@x.com", "the quik brown fox");
+      const { default: dbPatch } = await import("./patch.js");
+      // The SELECT reads through the view fine and the text match succeeds, but
+      // the UPDATE "documents" SET ... resolves to the temp view and throws.
+      await expect(
+        dbPatch([
+          "--db",
+          dbFile,
+          "--table",
+          "documents",
+          "--column",
+          "content",
+          "--where",
+          "id = 'd1'",
+          "--find",
+          "quik",
+          "--replace",
+          "quick",
+        ]),
+      ).rejects.toThrow(/cannot modify documents because it is a view/);
+      // And the row is left unchanged.
+      const after = await withClient((c) =>
+        c
+          .execute({
+            sql: `SELECT content FROM documents WHERE id = ?`,
+            args: ["d1"],
+          })
+          .then((r) => (r.rows[0]?.content ?? r.rows[0]?.[0]) as string),
+      );
+      expect(after).toBe("the quik brown fox");
+    });
+  });
+});

--- a/packages/core/src/scripts/db/patch.spec.ts
+++ b/packages/core/src/scripts/db/patch.spec.ts
@@ -784,11 +784,44 @@ describe("db-patch", () => {
       ).rejects.toThrow(/require an authenticated user identity/);
     });
 
-    it('BUG: under SQLite scoping a successful patch fails because the UPDATE hits the scoped temp view, which SQLite/libSQL cannot modify (desktop/local path). db-exec avoids this by qualifying writes to main."table"; db-patch does not.', async () => {
+    it('writes a scoped patch to main."table" (SQLite views are not updatable, so the UPDATE must target the real table with the scope predicate re-applied)', async () => {
       await seedDoc("d1", "owner@x.com", "the quik brown fox");
       const { default: dbPatch } = await import("./patch.js");
-      // The SELECT reads through the view fine and the text match succeeds, but
-      // the UPDATE "documents" SET ... resolves to the temp view and throws.
+      // The SELECT reads through the scoped temp view; the UPDATE must NOT —
+      // it targets main."documents" with the view's owner_email predicate
+      // re-applied, so the patch lands on the real table without ever exposing
+      // a row the SELECT couldn't see.
+      await dbPatch([
+        "--db",
+        dbFile,
+        "--table",
+        "documents",
+        "--column",
+        "content",
+        "--where",
+        "id = 'd1'",
+        "--find",
+        "quik",
+        "--replace",
+        "quick",
+      ]);
+      const after = await withClient((c) =>
+        c
+          .execute({
+            sql: `SELECT content FROM documents WHERE id = ?`,
+            args: ["d1"],
+          })
+          .then((r) => (r.rows[0]?.content ?? r.rows[0]?.[0]) as string),
+      );
+      expect(after).toBe("the quick brown fox");
+    });
+
+    it("refuses to patch a row owned by a different user under SQLite scoping (the re-applied predicate blocks the cross-tenant write)", async () => {
+      // The row exists but belongs to someone else. The scoped SELECT can't see
+      // it, so db-patch reports "no rows matched" and never issues the UPDATE —
+      // the cross-tenant row must stay untouched.
+      await seedDoc("d-other", "someone-else@x.com", "secret value");
+      const { default: dbPatch } = await import("./patch.js");
       await expect(
         dbPatch([
           "--db",
@@ -798,23 +831,22 @@ describe("db-patch", () => {
           "--column",
           "content",
           "--where",
-          "id = 'd1'",
+          "id = 'd-other'",
           "--find",
-          "quik",
+          "secret",
           "--replace",
-          "quick",
+          "leaked",
         ]),
-      ).rejects.toThrow(/cannot modify documents because it is a view/);
-      // And the row is left unchanged.
+      ).rejects.toThrow(/No rows matched/);
       const after = await withClient((c) =>
         c
           .execute({
             sql: `SELECT content FROM documents WHERE id = ?`,
-            args: ["d1"],
+            args: ["d-other"],
           })
           .then((r) => (r.rows[0]?.content ?? r.rows[0]?.[0]) as string),
       );
-      expect(after).toBe("the quik brown fox");
+      expect(after).toBe("secret value");
     });
   });
 });

--- a/packages/core/src/scripts/db/patch.ts
+++ b/packages/core/src/scripts/db/patch.ts
@@ -662,8 +662,23 @@ async function runSqlite(opts: RunOpts): Promise<void> {
     const { content, results, applied, total } = applyEither(original, opts);
 
     if (applied > 0) {
+      // SQLite views are not updatable, so the scoped temp view we read through
+      // above cannot be the write target — the UPDATE must hit the real table
+      // in the `main` schema. Re-apply the exact predicate the scoping view
+      // uses (db-exec performs the identical rewrite) so the write can never
+      // reach a row the scoped SELECT couldn't see. Falls back to the bare name
+      // only when scoping is inactive (e.g. a database with no tables).
+      const predicate = scoping.active
+        ? scoping.tablePredicates.get(opts.table)
+        : undefined;
+      const target = predicate
+        ? `main."${opts.table.replace(/"/g, '""')}"`
+        : `"${opts.table}"`;
+      const whereClause = predicate
+        ? `${predicate} AND (${opts.where})`
+        : opts.where;
       await client.execute({
-        sql: `UPDATE "${opts.table}" SET "${opts.column}" = ? WHERE ${opts.where}`,
+        sql: `UPDATE ${target} SET "${opts.column}" = ? WHERE ${whereClause}`,
         args: [content],
       });
     }

--- a/packages/core/src/scripts/db/schema.spec.ts
+++ b/packages/core/src/scripts/db/schema.spec.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createClient, type Client } from "@libsql/client";
+
+/**
+ * db-schema introspects the database and prints its structure for the agent.
+ * Two things matter most here:
+ *   1. The DATABASE label must REDACT credentials (passwords) — it's printed
+ *      to logs/tool output the agent can echo back.
+ *   2. The SQLite introspection (columns, types, PK/NOT NULL/DEFAULT, FKs,
+ *      indexes) must be faithful in both JSON and human-readable form.
+ * The functions aren't exported, so we drive the real default export against a
+ * temp-file SQLite database and capture stdout.
+ */
+describe("db-schema", () => {
+  let dir: string;
+  let dbFile: string;
+
+  async function withClient<T>(fn: (c: Client) => Promise<T>): Promise<T> {
+    const c = createClient({ url: "file:" + dbFile });
+    try {
+      return await fn(c);
+    } finally {
+      c.close();
+    }
+  }
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(os.tmpdir(), "db-schema-"));
+    dbFile = path.join(dir, "app.db");
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    vi.restoreAllMocks();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function runSchema(extra: string[]): Promise<string[]> {
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, "log")
+      .mockImplementation((...a: unknown[]) => {
+        logs.push(a.map(String).join(" "));
+      });
+    try {
+      const { default: dbSchema } = await import("./schema.js");
+      await dbSchema(extra);
+    } finally {
+      spy.mockRestore();
+    }
+    return logs;
+  }
+
+  async function runSchemaJson(extra: string[]): Promise<any> {
+    const logs = await runSchema([
+      "--db",
+      dbFile,
+      "--format",
+      "json",
+      ...extra,
+    ]);
+    const joined = logs.join("\n");
+    const start = joined.indexOf("{");
+    return JSON.parse(joined.slice(start));
+  }
+
+  it("introspects columns, PK, NOT NULL, DEFAULT, FKs, and indexes (JSON)", async () => {
+    await withClient(async (c) => {
+      await c.execute(
+        `CREATE TABLE authors (id TEXT PRIMARY KEY, name TEXT NOT NULL, bio TEXT DEFAULT 'none')`,
+      );
+      await c.execute(
+        `CREATE TABLE posts (
+           id TEXT PRIMARY KEY,
+           author_id TEXT NOT NULL REFERENCES authors(id),
+           title TEXT
+         )`,
+      );
+      await c.execute(`CREATE UNIQUE INDEX idx_posts_title ON posts(title)`);
+    });
+
+    const out = await runSchemaJson([]);
+
+    const tables = Object.fromEntries(out.tables.map((t: any) => [t.name, t]));
+    expect(Object.keys(tables).sort()).toEqual(["authors", "posts"]);
+
+    const authors = tables.authors;
+    const cols = Object.fromEntries(
+      authors.columns.map((c: any) => [c.name, c]),
+    );
+    expect(cols.id.pk).toBe(true);
+    expect(cols.name.notnull).toBe(true);
+    expect(cols.name.pk).toBe(false);
+    // SQLite stores a DEFAULT 'none' literal with quotes — just assert it's set.
+    expect(cols.bio.dflt_value).not.toBeNull();
+
+    const posts = tables.posts;
+    expect(posts.foreignKeys).toHaveLength(1);
+    expect(posts.foreignKeys[0]).toMatchObject({
+      from: "author_id",
+      table: "authors",
+      to: "id",
+    });
+
+    const titleIdx = posts.indexes.find((i: any) =>
+      i.name.includes("idx_posts_title"),
+    );
+    expect(titleIdx).toBeDefined();
+    expect(titleIdx.unique).toBe(true);
+    expect(titleIdx.columns).toEqual(["title"]);
+  });
+
+  it("excludes sqlite_* internal tables from introspection", async () => {
+    await withClient(async (c) => {
+      // An AUTOINCREMENT table makes SQLite create sqlite_sequence.
+      await c.execute(
+        `CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT)`,
+      );
+      await c.execute(`INSERT INTO t (v) VALUES ('x')`);
+    });
+    const out = await runSchemaJson([]);
+    const names = out.tables.map((t: any) => t.name);
+    expect(names).toContain("t");
+    expect(names.some((n: string) => n.startsWith("sqlite_"))).toBe(false);
+  });
+
+  it("emits human-readable output with annotations when no --format is given", async () => {
+    await withClient(async (c) => {
+      await c.execute(
+        `CREATE TABLE widgets (id TEXT PRIMARY KEY, label TEXT NOT NULL)`,
+      );
+    });
+    const logs = await runSchema(["--db", dbFile]);
+    const text = logs.join("\n");
+    expect(text).toContain("Table: widgets");
+    expect(text).toContain("PRIMARY KEY");
+    expect(text).toContain("NOT NULL");
+    // JSON braces must NOT appear in human-readable mode.
+    expect(text).not.toMatch(/^\s*\{/m);
+  });
+
+  it("labels a file: database as the bare filesystem path (no auth section to redact)", async () => {
+    await withClient(async (c) => {
+      await c.execute(`CREATE TABLE t (id TEXT PRIMARY KEY)`);
+    });
+    // The label of the local file DB is the plain filesystem path — the
+    // "file:" prefix is stripped and there is nothing to redact. The real
+    // redaction behavior is asserted by the Postgres test below.
+    const out = await runSchemaJson([]);
+    expect(out.database).toBe(dbFile);
+    expect(out.database.startsWith("file:")).toBe(false);
+  });
+
+  it("prints help and does not touch the database", async () => {
+    const logs = await runSchema(["--help"]);
+    expect(logs.join("\n")).toContain("Usage: pnpm action db-schema");
+  });
+
+  it("redacts the Postgres password in the database label (never leaks the secret to tool output)", async () => {
+    // Resolve to a Postgres URL via the env path (not --db, which forces file:).
+    vi.doMock("../../db/client.js", () => ({
+      getDatabaseUrl: () =>
+        "postgres://app_user:sup3r-secret@db.example.com:5432/appdb",
+    }));
+    // Mock the postgres driver so no real connection is attempted. The driver
+    // is a tagged-template function; return the table list for the tables
+    // query and empty arrays for the per-table column/pk/fk/index queries.
+    vi.doMock("postgres", () => ({
+      default: () =>
+        Object.assign(
+          async (strings: TemplateStringsArray) => {
+            const text = strings.join(" ");
+            if (text.includes("information_schema.tables")) {
+              return [{ name: "notes" }];
+            }
+            return [];
+          },
+          { end: vi.fn() },
+        ),
+    }));
+
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, "log")
+      .mockImplementation((...a: unknown[]) => {
+        logs.push(a.map(String).join(" "));
+      });
+    try {
+      const { default: dbSchema } = await import("./schema.js");
+      await dbSchema(["--format", "json"]);
+    } finally {
+      spy.mockRestore();
+    }
+    const joined = logs.join("\n");
+    const out = JSON.parse(joined.slice(joined.indexOf("{")));
+
+    expect(out.database).toContain("app_user:***@db.example.com");
+    expect(out.database).not.toContain("sup3r-secret");
+  });
+});

--- a/packages/core/src/secrets/crypto.spec.ts
+++ b/packages/core/src/secrets/crypto.spec.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import {
   encryptSecretValue,
   decryptSecretValue,
+  getSecretEncryptionKey,
   isEncryptedSecretValue,
 } from "./crypto.js";
 
@@ -43,5 +44,64 @@ describe("secret crypto", () => {
     process.env.SECRETS_ENCRYPTION_KEY = "key-B";
     expect(() => decryptSecretValue(enc)).toThrow();
     process.env.SECRETS_ENCRYPTION_KEY = "crypto-spec-encryption-key";
+  });
+
+  it("rejects payloads that are not v1-tagged ciphertext", () => {
+    // A legacy plaintext value (or any non-v1 string) is refused outright so
+    // the caller can fall back rather than mis-decrypt arbitrary bytes.
+    expect(() => decryptSecretValue("sk-plaintext-key")).toThrow(
+      /Unrecognised secret encoding/,
+    );
+  });
+
+  it("rejects a v1 payload that is missing one of its three segments", () => {
+    expect(() => decryptSecretValue("v1:onlyiv:onlyct")).toThrow(
+      /Corrupt secret payload/,
+    );
+    expect(() => decryptSecretValue("v1:")).toThrow(/Corrupt secret payload/);
+  });
+});
+
+describe("getSecretEncryptionKey", () => {
+  const ORIGINAL_KEY = process.env.SECRETS_ENCRYPTION_KEY;
+  const ORIGINAL_AUTH = process.env.BETTER_AUTH_SECRET;
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+  afterEach(() => {
+    if (ORIGINAL_KEY === undefined) delete process.env.SECRETS_ENCRYPTION_KEY;
+    else process.env.SECRETS_ENCRYPTION_KEY = ORIGINAL_KEY;
+    if (ORIGINAL_AUTH === undefined) delete process.env.BETTER_AUTH_SECRET;
+    else process.env.BETTER_AUTH_SECRET = ORIGINAL_AUTH;
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+  });
+
+  it("derives a stable 32-byte AES key from the configured material", () => {
+    process.env.SECRETS_ENCRYPTION_KEY = "stable-material";
+    const a = getSecretEncryptionKey();
+    const b = getSecretEncryptionKey();
+    expect(a).toHaveLength(32);
+    // Re-derived per call but deterministic for the same material.
+    expect(a.equals(b)).toBe(true);
+  });
+
+  it("falls back to BETTER_AUTH_SECRET when SECRETS_ENCRYPTION_KEY is unset", () => {
+    delete process.env.SECRETS_ENCRYPTION_KEY;
+    process.env.BETTER_AUTH_SECRET = "auth-fallback-material";
+    // The derived key must match deriving directly from the same material via
+    // SECRETS_ENCRYPTION_KEY — i.e. the fallback source is honored.
+    const viaAuth = getSecretEncryptionKey();
+    process.env.SECRETS_ENCRYPTION_KEY = "auth-fallback-material";
+    delete process.env.BETTER_AUTH_SECRET;
+    const viaExplicit = getSecretEncryptionKey();
+    expect(viaAuth.equals(viaExplicit)).toBe(true);
+  });
+
+  it("refuses to derive a key in production without any configured secret", () => {
+    delete process.env.SECRETS_ENCRYPTION_KEY;
+    delete process.env.BETTER_AUTH_SECRET;
+    process.env.NODE_ENV = "production";
+    expect(() => getSecretEncryptionKey()).toThrow(
+      /Refusing to start in production without an encryption key/,
+    );
   });
 });

--- a/packages/core/src/secrets/storage.spec.ts
+++ b/packages/core/src/secrets/storage.spec.ts
@@ -1,4 +1,63 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// A stable encryption key so values round-trip deterministically and the
+// crypto layer never falls through to the cwd-derived fallback (which would
+// warn on every run).
+beforeAll(() => {
+  process.env.SECRETS_ENCRYPTION_KEY = "storage-spec-encryption-key";
+});
+
+/**
+ * Wrap a real in-memory better-sqlite3 connection in the `DbExec` interface
+ * that `storage.ts` expects (`execute(string | { sql, args })`). Using a real
+ * DB lets us assert genuine behavior — encryption at rest, upsert id-stability,
+ * scope isolation, not-found/delete semantics — rather than captured SQL.
+ */
+function createSqliteExec() {
+  const sqlite = new Database(":memory:");
+  return {
+    sqlite,
+    exec: {
+      async execute(input: string | { sql: string; args?: any[] }) {
+        const sql = typeof input === "string" ? input : input.sql;
+        const args = typeof input === "string" ? [] : (input.args ?? []);
+        const trimmed = sql.trim().toUpperCase();
+        if (trimmed.startsWith("SELECT")) {
+          const rows = sqlite.prepare(sql).all(...args);
+          return { rows, rowsAffected: 0 };
+        }
+        const info = sqlite.prepare(sql).run(...args);
+        return { rows: [], rowsAffected: info.changes };
+      },
+    },
+  };
+}
+
+async function loadStorageWithSqlite() {
+  const { sqlite, exec } = createSqliteExec();
+  vi.doMock("../db/client.js", () => ({
+    getDialect: () => "sqlite",
+    getDbExec: () => exec,
+    isPostgres: () => false,
+  }));
+  const mod = await import("./storage.js");
+  return { sqlite, mod };
+}
+
+const userRef = {
+  scope: "user" as const,
+  scopeId: "alice@example.test",
+  key: "OPENAI_API_KEY",
+};
 
 describe("secrets storage bootstrap", () => {
   afterEach(() => {
@@ -32,5 +91,278 @@ describe("secrets storage bootstrap", () => {
     expect(String(execute.mock.calls[1]?.[0])).toContain(
       "CREATE TABLE IF NOT EXISTS app_secrets",
     );
+  });
+
+  it("rewrites INTEGER to BIGINT for Postgres so millisecond timestamps fit", async () => {
+    const execute = vi.fn(async () => ({ rows: [] as unknown[] }));
+
+    vi.doMock("../db/client.js", () => ({
+      getDialect: () => "postgres",
+      getDbExec: () => ({ execute }),
+      isPostgres: () => true,
+    }));
+
+    const { readAppSecret } = await import("./storage.js");
+    await readAppSecret(userRef);
+
+    const createSql = String(execute.mock.calls[0]?.[0]);
+    expect(createSql).toContain("CREATE TABLE IF NOT EXISTS app_secrets");
+    expect(createSql).toContain("BIGINT");
+    expect(createSql).not.toMatch(/\bINTEGER\b/);
+  });
+});
+
+describe("secrets storage CRUD (real sqlite)", () => {
+  let sqlite: Database.Database;
+  let mod: typeof import("./storage.js");
+
+  beforeEach(async () => {
+    const loaded = await loadStorageWithSqlite();
+    sqlite = loaded.sqlite;
+    mod = loaded.mod;
+  });
+
+  afterEach(() => {
+    sqlite.close();
+    vi.resetModules();
+    vi.doUnmock("../db/client.js");
+  });
+
+  it("encrypts the value at rest and round-trips the plaintext", async () => {
+    await mod.writeAppSecret({ ...userRef, value: "sk-live-abc12345" });
+
+    // The raw column never contains the plaintext — it is v1:-tagged ciphertext.
+    const row = sqlite
+      .prepare(`SELECT encrypted_value FROM app_secrets`)
+      .get() as { encrypted_value: string };
+    expect(row.encrypted_value).toMatch(/^v1:[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/);
+    expect(row.encrypted_value).not.toContain("sk-live-abc12345");
+
+    const read = await mod.readAppSecret(userRef);
+    expect(read).not.toBeNull();
+    expect(read!.value).toBe("sk-live-abc12345");
+    expect(read!.last4).toBe("••••2345");
+    expect(read!.updatedAt).toBeGreaterThan(0);
+  });
+
+  it("rejects writes missing any required field without persisting", async () => {
+    await expect(mod.writeAppSecret({ ...userRef, value: "" })).rejects.toThrow(
+      /key, value, scope, and scopeId are all required/,
+    );
+    await expect(
+      mod.writeAppSecret({ ...userRef, key: "", value: "x" }),
+    ).rejects.toThrow(/all required/);
+    await expect(
+      mod.writeAppSecret({
+        scope: "user",
+        scopeId: "",
+        key: "K",
+        value: "x",
+      }),
+    ).rejects.toThrow(/all required/);
+
+    const { count } = sqlite
+      .prepare(`SELECT COUNT(*) as count FROM app_secrets`)
+      .get() as { count: number };
+    expect(count).toBe(0);
+  });
+
+  it("upserts in place: same id, new value/description/allowlist on overwrite", async () => {
+    const firstId = await mod.writeAppSecret({
+      ...userRef,
+      value: "first-value",
+      description: "initial",
+    });
+    const secondId = await mod.writeAppSecret({
+      ...userRef,
+      value: "second-value-9999",
+      description: "updated",
+      urlAllowlist: JSON.stringify(["https://api.openai.com"]),
+    });
+
+    // Reference stability: overwriting a key must not mint a new id.
+    expect(secondId).toBe(firstId);
+
+    const { count } = sqlite
+      .prepare(`SELECT COUNT(*) as count FROM app_secrets`)
+      .get() as { count: number };
+    expect(count).toBe(1);
+
+    const read = await mod.readAppSecret(userRef);
+    expect(read!.value).toBe("second-value-9999");
+
+    const meta = await mod.readAppSecretMeta(userRef);
+    expect(meta!.description).toBe("updated");
+    expect(meta!.urlAllowlist).toEqual(["https://api.openai.com"]);
+  });
+
+  it("isolates secrets by scope and scopeId (no cross-tenant leakage)", async () => {
+    await mod.writeAppSecret({ ...userRef, value: "alice-secret" });
+    await mod.writeAppSecret({
+      scope: "user",
+      scopeId: "bob@example.test",
+      key: "OPENAI_API_KEY",
+      value: "bob-secret",
+    });
+    await mod.writeAppSecret({
+      scope: "workspace",
+      scopeId: "org_42",
+      key: "OPENAI_API_KEY",
+      value: "workspace-secret",
+    });
+
+    // Same key name, three different owners — each read returns only its own.
+    expect((await mod.readAppSecret(userRef))!.value).toBe("alice-secret");
+    expect(
+      (await mod.readAppSecret({
+        scope: "user",
+        scopeId: "bob@example.test",
+        key: "OPENAI_API_KEY",
+      }))!.value,
+    ).toBe("bob-secret");
+    expect(
+      (await mod.readAppSecret({
+        scope: "workspace",
+        scopeId: "org_42",
+        key: "OPENAI_API_KEY",
+      }))!.value,
+    ).toBe("workspace-secret");
+
+    // A scope that was never written returns null, not another tenant's value.
+    expect(
+      await mod.readAppSecret({
+        scope: "org",
+        scopeId: "org_42",
+        key: "OPENAI_API_KEY",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when reading a secret that does not exist", async () => {
+    expect(await mod.readAppSecret(userRef)).toBeNull();
+    expect(await mod.getAppSecretMeta(userRef)).toBeNull();
+    expect(await mod.readAppSecretMeta(userRef)).toBeNull();
+  });
+
+  it("returns null (never throws or leaks) when the stored ciphertext is corrupt", async () => {
+    await mod.writeAppSecret({ ...userRef, value: "tamperable" });
+    // Simulate a tampered / key-rotated row by overwriting the ciphertext with
+    // a syntactically-encrypted-but-undecryptable value.
+    sqlite
+      .prepare(`UPDATE app_secrets SET encrypted_value = ?`)
+      .run("v1:dead:beef:cafe");
+
+    // readAppSecret swallows decryption errors and reports "missing" so the
+    // ciphertext never escapes up the stack.
+    await expect(mod.readAppSecret(userRef)).resolves.toBeNull();
+
+    // readAppSecretMeta still returns metadata, but with an empty last4 — the
+    // value is not exposed.
+    const meta = await mod.readAppSecretMeta(userRef);
+    expect(meta).not.toBeNull();
+    expect(meta!.last4).toBe("");
+  });
+
+  it("getAppSecretMeta returns only last4 + updatedAt, never the value", async () => {
+    await mod.writeAppSecret({ ...userRef, value: "sk-meta-7777" });
+    const meta = await mod.getAppSecretMeta(userRef);
+    expect(meta).toEqual({
+      last4: "••••7777",
+      updatedAt: expect.any(Number),
+    });
+    expect(JSON.stringify(meta)).not.toContain("sk-meta-7777");
+  });
+
+  it("readAppSecretMeta parses a valid allowlist and tolerates malformed JSON", async () => {
+    await mod.writeAppSecret({
+      ...userRef,
+      value: "v",
+      urlAllowlist: JSON.stringify(["https://a.test", "https://b.test"]),
+    });
+    expect((await mod.readAppSecretMeta(userRef))!.urlAllowlist).toEqual([
+      "https://a.test",
+      "https://b.test",
+    ]);
+
+    // A non-array / non-string-array / malformed allowlist degrades to null
+    // rather than throwing or exposing junk.
+    sqlite.prepare(`UPDATE app_secrets SET url_allowlist = ?`).run("{not json");
+    expect((await mod.readAppSecretMeta(userRef))!.urlAllowlist).toBeNull();
+
+    sqlite
+      .prepare(`UPDATE app_secrets SET url_allowlist = ?`)
+      .run(JSON.stringify([1, 2, 3]));
+    expect((await mod.readAppSecretMeta(userRef))!.urlAllowlist).toBeNull();
+  });
+
+  it("lists only the requested scope's secrets as metadata (no values), newest first", async () => {
+    await mod.writeAppSecret({
+      ...userRef,
+      key: "FIRST_KEY",
+      value: "first-secret-1111",
+    });
+    await mod.writeAppSecret({
+      ...userRef,
+      key: "SECOND_KEY",
+      value: "second-secret-2222",
+      description: "second",
+    });
+    // A different scope must not appear in this scope's listing.
+    await mod.writeAppSecret({
+      scope: "user",
+      scopeId: "bob@example.test",
+      key: "BOB_KEY",
+      value: "bob-secret",
+    });
+
+    // Both writes can land in the same millisecond; force a distinct, newer
+    // updated_at on SECOND_KEY so the ORDER BY updated_at DESC contract is
+    // exercised deterministically rather than depending on clock resolution.
+    sqlite
+      .prepare(
+        `UPDATE app_secrets SET updated_at = ? WHERE scope_id = ? AND key = ?`,
+      )
+      .run(Date.now() + 10_000, "alice@example.test", "SECOND_KEY");
+
+    const list = await mod.listAppSecretsForScope("user", "alice@example.test");
+    expect(list.map((s) => s.key).sort()).toEqual(["FIRST_KEY", "SECOND_KEY"]);
+    // Newest write comes first (ORDER BY updated_at DESC).
+    expect(list[0].key).toBe("SECOND_KEY");
+    expect(list[0].description).toBe("second");
+    // Metadata only — plaintext never serialized into the list.
+    const serialized = JSON.stringify(list);
+    expect(serialized).not.toContain("first-secret-1111");
+    expect(serialized).not.toContain("second-secret-2222");
+    expect(serialized).not.toContain("bob-secret");
+    // last4 preview is still surfaced for set keys.
+    expect(list.find((s) => s.key === "FIRST_KEY")!.last4).toBe("••••1111");
+  });
+
+  it("deleteAppSecret reports whether a row was removed", async () => {
+    await mod.writeAppSecret({ ...userRef, value: "to-delete" });
+    expect(await mod.deleteAppSecret(userRef)).toBe(true);
+    expect(await mod.readAppSecret(userRef)).toBeNull();
+    // Deleting again is a no-op and reports false.
+    expect(await mod.deleteAppSecret(userRef)).toBe(false);
+  });
+});
+
+describe("last4 preview", () => {
+  let mod: typeof import("./storage.js");
+  beforeEach(async () => {
+    ({ mod } = await loadStorageWithSqlite());
+  });
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../db/client.js");
+  });
+
+  it("masks all but the trailing 4 characters and never reveals short values", () => {
+    expect(mod.last4("")).toBe("");
+    // Values <= 4 chars reveal nothing — fully masked.
+    expect(mod.last4("ab")).toBe("••••");
+    expect(mod.last4("abcd")).toBe("••••");
+    expect(mod.last4("abcde")).toBe("••••bcde");
+    expect(mod.last4("sk-live-1234567890")).toBe("••••7890");
   });
 });

--- a/packages/core/src/secrets/substitution.spec.ts
+++ b/packages/core/src/secrets/substitution.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockReadAppSecret = vi.fn();
 const mockReadAppSecretMeta = vi.fn();
@@ -22,9 +22,22 @@ vi.mock("../credentials/index.js", () => ({
 }));
 
 import {
+  getKeyAllowlist,
   getResolvedKeyAllowlist,
+  resolveKeyReferences,
   resolveKeyReferencesWithRequestScopes,
+  validateUrlAllowlist,
 } from "./substitution.js";
+
+const ORIGINAL_FALLBACK_ENV = process.env.AGENT_NATIVE_KEYS_WORKSPACE_FALLBACK;
+
+afterEach(() => {
+  if (ORIGINAL_FALLBACK_ENV === undefined) {
+    delete process.env.AGENT_NATIVE_KEYS_WORKSPACE_FALLBACK;
+  } else {
+    process.env.AGENT_NATIVE_KEYS_WORKSPACE_FALLBACK = ORIGINAL_FALLBACK_ENV;
+  }
+});
 
 describe("resolveKeyReferencesWithRequestScopes", () => {
   beforeEach(() => {
@@ -68,8 +81,9 @@ describe("resolveKeyReferencesWithRequestScopes", () => {
     });
   });
 
-  it("uses solo workspace scope when no org is active", async () => {
+  it("uses solo workspace scope when no org is active and never queries an org scope", async () => {
     mockGetRequestOrgId.mockReturnValue(null);
+    mockGetRequestUserEmail.mockReturnValue("alice@example.test");
     mockReadAppSecret.mockImplementation(async ({ scope, scopeId }) =>
       scope === "workspace" && scopeId === "solo:alice@example.test"
         ? { value: "solo-token" }
@@ -89,6 +103,40 @@ describe("resolveKeyReferencesWithRequestScopes", () => {
         scopeId: "solo:alice@example.test",
       },
     ]);
+    // With no active org the candidate set is [user, solo-workspace] only — an
+    // org-scoped row must never be consulted (no cross-org leakage path).
+    const consultedScopes = mockReadAppSecret.mock.calls.map((c) => c[0].scope);
+    expect(consultedScopes).not.toContain("org");
+  });
+
+  it("returns the user-scope value without consulting org or workspace scopes (first-hit precedence)", async () => {
+    // A personal override must win, and lower-precedence scopes must NOT be
+    // read once it is found — otherwise a shared org/workspace row could leak
+    // metadata reads or shadow the user's own value.
+    mockReadAppSecret.mockImplementation(async ({ scope }) =>
+      scope === "user"
+        ? { value: "personal-token" }
+        : { value: "shared-token" },
+    );
+
+    const result = await resolveKeyReferencesWithRequestScopes(
+      "Bearer ${keys.GITHUB_TOKEN}",
+      "alice@example.test",
+    );
+
+    expect(result.resolved).toBe("Bearer personal-token");
+    expect(result.resolvedKeys).toEqual([
+      { name: "GITHUB_TOKEN", scope: "user", scopeId: "alice@example.test" },
+    ]);
+    // Only the user scope was queried — org/workspace candidates short-circuit.
+    expect(mockReadAppSecret).toHaveBeenCalledTimes(1);
+    expect(mockReadAppSecret).toHaveBeenCalledWith({
+      key: "GITHUB_TOKEN",
+      scope: "user",
+      scopeId: "alice@example.test",
+    });
+    // The legacy credential store is never reached when a scoped row resolves.
+    expect(mockResolveCredentialForScope).not.toHaveBeenCalled();
   });
 
   it("falls back to a legacy user credential after scoped secrets miss", async () => {
@@ -160,6 +208,278 @@ describe("resolveKeyReferencesWithRequestScopes", () => {
       key: "GITHUB_TOKEN",
       scope: "org",
       scopeId: "org_123",
+    });
+  });
+
+  it("returns null from getResolvedKeyAllowlist when the key has no allowlist or is missing", async () => {
+    mockReadAppSecretMeta.mockResolvedValueOnce({ urlAllowlist: null });
+    await expect(
+      getResolvedKeyAllowlist({
+        name: "GITHUB_TOKEN",
+        scope: "org",
+        scopeId: "org_123",
+      }),
+    ).resolves.toBeNull();
+
+    mockReadAppSecretMeta.mockResolvedValueOnce(null);
+    await expect(
+      getResolvedKeyAllowlist({
+        name: "GITHUB_TOKEN",
+        scope: "org",
+        scopeId: "org_123",
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("resolveKeyReferences", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_NATIVE_KEYS_WORKSPACE_FALLBACK;
+    mockReadAppSecret.mockResolvedValue(null);
+  });
+
+  it("is a no-op when the text contains no ${keys.NAME} placeholders", async () => {
+    const result = await resolveKeyReferences(
+      "https://example.com/no/placeholders",
+      "user",
+      "alice@example.test",
+    );
+
+    expect(result.resolved).toBe("https://example.com/no/placeholders");
+    expect(result.usedKeys).toEqual([]);
+    expect(result.secretValues).toEqual([]);
+    // No lookup should happen when there's nothing to resolve.
+    expect(mockReadAppSecret).not.toHaveBeenCalled();
+  });
+
+  it("substitutes a single reference and returns the value for downstream redaction", async () => {
+    mockReadAppSecret.mockResolvedValue({ value: "sk-secret-123" });
+
+    const result = await resolveKeyReferences(
+      "Authorization: Bearer ${keys.OPENAI_API_KEY}",
+      "user",
+      "alice@example.test",
+    );
+
+    expect(result.resolved).toBe("Authorization: Bearer sk-secret-123");
+    // usedKeys carries NAMES (safe to log); secretValues carries the raw
+    // value separately so the caller can redact it from any output.
+    expect(result.usedKeys).toEqual(["OPENAI_API_KEY"]);
+    expect(result.secretValues).toEqual(["sk-secret-123"]);
+  });
+
+  it("deduplicates repeated references but substitutes every occurrence", async () => {
+    mockReadAppSecret.mockResolvedValue({ value: "tok" });
+
+    const result = await resolveKeyReferences(
+      "${keys.K}-${keys.K}-${keys.K}",
+      "user",
+      "alice@example.test",
+    );
+
+    expect(result.resolved).toBe("tok-tok-tok");
+    // The key is looked up exactly once even though it appears three times.
+    expect(mockReadAppSecret).toHaveBeenCalledTimes(1);
+    expect(result.usedKeys).toEqual(["K"]);
+    expect(result.secretValues).toEqual(["tok"]);
+  });
+
+  it("resolves multiple distinct references", async () => {
+    mockReadAppSecret.mockImplementation(async ({ key }) =>
+      key === "A" ? { value: "aaa" } : { value: "bbb" },
+    );
+
+    const result = await resolveKeyReferences(
+      "${keys.A}/${keys.B}",
+      "user",
+      "alice@example.test",
+    );
+
+    expect(result.resolved).toBe("aaa/bbb");
+    expect(result.usedKeys).toEqual(["A", "B"]);
+    expect(result.secretValues).toEqual(["aaa", "bbb"]);
+  });
+
+  it("throws a clear, value-free error when a referenced key is missing", async () => {
+    mockReadAppSecret.mockResolvedValue(null);
+
+    await expect(
+      resolveKeyReferences(
+        "Bearer ${keys.MISSING_KEY}",
+        "user",
+        "alice@example.test",
+      ),
+    ).rejects.toThrow(
+      /Referenced key "MISSING_KEY" is not defined for scope "user"/,
+    );
+  });
+
+  it("does NOT fall back to workspace scope by default (audit 05 H2)", async () => {
+    // user-scope miss; a workspace row exists but must be ignored unless the
+    // opt-in flag is set — this prevents one org member's workspace key from
+    // poisoning every other member's ${keys.NAME} resolution.
+    mockReadAppSecret.mockImplementation(async ({ scope }) =>
+      scope === "workspace" ? { value: "poisoned-workspace-value" } : null,
+    );
+
+    await expect(
+      resolveKeyReferences(
+        "Bearer ${keys.OPENAI_API_KEY}",
+        "user",
+        "alice@example.test",
+      ),
+    ).rejects.toThrow(/is not defined for scope "user"/);
+
+    // Only the user scope was queried — the workspace fallback never fired.
+    expect(mockReadAppSecret).toHaveBeenCalledTimes(1);
+    expect(mockReadAppSecret).toHaveBeenCalledWith({
+      key: "OPENAI_API_KEY",
+      scope: "user",
+      scopeId: "alice@example.test",
+    });
+  });
+
+  it("falls back to workspace scope only when the opt-in flag is enabled", async () => {
+    process.env.AGENT_NATIVE_KEYS_WORKSPACE_FALLBACK = "1";
+    mockGetRequestOrgId.mockReturnValue("org_999");
+    mockReadAppSecret.mockImplementation(async ({ scope }) =>
+      scope === "workspace" ? { value: "shared-default" } : null,
+    );
+
+    const result = await resolveKeyReferences(
+      "Bearer ${keys.OPENAI_API_KEY}",
+      "user",
+      "alice@example.test",
+    );
+
+    expect(result.resolved).toBe("Bearer shared-default");
+    expect(mockReadAppSecret).toHaveBeenCalledWith({
+      key: "OPENAI_API_KEY",
+      scope: "workspace",
+      scopeId: "org_999",
+    });
+  });
+
+  it("only honors recognized truthy values for the fallback flag", async () => {
+    // A non-truthy flag value must keep the fallback OFF.
+    process.env.AGENT_NATIVE_KEYS_WORKSPACE_FALLBACK = "0";
+    mockReadAppSecret.mockImplementation(async ({ scope }) =>
+      scope === "workspace" ? { value: "should-not-be-used" } : null,
+    );
+
+    await expect(
+      resolveKeyReferences("${keys.K}", "user", "alice@example.test"),
+    ).rejects.toThrow(/is not defined/);
+    expect(mockReadAppSecret).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("validateUrlAllowlist", () => {
+  it("is permissive when no allowlist is configured", () => {
+    expect(validateUrlAllowlist("https://anything.test/x", null)).toBe(true);
+    expect(validateUrlAllowlist("https://anything.test/x", [])).toBe(true);
+  });
+
+  it("allows a URL whose origin exactly matches an allowlist entry", () => {
+    // Path/query differences are ignored — matching is on origin only.
+    expect(
+      validateUrlAllowlist("https://hooks.slack.com/services/abc/def", [
+        "https://hooks.slack.com",
+      ]),
+    ).toBe(true);
+  });
+
+  it("blocks a URL whose origin is not in the allowlist", () => {
+    expect(
+      validateUrlAllowlist("https://evil.example.com/steal", [
+        "https://hooks.slack.com",
+      ]),
+    ).toBe(false);
+  });
+
+  it("treats scheme and port as part of the origin", () => {
+    expect(
+      validateUrlAllowlist("http://api.test/x", ["https://api.test"]),
+    ).toBe(false);
+    expect(
+      validateUrlAllowlist("https://api.test:8443/x", ["https://api.test"]),
+    ).toBe(false);
+  });
+
+  it("returns false for a malformed target URL", () => {
+    expect(validateUrlAllowlist("not a url", ["https://api.test"])).toBe(false);
+  });
+
+  it("skips malformed allowlist entries but still matches valid ones", () => {
+    expect(
+      validateUrlAllowlist("https://api.test/x", [
+        "::::garbage",
+        "https://api.test",
+      ]),
+    ).toBe(true);
+    // When every entry is malformed, nothing matches.
+    expect(
+      validateUrlAllowlist("https://api.test/x", ["::::garbage", "also bad"]),
+    ).toBe(false);
+  });
+});
+
+describe("getKeyAllowlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_NATIVE_KEYS_WORKSPACE_FALLBACK;
+    mockReadAppSecretMeta.mockResolvedValue(null);
+  });
+
+  it("returns the configured allowlist for the requested scope", async () => {
+    mockReadAppSecretMeta.mockResolvedValue({
+      urlAllowlist: ["https://api.openai.com"],
+    });
+
+    await expect(
+      getKeyAllowlist("OPENAI_API_KEY", "user", "alice@example.test"),
+    ).resolves.toEqual(["https://api.openai.com"]);
+  });
+
+  it("returns null when the key exists but has no allowlist", async () => {
+    mockReadAppSecretMeta.mockResolvedValue({ urlAllowlist: null });
+    await expect(
+      getKeyAllowlist("OPENAI_API_KEY", "user", "alice@example.test"),
+    ).resolves.toBeNull();
+  });
+
+  it("does NOT consult workspace scope by default, mirroring the resolver", async () => {
+    mockReadAppSecretMeta.mockImplementation(async ({ scope }) =>
+      scope === "workspace"
+        ? { urlAllowlist: ["https://workspace.test"] }
+        : null,
+    );
+
+    await expect(
+      getKeyAllowlist("OPENAI_API_KEY", "user", "alice@example.test"),
+    ).resolves.toBeNull();
+    // Only the user scope was consulted — the allowlist check stays aligned
+    // with resolveKeyReferences so we never allow a URL the resolver refuses.
+    expect(mockReadAppSecretMeta).toHaveBeenCalledTimes(1);
+  });
+
+  it("consults workspace scope only when the opt-in flag is enabled", async () => {
+    process.env.AGENT_NATIVE_KEYS_WORKSPACE_FALLBACK = "true";
+    mockGetRequestOrgId.mockReturnValue("org_555");
+    mockReadAppSecretMeta.mockImplementation(async ({ scope }) =>
+      scope === "workspace"
+        ? { urlAllowlist: ["https://workspace.test"] }
+        : null,
+    );
+
+    await expect(
+      getKeyAllowlist("OPENAI_API_KEY", "user", "alice@example.test"),
+    ).resolves.toEqual(["https://workspace.test"]);
+    expect(mockReadAppSecretMeta).toHaveBeenCalledWith({
+      key: "OPENAI_API_KEY",
+      scope: "workspace",
+      scopeId: "org_555",
     });
   });
 });

--- a/packages/core/src/server/action-discovery.spec.ts
+++ b/packages/core/src/server/action-discovery.spec.ts
@@ -93,6 +93,80 @@ describe("action discovery", () => {
     expect(registry["preview-thing"].mcpApp).toBe(mcpApp);
   });
 
+  it("threads the http config through named and default static entries", () => {
+    const registry = loadActionsFromStaticRegistry({
+      "named-get": {
+        tool: { description: "Named GET", parameters: {} },
+        http: { method: "GET", path: "/custom" },
+        run: async () => ({ ok: true }),
+      },
+      "default-post": {
+        default: {
+          tool: { description: "Default POST", parameters: {} },
+          http: { method: "POST" },
+          run: async () => ({ ok: true }),
+        },
+      },
+    });
+    expect(registry["named-get"].http).toEqual({
+      method: "GET",
+      path: "/custom",
+    });
+    expect(registry["default-post"].http).toEqual({ method: "POST" });
+  });
+
+  it("skips null/undefined and shape-less modules without throwing", () => {
+    const registry = loadActionsFromStaticRegistry({
+      "is-null": null as any,
+      "is-undefined": undefined as any,
+      "no-tool": { run: async () => "x" } as any,
+      "no-run": { tool: { description: "d", parameters: {} } } as any,
+      "default-not-callable": { default: { tool: {}, run: 42 } } as any,
+      "valid-one": {
+        tool: { description: "valid", parameters: {} },
+        run: async () => "ok",
+      },
+    });
+    expect(Object.keys(registry)).toEqual(["valid-one"]);
+  });
+
+  it("wraps a bare default function as a CLI-style action and captures its output", async () => {
+    const seenArgs: string[][] = [];
+    const registry = loadActionsFromStaticRegistry({
+      greet: {
+        default: async (args: string[]) => {
+          seenArgs.push(args);
+          console.log(`hello ${args[1] ?? ""}`.trim());
+        },
+      },
+    });
+
+    const entry = registry["greet"];
+    expect(entry).toBeDefined();
+    // A synthesized tool definition exposes a single space-separated `args` param.
+    expect(entry.tool.parameters?.properties).toHaveProperty("args");
+
+    // Single `args` string is shell-split into CLI tokens.
+    const out = await entry.run({ args: '--name "Ada Lovelace"' });
+    expect(seenArgs[0]).toEqual(["--name", "Ada Lovelace"]);
+    expect(out).toContain("hello Ada Lovelace");
+  });
+
+  it("converts arbitrary key/value params into --key value CLI tokens", async () => {
+    const seenArgs: string[][] = [];
+    const registry = loadActionsFromStaticRegistry({
+      "kv-action": {
+        default: async (args: string[]) => {
+          seenArgs.push(args);
+        },
+      },
+    });
+
+    await registry["kv-action"].run({ id: "abc", title: "Hi there" });
+    // Each entry becomes `--key`, `value` (order follows Object.entries).
+    expect(seenArgs[0]).toEqual(["--id", "abc", "--title", "Hi there"]);
+  });
+
   it("preserves toolCallable:false on merged core sharing actions (audit-H5)", async () => {
     // Regression guard: mergeCoreSharingActions must carry the security-relevant
     // toolCallable:false flag from the action defs into the registry, otherwise
@@ -112,5 +186,24 @@ describe("action discovery", () => {
         `${name} must keep toolCallable:false`,
       ).toBe(false);
     }
+  });
+
+  it("does not overwrite a template-provided action of the same name (template wins)", async () => {
+    const templateRun = async () => "template-share";
+    const registry: Record<string, any> = {
+      "share-resource": {
+        tool: { description: "Template share override", parameters: {} },
+        run: templateRun,
+      },
+    };
+    await mergeCoreSharingActions(registry);
+
+    // The template's own share-resource must survive — core must not clobber it.
+    expect(registry["share-resource"].run).toBe(templateRun);
+    expect(registry["share-resource"].tool.description).toBe(
+      "Template share override",
+    );
+    // Other core actions still get merged in.
+    expect(registry["unshare-resource"]).toBeDefined();
   });
 });

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -4551,11 +4551,19 @@ export function createAgentChatPlugin(
         filterReadOnlyActions(templateScripts),
       );
 
+      // Full-database admin tools. Gated on NODE_ENV=development to match the
+      // DB-admin UI + HTTP routes (which gate on the environment, not the
+      // Code-mode toggle), so the agent has the same DB-admin capability the UI
+      // does whenever it is available — true agent/UI parity, in App or Code mode.
+      const dbAdminScripts =
+        process.env.NODE_ENV === "development" ? createDbAdminAgentTools() : {};
+
       const prodActions = attachToolSearch({
         ...templateScripts,
         ...resourceScripts,
         ...docsScripts,
         ...dbScripts,
+        ...dbAdminScripts,
         ...refreshScreenTool,
         ...(lazyContext ? frameworkContextTool : {}),
         ...urlTools,
@@ -4813,9 +4821,9 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
                   ...browserTools,
                   ...mcpActionEntries,
                   ...(await createDevScriptRegistry()),
-                  // Dev-only full-database admin tools (gated to dev+localhost
-                  // by the surrounding `canToggle` block — never in prodActions).
-                  ...createDbAdminAgentTools(),
+                  // Full-database admin tools (NODE_ENV=development gate — see
+                  // dbAdminScripts; also in prodActions so App mode has them too).
+                  ...dbAdminScripts,
                 },
         );
         // Keep dev action dict in sync with runtime MCP additions. When

--- a/packages/core/src/server/design-token-utils.spec.ts
+++ b/packages/core/src/server/design-token-utils.spec.ts
@@ -1,8 +1,21 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  addFont,
+  analyzeCodeFile,
+  classifyFile,
+  createCodeAnalysisState,
+  detectStylingFramework,
+  extractCssVars,
+  extractDocumentColors,
+  extractDocumentFonts,
   fetchGitHubJsonResult,
   fetchGitHubRaw,
+  parseCss,
   parseOwnerRepo,
+  parseTailwindConfig,
+  suggestionsForType,
+  unique,
+  validateUrl,
 } from "./design-token-utils.js";
 
 describe("design-token GitHub helpers", () => {
@@ -93,5 +106,358 @@ describe("design-token GitHub helpers", () => {
       Authorization: "Bearer github-secret",
       Accept: "application/vnd.github.v3.raw",
     });
+  });
+
+  it("throws a clear error for unparseable repo references", () => {
+    expect(() => parseOwnerRepo("not a repo at all")).toThrow(
+      /Could not parse GitHub owner\/repo/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSRF pre-filter — the highest-value security invariant in this module.
+// ---------------------------------------------------------------------------
+describe("validateUrl (SSRF pre-filter)", () => {
+  it("accepts public http(s) URLs", () => {
+    expect(() => validateUrl("https://example.com/path")).not.toThrow();
+    expect(() => validateUrl("http://github.com")).not.toThrow();
+  });
+
+  it("rejects non-http(s) protocols (file:, ftp:, data:)", () => {
+    expect(() => validateUrl("file:///etc/passwd")).toThrow(
+      /Only http and https/,
+    );
+    expect(() => validateUrl("ftp://example.com")).toThrow(
+      /Only http and https/,
+    );
+    expect(() => validateUrl("data:text/html,<h1>x</h1>")).toThrow(
+      /Only http and https/,
+    );
+  });
+
+  it("rejects loopback and unspecified hosts", () => {
+    for (const host of [
+      "http://localhost",
+      "http://127.0.0.1",
+      "http://0.0.0.0",
+      "http://[::1]",
+    ]) {
+      expect(() => validateUrl(host), host).toThrow(/Internal\/private/);
+    }
+  });
+
+  it("rejects RFC1918 private ranges", () => {
+    for (const host of [
+      "http://10.0.0.5",
+      "http://192.168.1.1",
+      "http://172.16.0.1",
+      "http://172.31.255.255",
+    ]) {
+      expect(() => validateUrl(host), host).toThrow(/Internal\/private/);
+    }
+  });
+
+  it("rejects cloud metadata endpoints and internal TLDs", () => {
+    expect(() =>
+      validateUrl("http://169.254.169.254/latest/meta-data"),
+    ).toThrow(/Internal\/private/);
+    expect(() => validateUrl("http://metadata.google.internal")).toThrow(
+      /Internal\/private/,
+    );
+    expect(() => validateUrl("http://db.internal")).toThrow(
+      /Internal\/private/,
+    );
+    expect(() => validateUrl("http://printer.local")).toThrow(
+      /Internal\/private/,
+    );
+  });
+
+  it("does not block public hosts that merely start with a private-looking octet", () => {
+    // 10.x is blocked by prefix, but a public IP like 100.x must pass — the
+    // guard must not over-block legitimate public addresses.
+    expect(() => validateUrl("http://100.20.30.40")).not.toThrow();
+    expect(() => validateUrl("http://11.0.0.1")).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tailwind config parser
+// ---------------------------------------------------------------------------
+describe("parseTailwindConfig", () => {
+  it("extracts colors, fontFamily, spacing, and borderRadius blocks", () => {
+    const config = `
+module.exports = {
+  theme: {
+    colors: {
+      primary: "#5b21b6",
+      'accent-2': "#10b981",
+    },
+    fontFamily: {
+      sans: ["Inter", "sans-serif"],
+    },
+    spacing: {
+      "1": "4px",
+      "2": "8px",
+    },
+    borderRadius: {
+      lg: "12px",
+    },
+  },
+};`;
+    const result = parseTailwindConfig(config);
+    expect(result.colors).toMatchObject({
+      primary: "#5b21b6",
+      "accent-2": "#10b981",
+    });
+    expect(result.fontFamily).toMatchObject({ sans: "Inter" });
+    expect(result.spacing).toMatchObject({ "1": "4px", "2": "8px" });
+    expect(result.borderRadius).toMatchObject({ lg: "12px" });
+  });
+
+  it("returns an empty object when no token blocks are present", () => {
+    expect(parseTailwindConfig("export default { plugins: [] }")).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CSS parser
+// ---------------------------------------------------------------------------
+describe("parseCss", () => {
+  it("extracts custom properties and @font-face / Google Fonts families", () => {
+    const css = `
+:root {
+  --brand-primary: #123456;
+  --space-2: 0.5rem;
+}
+@font-face {
+  font-family: "Custom Sans";
+  src: url(/fonts/custom.woff2);
+}
+@import url('fonts.googleapis.com/css2?family=Inter+Tight&display=swap');
+`;
+    const result = parseCss(css);
+    expect(result.cssCustomProperties).toEqual({
+      "--brand-primary": "#123456",
+      "--space-2": "0.5rem",
+    });
+    expect(result.fonts).toContain("Custom Sans");
+    // Google Fonts family is URL-decoded and '+' becomes a space.
+    expect(result.fonts).toContain("Inter Tight");
+  });
+
+  it("dedupes fonts and returns undefined sections when nothing is found", () => {
+    const css = `
+@font-face { font-family: "Dup"; }
+@font-face { font-family: "Dup"; }
+`;
+    const result = parseCss(css);
+    expect(result.fonts).toEqual(["Dup"]);
+    // No CSS variables present → undefined, not an empty object.
+    expect(result.cssCustomProperties).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Styling framework detection
+// ---------------------------------------------------------------------------
+describe("detectStylingFramework", () => {
+  it("detects tailwind from dependencies or devDependencies", () => {
+    expect(
+      detectStylingFramework(
+        JSON.stringify({ dependencies: { tailwindcss: "^4.0.0" } }),
+      ),
+    ).toBe("tailwindcss");
+    expect(
+      detectStylingFramework(
+        JSON.stringify({ devDependencies: { "@tailwindcss/cli": "^4.0.0" } }),
+      ),
+    ).toBe("tailwindcss");
+  });
+
+  it("detects emotion, styled-components, sass, and vanilla-extract", () => {
+    expect(
+      detectStylingFramework(
+        JSON.stringify({ dependencies: { "@emotion/react": "11" } }),
+      ),
+    ).toBe("emotion");
+    expect(
+      detectStylingFramework(
+        JSON.stringify({ dependencies: { "styled-components": "6" } }),
+      ),
+    ).toBe("styled-components");
+    expect(
+      detectStylingFramework(
+        JSON.stringify({ devDependencies: { "node-sass": "9" } }),
+      ),
+    ).toBe("sass");
+    expect(
+      detectStylingFramework(
+        JSON.stringify({ dependencies: { "@vanilla-extract/css": "1" } }),
+      ),
+    ).toBe("vanilla-extract");
+  });
+
+  it("returns undefined for unknown deps and for invalid JSON", () => {
+    expect(
+      detectStylingFramework(JSON.stringify({ dependencies: { react: "19" } })),
+    ).toBeUndefined();
+    expect(detectStylingFramework("{not valid json")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Code analysis state + helpers
+// ---------------------------------------------------------------------------
+describe("addFont", () => {
+  it("normalizes quotes/whitespace and dedupes case-insensitively", () => {
+    const state = createCodeAnalysisState();
+    addFont(state, '  "Inter" ', "a.css");
+    addFont(state, "inter", "b.css"); // duplicate (case-insensitive)
+    addFont(state, "Roboto");
+    expect(state.fonts).toEqual([
+      { family: "Inter", source: "a.css" },
+      { family: "Roboto", source: undefined },
+    ]);
+  });
+
+  it("ignores empty font names", () => {
+    const state = createCodeAnalysisState();
+    addFont(state, "   ", "x.css");
+    expect(state.fonts).toEqual([]);
+  });
+});
+
+describe("extractCssVars", () => {
+  it("classifies custom properties into colors / spacing / radius buckets", () => {
+    const state = createCodeAnalysisState();
+    extractCssVars(
+      state,
+      `:root {
+        --primary-color: #ff0000;
+        --gap-md: 12px;
+        --radius-lg: 8px;
+        --z-index: 10;
+      }`,
+    );
+    // Everything goes into cssCustomProperties…
+    expect(Object.keys(state.cssCustomProperties)).toEqual([
+      "--primary-color",
+      "--gap-md",
+      "--radius-lg",
+      "--z-index",
+    ]);
+    // …and color/spacing/radius are also bucketed by name heuristics.
+    expect(state.colors["--primary-color"]).toBe("#ff0000");
+    expect(state.spacing["--gap-md"]).toBe("12px");
+    expect(state.borderRadius["--radius-lg"]).toBe("8px");
+    // Unclassifiable var stays only in the generic map.
+    expect(state.colors["--z-index"]).toBeUndefined();
+    expect(state.spacing["--z-index"]).toBeUndefined();
+  });
+});
+
+describe("analyzeCodeFile (routing by filename)", () => {
+  it("routes a tailwind config and records the styling framework", () => {
+    const state = createCodeAnalysisState();
+    analyzeCodeFile(
+      state,
+      "src/tailwind.config.ts",
+      `export default { theme: { colors: { brand: "#abcdef" } } };`,
+    );
+    expect(state.stylingFramework).toBe("tailwind");
+    expect(state.colors.brand).toBe("#abcdef");
+    expect(state.rawExtracts.at(-1)?.type).toBe("tailwind-config");
+  });
+
+  it("routes package.json to dependency detection", () => {
+    const state = createCodeAnalysisState();
+    analyzeCodeFile(
+      state,
+      "package.json",
+      JSON.stringify({ dependencies: { tailwindcss: "^4" } }),
+    );
+    expect(state.stylingFramework).toBe("tailwind");
+    expect(state.rawExtracts.at(-1)).toMatchObject({
+      type: "package-json",
+      data: { stylingDeps: ["tailwind"] },
+    });
+  });
+
+  it("routes a .css file through the CSS analyzer", () => {
+    const state = createCodeAnalysisState();
+    analyzeCodeFile(
+      state,
+      "app/globals.css",
+      `:root { --accent-color: #00ff00; } @font-face { font-family: "Brand"; }`,
+    );
+    expect(state.colors["--accent-color"]).toBe("#00ff00");
+    expect(state.fonts.map((f) => f.family)).toContain("Brand");
+    expect(state.rawExtracts.at(-1)?.type).toBe("css");
+  });
+
+  it("infers a styling framework from .scss / .less extensions", () => {
+    const scss = createCodeAnalysisState();
+    analyzeCodeFile(scss, "styles/main.scss", "$primary: #fff;");
+    expect(scss.stylingFramework).toBe("sass");
+
+    const less = createCodeAnalysisState();
+    analyzeCodeFile(less, "styles/main.less", "@primary: #fff;");
+    expect(less.stylingFramework).toBe("less");
+  });
+
+  it("records a parse error for malformed JSON themes instead of throwing", () => {
+    const state = createCodeAnalysisState();
+    expect(() =>
+      analyzeCodeFile(state, "theme.json", "{ not: valid"),
+    ).not.toThrow();
+    expect(state.rawExtracts.at(-1)).toMatchObject({
+      type: "json-theme",
+      data: { parseError: true },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Document analysis helpers
+// ---------------------------------------------------------------------------
+describe("document helpers", () => {
+  it("unique trims and dedupes", () => {
+    expect(unique([" a ", "a", "b "])).toEqual(["a", "b"]);
+  });
+
+  it("extracts hex and named colors, lowercasing named ones", () => {
+    const colors = extractDocumentColors(
+      "Our brand uses #FF0000 and a deep Navy, plus #abc.",
+    );
+    expect(colors).toContain("#FF0000");
+    expect(colors).toContain("#abc");
+    expect(colors).toContain("navy");
+  });
+
+  it("extracts known font family names from prose", () => {
+    const fonts = extractDocumentFonts(
+      "Headlines use Playfair Display, body copy uses Inter.",
+    );
+    expect(fonts).toEqual(
+      expect.arrayContaining(["Playfair Display", "Inter"]),
+    );
+  });
+
+  it("classifyFile maps file-type hints to content categories", () => {
+    expect(classifyFile("application/pdf")).toBe("pdf");
+    expect(classifyFile("MyDeck.pptx")).toBe("presentation");
+    expect(classifyFile("report.docx")).toBe("document");
+    expect(classifyFile("data.csv")).toBe("spreadsheet");
+    expect(classifyFile("notes.txt")).toBe("other");
+  });
+
+  it("suggestionsForType returns per-type guidance and a no-text hint when empty", () => {
+    const withText = suggestionsForType("presentation", true);
+    expect(withText.length).toBeGreaterThan(0);
+    expect(withText.some((s) => /no text content/i.test(s))).toBe(false);
+
+    const noText = suggestionsForType("presentation", false);
+    expect(noText.some((s) => /no text content/i.test(s))).toBe(true);
   });
 });

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -18,6 +18,7 @@ import {
   resolveBuiltInAuthMarketing,
   type AuthMarketingContent,
 } from "./auth-marketing.js";
+import { AUTH_REDIRECT_QUERY_PARAM } from "../shared/auth-redirect-url.js";
 
 function hasGoogleOAuth(): boolean {
   return !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
@@ -1097,7 +1098,7 @@ ${
     function __anWithAuthCacheBypass(ret) {
       try {
         var url = new URL(ret || __anPath('/'), window.location.origin);
-        url.searchParams.set('__an_auth_redirect', Date.now().toString(36));
+        url.searchParams.set('${AUTH_REDIRECT_QUERY_PARAM}', Date.now().toString(36));
         return url.pathname + url.search + url.hash;
       } catch(e) {
         var fallback = ret || __anPath('/');
@@ -1105,7 +1106,7 @@ ${
         var beforeHash = hashIndex === -1 ? fallback : fallback.slice(0, hashIndex);
         var hash = hashIndex === -1 ? '' : fallback.slice(hashIndex);
         var sep = beforeHash.indexOf('?') === -1 ? '?' : '&';
-        return beforeHash + sep + '__an_auth_redirect=' + Date.now().toString(36) + hash;
+        return beforeHash + sep + '${AUTH_REDIRECT_QUERY_PARAM}=' + Date.now().toString(36) + hash;
       }
     }
     function __anRedirectToSignedInApp(ret) {

--- a/packages/core/src/shared/auth-redirect-url.ts
+++ b/packages/core/src/shared/auth-redirect-url.ts
@@ -1,0 +1,1 @@
+export const AUTH_REDIRECT_QUERY_PARAM = "__an_auth_redirect";

--- a/packages/core/src/templates/default/AGENTS.md
+++ b/packages/core/src/templates/default/AGENTS.md
@@ -93,6 +93,7 @@ You do NOT get auto-injected screen state. **Call `pnpm action view-screen` at t
 - Use `db-exec UPDATE` only when no domain action exists and you need a small ad-hoc change.
 - Use `db-patch` when you only need to tweak a small slice of a **large** text/JSON column (documents, slide HTML, dashboard/form JSON). It saves tokens by sending `{find, replace}` instead of re-transmitting the whole column. Targets exactly one row per call — narrow `--where` by primary key. Supports `--edits '[{find,replace},...]'` for batch edits and `--all` for replace-every-occurrence.
 - If a template-specific action exists (e.g. `edit-document`, `update-slide`), prefer it — those also push live updates to any open collaborative editor.
+- **Database admin (dev only):** in development, `db-admin-query` / `db-admin-mutate` / `db-admin-rows` / `db-admin-tables` / `db-admin-schema` give **unscoped, full-database** access to ANY table — including framework tables and tables without `owner_email`/`org_id`. Prefer these over `db-exec`/`db-query` for database-admin work and for any non-owner-scoped table: `db-exec`/`db-query` auto-scope to the current user and return **0 rows** on unscoped tables. These mirror the in-app Database admin UI, so prompts and the UI do the same thing.
 
 ## Skills
 

--- a/packages/core/src/usage/store.spec.ts
+++ b/packages/core/src/usage/store.spec.ts
@@ -1,9 +1,80 @@
-import { describe, expect, it } from "vitest";
-import {
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Real in-memory sqlite behind the raw getDbExec client so recordUsage /
+// getUserUsageCents / getUsageSummary exercise genuine aggregation + scoping.
+// A fresh DB per test keeps the module-level _initPromise (CREATE TABLE IF NOT
+// EXISTS) idempotent across tests.
+let sqlite: Database.Database;
+
+const rawClient = {
+  execute: vi.fn(async (input: string | { sql: string; args?: unknown[] }) => {
+    if (typeof input === "string") {
+      sqlite.exec(input);
+      return { rows: [], rowsAffected: 0 };
+    }
+    const stmt = sqlite.prepare(input.sql);
+    const args = (input.args ?? []) as unknown[];
+    if (/^\s*select/i.test(input.sql)) {
+      return { rows: stmt.all(...args), rowsAffected: 0 };
+    }
+    const info = stmt.run(...args);
+    return { rows: [], rowsAffected: info.changes };
+  }),
+};
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => rawClient,
+  intType: () => "INTEGER",
+  isPostgres: () => false,
+}));
+
+const {
   builderCreditsFromCostCents,
   calculateCost,
   usageBillingForEngine,
-} from "./store.js";
+  recordUsage,
+  getUserUsageCents,
+  getUsageSummary,
+} = await import("./store.js");
+
+beforeEach(() => {
+  // recordUsage derives its primary key from Date.now()*1000 + random(0..999).
+  // Under a fast loop Date.now() is constant and the 1000-value random space
+  // collides, producing a UNIQUE-constraint failure. Drive Math.random from a
+  // monotonic counter so every insert in a test gets a distinct id without
+  // touching source behavior. (Real Postgres would not hit this in practice;
+  // we are only removing test-induced flakiness.)
+  let randomCursor = 0;
+  vi.spyOn(Math, "random").mockImplementation(() => {
+    randomCursor = (randomCursor + 1) % 1000;
+    return randomCursor / 1000;
+  });
+
+  sqlite = new Database(":memory:");
+  // The store caches CREATE TABLE in a module-level _initPromise that only runs
+  // once for the whole file, so create the table per fresh DB ourselves.
+  sqlite.exec(`CREATE TABLE IF NOT EXISTS token_usage (
+    id INTEGER PRIMARY KEY,
+    owner_email TEXT NOT NULL,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_cents_x100 INTEGER NOT NULL DEFAULT 0,
+    model TEXT NOT NULL DEFAULT '',
+    label TEXT NOT NULL DEFAULT 'chat',
+    app TEXT NOT NULL DEFAULT '',
+    created_at INTEGER NOT NULL
+  )`);
+  delete process.env.AGENT_APP;
+  delete process.env.APP_NAME;
+});
+
+afterEach(() => {
+  sqlite.close();
+  vi.restoreAllMocks();
+});
 
 describe("usage billing", () => {
   it("maps Builder hard costs to agent credits with margin", () => {
@@ -15,13 +86,298 @@ describe("usage billing", () => {
     expect(builderCreditsFromCostCents(0.001)).toBe(0.001);
   });
 
+  it("treats non-positive / non-finite cents as zero credits", () => {
+    expect(builderCreditsFromCostCents(0)).toBe(0);
+    expect(builderCreditsFromCostCents(-5)).toBe(0);
+    expect(builderCreditsFromCostCents(Number.NaN)).toBe(0);
+    expect(builderCreditsFromCostCents(Infinity)).toBe(0);
+  });
+
   it("uses Builder credit display only for the Builder engine", () => {
     expect(usageBillingForEngine("builder").unit).toBe("builder-credits");
     expect(usageBillingForEngine("anthropic").unit).toBe("usd");
     expect(usageBillingForEngine(null).unit).toBe("usd");
+    expect(usageBillingForEngine(undefined).unit).toBe("usd");
   });
+});
 
+describe("calculateCost pricing tiers", () => {
   it("does not round tiny completed calls down to zero spend", () => {
     expect(calculateCost(10, 2, "claude-sonnet-4-5")).toBe(1);
+  });
+
+  it("returns 0 for a call with no tokens", () => {
+    expect(calculateCost(0, 0, "claude-opus-4")).toBe(0);
+  });
+
+  it("prices opus higher than sonnet which is higher than haiku for the same tokens", () => {
+    // 1M input + 1M output, centicents.
+    const opus = calculateCost(1_000_000, 1_000_000, "claude-opus-4-1");
+    const sonnet = calculateCost(1_000_000, 1_000_000, "claude-sonnet-4-5");
+    const haiku = calculateCost(1_000_000, 1_000_000, "claude-haiku-4");
+    // opus = (1500 + 7500) * 100 = 900000 centicents.
+    expect(opus).toBe(900_000);
+    // sonnet (default) = (300 + 1500) * 100 = 180000.
+    expect(sonnet).toBe(180_000);
+    // haiku = (100 + 500) * 100 = 60000.
+    expect(haiku).toBe(60_000);
+    expect(opus).toBeGreaterThan(sonnet);
+    expect(sonnet).toBeGreaterThan(haiku);
+  });
+
+  it("falls back to sonnet pricing for unknown models", () => {
+    expect(calculateCost(1_000_000, 0, "some-future-model")).toBe(
+      calculateCost(1_000_000, 0, "claude-sonnet-4-5"),
+    );
+  });
+
+  it("prices cache read cheaper than cache write", () => {
+    const read = calculateCost(0, 0, "claude-sonnet-4-5", 1_000_000, 0);
+    const write = calculateCost(0, 0, "claude-sonnet-4-5", 0, 1_000_000);
+    // sonnet cacheRead 30, cacheWrite 375 → centicents.
+    expect(read).toBe(3_000);
+    expect(write).toBe(37_500);
+    expect(write).toBeGreaterThan(read);
+  });
+});
+
+describe("recordUsage", () => {
+  it("skips no-op writes when no tokens flowed", async () => {
+    await recordUsage({
+      ownerEmail: "a@example.com",
+      inputTokens: 0,
+      outputTokens: 0,
+      model: "claude-sonnet-4-5",
+    });
+    const inserts = rawClient.execute.mock.calls.filter((c) => {
+      const input = c[0] as string | { sql: string };
+      const sql = typeof input === "string" ? input : input.sql;
+      return /INSERT\s+INTO\s+token_usage/i.test(sql);
+    });
+    expect(inserts).toHaveLength(0);
+  });
+
+  it("persists a row and rolls it into the per-user total", async () => {
+    await recordUsage({
+      ownerEmail: "a@example.com",
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      model: "claude-sonnet-4-5",
+    });
+    // sonnet input 300/M → 30000 centicents = $3.00.
+    await expect(getUserUsageCents("a@example.com")).resolves.toBeCloseTo(300);
+  });
+
+  it("records a cache-only call (no input/output) instead of skipping it", async () => {
+    // The no-op guard checks cache tokens too, so a prompt-cache-heavy call
+    // with zero billable input/output must still be persisted and priced.
+    await recordUsage({
+      ownerEmail: "a@example.com",
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 1_000_000,
+      cacheWriteTokens: 0,
+      model: "claude-sonnet-4-5",
+    });
+    const summary = await getUsageSummary({ ownerEmail: "a@example.com" });
+    expect(summary.totalCalls).toBe(1);
+    expect(summary.totalCacheReadTokens).toBe(1_000_000);
+    // sonnet cacheRead 30/M → 3000 centicents; getUserUsageCents = /100 = 30.
+    await expect(getUserUsageCents("a@example.com")).resolves.toBeCloseTo(30);
+  });
+
+  it("supports the legacy positional 4-arg signature", async () => {
+    await recordUsage("legacy@example.com", 1_000_000, 0, "claude-sonnet-4-5");
+    await expect(getUserUsageCents("legacy@example.com")).resolves.toBeCloseTo(
+      300,
+    );
+  });
+
+  it("defaults label to 'chat' and resolves app from AGENT_APP env", async () => {
+    process.env.AGENT_APP = "mail";
+    await recordUsage({
+      ownerEmail: "a@example.com",
+      inputTokens: 100,
+      outputTokens: 50,
+      model: "claude-sonnet-4-5",
+    });
+    const summary = await getUsageSummary({ ownerEmail: "a@example.com" });
+    expect(summary.byLabel.map((b) => b.key)).toContain("chat");
+    expect(summary.byApp.map((b) => b.key)).toContain("mail");
+  });
+
+  it("explicit label/app override the env fallback", async () => {
+    process.env.AGENT_APP = "mail";
+    await recordUsage({
+      ownerEmail: "a@example.com",
+      inputTokens: 100,
+      outputTokens: 50,
+      model: "claude-sonnet-4-5",
+      label: "automation",
+      app: "calendar",
+    });
+    const summary = await getUsageSummary({ ownerEmail: "a@example.com" });
+    expect(summary.byLabel.map((b) => b.key)).toEqual(["automation"]);
+    expect(summary.byApp.map((b) => b.key)).toEqual(["calendar"]);
+  });
+});
+
+describe("getUserUsageCents scoping", () => {
+  it("never sums another owner's spend into a user's total", async () => {
+    await recordUsage({
+      ownerEmail: "alice@example.com",
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      model: "claude-sonnet-4-5",
+    });
+    await recordUsage({
+      ownerEmail: "bob@example.com",
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      model: "claude-opus-4-1",
+    });
+    await expect(getUserUsageCents("alice@example.com")).resolves.toBeCloseTo(
+      300,
+    );
+    // Bob's opus spend is far higher and must not leak into Alice's number.
+    const bob = await getUserUsageCents("bob@example.com");
+    expect(bob).toBeGreaterThan(300);
+    await expect(getUserUsageCents("nobody@example.com")).resolves.toBe(0);
+  });
+});
+
+describe("getUsageSummary", () => {
+  it("aggregates totals and buckets and is scoped to the owner", async () => {
+    // Alice: two chat calls + one automation call.
+    await recordUsage({
+      ownerEmail: "alice@example.com",
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      model: "claude-sonnet-4-5",
+      label: "chat",
+      app: "mail",
+    });
+    await recordUsage({
+      ownerEmail: "alice@example.com",
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      model: "claude-sonnet-4-5",
+      label: "chat",
+      app: "mail",
+    });
+    await recordUsage({
+      ownerEmail: "alice@example.com",
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      model: "claude-opus-4-1",
+      label: "automation",
+      app: "calendar",
+    });
+    // Bob's usage must not appear in Alice's summary.
+    await recordUsage({
+      ownerEmail: "bob@example.com",
+      inputTokens: 5_000_000,
+      outputTokens: 0,
+      model: "claude-opus-4-1",
+      label: "chat",
+      app: "mail",
+    });
+
+    const summary = await getUsageSummary({ ownerEmail: "alice@example.com" });
+
+    expect(summary.totalCalls).toBe(3);
+    expect(summary.totalInputTokens).toBe(3_000_000);
+
+    // byLabel buckets are owner-scoped and ordered by cents desc — automation
+    // (opus) outweighs the two sonnet chat calls.
+    const labels = Object.fromEntries(summary.byLabel.map((b) => [b.key, b]));
+    expect(labels.chat.calls).toBe(2);
+    expect(labels.automation.calls).toBe(1);
+    expect(summary.byLabel[0].key).toBe("automation");
+
+    // byApp similarly scoped — only Alice's apps.
+    expect(summary.byApp.map((b) => b.key).sort()).toEqual([
+      "calendar",
+      "mail",
+    ]);
+
+    // byModel has both models, opus first (more expensive).
+    expect(summary.byModel[0].key).toContain("opus");
+
+    // Total cents equals the sum across buckets.
+    const labelCentsSum = summary.byLabel.reduce((n, b) => n + b.cents, 0);
+    expect(summary.totalCents).toBeCloseTo(labelCentsSum);
+
+    // billing mode defaults to USD.
+    expect(summary.billing?.unit).toBe("usd");
+  });
+
+  it("filters by sinceMs while recent ignores the window", async () => {
+    const now = Date.now();
+    // Insert a stale row directly (200 days ago) and a fresh row via the API.
+    sqlite.exec(`CREATE TABLE IF NOT EXISTS token_usage (
+        id INTEGER PRIMARY KEY,
+        owner_email TEXT NOT NULL,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+        cost_cents_x100 INTEGER NOT NULL DEFAULT 0,
+        model TEXT NOT NULL DEFAULT '',
+        label TEXT NOT NULL DEFAULT 'chat',
+        app TEXT NOT NULL DEFAULT '',
+        created_at INTEGER NOT NULL
+      )`);
+    const oldTs = now - 200 * 86_400_000;
+    sqlite
+      .prepare(
+        `INSERT INTO token_usage
+          (id, owner_email, input_tokens, output_tokens, cost_cents_x100, model, label, app, created_at)
+         VALUES (1, 'alice@example.com', 1000000, 0, 5000, 'claude-sonnet-4-5', 'chat', 'mail', ?)`,
+      )
+      .run(oldTs);
+
+    await recordUsage({
+      ownerEmail: "alice@example.com",
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      model: "claude-sonnet-4-5",
+    });
+
+    // Default 30-day window excludes the 200-day-old row.
+    const windowed = await getUsageSummary({ ownerEmail: "alice@example.com" });
+    expect(windowed.totalCalls).toBe(1);
+    // recent (no window filter) sees both rows.
+    expect(windowed.recent.length).toBe(2);
+    expect(windowed.recent[0].createdAt).toBeGreaterThan(
+      windowed.recent[1].createdAt,
+    );
+
+    // Widening sinceMs to 1 year pulls the old row into the aggregates.
+    const wide = await getUsageSummary({
+      ownerEmail: "alice@example.com",
+      sinceMs: now - 365 * 86_400_000,
+    });
+    expect(wide.totalCalls).toBe(2);
+
+    // byDay buckets the two rows under their (distinct) UTC dates, ascending —
+    // the 200-day-old row sorts before today.
+    expect(wide.byDay).toHaveLength(2);
+    expect(wide.byDay.map((d) => d.date)).toEqual(
+      [...wide.byDay.map((d) => d.date)].sort(),
+    );
+    expect(wide.byDay[0].date).toBe(new Date(oldTs).toISOString().slice(0, 10));
+    expect(wide.byDay.reduce((n, d) => n + d.calls, 0)).toBe(2);
+  });
+
+  it("returns empty buckets and zeroed totals for an owner with no usage", async () => {
+    const summary = await getUsageSummary({ ownerEmail: "ghost@example.com" });
+    expect(summary.totalCalls).toBe(0);
+    expect(summary.totalCents).toBe(0);
+    expect(summary.byLabel).toEqual([]);
+    expect(summary.byModel).toEqual([]);
+    expect(summary.byApp).toEqual([]);
+    expect(summary.byDay).toEqual([]);
+    expect(summary.recent).toEqual([]);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,7 +232,7 @@ importers:
         version: 3.8.3(ai@6.0.168(zod@4.3.6))(zod@4.3.6)
       better-auth:
         specifier: 1.6.0
-        version: 1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)(vitest@4.1.5)
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -357,6 +357,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
         version: 4.3.0(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/coverage-v8':
+        specifier: 4.1.5
+        version: 4.1.5(vitest@4.1.5)
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -401,7 +404,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       ws:
         specifier: ^8.18.0
         version: 8.20.0
@@ -646,7 +649,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/docs:
     dependencies:
@@ -737,7 +740,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(happy-dom@20.8.9)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/embedding:
     devDependencies:
@@ -832,7 +835,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.13(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.13(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/mobile-app:
     dependencies:
@@ -954,7 +957,7 @@ importers:
         version: 2.11.11(solid-js@1.9.12)(vite@8.0.13(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.13(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.13(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/scheduling:
     dependencies:
@@ -1003,7 +1006,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.13(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.13(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/shared-app-config:
     devDependencies:
@@ -1262,7 +1265,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   templates/assets:
     dependencies:
@@ -1772,7 +1775,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   templates/calls:
     dependencies:
@@ -2545,7 +2548,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   templates/design:
     dependencies:
@@ -2771,7 +2774,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   templates/dispatch:
     dependencies:
@@ -2853,7 +2856,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   templates/forms:
     dependencies:
@@ -3248,7 +3251,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   templates/macros:
     dependencies:
@@ -3459,7 +3462,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   templates/mail:
     dependencies:
@@ -3718,7 +3721,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   templates/meeting-notes:
     dependencies:
@@ -4424,7 +4427,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   templates/slides:
     dependencies:
@@ -4767,7 +4770,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   templates/starter:
     dependencies:
@@ -5216,7 +5219,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   templates/voice:
     dependencies:
@@ -6341,6 +6344,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@better-auth/core@1.6.0':
     resolution: {integrity: sha512-LmdPTyKRDn6iCcXBGlOHOyzpJl1W/3w64zrEbhhHaWmtdpzQWlY8awlWBoDTL9eL4TAusr9dDvwIbMYTvEqaeA==}
@@ -12159,6 +12166,15 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+    peerDependencies:
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -12412,6 +12428,9 @@ packages:
 
   assistant-stream@0.3.9:
     resolution: {integrity: sha512-lemXFg+VFwKiAjqj3sIXF67d5Gy42ghVLYqJOFjhrT5+nPMrBMluFtoZSe/M7ZxZm5jNklIGRbkk6UU3T32iEg==}
+
+  ast-v8-to-istanbul@1.0.2:
+    resolution: {integrity: sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -14612,6 +14631,9 @@ packages:
   html-entities@2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -14885,6 +14907,14 @@ packages:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
 
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   its-fine@2.0.0:
     resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
     peerDependencies:
@@ -14965,6 +14995,9 @@ packages:
 
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -15334,6 +15367,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   make-fetch-happen@14.0.3:
     resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
@@ -19596,7 +19636,6 @@ snapshots:
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
-    optional: true
 
   '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0)':
     dependencies:
@@ -20033,6 +20072,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)':
     dependencies:
@@ -24487,7 +24528,7 @@ snapshots:
   '@react-native/codegen@0.83.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       glob: 13.0.6
       hermes-parser: 0.32.0
       invariant: 2.2.4
@@ -26704,7 +26745,7 @@ snapshots:
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
   '@types/babel__traverse@7.28.0':
@@ -27158,6 +27199,20 @@ snapshots:
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
 
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.5
+      ast-v8-to-istanbul: 1.0.2
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -27502,6 +27557,12 @@ snapshots:
       nanoid: 5.1.9
       secure-json-parse: 4.1.0
 
+  ast-v8-to-istanbul@1.0.2:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
   astral-regex@2.0.0:
     optional: true
 
@@ -27698,7 +27759,7 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))):
+  better-auth@1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)(vitest@4.1.5):
     dependencies:
       '@better-auth/core': 1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.0(@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))
@@ -27725,7 +27786,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       solid-js: 1.9.12
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -30195,6 +30256,8 @@ snapshots:
 
   html-entities@2.3.3: {}
 
+  html-escaper@2.0.2: {}
+
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
@@ -30428,12 +30491,23 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
 
   its-fine@2.0.0(@types/react@19.2.14)(react@19.2.5):
     dependencies:
@@ -30539,6 +30613,8 @@ snapshots:
   joycon@3.1.1: {}
 
   js-base64@3.7.8: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -30937,6 +31013,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.0
 
   make-fetch-happen@14.0.3:
     dependencies:
@@ -31478,7 +31564,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
       metro: 0.83.6
@@ -31520,7 +31606,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -34955,7 +35041,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.13(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(happy-dom@20.8.9)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -34980,12 +35066,13 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.17
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
       happy-dom: 20.8.9
       jsdom: 29.0.2(@noble/hashes@2.0.1)(canvas@3.2.3)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.13(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.13(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.13(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -35010,12 +35097,13 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.12.2
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
       happy-dom: 20.8.9
       jsdom: 29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -35040,6 +35128,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.12.2
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
       happy-dom: 20.8.9
       jsdom: 29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3)
     transitivePeerDependencies:

--- a/scripts/guard-public-packages.ts
+++ b/scripts/guard-public-packages.ts
@@ -7,11 +7,19 @@ const repoRoot = path.resolve(
   "..",
 );
 
+// Packages that are NOT published to npm and therefore exempt from the
+// publish-readiness checks below. Apps (desktop-app/docs/frame/mobile-app) plus
+// internal-only libraries that are consumed exclusively via `workspace:` by the
+// apps/templates above and have never been published (code-agents-ui,
+// shared-app-config). These are also listed in `.changeset/config.json` `ignore`
+// so version-packages never attempts to publish them.
 const packageAppAllowlist = new Set([
   "@agent-native/desktop-app",
   "@agent-native/docs",
   "@agent-native/frame",
   "@agent-native/mobile-app",
+  "@agent-native/code-agents-ui",
+  "@agent-native/shared-app-config",
 ]);
 
 type PackageJson = {

--- a/templates/analytics/.agents/skills/adhoc-analysis/SKILL.md
+++ b/templates/analytics/.agents/skills/adhoc-analysis/SKILL.md
@@ -20,6 +20,14 @@ Use the ad-hoc analysis workflow when:
 
 For simple one-off questions (e.g., "how many signups last week?"), just query the data and answer in chat — no need to save an analysis.
 
+If the user asks for an analysis output that needs a bespoke interactive
+surface, custom visualization, multi-step workflow, or UI that cannot be
+faithfully represented as saved-analysis Markdown, generated chart images, and
+structured `resultData`, create an extension instead of forcing the request into
+the saved-analysis format. In production mode, call `create-extension`
+automatically and tell the user the requested analysis needed bespoke UI/code, so
+you built it as an extension.
+
 ## Workflow
 
 ### Step 1: Understand the Question

--- a/templates/analytics/.agents/skills/dashboard-management/SKILL.md
+++ b/templates/analytics/.agents/skills/dashboard-management/SKILL.md
@@ -58,6 +58,22 @@ pnpm action navigate --view=adhoc --dashboardId=weekly-metrics
 
 The save path dry-runs BigQuery panels before persisting. If validation returns a provider error, fix the query and retry. Never work around validation by writing directly to a table.
 
+## When To Use An Extension Instead
+
+Native Analytics dashboards are JSON configs rendered by the built-in dashboard
+components. Use `update-dashboard` only when the request fits that model:
+standard panels, supported chart types, filters, variables, sections, and grid
+layout.
+
+If the user asks for a dashboard or analytical surface that needs bespoke UI or
+code beyond the dashboard JSON/component model, create an extension instead.
+Examples include custom interaction flows, non-standard visualizations, complex
+multi-step workflows, highly custom layouts, custom client-side state, or a
+dashboard-like app that needs behavior the built-in renderer cannot express. In
+production mode, call `create-extension` automatically and then tell the user
+that the request needed a bespoke surface, so you built it as an extension
+rather than forcing it into a native dashboard config.
+
 ## Config Shape
 
 ```jsonc

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -21,6 +21,11 @@ details live in `.agents/skills/`.
   and existing credential/integration flow.
 - Dashboards and charts should be useful, explainable, and scoped to the user's
   question. Avoid decorative metrics.
+- Native dashboards and saved analyses are constrained artifacts. If a requested
+  dashboard, analysis surface, visualization, interaction model, custom layout,
+  or bespoke workflow cannot be done faithfully with the built-in dashboard JSON
+  config/components or saved-analysis markdown/chart format, automatically build
+  it as an extension instead and tell the user why.
 - Use framework sharing and access helpers for dashboards, analyses, and saved
   resources.
 

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -72,19 +72,27 @@ export default createAgentChatPlugin({
       "For schema questions, prefer data-dictionary entries and configured warehouse schemas over assumptions; use `search-bigquery-schema` for BigQuery metadata before inventing datasets, tables, or columns. " +
       "Never substitute fabricated numbers for a failed query or unavailable provider. It is fine to ask a clarifying question, provide a plan, or say exactly which source is unavailable as long as you do not present metrics or source-record conclusions without evidence.\n" +
       "</data-source-guidance>";
+    const artifactGuidance =
+      "<analytics-artifact-guidance>\n" +
+      "Native Analytics dashboards and saved analyses are constrained artifacts: dashboards are JSON configs rendered by the built-in dashboard components, and analyses are Markdown reports with generated chart images plus structured resultData. " +
+      "If the user's requested dashboard, analysis surface, visualization, interaction model, custom layout, or bespoke workflow cannot be faithfully represented within those native components/config fields, do not hand-wave, force an approximate JSON dashboard, or route to source-code changes. In production mode, automatically create a sandboxed extension with `create-extension` instead, using Alpine.js HTML and the available app/data helpers. " +
+      "After creating the extension, briefly tell the user that the request needed bespoke UI/code beyond the native Analytics dashboard or analysis format, so you built it as an extension.\n" +
+      "</analytics-artifact-guidance>";
 
     try {
       const scope = await resolveSettingsScope(event);
       const all = await listScopedSettingRecords(scope, DATA_DICT_PREFIX);
       const entries = Object.values(all) as Array<Record<string, unknown>>;
       const dict = renderDataDictionary(entries);
-      return dict ? `${sourceGuidance}\n\n${dict}` : sourceGuidance;
+      return dict
+        ? `${sourceGuidance}\n\n${artifactGuidance}\n\n${dict}`
+        : `${sourceGuidance}\n\n${artifactGuidance}`;
     } catch (err) {
       console.warn(
         "[analytics] data dictionary context failed:",
         err instanceof Error ? err.message : err,
       );
-      return sourceGuidance;
+      return `${sourceGuidance}\n\n${artifactGuidance}`;
     }
   },
   mentionProviders: {

--- a/templates/assets/app/routes/_index.tsx
+++ b/templates/assets/app/routes/_index.tsx
@@ -45,7 +45,6 @@ import {
   SelectItem,
   SelectSeparator,
   SelectTrigger,
-  SelectValue,
 } from "@/components/ui/select";
 import { CreateLibraryDialog } from "@/components/library/CreateLibraryDialog";
 import { LibraryCard } from "@/components/library/LibraryCard";
@@ -85,6 +84,8 @@ const CUSTOM_RATIOS_KEY = "assets.customAspectRatios";
 const MAX_TEXT_CONTEXT_FILE_CHARS = 12_000;
 const MAX_TEXT_CONTEXT_TOTAL_CHARS = 24_000;
 const MAX_TEXT_CONTEXT_READ_BYTES_PER_CHAR = 4;
+const COMPOSER_SELECT_TRIGGER_CLASS =
+  "h-7 w-auto min-w-0 max-w-full rounded-md border-0 bg-transparent px-1.5 py-1 text-xs font-medium text-muted-foreground shadow-none ring-offset-transparent transition hover:bg-accent/50 hover:text-foreground focus:ring-0 focus:ring-offset-0 sm:px-2 data-[placeholder]:text-muted-foreground [&>svg]:ml-1 [&>svg]:size-3.5 [&>svg]:opacity-60";
 
 type ImageGenerationConfig = {
   builderEnabled?: boolean;
@@ -216,10 +217,10 @@ function GenerationSetupNotice({ config }: { config: ImageGenerationConfig }) {
         ? "Add an OpenAI or Gemini key for image generation."
         : "Add S3-compatible storage for originals, thumbnails, and exports.";
   const title = builderAvailable
-    ? "Connect Builder to create assets"
+    ? "Connect generation models"
     : "Finish asset setup";
   const description = builderAvailable
-    ? "One click enables image generation and asset storage. No provider keys needed."
+    ? "Connect to enable image generation, video generation, LLMs, and asset storage. Free credits and no keys needed."
     : "This deployment uses manual provider setup. Add the missing pieces in Settings.";
   const showContent = !!issueMessage || !!flow.error || builderAvailable;
 
@@ -463,6 +464,13 @@ function HomeGeneratePanel({
       return;
     }
     chooseLibrary(value);
+  };
+
+  const handleMediaTypeChange = (value: "image" | "video") => {
+    setMediaType(value);
+    if (value === "video" && aspectRatio !== "16:9" && aspectRatio !== "9:16") {
+      setAspectRatio("16:9");
+    }
   };
 
   const createPresetLibrary = (presetId: string) => {
@@ -778,6 +786,7 @@ function HomeGeneratePanel({
             ) : null}
 
             <PromptComposer
+              className="[&_[data-agent-composer-slot=toolbar-spacer]]:hidden"
               placeholder={
                 selectedLibrary
                   ? mediaType === "video"
@@ -792,144 +801,22 @@ function HomeGeneratePanel({
               showModelSelector={false}
               voiceEnabled={false}
               draftScope="assets-create"
+              toolbarSlot={
+                <AssetComposerToolbar
+                  mediaType={mediaType}
+                  onMediaTypeChange={handleMediaTypeChange}
+                  selectValue={selectValue}
+                  selectedLibraryLabel={selectedLibrary?.title ?? "Generic"}
+                  libraries={sortedLibraries}
+                  onLibraryChange={handleLibraryChange}
+                  aspectRatio={aspectRatio}
+                  onAspectChange={handleAspectChange}
+                  customRatios={customRatios}
+                  count={count}
+                  onCountChange={setCount}
+                />
+              }
             />
-
-            <div className="mt-5 rounded-lg border border-border/80 bg-card/50 p-3 text-sm">
-              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-[minmax(0,0.8fr)_minmax(12rem,1.6fr)_minmax(0,1fr)_minmax(0,0.85fr)]">
-                <div className="grid gap-1.5">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    Type
-                  </span>
-                  <Select
-                    value={mediaType}
-                    onValueChange={(value) => {
-                      const next = value as "image" | "video";
-                      setMediaType(next);
-                      if (
-                        next === "video" &&
-                        aspectRatio !== "16:9" &&
-                        aspectRatio !== "9:16"
-                      ) {
-                        setAspectRatio("16:9");
-                      }
-                    }}
-                  >
-                    <SelectTrigger className="h-9 w-full text-sm">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectItem value="image">Image</SelectItem>
-                        <SelectItem value="video">Video</SelectItem>
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="grid gap-1.5">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    Library
-                  </span>
-                  <Select
-                    value={selectValue}
-                    onValueChange={handleLibraryChange}
-                  >
-                    <SelectTrigger className="h-9 w-full text-sm">
-                      <SelectValue placeholder="Choose a library" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        {sortedLibraries.map((library) => (
-                          <SelectItem key={library.id} value={library.id}>
-                            {library.title}
-                          </SelectItem>
-                        ))}
-                        <SelectItem value="generic">
-                          No library - generic
-                        </SelectItem>
-                      </SelectGroup>
-                      <SelectSeparator />
-                      <SelectGroup>
-                        <SelectItem value="__new__">
-                          <span className="flex items-center gap-2">
-                            <IconPhotoPlus className="size-3.5" />
-                            New library...
-                          </span>
-                        </SelectItem>
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="grid gap-1.5">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    Aspect
-                  </span>
-                  <Select
-                    value={aspectRatio}
-                    onValueChange={handleAspectChange}
-                  >
-                    <SelectTrigger className="h-9 w-full text-sm">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        {ASPECT_RATIOS.filter(
-                          (ratio) =>
-                            mediaType === "image" ||
-                            ratio.value === "16:9" ||
-                            ratio.value === "9:16",
-                        ).map((ratio) => (
-                          <SelectItem key={ratio.value} value={ratio.value}>
-                            {ratio.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                      {customRatios.length > 0 ? (
-                        <>
-                          <SelectSeparator />
-                          <SelectGroup>
-                            {customRatios.map((ratio) => (
-                              <SelectItem key={ratio} value={ratio}>
-                                {ratio} - saved
-                              </SelectItem>
-                            ))}
-                          </SelectGroup>
-                        </>
-                      ) : null}
-                      <SelectSeparator />
-                      <SelectGroup>
-                        <SelectItem value="__custom__">
-                          Custom size...
-                        </SelectItem>
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </div>
-                {mediaType === "image" && (
-                  <div className="grid gap-1.5">
-                    <span className="text-xs font-medium text-muted-foreground">
-                      Count
-                    </span>
-                    <Select
-                      value={String(count)}
-                      onValueChange={(value) => setCount(Number(value))}
-                    >
-                      <SelectTrigger className="h-9 w-full text-sm">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          {[1, 2, 3, 4].map((n) => (
-                            <SelectItem key={n} value={String(n)}>
-                              {n} variants
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                )}
-              </div>
-            </div>
           </div>
 
           <div className="flex flex-wrap justify-center gap-2">
@@ -1082,5 +969,145 @@ function HomeGeneratePanel({
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+function AssetComposerToolbar({
+  mediaType,
+  onMediaTypeChange,
+  selectValue,
+  selectedLibraryLabel,
+  libraries,
+  onLibraryChange,
+  aspectRatio,
+  onAspectChange,
+  customRatios,
+  count,
+  onCountChange,
+}: {
+  mediaType: "image" | "video";
+  onMediaTypeChange: (value: "image" | "video") => void;
+  selectValue: string;
+  selectedLibraryLabel: string;
+  libraries: ImageLibrarySummary[];
+  onLibraryChange: (value: string) => void;
+  aspectRatio: string;
+  onAspectChange: (value: string) => void;
+  customRatios: string[];
+  count: number;
+  onCountChange: (value: number) => void;
+}) {
+  const aspectOptions = ASPECT_RATIOS.filter(
+    (ratio) =>
+      mediaType === "image" || ratio.value === "16:9" || ratio.value === "9:16",
+  );
+
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-1">
+      <Select
+        value={mediaType}
+        onValueChange={(value) => onMediaTypeChange(value as "image" | "video")}
+      >
+        <SelectTrigger
+          aria-label="Asset type"
+          className={`${COMPOSER_SELECT_TRIGGER_CLASS} max-w-[5.5rem] shrink-0`}
+        >
+          <span className="truncate capitalize">{mediaType}</span>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectItem value="image">Image</SelectItem>
+            <SelectItem value="video">Video</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+
+      <div className="flex min-w-0 flex-1 items-center justify-end gap-0.5 sm:gap-1">
+        <Select value={selectValue} onValueChange={onLibraryChange}>
+          <SelectTrigger
+            aria-label="Library"
+            className={`${COMPOSER_SELECT_TRIGGER_CLASS} max-w-[6rem] sm:max-w-[12rem]`}
+          >
+            <span className="truncate">{selectedLibraryLabel}</span>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {libraries.map((library) => (
+                <SelectItem key={library.id} value={library.id}>
+                  {library.title}
+                </SelectItem>
+              ))}
+              <SelectItem value="generic">No library - generic</SelectItem>
+            </SelectGroup>
+            <SelectSeparator />
+            <SelectGroup>
+              <SelectItem value="__new__">
+                <span className="flex items-center gap-2">
+                  <IconPhotoPlus className="size-3.5" />
+                  New library...
+                </span>
+              </SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+
+        <Select value={aspectRatio} onValueChange={onAspectChange}>
+          <SelectTrigger
+            aria-label="Aspect ratio"
+            className={`${COMPOSER_SELECT_TRIGGER_CLASS} max-w-[5rem] shrink-0`}
+          >
+            <span className="truncate">{aspectRatio}</span>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {aspectOptions.map((ratio) => (
+                <SelectItem key={ratio.value} value={ratio.value}>
+                  {ratio.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+            {customRatios.length > 0 ? (
+              <>
+                <SelectSeparator />
+                <SelectGroup>
+                  {customRatios.map((ratio) => (
+                    <SelectItem key={ratio} value={ratio}>
+                      {ratio} - saved
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </>
+            ) : null}
+            <SelectSeparator />
+            <SelectGroup>
+              <SelectItem value="__custom__">Custom size...</SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+
+        {mediaType === "image" ? (
+          <Select
+            value={String(count)}
+            onValueChange={(value) => onCountChange(Number(value))}
+          >
+            <SelectTrigger
+              aria-label="Variant count"
+              className={`${COMPOSER_SELECT_TRIGGER_CLASS} max-w-[4rem] shrink-0`}
+            >
+              <span>{count}x</span>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {[1, 2, 3, 4].map((n) => (
+                  <SelectItem key={n} value={String(n)}>
+                    {n}x
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        ) : null}
+      </div>
+    </div>
   );
 }

--- a/templates/assets/app/routes/_index.tsx
+++ b/templates/assets/app/routes/_index.tsx
@@ -220,7 +220,7 @@ function GenerationSetupNotice({ config }: { config: ImageGenerationConfig }) {
     ? "Connect generation models"
     : "Finish asset setup";
   const description = builderAvailable
-    ? "Connect to enable image generation, video generation, LLMs, and asset storage. Free credits and no keys needed."
+    ? "Connect to enable image generation, video generation, LLMs, and asset storage. Free credits and no keys needed"
     : "This deployment uses manual provider setup. Add the missing pieces in Settings.";
   const showContent = !!issueMessage || !!flow.error || builderAvailable;
 

--- a/templates/assets/app/routes/picker.tsx
+++ b/templates/assets/app/routes/picker.tsx
@@ -13,15 +13,7 @@ import {
   useActionMutation,
   useActionQuery,
 } from "@agent-native/core/client";
-import {
-  IconArrowUpRight,
-  IconLoader2,
-  IconPhoto,
-  IconPhotoPlus,
-  IconSearch,
-  IconVideo,
-  IconX,
-} from "@tabler/icons-react";
+import { IconArrowUpRight, IconX } from "@tabler/icons-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -29,6 +21,7 @@ import { cn } from "@/lib/utils";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -40,6 +33,8 @@ const ASPECT_RATIOS = ["16:9", "1:1", "9:16", "4:3", "3:4", "21:9"] as const;
 const GENERATION_COUNTS = [1, 2, 3, 4, 6] as const;
 const STARTER_PRESET = DEFAULT_LIBRARY_PRESETS[0];
 const STARTER_LIBRARY_ID = `starter:${STARTER_PRESET.id}`;
+const PICKER_INLINE_SELECT_CLASS =
+  "h-7 w-auto min-w-0 max-w-full rounded-md border-0 bg-transparent px-1.5 py-1 text-xs font-medium text-muted-foreground shadow-none ring-offset-transparent transition hover:bg-accent/50 hover:text-foreground focus:ring-0 focus:ring-offset-0 sm:px-2 [&>svg]:ml-1 [&>svg]:size-3.5 [&>svg]:opacity-60";
 type PickerMediaType = "image" | "video";
 
 type Asset = {
@@ -392,22 +387,10 @@ function notifyMcpHost(payload: ReturnType<typeof assetPayload>) {
     });
 }
 
-function dimensions(asset: Asset) {
-  if (!asset.width || !asset.height) return null;
-  return `${asset.width} x ${asset.height}`;
-}
-
 function assetDisplayTitle(asset: Asset) {
   return (
     asset.lineage?.label || asset.title || asset.prompt || "Untitled asset"
   );
-}
-
-function assetContextLabel(asset: Asset) {
-  if (asset.lineage?.kind === "variation" && asset.lineage.sourceLabel) {
-    return `from ${asset.lineage.sourceLabel}`;
-  }
-  return dimensions(asset);
 }
 
 function AssetThumbnail({ asset }: { asset: Asset }) {
@@ -451,11 +434,7 @@ function AssetThumbnail({ asset }: { asset: Asset }) {
   }, [asset.mimeType, source]);
 
   if (!displayUrl) {
-    return (
-      <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-        <IconPhoto className="h-6 w-6" />
-      </div>
-    );
+    return <div className="h-full w-full bg-muted" />;
   }
 
   return (
@@ -563,9 +542,6 @@ export default function AssetPicker() {
     data?: GenerationConfig;
   };
 
-  const selectedLibrary = displayLibraries.find(
-    (library) => library.id === selectedLibraryId,
-  );
   const usingStarterLibrary = selectedLibraryId === STARTER_LIBRARY_ID;
   const {
     data: presetData,
@@ -636,7 +612,9 @@ export default function AssetPicker() {
     );
   }, [query, starterAssets]);
   const assets = usingStarterLibrary
-    ? visibleStarterAssets
+    ? mediaType === "image"
+      ? visibleStarterAssets
+      : []
     : (assetData?.assets ?? []);
 
   const chooseAsset = (asset: Asset) => {
@@ -793,8 +771,8 @@ export default function AssetPicker() {
     typeof config?.lastIssue?.message === "string"
       ? config.lastIssue.message
       : config?.builderEnabled === false
-        ? "Add a Gemini key in Settings to generate image assets."
-        : "Connect Builder.io or add a Gemini key in Settings to generate image assets.";
+        ? "Add a generation key in Settings."
+        : "Connect generation models.";
   const needsGenerationLibrary =
     mediaType === "image" &&
     libraryListReady &&
@@ -870,24 +848,8 @@ export default function AssetPicker() {
       )}
     >
       <header className="flex h-12 shrink-0 items-center justify-between gap-3 border-b border-border px-3">
-        <div className="flex min-w-0 items-center gap-2">
-          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
-            {mediaType === "video" ? (
-              <IconVideo className="h-4 w-4" />
-            ) : (
-              <IconPhoto className="h-4 w-4" />
-            )}
-          </div>
-          <div className="min-w-0">
-            <div className="truncate text-sm font-semibold">
-              {embedded ? "Assets" : "Picker"}
-            </div>
-            {selectedLibrary && (
-              <div className="truncate text-xs text-muted-foreground">
-                {selectedLibrary.title} - {mediaLabel}
-              </div>
-            )}
-          </div>
+        <div className="min-w-0 truncate text-sm font-semibold">
+          {embedded ? "Assets" : "Assets picker"}
         </div>
         {embedded && (
           <div className="flex shrink-0 items-center gap-2">
@@ -909,111 +871,129 @@ export default function AssetPicker() {
       </header>
 
       <section className="shrink-0 border-b border-border px-3 py-3">
-        <div className="grid gap-2 md:grid-cols-[minmax(160px,220px)_1fr_auto]">
+        <div className="grid gap-2 sm:grid-cols-[minmax(0,12rem)_1fr]">
           <Select
             value={selectedLibraryId}
             onValueChange={setSelectedLibraryId}
           >
-            <SelectTrigger className="h-9">
+            <SelectTrigger className="h-9 border-border/70 bg-background">
               <SelectValue placeholder="Library" />
             </SelectTrigger>
             <SelectContent>
-              {displayLibraries.map((library) => (
-                <SelectItem key={library.id} value={library.id}>
-                  {library.title}
-                </SelectItem>
-              ))}
+              <SelectGroup>
+                {displayLibraries.map((library) => (
+                  <SelectItem key={library.id} value={library.id}>
+                    {library.title}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
             </SelectContent>
           </Select>
-          <div className="relative">
-            <IconSearch className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder={`Search ${mediaLabel} assets`}
-              className="h-9 pl-9"
-            />
-          </div>
-          <Button
-            variant="outline"
-            className="h-9"
-            onClick={() => setQuery("")}
-            disabled={!query}
-          >
-            Clear
-          </Button>
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={`Search ${mediaLabel}s`}
+            className="h-9 border-border/70 bg-background"
+          />
         </div>
 
-        <div className="mt-2 grid gap-2 md:grid-cols-[1fr_116px_92px_minmax(150px,190px)_auto]">
-          <Input
-            value={prompt}
-            onChange={(event) => setPrompt(event.target.value)}
-            placeholder={
-              mediaType === "video"
-                ? "Video generation runs through chat or actions"
-                : "Generate a new image asset"
-            }
-            className="h-9"
-            disabled={mediaType === "video"}
-          />
-          <Select value={aspectRatio} onValueChange={setAspectRatio}>
-            <SelectTrigger className="h-9">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {ASPECT_RATIOS.map((ratio) => (
-                <SelectItem key={ratio} value={ratio}>
-                  {ratio}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Select
-            value={String(count)}
-            onValueChange={(value) => setCount(normalizeCount(value))}
-          >
-            <SelectTrigger className="h-9">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {GENERATION_COUNTS.map((option) => (
-                <SelectItem key={option} value={String(option)}>
-                  {option}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Select
-            value={presetId}
-            onValueChange={(value) => setPresetId(value)}
-            disabled={!generationPresets.length}
-          >
-            <SelectTrigger className="h-9">
-              <SelectValue placeholder="Preset" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="none">No preset</SelectItem>
-              {generationPresets.map((preset) => (
-                <SelectItem key={preset.id} value={preset.id}>
-                  {preset.title}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Button className="h-9" disabled={!canGenerate} onClick={runGenerate}>
-            {generateBatch.isPending ? (
-              <IconLoader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <IconPhotoPlus className="h-4 w-4" />
-            )}
-            Generate
-          </Button>
-        </div>
+        {mediaType === "image" ? (
+          <div className="mt-2 rounded-lg border border-border/80 bg-background focus-within:ring-1 focus-within:ring-ring">
+            <Input
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter" || event.shiftKey) return;
+                if (!canGenerate) return;
+                event.preventDefault();
+                runGenerate();
+              }}
+              placeholder="Generate an image asset"
+              className="h-11 border-0 bg-transparent px-3 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+            />
+            <div className="flex items-center gap-1 px-2 pb-2">
+              <div className="flex min-w-0 flex-1 items-center justify-end gap-0.5 sm:gap-1">
+                <Select value={aspectRatio} onValueChange={setAspectRatio}>
+                  <SelectTrigger
+                    aria-label="Aspect ratio"
+                    className={`${PICKER_INLINE_SELECT_CLASS} shrink-0`}
+                  >
+                    <span>{aspectRatio}</span>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      {ASPECT_RATIOS.map((ratio) => (
+                        <SelectItem key={ratio} value={ratio}>
+                          {ratio}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+                <Select
+                  value={String(count)}
+                  onValueChange={(value) => setCount(normalizeCount(value))}
+                >
+                  <SelectTrigger
+                    aria-label="Candidate count"
+                    className={`${PICKER_INLINE_SELECT_CLASS} shrink-0`}
+                  >
+                    <span>{count}x</span>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      {GENERATION_COUNTS.map((option) => (
+                        <SelectItem key={option} value={String(option)}>
+                          {option}x
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+                {generationPresets.length > 0 || presetId !== "none" ? (
+                  <Select
+                    value={presetId}
+                    onValueChange={(value) => setPresetId(value)}
+                  >
+                    <SelectTrigger
+                      aria-label="Preset"
+                      className={`${PICKER_INLINE_SELECT_CLASS} max-w-[7.5rem] sm:max-w-[10rem]`}
+                    >
+                      <SelectValue placeholder="Preset" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectItem value="none">No preset</SelectItem>
+                        {generationPresets.map((preset) => (
+                          <SelectItem key={preset.id} value={preset.id}>
+                            {preset.title}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                ) : null}
+              </div>
+              <Button
+                className="h-7 shrink-0 px-3 text-xs"
+                disabled={!canGenerate}
+                onClick={runGenerate}
+              >
+                {generateBatch.isPending ? "Generating..." : "Generate"}
+              </Button>
+            </div>
+          </div>
+        ) : null}
 
         {setupNeeded && (
-          <div className="mt-2 flex items-center justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-950 dark:text-amber-100">
+          <div className="mt-2 flex items-center justify-between gap-3 rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
             <span className="min-w-0 truncate">{setupMessage}</span>
-            <Button asChild variant="outline" size="sm" className="h-7">
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className="h-7 shrink-0 px-2 text-xs"
+            >
               <a
                 href={absoluteAppUrl("/settings")}
                 target="_blank"
@@ -1039,10 +1019,7 @@ export default function AssetPicker() {
               onClick={prepareGenerationLibrary}
               disabled={preparingGenerationLibrary}
             >
-              {preparingGenerationLibrary ? (
-                <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : null}
-              Create library
+              {preparingGenerationLibrary ? "Preparing..." : "Create library"}
             </Button>
           </div>
         )}
@@ -1066,8 +1043,7 @@ export default function AssetPicker() {
         )}
 
         {selectedLibraryId && !assetsLoading && assets.length === 0 && (
-          <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
-            <IconPhoto className="h-8 w-8 text-muted-foreground" />
+          <div className="flex h-full items-center justify-center text-center">
             <div className="max-w-sm text-sm text-muted-foreground">
               {query
                 ? `No matching ${mediaLabel} assets in this library.`
@@ -1082,7 +1058,9 @@ export default function AssetPicker() {
               <button
                 key={asset.id}
                 type="button"
+                aria-label={`Select ${assetDisplayTitle(asset)}`}
                 onClick={() => chooseAsset(asset)}
+                title={assetDisplayTitle(asset)}
                 className="group overflow-hidden rounded-md border border-border bg-card text-left shadow-sm transition hover:border-primary/60 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 <div className="aspect-square bg-muted">
@@ -1097,16 +1075,6 @@ export default function AssetPicker() {
                     />
                   ) : (
                     <AssetThumbnail asset={asset} />
-                  )}
-                </div>
-                <div className="space-y-1 p-2">
-                  <div className="truncate text-xs font-medium">
-                    {assetDisplayTitle(asset)}
-                  </div>
-                  {assetContextLabel(asset) && (
-                    <div className="text-[11px] text-muted-foreground">
-                      {assetContextLabel(asset)}
-                    </div>
                   )}
                 </div>
               </button>


### PR DESCRIPTION
## Consolidated `changes-182` — all not-on-main work from this checkout

This branch bundles every not-yet-merged change from the agents working here:

- **Release-pipeline fix** — mark `@agent-native/shared-app-config` + `@agent-native/code-agents-ui` as internal (changeset `ignore` + `guard-public-packages` allowlist) so version-packages stops 404ing on their never-published first publish. Un-reds `auto-publish`.
- **Core unit-test coverage build** — ~35 new spec files across a2a, agent engine/model config, collab, event-bus, file-upload, integrations, jobs, mcp oauth, observability, org, scripts/db; plus db-admin operations specs (incl. postgres). Fixes the extension-share guard in the slots spec (`requireOrgMemberForUserShares: true`).
- **Assets** — move creation controls into the composer + setup-copy tweaks.
- **Analytics** — route bespoke artifacts to extensions (docs).
- **Core** — clean auth redirect cache param; observability/feedback + db exec tweaks.
- **CI** — skip netlify cleanup when no token is present.

Verified with `pnpm prep` (fmt + typecheck + full test suite + 13 guards) green on the consolidated tree; changeset coverage confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
