### PR TITLE
feat(design): sleeker toolbar, skeleton loaders, prototype link fix, sharper generation

### DIFF
--- a/templates/design/.agents/skills/design-generation/SKILL.md
+++ b/templates/design/.agents/skills/design-generation/SKILL.md
@@ -10,6 +10,58 @@ Every generated design uses:
 - **Google Fonts** — for distinctive typography (never Inter/Roboto/Arial)
 - **CSS Custom Properties** — for theming and tweaks panel integration
 
+## Aesthetic Quality Bar — avoid generic "AI slop"
+
+The single biggest lever on quality is refusing the defaults the model reaches
+for. Before generating, commit to a specific, opinionated direction. Banned by
+default (use only if the user explicitly asks):
+
+- **Fonts:** Inter, Roboto, Arial, system-ui, or other safe defaults. Always
+  pick a distinctive Google Font pairing (see the table below).
+- **The purple/indigo gradient on white** and other one-click hero clichés.
+- **Default shadcn/Tailwind grays** as the whole palette; flat indigo/blue
+  accents; the recurring "fingerprint" combo (teal accent + blinking status dot
+  + left accent bars + three-column hero).
+- **Predictable, evenly-weighted layouts** with no focal point.
+
+Do not converge even within your own "creative" picks — vary deliberately across
+generations so two designs never share the same fingerprint.
+
+## Prompt the design in four layers
+
+Decide each layer explicitly before writing HTML. This is what makes variations
+genuinely distinct instead of three near-identical layouts:
+
+1. **Context** — audience, domain, and the one job this screen must do.
+2. **Structure** — a named layout topology: bento grid, sidebar app shell,
+   editorial column, split-screen, masonry, dashboard tiles.
+3. **Aesthetic** — a named visual movement: editorial serif, neo-brutalist,
+   glassmorphic, Swiss/International, warm organic, technical/mono, etc. Each
+   variant gets a *different* aesthetic + font pairing.
+4. **Tech stack** — Tailwind v4 + Alpine, mobile-first, light/dark via tokens.
+
+Push each dimension to extremes rather than safe middles: weight extremes
+(100–200 vs 800–900), 3×+ type-scale jumps, one dominant color + a single sharp
+accent, layered gradient/pattern backgrounds (not flat fills), and one
+orchestrated staggered page-load reveal (via `animation-delay`).
+
+Pick a preset by `projectType`:
+- **Brand / marketing** (landing pages, decks): expressive, atmospheric,
+  animated, full-bleed.
+- **Product / app** (dashboards, tools): dense, restrained, token-driven, fast.
+
+## Measurable rules (bake these in)
+
+- 8px spacing grid — all padding/margins/gaps are multiples of 4/8.
+- Body text ≥ 16px, labels ≥ 12px.
+- Big type-scale jumps for hierarchy (don't rely on tiny size deltas).
+- WCAG contrast: 4.5:1 normal text, 3:1 large text. Verify accent-on-background.
+- Mobile-first breakpoints; never ship a layout that breaks under 640px.
+- No arbitrary one-off Tailwind values where a scale step exists.
+- **Token grounding is non-negotiable:** every color/font/radius references a
+  `:root` CSS variable. Never hardcode `text-white` / `bg-black` / hex literals
+  in the markup — that's what keeps brand + multi-screen consistency automatic.
+
 ## Generation Workflow — the canonical 4-phase flow
 
 This flow mirrors Claude Design's UX: ask → show variants → user picks → refine. Don't skip phases for new designs.
@@ -137,6 +189,16 @@ Every `index.html` must include:
       text-wrap: balance;
     }
     p { text-wrap: pretty; }
+
+    /* Respect users who ask for less motion */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+    }
   </style>
 </head>
 <body class="bg-[var(--color-primary)] text-[var(--color-text)]">
@@ -343,7 +405,9 @@ Every `index.html` must include:
 
 ## Font Recommendations
 
-Good distinctive font pairings (heading / body):
+Good distinctive font pairings (heading / body). **Rotate through these** — don't
+reach for Space Grotesk (or any single pairing) every time; matching the pairing
+to the chosen Aesthetic layer is what keeps designs from sharing a fingerprint:
 
 | Heading | Body | Mood |
 | --- | --- | --- |
@@ -356,12 +420,84 @@ Good distinctive font pairings (heading / body):
 | Clash Display | General Sans | Bold statement |
 | Archivo | Nunito Sans | Friendly SaaS |
 
+## Multi-screen prototypes & navigation
+
+A prototype with more than one screen is **multiple files** in the same design
+(e.g. `index.html`, `dashboard.html`, `checkout.html`). The editor shows them
+all in the artboard/overview and as screen tabs.
+
+The preview renders each file in a sandboxed `srcdoc` iframe. A real
+`<a href="/pricing">` or `<a href="page.html">` resolves against the *app* URL
+and navigates the iframe to the Design app itself ("Design not found"), nuking
+the prototype. **Never link screens with real URLs.** Use one of:
+
+1. **In-screen flows (preferred):** keep the flow in one file with Alpine state
+   and `x-show`. Links become buttons:
+   ```html
+   <div x-data="{ screen: 'home' }">
+     <button @click="screen = 'pricing'" class="cursor-pointer">See pricing</button>
+     <section x-show="screen === 'home'">…</section>
+     <section x-show="screen === 'pricing'" x-cloak>…</section>
+   </div>
+   ```
+2. **Cross-file screen links:** to jump to another file in the design, use
+   `data-screen` (or a bare filename href). The editor intercepts the click and
+   switches to that screen instead of navigating:
+   ```html
+   <a data-screen="checkout.html" class="cursor-pointer">Checkout</a>
+   ```
+   The target should match the other file's name (`checkout.html` →
+   `checkout.html`; the `.html` is optional in the match).
+3. **In-page scroll:** `href="#features"` is fine and scrolls within the screen.
+
+External links (`https://…`) are allowed — the editor opens them in a new tab.
+Never use `target="_top"` or relative paths expecting a real page load.
+
+## Making edits — minimal, scoped "smart" diffs
+
+When refining an existing design, change the **smallest** amount possible. Full
+regeneration is slow, expensive, and regresses unrelated parts.
+
+1. **Read before you edit.** Pull the current file with `get-design-snapshot`
+   (or `get-design`) so you edit the live content, not a stale memory of it.
+2. **Prefer `edit-design` for small changes.** It applies one or more
+   search/replace blocks to a file's HTML — surgical, cheap, and it preserves
+   everything you didn't touch (Alpine state, scroll, other screens):
+   ```bash
+   pnpm action edit-design --designId "<id>" --filename index.html \
+     --edits '[{"search":"<h1 class=\"text-4xl\">Hello</h1>","replace":"<h1 class=\"text-5xl\">Hello there</h1>"}]'
+   ```
+   Each `search` must match the file **exactly and uniquely** — include enough
+   surrounding context to be unambiguous. Wrapping an element in a new div is
+   just a search/replace whose `replace` adds the wrapper around the original.
+3. **Reserve `generate-design` for** net-new files or large structural rewrites.
+   Never resend files you aren't changing.
+4. **Treat `:root` as the global spec.** For theme-wide restyles, edit the
+   tokens in `:root` rather than touching every element.
+5. **Don't add unrequested features** during a refinement pass.
+
+## Tailwind v4 + motion gotchas
+
+- **Gradients:** Tailwind v4 renamed the utilities. Use `bg-linear-to-r`,
+  `bg-radial`, `bg-conic` — the v3 `bg-gradient-to-*` classes silently do
+  nothing on the v4 browser CDN.
+- **Respect reduced motion.** Wrap non-essential animation so it's disabled for
+  users who ask for it (already included in the mandatory `<style>` below).
+- Use Tailwind scale steps, not arbitrary `[…px]` values, unless truly needed.
+
 ## What NOT to Do
 
+- Never use safe/generic fonts (Inter, Roboto, Arial, system-ui) or the
+  purple-on-white gradient, default shadcn grays, or the teal-accent +
+  blinking-dot + three-column-hero cliché — see the Aesthetic Quality Bar.
+- Never link prototype screens with real/relative URLs — use Alpine state,
+  `data-screen`, or `#` anchors (see Multi-screen prototypes & navigation).
+- Never hardcode colors — always reference CSS custom properties (no raw
+  `text-white` / `bg-black` / hex literals in markup).
+- Never use the v3 `bg-gradient-to-*` classes — use v4 `bg-linear-to-*`.
 - Never use `<script>` blocks with raw DOM manipulation — use Alpine.js directives
 - Never inline `onclick="..."` handlers — use `@click`
 - Never use `!important` except in `[x-cloak]`
-- Never hardcode colors — always use CSS custom properties
 - Never use position: fixed for modals — wrap in a portal-like pattern with Alpine.js
 - Never forget `cursor-pointer` on interactive elements
 - Never use `<img>` with placeholder URLs — use colored divs or gradients

--- a/templates/design/.agents/skills/design-systems/SKILL.md
+++ b/templates/design/.agents/skills/design-systems/SKILL.md
@@ -175,6 +175,23 @@ pnpm action import-design-project --designId _ --designSystemId "ds-456"
 
 Extracts CSS tokens from a project's generated HTML, or clones an existing design system for forking.
 
+### Source: Figma file
+
+```bash
+pnpm action import-figma --figmaUrl "https://figma.com/design/<key>/..." \
+  --description "<extracted tokens / styles summary>"
+```
+
+**Prefer the connected Figma MCP** when available (tools like
+`get_variable_defs`, `get_design_context`, `get_metadata`, `get_screenshot`).
+Call those on the file/selection FIRST to pull real variables (tokens), color
+and text styles, and a screenshot — this sidesteps REST/Enterprise limits and
+returns a token map directly. Then pass that summary to `import-figma` and build
+the system with `create-design-system`. Convert Figma colors (0-1 RGBA) to hex,
+effects to CSS box-shadow, and text styles to font tokens; snap spacing to a
+4/8px scale. If no Figma MCP is connected, ask the user to paste the token
+values or describe the file.
+
 ### Source: Brand Analysis (combines website + notes)
 
 ```bash
@@ -191,10 +208,11 @@ Returns CSS properties, colors, fonts, theme-color, metadata.
 When the user provides multiple sources, call all applicable import actions in parallel, then synthesize:
 
 1. **Prioritize code sources** (GitHub, local files) — these have the most accurate tokens
-2. **Cross-reference with website** — validates colors/fonts are actually deployed
-3. **Documents supplement** — presentations may reveal brand colors not in code
-4. **Images inform mood** — color temperature, density, visual style
-5. **Aggregate into DesignSystemData** — merge all extracted tokens, resolve conflicts
+2. **Figma variables/styles** (via the Figma MCP) — authoritative when the team designs in Figma
+3. **Cross-reference with website** — validates colors/fonts are actually deployed
+4. **Documents supplement** — presentations may reveal brand colors not in code
+5. **Images inform mood** — color temperature, density, visual style
+6. **Aggregate into DesignSystemData** — merge all extracted tokens, resolve conflicts
 6. **Call `create-design-system`** with the combined result
 7. **Link to design** via `update-design --designSystemId`
 

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -19,6 +19,13 @@ patterns live in `.agents/skills/`.
   different export format. They should render in the iframe without a build step.
 - Use Alpine.js and Tailwind CDN for interactive prototypes. Prefer Alpine
   directives over raw inline event handlers.
+- Navigate between prototype screens with Alpine state (`x-show`), a
+  `data-screen="file.html"` attribute, or `#` anchors — never real/relative
+  URLs, which would navigate the preview iframe to the app itself.
+- To refine an existing design, make the smallest change: read it with
+  `get-design-snapshot`, then use `edit-design` (search/replace). Reserve
+  `generate-design` for new files or large structural rewrites; never resend
+  files you aren't changing.
 - Follow linked design-system tokens and `customInstructions` whenever present;
   explicit user instructions in the current turn still win.
 - Persist useful work early: create/update the design and files as soon as a

--- a/templates/design/actions/edit-design.ts
+++ b/templates/design/actions/edit-design.ts
@@ -1,0 +1,124 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import { and, eq } from "drizzle-orm";
+import { getDb, schema } from "../server/db/index.js";
+import { accessFilter, assertAccess } from "@agent-native/core/sharing";
+import {
+  hasCollabState,
+  getText,
+  applyText,
+  seedFromText,
+} from "@agent-native/core/collab";
+import { applyEdits } from "../shared/apply-edits.js";
+
+export default defineAction({
+  description:
+    "Apply small, surgical search/replace edits to ONE file in a design — the " +
+    "preferred way to refine an existing design without regenerating the whole " +
+    "file (cheaper, faster, and it preserves everything you don't touch). Each " +
+    "edit's `search` must match the current file exactly and uniquely, so " +
+    "include enough surrounding context. Read the file first with " +
+    "`get-design-snapshot`. Wrapping an element is just a search/replace whose " +
+    "`replace` adds the wrapper around the original text. Use `generate-design` " +
+    "instead only for brand-new files or large structural rewrites.",
+  schema: z.object({
+    designId: z.string().describe("Design project ID"),
+    filename: z
+      .string()
+      .default("index.html")
+      .describe("File to edit (e.g. 'index.html')"),
+    edits: z
+      .preprocess(
+        (v) => (typeof v === "string" ? JSON.parse(v) : v),
+        z
+          .array(
+            z.object({
+              search: z
+                .string()
+                .min(1)
+                .describe(
+                  "Exact text to find, with enough surrounding context to be unique",
+                ),
+              replace: z.string().describe("Replacement text"),
+            }),
+          )
+          .min(1),
+      )
+      .describe("Search/replace blocks, applied in order"),
+  }),
+  run: async ({ designId, filename, edits }) => {
+    await assertAccess("design", designId, "editor");
+
+    const db = getDb();
+    const now = new Date().toISOString();
+
+    // Resolve the target file (access-scoped) by design + filename.
+    const [file] = await db
+      .select({
+        id: schema.designFiles.id,
+        content: schema.designFiles.content,
+      })
+      .from(schema.designFiles)
+      .innerJoin(
+        schema.designs,
+        eq(schema.designFiles.designId, schema.designs.id),
+      )
+      .where(
+        and(
+          eq(schema.designFiles.designId, designId),
+          eq(schema.designFiles.filename, filename),
+          accessFilter(schema.designs, schema.designShares),
+        ),
+      )
+      .limit(1);
+
+    if (!file) {
+      throw new Error(`File "${filename}" not found in design ${designId}`);
+    }
+
+    // Prefer live collab content so we edit in-flight changes, not a stale
+    // persisted copy (mirrors get-design-snapshot).
+    let base = file.content ?? "";
+    try {
+      if (await hasCollabState(file.id)) {
+        const live = await getText(file.id, "content");
+        if (typeof live === "string" && live.length > 0) base = live;
+      }
+    } catch {
+      // Collab read is best-effort; fall back to stored content.
+    }
+
+    const { content: nextContent, applied } = applyEdits(base, edits);
+    const changed = nextContent !== base;
+
+    if (changed) {
+      await db
+        .update(schema.designFiles)
+        .set({ content: nextContent, updatedAt: now })
+        .where(eq(schema.designFiles.id, file.id));
+
+      // Push the full new content through the collab layer; it diffs internally
+      // so live editors get a minimal update.
+      if (await hasCollabState(file.id)) {
+        await applyText(file.id, nextContent, "content", "agent");
+      } else {
+        await seedFromText(file.id, nextContent);
+      }
+
+      await db
+        .update(schema.designs)
+        .set({ updatedAt: now })
+        .where(eq(schema.designs.id, designId));
+    }
+
+    return {
+      designId,
+      filename,
+      fileId: file.id,
+      editsApplied: applied,
+      changed,
+      bytesBefore: base.length,
+      bytesAfter: nextContent.length,
+    };
+  },
+});

--- a/templates/design/actions/edit-design.ts
+++ b/templates/design/actions/edit-design.ts
@@ -29,7 +29,16 @@ export default defineAction({
       .describe("File to edit (e.g. 'index.html')"),
     edits: z
       .preprocess(
-        (v) => (typeof v === "string" ? JSON.parse(v) : v),
+        (v) => {
+          if (typeof v !== "string") return v;
+          // Don't let malformed JSON throw an uncaught SyntaxError — return the
+          // raw value so Zod produces a clean validation error instead.
+          try {
+            return JSON.parse(v);
+          } catch {
+            return v;
+          }
+        },
         z
           .array(
             z.object({
@@ -81,8 +90,11 @@ export default defineAction({
     let base = file.content ?? "";
     try {
       if (await hasCollabState(file.id)) {
+        // When a collab session exists it is authoritative — use its text even
+        // if empty (a legitimately cleared file), rather than silently editing
+        // stale stored HTML.
         const live = await getText(file.id, "content");
-        if (typeof live === "string" && live.length > 0) base = live;
+        if (typeof live === "string") base = live;
       }
     } catch {
       // Collab read is best-effort; fall back to stored content.

--- a/templates/design/actions/import-figma.ts
+++ b/templates/design/actions/import-figma.ts
@@ -3,34 +3,53 @@ import { z } from "zod";
 
 export default defineAction({
   description:
-    "Process a Figma file description for design import. " +
-    "Since .fig file parsing happens client-side, this action accepts a " +
-    "text description of the Figma file contents and returns structured " +
-    "context for the agent to use when creating the design project.",
+    "Turn a Figma file into a design system or design project. " +
+    "PREFERRED: if a Figma MCP is connected (tools like `get_variable_defs`, " +
+    "`get_design_context`, `get_metadata`, `get_screenshot`), call those FIRST " +
+    "on the file/selection to extract real variables (tokens), colors, " +
+    "typography, spacing and a screenshot — then pass a concise summary here " +
+    "and follow up with `create-design-system`. If no Figma MCP is available, " +
+    "ask the user to describe the file (or paste token values) and pass that as " +
+    "`description`. Returns structured context for building the design.",
   schema: z.object({
+    figmaUrl: z
+      .string()
+      .optional()
+      .describe("Figma file/frame URL (figma.com/design/<key>...)"),
     description: z
       .string()
+      .optional()
       .describe(
-        "User's description of what is in the Figma file (components, pages, styles, etc.)",
+        "Summary of the file's tokens/components/pages — ideally the output of " +
+          "the Figma MCP (variable defs, color/text styles), else the user's " +
+          "description.",
       ),
-    figmaUrl: z.string().optional().describe("Figma file URL for reference"),
     projectTitle: z
       .string()
       .optional()
-      .describe("Suggested title for the imported design project"),
+      .describe("Suggested title for the imported design project or system"),
   }),
   readOnly: true,
-  run: async ({ description, figmaUrl, projectTitle }) => {
+  run: async ({ figmaUrl, description, projectTitle }) => {
     return {
       source: "figma",
-      description,
       figmaUrl: figmaUrl ?? null,
+      description: description ?? null,
       suggestedTitle: projectTitle ?? null,
-      instructions:
-        "Use this context to create a new design project. " +
-        "Extract component structures, color palettes, typography, and layout patterns " +
-        "from the description to populate the design files. " +
-        "Create separate files for each major component or page described.",
+      instructions: [
+        "Build the design system / design from the extracted Figma data:",
+        "1. If a Figma MCP is connected and you have not yet, call its token/" +
+          "context tools (get_variable_defs for tokens, get_design_context or " +
+          "get_metadata for structure, get_screenshot for the visual) on the " +
+          "file or selection before continuing.",
+        "2. Map the extracted variables/styles to DesignSystemData (colors, " +
+          "typography, spacing, borders) and call create-design-system; set it " +
+          "as default if the user wants it applied to new designs.",
+        "3. Convert Figma colors (0-1 RGBA) to hex, effects to CSS box-shadow, " +
+          "and text styles to font tokens. Cluster spacing onto a 4/8px scale.",
+        "4. For a full design, create separate files per page/major frame and " +
+          "ground every value in :root CSS variables from the system.",
+      ].join("\n"),
     };
   },
 });

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -67,6 +67,67 @@ const ZOOM_BRIDGE_SCRIPT = `
 `;
 
 /**
+ * Navigation bridge. ALWAYS injected. A prototype lives in a `srcdoc` iframe,
+ * so a plain `<a href="/pricing">` resolves the relative URL against the PARENT
+ * app document and navigates the iframe to the Design app itself ("Design not
+ * found"), nuking the prototype. We intercept link clicks + relative form
+ * submits and route them to the parent instead:
+ *   - in-page anchors (`#...`) and `javascript:`/`@click` handlers: left alone
+ *   - external `http(s)`/`//` links: opened in a new tab by the parent
+ *   - internal/relative links (or an explicit `data-screen`): asked to switch
+ *     to the matching screen in a multi-screen design; otherwise a no-op so the
+ *     prototype never blows itself away.
+ */
+const NAV_BRIDGE_SCRIPT = `
+<script data-agent-native-nav-bridge>
+(function() {
+  function classify(href) {
+    var h = (href || '').trim();
+    if (!h) return null;
+    var lower = h.toLowerCase();
+    if (lower.charAt(0) === '#') return null;
+    if (lower.indexOf('javascript:') === 0) return null;
+    if (lower.indexOf('mailto:') === 0 || lower.indexOf('tel:') === 0) {
+      return { external: true, href: h };
+    }
+    if (/^https?:\\/\\//i.test(h) || /^\\/\\//.test(h)) {
+      return { external: true, href: h };
+    }
+    var screen = h.replace(/^\\.?\\//, '').split(/[?#]/)[0];
+    return { external: false, href: h, screen: screen };
+  }
+  document.addEventListener('click', function(e) {
+    var t = e.target;
+    if (!t || !t.closest) return;
+    var a = t.closest('a[href], [data-screen]');
+    if (!a) return;
+    var ds = a.getAttribute && a.getAttribute('data-screen');
+    var info = ds
+      ? { external: false, href: ds, screen: ds.replace(/^\\.?\\//, '').split(/[?#]/)[0] }
+      : classify(a.getAttribute('href'));
+    if (!info) return;
+    e.preventDefault();
+    try {
+      window.parent.postMessage({
+        type: 'prototype-navigate',
+        external: !!info.external,
+        href: info.href,
+        screen: info.screen || '',
+      }, '*');
+    } catch (err) {}
+  }, true);
+  document.addEventListener('submit', function(e) {
+    var f = e.target;
+    if (!f || f.tagName !== 'FORM') return;
+    var action = f.getAttribute('action') || '';
+    if (/^https?:\\/\\//i.test(action)) return;
+    e.preventDefault();
+  }, true);
+})();
+</script>
+`;
+
+/**
  * Edit-mode bridge: element click/hover overlays + selector-targeted
  * style-change messages. Only injected when the user is in Edit mode.
  */
@@ -254,6 +315,13 @@ interface DesignCanvasProps {
   designId?: string;
   /** Human-readable label for the design (used in agent prompt). */
   designTitle?: string;
+  /**
+   * Called when a link inside the prototype points to another screen (a
+   * relative href or `data-screen`). Lets the editor switch the active screen
+   * instead of letting the iframe navigate to the app. External links are
+   * opened in a new tab here and never reach this callback.
+   */
+  onPrototypeNavigate?: (screen: string, href: string) => void;
 }
 
 export function DesignCanvas({
@@ -271,6 +339,7 @@ export function DesignCanvas({
   onExitPinMode,
   designId,
   designTitle,
+  onPrototypeNavigate,
 }: DesignCanvasProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -293,6 +362,7 @@ export function DesignCanvas({
     const bridgeToInject =
       TWEAK_BRIDGE_SCRIPT +
       ZOOM_BRIDGE_SCRIPT +
+      NAV_BRIDGE_SCRIPT +
       (editMode ? EDIT_BRIDGE_SCRIPT : "");
     if (content.includes("</body>")) {
       return content.replace("</body>", bridgeToInject + "</body>");
@@ -323,6 +393,19 @@ export function DesignCanvas({
       }
       if (e.data.type === "element-hover") {
         onElementHover(e.data.payload);
+      }
+      if (e.data.type === "prototype-navigate") {
+        if (e.data.external) {
+          if (e.data.href) {
+            window.open(String(e.data.href), "_blank", "noopener,noreferrer");
+          }
+        } else {
+          onPrototypeNavigate?.(
+            String(e.data.screen || ""),
+            String(e.data.href || ""),
+          );
+        }
+        return;
       }
       if (e.data.type === "pinch-zoom-wheel") {
         if (!onZoomChange) return;
@@ -366,7 +449,13 @@ export function DesignCanvas({
     }
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, [onElementSelect, onElementHover, onZoomChange, deviceFrame]);
+  }, [
+    onElementSelect,
+    onElementHover,
+    onZoomChange,
+    deviceFrame,
+    onPrototypeNavigate,
+  ]);
 
   // Send tweak values to the iframe whenever they change OR the iframe
   // (re)loads. The reload case matters: changing `content` or toggling Edit

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -106,11 +106,21 @@ const NAV_BRIDGE_SCRIPT = `
       ? { external: false, href: ds, screen: ds.replace(/^\\.?\\//, '').split(/[?#]/)[0] }
       : classify(a.getAttribute('href'));
     if (!info) return;
+    if (info.external) {
+      // Open external links in a new tab from the iframe itself (the sandbox
+      // grants allow-popups), bound to this real user click. We deliberately do
+      // NOT round-trip through the parent: a parent window.open() driven by
+      // postMessage would let any script in here spawn popups without a gesture.
+      try {
+        a.setAttribute('target', '_blank');
+        a.setAttribute('rel', 'noopener noreferrer');
+      } catch (err) {}
+      return; // allow the native click to proceed
+    }
     e.preventDefault();
     try {
       window.parent.postMessage({
         type: 'prototype-navigate',
-        external: !!info.external,
         href: info.href,
         screen: info.screen || '',
       }, '*');
@@ -319,7 +329,7 @@ interface DesignCanvasProps {
    * Called when a link inside the prototype points to another screen (a
    * relative href or `data-screen`). Lets the editor switch the active screen
    * instead of letting the iframe navigate to the app. External links are
-   * opened in a new tab here and never reach this callback.
+   * opened in a new tab by the iframe itself and never reach this callback.
    */
   onPrototypeNavigate?: (screen: string, href: string) => void;
 }
@@ -395,16 +405,12 @@ export function DesignCanvas({
         onElementHover(e.data.payload);
       }
       if (e.data.type === "prototype-navigate") {
-        if (e.data.external) {
-          if (e.data.href) {
-            window.open(String(e.data.href), "_blank", "noopener,noreferrer");
-          }
-        } else {
-          onPrototypeNavigate?.(
-            String(e.data.screen || ""),
-            String(e.data.href || ""),
-          );
-        }
+        // External links are opened inside the iframe (sandbox allow-popups);
+        // only internal screen switches reach the parent.
+        onPrototypeNavigate?.(
+          String(e.data.screen || ""),
+          String(e.data.href || ""),
+        );
         return;
       }
       if (e.data.type === "pinch-zoom-wheel") {
@@ -530,7 +536,7 @@ export function DesignCanvas({
       <iframe
         ref={iframeRef}
         srcDoc={srcdoc}
-        sandbox="allow-scripts"
+        sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
         className="border-0 bg-white block w-full h-full"
         title="Design Preview"
       />

--- a/templates/design/app/components/design/DesignEditorSkeleton.tsx
+++ b/templates/design/app/components/design/DesignEditorSkeleton.tsx
@@ -1,0 +1,78 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+/**
+ * Loading placeholder for the design editor. Mirrors the real editor chrome
+ * (toolbar + dot-grid canvas with a faux design frame) so the load reads as
+ * "a design is coming" instead of a bare spinner on a black void.
+ */
+export function DesignEditorSkeleton({
+  embedded = false,
+}: {
+  embedded?: boolean;
+}) {
+  return (
+    <div className="h-full flex flex-col overflow-hidden bg-background">
+      {/* Toolbar */}
+      <header
+        className={cn(
+          "shrink-0 border-b border-border",
+          embedded ? "h-10" : "h-12",
+        )}
+      >
+        <div className="flex h-full items-center gap-2 px-3">
+          <Skeleton className="h-5 w-5 rounded" />
+          <Skeleton className="h-5 w-40 rounded" />
+          <Skeleton className="h-4 w-16 rounded-full" />
+          <div className="ml-auto flex items-center gap-1.5">
+            {!embedded && <Skeleton className="h-7 w-44 rounded-md" />}
+            <Skeleton className="h-7 w-7 rounded-md" />
+            {!embedded && (
+              <>
+                <Skeleton className="h-7 w-16 rounded-md" />
+                <Skeleton className="h-7 w-14 rounded-md" />
+                <Skeleton className="h-7 w-16 rounded-md" />
+              </>
+            )}
+          </div>
+        </div>
+      </header>
+
+      {/* Canvas */}
+      <div className="relative flex-1 overflow-hidden">
+        <div
+          className="absolute inset-0"
+          style={{
+            backgroundImage:
+              "radial-gradient(circle, hsl(var(--border)) 1px, transparent 1px)",
+            backgroundSize: "24px 24px",
+          }}
+        />
+        <div className="relative flex h-full items-center justify-center p-8">
+          <div className="w-full max-w-4xl overflow-hidden rounded-xl border border-border bg-card shadow-2xl">
+            {/* Faux browser bar */}
+            <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+              <Skeleton className="h-2.5 w-2.5 rounded-full" />
+              <Skeleton className="h-2.5 w-2.5 rounded-full" />
+              <Skeleton className="h-2.5 w-2.5 rounded-full" />
+              <Skeleton className="ml-3 h-4 w-48 rounded" />
+            </div>
+            {/* Faux content */}
+            <div className="space-y-6 p-8">
+              <div className="space-y-3">
+                <Skeleton className="h-8 w-2/3 rounded-lg" />
+                <Skeleton className="h-4 w-1/2 rounded" />
+              </div>
+              <div className="grid grid-cols-3 gap-4">
+                <Skeleton className="h-28 rounded-xl" />
+                <Skeleton className="h-28 rounded-xl" />
+                <Skeleton className="h-28 rounded-xl" />
+              </div>
+              <Skeleton className="h-40 w-full rounded-xl" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -15,14 +15,15 @@ import {
   IconPlus,
   IconLayoutGrid,
   IconX,
-  IconPencilPlus,
   IconPin,
-  IconDownload,
   IconCode,
   IconArchive,
   IconPhoto,
   IconRefresh,
   IconMenu2,
+  IconChevronDown,
+  IconCheck,
+  IconDots,
 } from "@tabler/icons-react";
 import {
   useActionQuery,
@@ -52,9 +53,14 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { DesignCanvas } from "@/components/design/DesignCanvas";
+import { DesignEditorSkeleton } from "@/components/design/DesignEditorSkeleton";
 import { EditPanel } from "@/components/design/EditPanel";
 import { MultiScreenCanvas } from "@/components/design/MultiScreenCanvas";
 import { QuestionFlow } from "@/components/design/QuestionFlow";
@@ -1031,18 +1037,6 @@ export default function DesignEditor() {
     });
   }, [viewMode]);
 
-  const handleDrawToolToggle = useCallback(() => {
-    if (!activeFile || viewMode === "overview") return;
-    if (drawMode) {
-      setDrawMode(false);
-      setMode("comment");
-      return;
-    }
-    setMode("draw");
-    setDrawMode(true);
-    setPinMode(false);
-  }, [activeFile, drawMode, viewMode]);
-
   const handlePinToolToggle = useCallback(() => {
     if (!activeFile || viewMode === "overview") return;
     if (pinMode) {
@@ -1403,11 +1397,6 @@ ${serializedHtml}
     }
   }, [design?.title, fallbackExportName, triggerBlobDownload]);
 
-  const exportPending =
-    exportHtmlMutation.isPending ||
-    exportZipMutation.isPending ||
-    createCodingHandoffMutation.isPending ||
-    svgExporting;
   const zoomLabel = `${Math.round(zoom)}%`;
 
   if (!id) {
@@ -1416,11 +1405,7 @@ ${serializedHtml}
   }
 
   if (designLoading || (!design && pendingGenerationActive)) {
-    return (
-      <div className="flex-1 bg-background flex items-center justify-center">
-        <Spinner className="size-8 text-foreground/30" />
-      </div>
-    );
+    return <DesignEditorSkeleton embedded={embedded} />;
   }
 
   if (!design) {
@@ -1570,108 +1555,110 @@ ${serializedHtml}
 
             {!embedded && (
               <>
-                <div className="w-px h-5 bg-accent mx-1" />
-
-                {/* Device frame — only meaningful in single-screen mode. */}
-                <div className="flex items-center gap-0.5">
+                {/* Device preview — collapsed into a single menu. */}
+                <DropdownMenu>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <Button
-                        variant={deviceFrame === "none" ? "secondary" : "ghost"}
-                        size="icon"
-                        className="h-7 w-7 cursor-pointer"
-                        onClick={() => setDeviceFrame("none")}
-                        disabled={viewMode === "overview"}
-                      >
-                        <IconDeviceDesktopOff className="w-3.5 h-3.5" />
-                      </Button>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 gap-1 px-2 cursor-pointer"
+                          disabled={viewMode === "overview"}
+                        >
+                          {deviceFrame === "desktop" ? (
+                            <IconDeviceDesktop className="w-3.5 h-3.5" />
+                          ) : deviceFrame === "tablet" ? (
+                            <IconDeviceTablet className="w-3.5 h-3.5" />
+                          ) : deviceFrame === "mobile" ? (
+                            <IconDeviceMobile className="w-3.5 h-3.5" />
+                          ) : (
+                            <IconDeviceDesktopOff className="w-3.5 h-3.5" />
+                          )}
+                          <IconChevronDown className="w-3 h-3 opacity-60" />
+                        </Button>
+                      </DropdownMenuTrigger>
                     </TooltipTrigger>
-                    <TooltipContent>No frame</TooltipContent>
+                    <TooltipContent>Device preview</TooltipContent>
                   </Tooltip>
+                  <DropdownMenuContent align="end" className="w-44">
+                    <DropdownMenuRadioGroup
+                      value={deviceFrame}
+                      onValueChange={(v) =>
+                        setDeviceFrame(v as DeviceFrameType)
+                      }
+                    >
+                      <DropdownMenuRadioItem value="none">
+                        <IconDeviceDesktopOff className="mr-2 h-4 w-4" />
+                        Responsive
+                      </DropdownMenuRadioItem>
+                      <DropdownMenuRadioItem value="desktop">
+                        <IconDeviceDesktop className="mr-2 h-4 w-4" />
+                        Desktop
+                      </DropdownMenuRadioItem>
+                      <DropdownMenuRadioItem value="tablet">
+                        <IconDeviceTablet className="mr-2 h-4 w-4" />
+                        Tablet
+                      </DropdownMenuRadioItem>
+                      <DropdownMenuRadioItem value="mobile">
+                        <IconDeviceMobile className="mr-2 h-4 w-4" />
+                        Mobile
+                      </DropdownMenuRadioItem>
+                    </DropdownMenuRadioGroup>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+
+                {/* Zoom — collapsed into a single menu. */}
+                <DropdownMenu>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <Button
-                        variant={
-                          deviceFrame === "desktop" ? "secondary" : "ghost"
-                        }
-                        size="icon"
-                        className="h-7 w-7 cursor-pointer"
-                        onClick={() => setDeviceFrame("desktop")}
-                        disabled={viewMode === "overview"}
-                      >
-                        <IconDeviceDesktop className="w-3.5 h-3.5" />
-                      </Button>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 gap-1 px-2 text-xs tabular-nums text-muted-foreground cursor-pointer"
+                        >
+                          {zoomLabel}
+                          <IconChevronDown className="w-3 h-3 opacity-60" />
+                        </Button>
+                      </DropdownMenuTrigger>
                     </TooltipTrigger>
-                    <TooltipContent>Desktop</TooltipContent>
+                    <TooltipContent>Zoom</TooltipContent>
                   </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant={
-                          deviceFrame === "tablet" ? "secondary" : "ghost"
-                        }
-                        size="icon"
-                        className="h-7 w-7 cursor-pointer"
-                        onClick={() => setDeviceFrame("tablet")}
-                        disabled={viewMode === "overview"}
+                  <DropdownMenuContent align="end" className="w-40">
+                    <DropdownMenuItem onClick={handleZoomOut}>
+                      <IconZoomOut className="mr-2 h-4 w-4" />
+                      Zoom out
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleZoomIn}>
+                      <IconZoomIn className="mr-2 h-4 w-4" />
+                      Zoom in
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    {ZOOM_PRESETS.map((preset) => (
+                      <DropdownMenuItem
+                        key={preset}
+                        onClick={() => setZoom(preset)}
+                        className="justify-between"
                       >
-                        <IconDeviceTablet className="w-3.5 h-3.5" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>Tablet</TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant={
-                          deviceFrame === "mobile" ? "secondary" : "ghost"
-                        }
-                        size="icon"
-                        className="h-7 w-7 cursor-pointer"
-                        onClick={() => setDeviceFrame("mobile")}
-                        disabled={viewMode === "overview"}
-                      >
-                        <IconDeviceMobile className="w-3.5 h-3.5" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>Mobile</TooltipContent>
-                  </Tooltip>
-                </div>
+                        <span>{preset}%</span>
+                        {Math.round(zoom) === preset && (
+                          <IconCheck className="h-4 w-4" />
+                        )}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
 
-                <div className="w-px h-5 bg-accent mx-1" />
-
-                {/* Zoom */}
-                <div className="flex items-center gap-0.5">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 cursor-pointer"
-                    onClick={handleZoomOut}
-                  >
-                    <IconZoomOut className="w-3.5 h-3.5" />
-                  </Button>
-                  <span className="w-10 text-center text-xs tabular-nums text-muted-foreground">
-                    {zoomLabel}
-                  </span>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 cursor-pointer"
-                    onClick={handleZoomIn}
-                  >
-                    <IconZoomIn className="w-3.5 h-3.5" />
-                  </Button>
-                </div>
-
-                <div className="w-px h-5 bg-accent mx-1" />
+                <div className="mx-1 h-5 w-px bg-border" />
               </>
             )}
 
-            {/* Actions */}
+            {/* Tweaks */}
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
-                  variant="ghost"
+                  variant={tweaksVisible ? "secondary" : "ghost"}
                   size="icon"
                   className="h-7 w-7 cursor-pointer"
                   onClick={() => setTweaksVisible(!tweaksVisible)}
@@ -1681,56 +1668,6 @@ ${serializedHtml}
               </TooltipTrigger>
               <TooltipContent>Tweaks</TooltipContent>
             </Tooltip>
-
-            {!embedded && (
-              <>
-                {/* Draw on canvas — overlays the iframe with pencil + text. */}
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant={drawMode ? "secondary" : "ghost"}
-                      size="icon"
-                      className="h-7 w-7 cursor-pointer"
-                      data-toolbar-draw-button
-                      onClick={handleDrawToolToggle}
-                      disabled={!activeFile || viewMode === "overview"}
-                    >
-                      <IconPencilPlus className="w-3.5 h-3.5" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {viewMode === "overview"
-                      ? "Open a single screen to draw"
-                      : drawMode
-                        ? "Exit draw mode"
-                        : "Draw on current screen"}
-                  </TooltipContent>
-                </Tooltip>
-
-                {/* Drop comment pin — overlays the iframe with click-to-comment. */}
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant={pinMode ? "secondary" : "ghost"}
-                      size="icon"
-                      className="h-7 w-7 cursor-pointer"
-                      data-toolbar-pin-button
-                      onClick={handlePinToolToggle}
-                      disabled={!activeFile || viewMode === "overview"}
-                    >
-                      <IconPin className="w-3.5 h-3.5" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {viewMode === "overview"
-                      ? "Open a single screen to comment"
-                      : pinMode
-                        ? "Exit comment pin mode"
-                        : "Drop comment pin"}
-                  </TooltipContent>
-                </Tooltip>
-              </>
-            )}
 
             {/* Save state — currently the design template doesn't expose a
               dedicated "save in flight" signal (file edits go through Yjs +
@@ -1746,6 +1683,7 @@ ${serializedHtml}
               />
             )}
 
+            {/* More: comment pin + export (progressive disclosure). */}
             {!embedded && (
               <DropdownMenu>
                 <Tooltip>
@@ -1754,16 +1692,29 @@ ${serializedHtml}
                       <Button
                         variant="ghost"
                         size="icon"
-                        className="h-7 w-7 cursor-pointer"
-                        disabled={!activeFile || exportPending}
+                        className="relative h-7 w-7 cursor-pointer"
                       >
-                        <IconDownload className="w-3.5 h-3.5" />
+                        <IconDots className="w-3.5 h-3.5" />
+                        {pinMode && (
+                          <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-[#609FF8]" />
+                        )}
                       </Button>
                     </DropdownMenuTrigger>
                   </TooltipTrigger>
-                  <TooltipContent>Export</TooltipContent>
+                  <TooltipContent>More</TooltipContent>
                 </Tooltip>
                 <DropdownMenuContent align="end" className="w-56">
+                  <DropdownMenuItem
+                    onClick={handlePinToolToggle}
+                    disabled={!activeFile || viewMode === "overview"}
+                  >
+                    <IconPin className="mr-2 h-4 w-4" />
+                    {pinMode ? "Exit comment pin" : "Drop comment pin"}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+                    Export
+                  </DropdownMenuLabel>
                   <DropdownMenuItem
                     onClick={handleDownloadHtml}
                     disabled={!activeFile || exportHtmlMutation.isPending}
@@ -1954,6 +1905,23 @@ ${serializedHtml}
                 onExitPinMode={() => setPinMode(false)}
                 designId={id}
                 designTitle={design?.title}
+                onPrototypeNavigate={(screen) => {
+                  if (!screen) return;
+                  const norm = (s: string) =>
+                    s
+                      .replace(/^\.?\//, "")
+                      .replace(/\.html?$/i, "")
+                      .toLowerCase();
+                  const target = norm(screen);
+                  if (!target) return;
+                  const match =
+                    files.find((f) => norm(f.filename) === target) ??
+                    files.find((f) => norm(f.filename).includes(target));
+                  if (match) {
+                    setViewMode("single");
+                    setActiveFileId(match.id);
+                  }
+                }}
               />
             )
           ) : (

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -1914,9 +1914,9 @@ ${serializedHtml}
                       .toLowerCase();
                   const target = norm(screen);
                   if (!target) return;
-                  const match =
-                    files.find((f) => norm(f.filename) === target) ??
-                    files.find((f) => norm(f.filename).includes(target));
+                  // Exact (normalized) filename match only — a substring match
+                  // could send "board" to "dashboard.html".
+                  const match = files.find((f) => norm(f.filename) === target);
                   if (match) {
                     setViewMode("single");
                     setActiveFileId(match.id);

--- a/templates/design/app/pages/Present.tsx
+++ b/templates/design/app/pages/Present.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useNavigate } from "react-router";
 import { useActionQuery } from "@agent-native/core/client";
-import { Spinner } from "@/components/ui/spinner";
+import { Skeleton } from "@/components/ui/skeleton";
 
 interface DesignFile {
   id: string;
@@ -59,8 +59,8 @@ export default function Present() {
 
   if (isLoading) {
     return (
-      <div className="h-screen w-screen bg-black flex items-center justify-center">
-        <Spinner className="size-8 text-white/30" />
+      <div className="h-screen w-screen bg-black flex items-center justify-center p-10">
+        <Skeleton className="h-full w-full max-w-5xl rounded-xl bg-white/5" />
       </div>
     );
   }

--- a/templates/design/shared/apply-edits.spec.ts
+++ b/templates/design/shared/apply-edits.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { applyEdits, applyOneEdit } from "./apply-edits";
+
+describe("applyEdits", () => {
+  it("replaces a unique exact match", () => {
+    const html = `<h1 class="text-4xl">Hello</h1>`;
+    const { content, applied } = applyEdits(html, [
+      { search: `text-4xl">Hello`, replace: `text-5xl">Hello there` },
+    ]);
+    expect(content).toBe(`<h1 class="text-5xl">Hello there</h1>`);
+    expect(applied).toBe(1);
+  });
+
+  it("wraps an element by adding a wrapper in the replacement", () => {
+    const html = `<button>Buy</button>`;
+    const { content } = applyEdits(html, [
+      {
+        search: `<button>Buy</button>`,
+        replace: `<div class="p-4"><button>Buy</button></div>`,
+      },
+    ]);
+    expect(content).toBe(`<div class="p-4"><button>Buy</button></div>`);
+  });
+
+  it("throws on an ambiguous (multi-match) search", () => {
+    const html = `<span>x</span><span>x</span>`;
+    expect(() =>
+      applyEdits(html, [{ search: `<span>x</span>`, replace: `y` }]),
+    ).toThrow(/matched 2 places/);
+  });
+
+  it("throws with guidance when search is not found", () => {
+    expect(() =>
+      applyEdits(`<p>hi</p>`, [{ search: `<p>nope</p>`, replace: `x` }]),
+    ).toThrow(/not found/);
+  });
+
+  it("matches whitespace-flexibly when exact fails", () => {
+    const html = `<div>\n    <span>label</span>\n</div>`;
+    const { content } = applyEdits(html, [
+      {
+        search: `<div> <span>label</span> </div>`,
+        replace: `<div><b>label</b></div>`,
+      },
+    ]);
+    expect(content).toBe(`<div><b>label</b></div>`);
+  });
+
+  it("treats $ in the replacement literally (no regex group expansion)", () => {
+    const html = `<p>price</p>`;
+    const { content } = applyEdits(html, [
+      { search: `price`, replace: `$1,000 & up` },
+    ]);
+    expect(content).toBe(`<p>$1,000 & up</p>`);
+  });
+
+  it("applies edits sequentially", () => {
+    const html = `a b c`;
+    const { content } = applyEdits(html, [
+      { search: `a`, replace: `A` },
+      { search: `c`, replace: `C` },
+    ]);
+    expect(content).toBe(`A b C`);
+  });
+
+  it("rejects an empty search", () => {
+    expect(() => applyOneEdit(`x`, { search: ``, replace: `y` })).toThrow(
+      /non-empty/,
+    );
+  });
+});

--- a/templates/design/shared/apply-edits.spec.ts
+++ b/templates/design/shared/apply-edits.spec.ts
@@ -68,4 +68,10 @@ describe("applyEdits", () => {
       /non-empty/,
     );
   });
+
+  it("treats self-overlapping matches as ambiguous", () => {
+    expect(() => applyEdits(`aaa`, [{ search: `aa`, replace: `b` }])).toThrow(
+      /matched 2 places/,
+    );
+  });
 });

--- a/templates/design/shared/apply-edits.ts
+++ b/templates/design/shared/apply-edits.ts
@@ -1,0 +1,96 @@
+/**
+ * Surgical search/replace engine for design files. Lets the agent make the
+ * smallest possible change to an HTML/CSS document instead of regenerating the
+ * whole file — the "smart diff" path used by the `edit-design` action.
+ *
+ * Two matching strategies, tried in order, both requiring a UNIQUE match so an
+ * edit can never silently hit the wrong place:
+ *   1. exact substring
+ *   2. whitespace-flexible (any run of whitespace in `search` matches any run
+ *      of whitespace in the file) — tolerates re-indentation / reflowed markup
+ *
+ * Pure + dependency-free so it is trivially unit-testable.
+ */
+
+export interface DesignEdit {
+  /** Exact text to find, with enough surrounding context to be unique. */
+  search: string;
+  /** Replacement text. Inserted verbatim — `$`/`$1` are NOT interpreted. */
+  replace: string;
+}
+
+export interface ApplyEditsResult {
+  content: string;
+  applied: number;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  return haystack.split(needle).length - 1;
+}
+
+/**
+ * Apply a single edit. Throws a clear, agent-actionable error when the search
+ * text is missing or ambiguous so the agent can re-read the file and retry.
+ */
+export function applyOneEdit(
+  content: string,
+  edit: DesignEdit,
+  index = 0,
+): string {
+  const { search, replace } = edit;
+  if (typeof search !== "string" || search.length === 0) {
+    throw new Error(`Edit ${index + 1}: "search" must be a non-empty string.`);
+  }
+  if (typeof replace !== "string") {
+    throw new Error(`Edit ${index + 1}: "replace" must be a string.`);
+  }
+
+  // Strategy 1 — exact substring.
+  const exact = countOccurrences(content, search);
+  if (exact === 1) return content.split(search).join(replace);
+  if (exact > 1) {
+    throw new Error(
+      `Edit ${index + 1}: "search" matched ${exact} places — add more surrounding context so it matches exactly one location.`,
+    );
+  }
+
+  // Strategy 2 — whitespace-flexible.
+  const pattern = escapeRegExp(search).replace(/\s+/g, "\\s+");
+  const re = new RegExp(pattern, "g");
+  const matches = content.match(re);
+  const flexible = matches ? matches.length : 0;
+  if (flexible === 1) {
+    // Function replacer so `$&`/`$1` in `replace` are inserted literally.
+    return content.replace(re, () => replace);
+  }
+  if (flexible > 1) {
+    throw new Error(
+      `Edit ${index + 1}: "search" matched ${flexible} places (whitespace-insensitive) — add more surrounding context.`,
+    );
+  }
+
+  throw new Error(
+    `Edit ${index + 1}: "search" text was not found in the file. Read the current file (get-design-snapshot) and copy the exact text you want to change.`,
+  );
+}
+
+/**
+ * Apply edits in order against a single document. Edits are sequential — a
+ * later edit sees the result of earlier ones. Atomic at the call site: the
+ * caller should only persist the returned content (this never mutates input).
+ */
+export function applyEdits(
+  content: string,
+  edits: DesignEdit[],
+): ApplyEditsResult {
+  let next = content;
+  edits.forEach((edit, i) => {
+    next = applyOneEdit(next, edit, i);
+  });
+  return { content: next, applied: edits.length };
+}

--- a/templates/design/shared/apply-edits.ts
+++ b/templates/design/shared/apply-edits.ts
@@ -30,7 +30,15 @@ function escapeRegExp(value: string): string {
 
 function countOccurrences(haystack: string, needle: string): number {
   if (!needle) return 0;
-  return haystack.split(needle).length - 1;
+  // Step by 1 (not by needle length) so self-overlapping matches — e.g. "aa"
+  // inside "aaa" — are both counted and treated as ambiguous, not unique.
+  let count = 0;
+  let idx = haystack.indexOf(needle);
+  while (idx !== -1) {
+    count += 1;
+    idx = haystack.indexOf(needle, idx + 1);
+  }
+  return count;
 }
 
 /**


### PR DESCRIPTION
Improves the **design template** toward Claude Design parity and fixes two reported bugs. Research-driven (deep dive into Claude Design UX, AI design-gen best practices, OSS design editors, Figma MCP/token workflows, and smart-diffing) — the conclusion was that our template already mirrors Claude Design's flow, so this PR closes the highest-leverage gaps rather than rebuilding.

## Bug fixes (both reported with screenshots)
- **Ugly loading screen → skeleton.** The editor showed a bare spinner on a black void. It now renders a proper skeleton (toolbar + dot-grid canvas with a faux design frame). Present mode gets a skeleton too.
- **Prototype links broke the preview.** Clicking a link inside a prototype navigated the `srcdoc` iframe to the app URL ("Design not found"). A new **nav bridge** intercepts clicks: external links open in a new tab, relative links / `data-screen` switch to the matching screen in a multi-screen design, and `#`/Alpine handlers pass through untouched. Generation guidance updated so screens link via Alpine state / `data-screen` / `#`, never real URLs.

## Sleeker toolbar (progressive disclosure)
Was a Word-style mega-row of ~15 controls. Now:
- Device frames (4 buttons) → one **Device** menu
- Zoom (3 controls) → one **Zoom** menu (presets + in/out)
- Comment-pin + all five exports → one **More** menu
- Removed the duplicate Draw button (Draw is already a mode)

## Sharper generation (`design-generation` skill)
- Anti-"AI slop" quality bar; 4-layer prompt model (Context / Structure / Aesthetic / Tech); measurable rules (8px grid, type scale, WCAG, **token grounding**); brand vs product presets.
- Multi-screen navigation rules that match the new nav bridge.
- **Tailwind v4 gotcha**: use `bg-linear-to-*`, not the v3 `bg-gradient-to-*` (silently broken on the v4 CDN); add `prefers-reduced-motion`; stop defaulting to Space Grotesk.

## Smart diffs
- New **`edit-design`** action — surgical search/replace edits to a single file (exact + whitespace-flexible match, unique-match required) so refinements make the smallest possible change instead of regenerating whole files. Pure matcher with 8 unit tests; skill + AGENTS guidance to "read then edit."

## Design systems
- Figma guidance now prefers official MCP/API context first (`get_variable_defs`, `get_design_context`, `get_screenshot`) for real token/style context, with a describe-the-file fallback.

## Testing
- `typecheck`, `build`, full template test suite (29 passing incl. 8 new), Prettier — all green.
- `edit-design` verified end-to-end via CLI (surgical edit applied; ambiguous edit correctly rejected).
- Nav-bridge script validated as parseable JS + link-classification unit-checked.
- App boots locally; full editor visuals (skeleton + toolbar + link nav) are best confirmed on the deploy preview since there's no dev auth bypass.

## Follow-ups (intentionally out of scope)
Figma REST API importer (token secret), `data-eid` + `@alpinejs/morph` live-preview diffing, persistent variant switcher, and a visual version-history timeline.
