### PR TITLE
Improve Builder connect fallback, desktop downloads, and Notion page links

### DIFF
--- a/.changeset/builder-connect-popup-fallback.md
+++ b/.changeset/builder-connect-popup-fallback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the Builder connect popup open by falling back to the signed connect URL already rendered in the UI when the click-time status refresh fails.

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -339,6 +339,44 @@ describe("useBuilderConnectFlow", () => {
     resolveInitialFetch(jsonResponse({ configured: false }));
   });
 
+  it("falls back to a signed prop URL when status has not loaded and click refresh fails", async () => {
+    setUserAgent("Mozilla/5.0 Chrome/140.0");
+    const popup = createPopupStub();
+    openSpy.mockReturnValue(popup);
+    const signedConnectUrl =
+      "http://localhost:3000/_agent-native/builder/connect?_an_connect=signed-from-prop";
+
+    let resolveInitialFetch!: (response: Response) => void;
+    const initialFetch = new Promise<Response>((resolve) => {
+      resolveInitialFetch = resolve;
+    });
+    vi.mocked(fetch)
+      .mockReturnValueOnce(initialFetch)
+      .mockResolvedValueOnce(new Response("Unauthorized", { status: 401 }));
+
+    await act(async () => {
+      root.render(<BuilderConnectProbe popupUrl={signedConnectUrl} />);
+    });
+
+    await act(async () => {
+      container.querySelector("button")?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(openSpy).toHaveBeenCalledWith(
+      "about:blank",
+      "_blank",
+      "width=600,height=700",
+    );
+    expect(popup.location.href).toBe(expectedConnectUrl(signedConnectUrl));
+    expect(container.textContent).not.toContain(
+      "Couldn't start Builder connect",
+    );
+
+    resolveInitialFetch(jsonResponse({ configured: false }));
+  });
+
   it("refreshes status when a Builder preview callback posts success", async () => {
     setUserAgent("Mozilla/5.0 Chrome/140.0");
     vi.mocked(fetch)

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -738,11 +738,17 @@ export function useBuilderConnectFlow(
               setOrgName(s.orgName ?? null);
             }
 
-            // Prefer the click-time status response, but keep a recent signed
-            // URL from this hook as a fallback. This avoids closing the popup
-            // when the refresh hits a transient 401/HTML/error response.
+            // Prefer the click-time status response, but keep the signed URL
+            // already rendered into the CTA as a fallback. This avoids closing
+            // the popup when the refresh hits a transient 401/HTML/error
+            // response before the status cache has warmed.
             const freshUrl =
-              s?.cliAuthUrl ?? s?.connectUrl ?? cachedFreshUrl ?? null;
+              s?.cliAuthUrl ??
+              s?.connectUrl ??
+              cachedFreshUrl ??
+              signedCliPropUrl ??
+              signedPropUrl ??
+              fallbackUrl;
             if (!freshUrl) {
               try {
                 opened.close();

--- a/packages/docs/app/routes/download.tsx
+++ b/packages/docs/app/routes/download.tsx
@@ -14,6 +14,7 @@ const LATEST_JSON_URL = `${appBasePath()}/api/desktop-latest.json`;
 const RELEASES =
   "https://github.com/BuilderIO/agent-native/releases?q=Agent-Native";
 const OPEN_DESKTOP_URL = "agentnative://open";
+const MANIFEST_STORAGE_KEY = "agent-native-desktop-download-manifest-v1";
 
 type Platform = "mac" | "windows" | "linux";
 type DesktopAssetKind =
@@ -104,6 +105,50 @@ interface Manifest {
   }[];
 }
 
+function isManifestAsset(value: unknown): value is Manifest["assets"][number] {
+  if (!value || typeof value !== "object") return false;
+  const asset = value as Partial<Manifest["assets"][number]>;
+  return (
+    typeof asset.name === "string" &&
+    typeof asset.url === "string" &&
+    typeof asset.size === "number" &&
+    typeof asset.kind === "string"
+  );
+}
+
+function isManifest(value: unknown): value is Manifest {
+  if (!value || typeof value !== "object") return false;
+  const manifest = value as Partial<Manifest>;
+  return (
+    typeof manifest.version === "string" &&
+    typeof manifest.tag === "string" &&
+    (typeof manifest.pub_date === "string" || manifest.pub_date === null) &&
+    Array.isArray(manifest.assets) &&
+    manifest.assets.every(isManifestAsset)
+  );
+}
+
+function readCachedManifest(): Manifest | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const cached = window.localStorage.getItem(MANIFEST_STORAGE_KEY);
+    if (!cached) return null;
+    const parsed: unknown = JSON.parse(cached);
+    return isManifest(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedManifest(manifest: Manifest): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(MANIFEST_STORAGE_KEY, JSON.stringify(manifest));
+  } catch {
+    // Storage can be unavailable in private browsing or locked-down contexts.
+  }
+}
+
 function detectPlatform(): Platform {
   if (typeof navigator === "undefined") return "mac";
   const ua = navigator.userAgent.toLowerCase();
@@ -134,15 +179,25 @@ export default function DownloadPage() {
 
   useEffect(() => {
     let cancelled = false;
+    const cachedManifest = readCachedManifest();
+    if (cachedManifest) {
+      setManifest(cachedManifest);
+    }
+
     fetch(LATEST_JSON_URL)
       .then((response) =>
         response.ok ? response.json() : Promise.reject(new Error("failed")),
       )
       .then((json) => {
-        if (!cancelled) setManifest(json as Manifest);
+        if (!isManifest(json)) throw new Error("invalid manifest");
+        if (!cancelled) {
+          setManifest(json);
+          setManifestError(false);
+          writeCachedManifest(json);
+        }
       })
       .catch(() => {
-        if (!cancelled) setManifestError(true);
+        if (!cancelled && !cachedManifest) setManifestError(true);
       });
     return () => {
       cancelled = true;
@@ -170,6 +225,15 @@ export default function DownloadPage() {
     : manifestError
       ? "Could not load the latest desktop release. The releases page has all installers."
       : "Checking the latest desktop release...";
+  const primaryHref = primaryAsset?.url ?? RELEASES;
+  const primaryLabel = primaryAsset
+    ? primaryDownload?.option.label
+    : manifestError || !manifest
+      ? "View installers on GitHub"
+      : primaryDownload?.option.label;
+  const desktopDownloadLabel = primaryAsset
+    ? "Download installer"
+    : "View installers";
 
   function handleDownload(label: string) {
     trackEvent("desktop download", { platform, label });
@@ -229,38 +293,22 @@ export default function DownloadPage() {
             </a>
           )}
 
-          {primaryAsset || manifestError ? (
-            <a
-              href={primaryAsset?.url ?? RELEASES}
-              onClick={() =>
-                handleDownload(
-                  primaryDownload?.option.label ?? info.primary.label,
-                )
-              }
-              className={
-                isDesktopApp
-                  ? "inline-flex items-center gap-2.5 rounded-lg border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline hover:bg-[var(--sidebar-hover)] hover:no-underline"
-                  : "inline-flex items-center gap-2.5 rounded-lg bg-[var(--fg)] px-8 py-3.5 text-base font-medium text-[var(--bg)] no-underline hover:opacity-85 hover:no-underline"
-              }
-            >
-              <IconDownload size={18} />
-              {isDesktopApp
-                ? "Download installer"
-                : primaryDownload?.option.label}
-            </a>
-          ) : (
-            <button
-              disabled
-              className={
-                isDesktopApp
-                  ? "inline-flex items-center gap-2.5 rounded-lg border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] opacity-60"
-                  : "inline-flex items-center gap-2.5 rounded-lg bg-[var(--fg)] px-8 py-3.5 text-base font-medium text-[var(--bg)] opacity-60"
-              }
-            >
-              <IconDownload size={18} />
-              Loading latest release...
-            </button>
-          )}
+          <a
+            href={primaryHref}
+            onClick={() =>
+              handleDownload(
+                primaryDownload?.option.label ?? info.primary.label,
+              )
+            }
+            className={
+              isDesktopApp
+                ? "inline-flex items-center gap-2.5 rounded-lg border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline hover:bg-[var(--sidebar-hover)] hover:no-underline"
+                : "inline-flex items-center gap-2.5 rounded-lg bg-[var(--fg)] px-8 py-3.5 text-base font-medium text-[var(--bg)] no-underline hover:opacity-85 hover:no-underline"
+            }
+          >
+            <IconDownload size={18} />
+            {isDesktopApp ? desktopDownloadLabel : primaryLabel}
+          </a>
         </div>
 
         {alternativeDownloads.length > 0 && (

--- a/packages/docs/lib/desktop-releases.ts
+++ b/packages/docs/lib/desktop-releases.ts
@@ -4,7 +4,10 @@ const RELEASES_URL_BASE =
   "https://api.github.com/repos/BuilderIO/agent-native/releases";
 const PER_PAGE = 100;
 const MAX_PAGES = 10;
-const CACHE_TTL_MS = 5 * 60_000;
+const CACHE_FRESH_MS = 5 * 60_000;
+
+export const DESKTOP_RELEASE_CACHE_CONTROL =
+  "public, max-age=300, s-maxage=300, stale-while-revalidate=86400, stale-if-error=86400";
 
 const DESKTOP_UPDATE_METADATA = new Set([
   "latest-mac.yml",
@@ -196,23 +199,28 @@ async function buildManifest(): Promise<DesktopDownloadManifest> {
   };
 }
 
-export async function getDesktopDownloadManifest(): Promise<DesktopDownloadManifest> {
-  const now = Date.now();
-  if (cache && now - cache.ts < CACHE_TTL_MS) return cache.data;
+function refreshDesktopDownloadManifest(): Promise<DesktopDownloadManifest> {
   if (inFlight) return inFlight;
   inFlight = (async () => {
-    try {
-      const data = await buildManifest();
-      cache = { data, ts: Date.now() };
-      return data;
-    } catch (error) {
-      if (cache) return cache.data;
-      throw error;
-    } finally {
-      inFlight = null;
-    }
+    const data = await buildManifest();
+    cache = { data, ts: Date.now() };
+    return data;
   })();
+  inFlight = inFlight.finally(() => {
+    inFlight = null;
+  });
   return inFlight;
+}
+
+export async function getDesktopDownloadManifest(): Promise<DesktopDownloadManifest> {
+  const now = Date.now();
+  if (cache) {
+    if (now - cache.ts >= CACHE_FRESH_MS) {
+      void refreshDesktopDownloadManifest().catch(() => undefined);
+    }
+    return cache.data;
+  }
+  return refreshDesktopDownloadManifest();
 }
 
 export function getDesktopReleaseError(error: unknown): {
@@ -229,4 +237,9 @@ export function getDesktopReleaseError(error: unknown): {
     statusMessage:
       e.statusMessage ?? e.message ?? "Upstream releases fetch failed",
   };
+}
+
+export function resetDesktopDownloadManifestCacheForTests(): void {
+  cache = null;
+  inFlight = null;
 }

--- a/packages/docs/server/routes/api/desktop-latest.json.get.ts
+++ b/packages/docs/server/routes/api/desktop-latest.json.get.ts
@@ -1,5 +1,6 @@
 import { defineEventHandler, setResponseHeaders, setResponseStatus } from "h3";
 import {
+  DESKTOP_RELEASE_CACHE_CONTROL,
   type DesktopDownloadManifest,
   getDesktopDownloadManifest,
   getDesktopReleaseError,
@@ -21,7 +22,7 @@ export default defineEventHandler(async (event) => {
 
   setResponseHeaders(event, {
     "content-type": "application/json; charset=utf-8",
-    "cache-control": "public, max-age=60",
+    "cache-control": DESKTOP_RELEASE_CACHE_CONTROL,
   });
   return manifest;
 });

--- a/packages/docs/server/routes/api/desktop-latest.spec.ts
+++ b/packages/docs/server/routes/api/desktop-latest.spec.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   classifyDesktopAsset,
+  getDesktopDownloadManifest,
   isDesktopUpdateMetadataAsset,
   isDesktopUpdaterAsset,
+  resetDesktopDownloadManifestCacheForTests,
 } from "../../../lib/desktop-releases";
 
 describe("classifyDesktopAsset", () => {
@@ -41,5 +43,84 @@ describe("classifyDesktopAsset", () => {
       isDesktopUpdaterAsset("Agent.Native-0.1.7-85-arm64-mac.zip.blockmap"),
     ).toBe(true);
     expect(isDesktopUpdaterAsset("agent-native-core-0.8.2.tgz")).toBe(false);
+  });
+});
+
+function release(tag: string, publishedAt: string) {
+  return {
+    tag_name: tag,
+    name: tag,
+    published_at: publishedAt,
+    draft: false,
+    prerelease: false,
+    assets: [
+      {
+        name: "Agent-Native-arm64.dmg",
+        browser_download_url: `https://example.com/${tag}.dmg`,
+        size: 123,
+      },
+    ],
+  };
+}
+
+function jsonResponse(json: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => json,
+  } as Response;
+}
+
+async function flushPromises() {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("getDesktopDownloadManifest", () => {
+  beforeEach(() => {
+    resetDesktopDownloadManifestCacheForTests();
+  });
+
+  afterEach(() => {
+    resetDesktopDownloadManifestCacheForTests();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("serves stale manifests immediately while revalidating in the background", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([release("v1.0.0", "2026-01-01T00:00:00Z")]),
+    );
+    await expect(getDesktopDownloadManifest()).resolves.toMatchObject({
+      version: "1.0.0",
+    });
+
+    vi.setSystemTime(new Date("2026-01-01T00:06:00Z"));
+
+    let resolveRefresh!: (response: Response) => void;
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+
+    await expect(getDesktopDownloadManifest()).resolves.toMatchObject({
+      version: "1.0.0",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    resolveRefresh(jsonResponse([release("v1.1.0", "2026-01-01T00:06:00Z")]));
+    await flushPromises();
+
+    await expect(getDesktopDownloadManifest()).resolves.toMatchObject({
+      version: "1.1.0",
+    });
   });
 });

--- a/templates/brain/app/components/layout/Sidebar.test.ts
+++ b/templates/brain/app/components/layout/Sidebar.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./Sidebar.tsx", import.meta.url), "utf8");
+
+describe("Brain sidebar footer", () => {
+  it("keeps the organization switcher mounted in the bottom-left footer", () => {
+    expect(source).toContain("OrgSwitcher reserveSpace");
+    expect(source).toContain('from "@agent-native/core/client/org"');
+  });
+});

--- a/templates/brain/app/components/layout/Sidebar.tsx
+++ b/templates/brain/app/components/layout/Sidebar.tsx
@@ -378,7 +378,7 @@ export function Sidebar() {
         </div>
 
         <div className="border-t border-sidebar-border px-3 py-2">
-          <OrgSwitcher />
+          <OrgSwitcher reserveSpace />
         </div>
 
         <div className="border-t border-sidebar-border px-3 py-2">

--- a/templates/brain/app/routes.ts
+++ b/templates/brain/app/routes.ts
@@ -8,6 +8,7 @@ export default [
   route("sources", "./routes/sources.tsx"),
   route("ops", "./routes/ops.tsx"),
   route("settings", "./routes/settings.tsx"),
+  route("team", "./routes/team.tsx"),
   route("extensions", "./routes/extensions.tsx", [
     index("./routes/extensions._index.tsx"),
     route(":id", "./routes/extensions.$id.tsx"),

--- a/templates/brain/app/routes/team.tsx
+++ b/templates/brain/app/routes/team.tsx
@@ -1,0 +1,13 @@
+import { TeamPage } from "@agent-native/core/client/org";
+
+export function meta() {
+  return [{ title: "Team - Brain" }];
+}
+
+export default function TeamRoute() {
+  return (
+    <main className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 sm:py-10">
+      <TeamPage createOrgDescription="Set up a team to share Brain sources, reviewed knowledge, and settings with your colleagues." />
+    </main>
+  );
+}

--- a/templates/content/.agents/skills/notion-integration/SKILL.md
+++ b/templates/content/.agents/skills/notion-integration/SKILL.md
@@ -61,7 +61,7 @@ This overwrites the Notion page's content with the local document's markdown, co
 
 Documents are stored as **Notion-Flavored Markdown (NFM)** — the exact format
 Notion's `/pages/{id}/markdown` API emits and accepts. The storage form is
-Notion's *canonical* form, so a synced document is byte-identical on both sides.
+Notion's _canonical_ form, so a synced document is byte-identical on both sides.
 
 - `shared/nfm.ts` is the single deterministic converter: `nfmToDoc` (NFM →
   ProseMirror JSON) and `docToNfm` (ProseMirror JSON → NFM), plus
@@ -73,6 +73,11 @@ Notion's *canonical* form, so a synced document is byte-identical on both sides.
   `app/components/editor/nfm-editor.roundtrip.test.ts` (real TipTap schema).
   Because our canonical form equals Notion's emission, pull→edit→push→pull
   never drifts.
+- Pulls also materialize accessible Notion child pages referenced by `<page>`
+  atoms. Each child becomes a local `documents` row with `parent_id` set to the
+  pulled parent and a `document_sync_links` row pointing at the child Notion
+  page, so the sidebar tree and page blocks can open the same local subpage.
+  Inaccessible child pages remain preserved as NFM page references.
 - **Do not** route Notion content through `shared/notion-markdown.ts` (the old
   tiptap-markdown bridge). It is retained only for clipboard copy/paste.
 
@@ -90,16 +95,16 @@ attribute (Tab indents a block, matching Notion).
 
 The `document_sync_links` table tracks sync relationships:
 
-| Column                     | Description                                            |
-| -------------------------- | ----------------------------------------------------- |
-| `document_id`              | Local document ID                                     |
-| `provider`                 | Always "notion"                                        |
-| `remote_page_id`           | Notion page ID                                         |
-| `state`                    | "linked", "syncing", "error", "conflict"              |
-| `last_synced_at`           | Timestamp of last successful sync                     |
+| Column                     | Description                                                                                                                      |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `document_id`              | Local document ID                                                                                                                |
+| `provider`                 | Always "notion"                                                                                                                  |
+| `remote_page_id`           | Notion page ID                                                                                                                   |
+| `state`                    | "linked", "syncing", "error", "conflict"                                                                                         |
+| `last_synced_at`           | Timestamp of last successful sync                                                                                                |
 | `last_synced_content_hash` | SHA-256 of the canonical content identical on both sides — the authoritative "did it change" signal (immune to timestamp jitter) |
-| `has_conflict`             | Whether both sides changed since last sync (0 or 1)   |
-| `last_error`               | Error message if sync failed                          |
+| `has_conflict`             | Whether both sides changed since last sync (0 or 1)                                                                              |
+| `last_error`               | Error message if sync failed                                                                                                     |
 
 Conflict detection is **content-hash based**: a side has "changed" only when its
 canonical content hash differs from `last_synced_content_hash`. A no-op sync
@@ -108,13 +113,13 @@ the two copies from drifting.
 
 ## Common Tasks
 
-| User says                          | What to do                                            |
-| ---------------------------------- | ----------------------------------------------------- |
-| "Is Notion connected?"             | `connect-notion-status`                               |
-| "Link this doc to Notion"          | `link-notion-page --documentId ... --notionPageId ...`|
-| "Pull from Notion"                 | `pull-notion-page --documentId ...`                   |
-| "Push to Notion"                   | `push-notion-page --documentId ...`                   |
-| "Show Notion-linked documents"     | `list-notion-links`                                   |
+| User says                      | What to do                                             |
+| ------------------------------ | ------------------------------------------------------ |
+| "Is Notion connected?"         | `connect-notion-status`                                |
+| "Link this doc to Notion"      | `link-notion-page --documentId ... --notionPageId ...` |
+| "Pull from Notion"             | `pull-notion-page --documentId ...`                    |
+| "Push to Notion"               | `push-notion-page --documentId ...`                    |
+| "Show Notion-linked documents" | `list-notion-links`                                    |
 
 ## Important Notes
 

--- a/templates/content/actions/list-documents.ts
+++ b/templates/content/actions/list-documents.ts
@@ -59,7 +59,24 @@ export default defineAction({
       .orderBy(asc(schema.documents.position));
 
     const shareRoleByDocumentId = new Map<string, ShareRole>();
+    const notionPageIdByDocumentId = new Map<string, string>();
     if (documents.length > 0) {
+      const notionLinks = await db
+        .select({
+          documentId: schema.documentSyncLinks.documentId,
+          remotePageId: schema.documentSyncLinks.remotePageId,
+        })
+        .from(schema.documentSyncLinks)
+        .where(
+          inArray(
+            schema.documentSyncLinks.documentId,
+            documents.map((d) => d.id),
+          ),
+        );
+      for (const link of notionLinks) {
+        notionPageIdByDocumentId.set(link.documentId, link.remotePageId);
+      }
+
       const principalClauses: NonNullable<ReturnType<typeof and>>[] = [];
       if (userEmail) {
         principalClauses.push(
@@ -132,6 +149,10 @@ export default defineAction({
         position: d.position,
         isFavorite: parseDocumentFavorite(d.isFavorite),
         hideFromSearch: parseDocumentHideFromSearch(d.hideFromSearch),
+        notionPageId: notionPageIdByDocumentId.get(d.id) ?? null,
+        notionPageUrl: notionPageIdByDocumentId.has(d.id)
+          ? `https://www.notion.so/${notionPageIdByDocumentId.get(d.id)!.replace(/-/g, "")}`
+          : null,
         visibility: d.visibility,
         accessRole,
         canEdit: canEditRole(accessRole),

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -11,7 +12,11 @@ import { VisualEditor } from "./VisualEditor";
 import { DocumentToolbar } from "./DocumentToolbar";
 import { NotionConflictBanner } from "./NotionConflictBanner";
 import { EmojiPicker } from "./EmojiPicker";
-import { useDocument, useUpdateDocument } from "@/hooks/use-documents";
+import {
+  useDocument,
+  useDocuments,
+  useUpdateDocument,
+} from "@/hooks/use-documents";
 import { useDocumentSyncStatus } from "@/hooks/use-notion";
 import {
   useCollaborativeDoc,
@@ -33,6 +38,7 @@ import { useLocalStorage } from "@/hooks/use-local-storage";
 import { useQueryClient } from "@tanstack/react-query";
 import { IconLock } from "@tabler/icons-react";
 import type { Document, DocumentSyncStatus } from "@shared/api";
+import type { NotionPageLink } from "./VisualEditor";
 import {
   normalizeTitleText,
   stripMarkdownHeadingPrefixFromTitlePaste,
@@ -131,6 +137,8 @@ interface DocumentEditorBodyProps {
 function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
   const updateDocument = useUpdateDocument();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const { data: documents = [] } = useDocuments();
   // Shared with DocumentToolbar via the same localStorage key — both read it.
   const [autoSync] = useLocalStorage(`notion-auto-sync:${documentId}`, false);
   const canEdit = document.canEdit ?? true;
@@ -160,6 +168,28 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const titleInputRef = useRef<HTMLTextAreaElement>(null);
   const shouldFocusTitleRef = useRef(false);
+  const notionPageLinks = useMemo<NotionPageLink[]>(
+    () =>
+      documents.flatMap((doc) =>
+        doc.notionPageId
+          ? [
+              {
+                notionPageId: doc.notionPageId,
+                documentId: doc.id,
+                title: doc.title || "Untitled",
+                icon: doc.icon,
+              },
+            ]
+          : [],
+      ),
+    [documents],
+  );
+  const handleOpenNotionPageLink = useCallback(
+    (linkedDocumentId: string) => {
+      navigate(`/page/${linkedDocumentId}`, { flushSync: true });
+    },
+    [navigate],
+  );
 
   // An external write is authoritative (agent edit, Notion pull, or a peer's
   // edit mirrored to SQL) when the server `updatedAt` is newer than the last
@@ -624,6 +654,8 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
               editable={canEdit}
               onComment={canEdit ? handleComment : undefined}
               onJoinTitle={joinFirstBodyBlockToTitle}
+              notionPageLinks={notionPageLinks}
+              onOpenNotionPageLink={handleOpenNotionPageLink}
             />
           </div>
         </div>

--- a/templates/content/app/components/editor/VisualEditor.tsx
+++ b/templates/content/app/components/editor/VisualEditor.tsx
@@ -25,7 +25,7 @@ import { defaultMarkdownSerializer } from "prosemirror-markdown";
 import { Plugin, PluginKey, AllSelection, Selection } from "@tiptap/pm/state";
 import { Fragment, type Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { Decoration, DecorationSet, type EditorView } from "@tiptap/pm/view";
-import { useEffect, useRef, useMemo, useState } from "react";
+import { useCallback, useEffect, useRef, useMemo, useState } from "react";
 import { IconMusic, IconPhoto, IconVideo } from "@tabler/icons-react";
 import { BubbleToolbar } from "./BubbleToolbar";
 import { SlashCommandMenu } from "./SlashCommandMenu";
@@ -36,8 +36,9 @@ import { VideoNode } from "./extensions/VideoNode";
 import { AudioNode } from "./extensions/AudioNode";
 import {
   EMPTY_TOGGLE_BODY_PLACEHOLDER,
+  createNotionEditorExtensions,
   focusMostRecentEmptyToggleSummary,
-  notionEditorExtensions,
+  type NotionPageLink,
 } from "./extensions/NotionExtensions";
 import { notionFidelityExtensions } from "./extensions/NotionFidelity";
 import { DragHandle } from "./extensions/DragHandle";
@@ -723,7 +724,11 @@ interface VisualEditorProps {
   /** Called when user selects text and clicks "Comment" in bubble toolbar. */
   onComment?: (quotedText: string, offsetTop: number) => void;
   onJoinTitle?: (text: string) => void;
+  notionPageLinks?: NotionPageLink[];
+  onOpenNotionPageLink?: (documentId: string) => void;
 }
+
+export type { NotionPageLink };
 
 export function shouldSeedCollaborativeContent({
   content,
@@ -809,6 +814,8 @@ interface VisualEditorExtensionOptions {
   user?: { name: string; color: string; email?: string } | null;
   onImageComment?: (quotedText: string, offsetTop: number) => void;
   onJoinTitle?: (text: string) => void;
+  resolveNotionPageLink?: (notionPageId: string) => NotionPageLink | null;
+  onOpenNotionPageLink?: (documentId: string) => void;
 }
 
 function hasAncestorType(
@@ -1130,6 +1137,8 @@ export function createVisualEditorExtensions({
   user,
   onImageComment,
   onJoinTitle,
+  resolveNotionPageLink,
+  onOpenNotionPageLink,
 }: VisualEditorExtensionOptions = {}): Extensions {
   return [
     StarterKit.configure({
@@ -1186,7 +1195,10 @@ export function createVisualEditorExtensions({
     NotionTableHeader,
     TableCell,
     NormalizeTableHeaders,
-    ...notionEditorExtensions,
+    ...createNotionEditorExtensions({
+      resolvePageLink: resolveNotionPageLink,
+      onOpenPageLink: onOpenNotionPageLink,
+    }),
     ...notionFidelityExtensions,
     DragHandle,
     TypographyReplacements,
@@ -1224,11 +1236,24 @@ export function VisualEditor({
   editable = true,
   onComment,
   onJoinTitle,
+  notionPageLinks = [],
+  onOpenNotionPageLink,
 }: VisualEditorProps) {
   const [isDraggingMedia, setIsDraggingMedia] = useState(false);
   const isSettingContent = useRef(false);
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
+  const notionPageLinksRef = useRef(notionPageLinks);
+  notionPageLinksRef.current = notionPageLinks;
+  const resolveNotionPageLink = useCallback((notionPageId: string) => {
+    const normalized = notionPageId.replace(/-/g, "").toLowerCase();
+    return (
+      notionPageLinksRef.current.find(
+        (link) =>
+          link.notionPageId.replace(/-/g, "").toLowerCase() === normalized,
+      ) ?? null
+    );
+  }, []);
   const prevDocIdRef = useRef(documentId);
   // Track the last content the editor emitted via onChange, so we can
   // distinguish external SQL changes (agent/Notion/peer) from our own saves.
@@ -1317,6 +1342,8 @@ export function VisualEditor({
         user,
         onImageComment: onComment,
         onJoinTitle,
+        resolveNotionPageLink,
+        onOpenNotionPageLink,
       }),
     [
       documentId,
@@ -1327,6 +1354,8 @@ export function VisualEditor({
       user?.color,
       onComment,
       onJoinTitle,
+      resolveNotionPageLink,
+      onOpenNotionPageLink,
     ],
   );
 

--- a/templates/content/app/components/editor/extensions/NotionExtensions.tsx
+++ b/templates/content/app/components/editor/extensions/NotionExtensions.tsx
@@ -152,6 +152,18 @@ function getNotionPageId(attrs: Record<string, string>) {
   );
 }
 
+function safeExternalPageUrl(input: string | null): string | null {
+  if (!input) return null;
+  try {
+    const url = new URL(input);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.href
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export const TOGGLE_SUMMARY_PLACEHOLDER = "Toggle";
 export const EMPTY_TOGGLE_BODY_PLACEHOLDER =
   "Empty toggle. Click or drop blocks inside.";
@@ -437,7 +449,7 @@ function BlockAtomView({ node, extension }: NodeViewProps) {
     attrs.src ||
     humanizeTag(tagName);
   const canOpenLocalPage = Boolean(pageLink && options.onOpenPageLink);
-  const externalUrl = attrs.url || attrs.href || null;
+  const externalUrl = safeExternalPageUrl(attrs.url || attrs.href || null);
 
   if (tagName === "page") {
     const openPage = () => {

--- a/templates/content/app/components/editor/extensions/NotionExtensions.tsx
+++ b/templates/content/app/components/editor/extensions/NotionExtensions.tsx
@@ -7,7 +7,13 @@ import {
   mergeAttributes,
   type NodeViewProps,
 } from "@tiptap/react";
-import { IconChevronRight, IconChevronDown } from "@tabler/icons-react";
+import {
+  IconChevronRight,
+  IconChevronDown,
+  IconDatabase,
+  IconExternalLink,
+  IconFileText,
+} from "@tabler/icons-react";
 import {
   escapeHtml,
   indentMarkdown,
@@ -38,6 +44,18 @@ const INLINE_ATOM_TAGS = [
   "mention-template-mention",
   "mention-custom-emoji",
 ];
+
+export interface NotionPageLink {
+  notionPageId: string;
+  documentId: string;
+  title: string;
+  icon: string | null;
+}
+
+interface NotionBlockAtomOptions {
+  resolvePageLink?: (notionPageId: string) => NotionPageLink | null;
+  onOpenPageLink?: (documentId: string) => void;
+}
 
 function readElementAttributes(
   element: HTMLElement,
@@ -104,6 +122,34 @@ function serializeAtomTag(
 
 function humanizeTag(tagName: string): string {
   return tagName.replace(/[_-]/g, " ");
+}
+
+function normalizeNotionPageId(input: string | null | undefined) {
+  const trimmed = input?.trim();
+  if (!trimmed) return null;
+  if (/^[0-9a-fA-F]{32}$/.test(trimmed)) return trimmed.toLowerCase();
+  if (/^[0-9a-fA-F-]{36}$/.test(trimmed)) {
+    return trimmed.replace(/-/g, "").toLowerCase();
+  }
+  try {
+    const url = new URL(trimmed);
+    const slug = url.pathname.split("/").filter(Boolean).pop() || "";
+    const match =
+      slug.match(/([0-9a-fA-F]{32})$/) || slug.match(/([0-9a-fA-F-]{36})$/);
+    return match?.[1]?.replace(/-/g, "").toLowerCase() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function getNotionPageId(attrs: Record<string, string>) {
+  return (
+    normalizeNotionPageId(attrs.url) ??
+    normalizeNotionPageId(attrs.href) ??
+    normalizeNotionPageId(attrs.id) ??
+    normalizeNotionPageId(attrs.pageId) ??
+    normalizeNotionPageId(attrs.page_id)
+  );
 }
 
 export const TOGGLE_SUMMARY_PLACEHOLDER = "Toggle";
@@ -373,21 +419,80 @@ function ToggleView({ node, updateAttributes, editor, getPos }: NodeViewProps) {
   );
 }
 
-function BlockAtomView({ node }: NodeViewProps) {
+function BlockAtomView({ node, extension }: NodeViewProps) {
   const tagName = (node.attrs.tagName || "block") as string;
   const label = (node.attrs.label || "") as string;
   const attrs = parseAttrsJson(node.attrs.attrsJson as string);
+  const options = extension.options as NotionBlockAtomOptions;
+  const notionPageId = tagName === "page" ? getNotionPageId(attrs) : null;
+  const pageLink = notionPageId
+    ? options.resolvePageLink?.(notionPageId)
+    : null;
   const primary =
+    pageLink?.title ||
     label ||
     attrs.title ||
     attrs.alt ||
     attrs.url ||
     attrs.src ||
     humanizeTag(tagName);
+  const canOpenLocalPage = Boolean(pageLink && options.onOpenPageLink);
+  const externalUrl = attrs.url || attrs.href || null;
+
+  if (tagName === "page") {
+    const openPage = () => {
+      if (pageLink && options.onOpenPageLink) {
+        options.onOpenPageLink(pageLink.documentId);
+        return;
+      }
+      if (externalUrl) {
+        window.open(externalUrl, "_blank", "noopener,noreferrer");
+      }
+    };
+
+    return (
+      <NodeViewWrapper
+        className={`notion-page-reference ${
+          canOpenLocalPage || externalUrl
+            ? "notion-page-reference--clickable"
+            : ""
+        }`}
+      >
+        <button
+          type="button"
+          className="notion-page-reference__button"
+          contentEditable={false}
+          disabled={!canOpenLocalPage && !externalUrl}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            openPage();
+          }}
+        >
+          <span className="notion-page-reference__icon" aria-hidden="true">
+            {pageLink?.icon || <IconFileText size={20} stroke={1.8} />}
+          </span>
+          <span className="notion-page-reference__label">{primary}</span>
+          {!pageLink && externalUrl ? (
+            <IconExternalLink
+              className="notion-page-reference__external"
+              size={16}
+              stroke={1.8}
+            />
+          ) : null}
+        </button>
+      </NodeViewWrapper>
+    );
+  }
+
+  const AtomIcon = tagName === "database" ? IconDatabase : IconFileText;
 
   return (
     <NodeViewWrapper className="notion-atom notion-atom--block">
-      <div className="notion-atom__kind">{humanizeTag(tagName)}</div>
+      <div className="notion-atom__kind">
+        <AtomIcon size={14} stroke={1.8} />
+        {humanizeTag(tagName)}
+      </div>
       <div className="notion-atom__label">{primary}</div>
     </NodeViewWrapper>
   );
@@ -763,6 +868,13 @@ export const NotionBlockAtom = Node.create({
   selectable: true,
   draggable: true,
 
+  addOptions(): NotionBlockAtomOptions {
+    return {
+      resolvePageLink: undefined,
+      onOpenPageLink: undefined,
+    };
+  },
+
   addAttributes() {
     return {
       tagName: { default: "unknown" },
@@ -907,12 +1019,16 @@ export const NotionInlineAtom = Node.create({
   },
 });
 
-export const notionEditorExtensions = [
-  NotionSpanMark,
-  NotionToggle,
-  NotionCallout,
-  NotionColumns,
-  NotionColumn,
-  NotionBlockAtom,
-  NotionInlineAtom,
-];
+export function createNotionEditorExtensions(
+  blockAtomOptions: NotionBlockAtomOptions = {},
+) {
+  return [
+    NotionSpanMark,
+    NotionToggle,
+    NotionCallout,
+    NotionColumns,
+    NotionColumn,
+    NotionBlockAtom.configure(blockAtomOptions),
+    NotionInlineAtom,
+  ];
+}

--- a/templates/content/app/components/layout/Layout.tsx
+++ b/templates/content/app/components/layout/Layout.tsx
@@ -12,7 +12,7 @@ import { HeaderActionsProvider } from "./HeaderActions";
 
 const SIDEBAR_WIDTH_KEY = "sidebar-width";
 const DEFAULT_SIDEBAR_WIDTH = 240;
-const MIN_SIDEBAR_WIDTH = 180;
+const MIN_SIDEBAR_WIDTH = 240;
 const MAX_SIDEBAR_WIDTH = 480;
 
 // Routes whose page renders its own custom toolbar (with AgentToggleButton).

--- a/templates/content/app/components/sidebar/DocumentSidebar.layout.test.ts
+++ b/templates/content/app/components/sidebar/DocumentSidebar.layout.test.ts
@@ -7,10 +7,12 @@ function readSidebarSource(relativePath: string) {
 
 describe("document sidebar layout", () => {
   it("keeps deeply nested page rows reachable in the sidebar", () => {
+    const layout = readSidebarSource("../layout/Layout.tsx");
     const sidebar = readSidebarSource("./DocumentSidebar.tsx");
     const treeItem = readSidebarSource("./DocumentTreeItem.tsx");
     const scrollArea = readSidebarSource("../ui/scroll-area.tsx");
 
+    expect(layout).toContain("const MIN_SIDEBAR_WIDTH = 240");
     expect(sidebar).toContain('className="min-w-full w-max py-2 pr-2"');
     expect(treeItem).toContain("const indent = depth * 12 + 12");
     expect(treeItem).toContain("min-w-56");

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -177,6 +177,19 @@ export function DocumentSidebar({
   const expandedIds = new Set(
     documents.map((d) => d.id).filter((id) => !collapsedIds.current.has(id)),
   );
+
+  useEffect(() => {
+    if (!activeDocumentId) return;
+
+    let changed = false;
+    let parentId = parentByDocumentId.get(activeDocumentId) ?? null;
+    while (parentId) {
+      if (collapsedIds.current.delete(parentId)) changed = true;
+      parentId = parentByDocumentId.get(parentId) ?? null;
+    }
+
+    if (changed) forceUpdate((n) => n + 1);
+  }, [activeDocumentId, parentByDocumentId]);
 
   const handleToggleExpanded = useCallback((id: string) => {
     if (collapsedIds.current.has(id)) {

--- a/templates/content/app/components/sidebar/DocumentTreeItem.tsx
+++ b/templates/content/app/components/sidebar/DocumentTreeItem.tsx
@@ -116,12 +116,14 @@ export function DocumentTreeItem({
           width: rowWidth === undefined ? undefined : `${rowWidth}px`,
         }}
         onClick={() => onSelect(node.id)}
+        aria-expanded={hasChildren ? expanded : undefined}
       >
         <span className="relative flex-shrink-0 w-5 h-5">
           <span
             className={cn(
               "absolute inset-0 flex items-center justify-center text-center",
               hasChildren && "group-hover:opacity-0",
+              hasChildren && (expanded || isActive) && "opacity-0",
             )}
           >
             {node.icon || (
@@ -130,7 +132,16 @@ export function DocumentTreeItem({
           </span>
           {hasChildren && (
             <button
-              className="absolute inset-0 flex items-center justify-center rounded hover:bg-accent opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto"
+              type="button"
+              aria-label={
+                expanded
+                  ? `Collapse ${node.title || "Untitled"}`
+                  : `Expand ${node.title || "Untitled"}`
+              }
+              className={cn(
+                "absolute inset-0 flex items-center justify-center rounded hover:bg-accent opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto",
+                (expanded || isActive) && "opacity-100 pointer-events-auto",
+              )}
               onPointerDown={(e) => e.stopPropagation()}
               onClick={(e) => {
                 e.stopPropagation();

--- a/templates/content/app/global.css
+++ b/templates/content/app/global.css
@@ -1070,6 +1070,9 @@ div[data-notion-column] > :last-child {
 }
 
 .notion-atom__kind {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.68rem;
@@ -1080,6 +1083,72 @@ div[data-notion-column] > :last-child {
   font-size: 0.92rem;
   color: hsl(var(--foreground));
   word-break: break-word;
+}
+
+.notion-page-reference {
+  margin: 0.3rem 0;
+}
+
+.notion-page-reference__button {
+  display: inline-flex;
+  min-height: 2rem;
+  max-width: 100%;
+  align-items: center;
+  gap: 0.5rem;
+  border: 0;
+  border-radius: 0.375rem;
+  background: transparent;
+  padding: 0.18rem 0.3rem;
+  color: hsl(var(--foreground));
+  font: inherit;
+  font-weight: 600;
+  line-height: 1.35;
+  text-align: left;
+}
+
+.notion-page-reference--clickable .notion-page-reference__button {
+  cursor: pointer;
+}
+
+.notion-page-reference--clickable .notion-page-reference__button:hover,
+.notion-page-reference--clickable .notion-page-reference__button:focus-visible {
+  background: hsl(var(--accent) / 0.75);
+  outline: none;
+}
+
+.notion-page-reference__button:disabled {
+  cursor: default;
+}
+
+.notion-page-reference__icon {
+  display: inline-flex;
+  width: 1.35rem;
+  height: 1.35rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  color: hsl(var(--muted-foreground));
+  font-size: 1.05rem;
+  line-height: 1;
+}
+
+.notion-page-reference__label {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  text-decoration: underline;
+  text-decoration-color: hsl(var(--border));
+  text-underline-offset: 0.22em;
+}
+
+.notion-page-reference--clickable
+  .notion-page-reference__button:hover
+  .notion-page-reference__label {
+  text-decoration-color: currentColor;
+}
+
+.notion-page-reference__external {
+  flex: 0 0 auto;
+  color: hsl(var(--muted-foreground));
 }
 
 .notion-inline-atom {

--- a/templates/content/server/lib/notion-sync.ts
+++ b/templates/content/server/lib/notion-sync.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck — Drizzle ORM types from core vs local resolve to different instances
 // in pnpm's node_modules. Logic is correct; types just don't unify across instances.
 import crypto from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { InferSelectModel } from "drizzle-orm";
 import { getDb, schema } from "../db/index.js";
 import { canonicalizeNfm, nfmToDoc, type PMNode } from "../../shared/nfm.js";
@@ -85,6 +85,14 @@ function parseAttrsJson(value: unknown): Record<string, string> {
 type ChildPageReference = {
   pageId: string;
   title: string;
+};
+
+type RemotePageDocumentLookup = Map<string, string>;
+
+type LinkedChildRow = {
+  id: string;
+  position: number;
+  remotePageId: string | null;
 };
 
 function extractChildPageReferences(content: string): ChildPageReference[] {
@@ -239,10 +247,9 @@ async function upsertSyncLink(args: {
     });
 }
 
-async function findDocumentIdForRemotePage(
+async function loadRemotePageDocumentLookup(
   owner: string,
-  remotePageId: string,
-) {
+): Promise<RemotePageDocumentLookup> {
   const db = getDb();
   const links = await db
     .select({
@@ -252,11 +259,59 @@ async function findDocumentIdForRemotePage(
     .from(schema.documentSyncLinks)
     .where(eq(schema.documentSyncLinks.ownerEmail, owner));
 
-  return (
-    links.find(
-      (link) => normalizeNotionPageIdSafe(link.remotePageId) === remotePageId,
-    )?.documentId ?? null
+  const lookup: RemotePageDocumentLookup = new Map();
+  for (const link of links) {
+    const remotePageId = normalizeNotionPageIdSafe(link.remotePageId);
+    if (remotePageId) lookup.set(remotePageId, link.documentId);
+  }
+  return lookup;
+}
+
+async function listLinkedChildrenForParent(
+  owner: string,
+  parentId: string,
+): Promise<LinkedChildRow[]> {
+  const db = getDb();
+  const children = await db
+    .select({
+      id: schema.documents.id,
+      position: schema.documents.position,
+    })
+    .from(schema.documents)
+    .where(
+      and(
+        eq(schema.documents.ownerEmail, owner),
+        eq(schema.documents.parentId, parentId),
+      ),
+    );
+
+  if (children.length === 0) return [];
+
+  const links = await db
+    .select({
+      documentId: schema.documentSyncLinks.documentId,
+      remotePageId: schema.documentSyncLinks.remotePageId,
+    })
+    .from(schema.documentSyncLinks)
+    .where(
+      and(
+        eq(schema.documentSyncLinks.ownerEmail, owner),
+        inArray(
+          schema.documentSyncLinks.documentId,
+          children.map((child) => child.id),
+        ),
+      ),
+    );
+
+  const remotePageIdByDocumentId = new Map(
+    links.map((link) => [link.documentId, link.remotePageId]),
   );
+
+  return children.map((child) => ({
+    id: child.id,
+    position: child.position,
+    remotePageId: remotePageIdByDocumentId.get(child.id) ?? null,
+  }));
 }
 
 async function inheritShares(parentId: string, childId: string, now: string) {
@@ -297,30 +352,39 @@ async function createLinkedChildDocument(args: {
   const now = nowIso();
   const id = nanoid();
 
-  await db.insert(schema.documents).values({
-    id,
-    ownerEmail: args.parent.ownerEmail,
-    orgId: args.parent.orgId,
-    parentId: args.parent.id,
-    title: args.title || "Untitled",
-    content: "",
-    icon: null,
-    position: args.position,
-    isFavorite: 0,
-    hideFromSearch: args.parent.hideFromSearch,
-    visibility: args.parent.visibility,
-    createdAt: now,
-    updatedAt: now,
-  });
-  await inheritShares(args.parent.id, id, now);
-  await upsertSyncLink({
-    owner: args.owner,
-    documentId: id,
-    remotePageId: args.remotePageId,
-    state: "linked",
-    warnings: [],
-    hasConflict: false,
-  });
+  let inserted = false;
+  try {
+    await db.insert(schema.documents).values({
+      id,
+      ownerEmail: args.parent.ownerEmail,
+      orgId: args.parent.orgId,
+      parentId: args.parent.id,
+      title: args.title || "Untitled",
+      content: "",
+      icon: null,
+      position: args.position,
+      isFavorite: 0,
+      hideFromSearch: args.parent.hideFromSearch,
+      visibility: args.parent.visibility,
+      createdAt: now,
+      updatedAt: now,
+    });
+    inserted = true;
+    await inheritShares(args.parent.id, id, now);
+    await upsertSyncLink({
+      owner: args.owner,
+      documentId: id,
+      remotePageId: args.remotePageId,
+      state: "linked",
+      warnings: [],
+      hasConflict: false,
+    });
+  } catch (error) {
+    if (inserted) {
+      await deleteImportedPlaceholder(args.owner, id).catch(() => undefined);
+    }
+    throw error;
+  }
 
   return id;
 }
@@ -335,6 +399,9 @@ async function deleteImportedPlaceholder(owner: string, documentId: string) {
         eq(schema.documentSyncLinks.ownerEmail, owner),
       ),
     );
+  await db
+    .delete(schema.documentShares)
+    .where(eq(schema.documentShares.resourceId, documentId));
   await db
     .delete(schema.documents)
     .where(
@@ -352,19 +419,47 @@ async function syncChildPagesFromPulledContent(args: {
   force: boolean;
   depth: number;
   seenRemotePageIds: Set<string>;
+  remotePageDocumentIdByPageId: RemotePageDocumentLookup;
 }) {
   if (args.depth >= MAX_CHILD_PAGE_SYNC_DEPTH) return;
 
   const refs = extractChildPageReferences(args.content);
+  const currentRemotePageIds = new Set(refs.map((ref) => ref.pageId));
+  const db = getDb();
+  const existingChildren = await listLinkedChildrenForParent(
+    args.owner,
+    args.parent.id,
+  );
+
+  for (const child of existingChildren) {
+    const remotePageId = normalizeNotionPageIdSafe(child.remotePageId);
+    if (!remotePageId || currentRemotePageIds.has(remotePageId)) continue;
+    await db
+      .update(schema.documents)
+      .set({ parentId: null, updatedAt: nowIso() })
+      .where(
+        and(
+          eq(schema.documents.id, child.id),
+          eq(schema.documents.ownerEmail, args.owner),
+        ),
+      );
+  }
+
   if (refs.length === 0) return;
 
-  const db = getDb();
+  const manualSiblingMaxPosition = existingChildren.reduce((max, child) => {
+    const remotePageId = normalizeNotionPageIdSafe(child.remotePageId);
+    return remotePageId ? max : Math.max(max, child.position);
+  }, -1);
+  const basePosition = manualSiblingMaxPosition + 1;
+
   for (const [index, ref] of refs.entries()) {
     if (args.seenRemotePageIds.has(ref.pageId)) continue;
     args.seenRemotePageIds.add(ref.pageId);
 
-    let childId = await findDocumentIdForRemotePage(args.owner, ref.pageId);
+    let childId = args.remotePageDocumentIdByPageId.get(ref.pageId) ?? null;
     let createdPlaceholder = false;
+    const position = basePosition + index;
 
     if (!childId) {
       childId = await createLinkedChildDocument({
@@ -372,8 +467,9 @@ async function syncChildPagesFromPulledContent(args: {
         parent: args.parent,
         remotePageId: ref.pageId,
         title: ref.title,
-        position: index,
+        position,
       });
+      args.remotePageDocumentIdByPageId.set(ref.pageId, childId);
       createdPlaceholder = true;
     } else {
       const [child] = await db
@@ -392,8 +488,8 @@ async function syncChildPagesFromPulledContent(args: {
       if (child.parentId !== args.parent.id) {
         updates.parentId = args.parent.id;
       }
-      if (child.position !== index) {
-        updates.position = index;
+      if (child.position !== position) {
+        updates.position = position;
       }
       if (Object.keys(updates).length > 0) {
         await db
@@ -416,6 +512,7 @@ async function syncChildPagesFromPulledContent(args: {
     } catch (error) {
       if (createdPlaceholder) {
         await deleteImportedPlaceholder(args.owner, childId);
+        args.remotePageDocumentIdByPageId.delete(ref.pageId);
       } else {
         const link = await getSyncLink(childId, args.owner);
         if (link) {
@@ -543,6 +640,7 @@ export async function pullDocumentFromNotion(
   childSync: {
     depth?: number;
     seenRemotePageIds?: Set<string>;
+    remotePageDocumentIdByPageId?: RemotePageDocumentLookup;
   } = {},
 ): Promise<DocumentSyncStatus> {
   const db = getDb();
@@ -658,6 +756,9 @@ export async function pullDocumentFromNotion(
 
   const updatedLink = await getSyncLink(documentId, owner);
   const seenRemotePageIds = childSync.seenRemotePageIds ?? new Set<string>();
+  const remotePageDocumentIdByPageId =
+    childSync.remotePageDocumentIdByPageId ??
+    (await loadRemotePageDocumentLookup(owner));
   const currentRemotePageId = normalizeNotionPageIdSafe(link.remotePageId);
   if (currentRemotePageId) seenRemotePageIds.add(currentRemotePageId);
   await syncChildPagesFromPulledContent({
@@ -673,6 +774,7 @@ export async function pullDocumentFromNotion(
     force,
     depth: childSync.depth ?? 0,
     seenRemotePageIds,
+    remotePageDocumentIdByPageId,
   });
 
   return buildStatus({

--- a/templates/content/server/lib/notion-sync.ts
+++ b/templates/content/server/lib/notion-sync.ts
@@ -4,7 +4,7 @@ import crypto from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import type { InferSelectModel } from "drizzle-orm";
 import { getDb, schema } from "../db/index.js";
-import { canonicalizeNfm } from "../../shared/nfm.js";
+import { canonicalizeNfm, nfmToDoc, type PMNode } from "../../shared/nfm.js";
 import { deleteCollabState, releaseDoc } from "@agent-native/core/collab";
 import {
   createNotionPageWithMarkdown,
@@ -21,8 +21,17 @@ import type { DocumentSyncStatus } from "../../shared/api.js";
 type DocumentRow = InferSelectModel<typeof schema.documents>;
 type LinkRow = InferSelectModel<typeof schema.documentSyncLinks>;
 
+const MAX_CHILD_PAGE_SYNC_DEPTH = 5;
+
 function nowIso() {
   return new Date().toISOString();
+}
+
+function nanoid(size = 12): string {
+  const chars =
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  const bytes = crypto.randomBytes(size);
+  return Array.from(bytes, (byte) => chars[byte % chars.length]).join("");
 }
 
 /**
@@ -48,6 +57,68 @@ function parseWarnings(link: Pick<LinkRow, "warningsJson"> | null): string[] {
   } catch {
     return [];
   }
+}
+
+function normalizeNotionPageIdSafe(input: string | null | undefined) {
+  if (!input) return null;
+  try {
+    return normalizeNotionPageId(input);
+  } catch {
+    return null;
+  }
+}
+
+function parseAttrsJson(value: unknown): Record<string, string> {
+  if (typeof value !== "string" || !value) return {};
+  try {
+    const parsed = JSON.parse(value) as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.entries(parsed).filter((entry): entry is [string, string] => {
+        return typeof entry[0] === "string" && typeof entry[1] === "string";
+      }),
+    );
+  } catch {
+    return {};
+  }
+}
+
+type ChildPageReference = {
+  pageId: string;
+  title: string;
+};
+
+function extractChildPageReferences(content: string): ChildPageReference[] {
+  const doc = nfmToDoc(content);
+  const refs: ChildPageReference[] = [];
+  const seen = new Set<string>();
+
+  function visit(node: PMNode) {
+    if (node.type === "notionBlockAtom" && node.attrs?.tagName === "page") {
+      const attrs = parseAttrsJson(node.attrs.attrsJson);
+      const pageId =
+        normalizeNotionPageIdSafe(attrs.url) ??
+        normalizeNotionPageIdSafe(attrs.href) ??
+        normalizeNotionPageIdSafe(attrs.id) ??
+        normalizeNotionPageIdSafe(attrs.pageId) ??
+        normalizeNotionPageIdSafe(attrs.page_id);
+
+      if (pageId && !seen.has(pageId)) {
+        seen.add(pageId);
+        refs.push({
+          pageId,
+          title:
+            typeof node.attrs.label === "string" && node.attrs.label.trim()
+              ? node.attrs.label.trim()
+              : "Untitled",
+        });
+      }
+    }
+
+    for (const child of node.content ?? []) visit(child);
+  }
+
+  for (const child of doc.content) visit(child);
+  return refs;
 }
 
 function buildStatus(args: {
@@ -168,6 +239,209 @@ async function upsertSyncLink(args: {
     });
 }
 
+async function findDocumentIdForRemotePage(
+  owner: string,
+  remotePageId: string,
+) {
+  const db = getDb();
+  const links = await db
+    .select({
+      documentId: schema.documentSyncLinks.documentId,
+      remotePageId: schema.documentSyncLinks.remotePageId,
+    })
+    .from(schema.documentSyncLinks)
+    .where(eq(schema.documentSyncLinks.ownerEmail, owner));
+
+  return (
+    links.find(
+      (link) => normalizeNotionPageIdSafe(link.remotePageId) === remotePageId,
+    )?.documentId ?? null
+  );
+}
+
+async function inheritShares(parentId: string, childId: string, now: string) {
+  const db = getDb();
+  const shares = await db
+    .select({
+      principalType: schema.documentShares.principalType,
+      principalId: schema.documentShares.principalId,
+      role: schema.documentShares.role,
+      createdBy: schema.documentShares.createdBy,
+    })
+    .from(schema.documentShares)
+    .where(eq(schema.documentShares.resourceId, parentId));
+
+  if (shares.length === 0) return;
+
+  await db.insert(schema.documentShares).values(
+    shares.map((share) => ({
+      id: nanoid(),
+      resourceId: childId,
+      principalType: share.principalType,
+      principalId: share.principalId,
+      role: share.role,
+      createdBy: share.createdBy,
+      createdAt: now,
+    })),
+  );
+}
+
+async function createLinkedChildDocument(args: {
+  owner: string;
+  parent: DocumentRow;
+  remotePageId: string;
+  title: string;
+  position: number;
+}) {
+  const db = getDb();
+  const now = nowIso();
+  const id = nanoid();
+
+  await db.insert(schema.documents).values({
+    id,
+    ownerEmail: args.parent.ownerEmail,
+    orgId: args.parent.orgId,
+    parentId: args.parent.id,
+    title: args.title || "Untitled",
+    content: "",
+    icon: null,
+    position: args.position,
+    isFavorite: 0,
+    hideFromSearch: args.parent.hideFromSearch,
+    visibility: args.parent.visibility,
+    createdAt: now,
+    updatedAt: now,
+  });
+  await inheritShares(args.parent.id, id, now);
+  await upsertSyncLink({
+    owner: args.owner,
+    documentId: id,
+    remotePageId: args.remotePageId,
+    state: "linked",
+    warnings: [],
+    hasConflict: false,
+  });
+
+  return id;
+}
+
+async function deleteImportedPlaceholder(owner: string, documentId: string) {
+  const db = getDb();
+  await db
+    .delete(schema.documentSyncLinks)
+    .where(
+      and(
+        eq(schema.documentSyncLinks.documentId, documentId),
+        eq(schema.documentSyncLinks.ownerEmail, owner),
+      ),
+    );
+  await db
+    .delete(schema.documents)
+    .where(
+      and(
+        eq(schema.documents.id, documentId),
+        eq(schema.documents.ownerEmail, owner),
+      ),
+    );
+}
+
+async function syncChildPagesFromPulledContent(args: {
+  owner: string;
+  parent: DocumentRow;
+  content: string;
+  force: boolean;
+  depth: number;
+  seenRemotePageIds: Set<string>;
+}) {
+  if (args.depth >= MAX_CHILD_PAGE_SYNC_DEPTH) return;
+
+  const refs = extractChildPageReferences(args.content);
+  if (refs.length === 0) return;
+
+  const db = getDb();
+  for (const [index, ref] of refs.entries()) {
+    if (args.seenRemotePageIds.has(ref.pageId)) continue;
+    args.seenRemotePageIds.add(ref.pageId);
+
+    let childId = await findDocumentIdForRemotePage(args.owner, ref.pageId);
+    let createdPlaceholder = false;
+
+    if (!childId) {
+      childId = await createLinkedChildDocument({
+        owner: args.owner,
+        parent: args.parent,
+        remotePageId: ref.pageId,
+        title: ref.title,
+        position: index,
+      });
+      createdPlaceholder = true;
+    } else {
+      const [child] = await db
+        .select()
+        .from(schema.documents)
+        .where(
+          and(
+            eq(schema.documents.id, childId),
+            eq(schema.documents.ownerEmail, args.owner),
+          ),
+        );
+
+      if (!child) continue;
+
+      const updates: Partial<DocumentRow> = {};
+      if (child.parentId !== args.parent.id) {
+        updates.parentId = args.parent.id;
+      }
+      if (child.position !== index) {
+        updates.position = index;
+      }
+      if (Object.keys(updates).length > 0) {
+        await db
+          .update(schema.documents)
+          .set(updates)
+          .where(
+            and(
+              eq(schema.documents.id, childId),
+              eq(schema.documents.ownerEmail, args.owner),
+            ),
+          );
+      }
+    }
+
+    try {
+      await pullDocumentFromNotion(args.owner, childId, args.force, {
+        depth: args.depth + 1,
+        seenRemotePageIds: args.seenRemotePageIds,
+      });
+    } catch (error) {
+      if (createdPlaceholder) {
+        await deleteImportedPlaceholder(args.owner, childId);
+      } else {
+        const link = await getSyncLink(childId, args.owner);
+        if (link) {
+          await upsertSyncLink({
+            owner: args.owner,
+            documentId: childId,
+            remotePageId: link.remotePageId,
+            state: "error",
+            lastSyncedAt: link.lastSyncedAt,
+            lastPulledRemoteUpdatedAt: link.lastPulledRemoteUpdatedAt,
+            lastPushedLocalUpdatedAt: link.lastPushedLocalUpdatedAt,
+            lastKnownRemoteUpdatedAt: link.lastKnownRemoteUpdatedAt,
+            lastSyncedContentHash: link.lastSyncedContentHash,
+            lastError:
+              error instanceof Error
+                ? error.message
+                : "Failed to sync Notion child page",
+            warnings: parseWarnings(link),
+            hasConflict: Boolean(link.hasConflict),
+          });
+        }
+      }
+    }
+  }
+}
+
 export async function unlinkDocumentFromNotion(
   owner: string,
   documentId: string,
@@ -266,6 +540,10 @@ export async function pullDocumentFromNotion(
   owner: string,
   documentId: string,
   force = false,
+  childSync: {
+    depth?: number;
+    seenRemotePageIds?: Set<string>;
+  } = {},
 ): Promise<DocumentSyncStatus> {
   const db = getDb();
   const document = await getDocument(documentId, owner);
@@ -379,6 +657,24 @@ export async function pullDocumentFromNotion(
   });
 
   const updatedLink = await getSyncLink(documentId, owner);
+  const seenRemotePageIds = childSync.seenRemotePageIds ?? new Set<string>();
+  const currentRemotePageId = normalizeNotionPageIdSafe(link.remotePageId);
+  if (currentRemotePageId) seenRemotePageIds.add(currentRemotePageId);
+  await syncChildPagesFromPulledContent({
+    owner,
+    parent: {
+      ...document,
+      title: newTitle,
+      content: newContent,
+      icon: newIcon,
+      updatedAt,
+    },
+    content: newContent,
+    force,
+    depth: childSync.depth ?? 0,
+    seenRemotePageIds,
+  });
+
   return buildStatus({
     connected: true,
     documentId,

--- a/templates/content/shared/api.ts
+++ b/templates/content/shared/api.ts
@@ -9,6 +9,8 @@ export interface Document {
   position: number;
   isFavorite: boolean;
   hideFromSearch: boolean;
+  notionPageId?: string | null;
+  notionPageUrl?: string | null;
   visibility?: "private" | "org" | "public";
   accessRole?: DocumentAccessRole;
   canEdit?: boolean;


### PR DESCRIPTION
## Summary
- Keep Builder connect popups alive when click-time status refresh fails by falling back to signed URLs already rendered in the UI.
- Make desktop downloads more resilient with client-side manifest caching, stale server cache behavior, and GitHub installer fallback.
- Materialize pulled Notion child pages as local documents with sync links, inherited shares, sidebar expansion, and clickable local/external page references.
- Add a patch changeset for @agent-native/core.

## Tests
- pnpm --filter @agent-native/core test -- useBuilderStatus.spec.tsx
- pnpm --filter @agent-native/docs test -- desktop-latest.spec.ts
- pnpm --filter ./templates/content test -- notion-sync.spec.ts notion.spec.ts notion-markdown.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/docs typecheck
- pnpm --filter ./templates/content typecheck