### PR TITLE
Cache SSR at CDN and warm docs route assets

### DIFF
--- a/.changeset/code-agents-streaming.md
+++ b/.changeset/code-agents-streaming.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/code-agents-ui": patch
+---
+
+Smooth streamed assistant text in Agent-Native Code.

--- a/.changeset/netlify-ssr-cdn-cache.md
+++ b/.changeset/netlify-ssr-cdn-cache.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add CDN and Netlify durable cache headers to framework SSR and route data responses.

--- a/.changeset/netlify-ssr-cdn-cache.md
+++ b/.changeset/netlify-ssr-cdn-cache.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Add CDN and Netlify durable cache headers to framework SSR and route data responses, and smooth assistant text streaming.
+Add CDN and Netlify durable cache headers to framework SSR and route data responses.

--- a/.changeset/netlify-ssr-cdn-cache.md
+++ b/.changeset/netlify-ssr-cdn-cache.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Add CDN and Netlify durable cache headers to framework SSR and route data responses.
+Add CDN and Netlify durable cache headers to framework SSR and route data responses, and smooth assistant text streaming.

--- a/.changeset/smooth-agent-streaming.md
+++ b/.changeset/smooth-agent-streaming.md
@@ -1,6 +1,5 @@
 ---
 "@agent-native/core": patch
-"@agent-native/code-agents-ui": patch
 ---
 
 Smooth streamed assistant text in chat, Agent-Native Code, and the coding CLI.

--- a/.changeset/smooth-agent-streaming.md
+++ b/.changeset/smooth-agent-streaming.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/code-agents-ui": patch
+---
+
+Smooth streamed assistant text in chat, Agent-Native Code, and the coding CLI.

--- a/packages/code-agents-ui/src/CodeAgentsApp.tsx
+++ b/packages/code-agents-ui/src/CodeAgentsApp.tsx
@@ -3527,6 +3527,7 @@ function TranscriptPanel({
           adapterReloadKey={controller}
           loadHistoryRepository={loadHistoryRepository}
           historyReloadKey={historyReloadKey}
+          externalStreaming={runIsActive}
           composerAreaClassName="code-agents-standard-composer"
           composerToolbarSlot={
             <CodeAgentChatComposerSlot

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -113,7 +113,23 @@ Restart the agent client after connecting so it picks up the new MCP server; OAu
 
 Use `--client codex` (or `--client claude-code`, `--client claude-code-cli`, `--client cowork`, `--client all`) to skip the picker for scripts or one-off installs.
 
-First-party app skills install the instructions and the hosted MCP connector together with `npx @agent-native/core@latest skills add <name>`. Each has a short alias for demos and tutorials:
+First-party app skills are available through the open Skills CLI:
+
+```bash
+npx skills add BuilderIO/agent-native --skill assets
+npx skills add BuilderIO/agent-native --skill design-exploration
+```
+
+That installs instructions only. For local MCP clients, connect the hosted app
+once:
+
+```bash
+npx @agent-native/core@latest connect https://assets.agent-native.com
+npx @agent-native/core@latest connect https://design.agent-native.com
+```
+
+Use the Agent Native convenience installer when you want one command to install
+the instructions and register the hosted MCP connector together:
 
 ```bash
 npx @agent-native/core@latest skills add assets              # aliases: images, image-generation

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -113,28 +113,24 @@ Restart the agent client after connecting so it picks up the new MCP server; OAu
 
 Use `--client codex` (or `--client claude-code`, `--client claude-code-cli`, `--client cowork`, `--client all`) to skip the picker for scripts or one-off installs.
 
-First-party app skills are available through the open Skills CLI:
+First-party app skills install the instructions and the hosted MCP connector together with the Agent Native CLI:
+
+```bash
+npx @agent-native/core@latest skills add assets              # aliases: images, image-generation
+npx @agent-native/core@latest skills add design-exploration  # aliases: design, ux-exploration
+```
+
+The open Skills CLI path is also available when you only want portable
+instructions:
 
 ```bash
 npx skills add BuilderIO/agent-native --skill assets
 npx skills add BuilderIO/agent-native --skill design-exploration
 ```
 
-That installs instructions only. For local MCP clients, connect the hosted app
-once:
-
-```bash
-npx @agent-native/core@latest connect https://assets.agent-native.com
-npx @agent-native/core@latest connect https://design.agent-native.com
-```
-
-Use the Agent Native convenience installer when you want one command to install
-the instructions and register the hosted MCP connector together:
-
-```bash
-npx @agent-native/core@latest skills add assets              # aliases: images, image-generation
-npx @agent-native/core@latest skills add design-exploration  # aliases: design, ux-exploration
-```
+The raw `skills` CLI installs `SKILL.md` files only; local MCP clients still
+need a connector such as `npx @agent-native/core@latest connect
+https://assets.agent-native.com`.
 
 | Skill                | Alias    | For                    |
 | -------------------- | -------- | ---------------------- |

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -113,7 +113,7 @@ Restart the agent client after connecting so it picks up the new MCP server; OAu
 
 Use `--client codex` (or `--client claude-code`, `--client claude-code-cli`, `--client cowork`, `--client all`) to skip the picker for scripts or one-off installs.
 
-First-party app skills install the instructions and the hosted MCP connector together with `skills add <name>`. Each has a short alias for demos and tutorials:
+First-party app skills install the instructions and the hosted MCP connector together with `npx @agent-native/core@latest skills add <name>`. Each has a short alias for demos and tutorials:
 
 ```bash
 npx @agent-native/core@latest skills add assets              # aliases: images, image-generation

--- a/packages/core/docs/content/skills-guide.md
+++ b/packages/core/docs/content/skills-guide.md
@@ -81,13 +81,17 @@ Hosted is the default install path. Local launch is explicit for customization,
 offline work, or privacy-sensitive use.
 
 ```bash
-# One-command hosted install for the exported Assets skill plus MCP connector.
+# Public Skills CLI installs the exported instructions.
+npx skills add BuilderIO/agent-native --skill assets
+npx skills add BuilderIO/agent-native --skill design-exploration
+
+# Local MCP clients also need the hosted connector once.
+npx @agent-native/core@latest connect https://assets.agent-native.com
+npx @agent-native/core@latest connect https://design.agent-native.com
+
+# Convenience installers do both steps for local clients.
 npx @agent-native/core@latest skills add assets
-
-# Same install, using the image-generation alias for demos and tutorials.
 npx @agent-native/core@latest skills add images
-
-# One-command hosted install for Design exploration plus MCP connector.
 npx @agent-native/core@latest skills add design-exploration
 
 # Register a hosted MCP connector for local agent clients.
@@ -114,14 +118,7 @@ settings flow.
 
 The Vercel Labs `skills` adapter is a portable `skills/<name>/SKILL.md` bundle
 for `npx skills add ...`, but the raw `skills` CLI installs instructions only.
-For first-party hosted apps, keep the default docs on
-`npx @agent-native/core@latest skills add assets` and
-`npx @agent-native/core@latest skills add design-exploration`; each installs
-the exported instructions and runs the MCP registration step together.
-
-`npx skills add BuilderIO/agent-native-skills --skill assets` is only valid
-after `BuilderIO/agent-native-skills` exists as a real public GitHub repo, or
-after an equivalent well-known/full-URL source is published. `skills.sh` is a
+`BuilderIO/agent-native` is a real GitHub repository source; `skills.sh` is a
 discovery and leaderboard directory, not an npm-style package namespace.
 
 The Claude Code marketplace adapter writes

--- a/packages/core/docs/content/skills-guide.md
+++ b/packages/core/docs/content/skills-guide.md
@@ -100,7 +100,7 @@ agent-native app-skill launch --manifest templates/assets/agent-native.app-skill
 # plain/Claude skills, and MCP configs.
 agent-native app-skill pack --manifest templates/assets/agent-native.app-skill.json --out ./dist/assets-skill
 
-# Install the exported skill with the open skills CLI.
+# Install a local exported bundle with the open skills CLI.
 npx skills add ./dist/assets-skill --skill assets -a codex -y
 
 # Add the generated Claude Code marketplace, then install its Assets plugin.
@@ -113,10 +113,16 @@ metadata; OAuth/device setup happens in the MCP host or through the app's normal
 settings flow.
 
 The Vercel Labs `skills` adapter is a portable `skills/<name>/SKILL.md` bundle
-for `npx skills add ...`. For first-party hosted apps, prefer
-`agent-native skills add images`, `agent-native skills add assets`, or
-`agent-native skills add design-exploration`; each installs the exported
-instructions and runs the MCP registration step together.
+for `npx skills add ...`, but the raw `skills` CLI installs instructions only.
+For first-party hosted apps, keep the default docs on
+`npx @agent-native/core@latest skills add assets` and
+`npx @agent-native/core@latest skills add design-exploration`; each installs
+the exported instructions and runs the MCP registration step together.
+
+`npx skills add BuilderIO/agent-native-skills --skill assets` is only valid
+after `BuilderIO/agent-native-skills` exists as a real public GitHub repo, or
+after an equivalent well-known/full-URL source is published. `skills.sh` is a
+discovery and leaderboard directory, not an npm-style package namespace.
 
 The Claude Code marketplace adapter writes
 `adapters/claude-marketplace/.claude-plugin/marketplace.json` plus a nested

--- a/packages/core/docs/content/skills-guide.md
+++ b/packages/core/docs/content/skills-guide.md
@@ -81,18 +81,14 @@ Hosted is the default install path. Local launch is explicit for customization,
 offline work, or privacy-sensitive use.
 
 ```bash
-# Public Skills CLI installs the exported instructions.
-npx skills add BuilderIO/agent-native --skill assets
-npx skills add BuilderIO/agent-native --skill design-exploration
-
-# Local MCP clients also need the hosted connector once.
-npx @agent-native/core@latest connect https://assets.agent-native.com
-npx @agent-native/core@latest connect https://design.agent-native.com
-
-# Convenience installers do both steps for local clients.
+# Happy path: exported instructions plus hosted MCP connector.
 npx @agent-native/core@latest skills add assets
 npx @agent-native/core@latest skills add images
 npx @agent-native/core@latest skills add design-exploration
+
+# Open Skills CLI: exported instructions only.
+npx skills add BuilderIO/agent-native --skill assets
+npx skills add BuilderIO/agent-native --skill design-exploration
 
 # Register a hosted MCP connector for local agent clients.
 agent-native app-skill ensure --manifest templates/assets/agent-native.app-skill.json
@@ -118,8 +114,10 @@ settings flow.
 
 The Vercel Labs `skills` adapter is a portable `skills/<name>/SKILL.md` bundle
 for `npx skills add ...`, but the raw `skills` CLI installs instructions only.
-`BuilderIO/agent-native` is a real GitHub repository source; `skills.sh` is a
-discovery and leaderboard directory, not an npm-style package namespace.
+Keep the Agent Native CLI as the default docs path for local agents because it
+also registers the MCP connector. `BuilderIO/agent-native` is a real GitHub
+repository source for the open Skills CLI; `skills.sh` is a discovery and
+leaderboard directory, not an npm-style package namespace.
 
 The Claude Code marketplace adapter writes
 `adapters/claude-marketplace/.claude-plugin/marketplace.json` plus a nested

--- a/packages/core/docs/content/template-assets.md
+++ b/packages/core/docs/content/template-assets.md
@@ -47,13 +47,25 @@ Use it when your team needs reusable visual direction and searchable source asse
 
 Generate and pick brand media without leaving Codex, Claude Code, Claude, or ChatGPT.
 
-1. **Install once.** This adds the skill instructions and registers the hosted MCP connector together:
+1. **Install once.** This adds the public Assets skill instructions:
 
    ```bash
-   npx @agent-native/core@latest skills add assets   # aliases: images, image-generation
+   npx skills add BuilderIO/agent-native --skill assets
    ```
 
-   Default client is `codex`; add `--client claude-code` or `--client all` for others.
+   For local MCP clients such as Codex or Claude Code, also connect the hosted
+   Assets app once:
+
+   ```bash
+   npx @agent-native/core@latest connect https://assets.agent-native.com
+   ```
+
+   Or use the Agent Native convenience installer when you want one command to
+   install the skill and register the MCP connector together:
+
+   ```bash
+   npx @agent-native/core@latest skills add assets
+   ```
 
 2. **Ask for images.** In your agent's chat: "Generate three blog hero options from the Acme product shots." The agent opens the picker with candidate images you can regenerate, retune (prompt, aspect, count), and choose from.
 3. **Pick.** In inline hosts (ChatGPT, Claude.ai, Claude Desktop main chat) the picker renders right in the chat — click a candidate and the choice flows back automatically. On CLI/link-only hosts (Codex, Claude Code, Claude Desktop "Code" tab) you get an **"Open in Assets →"** link; open it, pick in the browser, then paste the copied handoff summary back into your chat — or just say "use image A".
@@ -142,7 +154,10 @@ The Assets app skill has app id `assets` and hosted MCP URL
 `https://assets.agent-native.com/_agent-native/mcp`.
 
 ```bash
-# Easiest hosted install: exported skill instructions plus MCP connector.
+# Public Skills CLI install: exported skill instructions.
+npx skills add BuilderIO/agent-native --skill assets
+
+# Convenience install: exported skill instructions plus MCP connector.
 npx @agent-native/core@latest skills add assets
 
 # Image-generation alias for demos and tutorials.
@@ -157,7 +172,7 @@ agent-native app-skill launch --manifest templates/assets/agent-native.app-skill
 # Marketplace package, including Claude Code marketplace and Vercel Labs skills adapters.
 agent-native app-skill pack --manifest templates/assets/agent-native.app-skill.json --out ./dist/assets-skill
 
-# Install the exported Assets skill with the open skills CLI.
+# Install a local exported Assets bundle with the open skills CLI.
 npx skills add ./dist/assets-skill --skill assets -a codex -y
 
 # Install from the generated Claude Code marketplace adapter.

--- a/packages/core/docs/content/template-assets.md
+++ b/packages/core/docs/content/template-assets.md
@@ -47,24 +47,18 @@ Use it when your team needs reusable visual direction and searchable source asse
 
 Generate and pick brand media without leaving Codex, Claude Code, Claude, or ChatGPT.
 
-1. **Install once.** This adds the public Assets skill instructions:
+1. **Install once.** This adds the skill instructions and registers the hosted MCP connector together:
+
+   ```bash
+   npx @agent-native/core@latest skills add assets   # aliases: images, image-generation
+   ```
+
+   Default client is `codex`; add `--client claude-code` or `--client all` for others.
+   If you only want the portable skill instructions through the open Skills CLI,
+   use:
 
    ```bash
    npx skills add BuilderIO/agent-native --skill assets
-   ```
-
-   For local MCP clients such as Codex or Claude Code, also connect the hosted
-   Assets app once:
-
-   ```bash
-   npx @agent-native/core@latest connect https://assets.agent-native.com
-   ```
-
-   Or use the Agent Native convenience installer when you want one command to
-   install the skill and register the MCP connector together:
-
-   ```bash
-   npx @agent-native/core@latest skills add assets
    ```
 
 2. **Ask for images.** In your agent's chat: "Generate three blog hero options from the Acme product shots." The agent opens the picker with candidate images you can regenerate, retune (prompt, aspect, count), and choose from.
@@ -154,14 +148,14 @@ The Assets app skill has app id `assets` and hosted MCP URL
 `https://assets.agent-native.com/_agent-native/mcp`.
 
 ```bash
-# Public Skills CLI install: exported skill instructions.
-npx skills add BuilderIO/agent-native --skill assets
-
-# Convenience install: exported skill instructions plus MCP connector.
+# Easiest hosted install: exported skill instructions plus MCP connector.
 npx @agent-native/core@latest skills add assets
 
 # Image-generation alias for demos and tutorials.
 npx @agent-native/core@latest skills add images
+
+# Open Skills CLI install: exported instructions only.
+npx skills add BuilderIO/agent-native --skill assets
 
 # Hosted install: URL-only MCP connector, no shared secrets in skill files.
 agent-native app-skill ensure --manifest templates/assets/agent-native.app-skill.json

--- a/packages/core/docs/content/template-design.md
+++ b/packages/core/docs/content/template-design.md
@@ -23,22 +23,24 @@ Use it when you want a polished landing page concept, product UI direction, bran
    is ready to hand to another tool or teammate.
 
 For Codex, Claude Code, and other local agent clients, the hosted Design app can
-be installed through the open Skills CLI:
+be installed as an app-backed skill plus MCP connector:
+
+```bash
+npx @agent-native/core@latest skills add design-exploration
+```
+
+If you only want the portable skill instructions through the open Skills CLI,
+use:
 
 ```bash
 npx skills add BuilderIO/agent-native --skill design-exploration
 ```
 
-For local MCP clients, also connect the hosted Design app once:
-
-```bash
-npx @agent-native/core@latest connect https://design.agent-native.com
-```
-
-That gives the agent instructions and MCP tools to create a design shell,
-present 2-5 visual directions (3 is the sweet spot) in the inline Design MCP
-app, wait for your pick, and iterate from the selected prototype. See
-[Using it from your coding agent](#coding-agent) for the full flow.
+The Agent Native CLI path gives the agent instructions and MCP tools to create
+a design shell, present 2-5 visual directions (3 is the sweet spot) in the
+inline Design MCP app, wait for your pick, and iterate from the selected
+prototype. See [Using it from your coding agent](#coding-agent) for the full
+flow.
 
 ## Useful Prompts
 
@@ -61,24 +63,18 @@ app, wait for your pick, and iterate from the selected prototype. See
 
 Generate and pick design directions without leaving Codex, Claude Code, Claude, or ChatGPT.
 
-1. **Install once.** This adds the public Design skill instructions:
+1. **Install once.** This adds the skill instructions and registers the hosted MCP connector together:
+
+   ```bash
+   npx @agent-native/core@latest skills add design-exploration   # aliases: design, ux-exploration
+   ```
+
+   Default client is `codex`; add `--client claude-code` or `--client all` for
+   others. If you only want the portable skill instructions through the open
+   Skills CLI, use:
 
    ```bash
    npx skills add BuilderIO/agent-native --skill design-exploration
-   ```
-
-   For local MCP clients such as Codex or Claude Code, also connect the hosted
-   Design app once:
-
-   ```bash
-   npx @agent-native/core@latest connect https://design.agent-native.com
-   ```
-
-   Or use the Agent Native convenience installer when you want one command to
-   install the skill and register the MCP connector together:
-
-   ```bash
-   npx @agent-native/core@latest skills add design-exploration
    ```
 
 2. **Ask for directions.** In your agent's chat: "Create three landing-page directions for a technical analytics product." The agent generates 2-5 directions (3 is the sweet spot) you can compare side by side.

--- a/packages/core/docs/content/template-design.md
+++ b/packages/core/docs/content/template-design.md
@@ -23,16 +23,22 @@ Use it when you want a polished landing page concept, product UI direction, bran
    is ready to hand to another tool or teammate.
 
 For Codex, Claude Code, and other local agent clients, the hosted Design app can
-be installed as an app-backed skill plus MCP connector:
+be installed through the open Skills CLI:
 
 ```bash
-npx @agent-native/core@latest skills add design-exploration
+npx skills add BuilderIO/agent-native --skill design-exploration
 ```
 
-That gives the agent instructions to create a design shell, present 2-5 visual
-directions (3 is the sweet spot) in the inline Design MCP app, wait for your
-pick, and iterate from the selected prototype. See [Using it from your coding
-agent](#coding-agent) for the full flow.
+For local MCP clients, also connect the hosted Design app once:
+
+```bash
+npx @agent-native/core@latest connect https://design.agent-native.com
+```
+
+That gives the agent instructions and MCP tools to create a design shell,
+present 2-5 visual directions (3 is the sweet spot) in the inline Design MCP
+app, wait for your pick, and iterate from the selected prototype. See
+[Using it from your coding agent](#coding-agent) for the full flow.
 
 ## Useful Prompts
 
@@ -55,13 +61,25 @@ agent](#coding-agent) for the full flow.
 
 Generate and pick design directions without leaving Codex, Claude Code, Claude, or ChatGPT.
 
-1. **Install once.** This adds the skill instructions and registers the hosted MCP connector together:
+1. **Install once.** This adds the public Design skill instructions:
 
    ```bash
-   npx @agent-native/core@latest skills add design-exploration   # aliases: design, ux-exploration
+   npx skills add BuilderIO/agent-native --skill design-exploration
    ```
 
-   Default client is `codex`; add `--client claude-code` or `--client all` for others.
+   For local MCP clients such as Codex or Claude Code, also connect the hosted
+   Design app once:
+
+   ```bash
+   npx @agent-native/core@latest connect https://design.agent-native.com
+   ```
+
+   Or use the Agent Native convenience installer when you want one command to
+   install the skill and register the MCP connector together:
+
+   ```bash
+   npx @agent-native/core@latest skills add design-exploration
+   ```
 
 2. **Ask for directions.** In your agent's chat: "Create three landing-page directions for a technical analytics product." The agent generates 2-5 directions (3 is the sweet spot) you can compare side by side.
 3. **Pick.** In inline hosts (ChatGPT, Claude.ai, Claude Desktop main chat) the variant grid renders right in the chat — pick a direction and it auto-persists as `index.html`, then keep refining. On CLI/link-only hosts (Codex, Claude Code, Claude Desktop "Code" tab) you get an **"Open in Design →"** link; open it, pick in the browser, then paste the copied handoff summary back into your chat — or just say "I picked direction B".

--- a/packages/core/src/cli/code-agent-executor.ts
+++ b/packages/core/src/cli/code-agent-executor.ts
@@ -49,6 +49,7 @@ import {
   type CodeAgentPermissionMode,
   type CodeAgentRunRecord,
 } from "./code-agent-runs.js";
+import { createCodeAgentOutputSmoother } from "./code-agent-output-smoother.js";
 
 export interface ExecuteCodeAgentRunOptions {
   runId: string;
@@ -188,10 +189,11 @@ export async function executeCodeAgentRun(
   }
 
   let assistantText = "";
+  const outputSmoother = createCodeAgentOutputSmoother(options.stdout);
   const send = (event: AgentChatEvent) => {
     if (event.type === "text") {
       assistantText += event.text;
-      options.stdout?.write(event.text);
+      outputSmoother.write(event.text);
       return;
     }
     if (event.type === "activity") {
@@ -251,6 +253,7 @@ export async function executeCodeAgentRun(
         reasoningEffort,
       }),
     );
+    await outputSmoother.flush();
     if (assistantText.trim()) {
       options.stdout?.write("\n");
       appendCodeAgentTranscriptEvent({
@@ -350,6 +353,7 @@ export async function executeCodeAgentRun(
       },
     });
   } catch (err) {
+    await outputSmoother.flush().catch(() => undefined);
     const message = err instanceof Error ? err.message : String(err);
     options.stdout?.write(`\nAgent-Native Code run failed: ${message}\n`);
     appendCodeAgentTranscriptEvent({
@@ -374,6 +378,7 @@ export async function executeCodeAgentRun(
       },
     });
   } finally {
+    outputSmoother.cancel();
     options.signal?.removeEventListener("abort", abortFromParent);
     await mcpManager?.stop().catch(() => undefined);
     void running;

--- a/packages/core/src/cli/code-agent-output-smoother.ts
+++ b/packages/core/src/cli/code-agent-output-smoother.ts
@@ -1,0 +1,140 @@
+import {
+  smoothStreamingPunctuationDelayMs,
+  smoothStreamingRevealCount,
+  splitStreamingTextGraphemes,
+} from "../shared/streaming-text-smoothing.js";
+
+export interface CodeAgentOutputSmoother {
+  write(delta: string): void;
+  flush(): Promise<void>;
+  cancel(): void;
+}
+
+const FRAME_DELAY_MS = 16;
+const FLUSH_DEADLINE_MS = 700;
+
+export function createCodeAgentOutputSmoother(
+  output: NodeJS.WritableStream | undefined,
+): CodeAgentOutputSmoother {
+  if (!output || !shouldSmoothOutput(output)) {
+    return {
+      write(delta) {
+        output?.write(delta);
+      },
+      async flush() {},
+      cancel() {},
+    };
+  }
+
+  return new TerminalCodeAgentOutputSmoother(output);
+}
+
+function shouldSmoothOutput(output: NodeJS.WritableStream): boolean {
+  if (process.env.AGENT_NATIVE_SMOOTH_STREAM === "0") return false;
+  if (process.env.CI) return false;
+  return Boolean((output as NodeJS.WriteStream).isTTY);
+}
+
+class TerminalCodeAgentOutputSmoother implements CodeAgentOutputSmoother {
+  private target = "";
+  private graphemes: string[] = [];
+  private visibleCount = 0;
+  private timer: NodeJS.Timeout | null = null;
+  private lastFrameAt = Date.now();
+  private flushDeadline: number | null = null;
+  private flushResolvers: Array<() => void> = [];
+
+  constructor(private readonly output: NodeJS.WritableStream) {}
+
+  write(delta: string): void {
+    if (!delta) return;
+    this.target += delta;
+    this.graphemes = splitStreamingTextGraphemes(this.target);
+    this.schedule(0);
+  }
+
+  flush(): Promise<void> {
+    if (this.visibleCount >= this.graphemes.length) {
+      return Promise.resolve();
+    }
+
+    this.flushDeadline = Date.now() + FLUSH_DEADLINE_MS;
+    this.schedule(0);
+    return new Promise((resolve) => {
+      this.flushResolvers.push(resolve);
+    });
+  }
+
+  cancel(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.resolveFlushes();
+  }
+
+  private schedule(delayMs: number): void {
+    if (this.timer) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.step();
+    }, delayMs);
+  }
+
+  private step(): void {
+    const backlog = this.graphemes.length - this.visibleCount;
+    if (backlog <= 0) {
+      this.flushDeadline = null;
+      this.resolveFlushes();
+      return;
+    }
+
+    const now = Date.now();
+    const forceFlush = this.flushDeadline != null && now >= this.flushDeadline;
+    const elapsedMs = Math.min(
+      120,
+      Math.max(FRAME_DELAY_MS, now - this.lastFrameAt),
+    );
+    this.lastFrameAt = now;
+    const revealCount = forceFlush
+      ? backlog
+      : smoothStreamingRevealCount({
+          backlog,
+          elapsedMs,
+          inputDone: this.flushDeadline != null,
+        });
+
+    if (revealCount > 0) {
+      const nextCount = Math.min(
+        this.graphemes.length,
+        this.visibleCount + revealCount,
+      );
+      const nextText = this.graphemes
+        .slice(this.visibleCount, nextCount)
+        .join("");
+      this.visibleCount = nextCount;
+      if (nextText) this.output.write(nextText);
+    }
+
+    const nextBacklog = this.graphemes.length - this.visibleCount;
+    if (nextBacklog <= 0) {
+      this.flushDeadline = null;
+      this.resolveFlushes();
+      return;
+    }
+
+    const pauseMs =
+      this.flushDeadline == null
+        ? smoothStreamingPunctuationDelayMs(
+            this.graphemes[this.visibleCount - 1],
+            nextBacklog,
+          )
+        : 0;
+    this.schedule(Math.max(FRAME_DELAY_MS, pauseMs));
+  }
+
+  private resolveFlushes(): void {
+    const resolvers = this.flushResolvers.splice(0);
+    for (const resolve of resolvers) resolve();
+  }
+}

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -15,6 +15,7 @@ import {
   useAui,
   useComposer,
   useComposerRuntime,
+  useMessagePartText,
   useMessageRuntime,
   ThreadPrimitive,
   MessagePrimitive,
@@ -29,7 +30,6 @@ import type {
   Attachment,
 } from "@assistant-ui/react";
 import { CompositeAttachmentAdapter } from "@assistant-ui/react";
-import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
@@ -41,6 +41,13 @@ import {
   type AgentDynamicSuggestionsOption,
 } from "./dynamic-suggestions.js";
 import type { ReasoningEffort } from "../shared/reasoning-effort.js";
+import {
+  initialSmoothStreamingGraphemeCount,
+  SMOOTH_STREAMING_COMMIT_INTERVAL_MS,
+  smoothStreamingPunctuationDelayMs,
+  smoothStreamingRevealCount,
+  splitStreamingTextGraphemes,
+} from "../shared/streaming-text-smoothing.js";
 import type { AgentMcpAppPayload } from "../mcp-client/app-result.js";
 import type {
   ChatThreadScope,
@@ -496,6 +503,9 @@ const markdownStyles = `
 .agent-markdown table { border-collapse: collapse; margin: 0.5em 0; font-size: 0.875em; }
 .agent-markdown th, .agent-markdown td { border: 1px solid hsl(var(--border, 0 0% 20%)); padding: 0.35em 0.65em; text-align: left; }
 .agent-markdown th { font-weight: 600; background: hsl(var(--muted, 0 0% 15%)); color: hsl(var(--foreground, 0 0% 90%)); }
+.agent-markdown[data-streaming="true"] > :last-child:not(pre):not(table)::after { content: ""; display: inline-block; width: 0.42em; height: 1em; margin-left: 0.12em; border-radius: 999px; background: currentColor; opacity: 0.35; transform: translateY(0.16em); animation: agent-markdown-stream-caret 1.15s ease-in-out infinite; }
+@keyframes agent-markdown-stream-caret { 0%, 100% { opacity: 0.2; } 50% { opacity: 0.58; } }
+@media (prefers-reduced-motion: reduce) { .agent-markdown[data-streaming="true"] > :last-child:not(pre):not(table)::after { animation: none; opacity: 0.28; } }
 `;
 
 /**
@@ -1050,19 +1060,257 @@ function markdownUrlTransform(value: string): string {
   return defaultUrlTransform(value);
 }
 
-function MarkdownText() {
+const TextStreamingContext = React.createContext(false);
+
+function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return undefined;
+
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handleChange = () => setPrefersReducedMotion(media.matches);
+    handleChange();
+
+    if (typeof media.addEventListener === "function") {
+      media.addEventListener("change", handleChange);
+      return () => media.removeEventListener("change", handleChange);
+    }
+
+    media.addListener(handleChange);
+    return () => media.removeListener(handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+function sliceGraphemes(
+  targetText: string,
+  graphemes: readonly string[],
+  count: number,
+): string {
+  if (count >= graphemes.length) return targetText;
+  if (count <= 0) return "";
+  return graphemes.slice(0, count).join("");
+}
+
+function useSmoothStreamingText(
+  targetText: string,
+  streaming: boolean,
+  resetKey: string,
+): string {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const [visibleText, setVisibleText] = useState(() => {
+    if (!streaming) return targetText;
+    const graphemes = splitStreamingTextGraphemes(targetText);
+    return sliceGraphemes(
+      targetText,
+      graphemes,
+      initialSmoothStreamingGraphemeCount(graphemes),
+    );
+  });
+  const visibleTextRef = useRef(visibleText);
+  const visibleCountRef = useRef(
+    splitStreamingTextGraphemes(visibleText).length,
+  );
+  const targetTextRef = useRef(targetText);
+  const targetGraphemesRef = useRef(splitStreamingTextGraphemes(targetText));
+  const frameRef = useRef<number | null>(null);
+  const lastFrameAtRef = useRef<number | null>(null);
+  const lastCommitAtRef = useRef(0);
+  const pauseUntilRef = useRef(0);
+  const resetKeyRef = useRef(resetKey);
+  const stepRef = useRef<(time: number) => void>(() => {});
+
+  const commitVisibleCount = useCallback((nextCount: number) => {
+    const graphemes = targetGraphemesRef.current;
+    const boundedCount = Math.max(0, Math.min(nextCount, graphemes.length));
+    const nextText = sliceGraphemes(
+      targetTextRef.current,
+      graphemes,
+      boundedCount,
+    );
+    visibleCountRef.current = boundedCount;
+    if (visibleTextRef.current !== nextText) {
+      visibleTextRef.current = nextText;
+      setVisibleText(nextText);
+    }
+  }, []);
+
+  const cancelFrame = useCallback(() => {
+    if (
+      frameRef.current != null &&
+      typeof window !== "undefined" &&
+      typeof window.cancelAnimationFrame === "function"
+    ) {
+      window.cancelAnimationFrame(frameRef.current);
+    }
+    frameRef.current = null;
+    lastFrameAtRef.current = null;
+    pauseUntilRef.current = 0;
+  }, []);
+
+  const scheduleFrame = useCallback(() => {
+    if (frameRef.current != null) return;
+    if (
+      typeof window === "undefined" ||
+      typeof window.requestAnimationFrame !== "function"
+    ) {
+      commitVisibleCount(targetGraphemesRef.current.length);
+      return;
+    }
+
+    frameRef.current = window.requestAnimationFrame((time) => {
+      frameRef.current = null;
+      stepRef.current(time);
+    });
+  }, [commitVisibleCount]);
+
+  stepRef.current = (time) => {
+    const targetGraphemes = targetGraphemesRef.current;
+    const backlog = targetGraphemes.length - visibleCountRef.current;
+    if (backlog <= 0) {
+      lastFrameAtRef.current = null;
+      pauseUntilRef.current = 0;
+      return;
+    }
+
+    if (pauseUntilRef.current > time) {
+      scheduleFrame();
+      return;
+    }
+
+    const lastFrameAt = lastFrameAtRef.current ?? time - 16;
+    lastFrameAtRef.current = time;
+    const revealCount = smoothStreamingRevealCount({
+      backlog,
+      elapsedMs: Math.min(120, Math.max(8, time - lastFrameAt)),
+    });
+
+    if (revealCount > 0) {
+      const nextCount = visibleCountRef.current + revealCount;
+      const shouldCommit =
+        time - lastCommitAtRef.current >= SMOOTH_STREAMING_COMMIT_INTERVAL_MS ||
+        nextCount >= targetGraphemes.length;
+
+      if (shouldCommit) {
+        commitVisibleCount(nextCount);
+        lastCommitAtRef.current = time;
+        const nextBacklog = targetGraphemes.length - visibleCountRef.current;
+        const pauseMs = smoothStreamingPunctuationDelayMs(
+          targetGraphemes[visibleCountRef.current - 1],
+          nextBacklog,
+        );
+        pauseUntilRef.current = pauseMs > 0 ? time + pauseMs : 0;
+      }
+    }
+
+    if (visibleCountRef.current < targetGraphemes.length) {
+      scheduleFrame();
+    } else {
+      lastFrameAtRef.current = null;
+      pauseUntilRef.current = 0;
+    }
+  };
+
+  useEffect(() => {
+    const targetGraphemes = splitStreamingTextGraphemes(targetText);
+    targetTextRef.current = targetText;
+    targetGraphemesRef.current = targetGraphemes;
+
+    const keyChanged = resetKeyRef.current !== resetKey;
+    resetKeyRef.current = resetKey;
+
+    if (!streaming || prefersReducedMotion) {
+      cancelFrame();
+      commitVisibleCount(targetGraphemes.length);
+      return;
+    }
+
+    const visibleNoLongerMatchesTarget =
+      visibleTextRef.current.length > 0 &&
+      !targetText.startsWith(visibleTextRef.current);
+
+    if (
+      keyChanged ||
+      visibleNoLongerMatchesTarget ||
+      visibleCountRef.current > targetGraphemes.length
+    ) {
+      commitVisibleCount(initialSmoothStreamingGraphemeCount(targetGraphemes));
+      lastFrameAtRef.current = null;
+      pauseUntilRef.current = 0;
+    }
+
+    if (visibleCountRef.current < targetGraphemes.length) {
+      scheduleFrame();
+    }
+  }, [
+    targetText,
+    streaming,
+    prefersReducedMotion,
+    resetKey,
+    cancelFrame,
+    commitVisibleCount,
+    scheduleFrame,
+  ]);
+
+  useEffect(() => cancelFrame, [cancelFrame]);
+
+  return visibleText;
+}
+
+function SmoothMarkdownText({
+  text,
+  streaming,
+  resetKey,
+  statusType = "complete",
+}: {
+  text: string;
+  streaming: boolean;
+  resetKey: string;
+  statusType?: string;
+}) {
   useEffect(() => {
     injectMarkdownStyles();
   }, []);
+
+  const visibleText = useSmoothStreamingText(text, streaming, resetKey);
+  const isVisuallyStreaming = streaming && visibleText !== text;
+
   return (
-    <MarkdownTextPrimitive
-      // assistant-ui's smooth renderer can briefly read past its token tap
-      // cache while React is reconciling streamed messages.
-      smooth={false}
+    <div
       className="agent-markdown break-words"
-      remarkPlugins={[remarkGfm]}
-      components={markdownComponents}
-      urlTransform={markdownUrlTransform}
+      data-status={statusType}
+      data-streaming={isVisuallyStreaming ? "true" : undefined}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={markdownComponents}
+        urlTransform={markdownUrlTransform}
+      >
+        {visibleText}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+function MarkdownText() {
+  const textPart = useMessagePartText();
+  const messageRuntime = useMessageRuntime();
+  const message = messageRuntime.getState();
+  const thread = useThread();
+  const textStreaming = React.useContext(TextStreamingContext);
+  const lastMessage = thread.messages[thread.messages.length - 1];
+  const isLastAssistantMessage =
+    message.role === "assistant" && lastMessage?.id === message.id;
+  const statusType = textPart.status?.type ?? message.status.type;
+
+  return (
+    <SmoothMarkdownText
+      text={textPart.text}
+      streaming={textStreaming && isLastAssistantMessage}
+      resetKey={`${message.id}:${statusType}`}
+      statusType={statusType}
     />
   );
 }
@@ -1736,18 +1984,13 @@ function ReconnectStreamMessage({ content }: { content: ContentPart[] }) {
         {content.map((part, i) => {
           if (part.type === "text") {
             return (
-              <div
+              <SmoothMarkdownText
                 key={`reconnect-text-${i}`}
-                className="agent-markdown break-words"
-              >
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  components={markdownComponents}
-                  urlTransform={markdownUrlTransform}
-                >
-                  {part.text}
-                </ReactMarkdown>
-              </div>
+                text={part.text}
+                streaming={chatRunning}
+                resetKey={`reconnect-text-${i}`}
+                statusType={chatRunning ? "running" : "complete"}
+              />
             );
           }
           if (part.type === "tool-call") {
@@ -3521,6 +3764,8 @@ export interface AssistantChatProps {
   loadHistoryRepository?: () => Promise<ExportedMessageRepository | null>;
   /** Re-run `loadHistoryRepository` when the host's external transcript changes. */
   historyReloadKey?: string | number | null;
+  /** Smooth the last assistant message while an external transcript is updating. */
+  externalStreaming?: boolean;
 }
 
 export const CHAT_STORAGE_PREFIX = "agent-chat:";
@@ -3622,6 +3867,7 @@ const AssistantChatInner = forwardRef<
     providerStatusChecksEnabled = true,
     loadHistoryRepository,
     historyReloadKey,
+    externalStreaming = false,
   },
   ref,
 ) {
@@ -3787,6 +4033,7 @@ const AssistantChatInner = forwardRef<
   // to an active run the same as running, UNLESS the user has explicitly
   // clicked stop (forceStopped).
   const isRunning = !forceStopped && (isRuntimeRunning || isReconnecting);
+  const textStreaming = isRunning || externalStreaming;
   // UI-only running state — drives the stop button and thinking indicator.
   const showRunningInUI = isRunning;
   const wasRunningRef = useRef(false);
@@ -4848,7 +5095,7 @@ const AssistantChatInner = forwardRef<
     scrollToBottomAfterPaint,
   } = useNearBottomAutoscroll<HTMLDivElement>({
     followKey: autoscrollFollowKey,
-    streaming: isRunning,
+    streaming: textStreaming,
   });
 
   const scrollToBottomWhileLayoutSettles = useCallback(() => {
@@ -4885,10 +5132,10 @@ const AssistantChatInner = forwardRef<
   }, [isRestoring, scrollToBottomWhileLayoutSettles]);
 
   useEffect(() => {
-    if (!isRunning && isNearBottomRef.current) {
+    if (!textStreaming && isNearBottomRef.current) {
       scrollToBottomAfterPaint();
     }
-  }, [isRunning, scrollToBottomAfterPaint]);
+  }, [textStreaming, scrollToBottomAfterPaint]);
 
   const { isDevMode: cpDevMode } = useDevMode(apiUrl);
   const checkpointCtx = useMemo(
@@ -4983,492 +5230,497 @@ const AssistantChatInner = forwardRef<
     <CheckpointContext.Provider value={checkpointCtx}>
       <MessageActionsContext.Provider value={messageActionsCtx}>
         <ChatRunningContext.Provider value={isRunning}>
-          <div
-            data-agent-empty-state={centeredEmptyState ? "centered" : undefined}
-            className={cn(
-              "relative flex flex-1 flex-col h-full min-h-0 text-foreground",
-              className,
-            )}
-            onDragEnter={handleChatDragEnter}
-            onDragOver={handleChatDragOver}
-            onDragLeave={handleChatDragLeave}
-            onDropCapture={handleChatDropCapture}
-            onDrop={handleChatDrop}
-          >
-            {dropActive && (
-              <div
-                aria-hidden="true"
-                className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center rounded-md border-2 border-dashed border-primary/70 bg-primary/5 backdrop-blur-[1px]"
-              >
-                <span className="rounded-md bg-background/90 px-3 py-1.5 text-xs font-medium text-foreground shadow-sm">
-                  Drop to attach
-                </span>
-              </div>
-            )}
-            {showHeader && (
-              <div className="flex h-11 shrink-0 items-center justify-between border-b border-border px-4">
-                <span className="text-[13px] font-medium text-muted-foreground">
-                  Agent
-                </span>
-                <div className="flex items-center gap-1">
-                  {onSwitchToCli && (
-                    <TooltipProvider delayDuration={200}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            onClick={onSwitchToCli}
-                            aria-label="Switch to CLI"
-                            className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground px-2 py-1 rounded-md hover:bg-accent"
-                          >
-                            <IconTerminal className="h-3.5 w-3.5" />
-                            CLI
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent>Switch to CLI</TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  )}
-                </div>
-              </div>
-            )}
-
-            {/* Messages area */}
+          <TextStreamingContext.Provider value={textStreaming}>
             <div
-              ref={scrollRef}
-              className="agent-chat-scroll flex-1 overflow-y-auto overflow-x-hidden min-h-0"
+              data-agent-empty-state={
+                centeredEmptyState ? "centered" : undefined
+              }
+              className={cn(
+                "relative flex flex-1 flex-col h-full min-h-0 text-foreground",
+                className,
+              )}
+              onDragEnter={handleChatDragEnter}
+              onDragOver={handleChatDragOver}
+              onDragLeave={handleChatDragLeave}
+              onDropCapture={handleChatDropCapture}
+              onDrop={handleChatDrop}
             >
-              {authError ? (
-                <div className="flex flex-col items-center justify-center h-full px-4 gap-3">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-destructive/10">
-                    <IconLock className="h-5 w-5 text-destructive" />
+              {dropActive && (
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center rounded-md border-2 border-dashed border-primary/70 bg-primary/5 backdrop-blur-[1px]"
+                >
+                  <span className="rounded-md bg-background/90 px-3 py-1.5 text-xs font-medium text-foreground shadow-sm">
+                    Drop to attach
+                  </span>
+                </div>
+              )}
+              {showHeader && (
+                <div className="flex h-11 shrink-0 items-center justify-between border-b border-border px-4">
+                  <span className="text-[13px] font-medium text-muted-foreground">
+                    Agent
+                  </span>
+                  <div className="flex items-center gap-1">
+                    {onSwitchToCli && (
+                      <TooltipProvider delayDuration={200}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={onSwitchToCli}
+                              aria-label="Switch to CLI"
+                              className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground px-2 py-1 rounded-md hover:bg-accent"
+                            >
+                              <IconTerminal className="h-3.5 w-3.5" />
+                              CLI
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>Switch to CLI</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    )}
                   </div>
-                  <div className="text-center max-w-[280px]">
-                    <p className="text-sm font-medium text-foreground mb-1">
-                      {authSessionAvailable
-                        ? "Chat session needs refresh"
-                        : authError.sessionExpired
-                          ? "Session expired"
-                          : "Authentication required"}
-                    </p>
-                    <p className="text-xs text-muted-foreground leading-relaxed">
-                      {authSessionAvailable
-                        ? "You're signed in, but this chat connection needs to reconnect."
-                        : authError.sessionExpired
-                          ? "Your session may have expired. Log out and log back in to reconnect."
-                          : "You need to log in to use the agent."}
-                    </p>
-                  </div>
-                  <div className="flex gap-2">
-                    {!authError.sessionExpired && !authSessionAvailable && (
+                </div>
+              )}
+
+              {/* Messages area */}
+              <div
+                ref={scrollRef}
+                className="agent-chat-scroll flex-1 overflow-y-auto overflow-x-hidden min-h-0"
+              >
+                {authError ? (
+                  <div className="flex flex-col items-center justify-center h-full px-4 gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-destructive/10">
+                      <IconLock className="h-5 w-5 text-destructive" />
+                    </div>
+                    <div className="text-center max-w-[280px]">
+                      <p className="text-sm font-medium text-foreground mb-1">
+                        {authSessionAvailable
+                          ? "Chat session needs refresh"
+                          : authError.sessionExpired
+                            ? "Session expired"
+                            : "Authentication required"}
+                      </p>
+                      <p className="text-xs text-muted-foreground leading-relaxed">
+                        {authSessionAvailable
+                          ? "You're signed in, but this chat connection needs to reconnect."
+                          : authError.sessionExpired
+                            ? "Your session may have expired. Log out and log back in to reconnect."
+                            : "You need to log in to use the agent."}
+                      </p>
+                    </div>
+                    <div className="flex gap-2">
+                      {!authError.sessionExpired && !authSessionAvailable && (
+                        <button
+                          onClick={() => {
+                            const ret =
+                              window.location.pathname + window.location.search;
+                            window.location.href =
+                              agentNativePath("/_agent-native/sign-in") +
+                              `?return=${encodeURIComponent(ret)}`;
+                          }}
+                          className="text-xs text-background bg-foreground hover:opacity-90 px-3 py-1.5 rounded-md"
+                        >
+                          Log in
+                        </button>
+                      )}
+                      {authError.sessionExpired && !authSessionAvailable && (
+                        <button
+                          onClick={async () => {
+                            try {
+                              await fetch(
+                                agentNativePath("/_agent-native/auth/logout"),
+                                {
+                                  method: "POST",
+                                },
+                              );
+                            } catch {}
+                            window.location.reload();
+                          }}
+                          className="text-xs text-destructive hover:text-destructive/80 px-3 py-1.5 rounded-md border border-destructive/30 hover:bg-destructive/10"
+                        >
+                          Log out
+                        </button>
+                      )}
                       <button
                         onClick={() => {
-                          const ret =
-                            window.location.pathname + window.location.search;
-                          window.location.href =
-                            agentNativePath("/_agent-native/sign-in") +
-                            `?return=${encodeURIComponent(ret)}`;
-                        }}
-                        className="text-xs text-background bg-foreground hover:opacity-90 px-3 py-1.5 rounded-md"
-                      >
-                        Log in
-                      </button>
-                    )}
-                    {authError.sessionExpired && !authSessionAvailable && (
-                      <button
-                        onClick={async () => {
-                          try {
-                            await fetch(
-                              agentNativePath("/_agent-native/auth/logout"),
-                              {
-                                method: "POST",
-                              },
-                            );
-                          } catch {}
+                          setAuthError(null);
                           window.location.reload();
                         }}
-                        className="text-xs text-destructive hover:text-destructive/80 px-3 py-1.5 rounded-md border border-destructive/30 hover:bg-destructive/10"
+                        className={
+                          authSessionAvailable
+                            ? "text-xs text-background bg-foreground hover:opacity-90 px-3 py-1.5 rounded-md"
+                            : "text-xs text-muted-foreground hover:text-foreground px-3 py-1.5 rounded-md border border-border hover:bg-accent"
+                        }
                       >
-                        Log out
+                        Refresh chat
                       </button>
-                    )}
-                    <button
-                      onClick={() => {
-                        setAuthError(null);
-                        window.location.reload();
-                      }}
-                      className={
-                        authSessionAvailable
-                          ? "text-xs text-background bg-foreground hover:opacity-90 px-3 py-1.5 rounded-md"
-                          : "text-xs text-muted-foreground hover:text-foreground px-3 py-1.5 rounded-md border border-border hover:bg-accent"
-                      }
-                    >
-                      Refresh chat
-                    </button>
-                  </div>
-                </div>
-              ) : missingApiKey && messages.length === 0 ? (
-                <div className="flex flex-col items-center justify-center h-full px-2">
-                  <BuilderSetupCard
-                    onConnected={handleBuilderConnected}
-                    bouncePulse={missingKeyBouncePulse}
-                  />
-                </div>
-              ) : isRestoring ? (
-                <div className="flex flex-col gap-3 p-4">
-                  <div className="flex justify-end">
-                    <div className="h-8 w-32 rounded-lg bg-muted animate-pulse" />
-                  </div>
-                  <div className="flex flex-col gap-1.5">
-                    <div className="h-4 w-48 rounded bg-muted animate-pulse" />
-                    <div className="h-4 w-64 rounded bg-muted animate-pulse" />
-                    <div className="h-4 w-40 rounded bg-muted animate-pulse" />
-                  </div>
-                </div>
-              ) : messages.length === 0 && !isReconnecting ? (
-                <div
-                  className={cn(
-                    "agent-empty-state",
-                    emptyStateDisplay === "hidden"
-                      ? "sr-only"
-                      : "flex h-full flex-col items-center justify-center gap-4 px-4 py-16",
-                  )}
-                >
-                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
-                    <IconMessage className="h-5 w-5 text-muted-foreground" />
-                  </div>
-                  <p className="text-sm text-muted-foreground text-center max-w-[240px]">
-                    {emptyStateText ?? "How can I help you?"}
-                  </p>
-                  {emptyStateAddon}
-                  {resolvedSuggestions && resolvedSuggestions.length > 0 && (
-                    <div className="flex flex-col gap-1.5 w-full max-w-[280px]">
-                      {resolvedSuggestions.map((suggestion) => (
-                        <button
-                          key={suggestion}
-                          onClick={() => {
-                            threadRuntime.append({
-                              role: "user",
-                              content: [{ type: "text", text: suggestion }],
-                            });
-                          }}
-                          className="w-full rounded-lg border border-border px-3 py-2 text-left text-[13px] text-muted-foreground hover:bg-accent hover:text-foreground"
-                        >
-                          {suggestion}
-                        </button>
-                      ))}
                     </div>
-                  )}
-                </div>
-              ) : (
-                <div className="agent-thread-content flex flex-col gap-4 px-4 py-4">
-                  <AssistantMessageListErrorBoundary
-                    resetKey={messageListResetKey}
-                  >
-                    <ThreadPrimitive.Messages
-                      components={{
-                        UserMessage,
-                        AssistantMessage,
-                      }}
-                    />
-                  </AssistantMessageListErrorBoundary>
-                  {missingApiKey && (
+                  </div>
+                ) : missingApiKey && messages.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center h-full px-2">
                     <BuilderSetupCard
                       onConnected={handleBuilderConnected}
                       bouncePulse={missingKeyBouncePulse}
                     />
-                  )}
-                  {visibleLoopLimit && !showRunningInUI && (
-                    <LoopLimitContinueCard
-                      info={visibleLoopLimit}
-                      onContinue={() => {
-                        setShowContinue(false);
-                        setLoopLimitInfo(null);
-                        addToQueue(
-                          "Continue from where you left off.",
-                          undefined,
-                          undefined,
-                          undefined,
-                          undefined,
-                          "queued",
-                          "continue",
-                        );
-                      }}
-                    />
-                  )}
-                  {shouldShowRunError && visibleRunError && (
-                    <RunErrorRecoveryCard
-                      info={visibleRunError}
-                      onContinue={() => {
-                        setRunErrorInfo(null);
-                        addToQueue(
-                          "Continue from where you stopped. Use the partial work above, verify what succeeded, and finish the original request. Do not rerun the exact same failed tool input unless the failure was transient or the user explicitly asked for an exact rerun. Prefer dedicated app actions over raw database edits when they exist.",
-                          undefined,
-                          undefined,
-                          undefined,
-                          undefined,
-                          "queued",
-                          "continue",
-                        );
-                      }}
-                      onRetry={() => {
-                        setRunErrorInfo(null);
-                        addToQueue(
-                          lastUserText
-                            ? `Retry the previous request from a clean approach. Do not rerun the exact same failed tool input unless the failure was transient or the user explicitly asked for an exact rerun. If a provider query failed because of schema, syntax, or type mismatch, diagnose the error and adjust the query first.\n\nOriginal request:\n\n${lastUserText}`
-                            : "Retry the previous request from a clean approach. Do not rerun the exact same failed tool input unless the failure was transient or the user explicitly asked for an exact rerun. If a provider query failed because of schema, syntax, or type mismatch, diagnose the error and adjust the query first.",
-                          undefined,
-                          undefined,
-                          undefined,
-                          undefined,
-                          "queued",
-                          "retry",
-                        );
-                      }}
-                      onFork={onForkChat}
-                      onDismiss={() => {
-                        if (visibleRunErrorKey) {
-                          setDismissedRunErrorKey(visibleRunErrorKey);
-                        }
-                        setRunErrorInfo(null);
-                      }}
-                    />
-                  )}
-                  {(isReconnecting || reconnectFrozen) &&
-                    reconnectContent.length > 0 && (
-                      <ReconnectStreamMessage content={reconnectContent} />
+                  </div>
+                ) : isRestoring ? (
+                  <div className="flex flex-col gap-3 p-4">
+                    <div className="flex justify-end">
+                      <div className="h-8 w-32 rounded-lg bg-muted animate-pulse" />
+                    </div>
+                    <div className="flex flex-col gap-1.5">
+                      <div className="h-4 w-48 rounded bg-muted animate-pulse" />
+                      <div className="h-4 w-64 rounded bg-muted animate-pulse" />
+                      <div className="h-4 w-40 rounded bg-muted animate-pulse" />
+                    </div>
+                  </div>
+                ) : messages.length === 0 && !isReconnecting ? (
+                  <div
+                    className={cn(
+                      "agent-empty-state",
+                      emptyStateDisplay === "hidden"
+                        ? "sr-only"
+                        : "flex h-full flex-col items-center justify-center gap-4 px-4 py-16",
                     )}
-                  {queuedMessages.map((msg) => {
-                    const displayText = msg.text
-                      .replace(/<context>[\s\S]*?<\/context>\n?/g, "")
-                      .trim();
-                    return (
-                      <div key={msg.id} className="flex justify-end group">
-                        <div className="relative max-w-[85%] rounded-lg bg-accent/50 text-foreground/60 px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words">
-                          <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground mb-1 font-medium uppercase tracking-wide">
-                            <IconClock className="h-3 w-3" />
-                            Queued
-                          </div>
-                          {displayText}
-                          {msg.images && msg.images.length > 0 && (
-                            <div className="flex flex-wrap gap-1.5 mt-1.5">
-                              {msg.images.map((img, j) => (
-                                <img
-                                  key={j}
-                                  src={img}
-                                  alt=""
-                                  className="h-12 w-12 rounded object-cover border border-border/50"
-                                />
-                              ))}
-                            </div>
-                          )}
+                  >
+                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+                      <IconMessage className="h-5 w-5 text-muted-foreground" />
+                    </div>
+                    <p className="text-sm text-muted-foreground text-center max-w-[240px]">
+                      {emptyStateText ?? "How can I help you?"}
+                    </p>
+                    {emptyStateAddon}
+                    {resolvedSuggestions && resolvedSuggestions.length > 0 && (
+                      <div className="flex flex-col gap-1.5 w-full max-w-[280px]">
+                        {resolvedSuggestions.map((suggestion) => (
                           <button
-                            type="button"
-                            onClick={() =>
-                              setQueuedMessages((prev) =>
-                                prev.filter((m) => m.id !== msg.id),
-                              )
-                            }
-                            aria-label="Remove from queue"
-                            className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full border border-border bg-background text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-foreground hover:bg-accent shadow-sm"
+                            key={suggestion}
+                            onClick={() => {
+                              threadRuntime.append({
+                                role: "user",
+                                content: [{ type: "text", text: suggestion }],
+                              });
+                            }}
+                            className="w-full rounded-lg border border-border px-3 py-2 text-left text-[13px] text-muted-foreground hover:bg-accent hover:text-foreground"
                           >
-                            <IconX className="h-3 w-3" />
+                            {suggestion}
                           </button>
-                        </div>
+                        ))}
                       </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-
-            {/* Scroll to bottom button */}
-            {showScrollToBottom && (
-              <div className="shrink-0 flex justify-center -mb-1">
-                <button
-                  type="button"
-                  onClick={scrollToBottom}
-                  className="flex h-7 w-7 items-center justify-center rounded-full border border-border bg-background shadow-sm hover:bg-accent"
-                  aria-label="Scroll to bottom"
-                >
-                  <IconChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-                </button>
-              </div>
-            )}
-
-            {composerSlot}
-            {guidedQuestions && guidedQuestions.length > 0 && (
-              <div className="shrink-0 px-3 pb-2 pt-1">
-                <div className="rounded-lg border border-border bg-card/60 shadow-sm">
-                  <GuidedQuestionFlow
-                    questions={guidedQuestions}
-                    onSubmit={handleGuidedQuestionsSubmit}
-                    onSkip={handleGuidedQuestionsSkip}
-                    {...(guidedQuestionsTitle
-                      ? { title: guidedQuestionsTitle }
-                      : {})}
-                    {...(guidedQuestionsDescription
-                      ? { description: guidedQuestionsDescription }
-                      : {})}
-                    {...(guidedQuestionsSkipLabel
-                      ? { skipLabel: guidedQuestionsSkipLabel }
-                      : {})}
-                    {...(guidedQuestionsSubmitLabel
-                      ? { submitLabel: guidedQuestionsSubmitLabel }
-                      : {})}
-                    className="h-auto items-stretch justify-stretch bg-transparent"
-                  />
-                </div>
-              </div>
-            )}
-            {showPlanModeCallout && (
-              <PlanModeCallout
-                canImplementPlan={canImplementPlan}
-                onImplementPlan={handleImplementPlan}
-                onSwitchToAct={handleSwitchToAct}
-              />
-            )}
-            <SelectionAttachedPill />
-            {/* Keep live run progress pinned in the composer footer while the
-                completed/collapsed trail remains attached to the transcript. */}
-            {showRunningInUI && (
-              <RunningActivityStatus
-                steps={activitySteps}
-                label={
-                  isReconnecting
-                    ? "Reconnecting"
-                    : SHOW_AGENT_ACTIVITY_STEPS
-                      ? (activityLabel ?? "Thinking")
-                      : "Thinking"
-                }
-              />
-            )}
-            {/* Input area */}
-            <AgentComposerFrame
-              layoutVariant={composerLayoutVariant}
-              className={cn(
-                composerAreaClassName,
-                missingApiKey && "cursor-pointer",
-                isComposerDisabled && "opacity-70",
-              )}
-              onClick={
-                missingApiKey
-                  ? () => setMissingKeyBouncePulse((p) => p + 1)
-                  : undefined
-              }
-            >
-              <ComposerAttachmentPreviewStrip />
-              <TiptapComposer
-                focusRef={tiptapRef}
-                disabled={isComposerDisabled}
-                placeholder={
-                  missingApiKey
-                    ? "Connect an AI engine above to start chatting…"
-                    : composerDisabled
-                      ? (composerDisabledPlaceholder ??
-                        "Open Desktop to use this chat.")
-                      : isRunning
-                        ? queuedMessages.length > 0
-                          ? `${queuedMessages.length} queued — send a follow-up...`
-                          : "Send a follow-up..."
-                        : composerPlaceholder
-                }
-                onSubmit={
-                  isRunning
-                    ? (text, references, attachments, options) =>
-                        void addToQueue(
-                          text,
-                          undefined,
-                          references.length > 0 ? references : undefined,
-                          attachments,
-                          undefined,
-                          options?.intent ?? "immediate",
-                        )
-                    : undefined
-                }
-                onSlashCommand={onSlashCommand}
-                execMode={execMode}
-                onExecModeChange={onExecModeChange}
-                planModeDisabled={planModeDisabled}
-                planModeDisabledReason={planModeDisabledReason}
-                selectedModel={selectedModel ?? defaultModel}
-                selectedEffort={selectedEffort}
-                availableModels={availableModels}
-                onModelChange={onModelChange}
-                onEffortChange={onEffortChange}
-                onConnectProvider={onConnectProvider}
-                toolbarSlot={composerToolbarSlot}
-                plusMenuMode={plusMenuMode}
-                layoutVariant={composerLayoutVariant}
-                providerConnectStatusEnabled={providerStatusChecksEnabled}
-                draftScope={threadId || tabId}
-                interceptBuildRequestsForBuilder
-                extraActionButton={
-                  composerExtraActionButton || showRunningInUI ? (
-                    <>
-                      {composerExtraActionButton}
-                      {showRunningInUI && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
+                    )}
+                  </div>
+                ) : (
+                  <div className="agent-thread-content flex flex-col gap-4 px-4 py-4">
+                    <AssistantMessageListErrorBoundary
+                      resetKey={messageListResetKey}
+                    >
+                      <ThreadPrimitive.Messages
+                        components={{
+                          UserMessage,
+                          AssistantMessage,
+                        }}
+                      />
+                    </AssistantMessageListErrorBoundary>
+                    {missingApiKey && (
+                      <BuilderSetupCard
+                        onConnected={handleBuilderConnected}
+                        bouncePulse={missingKeyBouncePulse}
+                      />
+                    )}
+                    {visibleLoopLimit && !showRunningInUI && (
+                      <LoopLimitContinueCard
+                        info={visibleLoopLimit}
+                        onContinue={() => {
+                          setShowContinue(false);
+                          setLoopLimitInfo(null);
+                          addToQueue(
+                            "Continue from where you left off.",
+                            undefined,
+                            undefined,
+                            undefined,
+                            undefined,
+                            "queued",
+                            "continue",
+                          );
+                        }}
+                      />
+                    )}
+                    {shouldShowRunError && visibleRunError && (
+                      <RunErrorRecoveryCard
+                        info={visibleRunError}
+                        onContinue={() => {
+                          setRunErrorInfo(null);
+                          addToQueue(
+                            "Continue from where you stopped. Use the partial work above, verify what succeeded, and finish the original request. Do not rerun the exact same failed tool input unless the failure was transient or the user explicitly asked for an exact rerun. Prefer dedicated app actions over raw database edits when they exist.",
+                            undefined,
+                            undefined,
+                            undefined,
+                            undefined,
+                            "queued",
+                            "continue",
+                          );
+                        }}
+                        onRetry={() => {
+                          setRunErrorInfo(null);
+                          addToQueue(
+                            lastUserText
+                              ? `Retry the previous request from a clean approach. Do not rerun the exact same failed tool input unless the failure was transient or the user explicitly asked for an exact rerun. If a provider query failed because of schema, syntax, or type mismatch, diagnose the error and adjust the query first.\n\nOriginal request:\n\n${lastUserText}`
+                              : "Retry the previous request from a clean approach. Do not rerun the exact same failed tool input unless the failure was transient or the user explicitly asked for an exact rerun. If a provider query failed because of schema, syntax, or type mismatch, diagnose the error and adjust the query first.",
+                            undefined,
+                            undefined,
+                            undefined,
+                            undefined,
+                            "queued",
+                            "retry",
+                          );
+                        }}
+                        onFork={onForkChat}
+                        onDismiss={() => {
+                          if (visibleRunErrorKey) {
+                            setDismissedRunErrorKey(visibleRunErrorKey);
+                          }
+                          setRunErrorInfo(null);
+                        }}
+                      />
+                    )}
+                    {(isReconnecting || reconnectFrozen) &&
+                      reconnectContent.length > 0 && (
+                        <ReconnectStreamMessage content={reconnectContent} />
+                      )}
+                    {queuedMessages.map((msg) => {
+                      const displayText = msg.text
+                        .replace(/<context>[\s\S]*?<\/context>\n?/g, "")
+                        .trim();
+                      return (
+                        <div key={msg.id} className="flex justify-end group">
+                          <div className="relative max-w-[85%] rounded-lg bg-accent/50 text-foreground/60 px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words">
+                            <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground mb-1 font-medium uppercase tracking-wide">
+                              <IconClock className="h-3 w-3" />
+                              Queued
+                            </div>
+                            {displayText}
+                            {msg.images && msg.images.length > 0 && (
+                              <div className="flex flex-wrap gap-1.5 mt-1.5">
+                                {msg.images.map((img, j) => (
+                                  <img
+                                    key={j}
+                                    src={img}
+                                    alt=""
+                                    className="h-12 w-12 rounded object-cover border border-border/50"
+                                  />
+                                ))}
+                              </div>
+                            )}
                             <button
                               type="button"
-                              onClick={() => {
-                                // Nuclear stop: flip forceStopped so isRunning is false
-                                // immediately. This unblocks submission even if the
-                                // runtime or reconnect state is stuck.
-                                setForceStopped(true);
-                                const activeRun = getActiveRun();
-                                const runIdToAbort =
-                                  reconnectRunIdRef.current ?? activeRun?.runId;
-                                userStoppedRunRef.current = {
-                                  at: Date.now(),
-                                  ...(runIdToAbort
-                                    ? { runId: runIdToAbort }
-                                    : {}),
-                                };
-                                setRunErrorInfo(null);
-                                setDismissedRunErrorKey(null);
-                                if (runIdToAbort) {
-                                  fetch(
-                                    `${apiUrl}/runs/${encodeURIComponent(runIdToAbort)}/abort`,
-                                    { method: "POST" },
-                                  ).catch(() => {});
-                                }
-
-                                if (isReconnecting) {
-                                  reconnectAbortRef.current?.abort();
-                                  reconnectAbortRef.current = null;
-                                  reconnectRunIdRef.current = null;
-                                  setIsReconnecting(false);
-                                  setReconnectFrozen(
-                                    reconnectContent.length > 0,
-                                  );
-                                }
-
-                                threadRuntime.cancelRun();
-
-                                window.dispatchEvent(
-                                  new CustomEvent("agentNative.chatRunning", {
-                                    detail: {
-                                      isRunning: false,
-                                      tabId: tabId || threadId,
-                                    },
-                                  }),
-                                );
-                              }}
-                              className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md bg-muted text-foreground hover:bg-muted/80"
+                              onClick={() =>
+                                setQueuedMessages((prev) =>
+                                  prev.filter((m) => m.id !== msg.id),
+                                )
+                              }
+                              aria-label="Remove from queue"
+                              className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full border border-border bg-background text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-foreground hover:bg-accent shadow-sm"
                             >
-                              <IconPlayerStop className="h-3.5 w-3.5" />
+                              <IconX className="h-3 w-3" />
                             </button>
-                          </TooltipTrigger>
-                          <TooltipContent>Stop generating</TooltipContent>
-                        </Tooltip>
-                      )}
-                    </>
-                  ) : undefined
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+
+              {/* Scroll to bottom button */}
+              {showScrollToBottom && (
+                <div className="shrink-0 flex justify-center -mb-1">
+                  <button
+                    type="button"
+                    onClick={scrollToBottom}
+                    className="flex h-7 w-7 items-center justify-center rounded-full border border-border bg-background shadow-sm hover:bg-accent"
+                    aria-label="Scroll to bottom"
+                  >
+                    <IconChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                  </button>
+                </div>
+              )}
+
+              {composerSlot}
+              {guidedQuestions && guidedQuestions.length > 0 && (
+                <div className="shrink-0 px-3 pb-2 pt-1">
+                  <div className="rounded-lg border border-border bg-card/60 shadow-sm">
+                    <GuidedQuestionFlow
+                      questions={guidedQuestions}
+                      onSubmit={handleGuidedQuestionsSubmit}
+                      onSkip={handleGuidedQuestionsSkip}
+                      {...(guidedQuestionsTitle
+                        ? { title: guidedQuestionsTitle }
+                        : {})}
+                      {...(guidedQuestionsDescription
+                        ? { description: guidedQuestionsDescription }
+                        : {})}
+                      {...(guidedQuestionsSkipLabel
+                        ? { skipLabel: guidedQuestionsSkipLabel }
+                        : {})}
+                      {...(guidedQuestionsSubmitLabel
+                        ? { submitLabel: guidedQuestionsSubmitLabel }
+                        : {})}
+                      className="h-auto items-stretch justify-stretch bg-transparent"
+                    />
+                  </div>
+                </div>
+              )}
+              {showPlanModeCallout && (
+                <PlanModeCallout
+                  canImplementPlan={canImplementPlan}
+                  onImplementPlan={handleImplementPlan}
+                  onSwitchToAct={handleSwitchToAct}
+                />
+              )}
+              <SelectionAttachedPill />
+              {/* Keep live run progress pinned in the composer footer while the
+                completed/collapsed trail remains attached to the transcript. */}
+              {showRunningInUI && (
+                <RunningActivityStatus
+                  steps={activitySteps}
+                  label={
+                    isReconnecting
+                      ? "Reconnecting"
+                      : SHOW_AGENT_ACTIVITY_STEPS
+                        ? (activityLabel ?? "Thinking")
+                        : "Thinking"
+                  }
+                />
+              )}
+              {/* Input area */}
+              <AgentComposerFrame
+                layoutVariant={composerLayoutVariant}
+                className={cn(
+                  composerAreaClassName,
+                  missingApiKey && "cursor-pointer",
+                  isComposerDisabled && "opacity-70",
+                )}
+                onClick={
+                  missingApiKey
+                    ? () => setMissingKeyBouncePulse((p) => p + 1)
+                    : undefined
                 }
-              />
-            </AgentComposerFrame>
-          </div>
+              >
+                <ComposerAttachmentPreviewStrip />
+                <TiptapComposer
+                  focusRef={tiptapRef}
+                  disabled={isComposerDisabled}
+                  placeholder={
+                    missingApiKey
+                      ? "Connect an AI engine above to start chatting…"
+                      : composerDisabled
+                        ? (composerDisabledPlaceholder ??
+                          "Open Desktop to use this chat.")
+                        : isRunning
+                          ? queuedMessages.length > 0
+                            ? `${queuedMessages.length} queued — send a follow-up...`
+                            : "Send a follow-up..."
+                          : composerPlaceholder
+                  }
+                  onSubmit={
+                    isRunning
+                      ? (text, references, attachments, options) =>
+                          void addToQueue(
+                            text,
+                            undefined,
+                            references.length > 0 ? references : undefined,
+                            attachments,
+                            undefined,
+                            options?.intent ?? "immediate",
+                          )
+                      : undefined
+                  }
+                  onSlashCommand={onSlashCommand}
+                  execMode={execMode}
+                  onExecModeChange={onExecModeChange}
+                  planModeDisabled={planModeDisabled}
+                  planModeDisabledReason={planModeDisabledReason}
+                  selectedModel={selectedModel ?? defaultModel}
+                  selectedEffort={selectedEffort}
+                  availableModels={availableModels}
+                  onModelChange={onModelChange}
+                  onEffortChange={onEffortChange}
+                  onConnectProvider={onConnectProvider}
+                  toolbarSlot={composerToolbarSlot}
+                  plusMenuMode={plusMenuMode}
+                  layoutVariant={composerLayoutVariant}
+                  providerConnectStatusEnabled={providerStatusChecksEnabled}
+                  draftScope={threadId || tabId}
+                  interceptBuildRequestsForBuilder
+                  extraActionButton={
+                    composerExtraActionButton || showRunningInUI ? (
+                      <>
+                        {composerExtraActionButton}
+                        {showRunningInUI && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  // Nuclear stop: flip forceStopped so isRunning is false
+                                  // immediately. This unblocks submission even if the
+                                  // runtime or reconnect state is stuck.
+                                  setForceStopped(true);
+                                  const activeRun = getActiveRun();
+                                  const runIdToAbort =
+                                    reconnectRunIdRef.current ??
+                                    activeRun?.runId;
+                                  userStoppedRunRef.current = {
+                                    at: Date.now(),
+                                    ...(runIdToAbort
+                                      ? { runId: runIdToAbort }
+                                      : {}),
+                                  };
+                                  setRunErrorInfo(null);
+                                  setDismissedRunErrorKey(null);
+                                  if (runIdToAbort) {
+                                    fetch(
+                                      `${apiUrl}/runs/${encodeURIComponent(runIdToAbort)}/abort`,
+                                      { method: "POST" },
+                                    ).catch(() => {});
+                                  }
+
+                                  if (isReconnecting) {
+                                    reconnectAbortRef.current?.abort();
+                                    reconnectAbortRef.current = null;
+                                    reconnectRunIdRef.current = null;
+                                    setIsReconnecting(false);
+                                    setReconnectFrozen(
+                                      reconnectContent.length > 0,
+                                    );
+                                  }
+
+                                  threadRuntime.cancelRun();
+
+                                  window.dispatchEvent(
+                                    new CustomEvent("agentNative.chatRunning", {
+                                      detail: {
+                                        isRunning: false,
+                                        tabId: tabId || threadId,
+                                      },
+                                    }),
+                                  );
+                                }}
+                                className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md bg-muted text-foreground hover:bg-muted/80"
+                              >
+                                <IconPlayerStop className="h-3.5 w-3.5" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent>Stop generating</TooltipContent>
+                          </Tooltip>
+                        )}
+                      </>
+                    ) : undefined
+                  }
+                />
+              </AgentComposerFrame>
+            </div>
+          </TextStreamingContext.Provider>
         </ChatRunningContext.Provider>
       </MessageActionsContext.Provider>
     </CheckpointContext.Provider>

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1116,7 +1116,6 @@ function useSmoothStreamingText(
   const targetTextRef = useRef(targetText);
   const targetGraphemesRef = useRef(splitStreamingTextGraphemes(targetText));
   const frameRef = useRef<number | null>(null);
-  const lastFrameAtRef = useRef<number | null>(null);
   const lastCommitAtRef = useRef(0);
   const pauseUntilRef = useRef(0);
   const resetKeyRef = useRef(resetKey);
@@ -1146,7 +1145,6 @@ function useSmoothStreamingText(
       window.cancelAnimationFrame(frameRef.current);
     }
     frameRef.current = null;
-    lastFrameAtRef.current = null;
     pauseUntilRef.current = 0;
   }, []);
 
@@ -1170,7 +1168,6 @@ function useSmoothStreamingText(
     const targetGraphemes = targetGraphemesRef.current;
     const backlog = targetGraphemes.length - visibleCountRef.current;
     if (backlog <= 0) {
-      lastFrameAtRef.current = null;
       pauseUntilRef.current = 0;
       return;
     }
@@ -1180,35 +1177,35 @@ function useSmoothStreamingText(
       return;
     }
 
-    const lastFrameAt = lastFrameAtRef.current ?? time - 16;
-    lastFrameAtRef.current = time;
+    const lastCommitAt = lastCommitAtRef.current || time - 16;
+    if (
+      time - lastCommitAt < SMOOTH_STREAMING_COMMIT_INTERVAL_MS &&
+      backlog > 1
+    ) {
+      scheduleFrame();
+      return;
+    }
+
     const revealCount = smoothStreamingRevealCount({
       backlog,
-      elapsedMs: Math.min(120, Math.max(8, time - lastFrameAt)),
+      elapsedMs: Math.min(120, Math.max(8, time - lastCommitAt)),
     });
 
     if (revealCount > 0) {
       const nextCount = visibleCountRef.current + revealCount;
-      const shouldCommit =
-        time - lastCommitAtRef.current >= SMOOTH_STREAMING_COMMIT_INTERVAL_MS ||
-        nextCount >= targetGraphemes.length;
-
-      if (shouldCommit) {
-        commitVisibleCount(nextCount);
-        lastCommitAtRef.current = time;
-        const nextBacklog = targetGraphemes.length - visibleCountRef.current;
-        const pauseMs = smoothStreamingPunctuationDelayMs(
-          targetGraphemes[visibleCountRef.current - 1],
-          nextBacklog,
-        );
-        pauseUntilRef.current = pauseMs > 0 ? time + pauseMs : 0;
-      }
+      commitVisibleCount(nextCount);
+      lastCommitAtRef.current = time;
+      const nextBacklog = targetGraphemes.length - visibleCountRef.current;
+      const pauseMs = smoothStreamingPunctuationDelayMs(
+        targetGraphemes[visibleCountRef.current - 1],
+        nextBacklog,
+      );
+      pauseUntilRef.current = pauseMs > 0 ? time + pauseMs : 0;
     }
 
     if (visibleCountRef.current < targetGraphemes.length) {
       scheduleFrame();
     } else {
-      lastFrameAtRef.current = null;
       pauseUntilRef.current = 0;
     }
   };
@@ -1237,7 +1234,7 @@ function useSmoothStreamingText(
       visibleCountRef.current > targetGraphemes.length
     ) {
       commitVisibleCount(initialSmoothStreamingGraphemeCount(targetGraphemes));
-      lastFrameAtRef.current = null;
+      lastCommitAtRef.current = 0;
       pauseUntilRef.current = 0;
     }
 
@@ -1303,7 +1300,8 @@ function MarkdownText() {
   const lastMessage = thread.messages[thread.messages.length - 1];
   const isLastAssistantMessage =
     message.role === "assistant" && lastMessage?.id === message.id;
-  const statusType = textPart.status?.type ?? message.status.type;
+  const statusType =
+    textPart.status?.type ?? message.status?.type ?? "complete";
 
   return (
     <SmoothMarkdownText

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1063,7 +1063,11 @@ function markdownUrlTransform(value: string): string {
 const TextStreamingContext = React.createContext(false);
 
 function usePrefersReducedMotion(): boolean {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() =>
+    typeof window !== "undefined" && window.matchMedia
+      ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      : false,
+  );
 
   useEffect(() => {
     if (typeof window === "undefined" || !window.matchMedia) return undefined;
@@ -1101,7 +1105,7 @@ function useSmoothStreamingText(
 ): string {
   const prefersReducedMotion = usePrefersReducedMotion();
   const [visibleText, setVisibleText] = useState(() => {
-    if (!streaming) return targetText;
+    if (!streaming || prefersReducedMotion) return targetText;
     const graphemes = splitStreamingTextGraphemes(targetText);
     return sliceGraphemes(
       targetText,

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -14,7 +14,20 @@ import { IMMUTABLE_ASSET_CACHE_CONTROL } from "./immutable-assets.js";
 
 const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+const DEFAULT_SSR_CDN_CACHE_CONTROL = DEFAULT_SSR_CACHE_CONTROL;
+const DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL =
+  "public, durable, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 const tempDirs: string[] = [];
+
+function expectDefaultWorkerSsrCacheHeaders(response: Response) {
+  expect(response.headers.get("cache-control")).toBe(DEFAULT_SSR_CACHE_CONTROL);
+  expect(response.headers.get("cdn-cache-control")).toBe(
+    DEFAULT_SSR_CDN_CACHE_CONTROL,
+  );
+  expect(response.headers.get("netlify-cdn-cache-control")).toBe(
+    DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL,
+  );
+}
 
 function makeTempDir(): string {
   const dir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-worker-test-"));
@@ -234,9 +247,7 @@ export default (event) =>
     expect(html).toContain(
       `<meta property="og:image" content="${AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE}">`,
     );
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expectDefaultWorkerSsrCacheHeaders(response);
     expect(response.headers.get("speculation-rules")).toBe(
       '"/docs/_agent-native/speculation-rules.json"',
     );
@@ -262,9 +273,7 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expectDefaultWorkerSsrCacheHeaders(response);
   });
 
   it("overwrites explicit no-store cache policies on Cloudflare worker SSR", async () => {
@@ -276,9 +285,7 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expectDefaultWorkerSsrCacheHeaders(response);
   });
 
   it("replaces React Router's default no-cache policy on Cloudflare worker data responses", async () => {
@@ -290,9 +297,7 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expectDefaultWorkerSsrCacheHeaders(response);
   });
 
   it("replaces default no-cache headers for authenticated Cloudflare worker data responses", async () => {
@@ -306,9 +311,7 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expectDefaultWorkerSsrCacheHeaders(response);
   });
 
   it("overwrites explicit private cache policies on authenticated Cloudflare worker data responses", async () => {
@@ -322,9 +325,7 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expectDefaultWorkerSsrCacheHeaders(response);
   });
 
   it("does not replace no-cache on non-React Router Cloudflare worker data responses", async () => {
@@ -337,6 +338,8 @@ export default (event) =>
     );
 
     expect(response.headers.get("cache-control")).toBe("no-cache");
+    expect(response.headers.get("cdn-cache-control")).toBeNull();
+    expect(response.headers.get("netlify-cdn-cache-control")).toBeNull();
   });
 
   it("keeps public SSR cache headers for anonymous Cloudflare worker preference cookies", async () => {
@@ -351,9 +354,7 @@ export default (event) =>
       {},
     );
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expectDefaultWorkerSsrCacheHeaders(response);
   });
 
   it("adds immutable cache headers to Cloudflare Pages hashed assets only", async () => {
@@ -384,6 +385,9 @@ export default (event) =>
     expect(hashed.headers.get("cdn-cache-control")).toBe(
       IMMUTABLE_ASSET_CACHE_CONTROL,
     );
+    expect(hashed.headers.get("netlify-cdn-cache-control")).toBe(
+      IMMUTABLE_ASSET_CACHE_CONTROL,
+    );
 
     const unhashed = await worker.fetch(
       new Request("https://app.test/docs/assets/logo.png"),
@@ -393,6 +397,7 @@ export default (event) =>
     expect(await unhashed.text()).toBe("asset");
     expect(unhashed.headers.get("cache-control")).toBeNull();
     expect(unhashed.headers.get("cdn-cache-control")).toBeNull();
+    expect(unhashed.headers.get("netlify-cdn-cache-control")).toBeNull();
 
     const manuallyVersioned = await worker.fetch(
       new Request("https://app.test/docs/assets/logo-20240501.png"),
@@ -402,6 +407,9 @@ export default (event) =>
     expect(await manuallyVersioned.text()).toBe("asset");
     expect(manuallyVersioned.headers.get("cache-control")).toBeNull();
     expect(manuallyVersioned.headers.get("cdn-cache-control")).toBeNull();
+    expect(
+      manuallyVersioned.headers.get("netlify-cdn-cache-control"),
+    ).toBeNull();
   });
 
   it("uses the build-time app base path for mounted Cloudflare Pages hashed assets", async () => {
@@ -435,6 +443,9 @@ export default (event) =>
       IMMUTABLE_ASSET_CACHE_CONTROL,
     );
     expect(response.headers.get("cdn-cache-control")).toBe(
+      IMMUTABLE_ASSET_CACHE_CONTROL,
+    );
+    expect(response.headers.get("netlify-cdn-cache-control")).toBe(
       IMMUTABLE_ASSET_CACHE_CONTROL,
     );
   });
@@ -690,6 +701,11 @@ describe("runNitroBuildPipeline", () => {
         "cdn-cache-control"
       ],
     ).toBe(IMMUTABLE_ASSET_CACHE_CONTROL);
+    expect(
+      nitro.options.routeRules["/docs/assets/entry.client-aB12_cdE.js"].headers[
+        "netlify-cdn-cache-control"
+      ],
+    ).toBe(IMMUTABLE_ASSET_CACHE_CONTROL);
     expect(nitro.options.routeRules["/assets/logo.png"]).toBeUndefined();
     expect(
       nitro.options.routeRules["/assets/entry.client-abc.js"],
@@ -712,6 +728,7 @@ describe("runNitroBuildPipeline", () => {
       "cross-origin-resource-policy": "cross-origin",
       "cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
       "cdn-cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
+      "netlify-cdn-cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
     });
   });
 

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -36,6 +36,8 @@ import { generateActionRegistryForProject } from "../vite/action-types-plugin.js
 import { mcpEmbedStaticAssetRouteRules } from "../shared/mcp-embed-headers.js";
 import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
 import {
+  DEFAULT_SSR_CDN_CACHE_CONTROL,
+  DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL,
   DEFAULT_SPECULATION_RULES_PATH,
   DEFAULT_SSR_CACHE_CONTROL,
 } from "../shared/cache-control.js";
@@ -398,6 +400,8 @@ function injectHeadScript(html, script) {
 }
 
 const DEFAULT_SSR_CACHE_CONTROL = ${JSON.stringify(DEFAULT_SSR_CACHE_CONTROL)};
+const DEFAULT_SSR_CDN_CACHE_CONTROL = ${JSON.stringify(DEFAULT_SSR_CDN_CACHE_CONTROL)};
+const DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL = ${JSON.stringify(DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL)};
 const DEFAULT_SPECULATION_RULES_PATH = ${JSON.stringify(DEFAULT_SPECULATION_RULES_PATH)};
 const IMMUTABLE_ASSET_CACHE_CONTROL = ${JSON.stringify(IMMUTABLE_ASSET_CACHE_CONTROL)};
 const IMMUTABLE_ASSET_PATHS = new Set(${JSON.stringify(
@@ -465,6 +469,12 @@ function shouldUseDefaultSsrCacheHeader(headers, status, pathname) {
 function applyDefaultSsrCacheHeader(headers, status, pathname) {
   if (!shouldUseDefaultSsrCacheHeader(headers, status, pathname)) return;
   headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
+  headers.set("cdn-cache-control", DEFAULT_SSR_CDN_CACHE_CONTROL);
+  // Netlify function responses are dynamic by default and can otherwise show
+  // Cache-Status fwd=bypass even with Cache-Control: public. Keep this
+  // Netlify-specific header so SSR HTML/.data are served from the shared
+  // durable CDN cache instead of stampeding origin under logged-in browsers.
+  headers.set("netlify-cdn-cache-control", DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL);
 }
 
 function applyDefaultSpeculationRulesHeader(headers, status, basePath) {
@@ -493,6 +503,7 @@ function applyImmutableAssetCacheHeaders(response, request) {
   const headers = new Headers(response.headers);
   headers.set("Cache-Control", IMMUTABLE_ASSET_CACHE_CONTROL);
   headers.set("CDN-Cache-Control", IMMUTABLE_ASSET_CACHE_CONTROL);
+  headers.set("Netlify-CDN-Cache-Control", IMMUTABLE_ASSET_CACHE_CONTROL);
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/packages/core/src/deploy/immutable-assets.ts
+++ b/packages/core/src/deploy/immutable-assets.ts
@@ -7,6 +7,7 @@ export const IMMUTABLE_ASSET_CACHE_CONTROL =
 export const IMMUTABLE_ASSET_CACHE_HEADERS = {
   "cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
   "cdn-cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
+  "netlify-cdn-cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
 } as const;
 
 export const IMMUTABLE_ASSET_PATH_PATTERN =

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -522,6 +522,9 @@ describe("workspace deploy", () => {
     expect(headers).toContain(
       `cdn-cache-control: ${IMMUTABLE_ASSET_CACHE_CONTROL}`,
     );
+    expect(headers).toContain(
+      `netlify-cdn-cache-control: ${IMMUTABLE_ASSET_CACHE_CONTROL}`,
+    );
     expect(headers).not.toContain("/dispatch/assets/app.js\n");
     expect(fs.existsSync(path.join(tmpDir, "dist", "_routes.json"))).toBe(
       false,
@@ -729,6 +732,7 @@ describe("workspace deploy", () => {
       headers: {
         "cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
         "cdn-cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
+        "netlify-cdn-cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
       },
       continue: true,
     });
@@ -737,6 +741,7 @@ describe("workspace deploy", () => {
       headers: {
         "cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
         "cdn-cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
+        "netlify-cdn-cache-control": IMMUTABLE_ASSET_CACHE_CONTROL,
       },
       continue: true,
     });

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+const DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL =
+  "public, durable, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 
 describe("server/auth", () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -438,6 +440,12 @@ describe("server/auth", () => {
       expect((result as Response).headers.get("Cache-Control")).toBe(
         DEFAULT_SSR_CACHE_CONTROL,
       );
+      expect((result as Response).headers.get("CDN-Cache-Control")).toBe(
+        DEFAULT_SSR_CACHE_CONTROL,
+      );
+      expect(
+        (result as Response).headers.get("Netlify-CDN-Cache-Control"),
+      ).toBe(DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL);
 
       const html = await (result as Response).text();
       expect(html).toContain("Create account");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -109,7 +109,7 @@ import {
   workspaceAppRouteAccessFromEnv,
   type WorkspaceAppAudience,
 } from "../shared/workspace-app-audience.js";
-import { DEFAULT_SSR_CACHE_CONTROL } from "../shared/cache-control.js";
+import { DEFAULT_SSR_CACHE_HEADERS } from "../shared/cache-control.js";
 import { resolveAuthCookieNamespace } from "./cookie-namespace.js";
 import {
   BUILDER_CONNECT_OWNER_COOKIE,
@@ -1309,7 +1309,7 @@ function loginHtmlResponse(loginHtml: string): Response {
     status: 200,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
-      "Cache-Control": DEFAULT_SSR_CACHE_CONTROL,
+      ...DEFAULT_SSR_CACHE_HEADERS,
       "X-Robots-Tag": "noindex, nofollow",
     },
   });

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -136,7 +136,7 @@ import { llmConnectionTrackingProperties } from "../shared/llm-connection.js";
 import { mountBrowserSessionRoutes } from "../browser-sessions/routes.js";
 import { mountDbAdminRoutes } from "../db-admin/routes.js";
 import {
-  DEFAULT_SSR_CACHE_CONTROL,
+  DEFAULT_SSR_CACHE_HEADERS,
   EMPTY_SPECULATION_RULES,
 } from "../shared/cache-control.js";
 
@@ -773,7 +773,11 @@ export function createCoreRoutesPlugin(
             "content-type",
             "application/speculationrules+json; charset=utf-8",
           );
-          setResponseHeader(event, "cache-control", DEFAULT_SSR_CACHE_CONTROL);
+          for (const [name, value] of Object.entries(
+            DEFAULT_SSR_CACHE_HEADERS,
+          )) {
+            setResponseHeader(event, name, value);
+          }
           return EMPTY_SPECULATION_RULES;
         }),
       );

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createH3SSRHandler,
+  DEFAULT_SSR_CACHE_HEADERS,
   DEFAULT_SPECULATION_RULES_HEADER,
   DEFAULT_SSR_CACHE_CONTROL,
 } from "./ssr-handler.js";
@@ -39,6 +40,17 @@ function createEvent(pathname: string, method = "GET", init: RequestInit = {}) {
     url: new URL(url),
     req: new Request(url, { method, ...init }),
   };
+}
+
+function expectDefaultSsrCacheHeaders(response: Response) {
+  for (const [name, value] of Object.entries(DEFAULT_SSR_CACHE_HEADERS)) {
+    expect(response.headers.get(name)).toBe(value);
+  }
+}
+
+function expectNoDefaultCdnCacheHeaders(response: Response) {
+  expect(response.headers.get("cdn-cache-control")).toBeNull();
+  expect(response.headers.get("netlify-cdn-cache-control")).toBeNull();
 }
 
 describe("createH3SSRHandler", () => {
@@ -119,9 +131,7 @@ describe("createH3SSRHandler", () => {
 
     const response = await handler(createEvent("/"));
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expectDefaultSsrCacheHeaders(response);
     expect(response.headers.get("speculation-rules")).toBe(
       DEFAULT_SPECULATION_RULES_HEADER,
     );
@@ -156,9 +166,7 @@ describe("createH3SSRHandler", () => {
 
     const response = await handler(createEvent("/private-html"));
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expectDefaultSsrCacheHeaders(response);
   });
 
   it("replaces React Router's default no-cache policy on .data responses", async () => {
@@ -175,9 +183,7 @@ describe("createH3SSRHandler", () => {
 
     const response = await handler(createEvent("/docs/template-calendar.data"));
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expectDefaultSsrCacheHeaders(response);
   });
 
   it("replaces React Router's default no-cache policy on authenticated .data responses", async () => {
@@ -198,9 +204,7 @@ describe("createH3SSRHandler", () => {
       }),
     );
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expectDefaultSsrCacheHeaders(response);
   });
 
   it("overwrites explicit private cache policies on React Router .data responses", async () => {
@@ -221,9 +225,7 @@ describe("createH3SSRHandler", () => {
       }),
     );
 
-    expect(response.headers.get("cache-control")).toBe(
-      DEFAULT_SSR_CACHE_CONTROL,
-    );
+    expectDefaultSsrCacheHeaders(response);
   });
 
   it("does not replace no-cache on non-React Router .data responses", async () => {
@@ -240,6 +242,7 @@ describe("createH3SSRHandler", () => {
     const response = await handler(createEvent("/custom.data"));
 
     expect(response.headers.get("cache-control")).toBe("no-cache");
+    expectNoDefaultCdnCacheHeaders(response);
   });
 
   it("injects the default social image into SSR HTML without one", async () => {

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -31,11 +31,13 @@ import {
 } from "../shared/embed-auth.js";
 import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
 import {
+  DEFAULT_SSR_CACHE_HEADERS,
   DEFAULT_SPECULATION_RULES_PATH,
   DEFAULT_SSR_CACHE_CONTROL,
 } from "../shared/cache-control.js";
 
 export {
+  DEFAULT_SSR_CACHE_HEADERS,
   DEFAULT_SPECULATION_RULES_HEADER,
   DEFAULT_SSR_CACHE_CONTROL,
 } from "../shared/cache-control.js";
@@ -281,7 +283,14 @@ function applyDefaultSsrCacheHeader(
   ) {
     return;
   }
-  headers.set("cache-control", DEFAULT_SSR_CACHE_CONTROL);
+  // Netlify Functions/proxies are not cached by default, and production docs
+  // requests often carry stale auth/doc cookies. Keep all three cache headers:
+  // Cache-Control for browsers, CDN-Cache-Control for generic CDNs, and
+  // Netlify-CDN-Cache-Control (with durable) so Netlify's shared cache actually
+  // serves SSR HTML/.data instead of forwarding every request to origin.
+  for (const [name, value] of Object.entries(DEFAULT_SSR_CACHE_HEADERS)) {
+    headers.set(name, value);
+  }
 }
 
 function applyDefaultSpeculationRulesHeader(

--- a/packages/core/src/shared/cache-control.ts
+++ b/packages/core/src/shared/cache-control.ts
@@ -1,6 +1,17 @@
 export const DEFAULT_SSR_CACHE_CONTROL =
   "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
 
+export const DEFAULT_SSR_CDN_CACHE_CONTROL = DEFAULT_SSR_CACHE_CONTROL;
+
+export const DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL =
+  "public, durable, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+
+export const DEFAULT_SSR_CACHE_HEADERS = {
+  "cache-control": DEFAULT_SSR_CACHE_CONTROL,
+  "cdn-cache-control": DEFAULT_SSR_CDN_CACHE_CONTROL,
+  "netlify-cdn-cache-control": DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL,
+} as const;
+
 export const DEFAULT_SPECULATION_RULES_PATH =
   "/_agent-native/speculation-rules.json";
 

--- a/packages/core/src/shared/streaming-text-smoothing.spec.ts
+++ b/packages/core/src/shared/streaming-text-smoothing.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  initialSmoothStreamingGraphemeCount,
+  smoothStreamingPunctuationDelayMs,
+  smoothStreamingRevealCount,
+  splitStreamingTextGraphemes,
+} from "./streaming-text-smoothing.js";
+
+describe("streaming text smoothing", () => {
+  it("splits text by grapheme clusters when Intl.Segmenter is available", () => {
+    expect(splitStreamingTextGraphemes("a👍🏽b")).toEqual(["a", "👍🏽", "b"]);
+  });
+
+  it("starts long responses near the tail instead of replaying the full text", () => {
+    const graphemes = Array.from({ length: 700 }, () => "x");
+
+    expect(initialSmoothStreamingGraphemeCount(graphemes)).toBe(520);
+  });
+
+  it("reveals at least one grapheme without exceeding the backlog or burst cap", () => {
+    expect(smoothStreamingRevealCount({ backlog: 10, elapsedMs: 1 })).toBe(1);
+    expect(smoothStreamingRevealCount({ backlog: 4, elapsedMs: 10_000 })).toBe(
+      4,
+    );
+    expect(
+      smoothStreamingRevealCount({ backlog: 2_000, elapsedMs: 10_000 }),
+    ).toBe(120);
+  });
+
+  it("uses punctuation pauses only when the backlog is small", () => {
+    expect(smoothStreamingPunctuationDelayMs(".", 100)).toBe(70);
+    expect(smoothStreamingPunctuationDelayMs(",", 100)).toBe(35);
+    expect(smoothStreamingPunctuationDelayMs("\n", 100)).toBe(80);
+    expect(smoothStreamingPunctuationDelayMs(".", 300)).toBe(0);
+  });
+});

--- a/packages/core/src/shared/streaming-text-smoothing.spec.ts
+++ b/packages/core/src/shared/streaming-text-smoothing.spec.ts
@@ -1,36 +1,51 @@
 import { describe, expect, it } from "vitest";
+
 import {
   initialSmoothStreamingGraphemeCount,
   smoothStreamingPunctuationDelayMs,
   smoothStreamingRevealCount,
   splitStreamingTextGraphemes,
+  SMOOTH_STREAMING_LONG_TEXT_TAIL_GRAPHEMES,
+  SMOOTH_STREAMING_LONG_TEXT_THRESHOLD_GRAPHEMES,
 } from "./streaming-text-smoothing.js";
 
-describe("streaming text smoothing", () => {
-  it("splits text by grapheme clusters when Intl.Segmenter is available", () => {
-    expect(splitStreamingTextGraphemes("a👍🏽b")).toEqual(["a", "👍🏽", "b"]);
+describe("streaming text smoothing helpers", () => {
+  it("splits by grapheme clusters so emoji and accents are not torn apart", () => {
+    expect(splitStreamingTextGraphemes("A👩‍💻é")).toEqual(["A", "👩‍💻", "é"]);
   });
 
-  it("starts long responses near the tail instead of replaying the full text", () => {
-    const graphemes = Array.from({ length: 700 }, () => "x");
+  it("replays short streaming text from the beginning", () => {
+    const graphemes = splitStreamingTextGraphemes("A short answer.");
 
-    expect(initialSmoothStreamingGraphemeCount(graphemes)).toBe(520);
+    expect(initialSmoothStreamingGraphemeCount(graphemes)).toBe(0);
   });
 
-  it("reveals at least one grapheme without exceeding the backlog or burst cap", () => {
-    expect(smoothStreamingRevealCount({ backlog: 10, elapsedMs: 1 })).toBe(1);
-    expect(smoothStreamingRevealCount({ backlog: 4, elapsedMs: 10_000 })).toBe(
-      4,
+  it("keeps only a tail buffered for long restored streams", () => {
+    const text = "x".repeat(SMOOTH_STREAMING_LONG_TEXT_THRESHOLD_GRAPHEMES + 1);
+    const graphemes = splitStreamingTextGraphemes(text);
+
+    expect(initialSmoothStreamingGraphemeCount(graphemes)).toBe(
+      graphemes.length - SMOOTH_STREAMING_LONG_TEXT_TAIL_GRAPHEMES,
     );
-    expect(
-      smoothStreamingRevealCount({ backlog: 2_000, elapsedMs: 10_000 }),
-    ).toBe(120);
   });
 
-  it("uses punctuation pauses only when the backlog is small", () => {
-    expect(smoothStreamingPunctuationDelayMs(".", 100)).toBe(70);
-    expect(smoothStreamingPunctuationDelayMs(",", 100)).toBe(35);
-    expect(smoothStreamingPunctuationDelayMs("\n", 100)).toBe(80);
-    expect(smoothStreamingPunctuationDelayMs(".", 300)).toBe(0);
+  it("reveals at least one grapheme while respecting backlog and burst limits", () => {
+    expect(smoothStreamingRevealCount({ backlog: 12, elapsedMs: 16 })).toBe(1);
+    expect(
+      smoothStreamingRevealCount({
+        backlog: 3,
+        elapsedMs: 1000,
+        inputDone: true,
+      }),
+    ).toBe(3);
+    expect(
+      smoothStreamingRevealCount({ backlog: 2000, elapsedMs: 1000 }),
+    ).toBeLessThanOrEqual(120);
+  });
+
+  it("pauses slightly on punctuation only when backlog is small", () => {
+    expect(smoothStreamingPunctuationDelayMs(".", 8)).toBeGreaterThan(0);
+    expect(smoothStreamingPunctuationDelayMs(",", 8)).toBeGreaterThan(0);
+    expect(smoothStreamingPunctuationDelayMs(".", 500)).toBe(0);
   });
 });

--- a/packages/core/src/shared/streaming-text-smoothing.ts
+++ b/packages/core/src/shared/streaming-text-smoothing.ts
@@ -1,0 +1,92 @@
+export const SMOOTH_STREAMING_COMMIT_INTERVAL_MS = 32;
+export const SMOOTH_STREAMING_LONG_TEXT_THRESHOLD_GRAPHEMES = 640;
+export const SMOOTH_STREAMING_LONG_TEXT_TAIL_GRAPHEMES = 180;
+
+type SegmenterInstance = {
+  segment(input: string): Iterable<{ segment: string }>;
+};
+
+type SegmenterConstructor = new (
+  locales?: string | string[],
+  options?: { granularity?: "grapheme" },
+) => SegmenterInstance;
+
+export function splitStreamingTextGraphemes(text: string): string[] {
+  const Segmenter = (Intl as typeof Intl & { Segmenter?: SegmenterConstructor })
+    .Segmenter;
+  if (Segmenter) {
+    return Array.from(
+      new Segmenter(undefined, { granularity: "grapheme" }).segment(text),
+      (entry) => entry.segment,
+    );
+  }
+
+  return Array.from(text);
+}
+
+export function initialSmoothStreamingGraphemeCount(
+  graphemes: readonly string[],
+): number {
+  if (graphemes.length <= SMOOTH_STREAMING_LONG_TEXT_THRESHOLD_GRAPHEMES) {
+    return 0;
+  }
+
+  return Math.max(
+    0,
+    graphemes.length - SMOOTH_STREAMING_LONG_TEXT_TAIL_GRAPHEMES,
+  );
+}
+
+export function smoothStreamingRevealCount({
+  backlog,
+  elapsedMs,
+  inputDone = false,
+}: {
+  backlog: number;
+  elapsedMs: number;
+  inputDone?: boolean;
+}): number {
+  if (backlog <= 0 || elapsedMs <= 0) {
+    return 0;
+  }
+
+  const charactersPerSecond = inputDone
+    ? backlog > 800
+      ? 900
+      : 420
+    : backlog > 1400
+      ? 640
+      : backlog > 520
+        ? 360
+        : backlog > 180
+          ? 190
+          : 95;
+
+  const maxBurst = inputDone ? 160 : backlog > 1400 ? 120 : 72;
+  const count = Math.floor((elapsedMs / 1000) * charactersPerSecond);
+
+  return Math.min(backlog, Math.max(1, count), maxBurst);
+}
+
+export function smoothStreamingPunctuationDelayMs(
+  grapheme: string | undefined,
+  backlog: number,
+): number {
+  if (!grapheme || backlog > 220) {
+    return 0;
+  }
+
+  if (grapheme === "\n") {
+    return 80;
+  }
+
+  if (/[.!?)]/.test(grapheme)) {
+    return 70;
+  }
+
+  if (/[,;:]/.test(grapheme)) {
+    return 35;
+  }
+
+  return 0;
+}

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -8,7 +8,9 @@ import {
   isRouteErrorResponse,
   useRouteError,
   useLocation,
+  matchRoutes,
 } from "react-router";
+import type { RouteObject } from "react-router";
 import { useState, useEffect, useRef } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AgentSidebar, configureTracking } from "@agent-native/core/client";
@@ -108,6 +110,40 @@ const DATA_ROUTE_PREFETCH_ATTR = "data-an-prefetch";
 const DATA_ROUTE_PREFETCH_SELECTOR = `a[${DATA_ROUTE_PREFETCH_ATTR}="render"][href]`;
 const MAX_CONCURRENT_DATA_PREFETCHES = 4;
 const warmedDataRoutes = new Set<string>();
+const warmedRouteAssets = new Set<string>();
+
+type ReactRouterManifestRoute = {
+  id: string;
+  parentId?: string;
+  path?: string;
+  index?: boolean;
+  module?: string;
+  clientActionModule?: string;
+  clientLoaderModule?: string;
+  hydrateFallbackModule?: string;
+  imports?: string[];
+};
+
+type ReactRouterManifest = {
+  routes?: Record<string, ReactRouterManifestRoute>;
+};
+
+type WarmupRouteObject = {
+  id: string;
+  path?: string;
+  index?: boolean;
+  children?: WarmupRouteObject[];
+};
+
+declare global {
+  interface Window {
+    __reactRouterContext?: { basename?: string };
+    __reactRouterManifest?: ReactRouterManifest;
+  }
+}
+
+let cachedManifest: ReactRouterManifest | undefined;
+let cachedManifestRouteTree: WarmupRouteObject[] = [];
 
 function CanonicalLink() {
   const location = useLocation();
@@ -259,7 +295,112 @@ function dataRouteUrlForHref(href: string): string | null {
   return url.href;
 }
 
-function DataRouteWarmup() {
+function getManifestRouteTree(
+  manifest: ReactRouterManifest,
+): WarmupRouteObject[] {
+  if (manifest === cachedManifest) return cachedManifestRouteTree;
+
+  const manifestRoutes = Object.values(manifest.routes ?? {});
+  const nodes = new Map<string, WarmupRouteObject>();
+  for (const route of manifestRoutes) {
+    nodes.set(route.id, {
+      id: route.id,
+      path: route.path,
+      index: route.index || undefined,
+    });
+  }
+
+  const tree: WarmupRouteObject[] = [];
+  for (const route of manifestRoutes) {
+    const node = nodes.get(route.id);
+    if (!node) continue;
+    const parent = route.parentId ? nodes.get(route.parentId) : null;
+    if (parent) {
+      parent.children ??= [];
+      parent.children.push(node);
+    } else {
+      tree.push(node);
+    }
+  }
+
+  cachedManifest = manifest;
+  cachedManifestRouteTree = tree;
+  return tree;
+}
+
+function assetUrlForManifestPath(assetPath: string): string | null {
+  try {
+    const url = new URL(assetPath, window.location.origin);
+    if (url.origin !== window.location.origin) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+function routeAssetUrlsForHref(href: string): string[] {
+  const manifest = window.__reactRouterManifest;
+  if (!manifest?.routes) return [];
+
+  let url: URL;
+  try {
+    url = new URL(href, window.location.href);
+  } catch {
+    return [];
+  }
+  if (url.origin !== window.location.origin) return [];
+  if (url.pathname === window.location.pathname && url.hash) return [];
+  if (
+    url.pathname.startsWith("/_agent-native/") ||
+    url.pathname.startsWith("/api/")
+  ) {
+    return [];
+  }
+  if (/\.\w+$/.test(url.pathname)) return [];
+
+  const basename = window.__reactRouterContext?.basename || "/";
+  const matches =
+    matchRoutes(
+      getManifestRouteTree(manifest) as unknown as RouteObject[],
+      url.pathname,
+      basename,
+    ) ?? [];
+  const assetUrls: string[] = [];
+
+  for (const match of matches) {
+    const routeId = match.route.id;
+    if (!routeId) continue;
+    const route = manifest.routes[routeId];
+    if (!route) continue;
+    for (const assetPath of [
+      route.module,
+      route.clientActionModule,
+      route.clientLoaderModule,
+      route.hydrateFallbackModule,
+      ...(route.imports ?? []),
+    ]) {
+      if (!assetPath) continue;
+      const assetUrl = assetUrlForManifestPath(assetPath);
+      if (assetUrl) assetUrls.push(assetUrl);
+    }
+  }
+
+  return assetUrls;
+}
+
+function warmRouteAssetsForHref(href: string) {
+  for (const assetUrl of routeAssetUrlsForHref(href)) {
+    if (warmedRouteAssets.has(assetUrl)) continue;
+    warmedRouteAssets.add(assetUrl);
+
+    const link = document.createElement("link");
+    link.rel = "modulepreload";
+    link.href = assetUrl;
+    document.head.appendChild(link);
+  }
+}
+
+function RouteWarmup() {
   useEffect(() => {
     const connection = (
       navigator as Navigator & { connection?: { saveData?: boolean } }
@@ -288,9 +429,16 @@ function DataRouteWarmup() {
     };
 
     const enqueue = () => {
+      for (const link of document.querySelectorAll<HTMLLinkElement>(
+        'link[rel="modulepreload"][href]',
+      )) {
+        warmedRouteAssets.add(link.href);
+      }
+
       for (const link of document.querySelectorAll<HTMLAnchorElement>(
         DATA_ROUTE_PREFETCH_SELECTOR,
       )) {
+        warmRouteAssetsForHref(link.href);
         const dataUrl = dataRouteUrlForHref(link.href);
         if (!dataUrl || warmedDataRoutes.has(dataUrl)) continue;
         warmedDataRoutes.add(dataUrl);
@@ -310,10 +458,10 @@ function DataRouteWarmup() {
     // Do not use React Router's native `prefetch="render"` on the public docs
     // site while it sits behind Cloudflare. Native link prefetches carry
     // `Sec-Purpose: prefetch`; Cloudflare Speed Brain intercepts those and
-    // returns 503 for cache-ineligible dynamic routes before Netlify/origin can
-    // serve the now-cacheable `.data` response. This normal fetch warmup keeps
-    // render-time route-data warming without tripping Cloudflare's prefetch
-    // refusal path.
+    // returns 503 for dynamic routes before Netlify/origin can serve the
+    // now-cacheable `.data` response. This custom warmup uses ordinary fetches
+    // for route data and `modulepreload` for route JS chunks, keeping render-time
+    // navigations fast without re-entering Cloudflare's speculation refusal path.
     schedule();
     const observer = new MutationObserver(schedule);
     observer.observe(document.documentElement, {
@@ -403,7 +551,7 @@ export default function Root() {
   const content = (
     <>
       <ScrollManager />
-      <DataRouteWarmup />
+      <RouteWarmup />
       <Header />
       <Outlet />
       <Footer />

--- a/packages/docs/netlify.toml
+++ b/packages/docs/netlify.toml
@@ -14,24 +14,8 @@
   AGENT_NATIVE_WORKSPACE_APP_AUDIENCE = "public"
   VITE_AGENT_NATIVE_WORKSPACE_APP_AUDIENCE = "public"
 
-# SSR pages: keep browsers fresh, let the CDN serve stale while revalidating.
-[[headers]]
-  for = "/*"
-  [headers.values]
-    Cache-Control = "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600"
-    CDN-Cache-Control = "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600"
-    Netlify-CDN-Cache-Control = "public, durable, max-age=5, stale-while-revalidate=604800, stale-if-error=3600"
-
-# Static assets: immutable long cache
-[[headers]]
-  for = "/assets/*"
-  [headers.values]
-    Cache-Control = "public, max-age=31536000, immutable"
-    CDN-Cache-Control = "public, max-age=31536000, immutable"
-    Netlify-CDN-Cache-Control = "public, max-age=31536000, immutable"
-
-# Agent-native API routes: no caching
-[[headers]]
-  for = "/_agent-native/*"
-  [headers.values]
-    Cache-Control = "no-cache, no-store"
+# Cache headers intentionally live in @agent-native/core instead of this
+# Netlify config. The framework emits SSR HTML/.data SWR headers from the
+# shared server handler and immutable hashed asset headers during build, so
+# docs and templates do not need provider-specific [[headers]] blocks to stay
+# fast or protect private client-side routes.

--- a/packages/docs/netlify.toml
+++ b/packages/docs/netlify.toml
@@ -19,12 +19,16 @@
   for = "/*"
   [headers.values]
     Cache-Control = "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600"
+    CDN-Cache-Control = "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600"
+    Netlify-CDN-Cache-Control = "public, durable, max-age=5, stale-while-revalidate=604800, stale-if-error=3600"
 
 # Static assets: immutable long cache
 [[headers]]
   for = "/assets/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
+    CDN-Cache-Control = "public, max-age=31536000, immutable"
+    Netlify-CDN-Cache-Control = "public, max-age=31536000, immutable"
 
 # Agent-native API routes: no caching
 [[headers]]

--- a/packages/docs/server/routes/[...page].get.ts
+++ b/packages/docs/server/routes/[...page].get.ts
@@ -1,6 +1,6 @@
 import {
   createH3SSRHandler,
-  DEFAULT_SSR_CACHE_CONTROL,
+  DEFAULT_SSR_CACHE_HEADERS,
 } from "@agent-native/core/server/ssr-handler";
 import { buildMarkdownResponseHeaders } from "../../../core/src/agent-web/index";
 import fs from "fs";
@@ -25,7 +25,7 @@ export default async function docsPageHandler(event: H3Event) {
   const agentWebAsset = readAgentWebAssetForRequest(event);
   if (agentWebAsset) {
     setHeader(event, "content-type", agentWebAsset.contentType);
-    setHeader(event, "cache-control", DEFAULT_SSR_CACHE_CONTROL);
+    setDefaultSsrCacheHeaders(event);
     setHeader(event, "link", `<${SITE_URL}/llms.txt>; rel="llms-txt"`);
     return agentWebAsset.content;
   }
@@ -42,7 +42,7 @@ export default async function docsPageHandler(event: H3Event) {
     )) {
       setHeader(event, name, value);
     }
-    setHeader(event, "cache-control", DEFAULT_SSR_CACHE_CONTROL);
+    setDefaultSsrCacheHeaders(event);
     return markdown.content;
   }
 
@@ -51,6 +51,16 @@ export default async function docsPageHandler(event: H3Event) {
   }
 
   return ssrHandler(event);
+}
+
+function setDefaultSsrCacheHeaders(event: H3Event) {
+  // Keep docs-only public text/markdown assets on the same framework SSR cache
+  // policy as HTML and React Router .data. Do not move these back to
+  // netlify.toml: core owns the browser/CDN/Netlify durable header set so every
+  // provider and template gets the same short-fresh/long-SWR behavior.
+  for (const [name, value] of Object.entries(DEFAULT_SSR_CACHE_HEADERS)) {
+    setHeader(event, name, value);
+  }
 }
 
 function readAgentWebAssetForRequest(

--- a/packages/docs/server/routes/[...page].head.ts
+++ b/packages/docs/server/routes/[...page].head.ts
@@ -1,6 +1,6 @@
 import {
   createH3SSRHandler,
-  DEFAULT_SSR_CACHE_CONTROL,
+  DEFAULT_SSR_CACHE_HEADERS,
 } from "@agent-native/core/server/ssr-handler";
 import { estimateMarkdownTokens } from "../../../core/src/agent-web/index";
 import fs from "fs";
@@ -24,7 +24,7 @@ export default async function docsHeadHandler(event: H3Event) {
       "content-length",
       String(Buffer.byteLength(asset.content)),
     );
-    setHeader(event, "cache-control", DEFAULT_SSR_CACHE_CONTROL);
+    setDefaultSsrCacheHeaders(event);
     setHeader(event, "link", `<${SITE_URL}/llms.txt>; rel="llms-txt"`);
     if (asset.contentType.startsWith("text/markdown")) {
       setHeader(
@@ -37,6 +37,15 @@ export default async function docsHeadHandler(event: H3Event) {
   }
 
   return ssrHandler(event);
+}
+
+function setDefaultSsrCacheHeaders(event: H3Event) {
+  // HEAD mirrors the GET cache policy exactly. Keep this tied to the framework
+  // header object instead of app-level provider config so public docs deploys
+  // keep CDN SWR and Netlify durable caching without local header blocks.
+  for (const [name, value] of Object.entries(DEFAULT_SSR_CACHE_HEADERS)) {
+    setHeader(event, name, value);
+  }
 }
 
 function readHeadAssetForRequest(

--- a/skills/assets/SKILL.md
+++ b/skills/assets/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: assets
+description: >-
+  Use Agent Native Assets for brand-safe image and video generation, asset
+  search, export, and human-in-the-loop asset selection through the hosted
+  Assets MCP app.
+metadata:
+  visibility: exported
+---
+
+# Assets
+
+Use Assets when a workflow needs reusable brand media, generated images or
+videos, or a person choosing the final asset from a picker.
+
+## Setup
+
+This skill installs instructions only. The hosted MCP connector must also be
+available in the agent host:
+
+```bash
+npx @agent-native/core@latest connect https://assets.agent-native.com
+```
+
+For cross-app workspace access, connect Dispatch instead:
+
+```bash
+npx @agent-native/core@latest connect https://dispatch.agent-native.com
+```
+
+OAuth-capable hosts can add this remote MCP URL directly:
+
+```text
+https://assets.agent-native.com/_agent-native/mcp
+```
+
+## Use The Picker
+
+Use `open-asset-picker` when a person should browse, search, generate, and
+select an image or video. For generate-and-choose requests, pass:
+
+```json
+{
+  "mediaType": "image",
+  "prompt": "<user prompt>",
+  "autoGenerate": true,
+  "count": 3
+}
+```
+
+Inline MCP hosts render the picker in chat. CLI and code-editor hosts return an
+"Open in Assets ->" link; after the user picks, continue from the pasted handoff
+summary or from a plain-language pick like "use image A".
+
+## Use Direct Actions
+
+Use unattended actions when the agent already knows what to do:
+
+- `search-assets`
+- `list-assets`
+- `list-libraries`
+- `generate-image`
+- `generate-image-batch`
+- `generate-video`
+- `refresh-generation-run`
+- `export-asset`
+
+For images, generation actions are synchronous; use the returned asset fields
+directly. For videos, poll `refresh-generation-run` until the run completes.
+
+Preserve returned `assetId`, `runId`, `previewUrl`, `downloadUrl`, media type,
+dimensions, `presetId`, and `sessionId` when present.
+
+## Guardrails
+
+- Do not call image or video providers directly from another app.
+- Do not treat `images` as the app identity; the app id is `assets`.
+- Do not use picker UI for unattended generation when direct actions are enough.
+- Do not store secrets in skill files; auth belongs in the MCP host.

--- a/skills/design-exploration/SKILL.md
+++ b/skills/design-exploration/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: design-exploration
+description: >-
+  Use Agent Native Design for UI exploration, side-by-side design directions,
+  interactive prototype previews, human selection, iteration, and coding
+  handoff through the hosted Design MCP app.
+metadata:
+  visibility: exported
+---
+
+# Design Exploration
+
+Use Design when a workflow needs complete UI/UX prototypes, several visual
+directions to compare, or a human-in-the-loop pick before implementation.
+
+## Setup
+
+This skill installs instructions only. The hosted MCP connector must also be
+available in the agent host:
+
+```bash
+npx @agent-native/core@latest connect https://design.agent-native.com
+```
+
+For cross-app workspace access, connect Dispatch instead:
+
+```bash
+npx @agent-native/core@latest connect https://dispatch.agent-native.com
+```
+
+OAuth-capable hosts can add this remote MCP URL directly:
+
+```text
+https://design.agent-native.com/_agent-native/mcp
+```
+
+## Exploration Flow
+
+1. Create a project shell with `create-design`.
+2. Generate 2-5 complete HTML directions, three by default.
+3. Call `present-design-variants` with the directions and wait for the user to
+   choose one.
+4. Refine the chosen direction with `get-design-snapshot` and `generate-design`.
+5. Use `export-coding-handoff` when the user wants to implement the result in a
+   codebase.
+
+Inline MCP hosts render the variant picker in chat. CLI and code-editor hosts
+return an "Open in Design ->" link; after the user picks, continue from the
+pasted handoff summary or from a plain-language pick like "use direction B".
+
+## Prototype Rules
+
+- Return complete, self-contained HTML documents.
+- Use Tailwind CSS v4 via `@tailwindcss/browser@4`.
+- Use Alpine.js for interaction.
+- Make variants genuinely distinct in structure, typography, color, and mood.
+- For product/app surfaces, prefer dense, scan-friendly layouts over marketing
+  hero pages.
+- For landing or brand surfaces, use expressive imagery or full-bleed visual
+  scenes rather than generic gradients.
+- Keep text readable, responsive, and non-overlapping on mobile and desktop.
+
+## Guardrails
+
+- Do not call `generate-design` while a variant picker is waiting for a user
+  selection.
+- Do not hardcode secrets or auth material in skill files.
+- Do not skip the user pick for open-ended exploration unless the user asks for
+  a single direction.

--- a/templates/assets/AGENTS.md
+++ b/templates/assets/AGENTS.md
@@ -42,12 +42,13 @@ Read the relevant skill before deeper work:
 
 ## App-Backed Skill Distribution
 
-- The public Skills CLI install path is
-  `npx skills add BuilderIO/agent-native --skill assets`. It installs the
-  exported Assets skill instructions. Local MCP clients also need
-  `npx @agent-native/core@latest connect https://assets.agent-native.com`, or
-  the combined convenience command
-  `npx @agent-native/core@latest skills add assets`.
+- The preferred hosted install path is
+  `npx @agent-native/core@latest skills add images` (or `assets`). It installs
+  the exported Assets skill instructions and registers the hosted Assets MCP
+  connector together.
+- The open Skills CLI path
+  `npx skills add BuilderIO/agent-native --skill assets` installs the
+  exported instructions only.
 - For human-in-the-loop image creation, call `open-asset-picker` with `prompt`,
   `autoGenerate: true`, and `count: 3` so the picker opens with candidates to
   preview, tweak by preset/aspect/count, and choose.

--- a/templates/assets/AGENTS.md
+++ b/templates/assets/AGENTS.md
@@ -42,10 +42,12 @@ Read the relevant skill before deeper work:
 
 ## App-Backed Skill Distribution
 
-- The preferred hosted install path is
-  `npx @agent-native/core@latest skills add images` (or `assets`). It installs
-  the exported Assets skill instructions and registers the hosted Assets MCP
-  connector together.
+- The public Skills CLI install path is
+  `npx skills add BuilderIO/agent-native --skill assets`. It installs the
+  exported Assets skill instructions. Local MCP clients also need
+  `npx @agent-native/core@latest connect https://assets.agent-native.com`, or
+  the combined convenience command
+  `npx @agent-native/core@latest skills add assets`.
 - For human-in-the-loop image creation, call `open-asset-picker` with `prompt`,
   `autoGenerate: true`, and `count: 3` so the picker opens with candidates to
   preview, tweak by preset/aspect/count, and choose.

--- a/templates/calendar/AGENTS.md
+++ b/templates/calendar/AGENTS.md
@@ -23,6 +23,9 @@ Detailed event, availability, booking, storage, and UI rules live in
   applicable.
 - Keep scheduling answers concrete: exact dates, time zones, conflicts, and
   assumptions.
+- Use `rsvp-event` for invitation responses. Pass `note` when the user wants a
+  visible RSVP comment on a declined or tentative response; pass an empty note to
+  clear an existing RSVP comment.
 
 ## Application State
 

--- a/templates/calendar/actions/rsvp-event.ts
+++ b/templates/calendar/actions/rsvp-event.ts
@@ -23,6 +23,13 @@ export default defineAction({
     status: z
       .enum(["accepted", "declined", "tentative"])
       .describe("The RSVP response to set"),
+    note: z
+      .string()
+      .max(1000)
+      .optional()
+      .describe(
+        "Optional RSVP note/comment to show with your response. Pass an empty string to clear it.",
+      ),
     scope: z
       .enum(["single", "all", "thisAndFollowing"])
       .optional()
@@ -52,6 +59,7 @@ export default defineAction({
       args.status,
       accountEmail,
       args.scope,
+      args.note?.trim() ?? args.note,
       args.sendUpdates,
     );
 
@@ -60,6 +68,7 @@ export default defineAction({
       id: `google-${googleEventId}`,
       accountEmail,
       status: args.status,
+      note: args.note?.trim() ?? args.note,
       scope: args.scope,
     };
   },

--- a/templates/calendar/actions/rsvp-event.ts
+++ b/templates/calendar/actions/rsvp-event.ts
@@ -9,7 +9,7 @@ import {
 
 export default defineAction({
   description:
-    "RSVP to a Google Calendar event as accepted, declined, or tentative. Use this when the user asks to accept, decline, or maybe a meeting invitation.",
+    "RSVP to a Google Calendar event as accepted, declined, or tentative, optionally with a response note. Use this when the user asks to accept, decline, or maybe a meeting invitation.",
   schema: z.object({
     id: z
       .string()

--- a/templates/calendar/app/components/calendar/EventAttendeesSection.tsx
+++ b/templates/calendar/app/components/calendar/EventAttendeesSection.tsx
@@ -1,13 +1,15 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { IconMessageCircle, IconUser } from "@tabler/icons-react";
 import type { CalendarEvent } from "@shared/api";
 import { AttendeeApolloPopover } from "@/components/calendar/ApolloPanel";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
 import { useAttendeePhotos } from "@/hooks/use-attendee-photos";
 import { useRsvpEvent } from "@/hooks/use-events";
 import { cn } from "@/lib/utils";
@@ -20,6 +22,7 @@ import {
 type RecurringScope = "single" | "all" | "thisAndFollowing";
 
 type Attendee = NonNullable<CalendarEvent["attendees"]>[number];
+type EditableRsvpStatus = Exclude<RsvpStatus, "needsAction">;
 
 const ATTENDEE_TRUNCATE_THRESHOLD = 5;
 const ATTENDEE_INITIAL_SHOW = 3;
@@ -73,23 +76,27 @@ function RsvpControls({
   eventId,
   accountEmail,
   value,
+  note,
   onChange,
   isRecurring,
 }: {
   eventId: string;
   accountEmail?: string;
   value: RsvpStatus;
-  onChange: (status: RsvpStatus) => void;
+  note?: string;
+  onChange: (status: RsvpStatus, note: string) => void;
   isRecurring?: boolean;
 }) {
   const mutation = useRsvpEvent();
-  const [pendingStatus, setPendingStatus] = useState<Exclude<
-    RsvpStatus,
-    "needsAction"
-  > | null>(null);
+  const noteId = useId();
+  const [pendingStatus, setPendingStatus] = useState<EditableRsvpStatus | null>(
+    null,
+  );
+  const [noteDraft, setNoteDraft] = useState("");
+  const currentNote = note?.trim() ?? "";
 
   const options: Array<{
-    value: Exclude<RsvpStatus, "needsAction">;
+    value: EditableRsvpStatus;
     label: string;
   }> = [
     { value: "accepted", label: "Yes" },
@@ -97,31 +104,49 @@ function RsvpControls({
     { value: "tentative", label: "Maybe" },
   ];
 
+  const supportsNote =
+    pendingStatus === "declined" || pendingStatus === "tentative";
+  const canEditNote = value === "declined" || value === "tentative";
+
+  const closePopover = () => {
+    setPendingStatus(null);
+    setNoteDraft("");
+  };
+
+  const openPopover = (status: EditableRsvpStatus) => {
+    setNoteDraft(status === "accepted" ? "" : currentNote);
+    setPendingStatus(status);
+  };
+
   const doRsvp = (
-    status: Exclude<RsvpStatus, "needsAction">,
+    status: EditableRsvpStatus,
     scope?: RecurringScope,
+    noteValue = noteDraft,
   ) => {
     const previous = value;
-    onChange(status);
+    const previousNote = currentNote;
+    const nextNote = status === "accepted" ? "" : noteValue.trim();
+    onChange(status, nextNote);
     mutation.mutate(
-      { id: eventId, status, accountEmail, scope },
-      { onError: () => onChange(previous) },
+      { id: eventId, status, accountEmail, scope, note: nextNote },
+      { onError: () => onChange(previous, previousNote) },
     );
   };
 
-  const handleRsvp = (status: Exclude<RsvpStatus, "needsAction">) => {
-    if (mutation.isPending || value === status) return;
-    if (isRecurring) {
-      setPendingStatus(status);
-    } else {
-      doRsvp(status);
+  const handleRsvp = (status: EditableRsvpStatus) => {
+    if (mutation.isPending) return;
+    if (isRecurring || status === "declined" || status === "tentative") {
+      openPopover(status);
+      return;
     }
+    if (value === status && !currentNote) return;
+    doRsvp(status, undefined, "");
   };
 
   return (
     <Popover
       open={!!pendingStatus}
-      onOpenChange={(open) => !open && setPendingStatus(null)}
+      onOpenChange={(open) => !open && closePopover()}
     >
       <div className="mt-2 flex items-center gap-1 rounded-2xl bg-muted/60 p-1">
         {options.map((option) => {
@@ -146,7 +171,7 @@ function RsvpControls({
               {option.label}
             </button>
           );
-          if (isRecurring && pendingStatus === option.value) {
+          if (pendingStatus === option.value) {
             return (
               <PopoverTrigger key={option.value} asChild>
                 {btn}
@@ -157,60 +182,130 @@ function RsvpControls({
         })}
       </div>
 
+      {canEditNote && (
+        <button
+          type="button"
+          disabled={mutation.isPending}
+          onClick={(e) => {
+            e.stopPropagation();
+            openPopover(value as EditableRsvpStatus);
+          }}
+          className="mt-1 inline-flex items-center gap-1 rounded-md px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
+        >
+          <IconMessageCircle className="h-3 w-3" />
+          {currentNote ? "Edit note" : "Add note"}
+        </button>
+      )}
+
       <PopoverContent
         side="left"
         align="center"
         sideOffset={8}
-        className="w-64"
+        className="w-72"
         onClick={(e) => e.stopPropagation()}
+        onPointerDownCapture={(e) => e.stopPropagation()}
       >
-        <div className="space-y-2">
-          <div>
-            <p className="text-sm font-medium">This is a recurring event</p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Would you like to change your response for just this event, this
-              and all following events, or all events in the series?
-            </p>
+        {pendingStatus && (
+          <div className="space-y-3">
+            <div>
+              <p className="text-sm font-medium">
+                {isRecurring ? "This is a recurring event" : "Update response"}
+              </p>
+              {isRecurring && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Would you like to change your response for just this event,
+                  this and all following events, or all events in the series?
+                </p>
+              )}
+            </div>
+
+            {supportsNote && (
+              <div className="space-y-1.5">
+                <Label htmlFor={noteId} className="text-xs">
+                  Optional note
+                </Label>
+                <Textarea
+                  id={noteId}
+                  value={noteDraft}
+                  onChange={(e) => setNoteDraft(e.target.value)}
+                  maxLength={1000}
+                  placeholder="Add a short note..."
+                  className="min-h-[76px] resize-none text-sm"
+                />
+              </div>
+            )}
+
+            {isRecurring ? (
+              <div className="space-y-1.5">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full justify-center"
+                  disabled={mutation.isPending}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    doRsvp(pendingStatus, "single");
+                    closePopover();
+                  }}
+                >
+                  This event
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full justify-center"
+                  disabled={mutation.isPending}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    doRsvp(pendingStatus, "thisAndFollowing");
+                    closePopover();
+                  }}
+                >
+                  This and following events
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full justify-center"
+                  disabled={mutation.isPending}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    doRsvp(pendingStatus, "all");
+                    closePopover();
+                  }}
+                >
+                  All events
+                </Button>
+              </div>
+            ) : (
+              <div className="flex justify-end gap-1.5">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    closePopover();
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  className="h-7 text-xs"
+                  disabled={mutation.isPending}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    doRsvp(pendingStatus);
+                    closePopover();
+                  }}
+                >
+                  Save response
+                </Button>
+              </div>
+            )}
           </div>
-          <div className="space-y-1.5">
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full justify-center"
-              onClick={(e) => {
-                e.stopPropagation();
-                doRsvp(pendingStatus!, "single");
-                setPendingStatus(null);
-              }}
-            >
-              This event
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full justify-center"
-              onClick={(e) => {
-                e.stopPropagation();
-                doRsvp(pendingStatus!, "thisAndFollowing");
-                setPendingStatus(null);
-              }}
-            >
-              This and following events
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full justify-center"
-              onClick={(e) => {
-                e.stopPropagation();
-                doRsvp(pendingStatus!, "all");
-                setPendingStatus(null);
-              }}
-            >
-              All events
-            </Button>
-          </div>
-        </div>
+        )}
       </PopoverContent>
     </Popover>
   );
@@ -222,7 +317,8 @@ function AttendeeRow({
   photoUrl,
   inlineRsvp,
   currentStatus,
-  onStatusChange,
+  currentNote,
+  onResponseChange,
   isRecurring,
 }: {
   attendee: Attendee;
@@ -230,16 +326,17 @@ function AttendeeRow({
   photoUrl?: string;
   inlineRsvp?: boolean;
   currentStatus?: RsvpStatus;
-  onStatusChange?: (status: Exclude<RsvpStatus, "needsAction">) => void;
+  currentNote?: string;
+  onResponseChange?: (status: RsvpStatus, note: string) => void;
   isRecurring?: boolean;
 }) {
   const displayStatus = inlineRsvp ? currentStatus : attendee.responseStatus;
   const statusLabel = getRsvpStatusLabel(displayStatus) ?? "Awaiting";
-  const comment = attendee.comment?.trim();
+  const comment = (inlineRsvp ? currentNote : attendee.comment)?.trim();
 
   return (
-    <AttendeeApolloPopover attendee={attendee}>
-      <div className="rounded-xl px-1 py-1 transition-colors hover:bg-muted/40">
+    <div className="rounded-xl px-1 py-1 transition-colors hover:bg-muted/40">
+      <AttendeeApolloPopover attendee={attendee}>
         <div className="flex items-center gap-2.5">
           <div className="relative shrink-0">
             <AttendeeAvatar attendee={attendee} resolvedPhotoUrl={photoUrl} />
@@ -274,17 +371,18 @@ function AttendeeRow({
             <span className="min-w-0 break-words">{comment}</span>
           </div>
         )}
-        {inlineRsvp && currentStatus && onStatusChange && (
-          <RsvpControls
-            eventId={event.id}
-            accountEmail={event.accountEmail}
-            value={currentStatus}
-            onChange={onStatusChange}
-            isRecurring={isRecurring}
-          />
-        )}
-      </div>
-    </AttendeeApolloPopover>
+      </AttendeeApolloPopover>
+      {inlineRsvp && currentStatus && onResponseChange && (
+        <RsvpControls
+          eventId={event.id}
+          accountEmail={event.accountEmail}
+          value={currentStatus}
+          note={currentNote}
+          onChange={onResponseChange}
+          isRecurring={isRecurring}
+        />
+      )}
+    </div>
   );
 }
 
@@ -316,16 +414,26 @@ export function EventAttendeesSection({
   const [selfStatus, setSelfStatus] = useState<RsvpStatus>(
     event.responseStatus || "needsAction",
   );
+  const [selfNote, setSelfNote] = useState(
+    attendees.find((attendee) => attendee.self)?.comment?.trim() ?? "",
+  );
   const emails = attendees.map((attendee) => attendee.email);
   const { data: photos } = useAttendeePhotos(emails);
-
-  useEffect(() => {
-    setSelfStatus(event.responseStatus || "needsAction");
-  }, [event.id, event.responseStatus]);
 
   const sorted = useMemo(() => sortAttendees(attendees), [attendees]);
   const selfAttendee = sorted.find((attendee) => attendee.self);
   const others = sorted.filter((attendee) => !attendee.self);
+
+  useEffect(() => {
+    setSelfStatus(event.responseStatus || "needsAction");
+    setSelfNote(selfAttendee?.comment?.trim() ?? "");
+  }, [event.id, event.responseStatus, selfAttendee?.comment]);
+
+  const handleSelfResponseChange = (status: RsvpStatus, note: string) => {
+    setSelfStatus(status);
+    setSelfNote(note);
+  };
+
   const shouldTruncate = attendees.length > ATTENDEE_TRUNCATE_THRESHOLD;
   const visibleOthers =
     shouldTruncate && !expanded
@@ -397,7 +505,8 @@ export function EventAttendeesSection({
                   photoUrl={photos?.[selfAttendee.email.toLowerCase()]}
                   inlineRsvp={event.source === "google"}
                   currentStatus={selfStatus}
-                  onStatusChange={setSelfStatus}
+                  currentNote={selfNote}
+                  onResponseChange={handleSelfResponseChange}
                   isRecurring={!!event.recurringEventId}
                 />
               </>

--- a/templates/calendar/app/hooks/event-list-cache.ts
+++ b/templates/calendar/app/hooks/event-list-cache.ts
@@ -1,5 +1,8 @@
 import type { CalendarEvent } from "@shared/api";
 
+type RsvpStatus = NonNullable<CalendarEvent["responseStatus"]>;
+type RsvpScope = "single" | "all" | "thisAndFollowing";
+
 export function calendarEventOverlapsListParams(
   event: Pick<CalendarEvent, "start" | "end">,
   params?: Record<string, string>,
@@ -55,5 +58,73 @@ export function removeOptimisticCalendarEventFromList(
 ) {
   return old?.filter(
     (event) => event.id !== optimisticId && event._tempId !== optimisticId,
+  );
+}
+
+function sameRecurringSeries(event: CalendarEvent, target: CalendarEvent) {
+  if (!target.recurringEventId) return false;
+  return event.recurringEventId === target.recurringEventId;
+}
+
+function shouldApplyRsvpToEvent(
+  event: CalendarEvent,
+  target: CalendarEvent,
+  scope: RsvpScope,
+) {
+  if (event.id === target.id) return true;
+  if (scope === "single" || !sameRecurringSeries(event, target)) return false;
+  if (scope === "all") return true;
+
+  const eventStart = Date.parse(event.start);
+  const targetStart = Date.parse(target.start);
+  if (!Number.isFinite(eventStart) || !Number.isFinite(targetStart)) {
+    return false;
+  }
+  return eventStart >= targetStart;
+}
+
+function isSelfAttendee(
+  attendee: NonNullable<CalendarEvent["attendees"]>[number],
+  event: CalendarEvent,
+  accountEmail?: string,
+) {
+  if (attendee.self) return true;
+  const email = (accountEmail || event.accountEmail)?.trim().toLowerCase();
+  return !!email && attendee.email.trim().toLowerCase() === email;
+}
+
+function applyRsvpStatus(
+  event: CalendarEvent,
+  status: RsvpStatus,
+  accountEmail?: string,
+) {
+  const attendees = event.attendees?.map((attendee) =>
+    isSelfAttendee(attendee, event, accountEmail)
+      ? { ...attendee, responseStatus: status }
+      : attendee,
+  );
+  return {
+    ...event,
+    responseStatus: status,
+    attendees,
+  };
+}
+
+export function applyCalendarEventRsvp(
+  old: CalendarEvent[] | undefined,
+  targetId: string,
+  status: RsvpStatus,
+  scope: RsvpScope = "single",
+  accountEmail?: string,
+) {
+  if (!old) return old;
+
+  const target = old.find((event) => event.id === targetId);
+  if (!target) return old;
+
+  return old.map((event) =>
+    shouldApplyRsvpToEvent(event, target, scope)
+      ? applyRsvpStatus(event, status, accountEmail)
+      : event,
   );
 }

--- a/templates/calendar/app/hooks/event-list-cache.ts
+++ b/templates/calendar/app/hooks/event-list-cache.ts
@@ -97,16 +97,22 @@ function applyRsvpStatus(
   event: CalendarEvent,
   status: RsvpStatus,
   accountEmail?: string,
+  note?: string,
 ) {
   const attendees = event.attendees?.map((attendee) =>
     isSelfAttendee(attendee, event, accountEmail)
-      ? { ...attendee, responseStatus: status }
+      ? {
+          ...attendee,
+          responseStatus: status,
+          ...(note !== undefined ? { comment: note || undefined } : {}),
+        }
       : attendee,
   );
   return {
     ...event,
     responseStatus: status,
     attendees,
+    updatedAt: new Date().toISOString(),
   };
 }
 
@@ -116,6 +122,7 @@ export function applyCalendarEventRsvp(
   status: RsvpStatus,
   scope: RsvpScope = "single",
   accountEmail?: string,
+  note?: string,
 ) {
   if (!old) return old;
 
@@ -124,7 +131,7 @@ export function applyCalendarEventRsvp(
 
   return old.map((event) =>
     shouldApplyRsvpToEvent(event, target, scope)
-      ? applyRsvpStatus(event, status, accountEmail)
+      ? applyRsvpStatus(event, status, accountEmail, note)
       : event,
   );
 }

--- a/templates/calendar/app/hooks/use-events.test.ts
+++ b/templates/calendar/app/hooks/use-events.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { CalendarEvent } from "@shared/api";
 import {
+  applyCalendarEventRsvp,
   calendarEventOverlapsListParams,
   mergeCalendarEventIntoList,
   removeOptimisticCalendarEventFromList,
@@ -99,5 +100,85 @@ describe("calendar event list cache helpers", () => {
     );
 
     expect(next?.map((event) => event.id)).toEqual(["event-3"]);
+  });
+
+  it("optimistically updates the event and self attendee RSVP status", () => {
+    const event = calendarEvent({
+      source: "google",
+      accountEmail: "me@example.com",
+      responseStatus: "needsAction",
+      attendees: [
+        {
+          email: "guest@example.com",
+          displayName: "Guest",
+          responseStatus: "accepted",
+        },
+        {
+          email: "me@example.com",
+          displayName: "Me",
+          responseStatus: "needsAction",
+          self: true,
+        },
+      ],
+    });
+
+    const next = applyCalendarEventRsvp(
+      [event],
+      event.id,
+      "declined",
+      "single",
+      "me@example.com",
+    );
+
+    expect(next?.[0]?.responseStatus).toBe("declined");
+    expect(next?.[0]?.attendees?.find((a) => a.self)?.responseStatus).toBe(
+      "declined",
+    );
+    expect(next?.[0]?.attendees?.[0]?.responseStatus).toBe("accepted");
+  });
+
+  it("optimistically updates this and following recurring RSVP instances", () => {
+    const past = calendarEvent({
+      id: "past",
+      recurringEventId: "series-1",
+      start: "2026-05-15T16:00:00.000Z",
+      end: "2026-05-15T17:00:00.000Z",
+      responseStatus: "accepted",
+    });
+    const target = calendarEvent({
+      id: "target",
+      recurringEventId: "series-1",
+      start: "2026-05-22T16:00:00.000Z",
+      end: "2026-05-22T17:00:00.000Z",
+      responseStatus: "accepted",
+    });
+    const future = calendarEvent({
+      id: "future",
+      recurringEventId: "series-1",
+      start: "2026-05-29T16:00:00.000Z",
+      end: "2026-05-29T17:00:00.000Z",
+      responseStatus: "accepted",
+    });
+    const otherSeries = calendarEvent({
+      id: "other-series",
+      recurringEventId: "series-2",
+      start: "2026-05-29T16:00:00.000Z",
+      end: "2026-05-29T17:00:00.000Z",
+      responseStatus: "accepted",
+    });
+
+    const next = applyCalendarEventRsvp(
+      [past, target, future, otherSeries],
+      target.id,
+      "tentative",
+      "thisAndFollowing",
+    );
+
+    expect(next?.map((event) => [event.id, event.responseStatus])).toEqual([
+      ["past", "accepted"],
+      ["target", "tentative"],
+      ["future", "tentative"],
+      ["other-series", "accepted"],
+    ]);
   });
 });

--- a/templates/calendar/app/hooks/use-events.test.ts
+++ b/templates/calendar/app/hooks/use-events.test.ts
@@ -128,13 +128,47 @@ describe("calendar event list cache helpers", () => {
       "declined",
       "single",
       "me@example.com",
+      "I have a conflict",
     );
 
     expect(next?.[0]?.responseStatus).toBe("declined");
-    expect(next?.[0]?.attendees?.find((a) => a.self)?.responseStatus).toBe(
-      "declined",
-    );
+    expect(next?.[0]?.attendees?.find((a) => a.self)).toMatchObject({
+      responseStatus: "declined",
+      comment: "I have a conflict",
+    });
     expect(next?.[0]?.attendees?.[0]?.responseStatus).toBe("accepted");
+  });
+
+  it("optimistically clears a self attendee RSVP note", () => {
+    const event = calendarEvent({
+      source: "google",
+      accountEmail: "me@example.com",
+      responseStatus: "declined",
+      attendees: [
+        {
+          email: "me@example.com",
+          displayName: "Me",
+          responseStatus: "declined",
+          comment: "I have a conflict",
+          self: true,
+        },
+      ],
+    });
+
+    const next = applyCalendarEventRsvp(
+      [event],
+      event.id,
+      "accepted",
+      "single",
+      "me@example.com",
+      "",
+    );
+
+    expect(next?.[0]?.responseStatus).toBe("accepted");
+    expect(next?.[0]?.attendees?.find((a) => a.self)).toMatchObject({
+      responseStatus: "accepted",
+      comment: undefined,
+    });
   });
 
   it("optimistically updates this and following recurring RSVP instances", () => {

--- a/templates/calendar/app/hooks/use-events.ts
+++ b/templates/calendar/app/hooks/use-events.ts
@@ -9,6 +9,7 @@ import { agentNativePath, useActionQuery } from "@agent-native/core/client";
 import { nanoid } from "nanoid";
 import { appApiPath } from "@/lib/api-path";
 import {
+  applyCalendarEventRsvp,
   calendarEventOverlapsListParams,
   mergeCalendarEventIntoList,
   removeOptimisticCalendarEventFromList,
@@ -389,8 +390,44 @@ export function useRsvpEvent() {
       if (!res.ok) throw new Error("Failed to update RSVP");
       return res.json();
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["action", "list-events"] });
+    onMutate: async ({ id, status, accountEmail, scope }) => {
+      await queryClient.cancelQueries({ queryKey: LIST_EVENTS_QUERY_KEY });
+      const previous = queryClient.getQueriesData<CalendarEvent[]>({
+        queryKey: LIST_EVENTS_QUERY_KEY,
+      });
+      const previousEvent = queryClient.getQueryData<CalendarEvent>([
+        "events",
+        id,
+      ]);
+
+      updateListEventQueries(queryClient, (old) =>
+        applyCalendarEventRsvp(old, id, status, scope, accountEmail),
+      );
+      queryClient.setQueryData<CalendarEvent>(["events", id], (old) => {
+        const updated = applyCalendarEventRsvp(
+          old ? [old] : undefined,
+          id,
+          status,
+          scope,
+          accountEmail,
+        );
+        return updated?.[0];
+      });
+
+      return { previous, previousEvent };
+    },
+    onError: (_err, vars, context) => {
+      if (context?.previous) {
+        for (const [key, data] of context.previous) {
+          queryClient.setQueryData(key, data);
+        }
+      }
+      if (context?.previousEvent) {
+        queryClient.setQueryData(["events", vars.id], context.previousEvent);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: LIST_EVENTS_QUERY_KEY });
     },
   });
 }

--- a/templates/calendar/app/hooks/use-events.ts
+++ b/templates/calendar/app/hooks/use-events.ts
@@ -376,21 +376,31 @@ export function useRsvpEvent() {
       status,
       accountEmail,
       scope,
+      note,
+      sendUpdates,
     }: {
       id: string;
       status: "accepted" | "declined" | "tentative";
       accountEmail?: string;
       scope?: "single" | "all" | "thisAndFollowing";
+      note?: string;
+      sendUpdates?: "all" | "none";
     }) => {
       const res = await fetch(appApiPath(`/api/events/${id}/rsvp`), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status, accountEmail, scope }),
+        body: JSON.stringify({
+          status,
+          accountEmail,
+          scope,
+          note,
+          sendUpdates,
+        }),
       });
       if (!res.ok) throw new Error("Failed to update RSVP");
       return res.json();
     },
-    onMutate: async ({ id, status, accountEmail, scope }) => {
+    onMutate: async ({ id, status, accountEmail, scope, note }) => {
       await queryClient.cancelQueries({ queryKey: LIST_EVENTS_QUERY_KEY });
       const previous = queryClient.getQueriesData<CalendarEvent[]>({
         queryKey: LIST_EVENTS_QUERY_KEY,
@@ -401,7 +411,7 @@ export function useRsvpEvent() {
       ]);
 
       updateListEventQueries(queryClient, (old) =>
-        applyCalendarEventRsvp(old, id, status, scope, accountEmail),
+        applyCalendarEventRsvp(old, id, status, scope, accountEmail, note),
       );
       queryClient.setQueryData<CalendarEvent>(["events", id], (old) => {
         const updated = applyCalendarEventRsvp(
@@ -410,6 +420,7 @@ export function useRsvpEvent() {
           status,
           scope,
           accountEmail,
+          note,
         );
         return updated?.[0];
       });
@@ -426,8 +437,9 @@ export function useRsvpEvent() {
         queryClient.setQueryData(["events", vars.id], context.previousEvent);
       }
     },
-    onSettled: () => {
+    onSettled: (_data, _error, vars) => {
       queryClient.invalidateQueries({ queryKey: LIST_EVENTS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: ["events", vars.id] });
     },
   });
 }

--- a/templates/calendar/server/handlers/events.ts
+++ b/templates/calendar/server/handlers/events.ts
@@ -587,6 +587,15 @@ export const rsvpEvent = defineEventHandler(async (event: H3Event) => {
       setResponseStatus(event, 400);
       return { error: "note must be 1000 characters or fewer" };
     }
+    const sendUpdates = body?.sendUpdates;
+    if (
+      sendUpdates !== undefined &&
+      sendUpdates !== "all" &&
+      sendUpdates !== "none"
+    ) {
+      setResponseStatus(event, 400);
+      return { error: "sendUpdates must be all or none" };
+    }
 
     try {
       await googleCalendar.rsvpEvent(
@@ -595,7 +604,7 @@ export const rsvpEvent = defineEventHandler(async (event: H3Event) => {
         acctEmail,
         scope,
         note,
-        body?.sendUpdates,
+        sendUpdates,
       );
     } catch (error: any) {
       setResponseStatus(event, 500);

--- a/templates/calendar/server/handlers/events.ts
+++ b/templates/calendar/server/handlers/events.ts
@@ -578,15 +578,31 @@ export const rsvpEvent = defineEventHandler(async (event: H3Event) => {
     const acctEmail = await resolveAccountEmail(body.accountEmail, email);
 
     const scope = body?.scope || "single";
+    const note = typeof body?.note === "string" ? body.note.trim() : undefined;
+    if (body?.note != null && typeof body.note !== "string") {
+      setResponseStatus(event, 400);
+      return { error: "note must be a string" };
+    }
+    if (note && note.length > 1000) {
+      setResponseStatus(event, 400);
+      return { error: "note must be 1000 characters or fewer" };
+    }
 
     try {
-      await googleCalendar.rsvpEvent(googleEventId, status, acctEmail, scope);
+      await googleCalendar.rsvpEvent(
+        googleEventId,
+        status,
+        acctEmail,
+        scope,
+        note,
+        body?.sendUpdates,
+      );
     } catch (error: any) {
       setResponseStatus(event, 500);
       return { error: `Failed to update RSVP: ${error.message}` };
     }
 
-    return { success: true, status };
+    return { success: true, status, note };
   } catch (error: any) {
     return handleError(event, error);
   }

--- a/templates/calendar/server/lib/google-calendar.spec.ts
+++ b/templates/calendar/server/lib/google-calendar.spec.ts
@@ -46,6 +46,7 @@ import {
   getAuthStatus,
   getFreeBusy,
   getPrimaryAccountPhotoUrl,
+  rsvpEvent,
   updateEvent,
 } from "./google-calendar";
 
@@ -208,6 +209,69 @@ describe("calendar recurring event updates", () => {
         end: { dateTime: "2026-05-06T17:00:00Z" },
       }),
       expect.any(Object),
+    );
+  });
+});
+
+describe("calendar RSVP updates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listOAuthAccountsByOwnerMock.mockResolvedValue([
+      {
+        accountId: "steve@example.com",
+        tokens: {
+          access_token: "access-token",
+          expiry_date: Date.now() + 10 * 60_000,
+        },
+      },
+    ]);
+  });
+
+  it("includes the attendee response note when RSVP-ing", async () => {
+    await rsvpEvent(
+      "event-1",
+      "declined",
+      "steve@example.com",
+      "single",
+      "I have a conflict",
+    );
+
+    expect(calendarPatchEventMock).toHaveBeenCalledWith(
+      "access-token",
+      "primary",
+      "event-1",
+      {
+        attendees: [
+          {
+            email: "steve@example.com",
+            responseStatus: "declined",
+            comment: "I have a conflict",
+          },
+        ],
+        attendeesOmitted: true,
+      },
+      { sendUpdates: "none" },
+    );
+  });
+
+  it("sends an empty comment so an RSVP note can be cleared", async () => {
+    await rsvpEvent("event-1", "accepted", "steve@example.com", "single", "");
+
+    expect(calendarPatchEventMock).toHaveBeenCalledWith(
+      "access-token",
+      "primary",
+      "event-1",
+      {
+        attendees: [
+          {
+            email: "steve@example.com",
+            responseStatus: "accepted",
+            comment: "",
+          },
+        ],
+        attendeesOmitted: true,
+      },
+      { sendUpdates: "none" },
     );
   });
 });

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -1272,6 +1272,7 @@ async function rsvpSingleEvent(
   eventId: string,
   responseStatus: string,
   accountEmail: string,
+  comment?: string,
   sendUpdates?: string,
 ): Promise<void> {
   await calendarPatchEvent(
@@ -1279,7 +1280,13 @@ async function rsvpSingleEvent(
     "primary",
     eventId,
     {
-      attendees: [{ email: accountEmail, responseStatus }],
+      attendees: [
+        {
+          email: accountEmail,
+          responseStatus,
+          ...(comment !== undefined ? { comment } : {}),
+        },
+      ],
       attendeesOmitted: true,
     },
     { sendUpdates: sendUpdates ?? "none" },
@@ -1295,6 +1302,7 @@ export async function rsvpEvent(
   responseStatus: "accepted" | "declined" | "tentative",
   accountEmail: string,
   scope: "single" | "all" | "thisAndFollowing" = "single",
+  comment?: string,
   sendUpdates?: string,
 ): Promise<void> {
   const client = await getClient(accountEmail);
@@ -1308,6 +1316,7 @@ export async function rsvpEvent(
       googleEventId,
       responseStatus,
       accountEmail,
+      comment,
       sendUpdates,
     );
     return;
@@ -1329,6 +1338,7 @@ export async function rsvpEvent(
       recurringEventId,
       responseStatus,
       accountEmail,
+      comment,
       sendUpdates,
     );
     return;
@@ -1363,6 +1373,7 @@ export async function rsvpEvent(
         e.id,
         responseStatus,
         accountEmail,
+        comment,
         sendUpdates,
       ),
     ),

--- a/templates/content/shared/__nfm_probe.test.ts
+++ b/templates/content/shared/__nfm_probe.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from "vitest";
+import fs from "node:fs";
+import {
+  VISUAL_INDENT,
+  parseNfmForEditor,
+  normalizeNfmForStorage,
+  normalizeNfmForNotion,
+  serializeEditorToNfm,
+} from "./notion-markdown";
+
+const out: string[] = [];
+const show = (label: string, s: string) =>
+  out.push(`=== ${label} ===\n${JSON.stringify(s)}`);
+
+describe("probe2", () => {
+  it("runs", () => {
+    // full pull/edit/push cycle for visual indent: editor uses em-space VISUAL_INDENT,
+    // storage uses &emsp; entity. Does a no-edit cycle drift?
+    const nfm = "parent\n\tchild";
+    const editor1 = parseNfmForEditor(nfm); // pull
+    const stored1 = serializeEditorToNfm(editor1); // push back to storage (no edit)
+    const editor2 = parseNfmForEditor(stored1); // pull again
+    const stored2 = serializeEditorToNfm(editor2);
+    show("VI editor1", editor1);
+    show("VI stored1", stored1);
+    show("VI editor2", editor2);
+    show("VI stored2", stored2);
+    show("VI stable?", String(stored1 === stored2));
+
+    // em-space vs entity: what does editor produce and does &emsp; in editor input survive?
+    show("emsp-entity input", parseNfmForEditor("\tchild"));
+    // editor would actually contain the literal em-space char VISUAL_INDENT; feed that back
+    const emspChild = `${VISUAL_INDENT}child`;
+    show("emsp-char back-to-storage", normalizeNfmForStorage(emspChild));
+
+    // block equation idempotency through full cycle
+    const eq = "$$\nx^2\n$$";
+    const e1 = parseNfmForEditor(eq);
+    const st1 = serializeEditorToNfm(e1);
+    show("EQ editor", e1);
+    show("EQ stored", st1);
+
+    // Does normalizeNfmForStorage wreck a block equation? $$ lines look like dividers?
+    show("EQ storage direct", normalizeNfmForStorage(eq));
+
+    // divider after equation - separateDividers won't touch $$ but does --- get mangled
+    // Leading '>' plain text quote that is REAL notion quote becomes tab -> visual indent on pull
+    const q = "> Real quote block";
+    const qe = parseNfmForEditor(q);
+    show("QUOTE editor (pull)", qe);
+    const qs = serializeEditorToNfm(qe);
+    show("QUOTE stored (push)", qs);
+
+    // multi-paragraph that has a line starting with literal '>' as text content (escaped in NFM)
+    show("escaped-gt", normalizeNfmForStorage("\\> not a quote"));
+
+    // empty quote line
+    show("bare-quote->storage", normalizeNfmForStorage(">"));
+
+    // nested list visual-indent insertion blowup: indent text then re-pull
+    const deep = "a\n\tb\n\tc"; // two siblings under a
+    const de = parseNfmForEditor(deep);
+    show("siblings editor", de);
+    const ds = serializeEditorToNfm(de);
+    show("siblings stored", ds);
+
+    // toggle-heading children to Notion: child should be tab-indented under heading;
+    // but it's a {toggle} heading, normalizeDetailsForNotion ignores it
+    const th = '## Section {toggle="true"}\n\tchild line';
+    show("TH storage", normalizeNfmForStorage(th));
+    show("TH notion", normalizeNfmForNotion(th));
+
+    fs.writeFileSync("/tmp/nfm_probe2_out.txt", out.join("\n\n"));
+  });
+});

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -47,10 +47,12 @@ patterns live in `.agents/skills/`.
 
 ## App-Backed Skill Distribution
 
-- The preferred hosted install path is
-  `npx @agent-native/core@latest skills add design-exploration` (or `design`).
-  It installs the exported Design exploration instructions and registers the
-  hosted Design MCP connector together.
+- The public Skills CLI install path is
+  `npx skills add BuilderIO/agent-native --skill design-exploration`. It
+  installs the exported Design exploration instructions. Local MCP clients also
+  need `npx @agent-native/core@latest connect https://design.agent-native.com`,
+  or the combined convenience command
+  `npx @agent-native/core@latest skills add design-exploration`.
 - For human-in-the-loop UI exploration, create a design shell, call
   `present-design-variants` with 2-5 complete HTML directions (three by
   default), wait for the user to pick one, then use `get-design-snapshot` and

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -47,12 +47,13 @@ patterns live in `.agents/skills/`.
 
 ## App-Backed Skill Distribution
 
-- The public Skills CLI install path is
-  `npx skills add BuilderIO/agent-native --skill design-exploration`. It
-  installs the exported Design exploration instructions. Local MCP clients also
-  need `npx @agent-native/core@latest connect https://design.agent-native.com`,
-  or the combined convenience command
-  `npx @agent-native/core@latest skills add design-exploration`.
+- The preferred hosted install path is
+  `npx @agent-native/core@latest skills add design-exploration` (or `design`).
+  It installs the exported Design exploration instructions and registers the
+  hosted Design MCP connector together.
+- The open Skills CLI path
+  `npx skills add BuilderIO/agent-native --skill design-exploration` installs
+  the exported instructions only.
 - For human-in-the-loop UI exploration, create a design shell, call
   `present-design-variants` with 2-5 complete HTML directions (three by
   default), wait for the user to pick one, then use `get-design-snapshot` and

--- a/templates/forms/server/lib/public-form-ssr.ts
+++ b/templates/forms/server/lib/public-form-ssr.ts
@@ -1,7 +1,7 @@
 import { getMethod, getRequestURL, type H3Event } from "h3";
 import { eq } from "drizzle-orm";
 import { getAppBasePath } from "@agent-native/core/server";
-import { DEFAULT_SSR_CACHE_CONTROL } from "@agent-native/core/server/ssr-handler";
+import { DEFAULT_SSR_CACHE_HEADERS } from "@agent-native/core/server/ssr-handler";
 import { getDb, schema } from "../db/index.js";
 import {
   toPublicFormSettings,
@@ -254,7 +254,10 @@ export async function renderPublicForm(event: H3Event) {
     "Content-Security-Policy": "frame-ancestors *",
   };
   if (status === 200) {
-    headers["Cache-Control"] = DEFAULT_SSR_CACHE_CONTROL;
+    // Public form SSR is anonymous HTML and follows the same framework-level
+    // short-fresh/long-SWR policy as React Router SSR. Keep all cache headers
+    // here; relying on provider config would make templates perform differently.
+    Object.assign(headers, DEFAULT_SSR_CACHE_HEADERS);
   }
   return new Response(getMethod(event) === "HEAD" ? null : html, {
     status,


### PR DESCRIPTION
## Summary
- add a framework SSR cache header set: Cache-Control, CDN-Cache-Control, and Netlify-CDN-Cache-Control
- apply durable Netlify CDN caching to HTML, React Router .data, speculation rules, login HTML, docs markdown/llms responses, public form SSR, and immutable hashed assets
- remove docs netlify.toml header blocks so production performance does not depend on app-level provider config
- warm docs route JS with modulepreload alongside ordinary .data fetch warmups, avoiding native prefetch requests that Cloudflare can reject
- include concurrent calendar RSVP improvements from local agents: optimistic event cache updates plus RSVP note/sendUpdates pass-through
- include concurrent core/code-agents streaming smoothing so active assistant output reveals more naturally

## Verification
- pnpm --filter @agent-native/core exec vitest run src/server/request-context.spec.ts src/server/ssr-handler.spec.ts src/deploy/build.spec.ts src/server/auth.spec.ts src/deploy/workspace-deploy.spec.ts
- pnpm --filter @agent-native/core exec vitest run src/shared/streaming-text-smoothing.spec.ts
- pnpm --filter @agent-native/docs typecheck
- pnpm --filter forms typecheck
- pnpm --filter calendar typecheck
- pnpm --filter calendar exec vitest run app/hooks/use-events.test.ts server/lib/google-calendar.spec.ts
- pnpm --filter @agent-native/code-agents-ui typecheck
- pnpm --filter @agent-native/core typecheck
- git diff --check
- NITRO_PRESET=netlify pnpm --filter @agent-native/docs build
- local Nitro preview curl: / and /docs/template-calendar.data return Cache-Control, CDN-Cache-Control, and Netlify-CDN-Cache-Control with SWR + durable
- in-app browser on the built docs homepage observed 25 .data fetch warmups and 12 route-specific JS modulepreload warmups

## Production context
After PR #999 deployed, live HTML and .data had SWR headers and browser warmup requests were 200, but Netlify still reported fwd=bypass. This PR adds the Netlify durable CDN header in framework code, keeps hashed asset immutability in generated build headers, and removes the docs-specific Netlify header blocks so the fix is not only working because of netlify.toml.