### PR TITLE
Collapse Content sidebar child trees by default

### DIFF
--- a/.agents/skills/actions/SKILL.md
+++ b/.agents/skills/actions/SKILL.md
@@ -15,6 +15,8 @@ metadata:
 
 Actions in `actions/` are the **single source of truth** for app operations. The agent calls them as tools, and the framework auto-exposes them as HTTP endpoints at `/_agent-native/actions/:name`. The frontend calls those endpoints using React Query hooks. No duplicate `/api/` routes needed.
 
+Before creating any custom REST/API route for app data, inspect `actions/` and the action table in `AGENTS.md`. If an action already exists, call it directly from the agent or with `useActionQuery` / `useActionMutation` from the UI. If the capability is missing, create or update a `defineAction`. Do not add `/api/*`, `server/routes/*`, or other pass-through endpoints whose main job is to call, repackage, or re-export an action.
+
 ## Why
 
 Actions give the agent callable tools with structured input/output, AND they give the frontend type-safe HTTP endpoints automatically. One implementation serves both the agent and the UI. They keep the agent's chat context clean, they're reusable, and they can be tested independently.
@@ -59,6 +61,16 @@ Tips:
 - Use `z.enum(["draft", "published"])` for constrained values
 
 The legacy `parameters` field (plain JSON Schema object) still works as a fallback but does not provide runtime validation or type inference.
+
+## Decision Order
+
+When you need app data or a mutation:
+
+1. **Use an existing action** if one already performs the operation.
+2. **Create or extend a `defineAction`** when the agent and UI both need a new operation.
+3. **Create a custom route only for route-only concerns** such as uploads, streaming, webhooks, OAuth callbacks, or a non-JSON protocol.
+
+Do not build an umbrella REST API to make actions "easier" to call. Actions are already callable by agents, CLIs, React hooks, HTTP, MCP/A2A exposure, and external hosts through the framework.
 
 ### The `http` Option
 
@@ -168,7 +180,7 @@ Most operations should be actions. You only need custom routes in `server/routes
 - **Webhooks** — external services POST to a specific URL
 - **OAuth callbacks** — redirect-based flows that need specific URL patterns
 
-If it's a standard CRUD operation or data query, use an action instead.
+If it's a standard CRUD operation, data query, or a wrapper around an action, use the action instead.
 
 ## Legacy Pattern (bare export)
 
@@ -197,6 +209,7 @@ This still works but is not auto-exposed as HTTP. Prefer `defineAction` for all 
 - **Use `loadEnv()`** if the action needs environment variables (API keys, etc.).
 - **Use `fail()`** for user-friendly error messages (exits with message, no stack trace).
 - **Import from `@agent-native/core`** — Don't redefine `parseArgs()` or other utilities locally.
+- **Do not re-export actions as REST.** The mounted `/_agent-native/actions/:name` endpoint is the REST surface; duplicating it under `/api/*` creates drift and hides the operation from agents.
 
 ## Common Patterns
 

--- a/.agents/skills/adding-a-feature/SKILL.md
+++ b/.agents/skills/adding-a-feature/SKILL.md
@@ -23,7 +23,7 @@ When you add a new feature, work through these four areas in order:
 
 ### 1. UI Component
 
-Build the user-facing interface — a page, component, dialog, or route. Use `useActionQuery` and `useActionMutation` from `@agent-native/core/client` to call actions for data fetching and mutations — you rarely need custom `/api/` routes.
+Build the user-facing interface — a page, component, dialog, or route. Use `useActionQuery` and `useActionMutation` from `@agent-native/core/client` to call actions for data fetching and mutations. Do not create a custom REST endpoint just so React can call action-backed data; the action endpoint already exists.
 
 **Auto-refresh on agent writes is non-negotiable** — when the agent mutates data, the UI must reflect the change without a manual refresh. There are two paths, and you must pick the right one:
 
@@ -47,6 +47,12 @@ Build the user-facing interface — a page, component, dialog, or route. Use `us
 ### 2. Action
 
 Create an action in `actions/` using `defineAction`. This serves double duty: the agent calls it as a tool, and the framework auto-exposes it as an HTTP endpoint at `/_agent-native/actions/:name` for the UI to call. Set `http: { method: "GET" }` for read actions, leave default for writes, or set `http: false` for agent-only actions like `navigate` and `view-screen`.
+
+Before adding a new route or endpoint, inspect the existing actions. Reuse an
+action if it already covers the business operation, extend it if the shared
+contract is incomplete, or create a new `defineAction` if the agent and UI both
+need the capability. Do not add pass-through `/api/*` routes that re-export
+actions.
 
 **If the action produces or lists a navigable resource**, add a `link` builder that returns `{ url: buildDeepLink({ app, view, params }), label }`. External coding agents and MCP hosts (Claude / ChatGPT / Claude Code / Cowork / Codex, over MCP/A2A) then surface an "Open in … →" deep link that drops the user back into the running UI focused on the record — for free. If a compatible MCP host should render an inline review/edit surface, also add `mcpApp` with `embedApp()` so the action embeds the real React app route instead of a one-off HTML UI. The `link` builder and `mcpApp` metadata must be pure and synchronous (no I/O). Any external-agent read/ingest action must be `http: { method: "GET" }` + `readOnly: true` + `publicAgent: { expose: true, readOnly: true, requiresAuth: true }`. See the `external-agents` skill.
 
@@ -112,7 +118,7 @@ See the "Client-Side Routing" section in the root `CLAUDE.md` for full details.
 - **Per-route `<AppLayout>` wrappers** — Every route file wraps its content in `<AppLayout>` or `<Layout>`. React sees a different component at the outlet on each nav and unmounts the whole shell, causing the agent sidebar to reload on every click. Mount the shell once above `<Outlet />` (root.tsx or `_app.tsx` pathless layout).
 - **UI without actions** — The user can create forms but the agent cannot. The agent says "I don't have access to that" when it should be able to do it.
 - **Actions without AGENTS.md** — The actions exist but the agent doesn't know about them because they're not documented. The agent reinvents solutions instead of using the actions.
-- **Duplicate API routes** — Creating `/api/` routes for operations that actions already handle. Actions are auto-exposed as HTTP endpoints — use `useActionQuery`/`useActionMutation` instead.
+- **Duplicate API routes** — Creating `/api/` routes for operations that actions already handle, including pass-through routes that just call or repackage an action. Actions are auto-exposed as HTTP endpoints — use `useActionQuery`/`useActionMutation` instead.
 - **Features without app-state** — The agent cannot see that the user is looking at a specific form, email, or chart. It asks "which one?" instead of acting on the current selection.
 - **Actions without UI** — The agent can do something the user cannot. This is less common but still breaks parity.
 

--- a/.agents/skills/authentication/SKILL.md
+++ b/.agents/skills/authentication/SKILL.md
@@ -90,7 +90,10 @@ Apps can connect to Builder via the `cli-auth` flow and persist shared browser c
 
 ## Protecting Custom Routes
 
-Actions are auto-protected. For custom `/api/` routes:
+Actions are auto-protected. Do not create custom `/api/` routes for normal
+CRUD, data queries, or action-backed operations; use `defineAction` and the
+auto-mounted action endpoint instead. If a route-only concern forces a custom
+route:
 
 ```ts
 import { getSession } from "@agent-native/core/server";

--- a/.agents/skills/context-awareness/SKILL.md
+++ b/.agents/skills/context-awareness/SKILL.md
@@ -67,7 +67,10 @@ const navigation = await readAppState("navigation");
 
 ### 2. The `view-screen` Script
 
-Every template should have a `view-screen` script. It reads navigation state, fetches the relevant data from the API, and returns a snapshot of what the user sees. This is the agent's eyes.
+Every template should have a `view-screen` script. It reads navigation state,
+fetches the relevant data from existing domain actions, shared data helpers, or
+Drizzle queries, and returns a snapshot of what the user sees. Do not add REST
+wrappers just so `view-screen` can read app data. This is the agent's eyes.
 
 ```ts
 // actions/view-screen.ts

--- a/.agents/skills/qa/SKILL.md
+++ b/.agents/skills/qa/SKILL.md
@@ -90,7 +90,8 @@ For each app, read these files to understand what to test:
 
 1. `templates/<app>/app/routes/` or `templates/<app>/app/routes.ts` — discover all pages
 2. `templates/<app>/CLAUDE.md` — features, API routes, data model
-3. `templates/<app>/server/routes/api/` — API endpoints
+3. `templates/<app>/actions/` — domain operations the UI and agent share
+4. `templates/<app>/server/routes/api/` — route-only endpoints such as uploads, streaming, webhooks, and OAuth callbacks
 
 Combine with any `--focus` guidance to produce a test plan. The test plan is a numbered list of user-facing flows to verify. Example:
 

--- a/.agents/skills/security/SKILL.md
+++ b/.agents/skills/security/SKILL.md
@@ -100,6 +100,9 @@ Two more CI guards (also wired into `pnpm prep`) target the 2026-04 cross-tenant
 ## Auth
 
 - All actions are protected by the auth guard automatically.
+- Prefer actions for normal app data. Do not hand-write `/api/*` routes for
+  CRUD, data queries, or action re-exports just to add auth; action endpoints
+  already get auth and request context.
 - If you must create custom `/api/` routes, always call `getSession(event)` and reject requests without a session:
 
 ```ts

--- a/.agents/skills/server-plugins/SKILL.md
+++ b/.agents/skills/server-plugins/SKILL.md
@@ -31,9 +31,12 @@ All framework-level routes live under `/_agent-native/` to avoid collisions with
 ### Hard rule
 
 - **ALL framework routes go under `/_agent-native/`.**
-- Templates own `/api/*` for their domain routes.
+- Templates own `/api/*` only for route-only domain concerns such as uploads,
+  streaming, webhooks, OAuth callbacks, or non-JSON protocols.
 - Never put framework routes under `/api/`.
 - Never put template routes under `/_agent-native/` — that namespace is reserved.
+- Never create `/api/*` routes that only wrap, proxy, or re-export actions. Use
+  the existing `/_agent-native/actions/:name` endpoint or the React action hooks.
 
 ### Auto-mounted framework routes
 
@@ -65,6 +68,11 @@ For standard CRUD and data operations, use `defineAction` in `actions/` — the 
 - Streaming responses
 - Webhooks from external services
 - OAuth callbacks
+
+Before adding a route, inspect the existing action files. Reuse the action if
+it already encodes the business rule, or add a new action if the operation
+should be available to both the agent and the UI. A route whose implementation
+mostly calls an action is usually the wrong abstraction.
 
 The Nitro Vite plugin handles both `/api/` and `/_agent-native/` prefixes via file-based routing in `server/routes/`.
 

--- a/.changeset/action-route-wrappers.md
+++ b/.changeset/action-route-wrappers.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Tighten generated agent instructions to prefer existing actions over duplicate REST wrappers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,12 @@ manual step is still pending. Use `🔴` only when blocked on user input.
 - Data lives in SQL via Drizzle. Keep schemas provider-agnostic.
 - Actions are the single source of truth. Define app operations in `actions/`
   with `defineAction`; the agent calls them as tools and the frontend calls the
-  mounted HTTP endpoint.
+  auto-mounted `/_agent-native/actions/:name` endpoint through
+  `useActionQuery` / `useActionMutation`.
+- Before adding any custom API or Nitro route for app data, inspect existing
+  actions first. Reuse or extend the action surface instead of creating REST
+  wrappers, pass-through endpoints, or duplicate CRUD routes that re-export
+  actions.
 - All AI work goes through the agent chat. UIs do not call LLMs directly.
 - Application state belongs in SQL `application_state` so the agent can know
   the current navigation, selection, and focused object.
@@ -102,7 +107,8 @@ instructions, and application state.
 Extensions are sandboxed Alpine.js mini-apps stored in SQL. When the user asks
 to create or edit an extension/widget/dashboard/calculator/mini-app, use the
 extension actions and `extensionData` instead of source changes. Extensions can
-call `appAction`, `dbQuery`, `dbExec`, `appFetch`, and `extensionFetch` from the
+call `appAction` for app actions/data, `dbQuery`, `dbExec`, `appFetch` for
+allowed framework endpoints, and `extensionFetch` for external APIs from the
 iframe bridge. Use the `extensions` skill for the full rules.
 
 ## Project Map

--- a/packages/core/docs/content/context-awareness.md
+++ b/packages/core/docs/content/context-awareness.md
@@ -1,25 +1,42 @@
 ---
 title: "Context Awareness"
-description: "How the agent knows what the user is looking at: navigation state, view-screen, navigate commands, and jitter prevention."
+description: "How the agent knows what the user is looking at: navigation state, selection context, view-screen, sendToAgentChat handoffs, navigate commands, and jitter prevention."
 ---
 
 # Context Awareness
 
-How the agent knows what the user is looking at — and how the agent can control what the user sees.
+How the agent knows what the user is looking at -- and how the agent can control what the user sees.
 
 ## Overview {#overview}
 
-Without context awareness, the agent is blind. It asks "which email?" when the user is staring at one. It cannot act on the current selection, cannot provide relevant suggestions, and cannot modify what the user sees.
+Without context awareness, the agent is blind. It asks "which email?" when the user is staring at one. It cannot act on the current selection, cannot provide relevant suggestions, and cannot modify what the user sees. With context awareness, the user can click a row, highlight a paragraph, select a slide element, or press Cmd+I, then say "summarize this" and the agent already knows what "this" means.
 
-Three patterns solve this:
+Five patterns solve this:
 
-1. **Navigation state** — the UI writes a `navigation` key to application-state on every route change
-2. **`view-screen`** — an action that reads navigation state, fetches contextual data, and returns a snapshot of what the user sees
-3. **`navigate`** — a one-shot command from the agent that tells the UI where to go
+1. **Navigation state** -- the UI writes a `navigation` key to application-state on every route change
+2. **Selection state** -- the UI writes a `selection` key when the user focuses, selects, or multi-selects something meaningful
+3. **`view-screen`** -- an action that reads application state, fetches contextual data, and returns a snapshot of what the user sees
+4. **Prompt handoff** -- UI controls call `sendToAgentChat()` when a click should become an agent turn
+5. **`navigate`** -- a one-shot command from the agent that tells the UI where to go
+
+## Context layers {#context-layers}
+
+Use different context channels for different jobs:
+
+| Layer                                     | Owner             | Use it for                                                                 |
+| ----------------------------------------- | ----------------- | -------------------------------------------------------------------------- |
+| `navigation` app-state key                | UI                | Current route, view, open record, filters, active tab                      |
+| `selection` app-state key                 | UI                | Durable semantic selection: rows, blocks, shapes, assets, messages         |
+| `pending-selection-context` app-state key | UI / `AgentPanel` | One-shot selected text attached to the next chat turn, usually from Cmd+I  |
+| `view-screen` action                      | Agent             | Hydrating the app-state keys into real records and screen summaries        |
+| `sendToAgentChat()`                       | UI                | Turning a click, command, comment pin, or selected item into a chat prompt |
+| `navigate` app-state key                  | Agent             | Asking the UI to move to another route or focus another object             |
+
+The short version: app state tells the agent what the user is looking at, `view-screen` turns that state into useful data, and `sendToAgentChat()` turns UI intent into a chat message when the user clicks a command.
 
 ## Navigation state {#navigation-state}
 
-The UI writes a `navigation` key to application-state on every route change. This tells the agent what view the user is on and what item is selected.
+The UI writes a `navigation` key to application-state on every route change. This tells the agent what view the user is on, what item is open, and which filters shape the visible list.
 
 ```json
 {
@@ -33,10 +50,12 @@ The UI writes a `navigation` key to application-state on every route change. Thi
 
 What to include in navigation state:
 
-- `view` — the current page/section (e.g., "inbox", "form-builder", "dashboard")
-- Item IDs — the selected/open item (e.g., `threadId`, `formId`)
-- Filter state — active search, label, or category filters
-- Any selection — focused item, selected text range, active tab
+- `view` -- the current page/section, such as "inbox", "form-builder", or "dashboard"
+- Item IDs -- the selected/open item, such as `threadId` or `formId`
+- Filter state -- active search, label, or category filters
+- Light focus state -- focused row, active tab, current panel
+
+Keep `navigation` small and URL-like. It should identify the current screen, not duplicate whole records. Fetch records in `view-screen` so the agent always gets fresh data.
 
 The agent reads this before acting:
 
@@ -47,27 +66,113 @@ const navigation = await readAppState("navigation");
 // { view: "inbox", threadId: "thread-123", label: "important" }
 ```
 
+## Selection state {#selection-state}
+
+Selection is semantic UI state. It is how "the chart I clicked", "these three rows", "this slide title", or "the current email draft range" becomes model-visible context.
+
+Use the `selection` app-state key for durable selection that should survive a moment of navigation, empty-chat suggestions, or a later `view-screen` call:
+
+```json
+{
+  "kind": "slide.elements",
+  "deckId": "deck-123",
+  "slideId": "slide-4",
+  "items": [
+    {
+      "id": "hero-title",
+      "selector": "[data-block-id='hero-title']",
+      "label": "Hero title",
+      "text": "Q3 launch plan"
+    }
+  ],
+  "capturedAt": 1780332977027
+}
+```
+
+Write it from the UI when the user selects, focuses, or multi-selects meaningful objects:
+
+```tsx
+import { agentNativePath } from "@agent-native/core/client";
+
+async function syncSelection(selection: unknown | null) {
+  const url = agentNativePath("/_agent-native/application-state/selection");
+
+  if (!selection) {
+    await fetch(url, { method: "DELETE", keepalive: true });
+    return;
+  }
+
+  await fetch(url, {
+    method: "PUT",
+    keepalive: true,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(selection),
+  });
+}
+```
+
+Good selection state includes:
+
+- Stable IDs the agent can use in actions, such as `threadId`, `slideId`, or `assetId`
+- A short human label so prompts and suggestions are readable
+- Enough text or metadata to disambiguate the object
+- Optional UI locators such as selectors or coordinates when the agent needs to refer back to a visual element
+- `capturedAt` when stale selection would be harmful
+
+Avoid storing secrets, full documents, large binary payloads, or whole API responses in `selection`. Store IDs plus short excerpts, then let `view-screen` fetch the current source of truth.
+
+### One-shot selected text {#pending-selection-context}
+
+`AgentPanel` already handles the common text-selection flow. When the user presses Cmd+I (or Ctrl+I) with text selected on the page, it:
+
+1. Reads `window.getSelection()`
+2. Writes `{ text, capturedAt }` to `pending-selection-context`
+3. Focuses the agent chat
+
+The production agent injects that key into the next turn as immediate selection context and ignores it once it is stale. This is the path that makes "select text, press Cmd+I, ask 'make this punchier'" work without the user copying the selection into the prompt.
+
+Custom editors can write the same key when their selection is not represented by native browser selection:
+
+```tsx
+await fetch(
+  agentNativePath("/_agent-native/application-state/pending-selection-context"),
+  {
+    method: "PUT",
+    keepalive: true,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      text: selectedMarkdown,
+      capturedAt: Date.now(),
+    }),
+  },
+);
+```
+
+Use `pending-selection-context` for one-shot "act on this exact highlighted text" flows. Use `selection` for durable object selection that `view-screen` and dynamic suggestions should keep seeing.
+
 ## The view-screen action {#view-screen-action}
 
-Every template should have a `view-screen` action. It reads navigation state, fetches the relevant data, and returns a snapshot of what the user sees. This is the agent's eyes.
+Every template should have a `view-screen` action. It reads navigation and selection state, fetches the relevant data, and returns a snapshot of what the user sees. This is the agent's eyes.
 
 ```ts
 // actions/view-screen.ts
 import { defineAction } from "@agent-native/core";
 import { readAppState } from "@agent-native/core/application-state";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 
 export default defineAction({
   description:
-    "See what the user is currently looking at on screen. Reads navigation state and fetches matching data.",
+    "See what the user is currently looking at on screen. Reads navigation and selection state and fetches matching data.",
   schema: z.object({}),
   http: false,
   run: async () => {
     const navigation = (await readAppState("navigation")) as any;
+    const selection = (await readAppState("selection")) as any;
     const screen: Record<string, unknown> = {};
     if (navigation) screen.navigation = navigation;
+    if (selection) screen.selection = selection;
 
     const db = getDb();
 
@@ -84,6 +189,12 @@ export default defineAction({
         .from(schema.threads)
         .where(eq(schema.threads.id, navigation.threadId));
     }
+    if (selection?.kind === "email.messages") {
+      screen.selectedMessages = await db
+        .select()
+        .from(schema.emails)
+        .where(inArray(schema.emails.id, selection.messageIds));
+    }
 
     if (Object.keys(screen).length === 0) {
       return "No application state found. Is the app running?";
@@ -93,14 +204,68 @@ export default defineAction({
 });
 ```
 
-The agent should always call `pnpm action view-screen` before acting. This is a hard convention across all templates. When adding new features, update `view-screen` to return data for the new view.
+The agent should call `pnpm action view-screen` before acting on the current UI. This is a hard convention across all templates. When adding new features, update `view-screen` to return data for the new view and any new selection shape.
+
+## Prompt handoff with `sendToAgentChat()` {#send-to-agent-chat}
+
+Sometimes context should not just sit in app state. A user clicks a button, drops a comment pin, selects an item and chooses "Ask agent", or presses an AI command in a toolbar. That click is an instruction. In browser UI, hand it to the agent with `sendToAgentChat()`.
+
+```tsx
+import { sendToAgentChat } from "@agent-native/core/client";
+
+function askAgentAboutSelection(selection: {
+  documentId: string;
+  blockId: string;
+  label: string;
+  text: string;
+}) {
+  sendToAgentChat({
+    message: `Improve the selected block: ${selection.label}`,
+    context: [
+      `Document id: ${selection.documentId}`,
+      `Block id: ${selection.blockId}`,
+      "Current selected text:",
+      selection.text,
+    ].join("\n"),
+    submit: false,
+    openSidebar: true,
+  });
+}
+```
+
+Use the fields deliberately:
+
+| Field               | Meaning                                                                          |
+| ------------------- | -------------------------------------------------------------------------------- |
+| `message`           | Visible prompt text shown in chat                                                |
+| `context`           | Hidden model-visible context, not shown as user-facing chat text                 |
+| `submit: true`      | Send immediately; good for explicit command buttons such as "Fix layout"         |
+| `submit: false`     | Prefill for user review; good for "Ask agent about this" or ambiguous selections |
+| `openSidebar: true` | Make the agent response visible even if the panel was collapsed                  |
+| `newTab: true`      | Start a separate chat thread for a larger creation task                          |
+| `type: "code"`      | Route to the code-editing frame when the request is about changing app source    |
+
+`sendToAgentChat()` is the supported browser wrapper for the submitted-chat path sometimes seen internally as `agentNative.submitChat`. App UI should call the wrapper instead of posting `agentNative.submitChat` directly because the wrapper handles local sidebars, Builder/Frame routing, MCP App host routing, tab IDs, and code-request routing.
+
+Use `agentChat.submit()` or `agentChat.prefill()` for Node/script contexts where there is no browser sidebar. Server actions generally should not call browser-only `sendToAgentChat()`; if an action needs the open UI to ask the agent something, write a small request into `application_state` and let a UI bridge send it from the browser.
+
+### Clicked items in the prompt {#clicked-items-in-prompt}
+
+For the "click items in the UI and they become part of the prompt" experience, combine selection state with prompt handoff:
+
+1. On click or multi-select, write semantic `selection` state so `view-screen`, dynamic suggestions, and future turns can see it.
+2. If the click is also a command, call `sendToAgentChat()` with a concise visible `message` and richer hidden `context`.
+3. In `view-screen`, hydrate the selected IDs into current records so the agent can verify the object before mutating it.
+4. Clear `selection` when the object is no longer selected, deleted, or no longer relevant.
+
+That gives the user the magic "this is what I meant" behavior without stuffing every prompt with bulky visible context.
 
 ## The navigate action {#navigate-action}
 
 The agent writes a one-shot `navigate` command to application-state. The UI reads it, performs the navigation, and deletes the entry.
 
 ```ts
-// Agent side — write a navigate command
+// Agent side -- write a navigate command
 import { writeAppState } from "@agent-native/core/application-state";
 
 await writeAppState("navigate", { view: "inbox", threadId: "thread-123" });
@@ -109,7 +274,7 @@ await writeAppState("navigate", { view: "inbox", threadId: "thread-123" });
 The UI polls for this command and navigates when it appears:
 
 ```ts
-// UI side — poll for navigate commands
+// UI side -- poll for navigate commands
 const { data: navCommand } = useQuery({
   queryKey: ["navigate-command"],
   queryFn: async () => {
@@ -133,7 +298,7 @@ useEffect(() => {
 }, [navCommand]);
 ```
 
-The `navigation` key belongs to the UI — the agent should never write to it directly. Instead, the agent writes to `navigate`, and the UI performs the actual navigation (which then updates `navigation`).
+The `navigation` key belongs to the UI -- the agent should never write to it directly. Instead, the agent writes to `navigate`, and the UI performs the actual navigation, which then updates `navigation`.
 
 ## useNavigationState hook {#use-navigation-state}
 
@@ -158,7 +323,7 @@ export function useNavigationState() {
 }
 ```
 
-The `deriveNavigationState()` function is template-specific — it parses the URL path and extracts the view, item IDs, and filters relevant to your app.
+The `deriveNavigationState()` function is template-specific -- it parses the URL path and extracts the view, item IDs, and filters relevant to your app.
 
 ## Jitter prevention {#jitter-prevention}
 
@@ -179,5 +344,5 @@ How it works:
 - Agent writes are tagged with `requestSource: "agent"` (the action helpers do this automatically)
 - UI writes include the tab's unique ID via `X-Request-Source` header
 - The server stores the source on each event
-- When processing sync events, the UI filters out events matching its own `ignoreSource` value — so it doesn't refetch data it just wrote
+- When processing sync events, the UI filters out events matching its own `ignoreSource` value -- so it doesn't refetch data it just wrote
 - Events from agents, other tabs, and actions still come through normally

--- a/packages/core/src/templates/default/AGENTS.md
+++ b/packages/core/src/templates/default/AGENTS.md
@@ -8,7 +8,7 @@ This is an **@agent-native/core** application -- the AI agent and UI share state
 
 1. **Shared SQL database** -- All app state lives in SQL. Local SQLite at `data/app.db` is the zero-setup dev fallback; deployed apps need a persistent `DATABASE_URL` so data survives container/serverless restarts. Turso is optional, not required: Neon, Supabase, Turso/libSQL, plain Postgres, durable SQLite, D1 bindings, and Builder.io-managed environments are all valid when supported by the deploy. Core stores: `application_state`, `settings`, `oauth_tokens`, `sessions`, `resources`.
 2. **All AI through agent chat** -- No inline LLM calls. UI delegates to the AI via `sendToAgentChat()` / `agentChat.submit()`.
-3. **Actions for agent operations** -- `pnpm action <name>` dispatches to callable action files in `actions/`.
+3. **Actions for app operations** -- `pnpm action <name>` dispatches to callable action files in `actions/`; `defineAction` also auto-exposes those operations at `/_agent-native/actions/:name` for the UI. Do not create custom REST routes that re-export actions.
 4. **Live sync keeps the UI current** -- Database writes stream over `/_agent-native/events` first, with `/_agent-native/poll` as the fallback. **When you (the agent) write data, the UI must reflect the change without a manual refresh.** This is non-negotiable. Use `useActionQuery` / `useActionMutation` for action-backed data (preferred). If you use raw `useQuery`, fold `useChangeVersions([<source>, "action"])` into the key for targeted refreshes. See the `real-time-sync` and `adding-a-feature` skills.
 5. **Agent can update code** -- The agent can modify this app's source code directly.
 
@@ -61,7 +61,7 @@ The `navigation` key is written by the UI whenever the route changes. The `navig
 
 This app may be mounted under `/<app-id>` in a workspace. Inside app source, React Router paths are app-local: use `<Link to="/review">` and `navigate("/review")`, not `/<app-id>/review`. The workspace gateway and `APP_BASE_PATH` add the mounted prefix in the browser; hardcoding it inside React Router links causes doubled URLs such as `/<app-id>/<app-id>/review`.
 
-For raw paths outside React Router, use the core helpers: `appPath()` for static assets or normal hrefs, `appApiPath()` for `/api/*`, and `agentNativePath()` for `/_agent-native/*`.
+For raw paths outside React Router, use the core helpers: `appPath()` for static assets or normal hrefs, `appApiPath()` for legitimate route-only `/api/*` endpoints, and `agentNativePath()` for `/_agent-native/*`. Do not use `appApiPath()` to build action-backed CRUD wrappers.
 
 ## Agent Operations
 
@@ -76,6 +76,11 @@ A `<current-screen>` block is auto-injected into every user message with the cur
 You do NOT get auto-injected screen state. **Call `pnpm action view-screen` at the start of every task and before any edit** so you're acting on the IDs the user currently sees, not what was open earlier. Do not rely on cached context from previous turns.
 
 ### Actions
+
+Use existing domain actions before reaching for SQL or custom routes. If a
+capability is missing, add or extend a `defineAction` so both the agent and UI
+share the same operation. Do not create `/api/*` routes that only call,
+repackage, or proxy an action.
 
 | Action        | Args                                                                           | Purpose                                                                                 |
 | ------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
@@ -120,7 +125,7 @@ Skills in `.agents/skills/` provide detailed guidance for each architectural rul
 
 1. **Add navigation state entries** — extend `app/hooks/use-navigation-state.ts` to track new routes
 2. **Enhance view-screen** — make the view-screen script return relevant context for the new view
-3. **Create domain actions** — add actions in `actions/` for CRUD operations on new data models
+3. **Create domain actions** — add actions in `actions/` for CRUD operations on new data models; do not create REST wrappers around those actions
 4. **Wire UI for auto-refresh** — use `useActionQuery` / `useActionMutation` for normal CRUD. If a raw `useQuery` is unavoidable, fold `useChangeVersions([<source>, "action"])` into its key with `placeholderData`. When the agent mutates this data, the UI must reflect the change without a manual refresh. See `real-time-sync` skill.
 5. **Create domain skills** — add `.agents/skills/<feature>/SKILL.md` documenting the data model, storage patterns, and agent operations
 6. **Update this AGENTS.md** — add the new actions, state keys, and common tasks

--- a/packages/core/src/templates/workspace-core/AGENTS.md
+++ b/packages/core/src/templates/workspace-core/AGENTS.md
@@ -74,7 +74,9 @@ create `defineAction` files in `actions/`, mark reads with
 `http: { method: "GET" }`, and call them from React with `useActionQuery` /
 `useActionMutation`. Do not add duplicate JSON CRUD routes under `/api/*` for
 the same data unless the route is for uploads, streaming, webhooks, OAuth, or
-another route-only concern. Action-backed UI is what makes agent-created or
+another route-only concern. Do not add routes whose main job is to wrap,
+proxy, or re-export an action; the action endpoint already exists at
+`/_agent-native/actions/:name`. Action-backed UI is what makes agent-created or
 agent-edited records appear without a manual refresh.
 
 App database code must be provider-agnostic. Define schemas with

--- a/packages/core/src/templates/workspace-root/AGENTS.md
+++ b/packages/core/src/templates/workspace-root/AGENTS.md
@@ -101,8 +101,10 @@ coding agents can discover the same workspace-wide guidance from the root.
   `http: { method: "GET" }`, and call them from React with `useActionQuery` /
   `useActionMutation`. Do not add duplicate JSON CRUD routes under `/api/*`
   for the same data unless the route is for uploads, streaming, webhooks,
-  OAuth, or another route-only concern. Action-backed UI is what makes
-  agent-created or agent-edited records appear without a manual refresh.
+  OAuth, or another route-only concern. Do not add routes whose main job is to
+  wrap, proxy, or re-export an action; the action endpoint already exists at
+  `/_agent-native/actions/:name`. Action-backed UI is what makes agent-created
+  or agent-edited records appear without a manual refresh.
 - App database code must be provider-agnostic. Define schemas with
   `@agent-native/core/db/schema` helpers and write app reads/writes with
   Drizzle's query builder and portable `drizzle-orm` operators. Do not import

--- a/templates/content/app/components/sidebar/DocumentSidebar.layout.test.ts
+++ b/templates/content/app/components/sidebar/DocumentSidebar.layout.test.ts
@@ -27,4 +27,14 @@ describe("document sidebar layout", () => {
     expect(treeItem).toContain("{canEdit && (");
     expect(treeItem).toContain("{canManage && (");
   });
+
+  it("keeps active ancestor expansion separate from user-expanded state", () => {
+    const sidebar = readSidebarSource("./DocumentSidebar.tsx");
+
+    expect(sidebar).toContain("const activeAncestorIds = useMemo");
+    expect(sidebar).toContain(
+      "for (const id of activeAncestorIds) expandedIds.add(id)",
+    );
+    expect(sidebar).toContain("if (activeAncestorIds.has(id)) return");
+  });
 });

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -121,8 +121,8 @@ export function DocumentSidebar({
   const updateDocument = useUpdateDocument();
   const [searchQuery, setSearchQuery] = useState("");
   const [isSearching, setIsSearching] = useState(false);
-  // Track which nodes have been explicitly expanded by the user.
-  // Child trees default to collapsed, but active child ancestors open below.
+  // Track user-expanded nodes only; active ancestors are derived below so they
+  // do not stay open after navigation unless the user explicitly expanded them.
   const expandedIdsRef = useRef(new Set<string>());
   const [, forceUpdate] = useState(0);
   const [isResizing, setIsResizing] = useState(false);
@@ -173,32 +173,33 @@ export function DocumentSidebar({
     [documents],
   );
 
-  const expandedIds = new Set(expandedIdsRef.current);
-
-  useEffect(() => {
-    if (!activeDocumentId) return;
-
-    let changed = false;
-    let parentId = parentByDocumentId.get(activeDocumentId) ?? null;
-    while (parentId) {
-      if (!expandedIdsRef.current.has(parentId)) {
-        expandedIdsRef.current.add(parentId);
-        changed = true;
-      }
+  const activeAncestorIds = useMemo(() => {
+    const ids = new Set<string>();
+    let parentId = activeDocumentId
+      ? (parentByDocumentId.get(activeDocumentId) ?? null)
+      : null;
+    while (parentId && !ids.has(parentId)) {
+      ids.add(parentId);
       parentId = parentByDocumentId.get(parentId) ?? null;
     }
-
-    if (changed) forceUpdate((n) => n + 1);
+    return ids;
   }, [activeDocumentId, parentByDocumentId]);
 
-  const handleToggleExpanded = useCallback((id: string) => {
-    if (expandedIdsRef.current.has(id)) {
-      expandedIdsRef.current.delete(id);
-    } else {
-      expandedIdsRef.current.add(id);
-    }
-    forceUpdate((n) => n + 1);
-  }, []);
+  const expandedIds = new Set(expandedIdsRef.current);
+  for (const id of activeAncestorIds) expandedIds.add(id);
+
+  const handleToggleExpanded = useCallback(
+    (id: string) => {
+      if (activeAncestorIds.has(id)) return;
+      if (expandedIdsRef.current.has(id)) {
+        expandedIdsRef.current.delete(id);
+      } else {
+        expandedIdsRef.current.add(id);
+      }
+      forceUpdate((n) => n + 1);
+    },
+    [activeAncestorIds],
+  );
 
   const navigateToDocument = useCallback(
     (id: string) => {

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -121,9 +121,9 @@ export function DocumentSidebar({
   const updateDocument = useUpdateDocument();
   const [searchQuery, setSearchQuery] = useState("");
   const [isSearching, setIsSearching] = useState(false);
-  // Track which nodes have been explicitly collapsed by the user.
-  // All nodes default to expanded; only collapsed IDs are tracked.
-  const collapsedIds = useRef(new Set<string>());
+  // Track which nodes have been explicitly expanded by the user.
+  // Child trees default to collapsed, but active child ancestors open below.
+  const expandedIdsRef = useRef(new Set<string>());
   const [, forceUpdate] = useState(0);
   const [isResizing, setIsResizing] = useState(false);
   const sensors = useSensors(
@@ -173,10 +173,7 @@ export function DocumentSidebar({
     [documents],
   );
 
-  // Build expanded set: all document IDs except those explicitly collapsed
-  const expandedIds = new Set(
-    documents.map((d) => d.id).filter((id) => !collapsedIds.current.has(id)),
-  );
+  const expandedIds = new Set(expandedIdsRef.current);
 
   useEffect(() => {
     if (!activeDocumentId) return;
@@ -184,7 +181,10 @@ export function DocumentSidebar({
     let changed = false;
     let parentId = parentByDocumentId.get(activeDocumentId) ?? null;
     while (parentId) {
-      if (collapsedIds.current.delete(parentId)) changed = true;
+      if (!expandedIdsRef.current.has(parentId)) {
+        expandedIdsRef.current.add(parentId);
+        changed = true;
+      }
       parentId = parentByDocumentId.get(parentId) ?? null;
     }
 
@@ -192,10 +192,10 @@ export function DocumentSidebar({
   }, [activeDocumentId, parentByDocumentId]);
 
   const handleToggleExpanded = useCallback((id: string) => {
-    if (collapsedIds.current.has(id)) {
-      collapsedIds.current.delete(id);
+    if (expandedIdsRef.current.has(id)) {
+      expandedIdsRef.current.delete(id);
     } else {
-      collapsedIds.current.add(id);
+      expandedIdsRef.current.add(id);
     }
     forceUpdate((n) => n + 1);
   }, []);


### PR DESCRIPTION
## Summary
- default nested document sidebar child trees to collapsed
- keep ancestors of the active document expanded so the current document remains visible
- preserve manual expand/collapse toggling with an explicit expanded-id set

## Tests
- pnpm --filter ./templates/content typecheck
- pnpm --filter ./templates/content test