### PR TITLE
feat(design): sleeker toolbar, skeleton loaders, prototype link fix, sharper generation

### DIFF
--- a/.changeset/clean-skill-installs.md
+++ b/.changeset/clean-skill-installs.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Align app-backed skill installs with user-scope requests, keep full JSON install output machine-readable, and let Connect/device-code flows mint standard MCP OAuth tokens when A2A_SECRET is absent.
+Align app-backed skill installs with user-scope requests, keep full JSON install output machine-readable, and let Connect/device-code flows mint standard MCP OAuth tokens with full-catalog coding-agent configs when A2A_SECRET is absent.

--- a/.changeset/clean-skill-installs.md
+++ b/.changeset/clean-skill-installs.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Align app-backed skill installs with user-scope requests, keep full JSON install output machine-readable, and let Connect/device-code flows mint standard MCP OAuth tokens with full-catalog coding-agent configs when A2A_SECRET is absent.
+Align app-backed skill installs with user-scope requests, keep full JSON install output machine-readable, and let Connect/device-code flows mint standard MCP OAuth tokens with full-catalog coding-agent configs when A2A_SECRET is absent or blank.

--- a/.changeset/clean-skill-installs.md
+++ b/.changeset/clean-skill-installs.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Align app-backed skill installs with user-scope requests, keep full JSON install output machine-readable, and let Connect/device-code flows mint standard MCP OAuth tokens when A2A_SECRET is absent.

--- a/.changeset/design-variant-link-handoff.md
+++ b/.changeset/design-variant-link-handoff.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Design exploration now works cleanly from link-only coding agents (Codex, Claude Code CLI, Claude Desktop Code tab): after the user picks a direction in the browser, the editor shows a copyable summary to paste back into chat — matching the Assets picker's standalone handoff. `present-design-variants` now accepts 2–5 directions (3 is the sweet spot) instead of erroring on anything but exactly 3, and its result includes `fallbackInstructions` for the browser path. Docs walk the full install → generate → pick (inline vs link) → apply-to-code flow for both Assets and Design, with the exact paste-back summaries and an install-alias matrix.

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -113,6 +113,20 @@ Restart the agent client after connecting so it picks up the new MCP server; OAu
 
 Use `--client codex` (or `--client claude-code`, `--client claude-code-cli`, `--client cowork`, `--client all`) to skip the picker for scripts or one-off installs.
 
+First-party app skills install the instructions and the hosted MCP connector together with `skills add <name>`. Each has a short alias for demos and tutorials:
+
+```bash
+npx @agent-native/core@latest skills add assets              # aliases: images, image-generation
+npx @agent-native/core@latest skills add design-exploration  # aliases: design, ux-exploration
+```
+
+| Skill                | Alias    | For                    |
+| -------------------- | -------- | ---------------------- |
+| `assets`             | `images` | image/video generation |
+| `design-exploration` | `design` | UI/design exploration  |
+
+The default client is `codex`; add `--client claude-code` or `--client all` for others. Inline hosts (ChatGPT, Claude.ai, Claude Desktop main chat) render the picker / variant grid in chat; CLI/link-only hosts (Codex, Claude Code, Claude Desktop "Code" tab) return an "Open in … →" link where the user picks in the browser and pastes a handoff summary back.
+
 When you truly need an isolated app instead of Dispatch's workspace gateway,
 run the same command with that app's host:
 
@@ -408,7 +422,7 @@ List/search actions point at a record-focused view the same way — e.g. calenda
 
 For hosts that support the MCP Apps extension, an action can also advertise an inline UI resource with `mcpApp`. This is a progressive enhancement for flows where the external agent should hand the user an interactive surface instead of only text — for example reviewing an email draft, editing a calendar invite, or choosing between generated dashboard variants.
 
-Use the real React app with `embedRoute()` or `embedApp()` whenever the user needs UI. The mental model is simple: the action's `link` target is also the MCP App embed target. Expose the operation as a normal action/tool, return a focused deep link with `link`, and add `mcpApp.resource = embedApp(...)` so capable hosts load that same route inline instead of opening a new tab. When both should be built from the same route, prefer `embedRoute({ title, openLabel, path })`; it returns matching `link` and `mcpApp` action fields.
+Use the real React app with `embedRoute()` or `embedApp()` whenever the user needs UI. The mental model is simple: the action's `link` target is also the MCP App embed target. Expose the operation as a normal action/tool, return a focused deep link with `link`, and add `mcpApp.resource = embedApp(...)` so capable hosts load that same route inline instead of opening a new tab. When both should be built from the same route, prefer `embedRoute({ title, openLabel, path })`: it is the convenience wrapper that returns matching `link` and `mcpApp` fields from one call, while `embedApp(...)` is the lower-level resource you assign to `mcpApp.resource` directly.
 
 That means full-app embeds can do anything the route can do once opened: review or edit an email draft, show a filtered inbox/search, open a calendar event or event draft, load an extension page, inspect a full analytics dashboard or saved analysis, continue a deck in the Slides editor, or open a Design project/editor. Prefer URL/deep-link params and the existing `/_agent-native/open` navigation/app-state bridge over inventing a second state protocol for MCP Apps.
 

--- a/packages/core/docs/content/template-assets.md
+++ b/packages/core/docs/content/template-assets.md
@@ -43,6 +43,34 @@ Use it when your team needs reusable visual direction and searchable source asse
 - **Install as an app-backed skill.** The `agent-native.app-skill.json` manifest exports an Assets skill plus MCP connector metadata so marketplaces can install the app, its instructions, and its picker together.
 - **Serve other agents.** Slides, Design, Content, Mail, and Dispatch can call Assets through A2A to list libraries, generate batches, create videos, refine an asset, fetch exports, and render inline previews where embedding is allowed.
 
+## Using it from your coding agent
+
+Generate and pick brand media without leaving Codex, Claude Code, Claude, or ChatGPT.
+
+1. **Install once.** This adds the skill instructions and registers the hosted MCP connector together:
+
+   ```bash
+   npx @agent-native/core@latest skills add assets   # aliases: images, image-generation
+   ```
+
+   Default client is `codex`; add `--client claude-code` or `--client all` for others.
+
+2. **Ask for images.** In your agent's chat: "Generate three blog hero options from the Acme product shots." The agent opens the picker with candidate images you can regenerate, retune (prompt, aspect, count), and choose from.
+3. **Pick.** In inline hosts (ChatGPT, Claude.ai, Claude Desktop main chat) the picker renders right in the chat — click a candidate and the choice flows back automatically. On CLI/link-only hosts (Codex, Claude Code, Claude Desktop "Code" tab) you get an **"Open in Assets →"** link; open it, pick in the browser, then paste the copied handoff summary back into your chat — or just say "use image A".
+
+   ```text
+   Paste this selection back into your chat so the agent can use it.
+
+   Selected Assets image for the next step: <label>
+   Media URL: <url>
+   Use this selected asset in the current artifact or design.
+
+   Selected asset context:
+   { "selectedAsset": { "assetId": "...", "url": "...", "mediaType": "image", ... } }
+   ```
+
+4. **Apply to code.** The chosen Media URL and `assetId` come back to the agent, which uses the URL directly in the code it writes (an `<img>` src, a download) or calls `export-asset`.
+
 ## Why it's interesting
 
 Most AI media tools treat brand consistency as a prompt-writing problem. Assets treats it as application state: references, folders, collections, style briefs, run history, descriptions, and saved assets live in SQL, while binary media lives in object storage or the local file-upload fallback during development.

--- a/packages/core/docs/content/template-design.md
+++ b/packages/core/docs/content/template-design.md
@@ -29,9 +29,10 @@ be installed as an app-backed skill plus MCP connector:
 npx @agent-native/core@latest skills add design-exploration
 ```
 
-That gives the agent instructions to create a design shell, present three visual
-directions in the inline Design MCP app, wait for your pick, and iterate from
-the selected prototype.
+That gives the agent instructions to create a design shell, present 2-5 visual
+directions (3 is the sweet spot) in the inline Design MCP app, wait for your
+pick, and iterate from the selected prototype. See [Using it from your coding
+agent](#coding-agent) for the full flow.
 
 ## Useful Prompts
 
@@ -49,6 +50,33 @@ the selected prototype.
 - **Apply design systems.** Save and reuse design-system preferences so generated work stays closer to your brand.
 - **Import references.** Bring in existing HTML or reference material as context for a new design pass.
 - **Export real files.** Export HTML, ZIP, or PDF from the generated prototype.
+
+## Using It From Your Coding Agent {#coding-agent}
+
+Generate and pick design directions without leaving Codex, Claude Code, Claude, or ChatGPT.
+
+1. **Install once.** This adds the skill instructions and registers the hosted MCP connector together:
+
+   ```bash
+   npx @agent-native/core@latest skills add design-exploration   # aliases: design, ux-exploration
+   ```
+
+   Default client is `codex`; add `--client claude-code` or `--client all` for others.
+
+2. **Ask for directions.** In your agent's chat: "Create three landing-page directions for a technical analytics product." The agent generates 2-5 directions (3 is the sweet spot) you can compare side by side.
+3. **Pick.** In inline hosts (ChatGPT, Claude.ai, Claude Desktop main chat) the variant grid renders right in the chat — pick a direction and it auto-persists as `index.html`, then keep refining. On CLI/link-only hosts (Codex, Claude Code, Claude Desktop "Code" tab) you get an **"Open in Design →"** link; open it, pick in the browser, then paste the copied handoff summary back into your chat — or just say "I picked direction B".
+
+   ```text
+   Paste this back into your chat so your agent continues from the chosen design.
+
+   I picked the "<label>" design direction.
+   It's saved as index.html in design <designId>. Refine from here with get-design-snapshot + generate-design, or export-coding-handoff to bring it into code. Don't show new variants unless I ask.
+
+   Design selection context:
+   { "selectedDesign": { "designId": "...", "variantId": "...", "label": "...", "file": "index.html" } }
+   ```
+
+4. **Apply to code.** Run `export-coding-handoff`; it returns a tokenized raw-code URL plus a ready-to-paste prompt. Your coding agent fetches that URL and writes the code.
 
 ## Why It's Interesting
 

--- a/packages/core/src/cli/connect.spec.ts
+++ b/packages/core/src/cli/connect.spec.ts
@@ -668,7 +668,10 @@ describe("runConnect", () => {
     expect(cfg.mcpServers["agent-native-mail"]).toEqual({
       type: "http",
       url: "https://mail.agent-native.com/_agent-native/mcp",
-      headers: { Authorization: "Bearer tok-fallback" },
+      headers: {
+        Authorization: "Bearer tok-fallback",
+        "X-Agent-Native-MCP-Full-Catalog": "1",
+      },
     });
   });
 
@@ -868,11 +871,13 @@ describe("runConnect", () => {
         "utf-8",
       );
       expect(codexToml).toContain('"Authorization" = "Bearer tok-device"');
+      expect(codexToml).toContain('"X-Agent-Native-MCP-Full-Catalog" = "1"');
       const coworkCfg = JSON.parse(
         fs.readFileSync(path.join(home, ".cowork", "mcp.json"), "utf-8"),
       );
       expect(coworkCfg.mcpServers["agent-native-mail"].headers).toEqual({
         Authorization: "Bearer tok-device",
+        "X-Agent-Native-MCP-Full-Catalog": "1",
       });
     } finally {
       process.env.HOME = oldHome;
@@ -1030,6 +1035,7 @@ describe("runConnect", () => {
       );
       expect(coworkJson.mcpServers["agent-native-mail"].headers).toEqual({
         Authorization: "Bearer tok-fallback",
+        "X-Agent-Native-MCP-Full-Catalog": "1",
       });
       expect(fs.existsSync(path.join(home, ".codex", "config.toml"))).toBe(
         false,
@@ -1098,12 +1104,18 @@ describe("runConnect", () => {
     expect(cfg.mcpServers["agent-native-calendar"]).toEqual({
       type: "http",
       url: "https://calendar.agent-native.com/_agent-native/mcp",
-      headers: { Authorization: "Bearer tok" },
+      headers: {
+        Authorization: "Bearer tok",
+        "X-Agent-Native-MCP-Full-Catalog": "1",
+      },
     });
     expect(cfg.mcpServers["agent-native-mail"]).toEqual({
       type: "http",
       url: "https://mail.agent-native.com/_agent-native/mcp",
-      headers: { Authorization: "Bearer tok" },
+      headers: {
+        Authorization: "Bearer tok",
+        "X-Agent-Native-MCP-Full-Catalog": "1",
+      },
     });
   });
 
@@ -1172,7 +1184,10 @@ describe("runConnect", () => {
     expect(cfg.mcpServers["agent-native-mail"]).toEqual({
       type: "http",
       url: "http://127.0.0.1:8080/mail/_agent-native/mcp",
-      headers: { "X-Agent-Native-Owner-Email": "u@example.com" },
+      headers: {
+        "X-Agent-Native-Owner-Email": "u@example.com",
+        "X-Agent-Native-MCP-Full-Catalog": "1",
+      },
     });
     const savedProfiles = JSON.parse(fs.readFileSync(profilesFile, "utf-8"));
     const savedJsonEntries =
@@ -1254,6 +1269,7 @@ describe("runConnect", () => {
         'url = "http://127.0.0.1:8080/mail/_agent-native/mcp"',
       );
       expect(toml).toContain('"X-Agent-Native-Owner-Email" = "u@example.com"');
+      expect(toml).toContain('"X-Agent-Native-MCP-Full-Catalog" = "1"');
 
       await runConnect(["prod", "--apps", "mail", "--client", "codex"], {
         profilesFile,

--- a/packages/core/src/cli/connect.ts
+++ b/packages/core/src/cli/connect.ts
@@ -51,6 +51,7 @@ const SERVER_NAME_PREFIX = "agent-native";
 const CONNECT_PREFERENCES_VERSION = 1;
 const CONNECT_PROFILES_VERSION = 1;
 const DEFAULT_DEV_GATEWAY = "http://127.0.0.1:8080";
+const MCP_FULL_CATALOG_HEADER = "X-Agent-Native-MCP-Full-Catalog";
 
 const CLIENT_LABELS: Record<ClientId, string> = {
   "claude-code": "Claude Code",
@@ -410,6 +411,12 @@ export function supportsRemoteMcpOAuth(client: ClientId): boolean {
 
 function clientLabelList(clients: ClientId[]): string {
   return clients.map((client) => CLIENT_LABELS[client]).join(", ");
+}
+
+function withFullCatalogHeader(
+  headers: Record<string, string> | undefined,
+): Record<string, string> {
+  return { ...(headers ?? {}), [MCP_FULL_CATALOG_HEADER]: "1" };
 }
 
 /** Derive an app slug from a deployed origin, e.g. mail.agent-native.com → mail. */
@@ -1133,7 +1140,9 @@ async function devHeadersForApp(params: {
   if (ownerEmail) {
     headers["X-Agent-Native-Owner-Email"] = ownerEmail;
   }
-  return Object.keys(headers).length ? headers : undefined;
+  return Object.keys(headers).length
+    ? withFullCatalogHeader(headers)
+    : undefined;
 }
 
 function connectableApps(includeHidden = false): ConnectableApp[] {
@@ -1468,7 +1477,7 @@ async function connectOne(
         token,
         scope,
         baseDir,
-        headers,
+        withFullCatalogHeader(headers),
       ),
     );
   }

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -253,6 +253,32 @@ describe("agent-native skills", () => {
     }
   });
 
+  it("preserves app base paths in --mcp-url overrides", async () => {
+    const root = tmpDir();
+
+    const result = await addAgentNativeSkill(
+      parseSkillsArgs([
+        "add",
+        "assets",
+        "--client",
+        "claude-code",
+        "--scope",
+        "project",
+        "--mcp-url",
+        "https://self-hosted.example.com/mail",
+      ]),
+      { baseDir: root, runCommand: async () => 0 },
+    );
+
+    expect(result.mcpUrl).toBe(
+      "https://self-hosted.example.com/mail/_agent-native/mcp",
+    );
+    expect(
+      JSON.parse(fs.readFileSync(path.join(root, ".mcp.json"), "utf-8"))
+        .mcpServers["agent-native-assets"].url,
+    ).toBe("https://self-hosted.example.com/mail/_agent-native/mcp");
+  });
+
   it("keeps --json output machine-readable for MCP-only installs", async () => {
     const root = tmpDir();
     const home = path.join(root, "home");

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -246,4 +246,66 @@ describe("agent-native skills", () => {
       else process.env.CODEX_HOME = previousCodexHome;
     }
   });
+
+  it("keeps full --json installs clean and aligns user scope for skills", async () => {
+    const root = tmpDir();
+    const home = path.join(root, "home");
+    const codexHome = path.join(root, "codex-home");
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(codexHome, { recursive: true });
+    const previousHome = process.env.HOME;
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.HOME = home;
+    process.env.CODEX_HOME = codexHome;
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const commands: { cmd: string; args: string[]; stdio?: string }[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    try {
+      await runSkills(
+        [
+          "add",
+          "images",
+          "--client",
+          "codex",
+          "--scope",
+          "user",
+          "--yes",
+          "--json",
+        ],
+        {
+          baseDir: root,
+          runCommand: async (cmd, args, options) => {
+            commands.push({ cmd, args, stdio: options?.stdio });
+            return 0;
+          },
+        },
+      );
+
+      const result = JSON.parse(stdout.join(""));
+      expect(result.id).toBe("assets");
+      expect(commands[0]).toMatchObject({
+        cmd: "npx",
+        stdio: "stderr",
+      });
+      expect(commands[0].args).toEqual(expect.arrayContaining(["-g"]));
+      expect(commands[0].args).toEqual(
+        expect.arrayContaining(["--skill", "assets", "-a", "codex"]),
+      );
+      expect(stderr.join("")).toBe("");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+    }
+  });
 });

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -156,6 +156,63 @@ describe("agent-native skills", () => {
     expect(fs.existsSync(path.join(root, ".mcp.json"))).toBe(false);
   });
 
+  it("registers the skill against a --mcp-url override (bare origin gets the mcp path)", async () => {
+    const root = tmpDir();
+
+    const result = await addAgentNativeSkill(
+      parseSkillsArgs([
+        "add",
+        "assets",
+        "--client",
+        "claude-code",
+        "--scope",
+        "project",
+        "--mcp-url",
+        "https://archer.ngrok-free.dev",
+      ]),
+      { baseDir: root, runCommand: async () => 0 },
+    );
+
+    expect(result.mcpUrl).toBe(
+      "https://archer.ngrok-free.dev/_agent-native/mcp",
+    );
+    expect(
+      JSON.parse(fs.readFileSync(path.join(root, ".mcp.json"), "utf-8"))
+        .mcpServers["agent-native-assets"].url,
+    ).toBe("https://archer.ngrok-free.dev/_agent-native/mcp");
+  });
+
+  it("accepts a full --mcp-url and surfaces it in dry-run", async () => {
+    const root = tmpDir();
+
+    const result = await addAgentNativeSkill(
+      parseSkillsArgs([
+        "add",
+        "design-exploration",
+        "--scope",
+        "project",
+        "--mcp-url",
+        "http://localhost:8092/_agent-native/mcp",
+        "--dry-run",
+      ]),
+      { baseDir: root },
+    );
+
+    expect(result.mcpUrl).toBe("http://localhost:8092/_agent-native/mcp");
+    expect(result.commands[0]).toContain(
+      "--mcp-url http://localhost:8092/_agent-native/mcp",
+    );
+  });
+
+  it("rejects an invalid --mcp-url", async () => {
+    await expect(
+      addAgentNativeSkill(
+        parseSkillsArgs(["add", "assets", "--mcp-url", "not-a-url"]),
+        { baseDir: tmpDir(), runCommand: async () => 0 },
+      ),
+    ).rejects.toThrow(/must be a valid URL/);
+  });
+
   it("writes Codex MCP config under CODEX_HOME when set", async () => {
     const root = tmpDir();
     const home = path.join(root, "home");

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -305,10 +305,18 @@ interface SkillInstallTarget {
   cleanup?: () => void;
 }
 
+interface RunCommandOptions {
+  stdio?: "inherit" | "stderr";
+}
+
 interface RunSkillsOptions {
   baseDir?: string;
   log?: (message: string) => void;
-  runCommand?: (cmd: string, args: string[]) => Promise<number>;
+  runCommand?: (
+    cmd: string,
+    args: string[],
+    options?: RunCommandOptions,
+  ) => Promise<number>;
 }
 
 function normalizeKnownSkillTarget(
@@ -477,13 +485,22 @@ function dryRunInstallCommand(
   return commandString("agent-native", args);
 }
 
-async function runCommand(cmd: string, args: string[]): Promise<number> {
+async function runCommand(
+  cmd: string,
+  args: string[],
+  options: RunCommandOptions = {},
+): Promise<number> {
   return new Promise((resolve, reject) => {
+    const pipeToStderr = options.stdio === "stderr";
     const child = spawn(cmd, args, {
-      stdio: "inherit",
+      stdio: pipeToStderr ? ["inherit", "pipe", "pipe"] : "inherit",
       shell: process.platform === "win32",
       env: process.env,
     });
+    if (pipeToStderr) {
+      child.stdout?.on("data", (chunk) => process.stderr.write(chunk));
+      child.stderr?.on("data", (chunk) => process.stderr.write(chunk));
+    }
     child.on("error", reject);
     child.on("exit", (code, signal) => {
       if (signal) {
@@ -545,11 +562,14 @@ export async function addAgentNativeSkill(
         "--copy",
         ...installTarget.skillNames.flatMap((skill) => ["--skill", skill]),
         ...skillsAgents.flatMap((agent) => ["-a", agent]),
+        ...(parsed.scope === "user" ? ["-g"] : []),
         ...(parsed.yes || knownTarget ? ["-y"] : []),
       ];
       commands.push(commandString("npx", args));
       if (!parsed.dryRun) {
-        const code = await (options.runCommand ?? runCommand)("npx", args);
+        const code = await (options.runCommand ?? runCommand)("npx", args, {
+          stdio: parsed.printJson ? "stderr" : "inherit",
+        });
         if (code !== 0) throw new Error(`npx skills add exited with ${code}.`);
       }
     }

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -477,6 +477,35 @@ function commandString(cmd: string, args: string[]): string {
   return [cmd, ...args].map(shellArg).join(" ");
 }
 
+function preserveMcpUrlAppPathOverride(
+  target: SkillInstallTarget,
+  input: string | undefined,
+): SkillInstallTarget {
+  if (!input) return target;
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    return target;
+  }
+  const trimmedPath = parsed.pathname.replace(/\/+$/, "");
+  const appPath = trimmedPath.endsWith("/_agent-native/mcp")
+    ? trimmedPath.slice(0, -"/_agent-native/mcp".length).replace(/\/+$/, "")
+    : trimmedPath;
+  if (!appPath) return target;
+  const url = `${parsed.origin}${appPath}`;
+  return {
+    ...target,
+    loaded: {
+      ...target.loaded,
+      manifest: {
+        ...target.loaded.manifest,
+        hosted: { url, mcpUrl: `${url}/_agent-native/mcp` },
+      },
+    },
+  };
+}
+
 function dryRunInstallCommand(
   parsed: ParsedSkillsArgs,
   target: string,
@@ -578,6 +607,7 @@ export async function addAgentNativeSkill(
     installTarget = withMcpUrlOverride(installTarget, parsed.mcpUrl);
   }
   const clients = resolveClients(parsed.client);
+  installTarget = preserveMcpUrlAppPathOverride(installTarget, parsed.mcpUrl);
   const skillsAgents = skillsAgentsForClients(clients);
   if (parsed.dryRun) {
     try {

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -24,18 +24,22 @@ const HELP = `agent-native skills
 
 Usage:
   agent-native skills list
-  agent-native skills add assets|design-exploration [--client codex|claude-code|claude-code-cli|cowork|all] [--scope user|project] [--yes] [--dry-run] [--json]
+  agent-native skills add assets|design-exploration [--client codex|claude-code|claude-code-cli|cowork|all] [--scope user|project] [--mcp-url <url>] [--yes] [--dry-run] [--json]
   agent-native skills add <manifest-or-app-dir> [--client ...] [--yes]
 
 Examples:
   agent-native skills add assets
   agent-native skills add design-exploration
   agent-native skills add assets --client claude-code
+  agent-native skills add assets --mcp-url https://my-app.ngrok-free.dev
   agent-native skills add ./dist/assets-skill --client codex
 
 The add command installs skill instructions with the open skills CLI, then
-registers the app-backed MCP connector. Use app-skill pack for marketplace
-bundles and custom adapter output.`;
+registers the app-backed MCP connector. Pass --mcp-url to register that
+connector against a custom origin (an ngrok tunnel, a local dev server, or a
+self-hosted deployment) instead of the built-in hosted default — a bare origin
+gets the standard /_agent-native/mcp path appended. Use app-skill pack for
+marketplace bundles and custom adapter output.`;
 
 const ASSETS_SKILL_MD = `---
 name: assets
@@ -282,6 +286,12 @@ export interface ParsedSkillsArgs {
   printJson: boolean;
   instructions: boolean;
   mcp: boolean;
+  /**
+   * Optional MCP URL override. When set, the skill's hosted MCP connector is
+   * registered against this URL instead of the built-in hosted default — e.g.
+   * an ngrok tunnel, a local dev origin, or a self-hosted deployment.
+   */
+  mcpUrl?: string;
 }
 
 export interface SkillsAddResult {
@@ -376,6 +386,7 @@ export function parseSkillsArgs(argv: string[]): ParsedSkillsArgs {
     let value: string | undefined;
     if ((value = eat("--client")) !== undefined) out.client = value;
     else if ((value = eat("--scope")) !== undefined) out.scope = value;
+    else if ((value = eat("--mcp-url")) !== undefined) out.mcpUrl = value;
     else if (arg === "--yes" || arg === "-y") out.yes = true;
     else if (arg === "--dry-run") out.dryRun = true;
     else if (arg === "--json") out.printJson = true;
@@ -479,6 +490,7 @@ function dryRunInstallCommand(
     "--scope",
     parsed.scope,
   ];
+  if (parsed.mcpUrl) args.push("--mcp-url", parsed.mcpUrl);
   if (parsed.instructions && !parsed.mcp) args.push("--instructions-only");
   if (!parsed.instructions && parsed.mcp) args.push("--mcp-only");
   if (parsed.yes || isKnownSkill(target)) args.push("--yes");
@@ -512,6 +524,44 @@ async function runCommand(
   });
 }
 
+/**
+ * Resolve a `--mcp-url` override into the `{ url, mcpUrl }` pair the manifest
+ * expects. Accepts a bare origin (`https://x.ngrok-free.dev`) — appending the
+ * standard `/_agent-native/mcp` path — or a full MCP URL already ending in it.
+ */
+function resolveMcpUrlOverride(input: string): { url: string; mcpUrl: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    throw new Error(`--mcp-url must be a valid URL (got "${input}").`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("--mcp-url must use http:// or https://.");
+  }
+  const origin = parsed.origin;
+  const trimmedPath = parsed.pathname.replace(/\/+$/, "");
+  const mcpUrl = trimmedPath.endsWith("/_agent-native/mcp")
+    ? `${origin}${trimmedPath}`
+    : `${origin}/_agent-native/mcp`;
+  return { url: origin, mcpUrl };
+}
+
+/** Return a copy of the install target with its hosted MCP URL overridden. */
+function withMcpUrlOverride(
+  target: SkillInstallTarget,
+  input: string,
+): SkillInstallTarget {
+  const { url, mcpUrl } = resolveMcpUrlOverride(input);
+  return {
+    ...target,
+    loaded: {
+      ...target.loaded,
+      manifest: { ...target.loaded.manifest, hosted: { url, mcpUrl } },
+    },
+  };
+}
+
 export async function addAgentNativeSkill(
   parsed: ParsedSkillsArgs,
   options: RunSkillsOptions = {},
@@ -523,7 +573,10 @@ export async function addAgentNativeSkill(
       `Unknown skill or manifest path: ${target}. Run "agent-native skills list".`,
     );
   }
-  const installTarget = loadSkillTarget(target);
+  let installTarget = loadSkillTarget(target);
+  if (parsed.mcpUrl) {
+    installTarget = withMcpUrlOverride(installTarget, parsed.mcpUrl);
+  }
   const clients = resolveClients(parsed.client);
   const skillsAgents = skillsAgentsForClients(clients);
   if (parsed.dryRun) {

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -107,9 +107,15 @@ iteration, or a human-in-the-loop choice among design directions.
 
 - Use \`create-design\` first to create a project shell. Do not report the
   design as ready until it has renderable HTML.
-- For open-ended UX exploration, generate three distinct, complete HTML
-  directions and call \`present-design-variants\`. The inline Design MCP app
-  shows the options, lets the user pick one, and persists the selected variant.
+- For open-ended UX exploration, generate distinct, complete HTML directions
+  (2-5, three by default) and call \`present-design-variants\`. The inline
+  Design MCP app shows the options, lets the user pick one, and persists the
+  selected variant.
+- If the Design app opens as a browser link instead of inline (CLI hosts like
+  Codex / Claude Code, where the deep link carries \`handoff=chat\`), the user
+  picks a direction there and the editor shows a copyable summary — ask them to
+  paste it back into chat so you can continue from the chosen direction. The
+  \`present-design-variants\` result's \`fallbackInstructions\` describe this.
 - For direct refinements to an already chosen direction, call
   \`get-design-snapshot\`, edit from the current tuned HTML, then call
   \`generate-design\`.
@@ -118,7 +124,8 @@ iteration, or a human-in-the-loop choice among design directions.
 
 ## Exploration Defaults
 
-1. Default to three variants unless the user asks for a different count.
+1. Default to three variants unless the user asks for a different count
+   (\`present-design-variants\` accepts 2-5; three is the sweet spot).
 2. Make variants structurally and stylistically distinct, not just color swaps.
 3. Each variant must be a complete standalone HTML document that renders
    without a build step.

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -43,7 +43,10 @@ import {
 } from "../shared/agent-sidebar-url.js";
 import { MCP_APP_CHAT_BRIDGE_QUERY_PARAM } from "../shared/embed-auth.js";
 import { getBuiltinCrossAppTools } from "./builtin-tools.js";
-import { MCP_CONNECT_SCOPE } from "./connect-store.js";
+import {
+  MCP_CONNECT_OAUTH_CLIENT_ID,
+  MCP_CONNECT_SCOPE,
+} from "./connect-store.js";
 import { getConfiguredAppBasePath } from "../server/app-base-path.js";
 import {
   MCP_OAUTH_SCOPES,
@@ -1660,6 +1663,22 @@ async function verifyA2AJwtForMcp(
   return null;
 }
 
+async function isConnectTokenAllowed(
+  jti: string | undefined,
+): Promise<boolean> {
+  if (!jti) return false;
+  try {
+    const { isJtiRevoked, touchTokenUsed } = await import("./connect-store.js");
+    if (await isJtiRevoked(jti)) return false;
+    // Best-effort usage telemetry — never blocks / throws.
+    void touchTokenUsed(jti);
+  } catch {
+    // Store import / lookup failed — fail open. Signature verification already
+    // passed; this only gates explicit revokes.
+  }
+  return true;
+}
+
 /**
  * Verify the inbound auth header. Returns:
  *   - { authed: true, identity } when verified — `identity` is derived from
@@ -1710,6 +1729,12 @@ export async function verifyAuth(
       options.resourceUrl,
     );
     if (oauthIdentity) {
+      if (
+        oauthIdentity.clientId === MCP_CONNECT_OAUTH_CLIENT_ID &&
+        !(await isConnectTokenAllowed(oauthIdentity.jti))
+      ) {
+        return { authed: false };
+      }
       return {
         authed: true,
         identity: {
@@ -1757,20 +1782,8 @@ export async function verifyAuth(
     // cryptographically verified, so failing open here only widens the
     // explicit-revoke gate, never the trust boundary.
     if (tokenScope === MCP_CONNECT_SCOPE) {
-      if (typeof payload.jti !== "string" || !payload.jti) {
+      if (!(await isConnectTokenAllowed(payload.jti as string | undefined))) {
         return { authed: false };
-      }
-      const jti = payload.jti;
-      try {
-        const { isJtiRevoked, touchTokenUsed } =
-          await import("./connect-store.js");
-        if (await isJtiRevoked(jti)) {
-          return { authed: false };
-        }
-        // Best-effort usage telemetry — never blocks / throws.
-        void touchTokenUsed(jti);
-      } catch {
-        // Store import / lookup failed — fail open (see comment above).
       }
     }
 

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -1719,7 +1719,7 @@ export async function verifyAuth(
   // established that this is a loopback/local dev request. Still honour an
   // owner hint there so the local install/connect flow stays tenant-scoped.
   const accessTokens = getAccessTokens();
-  const hasA2ASecret = !!process.env.A2A_SECRET;
+  const hasA2ASecret = !!process.env.A2A_SECRET?.trim();
   const token = authHeader?.startsWith("Bearer ")
     ? authHeader.slice(7)
     : undefined;

--- a/packages/core/src/mcp/build-server.verify-auth.spec.ts
+++ b/packages/core/src/mcp/build-server.verify-auth.spec.ts
@@ -10,6 +10,7 @@ const touchTokenUsedMock = vi.fn(async () => {});
 const getA2ASecretByDomainMock = vi.fn();
 vi.mock("./connect-store.js", () => ({
   MCP_CONNECT_SCOPE: "mcp-connect",
+  MCP_CONNECT_OAUTH_CLIENT_ID: "agent-native-connect",
   isJtiRevoked: (...a: any[]) => isJtiRevokedMock(...a),
   touchTokenUsed: (...a: any[]) => touchTokenUsedMock(...a),
 }));
@@ -160,6 +161,49 @@ describe("verifyAuth — connect-token revoke check", () => {
     });
     expect(res.authed).toBe(false);
     expect(res.identity).toBeUndefined();
+  });
+
+  it("accepts a connect-minted MCP OAuth token whose jti is not revoked", async () => {
+    isJtiRevokedMock.mockResolvedValue(false);
+    const resource = "https://mail.agent-native.com/_agent-native/mcp";
+    const token = await signMcpOAuthAccessToken({
+      ownerEmail: "oauth-connect@example.com",
+      clientId: "agent-native-connect",
+      scope: "mcp:read mcp:write mcp:apps",
+      resource,
+      issuer: "https://mail.agent-native.com",
+      jti: "jti-oauth-active",
+    });
+    const res = await verifyAuth(`Bearer ${token}`, undefined, {
+      resourceUrl: resource,
+    });
+    expect(res.authed).toBe(true);
+    expect(res.fullSurface).toBe(true);
+    expect(res.identity).toMatchObject({
+      userEmail: "oauth-connect@example.com",
+      oauthClientId: "agent-native-connect",
+    });
+    expect(isJtiRevokedMock).toHaveBeenCalledWith("jti-oauth-active");
+    expect(touchTokenUsedMock).toHaveBeenCalledWith("jti-oauth-active");
+  });
+
+  it("rejects a revoked connect-minted MCP OAuth token", async () => {
+    isJtiRevokedMock.mockResolvedValue(true);
+    const resource = "https://mail.agent-native.com/_agent-native/mcp";
+    const token = await signMcpOAuthAccessToken({
+      ownerEmail: "oauth-connect@example.com",
+      clientId: "agent-native-connect",
+      scope: "mcp:read mcp:write mcp:apps",
+      resource,
+      issuer: "https://mail.agent-native.com",
+      jti: "jti-oauth-revoked",
+    });
+    const res = await verifyAuth(`Bearer ${token}`, undefined, {
+      resourceUrl: resource,
+    });
+    expect(res.authed).toBe(false);
+    expect(isJtiRevokedMock).toHaveBeenCalledWith("jti-oauth-revoked");
+    expect(touchTokenUsedMock).not.toHaveBeenCalled();
   });
 
   it("rejects a connect-scoped token without a jti", async () => {

--- a/packages/core/src/mcp/connect-route.spec.ts
+++ b/packages/core/src/mcp/connect-route.spec.ts
@@ -37,6 +37,7 @@ const tokenRows: any[] = [];
 const deviceRows: any[] = [];
 vi.mock("./connect-store.js", () => ({
   MCP_CONNECT_SCOPE: "mcp-connect",
+  MCP_CONNECT_OAUTH_CLIENT_ID: "agent-native-connect",
   DEFAULT_TOKEN_TTL_DAYS: 365,
   MIN_TOKEN_TTL_DAYS: 1,
   MAX_TOKEN_TTL_DAYS: 365,
@@ -157,6 +158,7 @@ describe("handleMcpConnect", () => {
   });
   afterEach(() => {
     delete process.env.A2A_SECRET;
+    delete process.env.BETTER_AUTH_SECRET;
   });
 
   describe("connect page", () => {
@@ -286,11 +288,28 @@ describe("handleMcpConnect", () => {
       expect(Math.round(lifetimeDays)).toBe(365);
     });
 
-    it("returns 503 when no A2A_SECRET is configured", async () => {
+    it("mints a standard MCP OAuth token when no A2A_SECRET is configured", async () => {
       delete process.env.A2A_SECRET;
+      process.env.BETTER_AUTH_SECRET = SECRET;
       getSessionMock.mockResolvedValue({ email: "u@example.com" });
       const res = await handleMcpConnect(ev({ method: "POST" }), "/token");
-      expect(res.status).toBe(503);
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      const { verifyMcpOAuthAccessToken } = await import("./oauth-token.js");
+      const verified = await verifyMcpOAuthAccessToken(data.token, data.mcpUrl);
+      const decoded = jose.decodeJwt(data.token);
+      const lifetimeDays =
+        ((decoded.exp as number) - (decoded.iat as number)) / 86400;
+      expect(verified).toMatchObject({
+        userEmail: "u@example.com",
+        clientId: "agent-native-connect",
+        scopes: ["mcp:read", "mcp:write", "mcp:apps"],
+      });
+      expect(Math.round(lifetimeDays)).toBe(365);
+      expect(tokenRows[0]).toMatchObject({
+        jti: verified?.jti,
+        ownerEmail: "u@example.com",
+      });
     });
 
     it("returns a dev-open localhost entry when no A2A_SECRET is configured", async () => {
@@ -532,6 +551,52 @@ describe("handleMcpConnect", () => {
       expect(data.token).toBe("");
       expect(data.mcpServerEntry.headers).toEqual({
         "X-Agent-Native-Owner-Email": "u@example.com",
+      });
+    });
+
+    it("poll mints a standard MCP OAuth token for hosted deploys without A2A_SECRET", async () => {
+      delete process.env.A2A_SECRET;
+      process.env.BETTER_AUTH_SECRET = SECRET;
+      await handleMcpConnect(ev({ method: "POST" }), "/device/start");
+      const dc = deviceRows[0].deviceCode;
+
+      getSessionMock.mockResolvedValue({
+        email: "u@example.com",
+        orgId: "org-7",
+      });
+      await handleMcpConnect(
+        ev({ method: "POST", body: { user_code: "ABCD-2345" } }),
+        "/device/authorize",
+      );
+
+      getSessionMock.mockResolvedValue(null);
+      const res = await handleMcpConnect(
+        ev({ method: "POST", body: { device_code: dc } }),
+        "/device/poll",
+      );
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.status).toBe("approved");
+
+      const { verifyMcpOAuthAccessToken } = await import("./oauth-token.js");
+      const verified = await verifyMcpOAuthAccessToken(data.token, data.mcpUrl);
+      const decoded = jose.decodeJwt(data.token);
+      const lifetimeDays =
+        ((decoded.exp as number) - (decoded.iat as number)) / 86400;
+      expect(verified).toMatchObject({
+        userEmail: "u@example.com",
+        orgId: "org-7",
+        orgDomain: "builder.io",
+        clientId: "agent-native-connect",
+        scopes: ["mcp:read", "mcp:write", "mcp:apps"],
+      });
+      expect(Math.round(lifetimeDays)).toBe(365);
+      expect(verified?.jti).toBeTruthy();
+      expect(tokenRows[0]).toMatchObject({
+        jti: verified?.jti,
+        ownerEmail: "u@example.com",
+        orgId: "org-7",
+        label: "Device connection",
       });
     });
 

--- a/packages/core/src/mcp/connect-route.spec.ts
+++ b/packages/core/src/mcp/connect-route.spec.ts
@@ -235,7 +235,10 @@ describe("handleMcpConnect", () => {
       expect(data.mcpServerEntry).toEqual({
         type: "http",
         url: "https://mail.agent-native.com/_agent-native/mcp",
-        headers: { Authorization: `Bearer ${data.token}` },
+        headers: {
+          Authorization: `Bearer ${data.token}`,
+          "X-Agent-Native-MCP-Full-Catalog": "1",
+        },
       });
       expect(data.cli).toBe(
         "agent-native connect https://mail.agent-native.com",
@@ -305,6 +308,10 @@ describe("handleMcpConnect", () => {
         clientId: "agent-native-connect",
         scopes: ["mcp:read", "mcp:write", "mcp:apps"],
       });
+      expect(data.mcpServerEntry.headers).toMatchObject({
+        Authorization: `Bearer ${data.token}`,
+        "X-Agent-Native-MCP-Full-Catalog": "1",
+      });
       expect(Math.round(lifetimeDays)).toBe(365);
       expect(tokenRows[0]).toMatchObject({
         jti: verified?.jti,
@@ -327,7 +334,10 @@ describe("handleMcpConnect", () => {
       expect(data.mcpServerEntry).toEqual({
         type: "http",
         url: "http://localhost:4321/_agent-native/mcp",
-        headers: { "X-Agent-Native-Owner-Email": "u@example.com" },
+        headers: {
+          "X-Agent-Native-Owner-Email": "u@example.com",
+          "X-Agent-Native-MCP-Full-Catalog": "1",
+        },
       });
     });
   });
@@ -551,6 +561,7 @@ describe("handleMcpConnect", () => {
       expect(data.token).toBe("");
       expect(data.mcpServerEntry.headers).toEqual({
         "X-Agent-Native-Owner-Email": "u@example.com",
+        "X-Agent-Native-MCP-Full-Catalog": "1",
       });
     });
 
@@ -589,6 +600,10 @@ describe("handleMcpConnect", () => {
         orgDomain: "builder.io",
         clientId: "agent-native-connect",
         scopes: ["mcp:read", "mcp:write", "mcp:apps"],
+      });
+      expect(data.mcpServerEntry.headers).toMatchObject({
+        Authorization: `Bearer ${data.token}`,
+        "X-Agent-Native-MCP-Full-Catalog": "1",
       });
       expect(Math.round(lifetimeDays)).toBe(365);
       expect(verified?.jti).toBeTruthy();

--- a/packages/core/src/mcp/connect-route.ts
+++ b/packages/core/src/mcp/connect-route.ts
@@ -16,12 +16,11 @@
  *        POST /connect/device/authorize  (session) → binds user to the code
  *        POST /connect/device/poll       (unauth)  → mints + returns the token
  *
- * The minted token reuses the existing A2A signer (`signA2AToken`) — no new
- * crypto. We only add a random `jti` + `scope: "mcp-connect"` claim so it can
- * be revoked. `verifyAuth` already verifies A2A_SECRET JWTs and extracts
- * `sub`/`org_domain`, so a minted token works against `/_agent-native/mcp`
- * with no verify changes for the happy path (the revoke check is the only
- * addition there).
+ * When A2A_SECRET exists, the minted token reuses the existing A2A signer
+ * (`signA2AToken`) and adds a random `jti` + `scope: "mcp-connect"` claim so
+ * it can be revoked. Deployments without A2A_SECRET mint the same standard MCP
+ * OAuth access-token format used by remote MCP OAuth, signed with the auth
+ * secret fallback and bound to the exact MCP resource URL.
  *
  * Node-only (crypto + the A2A signer), bundled alongside the other framework
  * routes. Dialect-agnostic SQL lives in `connect-store.ts`.
@@ -50,12 +49,17 @@ import {
   finishDeviceCodeMint,
   releaseDeviceCodeMint,
   expireDeviceCode,
+  MCP_CONNECT_OAUTH_CLIENT_ID,
   MCP_CONNECT_SCOPE,
   DEFAULT_TOKEN_TTL_DAYS,
   MIN_TOKEN_TTL_DAYS,
   MAX_TOKEN_TTL_DAYS,
   DEVICE_CODE_TTL_MS,
 } from "./connect-store.js";
+import {
+  MCP_OAUTH_DEFAULT_SCOPE,
+  signMcpOAuthAccessToken,
+} from "./oauth-token.js";
 
 /** Device-flow poll interval hint (seconds). */
 const DEVICE_POLL_INTERVAL_S = 3;
@@ -192,26 +196,26 @@ function clampTtlDays(input: unknown): number {
 }
 
 /**
- * Mint a connect-scoped JWT and record it. The JWT is signed by the existing
- * A2A signer (HS256 over A2A_SECRET); we add a random `jti` and
- * `scope: "mcp-connect"` so the token is individually revocable. The token
- * value is returned to the caller exactly once and never persisted.
+ * Mint a connect-scoped JWT and record it. The token value is returned to the
+ * caller exactly once and never persisted; only the random `jti` is stored for
+ * revocation.
  */
 async function mintConnectToken(params: {
   email: string;
   orgId: string | undefined;
   label: string | null;
   ttlDays: number;
+  appUrl: string;
 }): Promise<{ token: string; jti: string }> {
   const orgDomain = await resolveOrgDomain(params.orgId);
   const jti = randomUUID();
-  // signA2AToken signs { sub: email, org_domain? } over A2A_SECRET (global)
-  // or the org secret. We extend its claims via the standard jose builder by
-  // re-using the same signer with extra claims threaded through `options`.
-  const token = await signA2AToken(params.email, orgDomain, undefined, {
-    preferGlobalSecret: true,
+  const token = await signConnectToken({
+    ownerEmail: params.email,
+    orgId: params.orgId,
+    orgDomain,
+    appUrl: params.appUrl,
     expiresIn: `${params.ttlDays}d`,
-    extraClaims: { jti, scope: MCP_CONNECT_SCOPE },
+    jti,
   });
   await recordMintedToken({
     jti,
@@ -222,12 +226,41 @@ async function mintConnectToken(params: {
   return { token, jti };
 }
 
+async function signConnectToken(params: {
+  ownerEmail: string;
+  orgId: string | null | undefined;
+  orgDomain: string | undefined;
+  appUrl: string;
+  expiresIn: string;
+  jti: string;
+}): Promise<string> {
+  if (process.env.A2A_SECRET?.trim()) {
+    return signA2AToken(params.ownerEmail, params.orgDomain, undefined, {
+      preferGlobalSecret: true,
+      expiresIn: params.expiresIn,
+      extraClaims: { jti: params.jti, scope: MCP_CONNECT_SCOPE },
+    });
+  }
+
+  return signMcpOAuthAccessToken({
+    ownerEmail: params.ownerEmail,
+    orgId: params.orgId ?? null,
+    orgDomain: params.orgDomain ?? null,
+    clientId: MCP_CONNECT_OAUTH_CLIENT_ID,
+    scope: MCP_OAUTH_DEFAULT_SCOPE,
+    resource: mcpResourceUrl(params.appUrl),
+    issuer: params.appUrl,
+    jti: params.jti,
+    expiresIn: params.expiresIn,
+  });
+}
+
 function mcpResultPayload(
   appUrl: string,
   options: McpConnectRouteOptions,
   auth: { token?: string; ownerEmail?: string },
 ) {
-  const mcpUrl = `${appUrl}/_agent-native/mcp`;
+  const mcpUrl = mcpResourceUrl(appUrl);
   const name = serverName(appUrl, options);
   const headers: Record<string, string> = {};
   if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
@@ -245,6 +278,10 @@ function mcpResultPayload(
     },
     cli: `agent-native connect ${appUrl}`,
   };
+}
+
+function mcpResourceUrl(appUrl: string): string {
+  return `${appUrl}/_agent-native/mcp`;
 }
 
 // ---------------------------------------------------------------------------
@@ -578,14 +615,19 @@ function renderConnectPage(params: {
   .primary-link {
     display: inline-flex; align-items: center; justify-content: center;
     gap: 0.35rem; min-height: 36px; padding: 0.45rem 0.85rem;
-    background: var(--accent); color: var(--accent-fg);
-    border: 1px solid var(--accent); border-radius: 8px;
+    background: var(--panel-2); color: var(--text);
+    border: 1px solid var(--border-strong); border-radius: 8px;
     font-size: 0.86rem; font-weight: 650; text-decoration: none;
-    cursor: pointer; width: 100%; text-align: center;
+    cursor: pointer; width: auto; max-width: 100%; text-align: center;
     margin: 0.5rem 0 0.2rem;
   }
-  .primary-link:hover { background: #e4e4e7; border-color: #e4e4e7; }
-  .primary-link.compact { width: auto; min-width: 0; }
+  .tab-panel a.primary-link {
+    color: var(--text); text-decoration: none;
+  }
+  .primary-link:hover {
+    background: rgba(255,255,255,0.06); border-color: rgba(255,255,255,0.2);
+  }
+  .primary-link.compact { min-width: 0; }
   .copy-flash {
     color: var(--ok) !important;
     border-color: var(--ok-border) !important;
@@ -1041,18 +1083,9 @@ export async function handleMcpConnect(
     if (method !== "POST") return json({ error: "Method not allowed" }, 405);
     const session = await getSession(event);
     if (!session?.email) return json({ error: "Unauthorized" }, 401);
-    if (!process.env.A2A_SECRET) {
-      if (canUseDevOpenConnect(event)) {
-        return json(
-          mcpResultPayload(appUrl, options, { ownerEmail: session.email }),
-        );
-      }
+    if (!process.env.A2A_SECRET?.trim() && canUseDevOpenConnect(event)) {
       return json(
-        {
-          error:
-            "This deployment has no A2A_SECRET configured, so connect tokens cannot be minted.",
-        },
-        503,
+        mcpResultPayload(appUrl, options, { ownerEmail: session.email }),
       );
     }
     const body = ((await readBody(event).catch(() => ({}))) ?? {}) as {
@@ -1070,6 +1103,7 @@ export async function handleMcpConnect(
         orgId: session.orgId,
         label,
         ttlDays,
+        appUrl,
       });
       return json(mcpResultPayload(appUrl, options, { token }));
     } catch {
@@ -1156,25 +1190,22 @@ export async function handleMcpConnect(
       return json({ status: "pending" });
     }
     // status === "approved" && ownerEmail bound → mint exactly once.
-    if (!process.env.A2A_SECRET) {
-      if (canUseDevOpenConnect(event)) {
-        const consumed = await consumeDeviceCode(
-          deviceCode,
-          `dev-open-${randomUUID()}`,
-        );
-        if (!consumed) {
-          const fresh = await getDeviceCode(deviceCode);
-          if (fresh?.status === "consumed") return json({ status: "consumed" });
-          return json({ status: "pending" });
-        }
-        return json({
-          status: "approved",
-          ...mcpResultPayload(appUrl, options, {
-            ownerEmail: row.ownerEmail,
-          }),
-        });
+    if (!process.env.A2A_SECRET?.trim() && canUseDevOpenConnect(event)) {
+      const consumed = await consumeDeviceCode(
+        deviceCode,
+        `dev-open-${randomUUID()}`,
+      );
+      if (!consumed) {
+        const fresh = await getDeviceCode(deviceCode);
+        if (fresh?.status === "consumed") return json({ status: "consumed" });
+        return json({ status: "pending" });
       }
-      return json({ status: "error", error: "A2A_SECRET not configured" }, 503);
+      return json({
+        status: "approved",
+        ...mcpResultPayload(appUrl, options, {
+          ownerEmail: row.ownerEmail,
+        }),
+      });
     }
     try {
       const jti = randomUUID();
@@ -1189,10 +1220,13 @@ export async function handleMcpConnect(
       let token: string;
       try {
         const orgDomain = await resolveOrgDomain(claimed.orgId ?? undefined);
-        token = await signA2AToken(claimed.ownerEmail!, orgDomain, undefined, {
-          preferGlobalSecret: true,
+        token = await signConnectToken({
+          ownerEmail: claimed.ownerEmail!,
+          orgId: claimed.orgId,
+          orgDomain,
+          appUrl,
           expiresIn: `${DEFAULT_TOKEN_TTL_DAYS}d`,
-          extraClaims: { jti, scope: MCP_CONNECT_SCOPE },
+          jti,
         });
         await recordMintedToken({
           jti,

--- a/packages/core/src/mcp/connect-route.ts
+++ b/packages/core/src/mcp/connect-route.ts
@@ -63,6 +63,7 @@ import {
 
 /** Device-flow poll interval hint (seconds). */
 const DEVICE_POLL_INTERVAL_S = 3;
+const MCP_FULL_CATALOG_HEADER = "X-Agent-Native-MCP-Full-Catalog";
 
 // Human-typable user code: 8 base32 chars, dashed XXXX-XXXX.
 const USER_CODE_RE = /^[A-Z2-7]{4}-[A-Z2-7]{4}$/;
@@ -266,6 +267,9 @@ function mcpResultPayload(
   if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
   if (!auth.token && auth.ownerEmail) {
     headers["X-Agent-Native-Owner-Email"] = auth.ownerEmail;
+  }
+  if (auth.token || auth.ownerEmail) {
+    headers[MCP_FULL_CATALOG_HEADER] = "1";
   }
   return {
     token: auth.token ?? "",

--- a/packages/core/src/mcp/connect-store.ts
+++ b/packages/core/src/mcp/connect-store.ts
@@ -35,6 +35,12 @@ let _initPromise: Promise<void> | undefined;
  */
 export const MCP_CONNECT_SCOPE = "mcp-connect";
 
+/**
+ * Client id used when connect/device flows have to mint a standard MCP OAuth
+ * access token instead of an A2A JWT (for deployments without A2A_SECRET).
+ */
+export const MCP_CONNECT_OAUTH_CLIENT_ID = "agent-native-connect";
+
 /** Device codes are valid for 10 minutes. */
 export const DEVICE_CODE_TTL_MS = 10 * 60_000;
 

--- a/packages/core/src/mcp/oauth-route.ts
+++ b/packages/core/src/mcp/oauth-route.ts
@@ -354,7 +354,7 @@ function base64UrlDecode(value: string): Buffer {
 }
 
 function consentSigningKey(): string {
-  return process.env.A2A_SECRET || getAuthSecret();
+  return process.env.A2A_SECRET?.trim() || getAuthSecret();
 }
 
 function consentPayload(params: {

--- a/packages/core/src/mcp/oauth-token.spec.ts
+++ b/packages/core/src/mcp/oauth-token.spec.ts
@@ -171,6 +171,23 @@ describe("signMcpOAuthAccessToken + verifyMcpOAuthAccessToken round-trip", () =>
     delete process.env.A2A_SECRET;
     expect(await verifyMcpOAuthAccessToken(token, RESOURCE)).toBeNull();
   });
+
+  it("ignores whitespace-only A2A_SECRET and falls back to the auth secret", async () => {
+    process.env.A2A_SECRET = "   ";
+    const token = await signMcpOAuthAccessToken(baseSign);
+
+    expect(await verifyMcpOAuthAccessToken(token, RESOURCE)).not.toBeNull();
+    await expect(
+      jose.jwtVerify(token, new TextEncoder().encode("   "), {
+        audience: RESOURCE,
+      }),
+    ).rejects.toThrow();
+    await expect(
+      jose.jwtVerify(token, new TextEncoder().encode("fallback-auth-secret"), {
+        audience: RESOURCE,
+      }),
+    ).resolves.toBeTruthy();
+  });
 });
 
 describe("verifyMcpOAuthAccessToken rejection branches", () => {

--- a/packages/core/src/mcp/oauth-token.spec.ts
+++ b/packages/core/src/mcp/oauth-token.spec.ts
@@ -109,13 +109,14 @@ describe("signMcpOAuthAccessToken + verifyMcpOAuthAccessToken round-trip", () =>
       orgDomain: "example.com",
     });
     const result = await verifyMcpOAuthAccessToken(token, RESOURCE);
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       userEmail: "owner@example.com",
       orgId: "org-1",
       orgDomain: "example.com",
       scopes: ["mcp:read", "mcp:write"],
       clientId: "client-abc",
     });
+    expect(typeof result?.jti).toBe("string");
   });
 
   it("omits org claims entirely when not provided", async () => {
@@ -137,6 +138,28 @@ describe("signMcpOAuthAccessToken + verifyMcpOAuthAccessToken round-trip", () =>
     expect(decoded.aud).toBe(RESOURCE);
     expect(typeof decoded.jti).toBe("string");
     expect(decoded.exp).toBeGreaterThan(decoded.iat);
+  });
+
+  it("uses a provided jti when supplied", async () => {
+    const token = await signMcpOAuthAccessToken({
+      ...baseSign,
+      jti: "connect-jti-123",
+    });
+    const decoded = jose.decodeJwt(token) as any;
+    expect(decoded.jti).toBe("connect-jti-123");
+    const result = await verifyMcpOAuthAccessToken(token, RESOURCE);
+    expect(result?.jti).toBe("connect-jti-123");
+  });
+
+  it("uses a provided expiry when supplied", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const token = await signMcpOAuthAccessToken({
+      ...baseSign,
+      expiresIn: "30d",
+    });
+    const decoded = jose.decodeJwt(token) as any;
+    const lifetimeDays = (decoded.exp - decoded.iat) / 86400;
+    expect(Math.round(lifetimeDays)).toBe(30);
   });
 
   it("prefers A2A_SECRET over the better-auth secret for signing+verify", async () => {

--- a/packages/core/src/mcp/oauth-token.ts
+++ b/packages/core/src/mcp/oauth-token.ts
@@ -14,6 +14,7 @@ export interface McpOAuthAccessTokenClaims {
   scope: string;
   client_id: string;
   resource: string;
+  jti?: string;
   typ: "agent-native-mcp-oauth";
 }
 
@@ -58,6 +59,8 @@ export async function signMcpOAuthAccessToken(params: {
   scope: string;
   resource: string;
   issuer: string;
+  jti?: string;
+  expiresIn?: string | number;
 }): Promise<string> {
   return new jose.SignJWT({
     typ: "agent-native-mcp-oauth",
@@ -71,9 +74,9 @@ export async function signMcpOAuthAccessToken(params: {
     .setProtectedHeader({ alg: "HS256" })
     .setIssuer(params.issuer)
     .setAudience(params.resource)
-    .setJti(randomUUID())
+    .setJti(params.jti ?? randomUUID())
     .setIssuedAt()
-    .setExpirationTime(MCP_OAUTH_ACCESS_TOKEN_TTL)
+    .setExpirationTime(params.expiresIn ?? MCP_OAUTH_ACCESS_TOKEN_TTL)
     .sign(signingSecret());
 }
 
@@ -86,6 +89,7 @@ export async function verifyMcpOAuthAccessToken(
   orgDomain?: string;
   scopes: string[];
   clientId: string;
+  jti?: string;
 } | null> {
   if (!resource) return null;
   try {
@@ -110,6 +114,7 @@ export async function verifyMcpOAuthAccessToken(
         typeof payload.org_domain === "string" ? payload.org_domain : undefined,
       scopes,
       clientId: payload.client_id,
+      jti: typeof payload.jti === "string" ? payload.jti : undefined,
     };
   } catch {
     return null;

--- a/packages/core/src/mcp/oauth-token.ts
+++ b/packages/core/src/mcp/oauth-token.ts
@@ -19,7 +19,9 @@ export interface McpOAuthAccessTokenClaims {
 }
 
 function signingSecret(): Uint8Array {
-  return new TextEncoder().encode(process.env.A2A_SECRET || getAuthSecret());
+  return new TextEncoder().encode(
+    process.env.A2A_SECRET?.trim() || getAuthSecret(),
+  );
 }
 
 export function normalizeOAuthScope(input: unknown): string | null {

--- a/scripts/e2e-mcp-test.ts
+++ b/scripts/e2e-mcp-test.ts
@@ -984,6 +984,24 @@ async function groupC_OpenAppPrivacy(
   const sc = listAppsResult?.structuredContent;
   if (Array.isArray(sc?.apps)) appsArray = sc.apps;
   else if (Array.isArray(listAppsResult?.apps)) appsArray = listAppsResult.apps;
+  else if (Array.isArray(listAppsResult?.content)) {
+    for (const item of listAppsResult.content as any[]) {
+      if (item?.type !== "text" || typeof item?.text !== "string") continue;
+      try {
+        const parsed = JSON.parse(item.text);
+        if (Array.isArray(parsed?.apps)) {
+          appsArray = parsed.apps;
+          break;
+        }
+        if (Array.isArray(parsed?.structuredContent?.apps)) {
+          appsArray = parsed.structuredContent.apps;
+          break;
+        }
+      } catch {
+        // Ignore non-JSON text blocks.
+      }
+    }
+  }
   out.apps = appsArray.map((a: any) => ({
     id: String(a?.id ?? a?.name ?? ""),
   }));

--- a/templates/design/.agents/skills/design-generation/SKILL.md
+++ b/templates/design/.agents/skills/design-generation/SKILL.md
@@ -69,7 +69,9 @@ as a browser link instead of inline (CLI hosts like Codex / Claude Code, where
 the deep link carries `handoff=chat`), the user picks a direction there and the
 editor shows a copyable handoff summary (auto-copied to the clipboard) — ask
 them to paste it back into chat so you can continue from the chosen direction.
-The `present-design-variants` result's `fallbackInstructions` describe this.
+The user can also simply name the pick in words (e.g. "use variant A" / "the
+editorial one") instead of pasting — honor either. The
+`present-design-variants` result's `fallbackInstructions` describe this.
 
 ### Phase 3 — Save with `generate-design` (when not using variants)
 

--- a/templates/design/.agents/skills/design-generation/SKILL.md
+++ b/templates/design/.agents/skills/design-generation/SKILL.md
@@ -34,10 +34,11 @@ Then, for any non-trivial first prompt, write `application-state/show-questions`
 #  uses the framework's `db-exec` to upsert into application_state.)
 ```
 
-### Phase 2 — Generate three side-by-side variations
+### Phase 2 — Generate side-by-side variations (2-5, three by default)
 
-For new designs, default to **three** variations. In normal app-agent flows,
-write candidates to `application-state/design-variants`:
+For new designs, default to **three** variations (`present-design-variants`
+accepts 2-5; three is the sweet spot). In normal app-agent flows, write
+candidates to `application-state/design-variants`:
 
 ```json
 {
@@ -58,9 +59,17 @@ The framework persists the chosen content as `index.html` automatically when the
 When the caller is an external MCP host (ChatGPT, Claude, Claude Code, Codex,
 Dispatch), call `present-design-variants` instead of writing
 `application-state` directly. Pass the existing `designId`, a concise prompt
-caption, and 2-5 complete HTML variants. The action opens the same editor
-variant picker as the first-party app and keeps the workflow visible inside
-MCP Apps. After that, wait for the user's pick before refining.
+caption, and 2-5 complete HTML variants (three by default). The action opens
+the same editor variant picker as the first-party app and keeps the workflow
+visible inside MCP Apps. After that, wait for the user's pick before refining.
+
+For inline MCP-app hosts (ChatGPT / Claude / Claude Desktop main chat) the pick
+rides the chat bridge automatically — no copy/paste. But if the Design app opens
+as a browser link instead of inline (CLI hosts like Codex / Claude Code, where
+the deep link carries `handoff=chat`), the user picks a direction there and the
+editor shows a copyable handoff summary (auto-copied to the clipboard) — ask
+them to paste it back into chat so you can continue from the chosen direction.
+The `present-design-variants` result's `fallbackInstructions` describe this.
 
 ### Phase 3 — Save with `generate-design` (when not using variants)
 

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -45,9 +45,15 @@ patterns live in `.agents/skills/`.
   It installs the exported Design exploration instructions and registers the
   hosted Design MCP connector together.
 - For human-in-the-loop UI exploration, create a design shell, call
-  `present-design-variants` with 2-5 complete HTML directions, wait for the
-  user to pick one, then use `get-design-snapshot` and `generate-design` for
-  follow-up refinements.
+  `present-design-variants` with 2-5 complete HTML directions (three by
+  default), wait for the user to pick one, then use `get-design-snapshot` and
+  `generate-design` for follow-up refinements.
+- Inline MCP-app hosts (ChatGPT / Claude / Claude Desktop main chat) carry the
+  pick back over the chat bridge automatically. If the Design app instead opens
+  as a browser link (CLI hosts like Codex / Claude Code, deep link carries
+  `handoff=chat`), the user picks there and the editor shows a copyable summary
+  (also in `present-design-variants` result `fallbackInstructions`) — ask them
+  to paste it back into chat so you can continue from the chosen direction.
 
 ## Skills
 

--- a/templates/design/actions/present-design-variants.spec.ts
+++ b/templates/design/actions/present-design-variants.spec.ts
@@ -65,9 +65,10 @@ describe("present-design-variants", () => {
     expect(result).toMatchObject({
       designId: "design_123",
       count: 3,
-      path: "/design/design_123",
+      path: "/design/design_123?handoff=chat",
       embed: true,
     });
+    expect(typeof result.fallbackInstructions).toBe("string");
     expect(action.mcpApp?.compactCatalog).toBe(true);
     expect(action.mcpApp?.resource.title).toBe("Design directions");
     expect(action.mcpApp?.resource.html()).toContain(
@@ -75,23 +76,23 @@ describe("present-design-variants", () => {
     );
   });
 
-  it("requires exactly three variants for the MCP picker flow", () => {
-    const base = {
+  it("accepts 2-5 variants for the MCP picker flow", () => {
+    const variant = (n: number) => ({
+      id: `v${n}`,
+      label: `V${n}`,
+      content: `<html>${n}</html>`,
+    });
+    const withVariants = (count: number) => ({
       designId: "design_123",
-      variants: [
-        { id: "one", label: "One", content: "<html>One</html>" },
-        { id: "two", label: "Two", content: "<html>Two</html>" },
-        { id: "three", label: "Three", content: "<html>Three</html>" },
-      ],
-    };
+      variants: Array.from({ length: count }, (_, i) => variant(i + 1)),
+    });
 
-    expect(action.schema.safeParse(base).success).toBe(true);
-    expect(
-      action.schema.safeParse({
-        ...base,
-        variants: base.variants.slice(0, 2),
-      }).success,
-    ).toBe(false);
+    // 3 is the sweet spot, but 2-5 are all valid; 1 and 6 are rejected.
+    expect(action.schema.safeParse(withVariants(2)).success).toBe(true);
+    expect(action.schema.safeParse(withVariants(3)).success).toBe(true);
+    expect(action.schema.safeParse(withVariants(5)).success).toBe(true);
+    expect(action.schema.safeParse(withVariants(1)).success).toBe(false);
+    expect(action.schema.safeParse(withVariants(6)).success).toBe(false);
   });
 
   it("returns an editor deep link for external hosts", async () => {

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -20,7 +20,9 @@ function designDeepLink(designId: string): string {
 const FALLBACK_INSTRUCTIONS =
   "If the design opens as a browser link instead of inline, the user picks a " +
   "direction there and the editor shows a copyable summary. Ask them to paste " +
-  "that summary back into chat so you can continue from the chosen direction.";
+  "that summary back into chat so you can continue from the chosen direction. " +
+  'They can also just tell you which one in words (e.g. "use variant A" / "the ' +
+  'editorial one") — honor that too instead of insisting on the paste-back.';
 
 const variantSchema = z.object({
   id: z.string().min(1).describe("Stable variant id, e.g. 'minimal-focus'"),
@@ -42,7 +44,8 @@ export default defineAction({
     "visually compare options and pick one. Provide 2-5 variants (3 is the " +
     "sweet spot). Use this for design exploration before calling " +
     "generate-design. The user's choice is persisted automatically by the app; " +
-    "if it opens as a browser link, they paste a copyable summary back to chat.",
+    "if it opens as a browser link, they paste a copyable summary back to chat " +
+    'or simply tell you which one (e.g. "use variant A").',
   schema: z.object({
     designId: z.string().describe("Design project ID to show variants for"),
     prompt: z

--- a/templates/design/actions/present-design-variants.ts
+++ b/templates/design/actions/present-design-variants.ts
@@ -10,9 +10,17 @@ function designDeepLink(designId: string): string {
     app: "design",
     view: "editor",
     params: { designId },
-    to: `/design/${encodeURIComponent(designId)}`,
+    // `handoff=chat` marks a link opened from a link-only host (CLI / Codex /
+    // Claude Code) so the editor shows a copyable paste-back summary after the
+    // user picks — the choice can't ride a host chat bridge there.
+    to: `/design/${encodeURIComponent(designId)}?handoff=chat`,
   });
 }
+
+const FALLBACK_INSTRUCTIONS =
+  "If the design opens as a browser link instead of inline, the user picks a " +
+  "direction there and the editor shows a copyable summary. Ask them to paste " +
+  "that summary back into chat so you can continue from the chosen direction.";
 
 const variantSchema = z.object({
   id: z.string().min(1).describe("Stable variant id, e.g. 'minimal-focus'"),
@@ -30,10 +38,11 @@ const variantSchema = z.object({
 
 export default defineAction({
   description:
-    "Present exactly 3 generated design directions in the Design editor so the " +
-    "user can visually compare options and pick one. Use this for design " +
-    "exploration before calling generate-design. The user's choice is " +
-    "persisted automatically by the app.",
+    "Present generated design directions in the Design editor so the user can " +
+    "visually compare options and pick one. Provide 2-5 variants (3 is the " +
+    "sweet spot). Use this for design exploration before calling " +
+    "generate-design. The user's choice is persisted automatically by the app; " +
+    "if it opens as a browser link, they paste a copyable summary back to chat.",
   schema: z.object({
     designId: z.string().describe("Design project ID to show variants for"),
     prompt: z
@@ -42,9 +51,10 @@ export default defineAction({
       .describe("Caption shown above the variant grid"),
     variants: z
       .array(variantSchema)
-      .length(3)
+      .min(2)
+      .max(5)
       .describe(
-        "Exactly 3 concise, visually distinct generated design options to preview side by side. Inline CSS so all options render in the MCP app preview.",
+        "2-5 concise, visually distinct generated design options to preview side by side (3 is the sweet spot). Inline CSS so all options render in the MCP app preview.",
       ),
   }),
   mcpApp: {
@@ -71,8 +81,9 @@ export default defineAction({
       designId,
       prompt: prompt ?? "Pick a direction",
       count: variants.length,
-      path: `/design/${encodeURIComponent(designId)}`,
+      path: `/design/${encodeURIComponent(designId)}?handoff=chat`,
       embed: true,
+      fallbackInstructions: FALLBACK_INSTRUCTIONS,
       nextRequiredAction:
         "Wait for the user to pick a variant before refining or calling generate-design.",
     };

--- a/templates/design/app/components/design/VariantGrid.tsx
+++ b/templates/design/app/components/design/VariantGrid.tsx
@@ -25,6 +25,10 @@ export function VariantGrid({
   compact = false,
 }: VariantGridProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [internalSelectedId, setInternalSelectedId] = useState<
+    string | undefined
+  >(selectedId);
+  const activeSelectedId = selectedId ?? internalSelectedId;
   const previewScale = compact ? 0.36 : 0.5;
   const previewSize = `${100 / previewScale}%`;
 
@@ -63,8 +67,13 @@ export function VariantGrid({
         )}
       >
         {variants.map((variant) => {
-          const isSelected = selectedId === variant.id;
+          const isSelected = activeSelectedId === variant.id;
           const isHovered = hoveredId === variant.id;
+          const showAction = isSelected || isHovered;
+          const selectVariant = () => {
+            setInternalSelectedId(variant.id);
+            onSelect(variant.id);
+          };
 
           return (
             <div
@@ -75,15 +84,15 @@ export function VariantGrid({
             >
               {/* Preview frame */}
               <div
-                onClick={() => onSelect(variant.id)}
+                onClick={selectVariant}
                 onKeyDown={(event) => {
                   if (event.key !== "Enter" && event.key !== " ") return;
                   event.preventDefault();
-                  onSelect(variant.id);
+                  selectVariant();
                 }}
                 role="button"
                 tabIndex={0}
-                aria-label={`Use ${variant.label}`}
+                aria-label={`Preview ${variant.label}`}
                 className={cn(
                   "relative flex-1 cursor-pointer overflow-hidden rounded-lg border-2 bg-muted/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                   isSelected
@@ -111,8 +120,8 @@ export function VariantGrid({
                   </div>
                 )}
 
-                {/* Hover overlay with "Use this one" */}
-                {isHovered && (
+                {/* Commit action appears after hover or selection, including touch. */}
+                {showAction && (
                   <div className="absolute inset-0 flex items-center justify-center bg-black/40">
                     <Button
                       size="sm"
@@ -120,8 +129,9 @@ export function VariantGrid({
                         e.stopPropagation();
                         onUse(variant.id);
                       }}
+                      aria-label={`Use ${variant.label}`}
                     >
-                      Use this one
+                      Use this direction
                     </Button>
                   </div>
                 )}

--- a/templates/design/app/components/design/VariantHandoffCard.tsx
+++ b/templates/design/app/components/design/VariantHandoffCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { IconCheck, IconCopy } from "@tabler/icons-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -11,26 +11,45 @@ interface VariantHandoffCardProps {
 }
 
 /**
- * Shown after a pick when the editor was opened from a link-only host (CLI /
- * Codex / Claude Code) that can't relay the choice over a chat bridge. The
- * summary is already on the clipboard; this makes the next step obvious and
- * lets the user re-copy or select it by hand.
+ * Shown after a pick (or dismiss) when the editor was opened from a link-only
+ * host (CLI / Codex / Claude Code) that can't relay the choice over a chat
+ * bridge. The card owns the clipboard write so its "Copied" state stays
+ * truthful even when the browser blocks programmatic copy.
  */
 export function VariantHandoffCard({
   pick,
   onDismiss,
 }: VariantHandoffCardProps) {
-  const [copied, setCopied] = useState(true);
+  const [copied, setCopied] = useState(false);
 
-  const copy = async () => {
+  const writeClipboard = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(pick.text);
-      setCopied(true);
-      toast.success("Summary copied");
+      return true;
     } catch {
-      setCopied(false);
-      toast.info("Select the summary to copy it");
+      return false;
     }
+  }, [pick.text]);
+
+  // Auto-copy on mount, but reflect what actually happened: if the browser
+  // blocks the write, leave the button on "Copy summary" so the user knows to
+  // copy (or select) it themselves.
+  useEffect(() => {
+    let active = true;
+    void writeClipboard().then((ok) => {
+      if (active) setCopied(ok);
+    });
+    return () => {
+      active = false;
+    };
+  }, [writeClipboard]);
+
+  const onCopyClick = async () => {
+    const ok = await writeClipboard();
+    setCopied(ok);
+    toast[ok ? "success" : "info"](
+      ok ? "Summary copied" : "Select the summary to copy it",
+    );
   };
 
   return (
@@ -42,17 +61,18 @@ export function VariantHandoffCard({
           </span>
           <div className="min-w-0">
             <div className="text-sm font-medium leading-tight">
-              Direction selected
+              {pick.heading}
             </div>
-            <div className="truncate text-xs text-muted-foreground">
-              “{pick.label}”
-            </div>
+            {pick.label && (
+              <div className="truncate text-xs text-muted-foreground">
+                “{pick.label}”
+              </div>
+            )}
           </div>
         </div>
 
         <p className="mt-3 text-sm text-muted-foreground">
-          Paste this summary into your coding agent to continue from this
-          direction.
+          Paste this summary into your coding agent to continue.
         </p>
 
         <Textarea
@@ -71,7 +91,11 @@ export function VariantHandoffCard({
           >
             Dismiss
           </Button>
-          <Button size="sm" className="cursor-pointer gap-1.5" onClick={copy}>
+          <Button
+            size="sm"
+            className="cursor-pointer gap-1.5"
+            onClick={onCopyClick}
+          >
             {copied ? (
               <IconCheck className="h-3.5 w-3.5" />
             ) : (

--- a/templates/design/app/components/design/VariantHandoffCard.tsx
+++ b/templates/design/app/components/design/VariantHandoffCard.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { IconCheck, IconCopy } from "@tabler/icons-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type { StandalonePick } from "@/hooks/use-variant-flow";
+
+interface VariantHandoffCardProps {
+  pick: StandalonePick;
+  onDismiss: () => void;
+}
+
+/**
+ * Shown after a pick when the editor was opened from a link-only host (CLI /
+ * Codex / Claude Code) that can't relay the choice over a chat bridge. The
+ * summary is already on the clipboard; this makes the next step obvious and
+ * lets the user re-copy or select it by hand.
+ */
+export function VariantHandoffCard({
+  pick,
+  onDismiss,
+}: VariantHandoffCardProps) {
+  const [copied, setCopied] = useState(true);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(pick.text);
+      setCopied(true);
+      toast.success("Summary copied");
+    } catch {
+      setCopied(false);
+      toast.info("Select the summary to copy it");
+    }
+  };
+
+  return (
+    <div className="absolute inset-0 z-40 grid place-items-center bg-background/80 p-4 backdrop-blur-sm">
+      <div className="w-full max-w-md rounded-xl border border-border bg-card p-5 shadow-lg">
+        <div className="flex items-center gap-2.5">
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary">
+            <IconCheck className="h-3.5 w-3.5 text-primary-foreground" />
+          </span>
+          <div className="min-w-0">
+            <div className="text-sm font-medium leading-tight">
+              Direction selected
+            </div>
+            <div className="truncate text-xs text-muted-foreground">
+              “{pick.label}”
+            </div>
+          </div>
+        </div>
+
+        <p className="mt-3 text-sm text-muted-foreground">
+          Paste this summary into your coding agent to continue from this
+          direction.
+        </p>
+
+        <Textarea
+          readOnly
+          value={pick.text}
+          className="mt-3 h-28 resize-none border-border/70 bg-muted/40 font-mono text-[11px] leading-relaxed"
+          onFocus={(event) => event.currentTarget.select()}
+        />
+
+        <div className="mt-3 flex justify-end gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="cursor-pointer"
+            onClick={onDismiss}
+          >
+            Dismiss
+          </Button>
+          <Button size="sm" className="cursor-pointer gap-1.5" onClick={copy}>
+            {copied ? (
+              <IconCheck className="h-3.5 w-3.5" />
+            ) : (
+              <IconCopy className="h-3.5 w-3.5" />
+            )}
+            {copied ? "Copied" : "Copy summary"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/templates/design/app/hooks/use-variant-flow.ts
+++ b/templates/design/app/hooks/use-variant-flow.ts
@@ -21,10 +21,12 @@ interface VariantState {
   prompt?: string;
 }
 
-/** A picked variant surfaced as a copyable handoff for link-only hosts. */
+/** A pick/dismiss surfaced as a copyable handoff for link-only hosts. */
 export interface StandalonePick {
-  label: string;
-  variantId: string;
+  /** Card heading, e.g. "Direction selected" or "Closed without picking". */
+  heading: string;
+  /** Chosen variant name, when a direction was picked. */
+  label?: string;
   /** Paste-back text the user copies into their coding agent's chat. */
   text: string;
 }
@@ -69,6 +71,14 @@ function variantHandoffText(
     "",
     "Design selection context:",
     JSON.stringify(context, null, 2),
+  ].join("\n");
+}
+
+function variantDismissText(): string {
+  return [
+    "Paste this back into your chat to keep going.",
+    "",
+    "I closed the design directions without picking one. Show me a different direction.",
   ].join("\n");
 }
 
@@ -207,12 +217,13 @@ export function useVariantFlow(designId: string | undefined) {
         });
       } else if (isLinkOnlyHandoff()) {
         // Link-only host (CLI / Codex / Claude Code): no chat bridge — show a
-        // copyable summary the user pastes back into their coding agent.
-        const text = variantHandoffText(designId, chosen, persisted);
-        setStandalonePick({ label: chosen.label, variantId: chosen.id, text });
-        if (typeof navigator !== "undefined" && navigator.clipboard) {
-          navigator.clipboard.writeText(text).catch(() => {});
-        }
+        // copyable summary the user pastes back into their coding agent. The
+        // card owns the clipboard write so its "Copied" state stays truthful.
+        setStandalonePick({
+          heading: "Direction selected",
+          label: chosen.label,
+          text: variantHandoffText(designId, chosen, persisted),
+        });
       } else {
         // First-party app: post the pick to its own agent sidebar composer.
         sendToAgentChat({
@@ -233,7 +244,15 @@ export function useVariantFlow(designId: string | undefined) {
 
   const dismiss = useCallback(() => {
     clear();
-    if (isLinkOnlyHandoff() && !isEmbedAuthActive()) return;
+    if (isLinkOnlyHandoff() && !isEmbedAuthActive()) {
+      // No chat bridge to relay the dismissal — give the user a copyable note
+      // so their coding agent doesn't wait on a pick that isn't coming.
+      setStandalonePick({
+        heading: "Closed without picking",
+        text: variantDismissText(),
+      });
+      return;
+    }
     sendToAgentChat({
       message: "Close the variants — none of these.",
       context:

--- a/templates/design/app/hooks/use-variant-flow.ts
+++ b/templates/design/app/hooks/use-variant-flow.ts
@@ -243,6 +243,7 @@ export function useVariantFlow(designId: string | undefined) {
   );
 
   const dismiss = useCallback(() => {
+    const embedded = isEmbedAuthActive();
     clear();
     if (isLinkOnlyHandoff() && !isEmbedAuthActive()) {
       // No chat bridge to relay the dismissal — give the user a copyable note
@@ -257,7 +258,8 @@ export function useVariantFlow(designId: string | undefined) {
       message: "Close the variants — none of these.",
       context:
         "User dismissed the variant grid without picking. Ask what direction they want instead.",
-      submit: false,
+      submit: embedded,
+      ...(embedded ? { openSidebar: false } : {}),
     });
   }, [clear]);
 

--- a/templates/design/app/hooks/use-variant-flow.ts
+++ b/templates/design/app/hooks/use-variant-flow.ts
@@ -1,6 +1,10 @@
 import { useEffect, useCallback, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { sendToAgentChat, agentNativePath } from "@agent-native/core/client";
+import {
+  sendToAgentChat,
+  agentNativePath,
+  isEmbedAuthActive,
+} from "@agent-native/core/client";
 
 export const DESIGN_VARIANT_PICKED_EVENT = "agent-native-design-variant-picked";
 
@@ -17,18 +21,74 @@ interface VariantState {
   prompt?: string;
 }
 
+/** A picked variant surfaced as a copyable handoff for link-only hosts. */
+export interface StandalonePick {
+  label: string;
+  variantId: string;
+  /** Paste-back text the user copies into their coding agent's chat. */
+  text: string;
+}
+
+/**
+ * True when this editor was opened from a link-only host (CLI / Codex / Claude
+ * Code) that can't render the inline MCP app — the deep link carries
+ * `handoff=chat`. There's no host chat bridge to receive the pick, so after the
+ * user chooses we show a copyable summary to paste back into their agent.
+ */
+function isLinkOnlyHandoff(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return (
+      new URLSearchParams(window.location.search).get("handoff") === "chat"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function variantHandoffText(
+  designId: string,
+  variant: VariantCandidate,
+  persisted: boolean,
+): string {
+  const context = {
+    selectedDesign: {
+      designId,
+      variantId: variant.id,
+      label: variant.label,
+      file: "index.html",
+    },
+  };
+  return [
+    "Paste this back into your chat so your agent continues from the chosen design.",
+    "",
+    `I picked the "${variant.label}" design direction.`,
+    persisted
+      ? `It's saved as index.html in design ${designId}. Refine from here with get-design-snapshot + generate-design, or export-coding-handoff to bring it into code. Don't show new variants unless I ask.`
+      : `Saving didn't finish — re-run present-design-variants or generate-design for design ${designId} before refining.`,
+    "",
+    "Design selection context:",
+    JSON.stringify(context, null, 2),
+  ].join("\n");
+}
+
 /**
  * Polls `application-state/design-variants`. When the agent generates 2-5
  * candidate variations, it writes them here; the editor surfaces a
  * full-canvas grid (Claude Design-style: pick a direction before refining).
  *
  * On "Use this one", the chosen variant's HTML is persisted to the design as
- * `index.html` via `generate-design`, the agent is messaged so it has the
- * choice in its history, and the variant state is cleared.
+ * `index.html` via `generate-design`, and the pick is reported back through the
+ * right channel for the host: an embedded MCP host gets a chat message over the
+ * bridge; the first-party app posts to its own sidebar; a link-only host (CLI)
+ * gets a copyable summary to paste back. The variant state is then cleared.
  */
 export function useVariantFlow(designId: string | undefined) {
   const qc = useQueryClient();
   const [state, setState] = useState<VariantState | null>(null);
+  const [standalonePick, setStandalonePick] = useState<StandalonePick | null>(
+    null,
+  );
 
   const { data } = useQuery({
     queryKey: ["design-variants"],
@@ -69,6 +129,8 @@ export function useVariantFlow(designId: string | undefined) {
     }).catch(() => {});
   }, [qc]);
 
+  const dismissStandalonePick = useCallback(() => setStandalonePick(null), []);
+
   const useVariant = useCallback(
     async (variantId: string) => {
       if (!state || !designId) return;
@@ -76,8 +138,7 @@ export function useVariantFlow(designId: string | undefined) {
       if (!chosen) return;
 
       // Persist the chosen variant as the design's primary file via the
-      // agent's own action endpoint. We keep the agent informed via chat so
-      // subsequent edits target the picked direction.
+      // agent's own action endpoint so every host lands on the same design.
       let persisted = false;
       try {
         const res = await fetch(
@@ -115,31 +176,55 @@ export function useVariantFlow(designId: string | undefined) {
             );
           }
         } else {
-          // Surface the failure rather than telling the agent the variant was
-          // saved when the server actually rejected it. The picker still
-          // clears so the user isn't stuck — they can re-pick after retrying.
           console.warn(
             `[use-variant-flow] generate-design returned ${res.status}; variant not persisted`,
           );
         }
       } catch {
-        // Network error: clear the picker anyway so the user isn't stuck;
-        // the agent message below records that they made a choice.
+        // Network error: report the choice below so the agent still records it;
+        // the grid still clears so the user isn't stuck.
       }
 
-      sendToAgentChat({
-        message: `I picked "${chosen.label}".`,
-        context: [
-          `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${designId}.`,
-          persisted
-            ? `Its content has been saved as index.html. Continue refining from there if the user asks.`
-            : `Saving the chosen variant did not complete. Ask the user whether to retry before refining it.`,
-          persisted
-            ? `Do not show further variants unless the user explicitly asks for "more options" or "alternatives".`
-            : `Do not claim the design file was updated until generate-design succeeds.`,
-        ].join("\n"),
-        submit: false,
-      });
+      const refineHint = persisted
+        ? `Its content has been saved as index.html. Continue refining from there if the user asks.`
+        : `Saving the chosen variant did not complete. Ask the user whether to retry before refining it.`;
+      const guardHint = persisted
+        ? `Do not show further variants unless the user explicitly asks for "more options" or "alternatives".`
+        : `Do not claim the design file was updated until generate-design succeeds.`;
+
+      if (isEmbedAuthActive()) {
+        // Embedded MCP host (ChatGPT / Claude): the pick rides the host chat
+        // bridge straight into the conversation.
+        sendToAgentChat({
+          message: `I picked "${chosen.label}".`,
+          context: [
+            `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${designId} inside the embedded Design app.`,
+            refineHint,
+            guardHint,
+          ].join("\n"),
+          submit: true,
+          openSidebar: false,
+        });
+      } else if (isLinkOnlyHandoff()) {
+        // Link-only host (CLI / Codex / Claude Code): no chat bridge — show a
+        // copyable summary the user pastes back into their coding agent.
+        const text = variantHandoffText(designId, chosen, persisted);
+        setStandalonePick({ label: chosen.label, variantId: chosen.id, text });
+        if (typeof navigator !== "undefined" && navigator.clipboard) {
+          navigator.clipboard.writeText(text).catch(() => {});
+        }
+      } else {
+        // First-party app: post the pick to its own agent sidebar composer.
+        sendToAgentChat({
+          message: `I picked "${chosen.label}".`,
+          context: [
+            `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${designId}.`,
+            refineHint,
+            guardHint,
+          ].join("\n"),
+          submit: false,
+        });
+      }
 
       clear();
     },
@@ -148,6 +233,7 @@ export function useVariantFlow(designId: string | undefined) {
 
   const dismiss = useCallback(() => {
     clear();
+    if (isLinkOnlyHandoff() && !isEmbedAuthActive()) return;
     sendToAgentChat({
       message: "Close the variants — none of these.",
       context:
@@ -156,5 +242,5 @@ export function useVariantFlow(designId: string | undefined) {
     });
   }, [clear]);
 
-  return { state, useVariant, dismiss };
+  return { state, useVariant, dismiss, standalonePick, dismissStandalonePick };
 }

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -342,6 +342,23 @@ export default function DesignEditor() {
     standalonePick,
     dismissStandalonePick,
   } = useVariantFlow(id);
+  const pendingVariantKey = useMemo(
+    () =>
+      pendingVariants
+        ? `${pendingVariants.designId}:${pendingVariants.variants
+            .map((variant) => variant.id)
+            .join(",")}`
+        : "",
+    [pendingVariants],
+  );
+  const [selectedVariantId, setSelectedVariantId] = useState<
+    string | undefined
+  >();
+  const initialVariantId = pendingVariants?.variants[0]?.id;
+
+  useEffect(() => {
+    setSelectedVariantId(initialVariantId);
+  }, [initialVariantId, pendingVariantKey]);
 
   const { session } = useSession();
 
@@ -1854,7 +1871,7 @@ ${serializedHtml}
           )}
 
         {/* Variant grid overlay — full canvas takeover with 2-5 candidate
-            designs. "Use this one" persists the chosen content as index.html. */}
+            designs. "Use this direction" persists the chosen content as index.html. */}
         {pendingVariants && (
           <div className="absolute inset-0 z-40 flex flex-col bg-background">
             <div
@@ -1883,7 +1900,8 @@ ${serializedHtml}
             <div className="flex-1 overflow-hidden">
               <VariantGrid
                 variants={pendingVariants.variants}
-                onSelect={handleVariantChoice}
+                selectedId={selectedVariantId}
+                onSelect={setSelectedVariantId}
                 onUse={handleVariantChoice}
                 compact={embedded}
               />

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -38,7 +38,6 @@ import {
   NotificationsBell,
   ShareButton,
   isEmbedAuthActive,
-  sendToAgentChat,
   type CollabUser,
   type PromptComposerSubmitOptions,
 } from "@agent-native/core/client";
@@ -61,6 +60,7 @@ import { MultiScreenCanvas } from "@/components/design/MultiScreenCanvas";
 import { QuestionFlow } from "@/components/design/QuestionFlow";
 import { TweaksPanel } from "@/components/design/TweaksPanel";
 import { VariantGrid } from "@/components/design/VariantGrid";
+import { VariantHandoffCard } from "@/components/design/VariantHandoffCard";
 import { SaveStatusIndicator } from "@/components/visual-editor";
 import PromptPopover from "@/components/editor/PromptDialog";
 import type { UploadedFile } from "@/components/editor/PromptDialog";
@@ -337,30 +337,11 @@ export default function DesignEditor() {
   } = useQuestionFlow(id);
   const {
     state: pendingVariants,
-    useVariant: handleUseVariant,
+    useVariant: handleVariantChoice,
     dismiss: handleVariantsDismiss,
+    standalonePick,
+    dismissStandalonePick,
   } = useVariantFlow(id);
-  const handleVariantChoice = useCallback(
-    async (variantId: string) => {
-      const chosen = pendingVariants?.variants.find(
-        (variant) => variant.id === variantId,
-      );
-      await handleUseVariant(variantId);
-
-      if (!embedded || !chosen || !id) return;
-      sendToAgentChat({
-        message: `I picked "${chosen.label}".`,
-        context: [
-          `The user chose variant "${chosen.label}" (id: ${chosen.id}) for design ${id} inside the embedded Design MCP app.`,
-          "Continue from the chosen direction when the user asks for refinements.",
-          'If the user asks for another iteration, use get-design-snapshot and generate-design against the current index.html; do not present new variants unless they ask for "more options" or "alternatives".',
-        ].join("\n"),
-        submit: true,
-        openSidebar: false,
-      });
-    },
-    [embedded, handleUseVariant, id, pendingVariants],
-  );
 
   const { session } = useSession();
 
@@ -1908,6 +1889,15 @@ ${serializedHtml}
               />
             </div>
           </div>
+        )}
+
+        {/* Link-only (CLI / Codex / Claude Code) paste-back: after a pick there
+            is no chat bridge, so surface a copyable summary to continue. */}
+        {standalonePick && (
+          <VariantHandoffCard
+            pick={standalonePick}
+            onDismiss={dismissStandalonePick}
+          />
         )}
 
         {/* Canvas */}

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -342,6 +342,8 @@ export default function DesignEditor() {
     standalonePick,
     dismissStandalonePick,
   } = useVariantFlow(id);
+
+  const { session } = useSession();
   const pendingVariantKey = useMemo(
     () =>
       pendingVariants
@@ -359,8 +361,6 @@ export default function DesignEditor() {
   useEffect(() => {
     setSelectedVariantId(initialVariantId);
   }, [initialVariantId, pendingVariantKey]);
-
-  const { session } = useSession();
 
   useEffect(() => {
     return () => clearGenerationCompleteTimer();


### PR DESCRIPTION
Improves the **design template** toward Claude Design parity and fixes two reported bugs. Research-driven (deep dive into Claude Design UX, AI design-gen best practices, OSS design editors, Figma MCP/token workflows, and smart-diffing) — the conclusion was that our template already mirrors Claude Design's flow, so this PR closes the highest-leverage gaps rather than rebuilding.

## Bug fixes (both reported with screenshots)
- **Ugly loading screen → skeleton.** The editor showed a bare spinner on a black void. It now renders a proper skeleton (toolbar + dot-grid canvas with a faux design frame). Present mode gets a skeleton too.
- **Prototype links broke the preview.** Clicking a link inside a prototype navigated the `srcdoc` iframe to the app URL ("Design not found"). A new **nav bridge** intercepts clicks: external links open in a new tab, relative links / `data-screen` switch to the matching screen in a multi-screen design, and `#`/Alpine handlers pass through untouched. Generation guidance updated so screens link via Alpine state / `data-screen` / `#`, never real URLs.

## Sleeker toolbar (progressive disclosure)
Was a Word-style mega-row of ~15 controls. Now:
- Device frames (4 buttons) → one **Device** menu
- Zoom (3 controls) → one **Zoom** menu (presets + in/out)
- Comment-pin + all five exports → one **More** menu
- Removed the duplicate Draw button (Draw is already a mode)

## Sharper generation (`design-generation` skill)
- Anti-"AI slop" quality bar; 4-layer prompt model (Context / Structure / Aesthetic / Tech); measurable rules (8px grid, type scale, WCAG, **token grounding**); brand vs product presets.
- Multi-screen navigation rules that match the new nav bridge.
- **Tailwind v4 gotcha**: use `bg-linear-to-*`, not the v3 `bg-gradient-to-*` (silently broken on the v4 CDN); add `prefers-reduced-motion`; stop defaulting to Space Grotesk.

## Smart diffs
- New **`edit-design`** action — surgical search/replace edits to a single file (exact + whitespace-flexible match, unique-match required) so refinements make the smallest possible change instead of regenerating whole files. Pure matcher with 8 unit tests; skill + AGENTS guidance to "read then edit."

## Design systems
- Figma guidance now prefers official MCP/API context first (`get_variable_defs`, `get_design_context`, `get_screenshot`) for real token/style context, with a describe-the-file fallback.

## Testing
- `typecheck`, `build`, full template test suite (29 passing incl. 8 new), Prettier — all green.
- `edit-design` verified end-to-end via CLI (surgical edit applied; ambiguous edit correctly rejected).
- Nav-bridge script validated as parseable JS + link-classification unit-checked.
- App boots locally; full editor visuals (skeleton + toolbar + link nav) are best confirmed on the deploy preview since there's no dev auth bypass.

## Follow-ups (intentionally out of scope)
Figma REST API importer (token secret), `data-eid` + `@alpinejs/morph` live-preview diffing, persistent variant switcher, and a visual version-history timeline.
