### PR TITLE
Fix MCP selected asset context for external hosts

### DIFF
--- a/.changeset/fix-mcp-selected-asset-context.md
+++ b/.changeset/fix-mcp-selected-asset-context.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Forward structured MCP app host context so external hosts can use selected assets from embedded apps.

--- a/packages/core/src/cli/connect.ts
+++ b/packages/core/src/cli/connect.ts
@@ -62,7 +62,7 @@ const CLIENT_LABELS: Record<ClientId, string> = {
 const CLIENT_HINTS: Record<ClientId, string> = {
   "claude-code": ".mcp.json or ~/.claude.json",
   "claude-code-cli": ".mcp.json or ~/.claude.json",
-  codex: "~/.codex/config.toml",
+  codex: "$CODEX_HOME/config.toml or ~/.codex/config.toml",
   cowork: "~/.cowork/mcp.json",
 };
 

--- a/packages/core/src/cli/mcp-config-writers.ts
+++ b/packages/core/src/cli/mcp-config-writers.ts
@@ -12,7 +12,8 @@
  *   - claude-code / claude-code-cli → `.mcp.json` (project) or
  *     `~/.claude.json` (user). JSON `mcpServers[name] = entry`.
  *   - cowork                        → `~/.cowork/mcp.json`. Same JSON shape.
- *   - codex                         → `~/.codex/config.toml`.
+ *   - codex                         → `$CODEX_HOME/config.toml` when set,
+ *     otherwise `~/.codex/config.toml`.
  *     `[mcp_servers.<name>]` block.
  *
  * Node-only. No new npm deps — hand-rolled JSON merge + minimal TOML block
@@ -77,6 +78,8 @@ export function claudeCodeUserConfig(): string {
 }
 
 export function codexConfigPath(): string {
+  const codexHome = process.env.CODEX_HOME?.trim();
+  if (codexHome) return path.join(codexHome, "config.toml");
   return path.join(os.homedir(), ".codex", "config.toml");
 }
 

--- a/packages/core/src/cli/mcp.ts
+++ b/packages/core/src/cli/mcp.ts
@@ -248,6 +248,8 @@ function claudeCodeUserConfig(): string {
   return path.join(os.homedir(), ".claude.json");
 }
 function codexConfigPath(): string {
+  const codexHome = process.env.CODEX_HOME?.trim();
+  if (codexHome) return path.join(codexHome, "config.toml");
   return path.join(os.homedir(), ".codex", "config.toml");
 }
 

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { addAgentNativeSkill, parseSkillsArgs } from "./skills.js";
+import { addAgentNativeSkill, parseSkillsArgs, runSkills } from "./skills.js";
 
 const tmpRoots: string[] = [];
 
@@ -11,6 +11,7 @@ afterEach(() => {
   for (const root of tmpRoots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
   }
+  vi.restoreAllMocks();
 });
 
 function tmpDir(): string {
@@ -148,7 +149,101 @@ describe("agent-native skills", () => {
       { baseDir: root },
     );
 
-    expect(result.commands.join("\n")).toContain("npx --yes skills@latest add");
+    expect(result.commands).toEqual([
+      "agent-native skills add assets --client codex --scope project --yes",
+    ]);
+    expect(result.commands.join("\n")).not.toContain(os.tmpdir());
     expect(fs.existsSync(path.join(root, ".mcp.json"))).toBe(false);
+  });
+
+  it("writes Codex MCP config under CODEX_HOME when set", async () => {
+    const root = tmpDir();
+    const home = path.join(root, "home");
+    const codexHome = path.join(root, "codex-home");
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(codexHome, { recursive: true });
+    const previousHome = process.env.HOME;
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.HOME = home;
+    process.env.CODEX_HOME = codexHome;
+    try {
+      await addAgentNativeSkill(
+        parseSkillsArgs([
+          "add",
+          "assets",
+          "--client",
+          "codex",
+          "--scope",
+          "user",
+          "--mcp-only",
+          "--yes",
+        ]),
+        { baseDir: root },
+      );
+
+      const codexConfig = path.join(codexHome, "config.toml");
+      expect(fs.readFileSync(codexConfig, "utf-8")).toContain(
+        'url = "https://assets.agent-native.com/_agent-native/mcp"',
+      );
+      expect(fs.existsSync(path.join(home, ".codex", "config.toml"))).toBe(
+        false,
+      );
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+    }
+  });
+
+  it("keeps --json output machine-readable for MCP-only installs", async () => {
+    const root = tmpDir();
+    const home = path.join(root, "home");
+    const codexHome = path.join(root, "codex-home");
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(codexHome, { recursive: true });
+    const previousHome = process.env.HOME;
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.HOME = home;
+    process.env.CODEX_HOME = codexHome;
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    try {
+      await runSkills(
+        [
+          "add",
+          "assets",
+          "--client",
+          "codex",
+          "--scope",
+          "user",
+          "--mcp-only",
+          "--yes",
+          "--json",
+        ],
+        { baseDir: root },
+      );
+
+      const result = JSON.parse(stdout.join(""));
+      expect(result.id).toBe("assets");
+      expect(result.mcpUrl).toBe(
+        "https://assets.agent-native.com/_agent-native/mcp",
+      );
+      expect(stderr.join("")).toBe("");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+    }
   });
 });

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -441,8 +441,32 @@ function skillsAgentsForClients(clients: ClientId[]): string[] {
   return [...agents];
 }
 
+function shellArg(value: string): string {
+  if (/^[A-Za-z0-9_/:=.,@+-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 function commandString(cmd: string, args: string[]): string {
-  return [cmd, ...args].join(" ");
+  return [cmd, ...args].map(shellArg).join(" ");
+}
+
+function dryRunInstallCommand(
+  parsed: ParsedSkillsArgs,
+  target: string,
+): string {
+  const args = [
+    "skills",
+    "add",
+    target,
+    "--client",
+    parsed.client,
+    "--scope",
+    parsed.scope,
+  ];
+  if (parsed.instructions && !parsed.mcp) args.push("--instructions-only");
+  if (!parsed.instructions && parsed.mcp) args.push("--mcp-only");
+  if (parsed.yes || isKnownSkill(target)) args.push("--yes");
+  return commandString("agent-native", args);
 }
 
 async function runCommand(cmd: string, args: string[]): Promise<number> {
@@ -477,6 +501,22 @@ export async function addAgentNativeSkill(
   const installTarget = loadSkillTarget(target);
   const clients = resolveClients(parsed.client);
   const skillsAgents = skillsAgentsForClients(clients);
+  if (parsed.dryRun) {
+    try {
+      return {
+        id: installTarget.id,
+        displayName: installTarget.displayName,
+        skillNames: installTarget.skillNames,
+        skillsAgents,
+        mcpUrl: installTarget.loaded.manifest.hosted.mcpUrl,
+        mcpClients: clients,
+        dryRun: true,
+        commands: [dryRunInstallCommand(parsed, target)],
+      };
+    } finally {
+      installTarget.cleanup?.();
+    }
+  }
   const commands: string[] = [];
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "an-skills-add-"));
   let instructionSource: string | undefined;
@@ -557,8 +597,9 @@ export async function runSkills(
   options: RunSkillsOptions = {},
 ): Promise<void> {
   const parsed = parseSkillsArgs(argv);
-  const log = (message: string) =>
-    (parsed.printJson ? process.stderr : process.stdout).write(`${message}\n`);
+  const log = parsed.printJson
+    ? undefined
+    : (message: string) => process.stdout.write(`${message}\n`);
 
   if (parsed.command === "help") {
     process.stdout.write(`${HELP}\n`);

--- a/packages/core/src/client/mcp-app-host.spec.ts
+++ b/packages/core/src/client/mcp-app-host.spec.ts
@@ -464,6 +464,12 @@ describe("MCP app host client helpers", () => {
     const result = sendMcpAppHostMessage({
       context: "Hidden selected asset context",
       message: "Use the selected Assets image",
+      structuredContent: {
+        selectedAsset: {
+          assetId: "asset-123",
+          url: "https://example.com/a.png",
+        },
+      },
       content: [
         { type: "text", text: "Use the selected Assets image" },
         { type: "image", data: "ZmFrZS1pbWFnZQ==", mimeType: "image/webp" },
@@ -479,6 +485,12 @@ describe("MCP app host client helpers", () => {
           { type: "text", text: "Hidden selected asset context" },
           { type: "image", data: "ZmFrZS1pbWFnZQ==", mimeType: "image/webp" },
         ],
+        structuredContent: {
+          selectedAsset: {
+            assetId: "asset-123",
+            url: "https://example.com/a.png",
+          },
+        },
       },
     });
     expect(sendFollowUpMessage).toHaveBeenCalledWith({
@@ -494,6 +506,12 @@ describe("MCP app host client helpers", () => {
     const result = sendMcpAppHostMessage({
       context: "Hidden selected asset context",
       message: "Use the selected Assets image",
+      structuredContent: {
+        selectedAsset: {
+          assetId: "asset-123",
+          url: "https://example.com/a.png",
+        },
+      },
       content: [
         { type: "text", text: "Use the selected Assets image" },
         { type: "image", data: "ZmFrZS1pbWFnZQ==", mimeType: "image/webp" },
@@ -513,6 +531,12 @@ describe("MCP app host client helpers", () => {
             { type: "text", text: "Use the selected Assets image" },
             { type: "image", data: "ZmFrZS1pbWFnZQ==", mimeType: "image/webp" },
           ],
+          structuredContent: {
+            selectedAsset: {
+              assetId: "asset-123",
+              url: "https://example.com/a.png",
+            },
+          },
           submit: true,
         },
       },
@@ -603,6 +627,12 @@ describe("MCP app host client helpers", () => {
     ];
     const result = sendMcpAppHostMessage({
       context: "Hidden selected asset context",
+      structuredContent: {
+        selectedAsset: {
+          assetId: "asset-123",
+          url: "https://example.com/a.png",
+        },
+      },
       content,
       message: "Use the selected Assets image",
     });
@@ -627,6 +657,12 @@ describe("MCP app host client helpers", () => {
           { type: "text", text: "Hidden selected asset context" },
           { type: "image", data: "ZmFrZS1pbWFnZQ==", mimeType: "image/webp" },
         ],
+        structuredContent: {
+          selectedAsset: {
+            assetId: "asset-123",
+            url: "https://example.com/a.png",
+          },
+        },
       },
     });
     dispatchHostMessage({ jsonrpc: "2.0", id: contextCall.id, result: {} });

--- a/packages/core/src/client/mcp-app-host.ts
+++ b/packages/core/src/client/mcp-app-host.ts
@@ -40,6 +40,7 @@ export interface McpAppHostChatMessage {
   message: string;
   context?: string;
   content?: McpAppModelContextContentPart[];
+  structuredContent?: unknown;
 }
 
 export interface McpAppHostCapabilities {
@@ -349,6 +350,9 @@ function postWrapperHostChat(chat: McpAppHostChatMessage): Promise<boolean> {
             context: chat.context?.trim() || "",
             submit: true,
             ...(chat.content?.length ? { content: chat.content } : {}),
+            ...(chat.structuredContent !== undefined
+              ? { structuredContent: chat.structuredContent }
+              : {}),
           },
         },
         "*",
@@ -550,7 +554,12 @@ export function sendMcpAppHostMessage(
         openAiBridge.setWidgetState({
           ...objectValue(openAiBridge.widgetState),
           agentNativeChatContext: context,
-          agentNativeModelContext: { content: contextContent },
+          agentNativeModelContext: {
+            content: contextContent,
+            ...(chat.structuredContent !== undefined
+              ? { structuredContent: chat.structuredContent }
+              : {}),
+          },
         });
       }
       await openAiBridge.sendFollowUpMessage({
@@ -564,6 +573,9 @@ export function sendMcpAppHostMessage(
     try {
       await postJsonRpcRequest("ui/update-model-context", {
         content: contextContent,
+        ...(chat.structuredContent !== undefined
+          ? { structuredContent: chat.structuredContent }
+          : {}),
       });
     } catch {
       // Best effort: a host without model-context support should still receive

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -30,9 +30,8 @@ describe("embedApp", () => {
     expect(html).toContain("openAiBridge.setOpenInAppUrl");
     expect(html).toContain("openAiBridge.sendFollowUpMessage");
     expect(html).toContain("prompt: message");
-    expect(html).toContain(
-      "agentNativeModelContext: { content: contextContent }",
-    );
+    expect(html).toContain("const modelContext = {");
+    expect(html).toContain("agentNativeModelContext: modelContext");
     expect(html).not.toContain('context.trim() + "\\\\n\\\\n" + message');
     expect(html).toContain(
       'const record = data && typeof data === "object" ? data : {}',

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -1178,22 +1178,26 @@ export function embedApp(
       const content = Array.isArray(chat.content) && chat.content.length
         ? chat.content
         : [{ type: "text", text: message }];
+      const structuredContent =
+        chat && chat.structuredContent !== undefined
+          ? chat.structuredContent
+          : undefined;
       try {
+        const contextContent = context
+          ? [{ type: "text", text: context }, ...content.filter((part) => part && part.type !== "text")]
+          : content.filter((part) => part && part.type !== "text");
+        const modelContext = {
+          content: contextContent,
+          ...(structuredContent !== undefined ? { structuredContent } : {})
+        };
         if (openAiBridge && typeof openAiBridge.setWidgetState === "function") {
-          const contextContent = context
-            ? [{ type: "text", text: context }, ...content.filter((part) => part && part.type !== "text")]
-            : content.filter((part) => part && part.type !== "text");
           openAiBridge.setWidgetState({
             ...objectValue(openAiBridge.widgetState),
             agentNativeChatContext: context || null,
-            agentNativeModelContext: { content: contextContent }
+            agentNativeModelContext: modelContext
           });
         } else if (app && typeof app.updateModelContext === "function") {
-          await app.updateModelContext({
-            content: context
-              ? [{ type: "text", text: context }, ...content.filter((part) => part && part.type !== "text")]
-              : content.filter((part) => part && part.type !== "text")
-          });
+          await app.updateModelContext(modelContext);
         }
       } catch (err) {
         console.warn("[agent-native] MCP host rejected model context update", err);

--- a/templates/assets/app/routes/picker.tsx
+++ b/templates/assets/app/routes/picker.tsx
@@ -387,6 +387,7 @@ function notifyMcpHost(payload: ReturnType<typeof assetPayload>) {
               message,
               context: JSON.stringify(context, null, 2),
               content: chatContent,
+              structuredContent: context,
             }) || false,
           ).catch(() => false),
         );

--- a/templates/design/.agents/skills/design-generation/SKILL.md
+++ b/templates/design/.agents/skills/design-generation/SKILL.md
@@ -21,6 +21,11 @@ pnpm action create-design --title "Project Name" --projectType prototype
 pnpm action navigate --view editor --designId <returned-id>
 ```
 
+The `navigate` step is only for first-party/local app agents that can write
+application state. External MCP hosts should surface the `create-design`
+returned "Open design" link, then use `present-design-variants` to open the
+visual picker.
+
 Then, for any non-trivial first prompt, write `application-state/show-questions` BEFORE generating. The editor renders a full-canvas overlay; answers come back as a chat message. Skip the questions only when the prompt is unambiguous ("re-skin this with my brand colors") or the user said "decide for me".
 
 ```bash

--- a/templates/design/actions/export-coding-handoff.spec.ts
+++ b/templates/design/actions/export-coding-handoff.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@agent-native/core/server", () => ({
+  buildDeepLink: (args: {
+    app: string;
+    view: string;
+    params?: Record<string, string>;
+  }) =>
+    `/_agent-native/open?app=${args.app}&view=${args.view}&designId=${args.params?.designId ?? ""}`,
+  getAppProductionUrl: () => "https://design.agent-native.com",
+  getRequestContext: () => null,
+  signShortLivedToken: () => "signed-token",
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  assertAccess: vi.fn(),
+  registerShareableResource: vi.fn(),
+}));
+
+vi.mock("../server/db/index.js", () => ({
+  schema: { designs: {} },
+}));
+
+vi.mock("../server/lib/coding-handoff.js", () => ({
+  buildCodingHandoffPrompt: () => "Use this handoff",
+  buildRawHandoffUrl: () =>
+    "https://design.agent-native.com/_agent-native/raw-code/design_123?token=signed-token&format=json",
+  normalizeHandoffFormat: (format?: string) => format ?? "markdown",
+}));
+
+vi.mock("../server/lib/design-snapshot.js", () => ({
+  buildDesignSnapshot: vi.fn(),
+}));
+
+import action from "./export-coding-handoff.js";
+
+describe("export-coding-handoff", () => {
+  it("is available in the compact MCP Apps catalog", () => {
+    expect(action.mcpApp?.compactCatalog).toBe(true);
+    expect(action.mcpApp?.resource.title).toBe("Design coding handoff");
+    expect(action.mcpApp?.resource.html()).toContain(
+      "--agent-native-shell-height: 680px",
+    );
+  });
+
+  it("returns an editor deep link for external hosts", () => {
+    const link = action.link?.({
+      args: {},
+      result: { designId: "design_123" },
+    });
+
+    expect(link).toEqual({
+      url: "/_agent-native/open?app=design&view=editor&designId=design_123",
+      label: "Open design",
+      view: "editor",
+    });
+  });
+});

--- a/templates/design/actions/export-coding-handoff.ts
+++ b/templates/design/actions/export-coding-handoff.ts
@@ -1,4 +1,4 @@
-import { defineAction } from "@agent-native/core";
+import { defineAction, embedApp } from "@agent-native/core";
 import {
   signShortLivedToken,
   buildDeepLink,
@@ -52,6 +52,16 @@ export default defineAction({
   }),
   readOnly: true,
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  mcpApp: {
+    compactCatalog: true,
+    resource: embedApp({
+      title: "Design coding handoff",
+      description: "Open the design in the real Design editor.",
+      iframeTitle: "Agent-Native Design",
+      openLabel: "Open design",
+      height: 680,
+    }),
+  },
   run: async ({ id, origin, format }) => {
     const access = await assertAccess("design", id, "viewer");
     const design = access.resource as typeof schema.designs.$inferSelect;

--- a/templates/design/agent-native.app-skill.json
+++ b/templates/design/agent-native.app-skill.json
@@ -13,7 +13,7 @@
   "local": {
     "template": "design",
     "sourcePath": ".",
-    "defaultUrl": "http://127.0.0.1:8101",
+    "defaultUrl": "http://127.0.0.1:8099",
     "commands": {
       "install": "pnpm install",
       "dev": "pnpm dev",


### PR DESCRIPTION
## Summary
- forward structured selected-asset context through MCP app host chat and model-context updates
- include selected asset structured content from the Assets picker so external hosts can use the chosen asset URL/title reliably
- correct the Design local app-skill URL to the template dev port

## Verification
- pnpm run prep
- ChatGPT stable connector: selected asset context reached continuation and produced an HTML card
- Claude stable connector: selected asset context reached continuation and produced an HTML artifact
- Assets Builder connect flow completed on stable ngrok and auto-generation produced 1 candidate
- Design v2 connector smoke: create design + generate renderable HTML