### PR TITLE
Improve docs template page mobile layout

### DIFF
--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -160,6 +160,59 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Template detail pages */
+.template-detail-page {
+  max-width: min(1200px, 100%);
+}
+
+.template-detail-page :where(.grid) > * {
+  min-width: 0;
+}
+
+.template-detail-page :where(h1, p) {
+  overflow-wrap: break-word;
+}
+
+.template-detail-page h1 {
+  text-wrap: balance;
+}
+
+.template-detail-actions > :where(a, button) {
+  min-width: 0;
+  width: 100%;
+  justify-content: center;
+  text-align: center;
+}
+
+.template-detail-actions [data-template-cli-copy] {
+  grid-column: 1 / -1;
+  justify-content: flex-start;
+  text-align: left;
+}
+
+[data-template-cli-copy] {
+  width: 100%;
+  max-width: 100%;
+}
+
+[data-template-cli-copy-text] {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (min-width: 640px) {
+  .template-detail-actions > :where(a, button) {
+    width: auto;
+  }
+
+  [data-template-cli-copy] {
+    width: auto;
+    max-width: min(100%, 36rem);
+  }
+}
+
 ::selection {
   background: var(--selection);
 }

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -190,6 +190,12 @@ body {
   text-align: left;
 }
 
+.template-detail-cta-actions > :where(a, button) {
+  min-width: 0;
+  justify-content: center;
+  text-align: center;
+}
+
 [data-template-cli-copy] {
   width: 100%;
   max-width: 100%;
@@ -210,6 +216,12 @@ body {
   [data-template-cli-copy] {
     width: auto;
     max-width: min(100%, 36rem);
+  }
+}
+
+@media (max-width: 639px) {
+  .template-detail-page > section:not(:first-child) {
+    padding-block: 3rem;
   }
 }
 

--- a/packages/docs/app/routes/templates.$slug.tsx
+++ b/packages/docs/app/routes/templates.$slug.tsx
@@ -89,13 +89,19 @@ function CliCopy({ template }: { template: Template }) {
   return (
     <button
       onClick={handleCopy}
-      className="flex min-w-0 items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-5 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)]"
+      data-template-cli-copy
+      className="flex w-full min-w-0 max-w-full items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-4 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)] sm:w-auto sm:max-w-[min(100%,36rem)] sm:px-5"
     >
       <IconTerminal2
         size={16}
         className="shrink-0 text-[var(--fg-secondary)]"
       />
-      <span className="truncate text-[var(--fg)]">{template.cliCommand}</span>
+      <span
+        data-template-cli-copy-text
+        className="min-w-0 truncate text-[var(--fg)]"
+      >
+        {template.cliCommand}
+      </span>
       <IconCopy
         size={16}
         className="ml-auto shrink-0 text-[var(--fg-secondary)]"
@@ -134,8 +140,8 @@ export default function GenericTemplatePage() {
   const sourceSlug = template.slug === "video" ? "videos" : template.slug;
 
   return (
-    <main className="mx-auto max-w-[1200px] px-6">
-      <section className="py-20">
+    <main className="template-detail-page mx-auto w-full max-w-[1200px] overflow-x-clip px-4 sm:px-6">
+      <section className="py-12 sm:py-16 lg:py-20">
         <Link
           data-an-prefetch="render"
           to="/templates"
@@ -145,7 +151,7 @@ export default function GenericTemplatePage() {
           All Templates
         </Link>
 
-        <div className="mt-8 grid gap-12 lg:grid-cols-2 lg:items-start">
+        <div className="mt-8 grid min-w-0 gap-10 lg:grid-cols-2 lg:items-start lg:gap-12">
           <div>
             <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-3 py-1 text-xs text-[var(--fg-secondary)]">
               <span
@@ -155,17 +161,17 @@ export default function GenericTemplatePage() {
               Agent-Native {template.name}
             </div>
 
-            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            <h1 className="mb-4 text-[2rem] font-bold leading-[1.08] tracking-tight sm:text-4xl md:text-5xl">
               {template.name} template
             </h1>
             <p className="mb-3 text-sm font-medium text-[var(--docs-accent)]">
               {template.replaces}
             </p>
-            <p className="mb-8 text-lg leading-relaxed text-[var(--fg-secondary)]">
+            <p className="mb-8 text-base leading-7 text-[var(--fg-secondary)] sm:text-lg sm:leading-relaxed">
               {template.description}
             </p>
 
-            <div className="mb-8 flex flex-wrap items-center gap-3">
+            <div className="template-detail-actions mb-8 grid grid-cols-2 items-stretch gap-3 sm:flex sm:flex-wrap sm:items-center">
               {hasDemoUrl && (
                 <a
                   href={template.demoUrl}

--- a/packages/docs/app/routes/templates.analytics.tsx
+++ b/packages/docs/app/routes/templates.analytics.tsx
@@ -48,11 +48,17 @@ function CliCopy() {
   return (
     <button
       onClick={handleCopy}
-      className="group flex items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-5 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)]"
+      data-template-cli-copy
+      className="group col-span-full flex w-full min-w-0 max-w-full items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-4 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)] sm:w-auto sm:max-w-[min(100%,36rem)] sm:px-5"
     >
       <span className="shrink-0 text-[var(--fg-secondary)]">$</span>
-      <span className="truncate text-[var(--fg)]">{template.cliCommand}</span>
-      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-0 transition group-hover:opacity-100">
+      <span
+        data-template-cli-copy-text
+        className="min-w-0 truncate text-[var(--fg)]"
+      >
+        {template.cliCommand}
+      </span>
+      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100">
         {copied ? (
           <svg
             width="16"
@@ -88,9 +94,9 @@ function CliCopy() {
 
 export default function AnalyticsTemplate() {
   return (
-    <main className="mx-auto max-w-[1200px] px-6">
+    <main className="template-detail-page mx-auto w-full max-w-[1200px] overflow-x-clip px-4 sm:px-6">
       {/* Hero */}
-      <section className="py-20">
+      <section className="py-12 sm:py-16 lg:py-20">
         <div className="mb-4">
           <Link
             data-an-prefetch="render"
@@ -113,7 +119,7 @@ export default function AnalyticsTemplate() {
           </Link>
         </div>
 
-        <div className="grid gap-12 lg:grid-cols-2 lg:items-start">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-2 lg:items-start lg:gap-12">
           <div>
             <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-3 py-1 text-xs text-[var(--fg-secondary)]">
               <span
@@ -123,16 +129,16 @@ export default function AnalyticsTemplate() {
               Agent-Native {template.name}
             </div>
 
-            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            <h1 className="mb-4 text-[2rem] font-bold leading-[1.08] tracking-tight sm:text-4xl md:text-5xl">
               The open-source alternative to Amplitude, Mixpanel &amp; Looker
             </h1>
 
-            <p className="mb-6 text-lg leading-relaxed text-[var(--fg-secondary)]">
+            <p className="mb-6 text-base leading-7 text-[var(--fg-secondary)] sm:text-lg sm:leading-relaxed">
               Connect any data source, prompt for any chart, build reusable
               dashboards — the AI agent writes the SQL.
             </p>
 
-            <div className="mb-8 flex flex-wrap items-center gap-3">
+            <div className="template-detail-actions mb-8 grid grid-cols-2 items-stretch gap-3 sm:flex sm:flex-wrap sm:items-center">
               <a
                 href="https://analytics.agent-native.com"
                 target="_blank"
@@ -473,8 +479,8 @@ export default function AnalyticsTemplate() {
         <h2 className="mb-8 text-2xl font-bold tracking-tight">
           How it compares
         </h2>
-        <div className="overflow-hidden rounded-xl border border-[var(--docs-border)]">
-          <table className="comparison-table w-full text-sm">
+        <div className="overflow-x-auto rounded-xl border border-[var(--docs-border)]">
+          <table className="comparison-table min-w-[42rem] w-full text-sm">
             <thead>
               <tr className="border-b border-[var(--docs-border)] bg-[var(--bg-secondary)]">
                 <th className="px-5 py-3 text-left font-semibold text-[var(--fg)]"></th>
@@ -561,7 +567,7 @@ export default function AnalyticsTemplate() {
         <p className="mx-auto mb-8 max-w-lg text-base text-[var(--fg-secondary)]">
           Fork the template, connect your data, start building dashboards.
         </p>
-        <div className="flex items-center justify-center gap-4">
+        <div className="template-detail-cta-actions flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center sm:gap-4">
           <TemplateDocsLink
             template={template}
             location="landing_page_cta"

--- a/packages/docs/app/routes/templates.calendar.tsx
+++ b/packages/docs/app/routes/templates.calendar.tsx
@@ -48,11 +48,17 @@ function CliCopy() {
   return (
     <button
       onClick={handleCopy}
-      className="group flex items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-5 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)]"
+      data-template-cli-copy
+      className="group col-span-full flex w-full min-w-0 max-w-full items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-4 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)] sm:w-auto sm:max-w-[min(100%,36rem)] sm:px-5"
     >
       <span className="shrink-0 text-[var(--fg-secondary)]">$</span>
-      <span className="truncate text-[var(--fg)]">{template.cliCommand}</span>
-      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-0 transition group-hover:opacity-100">
+      <span
+        data-template-cli-copy-text
+        className="min-w-0 truncate text-[var(--fg)]"
+      >
+        {template.cliCommand}
+      </span>
+      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100">
         {copied ? (
           <svg
             width="16"
@@ -88,9 +94,9 @@ function CliCopy() {
 
 export default function CalendarTemplate() {
   return (
-    <main className="mx-auto max-w-[1200px] px-6">
+    <main className="template-detail-page mx-auto w-full max-w-[1200px] overflow-x-clip px-4 sm:px-6">
       {/* Hero */}
-      <section className="py-20">
+      <section className="py-12 sm:py-16 lg:py-20">
         <div className="mb-4">
           <Link
             data-an-prefetch="render"
@@ -113,7 +119,7 @@ export default function CalendarTemplate() {
           </Link>
         </div>
 
-        <div className="grid gap-12 lg:grid-cols-2 lg:items-start">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-2 lg:items-start lg:gap-12">
           <div>
             <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-3 py-1 text-xs text-[var(--fg-secondary)]">
               <span
@@ -123,17 +129,17 @@ export default function CalendarTemplate() {
               Agent-Native {template.name}
             </div>
 
-            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            <h1 className="mb-4 text-[2rem] font-bold leading-[1.08] tracking-tight sm:text-4xl md:text-5xl">
               The open-source Google Calendar &amp; Calendly alternative
             </h1>
 
-            <p className="mb-6 text-lg leading-relaxed text-[var(--fg-secondary)]">
+            <p className="mb-6 text-base leading-7 text-[var(--fg-secondary)] sm:text-lg sm:leading-relaxed">
               Multi-account Google Calendar sync, configurable availability, and
               customizable Calendly-style booking links — with an AI agent that
               schedules on your behalf.
             </p>
 
-            <div className="mb-8 flex flex-wrap items-center gap-3">
+            <div className="template-detail-actions mb-8 grid grid-cols-2 items-stretch gap-3 sm:flex sm:flex-wrap sm:items-center">
               <a
                 href="https://calendar.agent-native.com"
                 target="_blank"
@@ -550,8 +556,8 @@ export default function CalendarTemplate() {
         <h2 className="mb-8 text-2xl font-bold tracking-tight">
           How it compares
         </h2>
-        <div className="overflow-hidden rounded-xl border border-[var(--docs-border)]">
-          <table className="comparison-table w-full text-sm">
+        <div className="overflow-x-auto rounded-xl border border-[var(--docs-border)]">
+          <table className="comparison-table min-w-[42rem] w-full text-sm">
             <thead>
               <tr className="border-b border-[var(--docs-border)] bg-[var(--bg-secondary)]">
                 <th className="px-5 py-3 text-left font-semibold text-[var(--fg)]"></th>
@@ -629,7 +635,7 @@ export default function CalendarTemplate() {
           Fork the template, connect Google Calendar, and start scheduling with
           AI.
         </p>
-        <div className="flex items-center justify-center gap-4">
+        <div className="template-detail-cta-actions flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center sm:gap-4">
           <TemplateDocsLink
             template={template}
             location="landing_page_cta"

--- a/packages/docs/app/routes/templates.clips.tsx
+++ b/packages/docs/app/routes/templates.clips.tsx
@@ -46,11 +46,17 @@ function CliCopy() {
   return (
     <button
       onClick={handleCopy}
-      className="group flex items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-5 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)]"
+      data-template-cli-copy
+      className="group col-span-full flex w-full min-w-0 max-w-full items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-4 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)] sm:w-auto sm:max-w-[min(100%,36rem)] sm:px-5"
     >
       <span className="shrink-0 text-[var(--fg-secondary)]">$</span>
-      <span className="truncate text-[var(--fg)]">{template.cliCommand}</span>
-      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-0 transition group-hover:opacity-100">
+      <span
+        data-template-cli-copy-text
+        className="min-w-0 truncate text-[var(--fg)]"
+      >
+        {template.cliCommand}
+      </span>
+      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100">
         {copied ? (
           <svg
             width="16"
@@ -86,9 +92,9 @@ function CliCopy() {
 
 export default function ClipsTemplate() {
   return (
-    <main className="mx-auto max-w-[1200px] px-6">
+    <main className="template-detail-page mx-auto w-full max-w-[1200px] overflow-x-clip px-4 sm:px-6">
       {/* Hero */}
-      <section className="py-20">
+      <section className="py-12 sm:py-16 lg:py-20">
         <div className="mb-4">
           <Link
             data-an-prefetch="render"
@@ -111,7 +117,7 @@ export default function ClipsTemplate() {
           </Link>
         </div>
 
-        <div className="grid gap-12 lg:grid-cols-2 lg:items-start">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-2 lg:items-start lg:gap-12">
           <div>
             <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-3 py-1 text-xs text-[var(--fg-secondary)]">
               <span
@@ -121,18 +127,18 @@ export default function ClipsTemplate() {
               Agent-Native {template.name}
             </div>
 
-            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            <h1 className="mb-4 text-[2rem] font-bold leading-[1.08] tracking-tight sm:text-4xl md:text-5xl">
               The open-source alternative to Loom, Granola, and Wisprflow
             </h1>
 
-            <p className="mb-6 text-lg leading-relaxed text-[var(--fg-secondary)]">
+            <p className="mb-6 text-base leading-7 text-[var(--fg-secondary)] sm:text-lg sm:leading-relaxed">
               One-click screen recording, calendar-synced meeting notes with AI
               summaries and action items, and Fn-hold voice dictation — all in
               one app, all transcribed, all yours. No vendor lock-in, no
               per-seat fees.
             </p>
 
-            <div className="mb-8 flex flex-wrap items-center gap-3">
+            <div className="template-detail-actions mb-8 grid grid-cols-2 items-stretch gap-3 sm:flex sm:flex-wrap sm:items-center">
               <a
                 href="https://clips.agent-native.com"
                 target="_blank"
@@ -552,8 +558,8 @@ export default function ClipsTemplate() {
         <h2 className="mb-8 text-2xl font-bold tracking-tight">
           How it compares
         </h2>
-        <div className="overflow-hidden rounded-xl border border-[var(--docs-border)]">
-          <table className="comparison-table w-full text-sm">
+        <div className="overflow-x-auto rounded-xl border border-[var(--docs-border)]">
+          <table className="comparison-table min-w-[42rem] w-full text-sm">
             <thead>
               <tr className="border-b border-[var(--docs-border)] bg-[var(--bg-secondary)]">
                 <th className="px-5 py-3 text-left font-semibold text-[var(--fg)]"></th>
@@ -653,7 +659,7 @@ export default function ClipsTemplate() {
           Fork the template, plug in your storage, and start recording clips
           your team actually owns.
         </p>
-        <div className="flex items-center justify-center gap-4">
+        <div className="template-detail-cta-actions flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center sm:gap-4">
           <TemplateDocsLink
             template={template}
             location="landing_page_cta"

--- a/packages/docs/app/routes/templates.content.tsx
+++ b/packages/docs/app/routes/templates.content.tsx
@@ -48,11 +48,17 @@ function CliCopy() {
   return (
     <button
       onClick={handleCopy}
-      className="group flex items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-5 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)]"
+      data-template-cli-copy
+      className="group col-span-full flex w-full min-w-0 max-w-full items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-4 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)] sm:w-auto sm:max-w-[min(100%,36rem)] sm:px-5"
     >
       <span className="shrink-0 text-[var(--fg-secondary)]">$</span>
-      <span className="truncate text-[var(--fg)]">{template.cliCommand}</span>
-      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-0 transition group-hover:opacity-100">
+      <span
+        data-template-cli-copy-text
+        className="min-w-0 truncate text-[var(--fg)]"
+      >
+        {template.cliCommand}
+      </span>
+      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100">
         {copied ? (
           <svg
             width="16"
@@ -88,9 +94,9 @@ function CliCopy() {
 
 export default function ContentTemplate() {
   return (
-    <main className="mx-auto max-w-[1200px] px-6">
+    <main className="template-detail-page mx-auto w-full max-w-[1200px] overflow-x-clip px-4 sm:px-6">
       {/* Hero */}
-      <section className="py-20">
+      <section className="py-12 sm:py-16 lg:py-20">
         <div className="mb-4">
           <Link
             data-an-prefetch="render"
@@ -113,7 +119,7 @@ export default function ContentTemplate() {
           </Link>
         </div>
 
-        <div className="grid gap-12 lg:grid-cols-2 lg:items-start">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-2 lg:items-start lg:gap-12">
           <div>
             <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-3 py-1 text-xs text-[var(--fg-secondary)]">
               <span
@@ -123,16 +129,16 @@ export default function ContentTemplate() {
               Agent-Native {template.name}
             </div>
 
-            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            <h1 className="mb-4 text-[2rem] font-bold leading-[1.08] tracking-tight sm:text-4xl md:text-5xl">
               The open-source AI Notion alternative
             </h1>
 
-            <p className="mb-6 text-lg leading-relaxed text-[var(--fg-secondary)]">
+            <p className="mb-6 text-base leading-7 text-[var(--fg-secondary)] sm:text-lg sm:leading-relaxed">
               Write, organize, and publish with an AI agent that knows your
               brand voice — and can modify the app itself.
             </p>
 
-            <div className="mb-8 flex flex-wrap items-center gap-3">
+            <div className="template-detail-actions mb-8 grid grid-cols-2 items-stretch gap-3 sm:flex sm:flex-wrap sm:items-center">
               <a
                 href="https://content.agent-native.com"
                 target="_blank"
@@ -418,8 +424,8 @@ export default function ContentTemplate() {
         <h2 className="mb-8 text-2xl font-bold tracking-tight">
           How it compares
         </h2>
-        <div className="overflow-hidden rounded-xl border border-[var(--docs-border)]">
-          <table className="comparison-table w-full text-sm">
+        <div className="overflow-x-auto rounded-xl border border-[var(--docs-border)]">
+          <table className="comparison-table min-w-[42rem] w-full text-sm">
             <thead>
               <tr className="border-b border-[var(--docs-border)] bg-[var(--bg-secondary)]">
                 <th className="px-5 py-3 text-left font-semibold text-[var(--fg)]"></th>
@@ -496,7 +502,7 @@ export default function ContentTemplate() {
         <p className="mx-auto mb-8 max-w-lg text-base text-[var(--fg-secondary)]">
           Fork the template, connect your CMS, start writing with AI.
         </p>
-        <div className="flex items-center justify-center gap-4">
+        <div className="template-detail-cta-actions flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center sm:gap-4">
           <TemplateDocsLink
             template={template}
             location="landing_page_cta"

--- a/packages/docs/app/routes/templates.design.tsx
+++ b/packages/docs/app/routes/templates.design.tsx
@@ -46,11 +46,17 @@ function CliCopy() {
   return (
     <button
       onClick={handleCopy}
-      className="group flex items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-5 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)]"
+      data-template-cli-copy
+      className="group col-span-full flex w-full min-w-0 max-w-full items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-4 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)] sm:w-auto sm:max-w-[min(100%,36rem)] sm:px-5"
     >
       <span className="shrink-0 text-[var(--fg-secondary)]">$</span>
-      <span className="truncate text-[var(--fg)]">{template.cliCommand}</span>
-      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-0 transition group-hover:opacity-100">
+      <span
+        data-template-cli-copy-text
+        className="min-w-0 truncate text-[var(--fg)]"
+      >
+        {template.cliCommand}
+      </span>
+      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100">
         {copied ? (
           <svg
             width="16"
@@ -86,9 +92,9 @@ function CliCopy() {
 
 export default function DesignTemplate() {
   return (
-    <main className="mx-auto max-w-[1200px] px-6">
+    <main className="template-detail-page mx-auto w-full max-w-[1200px] overflow-x-clip px-4 sm:px-6">
       {/* Hero */}
-      <section className="py-20">
+      <section className="py-12 sm:py-16 lg:py-20">
         <div className="mb-4">
           <Link
             data-an-prefetch="render"
@@ -111,7 +117,7 @@ export default function DesignTemplate() {
           </Link>
         </div>
 
-        <div className="grid gap-12 lg:grid-cols-2 lg:items-start">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-2 lg:items-start lg:gap-12">
           <div>
             <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-3 py-1 text-xs text-[var(--fg-secondary)]">
               <span
@@ -121,17 +127,17 @@ export default function DesignTemplate() {
               Agent-Native {template.name}
             </div>
 
-            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            <h1 className="mb-4 text-[2rem] font-bold leading-[1.08] tracking-tight sm:text-4xl md:text-5xl">
               The open-source AI HTML prototyping studio
             </h1>
 
-            <p className="mb-6 text-lg leading-relaxed text-[var(--fg-secondary)]">
+            <p className="mb-6 text-base leading-7 text-[var(--fg-secondary)] sm:text-lg sm:leading-relaxed">
               Generate interactive Alpine/Tailwind prototypes from a prompt,
               compare variants, refine with tweak controls, and export real
               files you own.
             </p>
 
-            <div className="mb-8 flex flex-wrap items-center gap-3">
+            <div className="template-detail-actions mb-8 grid grid-cols-2 items-stretch gap-3 sm:flex sm:flex-wrap sm:items-center">
               <a
                 href="https://design.agent-native.com"
                 target="_blank"
@@ -357,8 +363,8 @@ export default function DesignTemplate() {
         <h2 className="mb-8 text-2xl font-bold tracking-tight">
           How it compares
         </h2>
-        <div className="overflow-hidden rounded-xl border border-[var(--docs-border)]">
-          <table className="comparison-table w-full text-sm">
+        <div className="overflow-x-auto rounded-xl border border-[var(--docs-border)]">
+          <table className="comparison-table min-w-[42rem] w-full text-sm">
             <thead>
               <tr className="border-b border-[var(--docs-border)] bg-[var(--bg-secondary)]">
                 <th className="px-5 py-3 text-left font-semibold text-[var(--fg)]"></th>
@@ -436,7 +442,7 @@ export default function DesignTemplate() {
           Fork the template and start generating interactive prototypes with an
           agent that edits the source.
         </p>
-        <div className="flex items-center justify-center gap-4">
+        <div className="template-detail-cta-actions flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center sm:gap-4">
           <TemplateDocsLink
             template={template}
             location="landing_page_cta"

--- a/packages/docs/app/routes/templates.dispatch.tsx
+++ b/packages/docs/app/routes/templates.dispatch.tsx
@@ -48,11 +48,17 @@ function CliCopy() {
   return (
     <button
       onClick={handleCopy}
-      className="group flex items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-5 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)]"
+      data-template-cli-copy
+      className="group col-span-full flex w-full min-w-0 max-w-full items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-4 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)] sm:w-auto sm:max-w-[min(100%,36rem)] sm:px-5"
     >
       <span className="shrink-0 text-[var(--fg-secondary)]">$</span>
-      <span className="truncate text-[var(--fg)]">{template.cliCommand}</span>
-      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-0 transition group-hover:opacity-100">
+      <span
+        data-template-cli-copy-text
+        className="min-w-0 truncate text-[var(--fg)]"
+      >
+        {template.cliCommand}
+      </span>
+      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100">
         {copied ? (
           <svg
             width="16"
@@ -88,9 +94,9 @@ function CliCopy() {
 
 export default function DispatchTemplate() {
   return (
-    <main className="mx-auto max-w-[1200px] px-6">
+    <main className="template-detail-page mx-auto w-full max-w-[1200px] overflow-x-clip px-4 sm:px-6">
       {/* Hero */}
-      <section className="py-20">
+      <section className="py-12 sm:py-16 lg:py-20">
         <div className="mb-4">
           <Link
             data-an-prefetch="render"
@@ -113,7 +119,7 @@ export default function DispatchTemplate() {
           </Link>
         </div>
 
-        <div className="grid gap-12 lg:grid-cols-2 lg:items-start">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-2 lg:items-start lg:gap-12">
           <div>
             <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-3 py-1 text-xs text-[var(--fg-secondary)]">
               <span
@@ -123,17 +129,17 @@ export default function DispatchTemplate() {
               Agent-Native {template.name}
             </div>
 
-            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            <h1 className="mb-4 text-[2rem] font-bold leading-[1.08] tracking-tight sm:text-4xl md:text-5xl">
               Your agent's home base
             </h1>
 
-            <p className="mb-6 text-lg leading-relaxed text-[var(--fg-secondary)]">
+            <p className="mb-6 text-base leading-7 text-[var(--fg-secondary)] sm:text-lg sm:leading-relaxed">
               Talk to your agent from Slack, Telegram, or any messenger and it
               routes to your other apps. Jobs, memory, approvals, and A2A
               delegation — all in one place.
             </p>
 
-            <div className="mb-8 flex flex-wrap items-center gap-3">
+            <div className="template-detail-actions mb-8 grid grid-cols-2 items-stretch gap-3 sm:flex sm:flex-wrap sm:items-center">
               <a
                 href="https://dispatch.agent-native.com"
                 target="_blank"
@@ -538,8 +544,8 @@ export default function DispatchTemplate() {
         <h2 className="mb-8 text-2xl font-bold tracking-tight">
           How it compares
         </h2>
-        <div className="overflow-hidden rounded-xl border border-[var(--docs-border)]">
-          <table className="comparison-table w-full text-sm">
+        <div className="overflow-x-auto rounded-xl border border-[var(--docs-border)]">
+          <table className="comparison-table min-w-[42rem] w-full text-sm">
             <thead>
               <tr className="border-b border-[var(--docs-border)] bg-[var(--bg-secondary)]">
                 <th className="px-5 py-3 text-left font-semibold text-[var(--fg)]"></th>
@@ -617,7 +623,7 @@ export default function DispatchTemplate() {
           Fork the template, connect Slack or Telegram, and put your agent in
           every conversation.
         </p>
-        <div className="flex items-center justify-center gap-4">
+        <div className="template-detail-cta-actions flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center sm:gap-4">
           <TemplateDocsLink
             template={template}
             location="landing_page_cta"

--- a/packages/docs/app/routes/templates.forms.tsx
+++ b/packages/docs/app/routes/templates.forms.tsx
@@ -48,11 +48,17 @@ function CliCopy() {
   return (
     <button
       onClick={handleCopy}
-      className="group flex items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-5 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)]"
+      data-template-cli-copy
+      className="group col-span-full flex w-full min-w-0 max-w-full items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-4 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)] sm:w-auto sm:max-w-[min(100%,36rem)] sm:px-5"
     >
       <span className="shrink-0 text-[var(--fg-secondary)]">$</span>
-      <span className="truncate text-[var(--fg)]">{template.cliCommand}</span>
-      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-0 transition group-hover:opacity-100">
+      <span
+        data-template-cli-copy-text
+        className="min-w-0 truncate text-[var(--fg)]"
+      >
+        {template.cliCommand}
+      </span>
+      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100">
         {copied ? (
           <svg
             width="16"
@@ -88,9 +94,9 @@ function CliCopy() {
 
 export default function FormsTemplate() {
   return (
-    <main className="mx-auto max-w-[1200px] px-6">
+    <main className="template-detail-page mx-auto w-full max-w-[1200px] overflow-x-clip px-4 sm:px-6">
       {/* Hero */}
-      <section className="py-20">
+      <section className="py-12 sm:py-16 lg:py-20">
         <div className="mb-4">
           <Link
             data-an-prefetch="render"
@@ -113,7 +119,7 @@ export default function FormsTemplate() {
           </Link>
         </div>
 
-        <div className="grid gap-12 lg:grid-cols-2 lg:items-start">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-2 lg:items-start lg:gap-12">
           <div>
             <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-3 py-1 text-xs text-[var(--fg-secondary)]">
               <span
@@ -123,18 +129,18 @@ export default function FormsTemplate() {
               Agent-Native {template.name}
             </div>
 
-            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            <h1 className="mb-4 text-[2rem] font-bold leading-[1.08] tracking-tight sm:text-4xl md:text-5xl">
               The open-source AI alternative to Typeform &amp; Google Forms
             </h1>
 
-            <p className="mb-6 text-lg leading-relaxed text-[var(--fg-secondary)]">
+            <p className="mb-6 text-base leading-7 text-[var(--fg-secondary)] sm:text-lg sm:leading-relaxed">
               Generate a full form from a prompt, refine fields
               conversationally, and route submissions to Slack, Discord, Google
               Sheets, or webhooks. Own your data and your workflow — no
               per-response fees.
             </p>
 
-            <div className="mb-8 flex flex-wrap items-center gap-3">
+            <div className="template-detail-actions mb-8 grid grid-cols-2 items-stretch gap-3 sm:flex sm:flex-wrap sm:items-center">
               <a
                 href="https://forms.agent-native.com"
                 target="_blank"
@@ -361,8 +367,8 @@ export default function FormsTemplate() {
         <h2 className="mb-8 text-2xl font-bold tracking-tight">
           How it compares
         </h2>
-        <div className="overflow-hidden rounded-xl border border-[var(--docs-border)]">
-          <table className="comparison-table w-full text-sm">
+        <div className="overflow-x-auto rounded-xl border border-[var(--docs-border)]">
+          <table className="comparison-table min-w-[42rem] w-full text-sm">
             <thead>
               <tr className="border-b border-[var(--docs-border)] bg-[var(--bg-secondary)]">
                 <th className="px-5 py-3 text-left font-semibold text-[var(--fg)]"></th>
@@ -441,7 +447,7 @@ export default function FormsTemplate() {
         <p className="mx-auto mb-8 max-w-lg text-base text-[var(--fg-secondary)]">
           Fork the template and start collecting submissions you fully own.
         </p>
-        <div className="flex items-center justify-center gap-4">
+        <div className="template-detail-cta-actions flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center sm:gap-4">
           <TemplateDocsLink
             template={template}
             location="landing_page_cta"

--- a/packages/docs/app/routes/templates.mail.tsx
+++ b/packages/docs/app/routes/templates.mail.tsx
@@ -48,11 +48,17 @@ function CliCopy() {
   return (
     <button
       onClick={handleCopy}
-      className="group flex items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-5 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)]"
+      data-template-cli-copy
+      className="group col-span-full flex w-full min-w-0 max-w-full items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-4 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)] sm:w-auto sm:max-w-[min(100%,36rem)] sm:px-5"
     >
       <span className="shrink-0 text-[var(--fg-secondary)]">$</span>
-      <span className="truncate text-[var(--fg)]">{template.cliCommand}</span>
-      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-0 transition group-hover:opacity-100">
+      <span
+        data-template-cli-copy-text
+        className="min-w-0 truncate text-[var(--fg)]"
+      >
+        {template.cliCommand}
+      </span>
+      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100">
         {copied ? (
           <svg
             width="16"
@@ -88,9 +94,9 @@ function CliCopy() {
 
 export default function MailTemplate() {
   return (
-    <main className="mx-auto max-w-[1200px] px-6">
+    <main className="template-detail-page mx-auto w-full max-w-[1200px] overflow-x-clip px-4 sm:px-6">
       {/* Hero */}
-      <section className="py-20">
+      <section className="py-12 sm:py-16 lg:py-20">
         <div className="mb-4">
           <Link
             data-an-prefetch="render"
@@ -113,7 +119,7 @@ export default function MailTemplate() {
           </Link>
         </div>
 
-        <div className="grid gap-12 lg:grid-cols-2 lg:items-start">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-2 lg:items-start lg:gap-12">
           <div>
             <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-3 py-1 text-xs text-[var(--fg-secondary)]">
               <span
@@ -123,17 +129,17 @@ export default function MailTemplate() {
               Agent-Native {template.name}
             </div>
 
-            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            <h1 className="mb-4 text-[2rem] font-bold leading-[1.08] tracking-tight sm:text-4xl md:text-5xl">
               The open-source alternative to Superhuman and Gmail
             </h1>
 
-            <p className="mb-6 text-lg leading-relaxed text-[var(--fg-secondary)]">
+            <p className="mb-6 text-base leading-7 text-[var(--fg-secondary)] sm:text-lg sm:leading-relaxed">
               Superhuman-style keyboard shortcuts, AI triage, smart search, and
               multi-account support — built on an agent you own. No subscription
               fees, no vendor lock-in.
             </p>
 
-            <div className="mb-8 flex flex-wrap items-center gap-3">
+            <div className="template-detail-actions mb-8 grid grid-cols-2 items-stretch gap-3 sm:flex sm:flex-wrap sm:items-center">
               <a
                 href="https://mail.agent-native.com"
                 target="_blank"
@@ -559,8 +565,8 @@ export default function MailTemplate() {
         <h2 className="mb-8 text-2xl font-bold tracking-tight">
           How it compares
         </h2>
-        <div className="overflow-hidden rounded-xl border border-[var(--docs-border)]">
-          <table className="comparison-table w-full text-sm">
+        <div className="overflow-x-auto rounded-xl border border-[var(--docs-border)]">
+          <table className="comparison-table min-w-[42rem] w-full text-sm">
             <thead>
               <tr className="border-b border-[var(--docs-border)] bg-[var(--bg-secondary)]">
                 <th className="px-5 py-3 text-left font-semibold text-[var(--fg)]"></th>
@@ -636,7 +642,7 @@ export default function MailTemplate() {
           Fork the template, connect your email provider, and start managing
           your inbox with AI.
         </p>
-        <div className="flex items-center justify-center gap-4">
+        <div className="template-detail-cta-actions flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center sm:gap-4">
           <TemplateDocsLink
             template={template}
             location="landing_page_cta"

--- a/packages/docs/app/routes/templates.slides.tsx
+++ b/packages/docs/app/routes/templates.slides.tsx
@@ -44,11 +44,17 @@ function CliCopy() {
   return (
     <button
       onClick={handleCopy}
-      className="group flex items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-5 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)]"
+      data-template-cli-copy
+      className="group col-span-full flex w-full min-w-0 max-w-full items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-4 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)] sm:w-auto sm:max-w-[min(100%,36rem)] sm:px-5"
     >
       <span className="shrink-0 text-[var(--fg-secondary)]">$</span>
-      <span className="truncate text-[var(--fg)]">{template.cliCommand}</span>
-      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-0 transition group-hover:opacity-100">
+      <span
+        data-template-cli-copy-text
+        className="min-w-0 truncate text-[var(--fg)]"
+      >
+        {template.cliCommand}
+      </span>
+      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100">
         {copied ? (
           <svg
             width="16"
@@ -84,9 +90,9 @@ function CliCopy() {
 
 export default function SlidesTemplate() {
   return (
-    <main className="mx-auto max-w-[1200px] px-6">
+    <main className="template-detail-page mx-auto w-full max-w-[1200px] overflow-x-clip px-4 sm:px-6">
       {/* Hero */}
-      <section className="py-20">
+      <section className="py-12 sm:py-16 lg:py-20">
         <div className="mb-4">
           <Link
             data-an-prefetch="render"
@@ -109,7 +115,7 @@ export default function SlidesTemplate() {
           </Link>
         </div>
 
-        <div className="grid gap-12 lg:grid-cols-2 lg:items-start">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-2 lg:items-start lg:gap-12">
           <div>
             <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-3 py-1 text-xs text-[var(--fg-secondary)]">
               <span
@@ -119,16 +125,16 @@ export default function SlidesTemplate() {
               Agent-Native {template.name}
             </div>
 
-            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            <h1 className="mb-4 text-[2rem] font-bold leading-[1.08] tracking-tight sm:text-4xl md:text-5xl">
               The open-source AI alternative to PowerPoint &amp; Canva
             </h1>
 
-            <p className="mb-6 text-lg leading-relaxed text-[var(--fg-secondary)]">
+            <p className="mb-6 text-base leading-7 text-[var(--fg-secondary)] sm:text-lg sm:leading-relaxed">
               Generate a full deck from a prompt, then refine conversationally
               or edit visually.
             </p>
 
-            <div className="mb-8 flex flex-wrap items-center gap-3">
+            <div className="template-detail-actions mb-8 grid grid-cols-2 items-stretch gap-3 sm:flex sm:flex-wrap sm:items-center">
               <a
                 href="https://slides.agent-native.com"
                 target="_blank"
@@ -355,8 +361,8 @@ export default function SlidesTemplate() {
         <h2 className="mb-8 text-2xl font-bold tracking-tight">
           How it compares
         </h2>
-        <div className="overflow-hidden rounded-xl border border-[var(--docs-border)]">
-          <table className="comparison-table w-full text-sm">
+        <div className="overflow-x-auto rounded-xl border border-[var(--docs-border)]">
+          <table className="comparison-table min-w-[42rem] w-full text-sm">
             <thead>
               <tr className="border-b border-[var(--docs-border)] bg-[var(--bg-secondary)]">
                 <th className="px-5 py-3 text-left font-semibold text-[var(--fg)]"></th>
@@ -433,7 +439,7 @@ export default function SlidesTemplate() {
         <p className="mx-auto mb-8 max-w-lg text-base text-[var(--fg-secondary)]">
           Fork the template and start creating presentations with AI.
         </p>
-        <div className="flex items-center justify-center gap-4">
+        <div className="template-detail-cta-actions flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center sm:gap-4">
           <TemplateDocsLink
             template={template}
             location="landing_page_cta"

--- a/packages/docs/app/routes/templates.video.tsx
+++ b/packages/docs/app/routes/templates.video.tsx
@@ -48,11 +48,17 @@ function CliCopy() {
   return (
     <button
       onClick={handleCopy}
-      className="group flex items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-5 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)]"
+      data-template-cli-copy
+      className="group col-span-full flex w-full min-w-0 max-w-full items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-4 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)] sm:w-auto sm:max-w-[min(100%,36rem)] sm:px-5"
     >
       <span className="shrink-0 text-[var(--fg-secondary)]">$</span>
-      <span className="truncate text-[var(--fg)]">{template.cliCommand}</span>
-      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-0 transition group-hover:opacity-100">
+      <span
+        data-template-cli-copy-text
+        className="min-w-0 truncate text-[var(--fg)]"
+      >
+        {template.cliCommand}
+      </span>
+      <span className="ml-auto shrink-0 text-[var(--fg-secondary)] opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100">
         {copied ? (
           <svg
             width="16"
@@ -88,9 +94,9 @@ function CliCopy() {
 
 export default function VideoTemplate() {
   return (
-    <main className="mx-auto max-w-[1200px] px-6">
+    <main className="template-detail-page mx-auto w-full max-w-[1200px] overflow-x-clip px-4 sm:px-6">
       {/* Hero */}
-      <section className="py-20">
+      <section className="py-12 sm:py-16 lg:py-20">
         <div className="mb-4">
           <Link
             data-an-prefetch="render"
@@ -113,7 +119,7 @@ export default function VideoTemplate() {
           </Link>
         </div>
 
-        <div className="grid gap-12 lg:grid-cols-2 lg:items-start">
+        <div className="grid min-w-0 gap-10 lg:grid-cols-2 lg:items-start lg:gap-12">
           <div>
             <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] bg-[var(--bg-secondary)] px-3 py-1 text-xs text-[var(--fg-secondary)]">
               <span
@@ -123,16 +129,16 @@ export default function VideoTemplate() {
               Agent-Native {template.name}
             </div>
 
-            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            <h1 className="mb-4 text-[2rem] font-bold leading-[1.08] tracking-tight sm:text-4xl md:text-5xl">
               An open-source, Agent-native video editor
             </h1>
 
-            <p className="mb-6 text-lg leading-relaxed text-[var(--fg-secondary)]">
+            <p className="mb-6 text-base leading-7 text-[var(--fg-secondary)] sm:text-lg sm:leading-relaxed">
               A full composition studio built on Remotion — keyframe animation,
               30+ easing curves, and an agent that edits with you.
             </p>
 
-            <div className="mb-8 flex flex-wrap items-center gap-3">
+            <div className="template-detail-actions mb-8 grid grid-cols-2 items-stretch gap-3 sm:flex sm:flex-wrap sm:items-center">
               <a
                 href="https://videos.agent-native.com"
                 target="_blank"
@@ -435,8 +441,8 @@ export default function VideoTemplate() {
         <h2 className="mb-8 text-2xl font-bold tracking-tight">
           How it compares
         </h2>
-        <div className="overflow-hidden rounded-xl border border-[var(--docs-border)]">
-          <table className="comparison-table w-full text-sm">
+        <div className="overflow-x-auto rounded-xl border border-[var(--docs-border)]">
+          <table className="comparison-table min-w-[42rem] w-full text-sm">
             <thead>
               <tr className="border-b border-[var(--docs-border)] bg-[var(--bg-secondary)]">
                 <th className="px-5 py-3 text-left font-semibold text-[var(--fg)]"></th>
@@ -511,7 +517,7 @@ export default function VideoTemplate() {
         <p className="mx-auto mb-8 max-w-lg text-base text-[var(--fg-secondary)]">
           Fork the template and start creating video compositions with AI.
         </p>
-        <div className="flex items-center justify-center gap-4">
+        <div className="template-detail-cta-actions flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center sm:gap-4">
           <TemplateDocsLink
             template={template}
             location="landing_page_cta"


### PR DESCRIPTION
## Summary
- tighten template detail page spacing and text sizing on small screens
- prevent horizontal overflow from template hero grids and CLI copy commands
- make template action buttons stack cleanly on mobile while preserving desktop layout

## Verification
- pnpm --filter @agent-native/docs typecheck
- pnpm --filter @agent-native/docs test