### PR TITLE
fix(core): fix infinite spinner after login from Rolldown recharts prebundle

### DIFF
--- a/.changeset/fix-post-login-spinner-recharts.md
+++ b/.changeset/fix-post-login-spinner-recharts.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix apps stuck on the `ClientOnly` loading spinner after sign-in when Vite 8's Rolldown dependency optimizer mis-bundled `recharts` → `es-toolkit` CJS compat (`require_isUnsafeProperty is not a function`). Exclude those packages from `optimizeDeps`, allow workspace root `node_modules` in dev server `fs.allow`, and lazy-load Context X-Ray so the treemap is not on the critical startup path.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1370,6 +1370,39 @@ function isInternalContinuationTurn(messages: EngineMessage[]): boolean {
   return false;
 }
 
+function isToolResultOnlyUserMessage(message: EngineMessage): boolean {
+  return (
+    message.role === "user" &&
+    message.content.length > 0 &&
+    message.content.every((part) => part.type === "tool-result")
+  );
+}
+
+/** Start of the active turn on an internal continuation (real user prompt). */
+function findCurrentTurnStartForContinuation(
+  messages: EngineMessage[],
+): number {
+  let i = messages.length - 1;
+  while (i >= 0) {
+    const message = messages[i];
+    if (message.role !== "user") {
+      i--;
+      continue;
+    }
+    const userText = textFromEngineMessage(message);
+    if (userText.startsWith(AGENT_INTERNAL_CONTINUE_PROMPT)) {
+      i--;
+      continue;
+    }
+    if (isToolResultOnlyUserMessage(message)) {
+      i--;
+      continue;
+    }
+    return i;
+  }
+  return 0;
+}
+
 function seedReadOnlyToolResultsFromHistory(
   messages: EngineMessage[],
   actions: Record<string, ActionEntry>,
@@ -1422,19 +1455,7 @@ function seedWriteToolInterruptionsFromHistory(
   const interruptions = new Map<string, number>();
   if (!isInternalContinuationTurn(messages)) return interruptions;
 
-  // Only count interruptions from the CURRENT logical turn — the continuation
-  // chain after the most recent user message. `messages` on an internal
-  // continuation is `...structuredHistory` (prior turns) + the current turn, so
-  // scanning the whole array would let an interrupted write from an earlier
-  // turn inflate the retry budget of an identical (name + input) write in a
-  // later turn, tripping `repeated_write_tool_interruption` immediately.
-  let turnStart = 0;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].role === "user") {
-      turnStart = i;
-      break;
-    }
-  }
+  const turnStart = findCurrentTurnStartForContinuation(messages);
   const turnMessages = messages.slice(turnStart);
 
   const pendingToolCalls = new Map<string, { name: string; input: unknown }>();

--- a/packages/core/src/cli/plan-install.spec.ts
+++ b/packages/core/src/cli/plan-install.spec.ts
@@ -240,6 +240,8 @@ describe(
  * ───────────────────────────────────────────────────────────────────────── */
 
 describe("Plans skills install — materialized output", () => {
+  const PLANS_INSTALL_SKILL_NAMES = ["visual-plan", "visual-recap"];
+
   /**
    * Run a Plans install via `alias`, capturing each materialized SKILL.md's
    * contents from inside the runCommand callback. The CLI writes the skills to
@@ -303,14 +305,7 @@ describe("Plans skills install — materialized output", () => {
     const { result, captured, npxCalls } =
       await materializeViaAlias("visual-plan");
     expect(result.id).toBe("visual-plans");
-    expect(result.skillNames).toEqual([
-      "visual-plan",
-      "visual-recap",
-      "visual-questions",
-      "ui-plan",
-      "prototype-plan",
-      "plan-design",
-    ]);
+    expect(result.skillNames).toEqual(PLANS_INSTALL_SKILL_NAMES);
     expect(result.mcpUrl).toBe(
       "https://plan.agent-native.com/_agent-native/mcp",
     );
@@ -319,10 +314,6 @@ describe("Plans skills install — materialized output", () => {
     const expected: Array<[string, string]> = [
       ["visual-plan", VISUAL_PLANS_SKILL_MD],
       ["visual-recap", VISUAL_RECAP_SKILL_MD],
-      ["visual-questions", VISUAL_QUESTIONS_SKILL_MD],
-      ["ui-plan", UI_PLAN_SKILL_MD],
-      ["prototype-plan", PROTOTYPE_PLAN_SKILL_MD],
-      ["plan-design", PLAN_DESIGN_SKILL_MD],
     ];
     for (const [name, constant] of expected) {
       // The materialized file the user receives must be byte-identical to the
@@ -330,45 +321,53 @@ describe("Plans skills install — materialized output", () => {
       expect(captured[name], `materialized ${name}/SKILL.md`).toBe(constant);
     }
     // No extra surprise skills materialized.
-    expect(Object.keys(captured).sort()).toEqual([
-      "plan-design",
-      "prototype-plan",
-      "ui-plan",
-      "visual-plan",
-      "visual-questions",
-      "visual-recap",
-    ]);
+    expect(Object.keys(captured).sort()).toEqual(
+      [...PLANS_INSTALL_SKILL_NAMES].sort(),
+    );
   });
 
   it("normalizes every Plans alias to the same hosted Plans skill", async () => {
     for (const alias of [
       "visual-plans",
+      "visual-plan",
       "visual-recap",
       "visual-recaps",
       "code-review-recap",
       "code-review-recaps",
-      "ui-plan",
-      "prototype-plan",
-      "plan-design",
-      "plan-designs",
-      "design-plan",
-      "design-plans",
-      "visual-questions",
       "plannotate",
       "html-plan",
     ]) {
       const { result } = await materializeViaAlias(alias);
       expect(result.id, `alias ${alias}`).toBe("visual-plans");
-      expect(result.skillNames, `alias ${alias} skills`).toEqual([
-        "visual-plan",
-        "visual-recap",
-        "visual-questions",
-        "ui-plan",
-        "prototype-plan",
-        "plan-design",
-      ]);
+      expect(result.skillNames, `alias ${alias} skills`).toEqual(
+        PLANS_INSTALL_SKILL_NAMES,
+      );
     }
   });
+
+  it.each(["ui-plan", "prototype-plan", "plan-design", "visual-questions"])(
+    "no longer accepts %s as a Plans install alias",
+    async (removedAlias) => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "an-plan-skill-"));
+      await expect(
+        addAgentNativeSkill(
+          parseSkillsArgs([
+            "add",
+            removedAlias,
+            "--client",
+            "codex",
+            "--scope",
+            "project",
+          ]),
+          {
+            baseDir: root,
+            runCommand: async () => 0,
+          },
+        ),
+      ).rejects.toThrow(/Unknown skill or manifest path/);
+      fs.rmSync(root, { recursive: true, force: true });
+    },
+  );
 
   it("materialized visual-plan handles existing plan text and avoids legacy HTML", async () => {
     const { captured } = await materializeViaAlias("visual-plan");

--- a/packages/core/src/client/context-xray/ContextMeter.tsx
+++ b/packages/core/src/client/context-xray/ContextMeter.tsx
@@ -19,7 +19,9 @@ import { cn } from "../utils.js";
 import { CONTEXT_XRAY_MODEL_LIMIT, formatTokens } from "./format.js";
 
 const ContextXRayPanel = lazy(() =>
-  import("./ContextXRayPanel.js").then((m) => ({ default: m.ContextXRayPanel })),
+  import("./ContextXRayPanel.js").then((m) => ({
+    default: m.ContextXRayPanel,
+  })),
 );
 
 function ContextDonut({ pct, advisory }: { pct: number; advisory: boolean }) {

--- a/packages/core/src/client/context-xray/ContextMeter.tsx
+++ b/packages/core/src/client/context-xray/ContextMeter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import type {
   ContextManifest,
   ContextSegmentStatus,
@@ -16,8 +16,11 @@ import {
 } from "../components/ui/tooltip.js";
 import { useActionMutation, useActionQuery } from "../use-action.js";
 import { cn } from "../utils.js";
-import { ContextXRayPanel } from "./ContextXRayPanel.js";
 import { CONTEXT_XRAY_MODEL_LIMIT, formatTokens } from "./format.js";
+
+const ContextXRayPanel = lazy(() =>
+  import("./ContextXRayPanel.js").then((m) => ({ default: m.ContextXRayPanel })),
+);
 
 function ContextDonut({ pct, advisory }: { pct: number; advisory: boolean }) {
   const radius = 7.5;
@@ -156,15 +159,27 @@ export function ContextMeter({
           sideOffset={8}
           className="w-[min(92vw,380px)] overflow-hidden border-border/70 p-0"
         >
-          <ContextXRayPanel
-            manifest={manifest}
-            optimistic={optimistic}
-            onPin={(segmentId) => mutateStatus(segmentId, "pinned", "pin")}
-            onEvict={(segmentId) => mutateStatus(segmentId, "evicted", "evict")}
-            onRestore={(segmentId) =>
-              mutateStatus(segmentId, "active", "restore")
-            }
-          />
+          {open ? (
+            <Suspense
+              fallback={
+                <div className="flex h-52 items-center justify-center text-xs text-muted-foreground">
+                  Loading context view…
+                </div>
+              }
+            >
+              <ContextXRayPanel
+                manifest={manifest}
+                optimistic={optimistic}
+                onPin={(segmentId) => mutateStatus(segmentId, "pinned", "pin")}
+                onEvict={(segmentId) =>
+                  mutateStatus(segmentId, "evicted", "evict")
+                }
+                onRestore={(segmentId) =>
+                  mutateStatus(segmentId, "active", "restore")
+                }
+              />
+            </Suspense>
+          ) : null}
         </PopoverContent>
       </Popover>
     </TooltipProvider>

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -1489,7 +1489,12 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
         // leaving the app stuck on the ClientOnly spinner after sign-in.
         // Serve them as native ESM instead; workspaceNodeModulesAllow above
         // lets pnpm-resolved transitive deps load in workspace apps.
-        ...(hasDep("recharts", cwd) ? ["recharts", "es-toolkit"] : []),
+        // recharts is also a direct dep of @agent-native/core, so apps that
+        // depend on core transitively carry recharts even if they don't list
+        // it directly. Check both to cover the transitive case.
+        ...(hasDep("recharts", cwd) || hasDep("@agent-native/core", cwd)
+          ? ["recharts", "es-toolkit"]
+          : []),
         ...(options.optimizeDeps?.exclude ?? []),
       ],
     },

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -1310,6 +1310,9 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
   // pipeline (TypeScript, SSR HMR, the works).
   const workspaceCore = findWorkspaceCoreSync(cwd);
   const workspaceCoreFsAllow = workspaceCore ? [workspaceCore.packageDir] : [];
+  const workspaceNodeModulesAllow = isWorkspaceChild
+    ? [path.resolve(cwd, "../../node_modules")]
+    : [];
   const workspaceCoreNoExternal = workspaceCore
     ? [new RegExp(`^${escapeRegex(workspaceCore.packageName)}(/.*)?$`)]
     : [];
@@ -1342,6 +1345,7 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
           ".",
           ...monorepoCoreAllow,
           ...workspaceCoreFsAllow,
+          ...workspaceNodeModulesAllow,
           ...(options.fsAllow ?? []),
         ],
         deny: [
@@ -1480,6 +1484,12 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
       // serves stale code even after the source / dist is updated.
       exclude: [
         ...(findCoreSrcDir(cwd) !== null ? CORE_CLIENT_SUBPATHS : []),
+        // Vite 8's Rolldown dep optimizer can mis-bundle recharts' nested
+        // es-toolkit compat CJS (require_isUnsafeProperty is not a function),
+        // leaving the app stuck on the ClientOnly spinner after sign-in.
+        // Serve them as native ESM instead; workspaceNodeModulesAllow above
+        // lets pnpm-resolved transitive deps load in workspace apps.
+        ...(hasDep("recharts", cwd) ? ["recharts", "es-toolkit"] : []),
         ...(options.optimizeDeps?.exclude ?? []),
       ],
     },

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -47,7 +47,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  */
 function findWorkspaceCoreSync(
   startDir: string,
-): { packageName: string; packageDir: string } | null {
+): { packageName: string; packageDir: string; workspaceRoot: string } | null {
   // 1) Walk up looking for the root package.json that declares workspaceCore.
   let dir = path.resolve(startDir);
   let workspaceRoot: string | null = null;
@@ -76,7 +76,7 @@ function findWorkspaceCoreSync(
   // 2a) pnpm/npm symlink under workspaceRoot/node_modules.
   const nm = path.join(workspaceRoot, "node_modules", packageName);
   if (fs.existsSync(path.join(nm, "package.json"))) {
-    return { packageName, packageDir: fs.realpathSync(nm) };
+    return { packageName, packageDir: fs.realpathSync(nm), workspaceRoot };
   }
 
   // 2b) Scan packages/* and packages/@scope/* for a matching `name`.
@@ -99,7 +99,7 @@ function findWorkspaceCoreSync(
       try {
         const pkg = JSON.parse(fs.readFileSync(p, "utf-8"));
         if (pkg?.name === packageName)
-          return { packageName, packageDir: fs.realpathSync(c) };
+          return { packageName, packageDir: fs.realpathSync(c), workspaceRoot };
       } catch {
         // ignore malformed package.json
       }
@@ -1309,7 +1309,15 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
   // import in framework-request-handler.ts goes through Vite's transform
   // pipeline (TypeScript, SSR HMR, the works).
   const workspaceCore = findWorkspaceCoreSync(cwd);
-  const workspaceCoreFsAllow = workspaceCore ? [workspaceCore.packageDir] : [];
+  const workspaceCoreFsAllow = workspaceCore
+    ? [
+        workspaceCore.packageDir,
+        // Also allow the workspace root's node_modules so Vite can serve
+        // pnpm-hoisted transitive deps (e.g. recharts, es-toolkit) as native
+        // ESM when they are excluded from the Rolldown optimizer.
+        path.join(workspaceCore.workspaceRoot, "node_modules"),
+      ]
+    : [];
   const workspaceNodeModulesAllow = isWorkspaceChild
     ? [path.resolve(cwd, "../../node_modules")]
     : [];


### PR DESCRIPTION
## Summary

Fixes apps getting stuck on the full-screen `DefaultSpinner` after sign-in when `__an_auth_redirect` is already present in the URL.

This was not an auth regression. Sign-in completed, but client-side hydration never ran because startup JavaScript crashed with:

`Uncaught TypeError: require_isUnsafeProperty is not a function`

The crash came from Vite 8’s Rolldown dependency optimizer mis-bundling `recharts` → `es-toolkit` CJS compat code. That chain was pulled into the startup bundle via the agent sidebar:

`AssistantChat` → `ContextMeter` → `ContextXRayPanel` → `ContextTreemap` → `recharts`

even though the treemap is only needed when a user opens Context X-Ray.

**How to reproduce**


**Changes in `@agent-native/core`:**
Start a standalone agent-native app via cli, run it. Try to login and the spinner will run infinitely

- **`packages/core/src/vite/client.ts`**
  - Exclude `recharts` and `es-toolkit` from `optimizeDeps` when the app declares `recharts`, so Vite serves them as native ESM instead of a broken Rolldown prebundle
  - Add `../../node_modules` to `server.fs.allow` for workspace child apps (`AGENT_NATIVE_WORKSPACE=1`), so pnpm-hoisted transitive deps remain reachable when those packages are excluded from prebundling

- **`packages/core/src/client/context-xray/ContextMeter.tsx`**
  - Lazy-load `ContextXRayPanel` and render it only when the popover is open, removing `recharts` from the critical startup path

No template or workspace app changes are required.

## Test plan

- [ ] `pnpm --filter @agent-native/core build`
- [ ] Scaffold a fresh workspace against local core:
  ```bash
  cd ~/Desktop
  AGENT_NATIVE_CREATE_USE_LOCAL_CORE=1 node /path/to/agent-native/packages/core/dist/cli/index.js create pr-test --template starter,dispatch
  cd pr-test && pnpm install && pnpm dev