### PR TITLE
Add share button with scope toggle to meetings page

### DIFF
--- a/templates/clips/actions/get-meeting.ts
+++ b/templates/clips/actions/get-meeting.ts
@@ -121,6 +121,15 @@ export default defineAction({
       transcript = tr ?? null;
     }
 
-    return { meeting, participants, actionItems, recording, transcript };
+    // "AI notes only" share scope: viewers (people the meeting was shared with,
+    // not the owner/editor) see only the AI summary, bullets, and action items.
+    // The raw transcript, recording, and the owner's typed notes are withheld.
+    if (access.role === "viewer" && row.shareScope === "notes") {
+      meeting.userNotesMd = "";
+      recording = null;
+      transcript = null;
+    }
+
+    return { meeting, participants, actionItems, recording, transcript, role: access.role };
   },
 });

--- a/templates/clips/actions/update-meeting.ts
+++ b/templates/clips/actions/update-meeting.ts
@@ -41,6 +41,12 @@ export default defineAction({
       .describe("Replace the action item set on the meetings row JSON"),
     transcriptStatus: z.enum(["idle", "pending", "ready", "failed"]).optional(),
     visibility: z.enum(["private", "org", "public"]).optional(),
+    shareScope: z
+      .enum(["full", "notes"])
+      .optional()
+      .describe(
+        "What shared viewers see: 'full' = raw transcript + notes, 'notes' = AI notes only",
+      ),
   }),
   run: async (args) => {
     await assertAccess("meeting", args.id, "editor");
@@ -67,6 +73,7 @@ export default defineAction({
       patch.actionItemsJson = JSON.stringify(args.actionItems);
     if (args.transcriptStatus) patch.transcriptStatus = args.transcriptStatus;
     if (args.visibility) patch.visibility = args.visibility;
+    if (args.shareScope) patch.shareScope = args.shareScope;
 
     await db
       .update(schema.meetings)

--- a/templates/clips/app/routes/_app.meetings.$meetingId.tsx
+++ b/templates/clips/app/routes/_app.meetings.$meetingId.tsx
@@ -15,7 +15,11 @@ import {
   IconUsers,
   IconVideo,
 } from "@tabler/icons-react";
-import { useActionMutation, useActionQuery } from "@agent-native/core/client";
+import {
+  ShareButton,
+  useActionMutation,
+  useActionQuery,
+} from "@agent-native/core/client";
 import { useQueryClient } from "@tanstack/react-query";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
@@ -94,6 +98,50 @@ interface Meeting {
   actionItemsJson?: ActionItem[] | null;
   segmentsJson?: TranscriptSegment[] | null;
   participants?: Participant[];
+  shareScope?: "full" | "notes";
+}
+
+type MeetingRole = "owner" | "admin" | "editor" | "viewer";
+
+function ShareScopeToggle({
+  value,
+  onChange,
+}: {
+  value: "full" | "notes";
+  onChange: (next: "full" | "notes") => void;
+}) {
+  const options: Array<{ value: "full" | "notes"; label: string }> = [
+    { value: "full", label: "Full" },
+    { value: "notes", label: "AI notes only" },
+  ];
+  return (
+    <div
+      role="radiogroup"
+      aria-label="What shared viewers can see"
+      className="inline-flex items-center rounded-md border border-border p-0.5"
+    >
+      {options.map((opt) => {
+        const active = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(opt.value)}
+            className={cn(
+              "h-7 rounded-[5px] px-2.5 text-xs font-medium transition-colors cursor-pointer",
+              active
+                ? "bg-accent text-accent-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
 }
 
 function formatDateTime(iso?: string | null): string {
@@ -290,6 +338,7 @@ export default function MeetingDetailRoute() {
     actionItems?: ActionItem[];
     transcript?: { segmentsJson?: TranscriptSegment[] | null } | null;
     recording?: { id: string; durationMs?: number | null } | null;
+    role?: MeetingRole;
   };
 
   const { data, isLoading, isError } = useActionQuery<GetMeetingResp>(
@@ -423,6 +472,12 @@ export default function MeetingDetailRoute() {
     updateMeeting.mutate({ id: meeting.id, userNotesMd: next });
   };
 
+  const handleShareScopeChange = (next: "full" | "notes") => {
+    if (!meeting) return;
+    patchCachedMeeting({ shareScope: next });
+    updateMeeting.mutate({ id: meeting.id, shareScope: next });
+  };
+
   /**
    * Granola-signature behavior: when the user edits an AI block, "promote"
    * its content into userNotesMd so it survives re-generation. The AI block
@@ -541,6 +596,14 @@ export default function MeetingDetailRoute() {
   const segments = meeting.segmentsJson ?? [];
   const recordingDuration = formatDurationMs(meeting.recordingDurationMs);
 
+  const role = data?.role;
+  const canManageShare = role === "owner" || role === "admin";
+  const shareScope = meeting.shareScope ?? "full";
+  const shareUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/meetings/${meeting.id}`
+      : undefined;
+
   return (
     <div className="p-6 max-w-6xl mx-auto w-full">
       <PageHeader>
@@ -591,6 +654,25 @@ export default function MeetingDetailRoute() {
               Regenerate notes
             </Button>
           ) : null}
+          {canManageShare && (
+            <>
+              <ShareScopeToggle
+                value={shareScope}
+                onChange={handleShareScopeChange}
+              />
+              <ShareButton
+                resourceType="meeting"
+                resourceId={meeting.id}
+                resourceTitle={meeting.title}
+                shareUrl={shareUrl}
+                accessNote={
+                  shareScope === "notes"
+                    ? "Shared viewers see AI notes only — the transcript and your notes stay private."
+                    : "Shared viewers see the full transcript and notes."
+                }
+              />
+            </>
+          )}
           <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/templates/clips/server/db/schema.ts
+++ b/templates/clips/server/db/schema.ts
@@ -346,6 +346,12 @@ export const meetings = table("clips_meetings", {
   })
     .notNull()
     .default("adhoc"),
+  // Controls what shared viewers (non-owners) see: "full" exposes the raw
+  // transcript + the owner's typed notes; "notes" exposes only the AI summary,
+  // bullets, and action items. Owners/editors always see everything.
+  shareScope: text("share_scope", { enum: ["full", "notes"] })
+    .notNull()
+    .default("full"),
   // Reminder bookkeeping so the desktop notifier doesn't fire twice.
   reminderFiredAt: text("reminder_fired_at"),
   createdAt: text("created_at").notNull().default(now()),

--- a/templates/clips/server/plugins/db.ts
+++ b/templates/clips/server/plugins/db.ts
@@ -634,6 +634,10 @@ const migrations = runMigrations(
       version: 40,
       sql: `ALTER TABLE recordings ADD COLUMN IF NOT EXISTS source_window_title TEXT`,
     },
+    {
+      version: 41,
+      sql: `ALTER TABLE clips_meetings ADD COLUMN IF NOT EXISTS share_scope TEXT NOT NULL DEFAULT 'full'`,
+    },
   ],
   { table: "clips_migrations" },
 );


### PR DESCRIPTION
### Summary
Adds a share button to the meeting detail page, along with a toggle that lets owners control whether shared viewers see the full transcript and notes, or AI-generated notes only.

### Problem
There was no way to share a meeting from the clips meetings page. Users needed the ability to share either the full meeting content (raw transcript + notes) or just the AI-generated notes, keeping the transcript and personal notes private.

### Solution
A `shareScope` field (`"full"` | `"notes"`) was added to the meetings schema and surfaced in the UI as a segmented toggle. A `ShareButton` component was added next to the toggle for owners and admins. The `get-meeting` action enforces the scope server-side by stripping the transcript, recording, and typed notes for viewers when `shareScope` is `"notes"`.

### Key Changes
- **Schema & migration**: Added `share_scope TEXT NOT NULL DEFAULT 'full'` column to `clips_meetings` (migration version 41).
- **`get-meeting` action**: When the requester's role is `"viewer"` and `shareScope === "notes"`, `userNotesMd`, `recording`, and `transcript` are withheld before returning the response. The caller's `role` is now included in the response.
- **`update-meeting` action**: Accepts and persists the new `shareScope` field.
- **Meeting detail route**: Added a `ShareScopeToggle` radio-group component and wired it to `updateMeeting`. The `ShareButton` (from `@agent-native/core/client`) is rendered alongside the toggle, but only for `owner` / `admin` roles. The share URL and a contextual `accessNote` reflecting the current scope are passed to `ShareButton`.

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/scout-base-hwpsvnf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-scout-base-hwpsvnf7_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1109`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>scout-base-hwpsvnf7</branchName>-->