### PR TITLE
fix(deploy): stub browser-only Excalidraw/Mermaid in Nitro server bundle (prod 502)

### DIFF
--- a/.changeset/fix-excalidraw-ssr-window-crash.md
+++ b/.changeset/fix-excalidraw-ssr-window-crash.md
@@ -1,0 +1,15 @@
+---
+"@agent-native/core": patch
+---
+
+Fix production 502s on SSR apps (docs, slides, content, assets) caused by the
+browser-only Excalidraw/Mermaid renderers leaking into the Nitro server bundle.
+Nitro re-bundles the server from node_modules and Rolldown merged
+`@excalidraw/excalidraw` into a shared vendor chunk that the SSR render path
+(tiptap, radix-ui, recharts) imported statically, so its top-level `window`
+access ran at function cold-start and crashed every request with
+`ReferenceError: window is not defined`. The Vite SSR build already stubbed these
+libs for `build/server`, but that plugin didn't run during Nitro's separate
+bundle. The deploy build now mirrors the same stub as a Rolldown plugin, replacing
+`@excalidraw/excalidraw`, `@excalidraw/mermaid-to-excalidraw`, and `mermaid` with
+an inert proxy in the server bundle (they only ever render client-side).

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1721,6 +1721,68 @@ export async function runNitroBuildPipeline(
   await hooks.nitroBuild(nitro);
 }
 
+/**
+ * Browser-only diagram/drawing renderers that execute `window`-touching code at
+ * module-evaluation time. They are rendered exclusively client-side — core's
+ * `MermaidBlock` and templates' Excalidraw slides mount them inside `useEffect` /
+ * `React.lazy`, never during SSR — so the server never needs the real module.
+ *
+ * Keep this list to libraries that are *provably never* invoked on the server.
+ * Node-only deps that DO run server-side (pdf-parse, @google/genai, canvas, …)
+ * must NOT go here — see `heavyClientExternals` for the edge-worker externals.
+ */
+const BROWSER_ONLY_SERVER_LIBS = [
+  "@excalidraw/excalidraw",
+  "@excalidraw/mermaid-to-excalidraw",
+  "mermaid",
+];
+
+/**
+ * Rolldown plugin for the Nitro server bundle that replaces the browser-only
+ * renderers above with an inert proxy module.
+ *
+ * Why this is needed: Nitro re-bundles the server from node_modules with its own
+ * Rolldown pipeline, and Rolldown merges Excalidraw into a SHARED vendor chunk
+ * that the SSR render path (tiptap / radix-ui / recharts) imports *statically*.
+ * That evaluates Excalidraw's top-level `window` access at function cold-start
+ * and crashes every request with `ReferenceError: window is not defined` (HTTP
+ * 502). The Vite SSR build already stubs these via `ssrStubPlugin` for
+ * `build/server`, but that Vite plugin doesn't run during Nitro's separate
+ * bundle — so mirror the same stub here.
+ */
+function createBrowserOnlyServerStubPlugin() {
+  const stubbed = new Set(BROWSER_ONLY_SERVER_LIBS);
+  const STUB_ID = "\0agent-native-browser-only-server-stub";
+  return {
+    name: "agent-native-browser-only-server-stub",
+    // enforce: "pre" so we intercept before Nitro's node resolver bundles the
+    // real package. defu concatenates rollupConfig.plugins ahead of Nitro's own.
+    resolveId(id: string) {
+      // Match the bare package name or any subpath (incl. `/index.css`).
+      const pkg = id
+        .split("/")
+        .slice(0, id.startsWith("@") ? 2 : 1)
+        .join("/");
+      return stubbed.has(pkg) ? STUB_ID : null;
+    },
+    load(id: string) {
+      if (id !== STUB_ID) return null;
+      // A Proxy answers any property access (default or named) with another
+      // proxy, so every import shape resolves without evaluating real browser
+      // code. It is never actually invoked on the server, so it never throws.
+      return (
+        "const handler = { get(_t, p) {" +
+        " if (p === Symbol.toPrimitive) return () => '';" +
+        " if (p === 'then') return undefined;" +
+        " if (p === '__esModule') return true;" +
+        " return new Proxy(function () {}, handler); } };" +
+        "const stub = new Proxy(function () {}, handler);" +
+        "export default stub;"
+      );
+    },
+  };
+}
+
 async function buildWithNitro() {
   console.log(`[deploy] Building for preset "${preset}" via Nitro...`);
   const appBasePath = normalizeConfiguredAppBasePath();
@@ -1811,6 +1873,15 @@ export default bundle;
     },
     virtual: {
       "virtual:agents-bundle": agentsBundleModuleSource,
+    },
+    // Replace browser-only renderers (Excalidraw/Mermaid) with an inert proxy in
+    // the server bundle. Without this, Nitro's Rolldown build pulls the real
+    // Excalidraw into a shared vendor chunk imported statically by the SSR render
+    // path, and its top-level `window` access crashes the function at cold-start
+    // (ReferenceError: window is not defined → every request 502s). Mirrors the
+    // Vite `ssrStubPlugin`, which only covers the `build/server` step.
+    rollupConfig: {
+      plugins: [createBrowserOnlyServerStubPlugin()],
     },
     ...(providedPluginsNitroPlugin
       ? { plugins: [providedPluginsNitroPlugin] }


### PR DESCRIPTION
## Problem

**agent-native.com returned 502 on every request** (also slides, content, assets). The Netlify SSR `server` function crashed at cold-start, diagnosed from prod logs (`netlify logs:function server`):

```
ReferenceError: window is not defined
  at file:///var/task/_libs/@excalidraw/excalidraw+[...].mjs:89:...
  at ModuleJob.run ... async RO (___netlify-bootstrap.mjs) ... StreamingInvokeProcessor.handler
```

## Root cause

`@excalidraw/excalidraw` touches `window` at module-evaluation time. Nitro re-bundles the server from `node_modules` with its own Rolldown pipeline, and Rolldown **merged Excalidraw into a shared vendor chunk** imported **statically** by the SSR render path (tiptap / radix-ui / recharts) — so its top-level `window` access ran at function init and 502'd every request.

The Vite SSR build already stubs these libs for `build/server` via `ssrStubPlugin`, but **that plugin doesn't run during Nitro's separate bundle** (`.output/`, which is what deploys). That's why `slides` 502'd even though its `vite.config.ts` already listed `@excalidraw/excalidraw` in `ssrStubs`.

## Fix

The deploy build (`packages/core/src/deploy/build.ts`) mirrors the stub as a Rolldown plugin on the Nitro bundle, replacing `@excalidraw/excalidraw`, `@excalidraw/mermaid-to-excalidraw`, and `mermaid` with an inert proxy in the **server** bundle. They only ever render client-side (useEffect / React.lazy), so SSR never calls into them; the client build keeps the real modules.

## Verification

- **docs** (`netlify` preset, the agent-native.com target): **zero** `@excalidraw` references in `.output/server`.
- **slides** (`node` preset, the hardest case — app-level Excalidraw + the stub paradox): real `_libs/@excalidraw/excalidraw` chunk gone; static import chain severed; server entry imports with **no `window is not defined`**.
- `pnpm prep` passed locally on the identical change; core `tsc --noEmit` passes against latest main.