### PR TITLE
Bundle ffmpeg-static and add Clips toolbar actions

### DIFF
--- a/.changeset/clips-ffmpeg-static-bundle.md
+++ b/.changeset/clips-ffmpeg-static-bundle.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Copy ffmpeg-static into serverless bundles so Clips media transcription fallback can extract audio in production.

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   addImmutableAssetRouteRulesForClientBuild,
+  findInstalledFfmpegStaticPackage,
   generateProvidedPluginsNitroPluginSource,
   generateWorkerEntry,
   getNodeBuiltinNames,
@@ -560,6 +561,53 @@ describe("generateProvidedPluginsNitroPluginSource", () => {
 describe("Cloudflare deploy builtins", () => {
   it("externalizes node:sqlite references from optional runtime probes", () => {
     expect(getNodeBuiltinNames()).toContain("sqlite");
+  });
+});
+
+describe("findInstalledFfmpegStaticPackage", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of dirs.splice(0)) {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  function setupNodeModules() {
+    const cwd = fs.mkdtempSync(path.join(process.cwd(), ".tmp-ffmpeg-test-"));
+    dirs.push(cwd);
+    const nodeModules = path.join(cwd, "node_modules");
+    fs.mkdirSync(nodeModules, { recursive: true });
+    return nodeModules;
+  }
+
+  it("finds a direct ffmpeg-static install only when the binary exists", () => {
+    const nodeModules = setupNodeModules();
+    const packageDir = path.join(nodeModules, "ffmpeg-static");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(path.join(packageDir, "package.json"), "{}");
+
+    expect(findInstalledFfmpegStaticPackage([nodeModules])).toBeNull();
+
+    fs.writeFileSync(path.join(packageDir, "ffmpeg"), "binary");
+
+    expect(findInstalledFfmpegStaticPackage([nodeModules])).toBe(packageDir);
+  });
+
+  it("finds ffmpeg-static in pnpm's nested store layout", () => {
+    const nodeModules = setupNodeModules();
+    const packageDir = path.join(
+      nodeModules,
+      ".pnpm",
+      "ffmpeg-static@5.3.0",
+      "node_modules",
+      "ffmpeg-static",
+    );
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(path.join(packageDir, "package.json"), "{}");
+    fs.writeFileSync(path.join(packageDir, "ffmpeg"), "binary");
+
+    expect(findInstalledFfmpegStaticPackage([nodeModules])).toBe(packageDir);
   });
 });
 

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -658,7 +658,7 @@ describe("findInstalledFfmpegStaticPackage", () => {
 
   it("only bundles host ffmpeg-static binaries for matching Linux serverless targets", () => {
     expect(shouldBundleFfmpegStaticForServerless("linux", "x64")).toBe(true);
-    expect(shouldBundleFfmpegStaticForServerless("linux", "arm64")).toBe(false);
+    expect(shouldBundleFfmpegStaticForServerless("linux", "arm64")).toBe(true);
     expect(shouldBundleFfmpegStaticForServerless("darwin", "x64")).toBe(false);
     expect(shouldBundleFfmpegStaticForServerless("win32", "x64")).toBe(false);
   });

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -4,11 +4,13 @@ import { pathToFileURL } from "url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   addImmutableAssetRouteRulesForClientBuild,
+  copyDir,
   findInstalledFfmpegStaticPackage,
   generateProvidedPluginsNitroPluginSource,
   generateWorkerEntry,
   getNodeBuiltinNames,
   runNitroBuildPipeline,
+  shouldBundleFfmpegStaticForServerless,
 } from "./build.js";
 import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
 import { IMMUTABLE_ASSET_CACHE_CONTROL } from "./immutable-assets.js";
@@ -564,6 +566,38 @@ describe("Cloudflare deploy builtins", () => {
   });
 });
 
+describe("copyDir", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of dirs.splice(0)) {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  it("copies directory symlink targets instead of treating symlinks as files", () => {
+    const cwd = fs.mkdtempSync(path.join(process.cwd(), ".tmp-copy-dir-test-"));
+    dirs.push(cwd);
+    const src = path.join(cwd, "src");
+    const dest = path.join(cwd, "dest");
+    const linkedTarget = path.join(cwd, "linked-target");
+    fs.mkdirSync(src, { recursive: true });
+    fs.mkdirSync(linkedTarget, { recursive: true });
+    fs.writeFileSync(path.join(linkedTarget, "asset.txt"), "asset");
+    fs.symlinkSync(
+      linkedTarget,
+      path.join(src, "linked-dir"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    copyDir(src, dest);
+
+    expect(
+      fs.readFileSync(path.join(dest, "linked-dir", "asset.txt"), "utf8"),
+    ).toBe("asset");
+  });
+});
+
 describe("findInstalledFfmpegStaticPackage", () => {
   const dirs: string[] = [];
 
@@ -608,6 +642,12 @@ describe("findInstalledFfmpegStaticPackage", () => {
     fs.writeFileSync(path.join(packageDir, "ffmpeg"), "binary");
 
     expect(findInstalledFfmpegStaticPackage([nodeModules])).toBe(packageDir);
+  });
+
+  it("only bundles host ffmpeg-static binaries for matching Linux serverless targets", () => {
+    expect(shouldBundleFfmpegStaticForServerless("linux")).toBe(true);
+    expect(shouldBundleFfmpegStaticForServerless("darwin")).toBe(false);
+    expect(shouldBundleFfmpegStaticForServerless("win32")).toBe(false);
   });
 });
 

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -657,10 +657,24 @@ describe("findInstalledFfmpegStaticPackage", () => {
   });
 
   it("only bundles host ffmpeg-static binaries for matching Linux serverless targets", () => {
-    expect(shouldBundleFfmpegStaticForServerless("linux", "x64")).toBe(true);
-    expect(shouldBundleFfmpegStaticForServerless("linux", "arm64")).toBe(true);
-    expect(shouldBundleFfmpegStaticForServerless("darwin", "x64")).toBe(false);
-    expect(shouldBundleFfmpegStaticForServerless("win32", "x64")).toBe(false);
+    expect(shouldBundleFfmpegStaticForServerless("linux", "x64", "x64")).toBe(
+      true,
+    );
+    expect(
+      shouldBundleFfmpegStaticForServerless("linux", "arm64", "arm64"),
+    ).toBe(true);
+    expect(shouldBundleFfmpegStaticForServerless("linux", "x64", "arm64")).toBe(
+      false,
+    );
+    expect(shouldBundleFfmpegStaticForServerless("linux", "x64", null)).toBe(
+      false,
+    );
+    expect(shouldBundleFfmpegStaticForServerless("darwin", "x64", "x64")).toBe(
+      false,
+    );
+    expect(shouldBundleFfmpegStaticForServerless("win32", "x64", "x64")).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -596,6 +596,18 @@ describe("copyDir", () => {
       fs.readFileSync(path.join(dest, "linked-dir", "asset.txt"), "utf8"),
     ).toBe("asset");
   });
+
+  it("skips broken symlinks instead of crashing the copy", () => {
+    const cwd = fs.mkdtempSync(path.join(process.cwd(), ".tmp-copy-dir-test-"));
+    dirs.push(cwd);
+    const src = path.join(cwd, "src");
+    const dest = path.join(cwd, "dest");
+    fs.mkdirSync(src, { recursive: true });
+    fs.symlinkSync(path.join(cwd, "missing-target"), path.join(src, "broken"));
+
+    expect(() => copyDir(src, dest)).not.toThrow();
+    expect(fs.existsSync(path.join(dest, "broken"))).toBe(false);
+  });
 });
 
 describe("findInstalledFfmpegStaticPackage", () => {
@@ -645,9 +657,10 @@ describe("findInstalledFfmpegStaticPackage", () => {
   });
 
   it("only bundles host ffmpeg-static binaries for matching Linux serverless targets", () => {
-    expect(shouldBundleFfmpegStaticForServerless("linux")).toBe(true);
-    expect(shouldBundleFfmpegStaticForServerless("darwin")).toBe(false);
-    expect(shouldBundleFfmpegStaticForServerless("win32")).toBe(false);
+    expect(shouldBundleFfmpegStaticForServerless("linux", "x64")).toBe(true);
+    expect(shouldBundleFfmpegStaticForServerless("linux", "arm64")).toBe(false);
+    expect(shouldBundleFfmpegStaticForServerless("darwin", "x64")).toBe(false);
+    expect(shouldBundleFfmpegStaticForServerless("win32", "x64")).toBe(false);
   });
 });
 

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1197,6 +1197,9 @@ const LIBSQL_NATIVE_PACKAGE_NAMES = [
   "linux-x64-musl",
   "win32-x64-msvc",
 ];
+const FFMPEG_STATIC_PACKAGE_NAME = "ffmpeg-static";
+const FFMPEG_STATIC_BINARY_NAMES =
+  process.platform === "win32" ? ["ffmpeg.exe", "ffmpeg"] : ["ffmpeg"];
 
 function nodeModulesAncestors(startDir: string): string[] {
   const dirs: string[] = [];
@@ -1237,6 +1240,68 @@ function findInstalledLibsqlNativePackage(
   return null;
 }
 
+function hasFfmpegStaticBinary(packageDir: string): boolean {
+  return FFMPEG_STATIC_BINARY_NAMES.some((binaryName) =>
+    fs.existsSync(path.join(packageDir, binaryName)),
+  );
+}
+
+function hasInstalledFfmpegStaticPackage(nodeModulesRoots: string[]): boolean {
+  for (const root of nodeModulesRoots) {
+    const direct = path.join(root, FFMPEG_STATIC_PACKAGE_NAME);
+    if (fs.existsSync(path.join(direct, "package.json"))) return true;
+
+    const pnpmRoot = path.join(root, ".pnpm");
+    if (!fs.existsSync(pnpmRoot)) continue;
+    const pnpmPrefix = `${FFMPEG_STATIC_PACKAGE_NAME}@`;
+    for (const entry of fs.readdirSync(pnpmRoot)) {
+      if (!entry.startsWith(pnpmPrefix)) continue;
+      const nested = path.join(
+        pnpmRoot,
+        entry,
+        "node_modules",
+        FFMPEG_STATIC_PACKAGE_NAME,
+      );
+      if (fs.existsSync(path.join(nested, "package.json"))) return true;
+    }
+  }
+  return false;
+}
+
+export function findInstalledFfmpegStaticPackage(
+  nodeModulesRoots: string[],
+): string | null {
+  for (const root of nodeModulesRoots) {
+    const direct = path.join(root, FFMPEG_STATIC_PACKAGE_NAME);
+    if (
+      fs.existsSync(path.join(direct, "package.json")) &&
+      hasFfmpegStaticBinary(direct)
+    ) {
+      return direct;
+    }
+
+    const pnpmRoot = path.join(root, ".pnpm");
+    if (!fs.existsSync(pnpmRoot)) continue;
+    const pnpmPrefix = `${FFMPEG_STATIC_PACKAGE_NAME}@`;
+    for (const entry of fs.readdirSync(pnpmRoot)) {
+      if (!entry.startsWith(pnpmPrefix)) continue;
+      const nested = path.join(
+        pnpmRoot,
+        entry,
+        "node_modules",
+        FFMPEG_STATIC_PACKAGE_NAME,
+      );
+      if (
+        fs.existsSync(path.join(nested, "package.json")) &&
+        hasFfmpegStaticBinary(nested)
+      ) {
+        return nested;
+      }
+    }
+  }
+  return null;
+}
+
 function copyInstalledLibsqlNativePackages(serverDir: string | undefined) {
   if (!serverDir || !fs.existsSync(serverDir)) return;
   const nodeModulesRoots = nodeModulesAncestors(cwd);
@@ -1256,6 +1321,29 @@ function copyInstalledLibsqlNativePackages(serverDir: string | undefined) {
       `[deploy] Copied ${copied} installed libsql native package(s) into the server bundle.`,
     );
   }
+}
+
+function copyInstalledFfmpegStaticPackage(serverDir: string | undefined) {
+  if (!serverDir || !fs.existsSync(serverDir)) return;
+  const nodeModulesRoots = nodeModulesAncestors(cwd);
+  const src = findInstalledFfmpegStaticPackage(nodeModulesRoots);
+  if (!src) {
+    if (hasInstalledFfmpegStaticPackage(nodeModulesRoots)) {
+      console.warn(
+        "[deploy] ffmpeg-static is installed without a downloaded ffmpeg binary; " +
+          "server-side media transcription fallback will require FFMPEG_PATH or a system ffmpeg.",
+      );
+    }
+    return;
+  }
+
+  copyDir(
+    src,
+    path.join(serverDir, "node_modules", FFMPEG_STATIC_PACKAGE_NAME),
+  );
+  console.log(
+    "[deploy] Copied ffmpeg-static into the server bundle for media transcription fallback.",
+  );
 }
 
 /**
@@ -1575,6 +1663,7 @@ export default bundle;
 
   if (preset === "netlify" || preset === "vercel" || preset === "aws-lambda") {
     copyInstalledLibsqlNativePackages(nitro.options.output.serverDir);
+    copyInstalledFfmpegStaticPackage(nitro.options.output.serverDir);
   }
 
   // Resolve remaining bare npm imports by bundling them into _libs/.

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1187,13 +1187,26 @@ export function copyDir(
   for (const entry of entries) {
     const srcPath = path.join(src, entry.name);
     const destPath = path.join(dest, entry.name);
-    if (entry.isDirectory() || entry.isSymbolicLink()) {
-      const stat = fs.statSync(srcPath);
+    if (entry.isSymbolicLink()) {
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(srcPath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          console.warn(
+            `[deploy] Skipping broken symlink while copying ${srcPath}`,
+          );
+          continue;
+        }
+        throw error;
+      }
       if (stat.isDirectory()) {
         copyDir(srcPath, destPath, nextAncestorRealPaths);
       } else {
         fs.copyFileSync(srcPath, destPath);
       }
+    } else if (entry.isDirectory()) {
+      copyDir(srcPath, destPath, nextAncestorRealPaths);
     } else {
       fs.copyFileSync(srcPath, destPath);
     }
@@ -1215,11 +1228,16 @@ const FFMPEG_STATIC_PACKAGE_NAME = "ffmpeg-static";
 const FFMPEG_STATIC_BINARY_NAMES =
   process.platform === "win32" ? ["ffmpeg.exe", "ffmpeg"] : ["ffmpeg"];
 const SERVERLESS_FFMPEG_STATIC_PLATFORM = "linux";
+const SERVERLESS_FFMPEG_STATIC_ARCH = "x64";
 
 export function shouldBundleFfmpegStaticForServerless(
   hostPlatform: NodeJS.Platform = process.platform,
+  hostArch: NodeJS.Architecture = process.arch,
 ): boolean {
-  return hostPlatform === SERVERLESS_FFMPEG_STATIC_PLATFORM;
+  return (
+    hostPlatform === SERVERLESS_FFMPEG_STATIC_PLATFORM &&
+    hostArch === SERVERLESS_FFMPEG_STATIC_ARCH
+  );
 }
 
 function nodeModulesAncestors(startDir: string): string[] {
@@ -1350,7 +1368,7 @@ function copyInstalledFfmpegStaticPackage(serverDir: string | undefined) {
   if (!shouldBundleFfmpegStaticForServerless()) {
     if (hasInstalledFfmpegStaticPackage(nodeModulesRoots)) {
       console.warn(
-        `[deploy] ffmpeg-static installs a ${process.platform} binary, but serverless bundles run on ${SERVERLESS_FFMPEG_STATIC_PLATFORM}; ` +
+        `[deploy] ffmpeg-static installs a ${process.platform}-${process.arch} binary, but serverless bundles target ${SERVERLESS_FFMPEG_STATIC_PLATFORM}-${SERVERLESS_FFMPEG_STATIC_ARCH}; ` +
           "server-side media transcription fallback will require FFMPEG_PATH or a system ffmpeg.",
       );
     }

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1172,14 +1172,28 @@ function getDirSize(dir: string): number {
   return size;
 }
 
-function copyDir(src: string, dest: string) {
+export function copyDir(
+  src: string,
+  dest: string,
+  ancestorRealPaths = new Set<string>(),
+) {
+  const realSrc = fs.realpathSync(src);
+  if (ancestorRealPaths.has(realSrc)) return;
+  const nextAncestorRealPaths = new Set(ancestorRealPaths);
+  nextAncestorRealPaths.add(realSrc);
+
   fs.mkdirSync(dest, { recursive: true });
   const entries = fs.readdirSync(src, { withFileTypes: true });
   for (const entry of entries) {
     const srcPath = path.join(src, entry.name);
     const destPath = path.join(dest, entry.name);
-    if (entry.isDirectory()) {
-      copyDir(srcPath, destPath);
+    if (entry.isDirectory() || entry.isSymbolicLink()) {
+      const stat = fs.statSync(srcPath);
+      if (stat.isDirectory()) {
+        copyDir(srcPath, destPath, nextAncestorRealPaths);
+      } else {
+        fs.copyFileSync(srcPath, destPath);
+      }
     } else {
       fs.copyFileSync(srcPath, destPath);
     }
@@ -1200,6 +1214,13 @@ const LIBSQL_NATIVE_PACKAGE_NAMES = [
 const FFMPEG_STATIC_PACKAGE_NAME = "ffmpeg-static";
 const FFMPEG_STATIC_BINARY_NAMES =
   process.platform === "win32" ? ["ffmpeg.exe", "ffmpeg"] : ["ffmpeg"];
+const SERVERLESS_FFMPEG_STATIC_PLATFORM = "linux";
+
+export function shouldBundleFfmpegStaticForServerless(
+  hostPlatform: NodeJS.Platform = process.platform,
+): boolean {
+  return hostPlatform === SERVERLESS_FFMPEG_STATIC_PLATFORM;
+}
 
 function nodeModulesAncestors(startDir: string): string[] {
   const dirs: string[] = [];
@@ -1326,6 +1347,16 @@ function copyInstalledLibsqlNativePackages(serverDir: string | undefined) {
 function copyInstalledFfmpegStaticPackage(serverDir: string | undefined) {
   if (!serverDir || !fs.existsSync(serverDir)) return;
   const nodeModulesRoots = nodeModulesAncestors(cwd);
+  if (!shouldBundleFfmpegStaticForServerless()) {
+    if (hasInstalledFfmpegStaticPackage(nodeModulesRoots)) {
+      console.warn(
+        `[deploy] ffmpeg-static installs a ${process.platform} binary, but serverless bundles run on ${SERVERLESS_FFMPEG_STATIC_PLATFORM}; ` +
+          "server-side media transcription fallback will require FFMPEG_PATH or a system ffmpeg.",
+      );
+    }
+    return;
+  }
+
   const src = findInstalledFfmpegStaticPackage(nodeModulesRoots);
   if (!src) {
     if (hasInstalledFfmpegStaticPackage(nodeModulesRoots)) {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1232,14 +1232,24 @@ const SERVERLESS_FFMPEG_STATIC_ARCHES = new Set<NodeJS.Architecture>([
   "arm64",
   "x64",
 ]);
+type ServerlessFfmpegStaticArch = "arm64" | "x64";
+
+function serverlessFfmpegStaticTargetArchFromEnv(): ServerlessFfmpegStaticArch | null {
+  const value = process.env.AGENT_NATIVE_SERVERLESS_FFMPEG_ARCH;
+  if (value === "arm64" || value === "x64") return value;
+  return null;
+}
 
 export function shouldBundleFfmpegStaticForServerless(
   hostPlatform: NodeJS.Platform = process.platform,
   hostArch: NodeJS.Architecture = process.arch,
+  targetArch: ServerlessFfmpegStaticArch | null = serverlessFfmpegStaticTargetArchFromEnv(),
 ): boolean {
   return (
     hostPlatform === SERVERLESS_FFMPEG_STATIC_PLATFORM &&
-    SERVERLESS_FFMPEG_STATIC_ARCHES.has(hostArch)
+    targetArch !== null &&
+    hostArch === targetArch &&
+    SERVERLESS_FFMPEG_STATIC_ARCHES.has(targetArch)
   );
 }
 
@@ -1371,8 +1381,8 @@ function copyInstalledFfmpegStaticPackage(serverDir: string | undefined) {
   if (!shouldBundleFfmpegStaticForServerless()) {
     if (hasInstalledFfmpegStaticPackage(nodeModulesRoots)) {
       console.warn(
-        `[deploy] ffmpeg-static installs a ${process.platform}-${process.arch} binary, but serverless bundles target ${SERVERLESS_FFMPEG_STATIC_PLATFORM} on ${[...SERVERLESS_FFMPEG_STATIC_ARCHES].join("/")} architectures; ` +
-          "server-side media transcription fallback will require FFMPEG_PATH or a system ffmpeg.",
+        `[deploy] ffmpeg-static installs a ${process.platform}-${process.arch} binary, but the serverless runtime architecture is not known to match it; ` +
+          "set AGENT_NATIVE_SERVERLESS_FFMPEG_ARCH=x64 or arm64 to bundle a matching binary, otherwise server-side media transcription fallback will require FFMPEG_PATH or a system ffmpeg.",
       );
     }
     return;

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1228,7 +1228,10 @@ const FFMPEG_STATIC_PACKAGE_NAME = "ffmpeg-static";
 const FFMPEG_STATIC_BINARY_NAMES =
   process.platform === "win32" ? ["ffmpeg.exe", "ffmpeg"] : ["ffmpeg"];
 const SERVERLESS_FFMPEG_STATIC_PLATFORM = "linux";
-const SERVERLESS_FFMPEG_STATIC_ARCH = "x64";
+const SERVERLESS_FFMPEG_STATIC_ARCHES = new Set<NodeJS.Architecture>([
+  "arm64",
+  "x64",
+]);
 
 export function shouldBundleFfmpegStaticForServerless(
   hostPlatform: NodeJS.Platform = process.platform,
@@ -1236,7 +1239,7 @@ export function shouldBundleFfmpegStaticForServerless(
 ): boolean {
   return (
     hostPlatform === SERVERLESS_FFMPEG_STATIC_PLATFORM &&
-    hostArch === SERVERLESS_FFMPEG_STATIC_ARCH
+    SERVERLESS_FFMPEG_STATIC_ARCHES.has(hostArch)
   );
 }
 
@@ -1368,7 +1371,7 @@ function copyInstalledFfmpegStaticPackage(serverDir: string | undefined) {
   if (!shouldBundleFfmpegStaticForServerless()) {
     if (hasInstalledFfmpegStaticPackage(nodeModulesRoots)) {
       console.warn(
-        `[deploy] ffmpeg-static installs a ${process.platform}-${process.arch} binary, but serverless bundles target ${SERVERLESS_FFMPEG_STATIC_PLATFORM}-${SERVERLESS_FFMPEG_STATIC_ARCH}; ` +
+        `[deploy] ffmpeg-static installs a ${process.platform}-${process.arch} binary, but serverless bundles target ${SERVERLESS_FFMPEG_STATIC_PLATFORM} on ${[...SERVERLESS_FFMPEG_STATIC_ARCHES].join("/")} architectures; ` +
           "server-side media transcription fallback will require FFMPEG_PATH or a system ffmpeg.",
       );
     }

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -657,13 +657,6 @@ export default function RecordingPage() {
             </DropdownMenu>
           ) : null}
 
-          {canDelete ? (
-            <DeleteRecordingMenu
-              recordingId={recording.id}
-              onDeleted={() => navigate("/library", { replace: true })}
-            />
-          ) : null}
-
           <ShareRecordingPopover
             recordingId={recording.id}
             recordingTitle={recording.title}
@@ -678,6 +671,13 @@ export default function RecordingPage() {
               Share
             </Button>
           </ShareRecordingPopover>
+
+          {canDelete ? (
+            <DeleteRecordingMenu
+              recordingId={recording.id}
+              onDeleted={() => navigate("/library", { replace: true })}
+            />
+          ) : null}
         </header>
 
         <div

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -431,12 +431,14 @@ pub async fn show_toolbar(app: AppHandle) -> Result<(), String> {
     // window in physical px. Keep the visible toolbar large enough for the
     // fixed 30px circular controls on high-DPI displays.
     let content_w: u32 = (72.0 * scale).round() as u32;
-    let expanded_content_h: u32 = (234.0 * scale).round() as u32;
+    let collapsed_content_h: u32 = (150.0 * scale).round() as u32;
     let w: u32 = content_w + gutter * 2;
-    let h: u32 = expanded_content_h + gutter * 2;
-    // Flush-left with a small margin; vertically centered on the screen.
+    let h: u32 = collapsed_content_h + gutter * 2;
+    // Flush-left with a small margin; vertically center the collapsed pill.
+    // The React toolbar temporarily resizes this window while hover/focus
+    // reveals extra controls so transparent pixels don't block clicks.
     let x: i32 = mx + 48 - gutter as i32;
-    let y: i32 = my + (mh as i32 - expanded_content_h as i32) / 2 - gutter as i32;
+    let y: i32 = my + (mh as i32 - collapsed_content_h as i32) / 2 - gutter as i32;
     dlog!("[clips-tray] toolbar pos=({},{}) size={}x{}", x, y, w, h);
     if let Some(existing) = app.get_webview_window(TOOLBAR_LABEL) {
         let _ = existing.set_size(tauri::Size::Physical(PhysicalSize::new(w, h)));

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -416,7 +416,8 @@ pub async fn show_region_guide_editor(app: AppHandle) -> Result<(), String> {
 }
 
 /// Vertical recording pill anchored to the left edge. Stop + timer + pause,
-/// matching Loom's left-rail placement. Draggable, always on top.
+/// with hover-revealed restart/cancel controls matching Loom's left-rail
+/// placement. Draggable, always on top.
 #[tauri::command]
 pub async fn show_toolbar(app: AppHandle) -> Result<(), String> {
     dlog!("[clips-tray] show_toolbar invoked");
@@ -430,12 +431,13 @@ pub async fn show_toolbar(app: AppHandle) -> Result<(), String> {
     // window in physical px. Keep the visible toolbar large enough for the
     // fixed 30px circular controls on high-DPI displays.
     let content_w: u32 = (72.0 * scale).round() as u32;
-    let content_h: u32 = (150.0 * scale).round() as u32;
+    let collapsed_content_h: u32 = (150.0 * scale).round() as u32;
+    let expanded_content_h: u32 = (234.0 * scale).round() as u32;
     let w: u32 = content_w + gutter * 2;
-    let h: u32 = content_h + gutter * 2;
+    let h: u32 = expanded_content_h + gutter * 2;
     // Flush-left with a small margin; vertically centered on the screen.
     let x: i32 = mx + 48 - gutter as i32;
-    let y: i32 = my + (mh as i32 - content_h as i32) / 2 - gutter as i32;
+    let y: i32 = my + (mh as i32 - collapsed_content_h as i32) / 2 - gutter as i32;
     dlog!("[clips-tray] toolbar pos=({},{}) size={}x{}", x, y, w, h);
     if let Some(existing) = app.get_webview_window(TOOLBAR_LABEL) {
         let _ = existing.set_size(tauri::Size::Physical(PhysicalSize::new(w, h)));

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -431,13 +431,12 @@ pub async fn show_toolbar(app: AppHandle) -> Result<(), String> {
     // window in physical px. Keep the visible toolbar large enough for the
     // fixed 30px circular controls on high-DPI displays.
     let content_w: u32 = (72.0 * scale).round() as u32;
-    let collapsed_content_h: u32 = (150.0 * scale).round() as u32;
     let expanded_content_h: u32 = (234.0 * scale).round() as u32;
     let w: u32 = content_w + gutter * 2;
     let h: u32 = expanded_content_h + gutter * 2;
     // Flush-left with a small margin; vertically centered on the screen.
     let x: i32 = mx + 48 - gutter as i32;
-    let y: i32 = my + (mh as i32 - collapsed_content_h as i32) / 2 - gutter as i32;
+    let y: i32 = my + (mh as i32 - expanded_content_h as i32) / 2 - gutter as i32;
     dlog!("[clips-tray] toolbar pos=({},{}) size={}x{}", x, y, w, h);
     if let Some(existing) = app.get_webview_window(TOOLBAR_LABEL) {
         let _ = existing.set_size(tauri::Size::Physical(PhysicalSize::new(w, h)));

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2345,12 +2345,11 @@ export function App() {
             await invoke("set_recording_state", { active: false }).catch(
               () => {},
             );
-            await new Promise<void>((resolve) => {
-              window.setTimeout(resolve, 0);
-            });
-            if (!cancelled) {
-              await startRecording({ ignoreActiveRecorder: true });
-            }
+            // Starting a new browser capture must come from a fresh click in
+            // this webview. The toolbar click arrives here through async Tauri
+            // IPC, so reopen the popover and let the next Start click provide
+            // the required user activation.
+            invoke("show_popover").catch(() => {});
           }
         }
       }),

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2342,9 +2342,7 @@ export function App() {
             recordingFlowGateRef.current = false;
             setRecorder(null);
             setRecordingFlowActive(false);
-            await invoke("set_recording_state", { active: false }).catch(
-              () => {},
-            );
+            invoke("set_recording_state", { active: false }).catch(() => {});
             // Starting a new browser capture must come from a fresh click in
             // this webview. The toolbar click arrives here through async Tauri
             // IPC, so reopen the popover and let the next Start click provide

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2004,8 +2004,8 @@ export function App() {
     });
   }
 
-  async function startRecording() {
-    if (recorder) return;
+  async function startRecording(options?: { ignoreActiveRecorder?: boolean }) {
+    if (recorder && !options?.ignoreActiveRecorder) return;
     setRecError(null);
     setLocalRecordingNotice(null);
     console.log("[clips-popover] startRecording clicked", {
@@ -2328,6 +2328,33 @@ export function App() {
         }
       }),
     );
+    track(
+      listen("clips:recorder-restart", async () => {
+        try {
+          await recorder.cancel();
+        } finally {
+          if (!cancelled) {
+            (
+              window as unknown as { clipsForceAlive?: boolean }
+            ).clipsForceAlive = false;
+            bubbleStreamTransferredToRecorder.current = false;
+            bubbleStreamRef.current = null;
+            recordingFlowGateRef.current = false;
+            setRecorder(null);
+            setRecordingFlowActive(false);
+            await invoke("set_recording_state", { active: false }).catch(
+              () => {},
+            );
+            await new Promise<void>((resolve) => {
+              window.setTimeout(resolve, 0);
+            });
+            if (!cancelled) {
+              await startRecording({ ignoreActiveRecorder: true });
+            }
+          }
+        }
+      }),
+    );
     return () => {
       cancelled = true;
       unlisteners.forEach((u) => {
@@ -2518,7 +2545,12 @@ export function App() {
         onOpenPermission={openMacosPrivacySettings}
       />
 
-      <button className="primary start" onClick={startRecording}>
+      <button
+        className="primary start"
+        onClick={() => {
+          void startRecording();
+        }}
+      >
         {localRecordingMode === "off"
           ? "Start recording"
           : "Start local recording"}

--- a/templates/clips/desktop/src/overlays/toolbar.tsx
+++ b/templates/clips/desktop/src/overlays/toolbar.tsx
@@ -97,28 +97,33 @@ export function Toolbar() {
     };
   }, []);
 
+  function scheduleCloseFallback(action: string) {
+    fallbackTimer.current = setTimeout(() => {
+      console.warn(
+        `[clips-toolbar] recorder did not close toolbar within 3s after ${action} — self-closing`,
+      );
+      getCurrentWindow()
+        .close()
+        .catch(() => {});
+    }, 3_000);
+  }
+
   function stop() {
     if (pendingAction || !enabled) return;
     setPendingAction("stop");
     console.log("[clips-toolbar] stop clicked — emitting clips:recorder-stop");
-    emit("clips:recorder-stop").catch((err) => {
-      console.error("[clips-toolbar] emit clips:recorder-stop failed:", err);
-      setPendingAction(null);
-    });
+    emit("clips:recorder-stop")
+      .then(() => scheduleCloseFallback("stop"))
+      .catch((err) => {
+        console.error("[clips-toolbar] emit clips:recorder-stop failed:", err);
+        setPendingAction(null);
+      });
     // Defensive fallback: the recorder normally closes us via
     // `hide_overlays` within a second or two. If for any reason the
     // popover listener never fires (popover window closed, listener
     // torn down mid-emit, etc.), self-close after 3s so the user isn't
     // left with a zombie pill floating over their screen. The recorder
     // closing us first is a no-op on the already-closed window.
-    fallbackTimer.current = setTimeout(() => {
-      console.warn(
-        "[clips-toolbar] recorder did not close toolbar within 3s — self-closing",
-      );
-      getCurrentWindow()
-        .close()
-        .catch(() => {});
-    }, 3_000);
   }
   function togglePause() {
     if (!enabled || pendingAction) return;
@@ -132,10 +137,15 @@ export function Toolbar() {
     console.log(
       "[clips-toolbar] restart clicked — emitting clips:recorder-restart",
     );
-    emit("clips:recorder-restart").catch((err) => {
-      console.error("[clips-toolbar] emit clips:recorder-restart failed:", err);
-      setPendingAction(null);
-    });
+    emit("clips:recorder-restart")
+      .then(() => scheduleCloseFallback("restart"))
+      .catch((err) => {
+        console.error(
+          "[clips-toolbar] emit clips:recorder-restart failed:",
+          err,
+        );
+        setPendingAction(null);
+      });
   }
   function cancel() {
     if (pendingAction || !enabled) return;
@@ -143,10 +153,15 @@ export function Toolbar() {
     console.log(
       "[clips-toolbar] cancel clicked — emitting clips:recorder-cancel",
     );
-    emit("clips:recorder-cancel").catch((err) => {
-      console.error("[clips-toolbar] emit clips:recorder-cancel failed:", err);
-      setPendingAction(null);
-    });
+    emit("clips:recorder-cancel")
+      .then(() => scheduleCloseFallback("cancel"))
+      .catch((err) => {
+        console.error(
+          "[clips-toolbar] emit clips:recorder-cancel failed:",
+          err,
+        );
+        setPendingAction(null);
+      });
   }
 
   // Same explicit-drag pattern the bubble uses — `data-tauri-drag-region`
@@ -164,6 +179,13 @@ export function Toolbar() {
       });
   };
 
+  const pendingActionLabel =
+    pendingAction === "restart"
+      ? "Restarting..."
+      : pendingAction === "cancel"
+        ? "Cancelling..."
+        : "Stopping...";
+
   return (
     <div
       className={`toolbar-v ${paused ? "toolbar-v-paused" : ""} ${enabled ? "" : "toolbar-v-disabled"}`}
@@ -178,7 +200,7 @@ export function Toolbar() {
         }
         title={
           pendingAction === "stop"
-            ? "Stopping..."
+            ? pendingActionLabel
             : enabled
               ? "Stop recording"
               : "Recording not started yet"
@@ -199,7 +221,7 @@ export function Toolbar() {
         aria-label={paused ? "Resume" : "Pause"}
         title={
           pendingAction
-            ? "Stopping..."
+            ? pendingActionLabel
             : enabled
               ? paused
                 ? "Resume"
@@ -222,7 +244,7 @@ export function Toolbar() {
           aria-label="Restart recording"
           title={
             pendingAction === "restart"
-              ? "Restarting..."
+              ? pendingActionLabel
               : enabled
                 ? "Restart"
                 : "Recording not started yet"
@@ -242,7 +264,7 @@ export function Toolbar() {
           aria-label="Cancel recording"
           title={
             pendingAction === "cancel"
-              ? "Cancelling..."
+              ? pendingActionLabel
               : enabled
                 ? "Cancel"
                 : "Recording not started yet"

--- a/templates/clips/desktop/src/overlays/toolbar.tsx
+++ b/templates/clips/desktop/src/overlays/toolbar.tsx
@@ -236,7 +236,11 @@ export function Toolbar() {
           <IconPlayerPauseFilled size={18} />
         )}
       </button>
-      <div className="toolbar-v-hover-actions" aria-label="Recording actions">
+      <div
+        className="toolbar-v-hover-actions"
+        role="group"
+        aria-label="Recording actions"
+      >
         <button
           className="toolbar-v-action"
           onClick={restart}

--- a/templates/clips/desktop/src/overlays/toolbar.tsx
+++ b/templates/clips/desktop/src/overlays/toolbar.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from "react";
+import type { FocusEvent } from "react";
+import { LogicalSize } from "@tauri-apps/api/dpi";
 import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
@@ -8,6 +10,16 @@ import {
   IconRefresh,
   IconTrash,
 } from "@tabler/icons-react";
+
+const OVERLAY_SHADOW_GUTTER = 18;
+const TOOLBAR_CONTENT_WIDTH = 72;
+const TOOLBAR_COLLAPSED_HEIGHT = 150;
+const TOOLBAR_EXPANDED_HEIGHT = 234;
+const TOOLBAR_WINDOW_WIDTH = TOOLBAR_CONTENT_WIDTH + OVERLAY_SHADOW_GUTTER * 2;
+const TOOLBAR_COLLAPSED_WINDOW_HEIGHT =
+  TOOLBAR_COLLAPSED_HEIGHT + OVERLAY_SHADOW_GUTTER * 2;
+const TOOLBAR_EXPANDED_WINDOW_HEIGHT =
+  TOOLBAR_EXPANDED_HEIGHT + OVERLAY_SHADOW_GUTTER * 2;
 
 /**
  * Floating recording toolbar — vertical pill anchored to the LEFT edge of
@@ -43,6 +55,7 @@ export function Toolbar() {
   // point `clips:toolbar-enabled` fires with `true` from the recorder.
   const [enabled, setEnabled] = useState(false);
   const fallbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const expandedRef = useRef(false);
 
   useEffect(() => {
     const unlistens: Array<() => void> = [];
@@ -106,6 +119,19 @@ export function Toolbar() {
         .close()
         .catch(() => {});
     }, 3_000);
+  }
+
+  function resizeToolbarWindow(expanded: boolean) {
+    if (expandedRef.current === expanded) return;
+    expandedRef.current = expanded;
+    const height = expanded
+      ? TOOLBAR_EXPANDED_WINDOW_HEIGHT
+      : TOOLBAR_COLLAPSED_WINDOW_HEIGHT;
+    getCurrentWindow()
+      .setSize(new LogicalSize(TOOLBAR_WINDOW_WIDTH, height))
+      .catch((err) => {
+        console.warn("[clips-toolbar] resize failed", err);
+      });
   }
 
   function stop() {
@@ -178,6 +204,10 @@ export function Toolbar() {
         console.warn("[clips-toolbar] startDragging failed", err);
       });
   };
+  const handleToolbarBlur = (e: FocusEvent<HTMLDivElement>) => {
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+    resizeToolbarWindow(false);
+  };
 
   const pendingActionLabel =
     pendingAction === "restart"
@@ -190,6 +220,10 @@ export function Toolbar() {
     <div
       className={`toolbar-v ${paused ? "toolbar-v-paused" : ""} ${enabled ? "" : "toolbar-v-disabled"}`}
       onMouseDown={handleToolbarMouseDown}
+      onMouseEnter={() => resizeToolbarWindow(true)}
+      onMouseLeave={() => resizeToolbarWindow(false)}
+      onFocusCapture={() => resizeToolbarWindow(true)}
+      onBlurCapture={handleToolbarBlur}
     >
       <button
         className="toolbar-v-stop"

--- a/templates/clips/desktop/src/overlays/toolbar.tsx
+++ b/templates/clips/desktop/src/overlays/toolbar.tsx
@@ -5,17 +5,20 @@ import {
   IconLoader2,
   IconPlayerPauseFilled,
   IconPlayerPlayFilled,
+  IconRefresh,
+  IconTrash,
 } from "@tabler/icons-react";
 
 /**
  * Floating recording toolbar — vertical pill anchored to the LEFT edge of
  * the screen (Loom's placement). Big orange Stop at the top, elapsed time
- * below, pause underneath. Pure command emitter — the popover owns the
+ * below, pause underneath. On hover, it grows downward to expose restart
+ * and cancel controls. Pure command emitter — the popover owns the
  * MediaRecorder.
  *
  * IPC contract:
  *   receives → `clips:recorder-state` { paused, elapsedMs }
- *   emits    → `clips:recorder-stop`, `:pause`, `:resume`
+ *   emits    → `clips:recorder-stop`, `:pause`, `:resume`, `:restart`, `:cancel`
  *
  * IMPORTANT: The Stop button MUST NOT close its own window. The popover's
  * recorder listener is what drives the stop flow, and it invokes
@@ -31,7 +34,9 @@ import {
 export function Toolbar() {
   const [paused, setPaused] = useState(false);
   const [elapsed, setElapsed] = useState(0);
-  const [stopping, setStopping] = useState(false);
+  const [pendingAction, setPendingAction] = useState<
+    "stop" | "restart" | "cancel" | null
+  >(null);
   // Pre-record mode: the toolbar shows alongside the pre-record bubble so
   // the user can drag both around and position them before hitting Start.
   // Stop / Pause are disabled until the recorder actually begins, at which
@@ -93,11 +98,12 @@ export function Toolbar() {
   }, []);
 
   function stop() {
-    if (stopping || !enabled) return;
-    setStopping(true);
+    if (pendingAction || !enabled) return;
+    setPendingAction("stop");
     console.log("[clips-toolbar] stop clicked — emitting clips:recorder-stop");
     emit("clips:recorder-stop").catch((err) => {
       console.error("[clips-toolbar] emit clips:recorder-stop failed:", err);
+      setPendingAction(null);
     });
     // Defensive fallback: the recorder normally closes us via
     // `hide_overlays` within a second or two. If for any reason the
@@ -115,10 +121,32 @@ export function Toolbar() {
     }, 3_000);
   }
   function togglePause() {
-    if (!enabled) return;
+    if (!enabled || pendingAction) return;
     emit(paused ? "clips:recorder-resume" : "clips:recorder-pause").catch(
       () => {},
     );
+  }
+  function restart() {
+    if (pendingAction || !enabled) return;
+    setPendingAction("restart");
+    console.log(
+      "[clips-toolbar] restart clicked — emitting clips:recorder-restart",
+    );
+    emit("clips:recorder-restart").catch((err) => {
+      console.error("[clips-toolbar] emit clips:recorder-restart failed:", err);
+      setPendingAction(null);
+    });
+  }
+  function cancel() {
+    if (pendingAction || !enabled) return;
+    setPendingAction("cancel");
+    console.log(
+      "[clips-toolbar] cancel clicked — emitting clips:recorder-cancel",
+    );
+    emit("clips:recorder-cancel").catch((err) => {
+      console.error("[clips-toolbar] emit clips:recorder-cancel failed:", err);
+      setPendingAction(null);
+    });
   }
 
   // Same explicit-drag pattern the bubble uses — `data-tauri-drag-region`
@@ -144,10 +172,12 @@ export function Toolbar() {
       <button
         className="toolbar-v-stop"
         onClick={stop}
-        disabled={stopping || !enabled}
-        aria-label={stopping ? "Stopping recording" : "Stop recording"}
+        disabled={!!pendingAction || !enabled}
+        aria-label={
+          pendingAction === "stop" ? "Stopping recording" : "Stop recording"
+        }
         title={
-          stopping
+          pendingAction === "stop"
             ? "Stopping..."
             : enabled
               ? "Stop recording"
@@ -155,7 +185,7 @@ export function Toolbar() {
         }
         data-no-drag
       >
-        {stopping ? (
+        {pendingAction === "stop" ? (
           <IconLoader2 className="toolbar-v-spinner" size={18} />
         ) : (
           <span className="toolbar-v-stop-square" />
@@ -165,10 +195,10 @@ export function Toolbar() {
       <button
         className="toolbar-v-pause"
         onClick={togglePause}
-        disabled={!enabled || stopping}
+        disabled={!enabled || !!pendingAction}
         aria-label={paused ? "Resume" : "Pause"}
         title={
-          stopping
+          pendingAction
             ? "Stopping..."
             : enabled
               ? paused
@@ -184,6 +214,48 @@ export function Toolbar() {
           <IconPlayerPauseFilled size={18} />
         )}
       </button>
+      <div className="toolbar-v-hover-actions" aria-label="Recording actions">
+        <button
+          className="toolbar-v-action"
+          onClick={restart}
+          disabled={!enabled || !!pendingAction}
+          aria-label="Restart recording"
+          title={
+            pendingAction === "restart"
+              ? "Restarting..."
+              : enabled
+                ? "Restart"
+                : "Recording not started yet"
+          }
+          data-no-drag
+        >
+          {pendingAction === "restart" ? (
+            <IconLoader2 className="toolbar-v-spinner" size={18} />
+          ) : (
+            <IconRefresh size={24} stroke={1.9} />
+          )}
+        </button>
+        <button
+          className="toolbar-v-action toolbar-v-action-danger"
+          onClick={cancel}
+          disabled={!enabled || !!pendingAction}
+          aria-label="Cancel recording"
+          title={
+            pendingAction === "cancel"
+              ? "Cancelling..."
+              : enabled
+                ? "Cancel"
+                : "Recording not started yet"
+          }
+          data-no-drag
+        >
+          {pendingAction === "cancel" ? (
+            <IconLoader2 className="toolbar-v-spinner" size={18} />
+          ) : (
+            <IconTrash size={24} stroke={1.9} />
+          )}
+        </button>
+      </div>
     </div>
   );
 }

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -2281,14 +2281,18 @@ body[data-clips-route="recording-pill"] #root {
 
 .toolbar-v {
   position: fixed;
-  inset: var(--overlay-shadow-gutter);
+  left: var(--overlay-shadow-gutter);
+  top: var(--overlay-shadow-gutter);
+  width: 72px;
+  height: 150px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 10px;
   /* Equal inset on all four sides from the pill edge to the buttons. */
   padding: 10px;
+  overflow: hidden;
   border-radius: 24px;
   background: rgba(20, 22, 28, 0.94);
   backdrop-filter: blur(20px);
@@ -2297,6 +2301,15 @@ body[data-clips-route="recording-pill"] #root {
   user-select: none;
   -webkit-user-select: none;
   cursor: grab;
+  transition:
+    height 170ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-radius 170ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.toolbar-v:hover,
+.toolbar-v:focus-within {
+  height: 234px;
+  border-radius: 26px;
 }
 
 .toolbar-v:active {
@@ -2380,6 +2393,62 @@ body[data-clips-route="recording-pill"] #root {
   color: white;
 }
 
+.toolbar-v-hover-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+  opacity: 0;
+  transform: translateY(-6px);
+  pointer-events: none;
+  transition:
+    opacity 130ms ease-out,
+    transform 170ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.toolbar-v:hover .toolbar-v-hover-actions,
+.toolbar-v:focus-within .toolbar-v-hover-actions {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.toolbar-v-action {
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  min-height: 40px;
+  flex: 0 0 40px;
+  aspect-ratio: 1 / 1;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.95);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition:
+    background-color 120ms ease-out,
+    color 120ms ease-out,
+    transform 120ms ease-out;
+}
+
+.toolbar-v-action:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: white;
+}
+
+.toolbar-v-action:active {
+  transform: scale(0.94);
+}
+
+.toolbar-v-action-danger:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
 .toolbar-v-paused {
   border-color: rgba(245, 158, 11, 0.35);
 }
@@ -2389,20 +2458,31 @@ body[data-clips-route="recording-pill"] #root {
    (no recorder to drive yet). Greyed out + not-allowed cursor makes the
    "not yet" affordance obvious. */
 .toolbar-v-disabled .toolbar-v-stop,
-.toolbar-v-disabled .toolbar-v-pause {
+.toolbar-v-disabled .toolbar-v-pause,
+.toolbar-v-disabled .toolbar-v-action {
   background: rgba(255, 255, 255, 0.06);
   color: rgba(255, 255, 255, 0.35);
   cursor: not-allowed;
   pointer-events: auto;
 }
 .toolbar-v-disabled .toolbar-v-stop:hover,
-.toolbar-v-disabled .toolbar-v-pause:hover {
+.toolbar-v-disabled .toolbar-v-pause:hover,
+.toolbar-v-disabled .toolbar-v-action:hover {
   background: rgba(255, 255, 255, 0.06);
   color: rgba(255, 255, 255, 0.35);
 }
 .toolbar-v-stop:disabled,
-.toolbar-v-pause:disabled {
+.toolbar-v-pause:disabled,
+.toolbar-v-action:disabled {
   cursor: not-allowed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toolbar-v,
+  .toolbar-v-hover-actions,
+  .toolbar-v-action {
+    transition: none;
+  }
 }
 
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- copy installed ffmpeg-static, including pnpm store installs, into serverless Nitro bundles for Clips transcription fallback
- warn when ffmpeg-static is installed without its downloaded binary so deployments can fall back to FFMPEG_PATH/system ffmpeg
- keep the destructive Clips recording page action after sharing controls
- add desktop recording toolbar restart/cancel action buttons and wire restart back into the recorder flow

## Tests
- pnpm --filter @agent-native/core test -- build.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter ./templates/clips typecheck
