### PR TITLE
Fix release publishing allowlist

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,9 @@
   "ignore": [
     "@agent-native/desktop-app",
     "@agent-native/code-agents-ui",
-    "@agent-native/shared-app-config"
+    "@agent-native/shared-app-config",
+    "@agent-native/embedding",
+    "@agent-native/migrate"
   ],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -23,18 +23,18 @@ on:
   push:
     branches: [main]
     paths:
-      # changesets-managed npm packages — any source change reaches here
-      # via the Version Packages PR merge bumping their package.json.
+      # npm-published packages — any source change reaches here via the
+      # Version Packages PR merge bumping their package.json.
       - "packages/core/**"
       - "packages/dispatch/**"
-      - "packages/embedding/**"
-      - "packages/frame/**"
-      - "packages/migrate/**"
       - "packages/pinpoint/**"
       - "packages/scheduling/**"
       # Ignored internal packages are not versioned by changesets, but changes
       # here should still exercise release preflight/publish no-op behavior.
       - "packages/code-agents-ui/**"
+      - "packages/embedding/**"
+      - "packages/frame/**"
+      - "packages/migrate/**"
       - "packages/shared-app-config/**"
       - ".changeset/**"
       # Release workflow plumbing changes should exercise the npm release job.

--- a/scripts/changeset-publish-sequential.ts
+++ b/scripts/changeset-publish-sequential.ts
@@ -35,6 +35,12 @@ const rootDir = path.resolve(
   "..",
 );
 const registry = "https://registry.npmjs.org";
+const npmPublishAllowlist = new Set([
+  "@agent-native/core",
+  "@agent-native/dispatch",
+  "@agent-native/pinpoint",
+  "@agent-native/scheduling",
+]);
 
 async function readJson<T>(filePath: string): Promise<T> {
   return JSON.parse(await readFile(filePath, "utf8")) as T;
@@ -95,7 +101,8 @@ async function getPublishPackages(): Promise<PublishPackage[]> {
       packageJson.private ||
       !packageJson.name ||
       !packageJson.version ||
-      ignored.has(packageJson.name)
+      ignored.has(packageJson.name) ||
+      !npmPublishAllowlist.has(packageJson.name)
     ) {
       continue;
     }

--- a/scripts/guard-public-packages.ts
+++ b/scripts/guard-public-packages.ts
@@ -7,18 +7,25 @@ const repoRoot = path.resolve(
   "..",
 );
 
+const npmPublishAllowlist = new Set([
+  "@agent-native/core",
+  "@agent-native/dispatch",
+  "@agent-native/pinpoint",
+  "@agent-native/scheduling",
+]);
+
 // Packages that are NOT published to npm and therefore exempt from the
-// publish-readiness checks below. Apps (desktop-app/docs/frame/mobile-app) plus
-// internal-only libraries that are consumed exclusively via `workspace:` by the
-// apps/templates above and have never been published (code-agents-ui,
-// shared-app-config). These are also listed in `.changeset/config.json` `ignore`
-// so version-packages never attempts to publish them.
-const packageAppAllowlist = new Set([
+// publish-readiness checks below. Apps are private. Workspace-only libraries are
+// consumed through `workspace:` and must stay ignored by changesets until npm
+// trusted publishing is configured for them.
+const workspaceOnlyPackageAllowlist = new Set([
   "@agent-native/desktop-app",
   "@agent-native/docs",
   "@agent-native/frame",
   "@agent-native/mobile-app",
   "@agent-native/code-agents-ui",
+  "@agent-native/embedding",
+  "@agent-native/migrate",
   "@agent-native/shared-app-config",
 ]);
 
@@ -91,7 +98,21 @@ for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
 
   const pkg = readJson<PackageJson>(packageJsonPath);
   if (!pkg.name?.startsWith("@agent-native/")) continue;
-  if (packageAppAllowlist.has(pkg.name)) continue;
+  if (workspaceOnlyPackageAllowlist.has(pkg.name)) {
+    if (pkg.private !== true && !ignoredPackages.has(pkg.name)) {
+      failures.push(
+        `${pkg.name} is workspace-only and must be listed in .changeset/config.json ignore until npm publishing is enabled`,
+      );
+    }
+    continue;
+  }
+
+  if (!npmPublishAllowlist.has(pkg.name)) {
+    failures.push(
+      `${pkg.name} is not in the npm publish allowlist; add it only after npm trusted publishing is configured, or mark it workspace-only`,
+    );
+    continue;
+  }
 
   if (pkg.private === true) {
     failures.push(`${pkg.name} must not set "private": true`);


### PR DESCRIPTION
## Summary
- skip workspace-only packages that are not configured for npm publishing
- mark embedding and migrate as changeset-ignored until npm trusted publishing is enabled
- make the public package guard fail if a future package is neither publishable nor explicitly workspace-only

## Verification
- pnpm prettier --write .changeset/config.json .github/workflows/auto-publish.yml scripts/changeset-publish-sequential.ts scripts/guard-public-packages.ts
- pnpm guard:public-packages
- node scripts/check-changeset.mjs
- pnpm --filter @agent-native/core exec tsc --noEmit --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --types node ../../scripts/changeset-publish-sequential.ts ../../scripts/guard-public-packages.ts

## Release context
The publish run for version PR #1037 failed at @agent-native/embedding@0.2.0 with npm E404 before reaching @agent-native/scheduling@0.1.10. Core and dispatch published successfully; scheduling is still on npm latest 0.1.5 and should publish after this fix merges.