### PR TITLE
Fix Dispatch overview browser crash

### DIFF
--- a/.changeset/tidy-buses-serve.md
+++ b/.changeset/tidy-buses-serve.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Keep Dispatch thread preview route metadata browser-safe by moving pure preview helpers out of server modules.

--- a/packages/dispatch/package.json
+++ b/packages/dispatch/package.json
@@ -22,8 +22,10 @@
     "./routes": "./dist/routes/index.js",
     "./routes/pages/*": "./dist/routes/pages/*.js",
     "./server": "./dist/server/index.js",
+    "./server/lib/thread-link-preview": "./dist/server/lib/thread-link-preview.js",
     "./actions": "./dist/actions/index.js",
     "./db": "./dist/db/index.js",
+    "./lib/thread-link-preview": "./dist/lib/thread-link-preview.js",
     "./components": "./dist/components/index.js",
     "./components/ui/*": "./dist/components/ui/*.js",
     "./styles/dispatch.css": "./src/styles/dispatch.css"

--- a/packages/dispatch/src/lib/thread-link-preview.ts
+++ b/packages/dispatch/src/lib/thread-link-preview.ts
@@ -1,0 +1,160 @@
+export interface ThreadLinkPreview {
+  title: string;
+  description: string;
+  imageUrl: string | null;
+}
+
+const IMAGE_URL_KEYS = new Set([
+  "previewUrl",
+  "thumbnailUrl",
+  "imageUrl",
+  "image",
+  "downloadUrl",
+]);
+
+const GENERATION_TOOL_NAMES = new Set([
+  "generate-image",
+  "generate-image-batch",
+  "refine-image",
+  "rerun-generation-run",
+]);
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function cleanUrlCandidate(value: string): string {
+  return value
+    .trim()
+    .replace(/[),.;\]}]+$/g, "")
+    .replace(/^["'(<]+/g, "");
+}
+
+function isAbsoluteHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function isImageLikeUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      /\.(?:png|jpe?g|webp|gif|avif)(?:$|[?#])/i.test(url.pathname) ||
+      /\/api\/assets\/[^/]+\/content(?:$|[?#])/i.test(url.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function validPreviewImageUrl(value: unknown, key?: string): string | null {
+  if (typeof value !== "string") return null;
+  const candidate = cleanUrlCandidate(value);
+  if (!isAbsoluteHttpUrl(candidate)) return null;
+  if (key && IMAGE_URL_KEYS.has(key)) return candidate;
+  return isImageLikeUrl(candidate) ? candidate : null;
+}
+
+function imageUrlFromStructuredValue(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  if (Array.isArray(value)) {
+    for (let i = value.length - 1; i >= 0; i--) {
+      const found = imageUrlFromStructuredValue(value[i]);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  for (const key of IMAGE_URL_KEYS) {
+    const found = validPreviewImageUrl(record[key], key);
+    if (found) return found;
+  }
+  for (const [key, child] of Object.entries(record).reverse()) {
+    const direct = validPreviewImageUrl(child, key);
+    if (direct) return direct;
+    if (child && typeof child === "object") {
+      const nested = imageUrlFromStructuredValue(child);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+function imageUrlFromText(value: string): string | null {
+  const matches = value.match(/https?:\/\/[^\s<>"']+/g);
+  if (!matches) return null;
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const candidate = validPreviewImageUrl(matches[i]);
+    if (candidate) return candidate;
+  }
+  return null;
+}
+
+export function extractThreadPreviewImageUrl(
+  threadData: string,
+): string | null {
+  const parsed = safeJsonParse(threadData);
+  if (!parsed || typeof parsed !== "object") return null;
+  const messages = (parsed as { messages?: unknown }).messages;
+  if (!Array.isArray(messages)) return null;
+
+  for (
+    let messageIndex = messages.length - 1;
+    messageIndex >= 0;
+    messageIndex--
+  ) {
+    const entry = messages[messageIndex] as any;
+    const message = entry?.message ?? entry;
+    const content = message?.content;
+    if (!Array.isArray(content)) continue;
+
+    for (let partIndex = content.length - 1; partIndex >= 0; partIndex--) {
+      const part = content[partIndex] as Record<string, unknown>;
+      const result = typeof part.result === "string" ? part.result : "";
+      if (!result.trim()) continue;
+
+      const toolName = typeof part.toolName === "string" ? part.toolName : "";
+      const parsedResult = safeJsonParse(result);
+      if (parsedResult && GENERATION_TOOL_NAMES.has(toolName)) {
+        const structured = imageUrlFromStructuredValue(parsedResult);
+        if (structured) return structured;
+      }
+
+      const fromText = imageUrlFromText(result);
+      if (fromText) return fromText;
+    }
+  }
+  return null;
+}
+
+export function buildThreadLinkPreviewMeta(preview: ThreadLinkPreview | null) {
+  const title = preview?.title ? `${preview.title} - Dispatch` : "Dispatch";
+  const description =
+    preview?.description ||
+    "Open this Agent-Native thread in the Dispatch workspace.";
+  const image = preview?.imageUrl ?? null;
+  return [
+    { title },
+    { name: "description", content: description },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+    { property: "og:type", content: "website" },
+    ...(image ? [{ property: "og:image", content: image }] : []),
+    {
+      name: "twitter:card",
+      content: image ? "summary_large_image" : "summary",
+    },
+    { name: "twitter:title", content: title },
+    { name: "twitter:description", content: description },
+    ...(image ? [{ name: "twitter:image", content: image }] : []),
+  ];
+}

--- a/packages/dispatch/src/routes/pages/chat.tsx
+++ b/packages/dispatch/src/routes/pages/chat.tsx
@@ -1,15 +1,7 @@
 import { useEffect, useRef } from "react";
-import {
-  useLocation,
-  useNavigate,
-  type LoaderFunctionArgs,
-} from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { AgentChatSurface } from "@agent-native/core/client";
 import { submitOverviewPrompt } from "@/lib/overview-chat";
-import {
-  buildThreadLinkPreviewMeta,
-  loadThreadLinkPreview,
-} from "@/server/lib/thread-link-preview";
 
 interface DispatchChatLocationState {
   dispatchPrompt?: {
@@ -23,17 +15,8 @@ interface DispatchChatLocationState {
   };
 }
 
-export async function loader({ request }: LoaderFunctionArgs) {
-  const threadId = new URL(request.url).searchParams.get("thread");
-  return {
-    threadPreview: await loadThreadLinkPreview(threadId),
-  };
-}
-
-export function meta({ data }: { data?: Awaited<ReturnType<typeof loader>> }) {
-  return data?.threadPreview
-    ? buildThreadLinkPreviewMeta(data.threadPreview)
-    : [{ title: "Chat — Dispatch" }];
+export function meta() {
+  return [{ title: "Chat — Dispatch" }];
 }
 
 export default function ChatRoute() {

--- a/packages/dispatch/src/routes/pages/overview.tsx
+++ b/packages/dispatch/src/routes/pages/overview.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link, useNavigate, type LoaderFunctionArgs } from "react-router";
+import { Link, useNavigate } from "react-router";
 import {
   PromptComposer,
   useActionQuery,
@@ -34,10 +34,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { submitOverviewPrompt } from "@/lib/overview-chat";
-import {
-  buildThreadLinkPreviewMeta,
-  loadThreadLinkPreview,
-} from "@/server/lib/thread-link-preview";
 import type { WorkspaceAppSummary } from "@/lib/workspace-apps";
 
 interface IntegrationStatus {
@@ -475,17 +471,8 @@ function StepRow({ step }: { step: ChecklistStep }) {
   );
 }
 
-export async function loader({ request }: LoaderFunctionArgs) {
-  const threadId = new URL(request.url).searchParams.get("thread");
-  return {
-    threadPreview: await loadThreadLinkPreview(threadId),
-  };
-}
-
-export function meta({ data }: { data?: Awaited<ReturnType<typeof loader>> }) {
-  return data?.threadPreview
-    ? buildThreadLinkPreviewMeta(data.threadPreview)
-    : [{ title: "Overview — Dispatch" }];
+export function meta() {
+  return [{ title: "Overview — Dispatch" }];
 }
 
 export default function OverviewRoute() {

--- a/packages/dispatch/src/server/lib/thread-link-preview.spec.ts
+++ b/packages/dispatch/src/server/lib/thread-link-preview.spec.ts
@@ -9,10 +9,8 @@ vi.mock("@agent-native/core/server", () => ({
   getThread: getThreadMock,
 }));
 
-import {
-  extractThreadPreviewImageUrl,
-  loadThreadLinkPreview,
-} from "./thread-link-preview";
+import { loadThreadLinkPreview } from "./thread-link-preview";
+import { extractThreadPreviewImageUrl } from "../../lib/thread-link-preview";
 
 function threadDataWithResult(toolName: string, result: unknown) {
   return JSON.stringify({

--- a/packages/dispatch/src/server/lib/thread-link-preview.ts
+++ b/packages/dispatch/src/server/lib/thread-link-preview.ts
@@ -1,142 +1,8 @@
 import type { ChatThread } from "@agent-native/core/server";
-
-export interface ThreadLinkPreview {
-  title: string;
-  description: string;
-  imageUrl: string | null;
-}
-
-const IMAGE_URL_KEYS = new Set([
-  "previewUrl",
-  "thumbnailUrl",
-  "imageUrl",
-  "image",
-  "downloadUrl",
-]);
-
-const GENERATION_TOOL_NAMES = new Set([
-  "generate-image",
-  "generate-image-batch",
-  "refine-image",
-  "rerun-generation-run",
-]);
-
-function safeJsonParse(value: string): unknown {
-  try {
-    return JSON.parse(value);
-  } catch {
-    return null;
-  }
-}
-
-function cleanUrlCandidate(value: string): string {
-  return value
-    .trim()
-    .replace(/[),.;\]}]+$/g, "")
-    .replace(/^["'(<]+/g, "");
-}
-
-function isAbsoluteHttpUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return url.protocol === "https:" || url.protocol === "http:";
-  } catch {
-    return false;
-  }
-}
-
-function isImageLikeUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return (
-      /\.(?:png|jpe?g|webp|gif|avif)(?:$|[?#])/i.test(url.pathname) ||
-      /\/api\/assets\/[^/]+\/content(?:$|[?#])/i.test(url.pathname)
-    );
-  } catch {
-    return false;
-  }
-}
-
-function validPreviewImageUrl(value: unknown, key?: string): string | null {
-  if (typeof value !== "string") return null;
-  const candidate = cleanUrlCandidate(value);
-  if (!isAbsoluteHttpUrl(candidate)) return null;
-  if (key && IMAGE_URL_KEYS.has(key)) return candidate;
-  return isImageLikeUrl(candidate) ? candidate : null;
-}
-
-function imageUrlFromStructuredValue(value: unknown): string | null {
-  if (!value || typeof value !== "object") return null;
-  if (Array.isArray(value)) {
-    for (let i = value.length - 1; i >= 0; i--) {
-      const found = imageUrlFromStructuredValue(value[i]);
-      if (found) return found;
-    }
-    return null;
-  }
-
-  const record = value as Record<string, unknown>;
-  for (const key of IMAGE_URL_KEYS) {
-    const found = validPreviewImageUrl(record[key], key);
-    if (found) return found;
-  }
-  for (const [key, child] of Object.entries(record).reverse()) {
-    const direct = validPreviewImageUrl(child, key);
-    if (direct) return direct;
-    if (child && typeof child === "object") {
-      const nested = imageUrlFromStructuredValue(child);
-      if (nested) return nested;
-    }
-  }
-  return null;
-}
-
-function imageUrlFromText(value: string): string | null {
-  const matches = value.match(/https?:\/\/[^\s<>"']+/g);
-  if (!matches) return null;
-  for (let i = matches.length - 1; i >= 0; i--) {
-    const candidate = validPreviewImageUrl(matches[i]);
-    if (candidate) return candidate;
-  }
-  return null;
-}
-
-export function extractThreadPreviewImageUrl(
-  threadData: string,
-): string | null {
-  const parsed = safeJsonParse(threadData);
-  if (!parsed || typeof parsed !== "object") return null;
-  const messages = (parsed as { messages?: unknown }).messages;
-  if (!Array.isArray(messages)) return null;
-
-  for (
-    let messageIndex = messages.length - 1;
-    messageIndex >= 0;
-    messageIndex--
-  ) {
-    const entry = messages[messageIndex] as any;
-    const message = entry?.message ?? entry;
-    const content = message?.content;
-    if (!Array.isArray(content)) continue;
-
-    for (let partIndex = content.length - 1; partIndex >= 0; partIndex--) {
-      const part = content[partIndex] as Record<string, unknown>;
-      const result = typeof part.result === "string" ? part.result : "";
-      if (!result.trim()) continue;
-
-      const toolName = typeof part.toolName === "string" ? part.toolName : "";
-      const parsedResult = safeJsonParse(result);
-      if (parsedResult && GENERATION_TOOL_NAMES.has(toolName)) {
-        const structured = imageUrlFromStructuredValue(parsedResult);
-        if (structured) return structured;
-      }
-
-      const fromText = imageUrlFromText(result);
-      if (fromText) return fromText;
-    }
-  }
-  return null;
-}
+import {
+  extractThreadPreviewImageUrl,
+  type ThreadLinkPreview,
+} from "../../lib/thread-link-preview";
 
 function previewDescription(thread: ChatThread): string {
   const preview = thread.preview.trim();
@@ -147,7 +13,6 @@ function previewDescription(thread: ChatThread): string {
 export async function loadThreadLinkPreview(
   threadId: string | null | undefined,
 ): Promise<ThreadLinkPreview | null> {
-  if (!import.meta.env.SSR) return null;
   const id = threadId?.trim();
   if (!id) return null;
   const { getRequestContext, getThread } =
@@ -163,27 +28,4 @@ export async function loadThreadLinkPreview(
     description: previewDescription(thread),
     imageUrl: extractThreadPreviewImageUrl(thread.threadData),
   };
-}
-
-export function buildThreadLinkPreviewMeta(preview: ThreadLinkPreview | null) {
-  const title = preview?.title ? `${preview.title} - Dispatch` : "Dispatch";
-  const description =
-    preview?.description ||
-    "Open this Agent-Native thread in the Dispatch workspace.";
-  const image = preview?.imageUrl ?? null;
-  return [
-    { title },
-    { name: "description", content: description },
-    { property: "og:title", content: title },
-    { property: "og:description", content: description },
-    { property: "og:type", content: "website" },
-    ...(image ? [{ property: "og:image", content: image }] : []),
-    {
-      name: "twitter:card",
-      content: image ? "summary_large_image" : "summary",
-    },
-    { name: "twitter:title", content: title },
-    { name: "twitter:description", content: description },
-    ...(image ? [{ name: "twitter:image", content: image }] : []),
-  ];
 }

--- a/templates/dispatch/app/routes/chat.tsx
+++ b/templates/dispatch/app/routes/chat.tsx
@@ -1,5 +1,25 @@
-export {
-  default,
-  loader,
-  meta,
-} from "@agent-native/dispatch/routes/pages/chat";
+export { default } from "@agent-native/dispatch/routes/pages/chat";
+import type { LoaderFunctionArgs } from "react-router";
+import {
+  buildThreadLinkPreviewMeta,
+  type ThreadLinkPreview,
+} from "@agent-native/dispatch/lib/thread-link-preview";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const threadId = new URL(request.url).searchParams.get("thread");
+  const { loadThreadLinkPreview } =
+    await import("@agent-native/dispatch/server/lib/thread-link-preview");
+  return {
+    threadPreview: await loadThreadLinkPreview(threadId),
+  };
+}
+
+export function meta({
+  data,
+}: {
+  data?: { threadPreview: ThreadLinkPreview | null };
+}) {
+  return data?.threadPreview
+    ? buildThreadLinkPreviewMeta(data.threadPreview)
+    : [{ title: "Chat — Dispatch" }];
+}

--- a/templates/dispatch/app/routes/overview.tsx
+++ b/templates/dispatch/app/routes/overview.tsx
@@ -1,5 +1,25 @@
-export {
-  default,
-  loader,
-  meta,
-} from "@agent-native/dispatch/routes/pages/overview";
+export { default } from "@agent-native/dispatch/routes/pages/overview";
+import type { LoaderFunctionArgs } from "react-router";
+import {
+  buildThreadLinkPreviewMeta,
+  type ThreadLinkPreview,
+} from "@agent-native/dispatch/lib/thread-link-preview";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const threadId = new URL(request.url).searchParams.get("thread");
+  const { loadThreadLinkPreview } =
+    await import("@agent-native/dispatch/server/lib/thread-link-preview");
+  return {
+    threadPreview: await loadThreadLinkPreview(threadId),
+  };
+}
+
+export function meta({
+  data,
+}: {
+  data?: { threadPreview: ThreadLinkPreview | null };
+}) {
+  return data?.threadPreview
+    ? buildThreadLinkPreviewMeta(data.threadPreview)
+    : [{ title: "Overview — Dispatch" }];
+}


### PR DESCRIPTION
## Summary
- move Dispatch thread preview extraction/meta helpers into a browser-safe lib module
- keep request-context/thread loading in the server-only helper
- dynamically import the server helper from Overview and Chat loaders so browser route modules do not evaluate `@agent-native/core/server`

## Verification
- `source ~/.nvm/nvm.sh && nvm use && pnpm --filter @agent-native/dispatch test`
- `source ~/.nvm/nvm.sh && nvm use && pnpm --filter @agent-native/dispatch typecheck`
- `source ~/.nvm/nvm.sh && nvm use && pnpm --filter @agent-native/dispatch build`
- inspected emitted `packages/dispatch/dist/routes/pages/{overview,chat}.js` for no top-level `server/lib/thread-link-preview` import
- `source ~/.nvm/nvm.sh && nvm use && pnpm --filter dispatch typecheck`

## Dogfood
- run `source ~/.nvm/nvm.sh && nvm use && pnpm dev -- --apps dispatch --no-open`
- open `http://127.0.0.1:8080/dispatch/overview`
- sign in with the local dev account printed by the dev server
- confirm Overview renders without `AsyncLocalStorage is not a constructor` in the console
- repeat on `/dispatch/chat`, which used the same thread preview import path

Note: `pnpm --filter dispatch build` currently fails separately on a Vite/Rolldown `tiktoken_bg.wasm` load error.