### PR TITLE
Exclude pnpm-lock.yaml from CLI scaffold

### DIFF
--- a/.changeset/skip-lockfile-scaffold.md
+++ b/.changeset/skip-lockfile-scaffold.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Exclude `pnpm-lock.yaml` from CLI scaffolding so a freshly created app does not ship a stale lockfile copied from the source template.

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1637,6 +1637,7 @@ function shouldSkipScaffoldEntry(name: string, srcPath?: string): boolean {
     name === ".agent-native" ||
     name === ".env" ||
     name === ".env.local" ||
+    name === "pnpm-lock.yaml" ||
     name === ".netlify" ||
     name === ".vercel" ||
     name === ".generated" ||

--- a/scripts/qa-cli-smoke.ts
+++ b/scripts/qa-cli-smoke.ts
@@ -147,6 +147,7 @@ function assertNoLocalArtifacts(projectDir: string): void {
     "build",
     "dist",
     "node_modules",
+    "pnpm-lock.yaml",
   ];
   const present = forbidden.filter((name) =>
     fs.existsSync(path.join(projectDir, name)),


### PR DESCRIPTION
Prevents `agent-native create` from copying the source template's `pnpm-lock.yaml` into a freshly scaffolded app (which would ship a stale lockfile).

- `packages/core/src/cli/create.ts`: add `pnpm-lock.yaml` to `shouldSkipScaffoldEntry`.
- `scripts/qa-cli-smoke.ts`: assert `pnpm-lock.yaml` is absent from scaffolded output (forbidden-artifacts list).

Includes a `patch` changeset for `@agent-native/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)