### PR TITLE
Add plan design workflow

### DIFF
--- a/.changeset/plan-design-skill.md
+++ b/.changeset/plan-design-skill.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add `/plan-design` to the built-in Plans skill bundle and CLI aliases.

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -735,7 +735,7 @@ Usage:
                                 fallback. Usually run for you by 'skills add'.
   agent-native app-skill <cmd>  Install, launch, or package app-backed skills.
                                 cmds: ensure | launch | pack
-  agent-native skills add assets|design-exploration|visual-plan|visual-questions|ui-plan|visualize-plan
+  agent-native skills add assets|design-exploration|visual-plan|visual-questions|ui-plan|prototype-plan|plan-design|visualize-plan
                                 Install the skill instructions, register the MCP
                                 connector, AND authenticate it in one step.
                                 --no-connect skips auth (run 'connect' later);

--- a/packages/core/src/cli/plan-install.spec.ts
+++ b/packages/core/src/cli/plan-install.spec.ts
@@ -34,6 +34,7 @@ import {
 import {
   addAgentNativeSkill,
   parseSkillsArgs,
+  PLAN_DESIGN_SKILL_MD,
   PROTOTYPE_PLAN_SKILL_MD,
   UI_PLAN_SKILL_MD,
   VISUAL_PLANS_SKILL_MD,
@@ -166,6 +167,7 @@ describe(
         "visual-plan",
         "ui-plan",
         "prototype-plan",
+        "plan-design",
         "visualize-plan",
         "visual-questions",
       ]) {
@@ -306,6 +308,7 @@ describe("Plans skills install — materialized output", () => {
       "visual-questions",
       "ui-plan",
       "prototype-plan",
+      "plan-design",
       "visualize-plan",
     ]);
     expect(result.mcpUrl).toBe(
@@ -318,6 +321,7 @@ describe("Plans skills install — materialized output", () => {
       ["visual-questions", VISUAL_QUESTIONS_SKILL_MD],
       ["ui-plan", UI_PLAN_SKILL_MD],
       ["prototype-plan", PROTOTYPE_PLAN_SKILL_MD],
+      ["plan-design", PLAN_DESIGN_SKILL_MD],
       ["visualize-plan", VISUALIZE_PLAN_SKILL_MD],
     ];
     for (const [name, constant] of expected) {
@@ -327,6 +331,7 @@ describe("Plans skills install — materialized output", () => {
     }
     // No extra surprise skills materialized.
     expect(Object.keys(captured).sort()).toEqual([
+      "plan-design",
       "prototype-plan",
       "ui-plan",
       "visual-plan",
@@ -340,6 +345,10 @@ describe("Plans skills install — materialized output", () => {
       "visual-plans",
       "ui-plan",
       "prototype-plan",
+      "plan-design",
+      "plan-designs",
+      "design-plan",
+      "design-plans",
       "visualize-plan",
       "visual-questions",
       "plannotate",
@@ -352,6 +361,7 @@ describe("Plans skills install — materialized output", () => {
         "visual-questions",
         "ui-plan",
         "prototype-plan",
+        "plan-design",
         "visualize-plan",
       ]);
     }
@@ -386,6 +396,11 @@ describe("Plans skill three-copy sync (deep)", () => {
       constant: PROTOTYPE_PLAN_SKILL_MD,
       templateDir: "prototype-plan",
       exportedDir: "prototype-plan",
+    },
+    {
+      constant: PLAN_DESIGN_SKILL_MD,
+      templateDir: "plan-design",
+      exportedDir: "plan-design",
     },
     {
       constant: VISUALIZE_PLAN_SKILL_MD,

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -12,6 +12,7 @@ const PLANS_SKILL_NAMES = [
   "visual-questions",
   "ui-plan",
   "prototype-plan",
+  "plan-design",
   "visualize-plan",
 ];
 
@@ -241,6 +242,8 @@ describe("agent-native skills", () => {
           "--skill",
           "prototype-plan",
           "--skill",
+          "plan-design",
+          "--skill",
           "visualize-plan",
           "-a",
           "codex",
@@ -297,6 +300,8 @@ describe("agent-native skills", () => {
         "--skill",
         "prototype-plan",
         "--skill",
+        "plan-design",
+        "--skill",
         "visualize-plan",
       ]),
     );
@@ -339,6 +344,53 @@ describe("agent-native skills", () => {
         "ui-plan",
         "--skill",
         "prototype-plan",
+        "--skill",
+        "plan-design",
+        "--skill",
+        "visualize-plan",
+      ]),
+    );
+    expect(result.mcpUrl).toBe(
+      "https://plan.agent-native.com/_agent-native/mcp",
+    );
+  });
+
+  it("accepts plan-design as a Plans full-fidelity design alias", async () => {
+    const root = tmpDir();
+    const commands: { cmd: string; args: string[] }[] = [];
+
+    const result = await addAgentNativeSkill(
+      parseSkillsArgs([
+        "add",
+        "plan-design",
+        "--client",
+        "codex",
+        "--scope",
+        "project",
+      ]),
+      {
+        baseDir: root,
+        runCommand: async (cmd, args) => {
+          commands.push({ cmd, args });
+          return 0;
+        },
+      },
+    );
+
+    expect(result.id).toBe("visual-plans");
+    expect(result.skillNames).toEqual(PLANS_SKILL_NAMES);
+    expect(commands[0].args).toEqual(
+      expect.arrayContaining([
+        "--skill",
+        "visual-plan",
+        "--skill",
+        "visual-questions",
+        "--skill",
+        "ui-plan",
+        "--skill",
+        "prototype-plan",
+        "--skill",
+        "plan-design",
         "--skill",
         "visualize-plan",
       ]),
@@ -383,6 +435,8 @@ describe("agent-native skills", () => {
         "--skill",
         "prototype-plan",
         "--skill",
+        "plan-design",
+        "--skill",
         "visualize-plan",
       ]),
     );
@@ -398,6 +452,7 @@ describe("agent-native skills", () => {
       ["visual-questions", "visual-questions"],
       ["ui-plan", "ui-plan"],
       ["prototype-plan", "prototype-plan"],
+      ["plan-design", "plan-design"],
       ["visualize-plan", "visualize-plan"],
     ];
 

--- a/packages/core/src/cli/skills.sync.spec.ts
+++ b/packages/core/src/cli/skills.sync.spec.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  PLAN_DESIGN_SKILL_MD,
   PROTOTYPE_PLAN_SKILL_MD,
   UI_PLAN_SKILL_MD,
   VISUAL_PLANS_SKILL_MD,
@@ -61,6 +62,13 @@ const PLAN_SKILLS = [
     constant: PROTOTYPE_PLAN_SKILL_MD,
     templateDir: "prototype-plan",
     exportedDir: "prototype-plan",
+    hasCores: false,
+  },
+  {
+    label: "plan-design",
+    constant: PLAN_DESIGN_SKILL_MD,
+    templateDir: "plan-design",
+    exportedDir: "plan-design",
     hasCores: false,
   },
   {

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -33,7 +33,7 @@ const HELP = `agent-native skills
 
 Usage:
   agent-native skills list
-  agent-native skills add assets|design-exploration|visual-plan|visual-questions|ui-plan|prototype-plan|visualize-plan|context-xray [--client codex|claude-code|claude-code-cli|cowork|all] [--scope user|project] [--mcp-url <url>] [--no-connect] [--yes] [--dry-run] [--json]
+  agent-native skills add assets|design-exploration|visual-plan|visual-questions|ui-plan|prototype-plan|plan-design|visualize-plan|context-xray [--client codex|claude-code|claude-code-cli|cowork|all] [--scope user|project] [--mcp-url <url>] [--no-connect] [--yes] [--dry-run] [--json]
   agent-native skills add <manifest-or-app-dir> [--client ...] [--yes]
 
 Examples:
@@ -217,7 +217,7 @@ iteration, or a human-in-the-loop choice among design directions.
 
 /**
  * Shared setup/auth block for every Plans skill (`/visual-plan`, `/ui-plan`,
- * `/prototype-plan`, `/visual-questions`, `/visualize-plan`). Interpolated into each skill markdown
+ * `/prototype-plan`, `/plan-design`, `/visual-questions`, `/visualize-plan`). Interpolated into each skill markdown
  * so the install + one-step authenticate instructions never drift between them.
  * Keep this in sync with the copies under `templates/plan/.agents/skills/*` and
  * top-level `skills/*` (this skill's SKILL.md is triplicated with no sync test).
@@ -235,7 +235,7 @@ intended), so the first tool call does not hit an OAuth wall:
 agent-native skills add visual-plan
 \`\`\`
 
-After that, \`/visual-plan\` (and \`/ui-plan\`, \`/prototype-plan\`,
+After that, \`/visual-plan\` (and \`/ui-plan\`, \`/prototype-plan\`, \`/plan-design\`,
 \`/visual-questions\`, \`/visualize-plan\`) generate a plan and open the editor. Pass \`--no-connect\` to
 register the connector without authenticating, then run
 \`agent-native connect https://plan.agent-native.com\` whenever you are ready.
@@ -281,6 +281,7 @@ user reacts to visuals first and reads prose only where it helps.
 \`/visual-plan\` is the canonical command and the main entry point. Use \`/ui-plan\`
 when the work is primarily product UI and review should start with the screens.
 Use \`/prototype-plan\` when review should start with a functional live prototype.
+Use \`/plan-design\` when review should start with full-fidelity branded design.
 Use \`/visual-questions\` only when the user explicitly wants a visual intake form
 before planning. Use \`/visualize-plan\` to turn an existing Codex, Claude Code,
 Markdown, or pasted plan into a visual companion.
@@ -669,6 +670,8 @@ already shows. Never produce this.
 - \`create-ui-plan\`: start a UI-first plan when the work is primarily product UI.
 - \`create-prototype-plan\`: start a prototype-first plan with a functional top
   review surface.
+- \`create-plan-design\`: start a full-fidelity branded Design-tab plan with an
+  optional matching Prototype tab.
 - \`convert-visual-plan-to-prototype\`: convert an existing HTML wireframe canvas
   into a prototype plan.
 - \`create-visual-questions\`: use only for the explicit \`/visual-questions\`
@@ -705,7 +708,7 @@ intended), so the first tool call does not hit an OAuth wall:
 agent-native skills add visual-plan
 \`\`\`
 
-After that, \`/visual-plan\` (and \`/ui-plan\`, \`/prototype-plan\`,
+After that, \`/visual-plan\` (and \`/ui-plan\`, \`/prototype-plan\`, \`/plan-design\`,
 \`/visual-questions\`, \`/visualize-plan\`) generate a plan and open the editor. Pass \`--no-connect\` to
 register the connector without authenticating, then run
 \`agent-native connect https://plan.agent-native.com\` whenever you are ready.
@@ -750,9 +753,10 @@ react to.
 
 \`/visual-plan\` remains the general command for architecture, backend, refactors,
 and mixed work. Use \`/prototype-plan\` when the UI review needs a functional live
-prototype instead of static screens. Use \`/visual-questions\` only when the user
-explicitly wants visual intake before planning, and \`/visualize-plan\` when a text
-plan already exists.
+prototype instead of static screens. Use \`/plan-design\` when polish, brand, or
+visual fidelity are material to the decision. Use \`/visual-questions\` only when
+the user explicitly wants visual intake before planning, and \`/visualize-plan\`
+when a text plan already exists.
 
 ## Plan Discipline
 
@@ -1097,6 +1101,8 @@ already shows. Never produce this.
 - \`create-ui-plan\`: create the UI-first structured visual plan.
 - \`create-prototype-plan\`: create a prototype-first plan when UI review needs a
   functional live prototype.
+- \`create-plan-design\`: create a full-fidelity branded design plan when polish,
+  brand, and detailed visual direction are primary review inputs.
 - \`convert-visual-plan-to-prototype\`: convert an existing HTML wireframe canvas
   into a prototype plan.
 - \`create-visual-questions\`: use only for the explicit \`/visual-questions\`
@@ -1132,7 +1138,7 @@ intended), so the first tool call does not hit an OAuth wall:
 agent-native skills add visual-plan
 \`\`\`
 
-After that, \`/visual-plan\` (and \`/ui-plan\`, \`/prototype-plan\`,
+After that, \`/visual-plan\` (and \`/ui-plan\`, \`/prototype-plan\`, \`/plan-design\`,
 \`/visual-questions\`, \`/visualize-plan\`) generate a plan and open the editor. Pass \`--no-connect\` to
 register the connector without authenticating, then run
 \`agent-native connect https://plan.agent-native.com\` whenever you are ready.
@@ -1318,6 +1324,118 @@ reviewing and iterating.
 - \`visual-questions\`
 `;
 
+export const PLAN_DESIGN_SKILL_MD =
+  [
+    "---",
+    "name: plan-design",
+    "description: >-",
+    "  Use Agent-Native Plans for full-fidelity UI design planning with a Design",
+    "  canvas tab and optional interactive Prototype tab before implementation.",
+    "metadata:",
+    "  visibility: exported",
+    "---",
+    "",
+    "# Plan Design",
+    "",
+    "Use `/plan-design` when the user needs a high-fidelity product design before",
+    "implementation: polished branded screens, realistic content, visual direction,",
+    "and interaction review. It is the full-fidelity companion to `/visual-plan` and",
+    "`/prototype-plan`: the top review surface should show `Design` and, when the",
+    "flow needs interaction, `Prototype`.",
+    "",
+    "## When To Use",
+    "",
+    "Use this for UI-heavy work where brand, visual hierarchy, polished layout, or",
+    "interaction feel are material to the decision. Skip it for small copy, spacing,",
+    "or obvious component changes.",
+    "",
+    "## Research First",
+    "",
+    "Before creating the plan:",
+    "",
+    "1. Inspect the real app shell, routes, components, CSS variables, Tailwind",
+    "   tokens, theme files, and any relevant screenshots.",
+    "2. If `design.md` exists, treat it as the primary design brief and pass its",
+    "   important content into `create-plan-design.designMd`.",
+    "3. If a `.fig` local-copy file or parsed brand kit is available, use the",
+    "   Design/brand-kit parsing actions from the app or shared tooling first, then",
+    "   pass the extracted token summary into `brandKit`.",
+    "4. Parse existing codebase style info when possible: CSS custom properties,",
+    "   Tailwind config, global CSS, font declarations, spacing/radius tokens, and",
+    "   component conventions. Pass the compact evidence into `codebaseStyles`.",
+    "5. Ground every screen in actual product content. Avoid lorem ipsum, generic",
+    "   marketing filler, and placeholder gray boxes unless designing an explicit",
+    "   loading state.",
+    "",
+    "## Create The Plan",
+    "",
+    "Call `create-plan-design` with:",
+    "",
+    "- `title`, `brief`, `repoPath`, and any `implementationNotes`.",
+    "- `designMd`, `brandKit`, `codebaseStyles`, or `designNotes` when available.",
+    "- `screens`: one to six full-fidelity HTML/CSS screen fragments. Each screen",
+    "  must include a bounded `html` fragment, optional scoped `css`, a `surface`,",
+    "  and stable `data-design-id` attributes on elements a reviewer might edit.",
+    "- `transitions` only when the Prototype tab should support true screen/step",
+    '  navigation. Use `data-goto="screen-id"` in the screen HTML for those controls.',
+    "",
+    "The Design tab is the visual source of truth. The Prototype tab is for behavior",
+    "and should reuse the same visual styling where practical. Do not create a",
+    "separate design direction in the prototype.",
+    "",
+    "## Full-Fidelity HTML Rules",
+    "",
+    "- Write bounded fragments only: no `<html>`, `<head>`, `<body>`, `<script>`,",
+    "  `<style>`, external imports, iframes, SVG, or executable URLs.",
+    "- Put CSS in the screen `css` field. The renderer scopes it to the artboard.",
+    "- Use real CSS and CSS variables. Tailwind-like class names are fine only when",
+    "  the provided `css` defines them or the classes are harmless semantic hooks.",
+    '- Use `renderMode: "design"` on design screen data when authoring full',
+    "  structured content directly.",
+    '- Add `data-design-id="meaningful-name"` to editable elements such as hero',
+    "  panels, key buttons, cards, nav items, pricing rows, chart panels, and state",
+    "  chips. Keep ids stable and descriptive.",
+    "- Keep the design responsive within the selected surface. Text must not clip,",
+    "  overlap, or rely on viewport-sized type.",
+    "",
+    "## Targeted Style Edits",
+    "",
+    "When a reviewer selects an element in the Design tab or asks for a specific",
+    "style change, avoid regenerating the whole plan. Use:",
+    "",
+    "```json",
+    "{",
+    '  "op": "update-design-element-style",',
+    '  "frameId": "frame-overview",',
+    '  "elementId": "primary-cta",',
+    '  "styles": {',
+    '    "background-color": "#0f766e",',
+    '    "border-radius": "10px"',
+    "  }",
+    "}",
+    "```",
+    "",
+    "Use `frameId` for inline canvas designs or `blockId` for a referenced wireframe",
+    "block. Set a style value to `null` to remove it. Use `patch-wireframe-html` or",
+    "`patch-prototype-html` for text/content changes inside a fragment.",
+    "",
+    "## Document Handoff",
+    "",
+    "Below the visual surface, keep the document concise and implementation-oriented:",
+    "actual files and symbols, state/actions/contracts, open questions, risks, and",
+    "verification. The document should not repeat the same screens in prose.",
+    "",
+    "Before implementation, call `get-plan-feedback` and treat comments, selected",
+    "element details, and recent review events as the source of truth.",
+    "",
+    "## Related Skills",
+    "",
+    "- `visual-plan`",
+    "- `ui-plan`",
+    "- `prototype-plan`",
+    "- `frontend-design`",
+  ].join("\n") + "\n";
+
 export const VISUAL_QUESTIONS_SKILL_MD = `---
 name: visual-questions
 description: >-
@@ -1334,7 +1452,7 @@ Use \`/visual-questions\` when the next best step is not a plan yet, but a
 reviewable visual intake: single-choice chips, multi-select chips, freeform
 notes, mockup choices, sketch diagrams, and a generated answer summary that feeds
 the next planning prompt. It composes with \`/visual-plan\`, \`/ui-plan\`,
-\`/prototype-plan\`, and \`/visualize-plan\`.
+\`/prototype-plan\`, \`/plan-design\`, and \`/visualize-plan\`.
 
 ## When To Use
 
@@ -1345,11 +1463,11 @@ the next planning prompt. It composes with \`/visual-plan\`, \`/ui-plan\`,
   than answering text-only prompts.
 
 Gate hard: skip this for tiny, unambiguous changes. If the agent can reasonably
-infer the answer, prefer \`/ui-plan\`, \`/prototype-plan\`, or \`/visual-plan\` directly and put
-assumptions in the plan.
+infer the answer, prefer \`/ui-plan\`, \`/prototype-plan\`, \`/plan-design\`, or
+\`/visual-plan\` directly and put assumptions in the plan.
 
 Visual questions are an explicit intake command, not an automatic preflight for
-\`/visual-plan\`, \`/ui-plan\`, or \`/prototype-plan\`.
+\`/visual-plan\`, \`/ui-plan\`, \`/prototype-plan\`, or \`/plan-design\`.
 
 ## Workflow
 
@@ -1360,6 +1478,7 @@ Visual questions are an explicit intake command, not an automatic preflight for
 3. Surface the returned Plans link and ask the user to answer visually.
 4. The generated summary drives the next step: \`create-ui-plan\` for static UI
    review, \`create-prototype-plan\` for click-through UI flows,
+   \`create-plan-design\` for high-fidelity branded UI review,
    \`create-visual-plan\` for general plans, \`visualize-plan\` when a text plan
    already exists, or \`update-visual-plan\` with targeted \`contentPatches\` to
    fold answers into an active plan.
@@ -1399,6 +1518,8 @@ desktop/mobile pair for a popover, panel, or component.
 - \`create-ui-plan\`: create a UI-first plan from the answers.
 - \`create-prototype-plan\`: create a prototype-first plan from the answers when
   interaction feel matters.
+- \`create-plan-design\`: create a high-fidelity branded design plan from the
+  answers when visual polish is the primary review input.
 - \`create-visual-plan\`: create a general visual plan from the answers.
 - \`visualize-plan\`: enrich an existing text plan after answers are gathered.
 - \`export-visual-plan\`: export answer plans as HTML, Markdown fallback,
@@ -1419,7 +1540,7 @@ intended), so the first tool call does not hit an OAuth wall:
 agent-native skills add visual-plan
 \`\`\`
 
-After that, \`/visual-plan\` (and \`/ui-plan\`, \`/prototype-plan\`,
+After that, \`/visual-plan\` (and \`/ui-plan\`, \`/prototype-plan\`, \`/plan-design\`,
 \`/visual-questions\`, \`/visualize-plan\`) generate a plan and open the editor. Pass \`--no-connect\` to
 register the connector without authenticating, then run
 \`agent-native connect https://plan.agent-native.com\` whenever you are ready.
@@ -1868,7 +1989,7 @@ intended), so the first tool call does not hit an OAuth wall:
 agent-native skills add visual-plan
 \`\`\`
 
-After that, \`/visual-plan\` (and \`/ui-plan\`, \`/prototype-plan\`,
+After that, \`/visual-plan\` (and \`/ui-plan\`, \`/prototype-plan\`, \`/plan-design\`,
 \`/visual-questions\`, \`/visualize-plan\`) generate a plan and open the editor. Pass \`--no-connect\` to
 register the connector without authenticating, then run
 \`agent-native connect https://plan.agent-native.com\` whenever you are ready.
@@ -1991,6 +2112,7 @@ const BUILT_IN_APP_SKILLS = {
       "visual-questions": VISUAL_QUESTIONS_SKILL_MD,
       "ui-plan": UI_PLAN_SKILL_MD,
       "prototype-plan": PROTOTYPE_PLAN_SKILL_MD,
+      "plan-design": PLAN_DESIGN_SKILL_MD,
       "visualize-plan": VISUALIZE_PLAN_SKILL_MD,
     },
     manifest: normalizeAppSkillManifest({
@@ -2007,7 +2129,7 @@ const BUILT_IN_APP_SKILLS = {
       auth: {
         mode: "oauth",
         setup:
-          "Install with the Agent-Native CLI to add /visual-plan, /visual-questions, /ui-plan, /prototype-plan, and /visualize-plan skills plus the Plans MCP connector. Authenticate only for hosted/account-backed sharing.",
+          "Install with the Agent-Native CLI to add the /visual-plan, /ui-plan, /prototype-plan, /plan-design, /visual-questions, and /visualize-plan skills plus the Plans MCP connector. Authenticate only for hosted/account-backed sharing.",
       },
       surfaces: [
         {
@@ -2037,6 +2159,13 @@ const BUILT_IN_APP_SKILLS = {
             "Create a prototype-first Agent-Native plan with a functional live prototype above the document.",
         },
         {
+          id: "plan-design",
+          action: "create-plan-design",
+          path: "/plans",
+          description:
+            "Create a full-fidelity Agent-Native design plan with a Design canvas tab and optional matching Prototype tab.",
+        },
+        {
           id: "visualize-plan",
           action: "visualize-plan",
           path: "/plans",
@@ -2062,6 +2191,11 @@ const BUILT_IN_APP_SKILLS = {
           path: "skills/prototype-plan",
           visibility: "exported",
           exportAs: "prototype-plan",
+        },
+        {
+          path: "skills/plan-design",
+          visibility: "exported",
+          exportAs: "plan-design",
         },
         {
           path: "skills/visualize-plan",
@@ -2150,6 +2284,10 @@ const BUILT_IN_APP_SKILL_ALIASES = {
   "ui-plans": "visual-plans",
   "prototype-plan": "visual-plans",
   "prototype-plans": "visual-plans",
+  "plan-design": "visual-plans",
+  "plan-designs": "visual-plans",
+  "design-plan": "visual-plans",
+  "design-plans": "visual-plans",
   prototype: "visual-plans",
   "visualize-plan": "visual-plans",
   "visualize-plans": "visual-plans",
@@ -2178,6 +2316,7 @@ const BUILT_IN_APP_SKILL_DISPLAY_ALIASES = {
     "visual-questions",
     "ui-plan",
     "prototype-plan",
+    "plan-design",
     "visualize-plan",
     "html-plan",
     "plannotate",

--- a/skills/plan-design/SKILL.md
+++ b/skills/plan-design/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: plan-design
+description: >-
+  Use Agent-Native Plans for full-fidelity UI design planning with a Design
+  canvas tab and optional interactive Prototype tab before implementation.
+metadata:
+  visibility: exported
+---
+
+# Plan Design
+
+Use `/plan-design` when the user needs a high-fidelity product design before
+implementation: polished branded screens, realistic content, visual direction,
+and interaction review. It is the full-fidelity companion to `/visual-plan` and
+`/prototype-plan`: the top review surface should show `Design` and, when the
+flow needs interaction, `Prototype`.
+
+## When To Use
+
+Use this for UI-heavy work where brand, visual hierarchy, polished layout, or
+interaction feel are material to the decision. Skip it for small copy, spacing,
+or obvious component changes.
+
+## Research First
+
+Before creating the plan:
+
+1. Inspect the real app shell, routes, components, CSS variables, Tailwind
+   tokens, theme files, and any relevant screenshots.
+2. If `design.md` exists, treat it as the primary design brief and pass its
+   important content into `create-plan-design.designMd`.
+3. If a `.fig` local-copy file or parsed brand kit is available, use the
+   Design/brand-kit parsing actions from the app or shared tooling first, then
+   pass the extracted token summary into `brandKit`.
+4. Parse existing codebase style info when possible: CSS custom properties,
+   Tailwind config, global CSS, font declarations, spacing/radius tokens, and
+   component conventions. Pass the compact evidence into `codebaseStyles`.
+5. Ground every screen in actual product content. Avoid lorem ipsum, generic
+   marketing filler, and placeholder gray boxes unless designing an explicit
+   loading state.
+
+## Create The Plan
+
+Call `create-plan-design` with:
+
+- `title`, `brief`, `repoPath`, and any `implementationNotes`.
+- `designMd`, `brandKit`, `codebaseStyles`, or `designNotes` when available.
+- `screens`: one to six full-fidelity HTML/CSS screen fragments. Each screen
+  must include a bounded `html` fragment, optional scoped `css`, a `surface`,
+  and stable `data-design-id` attributes on elements a reviewer might edit.
+- `transitions` only when the Prototype tab should support true screen/step
+  navigation. Use `data-goto="screen-id"` in the screen HTML for those controls.
+
+The Design tab is the visual source of truth. The Prototype tab is for behavior
+and should reuse the same visual styling where practical. Do not create a
+separate design direction in the prototype.
+
+## Full-Fidelity HTML Rules
+
+- Write bounded fragments only: no `<html>`, `<head>`, `<body>`, `<script>`,
+  `<style>`, external imports, iframes, SVG, or executable URLs.
+- Put CSS in the screen `css` field. The renderer scopes it to the artboard.
+- Use real CSS and CSS variables. Tailwind-like class names are fine only when
+  the provided `css` defines them or the classes are harmless semantic hooks.
+- Use `renderMode: "design"` on design screen data when authoring full
+  structured content directly.
+- Add `data-design-id="meaningful-name"` to editable elements such as hero
+  panels, key buttons, cards, nav items, pricing rows, chart panels, and state
+  chips. Keep ids stable and descriptive.
+- Keep the design responsive within the selected surface. Text must not clip,
+  overlap, or rely on viewport-sized type.
+
+## Targeted Style Edits
+
+When a reviewer selects an element in the Design tab or asks for a specific
+style change, avoid regenerating the whole plan. Use:
+
+```json
+{
+  "op": "update-design-element-style",
+  "frameId": "frame-overview",
+  "elementId": "primary-cta",
+  "styles": {
+    "background-color": "#0f766e",
+    "border-radius": "10px"
+  }
+}
+```
+
+Use `frameId` for inline canvas designs or `blockId` for a referenced wireframe
+block. Set a style value to `null` to remove it. Use `patch-wireframe-html` or
+`patch-prototype-html` for text/content changes inside a fragment.
+
+## Document Handoff
+
+Below the visual surface, keep the document concise and implementation-oriented:
+actual files and symbols, state/actions/contracts, open questions, risks, and
+verification. The document should not repeat the same screens in prose.
+
+Before implementation, call `get-plan-feedback` and treat comments, selected
+element details, and recent review events as the source of truth.
+
+## Related Skills
+
+- `visual-plan`
+- `ui-plan`
+- `prototype-plan`
+- `frontend-design`

--- a/skills/ui-plan/SKILL.md
+++ b/skills/ui-plan/SKILL.md
@@ -17,9 +17,10 @@ react to.
 
 `/visual-plan` remains the general command for architecture, backend, refactors,
 and mixed work. Use `/prototype-plan` when the UI review needs a functional live
-prototype instead of static screens. Use `/visual-questions` only when the user
-explicitly wants visual intake before planning, and `/visualize-plan` when a text
-plan already exists.
+prototype instead of static screens. Use `/plan-design` when polish, brand, or
+visual fidelity are material to the decision. Use `/visual-questions` only when
+the user explicitly wants visual intake before planning, and `/visualize-plan`
+when a text plan already exists.
 
 ## Plan Discipline
 
@@ -364,6 +365,8 @@ already shows. Never produce this.
 - `create-ui-plan`: create the UI-first structured visual plan.
 - `create-prototype-plan`: create a prototype-first plan when UI review needs a
   functional live prototype.
+- `create-plan-design`: create a full-fidelity branded design plan when polish,
+  brand, and detailed visual direction are primary review inputs.
 - `convert-visual-plan-to-prototype`: convert an existing HTML wireframe canvas
   into a prototype plan.
 - `create-visual-questions`: use only for the explicit `/visual-questions`
@@ -399,7 +402,7 @@ intended), so the first tool call does not hit an OAuth wall:
 agent-native skills add visual-plan
 ```
 
-After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`,
+After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`, `/plan-design`,
 `/visual-questions`, `/visualize-plan`) generate a plan and open the editor. Pass `--no-connect` to
 register the connector without authenticating, then run
 `agent-native connect https://plan.agent-native.com` whenever you are ready.

--- a/skills/visual-plans/SKILL.md
+++ b/skills/visual-plans/SKILL.md
@@ -19,6 +19,7 @@ user reacts to visuals first and reads prose only where it helps.
 `/visual-plan` is the canonical command and the main entry point. Use `/ui-plan`
 when the work is primarily product UI and review should start with the screens.
 Use `/prototype-plan` when review should start with a functional live prototype.
+Use `/plan-design` when review should start with full-fidelity branded design.
 Use `/visual-questions` only when the user explicitly wants a visual intake form
 before planning. Use `/visualize-plan` to turn an existing Codex, Claude Code,
 Markdown, or pasted plan into a visual companion.
@@ -407,6 +408,8 @@ already shows. Never produce this.
 - `create-ui-plan`: start a UI-first plan when the work is primarily product UI.
 - `create-prototype-plan`: start a prototype-first plan with a functional top
   review surface.
+- `create-plan-design`: start a full-fidelity branded Design-tab plan with an
+  optional matching Prototype tab.
 - `convert-visual-plan-to-prototype`: convert an existing HTML wireframe canvas
   into a prototype plan.
 - `create-visual-questions`: use only for the explicit `/visual-questions`
@@ -443,7 +446,7 @@ intended), so the first tool call does not hit an OAuth wall:
 agent-native skills add visual-plan
 ```
 
-After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`,
+After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`, `/plan-design`,
 `/visual-questions`, `/visualize-plan`) generate a plan and open the editor. Pass `--no-connect` to
 register the connector without authenticating, then run
 `agent-native connect https://plan.agent-native.com` whenever you are ready.

--- a/skills/visual-questions/SKILL.md
+++ b/skills/visual-questions/SKILL.md
@@ -14,7 +14,7 @@ Use `/visual-questions` when the next best step is not a plan yet, but a
 reviewable visual intake: single-choice chips, multi-select chips, freeform
 notes, mockup choices, sketch diagrams, and a generated answer summary that feeds
 the next planning prompt. It composes with `/visual-plan`, `/ui-plan`,
-`/prototype-plan`, and `/visualize-plan`.
+`/prototype-plan`, `/plan-design`, and `/visualize-plan`.
 
 ## When To Use
 
@@ -25,11 +25,11 @@ the next planning prompt. It composes with `/visual-plan`, `/ui-plan`,
   than answering text-only prompts.
 
 Gate hard: skip this for tiny, unambiguous changes. If the agent can reasonably
-infer the answer, prefer `/ui-plan`, `/prototype-plan`, or `/visual-plan` directly and put
-assumptions in the plan.
+infer the answer, prefer `/ui-plan`, `/prototype-plan`, `/plan-design`, or
+`/visual-plan` directly and put assumptions in the plan.
 
 Visual questions are an explicit intake command, not an automatic preflight for
-`/visual-plan`, `/ui-plan`, or `/prototype-plan`.
+`/visual-plan`, `/ui-plan`, `/prototype-plan`, or `/plan-design`.
 
 ## Workflow
 
@@ -40,6 +40,7 @@ Visual questions are an explicit intake command, not an automatic preflight for
 3. Surface the returned Plans link and ask the user to answer visually.
 4. The generated summary drives the next step: `create-ui-plan` for static UI
    review, `create-prototype-plan` for click-through UI flows,
+   `create-plan-design` for high-fidelity branded UI review,
    `create-visual-plan` for general plans, `visualize-plan` when a text plan
    already exists, or `update-visual-plan` with targeted `contentPatches` to
    fold answers into an active plan.
@@ -79,6 +80,8 @@ desktop/mobile pair for a popover, panel, or component.
 - `create-ui-plan`: create a UI-first plan from the answers.
 - `create-prototype-plan`: create a prototype-first plan from the answers when
   interaction feel matters.
+- `create-plan-design`: create a high-fidelity branded design plan from the
+  answers when visual polish is the primary review input.
 - `create-visual-plan`: create a general visual plan from the answers.
 - `visualize-plan`: enrich an existing text plan after answers are gathered.
 - `export-visual-plan`: export answer plans as HTML, Markdown fallback,
@@ -99,7 +102,7 @@ intended), so the first tool call does not hit an OAuth wall:
 agent-native skills add visual-plan
 ```
 
-After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`,
+After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`, `/plan-design`,
 `/visual-questions`, `/visualize-plan`) generate a plan and open the editor. Pass `--no-connect` to
 register the connector without authenticating, then run
 `agent-native connect https://plan.agent-native.com` whenever you are ready.

--- a/skills/visualize-plan/SKILL.md
+++ b/skills/visualize-plan/SKILL.md
@@ -421,7 +421,7 @@ intended), so the first tool call does not hit an OAuth wall:
 agent-native skills add visual-plan
 ```
 
-After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`,
+After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`, `/plan-design`,
 `/visual-questions`, `/visualize-plan`) generate a plan and open the editor. Pass `--no-connect` to
 register the connector without authenticating, then run
 `agent-native connect https://plan.agent-native.com` whenever you are ready.

--- a/templates/plan/.agents/skills/plan-design/SKILL.md
+++ b/templates/plan/.agents/skills/plan-design/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: plan-design
+description: >-
+  Use Agent-Native Plans for full-fidelity UI design planning with a Design
+  canvas tab and optional interactive Prototype tab before implementation.
+metadata:
+  visibility: exported
+---
+
+# Plan Design
+
+Use `/plan-design` when the user needs a high-fidelity product design before
+implementation: polished branded screens, realistic content, visual direction,
+and interaction review. It is the full-fidelity companion to `/visual-plan` and
+`/prototype-plan`: the top review surface should show `Design` and, when the
+flow needs interaction, `Prototype`.
+
+## When To Use
+
+Use this for UI-heavy work where brand, visual hierarchy, polished layout, or
+interaction feel are material to the decision. Skip it for small copy, spacing,
+or obvious component changes.
+
+## Research First
+
+Before creating the plan:
+
+1. Inspect the real app shell, routes, components, CSS variables, Tailwind
+   tokens, theme files, and any relevant screenshots.
+2. If `design.md` exists, treat it as the primary design brief and pass its
+   important content into `create-plan-design.designMd`.
+3. If a `.fig` local-copy file or parsed brand kit is available, use the
+   Design/brand-kit parsing actions from the app or shared tooling first, then
+   pass the extracted token summary into `brandKit`.
+4. Parse existing codebase style info when possible: CSS custom properties,
+   Tailwind config, global CSS, font declarations, spacing/radius tokens, and
+   component conventions. Pass the compact evidence into `codebaseStyles`.
+5. Ground every screen in actual product content. Avoid lorem ipsum, generic
+   marketing filler, and placeholder gray boxes unless designing an explicit
+   loading state.
+
+## Create The Plan
+
+Call `create-plan-design` with:
+
+- `title`, `brief`, `repoPath`, and any `implementationNotes`.
+- `designMd`, `brandKit`, `codebaseStyles`, or `designNotes` when available.
+- `screens`: one to six full-fidelity HTML/CSS screen fragments. Each screen
+  must include a bounded `html` fragment, optional scoped `css`, a `surface`,
+  and stable `data-design-id` attributes on elements a reviewer might edit.
+- `transitions` only when the Prototype tab should support true screen/step
+  navigation. Use `data-goto="screen-id"` in the screen HTML for those controls.
+
+The Design tab is the visual source of truth. The Prototype tab is for behavior
+and should reuse the same visual styling where practical. Do not create a
+separate design direction in the prototype.
+
+## Full-Fidelity HTML Rules
+
+- Write bounded fragments only: no `<html>`, `<head>`, `<body>`, `<script>`,
+  `<style>`, external imports, iframes, SVG, or executable URLs.
+- Put CSS in the screen `css` field. The renderer scopes it to the artboard.
+- Use real CSS and CSS variables. Tailwind-like class names are fine only when
+  the provided `css` defines them or the classes are harmless semantic hooks.
+- Use `renderMode: "design"` on design screen data when authoring full
+  structured content directly.
+- Add `data-design-id="meaningful-name"` to editable elements such as hero
+  panels, key buttons, cards, nav items, pricing rows, chart panels, and state
+  chips. Keep ids stable and descriptive.
+- Keep the design responsive within the selected surface. Text must not clip,
+  overlap, or rely on viewport-sized type.
+
+## Targeted Style Edits
+
+When a reviewer selects an element in the Design tab or asks for a specific
+style change, avoid regenerating the whole plan. Use:
+
+```json
+{
+  "op": "update-design-element-style",
+  "frameId": "frame-overview",
+  "elementId": "primary-cta",
+  "styles": {
+    "background-color": "#0f766e",
+    "border-radius": "10px"
+  }
+}
+```
+
+Use `frameId` for inline canvas designs or `blockId` for a referenced wireframe
+block. Set a style value to `null` to remove it. Use `patch-wireframe-html` or
+`patch-prototype-html` for text/content changes inside a fragment.
+
+## Document Handoff
+
+Below the visual surface, keep the document concise and implementation-oriented:
+actual files and symbols, state/actions/contracts, open questions, risks, and
+verification. The document should not repeat the same screens in prose.
+
+Before implementation, call `get-plan-feedback` and treat comments, selected
+element details, and recent review events as the source of truth.
+
+## Related Skills
+
+- `visual-plan`
+- `ui-plan`
+- `prototype-plan`
+- `frontend-design`

--- a/templates/plan/.agents/skills/ui-plan/SKILL.md
+++ b/templates/plan/.agents/skills/ui-plan/SKILL.md
@@ -17,9 +17,10 @@ react to.
 
 `/visual-plan` remains the general command for architecture, backend, refactors,
 and mixed work. Use `/prototype-plan` when the UI review needs a functional live
-prototype instead of static screens. Use `/visual-questions` only when the user
-explicitly wants visual intake before planning, and `/visualize-plan` when a text
-plan already exists.
+prototype instead of static screens. Use `/plan-design` when polish, brand, or
+visual fidelity are material to the decision. Use `/visual-questions` only when
+the user explicitly wants visual intake before planning, and `/visualize-plan`
+when a text plan already exists.
 
 ## Plan Discipline
 
@@ -364,6 +365,8 @@ already shows. Never produce this.
 - `create-ui-plan`: create the UI-first structured visual plan.
 - `create-prototype-plan`: create a prototype-first plan when UI review needs a
   functional live prototype.
+- `create-plan-design`: create a full-fidelity branded design plan when polish,
+  brand, and detailed visual direction are primary review inputs.
 - `convert-visual-plan-to-prototype`: convert an existing HTML wireframe canvas
   into a prototype plan.
 - `create-visual-questions`: use only for the explicit `/visual-questions`
@@ -399,7 +402,7 @@ intended), so the first tool call does not hit an OAuth wall:
 agent-native skills add visual-plan
 ```
 
-After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`,
+After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`, `/plan-design`,
 `/visual-questions`, `/visualize-plan`) generate a plan and open the editor. Pass `--no-connect` to
 register the connector without authenticating, then run
 `agent-native connect https://plan.agent-native.com` whenever you are ready.

--- a/templates/plan/.agents/skills/visual-plan/SKILL.md
+++ b/templates/plan/.agents/skills/visual-plan/SKILL.md
@@ -19,6 +19,7 @@ user reacts to visuals first and reads prose only where it helps.
 `/visual-plan` is the canonical command and the main entry point. Use `/ui-plan`
 when the work is primarily product UI and review should start with the screens.
 Use `/prototype-plan` when review should start with a functional live prototype.
+Use `/plan-design` when review should start with full-fidelity branded design.
 Use `/visual-questions` only when the user explicitly wants a visual intake form
 before planning. Use `/visualize-plan` to turn an existing Codex, Claude Code,
 Markdown, or pasted plan into a visual companion.
@@ -407,6 +408,8 @@ already shows. Never produce this.
 - `create-ui-plan`: start a UI-first plan when the work is primarily product UI.
 - `create-prototype-plan`: start a prototype-first plan with a functional top
   review surface.
+- `create-plan-design`: start a full-fidelity branded Design-tab plan with an
+  optional matching Prototype tab.
 - `convert-visual-plan-to-prototype`: convert an existing HTML wireframe canvas
   into a prototype plan.
 - `create-visual-questions`: use only for the explicit `/visual-questions`
@@ -443,7 +446,7 @@ intended), so the first tool call does not hit an OAuth wall:
 agent-native skills add visual-plan
 ```
 
-After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`,
+After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`, `/plan-design`,
 `/visual-questions`, `/visualize-plan`) generate a plan and open the editor. Pass `--no-connect` to
 register the connector without authenticating, then run
 `agent-native connect https://plan.agent-native.com` whenever you are ready.

--- a/templates/plan/.agents/skills/visual-questions/SKILL.md
+++ b/templates/plan/.agents/skills/visual-questions/SKILL.md
@@ -14,7 +14,7 @@ Use `/visual-questions` when the next best step is not a plan yet, but a
 reviewable visual intake: single-choice chips, multi-select chips, freeform
 notes, mockup choices, sketch diagrams, and a generated answer summary that feeds
 the next planning prompt. It composes with `/visual-plan`, `/ui-plan`,
-`/prototype-plan`, and `/visualize-plan`.
+`/prototype-plan`, `/plan-design`, and `/visualize-plan`.
 
 ## When To Use
 
@@ -25,11 +25,11 @@ the next planning prompt. It composes with `/visual-plan`, `/ui-plan`,
   than answering text-only prompts.
 
 Gate hard: skip this for tiny, unambiguous changes. If the agent can reasonably
-infer the answer, prefer `/ui-plan`, `/prototype-plan`, or `/visual-plan` directly and put
-assumptions in the plan.
+infer the answer, prefer `/ui-plan`, `/prototype-plan`, `/plan-design`, or
+`/visual-plan` directly and put assumptions in the plan.
 
 Visual questions are an explicit intake command, not an automatic preflight for
-`/visual-plan`, `/ui-plan`, or `/prototype-plan`.
+`/visual-plan`, `/ui-plan`, `/prototype-plan`, or `/plan-design`.
 
 ## Workflow
 
@@ -40,6 +40,7 @@ Visual questions are an explicit intake command, not an automatic preflight for
 3. Surface the returned Plans link and ask the user to answer visually.
 4. The generated summary drives the next step: `create-ui-plan` for static UI
    review, `create-prototype-plan` for click-through UI flows,
+   `create-plan-design` for high-fidelity branded UI review,
    `create-visual-plan` for general plans, `visualize-plan` when a text plan
    already exists, or `update-visual-plan` with targeted `contentPatches` to
    fold answers into an active plan.
@@ -79,6 +80,8 @@ desktop/mobile pair for a popover, panel, or component.
 - `create-ui-plan`: create a UI-first plan from the answers.
 - `create-prototype-plan`: create a prototype-first plan from the answers when
   interaction feel matters.
+- `create-plan-design`: create a high-fidelity branded design plan from the
+  answers when visual polish is the primary review input.
 - `create-visual-plan`: create a general visual plan from the answers.
 - `visualize-plan`: enrich an existing text plan after answers are gathered.
 - `export-visual-plan`: export answer plans as HTML, Markdown fallback,
@@ -99,7 +102,7 @@ intended), so the first tool call does not hit an OAuth wall:
 agent-native skills add visual-plan
 ```
 
-After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`,
+After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`, `/plan-design`,
 `/visual-questions`, `/visualize-plan`) generate a plan and open the editor. Pass `--no-connect` to
 register the connector without authenticating, then run
 `agent-native connect https://plan.agent-native.com` whenever you are ready.

--- a/templates/plan/.agents/skills/visualize-plan/SKILL.md
+++ b/templates/plan/.agents/skills/visualize-plan/SKILL.md
@@ -421,7 +421,7 @@ intended), so the first tool call does not hit an OAuth wall:
 agent-native skills add visual-plan
 ```
 
-After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`,
+After that, `/visual-plan` (and `/ui-plan`, `/prototype-plan`, `/plan-design`,
 `/visual-questions`, `/visualize-plan`) generate a plan and open the editor. Pass `--no-connect` to
 register the connector without authenticating, then run
 `agent-native connect https://plan.agent-native.com` whenever you are ready.

--- a/templates/plan/AGENTS.md
+++ b/templates/plan/AGENTS.md
@@ -55,6 +55,15 @@ prototype. Prototype plans keep static mocks in the document and use the top
 viewer for clickable review, comments, rough/clean mode, dark/light mode, and
 prototype popout.
 
+Use `/plan-design` when the user needs full-fidelity, branded UI design before
+implementation. Research the real app shell, `design.md` if present, `.fig`
+brand-kit/design-system data when available, and codebase CSS/Tailwind/token
+signals. Call `create-plan-design` with high-fidelity bounded HTML/CSS screens
+for the Design tab, stable `data-design-id` attributes for targeted element
+style edits, and transitions only when a matching Prototype tab should be
+clickable. Treat the Design tab as the visual source of truth and the Prototype
+tab as the same direction made interactive.
+
 The markdown/document portion should stay close to the plan the agent would
 normally produce. Diagrams, wireframes, mockups, annotations, and an optional
 bottom `question-form` Open Questions block are additive review aids, not a
@@ -80,6 +89,8 @@ Document Quality cores, so do not restate those rules here.
   the screens.
 - `.agents/skills/prototype-plan/SKILL.md` — `/prototype-plan`, clickable
   prototype-first planning and visual-plan conversion.
+- `.agents/skills/plan-design/SKILL.md` — `/plan-design`, full-fidelity branded
+  Design tab plus optional matching Prototype tab.
 - `.agents/skills/visual-questions/SKILL.md` — `/visual-questions`, visual intake
   before a plan.
 - `.agents/skills/visualize-plan/SKILL.md` — `/visualize-plan`, a companion for
@@ -112,6 +123,11 @@ sync-guarded skills (not just one stored plan) so the improvement sticks.
 - Canvas, artboard, wireframe, diagram, and custom visual edits remain driven by
   comments, source patches, or structured content patches rather than direct
   rich-text editing.
+- Design-mode artboards can be element-edited with `update-visual-plan`
+  `contentPatches: [{ op: "update-design-element-style", frameId, blockId,
+elementId, styles }]`. Elements must have `data-design-id` or
+  `data-plan-design-id`; use `patch-wireframe-html` / `patch-prototype-html` for
+  structural or text changes.
 - Plan comments include reviewer identity, @mentions, resolver intent
   (`agent` or `human`), exact anchors, and Figma-style threads. When adding
   human feedback through `update-visual-plan`, preserve `authorEmail` and

--- a/templates/plan/actions/create-plan-design.ts
+++ b/templates/plan/actions/create-plan-design.ts
@@ -1,0 +1,371 @@
+import { defineAction, embedApp } from "@agent-native/core";
+import {
+  getRequestOrgId,
+  getRequestUserEmail,
+  getRequestUserName,
+} from "@agent-native/core/server/request-context";
+import { z } from "zod";
+import { getDb, schema } from "../server/db/index.js";
+import {
+  createPlanDesignContent,
+  normalizePlanDesignContent,
+  serializePlanContent,
+} from "../server/plan-content.js";
+import {
+  isLocalPlanRuntime,
+  requirePlanOwnerEmailForWrite,
+} from "../server/lib/local-identity.js";
+import { assertGuestCreateWithinLimits } from "../server/lib/guest-abuse.js";
+import { writePlanLocalFiles } from "../server/lib/local-plan-files.js";
+import {
+  buildPlanHtml,
+  commentInputSchema,
+  insertInitialPlanComments,
+  loadPlanBundle,
+  newId,
+  nowIso,
+  planDeepLink,
+  planPath,
+  planSourceSchema,
+  planStatusSchema,
+  sectionInputSchema,
+  writeEvent,
+} from "../server/plans.js";
+import { planContentSchema } from "../shared/plan-content.js";
+
+const designSurfaceSchema = z.enum([
+  "desktop",
+  "mobile",
+  "popover",
+  "panel",
+  "browser",
+]);
+
+const designScreenSchema = z.object({
+  id: z.string().trim().min(1).max(120).optional().describe("Stable screen id"),
+  title: z.string().min(1).max(180).describe("Design screen title"),
+  summary: z
+    .string()
+    .max(500)
+    .optional()
+    .describe("What the reviewer should inspect on this screen"),
+  surface: designSurfaceSchema.optional().default("browser"),
+  html: z
+    .string()
+    .max(40_000)
+    .optional()
+    .describe(
+      "Bounded full-fidelity HTML fragment for this design screen. Use real content, semantic structure, Tailwind-like class names if helpful, and `data-design-id` attributes on editable elements. Never include html/body/script/style tags.",
+    ),
+  css: z
+    .string()
+    .max(20_000)
+    .optional()
+    .describe(
+      "Scoped CSS for the design screen. Prefer CSS variables and brand tokens; never include style tags, imports, scripts, or executable URLs.",
+    ),
+  state: z
+    .array(
+      z.object({
+        id: z.string().trim().min(1).max(120).optional(),
+        label: z.string().min(1).max(80),
+        value: z.string().max(180),
+      }),
+    )
+    .max(24)
+    .optional(),
+});
+
+const designTransitionSchema = z.object({
+  id: z.string().trim().min(1).max(120).optional(),
+  from: z.string().min(1).max(120),
+  to: z.string().min(1).max(120),
+  label: z.string().max(120).optional(),
+  trigger: z.string().max(240).optional(),
+});
+
+const DESIGN_CONTEXT_JSON_MAX = 20_000;
+
+const designContextRecordSchema = z.record(z.string(), z.unknown()).refine(
+  (value) => {
+    try {
+      return JSON.stringify(value).length <= DESIGN_CONTEXT_JSON_MAX;
+    } catch {
+      return false;
+    }
+  },
+  { message: "Design context metadata is too large." },
+);
+
+export default defineAction({
+  description:
+    "Create a /plan-design Agent-Native plan: a full-fidelity Design tab on a Figma-style canvas, plus a matching Prototype tab when interaction or flow review is useful. Use design.md, parsed .fig brand kits, and codebase CSS/Tailwind/token evidence when available. Design screens are bounded HTML/CSS fragments with `data-design-id` targets for specific style edits.",
+  schema: z
+    .object({
+      title: z.string().optional().describe("Short design plan title"),
+      brief: z.string().optional().describe("Plain-language design brief"),
+      goal: z
+        .string()
+        .optional()
+        .describe("Compatibility alias for brief; prefer brief"),
+      source: planSourceSchema.optional().default("manual"),
+      repoPath: z.string().optional().describe("Repository path for the run"),
+      currentFocus: z
+        .string()
+        .optional()
+        .describe("Current design review focus"),
+      status: planStatusSchema.optional().default("review"),
+      content: planContentSchema
+        .optional()
+        .describe(
+          "Full structured content when the caller has already authored the design/prototype. Prefer screens/transitions for normal /plan-design creation.",
+        ),
+      screens: z
+        .array(designScreenSchema)
+        .max(6)
+        .optional()
+        .default([])
+        .describe(
+          "Full-fidelity design screens. Include one to six substantial screens/states with real labels, brand styling, and data-design-id attributes on editable elements. Use CSS for Tailwind-like utility classes because the Plan renderer does not load arbitrary CDN scripts.",
+        ),
+      transitions: z
+        .array(designTransitionSchema)
+        .max(24)
+        .optional()
+        .default([])
+        .describe(
+          "Expected screen transitions for the Prototype tab. Use data-goto attributes in screen HTML for true route/step changes.",
+        ),
+      designMd: z
+        .string()
+        .max(100_000)
+        .optional()
+        .describe("Optional design.md content used as design direction"),
+      brandKit: designContextRecordSchema
+        .optional()
+        .describe("Optional parsed brand kit or .fig design-system data"),
+      codebaseStyles: designContextRecordSchema
+        .optional()
+        .describe(
+          "Optional parsed CSS vars, Tailwind tokens, fonts, and colors",
+        ),
+      designNotes: z
+        .string()
+        .max(20_000)
+        .optional()
+        .describe("Concise notes about brand/style assumptions"),
+      implementationNotes: z
+        .string()
+        .max(20_000)
+        .optional()
+        .describe("Concise notes for the implementation map section"),
+      markdown: z
+        .string()
+        .max(100_000)
+        .optional()
+        .describe("Markdown/text fallback or source design plan"),
+      sections: z
+        .array(sectionInputSchema)
+        .optional()
+        .default([])
+        .describe("Optional legacy plan sections"),
+      comments: z
+        .array(commentInputSchema)
+        .optional()
+        .default([])
+        .describe("Initial annotations or review prompts"),
+    })
+    .refine((args) => Boolean(args.brief || args.goal), {
+      message: "Either brief or goal is required.",
+    }),
+  publicAgent: {
+    expose: true,
+    readOnly: false,
+    requiresAuth: true,
+    isConsequential: true,
+    title: "Create Plan Design",
+    description:
+      "Create a plan whose primary review surface is a full-fidelity design canvas.",
+  },
+  mcpApp: {
+    compactCatalog: true,
+    resource: embedApp({
+      title: "Plan Design",
+      description:
+        "Open the Agent-Native Plans design review surface for full-fidelity screens, prototype behavior, comments, and implementation notes.",
+      iframeTitle: "Agent-Native Plans",
+      openLabel: "Open Plan Design",
+      height: 860,
+    }),
+  },
+  run: async (args) => {
+    const requesterEmail = getRequestUserEmail();
+    const requesterName = getRequestUserName();
+    const ownerEmail = requirePlanOwnerEmailForWrite(
+      requesterEmail,
+      "Creating a plan design",
+    );
+    await assertGuestCreateWithinLimits(ownerEmail);
+
+    const id = newId("plan");
+    const now = nowIso();
+    const brief = args.brief || args.goal || "";
+    const title = args.title || "Untitled plan design";
+    const sections =
+      args.sections.length > 0
+        ? args.sections
+        : [
+            {
+              type: "summary" as const,
+              title: "Design objective",
+              body: brief,
+              order: 0,
+              createdBy: "agent" as const,
+            },
+            {
+              type: "prototype" as const,
+              title: "Design and prototype",
+              body: "The Design tab is a full-fidelity, brand-aware canvas. The Prototype tab uses the same screen HTML/CSS when interaction review is useful.",
+              order: 1,
+              createdBy: "agent" as const,
+            },
+            {
+              type: "implementation" as const,
+              title: "Implementation map",
+              body:
+                args.implementationNotes ||
+                "Add file references, symbols, and short code previews once the design direction is approved.",
+              order: 2,
+              createdBy: "agent" as const,
+            },
+          ];
+    const content = (() => {
+      try {
+        return args.content
+          ? normalizePlanDesignContent(args.content, {
+              title,
+              brief,
+              source: args.source,
+              repoPath: args.repoPath,
+              screens: args.screens,
+              transitions: args.transitions,
+              designMd: args.designMd,
+              brandKit: args.brandKit,
+              codebaseStyles: args.codebaseStyles,
+              designNotes: args.designNotes,
+              implementationNotes: args.implementationNotes,
+            })
+          : createPlanDesignContent({
+              title,
+              brief,
+              source: args.source,
+              repoPath: args.repoPath,
+              screens: args.screens,
+              transitions: args.transitions,
+              designMd: args.designMd,
+              brandKit: args.brandKit,
+              codebaseStyles: args.codebaseStyles,
+              designNotes: args.designNotes,
+              implementationNotes: args.implementationNotes,
+            });
+      } catch (error) {
+        throw Object.assign(
+          new Error(
+            `Invalid plan design content: ${(error as Error)?.message ?? "validation failed"}`,
+          ),
+          { statusCode: 400 },
+        );
+      }
+    })();
+
+    await getDb()
+      .insert(schema.plans)
+      .values({
+        id,
+        title,
+        brief,
+        status: args.status,
+        source: args.source,
+        repoPath: args.repoPath ?? null,
+        currentFocus: args.currentFocus ?? "design review",
+        html: null,
+        markdown: args.markdown ?? null,
+        content: content ? serializePlanContent(content) : null,
+        createdAt: now,
+        updatedAt: now,
+        approvedAt: args.status === "approved" ? now : null,
+        ownerEmail,
+        orgId: getRequestOrgId(),
+        visibility: "private",
+      });
+
+    await getDb()
+      .insert(schema.planSections)
+      .values(
+        sections.map((section, index) => ({
+          id: section.id ?? newId("sec"),
+          planId: id,
+          type: section.type,
+          title: section.title,
+          body: section.body,
+          html: section.html ?? null,
+          order: section.order ?? index,
+          createdBy: section.createdBy,
+          createdAt: now,
+          updatedAt: now,
+        })),
+      );
+
+    await insertInitialPlanComments({
+      planId: id,
+      comments: args.comments,
+      requestEmail: requesterEmail,
+      requestName: requesterName,
+      now,
+    });
+
+    await writeEvent({
+      planId: id,
+      type: "plan.design_created",
+      message: "Full-fidelity plan design created.",
+      payload: {
+        screens: args.screens.map((screen) => screen.title),
+        hasDesignMd: Boolean(args.designMd),
+        hasBrandKit: Boolean(args.brandKit),
+        hasCodebaseStyles: Boolean(args.codebaseStyles),
+      },
+      createdBy: "agent",
+    });
+
+    const bundle = await loadPlanBundle(id);
+    const local = isLocalPlanRuntime()
+      ? await writePlanLocalFiles({
+          planId: id,
+          title: bundle.plan.title,
+          brief: bundle.plan.brief,
+          content: bundle.plan.content,
+          url: planPath(id),
+        })
+      : null;
+
+    return {
+      ...bundle,
+      planId: id,
+      html: buildPlanHtml(bundle),
+      path: planPath(id),
+      url: planPath(id),
+      ...(local?.written ? { localFiles: local } : {}),
+      fallbackInstructions:
+        "Open the Agent-Native Plans link, review the full-fidelity Design tab first, click through the Prototype tab when present, add comments or targeted style edits, then I will call get-plan-feedback before continuing.",
+    };
+  },
+  link: ({ result }) => {
+    const plan = (result as { plan?: { id?: string } } | null)?.plan;
+    if (!plan?.id) return null;
+    return {
+      url: planDeepLink(plan.id),
+      label: "Open Plan Design",
+      view: "plan",
+    };
+  },
+});

--- a/templates/plan/agent-native.app-skill.json
+++ b/templates/plan/agent-native.app-skill.json
@@ -22,7 +22,7 @@
   },
   "auth": {
     "mode": "oauth",
-    "setup": "Install with the Agent-Native CLI to add the /visual-plan, /ui-plan, /prototype-plan, /visual-questions, and /visualize-plan skills plus the Plans MCP connector. Plans use the app session for scoped storage and review; Google sign-in is available when OAuth env vars are configured."
+    "setup": "Install with the Agent-Native CLI to add the /visual-plan, /ui-plan, /prototype-plan, /plan-design, /visual-questions, and /visualize-plan skills plus the Plans MCP connector. Plans use the app session for scoped storage and review; Google sign-in is available when OAuth env vars are configured."
   },
   "surfaces": [
     {
@@ -42,6 +42,12 @@
       "action": "create-prototype-plan",
       "path": "/plans",
       "description": "Create a prototype-first Agent-Native plan with a functional live prototype above the document."
+    },
+    {
+      "id": "plan-design",
+      "action": "create-plan-design",
+      "path": "/plans",
+      "description": "Create a full-fidelity Agent-Native design plan with a Design canvas tab and optional matching Prototype tab."
     },
     {
       "id": "visual-questions",
@@ -71,6 +77,11 @@
       "path": ".agents/skills/prototype-plan",
       "visibility": "both",
       "exportAs": "prototype-plan"
+    },
+    {
+      "path": ".agents/skills/plan-design",
+      "visibility": "both",
+      "exportAs": "plan-design"
     },
     {
       "path": ".agents/skills/visual-questions",

--- a/templates/plan/app/components/plan/CanvasArea.tsx
+++ b/templates/plan/app/components/plan/CanvasArea.tsx
@@ -23,7 +23,7 @@ import type {
   PlanContent,
   PlanWireframeSurface,
 } from "@shared/plan-content";
-import { Wireframe } from "./wireframe/Wireframe";
+import { Wireframe, type DesignElementSelection } from "./wireframe/Wireframe";
 
 /* -------------------------------------------------------------------------- */
 /* Pan / zoom feel — recovered from the on-main hardcoded renderer            */
@@ -59,6 +59,8 @@ export type CanvasMarkupCreateContext = {
   };
 };
 
+export type { DesignElementSelection };
+
 type WorldPoint = {
   x: number;
   y: number;
@@ -93,6 +95,8 @@ export function CanvasArea({
   blockLookup,
   markupMode = "none",
   onCanvasMarkupCreate,
+  selectedDesignElementKey,
+  onDesignElementSelect,
 }: {
   canvas: NonNullable<PlanContent["canvas"]>;
   blockLookup: Map<string, PlanBlock>;
@@ -101,6 +105,8 @@ export function CanvasArea({
     annotation: CanvasMarkupAnnotationInput,
     context: CanvasMarkupCreateContext,
   ) => Promise<void> | void;
+  selectedDesignElementKey?: string | null;
+  onDesignElementSelect?: (selection: DesignElementSelection) => void;
 }) {
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const initialView = useMemo<CanvasView>(
@@ -264,6 +270,47 @@ export function CanvasArea({
     );
     return { width: maxX + 360, height: maxY + 280 };
   }, [frames, annotations, legacyNotes]);
+
+  const hasSavedViewport = Boolean(
+    canvas.viewport?.zoom !== undefined ||
+    canvas.viewport?.pan?.x !== undefined ||
+    canvas.viewport?.pan?.y !== undefined,
+  );
+
+  useEffect(() => {
+    if (hasSavedViewport || canvas.mode !== "design") return;
+    const element = viewportRef.current;
+    const firstFrame = frames[0];
+    if (!element || !firstFrame) return;
+    const frameWidth =
+      firstFrame.width ?? SURFACE_SIZE[surfaceOf(firstFrame)].width;
+    const frameHeight =
+      firstFrame.height ?? SURFACE_SIZE[surfaceOf(firstFrame)].height;
+    const zoom = clamp(
+      Math.min(
+        DEFAULT_VIEW.zoom,
+        (element.clientWidth - 48) / frameWidth,
+        (element.clientHeight - 48) / frameHeight,
+      ),
+      MIN_ZOOM,
+      MAX_ZOOM,
+    );
+    setView({
+      zoom,
+      pan: {
+        x: Math.max(
+          16,
+          (element.clientWidth - frameWidth * zoom) / 2 -
+            (firstFrame.x ?? 96) * zoom,
+        ),
+        y: Math.max(
+          24,
+          (element.clientHeight - frameHeight * zoom) / 2 -
+            (firstFrame.y ?? 96) * zoom,
+        ),
+      },
+    });
+  }, [canvas.mode, frames, hasSavedViewport]);
 
   const { zoom, pan } = view;
   const isCanvasMarkupMode =
@@ -445,6 +492,13 @@ export function CanvasArea({
     const target = event.target as HTMLElement;
     // Don't start a pan when grabbing interactive chrome (zoom controls etc.).
     if (event.button === 0 && target.closest("[data-plan-interactive]")) return;
+    if (
+      event.button === 0 &&
+      onDesignElementSelect &&
+      target.closest("[data-design-id], [data-plan-design-id]")
+    ) {
+      return;
+    }
     if (markupMode === "comment") return;
     if (isCanvasMarkupMode && event.button === 0) {
       const point = clientPointToWorld(event);
@@ -572,6 +626,7 @@ export function CanvasArea({
               key={`${edge.from}-${edge.to}-${index}`}
               edge={edge}
               frameById={measuredFrameById}
+              showLabel={false}
             />
           ))}
 
@@ -598,6 +653,18 @@ export function CanvasArea({
               frame={frame}
               block={frame.blockId ? blockLookup.get(frame.blockId) : undefined}
               onMeasure={reportFrameHeight}
+              selectedDesignElementKey={selectedDesignElementKey}
+              onDesignElementSelect={
+                markupMode === "none" ? onDesignElementSelect : undefined
+              }
+            />
+          ))}
+
+          {connectors.map((edge, index) => (
+            <CanvasConnectorLabel
+              key={`connector-label-${edge.from}-${edge.to}-${index}`}
+              edge={edge}
+              frameById={measuredFrameById}
             />
           ))}
 
@@ -796,10 +863,14 @@ function CanvasArtboard({
   frame,
   block,
   onMeasure,
+  selectedDesignElementKey,
+  onDesignElementSelect,
 }: {
   frame: PlanArtboard;
   block?: PlanBlock;
   onMeasure?: (id: string, height: number) => void;
+  selectedDesignElementKey?: string | null;
+  onDesignElementSelect?: (selection: DesignElementSelection) => void;
 }) {
   const surface = surfaceOf(frame);
   const preset = SURFACE_SIZE[surface];
@@ -858,6 +929,10 @@ function CanvasArtboard({
             data={kitData as unknown as Parameters<typeof Wireframe>[0]["data"]}
             canvasSize={height}
             canvasWidth={width}
+            frameId={frame.id}
+            blockId={frame.blockId}
+            selectedDesignElementKey={selectedDesignElementKey}
+            onDesignElementSelect={onDesignElementSelect}
           />
         ) : legacyData ? (
           <Wireframe data={legacyData} canvasSize={height} />
@@ -1885,9 +1960,11 @@ function CanvasLegacyNote({ note }: { note: PlanCanvasNote }) {
 function CanvasConnector({
   edge,
   frameById,
+  showLabel = true,
 }: {
   edge: PlanConnector;
   frameById: Map<string, PlanArtboard>;
+  showLabel?: boolean;
 }) {
   const from = frameById.get(edge.from);
   const to = frameById.get(edge.to);
@@ -1943,7 +2020,7 @@ function CanvasConnector({
         <path d={path} />
         <path d={sketchHeadPath(ex, ey, headBase.x, headBase.y)} />
       </g>
-      {edge.label && (
+      {showLabel && edge.label && (
         <text
           x={isHorizontal ? midX : (sx + ex) / 2}
           y={isHorizontal ? Math.min(sy, ey) - 9 : midY - 9}
@@ -1954,6 +2031,37 @@ function CanvasConnector({
         </text>
       )}
     </svg>
+  );
+}
+
+function CanvasConnectorLabel({
+  edge,
+  frameById,
+}: {
+  edge: PlanConnector;
+  frameById: Map<string, PlanArtboard>;
+}) {
+  if (!edge.label) return null;
+  const from = frameById.get(edge.from);
+  const to = frameById.get(edge.to);
+  if (!from || !to) return null;
+
+  const route = connectorRoute(from, to);
+  const isHorizontal = route.axis === "horizontal";
+  const left = isHorizontal
+    ? (route.from.x + route.to.x) / 2
+    : (route.from.x + route.to.x) / 2;
+  const top = isHorizontal
+    ? Math.min(route.from.y, route.to.y) - 26
+    : (route.from.y + route.to.y) / 2 - 28;
+
+  return (
+    <div
+      className="pointer-events-none absolute z-20 -translate-x-1/2 rounded-full border border-plan-line bg-plan-paper/95 px-2 py-0.5 text-[15px] font-semibold text-[hsl(var(--ring))] shadow-sm"
+      style={{ left, top }}
+    >
+      {edge.label}
+    </div>
   );
 }
 

--- a/templates/plan/app/components/plan/PlanContentRenderer.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.tsx
@@ -11,6 +11,7 @@ import type {
 import {
   type CanvasMarkupCreateContext,
   type CanvasMarkupMode,
+  type DesignElementSelection,
 } from "./CanvasArea";
 import { PlanBlockView } from "./DocumentArea";
 import {
@@ -121,6 +122,20 @@ export function PlanContentRenderer({
     await updateBlock(blockId, {
       ...block,
       data: { ...block.data, markdown },
+    });
+  };
+
+  const updateDesignElementStyle = async (
+    selection: DesignElementSelection,
+    styles: Record<string, string | null>,
+  ) => {
+    if (!onContentPatch || editingDisabled) return;
+    await onContentPatch({
+      op: "update-design-element-style",
+      elementId: selection.elementId,
+      frameId: selection.frameId,
+      blockId: selection.blockId,
+      styles,
     });
   };
 
@@ -267,6 +282,11 @@ export function PlanContentRenderer({
             prototypeOnly={prototypeOnly}
             visualMode={visualSurfaceMode}
             onVisualModeChange={onVisualSurfaceModeChange}
+            onDesignElementStyleChange={
+              editingDisabled || !onContentPatch
+                ? undefined
+                : updateDesignElementStyle
+            }
           />
         )}
         {!prototypeOnly && (

--- a/templates/plan/app/components/plan/PlanVisualSurface.tsx
+++ b/templates/plan/app/components/plan/PlanVisualSurface.tsx
@@ -1,11 +1,20 @@
 import { useEffect, useMemo, useState } from "react";
-import { IconClick, IconLayoutBoard } from "@tabler/icons-react";
+import {
+  IconClick,
+  IconLayoutBoard,
+  IconPalette,
+  IconX,
+} from "@tabler/icons-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { PlanBlock, PlanContent } from "@shared/plan-content";
 import {
   CanvasArea,
   type CanvasMarkupMode,
   type CanvasMarkupCreateContext,
+  type DesignElementSelection,
 } from "./CanvasArea";
 import { PrototypeViewer } from "./PrototypeViewer";
 import type { PlanAnnotation } from "@shared/plan-content";
@@ -25,6 +34,10 @@ type PlanVisualSurfaceProps = {
   prototypeOnly?: boolean;
   visualMode?: PlanVisualSurfaceMode;
   onVisualModeChange?: (mode: PlanVisualSurfaceMode) => void;
+  onDesignElementStyleChange?: (
+    selection: DesignElementSelection,
+    styles: Record<string, string | null>,
+  ) => Promise<void> | void;
 };
 
 export function PlanVisualSurface({
@@ -36,9 +49,16 @@ export function PlanVisualSurface({
   prototypeOnly = false,
   visualMode: requestedVisualMode,
   onVisualModeChange,
+  onDesignElementStyleChange,
 }: PlanVisualSurfaceProps) {
+  const designCanvas = isDesignCanvas(canvas);
+  const [selectedDesignElement, setSelectedDesignElement] =
+    useState<DesignElementSelection | null>(null);
+  const selectedDesignElementKey = selectedDesignElement
+    ? `${selectedDesignElement.frameId ?? ""}::${selectedDesignElement.blockId ?? ""}::${selectedDesignElement.elementId}`
+    : null;
   const [tabValue, setTabValue] = useState<"prototype" | "wireframes">(
-    prototype ? "prototype" : "wireframes",
+    designCanvas ? "wireframes" : prototype ? "prototype" : "wireframes",
   );
   const requestedTabValue =
     requestedVisualMode === "prototype" || requestedVisualMode === "wireframes"
@@ -71,6 +91,12 @@ export function PlanVisualSurface({
   useEffect(() => {
     onVisualModeChange?.(visualMode);
   }, [onVisualModeChange, visualMode]);
+
+  useEffect(() => {
+    if (!designCanvas || visualMode !== "wireframes") {
+      setSelectedDesignElement(null);
+    }
+  }, [designCanvas, visualMode]);
 
   if (prototypeOnly) {
     return prototype ? (
@@ -111,11 +137,22 @@ export function PlanVisualSurface({
               value="wireframes"
               className="h-7 gap-1.5 px-2.5 text-xs"
             >
-              <IconLayoutBoard className="size-3.5" aria-hidden="true" />
-              Wireframes
+              {designCanvas ? (
+                <IconPalette className="size-3.5" aria-hidden="true" />
+              ) : (
+                <IconLayoutBoard className="size-3.5" aria-hidden="true" />
+              )}
+              {designCanvas ? "Design" : "Wireframes"}
             </TabsTrigger>
           </TabsList>
         </div>
+        {designCanvas && activeTabValue === "wireframes" && (
+          <DesignStyleInspector
+            selection={selectedDesignElement}
+            onClear={() => setSelectedDesignElement(null)}
+            onStyleChange={onDesignElementStyleChange}
+          />
+        )}
         <TabsContent value="prototype" className="m-0">
           <PrototypeViewer
             prototype={prototype}
@@ -128,6 +165,10 @@ export function PlanVisualSurface({
             blockLookup={blockLookup}
             markupMode={canvasMarkupMode}
             onCanvasMarkupCreate={onCanvasMarkupCreate}
+            selectedDesignElementKey={selectedDesignElementKey}
+            onDesignElementSelect={
+              designCanvas ? setSelectedDesignElement : undefined
+            }
           />
         </TabsContent>
       </Tabs>
@@ -145,14 +186,147 @@ export function PlanVisualSurface({
 
   if (canvas) {
     return (
-      <CanvasArea
-        canvas={canvas}
-        blockLookup={blockLookup}
-        markupMode={canvasMarkupMode}
-        onCanvasMarkupCreate={onCanvasMarkupCreate}
-      />
+      <div className="relative">
+        <CanvasArea
+          canvas={canvas}
+          blockLookup={blockLookup}
+          markupMode={canvasMarkupMode}
+          onCanvasMarkupCreate={onCanvasMarkupCreate}
+          selectedDesignElementKey={selectedDesignElementKey}
+          onDesignElementSelect={
+            designCanvas ? setSelectedDesignElement : undefined
+          }
+        />
+        {designCanvas && (
+          <DesignStyleInspector
+            selection={selectedDesignElement}
+            onClear={() => setSelectedDesignElement(null)}
+            onStyleChange={onDesignElementStyleChange}
+          />
+        )}
+      </div>
     );
   }
 
   return null;
+}
+
+function isDesignCanvas(canvas: PlanContent["canvas"] | undefined) {
+  return Boolean(
+    canvas?.mode === "design" ||
+    canvas?.frames.some((frame) => frame.wireframe?.renderMode === "design"),
+  );
+}
+
+function DesignStyleInspector({
+  selection,
+  onClear,
+  onStyleChange,
+}: {
+  selection: DesignElementSelection | null;
+  onClear: () => void;
+  onStyleChange?: (
+    selection: DesignElementSelection,
+    styles: Record<string, string | null>,
+  ) => Promise<void> | void;
+}) {
+  if (!selection) return null;
+  const canEdit = Boolean(onStyleChange);
+  const apply = (property: string, value: string) => {
+    if (!onStyleChange) return;
+    void onStyleChange(selection, { [property]: value.trim() || null });
+  };
+
+  return (
+    <div
+      className="absolute right-4 top-16 z-40 w-72 rounded-xl border border-plan-line bg-plan-chrome/95 p-3 shadow-2xl backdrop-blur"
+      data-plan-interactive
+    >
+      <div className="mb-3 flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-xs font-semibold uppercase tracking-[0.12em] text-plan-muted">
+            Design element
+          </p>
+          <p className="mt-0.5 truncate text-sm font-semibold text-plan-text">
+            {selection.elementId}
+          </p>
+          <p className="truncate text-xs text-plan-muted">
+            {`<${selection.tagName}>`}
+            {selection.text ? ` ${selection.text}` : ""}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-7"
+          onClick={onClear}
+          aria-label="Clear design selection"
+        >
+          <IconX className="size-4" />
+        </Button>
+      </div>
+      <div className="grid gap-2">
+        <StyleInput
+          label="Text"
+          value={selection.computedStyles.color}
+          disabled={!canEdit}
+          onCommit={(value) => apply("color", value)}
+        />
+        <StyleInput
+          label="Fill"
+          value={selection.computedStyles.backgroundColor}
+          disabled={!canEdit}
+          onCommit={(value) => apply("background-color", value)}
+        />
+        <StyleInput
+          label="Radius"
+          value={selection.computedStyles.borderRadius}
+          disabled={!canEdit}
+          onCommit={(value) => apply("border-radius", value)}
+        />
+        <StyleInput
+          label="Padding"
+          value={selection.computedStyles.padding}
+          disabled={!canEdit}
+          onCommit={(value) => apply("padding", value)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function StyleInput({
+  label,
+  value,
+  disabled,
+  onCommit,
+}: {
+  label: string;
+  value: string;
+  disabled?: boolean;
+  onCommit: (value: string) => void;
+}) {
+  const [draft, setDraft] = useState(value);
+  useEffect(() => setDraft(value), [value]);
+  return (
+    <div className="grid gap-1">
+      <Label className="text-[11px] font-semibold uppercase tracking-[0.12em] text-plan-muted">
+        {label}
+      </Label>
+      <Input
+        aria-label={label}
+        value={draft}
+        disabled={disabled}
+        className="h-8 bg-background/80 text-xs"
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={() => onCommit(draft)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.currentTarget.blur();
+          }
+        }}
+      />
+    </div>
+  );
 }

--- a/templates/plan/app/components/plan/PrototypeViewer.tsx
+++ b/templates/plan/app/components/plan/PrototypeViewer.tsx
@@ -45,7 +45,9 @@ export function PrototypeViewer({
 
   const wireframeData = {
     surface: activeScreen.surface ?? prototype.surface ?? "browser",
+    renderMode: activeScreen.renderMode,
     html: activeScreen.html,
+    css: activeScreen.css,
   };
 
   return (

--- a/templates/plan/app/components/plan/wireframe/Wireframe.tsx
+++ b/templates/plan/app/components/plan/wireframe/Wireframe.tsx
@@ -353,8 +353,14 @@ function HtmlArtboard({
     ) {
       return;
     }
-    const target = root.querySelector<HTMLElement>(
-      `[data-design-id="${cssAttr(selectedElementId)}"], [data-plan-design-id="${cssAttr(selectedElementId)}"]`,
+    const target = Array.from(
+      root.querySelectorAll<HTMLElement>(
+        "[data-design-id], [data-plan-design-id]",
+      ),
+    ).find(
+      (candidate) =>
+        candidate.getAttribute("data-design-id") === selectedElementId ||
+        candidate.getAttribute("data-plan-design-id") === selectedElementId,
     );
     target?.setAttribute("data-plan-design-selected", "true");
   }, [blockId, designMode, frameId, selectedDesignElementKey, safeHtml]);
@@ -601,8 +607,4 @@ function orderDiagramNodes(
     if (!seen.has(node.id)) ordered.push(node);
   }
   return ordered;
-}
-
-function cssAttr(value: string) {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }

--- a/templates/plan/app/components/plan/wireframe/Wireframe.tsx
+++ b/templates/plan/app/components/plan/wireframe/Wireframe.tsx
@@ -1,4 +1,12 @@
-import { type ReactNode, useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  type MouseEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+} from "react";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/utils";
 import type {
@@ -16,7 +24,11 @@ import {
   renderNodes,
 } from "./kit";
 import { useWireframeStyle } from "./use-wireframe-style";
-import { sanitizeWireframeHtml } from "./sanitize-html";
+import {
+  sanitizeWireframeCss,
+  sanitizeWireframeHtml,
+  scopeDesignCss,
+} from "./sanitize-html";
 import {
   RUNTIME_SENTINEL_ATTR,
   mountPrototypeRuntime,
@@ -58,6 +70,17 @@ type WireframeData =
   | PlanWireframeBlock["data"]
   | PlanLegacyWireframeBlock["data"];
 
+export type DesignElementSelection = {
+  frameId?: string;
+  blockId?: string;
+  elementId: string;
+  tagName: string;
+  className: string;
+  inlineStyle: string;
+  text: string;
+  computedStyles: Record<string, string>;
+};
+
 function isHtmlData(data: WireframeData): data is PlanWireframeBlock["data"] {
   const html = (data as PlanWireframeBlock["data"]).html;
   return typeof html === "string" && html.trim().length > 0;
@@ -75,12 +98,20 @@ export function Wireframe({
   canvasSize,
   canvasWidth,
   interactive,
+  frameId,
+  blockId,
+  selectedDesignElementKey,
+  onDesignElementSelect,
 }: {
   data: WireframeData;
   compact?: boolean;
   canvasSize?: number;
   canvasWidth?: number;
   interactive?: boolean;
+  frameId?: string;
+  blockId?: string;
+  selectedDesignElementKey?: string | null;
+  onDesignElementSelect?: (selection: DesignElementSelection) => void;
 }) {
   if (isHtmlData(data)) {
     return (
@@ -90,6 +121,10 @@ export function Wireframe({
         canvasSize={canvasSize}
         canvasWidth={canvasWidth}
         interactive={interactive}
+        frameId={frameId}
+        blockId={blockId}
+        selectedDesignElementKey={selectedDesignElementKey}
+        onDesignElementSelect={onDesignElementSelect}
       />
     );
   }
@@ -122,6 +157,7 @@ function ArtboardFrame({
   canvasSize,
   canvasWidth,
   skeleton,
+  renderMode,
   selector,
   caption,
   render,
@@ -131,6 +167,7 @@ function ArtboardFrame({
   canvasSize?: number;
   canvasWidth?: number;
   skeleton?: boolean;
+  renderMode?: "wireframe" | "design";
   selector: string;
   caption?: string;
   render: (ctx: {
@@ -146,8 +183,15 @@ function ArtboardFrame({
   const height = canvasSize ?? preset.height;
   const width = canvasWidth ?? preset.width;
   const scale = compact ? Math.min(1, 320 / preset.width) : 1;
-  const sketchy = style === "sketchy" && !skeleton;
-  const paper = theme === "dark" ? "#201f1c" : "#fbfaf6";
+  const designMode = renderMode === "design";
+  const sketchy = !designMode && style === "sketchy" && !skeleton;
+  const paper = designMode
+    ? theme === "dark"
+      ? "#0f1115"
+      : "#ffffff"
+    : theme === "dark"
+      ? "#201f1c"
+      : "#fbfaf6";
   // Frame border for clean + skeleton modes (sketchy draws its frame via the
   // rough overlay). Soft, matching --wf-line — not hard ink. Skeleton uses its
   // own neutral fill so the loader frame still reads as a frame.
@@ -233,17 +277,33 @@ function HtmlArtboard({
   canvasSize,
   canvasWidth,
   interactive,
+  frameId,
+  blockId,
+  selectedDesignElementKey,
+  onDesignElementSelect,
 }: {
   data: PlanWireframeBlock["data"];
   compact?: boolean;
   canvasSize?: number;
   canvasWidth?: number;
   interactive?: boolean;
+  frameId?: string;
+  blockId?: string;
+  selectedDesignElementKey?: string | null;
+  onDesignElementSelect?: (selection: DesignElementSelection) => void;
 }) {
   // Sanitize model-authored HTML at the render point (defense-in-depth against
   // stored XSS) — see sanitize-html.ts. Memoized so it only re-runs when the
   // html changes, not on every theme/zoom re-render.
   const safeHtml = useMemo(() => sanitizeWireframeHtml(data.html), [data.html]);
+  const renderMode = data.renderMode ?? "wireframe";
+  const designMode = renderMode === "design";
+  const scopeId = useId().replace(/[^a-zA-Z0-9_-]/g, "");
+  const scopeSelector = `[data-plan-design-scope="${scopeId}"]`;
+  const scopedCss = useMemo(() => {
+    const safeCss = sanitizeWireframeCss(data.css);
+    return scopeDesignCss(safeCss, scopeSelector);
+  }, [data.css, scopeSelector]);
   const htmlRef = useRef<HTMLDivElement>(null);
   const runtimeCleanupRef = useRef<(() => void) | null>(null);
   const runtimeTimerRef = useRef<number | null>(null);
@@ -276,6 +336,68 @@ function HtmlArtboard({
 
   useEffect(() => cleanupRuntime, [cleanupRuntime]);
 
+  useEffect(() => {
+    if (!designMode) return;
+    const root = htmlRef.current;
+    if (!root) return;
+    root
+      .querySelectorAll("[data-plan-design-selected]")
+      .forEach((node) => node.removeAttribute("data-plan-design-selected"));
+    if (!selectedDesignElementKey) return;
+    const [selectedFrameId, selectedBlockId, selectedElementId] =
+      selectedDesignElementKey.split("::");
+    if (
+      selectedFrameId !== (frameId ?? "") ||
+      selectedBlockId !== (blockId ?? "") ||
+      !selectedElementId
+    ) {
+      return;
+    }
+    const target = root.querySelector<HTMLElement>(
+      `[data-design-id="${cssAttr(selectedElementId)}"], [data-plan-design-id="${cssAttr(selectedElementId)}"]`,
+    );
+    target?.setAttribute("data-plan-design-selected", "true");
+  }, [blockId, designMode, frameId, selectedDesignElementKey, safeHtml]);
+
+  const handleDesignClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (!designMode || !onDesignElementSelect) return;
+      const root = htmlRef.current;
+      const rawTarget = event.target;
+      if (!root || !(rawTarget instanceof HTMLElement)) return;
+      const target = rawTarget.closest<HTMLElement>(
+        "[data-design-id], [data-plan-design-id]",
+      );
+      if (!target || !root.contains(target)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const computed = window.getComputedStyle(target);
+      onDesignElementSelect({
+        frameId,
+        blockId,
+        elementId:
+          target.getAttribute("data-design-id") ??
+          target.getAttribute("data-plan-design-id") ??
+          "",
+        tagName: target.tagName.toLowerCase(),
+        className: target.getAttribute("class") ?? "",
+        inlineStyle: target.getAttribute("style") ?? "",
+        text: (target.textContent ?? "").trim().slice(0, 120),
+        computedStyles: {
+          color: computed.color,
+          backgroundColor: computed.backgroundColor,
+          fontFamily: computed.fontFamily,
+          fontSize: computed.fontSize,
+          fontWeight: computed.fontWeight,
+          borderRadius: computed.borderRadius,
+          padding: computed.padding,
+          margin: computed.margin,
+        },
+      });
+    },
+    [blockId, designMode, frameId, onDesignElementSelect],
+  );
+
   return (
     <ArtboardFrame
       surface={data.surface}
@@ -283,6 +405,7 @@ function HtmlArtboard({
       canvasSize={canvasSize}
       canvasWidth={canvasWidth}
       skeleton={data.skeleton}
+      renderMode={renderMode}
       selector={HTML_ROUGH_SELECTOR}
       caption={data.caption}
       render={({ theme, style }) => (
@@ -291,10 +414,18 @@ function HtmlArtboard({
           className="plan-html-frame"
           data-theme={theme}
           data-style={style}
+          data-render-mode={renderMode}
+          data-plan-design-scope={scopeId}
           data-skeleton={data.skeleton ? "true" : undefined}
           data-prototype-live={interactive ? "true" : undefined}
-          dangerouslySetInnerHTML={{ __html: safeHtml }}
-        />
+          onClick={handleDesignClick}
+        >
+          {scopedCss && <style>{scopedCss}</style>}
+          <div
+            className="plan-html-frame-content"
+            dangerouslySetInnerHTML={{ __html: safeHtml }}
+          />
+        </div>
       )}
     />
   );
@@ -470,4 +601,8 @@ function orderDiagramNodes(
     if (!seen.has(node.id)) ordered.push(node);
   }
   return ordered;
+}
+
+function cssAttr(value: string) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }

--- a/templates/plan/app/components/plan/wireframe/html-artboard.css
+++ b/templates/plan/app/components/plan/wireframe/html-artboard.css
@@ -51,10 +51,15 @@
   line-height: 1.45;
 }
 
+.plan-html-frame-content {
+  width: 100%;
+  height: 100%;
+}
+
 .plan-html-frame[data-prototype-live="true"] {
   overflow: auto;
 }
-.plan-html-frame[data-prototype-live="true"] > :first-child {
+.plan-html-frame[data-prototype-live="true"] > .plan-html-frame-content {
   height: 100%;
   min-height: 0;
   overflow: auto !important;
@@ -81,49 +86,75 @@
   --wf-font: var(--wf-font-clean);
 }
 
+.plan-html-frame[data-render-mode="design"] {
+  --wf-font: var(--wf-font-clean);
+  background: transparent;
+  color: inherit;
+  font-family: var(--wf-font-clean);
+  font-size: 16px;
+  line-height: normal;
+}
+
+:where(.plan-html-frame[data-render-mode="design"] .plan-html-frame-content)
+  :where(h1, h2, h3, p, small, a, button, input, textarea, select, hr) {
+  all: revert;
+  box-sizing: border-box;
+}
+
+.plan-html-frame[data-render-mode="design"] button,
+.plan-html-frame[data-render-mode="design"] [role="button"],
+.plan-html-frame[data-render-mode="design"] [data-goto] {
+  cursor: pointer;
+}
+
+.plan-html-frame[data-render-mode="design"] [data-plan-design-selected] {
+  outline: 2px solid #60a5fa !important;
+  outline-offset: 2px;
+}
+
 .plan-html-frame * {
   box-sizing: border-box;
   min-width: 0;
 }
 
 /* Bare semantic elements get the wireframe look from tokens. */
-.plan-html-frame h1 {
+.plan-html-frame:not([data-render-mode="design"]) h1 {
   font-size: 22px;
   font-weight: 700;
   line-height: 1.15;
   margin: 0 0 8px;
 }
-.plan-html-frame h2 {
+.plan-html-frame:not([data-render-mode="design"]) h2 {
   font-size: 17px;
   font-weight: 700;
   line-height: 1.2;
   margin: 0 0 6px;
 }
-.plan-html-frame h3 {
+.plan-html-frame:not([data-render-mode="design"]) h3 {
   font-size: 14px;
   font-weight: 700;
   margin: 0 0 4px;
 }
-.plan-html-frame p {
+.plan-html-frame:not([data-render-mode="design"]) p {
   margin: 0 0 8px;
 }
-.plan-html-frame small,
-.plan-html-frame .wf-muted {
+.plan-html-frame:not([data-render-mode="design"]) small,
+.plan-html-frame:not([data-render-mode="design"]) .wf-muted {
   color: var(--wf-muted);
   font-size: 12.5px;
 }
-.plan-html-frame a {
+.plan-html-frame:not([data-render-mode="design"]) a {
   color: var(--wf-accent);
   text-decoration: none;
 }
-.plan-html-frame hr {
+.plan-html-frame:not([data-render-mode="design"]) hr {
   border: 0;
   border-top: 1.4px solid var(--wf-line);
   margin: 10px 0;
 }
 
-.plan-html-frame button,
-.plan-html-frame .wf-btn {
+.plan-html-frame:not([data-render-mode="design"]) button,
+.plan-html-frame:not([data-render-mode="design"]) .wf-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -156,17 +187,17 @@
   text-decoration: line-through;
   text-decoration-thickness: 1.5px;
 }
-.plan-html-frame button.primary,
-.plan-html-frame .wf-btn.primary,
-.plan-html-frame [data-primary] {
+.plan-html-frame:not([data-render-mode="design"]) button.primary,
+.plan-html-frame:not([data-render-mode="design"]) .wf-btn.primary,
+.plan-html-frame:not([data-render-mode="design"]) [data-primary] {
   background: var(--wf-accent);
   border-color: var(--wf-accent);
   color: var(--wf-accent-fg);
 }
 
-.plan-html-frame input,
-.plan-html-frame textarea,
-.plan-html-frame select {
+.plan-html-frame:not([data-render-mode="design"]) input,
+.plan-html-frame:not([data-render-mode="design"]) textarea,
+.plan-html-frame:not([data-render-mode="design"]) select {
   font: inherit;
   color: var(--wf-ink);
   background: var(--wf-card);
@@ -175,8 +206,8 @@
   padding: 8px 10px;
   width: 100%;
 }
-.plan-html-frame input[type="checkbox"],
-.plan-html-frame input[type="radio"] {
+.plan-html-frame:not([data-render-mode="design"]) input[type="checkbox"],
+.plan-html-frame:not([data-render-mode="design"]) input[type="radio"] {
   width: 16px;
   height: 16px;
   padding: 0;
@@ -184,15 +215,15 @@
   flex: 0 0 auto;
 }
 
-.plan-html-frame .wf-card,
-.plan-html-frame .wf-box {
+.plan-html-frame:not([data-render-mode="design"]) .wf-card,
+.plan-html-frame:not([data-render-mode="design"]) .wf-box {
   background: var(--wf-card);
   border: 1.4px solid var(--wf-line);
   border-radius: var(--wf-radius);
   padding: 12px;
 }
-.plan-html-frame .wf-pill,
-.plan-html-frame .wf-chip {
+.plan-html-frame:not([data-render-mode="design"]) .wf-pill,
+.plan-html-frame:not([data-render-mode="design"]) .wf-chip {
   display: inline-flex;
   align-items: center;
   gap: 5px;
@@ -201,7 +232,7 @@
   padding: 2px 10px;
   font-size: 12.5px;
 }
-.plan-html-frame .wf-pill.accent {
+.plan-html-frame:not([data-render-mode="design"]) .wf-pill.accent {
   border-color: var(--wf-accent);
   color: var(--wf-accent);
   background: var(--wf-accent-soft);

--- a/templates/plan/app/components/plan/wireframe/sanitize-html.spec.ts
+++ b/templates/plan/app/components/plan/wireframe/sanitize-html.spec.ts
@@ -159,4 +159,17 @@ describe("scopeDesignCss", () => {
     expect(out).toContain(`${scope} { padding: 12px; }`);
     expect(out).not.toContain("{ .hero");
   });
+
+  it("keeps commas inside pseudo-class arguments and attribute selectors", () => {
+    const scope = '[data-plan-design-scope="selectors"]';
+    const out = scopeDesignCss(
+      ':is(.primary, .secondary), [data-label="A,B"] { color: #111; }',
+      scope,
+    );
+
+    expect(out).toContain(`${scope} :is(.primary, .secondary)`);
+    expect(out).toContain(`${scope} [data-label="A,B"]`);
+    expect(out).not.toContain(`, ${scope} .secondary)`);
+    expect(out).not.toContain(`A, ${scope} B`);
+  });
 });

--- a/templates/plan/app/components/plan/wireframe/sanitize-html.spec.ts
+++ b/templates/plan/app/components/plan/wireframe/sanitize-html.spec.ts
@@ -1,6 +1,10 @@
 // @vitest-environment happy-dom
 import { describe, it, expect } from "vitest";
-import { sanitizeWireframeHtml } from "./sanitize-html";
+import {
+  sanitizeWireframeCss,
+  sanitizeWireframeHtml,
+  scopeDesignCss,
+} from "./sanitize-html";
 
 describe("sanitizeWireframeHtml", () => {
   it("drops <script> elements", () => {
@@ -87,5 +91,72 @@ describe("sanitizeWireframeHtml", () => {
   it("handles empty / undefined", () => {
     expect(sanitizeWireframeHtml(undefined)).toBe("");
     expect(sanitizeWireframeHtml("")).toBe("");
+  });
+});
+
+describe("sanitizeWireframeCss", () => {
+  it("drops dangerous CSS while keeping safe design rules", () => {
+    const out = sanitizeWireframeCss(`
+@import url("https://example.com/theme.css");
+@font-face { font-family: Leaky; src: url(https://example.com/leaky.woff2); }
+@keyframes pulse { from { opacity: 0; } to { opacity: 1; } }
+.card { color: #111; }
+.bad { background: url(javascript:alert(1)); }
+.icon { background: url(data:image/svg+xml,<svg></svg>); }
+.safe { border-radius: 10px; }
+`);
+
+    expect(out).not.toContain("@import");
+    expect(out).not.toContain("@font-face");
+    expect(out).not.toContain("@keyframes");
+    expect(out).not.toContain("javascript");
+    expect(out).not.toContain("image/svg+xml");
+    expect(out).toContain(".card { color: #111; }");
+    expect(out).toContain(".safe { border-radius: 10px; }");
+  });
+
+  it("drops CSS escape obfuscation and viewport-trapping declarations", () => {
+    const out = sanitizeWireframeCss(String.raw`
+.\69 mportant { color: #111; }
+@\69mport url("https://example.com/theme.css");
+.bad-url { background: url("\\6a avascript:alert(1)"); }
+.fixed { position: fixed; inset: 0; }
+.sticky { position: sticky; top: 0; }
+.stack { z-index: 100000; }
+.safe { color: #0f172a; }
+`);
+
+    expect(out).not.toMatch(/@\\?69?mport|javascript|position:\s*fixed/i);
+    expect(out).not.toContain("position: sticky");
+    expect(out).not.toContain("100000");
+    expect(out).toContain(".safe { color: #0f172a; }");
+  });
+});
+
+describe("scopeDesignCss", () => {
+  it("scopes element and class selectors to one design artboard", () => {
+    const scope = '[data-plan-design-scope="abc"]';
+    const out = scopeDesignCss(
+      '.hero, body, :root { color: #111; }\n[data-plan-design-scope="abc"] .pill { color: red; }',
+      scope,
+    );
+
+    expect(out).toContain(`${scope} .hero`);
+    expect(out).toContain(`${scope} { color: #111; }`);
+    expect(out).toContain(`${scope} .pill { color: red; }`);
+    expect(out).not.toContain(`${scope} ${scope} .pill`);
+  });
+
+  it("scopes selectors nested inside media queries", () => {
+    const scope = '[data-plan-design-scope="responsive"]';
+    const out = scopeDesignCss(
+      "@media (max-width: 640px) { .hero, body { padding: 12px; } }",
+      scope,
+    );
+
+    expect(out).toContain("@media (max-width: 640px) {");
+    expect(out).toContain(`${scope} .hero`);
+    expect(out).toContain(`${scope} { padding: 12px; }`);
+    expect(out).not.toContain("{ .hero");
   });
 });

--- a/templates/plan/app/components/plan/wireframe/sanitize-html.ts
+++ b/templates/plan/app/components/plan/wireframe/sanitize-html.ts
@@ -152,8 +152,7 @@ export function scopeDesignCss(css: string, scopeSelector: string): string {
   return css.replace(
     /(^|[{}])\s*([^@{}][^{}]*)\{/g,
     (_match, boundary: string, selectors: string) => {
-      const scoped = selectors
-        .split(",")
+      const scoped = splitSelectorList(selectors)
         .map((selector) => selector.trim())
         .filter(Boolean)
         .map((selector) => {
@@ -170,6 +169,58 @@ export function scopeDesignCss(css: string, scopeSelector: string): string {
       return `${boundary} ${scoped} {`;
     },
   );
+}
+
+function splitSelectorList(selectors: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+
+  for (const char of selectors) {
+    current += char;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === "[") {
+      bracketDepth += 1;
+      continue;
+    }
+    if (char === "]") {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+      continue;
+    }
+    if (char === "(") {
+      parenDepth += 1;
+      continue;
+    }
+    if (char === ")") {
+      parenDepth = Math.max(0, parenDepth - 1);
+      continue;
+    }
+    if (char === "," && parenDepth === 0 && bracketDepth === 0) {
+      parts.push(current.slice(0, -1));
+      current = "";
+    }
+  }
+
+  parts.push(current);
+  return parts;
 }
 
 function sanitizeElementAttributes(root: ParentNode) {

--- a/templates/plan/app/components/plan/wireframe/sanitize-html.ts
+++ b/templates/plan/app/components/plan/wireframe/sanitize-html.ts
@@ -68,6 +68,27 @@ function isSafeUrl(value: string): boolean {
 
 const DANGEROUS_STYLE =
   /(expression\s*\(|javascript:|vbscript:|url\s*\(\s*['"]?\s*(?:javascript|vbscript|data:text\/html))/i;
+const DANGEROUS_CSS =
+  /(@(?:import|font-face|keyframes|page|namespace|charset)\b|expression\s*\(|javascript:|vbscript:|data:text\/html|data:image\/svg\+xml|<\/?\s*(?:script|style)\b)/i;
+const DANGEROUS_VIEWPORT_CSS =
+  /(?:^|[;{\s])position\s*:\s*(?:fixed|sticky)\b|(?:^|[;{\s])z-index\s*:\s*[1-9]\d{4,}\b/i;
+
+function decodeCssSafetyEscapes(value: string): string {
+  return value.replace(/\\([0-9a-fA-F]{1,6}\s?|.)/g, (_match, escaped) => {
+    const hex = String(escaped).match(/^[0-9a-fA-F]{1,6}/)?.[0];
+    if (hex) {
+      const point = Number.parseInt(hex, 16);
+      return Number.isFinite(point) ? String.fromCodePoint(point) : "";
+    }
+    return String(escaped)[0] ?? "";
+  });
+}
+
+function cssSafetyText(value: string): string {
+  return decodeCssSafetyEscapes(value)
+    .toLowerCase()
+    .replace(/[\u0000-\u0020]+/g, "");
+}
 
 /** Conservative no-DOM fallback for any non-browser code path (SSR). */
 function fallbackStrip(html: string): string {
@@ -102,6 +123,53 @@ export function sanitizeWireframeHtml(html: string | undefined): string {
   doc.querySelectorAll(BLOCKED_TAGS).forEach((el) => el.remove());
   sanitizeElementAttributes(doc.body);
   return doc.body.innerHTML;
+}
+
+export function sanitizeWireframeCss(css: string | undefined): string {
+  if (!css) return "";
+  return css
+    .split("\n")
+    .filter((line) => {
+      const decoded = decodeCssSafetyEscapes(line);
+      const compact = cssSafetyText(line);
+      return !(
+        DANGEROUS_CSS.test(line) ||
+        DANGEROUS_CSS.test(decoded) ||
+        DANGEROUS_VIEWPORT_CSS.test(decoded) ||
+        /(?:javascript|vbscript):|data:(?:text\/html|image\/svg\+xml)|expression\(|url\(['"]?(?:javascript|vbscript|data:(?:text\/html|image\/svg\+xml))/.test(
+          compact,
+        )
+      );
+    })
+    .join("\n")
+    .replace(/\bjava\s*script\s*:/gi, "")
+    .replace(/\bvb\s*script\s*:/gi, "")
+    .replace(/\bdata\s*:\s*(?:text\/html|image\/svg\+xml)/gi, "");
+}
+
+export function scopeDesignCss(css: string, scopeSelector: string): string {
+  if (!css.trim()) return "";
+  return css.replace(
+    /(^|[{}])\s*([^@{}][^{}]*)\{/g,
+    (_match, boundary: string, selectors: string) => {
+      const scoped = selectors
+        .split(",")
+        .map((selector) => selector.trim())
+        .filter(Boolean)
+        .map((selector) => {
+          if (selector.startsWith(scopeSelector)) return selector;
+          if (
+            selector === ":root" ||
+            selector === "html" ||
+            selector === "body"
+          )
+            return scopeSelector;
+          return `${scopeSelector} ${selector}`;
+        })
+        .join(", ");
+      return `${boundary} ${scoped} {`;
+    },
+  );
 }
 
 function sanitizeElementAttributes(root: ParentNode) {

--- a/templates/plan/app/hooks/use-plans.ts
+++ b/templates/plan/app/hooks/use-plans.ts
@@ -71,7 +71,9 @@ export type CreatePrototypePlanInput = CreatePlanInput & {
     title: string;
     summary?: string;
     surface?: "desktop" | "mobile" | "popover" | "panel" | "browser";
+    renderMode?: "wireframe" | "design";
     html?: string;
+    css?: string;
     state?: Array<{ id?: string; label: string; value: string }>;
   }>;
   transitions?: Array<{
@@ -82,6 +84,13 @@ export type CreatePrototypePlanInput = CreatePlanInput & {
     trigger?: string;
   }>;
   implementationNotes?: string;
+};
+
+export type CreatePlanDesignInput = CreatePrototypePlanInput & {
+  designMd?: string;
+  brandKit?: Record<string, unknown>;
+  codebaseStyles?: Record<string, unknown>;
+  designNotes?: string;
 };
 
 export type VisualQuestionOptionInput = {
@@ -210,6 +219,17 @@ export function useCreatePrototypePlan() {
   >("create-prototype-plan", {
     onSuccess: invalidate,
     onError: showActionError("Failed to create prototype plan"),
+  });
+}
+
+export function useCreatePlanDesign() {
+  const invalidate = usePlanInvalidation();
+  return useActionMutation<
+    PlanBundle & { path?: string; url?: string; html?: string },
+    CreatePlanDesignInput
+  >("create-plan-design", {
+    onSuccess: invalidate,
+    onError: showActionError("Failed to create plan design"),
   });
 }
 

--- a/templates/plan/e2e/plan-design.spec.ts
+++ b/templates/plan/e2e/plan-design.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+
+type ActionResult = Record<string, any>;
+
+async function action(
+  req: APIRequestContext,
+  name: string,
+  data: Record<string, unknown>,
+): Promise<{ status: number; ok: boolean; body: ActionResult; raw: string }> {
+  const res = await req.post(`/_agent-native/actions/${name}`, { data });
+  const raw = await res.text();
+  let body: ActionResult = {};
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    body = {};
+  }
+  return { status: res.status(), ok: res.ok(), body, raw };
+}
+
+function planIdFrom(body: ActionResult): string | undefined {
+  return body.planId ?? body.plan?.id;
+}
+
+test.describe("plan-design full-fidelity review surface", () => {
+  test("renders scoped design CSS, selection inspector, and matching prototype tab", async ({
+    page,
+    request,
+  }) => {
+    const res = await action(request, "create-plan-design", {
+      title: `Plan Design E2E ${Date.now()}`,
+      brief:
+        "Verify full-fidelity CSS, selected design-element editing, and prototype tab rendering.",
+      designMd:
+        "Use a compact billing settings surface with a teal primary action.",
+      codebaseStyles: {
+        cssVars: {
+          "--color-primary": "#0f766e",
+          "--radius-card": "12px",
+        },
+      },
+      screens: [
+        {
+          id: "billing-overview",
+          title: "Billing Overview",
+          summary: "Full-fidelity billing settings review.",
+          surface: "browser",
+          html: [
+            '<main class="billing-shell" data-design-id="billing-shell">',
+            '<section class="billing-main" data-design-id="billing-main">',
+            '<p class="eyebrow">Workspace billing</p>',
+            "<h1>Plan and usage</h1>",
+            '<button class="primary-action" data-design-id="primary-action">Update plan</button>',
+            "</section>",
+            "</main>",
+          ].join(""),
+          css: [
+            ".billing-shell { min-height: 100%; display: grid; background: #f8fafc; color: #111827; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }",
+            ".billing-main { display: grid; align-content: start; gap: 18px; padding: 36px; }",
+            ".eyebrow { margin: 0; color: #0f766e; font-size: 12px; font-weight: 800; text-transform: uppercase; }",
+            ".billing-main h1 { margin: 0; font-size: 38px; line-height: 1.05; }",
+            ".primary-action { justify-self: start; border: 0; border-radius: 12px; padding: 12px 16px; background: #0f766e; color: white; font-weight: 800; }",
+            "@media (max-width: 640px) { .billing-main { padding: 20px; } }",
+          ].join("\n"),
+        },
+        {
+          id: "billing-mobile",
+          title: "Billing Mobile",
+          summary: "Mobile billing confirmation state.",
+          surface: "mobile",
+          html: [
+            '<main class="mobile-billing-shell" data-design-id="mobile-shell">',
+            "<h1>Mobile billing</h1>",
+            '<button class="primary-action" data-design-id="mobile-action">Confirm plan</button>',
+            "</main>",
+          ].join(""),
+          css: [
+            ".mobile-billing-shell { min-height: 100%; display: grid; align-content: start; gap: 16px; padding: 24px; background: #ffffff; color: #111827; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }",
+            ".mobile-billing-shell h1 { margin: 0; font-size: 28px; line-height: 1.1; }",
+            ".primary-action { border: 0; border-radius: 12px; padding: 12px 16px; background: #0f766e; color: white; font-weight: 800; }",
+          ].join("\n"),
+        },
+      ],
+      transitions: [
+        {
+          from: "billing-overview",
+          to: "billing-mobile",
+          label: "Review mobile flow",
+          trigger: "Open mobile review",
+        },
+      ],
+    });
+
+    expect(
+      res.ok,
+      `create-plan-design should succeed (${res.status}: ${res.raw.slice(0, 240)})`,
+    ).toBeTruthy();
+    const planId = planIdFrom(res.body);
+    expect(planId, "create-plan-design must return a plan id").toBeTruthy();
+
+    await page.goto(`/plans/${planId}`);
+    await page.waitForLoadState("domcontentloaded");
+    const tabs = page.locator("[data-plan-visual-tabs]");
+    await expect(tabs).toContainText("Design");
+    await expect(tabs).toContainText("Prototype");
+
+    const primary = page.locator('[data-design-id="primary-action"]').first();
+    await expect(primary).toBeVisible();
+    await expect(primary).toHaveCSS("background-color", "rgb(15, 118, 110)");
+    await expect(primary).toHaveCSS("border-radius", "12px");
+    await expect(primary).toHaveCSS("padding", "12px 16px");
+
+    await primary.click();
+    await expect(page.getByText("Design element")).toBeVisible();
+    await expect(page.getByText("primary-action")).toBeVisible();
+    await expect(page.getByText("Review mobile flow")).toBeVisible();
+
+    await page.getByLabel("Fill").fill("#ff0055");
+    await page.getByLabel("Fill").press("Enter");
+    await expect(primary).toHaveCSS("background-color", "rgb(255, 0, 85)");
+
+    await page.getByRole("tab", { name: /Prototype/i }).click();
+    await expect(page.getByText("Update plan").first()).toBeVisible();
+    const prototypePrimary = page.locator(
+      '[data-plan-prototype-viewer] [data-design-id="primary-action"]',
+    );
+    await expect(prototypePrimary).toHaveCSS(
+      "background-color",
+      "rgb(255, 0, 85)",
+    );
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(`/plans/${planId}`);
+    await page.waitForLoadState("domcontentloaded");
+    const mobilePrimary = page
+      .locator('[data-plan-canvas-world] [data-design-id="primary-action"]')
+      .first();
+    await expect(mobilePrimary).toBeVisible();
+    const box = await mobilePrimary.boundingBox();
+    expect(
+      box,
+      "primary action should have a visible mobile bounding box",
+    ).not.toBeNull();
+    expect(box?.x ?? -1).toBeGreaterThanOrEqual(0);
+    expect((box?.x ?? 999) + (box?.width ?? 999)).toBeLessThanOrEqual(390);
+  });
+});

--- a/templates/plan/server/lib/public-action-paths.spec.ts
+++ b/templates/plan/server/lib/public-action-paths.spec.ts
@@ -19,6 +19,9 @@ describe("PUBLIC_PLAN_ACTION_PATHS", () => {
       "/_agent-native/actions/create-prototype-plan",
     );
     expect(PUBLIC_PLAN_ACTION_PATHS).not.toContain(
+      "/_agent-native/actions/create-plan-design",
+    );
+    expect(PUBLIC_PLAN_ACTION_PATHS).not.toContain(
       "/_agent-native/actions/create-visual-questions",
     );
     expect(PUBLIC_PLAN_ACTION_PATHS).not.toContain(

--- a/templates/plan/server/plan-content-patches.deep.spec.ts
+++ b/templates/plan/server/plan-content-patches.deep.spec.ts
@@ -404,6 +404,54 @@ describe("update-design-element-style", () => {
     expect(block.data.html).not.toContain("padding");
   });
 
+  it("does not auto-sync block-only patches across prototype screens with matching element ids", () => {
+    const content = planContentSchema.parse({
+      version: 2,
+      prototype: {
+        initialScreenId: "one",
+        screens: [
+          {
+            id: "one",
+            renderMode: "design",
+            html: '<button data-design-id="shared">One</button>',
+          },
+          {
+            id: "two",
+            renderMode: "design",
+            html: '<button data-design-id="shared">Two</button>',
+          },
+        ],
+      },
+      blocks: [
+        {
+          id: "block-source",
+          type: "wireframe",
+          data: {
+            surface: "desktop",
+            renderMode: "design",
+            html: '<button data-design-id="shared">Block</button>',
+          },
+        },
+      ],
+    });
+
+    const next = applyPlanContentPatches(content, [
+      {
+        op: "update-design-element-style",
+        blockId: "block-source",
+        elementId: "shared",
+        styles: { color: "#0f766e" },
+      },
+    ]);
+    const block = next.blocks.find(
+      (candidate) => candidate.id === "block-source",
+    );
+    if (block?.type !== "wireframe") throw new Error("expected wireframe");
+    expect(block.data.html).toContain('style="color: #0f766e"');
+    expect(next.prototype?.screens[0]?.html).not.toContain("#0f766e");
+    expect(next.prototype?.screens[1]?.html).not.toContain("#0f766e");
+  });
+
   it("rejects unsafe property names, style values, and viewport traps", () => {
     expect(() =>
       applyPlanContentPatches(designPlan(), [

--- a/templates/plan/server/plan-content-patches.deep.spec.ts
+++ b/templates/plan/server/plan-content-patches.deep.spec.ts
@@ -258,6 +258,232 @@ describe("legacy canvas structures survive patching", () => {
 });
 
 /* -------------------------------------------------------------------------- */
+/* update-design-element-style for full-fidelity design fragments              */
+/* -------------------------------------------------------------------------- */
+
+describe("update-design-element-style", () => {
+  const designPlan = (): PlanContent =>
+    planContentSchema.parse({
+      version: 2,
+      canvas: {
+        mode: "design",
+        frames: [
+          {
+            id: "home-frame",
+            label: "Home",
+            wireframe: {
+              surface: "desktop",
+              renderMode: "design",
+              html: '<main><button data-design-id="primary-cta" class="cta">Buy now</button></main>',
+            },
+          },
+        ],
+      },
+      prototype: {
+        initialScreenId: "home-frame",
+        screens: [
+          {
+            id: "home-frame",
+            renderMode: "design",
+            html: '<main><button data-design-id="primary-cta" class="cta">Buy now</button></main>',
+          },
+        ],
+      },
+      blocks: [
+        {
+          id: "linked-design",
+          type: "wireframe",
+          data: {
+            surface: "desktop",
+            renderMode: "design",
+            html: '<section data-plan-design-id="hero-panel" style="color: #111; padding: 8px">Hero</section>',
+          },
+        },
+      ],
+    });
+
+  it("updates a selected canvas design element by data-design-id", () => {
+    const next = applyPlanContentPatches(designPlan(), [
+      {
+        op: "update-design-element-style",
+        frameId: "home-frame",
+        elementId: "primary-cta",
+        styles: {
+          "background-color": "#0f766e",
+          borderRadius: "10px",
+        },
+      },
+    ]);
+
+    const html = next.canvas?.frames[0]?.wireframe?.html;
+    expect(html).toContain('data-design-id="primary-cta"');
+    expect(html).toContain(
+      'style="background-color: #0f766e; border-radius: 10px"',
+    );
+    expect(next.prototype?.screens[0]?.html).toContain(
+      'style="background-color: #0f766e; border-radius: 10px"',
+    );
+  });
+
+  it("uses frameId as the selected source and does not patch a mismatched blockId", () => {
+    const content = planContentSchema.parse({
+      version: 2,
+      canvas: {
+        mode: "design",
+        frames: [
+          {
+            id: "selected-frame",
+            blockId: "frame-source",
+            wireframe: {
+              surface: "desktop",
+              renderMode: "design",
+              html: '<button data-design-id="target">Inline source</button>',
+            },
+          },
+        ],
+      },
+      blocks: [
+        {
+          id: "frame-source",
+          type: "wireframe",
+          data: {
+            surface: "desktop",
+            renderMode: "design",
+            html: '<button data-design-id="target">Block source</button>',
+          },
+        },
+        {
+          id: "wrong-block",
+          type: "wireframe",
+          data: {
+            surface: "desktop",
+            renderMode: "design",
+            html: '<button data-design-id="target">Wrong source</button>',
+          },
+        },
+      ],
+    });
+
+    const next = applyPlanContentPatches(content, [
+      {
+        op: "update-design-element-style",
+        frameId: "selected-frame",
+        blockId: "wrong-block",
+        elementId: "target",
+        styles: { color: "#0f766e" },
+      },
+    ]);
+    const source = next.blocks.find((block) => block.id === "frame-source");
+    const wrong = next.blocks.find((block) => block.id === "wrong-block");
+    if (source?.type !== "wireframe" || wrong?.type !== "wireframe") {
+      throw new Error("expected wireframes");
+    }
+    expect(source.data.html).toContain('style="color: #0f766e"');
+    expect(next.canvas?.frames[0]?.wireframe?.html).toBe(source.data.html);
+    expect(wrong.data.html).not.toContain("#0f766e");
+  });
+
+  it("updates and removes inline styles on block-backed design fragments", () => {
+    const next = applyPlanContentPatches(designPlan(), [
+      {
+        op: "update-design-element-style",
+        blockId: "linked-design",
+        elementId: "hero-panel",
+        styles: {
+          color: "#222",
+          padding: null,
+        },
+      },
+    ]);
+
+    const block = next.blocks.find(
+      (candidate) => candidate.id === "linked-design",
+    );
+    if (block?.type !== "wireframe") throw new Error("expected wireframe");
+    expect(block.data.html).toContain('style="color: #222"');
+    expect(block.data.html).not.toContain("padding");
+  });
+
+  it("rejects unsafe property names, style values, and viewport traps", () => {
+    expect(() =>
+      applyPlanContentPatches(designPlan(), [
+        {
+          op: "update-design-element-style",
+          frameId: "home-frame",
+          elementId: "primary-cta",
+          styles: { "background-color;position": "fixed" },
+        },
+      ]),
+    ).toThrow(/Invalid CSS property name/i);
+
+    expect(() =>
+      applyPlanContentPatches(designPlan(), [
+        {
+          op: "update-design-element-style",
+          frameId: "home-frame",
+          elementId: "primary-cta",
+          styles: { background: "url(javascript:alert(1))" },
+        },
+      ]),
+    ).toThrow(/Unsafe CSS style value/i);
+
+    expect(() =>
+      applyPlanContentPatches(designPlan(), [
+        {
+          op: "update-design-element-style",
+          frameId: "home-frame",
+          elementId: "primary-cta",
+          styles: { position: "fixed" },
+        },
+      ]),
+    ).toThrow(/Unsafe CSS style value/i);
+
+    expect(() =>
+      applyPlanContentPatches(designPlan(), [
+        {
+          op: "update-design-element-style",
+          frameId: "home-frame",
+          elementId: "primary-cta",
+          styles: { background: String.raw`url(\6a avascript:alert(1))` },
+        },
+      ]),
+    ).toThrow(/Unsafe CSS style value/i);
+  });
+
+  it("rejects duplicate data-design-id targets in one design screen", () => {
+    expect(() =>
+      applyPlanContentPatches(
+        planContentSchema.parse({
+          version: 2,
+          canvas: {
+            mode: "design",
+            frames: [
+              {
+                id: "dup-frame",
+                wireframe: {
+                  surface: "desktop",
+                  renderMode: "design",
+                  html: '<button data-design-id="dup">One</button><button data-design-id="dup">Two</button>',
+                },
+              },
+            ],
+          },
+          blocks: [],
+        }),
+        [
+          {
+            op: "update-design-element-style",
+            frameId: "dup-frame",
+            elementId: "dup",
+            styles: { color: "#0f766e" },
+          },
+        ],
+      ),
+    ).toThrow(/matched 2 elements/i);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
 /* batch patches in one call applied sequentially                             */
 /* -------------------------------------------------------------------------- */
 

--- a/templates/plan/server/plan-content.spec.ts
+++ b/templates/plan/server/plan-content.spec.ts
@@ -7,11 +7,13 @@ import {
 } from "../shared/plan-content.js";
 import {
   buildPlanContentHtml,
+  createPlanDesignContent,
   createPlanContentFromSections,
   createPrototypeFromPlanContent,
   createPrototypePlanContent,
   createUiPlanContent,
   createVisualQuestionsContent,
+  normalizePlanDesignContent,
   parsePlanContent,
   sanitizeCustomHtml,
   serializePlanContent,
@@ -716,6 +718,75 @@ describe("back-compat parsing and migration", () => {
 });
 
 describe("prototype plan content", () => {
+  it("creates design-mode fallback content when no /plan-design screens are provided", () => {
+    const content = createPlanDesignContent({
+      title: "Billing redesign",
+      brief: "Create a polished billing settings direction.",
+      screens: [],
+    });
+
+    expect(content.canvas?.mode).toBe("design");
+    expect(content.canvas?.frames[0]?.wireframe?.renderMode).toBe("design");
+    expect(content.canvas?.frames[0]?.wireframe?.html).toContain(
+      'data-design-id="primary-action"',
+    );
+    expect(content.prototype?.screens[0]?.renderMode).toBe("design");
+    expect(content.prototype?.screens[0]?.css).toContain(".pd-shell");
+  });
+
+  it("normalizes supplied /plan-design content into design canvas and prototype surfaces", () => {
+    const content = normalizePlanDesignContent(
+      {
+        version: 2,
+        prototype: {
+          initialScreenId: "settings",
+          screens: [
+            {
+              id: "settings",
+              html: '<main><button data-design-id="save">Save</button></main>',
+            },
+          ],
+        },
+        blocks: [
+          { id: "notes", type: "rich-text", data: { markdown: "Keep" } },
+        ],
+      },
+      {
+        title: "Settings redesign",
+        brief: "Make settings feel finished.",
+        screens: [],
+        designMd: "Use the product brand.",
+        brandKit: { colors: { primary: "#0f766e" } },
+        codebaseStyles: { vars: ["--radius"] },
+      },
+    );
+
+    expect(content?.canvas?.mode).toBe("design");
+    expect(content?.canvas?.design?.designMd).toContain("product brand");
+    expect(content?.canvas?.design?.brandKit).toEqual({
+      colors: { primary: "#0f766e" },
+    });
+    expect(content?.canvas?.frames[0]?.wireframe?.renderMode).toBe("design");
+    expect(content?.prototype?.screens[0]?.renderMode).toBe("design");
+    expect(content?.blocks[0]?.id).toBe("notes");
+  });
+
+  it("bounds /plan-design metadata records", () => {
+    const result = planContentSchema.safeParse({
+      version: 2,
+      canvas: {
+        mode: "design",
+        design: {
+          brandKit: { huge: "x".repeat(25_000) },
+        },
+        frames: [],
+      },
+      blocks: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("accepts safe Alpine-like prototype directives but still rejects event handlers", () => {
     const result = planContentSchema.safeParse({
       version: 2,

--- a/templates/plan/server/plan-content.ts
+++ b/templates/plan/server/plan-content.ts
@@ -89,6 +89,73 @@ export function normalizePlanContent(
   );
 }
 
+export function normalizePlanDesignContent(
+  content: PlanContentInput | undefined,
+  input: PlanDesignContentInput,
+): PlanContent | null {
+  const normalized = normalizePlanContent(content);
+  if (!normalized) return null;
+  const next = cloneJson(normalized);
+
+  if (next.prototype) {
+    next.prototype = sanitizePrototype({
+      ...next.prototype,
+      screens: next.prototype.screens.map((screen) => ({
+        ...screen,
+        renderMode: "design",
+      })),
+    });
+  }
+
+  if (!next.prototype && next.canvas?.frames.length) {
+    const prototype = createPrototypeFromPlanContent(next, {
+      title: input.title,
+      brief: input.brief,
+    });
+    if (prototype) {
+      next.prototype = sanitizePrototype({
+        ...prototype,
+        screens: prototype.screens.map((screen) => ({
+          ...screen,
+          renderMode: "design",
+        })),
+      });
+    }
+  }
+
+  if (!next.canvas && next.prototype) {
+    next.canvas = prototypeToCanvas(next.prototype);
+  }
+
+  if (!next.canvas) {
+    const fallback = createPlanDesignContent({ ...input, screens: [] });
+    next.canvas = fallback.canvas;
+    next.prototype = fallback.prototype;
+  }
+
+  if (next.canvas) {
+    next.canvas = {
+      ...next.canvas,
+      mode: "design",
+      title: next.canvas.title ?? "Design Direction",
+      design: mergeDesignMetadata(next.canvas.design, input),
+      frames: next.canvas.frames.map((frame) => ({
+        ...frame,
+        wireframe: frame.wireframe?.html
+          ? { ...frame.wireframe, renderMode: "design" }
+          : frame.wireframe,
+      })),
+    };
+  }
+
+  return sanitizePlanContent(
+    planContentSchema.parse({
+      ...next,
+      blocks: next.blocks.map(forceDesignWireframeBlocks),
+    }),
+  );
+}
+
 /* -------------------------------------------------------------------------- */
 /* custom-html sanitization (defense in depth at the action boundary)         */
 /* -------------------------------------------------------------------------- */
@@ -134,10 +201,27 @@ function decodeSafetyEntities(value: string): string {
     });
 }
 
+function decodeCssSafetyEscapes(value: string): string {
+  return value.replace(/\\([0-9a-fA-F]{1,6}\s?|.)/g, (_match, escaped) => {
+    const hex = String(escaped).match(/^[0-9a-fA-F]{1,6}/)?.[0];
+    if (hex) {
+      const point = Number.parseInt(hex, 16);
+      return Number.isFinite(point) ? String.fromCodePoint(point) : "";
+    }
+    return String(escaped)[0] ?? "";
+  });
+}
+
+const decodedSafetyText = (value: string) =>
+  decodeCssSafetyEscapes(decodeSafetyEntities(value));
+
 const compactSafetyText = (value: string) =>
-  decodeSafetyEntities(value)
+  decodedSafetyText(value)
     .toLowerCase()
     .replace(/[\u0000-\u0020]+/g, "");
+
+const unsafeViewportCssPattern =
+  /(?:^|[;{\s])position\s*:\s*(?:fixed|sticky)\b|(?:^|[;{\s])z-index\s*:\s*[1-9]\d{4,}\b/i;
 
 function hasUnsafeUrl(value: string): boolean {
   const compact = compactSafetyText(value);
@@ -150,8 +234,10 @@ function hasUnsafeUrl(value: string): boolean {
 }
 
 function hasUnsafeStyle(value: string): boolean {
+  const decoded = decodedSafetyText(value);
   const compact = compactSafetyText(value);
   return (
+    unsafeViewportCssPattern.test(decoded) ||
     compact.includes("expression(") ||
     compact.includes("javascript:") ||
     compact.includes("vbscript:") ||
@@ -221,6 +307,9 @@ function preSanitizePlanContentInput(input: unknown): unknown {
       const record = screen as Record<string, unknown>;
       if (typeof record.html === "string") {
         record.html = sanitizeCustomHtml(record.html);
+      }
+      if (typeof record.css === "string") {
+        record.css = sanitizeCustomHtml(record.css);
       }
     }
   }
@@ -325,6 +414,8 @@ function sanitizePrototype(prototype: PlanPrototype | undefined) {
     screens: prototype.screens.map((screen) => ({
       ...screen,
       html: sanitizeCustomHtml(screen.html),
+      css:
+        screen.css === undefined ? undefined : sanitizeCustomHtml(screen.css),
     })),
   };
 }
@@ -467,12 +558,84 @@ type PrototypePlanContentInput = {
     title: string;
     summary?: string;
     surface?: PlanWireframeSurface;
+    renderMode?: "wireframe" | "design";
     html?: string;
+    css?: string;
     state?: PlanPrototypeScreen["state"];
   }>;
   transitions?: PlanPrototype["transitions"];
   implementationNotes?: string | null;
 };
+
+type PlanDesignContentInput = Omit<PrototypePlanContentInput, "prototype"> & {
+  designMd?: string | null;
+  brandKit?: Record<string, unknown> | null;
+  codebaseStyles?: Record<string, unknown> | null;
+  designNotes?: string | null;
+};
+
+function forceDesignWireframeBlocks(block: PlanBlock): PlanBlock {
+  if (block.type === "wireframe" && block.data.html) {
+    return {
+      ...block,
+      data: { ...block.data, renderMode: "design" },
+    };
+  }
+  if (block.type === "tabs") {
+    return {
+      ...block,
+      data: {
+        ...block.data,
+        tabs: block.data.tabs.map((tab) => ({
+          ...tab,
+          blocks: tab.blocks.map(forceDesignWireframeBlocks),
+        })),
+      },
+    };
+  }
+  return block;
+}
+
+function mergeDesignMetadata(
+  existing: NonNullable<PlanContent["canvas"]>["design"],
+  input: PlanDesignContentInput,
+): NonNullable<PlanContent["canvas"]>["design"] {
+  const incoming = createDesignMetadata(input);
+  const styleSources = [
+    ...(existing?.styleSources ?? []),
+    ...(incoming.styleSources ?? []),
+  ];
+  return {
+    ...(existing ?? {}),
+    ...incoming,
+    ...(styleSources.length > 0 ? { styleSources } : {}),
+  };
+}
+
+function createDesignMetadata(
+  input: Pick<
+    PlanDesignContentInput,
+    "designMd" | "brandKit" | "codebaseStyles" | "designNotes"
+  >,
+): NonNullable<PlanContent["canvas"]>["design"] {
+  return {
+    ...(input.designMd ? { designMd: input.designMd } : {}),
+    ...(input.brandKit ? { brandKit: input.brandKit } : {}),
+    ...(input.codebaseStyles ? { codebaseStyles: input.codebaseStyles } : {}),
+    ...(input.designNotes ? { notes: input.designNotes } : {}),
+    styleSources: [
+      ...(input.designMd
+        ? [{ kind: "design-md" as const, title: "design.md" }]
+        : []),
+      ...(input.brandKit
+        ? [{ kind: "fig-file" as const, title: "Brand kit" }]
+        : []),
+      ...(input.codebaseStyles
+        ? [{ kind: "codebase" as const, title: "Codebase styles" }]
+        : []),
+    ],
+  };
+}
 
 export function createUiPlanContent(input: UiPlanContentInput): PlanContent {
   const states = input.states;
@@ -793,7 +956,9 @@ export function createPrototypePlanContent(
         "Static reference for the live prototype screen above.",
       data: {
         surface: screen.surface ?? prototype.surface ?? "browser",
+        renderMode: screen.renderMode,
         html: screen.html,
+        css: screen.css,
         caption:
           screen.summary ?? "Static screen reference from the prototype.",
       },
@@ -902,6 +1067,137 @@ export function createPrototypePlanContent(
   );
 }
 
+export function createPlanDesignContent(
+  input: PlanDesignContentInput,
+): PlanContent {
+  const designScreens =
+    input.screens.length > 0
+      ? input.screens
+      : [
+          {
+            title: "Design draft",
+            summary: input.brief,
+            surface: "browser" as const,
+            html: `<main class="pd-shell" data-design-id="design-shell"><section class="pd-hero" data-design-id="hero-panel"><p class="pd-kicker">Design direction</p><h1>${escapeHtml(input.title)}</h1><p>${escapeHtml(input.brief)}</p><button class="pd-primary" data-design-id="primary-action">Review direction</button></section><aside class="pd-card" data-design-id="detail-card"><span>Brand signals</span><strong>Use design.md, .fig tokens, and codebase styles when available.</strong></aside></main>`,
+            css: [
+              ".pd-shell { min-height: 100%; display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 24px; padding: 32px; background: #f8fafc; color: #111827; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }",
+              ".pd-hero { display: grid; align-content: center; gap: 14px; border: 1px solid rgba(17, 24, 39, 0.1); border-radius: 18px; padding: 36px; background: linear-gradient(135deg, #ffffff 0%, #ecfeff 100%); box-shadow: 0 18px 45px rgba(15, 23, 42, 0.08); }",
+              ".pd-kicker { margin: 0; font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: #0f766e; }",
+              ".pd-hero h1 { margin: 0; font-size: 34px; line-height: 1.08; max-width: 720px; }",
+              ".pd-hero p { margin: 0; max-width: 680px; color: #475569; line-height: 1.6; }",
+              ".pd-primary { justify-self: start; border: 0; border-radius: 12px; padding: 12px 16px; background: #0f766e; color: #ffffff; font-weight: 700; }",
+              ".pd-card { display: grid; align-content: end; gap: 10px; border-radius: 16px; padding: 24px; background: #111827; color: #f8fafc; }",
+              ".pd-card span { color: #99f6e4; font-size: 12px; font-weight: 700; text-transform: uppercase; }",
+            ].join("\n"),
+          },
+        ];
+  const prototype = createPrototypeFromScreens({
+    title: input.title,
+    brief: input.brief,
+    screens: designScreens.map((screen) => ({
+      ...screen,
+      renderMode: "design",
+    })),
+    transitions: input.transitions,
+  });
+  const canvas = prototypeToCanvas(prototype);
+  const sourceLines = [
+    input.designMd
+      ? "- `design.md` was provided and should drive tone, layout, and component details."
+      : "",
+    input.brandKit
+      ? "- Brand kit / `.fig` style data was provided and should drive color, typography, spacing, radii, and imagery."
+      : "",
+    input.codebaseStyles
+      ? "- Codebase style tokens were provided and should drive CSS variables, Tailwind classes, and existing visual conventions."
+      : "",
+    input.designNotes ? `- ${input.designNotes}` : "",
+  ].filter(Boolean);
+  const blocks: PlanBlock[] = [
+    {
+      id: createPlanBlockId("plan-design-overview"),
+      type: "rich-text",
+      title: "Design Plan",
+      editable: true,
+      data: {
+        markdown: [
+          `## Objective\n${input.brief}`,
+          "## Design Review\nUse the Design tab as the full-fidelity source of truth. It should contain detailed, on-brand HTML/CSS screens on the Figma-style canvas, with editable `data-design-id` targets for focused style changes. Use the Prototype tab only when interaction, flow, or state needs to be felt before implementation.",
+          sourceLines.length
+            ? `## Style Sources\n${sourceLines.join("\n")}`
+            : "## Style Sources\nNo external brand kit was provided; infer the smallest useful design system from the inspected codebase and document the assumptions here.",
+        ].join("\n\n"),
+      },
+    },
+    {
+      id: createPlanBlockId("design-implementation-map"),
+      type: "implementation-map",
+      title: "Implementation Map",
+      data: {
+        files: [
+          {
+            path: input.repoPath ? `${input.repoPath}/...` : "repo/path.tsx",
+            title: "Production files to update",
+            note:
+              input.implementationNotes ||
+              "Replace with concrete components, routes, style files, token sources, actions, and tests after the design direction is approved.",
+            language: "tsx",
+            snippet:
+              'const designDecision = {\n  designTab: "full-fidelity HTML/CSS review",\n  prototypeTab: "interactive behavior to rebuild in production components",\n};',
+          },
+        ],
+      },
+    },
+    {
+      id: createPlanBlockId("design-verification"),
+      type: "checklist",
+      title: "Verification",
+      data: {
+        items: [
+          {
+            id: "design-canvas",
+            label:
+              "Review the Design tab at desktop and narrow widths for real content, brand fidelity, readable type, and no clipped controls.",
+          },
+          {
+            id: "prototype-behavior",
+            label:
+              "Click through the Prototype tab when present and verify the design styling matches the canvas.",
+          },
+          {
+            id: "targeted-edits",
+            label:
+              "Select at least one `data-design-id` element in design mode and confirm targeted style patches preserve the rest of the screen.",
+          },
+          {
+            id: "implementation",
+            label:
+              "After approval, rebuild the chosen direction in production components rather than copying temporary prototype markup.",
+          },
+        ],
+      },
+    },
+  ];
+
+  return sanitizePlanContent(
+    planContentSchema.parse({
+      version: PLAN_CONTENT_VERSION,
+      title: input.title,
+      brief: input.brief,
+      prototype,
+      canvas: canvas
+        ? {
+            ...canvas,
+            mode: "design",
+            title: "Design Direction",
+            design: createDesignMetadata(input),
+          }
+        : undefined,
+      blocks,
+    }),
+  );
+}
+
 export function createPrototypeFromPlanContent(
   content: PlanContent,
   input?: { title?: string; brief?: string },
@@ -990,6 +1286,7 @@ function createPrototypeFromScreens(input: {
       title: screen.title,
       summary: screen.summary,
       surface: screen.surface ?? "browser",
+      renderMode: screen.renderMode,
       html:
         screen.html ??
         createPrototypeScreenHtml({
@@ -997,6 +1294,7 @@ function createPrototypeFromScreens(input: {
           summary: screen.summary ?? input.brief,
           nextId,
         }),
+      css: screen.css,
       state: screen.state,
     } satisfies PlanPrototypeScreen;
   });
@@ -1067,7 +1365,9 @@ function prototypeScreenFromArtboard(
       block?.summary ??
       (canvasTitle ? `From ${canvasTitle}` : undefined),
     surface: frame.surface ?? wireframe.surface,
+    renderMode: wireframe.renderMode,
     html: wireframe.html,
+    css: wireframe.css,
   };
 }
 
@@ -1119,7 +1419,9 @@ function prototypeToCanvas(prototype: PlanPrototype): PlanContent["canvas"] {
     surface: screen.surface ?? prototype.surface ?? "browser",
     wireframe: {
       surface: screen.surface ?? prototype.surface ?? "browser",
+      renderMode: screen.renderMode,
       html: screen.html,
+      css: screen.css,
       caption: screen.summary,
     },
   }));

--- a/templates/plan/server/plan-mdx.roundtrip.spec.ts
+++ b/templates/plan/server/plan-mdx.roundtrip.spec.ts
@@ -45,7 +45,9 @@ describe("plan MDX round-trip fidelity per block type", () => {
             title: "Start",
             summary: "Reviewer sees the request.",
             surface: "browser",
+            renderMode: "design",
             html: '<div><h1>Request</h1><button data-goto="approved">Approve</button></div>',
+            css: ".request-shell { color: #111827; }",
             state: [{ label: "Mode", value: "Review" }],
           },
           {
@@ -86,6 +88,10 @@ describe("plan MDX round-trip fidelity per block type", () => {
       'data-goto="approved"',
     );
     expect(result.prototype?.screens[0]?.state?.[0]?.value).toBe("Review");
+    expect(result.prototype?.screens[0]?.renderMode).toBe("design");
+    expect(result.prototype?.screens[0]?.css).toBe(
+      ".request-shell { color: #111827; }",
+    );
     expect(result.prototype?.transitions?.[0]).toMatchObject({
       from: "start",
       to: "approved",
@@ -106,6 +112,7 @@ describe("plan MDX round-trip fidelity per block type", () => {
             surface: "desktop",
             caption: "An HTML mockup screen",
             skeleton: false,
+            renderMode: "design",
             html: '<div class="grid"><h1>Dashboard</h1><p>Welcome back</p></div>',
             css: ".grid { display: grid; gap: 8px; }",
           },
@@ -123,6 +130,7 @@ describe("plan MDX round-trip fidelity per block type", () => {
     );
     expect(block.data.css).toBe(".grid { display: grid; gap: 8px; }");
     expect(block.data.caption).toBe("An HTML mockup screen");
+    expect(block.data.renderMode).toBe("design");
   });
 
   it("skeleton wireframe: round-trips skeleton:true flag", async () => {

--- a/templates/plan/server/plan-mdx.spec.ts
+++ b/templates/plan/server/plan-mdx.spec.ts
@@ -12,7 +12,31 @@ function sampleContent(): PlanContent {
     title: "Checkout review flow",
     brief: "Review checkout states before implementation.",
     canvas: {
+      mode: "design",
       title: "Checkout board",
+      design: {
+        designMd: "Use polished checkout review surfaces.",
+        brandKit: {
+          colors: { primary: "#0f766e", ink: "#111827" },
+          radius: { card: "8px" },
+        },
+        codebaseStyles: {
+          cssVars: { "--radius-card": "8px", "--color-primary": "#0f766e" },
+        },
+        notes: "Prefer dense operational UI over marketing layout.",
+        styleSources: [
+          {
+            kind: "design-md",
+            title: "design.md",
+            summary: "Primary design brief.",
+          },
+          {
+            kind: "codebase",
+            title: "app/globals.css",
+            summary: "Existing CSS custom properties.",
+          },
+        ],
+      },
       viewport: { zoom: 0.81, pan: { x: 24, y: 36 } },
       sections: [
         {
@@ -189,6 +213,8 @@ describe("plan MDX source adapter", () => {
     expect(folder["plan.mdx"]).toContain("<RichText");
     expect(folder["plan.mdx"]).toContain("<ImplementationMap");
     expect(folder["canvas.mdx"]).toContain("<DesignBoard");
+    expect(folder["canvas.mdx"]).toContain('mode="design"');
+    expect(folder["canvas.mdx"]).toContain("styleSources");
     expect(folder["canvas.mdx"]).toContain("<Artboard");
     expect(folder["canvas.mdx"]).toContain("<FrameScreen");
     expect(folder["canvas.mdx"]).toContain("<Annotation");
@@ -221,6 +247,13 @@ describe("plan MDX source adapter", () => {
     ).toBe("Continue");
     expect(parsed.canvas?.viewport?.zoom).toBe(0.81);
     expect(parsed.canvas?.viewport?.pan?.x).toBe(24);
+    expect(parsed.canvas?.mode).toBe("design");
+    expect(
+      parsed.canvas?.design?.styleSources?.map((source) => source.title),
+    ).toEqual(["design.md", "app/globals.css"]);
+    expect(parsed.canvas?.design?.brandKit?.colors).toMatchObject({
+      primary: "#0f766e",
+    });
     expect(parsed.canvas?.annotations?.map((note) => note.id)).toContain(
       "legacy-review-note",
     );

--- a/templates/plan/server/plan-mdx.ts
+++ b/templates/plan/server/plan-mdx.ts
@@ -298,6 +298,7 @@ function serializeNode(node: PlanWireframeNode, indent = ""): string {
 
 function serializeScreen(data: {
   surface: string;
+  renderMode?: string;
   caption?: string;
   html?: string;
   css?: string;
@@ -306,6 +307,7 @@ function serializeScreen(data: {
 }): string {
   const attrs = [
     prop("surface", data.surface),
+    prop("renderMode", data.renderMode),
     prop("caption", data.caption),
     prop("html", data.html),
     prop("css", data.css),
@@ -463,7 +465,7 @@ function serializePrototype(prototype: PlanPrototype): string {
   const screens = prototype.screens
     .map(
       (screen) =>
-        `<PrototypeScreen${prop("id", screen.id)}${prop("title", screen.title)}${prop("summary", screen.summary)}${prop("surface", screen.surface)}${prop("state", screen.state)}${prop("html", screen.html)} />`,
+        `<PrototypeScreen${prop("id", screen.id)}${prop("title", screen.title)}${prop("summary", screen.summary)}${prop("surface", screen.surface)}${prop("renderMode", screen.renderMode)}${prop("state", screen.state)}${prop("html", screen.html)}${prop("css", screen.css)} />`,
     )
     .join("\n\n");
   const transitions = (prototype.transitions ?? [])
@@ -536,7 +538,7 @@ function serializeCanvas(content: PlanContent): string {
     )
     .join("\n");
 
-  return `<DesignBoard${prop("title", canvas.title)}${prop("version", content.version)}>\n${[
+  return `<DesignBoard${prop("title", canvas.title)}${prop("mode", canvas.mode)}${prop("design", canvas.design)}${prop("version", content.version)}>\n${[
     sectionSource,
     looseFrames,
     annotations,
@@ -789,6 +791,10 @@ function parseScreen(
   return {
     surface:
       (stringAttr(node, "surface") as PlanArtboard["surface"]) ?? "desktop",
+    renderMode: stringAttr(
+      node,
+      "renderMode",
+    ) as PlanWireframeBlock["data"]["renderMode"],
     caption: stringAttr(node, "caption"),
     html: stringAttr(node, "html"),
     css: stringAttr(node, "css"),
@@ -918,11 +924,16 @@ function parsePrototype(source: string): PlanPrototype | undefined {
         title: stringAttr(child, "title"),
         summary: stringAttr(child, "summary"),
         surface: stringAttr(child, "surface") as PlanPrototypeScreen["surface"],
+        renderMode: stringAttr(
+          child,
+          "renderMode",
+        ) as PlanPrototypeScreen["renderMode"],
         state: arrayAttr<NonNullable<PlanPrototypeScreen["state"]>[number]>(
           child,
           "state",
         ),
         html,
+        css: stringAttr(child, "css"),
       });
       continue;
     }
@@ -1032,7 +1043,14 @@ function parseCanvas(source: string): PlanContent["canvas"] {
     parseCanvasChild(child, undefined, `canvas-${index}`);
 
   return {
+    mode: stringAttr(board, "mode") as NonNullable<
+      PlanContent["canvas"]
+    >["mode"],
     title: stringAttr(board, "title"),
+    design: dataAttr<NonNullable<PlanContent["canvas"]>["design"]>(
+      board,
+      "design",
+    ),
     sections: sections.length ? sections : undefined,
     frames,
     flow: flow.length ? flow : undefined,

--- a/templates/plan/shared/blocks/wireframe.config.ts
+++ b/templates/plan/shared/blocks/wireframe.config.ts
@@ -98,6 +98,7 @@ function serializeNode(node: PlanWireframeNode, indent = ""): string {
 function serializeScreen(data: WireframeData): string {
   const attrs = [
     prop("surface", data.surface),
+    prop("renderMode", data.renderMode),
     prop("caption", data.caption),
     prop("html", data.html),
     prop("css", data.css),
@@ -193,6 +194,7 @@ function parseScreen(node: WireframeMdxNode, idContext: string): WireframeData {
   return {
     surface:
       (stringAttr(node, "surface") as WireframeData["surface"]) ?? "desktop",
+    renderMode: stringAttr(node, "renderMode") as WireframeData["renderMode"],
     caption: stringAttr(node, "caption"),
     html: stringAttr(node, "html"),
     css: stringAttr(node, "css"),

--- a/templates/plan/shared/plan-content.ts
+++ b/templates/plan/shared/plan-content.ts
@@ -134,6 +134,8 @@ export type PlanWireframeSurface =
   | "panel"
   | "browser";
 
+export type PlanVisualCanvasMode = "wireframe" | "design";
+
 /** Tone keyword reused across screen primitives. The renderer maps to color. */
 export type PlanWireframeTone = "default" | "accent" | "warn" | "ok" | "muted";
 
@@ -241,6 +243,8 @@ export type PlanWireframeBlock = PlanBlockBase & {
   type: "wireframe";
   data: {
     surface: PlanWireframeSurface;
+    /** `design` renders full-fidelity branded HTML/CSS instead of a sketch. */
+    renderMode?: PlanVisualCanvasMode;
     caption?: string;
     /**
      * Neutral, textless loading register. The renderer drops borders, the sketch
@@ -701,6 +705,7 @@ export type PlanPrototypeScreen = {
   title?: string;
   summary?: string;
   surface?: PlanWireframeSurface;
+  renderMode?: PlanVisualCanvasMode;
   /**
    * A bounded semantic HTML fragment. Prototype HTML may use the renderer's
    * safe Alpine-like directives (`x-data`, `x-model`, `x-for`, `x-text`,
@@ -709,6 +714,8 @@ export type PlanPrototypeScreen = {
    * changes; never include scripts.
    */
   html: string;
+  /** Scoped CSS for full-fidelity prototype screens. */
+  css?: string;
   /** Optional metadata for exports/back-compat; the live viewer does not render this as chrome. */
   state?: Array<{
     id?: string;
@@ -751,7 +758,21 @@ export type PlanContent = {
   notionSync?: boolean;
   prototype?: PlanPrototype;
   canvas?: {
+    /** `design` changes the top canvas tab from Wireframes to Design. */
+    mode?: PlanVisualCanvasMode;
     title?: string;
+    /** Captured brand/design source context used by /plan-design. */
+    design?: {
+      designMd?: string;
+      brandKit?: Record<string, unknown>;
+      codebaseStyles?: Record<string, unknown>;
+      notes?: string;
+      styleSources?: Array<{
+        kind: "design-md" | "fig-file" | "codebase" | "manual";
+        title?: string;
+        summary?: string;
+      }>;
+    };
     /** Optional initial viewport persisted by source-sync exports. */
     viewport?: PlanCanvasViewport;
     sections?: PlanBoardSection[];
@@ -793,6 +814,17 @@ export type PlanContentPatch =
       op: "patch-prototype-html";
       screenId: string;
       edits: Array<{ find: string; replace: string; all?: boolean }>;
+    }
+  | {
+      /**
+       * Update inline CSS for one full-fidelity design element identified by
+       * `data-design-id` or `data-plan-design-id`.
+       */
+      op: "update-design-element-style";
+      elementId: string;
+      frameId?: string;
+      blockId?: string;
+      styles: Record<string, string | null>;
     }
   | {
       op: "replace-block";
@@ -900,7 +932,7 @@ const baseBlockSchema = z.object({
 });
 
 const unsafeCustomHtmlPattern =
-  /(?:<!doctype|<\/?(?:html|head|body|script|style|iframe|object|embed|link|meta|base|form|svg|math|noscript|frame|frameset|applet|portal|marquee)[\s>/]|\b(?:java\s*script|vb\s*script|data\s*:\s*(?:text\/html|image\/svg\+xml))\s*:?\s*|\bsrcdoc\s*=|(?:^|\s)(?:on[a-z][\w:-]*|:on[a-z][\w:-]*|x-bind:on[a-z][\w:-]*|:style|x-bind:style)\s*=|expression\s*\(|url\s*\(\s*['"]?\s*(?:java\s*script|vb\s*script|data\s*:\s*(?:text\/html|image\/svg\+xml)))/i;
+  /(?:<!doctype|<\/?(?:html|head|body|script|style|iframe|object|embed|link|meta|base|form|svg|math|noscript|frame|frameset|applet|portal|marquee)[\s>/]|@(?:import|font-face|keyframes|page|namespace|charset)\b|\b(?:java\s*script|vb\s*script|data\s*:\s*(?:text\/html|image\/svg\+xml))\s*:?\s*|\bsrcdoc\s*=|(?:^|\s)(?:on[a-z][\w:-]*|:on[a-z][\w:-]*|x-bind:on[a-z][\w:-]*|:style|x-bind:style)\s*=|expression\s*\(|url\s*\(\s*['"]?\s*(?:java\s*script|vb\s*script|data\s*:\s*(?:text\/html|image\/svg\+xml)))/i;
 
 function decodeSafetyEntities(value: string): string {
   return value
@@ -917,15 +949,35 @@ function decodeSafetyEntities(value: string): string {
     });
 }
 
+function decodeCssSafetyEscapes(value: string): string {
+  return value.replace(/\\([0-9a-fA-F]{1,6}\s?|.)/g, (_match, escaped) => {
+    const hex = String(escaped).match(/^[0-9a-fA-F]{1,6}/)?.[0];
+    if (hex) {
+      const point = Number.parseInt(hex, 16);
+      return Number.isFinite(point) ? String.fromCodePoint(point) : "";
+    }
+    return String(escaped)[0] ?? "";
+  });
+}
+
+const decodedSafetyText = (value: string) =>
+  decodeCssSafetyEscapes(decodeSafetyEntities(value));
+
 const compactSafetyText = (value: string) =>
-  decodeSafetyEntities(value)
+  decodedSafetyText(value)
     .toLowerCase()
     .replace(/[\u0000-\u0020]+/g, "");
 
+const unsafeViewportCssPattern =
+  /(?:^|[;{\s])position\s*:\s*(?:fixed|sticky)\b|(?:^|[;{\s])z-index\s*:\s*[1-9]\d{4,}\b/i;
+
 const noFullHtmlDocument = (value: string) => {
+  const decoded = decodedSafetyText(value);
   const compact = compactSafetyText(value);
   return (
     !unsafeCustomHtmlPattern.test(value) &&
+    !unsafeCustomHtmlPattern.test(decoded) &&
+    !unsafeViewportCssPattern.test(decoded) &&
     !/(?:javascript|vbscript):|data:(?:text\/html|image\/svg\+xml)|expression\(|url\(['"]?(?:javascript|vbscript|data:(?:text\/html|image\/svg\+xml))/.test(
       compact,
     )
@@ -1045,9 +1097,12 @@ const wireframeSurfaceSchema = z.enum([
   "browser",
 ]);
 
+const visualCanvasModeSchema = z.enum(["wireframe", "design"]);
+
 export const wireframeDataSchema: z.ZodType<PlanWireframeBlock["data"]> = z
   .object({
     surface: wireframeSurfaceSchema,
+    renderMode: visualCanvasModeSchema.optional(),
     caption: z.string().trim().max(400).optional(),
     skeleton: z.boolean().optional(),
     html: z
@@ -1623,6 +1678,43 @@ const boardSectionSchema: z.ZodType<PlanBoardSection> = z.object({
   artboardIds: z.array(idSchema).max(80).optional(),
 });
 
+const DESIGN_METADATA_JSON_MAX = 20_000;
+
+function isCompactJsonRecord(value: Record<string, unknown>): boolean {
+  try {
+    return JSON.stringify(value).length <= DESIGN_METADATA_JSON_MAX;
+  } catch {
+    return false;
+  }
+}
+
+const designMetadataSchema = z.object({
+  designMd: z.string().max(100_000).optional(),
+  brandKit: z
+    .record(z.string(), z.unknown())
+    .refine(isCompactJsonRecord, {
+      message: "Brand kit metadata is too large.",
+    })
+    .optional(),
+  codebaseStyles: z
+    .record(z.string(), z.unknown())
+    .refine(isCompactJsonRecord, {
+      message: "Codebase style metadata is too large.",
+    })
+    .optional(),
+  notes: z.string().max(20_000).optional(),
+  styleSources: z
+    .array(
+      z.object({
+        kind: z.enum(["design-md", "fig-file", "codebase", "manual"]),
+        title: z.string().trim().max(180).optional(),
+        summary: z.string().trim().max(2_000).optional(),
+      }),
+    )
+    .max(20)
+    .optional(),
+});
+
 const prototypeScreenStateSchema = z.object({
   id: idSchema.optional(),
   label: z.string().trim().min(1).max(80),
@@ -1635,10 +1727,19 @@ const prototypeScreenSchema: z.ZodType<PlanPrototypeScreen> = z
     title: z.string().trim().max(180).optional(),
     summary: z.string().trim().max(500).optional(),
     surface: wireframeSurfaceSchema.optional(),
+    renderMode: visualCanvasModeSchema.optional(),
     html: z.string().max(40_000).refine(noFullHtmlDocument, {
       message:
         "Prototype screen html must be a bounded fragment without html/head/body/script/style tags.",
     }),
+    css: z
+      .string()
+      .max(20_000)
+      .refine(noFullHtmlDocument, {
+        message:
+          "Prototype screen css must not include document or script tags.",
+      })
+      .optional(),
     state: z.array(prototypeScreenStateSchema).max(24).optional(),
   })
   .strict();
@@ -1768,7 +1869,9 @@ export const planContentSchema: z.ZodType<PlanContent> = z
       prototype: prototypeSchema.optional(),
       canvas: z
         .object({
+          mode: visualCanvasModeSchema.optional(),
           title: z.string().trim().max(180).optional(),
+          design: designMetadataSchema.optional(),
           viewport: z
             .object({
               zoom: z.number().min(0.05).max(8).optional(),
@@ -2017,12 +2120,21 @@ const prototypeScreenPatchSchema = z
     title: z.string().trim().max(180).optional(),
     summary: z.string().trim().max(500).optional(),
     surface: wireframeSurfaceSchema.optional(),
+    renderMode: visualCanvasModeSchema.optional(),
     html: z
       .string()
       .max(40_000)
       .refine(noFullHtmlDocument, {
         message:
           "Prototype screen html must be a bounded fragment without html/head/body/script/style tags.",
+      })
+      .optional(),
+    css: z
+      .string()
+      .max(20_000)
+      .refine(noFullHtmlDocument, {
+        message:
+          "Prototype screen css must not include document or script tags.",
       })
       .optional(),
     state: z.array(prototypeScreenStateSchema).max(24).optional(),
@@ -2062,6 +2174,24 @@ export const planContentPatchSchema: z.ZodType<PlanContentPatch> =
         .min(1)
         .max(40),
     }),
+    z
+      .object({
+        op: z.literal("update-design-element-style"),
+        elementId: z.string().trim().min(1).max(160),
+        frameId: idSchema.optional(),
+        blockId: idSchema.optional(),
+        styles: z.record(
+          z.string().trim().min(1).max(80),
+          z.union([z.string().max(400), z.null()]),
+        ),
+      })
+      .refine((patch) => Boolean(patch.frameId || patch.blockId), {
+        message: "Provide frameId or blockId for update-design-element-style.",
+      })
+      .refine((patch) => Object.keys(patch.styles).length > 0, {
+        message: "Provide at least one style to update.",
+        path: ["styles"],
+      }),
     z.object({
       op: z.literal("replace-block"),
       blockId: idSchema,
@@ -2228,6 +2358,10 @@ export function applyPlanContentPatches(
           : html.replace(edit.find, edit.replace);
       }
       screen.html = html;
+      continue;
+    }
+    if (patch.op === "update-design-element-style") {
+      updateDesignElementStyle(next, patch);
       continue;
     }
     if (patch.op === "replace-block") {
@@ -2480,6 +2614,227 @@ export function applyPlanContentPatches(
 
 function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
+}
+
+type DesignElementStylePatch = Extract<
+  PlanContentPatch,
+  { op: "update-design-element-style" }
+>;
+
+function updateDesignElementStyle(
+  content: PlanContent,
+  patch: DesignElementStylePatch,
+) {
+  const updateData = (
+    data: PlanWireframeBlock["data"],
+    label: string,
+  ): PlanWireframeBlock["data"] => {
+    if (typeof data.html !== "string") {
+      throw new Error(`${label} has no HTML design fragment to edit.`);
+    }
+    return {
+      ...data,
+      html: updateDesignElementStyleHtml(
+        data.html,
+        patch.elementId,
+        patch.styles,
+      ),
+    };
+  };
+
+  const updateBlockWireframe = (
+    blockId: string,
+    sourceData?: PlanWireframeBlock["data"],
+  ) => {
+    content.blocks = updateBlock(content.blocks, blockId, (block) => {
+      if (block.type !== "wireframe") {
+        throw new Error(`Block ${blockId} is ${block.type}, not wireframe.`);
+      }
+      return {
+        ...block,
+        data: sourceData
+          ? updateData(sourceData, `Canvas frame ${patch.frameId}`)
+          : updateData(block.data, `Block ${blockId}`),
+      };
+    }).blocks;
+  };
+
+  if (patch.frameId) {
+    const frame = content.canvas?.frames.find(
+      (candidate) => candidate.id === patch.frameId,
+    );
+    if (!frame) {
+      throw new Error(`Canvas frame ${patch.frameId} was not found.`);
+    }
+    if (frame.wireframe) {
+      const updated = updateData(frame.wireframe, `Canvas frame ${frame.id}`);
+      frame.wireframe = updated;
+      if (frame.blockId) updateBlockWireframe(frame.blockId, updated);
+      updatePrototypeDesignElementStyle(content, patch, frame);
+      return;
+    }
+    if (frame.blockId) {
+      updateBlockWireframe(frame.blockId);
+      updatePrototypeDesignElementStyle(content, patch, frame);
+      return;
+    }
+    throw new Error(`Canvas frame ${frame.id} has no editable design HTML.`);
+  }
+
+  if (patch.blockId) {
+    updateBlockWireframe(patch.blockId);
+    updatePrototypeDesignElementStyle(content, patch);
+    return;
+  }
+
+  throw new Error(
+    "Provide frameId or blockId for update-design-element-style.",
+  );
+}
+
+function updatePrototypeDesignElementStyle(
+  content: PlanContent,
+  patch: DesignElementStylePatch,
+  frame?: PlanArtboard,
+) {
+  if (!content.prototype) return;
+  const candidateIds = new Set<string>();
+  const addFrameScreenIds = (id: string | undefined) => {
+    if (!id) return;
+    candidateIds.add(id);
+    if (id.startsWith("frame-")) candidateIds.add(id.slice("frame-".length));
+  };
+
+  addFrameScreenIds(frame?.id ?? patch.frameId);
+  if (candidateIds.size === 0 && patch.blockId) {
+    for (const screen of content.prototype.screens) {
+      if (countDesignElementMatches(screen.html, patch.elementId) > 0) {
+        candidateIds.add(screen.id);
+      }
+    }
+  }
+
+  for (const screen of content.prototype.screens) {
+    if (!candidateIds.has(screen.id)) continue;
+    if (countDesignElementMatches(screen.html, patch.elementId) === 0) continue;
+    screen.html = updateDesignElementStyleHtml(
+      screen.html,
+      patch.elementId,
+      patch.styles,
+    );
+  }
+}
+
+function updateDesignElementStyleHtml(
+  html: string,
+  elementId: string,
+  styles: Record<string, string | null>,
+): string {
+  const escaped = escapeRegExp(elementId);
+  const tagPattern = new RegExp(
+    `<([a-zA-Z][\\w:-]*)([^<>]*\\s(?:data-design-id|data-plan-design-id)\\s*=\\s*(["'])${escaped}\\3[^<>]*)>`,
+    "gi",
+  );
+  const matches = Array.from(html.matchAll(tagPattern));
+  if (matches.length === 0) {
+    throw new Error(
+      `Design element ${elementId} was not found. Add data-design-id="${elementId}" to the target element or select an existing design id.`,
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Design element ${elementId} matched ${matches.length} elements; data-design-id values must be unique within a design screen.`,
+    );
+  }
+  const match = matches[0];
+  if (!match) throw new Error(`Design element ${elementId} was not found.`);
+  const [openingTag, tagName, attrs] = match;
+  const nextAttrs = mergeStyleAttribute(attrs, styles);
+  return html.replace(openingTag, `<${tagName}${nextAttrs}>`);
+}
+
+function countDesignElementMatches(html: string, elementId: string): number {
+  const escaped = escapeRegExp(elementId);
+  return Array.from(
+    html.matchAll(
+      new RegExp(
+        `<[a-zA-Z][\\w:-]*[^<>]*\\s(?:data-design-id|data-plan-design-id)\\s*=\\s*(["'])${escaped}\\1[^<>]*>`,
+        "gi",
+      ),
+    ),
+  ).length;
+}
+
+function mergeStyleAttribute(
+  attrs: string,
+  updates: Record<string, string | null>,
+) {
+  const styleAttr = attrs.match(/\sstyle\s*=\s*(["'])([\s\S]*?)\1/i);
+  const styles = parseInlineStyle(styleAttr?.[2] ?? "");
+
+  for (const [rawName, value] of Object.entries(updates)) {
+    const name = normalizeCssPropertyName(rawName);
+    if (value === null || value.trim() === "") styles.delete(name);
+    else {
+      const trimmed = value.trim();
+      if (!noFullHtmlDocument(`${name}: ${trimmed}`)) {
+        throw new Error(`Unsafe CSS style value for ${name}.`);
+      }
+      styles.set(name, trimmed);
+    }
+  }
+
+  const nextStyle = serializeInlineStyle(styles);
+  if (!nextStyle) return attrs.replace(/\sstyle\s*=\s*(["'])([\s\S]*?)\1/i, "");
+  const escapedStyle = escapeHtmlAttribute(nextStyle);
+  if (styleAttr) {
+    return attrs.replace(
+      /\sstyle\s*=\s*(["'])([\s\S]*?)\1/i,
+      ` style="${escapedStyle}"`,
+    );
+  }
+  return `${attrs} style="${escapedStyle}"`;
+}
+
+function parseInlineStyle(style: string) {
+  const parsed = new Map<string, string>();
+  for (const entry of style.split(";")) {
+    const colon = entry.indexOf(":");
+    if (colon <= 0) continue;
+    const name = normalizeCssPropertyName(entry.slice(0, colon));
+    const value = entry.slice(colon + 1).trim();
+    if (value) parsed.set(name, value);
+  }
+  return parsed;
+}
+
+function serializeInlineStyle(styles: Map<string, string>) {
+  return Array.from(styles.entries())
+    .map(([name, value]) => `${name}: ${value}`)
+    .join("; ");
+}
+
+function normalizeCssPropertyName(name: string) {
+  const normalized = name
+    .trim()
+    .replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)
+    .toLowerCase();
+  if (!/^(?:--)?[a-z0-9][a-z0-9-]*$/.test(normalized)) {
+    throw new Error(`Invalid CSS property name: ${name}`);
+  }
+  return normalized;
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function escapeHtmlAttribute(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 /** Compact a snippet for find/replace error messages. */

--- a/templates/plan/shared/plan-content.ts
+++ b/templates/plan/shared/plan-content.ts
@@ -2683,7 +2683,6 @@ function updateDesignElementStyle(
 
   if (patch.blockId) {
     updateBlockWireframe(patch.blockId);
-    updatePrototypeDesignElementStyle(content, patch);
     return;
   }
 
@@ -2706,13 +2705,7 @@ function updatePrototypeDesignElementStyle(
   };
 
   addFrameScreenIds(frame?.id ?? patch.frameId);
-  if (candidateIds.size === 0 && patch.blockId) {
-    for (const screen of content.prototype.screens) {
-      if (countDesignElementMatches(screen.html, patch.elementId) > 0) {
-        candidateIds.add(screen.id);
-      }
-    }
-  }
+  if (candidateIds.size === 0) return;
 
   for (const screen of content.prototype.screens) {
     if (!candidateIds.has(screen.id)) continue;


### PR DESCRIPTION
## Summary
- add `/plan-design` as a full-fidelity Plans workflow with a design canvas and matching prototype surface
- add design metadata parsing/storage hooks for design.md, brand kit/.fig data, and codebase style tokens
- add selectable design elements with targeted style patching, prototype sync, CSS sanitization, mobile fit, and connector label layering
- package and sync the new skill across template, exported skills, and CLI install/materialization flows

## Verification
- `pnpm run prep`
- `pnpm --dir templates/plan exec vitest run`
- `PLAN_BASE_URL=http://localhost:8081 pnpm --dir templates/plan exec playwright test e2e/plan-design.spec.ts --project=authed`
- `pnpm --dir templates/plan build`
- `pnpm --dir packages/core exec vitest run src/cli/skills.spec.ts src/cli/plan-install.spec.ts src/cli/skills.sync.spec.ts`