### PR TITLE
Animate docs sidebar accordions

### DIFF
--- a/packages/docs/app/components/DocsSidebar.test.tsx
+++ b/packages/docs/app/components/DocsSidebar.test.tsx
@@ -11,6 +11,16 @@ function renderSidebar(path: string) {
   );
 }
 
+function getLinkMarkup(html: string, href: string) {
+  const match = html.match(new RegExp(`<a\\b[^>]*href="${href}"[^>]*>`));
+
+  if (!match) {
+    throw new Error(`Expected sidebar link for ${href}`);
+  }
+
+  return match[0];
+}
+
 describe("DocsSidebar", () => {
   it("keeps the overview section expanded without a toggle", () => {
     const html = renderSidebar("/docs");
@@ -26,6 +36,14 @@ describe("DocsSidebar", () => {
     expect(html).toContain("Tracking &amp; Analytics");
     expect(html).toContain('href="/docs/tracking"');
     expect(html).toContain('aria-expanded="true"');
-    expect(html).not.toContain('href="/docs/creating-templates"');
+
+    const activeLink = getLinkMarkup(html, "/docs/tracking");
+    const closedLink = getLinkMarkup(html, "/docs/creating-templates");
+
+    expect(activeLink).toContain('data-an-prefetch="render"');
+    expect(activeLink).not.toContain("tabindex");
+    expect(closedLink).not.toContain("data-an-prefetch");
+    expect(closedLink).toContain('tabindex="-1"');
+    expect(html).toContain('data-state="closed" aria-hidden="true" inert=""');
   });
 });

--- a/packages/docs/app/components/DocsSidebar.tsx
+++ b/packages/docs/app/components/DocsSidebar.tsx
@@ -75,7 +75,7 @@ export default function DocsSidebar() {
     <aside className="hidden w-[220px] shrink-0 lg:block">
       <nav
         ref={navRef}
-        className="sticky top-[65px] max-h-[calc(100vh-65px)] overflow-y-auto pb-8 pt-8 pr-4"
+        className="docs-sidebar-nav sticky top-[65px] max-h-[calc(100vh-65px)] overflow-y-auto pb-8 pt-8 pr-4"
       >
         {NAV_SECTIONS.map((section, index) => {
           const isAlwaysOpen = index === ALWAYS_OPEN_SECTION_INDEX;
@@ -108,16 +108,23 @@ export default function DocsSidebar() {
                 </button>
               )}
 
-              {isOpen ? (
-                <ul id={sectionId} className="docs-sidebar-section-items">
+              <div
+                id={sectionId}
+                className="docs-sidebar-section-items-clip"
+                data-state={isOpen ? "open" : "closed"}
+                aria-hidden={isOpen ? undefined : true}
+                inert={isOpen ? undefined : true}
+              >
+                <ul className="docs-sidebar-section-items">
                   {section.items.map((item) => {
                     const active = isItemActive(item.to, location.pathname);
                     return (
                       <li key={item.to}>
                         <Link
-                          data-an-prefetch="render"
+                          data-an-prefetch={isOpen ? "render" : undefined}
                           to={item.to}
                           className={`sidebar-link${active ? " is-active" : ""}`}
+                          tabIndex={isOpen ? undefined : -1}
                         >
                           {item.label}
                         </Link>
@@ -125,7 +132,7 @@ export default function DocsSidebar() {
                     );
                   })}
                 </ul>
-              ) : null}
+              </div>
             </section>
           );
         })}

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -498,7 +498,6 @@ h4 {
   }
 
   .docs-sidebar-section-items-clip[data-state="closed"] {
-    height: auto;
     max-height: 0;
   }
 }

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -408,6 +408,10 @@ h4 {
 }
 
 /* Sidebar nav */
+.docs-sidebar-nav {
+  overflow-anchor: none;
+}
+
 .docs-sidebar-section + .docs-sidebar-section {
   margin-top: 6px;
 }
@@ -460,6 +464,50 @@ h4 {
 
 .docs-sidebar-chevron.is-open {
   transform: rotate(90deg);
+}
+
+.docs-sidebar-section-items-clip {
+  display: flow-root;
+  height: auto;
+  overflow: hidden;
+  overflow: clip;
+  opacity: 1;
+  clip-path: inset(0);
+  interpolate-size: allow-keywords;
+  transition:
+    height 220ms cubic-bezier(0.2, 0, 0, 1),
+    opacity 160ms ease,
+    clip-path 220ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.docs-sidebar-section-items-clip[data-state="closed"] {
+  height: 0;
+  opacity: 0;
+  clip-path: inset(0 0 100% 0);
+  pointer-events: none;
+}
+
+@supports not (interpolate-size: allow-keywords) {
+  .docs-sidebar-section-items-clip {
+    height: auto;
+    max-height: 32rem;
+    transition:
+      max-height 220ms cubic-bezier(0.2, 0, 0, 1),
+      opacity 160ms ease,
+      clip-path 220ms cubic-bezier(0.2, 0, 0, 1);
+  }
+
+  .docs-sidebar-section-items-clip[data-state="closed"] {
+    height: auto;
+    max-height: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .docs-sidebar-section-items-clip,
+  .docs-sidebar-chevron {
+    transition: none;
+  }
 }
 
 .docs-sidebar-section-items {


### PR DESCRIPTION
## Summary
- keep docs sidebar sections mounted so open/close can animate smoothly
- add intrinsic-height accordion transitions with a max-height fallback
- keep collapsed links inert, unfocusable, and out of render-time prefetch warmup

## Verification
- pnpm --filter @agent-native/docs test -- DocsSidebar
- pnpm --filter @agent-native/docs typecheck
- local browser smoke check of sidebar toggles