### PR TITLE
Add Sentry Error Intelligence dashboard with Slack search

### DIFF
--- a/templates/analytics/actions/github-blame.ts
+++ b/templates/analytics/actions/github-blame.ts
@@ -1,0 +1,41 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import { getFileBlame } from "../server/lib/github";
+import {
+  providerError,
+  requireActionCredentials,
+} from "./_provider-action-utils";
+
+export default defineAction({
+  description:
+    "Get Git blame for a file path in a GitHub repository. Returns the most recent commit per blame range, who authored it, and any associated PR.",
+  schema: z.object({
+    owner: z.string().describe("GitHub repository owner (org or user)"),
+    repo: z.string().describe("GitHub repository name"),
+    path: z.string().describe("File path within the repository"),
+    ref: z
+      .string()
+      .default("HEAD")
+      .describe("Branch, tag, or commit SHA (default: HEAD)"),
+  }),
+  readOnly: true,
+  run: async (args) => {
+    const credentials = await requireActionCredentials(
+      ["GITHUB_TOKEN"],
+      "GitHub",
+    );
+    if (credentials.ok === false) return credentials.response;
+
+    try {
+      const result = await getFileBlame(
+        args.owner,
+        args.repo,
+        args.path,
+        args.ref,
+      );
+      return result;
+    } catch (err) {
+      return providerError(err);
+    }
+  },
+});

--- a/templates/analytics/actions/sentry.ts
+++ b/templates/analytics/actions/sentry.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   getIssueEvents,
   getOrganizationStats,
+  getCodeMappings,
   listOrganizations,
   listIssues,
   listProjects,
@@ -17,7 +18,14 @@ export default defineAction({
     "Query Sentry projects, frequent issues, issue events, and organization error stats. Use this for Sentry error questions; pass statsPeriod like 7d, 30d, or 1y.",
   schema: z.object({
     mode: z
-      .enum(["organizations", "projects", "issues", "issue-events", "stats"])
+      .enum([
+        "organizations",
+        "projects",
+        "issues",
+        "issue-events",
+        "stats",
+        "code-mappings",
+      ])
       .default("issues")
       .describe("What to query from Sentry"),
     orgSlug: z
@@ -53,6 +61,11 @@ export default defineAction({
     if (credentials.ok === false) return credentials.response;
 
     try {
+      if (args.mode === "code-mappings") {
+        const mappings = await getCodeMappings(args.orgSlug);
+        return { mappings };
+      }
+
       if (args.mode === "organizations") {
         const organizations = await listOrganizations();
         return { organizations, total: organizations.length };

--- a/templates/analytics/actions/slack-messages.ts
+++ b/templates/analytics/actions/slack-messages.ts
@@ -153,7 +153,7 @@ export default defineAction({
 
       if (args.mode === "search") {
         if (!args.query) return { error: "query is required" };
-        const result = await searchMessages(workspace, args.query);
+        const result = await searchMessages(workspace, args.query, args.limit);
         const userIds = result.messages
           .map((message) => message.user)
           .filter((id): id is string => !!id);

--- a/templates/analytics/app/lib/data-sources.ts
+++ b/templates/analytics/app/lib/data-sources.ts
@@ -677,11 +677,12 @@ export const dataSources: DataSource[] = [
       {
         title: "Add a User Token for search (optional)",
         description:
-          'Slack\'s search API requires a user token. Under "OAuth & Permissions", copy the User OAuth Token (starts with "xoxp-"). Required for the Slack search feature in Sentry Error Intelligence.',
+          "Optional. Enables the Slack search.messages API for richer search results. Without it, the bot scans channels it's been invited to.",
         inputKey: "SLACK_USER_TOKEN",
         inputLabel: "User Token (for search)",
         inputPlaceholder: "xoxp-...",
         inputType: "password",
+        optional: true,
       },
     ],
   },

--- a/templates/analytics/app/lib/data-sources.ts
+++ b/templates/analytics/app/lib/data-sources.ts
@@ -548,7 +548,7 @@ export const dataSources: DataSource[] = [
     description: "Error tracking and performance monitoring",
     category: "engineering",
     icon: IconBug,
-    envKeys: ["SENTRY_AUTH_TOKEN"],
+    envKeys: ["SENTRY_AUTH_TOKEN", "SENTRY_ORG_SLUG"],
     docsUrl: "https://docs.sentry.io/api/",
     walkthroughSteps: [
       {
@@ -565,6 +565,14 @@ export const dataSources: DataSource[] = [
         inputLabel: "Auth Token",
         inputPlaceholder: "sntrys_...",
         inputType: "password",
+      },
+      {
+        title: "Enter your Organization Slug",
+        description:
+          "Your Sentry organization slug (e.g. my-company). Find it in your Sentry URL: sentry.io/organizations/<slug>/",
+        inputKey: "SENTRY_ORG_SLUG",
+        inputLabel: "Organization Slug",
+        inputPlaceholder: "my-company",
       },
     ],
   },

--- a/templates/analytics/app/lib/data-sources.ts
+++ b/templates/analytics/app/lib/data-sources.ts
@@ -651,7 +651,7 @@ export const dataSources: DataSource[] = [
     description: "Channel messages and workspace search",
     category: "communication",
     icon: IconMessage,
-    envKeys: ["SLACK_BOT_TOKEN"],
+    envKeys: ["SLACK_BOT_TOKEN", "SLACK_USER_TOKEN"],
     docsUrl: "https://api.slack.com/methods",
     walkthroughSteps: [
       {
@@ -672,6 +672,15 @@ export const dataSources: DataSource[] = [
         inputKey: "SLACK_BOT_TOKEN",
         inputLabel: "Bot Token",
         inputPlaceholder: "xoxb-...",
+        inputType: "password",
+      },
+      {
+        title: "Add a User Token for search (optional)",
+        description:
+          'Slack\'s search API requires a user token. Under "OAuth & Permissions", copy the User OAuth Token (starts with "xoxp-"). Required for the Slack search feature in Sentry Error Intelligence.',
+        inputKey: "SLACK_USER_TOKEN",
+        inputLabel: "User Token (for search)",
+        inputPlaceholder: "xoxp-...",
         inputType: "password",
       },
     ],

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -535,10 +535,14 @@ function ConnectedView({
                       Configured
                     </span>
                   ) : optional ? (
-                    <span className="flex items-center gap-1 whitespace-nowrap text-muted-foreground">
-                      <IconCircle className="h-3 w-3" />
-                      Optional
-                    </span>
+                    <button
+                      type="button"
+                      onClick={() => setEditing(true)}
+                      className="flex items-center gap-1 whitespace-nowrap text-muted-foreground hover:text-primary text-xs cursor-pointer"
+                    >
+                      <IconPlus className="h-3 w-3" />
+                      Add
+                    </button>
                   ) : (
                     <span className="flex items-center gap-1 whitespace-nowrap text-rose-400">
                       <IconAlertCircle className="h-3 w-3" />

--- a/templates/analytics/app/pages/adhoc/registry.ts
+++ b/templates/analytics/app/pages/adhoc/registry.ts
@@ -63,7 +63,17 @@ export interface DashboardMeta {
 
 // Add new dashboards here. Each entry needs a matching file in this directory.
 // REQUIRED FIELDS: id, name, author, lastUpdated
-export const dashboards: DashboardMeta[] = [];
+export const dashboards: DashboardMeta[] = [
+  {
+    id: "sentry-errors",
+    name: "Sentry Error Intelligence",
+    description:
+      "Top 10 errors, escalating issues, related error groups, and project breakdown",
+    author: "Liam DeBeasi",
+    lastUpdated: "2025-05-12",
+    dateCreated: "2025-05-12",
+  },
+];
 
 const HIDDEN_KEY = "hidden-dashboards";
 
@@ -143,6 +153,7 @@ export const dashboardComponents: Record<
 > = {
   explorer: lazy(() => import("./explorer")),
   "explorer-dashboard": lazy(() => import("./explorer-dashboard")),
+  "sentry-errors": lazy(() => import("./sentry-errors")),
 };
 
 // Validate all dashboards at module load time

--- a/templates/analytics/app/pages/adhoc/sentry-errors/ErrorGroupsPanel.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/ErrorGroupsPanel.tsx
@@ -1,0 +1,186 @@
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  IconChevronDown,
+  IconChevronRight,
+  IconExternalLink,
+} from "@tabler/icons-react";
+import type { SentryIssue } from "./index";
+
+interface ErrorGroup {
+  type: string;
+  issues: SentryIssue[];
+  totalEvents: number;
+  totalUsers: number;
+  worstLevel: string;
+}
+
+function levelOrder(level: string): number {
+  return { fatal: 0, error: 1, warning: 2, info: 3, debug: 4 }[level] ?? 5;
+}
+
+function levelColor(level: string): string {
+  switch (level) {
+    case "fatal":
+      return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800";
+    case "error":
+      return "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400 border-orange-200 dark:border-orange-800";
+    case "warning":
+      return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400 border-yellow-200 dark:border-yellow-800";
+    default:
+      return "bg-muted text-muted-foreground border-border";
+  }
+}
+
+function formatCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function timeAgo(date: string): string {
+  const ms = Date.now() - new Date(date).getTime();
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+function GroupRow({ group }: { group: ErrorGroup }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="border-b border-border/50 last:border-0">
+      <button
+        type="button"
+        className="w-full text-left px-4 py-3 hover:bg-muted/40 transition-colors flex items-start gap-3"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <Badge
+              className={`text-[10px] px-1.5 py-0 ${levelColor(group.worstLevel)} border`}
+            >
+              {group.worstLevel}
+            </Badge>
+            <span className="text-xs text-muted-foreground">
+              {group.issues.length} issue{group.issues.length !== 1 ? "s" : ""}
+            </span>
+          </div>
+          <p className="text-sm font-medium mt-1 truncate">{group.type}</p>
+        </div>
+        <div className="shrink-0 text-right">
+          <p className="text-sm font-semibold tabular-nums">
+            {formatCount(group.totalEvents)}
+          </p>
+          <p className="text-xs text-muted-foreground">events</p>
+        </div>
+        <div className="shrink-0 pt-0.5">
+          {expanded ? (
+            <IconChevronDown className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <IconChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="bg-muted/20 border-t border-border/50">
+          {group.issues.map((issue) => (
+            <a
+              key={issue.id}
+              href={issue.permalink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-start gap-3 px-6 py-2.5 hover:bg-muted/50 transition-colors group"
+            >
+              <Badge
+                className={`text-[10px] px-1.5 py-0 shrink-0 mt-0.5 ${levelColor(issue.level)} border`}
+              >
+                {issue.level}
+              </Badge>
+              <div className="flex-1 min-w-0">
+                <p className="text-xs font-medium truncate">
+                  {issue.metadata.value ?? issue.title}
+                </p>
+                <p className="text-[10px] text-muted-foreground mt-0.5">
+                  {issue.project.name} · {timeAgo(issue.lastSeen)} ·{" "}
+                  {formatCount(parseInt(issue.count, 10))} events
+                </p>
+              </div>
+              <IconExternalLink className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5 opacity-0 group-hover:opacity-100 transition-opacity" />
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface ErrorGroupsPanelProps {
+  issues: SentryIssue[];
+  isLoading: boolean;
+}
+
+export function ErrorGroupsPanel({ issues, isLoading }: ErrorGroupsPanelProps) {
+  const groups = useMemo((): ErrorGroup[] => {
+    const map = new Map<string, SentryIssue[]>();
+    for (const issue of issues) {
+      const type = issue.metadata.type ?? issue.type ?? "Unknown";
+      const arr = map.get(type) ?? [];
+      arr.push(issue);
+      map.set(type, arr);
+    }
+    return [...map.entries()]
+      .map(([type, issueList]) => {
+        const totalEvents = issueList.reduce(
+          (s, i) => s + parseInt(i.count, 10),
+          0,
+        );
+        const totalUsers = issueList.reduce((s, i) => s + i.userCount, 0);
+        const worstLevel = issueList.reduce((worst, i) => {
+          return levelOrder(i.level) < levelOrder(worst) ? i.level : worst;
+        }, "debug");
+        return { type, issues: issueList, totalEvents, totalUsers, worstLevel };
+      })
+      .sort((a, b) => b.totalEvents - a.totalEvents);
+  }, [issues]);
+
+  if (isLoading) {
+    return (
+      <div className="divide-y divide-border/50">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="px-4 py-3 flex gap-3">
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-4 w-2/3" />
+            </div>
+            <Skeleton className="h-6 w-10 shrink-0" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!groups.length) {
+    return (
+      <div className="py-16 text-center">
+        <p className="text-sm text-muted-foreground">No error groups found</p>
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="h-[520px]">
+      <div>
+        {groups.map((group) => (
+          <GroupRow key={group.type} group={group} />
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/templates/analytics/app/pages/adhoc/sentry-errors/GitHubBlamePanel.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/GitHubBlamePanel.tsx
@@ -1,0 +1,348 @@
+import { useState, useEffect } from "react";
+import { useActionMutation, useActionQuery } from "@agent-native/core/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  IconBrandGithub,
+  IconGitCommit,
+  IconExternalLink,
+  IconAlertTriangle,
+  IconRefresh,
+  IconSettings,
+} from "@tabler/icons-react";
+import type { SentryIssue } from "./index";
+
+// ---- Types ------------------------------------------------------------------
+
+interface BlameCommit {
+  oid: string;
+  abbreviatedOid: string;
+  message: string;
+  committedDate: string;
+  url: string;
+  author: { name: string; email: string; avatarUrl?: string };
+  associatedPullRequests?: {
+    nodes: { number: number; title: string; url: string }[];
+  };
+}
+
+interface BlameRange {
+  startingLine: number;
+  endingLine: number;
+  age: number;
+  commit: BlameCommit;
+}
+
+interface BlameResult {
+  owner: string;
+  repo: string;
+  path: string;
+  ranges: BlameRange[];
+  latestCommit: BlameCommit | null;
+  hotRange: BlameRange | null;
+  error?: string;
+}
+
+interface CodeMapping {
+  projectSlug: string;
+  repoName: string;
+  stackRoot: string;
+  sourceRoot: string;
+}
+
+// ---- Helpers ----------------------------------------------------------------
+
+function parseCulpritPath(issue: SentryIssue): string {
+  // Prefer the explicit filename from metadata
+  if (issue.metadata.filename) return issue.metadata.filename;
+  // Culprit is usually "path/to/file.ts in functionName"
+  const culprit = issue.culprit ?? "";
+  const inIdx = culprit.indexOf(" in ");
+  return inIdx !== -1 ? culprit.slice(0, inIdx).trim() : culprit.trim();
+}
+
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const days = Math.floor(diff / 86_400_000);
+  if (days === 0) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(months / 12)}y ago`;
+}
+
+function getRepoFromStorage(): string {
+  return localStorage.getItem("sentry_github_repo") ?? "";
+}
+function saveRepoToStorage(repo: string) {
+  localStorage.setItem("sentry_github_repo", repo);
+}
+
+// ---- Main Component ---------------------------------------------------------
+
+interface GitHubBlamePanelProps {
+  issue: SentryIssue;
+}
+
+export function GitHubBlamePanel({ issue }: GitHubBlamePanelProps) {
+  const filePath = parseCulpritPath(issue);
+  const [repo, setRepo] = useState(getRepoFromStorage);
+  const [repoInput, setRepoInput] = useState(getRepoFromStorage);
+  const [editingRepo, setEditingRepo] = useState(!getRepoFromStorage());
+  const [result, setResult] = useState<BlameResult | null>(null);
+  const [fetched, setFetched] = useState(false);
+
+  const mutation = useActionMutation("github-blame");
+
+  // Auto-detect repo from Sentry code mappings
+  const mappingsQuery = useActionQuery("sentry", { mode: "code-mappings" });
+  const mappingsData = mappingsQuery.data as {
+    mappings?: CodeMapping[];
+  } | null;
+
+  useEffect(() => {
+    if (repo || !mappingsData?.mappings) return;
+    const projectSlug = issue.project.slug;
+    // Try to find a mapping for this project, or fall back to the first mapping
+    const match =
+      mappingsData.mappings.find((m) => m.projectSlug === projectSlug) ??
+      mappingsData.mappings[0];
+    if (match?.repoName) {
+      setRepo(match.repoName);
+      setRepoInput(match.repoName);
+      saveRepoToStorage(match.repoName);
+      setEditingRepo(false);
+    }
+  }, [mappingsData, issue.project.slug, repo]);
+
+  const dataError =
+    result?.error ??
+    (mutation.error ? (mutation.error as Error).message : null);
+
+  function runBlame(repoSlug: string) {
+    if (!repoSlug || !filePath) return;
+    const [owner, repoName] = repoSlug.split("/");
+    if (!owner || !repoName) return;
+    setFetched(true);
+    mutation.mutate(
+      { owner, repo: repoName, path: filePath },
+      { onSuccess: (data) => setResult(data as BlameResult) },
+    );
+  }
+
+  function handleSaveRepo() {
+    const slug = repoInput.trim();
+    setRepo(slug);
+    saveRepoToStorage(slug);
+    setEditingRepo(false);
+    runBlame(slug);
+  }
+
+  const latestCommit = result?.latestCommit;
+  const pr = latestCommit?.associatedPullRequests?.nodes?.[0];
+
+  // Top-N unique authors weighted by recency
+  const authors = result?.ranges
+    ? Object.values(
+        result.ranges.reduce<
+          Record<
+            string,
+            { name: string; email: string; age: number; lines: number }
+          >
+        >((acc, r) => {
+          const key = r.commit.author.email;
+          if (!acc[key]) {
+            acc[key] = {
+              name: r.commit.author.name,
+              email: key,
+              age: r.age,
+              lines: 0,
+            };
+          }
+          acc[key].lines += r.endingLine - r.startingLine + 1;
+          if (r.age < acc[key].age) acc[key].age = r.age;
+          return acc;
+        }, {}),
+      ).sort((a, b) => b.lines - a.lines)
+    : [];
+
+  return (
+    <div className="pt-3 border-t border-border/50 space-y-2.5">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <IconBrandGithub className="h-3.5 w-3.5 shrink-0" />
+          GitHub blame
+          {filePath && (
+            <span className="font-mono font-normal truncate max-w-[180px]">
+              · {filePath.split("/").pop()}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          {fetched && !editingRepo && (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-6 w-6 p-0 shrink-0"
+              onClick={() => runBlame(repo)}
+              disabled={mutation.isPending}
+            >
+              <IconRefresh
+                className={`h-3.5 w-3.5 ${mutation.isPending ? "animate-spin" : ""}`}
+              />
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 w-6 p-0 shrink-0"
+            onClick={() => setEditingRepo((v) => !v)}
+          >
+            <IconSettings className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Repo config */}
+      {editingRepo && (
+        <div className="flex gap-1.5">
+          <Input
+            value={repoInput}
+            onChange={(e) => setRepoInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleSaveRepo();
+              if (e.key === "Escape") setEditingRepo(false);
+            }}
+            placeholder="owner/repo (e.g. acme/backend)"
+            className="h-8 text-xs font-mono"
+            autoFocus
+          />
+          <Button
+            size="sm"
+            className="h-8 px-3 text-xs shrink-0"
+            onClick={handleSaveRepo}
+            disabled={!repoInput.trim().includes("/")}
+          >
+            Blame
+          </Button>
+        </div>
+      )}
+
+      {/* No file path */}
+      {!filePath && !editingRepo && (
+        <p className="text-xs text-muted-foreground">
+          No file path found in this issue&apos;s culprit.
+        </p>
+      )}
+
+      {/* Prompt to configure repo */}
+      {!editingRepo && !repo && filePath && (
+        <button
+          type="button"
+          onClick={() => setEditingRepo(true)}
+          className="w-full flex items-center gap-2 h-8 px-3 rounded-md border border-dashed border-border/60 hover:border-border hover:bg-muted/40 transition-colors text-left"
+        >
+          <IconBrandGithub className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          <span className="text-xs text-muted-foreground">
+            {mappingsQuery.isLoading
+              ? "Detecting repository from Sentry…"
+              : "Set repo to see who last touched "}
+            {!mappingsQuery.isLoading && (
+              <span className="font-mono">{filePath.split("/").pop()}</span>
+            )}
+          </span>
+        </button>
+      )}
+
+      {/* Loading */}
+      {mutation.isPending && (
+        <div className="space-y-2.5 pt-1">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="flex gap-2">
+              <Skeleton className="h-6 w-6 rounded-full shrink-0" />
+              <div className="flex-1 space-y-1.5">
+                <Skeleton className="h-3 w-32" />
+                <Skeleton className="h-3 w-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Error */}
+      {!mutation.isPending && dataError && (
+        <div className="flex items-start gap-2 text-xs text-muted-foreground py-1">
+          <IconAlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-yellow-500" />
+          <span>{dataError}</span>
+        </div>
+      )}
+
+      {/* Results */}
+      {!mutation.isPending && !dataError && latestCommit && (
+        <div className="space-y-3">
+          {/* Latest commit card */}
+          <a
+            href={pr?.url ?? latestCommit.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block rounded-md border border-border/60 bg-muted/20 px-3 py-2.5 hover:bg-muted/40 transition-colors group"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex items-center gap-1.5 text-xs font-medium">
+                <IconGitCommit className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                {pr ? (
+                  <span>
+                    PR #{pr.number}{" "}
+                    <span className="font-normal text-muted-foreground">
+                      · {pr.title}
+                    </span>
+                  </span>
+                ) : (
+                  <span className="font-mono">
+                    {latestCommit.abbreviatedOid}
+                  </span>
+                )}
+              </div>
+              <IconExternalLink className="h-3 w-3 text-muted-foreground shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+            </div>
+            <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
+              {latestCommit.message.split("\n")[0]}
+            </p>
+            <div className="flex items-center gap-2 mt-1.5 text-[11px] text-muted-foreground">
+              <span className="font-medium text-foreground/70">
+                {latestCommit.author.name}
+              </span>
+              <span>·</span>
+              <span>{timeAgo(latestCommit.committedDate)}</span>
+            </div>
+          </a>
+
+          {/* Author breakdown */}
+          {authors.length > 1 && (
+            <div className="space-y-1">
+              <p className="text-[10px] text-muted-foreground uppercase tracking-wide font-medium">
+                File ownership
+              </p>
+              {authors.slice(0, 4).map((a) => (
+                <div key={a.email} className="flex items-center gap-2 text-xs">
+                  <div className="h-5 w-5 rounded-full bg-muted/60 shrink-0 flex items-center justify-center text-[9px] font-bold text-muted-foreground uppercase">
+                    {a.name[0]}
+                  </div>
+                  <span className="flex-1 truncate text-foreground/80">
+                    {a.name}
+                  </span>
+                  <span className="text-[10px] text-muted-foreground">
+                    {a.lines} lines · last {a.age}d ago
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/templates/analytics/app/pages/adhoc/sentry-errors/IssueSparkline.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/IssueSparkline.tsx
@@ -1,0 +1,46 @@
+interface IssueSparklineProps {
+  data: number[][];
+  escalating?: boolean;
+}
+
+export function IssueSparkline({ data, escalating }: IssueSparklineProps) {
+  if (!data.length) return null;
+
+  const values = data.map(([, v]) => v);
+  const max = Math.max(...values, 1);
+  const height = 24;
+  const width = 120;
+  const barW = Math.max(2, Math.floor(width / values.length) - 1);
+  const gap = Math.max(1, Math.floor(width / values.length) - barW);
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className="overflow-visible"
+      aria-hidden="true"
+    >
+      {values.map((v, i) => {
+        const barH = Math.max(1, Math.round((v / max) * (height - 2)));
+        const x = i * (barW + gap);
+        const y = height - barH;
+        const isRecent = i >= values.length - 4;
+        return (
+          <rect
+            key={i}
+            x={x}
+            y={y}
+            width={barW}
+            height={barH}
+            rx={1}
+            className={
+              escalating && isRecent
+                ? "fill-rose-500/80"
+                : "fill-muted-foreground/30"
+            }
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
@@ -118,7 +118,7 @@ export function SlackMentionsPanel({ issue }: SlackMentionsPanelProps) {
 
   const mutation = useActionMutation("slack-messages");
 
-  const messages = result?.messages ?? [];
+  const messages = (result?.messages ?? []).slice(0, 10);
   const users: Record<string, SlackUser> = result?.users ?? {};
   const dataError =
     result?.error ??
@@ -130,7 +130,7 @@ export function SlackMentionsPanel({ issue }: SlackMentionsPanelProps) {
     setEditingQuery(false);
     setSearched(true);
     mutation.mutate(
-      { mode: "search", query: q },
+      { mode: "search", query: q, limit: 10 },
       { onSuccess: (data) => setResult(data as SlackSearchResult) },
     );
   }

--- a/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
@@ -86,6 +86,8 @@ function buildSearchQuery(issue: SentryIssue): string {
   const parts: string[] = [];
   // Issue short ID (e.g. "AIR-LAYOUT-1176") is the most specific search term
   if (issue.shortId) parts.push(issue.shortId);
+  // Permalink — matches messages where someone pasted the Sentry issue URL
+  if (issue.permalink) parts.push(issue.permalink.replace(/\/$/, ""));
   // Error type is meaningful (e.g. "McpError", "TypeError")
   if (issue.metadata.type) parts.push(issue.metadata.type);
   // Truncated error value gives context

--- a/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useActionQuery } from "@agent-native/core/client";
+import { useActionMutation } from "@agent-native/core/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -10,6 +10,7 @@ import {
   IconAlertTriangle,
   IconExternalLink,
   IconRefresh,
+  IconX,
 } from "@tabler/icons-react";
 import type { SentryIssue } from "./index";
 
@@ -34,13 +35,18 @@ interface SlackUser {
   profile: { display_name: string };
 }
 
+interface SlackSearchResult {
+  messages?: SlackMessage[];
+  users?: Record<string, SlackUser>;
+  total?: number;
+  error?: string;
+}
+
 // ---- Helpers ----------------------------------------------------------------
 
 function tsToDate(ts: string): string {
   const ms = parseFloat(ts) * 1000;
-  const d = new Date(ms);
-  const now = Date.now();
-  const diff = now - ms;
+  const diff = Date.now() - ms;
   const mins = Math.floor(diff / 60_000);
   if (mins < 1) return "just now";
   if (mins < 60) return `${mins}m ago`;
@@ -48,7 +54,10 @@ function tsToDate(ts: string): string {
   if (hrs < 24) return `${hrs}h ago`;
   const days = Math.floor(hrs / 24);
   if (days < 7) return `${days}d ago`;
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return new Date(ms).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
 }
 
 function resolveUsername(
@@ -75,12 +84,18 @@ function stripSlackFormatting(text: string): string {
 
 function buildSearchQuery(issue: SentryIssue): string {
   const parts: string[] = [];
+  // Issue short ID (e.g. "AIR-LAYOUT-1176") is the most specific search term
+  if (issue.shortId) parts.push(issue.shortId);
+  // Error type is meaningful (e.g. "McpError", "TypeError")
   if (issue.metadata.type) parts.push(issue.metadata.type);
+  // Truncated error value gives context
   if (issue.metadata.value) {
-    const trimmed = issue.metadata.value.slice(0, 60).trim();
-    if (trimmed) parts.push(trimmed);
+    const trimmed = issue.metadata.value.slice(0, 50).trim();
+    if (trimmed && !parts.some((p) => trimmed.includes(p))) {
+      parts.push(trimmed);
+    }
   }
-  if (!parts.length) parts.push(issue.title.slice(0, 80));
+  if (parts.length === 0) parts.push(issue.title.slice(0, 80));
   return parts.join(" ").replace(/['"]/g, "").trim();
 }
 
@@ -93,146 +108,139 @@ interface SlackMentionsPanelProps {
 export function SlackMentionsPanel({ issue }: SlackMentionsPanelProps) {
   const defaultQuery = buildSearchQuery(issue);
   const [query, setQuery] = useState(defaultQuery);
-  const [activeQuery, setActiveQuery] = useState<string | null>(null);
   const [editingQuery, setEditingQuery] = useState(false);
+  const [result, setResult] = useState<SlackSearchResult | null>(null);
+  const [searched, setSearched] = useState(false);
 
-  const searchQuery = useActionQuery(
-    "slack-messages",
-    { mode: "search", query: activeQuery ?? "" },
-    { enabled: !!activeQuery },
-  );
+  const mutation = useActionMutation("slack-messages");
 
-  const rawData = searchQuery.data as {
-    messages?: SlackMessage[];
-    users?: Record<string, SlackUser>;
-    total?: number;
-    error?: string;
-  } | null;
-
-  const messages =
-    rawData && "messages" in rawData ? (rawData.messages ?? []) : [];
-  const users: Record<string, SlackUser> =
-    rawData && "users" in rawData ? (rawData.users ?? {}) : {};
+  const messages = result?.messages ?? [];
+  const users: Record<string, SlackUser> = result?.users ?? {};
   const dataError =
-    (rawData && "error" in rawData ? rawData.error : null) ??
-    (searchQuery.error ? (searchQuery.error as Error).message : null);
+    result?.error ??
+    (mutation.error ? (mutation.error as Error).message : null);
 
   function handleSearch() {
     const q = query.trim();
     if (!q) return;
-    setActiveQuery(q);
     setEditingQuery(false);
-    if (activeQuery === q) searchQuery.refetch();
+    setSearched(true);
+    mutation.mutate(
+      { mode: "search", query: q },
+      { onSuccess: (data) => setResult(data as SlackSearchResult) },
+    );
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === "Enter") handleSearch();
-  }
-
-  // Not yet triggered
-  if (!activeQuery) {
-    return (
-      <div className="pt-3 border-t border-border/50">
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <IconBrandSlack className="h-4 w-4 shrink-0" />
-            <span>Search Slack for mentions of this error</span>
-          </div>
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-7 gap-1.5 text-xs shrink-0"
-            onClick={() => {
-              setActiveQuery(query);
-            }}
-          >
-            <IconSearch className="h-3.5 w-3.5" />
-            Search Slack
-          </Button>
-        </div>
-        {/* Query preview */}
-        <p className="mt-1.5 text-[10px] text-muted-foreground/70 font-mono truncate">
-          "{query}"
-        </p>
-      </div>
-    );
+    if (e.key === "Escape") setEditingQuery(false);
   }
 
   return (
-    <div className="pt-3 border-t border-border/50 space-y-3">
-      {/* Header row */}
+    <div className="pt-3 border-t border-border/50 space-y-2.5">
+      {/* Header */}
       <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <IconBrandSlack className="h-4 w-4 shrink-0 text-muted-foreground" />
-          <span className="text-sm font-medium">Slack mentions</span>
-          {!searchQuery.isLoading && !dataError && (
-            <span className="text-xs text-muted-foreground">
+        <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <IconBrandSlack className="h-3.5 w-3.5 shrink-0" />
+          Slack mentions
+          {searched && !mutation.isPending && !dataError && (
+            <span className="font-normal">
               ({messages.length} result{messages.length !== 1 ? "s" : ""})
             </span>
           )}
         </div>
-        <Button
-          size="sm"
-          variant="ghost"
-          className="h-7 w-7 p-0 shrink-0"
-          onClick={() => searchQuery.refetch()}
-          disabled={searchQuery.isLoading}
-        >
-          <IconRefresh
-            className={`h-3.5 w-3.5 ${searchQuery.isLoading ? "animate-spin" : ""}`}
-          />
-        </Button>
+        {searched && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 w-6 p-0 shrink-0"
+            onClick={handleSearch}
+            disabled={mutation.isPending}
+          >
+            <IconRefresh
+              className={`h-3.5 w-3.5 ${mutation.isPending ? "animate-spin" : ""}`}
+            />
+          </Button>
+        )}
       </div>
 
-      {/* Query editor */}
+      {/* Search bar */}
       {editingQuery ? (
-        <div className="flex gap-2">
+        <div className="flex gap-1.5">
           <Input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
-            className="h-7 text-xs font-mono"
+            className="h-8 text-xs font-mono"
             autoFocus
           />
-          <Button size="sm" className="h-7 text-xs px-3" onClick={handleSearch}>
+          <Button
+            size="sm"
+            className="h-8 px-3 text-xs shrink-0"
+            onClick={handleSearch}
+            disabled={mutation.isPending}
+          >
             Search
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-8 w-8 p-0 shrink-0"
+            onClick={() => setEditingQuery(false)}
+          >
+            <IconX className="h-3.5 w-3.5" />
           </Button>
         </div>
       ) : (
         <button
           type="button"
-          onClick={() => setEditingQuery(true)}
-          className="text-[10px] text-muted-foreground/70 font-mono truncate hover:text-muted-foreground transition-colors text-left w-full"
+          className="w-full flex items-center gap-2 h-8 px-3 rounded-md border border-border/60 hover:border-border hover:bg-muted/40 transition-colors text-left group"
+          onClick={() => {
+            if (!searched) {
+              handleSearch();
+            } else {
+              setEditingQuery(true);
+            }
+          }}
         >
-          "{activeQuery}" — click to edit
+          <IconSearch className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          <span className="text-xs font-mono text-muted-foreground truncate flex-1">
+            {query}
+          </span>
+          {searched && (
+            <span className="text-[10px] text-muted-foreground/60 shrink-0 group-hover:text-muted-foreground">
+              edit
+            </span>
+          )}
         </button>
       )}
 
       {/* Results */}
-      {searchQuery.isLoading ? (
-        <div className="space-y-2">
+      {mutation.isPending ? (
+        <div className="space-y-2.5 pt-1">
           {Array.from({ length: 3 }).map((_, i) => (
             <div key={i} className="flex gap-2">
               <Skeleton className="h-6 w-6 rounded-full shrink-0" />
               <div className="flex-1 space-y-1.5">
                 <Skeleton className="h-3 w-24" />
                 <Skeleton className="h-3 w-full" />
+                <Skeleton className="h-3 w-3/4" />
               </div>
             </div>
           ))}
         </div>
       ) : dataError ? (
-        <div className="flex items-start gap-2 text-xs text-muted-foreground py-2">
+        <div className="flex items-start gap-2 text-xs text-muted-foreground py-1">
           <IconAlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-yellow-500" />
           <span>{dataError}</span>
         </div>
-      ) : messages.length === 0 ? (
-        <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
+      ) : searched && messages.length === 0 ? (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground py-1">
           <IconMessage className="h-4 w-4 shrink-0" />
-          <span>No Slack messages found for this query</span>
+          <span>No Slack messages found</span>
         </div>
       ) : (
-        <div className="space-y-2.5 max-h-64 overflow-y-auto pr-0.5">
+        <div className="space-y-3 max-h-56 overflow-y-auto">
           {messages.map((msg) => {
             const name = resolveUsername(msg, users);
             const text = stripSlackFormatting(msg.text);
@@ -242,7 +250,7 @@ export function SlackMentionsPanel({ issue }: SlackMentionsPanelProps) {
                   {name[0] ?? "?"}
                 </div>
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-baseline gap-2 flex-wrap">
+                  <div className="flex items-baseline gap-1.5 flex-wrap">
                     <span className="text-xs font-semibold">{name}</span>
                     <span className="text-[10px] text-muted-foreground">
                       {tsToDate(msg.ts)}

--- a/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useActionMutation } from "@agent-native/core/client";
+import { useActionMutation, sendToAgentChat } from "@agent-native/core/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -13,6 +13,7 @@ import {
   IconX,
   IconChevronDown,
   IconChevronUp,
+  IconSparkles,
 } from "@tabler/icons-react";
 import type { SentryIssue } from "./index";
 
@@ -360,33 +361,60 @@ export function SlackMentionsPanel({ issue }: SlackMentionsPanelProps) {
                   )}
                 </div>
 
-                {/* Thread toggle */}
+                {/* Thread section */}
                 {hasThread && (
-                  <div className="ml-2 pl-4 border-l-2 border-border/40">
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setExpandedThreads((prev) => {
-                          const next = new Set(prev);
-                          if (next.has(msg.ts)) next.delete(msg.ts);
-                          else next.add(msg.ts);
-                          return next;
-                        })
-                      }
-                      className="flex items-center gap-1 text-[11px] text-primary hover:text-primary/80 py-0.5"
-                    >
-                      {isExpanded ? (
-                        <IconChevronUp className="h-3 w-3" />
-                      ) : (
-                        <IconChevronDown className="h-3 w-3" />
-                      )}
-                      {isExpanded
-                        ? "Hide thread"
-                        : `${msg.replies!.length} repl${msg.replies!.length !== 1 ? "ies" : "y"} — show investigation thread`}
-                    </button>
+                  <div className="ml-2 pl-3 border-l-2 border-border/40 space-y-1">
+                    {/* Toggle */}
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setExpandedThreads((prev) => {
+                            const next = new Set(prev);
+                            if (next.has(msg.ts)) next.delete(msg.ts);
+                            else next.add(msg.ts);
+                            return next;
+                          })
+                        }
+                        className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground py-0.5"
+                      >
+                        {isExpanded ? (
+                          <IconChevronUp className="h-3 w-3" />
+                        ) : (
+                          <IconChevronDown className="h-3 w-3" />
+                        )}
+                        {msg.replies!.length} repl
+                        {msg.replies!.length !== 1 ? "ies" : "y"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const allMsgs = [
+                            { name, text, ts: msg.ts },
+                            ...msg.replies!.map((r) => ({
+                              name: resolveUsername(r, users),
+                              text: stripSlackFormatting(r.text),
+                              ts: r.ts,
+                            })),
+                          ];
+                          const transcript = allMsgs
+                            .map((m) => `${m.name}: ${m.text}`)
+                            .join("\n");
+                          sendToAgentChat({
+                            message: `Summarize this Slack thread about a Sentry error. Extract: initial investigation findings, root cause hypotheses, any fixes attempted, and current status.\n\nThread:\n${transcript}`,
+                            submit: true,
+                          });
+                        }}
+                        className="flex items-center gap-1 text-[11px] text-primary hover:text-primary/80 py-0.5"
+                      >
+                        <IconSparkles className="h-3 w-3" />
+                        Summarize
+                      </button>
+                    </div>
 
+                    {/* Replies */}
                     {isExpanded && (
-                      <div className="space-y-1.5 pt-1 pb-1">
+                      <div className="space-y-1.5 py-1">
                         {msg.replies!.map((reply) => {
                           const rName = resolveUsername(reply, users);
                           const rText = stripSlackFormatting(reply.text);

--- a/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useState as useLocalState } from "react";
 import { useActionMutation } from "@agent-native/core/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -11,6 +12,8 @@ import {
   IconExternalLink,
   IconRefresh,
   IconX,
+  IconChevronDown,
+  IconChevronUp,
 } from "@tabler/icons-react";
 import type { SentryIssue } from "./index";
 
@@ -26,6 +29,7 @@ interface SlackMessage {
   reply_count?: number;
   channel?: { id: string; name: string } | string;
   permalink?: string;
+  replies?: SlackMessage[];
 }
 
 interface SlackUser {
@@ -103,6 +107,49 @@ function buildSearchQuery(issue: SentryIssue): string {
   return parts.join(" ").replace(/['"]/g, "").trim();
 }
 
+// ---- Sub-components ---------------------------------------------------------
+
+function MessageContent({
+  name,
+  text,
+  ts,
+  channelName,
+  showLink,
+}: {
+  name: string;
+  text: string;
+  ts: string;
+  channelName?: string;
+  showLink?: boolean;
+}) {
+  return (
+    <>
+      <div className="h-6 w-6 rounded-full bg-muted/60 shrink-0 flex items-center justify-center text-[10px] font-bold text-muted-foreground uppercase mt-0.5">
+        {name[0] ?? "?"}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline gap-1.5 flex-wrap">
+          <span className="text-xs font-semibold">{name}</span>
+          <span className="text-[10px] text-muted-foreground">
+            {tsToDate(ts)}
+          </span>
+          {channelName && (
+            <span className="text-[10px] text-muted-foreground">
+              #{channelName}
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground mt-0.5 line-clamp-3 break-words">
+          {text}
+        </p>
+      </div>
+      {showLink && (
+        <IconExternalLink className="h-3.5 w-3.5 text-muted-foreground shrink-0 opacity-0 group-hover:opacity-100 transition-opacity mt-1 ml-auto" />
+      )}
+    </>
+  );
+}
+
 // ---- Main Component ---------------------------------------------------------
 
 interface SlackMentionsPanelProps {
@@ -115,6 +162,9 @@ export function SlackMentionsPanel({ issue }: SlackMentionsPanelProps) {
   const [editingQuery, setEditingQuery] = useState(false);
   const [result, setResult] = useState<SlackSearchResult | null>(null);
   const [searched, setSearched] = useState(false);
+  const [expandedThreads, setExpandedThreads] = useLocalState<Set<string>>(
+    new Set(),
+  );
 
   const mutation = useActionMutation("slack-messages");
 
@@ -271,55 +321,100 @@ export function SlackMentionsPanel({ issue }: SlackMentionsPanelProps) {
           </div>
         </div>
       ) : (
-        <div className="space-y-1 max-h-56 overflow-y-auto">
+        <div className="space-y-2 max-h-72 overflow-y-auto">
           {messages.map((msg) => {
             const name = resolveUsername(msg, users);
             const text = stripSlackFormatting(msg.text);
             const channelName =
               typeof msg.channel === "string" ? msg.channel : msg.channel?.name;
-            const Row = msg.permalink ? "a" : "div";
-            const rowProps = msg.permalink
-              ? {
-                  href: msg.permalink,
-                  target: "_blank" as const,
-                  rel: "noopener noreferrer",
-                }
-              : {};
+            const hasThread = msg.replies && msg.replies.length > 0;
+            const isExpanded = expandedThreads.has(msg.ts);
+
             return (
-              <Row
-                key={msg.ts}
-                {...rowProps}
-                className="flex gap-2 group px-2 py-1.5 rounded-md hover:bg-muted/50 transition-colors cursor-pointer -mx-2"
-              >
-                <div className="h-6 w-6 rounded-full bg-muted/60 shrink-0 flex items-center justify-center text-[10px] font-bold text-muted-foreground uppercase mt-0.5">
-                  {name[0] ?? "?"}
+              <div key={msg.ts} className="space-y-0.5">
+                {/* Parent message */}
+                <div className="flex gap-2 group -mx-2">
+                  {msg.permalink ? (
+                    <a
+                      href={msg.permalink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex gap-2 flex-1 min-w-0 px-2 py-1.5 rounded-md hover:bg-muted/50 transition-colors"
+                    >
+                      <MessageContent
+                        name={name}
+                        text={text}
+                        ts={msg.ts}
+                        channelName={channelName}
+                        showLink
+                      />
+                    </a>
+                  ) : (
+                    <div className="flex gap-2 flex-1 min-w-0 px-2 py-1.5">
+                      <MessageContent
+                        name={name}
+                        text={text}
+                        ts={msg.ts}
+                        channelName={channelName}
+                      />
+                    </div>
+                  )}
                 </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-baseline gap-1.5 flex-wrap">
-                    <span className="text-xs font-semibold">{name}</span>
-                    <span className="text-[10px] text-muted-foreground">
-                      {tsToDate(msg.ts)}
-                    </span>
-                    {channelName && (
-                      <span className="text-[10px] text-muted-foreground">
-                        #{channelName}
-                      </span>
+
+                {/* Thread toggle */}
+                {hasThread && (
+                  <div className="ml-2 pl-4 border-l-2 border-border/40">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setExpandedThreads((prev) => {
+                          const next = new Set(prev);
+                          if (next.has(msg.ts)) next.delete(msg.ts);
+                          else next.add(msg.ts);
+                          return next;
+                        })
+                      }
+                      className="flex items-center gap-1 text-[11px] text-primary hover:text-primary/80 py-0.5"
+                    >
+                      {isExpanded ? (
+                        <IconChevronUp className="h-3 w-3" />
+                      ) : (
+                        <IconChevronDown className="h-3 w-3" />
+                      )}
+                      {isExpanded
+                        ? "Hide thread"
+                        : `${msg.replies!.length} repl${msg.replies!.length !== 1 ? "ies" : "y"} — show investigation thread`}
+                    </button>
+
+                    {isExpanded && (
+                      <div className="space-y-1.5 pt-1 pb-1">
+                        {msg.replies!.map((reply) => {
+                          const rName = resolveUsername(reply, users);
+                          const rText = stripSlackFormatting(reply.text);
+                          return (
+                            <div key={reply.ts} className="flex gap-2 text-xs">
+                              <div className="h-5 w-5 rounded-full bg-muted/60 shrink-0 flex items-center justify-center text-[9px] font-bold text-muted-foreground uppercase mt-0.5">
+                                {rName[0] ?? "?"}
+                              </div>
+                              <div className="flex-1 min-w-0">
+                                <span className="font-semibold text-[11px]">
+                                  {rName}
+                                </span>
+                                <span className="text-[10px] text-muted-foreground ml-1.5">
+                                  {tsToDate(reply.ts)}
+                                </span>
+                                <p className="text-muted-foreground mt-0.5 break-words">
+                                  {rText}
+                                </p>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
                     )}
-                    {msg.reply_count ? (
-                      <span className="text-[10px] text-muted-foreground">
-                        {msg.reply_count} repl
-                        {msg.reply_count !== 1 ? "ies" : "y"}
-                      </span>
-                    ) : null}
                   </div>
-                  <p className="text-xs text-muted-foreground mt-0.5 line-clamp-3 break-words">
-                    {text}
-                  </p>
-                </div>
-                {msg.permalink && (
-                  <IconExternalLink className="h-3.5 w-3.5 text-muted-foreground shrink-0 opacity-0 group-hover:opacity-100 transition-opacity mt-1" />
                 )}
-              </Row>
+              </div>
             );
           })}
         </div>

--- a/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
@@ -87,7 +87,7 @@ function buildSearchQuery(issue: SentryIssue): string {
   // Issue short ID (e.g. "AIR-LAYOUT-1176") is the most specific search term
   if (issue.shortId) parts.push(issue.shortId);
   // Permalink — matches messages where someone pasted the Sentry issue URL
-  if (issue.permalink) parts.push(issue.permalink.replace(/\/$/, ""));
+  if (issue.permalink) parts.push(issue.permalink);
   // Error type is meaningful (e.g. "McpError", "TypeError")
   if (issue.metadata.type) parts.push(issue.metadata.type);
   // Truncated error value gives context

--- a/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
@@ -24,7 +24,7 @@ interface SlackMessage {
   ts: string;
   thread_ts?: string;
   reply_count?: number;
-  channel?: { id: string; name: string };
+  channel?: { id: string; name: string } | string;
   permalink?: string;
 }
 
@@ -269,12 +269,26 @@ export function SlackMentionsPanel({ issue }: SlackMentionsPanelProps) {
           </div>
         </div>
       ) : (
-        <div className="space-y-3 max-h-56 overflow-y-auto">
+        <div className="space-y-1 max-h-56 overflow-y-auto">
           {messages.map((msg) => {
             const name = resolveUsername(msg, users);
             const text = stripSlackFormatting(msg.text);
+            const channelName =
+              typeof msg.channel === "string" ? msg.channel : msg.channel?.name;
+            const Row = msg.permalink ? "a" : "div";
+            const rowProps = msg.permalink
+              ? {
+                  href: msg.permalink,
+                  target: "_blank" as const,
+                  rel: "noopener noreferrer",
+                }
+              : {};
             return (
-              <div key={msg.ts} className="flex gap-2 group">
+              <Row
+                key={msg.ts}
+                {...rowProps}
+                className="flex gap-2 group px-2 py-1.5 rounded-md hover:bg-muted/50 transition-colors cursor-pointer -mx-2"
+              >
                 <div className="h-6 w-6 rounded-full bg-muted/60 shrink-0 flex items-center justify-center text-[10px] font-bold text-muted-foreground uppercase mt-0.5">
                   {name[0] ?? "?"}
                 </div>
@@ -284,9 +298,9 @@ export function SlackMentionsPanel({ issue }: SlackMentionsPanelProps) {
                     <span className="text-[10px] text-muted-foreground">
                       {tsToDate(msg.ts)}
                     </span>
-                    {msg.channel && (
+                    {channelName && (
                       <span className="text-[10px] text-muted-foreground">
-                        #{msg.channel.name}
+                        #{channelName}
                       </span>
                     )}
                     {msg.reply_count ? (
@@ -301,16 +315,9 @@ export function SlackMentionsPanel({ issue }: SlackMentionsPanelProps) {
                   </p>
                 </div>
                 {msg.permalink && (
-                  <a
-                    href={msg.permalink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity mt-0.5"
-                  >
-                    <IconExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
-                  </a>
+                  <IconExternalLink className="h-3.5 w-3.5 text-muted-foreground shrink-0 opacity-0 group-hover:opacity-100 transition-opacity mt-1" />
                 )}
-              </div>
+              </Row>
             );
           })}
         </div>

--- a/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useState as useLocalState } from "react";
 import { useActionMutation } from "@agent-native/core/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -162,7 +161,7 @@ export function SlackMentionsPanel({ issue }: SlackMentionsPanelProps) {
   const [editingQuery, setEditingQuery] = useState(false);
   const [result, setResult] = useState<SlackSearchResult | null>(null);
   const [searched, setSearched] = useState(false);
-  const [expandedThreads, setExpandedThreads] = useLocalState<Set<string>>(
+  const [expandedThreads, setExpandedThreads] = useState<Set<string>>(
     new Set(),
   );
 

--- a/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
@@ -237,9 +237,36 @@ export function SlackMentionsPanel({ issue }: SlackMentionsPanelProps) {
           <span>{dataError}</span>
         </div>
       ) : searched && messages.length === 0 ? (
-        <div className="flex items-center gap-2 text-xs text-muted-foreground py-1">
-          <IconMessage className="h-4 w-4 shrink-0" />
-          <span>No Slack messages found</span>
+        <div className="space-y-2 py-1">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <IconMessage className="h-4 w-4 shrink-0" />
+            <span>No messages found in accessible channels</span>
+          </div>
+          <div className="rounded-md border border-border/50 bg-muted/20 px-3 py-2.5 space-y-1.5">
+            <p className="text-[11px] font-medium text-foreground/80">
+              Searching private channels?
+            </p>
+            <p className="text-[11px] text-muted-foreground leading-relaxed">
+              The bot can only scan public channels it&apos;s been added to. To
+              search private channels, add a Slack{" "}
+              <strong>User OAuth Token</strong> (xoxp-) in{" "}
+              <a
+                href="/analytics/data-sources"
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                Data Sources → Slack
+              </a>
+              .
+            </p>
+            <p className="text-[11px] text-muted-foreground leading-relaxed">
+              To get one: Slack app → <strong>OAuth &amp; Permissions</strong> →{" "}
+              <strong>User Token Scopes</strong> → add{" "}
+              <code className="font-mono bg-muted px-1 rounded">
+                search:read
+              </code>{" "}
+              → Reinstall app → copy the <strong>User OAuth Token</strong>.
+            </p>
+          </div>
         </div>
       ) : (
         <div className="space-y-3 max-h-56 overflow-y-auto">

--- a/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
@@ -66,9 +66,11 @@ function resolveUsername(
 ): string {
   if (msg.user && users[msg.user]) {
     const u = users[msg.user];
-    return u.profile.display_name || u.real_name || u.name;
+    const resolved = u.profile.display_name || u.real_name || u.name;
+    // Reject raw user IDs (e.g. "U08ABC123") — fall through to username
+    if (resolved && !/^[UW][A-Z0-9]{6,}$/.test(resolved)) return resolved;
   }
-  return msg.username ?? "Unknown";
+  return msg.username || "Unknown";
 }
 
 function stripSlackFormatting(text: string): string {

--- a/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/SlackMentionsPanel.tsx
@@ -1,0 +1,283 @@
+import { useState } from "react";
+import { useActionQuery } from "@agent-native/core/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  IconBrandSlack,
+  IconSearch,
+  IconMessage,
+  IconAlertTriangle,
+  IconExternalLink,
+  IconRefresh,
+} from "@tabler/icons-react";
+import type { SentryIssue } from "./index";
+
+// ---- Types ------------------------------------------------------------------
+
+interface SlackMessage {
+  type: string;
+  user?: string;
+  username?: string;
+  text: string;
+  ts: string;
+  thread_ts?: string;
+  reply_count?: number;
+  channel?: { id: string; name: string };
+  permalink?: string;
+}
+
+interface SlackUser {
+  id: string;
+  name: string;
+  real_name: string;
+  profile: { display_name: string };
+}
+
+// ---- Helpers ----------------------------------------------------------------
+
+function tsToDate(ts: string): string {
+  const ms = parseFloat(ts) * 1000;
+  const d = new Date(ms);
+  const now = Date.now();
+  const diff = now - ms;
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function resolveUsername(
+  msg: SlackMessage,
+  users: Record<string, SlackUser>,
+): string {
+  if (msg.user && users[msg.user]) {
+    const u = users[msg.user];
+    return u.profile.display_name || u.real_name || u.name;
+  }
+  return msg.username ?? "Unknown";
+}
+
+function stripSlackFormatting(text: string): string {
+  return text
+    .replace(/<@[A-Z0-9]+>/g, "@user")
+    .replace(/<#[A-Z0-9]+\|([^>]+)>/g, "#$1")
+    .replace(/<([^>|]+)\|([^>]+)>/g, "$2")
+    .replace(/<([^>]+)>/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    .replace(/`([^`]+)`/g, "$1");
+}
+
+function buildSearchQuery(issue: SentryIssue): string {
+  const parts: string[] = [];
+  if (issue.metadata.type) parts.push(issue.metadata.type);
+  if (issue.metadata.value) {
+    const trimmed = issue.metadata.value.slice(0, 60).trim();
+    if (trimmed) parts.push(trimmed);
+  }
+  if (!parts.length) parts.push(issue.title.slice(0, 80));
+  return parts.join(" ").replace(/['"]/g, "").trim();
+}
+
+// ---- Main Component ---------------------------------------------------------
+
+interface SlackMentionsPanelProps {
+  issue: SentryIssue;
+}
+
+export function SlackMentionsPanel({ issue }: SlackMentionsPanelProps) {
+  const defaultQuery = buildSearchQuery(issue);
+  const [query, setQuery] = useState(defaultQuery);
+  const [activeQuery, setActiveQuery] = useState<string | null>(null);
+  const [editingQuery, setEditingQuery] = useState(false);
+
+  const searchQuery = useActionQuery(
+    "slack-messages",
+    { mode: "search", query: activeQuery ?? "" },
+    { enabled: !!activeQuery },
+  );
+
+  const rawData = searchQuery.data as {
+    messages?: SlackMessage[];
+    users?: Record<string, SlackUser>;
+    total?: number;
+    error?: string;
+  } | null;
+
+  const messages =
+    rawData && "messages" in rawData ? (rawData.messages ?? []) : [];
+  const users: Record<string, SlackUser> =
+    rawData && "users" in rawData ? (rawData.users ?? {}) : {};
+  const dataError =
+    (rawData && "error" in rawData ? rawData.error : null) ??
+    (searchQuery.error ? (searchQuery.error as Error).message : null);
+
+  function handleSearch() {
+    const q = query.trim();
+    if (!q) return;
+    setActiveQuery(q);
+    setEditingQuery(false);
+    if (activeQuery === q) searchQuery.refetch();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") handleSearch();
+  }
+
+  // Not yet triggered
+  if (!activeQuery) {
+    return (
+      <div className="pt-3 border-t border-border/50">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <IconBrandSlack className="h-4 w-4 shrink-0" />
+            <span>Search Slack for mentions of this error</span>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 gap-1.5 text-xs shrink-0"
+            onClick={() => {
+              setActiveQuery(query);
+            }}
+          >
+            <IconSearch className="h-3.5 w-3.5" />
+            Search Slack
+          </Button>
+        </div>
+        {/* Query preview */}
+        <p className="mt-1.5 text-[10px] text-muted-foreground/70 font-mono truncate">
+          "{query}"
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pt-3 border-t border-border/50 space-y-3">
+      {/* Header row */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <IconBrandSlack className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="text-sm font-medium">Slack mentions</span>
+          {!searchQuery.isLoading && !dataError && (
+            <span className="text-xs text-muted-foreground">
+              ({messages.length} result{messages.length !== 1 ? "s" : ""})
+            </span>
+          )}
+        </div>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 w-7 p-0 shrink-0"
+          onClick={() => searchQuery.refetch()}
+          disabled={searchQuery.isLoading}
+        >
+          <IconRefresh
+            className={`h-3.5 w-3.5 ${searchQuery.isLoading ? "animate-spin" : ""}`}
+          />
+        </Button>
+      </div>
+
+      {/* Query editor */}
+      {editingQuery ? (
+        <div className="flex gap-2">
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="h-7 text-xs font-mono"
+            autoFocus
+          />
+          <Button size="sm" className="h-7 text-xs px-3" onClick={handleSearch}>
+            Search
+          </Button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setEditingQuery(true)}
+          className="text-[10px] text-muted-foreground/70 font-mono truncate hover:text-muted-foreground transition-colors text-left w-full"
+        >
+          "{activeQuery}" — click to edit
+        </button>
+      )}
+
+      {/* Results */}
+      {searchQuery.isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex gap-2">
+              <Skeleton className="h-6 w-6 rounded-full shrink-0" />
+              <div className="flex-1 space-y-1.5">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-3 w-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : dataError ? (
+        <div className="flex items-start gap-2 text-xs text-muted-foreground py-2">
+          <IconAlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-yellow-500" />
+          <span>{dataError}</span>
+        </div>
+      ) : messages.length === 0 ? (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
+          <IconMessage className="h-4 w-4 shrink-0" />
+          <span>No Slack messages found for this query</span>
+        </div>
+      ) : (
+        <div className="space-y-2.5 max-h-64 overflow-y-auto pr-0.5">
+          {messages.map((msg) => {
+            const name = resolveUsername(msg, users);
+            const text = stripSlackFormatting(msg.text);
+            return (
+              <div key={msg.ts} className="flex gap-2 group">
+                <div className="h-6 w-6 rounded-full bg-muted/60 shrink-0 flex items-center justify-center text-[10px] font-bold text-muted-foreground uppercase mt-0.5">
+                  {name[0] ?? "?"}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline gap-2 flex-wrap">
+                    <span className="text-xs font-semibold">{name}</span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {tsToDate(msg.ts)}
+                    </span>
+                    {msg.channel && (
+                      <span className="text-[10px] text-muted-foreground">
+                        #{msg.channel.name}
+                      </span>
+                    )}
+                    {msg.reply_count ? (
+                      <span className="text-[10px] text-muted-foreground">
+                        {msg.reply_count} repl
+                        {msg.reply_count !== 1 ? "ies" : "y"}
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-0.5 line-clamp-3 break-words">
+                    {text}
+                  </p>
+                </div>
+                {msg.permalink && (
+                  <a
+                    href={msg.permalink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity mt-0.5"
+                  >
+                    <IconExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
+                  </a>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
@@ -348,9 +348,27 @@ export default function SentryErrorsDashboard() {
     statsPeriod: period,
   });
 
+  const rawData = issuesQuery.data as
+    | { issues?: SentryIssue[] }
+    | { error: string; message?: string }
+    | null;
+
+  // Action returns 200 with { error: "missing_api_key", message: "..." } when
+  // credentials aren't configured — treat it the same as a fetch error.
+  const dataError: string | null = useMemo(() => {
+    if (issuesQuery.error) return (issuesQuery.error as Error).message;
+    if (rawData && "error" in rawData) {
+      return (
+        (rawData as { message?: string }).message ??
+        String((rawData as { error: string }).error)
+      );
+    }
+    return null;
+  }, [issuesQuery.error, rawData]);
+
   const issues: SentryIssue[] = useMemo(
-    () => (issuesQuery.data as { issues?: SentryIssue[] })?.issues ?? [],
-    [issuesQuery.data],
+    () => (rawData && "issues" in rawData ? (rawData.issues ?? []) : []),
+    [rawData],
   );
 
   const top10 = useMemo(
@@ -384,7 +402,7 @@ export default function SentryErrorsDashboard() {
         : [];
 
   const isLoading = issuesQuery.isLoading;
-  const error = issuesQuery.error as Error | null;
+  const error = dataError;
 
   function toggleIssue(id: string) {
     setSelectedIssueId((prev) => (prev === id ? null : id));
@@ -474,7 +492,7 @@ export default function SentryErrorsDashboard() {
       {/* Main Content */}
       {error ? (
         <Card className="border-border/50">
-          <ErrorState message={error.message} />
+          <ErrorState message={error} />
         </Card>
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">

--- a/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
@@ -1,0 +1,732 @@
+import { useState, useMemo } from "react";
+import { useActionQuery } from "@agent-native/core/client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import {
+  IconBug,
+  IconUsers,
+  IconAlertTriangle,
+  IconTrendingUp,
+  IconChevronRight,
+  IconChevronDown,
+  IconExternalLink,
+  IconRefresh,
+  IconClock,
+  IconCopy,
+  IconCircleCheck,
+  IconLink,
+} from "@tabler/icons-react";
+import { IssueSparkline } from "./IssueSparkline";
+import { ErrorGroupsPanel } from "./ErrorGroupsPanel";
+
+// ---- Types ------------------------------------------------------------------
+
+export interface SentryIssue {
+  id: string;
+  shortId: string;
+  title: string;
+  culprit: string;
+  permalink: string;
+  level: "fatal" | "error" | "warning" | "info" | "debug";
+  status: string;
+  platform: string;
+  project: { id: string; name: string; slug: string };
+  type: string;
+  metadata: {
+    type?: string;
+    value?: string;
+    filename?: string;
+    function?: string;
+  };
+  count: string;
+  userCount: number;
+  firstSeen: string;
+  lastSeen: string;
+  stats?: Record<string, number[][]>;
+}
+
+interface SentryProject {
+  id: string;
+  slug: string;
+  name: string;
+  platform: string | null;
+}
+
+type StatsPeriod = "24h" | "7d" | "14d" | "30d";
+
+// ---- Helpers ----------------------------------------------------------------
+
+function formatCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function timeAgo(date: string): string {
+  const ms = Date.now() - new Date(date).getTime();
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+function isEscalating(issue: SentryIssue): boolean {
+  const stats = issue.stats?.["24h"];
+  if (!stats || stats.length < 4) return false;
+  const recent = stats.slice(-4).reduce((s, [, v]) => s + v, 0);
+  const earlier = stats.slice(-8, -4).reduce((s, [, v]) => s + v, 0);
+  return recent > earlier * 1.5 && recent > 0;
+}
+
+function levelColor(level: string): string {
+  switch (level) {
+    case "fatal":
+      return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800";
+    case "error":
+      return "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400 border-orange-200 dark:border-orange-800";
+    case "warning":
+      return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400 border-yellow-200 dark:border-yellow-800";
+    default:
+      return "bg-muted text-muted-foreground border-border";
+  }
+}
+
+// ---- Sub-components ---------------------------------------------------------
+
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+  accent,
+  isLoading,
+}: {
+  label: string;
+  value: string | number;
+  icon: React.ComponentType<{ className?: string }>;
+  accent?: string;
+  isLoading?: boolean;
+}) {
+  return (
+    <Card className="border-border/50">
+      <CardContent className="pt-5">
+        <div className="flex items-center justify-between">
+          <div className="min-w-0">
+            <p className="text-xs text-muted-foreground truncate">{label}</p>
+            {isLoading ? (
+              <Skeleton className="h-7 w-20 mt-1" />
+            ) : (
+              <p className={`text-2xl font-bold mt-0.5 ${accent ?? ""}`}>
+                {value}
+              </p>
+            )}
+          </div>
+          <div className="ml-3 p-2 rounded-lg bg-muted/50 shrink-0">
+            <Icon className="h-5 w-5 text-muted-foreground" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function IssueRow({
+  issue,
+  rank,
+  isSelected,
+  escalating,
+  onSelect,
+}: {
+  issue: SentryIssue;
+  rank: number;
+  isSelected: boolean;
+  escalating: boolean;
+  onSelect: () => void;
+}) {
+  const count = parseInt(issue.count, 10);
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`w-full text-left px-4 py-3 border-b border-border/50 last:border-0 hover:bg-muted/40 transition-colors ${
+        isSelected ? "bg-muted/60" : ""
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-xs text-muted-foreground w-5 pt-0.5 shrink-0 font-mono">
+          {rank}
+        </span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <Badge
+              className={`text-[10px] px-1.5 py-0 ${levelColor(issue.level)} border`}
+            >
+              {issue.level}
+            </Badge>
+            {escalating && (
+              <Badge className="text-[10px] px-1.5 py-0 bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400 border border-rose-200 dark:border-rose-800 gap-0.5">
+                <IconTrendingUp className="h-2.5 w-2.5" />
+                escalating
+              </Badge>
+            )}
+            <span className="text-xs text-muted-foreground font-mono">
+              {issue.project.name}
+            </span>
+          </div>
+          <p className="text-sm font-medium mt-1 truncate leading-snug">
+            {issue.metadata.type ?? issue.title}
+          </p>
+          {issue.metadata.value && (
+            <p className="text-xs text-muted-foreground mt-0.5 truncate">
+              {issue.metadata.value}
+            </p>
+          )}
+        </div>
+        <div className="shrink-0 text-right min-w-[60px]">
+          <p className="text-sm font-semibold tabular-nums">
+            {formatCount(count)}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {issue.userCount > 0 ? `${issue.userCount} users` : ""}
+          </p>
+        </div>
+        <div className="shrink-0 pt-0.5">
+          {isSelected ? (
+            <IconChevronDown className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <IconChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+        </div>
+      </div>
+
+      {/* Sparkline */}
+      {issue.stats?.["24h"] && (
+        <div className="ml-8 mt-2">
+          <IssueSparkline data={issue.stats["24h"]} escalating={escalating} />
+        </div>
+      )}
+    </button>
+  );
+}
+
+function IssueDetail({ issue }: { issue: SentryIssue }) {
+  const count = parseInt(issue.count, 10);
+  return (
+    <div className="bg-muted/30 border-b border-border/50 px-4 py-4 space-y-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div>
+          <p className="text-xs text-muted-foreground">Total events</p>
+          <p className="text-sm font-semibold mt-0.5">{formatCount(count)}</p>
+        </div>
+        <div>
+          <p className="text-xs text-muted-foreground">Affected users</p>
+          <p className="text-sm font-semibold mt-0.5">{issue.userCount}</p>
+        </div>
+        <div>
+          <p className="text-xs text-muted-foreground">First seen</p>
+          <p className="text-sm font-semibold mt-0.5">
+            {timeAgo(issue.firstSeen)}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-muted-foreground">Last seen</p>
+          <p className="text-sm font-semibold mt-0.5">
+            {timeAgo(issue.lastSeen)}
+          </p>
+        </div>
+      </div>
+
+      {issue.culprit && (
+        <div>
+          <p className="text-xs text-muted-foreground mb-1">Culprit</p>
+          <code className="text-xs bg-muted px-2 py-1 rounded font-mono break-all">
+            {issue.culprit}
+          </code>
+        </div>
+      )}
+
+      {issue.metadata.filename && (
+        <div>
+          <p className="text-xs text-muted-foreground mb-1">Location</p>
+          <code className="text-xs bg-muted px-2 py-1 rounded font-mono break-all">
+            {issue.metadata.filename}
+            {issue.metadata.function && ` · ${issue.metadata.function}`}
+          </code>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <a
+          href={issue.permalink}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
+        >
+          <IconExternalLink className="h-3.5 w-3.5" />
+          Open in Sentry
+        </a>
+        <span className="text-muted-foreground/40">·</span>
+        <span className="text-xs text-muted-foreground font-mono">
+          {issue.shortId}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center px-6">
+      <div className="p-3 rounded-full bg-muted/60 mb-4">
+        <IconCircleCheck className="h-8 w-8 text-muted-foreground" />
+      </div>
+      <p className="text-sm text-muted-foreground max-w-xs">{message}</p>
+    </div>
+  );
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center px-6">
+      <div className="p-3 rounded-full bg-muted/60 mb-4">
+        <IconAlertTriangle className="h-8 w-8 text-muted-foreground" />
+      </div>
+      <p className="text-sm font-medium mb-1">Could not load Sentry data</p>
+      <p className="text-xs text-muted-foreground max-w-sm">{message}</p>
+      <p className="text-xs text-muted-foreground mt-2">
+        Check <span className="font-medium">Settings → Data sources</span> and
+        ensure <span className="font-mono">SENTRY_AUTH_TOKEN</span> is
+        configured.
+      </p>
+    </div>
+  );
+}
+
+function IssueListSkeleton() {
+  return (
+    <div className="divide-y divide-border/50">
+      {Array.from({ length: 10 }).map((_, i) => (
+        <div key={i} className="px-4 py-3 flex gap-3">
+          <Skeleton className="h-4 w-4 mt-0.5 shrink-0" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+          <Skeleton className="h-6 w-12 shrink-0" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---- Main Component ---------------------------------------------------------
+
+export default function SentryErrorsDashboard() {
+  const [period, setPeriod] = useState<StatsPeriod>("7d");
+  const [selectedIssueId, setSelectedIssueId] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<"top10" | "escalating" | "groups">(
+    "top10",
+  );
+
+  const issuesQuery = useActionQuery("sentry", {
+    mode: "issues",
+    statsPeriod: period,
+    query: "is:unresolved",
+  });
+
+  const statsQuery = useActionQuery("sentry", {
+    mode: "stats",
+    statsPeriod: period,
+  });
+
+  const issues: SentryIssue[] = useMemo(
+    () => (issuesQuery.data as { issues?: SentryIssue[] })?.issues ?? [],
+    [issuesQuery.data],
+  );
+
+  const top10 = useMemo(
+    () =>
+      [...issues]
+        .sort((a, b) => parseInt(b.count, 10) - parseInt(a.count, 10))
+        .slice(0, 10),
+    [issues],
+  );
+
+  const escalating = useMemo(
+    () => issues.filter(isEscalating).slice(0, 10),
+    [issues],
+  );
+
+  const totalEvents = useMemo(
+    () => issues.reduce((s, i) => s + parseInt(i.count, 10), 0),
+    [issues],
+  );
+
+  const totalUsers = useMemo(
+    () => issues.reduce((s, i) => s + i.userCount, 0),
+    [issues],
+  );
+
+  const displayedIssues =
+    activeTab === "top10"
+      ? top10
+      : activeTab === "escalating"
+        ? escalating
+        : [];
+
+  const isLoading = issuesQuery.isLoading;
+  const error = issuesQuery.error as Error | null;
+
+  function toggleIssue(id: string) {
+    setSelectedIssueId((prev) => (prev === id ? null : id));
+  }
+
+  return (
+    <div className="space-y-5 max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div>
+          <h1 className="text-xl font-semibold flex items-center gap-2">
+            <IconBug className="h-5 w-5 text-muted-foreground" />
+            Sentry Error Intelligence
+          </h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Top errors, escalating issues, and related error groups
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Tabs
+            value={period}
+            onValueChange={(v) => setPeriod(v as StatsPeriod)}
+          >
+            <TabsList className="h-8">
+              <TabsTrigger value="24h" className="text-xs px-2.5">
+                24h
+              </TabsTrigger>
+              <TabsTrigger value="7d" className="text-xs px-2.5">
+                7d
+              </TabsTrigger>
+              <TabsTrigger value="14d" className="text-xs px-2.5">
+                14d
+              </TabsTrigger>
+              <TabsTrigger value="30d" className="text-xs px-2.5">
+                30d
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={() => issuesQuery.refetch()}
+            disabled={isLoading}
+          >
+            <IconRefresh
+              className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`}
+            />
+          </Button>
+        </div>
+      </div>
+
+      {/* Stat Cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <StatCard
+          label="Unresolved Issues"
+          value={formatCount(issues.length)}
+          icon={IconBug}
+          isLoading={isLoading}
+        />
+        <StatCard
+          label="Total Events"
+          value={formatCount(totalEvents)}
+          icon={IconAlertTriangle}
+          accent="text-orange-600 dark:text-orange-400"
+          isLoading={isLoading}
+        />
+        <StatCard
+          label="Affected Users"
+          value={formatCount(totalUsers)}
+          icon={IconUsers}
+          isLoading={isLoading}
+        />
+        <StatCard
+          label="Escalating"
+          value={escalating.length}
+          icon={IconTrendingUp}
+          accent={
+            escalating.length > 0
+              ? "text-rose-600 dark:text-rose-400"
+              : undefined
+          }
+          isLoading={isLoading}
+        />
+      </div>
+
+      {/* Main Content */}
+      {error ? (
+        <Card className="border-border/50">
+          <ErrorState message={error.message} />
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          {/* Issue List */}
+          <Card className="lg:col-span-2 border-border/50 overflow-hidden">
+            <CardHeader className="pb-0 pt-4 px-4">
+              <Tabs
+                value={activeTab}
+                onValueChange={(v) =>
+                  setActiveTab(v as "top10" | "escalating" | "groups")
+                }
+              >
+                <TabsList className="h-8">
+                  <TabsTrigger value="top10" className="text-xs px-3">
+                    Top 10 Errors
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="escalating"
+                    className="text-xs px-3 gap-1.5"
+                  >
+                    <IconTrendingUp className="h-3 w-3" />
+                    Escalating
+                    {escalating.length > 0 && !isLoading && (
+                      <span className="ml-0.5 rounded-full bg-rose-500 text-white text-[9px] w-4 h-4 flex items-center justify-center font-bold">
+                        {escalating.length}
+                      </span>
+                    )}
+                  </TabsTrigger>
+                  <TabsTrigger value="groups" className="text-xs px-3">
+                    Error Groups
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+            </CardHeader>
+
+            <div className="mt-3">
+              {activeTab === "groups" ? (
+                <ErrorGroupsPanel issues={issues} isLoading={isLoading} />
+              ) : isLoading ? (
+                <IssueListSkeleton />
+              ) : displayedIssues.length === 0 ? (
+                <EmptyState
+                  message={
+                    activeTab === "escalating"
+                      ? "No escalating errors detected in this period."
+                      : "No issues found."
+                  }
+                />
+              ) : (
+                <ScrollArea className="h-[520px]">
+                  <div>
+                    {displayedIssues.map((issue, i) => {
+                      const escalating_ = isEscalating(issue);
+                      return (
+                        <div key={issue.id}>
+                          <IssueRow
+                            issue={issue}
+                            rank={i + 1}
+                            isSelected={selectedIssueId === issue.id}
+                            escalating={escalating_}
+                            onSelect={() => toggleIssue(issue.id)}
+                          />
+                          {selectedIssueId === issue.id && (
+                            <IssueDetail issue={issue} />
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </ScrollArea>
+              )}
+            </div>
+          </Card>
+
+          {/* Right Panel */}
+          <div className="space-y-4">
+            {/* Related Issues panel */}
+            <RelatedIssuesPanel
+              issues={issues}
+              selectedIssue={
+                selectedIssueId
+                  ? (issues.find((i) => i.id === selectedIssueId) ?? null)
+                  : null
+              }
+              isLoading={isLoading}
+            />
+
+            {/* Project Breakdown */}
+            <ProjectBreakdownPanel issues={issues} isLoading={isLoading} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---- Related Issues Panel ---------------------------------------------------
+
+function RelatedIssuesPanel({
+  issues,
+  selectedIssue,
+  isLoading,
+}: {
+  issues: SentryIssue[];
+  selectedIssue: SentryIssue | null;
+  isLoading: boolean;
+}) {
+  const related = useMemo(() => {
+    if (!selectedIssue) return [];
+    const selectedType = selectedIssue.metadata.type ?? "";
+    const selectedCulprit = selectedIssue.culprit;
+    return issues
+      .filter(
+        (i) =>
+          i.id !== selectedIssue.id &&
+          (i.culprit === selectedCulprit ||
+            (selectedType && i.metadata.type === selectedType)),
+      )
+      .slice(0, 5);
+  }, [issues, selectedIssue]);
+
+  return (
+    <Card className="border-border/50">
+      <CardHeader className="pb-2 pt-4">
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          <IconLink className="h-4 w-4 text-muted-foreground" />
+          Related Issues
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        {isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+        ) : !selectedIssue ? (
+          <p className="text-xs text-muted-foreground py-4 text-center">
+            Select an issue to see related errors
+          </p>
+        ) : related.length === 0 ? (
+          <p className="text-xs text-muted-foreground py-4 text-center">
+            No related issues found
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {related.map((issue) => (
+              <a
+                key={issue.id}
+                href={issue.permalink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block p-2.5 rounded-lg border border-border/60 hover:border-border hover:bg-muted/40 transition-colors text-left"
+              >
+                <div className="flex items-start gap-2">
+                  <Badge
+                    className={`text-[10px] px-1.5 py-0 shrink-0 mt-0.5 ${levelColor(issue.level)} border`}
+                  >
+                    {issue.level}
+                  </Badge>
+                  <div className="min-w-0">
+                    <p className="text-xs font-medium truncate leading-snug">
+                      {issue.metadata.type ?? issue.title}
+                    </p>
+                    <p className="text-[10px] text-muted-foreground mt-0.5 flex items-center gap-1">
+                      <IconClock className="h-2.5 w-2.5" />
+                      {timeAgo(issue.lastSeen)} ·{" "}
+                      {formatCount(parseInt(issue.count, 10))} events
+                    </p>
+                  </div>
+                </div>
+              </a>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---- Project Breakdown Panel ------------------------------------------------
+
+function ProjectBreakdownPanel({
+  issues,
+  isLoading,
+}: {
+  issues: SentryIssue[];
+  isLoading: boolean;
+}) {
+  const projectCounts = useMemo(() => {
+    const map = new Map<
+      string,
+      { name: string; count: number; events: number }
+    >();
+    for (const issue of issues) {
+      const key = issue.project.slug;
+      const existing = map.get(key) ?? {
+        name: issue.project.name,
+        count: 0,
+        events: 0,
+      };
+      map.set(key, {
+        name: issue.project.name,
+        count: existing.count + 1,
+        events: existing.events + parseInt(issue.count, 10),
+      });
+    }
+    return [...map.values()].sort((a, b) => b.events - a.events).slice(0, 6);
+  }, [issues]);
+
+  const maxEvents = projectCounts[0]?.events ?? 1;
+
+  return (
+    <Card className="border-border/50">
+      <CardHeader className="pb-2 pt-4">
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          <IconCopy className="h-4 w-4 text-muted-foreground" />
+          By Project
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0 space-y-2.5">
+        {isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-8 w-full" />
+            ))}
+          </div>
+        ) : projectCounts.length === 0 ? (
+          <p className="text-xs text-muted-foreground py-4 text-center">
+            No projects
+          </p>
+        ) : (
+          projectCounts.map((proj) => (
+            <div key={proj.name}>
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-xs truncate font-medium">
+                  {proj.name}
+                </span>
+                <span className="text-xs text-muted-foreground tabular-nums shrink-0 ml-2">
+                  {formatCount(proj.events)}
+                </span>
+              </div>
+              <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-orange-500/70"
+                  style={{ width: `${(proj.events / maxEvents) * 100}%` }}
+                />
+              </div>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
@@ -31,6 +31,7 @@ import {
 import { IssueSparkline } from "./IssueSparkline";
 import { ErrorGroupsPanel } from "./ErrorGroupsPanel";
 import { SlackMentionsPanel } from "./SlackMentionsPanel";
+import { GitHubBlamePanel } from "./GitHubBlamePanel";
 import {
   classifyIssue,
   classificationLabel,
@@ -308,6 +309,7 @@ function IssueDetail({ issue }: { issue: SentryIssue }) {
         </span>
       </div>
 
+      <GitHubBlamePanel issue={issue} />
       <SlackMentionsPanel issue={issue} />
     </div>
   );

--- a/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
@@ -367,6 +367,9 @@ export default function SentryErrorsDashboard() {
   const [activeTab, setActiveTab] = useState<"top10" | "escalating" | "groups">(
     "top10",
   );
+  const [selectedProjects, setSelectedProjects] = useState<Set<string>>(
+    new Set(),
+  );
 
   const issuesQuery = useActionQuery("sentry", {
     mode: "issues",
@@ -397,10 +400,38 @@ export default function SentryErrorsDashboard() {
     return null;
   }, [issuesQuery.error, rawData]);
 
-  const issues: SentryIssue[] = useMemo(
+  const allIssues: SentryIssue[] = useMemo(
     () => (rawData && "issues" in rawData ? (rawData.issues ?? []) : []),
     [rawData],
   );
+
+  const allProjects = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const issue of allIssues) {
+      if (!seen.has(issue.project.slug)) {
+        seen.set(issue.project.slug, issue.project.name);
+      }
+    }
+    return Array.from(seen.entries()).map(([slug, name]) => ({ slug, name }));
+  }, [allIssues]);
+
+  const issues: SentryIssue[] = useMemo(
+    () =>
+      selectedProjects.size === 0
+        ? allIssues
+        : allIssues.filter((i) => selectedProjects.has(i.project.slug)),
+    [allIssues, selectedProjects],
+  );
+
+  function toggleProject(slug: string) {
+    setSelectedProjects((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
+    setSelectedIssueId(null);
+  }
 
   const top10 = useMemo(
     () =>
@@ -546,6 +577,44 @@ export default function SentryErrorsDashboard() {
           isLoading={isLoading}
         />
       </div>
+
+      {/* Project Filter */}
+      {!isLoading && allProjects.length > 1 && (
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-xs text-muted-foreground shrink-0">
+            Projects:
+          </span>
+          {allProjects.map(({ slug, name }) => {
+            const active = selectedProjects.has(slug);
+            return (
+              <button
+                key={slug}
+                type="button"
+                onClick={() => toggleProject(slug)}
+                className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                  active
+                    ? "bg-primary text-primary-foreground border-primary"
+                    : "bg-background border-border text-muted-foreground hover:border-primary/50 hover:text-foreground"
+                }`}
+              >
+                {name}
+              </button>
+            );
+          })}
+          {selectedProjects.size > 0 && (
+            <button
+              type="button"
+              onClick={() => {
+                setSelectedProjects(new Set());
+                setSelectedIssueId(null);
+              }}
+              className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Classification Summary */}
       {!isLoading && !error && issues.length > 0 && (

--- a/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
@@ -31,7 +31,6 @@ import {
 import { IssueSparkline } from "./IssueSparkline";
 import { ErrorGroupsPanel } from "./ErrorGroupsPanel";
 import { SlackMentionsPanel } from "./SlackMentionsPanel";
-import { GitHubBlamePanel } from "./GitHubBlamePanel";
 import {
   classifyIssue,
   classificationLabel,
@@ -309,7 +308,6 @@ function IssueDetail({ issue }: { issue: SentryIssue }) {
         </span>
       </div>
 
-      <GitHubBlamePanel issue={issue} />
       <SlackMentionsPanel issue={issue} />
     </div>
   );

--- a/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
@@ -1,6 +1,11 @@
 import { useState, useMemo } from "react";
-import { useActionQuery } from "@agent-native/core/client";
+import { useActionQuery, sendToAgentChat } from "@agent-native/core/client";
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -20,10 +25,18 @@ import {
   IconCopy,
   IconCircleCheck,
   IconLink,
+  IconSparkles,
+  IconFilter,
 } from "@tabler/icons-react";
 import { IssueSparkline } from "./IssueSparkline";
 import { ErrorGroupsPanel } from "./ErrorGroupsPanel";
 import { SlackMentionsPanel } from "./SlackMentionsPanel";
+import {
+  classifyIssue,
+  classificationLabel,
+  classificationColor,
+  type IssueClass,
+} from "./issueClassifier";
 
 // ---- Types ------------------------------------------------------------------
 
@@ -152,13 +165,14 @@ function IssueRow({
   onSelect: () => void;
 }) {
   const count = parseInt(issue.count, 10);
+  const { classification, reason } = classifyIssue(issue);
   return (
     <button
       type="button"
       onClick={onSelect}
       className={`w-full text-left px-4 py-3 border-b border-border/50 last:border-0 hover:bg-muted/40 transition-colors ${
         isSelected ? "bg-muted/60" : ""
-      }`}
+      } ${classification === "noise" || classification === "user-error" ? "opacity-60" : ""}`}
     >
       <div className="flex items-start gap-3">
         <span className="text-xs text-muted-foreground w-5 pt-0.5 shrink-0 font-mono">
@@ -176,6 +190,20 @@ function IssueRow({
                 <IconTrendingUp className="h-2.5 w-2.5" />
                 escalating
               </Badge>
+            )}
+            {classification !== "unknown" && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge
+                    className={`text-[10px] px-1.5 py-0 border cursor-default ${classificationColor(classification)}`}
+                  >
+                    {classificationLabel(classification)}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs text-xs">
+                  {reason}
+                </TooltipContent>
+              </Tooltip>
             )}
             <span className="text-xs text-muted-foreground font-mono">
               {issue.project.name}
@@ -407,6 +435,33 @@ export default function SentryErrorsDashboard() {
   const isLoading = issuesQuery.isLoading;
   const error = dataError;
 
+  const classifications = useMemo(
+    () => issues.map((i) => ({ id: i.id, ...classifyIssue(i) })),
+    [issues],
+  );
+
+  const actionableCount = classifications.filter(
+    (c) => c.classification === "actionable",
+  ).length;
+  const noiseCount = classifications.filter(
+    (c) => c.classification === "noise" || c.classification === "user-error",
+  ).length;
+
+  function handleClassifyWithAI() {
+    const sample = top10
+      .map((issue, i) => {
+        const { classification, reason } = classifyIssue(issue);
+        return `${i + 1}. [${issue.shortId}] ${issue.metadata.type ?? issue.title}${
+          issue.metadata.value ? `: ${issue.metadata.value.slice(0, 80)}` : ""
+        } — ${issue.count} events, ${issue.userCount} users, culprit: ${issue.culprit} (heuristic: ${classification}, ${reason})`;
+      })
+      .join("\n");
+    sendToAgentChat({
+      message: `Please analyze these top Sentry errors and classify each one as: "actionable" (real bug we should fix), "user-error" (expected from bad user input/auth), or "noise" (transient/third-party/not worth fixing). For each, briefly explain why and suggest what to do.\n\n${sample}`,
+      submit: true,
+    });
+  }
+
   function toggleIssue(id: string) {
     setSelectedIssueId((prev) => (prev === id ? null : id));
   }
@@ -491,6 +546,44 @@ export default function SentryErrorsDashboard() {
           isLoading={isLoading}
         />
       </div>
+
+      {/* Classification Summary */}
+      {!isLoading && !error && issues.length > 0 && (
+        <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-lg border border-border/50 bg-muted/20 flex-wrap">
+          <div className="flex items-center gap-4 text-sm flex-wrap">
+            <span className="text-muted-foreground text-xs">
+              Heuristic classification:
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-full bg-red-500 shrink-0" />
+              <span className="text-xs font-medium">
+                {actionableCount} actionable
+              </span>
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-full bg-slate-400 shrink-0" />
+              <span className="text-xs font-medium">
+                {noiseCount} noise / user error
+              </span>
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-full bg-muted-foreground/30 shrink-0" />
+              <span className="text-xs font-medium">
+                {issues.length - actionableCount - noiseCount} unclassified
+              </span>
+            </span>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 gap-1.5 text-xs shrink-0"
+            onClick={handleClassifyWithAI}
+          >
+            <IconSparkles className="h-3.5 w-3.5" />
+            Classify top 10 with AI
+          </Button>
+        </div>
+      )}
 
       {/* Main Content */}
       {error ? (

--- a/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/index.tsx
@@ -23,6 +23,7 @@ import {
 } from "@tabler/icons-react";
 import { IssueSparkline } from "./IssueSparkline";
 import { ErrorGroupsPanel } from "./ErrorGroupsPanel";
+import { SlackMentionsPanel } from "./SlackMentionsPanel";
 
 // ---- Types ------------------------------------------------------------------
 
@@ -278,6 +279,8 @@ function IssueDetail({ issue }: { issue: SentryIssue }) {
           {issue.shortId}
         </span>
       </div>
+
+      <SlackMentionsPanel issue={issue} />
     </div>
   );
 }

--- a/templates/analytics/app/pages/adhoc/sentry-errors/issueClassifier.ts
+++ b/templates/analytics/app/pages/adhoc/sentry-errors/issueClassifier.ts
@@ -1,0 +1,159 @@
+import type { SentryIssue } from "./index";
+
+export type IssueClass = "actionable" | "noise" | "user-error" | "unknown";
+
+export interface ClassificationResult {
+  classification: IssueClass;
+  reason: string;
+}
+
+// Patterns strongly indicating non-actionable / noise
+const NOISE_TYPE_PATTERNS = [
+  /^ChunkLoadError/i,
+  /^ResizeObserver loop/i,
+  /^Script error/i,
+  /^Non-Error (promise rejection|exception)/i,
+  /^UnhandledRejection.*undefined/i,
+  /cancelled/i,
+  /aborted/i,
+];
+
+const NOISE_VALUE_PATTERNS = [
+  /load failed/i,
+  /failed to fetch/i,
+  /networkerror/i,
+  /network request failed/i,
+  /the internet connection appears to be offline/i,
+  /cancelled/i,
+  /aborted/i,
+  /timeout/i,
+];
+
+// Patterns indicating user-caused errors (auth, validation, not-found)
+const USER_ERROR_TYPE_PATTERNS = [
+  /ValidationError/i,
+  /ZodError/i,
+  /AuthError/i,
+  /UnauthorizedError/i,
+  /ForbiddenError/i,
+  /NotFoundError/i,
+];
+
+const USER_ERROR_VALUE_PATTERNS = [
+  /401/,
+  /403/,
+  /404/,
+  /unauthorized/i,
+  /forbidden/i,
+  /not found/i,
+  /invalid (token|credentials|password|email)/i,
+  /user.*not.*found/i,
+  /permission denied/i,
+  /not_allowed_token_type/i,
+  /invalid_auth/i,
+];
+
+// Third-party culprit patterns — lower signal, only marks as noise when combined
+const THIRD_PARTY_CULPRIT_PATTERNS = [
+  /node_modules/,
+  /cdn\./,
+  /googleapis\.com/,
+  /cloudflare/,
+  /amazonaws\.com/,
+];
+
+export function classifyIssue(issue: SentryIssue): ClassificationResult {
+  const type = (issue.metadata.type ?? issue.type ?? "").toLowerCase();
+  const value = (issue.metadata.value ?? issue.title ?? "").toLowerCase();
+  const culprit = (issue.culprit ?? "").toLowerCase();
+  const title = (issue.title ?? "").toLowerCase();
+
+  // 1. Noise: known transient / browser / network patterns
+  for (const pat of NOISE_TYPE_PATTERNS) {
+    if (pat.test(issue.metadata.type ?? issue.type ?? issue.title)) {
+      return {
+        classification: "noise",
+        reason: `Error type "${issue.metadata.type ?? issue.type}" is typically non-actionable browser/network noise`,
+      };
+    }
+  }
+  for (const pat of NOISE_VALUE_PATTERNS) {
+    if (pat.test(value) || pat.test(title)) {
+      return {
+        classification: "noise",
+        reason:
+          "Error message matches known transient network/browser noise patterns",
+      };
+    }
+  }
+
+  // 2. User error: auth, validation, expected HTTP errors
+  for (const pat of USER_ERROR_TYPE_PATTERNS) {
+    if (pat.test(issue.metadata.type ?? issue.type ?? "")) {
+      return {
+        classification: "user-error",
+        reason: `Error type "${issue.metadata.type ?? issue.type}" is typically caused by invalid user input or auth`,
+      };
+    }
+  }
+  for (const pat of USER_ERROR_VALUE_PATTERNS) {
+    if (pat.test(value) || pat.test(title)) {
+      return {
+        classification: "user-error",
+        reason:
+          "Error message matches expected user-caused patterns (auth, validation, not-found)",
+      };
+    }
+  }
+
+  // 3. Third-party culprit with no affected users → likely noise
+  const isThirdParty = THIRD_PARTY_CULPRIT_PATTERNS.some((p) =>
+    p.test(culprit),
+  );
+  if (isThirdParty && issue.userCount === 0) {
+    return {
+      classification: "noise",
+      reason:
+        "Error originates in a third-party dependency and affects no users",
+    };
+  }
+
+  // 4. High user count + first-party → likely actionable
+  if (issue.userCount > 5 && !isThirdParty) {
+    return {
+      classification: "actionable",
+      reason: `Affects ${issue.userCount} users and originates in first-party code`,
+    };
+  }
+
+  return {
+    classification: "unknown",
+    reason: "Could not determine actionability from available metadata",
+  };
+}
+
+export function classificationLabel(c: IssueClass): string {
+  switch (c) {
+    case "actionable":
+      return "Actionable";
+    case "noise":
+      return "Noise";
+    case "user-error":
+      return "User error";
+    case "unknown":
+      return "Unclassified";
+  }
+}
+
+export function classificationColor(c: IssueClass): string {
+  switch (c) {
+    case "actionable":
+      return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800";
+    case "noise":
+      return "bg-slate-100 text-slate-500 dark:bg-slate-800/50 dark:text-slate-400 border-slate-200 dark:border-slate-700";
+    case "user-error":
+      return "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 border-blue-200 dark:border-blue-800";
+    case "unknown":
+      return "bg-muted text-muted-foreground border-border";
+  }
+}

--- a/templates/analytics/server/lib/credential-keys.ts
+++ b/templates/analytics/server/lib/credential-keys.ts
@@ -87,6 +87,11 @@ export const credentialKeys: CredentialKeyConfig[] = [
     label: "Slack Bot Token (secondary)",
     required: false,
   },
+  {
+    key: "SLACK_USER_TOKEN",
+    label: "Slack User Token",
+    required: false,
+  },
   // Notion
   { key: "NOTION_API_KEY", label: "Notion", required: false },
   // Twitter/X
@@ -240,7 +245,7 @@ export const credentialProviderConfigs: CredentialProviderConfig[] = [
     provider: "slack",
     label: "Slack",
     requiredKeys: ["SLACK_BOT_TOKEN"],
-    optionalKeys: ["SLACK_BOT_TOKEN_2"],
+    optionalKeys: ["SLACK_BOT_TOKEN_2", "SLACK_USER_TOKEN"],
   },
   {
     provider: "notion",
@@ -294,7 +299,7 @@ const credentialAliases: Record<string, string[]> = {
   posthog: ["POSTHOG_API_KEY", "POSTHOG_PROJECT_ID"],
   pylon: ["PYLON_API_KEY"],
   sentry: ["SENTRY_AUTH_TOKEN", "SENTRY_ORG_SLUG", "SENTRY_SERVER_TOKEN"],
-  slack: ["SLACK_BOT_TOKEN", "SLACK_BOT_TOKEN_2"],
+  slack: ["SLACK_BOT_TOKEN", "SLACK_BOT_TOKEN_2", "SLACK_USER_TOKEN"],
   stripe: ["STRIPE_SECRET_KEY"],
   twitter: ["TWITTER_BEARER_TOKEN"],
   x: ["TWITTER_BEARER_TOKEN"],

--- a/templates/analytics/server/lib/github.ts
+++ b/templates/analytics/server/lib/github.ts
@@ -420,3 +420,119 @@ export async function searchOrgPRs(opts: {
 
   return searchPRs({ query: q, type: "pr", limit });
 }
+
+// ─── File blame (last commit per line range) ──────────────────────────────────
+
+export interface BlameRange {
+  startingLine: number;
+  endingLine: number;
+  age: number; // days since last commit
+  commit: {
+    oid: string;
+    abbreviatedOid: string;
+    message: string;
+    committedDate: string;
+    url: string;
+    author: {
+      name: string;
+      email: string;
+      avatarUrl?: string;
+    };
+    associatedPullRequests?: {
+      nodes: { number: number; title: string; url: string }[];
+    };
+  };
+}
+
+export interface FileBlameResult {
+  owner: string;
+  repo: string;
+  path: string;
+  ref: string;
+  ranges: BlameRange[];
+  /** The single most recent commit touching this file */
+  latestCommit: BlameRange["commit"] | null;
+  /** The most recent blame range (covers the most recently touched lines) */
+  hotRange: BlameRange | null;
+}
+
+export async function getFileBlame(
+  owner: string,
+  repo: string,
+  path: string,
+  ref = "HEAD",
+): Promise<FileBlameResult> {
+  const query = `
+    query FileBlame($owner: String!, $repo: String!, $path: String!, $ref: String!) {
+      repository(owner: $owner, name: $repo) {
+        object(expression: $ref) {
+          ... on Commit {
+            blame(path: $path) {
+              ranges {
+                startingLine
+                endingLine
+                commit {
+                  oid
+                  abbreviatedOid
+                  message
+                  committedDate
+                  url
+                  author {
+                    name
+                    email
+                    avatarUrl
+                  }
+                  associatedPullRequests(first: 1) {
+                    nodes {
+                      number
+                      title
+                      url
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const data = await graphql<{
+    repository: {
+      object: {
+        blame: {
+          ranges: {
+            startingLine: number;
+            endingLine: number;
+            commit: BlameRange["commit"];
+          }[];
+        };
+      } | null;
+    } | null;
+  }>(query, { owner, repo, path, ref });
+
+  const rawRanges = data?.repository?.object?.blame?.ranges ?? [];
+
+  const ranges: BlameRange[] = rawRanges.map((r) => ({
+    ...r,
+    age: Math.floor(
+      (Date.now() - new Date(r.commit.committedDate).getTime()) /
+        (1000 * 60 * 60 * 24),
+    ),
+  }));
+
+  // Most recently committed range
+  const hotRange =
+    ranges.length > 0
+      ? ranges.reduce((a, b) =>
+          new Date(a.commit.committedDate) > new Date(b.commit.committedDate)
+            ? a
+            : b,
+        )
+      : null;
+
+  const latestCommit = hotRange?.commit ?? null;
+
+  return { owner, repo, path, ref, ranges, latestCommit, hotRange };
+}

--- a/templates/analytics/server/lib/sentry.ts
+++ b/templates/analytics/server/lib/sentry.ts
@@ -199,3 +199,37 @@ export async function getOrganizationStats(
     `/organizations/${org}/stats_v2/?${params.toString()}`,
   );
 }
+
+export interface SentryCodeMapping {
+  id: string;
+  projectSlug: string;
+  repoName: string; // "owner/repo"
+  sourceRoot: string;
+  stackRoot: string;
+  defaultBranch: string;
+}
+
+export async function getCodeMappings(
+  orgSlug?: string,
+): Promise<SentryCodeMapping[]> {
+  const org = await getOrgSlug(orgSlug);
+  const raw = await apiGet<
+    {
+      id: string;
+      project: { slug: string };
+      repoName?: string;
+      repository?: { name: string };
+      sourceRoot: string;
+      stackRoot: string;
+      defaultBranch: string;
+    }[]
+  >(`/organizations/${org}/code-mappings/`);
+  return raw.map((m) => ({
+    id: m.id,
+    projectSlug: m.project?.slug ?? "",
+    repoName: m.repoName ?? m.repository?.name ?? "",
+    sourceRoot: m.sourceRoot ?? "",
+    stackRoot: m.stackRoot ?? "",
+    defaultBranch: m.defaultBranch ?? "main",
+  }));
+}

--- a/templates/analytics/server/lib/slack.ts
+++ b/templates/analytics/server/lib/slack.ts
@@ -316,6 +316,9 @@ export async function searchMessages(
     .split(/\s+/)
     .filter((t) => t.length > 2);
 
+  console.log("[slack-search] query:", query);
+  console.log("[slack-search] terms:", terms);
+
   function fuzzyMatch(text: string, term: string): boolean {
     if (text.includes(term)) return true;
     // URLs must match exactly (trailing slash variations are already normalised)
@@ -339,7 +342,14 @@ export async function searchMessages(
     limit: "200",
   });
 
-  const channels = (channelsData.channels ?? []).slice(0, 20);
+  const allChannels = channelsData.channels ?? [];
+  console.log(
+    "[slack-search] total channels visible to bot:",
+    allChannels.length,
+    allChannels.map((c) => c.name),
+  );
+
+  const channels = allChannels.slice(0, 20);
   const oldest = String(
     Math.floor((Date.now() - 30 * 24 * 60 * 60 * 1000) / 1000),
   );
@@ -354,20 +364,33 @@ export async function searchMessages(
           { channel: ch.id, limit: "200", oldest },
           false,
         );
-        for (const msg of histData.messages ?? []) {
+        const msgs = histData.messages ?? [];
+        console.log(
+          `[slack-search] #${ch.name} (${ch.id}): ${msgs.length} messages fetched`,
+        );
+        for (const msg of msgs) {
           const text = msg.text?.toLowerCase() ?? "";
-          if (terms.length === 0 || terms.some((t) => fuzzyMatch(text, t))) {
+          const matched =
+            terms.length === 0 || terms.some((t) => fuzzyMatch(text, t));
+          if (matched) {
+            console.log(
+              `[slack-search]   MATCH in #${ch.name}: "${msg.text?.slice(0, 80)}"`,
+            );
             matches.push({ ...msg, channel: ch.id } as SlackMessage & {
               channel: string;
             });
           }
         }
-      } catch {
-        // bot may not have access to this channel — skip silently
+      } catch (err) {
+        console.log(
+          `[slack-search] #${ch.name} error:`,
+          (err as Error).message,
+        );
       }
     }),
   );
 
+  console.log("[slack-search] total matches:", matches.length);
   matches.sort((a, b) => parseFloat(b.ts) - parseFloat(a.ts));
   const limited = matches.slice(0, count);
   return { messages: limited, total: matches.length };

--- a/templates/analytics/server/lib/slack.ts
+++ b/templates/analytics/server/lib/slack.ts
@@ -319,7 +319,7 @@ export async function searchMessages(
   const channelsData = await slackApi<{
     channels: { id: string; name: string }[];
   }>(workspace, "conversations.list", {
-    types: "public_channel,private_channel",
+    types: "public_channel",
     exclude_archived: "true",
     limit: "200",
   });

--- a/templates/analytics/server/lib/slack.ts
+++ b/templates/analytics/server/lib/slack.ts
@@ -274,11 +274,11 @@ export async function getChannelHistory(
   }
 }
 
-async function fetchThreadReplies(
+async function fetchFullThread(
   workspace: Workspace,
   channelId: string,
   threadTs: string,
-  limit = 10,
+  limit = 20,
 ): Promise<SlackMessage[]> {
   try {
     const data = await slackApi<{ messages: SlackMessage[] }>(
@@ -287,8 +287,7 @@ async function fetchThreadReplies(
       { channel: channelId, ts: threadTs, limit: String(limit) },
       false,
     );
-    // First message is the parent — skip it, return only replies
-    return (data.messages ?? []).slice(1);
+    return data.messages ?? [];
   } catch {
     return [];
   }
@@ -300,16 +299,22 @@ async function enrichWithThreads(
 ): Promise<SlackMessage[]> {
   return Promise.all(
     messages.map(async (msg) => {
-      if (!msg.reply_count || msg.reply_count === 0) return msg;
       const channelId =
         typeof msg.channel === "string" ? msg.channel : msg.channel?.id;
       if (!channelId) return msg;
-      const replies = await fetchThreadReplies(
-        workspace,
-        channelId,
-        msg.thread_ts ?? msg.ts,
-        8,
-      );
+
+      // Determine the thread root timestamp:
+      // - If msg is a reply (thread_ts differs from ts), the root is thread_ts
+      // - If msg is a parent with replies (reply_count > 0), the root is ts
+      const isReply = msg.thread_ts && msg.thread_ts !== msg.ts;
+      const hasReplies = (msg.reply_count ?? 0) > 0;
+
+      if (!isReply && !hasReplies) return msg;
+
+      const threadRootTs = isReply ? msg.thread_ts! : msg.ts;
+      const thread = await fetchFullThread(workspace, channelId, threadRootTs);
+      // thread[0] is the parent message; the rest are replies
+      const replies = thread.slice(1);
       return { ...msg, replies };
     }),
   );

--- a/templates/analytics/server/lib/slack.ts
+++ b/templates/analytics/server/lib/slack.ts
@@ -104,6 +104,7 @@ export interface SlackMessage {
   icons?: { image_48?: string; image_72?: string };
   channel?: { id: string; name: string } | string;
   permalink?: string;
+  replies?: SlackMessage[];
 }
 
 export interface SlackBotInfo {
@@ -273,6 +274,47 @@ export async function getChannelHistory(
   }
 }
 
+async function fetchThreadReplies(
+  workspace: Workspace,
+  channelId: string,
+  threadTs: string,
+  limit = 10,
+): Promise<SlackMessage[]> {
+  try {
+    const data = await slackApi<{ messages: SlackMessage[] }>(
+      workspace,
+      "conversations.replies",
+      { channel: channelId, ts: threadTs, limit: String(limit) },
+      false,
+    );
+    // First message is the parent — skip it, return only replies
+    return (data.messages ?? []).slice(1);
+  } catch {
+    return [];
+  }
+}
+
+async function enrichWithThreads(
+  workspace: Workspace,
+  messages: SlackMessage[],
+): Promise<SlackMessage[]> {
+  return Promise.all(
+    messages.map(async (msg) => {
+      if (!msg.reply_count || msg.reply_count === 0) return msg;
+      const channelId =
+        typeof msg.channel === "string" ? msg.channel : msg.channel?.id;
+      if (!channelId) return msg;
+      const replies = await fetchThreadReplies(
+        workspace,
+        channelId,
+        msg.thread_ts ?? msg.ts,
+        8,
+      );
+      return { ...msg, replies };
+    }),
+  );
+}
+
 export async function searchMessages(
   workspace: Workspace,
   query: string,
@@ -301,10 +343,9 @@ export async function searchMessages(
       messages?: { matches: SlackMessage[]; total: number };
     };
     if (json.ok) {
-      return {
-        messages: json.messages?.matches || [],
-        total: json.messages?.total || 0,
-      };
+      const matches = json.messages?.matches || [];
+      const enriched = await enrichWithThreads(workspace, matches);
+      return { messages: enriched, total: json.messages?.total || 0 };
     }
     // fall through to bot-token scan on token errors
   }
@@ -414,7 +455,8 @@ export async function searchMessages(
   console.log("[slack-search] total matches:", matches.length);
   matches.sort((a, b) => parseFloat(b.ts) - parseFloat(a.ts));
   const limited = matches.slice(0, count);
-  return { messages: limited, total: matches.length };
+  const enriched = await enrichWithThreads(workspace, limited);
+  return { messages: enriched, total: matches.length };
 }
 
 export async function getUserInfo(

--- a/templates/analytics/server/lib/slack.ts
+++ b/templates/analytics/server/lib/slack.ts
@@ -102,7 +102,8 @@ export interface SlackMessage {
   reactions?: { name: string; count: number }[];
   files?: { name: string; mimetype: string; url_private: string }[];
   icons?: { image_48?: string; image_72?: string };
-  channel?: string;
+  channel?: { id: string; name: string } | string;
+  permalink?: string;
 }
 
 export interface SlackBotInfo {
@@ -353,6 +354,19 @@ export async function searchMessages(
   const oldest = String(
     Math.floor((Date.now() - 30 * 24 * 60 * 60 * 1000) / 1000),
   );
+
+  // Fetch team domain so we can build message permalinks
+  let teamDomain = "";
+  try {
+    const teamData = await slackApi<{ team: { domain: string } }>(
+      workspace,
+      "team.info",
+    );
+    teamDomain = teamData.team?.domain ?? "";
+  } catch {
+    // non-fatal
+  }
+
   const matches: SlackMessage[] = [];
 
   await Promise.all(
@@ -376,9 +390,16 @@ export async function searchMessages(
             console.log(
               `[slack-search]   MATCH in #${ch.name}: "${msg.text?.slice(0, 80)}"`,
             );
-            matches.push({ ...msg, channel: ch.id } as SlackMessage & {
-              channel: string;
-            });
+            // Build a Slack deep-link permalink for bot-scanned messages
+            const tsSlug = msg.ts.replace(".", "");
+            const permalink = teamDomain
+              ? `https://${teamDomain}.slack.com/archives/${ch.id}/p${tsSlug}`
+              : undefined;
+            matches.push({
+              ...msg,
+              channel: { id: ch.id, name: ch.name },
+              permalink,
+            } as SlackMessage);
           }
         }
       } catch (err) {

--- a/templates/analytics/server/lib/slack.ts
+++ b/templates/analytics/server/lib/slack.ts
@@ -316,6 +316,21 @@ export async function searchMessages(
     .split(/\s+/)
     .filter((t) => t.length > 2);
 
+  function fuzzyMatch(text: string, term: string): boolean {
+    if (text.includes(term)) return true;
+    // URLs must match exactly (trailing slash variations are already normalised)
+    if (term.startsWith("http")) return false;
+    // For Sentry short IDs like BRIDGE-TM-1234, also try just the numeric suffix
+    const numericSuffix = term.match(/\d{4,}$/)?.[0];
+    if (numericSuffix && text.includes(numericSuffix)) return true;
+    // Prefix fuzzy: if the term is 6+ chars, match on the first 70% of it
+    if (term.length >= 6) {
+      const prefix = term.slice(0, Math.floor(term.length * 0.7));
+      if (text.includes(prefix)) return true;
+    }
+    return false;
+  }
+
   const channelsData = await slackApi<{
     channels: { id: string; name: string }[];
   }>(workspace, "conversations.list", {
@@ -341,7 +356,7 @@ export async function searchMessages(
         );
         for (const msg of histData.messages ?? []) {
           const text = msg.text?.toLowerCase() ?? "";
-          if (terms.length === 0 || terms.some((t) => text.includes(t))) {
+          if (terms.length === 0 || terms.some((t) => fuzzyMatch(text, t))) {
             matches.push({ ...msg, channel: ch.id } as SlackMessage & {
               channel: string;
             });

--- a/templates/analytics/server/lib/slack.ts
+++ b/templates/analytics/server/lib/slack.ts
@@ -276,24 +276,47 @@ export async function searchMessages(
   query: string,
   count = 50,
 ): Promise<{ messages: SlackMessage[]; total: number }> {
-  // search.messages requires a user token, but we'll try with bot token
-  // If it fails, we'll fall back to channel history filtering
-  const data = await slackApi<{
-    messages: { matches: SlackMessage[]; total: number };
-  }>(
-    workspace,
-    "search.messages",
-    {
-      query,
-      count: String(Math.min(count, 100)),
-      sort: "timestamp",
-      sort_dir: "desc",
-    },
-    false,
+  // search.messages requires a user token (xoxp-), not a bot token.
+  // Try SLACK_USER_TOKEN first, fall back to the configured bot token.
+  const ctx = requireRequestCredentialContext(
+    workspace === "secondary" ? "SLACK_BOT_TOKEN_2" : "SLACK_BOT_TOKEN",
   );
+  const userToken = await resolveCredential("SLACK_USER_TOKEN", ctx);
+  const botToken = userToken
+    ? null
+    : await resolveCredential(
+        workspace === "secondary" ? "SLACK_BOT_TOKEN_2" : "SLACK_BOT_TOKEN",
+        ctx,
+      );
+  const token = userToken ?? botToken;
+  if (!token) throw new Error("No Slack token configured");
+
+  const params = new URLSearchParams({
+    query,
+    count: String(Math.min(count, 100)),
+    sort: "timestamp",
+    sort_dir: "desc",
+  });
+  const res = await fetch(`https://slack.com/api/search.messages?${params}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`Slack API error ${res.status}`);
+  const json = (await res.json()) as {
+    ok: boolean;
+    error?: string;
+    messages?: { matches: SlackMessage[]; total: number };
+  };
+  if (!json.ok) {
+    if (json.error === "not_allowed_token_type") {
+      throw new Error(
+        "Slack search requires a user token (xoxp-). Add SLACK_USER_TOKEN in Data Sources → Slack.",
+      );
+    }
+    throw new Error(`Slack API error: ${json.error}`);
+  }
   return {
-    messages: data.messages?.matches || [],
-    total: data.messages?.total || 0,
+    messages: json.messages?.matches || [],
+    total: json.messages?.total || 0,
   };
 }
 

--- a/templates/analytics/server/lib/slack.ts
+++ b/templates/analytics/server/lib/slack.ts
@@ -476,12 +476,8 @@ export async function resolveUsers(
       try {
         results[id] = await getUserInfo(workspace, id);
       } catch {
-        results[id] = {
-          id,
-          name: id,
-          real_name: id,
-          profile: { display_name: id, image_48: "", image_72: "" },
-        };
+        // Don't create a fake entry — leave it absent so resolveUsername
+        // falls back to msg.username (populated by search.messages API).
       }
     }),
   );

--- a/templates/analytics/server/lib/slack.ts
+++ b/templates/analytics/server/lib/slack.ts
@@ -102,6 +102,7 @@ export interface SlackMessage {
   reactions?: { name: string; count: number }[];
   files?: { name: string; mimetype: string; url_private: string }[];
   icons?: { image_48?: string; image_72?: string };
+  channel?: string;
 }
 
 export interface SlackBotInfo {
@@ -276,48 +277,85 @@ export async function searchMessages(
   query: string,
   count = 50,
 ): Promise<{ messages: SlackMessage[]; total: number }> {
-  // search.messages requires a user token (xoxp-), not a bot token.
-  // Try SLACK_USER_TOKEN first, fall back to the configured bot token.
-  const ctx = requireRequestCredentialContext(
-    workspace === "secondary" ? "SLACK_BOT_TOKEN_2" : "SLACK_BOT_TOKEN",
-  );
-  const userToken = await resolveCredential("SLACK_USER_TOKEN", ctx);
-  const botToken = userToken
-    ? null
-    : await resolveCredential(
-        workspace === "secondary" ? "SLACK_BOT_TOKEN_2" : "SLACK_BOT_TOKEN",
-        ctx,
-      );
-  const token = userToken ?? botToken;
-  if (!token) throw new Error("No Slack token configured");
+  const botEnvKey =
+    workspace === "secondary" ? "SLACK_BOT_TOKEN_2" : "SLACK_BOT_TOKEN";
+  const ctx = requireRequestCredentialContext(botEnvKey);
 
-  const params = new URLSearchParams({
-    query,
-    count: String(Math.min(count, 100)),
-    sort: "timestamp",
-    sort_dir: "desc",
-  });
-  const res = await fetch(`https://slack.com/api/search.messages?${params}`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) throw new Error(`Slack API error ${res.status}`);
-  const json = (await res.json()) as {
-    ok: boolean;
-    error?: string;
-    messages?: { matches: SlackMessage[]; total: number };
-  };
-  if (!json.ok) {
-    if (json.error === "not_allowed_token_type") {
-      throw new Error(
-        "Slack search requires a user token (xoxp-). Add SLACK_USER_TOKEN in Data Sources → Slack.",
-      );
+  // Prefer a user token (xoxp-) for search.messages if one was configured.
+  const userToken = await resolveCredential("SLACK_USER_TOKEN", ctx);
+  if (userToken) {
+    const params = new URLSearchParams({
+      query,
+      count: String(Math.min(count, 100)),
+      sort: "timestamp",
+      sort_dir: "desc",
+    });
+    const res = await fetch(`https://slack.com/api/search.messages?${params}`, {
+      headers: { Authorization: `Bearer ${userToken}` },
+    });
+    if (!res.ok) throw new Error(`Slack API error ${res.status}`);
+    const json = (await res.json()) as {
+      ok: boolean;
+      error?: string;
+      messages?: { matches: SlackMessage[]; total: number };
+    };
+    if (json.ok) {
+      return {
+        messages: json.messages?.matches || [],
+        total: json.messages?.total || 0,
+      };
     }
-    throw new Error(`Slack API error: ${json.error}`);
+    // fall through to bot-token scan on token errors
   }
-  return {
-    messages: json.messages?.matches || [],
-    total: json.messages?.total || 0,
-  };
+
+  // Fallback: scan recent messages from accessible channels using the bot token.
+  // search.messages requires a user token; this covers the common case where only
+  // a bot token is configured.
+  const terms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 2);
+
+  const channelsData = await slackApi<{
+    channels: { id: string; name: string }[];
+  }>(workspace, "conversations.list", {
+    types: "public_channel,private_channel",
+    exclude_archived: "true",
+    limit: "200",
+  });
+
+  const channels = (channelsData.channels ?? []).slice(0, 20);
+  const oldest = String(
+    Math.floor((Date.now() - 30 * 24 * 60 * 60 * 1000) / 1000),
+  );
+  const matches: SlackMessage[] = [];
+
+  await Promise.all(
+    channels.map(async (ch) => {
+      try {
+        const histData = await slackApi<{ messages: SlackMessage[] }>(
+          workspace,
+          "conversations.history",
+          { channel: ch.id, limit: "200", oldest },
+          false,
+        );
+        for (const msg of histData.messages ?? []) {
+          const text = msg.text?.toLowerCase() ?? "";
+          if (terms.length === 0 || terms.some((t) => text.includes(t))) {
+            matches.push({ ...msg, channel: ch.id } as SlackMessage & {
+              channel: string;
+            });
+          }
+        }
+      } catch {
+        // bot may not have access to this channel — skip silently
+      }
+    }),
+  );
+
+  matches.sort((a, b) => parseFloat(b.ts) - parseFloat(a.ts));
+  const limited = matches.slice(0, count);
+  return { messages: limited, total: matches.length };
 }
 
 export async function getUserInfo(


### PR DESCRIPTION
### Summary
Adds a new "Sentry Error Intelligence" dashboard that surfaces top errors, escalating issues, and related error groups. Enhances the Slack integration with thread enrichment, fuzzy search, and user token support, and extends the Sentry data source to require an org slug.

### Problem
There was no dedicated app for analyzing Sentry errors beyond what the official Sentry UI provides. Additionally, the Sentry data source lacked an org slug configuration field, and the Slack search integration only supported a bot token (which cannot use the `search.messages` API) and did not surface thread context or clickable message links.

### Key Changes
- **New `sentry-errors` dashboard** registered in the adhoc dashboard registry (`ErrorGroupsPanel.tsx` and related components) with top-10 error analysis, escalation detection, related error grouping, and project filtering
- **Sentry `SENTRY_ORG_SLUG` data source field** added to the walkthrough steps so users can configure their org slug via the UI
- **`getCodeMappings`** added to the Sentry server lib and exposed as a new `code-mappings` mode in the Sentry action
- **`github-blame` action** added to fetch Git blame for a file path via GitHub's GraphQL API
- **Slack `SLACK_USER_TOKEN` data source field** added as an optional walkthrough step (with an "Add" button replacing the static "Optional" label in the connected view)
- **Slack `searchMessages` overhauled**: prefers a user token (`xoxp-`) for `search.messages`; falls back to bot-token channel history scanning with fuzzy matching (URL normalization, numeric suffix matching, prefix matching)
- **Thread enrichment** (`enrichWithThreads`) fetches full reply threads for matched Slack messages so conversation context is surfaced alongside search results
- **Slack search limit** passed through from the action call; results capped and sorted by recency
- **User resolution fallback** removed fake placeholder entries so `resolveUsername` can fall back to the `username` field populated by the search API


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/quad-network-jzlu0vbo"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-quad-network-jzlu0vbo_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1035`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>quad-network-jzlu0vbo</branchName>-->