### PR TITLE
Fix file uploads failing with org-scoped Builder credentials

### DIFF
--- a/.changeset/file-upload-org-scope.md
+++ b/.changeset/file-upload-org-scope.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix file uploads failing with a misleading "needs file storage" error when Builder.io was connected at org scope. The `/_agent-native/file-upload` route (and its status endpoint) now resolve the active org and include `orgId` in the request context, so org-scoped Builder credentials are found during upload.

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -2339,13 +2339,19 @@ export function createCoreRoutesPlugin(
           // and it falls back to process.env only — missing OAuth-connected users.
           const session = await getSession(event).catch(() => null);
           const userEmail = session?.email;
+          // Include orgId so org-scoped Builder credentials resolve here too,
+          // keeping the Settings status in sync with the upload route.
+          const orgCtx = userEmail
+            ? await getOrgContext(event).catch(() => null)
+            : null;
+          const orgId = orgCtx?.orgId ?? session?.orgId ?? undefined;
           let builderConfigured = !!process.env.BUILDER_PRIVATE_KEY;
           try {
             const { resolveBuilderPrivateKey } =
               await import("./credential-provider.js");
             const resolve = () => resolveBuilderPrivateKey().then((k) => !!k);
             builderConfigured = userEmail
-              ? await runWithRequestContext({ userEmail }, resolve)
+              ? await runWithRequestContext({ userEmail, orgId }, resolve)
               : await resolve();
           } catch {
             // fall back to env check above
@@ -2400,7 +2406,14 @@ export function createCoreRoutesPlugin(
             return { error: "Unauthorized" };
           }
           const userEmail = session.email;
-          const result = await runWithRequestContext({ userEmail }, () =>
+          // Resolve the active org so org-scoped Builder credentials (written
+          // when an owner/admin connects Builder.io) are found during upload.
+          // Without orgId in the request context, resolveBuilderPrivateKey()
+          // skips the org-scope lookup and uploads fail with a misleading
+          // "needs file storage" 503 even though Builder is connected.
+          const orgCtx = await getOrgContext(event).catch(() => null);
+          const orgId = orgCtx?.orgId ?? session.orgId ?? undefined;
+          const result = await runWithRequestContext({ userEmail, orgId }, () =>
             uploadFile({
               data: filePart.data,
               filename: filePart.filename,

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -2341,10 +2341,11 @@ export function createCoreRoutesPlugin(
           const userEmail = session?.email;
           // Include orgId so org-scoped Builder credentials resolve here too,
           // keeping the Settings status in sync with the upload route.
-          const orgCtx = userEmail
-            ? await getOrgContext(event).catch(() => null)
-            : null;
-          const orgId = orgCtx?.orgId ?? session?.orgId ?? undefined;
+          let orgId = session?.orgId ?? undefined;
+          if (userEmail && !orgId) {
+            const orgCtx = await getOrgContext(event).catch(() => null);
+            orgId = orgCtx?.orgId ?? undefined;
+          }
           let builderConfigured = !!process.env.BUILDER_PRIVATE_KEY;
           try {
             const { resolveBuilderPrivateKey } =
@@ -2411,8 +2412,11 @@ export function createCoreRoutesPlugin(
           // Without orgId in the request context, resolveBuilderPrivateKey()
           // skips the org-scope lookup and uploads fail with a misleading
           // "needs file storage" 503 even though Builder is connected.
-          const orgCtx = await getOrgContext(event).catch(() => null);
-          const orgId = orgCtx?.orgId ?? session.orgId ?? undefined;
+          let orgId = session.orgId ?? undefined;
+          if (!orgId) {
+            const orgCtx = await getOrgContext(event).catch(() => null);
+            orgId = orgCtx?.orgId ?? undefined;
+          }
           const result = await runWithRequestContext({ userEmail, orgId }, () =>
             uploadFile({
               data: filePart.data,

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -2339,14 +2339,16 @@ export function createCoreRoutesPlugin(
           // and it falls back to process.env only — missing OAuth-connected users.
           const session = await getSession(event).catch(() => null);
           const userEmail = session?.email;
-          const orgId = session?.orgId ?? undefined;
           let builderConfigured = !!process.env.BUILDER_PRIVATE_KEY;
           try {
             const { resolveBuilderPrivateKey } =
               await import("./credential-provider.js");
             const resolve = () => resolveBuilderPrivateKey().then((k) => !!k);
             builderConfigured = userEmail
-              ? await runWithRequestContext({ userEmail, orgId }, resolve)
+              ? await runWithRequestContext(
+                  { userEmail, orgId: session?.orgId },
+                  resolve,
+                )
               : await resolve();
           } catch {
             // fall back to env check above
@@ -2401,14 +2403,15 @@ export function createCoreRoutesPlugin(
             return { error: "Unauthorized" };
           }
           const userEmail = session.email;
-          const orgId = session.orgId ?? undefined;
-          const result = await runWithRequestContext({ userEmail, orgId }, () =>
-            uploadFile({
-              data: filePart.data,
-              filename: filePart.filename,
-              mimeType: filePart.type,
-              ownerEmail: userEmail,
-            }),
+          const result = await runWithRequestContext(
+            { userEmail, orgId: session.orgId },
+            () =>
+              uploadFile({
+                data: filePart.data,
+                filename: filePart.filename,
+                mimeType: filePart.type,
+                ownerEmail: userEmail,
+              }),
           );
 
           if (result) {

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -2339,13 +2339,7 @@ export function createCoreRoutesPlugin(
           // and it falls back to process.env only — missing OAuth-connected users.
           const session = await getSession(event).catch(() => null);
           const userEmail = session?.email;
-          // Include orgId so org-scoped Builder credentials resolve here too,
-          // keeping the Settings status in sync with the upload route.
-          let orgId = session?.orgId ?? undefined;
-          if (userEmail && !orgId) {
-            const orgCtx = await getOrgContext(event).catch(() => null);
-            orgId = orgCtx?.orgId ?? undefined;
-          }
+          const orgId = session?.orgId ?? undefined;
           let builderConfigured = !!process.env.BUILDER_PRIVATE_KEY;
           try {
             const { resolveBuilderPrivateKey } =
@@ -2407,16 +2401,7 @@ export function createCoreRoutesPlugin(
             return { error: "Unauthorized" };
           }
           const userEmail = session.email;
-          // Resolve the active org so org-scoped Builder credentials (written
-          // when an owner/admin connects Builder.io) are found during upload.
-          // Without orgId in the request context, resolveBuilderPrivateKey()
-          // skips the org-scope lookup and uploads fail with a misleading
-          // "needs file storage" 503 even though Builder is connected.
-          let orgId = session.orgId ?? undefined;
-          if (!orgId) {
-            const orgCtx = await getOrgContext(event).catch(() => null);
-            orgId = orgCtx?.orgId ?? undefined;
-          }
+          const orgId = session.orgId ?? undefined;
           const result = await runWithRequestContext({ userEmail, orgId }, () =>
             uploadFile({
               data: filePart.data,

--- a/templates/content/app/components/editor/extensions/ImageBlock.tsx
+++ b/templates/content/app/components/editor/extensions/ImageBlock.tsx
@@ -180,28 +180,27 @@ async function blobToPng(blob: Blob): Promise<Blob> {
   return pngBlob;
 }
 
-async function fetchImageAsPng(src: string): Promise<Blob> {
-  const response = await fetch(src);
-  if (!response.ok) throw new Error("Copy failed");
-  const blob = await response.blob();
-  // PNG is the only image type the clipboard accepts across browsers, so
-  // re-encode anything that isn't already a PNG before writing it.
-  return blob.type === "image/png" ? blob : await blobToPng(blob);
-}
-
 async function copyImage(src: string) {
   try {
     if (!navigator.clipboard || typeof ClipboardItem === "undefined") {
       throw new Error("Image clipboard unavailable");
     }
 
-    // Pass a Promise to ClipboardItem so clipboard.write stays within the
-    // user gesture (required by Safari). The resolved type is always one the
-    // clipboard accepts (PNG fallback) so the write does not get rejected.
+    const response = await fetch(src);
+    if (!response.ok) throw new Error("Copy failed");
+    const blob = await response.blob();
+    const clipboardItem = ClipboardItem as typeof ClipboardItem & {
+      supports?: (type: string) => boolean;
+    };
+    const originalType = blob.type || "image/png";
+    const canCopyOriginalType =
+      originalType.startsWith("image/") &&
+      (!clipboardItem.supports || clipboardItem.supports(originalType));
+    const imageBlob = canCopyOriginalType ? blob : await blobToPng(blob);
+    const imageType = canCopyOriginalType ? originalType : "image/png";
+
     await navigator.clipboard.write([
-      new ClipboardItem({
-        "image/png": fetchImageAsPng(src),
-      }),
+      new ClipboardItem({ [imageType]: imageBlob }),
     ]);
     toast.success("Image copied.");
   } catch {

--- a/templates/content/app/components/editor/extensions/ImageBlock.tsx
+++ b/templates/content/app/components/editor/extensions/ImageBlock.tsx
@@ -180,27 +180,28 @@ async function blobToPng(blob: Blob): Promise<Blob> {
   return pngBlob;
 }
 
+async function fetchImageAsPng(src: string): Promise<Blob> {
+  const response = await fetch(src);
+  if (!response.ok) throw new Error("Copy failed");
+  const blob = await response.blob();
+  // PNG is the only image type the clipboard accepts across browsers, so
+  // re-encode anything that isn't already a PNG before writing it.
+  return blob.type === "image/png" ? blob : await blobToPng(blob);
+}
+
 async function copyImage(src: string) {
   try {
     if (!navigator.clipboard || typeof ClipboardItem === "undefined") {
       throw new Error("Image clipboard unavailable");
     }
 
-    const response = await fetch(src);
-    if (!response.ok) throw new Error("Copy failed");
-    const blob = await response.blob();
-    const clipboardItem = ClipboardItem as typeof ClipboardItem & {
-      supports?: (type: string) => boolean;
-    };
-    const originalType = blob.type || "image/png";
-    const canCopyOriginalType =
-      originalType.startsWith("image/") &&
-      (!clipboardItem.supports || clipboardItem.supports(originalType));
-    const imageBlob = canCopyOriginalType ? blob : await blobToPng(blob);
-    const imageType = canCopyOriginalType ? originalType : "image/png";
-
+    // Pass a Promise to ClipboardItem so clipboard.write stays within the
+    // user gesture (required by Safari). The resolved type is always one the
+    // clipboard accepts (PNG fallback) so the write does not get rejected.
     await navigator.clipboard.write([
-      new ClipboardItem({ [imageType]: imageBlob }),
+      new ClipboardItem({
+        "image/png": fetchImageAsPng(src),
+      }),
     ]);
     toast.success("Image copied.");
   } catch {


### PR DESCRIPTION
### Summary
Fixes file uploads in the content editor failing with a misleading "Image uploads need file storage" error even when Builder.io was properly connected at the org scope.

### Problem
When copying or uploading images in the templates/content editor, the upload would fail with an error suggesting Builder.io wasn't connected — even though it was. The issue was that the file upload route and its status endpoint were not including `orgId` in the request context, so org-scoped Builder credentials could not be resolved during the upload.

### Solution
Pass `orgId` from the active session into `runWithRequestContext` for both the Builder configuration check and the actual file upload handler, so org-scoped credentials are correctly found and used.

### Key Changes
- Updated the Builder configuration status check in `core-routes-plugin.ts` to include `orgId: session?.orgId` in the request context
- Updated the `/_agent-native/file-upload` route handler to include `orgId: session.orgId` in the request context passed to `uploadFile`


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/tessellated-ball-tiqchog7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-tessellated-ball-tiqchog7_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1023`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>tessellated-ball-tiqchog7</branchName>-->