### PR TITLE
Design: link-only paste-back for variant picks + accept 2–5 directions

### DIFF
--- a/.changeset/design-variant-link-handoff.md
+++ b/.changeset/design-variant-link-handoff.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Design exploration now works cleanly from link-only coding agents (Codex, Claude Code CLI, Claude Desktop Code tab): after the user picks a direction in the browser, the editor shows a copyable summary to paste back into chat — matching the Assets picker's standalone handoff. `present-design-variants` now accepts 2–5 directions (3 is the sweet spot) instead of erroring on anything but exactly 3, and its result includes `fallbackInstructions` for the browser path. Docs walk the full install → generate → pick (inline vs link) → apply-to-code flow for both Assets and Design, with the exact paste-back summaries and an install-alias matrix.

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -113,6 +113,20 @@ Restart the agent client after connecting so it picks up the new MCP server; OAu
 
 Use `--client codex` (or `--client claude-code`, `--client claude-code-cli`, `--client cowork`, `--client all`) to skip the picker for scripts or one-off installs.
 
+First-party app skills install the instructions and the hosted MCP connector together with `skills add <name>`. Each has a short alias for demos and tutorials:
+
+```bash
+npx @agent-native/core@latest skills add assets              # aliases: images, image-generation
+npx @agent-native/core@latest skills add design-exploration  # aliases: design, ux-exploration
+```
+
+| Skill                | Alias    | For                    |
+| -------------------- | -------- | ---------------------- |
+| `assets`             | `images` | image/video generation |
+| `design-exploration` | `design` | UI/design exploration  |
+
+The default client is `codex`; add `--client claude-code` or `--client all` for others. Inline hosts (ChatGPT, Claude.ai, Claude Desktop main chat) render the picker / variant grid in chat; CLI/link-only hosts (Codex, Claude Code, Claude Desktop "Code" tab) return an "Open in … →" link where the user picks in the browser and pastes a handoff summary back.
+
 When you truly need an isolated app instead of Dispatch's workspace gateway,
 run the same command with that app's host:
 
@@ -408,7 +422,7 @@ List/search actions point at a record-focused view the same way — e.g. calenda
 
 For hosts that support the MCP Apps extension, an action can also advertise an inline UI resource with `mcpApp`. This is a progressive enhancement for flows where the external agent should hand the user an interactive surface instead of only text — for example reviewing an email draft, editing a calendar invite, or choosing between generated dashboard variants.
 
-Use the real React app with `embedRoute()` or `embedApp()` whenever the user needs UI. The mental model is simple: the action's `link` target is also the MCP App embed target. Expose the operation as a normal action/tool, return a focused deep link with `link`, and add `mcpApp.resource = embedApp(...)` so capable hosts load that same route inline instead of opening a new tab. When both should be built from the same route, prefer `embedRoute({ title, openLabel, path })`; it returns matching `link` and `mcpApp` action fields.
+Use the real React app with `embedRoute()` or `embedApp()` whenever the user needs UI. The mental model is simple: the action's `link` target is also the MCP App embed target. Expose the operation as a normal action/tool, return a focused deep link with `link`, and add `mcpApp.resource = embedApp(...)` so capable hosts load that same route inline instead of opening a new tab. When both should be built from the same route, prefer `embedRoute({ title, openLabel, path })`: it is the convenience wrapper that returns matching `link` and `mcpApp` fields from one call, while `embedApp(...)` is the lower-level resource you assign to `mcpApp.resource` directly.
 
 That means full-app embeds can do anything the route can do once opened: review or edit an email draft, show a filtered inbox/search, open a calendar event or event draft, load an extension page, inspect a full analytics dashboard or saved analysis, continue a deck in the Slides editor, or open a Design project/editor. Prefer URL/deep-link params and the existing `/_agent-native/open` navigation/app-state bridge over inventing a second state protocol for MCP Apps.
 

--- a/packages/core/docs/content/template-assets.md
+++ b/packages/core/docs/content/template-assets.md
@@ -43,6 +43,34 @@ Use it when your team needs reusable visual direction and searchable source asse
 - **Install as an app-backed skill.** The `agent-native.app-skill.json` manifest exports an Assets skill plus MCP connector metadata so marketplaces can install the app, its instructions, and its picker together.
 - **Serve other agents.** Slides, Design, Content, Mail, and Dispatch can call Assets through A2A to list libraries, generate batches, create videos, refine an asset, fetch exports, and render inline previews where embedding is allowed.
 
+## Using it from your coding agent
+
+Generate and pick brand media without leaving Codex, Claude Code, Claude, or ChatGPT.
+
+1. **Install once.** This adds the skill instructions and registers the hosted MCP connector together:
+
+   ```bash
+   npx @agent-native/core@latest skills add assets   # aliases: images, image-generation
+   ```
+
+   Default client is `codex`; add `--client claude-code` or `--client all` for others.
+
+2. **Ask for images.** In your agent's chat: "Generate three blog hero options from the Acme product shots." The agent opens the picker with candidate images you can regenerate, retune (prompt, aspect, count), and choose from.
+3. **Pick.** In inline hosts (ChatGPT, Claude.ai, Claude Desktop main chat) the picker renders right in the chat — click a candidate and the choice flows back automatically. On CLI/link-only hosts (Codex, Claude Code, Claude Desktop "Code" tab) you get an **"Open in Assets →"** link; open it, pick in the browser, then paste the copied handoff summary back into your chat — or just say "use image A".
+
+   ```text
+   Paste this selection back into your chat so the agent can use it.
+
+   Selected Assets image for the next step: <label>
+   Media URL: <url>
+   Use this selected asset in the current artifact or design.
+
+   Selected asset context:
+   { "selectedAsset": { "assetId": "...", "url": "...", "mediaType": "image", ... } }
+   ```
+
+4. **Apply to code.** The chosen Media URL and `assetId` come back to the agent, which uses the URL directly in the code it writes (an `<img>` src, a download) or calls `export-asset`.
+
 ## Why it's interesting
 
 Most AI media tools treat brand consistency as a prompt-writing problem. Assets treats it as application state: references, folders, collections, style briefs, run history, descriptions, and saved assets live in SQL, while binary media lives in object storage or the local file-upload fallback during development.

--- a/packages/core/docs/content/template-design.md
+++ b/packages/core/docs/content/template-design.md
@@ -29,9 +29,10 @@ be installed as an app-backed skill plus MCP connector:
 npx @agent-native/core@latest skills add design-exploration
 ```
 
-That gives the agent instructions to create a design shell, present three visual
-directions in the inline Design MCP app, wait for your pick, and iterate from
-the selected prototype.
+That gives the agent instructions to create a design shell, present 2-5 visual
+directions (3 is the sweet spot) in the inline Design MCP app, wait for your
+pick, and iterate from the selected prototype. See [Using it from your coding
+agent](#coding-agent) for the full flow.
 
 ## Useful Prompts
 
@@ -49,6 +50,33 @@ the selected prototype.
 - **Apply design systems.** Save and reuse design-system preferences so generated work stays closer to your brand.
 - **Import references.** Bring in existing HTML or reference material as context for a new design pass.
 - **Export real files.** Export HTML, ZIP, or PDF from the generated prototype.
+
+## Using It From Your Coding Agent {#coding-agent}
+
+Generate and pick design directions without leaving Codex, Claude Code, Claude, or ChatGPT.
+
+1. **Install once.** This adds the skill instructions and registers the hosted MCP connector together:
+
+   ```bash
+   npx @agent-native/core@latest skills add design-exploration   # aliases: design, ux-exploration
+   ```
+
+   Default client is `codex`; add `--client claude-code` or `--client all` for others.
+
+2. **Ask for directions.** In your agent's chat: "Create three landing-page directions for a technical analytics product." The agent generates 2-5 directions (3 is the sweet spot) you can compare side by side.
+3. **Pick.** In inline hosts (ChatGPT, Claude.ai, Claude Desktop main chat) the variant grid renders right in the chat — pick a direction and it auto-persists as `index.html`, then keep refining. On CLI/link-only hosts (Codex, Claude Code, Claude Desktop "Code" tab) you get an **"Open in Design →"** link; open it, pick in the browser, then paste the copied handoff summary back into your chat — or just say "I picked direction B".
+
+   ```text
+   Paste this back into your chat so your agent continues from the chosen design.
+
+   I picked the "<label>" design direction.
+   It's saved as index.html in design <designId>. Refine from here with get-design-snapshot + generate-design, or export-coding-handoff to bring it into code. Don't show new variants unless I ask.
+
+   Design selection context:
+   { "selectedDesign": { "designId": "...", "variantId": "...", "label": "...", "file": "index.html" } }
+   ```
+
+4. **Apply to code.** Run `export-coding-handoff`; it returns a tokenized raw-code URL plus a ready-to-paste prompt. Your coding agent fetches that URL and writes the code.
 
 ## Why It's Interesting
 

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -107,9 +107,15 @@ iteration, or a human-in-the-loop choice among design directions.
 
 - Use \`create-design\` first to create a project shell. Do not report the
   design as ready until it has renderable HTML.
-- For open-ended UX exploration, generate three distinct, complete HTML
-  directions and call \`present-design-variants\`. The inline Design MCP app
-  shows the options, lets the user pick one, and persists the selected variant.
+- For open-ended UX exploration, generate distinct, complete HTML directions
+  (2-5, three by default) and call \`present-design-variants\`. The inline
+  Design MCP app shows the options, lets the user pick one, and persists the
+  selected variant.
+- If the Design app opens as a browser link instead of inline (CLI hosts like
+  Codex / Claude Code, where the deep link carries \`handoff=chat\`), the user
+  picks a direction there and the editor shows a copyable summary — ask them to
+  paste it back into chat so you can continue from the chosen direction. The
+  \`present-design-variants\` result's \`fallbackInstructions\` describe this.
 - For direct refinements to an already chosen direction, call
   \`get-design-snapshot\`, edit from the current tuned HTML, then call
   \`generate-design\`.
@@ -118,7 +124,8 @@ iteration, or a human-in-the-loop choice among design directions.
 
 ## Exploration Defaults
 
-1. Default to three variants unless the user asks for a different count.
+1. Default to three variants unless the user asks for a different count
+   (\`present-design-variants\` accepts 2-5; three is the sweet spot).
 2. Make variants structurally and stylistically distinct, not just color swaps.
 3. Each variant must be a complete standalone HTML document that renders
    without a build step.

--- a/templates/design/.agents/skills/design-generation/SKILL.md
+++ b/templates/design/.agents/skills/design-generation/SKILL.md
@@ -34,10 +34,11 @@ Then, for any non-trivial first prompt, write `application-state/show-questions`
 #  uses the framework's `db-exec` to upsert into application_state.)
 ```
 
-### Phase 2 — Generate three side-by-side variations
+### Phase 2 — Generate side-by-side variations (2-5, three by default)
 
-For new designs, default to **three** variations. In normal app-agent flows,
-write candidates to `application-state/design-variants`:
+For new designs, default to **three** variations (`present-design-variants`
+accepts 2-5; three is the sweet spot). In normal app-agent flows, write
+candidates to `application-state/design-variants`:
 
 ```json
 {
@@ -58,9 +59,17 @@ The framework persists the chosen content as `index.html` automatically when the
 When the caller is an external MCP host (ChatGPT, Claude, Claude Code, Codex,
 Dispatch), call `present-design-variants` instead of writing
 `application-state` directly. Pass the existing `designId`, a concise prompt
-caption, and 2-5 complete HTML variants. The action opens the same editor
-variant picker as the first-party app and keeps the workflow visible inside
-MCP Apps. After that, wait for the user's pick before refining.
+caption, and 2-5 complete HTML variants (three by default). The action opens
+the same editor variant picker as the first-party app and keeps the workflow
+visible inside MCP Apps. After that, wait for the user's pick before refining.
+
+For inline MCP-app hosts (ChatGPT / Claude / Claude Desktop main chat) the pick
+rides the chat bridge automatically — no copy/paste. But if the Design app opens
+as a browser link instead of inline (CLI hosts like Codex / Claude Code, where
+the deep link carries `handoff=chat`), the user picks a direction there and the
+editor shows a copyable handoff summary (auto-copied to the clipboard) — ask
+them to paste it back into chat so you can continue from the chosen direction.
+The `present-design-variants` result's `fallbackInstructions` describe this.
 
 ### Phase 3 — Save with `generate-design` (when not using variants)
 

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -45,9 +45,15 @@ patterns live in `.agents/skills/`.
   It installs the exported Design exploration instructions and registers the
   hosted Design MCP connector together.
 - For human-in-the-loop UI exploration, create a design shell, call
-  `present-design-variants` with 2-5 complete HTML directions, wait for the
-  user to pick one, then use `get-design-snapshot` and `generate-design` for
-  follow-up refinements.
+  `present-design-variants` with 2-5 complete HTML directions (three by
+  default), wait for the user to pick one, then use `get-design-snapshot` and
+  `generate-design` for follow-up refinements.
+- Inline MCP-app hosts (ChatGPT / Claude / Claude Desktop main chat) carry the
+  pick back over the chat bridge automatically. If the Design app instead opens
+  as a browser link (CLI hosts like Codex / Claude Code, deep link carries
+  `handoff=chat`), the user picks there and the editor shows a copyable summary
+  (also in `present-design-variants` result `fallbackInstructions`) — ask them
+  to paste it back into chat so you can continue from the chosen direction.
 
 ## Skills
 

--- a/templates/design/actions/present-design-variants.spec.ts
+++ b/templates/design/actions/present-design-variants.spec.ts
@@ -65,9 +65,10 @@ describe("present-design-variants", () => {
     expect(result).toMatchObject({
       designId: "design_123",
       count: 3,
-      path: "/design/design_123",
+      path: "/design/design_123?handoff=chat",
       embed: true,
     });
+    expect(typeof result.fallbackInstructions).toBe("string");
     expect(action.mcpApp?.compactCatalog).toBe(true);
     expect(action.mcpApp?.resource.title).toBe("Design directions");
     expect(action.mcpApp?.resource.html()).toContain(
@@ -75,23 +76,23 @@ describe("present-design-variants", () => {
     );
   });
 
-  it("requires exactly three variants for the MCP picker flow", () => {
-    const base = {
+  it("accepts 2-5 variants for the MCP picker flow", () => {
+    const variant = (n: number) => ({
+      id: `v${n}`,
+      label: `V${n}`,
+      content: `<html>${n}</html>`,
+    });
+    const withVariants = (count: number) => ({
       designId: "design_123",
-      variants: [
-        { id: "one", label: "One", content: "<html>One</html>" },
-        { id: "two", label: "Two", content: "<html>Two</html>" },
-        { id: "three", label: "Three", content: "<html>Three</html>" },
-      ],
-    };
+      variants: Array.from({ length: count }, (_, i) => variant(i + 1)),
+    });
 
-    expect(action.schema.safeParse(base).success).toBe(true);
-    expect(
-      action.schema.safeParse({
-        ...base,
-        variants: base.variants.slice(0, 2),
-      }).success,
-    ).toBe(false);
+    // 3 is the sweet spot, but 2-5 are all valid; 1 and 6 are rejected.
+    expect(action.schema.safeParse(withVariants(2)).success).toBe(true);
+    expect(action.schema.safeParse(withVariants(3)).success).toBe(true);
+    expect(action.schema.safeParse(withVariants(5)).success).toBe(true);
+    expect(action.schema.safeParse(withVariants(1)).success).toBe(false);
+    expect(action.schema.safeParse(withVariants(6)).success).toBe(false);
   });
 
   it("returns an editor deep link for external hosts", async () => {

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -10,9 +10,17 @@ function designDeepLink(designId: string): string {
     app: "design",
     view: "editor",
     params: { designId },
-    to: `/design/${encodeURIComponent(designId)}`,
+    // `handoff=chat` marks a link opened from a link-only host (CLI / Codex /
+    // Claude Code) so the editor shows a copyable paste-back summary after the
+    // user picks — the choice can't ride a host chat bridge there.
+    to: `/design/${encodeURIComponent(designId)}?handoff=chat`,
   });
 }
+
+const FALLBACK_INSTRUCTIONS =
+  "If the design opens as a browser link instead of inline, the user picks a " +
+  "direction there and the editor shows a copyable summary. Ask them to paste " +
+  "that summary back into chat so you can continue from the chosen direction.";
 
 const variantSchema = z.object({
   id: z.string().min(1).describe("Stable variant id, e.g. 'minimal-focus'"),
@@ -30,10 +38,11 @@ const variantSchema = z.object({
 
 export default defineAction({
   description:
-    "Present exactly 3 generated design directions in the Design editor so the " +
-    "user can visually compare options and pick one. Use this for design " +
-    "exploration before calling generate-design. The user's choice is " +
-    "persisted automatically by the app.",
+    "Present generated design directions in the Design editor so the user can " +
+    "visually compare options and pick one. Provide 2-5 variants (3 is the " +
+    "sweet spot). Use this for design exploration before calling " +
+    "generate-design. The user's choice is persisted automatically by the app; " +
+    "if it opens as a browser link, they paste a copyable summary back to chat.",
   schema: z.object({
     designId: z.string().describe("Design project ID to show variants for"),
     prompt: z
@@ -42,9 +51,10 @@ export default defineAction({
       .describe("Caption shown above the variant grid"),
     variants: z
       .array(variantSchema)
-      .length(3)
+      .min(2)
+      .max(5)
       .describe(
-        "Exactly 3 concise, visually distinct generated design options to preview side by side. Inline CSS so all options render in the MCP app preview.",
+        "2-5 concise, visually distinct generated design options to preview side by side (3 is the sweet spot). Inline CSS so all options render in the MCP app preview.",
       ),
   }),
   mcpApp: {
@@ -71,8 +81,9 @@ export default defineAction({
       designId,
       prompt: prompt ?? "Pick a direction",
       count: variants.length,
-      path: `/design/${encodeURIComponent(designId)}`,
+      path: `/design/${encodeURIComponent(designId)}?handoff=chat`,
       embed: true,
+      fallbackInstructions: FALLBACK_INSTRUCTIONS,
       nextRequiredAction:
         "Wait for the user to pick a variant before refining or calling generate-design.",
     };

--- a/templates/design/app/components/design/VariantHandoffCard.tsx
+++ b/templates/design/app/components/design/VariantHandoffCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { IconCheck, IconCopy } from "@tabler/icons-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -11,26 +11,45 @@ interface VariantHandoffCardProps {
 }
 
 /**
- * Shown after a pick when the editor was opened from a link-only host (CLI /
- * Codex / Claude Code) that can't relay the choice over a chat bridge. The
- * summary is already on the clipboard; this makes the next step obvious and
- * lets the user re-copy or select it by hand.
+ * Shown after a pick (or dismiss) when the editor was opened from a link-only
+ * host (CLI / Codex / Claude Code) that can't relay the choice over a chat
+ * bridge. The card owns the clipboard write so its "Copied" state stays
+ * truthful even when the browser blocks programmatic copy.
  */
 export function VariantHandoffCard({
   pick,
   onDismiss,
 }: VariantHandoffCardProps) {
-  const [copied, setCopied] = useState(true);
+  const [copied, setCopied] = useState(false);
 
-  const copy = async () => {
+  const writeClipboard = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(pick.text);
-      setCopied(true);
-      toast.success("Summary copied");
+      return true;
     } catch {
-      setCopied(false);
-      toast.info("Select the summary to copy it");
+      return false;
     }
+  }, [pick.text]);
+
+  // Auto-copy on mount, but reflect what actually happened: if the browser
+  // blocks the write, leave the button on "Copy summary" so the user knows to
+  // copy (or select) it themselves.
+  useEffect(() => {
+    let active = true;
+    void writeClipboard().then((ok) => {
+      if (active) setCopied(ok);
+    });
+    return () => {
+      active = false;
+    };
+  }, [writeClipboard]);
+
+  const onCopyClick = async () => {
+    const ok = await writeClipboard();
+    setCopied(ok);
+    toast[ok ? "success" : "info"](
+      ok ? "Summary copied" : "Select the summary to copy it",
+    );
   };
 
   return (
@@ -42,17 +61,18 @@ export function VariantHandoffCard({
           </span>
           <div className="min-w-0">
             <div className="text-sm font-medium leading-tight">
-              Direction selected
+              {pick.heading}
             </div>
-            <div className="truncate text-xs text-muted-foreground">
-              “{pick.label}”
-            </div>
+            {pick.label && (
+              <div className="truncate text-xs text-muted-foreground">
+                “{pick.label}”
+              </div>
+            )}
           </div>
         </div>
 
         <p className="mt-3 text-sm text-muted-foreground">
-          Paste this summary into your coding agent to continue from this
-          direction.
+          Paste this summary into your coding agent to continue.
         </p>
 
         <Textarea
@@ -71,7 +91,11 @@ export function VariantHandoffCard({
           >
             Dismiss
           </Button>
-          <Button size="sm" className="cursor-pointer gap-1.5" onClick={copy}>
+          <Button
+            size="sm"
+            className="cursor-pointer gap-1.5"
+            onClick={onCopyClick}
+          >
             {copied ? (
               <IconCheck className="h-3.5 w-3.5" />
             ) : (

--- a/templates/design/app/components/design/VariantHandoffCard.tsx
+++ b/templates/design/app/components/design/VariantHandoffCard.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { IconCheck, IconCopy } from "@tabler/icons-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type { StandalonePick } from "@/hooks/use-variant-flow";
+
+interface VariantHandoffCardProps {
+  pick: StandalonePick;
+  onDismiss: () => void;
+}
+
+/**
+ * Shown after a pick when the editor was opened from a link-only host (CLI /
+ * Codex / Claude Code) that can't relay the choice over a chat bridge. The
+ * summary is already on the clipboard; this makes the next step obvious and
+ * lets the user re-copy or select it by hand.
+ */
+export function VariantHandoffCard({
+  pick,
+  onDismiss,
+}: VariantHandoffCardProps) {
+  const [copied, setCopied] = useState(true);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(pick.text);
+      setCopied(true);
+      toast.success("Summary copied");
+    } catch {
+      setCopied(false);
+      toast.info("Select the summary to copy it");
+    }
+  };
+
+  return (
+    <div className="absolute inset-0 z-40 grid place-items-center bg-background/80 p-4 backdrop-blur-sm">
+      <div className="w-full max-w-md rounded-xl border border-border bg-card p-5 shadow-lg">
+        <div className="flex items-center gap-2.5">
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary">
+            <IconCheck className="h-3.5 w-3.5 text-primary-foreground" />
+          </span>
+          <div className="min-w-0">
+            <div className="text-sm font-medium leading-tight">
+              Direction selected
+            </div>
+            <div className="truncate text-xs text-muted-foreground">
+              “{pick.label}”
+            </div>
+          </div>
+        </div>
+
+        <p className="mt-3 text-sm text-muted-foreground">
+          Paste this summary into your coding agent to continue from this
+          direction.
+        </p>
+
+        <Textarea
+          readOnly
+          value={pick.text}
+          className="mt-3 h-28 resize-none border-border/70 bg-muted/40 font-mono text-[11px] leading-relaxed"
+          onFocus={(event) => event.currentTarget.select()}
+        />
+
+        <div className="mt-3 flex justify-end gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="cursor-pointer"
+            onClick={onDismiss}
+          >
+            Dismiss
+          </Button>
+          <Button size="sm" className="cursor-pointer gap-1.5" onClick={copy}>
+            {copied ? (
+              <IconCheck className="h-3.5 w-3.5" />
+            ) : (
+              <IconCopy className="h-3.5 w-3.5" />
+            )}
+            {copied ? "Copied" : "Copy summary"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/templates/design/app/hooks/use-variant-flow.ts
+++ b/templates/design/app/hooks/use-variant-flow.ts
@@ -21,10 +21,12 @@ interface VariantState {
   prompt?: string;
 }
 
-/** A picked variant surfaced as a copyable handoff for link-only hosts. */
+/** A pick/dismiss surfaced as a copyable handoff for link-only hosts. */
 export interface StandalonePick {
-  label: string;
-  variantId: string;
+  /** Card heading, e.g. "Direction selected" or "Closed without picking". */
+  heading: string;
+  /** Chosen variant name, when a direction was picked. */
+  label?: string;
   /** Paste-back text the user copies into their coding agent's chat. */
   text: string;
 }
@@ -69,6 +71,14 @@ function variantHandoffText(
     "",
     "Design selection context:",
     JSON.stringify(context, null, 2),
+  ].join("\n");
+}
+
+function variantDismissText(): string {
+  return [
+    "Paste this back into your chat to keep going.",
+    "",
+    "I closed the design directions without picking one. Show me a different direction.",
   ].join("\n");
 }
 
@@ -207,12 +217,13 @@ export function useVariantFlow(designId: string | undefined) {
         });
       } else if (isLinkOnlyHandoff()) {
         // Link-only host (CLI / Codex / Claude Code): no chat bridge — show a
-        // copyable summary the user pastes back into their coding agent.
-        const text = variantHandoffText(designId, chosen, persisted);
-        setStandalonePick({ label: chosen.label, variantId: chosen.id, text });
-        if (typeof navigator !== "undefined" && navigator.clipboard) {
-          navigator.clipboard.writeText(text).catch(() => {});
-        }
+        // copyable summary the user pastes back into their coding agent. The
+        // card owns the clipboard write so its "Copied" state stays truthful.
+        setStandalonePick({
+          heading: "Direction selected",
+          label: chosen.label,
+          text: variantHandoffText(designId, chosen, persisted),
+        });
       } else {
         // First-party app: post the pick to its own agent sidebar composer.
         sendToAgentChat({
@@ -233,7 +244,15 @@ export function useVariantFlow(designId: string | undefined) {
 
   const dismiss = useCallback(() => {
     clear();
-    if (isLinkOnlyHandoff() && !isEmbedAuthActive()) return;
+    if (isLinkOnlyHandoff() && !isEmbedAuthActive()) {
+      // No chat bridge to relay the dismissal — give the user a copyable note
+      // so their coding agent doesn't wait on a pick that isn't coming.
+      setStandalonePick({
+        heading: "Closed without picking",
+        text: variantDismissText(),
+      });
+      return;
+    }
     sendToAgentChat({
       message: "Close the variants — none of these.",
       context:

--- a/templates/design/app/hooks/use-variant-flow.ts
+++ b/templates/design/app/hooks/use-variant-flow.ts
@@ -1,6 +1,10 @@
 import { useEffect, useCallback, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { sendToAgentChat, agentNativePath } from "@agent-native/core/client";
+import {
+  sendToAgentChat,
+  agentNativePath,
+  isEmbedAuthActive,
+} from "@agent-native/core/client";
 
 export const DESIGN_VARIANT_PICKED_EVENT = "agent-native-design-variant-picked";
 
@@ -17,18 +21,74 @@ interface VariantState {
   prompt?: string;
 }
 
+/** A picked variant surfaced as a copyable handoff for link-only hosts. */
+export interface StandalonePick {
+  label: string;
+  variantId: string;
+  /** Paste-back text the user copies into their coding agent's chat. */
+  text: string;
+}
+
+/**
+ * True when this editor was opened from a link-only host (CLI / Codex / Claude
+ * Code) that can't render the inline MCP app — the deep link carries
+ * `handoff=chat`. There's no host chat bridge to receive the pick, so after the
+ * user chooses we show a copyable summary to paste back into their agent.
+ */
+function isLinkOnlyHandoff(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return (
+      new URLSearchParams(window.location.search).get("handoff") === "chat"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function variantHandoffText(
+  designId: string,
+  variant: VariantCandidate,
+  persisted: boolean,
+): string {
+  const context = {
+    selectedDesign: {
+      designId,
+      variantId: variant.id,
+      label: variant.label,
+      file: "index.html",
+    },
+  };
+  return [
+    "Paste this back into your chat so your agent continues from the chosen design.",
+    "",
+    `I picked the "${variant.label}" design direction.`,
+    persisted
+      ? `It's saved as index.html in design ${designId}. Refine from here with get-design-snapshot + generate-design, or export-coding-handoff to bring it into code. Don't show new variants unless I ask.`
+      : `Saving didn't finish — re-run present-design-variants or generate-design for design ${designId} before refining.`,
+    "",
+    "Design selection context:",
+    JSON.stringify(context, null, 2),
+  ].join("\n");
+}
+
 /**
  * Polls `application-state/design-variants`. When the agent generates 2-5
  * candidate variations, it writes them here; the editor surfaces a
  * full-canvas grid (Claude Design-style: pick a direction before refining).
  *
  * On "Use this one", the chosen variant's HTML is persisted to the design as
- * `index.html` via `generate-design`, the agent is messaged so it has the
- * choice in its history, and the variant state is cleared.
+ * `index.html` via `generate-design`, and the pick is reported back through the
+ * right channel for the host: an embedded MCP host gets a chat message over the
+ * bridge; the first-party app posts to its own sidebar; a link-only host (CLI)
+ * gets a copyable summary to paste back. The variant state is then cleared.
  */
 export function useVariantFlow(designId: string | undefined) {
   const qc = useQueryClient();
   const [state, setState] = useState<VariantState | null>(null);
+  const [standalonePick, setStandalonePick] = useState<StandalonePick | null>(
+    null,
+  );
 
   const { data } = useQuery({
     queryKey: ["design-variants"],
@@ -69,6 +129,8 @@ export function useVariantFlow(designId: string | undefined) {
     }).catch(() => {});
   }, [qc]);
 
+  const dismissStandalonePick = useCallback(() => setStandalonePick(null), []);
+
   const useVariant = useCallback(
     async (variantId: string) => {
       if (!state || !designId) return;
@@ -76,8 +138,7 @@ export function useVariantFlow(designId: string | undefined) {
       if (!chosen) return;
 
       // Persist the chosen variant as the design's primary file via the
-      // agent's own action endpoint. We keep the agent informed via chat so
-      // subsequent edits target the picked direction.
+      // agent's own action endpoint so every host lands on the same design.
       let persisted = false;
       try {
         const res = await fetch(
@@ -115,31 +176,55 @@ export function useVariantFlow(designId: string | undefined) {
             );
           }
         } else {
-          // Surface the failure rather than telling the agent the variant was
-          // saved when the server actually rejected it. The picker still
-          // clears so the user isn't stuck — they can re-pick after retrying.
           console.warn(
             `[use-variant-flow] generate-design returned ${res.status}; variant not persisted`,
           );
         }
       } catch {
-        // Network error: clear the picker anyway so the user isn't stuck;
-        // the agent message below records that they made a choice.
+        // Network error: report the choice below so the agent still records it;
+        // the grid still clears so the user isn't stuck.
       }
 
-      sendToAgentChat({
-        message: `I picked "${chosen.label}".`,
-        context: [
-          `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${designId}.`,
-          persisted
-            ? `Its content has been saved as index.html. Continue refining from there if the user asks.`
-            : `Saving the chosen variant did not complete. Ask the user whether to retry before refining it.`,
-          persisted
-            ? `Do not show further variants unless the user explicitly asks for "more options" or "alternatives".`
-            : `Do not claim the design file was updated until generate-design succeeds.`,
-        ].join("\n"),
-        submit: false,
-      });
+      const refineHint = persisted
+        ? `Its content has been saved as index.html. Continue refining from there if the user asks.`
+        : `Saving the chosen variant did not complete. Ask the user whether to retry before refining it.`;
+      const guardHint = persisted
+        ? `Do not show further variants unless the user explicitly asks for "more options" or "alternatives".`
+        : `Do not claim the design file was updated until generate-design succeeds.`;
+
+      if (isEmbedAuthActive()) {
+        // Embedded MCP host (ChatGPT / Claude): the pick rides the host chat
+        // bridge straight into the conversation.
+        sendToAgentChat({
+          message: `I picked "${chosen.label}".`,
+          context: [
+            `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${designId} inside the embedded Design app.`,
+            refineHint,
+            guardHint,
+          ].join("\n"),
+          submit: true,
+          openSidebar: false,
+        });
+      } else if (isLinkOnlyHandoff()) {
+        // Link-only host (CLI / Codex / Claude Code): no chat bridge — show a
+        // copyable summary the user pastes back into their coding agent.
+        const text = variantHandoffText(designId, chosen, persisted);
+        setStandalonePick({ label: chosen.label, variantId: chosen.id, text });
+        if (typeof navigator !== "undefined" && navigator.clipboard) {
+          navigator.clipboard.writeText(text).catch(() => {});
+        }
+      } else {
+        // First-party app: post the pick to its own agent sidebar composer.
+        sendToAgentChat({
+          message: `I picked "${chosen.label}".`,
+          context: [
+            `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${designId}.`,
+            refineHint,
+            guardHint,
+          ].join("\n"),
+          submit: false,
+        });
+      }
 
       clear();
     },
@@ -148,6 +233,7 @@ export function useVariantFlow(designId: string | undefined) {
 
   const dismiss = useCallback(() => {
     clear();
+    if (isLinkOnlyHandoff() && !isEmbedAuthActive()) return;
     sendToAgentChat({
       message: "Close the variants — none of these.",
       context:
@@ -156,5 +242,5 @@ export function useVariantFlow(designId: string | undefined) {
     });
   }, [clear]);
 
-  return { state, useVariant, dismiss };
+  return { state, useVariant, dismiss, standalonePick, dismissStandalonePick };
 }

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -38,7 +38,6 @@ import {
   NotificationsBell,
   ShareButton,
   isEmbedAuthActive,
-  sendToAgentChat,
   type CollabUser,
   type PromptComposerSubmitOptions,
 } from "@agent-native/core/client";
@@ -61,6 +60,7 @@ import { MultiScreenCanvas } from "@/components/design/MultiScreenCanvas";
 import { QuestionFlow } from "@/components/design/QuestionFlow";
 import { TweaksPanel } from "@/components/design/TweaksPanel";
 import { VariantGrid } from "@/components/design/VariantGrid";
+import { VariantHandoffCard } from "@/components/design/VariantHandoffCard";
 import { SaveStatusIndicator } from "@/components/visual-editor";
 import PromptPopover from "@/components/editor/PromptDialog";
 import type { UploadedFile } from "@/components/editor/PromptDialog";
@@ -337,30 +337,11 @@ export default function DesignEditor() {
   } = useQuestionFlow(id);
   const {
     state: pendingVariants,
-    useVariant: handleUseVariant,
+    useVariant: handleVariantChoice,
     dismiss: handleVariantsDismiss,
+    standalonePick,
+    dismissStandalonePick,
   } = useVariantFlow(id);
-  const handleVariantChoice = useCallback(
-    async (variantId: string) => {
-      const chosen = pendingVariants?.variants.find(
-        (variant) => variant.id === variantId,
-      );
-      await handleUseVariant(variantId);
-
-      if (!embedded || !chosen || !id) return;
-      sendToAgentChat({
-        message: `I picked "${chosen.label}".`,
-        context: [
-          `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${id} inside the embedded Design MCP app.`,
-          "Continue from the chosen direction when the user asks for refinements.",
-          'If the user asks for another iteration, use get-design-snapshot and generate-design against the current index.html; do not present new variants unless they ask for "more options" or "alternatives".',
-        ].join("\n"),
-        submit: true,
-        openSidebar: false,
-      });
-    },
-    [embedded, handleUseVariant, id, pendingVariants],
-  );
 
   const { session } = useSession();
 
@@ -1908,6 +1889,15 @@ ${serializedHtml}
               />
             </div>
           </div>
+        )}
+
+        {/* Link-only (CLI / Codex / Claude Code) paste-back: after a pick there
+            is no chat bridge, so surface a copyable summary to continue. */}
+        {standalonePick && (
+          <VariantHandoffCard
+            pick={standalonePick}
+            onDismiss={dismissStandalonePick}
+          />
         )}
 
         {/* Canvas */}


### PR DESCRIPTION
## Why

When you generate design directions from a **link-only coding agent** — Codex, Claude Code CLI, the Claude Desktop **Code** tab — the MCP server returns an "Open in Design →" link instead of an inline app. You open it, pick a direction… and then there was **no way to tell your agent which one you picked**. The pick only traveled over a chat bridge that those hosts don't have (only ChatGPT / Claude.ai / Claude Desktop main chat render the inline MCP app and relay the choice automatically).

The Assets picker already solved this with a copyable paste-back summary. Design didn't have it — that was the gap.

Two smaller correctness issues surfaced alongside:
- `present-design-variants` **hard-required exactly 3** variants (`.length(3)`), while the skill/AGENTS docs told the agent to send **2–5** → agents following the docs hit a Zod error.
- The "communicate the pick back to chat" flow was documented for Assets but **not for Design**, and the end-to-end "install → generate → pick → apply to code" path wasn't written down as one walkthrough.

## What changed

**Design variant link-only paste-back (the fix)**
- The `present-design-variants` deep link now carries `handoff=chat`. When the editor is opened that way (i.e. from a link-only host) and a pick is made, it shows a clean, dismissible **paste-back card** with a copyable summary (auto-copied to clipboard) — mirroring the Assets picker's standalone handoff. Embedded MCP hosts still relay the pick over the chat bridge as before; normal in-app picks still post to the in-app sidebar.
- `useVariantFlow` now owns all post-pick messaging (embedded → host chat; first-party → sidebar; link-only → paste-back card), removing a double-send that existed when embedded.
- New `VariantHandoffCard` component (Apple/Linear/Vercel-clean: centered card, check + label, copyable mono summary, Copy / Dismiss).

**Count fix**
- `present-design-variants` accepts **2–5 variants (3 is the sweet spot)** instead of erroring on anything but 3. Result now includes `fallbackInstructions`.

**Docs**
- `template-assets.md` + `template-design.md`: a single "Using it from your coding agent" walkthrough — install → ask for images/designs → pick (inline vs. open-the-link + paste the summary, or just "use image A") → apply to code. Each shows the exact handoff summary.
- `external-agents.md`: install-alias matrix (`assets`≈`images`, `design-exploration`≈`design`) + an `embedApp` vs `embedRoute` clarification.
- Agent-facing instructions (`skills.ts` Design skill, `design-generation/SKILL.md`, design `AGENTS.md`) now describe the browser/link fallback and use consistent "2–5 (3 default)" wording.

## Testing
- `packages/core` typecheck ✓, CLI + embed-app tests ✓ (24)
- `templates/design` typecheck ✓, full suite ✓ (21) — incl. updated `present-design-variants.spec.ts` (2–5 range, `handoff=chat` path, `fallbackInstructions`)
- Prettier ✓ on all changed files

The new paste-back card is gated on `handoff=chat` + not-embedded, so it never shows for inline hosts or normal in-app browsing.