### PR TITLE
Fix ffmpeg loading

### DIFF
--- a/templates/clips/app/lib/ffmpeg-export.ts
+++ b/templates/clips/app/lib/ffmpeg-export.ts
@@ -92,7 +92,7 @@ export async function loadFfmpeg(onLog?: (msg: string) => void): Promise<any> {
         }
       });
       // Match the version of @ffmpeg/ffmpeg installed in package.json.
-      const baseURL = "https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd";
+      const baseURL = "https://unpkg.com/@ffmpeg/core@0.12.6/dist/esm";
       await ffmpeg.load({
         coreURL: await util.toBlobURL(
           `${baseURL}/ffmpeg-core.js`,

--- a/templates/clips/vite.config.ts
+++ b/templates/clips/vite.config.ts
@@ -1,9 +1,21 @@
+import path from "path";
+import { createRequire } from "module";
 import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from "@agent-native/core/vite";
+
+const _require = createRequire(import.meta.url);
+const ffmpegDir = path.resolve(
+  path.dirname(_require.resolve("@ffmpeg/ffmpeg")),
+  "../..",
+);
 
 export default defineConfig({
   plugins: [reactRouter()],
   // shiki only runs in AssistantChat's useEffect — keep it out of the
   // CF Pages Functions bundle (25 MiB limit).
   ssrStubs: ["shiki"],
+  fsAllow: [ffmpegDir],
+  optimizeDeps: {
+    exclude: ["@ffmpeg/ffmpeg", "@ffmpeg/util"],
+  },
 });


### PR DESCRIPTION
### 1. ffmpeg loads correctly in the browser (`ffmpeg-export.ts`)

**Problem:** The ffmpeg.wasm core was being loaded from the UMD build (`dist/umd`).
`@ffmpeg/ffmpeg` v0.12.x spins up a module worker (ES module worker), so it expects
the ESM build of the core. Loading UMD into a module worker causes ffmpeg to fail
silently or crash on load.

**Fix:** Changed the unpkg URL from `dist/umd` to `dist/esm`.

---

### 2. Vite dev server can serve ffmpeg files (`vite.config.ts`)

**Problem:** Vite's file-serving restrictions blocked the ffmpeg package files
during local development, causing 403 errors when the browser tried to load
the wasm worker.

**Fix:**

- Added `fsAllow` pointing to the ffmpeg package directory so Vite will serve it.
- Added `optimizeDeps.exclude` for `@ffmpeg/ffmpeg` and `@ffmpeg/util` so Vite
  doesn't try to pre-bundle them (they use dynamic imports and WASM, which
  pre-bundling breaks).