### PR TITLE
Concurrent sweep: agent-teams delegation prompts + clips recording/compression cleanup

### DIFF
--- a/.changeset/bright-agent-teams-starts.md
+++ b/.changeset/bright-agent-teams-starts.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Clarify Agent Teams delegation intent and distinguish spawned background tasks from completed work.

--- a/packages/core/src/server/agent-chat-plugin.surface.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.surface.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { shouldBlockInProductCodeEditingSurface } from "./agent-chat-plugin.js";
+import {
+  _agentChatPromptSectionsForTests,
+  shouldBlockInProductCodeEditingSurface,
+} from "./agent-chat-plugin.js";
 
 describe("shouldBlockInProductCodeEditingSurface", () => {
   it("blocks app-rendered chat surfaces, including legacy iframe labels", () => {
@@ -49,5 +52,34 @@ describe("shouldBlockInProductCodeEditingSurface", () => {
         host: "agent.example.com",
       }),
     ).toBe(false);
+  });
+});
+
+describe("agent teams prompt guidance", () => {
+  const { frameworkCore, frameworkCoreCompact, frameworkContextSections } =
+    _agentChatPromptSectionsForTests;
+
+  it("treats equivalent background batch phrasing as delegation intent", () => {
+    for (const prompt of [frameworkCore, frameworkCoreCompact]) {
+      expect(prompt).toContain('"background agent"');
+      expect(prompt).toContain('"sub-agent"');
+      expect(prompt).toContain('"parallel"');
+      expect(prompt).toContain('"batch"');
+      expect(prompt).toContain('"kick off"');
+      expect(prompt).toContain('"run the rest"');
+      expect(prompt).toContain('"queued items"');
+    }
+  });
+
+  it("makes agent-teams spawn distinct from completed delegated work", () => {
+    const agentTeams = frameworkContextSections["agent-teams"];
+
+    expect(agentTeams).toContain("**Spawn is not completion.**");
+    expect(agentTeams).toContain(
+      "A successful `spawn` call means the sub-agent started and is running.",
+    );
+    expect(agentTeams).toContain(
+      'Never say the delegated task "completed", "ran successfully", or "finished"',
+    );
   });
 });

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1831,7 +1831,7 @@ function createTeamTools(deps: {
     "agent-teams": {
       tool: {
         description:
-          "Manage sub-agent tasks. Use action 'spawn' to launch a new sub-agent, 'status' to check progress, 'read-result' to get a finished task's output, 'send' to message a running sub-agent, or 'list' to see all tasks. A spawn result only confirms launch; it is not the task result.",
+          "Manage background sub-agent tasks. Use action 'spawn' to start a new sub-agent, 'status' to check progress, 'read-result' to get a finished task's output, 'send' to message a running sub-agent, or 'list' to see all tasks. A successful spawn only means the task started and is running; do not report it as finished until status/read-result shows a terminal status.",
         parameters: {
           type: "object",
           properties: {
@@ -1974,7 +1974,8 @@ function createTeamTools(deps: {
               parentThreadId: task.parentThreadId,
               name: task.name,
               preview: task.preview,
-              message: "Task is still running. Check back later.",
+              message:
+                "Task is still running. Do not report it as complete; use status/read-result later.",
             });
           }
           return JSON.stringify({
@@ -2297,7 +2298,7 @@ On the user's first interaction, check \`readAppState("personalization")\`. If i
 
 You also have tools for: inline embeds, chat history search, agent teams/sub-agents, recurring jobs, A2A cross-app calls, structured memory, live embedded browser sessions (\`list-browser-sessions\`, \`view-browser-session\`, \`run-browser-session-action\`, \`send-browser-session-command\`), and browser automation (\`activate-browser\` for Builder-provisioned Chrome; local development may also include \`set-browser-control\`). Call \`get-framework-context\` to read detailed instructions for any of these when needed — each capability's full doc lives there.
 
-**Agent teams:** default to doing the work yourself. Delegate ONE sub-agent (\`agent-teams\` action "spawn") for self-contained heavy work; fan out to several only for genuinely independent units; never parallelize tightly-coupled work; cap fan-out around 3. Give each sub-agent a self-contained brief (objective, the specific context/IDs it needs, output format, boundaries) — it can't see this thread. Treat a spawn response as "launched and still running," never as completed work. Before claiming delegated work is done, use \`agent-teams\` "status" or "read-result" and synthesize the returned result. Full details: \`get-framework-context\` key \`agent-teams\`.
+**Agent teams:** default to doing the work yourself. Delegate ONE sub-agent (\`agent-teams\` action "spawn") for self-contained heavy work; fan out to several only for genuinely independent units; never parallelize tightly-coupled work; cap fan-out around 3. Treat "background agent", "sub-agent", "parallel", "batch", "kick off", "run the rest", and "queued items" as delegation intent when the user is asking you to start or continue independent work items. After \`spawn\`, say the task started/running, not completed; use \`status\`/\`read-result\` before claiming the delegated work is done. Give each sub-agent a self-contained brief (objective, the specific context/IDs it needs, output format, boundaries) — it can't see this thread — then read all results and synthesize one integrated answer. Full details: \`get-framework-context\` key \`agent-teams\`.
 
 For brand-consistent generated media, use the first-party Assets agent via \`call-agent\` with agent "assets" when another app needs generated heroes, diagrams, product shots, thumbnails, videos, or design imagery. If this app has a native generation action, prefer that action because it may attach the asset to the local document/deck/design.
 `;
@@ -2349,7 +2350,9 @@ You can delegate to background sub-agents with the \`agent-teams\` tool:
 
 Sub-agents inherit all of your template tools but **cannot spawn sub-agents themselves** — only you orchestrate.
 
-Do not tell the user a spawned task completed from the spawn response. Use \`status\` or \`read-result\` before summarizing delegated work as done.
+**User intent phrases.** If the user asks you to use a "sub-agent" or "background agent", that is explicit delegation intent. Also treat phrases like "run these in the background", "kick off the rest", "run the queued items", "batch run these jobs", "parallelize this", or "start the next batch" as delegation intent when the context is a set of independent work items.
+
+**Spawn is not completion.** A successful \`spawn\` call means the sub-agent started and is running. Tell the user it started, show the task id if useful, and then use \`status\`/\`list\`/\`read-result\` to monitor it. Never say the delegated task "completed", "ran successfully", or "finished" until \`status\` or \`read-result\` reports \`completed\` or \`errored\`. If a task is still running, say that plainly.
 
 **Default to doing the work yourself in this thread.** A sub-agent costs real tokens and adds a merge step, so reach for one only when delegation clearly pays for that overhead.
 
@@ -2554,7 +2557,7 @@ Each of these has a one-line pointer here and a full doc you can pull on demand 
 
 - **Inline embeds** — render an interactive app view inline in chat via an \`embed\` fenced code block. Detailed instructions: call \`get-framework-context\` with key \`embeds\`.
 - **Chat history** — search and reopen past conversations with \`chat-history\` (actions: search, open, rename, pin, unpin, archive). Detailed instructions: call \`get-framework-context\` with key \`chat-history\`.
-- **Agent teams / sub-agents** — orchestrate background sub-agents with \`agent-teams\` (actions: spawn, status, read-result, send, list). Default to doing the work yourself in this thread. Delegate ONE sub-agent for self-contained heavy work (deep research, long multi-step generation, noisy scans); fan out to MULTIPLE only for genuinely independent units; never parallelize tightly-coupled work; cap fan-out around 3. Give every sub-agent a self-contained brief (objective, the specific context/IDs it needs, output format, boundaries). Treat spawn as launch-only; use status/read-result before reporting delegated work as complete. Detailed instructions: call \`get-framework-context\` with key \`agent-teams\`.
+- **Agent teams / sub-agents** — orchestrate background sub-agents with \`agent-teams\` (actions: spawn, status, read-result, send, list). Default to doing the work yourself in this thread, but treat "background agent", "sub-agent", "parallel", "batch", "kick off", "run the rest", and "queued items" as delegation intent when the user is asking you to start or continue independent work items. Delegate ONE sub-agent for self-contained heavy work (deep research, long multi-step generation, noisy scans); fan out to MULTIPLE only for genuinely independent units; never parallelize tightly-coupled work; cap fan-out around 3. After \`spawn\`, say the task started/running, not completed; use \`status\`/\`read-result\` before claiming delegated work is done. Give every sub-agent a self-contained brief (objective, the specific context/IDs it needs, output format, boundaries), then read all results and synthesize one integrated answer. Detailed instructions: call \`get-framework-context\` with key \`agent-teams\`.
 - **Recurring jobs** — create cron-scheduled jobs with \`manage-jobs\` (actions: create, list, update). After a task with obvious recurring value, offer in one line to save it as an automation. Detailed instructions: call \`get-framework-context\` with key \`recurring-jobs\`.
 - **Connecting Builder.io** — when the user needs a source-code change or hits "Builder not configured", call \`connect-builder\`; it renders a one-click Connect card. Do NOT write setup steps yourself, and never route users to Builder org/beta settings. Detailed instructions: call \`get-framework-context\` with key \`builder\`.
 - **Browser automation** — drive a real Chrome via \`set-browser-control\` (local dev) or \`activate-browser\` (production) for rendered pages, screenshots, and design-token extraction. Detailed instructions: call \`get-framework-context\` with key \`browser\`.
@@ -2710,6 +2713,12 @@ When editing code, follow the agent-native architecture:
 - No Node.js-specific APIs in server routes (must work on Cloudflare Workers, etc.)
 - Use shadcn/ui components and Tabler Icons for all UI work
 ${FRAMEWORK_CORE_COMPACT}`;
+
+export const _agentChatPromptSectionsForTests = {
+  frameworkCore: FRAMEWORK_CORE,
+  frameworkCoreCompact: FRAMEWORK_CORE_COMPACT,
+  frameworkContextSections: FRAMEWORK_CONTEXT_SECTIONS,
+};
 
 /**
  * Pre-load the agent's context: AGENTS.md (workspace/template/runtime

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -76,7 +76,7 @@ const STORAGE_SETUP_REQUIRED_REASON =
   "Video storage is not connected yet. Connect Builder.io or configure S3-compatible storage to upload and finish saving this clip.";
 const MAX_RECORDING_UPLOAD_BYTES = 64 * 1024 * 1024;
 const RECORDING_TOO_LARGE_REASON =
-  "Recording is too large to process. Clips now compresses before upload; please update the app and try again, or record a shorter clip / lower-resolution screen.";
+  "Recording is too large to process after automatic compression. Please update the app and try again, or record a shorter clip.";
 
 function stateNumber(
   value: Record<string, unknown> | null | undefined,

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -139,6 +139,11 @@ const CHUNK_UPLOAD_MAX_ATTEMPTS = 3;
 const RETRYABLE_CHUNK_UPLOAD_STATUSES = new Set([
   408, 425, 429, 500, 502, 503, 504,
 ]);
+const SCREEN_CAPTURE_FRAME_RATE = 24;
+const SCREEN_CAPTURE_MAX_WIDTH = 1920;
+const SCREEN_CAPTURE_MAX_HEIGHT = 1080;
+const RECORDING_VIDEO_BITRATE_BPS = 1_200_000;
+const RECORDING_AUDIO_BITRATE_BPS = 96_000;
 type CaptureSource = "screen" | "camera" | "microphone" | "unknown";
 
 const VOICE_FOCUSED_AUDIO_CONSTRAINTS: MediaTrackConstraints = {
@@ -281,6 +286,19 @@ function isRetryableChunkUploadStatus(status: number): boolean {
 
 function retryDelayMs(attempt: number): number {
   return attempt === 1 ? 500 : 1500;
+}
+
+function mediaRecorderOptions(
+  mimeType: string,
+  includeBitrateBudget: boolean,
+): MediaRecorderOptions | undefined {
+  const options: MediaRecorderOptions = {};
+  if (mimeType) options.mimeType = mimeType;
+  if (includeBitrateBudget) {
+    options.videoBitsPerSecond = RECORDING_VIDEO_BITRATE_BPS;
+    options.audioBitsPerSecond = RECORDING_AUDIO_BITRATE_BPS;
+  }
+  return Object.keys(options).length > 0 ? options : undefined;
 }
 
 function waitForRetry(ms: number, signal?: AbortSignal): Promise<void> {
@@ -482,7 +500,15 @@ export class RecorderEngine {
       // screen picker can make Chrome/macOS report a false permission failure.
       const displaySurface = this.opts.displaySurface ?? "window";
       const displayOptions: ExtendedDisplayMediaOptions = {
-        video: { frameRate: { ideal: 30 }, displaySurface },
+        video: {
+          frameRate: {
+            ideal: SCREEN_CAPTURE_FRAME_RATE,
+            max: SCREEN_CAPTURE_FRAME_RATE,
+          },
+          width: { ideal: SCREEN_CAPTURE_MAX_WIDTH },
+          height: { ideal: SCREEN_CAPTURE_MAX_HEIGHT },
+          displaySurface,
+        },
         audio: wantsMic,
         // Let "Browser tab" open the tab picker. preferCurrentTab turns it
         // into a current-tab shortcut, which makes choosing another tab harder.
@@ -644,18 +670,21 @@ export class RecorderEngine {
       let lastError: unknown = null;
 
       for (const type of candidates) {
-        try {
-          this.recorder = new MediaRecorder(
-            this.combinedStream,
-            type ? { mimeType: type } : undefined,
-          );
-          this.mimeType = this.recorder.mimeType || type;
-          lastError = null;
-          break;
-        } catch (err) {
-          lastError = err;
-          this.recorder = null;
+        for (const includeBitrateBudget of [true, false]) {
+          try {
+            this.recorder = new MediaRecorder(
+              this.combinedStream,
+              mediaRecorderOptions(type, includeBitrateBudget),
+            );
+            this.mimeType = this.recorder.mimeType || type;
+            lastError = null;
+            break;
+          } catch (err) {
+            lastError = err;
+            this.recorder = null;
+          }
         }
+        if (this.recorder) break;
       }
 
       if (!this.recorder && lastError) {
@@ -1128,7 +1157,7 @@ export class RecorderEngine {
         throw new Error(
           `Recording is too large to upload (${detail}, limit is ${formatMb(
             MAX_UPLOAD_BYTES,
-          )}). Try a shorter recording or lower the screen resolution / frame rate.`,
+          )}) after automatic compression. Try a shorter recording.`,
         );
       }
 

--- a/templates/clips/app/lib/compress.test.ts
+++ b/templates/clips/app/lib/compress.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { pickCompressedDimensions, pickVideoBitrate } from "./compress";
+import {
+  pickCompressedDimensions,
+  pickVideoBitrate,
+  pickVideoFilters,
+} from "./compress";
 
 describe("pickCompressedDimensions", () => {
   it("caps landscape recordings at 720p", () => {
@@ -20,6 +24,13 @@ describe("pickCompressedDimensions", () => {
     expect(pickCompressedDimensions(960, 540)).toEqual({
       width: 960,
       height: 540,
+    });
+  });
+
+  it("keeps encoder dimensions even", () => {
+    expect(pickCompressedDimensions(1921, 1081)).toEqual({
+      width: 1280,
+      height: 720,
     });
   });
 });
@@ -49,5 +60,18 @@ describe("pickVideoBitrate", () => {
       maxrate: "0.4M",
       bufsize: "0.7M",
     });
+  });
+});
+
+describe("pickVideoFilters", () => {
+  it("caps frame rate and adds a scale filter when needed", () => {
+    expect(pickVideoFilters(2560, 1440)).toEqual([
+      "fps=24",
+      "scale=1280:720:flags=lanczos",
+    ]);
+  });
+
+  it("caps frame rate without resizing smaller recordings", () => {
+    expect(pickVideoFilters(1280, 720)).toEqual(["fps=24"]);
   });
 });

--- a/templates/clips/app/lib/compress.ts
+++ b/templates/clips/app/lib/compress.ts
@@ -63,6 +63,7 @@ const ASSUMED_AUDIO_BITRATE_BPS = 96_000;
 const MIN_VIDEO_BITRATE_BPS = 350_000;
 const MAX_COMPRESSED_LONG_SIDE = 1280;
 const MAX_COMPRESSED_SHORT_SIDE = 720;
+const COMPRESSED_FRAME_RATE = 24;
 
 /** Hard cap on total compression time. ffmpeg.wasm is single-threaded WASM
  * and can wedge on certain inputs; we'd rather give the user a clear error
@@ -156,14 +157,8 @@ export function pickCompressedDimensions(
 }
 
 function pickScaleArgs(width?: number, height?: number): string[] {
-  const dimensions = pickCompressedDimensions(width, height);
-  if (
-    !dimensions ||
-    (dimensions.width === width && dimensions.height === height)
-  ) {
-    return [];
-  }
-  return ["-vf", `scale=${dimensions.width}:${dimensions.height}`];
+  const filters = pickVideoFilters(width, height);
+  return filters.length > 0 ? ["-vf", filters.join(",")] : [];
 }
 
 export function pickVideoBitrate(
@@ -218,6 +213,21 @@ export function pickVideoBitrate(
   };
 }
 
+export function pickVideoFilters(width?: number, height?: number): string[] {
+  const filters = [`fps=${COMPRESSED_FRAME_RATE}`];
+  const dimensions = pickCompressedDimensions(width, height);
+  if (
+    dimensions &&
+    (dimensions.width !== Math.round(width ?? 0) ||
+      dimensions.height !== Math.round(height ?? 0))
+  ) {
+    filters.push(
+      `scale=${dimensions.width}:${dimensions.height}:flags=lanczos`,
+    );
+  }
+  return filters;
+}
+
 /** Pick container + codecs to match the source. WebM keeps VP8/9 + Opus,
  * MP4 keeps H.264 + AAC. Audio is always copy — re-encoding adds latency
  * and compresses very little compared to video. */
@@ -240,11 +250,11 @@ function pickEncodeArgs(
       outputName: "compressed.mp4",
       outputMimeType: "video/mp4",
       args: [
+        ...scaleArgs,
         "-c:v",
         "libx264",
         "-preset",
         "fast",
-        ...scaleArgs,
         "-b:v",
         bitrate,
         "-maxrate",
@@ -273,13 +283,13 @@ function pickEncodeArgs(
     outputName: "compressed.webm",
     outputMimeType: "video/webm",
     args: [
+      ...scaleArgs,
       "-c:v",
       "libvpx",
       "-deadline",
       "realtime",
       "-cpu-used",
       "5",
-      ...scaleArgs,
       "-b:v",
       bitrate,
       "-maxrate",

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -388,9 +388,9 @@ function isUploadSizeError(error: string): boolean {
 function uploadTooLargeMessage(size: number, detail?: string): string {
   return `Video is too large to upload (${
     detail ?? formatMb(size)
-  }, limit is ${formatMb(MAX_UPLOAD_BYTES)}). Choose a video under ${formatMb(
+  }, limit is ${formatMb(
     MAX_UPLOAD_BYTES,
-  )}, or trim/export a smaller copy and upload again.`;
+  )}) after automatic compression. Trim or export a shorter copy and upload again.`;
 }
 
 function isUploadFailureError(error: string): boolean {
@@ -402,9 +402,9 @@ function isUploadFailureError(error: string): boolean {
 
 function friendlyRecordingErrorMessage(error: string): string {
   if (isUploadSizeError(error)) {
-    return `This video is too large for Clips to upload directly. Choose a video under ${formatMb(
+    return `This video is too large for Clips after automatic compression. Trim or export a shorter copy under ${formatMb(
       MAX_UPLOAD_BYTES,
-    )}, or trim/export a smaller copy and upload again.`;
+    )} and upload again.`;
   }
   if (isUploadFailureError(error)) {
     return "The video could not finish uploading. Retry the upload before starting over.";

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -30,7 +30,9 @@ const MP4_RECORDING_MIME_TYPE: &str = "video/mp4";
 const UPLOAD_CHUNK_BYTES: usize = 3 * 1024 * 1024;
 const TRANSCODE_THRESHOLD_BYTES: u64 = 24 * 1024 * 1024;
 const TARGET_UPLOAD_BYTES: u64 = 18 * 1024 * 1024;
-const SERVER_STAGING_LIMIT_BYTES: u64 = 64 * 1024 * 1024;
+const SERVER_STAGING_LIMIT_BYTES: u64 = 30 * 1024 * 1024;
+const NATIVE_CAPTURE_MAX_LONG_EDGE: u32 = 1280;
+const NATIVE_CAPTURE_FPS: u32 = 24;
 const AVCONVERT_PATH: &str = "/usr/bin/avconvert";
 const AVCONVERT_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const PENDING_UPLOADS_DIR: &str = "pending-recording-uploads";
@@ -792,8 +794,9 @@ fn start_screencapturekit_backend_at(
         .or_else(|| displays.first())
         .ok_or_else(|| "No displays available for ScreenCaptureKit recording.".to_string())?;
 
-    let width = display.width();
-    let height = display.height();
+    let source_width = display.width();
+    let source_height = display.height();
+    let (width, height) = native_capture_dimensions(source_width, source_height);
     let filter = SCContentFilter::create()
         .with_display(display)
         .with_excluding_windows(&[])
@@ -807,7 +810,7 @@ fn start_screencapturekit_backend_at(
     let mut config = SCStreamConfiguration::new()
         .with_width(width)
         .with_height(height)
-        .with_fps(30)
+        .with_fps(NATIVE_CAPTURE_FPS)
         .with_queue_depth(8)
         .with_shows_cursor(true)
         .with_captures_audio(false)
@@ -848,7 +851,7 @@ fn start_screencapturekit_backend_at(
         return Err(format!("capture start failed: {err:?}"));
     }
     eprintln!(
-        "[clips-tray] ScreenCaptureKit recording started: {width}x{height} @ 30fps, microphone={include_audio}"
+        "[clips-tray] ScreenCaptureKit recording started: {width}x{height} @ {NATIVE_CAPTURE_FPS}fps from {source_width}x{source_height}, microphone={include_audio}"
     );
     Ok((
         NativeFullscreenBackend::ScreenCaptureKit {
@@ -1603,6 +1606,25 @@ fn primary_monitor_size(app: &AppHandle) -> (Option<u32>, Option<u32>) {
     )
 }
 
+#[cfg(target_os = "macos")]
+fn even_dimension(value: u32) -> u32 {
+    ((value.max(2)) / 2) * 2
+}
+
+#[cfg(target_os = "macos")]
+fn native_capture_dimensions(width: u32, height: u32) -> (u32, u32) {
+    let long_side = width.max(height).max(1);
+    let scale = if long_side > NATIVE_CAPTURE_MAX_LONG_EDGE {
+        NATIVE_CAPTURE_MAX_LONG_EDGE as f64 / long_side as f64
+    } else {
+        1.0
+    };
+    (
+        even_dimension((width as f64 * scale).floor() as u32),
+        even_dimension((height as f64 * scale).floor() as u32),
+    )
+}
+
 /// How long to wait for `SCRecordingOutput` to flush its trailing fragment
 /// and write the `moov` after we ask it to stop. Normal finalize is well
 /// under a second for these clips; this is only a safety ceiling for the
@@ -2244,7 +2266,7 @@ fn prepare_recording_file(
             .map(|bytes| format!(", smallest compressed result was {}", format_mb(bytes)))
             .unwrap_or_default();
         return Err(format!(
-            "Native recording is too large to upload after compression attempts (source {}, limit is {}{}). Try a shorter recording or lower-resolution screen.",
+            "Native recording is too large to upload after automatic compression (source {}, limit is {}{}). Try a shorter recording.",
             format_mb(source_bytes),
             format_mb(SERVER_STAGING_LIMIT_BYTES),
             attempt_detail
@@ -2283,6 +2305,7 @@ fn native_transcode_presets(
             "Preset960x540",
             "Preset640x480",
             "PresetAppleM4V480pSD",
+            "PresetAppleM4VCellular",
         ]
     }
 }

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -71,6 +71,12 @@ const NATIVE_FULLSCREEN_RECORDING_FLAG = "clips:native-fullscreen-recording";
 const DEV_SYNTHETIC_CAPTURE_FLAG = "clips:dev-synthetic-capture";
 const LEGACY_DEV_REAL_CAPTURE_FLAG = "clips:dev-real-capture";
 const LIVE_UPLOAD_CHUNK_MS = 1_000;
+const CLOUD_CAPTURE_FRAME_RATE = 24;
+const CLOUD_CAPTURE_MAX_WIDTH = 1920;
+const CLOUD_CAPTURE_MAX_HEIGHT = 1080;
+const CLOUD_RECORDING_MAX_LONG_EDGE = 1280;
+const CLOUD_RECORDING_VIDEO_BITRATE_BPS = 900_000;
+const CLOUD_RECORDING_AUDIO_BITRATE_BPS = 96_000;
 
 function isMacPlatform(): boolean {
   if (typeof navigator === "undefined") return false;
@@ -180,6 +186,161 @@ function streamFromTracks(tracks: MediaStreamTrack[]): MediaStream {
   const stream = new MediaStream();
   tracks.forEach((track) => stream.addTrack(track));
   return stream;
+}
+
+function positiveNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function evenDimension(value: number): number {
+  return Math.max(2, Math.floor(value / 2) * 2);
+}
+
+function scaledVideoDimensions(
+  width: number,
+  height: number,
+): { width: number; height: number } {
+  const longSide = Math.max(width, height);
+  const scale = Math.min(1, CLOUD_RECORDING_MAX_LONG_EDGE / longSide);
+  return {
+    width: evenDimension(width * scale),
+    height: evenDimension(height * scale),
+  };
+}
+
+function videoTrackDimensions(stream: MediaStream): {
+  width: number | null;
+  height: number | null;
+} {
+  const settings = stream.getVideoTracks()[0]?.getSettings();
+  return {
+    width: positiveNumber(settings?.width) ? Math.round(settings.width) : null,
+    height: positiveNumber(settings?.height)
+      ? Math.round(settings.height)
+      : null,
+  };
+}
+
+interface UploadOptimizedVideoStream {
+  stream: MediaStream;
+  cleanup(): void;
+}
+
+function createUploadOptimizedVideoStream(
+  source: MediaStream,
+): UploadOptimizedVideoStream {
+  const sourceTrack = source.getVideoTracks()[0];
+  if (
+    !sourceTrack ||
+    typeof document === "undefined" ||
+    typeof document.createElement !== "function"
+  ) {
+    return { stream: source, cleanup() {} };
+  }
+
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d", { alpha: false });
+  if (!ctx || typeof canvas.captureStream !== "function") {
+    return { stream: source, cleanup() {} };
+  }
+
+  const sourceSize = videoTrackDimensions(source);
+  const initial = scaledVideoDimensions(
+    sourceSize.width ?? 1280,
+    sourceSize.height ?? 720,
+  );
+  canvas.width = initial.width;
+  canvas.height = initial.height;
+
+  const video = document.createElement("video");
+  video.muted = true;
+  video.playsInline = true;
+  video.autoplay = true;
+  video.srcObject = source;
+  video.style.position = "fixed";
+  video.style.left = "-10000px";
+  video.style.top = "0";
+  video.style.width = "1px";
+  video.style.height = "1px";
+  video.style.opacity = "0";
+  video.style.pointerEvents = "none";
+  document.body.appendChild(video);
+  const play = () => video.play().catch(() => undefined);
+  video.addEventListener("loadedmetadata", play);
+  play();
+
+  const resizeCanvas = () => {
+    const width = positiveNumber(video.videoWidth)
+      ? video.videoWidth
+      : (videoTrackDimensions(source).width ?? canvas.width);
+    const height = positiveNumber(video.videoHeight)
+      ? video.videoHeight
+      : (videoTrackDimensions(source).height ?? canvas.height);
+    const next = scaledVideoDimensions(width, height);
+    if (canvas.width !== next.width) canvas.width = next.width;
+    if (canvas.height !== next.height) canvas.height = next.height;
+  };
+
+  const draw = () => {
+    resizeCanvas();
+    ctx.fillStyle = "#000";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    try {
+      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    } catch {
+      // Source metadata may not be ready for the first tick.
+    }
+  };
+
+  const stream = canvas.captureStream(CLOUD_CAPTURE_FRAME_RATE);
+  const interval = window.setInterval(
+    draw,
+    Math.round(1000 / CLOUD_CAPTURE_FRAME_RATE),
+  );
+  draw();
+
+  return {
+    stream,
+    cleanup() {
+      window.clearInterval(interval);
+      stream.getTracks().forEach((track) => track.stop());
+      video.removeEventListener("loadedmetadata", play);
+      video.pause();
+      video.srcObject = null;
+      video.remove();
+    },
+  };
+}
+
+function mediaRecorderOptions(
+  mimeType: string,
+  includeBitrateBudget: boolean,
+): MediaRecorderOptions | undefined {
+  const options: MediaRecorderOptions = {};
+  if (mimeType) options.mimeType = mimeType;
+  if (includeBitrateBudget) {
+    options.videoBitsPerSecond = CLOUD_RECORDING_VIDEO_BITRATE_BPS;
+    options.audioBitsPerSecond = CLOUD_RECORDING_AUDIO_BITRATE_BPS;
+  }
+  return Object.keys(options).length > 0 ? options : undefined;
+}
+
+function createCloudMediaRecorder(
+  stream: MediaStream,
+  mimeType: string,
+): MediaRecorder {
+  let lastError: unknown = null;
+  for (const includeBitrateBudget of [true, false]) {
+    try {
+      return new MediaRecorder(
+        stream,
+        mediaRecorderOptions(mimeType, includeBitrateBudget),
+      );
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
 const VOICE_FOCUSED_AUDIO_CONSTRAINTS: MediaTrackConstraints = {
@@ -1798,7 +1959,7 @@ function createSyntheticScreenStream(): {
   };
   draw();
   const interval = window.setInterval(draw, 250);
-  const stream = canvas.captureStream(30);
+  const stream = canvas.captureStream(CLOUD_CAPTURE_FRAME_RATE);
   return {
     stream,
     cleanup: () => {
@@ -2030,7 +2191,15 @@ async function startNativeRecordingInner(
           const displaySurface =
             captureSource === "window" ? "window" : "monitor";
           return navigator.mediaDevices.getDisplayMedia({
-            video: { frameRate: 30, displaySurface },
+            video: {
+              frameRate: {
+                ideal: CLOUD_CAPTURE_FRAME_RATE,
+                max: CLOUD_CAPTURE_FRAME_RATE,
+              },
+              width: { ideal: CLOUD_CAPTURE_MAX_WIDTH },
+              height: { ideal: CLOUD_CAPTURE_MAX_HEIGHT },
+              displaySurface,
+            },
             audio: wantsAudio,
           });
         }
@@ -2413,6 +2582,23 @@ async function startNativeRecordingInner(
     return handle;
   }
 
+  const uploadPrimaryVideo = createUploadOptimizedVideoStream(primaryVideo);
+  streamCleanups.push(uploadPrimaryVideo.cleanup);
+
+  const uploadCombined = new MediaStream();
+  uploadPrimaryVideo.stream
+    .getVideoTracks()
+    .forEach((track) => uploadCombined.addTrack(track));
+  if (audioStream) {
+    audioStream
+      .getAudioTracks()
+      .forEach((track) => uploadCombined.addTrack(track));
+  } else if (displayStream) {
+    displayStream
+      .getAudioTracks()
+      .forEach((track) => uploadCombined.addTrack(track));
+  }
+
   // 2+3. Countdown + create-recording happen IN PARALLEL. The countdown is
   // pure visual feedback — gating it on a network round-trip makes the
   // 3-2-1 feel laggy after the user picks a screen. Kick both off and
@@ -2467,10 +2653,7 @@ async function startNativeRecordingInner(
   ];
   const mimeType =
     mimeCandidates.find((m) => MediaRecorder.isTypeSupported(m)) ?? "";
-  const recorder = new MediaRecorder(
-    combined,
-    mimeType ? { mimeType } : undefined,
-  );
+  const recorder = createCloudMediaRecorder(uploadCombined, mimeType);
   let chunkIndex = 0;
   let failed: Error | null = null;
   let backupBytes = 0;
@@ -2481,7 +2664,7 @@ async function startNativeRecordingInner(
     width: null,
     height: null,
     bytes: 0,
-    hasAudio: combined.getAudioTracks().length > 0,
+    hasAudio: uploadCombined.getAudioTracks().length > 0,
     hasCamera: wantsCamera,
     savedAt: new Date().toISOString(),
     lastAttemptAt: null,
@@ -2706,7 +2889,9 @@ async function startNativeRecordingInner(
       }
       await thumbnailUploadPromise;
 
-      const videoSettings = primaryVideo.getVideoTracks()[0]?.getSettings();
+      const videoSettings = uploadPrimaryVideo.stream
+        .getVideoTracks()[0]
+        ?.getSettings();
       const displaySettings = displayStream?.getVideoTracks()[0]?.getSettings();
       const durationMs = Math.max(
         0,
@@ -2730,7 +2915,7 @@ async function startNativeRecordingInner(
         width,
         height,
         bytes: backupBytes,
-        hasAudio: combined.getAudioTracks().length > 0,
+        hasAudio: uploadCombined.getAudioTracks().length > 0,
         hasCamera: wantsCamera,
         chunkCount: chunkIndex,
         mimeType: finalMimeType,
@@ -2749,11 +2934,14 @@ async function startNativeRecordingInner(
       // its event handler for the life of the object if you leave a
       // non-null ondataavailable in place — null it to break the chain.
       recorder.ondataavailable = null;
-      // Clear combined MediaStream's track list — just removing our
+      // Clear MediaStream track lists — just removing our
       // references to the tracks is enough; the tracks themselves are
       // owned by `displayStream` / `audioStream` / `bubbleCameraStream`
       // and get stopped below.
       try {
+        uploadCombined
+          .getTracks()
+          .forEach((t) => uploadCombined.removeTrack(t));
         combined.getTracks().forEach((t) => combined.removeTrack(t));
       } catch {
         // ignore — best-effort
@@ -2882,10 +3070,13 @@ async function startNativeRecordingInner(
       } catch {
         // ignore
       }
-      // Drop the combined stream's track references — same rationale as
-      // in stop(). Just detaches from `combined`; the originating
-      // streams own the tracks and we stop them below.
+      // Drop stream track references — same rationale as in stop(). This
+      // detaches only from the MediaStreams; the originating streams own the
+      // tracks and we stop them below.
       try {
+        uploadCombined
+          .getTracks()
+          .forEach((t) => uploadCombined.removeTrack(t));
         combined.getTracks().forEach((t) => combined.removeTrack(t));
       } catch {
         // ignore

--- a/templates/clips/server/routes/api/uploads/[recordingId]/chunk.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/chunk.post.ts
@@ -37,7 +37,7 @@ import finalizeRecording from "../../../../../actions/finalize-recording.js";
 
 const MAX_RECORDING_UPLOAD_BYTES = 64 * 1024 * 1024;
 const RECORDING_TOO_LARGE_REASON =
-  "Recording is too large to process. Clips now compresses before upload; please update the app and try again, or record a shorter clip / lower-resolution screen.";
+  "Recording is too large to process after automatic compression. Please update the app and try again, or record a shorter clip.";
 
 const ALLOWED_RECORDING_MIME_TYPES = new Set([
   "video/webm",


### PR DESCRIPTION
## Summary

Rolling concurrent-sweep PR carrying the latest local working-tree changes from a parallel agent/machine so nothing strands.

**`@agent-native/core` — agent-teams delegation prompts** (`server/agent-chat-plugin.ts` + surface spec):
- Clarify that a `spawn` is *not* completion — the tool description, spawn response, and framework prompt now consistently say a spawned sub-agent is "started/running" and direct the agent to use `status`/`read-result` before reporting delegated work as done.
- Treat delegation-intent phrasing ("background agent", "sub-agent", "parallel", "batch", "kick off", "run the rest", "queued items") as explicit intent to delegate independent work items.
- New `_agentChatPromptSectionsForTests` export + tests asserting the above appear in `FRAMEWORK_CORE`, `FRAMEWORK_CORE_COMPACT`, and the `agent-teams` context section.

**`templates/clips` — recording/compression/desktop cleanup** (not publishable):
- `app/lib/compress.ts` + tests, `recorder-engine.ts`, `record.tsx`, `finalize-recording.ts`, chunk-upload route, and Tauri `native_screen.rs` / desktop `recorder.ts` refinements.

## Conflict resolution note
The core change collided with a sibling version already merged to `main`. Resolved inline: kept main's richer **spawn-response object** (`runId`/`parentThreadId`/`state: "launched_pending_completion"`) and took this wave's **prompt wording** (which the new tests pin). No content lost.

## Verification (local)
- `pnpm typecheck` — green across all packages + templates
- `pnpm --filter @agent-native/core test` — 3511 passed (incl. the new agent-teams guidance test)
- `node scripts/check-changeset.mjs` — `@agent-native/core` covered
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
