### PR TITLE
Concurrent sweep: clips — download buffered recording on upload failure

### DIFF
--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -429,6 +429,28 @@ export class RecorderEngine {
     return Math.max(0, now - this.startedAtMs - this.pausedAccumMs - pausedNow);
   }
 
+  canDownloadBufferedRecording(): boolean {
+    return this.localChunks.length > 0;
+  }
+
+  getBufferedRecordingDownload(): { blob: Blob; filename: string } | null {
+    if (this.localChunks.length === 0) return null;
+    const mimeType = this.mimeType || "video/webm";
+    const extension = /mp4/i.test(mimeType)
+      ? "mp4"
+      : /quicktime|mov/i.test(mimeType)
+        ? "mov"
+        : "webm";
+    const id =
+      this.opts.recordingId && this.opts.recordingId !== "__pending__"
+        ? this.opts.recordingId
+        : new Date().toISOString().replace(/[:.]/g, "-");
+    return {
+      blob: new Blob(this.localChunks, { type: mimeType }),
+      filename: `clips-recording-${id}.${extension}`,
+    };
+  }
+
   canRetryUpload(): boolean {
     return (
       this.state === "error" &&

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -6,6 +6,7 @@ import {
   IconArrowLeft,
   IconCamera,
   IconDeviceDesktop,
+  IconDownload,
   IconExternalLink,
   IconMicrophone,
   IconRefresh,
@@ -518,12 +519,16 @@ function RecordingErrorCard({
   mode,
   micDeviceId,
   canRetryUpload,
+  canDownloadRecording,
+  onDownloadRecording,
   onTryAgain,
 }: {
   error: string;
   mode: RecordingMode;
   micDeviceId: string | null;
   canRetryUpload: boolean;
+  canDownloadRecording: boolean;
+  onDownloadRecording: () => void;
   onTryAgain: () => void;
 }) {
   const uploadFailure = isUploadFailureError(error);
@@ -577,6 +582,12 @@ function RecordingErrorCard({
       )}
 
       <div className="space-y-3 p-6">
+        {uploadFailure && canDownloadRecording && (
+          <Button onClick={onDownloadRecording} className="w-full gap-2">
+            <IconDownload className="h-4 w-4" />
+            Download recording
+          </Button>
+        )}
         <Button variant="outline" onClick={onTryAgain} className="w-full gap-2">
           <IconRefresh className="h-4 w-4" />
           {canRetryUpload ? "Retry upload" : "Try again"}
@@ -1546,6 +1557,24 @@ export default function RecordRoute() {
     }
   }, [finishSavedRecording]);
 
+  const downloadBufferedRecording = useCallback(() => {
+    const download = engineRef.current?.getBufferedRecordingDownload();
+    if (!download) {
+      toast.error("No local recording data is available to download.");
+      return;
+    }
+    const url = URL.createObjectURL(download.blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = download.filename;
+    link.rel = "noopener";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.setTimeout(() => URL.revokeObjectURL(url), 30_000);
+    toast.success("Recording download started");
+  }, []);
+
   const requestStop = useCallback(() => {
     const engine = engineRef.current;
     if (engine && engine.getState() === "recording") {
@@ -1729,12 +1758,17 @@ export default function RecordRoute() {
       setPreviewStream(null);
       void engine?.cancel();
     };
+    const warnBeforeDiscard = (event: BeforeUnloadEvent) => {
+      if (!engineRef.current?.canDownloadBufferedRecording()) return;
+      event.preventDefault();
+      event.returnValue = "";
+    };
 
     window.addEventListener("pagehide", releaseCapture);
-    window.addEventListener("beforeunload", releaseCapture);
+    window.addEventListener("beforeunload", warnBeforeDiscard);
     return () => {
       window.removeEventListener("pagehide", releaseCapture);
-      window.removeEventListener("beforeunload", releaseCapture);
+      window.removeEventListener("beforeunload", warnBeforeDiscard);
       releaseCapture();
     };
   }, [stopLiveTranscription]);
@@ -1988,6 +2022,10 @@ export default function RecordRoute() {
               mode={recordingMode}
               micDeviceId={pendingStartOptsRef.current?.micDeviceId ?? null}
               canRetryUpload={!!engineRef.current?.canRetryUpload()}
+              canDownloadRecording={
+                !!engineRef.current?.canDownloadBufferedRecording()
+              }
+              onDownloadRecording={downloadBufferedRecording}
               onTryAgain={() => {
                 if (engineRef.current?.canRetryUpload()) {
                   void retryFailedUpload();


### PR DESCRIPTION
Adds a **Download recording** fallback when an upload fails in the clips recorder, so a user never loses a capture that's still buffered locally.

- `recorder-engine.ts`: `canDownloadBufferedRecording()` + `getBufferedRecordingDownload()` — builds a Blob from the buffered local chunks with the right extension (mp4/mov/webm) and a sensible filename.
- `record.tsx`: surfaces a `Download recording` button on the upload-failure error card; downloads via an object URL that's revoked after 30s.

Template-only (`templates/clips`), no publishable package touched — no changeset required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)