### PR TITLE
fix(slides): harden isRawHtml detection and add rehype-raw safety net

### DIFF
--- a/templates/slides/app/components/deck/SlideRenderer.tsx
+++ b/templates/slides/app/components/deck/SlideRenderer.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import ReactMarkdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
 import type { Slide } from "@/context/DeckContext";
 import { Skeleton } from "@/components/ui/skeleton";
 import { MermaidRenderer } from "./MermaidRenderer";
@@ -593,6 +594,7 @@ export function SlideInner({
   const content = typeof slide.content === "string" ? slide.content : "";
   const isRawHtml =
     content.includes('class="fmd-slide"') ||
+    content.trimStart().startsWith("<") ||
     ["blank", "section", "statement", "full-image"].includes(slide.layout);
 
   if (!isRawHtml && slide.layout === "two-column") {
@@ -614,7 +616,10 @@ export function SlideInner({
           className="slide-content text-white/90"
           onOverflowChange={onOverflowChange}
         >
-          <ReactMarkdown components={markdownComponents}>
+          <ReactMarkdown
+            components={markdownComponents}
+            rehypePlugins={[rehypeRaw]}
+          >
             {left.trim()}
           </ReactMarkdown>
         </AutoFitContent>
@@ -624,7 +629,10 @@ export function SlideInner({
           fitKey={right}
           className="slide-content text-white/90"
         >
-          <ReactMarkdown components={markdownComponents}>
+          <ReactMarkdown
+            components={markdownComponents}
+            rehypePlugins={[rehypeRaw]}
+          >
             {right.trim()}
           </ReactMarkdown>
         </AutoFitContent>
@@ -671,7 +679,12 @@ export function SlideInner({
         className="slide-content text-white/90 w-full"
         onOverflowChange={onOverflowChange}
       >
-        <ReactMarkdown components={markdownComponents}>{content}</ReactMarkdown>
+        <ReactMarkdown
+          components={markdownComponents}
+          rehypePlugins={[rehypeRaw]}
+        >
+          {content}
+        </ReactMarkdown>
       </AutoFitContent>
     </div>
   );


### PR DESCRIPTION
**Summary**
Fixes slide content rendering as escaped HTML text in the editor when agent-generated slides do not include `class="fmd-slide"` on the content wrapper.

**Problem**
The `isRawHtml` check in `SlideRenderer.tsx` coupled rendering path selection to a specific CSS class name in agent output. Models that produce valid HTML without `class="fmd-slide"` caused content to fall through to `ReactMarkdown`, which escaped it as visible text instead of rendering it.

**Solution**
Added a structural HTML check so any content beginning with `<` is routed to `dangerouslySetInnerHTML` regardless of CSS classes present. Imported and wired `rehype-raw` into all three `ReactMarkdown` call sites as a safety net for any HTML that reaches the markdown path.

**Key Changes**
* Added `content.trimStart().startsWith("<")` to the `isRawHtml` condition in `SlideRenderer.tsx`
* Imported `rehype-raw` and added it to `rehypePlugins` on all three `ReactMarkdown` instances