### PR TITLE
docs: clarify flexible provider integration guidance

### DIFF
--- a/.agents/skills/adding-a-feature/SKILL.md
+++ b/.agents/skills/adding-a-feature/SKILL.md
@@ -54,6 +54,12 @@ contract is incomplete, or create a new `defineAction` if the agent and UI both
 need the capability. Do not add pass-through `/api/*` routes that re-export
 actions.
 
+For provider-backed analysis/query/reporting integrations, do not turn every
+provider endpoint or filter into a rigid action. Prefer the shared
+`provider-api-catalog` / `provider-api-docs` / `provider-api-request` pattern
+from `@agent-native/core/provider-api`, then add narrow convenience actions only
+for workflows that truly deserve a first-class shortcut.
+
 **If the action produces or lists a navigable resource**, add a `link` builder that returns `{ url: buildDeepLink({ app, view, params }), label }`. External coding agents and MCP hosts (Claude / ChatGPT / Claude Code / Cowork / Codex, over MCP/A2A) then surface an "Open in … →" deep link that drops the user back into the running UI focused on the record — for free. If a compatible MCP host should render an inline review/edit surface, also add `mcpApp` with `embedApp()` so the action embeds the real React app route instead of a one-off HTML UI. The `link` builder and `mcpApp` metadata must be pure and synchronous (no I/O). Any external-agent read/ingest action must be `http: { method: "GET" }` + `readOnly: true` + `publicAgent: { expose: true, readOnly: true, requiresAuth: true }`. See the `external-agents` skill.
 
 ### 3. Skills / Instructions

--- a/.agents/skills/writing-agent-instructions/SKILL.md
+++ b/.agents/skills/writing-agent-instructions/SKILL.md
@@ -127,6 +127,11 @@ one a precise, single-purpose sentence:
 - One responsibility per action. If a description needs "and also…", split it.
 - Mark read-only actions (`readOnly: true` / `http: { method: "GET" }`) so the
   agent knows they're safe to call freely.
+- For provider-backed shortcuts, make clear they are convenience paths, not
+  capability ceilings. If arbitrary provider endpoints/filters may matter,
+  point instructions to `provider-api-catalog`, `provider-api-docs`, and
+  `provider-api-request` instead of implying the shortcut is all the agent can
+  do.
 
 ```ts
 defineAction({


### PR DESCRIPTION
## Summary
- Clarify that provider-backed analysis, querying, and reporting integrations should use the flexible provider API catalog/docs/request pattern
- Note that provider shortcut actions are convenience paths, not capability ceilings

## Verification
- pnpm run prep