### PR TITLE
Fix desktop app login in dev (CORS credentials)

### DIFF
--- a/.changeset/desktop-login-cors-credentials.md
+++ b/.changeset/desktop-login-cors-credentials.md
@@ -1,0 +1,13 @@
+---
+"@agent-native/core": patch
+---
+
+Fix desktop app login failing in dev with a CORS error
+(`Access-Control-Allow-Credentials is not "true"`).
+
+The desktop app logs in with `credentials: "include"`. In dev its origin
+(`http://localhost:1420`) was matched by the embed-frame Vite middleware, which
+answered the CORS preflight with `Access-Control-Allow-Origin` but no
+`Access-Control-Allow-Credentials`. The browser then rejected the credentialed
+login. The middleware now also sends `Access-Control-Allow-Credentials: true`
+for origins allowed to use credentials, matching how production responds.

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -19,6 +19,7 @@ import {
   MCP_EMBED_CORS_ALLOW_HEADERS,
   MCP_EMBED_STATIC_ASSET_HEADERS,
   mcpEmbedStaticAssetRouteRules,
+  shouldAllowMcpEmbedCredentials,
 } from "../shared/mcp-embed-headers.js";
 
 import { fileURLToPath } from "url";
@@ -882,6 +883,15 @@ function embedDevFrameHeaders(): Plugin {
         if (isMcpEmbedCorsOrigin(origin)) {
           res.setHeader("Access-Control-Allow-Origin", origin);
           res.setHeader("Vary", "Origin");
+          // The desktop app's dev origin (http://localhost:1420) also matches
+          // here, and it logs in with `credentials: "include"`. A credentialed
+          // request needs this header or the browser discards the response.
+          // The OPTIONS short-circuit below means we can't rely on the real
+          // auth handler to set it, so set it here too (production already does
+          // the same).
+          if (shouldAllowMcpEmbedCredentials(origin)) {
+            res.setHeader("Access-Control-Allow-Credentials", "true");
+          }
           res.setHeader(
             "Access-Control-Allow-Methods",
             "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS",


### PR DESCRIPTION
Logging in from the desktop app (`templates/clips/desktop`) failed in DEV with:

```
Fetch API cannot load http://localhost:8094/_agent-native/auth/login due to access control checks.
Credentials flag is true, but Access-Control-Allow-Credentials is not "true".
```

## Cause

The desktop app sends its login request with `credentials: "include"`.

In dev, a Vite middleware (`embedDevFrameHeaders`) handles CORS for embed-frame origins. Because the desktop app's dev origin is `http://localhost:1420` — a local `http` origin — it matched that middleware. The middleware answered the preflight with `Access-Control-Allow-Origin` but never `Access-Control-Allow-Credentials`, and short-circuited the `OPTIONS` request before it could reach the real auth handler. A credentialed request without that header is rejected by the browser.

## Fix

The middleware now also sends `Access-Control-Allow-Credentials: true` for origins allowed to use credentials — the same thing production already does. Origins that must not carry credentials (e.g. hosted MCP embed sandboxes) are unaffected.

## Testing

- Logged in from the desktop app in dev — works.
- Verified the preflight to `/_agent-native/auth/login` now returns `Access-Control-Allow-Credentials: true`.
