### PR TITLE
Fix docs data prefetch caching

### DIFF
--- a/.changeset/clean-dispatch-browser-build.md
+++ b/.changeset/clean-dispatch-browser-build.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Keep Dispatch route loaders from pulling server-only framework modules into the browser bundle.

--- a/.changeset/fix-prefetch-cache.md
+++ b/.changeset/fix-prefetch-cache.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep SSR HTML and React Router data responses CDN-cacheable across auth-looking requests, and publish a default no-op Speculation-Rules header to prevent Cloudflare Speed Brain prefetch refusals from surfacing as 503s.

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -14,9 +14,6 @@ import { IMMUTABLE_ASSET_CACHE_CONTROL } from "./immutable-assets.js";
 
 const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
-const DEFAULT_SPECULATION_RULES_HEADER =
-  '"/_agent-native/speculation-rules.json"';
-
 const tempDirs: string[] = [];
 
 function makeTempDir(): string {
@@ -241,7 +238,7 @@ export default (event) =>
       DEFAULT_SSR_CACHE_CONTROL,
     );
     expect(response.headers.get("speculation-rules")).toBe(
-      DEFAULT_SPECULATION_RULES_HEADER,
+      '"/docs/_agent-native/speculation-rules.json"',
     );
 
     const redirect = await worker.fetch(
@@ -253,7 +250,7 @@ export default (event) =>
     expect(redirect.headers.get("location")).toBe("/docs/login");
   });
 
-  it("does not add public SSR cache headers for authenticated Cloudflare worker SSR", async () => {
+  it("adds public SSR cache headers for authenticated Cloudflare worker SSR", async () => {
     const worker = await importGeneratedWorker(generateWorkerEntry([], []));
 
     const response = await worker.fetch(
@@ -265,7 +262,9 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBeNull();
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
   });
 
   it("overwrites explicit no-store cache policies on Cloudflare worker SSR", async () => {
@@ -296,7 +295,7 @@ export default (event) =>
     );
   });
 
-  it("preserves default no-cache headers for authenticated Cloudflare worker data responses", async () => {
+  it("replaces default no-cache headers for authenticated Cloudflare worker data responses", async () => {
     const worker = await importGeneratedWorker(generateWorkerEntry([], []));
 
     const response = await worker.fetch(
@@ -307,10 +306,12 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe("no-cache");
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
   });
 
-  it("preserves explicit private cache policies on authenticated Cloudflare worker data responses", async () => {
+  it("overwrites explicit private cache policies on authenticated Cloudflare worker data responses", async () => {
     const worker = await importGeneratedWorker(generateWorkerEntry([], []));
 
     const response = await worker.fetch(
@@ -321,7 +322,9 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
   });
 
   it("does not replace no-cache on non-React Router Cloudflare worker data responses", async () => {

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -14,6 +14,8 @@ import { IMMUTABLE_ASSET_CACHE_CONTROL } from "./immutable-assets.js";
 
 const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+const DEFAULT_SPECULATION_RULES_HEADER =
+  '"/_agent-native/speculation-rules.json"';
 
 const tempDirs: string[] = [];
 
@@ -238,6 +240,9 @@ export default (event) =>
     expect(response.headers.get("cache-control")).toBe(
       DEFAULT_SSR_CACHE_CONTROL,
     );
+    expect(response.headers.get("speculation-rules")).toBe(
+      DEFAULT_SPECULATION_RULES_HEADER,
+    );
 
     const redirect = await worker.fetch(
       new Request("https://app.test/docs/redirect", { method: "GET" }),
@@ -248,7 +253,7 @@ export default (event) =>
     expect(redirect.headers.get("location")).toBe("/docs/login");
   });
 
-  it("does not add public SSR cache headers for authenticated Cloudflare worker SSR", async () => {
+  it("adds public SSR cache headers for authenticated Cloudflare worker SSR", async () => {
     const worker = await importGeneratedWorker(generateWorkerEntry([], []));
 
     const response = await worker.fetch(
@@ -260,10 +265,12 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBeNull();
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
   });
 
-  it("preserves explicit no-store cache policies on Cloudflare worker SSR", async () => {
+  it("overwrites explicit no-store cache policies on Cloudflare worker SSR", async () => {
     const worker = await importGeneratedWorker(generateWorkerEntry([], []));
 
     const response = await worker.fetch(
@@ -272,7 +279,9 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
   });
 
   it("replaces React Router's default no-cache policy on Cloudflare worker data responses", async () => {
@@ -289,7 +298,7 @@ export default (event) =>
     );
   });
 
-  it("preserves default no-cache headers for authenticated Cloudflare worker data responses", async () => {
+  it("replaces default no-cache headers for authenticated Cloudflare worker data responses", async () => {
     const worker = await importGeneratedWorker(generateWorkerEntry([], []));
 
     const response = await worker.fetch(
@@ -300,10 +309,12 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe("no-cache");
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
   });
 
-  it("preserves explicit private cache policies on Cloudflare worker data responses", async () => {
+  it("overwrites explicit private cache policies on Cloudflare worker data responses", async () => {
     const worker = await importGeneratedWorker(generateWorkerEntry([], []));
 
     const response = await worker.fetch(
@@ -314,7 +325,9 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
   });
 
   it("does not replace no-cache on non-React Router Cloudflare worker data responses", async () => {

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -253,7 +253,7 @@ export default (event) =>
     expect(redirect.headers.get("location")).toBe("/docs/login");
   });
 
-  it("adds public SSR cache headers for authenticated Cloudflare worker SSR", async () => {
+  it("does not add public SSR cache headers for authenticated Cloudflare worker SSR", async () => {
     const worker = await importGeneratedWorker(generateWorkerEntry([], []));
 
     const response = await worker.fetch(
@@ -265,9 +265,7 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expect(response.headers.get("cache-control")).toBeNull();
   });
 
   it("overwrites explicit no-store cache policies on Cloudflare worker SSR", async () => {
@@ -298,7 +296,7 @@ export default (event) =>
     );
   });
 
-  it("replaces default no-cache headers for authenticated Cloudflare worker data responses", async () => {
+  it("preserves default no-cache headers for authenticated Cloudflare worker data responses", async () => {
     const worker = await importGeneratedWorker(generateWorkerEntry([], []));
 
     const response = await worker.fetch(
@@ -309,12 +307,10 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expect(response.headers.get("cache-control")).toBe("no-cache");
   });
 
-  it("overwrites explicit private cache policies on Cloudflare worker data responses", async () => {
+  it("preserves explicit private cache policies on authenticated Cloudflare worker data responses", async () => {
     const worker = await importGeneratedWorker(generateWorkerEntry([], []));
 
     const response = await worker.fetch(
@@ -325,9 +321,7 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
   });
 
   it("does not replace no-cache on non-React Router Cloudflare worker data responses", async () => {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -36,6 +36,10 @@ import { generateActionRegistryForProject } from "../vite/action-types-plugin.js
 import { mcpEmbedStaticAssetRouteRules } from "../shared/mcp-embed-headers.js";
 import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
 import {
+  DEFAULT_SPECULATION_RULES_HEADER,
+  DEFAULT_SSR_CACHE_CONTROL,
+} from "../shared/cache-control.js";
+import {
   collectImmutableAssetPaths,
   IMMUTABLE_ASSET_CACHE_CONTROL,
   IMMUTABLE_ASSET_CACHE_HEADERS,
@@ -44,8 +48,6 @@ import {
 
 const cwd = process.cwd();
 const preset = process.env.NITRO_PRESET || "node";
-const DEFAULT_SSR_CACHE_CONTROL =
-  "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 
 function normalizeConfiguredAppBasePath(): string {
   const raw = process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH;
@@ -396,6 +398,7 @@ function injectHeadScript(html, script) {
 }
 
 const DEFAULT_SSR_CACHE_CONTROL = ${JSON.stringify(DEFAULT_SSR_CACHE_CONTROL)};
+const DEFAULT_SPECULATION_RULES_HEADER = ${JSON.stringify(DEFAULT_SPECULATION_RULES_HEADER)};
 const IMMUTABLE_ASSET_CACHE_CONTROL = ${JSON.stringify(IMMUTABLE_ASSET_CACHE_CONTROL)};
 const IMMUTABLE_ASSET_PATHS = new Set(${JSON.stringify(
     [...new Set(immutableAssetPaths)].sort(),
@@ -463,31 +466,50 @@ function requestHasAuthSignal(request) {
   );
 }
 
-function shouldUseDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal) {
+function shouldUseDefaultSsrCacheHeader(headers, status, pathname) {
   if (status < 200 || status >= 400) return false;
-  if (hasAuthSignal) return false;
 
   const contentType = (headers.get("content-type") || "").toLowerCase();
   if (contentType.includes("text/html")) {
-    return !headers.has("cache-control");
+    // SSR HTML is public app shell in this framework; any per-user state is
+    // fetched after hydration. Always enforce the framework SWR default here;
+    // route-level no-cache/private headers on SSR HTML recreate the same
+    // origin stampede this cache policy is meant to prevent.
+    return true;
   }
 
   if (!pathname.endsWith(".data")) return false;
   if (!contentType.includes("text/x-script")) return false;
 
   // React Router marks loader .data responses no-cache by default. Agent-Native
-  // default. For public loader responses, replace that default with the same
-  // short-fresh/long-SWR policy as HTML so route prefetch warms the CDN. Keep
-  // explicit route cache policies and any authenticated request untouched.
-  const cacheControl = headers.get("cache-control");
-  return !cacheControl || cacheControl.trim().toLowerCase() === "no-cache";
+  // SSR is public app shell, even for browsers carrying auth-looking cookies;
+  // user/org-specific data is loaded client-side through actions/API routes
+  // after hydration. Keep .data on the same SWR policy as HTML so normal route
+  // data fetches fill CDN cache instead of bypassing it and slamming origin.
+  // Also do not preserve route-level private/no-store for React Router .data:
+  // if a route needs per-user data, it belongs behind a client-side action/API
+  // call rather than in the shared SSR payload.
+  return true;
 }
 
-function applyDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal) {
-  if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal)) return;
+function applyDefaultSsrCacheHeader(headers, status, pathname) {
+  if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname)) return;
   headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
 }
 
+function applyDefaultSpeculationRulesHeader(headers, status) {
+  if (status < 200 || status >= 400) return;
+  if (headers.has("speculation-rules")) return;
+
+  const contentType = (headers.get("content-type") || "").toLowerCase();
+  if (!contentType.includes("text/html")) return;
+
+  // Cloudflare Speed Brain injects Speculation-Rules when origin omits this
+  // header. Those browser prefetches carry Sec-Purpose: prefetch and
+  // Cloudflare can return 503 before the request reaches origin. Publish an
+  // explicit no-op ruleset by default; apps can still provide their own header.
+  headers.set("speculation-rules", DEFAULT_SPECULATION_RULES_HEADER);
+}
 function isImmutableAssetRequest(request) {
   const pathname = stripAppBasePath(new URL(request.url).pathname);
   return IMMUTABLE_ASSET_PATHS.has(pathname);
@@ -508,10 +530,11 @@ function applyImmutableAssetCacheHeaders(response, request) {
   });
 }
 
-async function rewriteMountedResponse(response, basePath, pathname, hasAuthSignal) {
+async function rewriteMountedResponse(response, basePath, pathname) {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
-  applyDefaultSsrCacheHeader(headers, response.status, pathname, hasAuthSignal);
+  applyDefaultSsrCacheHeader(headers, response.status, pathname);
+  applyDefaultSpeculationRulesHeader(headers, response.status);
 
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {
@@ -628,7 +651,6 @@ ${actionRegistrations.join("\n")}
       return new Response(null, { status: 404 });
     }
     const request = requestWithPathname(event.req, p);
-    const hasAuthSignal = requestHasAuthSignal(request);
     if (event.req.method === "HEAD") {
       const getRequest = requestWithMethod(request, "GET");
       const response = await rrHandler(getRequest);
@@ -639,11 +661,10 @@ ${actionRegistrations.join("\n")}
           headers: response.headers,
         }),
         basePath,
-        p,
-        hasAuthSignal,
+        p
       );
     }
-    return rewriteMountedResponse(await rrHandler(request), basePath, p, hasAuthSignal);
+    return rewriteMountedResponse(await rrHandler(request), basePath, p);
   }));
 
   _handler = app.fetch.bind(app);

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -36,7 +36,7 @@ import { generateActionRegistryForProject } from "../vite/action-types-plugin.js
 import { mcpEmbedStaticAssetRouteRules } from "../shared/mcp-embed-headers.js";
 import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
 import {
-  DEFAULT_SPECULATION_RULES_HEADER,
+  DEFAULT_SPECULATION_RULES_PATH,
   DEFAULT_SSR_CACHE_CONTROL,
 } from "../shared/cache-control.js";
 import {
@@ -398,13 +398,11 @@ function injectHeadScript(html, script) {
 }
 
 const DEFAULT_SSR_CACHE_CONTROL = ${JSON.stringify(DEFAULT_SSR_CACHE_CONTROL)};
-const DEFAULT_SPECULATION_RULES_HEADER = ${JSON.stringify(DEFAULT_SPECULATION_RULES_HEADER)};
+const DEFAULT_SPECULATION_RULES_PATH = ${JSON.stringify(DEFAULT_SPECULATION_RULES_PATH)};
 const IMMUTABLE_ASSET_CACHE_CONTROL = ${JSON.stringify(IMMUTABLE_ASSET_CACHE_CONTROL)};
 const IMMUTABLE_ASSET_PATHS = new Set(${JSON.stringify(
     [...new Set(immutableAssetPaths)].sort(),
   )});
-const ANONYMOUS_SESSION_COOKIE_NAMES = new Set(["an_docs_session"]);
-const BETTER_AUTH_SESSION_COOKIE_RE = /\\.session_(?:token|data)$/;
 const AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE = ${JSON.stringify(
     AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE,
   )};
@@ -434,47 +432,8 @@ function injectDefaultSocialImageMeta(html) {
   return html.slice(0, headCloseIdx) + tags.join("") + html.slice(headCloseIdx);
 }
 
-function requestHasAuthenticatedCookie(cookieHeader) {
-  if (!cookieHeader) return false;
-  return cookieHeader
-    .split(";")
-    .map((cookie) => (cookie.trim().split("=", 1)[0] || "").trim())
-    .filter(Boolean)
-    .some(isAuthenticatedCookieName);
-}
-
-function isAuthenticatedCookieName(name) {
-  if (ANONYMOUS_SESSION_COOKIE_NAMES.has(name)) return false;
-  const bareName = name.replace(/^__(?:Secure|Host)-/, "");
-  return (
-    bareName === "an_embed_session" ||
-    bareName === "an_session" ||
-    bareName === "an_session_workspace" ||
-    bareName.startsWith("an_session_") ||
-    BETTER_AUTH_SESSION_COOKIE_RE.test(bareName)
-  );
-}
-
-function requestHasAuthSignal(request) {
-  const headers = request.headers;
-  const url = new URL(request.url);
-  return Boolean(
-    headers.get("authorization") ||
-    requestHasAuthenticatedCookie(headers.get("cookie")) ||
-    url.searchParams.has("__an_embed_token") ||
-    url.searchParams.has("_session")
-  );
-}
-
-function shouldUseDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal) {
+function shouldUseDefaultSsrCacheHeader(headers, status, pathname) {
   if (status < 200 || status >= 400) return false;
-  if (hasAuthSignal) {
-    // The generated worker does not have the Node/H3 request-context leak guard
-    // that can tell whether SSR code actually read user/org state. Keep
-    // auth-looking worker requests private until templates move those reads
-    // behind client-side actions/API.
-    return false;
-  }
 
   const contentType = (headers.get("content-type") || "").toLowerCase();
   if (contentType.includes("text/html")) {
@@ -493,21 +452,22 @@ function shouldUseDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal
   // user/org-specific data is loaded client-side through actions/API routes
   // after hydration. Keep .data on the same SWR policy as HTML so normal route
   // data fetches fill CDN cache instead of bypassing it and slamming origin.
-  // Do not re-add a blanket auth-signal bypass here for Node/H3 SSR; that path
-  // uses an auth-context access guard instead. Worker output keeps the
-  // conservative hasAuthSignal guard above because it lacks that instrumentation.
+  // Do not re-add a blanket auth-signal bypass here; logged-in browsers still
+  // need CDN-cached public route data. Worker SSR does not populate
+  // getRequestUserEmail()/accessFilter() context for private loaders, and
+  // Node/H3 has an auth-context access guard for older loaders that still do.
   // Also do not preserve route-level private/no-store for React Router .data:
   // if a route needs per-user data, it belongs behind a client-side action/API
   // call rather than in the shared SSR payload.
   return true;
 }
 
-function applyDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal) {
-  if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal)) return;
+function applyDefaultSsrCacheHeader(headers, status, pathname) {
+  if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname)) return;
   headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
 }
 
-function applyDefaultSpeculationRulesHeader(headers, status) {
+function applyDefaultSpeculationRulesHeader(headers, status, basePath) {
   if (status < 200 || status >= 400) return;
   if (headers.has("speculation-rules")) return;
 
@@ -518,7 +478,7 @@ function applyDefaultSpeculationRulesHeader(headers, status) {
   // header. Those browser prefetches carry Sec-Purpose: prefetch and
   // Cloudflare can return 503 before the request reaches origin. Publish an
   // explicit no-op ruleset by default; apps can still provide their own header.
-  headers.set("speculation-rules", DEFAULT_SPECULATION_RULES_HEADER);
+  headers.set("speculation-rules", '"' + prefixMountedPath(DEFAULT_SPECULATION_RULES_PATH, basePath) + '"');
 }
 function isImmutableAssetRequest(request) {
   const pathname = stripAppBasePath(new URL(request.url).pathname);
@@ -540,11 +500,11 @@ function applyImmutableAssetCacheHeaders(response, request) {
   });
 }
 
-async function rewriteMountedResponse(response, basePath, pathname, hasAuthSignal) {
+async function rewriteMountedResponse(response, basePath, pathname) {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
-  applyDefaultSsrCacheHeader(headers, response.status, pathname, hasAuthSignal);
-  applyDefaultSpeculationRulesHeader(headers, response.status);
+  applyDefaultSsrCacheHeader(headers, response.status, pathname);
+  applyDefaultSpeculationRulesHeader(headers, response.status, basePath);
 
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {
@@ -661,7 +621,6 @@ ${actionRegistrations.join("\n")}
       return new Response(null, { status: 404 });
     }
     const request = requestWithPathname(event.req, p);
-    const hasAuthSignal = requestHasAuthSignal(request);
     if (event.req.method === "HEAD") {
       const getRequest = requestWithMethod(request, "GET");
       const response = await rrHandler(getRequest);
@@ -672,11 +631,10 @@ ${actionRegistrations.join("\n")}
           headers: response.headers,
         }),
         basePath,
-        p,
-        hasAuthSignal
+        p
       );
     }
-    return rewriteMountedResponse(await rrHandler(request), basePath, p, hasAuthSignal);
+    return rewriteMountedResponse(await rrHandler(request), basePath, p);
   }));
 
   _handler = app.fetch.bind(app);

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -466,8 +466,15 @@ function requestHasAuthSignal(request) {
   );
 }
 
-function shouldUseDefaultSsrCacheHeader(headers, status, pathname) {
+function shouldUseDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal) {
   if (status < 200 || status >= 400) return false;
+  if (hasAuthSignal) {
+    // The generated worker does not have the Node/H3 request-context leak guard
+    // that can tell whether SSR code actually read user/org state. Keep
+    // auth-looking worker requests private until templates move those reads
+    // behind client-side actions/API.
+    return false;
+  }
 
   const contentType = (headers.get("content-type") || "").toLowerCase();
   if (contentType.includes("text/html")) {
@@ -486,14 +493,17 @@ function shouldUseDefaultSsrCacheHeader(headers, status, pathname) {
   // user/org-specific data is loaded client-side through actions/API routes
   // after hydration. Keep .data on the same SWR policy as HTML so normal route
   // data fetches fill CDN cache instead of bypassing it and slamming origin.
+  // Do not re-add a blanket auth-signal bypass here for Node/H3 SSR; that path
+  // uses an auth-context access guard instead. Worker output keeps the
+  // conservative hasAuthSignal guard above because it lacks that instrumentation.
   // Also do not preserve route-level private/no-store for React Router .data:
   // if a route needs per-user data, it belongs behind a client-side action/API
   // call rather than in the shared SSR payload.
   return true;
 }
 
-function applyDefaultSsrCacheHeader(headers, status, pathname) {
-  if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname)) return;
+function applyDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal) {
+  if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal)) return;
   headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
 }
 
@@ -530,10 +540,10 @@ function applyImmutableAssetCacheHeaders(response, request) {
   });
 }
 
-async function rewriteMountedResponse(response, basePath, pathname) {
+async function rewriteMountedResponse(response, basePath, pathname, hasAuthSignal) {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
-  applyDefaultSsrCacheHeader(headers, response.status, pathname);
+  applyDefaultSsrCacheHeader(headers, response.status, pathname, hasAuthSignal);
   applyDefaultSpeculationRulesHeader(headers, response.status);
 
   const location = headers.get("location");
@@ -651,6 +661,7 @@ ${actionRegistrations.join("\n")}
       return new Response(null, { status: 404 });
     }
     const request = requestWithPathname(event.req, p);
+    const hasAuthSignal = requestHasAuthSignal(request);
     if (event.req.method === "HEAD") {
       const getRequest = requestWithMethod(request, "GET");
       const response = await rrHandler(getRequest);
@@ -661,10 +672,11 @@ ${actionRegistrations.join("\n")}
           headers: response.headers,
         }),
         basePath,
-        p
+        p,
+        hasAuthSignal
       );
     }
-    return rewriteMountedResponse(await rrHandler(request), basePath, p);
+    return rewriteMountedResponse(await rrHandler(request), basePath, p, hasAuthSignal);
   }));
 
   _handler = app.fetch.bind(app);

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -135,6 +135,10 @@ import { isEnvVarWriteAllowed } from "./env-var-writes.js";
 import { llmConnectionTrackingProperties } from "../shared/llm-connection.js";
 import { mountBrowserSessionRoutes } from "../browser-sessions/routes.js";
 import { mountDbAdminRoutes } from "../db-admin/routes.js";
+import {
+  DEFAULT_SSR_CACHE_CONTROL,
+  EMPTY_SPECULATION_RULES,
+} from "../shared/cache-control.js";
 
 /**
  * The base path prefix for all framework-level routes.
@@ -756,6 +760,23 @@ export function createCoreRoutesPlugin(
           })),
         );
       }
+
+      getH3App(nitroApp).use(
+        `${P}/speculation-rules.json`,
+        defineEventHandler((event) => {
+          // `createH3SSRHandler` points the Speculation-Rules response header
+          // here to prevent Cloudflare Speed Brain from injecting its own
+          // edge prefetch rules. Keep this route public and side-effect free:
+          // browsers may request it while parsing any SSR HTML document.
+          setResponseHeader(
+            event,
+            "content-type",
+            "application/speculationrules+json; charset=utf-8",
+          );
+          setResponseHeader(event, "cache-control", DEFAULT_SSR_CACHE_CONTROL);
+          return EMPTY_SPECULATION_RULES;
+        }),
+      );
 
       mountBrowserSessionRoutes(nitroApp, { routePrefix: P });
 

--- a/packages/core/src/server/request-context.spec.ts
+++ b/packages/core/src/server/request-context.spec.ts
@@ -6,6 +6,7 @@ import {
   getRequestTimezone,
   getRequestContext,
   hasRequestContext,
+  hasAuthContextAccess,
 } from "./request-context.js";
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -148,6 +149,20 @@ describe("server/request-context", () => {
         expect(hasRequestContext()).toBe(true);
         expect(getRequestContext()).toEqual({});
         expect(getRequestUserEmail()).toBeUndefined();
+      });
+    });
+
+    it("marks contexts when authenticated request identity is read", () => {
+      runWithRequestContext({ userEmail: "alice@example.com" }, () => {
+        const ctx = getRequestContext();
+        expect(hasAuthContextAccess(ctx)).toBe(true);
+      });
+    });
+
+    it("does not mark anonymous contexts as auth-accessed", () => {
+      runWithRequestContext({}, () => {
+        expect(getRequestUserEmail()).toBeUndefined();
+        expect(hasAuthContextAccess(getRequestContext())).toBe(false);
       });
     });
 

--- a/packages/core/src/server/request-context.ts
+++ b/packages/core/src/server/request-context.ts
@@ -63,6 +63,13 @@ export interface RequestContext {
   orgId?: string;
   timezone?: string;
   /**
+   * Set when SSR code reads authenticated request context. The SSR cache layer
+   * uses this as a last-resort leak guard: public shell/data should not read
+   * user/org state during render, but older templates still do. Routes that
+   * need CDN caching should move those reads behind client-side actions/API.
+   */
+  authContextAccessed?: boolean;
+  /**
    * Origin of the inbound request (e.g. `http://127.0.0.1:8100`). Set by the
    * MCP mount from the request headers so actions that build externally
    * fetchable URLs (e.g. design `export-coding-handoff`'s signed raw-code URL)
@@ -167,7 +174,9 @@ export function runWithRequestContext<T>(
  * process-wide CLI fallbacks such as `AGENT_USER_EMAIL` or "latest session".
  */
 export function getRequestContext(): RequestContext | undefined {
-  return als.getStore();
+  const store = als.getStore();
+  markAuthContextAccess(store);
+  return store;
 }
 
 /**
@@ -191,7 +200,10 @@ export function hasRequestContext(): boolean {
  */
 export function getRequestUserEmail(): string | undefined {
   const store = als.getStore();
-  if (store !== undefined) return store.userEmail;
+  if (store !== undefined) {
+    if (store.userEmail) markAuthContextAccess(store);
+    return store.userEmail;
+  }
   return process.env.AGENT_USER_EMAIL;
 }
 
@@ -204,7 +216,10 @@ export function getRequestUserEmail(): string | undefined {
  */
 export function getRequestUserName(): string | undefined {
   const store = als.getStore();
-  if (store !== undefined) return store.userName;
+  if (store !== undefined) {
+    if (store.userName) markAuthContextAccess(store);
+    return store.userName;
+  }
   return process.env.AGENT_USER_NAME;
 }
 
@@ -217,8 +232,22 @@ export function getRequestUserName(): string | undefined {
  */
 export function getRequestOrgId(): string | undefined {
   const store = als.getStore();
-  if (store !== undefined) return store.orgId;
+  if (store !== undefined) {
+    if (store.orgId) markAuthContextAccess(store);
+    return store.orgId;
+  }
   return process.env.AGENT_ORG_ID;
+}
+
+function markAuthContextAccess(ctx: RequestContext | undefined) {
+  if (!ctx) return;
+  if (ctx.userEmail || ctx.userName || ctx.orgId) {
+    ctx.authContextAccessed = true;
+  }
+}
+
+export function hasAuthContextAccess(ctx: RequestContext | undefined): boolean {
+  return Boolean(ctx?.authContextAccessed);
 }
 
 /**

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createH3SSRHandler,
+  DEFAULT_SPECULATION_RULES_HEADER,
   DEFAULT_SSR_CACHE_CONTROL,
 } from "./ssr-handler.js";
 import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
@@ -120,9 +121,12 @@ describe("createH3SSRHandler", () => {
     expect(response.headers.get("cache-control")).toBe(
       DEFAULT_SSR_CACHE_CONTROL,
     );
+    expect(response.headers.get("speculation-rules")).toBe(
+      DEFAULT_SPECULATION_RULES_HEADER,
+    );
   });
 
-  it("preserves explicit no-store cache policies on SSR HTML responses", async () => {
+  it("overwrites explicit no-store cache policies on SSR HTML responses", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response("<html><head></head><body>ok</body></html>", {
         headers: {
@@ -135,7 +139,9 @@ describe("createH3SSRHandler", () => {
 
     const response = await handler(createEvent("/private-html"));
 
-    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
   });
 
   it("replaces React Router's default no-cache policy on .data responses", async () => {
@@ -157,7 +163,7 @@ describe("createH3SSRHandler", () => {
     );
   });
 
-  it("preserves React Router's default no-cache policy on authenticated .data responses", async () => {
+  it("replaces React Router's default no-cache policy on authenticated .data responses", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response('[{"_1":2},"routes/account"]', {
         headers: {
@@ -175,10 +181,12 @@ describe("createH3SSRHandler", () => {
       }),
     );
 
-    expect(response.headers.get("cache-control")).toBe("no-cache");
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
   });
 
-  it("preserves explicit private cache policies on React Router .data responses", async () => {
+  it("overwrites explicit private cache policies on React Router .data responses", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response('[{"_1":2},"routes/private"]', {
         headers: {
@@ -196,7 +204,9 @@ describe("createH3SSRHandler", () => {
       }),
     );
 
-    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
   });
 
   it("does not replace no-cache on non-React Router .data responses", async () => {
@@ -261,7 +271,7 @@ describe("createH3SSRHandler", () => {
     );
   });
 
-  it("does not add public SSR caching when a page request carries a framework session cookie", async () => {
+  it("adds public SSR caching when a page request carries a framework session cookie", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response("<html><head></head><body>ok</body></html>", {
         headers: { "content-type": "text/html; charset=utf-8" },
@@ -275,7 +285,9 @@ describe("createH3SSRHandler", () => {
       }),
     );
 
-    expect(response.headers.get("cache-control")).toBeNull();
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
   });
 
   it("keeps public SSR caching for docs anonymous session cookies", async () => {
@@ -318,7 +330,7 @@ describe("createH3SSRHandler", () => {
     expect(mocks.getSession).not.toHaveBeenCalled();
   });
 
-  it("does not add public SSR caching when anonymous and authenticated cookies coexist", async () => {
+  it("adds public SSR caching when anonymous and authenticated cookies coexist", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response("<html><head></head><body>ok</body></html>", {
         headers: { "content-type": "text/html; charset=utf-8" },
@@ -332,11 +344,13 @@ describe("createH3SSRHandler", () => {
       }),
     );
 
-    expect(response.headers.get("cache-control")).toBeNull();
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
     expect(mocks.getSession).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves explicit SSR cache policies from routes", async () => {
+  it("overwrites explicit SSR cache policies from routes", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response("<html><head></head><body>ok</body></html>", {
         headers: {
@@ -349,7 +363,9 @@ describe("createH3SSRHandler", () => {
 
     const response = await handler(createEvent("/"));
 
-    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("cache-control")).toBe(
+      DEFAULT_SSR_CACHE_CONTROL,
+    );
   });
 
   it("does not resolve auth for anonymous SSR page requests", async () => {

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_SSR_CACHE_CONTROL,
 } from "./ssr-handler.js";
 import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
+import { getRequestUserEmail } from "./request-context.js";
 
 const mocks = vi.hoisted(() => {
   const requestHandler = vi.fn(async (request: Request) => {
@@ -288,6 +289,50 @@ describe("createH3SSRHandler", () => {
     expect(response.headers.get("cache-control")).toBe(
       DEFAULT_SSR_CACHE_CONTROL,
     );
+  });
+
+  it("withholds public SSR caching when authenticated HTML reads user context", async () => {
+    mocks.getSession.mockResolvedValueOnce({ email: "alice@example.com" });
+    mocks.requestHandler.mockImplementationOnce(async () => {
+      const email = getRequestUserEmail();
+      return new Response(`<html><head></head><body>${email}</body></html>`, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    });
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(
+      createEvent("/app/private", "GET", {
+        headers: { cookie: "an_session=active" },
+      }),
+    );
+
+    expect(await response.text()).toContain("alice@example.com");
+    expect(response.headers.get("cache-control")).toBeNull();
+  });
+
+  it("withholds public .data caching when authenticated loader reads user context", async () => {
+    mocks.getSession.mockResolvedValueOnce({ email: "alice@example.com" });
+    mocks.requestHandler.mockImplementationOnce(async () => {
+      const email = getRequestUserEmail();
+      return new Response(`[{"email":${JSON.stringify(email)}}]`, {
+        headers: {
+          "cache-control": "no-cache",
+          "content-type": "text/x-script",
+          "x-remix-response": "yes",
+        },
+      });
+    });
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(
+      createEvent("/app/private.data", "GET", {
+        headers: { cookie: "an_session=active" },
+      }),
+    );
+
+    expect(await response.text()).toContain("alice@example.com");
+    expect(response.headers.get("cache-control")).toBe("no-cache");
   });
 
   it("keeps public SSR caching for docs anonymous session cookies", async () => {

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -127,6 +127,22 @@ describe("createH3SSRHandler", () => {
     );
   });
 
+  it("prefixes the default Speculation-Rules header under APP_BASE_PATH", async () => {
+    process.env.APP_BASE_PATH = "/docs";
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response("<html><head></head><body>ok</body></html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(createEvent("/docs"));
+
+    expect(response.headers.get("speculation-rules")).toBe(
+      '"/docs/_agent-native/speculation-rules.json"',
+    );
+  });
+
   it("overwrites explicit no-store cache policies on SSR HTML responses", async () => {
     mocks.requestHandler.mockResolvedValueOnce(
       new Response("<html><head></head><body>ok</body></html>", {

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -31,7 +31,7 @@ import {
 } from "../shared/embed-auth.js";
 import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
 import {
-  DEFAULT_SPECULATION_RULES_HEADER,
+  DEFAULT_SPECULATION_RULES_PATH,
   DEFAULT_SSR_CACHE_CONTROL,
 } from "../shared/cache-control.js";
 
@@ -284,7 +284,11 @@ function applyDefaultSsrCacheHeader(
   headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
 }
 
-function applyDefaultSpeculationRulesHeader(headers: Headers, status: number) {
+function applyDefaultSpeculationRulesHeader(
+  headers: Headers,
+  status: number,
+  basePath: string,
+) {
   if (status < 200 || status >= 400) return;
   if (headers.has("speculation-rules")) return;
 
@@ -298,7 +302,8 @@ function applyDefaultSpeculationRulesHeader(headers: Headers, status: number) {
   // by default so Cloudflare does not inject its edge prefetch rules. Preserve
   // an app-provided Speculation-Rules header above if a template deliberately
   // owns this behavior.
-  headers.set("speculation-rules", DEFAULT_SPECULATION_RULES_HEADER);
+  const rulesPath = prefixMountedPath(DEFAULT_SPECULATION_RULES_PATH, basePath);
+  headers.set("speculation-rules", `"${rulesPath}"`);
 }
 
 function isFrameworkOrAssetPath(pathname: string): boolean {
@@ -333,7 +338,7 @@ async function rewriteMountedResponse(
     pathname,
     hasAuthContextAccess(requestContext),
   );
-  applyDefaultSpeculationRulesHeader(headers, response.status);
+  applyDefaultSpeculationRulesHeader(headers, response.status, basePath);
 
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -19,7 +19,11 @@ import { createRequestHandler } from "react-router";
 import { defineEventHandler, type H3Event } from "h3";
 import { getSentryClientConfigScript } from "./sentry-config.js";
 import { BETTER_AUTH_COOKIE_PREFIX, COOKIE_NAME, getSession } from "./auth.js";
-import { runWithRequestContext } from "./request-context.js";
+import {
+  hasAuthContextAccess,
+  runWithRequestContext,
+  type RequestContext,
+} from "./request-context.js";
 import { requestHasEmbedAuthMarker } from "./embed-session.js";
 import {
   EMBED_SESSION_COOKIE,
@@ -223,8 +227,17 @@ function shouldUseDefaultSsrCacheHeader(
   headers: Headers,
   status: number,
   pathname: string,
+  authContextAccessed: boolean,
 ): boolean {
   if (status < 200 || status >= 400) return false;
+  if (authContextAccessed) {
+    // Do not bypass cache just because a browser carries an auth-looking
+    // cookie: public docs/pages can receive stale workspace cookies and should
+    // still warm the CDN. But if SSR code actually reads user/org context,
+    // that route is rendering private data and must not be public-cached.
+    // Move those reads to client-side actions/API to regain CDN caching.
+    return false;
+  }
 
   const contentType = headers.get("content-type")?.toLowerCase() ?? "";
   if (contentType.includes("text/html")) {
@@ -243,8 +256,9 @@ function shouldUseDefaultSsrCacheHeader(
   // user/org-specific reads happen after hydration through actions and API
   // routes. Keep `.data` on the same short-fresh/long-SWR policy as HTML so
   // route data fetches warm the CDN instead of hammering origin.
-  // Do not re-add a cookie/auth-signal bypass here without changing that
-  // architecture; logged-in browsers still need CDN-cached public route data.
+  // Do not re-add a blanket cookie/auth-signal bypass here: logged-in browsers
+  // still need CDN-cached public route data. The auth-context leak guard above
+  // is the narrow protection for old SSR loaders that still read user/org data.
   // Also do not preserve route-level private/no-store for React Router .data:
   // if a route needs per-user data, it belongs behind a client-side action/API
   // call rather than in the shared SSR payload.
@@ -255,8 +269,16 @@ function applyDefaultSsrCacheHeader(
   headers: Headers,
   status: number,
   pathname: string,
+  authContextAccessed: boolean,
 ) {
-  if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname)) {
+  if (
+    !shouldUseDefaultSsrCacheHeader(
+      headers,
+      status,
+      pathname,
+      authContextAccessed,
+    )
+  ) {
     return;
   }
   headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
@@ -301,10 +323,16 @@ async function rewriteMountedResponse(
   response: Response,
   basePath: string,
   pathname: string,
+  requestContext?: RequestContext,
 ): Promise<Response> {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
-  applyDefaultSsrCacheHeader(headers, response.status, pathname);
+  applyDefaultSsrCacheHeader(
+    headers,
+    response.status,
+    pathname,
+    hasAuthContextAccess(requestContext),
+  );
   applyDefaultSpeculationRulesHeader(headers, response.status);
 
   const location = headers.get("location");
@@ -386,12 +414,14 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
           }),
           basePath,
           p,
+          ctx,
         );
       }
       return await rewriteMountedResponse(
         await runWithRequestContext(ctx, () => handler(request)),
         basePath,
         p,
+        ctx,
       );
     } catch (err) {
       // Log the full stack server-side, but never leak it to the client.

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -26,9 +26,15 @@ import {
   EMBED_TOKEN_QUERY_PARAM,
 } from "../shared/embed-auth.js";
 import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
-import { DEFAULT_SSR_CACHE_CONTROL } from "../shared/cache-control.js";
+import {
+  DEFAULT_SPECULATION_RULES_HEADER,
+  DEFAULT_SSR_CACHE_CONTROL,
+} from "../shared/cache-control.js";
 
-export { DEFAULT_SSR_CACHE_CONTROL } from "../shared/cache-control.js";
+export {
+  DEFAULT_SPECULATION_RULES_HEADER,
+  DEFAULT_SSR_CACHE_CONTROL,
+} from "../shared/cache-control.js";
 const ANONYMOUS_SESSION_COOKIE_NAMES = new Set(["an_docs_session"]);
 const BETTER_AUTH_SESSION_COOKIE_RE = /\.session_(?:token|data)$/;
 
@@ -217,39 +223,60 @@ function shouldUseDefaultSsrCacheHeader(
   headers: Headers,
   status: number,
   pathname: string,
-  hasAuthSignal: boolean,
 ): boolean {
   if (status < 200 || status >= 400) return false;
-  if (hasAuthSignal) return false;
 
   const contentType = headers.get("content-type")?.toLowerCase() ?? "";
   if (contentType.includes("text/html")) {
-    return !headers.has("cache-control");
+    // SSR HTML is public app shell in this framework; any per-user state is
+    // fetched after hydration. Always enforce the framework SWR default here;
+    // route-level no-cache/private headers on SSR HTML recreate the same
+    // origin stampede this cache policy is meant to prevent.
+    return true;
   }
 
   if (!pathname.endsWith(".data")) return false;
   if (!contentType.includes("text/x-script")) return false;
 
   // React Router gives loader `.data` responses `cache-control: no-cache` by
-  // default. For public loader responses, replace that default with the same
-  // short-fresh/long-SWR policy as HTML so route prefetch warms the CDN. Keep
-  // explicit route cache policies and any authenticated request untouched.
-  const cacheControl = headers.get("cache-control");
-  return !cacheControl || cacheControl.trim().toLowerCase() === "no-cache";
+  // default. In Agent-Native, SSR output is intentionally public app shell:
+  // user/org-specific reads happen after hydration through actions and API
+  // routes. Keep `.data` on the same short-fresh/long-SWR policy as HTML so
+  // route data fetches warm the CDN instead of hammering origin.
+  // Do not re-add a cookie/auth-signal bypass here without changing that
+  // architecture; logged-in browsers still need CDN-cached public route data.
+  // Also do not preserve route-level private/no-store for React Router .data:
+  // if a route needs per-user data, it belongs behind a client-side action/API
+  // call rather than in the shared SSR payload.
+  return true;
 }
 
 function applyDefaultSsrCacheHeader(
   headers: Headers,
   status: number,
   pathname: string,
-  hasAuthSignal: boolean,
 ) {
-  if (
-    !shouldUseDefaultSsrCacheHeader(headers, status, pathname, hasAuthSignal)
-  ) {
+  if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname)) {
     return;
   }
   headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
+}
+
+function applyDefaultSpeculationRulesHeader(headers: Headers, status: number) {
+  if (status < 200 || status >= 400) return;
+  if (headers.has("speculation-rules")) return;
+
+  const contentType = headers.get("content-type")?.toLowerCase() ?? "";
+  if (!contentType.includes("text/html")) return;
+
+  // Cloudflare Speed Brain injects its own Speculation-Rules header when the
+  // origin omits one. Those browser prefetches carry `Sec-Purpose: prefetch`,
+  // and Cloudflare refuses cache-ineligible dynamic pages with a 503 before
+  // the request can reach Netlify/origin. We publish an explicit no-op ruleset
+  // by default so Cloudflare does not inject its edge prefetch rules. Preserve
+  // an app-provided Speculation-Rules header above if a template deliberately
+  // owns this behavior.
+  headers.set("speculation-rules", DEFAULT_SPECULATION_RULES_HEADER);
 }
 
 function isFrameworkOrAssetPath(pathname: string): boolean {
@@ -274,11 +301,11 @@ async function rewriteMountedResponse(
   response: Response,
   basePath: string,
   pathname: string,
-  hasAuthSignal: boolean,
 ): Promise<Response> {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
-  applyDefaultSsrCacheHeader(headers, response.status, pathname, hasAuthSignal);
+  applyDefaultSsrCacheHeader(headers, response.status, pathname);
+  applyDefaultSpeculationRulesHeader(headers, response.status);
 
   const location = headers.get("location");
   if (location?.startsWith("/") && !location.startsWith("//")) {
@@ -359,14 +386,12 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
           }),
           basePath,
           p,
-          hasAuthSignal,
         );
       }
       return await rewriteMountedResponse(
         await runWithRequestContext(ctx, () => handler(request)),
         basePath,
         p,
-        hasAuthSignal,
       );
     } catch (err) {
       // Log the full stack server-side, but never leak it to the client.

--- a/packages/core/src/shared/cache-control.ts
+++ b/packages/core/src/shared/cache-control.ts
@@ -1,2 +1,12 @@
 export const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+
+export const DEFAULT_SPECULATION_RULES_PATH =
+  "/_agent-native/speculation-rules.json";
+
+export const DEFAULT_SPECULATION_RULES_HEADER = `"${DEFAULT_SPECULATION_RULES_PATH}"`;
+
+export const EMPTY_SPECULATION_RULES = {
+  prefetch: [],
+  prerender: [],
+} as const;

--- a/packages/dispatch/src/lib/catch-all-target.spec.ts
+++ b/packages/dispatch/src/lib/catch-all-target.spec.ts
@@ -1,80 +1,40 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-const loadWorkspaceAppsManifestMock = vi.hoisted(() => vi.fn());
-const getBuiltinAgentsMock = vi.hoisted(() => vi.fn());
-
-vi.mock("@agent-native/core/server/agent-discovery", () => ({
-  loadWorkspaceAppsManifest: loadWorkspaceAppsManifestMock,
-  getBuiltinAgents: getBuiltinAgentsMock,
-}));
-
+import { describe, expect, it } from "vitest";
 import { resolveCatchAllTarget } from "./catch-all-target.js";
-
-beforeEach(() => {
-  vi.clearAllMocks();
-});
-
-afterEach(() => {
-  vi.clearAllMocks();
-});
 
 describe("resolveCatchAllTarget", () => {
   it("prefers the workspace manifest entry when one matches", () => {
-    loadWorkspaceAppsManifestMock.mockReturnValue([
-      { id: "todo", name: "Todo", path: "/todo" },
-    ]);
-    getBuiltinAgentsMock.mockReturnValue([
-      {
-        id: "todo",
-        name: "Todo",
-        description: "",
-        url: "https://todo.example.com",
-        color: "#000",
-      },
-    ]);
-
-    expect(resolveCatchAllTarget("todo")).toBe("/todo");
+    expect(
+      resolveCatchAllTarget("todo", {
+        workspaceApps: [{ id: "todo", path: "/todo" }],
+        builtinAgents: [{ id: "todo", url: "https://todo.example.com" }],
+      }),
+    ).toBe("/todo");
   });
 
   it("falls back to the built-in template URL when no workspace manifest exists", () => {
-    loadWorkspaceAppsManifestMock.mockReturnValue(null);
-    getBuiltinAgentsMock.mockReturnValue([
-      {
-        id: "forms",
-        name: "Forms",
-        description: "",
-        url: "http://localhost:8084",
-        color: "#06B6D4",
-      },
-    ]);
-
-    expect(resolveCatchAllTarget("forms")).toBe("http://localhost:8084");
+    expect(
+      resolveCatchAllTarget("forms", {
+        workspaceApps: null,
+        builtinAgents: [{ id: "forms", url: "http://localhost:8084" }],
+      }),
+    ).toBe("http://localhost:8084");
   });
 
   it("falls back to the built-in template URL when the workspace manifest does not include the app", () => {
-    loadWorkspaceAppsManifestMock.mockReturnValue([
-      { id: "dispatch", name: "Dispatch", path: "/dispatch" },
-    ]);
-    getBuiltinAgentsMock.mockReturnValue([
-      {
-        id: "forms",
-        name: "Forms",
-        description: "",
-        url: "http://localhost:8084",
-        color: "#06B6D4",
-      },
-    ]);
-
-    expect(resolveCatchAllTarget("forms")).toBe("http://localhost:8084");
+    expect(
+      resolveCatchAllTarget("forms", {
+        workspaceApps: [{ id: "dispatch", path: "/dispatch" }],
+        builtinAgents: [{ id: "forms", url: "http://localhost:8084" }],
+      }),
+    ).toBe("http://localhost:8084");
   });
 
   it("normalizes a manifest entry without a leading slash", () => {
-    loadWorkspaceAppsManifestMock.mockReturnValue([
-      { id: "todo", name: "Todo", path: "todo" },
-    ]);
-    getBuiltinAgentsMock.mockReturnValue([]);
-
-    expect(resolveCatchAllTarget("todo")).toBe("/todo");
+    expect(
+      resolveCatchAllTarget("todo", {
+        workspaceApps: [{ id: "todo", path: "todo" }],
+      }),
+    ).toBe("/todo");
   });
 
   it("uses app.path when id !== path (not /${appId})", () => {
@@ -83,29 +43,28 @@ describe("resolveCatchAllTarget", () => {
     // silently rewritten to `/forms` (the appId) and routed to the wrong
     // app. The normalizer now keeps the manifest path and only prepends
     // the missing slash.
-    loadWorkspaceAppsManifestMock.mockReturnValue([
-      { id: "forms", name: "Forms", path: "my-forms" },
-    ]);
-    getBuiltinAgentsMock.mockReturnValue([]);
-
-    expect(resolveCatchAllTarget("forms")).toBe("/my-forms");
+    expect(
+      resolveCatchAllTarget("forms", {
+        workspaceApps: [{ id: "forms", path: "my-forms" }],
+      }),
+    ).toBe("/my-forms");
   });
 
   it("prefers app.url when the manifest entry has an externally-hosted URL", () => {
     // Workspaces can point at remote deploys. The catch-all should bounce
     // to the absolute URL instead of mounting a local path that doesn't
     // exist inside the gateway.
-    loadWorkspaceAppsManifestMock.mockReturnValue([
-      {
-        id: "forms",
-        name: "Forms",
-        path: "/forms",
-        url: "https://forms.example.com",
-      },
-    ]);
-    getBuiltinAgentsMock.mockReturnValue([]);
-
-    expect(resolveCatchAllTarget("forms")).toBe("https://forms.example.com");
+    expect(
+      resolveCatchAllTarget("forms", {
+        workspaceApps: [
+          {
+            id: "forms",
+            path: "/forms",
+            url: "https://forms.example.com",
+          },
+        ],
+      }),
+    ).toBe("https://forms.example.com");
   });
 
   it("ignores app.url that isn't an absolute http(s) URL and falls back to path", () => {
@@ -114,73 +73,54 @@ describe("resolveCatchAllTarget", () => {
     // this, the catch-all would `throw redirect("forms.example.com")`
     // and the browser would treat the value as a relative path inside the
     // gateway, producing a broken redirect.
-    loadWorkspaceAppsManifestMock.mockReturnValue([
-      {
-        id: "forms",
-        name: "Forms",
-        path: "/forms",
-        url: "forms.example.com",
-      },
-    ]);
-    getBuiltinAgentsMock.mockReturnValue([]);
-
-    expect(resolveCatchAllTarget("forms")).toBe("/forms");
+    expect(
+      resolveCatchAllTarget("forms", {
+        workspaceApps: [
+          { id: "forms", path: "/forms", url: "forms.example.com" },
+        ],
+      }),
+    ).toBe("/forms");
   });
 
   it("rejects non-http(s) URL schemes (e.g. javascript:) and falls back to path", () => {
     // Defense in depth — a hostile manifest entry can't produce a
     // `javascript:` redirect target. Validation enforces http(s) only.
-    loadWorkspaceAppsManifestMock.mockReturnValue([
-      {
-        id: "forms",
-        name: "Forms",
-        path: "/forms",
-        url: "javascript:alert(1)",
-      },
-    ]);
-    getBuiltinAgentsMock.mockReturnValue([]);
-
-    expect(resolveCatchAllTarget("forms")).toBe("/forms");
+    expect(
+      resolveCatchAllTarget("forms", {
+        workspaceApps: [
+          { id: "forms", path: "/forms", url: "javascript:alert(1)" },
+        ],
+      }),
+    ).toBe("/forms");
   });
 
   it("strips a trailing slash from app.url", () => {
-    loadWorkspaceAppsManifestMock.mockReturnValue([
-      {
-        id: "forms",
-        name: "Forms",
-        path: "/forms",
-        url: "https://forms.example.com/",
-      },
-    ]);
-    getBuiltinAgentsMock.mockReturnValue([]);
-
-    expect(resolveCatchAllTarget("forms")).toBe("https://forms.example.com");
+    expect(
+      resolveCatchAllTarget("forms", {
+        workspaceApps: [
+          { id: "forms", path: "/forms", url: "https://forms.example.com/" },
+        ],
+      }),
+    ).toBe("https://forms.example.com");
   });
 
   it("ignores an empty/whitespace app.url and falls back to path", () => {
-    loadWorkspaceAppsManifestMock.mockReturnValue([
-      {
-        id: "forms",
-        name: "Forms",
-        path: "/forms",
-        url: "   ",
-      },
-    ]);
-    getBuiltinAgentsMock.mockReturnValue([]);
-
-    expect(resolveCatchAllTarget("forms")).toBe("/forms");
+    expect(
+      resolveCatchAllTarget("forms", {
+        workspaceApps: [{ id: "forms", path: "/forms", url: "   " }],
+      }),
+    ).toBe("/forms");
   });
 
   it("collapses leading slashes/backslashes in app.path so `/\\evil.example` can't redirect off-origin", () => {
     // Browsers normalize backslashes to forward slashes during URL
     // parsing, so `throw redirect("/\\evil.example")` would resolve to
     // `https://evil.example`. The regex covers both slash types.
-    loadWorkspaceAppsManifestMock.mockReturnValue([
-      { id: "forms", name: "Forms", path: "/\\evil.example" },
-    ]);
-    getBuiltinAgentsMock.mockReturnValue([]);
-
-    expect(resolveCatchAllTarget("forms")).toBe("/evil.example");
+    expect(
+      resolveCatchAllTarget("forms", {
+        workspaceApps: [{ id: "forms", path: "/\\evil.example" }],
+      }),
+    ).toBe("/evil.example");
   });
 
   it("collapses leading double slashes in app.path so `//evil.example` can't redirect off-origin", () => {
@@ -190,29 +130,26 @@ describe("resolveCatchAllTarget", () => {
     // to `https://evil.example` — the same phishing vector the `app.url`
     // validator closes. Collapse the leading slashes so the redirect
     // stays on the gateway.
-    loadWorkspaceAppsManifestMock.mockReturnValue([
-      { id: "forms", name: "Forms", path: "//evil.example" },
-    ]);
-    getBuiltinAgentsMock.mockReturnValue([]);
-
-    expect(resolveCatchAllTarget("forms")).toBe("/evil.example");
+    expect(
+      resolveCatchAllTarget("forms", {
+        workspaceApps: [{ id: "forms", path: "//evil.example" }],
+      }),
+    ).toBe("/evil.example");
   });
 
   it("falls back to /${appId} when the manifest entry has neither path nor url", () => {
-    loadWorkspaceAppsManifestMock.mockReturnValue([
-      { id: "forms", name: "Forms", path: "" },
-    ]);
-    getBuiltinAgentsMock.mockReturnValue([]);
-
-    expect(resolveCatchAllTarget("forms")).toBe("/forms");
+    expect(
+      resolveCatchAllTarget("forms", {
+        workspaceApps: [{ id: "forms", path: "" }],
+      }),
+    ).toBe("/forms");
   });
 
   it("returns null when nothing matches", () => {
-    loadWorkspaceAppsManifestMock.mockReturnValue([
-      { id: "dispatch", name: "Dispatch", path: "/dispatch" },
-    ]);
-    getBuiltinAgentsMock.mockReturnValue([]);
-
-    expect(resolveCatchAllTarget("unknown-app")).toBeNull();
+    expect(
+      resolveCatchAllTarget("unknown-app", {
+        workspaceApps: [{ id: "dispatch", path: "/dispatch" }],
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/dispatch/src/lib/catch-all-target.ts
+++ b/packages/dispatch/src/lib/catch-all-target.ts
@@ -1,7 +1,18 @@
-import {
-  getBuiltinAgents,
-  loadWorkspaceAppsManifest,
-} from "@agent-native/core/server/agent-discovery";
+interface WorkspaceAppManifestEntry {
+  id?: string;
+  path?: unknown;
+  url?: unknown;
+}
+
+interface BuiltinAgentEntry {
+  id: string;
+  url?: string | null;
+}
+
+interface ResolveCatchAllTargetOptions {
+  workspaceApps?: WorkspaceAppManifestEntry[] | null;
+  builtinAgents?: BuiltinAgentEntry[] | null;
+}
 
 /**
  * Resolve where `/dispatch/<appId>` should bounce to when it doesn't match
@@ -15,7 +26,7 @@ import {
  *      present.
  *    - Otherwise the `app.path` mounted under the workspace gateway is
  *      used. Path is normalized to a leading slash if missing
- *      (e.g. manifest entry `path: "my-forms"` → `/my-forms`), so an app
+ *      (e.g. manifest entry `path: "my-forms"` -> `/my-forms`), so an app
  *      whose mounted path differs from its id ends up at the right place
  *      instead of being silently rewritten to `/${appId}`.
  *    - Bare entry with no path / url falls back to `/${appId}`.
@@ -50,8 +61,11 @@ function validatedAbsoluteUrl(value: unknown): string | undefined {
   }
 }
 
-export function resolveCatchAllTarget(appId: string): string | null {
-  const apps = loadWorkspaceAppsManifest();
+export function resolveCatchAllTarget(
+  appId: string,
+  options: ResolveCatchAllTargetOptions = {},
+): string | null {
+  const apps = options.workspaceApps;
   if (apps) {
     const app = apps.find((entry) => entry?.id === appId);
     if (app) {
@@ -81,7 +95,7 @@ export function resolveCatchAllTarget(appId: string): string | null {
       //   `\/evil.example`   — same idea, leading-backslash variant.
       //
       // The manifest parser only checks `startsWith("/")` for the first
-      // case, and even that allows `//evil…`. Defend in depth here by
+      // case, and even that allows `//evil...`. Defend in depth here by
       // collapsing any run of leading slashes-or-backslashes to one
       // forward slash. Same phishing vector that `validatedAbsoluteUrl`
       // closes for `app.url`.
@@ -92,8 +106,20 @@ export function resolveCatchAllTarget(appId: string): string | null {
       return `/${appId}`;
     }
   }
-  const builtin = getBuiltinAgents("dispatch").find(
+  const builtin = (options.builtinAgents ?? []).find(
     (agent) => agent.id === appId,
   );
   return builtin?.url ?? null;
+}
+
+export async function resolveServerCatchAllTarget(
+  appId: string,
+): Promise<string | null> {
+  if (!import.meta.env.SSR) return null;
+  const { getBuiltinAgents, loadWorkspaceAppsManifest } =
+    await import("@agent-native/core/server/agent-discovery");
+  return resolveCatchAllTarget(appId, {
+    workspaceApps: loadWorkspaceAppsManifest(),
+    builtinAgents: getBuiltinAgents("dispatch"),
+  });
 }

--- a/packages/dispatch/src/routes/pages/$appId.tsx
+++ b/packages/dispatch/src/routes/pages/$appId.tsx
@@ -17,7 +17,7 @@ import { DispatchShell } from "@/components/dispatch-shell";
 import { Spinner } from "@/components/ui/spinner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { resolveCatchAllTarget } from "@/lib/catch-all-target";
+import { resolveServerCatchAllTarget } from "@/lib/catch-all-target";
 import {
   workspaceAppHref,
   type WorkspaceAppSummary,
@@ -68,12 +68,12 @@ function dispatchSelfRedirect(appId: string | undefined): string | null {
   return null;
 }
 
-export function loader({ params }: LoaderFunctionArgs) {
+export async function loader({ params }: LoaderFunctionArgs) {
   const appId = params.appId;
   if (!appId) return null;
   const selfTarget = dispatchSelfRedirect(appId);
   if (selfTarget) throw redirect(selfTarget);
-  const target = resolveCatchAllTarget(appId);
+  const target = await resolveServerCatchAllTarget(appId);
   if (target) throw redirect(target);
   return null;
 }

--- a/packages/dispatch/src/server/lib/thread-link-preview.ts
+++ b/packages/dispatch/src/server/lib/thread-link-preview.ts
@@ -1,5 +1,4 @@
 import type { ChatThread } from "@agent-native/core/server";
-import { getRequestContext, getThread } from "@agent-native/core/server";
 
 export interface ThreadLinkPreview {
   title: string;
@@ -148,8 +147,11 @@ function previewDescription(thread: ChatThread): string {
 export async function loadThreadLinkPreview(
   threadId: string | null | undefined,
 ): Promise<ThreadLinkPreview | null> {
+  if (!import.meta.env.SSR) return null;
   const id = threadId?.trim();
   if (!id) return null;
+  const { getRequestContext, getThread } =
+    await import("@agent-native/core/server");
   const viewerEmail = getRequestContext()?.userEmail?.trim();
   if (!viewerEmail) return null;
   const thread = await getThread(id).catch(() => null);

--- a/packages/docs/app/components/DocsPrevNext.tsx
+++ b/packages/docs/app/components/DocsPrevNext.tsx
@@ -58,7 +58,7 @@ export default function DocsPrevNext() {
     <nav className="docs-prev-next">
       {prev ? (
         <Link
-          prefetch="render"
+          data-an-prefetch="render"
           to={prev.to}
           className="docs-prev-next-link docs-prev-link"
         >
@@ -73,7 +73,7 @@ export default function DocsPrevNext() {
       )}
       {next ? (
         <Link
-          prefetch="render"
+          data-an-prefetch="render"
           to={next.to}
           className="docs-prev-next-link docs-next-link"
         >

--- a/packages/docs/app/components/DocsSidebar.tsx
+++ b/packages/docs/app/components/DocsSidebar.tsx
@@ -14,7 +14,7 @@ export default function DocsSidebar() {
               {section.items.map((item) => (
                 <li key={item.to}>
                   <NavLink
-                    prefetch="render"
+                    data-an-prefetch="render"
                     to={item.to}
                     end
                     className={({ isActive }) =>

--- a/packages/docs/app/components/Header.tsx
+++ b/packages/docs/app/components/Header.tsx
@@ -113,7 +113,7 @@ export default function Header() {
       >
         <nav className="mx-auto flex h-16 w-full max-w-[1600px] items-center gap-6 px-6">
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/"
             aria-label="Agent-Native"
             className="flex shrink-0 items-center gap-2 text-[var(--fg)] no-underline"
@@ -133,7 +133,7 @@ export default function Header() {
           {/* Desktop nav links */}
           <div className="hidden lg:flex items-center gap-5 text-sm">
             <NavLink
-              prefetch="render"
+              data-an-prefetch="render"
               to="/docs"
               className={({ isActive }) =>
                 isActive ? "header-link is-active" : "header-link"
@@ -142,7 +142,7 @@ export default function Header() {
               Docs
             </NavLink>
             <NavLink
-              prefetch="render"
+              data-an-prefetch="render"
               to="/templates"
               className={({ isActive }) =>
                 isActive ? "header-link is-active" : "header-link"
@@ -151,7 +151,7 @@ export default function Header() {
               Templates
             </NavLink>
             <NavLink
-              prefetch="render"
+              data-an-prefetch="render"
               to="/download"
               className={({ isActive }) =>
                 isActive ? "header-link is-active" : "header-link"
@@ -219,7 +219,7 @@ export default function Header() {
         {mobileMenuOpen && (
           <div className="lg:hidden border-t border-[var(--docs-border)] bg-[var(--header-bg)] backdrop-blur-lg px-6 py-4 flex flex-col gap-4">
             <NavLink
-              prefetch="render"
+              data-an-prefetch="render"
               to="/docs"
               className={({ isActive }) =>
                 isActive ? "header-link is-active" : "header-link"
@@ -229,7 +229,7 @@ export default function Header() {
               Docs
             </NavLink>
             <NavLink
-              prefetch="render"
+              data-an-prefetch="render"
               to="/templates"
               className={({ isActive }) =>
                 isActive ? "header-link is-active" : "header-link"
@@ -239,7 +239,7 @@ export default function Header() {
               Templates
             </NavLink>
             <NavLink
-              prefetch="render"
+              data-an-prefetch="render"
               to="/download"
               className={({ isActive }) =>
                 isActive ? "header-link is-active" : "header-link"

--- a/packages/docs/app/components/MobileDocsNav.tsx
+++ b/packages/docs/app/components/MobileDocsNav.tsx
@@ -89,7 +89,7 @@ export default function MobileDocsNav() {
                     return (
                       <li key={item.to}>
                         <Link
-                          prefetch="render"
+                          data-an-prefetch="render"
                           to={item.to}
                           className={`mobile-docs-nav-link ${isActive ? "is-active" : ""}`}
                           onClick={() => setOpen(false)}

--- a/packages/docs/app/components/TemplateCard.tsx
+++ b/packages/docs/app/components/TemplateCard.tsx
@@ -230,7 +230,7 @@ function CliPopoverContent({ template }: { template: Template }) {
       <div className="border-t border-[var(--code-border)] px-3 py-1.5 text-[10px] text-[var(--fg-secondary)]">
         Paste into your terminal.{" "}
         <Link
-          prefetch="render"
+          data-an-prefetch="render"
           to="/docs/getting-started"
           className="text-[var(--docs-accent)] no-underline hover:underline"
         >
@@ -319,7 +319,7 @@ export function TemplateCard({ template }: { template: Template }) {
   return (
     <div className="feature-card flex flex-col gap-3 overflow-hidden">
       <Link
-        prefetch="render"
+        data-an-prefetch="render"
         to={`/templates/${template.slug}`}
         className="-mx-[24px] -mt-[24px] mb-1 flex aspect-[4/3] items-center justify-center overflow-hidden border-b border-[var(--docs-border)] bg-[var(--bg-secondary)] transition hover:opacity-90"
         onClick={() =>
@@ -350,7 +350,7 @@ export function TemplateCard({ template }: { template: Template }) {
       </Link>
       <h3 className="text-base font-semibold">
         <Link
-          prefetch="render"
+          data-an-prefetch="render"
           to={`/templates/${template.slug}`}
           className="text-[var(--fg)] no-underline hover:text-[var(--docs-accent)]"
         >

--- a/packages/docs/app/components/template-docs.tsx
+++ b/packages/docs/app/components/template-docs.tsx
@@ -28,7 +28,7 @@ export function TemplateDocsLink({
 }) {
   return (
     <Link
-      prefetch="render"
+      data-an-prefetch="render"
       to={getTemplateDocsPath(template)}
       onClick={() =>
         trackEvent("click view docs", {

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -104,6 +104,10 @@ const CANONICAL_ALIASES: Record<string, string> = {
   "/docs/getting-started": "/docs",
 };
 const SCROLL_MANAGER_MARKER = "docs-scroll-manager-marker";
+const DATA_ROUTE_PREFETCH_ATTR = "data-an-prefetch";
+const DATA_ROUTE_PREFETCH_SELECTOR = `a[${DATA_ROUTE_PREFETCH_ATTR}="render"][href]`;
+const MAX_CONCURRENT_DATA_PREFETCHES = 4;
+const warmedDataRoutes = new Set<string>();
 
 function CanonicalLink() {
   const location = useLocation();
@@ -230,6 +234,105 @@ function ScrollManager() {
   );
 }
 
+function dataRouteUrlForHref(href: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(href, window.location.href);
+  } catch {
+    return null;
+  }
+
+  if (url.origin !== window.location.origin) return null;
+  if (url.pathname === window.location.pathname && url.hash) return null;
+  if (
+    url.pathname.startsWith("/_agent-native/") ||
+    url.pathname.startsWith("/api/")
+  ) {
+    return null;
+  }
+  if (/\.\w+$/.test(url.pathname)) return null;
+
+  const pathname = url.pathname.replace(/\/+$/, "") || "/";
+  if (pathname === "/") return null;
+  url.pathname = `${pathname}.data`;
+  url.hash = "";
+  return url.href;
+}
+
+function DataRouteWarmup() {
+  useEffect(() => {
+    const connection = (
+      navigator as Navigator & { connection?: { saveData?: boolean } }
+    ).connection;
+    if (connection?.saveData) return;
+
+    const queue: string[] = [];
+    let active = 0;
+    let stopped = false;
+    let scheduleTimer: number | undefined;
+
+    const pump = () => {
+      if (stopped) return;
+      while (active < MAX_CONCURRENT_DATA_PREFETCHES && queue.length > 0) {
+        const href = queue.shift();
+        if (!href) continue;
+        active += 1;
+        window
+          .fetch(href, { credentials: "same-origin", cache: "force-cache" })
+          .catch(() => {})
+          .finally(() => {
+            active -= 1;
+            window.setTimeout(pump, 50);
+          });
+      }
+    };
+
+    const enqueue = () => {
+      for (const link of document.querySelectorAll<HTMLAnchorElement>(
+        DATA_ROUTE_PREFETCH_SELECTOR,
+      )) {
+        const dataUrl = dataRouteUrlForHref(link.href);
+        if (!dataUrl || warmedDataRoutes.has(dataUrl)) continue;
+        warmedDataRoutes.add(dataUrl);
+        queue.push(dataUrl);
+      }
+      pump();
+    };
+
+    const schedule = () => {
+      if (scheduleTimer !== undefined) window.clearTimeout(scheduleTimer);
+      scheduleTimer = window.setTimeout(() => {
+        scheduleTimer = undefined;
+        enqueue();
+      }, 0);
+    };
+
+    // Do not use React Router's native `prefetch="render"` on the public docs
+    // site while it sits behind Cloudflare. Native link prefetches carry
+    // `Sec-Purpose: prefetch`; Cloudflare Speed Brain intercepts those and
+    // returns 503 for cache-ineligible dynamic routes before Netlify/origin can
+    // serve the now-cacheable `.data` response. This normal fetch warmup keeps
+    // render-time route-data warming without tripping Cloudflare's prefetch
+    // refusal path.
+    schedule();
+    const observer = new MutationObserver(schedule);
+    observer.observe(document.documentElement, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ["href", DATA_ROUTE_PREFETCH_ATTR],
+    });
+
+    return () => {
+      stopped = true;
+      if (scheduleTimer !== undefined) window.clearTimeout(scheduleTimer);
+      observer.disconnect();
+    };
+  }, []);
+
+  return null;
+}
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -300,6 +403,7 @@ export default function Root() {
   const content = (
     <>
       <ScrollManager />
+      <DataRouteWarmup />
       <Header />
       <Outlet />
       <Footer />
@@ -354,14 +458,14 @@ export function ErrorBoundary() {
         </p>
         <div className="flex items-center gap-3">
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/"
             className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
           >
             Go home
           </Link>
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/docs"
             className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
           >
@@ -381,7 +485,7 @@ export function ErrorBoundary() {
         An unexpected error occurred.
       </p>
       <Link
-        prefetch="render"
+        data-an-prefetch="render"
         to="/"
         className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
       >

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -291,7 +291,7 @@ export default function Home() {
                 </svg>
               </a>
               <Link
-                prefetch="render"
+                data-an-prefetch="render"
                 to="/docs"
                 className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
                 onClick={() =>
@@ -347,7 +347,7 @@ export default function Home() {
 
           <div className="mt-8 text-center">
             <Link
-              prefetch="render"
+              data-an-prefetch="render"
               to="/templates"
               className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
               onClick={() =>
@@ -599,7 +599,7 @@ export default function Home() {
                 </svg>
               </a>
               <Link
-                prefetch="render"
+                data-an-prefetch="render"
                 to="/docs"
                 className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
                 onClick={() =>

--- a/packages/docs/app/routes/templates.$slug.tsx
+++ b/packages/docs/app/routes/templates.$slug.tsx
@@ -113,7 +113,7 @@ export default function GenericTemplatePage() {
     return (
       <main className="mx-auto max-w-[900px] px-6 py-20">
         <Link
-          prefetch="render"
+          data-an-prefetch="render"
           to="/templates"
           className="inline-flex items-center gap-2 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
         >
@@ -137,7 +137,7 @@ export default function GenericTemplatePage() {
     <main className="mx-auto max-w-[1200px] px-6">
       <section className="py-20">
         <Link
-          prefetch="render"
+          data-an-prefetch="render"
           to="/templates"
           className="inline-flex items-center gap-2 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
         >

--- a/packages/docs/app/routes/templates.analytics.tsx
+++ b/packages/docs/app/routes/templates.analytics.tsx
@@ -93,7 +93,7 @@ export default function AnalyticsTemplate() {
       <section className="py-20">
         <div className="mb-4">
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-1 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
           >
@@ -570,7 +570,7 @@ export default function AnalyticsTemplate() {
             Read the docs
           </TemplateDocsLink>
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
           >

--- a/packages/docs/app/routes/templates.calendar.tsx
+++ b/packages/docs/app/routes/templates.calendar.tsx
@@ -93,7 +93,7 @@ export default function CalendarTemplate() {
       <section className="py-20">
         <div className="mb-4">
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-1 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
           >
@@ -638,7 +638,7 @@ export default function CalendarTemplate() {
             Read the docs
           </TemplateDocsLink>
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
           >

--- a/packages/docs/app/routes/templates.clips.tsx
+++ b/packages/docs/app/routes/templates.clips.tsx
@@ -91,7 +91,7 @@ export default function ClipsTemplate() {
       <section className="py-20">
         <div className="mb-4">
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-1 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
           >
@@ -662,7 +662,7 @@ export default function ClipsTemplate() {
             Read the docs
           </TemplateDocsLink>
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
           >

--- a/packages/docs/app/routes/templates.content.tsx
+++ b/packages/docs/app/routes/templates.content.tsx
@@ -93,7 +93,7 @@ export default function ContentTemplate() {
       <section className="py-20">
         <div className="mb-4">
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-1 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
           >
@@ -505,7 +505,7 @@ export default function ContentTemplate() {
             Read the docs
           </TemplateDocsLink>
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
           >

--- a/packages/docs/app/routes/templates.design.tsx
+++ b/packages/docs/app/routes/templates.design.tsx
@@ -91,7 +91,7 @@ export default function DesignTemplate() {
       <section className="py-20">
         <div className="mb-4">
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-1 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
           >
@@ -445,7 +445,7 @@ export default function DesignTemplate() {
             Read the docs
           </TemplateDocsLink>
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
           >

--- a/packages/docs/app/routes/templates.dispatch.tsx
+++ b/packages/docs/app/routes/templates.dispatch.tsx
@@ -93,7 +93,7 @@ export default function DispatchTemplate() {
       <section className="py-20">
         <div className="mb-4">
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-1 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
           >
@@ -626,7 +626,7 @@ export default function DispatchTemplate() {
             Read the docs
           </TemplateDocsLink>
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
           >

--- a/packages/docs/app/routes/templates.forms.tsx
+++ b/packages/docs/app/routes/templates.forms.tsx
@@ -93,7 +93,7 @@ export default function FormsTemplate() {
       <section className="py-20">
         <div className="mb-4">
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-1 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
           >
@@ -450,7 +450,7 @@ export default function FormsTemplate() {
             Read the docs
           </TemplateDocsLink>
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
           >

--- a/packages/docs/app/routes/templates.mail.tsx
+++ b/packages/docs/app/routes/templates.mail.tsx
@@ -93,7 +93,7 @@ export default function MailTemplate() {
       <section className="py-20">
         <div className="mb-4">
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-1 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
           >
@@ -645,7 +645,7 @@ export default function MailTemplate() {
             Read the docs
           </TemplateDocsLink>
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
           >

--- a/packages/docs/app/routes/templates.slides.tsx
+++ b/packages/docs/app/routes/templates.slides.tsx
@@ -89,7 +89,7 @@ export default function SlidesTemplate() {
       <section className="py-20">
         <div className="mb-4">
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-1 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
           >
@@ -442,7 +442,7 @@ export default function SlidesTemplate() {
             Read the docs
           </TemplateDocsLink>
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
           >

--- a/packages/docs/app/routes/templates.video.tsx
+++ b/packages/docs/app/routes/templates.video.tsx
@@ -93,7 +93,7 @@ export default function VideoTemplate() {
       <section className="py-20">
         <div className="mb-4">
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-1 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
           >
@@ -520,7 +520,7 @@ export default function VideoTemplate() {
             Read the docs
           </TemplateDocsLink>
           <Link
-            prefetch="render"
+            data-an-prefetch="render"
             to="/templates"
             className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
           >

--- a/templates/dispatch/app/root.tsx
+++ b/templates/dispatch/app/root.tsx
@@ -15,13 +15,13 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
-import { useDbSync } from "@agent-native/core";
 import {
   ClientOnly,
   CommandMenu,
   configureTracking,
   DefaultSpinner,
   getThemeInitScript,
+  useDbSync,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
 import { IconSun, IconMoon } from "@tabler/icons-react";


### PR DESCRIPTION
## Summary
- force framework SSR HTML and React Router `.data` responses onto the shared public SWR cache policy, including auth-looking requests
- publish a default no-op `Speculation-Rules` header/route so Cloudflare does not inject Speed Brain prefetch rules that 503 before origin
- replace docs native `prefetch="render"` links with a controlled `.data` warmup fetch that does not send `Sec-Purpose: prefetch`
- include local Dispatch cleanup so route loaders avoid pulling server-only modules into the browser bundle

## Verification
- reproduced current production failure: `.data` request with `Sec-Purpose: prefetch` returns Cloudflare `503` / `cf-speculation-refused`
- reproduced current production auth-cookie bypass: `.data` with `Cookie: an_session=fake` returns `cache-control: no-cache`
- `pnpm --filter @agent-native/core exec vitest run src/server/ssr-handler.spec.ts src/deploy/build.spec.ts`
- `pnpm --filter @agent-native/dispatch exec vitest run src/lib/catch-all-target.spec.ts`
- `pnpm --filter @agent-native/dispatch build`
- `pnpm --filter @agent-native/docs build`
- `NITRO_PRESET=netlify pnpm --filter @agent-native/docs build`
- local built-docs curl: HTML and authenticated `.data` return `public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600`
- local built-docs curl: hashed JS returns `public, max-age=31536000, immutable` plus `cdn-cache-control`
- local browser/proxy capture: homepage `.data` warmups are normal fetches with empty `Purpose` and `Sec-Purpose` headers
