### PR TITLE
Meeting notes tabs, copy transcript, resume-friendly recording

### DIFF
--- a/templates/clips/app/components/meetings/canvas-editor.tsx
+++ b/templates/clips/app/components/meetings/canvas-editor.tsx
@@ -101,14 +101,28 @@ function UserNotesBlock({
   onChange: (next: string) => void;
 }) {
   const ref = useRef<HTMLTextAreaElement>(null);
-  useAutoGrow(ref, value);
+  const [draft, setDraft] = useState(value);
+  const focusedRef = useRef(false);
+
+  // Sync external updates (live polling, desktop-app sync) into the editor —
+  // but only while it's not focused, so we never clobber what's being typed.
+  useEffect(() => {
+    if (!focusedRef.current) setDraft(value);
+  }, [value]);
+
+  useAutoGrow(ref, draft);
 
   return (
     <Textarea
       ref={ref}
-      defaultValue={value}
+      value={draft}
       placeholder="Your notes…"
+      onChange={(e) => setDraft(e.target.value)}
+      onFocus={() => {
+        focusedRef.current = true;
+      }}
       onBlur={(e) => {
+        focusedRef.current = false;
         if (e.target.value !== value) onChange(e.target.value);
       }}
       className="min-h-[80px] resize-none overflow-hidden text-base leading-relaxed text-foreground font-medium border-none shadow-none focus-visible:ring-0 px-0"

--- a/templates/clips/app/components/meetings/canvas-editor.tsx
+++ b/templates/clips/app/components/meetings/canvas-editor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { IconWand } from "@tabler/icons-react";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
@@ -9,33 +9,31 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-export interface ActionItem {
-  id?: string;
-  text: string;
-  assigneeEmail?: string | null;
-  dueDate?: string | null;
-  completedAt?: string | null;
+function useAutoGrow(
+  ref: React.RefObject<HTMLTextAreaElement | null>,
+  dep: unknown,
+) {
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [ref, dep]);
 }
 
 interface CanvasEditorProps {
-  /** AI-generated summary (renders muted-gray). */
-  summaryMd: string;
-  /** AI-generated bullets (renders muted-gray). */
-  bullets: string[];
-  /** AI-generated action items (renders muted-gray). */
-  actionItems: ActionItem[];
-  /** User's own notes (renders bold black). Top of the canvas. */
-  userNotesMd: string;
-  /**
-   * Save user notes. Called on blur after edit.
-   */
-  onUserNotesChange: (next: string) => void;
-  /**
-   * Save AI summary. Called when the user edits the summary section.
-   * The container should also flip the section to userNotesMd if you want
-   * Granola's "transfer to user" behavior — see onTransferAiToUser.
-   */
-  onSummaryChange: (next: string) => void;
+  /** Which content this canvas renders. */
+  view: "user" | "ai";
+  /** User's own notes (renders bold black). Required for the "user" view. */
+  userNotesMd?: string;
+  /** Save user notes. Called on blur after edit. */
+  onUserNotesChange?: (next: string) => void;
+  /** AI-generated summary (renders muted-gray). For the "ai" view. */
+  summaryMd?: string;
+  /** AI-generated bullets (renders muted-gray). For the "ai" view. */
+  bullets?: string[];
+  /** Save AI summary when the user edits the summary section. */
+  onSummaryChange?: (next: string) => void;
   /**
    * Optional: when the user starts editing AI content, "promote" it into
    * userNotesMd so re-generation doesn't blow it away. Granola convention.
@@ -45,53 +43,50 @@ interface CanvasEditorProps {
   renderBullet?: (bullet: string, index: number) => React.ReactNode;
 }
 
-/**
- * Two-tone meeting canvas (Granola-signature):
- *   - User notes (top): bold black `text-foreground`
- *   - AI content (below): muted gray `text-muted-foreground`
- *   - Click any block to edit; on blur saves optimistically.
- *   - Editing AI text "transfers" it into the user's notes (so it survives
- *     re-generation), and the new merged text flips to black.
- */
 export function CanvasEditor({
-  summaryMd,
-  bullets,
-  actionItems,
-  userNotesMd,
+  view,
+  userNotesMd = "",
   onUserNotesChange,
+  summaryMd = "",
+  bullets = [],
   onSummaryChange,
   onTransferAiToUser,
   renderBullet,
 }: CanvasEditorProps) {
+  const showUser = view === "user";
+  const showAi = view === "ai";
+  const hasAi = summaryMd || bullets.length > 0;
+
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="px-6 py-6 space-y-6 max-w-2xl">
-        {/* User notes block — black, top */}
-        <UserNotesBlock value={userNotesMd} onChange={onUserNotesChange} />
+    <div className="px-6 py-6 space-y-6 max-w-2xl">
+      {/* User notes block */}
+      {showUser && (
+        <UserNotesBlock
+          value={userNotesMd}
+          onChange={onUserNotesChange ?? (() => {})}
+        />
+      )}
 
-        {/* Divider only when there's both user notes and AI content */}
-        {userNotesMd &&
-          (summaryMd || bullets.length > 0 || actionItems.length > 0) && (
-            <div className="h-px bg-border/60" />
-          )}
+      {/* AI summary */}
+      {showAi && summaryMd && (
+        <AiSummaryBlock
+          value={summaryMd}
+          onChange={onSummaryChange ?? (() => {})}
+          onTransferToUser={onTransferAiToUser}
+        />
+      )}
 
-        {/* AI summary — muted gray */}
-        {summaryMd && (
-          <AiSummaryBlock
-            value={summaryMd}
-            onChange={onSummaryChange}
-            onTransferToUser={onTransferAiToUser}
-          />
-        )}
+      {/* AI bullets — muted gray, with optional BulletLink wrappers */}
+      {showAi && bullets.length > 0 && (
+        <AiBulletsBlock bullets={bullets} renderBullet={renderBullet} />
+      )}
 
-        {/* AI bullets — muted gray, with optional BulletLink wrappers */}
-        {bullets.length > 0 && (
-          <AiBulletsBlock bullets={bullets} renderBullet={renderBullet} />
-        )}
-
-        {/* AI action items — muted gray */}
-        {actionItems.length > 0 && <AiActionItemsBlock items={actionItems} />}
-      </div>
+      {/* Empty state when AI notes haven't been generated yet */}
+      {showAi && !hasAi && (
+        <p className="text-sm leading-relaxed text-muted-foreground/50 italic">
+          No AI notes yet. Generate notes from a finished transcript.
+        </p>
+      )}
     </div>
   );
 }
@@ -105,74 +100,19 @@ function UserNotesBlock({
   value: string;
   onChange: (next: string) => void;
 }) {
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(value);
   const ref = useRef<HTMLTextAreaElement>(null);
-
-  useEffect(() => {
-    if (!editing) setDraft(value);
-  }, [value, editing]);
-
-  useEffect(() => {
-    if (editing) {
-      const el = ref.current;
-      if (el) {
-        el.focus();
-        el.setSelectionRange(el.value.length, el.value.length);
-      }
-    }
-  }, [editing]);
-
-  const commit = () => {
-    setEditing(false);
-    const next = draft;
-    if (next !== value) onChange(next);
-  };
-
-  if (editing) {
-    return (
-      <Textarea
-        ref={ref}
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={commit}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") {
-            setDraft(value);
-            setEditing(false);
-          }
-          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-            e.preventDefault();
-            commit();
-          }
-        }}
-        placeholder="Your notes…"
-        className="min-h-[80px] text-base leading-relaxed text-foreground font-medium border-none shadow-none focus-visible:ring-0 px-0"
-      />
-    );
-  }
+  useAutoGrow(ref, value);
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          onClick={() => setEditing(true)}
-          className="block w-full text-left cursor-text"
-        >
-          {value ? (
-            <p className="text-base leading-relaxed text-foreground font-medium whitespace-pre-wrap">
-              {value}
-            </p>
-          ) : (
-            <p className="text-base leading-relaxed text-muted-foreground/50 italic">
-              Click to add your notes…
-            </p>
-          )}
-        </button>
-      </TooltipTrigger>
-      <TooltipContent>Click to add your notes</TooltipContent>
-    </Tooltip>
+    <Textarea
+      ref={ref}
+      defaultValue={value}
+      placeholder="Your notes…"
+      onBlur={(e) => {
+        if (e.target.value !== value) onChange(e.target.value);
+      }}
+      className="min-h-[80px] resize-none overflow-hidden text-base leading-relaxed text-foreground font-medium border-none shadow-none focus-visible:ring-0 px-0"
+    />
   );
 }
 
@@ -204,6 +144,8 @@ function AiSummaryBlock({
       }
     }
   }, [editing]);
+
+  useAutoGrow(ref, editing ? draft : null);
 
   const commit = () => {
     setEditing(false);
@@ -238,7 +180,7 @@ function AiSummaryBlock({
             }
           }}
           // Once the user starts typing, it visually flips to foreground.
-          className="min-h-[100px] text-sm leading-relaxed text-foreground border-none shadow-none focus-visible:ring-0 px-0"
+          className="min-h-[100px] resize-none overflow-hidden text-sm leading-relaxed text-foreground border-none shadow-none focus-visible:ring-0 px-0"
         />
       </div>
     );
@@ -302,34 +244,11 @@ function AiBulletsBlock({
 
 /* -------------------------------------------------------------------------- */
 
-function AiActionItemsBlock({ items }: { items: ActionItem[] }) {
-  return (
-    <div className="space-y-1.5">
-      <AiTabIndicator label="Action items" />
-      <ul className="space-y-1 text-sm leading-relaxed text-muted-foreground">
-        {items.map((it, i) => (
-          <li key={i} className="flex gap-2">
-            <span>☐</span>
-            <span className={cn("flex-1", it.completedAt && "line-through")}>
-              {it.text}
-              {it.assigneeEmail && (
-                <span className="ml-1.5 text-xs">— {it.assigneeEmail}</span>
-              )}
-            </span>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-/* -------------------------------------------------------------------------- */
-
-function AiTabIndicator({ label = "AI" }: { label?: string }) {
+function AiTabIndicator() {
   return (
     <div className="flex items-center gap-1 text-[10px] uppercase tracking-wide text-muted-foreground/60 opacity-0 group-hover:opacity-100 transition-opacity">
       <IconWand className="h-3 w-3" />
-      <span>{label}</span>
+      <span>AI</span>
     </div>
   );
 }

--- a/templates/clips/app/routes/_app.meetings.$meetingId.tsx
+++ b/templates/clips/app/routes/_app.meetings.$meetingId.tsx
@@ -5,6 +5,7 @@ import {
   IconArrowLeft,
   IconCheck,
   IconClock,
+  IconCopy,
   IconDeviceDesktop,
   IconDots,
   IconEdit,
@@ -13,7 +14,7 @@ import {
   IconNotes,
   IconTrash,
   IconUsers,
-  IconVideo,
+  IconWand,
 } from "@tabler/icons-react";
 import { useActionMutation, useActionQuery } from "@agent-native/core/client";
 import { useQueryClient } from "@tanstack/react-query";
@@ -37,6 +38,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import {
   AttendeeStack,
@@ -316,6 +318,7 @@ export default function MeetingDetailRoute() {
   const { isDesktopApp } = useDesktopPromo();
   const [notesJustArrived, setNotesJustArrived] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [transcriptCopied, setTranscriptCopied] = useState(false);
   const previousHasNotesRef = useRef(false);
   const autoFinalizedRef = useRef(false);
 
@@ -541,8 +544,26 @@ export default function MeetingDetailRoute() {
   const segments = meeting.segmentsJson ?? [];
   const recordingDuration = formatDurationMs(meeting.recordingDurationMs);
 
+  const handleCopyTranscript = async () => {
+    if (!segments.length) return;
+    const text = segments
+      .map((s) => {
+        const label = s.speaker || (s.source === "system" ? "Them" : "Me");
+        return `${label}: ${s.text}`;
+      })
+      .join("\n");
+    try {
+      await navigator.clipboard.writeText(text);
+      setTranscriptCopied(true);
+      toast.success("Transcript copied");
+      setTimeout(() => setTranscriptCopied(false), 1500);
+    } catch {
+      toast.error("Couldn't copy transcript");
+    }
+  };
+
   return (
-    <div className="p-6 max-w-6xl mx-auto w-full">
+    <div className="p-6 max-w-6xl mx-auto w-full flex flex-col min-h-0 flex-1">
       <PageHeader>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -674,7 +695,7 @@ export default function MeetingDetailRoute() {
         </div>
       )}
 
-      <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground mb-6">
+      <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground mb-6 shrink-0">
         <span className="inline-flex items-center gap-1">
           <IconClock className="h-3.5 w-3.5" />
           {formatDateTime(meeting.scheduledStart)}
@@ -706,72 +727,142 @@ export default function MeetingDetailRoute() {
         )}
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] lg:grid-rows-[minmax(0,1fr)] gap-6 flex-1 min-h-0">
         {/* Two-tone canvas: user notes (black) + AI summary/bullets (gray) */}
         <div
           className={cn(
-            "rounded-lg border border-border bg-background min-h-[480px] flex flex-col",
+            "rounded-lg border border-border bg-background min-h-[480px] lg:min-h-0 overflow-hidden flex flex-col",
             notesJustArrived && "animate-in fade-in duration-500",
           )}
         >
-          <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2.5">
-            <div className="flex items-center gap-1.5 text-xs font-medium">
-              <IconNotes className="h-3.5 w-3.5" />
-              Notes
+          <Tabs
+            defaultValue="notes"
+            className="flex min-h-0 flex-1 flex-col gap-0"
+          >
+            <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border px-3 py-2">
+              <TabsList className="h-8 gap-1 bg-transparent p-0">
+                <TabsTrigger
+                  value="notes"
+                  className="h-7 px-2.5 text-xs data-[state=active]:bg-muted"
+                >
+                  My notes
+                </TabsTrigger>
+                <TabsTrigger
+                  value="ai"
+                  className="h-7 gap-1 px-2.5 text-xs data-[state=active]:bg-muted"
+                >
+                  <IconWand className="h-3 w-3" />
+                  AI notes
+                </TabsTrigger>
+                <TabsTrigger
+                  value="actions"
+                  className="h-7 px-2.5 text-xs data-[state=active]:bg-muted"
+                >
+                  Action items
+                  {actionItems.length > 0 && (
+                    <span className="ml-1 text-muted-foreground">
+                      {actionItems.length}
+                    </span>
+                  )}
+                </TabsTrigger>
+              </TabsList>
+              {finalize.isPending && (
+                <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                  <IconLoader2 className="h-3 w-3 animate-spin" />
+                  Working…
+                </span>
+              )}
             </div>
-            {finalize.isPending && (
-              <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
-                <IconLoader2 className="h-3 w-3 animate-spin" />
-                Working…
-              </span>
-            )}
-          </div>
-          <CanvasEditor
-            summaryMd={meeting.summaryMd ?? ""}
-            bullets={bullets.map((b) => b.text)}
-            actionItems={actionItems}
-            userNotesMd={meeting.userNotesMd ?? ""}
-            onUserNotesChange={handleUserNotesChange}
-            onSummaryChange={handleSummaryChange}
-            onTransferAiToUser={handleTransferAiToUser}
-            renderBullet={(b, i) => (
-              <BulletLink
-                bullet={b}
-                segments={segments}
-                onJumpTo={handleJumpToSegment}
-              >
-                <div className="flex gap-2 text-sm leading-relaxed text-muted-foreground">
-                  <span>•</span>
-                  <span className="flex-1">{b}</span>
-                </div>
-              </BulletLink>
-            )}
-          />
-          {actionItems.length > 0 && (
-            <div className="border-t border-border px-6 py-4">
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
-                Action items
-              </h3>
-              <ActionItemsByPerson
-                items={actionItems}
-                onToggle={handleToggleActionItem}
+
+            <TabsContent
+              value="notes"
+              className="mt-0 min-h-0 flex-1 overflow-y-auto"
+            >
+              <CanvasEditor
+                view="user"
+                userNotesMd={meeting.userNotesMd ?? ""}
+                onUserNotesChange={handleUserNotesChange}
               />
-            </div>
-          )}
+            </TabsContent>
+
+            <TabsContent
+              value="ai"
+              className="mt-0 min-h-0 flex-1 overflow-y-auto"
+            >
+              <CanvasEditor
+                view="ai"
+                summaryMd={meeting.summaryMd ?? ""}
+                bullets={bullets.map((b) => b.text)}
+                onSummaryChange={handleSummaryChange}
+                onTransferAiToUser={handleTransferAiToUser}
+                renderBullet={(b) => (
+                  <BulletLink
+                    bullet={b}
+                    segments={segments}
+                    onJumpTo={handleJumpToSegment}
+                  >
+                    <div className="flex gap-2 text-sm leading-relaxed text-muted-foreground">
+                      <span>•</span>
+                      <span className="flex-1">{b}</span>
+                    </div>
+                  </BulletLink>
+                )}
+              />
+            </TabsContent>
+
+            <TabsContent
+              value="actions"
+              className="mt-0 min-h-0 flex-1 overflow-y-auto px-6 py-4"
+            >
+              {actionItems.length > 0 ? (
+                <ActionItemsByPerson
+                  items={actionItems}
+                  onToggle={handleToggleActionItem}
+                />
+              ) : (
+                <p className="text-sm leading-relaxed text-muted-foreground/50 italic">
+                  No action items yet. They appear here after notes are
+                  generated from a transcript.
+                </p>
+              )}
+            </TabsContent>
+          </Tabs>
         </div>
 
         {/* Transcript pane — chat-bubble layout */}
-        <div className="rounded-lg border border-border bg-background min-h-[480px] flex flex-col">
-          <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2.5 sticky top-0 bg-background z-10">
+        <div className="rounded-lg border border-border bg-background min-h-[480px] lg:min-h-0 overflow-hidden flex flex-col">
+          <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border px-4 py-2.5 bg-background">
             <div className="flex items-center gap-1.5 text-xs font-medium">
               <IconNotes className="h-3.5 w-3.5" />
               Transcript
             </div>
-            {meeting.transcriptStatus === "ready" && (
-              <span className="text-[10px] text-muted-foreground">
-                {segments.length} segments
-              </span>
-            )}
+            <div className="flex items-center gap-2">
+              {meeting.transcriptStatus === "ready" && (
+                <span className="text-[10px] text-muted-foreground">
+                  {segments.length} segments
+                </span>
+              )}
+              {segments.length > 0 && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-7 w-7 cursor-pointer"
+                      aria-label="Copy transcript"
+                      onClick={handleCopyTranscript}
+                    >
+                      {transcriptCopied ? (
+                        <IconCheck className="h-3.5 w-3.5 text-green-600" />
+                      ) : (
+                        <IconCopy className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Copy full transcript</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
           </div>
           <TranscriptBubbles
             segments={segments}

--- a/templates/clips/desktop/src-tauri/src/tray_meetings.rs
+++ b/templates/clips/desktop/src-tauri/src/tray_meetings.rs
@@ -75,7 +75,10 @@ pub fn handle_meeting_menu_click(app: &AppHandle, menu_id: &str) -> bool {
         let _ = window.show();
         let _ = window.set_focus();
     }
-    let _ = app.emit("meetings:open", serde_json::json!({ "meetingId": id }));
+    let _ = app.emit(
+        "meetings:start-transcription",
+        serde_json::json!({ "meetingId": id, "joinUrl": null, "reason": "tray" }),
+    );
     true
 }
 

--- a/templates/clips/desktop/src-tauri/src/tray_meetings.rs
+++ b/templates/clips/desktop/src-tauri/src/tray_meetings.rs
@@ -10,7 +10,7 @@ use chrono::{Datelike, Duration as ChronoDuration, Local, Timelike, Weekday};
 use serde::{Deserialize, Serialize};
 use tauri::{
     menu::{MenuItem, Submenu, SubmenuBuilder},
-    AppHandle, Manager, Wry,
+    AppHandle, Wry,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -70,11 +70,9 @@ pub fn handle_meeting_menu_click(app: &AppHandle, menu_id: &str) -> bool {
         return false;
     }
     use tauri::Emitter;
-    if let Some(window) = app.get_webview_window("popover") {
-        crate::util::configure_overlay_behavior(&window);
-        let _ = window.show();
-        let _ = window.set_focus();
-    }
+    // Only the recording pill should open — the popover's background listener
+    // handles this event and shows the pill, so we must NOT show the popover
+    // window itself here.
     let _ = app.emit(
         "meetings:start-transcription",
         serde_json::json!({ "meetingId": id, "joinUrl": null, "reason": "tray" }),

--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -419,16 +419,21 @@ export function useMeetingTranscription({
                   source?: "mic" | "system";
                 }>;
                 if (segs.length > 0) {
-                  session.lines = segs.map((s) => {
+                  const preloadedLineStrings = segs.map((s) => {
                     const label = s.source === "system" ? "Them" : "Me";
                     return `${label}: ${s.text}`;
                   });
-                  session.segments = segs.map((s) => ({
+                  const preloadedSegments = segs.map((s) => ({
                     startMs: s.startMs ?? 0,
                     endMs: s.endMs ?? 0,
                     text: s.text,
                     source: s.source ?? ("mic" as const),
                   }));
+                  session.lines = [...preloadedLineStrings, ...session.lines];
+                  session.segments = [
+                    ...preloadedSegments,
+                    ...session.segments,
+                  ];
                   const preloadedLines = segs.map((s) => ({
                     text: s.text,
                     source: (s.source ?? "mic") as "mic" | "system",

--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -62,6 +62,11 @@ export function useMeetingTranscription({
   const pendingPillInitRef = useRef<{
     meetingId: string;
     initialNotes: string;
+    preloadedLines?: Array<{
+      text: string;
+      source: "mic" | "system";
+      startMs?: number;
+    }>;
   } | null>(null);
 
   const normalizedServerUrl = useMemo(
@@ -383,11 +388,10 @@ export function useMeetingTranscription({
           mode: "meeting",
         }).catch(() => {});
 
-        callClipsAction<{ meeting?: { userNotesMd?: string } }>(
-          "get-meeting",
-          { id: resolvedMeetingId },
-          { method: "GET" },
-        )
+        callClipsAction<{
+          meeting?: { userNotesMd?: string };
+          transcript?: { segmentsJson?: string | null } | null;
+        }>("get-meeting", { id: resolvedMeetingId }, { method: "GET" })
           .then((data) => {
             // Guard: if the session changed while the fetch was in-flight
             // (user switched meetings), don't overwrite the new meeting's
@@ -403,6 +407,51 @@ export function useMeetingTranscription({
               meetingId: resolvedMeetingId,
               initialNotes,
             }).catch(() => {});
+
+            // Preload any existing transcript segments into the pill and session.
+            const segmentsJson = data?.transcript?.segmentsJson;
+            if (segmentsJson && sessionRef.current === session) {
+              try {
+                const segs = JSON.parse(segmentsJson) as Array<{
+                  startMs?: number;
+                  endMs?: number;
+                  text: string;
+                  source?: "mic" | "system";
+                }>;
+                if (segs.length > 0) {
+                  session.lines = segs.map((s) => {
+                    const label = s.source === "system" ? "Them" : "Me";
+                    return `${label}: ${s.text}`;
+                  });
+                  session.segments = segs.map((s) => ({
+                    startMs: s.startMs ?? 0,
+                    endMs: s.endMs ?? 0,
+                    text: s.text,
+                    source: s.source ?? ("mic" as const),
+                  }));
+                  const preloadedLines = segs.map((s) => ({
+                    text: s.text,
+                    source: (s.source ?? "mic") as "mic" | "system",
+                    startMs: s.startMs,
+                  }));
+                  // Store in ref so clips:pill-ready can re-emit if the
+                  // pill window mounts after this fetch resolves.
+                  if (
+                    pendingPillInitRef.current?.meetingId === resolvedMeetingId
+                  ) {
+                    pendingPillInitRef.current = {
+                      ...pendingPillInitRef.current,
+                      preloadedLines,
+                    };
+                  }
+                  emit("clips:transcript-preload", {
+                    lines: preloadedLines,
+                  }).catch(() => {});
+                }
+              } catch {
+                // ignore malformed segmentsJson
+              }
+            }
           })
           .catch(() => {});
 
@@ -539,6 +588,11 @@ export function useMeetingTranscription({
           meetingId: pending.meetingId,
           initialNotes: pending.initialNotes,
         }).catch(() => {});
+        if (pending.preloadedLines?.length) {
+          emit("clips:transcript-preload", {
+            lines: pending.preloadedLines,
+          }).catch(() => {});
+        }
       }),
     );
 

--- a/templates/clips/desktop/src/overlays/live-transcript.tsx
+++ b/templates/clips/desktop/src/overlays/live-transcript.tsx
@@ -19,7 +19,7 @@ interface FinalPayload {
   segments?: Segment[];
 }
 
-interface FinalLine {
+export interface FinalLine {
   text: string;
   source: Source;
   startMs?: number;
@@ -46,11 +46,29 @@ function formatTimestamp(ms: number): string {
  * partial for each source is rendered separately so the two streams don't
  * clobber each other.
  */
-export function LiveTranscript() {
-  const [finals, setFinals] = useState<FinalLine[]>([]);
+export function LiveTranscript({
+  onLinesChange,
+  initialLines,
+}: {
+  onLinesChange?: (lines: FinalLine[]) => void;
+  initialLines?: FinalLine[];
+} = {}) {
+  const [finals, setFinals] = useState<FinalLine[]>(initialLines ?? []);
   const [micPartial, setMicPartial] = useState("");
   const [sysPartial, setSysPartial] = useState("");
   const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (onLinesChange) onLinesChange(finals);
+  }, [finals, onLinesChange]);
+
+  // When the pill context changes (new meeting) or preloaded lines arrive,
+  // replace finals. New voice events will append on top after this.
+  useEffect(() => {
+    setFinals(initialLines ?? []);
+    setMicPartial("");
+    setSysPartial("");
+  }, [initialLines]);
 
   useEffect(() => {
     const unlistens: Array<() => void> = [];

--- a/templates/clips/desktop/src/overlays/live-transcript.tsx
+++ b/templates/clips/desktop/src/overlays/live-transcript.tsx
@@ -57,17 +57,31 @@ export function LiveTranscript({
   const [micPartial, setMicPartial] = useState("");
   const [sysPartial, setSysPartial] = useState("");
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  // Whether the current session's preloaded history has been merged in. Guards
+  // against the preload event firing more than once (the host emits it on both
+  // the get-meeting fetch and clips:pill-ready), which would duplicate lines.
+  const preloadAppliedRef = useRef((initialLines?.length ?? 0) > 0);
 
   useEffect(() => {
     if (onLinesChange) onLinesChange(finals);
   }, [finals, onLinesChange]);
 
-  // When the pill context changes (new meeting) or preloaded lines arrive,
-  // replace finals. New voice events will append on top after this.
   useEffect(() => {
-    setFinals(initialLines ?? []);
-    setMicPartial("");
-    setSysPartial("");
+    const lines = initialLines ?? [];
+    // Empty = pill context reset for a new meeting: clear everything.
+    if (lines.length === 0) {
+      preloadAppliedRef.current = false;
+      setFinals([]);
+      setMicPartial("");
+      setSysPartial("");
+      return;
+    }
+    // Preloaded history arrived. Apply once, and PREPEND so any live lines that
+    // were captured before the async preload resolved are kept (after the
+    // older history), instead of being overwritten.
+    if (preloadAppliedRef.current) return;
+    preloadAppliedRef.current = true;
+    setFinals((prev) => [...lines, ...prev]);
   }, [initialLines]);
 
   useEffect(() => {

--- a/templates/clips/desktop/src/overlays/recording-pill.tsx
+++ b/templates/clips/desktop/src/overlays/recording-pill.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
+  IconCheck,
   IconChevronDown,
   IconChevronUp,
+  IconCopy,
   IconExternalLink,
   IconGripHorizontal,
   IconLoader2,
@@ -13,7 +15,7 @@ import {
   IconPlayerStopFilled,
 } from "@tabler/icons-react";
 
-import { LiveTranscript } from "./live-transcript";
+import { LiveTranscript, type FinalLine } from "./live-transcript";
 import { PillLogo } from "./pill-logo";
 
 type PillMode = "meeting" | "clip";
@@ -54,6 +56,10 @@ export function RecordingPill() {
   const ctxRef = useRef<PillContext>({ mode: "clip" });
   const [stopping, setStopping] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const transcriptLinesRef = useRef<FinalLine[]>([]);
+  const [hasTranscriptLines, setHasTranscriptLines] = useState(false);
+  const [transcriptCopied, setTranscriptCopied] = useState(false);
+  const [preloadedLines, setPreloadedLines] = useState<FinalLine[]>([]);
   const [notes, setNotes] = useState("");
   const [savedAt, setSavedAt] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
@@ -127,11 +133,12 @@ export function RecordingPill() {
         // disabled and a stale fallback timer can fire mid-session.
         setStopping(false);
         setError(null);
-        // Reset notes state for the new session.
+        // Reset notes and transcript state for the new session.
         setNotes("");
         setSaving(false);
         setSaveError(false);
         setSavedAt(null);
+        setPreloadedLines([]);
         pendingNotesRef.current = null;
         // Only clear the meeting id when leaving meeting mode. In meeting mode
         // clips:meeting-notes-init is the authoritative setter — resetting here
@@ -168,6 +175,12 @@ export function RecordingPill() {
           }
         },
       ),
+    );
+    trackListen(
+      listen<{ lines: FinalLine[] }>("clips:transcript-preload", (ev) => {
+        const lines = ev.payload?.lines;
+        if (lines?.length) setPreloadedLines(lines);
+      }),
     );
     // Unified auto-save signal from the popover — fires after either the
     // transcript or the notes are persisted. Drives the single "Auto-saved"
@@ -452,6 +465,28 @@ export function RecordingPill() {
     }
   }
 
+  // Stable callback for LiveTranscript to push locked-in lines up. Stable
+  // identity matters — it's a dep of an effect inside LiveTranscript.
+  const handleTranscriptLines = useCallback((lines: FinalLine[]) => {
+    transcriptLinesRef.current = lines;
+    setHasTranscriptLines(lines.length > 0);
+  }, []);
+
+  const handleCopyTranscript = async () => {
+    const lines = transcriptLinesRef.current;
+    if (!lines.length) return;
+    const text = lines
+      .map((l) => `${l.source === "system" ? "Them" : "Me"}: ${l.text}`)
+      .join("\n");
+    try {
+      await navigator.clipboard.writeText(text);
+      setTranscriptCopied(true);
+      setTimeout(() => setTranscriptCopied(false), 1500);
+    } catch {
+      // ignore — clipboard may be unavailable in this window
+    }
+  };
+
   // Immediately persist any pending (debounced) note edit. Used on blur and on
   // unmount so notes typed in the last ~800ms before stopping aren't dropped.
   const flushNotesNow = () => {
@@ -619,9 +654,29 @@ export function RecordingPill() {
           {ctx.mode === "meeting" ? (
             <div className="pill-split">
               <div className="pill-split-pane">
-                <div className="pill-pane-label">Transcript</div>
+                <div className="pill-pane-label pill-pane-label-row">
+                  <span>Transcript</span>
+                  <button
+                    type="button"
+                    data-no-drag
+                    className="pill-copy-btn"
+                    onClick={handleCopyTranscript}
+                    disabled={!hasTranscriptLines}
+                    aria-label="Copy transcript"
+                    title="Copy transcript"
+                  >
+                    {transcriptCopied ? (
+                      <IconCheck size={12} />
+                    ) : (
+                      <IconCopy size={12} />
+                    )}
+                  </button>
+                </div>
                 <div className="pill-transcript-area">
-                  <LiveTranscript />
+                  <LiveTranscript
+                    onLinesChange={handleTranscriptLines}
+                    initialLines={preloadedLines}
+                  />
                 </div>
               </div>
               <div className="pill-split-divider" />
@@ -659,7 +714,10 @@ export function RecordingPill() {
             </div>
           ) : (
             <div className="pill-transcript-area">
-              <LiveTranscript />
+              <LiveTranscript
+                onLinesChange={handleTranscriptLines}
+                initialLines={preloadedLines}
+              />
             </div>
           )}
           {ctx.mode === "meeting" ? (

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -4133,6 +4133,38 @@ body[data-clips-route="recording-pill"] #root {
   color: rgba(244, 244, 245, 0.4);
 }
 
+.pill-pane-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.pill-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: rgba(244, 244, 245, 0.5);
+  cursor: pointer;
+  transition:
+    background 120ms,
+    color 120ms;
+}
+
+.pill-copy-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+  color: #f4f4f5;
+}
+
+.pill-copy-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
 /* In the split, the transcript area should fill its pane below the label. */
 .pill-split-pane .pill-transcript-area {
   flex: 1;


### PR DESCRIPTION
Improves the Clips meetings experience:

- **Tabbed notes** — meeting notes split into **My notes**, **AI notes**, and **Action items**, each with a clear empty state. Editing your notes is now always-on (click and type).
<img width="1180" height="599" alt="image" src="https://github.com/user-attachments/assets/b4dc89d4-d1da-4036-856d-9586a99127cc" />

- **Copy transcript** — one-click copy of the full, speaker-labelled transcript, on both the web meeting page and the desktop recording pill.
<img width="466" height="314" alt="image" src="https://github.com/user-attachments/assets/bd3c49e2-855a-434d-b478-e95c41181ba6" />
<img width="441" height="341" alt="image" src="https://github.com/user-attachments/assets/6001e98e-d8a2-4e1f-94fe-a3e40824a8cd" />

- **Resume without losing the transcript** — reopening or re-recording a meeting reloads its existing transcript instead of starting blank. Picking a meeting from the desktop tray now goes straight into recording.