### PR TITLE
Clarify analytics HubSpot actions are shortcuts, point to provider-api

### DIFF
--- a/templates/analytics/.agents/skills/hubspot/SKILL.md
+++ b/templates/analytics/.agents/skills/hubspot/SKILL.md
@@ -10,6 +10,12 @@ description: >-
 Use HubSpot for CRM facts: deal status, amount, stage, owner, forecast,
 associated account context, contacts, companies, and tickets.
 
+`hubspot-deals` is a legacy-named deal analytics shortcut, not the boundary of
+the HubSpot integration. If the user asks for any HubSpot object, endpoint,
+association, property, filter, batch read/write, or API version that the typed
+actions do not expose, inspect the provider catalog/docs and call
+`provider-api-request` with `provider: "hubspot"`.
+
 ## Actions
 
 - `account-deep-dive` — first choice for named account/deal deep dives. It

--- a/templates/analytics/actions/hubspot-deals.ts
+++ b/templates/analytics/actions/hubspot-deals.ts
@@ -277,7 +277,7 @@ function buildGuidance(options: {
 
 export default defineAction({
   description:
-    "Get HubSpot deals with normalized stage, pipeline, owner, forecast, and NBM fields. Use query for a specific customer/deal/account deep dive. For cohorts like products field = Publish, closed-won, pipeline = New Business, or close date in a range, use the structured product, pipeline, closedStatus, closedDateFrom, and closedDateTo filters instead of query.",
+    "Get HubSpot deals with normalized stage, pipeline, owner, forecast, and NBM fields. This is a deal analytics shortcut, not the full HubSpot capability surface. Use query for a specific customer/deal/account deep dive. For cohorts like products field = Publish, closed-won, pipeline = New Business, or close date in a range, use the structured product, pipeline, closedStatus, closedDateFrom, and closedDateTo filters instead of query. For non-deal CRM records use hubspot-records; for arbitrary HubSpot endpoints, filters, associations, batch APIs, or payloads use provider-api-catalog/provider-api-docs/provider-api-request with provider = hubspot.",
   schema: z.object({
     properties: StringListSchema.describe(
       "Optional comma-separated extra HubSpot deal property names to include.",

--- a/templates/analytics/actions/hubspot-records.ts
+++ b/templates/analytics/actions/hubspot-records.ts
@@ -16,7 +16,7 @@ const StringListSchema = z.preprocess((value) => {
 
 export default defineAction({
   description:
-    "Search or list HubSpot CRM records across contacts, companies, deals, and tickets. Use this for HubSpot data that is not just deal pipeline metrics.",
+    "Search or list HubSpot CRM records across contacts, companies, deals, and tickets. Use this for HubSpot data that is not just deal pipeline metrics. This is a convenience reader; for unsupported object types, associations, custom filters, batch APIs, pagination modes, or any HubSpot endpoint this does not model, use provider-api-catalog/provider-api-docs/provider-api-request with provider = hubspot.",
   schema: z.object({
     objectType: z
       .enum(HUBSPOT_OBJECT_TYPES)


### PR DESCRIPTION
Tightens the analytics HubSpot surface wording so the agent knows the typed actions are convenience shortcuts, not the integration boundary — falling back to the provider-API trio for anything they don't model.

- `actions/hubspot-deals.ts`: description now says it's a deal-analytics shortcut and points at `hubspot-records` for non-deal CRM records and `provider-api-catalog`/`provider-api-docs`/`provider-api-request` (`provider = hubspot`) for arbitrary endpoints/filters/associations/batch APIs.
- `actions/hubspot-records.ts`: description points at the provider-API trio for unsupported object types, associations, custom filters, batch APIs, or pagination modes.
- `.agents/skills/hubspot/SKILL.md`: notes `hubspot-deals` is a legacy-named shortcut, not the boundary; use `provider-api-request` with `provider: "hubspot"` for anything the typed actions don't expose.

Template-only (`templates/analytics`) — no publishable package touched, no changeset required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)