### PR TITLE
Fix scrubber duration and redirect bug in clips

### DIFF
--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -1345,6 +1345,10 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
           ...(options.fsDeny ?? []),
         ],
       },
+      headers: {
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "Cross-Origin-Embedder-Policy": "require-corp",
+      },
     },
     build: {
       outDir: options.outDir ?? "dist/spa",

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -1345,10 +1345,6 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
           ...(options.fsDeny ?? []),
         ],
       },
-      headers: {
-        "Cross-Origin-Opener-Policy": "same-origin",
-        "Cross-Origin-Embedder-Policy": "require-corp",
-      },
     },
     build: {
       outDir: options.outDir ?? "dist/spa",

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -471,26 +471,39 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       durationProbedRef.current = false;
     }, [activeVideoSrc, durationMs]);
 
-    const probeDurationIfNeeded = useCallback((v: HTMLVideoElement) => {
-      if (durationProbedRef.current) return;
-      if (Number.isFinite(v.duration) && v.duration > 0) {
-        durationProbedRef.current = true;
-        setResolvedDurationMs(Math.round(v.duration * 1000));
-        return;
-      }
-      if (playAttemptPendingRef.current || !v.paused) return;
+    // The recorder's elapsed-time counter (durationMs prop) is the most
+    // trustworthy length we have. A MediaRecorder WebM's own duration is
+    // cluster-estimated and lands short by up to one timeslice, so we never
+    // let it overwrite a real prop — doing so makes the scrubber jump to a
+    // shorter length than the actual recording on first watch.
+    const hasReliableDurationProp =
+      Number.isFinite(durationMs) && durationMs > 0;
 
-      // Poke the browser into computing the real duration for MediaRecorder
-      // WebM files. Defer this while playback is starting; the large seek can
-      // otherwise abort the first user-initiated play().
-      durationProbedRef.current = true;
-      try {
-        v.currentTime = 1e10;
-      } catch {
-        // Safari occasionally throws — the durationchange fallback still picks
-        // up the real duration.
-      }
-    }, []);
+    const probeDurationIfNeeded = useCallback(
+      (v: HTMLVideoElement) => {
+        if (durationProbedRef.current) return;
+        if (Number.isFinite(v.duration) && v.duration > 0) {
+          durationProbedRef.current = true;
+          if (!hasReliableDurationProp) {
+            setResolvedDurationMs(Math.round(v.duration * 1000));
+          }
+          return;
+        }
+        if (playAttemptPendingRef.current || !v.paused) return;
+
+        // Poke the browser into computing the real duration for MediaRecorder
+        // WebM files. Defer this while playback is starting; the large seek can
+        // otherwise abort the first user-initiated play().
+        durationProbedRef.current = true;
+        try {
+          v.currentTime = 1e10;
+        } catch {
+          // Safari occasionally throws — the durationchange fallback still
+          // picks up the real duration.
+        }
+      },
+      [hasReliableDurationProp],
+    );
 
     // Resolve the WebM-duration-is-Infinity Chrome quirk: when a video created
     // by MediaRecorder doesn't have a Duration element in the container, the
@@ -507,7 +520,11 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
 
       const onDurationChange = () => {
         if (Number.isFinite(v.duration) && v.duration > 0) {
-          setResolvedDurationMs(Math.round(v.duration * 1000));
+          // Don't downgrade a trustworthy recorder duration to the
+          // cluster-estimated WebM duration; only adopt it as a fallback.
+          if (!hasReliableDurationProp) {
+            setResolvedDurationMs(Math.round(v.duration * 1000));
+          }
           // After we've resolved the real duration, rewind back to 0 so the
           // user isn't sitting at the end of the clip.
           if (durationProbedRef.current && v.currentTime > v.duration) {
@@ -530,7 +547,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         v.removeEventListener("loadedmetadata", onLoadedMetadata);
         v.removeEventListener("durationchange", onDurationChange);
       };
-    }, [activeVideoSrc, probeDurationIfNeeded]);
+    }, [activeVideoSrc, hasReliableDurationProp, probeDurationIfNeeded]);
 
     // Reset the thumbnail-capture flag when the source changes (e.g. the
     // player is reused for a different recording via React Router).

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -55,7 +55,7 @@ async function writeAppState(key: string, value: unknown): Promise<void> {
     {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ value }),
+      body: JSON.stringify(value),
     },
   );
 }


### PR DESCRIPTION
### Summary
Fixes two bugs in the clips template: the recording progress bar showing an incorrect (shorter) duration on first watch, and a broken `writeAppState` call caused by double-wrapping the request body.

### Problem
1. After recording a clip and immediately watching it, the scrubber/progress bar would display a shorter duration than the actual recording. This happened because the browser's cluster-estimated WebM duration was overwriting the more accurate recorder elapsed-time counter.
2. The `writeAppState` helper was serializing its payload as `{ value: ... }` instead of the raw value, causing malformed PUT requests — which likely contributed to unexpected redirects after upload.

### Solution
1. Treat the `durationMs` prop (from the recorder's elapsed-time counter) as the authoritative source of truth. The browser-reported WebM duration is now only used as a fallback when no reliable prop duration is available, preventing it from downgrading the scrubber length.
2. Fixed `writeAppState` to serialize `value` directly instead of wrapping it in an extra object.

### Key Changes
- Added `hasReliableDurationProp` guard in `video-player.tsx` so that `probeDurationIfNeeded` and the `onDurationChange` handler only call `setResolvedDurationMs` when no trustworthy recorder duration prop exists.
- Updated `probeDurationIfNeeded`'s dependency array to include `hasReliableDurationProp`.
- Fixed `writeAppState` in `record.tsx` to pass `JSON.stringify(value)` instead of `JSON.stringify({ value })`.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/paladin-fragment-ugnif982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-paladin-fragment-ugnif982_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1078`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>paladin-fragment-ugnif982</branchName>-->