### PR TITLE
Improve skills install flow, docs sidebar, and Notion sync refresh

### DIFF
--- a/.changeset/skill-notion-sync-fixes.md
+++ b/.changeset/skill-notion-sync-fixes.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix skill installation edge cases and Notion sync refresh behavior.

--- a/packages/core/src/cli/connect.ts
+++ b/packages/core/src/cli/connect.ts
@@ -190,6 +190,10 @@ export function normalizeUrl(raw: string): string {
 export function resolveClients(client: string): ClientId[] {
   const c = (client ?? "all").toLowerCase();
   if (c === "all" || c === "") return [...CLIENTS];
+  if (c.includes(",")) {
+    const clients = normalizeClientIds(c.split(",").map((part) => part.trim()));
+    if (clients.length > 0) return clients;
+  }
   if ((CLIENTS as string[]).includes(c)) return [c as ClientId];
   throw new Error(
     `Unknown --client "${client}". Use: all, ${CLIENTS.join(", ")}`,

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -208,41 +208,61 @@ describe("agent-native skills", () => {
   it("skips the client prompt when --client is explicit", async () => {
     const root = tmpDir();
     const promptClients = vi.fn(async () => ["codex" as const]);
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 
-    await runSkills(["add", "assets", "--client", "claude-code"], {
-      baseDir: root,
-      isInteractive: () => true,
-      promptClients,
-      runCommand: async () => 0,
-    });
+    await runSkills(
+      ["add", "assets", "--client", "claude-code", "--scope", "project"],
+      {
+        baseDir: root,
+        isInteractive: () => true,
+        promptClients,
+        runCommand: async () => 0,
+      },
+    );
 
     expect(promptClients).not.toHaveBeenCalled();
   });
 
   it("prompts for skills when interactive add has no target", async () => {
     const root = tmpDir();
+    const home = path.join(root, "home");
+    const codexHome = path.join(root, "codex-home");
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(codexHome, { recursive: true });
+    const previousHome = process.env.HOME;
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.HOME = home;
+    process.env.CODEX_HOME = codexHome;
     const commands: { args: string[] }[] = [];
     const promptSkills = vi.fn(async () => ["assets", "design-exploration"]);
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 
-    await runSkills(["add"], {
-      baseDir: root,
-      isInteractive: () => true,
-      promptClients: async () => ["codex"],
-      promptSkills,
-      runCommand: async (_cmd, args) => {
-        commands.push({ args });
-        return 0;
-      },
-    });
+    try {
+      await runSkills(["add"], {
+        baseDir: root,
+        isInteractive: () => true,
+        promptClients: async () => ["codex"],
+        promptSkills,
+        runCommand: async (_cmd, args) => {
+          commands.push({ args });
+          return 0;
+        },
+      });
 
-    expect(promptSkills).toHaveBeenCalledTimes(1);
-    expect(commands).toHaveLength(2);
-    expect(commands[0].args).toEqual(
-      expect.arrayContaining(["--skill", "assets"]),
-    );
-    expect(commands[1].args).toEqual(
-      expect.arrayContaining(["--skill", "design-exploration"]),
-    );
+      expect(promptSkills).toHaveBeenCalledTimes(1);
+      expect(commands).toHaveLength(2);
+      expect(commands[0].args).toEqual(
+        expect.arrayContaining(["--skill", "assets"]),
+      );
+      expect(commands[1].args).toEqual(
+        expect.arrayContaining(["--skill", "design-exploration"]),
+      );
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+    }
   });
 
   it("supports dry-run without writing local agent config", async () => {

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -26,8 +26,18 @@ describe("agent-native skills", () => {
       command: "add",
       target: "assets",
       client: "codex",
+      clientExplicit: false,
       instructions: true,
       mcp: true,
+    });
+  });
+
+  it("tracks when --client is explicit", () => {
+    expect(
+      parseSkillsArgs(["add", "assets", "--client", "claude-code"]),
+    ).toMatchObject({
+      client: "claude-code",
+      clientExplicit: true,
     });
   });
 
@@ -139,6 +149,100 @@ describe("agent-native skills", () => {
       JSON.parse(fs.readFileSync(path.join(root, ".mcp.json"), "utf-8"))
         .mcpServers["agent-native-assets"].url,
     ).toBe("https://assets.agent-native.com/_agent-native/mcp");
+  });
+
+  it("prompts for target clients in interactive installs when --client is omitted", async () => {
+    const root = tmpDir();
+    const home = path.join(root, "home");
+    const codexHome = path.join(root, "codex-home");
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(codexHome, { recursive: true });
+    const previousHome = process.env.HOME;
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.HOME = home;
+    process.env.CODEX_HOME = codexHome;
+    const stdout: string[] = [];
+    const commands: { cmd: string; args: string[]; stdio?: string }[] = [];
+    const promptClients = vi.fn(async () => [
+      "codex" as const,
+      "claude-code" as const,
+    ]);
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+
+    try {
+      await runSkills(["add", "assets"], {
+        baseDir: root,
+        isInteractive: () => true,
+        promptClients,
+        runCommand: async (cmd, args, options) => {
+          commands.push({ cmd, args, stdio: options?.stdio });
+          return 0;
+        },
+      });
+
+      expect(promptClients).toHaveBeenCalledTimes(1);
+      expect(commands[0]).toMatchObject({ cmd: "npx", stdio: "silent" });
+      expect(commands[0].args).toEqual(
+        expect.arrayContaining(["-a", "codex", "-a", "claude-code"]),
+      );
+      expect(
+        fs.readFileSync(path.join(codexHome, "config.toml"), "utf-8"),
+      ).toContain("agent-native-assets");
+      expect(
+        JSON.parse(fs.readFileSync(path.join(home, ".claude.json"), "utf-8"))
+          .mcpServers["agent-native-assets"].url,
+      ).toBe("https://assets.agent-native.com/_agent-native/mcp");
+      expect(stdout.join("")).toContain("MCP config: codex, claude-code.");
+      expect(stdout.join("")).toContain("rerun with --client <client>");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+    }
+  });
+
+  it("skips the client prompt when --client is explicit", async () => {
+    const root = tmpDir();
+    const promptClients = vi.fn(async () => ["codex" as const]);
+
+    await runSkills(["add", "assets", "--client", "claude-code"], {
+      baseDir: root,
+      isInteractive: () => true,
+      promptClients,
+      runCommand: async () => 0,
+    });
+
+    expect(promptClients).not.toHaveBeenCalled();
+  });
+
+  it("prompts for skills when interactive add has no target", async () => {
+    const root = tmpDir();
+    const commands: { args: string[] }[] = [];
+    const promptSkills = vi.fn(async () => ["assets", "design-exploration"]);
+
+    await runSkills(["add"], {
+      baseDir: root,
+      isInteractive: () => true,
+      promptClients: async () => ["codex"],
+      promptSkills,
+      runCommand: async (_cmd, args) => {
+        commands.push({ args });
+        return 0;
+      },
+    });
+
+    expect(promptSkills).toHaveBeenCalledTimes(1);
+    expect(commands).toHaveLength(2);
+    expect(commands[0].args).toEqual(
+      expect.arrayContaining(["--skill", "assets"]),
+    );
+    expect(commands[1].args).toEqual(
+      expect.arrayContaining(["--skill", "design-exploration"]),
+    );
   });
 
   it("supports dry-run without writing local agent config", async () => {
@@ -377,7 +481,7 @@ describe("agent-native skills", () => {
       expect(result.id).toBe("assets");
       expect(commands[0]).toMatchObject({
         cmd: "npx",
-        stdio: "stderr",
+        stdio: "silent",
       });
       expect(commands[0].args).toEqual(expect.arrayContaining(["-g"]));
       expect(commands[0].args).toEqual(

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -17,8 +17,12 @@ import {
   type AppSkillManifest,
   type LoadedAppSkillManifest,
 } from "./app-skill.js";
-import { resolveClients } from "./connect.js";
-import type { ClientId } from "./mcp-config-writers.js";
+import {
+  readConnectClientPreferences,
+  resolveClients,
+  writeConnectClientPreferences,
+} from "./connect.js";
+import { CLIENTS, type ClientId } from "./mcp-config-writers.js";
 
 const HELP = `agent-native skills
 
@@ -320,12 +324,28 @@ const BUILT_IN_APP_SKILL_DISPLAY_ALIASES = {
   ],
 } satisfies Record<BuiltInAppSkillId, string[]>;
 
+const CLIENT_LABELS: Record<ClientId, string> = {
+  "claude-code": "Claude Code",
+  "claude-code-cli": "Claude Code CLI",
+  codex: "Codex",
+  cowork: "Claude Cowork",
+};
+
+const CLIENT_HINTS: Record<ClientId, string> = {
+  "claude-code": ".mcp.json or ~/.claude.json",
+  "claude-code-cli": ".mcp.json or ~/.claude.json",
+  codex: "$CODEX_HOME/config.toml or ~/.codex/config.toml",
+  cowork: "~/.cowork/mcp.json",
+};
+
 type SkillsCommand = "list" | "add" | "help";
 
 export interface ParsedSkillsArgs {
   command: SkillsCommand;
   target?: string;
   client: string;
+  clientExplicit: boolean;
+  clients?: ClientId[];
   scope: string;
   yes: boolean;
   dryRun: boolean;
@@ -362,17 +382,34 @@ interface SkillInstallTarget {
 }
 
 interface RunCommandOptions {
-  stdio?: "inherit" | "stderr";
+  stdio?: "inherit" | "stderr" | "silent";
 }
 
 interface RunSkillsOptions {
   baseDir?: string;
+  isInteractive?: () => boolean;
   log?: (message: string) => void;
+  promptClients?: (
+    context: SkillsClientPromptContext,
+  ) => Promise<ClientId[] | null>;
+  promptSkills?: (
+    context: SkillsTargetPromptContext,
+  ) => Promise<string[] | null>;
   runCommand?: (
     cmd: string,
     args: string[],
     options?: RunCommandOptions,
   ) => Promise<number>;
+}
+
+interface SkillsClientPromptContext {
+  initialClients: ClientId[];
+  options: Array<{ value: ClientId; label: string; hint: string }>;
+}
+
+interface SkillsTargetPromptContext {
+  initialTargets: string[];
+  options: Array<{ value: string; label: string; hint: string }>;
 }
 
 function normalizeKnownSkillTarget(
@@ -385,6 +422,124 @@ function normalizeKnownSkillTarget(
 
 function isKnownSkill(value: string | undefined): boolean {
   return Boolean(normalizeKnownSkillTarget(value));
+}
+
+function normalizeClientIds(values: unknown): ClientId[] {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set<ClientId>();
+  const out: ClientId[] = [];
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const id = value.toLowerCase();
+    if (!(CLIENTS as string[]).includes(id)) continue;
+    const client = id as ClientId;
+    if (seen.has(client)) continue;
+    seen.add(client);
+    out.push(client);
+  }
+  return out;
+}
+
+function clientPromptOptions(): SkillsClientPromptContext["options"] {
+  return CLIENTS.map((client) => ({
+    value: client,
+    label: CLIENT_LABELS[client],
+    hint: CLIENT_HINTS[client],
+  }));
+}
+
+function skillPromptOptions(): SkillsTargetPromptContext["options"] {
+  return Object.values(BUILT_IN_APP_SKILLS).map((entry) => ({
+    value: entry.skillName,
+    label: entry.manifest.displayName,
+    hint: entry.manifest.description,
+  }));
+}
+
+function shouldPrompt(parsed: ParsedSkillsArgs, options: RunSkillsOptions) {
+  if (parsed.yes || parsed.printJson) return false;
+  if (options.isInteractive) return options.isInteractive();
+  if (process.env.AGENT_NATIVE_NO_PROMPT === "1") return false;
+  if (process.env.CI === "true") return false;
+  return !!process.stdin.isTTY && !!process.stdout.isTTY;
+}
+
+async function promptForClients(
+  context: SkillsClientPromptContext,
+): Promise<ClientId[] | null> {
+  const clack = await import("@clack/prompts");
+  const result = await clack.multiselect({
+    message:
+      "Install the MCP connector for which local agents?\n" +
+      "  (space toggles, enter confirms; saved for next time)",
+    options: context.options,
+    initialValues: context.initialClients,
+    required: true,
+  });
+  if (clack.isCancel(result)) {
+    clack.cancel("Cancelled.");
+    return null;
+  }
+  return normalizeClientIds(result);
+}
+
+async function promptForSkills(
+  context: SkillsTargetPromptContext,
+): Promise<string[] | null> {
+  const clack = await import("@clack/prompts");
+  const result = await clack.multiselect({
+    message:
+      "Which Agent Native skills do you want to install?\n" +
+      "  (space toggles, enter confirms)",
+    options: context.options,
+    initialValues: context.initialTargets,
+    required: true,
+  });
+  if (clack.isCancel(result)) {
+    clack.cancel("Cancelled.");
+    return null;
+  }
+  if (!Array.isArray(result)) return [];
+  return result.filter((value): value is string => typeof value === "string");
+}
+
+async function resolveSkillsClients(
+  parsed: ParsedSkillsArgs,
+  options: RunSkillsOptions,
+): Promise<ClientId[] | null> {
+  if (parsed.clientExplicit || !shouldPrompt(parsed, options)) {
+    return resolveClients(parsed.client);
+  }
+  const initialClients =
+    readConnectClientPreferences() ?? resolveClients("codex");
+  const prompt = options.promptClients ?? promptForClients;
+  const selected = normalizeClientIds(
+    await prompt({
+      initialClients,
+      options: clientPromptOptions(),
+    }),
+  );
+  if (selected.length === 0) return null;
+  try {
+    writeConnectClientPreferences(selected);
+  } catch {}
+  return selected;
+}
+
+async function resolveSkillTargets(
+  parsed: ParsedSkillsArgs,
+  options: RunSkillsOptions,
+): Promise<string[] | null> {
+  if (parsed.target || !shouldPrompt(parsed, options)) {
+    return [parsed.target ?? "assets"];
+  }
+  const prompt = options.promptSkills ?? promptForSkills;
+  const selected = await prompt({
+    initialTargets: ["assets"],
+    options: skillPromptOptions(),
+  });
+  if (!selected || selected.length === 0) return null;
+  return selected;
 }
 
 export function parseSkillsArgs(argv: string[]): ParsedSkillsArgs {
@@ -404,6 +559,7 @@ export function parseSkillsArgs(argv: string[]): ParsedSkillsArgs {
   const out: ParsedSkillsArgs = {
     command,
     client: "codex",
+    clientExplicit: false,
     scope: "user",
     yes: false,
     dryRun: false,
@@ -430,8 +586,10 @@ export function parseSkillsArgs(argv: string[]): ParsedSkillsArgs {
       return undefined;
     };
     let value: string | undefined;
-    if ((value = eat("--client")) !== undefined) out.client = value;
-    else if ((value = eat("--scope")) !== undefined) out.scope = value;
+    if ((value = eat("--client")) !== undefined) {
+      out.client = value;
+      out.clientExplicit = true;
+    } else if ((value = eat("--scope")) !== undefined) out.scope = value;
     else if ((value = eat("--mcp-url")) !== undefined) out.mcpUrl = value;
     else if (arg === "--yes" || arg === "-y") out.yes = true;
     else if (arg === "--dry-run") out.dryRun = true;
@@ -523,6 +681,12 @@ function commandString(cmd: string, args: string[]): string {
   return [cmd, ...args].map(shellArg).join(" ");
 }
 
+function clientArgForClients(clients: ClientId[]): string {
+  if (clients.length === CLIENTS.length) return "all";
+  if (clients.length === 1) return clients[0];
+  return clients.join(",");
+}
+
 function preserveMcpUrlAppPathOverride(
   target: SkillInstallTarget,
   input: string | undefined,
@@ -556,12 +720,13 @@ function dryRunInstallCommand(
   parsed: ParsedSkillsArgs,
   target: string,
 ): string {
+  const clients = parsed.clients ?? resolveClients(parsed.client);
   const args = [
     "skills",
     "add",
     target,
     "--client",
-    parsed.client,
+    clientArgForClients(clients),
     "--scope",
     parsed.scope,
   ];
@@ -579,20 +744,34 @@ async function runCommand(
 ): Promise<number> {
   return new Promise((resolve, reject) => {
     const pipeToStderr = options.stdio === "stderr";
+    const silent = options.stdio === "silent";
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
     const child = spawn(cmd, args, {
-      stdio: pipeToStderr ? ["inherit", "pipe", "pipe"] : "inherit",
+      stdio: pipeToStderr || silent ? ["inherit", "pipe", "pipe"] : "inherit",
       shell: process.platform === "win32",
       env: process.env,
     });
     if (pipeToStderr) {
       child.stdout?.on("data", (chunk) => process.stderr.write(chunk));
       child.stderr?.on("data", (chunk) => process.stderr.write(chunk));
+    } else if (silent) {
+      child.stdout?.on("data", (chunk) =>
+        stdoutChunks.push(Buffer.from(chunk)),
+      );
+      child.stderr?.on("data", (chunk) =>
+        stderrChunks.push(Buffer.from(chunk)),
+      );
     }
     child.on("error", reject);
     child.on("exit", (code, signal) => {
       if (signal) {
         reject(new Error(`${cmd} was interrupted by ${signal}.`));
         return;
+      }
+      if (silent && code !== 0) {
+        for (const chunk of stdoutChunks) process.stderr.write(chunk);
+        for (const chunk of stderrChunks) process.stderr.write(chunk);
       }
       resolve(code ?? 0);
     });
@@ -652,7 +831,7 @@ export async function addAgentNativeSkill(
   if (parsed.mcpUrl) {
     installTarget = withMcpUrlOverride(installTarget, parsed.mcpUrl);
   }
-  const clients = resolveClients(parsed.client);
+  const clients = parsed.clients ?? resolveClients(parsed.client);
   installTarget = preserveMcpUrlAppPathOverride(installTarget, parsed.mcpUrl);
   const skillsAgents = skillsAgentsForClients(clients);
   if (parsed.dryRun) {
@@ -697,7 +876,7 @@ export async function addAgentNativeSkill(
       commands.push(commandString("npx", args));
       if (!parsed.dryRun) {
         const code = await (options.runCommand ?? runCommand)("npx", args, {
-          stdio: parsed.printJson ? "stderr" : "inherit",
+          stdio: "silent",
         });
         if (code !== 0) throw new Error(`npx skills add exited with ${code}.`);
       }
@@ -781,24 +960,65 @@ export async function runSkills(
     return;
   }
 
-  const result = await addAgentNativeSkill(parsed, {
-    ...options,
-    log,
-  });
+  const targets = await resolveSkillTargets(parsed, options);
+  if (!targets) return;
+  const clients = await resolveSkillsClients(parsed, options);
+  if (!clients) return;
+
+  const results: SkillsAddResult[] = [];
+  for (const target of targets) {
+    results.push(
+      await addAgentNativeSkill(
+        {
+          ...parsed,
+          target,
+          client: clientArgForClients(clients),
+          clients,
+        },
+        {
+          ...options,
+          log,
+        },
+      ),
+    );
+  }
 
   if (parsed.printJson) {
-    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    process.stdout.write(
+      `${JSON.stringify(results.length === 1 ? results[0] : results, null, 2)}\n`,
+    );
     return;
   }
 
   if (parsed.dryRun) {
-    process.stdout.write(`${result.commands.join("\n")}\n`);
+    process.stdout.write(
+      `${results.flatMap((result) => result.commands).join("\n")}\n`,
+    );
     return;
   }
 
+  const installedNames = results.map((result) => result.displayName).join(", ");
+  const skillsAgents = [
+    ...new Set(results.flatMap((result) => result.skillsAgents)),
+  ];
+  const mcpClients = [
+    ...new Set(results.flatMap((result) => result.mcpClients)),
+  ];
+  const mcpUrls = [...new Set(results.map((result) => result.mcpUrl))];
   process.stdout.write(
-    `Installed ${result.displayName} skill for ${result.skillsAgents.join(
-      ", ",
-    )} and registered ${result.mcpUrl} for ${result.mcpClients.join(", ")}.\n`,
+    [
+      `Installed ${installedNames} skill${results.length === 1 ? "" : "s"}.`,
+      skillsAgents.length
+        ? `Skill instructions: ${skillsAgents.join(", ")}.`
+        : "Skill instructions: skipped.",
+      `MCP config: ${mcpClients.join(", ")}.`,
+      `MCP URL${mcpUrls.length === 1 ? "" : "s"}: ${mcpUrls.join(", ")}.`,
+      "Restart or reload selected agent clients if the tools are not visible yet.",
+      parsed.clientExplicit
+        ? ""
+        : `To add another client later, rerun with --client <client> (for example: --client claude-code).`,
+    ]
+      .filter(Boolean)
+      .join("\n") + "\n",
   );
 }

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -520,9 +520,11 @@ async function resolveSkillsClients(
     }),
   );
   if (selected.length === 0) return null;
-  try {
-    writeConnectClientPreferences(selected);
-  } catch {}
+  if (!parsed.dryRun) {
+    try {
+      writeConnectClientPreferences(selected);
+    } catch {}
+  }
   return selected;
 }
 
@@ -857,28 +859,32 @@ export async function addAgentNativeSkill(
   try {
     if (parsed.instructions) {
       if (skillsAgents.length === 0) {
-        throw new Error(
-          "Skill instructions can only be installed for Codex or Claude Code clients. Use --mcp-only for MCP-only clients.",
-        );
-      }
-      instructionSource = installTarget.materializeInstructions(tmpRoot);
-      const args = [
-        "--yes",
-        "skills@latest",
-        "add",
-        instructionSource,
-        "--copy",
-        ...installTarget.skillNames.flatMap((skill) => ["--skill", skill]),
-        ...skillsAgents.flatMap((agent) => ["-a", agent]),
-        ...(parsed.scope === "user" ? ["-g"] : []),
-        ...(parsed.yes || knownTarget ? ["-y"] : []),
-      ];
-      commands.push(commandString("npx", args));
-      if (!parsed.dryRun) {
-        const code = await (options.runCommand ?? runCommand)("npx", args, {
-          stdio: "silent",
-        });
-        if (code !== 0) throw new Error(`npx skills add exited with ${code}.`);
+        if (!parsed.mcp) {
+          throw new Error(
+            "Skill instructions can only be installed for Codex or Claude Code clients. Use an MCP-capable client or omit --instructions-only.",
+          );
+        }
+      } else {
+        instructionSource = installTarget.materializeInstructions(tmpRoot);
+        const args = [
+          "--yes",
+          "skills@latest",
+          "add",
+          instructionSource,
+          "--copy",
+          ...installTarget.skillNames.flatMap((skill) => ["--skill", skill]),
+          ...skillsAgents.flatMap((agent) => ["-a", agent]),
+          ...(parsed.scope === "user" ? ["-g"] : []),
+          ...(parsed.yes || knownTarget ? ["-y"] : []),
+        ];
+        commands.push(commandString("npx", args));
+        if (!parsed.dryRun) {
+          const code = await (options.runCommand ?? runCommand)("npx", args, {
+            stdio: "silent",
+          });
+          if (code !== 0)
+            throw new Error(`npx skills add exited with ${code}.`);
+        }
       }
     }
 

--- a/packages/docs/app/components/DocsSidebar.test.tsx
+++ b/packages/docs/app/components/DocsSidebar.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import DocsSidebar from "./DocsSidebar";
+
+function renderSidebar(path: string) {
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={[path]}>
+      <DocsSidebar />
+    </MemoryRouter>,
+  );
+}
+
+describe("DocsSidebar", () => {
+  it("keeps the overview section expanded without a toggle", () => {
+    const html = renderSidebar("/docs");
+
+    expect(html).toContain("Overview");
+    expect(html).toContain('href="/docs"');
+    expect(html).not.toContain('aria-controls="docs-sidebar-section-0"');
+  });
+
+  it("expands the section that contains the active docs page", () => {
+    const html = renderSidebar("/docs/tracking");
+
+    expect(html).toContain("Tracking &amp; Analytics");
+    expect(html).toContain('href="/docs/tracking"');
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).not.toContain('href="/docs/creating-templates"');
+  });
+});

--- a/packages/docs/app/components/DocsSidebar.tsx
+++ b/packages/docs/app/components/DocsSidebar.tsx
@@ -1,33 +1,134 @@
-import { NavLink } from "react-router";
+import { IconChevronRight } from "@tabler/icons-react";
+import { useEffect, useRef, useState } from "react";
+import { Link, useLocation } from "react-router";
 import { NAV_SECTIONS } from "./docsNavItems";
 
+const ALWAYS_OPEN_SECTION_INDEX = 0;
+
+function normalizePath(pathname: string) {
+  return pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+}
+
+function isItemActive(itemPath: string, pathname: string) {
+  return normalizePath(pathname) === itemPath;
+}
+
+function getActiveSectionTitle(pathname: string) {
+  const activeSectionIndex = NAV_SECTIONS.findIndex((section) =>
+    section.items.some((item) => isItemActive(item.to, pathname)),
+  );
+
+  if (activeSectionIndex <= ALWAYS_OPEN_SECTION_INDEX) {
+    return null;
+  }
+
+  return NAV_SECTIONS[activeSectionIndex]?.title ?? null;
+}
+
 export default function DocsSidebar() {
+  const location = useLocation();
+  const navRef = useRef<HTMLElement>(null);
+  const [openSectionTitle, setOpenSectionTitle] = useState<string | null>(() =>
+    getActiveSectionTitle(location.pathname),
+  );
+
+  useEffect(() => {
+    setOpenSectionTitle(getActiveSectionTitle(location.pathname));
+  }, [location.pathname]);
+
+  useEffect(() => {
+    const nav = navRef.current;
+    if (!nav) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      const activeLink = nav.querySelector<HTMLAnchorElement>(
+        ".sidebar-link.is-active",
+      );
+      if (!activeLink) return;
+
+      const navRect = nav.getBoundingClientRect();
+      const linkRect = activeLink.getBoundingClientRect();
+      const topPadding = 24;
+      const bottomPadding = 32;
+      const isVisible =
+        linkRect.top >= navRect.top + topPadding &&
+        linkRect.bottom <= navRect.bottom - bottomPadding;
+
+      if (isVisible) return;
+
+      nav.scrollTo({
+        top: Math.max(
+          0,
+          nav.scrollTop +
+            linkRect.top +
+            linkRect.height / 2 -
+            (navRect.top + navRect.height / 2),
+        ),
+        behavior: "auto",
+      });
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [location.pathname, openSectionTitle]);
+
   return (
     <aside className="hidden w-[220px] shrink-0 lg:block">
-      <nav className="sticky top-[65px] max-h-[calc(100vh-65px)] overflow-y-auto pb-8 pt-8 pr-4">
-        {NAV_SECTIONS.map((section, i) => (
-          <div key={section.title} className={i > 0 ? "mt-4" : ""}>
-            <p className="mb-1 px-2 text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--fg-secondary)] opacity-50">
-              {section.title}
-            </p>
-            <ul className="list-none space-y-0.5 p-0">
-              {section.items.map((item) => (
-                <li key={item.to}>
-                  <NavLink
-                    data-an-prefetch="render"
-                    to={item.to}
-                    end
-                    className={({ isActive }) =>
-                      isActive ? "sidebar-link is-active" : "sidebar-link"
-                    }
-                  >
-                    {item.label}
-                  </NavLink>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
+      <nav
+        ref={navRef}
+        className="sticky top-[65px] max-h-[calc(100vh-65px)] overflow-y-auto pb-8 pt-8 pr-4"
+      >
+        {NAV_SECTIONS.map((section, index) => {
+          const isAlwaysOpen = index === ALWAYS_OPEN_SECTION_INDEX;
+          const isOpen = isAlwaysOpen || openSectionTitle === section.title;
+          const sectionId = `docs-sidebar-section-${index}`;
+
+          return (
+            <section key={section.title} className="docs-sidebar-section">
+              {isAlwaysOpen ? (
+                <p className="docs-sidebar-section-label">{section.title}</p>
+              ) : (
+                <button
+                  type="button"
+                  className="docs-sidebar-section-trigger"
+                  aria-expanded={isOpen}
+                  aria-controls={sectionId}
+                  onClick={() =>
+                    setOpenSectionTitle((current) =>
+                      current === section.title ? null : section.title,
+                    )
+                  }
+                >
+                  <span>{section.title}</span>
+                  <IconChevronRight
+                    size={16}
+                    stroke={1.75}
+                    className={`docs-sidebar-chevron${isOpen ? " is-open" : ""}`}
+                    aria-hidden="true"
+                  />
+                </button>
+              )}
+
+              {isOpen ? (
+                <ul id={sectionId} className="docs-sidebar-section-items">
+                  {section.items.map((item) => {
+                    const active = isItemActive(item.to, location.pathname);
+                    return (
+                      <li key={item.to}>
+                        <Link
+                          data-an-prefetch="render"
+                          to={item.to}
+                          className={`sidebar-link${active ? " is-active" : ""}`}
+                        >
+                          {item.label}
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : null}
+            </section>
+          );
+        })}
       </nav>
     </aside>
   );

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -343,6 +343,71 @@ h4 {
 }
 
 /* Sidebar nav */
+.docs-sidebar-section + .docs-sidebar-section {
+  margin-top: 6px;
+}
+
+.docs-sidebar-section-label,
+.docs-sidebar-section-trigger {
+  display: flex;
+  min-height: 30px;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  padding: 5px 8px;
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  text-align: left;
+}
+
+.docs-sidebar-section-label {
+  margin: 0;
+}
+
+.docs-sidebar-section-trigger {
+  cursor: pointer;
+  transition:
+    background-color 120ms,
+    color 120ms;
+}
+
+.docs-sidebar-section-trigger:hover {
+  background: var(--sidebar-hover);
+}
+
+.docs-sidebar-section-trigger:focus-visible {
+  outline: 2px solid var(--docs-accent);
+  outline-offset: 2px;
+}
+
+.docs-sidebar-chevron {
+  flex: 0 0 auto;
+  color: var(--fg-secondary);
+  transition: transform 150ms ease;
+}
+
+.docs-sidebar-chevron.is-open {
+  transform: rotate(90deg);
+}
+
+.docs-sidebar-section-items {
+  list-style: none;
+  margin: 2px 0 0 8px;
+  border-left: 1px solid var(--docs-border);
+  padding: 0 0 0 8px;
+}
+
+.docs-sidebar-section-items li {
+  margin: 1px 0;
+}
+
 .sidebar-link {
   display: block;
   font-size: 14px;

--- a/templates/content/app/hooks/use-local-storage.test.tsx
+++ b/templates/content/app/hooks/use-local-storage.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useLocalStorage } from "./use-local-storage";
+
+describe("useLocalStorage", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+    }
+    root = null;
+    container?.remove();
+    container = null;
+    window.localStorage.clear();
+  });
+
+  it("updates same-tab hooks that share a key", () => {
+    const values: Record<string, boolean> = {};
+    const setters: Record<string, (value: boolean) => void> = {};
+
+    function Probe({ id }: { id: string }) {
+      const [value, setValue] = useLocalStorage("shared-key", false);
+      values[id] = value;
+      setters[id] = setValue;
+      return null;
+    }
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root?.render(
+        <>
+          <Probe id="a" />
+          <Probe id="b" />
+        </>,
+      );
+    });
+
+    expect(values).toEqual({ a: false, b: false });
+
+    act(() => {
+      setters.a(true);
+    });
+
+    expect(values).toEqual({ a: true, b: true });
+  });
+});

--- a/templates/content/app/hooks/use-local-storage.ts
+++ b/templates/content/app/hooks/use-local-storage.ts
@@ -1,8 +1,12 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
+
+const LOCAL_STORAGE_CHANGE_EVENT = "content-local-storage-change";
 
 function readStorage<T>(key: string, defaultValue: T): T {
+  if (typeof window === "undefined") return defaultValue;
+
   try {
-    const stored = localStorage.getItem(key);
+    const stored = window.localStorage.getItem(key);
     return stored ? JSON.parse(stored) : defaultValue;
   } catch {
     return defaultValue;
@@ -23,12 +27,46 @@ export function useLocalStorage<T>(
     setValue(fresh);
   }
 
+  useEffect(() => {
+    function handleStorage(event: StorageEvent) {
+      if (event.key === key) {
+        setValue(readStorage(key, defaultValue));
+      }
+    }
+
+    function handleLocalStorageChange(event: Event) {
+      const detail = (event as CustomEvent<{ key?: string; value?: T }>).detail;
+      if (detail?.key === key) {
+        setValue(detail.value as T);
+      }
+    }
+
+    window.addEventListener("storage", handleStorage);
+    window.addEventListener(
+      LOCAL_STORAGE_CHANGE_EVENT,
+      handleLocalStorageChange,
+    );
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      window.removeEventListener(
+        LOCAL_STORAGE_CHANGE_EVENT,
+        handleLocalStorageChange,
+      );
+    };
+  }, [key, defaultValue]);
+
   const set = useCallback(
     (val: T | ((prev: T) => T)) => {
       setValue((prev) => {
         const next = val instanceof Function ? val(prev) : val;
         try {
-          localStorage.setItem(key, JSON.stringify(next));
+          window.localStorage.setItem(key, JSON.stringify(next));
+          window.dispatchEvent(
+            new CustomEvent(LOCAL_STORAGE_CHANGE_EVENT, {
+              detail: { key, value: next },
+            }),
+          );
         } catch {}
         return next;
       });

--- a/templates/content/app/hooks/use-notion.ts
+++ b/templates/content/app/hooks/use-notion.ts
@@ -1,7 +1,9 @@
+import { useEffect, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { appApiPath } from "@agent-native/core/client";
 import type {
   CreateNotionPageRequest,
+  Document,
   DocumentSyncStatus,
   LinkNotionPageRequest,
   NotionConnectionStatus,
@@ -40,7 +42,9 @@ export function useDocumentSyncStatus(
   documentId: string | null,
   options?: { autoSync?: boolean },
 ) {
-  return useQuery({
+  const queryClient = useQueryClient();
+  const lastObservedSyncedAtRef = useRef<string | null>(null);
+  const query = useQuery({
     queryKey: ["document-sync", documentId],
     queryFn: () =>
       fetchJson<DocumentSyncStatus>(
@@ -57,6 +61,38 @@ export function useDocumentSyncStatus(
     // notion-sync.ts) so we make at most one real Notion request per 2s per doc.
     refetchInterval: options?.autoSync ? 2_000 : 30_000,
   });
+
+  useEffect(() => {
+    if (!documentId || !query.data?.lastSyncedAt) return;
+    if (lastObservedSyncedAtRef.current === query.data.lastSyncedAt) return;
+
+    lastObservedSyncedAtRef.current = query.data.lastSyncedAt;
+
+    const cachedDocument = queryClient.getQueryData<Document>([
+      "action",
+      "get-document",
+      { id: documentId },
+    ]);
+    const syncedLocalUpdatedAt = query.data.lastPushedLocalUpdatedAt;
+
+    if (
+      cachedDocument?.updatedAt &&
+      syncedLocalUpdatedAt &&
+      syncedLocalUpdatedAt > cachedDocument.updatedAt
+    ) {
+      queryClient.invalidateQueries({
+        queryKey: ["action", "get-document", { id: documentId }],
+      });
+      queryClient.invalidateQueries({ queryKey: ["action", "list-documents"] });
+    }
+  }, [
+    documentId,
+    query.data?.lastPushedLocalUpdatedAt,
+    query.data?.lastSyncedAt,
+    queryClient,
+  ]);
+
+  return query;
 }
 
 export function useDisconnectNotion() {

--- a/templates/content/server/lib/notion-sync.spec.ts
+++ b/templates/content/server/lib/notion-sync.spec.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const testState = vi.hoisted(() => ({
+  document: {
+    id: "doc-1",
+    ownerEmail: "alice@example.com",
+    title: "Local title",
+    content: "Local body",
+    icon: null as string | null,
+    updatedAt: "2026-06-01T10:00:00.000Z",
+  },
+  link: null as any,
+}));
+
+const notionMocks = vi.hoisted(() => ({
+  createNotionPageWithMarkdown: vi.fn(),
+  fetchNotionPage: vi.fn(),
+  getNotionConnectionForOwner: vi.fn(),
+  normalizeNotionPageId: vi.fn((input: string) => input),
+  notionFetch: vi.fn(),
+  readNotionPageAsDocument: vi.fn(),
+}));
+
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("drizzle-orm")>();
+  return {
+    ...actual,
+    and: vi.fn(),
+    eq: vi.fn(),
+  };
+});
+
+vi.mock("@agent-native/core/collab", () => ({
+  deleteCollabState: vi.fn(),
+  releaseDoc: vi.fn(),
+}));
+
+vi.mock("../db/index.js", () => {
+  const schema = {
+    documents: {
+      id: "documents.id",
+      ownerEmail: "documents.ownerEmail",
+    },
+    documentSyncLinks: {
+      documentId: "documentSyncLinks.documentId",
+      ownerEmail: "documentSyncLinks.ownerEmail",
+    },
+  };
+
+  const db = {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: async () => {
+          if (table === schema.documents) return [testState.document];
+          if (table === schema.documentSyncLinks) {
+            return testState.link ? [testState.link] : [];
+          }
+          return [];
+        },
+      }),
+    }),
+    insert: (table: unknown) => ({
+      values: (row: Record<string, unknown>) => ({
+        onConflictDoUpdate: async ({
+          set,
+        }: {
+          set: Record<string, unknown>;
+        }) => {
+          if (table === schema.documentSyncLinks) {
+            testState.link = { ...row, ...set };
+          }
+        },
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (updates: Record<string, unknown>) => ({
+        where: async () => {
+          if (table === schema.documents) {
+            testState.document = { ...testState.document, ...updates };
+          }
+        },
+      }),
+    }),
+  };
+
+  return { getDb: () => db, schema };
+});
+
+vi.mock("./documents.js", () => ({
+  getCurrentOwnerEmail: () => "alice@example.com",
+}));
+
+vi.mock("./notion.js", () => notionMocks);
+
+describe("createAndLinkNotionPage", () => {
+  beforeEach(() => {
+    testState.document = {
+      id: "doc-1",
+      ownerEmail: "alice@example.com",
+      title: "Local title",
+      content: "Local body",
+      icon: null,
+      updatedAt: "2026-06-01T10:00:00.000Z",
+    };
+    testState.link = null;
+    vi.clearAllMocks();
+
+    notionMocks.getNotionConnectionForOwner.mockResolvedValue({
+      accessToken: "notion-token",
+    });
+    notionMocks.fetchNotionPage.mockResolvedValue({
+      id: "parent-page",
+      last_edited_time: "2026-06-01T10:30:00.000Z",
+    });
+    notionMocks.createNotionPageWithMarkdown.mockResolvedValue({
+      id: "new-page",
+      url: "https://notion.so/new-page",
+    });
+    notionMocks.readNotionPageAsDocument.mockResolvedValue({
+      pageId: "new-page",
+      title: "Local title",
+      icon: null,
+      content: "Local body",
+      lastEditedTime: "2026-06-01T10:31:00.000Z",
+      warnings: [],
+    });
+  });
+
+  it("establishes a pulled baseline after creating the remote page", async () => {
+    const { createAndLinkNotionPage } = await import("./notion-sync.js");
+
+    const status = await createAndLinkNotionPage(
+      "alice@example.com",
+      "doc-1",
+      "parent-page",
+    );
+
+    expect(notionMocks.createNotionPageWithMarkdown).toHaveBeenCalledWith({
+      accessToken: "notion-token",
+      parentPageId: "parent-page",
+      title: "Local title",
+      content: "Local body",
+      icon: null,
+    });
+    expect(notionMocks.readNotionPageAsDocument).toHaveBeenCalledWith(
+      "notion-token",
+      "new-page",
+    );
+    expect(testState.link?.lastPulledRemoteUpdatedAt).toBe(
+      "2026-06-01T10:31:00.000Z",
+    );
+    expect(testState.link?.lastKnownRemoteUpdatedAt).toBe(
+      "2026-06-01T10:31:00.000Z",
+    );
+    expect(status.remoteChanged).toBe(false);
+  });
+});

--- a/templates/content/server/lib/notion-sync.ts
+++ b/templates/content/server/lib/notion-sync.ts
@@ -659,13 +659,15 @@ export async function createAndLinkNotionPage(
     remotePageId: newPage.id,
     state: "linked",
     lastPushedLocalUpdatedAt: document.updatedAt,
-    lastKnownRemoteUpdatedAt: null,
     lastSyncedContentHash: hashContent(document.content),
     warnings: [],
     hasConflict: false,
   });
 
-  return refreshDocumentSyncStatus(owner, documentId);
+  // Establish the same pulled baseline as linking an existing page. Without a
+  // `lastPulledRemoteUpdatedAt`, later Notion edits are never considered remote
+  // changes, so create-and-link can look like inbound sync is broken.
+  return pullDocumentFromNotion(owner, documentId, true);
 }
 
 export async function listNotionLinks(owner: string) {


### PR DESCRIPTION
## Summary
- Improve skills CLI client selection and install behavior, including multi-client prompting, comma-separated clients, dry-run preference handling, and MCP/instructions edge cases.
- Make the docs sidebar collapsible and better preserve/scroll the active navigation state.
- Fix content template same-tab local-storage updates and Notion create/link sync baselines with document cache invalidation.
- Add a patch changeset for @agent-native/core.

## Tests
- pnpm --filter @agent-native/core test -- skills.spec.ts
- pnpm --filter ./templates/content test -- use-local-storage.test.tsx notion-sync.spec.ts
- pnpm --filter @agent-native/docs test -- DocsSidebar.test.tsx