### PR TITLE
Add generated social previews and improve agent run state

### DIFF
--- a/.changeset/agent-chat-context-nuggets.md
+++ b/.changeset/agent-chat-context-nuggets.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add a keyed agent chat composer context API for staging hidden context before the next prompt is submitted.

--- a/.changeset/agent-teams-durable-serverless-runs.md
+++ b/.changeset/agent-teams-durable-serverless-runs.md
@@ -1,0 +1,15 @@
+---
+"@agent-native/core": patch
+---
+
+Agent Teams sub-agents now run reliably on serverless hosts (Netlify/Vercel/AWS Lambda).
+
+Previously a spawned sub-agent executed as an in-process detached promise from the spawning request. Serverless hosts freeze the function the moment that response flushes, so the sub-agent was suspended mid-run and never completed — yet `spawn` had already returned `status: "running"`, which the orchestrator narrated as "done." Background "batch" jobs reported success but produced no output.
+
+Sub-agents now use the framework's durable enqueue-to-SQL + self-fire-HTTP pattern (the same one A2A async tasks and integration webhooks use): `spawnTask` enqueues the run and self-fires a fresh, HMAC-signed POST to a new `/_agent-native/agent-teams/_process-run` route, which executes the run in its own function invocation with its own timeout budget. Runs longer than one function's wall-clock checkpoint at the soft-timeout boundary and self-fire a continuation chunk (the server-side analog of the main chat's client-driven continuation), folding into one durable assistant message via a stable turn id. An atomic SQL claim makes duplicate dispatches idempotent.
+
+Status reporting is now truthful and observable: `status`/`read-result`/`list` reconcile against the durable queue (a single completed chunk at a continuation boundary no longer prematurely marks a multi-chunk task done), dropped dispatches are re-fired, and genuinely-stalled runs fail with a real message instead of hanging as "running." The RunsTray now self-heals an owner's in-flight runs on read, so it reflects precise status without waiting on the orchestrator to poll.
+
+This path is host-agnostic — it works anywhere Nitro deploys (no `waitUntil` dependency) and falls back to localhost self-dispatch in dev. It requires `APP_URL`/`URL`/`DEPLOY_URL`/`BETTER_AUTH_URL` to be set in production/shared deployments so the deployment can reach its own URL (the same requirement async A2A and webhooks already carry).
+
+Note: the previous best-effort "sub-agent finished" auto-recap on the parent thread (a second in-process run that also never survived serverless) is removed; the orchestrator is instead prompted to read `status`/`read-result`, and the RunsTray surfaces completion.

--- a/.changeset/clear-runs-tray.md
+++ b/.changeset/clear-runs-tray.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Improve background agent visibility by surfacing recent runs in the agent panel and tracking Agent Teams launches in the shared progress tray.

--- a/.changeset/dedupe-folded-tool-call-turns.md
+++ b/.changeset/dedupe-folded-tool-call-turns.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Dedupe the client export and server fold of the same tool-call turn so it no longer renders twice. Now that rebuilt tool-call ids are scoped by run (`${runId}:tc_1`) while the live client stream uses a bare counter (`tc_1`), the two copies of one turn hashed to different thread-merge fingerprints; the render-only `toolCallId` is now stripped before fingerprinting so they match again.

--- a/.changeset/fix-assistant-ui-fiber-recovery.md
+++ b/.changeset/fix-assistant-ui-fiber-recovery.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Recover the agent panel after assistant-ui React fiber unmount crashes instead of leaving the chat UI stuck behind the reset panel.

--- a/.changeset/retry-silent-run-timeouts.md
+++ b/.changeset/retry-silent-run-timeouts.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stop the agent chat from giving up on the first soft-timeout when a turn hasn't produced visible output yet. A complex first turn can spend the whole ~40s soft-timeout window "thinking" before any text or tool call, which previously surfaced "The agent stopped before finishing" with zero retries. Silent run timeouts now retry through a larger empty-continuation budget (1 → 3) so transient slow starts recover, while the cap still terminates a genuinely stuck turn with a clear message instead of looping forever.

--- a/.changeset/silent-web-stream-close-races.md
+++ b/.changeset/silent-web-stream-close-races.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Suppress Node 22 web stream close races from Vite dev socket error handling so `agent-native dev` does not crash during startup.

--- a/.changeset/social-og-images.md
+++ b/.changeset/social-og-images.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add generated Agent-Native social preview images and default OG image metadata.

--- a/.changeset/tame-assistant-ui-resource-key.md
+++ b/.changeset/tame-assistant-ui-resource-key.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prevent folded continuation turns from persisting duplicate assistant-ui tool-call resource keys, sanitize already-saved duplicates, and recover standalone prompt composers if the duplicate-key crash still appears.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ docs/superpowers
 .DS_Store
 
 /*.png
+tmp/
 
 # Playwright MCP logs
 .playwright-mcp/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -130,6 +130,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-router/dev": "^7.13.1",
     "@react-router/fs-routes": "^7.13.1",
+    "@resvg/resvg-js": "^2.6.2",
     "@sentry/browser": "^10.50.0",
     "@sentry/node": "^10.50.0",
     "@standard-schema/spec": "^1.1.0",

--- a/packages/core/src/agent/thread-data-builder.engine-messages.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.engine-messages.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { threadDataToEngineMessages } from "./thread-data-builder.js";
+
+describe("threadDataToEngineMessages", () => {
+  it("returns [] for empty / unparseable input", () => {
+    expect(threadDataToEngineMessages(undefined)).toEqual([]);
+    expect(threadDataToEngineMessages(null)).toEqual([]);
+    expect(threadDataToEngineMessages("")).toEqual([]);
+    expect(threadDataToEngineMessages("{not json")).toEqual([]);
+    expect(threadDataToEngineMessages(JSON.stringify({}))).toEqual([]);
+  });
+
+  it("rebuilds user + assistant text messages from the repo shape", () => {
+    const repo = JSON.stringify({
+      headId: "a1",
+      messages: [
+        {
+          message: {
+            id: "u1",
+            role: "user",
+            content: [{ type: "text", text: "Summarize Q3." }],
+          },
+          parentId: null,
+        },
+        {
+          message: {
+            id: "a1",
+            role: "assistant",
+            content: [
+              { type: "text", text: "Here is the summary." },
+              { type: "tool-call", toolName: "db-query", args: {} },
+            ],
+          },
+          parentId: "u1",
+        },
+      ],
+    });
+    expect(threadDataToEngineMessages(repo)).toEqual([
+      { role: "user", content: [{ type: "text", text: "Summarize Q3." }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Here is the summary." }],
+      },
+    ]);
+  });
+
+  it("accepts a string content field and skips empty/non-text messages", () => {
+    const repo = {
+      messages: [
+        { message: { id: "u1", role: "user", content: "hello" } },
+        { message: { id: "a1", role: "assistant", content: [] } }, // no text → skipped
+        { message: { id: "x1", role: "system", content: "ignored" } }, // not user/assistant
+      ],
+    };
+    expect(threadDataToEngineMessages(repo)).toEqual([
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+    ]);
+  });
+});

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -81,6 +81,32 @@ describe("buildAssistantMessage", () => {
     });
   });
 
+  it("scopes rebuilt tool call ids by run id", () => {
+    const message = buildAssistantMessage(
+      [
+        {
+          seq: 0,
+          event: { type: "tool_start", tool: "search", input: { q: "logs" } },
+        },
+        {
+          seq: 1,
+          event: { type: "tool_done", tool: "search", result: "found" },
+        },
+      ],
+      "run-tools",
+      { turnId: "turn-tools" },
+    );
+
+    expect(message?.content).toEqual([
+      expect.objectContaining({
+        type: "tool-call",
+        toolCallId: "run-tools:tc_1",
+        toolName: "search",
+        result: "found",
+      }),
+    ]);
+  });
+
   it("persists partial output from recoverable gateway errors when suppressed", () => {
     const events: RunEvent[] = [
       { seq: 0, event: { type: "text", text: "checking..." } },
@@ -405,6 +431,60 @@ describe("buildAssistantMessage", () => {
     });
     expect(repo.messages[1].message.metadata.custom.continued).toBeUndefined();
   });
+
+  it("keeps tool call ids unique when folding continuation chunks", () => {
+    const firstChunk = buildAssistantMessage(
+      [
+        {
+          seq: 0,
+          event: { type: "tool_start", tool: "search", input: { q: "one" } },
+        },
+        {
+          seq: 1,
+          event: { type: "tool_done", tool: "search", result: "one" },
+        },
+        { seq: 2, event: { type: "auto_continue", reason: "run_timeout" } },
+      ],
+      "run-fold-tools-1",
+      { suppressInternalContinuation: true, turnId: "turn-fold-tools" },
+    );
+    const secondChunk = buildAssistantMessage(
+      [
+        {
+          seq: 0,
+          event: { type: "tool_start", tool: "search", input: { q: "two" } },
+        },
+        {
+          seq: 1,
+          event: { type: "tool_done", tool: "search", result: "two" },
+        },
+        { seq: 2, event: { type: "done" } },
+      ],
+      "run-fold-tools-2",
+      { suppressInternalContinuation: true, turnId: "turn-fold-tools" },
+    );
+    expect(firstChunk).not.toBeNull();
+    expect(secondChunk).not.toBeNull();
+
+    let repo = foldAssistantTurn({ messages: [] }, firstChunk!, {
+      turnId: "turn-fold-tools",
+      runId: "run-fold-tools-1",
+    });
+    repo = foldAssistantTurn(repo, secondChunk!, {
+      turnId: "turn-fold-tools",
+      runId: "run-fold-tools-2",
+    });
+
+    const toolCallIds = repo.messages[0].message.content
+      .filter((part: any) => part.type === "tool-call")
+      .map((part: any) => part.toolCallId);
+
+    expect(toolCallIds).toEqual([
+      "run-fold-tools-1:tc_1",
+      "run-fold-tools-2:tc_1",
+    ]);
+    expect(new Set(toolCallIds).size).toBe(toolCallIds.length);
+  });
 });
 
 describe("mergeThreadDataForClientSave", () => {
@@ -712,6 +792,31 @@ describe("normalizeThreadRepository", () => {
         message: expect.objectContaining({ id: "assistant-1" }),
       }),
     ]);
+  });
+
+  it("deduplicates persisted assistant tool call ids", () => {
+    const normalized = normalizeThreadRepository({
+      messages: [
+        {
+          message: {
+            id: "assistant-1",
+            role: "assistant",
+            content: [
+              { type: "tool-call", toolCallId: "tc_1", toolName: "search" },
+              { type: "tool-call", toolCallId: "tc_1", toolName: "search" },
+              { type: "tool-call", toolCallId: "tc_1", toolName: "search" },
+            ],
+          },
+          parentId: null,
+        },
+      ],
+    });
+
+    expect(
+      normalized.messages[0].message.content.map(
+        (part: any) => part.toolCallId,
+      ),
+    ).toEqual(["tc_1", "tc_1__dedup_2", "tc_1__dedup_3"]);
   });
 });
 

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -662,6 +662,67 @@ describe("mergeThreadDataForClientSave", () => {
     ]);
   });
 
+  it("dedupes a clean client tool-call turn against the server fold of the same turn", () => {
+    // Regression: the server now scopes rebuilt tool-call ids by run
+    // (`${runId}:tc_1`) while the client's live stream uses a bare counter
+    // (`tc_1`). A cleanly-completed client export carries neither runId nor
+    // turnId (only requestMode), so without stripping the render-only id from
+    // the dedup fingerprint these two copies of ONE turn no longer match and the
+    // turn renders twice. The fingerprint must ignore toolCallId.
+    // Server fold of a tool-call turn: runId-scoped tool ids, has runId+turnId.
+    const existing = {
+      messages: [
+        {
+          message: {
+            id: "server-run-1",
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "run-1:tc_1",
+                toolName: "bigquery",
+                argsText: '{"sql":"select 1"}',
+                args: { sql: "select 1" },
+                result: "rows",
+              },
+            ],
+            status: { type: "complete", reason: "stop" },
+            metadata: { runId: "run-1", custom: { turnId: "turn-1" } },
+          },
+          parentId: null,
+        },
+      ],
+    };
+    // Client export of the SAME turn after a clean completion: tc_N ids, and the
+    // adapter stamps only requestMode (no runId, no turnId).
+    const incoming = {
+      messages: [
+        {
+          message: {
+            id: "aui-abc",
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "tc_1",
+                toolName: "bigquery",
+                argsText: '{"sql":"select 1"}',
+                args: { sql: "select 1" },
+                result: "rows",
+              },
+            ],
+            status: { type: "complete", reason: "stop" },
+            metadata: { custom: { requestMode: "chat" } },
+          },
+          parentId: null,
+        },
+      ],
+    };
+
+    const merged = mergeThreadDataForClientSave(existing, incoming);
+    expect(merged.messages).toHaveLength(1);
+  });
+
   it("matches server-persisted user attachments to later client saves by attachment metadata", () => {
     const existing = {
       messages: [

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -120,7 +120,10 @@ export function buildAssistantMessage(
     }
 
     if (event.type === "tool_start") {
-      const toolCallId = `tc_${++toolCallCounter}`;
+      toolCallCounter += 1;
+      const toolCallId = runId
+        ? `${runId}:tc_${toolCallCounter}`
+        : `tc_${toolCallCounter}`;
       const args = (event.input ?? {}) as Record<string, string>;
       content.push({
         type: "tool-call",
@@ -381,12 +384,50 @@ function normalizeMessageEntry(
 ): { message: any; parentId: string | null; runConfig?: any } | null {
   const message = getStoredMessage(entry);
   if (!messageId(message)) return null;
+  const normalizedMessage = normalizeAssistantToolCallIds(message);
   const runConfig = getStoredRunConfig(entry);
   return {
-    message,
+    message: normalizedMessage,
     parentId,
     ...(runConfig !== undefined ? { runConfig } : {}),
   };
+}
+
+function uniqueToolCallId(toolCallId: string, seen: Set<string>): string {
+  if (!seen.has(toolCallId)) return toolCallId;
+  let suffix = 2;
+  let candidate = `${toolCallId}__dedup_${suffix}`;
+  while (seen.has(candidate)) {
+    suffix += 1;
+    candidate = `${toolCallId}__dedup_${suffix}`;
+  }
+  return candidate;
+}
+
+function normalizeAssistantToolCallIds(message: any): any {
+  if (message?.role !== "assistant" || !Array.isArray(message.content)) {
+    return message;
+  }
+
+  const seen = new Set<string>();
+  let changed = false;
+  const content = message.content.map((part: any) => {
+    if (
+      part?.type !== "tool-call" ||
+      typeof part.toolCallId !== "string" ||
+      part.toolCallId.length === 0
+    ) {
+      return part;
+    }
+
+    const nextToolCallId = uniqueToolCallId(part.toolCallId, seen);
+    seen.add(nextToolCallId);
+    if (nextToolCallId === part.toolCallId) return part;
+    changed = true;
+    return { ...part, toolCallId: nextToolCallId };
+  });
+
+  return changed ? { ...message, content } : message;
 }
 
 /**
@@ -1053,7 +1094,10 @@ function appendFoldedContent(existing: any[], incoming: any[]): any[] {
       merged.push({ ...part });
     }
   }
-  return merged;
+  return normalizeAssistantToolCallIds({
+    role: "assistant",
+    content: merged,
+  }).content;
 }
 
 /**
@@ -1144,7 +1188,10 @@ export function foldAssistantTurn(
 
   const mergedMessage = {
     ...lastMsg,
-    content: mergedContent,
+    content: normalizeAssistantToolCallIds({
+      role: "assistant",
+      content: mergedContent,
+    }).content,
     // The freshest chunk's status wins: a clean done supersedes a prior
     // partial; a real error supersedes a partial.
     status: assistantMsg.status ?? lastMsg.status,

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -1,4 +1,5 @@
 import type { AgentChatAttachment, RunEvent } from "./types.js";
+import type { EngineMessage } from "./engine/types.js";
 import {
   normalizeCodeAgentTranscript,
   type CodeAgentTranscriptEvent as CoreCodeAgentTranscriptEvent,
@@ -287,6 +288,23 @@ function normalizeAttachmentIdentity(attachments: unknown): unknown {
   }));
 }
 
+// Strip the render-only `toolCallId` before fingerprinting. The id is generated
+// differently depending on who built the message — the server now scopes it by
+// run (`${runId}:tc_1`) while the client's live stream uses a bare counter
+// (`tc_1`) — so the client export and the server fold of the SAME tool-call turn
+// would otherwise hash to different fingerprints and fail to dedupe, leaving the
+// turn rendered twice. The id never participates in message identity (history
+// replay regenerates its own ids), so hashing content without it is the correct
+// notion of "same message".
+function normalizeContentForFingerprint(content: unknown): unknown {
+  if (!Array.isArray(content)) return content;
+  return content.map((part: any) =>
+    part && typeof part === "object" && part.type === "tool-call"
+      ? { ...part, toolCallId: undefined }
+      : part,
+  );
+}
+
 function messageIdentityKeys(message: any): string[] {
   const keys: string[] = [];
   if (typeof message?.id === "string" && message.id) {
@@ -315,7 +333,7 @@ function messageIdentityKeys(message: any): string[] {
     keys.push(
       `fingerprint:${JSON.stringify({
         role: message?.role,
-        content: message?.content,
+        content: normalizeContentForFingerprint(message?.content),
         attachments: normalizeAttachmentIdentity(message?.attachments),
       })}`,
     );
@@ -327,7 +345,7 @@ function messageIdentityKeys(message: any): string[] {
       keys.push(
         `user-fingerprint:${JSON.stringify({
           role: message.role,
-          content: message.content,
+          content: normalizeContentForFingerprint(message.content),
           attachments: normalizeAttachmentIdentity(message.attachments),
         })}`,
       );
@@ -472,6 +490,48 @@ export function normalizeThreadRepository(repo: any): any {
   normalized.headId =
     headId && seenIds.has(headId) ? headId : (previousId ?? null);
   return normalized;
+}
+
+/**
+ * Rebuild a flat `EngineMessage[]` from persisted thread_data (the
+ * assistant-ui ExportedMessageRepository shape). Text-only — tool calls/results
+ * are flattened to their text so a continuation run gets the conversation
+ * prefix as plain context (Anthropic's prompt cache makes the resume cheap).
+ *
+ * Used to resume a background sub-agent in a fresh function invocation (the
+ * server-side analog of the browser re-POSTing history for the main chat).
+ * Originally inlined in `integrations/webhook-handler.ts`.
+ */
+export function threadDataToEngineMessages(
+  threadData: string | Record<string, unknown> | null | undefined,
+): EngineMessage[] {
+  const messages: EngineMessage[] = [];
+  if (!threadData) return messages;
+  let data: any;
+  try {
+    data = typeof threadData === "string" ? JSON.parse(threadData) : threadData;
+  } catch {
+    return messages;
+  }
+  if (!Array.isArray(data?.messages)) return messages;
+  for (const entry of data.messages) {
+    const m = entry?.message ?? entry;
+    if (!m || (m.role !== "user" && m.role !== "assistant")) continue;
+    const text =
+      typeof m.content === "string"
+        ? m.content
+        : Array.isArray(m.content)
+          ? m.content
+              .filter(
+                (c: any) => c?.type === "text" && typeof c.text === "string",
+              )
+              .map((c: any) => c.text)
+              .join("\n")
+          : "";
+    if (!text.trim()) continue;
+    messages.push({ role: m.role, content: [{ type: "text", text }] });
+  }
+  return messages;
 }
 
 export interface CodeAgentThreadTranscriptEvent {

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -63,12 +63,13 @@ import {
   IconExternalLink,
 } from "@tabler/icons-react";
 import { FeedbackButton } from "./FeedbackButton.js";
+import { RunsTray } from "./progress/RunsTray.js";
 import {
   MultiTabAssistantChat,
   type MultiTabAssistantChatHeaderProps,
 } from "./MultiTabAssistantChat.js";
 import {
-  isAssistantUiStaleIndexError,
+  assistantUiRecoverableRenderErrorKind,
   type AssistantChatProps,
 } from "./AssistantChat.js";
 import { useDevMode } from "./use-dev-mode.js";
@@ -561,6 +562,17 @@ function AgentPanelInner({
   const switchMode = useCallback((m: PanelMode) => {
     startTransition(() => setMode(m));
   }, []);
+  const openRunThread = useCallback(
+    (threadId: string) => {
+      switchMode("chat");
+      window.dispatchEvent(
+        new CustomEvent("agent-chat:open-thread", {
+          detail: { threadId },
+        }),
+      );
+    },
+    [switchMode],
+  );
   const activateOnKeyDown = useCallback(
     (activate: () => void) => (event: React.KeyboardEvent) => {
       if (!ACTIVATE_KEYS.has(event.key)) return;
@@ -838,6 +850,14 @@ function AgentPanelInner({
             <SetupButton />
           </Suspense>
         )}
+        <RunsTray
+          pollMs={2000}
+          limit={12}
+          hideWhenIdle={false}
+          showRecent
+          triggerVariant="pill"
+          onOpenThread={openRunThread}
+        />
         <FeedbackButton
           variant="icon"
           side="bottom"
@@ -875,7 +895,14 @@ function AgentPanelInner({
         )}
       </div>
     ),
-    [onCollapse, canUseCodeTools, onToggleFullscreen, isFullscreen],
+    [
+      canUseCodeTools,
+      isFullscreen,
+      onCollapse,
+      onToggleFullscreen,
+      openRunThread,
+      storageKey,
+    ],
   );
 
   const [tabMenuOpen, setTabMenuOpen] = useState<string | null>(null);
@@ -1823,13 +1850,15 @@ class AgentPanelErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    if (isAssistantUiStaleIndexError(error)) {
+    const recoverableKind = assistantUiRecoverableRenderErrorKind(error);
+    if (recoverableKind) {
       console.warn(
-        "[agent-native] Recovering agent panel after stale UI index",
+        "[agent-native] Recovering agent panel after assistant UI render error",
+        recoverableKind,
       );
       if (this.state.staleIndexRecoveryCount >= 2) {
         console.error(
-          "[agent-native] Agent panel stale-index recovery failed",
+          "[agent-native] Agent panel assistant UI recovery failed",
           error,
           errorInfo,
         );
@@ -1887,7 +1916,7 @@ class AgentPanelErrorBoundary extends React.Component<
     if (!this.state.error) return this.props.children;
 
     if (
-      isAssistantUiStaleIndexError(this.state.error) &&
+      assistantUiRecoverableRenderErrorKind(this.state.error) &&
       this.state.staleIndexRecoveryCount < 2
     ) {
       return (

--- a/packages/core/src/client/AgentTaskCard.tsx
+++ b/packages/core/src/client/AgentTaskCard.tsx
@@ -65,12 +65,10 @@ export function AgentTaskCard({
   useEffect(() => {
     if (status !== "running") return;
     let stopped = false;
-    let pollCount = 0;
     const poll = async () => {
       while (!stopped) {
         await new Promise((r) => setTimeout(r, 3000));
         if (stopped) break;
-        pollCount++;
         try {
           const res = await fetch(
             agentNativePath(
@@ -97,41 +95,6 @@ export function AgentTaskCard({
             // Still running — update preview from persisted state
             if (task.preview) setPreview(task.preview);
             if (task.currentStep) setCurrentStep(task.currentStep);
-          }
-
-          // Fallback: every 5th poll, check if the sub-agent's run is still
-          // active. If it's gone (completed without updating app-state), mark
-          // the task as completed so the card doesn't spin forever.
-          if (pollCount % 5 === 0) {
-            try {
-              const runRes = await fetch(
-                agentNativePath(
-                  `/_agent-native/agent-chat/runs/active?threadId=${encodeURIComponent(threadId)}`,
-                ),
-              );
-              if (runRes.ok) {
-                const runData = await runRes.json();
-                // null or non-running status means the run finished
-                if (
-                  !runData ||
-                  runData.active === false ||
-                  (runData.status && runData.status !== "running") ||
-                  runData.status === "completed" ||
-                  runData.status === "errored"
-                ) {
-                  const finalStatus =
-                    runData?.status === "errored" ? "errored" : "completed";
-                  setStatus(finalStatus);
-                  setCurrentStep("");
-                  setSummary(
-                    (prev) => prev || task?.preview || "Task completed.",
-                  );
-                  break;
-                }
-              }
-            } catch {
-              // Fallback check failed — continue normal polling
-            }
           }
         } catch {
           // Polling error — continue

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -6,7 +6,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AssistantMessageListErrorBoundary,
   AssistantUiStaleIndexErrorBoundary,
+  assistantUiRecoverableRenderErrorKind,
   displayableUserMessageText,
+  isAssistantUiRecoverableRenderError,
   isAssistantUiStaleIndexError,
   latestNonRecoveryUserMessageText,
 } from "./AssistantChat.js";
@@ -72,8 +74,58 @@ describe("isAssistantUiStaleIndexError", () => {
     ).toBe(true);
   });
 
+  it("does not match other assistant-ui recoverable errors", () => {
+    expect(
+      isAssistantUiStaleIndexError(
+        new Error("Duplicate key toolCallId-tc_1 in tapResources"),
+      ),
+    ).toBe(false);
+  });
+
   it("ignores unrelated errors", () => {
     expect(isAssistantUiStaleIndexError(new Error("boom"))).toBe(false);
+  });
+});
+
+describe("assistantUiRecoverableRenderErrorKind", () => {
+  it("matches assistant-ui stale message index crashes", () => {
+    expect(
+      assistantUiRecoverableRenderErrorKind(
+        new Error("tapClientLookup: Index 79 out of bounds (length: 78)"),
+      ),
+    ).toBe("assistant-ui-stale-message-index");
+  });
+
+  it("matches React fiber unmount crashes from assistant-ui composer teardown", () => {
+    expect(
+      assistantUiRecoverableRenderErrorKind(
+        new Error(
+          "Tried to unmount a fiber that is already unmounted. This is a React internal error.",
+        ),
+      ),
+    ).toBe("assistant-ui-react-fiber-unmount");
+  });
+
+  it("matches duplicate resource-key crashes from assistant-ui composer state", () => {
+    expect(
+      assistantUiRecoverableRenderErrorKind(
+        new Error("Duplicate key toolCallId-tc_1 in tapResources"),
+      ),
+    ).toBe("assistant-ui-duplicate-resource-key");
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(assistantUiRecoverableRenderErrorKind(new Error("boom"))).toBeNull();
+  });
+});
+
+describe("isAssistantUiRecoverableRenderError", () => {
+  it("matches assistant-ui duplicate resource key crashes", () => {
+    expect(
+      isAssistantUiRecoverableRenderError(
+        new Error("Duplicate key toolCallId-tc_1 in tapResources"),
+      ),
+    ).toBe(true);
   });
 });
 
@@ -172,5 +224,61 @@ describe("AssistantUiStaleIndexErrorBoundary", () => {
     });
 
     expect(container.textContent).toContain("Recovered composer");
+  });
+
+  it("remounts any assistant-ui subtree after a React fiber unmount error", async () => {
+    let renders = 0;
+    function FlakyComposer() {
+      renders += 1;
+      if (renders === 1) {
+        throw new Error(
+          "Tried to unmount a fiber that is already unmounted. This is a React internal error.",
+        );
+      }
+      return React.createElement("div", null, "Recovered composer");
+    }
+
+    act(() => {
+      root.render(
+        React.createElement(
+          AssistantUiStaleIndexErrorBoundary,
+          { resetKey: "thread-1", componentName: "AssistantChat" },
+          React.createElement(FlakyComposer),
+        ),
+      );
+    });
+
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(container.textContent).toContain("Recovered composer");
+  });
+
+  it("remounts any assistant-ui subtree after a duplicate resource key error", async () => {
+    let renders = 0;
+    function FlakyComposer() {
+      renders += 1;
+      if (renders === 1) {
+        throw new Error("Duplicate key toolCallId-tc_1 in tapResources");
+      }
+      return React.createElement("div", null, "Recovered resources");
+    }
+
+    act(() => {
+      root.render(
+        React.createElement(
+          AssistantUiStaleIndexErrorBoundary,
+          { resetKey: "thread-1", componentName: "PromptComposer" },
+          React.createElement(FlakyComposer),
+        ),
+      );
+    });
+
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(container.textContent).toContain("Recovered resources");
   });
 });

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -60,6 +60,10 @@ import {
   readSSEStreamRaw,
 } from "./sse-event-processor.js";
 import { captureError } from "./analytics.js";
+import {
+  AssistantMessageListErrorBoundary,
+  AssistantUiStaleIndexErrorBoundary,
+} from "./assistant-ui-recovery.js";
 import { cn } from "./utils.js";
 import { writeClipboardText } from "./clipboard.js";
 import { useNearBottomAutoscroll } from "./conversation/index.js";
@@ -146,6 +150,14 @@ import {
   IconArrowsMinimize,
   IconPlus,
 } from "@tabler/icons-react";
+
+export {
+  AssistantMessageListErrorBoundary,
+  AssistantUiStaleIndexErrorBoundary,
+  assistantUiRecoverableRenderErrorKind,
+  isAssistantUiRecoverableRenderError,
+  isAssistantUiStaleIndexError,
+} from "./assistant-ui-recovery.js";
 
 class DownscalingImageAttachmentAdapter implements AttachmentAdapter {
   public accept = "image/*";
@@ -2118,121 +2130,6 @@ function UserMessageText({ text }: { text: string }) {
 
 export function displayableUserMessageText(text: string): string {
   return text.replace(/<context>[\s\S]*?<\/context>\n?/g, "").trim();
-}
-
-export function isAssistantUiStaleIndexError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error ?? "");
-  return /^tapClientLookup: Index \d+ out of bounds \(length: \d+\)$/.test(
-    message,
-  );
-}
-
-type AssistantUiStaleIndexErrorBoundaryProps = {
-  resetKey: string;
-  componentName?: string;
-  children: React.ReactNode;
-};
-
-type AssistantUiStaleIndexErrorBoundaryState = {
-  error: Error | null;
-  retryToken: number;
-};
-
-export class AssistantUiStaleIndexErrorBoundary extends React.Component<
-  AssistantUiStaleIndexErrorBoundaryProps,
-  AssistantUiStaleIndexErrorBoundaryState
-> {
-  state: AssistantUiStaleIndexErrorBoundaryState = {
-    error: null,
-    retryToken: 0,
-  };
-
-  private retryTimer: ReturnType<typeof setTimeout> | null = null;
-
-  static getDerivedStateFromError(
-    error: unknown,
-  ): Partial<AssistantUiStaleIndexErrorBoundaryState> {
-    return {
-      error: error instanceof Error ? error : new Error(String(error ?? "")),
-    };
-  }
-
-  componentDidCatch(error: unknown, info: React.ErrorInfo) {
-    if (!isAssistantUiStaleIndexError(error)) return;
-
-    captureError(error, {
-      tags: {
-        component: this.props.componentName ?? "AssistantChat",
-        recoverable: "assistant-ui-stale-message-index",
-      },
-      extra: {
-        resetKey: this.props.resetKey,
-        componentStack: info.componentStack,
-      },
-    });
-
-    if (this.retryTimer) return;
-    this.retryTimer = setTimeout(() => {
-      this.retryTimer = null;
-      this.setState((state) => {
-        if (!state.error || !isAssistantUiStaleIndexError(state.error)) {
-          return null;
-        }
-        return { error: null, retryToken: state.retryToken + 1 };
-      });
-    }, 0);
-  }
-
-  componentDidUpdate(prevProps: AssistantUiStaleIndexErrorBoundaryProps) {
-    if (
-      this.state.error &&
-      isAssistantUiStaleIndexError(this.state.error) &&
-      prevProps.resetKey !== this.props.resetKey
-    ) {
-      this.setState((state) => ({
-        error: null,
-        retryToken: state.retryToken + 1,
-      }));
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.retryTimer) {
-      clearTimeout(this.retryTimer);
-    }
-  }
-
-  render() {
-    if (this.state.error) {
-      if (!isAssistantUiStaleIndexError(this.state.error)) {
-        throw this.state.error;
-      }
-      return null;
-    }
-
-    return (
-      <React.Fragment key={`${this.props.resetKey}:${this.state.retryToken}`}>
-        {this.props.children}
-      </React.Fragment>
-    );
-  }
-}
-
-export function AssistantMessageListErrorBoundary({
-  resetKey,
-  children,
-}: {
-  resetKey: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <AssistantUiStaleIndexErrorBoundary
-      resetKey={resetKey}
-      componentName="AssistantMessageList"
-    >
-      {children}
-    </AssistantUiStaleIndexErrorBoundary>
-  );
 }
 
 function UserMessageAttachments() {

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -37,6 +37,12 @@ import {
   type AgentChatSurfaceKind,
 } from "./agent-chat-adapter.js";
 import {
+  appendAgentChatContextToMessage,
+  formatAgentChatContextItemsForPrompt,
+  normalizeAgentChatContextItem,
+  type AgentChatContextItem,
+} from "./agent-chat.js";
+import {
   useAgentDynamicSuggestions,
   type AgentDynamicSuggestionsOption,
 } from "./dynamic-suggestions.js";
@@ -3508,6 +3514,8 @@ export interface AssistantChatHandle {
   sendMessage(text: string, images?: string[]): void;
   /** Programmatically prefill the composer without submitting. */
   prefillMessage(text: string): void;
+  /** Add or replace keyed context for the next composer submission. */
+  setComposerContextItem(item: AgentChatContextItem): void;
   /** Programmatically send a recovery prompt without replacing the original request. */
   sendRecoveryMessage(
     text: string,
@@ -3902,6 +3910,52 @@ const AssistantChatInner = forwardRef<
       recoveryAction?: AgentRecoveryAction;
     }>
   >([]);
+  const [composerContextItems, setComposerContextItems] = useState<
+    AgentChatContextItem[]
+  >([]);
+  const composerContextItemsRef = useRef<AgentChatContextItem[]>([]);
+  const updateComposerContextItems = useCallback(
+    (updater: (previous: AgentChatContextItem[]) => AgentChatContextItem[]) => {
+      setComposerContextItems((previous) => {
+        const next = updater(previous);
+        composerContextItemsRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
+  const stageComposerContextItem = useCallback(
+    (rawItem: AgentChatContextItem) => {
+      const item = normalizeAgentChatContextItem(rawItem);
+      if (!item) return;
+      updateComposerContextItems((previous) => {
+        const index = previous.findIndex((current) => current.key === item.key);
+        if (index === -1) return [...previous, item];
+        return previous.map((current, currentIndex) =>
+          currentIndex === index ? item : current,
+        );
+      });
+    },
+    [updateComposerContextItems],
+  );
+  const removeComposerContextItem = useCallback(
+    (key: string) => {
+      updateComposerContextItems((previous) =>
+        previous.filter((item) => item.key !== key),
+      );
+    },
+    [updateComposerContextItems],
+  );
+  const buildComposerContextSubmission = useCallback((text: string) => {
+    const context = formatAgentChatContextItemsForPrompt(
+      composerContextItemsRef.current,
+    );
+    if (!context) return { text, includesContext: false };
+    return {
+      text: appendAgentChatContextToMessage(text, context),
+      includesContext: true,
+    };
+  }, []);
   // Tracks the JSON of the last queue we successfully persisted so the
   // debounced save effect can skip no-op writes (e.g. restore-from-server
   // on mount, or queue state that hasn't actually changed).
@@ -4862,6 +4916,7 @@ const AssistantChatInner = forwardRef<
       requestMode?: AgentRequestMode,
       intent: ComposerSubmitIntent = "queued",
       recoveryAction?: AgentRecoveryAction,
+      includeComposerContext = false,
     ) => {
       materializeFrozenReconnectContent();
       setShowContinue(false);
@@ -4880,6 +4935,10 @@ const AssistantChatInner = forwardRef<
       // exists to stop streaming from yanking the viewport, not to swallow
       // direct sends.
       markNearBottom();
+      const submitted = includeComposerContext
+        ? buildComposerContextSubmission(text)
+        : { text, includesContext: false };
+      const submittedText = submitted.text;
       const queuedAttachments = await serializeQueuedAttachments(attachments);
       const imageAttachments = createAgentImageAttachments(images);
       const messageAttachments = [
@@ -4905,7 +4964,7 @@ const AssistantChatInner = forwardRef<
               typeof crypto !== "undefined" && crypto.randomUUID
                 ? crypto.randomUUID()
                 : `q-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-            text,
+            text: submittedText,
             images,
             attachments:
               messageAttachments.length > 0 ? messageAttachments : undefined,
@@ -4917,7 +4976,7 @@ const AssistantChatInner = forwardRef<
       } else {
         threadRuntime.append({
           role: "user",
-          content: [{ type: "text", text }],
+          content: [{ type: "text", text: submittedText }],
           ...(messageAttachments.length > 0
             ? { attachments: messageAttachments }
             : {}),
@@ -4928,8 +4987,18 @@ const AssistantChatInner = forwardRef<
           ),
         } as Parameters<typeof threadRuntime.append>[0]);
       }
+      if (submitted.includesContext) {
+        updateComposerContextItems(() => []);
+      }
     },
-    [execMode, isRunning, materializeFrozenReconnectContent, threadRuntime],
+    [
+      buildComposerContextSubmission,
+      execMode,
+      isRunning,
+      materializeFrozenReconnectContent,
+      threadRuntime,
+      updateComposerContextItems,
+    ],
   );
 
   // Expose imperative handle
@@ -4941,6 +5010,10 @@ const AssistantChatInner = forwardRef<
       },
       prefillMessage(text: string) {
         tiptapRef.current?.setText(text);
+        tiptapRef.current?.focus();
+      },
+      setComposerContextItem(item: AgentChatContextItem) {
+        stageComposerContextItem(item);
         tiptapRef.current?.focus();
       },
       sendRecoveryMessage(
@@ -4979,7 +5052,13 @@ const AssistantChatInner = forwardRef<
         };
       },
     }),
-    [addToQueue, messages.length, thread.isRunning, threadRuntime],
+    [
+      addToQueue,
+      messages.length,
+      stageComposerContextItem,
+      thread.isRunning,
+      threadRuntime,
+    ],
   );
 
   const autoscrollFollowKey = useMemo(
@@ -5529,7 +5608,7 @@ const AssistantChatInner = forwardRef<
                           : composerPlaceholder
                   }
                   onSubmit={
-                    isRunning
+                    isRunning || composerContextItems.length > 0
                       ? (text, references, attachments, options) =>
                           void addToQueue(
                             text,
@@ -5538,6 +5617,8 @@ const AssistantChatInner = forwardRef<
                             attachments,
                             undefined,
                             options?.intent ?? "immediate",
+                            undefined,
+                            true,
                           )
                       : undefined
                   }
@@ -5553,6 +5634,8 @@ const AssistantChatInner = forwardRef<
                   onEffortChange={onEffortChange}
                   onConnectProvider={onConnectProvider}
                   toolbarSlot={composerToolbarSlot}
+                  contextItems={composerContextItems}
+                  onRemoveContextItem={removeComposerContextItem}
                   plusMenuMode={plusMenuMode}
                   layoutVariant={composerLayoutVariant}
                   providerConnectStatusEnabled={providerStatusChecksEnabled}

--- a/packages/core/src/client/MultiTabAssistantChat.spec.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.spec.tsx
@@ -8,6 +8,7 @@ import { MultiTabAssistantChat } from "./MultiTabAssistantChat.js";
 const chatHandleMocks = vi.hoisted(() => ({
   sendMessage: vi.fn(),
   prefillMessage: vi.fn(),
+  setComposerContextItem: vi.fn(),
   sendRecoveryMessage: vi.fn(),
   queueMessage: vi.fn(),
   focusComposer: vi.fn(),
@@ -91,6 +92,7 @@ vi.mock("./AssistantChat.js", async () => {
       React.useImperativeHandle(ref, () => ({
         sendMessage: chatHandleMocks.sendMessage,
         prefillMessage: chatHandleMocks.prefillMessage,
+        setComposerContextItem: chatHandleMocks.setComposerContextItem,
         sendRecoveryMessage: chatHandleMocks.sendRecoveryMessage,
         queueMessage: chatHandleMocks.queueMessage,
         isRunning: () => false,
@@ -177,6 +179,32 @@ describe("MultiTabAssistantChat postMessage bridge", () => {
       "Send this now",
       undefined,
     );
+    expect(chatHandleMocks.prefillMessage).not.toHaveBeenCalled();
+  });
+
+  it("adds keyed context to the active composer without prefill or submit", () => {
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: "agentNative.setChatContext",
+            data: {
+              key: "selected-element",
+              title: "Selected Element",
+              context: "<button>Buy</button>",
+            },
+          },
+          origin: window.location.origin,
+        }),
+      );
+    });
+
+    expect(chatHandleMocks.setComposerContextItem).toHaveBeenCalledWith({
+      key: "selected-element",
+      title: "Selected Element",
+      context: "<button>Buy</button>",
+    });
+    expect(chatHandleMocks.sendMessage).not.toHaveBeenCalled();
     expect(chatHandleMocks.prefillMessage).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -45,6 +45,11 @@ import {
   isReasoningEffort,
   type ReasoningEffort,
 } from "../shared/reasoning-effort.js";
+import {
+  appendAgentChatContextToMessage,
+  normalizeAgentChatContextItem,
+  type AgentChatContextItem,
+} from "./agent-chat.js";
 
 interface EngineModelGroup {
   engine: string;
@@ -765,6 +770,9 @@ export function MultiTabAssistantChat({
   if (activeThreadId) mountedTabsRef.current.add(activeThreadId);
   const chatRefs = useRef<Map<string, AssistantChatHandle>>(new Map());
   const pendingSends = useRef<Map<string, PendingSend>>(new Map());
+  const pendingContextItems = useRef<Map<string, AgentChatContextItem[]>>(
+    new Map(),
+  );
   const [runningThreads, setRunningThreads] = useState<Set<string>>(new Set());
   const [showHistory, setShowHistory] = useState(false);
   const newThreadIds = useRef<Set<string>>(new Set());
@@ -790,6 +798,26 @@ export function MultiTabAssistantChat({
     setModelSelectionVersion((version) => version + 1);
   }, []);
   const postMessageSubmissionsDisabled = props.composerDisabled === true;
+
+  const setContextInTab = useCallback(
+    (threadId: string, item: AgentChatContextItem) => {
+      const ref = chatRefs.current.get(threadId);
+      if (ref) {
+        ref.setComposerContextItem(item);
+        return;
+      }
+      const existing = pendingContextItems.current.get(threadId) ?? [];
+      const index = existing.findIndex((current) => current.key === item.key);
+      const next =
+        index === -1
+          ? [...existing, item]
+          : existing.map((current, currentIndex) =>
+              currentIndex === index ? item : current,
+            );
+      pendingContextItems.current.set(threadId, next);
+    },
+    [],
+  );
 
   const resolveThreadModelSelection = useCallback(
     (threadId: string) =>
@@ -1278,6 +1306,19 @@ export function MultiTabAssistantChat({
   useEffect(() => {
     const handler = (event: MessageEvent) => {
       if (!isTrustedFrameMessage(event)) return;
+      if (event.data?.type === "agentNative.setChatContext") {
+        const item = normalizeAgentChatContextItem(event.data.data);
+        if (!item) return;
+        const openSidebar = event.data.data?.openSidebar as boolean | undefined;
+        if (openSidebar !== false) {
+          window.dispatchEvent(new CustomEvent("agent-panel:open"));
+        }
+        if (postMessageSubmissionsDisabled) return;
+        const currentTabId = activeThreadIdRef.current;
+        if (!currentTabId) return;
+        setContextInTab(currentTabId, item);
+        return;
+      }
       if (event.data?.type !== "agentNative.submitChat") return;
       const message = event.data.data?.message as string;
       if (!message) return;
@@ -1308,7 +1349,7 @@ export function MultiTabAssistantChat({
       // Plan mode is sent as request metadata by the chat adapter. Keep the
       // user-visible message clean so mode instructions never enter history.
       const fullMessage = context
-        ? `${message}\n\n<context>\n${context}\n</context>`
+        ? appendAgentChatContextToMessage(message, context)
         : message;
 
       const sendToTab = (threadId: string) => {
@@ -1374,22 +1415,37 @@ export function MultiTabAssistantChat({
     bumpModelSelectionVersion,
     createThread,
     postMessageSubmissionsDisabled,
+    setContextInTab,
     switchThread,
   ]);
 
   // Process pending sends when refs mount
   useEffect(() => {
-    for (const [tabId, pending] of pendingSends.current) {
+    const pendingTabIds = new Set([
+      ...pendingSends.current.keys(),
+      ...pendingContextItems.current.keys(),
+    ]);
+    for (const tabId of pendingTabIds) {
       const ref = chatRefs.current.get(tabId);
       if (ref) {
-        setTimeout(() => {
-          if (pending.submit) {
-            ref.sendMessage(pending.message, pending.images);
-          } else {
-            ref.prefillMessage(pending.message);
+        const pendingContext = pendingContextItems.current.get(tabId);
+        if (pendingContext) {
+          for (const item of pendingContext) {
+            ref.setComposerContextItem(item);
           }
-        }, 50);
-        pendingSends.current.delete(tabId);
+          pendingContextItems.current.delete(tabId);
+        }
+        const pending = pendingSends.current.get(tabId);
+        if (pending) {
+          setTimeout(() => {
+            if (pending.submit) {
+              ref.sendMessage(pending.message, pending.images);
+            } else {
+              ref.prefillMessage(pending.message);
+            }
+          }, 50);
+          pendingSends.current.delete(tabId);
+        }
       }
     }
   }, [openTabIds]);
@@ -1445,6 +1501,7 @@ export function MultiTabAssistantChat({
       });
       chatRefs.current.delete(tabId);
       pendingSends.current.delete(tabId);
+      pendingContextItems.current.delete(tabId);
       newThreadIds.current.delete(tabId);
       threadModelRef.current.delete(tabId);
       // Clean up parent map and sub-agent names

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -1346,7 +1346,7 @@ describe("createAgentChatAdapter", () => {
     expect(last.content.at(-1).text).toBe("finished after idle recovery");
   });
 
-  it("stops silent run timeouts without retrying the same no-progress request", async () => {
+  it("retries silent run timeouts a few times before giving up", async () => {
     vi.useFakeTimers();
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", { dispatchEvent });
@@ -1395,7 +1395,12 @@ describe("createAgentChatAdapter", () => {
     await vi.advanceTimersByTimeAsync(1000);
     const results = await promise;
 
-    expect(postCount).toBe(1);
+    // A run that produces nothing visible no longer gives up on the first
+    // soft-timeout (that made heavier prompts feel like they "stop midway").
+    // It retries through the empty-continuation budget
+    // (MAX_EMPTY_TRANSIENT_CONTINUATIONS = 3) — 1 initial + 3 retries = 4
+    // POSTs — then surfaces the "no visible progress" error.
+    expect(postCount).toBe(4);
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "agent-chat:run-error",
@@ -1412,6 +1417,75 @@ describe("createAgentChatAdapter", () => {
     expect(last.content.at(-1).text).toContain(
       "did not produce any visible progress",
     );
+  });
+
+  it("recovers when a silent run timeout is followed by real output", async () => {
+    // The point of the empty-continuation budget: a transient slow start (the
+    // model thinks through the soft-timeout window with no visible output) must
+    // recover on a later continuation, not give up. Two empty run_timeouts
+    // followed by real text should finish cleanly with no "no visible progress"
+    // error. This is the regression that made heavier prompts feel like they
+    // "crap out / stop midway".
+    vi.useFakeTimers();
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        postCount += 1;
+        if (postCount < 3) {
+          return sseResponse([
+            { type: "auto_continue", reason: "run_timeout" },
+          ]);
+        }
+        return sseResponse([{ type: "text", text: "done" }, { type: "done" }]);
+      }
+      if (url.includes("/runs/")) {
+        return jsonResponse({ active: false, status: "idle" });
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-recover",
+      threadId: "thread-recover",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "slow analytical question" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(2000);
+    const results = await promise;
+
+    // 2 empty run_timeouts (within the budget of 3) then a successful run.
+    expect(postCount).toBe(3);
+    expect(dispatchEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "agent-chat:run-error" }),
+    );
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toBe("done");
   });
 
   it("continues once when a run timeout happened during action input streaming", async () => {
@@ -2484,9 +2558,9 @@ describe("createAgentChatAdapter", () => {
   it("counts whitespace-only output against the empty recovery cap", async () => {
     // Resetting the empty-continuation counter on a non-zero PART count let
     // whitespace-only output keep the run alive indefinitely. The counter must
-    // reset on real content-weight progress, so two whitespace-only timeouts
-    // exhaust the empty cap (1) and give up promptly instead of looping until
-    // the stalled cap (8).
+    // reset only on real content-weight progress, so whitespace-only timeouts
+    // exhaust the empty cap (MAX_EMPTY_TRANSIENT_CONTINUATIONS = 3) and give up
+    // instead of looping until the much larger stalled cap (8).
     vi.useFakeTimers();
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", { dispatchEvent });
@@ -2535,9 +2609,9 @@ describe("createAgentChatAdapter", () => {
     await vi.advanceTimersByTimeAsync(10_000);
     const results = await promise;
 
-    // 1 initial + 1 empty retry, then the empty cap (1) is exceeded — no
+    // 1 initial + 3 empty retries, then the empty cap (3) is exceeded — no
     // 10-POST runaway up to the stalled cap.
-    expect(postCount).toBe(2);
+    expect(postCount).toBe(4);
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "agent-chat:run-error",

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -69,7 +69,14 @@ const MAX_STARTUP_RECOVERY_ATTEMPTS = 8;
 const MAX_STALE_RUN_CONTINUATIONS = 3;
 const MAX_STALLED_TRANSIENT_CONTINUATIONS = 8;
 const MAX_TOTAL_TRANSIENT_CONTINUATIONS = 32;
-const MAX_EMPTY_TRANSIENT_CONTINUATIONS = 1;
+// How many consecutive continuations that produce NO progress (no streamed
+// text, no completed/in-flight tool) we tolerate before giving up. A complex
+// first turn can spend the whole soft-timeout window (~40s) "thinking" with no
+// visible output; giving up after a single such window made the agent feel like
+// it "craps out / stops midway" on heavier prompts (Analytics). Retrying a few
+// times lets a transient slow start recover, while the cap still terminates a
+// genuinely stuck turn with a clear message instead of looping forever.
+const MAX_EMPTY_TRANSIENT_CONTINUATIONS = 3;
 const RETRY_BASE_DELAY_MS = 500;
 const RETRY_MAX_DELAY_MS = 8_000;
 const MAX_HISTORY_ATTACHMENT_CHARS = 60_000;
@@ -1372,7 +1379,6 @@ export function createAgentChatAdapter(options?: {
           // Either real output or an actively-running tool counts as progress
           // for the stalled/empty caps.
           const madeProgress = madeContentProgress || hasInFlightTool;
-          const madeVisibleProgress = visibleContent.length > 0;
           const madeDurableToolProgress = visibleContent.some(
             (part) => part.type === "tool-call" && part.result !== undefined,
           );
@@ -1382,16 +1388,12 @@ export function createAgentChatAdapter(options?: {
             emptyTransientContinuationAttempts = 0;
           } else {
             totalTransientContinuationAttempts += 1;
-            const madeActivityProgress =
-              signal.activityTrail.length > 0 ||
-              Boolean(lastActivityTool(signal.activityTrail));
-            if (
-              !madeVisibleProgress &&
-              signal.reason === "run_timeout" &&
-              !madeActivityProgress
-            ) {
-              return { ok: false, resetVisibleContent: false };
-            }
+            // A run_timeout that produced nothing visible and no activity (the
+            // model spent the whole soft-timeout window thinking before its
+            // first output) is NOT an immediate give-up: a transient slow start
+            // routinely recovers on the next continuation. Let it fall through
+            // to the empty-continuation budget below so it retries a bounded
+            // number of times before surfacing the "no visible progress" error.
             // Reset the empty-continuation counter on real progress — streamed
             // text/completed tool OR an in-flight tool the server is running —
             // not merely on a non-zero part count, which whitespace-only or

--- a/packages/core/src/client/agent-chat.spec.ts
+++ b/packages/core/src/client/agent-chat.spec.ts
@@ -29,7 +29,13 @@ vi.stubGlobal("window", {
   },
 });
 
-const { sendToAgentChat, generateTabId } = await import("./agent-chat.js");
+const {
+  addContextToAgentChat,
+  formatAgentChatContextItemsForPrompt,
+  generateTabId,
+  sendToAgentChat,
+  setContextToAgentChat,
+} = await import("./agent-chat.js");
 const { _resetEmbedAuthForTests } = await import("./embed-auth.js");
 
 async function flushMicrotasks() {
@@ -336,6 +342,47 @@ describe("sendToAgentChat", () => {
     const id2 = sendToAgentChat({ message: "b" });
     expect(id1).not.toBe(id2);
   });
+
+  it("posts keyed context to the active chat without submitting", () => {
+    setContextToAgentChat({
+      key: ".thing#hello",
+      title: "Selected Element",
+      context: "<div>Hello</div>",
+    });
+
+    expect(parentPostMessageSpy).toHaveBeenCalledOnce();
+    const [payload, targetOrigin] = parentPostMessageSpy.mock.calls[0];
+    expect(targetOrigin).toBe("http://localhost:3000");
+    expect(payload).toEqual({
+      type: "agentNative.setChatContext",
+      data: {
+        key: ".thing#hello",
+        title: "Selected Element",
+        context: "<div>Hello</div>",
+      },
+    });
+    expect(dispatchEventSpy.mock.calls.map(([event]) => event.type)).toEqual([
+      "agent-panel:set-mode",
+      "agent-panel:open",
+    ]);
+  });
+
+  it("uses addContextToAgentChat as an alias for replacing keyed context", () => {
+    addContextToAgentChat({
+      key: "cart",
+      title: "Cart",
+      context: "Line item A",
+      openSidebar: false,
+    });
+
+    expect(parentPostMessageSpy).toHaveBeenCalledOnce();
+    expect(parentPostMessageSpy.mock.calls[0][0].type).toBe(
+      "agentNative.setChatContext",
+    );
+    expect(dispatchEventSpy.mock.calls.map(([event]) => event.type)).toEqual([
+      "agent-panel:prepare",
+    ]);
+  });
 });
 
 describe("generateTabId", () => {
@@ -347,5 +394,20 @@ describe("generateTabId", () => {
   it("generates unique ids", () => {
     const ids = new Set(Array.from({ length: 100 }, () => generateTabId()));
     expect(ids.size).toBe(100);
+  });
+});
+
+describe("formatAgentChatContextItemsForPrompt", () => {
+  it("formats multiple context nuggets as titled hidden prompt sections", () => {
+    expect(
+      formatAgentChatContextItemsForPrompt([
+        {
+          key: "a",
+          title: "Selected Element",
+          context: "<button>Buy</button>",
+        },
+        { key: "b", title: "Cart", context: "2 items" },
+      ]),
+    ).toBe("## Selected Element\n<button>Buy</button>\n\n## Cart\n2 items");
   });
 });

--- a/packages/core/src/client/agent-chat.ts
+++ b/packages/core/src/client/agent-chat.ts
@@ -82,7 +82,25 @@ export interface AgentChatMessage {
   background?: boolean;
 }
 
+export interface AgentChatContextItem {
+  /** Stable key used to replace an existing context nugget. */
+  key: string;
+  /** Short label shown in the composer context chip. */
+  title: string;
+  /** Hidden context included with the next submitted prompt. */
+  context: string;
+}
+
+export interface AgentChatContextMessage extends AgentChatContextItem {
+  /**
+   * Whether to open the agent sidebar if it's currently hidden.
+   * Defaults to true so the user can see the staged context.
+   */
+  openSidebar?: boolean;
+}
+
 const AGENT_CHAT_MESSAGE_TYPE = "agentNative.submitChat";
+const AGENT_CHAT_CONTEXT_MESSAGE_TYPE = "agentNative.setChatContext";
 const AGENT_PANEL_PREPARE_EVENT = "agent-panel:prepare";
 
 /**
@@ -110,6 +128,47 @@ if (typeof window !== "undefined") {
 /** Generate a unique tab ID */
 export function generateTabId(): string {
   return `chat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function normalizeAgentChatContextItem(
+  item: unknown,
+): AgentChatContextItem | null {
+  if (typeof item !== "object" || item === null) return null;
+  const candidate = item as Partial<AgentChatContextItem>;
+  if (
+    typeof candidate.key !== "string" ||
+    typeof candidate.context !== "string" ||
+    typeof candidate.title !== "string"
+  ) {
+    return null;
+  }
+  const key = candidate.key.trim();
+  const context = candidate.context.trim();
+  if (!key || !context) return null;
+  return {
+    key,
+    title: candidate.title.trim() || key,
+    context,
+  };
+}
+
+export function formatAgentChatContextItemsForPrompt(
+  items: readonly AgentChatContextItem[],
+): string {
+  return items
+    .map(normalizeAgentChatContextItem)
+    .filter((item): item is AgentChatContextItem => item !== null)
+    .map((item) => [`## ${item.title}`, item.context].join("\n"))
+    .join("\n\n");
+}
+
+export function appendAgentChatContextToMessage(
+  message: string,
+  context: string,
+): string {
+  const trimmedContext = context.trim();
+  if (!trimmedContext) return message;
+  return `${message.trim()}\n\n<context>\n${trimmedContext}\n</context>`;
 }
 
 function isMcpAppChatBridgeEnabled(): boolean {
@@ -216,3 +275,47 @@ export function sendToAgentChat(opts: AgentChatMessage): string {
   }
   return tabId;
 }
+
+/**
+ * Add or replace a keyed context nugget in the active agent chat composer.
+ * The context is not submitted until the user sends the prompt.
+ */
+export function setContextToAgentChat(opts: AgentChatContextMessage): void {
+  const item = normalizeAgentChatContextItem(opts);
+  if (!item || typeof window === "undefined") return;
+
+  const payload = {
+    type: AGENT_CHAT_CONTEXT_MESSAGE_TYPE,
+    data: item,
+  };
+  const shouldOpenSidebar = opts.openSidebar !== false;
+  const targetSelf = isInBuilderFrame() || isDirectMcpAppEmbedSession();
+  const target = targetSelf
+    ? window
+    : window.parent !== window
+      ? window.parent
+      : window;
+  const targetOrigin = targetSelf
+    ? window.location.origin
+    : getFramePostMessageTargetOrigin() || window.location.origin;
+
+  if (shouldOpenSidebar) {
+    window.dispatchEvent(
+      new CustomEvent("agent-panel:set-mode", {
+        detail: { mode: "chat" },
+      }),
+    );
+    window.dispatchEvent(new CustomEvent("agent-panel:open"));
+  } else {
+    window.dispatchEvent(new CustomEvent(AGENT_PANEL_PREPARE_EVENT));
+  }
+
+  const postToTarget = () => target.postMessage(payload, targetOrigin);
+  if (target === window) {
+    setTimeout(postToTarget, 0);
+  } else {
+    postToTarget();
+  }
+}
+
+export const addContextToAgentChat = setContextToAgentChat;

--- a/packages/core/src/client/assistant-ui-recovery.tsx
+++ b/packages/core/src/client/assistant-ui-recovery.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+
+import { captureError } from "./analytics.js";
+
+type AssistantUiRecoverableErrorKind =
+  | "assistant-ui-stale-message-index"
+  | "assistant-ui-duplicate-resource-key"
+  | "assistant-ui-react-fiber-unmount";
+
+export function assistantUiRecoverableRenderErrorKind(
+  error: unknown,
+): AssistantUiRecoverableErrorKind | null {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  if (
+    /^tapClientLookup: Index \d+ out of bounds \(length: \d+\)$/.test(message)
+  ) {
+    return "assistant-ui-stale-message-index";
+  }
+  if (/^Duplicate key .+ in tapResources$/.test(message)) {
+    return "assistant-ui-duplicate-resource-key";
+  }
+  if (/^Tried to unmount a fiber that is already unmounted\b/.test(message)) {
+    return "assistant-ui-react-fiber-unmount";
+  }
+  return null;
+}
+
+export function isAssistantUiStaleIndexError(error: unknown): boolean {
+  return (
+    assistantUiRecoverableRenderErrorKind(error) ===
+    "assistant-ui-stale-message-index"
+  );
+}
+
+export function isAssistantUiRecoverableRenderError(error: unknown): boolean {
+  return assistantUiRecoverableRenderErrorKind(error) !== null;
+}
+
+type AssistantUiStaleIndexErrorBoundaryProps = {
+  resetKey: string;
+  componentName?: string;
+  children: React.ReactNode;
+};
+
+type AssistantUiStaleIndexErrorBoundaryState = {
+  error: Error | null;
+  retryToken: number;
+};
+
+export class AssistantUiStaleIndexErrorBoundary extends React.Component<
+  AssistantUiStaleIndexErrorBoundaryProps,
+  AssistantUiStaleIndexErrorBoundaryState
+> {
+  state: AssistantUiStaleIndexErrorBoundaryState = {
+    error: null,
+    retryToken: 0,
+  };
+
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  static getDerivedStateFromError(
+    error: unknown,
+  ): Partial<AssistantUiStaleIndexErrorBoundaryState> {
+    return {
+      error: error instanceof Error ? error : new Error(String(error ?? "")),
+    };
+  }
+
+  componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    const recoverable = assistantUiRecoverableRenderErrorKind(error);
+    if (!recoverable) return;
+
+    captureError(error, {
+      tags: {
+        component: this.props.componentName ?? "AssistantChat",
+        recoverable,
+      },
+      extra: {
+        resetKey: this.props.resetKey,
+        componentStack: info.componentStack,
+      },
+    });
+
+    if (this.retryTimer) return;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      this.setState((state) => {
+        if (!state.error || !isAssistantUiRecoverableRenderError(state.error)) {
+          return null;
+        }
+        return { error: null, retryToken: state.retryToken + 1 };
+      });
+    }, 0);
+  }
+
+  componentDidUpdate(prevProps: AssistantUiStaleIndexErrorBoundaryProps) {
+    if (
+      this.state.error &&
+      isAssistantUiRecoverableRenderError(this.state.error) &&
+      prevProps.resetKey !== this.props.resetKey
+    ) {
+      this.setState((state) => ({
+        error: null,
+        retryToken: state.retryToken + 1,
+      }));
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+    }
+  }
+
+  render() {
+    if (this.state.error) {
+      if (!isAssistantUiRecoverableRenderError(this.state.error)) {
+        throw this.state.error;
+      }
+      return null;
+    }
+
+    return (
+      <React.Fragment key={`${this.props.resetKey}:${this.state.retryToken}`}>
+        {this.props.children}
+      </React.Fragment>
+    );
+  }
+}
+
+export function AssistantMessageListErrorBoundary({
+  resetKey,
+  children,
+}: {
+  resetKey: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <AssistantUiStaleIndexErrorBoundary
+      resetKey={resetKey}
+      componentName="AssistantMessageList"
+    >
+      {children}
+    </AssistantUiStaleIndexErrorBoundary>
+  );
+}

--- a/packages/core/src/client/composer/PromptComposer.tsx
+++ b/packages/core/src/client/composer/PromptComposer.tsx
@@ -43,6 +43,7 @@ import type {
 } from "./types.js";
 import { useChatModels, type EngineModelGroup } from "../use-chat-models.js";
 import { TooltipProvider } from "../components/ui/tooltip.js";
+import { AssistantUiStaleIndexErrorBoundary } from "../assistant-ui-recovery.js";
 import type { ReasoningEffort } from "../../shared/reasoning-effort.js";
 import { isPastedTextAttachmentName } from "./pasted-text.js";
 import { PastedTextChip } from "./PastedTextChip.js";
@@ -632,6 +633,11 @@ export function PromptComposer(props: PromptComposerProps) {
   const runtime = useLocalRuntime(NOOP_ADAPTER, {
     adapters: { attachments: attachmentAdapter },
   });
+  const resetKey = [
+    props.draftScope ?? "",
+    props.initialTextKey ?? "",
+    props.initialText ?? "",
+  ].join(":");
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -640,7 +646,12 @@ export function PromptComposer(props: PromptComposerProps) {
           className="contents"
           style={{ display: "contents" }}
         >
-          <PromptComposerInner {...props} />
+          <AssistantUiStaleIndexErrorBoundary
+            resetKey={resetKey}
+            componentName="PromptComposer"
+          >
+            <PromptComposerInner {...props} />
+          </AssistantUiStaleIndexErrorBoundary>
         </ThreadPrimitive.Root>
       </AssistantRuntimeProvider>
     </TooltipProvider>

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -48,7 +48,7 @@ import type {
 import { useVoiceDictation } from "./useVoiceDictation.js";
 import { VoiceButton, VoiceRecordingOverlay } from "./VoiceButton.js";
 import { ComposerPlusMenu } from "./ComposerPlusMenu.js";
-import { sendToAgentChat } from "../agent-chat.js";
+import { sendToAgentChat, type AgentChatContextItem } from "../agent-chat.js";
 import { tryDelegateBuildRequestToBuilder } from "../builder-frame.js";
 import { getComposerDraftKey } from "./draft-key.js";
 import {
@@ -391,6 +391,10 @@ interface TiptapComposerProps {
   onConnectProvider?: () => void;
   /** Stable scope for persisted drafts, usually the active thread or tab id. */
   draftScope?: string;
+  /** Keyed context nuggets staged for the next submitted prompt. */
+  contextItems?: AgentChatContextItem[];
+  /** Remove a staged context nugget by key. */
+  onRemoveContextItem?: (key: string) => void;
   /**
    * Controls the "+" menu next to the composer. `"full"` (default) shows the
    * normal Upload / Skill / Job / Automation / Tool / MCP picker. `"upload-only"`
@@ -956,6 +960,8 @@ export function TiptapComposer({
   providerConnectStatusEnabled,
   onConnectProvider,
   draftScope,
+  contextItems = [],
+  onRemoveContextItem,
   plusMenuMode = "full",
   interceptBuildRequestsForBuilder = false,
 }: TiptapComposerProps) {
@@ -970,6 +976,7 @@ export function TiptapComposer({
     attachmentCount: composerAttachments.length,
     disabled,
   });
+  const hasContextItems = contextItems.length > 0;
   const [composerMode, setComposerMode] = useState<ComposerMode | null>(null);
   const composerModeRef = useRef<ComposerMode | null>(null);
   const isMac =
@@ -1938,11 +1945,36 @@ export function TiptapComposer({
           />
         </div>
       )}
+      {hasContextItems && (
+        <div
+          data-agent-composer-variant={layoutVariant}
+          data-agent-composer-slot="context-row"
+          className="agent-composer-context-row flex flex-wrap gap-1.5 px-2.5 pt-2 pb-0"
+        >
+          {contextItems.map((item) => (
+            <span
+              key={item.key}
+              className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border bg-muted/50 px-2 py-1 text-[11px] font-medium text-foreground"
+            >
+              <IconClipboardList className="h-3 w-3 shrink-0 text-muted-foreground" />
+              <span className="min-w-0 truncate">{item.title}</span>
+              <button
+                type="button"
+                onClick={() => onRemoveContextItem?.(item.key)}
+                aria-label={`Remove ${item.title} context`}
+                className="ml-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                <IconX className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
       <div
         data-agent-composer-variant={layoutVariant}
         data-agent-composer-slot="editor-wrap"
         className={`agent-composer-editor-wrap ${
-          composerMode ? "px-2 pt-1 pb-1" : "px-2 pt-2 pb-1"
+          composerMode || hasContextItems ? "px-2 pt-1 pb-1" : "px-2 pt-2 pb-1"
         }`}
       >
         <EditorContent

--- a/packages/core/src/client/frame-protocol.ts
+++ b/packages/core/src/client/frame-protocol.ts
@@ -6,7 +6,10 @@
  * between the app iframe and the parent frame.
  */
 
-import type { AgentChatMessage } from "./agent-chat.js";
+import type {
+  AgentChatContextMessage,
+  AgentChatMessage,
+} from "./agent-chat.js";
 
 // ---------------------------------------------------------------------------
 // Messages FROM app TO frame
@@ -19,6 +22,11 @@ export interface AppReadyMessage {
 export interface SubmitChatMessage {
   type: "agentNative.submitChat";
   data: AgentChatMessage;
+}
+
+export interface SetChatContextMessage {
+  type: "agentNative.setChatContext";
+  data: AgentChatContextMessage;
 }
 
 export interface GetUserInfoMessage {
@@ -67,6 +75,7 @@ export interface PresentationModeMessage {
 export type AppToFrameMessage =
   | AppReadyMessage
   | SubmitChatMessage
+  | SetChatContextMessage
   | GetUserInfoMessage
   | SetEnvVarsMessage
   | DevModeChangeMessage

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -5,8 +5,14 @@ installRouteChunkRecovery();
 stripAuthRedirectParamFromUrl();
 
 export {
+  addContextToAgentChat,
+  appendAgentChatContextToMessage,
+  formatAgentChatContextItemsForPrompt,
   sendToAgentChat,
+  setContextToAgentChat,
   generateTabId,
+  type AgentChatContextItem,
+  type AgentChatContextMessage,
   type AgentChatMessage,
 } from "./agent-chat.js";
 export { useAgentChatGenerating } from "./use-agent-chat.js";

--- a/packages/core/src/client/progress/RunsTray.tsx
+++ b/packages/core/src/client/progress/RunsTray.tsx
@@ -1,10 +1,30 @@
 import { agentNativePath } from "../api-path.js";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { IconLoader2, IconCheck, IconX, IconClock } from "@tabler/icons-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  IconAlertCircle,
+  IconCheck,
+  IconClock,
+  IconExternalLink,
+  IconLoader2,
+  IconX,
+} from "@tabler/icons-react";
 import { usePausingInterval } from "../use-pausing-interval.js";
 import type { AgentRun, ProgressStatus } from "../../progress/types.js";
+import { cn } from "../utils.js";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../components/ui/popover.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 type AgentRunDto = AgentRun;
+type RunsTrayTriggerVariant = "icon" | "pill";
 
 interface RunsTrayProps {
   /** Poll interval in ms. 0 disables. Default 3000. */
@@ -13,12 +33,19 @@ interface RunsTrayProps {
   limit?: number;
   /** Hide the trigger entirely when no active runs. Default true. */
   hideWhenIdle?: boolean;
+  /** Include recent terminal runs instead of active runs only. Defaults to !hideWhenIdle. */
+  showRecent?: boolean;
+  /** Compact icon for app headers, or a labeled pill for the agent panel. */
+  triggerVariant?: RunsTrayTriggerVariant;
+  /** Called when a run can open a related agent chat thread. */
+  onOpenThread?: (threadId: string) => void;
+  align?: "start" | "center" | "end";
   className?: string;
 }
 
 /**
- * Header-bar progress indicator. Shows a spinner icon with a count badge
- * when runs are active; opens a dropdown with live progress bars for each.
+ * Header-bar progress indicator. Shows a spinner icon or labeled Runs pill
+ * with a count badge when runs are active; opens a popover with live progress.
  * Same inline-header pattern as <NotificationsBell /> — drop it into the
  * header, no floating overlay over the main content.
  */
@@ -26,16 +53,22 @@ export function RunsTray({
   pollMs = 3000,
   limit = 5,
   hideWhenIdle = true,
+  showRecent,
+  triggerVariant = "icon",
+  onOpenThread,
+  align = "end",
   className,
 }: RunsTrayProps) {
   const [runs, setRuns] = useState<AgentRunDto[]>([]);
   const [open, setOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement | null>(null);
+  const includeRecent = showRecent ?? !hideWhenIdle;
 
   const refresh = useCallback(async () => {
     try {
+      const query = new URLSearchParams({ limit: String(limit) });
+      if (!includeRecent) query.set("active", "true");
       const res = await fetch(
-        agentNativePath(`/_agent-native/runs?active=true&limit=${limit}`),
+        agentNativePath(`/_agent-native/runs?${query.toString()}`),
       );
       if (!res.ok) return;
       const rows = (await res.json()) as AgentRunDto[];
@@ -43,7 +76,7 @@ export function RunsTray({
     } catch {
       // best-effort
     }
-  }, [limit]);
+  }, [includeRecent, limit]);
 
   useEffect(() => {
     refresh();
@@ -70,119 +103,281 @@ export function RunsTray({
     [refresh],
   );
 
-  useEffect(() => {
-    if (!open) return;
-    const onDocClick = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", onDocClick);
-    return () => document.removeEventListener("mousedown", onDocClick);
-  }, [open]);
-
-  // Close the dropdown when the last active run finishes.
-  useEffect(() => {
-    if (runs.length === 0 && open) setOpen(false);
-  }, [runs.length, open]);
-
   const hasRuns = runs.length > 0;
+  const activeCount = useMemo(
+    () => runs.filter((run) => run.status === "running").length,
+    [runs],
+  );
+  const failedCount = useMemo(
+    () => runs.filter((run) => run.status === "failed").length,
+    [runs],
+  );
   if (!hasRuns && hideWhenIdle) return null;
 
+  const triggerLabel =
+    activeCount > 0
+      ? `${activeCount} active run${activeCount > 1 ? "s" : ""}`
+      : failedCount > 0
+        ? `${failedCount} failed run${failedCount > 1 ? "s" : ""}`
+        : hasRuns
+          ? "Recent runs"
+          : "No recent runs";
+  const TriggerIcon =
+    activeCount > 0
+      ? IconLoader2
+      : failedCount > 0
+        ? IconAlertCircle
+        : IconClock;
+  const triggerTone =
+    activeCount > 0
+      ? "text-primary"
+      : failedCount > 0
+        ? "text-destructive"
+        : "text-muted-foreground";
+  const terminalCount = runs.length - activeCount;
+
   return (
-    <div
-      ref={menuRef}
-      className={
-        "an-runs-tray relative inline-flex" + (className ? ` ${className}` : "")
-      }
-    >
-      <button
-        type="button"
-        aria-label={
-          hasRuns
-            ? `${runs.length} active run${runs.length > 1 ? "s" : ""}`
-            : "No active runs"
-        }
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-        className="an-runs-tray__trigger relative inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/40 hover:text-foreground"
+    <Popover open={open} onOpenChange={setOpen}>
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                aria-label={triggerLabel}
+                aria-expanded={open}
+                className={cn(
+                  "an-runs-tray__trigger relative inline-flex shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/40 hover:text-foreground",
+                  triggerVariant === "pill"
+                    ? "h-7 min-w-[68px] gap-1.5 border border-border/70 bg-background px-2 text-[11px] font-medium"
+                    : "h-8 w-8",
+                  open && "bg-accent/50 text-foreground",
+                  className,
+                )}
+              >
+                <TriggerIcon
+                  size={triggerVariant === "pill" ? 14 : 18}
+                  className={cn(triggerTone, activeCount > 0 && "animate-spin")}
+                  aria-hidden
+                />
+                {triggerVariant === "pill" ? (
+                  <span className="leading-none">Runs</span>
+                ) : null}
+                {activeCount > 0 ? (
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "an-runs-tray__badge rounded-full bg-primary text-[10px] font-medium leading-[14px] text-primary-foreground",
+                      triggerVariant === "pill"
+                        ? "min-w-4 px-1"
+                        : "absolute -right-0.5 -top-0.5 px-1",
+                    )}
+                  >
+                    {activeCount > 9 ? "9+" : activeCount}
+                  </span>
+                ) : failedCount > 0 ? (
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "rounded-full bg-destructive text-[10px] font-medium leading-[14px] text-destructive-foreground",
+                      triggerVariant === "pill"
+                        ? "min-w-4 px-1"
+                        : "absolute -right-0.5 -top-0.5 px-1",
+                    )}
+                  >
+                    {failedCount > 9 ? "9+" : failedCount}
+                  </span>
+                ) : null}
+              </button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent>{triggerLabel}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <PopoverContent
+        align={align}
+        sideOffset={8}
+        className="an-runs-tray__menu w-80 max-w-[calc(100vw-24px)] p-0"
       >
-        <IconLoader2
-          size={18}
-          className={hasRuns ? "animate-spin text-primary" : ""}
-          aria-hidden
-        />
-        {hasRuns ? (
-          <span
-            aria-hidden
-            className="an-runs-tray__badge absolute -right-0.5 -top-0.5 rounded-full bg-primary px-1 text-[10px] leading-[14px] font-medium text-primary-foreground"
-          >
-            {runs.length > 9 ? "9+" : runs.length}
-          </span>
-        ) : null}
-      </button>
-      {open && hasRuns ? (
-        <div
-          role="menu"
-          className="an-runs-tray__menu absolute right-0 top-full z-50 mt-2 w-80 rounded-md border border-border bg-popover text-popover-foreground shadow-lg"
-        >
-          <div className="border-b border-border px-3 py-2 text-sm font-medium">
-            {runs.length} active run{runs.length > 1 ? "s" : ""}
-          </div>
-          <div className="max-h-96 divide-y divide-border overflow-y-auto">
-            {runs.map((r) => (
-              <RunRow key={r.id} run={r} onDismiss={dismissRun} />
-            ))}
+        <div className="border-b border-border px-3 py-2">
+          <div className="text-sm font-medium text-foreground">Agent runs</div>
+          <div className="mt-0.5 text-[11px] text-muted-foreground">
+            {activeCount > 0
+              ? `${activeCount} running${terminalCount > 0 ? ` · ${terminalCount} recent` : ""}`
+              : hasRuns
+                ? `${runs.length} recent run${runs.length > 1 ? "s" : ""}`
+                : "No tracked work yet"}
           </div>
         </div>
-      ) : null}
-    </div>
+        {hasRuns ? (
+          <div className="max-h-96 divide-y divide-border overflow-y-auto">
+            {runs.map((run) => (
+              <RunRow
+                key={run.id}
+                run={run}
+                onDismiss={dismissRun}
+                onOpenThread={onOpenThread}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="px-3 py-6 text-center">
+            <IconClock
+              size={22}
+              className="mx-auto text-muted-foreground/50"
+              aria-hidden
+            />
+            <div className="mt-2 text-sm font-medium text-foreground">
+              No recent runs
+            </div>
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              Background agent work will appear here while it runs and after it
+              finishes.
+            </p>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
   );
+}
+
+function getRunThreadId(run: AgentRunDto): string | undefined {
+  const metadata = run.metadata ?? {};
+  const direct =
+    typeof metadata.threadId === "string"
+      ? metadata.threadId
+      : typeof metadata.thread_id === "string"
+        ? metadata.thread_id
+        : undefined;
+  if (direct?.trim()) return direct.trim();
+
+  const surfaceUrl =
+    typeof metadata.surfaceUrl === "string" ? metadata.surfaceUrl : undefined;
+  const match = surfaceUrl?.match(/^agent-native:\/\/threads\/(.+)$/);
+  return match?.[1] ? decodeURIComponent(match[1]) : undefined;
+}
+
+function formatRunTime(run: AgentRunDto): string {
+  const when = run.completedAt ?? run.updatedAt ?? run.startedAt;
+  const timestamp = Date.parse(when);
+  if (!Number.isFinite(timestamp)) return "";
+  const diffMs = Date.now() - timestamp;
+  const prefix = run.status === "running" ? "Updated" : "Finished";
+  if (diffMs < 30_000) return `${prefix} just now`;
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${prefix} ${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${prefix} ${hours}h ago`;
+  return `${prefix} ${new Date(timestamp).toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+  })}`;
 }
 
 function RunRow({
   run,
   onDismiss,
+  onOpenThread,
 }: {
   run: AgentRunDto;
   onDismiss: (runId: string) => void;
+  onOpenThread?: (threadId: string) => void;
 }) {
+  const threadId = getRunThreadId(run);
+  const isRunning = run.status === "running";
+
   return (
-    <div className="flex flex-col gap-1 px-3 py-2 text-sm">
+    <div className="flex flex-col gap-1.5 px-3 py-2.5 text-sm">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium text-foreground">
+            {run.title}
+          </div>
+          {run.step ? (
+            <div className="mt-0.5 truncate text-xs text-muted-foreground">
+              {run.step}
+            </div>
+          ) : null}
+        </div>
+        <StatusPill status={run.status} />
+      </div>
+      {run.percent != null || isRunning ? (
+        <div className="h-1 w-full overflow-hidden rounded bg-muted">
+          {run.percent != null ? (
+            <div
+              className={cn(
+                "h-full transition-all",
+                run.status === "failed"
+                  ? "bg-destructive"
+                  : run.status === "cancelled"
+                    ? "bg-muted-foreground/50"
+                    : "bg-primary",
+              )}
+              style={{ width: `${run.percent}%` }}
+            />
+          ) : (
+            <div className="h-full w-1/3 animate-pulse bg-primary/60" />
+          )}
+        </div>
+      ) : null}
       <div className="flex items-center justify-between gap-2">
-        <span className="truncate font-medium text-foreground">
-          {run.title}
+        <span className="min-w-0 truncate text-[10px] text-muted-foreground/70">
+          {formatRunTime(run)}
         </span>
         <div className="flex shrink-0 items-center gap-1">
-          <StatusGlyph status={run.status} />
-          <button
-            type="button"
-            aria-label={`Dismiss ${run.title}`}
-            className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-accent/60 hover:text-foreground"
-            onClick={() => onDismiss(run.id)}
-          >
-            <IconX size={13} aria-hidden />
-          </button>
+          {threadId && onOpenThread ? (
+            <button
+              type="button"
+              className="inline-flex h-6 items-center gap-1 rounded px-1.5 text-[11px] font-medium text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+              onClick={() => onOpenThread(threadId)}
+            >
+              Open
+              <IconExternalLink size={12} aria-hidden />
+            </button>
+          ) : null}
+          {!isRunning ? (
+            <button
+              type="button"
+              aria-label={`Hide ${run.title}`}
+              className="inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+              onClick={() => onDismiss(run.id)}
+            >
+              <IconX size={13} aria-hidden />
+            </button>
+          ) : null}
         </div>
       </div>
-      {run.step ? (
-        <span className="truncate text-xs text-muted-foreground">
-          {run.step}
-        </span>
-      ) : null}
-      {run.percent != null ? (
-        <div className="mt-0.5 h-1 w-full overflow-hidden rounded bg-muted">
-          <div
-            className="h-full bg-primary transition-all"
-            style={{ width: `${run.percent}%` }}
-          />
-        </div>
-      ) : (
-        <div className="mt-0.5 h-1 w-full overflow-hidden rounded bg-muted">
-          <div className="h-full w-1/3 animate-pulse bg-primary/60" />
-        </div>
-      )}
     </div>
+  );
+}
+
+const STATUS_COPY: Record<ProgressStatus, string> = {
+  running: "Running",
+  succeeded: "Done",
+  failed: "Failed",
+  cancelled: "Stopped",
+};
+
+const STATUS_PILL_STYLES: Record<ProgressStatus, string> = {
+  running: "bg-primary/10 text-primary",
+  succeeded: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+  failed: "bg-destructive/10 text-destructive",
+  cancelled: "bg-muted text-muted-foreground",
+};
+
+function StatusPill({ status }: { status: ProgressStatus }) {
+  const { Icon, className } = STATUS_GLYPHS[status];
+  const spinClass = status === "running" ? " animate-spin" : "";
+  return (
+    <span
+      className={cn(
+        "inline-flex h-5 shrink-0 items-center gap-1 rounded-md px-1.5 text-[10px] font-medium",
+        STATUS_PILL_STYLES[status],
+      )}
+    >
+      <Icon size={12} className={`${className}${spinClass}`} aria-hidden />
+      {STATUS_COPY[status]}
+    </span>
   );
 }
 
@@ -195,14 +390,8 @@ const STATUS_GLYPHS: Record<
   running: { Icon: IconLoader2, className: "text-primary" },
   succeeded: {
     Icon: IconCheck,
-    className: "text-green-600 dark:text-green-400",
+    className: "text-emerald-600 dark:text-emerald-400",
   },
-  failed: { Icon: IconX, className: "text-destructive" },
+  failed: { Icon: IconAlertCircle, className: "text-destructive" },
   cancelled: { Icon: IconClock, className: "text-muted-foreground" },
 };
-
-function StatusGlyph({ status }: { status: ProgressStatus }) {
-  const { Icon, className } = STATUS_GLYPHS[status];
-  const spinClass = status === "running" ? " animate-spin" : "";
-  return <Icon size={14} className={`${className}${spinClass}`} aria-hidden />;
-}

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -12,7 +12,7 @@ import {
   runNitroBuildPipeline,
   shouldBundleFfmpegStaticForServerless,
 } from "./build.js";
-import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
+import { AGENT_NATIVE_SOCIAL_IMAGE_PATH } from "../shared/social-meta.js";
 import { IMMUTABLE_ASSET_CACHE_CONTROL } from "./immutable-assets.js";
 
 const DEFAULT_SSR_CACHE_CONTROL =
@@ -248,7 +248,7 @@ export default (event) =>
     expect(html).toContain('action="/docs/api/search"');
     expect(html).toContain('url("/docs/hero.png")');
     expect(html).toContain(
-      `<meta property="og:image" content="${AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE}">`,
+      `<meta property="og:image" content="https://app.test/docs${AGENT_NATIVE_SOCIAL_IMAGE_PATH}">`,
     );
     expectDefaultWorkerSsrCacheHeaders(response);
     expect(response.headers.get("speculation-rules")).toBe(

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -34,7 +34,13 @@ import {
 } from "./workspace-core.js";
 import { generateActionRegistryForProject } from "../vite/action-types-plugin.js";
 import { mcpEmbedStaticAssetRouteRules } from "../shared/mcp-embed-headers.js";
-import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
+import {
+  AGENT_NATIVE_SOCIAL_IMAGE_ALT,
+  AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT,
+  AGENT_NATIVE_SOCIAL_IMAGE_PATH,
+  AGENT_NATIVE_SOCIAL_IMAGE_TYPE,
+  AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
+} from "../shared/social-meta.js";
 import {
   DEFAULT_SSR_CDN_CACHE_CONTROL,
   DEFAULT_SSR_NETLIFY_CDN_CACHE_CONTROL,
@@ -426,14 +432,30 @@ const IMMUTABLE_ASSET_CACHE_CONTROL = ${JSON.stringify(IMMUTABLE_ASSET_CACHE_CON
 const IMMUTABLE_ASSET_PATHS = new Set(${JSON.stringify(
     [...new Set(immutableAssetPaths)].sort(),
   )});
-const AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE = ${JSON.stringify(
-    AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE,
+const AGENT_NATIVE_SOCIAL_IMAGE_PATH = ${JSON.stringify(
+    AGENT_NATIVE_SOCIAL_IMAGE_PATH,
+  )};
+const AGENT_NATIVE_SOCIAL_IMAGE_ALT = ${JSON.stringify(
+    AGENT_NATIVE_SOCIAL_IMAGE_ALT,
+  )};
+const AGENT_NATIVE_SOCIAL_IMAGE_TYPE = ${JSON.stringify(
+    AGENT_NATIVE_SOCIAL_IMAGE_TYPE,
+  )};
+const AGENT_NATIVE_SOCIAL_IMAGE_WIDTH = ${JSON.stringify(
+    AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
+  )};
+const AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT = ${JSON.stringify(
+    AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT,
   )};
 const OG_IMAGE_META_RE = /<meta\\b(?=[^>]*\\bproperty=(["'])og:image\\1)[^>]*>/i;
 const TWITTER_CARD_META_RE = /<meta\\b(?=[^>]*\\bname=(["'])twitter:card\\1)[^>]*>/i;
 const TWITTER_IMAGE_META_RE = /<meta\\b(?=[^>]*\\bname=(["'])twitter:image\\1)[^>]*>/i;
 
-function injectDefaultSocialImageMeta(html) {
+function defaultSocialImageUrl(request, basePath) {
+  return new URL(prefixMountedPath(AGENT_NATIVE_SOCIAL_IMAGE_PATH, basePath), request.url).toString();
+}
+
+function injectDefaultSocialImageMeta(html, imageUrl) {
   const headCloseIdx = html.indexOf("</head>");
   if (headCloseIdx === -1) return html;
 
@@ -442,13 +464,19 @@ function injectDefaultSocialImageMeta(html) {
   const tags = [];
 
   if (!hasAnySocialImage) {
-    tags.push('<meta property="og:image" content="' + AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE + '">');
+    tags.push('<meta property="og:image" content="' + imageUrl + '">');
+    tags.push('<meta property="og:image:secure_url" content="' + imageUrl + '">');
+    tags.push('<meta property="og:image:type" content="' + AGENT_NATIVE_SOCIAL_IMAGE_TYPE + '">');
+    tags.push('<meta property="og:image:width" content="' + AGENT_NATIVE_SOCIAL_IMAGE_WIDTH + '">');
+    tags.push('<meta property="og:image:height" content="' + AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT + '">');
+    tags.push('<meta property="og:image:alt" content="' + AGENT_NATIVE_SOCIAL_IMAGE_ALT + '">');
   }
   if (!TWITTER_CARD_META_RE.test(html)) {
     tags.push('<meta name="twitter:card" content="summary_large_image">');
   }
   if (!hasAnySocialImage) {
-    tags.push('<meta name="twitter:image" content="' + AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE + '">');
+    tags.push('<meta name="twitter:image" content="' + imageUrl + '">');
+    tags.push('<meta name="twitter:image:alt" content="' + AGENT_NATIVE_SOCIAL_IMAGE_ALT + '">');
   }
 
   if (tags.length === 0) return html;
@@ -530,7 +558,7 @@ function applyImmutableAssetCacheHeaders(response, request) {
   });
 }
 
-async function rewriteMountedResponse(response, basePath, pathname) {
+async function rewriteMountedResponse(response, basePath, pathname, request) {
   const sentryClientConfigScript = getSentryClientConfigScript();
   const headers = new Headers(response.headers);
   applyDefaultSsrCacheHeader(headers, response.status, pathname);
@@ -554,7 +582,10 @@ async function rewriteMountedResponse(response, basePath, pathname) {
   headers.delete("content-length");
   return new Response(
     injectHeadScript(
-      injectDefaultSocialImageMeta(prefixMountedHtml(html, basePath)),
+      injectDefaultSocialImageMeta(
+        prefixMountedHtml(html, basePath),
+        defaultSocialImageUrl(request, basePath),
+      ),
       sentryClientConfigScript,
     ),
     {
@@ -661,10 +692,11 @@ ${actionRegistrations.join("\n")}
           headers: response.headers,
         }),
         basePath,
-        p
+        p,
+        getRequest
       );
     }
-    return rewriteMountedResponse(await rrHandler(request), basePath, p);
+    return rewriteMountedResponse(await rrHandler(request), basePath, p, request);
   }));
 
   _handler = app.fetch.bind(app);

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -2,7 +2,11 @@
 
 // Client
 export {
+  addContextToAgentChat,
+  appendAgentChatContextToMessage,
+  formatAgentChatContextItemsForPrompt,
   sendToAgentChat,
+  setContextToAgentChat,
   isEmbedMcpChatBridgeActive,
   useAgentChatGenerating,
   useDevMode,
@@ -20,6 +24,8 @@ export {
   useSession,
   cn,
   ApiKeySettings,
+  type AgentChatContextItem,
+  type AgentChatContextMessage,
   type AgentChatMessage,
   type AgentNativeMcpAppHostMessageType,
   type McpAppDisplayMode,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,7 +74,11 @@ export {
 
 // Client
 export {
+  addContextToAgentChat,
+  appendAgentChatContextToMessage,
+  formatAgentChatContextItemsForPrompt,
   sendToAgentChat,
+  setContextToAgentChat,
   isEmbedMcpChatBridgeActive,
   useAgentChatGenerating,
   useDevMode,
@@ -95,6 +99,8 @@ export {
   AgentNativeEmbedded,
   useProductionAgent,
   ProductionAgentPanel,
+  type AgentChatContextItem,
+  type AgentChatContextMessage,
   type AgentChatMessage,
   type AgentNativeMcpAppHostMessageType,
   type McpAppDisplayMode,

--- a/packages/core/src/progress/store.ts
+++ b/packages/core/src/progress/store.ts
@@ -264,11 +264,40 @@ export async function cancelStaleRunsForOwner(
 const _lastStaleSweep = new Map<string, number>();
 const STALE_SWEEP_INTERVAL_MS = 30_000;
 
+/**
+ * Optional hook run (throttled) before each owner's run list is read. Lets a
+ * producer of progress rows reconcile its own backing state first — e.g. Agent
+ * Teams re-fires dropped sub-agent dispatches and marks dead runs failed so the
+ * tray shows precise status instead of waiting on the generic stale sweep.
+ * Registered by the agent-chat plugin to avoid a layering cycle (this generic
+ * store must not import feature modules).
+ */
+export type ProgressPreListHook = (owner: string) => Promise<void> | void;
+let _preListHook: ProgressPreListHook | undefined;
+export function setProgressPreListHook(
+  hook: ProgressPreListHook | undefined,
+): void {
+  _preListHook = hook;
+}
+const _lastPreListHook = new Map<string, number>();
+const PRE_LIST_HOOK_INTERVAL_MS = 8_000;
+
 export async function listRuns(
   owner: string,
   options: ListRunsOptions = {},
 ): Promise<AgentRun[]> {
   await ensureTable();
+  if (_preListHook) {
+    const lastHook = _lastPreListHook.get(owner) ?? 0;
+    if (Date.now() - lastHook > PRE_LIST_HOOK_INTERVAL_MS) {
+      _lastPreListHook.set(owner, Date.now());
+      try {
+        await _preListHook(owner);
+      } catch {
+        // best-effort — never let reconciliation break the list read
+      }
+    }
+  }
   const lastSweep = _lastStaleSweep.get(owner) ?? 0;
   if (Date.now() - lastSweep > STALE_SWEEP_INTERVAL_MS) {
     _lastStaleSweep.set(owner, Date.now());

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -122,6 +122,18 @@ import {
 import nodePath from "node:path";
 import { readBody } from "./h3-helpers.js";
 import {
+  AGENT_TEAM_PROCESS_RUN_PATH,
+  processAgentTeamRun,
+} from "./agent-teams.js";
+import {
+  verifyInternalToken,
+  extractBearerToken,
+} from "../integrations/internal-token.js";
+import {
+  hasConfiguredA2ASecret,
+  isA2AProductionRuntime,
+} from "../a2a/auth-policy.js";
+import {
   getBuilderBrowserConnectUrlForOwner,
   resolveBuilderBranchProjectId,
 } from "./builder-browser.js";
@@ -1906,6 +1918,7 @@ function createTeamTools(deps: {
             actions: subAgentActions,
             engine: deps.getEngine(),
             model: selectedModel,
+            name: selectedName || undefined,
             parentThreadId: deps.getParentThreadId(),
             parentSend: (event) => {
               if (capturedSend) capturedSend(event);
@@ -4502,31 +4515,36 @@ export function createAgentChatPlugin(
       >();
       const resolvedModel = options?.model ?? DEFAULT_ANTHROPIC_MODEL;
 
+      // The action set a sub-agent inherits. Shared between the spawn-time team
+      // tool and the `_process-run` processor route below so the durable run
+      // executes with exactly the tools the orchestrator intended.
+      const buildSubAgentActions = (): Record<string, ActionEntry> =>
+        isDevMode()
+          ? {
+              // Sub-agents spawned in dev mode also invoke template actions
+              // via bash, so omit them from the native tool registry.
+              ...resourceScripts,
+              ...docsScripts,
+              ...(lazyContext ? frameworkContextTool : {}),
+              ...chatScripts,
+              ...devScriptsForA2A,
+            }
+          : {
+              ...templateScripts,
+              ...resourceScripts,
+              ...docsScripts,
+              ...dbScripts,
+              ...refreshScreenTool,
+              ...(lazyContext ? frameworkContextTool : {}),
+              ...urlTools,
+              ...chatScripts,
+            };
+
       const teamTools = createTeamTools({
         getOwner: () => requireCurrentRunOwner("spawn or manage sub-agents"),
         getSystemPrompt: () =>
           getRequestRunContext()?.systemPrompt ?? basePrompt,
-        getActions: () =>
-          isDevMode()
-            ? {
-                // Sub-agents spawned in dev mode also invoke template actions
-                // via bash, so omit them from the native tool registry.
-                ...resourceScripts,
-                ...docsScripts,
-                ...(lazyContext ? frameworkContextTool : {}),
-                ...chatScripts,
-                ...devScriptsForA2A,
-              }
-            : {
-                ...templateScripts,
-                ...resourceScripts,
-                ...docsScripts,
-                ...dbScripts,
-                ...refreshScreenTool,
-                ...(lazyContext ? frameworkContextTool : {}),
-                ...urlTools,
-                ...chatScripts,
-              },
+        getActions: buildSubAgentActions,
         getEngine: () => {
           const runCtx = getRequestRunContext();
           return (
@@ -4961,6 +4979,83 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
             codeMode: currentDevMode,
             canToggle,
           };
+        }),
+      );
+
+      // ─── Agent Teams: durable sub-agent run processor ─────────────────
+      // Self-fire target for `spawnTask`. Executes one chunk of a queued
+      // sub-agent in this fresh function invocation (its own timeout budget)
+      // so background sub-agents survive serverless instead of dying as a
+      // detached promise. Mounted here so it closes over the sub-agent action
+      // set / base prompt / engine (per-deployment closures that can't be
+      // serialized into the queue). HMAC-authed with the same internal-token
+      // scheme as the A2A/webhook processors.
+      getH3App(nitroApp).use(
+        AGENT_TEAM_PROCESS_RUN_PATH,
+        defineEventHandler(async (event) => {
+          if (getMethod(event) !== "POST") {
+            setResponseStatus(event, 405);
+            return { error: "Method not allowed" };
+          }
+          const body = (await readBody(event)) as {
+            taskId?: unknown;
+            mode?: unknown;
+          } | null;
+          const taskId =
+            body && typeof body.taskId === "string" ? body.taskId : "";
+          if (!taskId) {
+            setResponseStatus(event, 400);
+            return { error: "taskId required" };
+          }
+          const mode: "start" | "continue" =
+            body?.mode === "continue" ? "continue" : "start";
+
+          if (hasConfiguredA2ASecret()) {
+            const tok = extractBearerToken(getHeader(event, "authorization"));
+            if (!verifyInternalToken(taskId, tok ?? "")) {
+              setResponseStatus(event, 401);
+              return { error: "Invalid or expired processor token" };
+            }
+          } else if (isA2AProductionRuntime()) {
+            setResponseStatus(event, 503);
+            return {
+              error:
+                "Agent Teams processor not configured — set A2A_SECRET on this deployment.",
+            };
+          }
+
+          try {
+            return await processAgentTeamRun({
+              taskId,
+              mode,
+              event,
+              resolveConfig: async ({ payload, ownerEmail }) => {
+                let apiKey: string | undefined;
+                try {
+                  const { getOwnerActiveApiKey } =
+                    await import("../agent/production-agent.js");
+                  apiKey =
+                    (await getOwnerActiveApiKey(ownerEmail)) ?? undefined;
+                } catch {
+                  apiKey = undefined;
+                }
+                const engine = createAnthropicEngine({
+                  apiKey:
+                    apiKey ?? options?.apiKey ?? process.env.ANTHROPIC_API_KEY,
+                });
+                return {
+                  baseSystemPrompt: basePrompt,
+                  actions: buildSubAgentActions(),
+                  engine,
+                  model: payload.model ?? resolvedModel,
+                };
+              },
+            });
+          } catch (err: any) {
+            console.error("[agent-teams] _process-run failed:", err);
+            setResponseStatus(event, 500);
+            return { error: "process-run failed" };
+          }
         }),
       );
 

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -124,7 +124,9 @@ import { readBody } from "./h3-helpers.js";
 import {
   AGENT_TEAM_PROCESS_RUN_PATH,
   processAgentTeamRun,
+  reconcileAgentTeamRunsForOwner,
 } from "./agent-teams.js";
+import { setProgressPreListHook } from "../progress/store.js";
 import {
   verifyInternalToken,
   extractBearerToken,
@@ -4981,6 +4983,13 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
           };
         }),
       );
+
+      // Self-heal the RunsTray: when the tray lists this owner's runs, first
+      // reconcile their in-flight sub-agent runs (re-fire dropped dispatches,
+      // mark dead runs failed) so the tray reflects precise status without
+      // waiting on the orchestrator chat to poll. Registered here to keep the
+      // generic progress store free of feature-module imports.
+      setProgressPreListHook(reconcileAgentTeamRunsForOwner);
 
       // ─── Agent Teams: durable sub-agent run processor ─────────────────
       // Self-fire target for `spawnTask`. Executes one chunk of a queued

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1817,7 +1817,7 @@ function createTeamTools(deps: {
     "agent-teams": {
       tool: {
         description:
-          "Manage sub-agent tasks. Use action 'spawn' to start a new sub-agent, 'status' to check progress, 'read-result' to get a finished task's output, 'send' to message a running sub-agent, or 'list' to see all tasks.",
+          "Manage sub-agent tasks. Use action 'spawn' to launch a new sub-agent, 'status' to check progress, 'read-result' to get a finished task's output, 'send' to message a running sub-agent, or 'list' to see all tasks. A spawn result only confirms launch; it is not the task result.",
         parameters: {
           type: "object",
           properties: {
@@ -1914,7 +1914,11 @@ function createTeamTools(deps: {
           return JSON.stringify({
             taskId: task.taskId,
             threadId: task.threadId,
+            runId: task.runId,
             status: task.status,
+            state: "launched_pending_completion",
+            message:
+              "Sub-agent launched and is still running. Use status or read-result later; do not describe this task as completed from the spawn response alone.",
             description: task.description,
             name: selectedName,
           });
@@ -2266,7 +2270,7 @@ On the user's first interaction, check \`readAppState("personalization")\`. If i
 
 You also have tools for: inline embeds, chat history search, agent teams/sub-agents, recurring jobs, A2A cross-app calls, structured memory, live embedded browser sessions (\`list-browser-sessions\`, \`view-browser-session\`, \`run-browser-session-action\`, \`send-browser-session-command\`), and browser automation (\`activate-browser\` for Builder-provisioned Chrome; local development may also include \`set-browser-control\`). Call \`get-framework-context\` to read detailed instructions for any of these when needed — each capability's full doc lives there.
 
-**Agent teams:** default to doing the work yourself. Delegate ONE sub-agent (\`agent-teams\` action "spawn") for self-contained heavy work; fan out to several only for genuinely independent units; never parallelize tightly-coupled work; cap fan-out around 3. Give each sub-agent a self-contained brief (objective, the specific context/IDs it needs, output format, boundaries) — it can't see this thread — then read all results and synthesize one integrated answer. Full details: \`get-framework-context\` key \`agent-teams\`.
+**Agent teams:** default to doing the work yourself. Delegate ONE sub-agent (\`agent-teams\` action "spawn") for self-contained heavy work; fan out to several only for genuinely independent units; never parallelize tightly-coupled work; cap fan-out around 3. Give each sub-agent a self-contained brief (objective, the specific context/IDs it needs, output format, boundaries) — it can't see this thread. Treat a spawn response as "launched and still running," never as completed work. Before claiming delegated work is done, use \`agent-teams\` "status" or "read-result" and synthesize the returned result. Full details: \`get-framework-context\` key \`agent-teams\`.
 
 For brand-consistent generated media, use the first-party Assets agent via \`call-agent\` with agent "assets" when another app needs generated heroes, diagrams, product shots, thumbnails, videos, or design imagery. If this app has a native generation action, prefer that action because it may attach the asset to the local document/deck/design.
 `;
@@ -2310,13 +2314,15 @@ When the user asks to find a previous conversation, use \`chat-history\` with ac
   "agent-teams": `### Agent Teams — Orchestration
 
 You can delegate to background sub-agents with the \`agent-teams\` tool:
-- \`agent-teams\` (action: "spawn") — Start a sub-agent on a task. It runs in its own thread with a clean context while you stay available; a live preview card appears in the chat. Optionally pass a custom agent profile from \`agents/*.md\` via the \`agent\` parameter.
+- \`agent-teams\` (action: "spawn") — Launch a sub-agent on a task. It runs in its own thread with a clean context while you stay available; a live preview card appears in the chat. The spawn result confirms launch only, not completion. Optionally pass a custom agent profile from \`agents/*.md\` via the \`agent\` parameter.
 - \`agent-teams\` (action: "status") — Check a running sub-agent's progress.
 - \`agent-teams\` (action: "read-result") — Read a finished sub-agent's output.
 - \`agent-teams\` (action: "send") — Message a running sub-agent.
 - \`agent-teams\` (action: "list") — List sub-agent tasks.
 
 Sub-agents inherit all of your template tools but **cannot spawn sub-agents themselves** — only you orchestrate.
+
+Do not tell the user a spawned task completed from the spawn response. Use \`status\` or \`read-result\` before summarizing delegated work as done.
 
 **Default to doing the work yourself in this thread.** A sub-agent costs real tokens and adds a merge step, so reach for one only when delegation clearly pays for that overhead.
 
@@ -2521,7 +2527,7 @@ Each of these has a one-line pointer here and a full doc you can pull on demand 
 
 - **Inline embeds** — render an interactive app view inline in chat via an \`embed\` fenced code block. Detailed instructions: call \`get-framework-context\` with key \`embeds\`.
 - **Chat history** — search and reopen past conversations with \`chat-history\` (actions: search, open, rename, pin, unpin, archive). Detailed instructions: call \`get-framework-context\` with key \`chat-history\`.
-- **Agent teams / sub-agents** — orchestrate background sub-agents with \`agent-teams\` (actions: spawn, status, read-result, send, list). Default to doing the work yourself in this thread. Delegate ONE sub-agent for self-contained heavy work (deep research, long multi-step generation, noisy scans); fan out to MULTIPLE only for genuinely independent units; never parallelize tightly-coupled work; cap fan-out around 3. Give every sub-agent a self-contained brief (objective, the specific context/IDs it needs, output format, boundaries), then read all results and synthesize one integrated answer. Detailed instructions: call \`get-framework-context\` with key \`agent-teams\`.
+- **Agent teams / sub-agents** — orchestrate background sub-agents with \`agent-teams\` (actions: spawn, status, read-result, send, list). Default to doing the work yourself in this thread. Delegate ONE sub-agent for self-contained heavy work (deep research, long multi-step generation, noisy scans); fan out to MULTIPLE only for genuinely independent units; never parallelize tightly-coupled work; cap fan-out around 3. Give every sub-agent a self-contained brief (objective, the specific context/IDs it needs, output format, boundaries). Treat spawn as launch-only; use status/read-result before reporting delegated work as complete. Detailed instructions: call \`get-framework-context\` with key \`agent-teams\`.
 - **Recurring jobs** — create cron-scheduled jobs with \`manage-jobs\` (actions: create, list, update). After a task with obvious recurring value, offer in one line to save it as an automation. Detailed instructions: call \`get-framework-context\` with key \`recurring-jobs\`.
 - **Connecting Builder.io** — when the user needs a source-code change or hits "Builder not configured", call \`connect-builder\`; it renders a one-click Connect card. Do NOT write setup steps yourself, and never route users to Builder org/beta settings. Detailed instructions: call \`get-framework-context\` with key \`builder\`.
 - **Browser automation** — drive a real Chrome via \`set-browser-control\` (local dev) or \`activate-browser\` (production) for rendered pages, screenshots, and design-token extraction. Detailed instructions: call \`get-framework-context\` with key \`browser\`.

--- a/packages/core/src/server/agent-teams-process-run.spec.ts
+++ b/packages/core/src/server/agent-teams-process-run.spec.ts
@@ -1,0 +1,361 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── In-memory queue table (real queue module runs against this) ───────────
+let queueRows: Record<string, any>[] = [];
+function affected(n: number) {
+  return { rows: [], rowsAffected: n };
+}
+const queueDb = {
+  execute: vi.fn(async (q: string | { sql: string; args?: any[] }) => {
+    const s = (typeof q === "string" ? q : q.sql).replace(/\s+/g, " ").trim();
+    const args = typeof q === "string" ? [] : (q.args ?? []);
+    if (s.includes("CREATE TABLE") || s.includes("CREATE INDEX"))
+      return affected(0);
+    if (s.includes("INSERT INTO agent_team_run_queue")) {
+      queueRows.push({
+        task_id: args[0],
+        thread_id: args[1],
+        run_id: args[2],
+        status: "queued",
+        owner_email: args[3] ?? null,
+        org_id: args[4] ?? null,
+        payload: args[5],
+        continuation_count: 0,
+        attempts: 0,
+        created_at: args[6],
+        updated_at: args[7],
+      });
+      return affected(1);
+    }
+    if (s.includes("SET status = 'running', attempts = attempts + 1")) {
+      const [updatedAt, taskId, stuckCutoff] = args;
+      const r = queueRows.find((x) => x.task_id === taskId);
+      if (
+        r &&
+        (r.status === "queued" ||
+          (r.status === "running" && r.updated_at < stuckCutoff))
+      ) {
+        r.status = "running";
+        r.attempts += 1;
+        r.updated_at = updatedAt;
+        return affected(1);
+      }
+      return affected(0);
+    }
+    if (s.includes("continuation_count = continuation_count + 1")) {
+      const [updatedAt, taskId] = args;
+      const r = queueRows.find(
+        (x) => x.task_id === taskId && x.status === "running",
+      );
+      if (r) {
+        r.continuation_count += 1;
+        r.status = "queued";
+        r.updated_at = updatedAt;
+        return affected(1);
+      }
+      return affected(0);
+    }
+    if (s.includes("SET status = ?, updated_at = ? WHERE task_id = ?")) {
+      const [status, updatedAt, taskId] = args;
+      const r = queueRows.find((x) => x.task_id === taskId);
+      if (r) {
+        r.status = status;
+        r.updated_at = updatedAt;
+        return affected(1);
+      }
+      return affected(0);
+    }
+    if (
+      s.includes("SET updated_at = ? WHERE task_id = ? AND status = 'running'")
+    ) {
+      const [updatedAt, taskId] = args;
+      const r = queueRows.find(
+        (x) => x.task_id === taskId && x.status === "running",
+      );
+      if (r) {
+        r.updated_at = updatedAt;
+        return affected(1);
+      }
+      return affected(0);
+    }
+    if (s.includes("SELECT continuation_count")) {
+      const r = queueRows.find((x) => x.task_id === args[0]);
+      return {
+        rows: r ? [{ continuation_count: r.continuation_count }] : [],
+        rowsAffected: 0,
+      };
+    }
+    if (s.includes("SELECT task_id FROM agent_team_run_queue")) {
+      return {
+        rows: queueRows
+          .filter(
+            (x) =>
+              x.owner_email === args[0] &&
+              (x.status === "queued" || x.status === "running"),
+          )
+          .map((x) => ({ task_id: x.task_id })),
+        rowsAffected: 0,
+      };
+    }
+    if (s.includes("SELECT * FROM agent_team_run_queue WHERE task_id = ?")) {
+      const r = queueRows.find((x) => x.task_id === args[0]);
+      return { rows: r ? [{ ...r }] : [], rowsAffected: 0 };
+    }
+    return affected(0);
+  }),
+};
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => queueDb,
+  intType: () => "INTEGER",
+  retryOnDdlRace: (fn: () => unknown) => fn(),
+}));
+
+// ── app_state (task records + thread reverse-lookup) ──────────────────────
+const appState = new Map<string, any>();
+vi.mock("../application-state/script-helpers.js", () => ({
+  readAppState: vi.fn(async (k: string) => appState.get(k) ?? null),
+  writeAppState: vi.fn(async (k: string, v: any) => {
+    appState.set(k, v);
+  }),
+  deleteAppState: vi.fn(async (k: string) => appState.delete(k)),
+  listAppState: vi.fn(async (prefix: string) =>
+    [...appState.entries()]
+      .filter(([k]) => k.startsWith(prefix))
+      .map(([k, v]) => ({ key: k, value: v })),
+  ),
+}));
+
+// ── chat thread store (thread_data round-trips through here) ──────────────
+const threadData = new Map<string, string>();
+vi.mock("../chat-threads/store.js", () => ({
+  createThread: vi.fn(async (_owner: string, opts: any) => ({
+    id: "thread-1",
+    title: opts?.title ?? "",
+  })),
+  getThread: vi.fn(async (id: string) => ({
+    id,
+    threadData: threadData.get(id) ?? null,
+    ownerEmail: "owner@example.com",
+  })),
+  updateThreadData: vi.fn(async (id: string, data: string) => {
+    threadData.set(id, data);
+  }),
+}));
+
+// ── run-manager: drive runFn then onComplete with a synthetic run ─────────
+const runAgentLoopMock = vi.fn();
+vi.mock("../agent/run-manager.js", () => ({
+  startRun: (
+    runId: string,
+    threadId: string,
+    runFn: (send: any, signal: any) => Promise<void>,
+    onComplete?: (run: any) => Promise<void>,
+    options?: any,
+  ) => {
+    void (async () => {
+      const events: any[] = [];
+      const send = (e: any) => events.push({ seq: events.length, event: e });
+      const signal = {
+        aborted: false,
+        addEventListener() {},
+        removeEventListener() {},
+      };
+      try {
+        await runFn(send, signal);
+      } catch {
+        /* ignore */
+      }
+      const run = {
+        runId,
+        threadId,
+        turnId: options?.turnId ?? runId,
+        events,
+        status: "completed",
+        subscribers: new Set(),
+        abort: new AbortController(),
+        startedAt: Date.now(),
+      };
+      if (onComplete) await onComplete(run);
+    })();
+    return {
+      runId,
+      threadId,
+      turnId: runId,
+      events: [],
+      status: "running",
+      subscribers: new Set(),
+      abort: new AbortController(),
+      startedAt: Date.now(),
+    };
+  },
+  abortRun: vi.fn(),
+  getActiveRunForThreadAsync: vi.fn(async () => null),
+  getRun: vi.fn(),
+  subscribeToRun: vi.fn(),
+}));
+
+vi.mock("../agent/run-store.js", () => ({ getRunEventsSince: vi.fn() }));
+
+// ── production-agent: scripted agent loop ─────────────────────────────────
+vi.mock("../agent/production-agent.js", () => ({
+  actionsToEngineTools: () => [],
+  appendAgentLoopContinuation: vi.fn(),
+  runAgentLoop: (opts: any) => runAgentLoopMock(opts),
+}));
+
+// ── progress registry: no-op writes ──────────────────────────────────────
+vi.mock("../progress/registry.js", () => ({
+  startRun: vi.fn(async () => ({})),
+  updateRunProgress: vi.fn(async () => ({})),
+  completeRun: vi.fn(async () => ({})),
+}));
+
+vi.mock("../org/context.js", () => ({
+  resolveOrgIdForEmail: vi.fn(async () => null),
+}));
+
+vi.mock("./request-context.js", () => ({
+  getRequestUserEmail: () => "owner@example.com",
+  runWithRequestContext: (_ctx: any, fn: () => any) => fn(),
+}));
+
+// ── capture self-fire dispatches ──────────────────────────────────────────
+const dispatches: Array<{ taskId: string; body?: any }> = [];
+vi.mock("./self-dispatch.js", () => ({
+  fireInternalDispatch: vi.fn(async (o: any) => {
+    dispatches.push({ taskId: o.taskId, body: o.body });
+  }),
+}));
+
+const queue = await import("./agent-teams-run-queue.js");
+const { processAgentTeamRun } = await import("./agent-teams.js");
+
+const OWNER = "owner@example.com";
+
+async function seedTask(taskId: string) {
+  await queue.enqueueAgentTeamRun({
+    taskId,
+    threadId: "thread-1",
+    runId: `run-task-${taskId}`,
+    ownerEmail: OWNER,
+    orgId: null,
+    payload: { description: "do the thing", turnId: `run-task-${taskId}` },
+  });
+  appState.set(`agent-task:${taskId}`, {
+    taskId,
+    threadId: "thread-1",
+    description: "do the thing",
+    status: "running",
+    preview: "",
+    summary: "",
+    currentStep: "Starting sub-agent",
+    createdAt: Date.now(),
+    runId: `run-task-${taskId}`,
+  });
+}
+
+function resolveConfig() {
+  return {
+    baseSystemPrompt: "base",
+    actions: {},
+    engine: { name: "test", defaultModel: "m" } as any,
+    model: "m",
+  };
+}
+
+describe("processAgentTeamRun (durable serverless execution)", () => {
+  beforeEach(() => {
+    queueRows = [];
+    appState.clear();
+    threadData.clear();
+    dispatches.length = 0;
+    queue._agentTeamRunQueueForTests.resetInit();
+    runAgentLoopMock.mockReset();
+    vi.clearAllMocks();
+  });
+
+  it("claims, runs, and finalizes a queued sub-agent to completed", async () => {
+    runAgentLoopMock.mockImplementation(async (opts: any) => {
+      opts.send({ type: "text", text: "the result" });
+    });
+    await seedTask("t1");
+
+    const res = await processAgentTeamRun({
+      taskId: "t1",
+      mode: "start",
+      resolveConfig: async () => resolveConfig(),
+    });
+    expect(res.ok).toBe(true);
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
+
+    const task = appState.get("agent-task:t1");
+    expect(task.status).toBe("completed");
+    expect(task.summary).toContain("the result");
+    expect((await queue.getAgentTeamRunDispatchState("t1"))?.status).toBe(
+      "done",
+    );
+    // thread_data persisted with the assistant turn
+    expect(threadData.get("thread-1")).toContain("the result");
+  });
+
+  it("is idempotent: a duplicate dispatch does not re-run the agent", async () => {
+    runAgentLoopMock.mockImplementation(async (opts: any) => {
+      opts.send({ type: "text", text: "once" });
+    });
+    await seedTask("t2");
+
+    await processAgentTeamRun({
+      taskId: "t2",
+      resolveConfig: async () => resolveConfig(),
+    });
+    const second = await processAgentTeamRun({
+      taskId: "t2",
+      resolveConfig: async () => resolveConfig(),
+    });
+
+    expect(second.skipped).toBeTruthy();
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("self-fires a continuation at a soft-timeout boundary, then finalizes", async () => {
+    // First chunk hits the soft-timeout boundary; second chunk finishes.
+    runAgentLoopMock
+      .mockImplementationOnce(async (opts: any) => {
+        opts.send({ type: "text", text: "partial " });
+        opts.send({ type: "auto_continue", reason: "run_timeout" });
+      })
+      .mockImplementationOnce(async (opts: any) => {
+        opts.send({ type: "text", text: "and the rest" });
+      });
+    await seedTask("t3");
+
+    // Chunk 1 — should NOT finalize; should bump + self-fire a continuation.
+    await processAgentTeamRun({
+      taskId: "t3",
+      mode: "start",
+      resolveConfig: async () => resolveConfig(),
+    });
+    expect(appState.get("agent-task:t3").status).toBe("running");
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0]).toMatchObject({
+      taskId: "t3",
+      body: { mode: "continue" },
+    });
+    expect(
+      (await queue.getAgentTeamRunDispatchState("t3"))?.continuationCount,
+    ).toBe(1);
+
+    // Chunk 2 — the self-fired continuation completes the task.
+    await processAgentTeamRun({
+      taskId: "t3",
+      mode: "continue",
+      resolveConfig: async () => resolveConfig(),
+    });
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(2);
+    const task = appState.get("agent-task:t3");
+    expect(task.status).toBe("completed");
+    expect((await queue.getAgentTeamRunDispatchState("t3"))?.status).toBe(
+      "done",
+    );
+  });
+});

--- a/packages/core/src/server/agent-teams-run-queue.spec.ts
+++ b/packages/core/src/server/agent-teams-run-queue.spec.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Minimal in-memory emulation of the agent_team_run_queue table, matching the
+// exact statements the queue module issues. Whitespace-normalized so it's
+// robust to formatting.
+let rows: Record<string, any>[] = [];
+
+function affected(n: number) {
+  return { rows: [], rowsAffected: n };
+}
+
+const mockDb = {
+  execute: vi.fn(async (q: string | { sql: string; args?: any[] }) => {
+    const rawSql = typeof q === "string" ? q : q.sql;
+    const args = typeof q === "string" ? [] : (q.args ?? []);
+    const s = rawSql.replace(/\s+/g, " ").trim();
+
+    if (s.includes("CREATE TABLE") || s.includes("CREATE INDEX")) {
+      return affected(0);
+    }
+    if (s.includes("INSERT INTO agent_team_run_queue")) {
+      rows.push({
+        task_id: args[0],
+        thread_id: args[1],
+        run_id: args[2],
+        status: "queued",
+        owner_email: args[3] ?? null,
+        org_id: args[4] ?? null,
+        payload: args[5],
+        continuation_count: 0,
+        attempts: 0,
+        created_at: args[6],
+        updated_at: args[7],
+      });
+      return affected(1);
+    }
+    // claim CAS
+    if (s.includes("SET status = 'running', attempts = attempts + 1")) {
+      const [updatedAt, taskId, stuckCutoff] = args;
+      const r = rows.find((x) => x.task_id === taskId);
+      if (
+        r &&
+        (r.status === "queued" ||
+          (r.status === "running" && r.updated_at < stuckCutoff))
+      ) {
+        r.status = "running";
+        r.attempts += 1;
+        r.updated_at = updatedAt;
+        return affected(1);
+      }
+      return affected(0);
+    }
+    // bump continuation
+    if (s.includes("continuation_count = continuation_count + 1")) {
+      const [updatedAt, taskId] = args;
+      const r = rows.find(
+        (x) => x.task_id === taskId && x.status === "running",
+      );
+      if (r) {
+        r.continuation_count += 1;
+        r.status = "queued";
+        r.updated_at = updatedAt;
+        return affected(1);
+      }
+      return affected(0);
+    }
+    // complete
+    if (s.includes("SET status = ?, updated_at = ? WHERE task_id = ?")) {
+      const [status, updatedAt, taskId] = args;
+      const r = rows.find((x) => x.task_id === taskId);
+      if (r) {
+        r.status = status;
+        r.updated_at = updatedAt;
+        return affected(1);
+      }
+      return affected(0);
+    }
+    // touch
+    if (
+      s.includes("SET updated_at = ? WHERE task_id = ? AND status = 'running'")
+    ) {
+      const [updatedAt, taskId] = args;
+      const r = rows.find(
+        (x) => x.task_id === taskId && x.status === "running",
+      );
+      if (r) {
+        r.updated_at = updatedAt;
+        return affected(1);
+      }
+      return affected(0);
+    }
+    if (s.includes("SELECT continuation_count")) {
+      const r = rows.find((x) => x.task_id === args[0]);
+      return {
+        rows: r ? [{ continuation_count: r.continuation_count }] : [],
+        rowsAffected: 0,
+      };
+    }
+    if (s.includes("SELECT task_id FROM agent_team_run_queue")) {
+      const owner = args[0];
+      return {
+        rows: rows
+          .filter(
+            (x) =>
+              x.owner_email === owner &&
+              (x.status === "queued" || x.status === "running"),
+          )
+          .map((x) => ({ task_id: x.task_id })),
+        rowsAffected: 0,
+      };
+    }
+    if (s.includes("SELECT * FROM agent_team_run_queue WHERE task_id = ?")) {
+      const r = rows.find((x) => x.task_id === args[0]);
+      return { rows: r ? [{ ...r }] : [], rowsAffected: 0 };
+    }
+    return affected(0);
+  }),
+};
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => mockDb,
+  intType: () => "INTEGER",
+  retryOnDdlRace: (fn: () => unknown) => fn(),
+}));
+
+const queue = await import("./agent-teams-run-queue.js");
+
+function enqueue(taskId: string, owner = "owner@example.com") {
+  return queue.enqueueAgentTeamRun({
+    taskId,
+    threadId: `thread-${taskId}`,
+    runId: `run-task-${taskId}`,
+    ownerEmail: owner,
+    orgId: null,
+    payload: { description: "do work", turnId: `run-task-${taskId}` },
+  });
+}
+
+describe("agent_team_run_queue", () => {
+  beforeEach(() => {
+    rows = [];
+    queue._agentTeamRunQueueForTests.resetInit();
+    vi.clearAllMocks();
+  });
+
+  it("claims a queued run exactly once (idempotent on duplicate dispatch)", async () => {
+    await enqueue("t1");
+    const first = await queue.claimAgentTeamRun("t1");
+    expect(first).not.toBeNull();
+    expect(first?.status).toBe("running");
+    expect(first?.attempts).toBe(1);
+
+    // A concurrent / duplicate self-fire must NOT re-run the sub-agent.
+    const second = await queue.claimAgentTeamRun("t1");
+    expect(second).toBeNull();
+  });
+
+  it("returns null when claiming a missing run", async () => {
+    expect(await queue.claimAgentTeamRun("nope")).toBeNull();
+  });
+
+  it("re-queues + counts a continuation, then re-claims it", async () => {
+    await enqueue("t2");
+    await queue.claimAgentTeamRun("t2"); // running
+    const count = await queue.bumpAgentTeamContinuation("t2");
+    expect(count).toBe(1);
+
+    // bumped back to queued → the next self-fire claims it cleanly.
+    const reclaimed = await queue.claimAgentTeamRun("t2");
+    expect(reclaimed).not.toBeNull();
+    expect(reclaimed?.continuationCount).toBe(1);
+
+    // and again, idempotent.
+    expect(await queue.claimAgentTeamRun("t2")).toBeNull();
+  });
+
+  it("does not re-claim a fresh running row, but re-claims a stale one", async () => {
+    await enqueue("t3");
+    await queue.claimAgentTeamRun("t3"); // running, fresh
+
+    // Fresh → a dropped-dispatch refire must not double-run it.
+    expect(
+      await queue.claimAgentTeamRun("t3", { stuckAfterMs: 15_000 }),
+    ).toBeNull();
+
+    // Age the row past the stuck cutoff → now re-claimable.
+    const r = rows.find((x) => x.task_id === "t3")!;
+    r.updated_at = Date.now() - 60_000;
+    const reclaimed = await queue.claimAgentTeamRun("t3", {
+      stuckAfterMs: 15_000,
+    });
+    expect(reclaimed).not.toBeNull();
+    expect(reclaimed?.status).toBe("running");
+  });
+
+  it("completes a run terminally", async () => {
+    await enqueue("t4");
+    await queue.claimAgentTeamRun("t4");
+    await queue.completeAgentTeamRun("t4", "done");
+    const state = await queue.getAgentTeamRunDispatchState("t4");
+    expect(state?.status).toBe("done");
+    // A late duplicate dispatch finds nothing to claim.
+    expect(await queue.claimAgentTeamRun("t4")).toBeNull();
+  });
+
+  it("lists an owner's in-flight task ids only", async () => {
+    await enqueue("a", "me@example.com");
+    await enqueue("b", "me@example.com");
+    await enqueue("c", "other@example.com");
+    await queue.completeAgentTeamRun("b", "done");
+
+    const ids =
+      await queue.listActiveAgentTeamTaskIdsForOwner("me@example.com");
+    expect(ids).toContain("a");
+    expect(ids).not.toContain("b"); // terminal
+    expect(ids).not.toContain("c"); // different owner
+  });
+});

--- a/packages/core/src/server/agent-teams-run-queue.ts
+++ b/packages/core/src/server/agent-teams-run-queue.ts
@@ -172,7 +172,8 @@ export async function claimAgentTeamRun(
   await ensureTable();
   const client = getDbExec();
   const now = Date.now();
-  const stuckCutoff = now - (options.stuckAfterMs ?? RUN_DISPATCH_STUCK_AFTER_MS);
+  const stuckCutoff =
+    now - (options.stuckAfterMs ?? RUN_DISPATCH_STUCK_AFTER_MS);
   const result = await client.execute({
     sql: `UPDATE agent_team_run_queue
             SET status = 'running', attempts = attempts + 1, updated_at = ?
@@ -238,6 +239,24 @@ export async function completeAgentTeamRun(
     sql: `UPDATE agent_team_run_queue SET status = ?, updated_at = ? WHERE task_id = ?`,
     args: [status, Date.now(), taskId],
   });
+}
+
+/** Task ids of an owner's in-flight (queued/running) sub-agent runs. Used by
+ * the RunsTray data path to self-heal dropped dispatches and dead runs. */
+export async function listActiveAgentTeamTaskIdsForOwner(
+  owner: string,
+  limit = 50,
+): Promise<string[]> {
+  await ensureTable();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT task_id FROM agent_team_run_queue
+            WHERE owner_email = ? AND status IN ('queued', 'running')
+          ORDER BY updated_at DESC
+          LIMIT ?`,
+    args: [owner, limit],
+  });
+  return rows.map((r: any) => String(r.task_id));
 }
 
 export async function getAgentTeamRunDispatchState(

--- a/packages/core/src/server/agent-teams-run-queue.ts
+++ b/packages/core/src/server/agent-teams-run-queue.ts
@@ -1,0 +1,262 @@
+/**
+ * Durable dispatch queue for Agent Teams sub-agent runs.
+ *
+ * Background sub-agents used to run as an in-process detached promise from the
+ * spawning request, which serverless hosts (Netlify/Lambda/Vercel) freeze the
+ * moment the response flushes — so the sub-agent never actually completed. This
+ * queue is the durable hand-off: `spawnTask` enqueues a row here and self-fires
+ * the `/_agent-native/agent-teams/_process-run` route (see `self-dispatch.ts`),
+ * which claims the row and runs the sub-agent in its own fresh function
+ * invocation. The same pattern A2A (`a2a/task-store.ts`) and integration
+ * webhooks use.
+ *
+ * The app_state task record (`agent-task:{taskId}`) remains the source of truth
+ * for UI/status; this table only drives dispatch, idempotent claiming, and
+ * cross-invocation continuation.
+ */
+import { getDbExec, intType, retryOnDdlRace } from "../db/client.js";
+
+/** Max cross-invocation continuations for one sub-agent run. Each continuation
+ * is one ~40s soft-timeout chunk, so ~12 ≈ ~8 minutes of wall-clock work. Two
+ * independent guards bound runaway self-fire: this persisted cap and the
+ * per-invocation `MAX_RUN_LOOP_CONTINUATIONS` inside the run loop. */
+export const MAX_AGENT_TEAM_CONTINUATIONS = 12;
+
+/** A `running` row whose `updated_at` is older than this is treated as a
+ * dropped dispatch and may be re-claimed / re-fired. Must be comfortably larger
+ * than the processor heartbeat interval so a healthy run is never re-claimed. */
+export const RUN_DISPATCH_STUCK_AFTER_MS = 15_000;
+
+/** Hard cutoff after which a stuck row is failed deterministically rather than
+ * retried (side-effectful work may already have happened). Mirrors A2A. */
+export const RUN_PROCESSING_STUCK_AFTER_MS = 5 * 60 * 1000;
+
+export type AgentTeamRunQueueStatus = "queued" | "running" | "done" | "failed";
+
+export interface AgentTeamRunPayload {
+  description: string;
+  instructions?: string;
+  model?: string;
+  /** Custom agent profile name (agents/*.md) to brief the sub-agent with. */
+  agentRef?: string;
+  /** Parent thread to post a completion recap to. */
+  parentThreadId?: string;
+  /** Display name for the sub-agent tab. */
+  name?: string;
+  /** Logical-turn id, stable across continuation chunks so durable assistant
+   * messages fold into one. */
+  turnId: string;
+}
+
+export interface AgentTeamRunQueueRow {
+  taskId: string;
+  threadId: string;
+  runId: string;
+  status: AgentTeamRunQueueStatus;
+  ownerEmail: string | null;
+  orgId: string | null;
+  payload: AgentTeamRunPayload;
+  continuationCount: number;
+  attempts: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+let _initPromise: Promise<void> | undefined;
+
+async function ensureTable(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = (async () => {
+      const client = getDbExec();
+      await retryOnDdlRace(() =>
+        client.execute(`
+          CREATE TABLE IF NOT EXISTS agent_team_run_queue (
+            task_id TEXT PRIMARY KEY,
+            thread_id TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'queued',
+            owner_email TEXT,
+            org_id TEXT,
+            payload TEXT NOT NULL,
+            continuation_count ${intType()} NOT NULL DEFAULT 0,
+            attempts ${intType()} NOT NULL DEFAULT 0,
+            created_at ${intType()} NOT NULL,
+            updated_at ${intType()} NOT NULL
+          )
+        `),
+      );
+      await retryOnDdlRace(() =>
+        client.execute(
+          `CREATE INDEX IF NOT EXISTS idx_agent_team_run_queue_status ON agent_team_run_queue (status, updated_at)`,
+        ),
+      );
+    })().catch((err) => {
+      _initPromise = undefined;
+      throw err;
+    });
+  }
+  return _initPromise;
+}
+
+function getAffectedRowCount(result: unknown): number {
+  const r = result as
+    | { rowsAffected?: number; rowCount?: number; count?: number }
+    | undefined;
+  return r?.rowsAffected ?? r?.rowCount ?? r?.count ?? 0;
+}
+
+function rowToQueueRow(row: any): AgentTeamRunQueueRow {
+  let payload: AgentTeamRunPayload;
+  try {
+    payload = JSON.parse(String(row.payload));
+  } catch {
+    payload = { description: "", turnId: String(row.run_id ?? row.task_id) };
+  }
+  return {
+    taskId: String(row.task_id),
+    threadId: String(row.thread_id),
+    runId: String(row.run_id),
+    status: String(row.status) as AgentTeamRunQueueStatus,
+    ownerEmail: (row.owner_email as string | null) ?? null,
+    orgId: (row.org_id as string | null) ?? null,
+    payload,
+    continuationCount: Number(row.continuation_count ?? 0),
+    attempts: Number(row.attempts ?? 0),
+    createdAt: Number(row.created_at ?? 0),
+    updatedAt: Number(row.updated_at ?? 0),
+  };
+}
+
+export interface EnqueueAgentTeamRunInput {
+  taskId: string;
+  threadId: string;
+  runId: string;
+  ownerEmail?: string | null;
+  orgId?: string | null;
+  payload: AgentTeamRunPayload;
+}
+
+export async function enqueueAgentTeamRun(
+  input: EnqueueAgentTeamRunInput,
+): Promise<void> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  await client.execute({
+    sql: `INSERT INTO agent_team_run_queue
+            (task_id, thread_id, run_id, status, owner_email, org_id, payload, continuation_count, attempts, created_at, updated_at)
+          VALUES (?, ?, ?, 'queued', ?, ?, ?, 0, 0, ?, ?)`,
+    args: [
+      input.taskId,
+      input.threadId,
+      input.runId,
+      input.ownerEmail ?? null,
+      input.orgId ?? null,
+      JSON.stringify(input.payload),
+      now,
+      now,
+    ],
+  });
+}
+
+/**
+ * Atomically claim a run for processing. Succeeds when the row is `queued`, or
+ * `running` but stale (a dropped dispatch past `RUN_DISPATCH_STUCK_AFTER_MS`).
+ * Flips it to `running`, bumps `attempts`, and stamps `updated_at`. Returns the
+ * claimed row, or null if another invocation already holds it (idempotency).
+ */
+export async function claimAgentTeamRun(
+  taskId: string,
+  options: { stuckAfterMs?: number } = {},
+): Promise<AgentTeamRunQueueRow | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const stuckCutoff = now - (options.stuckAfterMs ?? RUN_DISPATCH_STUCK_AFTER_MS);
+  const result = await client.execute({
+    sql: `UPDATE agent_team_run_queue
+            SET status = 'running', attempts = attempts + 1, updated_at = ?
+          WHERE task_id = ?
+            AND (status = 'queued' OR (status = 'running' AND updated_at < ?))`,
+    args: [now, taskId, stuckCutoff],
+  });
+  if (getAffectedRowCount(result) === 0) return null;
+
+  const { rows } = await client.execute({
+    sql: `SELECT * FROM agent_team_run_queue WHERE task_id = ?`,
+    args: [taskId],
+  });
+  if (rows.length === 0) return null;
+  return rowToQueueRow(rows[0]);
+}
+
+/** Heartbeat: bump `updated_at` while a claimed run is actively processing so a
+ * healthy run isn't re-claimed by the stuck-refire path. */
+export async function touchAgentTeamRun(taskId: string): Promise<boolean> {
+  await ensureTable();
+  const client = getDbExec();
+  const result = await client.execute({
+    sql: `UPDATE agent_team_run_queue SET updated_at = ? WHERE task_id = ? AND status = 'running'`,
+    args: [Date.now(), taskId],
+  });
+  return getAffectedRowCount(result) > 0;
+}
+
+/**
+ * Record a soft-timeout continuation: re-queue the row (so the next
+ * self-fired invocation can claim it) and increment the counter. Returns the
+ * new continuation count, or null if the row wasn't in a continuable state.
+ */
+export async function bumpAgentTeamContinuation(
+  taskId: string,
+): Promise<number | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const result = await client.execute({
+    sql: `UPDATE agent_team_run_queue
+            SET continuation_count = continuation_count + 1, status = 'queued', updated_at = ?
+          WHERE task_id = ? AND status = 'running'`,
+    args: [now, taskId],
+  });
+  if (getAffectedRowCount(result) === 0) return null;
+  const { rows } = await client.execute({
+    sql: `SELECT continuation_count FROM agent_team_run_queue WHERE task_id = ?`,
+    args: [taskId],
+  });
+  if (rows.length === 0) return null;
+  return Number((rows[0] as any).continuation_count ?? 0);
+}
+
+export async function completeAgentTeamRun(
+  taskId: string,
+  status: "done" | "failed",
+): Promise<void> {
+  await ensureTable();
+  const client = getDbExec();
+  await client.execute({
+    sql: `UPDATE agent_team_run_queue SET status = ?, updated_at = ? WHERE task_id = ?`,
+    args: [status, Date.now(), taskId],
+  });
+}
+
+export async function getAgentTeamRunDispatchState(
+  taskId: string,
+): Promise<AgentTeamRunQueueRow | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT * FROM agent_team_run_queue WHERE task_id = ?`,
+    args: [taskId],
+  });
+  if (rows.length === 0) return null;
+  return rowToQueueRow(rows[0]);
+}
+
+/** Test-only accessor for resetting the cached init promise between specs. */
+export const _agentTeamRunQueueForTests = {
+  resetInit() {
+    _initPromise = undefined;
+  },
+  getAffectedRowCount,
+};

--- a/packages/core/src/server/agent-teams.spec.ts
+++ b/packages/core/src/server/agent-teams.spec.ts
@@ -126,6 +126,41 @@ describe("agent teams message queue", () => {
     ).resolves.toEqual([]);
   });
 
+  it("maps aborted and errored child runs to non-success task outcomes", async () => {
+    const { _agentTeamsQueueForTests } = await import("./agent-teams.js");
+
+    expect(
+      _agentTeamsQueueForTests.resolveTaskCompletion(
+        { status: "aborted", abortReason: "user" },
+        "",
+      ),
+    ).toMatchObject({
+      taskStatus: "errored",
+      progressStatus: "cancelled",
+      summary: "Task stopped.",
+    });
+    expect(
+      _agentTeamsQueueForTests.resolveTaskCompletion(
+        { status: "errored" },
+        "partial failure detail",
+      ),
+    ).toMatchObject({
+      taskStatus: "errored",
+      progressStatus: "failed",
+      summary: "partial failure detail",
+    });
+    expect(
+      _agentTeamsQueueForTests.resolveTaskCompletion(
+        { status: "completed" },
+        "finished",
+      ),
+    ).toMatchObject({
+      taskStatus: "completed",
+      progressStatus: "succeeded",
+      summary: "finished",
+    });
+  });
+
   it("maps tasks into the shared background run vocabulary", async () => {
     const {
       getAgentTeamBackgroundRun,
@@ -279,7 +314,7 @@ describe("agent teams message queue", () => {
       controller.control({ runId: "run-task-task-1", command: "stop" }),
     ).resolves.toMatchObject({
       ok: true,
-      run: { status: "errored", phase: "Scanning" },
+      run: { status: "errored", phase: "Task stopped." },
     });
   });
 

--- a/packages/core/src/server/agent-teams.ts
+++ b/packages/core/src/server/agent-teams.ts
@@ -33,14 +33,35 @@ import {
   type ActiveRun,
 } from "../agent/run-manager.js";
 import { getRunEventsSince } from "../agent/run-store.js";
-import { runAgentLoop } from "../agent/production-agent.js";
-import { buildAssistantMessage } from "../agent/thread-data-builder.js";
+import {
+  runAgentLoop,
+  appendAgentLoopContinuation,
+} from "../agent/production-agent.js";
+import {
+  buildAssistantMessage,
+  foldAssistantTurn,
+  threadDataToEngineMessages,
+} from "../agent/thread-data-builder.js";
 import type { RunEvent } from "../agent/types.js";
 import {
   completeRun as completeProgressRun,
   startRun as startProgressRun,
   updateRunProgress,
 } from "../progress/registry.js";
+import {
+  enqueueAgentTeamRun,
+  claimAgentTeamRun,
+  touchAgentTeamRun,
+  bumpAgentTeamContinuation,
+  completeAgentTeamRun,
+  getAgentTeamRunDispatchState,
+  MAX_AGENT_TEAM_CONTINUATIONS,
+  RUN_DISPATCH_STUCK_AFTER_MS,
+  RUN_PROCESSING_STUCK_AFTER_MS,
+  type AgentTeamRunPayload,
+} from "./agent-teams-run-queue.js";
+import { fireInternalDispatch } from "./self-dispatch.js";
+import { resolveOrgIdForEmail } from "../org/context.js";
 import type {
   BackgroundAgentRun,
   BackgroundAgentRunStatus,
@@ -59,7 +80,19 @@ import {
   listAppState,
   deleteAppState,
 } from "../application-state/script-helpers.js";
-import { getRequestUserEmail } from "./request-context.js";
+import {
+  getRequestUserEmail,
+  runWithRequestContext,
+} from "./request-context.js";
+
+/** Framework route the self-fire dispatch targets to run a queued sub-agent in
+ * a fresh function invocation. Mounted inside the agent-chat plugin (where the
+ * sub-agent action/prompt/engine closures live). */
+export const AGENT_TEAM_PROCESS_RUN_PATH =
+  "/_agent-native/agent-teams/_process-run";
+
+/** Heartbeat cadence for the queue row while a chunk is actively processing. */
+const RUN_QUEUE_HEARTBEAT_MS = 5_000;
 
 export interface AgentTask {
   taskId: string;
@@ -354,10 +387,124 @@ async function loadTaskByThread(threadId: string): Promise<AgentTask | null> {
   return loadTask(ref.taskId as string);
 }
 
+async function completeReconciledTask(
+  task: AgentTask,
+  ownerEmail: string | null,
+): Promise<AgentTask> {
+  task.status = "completed";
+  task.summary = task.summary || task.preview || "Task completed.";
+  task.currentStep = "";
+  task.completedAt = Date.now();
+  await saveTask(task);
+  if (ownerEmail) {
+    await completeTaskProgressRun(
+      task,
+      ownerEmail,
+      "succeeded",
+      "Task completed.",
+    );
+  }
+  return task;
+}
+
+async function failReconciledTask(
+  task: AgentTask,
+  ownerEmail: string | null,
+  message: string,
+  progressStatus: TerminalProgressStatus = "failed",
+): Promise<AgentTask> {
+  task.status = "errored";
+  task.summary = task.summary || task.preview || message;
+  task.error = task.error || message;
+  task.currentStep = "";
+  task.completedAt = Date.now();
+  await saveTask(task);
+  if (ownerEmail) {
+    await completeTaskProgressRun(task, ownerEmail, progressStatus, message);
+  }
+  // Make the dispatch row terminal too so it isn't re-fired.
+  await completeAgentTeamRun(task.taskId, "failed").catch(() => {});
+  return task;
+}
+
+/**
+ * Re-fire a dropped self-dispatch. When the queue row is still queued/running
+ * but its heartbeat has gone stale (the self-fire never landed, or the
+ * processing invocation died), kick the processor again before the hard
+ * stuck-cutoff fail path gives up. Best-effort — the fail path is the backstop.
+ */
+async function refireStuckAgentTeamRunIfNeeded(
+  task: AgentTask,
+  dispatch: NonNullable<
+    Awaited<ReturnType<typeof getAgentTeamRunDispatchState>>
+  >,
+): Promise<void> {
+  if (dispatch.status !== "queued" && dispatch.status !== "running") return;
+  const idleFor = Date.now() - dispatch.updatedAt;
+  if (idleFor < RUN_DISPATCH_STUCK_AFTER_MS) return; // still fresh — leave it
+  if (idleFor >= RUN_PROCESSING_STUCK_AFTER_MS) return; // fail path owns this
+  try {
+    await fireInternalDispatch({
+      path: AGENT_TEAM_PROCESS_RUN_PATH,
+      taskId: task.taskId,
+      body: { mode: dispatch.continuationCount > 0 ? "continue" : "start" },
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Reconcile a task that still reads "running" against the actual run state.
+ *
+ * Durable-dispatch path (the normal case): the `agent_team_run_queue` row is
+ * the authority. While it's queued/running the task stays running (a single
+ * completed agent_runs chunk at a soft-timeout boundary does NOT mean the task
+ * finished — a continuation may be queued/in-flight). A dropped dispatch is
+ * re-fired; a genuinely stalled one (past the hard cutoff) is failed.
+ *
+ * Legacy fallback (no queue row — pre-upgrade tasks, or the in-process
+ * Cloudflare path): fall back to the in-memory/SQL run state via
+ * `getActiveRunForThreadAsync`, with the original missing-run grace.
+ */
 async function reconcileTaskWithRun(task: AgentTask): Promise<AgentTask> {
   if (task.status !== "running") return task;
-  if (!task.runId) return task;
 
+  let dispatch: Awaited<ReturnType<typeof getAgentTeamRunDispatchState>> = null;
+  try {
+    dispatch = await getAgentTeamRunDispatchState(task.taskId);
+  } catch {
+    dispatch = null;
+  }
+
+  if (dispatch) {
+    const ownerEmail = dispatch.ownerEmail ?? getRequestUserEmail() ?? null;
+    if (dispatch.status === "queued" || dispatch.status === "running") {
+      const stuckFor = Date.now() - dispatch.updatedAt;
+      if (stuckFor < RUN_PROCESSING_STUCK_AFTER_MS) {
+        await refireStuckAgentTeamRunIfNeeded(task, dispatch);
+        return task;
+      }
+      return await failReconciledTask(
+        task,
+        ownerEmail,
+        "Sub-agent run stalled and did not produce a result.",
+      );
+    }
+    if (dispatch.status === "failed") {
+      return await failReconciledTask(
+        task,
+        ownerEmail,
+        task.error || task.summary || "Sub-agent run failed.",
+      );
+    }
+    // status === "done" but task still running — safety net (the processor
+    // normally sets the task terminal before completing the queue row).
+    return await completeReconciledTask(task, ownerEmail);
+  }
+
+  // ── Legacy fallback: no durable queue row ────────────────────────────────
+  if (!task.runId) return task;
   let runState:
     | Awaited<ReturnType<typeof getActiveRunForThreadAsync>>
     | undefined;
@@ -366,62 +513,28 @@ async function reconcileTaskWithRun(task: AgentTask): Promise<AgentTask> {
   } catch {
     return task;
   }
-
   if (runState?.status === "running") return task;
 
   const ownerEmail = getRequestUserEmail();
   if (runState?.status === "completed") {
-    task.status = "completed";
-    task.summary = task.summary || task.preview || "Task completed.";
-    task.currentStep = "";
-    task.completedAt = Date.now();
-    await saveTask(task);
-    if (ownerEmail) {
-      await completeTaskProgressRun(
-        task,
-        ownerEmail,
-        "succeeded",
-        "Task completed.",
-      );
-    }
-    return task;
+    return await completeReconciledTask(task, ownerEmail);
   }
-
   if (runState?.status === "errored" || runState?.status === "aborted") {
-    const message =
-      runState.status === "aborted" ? "Task stopped." : "Task failed.";
-    task.status = "errored";
-    task.summary = task.summary || task.preview || message;
-    task.error = task.error || message;
-    task.currentStep = "";
-    task.completedAt = Date.now();
-    await saveTask(task);
-    if (ownerEmail) {
-      await completeTaskProgressRun(
-        task,
-        ownerEmail,
-        runState.status === "aborted" ? "cancelled" : "failed",
-        message,
-      );
-    }
-    return task;
+    return await failReconciledTask(
+      task,
+      ownerEmail,
+      runState.status === "aborted" ? "Task stopped." : "Task failed.",
+      runState.status === "aborted" ? "cancelled" : "failed",
+    );
   }
 
   const referenceAt = task.startedAt ?? task.createdAt;
   if (Date.now() - referenceAt < TASK_RUN_MISSING_GRACE_MS) return task;
-
-  const message =
-    "Sub-agent run is no longer active and did not produce a result.";
-  task.status = "errored";
-  task.summary = message;
-  task.error = message;
-  task.currentStep = "";
-  task.completedAt = Date.now();
-  await saveTask(task);
-  if (ownerEmail) {
-    await completeTaskProgressRun(task, ownerEmail, "failed", message);
-  }
-  return task;
+  return await failReconciledTask(
+    task,
+    ownerEmail,
+    "Sub-agent run is no longer active and did not produce a result.",
+  );
 }
 
 function generateTaskId(): string {
@@ -769,6 +882,8 @@ export interface SpawnTaskOptions {
   parentSend: (event: AgentChatEvent) => void;
   /** Parent thread ID — used to auto-respond when the sub-agent finishes */
   parentThreadId?: string;
+  /** Display name for the sub-agent tab (carried into the dispatch payload). */
+  name?: string;
 }
 
 /**
@@ -844,11 +959,73 @@ export async function spawnTask(opts: SpawnTaskOptions): Promise<AgentTask> {
     status: "running",
   });
 
-  // Build scoped system prompt
-  // Prepend a clear "you are a sub-agent" reminder so the agent doesn't
-  // start exploring the file system or database before using its actions.
-  const actionNames = Object.keys(opts.actions).join(", ");
-  const subAgentPreamble = `## You Are a Sub-Agent
+  // Hand the run off to the durable dispatch queue and self-fire a fresh
+  // function invocation to execute it. This is what makes background
+  // sub-agents survive serverless: the spawning request returns immediately
+  // while the sub-agent runs in its OWN invocation (with its own timeout
+  // budget) instead of as a detached in-process promise that the host freezes
+  // when this response flushes. Same enqueue-to-SQL + self-fire-HTTP pattern
+  // as A2A async tasks (a2a/handlers.ts) and integration webhooks
+  // (integrations/webhook-handler.ts). Execution happens in `processAgentTeamRun`,
+  // invoked by the `/_agent-native/agent-teams/_process-run` route mounted
+  // inside the agent-chat plugin (where the action/prompt/engine closures live).
+  let orgId: string | null = null;
+  try {
+    orgId = (await resolveOrgIdForEmail(opts.ownerEmail)) ?? null;
+  } catch {
+    orgId = null;
+  }
+
+  const payload: AgentTeamRunPayload = {
+    description: opts.description,
+    instructions: opts.instructions,
+    model: opts.model,
+    parentThreadId: opts.parentThreadId,
+    name: opts.name,
+    // Stable across continuation chunks so the durable assistant message folds.
+    turnId: runId,
+  };
+
+  try {
+    await enqueueAgentTeamRun({
+      taskId,
+      threadId: thread.id,
+      runId,
+      ownerEmail: opts.ownerEmail,
+      orgId,
+      payload,
+    });
+    await fireInternalDispatch({
+      path: AGENT_TEAM_PROCESS_RUN_PATH,
+      taskId,
+      body: { mode: "start" },
+    });
+  } catch (err) {
+    // Enqueue/dispatch failed outright — surface as an errored task rather
+    // than a ghost "running" one. (A dropped self-fire that still enqueued is
+    // recovered by the reconcile stuck-refire path.)
+    const message =
+      err instanceof Error
+        ? `Failed to start sub-agent: ${err.message}`
+        : "Failed to start sub-agent.";
+    await failReconciledTask(task, opts.ownerEmail, message);
+  }
+
+  return task;
+}
+
+/**
+ * Build the sub-agent system prompt: a "you are a sub-agent" preamble (so it
+ * starts on its task instead of exploring), the base prompt, and any
+ * task-specific instructions.
+ */
+function buildSubAgentSystemPrompt(
+  baseSystemPrompt: string,
+  actions: Record<string, ActionEntry>,
+  instructions?: string,
+): string {
+  const actionNames = Object.keys(actions).join(", ");
+  const preamble = `## You Are a Sub-Agent
 
 You are a focused sub-agent with a specific task. You have been given a curated set of actions that connect directly to the app's database and services.
 
@@ -861,226 +1038,337 @@ You are a focused sub-agent with a specific task. You have been given a curated 
 **Your available actions (${actionNames}) work directly. Use them.**
 
 `;
-  let systemPrompt = subAgentPreamble + opts.systemPrompt;
-  if (opts.instructions) {
-    systemPrompt += `\n\n## Task-Specific Instructions\n\n${opts.instructions}`;
+  let prompt = preamble + baseSystemPrompt;
+  if (instructions) {
+    prompt += `\n\n## Task-Specific Instructions\n\n${instructions}`;
+  }
+  return prompt;
+}
+
+/**
+ * Persist the sub-agent conversation to thread_data, folding continuation
+ * chunks of the same turn into one assistant message (same `foldAssistantTurn`
+ * mechanism the main chat uses). Returns the full folded assistant text for use
+ * as the task summary so multi-chunk runs don't lose earlier chunks' output.
+ */
+async function persistTaskThreadData(
+  task: AgentTask,
+  description: string,
+  run: ActiveRun,
+  runId: string,
+  turnId: string,
+): Promise<string> {
+  try {
+    const { getThread, updateThreadData } =
+      await import("../chat-threads/store.js");
+    const thread = await getThread(task.threadId);
+    let repo: any;
+    try {
+      repo = JSON.parse(thread?.threadData || "{}");
+    } catch {
+      repo = {};
+    }
+    if (!Array.isArray(repo.messages)) repo.messages = [];
+
+    // Ensure the seed user message exists (first chunk / fresh thread).
+    const userMsgId = `msg-${task.taskId}-user`;
+    const hasUser = repo.messages.some(
+      (m: any) => (m?.message ?? m)?.id === userMsgId,
+    );
+    if (!hasUser) {
+      repo.messages.unshift({
+        message: {
+          id: userMsgId,
+          role: "user",
+          content: [{ type: "text", text: description }],
+          metadata: {},
+        },
+        parentId: null,
+      });
+      if (!repo.headId) repo.headId = userMsgId;
+    }
+
+    const assistantMsg = buildAssistantMessage(run.events ?? [], runId, {
+      suppressInternalContinuation: true,
+      turnId,
+    });
+    if (assistantMsg) {
+      repo = foldAssistantTurn(repo, assistantMsg, { runId, turnId });
+    }
+
+    // Extract the folded assistant text (full content across chunks).
+    let assistantText = "";
+    const headEntry = Array.isArray(repo.messages)
+      ? repo.messages.find((m: any) => (m?.message ?? m)?.id === repo.headId)
+      : undefined;
+    const headMsg = headEntry?.message ?? headEntry;
+    if (headMsg?.role === "assistant" && Array.isArray(headMsg.content)) {
+      assistantText = headMsg.content
+        .filter((c: any) => c?.type === "text" && typeof c.text === "string")
+        .map((c: any) => c.text)
+        .join("\n");
+    }
+
+    await updateThreadData(
+      task.threadId,
+      JSON.stringify(repo),
+      description.slice(0, 100),
+      assistantText.slice(0, 200),
+      Array.isArray(repo.messages) ? repo.messages.length : 1,
+    );
+    return assistantText;
+  } catch {
+    return "";
+  }
+}
+
+/** Mark a sub-agent task terminal: task record, progress row, and queue row. */
+async function finalizeAgentTeamRun(
+  task: AgentTask,
+  run: ActiveRun,
+  ownerEmail: string | null,
+  fullText: string,
+): Promise<void> {
+  const terminal = resolveTaskCompletion(run, fullText);
+  task.status = terminal.taskStatus;
+  task.summary = terminal.summary;
+  task.error = terminal.error;
+  task.currentStep = "";
+  task.completedAt = Date.now();
+  await saveTask(task);
+  if (ownerEmail) {
+    await completeTaskProgressRun(
+      task,
+      ownerEmail,
+      terminal.progressStatus,
+      terminal.progressStep,
+    );
+  }
+  await completeAgentTeamRun(
+    task.taskId,
+    terminal.taskStatus === "completed" ? "done" : "failed",
+  );
+}
+
+/** Run config the processor route resolves from plugin-scope closures. */
+export interface AgentTeamRunConfig {
+  baseSystemPrompt: string;
+  actions: Record<string, ActionEntry>;
+  engine: AgentEngine;
+  model: string;
+}
+
+export interface ProcessAgentTeamRunOptions {
+  taskId: string;
+  /** "start" = first chunk; "continue" = resume from thread_data after a
+   * soft-timeout boundary. Defaults from the queue row's continuation count. */
+  mode?: "start" | "continue";
+  /** Inbound request event, used to resolve the self-dispatch base URL for
+   * continuation self-fires. */
+  event?: any;
+  /** Builds the sub-agent run config from the queue payload + resolved owner.
+   * The plugin supplies this because the action registry / base prompt /
+   * engine are per-deployment plugin-scope closures, not serializable. */
+  resolveConfig: (ctx: {
+    payload: AgentTeamRunPayload;
+    ownerEmail: string;
+    orgId: string | null;
+  }) => Promise<AgentTeamRunConfig>;
+}
+
+/**
+ * Execute one chunk of a queued sub-agent run in a fresh function invocation.
+ * Called by the `/_agent-native/agent-teams/_process-run` route. Atomically
+ * claims the run (idempotent on duplicate self-fires), reconstructs the
+ * messages (start vs continue), runs the agent loop to completion, persists
+ * thread_data, and either self-fires a continuation (soft-timeout boundary,
+ * under the cap) or finalizes the task.
+ */
+export async function processAgentTeamRun(
+  opts: ProcessAgentTeamRunOptions,
+): Promise<{ ok: boolean; skipped?: string }> {
+  const claimed = await claimAgentTeamRun(opts.taskId);
+  if (!claimed) return { ok: true, skipped: "already-claimed-or-missing" };
+
+  const task = await loadTask(opts.taskId);
+  if (!task) {
+    await completeAgentTeamRun(opts.taskId, "failed");
+    return { ok: true, skipped: "task-missing" };
+  }
+  if (task.status !== "running") {
+    await completeAgentTeamRun(
+      opts.taskId,
+      task.status === "completed" ? "done" : "failed",
+    );
+    return { ok: true, skipped: "task-terminal" };
   }
 
-  // Resolve the engine — prefer the passed engine, fall back to Anthropic with apiKey
-  const engine: AgentEngine =
-    opts.engine ?? createAnthropicEngine({ apiKey: opts.apiKey });
-  const model = opts.model ?? engine.defaultModel;
+  const payload = claimed.payload;
+  const ownerEmail = claimed.ownerEmail ?? getRequestUserEmail() ?? "";
+  const orgId = claimed.orgId;
+  const turnId = payload.turnId || taskRunId(opts.taskId);
 
-  // Build tools from actions using the normalized EngineTool format
-  const messageAwareActions = createMessageAwareActions(taskId, opts.actions);
-  const tools = actionsToEngineTools(messageAwareActions);
+  let config: AgentTeamRunConfig;
+  try {
+    config = await opts.resolveConfig({ payload, ownerEmail, orgId });
+  } catch (err) {
+    const message =
+      err instanceof Error
+        ? `Failed to prepare sub-agent: ${err.message}`
+        : "Failed to prepare sub-agent.";
+    await failReconciledTask(task, ownerEmail || null, message);
+    return { ok: false, skipped: "config-failed" };
+  }
 
-  const messages: EngineMessage[] = [
-    { role: "user", content: [{ type: "text", text: opts.description }] },
-  ];
+  const mode: "start" | "continue" =
+    opts.mode ?? (claimed.continuationCount > 0 ? "continue" : "start");
 
-  // Start the agent run in background
-  let accumulatedText = "";
-  let lastPreviewSent = 0;
-  const PREVIEW_INTERVAL_MS = 300; // Throttle preview updates to every 300ms
-  let lastProgressSent = 0;
-  const PROGRESS_INTERVAL_MS = 2000;
-  // Gate to prevent sendPreviewUpdate from overwriting terminal status
-  let runFinished = false;
-
-  startRun(
-    runId,
-    thread.id,
-    async (send, signal) => {
-      const sendPreviewUpdate = async (force = false) => {
-        if (runFinished) return; // Don't overwrite completed/errored status
-        const now = Date.now();
-        if (!force && now - lastPreviewSent < PREVIEW_INTERVAL_MS) return;
-        lastPreviewSent = now;
-        task.preview = accumulatedText.slice(-800);
-        // Persist to SQL so status checks from other processes see live state
-        await saveTask(task);
-        const shouldUpdateProgress =
-          force || now - lastProgressSent >= PROGRESS_INTERVAL_MS;
-        if (shouldUpdateProgress) {
-          lastProgressSent = now;
-          void updateTaskProgressRun(task, opts.ownerEmail);
-        }
-        opts.parentSend({
-          type: "agent_task_update",
-          taskId,
-          preview: task.preview,
-          currentStep: task.currentStep,
-        });
-      };
-
-      // Wrap the send function to also emit preview updates to parent
-      const wrappedSend = (event: AgentChatEvent) => {
-        send(event);
-
-        if (event.type === "text") {
-          accumulatedText += event.text;
-          sendPreviewUpdate();
-        } else if (event.type === "tool_start") {
-          task.currentStep = `Running ${event.tool}...`;
-          sendPreviewUpdate(true);
-        } else if (event.type === "tool_done") {
-          task.currentStep = "";
-          sendPreviewUpdate(true);
-        }
-      };
-
-      await runAgentLoop({
-        engine,
-        model,
-        systemPrompt,
-        tools,
-        messages,
-        actions: messageAwareActions,
-        send: wrappedSend,
-        signal,
-        finalResponseGuard: createTaskMessageFinalGuard(taskId),
-      });
-    },
-    // onComplete callback — called when the run finishes (success or error)
-    async (run) => {
-      // Prevent any in-flight sendPreviewUpdate from overwriting terminal status
-      runFinished = true;
-
-      const terminal = resolveTaskCompletion(run, accumulatedText);
-      task.status = terminal.taskStatus;
-      task.summary = terminal.summary;
-      task.error = terminal.error;
-      task.currentStep = "";
-      task.completedAt = Date.now();
-      await saveTask(task);
-      await completeTaskProgressRun(
-        task,
-        opts.ownerEmail,
-        terminal.progressStatus,
-        terminal.progressStep,
-      );
-
-      if (terminal.taskStatus === "errored") {
-        // Emit error as agent_task_complete with errored status
-        opts.parentSend({
-          type: "agent_task",
-          taskId,
-          threadId: thread.id,
-          description: task.description,
-          status: "errored",
-        });
-      } else {
-        opts.parentSend({
-          type: "agent_task_complete",
-          taskId,
-          summary: task.summary,
-        });
-      }
-
-      // Persist the full conversation to threadData so the sub-agent tab
-      // can restore it later (after the in-memory run is cleaned up).
-      // Rebuild from run.events via buildAssistantMessage so partial text
-      // streamed in an interrupted final iteration is preserved — the
-      // EngineMessage[] array only picks up a turn after runAgentLoop
-      // finishes pushing, so an aborted mid-stream would otherwise be lost.
-      try {
-        const { updateThreadData } = await import("../chat-threads/store.js");
-        const userMsg = {
-          id: `msg-${taskId}-user`,
-          role: "user" as const,
-          content: [{ type: "text", text: opts.description }],
-          metadata: {},
-        };
-        const assistantMsg = buildAssistantMessage(
-          run.events ?? [],
-          `task-${taskId}`,
-        );
-        // Chain assistant → user via parentId so assistant-ui renders them
-        // as a linked conversation, not orphaned siblings. headId points to
-        // the leaf (assistant if present, otherwise the user message).
-        const messages: Array<{
-          message: Record<string, unknown>;
-          parentId: string | null;
-        }> = [{ message: userMsg, parentId: null }];
-        if (assistantMsg) {
-          messages.push({
-            message: {
-              ...assistantMsg,
-              status: { type: "complete", reason: "stop" },
-            },
-            parentId: userMsg.id,
-          });
-        }
-        const headId = assistantMsg?.id ?? (userMsg.id as string | undefined);
-        const repo = { headId, messages };
-
-        const title = opts.description.slice(0, 100);
-        const preview = accumulatedText.slice(0, 200);
-        await updateThreadData(
-          thread.id,
-          JSON.stringify(repo),
-          title,
-          preview,
-          repo.messages.length,
-        );
-      } catch {
-        // Best effort — the in-memory replay path still works
-      }
-
-      // ─── Auto-follow-up on parent thread ────────────────────────────
-      // When the sub-agent finishes, start a short agent run on the
-      // parent thread so the user sees a recap without having to scroll
-      // up or manually check the sub-agent card.
-      if (opts.parentThreadId) {
-        try {
-          const { getActiveRunForThread } =
-            await import("../agent/run-manager.js");
-          // Only auto-respond if the parent thread is idle — don't
-          // interrupt an ongoing conversation.
-          const activeRun = getActiveRunForThread(opts.parentThreadId);
-          if (!activeRun || activeRun.status !== "running") {
-            const followUpEngine =
-              opts.engine ?? createAnthropicEngine({ apiKey: opts.apiKey });
-            const followUpModel = opts.model ?? followUpEngine.defaultModel;
-
-            const statusEmoji = task.status === "errored" ? "!" : "done";
-            const notification =
-              `[Sub-agent ${statusEmoji}] The sub-agent task "${task.description}" has ${task.status === "errored" ? "failed" : "completed"}.\n\n` +
-              `Summary of what it did:\n${task.summary}\n\n` +
-              `Briefly let the user know the sub-agent finished and highlight any key results. Be concise — 1-2 sentences.`;
-
-            const followUpRunId = `run-followup-${taskId}`;
-            startRun(
-              followUpRunId,
-              opts.parentThreadId,
-              async (send, signal) => {
-                await runAgentLoop({
-                  engine: followUpEngine,
-                  model: followUpModel,
-                  systemPrompt: opts.systemPrompt,
-                  tools: [], // No tools needed for a recap
-                  messages: [
-                    {
-                      role: "user",
-                      content: [{ type: "text", text: notification }],
-                    },
-                  ],
-                  actions: {},
-                  send,
-                  signal,
-                });
-              },
-            );
-          }
-        } catch {
-          // Best effort — don't break the sub-agent completion
-        }
-      }
-    },
+  const systemPrompt = buildSubAgentSystemPrompt(
+    config.baseSystemPrompt,
+    config.actions,
+    payload.instructions,
   );
 
-  return task;
+  let messages: EngineMessage[];
+  if (mode === "continue") {
+    let priorThreadData: string | null | undefined;
+    try {
+      const { getThread } = await import("../chat-threads/store.js");
+      priorThreadData = (await getThread(task.threadId))?.threadData;
+    } catch {
+      priorThreadData = undefined;
+    }
+    messages = threadDataToEngineMessages(priorThreadData);
+    if (messages.length === 0) {
+      messages = [
+        {
+          role: "user",
+          content: [{ type: "text", text: payload.description }],
+        },
+      ];
+    }
+    appendAgentLoopContinuation(messages, "run_timeout");
+  } else {
+    messages = [
+      { role: "user", content: [{ type: "text", text: payload.description }] },
+    ];
+  }
+
+  const messageAwareActions = createMessageAwareActions(
+    opts.taskId,
+    config.actions,
+  );
+  const tools = actionsToEngineTools(messageAwareActions);
+
+  // Fresh runId per chunk (avoids agent_runs PK collisions); stable turnId so
+  // the durable assistant message folds across chunks.
+  const runId = `${taskRunId(opts.taskId)}-c${claimed.continuationCount}`;
+
+  task.currentStep =
+    mode === "continue" ? "Continuing sub-agent" : "Working on response";
+  task.startedAt = task.startedAt ?? Date.now();
+  await saveTask(task);
+  if (ownerEmail) await updateTaskProgressRun(task, ownerEmail);
+
+  const heartbeat = setInterval(() => {
+    void touchAgentTeamRun(opts.taskId);
+  }, RUN_QUEUE_HEARTBEAT_MS);
+  (heartbeat as unknown as { unref?: () => void }).unref?.();
+
+  let accumulatedText = "";
+  let lastProgressSent = 0;
+  const PROGRESS_INTERVAL_MS = 2000;
+
+  await new Promise<void>((resolve) => {
+    startRun(
+      runId,
+      task.threadId,
+      async (send, signal) => {
+        const wrappedSend = (event: AgentChatEvent) => {
+          send(event);
+          if (event.type === "text") {
+            accumulatedText += event.text;
+            task.preview = accumulatedText.slice(-800);
+            const now = Date.now();
+            if (now - lastProgressSent >= PROGRESS_INTERVAL_MS) {
+              lastProgressSent = now;
+              void saveTask(task);
+              if (ownerEmail) void updateTaskProgressRun(task, ownerEmail);
+            }
+          } else if (event.type === "tool_start") {
+            task.currentStep = `Running ${event.tool}...`;
+          } else if (event.type === "tool_done") {
+            task.currentStep = "";
+          }
+        };
+        await runWithRequestContext(
+          { userEmail: ownerEmail || undefined, orgId: orgId ?? undefined },
+          async () => {
+            await runAgentLoop({
+              engine: config.engine,
+              model: config.model,
+              systemPrompt,
+              tools,
+              messages,
+              actions: messageAwareActions,
+              send: wrappedSend,
+              signal,
+              finalResponseGuard: createTaskMessageFinalGuard(opts.taskId),
+            });
+          },
+        );
+      },
+      async (run) => {
+        clearInterval(heartbeat);
+        try {
+          const fullText = await persistTaskThreadData(
+            task,
+            payload.description,
+            run,
+            runId,
+            turnId,
+          );
+
+          // A soft-timeout boundary means the host function wall is near and
+          // the partial turn is checkpointed in thread_data — self-fire the
+          // next continuation chunk (server-side analog of the client re-POST
+          // that continues the main chat) instead of finalizing.
+          const reachedBoundary = (run.events ?? []).some(
+            (e) => e.event.type === "auto_continue",
+          );
+          if (reachedBoundary) {
+            const count = await bumpAgentTeamContinuation(opts.taskId);
+            if (count !== null && count <= MAX_AGENT_TEAM_CONTINUATIONS) {
+              task.currentStep = "Continuing sub-agent";
+              task.preview = (fullText || accumulatedText).slice(-800);
+              await saveTask(task);
+              if (ownerEmail) await updateTaskProgressRun(task, ownerEmail);
+              await fireInternalDispatch({
+                event: opts.event,
+                path: AGENT_TEAM_PROCESS_RUN_PATH,
+                taskId: opts.taskId,
+                body: { mode: "continue" },
+              });
+              return;
+            }
+            // Hit the cap — finalize with whatever was produced.
+          }
+
+          await finalizeAgentTeamRun(
+            task,
+            run,
+            ownerEmail || null,
+            fullText || accumulatedText,
+          );
+        } finally {
+          resolve();
+        }
+      },
+      { useHostedSoftTimeoutDefault: true, turnId },
+    );
+  });
+
+  return { ok: true };
 }
 
 /** Get task by ID */

--- a/packages/core/src/server/agent-teams.ts
+++ b/packages/core/src/server/agent-teams.ts
@@ -26,14 +26,21 @@ import { createAnthropicEngine } from "../agent/engine/anthropic-engine.js";
 import { createThread } from "../chat-threads/store.js";
 import {
   abortRun,
+  getActiveRunForThreadAsync,
   getRun,
   startRun,
   subscribeToRun,
+  type ActiveRun,
 } from "../agent/run-manager.js";
 import { getRunEventsSince } from "../agent/run-store.js";
 import { runAgentLoop } from "../agent/production-agent.js";
 import { buildAssistantMessage } from "../agent/thread-data-builder.js";
 import type { RunEvent } from "../agent/types.js";
+import {
+  completeRun as completeProgressRun,
+  startRun as startProgressRun,
+  updateRunProgress,
+} from "../progress/registry.js";
 import type {
   BackgroundAgentRun,
   BackgroundAgentRunStatus,
@@ -63,6 +70,11 @@ export interface AgentTask {
   summary: string;
   currentStep: string;
   createdAt: number;
+  updatedAt?: number;
+  startedAt?: number;
+  completedAt?: number;
+  runId?: string;
+  error?: string;
 }
 
 export type AgentTeamBackgroundRun = Omit<
@@ -139,6 +151,8 @@ const THREAD_PREFIX = "agent-task-thread:";
 
 /** Key prefix for queued orchestrator→sub-agent messages. */
 const TASK_MESSAGE_PREFIX = "task-message:";
+
+const TASK_RUN_MISSING_GRACE_MS = 60_000;
 
 export interface QueuedTaskMessage {
   id: string;
@@ -322,6 +336,7 @@ function createTaskMessageFinalGuard(
 }
 
 async function saveTask(task: AgentTask): Promise<void> {
+  task.updatedAt = Date.now();
   await writeAppState(`${TASK_PREFIX}${task.taskId}`, task as any);
   await writeAppState(`${THREAD_PREFIX}${task.threadId}`, {
     taskId: task.taskId,
@@ -337,6 +352,76 @@ async function loadTaskByThread(threadId: string): Promise<AgentTask | null> {
   const ref = await readAppState(`${THREAD_PREFIX}${threadId}`);
   if (!ref || !ref.taskId) return null;
   return loadTask(ref.taskId as string);
+}
+
+async function reconcileTaskWithRun(task: AgentTask): Promise<AgentTask> {
+  if (task.status !== "running") return task;
+  if (!task.runId) return task;
+
+  let runState:
+    | Awaited<ReturnType<typeof getActiveRunForThreadAsync>>
+    | undefined;
+  try {
+    runState = await getActiveRunForThreadAsync(task.threadId);
+  } catch {
+    return task;
+  }
+
+  if (runState?.status === "running") return task;
+
+  const ownerEmail = getRequestUserEmail();
+  if (runState?.status === "completed") {
+    task.status = "completed";
+    task.summary = task.summary || task.preview || "Task completed.";
+    task.currentStep = "";
+    task.completedAt = Date.now();
+    await saveTask(task);
+    if (ownerEmail) {
+      await completeTaskProgressRun(
+        task,
+        ownerEmail,
+        "succeeded",
+        "Task completed.",
+      );
+    }
+    return task;
+  }
+
+  if (runState?.status === "errored" || runState?.status === "aborted") {
+    const message =
+      runState.status === "aborted" ? "Task stopped." : "Task failed.";
+    task.status = "errored";
+    task.summary = task.summary || task.preview || message;
+    task.error = task.error || message;
+    task.currentStep = "";
+    task.completedAt = Date.now();
+    await saveTask(task);
+    if (ownerEmail) {
+      await completeTaskProgressRun(
+        task,
+        ownerEmail,
+        runState.status === "aborted" ? "cancelled" : "failed",
+        message,
+      );
+    }
+    return task;
+  }
+
+  const referenceAt = task.startedAt ?? task.createdAt;
+  if (Date.now() - referenceAt < TASK_RUN_MISSING_GRACE_MS) return task;
+
+  const message =
+    "Sub-agent run is no longer active and did not produce a result.";
+  task.status = "errored";
+  task.summary = message;
+  task.error = message;
+  task.currentStep = "";
+  task.completedAt = Date.now();
+  await saveTask(task);
+  if (ownerEmail) {
+    await completeTaskProgressRun(task, ownerEmail, "failed", message);
+  }
+  return task;
 }
 
 function generateTaskId(): string {
@@ -370,10 +455,141 @@ function latestTaskText(task: AgentTask): string | undefined {
   return task.summary || task.preview || task.currentStep || undefined;
 }
 
+function formatTaskPhase(task: AgentTask): string {
+  if (task.status === "running") return task.currentStep || "Running";
+  if (task.status === "completed") return "Completed";
+  const phase = task.error || task.summary || "Task failed.";
+  return phase.length > 120 ? `${phase.slice(0, 117)}...` : phase;
+}
+
+type TerminalProgressStatus = "succeeded" | "failed" | "cancelled";
+
+function taskProgressMetadata(task: AgentTask): Record<string, unknown> {
+  return {
+    kind: "agent-team",
+    source: "agent-teams",
+    taskId: task.taskId,
+    threadId: task.threadId,
+    description: task.description,
+    preview: task.preview,
+    summary: task.summary,
+    currentStep: task.currentStep,
+    surfaceUrl: `agent-native://threads/${encodeURIComponent(task.threadId)}`,
+  };
+}
+
+function currentTaskProgressStep(task: AgentTask): string {
+  return (
+    task.currentStep ||
+    (task.preview ? "Working on response" : "Starting sub-agent")
+  );
+}
+
+async function startTaskProgressRun(
+  task: AgentTask,
+  ownerEmail: string,
+): Promise<void> {
+  const runId = task.runId ?? taskRunId(task.taskId);
+  task.runId = runId;
+  try {
+    await startProgressRun({
+      id: runId,
+      owner: ownerEmail,
+      title: task.description,
+      step: currentTaskProgressStep(task),
+      metadata: taskProgressMetadata(task),
+    });
+  } catch {
+    // Progress rows are user-facing visibility. A write failure should not
+    // prevent the sub-agent from running or the task card from updating.
+  }
+}
+
+async function updateTaskProgressRun(
+  task: AgentTask,
+  ownerEmail: string,
+): Promise<void> {
+  const runId = task.runId ?? taskRunId(task.taskId);
+  task.runId = runId;
+  try {
+    await updateRunProgress(runId, ownerEmail, {
+      step: currentTaskProgressStep(task),
+      metadata: taskProgressMetadata(task),
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+async function completeTaskProgressRun(
+  task: AgentTask,
+  ownerEmail: string,
+  status: TerminalProgressStatus,
+  step: string,
+): Promise<void> {
+  const runId = task.runId ?? taskRunId(task.taskId);
+  task.runId = runId;
+  try {
+    await completeProgressRun(runId, ownerEmail, status, {
+      step,
+      metadata: taskProgressMetadata(task),
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+function resolveTaskCompletion(
+  run: Pick<ActiveRun, "status" | "abortReason">,
+  accumulatedText: string,
+): {
+  taskStatus: "completed" | "errored";
+  summary: string;
+  progressStatus: TerminalProgressStatus;
+  progressStep: string;
+  error?: string;
+} {
+  const text = accumulatedText.trim();
+  if (run.status === "aborted") {
+    const stopped =
+      run.abortReason && run.abortReason !== "user"
+        ? `Task stopped: ${run.abortReason}`
+        : "Task stopped.";
+    return {
+      taskStatus: "errored",
+      summary: stopped,
+      progressStatus: "cancelled",
+      progressStep: stopped,
+      error: stopped,
+    };
+  }
+  if (run.status === "errored") {
+    const failed = text.slice(-500) || "Task failed.";
+    return {
+      taskStatus: "errored",
+      summary: failed,
+      progressStatus: "failed",
+      progressStep: "Task failed.",
+      error: failed,
+    };
+  }
+  const summary = text.slice(-1000) || "Task completed successfully.";
+  return {
+    taskStatus: "completed",
+    summary,
+    progressStatus: "succeeded",
+    progressStep: "Task completed.",
+  };
+}
+
 export function toAgentTaskBackgroundRun(
   task: AgentTask,
 ): AgentTeamBackgroundRun {
   const createdAt = taskTimestampToIso(task.createdAt);
+  const updatedAt = taskTimestampToIso(
+    task.completedAt ?? task.updatedAt ?? task.createdAt,
+  );
+  const phase = formatTaskPhase(task);
   return {
     schemaVersion: 1,
     id: taskRunId(task.taskId),
@@ -386,11 +602,12 @@ export function toAgentTaskBackgroundRun(
       threadId: task.threadId,
     },
     title: task.description,
-    subtitle: task.currentStep || undefined,
+    subtitle:
+      task.currentStep || (task.status === "errored" ? phase : undefined),
     status: mapTaskStatusToBackgroundStatus(task.status),
-    phase: task.currentStep || task.status,
+    phase,
     createdAt,
-    updatedAt: createdAt,
+    updatedAt,
     goalId: "agent-team",
     needsInput: false,
     needsApproval: false,
@@ -407,6 +624,8 @@ export function toAgentTaskBackgroundRun(
       summary: task.summary,
       currentStep: task.currentStep,
       latestText: latestTaskText(task),
+      completedAt: task.completedAt,
+      error: task.error,
     },
   };
 }
@@ -597,6 +816,8 @@ export async function spawnTask(opts: SpawnTaskOptions): Promise<AgentTask> {
     // Best effort — thread will still work without persisted messages
   }
 
+  const runId = taskRunId(taskId);
+  const createdAt = Date.now();
   const task: AgentTask = {
     taskId,
     threadId: thread.id,
@@ -604,11 +825,15 @@ export async function spawnTask(opts: SpawnTaskOptions): Promise<AgentTask> {
     status: "running",
     preview: "",
     summary: "",
-    currentStep: "",
-    createdAt: Date.now(),
+    currentStep: "Starting sub-agent",
+    createdAt,
+    updatedAt: createdAt,
+    startedAt: createdAt,
+    runId,
   };
 
   await saveTask(task);
+  await startTaskProgressRun(task, opts.ownerEmail);
 
   // Notify parent chat that a sub-agent was spawned
   opts.parentSend({
@@ -655,10 +880,11 @@ You are a focused sub-agent with a specific task. You have been given a curated 
   ];
 
   // Start the agent run in background
-  const runId = `run-task-${taskId}`;
   let accumulatedText = "";
   let lastPreviewSent = 0;
   const PREVIEW_INTERVAL_MS = 300; // Throttle preview updates to every 300ms
+  let lastProgressSent = 0;
+  const PROGRESS_INTERVAL_MS = 2000;
   // Gate to prevent sendPreviewUpdate from overwriting terminal status
   let runFinished = false;
 
@@ -674,6 +900,12 @@ You are a focused sub-agent with a specific task. You have been given a curated 
         task.preview = accumulatedText.slice(-800);
         // Persist to SQL so status checks from other processes see live state
         await saveTask(task);
+        const shouldUpdateProgress =
+          force || now - lastProgressSent >= PROGRESS_INTERVAL_MS;
+        if (shouldUpdateProgress) {
+          lastProgressSent = now;
+          void updateTaskProgressRun(task, opts.ownerEmail);
+        }
         opts.parentSend({
           type: "agent_task_update",
           taskId,
@@ -715,10 +947,21 @@ You are a focused sub-agent with a specific task. You have been given a curated 
       // Prevent any in-flight sendPreviewUpdate from overwriting terminal status
       runFinished = true;
 
-      if (run.status === "errored") {
-        task.status = "errored";
-        task.summary = accumulatedText.slice(-500) || "Task failed.";
-        await saveTask(task);
+      const terminal = resolveTaskCompletion(run, accumulatedText);
+      task.status = terminal.taskStatus;
+      task.summary = terminal.summary;
+      task.error = terminal.error;
+      task.currentStep = "";
+      task.completedAt = Date.now();
+      await saveTask(task);
+      await completeTaskProgressRun(
+        task,
+        opts.ownerEmail,
+        terminal.progressStatus,
+        terminal.progressStep,
+      );
+
+      if (terminal.taskStatus === "errored") {
         // Emit error as agent_task_complete with errored status
         opts.parentSend({
           type: "agent_task",
@@ -728,10 +971,6 @@ You are a focused sub-agent with a specific task. You have been given a curated 
           status: "errored",
         });
       } else {
-        task.status = "completed";
-        task.summary =
-          accumulatedText.slice(-1000) || "Task completed successfully.";
-        await saveTask(task);
         opts.parentSend({
           type: "agent_task_complete",
           taskId,
@@ -847,7 +1086,7 @@ You are a focused sub-agent with a specific task. You have been given a curated 
 /** Get task by ID */
 export async function getTask(taskId: string): Promise<AgentTask | undefined> {
   const task = await loadTask(taskId);
-  return task ?? undefined;
+  return task ? await reconcileTaskWithRun(task) : undefined;
 }
 
 /** Get task by thread ID */
@@ -855,14 +1094,19 @@ export async function getTaskByThread(
   threadId: string,
 ): Promise<AgentTask | undefined> {
   const task = await loadTaskByThread(threadId);
-  return task ?? undefined;
+  return task ? await reconcileTaskWithRun(task) : undefined;
 }
 
 /** List all tasks (most recent first) */
 export async function listTasks(): Promise<AgentTask[]> {
   const entries = await listAppState(TASK_PREFIX);
   const tasks = entries.map((e) => e.value as unknown as AgentTask);
-  return tasks.sort((a, b) => b.createdAt - a.createdAt);
+  const reconciled = await Promise.all(tasks.map(reconcileTaskWithRun));
+  return reconciled.sort(
+    (a, b) =>
+      (b.updatedAt ?? b.completedAt ?? b.createdAt) -
+      (a.updatedAt ?? a.completedAt ?? a.createdAt),
+  );
 }
 
 export async function listAgentTeamBackgroundRuns(): Promise<
@@ -875,7 +1119,9 @@ export async function getAgentTeamBackgroundRun(
   runId: string,
 ): Promise<AgentTeamBackgroundRun | null> {
   const task = await loadTask(taskIdFromBackgroundRunId(runId));
-  return task ? toAgentTaskBackgroundRun(task) : null;
+  return task
+    ? toAgentTaskBackgroundRun(await reconcileTaskWithRun(task))
+    : null;
 }
 
 export async function listAgentTeamBackgroundTranscriptEvents(
@@ -1021,7 +1267,14 @@ export async function stopAgentTeamBackgroundRun(
   task.status = "errored";
   task.summary =
     reason === "user" ? "Task stopped." : `Task stopped: ${reason}`;
+  task.error = task.summary;
+  task.currentStep = "";
+  task.completedAt = Date.now();
   await saveTask(task);
+  const ownerEmail = getRequestUserEmail();
+  if (ownerEmail) {
+    await completeTaskProgressRun(task, ownerEmail, "cancelled", task.summary);
+  }
   return { ok: true };
 }
 
@@ -1034,7 +1287,14 @@ export async function markTaskErrored(
   if (task) {
     task.status = "errored";
     task.summary = error;
+    task.error = error;
+    task.currentStep = "";
+    task.completedAt = Date.now();
     await saveTask(task);
+    const ownerEmail = getRequestUserEmail();
+    if (ownerEmail) {
+      await completeTaskProgressRun(task, ownerEmail, "failed", error);
+    }
   }
 }
 
@@ -1043,4 +1303,5 @@ export const _agentTeamsQueueForTests = {
   createTaskMessageFinalGuard,
   drainQueuedTaskMessages,
   formatQueuedTaskMessages,
+  resolveTaskCompletion,
 };

--- a/packages/core/src/server/agent-teams.ts
+++ b/packages/core/src/server/agent-teams.ts
@@ -22,7 +22,6 @@ import type {
 } from "../agent/production-agent.js";
 import { actionsToEngineTools } from "../agent/production-agent.js";
 import type { AgentEngine, EngineMessage } from "../agent/engine/types.js";
-import { createAnthropicEngine } from "../agent/engine/anthropic-engine.js";
 import { createThread } from "../chat-threads/store.js";
 import {
   abortRun,
@@ -55,6 +54,7 @@ import {
   bumpAgentTeamContinuation,
   completeAgentTeamRun,
   getAgentTeamRunDispatchState,
+  listActiveAgentTeamTaskIdsForOwner,
   MAX_AGENT_TEAM_CONTINUATIONS,
   RUN_DISPATCH_STUCK_AFTER_MS,
   RUN_PROCESSING_STUCK_AFTER_MS,
@@ -535,6 +535,31 @@ async function reconcileTaskWithRun(task: AgentTask): Promise<AgentTask> {
     ownerEmail,
     "Sub-agent run is no longer active and did not produce a result.",
   );
+}
+
+/**
+ * Reconcile all of an owner's in-flight sub-agent runs. Wired into the RunsTray
+ * data path (`/_agent-native/runs`) so the tray self-heals: dropped dispatches
+ * are re-fired and dead runs are marked failed promptly, even when the
+ * orchestrator chat never polls `status`/`read-result`.
+ */
+export async function reconcileAgentTeamRunsForOwner(
+  owner: string,
+): Promise<void> {
+  let taskIds: string[];
+  try {
+    taskIds = await listActiveAgentTeamTaskIdsForOwner(owner);
+  } catch {
+    return;
+  }
+  for (const taskId of taskIds) {
+    try {
+      const task = await loadTask(taskId);
+      if (task) await reconcileTaskWithRun(task);
+    } catch {
+      // best-effort per task — one bad row shouldn't block the rest
+    }
+  }
 }
 
 function generateTaskId(): string {

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1476,6 +1476,14 @@ function createAuthGuardFn(): (
       return;
     }
 
+    // Agent Teams durable sub-agent processor. Self-fired by `spawnTask` to run
+    // a queued sub-agent in a fresh function invocation; authenticity is
+    // verified by the same HMAC internal-token scheme plus an atomic SQL claim,
+    // so it bypasses cookie/session auth (mirrors the integration processor).
+    if (p === "/_agent-native/agent-teams/_process-run") {
+      return;
+    }
+
     // A2A endpoint verifies authenticity via JWT signed with the org's A2A
     // secret (or the global A2A_SECRET fallback), not via session cookies.
     if (p === "/_agent-native/a2a") {

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -91,6 +91,7 @@ import {
   isElectron as isElectronRequest,
   getAppBasePath,
   getAppUrl,
+  getOrigin,
   encodeOAuthState,
   decodeOAuthState,
   createOAuthSession,
@@ -103,6 +104,13 @@ import { safeOAuthReturnUrl } from "./oauth-return-url.js";
 import { captureAuthError } from "./sentry.js";
 import { extractOAuthStateAppId } from "../shared/oauth-state.js";
 import { isValidWorkspaceAppIdFormat } from "../shared/workspace-app-id.js";
+import {
+  AGENT_NATIVE_SOCIAL_IMAGE_ALT,
+  AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT,
+  AGENT_NATIVE_SOCIAL_IMAGE_PATH,
+  AGENT_NATIVE_SOCIAL_IMAGE_TYPE,
+  AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
+} from "../shared/social-meta.js";
 import {
   normalizeWorkspaceAppAudience,
   workspaceAppAudienceFromEnv,
@@ -536,7 +544,9 @@ export function getConfiguredLoginHtml(event: H3Event): string | null {
   const url = event.node?.req?.url ?? event.path ?? "/";
   const queryStart = url.indexOf("?");
   const rawPath = queryStart >= 0 ? url.slice(0, queryStart) : url;
-  return config.getLoginHtml?.(event, rawPath) ?? config.loginHtml ?? null;
+  const loginHtml =
+    config.getLoginHtml?.(event, rawPath) ?? config.loginHtml ?? null;
+  return loginHtml ? injectLoginSocialImageMeta(loginHtml, event) : null;
 }
 
 /**
@@ -873,6 +883,7 @@ function getOnboardingHtmlOptions(
     googleAuthMode: options.googleAuthMode,
     requestHost: event ? getRequestHost(event) : undefined,
     requestPath: rawPath,
+    requestOrigin: event ? getOrigin(event) : undefined,
   };
 }
 
@@ -1303,8 +1314,69 @@ function shouldBypassAuthForBuilderConnect(event: H3Event, p: string): boolean {
   return false;
 }
 
-function loginHtmlResponse(loginHtml: string): Response {
-  return new Response(loginHtml, {
+const LOGIN_OG_IMAGE_META_RE =
+  /<meta\b(?=[^>]*\bproperty=(["'])og:image\1)[^>]*>/i;
+const LOGIN_TWITTER_CARD_META_RE =
+  /<meta\b(?=[^>]*\bname=(["'])twitter:card\1)[^>]*>/i;
+const LOGIN_TWITTER_IMAGE_META_RE =
+  /<meta\b(?=[^>]*\bname=(["'])twitter:image\1)[^>]*>/i;
+
+function escapeHtmlAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function injectLoginSocialImageMeta(loginHtml: string, event: H3Event): string {
+  const headCloseIdx = loginHtml.indexOf("</head>");
+  if (headCloseIdx === -1) return loginHtml;
+
+  const hasAnySocialImage =
+    LOGIN_OG_IMAGE_META_RE.test(loginHtml) ||
+    LOGIN_TWITTER_IMAGE_META_RE.test(loginHtml);
+  const imageUrl = escapeHtmlAttr(
+    getAppUrl(event, AGENT_NATIVE_SOCIAL_IMAGE_PATH),
+  );
+  const tags: string[] = [];
+
+  if (!hasAnySocialImage) {
+    tags.push(`<meta property="og:image" content="${imageUrl}">`);
+    tags.push(`<meta property="og:image:secure_url" content="${imageUrl}">`);
+    tags.push(
+      `<meta property="og:image:type" content="${AGENT_NATIVE_SOCIAL_IMAGE_TYPE}">`,
+    );
+    tags.push(
+      `<meta property="og:image:width" content="${AGENT_NATIVE_SOCIAL_IMAGE_WIDTH}">`,
+    );
+    tags.push(
+      `<meta property="og:image:height" content="${AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT}">`,
+    );
+    tags.push(
+      `<meta property="og:image:alt" content="${AGENT_NATIVE_SOCIAL_IMAGE_ALT}">`,
+    );
+  }
+  if (!LOGIN_TWITTER_CARD_META_RE.test(loginHtml)) {
+    tags.push(`<meta name="twitter:card" content="summary_large_image">`);
+  }
+  if (!hasAnySocialImage) {
+    tags.push(`<meta name="twitter:image" content="${imageUrl}">`);
+    tags.push(
+      `<meta name="twitter:image:alt" content="${AGENT_NATIVE_SOCIAL_IMAGE_ALT}">`,
+    );
+  }
+
+  if (tags.length === 0) return loginHtml;
+  return (
+    loginHtml.slice(0, headCloseIdx) +
+    tags.join("") +
+    loginHtml.slice(headCloseIdx)
+  );
+}
+
+function loginHtmlResponse(loginHtml: string, event: H3Event): Response {
+  return new Response(injectLoginSocialImageMeta(loginHtml, event), {
     status: 200,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
@@ -1516,7 +1588,7 @@ function createAuthGuardFn(): (
           headers: { Location: safeReturn },
         });
       }
-      return loginHtmlResponse(loginHtml);
+      return loginHtmlResponse(loginHtml, event);
     }
 
     // Auth entry pages are framework-owned pages, not app routes. When a user
@@ -1530,7 +1602,7 @@ function createAuthGuardFn(): (
           headers: { Location: getAppBasePath() || "/" },
         });
       }
-      return loginHtmlResponse(loginHtml);
+      return loginHtmlResponse(loginHtml, event);
     }
 
     // Skip static assets (Vite chunks, fonts, images, etc.)
@@ -1586,7 +1658,7 @@ function createAuthGuardFn(): (
       if (autoSession) return autoSession;
     }
 
-    return loginHtmlResponse(loginHtml);
+    return loginHtmlResponse(loginHtml, event);
   };
 }
 

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -789,6 +789,15 @@ export function createCoreRoutesPlugin(
         }),
       );
 
+      {
+        const { createAgentNativeOgImageHandler } =
+          await import("./social-og-image.js");
+        getH3App(nitroApp).use(
+          `${P}/og-image.png`,
+          createAgentNativeOgImageHandler(),
+        );
+      }
+
       mountBrowserSessionRoutes(nitroApp, { routePrefix: P });
 
       // Dev-mode DB admin (Supabase-Studio-like). Mounted unconditionally; every

--- a/packages/core/src/server/csrf.ts
+++ b/packages/core/src/server/csrf.ts
@@ -59,6 +59,9 @@ import {
 const CSRF_ALLOWLIST_PREFIXES = [
   // Integration webhooks — verified by HMAC against a per-integration secret.
   "/integrations/",
+  // Agent Teams durable sub-agent processor self-fire — verified by the same
+  // HMAC internal-token scheme as the integration/A2A processors.
+  "/agent-teams/",
   // A2A JSON-RPC endpoints — verified by signed JWT (when A2A_SECRET set) or
   // explicitly opt-in unauthenticated (handled at the A2A layer).
   "/a2a",

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -175,6 +175,17 @@ export {
   type CoreRoutesPluginOptions,
 } from "./core-routes-plugin.js";
 export {
+  AGENT_NATIVE_OG_IMAGE_CACHE_CONTROL,
+  AGENT_NATIVE_OG_IMAGE_HEIGHT,
+  AGENT_NATIVE_OG_IMAGE_NETLIFY_CACHE_CONTROL,
+  AGENT_NATIVE_OG_IMAGE_WIDTH,
+  agentNativeOgImageResponseHeaders,
+  createAgentNativeOgImageHandler,
+  renderAgentNativeOgImagePng,
+  renderAgentNativeOgImageSvg,
+  type AgentNativeOgImageInput,
+} from "./social-og-image.js";
+export {
   createBrowserSessionActionEntries,
   type CreateBrowserSessionActionEntriesOptions,
 } from "../browser-sessions/actions.js";

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -19,6 +19,13 @@ import {
   type AuthMarketingContent,
 } from "./auth-marketing.js";
 import { AUTH_REDIRECT_QUERY_PARAM } from "../shared/auth-redirect-url.js";
+import {
+  AGENT_NATIVE_SOCIAL_IMAGE_ALT,
+  AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT,
+  AGENT_NATIVE_SOCIAL_IMAGE_PATH,
+  AGENT_NATIVE_SOCIAL_IMAGE_TYPE,
+  AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
+} from "../shared/social-meta.js";
 
 function hasGoogleOAuth(): boolean {
   return !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
@@ -77,6 +84,7 @@ export interface OnboardingHtmlOptions {
    */
   requestHost?: string;
   requestPath?: string;
+  requestOrigin?: string;
   /**
    * Optional preflight copy shown before redirecting through Google sign-in.
    * Use this when a hosted app needs to warn about provider-specific consent
@@ -116,6 +124,9 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
   const hasMarketing = !!marketing;
   const runLocalCommand = marketing?.runLocalCommand?.trim();
   const brandMarkSrc = withAppBasePath("/agent-native-icon-dark.svg");
+  const socialImageUrl = opts.requestOrigin
+    ? `${opts.requestOrigin}${withAppBasePath(AGENT_NATIVE_SOCIAL_IMAGE_PATH)}`
+    : withAppBasePath(AGENT_NATIVE_SOCIAL_IMAGE_PATH);
   const esc = (s: string) =>
     s
       .replace(/&/g, "&amp;")
@@ -543,7 +554,16 @@ ${
   hasMarketing
     ? `<meta name="description" content="${esc(marketing!.tagline)}">
 <meta property="og:title" content="${esc(marketing!.appName)}">
-<meta property="og:description" content="${esc(marketing!.tagline)}">`
+<meta property="og:description" content="${esc(marketing!.tagline)}">
+<meta property="og:image" content="${esc(socialImageUrl)}">
+<meta property="og:image:secure_url" content="${esc(socialImageUrl)}">
+<meta property="og:image:type" content="${AGENT_NATIVE_SOCIAL_IMAGE_TYPE}">
+<meta property="og:image:width" content="${AGENT_NATIVE_SOCIAL_IMAGE_WIDTH}">
+<meta property="og:image:height" content="${AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT}">
+<meta property="og:image:alt" content="${AGENT_NATIVE_SOCIAL_IMAGE_ALT}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="${esc(socialImageUrl)}">
+<meta name="twitter:image:alt" content="${AGENT_NATIVE_SOCIAL_IMAGE_ALT}">`
     : ""
 }
 <style>

--- a/packages/core/src/server/self-dispatch.ts
+++ b/packages/core/src/server/self-dispatch.ts
@@ -1,0 +1,137 @@
+/**
+ * Shared self-dispatch helper for the framework's serverless background-work
+ * pattern: enqueue a unit of work to SQL, then fire a fresh HTTP POST back to
+ * this same deployment so the work runs in its own function invocation (with
+ * its own full timeout budget) instead of riding on the request that created
+ * it.
+ *
+ * This is the single mechanism that makes background work portable across every
+ * host Nitro deploys to:
+ *   - Netlify Lambda / Vercel Functions / AWS Lambda — the dispatched request
+ *     hits a fresh function with its own budget; no `waitUntil` needed.
+ *   - Cloudflare Workers — same (and `waitUntil` still works as a belt-and-
+ *     suspenders fallback where the in-process path is used).
+ *   - Self-hosted / long-lived Node — the dispatch comes back as another
+ *     request to the same process; each handler still runs to completion.
+ *
+ * Originally inlined in both `a2a/handlers.ts` (`resolveSelfBaseUrl` +
+ * `fireProcessTaskDispatch`) and `integrations/webhook-handler.ts`
+ * (`resolveBaseUrl` + the dispatch in `enqueueAndDispatch`). Extracted here so
+ * A2A, integration webhooks, and Agent Teams sub-agents share one tested
+ * implementation.
+ */
+import { withConfiguredAppBasePath } from "./app-base-path.js";
+import { isLocalDatabase } from "../db/client.js";
+import { signInternalToken } from "../integrations/internal-token.js";
+
+/**
+ * On serverless, returning from the dispatching handler before the outbound
+ * TCP handshake starts can freeze the function with the dispatch request stuck
+ * in the queue. Racing the fetch against a short timer gives the request a
+ * chance to leave the box at the cost of a little added latency on the
+ * dispatching call. Mirrors the 250ms used by the A2A/webhook paths.
+ */
+export const DEFAULT_DISPATCH_SETTLE_MS = 250;
+
+function readHeader(event: any, name: string): string | undefined {
+  try {
+    const headers = event?.node?.req?.headers ?? event?.headers;
+    if (!headers) return undefined;
+    if (typeof headers.get === "function") {
+      return headers.get(name) ?? undefined;
+    }
+    const map = headers as Record<string, string | undefined>;
+    return map[name] ?? map[String(name).toLowerCase()];
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the base URL to fire a self-dispatch request at. Prefers explicit env
+ * vars (most reliable on serverless, where inbound host headers can be the
+ * platform's internal hostname), falling back to the inbound request headers
+ * and finally localhost in dev.
+ *
+ * Throws in production / shared deployments when no env var is set — a silent
+ * fallback to a bad host there would drop background work invisibly.
+ */
+export function resolveSelfDispatchBaseUrl(event?: any): string {
+  const fromEnv =
+    process.env.APP_URL ||
+    process.env.URL ||
+    process.env.DEPLOY_URL ||
+    process.env.BETTER_AUTH_URL;
+  if (fromEnv) return withConfiguredAppBasePath(String(fromEnv));
+
+  if (process.env.NODE_ENV === "production" || !isLocalDatabase()) {
+    throw new Error(
+      "Self-dispatch requires APP_URL, URL, DEPLOY_URL, or BETTER_AUTH_URL in " +
+        "production/shared deployments so background work can reach this " +
+        "deployment's own URL.",
+    );
+  }
+
+  const proto = readHeader(event, "x-forwarded-proto") || "http";
+  const host = readHeader(event, "host") || `localhost:${process.env.PORT || 3000}`;
+  return withConfiguredAppBasePath(`${proto}://${host}`);
+}
+
+export interface FireInternalDispatchOptions {
+  /** Base URL of this deployment. Defaults to `resolveSelfDispatchBaseUrl(event)`. */
+  baseUrl?: string;
+  /** Request event used to derive the base URL when `baseUrl` is omitted. */
+  event?: any;
+  /** Framework route path to POST to (e.g. "/_agent-native/agent-teams/_process-run"). */
+  path: string;
+  /** Task/run id the processor will claim. Used to sign the HMAC token and as the default body. */
+  taskId: string;
+  /** Extra fields merged into the JSON body alongside `{ taskId }`. */
+  body?: Record<string, unknown>;
+  /** Max ms to wait for the outbound request to leave the box. Default 250ms. */
+  settleMs?: number;
+}
+
+/**
+ * Fire a fresh, HMAC-signed POST to a processor route on this same deployment.
+ * Fire-and-forget: the dispatch is NOT awaited to completion (the processed run
+ * may take minutes); it is only raced against a short settle timer so the
+ * request reliably leaves a serverless box before it freezes.
+ *
+ * When `A2A_SECRET` is unset (local dev), the request is sent unsigned — the
+ * processor accepts unsigned dispatches in dev and relies on the SQL atomic
+ * claim for double-processing protection, mirroring the A2A/webhook flow.
+ */
+export async function fireInternalDispatch(
+  options: FireInternalDispatchOptions,
+): Promise<void> {
+  const baseUrl = options.baseUrl ?? resolveSelfDispatchBaseUrl(options.event);
+  const url = `${baseUrl}${options.path}`;
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  try {
+    headers["Authorization"] = `Bearer ${signInternalToken(options.taskId)}`;
+  } catch (err) {
+    // Distinguish the documented "no A2A_SECRET in dev" path from a real
+    // signing failure, so a malformed secret doesn't fail invisibly.
+    if (err instanceof Error && !/A2A_SECRET/i.test(err.message)) {
+      console.error(
+        `[self-dispatch] signInternalToken failed unexpectedly for ${options.taskId}:`,
+        err,
+      );
+    }
+  }
+
+  const dispatchPromise = fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ taskId: options.taskId, ...(options.body ?? {}) }),
+  }).catch((err) => {
+    console.error(`[self-dispatch] dispatch to ${options.path} failed:`, err);
+  });
+
+  const settleMs = options.settleMs ?? DEFAULT_DISPATCH_SETTLE_MS;
+  await Promise.race([
+    dispatchPromise,
+    new Promise<void>((resolve) => setTimeout(resolve, settleMs)),
+  ]);
+}

--- a/packages/core/src/server/self-dispatch.ts
+++ b/packages/core/src/server/self-dispatch.ts
@@ -73,7 +73,8 @@ export function resolveSelfDispatchBaseUrl(event?: any): string {
   }
 
   const proto = readHeader(event, "x-forwarded-proto") || "http";
-  const host = readHeader(event, "host") || `localhost:${process.env.PORT || 3000}`;
+  const host =
+    readHeader(event, "host") || `localhost:${process.env.PORT || 3000}`;
   return withConfiguredAppBasePath(`${proto}://${host}`);
 }
 
@@ -107,7 +108,9 @@ export async function fireInternalDispatch(
 ): Promise<void> {
   const baseUrl = options.baseUrl ?? resolveSelfDispatchBaseUrl(options.event);
   const url = `${baseUrl}${options.path}`;
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
   try {
     headers["Authorization"] = `Bearer ${signInternalToken(options.taskId)}`;
   } catch (err) {

--- a/packages/core/src/server/social-og-image.ts
+++ b/packages/core/src/server/social-og-image.ts
@@ -1,0 +1,364 @@
+import {
+  defineEventHandler,
+  getHeader,
+  getMethod,
+  getQuery,
+  getRequestURL,
+  type H3Event,
+} from "h3";
+import { resolveBuiltInAuthMarketing } from "./auth-marketing.js";
+import { getAppName } from "./app-name.js";
+
+export interface AgentNativeOgImageInput {
+  appName?: string | null;
+  title?: string | null;
+  subtitle?: string | null;
+  accentText?: string | null;
+}
+
+export const AGENT_NATIVE_OG_IMAGE_WIDTH = 1200;
+export const AGENT_NATIVE_OG_IMAGE_HEIGHT = 630;
+export const AGENT_NATIVE_OG_IMAGE_CACHE_CONTROL =
+  "public, max-age=60, stale-while-revalidate=604800, stale-if-error=3600";
+export const AGENT_NATIVE_OG_IMAGE_NETLIFY_CACHE_CONTROL =
+  "public, durable, max-age=60, stale-while-revalidate=604800, stale-if-error=3600";
+
+const WIDTH = AGENT_NATIVE_OG_IMAGE_WIDTH;
+const HEIGHT = AGENT_NATIVE_OG_IMAGE_HEIGHT;
+const BRAND_BLUE = "#00B5FF";
+const BRAND_MINT = "#48FFE4";
+const BG = "#000000";
+const SURFACE = "#080808";
+const BORDER = "#202020";
+const FG = "#f5f5f5";
+const MUTED = "#9ca3af";
+const FONT_FAMILY =
+  "Inter, Liberation Sans, Arial, Helvetica, system-ui, sans-serif";
+const DEFAULT_ACCENT_TEXT = "100% free and open source";
+
+const LOGO_MARK = `
+  <path d="M24.5537 65.7695H0L15.0859 39.4619L37.708 0L60.4912 39.4619H39.6396L24.5537 65.7695Z" fill="white"/>
+  <path d="M89.446 0H114L76.2921 65.7704H51.7383L89.446 0Z" fill="url(#brand)"/>
+`;
+
+function escapeSvg(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function cleanText(value: string | null | undefined): string {
+  return String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(/[\s._-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function stripAgentNativePrefix(appName: string): string {
+  return appName.replace(/^agent-native\s+/i, "").trim() || appName;
+}
+
+function titleFromAppName(appName: string): string {
+  if (appName) return stripAgentNativePrefix(appName);
+  const basePath =
+    process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH || "";
+  const slug = basePath.split("/").filter(Boolean)[0] || "";
+  return titleCase(slug) || "Agent-Native";
+}
+
+interface WrappedText {
+  lines: string[];
+  truncated: boolean;
+}
+
+interface TitleLayout {
+  lines: string[];
+  fontSize: number;
+  lineHeight: number;
+  subtitleLocalY: number;
+}
+
+function estimateTextWidth(value: string, fontSize: number): number {
+  let units = 0;
+  for (const char of value) {
+    if (char === " ") {
+      units += 0.28;
+    } else if (/[MW@#%&]/.test(char)) {
+      units += 0.86;
+    } else if (/[A-Z]/.test(char)) {
+      units += 0.64;
+    } else if (/[ilI.,:;|!']/u.test(char)) {
+      units += 0.26;
+    } else if (/[0-9]/.test(char)) {
+      units += 0.56;
+    } else {
+      units += 0.54;
+    }
+  }
+  return units * fontSize;
+}
+
+function trimTextToWidth(
+  value: string,
+  fontSize: number,
+  maxWidth: number,
+): string {
+  const ellipsis = "...";
+  let trimmed = value.trim();
+  while (
+    trimmed.length > 0 &&
+    estimateTextWidth(`${trimmed}${ellipsis}`, fontSize) > maxWidth
+  ) {
+    trimmed = trimmed.slice(0, -1).trimEnd();
+  }
+  return trimmed ? `${trimmed}${ellipsis}` : ellipsis;
+}
+
+function wrapTextToWidth(
+  value: string,
+  fontSize: number,
+  maxWidth: number,
+  maxLines: number,
+): WrappedText {
+  const words = value.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = "";
+  let truncated = false;
+
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (estimateTextWidth(next, fontSize) <= maxWidth) {
+      current = next;
+      continue;
+    }
+    if (!current) {
+      lines.push(trimTextToWidth(word, fontSize, maxWidth));
+      truncated = true;
+      current = "";
+    } else {
+      lines.push(current);
+      current = word;
+    }
+    if (lines.length === maxLines) {
+      truncated = true;
+      break;
+    }
+  }
+  if (current && lines.length < maxLines) lines.push(current);
+
+  const usedWordCount = lines.join(" ").split(/\s+/).filter(Boolean).length;
+  if (usedWordCount < words.length && lines.length > 0) {
+    lines[lines.length - 1] = trimTextToWidth(
+      lines[lines.length - 1],
+      fontSize,
+      maxWidth,
+    );
+    truncated = true;
+  }
+
+  return {
+    lines: lines.length ? lines : [trimTextToWidth(value, fontSize, maxWidth)],
+    truncated,
+  };
+}
+
+function getTitleLayout(title: string): TitleLayout {
+  const maxTitleWidth = 1040;
+  if (estimateTextWidth(title, 92) <= maxTitleWidth) {
+    return {
+      lines: [title],
+      fontSize: 92,
+      lineHeight: 98,
+      subtitleLocalY: 112,
+    };
+  }
+
+  for (const fontSize of [82, 76, 70, 64, 58, 52]) {
+    const wrapped = wrapTextToWidth(title, fontSize, maxTitleWidth, 2);
+    if (!wrapped.truncated) {
+      return {
+        lines: wrapped.lines,
+        fontSize,
+        lineHeight: Math.round(fontSize * 1.12),
+        subtitleLocalY:
+          Math.round(fontSize * 1.12) * (wrapped.lines.length - 1) + 56,
+      };
+    }
+  }
+
+  const fallbackFontSize = 52;
+  const wrapped = wrapTextToWidth(title, fallbackFontSize, maxTitleWidth, 2);
+  return {
+    lines: wrapped.lines,
+    fontSize: fallbackFontSize,
+    lineHeight: 60,
+    subtitleLocalY: 116,
+  };
+}
+
+function textBlock({
+  lines,
+  x,
+  y,
+  fontSize,
+  lineHeight,
+  weight,
+  fill,
+}: {
+  lines: string[];
+  x: number;
+  y: number;
+  fontSize: number;
+  lineHeight: number;
+  weight: number;
+  fill: string;
+}): string {
+  return `<text x="${x}" y="${y}" font-family="${FONT_FAMILY}" font-size="${fontSize}" font-weight="${weight}" fill="${fill}">${lines
+    .map(
+      (line, index) =>
+        `<tspan x="${x}" dy="${index === 0 ? 0 : lineHeight}">${escapeSvg(line)}</tspan>`,
+    )
+    .join("")}</text>`;
+}
+
+function resolveDefaultAppName(event?: H3Event): string {
+  const requestHost = event
+    ? (getHeader(event, "x-forwarded-host") ?? getHeader(event, "host"))
+    : undefined;
+  const requestPath = event ? getRequestURL(event).pathname : undefined;
+  return (
+    getAppName() ??
+    resolveBuiltInAuthMarketing({ requestHost, requestPath })?.appName ??
+    "Agent-Native"
+  );
+}
+
+function queryStringValue(
+  value: unknown,
+  maxLength: number,
+): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const clean = cleanText(value).slice(0, maxLength);
+  return clean || undefined;
+}
+
+export function renderAgentNativeOgImageSvg(
+  input: AgentNativeOgImageInput = {},
+): string {
+  const appName = cleanText(input.appName) || resolveDefaultAppName();
+  const title = cleanText(input.title) || titleFromAppName(appName);
+  const subtitle = cleanText(input.subtitle) || appName;
+  const accentText = cleanText(input.accentText) || DEFAULT_ACCENT_TEXT;
+  const titleLayout = getTitleLayout(title);
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">
+  <title>${escapeSvg(title)} - Agent-Native preview</title>
+  <defs>
+    <linearGradient id="brand" x1="101.702" y1="67.4791" x2="113.672" y2="-37.4275" gradientUnits="userSpaceOnUse">
+      <stop stop-color="${BRAND_BLUE}"/>
+      <stop offset="1" stop-color="${BRAND_MINT}"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="50%" cy="45%" r="65%">
+      <stop offset="0" stop-color="${BRAND_BLUE}" stop-opacity="0.22"/>
+      <stop offset="0.48" stop-color="${BRAND_BLUE}" stop-opacity="0.08"/>
+      <stop offset="1" stop-color="${BG}" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#ffffff" stroke-opacity="0.07" stroke-width="1"/>
+    </pattern>
+  </defs>
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="${BG}"/>
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#halo)"/>
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#grid)"/>
+  <rect x="64" y="64" width="1072" height="502" rx="26" fill="${SURFACE}" fill-opacity="0.78" stroke="${BORDER}" stroke-width="1"/>
+  <path d="M80 154 H1120" stroke="${BORDER}"/>
+  <g transform="translate(80 86)">
+    <g transform="scale(0.62)">
+      ${LOGO_MARK}
+    </g>
+    <text x="90" y="31" font-family="${FONT_FAMILY}" font-size="28" font-weight="800" fill="${FG}">Agent-Native</text>
+    <text x="91" y="58" font-family="${FONT_FAMILY}" font-size="18" font-weight="700" fill="${BRAND_BLUE}">${escapeSvg(accentText)}</text>
+  </g>
+  <g transform="translate(80 296)">
+    ${textBlock({
+      lines: titleLayout.lines,
+      x: 0,
+      y: 0,
+      fontSize: titleLayout.fontSize,
+      lineHeight: titleLayout.lineHeight,
+      weight: 850,
+      fill: FG,
+    })}
+    <text x="2" y="${titleLayout.subtitleLocalY}" font-family="${FONT_FAMILY}" font-size="30" font-weight="650" fill="${MUTED}">${escapeSvg(subtitle)}</text>
+  </g>
+  <g transform="translate(976 452)">
+    <circle cx="0" cy="0" r="74" fill="url(#brand)" fill-opacity="0.16" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
+    <g transform="translate(-44 -25) scale(0.78)">
+      ${LOGO_MARK}
+    </g>
+  </g>
+</svg>`;
+}
+
+export async function renderAgentNativeOgImagePng(
+  input: AgentNativeOgImageInput = {},
+): Promise<Uint8Array> {
+  const { Resvg } = await import("@resvg/resvg-js");
+  const image = new Resvg(renderAgentNativeOgImageSvg(input), {
+    fitTo: { mode: "width", value: WIDTH },
+    font: {
+      loadSystemFonts: true,
+      defaultFontFamily: "Arial",
+      sansSerifFamily: "Arial",
+    },
+  }).render();
+  return image.asPng();
+}
+
+export function agentNativeOgImageResponseHeaders(
+  byteLength: number,
+): Record<string, string> {
+  return {
+    "Content-Type": "image/png",
+    "Content-Length": String(byteLength),
+    "Cache-Control": AGENT_NATIVE_OG_IMAGE_CACHE_CONTROL,
+    "CDN-Cache-Control": AGENT_NATIVE_OG_IMAGE_CACHE_CONTROL,
+    "Netlify-CDN-Cache-Control": AGENT_NATIVE_OG_IMAGE_NETLIFY_CACHE_CONTROL,
+    "Cross-Origin-Resource-Policy": "cross-origin",
+  };
+}
+
+export function createAgentNativeOgImageHandler(
+  options: AgentNativeOgImageInput = {},
+) {
+  return defineEventHandler(async (event) => {
+    const query = getQuery(event);
+    const appName = cleanText(options.appName) || resolveDefaultAppName(event);
+    const png = await renderAgentNativeOgImagePng({
+      ...options,
+      appName,
+      title: cleanText(options.title) || queryStringValue(query.title, 140),
+      subtitle:
+        cleanText(options.subtitle) || queryStringValue(query.subtitle, 140),
+      accentText:
+        cleanText(options.accentText) || queryStringValue(query.accentText, 80),
+    });
+    const body = png.buffer.slice(
+      png.byteOffset,
+      png.byteOffset + png.byteLength,
+    ) as ArrayBuffer;
+
+    return new Response(getMethod(event) === "HEAD" ? null : body, {
+      headers: agentNativeOgImageResponseHeaders(png.byteLength),
+    });
+  });
+}

--- a/packages/core/src/server/social-og-image.ts
+++ b/packages/core/src/server/social-og-image.ts
@@ -28,10 +28,7 @@ const HEIGHT = AGENT_NATIVE_OG_IMAGE_HEIGHT;
 const BRAND_BLUE = "#00B5FF";
 const BRAND_MINT = "#48FFE4";
 const BG = "#000000";
-const SURFACE = "#080808";
-const BORDER = "#202020";
 const FG = "#f5f5f5";
-const MUTED = "#9ca3af";
 const FONT_FAMILY =
   "Inter, Liberation Sans, Arial, Helvetica, system-ui, sans-serif";
 const DEFAULT_ACCENT_TEXT = "100% free and open source";
@@ -63,12 +60,8 @@ function titleCase(value: string): string {
     .join(" ");
 }
 
-function stripAgentNativePrefix(appName: string): string {
-  return appName.replace(/^agent-native\s+/i, "").trim() || appName;
-}
-
 function titleFromAppName(appName: string): string {
-  if (appName) return stripAgentNativePrefix(appName);
+  if (appName) return appName;
   const basePath =
     process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH || "";
   const slug = basePath.split("/").filter(Boolean)[0] || "";
@@ -84,7 +77,8 @@ interface TitleLayout {
   lines: string[];
   fontSize: number;
   lineHeight: number;
-  subtitleLocalY: number;
+  firstLineY: number;
+  accentTextY: number;
 }
 
 function estimateTextWidth(value: string, fontSize: number): number {
@@ -173,24 +167,29 @@ function wrapTextToWidth(
 
 function getTitleLayout(title: string): TitleLayout {
   const maxTitleWidth = 1040;
-  if (estimateTextWidth(title, 92) <= maxTitleWidth) {
+  if (estimateTextWidth(title, 84) <= maxTitleWidth) {
     return {
       lines: [title],
-      fontSize: 92,
-      lineHeight: 98,
-      subtitleLocalY: 112,
+      fontSize: 84,
+      lineHeight: 92,
+      firstLineY: 330,
+      accentTextY: 396,
     };
   }
 
-  for (const fontSize of [82, 76, 70, 64, 58, 52]) {
+  for (const fontSize of [76, 70, 64, 58, 52]) {
     const wrapped = wrapTextToWidth(title, fontSize, maxTitleWidth, 2);
     if (!wrapped.truncated) {
+      const lineHeight = Math.round(fontSize * 1.1);
       return {
         lines: wrapped.lines,
         fontSize,
-        lineHeight: Math.round(fontSize * 1.12),
-        subtitleLocalY:
-          Math.round(fontSize * 1.12) * (wrapped.lines.length - 1) + 56,
+        lineHeight,
+        firstLineY: wrapped.lines.length > 1 ? 292 : 330,
+        accentTextY:
+          (wrapped.lines.length > 1 ? 292 : 330) +
+          lineHeight * (wrapped.lines.length - 1) +
+          66,
       };
     }
   }
@@ -201,7 +200,11 @@ function getTitleLayout(title: string): TitleLayout {
     lines: wrapped.lines,
     fontSize: fallbackFontSize,
     lineHeight: 60,
-    subtitleLocalY: 116,
+    firstLineY: wrapped.lines.length > 1 ? 292 : 330,
+    accentTextY:
+      (wrapped.lines.length > 1 ? 292 : 330) +
+      60 * (wrapped.lines.length - 1) +
+      66,
   };
 }
 
@@ -213,6 +216,7 @@ function textBlock({
   lineHeight,
   weight,
   fill,
+  anchor = "start",
 }: {
   lines: string[];
   x: number;
@@ -221,8 +225,9 @@ function textBlock({
   lineHeight: number;
   weight: number;
   fill: string;
+  anchor?: "start" | "middle";
 }): string {
-  return `<text x="${x}" y="${y}" font-family="${FONT_FAMILY}" font-size="${fontSize}" font-weight="${weight}" fill="${fill}">${lines
+  return `<text x="${x}" y="${y}" text-anchor="${anchor}" font-family="${FONT_FAMILY}" font-size="${fontSize}" font-weight="${weight}" fill="${fill}">${lines
     .map(
       (line, index) =>
         `<tspan x="${x}" dy="${index === 0 ? 0 : lineHeight}">${escapeSvg(line)}</tspan>`,
@@ -256,9 +261,10 @@ export function renderAgentNativeOgImageSvg(
 ): string {
   const appName = cleanText(input.appName) || resolveDefaultAppName();
   const title = cleanText(input.title) || titleFromAppName(appName);
-  const subtitle = cleanText(input.subtitle) || appName;
   const accentText = cleanText(input.accentText) || DEFAULT_ACCENT_TEXT;
   const titleLayout = getTitleLayout(title);
+  const logoScale = 1.16;
+  const logoWidth = 114 * logoScale;
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">
   <title>${escapeSvg(title)} - Agent-Native preview</title>
@@ -267,44 +273,23 @@ export function renderAgentNativeOgImageSvg(
       <stop stop-color="${BRAND_BLUE}"/>
       <stop offset="1" stop-color="${BRAND_MINT}"/>
     </linearGradient>
-    <radialGradient id="halo" cx="50%" cy="45%" r="65%">
-      <stop offset="0" stop-color="${BRAND_BLUE}" stop-opacity="0.22"/>
-      <stop offset="0.48" stop-color="${BRAND_BLUE}" stop-opacity="0.08"/>
-      <stop offset="1" stop-color="${BG}" stop-opacity="0"/>
-    </radialGradient>
-    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
-      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#ffffff" stroke-opacity="0.07" stroke-width="1"/>
-    </pattern>
   </defs>
   <rect width="${WIDTH}" height="${HEIGHT}" fill="${BG}"/>
-  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#halo)"/>
-  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#grid)"/>
-  <rect x="64" y="64" width="1072" height="502" rx="26" fill="${SURFACE}" fill-opacity="0.78" stroke="${BORDER}" stroke-width="1"/>
-  <path d="M80 154 H1120" stroke="${BORDER}"/>
-  <g transform="translate(80 86)">
-    <g transform="scale(0.62)">
-      ${LOGO_MARK}
-    </g>
-    <text x="90" y="31" font-family="${FONT_FAMILY}" font-size="28" font-weight="800" fill="${FG}">Agent-Native</text>
-    <text x="91" y="58" font-family="${FONT_FAMILY}" font-size="18" font-weight="700" fill="${BRAND_BLUE}">${escapeSvg(accentText)}</text>
+  <g transform="translate(${(WIDTH - logoWidth) / 2} 148) scale(${logoScale})">
+    ${LOGO_MARK}
   </g>
-  <g transform="translate(80 296)">
+  <g>
     ${textBlock({
       lines: titleLayout.lines,
-      x: 0,
-      y: 0,
+      x: WIDTH / 2,
+      y: titleLayout.firstLineY,
       fontSize: titleLayout.fontSize,
       lineHeight: titleLayout.lineHeight,
       weight: 850,
       fill: FG,
+      anchor: "middle",
     })}
-    <text x="2" y="${titleLayout.subtitleLocalY}" font-family="${FONT_FAMILY}" font-size="30" font-weight="650" fill="${MUTED}">${escapeSvg(subtitle)}</text>
-  </g>
-  <g transform="translate(976 452)">
-    <circle cx="0" cy="0" r="74" fill="url(#brand)" fill-opacity="0.16" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
-    <g transform="translate(-44 -25) scale(0.78)">
-      ${LOGO_MARK}
-    </g>
+    <text x="${WIDTH / 2}" y="${titleLayout.accentTextY}" text-anchor="middle" font-family="${FONT_FAMILY}" font-size="32" font-weight="800" fill="${BRAND_BLUE}">${escapeSvg(accentText)}</text>
   </g>
 </svg>`;
 }

--- a/packages/core/src/server/social-og-image.ts
+++ b/packages/core/src/server/social-og-image.ts
@@ -287,7 +287,7 @@ export function renderAgentNativeOgImageSvg(
 export async function renderAgentNativeOgImagePng(
   input: AgentNativeOgImageInput = {},
 ): Promise<Uint8Array> {
-  const { Resvg } = await import("@resvg/resvg-js");
+  const { Resvg } = await import(/* @vite-ignore */ "@resvg/resvg-js");
   const image = new Resvg(renderAgentNativeOgImageSvg(input), {
     fitTo: { mode: "width", value: WIDTH },
     font: {

--- a/packages/core/src/server/social-og-image.ts
+++ b/packages/core/src/server/social-og-image.ts
@@ -77,8 +77,6 @@ interface TitleLayout {
   lines: string[];
   fontSize: number;
   lineHeight: number;
-  firstLineY: number;
-  accentTextY: number;
 }
 
 function estimateTextWidth(value: string, fontSize: number): number {
@@ -166,14 +164,12 @@ function wrapTextToWidth(
 }
 
 function getTitleLayout(title: string): TitleLayout {
-  const maxTitleWidth = 1040;
-  if (estimateTextWidth(title, 84) <= maxTitleWidth) {
+  const maxTitleWidth = 900;
+  if (estimateTextWidth(title, 88) <= maxTitleWidth) {
     return {
       lines: [title],
-      fontSize: 84,
-      lineHeight: 92,
-      firstLineY: 330,
-      accentTextY: 396,
+      fontSize: 88,
+      lineHeight: 96,
     };
   }
 
@@ -185,11 +181,6 @@ function getTitleLayout(title: string): TitleLayout {
         lines: wrapped.lines,
         fontSize,
         lineHeight,
-        firstLineY: wrapped.lines.length > 1 ? 292 : 330,
-        accentTextY:
-          (wrapped.lines.length > 1 ? 292 : 330) +
-          lineHeight * (wrapped.lines.length - 1) +
-          66,
       };
     }
   }
@@ -200,11 +191,6 @@ function getTitleLayout(title: string): TitleLayout {
     lines: wrapped.lines,
     fontSize: fallbackFontSize,
     lineHeight: 60,
-    firstLineY: wrapped.lines.length > 1 ? 292 : 330,
-    accentTextY:
-      (wrapped.lines.length > 1 ? 292 : 330) +
-      60 * (wrapped.lines.length - 1) +
-      66,
   };
 }
 
@@ -263,8 +249,9 @@ export function renderAgentNativeOgImageSvg(
   const title = cleanText(input.title) || titleFromAppName(appName);
   const accentText = cleanText(input.accentText) || DEFAULT_ACCENT_TEXT;
   const titleLayout = getTitleLayout(title);
-  const logoScale = 1.16;
-  const logoWidth = 114 * logoScale;
+  const titleY = titleLayout.lines.length > 1 ? 288 : 330;
+  const accentY =
+    titleY + titleLayout.lineHeight * (titleLayout.lines.length - 1) + 70;
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">
   <title>${escapeSvg(title)} - Agent-Native preview</title>
@@ -273,23 +260,26 @@ export function renderAgentNativeOgImageSvg(
       <stop stop-color="${BRAND_BLUE}"/>
       <stop offset="1" stop-color="${BRAND_MINT}"/>
     </linearGradient>
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#ffffff" stroke-opacity="0.07" stroke-width="1"/>
+    </pattern>
   </defs>
   <rect width="${WIDTH}" height="${HEIGHT}" fill="${BG}"/>
-  <g transform="translate(${(WIDTH - logoWidth) / 2} 148) scale(${logoScale})">
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#grid)"/>
+  <g transform="translate(80 116) scale(0.94)">
     ${LOGO_MARK}
   </g>
   <g>
     ${textBlock({
       lines: titleLayout.lines,
-      x: WIDTH / 2,
-      y: titleLayout.firstLineY,
+      x: 80,
+      y: titleY,
       fontSize: titleLayout.fontSize,
       lineHeight: titleLayout.lineHeight,
       weight: 850,
       fill: FG,
-      anchor: "middle",
     })}
-    <text x="${WIDTH / 2}" y="${titleLayout.accentTextY}" text-anchor="middle" font-family="${FONT_FAMILY}" font-size="32" font-weight="800" fill="${BRAND_BLUE}">${escapeSvg(accentText)}</text>
+    <text x="84" y="${accentY}" font-family="${FONT_FAMILY}" font-size="34" font-weight="800" fill="${BRAND_BLUE}">${escapeSvg(accentText)}</text>
   </g>
 </svg>`;
 }

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_SPECULATION_RULES_HEADER,
   DEFAULT_SSR_CACHE_CONTROL,
 } from "./ssr-handler.js";
-import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
+import { AGENT_NATIVE_SOCIAL_IMAGE_PATH } from "../shared/social-meta.js";
 import { getRequestUserEmail } from "./request-context.js";
 
 const mocks = vi.hoisted(() => {
@@ -260,10 +260,10 @@ describe("createH3SSRHandler", () => {
     const html = await response.text();
 
     expect(html).toContain(
-      `<meta property="og:image" content="${AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE}">`,
+      `<meta property="og:image" content="http://example.test${AGENT_NATIVE_SOCIAL_IMAGE_PATH}">`,
     );
     expect(html).toContain(
-      `<meta name="twitter:image" content="${AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE}">`,
+      `<meta name="twitter:image" content="http://example.test${AGENT_NATIVE_SOCIAL_IMAGE_PATH}">`,
     );
     expect(html).toContain(
       '<meta name="twitter:card" content="summary_large_image">',
@@ -285,7 +285,7 @@ describe("createH3SSRHandler", () => {
     const html = await response.text();
 
     expect(html).toContain("https://example.test/custom.png");
-    expect(html).not.toContain(AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE);
+    expect(html).not.toContain(AGENT_NATIVE_SOCIAL_IMAGE_PATH);
     expect(html).toContain(
       '<meta name="twitter:card" content="summary_large_image">',
     );

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -29,7 +29,13 @@ import {
   EMBED_SESSION_COOKIE,
   EMBED_TOKEN_QUERY_PARAM,
 } from "../shared/embed-auth.js";
-import { AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE } from "../shared/social-meta.js";
+import {
+  AGENT_NATIVE_SOCIAL_IMAGE_ALT,
+  AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT,
+  AGENT_NATIVE_SOCIAL_IMAGE_PATH,
+  AGENT_NATIVE_SOCIAL_IMAGE_TYPE,
+  AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
+} from "../shared/social-meta.js";
 import {
   DEFAULT_SSR_CACHE_HEADERS,
   DEFAULT_SPECULATION_RULES_PATH,
@@ -164,7 +170,14 @@ const TWITTER_CARD_META_RE =
 const TWITTER_IMAGE_META_RE =
   /<meta\b(?=[^>]*\bname=(["'])twitter:image\1)[^>]*>/i;
 
-function injectDefaultSocialImageMeta(html: string): string {
+function defaultSocialImageUrl(requestUrl: string, basePath: string): string {
+  return new URL(
+    prefixMountedPath(AGENT_NATIVE_SOCIAL_IMAGE_PATH, basePath),
+    requestUrl,
+  ).toString();
+}
+
+function injectDefaultSocialImageMeta(html: string, imageUrl: string): string {
   const headCloseIdx = html.indexOf("</head>");
   if (headCloseIdx === -1) return html;
 
@@ -173,16 +186,28 @@ function injectDefaultSocialImageMeta(html: string): string {
   const tags: string[] = [];
 
   if (!hasAnySocialImage) {
+    tags.push(`<meta property="og:image" content="${imageUrl}">`);
+    tags.push(`<meta property="og:image:secure_url" content="${imageUrl}">`);
     tags.push(
-      `<meta property="og:image" content="${AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE}">`,
+      `<meta property="og:image:type" content="${AGENT_NATIVE_SOCIAL_IMAGE_TYPE}">`,
+    );
+    tags.push(
+      `<meta property="og:image:width" content="${AGENT_NATIVE_SOCIAL_IMAGE_WIDTH}">`,
+    );
+    tags.push(
+      `<meta property="og:image:height" content="${AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT}">`,
+    );
+    tags.push(
+      `<meta property="og:image:alt" content="${AGENT_NATIVE_SOCIAL_IMAGE_ALT}">`,
     );
   }
   if (!TWITTER_CARD_META_RE.test(html)) {
     tags.push(`<meta name="twitter:card" content="summary_large_image">`);
   }
   if (!hasAnySocialImage) {
+    tags.push(`<meta name="twitter:image" content="${imageUrl}">`);
     tags.push(
-      `<meta name="twitter:image" content="${AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE}">`,
+      `<meta name="twitter:image:alt" content="${AGENT_NATIVE_SOCIAL_IMAGE_ALT}">`,
     );
   }
 
@@ -337,6 +362,7 @@ async function rewriteMountedResponse(
   response: Response,
   basePath: string,
   pathname: string,
+  requestUrl: string,
   requestContext?: RequestContext,
 ): Promise<Response> {
   const sentryClientConfigScript = getSentryClientConfigScript();
@@ -367,7 +393,10 @@ async function rewriteMountedResponse(
   headers.delete("content-length");
   return new Response(
     injectHeadScript(
-      injectDefaultSocialImageMeta(prefixMountedHtml(html, basePath)),
+      injectDefaultSocialImageMeta(
+        prefixMountedHtml(html, basePath),
+        defaultSocialImageUrl(requestUrl, basePath),
+      ),
       sentryClientConfigScript,
     ),
     {
@@ -428,6 +457,7 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
           }),
           basePath,
           p,
+          request.url,
           ctx,
         );
       }
@@ -435,6 +465,7 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
         await runWithRequestContext(ctx, () => handler(request)),
         basePath,
         p,
+        request.url,
         ctx,
       );
     } catch (err) {

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -41,6 +41,11 @@ export {
 } from "./agent-sidebar-url.js";
 export {
   AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE,
+  AGENT_NATIVE_SOCIAL_IMAGE_ALT,
+  AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT,
+  AGENT_NATIVE_SOCIAL_IMAGE_PATH,
+  AGENT_NATIVE_SOCIAL_IMAGE_TYPE,
+  AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
   defaultSocialImageMeta,
   withDefaultSocialImage,
   type SocialMetaDescriptor,

--- a/packages/core/src/shared/social-meta.ts
+++ b/packages/core/src/shared/social-meta.ts
@@ -5,6 +5,11 @@ export type SocialMetaDescriptor =
 
 export const AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE =
   "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9c533fed169648069bffaed652ec0897";
+export const AGENT_NATIVE_SOCIAL_IMAGE_PATH = "/_agent-native/og-image.png";
+export const AGENT_NATIVE_SOCIAL_IMAGE_WIDTH = "1200";
+export const AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT = "630";
+export const AGENT_NATIVE_SOCIAL_IMAGE_TYPE = "image/png";
+export const AGENT_NATIVE_SOCIAL_IMAGE_ALT = "Agent-Native app preview";
 
 function hasMetaProperty(meta: SocialMetaDescriptor[], property: string) {
   return meta.some((item) => "property" in item && item.property === property);
@@ -19,8 +24,14 @@ export function defaultSocialImageMeta(
 ): SocialMetaDescriptor[] {
   return [
     { property: "og:image", content: image },
+    { property: "og:image:secure_url", content: image },
+    { property: "og:image:type", content: AGENT_NATIVE_SOCIAL_IMAGE_TYPE },
+    { property: "og:image:width", content: AGENT_NATIVE_SOCIAL_IMAGE_WIDTH },
+    { property: "og:image:height", content: AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT },
+    { property: "og:image:alt", content: AGENT_NATIVE_SOCIAL_IMAGE_ALT },
     { name: "twitter:card", content: "summary_large_image" },
     { name: "twitter:image", content: image },
+    { name: "twitter:image:alt", content: AGENT_NATIVE_SOCIAL_IMAGE_ALT },
   ];
 }
 
@@ -33,10 +44,33 @@ export function withDefaultSocialImage<T extends SocialMetaDescriptor>(
 
   return [
     ...meta,
-    ...(hasAnySocialImage ? [] : [{ property: "og:image", content: image }]),
+    ...(hasAnySocialImage
+      ? []
+      : [
+          { property: "og:image", content: image },
+          { property: "og:image:secure_url", content: image },
+          {
+            property: "og:image:type",
+            content: AGENT_NATIVE_SOCIAL_IMAGE_TYPE,
+          },
+          {
+            property: "og:image:width",
+            content: AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
+          },
+          {
+            property: "og:image:height",
+            content: AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT,
+          },
+          { property: "og:image:alt", content: AGENT_NATIVE_SOCIAL_IMAGE_ALT },
+        ]),
     ...(hasMetaName(meta, "twitter:card")
       ? []
       : [{ name: "twitter:card", content: "summary_large_image" }]),
-    ...(hasAnySocialImage ? [] : [{ name: "twitter:image", content: image }]),
+    ...(hasAnySocialImage
+      ? []
+      : [
+          { name: "twitter:image", content: image },
+          { name: "twitter:image:alt", content: AGENT_NATIVE_SOCIAL_IMAGE_ALT },
+        ]),
   ];
 }

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -508,6 +508,47 @@ describe("Vite connection reset noise", () => {
     expect(hotSend).toHaveBeenCalledWith(payload);
     expect(wsSend).toHaveBeenCalledWith(payload);
   });
+
+  it("suppresses Node web stream close races from socket error handlers", () => {
+    const plugin = findPlugin("agent-native-silence-connection-resets");
+    let connectionHandler: ((socket: { on: Function }) => void) | undefined;
+    let socketErrorHandler: ((err: Error) => void) | undefined;
+    const server = {
+      httpServer: {
+        on: vi.fn((event: string, handler: typeof connectionHandler) => {
+          if (event === "connection") connectionHandler = handler;
+        }),
+      },
+      config: { logger: { error: vi.fn() } },
+    };
+
+    plugin.configureServer(server);
+    connectionHandler?.({
+      on: vi.fn((event: string, handler: typeof socketErrorHandler) => {
+        if (event === "error") socketErrorHandler = handler;
+      }),
+    });
+
+    const err = Object.assign(
+      new TypeError("Invalid state: Controller is already closed"),
+      {
+        code: "ERR_INVALID_STATE",
+        stack:
+          "TypeError: Invalid state: Controller is already closed\n" +
+          "    at ReadableStreamDefaultController.close " +
+          "(node:internal/webstreams/readablestream:1068:13)\n" +
+          "    at IncomingMessage.<anonymous> " +
+          "(node:internal/webstreams/adapters:483:16)\n" +
+          "    at IncomingMessage.onclose " +
+          "(node:internal/streams/end-of-stream:161:14)",
+      },
+    );
+
+    expect(() => socketErrorHandler?.(err)).not.toThrow();
+    expect(() =>
+      socketErrorHandler?.(Object.assign(new Error("real socket failure"), {})),
+    ).toThrow("real socket failure");
+  });
 });
 
 describe("Vite CSS build defaults", () => {

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -1111,6 +1111,28 @@ function portExposer(): Plugin {
  * Vite's own connect pipeline.
  */
 function silenceConnectionResets(): Plugin {
+  const isClosedWebStreamController = (err: unknown) => {
+    const e = err as
+      | (NodeJS.ErrnoException & { cause?: NodeJS.ErrnoException })
+      | undefined;
+    const code = e?.code || (e?.cause as NodeJS.ErrnoException)?.code;
+    const message = [
+      String(e?.message ?? ""),
+      String((e?.cause as NodeJS.ErrnoException | undefined)?.message ?? ""),
+    ].join("\n");
+    const stack = [
+      String(e?.stack ?? ""),
+      String((e?.cause as NodeJS.ErrnoException | undefined)?.stack ?? ""),
+    ].join("\n");
+    return (
+      code === "ERR_INVALID_STATE" &&
+      /Controller is already closed/i.test(message) &&
+      (!stack ||
+        /ReadableStreamDefaultController\.close|internal\/webstreams\/adapters|IncomingMessage\.onclose/.test(
+          stack,
+        ))
+    );
+  };
   const isBenign = (err: unknown) => {
     const e = err as
       | (NodeJS.ErrnoException & { cause?: NodeJS.ErrnoException })
@@ -1121,6 +1143,7 @@ function silenceConnectionResets(): Plugin {
       code === "ECONNRESET" ||
       code === "ECONNABORTED" ||
       code === "EPIPE" ||
+      isClosedWebStreamController(err) ||
       /^(read ECONNRESET|write ECONNRESET|socket hang up|aborted|write EPIPE)$/i.test(
         message,
       )

--- a/packages/docs/app/routes/templates._index.tsx
+++ b/packages/docs/app/routes/templates._index.tsx
@@ -9,12 +9,14 @@ export default function TemplatesPage() {
     <main className="mx-auto max-w-[1200px] px-6 py-20">
       <div className="mb-12 text-center">
         <h1 className="mb-3 text-3xl font-bold tracking-tight md:text-4xl">
-          Open-source, Agent-native app templates you own
+          Open-source, Agent-native apps you own
         </h1>
+        <p className="mb-3 text-sm font-semibold text-[var(--docs-accent)]">
+          100% free and open source
+        </p>
         <p className="mx-auto max-w-2xl text-base leading-relaxed text-[var(--fg-secondary)]">
-          Fork a template, run it locally, and let the agent evolve it.
-          Alternatives to Superhuman, Notion, Google Calendar, PowerPoint, and
-          more — you own the code and can customize everything.
+          Fork a template, run it locally, and let the agent evolve it. You own
+          the code and can customize everything.
         </p>
       </div>
 

--- a/packages/frame/client/App.tsx
+++ b/packages/frame/client/App.tsx
@@ -337,7 +337,7 @@ export function App() {
         );
         return;
       }
-      // Relay submitChat from the iframe; the agent chat rejects
+      // Relay chat bridge events from the iframe; the agent chat rejects
       // cross-origin messages, so re-dispatch same-origin so it accepts it.
       // Only relay from known app dev-server origins to prevent arbitrary
       // cross-origin pages from injecting agent messages.
@@ -345,7 +345,10 @@ export function App() {
         setIsPresentationMode(event.data.data?.active === true);
         return;
       }
-      if (event.data.type === "agentNative.submitChat") {
+      if (
+        event.data.type === "agentNative.submitChat" ||
+        event.data.type === "agentNative.setChatContext"
+      ) {
         const host = window.location.hostname || "localhost";
         const gatewayOrigin = (() => {
           const gatewayUrl = getTemplateGatewayUrl();

--- a/packages/frame/vite.config.ts
+++ b/packages/frame/vite.config.ts
@@ -14,11 +14,24 @@ import { extractAppFromState } from "./src/oauth-state.js";
 // retries), but flood the terminal with hundreds of identical lines.
 const logger = createLogger();
 const _loggerError = logger.error.bind(logger);
+
+function isBenignProxyError(err: unknown, fallback = ""): boolean {
+  const e = err as NodeJS.ErrnoException | undefined;
+  const code = e?.code;
+  const message = `${String(e?.message ?? "")}\n${fallback}`;
+  return (
+    code === "ECONNREFUSED" ||
+    code === "ECONNRESET" ||
+    code === "ECONNABORTED" ||
+    code === "EPIPE" ||
+    /^(read ECONNRESET|write ECONNRESET|socket hang up|aborted|write EPIPE)$/im.test(
+      message,
+    )
+  );
+}
+
 logger.error = (msg, opts) => {
-  if (
-    opts?.error?.code === "ECONNREFUSED" ||
-    (typeof msg === "string" && msg.includes("ECONNREFUSED"))
-  )
+  if (isBenignProxyError(opts?.error, typeof msg === "string" ? msg : ""))
     return;
   _loggerError(msg, opts);
 };
@@ -146,6 +159,49 @@ function getAppPort(req: IncomingMessage): number {
   return portMap.get(getAppId(req)) || 8085;
 }
 
+function endProxyResponse(
+  res: ServerResponse,
+  status: number,
+  body: string,
+): void {
+  if (res.destroyed) return;
+  if (res.headersSent) {
+    res.end();
+    return;
+  }
+  res.writeHead(status, { "Content-Type": "text/plain" });
+  res.end(body);
+}
+
+function attachProxyAbortHandlers(
+  req: IncomingMessage,
+  res: ServerResponse,
+  proxyReq: http.ClientRequest,
+): void {
+  const abortProxy = () => {
+    if (!res.writableEnded) proxyReq.destroy();
+  };
+  req.on("aborted", abortProxy);
+  res.on("close", abortProxy);
+}
+
+function handleProxyError(
+  res: ServerResponse,
+  next: (err?: unknown) => void,
+  err: NodeJS.ErrnoException,
+  messages: { refused: string; closed: string },
+): void {
+  if (err.code === "ECONNREFUSED") {
+    endProxyResponse(res, 503, messages.refused);
+    return;
+  }
+  if (isBenignProxyError(err)) {
+    endProxyResponse(res, 502, messages.closed);
+    return;
+  }
+  next(err);
+}
+
 /**
  * Custom proxy middleware — Vite 8's built-in proxy uses http-proxy-3, which
  * silently ignores the `router` option. We need per-request target resolution
@@ -212,15 +268,13 @@ function framePlugin(): Plugin {
     );
 
     proxyReq.on("error", (err: NodeJS.ErrnoException) => {
-      if (err.code === "ECONNREFUSED") {
-        // App server isn't up yet — return 503 without flooding logs
-        res.writeHead(503, { "Content-Type": "text/plain" });
-        res.end(`App server on port ${port} is not running`);
-        return;
-      }
-      next(err);
+      handleProxyError(res, next, err, {
+        refused: `App server on port ${port} is not running`,
+        closed: `App server on port ${port} closed the connection`,
+      });
     });
 
+    attachProxyAbortHandlers(req, res, proxyReq);
     req.pipe(proxyReq);
   }
 
@@ -253,14 +307,13 @@ function framePlugin(): Plugin {
     );
 
     proxyReq.on("error", (err: NodeJS.ErrnoException) => {
-      if (err.code === "ECONNREFUSED") {
-        res.writeHead(503, { "Content-Type": "text/plain" });
-        res.end(`Template gateway at ${gatewayUrl} is not running`);
-        return;
-      }
-      next(err);
+      handleProxyError(res, next, err, {
+        refused: `Template gateway at ${gatewayUrl} is not running`,
+        closed: `Template gateway at ${gatewayUrl} closed the connection`,
+      });
     });
 
+    attachProxyAbortHandlers(req, res, proxyReq);
     req.pipe(proxyReq);
   }
 
@@ -293,14 +346,13 @@ function framePlugin(): Plugin {
     );
 
     proxyReq.on("error", (err: NodeJS.ErrnoException) => {
-      if (err.code === "ECONNREFUSED") {
-        res.writeHead(503, { "Content-Type": "text/plain" });
-        res.end(`App server at ${baseUrl} is not running`);
-        return;
-      }
-      next(err);
+      handleProxyError(res, next, err, {
+        refused: `App server at ${baseUrl} is not running`,
+        closed: `App server at ${baseUrl} closed the connection`,
+      });
     });
 
+    attachProxyAbortHandlers(req, res, proxyReq);
     req.pipe(proxyReq);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       '@react-router/fs-routes':
         specifier: ^7.13.1
         version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(wrangler@4.81.0)(yaml@2.8.3))(typescript@6.0.3)
+      '@resvg/resvg-js':
+        specifier: ^2.6.2
+        version: 2.6.2
       '@sentry/browser':
         specifier: ^10.50.0
         version: 10.50.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2929,6 +2929,9 @@ importers:
       '@radix-ui/react-toggle-group':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@resvg/resvg-js':
+        specifier: ^2.6.2
+        version: 2.6.2
       '@tabler/icons-react':
         specifier: ^3.40.0
         version: 3.41.1(react@19.2.5)

--- a/templates/calendar/server/lib/booking-og-image.spec.ts
+++ b/templates/calendar/server/lib/booking-og-image.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "./booking-og-image";
 
 function countBrightPixels(
-  image: ReturnType<typeof renderBookingOgImage>,
+  image: Awaited<ReturnType<typeof renderBookingOgImage>>,
   bounds: { left: number; top: number; right: number; bottom: number },
 ): number {
   const pixels = image.pixels;
@@ -53,8 +53,8 @@ describe("booking OG image", () => {
     expect(svg).not.toContain("Pick a time");
   });
 
-  it("renders a PNG image", () => {
-    const png = renderBookingOgImagePng({
+  it("renders a PNG image", async () => {
+    const png = await renderBookingOgImagePng({
       title: "Meeting",
       duration: 30,
       username: "steve",
@@ -67,8 +67,8 @@ describe("booking OG image", () => {
     ]);
   });
 
-  it("rasterizes title and duration text as visible white pixels", () => {
-    const image = renderBookingOgImage({
+  it("rasterizes title and duration text as visible white pixels", async () => {
+    const image = await renderBookingOgImage({
       title: "Meeting",
       duration: 30,
       username: "steve",
@@ -104,7 +104,7 @@ describe("booking OG image", () => {
 
       expect(fontFiles).toHaveLength(2);
 
-      const image = renderBookingOgImage(
+      const image = await renderBookingOgImage(
         {
           title: "Meeting",
           duration: 30,

--- a/templates/calendar/server/lib/booking-og-image.ts
+++ b/templates/calendar/server/lib/booking-og-image.ts
@@ -1,10 +1,6 @@
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import {
-  Resvg,
-  type RenderedImage,
-  type ResvgRenderOptions,
-} from "@resvg/resvg-js";
+import type { RenderedImage, ResvgRenderOptions } from "@resvg/resvg-js";
 
 export interface BookingOgImageInput {
   title?: string | null;
@@ -321,18 +317,23 @@ function bookingOgResvgOptions(
   };
 }
 
-export function renderBookingOgImage(
+async function loadResvg(): Promise<typeof import("@resvg/resvg-js")> {
+  return import(/* @vite-ignore */ "@resvg/resvg-js");
+}
+
+export async function renderBookingOgImage(
   input: BookingOgImageInput,
   options: BookingOgRenderOptions = {},
-): RenderedImage {
+): Promise<RenderedImage> {
+  const { Resvg } = await loadResvg();
   return new Resvg(renderBookingOgImageSvg(input), {
     ...bookingOgResvgOptions(options),
   }).render();
 }
 
-export function renderBookingOgImagePng(
+export async function renderBookingOgImagePng(
   input: BookingOgImageInput,
   options: BookingOgRenderOptions = {},
-): Uint8Array {
-  return renderBookingOgImage(input, options).asPng();
+): Promise<Uint8Array> {
+  return (await renderBookingOgImage(input, options)).asPng();
 }

--- a/templates/calendar/server/lib/booking-og-image.ts
+++ b/templates/calendar/server/lib/booking-og-image.ts
@@ -123,33 +123,79 @@ function validProfileImageDataUrl(value: string | null | undefined): string {
   return /^data:image\/[a-z0-9.+-]+;base64,/i.test(dataUrl) ? dataUrl : "";
 }
 
-function wrapText(value: string, maxChars: number, maxLines: number): string[] {
+function estimateTextWidth(value: string, fontSize: number): number {
+  let units = 0;
+  for (const char of value) {
+    if (char === " ") {
+      units += 0.28;
+    } else if (/[MW@#%&]/.test(char)) {
+      units += 0.86;
+    } else if (/[A-Z]/.test(char)) {
+      units += 0.64;
+    } else if (/[ilI.,:;|!']/u.test(char)) {
+      units += 0.26;
+    } else if (/[0-9]/.test(char)) {
+      units += 0.56;
+    } else {
+      units += 0.54;
+    }
+  }
+  return units * fontSize;
+}
+
+function trimTextToWidth(
+  value: string,
+  fontSize: number,
+  maxWidth: number,
+): string {
+  const ellipsis = "...";
+  let trimmed = value.trim();
+  while (
+    trimmed.length > 0 &&
+    estimateTextWidth(`${trimmed}${ellipsis}`, fontSize) > maxWidth
+  ) {
+    trimmed = trimmed.slice(0, -1).trimEnd();
+  }
+  return trimmed ? `${trimmed}${ellipsis}` : ellipsis;
+}
+
+function wrapText(
+  value: string,
+  fontSize: number,
+  maxWidth: number,
+  maxLines: number,
+): string[] {
   const words = value.split(/\s+/).filter(Boolean);
   const lines: string[] = [];
   let current = "";
 
   for (const word of words) {
     const next = current ? `${current} ${word}` : word;
-    if (next.length <= maxChars) {
+    if (estimateTextWidth(next, fontSize) <= maxWidth) {
       current = next;
       continue;
     }
-    if (current) lines.push(current);
-    current = word;
+    if (!current) {
+      lines.push(trimTextToWidth(word, fontSize, maxWidth));
+      current = "";
+    } else {
+      lines.push(current);
+      current = word;
+    }
     if (lines.length === maxLines) break;
   }
   if (current && lines.length < maxLines) lines.push(current);
 
-  if (lines.length > maxLines) return lines.slice(0, maxLines);
-  const last = lines[lines.length - 1];
-  const remainingWords = words.slice(lines.join(" ").split(/\s+/).length);
-  if (remainingWords.length > 0 && last) {
-    lines[lines.length - 1] =
-      last.length > maxChars - 1
-        ? `${last.slice(0, Math.max(0, maxChars - 1)).trim()}...`
-        : `${last}...`;
+  const usedWordCount = lines.join(" ").split(/\s+/).filter(Boolean).length;
+  if (usedWordCount < words.length && lines.length > 0) {
+    lines[lines.length - 1] = trimTextToWidth(
+      lines[lines.length - 1],
+      fontSize,
+      maxWidth,
+    );
   }
-  return lines.length ? lines : [value.slice(0, maxChars)];
+
+  return lines.length ? lines : [trimTextToWidth(value, fontSize, maxWidth)];
 }
 
 function textBlock({
@@ -182,16 +228,26 @@ export function renderBookingOgImageSvg(input: BookingOgImageInput): string {
     hostNameFromBookingPageTitle(input.bookingPageTitle) ??
     displayNameFromIdentifier(input.username, input.ownerEmail);
   const title = displayTitle(input, inferredHost);
-  const titleLines = wrapText(title, title.length > 34 ? 23 : 28, 2);
+  const titleFitsSingleLine = estimateTextWidth(title, 82) <= 820;
+  const titleLines = titleFitsSingleLine
+    ? [title]
+    : wrapText(title, 66, 820, 2);
   const duration = durationLabel(input);
   const initials = initialsFor(inferredHost);
   const profileImageDataUrl = validProfileImageDataUrl(
     input.profileImageDataUrl,
   );
-  const titleFontSize = titleLines.length > 1 ? 66 : 82;
+  const titleFontSize = titleFitsSingleLine ? 82 : 66;
   const titleLineHeight = titleLines.length > 1 ? 76 : 92;
-  const titleGroupY = titleLines.length > 1 ? 350 : 382;
-  const durationY = titleLines.length > 1 ? 186 : 150;
+  const titleGroupY = titleLines.length > 1 ? 332 : 382;
+  const durationBadge =
+    titleLines.length === 1
+      ? `<g transform="translate(0 150)">
+      <rect x="0" y="-34" width="${Math.max(246, duration.length * 17 + 54)}" height="58" rx="29" fill="${SURFACE}" stroke="${BORDER}"/>
+      <circle cx="31" cy="-5" r="8" fill="${BRAND_MINT}"/>
+      <text x="54" y="4" font-family="${FONT_FAMILY}" font-size="27" font-weight="700" fill="${FG}">${escapeSvg(duration)}</text>
+    </g>`
+      : "";
   const avatarContent = profileImageDataUrl
     ? `<image x="${AVATAR_CX - AVATAR_SIZE / 2}" y="${AVATAR_CY - AVATAR_SIZE / 2}" width="${AVATAR_SIZE}" height="${AVATAR_SIZE}" href="${escapeSvg(profileImageDataUrl)}" preserveAspectRatio="xMidYMid slice" mask="url(#avatarMask)"/>`
     : `<circle cx="${AVATAR_CX}" cy="${AVATAR_CY}" r="72" fill="url(#brand)" fill-opacity="0.2"/>
@@ -238,11 +294,7 @@ export function renderBookingOgImageSvg(input: BookingOgImageInput): string {
       weight: 800,
       fill: FG,
     })}
-    <g transform="translate(0 ${durationY})">
-      <rect x="0" y="-34" width="${Math.max(246, duration.length * 17 + 54)}" height="58" rx="29" fill="${SURFACE}" stroke="${BORDER}"/>
-      <circle cx="31" cy="-5" r="8" fill="${BRAND_MINT}"/>
-      <text x="54" y="4" font-family="${FONT_FAMILY}" font-size="27" font-weight="700" fill="${FG}">${escapeSvg(duration)}</text>
-    </g>
+    ${durationBadge}
   </g>
 </svg>`;
 }

--- a/templates/calendar/server/lib/booking-og-response.ts
+++ b/templates/calendar/server/lib/booking-og-response.ts
@@ -1,14 +1,10 @@
 export function bookingOgImageResponseHeaders(
   byteLength: number,
 ): Record<string, string> {
-  const cacheControl =
-    "public, max-age=60, stale-while-revalidate=604800, stale-if-error=3600";
   return {
     "Content-Type": "image/png",
     "Content-Length": String(byteLength),
-    "Cache-Control": cacheControl,
-    "CDN-Cache-Control": cacheControl,
-    "Netlify-CDN-Cache-Control": `public, durable, max-age=60, stale-while-revalidate=604800, stale-if-error=3600`,
+    "Cache-Control": "public, max-age=300, stale-while-revalidate=86400",
     "Cross-Origin-Resource-Policy": "cross-origin",
   };
 }

--- a/templates/calendar/server/lib/booking-og-response.ts
+++ b/templates/calendar/server/lib/booking-og-response.ts
@@ -1,10 +1,14 @@
 export function bookingOgImageResponseHeaders(
   byteLength: number,
 ): Record<string, string> {
+  const cacheControl =
+    "public, max-age=60, stale-while-revalidate=604800, stale-if-error=3600";
   return {
     "Content-Type": "image/png",
     "Content-Length": String(byteLength),
-    "Cache-Control": "public, max-age=300, stale-while-revalidate=86400",
+    "Cache-Control": cacheControl,
+    "CDN-Cache-Control": cacheControl,
+    "Netlify-CDN-Cache-Control": `public, durable, max-age=60, stale-while-revalidate=604800, stale-if-error=3600`,
     "Cross-Origin-Resource-Policy": "cross-origin",
   };
 }

--- a/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
+++ b/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
@@ -116,7 +116,7 @@ export default defineEventHandler(async (event: H3Event) => {
     profileImageDataUrl,
   };
   const fontFiles = await loadBundledOgFontFiles(serverAssets);
-  const png = renderBookingOgImagePng(
+  const png = await renderBookingOgImagePng(
     imageInput,
     fontFiles ? { fontFiles } : {},
   );

--- a/templates/forms/package.json
+++ b/templates/forms/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
+    "@resvg/resvg-js": "^2.6.2",
     "@tabler/icons-react": "^3.40.0",
     "cmdk": "^1.1.1",
     "drizzle-orm": "^0.45.2",

--- a/templates/forms/server/lib/form-og-image.ts
+++ b/templates/forms/server/lib/form-og-image.ts
@@ -1,8 +1,4 @@
-import {
-  Resvg,
-  type RenderedImage,
-  type ResvgRenderOptions,
-} from "@resvg/resvg-js";
+import type { RenderedImage, ResvgRenderOptions } from "@resvg/resvg-js";
 
 export interface FormOgImageInput {
   title?: string | null;
@@ -212,10 +208,19 @@ function formOgResvgOptions(): ResvgRenderOptions {
   };
 }
 
-export function renderFormOgImage(input: FormOgImageInput = {}): RenderedImage {
+async function loadResvg(): Promise<typeof import("@resvg/resvg-js")> {
+  return import(/* @vite-ignore */ "@resvg/resvg-js");
+}
+
+export async function renderFormOgImage(
+  input: FormOgImageInput = {},
+): Promise<RenderedImage> {
+  const { Resvg } = await loadResvg();
   return new Resvg(renderFormOgImageSvg(input), formOgResvgOptions()).render();
 }
 
-export function renderFormOgImagePng(input: FormOgImageInput = {}): Uint8Array {
-  return renderFormOgImage(input).asPng();
+export async function renderFormOgImagePng(
+  input: FormOgImageInput = {},
+): Promise<Uint8Array> {
+  return (await renderFormOgImage(input)).asPng();
 }

--- a/templates/forms/server/lib/form-og-image.ts
+++ b/templates/forms/server/lib/form-og-image.ts
@@ -1,0 +1,221 @@
+import {
+  Resvg,
+  type RenderedImage,
+  type ResvgRenderOptions,
+} from "@resvg/resvg-js";
+
+export interface FormOgImageInput {
+  title?: string | null;
+}
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+const BRAND_BLUE = "#00B5FF";
+const BRAND_MINT = "#48FFE4";
+const BG = "#000000";
+const SURFACE = "#0a0a0a";
+const BORDER = "#1f1f1f";
+const FG = "#ededed";
+const MUTED = "#a0a0a0";
+const FONT_FAMILY = "Liberation Sans, Arial, system-ui, sans-serif";
+
+const BADGE_CX = 996;
+const BADGE_CY = 170;
+
+const LOGO_MARK = `
+  <path d="M24.5537 65.7695H0L15.0859 39.4619L37.708 0L60.4912 39.4619H39.6396L24.5537 65.7695Z" fill="white"/>
+  <path d="M89.446 0H114L76.2921 65.7704H51.7383L89.446 0Z" fill="url(#brand)"/>
+`;
+
+function escapeSvg(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function cleanText(value: string | null | undefined): string {
+  return String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function estimateTextWidth(value: string, fontSize: number): number {
+  let units = 0;
+  for (const char of value) {
+    if (char === " ") {
+      units += 0.28;
+    } else if (/[MW@#%&]/.test(char)) {
+      units += 0.86;
+    } else if (/[A-Z]/.test(char)) {
+      units += 0.64;
+    } else if (/[ilI.,:;|!']/u.test(char)) {
+      units += 0.26;
+    } else if (/[0-9]/.test(char)) {
+      units += 0.56;
+    } else {
+      units += 0.54;
+    }
+  }
+  return units * fontSize;
+}
+
+function trimTextToWidth(
+  value: string,
+  fontSize: number,
+  maxWidth: number,
+): string {
+  const ellipsis = "...";
+  let trimmed = value.trim();
+  while (
+    trimmed.length > 0 &&
+    estimateTextWidth(`${trimmed}${ellipsis}`, fontSize) > maxWidth
+  ) {
+    trimmed = trimmed.slice(0, -1).trimEnd();
+  }
+  return trimmed ? `${trimmed}${ellipsis}` : ellipsis;
+}
+
+function wrapText(
+  value: string,
+  fontSize: number,
+  maxWidth: number,
+  maxLines: number,
+): string[] {
+  const words = value.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (estimateTextWidth(next, fontSize) <= maxWidth) {
+      current = next;
+      continue;
+    }
+    if (!current) {
+      lines.push(trimTextToWidth(word, fontSize, maxWidth));
+      current = "";
+    } else {
+      lines.push(current);
+      current = word;
+    }
+    if (lines.length === maxLines) break;
+  }
+  if (current && lines.length < maxLines) lines.push(current);
+
+  const usedWordCount = lines.join(" ").split(/\s+/).filter(Boolean).length;
+  if (usedWordCount < words.length && lines.length > 0) {
+    lines[lines.length - 1] = trimTextToWidth(
+      lines[lines.length - 1],
+      fontSize,
+      maxWidth,
+    );
+  }
+
+  return lines.length ? lines : [trimTextToWidth(value, fontSize, maxWidth)];
+}
+
+function initialsFor(title: string): string {
+  const words = title.split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "AN";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return `${words[0][0]}${words[words.length - 1][0]}`.toUpperCase();
+}
+
+function textBlock({
+  lines,
+  x,
+  y,
+  fontSize,
+  lineHeight,
+  weight,
+  fill,
+}: {
+  lines: string[];
+  x: number;
+  y: number;
+  fontSize: number;
+  lineHeight: number;
+  weight: number;
+  fill: string;
+}): string {
+  return `<text x="${x}" y="${y}" font-family="${FONT_FAMILY}" font-size="${fontSize}" font-weight="${weight}" fill="${fill}">${lines
+    .map(
+      (line, index) =>
+        `<tspan x="${x}" dy="${index === 0 ? 0 : lineHeight}">${escapeSvg(line)}</tspan>`,
+    )
+    .join("")}</text>`;
+}
+
+export function renderFormOgImageSvg(input: FormOgImageInput = {}): string {
+  const title = cleanText(input.title) || "Agent-Native Form";
+  const titleFitsSingleLine = estimateTextWidth(title, 82) <= 820;
+  const titleLines = titleFitsSingleLine
+    ? [title]
+    : wrapText(title, 66, 820, 2);
+  const titleFontSize = titleFitsSingleLine ? 82 : 66;
+  const titleLineHeight = titleLines.length > 1 ? 76 : 92;
+  const titleGroupY = titleLines.length > 1 ? 332 : 382;
+  const initials = initialsFor(title);
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">
+  <title>${escapeSvg(title)} - Agent-Native Forms preview</title>
+  <defs>
+    <linearGradient id="brand" x1="101.702" y1="67.4791" x2="113.672" y2="-37.4275" gradientUnits="userSpaceOnUse">
+      <stop stop-color="${BRAND_BLUE}"/>
+      <stop offset="1" stop-color="${BRAND_MINT}"/>
+    </linearGradient>
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#ffffff" stroke-opacity="0.07" stroke-width="1"/>
+    </pattern>
+  </defs>
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="${BG}"/>
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#grid)"/>
+  <rect x="64" y="64" width="1072" height="502" rx="28" fill="${BG}" fill-opacity="0.72" stroke="${BORDER}" stroke-width="1"/>
+  <path d="M80 154 H1120" stroke="${BORDER}"/>
+  <g transform="translate(80 86)">
+    <g transform="scale(0.62)">
+      ${LOGO_MARK}
+    </g>
+    <text x="90" y="31" font-family="${FONT_FAMILY}" font-size="28" font-weight="800" fill="${FG}">Agent-Native</text>
+    <text x="91" y="58" font-family="${FONT_FAMILY}" font-size="18" font-weight="600" fill="${MUTED}">Forms</text>
+  </g>
+  <g>
+    <circle cx="${BADGE_CX}" cy="${BADGE_CY}" r="86" fill="${SURFACE}" stroke="${BORDER}" stroke-width="2"/>
+    <circle cx="${BADGE_CX}" cy="${BADGE_CY}" r="72" fill="url(#brand)" fill-opacity="0.2"/>
+    <text x="${BADGE_CX}" y="${BADGE_CY + 20}" text-anchor="middle" font-family="${FONT_FAMILY}" font-size="56" font-weight="800" fill="${FG}">${escapeSvg(initials)}</text>
+    <circle cx="${BADGE_CX}" cy="${BADGE_CY}" r="78" fill="none" stroke="#ffffff" stroke-opacity="0.14" stroke-width="1"/>
+  </g>
+  <g transform="translate(80 ${titleGroupY})">
+    ${textBlock({
+      lines: titleLines,
+      x: 0,
+      y: 0,
+      fontSize: titleFontSize,
+      lineHeight: titleLineHeight,
+      weight: 800,
+      fill: FG,
+    })}
+  </g>
+</svg>`;
+}
+
+function formOgResvgOptions(): ResvgRenderOptions {
+  return {
+    fitTo: { mode: "width", value: WIDTH },
+    font: {
+      loadSystemFonts: true,
+      defaultFontFamily: "Liberation Sans",
+      sansSerifFamily: "Liberation Sans",
+    },
+  };
+}
+
+export function renderFormOgImage(input: FormOgImageInput = {}): RenderedImage {
+  return new Resvg(renderFormOgImageSvg(input), formOgResvgOptions()).render();
+}
+
+export function renderFormOgImagePng(input: FormOgImageInput = {}): Uint8Array {
+  return renderFormOgImage(input).asPng();
+}

--- a/templates/forms/server/lib/public-form-ssr.ts
+++ b/templates/forms/server/lib/public-form-ssr.ts
@@ -2,6 +2,12 @@ import { getMethod, getRequestURL, type H3Event } from "h3";
 import { eq } from "drizzle-orm";
 import { getAppBasePath } from "@agent-native/core/server";
 import { DEFAULT_SSR_CACHE_HEADERS } from "@agent-native/core/server/ssr-handler";
+import {
+  AGENT_NATIVE_SOCIAL_IMAGE_ALT,
+  AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT,
+  AGENT_NATIVE_SOCIAL_IMAGE_TYPE,
+  AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
+} from "@agent-native/core/shared";
 import { getDb, schema } from "../db/index.js";
 import {
   toPublicFormSettings,
@@ -20,7 +26,7 @@ function getCached(key: string) {
   return null;
 }
 
-async function getFormBySlugOrId(slugOrId: string) {
+export async function getPublicFormBySlugOrId(slugOrId: string) {
   const cached = getCached(slugOrId);
   if (cached) return cached;
 
@@ -49,6 +55,7 @@ async function getFormBySlugOrId(slugOrId: string) {
   const settings = JSON.parse(row.settings) as FormSettings;
   const result = {
     id: row.id,
+    slug: row.slug,
     title: row.title,
     description: row.description,
     fields: JSON.parse(row.fields) as FormField[],
@@ -85,6 +92,24 @@ function escapeHtml(value: unknown): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
+}
+
+const FALLBACK_PUBLIC_FORM_ORIGIN = "http://agent-native.local";
+
+function parsePublicFormUrl(url: string): {
+  pathname: string;
+  origin?: string;
+} {
+  try {
+    const parsed = new URL(url, FALLBACK_PUBLIC_FORM_ORIGIN);
+    const isAbsolute = /^[a-z][a-z0-9+.-]*:\/\//i.test(url);
+    return {
+      pathname: parsed.pathname,
+      origin: isAbsolute ? parsed.origin : undefined,
+    };
+  } catch {
+    return { pathname: url.split("?")[0] || "/" };
+  }
 }
 
 // Mirror app/components/builder/FieldRenderer.tsx#dedupeRenderableOptions.
@@ -225,19 +250,20 @@ export async function renderPublicFormHtml(
 ): Promise<{ html: string; status: number }> {
   // Extract everything after /f/ as the slug (may contain slashes for legacy URLs)
   const basePath = getAppBasePath();
-  const pathname = url.split("?")[0];
+  const parsedUrl = parsePublicFormUrl(url);
+  const pathname = parsedUrl.pathname;
   const pathWithoutBase =
     basePath && pathname.startsWith(`${basePath}/`)
       ? pathname.slice(basePath.length)
       : pathname;
   const slugOrId = decodeURIComponent(pathWithoutBase.replace(/^\/f\//, ""));
-  const form = slugOrId ? await getFormBySlugOrId(slugOrId) : null;
+  const form = slugOrId ? await getPublicFormBySlugOrId(slugOrId) : null;
 
   if (!form) {
-    return { html: notFoundPage(), status: 404 };
+    return { html: notFoundPage(parsedUrl.origin), status: 404 };
   }
 
-  return { html: renderFormPage(form), status: 200 };
+  return { html: renderFormPage(form, parsedUrl.origin), status: 200 };
 }
 
 // ---------------------------------------------------------------------------
@@ -246,7 +272,7 @@ export async function renderPublicFormHtml(
 
 export async function renderPublicForm(event: H3Event) {
   const reqUrl = getRequestURL(event);
-  const url = reqUrl.pathname + reqUrl.search;
+  const url = reqUrl.toString();
   const { html, status } = await renderPublicFormHtml(url);
 
   const headers: Record<string, string> = {
@@ -269,19 +295,31 @@ export async function renderPublicForm(event: H3Event) {
 // HTML generation
 // ---------------------------------------------------------------------------
 
-function renderFormPage(form: {
-  id: string;
-  title: string;
-  description?: string | null;
-  fields: FormField[];
-  settings: PublicFormSettings;
-}): string {
+function renderFormPage(
+  form: {
+    id: string;
+    slug: string;
+    title: string;
+    description?: string | null;
+    fields: FormField[];
+    settings: PublicFormSettings;
+  },
+  origin?: string,
+): string {
   const settings: PublicFormSettings = form.settings || {};
   const fields: FormField[] = form.fields || [];
   const turnstileSiteKey = process.env.VITE_TURNSTILE_SITE_KEY || "";
   const appBasePath = getAppBasePath();
   const submitPath = `${appBasePath}/api/submit/`;
   const faviconPath = `${appBasePath}/favicon.svg`;
+  const ogImagePath = `${appBasePath}/api/forms/og/${encodeURIComponent(
+    form.slug || form.id,
+  )}/og.png`;
+  const ogImageUrl = origin
+    ? new URL(ogImagePath, origin).toString()
+    : ogImagePath;
+  const metaDescription =
+    form.description || "Submit this Agent-Native Forms form.";
 
   const fieldsHtml = fields.map(renderField).join("\n");
 
@@ -291,7 +329,19 @@ function renderFormPage(form: {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <title>${escapeHtml(form.title)}</title>
-${form.description ? `<meta name="description" content="${escapeHtml(form.description)}">` : ""}
+<meta name="description" content="${escapeHtml(metaDescription)}">
+<meta property="og:title" content="${escapeHtml(form.title)}">
+<meta property="og:description" content="${escapeHtml(metaDescription)}">
+<meta property="og:type" content="website">
+<meta property="og:image" content="${escapeHtml(ogImageUrl)}">
+<meta property="og:image:secure_url" content="${escapeHtml(ogImageUrl)}">
+<meta property="og:image:type" content="${AGENT_NATIVE_SOCIAL_IMAGE_TYPE}">
+<meta property="og:image:width" content="${AGENT_NATIVE_SOCIAL_IMAGE_WIDTH}">
+<meta property="og:image:height" content="${AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT}">
+<meta property="og:image:alt" content="${escapeHtml(`${form.title} form preview`)}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="${escapeHtml(ogImageUrl)}">
+<meta name="twitter:image:alt" content="${AGENT_NATIVE_SOCIAL_IMAGE_ALT}">
 <link rel="icon" type="image/svg+xml" href="${faviconPath}">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -545,13 +595,30 @@ ${form.description ? `<meta name="description" content="${escapeHtml(form.descri
 // 404 page
 // ---------------------------------------------------------------------------
 
-function notFoundPage() {
+function notFoundPage(origin?: string) {
+  const appBasePath = getAppBasePath();
+  const ogImagePath = `${appBasePath}/_agent-native/og-image.png`;
+  const ogImageUrl = origin
+    ? new URL(ogImagePath, origin).toString()
+    : ogImagePath;
   return `<!DOCTYPE html>
 <html lang="en" class="dark">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <title>Form not found</title>
+<meta name="description" content="This Agent-Native Forms link is no longer available.">
+<meta property="og:title" content="Form not found">
+<meta property="og:description" content="This Agent-Native Forms link is no longer available.">
+<meta property="og:image" content="${escapeHtml(ogImageUrl)}">
+<meta property="og:image:secure_url" content="${escapeHtml(ogImageUrl)}">
+<meta property="og:image:type" content="${AGENT_NATIVE_SOCIAL_IMAGE_TYPE}">
+<meta property="og:image:width" content="${AGENT_NATIVE_SOCIAL_IMAGE_WIDTH}">
+<meta property="og:image:height" content="${AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT}">
+<meta property="og:image:alt" content="${AGENT_NATIVE_SOCIAL_IMAGE_ALT}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="${escapeHtml(ogImageUrl)}">
+<meta name="twitter:image:alt" content="${AGENT_NATIVE_SOCIAL_IMAGE_ALT}">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
 <style>${CSS()}</style>
 </head>

--- a/templates/forms/server/plugins/auth.ts
+++ b/templates/forms/server/plugins/auth.ts
@@ -11,5 +11,5 @@ export default createAuthPlugin({
       "Response summaries, exports, and trend analysis on demand",
     ],
   },
-  publicPaths: ["/f", "/api/forms/public", "/api/submit"],
+  publicPaths: ["/f", "/api/forms/public", "/api/forms/og", "/api/submit"],
 });

--- a/templates/forms/server/routes/api/forms/og/[slug]/og.png.get.ts
+++ b/templates/forms/server/routes/api/forms/og/[slug]/og.png.get.ts
@@ -1,0 +1,40 @@
+import {
+  defineEventHandler,
+  getMethod,
+  getRouterParam,
+  setResponseStatus,
+  type H3Event,
+} from "h3";
+import {
+  agentNativeOgImageResponseHeaders,
+  renderAgentNativeOgImagePng,
+} from "@agent-native/core/server";
+import { getPublicFormBySlugOrId } from "../../../../../lib/public-form-ssr.js";
+
+export default defineEventHandler(async (event: H3Event) => {
+  const slug = getRouterParam(event, "slug");
+  if (!slug) {
+    setResponseStatus(event, 400);
+    return { error: "slug is required" };
+  }
+
+  const form = await getPublicFormBySlugOrId(slug);
+  if (!form) {
+    setResponseStatus(event, 404);
+    return { error: "Form not found" };
+  }
+
+  const png = await renderAgentNativeOgImagePng({
+    appName: "Agent-Native Forms",
+    title: form.title,
+    subtitle: "Agent-Native Forms",
+  });
+  const body = png.buffer.slice(
+    png.byteOffset,
+    png.byteOffset + png.byteLength,
+  ) as ArrayBuffer;
+
+  return new Response(getMethod(event) === "HEAD" ? null : body, {
+    headers: agentNativeOgImageResponseHeaders(png.byteLength),
+  });
+});

--- a/templates/forms/server/routes/api/forms/og/[slug]/og.png.get.ts
+++ b/templates/forms/server/routes/api/forms/og/[slug]/og.png.get.ts
@@ -5,10 +5,8 @@ import {
   setResponseStatus,
   type H3Event,
 } from "h3";
-import {
-  agentNativeOgImageResponseHeaders,
-  renderAgentNativeOgImagePng,
-} from "@agent-native/core/server";
+import { agentNativeOgImageResponseHeaders } from "@agent-native/core/server";
+import { renderFormOgImagePng } from "../../../../../lib/form-og-image.js";
 import { getPublicFormBySlugOrId } from "../../../../../lib/public-form-ssr.js";
 
 export default defineEventHandler(async (event: H3Event) => {
@@ -24,10 +22,8 @@ export default defineEventHandler(async (event: H3Event) => {
     return { error: "Form not found" };
   }
 
-  const png = await renderAgentNativeOgImagePng({
-    appName: "Agent-Native Forms",
+  const png = renderFormOgImagePng({
     title: form.title,
-    subtitle: "Agent-Native Forms",
   });
   const body = png.buffer.slice(
     png.byteOffset,

--- a/templates/forms/server/routes/api/forms/og/[slug]/og.png.get.ts
+++ b/templates/forms/server/routes/api/forms/og/[slug]/og.png.get.ts
@@ -22,7 +22,7 @@ export default defineEventHandler(async (event: H3Event) => {
     return { error: "Form not found" };
   }
 
-  const png = renderFormOgImagePng({
+  const png = await renderFormOgImagePng({
     title: form.title,
   });
   const body = png.buffer.slice(

--- a/templates/scheduling/app/lib/social-og.ts
+++ b/templates/scheduling/app/lib/social-og.ts
@@ -1,0 +1,65 @@
+import type { MetaDescriptor } from "react-router";
+import {
+  AGENT_NATIVE_SOCIAL_IMAGE_ALT,
+  AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT,
+  AGENT_NATIVE_SOCIAL_IMAGE_PATH,
+  AGENT_NATIVE_SOCIAL_IMAGE_TYPE,
+  AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
+} from "@agent-native/core/shared";
+
+function normalizeAppBasePath(value: string | undefined): string {
+  if (!value || value === "/") return "";
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === "/") return "";
+  return `/${trimmed.replace(/^\/+/, "").replace(/\/+$/, "")}`;
+}
+
+function appBasePath(): string {
+  const metaEnv = (
+    import.meta as unknown as {
+      env?: Record<string, string | undefined>;
+    }
+  ).env;
+  return normalizeAppBasePath(
+    process.env.VITE_APP_BASE_PATH ||
+      process.env.APP_BASE_PATH ||
+      metaEnv?.VITE_APP_BASE_PATH ||
+      metaEnv?.APP_BASE_PATH ||
+      metaEnv?.BASE_URL,
+  );
+}
+
+export function buildSocialOgImageUrl({
+  request,
+  title,
+  subtitle,
+}: {
+  request: Request;
+  title: string;
+  subtitle: string;
+}): string {
+  const imageUrl = new URL(
+    `${appBasePath()}${AGENT_NATIVE_SOCIAL_IMAGE_PATH}`,
+    request.url,
+  );
+  imageUrl.searchParams.set("title", title);
+  imageUrl.searchParams.set("subtitle", subtitle);
+  return imageUrl.toString();
+}
+
+export function socialImageMeta(
+  image: string,
+  alt = AGENT_NATIVE_SOCIAL_IMAGE_ALT,
+): MetaDescriptor[] {
+  return [
+    { property: "og:image", content: image },
+    { property: "og:image:secure_url", content: image },
+    { property: "og:image:type", content: AGENT_NATIVE_SOCIAL_IMAGE_TYPE },
+    { property: "og:image:width", content: AGENT_NATIVE_SOCIAL_IMAGE_WIDTH },
+    { property: "og:image:height", content: AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT },
+    { property: "og:image:alt", content: alt },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:image", content: image },
+    { name: "twitter:image:alt", content: alt },
+  ];
+}

--- a/templates/scheduling/app/routes/$user.$slug.tsx
+++ b/templates/scheduling/app/routes/$user.$slug.tsx
@@ -5,8 +5,9 @@ import {
   resolveEventTypeSlug,
 } from "@agent-native/scheduling/server";
 import { Booker } from "@/components/booker/Booker";
+import { buildSocialOgImageUrl, socialImageMeta } from "@/lib/social-og";
 
-export async function loader({ params }: LoaderFunctionArgs) {
+export async function loader({ params, request }: LoaderFunctionArgs) {
   const ownerEmail = params.user!;
   const slug = params.slug!;
   const eventType =
@@ -14,7 +15,17 @@ export async function loader({ params }: LoaderFunctionArgs) {
     (await resolveEventTypeSlug({ ownerEmail, slug }));
   if (!eventType || eventType.hidden)
     throw new Response("Not found", { status: 404 });
-  return { eventType, ownerEmail };
+  const name = ownerEmail.split("@")[0];
+  const title = `${eventType.title} with ${name}`;
+  return {
+    eventType,
+    ownerEmail,
+    ogImageUrl: buildSocialOgImageUrl({
+      request,
+      title,
+      subtitle: "Agent-Native Scheduling",
+    }),
+  };
 }
 
 export function meta({
@@ -23,16 +34,27 @@ export function meta({
   data?: {
     eventType: { title: string; description?: string | null };
     ownerEmail: string;
+    ogImageUrl?: string;
   };
 }) {
   if (!data) return [{ title: "Book a meeting" }];
   const name = data.ownerEmail.split("@")[0];
+  const title = `${data.eventType.title} with ${name}`;
   return [
-    { title: `${data.eventType.title} with ${name}` },
+    { title },
     {
       name: "description",
       content: data.eventType.description || `Book a meeting with ${name}.`,
     },
+    { property: "og:title", content: title },
+    {
+      property: "og:description",
+      content: data.eventType.description || `Book a meeting with ${name}.`,
+    },
+    { property: "og:type", content: "website" },
+    ...(data.ogImageUrl
+      ? socialImageMeta(data.ogImageUrl, "Agent-Native Scheduling booking link")
+      : []),
   ];
 }
 

--- a/templates/scheduling/app/routes/forms.$formId.tsx
+++ b/templates/scheduling/app/routes/forms.$formId.tsx
@@ -9,6 +9,7 @@ import type { LoaderFunctionArgs } from "react-router";
 import { eq, inArray } from "drizzle-orm";
 import { agentNativePath } from "@agent-native/core/client";
 import { getDb, schema } from "../../server/db";
+import { buildSocialOgImageUrl, socialImageMeta } from "@/lib/social-og";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -20,8 +21,28 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-export function meta() {
-  return [{ title: "Routing form" }];
+export function meta({
+  data,
+}: {
+  data?: {
+    form: { name: string; description?: string | null };
+    ogImageUrl?: string;
+  };
+}) {
+  const title = data?.form?.name || "Routing form";
+  const description =
+    data?.form?.description ||
+    "Answer a few questions to find the right meeting.";
+  return [
+    { title },
+    { name: "description", content: description },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+    { property: "og:type", content: "website" },
+    ...(data?.ogImageUrl
+      ? socialImageMeta(data.ogImageUrl, "Agent-Native Scheduling routing form")
+      : []),
+  ];
 }
 
 function safeExternalUrl(value: unknown): string | null {
@@ -36,7 +57,7 @@ function safeExternalUrl(value: unknown): string | null {
   }
 }
 
-export async function loader({ params }: LoaderFunctionArgs) {
+export async function loader({ params, request }: LoaderFunctionArgs) {
   const db = getDb();
   const rows = await db
     .select()
@@ -67,6 +88,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     }
   }
 
+  const title = row.name;
   return {
     form: {
       id: row.id,
@@ -77,6 +99,11 @@ export async function loader({ params }: LoaderFunctionArgs) {
       fallback,
       eventRoutes,
     },
+    ogImageUrl: buildSocialOgImageUrl({
+      request,
+      title,
+      subtitle: "Agent-Native Scheduling",
+    }),
   };
 }
 


### PR DESCRIPTION
## Summary
- add generated Agent-Native OG preview images and default social image metadata across SSR, auth, and onboarding pages
- add dynamic public form and scheduling share OG images, and update booking OG caching to stale-while-revalidate with max-age=60
- include the local assistant UI recovery, duplicate resource-key cleanup, and background run visibility changes already on this branch

## Tests
- pnpm --filter @agent-native/core typecheck
- pnpm --filter forms typecheck
- pnpm --filter scheduling typecheck
- pnpm --filter calendar typecheck
- pnpm --filter @agent-native/core exec vitest --run src/server/ssr-handler.spec.ts src/deploy/build.spec.ts src/server/auth.spec.ts src/server/onboarding-html.spec.ts
- rendered OG examples at tmp/og-examples/*.png and verified 1200x630 dimensions