### PR TITLE
Fix agent skill loading and resource guidance

### DIFF
--- a/.changeset/fix-skill-resource-guidance.md
+++ b/.changeset/fix-skill-resource-guidance.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix skill discovery and resource read guidance for agent-native agents.

--- a/packages/core/docs/content/workspace.md
+++ b/packages/core/docs/content/workspace.md
@@ -139,7 +139,7 @@ Change how the agent behaves, in 60 seconds.
 
 ## How the Agent Uses Resources {#how-the-agent-uses-resources}
 
-The agent has built-in tools for managing resources: `resource-list`, `resource-read`, `resource-effective`, `resource-write`, and `resource-delete`. These are available in both Code mode and App mode.
+The built-in app agent manages resources with the unified `resources` tool: use `action: "list"`, `"read"`, `"effective"`, `"write"`, `"promote"`, or `"delete"`. External CLI/code agents can use the equivalent `pnpm action resource-*` commands.
 
 At the start of every conversation, the agent automatically reads:
 
@@ -182,7 +182,7 @@ Both normal chat and integration-triggered agent runs load these instruction res
 
 ### Reference Resources {#reference-resources}
 
-Put reusable company context under `context/`: personas, positioning, messaging, product facts, customer proof points, brand guidelines, competitive notes, and similar material. The agent sees an index of workspace and shared reference resources and reads the relevant file with `resource-read` when a task may depend on it. Use `resource-effective --path "context/brand.md"` when you need to see whether a workspace default is overridden by an organization/app or personal resource.
+Put reusable company context under `context/`: personas, positioning, messaging, product facts, customer proof points, brand guidelines, competitive notes, and similar material. The agent sees an index of workspace and shared reference resources and reads the relevant file with the `resources` tool (`action: "read"`) when a task may depend on it. Use `resources` with `action: "effective"` and `path: "context/brand.md"` when you need to see whether a workspace default is overridden by an organization/app or personal resource.
 
 Examples:
 
@@ -440,7 +440,7 @@ What shows up depends on the mode:
 
 ## / Slash Commands {#slash-commands}
 
-Type `/` at the start of a line to invoke a skill. A dropdown shows available skills with their names and descriptions. Selecting a skill adds it as an inline chip, and its content is included as context when the message is sent.
+Type `/` at the start of a line to invoke a skill. A dropdown shows available skills with their names and descriptions. Selecting a skill adds it as an inline chip, and its content is included as context when the message is sent when the backend can resolve it; otherwise the agent receives the exact skill path and reads it with the appropriate resource or file tool.
 
 What shows up depends on the mode:
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -666,6 +666,7 @@ const MAX_TEXT_ATTACHMENT_CHARS = 60_000;
 const MAX_SELECTION_CONTEXT_CHARS = 8_000;
 const MAX_RESOURCE_INVENTORY_ITEMS = 40;
 const MAX_RESOURCE_INVENTORY_DESCRIPTION_CHARS = 160;
+const MAX_INLINE_SKILL_REFERENCE_CHARS = 40_000;
 
 /**
  * Hard cap on the `<current-screen>` block injected into EVERY user message.
@@ -704,7 +705,7 @@ function limitInventoryLines(lines: string[], label: string): string[] {
   const omitted = lines.length - MAX_RESOURCE_INVENTORY_ITEMS;
   return [
     ...lines.slice(0, MAX_RESOURCE_INVENTORY_ITEMS),
-    `  … ${omitted} more ${label} omitted; use resource-list/resource-read for the full inventory.`,
+    `  … ${omitted} more ${label} omitted; use the resources tool with action "list" or "read" for the full inventory.`,
   ];
 }
 
@@ -1034,10 +1035,67 @@ export function structuredHistoryToEngineMessages(
 }
 
 /** Build enriched message with file/skill/mention references */
-function enrichMessage(
+function capInlineSkillReferenceContent(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= MAX_INLINE_SKILL_REFERENCE_CHARS) return trimmed;
+  const omitted = trimmed.length - MAX_INLINE_SKILL_REFERENCE_CHARS;
+  return `${trimmed.slice(0, MAX_INLINE_SKILL_REFERENCE_CHARS)}\n\n[Skill content truncated after ${MAX_INLINE_SKILL_REFERENCE_CHARS.toLocaleString()} chars; ${omitted.toLocaleString()} chars omitted.]`;
+}
+
+function escapeReferenceAttribute(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+async function resolveSkillReferenceContent(
+  ref: AgentChatReference,
+): Promise<string | null> {
+  if (!ref.path && !ref.name) return null;
+
+  if (ref.source === "resource") {
+    const ownerEmail = getRequestUserEmail();
+    if (!ownerEmail || !ref.path) return null;
+    try {
+      const { resourceEffectiveContext, resourceGet } =
+        await import("../resources/store.js");
+      const resourceOptions = {
+        userEmail: ownerEmail,
+        orgId: getRequestOrgId() ?? null,
+      };
+      const effective = await resourceEffectiveContext(ownerEmail, ref.path, {
+        ...resourceOptions,
+      });
+      if (!effective.effectiveResource) return null;
+      const full = await resourceGet(effective.effectiveResource.id, {
+        ...resourceOptions,
+      });
+      return full?.content ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    const { loadAgentsBundle } = await import("../server/agents-bundle.js");
+    const bundle = await loadAgentsBundle();
+    const normalizedPath = ref.path.replace(/\/+$/g, "");
+    const skill = Object.values(bundle.skills).find((candidate) => {
+      const skillPath = candidate.dir.replace(/\/+$/g, "");
+      return (
+        candidate.meta.name === ref.name ||
+        normalizedPath === skillPath ||
+        normalizedPath === `${skillPath}/SKILL.md`
+      );
+    });
+    return skill?.content ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function enrichMessage(
   message: string,
   references: AgentChatReference[],
-): string {
+): Promise<string> {
   if (references.length === 0) return message;
 
   const fileRefs = references.filter((r) => r.type === "file");
@@ -1057,14 +1115,22 @@ function enrichMessage(
     );
   }
   if (skillRefs.length > 0) {
+    const skillLines = await Promise.all(
+      skillRefs.map(async (r) => {
+        const content = await resolveSkillReferenceContent(r);
+        if (content?.trim()) {
+          return `- ${r.name} (${r.path})\n\n<applied-skill name="${escapeReferenceAttribute(r.name)}" path="${escapeReferenceAttribute(r.path)}" source="${escapeReferenceAttribute(r.source)}">\n${capInlineSkillReferenceContent(content)}\n</applied-skill>`;
+        }
+        return `- ${r.name} (${r.path})${
+          r.source === "resource"
+            ? ' — content was not inlined; read with the resources tool (action: "read") if needed'
+            : " — content was not inlined; read with the read tool if needed"
+        }`;
+      }),
+    );
     parts.push(
-      "Applied skills:\n" +
-        skillRefs
-          .map(
-            (r) =>
-              `- ${r.name} (${r.path})${r.source === "resource" ? " — read with resource-read" : " — read with read"}`,
-          )
-          .join("\n"),
+      "Applied skills (read and follow before acting):\n" +
+        skillLines.join("\n"),
     );
   }
   if (customAgentRefs.length > 0) {
@@ -2299,7 +2365,7 @@ export function createProductionAgentHandler(
     // Run all independent pre-send steps in parallel. Each of these hits
     // the DB or invokes an action; running them sequentially was the
     // single biggest contributor to pre-LLM latency.
-    const enrichedMessage = enrichMessage(requestMessage, references);
+    const enrichedMessagePromise = enrichMessage(requestMessage, references);
     const loopSettingsPromise = readAgentLoopSettings({
       userEmail: ownerEmail ?? getRequestUserEmail() ?? null,
       orgId: getRequestOrgId() ?? null,
@@ -2488,13 +2554,13 @@ export function createProductionAgentHandler(
             if (fileLines.length > 0) {
               const lines = limitInventoryLines(fileLines, "files");
               blocks.push(
-                `<available-files>\nFiles in the workspace:\n${lines.join("\n")}\n\nTo read a file's contents, use the resource-read action with the file path.\n</available-files>`,
+                `<available-files>\nFiles in the workspace:\n${lines.join("\n")}\n\nTo read a resource file's contents, use the resources tool with action "read" and the file path.\n</available-files>`,
               );
             }
             if (skillLines.length > 0) {
               const lines = limitInventoryLines(skillLines, "skills");
               blocks.push(
-                `<available-skills>\nSkills in the workspace:\n${lines.join("\n")}\n</available-skills>`,
+                `<available-skills>\nSkills in the workspace:\n${lines.join("\n")}\n\nBefore using a matching workspace skill, read its path with the resources tool using action "read"; slash-selected skills are inlined automatically when available.\n</available-skills>`,
               );
             }
             if (agentLines.length > 0) {
@@ -2526,6 +2592,7 @@ export function createProductionAgentHandler(
       selectionBlock,
       filesContext,
       loopSettings,
+      enrichedMessage,
     ] = await Promise.all([
       systemPromptPromise,
       screenContextPromise,
@@ -2533,6 +2600,7 @@ export function createProductionAgentHandler(
       selectionContextPromise,
       filesContextPromise,
       loopSettingsPromise,
+      enrichedMessagePromise,
     ]);
 
     if (systemPromptError) {

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -215,7 +215,7 @@ Follow the create-skill pattern to build this. Before writing:
 
 1. **Determine the skill name** — derive a hyphen-case name from the description (e.g. "code review" → "code-review")
 2. **Determine the skill type** — Pattern (architectural rule), Workflow (step-by-step), or Generator (scaffolding)
-3. **Write the skill** as a personal resource at path "skills/<name>/SKILL.md" using resource-write
+3. **Write the skill** as a personal resource at path "skills/<name>/SKILL.md" using the \`resources\` tool with \`action: "write"\`
 
 The skill file MUST have YAML frontmatter with name and description (under 40 words), then markdown with:
 - Clear rule/purpose statement

--- a/packages/core/src/client/composer/extensions/SkillReference.tsx
+++ b/packages/core/src/client/composer/extensions/SkillReference.tsx
@@ -5,7 +5,7 @@ import { IconStack2 } from "@tabler/icons-react";
 const SkillReferenceComponent = ({ node }: { node: any }) => {
   const displayName =
     (node.attrs.name || node.attrs.path || "")
-      .replace(/^(\.agents\/)?skills\//, "")
+      .replace(/^(\.agents?\/)?skills\//, "")
       .replace(/\/SKILL\.md$/i, "")
       .replace(/\.md$/i, "")
       .split("/")

--- a/packages/core/src/client/resources/ResourcesPanel.tsx
+++ b/packages/core/src/client/resources/ResourcesPanel.tsx
@@ -273,7 +273,7 @@ Follow the create-skill pattern to build this. Before writing:
 
 1. **Determine the skill name** — derive a hyphen-case name from the description (e.g. "code review" → "code-review")
 2. **Determine the skill type** — Pattern (architectural rule), Workflow (step-by-step), or Generator (scaffolding)
-3. **Write the skill** as a ${scope} resource at path "skills/<name>/SKILL.md" using resource-write
+3. **Write the skill** as a ${scope} resource at path "skills/<name>/SKILL.md" using the \`resources\` tool with \`action: "write"\`
 
 The skill file MUST have YAML frontmatter with name and description (under 40 words), then markdown with:
 - Clear rule/purpose statement
@@ -402,7 +402,7 @@ The job will run automatically on the schedule. Make the instructions specific �
       newTab: true,
       context: `The user wants a reusable custom sub-agent profile for the workspace. Their description: "${trimmed}"
 
-Create it as a ${scope} resource under "agents/<name>.md" using resource-write.
+Create it as a ${scope} resource under "agents/<name>.md" using the \`resources\` tool with \`action: "write"\`.
 
 Requirements:
 1. Derive a hyphen-case file name from the intent

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -158,9 +158,9 @@ Review the current conversation and save anything worth remembering using the st
 ## Steps
 
 1. Review the conversation for new insights
-2. Check your memory index: \`resource-read --path memory/MEMORY.md\`
+2. Check your memory index with the \`resources\` tool: \`action: "read"\`, \`path: "memory/MEMORY.md"\`
 3. For each new insight, use \`save-memory\` with a descriptive name, type, and content
-4. If updating an existing memory, read it first with \`resource-read --path memory/<name>.md\`, then save with merged content
+4. If updating an existing memory, read it first with the \`resources\` tool (\`action: "read"\`, \`path: "memory/<name>.md"\`), then save with merged content
 
 ## What NOT to capture
 
@@ -199,10 +199,10 @@ Review the current conversation and update the shared \`LEARNINGS.md\` resource 
 
 ## Steps
 
-1. Read shared learnings: \`pnpm action resource-read --path LEARNINGS.md --scope shared\`
+1. Read shared learnings with the \`resources\` tool: \`action: "read"\`, \`path: "LEARNINGS.md"\`, \`scope: "shared"\`
 2. Review the conversation for team-relevant insights
 3. Merge new learnings with existing ones — don't duplicate, refine existing entries
-4. Write back: \`pnpm action resource-write --path LEARNINGS.md --scope shared --content "..."\`
+4. Write back with the \`resources\` tool: \`action: "write"\`, \`path: "LEARNINGS.md"\`, \`scope: "shared"\`, \`content: "..."\`
 
 Keep entries concise — one line per learning, grouped by category (Conventions, Technical, Patterns).
 `;

--- a/packages/core/src/server/agent-chat-plugin.resources.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.resources.spec.ts
@@ -8,6 +8,12 @@ const mocks = vi.hoisted(() => ({
   resourceGet: vi.fn(),
   resourcePut: vi.fn(async () => undefined),
   discoverAgents: vi.fn(async () => []),
+  loadAgentsBundle: vi.fn(async () => ({
+    workspaceAgentsMd: "",
+    agentsMd: "",
+    skills: {},
+  })),
+  generateSkillsPromptBlock: vi.fn(() => ""),
 }));
 
 vi.mock("../resources/store.js", () => ({
@@ -28,12 +34,9 @@ vi.mock("./agent-discovery.js", () => ({
 }));
 
 vi.mock("./agents-bundle.js", () => ({
-  loadAgentsBundle: vi.fn(async () => ({
-    workspaceAgentsMd: "",
-    agentsMd: "",
-    skills: {},
-  })),
-  generateSkillsPromptBlock: vi.fn(() => ""),
+  loadAgentsBundle: (...args: any[]) => mocks.loadAgentsBundle(...args),
+  generateSkillsPromptBlock: (...args: any[]) =>
+    mocks.generateSkillsPromptBlock(...args),
 }));
 
 import { loadResourcesForPrompt } from "./agent-chat-plugin.js";
@@ -135,6 +138,12 @@ function meta(id: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.loadAgentsBundle.mockResolvedValue({
+    workspaceAgentsMd: "",
+    agentsMd: "",
+    skills: {},
+  });
+  mocks.generateSkillsPromptBlock.mockReturnValue("");
   mocks.resourceGetByPath.mockImplementation(async (owner, path) => {
     if (owner === "__workspace__" && path === "AGENTS.md") {
       return { content: "# Workspace Instructions\n\nUse global context." };
@@ -248,7 +257,7 @@ describe("loadResourcesForPrompt", () => {
       '<resource name="instructions/guardrails.md" scope="workspace-instruction"',
     );
     expect(analyticsPrompt).toContain(
-      "`company-voice` at resource `skills/company-voice/SKILL.md` (personal) - Personal voice override.",
+      '`company-voice` at resource `skills/company-voice/SKILL.md` (personal) - Personal voice override. Use the `resources` tool with `action: "read"`',
     );
     expect(analyticsPrompt).toContain(
       '<workspace-resources scope="workspace">',
@@ -301,6 +310,10 @@ describe("loadResourcesForPrompt", () => {
     expect(prompt).toContain("<resource-skills>");
     expect(prompt).toContain("`company-voice` at resource");
     expect(prompt).toContain("(personal) - Personal voice override.");
+    expect(prompt).toContain(
+      'Use the `resources` tool with `action: "read"`, `path: "skills/company-voice/SKILL.md"` and `scope: "personal"`',
+    );
+    expect(prompt).not.toContain("resource-read --path");
     expect(prompt).not.toContain("Workspace voice default.");
     expect(prompt).not.toContain("Organization voice override.");
     expect(prompt).toContain('<workspace-resources scope="workspace">');
@@ -308,8 +321,33 @@ describe("loadResourcesForPrompt", () => {
     expect(prompt).toContain(
       "`context/messaging.md` - Messaging: Core value props and proof points.",
     );
-    expect(prompt).not.toContain(
-      '<workspace-resources scope="workspace">\nWorkspace reference resources are inherited by every app and are available for company, brand, positioning, persona, product, or domain context. Use `resource-read --path <path> --scope workspace` when a task may depend on them; do not assume their contents without reading the relevant file.\n\n- `instructions/guardrails.md`',
+    expect(prompt).not.toContain("Use `resource-read --path <path>");
+  });
+
+  it("points compact bundled skills at their docs-search skill slugs", async () => {
+    mocks.loadAgentsBundle.mockResolvedValueOnce({
+      workspaceAgentsMd: "",
+      agentsMd: "",
+      skills: {
+        "deep-review": {
+          meta: {
+            name: "deep-review",
+            description: "Use when reviewing risky changes.",
+          },
+          content: "---\nname: deep-review\n---\n# Deep Review",
+          dir: ".agents/skills/deep-review",
+          extraFiles: [],
+        },
+      },
+    });
+
+    const prompt = await loadResourcesForPrompt("user@example.test", true);
+
+    expect(prompt).toContain("<skills-summary>");
+    expect(prompt).toContain(
+      'Read with `docs-search --slug "skill-deep-review"` before starting a task it applies to.',
     );
+    expect(prompt).toContain("Do not use MCP resource reads for these skills.");
+    expect(prompt).not.toContain("Use `docs-search` to read a skill");
   });
 });

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -177,6 +177,27 @@ function normalizeResourcePathForPrompt(path: string): string {
   return path.replace(/^\/+/, "").trim();
 }
 
+function resourceToolHint(
+  action: "list" | "read" | "effective" | "write" | "delete" | "promote",
+  extra?: string,
+): string {
+  return `Use the \`resources\` tool with \`action: "${action}"\`${extra ? `, ${extra}` : ""}.`;
+}
+
+function skillDocsSlug(name: string): string {
+  return `skill-${name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")}`;
+}
+
+function ensureSentence(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
 function escapeXmlAttribute(value: string): string {
   return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
 }
@@ -192,7 +213,10 @@ function truncatePromptResourceContent(
   const omitted = trimmed.length - maxChars;
   const hint =
     readHint ??
-    `Use resource-read --path "${path}" with the resource's scope for the full content.`;
+    resourceToolHint(
+      "read",
+      `\`path: "${path}"\` and the resource's \`scope\` for the full content`,
+    );
   return `${trimmed.slice(0, maxChars)}\n\n[Resource ${path} truncated after ${maxChars.toLocaleString()} characters; ${omitted.toLocaleString()} characters omitted. ${hint}]`;
 }
 
@@ -365,7 +389,10 @@ async function loadResourceSkillsPromptBlock(
       const scope = resourceScopeForOwner(resource.owner, owner);
       const description = meta.description || "(no description)";
       lines.push(
-        `- \`${name}\` at resource \`${resource.path}\` (${scope}) - ${description}. Read it with \`resource-read --path "${resource.path}" --scope ${scope}\` before starting a task it applies to.`,
+        `- \`${name}\` at resource \`${resource.path}\` (${scope}) - ${ensureSentence(description)} ${resourceToolHint(
+          "read",
+          `\`path: "${resource.path}"\` and \`scope: "${scope}"\` before starting a task it applies to`,
+        )}`,
       );
     }
     if (lines.length === 0) return null;
@@ -400,7 +427,10 @@ async function loadResourceIndexForPrompt(
     }
     if (resources.length > listed.length) {
       lines.push(
-        `- ...${resources.length - listed.length} more ${scope} resources. Use \`resource-list --scope ${scope}\` to inspect them.`,
+        `- ...${resources.length - listed.length} more ${scope} resources. ${resourceToolHint(
+          "list",
+          `\`scope: "${scope}"\` to inspect them`,
+        )}`,
       );
     }
 
@@ -408,7 +438,10 @@ async function loadResourceIndexForPrompt(
       scope === "workspace"
         ? "Workspace reference resources are inherited by every app and are available for company, brand, positioning, persona, product, or domain context."
         : "Shared app/organization reference resources are available for app-specific or team context.";
-    return `<workspace-resources scope="${scope}">\n${label} Use \`resource-read --path <path> --scope ${scope}\` when a task may depend on them; do not assume their contents without reading the relevant file.\n\n${lines.join("\n")}\n</workspace-resources>`;
+    return `<workspace-resources scope="${scope}">\n${label} ${resourceToolHint(
+      "read",
+      `\`path: <path>\` and \`scope: "${scope}"\` when a task may depend on them`,
+    )} Do not assume their contents without reading the relevant file.\n\n${lines.join("\n")}\n</workspace-resources>`;
   } catch {
     return null;
   }
@@ -1029,7 +1062,7 @@ async function createDocsScriptEntries(): Promise<Record<string, ActionEntry>> {
       "docs-search": wrapCliScript(
         {
           description:
-            "Search and read agent-native framework documentation. Use --list to see all pages, --query to search, --slug to read a specific page.",
+            "Search and read agent-native framework documentation, bundled AGENTS.md, and codebase skills. Use --list to see all pages, --query to search, --slug to read a specific page. Codebase skill pages use slugs like skill-<name>.",
           parameters: {
             type: "object",
             properties: {
@@ -2282,8 +2315,8 @@ Bring a senior engineer's judgment, arrived at through attention not premature c
 
 ### Resources
 
-Use resource-list, resource-read, resource-effective, resource-write, resource-delete for persistent notes and context files.
-Resources have three levels: workspace defaults inherited from Dispatch, shared organization/app overrides, and personal overrides. Use resource-effective before editing when you need to explain or inspect which level is active for a path.
+Use the \`resources\` tool for persistent notes and context files: \`action: "list"\`, \`"read"\`, \`"effective"\`, \`"write"\`, \`"promote"\`, or \`"delete"\`.
+Resources have three levels: workspace defaults inherited from Dispatch, shared organization/app overrides, and personal overrides. Use \`resources\` with \`action: "effective"\` before editing when you need to explain or inspect which level is active for a path.
 Workspace resources are user-facing by default. If you need temporary working files, write them as agent scratch (\`visibility: "agent_scratch"\`); scratch is hidden from the Workspace view by default and expires. Use \`visibility: "workspace"\` only when the user explicitly asked to save/manage that file, or for durable AGENTS.md, LEARNINGS.md, memory, skills, jobs, or custom agents.
 
 ### Navigation Rule
@@ -2381,7 +2414,7 @@ You can create recurring jobs that run on a cron schedule. Jobs are resource fil
 - \`manage-jobs\` (action: "create") — Create a new recurring job with a cron schedule and instructions
 - \`manage-jobs\` (action: "list") — List all recurring jobs and their status
 - \`manage-jobs\` (action: "update") — Update a job's schedule, instructions, or toggle enabled/disabled
-- Delete a job with \`resource-delete --path jobs/<name>.md\`
+- Delete a job with the \`resources\` tool: \`action: "delete"\`, \`path: "jobs/<name>.md"\`
 
 Convert natural language to 5-field cron format:
 - "every morning" / "daily at 9am" → \`0 9 * * *\`
@@ -2448,7 +2481,7 @@ Your memory index (\`memory/MEMORY.md\`) is loaded at the start of every convers
 **Tools:**
 - \`save-memory\` — Create or update a memory (name, type, description, content)
 - \`delete-memory\` — Remove a memory and its index entry
-- \`resource-read --path memory/<name>.md\` — Read the full content of a specific memory
+- \`resources\` with \`action: "read"\` and \`path: "memory/<name>.md"\` — Read the full content of a specific memory
 
 **Memory types:** user, feedback, project, reference
 
@@ -2540,7 +2573,7 @@ Gather context efficiently: when you need several independent read-only lookups 
 ### Resources
 
 You have access to a Resources system for persistent notes and context files.
-Use resource-list, resource-read, resource-effective, resource-write, resource-delete to manage resources.
+Use the \`resources\` tool to manage resources: \`action: "list"\`, \`"read"\`, \`"effective"\`, \`"write"\`, \`"promote"\`, or \`"delete"\`.
 Resources can be workspace defaults inherited from Dispatch, shared organization/app overrides, or personal overrides. By default, resources are personal. Workspace-scope resources are read-only from app agents; create shared or personal resources to override or narrow them.
 
 When the user gives instructions that should apply to all users/sessions, update the shared "AGENTS.md" resource.
@@ -2638,7 +2671,7 @@ In Act mode, when the user asks you to change the UI, modify code, add a feature
 
 When \`builderEnabled\` is false, Builder Cloud Agents are not self-serve from Builder org settings. Do NOT tell the user to go to Builder org settings, beta features, "Cloud Agents", or "AI Agents" to enable them. The only allowed guidance is the card's waitlist/local-dev fallback: join the waitlist when the card offers it, use Agent Native Desktop, or edit from a local clone.
 
-**Act-mode handoff — do exactly this:** The moment a code change is requested, call \`connect-builder\` with the user's verbatim request, then write one sentence framing the next click. That is the whole job: Builder plans and edits in its own sandbox, so the planning, file-mapping, and code all happen there, not here. Keep your turn to the call plus that one sentence — skip code exploration, implementation plans, \`resource-write\` of specs, and sub-agents (they have no code-editing tools either). You don't need filesystem access to recommend Builder, so don't reach for it or list tools you lack.
+**Act-mode handoff — do exactly this:** The moment a code change is requested, call \`connect-builder\` with the user's verbatim request, then write one sentence framing the next click. That is the whole job: Builder plans and edits in its own sandbox, so the planning, file-mapping, and code all happen there, not here. Keep your turn to the call plus that one sentence — skip code exploration, implementation plans, \`resources\` writes of specs, and sub-agents (they have no code-editing tools either). You don't need filesystem access to recommend Builder, so don't reach for it or list tools you lack.
 
 Builder Cloud Agents are the recommended path when available because they are one-click and run in the cloud. Local dev and the desktop app are the fallback when cloud agent access is waitlisted or unavailable.
 ${FRAMEWORK_CORE}`;
@@ -2795,11 +2828,14 @@ export async function loadResourcesForPrompt(
       const skillsBlock = generateSkillsPromptBlock(bundle);
       if (skillsBlock) sections.push(skillsBlock);
     } else if (Object.keys(bundle.skills).length > 0) {
-      const names = Object.values(bundle.skills)
-        .map((s) => s.meta.name)
-        .join(", ");
+      const lines = Object.values(bundle.skills).map((s) => {
+        const description = s.meta.description?.trim()
+          ? ` - ${ensureSentence(s.meta.description)}`
+          : "";
+        return `- \`${s.meta.name}\`${description} Read with \`docs-search --slug "${skillDocsSlug(s.meta.name)}"\` before starting a task it applies to.`;
+      });
       sections.push(
-        `<skills-summary>\nSkills available in .agents/skills/: ${names}. Use \`docs-search\` to read a skill before starting a task it applies to.\n</skills-summary>`,
+        `<skills-summary>\nCodebase skills bundled from \`.agents/skills/\` (or legacy \`.agent/skills/\`) are available as docs-search pages. Do not use MCP resource reads for these skills.\n\n${lines.join("\n")}\n</skills-summary>`,
       );
     }
   } catch {}
@@ -2859,10 +2895,10 @@ export async function loadResourcesForPrompt(
 
   if (compact) {
     // In compact mode, skip learnings and memory in the prompt.
-    // The agent can access them via resource-read when needed.
+    // The agent can access them via the resources tool when needed.
     // Add a brief pointer so the agent knows they exist.
     sections.push(
-      `<context-note>Shared learnings (LEARNINGS.md) and your personal memory (memory/MEMORY.md) are available via \`resource-read\`. Check them when making decisions that might benefit from prior context.</context-note>`,
+      `<context-note>Shared learnings (LEARNINGS.md) and your personal memory (memory/MEMORY.md) are available via the \`resources\` tool with \`action: "read"\`. Check them when making decisions that might benefit from prior context.</context-note>`,
     );
   } else {
     // LEARNINGS.md from SQL (template-level instructions are in AGENTS.md above).
@@ -5435,61 +5471,78 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
           }> = [];
           const seenNames = new Set<string>();
 
-          // In dev mode, scan .agents/skills/ directory
+          // In dev mode, scan .agents/skills/ plus legacy .agent/skills/.
           if (currentDevMode) {
             try {
               const _fs = await lazyFs();
-              const skillsDir = nodePath.join(
-                process.cwd(),
-                ".agents",
-                "skills",
-              );
-              const entries = _fs.readdirSync(skillsDir, {
-                withFileTypes: true,
-              });
-              for (const entry of entries) {
-                // Support both flat .md files and subdirectory-based skills (dir/SKILL.md)
-                let skillFilePath: string;
-                let skillRelPath: string;
-
-                if (entry.isDirectory()) {
-                  // Subdirectory layout: .agents/skills/<name>/SKILL.md
-                  const candidate = nodePath.join(
-                    skillsDir,
-                    entry.name,
-                    "SKILL.md",
-                  );
-                  if (!_fs.existsSync(candidate)) continue;
-                  skillFilePath = candidate;
-                  skillRelPath = `.agents/skills/${entry.name}/SKILL.md`;
-                } else if (entry.isFile() && entry.name.endsWith(".md")) {
-                  // Flat layout: .agents/skills/<name>.md
-                  skillFilePath = nodePath.join(skillsDir, entry.name);
-                  skillRelPath = `.agents/skills/${entry.name}`;
-                } else {
+              const skillRoots = [
+                {
+                  dir: nodePath.join(process.cwd(), ".agents", "skills"),
+                  display: ".agents/skills",
+                },
+                {
+                  dir: nodePath.join(process.cwd(), ".agent", "skills"),
+                  display: ".agent/skills",
+                },
+              ];
+              for (const root of skillRoots) {
+                let entries: Array<{
+                  name: string;
+                  isDirectory: () => boolean;
+                  isFile: () => boolean;
+                }>;
+                try {
+                  entries = _fs.readdirSync(root.dir, {
+                    withFileTypes: true,
+                  });
+                } catch {
                   continue;
                 }
+                for (const entry of entries) {
+                  // Support both flat .md files and subdirectory-based skills (dir/SKILL.md)
+                  let skillFilePath: string;
+                  let skillRelPath: string;
 
-                try {
-                  const content = _fs.readFileSync(skillFilePath, "utf-8");
-                  const fm = parseSkillFrontmatter(content);
-                  if (fm.userInvocable === false) continue;
-                  const skillName = fm.name || entry.name.replace(/\.md$/, "");
-                  if (!seenNames.has(skillName)) {
-                    seenNames.add(skillName);
-                    skills.push({
-                      name: skillName,
-                      description: fm.description,
-                      path: skillRelPath,
-                      source: "codebase",
-                    });
+                  if (entry.isDirectory()) {
+                    // Subdirectory layout: <skills-root>/<name>/SKILL.md
+                    const candidate = nodePath.join(
+                      root.dir,
+                      entry.name,
+                      "SKILL.md",
+                    );
+                    if (!_fs.existsSync(candidate)) continue;
+                    skillFilePath = candidate;
+                    skillRelPath = `${root.display}/${entry.name}/SKILL.md`;
+                  } else if (entry.isFile() && entry.name.endsWith(".md")) {
+                    // Flat layout: <skills-root>/<name>.md
+                    skillFilePath = nodePath.join(root.dir, entry.name);
+                    skillRelPath = `${root.display}/${entry.name}`;
+                  } else {
+                    continue;
                   }
-                } catch {
-                  // Could not read individual skill file — skip
+
+                  try {
+                    const content = _fs.readFileSync(skillFilePath, "utf-8");
+                    const fm = parseSkillFrontmatter(content);
+                    if (fm.userInvocable === false) continue;
+                    const skillName =
+                      fm.name || entry.name.replace(/\.md$/, "");
+                    if (!seenNames.has(skillName)) {
+                      seenNames.add(skillName);
+                      skills.push({
+                        name: skillName,
+                        description: fm.description,
+                        path: skillRelPath,
+                        source: "codebase",
+                      });
+                    }
+                  } catch {
+                    // Could not read individual skill file — skip
+                  }
                 }
               }
             } catch {
-              // .agents/skills/ directory doesn't exist or not readable — skip
+              // Skill directories don't exist or are not readable — skip.
             }
           }
 

--- a/packages/core/src/server/agents-bundle.spec.ts
+++ b/packages/core/src/server/agents-bundle.spec.ts
@@ -78,6 +78,49 @@ describe("readAgentsBundleFromFs", () => {
     }
   });
 
+  it("accepts legacy .agent/skills as a codebase skills directory", () => {
+    const tpl = fs.mkdtempSync(path.join(os.tmpdir(), "agents-bundle-tpl-"));
+    const skillDir = path.join(tpl, ".agent", "skills", "runtime");
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir, "SKILL.md"),
+      "---\nname: runtime\ndescription: Runtime skill\n---\nRuntime body",
+    );
+
+    try {
+      const bundle = readAgentsBundleFromFs(tpl);
+      expect(bundle.skills.runtime).toBeDefined();
+      expect(bundle.skills.runtime!.dir).toBe(".agent/skills/runtime");
+      expect(bundle.skills.runtime!.content).toContain("Runtime body");
+    } finally {
+      fs.rmSync(tpl, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps .agents/skills canonical when legacy .agent/skills has the same skill", () => {
+    const tpl = fs.mkdtempSync(path.join(os.tmpdir(), "agents-bundle-tpl-"));
+    const canonical = path.join(tpl, ".agents", "skills", "policy");
+    const legacy = path.join(tpl, ".agent", "skills", "policy");
+    fs.mkdirSync(canonical, { recursive: true });
+    fs.mkdirSync(legacy, { recursive: true });
+    fs.writeFileSync(
+      path.join(canonical, "SKILL.md"),
+      "---\nname: policy\ndescription: Canonical\n---\nCanonical body",
+    );
+    fs.writeFileSync(
+      path.join(legacy, "SKILL.md"),
+      "---\nname: policy\ndescription: Legacy\n---\nLegacy body",
+    );
+
+    try {
+      const bundle = readAgentsBundleFromFs(tpl);
+      expect(bundle.skills.policy!.meta.description).toBe("Canonical");
+      expect(bundle.skills.policy!.dir).toBe(".agents/skills/policy");
+    } finally {
+      fs.rmSync(tpl, { recursive: true, force: true });
+    }
+  });
+
   it("adds workspace AGENTS.md when provided", () => {
     const tpl = makeTemplate(null);
     const ws = makeWorkspaceSource({ agentsMd: "# Workspace wide" });

--- a/packages/core/src/server/agents-bundle.ts
+++ b/packages/core/src/server/agents-bundle.ts
@@ -1,5 +1,6 @@
 /**
  * Agents bundle — loads AGENTS.md and .agents/skills/ from the template.
+ * The legacy singular .agent/skills/ directory is also accepted as an alias.
  *
  * This is the single source of truth the framework's agent uses to mirror what
  * Claude Code / Codex / any other agent would see when running locally in the
@@ -12,7 +13,7 @@
  *      framework's Vite plugin. This is the ONLY path that works on edge
  *      runtimes (Cloudflare Workers) where `readFileSync` doesn't exist.
  *   2. Filesystem fallback — `process.cwd()/AGENTS.md` +
- *      `process.cwd()/.agents/skills/`. Only reliable in local dev and Node
+ *      `process.cwd()/.agents/skills/` (or legacy `.agent/skills/`). Only reliable in local dev and Node
  *      production (`agent-native start`); not on Netlify/Vercel/CF at runtime.
  *   3. Empty bundle — everything silently returns empty strings.
  *
@@ -127,6 +128,11 @@ export function parseSkillFrontmatter(content: string): Partial<SkillMeta> {
 import fs from "node:fs";
 import path from "node:path";
 
+const TEMPLATE_SKILLS_DIRS = [
+  path.join(".agents", "skills"),
+  path.join(".agent", "skills"),
+] as const;
+
 /**
  * Paths to a workspace-core's agent resources, for merging into a template's
  * bundle. All fields optional — pass null for any missing piece.
@@ -233,12 +239,14 @@ export function readAgentsBundleFromFs(
 
   // Merge skills: template first (so its entries are authoritative), then
   // workspace-core with skipExistingNames=true so same-named skills don't
-  // overwrite the template's.
+  // overwrite the template's. `.agents/skills` is canonical; `.agent/skills`
+  // is accepted as a legacy alias and does not override canonical skills.
   const skills: Record<string, Skill> = {};
-  try {
-    const skillsDir = path.join(cwd, ".agents", "skills");
-    readSkillsDir(skillsDir, cwd, skills, false);
-  } catch {}
+  for (const [index, relSkillsDir] of TEMPLATE_SKILLS_DIRS.entries()) {
+    try {
+      readSkillsDir(path.join(cwd, relSkillsDir), cwd, skills, index > 0);
+    } catch {}
+  }
 
   if (workspaceSource?.skillsDir) {
     try {
@@ -309,9 +317,10 @@ export async function loadAgentsBundle(): Promise<AgentsBundle> {
 /**
  * Generate the `<skills>` block to inject into the system prompt.
  *
- * Skills are folders at `.agents/skills/<name>/` containing a `SKILL.md` entry
- * file plus any number of supporting files (additional markdown, examples,
- * images, scripts). This block lists what's available and how to read them.
+ * Skills are folders at `.agents/skills/<name>/` (or legacy
+ * `.agent/skills/<name>/`) containing a `SKILL.md` entry file plus any number
+ * of supporting files (additional markdown, examples, images, scripts). This
+ * block lists what's available and how to read them.
  *
  * In dev mode the agent has bash access and reads skills via `cat` — exactly
  * like running `claude` locally in the repo. In production mode the agent has
@@ -331,11 +340,11 @@ export function generateSkillsPromptBlock(bundle: AgentsBundle): string {
   });
 
   return `<skills>
-The following skills live in the repo at \`.agents/skills/<name>/\`. Each skill is a folder containing a \`SKILL.md\` entry file and sometimes supporting files. Read a skill BEFORE starting a task it applies to.
+The following skills live in the repo, usually at \`.agents/skills/<name>/\` (legacy \`.agent/skills/<name>/\` is also supported). Each skill is a folder containing a \`SKILL.md\` entry file and sometimes supporting files. Read a skill BEFORE starting a task it applies to.
 
 To read a skill in dev mode (when you have bash access):
-  \`bash(command="cat .agents/skills/<name>/SKILL.md")\`
-  \`bash(command="ls .agents/skills/<name>/")\` to see all files in the folder
+  \`bash(command="cat <skill-dir>/SKILL.md")\`
+  \`bash(command="ls <skill-dir>/")\` to see all files in the folder
 
 Available skills:
 ${lines.join("\n")}

--- a/packages/core/src/templates/default/AGENTS.md
+++ b/packages/core/src/templates/default/AGENTS.md
@@ -37,14 +37,16 @@ Resources are SQL-backed persistent files for notes, learnings, and context.
 1. **`AGENTS.md`** -- inherited workspace defaults, app/team instructions, and user-specific context.
 2. **`LEARNINGS.md`** -- user preferences, corrections, and patterns. Read personal and shared scopes.
 
-**Update `LEARNINGS.md` when you learn something important.**
+**Update `LEARNINGS.md` when you learn something important.** Built-in app
+chat agents use the `resources` tool with the `action` argument. External CLI
+agents can use the equivalent `pnpm action resource-*` commands.
 
-| Action            | Args                                                        | Purpose                 |
-| ----------------- | ----------------------------------------------------------- | ----------------------- |
-| `resource-read`   | `--path <path> [--scope personal\|shared]`                  | Read a resource         |
-| `resource-write`  | `--path <path> --content <text> [--scope personal\|shared]` | Write/update a resource |
-| `resource-list`   | `[--prefix <path>] [--scope personal\|shared\|all]`         | List resources          |
-| `resource-delete` | `--path <path> [--scope personal\|shared]`                  | Delete a resource       |
+| Built-in agent tool call                                                | CLI equivalent                                                                         | Purpose                 |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------------- |
+| `resources` with `action: "read"`, `path`, optional `scope`             | `pnpm action resource-read --path <path> [--scope personal\|shared]`                   | Read a resource         |
+| `resources` with `action: "write"`, `path`, `content`, optional `scope` | `pnpm action resource-write --path <path> --content <text> [--scope personal\|shared]` | Write/update a resource |
+| `resources` with `action: "list"`, optional `prefix`/`scope`            | `pnpm action resource-list [--prefix <path>] [--scope personal\|shared\|all]`          | List resources          |
+| `resources` with `action: "delete"`, `path`, optional `scope`           | `pnpm action resource-delete --path <path> [--scope personal\|shared]`                 | Delete a resource       |
 
 ## Application State
 

--- a/packages/core/src/vite/agents-bundle-plugin.ts
+++ b/packages/core/src/vite/agents-bundle-plugin.ts
@@ -1,6 +1,7 @@
 /**
  * Vite plugin that resolves `virtual:agents-bundle` to a statically-inlined
  * ES module containing the template's AGENTS.md + .agents/skills/ content.
+ * The legacy singular .agent/skills/ directory is also watched as an alias.
  *
  * This is how the framework's agent gets its instructions and skills into the
  * system prompt on EVERY deployment target — Node, Netlify Functions, Vercel
@@ -22,6 +23,10 @@ import { getWorkspaceCoreExports } from "../deploy/workspace-core.js";
 
 const VIRTUAL_ID = "virtual:agents-bundle";
 const RESOLVED_ID = "\0" + VIRTUAL_ID;
+const TEMPLATE_SKILLS_DIRS = [
+  path.join(".agents", "skills"),
+  path.join(".agent", "skills"),
+] as const;
 
 async function emitBundleModule(projectRoot: string): Promise<string> {
   // If the project is inside an enterprise monorepo with a workspace core,
@@ -99,11 +104,11 @@ export function agentsBundlePlugin(): Plugin {
         const rel = path.relative(projectRoot, file);
         if (!rel.startsWith("..")) {
           if (rel === "AGENTS.md") return true;
-          if (
-            rel.startsWith(".agents" + path.sep + "skills") &&
-            rel.endsWith("SKILL.md")
-          )
-            return true;
+          if (rel.endsWith("SKILL.md")) {
+            for (const skillsDir of TEMPLATE_SKILLS_DIRS) {
+              if (rel.startsWith(skillsDir + path.sep)) return true;
+            }
+          }
         }
         // Workspace-core files
         if (workspaceAgentsMdPath && file === workspaceAgentsMdPath) {
@@ -131,9 +136,13 @@ export function agentsBundlePlugin(): Plugin {
       // Explicitly add template + workspace-core paths to the watcher so
       // edits outside the normal Vite watch set still trigger invalidation.
       const agentsMdPath = path.join(projectRoot, "AGENTS.md");
-      const skillsDir = path.join(projectRoot, ".agents", "skills");
+      const skillsDirs = TEMPLATE_SKILLS_DIRS.map((rel) =>
+        path.join(projectRoot, rel),
+      );
       if (fs.existsSync(agentsMdPath)) watcher.add(agentsMdPath);
-      if (fs.existsSync(skillsDir)) watcher.add(skillsDir);
+      for (const skillsDir of skillsDirs) {
+        if (fs.existsSync(skillsDir)) watcher.add(skillsDir);
+      }
       if (workspaceAgentsMdPath && fs.existsSync(workspaceAgentsMdPath)) {
         watcher.add(workspaceAgentsMdPath);
       }

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -364,7 +364,7 @@ export default function Index() {
       "If the user asked for a specific slide count, keep going sequentially until that count is reached unless a tool error blocks you.",
       "Every slide is rendered into a fixed native canvas (default 16:9 is 960x540 CSS pixels). Keep each slide within the density limits in AGENTS.md; split dense source material across more slides instead of packing it tightly.",
       "Each slide's --content must be full HTML. Slide HTML templates are in your AGENTS.md.",
-      "Do NOT use create-deck (the deck already exists). Do NOT call db-schema, resource-read, or search-files.",
+      "Do NOT use create-deck (the deck already exists). Do NOT call db-schema, the resources tool, or search-files.",
     ].join("\n");
 
     const persisted = await ensureDeckPersisted(deck.id);


### PR DESCRIPTION
## Summary
- inline explicitly selected skill content before agent execution when it can be resolved
- point agents at the actual `resources` tool actions instead of stale `resource-read`/MCP resource hints
- support legacy `.agent/skills` alongside canonical `.agents/skills`, with canonical precedence
- document and test docs-search skill slugs for bundled codebase skills

## Tests
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core exec vitest run src/server/agent-chat-plugin.resources.spec.ts src/server/agents-bundle.spec.ts src/agent/production-agent.spec.ts
- pnpm run prep
