### PR TITLE
Fix cache feedback follow-up

### DIFF
--- a/.agents/skills/a2a-protocol/SKILL.md
+++ b/.agents/skills/a2a-protocol/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   How agents call other agents via the A2A (agent-to-agent) JSON-RPC protocol.
   Use when enabling inter-agent communication, exposing agent skills to other
   agents, or calling external agents from scripts.
+metadata:
+  internal: true
 ---
 
 # A2A Protocol (Agent-to-Agent)

--- a/.agents/skills/actions/SKILL.md
+++ b/.agents/skills/actions/SKILL.md
@@ -5,6 +5,8 @@ description: >-
   for app operations — the agent calls them as tools, the frontend calls them
   as HTTP endpoints. Use when creating a new action, adding an API integration,
   or wiring up frontend data fetching.
+metadata:
+  internal: true
 ---
 
 # Agent Actions

--- a/.agents/skills/adding-a-feature/SKILL.md
+++ b/.agents/skills/adding-a-feature/SKILL.md
@@ -3,6 +3,8 @@ name: adding-a-feature
 description: >-
   The four-area checklist every new feature must complete. Use when adding any
   feature, integration, or capability to ensure the agent and UI stay in parity.
+metadata:
+  internal: true
 ---
 
 # Adding a Feature — The Four-Area Checklist

--- a/.agents/skills/address-feedback/SKILL.md
+++ b/.agents/skills/address-feedback/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   Triage feedback docs or pasted feedback into bugs to fix, UX suggestions to
   propose, unclear questions, and skipped noise; verify bugs, check Sentry when
   relevant, and keep UI changes minimal.
+metadata:
+  internal: true
 ---
 
 # Address Feedback

--- a/.agents/skills/authentication/SKILL.md
+++ b/.agents/skills/authentication/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   How auth works in agent-native apps. Use when wiring login/signup,
   configuring auth modes, setting up organizations, protecting routes, or
   debugging session issues.
+metadata:
+  internal: true
 ---
 
 # Authentication

--- a/.agents/skills/automations/SKILL.md
+++ b/.agents/skills/automations/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   Event-triggered and schedule-triggered automations with natural-language
   conditions. Use when creating automations, wiring events, or understanding
   how triggers fire.
+metadata:
+  internal: true
 ---
 
 # Automations

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -2,6 +2,8 @@
 name: babysit-pr
 description: Monitor a PR, fix feedback and CI failures until fully green for 30 min. Run with /babysit-pr <number>
 user-invocable: true
+metadata:
+  internal: true
 ---
 
 Monitor PR #$ARGUMENTS in the current repo. Fix CI failures and human or bot review feedback until everything is green and no new feedback arrives for 30 minutes.

--- a/.agents/skills/capture-learnings/SKILL.md
+++ b/.agents/skills/capture-learnings/SKILL.md
@@ -5,6 +5,8 @@ description: >-
   user gives feedback, shares preferences, corrects a mistake, or when you
   discover something worth remembering for future conversations.
 user-invocable: false
+metadata:
+  internal: true
 ---
 
 # Capture Learnings

--- a/.agents/skills/client-side-routing/SKILL.md
+++ b/.agents/skills/client-side-routing/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   How to add routes without remounting the app shell. Use when adding a new
   route, fixing agent sidebar reloads on navigation, or choosing between
   `root.tsx` layout and pathless `_app.tsx` layout patterns.
+metadata:
+  internal: true
 ---
 
 # Client-Side Routing

--- a/.agents/skills/context-awareness/SKILL.md
+++ b/.agents/skills/context-awareness/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   How the agent knows what the user is looking at. Use when exposing UI state to
   the agent, implementing view-screen or navigate actions, wiring navigation
   state, or debugging agent context issues.
+metadata:
+  internal: true
 ---
 
 # Context Awareness

--- a/.agents/skills/create-skill/SKILL.md
+++ b/.agents/skills/create-skill/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   How to create new skills for an agent-native app. Use when adding a new
   skill, documenting a pattern the agent should follow, or creating reusable
   guidance for the agent.
+metadata:
+  internal: true
 ---
 
 # Create a Skill

--- a/.agents/skills/delegate-to-agent/SKILL.md
+++ b/.agents/skills/delegate-to-agent/SKILL.md
@@ -5,6 +5,8 @@ description: >-
   from UI or scripts to the agent, when a user asks for agent behavior or
   LLM-powered features, when tempted to add inline LLM calls, or when sending
   messages to the agent from application code.
+metadata:
+  internal: true
 ---
 
 # Delegate All AI to the Agent

--- a/.agents/skills/extension-points/SKILL.md
+++ b/.agents/skills/extension-points/SKILL.md
@@ -6,6 +6,8 @@ description: >-
   custom widget to an app surface (e.g. "add a sticky-note widget to my mail
   contact sidebar"), when wiring an ExtensionSlot in a template, or when
   marking an extension as installable into a slot.
+metadata:
+  internal: true
 ---
 
 # Extension Points

--- a/.agents/skills/extensions/SKILL.md
+++ b/.agents/skills/extensions/SKILL.md
@@ -5,6 +5,8 @@ description: >-
   that run inside iframes. Use when a user asks for a dashboard, widget,
   calculator, or any interactive mini-app that calls external APIs. Distinct
   from LLM "tools" (function calls) — see note below.
+metadata:
+  internal: true
 ---
 
 # Extensions

--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -8,6 +8,8 @@ description: >-
   adding an action's `link` builder or `mcpApp`, wiring the
   `/_agent-native/open` route, exposing an "ingest" action to MCP/A2A, or
   scaffolding apps from an external agent.
+metadata:
+  internal: true
 ---
 
 # External Agents (MCP bridge + deep links)

--- a/.agents/skills/frontend-design/SKILL.md
+++ b/.agents/skills/frontend-design/SKILL.md
@@ -8,6 +8,8 @@ description: >-
   creative, polished UI that avoids generic AI aesthetics.
 license: Complete terms in LICENSE.txt
 source: https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md
+metadata:
+  internal: true
 ---
 
 # Frontend Design

--- a/.agents/skills/integration-webhooks/SKILL.md
+++ b/.agents/skills/integration-webhooks/SKILL.md
@@ -5,6 +5,8 @@ description: >-
   Telegram, WhatsApp, email, etc.) on serverless hosts. Use when adding a new
   integration adapter, debugging dropped messages, or wiring long-running agent
   work into a webhook handler.
+metadata:
+  internal: true
 ---
 
 # Integration Webhooks

--- a/.agents/skills/mvp-followup/SKILL.md
+++ b/.agents/skills/mvp-followup/SKILL.md
@@ -3,6 +3,8 @@ name: mvp-followup
 description: >-
   Use when asking what to do next after a feature pass while avoiding bloat and
   checking for unfinished MVP work.
+metadata:
+  internal: true
 ---
 
 # MVP Follow-Up

--- a/.agents/skills/new-branch/SKILL.md
+++ b/.agents/skills/new-branch/SKILL.md
@@ -5,6 +5,8 @@ description: >-
   changes, update main, and create it. Do not auto-run for normal coding, PR,
   Builder.io, or Fusion branch workflows.
 user-invocable: true
+metadata:
+  internal: true
 ---
 
 # New Branch

--- a/.agents/skills/observability/SKILL.md
+++ b/.agents/skills/observability/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   Agent observability, evals, feedback, and experiments. Use when adding
   observability dashboards, configuring trace capture, setting up evals,
   creating A/B experiments, or collecting user feedback on agent responses.
+metadata:
+  internal: true
 ---
 
 # Agent Observability

--- a/.agents/skills/onboarding/SKILL.md
+++ b/.agents/skills/onboarding/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   How to register user-facing setup steps (API keys, OAuth, connecting
   third-party services) for the sidebar setup checklist. Use when adding a
   feature that needs initial user configuration.
+metadata:
+  internal: true
 ---
 
 # Onboarding Steps

--- a/.agents/skills/portability/SKILL.md
+++ b/.agents/skills/portability/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   How to keep template code database-agnostic and hosting-agnostic. Use when
   defining schemas, writing raw SQL, creating server routes, or anything that
   could leak a SQLite-only, Postgres-only, or Node-only assumption.
+metadata:
+  internal: true
 ---
 
 # Portability

--- a/.agents/skills/qa/SKILL.md
+++ b/.agents/skills/qa/SKILL.md
@@ -5,6 +5,8 @@ description: >-
   apps end-to-end, finding and fixing bugs, or running a QA sweep. Invoke as
   /qa with optional --apps and --focus args.
 user-invocable: true
+metadata:
+  internal: true
 ---
 
 # QA Testing

--- a/.agents/skills/real-time-collab/SKILL.md
+++ b/.agents/skills/real-time-collab/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   Multi-user collaborative editing with Yjs CRDT and live cursors. Use when
   adding real-time collaborative editing to a template, debugging sync issues,
   or understanding how the agent and humans edit documents simultaneously.
+metadata:
+  internal: true
 ---
 
 # Real-Time Collaboration

--- a/.agents/skills/real-time-sync/SKILL.md
+++ b/.agents/skills/real-time-sync/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   How to keep the UI in sync with agent changes via SSE plus polling fallback.
   Use when wiring query invalidation for new data models, debugging UI not
   updating, or understanding jitter prevention.
+metadata:
+  internal: true
 ---
 
 # Real-Time Sync

--- a/.agents/skills/recurring-jobs/SKILL.md
+++ b/.agents/skills/recurring-jobs/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   Scheduled tasks the agent runs on a cron schedule. Use when a user asks for
   something recurring ("every morning", "daily", "weekly"), when creating or
   updating jobs, or when debugging the job scheduler.
+metadata:
+  internal: true
 ---
 
 # Recurring Jobs

--- a/.agents/skills/secrets/SKILL.md
+++ b/.agents/skills/secrets/SKILL.md
@@ -5,6 +5,8 @@ description: >-
   they appear in the agent sidebar settings UI and the onboarding checklist.
   Use for any third-party API key (OpenAI, Stripe, Twilio, etc.) and for
   surfacing OAuth connections in the unified settings UI.
+metadata:
+  internal: true
 ---
 
 # Secrets Registry

--- a/.agents/skills/security/SKILL.md
+++ b/.agents/skills/security/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   Secure coding practices for agent-native apps: input validation, SQL
   injection, XSS, secrets, data scoping, and auth. Use when writing any action,
   route, or component that touches user data or external input.
+metadata:
+  internal: true
 ---
 
 # Security

--- a/.agents/skills/self-modifying-code/SKILL.md
+++ b/.agents/skills/self-modifying-code/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   How the agent can modify the app's own source code. Use when the agent needs
   to edit components, routes, styles, or scripts, when designing UI for agent
   editability, or when deciding what the agent should and shouldn't modify.
+metadata:
+  internal: true
 ---
 
 # Self-Modifying Code

--- a/.agents/skills/server-plugins/SKILL.md
+++ b/.agents/skills/server-plugins/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   Framework server plugins and the `/_agent-native/` route namespace. Use when
   adding a custom server plugin, deciding whether to create an `/api/` route vs
   an action, or debugging auto-mounted framework routes.
+metadata:
+  internal: true
 ---
 
 # Server Plugins & Framework Routes

--- a/.agents/skills/shadcn-ui/SKILL.md
+++ b/.agents/skills/shadcn-ui/SKILL.md
@@ -5,6 +5,8 @@ description: >-
   components, forms, dialogs, menus, charts, sidebars, themes, registries, or
   any project with a components.json file.
 source: https://ui.shadcn.com/docs/skills
+metadata:
+  internal: true
 ---
 
 # shadcn/ui

--- a/.agents/skills/sharing/SKILL.md
+++ b/.agents/skills/sharing/SKILL.md
@@ -5,6 +5,8 @@ description: >-
   (dashboards, documents, forms, decks, etc.). Use when making a resource
   table ownable, wiring list/read/update access checks, or dropping the
   standard share dialog into a template.
+metadata:
+  internal: true
 ---
 
 # Sharing — Private by Default, Explicit Share

--- a/.agents/skills/ship-desktop/SKILL.md
+++ b/.agents/skills/ship-desktop/SKILL.md
@@ -2,6 +2,8 @@
 name: ship-desktop
 description: Build the Agent Native desktop app locally, kill the running copy, install the fresh DMG to /Applications, and launch it. Use when the user says "rebuild/reinstall the desktop app", "ship desktop", "install the desktop app", or similar.
 user-invocable: true
+metadata:
+  internal: true
 ---
 
 # Ship Desktop

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -2,6 +2,8 @@
 name: ship
 description: Commit all local changes, run prep, push, check CI, and address PR feedback
 user-invocable: true
+metadata:
+  internal: true
 ---
 
 # Ship

--- a/.agents/skills/storing-data/SKILL.md
+++ b/.agents/skills/storing-data/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   How to store application data in agent-native apps. All data lives in SQL.
   Use when adding data models, deciding where to store data, or reading/writing
   application data.
+metadata:
+  internal: true
 ---
 
 # Storing Data — SQL is the Source of Truth

--- a/.agents/skills/tracking/SKILL.md
+++ b/.agents/skills/tracking/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   Server-side analytics tracking with pluggable providers. Use when adding
   analytics events, registering custom tracking providers, or configuring
   built-in providers (PostHog, Mixpanel, Amplitude, Webhook).
+metadata:
+  internal: true
 ---
 
 # Tracking

--- a/.agents/skills/voice-transcription/SKILL.md
+++ b/.agents/skills/voice-transcription/SKILL.md
@@ -6,6 +6,8 @@ description: >-
   Voice Transcription settings section. Covers transcription-source routing,
   cleanup routing, Google realtime gating, and the voice transcription
   application-state keys.
+metadata:
+  internal: true
 ---
 
 # Voice Transcription

--- a/.agents/skills/writing-agent-instructions/SKILL.md
+++ b/.agents/skills/writing-agent-instructions/SKILL.md
@@ -5,6 +5,8 @@ description: >-
   AGENTS.md, skills, and tool/action descriptions. Use when authoring or
   reviewing AGENTS.md, writing a SKILL.md, wording action descriptions, or
   deciding what belongs in instructions vs skills vs memory.
+metadata:
+  internal: true
 ---
 
 # Writing Agent Instructions & Skills

--- a/.changeset/auth-docs-cache-followup.md
+++ b/.changeset/auth-docs-cache-followup.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep auth fallback HTML out of shared CDN caches and vary docs markdown/html responses by Accept.

--- a/.changeset/core-route-warmup.md
+++ b/.changeset/core-route-warmup.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Move safe React Router route data and JS warmup into the core client with configurable Vite defaults.

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -91,6 +91,7 @@ import {
   SIDEBAR_OPEN_KEY,
   subscribeAgentSidebarUrlChanges,
 } from "./agent-sidebar-state.js";
+import { AgentNativeRouteWarmup } from "./route-warmup.js";
 
 // Lazy-load AgentTerminal to avoid bundling xterm.js when not needed
 const AgentTerminal = lazy(() =>
@@ -2495,6 +2496,7 @@ export function AgentSidebar({
 
   return (
     <div className="flex min-w-0 flex-1 h-screen overflow-hidden">
+      <AgentNativeRouteWarmup />
       {/* Mobile backdrop — tapping it closes the sidebar */}
       {isMobile && !presentationMode && (animateMobile || open) && (
         <div

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -166,6 +166,10 @@ export {
   type AgentNativeFrameProps,
 } from "./AgentNativeFrame.js";
 export {
+  AgentNativeRouteWarmup,
+  type AgentNativeRouteWarmupProps,
+} from "./route-warmup.js";
+export {
   AgentNativeExtensionFrame,
   AgentNativeExtensionSlot,
   type AgentNativeExtensionFrameProps,

--- a/packages/core/src/client/route-warmup.spec.ts
+++ b/packages/core/src/client/route-warmup.spec.ts
@@ -5,6 +5,7 @@ import { __routeWarmupInternalsForTests } from "./route-warmup.js";
 
 const {
   getManifestRouteTree,
+  hasReactRouterManifestRoutes,
   parseBuildTimeRouteWarmupConfig,
   renderWarmupLinksForSelector,
   resetRouteWarmupCachesForTests,
@@ -13,6 +14,8 @@ const {
 describe("route warmup runtime helpers", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
+    delete window.__reactRouterManifest;
+    delete window.__reactRouterContext;
     resetRouteWarmupCachesForTests();
   });
 
@@ -50,6 +53,20 @@ describe("route warmup runtime helpers", () => {
       id: "docs",
       path: "docs",
     });
+  });
+
+  it("requires a React Router manifest before route data warmup can run", () => {
+    expect(hasReactRouterManifestRoutes()).toBe(false);
+
+    window.__reactRouterManifest = { routes: {} };
+    expect(hasReactRouterManifestRoutes()).toBe(false);
+
+    window.__reactRouterManifest = {
+      routes: {
+        root: { id: "root", path: "/" },
+      },
+    };
+    expect(hasReactRouterManifestRoutes()).toBe(true);
   });
 
   it("finds render warmup links using the configured selector", () => {

--- a/packages/core/src/client/route-warmup.spec.ts
+++ b/packages/core/src/client/route-warmup.spec.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { __routeWarmupInternalsForTests } from "./route-warmup.js";
+
+const {
+  getManifestRouteTree,
+  parseBuildTimeRouteWarmupConfig,
+  renderWarmupLinksForSelector,
+  resetRouteWarmupCachesForTests,
+} = __routeWarmupInternalsForTests;
+
+describe("route warmup runtime helpers", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    resetRouteWarmupCachesForTests();
+  });
+
+  it("parses JSON-injected route warmup config strings", () => {
+    expect(
+      parseBuildTimeRouteWarmupConfig(
+        JSON.stringify({ strategy: "viewport", data: false }),
+      ),
+    ).toEqual({ strategy: "viewport", data: false });
+    expect(parseBuildTimeRouteWarmupConfig(JSON.stringify("render"))).toBe(
+      "render",
+    );
+    expect(parseBuildTimeRouteWarmupConfig("render")).toBe("render");
+  });
+
+  it("refreshes the route tree when React Router patches manifest routes in place", () => {
+    const manifest = {
+      routes: {
+        root: { id: "root", path: "/" },
+      },
+    };
+
+    const initialTree = getManifestRouteTree(manifest);
+    expect(initialTree[0]?.children).toBeUndefined();
+
+    manifest.routes.docs = {
+      id: "docs",
+      parentId: "root",
+      path: "docs",
+    };
+
+    const patchedTree = getManifestRouteTree(manifest);
+    expect(patchedTree).not.toBe(initialTree);
+    expect(patchedTree[0]?.children?.[0]).toMatchObject({
+      id: "docs",
+      path: "docs",
+    });
+  });
+
+  it("finds render warmup links using the configured selector", () => {
+    document.body.innerHTML = `
+      <a href="/docs" class="warm">Docs</a>
+      <span class="warm-wrapper"><a href="/templates">Templates</a></span>
+      <a href="/skip">Skip</a>
+    `;
+
+    expect(
+      renderWarmupLinksForSelector("a.warm[href], .warm-wrapper").map(
+        (link) => new URL(link.href).pathname,
+      ),
+    ).toEqual(["/docs", "/templates"]);
+  });
+
+  it("ignores invalid custom selectors", () => {
+    document.body.innerHTML = '<a href="/docs">Docs</a>';
+
+    expect(renderWarmupLinksForSelector("[")).toEqual([]);
+  });
+});

--- a/packages/core/src/client/route-warmup.tsx
+++ b/packages/core/src/client/route-warmup.tsx
@@ -75,6 +75,13 @@ function getRouteWarmupConfig(
   );
 }
 
+function isProductionClientBuild(): boolean {
+  const meta = import.meta as ImportMeta & {
+    env?: Record<string, boolean | string | undefined>;
+  };
+  return meta.env?.PROD === true || meta.env?.MODE === "production";
+}
+
 function normalizeBasename(basename: string | undefined): string {
   if (!basename || basename === "/") return "/";
   return basename.startsWith("/") ? basename.replace(/\/+$/, "") : "/";
@@ -268,7 +275,12 @@ export function AgentNativeRouteWarmup({
 }: AgentNativeRouteWarmupProps) {
   useEffect(() => {
     const resolved = getRouteWarmupConfig(config);
-    if (resolved.strategy === "off" || (!resolved.data && !resolved.modules)) {
+    // Vite dev manifests contain raw source module ids. Warming those with
+    // modulepreload can route through React Router's dev SSR loader and make
+    // local servers log false-positive internal errors. Production manifests
+    // point at real hashed JS assets, which is the path we need to make fast.
+    const warmModules = resolved.modules && isProductionClientBuild();
+    if (resolved.strategy === "off" || (!resolved.data && !warmModules)) {
       return;
     }
 
@@ -277,7 +289,7 @@ export function AgentNativeRouteWarmup({
     ).connection;
     if (connection?.saveData) return;
 
-    seedExistingModulepreloads();
+    if (warmModules) seedExistingModulepreloads();
 
     const queue: string[] = [];
     const queuedDataRoutes = new Set<string>();
@@ -303,7 +315,7 @@ export function AgentNativeRouteWarmup({
     };
 
     const warmHref = (href: string) => {
-      if (resolved.modules) warmRouteAssetsForHref(href);
+      if (warmModules) warmRouteAssetsForHref(href);
       if (!resolved.data) return;
       const dataUrl = dataRouteUrlForHref(href);
       if (!dataUrl || warmedDataRoutes.has(dataUrl)) return;
@@ -327,7 +339,7 @@ export function AgentNativeRouteWarmup({
           });
 
     const scan = () => {
-      seedExistingModulepreloads();
+      if (warmModules) seedExistingModulepreloads();
 
       for (const link of document.querySelectorAll<HTMLAnchorElement>(
         "a[href]",

--- a/packages/core/src/client/route-warmup.tsx
+++ b/packages/core/src/client/route-warmup.tsx
@@ -9,6 +9,7 @@ import {
 
 declare const __AGENT_NATIVE_ROUTE_WARMUP_CONFIG__:
   | AgentNativeRouteWarmupConfigInput
+  | string
   | undefined;
 
 type ReactRouterManifestRoute = {
@@ -48,10 +49,25 @@ const warmedDataRoutes = new Set<string>();
 const warmedRouteAssets = new Set<string>();
 
 let cachedManifest: ReactRouterManifest | undefined;
+let cachedManifestRoutesSignature = "";
 let cachedManifestRouteTree: WarmupRouteObject[] = [];
 
 export interface AgentNativeRouteWarmupProps {
   config?: AgentNativeRouteWarmupConfigInput;
+}
+
+function parseBuildTimeRouteWarmupConfig(
+  raw: AgentNativeRouteWarmupConfigInput | string | undefined,
+): AgentNativeRouteWarmupConfigInput | undefined {
+  if (typeof raw !== "string") return raw;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  try {
+    return JSON.parse(trimmed) as AgentNativeRouteWarmupConfigInput;
+  } catch {
+    // Some test/build paths may inject a bare strategy string instead of JSON.
+    return raw as AgentNativeRouteWarmupConfigInput;
+  }
 }
 
 function getBuildTimeRouteWarmupConfig():
@@ -59,7 +75,9 @@ function getBuildTimeRouteWarmupConfig():
   | undefined {
   try {
     if (typeof __AGENT_NATIVE_ROUTE_WARMUP_CONFIG__ !== "undefined") {
-      return __AGENT_NATIVE_ROUTE_WARMUP_CONFIG__;
+      return parseBuildTimeRouteWarmupConfig(
+        __AGENT_NATIVE_ROUTE_WARMUP_CONFIG__,
+      );
     }
   } catch {
     // Some non-Vite test/runtime paths do not define the global.
@@ -141,10 +159,32 @@ function dataRouteUrlForHref(href: string): string | null {
   return url.href;
 }
 
+function manifestRoutesSignature(
+  routes: Record<string, ReactRouterManifestRoute> | undefined,
+): string {
+  return Object.values(routes ?? {})
+    .map((route) =>
+      [
+        route.id,
+        route.parentId ?? "",
+        route.path ?? "",
+        route.index ? "1" : "0",
+      ].join("\0"),
+    )
+    .sort()
+    .join("\n");
+}
+
 function getManifestRouteTree(
   manifest: ReactRouterManifest,
 ): WarmupRouteObject[] {
-  if (manifest === cachedManifest) return cachedManifestRouteTree;
+  const routesSignature = manifestRoutesSignature(manifest.routes);
+  if (
+    manifest === cachedManifest &&
+    routesSignature === cachedManifestRoutesSignature
+  ) {
+    return cachedManifestRouteTree;
+  }
 
   const manifestRoutes = Object.values(manifest.routes ?? {});
   const nodes = new Map<string, WarmupRouteObject>();
@@ -170,6 +210,7 @@ function getManifestRouteTree(
   }
 
   cachedManifest = manifest;
+  cachedManifestRoutesSignature = routesSignature;
   cachedManifestRouteTree = tree;
   return tree;
 }
@@ -260,6 +301,44 @@ function linkWarmupMode(
   return strategy;
 }
 
+function selectorWarmupMode(link: HTMLAnchorElement): "render" | "none" {
+  const explicit = link.getAttribute(PREFETCH_ATTR)?.trim().toLowerCase();
+  return explicit === "none" || explicit === "off" || explicit === "false"
+    ? "none"
+    : "render";
+}
+
+function renderWarmupLinksForSelector(selector: string): HTMLAnchorElement[] {
+  let elements: Element[];
+  try {
+    elements = Array.from(document.querySelectorAll(selector));
+  } catch {
+    return [];
+  }
+
+  const links: HTMLAnchorElement[] = [];
+  const seen = new Set<HTMLAnchorElement>();
+  for (const element of elements) {
+    const link =
+      element instanceof HTMLAnchorElement
+        ? element
+        : (element.querySelector<HTMLAnchorElement>("a[href]") ??
+          element.closest<HTMLAnchorElement>("a[href]"));
+    if (!link || seen.has(link)) continue;
+    seen.add(link);
+    links.push(link);
+  }
+  return links;
+}
+
+function resetRouteWarmupCachesForTests() {
+  cachedManifest = undefined;
+  cachedManifestRoutesSignature = "";
+  cachedManifestRouteTree = [];
+  warmedDataRoutes.clear();
+  warmedRouteAssets.clear();
+}
+
 /**
  * Warms React Router route data and matched route JS without using native link
  * prefetch. React Router's built-in `<Link prefetch>` does both pieces, but
@@ -344,6 +423,13 @@ export function AgentNativeRouteWarmup({
     const scan = () => {
       if (warmModules) seedExistingModulepreloads();
 
+      for (const link of renderWarmupLinksForSelector(resolved.selector)) {
+        if (!isWarmableAnchor(link)) continue;
+        const mode = selectorWarmupMode(link);
+        if (mode === "none") continue;
+        warmHref(link.href);
+      }
+
       for (const link of document.querySelectorAll<HTMLAnchorElement>(
         "a[href]",
       )) {
@@ -385,11 +471,12 @@ export function AgentNativeRouteWarmup({
 
     schedule();
     const observer = new MutationObserver(schedule);
+    // The render-warmup selector is configurable, so it may depend on class or
+    // custom data attributes. Watch all attribute changes and debounce rescans.
     observer.observe(document.documentElement, {
       subtree: true,
       childList: true,
       attributes: true,
-      attributeFilter: ["href", PREFETCH_ATTR],
     });
 
     document.addEventListener("pointerover", warmFromIntent, {
@@ -415,3 +502,10 @@ export function AgentNativeRouteWarmup({
 
   return null;
 }
+
+export const __routeWarmupInternalsForTests = {
+  getManifestRouteTree,
+  parseBuildTimeRouteWarmupConfig,
+  renderWarmupLinksForSelector,
+  resetRouteWarmupCachesForTests,
+};

--- a/packages/core/src/client/route-warmup.tsx
+++ b/packages/core/src/client/route-warmup.tsx
@@ -1,0 +1,402 @@
+import { useEffect } from "react";
+import { matchRoutes, type RouteObject } from "react-router";
+import {
+  normalizeAgentNativeRouteWarmupConfig,
+  type AgentNativeRouteWarmupConfigInput,
+  type AgentNativeRouteWarmupResolvedConfig,
+  type AgentNativeRouteWarmupStrategy,
+} from "../shared/route-warmup-config.js";
+
+declare const __AGENT_NATIVE_ROUTE_WARMUP_CONFIG__:
+  | AgentNativeRouteWarmupConfigInput
+  | undefined;
+
+type ReactRouterManifestRoute = {
+  id: string;
+  parentId?: string;
+  path?: string;
+  index?: boolean;
+  module?: string;
+  clientActionModule?: string;
+  clientLoaderModule?: string;
+  hydrateFallbackModule?: string;
+  imports?: string[];
+};
+
+type ReactRouterManifest = {
+  routes?: Record<string, ReactRouterManifestRoute>;
+};
+
+type WarmupRouteObject = {
+  id: string;
+  path?: string;
+  index?: boolean;
+  children?: WarmupRouteObject[];
+};
+
+type LinkWarmupMode = Exclude<AgentNativeRouteWarmupStrategy, "off" | "marked">;
+
+declare global {
+  interface Window {
+    __reactRouterContext?: { basename?: string };
+    __reactRouterManifest?: ReactRouterManifest;
+  }
+}
+
+const PREFETCH_ATTR = "data-an-prefetch";
+const warmedDataRoutes = new Set<string>();
+const warmedRouteAssets = new Set<string>();
+
+let cachedManifest: ReactRouterManifest | undefined;
+let cachedManifestRouteTree: WarmupRouteObject[] = [];
+
+export interface AgentNativeRouteWarmupProps {
+  config?: AgentNativeRouteWarmupConfigInput;
+}
+
+function getBuildTimeRouteWarmupConfig():
+  | AgentNativeRouteWarmupConfigInput
+  | undefined {
+  try {
+    if (typeof __AGENT_NATIVE_ROUTE_WARMUP_CONFIG__ !== "undefined") {
+      return __AGENT_NATIVE_ROUTE_WARMUP_CONFIG__;
+    }
+  } catch {
+    // Some non-Vite test/runtime paths do not define the global.
+  }
+  return undefined;
+}
+
+function getRouteWarmupConfig(
+  config: AgentNativeRouteWarmupConfigInput | undefined,
+): AgentNativeRouteWarmupResolvedConfig {
+  return normalizeAgentNativeRouteWarmupConfig(
+    config ?? getBuildTimeRouteWarmupConfig(),
+  );
+}
+
+function normalizeBasename(basename: string | undefined): string {
+  if (!basename || basename === "/") return "/";
+  return basename.startsWith("/") ? basename.replace(/\/+$/, "") : "/";
+}
+
+function stripBasename(pathname: string): string {
+  const basename = normalizeBasename(window.__reactRouterContext?.basename);
+  if (basename === "/") return pathname;
+  if (pathname === basename) return "/";
+  if (pathname.startsWith(`${basename}/`)) {
+    return pathname.slice(basename.length) || "/";
+  }
+  return pathname;
+}
+
+function isFrameworkOrApiPath(pathname: string): boolean {
+  const appPath = stripBasename(pathname);
+  return (
+    appPath === "/_agent-native" ||
+    appPath.startsWith("/_agent-native/") ||
+    appPath === "/api" ||
+    appPath.startsWith("/api/")
+  );
+}
+
+function hrefUrl(href: string): URL | null {
+  try {
+    return new URL(href, window.location.href);
+  } catch {
+    return null;
+  }
+}
+
+function isWarmableRouteUrl(url: URL): boolean {
+  if (url.origin !== window.location.origin) return false;
+  if (url.pathname === window.location.pathname && url.hash) return false;
+  if (isFrameworkOrApiPath(url.pathname)) return false;
+  if (/\.\w+$/.test(url.pathname)) return false;
+  return true;
+}
+
+function isWarmableAnchor(link: HTMLAnchorElement): boolean {
+  if (link.hasAttribute("download")) return false;
+  if (link.target && link.target !== "_self") return false;
+  const url = hrefUrl(link.href);
+  return url ? isWarmableRouteUrl(url) : false;
+}
+
+function dataRouteUrlForHref(href: string): string | null {
+  const url = hrefUrl(href);
+  if (!url || !isWarmableRouteUrl(url)) return null;
+
+  const pathname = url.pathname.replace(/\/+$/, "") || "/";
+  if (pathname === "/") return null;
+  url.pathname = `${pathname}.data`;
+  url.hash = "";
+  return url.href;
+}
+
+function getManifestRouteTree(
+  manifest: ReactRouterManifest,
+): WarmupRouteObject[] {
+  if (manifest === cachedManifest) return cachedManifestRouteTree;
+
+  const manifestRoutes = Object.values(manifest.routes ?? {});
+  const nodes = new Map<string, WarmupRouteObject>();
+  for (const route of manifestRoutes) {
+    nodes.set(route.id, {
+      id: route.id,
+      path: route.path,
+      index: route.index || undefined,
+    });
+  }
+
+  const tree: WarmupRouteObject[] = [];
+  for (const route of manifestRoutes) {
+    const node = nodes.get(route.id);
+    if (!node) continue;
+    const parent = route.parentId ? nodes.get(route.parentId) : null;
+    if (parent) {
+      parent.children ??= [];
+      parent.children.push(node);
+    } else {
+      tree.push(node);
+    }
+  }
+
+  cachedManifest = manifest;
+  cachedManifestRouteTree = tree;
+  return tree;
+}
+
+function assetUrlForManifestPath(assetPath: string): string | null {
+  try {
+    const url = new URL(assetPath, window.location.origin);
+    if (url.origin !== window.location.origin) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+function routeAssetUrlsForHref(href: string): string[] {
+  const manifest = window.__reactRouterManifest;
+  if (!manifest?.routes) return [];
+
+  const url = hrefUrl(href);
+  if (!url || !isWarmableRouteUrl(url)) return [];
+
+  const basename = normalizeBasename(window.__reactRouterContext?.basename);
+  const matches =
+    matchRoutes(
+      getManifestRouteTree(manifest) as unknown as RouteObject[],
+      url.pathname,
+      basename,
+    ) ?? [];
+  const assetUrls: string[] = [];
+
+  for (const match of matches) {
+    const routeId = match.route.id;
+    if (!routeId) continue;
+    const route = manifest.routes[routeId];
+    if (!route) continue;
+    for (const assetPath of [
+      route.module,
+      route.clientActionModule,
+      route.clientLoaderModule,
+      route.hydrateFallbackModule,
+      ...(route.imports ?? []),
+    ]) {
+      if (!assetPath) continue;
+      const assetUrl = assetUrlForManifestPath(assetPath);
+      if (assetUrl) assetUrls.push(assetUrl);
+    }
+  }
+
+  return assetUrls;
+}
+
+function seedExistingModulepreloads() {
+  for (const link of document.querySelectorAll<HTMLLinkElement>(
+    'link[rel="modulepreload"][href]',
+  )) {
+    warmedRouteAssets.add(link.href);
+  }
+}
+
+function warmRouteAssetsForHref(href: string) {
+  for (const assetUrl of routeAssetUrlsForHref(href)) {
+    if (warmedRouteAssets.has(assetUrl)) continue;
+    warmedRouteAssets.add(assetUrl);
+
+    const link = document.createElement("link");
+    link.rel = "modulepreload";
+    link.href = assetUrl;
+    document.head.appendChild(link);
+  }
+}
+
+function linkWarmupMode(
+  link: HTMLAnchorElement,
+  strategy: AgentNativeRouteWarmupStrategy,
+): LinkWarmupMode | "none" {
+  const explicit = link.getAttribute(PREFETCH_ATTR)?.trim().toLowerCase();
+  if (explicit === "none" || explicit === "off" || explicit === "false") {
+    return "none";
+  }
+  if (
+    explicit === "render" ||
+    explicit === "intent" ||
+    explicit === "viewport"
+  ) {
+    return explicit;
+  }
+  if (strategy === "off" || strategy === "marked") return "none";
+  return strategy;
+}
+
+/**
+ * Warms React Router route data and matched route JS without using native link
+ * prefetch. React Router's built-in `<Link prefetch>` does both pieces, but
+ * its data side emits `<link rel="prefetch" as="fetch">`; Chrome sends
+ * `Sec-Purpose: prefetch` for that request and Cloudflare Speed Brain can 503
+ * dynamic `.data` routes before the CDN/origin can serve the cacheable result.
+ *
+ * Keep `.data` warmup as ordinary `fetch()` and JS warmup as `modulepreload`
+ * unless production providers stop rejecting `Sec-Purpose: prefetch`.
+ */
+export function AgentNativeRouteWarmup({
+  config,
+}: AgentNativeRouteWarmupProps) {
+  useEffect(() => {
+    const resolved = getRouteWarmupConfig(config);
+    if (resolved.strategy === "off" || (!resolved.data && !resolved.modules)) {
+      return;
+    }
+
+    const connection = (
+      navigator as Navigator & { connection?: { saveData?: boolean } }
+    ).connection;
+    if (connection?.saveData) return;
+
+    seedExistingModulepreloads();
+
+    const queue: string[] = [];
+    const queuedDataRoutes = new Set<string>();
+    const observedLinks = new WeakSet<HTMLAnchorElement>();
+    let active = 0;
+    let stopped = false;
+    let scheduleTimer: number | undefined;
+
+    const pump = () => {
+      if (stopped || !resolved.data) return;
+      while (active < resolved.maxConcurrent && queue.length > 0) {
+        const href = queue.shift();
+        if (!href) continue;
+        active += 1;
+        window
+          .fetch(href, { credentials: "same-origin", cache: "force-cache" })
+          .catch(() => {})
+          .finally(() => {
+            active -= 1;
+            window.setTimeout(pump, 50);
+          });
+      }
+    };
+
+    const warmHref = (href: string) => {
+      if (resolved.modules) warmRouteAssetsForHref(href);
+      if (!resolved.data) return;
+      const dataUrl = dataRouteUrlForHref(href);
+      if (!dataUrl || warmedDataRoutes.has(dataUrl)) return;
+      warmedDataRoutes.add(dataUrl);
+      if (queuedDataRoutes.has(dataUrl)) return;
+      queuedDataRoutes.add(dataUrl);
+      queue.push(dataUrl);
+      pump();
+    };
+
+    const viewportObserver =
+      typeof IntersectionObserver === "undefined"
+        ? null
+        : new IntersectionObserver((entries) => {
+            for (const entry of entries) {
+              if (!entry.isIntersecting) continue;
+              const link = entry.target as HTMLAnchorElement;
+              viewportObserver?.unobserve(link);
+              warmHref(link.href);
+            }
+          });
+
+    const scan = () => {
+      seedExistingModulepreloads();
+
+      for (const link of document.querySelectorAll<HTMLAnchorElement>(
+        "a[href]",
+      )) {
+        if (!isWarmableAnchor(link)) continue;
+        const mode = linkWarmupMode(link, resolved.strategy);
+        if (mode === "none") continue;
+        if (mode === "render") {
+          warmHref(link.href);
+          continue;
+        }
+        if (mode === "viewport") {
+          if (!viewportObserver) {
+            warmHref(link.href);
+          } else if (!observedLinks.has(link)) {
+            observedLinks.add(link);
+            viewportObserver.observe(link);
+          }
+        }
+      }
+    };
+
+    const schedule = () => {
+      if (scheduleTimer !== undefined) window.clearTimeout(scheduleTimer);
+      scheduleTimer = window.setTimeout(() => {
+        scheduleTimer = undefined;
+        scan();
+      }, 0);
+    };
+
+    const warmFromIntent = (event: Event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      const link = target.closest<HTMLAnchorElement>("a[href]");
+      if (!link || !isWarmableAnchor(link)) return;
+      const mode = linkWarmupMode(link, resolved.strategy);
+      if (mode === "none") return;
+      warmHref(link.href);
+    };
+
+    schedule();
+    const observer = new MutationObserver(schedule);
+    observer.observe(document.documentElement, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ["href", PREFETCH_ATTR],
+    });
+
+    document.addEventListener("pointerover", warmFromIntent, {
+      capture: true,
+      passive: true,
+    });
+    document.addEventListener("touchstart", warmFromIntent, {
+      capture: true,
+      passive: true,
+    });
+    document.addEventListener("focusin", warmFromIntent, true);
+
+    return () => {
+      stopped = true;
+      if (scheduleTimer !== undefined) window.clearTimeout(scheduleTimer);
+      observer.disconnect();
+      viewportObserver?.disconnect();
+      document.removeEventListener("pointerover", warmFromIntent, true);
+      document.removeEventListener("touchstart", warmFromIntent, true);
+      document.removeEventListener("focusin", warmFromIntent, true);
+    };
+  }, [config]);
+
+  return null;
+}

--- a/packages/core/src/client/route-warmup.tsx
+++ b/packages/core/src/client/route-warmup.tsx
@@ -159,6 +159,11 @@ function dataRouteUrlForHref(href: string): string | null {
   return url.href;
 }
 
+function hasReactRouterManifestRoutes(): boolean {
+  const routes = window.__reactRouterManifest?.routes;
+  return Boolean(routes && Object.keys(routes).length > 0);
+}
+
 function manifestRoutesSignature(
   routes: Record<string, ReactRouterManifestRoute> | undefined,
 ): string {
@@ -363,8 +368,14 @@ export function AgentNativeRouteWarmup({
     if (!isProduction || resolved.strategy === "off") {
       return;
     }
-    const warmModules = resolved.modules;
-    if (!resolved.data && !warmModules) return;
+    // Legacy SPA builds still mount the AgentPanel but do not expose React
+    // Router framework `.data` endpoints or a route asset manifest. Only warm
+    // route data/modules when that manifest is present; otherwise this would
+    // generate noisy `/<path>.data` 404s for apps that cannot serve them.
+    const hasManifestRoutes = hasReactRouterManifestRoutes();
+    const warmData = resolved.data && hasManifestRoutes;
+    const warmModules = resolved.modules && hasManifestRoutes;
+    if (!warmData && !warmModules) return;
 
     const connection = (
       navigator as Navigator & { connection?: { saveData?: boolean } }
@@ -381,7 +392,7 @@ export function AgentNativeRouteWarmup({
     let scheduleTimer: number | undefined;
 
     const pump = () => {
-      if (stopped || !resolved.data) return;
+      if (stopped || !warmData) return;
       while (active < resolved.maxConcurrent && queue.length > 0) {
         const href = queue.shift();
         if (!href) continue;
@@ -398,7 +409,7 @@ export function AgentNativeRouteWarmup({
 
     const warmHref = (href: string) => {
       if (warmModules) warmRouteAssetsForHref(href);
-      if (!resolved.data) return;
+      if (!warmData) return;
       const dataUrl = dataRouteUrlForHref(href);
       if (!dataUrl || warmedDataRoutes.has(dataUrl)) return;
       warmedDataRoutes.add(dataUrl);
@@ -505,6 +516,7 @@ export function AgentNativeRouteWarmup({
 
 export const __routeWarmupInternalsForTests = {
   getManifestRouteTree,
+  hasReactRouterManifestRoutes,
   parseBuildTimeRouteWarmupConfig,
   renderWarmupLinksForSelector,
   resetRouteWarmupCachesForTests,

--- a/packages/core/src/client/route-warmup.tsx
+++ b/packages/core/src/client/route-warmup.tsx
@@ -277,12 +277,15 @@ export function AgentNativeRouteWarmup({
     const resolved = getRouteWarmupConfig(config);
     // Vite dev manifests contain raw source module ids. Warming those with
     // modulepreload can route through React Router's dev SSR loader and make
-    // local servers log false-positive internal errors. Production manifests
-    // point at real hashed JS assets, which is the path we need to make fast.
-    const warmModules = resolved.modules && isProductionClientBuild();
-    if (resolved.strategy === "off" || (!resolved.data && !warmModules)) {
+    // local servers log false-positive internal errors. Keep route warmup to
+    // production builds, where manifests point at real hashed JS assets and
+    // SSR `.data` requests have the CDN cache headers this feature relies on.
+    const isProduction = isProductionClientBuild();
+    if (!isProduction || resolved.strategy === "off") {
       return;
     }
+    const warmModules = resolved.modules;
+    if (!resolved.data && !warmModules) return;
 
     const connection = (
       navigator as Navigator & { connection?: { saveData?: boolean } }

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const DEFAULT_SSR_CACHE_CONTROL =
-  "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
-const DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL =
-  "public, durable, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+const LOGIN_HTML_CACHE_CONTROL =
+  "private, no-store, max-age=0, must-revalidate";
 
 describe("server/auth", () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -438,14 +436,14 @@ describe("server/auth", () => {
       expect(result).toBeInstanceOf(Response);
       expect((result as Response).status).toBe(200);
       expect((result as Response).headers.get("Cache-Control")).toBe(
-        DEFAULT_SSR_CACHE_CONTROL,
+        LOGIN_HTML_CACHE_CONTROL,
       );
       expect((result as Response).headers.get("CDN-Cache-Control")).toBe(
-        DEFAULT_SSR_CACHE_CONTROL,
+        "no-store",
       );
       expect(
         (result as Response).headers.get("Netlify-CDN-Cache-Control"),
-      ).toBe(DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL);
+      ).toBe("no-store");
 
       const html = await (result as Response).text();
       expect(html).toContain("Create account");
@@ -529,7 +527,7 @@ describe("server/auth", () => {
       expect(adminResult).toBeInstanceOf(Response);
       expect((adminResult as Response).status).toBe(200);
       expect((adminResult as Response).headers.get("Cache-Control")).toBe(
-        DEFAULT_SSR_CACHE_CONTROL,
+        LOGIN_HTML_CACHE_CONTROL,
       );
 
       const adminDataResult = await guard(
@@ -580,7 +578,7 @@ describe("server/auth", () => {
       expect(privateResult).toBeInstanceOf(Response);
       expect((privateResult as Response).status).toBe(200);
       expect((privateResult as Response).headers.get("Cache-Control")).toBe(
-        DEFAULT_SSR_CACHE_CONTROL,
+        LOGIN_HTML_CACHE_CONTROL,
       );
     });
 
@@ -842,7 +840,7 @@ describe("server/auth", () => {
       }
     });
 
-    it("serves cacheable first-party branded auth when the default guard handles a built-in host", async () => {
+    it("serves uncached first-party branded auth when the default guard handles a built-in host", async () => {
       vi.stubEnv("NODE_ENV", "production");
       delete process.env.ACCESS_TOKEN;
       delete process.env.ACCESS_TOKENS;
@@ -879,7 +877,7 @@ describe("server/auth", () => {
       expect(result).toBeInstanceOf(Response);
       expect((result as Response).status).toBe(200);
       expect((result as Response).headers.get("Cache-Control")).toBe(
-        DEFAULT_SSR_CACHE_CONTROL,
+        LOGIN_HTML_CACHE_CONTROL,
       );
       expect((result as Response).headers.get("X-Robots-Tag")).toBe(
         "noindex, nofollow",

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -109,7 +109,6 @@ import {
   workspaceAppRouteAccessFromEnv,
   type WorkspaceAppAudience,
 } from "../shared/workspace-app-audience.js";
-import { DEFAULT_SSR_CACHE_HEADERS } from "../shared/cache-control.js";
 import { resolveAuthCookieNamespace } from "./cookie-namespace.js";
 import {
   BUILDER_CONNECT_OWNER_COOKIE,
@@ -1309,7 +1308,12 @@ function loginHtmlResponse(loginHtml: string): Response {
     status: 200,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
-      ...DEFAULT_SSR_CACHE_HEADERS,
+      // Login HTML is selected by the absence of a session cookie. Never put it
+      // in a shared CDN cache: the same route may redirect authenticated users
+      // or render the app after sign-in.
+      "Cache-Control": "private, no-store, max-age=0, must-revalidate",
+      "CDN-Cache-Control": "no-store",
+      "Netlify-CDN-Cache-Control": "no-store",
       "X-Robots-Tag": "noindex, nofollow",
     },
   });

--- a/packages/core/src/shared/route-warmup-config.spec.ts
+++ b/packages/core/src/shared/route-warmup-config.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeAgentNativeRouteWarmupConfig,
+  isAgentNativeRouteWarmupStrategy,
+} from "./route-warmup-config.js";
+
+describe("route warmup config normalization", () => {
+  it("accepts only known route warmup strategy strings", () => {
+    expect(isAgentNativeRouteWarmupStrategy("render")).toBe(true);
+    expect(isAgentNativeRouteWarmupStrategy("hover")).toBe(false);
+  });
+
+  it("normalizes invalid strategy strings to the safe default", () => {
+    expect(normalizeAgentNativeRouteWarmupConfig("hover" as any).strategy).toBe(
+      "intent",
+    );
+    expect(
+      normalizeAgentNativeRouteWarmupConfig({
+        strategy: "eager" as any,
+        selector: "",
+        maxConcurrent: -1,
+      }),
+    ).toMatchObject({
+      strategy: "intent",
+      selector: 'a[data-an-prefetch="render"][href]',
+      maxConcurrent: 4,
+    });
+  });
+});

--- a/packages/core/src/shared/route-warmup-config.ts
+++ b/packages/core/src/shared/route-warmup-config.ts
@@ -1,0 +1,71 @@
+export type AgentNativeRouteWarmupStrategy =
+  | "off"
+  | "marked"
+  | "intent"
+  | "render"
+  | "viewport";
+
+export interface AgentNativeRouteWarmupResolvedConfig {
+  /**
+   * How unmarked internal route links are warmed.
+   *
+   * Links can opt in/out individually with `data-an-prefetch`:
+   * - `render`: warm as soon as the link renders.
+   * - `intent`: warm on hover/focus/touch.
+   * - `viewport`: warm when the link scrolls into view.
+   * - `none`: never warm this link.
+   */
+  strategy: AgentNativeRouteWarmupStrategy;
+  /** Warm React Router `.data` URLs with ordinary fetches. */
+  data: boolean;
+  /** Warm matched route JS chunks with `modulepreload`. */
+  modules: boolean;
+  /** Selector for links explicitly marked for render-time warmup. */
+  selector: string;
+  /** Maximum concurrent `.data` fetches. */
+  maxConcurrent: number;
+}
+
+export type AgentNativeRouteWarmupConfigInput =
+  | boolean
+  | AgentNativeRouteWarmupStrategy
+  | Partial<AgentNativeRouteWarmupResolvedConfig>;
+
+export const DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_SELECTOR =
+  'a[data-an-prefetch="render"][href]';
+
+export const DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG: AgentNativeRouteWarmupResolvedConfig =
+  {
+    strategy: "intent",
+    data: true,
+    modules: true,
+    selector: DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_SELECTOR,
+    maxConcurrent: 4,
+  };
+
+export function normalizeAgentNativeRouteWarmupConfig(
+  input: AgentNativeRouteWarmupConfigInput | undefined = true,
+): AgentNativeRouteWarmupResolvedConfig {
+  if (input === false) {
+    return { ...DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG, strategy: "off" };
+  }
+
+  if (typeof input === "string") {
+    return { ...DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG, strategy: input };
+  }
+
+  if (input === true || input === undefined) {
+    return { ...DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG };
+  }
+
+  return {
+    ...DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG,
+    ...input,
+    maxConcurrent:
+      typeof input.maxConcurrent === "number" &&
+      Number.isFinite(input.maxConcurrent) &&
+      input.maxConcurrent > 0
+        ? Math.floor(input.maxConcurrent)
+        : DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG.maxConcurrent,
+  };
+}

--- a/packages/core/src/shared/route-warmup-config.ts
+++ b/packages/core/src/shared/route-warmup-config.ts
@@ -5,6 +5,15 @@ export type AgentNativeRouteWarmupStrategy =
   | "render"
   | "viewport";
 
+const AGENT_NATIVE_ROUTE_WARMUP_STRATEGIES =
+  new Set<AgentNativeRouteWarmupStrategy>([
+    "off",
+    "marked",
+    "intent",
+    "render",
+    "viewport",
+  ]);
+
 export interface AgentNativeRouteWarmupResolvedConfig {
   /**
    * How unmarked internal route links are warmed.
@@ -43,6 +52,25 @@ export const DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG: AgentNativeRouteWarmupRes
     maxConcurrent: 4,
   };
 
+export function isAgentNativeRouteWarmupStrategy(
+  value: unknown,
+): value is AgentNativeRouteWarmupStrategy {
+  return (
+    typeof value === "string" &&
+    AGENT_NATIVE_ROUTE_WARMUP_STRATEGIES.has(
+      value as AgentNativeRouteWarmupStrategy,
+    )
+  );
+}
+
+function normalizeRouteWarmupStrategy(
+  value: unknown,
+): AgentNativeRouteWarmupStrategy {
+  return isAgentNativeRouteWarmupStrategy(value)
+    ? value
+    : DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG.strategy;
+}
+
 export function normalizeAgentNativeRouteWarmupConfig(
   input: AgentNativeRouteWarmupConfigInput | undefined = true,
 ): AgentNativeRouteWarmupResolvedConfig {
@@ -51,7 +79,10 @@ export function normalizeAgentNativeRouteWarmupConfig(
   }
 
   if (typeof input === "string") {
-    return { ...DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG, strategy: input };
+    return {
+      ...DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG,
+      strategy: normalizeRouteWarmupStrategy(input),
+    };
   }
 
   if (input === true || input === undefined) {
@@ -61,6 +92,19 @@ export function normalizeAgentNativeRouteWarmupConfig(
   return {
     ...DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG,
     ...input,
+    strategy: normalizeRouteWarmupStrategy(input.strategy),
+    data:
+      typeof input.data === "boolean"
+        ? input.data
+        : DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG.data,
+    modules:
+      typeof input.modules === "boolean"
+        ? input.modules
+        : DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG.modules,
+    selector:
+      typeof input.selector === "string" && input.selector.trim()
+        ? input.selector
+        : DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG.selector,
     maxConcurrent:
       typeof input.maxConcurrent === "number" &&
       Number.isFinite(input.maxConcurrent) &&

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -285,6 +285,22 @@ describe("route warmup config", () => {
     expect(routeWarmup.modules).toBe(true);
     expect(config.define?.__APP_DEFINE__).toBe(JSON.stringify("ok"));
   });
+
+  it("does not let app define options override the framework route warmup config", () => {
+    const config = defineConfig({
+      routeWarmup: { strategy: "viewport" },
+      define: {
+        __AGENT_NATIVE_ROUTE_WARMUP_CONFIG__: JSON.stringify({
+          strategy: "off",
+        }),
+      },
+    });
+    const routeWarmup = JSON.parse(
+      String(config.define?.__AGENT_NATIVE_ROUTE_WARMUP_CONFIG__),
+    );
+
+    expect(routeWarmup.strategy).toBe("viewport");
+  });
 });
 
 describe("Vite MCP embed headers", () => {

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -254,6 +254,39 @@ describe("Vite optimized dependency recovery", () => {
   });
 });
 
+describe("route warmup config", () => {
+  it("enables safe React Router route warmup by default", () => {
+    const config = defineConfig();
+    const routeWarmup = JSON.parse(
+      String(config.define?.__AGENT_NATIVE_ROUTE_WARMUP_CONFIG__),
+    );
+
+    expect(routeWarmup).toEqual({
+      strategy: "intent",
+      data: true,
+      modules: true,
+      selector: 'a[data-an-prefetch="render"][href]',
+      maxConcurrent: 4,
+    });
+  });
+
+  it("allows apps to choose a route warmup strategy in one Vite config place", () => {
+    const config = defineConfig({
+      routeWarmup: { strategy: "render", maxConcurrent: 8 },
+      define: { __APP_DEFINE__: JSON.stringify("ok") },
+    });
+    const routeWarmup = JSON.parse(
+      String(config.define?.__AGENT_NATIVE_ROUTE_WARMUP_CONFIG__),
+    );
+
+    expect(routeWarmup.strategy).toBe("render");
+    expect(routeWarmup.maxConcurrent).toBe(8);
+    expect(routeWarmup.data).toBe(true);
+    expect(routeWarmup.modules).toBe(true);
+    expect(config.define?.__APP_DEFINE__).toBe(JSON.stringify("ok"));
+  });
+});
+
 describe("Vite MCP embed headers", () => {
   it("adds COEP-compatible headers to embed-token page loads in dev", () => {
     const plugin = findPlugin("agent-native-embed-dev-frame-headers");

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -1285,10 +1285,14 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
     envDir,
     base,
     define: {
+      ...(options.define ?? {}),
+      // Framework route warmup controls how SSR `.data` routes are fetched:
+      // ordinary fetches keep them CDN-cacheable, while native prefetch headers
+      // can be refused before the CDN/origin sees the request. Keep this value
+      // authoritative even if app config provides its own `define` entries.
       __AGENT_NATIVE_ROUTE_WARMUP_CONFIG__: JSON.stringify(
         normalizeAgentNativeRouteWarmupConfig(options.routeWarmup),
       ),
-      ...(options.define ?? {}),
     },
     server: {
       host: "::",

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -21,6 +21,10 @@ import {
   mcpEmbedStaticAssetRouteRules,
   shouldAllowMcpEmbedCredentials,
 } from "../shared/mcp-embed-headers.js";
+import {
+  normalizeAgentNativeRouteWarmupConfig,
+  type AgentNativeRouteWarmupConfigInput,
+} from "../shared/route-warmup-config.js";
 
 import { fileURLToPath } from "url";
 
@@ -459,6 +463,18 @@ export interface ClientConfigOptions {
   fsDeny?: string[];
   /** Additional Vite optimizeDeps configuration */
   optimizeDeps?: NonNullable<UserConfig["optimizeDeps"]>;
+  /** Additional Vite define constants. */
+  define?: UserConfig["define"];
+  /**
+   * Framework route warmup behavior mounted by AgentSidebar.
+   *
+   * React Router's native prefetch warms both `.data` and JS, but its `.data`
+   * request uses browser link prefetch. Chrome sends `Sec-Purpose: prefetch`
+   * on those requests, which some production CDNs reject for dynamic `.data`
+   * URLs before our SWR cache headers can help. Agent-Native therefore uses
+   * ordinary fetches for `.data` and `modulepreload` for route JS by default.
+   */
+  routeWarmup?: AgentNativeRouteWarmupConfigInput;
   /**
    * Whether to auto-inject the Tailwind v4 Vite plugin (`@tailwindcss/vite`).
    * Defaults to true — set to `false` if a template wants to manage Tailwind
@@ -1268,6 +1284,12 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
     logLevel: options.logLevel ?? (isWorkspaceChild ? "warn" : undefined),
     envDir,
     base,
+    define: {
+      __AGENT_NATIVE_ROUTE_WARMUP_CONFIG__: JSON.stringify(
+        normalizeAgentNativeRouteWarmupConfig(options.routeWarmup),
+      ),
+      ...(options.define ?? {}),
+    },
     server: {
       host: "::",
       port: options.port ?? 8080,

--- a/packages/core/src/vite/index.ts
+++ b/packages/core/src/vite/index.ts
@@ -3,6 +3,11 @@ export {
   type ClientConfigOptions,
   type NitroOptions,
 } from "./client.js";
+export type {
+  AgentNativeRouteWarmupConfigInput,
+  AgentNativeRouteWarmupResolvedConfig,
+  AgentNativeRouteWarmupStrategy,
+} from "../shared/route-warmup-config.js";
 export {
   actionTypesPlugin,
   generateActionRegistryForProject,

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -8,9 +8,7 @@ import {
   isRouteErrorResponse,
   useRouteError,
   useLocation,
-  matchRoutes,
 } from "react-router";
-import type { RouteObject } from "react-router";
 import { useState, useEffect, useRef } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AgentSidebar, configureTracking } from "@agent-native/core/client";
@@ -106,44 +104,6 @@ const CANONICAL_ALIASES: Record<string, string> = {
   "/docs/getting-started": "/docs",
 };
 const SCROLL_MANAGER_MARKER = "docs-scroll-manager-marker";
-const DATA_ROUTE_PREFETCH_ATTR = "data-an-prefetch";
-const DATA_ROUTE_PREFETCH_SELECTOR = `a[${DATA_ROUTE_PREFETCH_ATTR}="render"][href]`;
-const MAX_CONCURRENT_DATA_PREFETCHES = 4;
-const warmedDataRoutes = new Set<string>();
-const warmedRouteAssets = new Set<string>();
-
-type ReactRouterManifestRoute = {
-  id: string;
-  parentId?: string;
-  path?: string;
-  index?: boolean;
-  module?: string;
-  clientActionModule?: string;
-  clientLoaderModule?: string;
-  hydrateFallbackModule?: string;
-  imports?: string[];
-};
-
-type ReactRouterManifest = {
-  routes?: Record<string, ReactRouterManifestRoute>;
-};
-
-type WarmupRouteObject = {
-  id: string;
-  path?: string;
-  index?: boolean;
-  children?: WarmupRouteObject[];
-};
-
-declare global {
-  interface Window {
-    __reactRouterContext?: { basename?: string };
-    __reactRouterManifest?: ReactRouterManifest;
-  }
-}
-
-let cachedManifest: ReactRouterManifest | undefined;
-let cachedManifestRouteTree: WarmupRouteObject[] = [];
 
 function CanonicalLink() {
   const location = useLocation();
@@ -270,217 +230,6 @@ function ScrollManager() {
   );
 }
 
-function dataRouteUrlForHref(href: string): string | null {
-  let url: URL;
-  try {
-    url = new URL(href, window.location.href);
-  } catch {
-    return null;
-  }
-
-  if (url.origin !== window.location.origin) return null;
-  if (url.pathname === window.location.pathname && url.hash) return null;
-  if (
-    url.pathname.startsWith("/_agent-native/") ||
-    url.pathname.startsWith("/api/")
-  ) {
-    return null;
-  }
-  if (/\.\w+$/.test(url.pathname)) return null;
-
-  const pathname = url.pathname.replace(/\/+$/, "") || "/";
-  if (pathname === "/") return null;
-  url.pathname = `${pathname}.data`;
-  url.hash = "";
-  return url.href;
-}
-
-function getManifestRouteTree(
-  manifest: ReactRouterManifest,
-): WarmupRouteObject[] {
-  if (manifest === cachedManifest) return cachedManifestRouteTree;
-
-  const manifestRoutes = Object.values(manifest.routes ?? {});
-  const nodes = new Map<string, WarmupRouteObject>();
-  for (const route of manifestRoutes) {
-    nodes.set(route.id, {
-      id: route.id,
-      path: route.path,
-      index: route.index || undefined,
-    });
-  }
-
-  const tree: WarmupRouteObject[] = [];
-  for (const route of manifestRoutes) {
-    const node = nodes.get(route.id);
-    if (!node) continue;
-    const parent = route.parentId ? nodes.get(route.parentId) : null;
-    if (parent) {
-      parent.children ??= [];
-      parent.children.push(node);
-    } else {
-      tree.push(node);
-    }
-  }
-
-  cachedManifest = manifest;
-  cachedManifestRouteTree = tree;
-  return tree;
-}
-
-function assetUrlForManifestPath(assetPath: string): string | null {
-  try {
-    const url = new URL(assetPath, window.location.origin);
-    if (url.origin !== window.location.origin) return null;
-    return url.href;
-  } catch {
-    return null;
-  }
-}
-
-function routeAssetUrlsForHref(href: string): string[] {
-  const manifest = window.__reactRouterManifest;
-  if (!manifest?.routes) return [];
-
-  let url: URL;
-  try {
-    url = new URL(href, window.location.href);
-  } catch {
-    return [];
-  }
-  if (url.origin !== window.location.origin) return [];
-  if (url.pathname === window.location.pathname && url.hash) return [];
-  if (
-    url.pathname.startsWith("/_agent-native/") ||
-    url.pathname.startsWith("/api/")
-  ) {
-    return [];
-  }
-  if (/\.\w+$/.test(url.pathname)) return [];
-
-  const basename = window.__reactRouterContext?.basename || "/";
-  const matches =
-    matchRoutes(
-      getManifestRouteTree(manifest) as unknown as RouteObject[],
-      url.pathname,
-      basename,
-    ) ?? [];
-  const assetUrls: string[] = [];
-
-  for (const match of matches) {
-    const routeId = match.route.id;
-    if (!routeId) continue;
-    const route = manifest.routes[routeId];
-    if (!route) continue;
-    for (const assetPath of [
-      route.module,
-      route.clientActionModule,
-      route.clientLoaderModule,
-      route.hydrateFallbackModule,
-      ...(route.imports ?? []),
-    ]) {
-      if (!assetPath) continue;
-      const assetUrl = assetUrlForManifestPath(assetPath);
-      if (assetUrl) assetUrls.push(assetUrl);
-    }
-  }
-
-  return assetUrls;
-}
-
-function warmRouteAssetsForHref(href: string) {
-  for (const assetUrl of routeAssetUrlsForHref(href)) {
-    if (warmedRouteAssets.has(assetUrl)) continue;
-    warmedRouteAssets.add(assetUrl);
-
-    const link = document.createElement("link");
-    link.rel = "modulepreload";
-    link.href = assetUrl;
-    document.head.appendChild(link);
-  }
-}
-
-function RouteWarmup() {
-  useEffect(() => {
-    const connection = (
-      navigator as Navigator & { connection?: { saveData?: boolean } }
-    ).connection;
-    if (connection?.saveData) return;
-
-    const queue: string[] = [];
-    let active = 0;
-    let stopped = false;
-    let scheduleTimer: number | undefined;
-
-    const pump = () => {
-      if (stopped) return;
-      while (active < MAX_CONCURRENT_DATA_PREFETCHES && queue.length > 0) {
-        const href = queue.shift();
-        if (!href) continue;
-        active += 1;
-        window
-          .fetch(href, { credentials: "same-origin", cache: "force-cache" })
-          .catch(() => {})
-          .finally(() => {
-            active -= 1;
-            window.setTimeout(pump, 50);
-          });
-      }
-    };
-
-    const enqueue = () => {
-      for (const link of document.querySelectorAll<HTMLLinkElement>(
-        'link[rel="modulepreload"][href]',
-      )) {
-        warmedRouteAssets.add(link.href);
-      }
-
-      for (const link of document.querySelectorAll<HTMLAnchorElement>(
-        DATA_ROUTE_PREFETCH_SELECTOR,
-      )) {
-        warmRouteAssetsForHref(link.href);
-        const dataUrl = dataRouteUrlForHref(link.href);
-        if (!dataUrl || warmedDataRoutes.has(dataUrl)) continue;
-        warmedDataRoutes.add(dataUrl);
-        queue.push(dataUrl);
-      }
-      pump();
-    };
-
-    const schedule = () => {
-      if (scheduleTimer !== undefined) window.clearTimeout(scheduleTimer);
-      scheduleTimer = window.setTimeout(() => {
-        scheduleTimer = undefined;
-        enqueue();
-      }, 0);
-    };
-
-    // Do not use React Router's native `prefetch="render"` on the public docs
-    // site while it sits behind Cloudflare. Native link prefetches carry
-    // `Sec-Purpose: prefetch`; Cloudflare Speed Brain intercepts those and
-    // returns 503 for dynamic routes before Netlify/origin can serve the
-    // now-cacheable `.data` response. This custom warmup uses ordinary fetches
-    // for route data and `modulepreload` for route JS chunks, keeping render-time
-    // navigations fast without re-entering Cloudflare's speculation refusal path.
-    schedule();
-    const observer = new MutationObserver(schedule);
-    observer.observe(document.documentElement, {
-      subtree: true,
-      childList: true,
-      attributes: true,
-      attributeFilter: ["href", DATA_ROUTE_PREFETCH_ATTR],
-    });
-
-    return () => {
-      stopped = true;
-      if (scheduleTimer !== undefined) window.clearTimeout(scheduleTimer);
-      observer.disconnect();
-    };
-  }, []);
-
-  return null;
-}
-
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -551,7 +300,6 @@ export default function Root() {
   const content = (
     <>
       <ScrollManager />
-      <RouteWarmup />
       <Header />
       <Outlet />
       <Footer />

--- a/packages/docs/server/routes/[...page].get.ts
+++ b/packages/docs/server/routes/[...page].get.ts
@@ -43,6 +43,9 @@ export default async function docsPageHandler(event: H3Event) {
       setHeader(event, name, value);
     }
     setDefaultSsrCacheHeaders(event);
+    // These page URLs can return either HTML or markdown based on Accept.
+    // Keep the variants isolated in browser/CDN caches.
+    setHeader(event, "vary", "Accept");
     return markdown.content;
   }
 
@@ -50,7 +53,8 @@ export default async function docsPageHandler(event: H3Event) {
     throw createError({ statusCode: 404, statusMessage: "Markdown not found" });
   }
 
-  return ssrHandler(event);
+  const response = await ssrHandler(event);
+  return responseWithVaryAccept(response);
 }
 
 function setDefaultSsrCacheHeaders(event: H3Event) {
@@ -60,6 +64,32 @@ function setDefaultSsrCacheHeaders(event: H3Event) {
   // provider and template gets the same short-fresh/long-SWR behavior.
   for (const [name, value] of Object.entries(DEFAULT_SSR_CACHE_HEADERS)) {
     setHeader(event, name, value);
+  }
+}
+
+function responseWithVaryAccept(response: Response): Response {
+  const headers = new Headers(response.headers);
+  appendVary(headers, "Accept");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function appendVary(headers: Headers, value: string) {
+  const existing = headers.get("vary");
+  if (!existing) {
+    headers.set("vary", value);
+    return;
+  }
+
+  const lowerValue = value.toLowerCase();
+  const alreadyPresent = existing
+    .split(",")
+    .some((part) => part.trim().toLowerCase() === lowerValue);
+  if (!alreadyPresent) {
+    headers.set("vary", `${existing}, ${value}`);
   }
 }
 

--- a/templates/clips/app/components/recorder/pre-record-panel.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.tsx
@@ -25,11 +25,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import {
   NO_CAMERA_DEVICE_ID,
@@ -386,8 +381,8 @@ export function PreRecordPanel({
           <div className="min-w-0">
             <h2 className="text-lg font-semibold">Record a clip</h2>
             <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-              {selectedMode?.label ?? "Screen + camera"} is selected. Choose
-              the exact tab, window, or screen after you start.
+              {selectedMode?.label ?? "Screen + camera"} is selected. Choose the
+              exact tab, window, or screen after you start.
             </p>
           </div>
         </div>

--- a/templates/clips/app/components/recorder/pre-record-panel.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.tsx
@@ -6,6 +6,7 @@ import {
   IconDeviceDesktop,
   IconDeviceScreen,
   IconMicrophone,
+  IconPlayerRecord,
   IconUpload,
   IconVideo,
 } from "@tabler/icons-react";
@@ -90,22 +91,22 @@ const MODE_OPTIONS: Array<{
   sub: string;
 }> = [
   {
-    value: "screen",
-    label: "Screen",
-    icon: IconDeviceScreen,
-    sub: "Record your screen",
+    value: "screen+camera",
+    label: "Screen + camera",
+    icon: IconVideo,
+    sub: "Show your face while sharing",
   },
   {
-    value: "screen+camera",
-    label: "Screen + cam",
-    icon: IconVideo,
-    sub: "Screen with webcam bubble",
+    value: "screen",
+    label: "Screen only",
+    icon: IconDeviceScreen,
+    sub: "Narrate without camera",
   },
   {
     value: "camera",
-    label: "Camera",
+    label: "Camera only",
     icon: IconCamera,
-    sub: "Just your webcam",
+    sub: "Talk directly to camera",
   },
 ];
 
@@ -253,6 +254,10 @@ export function PreRecordPanel({
         ?.label ?? "Window"
     );
   }, [displaySurface]);
+  const selectedMode = useMemo(
+    () => MODE_OPTIONS.find((option) => option.value === mode),
+    [mode],
+  );
 
   const deviceSummary = useMemo(() => {
     const parts = [audioEnabled ? selectedMicLabel : "No audio"];
@@ -372,47 +377,80 @@ export function PreRecordPanel({
   }, [audioEnabled, cameraTest.status, micTest.status, needsCamera]);
 
   return (
-    <div className="mx-auto w-full max-w-md overflow-hidden rounded-2xl border border-border bg-muted/20 shadow-lg">
-      <div className="space-y-4 p-6">
-        <div>
-          <h2 className="text-lg font-semibold">New recording</h2>
-          <p className="text-sm text-muted-foreground">
-            Choose a mode. The browser picker opens after Start.
-          </p>
+    <div className="mx-auto w-full max-w-lg overflow-hidden rounded-2xl border border-border bg-card shadow-lg">
+      <div className="border-b border-border p-6">
+        <div className="flex items-start gap-3">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-red-500/10 text-red-600">
+            <IconPlayerRecord className="h-5 w-5" />
+          </div>
+          <div className="min-w-0">
+            <h2 className="text-lg font-semibold">Record a clip</h2>
+            <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+              {selectedMode?.label ?? "Screen + camera"} is selected. Choose
+              the exact tab, window, or screen after you start.
+            </p>
+          </div>
         </div>
+      </div>
 
-        <div className="grid grid-cols-3 gap-1 rounded-xl bg-muted p-1">
+      <div className="space-y-3 p-6">
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Capture mode
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {selectedMode?.sub}
+          </div>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-3">
           {MODE_OPTIONS.map((opt) => {
             const Icon = opt.icon;
             const active = opt.value === mode;
             return (
-              <Tooltip key={opt.value}>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setMode(opt.value);
-                      if (
-                        opt.value === "camera" &&
-                        cameraId === NO_CAMERA_DEVICE_ID
-                      ) {
-                        setCameraId("default");
-                      }
-                    }}
-                    className={cn(
-                      "flex h-11 min-w-0 items-center justify-center rounded-lg px-2 transition-colors",
-                      active
-                        ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
-                    )}
-                    aria-label={`${opt.label}: ${opt.sub}`}
-                    aria-pressed={active}
-                  >
-                    <Icon className="h-5 w-5 shrink-0" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>{opt.label}</TooltipContent>
-              </Tooltip>
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => {
+                  setMode(opt.value);
+                  if (
+                    opt.value === "camera" &&
+                    cameraId === NO_CAMERA_DEVICE_ID
+                  ) {
+                    setCameraId("default");
+                  }
+                }}
+                className={cn(
+                  "flex min-h-24 min-w-0 flex-col rounded-xl border p-3 text-left transition-colors",
+                  active
+                    ? "border-primary bg-primary text-primary-foreground shadow-sm"
+                    : "border-border bg-background text-foreground hover:border-foreground/30 hover:bg-muted/45",
+                )}
+                aria-pressed={active}
+              >
+                <span
+                  className={cn(
+                    "mb-3 flex h-9 w-9 items-center justify-center rounded-full",
+                    active
+                      ? "bg-primary-foreground/15 text-primary-foreground"
+                      : "bg-muted text-muted-foreground",
+                  )}
+                >
+                  <Icon className="h-4 w-4" />
+                </span>
+                <span className="text-sm font-medium leading-tight">
+                  {opt.label}
+                </span>
+                <span
+                  className={cn(
+                    "mt-1 text-[11px] leading-snug",
+                    active
+                      ? "text-primary-foreground/70"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  {opt.sub}
+                </span>
+              </button>
             );
           })}
         </div>
@@ -656,10 +694,11 @@ export function PreRecordPanel({
               })
             }
             className={cn(
-              "h-11 bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-primary",
+              "h-12 gap-2 bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-600",
               onCancel ? "flex-1" : "w-full",
             )}
           >
+            <IconPlayerRecord className="h-4 w-4" />
             Start recording
           </Button>
         </div>

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -487,22 +487,27 @@ function PreRecordPanelSkeleton() {
 
 function DesktopRecorderCallout() {
   return (
-    <aside className="w-full p-1">
-      <div className="min-w-0">
-        <div className="text-sm font-medium text-foreground">
-          Get the desktop app
+    <aside className="w-full rounded-2xl border border-border bg-card p-4 shadow-lg">
+      <div className="flex items-start gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+          <IconDeviceDesktop className="h-4 w-4" />
         </div>
-        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-          Menu-bar launch and global shortcuts make repeat recordings smoother.
-        </p>
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-foreground">
+            Better in the desktop app
+          </div>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            Menu-bar launch, global shortcuts, auto-updates, and smoother repeat
+            recordings.
+          </p>
+        </div>
       </div>
       <Button
         asChild
-        variant="outline"
         size="sm"
-        className="mt-3 w-full bg-background/70"
+        className="mt-4 w-full bg-primary text-primary-foreground hover:bg-primary/90"
       >
-        <Link to="/download">Download</Link>
+        <Link to="/download">Download desktop app</Link>
       </Button>
     </aside>
   );
@@ -1818,7 +1823,7 @@ export default function RecordRoute() {
                 )}
               </div>
               {!isDesktopApp && (
-                <div className="mx-auto mt-4 w-full max-w-md xl:absolute xl:left-[calc(50%+15rem)] xl:top-0 xl:mt-0 xl:w-72">
+                <div className="mx-auto mt-4 w-full max-w-lg xl:absolute xl:left-[calc(50%+18rem)] xl:top-0 xl:mt-0 xl:w-72">
                   <DesktopRecorderCallout />
                 </div>
               )}

--- a/templates/content/.agents/skills/notion-integration/SKILL.md
+++ b/templates/content/.agents/skills/notion-integration/SKILL.md
@@ -57,19 +57,54 @@ pnpm action push-notion-page --documentId abc123
 
 This overwrites the Notion page's content with the local document's markdown, converted to Notion blocks.
 
+## How Sync Works (Architecture)
+
+Documents are stored as **Notion-Flavored Markdown (NFM)** — the exact format
+Notion's `/pages/{id}/markdown` API emits and accepts. The storage form is
+Notion's *canonical* form, so a synced document is byte-identical on both sides.
+
+- `shared/nfm.ts` is the single deterministic converter: `nfmToDoc` (NFM →
+  ProseMirror JSON) and `docToNfm` (ProseMirror JSON → NFM), plus
+  `canonicalizeNfm = docToNfm ∘ nfmToDoc`. It is used by **both** the editor
+  (`setContent(nfmToDoc(x))` / `docToNfm(editor.getJSON())`) and the server
+  (pull canonicalization + content hashing).
+- The converter is a proven **fixpoint**: `docToNfm(nfmToDoc(x)) === x` for all
+  canonical NFM `x`, verified by `shared/nfm.spec.ts` (pure) and
+  `app/components/editor/nfm-editor.roundtrip.test.ts` (real TipTap schema).
+  Because our canonical form equals Notion's emission, pull→edit→push→pull
+  never drifts.
+- **Do not** route Notion content through `shared/notion-markdown.ts` (the old
+  tiptap-markdown bridge). It is retained only for clipboard copy/paste.
+
+Supported losslessly: paragraphs, headings (incl. toggle headings via
+`{toggle="true"}`), bulleted/numbered/to-do lists with tab nesting, real quote
+blocks (multi-line via `<br>`), block colors (`{color="…"}`), inline
+bold/italic/strike/code/underline/color/background and links, inline + block
+equations, code blocks, dividers, `<empty-block/>`, callouts, toggles, columns,
+tables (header row/column, cell/row colors), images/audio/video/file/pdf, page
+and database references, synced blocks (children preserved), mentions, and
+backslash-escaped special characters. Visual indentation is a block `indent`
+attribute (Tab indents a block, matching Notion).
+
 ## Sync State
 
 The `document_sync_links` table tracks sync relationships:
 
-| Column                         | Description                                |
-| ------------------------------ | ------------------------------------------ |
-| `document_id`                  | Local document ID                          |
-| `provider`                     | Always "notion"                            |
-| `remote_page_id`               | Notion page ID                             |
-| `state`                        | "linked", "syncing", "error"               |
-| `last_synced_at`               | Timestamp of last successful sync          |
-| `has_conflict`                 | Whether there's a merge conflict (0 or 1)  |
-| `last_error`                   | Error message if sync failed               |
+| Column                     | Description                                            |
+| -------------------------- | ----------------------------------------------------- |
+| `document_id`              | Local document ID                                     |
+| `provider`                 | Always "notion"                                        |
+| `remote_page_id`           | Notion page ID                                         |
+| `state`                    | "linked", "syncing", "error", "conflict"              |
+| `last_synced_at`           | Timestamp of last successful sync                     |
+| `last_synced_content_hash` | SHA-256 of the canonical content identical on both sides — the authoritative "did it change" signal (immune to timestamp jitter) |
+| `has_conflict`             | Whether both sides changed since last sync (0 or 1)   |
+| `last_error`               | Error message if sync failed                          |
+
+Conflict detection is **content-hash based**: a side has "changed" only when its
+canonical content hash differs from `last_synced_content_hash`. A no-op sync
+(identical canonical content) is never mistaken for an edit — this is what keeps
+the two copies from drifting.
 
 ## Common Tasks
 
@@ -83,7 +118,11 @@ The `document_sync_links` table tracks sync relationships:
 
 ## Important Notes
 
-- Notion sync requires a connected Notion integration (API key configured in settings)
-- Pull overwrites local content; push overwrites Notion content — there is no automatic merge
-- The `has_conflict` flag is set when both sides have changed since last sync
-- Always check `connect-notion-status` before attempting sync operations
+- Notion access is **per-user OAuth only**. Never read `NOTION_API_KEY` from the
+  environment or accept a user-pasted token; require editor access for pull/push.
+- Pull replaces local content with Notion's; push replaces Notion's with local.
+  When both sides changed since the last sync the link enters `conflict` state and
+  the user resolves it (pull-wins or push-wins) — there is no line-level merge.
+- Because storage is canonical NFM, a no-op sync changes nothing: editing the
+  same document in Notion and in the app will not create growing inconsistencies.
+- Always check `connect-notion-status` before attempting sync operations.

--- a/templates/content/app/components/editor/VisualEditor.tsx
+++ b/templates/content/app/components/editor/VisualEditor.tsx
@@ -43,10 +43,7 @@ import { notionFidelityExtensions } from "./extensions/NotionFidelity";
 import { DragHandle } from "./extensions/DragHandle";
 import { CodeBlock } from "./extensions/CodeBlockNode";
 import { toast } from "sonner";
-import {
-  parseNfmForEditor,
-  serializeEditorToNfm,
-} from "@shared/notion-markdown";
+import { canonicalizeNfm, docToNfm, nfmToDoc } from "@shared/nfm";
 import {
   isReconcileLeadClient,
   AGENT_CLIENT_ID,
@@ -1341,7 +1338,7 @@ export function VisualEditor({
     // prop AND the Y.Doc, firing an initial (non-remote) update that could
     // autosave a stale value over newer SQL. Only seed `content` when there is
     // no ydoc (tests / non-collaborative embedders).
-    content: ydoc ? undefined : parseNfmForEditor(content),
+    content: ydoc ? undefined : nfmToDoc(content),
     editorProps: {
       attributes: {
         class: "notion-editor",
@@ -1455,8 +1452,7 @@ export function VisualEditor({
       if (transaction && isChangeOrigin(transaction)) return;
       lastTypedAtRef.current = Date.now();
       try {
-        const md = (editor.storage as any).markdown.getMarkdown();
-        const normalized = serializeEditorToNfm(md);
+        const normalized = docToNfm(editor.getJSON() as any);
         // Don't save empty content when Collaboration hasn't seeded yet —
         // this prevents overwriting DB content with empty string
         if (!normalized.trim() && ydoc) return;
@@ -1486,9 +1482,7 @@ export function VisualEditor({
     // brand-new doc at once don't both seed and duplicate the content.
     if (!isLeadClient) return;
     const fragment = ydoc.getXmlFragment("default");
-    const currentMd = serializeEditorToNfm(
-      (editor.storage as any).markdown.getMarkdown(),
-    );
+    const currentMd = docToNfm(editor.getJSON() as any);
     if (
       shouldSeedCollaborativeContent({
         content,
@@ -1497,7 +1491,7 @@ export function VisualEditor({
       })
     ) {
       isSettingContent.current = true;
-      editor.commands.setContent(parseNfmForEditor(content));
+      editor.commands.setContent(nfmToDoc(content));
       isSettingContent.current = false;
       if (contentUpdatedAt) lastAppliedUpdatedAtRef.current = contentUpdatedAt;
     }
@@ -1527,11 +1521,9 @@ export function VisualEditor({
 
     const run = (deferred = false) => {
       if (cancelled || !editor || editor.isDestroyed) return;
-      const nextEditorContent = parseNfmForEditor(content);
-      const currentMd = serializeEditorToNfm(
-        (editor.storage as any).markdown.getMarkdown(),
-      );
-      const normalizedNext = serializeEditorToNfm(nextEditorContent);
+      const nextEditorContent = nfmToDoc(content);
+      const currentMd = docToNfm(editor.getJSON() as any);
+      const normalizedNext = canonicalizeNfm(content);
 
       // Already in sync, or our own echo: advance the applied watermark so a
       // later write is correctly recognized as newer, then stop. (After a peer's

--- a/templates/content/app/components/editor/VisualEditor.tsx
+++ b/templates/content/app/components/editor/VisualEditor.tsx
@@ -39,6 +39,7 @@ import {
   focusMostRecentEmptyToggleSummary,
   notionEditorExtensions,
 } from "./extensions/NotionExtensions";
+import { notionFidelityExtensions } from "./extensions/NotionFidelity";
 import { DragHandle } from "./extensions/DragHandle";
 import { CodeBlock } from "./extensions/CodeBlockNode";
 import { toast } from "sonner";
@@ -467,32 +468,40 @@ const NotionToggleBodyPlaceholder = Extension.create({
  * Runs at lower priority than ListItem/TaskItem (which bind Tab to sinkListItem),
  * so list sinking still works and we only kick in for non-list blocks.
  */
-const NotionBlockIndent = Extension.create({
-  name: "notionBlockIndent",
-  priority: 50,
-  addKeyboardShortcuts() {
-    const inHandled = (editor: any) =>
-      editor.isActive("listItem") ||
-      editor.isActive("taskItem") ||
-      editor.isActive("tableCell") ||
-      editor.isActive("tableHeader") ||
-      editor.isActive("codeBlock");
-
+const CustomTable = BaseTable.extend({
+  addAttributes() {
     return {
-      Tab: ({ editor }) => {
-        if (inHandled(editor)) return false;
-        return editor.chain().focus().wrapIn("blockquote").run();
+      ...this.parent?.(),
+      // Notion table structure attributes — preserved so the NFM converter can
+      // round-trip header rows/columns, full-width tables, and column colors.
+      headerRow: {
+        default: false,
+        parseHTML: (element: HTMLElement) =>
+          element.getAttribute("data-header-row") === "true",
+        renderHTML: (attributes: Record<string, any>) =>
+          attributes.headerRow ? { "data-header-row": "true" } : {},
       },
-      "Shift-Tab": ({ editor }) => {
-        if (inHandled(editor)) return false;
-        if (!editor.isActive("blockquote")) return false;
-        return editor.chain().focus().lift("blockquote").run();
+      headerColumn: {
+        default: false,
+        parseHTML: (element: HTMLElement) =>
+          element.getAttribute("data-header-column") === "true",
+        renderHTML: (attributes: Record<string, any>) =>
+          attributes.headerColumn ? { "data-header-column": "true" } : {},
+      },
+      fitPageWidth: {
+        default: false,
+        parseHTML: (element: HTMLElement) =>
+          element.getAttribute("data-fit-page-width") === "true",
+        renderHTML: (attributes: Record<string, any>) =>
+          attributes.fitPageWidth ? { "data-fit-page-width": "true" } : {},
+      },
+      colMeta: {
+        default: null,
+        parseHTML: () => null,
+        renderHTML: () => ({}),
       },
     };
   },
-});
-
-const CustomTable = BaseTable.extend({
   addStorage() {
     return {
       markdown: {
@@ -1181,13 +1190,13 @@ export function createVisualEditorExtensions({
     TableCell,
     NormalizeTableHeaders,
     ...notionEditorExtensions,
+    ...notionFidelityExtensions,
     DragHandle,
     TypographyReplacements,
     NotionMarkdownShortcuts,
     MarkdownPasteDetection,
     SelectAllDocument,
     JoinFirstBodyBlockToTitle.configure({ onJoinTitle }),
-    NotionBlockIndent,
     Markdown.configure({
       html: true,
       transformPastedText: true,

--- a/templates/content/app/components/editor/__claim_verify.test.ts
+++ b/templates/content/app/components/editor/__claim_verify.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { Markdown } from "tiptap-markdown";
+import { describe, expect, it } from "vitest";
+import {
+  parseNfmForEditor,
+  serializeEditorToNfm,
+  normalizeNfmForStorage,
+  normalizeNfmForNotion,
+} from "@shared/notion-markdown";
+import { EmptyLineParagraph } from "./VisualEditor";
+import { CodeBlock } from "./extensions/CodeBlockNode";
+import { NotionToggle } from "./extensions/NotionExtensions";
+
+// Mirror the markdown editor used in existing tests + the real serialize path.
+function createMarkdownEditor(content: string) {
+  return new Editor({
+    extensions: [
+      StarterKit.configure({ codeBlock: false, paragraph: false }),
+      CodeBlock,
+      EmptyLineParagraph,
+      NotionToggle,
+      Markdown.configure({
+        html: true,
+        transformPastedText: true,
+        transformCopiedText: true,
+      }),
+    ],
+    content: parseNfmForEditor(content),
+  });
+}
+
+// The REAL production round trip: stored NFM -> editor -> getMarkdown -> serializeEditorToNfm
+function realRoundTrip(stored: string): string {
+  const editor = createMarkdownEditor(stored);
+  try {
+    const md = (editor.storage as any).markdown.getMarkdown();
+    return serializeEditorToNfm(md);
+  } finally {
+    editor.destroy();
+  }
+}
+
+describe("CLAIM: phantom blank line between parent and tab-indented child", () => {
+  const cases = [
+    ["plain indented text", "parent\n\tchild"],
+    ["list under paragraph", "parent\n\t- child"],
+    ["deeper plain indent", "parent\n\tchild\n\t\tgrandchild"],
+  ];
+
+  it.fails("CLAIM shortcut: serializeEditorToNfm(parseNfmForEditor(x))", () => {
+    for (const [label, input] of cases) {
+      const stored = normalizeNfmForStorage(input);
+      const editorMd = parseNfmForEditor(input);
+      const shortcut = serializeEditorToNfm(editorMd);
+
+      expect(shortcut, label).not.toContain("\n\n\t");
+      expect(normalizeNfmForNotion(shortcut), label).toBe(
+        normalizeNfmForNotion(stored),
+      );
+    }
+  });
+
+  it.fails("REAL markdown editor round trip", () => {
+    for (const [label, input] of cases) {
+      const stored = normalizeNfmForStorage(input);
+      const rt = realRoundTrip(stored);
+      const notionStored = normalizeNfmForNotion(stored);
+      const notionRt = normalizeNfmForNotion(rt);
+
+      expect(rt, label).not.toContain("\n\n\t");
+      expect(notionRt, label).toBe(notionStored);
+    }
+  });
+});

--- a/templates/content/app/components/editor/extensions/NotionFidelity.ts
+++ b/templates/content/app/components/editor/extensions/NotionFidelity.ts
@@ -1,0 +1,166 @@
+import { Extension, Node, mergeAttributes } from "@tiptap/core";
+
+/**
+ * Fidelity extensions that let the TipTap schema losslessly represent the
+ * Notion-flavored-Markdown features the sync converter (`shared/nfm.ts`) needs:
+ *
+ *   - Block colors (`{color="red"}`) on paragraphs, headings, quotes, table
+ *     cells/rows.
+ *   - Visual indentation (Notion lets any block be a child of another). We model
+ *     it as an `indent` attribute on paragraphs/headings, set by Tab — matching
+ *     Notion, where Tab indents a block rather than turning it into a quote.
+ *   - Synced blocks as a real container node so their children round-trip
+ *     instead of being dropped (the previous atom modelling silently lost the
+ *     synced content, risking deletion on push).
+ *
+ * These keep the editor's ProseMirror JSON a faithful mirror of the Notion
+ * block tree so `docToNfm(editor.getJSON())` is byte-stable.
+ */
+
+const COLOR_TYPES = [
+  "paragraph",
+  "heading",
+  "blockquote",
+  "tableCell",
+  "tableHeader",
+  "tableRow",
+];
+const INDENT_TYPES = ["paragraph", "heading"];
+const MAX_INDENT = 12;
+
+export const NotionBlockColor = Extension.create({
+  name: "notionBlockColor",
+  addGlobalAttributes() {
+    return [
+      {
+        types: COLOR_TYPES,
+        attributes: {
+          color: {
+            default: null,
+            parseHTML: (element) => element.getAttribute("data-notion-color"),
+            renderHTML: (attributes) => {
+              if (!attributes.color) return {};
+              const color = String(attributes.color);
+              const isBg = color.endsWith("_bg");
+              const base = isBg ? color.slice(0, -3) : color;
+              return {
+                "data-notion-color": color,
+                class: isBg
+                  ? `notion-block-bg notion-block-bg--${base}`
+                  : `notion-block-color notion-block-color--${base}`,
+              };
+            },
+          },
+        },
+      },
+    ];
+  },
+});
+
+export const NotionBlockIndentAttr = Extension.create({
+  name: "notionBlockIndentAttr",
+  priority: 50,
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: INDENT_TYPES,
+        attributes: {
+          indent: {
+            default: 0,
+            parseHTML: (element) => {
+              const value = Number.parseInt(
+                element.getAttribute("data-indent") || "0",
+                10,
+              );
+              return Number.isFinite(value) && value > 0
+                ? Math.min(value, MAX_INDENT)
+                : 0;
+            },
+            renderHTML: (attributes) => {
+              const value = Number(attributes.indent) || 0;
+              if (value <= 0) return {};
+              return {
+                "data-indent": String(value),
+                style: `margin-left: ${value * 1.5}em`,
+              };
+            },
+          },
+        },
+      },
+    ];
+  },
+
+  addKeyboardShortcuts() {
+    const inHandledNode = (editor: any) =>
+      editor.isActive("listItem") ||
+      editor.isActive("taskItem") ||
+      editor.isActive("tableCell") ||
+      editor.isActive("tableHeader") ||
+      editor.isActive("codeBlock");
+
+    const shiftIndent = (editor: any, delta: number) => {
+      const { selection } = editor.state;
+      const node = selection.$from.parent;
+      if (!node || !INDENT_TYPES.includes(node.type.name)) return false;
+      const current = Number(node.attrs.indent) || 0;
+      const next = Math.max(0, Math.min(MAX_INDENT, current + delta));
+      if (next === current) return delta < 0;
+      return editor.commands.updateAttributes(node.type.name, { indent: next });
+    };
+
+    return {
+      Tab: ({ editor }) => {
+        if (inHandledNode(editor)) return false;
+        return shiftIndent(editor, 1);
+      },
+      "Shift-Tab": ({ editor }) => {
+        if (inHandledNode(editor)) return false;
+        return shiftIndent(editor, -1);
+      },
+    };
+  },
+});
+
+/**
+ * A synced block container. Children are real editor blocks so the synced
+ * content round-trips to/from Notion instead of being discarded.
+ */
+export const NotionSyncedBlock = Node.create({
+  name: "notionSyncedBlock",
+  group: "block",
+  content: "block+",
+  defining: true,
+
+  addAttributes() {
+    return {
+      url: { default: null },
+      isReference: { default: false },
+      notice: { default: null },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "div[data-notion-synced-block]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, {
+        "data-notion-synced-block": "true",
+        "data-synced-reference": HTMLAttributes.isReference
+          ? "true"
+          : undefined,
+        class: "notion-synced-block",
+      }),
+      0,
+    ];
+  },
+});
+
+export const notionFidelityExtensions = [
+  NotionBlockColor,
+  NotionBlockIndentAttr,
+  NotionSyncedBlock,
+];

--- a/templates/content/app/components/editor/nfm-editor.roundtrip.test.ts
+++ b/templates/content/app/components/editor/nfm-editor.roundtrip.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment happy-dom
+
+import { Editor } from "@tiptap/core";
+import { describe, expect, it } from "vitest";
+import { createVisualEditorExtensions } from "./VisualEditor";
+import { docToNfm, nfmToDoc } from "@shared/nfm";
+
+/**
+ * End-to-end fidelity: load canonical NFM into a REAL TipTap editor (full
+ * extension set, the same schema the app runs) and serialize it back. If the
+ * result differs from the input, opening a synced document and saving it with
+ * no edits would mutate it — exactly the drift this rewrite eliminates.
+ */
+function editorRoundTrip(nfm: string): string {
+  const editor = new Editor({
+    extensions: createVisualEditorExtensions(),
+    content: nfmToDoc(nfm),
+  });
+  const out = docToNfm(editor.getJSON() as any);
+  editor.destroy();
+  return out;
+}
+
+const L = (...lines: string[]) => lines.join("\n");
+
+const CASES: Array<{ name: string; nfm: string }> = [
+  { name: "plain paragraph", nfm: "Just a paragraph." },
+  {
+    name: "inline marks",
+    nfm: 'Intro with **bold**, *italic*, ~~strike~~, `code`, <span underline="true">underline</span>, <span color="red">red text</span>, a [link](https://example.com).',
+  },
+  { name: "inline math", nfm: "before $`a^2 + b^2`$ after" },
+  { name: "block color paragraph", nfm: 'Colored paragraph {color="red"}' },
+  {
+    name: "headings",
+    nfm: L(
+      "# Heading One",
+      "## Heading Two",
+      "### Heading Three",
+      "#### Heading Four",
+    ),
+  },
+  { name: "colored heading", nfm: '## Blue heading {color="blue"}' },
+  {
+    name: "toggle heading",
+    nfm: L(
+      '## Toggle Heading Two {toggle="true"}',
+      "\tChild under toggle heading",
+    ),
+  },
+  { name: "single quote", nfm: "> A single real quote block" },
+  {
+    name: "multi-line quote",
+    nfm: "> Multi-line quote line one<br>line two<br>line three",
+  },
+  {
+    name: "nested bullets",
+    nfm: L("- bullet one", "\t- nested bullet", "- bullet two"),
+  },
+  { name: "numbered list", nfm: L("1. first", "2. second") },
+  { name: "todo list", nfm: L("- [ ] unchecked todo", "- [x] checked todo") },
+  {
+    name: "callout with nested list",
+    nfm: L(
+      '<callout icon="💡" color="blue_bg">',
+      "\tCallout with **bold** text",
+      "\t- callout item one",
+      "\t- callout item two",
+      "</callout>",
+    ),
+  },
+  {
+    name: "toggle with children",
+    nfm: L(
+      "<details>",
+      "<summary>A toggle</summary>",
+      "\tHidden child paragraph",
+      "\t- hidden bullet",
+      "</details>",
+    ),
+  },
+  {
+    name: "columns",
+    nfm: L(
+      "<columns>",
+      "\t<column>",
+      "\t\tLeft column text",
+      "\t</column>",
+      "\t<column>",
+      "\t\tRight column text",
+      "\t</column>",
+      "</columns>",
+    ),
+  },
+  {
+    name: "table with header row + column + cell color",
+    nfm: L(
+      '<table header-row="true" header-column="true">',
+      "<tr>",
+      "<td>H1</td>",
+      "<td>H2</td>",
+      "</tr>",
+      "<tr>",
+      "<td>r1c1</td>",
+      '<td color="green_bg">r1c2 green</td>',
+      "</tr>",
+      "</table>",
+    ),
+  },
+  {
+    name: "code block",
+    nfm: L("```python", "def f(x):", "    return x < 3 and x * 2", "```"),
+  },
+  {
+    name: "block equation",
+    nfm: L("$$", "\\int_0^1 x^2 dx = \\frac{1}{3}", "$$"),
+  },
+  { name: "divider between text", nfm: L("above", "---", "below") },
+  { name: "empty block", nfm: L("above", "<empty-block/>", "below") },
+  {
+    name: "visual indent",
+    nfm: L("root", "\tindented once", "\t\tindented twice"),
+  },
+  { name: "image", nfm: "![A caption](https://cdn.example.com/x.png)" },
+  {
+    name: "page atom",
+    nfm: '<page url="https://www.notion.so/abc">Child Page</page>',
+  },
+  {
+    name: "mention inline",
+    nfm: 'Hello <mention-page url="https://www.notion.so/abc">A Page</mention-page> there',
+  },
+  {
+    name: "synced block with children",
+    nfm: L(
+      '<synced_block url="https://www.notion.so/s">',
+      "\tShared content",
+      "</synced_block>",
+    ),
+  },
+  {
+    name: "literal special chars",
+    nfm: "Text with a \\< b, 2 \\* 3, price \\$5, \\[bracket\\].",
+  },
+];
+
+describe("NFM ⇄ real TipTap editor round-trip", () => {
+  for (const { name, nfm } of CASES) {
+    it(`round-trips through the live schema: ${name}`, () => {
+      expect(editorRoundTrip(nfm)).toBe(nfm);
+    });
+  }
+});

--- a/templates/content/app/components/editor/nfm-editor.roundtrip.test.ts
+++ b/templates/content/app/components/editor/nfm-editor.roundtrip.test.ts
@@ -144,8 +144,72 @@ const CASES: Array<{ name: string; nfm: string }> = [
   },
 ];
 
+const HARD_CASES: Array<{ name: string; nfm: string }> = [
+  { name: "colored bullet item", nfm: '- colored item {color="green"}' },
+  { name: "colored heading", nfm: '# Big red {color="red"}' },
+  { name: "colored quote", nfm: '> Quoted in gray {color="gray"}' },
+  {
+    name: "toggle inside callout",
+    nfm: L(
+      '<callout icon="📌">',
+      "\tCallout intro",
+      "\t<details>",
+      "\t<summary>Nested toggle</summary>",
+      "\t\tdeep content",
+      "\t</details>",
+      "</callout>",
+    ),
+  },
+  {
+    name: "quote with child blocks",
+    nfm: L(
+      "> Quote lead",
+      "\tChild paragraph of the quote",
+      "\t- child bullet",
+    ),
+  },
+  {
+    name: "table with column colors (colgroup)",
+    nfm: L(
+      '<table header-row="true">',
+      "<colgroup>",
+      '<col color="gray"/>',
+      "<col/>",
+      "</colgroup>",
+      "<tr>",
+      "<td>A</td>",
+      "<td>B</td>",
+      "</tr>",
+      "<tr>",
+      '<td color="red_bg">1</td>',
+      "<td>2</td>",
+      "</tr>",
+      "</table>",
+    ),
+  },
+  {
+    name: "row color",
+    nfm: L(
+      "<table>",
+      '<tr color="blue_bg">',
+      "<td>x</td>",
+      "</tr>",
+      "</table>",
+    ),
+  },
+  { name: "combined marks", nfm: "[**important**](https://x.com)" },
+  {
+    name: "synced block reference",
+    nfm: L(
+      '<synced_block_reference url="https://www.notion.so/r">',
+      "\tref content",
+      "</synced_block_reference>",
+    ),
+  },
+];
+
 describe("NFM ⇄ real TipTap editor round-trip", () => {
-  for (const { name, nfm } of CASES) {
+  for (const { name, nfm } of [...CASES, ...HARD_CASES]) {
     it(`round-trips through the live schema: ${name}`, () => {
       expect(editorRoundTrip(nfm)).toBe(nfm);
     });

--- a/templates/content/app/global.css
+++ b/templates/content/app/global.css
@@ -880,6 +880,80 @@
 }
 
 /* Enhanced Notion-flavored markdown blocks */
+/* Notion block colors and backgrounds (matches Notion's light-mode palette).
+   Applied by the NotionBlockColor fidelity extension via `data-notion-color`
+   and the .notion-block-color--* / .notion-block-bg--* classes. */
+.notion-block-color--gray {
+  color: #787774;
+}
+.notion-block-color--brown {
+  color: #976d57;
+}
+.notion-block-color--orange {
+  color: #cc772f;
+}
+.notion-block-color--yellow {
+  color: #c29243;
+}
+.notion-block-color--green {
+  color: #548164;
+}
+.notion-block-color--blue {
+  color: #487ca5;
+}
+.notion-block-color--purple {
+  color: #8a67ab;
+}
+.notion-block-color--pink {
+  color: #b35488;
+}
+.notion-block-color--red {
+  color: #c4554d;
+}
+
+.notion-block-bg {
+  display: block;
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+}
+.notion-block-bg--gray {
+  background-color: #f1f1ef;
+}
+.notion-block-bg--brown {
+  background-color: #f4eeee;
+}
+.notion-block-bg--orange {
+  background-color: #fbecdd;
+}
+.notion-block-bg--yellow {
+  background-color: #fbf3db;
+}
+.notion-block-bg--green {
+  background-color: #edf3ec;
+}
+.notion-block-bg--blue {
+  background-color: #e7f3f8;
+}
+.notion-block-bg--purple {
+  background-color: #f6f3f9;
+}
+.notion-block-bg--pink {
+  background-color: #faf1f5;
+}
+.notion-block-bg--red {
+  background-color: #fdebec;
+}
+
+/* Synced block container — a subtle marker so it reads as shared content. */
+.notion-synced-block {
+  border-left: 2px solid #d0a8e0;
+  padding-left: 0.75em;
+  margin: 0.2em 0;
+}
+.notion-synced-block[data-synced-reference="true"] {
+  border-left-color: #b0b0b0;
+}
+
 .notion-toggle {
   margin: 0.2em 0;
 }

--- a/templates/content/server/db/schema.ts
+++ b/templates/content/server/db/schema.ts
@@ -56,6 +56,11 @@ export const documentSyncLinks = table("document_sync_links", {
   lastPulledRemoteUpdatedAt: text("last_pulled_remote_updated_at"),
   lastPushedLocalUpdatedAt: text("last_pushed_local_updated_at"),
   lastKnownRemoteUpdatedAt: text("last_known_remote_updated_at"),
+  // Hash of the canonical content that is currently identical on both sides.
+  // Content-based change detection is immune to timestamp jitter and the
+  // normalization mismatches that previously caused no-op syncs to look like
+  // real edits (the root of the bidirectional drift).
+  lastSyncedContentHash: text("last_synced_content_hash"),
   lastError: text("last_error"),
   warningsJson: text("warnings_json"),
   hasConflict: integer("has_conflict").notNull().default(0),

--- a/templates/content/server/lib/notion-sync.ts
+++ b/templates/content/server/lib/notion-sync.ts
@@ -196,6 +196,7 @@ export async function getDocumentSyncStatus(
       documentId,
       link,
       documentUpdatedAt: document.updatedAt,
+      documentContent: document.content,
     });
   }
 
@@ -211,6 +212,7 @@ export async function getDocumentSyncStatus(
       link,
       remoteUpdatedAt,
       documentUpdatedAt: document.updatedAt,
+      documentContent: document.content,
     });
   } catch (error: any) {
     await upsertSyncLink({
@@ -222,6 +224,7 @@ export async function getDocumentSyncStatus(
       lastPulledRemoteUpdatedAt: link.lastPulledRemoteUpdatedAt,
       lastPushedLocalUpdatedAt: link.lastPushedLocalUpdatedAt,
       lastKnownRemoteUpdatedAt: link.lastKnownRemoteUpdatedAt,
+      lastSyncedContentHash: link.lastSyncedContentHash,
       lastError: error.message || "Failed to load Notion page",
       warnings: parseWarnings(link),
       hasConflict: Boolean(link.hasConflict),
@@ -232,6 +235,7 @@ export async function getDocumentSyncStatus(
       documentId,
       link: next,
       documentUpdatedAt: document.updatedAt,
+      documentContent: document.content,
     });
   }
 }
@@ -534,6 +538,7 @@ export async function refreshDocumentSyncStatus(
       documentId,
       link,
       documentUpdatedAt: document.updatedAt,
+      documentContent: document.content,
     });
   }
   lastRefreshAt.set(documentId, now);
@@ -563,6 +568,7 @@ export async function refreshDocumentSyncStatus(
           lastPulledRemoteUpdatedAt: link.lastPulledRemoteUpdatedAt,
           lastPushedLocalUpdatedAt: link.lastPushedLocalUpdatedAt,
           lastKnownRemoteUpdatedAt: status.lastKnownRemoteUpdatedAt,
+          lastSyncedContentHash: link.lastSyncedContentHash,
           lastError: null,
           warnings: parseWarnings(link),
           hasConflict: true,
@@ -575,6 +581,7 @@ export async function refreshDocumentSyncStatus(
           link: updatedLink,
           remoteUpdatedAt: status.lastKnownRemoteUpdatedAt,
           documentUpdatedAt: document.updatedAt,
+          documentContent: document.content,
         });
       }
     }

--- a/templates/content/server/lib/notion-sync.ts
+++ b/templates/content/server/lib/notion-sync.ts
@@ -287,14 +287,14 @@ export async function pullDocumentFromNotion(
     ? hashContent(document.content) !== link.lastSyncedContentHash
     : Boolean(
         link.lastPushedLocalUpdatedAt &&
-          document.updatedAt > link.lastPushedLocalUpdatedAt,
+        document.updatedAt > link.lastPushedLocalUpdatedAt,
       );
   const remoteChanged = link.lastSyncedContentHash
     ? hashContent(pageContent.content) !== link.lastSyncedContentHash
     : Boolean(
         link.lastPulledRemoteUpdatedAt &&
-          pageContent.lastEditedTime &&
-          pageContent.lastEditedTime > link.lastPulledRemoteUpdatedAt,
+        pageContent.lastEditedTime &&
+        pageContent.lastEditedTime > link.lastPulledRemoteUpdatedAt,
       );
 
   if (!force && localChanged && remoteChanged) {
@@ -407,14 +407,14 @@ export async function pushDocumentToNotion(
   // candidate remote change (the pulled content below confirms it).
   const remoteChanged = Boolean(
     link.lastKnownRemoteUpdatedAt &&
-      remoteUpdatedAt &&
-      remoteUpdatedAt > link.lastKnownRemoteUpdatedAt,
+    remoteUpdatedAt &&
+    remoteUpdatedAt > link.lastKnownRemoteUpdatedAt,
   );
   const localChanged = link.lastSyncedContentHash
     ? hashContent(document.content) !== link.lastSyncedContentHash
     : Boolean(
         !link.lastPushedLocalUpdatedAt ||
-          document.updatedAt > link.lastPushedLocalUpdatedAt,
+        document.updatedAt > link.lastPushedLocalUpdatedAt,
       );
 
   if (!force && localChanged && remoteChanged) {
@@ -468,7 +468,12 @@ export async function pushDocumentToNotion(
   if (contentChanged) {
     await db
       .update(schema.documents)
-      .set({ title: newTitle, content: newContent, icon: newIcon, updatedAt: pushedAt })
+      .set({
+        title: newTitle,
+        content: newContent,
+        icon: newIcon,
+        updatedAt: pushedAt,
+      })
       .where(
         and(
           eq(schema.documents.id, documentId),

--- a/templates/content/server/lib/notion-sync.ts
+++ b/templates/content/server/lib/notion-sync.ts
@@ -653,7 +653,9 @@ export async function createAndLinkNotionPage(
     documentId,
     remotePageId: newPage.id,
     state: "linked",
+    lastPushedLocalUpdatedAt: document.updatedAt,
     lastKnownRemoteUpdatedAt: null,
+    lastSyncedContentHash: hashContent(document.content),
     warnings: [],
     hasConflict: false,
   });

--- a/templates/content/server/lib/notion-sync.ts
+++ b/templates/content/server/lib/notion-sync.ts
@@ -1,8 +1,10 @@
 // @ts-nocheck — Drizzle ORM types from core vs local resolve to different instances
 // in pnpm's node_modules. Logic is correct; types just don't unify across instances.
+import crypto from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import type { InferSelectModel } from "drizzle-orm";
 import { getDb, schema } from "../db/index.js";
+import { canonicalizeNfm } from "../../shared/nfm.js";
 import { deleteCollabState, releaseDoc } from "@agent-native/core/collab";
 import {
   createNotionPageWithMarkdown,
@@ -23,6 +25,19 @@ function nowIso() {
   return new Date().toISOString();
 }
 
+/**
+ * Hash of the canonical content. Two documents with the same hash are
+ * byte-identical once canonicalized, so this is the authoritative "did the
+ * content actually change" signal — immune to timestamp jitter and to the
+ * normalization differences that previously made no-op syncs look like edits.
+ */
+function hashContent(content: string | null | undefined): string {
+  return crypto
+    .createHash("sha256")
+    .update(canonicalizeNfm(content ?? ""))
+    .digest("hex");
+}
+
 function parseWarnings(link: Pick<LinkRow, "warningsJson"> | null): string[] {
   if (!link?.warningsJson) return [];
   try {
@@ -41,6 +56,7 @@ function buildStatus(args: {
   link: LinkRow | null;
   remoteUpdatedAt?: string | null;
   documentUpdatedAt?: string | null;
+  documentContent?: string | null;
 }): DocumentSyncStatus {
   const link = args.link;
   const lastPushed = link?.lastPushedLocalUpdatedAt || null;
@@ -52,9 +68,15 @@ function buildStatus(args: {
     link?.lastPulledRemoteUpdatedAt &&
     remoteKnown > link.lastPulledRemoteUpdatedAt,
   );
-  const localChanged = Boolean(
-    localUpdatedAt && lastPushed && localUpdatedAt > lastPushed,
-  );
+  // Prefer content-hash change detection: the local doc differs from the
+  // last-synced state only if its canonical content hash differs. This is the
+  // key fix for the drift — a no-op editor save (identical canonical content)
+  // no longer registers as a local change. Fall back to timestamps for links
+  // synced before the hash column existed.
+  const localChanged =
+    args.documentContent != null && link?.lastSyncedContentHash
+      ? hashContent(args.documentContent) !== link.lastSyncedContentHash
+      : Boolean(localUpdatedAt && lastPushed && localUpdatedAt > lastPushed);
 
   return {
     provider: "notion",
@@ -115,6 +137,7 @@ async function upsertSyncLink(args: {
   lastPulledRemoteUpdatedAt?: string | null;
   lastPushedLocalUpdatedAt?: string | null;
   lastKnownRemoteUpdatedAt?: string | null;
+  lastSyncedContentHash?: string | null;
   lastError?: string | null;
   warnings?: string[];
   hasConflict?: boolean;
@@ -130,6 +153,7 @@ async function upsertSyncLink(args: {
     lastPulledRemoteUpdatedAt: args.lastPulledRemoteUpdatedAt ?? null,
     lastPushedLocalUpdatedAt: args.lastPushedLocalUpdatedAt ?? null,
     lastKnownRemoteUpdatedAt: args.lastKnownRemoteUpdatedAt ?? null,
+    lastSyncedContentHash: args.lastSyncedContentHash ?? null,
     lastError: args.lastError ?? null,
     warningsJson: JSON.stringify(args.warnings || []),
     hasConflict: args.hasConflict ? 1 : 0,

--- a/templates/content/server/lib/notion-sync.ts
+++ b/templates/content/server/lib/notion-sync.ts
@@ -275,15 +275,23 @@ export async function pullDocumentFromNotion(
     link.remotePageId,
   );
 
-  const localChanged = Boolean(
-    link.lastPushedLocalUpdatedAt &&
-    document.updatedAt > link.lastPushedLocalUpdatedAt,
-  );
-  const remoteChanged = Boolean(
-    link.lastPulledRemoteUpdatedAt &&
-    pageContent.lastEditedTime &&
-    pageContent.lastEditedTime > link.lastPulledRemoteUpdatedAt,
-  );
+  // Content-hash change detection: a side "changed" only if its canonical
+  // content actually differs from the last-synced baseline. This is immune to
+  // the normalization mismatches and timestamp jitter that previously made
+  // every no-op pull look like a fresh edit and drove the drift.
+  const localChanged = link.lastSyncedContentHash
+    ? hashContent(document.content) !== link.lastSyncedContentHash
+    : Boolean(
+        link.lastPushedLocalUpdatedAt &&
+          document.updatedAt > link.lastPushedLocalUpdatedAt,
+      );
+  const remoteChanged = link.lastSyncedContentHash
+    ? hashContent(pageContent.content) !== link.lastSyncedContentHash
+    : Boolean(
+        link.lastPulledRemoteUpdatedAt &&
+          pageContent.lastEditedTime &&
+          pageContent.lastEditedTime > link.lastPulledRemoteUpdatedAt,
+      );
 
   if (!force && localChanged && remoteChanged) {
     await upsertSyncLink({
@@ -295,6 +303,7 @@ export async function pullDocumentFromNotion(
       lastPulledRemoteUpdatedAt: link.lastPulledRemoteUpdatedAt,
       lastPushedLocalUpdatedAt: link.lastPushedLocalUpdatedAt,
       lastKnownRemoteUpdatedAt: pageContent.lastEditedTime,
+      lastSyncedContentHash: link.lastSyncedContentHash,
       lastError: null,
       warnings: pageContent.warnings,
       hasConflict: true,
@@ -306,6 +315,7 @@ export async function pullDocumentFromNotion(
       link: updatedLink,
       remoteUpdatedAt: pageContent.lastEditedTime,
       documentUpdatedAt: document.updatedAt,
+      documentContent: document.content,
     });
   }
 
@@ -358,6 +368,7 @@ export async function pullDocumentFromNotion(
     lastPulledRemoteUpdatedAt: pageContent.lastEditedTime,
     lastPushedLocalUpdatedAt: updatedAt,
     lastKnownRemoteUpdatedAt: pageContent.lastEditedTime,
+    lastSyncedContentHash: hashContent(newContent),
     lastError: null,
     warnings: pageContent.warnings,
     hasConflict: false,
@@ -370,6 +381,7 @@ export async function pullDocumentFromNotion(
     link: updatedLink,
     remoteUpdatedAt: pageContent.lastEditedTime,
     documentUpdatedAt: updatedAt,
+    documentContent: newContent,
   });
 }
 
@@ -385,15 +397,21 @@ export async function pushDocumentToNotion(
   if (!connection) throw new Error("Connect Notion before pushing.");
 
   const page = await fetchNotionPage(connection.accessToken, link.remotePageId);
+  const remoteUpdatedAt = page.last_edited_time || null;
+  // Did Notion's content actually change since we last synced? The cheap signal
+  // is last_edited_time; with a content baseline we treat any time bump as a
+  // candidate remote change (the pulled content below confirms it).
   const remoteChanged = Boolean(
-    link.lastPulledRemoteUpdatedAt &&
-    page.last_edited_time &&
-    page.last_edited_time > link.lastPulledRemoteUpdatedAt,
+    link.lastKnownRemoteUpdatedAt &&
+      remoteUpdatedAt &&
+      remoteUpdatedAt > link.lastKnownRemoteUpdatedAt,
   );
-  const localChanged = Boolean(
-    !link.lastPushedLocalUpdatedAt ||
-    document.updatedAt > link.lastPushedLocalUpdatedAt,
-  );
+  const localChanged = link.lastSyncedContentHash
+    ? hashContent(document.content) !== link.lastSyncedContentHash
+    : Boolean(
+        !link.lastPushedLocalUpdatedAt ||
+          document.updatedAt > link.lastPushedLocalUpdatedAt,
+      );
 
   if (!force && localChanged && remoteChanged) {
     await upsertSyncLink({
@@ -404,7 +422,8 @@ export async function pushDocumentToNotion(
       lastSyncedAt: link.lastSyncedAt,
       lastPulledRemoteUpdatedAt: link.lastPulledRemoteUpdatedAt,
       lastPushedLocalUpdatedAt: link.lastPushedLocalUpdatedAt,
-      lastKnownRemoteUpdatedAt: page.last_edited_time || null,
+      lastKnownRemoteUpdatedAt: remoteUpdatedAt,
+      lastSyncedContentHash: link.lastSyncedContentHash,
       lastError: null,
       warnings: parseWarnings(link),
       hasConflict: true,
@@ -414,8 +433,9 @@ export async function pushDocumentToNotion(
       connected: true,
       documentId,
       link: updatedLink,
-      remoteUpdatedAt: page.last_edited_time || null,
+      remoteUpdatedAt,
       documentUpdatedAt: document.updatedAt,
+      documentContent: document.content,
     });
   }
 
@@ -427,16 +447,48 @@ export async function pushDocumentToNotion(
     icon: document.icon,
   });
 
-  const pushedAt = nowIso();
+  // Adopt Notion's post-push normalization locally so both sides are
+  // byte-identical and the next sync sees no change. For canonical content this
+  // is a no-op (the converter matches Notion's emission); it only does work in
+  // the rare case Notion normalizes a construct differently, immediately
+  // converging instead of ping-ponging.
+  const db = getDb();
+  const newContent = remote.content ?? document.content;
+  const newTitle = remote.title || document.title;
+  const newIcon = remote.icon;
+  const contentChanged =
+    newTitle !== document.title ||
+    newContent !== document.content ||
+    newIcon !== document.icon;
+  const pushedAt = contentChanged ? nowIso() : document.updatedAt;
+  if (contentChanged) {
+    await db
+      .update(schema.documents)
+      .set({ title: newTitle, content: newContent, icon: newIcon, updatedAt: pushedAt })
+      .where(
+        and(
+          eq(schema.documents.id, documentId),
+          eq(schema.documents.ownerEmail, owner),
+        ),
+      );
+    try {
+      await deleteCollabState(documentId);
+      releaseDoc(documentId);
+    } catch {
+      // Non-fatal — the client reconciles via setContent.
+    }
+  }
+
   await upsertSyncLink({
     owner,
     documentId,
     remotePageId: link.remotePageId,
     state: "linked",
-    lastSyncedAt: pushedAt,
+    lastSyncedAt: nowIso(),
     lastPulledRemoteUpdatedAt: remote.lastEditedTime,
-    lastPushedLocalUpdatedAt: document.updatedAt,
+    lastPushedLocalUpdatedAt: pushedAt,
     lastKnownRemoteUpdatedAt: remote.lastEditedTime,
+    lastSyncedContentHash: hashContent(newContent),
     lastError: null,
     warnings: remote.warnings,
     hasConflict: false,
@@ -448,7 +500,8 @@ export async function pushDocumentToNotion(
     documentId,
     link: updatedLink,
     remoteUpdatedAt: remote.lastEditedTime,
-    documentUpdatedAt: document.updatedAt,
+    documentUpdatedAt: pushedAt,
+    documentContent: newContent,
   });
 }
 

--- a/templates/content/server/lib/notion.spec.ts
+++ b/templates/content/server/lib/notion.spec.ts
@@ -18,6 +18,7 @@ import {
   type NotionPageMarkdown,
 } from "./notion";
 import { listOAuthAccountsByOwner } from "@agent-native/core/oauth-tokens";
+import { canonicalizeNfm } from "../../shared/nfm";
 import {
   normalizeNfmForStorage,
   parseNfmForEditor,
@@ -151,7 +152,7 @@ describe("resolveNotionMarkdownResponse", () => {
     );
   });
 
-  it("hydrates indented list subtrees without creating code-block indentation", async () => {
+  it("hydrates unknown-block subtrees into canonical content", async () => {
     vi.mocked(global.fetch).mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -175,14 +176,16 @@ describe("resolveNotionMarkdownResponse", () => {
       truncated: false,
       unknown_block_ids: ["child-block"],
     });
-    const editorMarkdown = parseNfmForEditor(result.markdown);
 
-    expect(result.markdown).toContain("\t- notion doc");
-    expect(editorMarkdown).toContain("> - notion doc");
-    expect(editorMarkdown).toContain(
-      "> - access: amplitude, fullstory, sigma, jira",
+    // The hydrated subtree is present and the result is already canonical
+    // (re-canonicalizing is a no-op — no drift).
+    expect(result.markdown).toContain("- notion doc");
+    expect(result.markdown).toContain(
+      "- access: amplitude, fullstory, sigma, jira",
     );
-    expect(editorMarkdown).not.toMatch(/^ {4,}- /m);
+    expect(result.markdown).toContain("michael onboarding");
+    expect(result.markdown).not.toContain("<unknown");
+    expect(canonicalizeNfm(result.markdown)).toBe(result.markdown);
   });
 
   it("hydrates indented toggle subtrees without creating code-block HTML", async () => {
@@ -276,7 +279,7 @@ describe("createNotionPageWithMarkdown", () => {
     global.fetch = originalFetch;
   });
 
-  it("sends Notion-normalized markdown for toggles, lists, and dividers", async () => {
+  it("sends canonical Notion-flavored markdown (toggles, lists, dividers)", async () => {
     vi.mocked(global.fetch).mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -290,37 +293,33 @@ describe("createNotionPageWithMarkdown", () => {
       ),
     );
 
+    const content = [
+      "<details>",
+      "<summary>→ → team mtg guidance on hackathon</summary>",
+      "\tInside the toggle",
+      "</details>",
+      "- parent",
+      "\t- child",
+      "above",
+      "---",
+      "below",
+    ].join("\n");
+
     await createNotionPageWithMarkdown({
       accessToken: "token",
       parentPageId: "parent-page",
       title: "Builder Todo",
-      content: [
-        '<details open="" data-heading-level="2">',
-        "<summary>→ → team mtg guidance on hackathon</summary>",
-        "</details>",
-        "",
-        "- parent",
-        "    - child",
-        "above",
-        "---",
-        "below",
-      ].join("\n"),
+      content,
     });
 
     const request = vi.mocked(global.fetch).mock.calls[0];
     expect(request[0]).toBe("https://api.notion.com/v1/pages");
     const body = JSON.parse(String(request[1]?.body));
-    expect(body.markdown).toContain(
-      [
-        "<details>",
-        "<summary>→ → team mtg guidance on hackathon</summary>",
-        "\t<empty-block/>",
-        "</details>",
-      ].join("\n"),
-    );
+    // The pushed markdown is exactly the canonical form — and canonical content
+    // is already a fixpoint, so this push will round-trip without drift.
+    expect(body.markdown).toBe(canonicalizeNfm(content));
+    expect(canonicalizeNfm(body.markdown)).toBe(body.markdown);
     expect(body.markdown).toContain("- parent\n\t- child");
-    expect(body.markdown).toContain("above\n\n---\n\nbelow");
-    expect(body.markdown).not.toContain("data-heading-level");
-    expect(body.markdown).not.toContain("open=");
+    expect(body.markdown).toContain("<summary>→ → team mtg guidance on hackathon</summary>");
   });
 });

--- a/templates/content/server/lib/notion.spec.ts
+++ b/templates/content/server/lib/notion.spec.ts
@@ -320,6 +320,8 @@ describe("createNotionPageWithMarkdown", () => {
     expect(body.markdown).toBe(canonicalizeNfm(content));
     expect(canonicalizeNfm(body.markdown)).toBe(body.markdown);
     expect(body.markdown).toContain("- parent\n\t- child");
-    expect(body.markdown).toContain("<summary>→ → team mtg guidance on hackathon</summary>");
+    expect(body.markdown).toContain(
+      "<summary>→ → team mtg guidance on hackathon</summary>",
+    );
   });
 });

--- a/templates/content/server/lib/notion.ts
+++ b/templates/content/server/lib/notion.ts
@@ -7,10 +7,7 @@ import {
 import { assertAccess } from "@agent-native/core/sharing";
 import { getSession, runWithRequestContext } from "@agent-native/core/server";
 import { createError, type H3Event } from "h3";
-import {
-  normalizeNfmForNotion,
-  normalizeNfmForStorage,
-} from "../../shared/notion-markdown.js";
+import { canonicalizeNfm } from "../../shared/nfm.js";
 
 export const NOTION_PROVIDER = "notion";
 export const NOTION_API_BASE = "https://api.notion.com/v1";
@@ -197,7 +194,7 @@ async function hydrateUnknownBlockSubtrees(
 
       hydrated = replaceFirstUnknownPlaceholder(
         hydrated,
-        normalizeNfmForStorage(resolvedSubtree),
+        canonicalizeNfm(resolvedSubtree),
       );
     } catch (error) {
       if (
@@ -249,7 +246,7 @@ export async function resolveNotionMarkdownResponse(
     );
   }
 
-  markdown = normalizeNfmForStorage(markdown);
+  markdown = canonicalizeNfm(markdown);
 
   return { markdown, warnings: uniqueWarnings(warnings) };
 }
@@ -345,66 +342,6 @@ export async function readNotionPageAsDocument(
   };
 }
 
-type ChildRef = { kind: "page" | "database"; id: string };
-
-async function fetchChildRefs(
-  accessToken: string,
-  pageId: string,
-): Promise<ChildRef[]> {
-  const refs: ChildRef[] = [];
-  let cursor: string | undefined;
-
-  do {
-    const query = cursor
-      ? `?start_cursor=${cursor}&page_size=100`
-      : "?page_size=100";
-    const response = await notionFetch<{
-      results: Array<{ type: string; id: string }>;
-      has_more: boolean;
-      next_cursor: string | null;
-    }>(`/blocks/${pageId}/children${query}`, accessToken);
-
-    for (const block of response.results) {
-      if (block.type === "child_page") {
-        refs.push({ kind: "page", id: block.id });
-      } else if (block.type === "child_database") {
-        refs.push({ kind: "database", id: block.id });
-      }
-    }
-
-    cursor =
-      response.has_more && response.next_cursor
-        ? response.next_cursor
-        : undefined;
-  } while (cursor);
-
-  return refs;
-}
-
-/**
- * Build a Notion URL from a block ID. The canonical `https://www.notion.so/<id>`
- * form (hyphens stripped) is accepted by Notion's markdown API and resolves to
- * the correct page/database. Using `url` attribute (not `id`) is required —
- * Notion's `replace_content` markdown validator looks for the URL attribute
- * when checking whether children are preserved.
- */
-function notionUrlForId(id: string): string {
-  return `https://www.notion.so/${id.replace(/-/g, "")}`;
-}
-
-function appendChildRefTags(markdown: string, refs: ChildRef[]): string {
-  if (refs.length === 0) return markdown;
-  const tags = refs
-    .map((ref) => {
-      const url = notionUrlForId(ref.id);
-      return ref.kind === "database"
-        ? `<database url="${url}" />`
-        : `<page url="${url}" />`;
-    })
-    .join("\n");
-  return `${markdown}\n${tags}`;
-}
-
 export async function pushDocumentToNotionPage(args: {
   accessToken: string;
   pageId: string;
@@ -412,15 +349,15 @@ export async function pushDocumentToNotionPage(args: {
   content: string;
   icon?: string | null;
 }): Promise<NotionPageContent> {
-  const [page, childRefs] = await Promise.all([
-    fetchNotionPage(args.accessToken, args.pageId),
-    fetchChildRefs(args.accessToken, args.pageId),
-  ]);
+  const page = await fetchNotionPage(args.accessToken, args.pageId);
 
-  const markdown = appendChildRefTags(
-    normalizeNfmForNotion(args.content),
-    childRefs,
-  );
+  // The canonical content already contains `<page>`/`<database>` tags for any
+  // child pages/databases (they round-trip through the converter), so they stay
+  // in place. We must NOT re-append them — per the NFM spec an existing-URL
+  // `<page>` tag MOVES that child, which previously reordered children to the
+  // bottom of the page on every push. `allow_deleting_content: false` remains
+  // the backstop against accidental removal.
+  const markdown = canonicalizeNfm(args.content);
 
   try {
     await notionFetch(`/pages/${args.pageId}/markdown`, args.accessToken, {
@@ -482,7 +419,7 @@ export async function createNotionPageWithMarkdown(args: {
         ],
       },
     },
-    markdown: normalizeNfmForNotion(args.content),
+    markdown: canonicalizeNfm(args.content),
   };
 
   if (args.icon) {

--- a/templates/content/shared/__eq_roundtrip.test.ts
+++ b/templates/content/shared/__eq_roundtrip.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { parseNfmForEditor, serializeEditorToNfm } from "./notion-markdown";
+
+describe("equation roundtrip", () => {
+  it.fails("preserves block equations through NFM parse/serialize", () => {
+    const storage = "$$\nx^2\n$$";
+    const editorMarkdown = parseNfmForEditor(storage);
+    const restored = serializeEditorToNfm(editorMarkdown);
+
+    expect(restored).toBe(storage);
+  });
+});

--- a/templates/content/shared/nfm.spec.ts
+++ b/templates/content/shared/nfm.spec.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import { canonicalizeNfm, docToNfm, nfmToDoc } from "./nfm";
+
+/**
+ * Every fixture below is a byte-exact sample of what Notion's
+ * `/pages/{id}/markdown` API actually emits (captured from a live round-trip
+ * probe). The whole contract of the converter is that these are FIXPOINTS:
+ * canonicalizeNfm(x) === x and docToNfm(nfmToDoc(x)) === x. If a fixture is not
+ * a fixpoint, a pull/edit/push cycle would mutate the document — the exact drift
+ * bug this module exists to prevent.
+ */
+const L = (...lines: string[]) => lines.join("\n");
+
+const FIXTURES: Array<{ name: string; nfm: string }> = [
+  { name: "plain paragraph", nfm: "Just a paragraph." },
+  {
+    name: "inline marks",
+    nfm: "Intro with **bold**, *italic*, ~~strike~~, `code`, <span underline=\"true\">underline</span>, <span color=\"red\">red text</span>, <span color=\"blue_bg\">blue bg</span>, a [link](https://example.com), and inline math $`E = mc^2`$.",
+  },
+  { name: "block color paragraph", nfm: 'Colored paragraph {color="red"}' },
+  { name: "headings", nfm: L("# Heading One", "## Heading Two", "### Heading Three", "#### Heading Four") },
+  { name: "toggle heading", nfm: L('## Toggle Heading Two {toggle="true"}', "\tChild under toggle heading") },
+  { name: "single quote", nfm: "> A single real quote block" },
+  { name: "multi-line quote", nfm: "> Multi-line quote line one<br>line two<br>line three" },
+  { name: "quote with color", nfm: '> Quoted {color="gray"}' },
+  { name: "nested bullets", nfm: L("- bullet one", "\t- nested bullet", "- bullet two") },
+  { name: "numbered list", nfm: L("1. first", "2. second", "3. third") },
+  { name: "todo list", nfm: L("- [ ] unchecked todo", "- [x] checked todo") },
+  {
+    name: "callout with nested list",
+    nfm: L(
+      '<callout icon="💡" color="blue_bg">',
+      "\tCallout with **bold** and a nested list:",
+      "\t- callout item one",
+      "\t- callout item two",
+      "</callout>",
+    ),
+  },
+  {
+    name: "toggle with children",
+    nfm: L(
+      "<details>",
+      "<summary>A toggle</summary>",
+      "\tHidden child paragraph",
+      "\t- hidden bullet",
+      "</details>",
+    ),
+  },
+  {
+    name: "columns",
+    nfm: L(
+      "<columns>",
+      "\t<column>",
+      "\t\tLeft column text",
+      "\t</column>",
+      "\t<column>",
+      "\t\tRight column text",
+      "\t</column>",
+      "</columns>",
+    ),
+  },
+  {
+    name: "table with header row + column + cell color",
+    nfm: L(
+      '<table header-row="true" header-column="true">',
+      "<tr>",
+      "<td>H1</td>",
+      "<td>H2</td>",
+      "</tr>",
+      "<tr>",
+      "<td>r1c1</td>",
+      '<td color="green_bg">r1c2 green</td>',
+      "</tr>",
+      "</table>",
+    ),
+  },
+  {
+    name: "code block (literal, unescaped)",
+    nfm: L("```python", "def f(x):", "    return x < 3 and x * 2", "```"),
+  },
+  { name: "block equation", nfm: L("$$", "\\int_0^1 x^2 dx = \\frac{1}{3}", "$$") },
+  {
+    name: "literal special chars (escaped)",
+    nfm: "Text with literal special chars: a \\< b, 2 \\* 3, x_y, price \\$5, \\[bracket\\], \\{brace\\}.",
+  },
+  { name: "divider", nfm: "---" },
+  { name: "empty block", nfm: L("above", "<empty-block/>", "below") },
+  { name: "consecutive empty blocks", nfm: L("first", "<empty-block/>", "<empty-block/>", "last") },
+  { name: "page atom", nfm: '<page url="https://www.notion.so/abc">Child Page</page>' },
+  { name: "table of contents atom", nfm: "<table_of_contents/>" },
+  { name: "image", nfm: "![A caption](https://cdn.example.com/x.png)" },
+  { name: "mention inline", nfm: '<mention-page url="https://www.notion.so/abc">A Page</mention-page>' },
+  { name: "mention date self-closing", nfm: '<mention-date start="2026-06-01"/>' },
+  {
+    name: "synced block with children",
+    nfm: L('<synced_block url="https://www.notion.so/s">', "\tShared content", "</synced_block>"),
+  },
+  { name: "visual-indented paragraphs", nfm: L("root", "\tindented once", "\t\tindented twice") },
+  {
+    name: "nested toggles",
+    nfm: L(
+      "<details>",
+      "<summary>Outer</summary>",
+      "\t<details>",
+      "\t<summary>Inner</summary>",
+      "\t\tinner child",
+      "\t</details>",
+      "</details>",
+    ),
+  },
+];
+
+describe("nfm converter — canonical fixpoints", () => {
+  for (const { name, nfm } of FIXTURES) {
+    it(`is a fixpoint: ${name}`, () => {
+      expect(canonicalizeNfm(nfm)).toBe(nfm);
+      expect(docToNfm(nfmToDoc(nfm))).toBe(nfm);
+    });
+  }
+
+  it("the whole probe document round-trips byte-exact", () => {
+    const doc = FIXTURES.map((f) => f.nfm).join("\n");
+    expect(canonicalizeNfm(doc)).toBe(doc);
+  });
+
+  it("is idempotent under double canonicalization", () => {
+    const doc = FIXTURES.map((f) => f.nfm).join("\n");
+    expect(canonicalizeNfm(canonicalizeNfm(doc))).toBe(canonicalizeNfm(doc));
+  });
+});
+
+describe("nfm converter — structural parsing", () => {
+  it("parses a toggle heading into notionToggle with headingLevel", () => {
+    const doc = nfmToDoc('## H {toggle="true"}\n\tchild');
+    expect(doc.content[0].type).toBe("notionToggle");
+    expect(doc.content[0].attrs?.headingLevel).toBe(2);
+    expect(doc.content[0].attrs?.summary).toBe("H");
+    expect(doc.content[0].content?.[0].type).toBe("paragraph");
+  });
+
+  it("keeps a real quote distinct from indentation", () => {
+    const quote = nfmToDoc("> quote");
+    expect(quote.content[0].type).toBe("blockquote");
+    const indent = nfmToDoc("root\n\tchild");
+    expect(indent.content[1].type).toBe("paragraph");
+    expect(indent.content[1].attrs?.indent).toBe(1);
+  });
+
+  it("models a synced block as a container (children preserved)", () => {
+    const doc = nfmToDoc('<synced_block url="u">\n\tkid\n</synced_block>');
+    expect(doc.content[0].type).toBe("notionSyncedBlock");
+    expect(doc.content[0].content?.[0].type).toBe("paragraph");
+  });
+
+  it("parses table header cells and cell colors", () => {
+    const doc = nfmToDoc(
+      '<table header-row="true">\n<tr>\n<td>A</td>\n</tr>\n<tr>\n<td color="red">b</td>\n</tr>\n</table>',
+    );
+    const table = doc.content[0];
+    expect(table.type).toBe("table");
+    expect(table.content?.[0].content?.[0].type).toBe("tableHeader");
+    expect(table.content?.[1].content?.[0].type).toBe("tableCell");
+    expect(table.content?.[1].content?.[0].attrs?.color).toBe("red");
+  });
+});
+
+describe("nfm converter — inline round-trips", () => {
+  const inlineCases = [
+    "**bold**",
+    "*italic*",
+    "***bold italic***",
+    "~~strike~~",
+    "`code span`",
+    "`multi<br>line code`",
+    "<span underline=\"true\">u</span>",
+    "<span color=\"purple\">colored</span>",
+    "<span color=\"green_bg\">bg</span>",
+    "[text](https://x.com)",
+    "[**bold link**](https://x.com)",
+    "before $`a^2 + b^2`$ after",
+    "line one<br>line two",
+    "literal \\* not italic and a \\[ bracket",
+  ];
+  for (const text of inlineCases) {
+    it(`inline fixpoint: ${text}`, () => {
+      expect(canonicalizeNfm(text)).toBe(text);
+    });
+  }
+});

--- a/templates/content/shared/nfm.spec.ts
+++ b/templates/content/shared/nfm.spec.ts
@@ -15,15 +15,35 @@ const FIXTURES: Array<{ name: string; nfm: string }> = [
   { name: "plain paragraph", nfm: "Just a paragraph." },
   {
     name: "inline marks",
-    nfm: "Intro with **bold**, *italic*, ~~strike~~, `code`, <span underline=\"true\">underline</span>, <span color=\"red\">red text</span>, <span color=\"blue_bg\">blue bg</span>, a [link](https://example.com), and inline math $`E = mc^2`$.",
+    nfm: 'Intro with **bold**, *italic*, ~~strike~~, `code`, <span underline="true">underline</span>, <span color="red">red text</span>, <span color="blue_bg">blue bg</span>, a [link](https://example.com), and inline math $`E = mc^2`$.',
   },
   { name: "block color paragraph", nfm: 'Colored paragraph {color="red"}' },
-  { name: "headings", nfm: L("# Heading One", "## Heading Two", "### Heading Three", "#### Heading Four") },
-  { name: "toggle heading", nfm: L('## Toggle Heading Two {toggle="true"}', "\tChild under toggle heading") },
+  {
+    name: "headings",
+    nfm: L(
+      "# Heading One",
+      "## Heading Two",
+      "### Heading Three",
+      "#### Heading Four",
+    ),
+  },
+  {
+    name: "toggle heading",
+    nfm: L(
+      '## Toggle Heading Two {toggle="true"}',
+      "\tChild under toggle heading",
+    ),
+  },
   { name: "single quote", nfm: "> A single real quote block" },
-  { name: "multi-line quote", nfm: "> Multi-line quote line one<br>line two<br>line three" },
+  {
+    name: "multi-line quote",
+    nfm: "> Multi-line quote line one<br>line two<br>line three",
+  },
   { name: "quote with color", nfm: '> Quoted {color="gray"}' },
-  { name: "nested bullets", nfm: L("- bullet one", "\t- nested bullet", "- bullet two") },
+  {
+    name: "nested bullets",
+    nfm: L("- bullet one", "\t- nested bullet", "- bullet two"),
+  },
   { name: "numbered list", nfm: L("1. first", "2. second", "3. third") },
   { name: "todo list", nfm: L("- [ ] unchecked todo", "- [x] checked todo") },
   {
@@ -78,24 +98,46 @@ const FIXTURES: Array<{ name: string; nfm: string }> = [
     name: "code block (literal, unescaped)",
     nfm: L("```python", "def f(x):", "    return x < 3 and x * 2", "```"),
   },
-  { name: "block equation", nfm: L("$$", "\\int_0^1 x^2 dx = \\frac{1}{3}", "$$") },
+  {
+    name: "block equation",
+    nfm: L("$$", "\\int_0^1 x^2 dx = \\frac{1}{3}", "$$"),
+  },
   {
     name: "literal special chars (escaped)",
     nfm: "Text with literal special chars: a \\< b, 2 \\* 3, x_y, price \\$5, \\[bracket\\], \\{brace\\}.",
   },
   { name: "divider", nfm: "---" },
   { name: "empty block", nfm: L("above", "<empty-block/>", "below") },
-  { name: "consecutive empty blocks", nfm: L("first", "<empty-block/>", "<empty-block/>", "last") },
-  { name: "page atom", nfm: '<page url="https://www.notion.so/abc">Child Page</page>' },
+  {
+    name: "consecutive empty blocks",
+    nfm: L("first", "<empty-block/>", "<empty-block/>", "last"),
+  },
+  {
+    name: "page atom",
+    nfm: '<page url="https://www.notion.so/abc">Child Page</page>',
+  },
   { name: "table of contents atom", nfm: "<table_of_contents/>" },
   { name: "image", nfm: "![A caption](https://cdn.example.com/x.png)" },
-  { name: "mention inline", nfm: '<mention-page url="https://www.notion.so/abc">A Page</mention-page>' },
-  { name: "mention date self-closing", nfm: '<mention-date start="2026-06-01"/>' },
+  {
+    name: "mention inline",
+    nfm: '<mention-page url="https://www.notion.so/abc">A Page</mention-page>',
+  },
+  {
+    name: "mention date self-closing",
+    nfm: '<mention-date start="2026-06-01"/>',
+  },
   {
     name: "synced block with children",
-    nfm: L('<synced_block url="https://www.notion.so/s">', "\tShared content", "</synced_block>"),
+    nfm: L(
+      '<synced_block url="https://www.notion.so/s">',
+      "\tShared content",
+      "</synced_block>",
+    ),
   },
-  { name: "visual-indented paragraphs", nfm: L("root", "\tindented once", "\t\tindented twice") },
+  {
+    name: "visual-indented paragraphs",
+    nfm: L("root", "\tindented once", "\t\tindented twice"),
+  },
   {
     name: "nested toggles",
     nfm: L(
@@ -172,9 +214,9 @@ describe("nfm converter — inline round-trips", () => {
     "~~strike~~",
     "`code span`",
     "`multi<br>line code`",
-    "<span underline=\"true\">u</span>",
-    "<span color=\"purple\">colored</span>",
-    "<span color=\"green_bg\">bg</span>",
+    '<span underline="true">u</span>',
+    '<span color="purple">colored</span>',
+    '<span color="green_bg">bg</span>',
     "[text](https://x.com)",
     "[**bold link**](https://x.com)",
     "before $`a^2 + b^2`$ after",

--- a/templates/content/shared/nfm.spec.ts
+++ b/templates/content/shared/nfm.spec.ts
@@ -206,6 +206,107 @@ describe("nfm converter — structural parsing", () => {
   });
 });
 
+const HARD_FIXTURES: Array<{ name: string; nfm: string }> = [
+  { name: "colored bullet item", nfm: '- colored item {color="green"}' },
+  { name: "colored todo item", nfm: '- [x] done {color="blue_bg"}' },
+  { name: "colored heading", nfm: '# Big red {color="red"}' },
+  { name: "colored quote", nfm: '> Quoted in gray {color="gray"}' },
+  {
+    name: "toggle inside callout",
+    nfm: L(
+      '<callout icon="📌">',
+      "\tCallout intro",
+      "\t<details>",
+      "\t<summary>Nested toggle</summary>",
+      "\t\tdeep content",
+      "\t</details>",
+      "</callout>",
+    ),
+  },
+  {
+    name: "quote with child blocks",
+    nfm: L(
+      "> Quote lead",
+      "\tChild paragraph of the quote",
+      "\t- child bullet",
+    ),
+  },
+  {
+    name: "deeply nested bullets",
+    nfm: L("- a", "\t- b", "\t\t- c", "\t\t\t- d", "- e"),
+  },
+  {
+    name: "table with column colors (colgroup)",
+    nfm: L(
+      '<table header-row="true">',
+      "<colgroup>",
+      '<col color="gray"/>',
+      "<col/>",
+      "</colgroup>",
+      "<tr>",
+      "<td>A</td>",
+      "<td>B</td>",
+      "</tr>",
+      "<tr>",
+      '<td color="red_bg">1</td>',
+      "<td>2</td>",
+      "</tr>",
+      "</table>",
+    ),
+  },
+  {
+    name: "row color",
+    nfm: L(
+      "<table>",
+      '<tr color="blue_bg">',
+      "<td>x</td>",
+      "</tr>",
+      "</table>",
+    ),
+  },
+  { name: "combined bold italic strike", nfm: "~~***everything***~~" },
+  { name: "bold link", nfm: "[**important**](https://x.com)" },
+  { name: "code with specials inside", nfm: "`a < b && c[0]`" },
+  { name: "underline + color span", nfm: '<span color="purple">u</span>' },
+  {
+    name: "list with nested paragraph child",
+    nfm: L("- item", "\tnested paragraph under the item"),
+  },
+  {
+    name: "numbered list starting at 3",
+    nfm: L("3. three", "4. four"),
+  },
+  {
+    name: "audio and file blocks",
+    nfm: L(
+      '<audio src="https://x.com/a.mp3">My audio</audio>',
+      '<file src="https://x.com/f.pdf">A file</file>',
+    ),
+  },
+  {
+    name: "synced block reference",
+    nfm: L(
+      '<synced_block_reference url="https://www.notion.so/r">',
+      "\tref content",
+      "</synced_block_reference>",
+    ),
+  },
+];
+
+describe("nfm converter — hardening fixpoints", () => {
+  for (const { name, nfm } of HARD_FIXTURES) {
+    it(`is a fixpoint: ${name}`, () => {
+      expect(canonicalizeNfm(nfm)).toBe(nfm);
+    });
+  }
+
+  it("a large mixed torture document is a stable fixpoint", () => {
+    const doc = [...FIXTURES, ...HARD_FIXTURES].map((f) => f.nfm).join("\n");
+    const once = canonicalizeNfm(doc);
+    expect(canonicalizeNfm(once)).toBe(once);
+  });
+});
+
 describe("nfm converter — inline round-trips", () => {
   const inlineCases = [
     "**bold**",

--- a/templates/content/shared/nfm.ts
+++ b/templates/content/shared/nfm.ts
@@ -1,0 +1,1436 @@
+/**
+ * Notion-Flavored Markdown (NFM) ⇄ ProseMirror JSON.
+ *
+ * This is the single, deterministic bridge between Notion's canonical
+ * Notion-flavored Markdown (the exact bytes Notion's `/pages/{id}/markdown`
+ * API emits and accepts, Notion-Version 2026-03-11) and the TipTap/ProseMirror
+ * document used by the editor.
+ *
+ * Design goals (the whole reason this exists):
+ *   1. Idempotency / no drift. `docToNfm(nfmToDoc(x)) === x` for every piece of
+ *      canonical NFM `x`. A document authored in Notion, pulled, opened in the
+ *      editor, and saved back with no edits produces byte-identical NFM — so
+ *      pulling and pushing never mutates content.
+ *   2. Lossless fidelity. Every Notion block/inline type round-trips, including
+ *      quotes, toggle headings, block colors, tables (with header rows/columns
+ *      and cell colors), equations, callouts, columns, synced blocks, mentions,
+ *      and inline color/underline/background — matching the ground-truth spec at
+ *      the `notion://docs/enhanced-markdown-spec` MCP resource.
+ *   3. Shared. Pure functions with no editor/React/DOM dependency, usable by the
+ *      server (pull canonicalization + content hashing) and the editor
+ *      (`setContent(nfmToDoc(x))` / `docToNfm(editor.getJSON())`) alike.
+ *
+ * Canonical NFM form (what `docToNfm` emits):
+ *   - One block per line; children indented one extra TAB. No blank separator
+ *     lines (Notion strips them). Intentional blank blocks are `<empty-block/>`.
+ *   - Block attributes as a trailing `{toggle="true" color="red"}` list.
+ *   - Tables, toggles, callouts, columns, synced blocks, media, mentions use the
+ *     HTML-ish tags from the spec. Tables are `<table>` HTML, never pipe tables.
+ *   - Inline text backslash-escapes the spec's special characters outside code.
+ */
+
+// ── Shared PM JSON types ────────────────────────────────────────────
+export interface PMMark {
+  type: string;
+  attrs?: Record<string, any>;
+}
+export interface PMNode {
+  type: string;
+  attrs?: Record<string, any>;
+  content?: PMNode[];
+  marks?: PMMark[];
+  text?: string;
+}
+export interface PMDoc {
+  type: "doc";
+  content: PMNode[];
+}
+
+// ── Colors (from the NFM spec) ──────────────────────────────────────
+const BASE_COLORS = [
+  "gray",
+  "brown",
+  "orange",
+  "yellow",
+  "green",
+  "blue",
+  "purple",
+  "pink",
+  "red",
+];
+export const NFM_COLORS = new Set<string>([
+  "default",
+  ...BASE_COLORS,
+  ...BASE_COLORS.map((c) => `${c}_bg`),
+]);
+function isColor(value: string | null | undefined): value is string {
+  return !!value && NFM_COLORS.has(value) && value !== "default";
+}
+
+// ── Inline escaping ─────────────────────────────────────────────────
+// The spec escapes these characters OUTSIDE code: \ * ~ ` $ [ ] < > { } | ^
+const ESCAPABLE = new Set("\\*~`$[]<>{}|^".split(""));
+
+export function escapeInlineText(text: string): string {
+  let out = "";
+  for (const ch of text) {
+    if (ESCAPABLE.has(ch)) out += "\\" + ch;
+    else out += ch;
+  }
+  return out;
+}
+
+function unescapeInlineText(text: string): string {
+  let out = "";
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === "\\" && i + 1 < text.length && ESCAPABLE.has(text[i + 1])) {
+      out += text[i + 1];
+      i++;
+    } else {
+      out += text[i];
+    }
+  }
+  return out;
+}
+
+// ── Attribute helpers (for the HTML-ish tags) ───────────────────────
+function escapeAttr(value: string): string {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+function unescapeAttr(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+function serializeAttrs(
+  attrs: Array<[string, string | number | boolean | null | undefined]>,
+): string {
+  const parts = attrs
+    .filter(([, v]) => v !== undefined && v !== null && v !== "" && v !== false)
+    .map(([k, v]) =>
+      v === true ? `${k}="true"` : `${k}="${escapeAttr(String(v))}"`,
+    );
+  return parts.length ? " " + parts.join(" ") : "";
+}
+function parseAttrs(raw: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const re = /([a-zA-Z_:][\w:-]*)\s*=\s*"([^"]*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(raw))) attrs[m[1]] = unescapeAttr(m[2]);
+  return attrs;
+}
+
+// Trailing `{toggle="true" color="red"}` attribute list on a block line.
+function blockAttrSuffix(opts: {
+  toggle?: boolean;
+  color?: string | null;
+}): string {
+  const parts: string[] = [];
+  if (opts.toggle) parts.push('toggle="true"');
+  if (isColor(opts.color)) parts.push(`color="${opts.color}"`);
+  return parts.length ? ` {${parts.join(" ")}}` : "";
+}
+// Strip + read a trailing `{...}` attribute list from a block line.
+function splitBlockAttrs(line: string): {
+  text: string;
+  toggle: boolean;
+  color: string | null;
+} {
+  const m = line.match(/^(.*?)\s*\{([^{}]*)\}\s*$/);
+  if (!m) return { text: line, toggle: false, color: null };
+  const body = m[2];
+  const toggle = /\btoggle\s*=\s*"true"/.test(body);
+  const colorMatch = body.match(/\bcolor\s*=\s*"([^"]+)"/);
+  const color = colorMatch && isColor(colorMatch[1]) ? colorMatch[1] : null;
+  // Only treat as an attribute list if it actually contained known attrs;
+  // otherwise it was literal braces (which would have been escaped anyway).
+  if (!toggle && !color) return { text: line, toggle: false, color: null };
+  return { text: m[1], toggle, color };
+}
+
+// ════════════════════════════════════════════════════════════════════
+// INLINE: serialize
+// ════════════════════════════════════════════════════════════════════
+
+function markOf(node: PMNode, type: string): PMMark | undefined {
+  return node.marks?.find((m) => m.type === type);
+}
+
+function serializeInlineAtom(node: PMNode): string {
+  const tagName = (node.attrs?.tagName as string) || "mention";
+  const label = (node.attrs?.label as string) || "";
+  let attrs: Record<string, string> = {};
+  try {
+    attrs = JSON.parse((node.attrs?.attrsJson as string) || "{}");
+  } catch {
+    attrs = {};
+  }
+  if (tagName === "math") {
+    return "$`" + (label || attrs.latex || "") + "`$";
+  }
+  const attrEntries = Object.entries(attrs).filter(([k]) => k !== "latex");
+  const attrStr = serializeAttrs(attrEntries);
+  const selfClosing = !label.trim();
+  if (selfClosing) return `<${tagName}${attrStr}/>`;
+  return `<${tagName}${attrStr}>${escapeAttr(label)}</${tagName}>`;
+}
+
+function serializeInline(nodes: PMNode[] | undefined): string {
+  if (!nodes || !nodes.length) return "";
+  return nodes.map(serializeInlineNode).join("");
+}
+
+function serializeInlineNode(node: PMNode): string {
+  if (node.type === "hardBreak") return "<br>";
+  if (node.type === "notionInlineAtom") return serializeInlineAtom(node);
+  if (node.type !== "text") {
+    // Unknown inline node — best-effort textContent.
+    return node.text ? escapeInlineText(node.text) : "";
+  }
+
+  const raw = node.text ?? "";
+  const code = markOf(node, "code");
+  let out: string;
+  if (code) {
+    out = "`" + raw.replace(/\n/g, "<br>") + "`";
+  } else {
+    out = escapeInlineText(raw);
+  }
+
+  const bold = markOf(node, "bold");
+  const italic = markOf(node, "italic");
+  if (bold && italic) {
+    out = "***" + out + "***";
+  } else {
+    if (markOf(node, "strike")) out = "~~" + out + "~~";
+    if (italic) out = "*" + out + "*";
+    if (bold) out = "**" + out + "**";
+  }
+  if (!(bold && italic) && markOf(node, "strike") && (bold || italic)) {
+    // strike already applied above; nothing to do
+  }
+  // strike for the bold+italic branch
+  if (bold && italic && markOf(node, "strike")) {
+    out = "~~" + out + "~~";
+  }
+
+  const span = markOf(node, "notionSpan");
+  if (span) {
+    const a = span.attrs || {};
+    const attrStr = serializeAttrs([
+      ["color", a.color || a.bgColor || null],
+      [
+        "underline",
+        a.underline === "true" || a.underline === true ? "true" : null,
+      ],
+    ]);
+    if (attrStr) out = `<span${attrStr}>${out}</span>`;
+  }
+
+  const link = markOf(node, "link");
+  if (link?.attrs?.href) {
+    out = `[${out}](${link.attrs.href})`;
+  }
+  return out;
+}
+
+// ════════════════════════════════════════════════════════════════════
+// INLINE: parse
+// ════════════════════════════════════════════════════════════════════
+
+function textNode(text: string, marks: PMMark[]): PMNode {
+  return marks.length ? { type: "text", text, marks } : { type: "text", text };
+}
+
+function addMark(nodes: PMNode[], mark: PMMark): void {
+  for (const n of nodes) {
+    if (n.type === "text") {
+      n.marks = n.marks || [];
+      if (!n.marks.some((m) => m.type === mark.type)) n.marks.push(mark);
+    }
+  }
+}
+
+function mergeSpanMark(nodes: PMNode[], attrs: Record<string, string>): void {
+  const color = attrs.color;
+  const isBg = color ? color.endsWith("_bg") : false;
+  const spanAttrs: Record<string, any> = {
+    color: color && !isBg ? color : null,
+    bgColor: color && isBg ? color : null,
+    underline: attrs.underline === "true" ? "true" : null,
+    href: attrs.href || null,
+    attrsJson: "{}",
+  };
+  for (const n of nodes) {
+    if (n.type === "text") {
+      n.marks = n.marks || [];
+      if (!n.marks.some((m) => m.type === "notionSpan")) {
+        n.marks.push({ type: "notionSpan", attrs: spanAttrs });
+      }
+    }
+  }
+}
+
+// Find the index of the next unescaped occurrence of `token` starting at `from`.
+function findToken(s: string, token: string, from: number): number {
+  for (let i = from; i <= s.length - token.length; i++) {
+    if (s[i] === "\\") {
+      i++;
+      continue;
+    }
+    if (s.startsWith(token, i)) return i;
+  }
+  return -1;
+}
+
+function parseInline(input: string): PMNode[] {
+  const out: PMNode[] = [];
+  let buf = "";
+  let i = 0;
+  const flush = () => {
+    if (buf) {
+      out.push(textNode(buf, []));
+      buf = "";
+    }
+  };
+
+  while (i < input.length) {
+    const ch = input[i];
+
+    // Escape
+    if (ch === "\\" && i + 1 < input.length && ESCAPABLE.has(input[i + 1])) {
+      buf += input[i + 1];
+      i += 2;
+      continue;
+    }
+
+    // Inline math $`...`$
+    if (ch === "$" && input[i + 1] === "`") {
+      const close = input.indexOf("`$", i + 2);
+      if (close !== -1) {
+        flush();
+        const latex = input.slice(i + 2, close);
+        out.push({
+          type: "notionInlineAtom",
+          attrs: { tagName: "math", attrsJson: "{}", label: latex },
+        });
+        i = close + 2;
+        continue;
+      }
+    }
+
+    // Inline code `...`
+    if (ch === "`") {
+      const close = input.indexOf("`", i + 1);
+      if (close !== -1) {
+        flush();
+        const codeText = input.slice(i + 1, close).replace(/<br\/?>/g, "\n");
+        out.push(textNode(codeText, [{ type: "code" }]));
+        i = close + 1;
+        continue;
+      }
+    }
+
+    // Hard break
+    if (input.startsWith("<br/>", i) || input.startsWith("<br>", i)) {
+      flush();
+      out.push({ type: "hardBreak" });
+      i += input.startsWith("<br/>", i) ? 5 : 4;
+      continue;
+    }
+
+    // <span ...>...</span>
+    if (input.startsWith("<span", i)) {
+      const open = input.indexOf(">", i);
+      const close = input.indexOf("</span>", open);
+      if (open !== -1 && close !== -1) {
+        flush();
+        const attrs = parseAttrs(input.slice(i + 5, open));
+        const inner = parseInline(input.slice(open + 1, close));
+        mergeSpanMark(inner, attrs);
+        out.push(...inner);
+        i = close + "</span>".length;
+        continue;
+      }
+    }
+
+    // Inline mention / atom tags: <mention-*...> or <mention-*.../>
+    if (input.startsWith("<mention-", i)) {
+      const selfClose = input.indexOf("/>", i);
+      const open = input.indexOf(">", i);
+      // self-closing form <mention-date .../>
+      if (selfClose !== -1 && (open === -1 || selfClose <= open)) {
+        flush();
+        const tagMatch = input.slice(i).match(/^<(mention-[\w-]+)([^>]*?)\/>/);
+        if (tagMatch) {
+          out.push(makeInlineAtom(tagMatch[1], tagMatch[2], ""));
+          i += tagMatch[0].length;
+          continue;
+        }
+      }
+      const tagMatch = input
+        .slice(i)
+        .match(/^<(mention-[\w-]+)([^>]*)>([\s\S]*?)<\/\1>/);
+      if (tagMatch) {
+        flush();
+        out.push(makeInlineAtom(tagMatch[1], tagMatch[2], tagMatch[3]));
+        i += tagMatch[0].length;
+        continue;
+      }
+    }
+
+    // Bold+italic ***...***
+    if (input.startsWith("***", i)) {
+      const close = findToken(input, "***", i + 3);
+      if (close !== -1) {
+        flush();
+        const inner = parseInline(input.slice(i + 3, close));
+        addMark(inner, { type: "bold" });
+        addMark(inner, { type: "italic" });
+        out.push(...inner);
+        i = close + 3;
+        continue;
+      }
+    }
+
+    // Bold **...**
+    if (input.startsWith("**", i)) {
+      const close = findToken(input, "**", i + 2);
+      if (close !== -1) {
+        flush();
+        const inner = parseInline(input.slice(i + 2, close));
+        addMark(inner, { type: "bold" });
+        out.push(...inner);
+        i = close + 2;
+        continue;
+      }
+    }
+
+    // Strike ~~...~~
+    if (input.startsWith("~~", i)) {
+      const close = findToken(input, "~~", i + 2);
+      if (close !== -1) {
+        flush();
+        const inner = parseInline(input.slice(i + 2, close));
+        addMark(inner, { type: "strike" });
+        out.push(...inner);
+        i = close + 2;
+        continue;
+      }
+    }
+
+    // Italic *...*
+    if (ch === "*") {
+      const close = findToken(input, "*", i + 1);
+      if (close !== -1) {
+        flush();
+        const inner = parseInline(input.slice(i + 1, close));
+        addMark(inner, { type: "italic" });
+        out.push(...inner);
+        i = close + 1;
+        continue;
+      }
+    }
+
+    // Link [text](url)
+    if (ch === "[") {
+      const link = matchLink(input, i);
+      if (link) {
+        flush();
+        const inner = parseInline(link.text);
+        addMark(inner, { type: "link", attrs: { href: link.href } });
+        out.push(...inner);
+        i = link.end;
+        continue;
+      }
+    }
+
+    buf += ch;
+    i++;
+  }
+  flush();
+  return out;
+}
+
+function makeInlineAtom(
+  tagName: string,
+  rawAttrs: string,
+  label: string,
+): PMNode {
+  const attrs = parseAttrs(rawAttrs);
+  return {
+    type: "notionInlineAtom",
+    attrs: {
+      tagName,
+      attrsJson: JSON.stringify(attrs),
+      label: label.trim(),
+    },
+  };
+}
+
+function matchLink(
+  s: string,
+  start: number,
+): { text: string; href: string; end: number } | null {
+  // Find matching unescaped ] then immediately ( ... )
+  let depth = 0;
+  let i = start;
+  let closeBracket = -1;
+  for (; i < s.length; i++) {
+    if (s[i] === "\\") {
+      i++;
+      continue;
+    }
+    if (s[i] === "[") depth++;
+    else if (s[i] === "]") {
+      depth--;
+      if (depth === 0) {
+        closeBracket = i;
+        break;
+      }
+    }
+  }
+  if (closeBracket === -1 || s[closeBracket + 1] !== "(") return null;
+  const closeParen = s.indexOf(")", closeBracket + 2);
+  if (closeParen === -1) return null;
+  return {
+    text: s.slice(start + 1, closeBracket),
+    href: s.slice(closeBracket + 2, closeParen),
+    end: closeParen + 1,
+  };
+}
+
+// ════════════════════════════════════════════════════════════════════
+// BLOCK: serialize (docToNfm)
+// ════════════════════════════════════════════════════════════════════
+
+const TAB = "\t";
+function indentStr(n: number): string {
+  return TAB.repeat(Math.max(0, n));
+}
+
+export function docToNfm(doc: PMDoc | PMNode | null | undefined): string {
+  const content = (doc?.content as PMNode[]) || [];
+  const lines = serializeBlocks(content, 0);
+  return lines.join("\n");
+}
+
+function serializeBlocks(blocks: PMNode[], indent: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    if (block.type === "bulletList" || block.type === "orderedList") {
+      out.push(...serializeList(block, indent));
+    } else if (block.type === "taskList") {
+      out.push(...serializeTaskList(block, indent));
+    } else {
+      out.push(...serializeBlock(block, indent));
+    }
+  }
+  return out;
+}
+
+function firstParagraph(node: PMNode): PMNode | null {
+  const first = node.content?.[0];
+  return first && first.type === "paragraph" ? first : null;
+}
+
+function serializeBlock(node: PMNode, indent: number): string[] {
+  const extra = Number(node.attrs?.indent) || 0;
+  const ind = indent + extra;
+
+  switch (node.type) {
+    case "paragraph": {
+      const inline = serializeInline(node.content);
+      if (!inline) return [indentStr(ind) + "<empty-block/>"];
+      return [
+        indentStr(ind) + inline + blockAttrSuffix({ color: node.attrs?.color }),
+      ];
+    }
+    case "heading": {
+      const level = Math.min(4, Math.max(1, Number(node.attrs?.level) || 1));
+      const inline = serializeInline(node.content);
+      return [
+        indentStr(ind) +
+          "#".repeat(level) +
+          " " +
+          inline +
+          blockAttrSuffix({ color: node.attrs?.color }),
+      ];
+    }
+    case "horizontalRule":
+      return [indentStr(ind) + "---"];
+    case "codeBlock": {
+      const lang = (node.attrs?.language as string) || "";
+      const text = (node.content || []).map((t) => t.text || "").join("");
+      const body = text.split("\n").map((l) => indentStr(ind) + l);
+      return [indentStr(ind) + "```" + lang, ...body, indentStr(ind) + "```"];
+    }
+    case "blockquote":
+      return serializeQuote(node, ind);
+    case "notionToggle":
+      return serializeToggle(node, ind);
+    case "notionCallout":
+      return serializeCallout(node, ind);
+    case "notionColumns":
+      return serializeColumns(node, ind);
+    case "notionColumn": {
+      const out = [indentStr(ind) + "<column>"];
+      out.push(...serializeBlocks(node.content || [], ind + 1));
+      out.push(indentStr(ind) + "</column>");
+      return out;
+    }
+    case "notionSyncedBlock":
+      return serializeSynced(node, ind);
+    case "table":
+      return serializeTable(node, ind);
+    case "image":
+      return serializeImage(node, ind);
+    case "video":
+    case "audio":
+      return serializeMedia(node, ind);
+    case "notionBlockAtom":
+      return serializeBlockAtom(node, ind);
+    default: {
+      // Unknown block: preserve its raw text if present so nothing is lost.
+      if (typeof node.attrs?.__raw === "string") {
+        return (node.attrs.__raw as string)
+          .split("\n")
+          .map((l) => indentStr(ind) + l);
+      }
+      const inline = serializeInline(node.content);
+      return inline ? [indentStr(ind) + inline] : [];
+    }
+  }
+}
+
+function serializeChildrenAfterFirst(node: PMNode, indent: number): string[] {
+  const children = (node.content || []).slice(1);
+  return serializeBlocks(children, indent);
+}
+
+function serializeQuote(node: PMNode, ind: number): string[] {
+  const textPara = firstParagraph(node);
+  const out: string[] = [];
+  const inline = textPara ? serializeInline(textPara.content) : "";
+  out.push(
+    indentStr(ind) +
+      "> " +
+      inline +
+      blockAttrSuffix({ color: node.attrs?.color }),
+  );
+  // Children (blocks after the text paragraph) are nested one tab deeper.
+  const children = textPara
+    ? (node.content || []).slice(1)
+    : node.content || [];
+  out.push(...serializeBlocks(children, ind + 1));
+  return out;
+}
+
+function serializeToggle(node: PMNode, ind: number): string[] {
+  const summary = (node.attrs?.summary as string) || "";
+  const headingLevel = Number(node.attrs?.headingLevel) || 0;
+  const color = node.attrs?.color;
+  const out: string[] = [];
+  if (headingLevel >= 1 && headingLevel <= 4) {
+    out.push(
+      indentStr(ind) +
+        "#".repeat(headingLevel) +
+        " " +
+        escapeInlineText(summary) +
+        blockAttrSuffix({ toggle: true, color }),
+    );
+    out.push(...serializeBlocks(node.content || [], ind + 1));
+    return out;
+  }
+  const attrStr = serializeAttrs([["color", isColor(color) ? color : null]]);
+  out.push(indentStr(ind) + `<details${attrStr}>`);
+  out.push(indentStr(ind) + `<summary>${escapeInlineText(summary)}</summary>`);
+  out.push(...serializeBlocks(node.content || [], ind + 1));
+  out.push(indentStr(ind) + "</details>");
+  return out;
+}
+
+function serializeCallout(node: PMNode, ind: number): string[] {
+  const icon = (node.attrs?.icon as string) ?? "";
+  const color = node.attrs?.color;
+  const attrStr = serializeAttrs([
+    ["icon", icon || null],
+    ["color", isColor(color) ? color : null],
+  ]);
+  const out = [indentStr(ind) + `<callout${attrStr}>`];
+  out.push(...serializeBlocks(node.content || [], ind + 1));
+  out.push(indentStr(ind) + "</callout>");
+  return out;
+}
+
+function serializeColumns(node: PMNode, ind: number): string[] {
+  const out = [indentStr(ind) + "<columns>"];
+  out.push(...serializeBlocks(node.content || [], ind + 1));
+  out.push(indentStr(ind) + "</columns>");
+  return out;
+}
+
+function serializeSynced(node: PMNode, ind: number): string[] {
+  const tag = node.attrs?.isReference
+    ? "synced_block_reference"
+    : "synced_block";
+  const attrStr = serializeAttrs([
+    ["url", node.attrs?.url || null],
+    ["notice", node.attrs?.notice || null],
+  ]);
+  const out = [indentStr(ind) + `<${tag}${attrStr}>`];
+  out.push(...serializeBlocks(node.content || [], ind + 1));
+  out.push(indentStr(ind) + `</${tag}>`);
+  return out;
+}
+
+function serializeImage(node: PMNode, ind: number): string[] {
+  const src = (node.attrs?.src as string) || "";
+  const alt = (node.attrs?.alt as string) || "";
+  const color = node.attrs?.color;
+  const suffix = isColor(color) ? ` {color="${color}"}` : "";
+  return [indentStr(ind) + `![${escapeInlineText(alt)}](${src})${suffix}`];
+}
+
+function serializeMedia(node: PMNode, ind: number): string[] {
+  const tag = node.type; // video | audio
+  const src = (node.attrs?.src as string) || "";
+  const caption = (node.attrs?.title as string) || "";
+  const color = node.attrs?.color;
+  const attrStr = serializeAttrs([
+    ["src", src],
+    ["color", isColor(color) ? color : null],
+  ]);
+  return [
+    indentStr(ind) +
+      `<${tag}${attrStr}>${caption ? escapeAttr(caption) : ""}</${tag}>`,
+  ];
+}
+
+function serializeBlockAtom(node: PMNode, ind: number): string[] {
+  const tagName = (node.attrs?.tagName as string) || "unknown";
+  const label = (node.attrs?.label as string) || "";
+  let attrs: Record<string, string> = {};
+  try {
+    attrs = JSON.parse((node.attrs?.attrsJson as string) || "{}");
+  } catch {
+    attrs = {};
+  }
+
+  if (tagName === "equation") {
+    const latex = label || attrs.latex || "";
+    return [
+      indentStr(ind) + "$$",
+      ...latex.split("\n").map((l) => indentStr(ind) + l),
+      indentStr(ind) + "$$",
+    ];
+  }
+
+  const rawEntries = Object.entries(attrs);
+  const attrStr = serializeAttrs(rawEntries);
+  if (label.trim()) {
+    return [
+      indentStr(ind) +
+        `<${tagName}${attrStr}>${escapeAttr(label)}</${tagName}>`,
+    ];
+  }
+  return [indentStr(ind) + `<${tagName}${attrStr}/>`];
+}
+
+function serializeList(node: PMNode, indent: number): string[] {
+  const ordered = node.type === "orderedList";
+  const start = ordered ? Number(node.attrs?.start) || 1 : 0;
+  const out: string[] = [];
+  let n = start;
+  for (const item of node.content || []) {
+    const textPara = firstParagraph(item);
+    const inline = textPara ? serializeInline(textPara.content) : "";
+    const color = textPara?.attrs?.color;
+    const marker = ordered ? `${n}. ` : "- ";
+    out.push(indentStr(indent) + marker + inline + blockAttrSuffix({ color }));
+    const children = textPara
+      ? (item.content || []).slice(1)
+      : item.content || [];
+    out.push(...serializeBlocks(children, indent + 1));
+    n++;
+  }
+  return out;
+}
+
+function serializeTaskList(node: PMNode, indent: number): string[] {
+  const out: string[] = [];
+  for (const item of node.content || []) {
+    const checked = !!item.attrs?.checked;
+    const textPara = firstParagraph(item);
+    const inline = textPara ? serializeInline(textPara.content) : "";
+    const color = textPara?.attrs?.color;
+    out.push(
+      indentStr(indent) +
+        `- [${checked ? "x" : " "}] ` +
+        inline +
+        blockAttrSuffix({ color }),
+    );
+    const children = textPara
+      ? (item.content || []).slice(1)
+      : item.content || [];
+    out.push(...serializeBlocks(children, indent + 1));
+  }
+  return out;
+}
+
+function serializeTable(node: PMNode, ind: number): string[] {
+  const attrs = node.attrs || {};
+  const tableAttrStr = serializeAttrs([
+    ["fit-page-width", attrs.fitPageWidth ? "true" : null],
+    ["header-row", attrs.headerRow ? "true" : null],
+    ["header-column", attrs.headerColumn ? "true" : null],
+  ]);
+  const out = [indentStr(ind) + `<table${tableAttrStr}>`];
+
+  const colMeta: Array<{ color?: string; width?: string }> = Array.isArray(
+    attrs.colMeta,
+  )
+    ? attrs.colMeta
+    : [];
+  if (colMeta.some((c) => c && (c.color || c.width))) {
+    out.push(indentStr(ind) + "<colgroup>");
+    for (const col of colMeta) {
+      const colAttrStr = serializeAttrs([
+        ["color", col && isColor(col.color) ? col.color : null],
+        ["width", col && col.width ? col.width : null],
+      ]);
+      out.push(indentStr(ind) + `<col${colAttrStr}/>`);
+    }
+    out.push(indentStr(ind) + "</colgroup>");
+  }
+
+  for (const row of node.content || []) {
+    const rowAttrStr = serializeAttrs([
+      ["color", isColor(row.attrs?.color) ? row.attrs?.color : null],
+    ]);
+    out.push(indentStr(ind) + `<tr${rowAttrStr}>`);
+    for (const cell of row.content || []) {
+      const cellColor = isColor(cell.attrs?.color) ? cell.attrs?.color : null;
+      // Cells hold inline rich text only; flatten the single paragraph.
+      const para =
+        cell.content?.find((c) => c.type === "paragraph") || cell.content?.[0];
+      const inline = para ? serializeInline(para.content) : "";
+      const cellAttrStr = serializeAttrs([["color", cellColor]]);
+      out.push(indentStr(ind) + `<td${cellAttrStr}>${inline}</td>`);
+    }
+    out.push(indentStr(ind) + "</tr>");
+  }
+  out.push(indentStr(ind) + "</table>");
+  return out;
+}
+
+// ════════════════════════════════════════════════════════════════════
+// BLOCK: parse (nfmToDoc)
+// ════════════════════════════════════════════════════════════════════
+
+function leadingTabs(line: string): number {
+  let n = 0;
+  while (n < line.length && line[n] === "\t") n++;
+  return n;
+}
+
+export function nfmToDoc(nfm: string | null | undefined): PMDoc {
+  const lines = (nfm ?? "").replace(/\r\n?/g, "\n").split("\n");
+  const { nodes } = parseBlockSequence(lines, 0, 0);
+  return {
+    type: "doc",
+    content: nodes.length ? nodes : [{ type: "paragraph" }],
+  };
+}
+
+interface ParseResult {
+  nodes: PMNode[];
+  end: number;
+}
+
+const CONTAINER_CLOSE: Record<string, string> = {
+  "<details": "</details>",
+  "<callout": "</callout>",
+  "<columns>": "</columns>",
+  "<column>": "</column>",
+  "<table": "</table>",
+  "<synced_block_reference": "</synced_block_reference>",
+  "<synced_block": "</synced_block>",
+  "<meeting-notes>": "</meeting-notes>",
+};
+
+function parseBlockSequence(
+  lines: string[],
+  start: number,
+  baseIndent: number,
+): ParseResult {
+  const out: PMNode[] = [];
+  let i = start;
+
+  while (i < lines.length) {
+    const raw = lines[i];
+    if (raw.trim() === "") {
+      i++;
+      continue;
+    }
+    const ind = leadingTabs(raw);
+    if (ind < baseIndent) break;
+
+    const dedent = raw.slice(ind);
+    const rel = ind - baseIndent;
+
+    // Lists group consecutive items.
+    const listKind = listKindOf(dedent);
+    if (listKind) {
+      const res = parseList(lines, i, ind, listKind);
+      out.push(res.nodes[0]);
+      i = res.end;
+      continue;
+    }
+
+    const res = parseSingleBlock(lines, i, ind, rel);
+    if (res.nodes.length) out.push(...res.nodes);
+    i = res.end;
+  }
+
+  return { nodes: out, end: i };
+}
+
+type ListKind = "bullet" | "ordered" | "task";
+function listKindOf(dedent: string): ListKind | null {
+  if (/^- \[[ xX]\]\s/.test(dedent)) return "task";
+  if (/^[-*+] /.test(dedent)) return "bullet";
+  if (/^\d+[.)] /.test(dedent)) return "ordered";
+  return null;
+}
+
+function parseList(
+  lines: string[],
+  start: number,
+  indent: number,
+  kind: ListKind,
+): ParseResult {
+  const items: PMNode[] = [];
+  let i = start;
+  let orderedStart: number | null = null;
+
+  while (i < lines.length) {
+    const raw = lines[i];
+    if (raw.trim() === "") {
+      i++;
+      continue;
+    }
+    const ind = leadingTabs(raw);
+    if (ind !== indent) break;
+    const dedent = raw.slice(ind);
+    if (listKindOf(dedent) !== kind) break;
+
+    let itemText: string;
+    let checked = false;
+    if (kind === "task") {
+      const m = dedent.match(/^- \[([ xX])\]\s(.*)$/);
+      checked = m ? m[1].toLowerCase() === "x" : false;
+      itemText = m ? m[2] : "";
+    } else if (kind === "ordered") {
+      const m = dedent.match(/^(\d+)[.)] (.*)$/);
+      if (orderedStart === null && m) orderedStart = Number(m[1]);
+      itemText = m ? m[2] : "";
+    } else {
+      itemText = dedent.replace(/^[-*+] /, "");
+    }
+
+    const { text, color } = splitBlockAttrs(itemText);
+    const para: PMNode = { type: "paragraph", content: parseInline(text) };
+    if (isColor(color)) para.attrs = { color };
+
+    // Children: deeper-indented blocks belong to this item.
+    const childRes = parseBlockSequence(lines, i + 1, indent + 1);
+    const itemContent: PMNode[] = [para, ...childRes.nodes];
+
+    if (kind === "task") {
+      items.push({
+        type: "taskItem",
+        attrs: { checked },
+        content: itemContent,
+      });
+    } else {
+      items.push({ type: "listItem", content: itemContent });
+    }
+    i = childRes.end;
+  }
+
+  if (kind === "task") {
+    return { nodes: [{ type: "taskList", content: items }], end: i };
+  }
+  if (kind === "ordered") {
+    const node: PMNode = { type: "orderedList", content: items };
+    if (orderedStart && orderedStart !== 1)
+      node.attrs = { start: orderedStart };
+    return { nodes: [node], end: i };
+  }
+  return { nodes: [{ type: "bulletList", content: items }], end: i };
+}
+
+function parseSingleBlock(
+  lines: string[],
+  start: number,
+  indent: number,
+  rel: number,
+): ParseResult {
+  const raw = lines[start];
+  const dedent = raw.slice(indent);
+  const withIndentAttr = (node: PMNode): PMNode => {
+    if (rel > 0) node.attrs = { ...(node.attrs || {}), indent: rel };
+    return node;
+  };
+
+  // Empty block
+  if (/^<empty-block\s*\/?>/.test(dedent)) {
+    return { nodes: [withIndentAttr({ type: "paragraph" })], end: start + 1 };
+  }
+
+  // Divider
+  if (/^(---+|\*\*\*+|___+)$/.test(dedent.trim())) {
+    return {
+      nodes: [withIndentAttr({ type: "horizontalRule" })],
+      end: start + 1,
+    };
+  }
+
+  // Code fence
+  if (/^```/.test(dedent)) {
+    const lang = dedent.slice(3).trim();
+    const body: string[] = [];
+    let i = start + 1;
+    for (; i < lines.length; i++) {
+      const l = lines[i];
+      const ld = l.slice(Math.min(indent, leadingTabs(l)));
+      if (/^```\s*$/.test(ld.trim()) && leadingTabs(l) >= indent) break;
+      // Strip exactly `indent` leading tabs (structural), keep the rest literal.
+      body.push(stripTabs(l, indent));
+    }
+    const node: PMNode = {
+      type: "codeBlock",
+      attrs: { language: lang || null },
+      content: body.length ? [{ type: "text", text: body.join("\n") }] : [],
+    };
+    return { nodes: [withIndentAttr(node)], end: i + 1 };
+  }
+
+  // Block equation $$ ... $$
+  if (dedent.trim() === "$$") {
+    const body: string[] = [];
+    let i = start + 1;
+    for (; i < lines.length; i++) {
+      if (
+        lines[i].slice(indent).trim() === "$$" &&
+        leadingTabs(lines[i]) >= indent
+      )
+        break;
+      body.push(stripTabs(lines[i], indent));
+    }
+    const node: PMNode = {
+      type: "notionBlockAtom",
+      attrs: {
+        tagName: "equation",
+        attrsJson: "{}",
+        label: body.join("\n"),
+      },
+    };
+    return { nodes: [withIndentAttr(node)], end: i + 1 };
+  }
+
+  // Heading (possibly a toggle heading)
+  const headingMatch = dedent.match(/^(#{1,6})\s+(.*)$/);
+  if (headingMatch) {
+    const level = Math.min(4, headingMatch[1].length);
+    const { text, toggle, color } = splitBlockAttrs(headingMatch[2]);
+    if (toggle) {
+      const childRes = parseBlockSequence(lines, start + 1, indent + 1);
+      const node: PMNode = {
+        type: "notionToggle",
+        attrs: {
+          summary: unescapeInlineText(text),
+          headingLevel: level,
+          open: false,
+          color: isColor(color) ? color : null,
+          indent: 0,
+        },
+        content: childRes.nodes,
+      };
+      return { nodes: [withIndentAttr(node)], end: childRes.end };
+    }
+    const node: PMNode = {
+      type: "heading",
+      attrs: { level, ...(isColor(color) ? { color } : {}) },
+      content: parseInline(text),
+    };
+    return { nodes: [withIndentAttr(node)], end: start + 1 };
+  }
+
+  // Quote
+  if (/^> /.test(dedent) || dedent === ">") {
+    const { text, color } = splitBlockAttrs(dedent.replace(/^>\s?/, ""));
+    const textPara: PMNode = { type: "paragraph", content: parseInline(text) };
+    const childRes = parseBlockSequence(lines, start + 1, indent + 1);
+    const node: PMNode = {
+      type: "blockquote",
+      ...(isColor(color) ? { attrs: { color } } : {}),
+      content: [textPara, ...childRes.nodes],
+    };
+    return { nodes: [withIndentAttr(node)], end: childRes.end };
+  }
+
+  // Container tags
+  const containerTag = matchContainerOpen(dedent);
+  if (containerTag) {
+    return parseContainer(lines, start, indent, rel, containerTag);
+  }
+
+  // Image ![alt](src)
+  const imageMatch = dedent.match(
+    /^!\[([^\]]*)\]\(([^)]*)\)\s*(\{[^}]*\})?\s*$/,
+  );
+  if (imageMatch) {
+    const colorMatch = imageMatch[3]?.match(/color="([^"]+)"/);
+    const node: PMNode = {
+      type: "image",
+      attrs: {
+        src: imageMatch[2],
+        alt: unescapeInlineText(imageMatch[1]),
+        ...(colorMatch && isColor(colorMatch[1])
+          ? { color: colorMatch[1] }
+          : {}),
+      },
+    };
+    return { nodes: [withIndentAttr(node)], end: start + 1 };
+  }
+
+  // Self-contained media / atom tags on one line: <video.../>, <page ...>..</page>, <x .../>
+  const tagLine = dedent.match(
+    /^<([a-zA-Z_][\w-]*)([^>]*?)(\/?)>(?:([\s\S]*?)<\/\1>)?\s*$/,
+  );
+  if (tagLine) {
+    const node = parseLeafTag(tagLine[1], tagLine[2], tagLine[4] ?? "");
+    if (node) return { nodes: [withIndentAttr(node)], end: start + 1 };
+  }
+
+  // Plain paragraph
+  const { text, color } = splitBlockAttrs(dedent);
+  const node: PMNode = { type: "paragraph", content: parseInline(text) };
+  if (isColor(color)) node.attrs = { color };
+  return { nodes: [withIndentAttr(node)], end: start + 1 };
+}
+
+function stripTabs(line: string, count: number): string {
+  let i = 0;
+  while (i < count && line[i] === "\t") i++;
+  return line.slice(i);
+}
+
+function matchContainerOpen(dedent: string): string | null {
+  for (const key of Object.keys(CONTAINER_CLOSE)) {
+    if (key.endsWith(">")) {
+      // Exact tag with no attributes: <columns>, <column>, <meeting-notes>.
+      if (dedent === key) return key;
+    } else {
+      // Tag that may carry attributes: <details ...>, <callout ...>, <table ...>.
+      if (
+        dedent === key + ">" ||
+        dedent.startsWith(key + " ") ||
+        dedent.startsWith(key + ">")
+      ) {
+        return key;
+      }
+    }
+  }
+  return null;
+}
+
+function parseContainer(
+  lines: string[],
+  start: number,
+  indent: number,
+  rel: number,
+  tagKey: string,
+): ParseResult {
+  const closeTag = CONTAINER_CLOSE[tagKey];
+  const openLine = lines[start].slice(indent);
+  const withIndentAttr = (node: PMNode): PMNode => {
+    if (rel > 0) node.attrs = { ...(node.attrs || {}), indent: rel };
+    return node;
+  };
+
+  // Tables and meeting-notes are parsed as flat tag lines (not tab-indented children).
+  if (tagKey === "<table") {
+    return parseTable(lines, start, indent, withIndentAttr);
+  }
+  if (tagKey === "<meeting-notes>") {
+    return parseRawContainer(
+      lines,
+      start,
+      indent,
+      closeTag,
+      "meeting-notes",
+      withIndentAttr,
+    );
+  }
+
+  // Find close line at the same indent.
+  let i = start + 1;
+  const childStart = i;
+  let depth = 1;
+  for (; i < lines.length; i++) {
+    const li = leadingTabs(lines[i]);
+    const ld = lines[i].slice(li);
+    if (
+      li === indent &&
+      matchContainerOpen(ld) === tagKey &&
+      !ld.startsWith("</")
+    ) {
+      depth++;
+    }
+    if (li === indent && ld === closeTag) {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  const closeIdx = i;
+  const innerEnd = closeIdx;
+
+  // <details> with a <summary> on the next line.
+  if (tagKey === "<details") {
+    const attrs = parseAttrs(openLine);
+    let summary = "";
+    let bodyStart = childStart;
+    const summaryLine = lines[childStart]?.slice(indent) ?? "";
+    const sm = summaryLine.match(/^<summary>([\s\S]*?)<\/summary>\s*$/);
+    if (sm) {
+      summary = unescapeInlineText(sm[1]);
+      bodyStart = childStart + 1;
+    }
+    const childRes = parseBlockSequence(lines, bodyStart, indent + 1);
+    const node: PMNode = {
+      type: "notionToggle",
+      attrs: {
+        summary,
+        headingLevel: null,
+        open: false,
+        color: isColor(attrs.color) ? attrs.color : null,
+        indent: 0,
+      },
+      content: childRes.nodes,
+    };
+    return { nodes: [withIndentAttr(node)], end: closeIdx + 1 };
+  }
+
+  if (tagKey === "<callout") {
+    const attrs = parseAttrs(openLine);
+    const childRes = parseBlockSequence(lines, childStart, indent + 1);
+    const node: PMNode = {
+      type: "notionCallout",
+      attrs: {
+        icon: attrs.icon ?? "",
+        color: isColor(attrs.color) ? attrs.color : null,
+      },
+      content: childRes.nodes,
+    };
+    return { nodes: [withIndentAttr(node)], end: closeIdx + 1 };
+  }
+
+  if (tagKey === "<columns>") {
+    const childRes = parseBlockSequence(lines, childStart, indent + 1);
+    const columns = childRes.nodes.filter((n) => n.type === "notionColumn");
+    const node: PMNode = { type: "notionColumns", content: columns };
+    return { nodes: [withIndentAttr(node)], end: closeIdx + 1 };
+  }
+
+  if (tagKey === "<column>") {
+    const childRes = parseBlockSequence(lines, childStart, indent + 1);
+    const node: PMNode = { type: "notionColumn", content: childRes.nodes };
+    return { nodes: [withIndentAttr(node)], end: closeIdx + 1 };
+  }
+
+  if (tagKey === "<synced_block" || tagKey === "<synced_block_reference") {
+    const attrs = parseAttrs(openLine);
+    const childRes = parseBlockSequence(lines, childStart, indent + 1);
+    const node: PMNode = {
+      type: "notionSyncedBlock",
+      attrs: {
+        isReference: tagKey === "<synced_block_reference",
+        url: attrs.url || null,
+        notice: attrs.notice || null,
+      },
+      content: childRes.nodes,
+    };
+    return { nodes: [withIndentAttr(node)], end: closeIdx + 1 };
+  }
+
+  // Fallback: preserve raw.
+  return parseRawContainer(
+    lines,
+    start,
+    indent,
+    closeTag,
+    "unknown",
+    withIndentAttr,
+  );
+}
+
+function parseRawContainer(
+  lines: string[],
+  start: number,
+  indent: number,
+  closeTag: string,
+  tagName: string,
+  withIndentAttr: (n: PMNode) => PMNode,
+): ParseResult {
+  let i = start + 1;
+  for (; i < lines.length; i++) {
+    if (lines[i].slice(indent) === closeTag && leadingTabs(lines[i]) >= indent)
+      break;
+  }
+  const rawLines = lines.slice(start, i + 1).map((l) => stripTabs(l, indent));
+  const node: PMNode = {
+    type: "notionBlockAtom",
+    attrs: {
+      tagName,
+      attrsJson: "{}",
+      label: tagName,
+      __raw: rawLines.join("\n"),
+    },
+  };
+  return { nodes: [withIndentAttr(node)], end: i + 1 };
+}
+
+function parseTable(
+  lines: string[],
+  start: number,
+  indent: number,
+  withIndentAttr: (n: PMNode) => PMNode,
+): ParseResult {
+  const openAttrs = parseAttrs(lines[start].slice(indent));
+  const headerRow = openAttrs["header-row"] === "true";
+  const headerColumn = openAttrs["header-column"] === "true";
+  const fitPageWidth = openAttrs["fit-page-width"] === "true";
+
+  let i = start + 1;
+  const colMeta: Array<{ color?: string; width?: string }> = [];
+  const rows: PMNode[] = [];
+
+  for (; i < lines.length; i++) {
+    const ld = lines[i].slice(Math.min(indent, leadingTabs(lines[i]))).trim();
+    if (ld === "</table>") {
+      i++;
+      break;
+    }
+    if (ld === "<colgroup>") continue;
+    if (ld === "</colgroup>") continue;
+    const colMatch = ld.match(/^<col([^>]*)\/?>$/);
+    if (colMatch) {
+      const a = parseAttrs(colMatch[1]);
+      colMeta.push({ color: a.color, width: a.width });
+      continue;
+    }
+    if (/^<tr/.test(ld)) {
+      const rowAttrs = parseAttrs(ld);
+      const cells: PMNode[] = [];
+      // consume cells until </tr>
+      for (i++; i < lines.length; i++) {
+        const cd = lines[i]
+          .slice(Math.min(indent, leadingTabs(lines[i])))
+          .trim();
+        if (cd === "</tr>") break;
+        const cellMatch = cd.match(/^<t[dh]([^>]*)>([\s\S]*?)<\/t[dh]>$/);
+        if (cellMatch) {
+          const ca = parseAttrs(cellMatch[1]);
+          const isHeader =
+            (headerRow && rows.length === 0) ||
+            (headerColumn && cells.length === 0);
+          cells.push({
+            type: isHeader ? "tableHeader" : "tableCell",
+            attrs: { color: isColor(ca.color) ? ca.color : null },
+            content: [
+              { type: "paragraph", content: parseInline(cellMatch[2]) },
+            ],
+          });
+        }
+      }
+      rows.push({
+        type: "tableRow",
+        attrs: { color: isColor(rowAttrs.color) ? rowAttrs.color : null },
+        content: cells,
+      });
+    }
+  }
+
+  const node: PMNode = {
+    type: "table",
+    attrs: {
+      headerRow,
+      headerColumn,
+      fitPageWidth,
+      colMeta: colMeta.length ? colMeta : null,
+    },
+    content: rows,
+  };
+  return { nodes: [withIndentAttr(node)], end: i };
+}
+
+const MEDIA_TAGS = new Set(["video", "audio"]);
+const BLOCK_ATOM_TAGS = new Set([
+  "page",
+  "database",
+  "file",
+  "pdf",
+  "bookmark",
+  "embed",
+  "table_of_contents",
+  "unknown",
+]);
+
+function parseLeafTag(
+  tagName: string,
+  rawAttrs: string,
+  label: string,
+): PMNode | null {
+  if (MEDIA_TAGS.has(tagName)) {
+    const attrs = parseAttrs(rawAttrs);
+    return {
+      type: tagName,
+      attrs: {
+        src: attrs.src || null,
+        title: label ? unescapeAttr(label) : null,
+        ...(isColor(attrs.color) ? { color: attrs.color } : {}),
+      },
+    };
+  }
+  if (BLOCK_ATOM_TAGS.has(tagName)) {
+    const attrs = parseAttrs(rawAttrs);
+    return {
+      type: "notionBlockAtom",
+      attrs: {
+        tagName,
+        attrsJson: JSON.stringify(attrs),
+        label: label ? unescapeAttr(label) : "",
+      },
+    };
+  }
+  return null;
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Public helpers
+// ════════════════════════════════════════════════════════════════════
+
+/** Canonicalize NFM into the exact stable form (Notion's emission form). */
+export function canonicalizeNfm(nfm: string | null | undefined): string {
+  return docToNfm(nfmToDoc(nfm ?? ""));
+}


### PR DESCRIPTION
## Summary
- keep auth/login fallback HTML out of shared CDN caches with explicit no-store browser/CDN headers
- add Vary: Accept to docs markdown/HTML content negotiation
- move safe React Router route warmup into core and keep .data warmup on ordinary fetch/modulepreload rather than native prefetch
- include local agent skill metadata updates

## Validation
- pnpm --filter @agent-native/core exec vitest run src/vite/client.spec.ts src/server/auth.spec.ts
- pnpm --filter @agent-native/core build
- NITRO_PRESET=netlify pnpm --filter @agent-native/docs build

Follow-up to #1001 review feedback.