### PR TITLE
Meeting sharing

### DIFF
--- a/templates/clips/actions/get-meeting.ts
+++ b/templates/clips/actions/get-meeting.ts
@@ -121,6 +121,13 @@ export default defineAction({
       transcript = tr ?? null;
     }
 
-    return { meeting, participants, actionItems, recording, transcript };
+    return {
+      meeting,
+      participants,
+      actionItems,
+      recording,
+      transcript,
+      role: access.role,
+    };
   },
 });

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -499,7 +499,7 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
             {/* Main content area */}
             <div className="flex min-w-0 flex-1 flex-col">
               {!pageOwnsToolbar && (
-                <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border px-5">
+                <header className="flex shrink-0 items-center gap-3 border-b border-border px-5 py-3">
                   <button
                     onClick={() => setSidebarOpen(true)}
                     className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground md:hidden"

--- a/templates/clips/app/components/meetings/canvas-editor.tsx
+++ b/templates/clips/app/components/meetings/canvas-editor.tsx
@@ -34,13 +34,10 @@ interface CanvasEditorProps {
   bullets?: string[];
   /** Save AI summary when the user edits the summary section. */
   onSummaryChange?: (next: string) => void;
-  /**
-   * Optional: when the user starts editing AI content, "promote" it into
-   * userNotesMd so re-generation doesn't blow it away. Granola convention.
-   */
-  onTransferAiToUser?: (transferredMd: string) => void;
   /** Render bullets with magnifier (BulletLink) wrappers. */
   renderBullet?: (bullet: string, index: number) => React.ReactNode;
+  /** When true, notes render as read-only (viewer-role access). */
+  readOnly?: boolean;
 }
 
 export function CanvasEditor({
@@ -50,8 +47,8 @@ export function CanvasEditor({
   summaryMd = "",
   bullets = [],
   onSummaryChange,
-  onTransferAiToUser,
   renderBullet,
+  readOnly = false,
 }: CanvasEditorProps) {
   const showUser = view === "user";
   const showAi = view === "ai";
@@ -64,6 +61,7 @@ export function CanvasEditor({
         <UserNotesBlock
           value={userNotesMd}
           onChange={onUserNotesChange ?? (() => {})}
+          readOnly={readOnly}
         />
       )}
 
@@ -72,7 +70,7 @@ export function CanvasEditor({
         <AiSummaryBlock
           value={summaryMd}
           onChange={onSummaryChange ?? (() => {})}
-          onTransferToUser={onTransferAiToUser}
+          readOnly={readOnly}
         />
       )}
 
@@ -96,9 +94,11 @@ export function CanvasEditor({
 function UserNotesBlock({
   value,
   onChange,
+  readOnly = false,
 }: {
   value: string;
   onChange: (next: string) => void;
+  readOnly?: boolean;
 }) {
   const ref = useRef<HTMLTextAreaElement>(null);
   const [draft, setDraft] = useState(value);
@@ -111,6 +111,18 @@ function UserNotesBlock({
   }, [value]);
 
   useAutoGrow(ref, draft);
+
+  if (readOnly) {
+    return value ? (
+      <p className="text-base leading-relaxed text-foreground font-medium whitespace-pre-wrap">
+        {value}
+      </p>
+    ) : (
+      <p className="text-sm leading-relaxed text-muted-foreground/50 italic">
+        No notes.
+      </p>
+    );
+  }
 
   return (
     <Textarea
@@ -135,11 +147,11 @@ function UserNotesBlock({
 function AiSummaryBlock({
   value,
   onChange,
-  onTransferToUser,
+  readOnly = false,
 }: {
   value: string;
   onChange: (next: string) => void;
-  onTransferToUser?: (transferred: string) => void;
+  readOnly?: boolean;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
@@ -161,17 +173,22 @@ function AiSummaryBlock({
 
   useAutoGrow(ref, editing ? draft : null);
 
+  if (readOnly) {
+    return (
+      <div className="space-y-1.5">
+        <AiTabIndicator />
+        <p className="text-sm leading-relaxed whitespace-pre-wrap text-muted-foreground">
+          {value}
+        </p>
+      </div>
+    );
+  }
+
   const commit = () => {
     setEditing(false);
     const next = draft;
     if (next === value) return;
-    if (onTransferToUser) {
-      // Promote edited AI content into user notes; clear original AI summary.
-      onTransferToUser(next);
-      onChange("");
-    } else {
-      onChange(next);
-    }
+    onChange(next);
   };
 
   if (editing) {
@@ -220,9 +237,7 @@ function AiSummaryBlock({
               </p>
             </button>
           </TooltipTrigger>
-          <TooltipContent>
-            Click to edit (your edits are saved as your own notes)
-          </TooltipContent>
+          <TooltipContent>Click to edit</TooltipContent>
         </Tooltip>
       </div>
     </TooltipProvider>

--- a/templates/clips/app/components/meetings/share-meeting-dialog.tsx
+++ b/templates/clips/app/components/meetings/share-meeting-dialog.tsx
@@ -1,7 +1,7 @@
 import { useMemo, type ReactNode } from "react";
 import { toast } from "sonner";
 import { IconLink, IconMail } from "@tabler/icons-react";
-import { useActionQuery } from "@agent-native/core/client";
+import { appPath, useActionQuery } from "@agent-native/core/client";
 import {
   Popover,
   PopoverContent,
@@ -56,7 +56,7 @@ function ShareMeetingContent({
   meetingTitle?: string;
 }) {
   const shareUrl = useMemo(
-    () => `${window.location.origin}/share/meeting/${meetingId}`,
+    () => `${window.location.origin}${appPath(`/share/meeting/${meetingId}`)}`,
     [meetingId],
   );
 

--- a/templates/clips/app/components/meetings/share-meeting-dialog.tsx
+++ b/templates/clips/app/components/meetings/share-meeting-dialog.tsx
@@ -1,0 +1,163 @@
+import { useMemo, type ReactNode } from "react";
+import { toast } from "sonner";
+import { IconLink, IconMail } from "@tabler/icons-react";
+import { useActionQuery } from "@agent-native/core/client";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  CopyField,
+  GeneralAccessSelect,
+  MakePublicCard,
+  ShareCardHeader,
+  SharePeopleTab,
+  copyToClipboard,
+  useResourceVisibilityMutation,
+  type SharesQuery,
+  type SharesResponse,
+  type Visibility,
+} from "@/components/sharing/share-ui";
+
+export interface ShareMeetingPopoverProps {
+  meetingId: string;
+  meetingTitle?: string;
+  children: ReactNode;
+}
+
+export function ShareMeetingPopover({
+  meetingId,
+  meetingTitle,
+  children,
+}: ShareMeetingPopoverProps) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-[440px] max-w-[calc(100vw-1rem)] overflow-hidden p-0"
+      >
+        <ShareMeetingContent
+          meetingId={meetingId}
+          meetingTitle={meetingTitle}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ShareMeetingContent({
+  meetingId,
+  meetingTitle,
+}: {
+  meetingId: string;
+  meetingTitle?: string;
+}) {
+  const shareUrl = useMemo(
+    () => `${window.location.origin}/share/meeting/${meetingId}`,
+    [meetingId],
+  );
+
+  const sharesQuery = useActionQuery<SharesResponse>("list-resource-shares", {
+    resourceType: "meeting",
+    resourceId: meetingId,
+  });
+
+  const data = sharesQuery.data;
+  const canManage = data?.role === "owner" || data?.role === "admin";
+  const titleText = meetingTitle ? `Share "${meetingTitle}"` : "Share meeting";
+
+  return (
+    <>
+      <ShareCardHeader title={titleText} ownerEmail={data?.ownerEmail} />
+
+      <Tabs defaultValue="link" className="min-w-0 px-4 py-3">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="link" className="gap-1.5">
+            <IconLink size={14} />
+            Link
+          </TabsTrigger>
+          <TabsTrigger value="invite" className="gap-1.5">
+            <IconMail size={14} />
+            Invite
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="link" className="mt-3">
+          <LinkTab
+            meetingId={meetingId}
+            shareUrl={shareUrl}
+            sharesQuery={sharesQuery}
+            canManage={canManage}
+          />
+        </TabsContent>
+
+        <TabsContent value="invite" className="mt-3">
+          <SharePeopleTab
+            resourceType="meeting"
+            resourceId={meetingId}
+            sharesQuery={sharesQuery}
+            canManage={canManage}
+            onError={(err, action) =>
+              toast.error(
+                err instanceof Error
+                  ? err.message
+                  : action === "invite"
+                    ? "Couldn't invite person"
+                    : "Couldn't remove person",
+              )
+            }
+          />
+        </TabsContent>
+      </Tabs>
+    </>
+  );
+}
+
+function LinkTab({
+  meetingId,
+  shareUrl,
+  sharesQuery,
+  canManage,
+}: {
+  meetingId: string;
+  shareUrl: string;
+  sharesQuery: SharesQuery;
+  canManage: boolean;
+}) {
+  const { setResourceVisibility, isPending } = useResourceVisibilityMutation(
+    "meeting",
+    meetingId,
+    sharesQuery,
+  );
+  const data = sharesQuery.data;
+  const visibility: Visibility =
+    (data?.visibility as Visibility | null) ?? "private";
+  const isPublic = visibility === "public";
+
+  return (
+    <div className="space-y-4">
+      <GeneralAccessSelect
+        visibility={visibility}
+        canManage={canManage}
+        isPending={isPending}
+        onChange={(next) => setResourceVisibility(next)}
+      />
+
+      <CopyField label="Share link" value={shareUrl} />
+
+      {!isPublic && canManage ? (
+        <MakePublicCard
+          isPending={isPending}
+          onMakePublic={() =>
+            setResourceVisibility("public", {
+              onSuccess: () => copyToClipboard(shareUrl),
+            })
+          }
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -1,21 +1,6 @@
 import { useMemo, useState, type ReactNode } from "react";
-import { useQueryClient } from "@tanstack/react-query";
-import {
-  IconTrash,
-  IconLock,
-  IconBuilding,
-  IconWorld,
-  IconCheck,
-  IconCopy,
-  IconLink,
-  IconMail,
-  IconCode,
-} from "@tabler/icons-react";
-import {
-  appPath,
-  useActionQuery,
-  useActionMutation,
-} from "@agent-native/core/client";
+import { IconLink, IconMail, IconCode } from "@tabler/icons-react";
+import { appPath, useActionQuery } from "@agent-native/core/client";
 import {
   Popover,
   PopoverTrigger,
@@ -24,71 +9,29 @@ import {
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { cn } from "@/lib/utils";
+  CopyField,
+  GeneralAccessSelect,
+  MakePublicCard,
+  ShareCardHeader,
+  SharePeopleTab,
+  VIS_META,
+  copyToClipboard,
+  useResourceVisibilityMutation,
+  type SharesQuery,
+  type SharesResponse,
+  type Visibility,
+} from "@/components/sharing/share-ui";
 
-type Visibility = "private" | "org" | "public";
-type Role = "viewer" | "editor" | "admin";
-
-interface Share {
-  id: string;
-  principalType: "user" | "org";
-  principalId: string;
-  role: Role;
-}
-
-interface SharesResponse {
-  ownerEmail: string | null;
-  orgId: string | null;
-  visibility: Visibility | null;
-  role?: "owner" | Role;
-  shares: Share[];
-}
-
-const VIS_META: Record<
-  Visibility,
-  { label: string; description: string; Icon: typeof IconLock }
-> = {
-  private: {
-    label: "Private",
-    description: "Only people with access can view",
-    Icon: IconLock,
-  },
-  org: {
-    label: "Organization",
-    description: "Anyone in your organization can view",
-    Icon: IconBuilding,
-  },
-  public: {
-    label: "Public",
-    description: "Anyone with the link can view — sign in to comment or react",
-    Icon: IconWorld,
-  },
-};
-
-const ROLE_OPTIONS: Array<{ value: Role; label: string }> = [
-  { value: "viewer", label: "Viewer" },
-  { value: "editor", label: "Editor" },
-  { value: "admin", label: "Admin" },
-];
+const PUBLIC_DESCRIPTION =
+  "Anyone with the link can view — sign in to comment or react";
 
 function absoluteAppUrl(path: string): string {
   if (typeof window === "undefined") return "";
   return new URL(appPath(path), window.location.origin).toString();
-}
-
-function copyToClipboard(value: string): void {
-  navigator.clipboard.writeText(value).catch(() => {});
 }
 
 export interface ShareRecordingPopoverProps {
@@ -198,30 +141,20 @@ function ShareRecordingContent({
     resourceId: recordingId,
   });
 
+  const data = sharesQuery.data;
+  const canManage =
+    data?.role === "owner" || data?.role === "admin" || !data?.role;
   const titleText = recordingTitle
     ? `Share "${recordingTitle}"`
     : "Share recording";
 
   return (
     <>
-      <div
-        className={cn(
-          "min-w-0 border-b border-border px-4 pb-3 pt-3",
-          reserveCloseButton && "pr-12",
-        )}
-      >
-        <div
-          className="min-w-0 truncate text-sm font-semibold"
-          title={titleText}
-        >
-          {titleText}
-        </div>
-        {sharesQuery.data?.ownerEmail ? (
-          <div className="mt-0.5 truncate text-xs text-muted-foreground">
-            Owner: {sharesQuery.data.ownerEmail}
-          </div>
-        ) : null}
-      </div>
+      <ShareCardHeader
+        title={titleText}
+        ownerEmail={data?.ownerEmail}
+        reserveCloseButton={reserveCloseButton}
+      />
 
       <Tabs defaultValue="link" className="min-w-0 px-4 py-3">
         <TabsList className="grid w-full grid-cols-3">
@@ -244,16 +177,19 @@ function ShareRecordingContent({
             recordingId={recordingId}
             shareUrl={shareUrl}
             sharesQuery={sharesQuery}
+            canManage={canManage}
             videoUrl={videoUrl}
             animatedThumbnailUrl={animatedThumbnailUrl}
           />
         </TabsContent>
 
         <TabsContent value="invite" className="mt-3">
-          <InviteTab
-            recordingId={recordingId}
+          <SharePeopleTab
+            resourceType="recording"
+            resourceId={recordingId}
             resourceUrl={absoluteAppUrl(`/r/${recordingId}`)}
             sharesQuery={sharesQuery}
+            canManage={canManage}
           />
         </TabsContent>
 
@@ -261,6 +197,7 @@ function ShareRecordingContent({
           <ClipsEmbedConfigurator
             recordingId={recordingId}
             sharesQuery={sharesQuery}
+            canManage={canManage}
           />
         </TabsContent>
       </Tabs>
@@ -269,23 +206,26 @@ function ShareRecordingContent({
 }
 
 // ---------------------------------------------------------------------------
-// Link tab — visibility + copy link + extras
+// Link tab — visibility + copy link + Clips extras (GIF / MP4)
 // ---------------------------------------------------------------------------
 
 function LinkTab({
   recordingId,
   shareUrl,
   sharesQuery,
+  canManage,
   videoUrl,
   animatedThumbnailUrl,
 }: {
   recordingId: string;
   shareUrl: string;
-  sharesQuery: ReturnType<typeof useActionQuery<SharesResponse>>;
+  sharesQuery: SharesQuery;
+  canManage: boolean;
   videoUrl?: string | null;
   animatedThumbnailUrl?: string | null;
 }) {
-  const { setRecordingVisibility, isPending } = useRecordingVisibilityMutation(
+  const { setResourceVisibility, isPending } = useResourceVisibilityMutation(
+    "recording",
     recordingId,
     sharesQuery,
   );
@@ -293,49 +233,16 @@ function LinkTab({
   const visibility: Visibility =
     (data?.visibility as Visibility | null) ?? "private";
   const isPublic = visibility === "public";
-  const canManage =
-    data?.role === "owner" || data?.role === "admin" || !data?.role;
-  const meta = VIS_META[visibility];
-
-  const handleVisibility = (next: string) => {
-    if (next === visibility) return;
-    setRecordingVisibility(next as Visibility);
-  };
 
   return (
     <div className="space-y-4">
-      <div>
-        <div className="mb-2 text-xs font-semibold">General access</div>
-        <div className="flex items-center gap-3">
-          <span
-            aria-hidden
-            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"
-          >
-            <meta.Icon size={16} strokeWidth={1.75} />
-          </span>
-          <div className="min-w-0 flex-1">
-            <Select
-              value={visibility}
-              onValueChange={handleVisibility}
-              disabled={!canManage || isPending}
-            >
-              <SelectTrigger className="h-8 border-0 -ml-2 bg-transparent px-2 shadow-none focus:ring-0 [&>span]:text-left">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {(Object.keys(VIS_META) as Visibility[]).map((k) => (
-                  <SelectItem key={k} value={k}>
-                    {VIS_META[k].label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <div className="mt-0.5 text-xs text-muted-foreground">
-              {meta.description}
-            </div>
-          </div>
-        </div>
-      </div>
+      <GeneralAccessSelect
+        visibility={visibility}
+        canManage={canManage}
+        isPending={isPending}
+        onChange={(next) => setResourceVisibility(next)}
+        publicDescription={PUBLIC_DESCRIPTION}
+      />
 
       <CopyField
         label="Share link"
@@ -344,24 +251,14 @@ function LinkTab({
       />
 
       {!isPublic && canManage ? (
-        <div className="rounded-md border border-border bg-muted/40 px-3 py-2.5">
-          <p className="text-xs text-muted-foreground">
-            This link will only work for people who already have access.
-          </p>
-          <Button
-            type="button"
-            size="sm"
-            className="mt-2 h-7"
-            onClick={() =>
-              setRecordingVisibility("public", {
-                onSuccess: () => copyToClipboard(shareUrl),
-              })
-            }
-            disabled={isPending}
-          >
-            {isPending ? "Making public…" : "Make public and copy"}
-          </Button>
-        </div>
+        <MakePublicCard
+          isPending={isPending}
+          onMakePublic={() =>
+            setResourceVisibility("public", {
+              onSuccess: () => copyToClipboard(shareUrl),
+            })
+          }
+        />
       ) : null}
 
       {videoUrl || animatedThumbnailUrl ? (
@@ -391,161 +288,17 @@ function LinkTab({
 }
 
 // ---------------------------------------------------------------------------
-// Invite tab — invite-by-email + shares list
-// ---------------------------------------------------------------------------
-
-function InviteTab({
-  recordingId,
-  resourceUrl,
-  sharesQuery,
-}: {
-  recordingId: string;
-  resourceUrl: string;
-  sharesQuery: ReturnType<typeof useActionQuery<SharesResponse>>;
-}) {
-  const share = useActionMutation("share-resource");
-  const unshare = useActionMutation("unshare-resource");
-
-  const [email, setEmail] = useState("");
-  const [role, setRole] = useState<Role>("viewer");
-  const [notifyPeople, setNotifyPeople] = useState(true);
-  const hasInviteEmail = email.trim().length > 0;
-
-  const data = sharesQuery.data;
-  const shares = data?.shares ?? [];
-  const canManage =
-    data?.role === "owner" || data?.role === "admin" || !data?.role;
-
-  const handleAdd = () => {
-    const trimmed = email.trim();
-    if (!trimmed) return;
-    share.mutate(
-      {
-        resourceType: "recording",
-        resourceId: recordingId,
-        principalType: "user",
-        principalId: trimmed,
-        role,
-        notify: notifyPeople,
-        resourceUrl,
-      },
-      {
-        onSuccess: () => {
-          setEmail("");
-          sharesQuery.refetch();
-        },
-      },
-    );
-  };
-
-  const handleRemove = (s: Share) => {
-    unshare.mutate(
-      {
-        resourceType: "recording",
-        resourceId: recordingId,
-        principalType: s.principalType,
-        principalId: s.principalId,
-      },
-      { onSuccess: () => sharesQuery.refetch() },
-    );
-  };
-
-  return (
-    <div className="space-y-3">
-      {canManage ? (
-        <div className="space-y-2">
-          <div className="flex items-stretch gap-2">
-            <Input
-              type="email"
-              placeholder="Add people by email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleAdd();
-              }}
-              autoComplete="off"
-              className="flex-1 h-9"
-            />
-            <Select value={role} onValueChange={(v) => setRole(v as Role)}>
-              <SelectTrigger className="h-9 w-[110px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {ROLE_OPTIONS.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          {hasInviteEmail ? (
-            <label className="flex items-center gap-2 text-xs text-muted-foreground">
-              <Checkbox
-                checked={notifyPeople}
-                onCheckedChange={(checked) => setNotifyPeople(checked === true)}
-              />
-              Notify people
-            </label>
-          ) : null}
-        </div>
-      ) : null}
-
-      <div>
-        <div className="mb-2 text-xs font-semibold">People with access</div>
-        <ul className="flex max-h-56 flex-col gap-1 overflow-y-auto p-0 m-0">
-          {data?.ownerEmail ? (
-            <li className="flex items-center gap-3 px-1 py-1.5 text-sm">
-              <Avatar label={data.ownerEmail} />
-              <span className="flex-1 min-w-0 truncate">{data.ownerEmail}</span>
-              <span className="text-xs text-muted-foreground">Owner</span>
-            </li>
-          ) : null}
-          {shares.map((s) => (
-            <li
-              key={`${s.principalType}:${s.principalId}`}
-              className="flex items-center gap-3 px-1 py-1.5 text-sm"
-            >
-              <Avatar label={s.principalId} org={s.principalType === "org"} />
-              <span className="flex-1 min-w-0 truncate">{s.principalId}</span>
-              <span className="text-xs text-muted-foreground">
-                {cap(s.role)}
-              </span>
-              {canManage ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  aria-label="Remove"
-                  onClick={() => handleRemove(s)}
-                  className="h-7 w-7"
-                >
-                  <IconTrash size={14} />
-                </Button>
-              ) : null}
-            </li>
-          ))}
-          {!shares.length && !data?.ownerEmail ? (
-            <li className="px-1 py-1.5 text-sm text-muted-foreground">
-              No one has access yet.
-            </li>
-          ) : null}
-        </ul>
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Embed tab — Clips-specific configurator
 // ---------------------------------------------------------------------------
 
 function ClipsEmbedConfigurator({
   recordingId,
   sharesQuery,
+  canManage,
 }: {
   recordingId: string;
-  sharesQuery: ReturnType<typeof useActionQuery<SharesResponse>>;
+  sharesQuery: SharesQuery;
+  canManage: boolean;
 }) {
   const [autoplay, setAutoplay] = useState(false);
   const [startMs, setStartMs] = useState(0);
@@ -557,13 +310,12 @@ function ClipsEmbedConfigurator({
   const visibility: Visibility =
     (data?.visibility as Visibility | null) ?? "private";
   const isPublic = visibility === "public";
-  const canManage =
-    data?.role === "owner" || data?.role === "admin" || !data?.role;
-  const { setRecordingVisibility, isPending } = useRecordingVisibilityMutation(
+  const { setResourceVisibility, isPending } = useResourceVisibilityMutation(
+    "recording",
     recordingId,
     sharesQuery,
   );
-  const makePublic = () => setRecordingVisibility("public");
+  const makePublic = () => setResourceVisibility("public");
 
   const src = useMemo(() => {
     const params: string[] = [];
@@ -673,118 +425,4 @@ function ClipsEmbedConfigurator({
       </div>
     </div>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Primitives
-// ---------------------------------------------------------------------------
-
-function CopyField({
-  label,
-  value,
-  disabled,
-}: {
-  label: string;
-  value: string;
-  disabled?: boolean;
-}) {
-  const [copied, setCopied] = useState(false);
-  const copy = () => {
-    if (disabled) return;
-    copyToClipboard(value);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1400);
-  };
-  return (
-    <div>
-      <div className="mb-1 text-xs font-medium text-muted-foreground">
-        {label}
-      </div>
-      <div className="flex items-stretch gap-2">
-        <Input
-          readOnly
-          value={value}
-          className="flex-1 h-9 font-mono text-xs"
-        />
-        <Button
-          type="button"
-          variant="outline"
-          size="icon"
-          onClick={copy}
-          aria-label="Copy"
-          disabled={disabled}
-          className="h-9 w-9"
-        >
-          {copied ? <IconCheck size={14} /> : <IconCopy size={14} />}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-function useRecordingVisibilityMutation(
-  recordingId: string,
-  sharesQuery: ReturnType<typeof useActionQuery<SharesResponse>>,
-) {
-  const queryClient = useQueryClient();
-  const setVisibility = useActionMutation("set-resource-visibility");
-  const shareQueryKey = useMemo(
-    () =>
-      [
-        "action",
-        "list-resource-shares",
-        { resourceType: "recording", resourceId: recordingId },
-      ] as const,
-    [recordingId],
-  );
-
-  const setRecordingVisibility = (
-    next: Visibility,
-    options?: { onSuccess?: () => void },
-  ) => {
-    const previous = queryClient.getQueryData<SharesResponse>(shareQueryKey);
-    queryClient.setQueryData<SharesResponse>(shareQueryKey, (current) =>
-      current ? { ...current, visibility: next } : current,
-    );
-    setVisibility.mutate(
-      {
-        resourceType: "recording",
-        resourceId: recordingId,
-        visibility: next,
-      } as any,
-      {
-        onSuccess: () => {
-          void sharesQuery.refetch().finally(() => options?.onSuccess?.());
-        },
-        onError: () => {
-          if (previous) {
-            queryClient.setQueryData(shareQueryKey, previous);
-          } else {
-            queryClient.invalidateQueries({ queryKey: shareQueryKey });
-          }
-        },
-      },
-    );
-  };
-
-  return { setRecordingVisibility, isPending: setVisibility.isPending };
-}
-
-function Avatar({ label, org }: { label: string; org?: boolean }) {
-  return (
-    <span
-      aria-hidden
-      className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-[11px] font-semibold text-muted-foreground"
-    >
-      {org ? (
-        <IconBuilding size={14} strokeWidth={1.75} />
-      ) : (
-        (label.split("@")[0]?.[0] ?? label[0] ?? "?").toUpperCase()
-      )}
-    </span>
-  );
-}
-
-function cap(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1);
 }

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -142,8 +142,7 @@ function ShareRecordingContent({
   });
 
   const data = sharesQuery.data;
-  const canManage =
-    data?.role === "owner" || data?.role === "admin" || !data?.role;
+  const canManage = data?.role === "owner" || data?.role === "admin";
   const titleText = recordingTitle
     ? `Share "${recordingTitle}"`
     : "Share recording";

--- a/templates/clips/app/components/sharing/share-ui.tsx
+++ b/templates/clips/app/components/sharing/share-ui.tsx
@@ -348,7 +348,7 @@ export function SharePeopleTab({
   const shares = data?.shares ?? [];
 
   const handleAdd = () => {
-    const trimmed = email.trim();
+    const trimmed = email.trim().toLowerCase();
     if (!trimmed) return;
     share.mutate(
       {

--- a/templates/clips/app/components/sharing/share-ui.tsx
+++ b/templates/clips/app/components/sharing/share-ui.tsx
@@ -1,0 +1,472 @@
+import { useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  IconBuilding,
+  IconCheck,
+  IconCopy,
+  IconLock,
+  IconTrash,
+  IconWorld,
+} from "@tabler/icons-react";
+import { useActionMutation, useActionQuery } from "@agent-native/core/client";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Shared types + constants
+// ---------------------------------------------------------------------------
+
+export type Visibility = "private" | "org" | "public";
+export type Role = "viewer" | "editor" | "admin";
+
+export interface Share {
+  id: string;
+  principalType: "user" | "org";
+  principalId: string;
+  role: Role;
+}
+
+export interface SharesResponse {
+  ownerEmail: string | null;
+  orgId: string | null;
+  visibility: Visibility | null;
+  role?: "owner" | Role;
+  shares: Share[];
+}
+
+export type SharesQuery = ReturnType<typeof useActionQuery<SharesResponse>>;
+
+export const VIS_META: Record<
+  Visibility,
+  { label: string; description: string; Icon: typeof IconLock }
+> = {
+  private: {
+    label: "Private",
+    description: "Only people with access can view",
+    Icon: IconLock,
+  },
+  org: {
+    label: "Organization",
+    description: "Anyone in your organization can view",
+    Icon: IconBuilding,
+  },
+  public: {
+    label: "Public",
+    description: "Anyone with the link can view",
+    Icon: IconWorld,
+  },
+};
+
+export const ROLE_OPTIONS: Array<{ value: Role; label: string }> = [
+  { value: "viewer", label: "Viewer" },
+  { value: "editor", label: "Editor" },
+  { value: "admin", label: "Admin" },
+];
+
+export function copyToClipboard(value: string): void {
+  navigator.clipboard.writeText(value).catch(() => {});
+}
+
+export function cap(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// ---------------------------------------------------------------------------
+// Optimistic visibility mutation (resource-agnostic)
+// ---------------------------------------------------------------------------
+
+export function useResourceVisibilityMutation(
+  resourceType: string,
+  resourceId: string,
+  sharesQuery: SharesQuery,
+) {
+  const queryClient = useQueryClient();
+  const setVisibility = useActionMutation("set-resource-visibility");
+  const shareQueryKey = useMemo(
+    () =>
+      ["action", "list-resource-shares", { resourceType, resourceId }] as const,
+    [resourceType, resourceId],
+  );
+
+  const setResourceVisibility = (
+    next: Visibility,
+    options?: { onSuccess?: () => void },
+  ) => {
+    const previous = queryClient.getQueryData<SharesResponse>(shareQueryKey);
+    queryClient.setQueryData<SharesResponse>(shareQueryKey, (current) =>
+      current ? { ...current, visibility: next } : current,
+    );
+    setVisibility.mutate(
+      {
+        resourceType,
+        resourceId,
+        visibility: next,
+      } as any,
+      {
+        onSuccess: () => {
+          void sharesQuery.refetch().finally(() => options?.onSuccess?.());
+        },
+        onError: () => {
+          if (previous) {
+            queryClient.setQueryData(shareQueryKey, previous);
+          } else {
+            queryClient.invalidateQueries({ queryKey: shareQueryKey });
+          }
+        },
+      },
+    );
+  };
+
+  return { setResourceVisibility, isPending: setVisibility.isPending };
+}
+
+// ---------------------------------------------------------------------------
+// Header (title + owner)
+// ---------------------------------------------------------------------------
+
+export function ShareCardHeader({
+  title,
+  ownerEmail,
+  reserveCloseButton = false,
+}: {
+  title: string;
+  ownerEmail?: string | null;
+  reserveCloseButton?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "min-w-0 border-b border-border px-4 pb-3 pt-3",
+        reserveCloseButton && "pr-12",
+      )}
+    >
+      <div className="min-w-0 truncate text-sm font-semibold" title={title}>
+        {title}
+      </div>
+      {ownerEmail ? (
+        <div className="mt-0.5 truncate text-xs text-muted-foreground">
+          Owner: {ownerEmail}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// General-access (visibility) selector
+// ---------------------------------------------------------------------------
+
+export function GeneralAccessSelect({
+  visibility,
+  canManage,
+  isPending,
+  onChange,
+  publicDescription,
+}: {
+  visibility: Visibility;
+  canManage: boolean;
+  isPending: boolean;
+  onChange: (next: Visibility) => void;
+  /** Override for the "public" visibility description (e.g. Clips comment hint). */
+  publicDescription?: string;
+}) {
+  const meta = VIS_META[visibility];
+  const description =
+    visibility === "public" && publicDescription
+      ? publicDescription
+      : meta.description;
+
+  return (
+    <div>
+      <div className="mb-2 text-xs font-semibold">General access</div>
+      <div className="flex items-center gap-3">
+        <span
+          aria-hidden
+          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"
+        >
+          <meta.Icon size={16} strokeWidth={1.75} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <Select
+            value={visibility}
+            onValueChange={(v) => onChange(v as Visibility)}
+            disabled={!canManage || isPending}
+          >
+            <SelectTrigger className="h-8 border-0 -ml-2 bg-transparent px-2 shadow-none focus:ring-0 [&>span]:text-left">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(Object.keys(VIS_META) as Visibility[]).map((k) => (
+                <SelectItem key={k} value={k}>
+                  {VIS_META[k].label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            {description}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// "Make public and copy" card (shown for private/org links the user manages)
+// ---------------------------------------------------------------------------
+
+export function MakePublicCard({
+  isPending,
+  onMakePublic,
+}: {
+  isPending: boolean;
+  onMakePublic: () => void;
+}) {
+  return (
+    <div className="rounded-md border border-border bg-muted/40 px-3 py-2.5">
+      <p className="text-xs text-muted-foreground">
+        This link will only work for people who already have access.
+      </p>
+      <Button
+        type="button"
+        size="sm"
+        className="mt-2 h-7"
+        onClick={onMakePublic}
+        disabled={isPending}
+      >
+        {isPending ? "Making public…" : "Make public and copy"}
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Copy-to-clipboard field
+// ---------------------------------------------------------------------------
+
+export function CopyField({
+  label,
+  value,
+  disabled,
+}: {
+  label: string;
+  value: string;
+  disabled?: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    if (disabled) return;
+    copyToClipboard(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1400);
+  };
+  return (
+    <div>
+      <div className="mb-1 text-xs font-medium text-muted-foreground">
+        {label}
+      </div>
+      <div className="flex items-stretch gap-2">
+        <Input
+          readOnly
+          value={value}
+          className="flex-1 h-9 font-mono text-xs"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          onClick={copy}
+          aria-label="Copy"
+          disabled={disabled}
+          className="h-9 w-9"
+        >
+          {copied ? <IconCheck size={14} /> : <IconCopy size={14} />}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Avatar chip
+// ---------------------------------------------------------------------------
+
+export function Avatar({ label, org }: { label: string; org?: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-[11px] font-semibold text-muted-foreground"
+    >
+      {org ? (
+        <IconBuilding size={14} strokeWidth={1.75} />
+      ) : (
+        (label.split("@")[0]?.[0] ?? label[0] ?? "?").toUpperCase()
+      )}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Invite tab — invite-by-email + shares list
+// ---------------------------------------------------------------------------
+
+export function SharePeopleTab({
+  resourceType,
+  resourceId,
+  resourceUrl,
+  sharesQuery,
+  canManage,
+  onError,
+}: {
+  resourceType: string;
+  resourceId: string;
+  /** Optional notification deep-link passed to `share-resource`. */
+  resourceUrl?: string;
+  sharesQuery: SharesQuery;
+  canManage: boolean;
+  onError?: (err: unknown, action: "invite" | "remove") => void;
+}) {
+  const share = useActionMutation("share-resource");
+  const unshare = useActionMutation("unshare-resource");
+
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<Role>("viewer");
+  const [notifyPeople, setNotifyPeople] = useState(true);
+  const hasInviteEmail = email.trim().length > 0;
+
+  const data = sharesQuery.data;
+  const shares = data?.shares ?? [];
+
+  const handleAdd = () => {
+    const trimmed = email.trim();
+    if (!trimmed) return;
+    share.mutate(
+      {
+        resourceType,
+        resourceId,
+        principalType: "user",
+        principalId: trimmed,
+        role,
+        notify: notifyPeople,
+        ...(resourceUrl ? { resourceUrl } : {}),
+      } as any,
+      {
+        onSuccess: () => {
+          setEmail("");
+          sharesQuery.refetch();
+        },
+        onError: (err: unknown) => onError?.(err, "invite"),
+      },
+    );
+  };
+
+  const handleRemove = (s: Share) => {
+    unshare.mutate(
+      {
+        resourceType,
+        resourceId,
+        principalType: s.principalType,
+        principalId: s.principalId,
+      } as any,
+      {
+        onSuccess: () => sharesQuery.refetch(),
+        onError: (err: unknown) => onError?.(err, "remove"),
+      },
+    );
+  };
+
+  return (
+    <div className="space-y-3">
+      {canManage ? (
+        <div className="space-y-2">
+          <div className="flex items-stretch gap-2">
+            <Input
+              type="email"
+              placeholder="Add people by email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleAdd();
+              }}
+              autoComplete="off"
+              className="flex-1 h-9"
+            />
+            <Select value={role} onValueChange={(v) => setRole(v as Role)}>
+              <SelectTrigger className="h-9 w-[110px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ROLE_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {hasInviteEmail ? (
+            <label className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Checkbox
+                checked={notifyPeople}
+                onCheckedChange={(checked) => setNotifyPeople(checked === true)}
+              />
+              Notify people
+            </label>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div>
+        <div className="mb-2 text-xs font-semibold">People with access</div>
+        <ul className="flex max-h-56 flex-col gap-1 overflow-y-auto p-0 m-0">
+          {data?.ownerEmail ? (
+            <li className="flex items-center gap-3 px-1 py-1.5 text-sm">
+              <Avatar label={data.ownerEmail} />
+              <span className="flex-1 min-w-0 truncate">{data.ownerEmail}</span>
+              <span className="text-xs text-muted-foreground">Owner</span>
+            </li>
+          ) : null}
+          {shares.map((s) => (
+            <li
+              key={`${s.principalType}:${s.principalId}`}
+              className="flex items-center gap-3 px-1 py-1.5 text-sm"
+            >
+              <Avatar label={s.principalId} org={s.principalType === "org"} />
+              <span className="flex-1 min-w-0 truncate">{s.principalId}</span>
+              <span className="text-xs text-muted-foreground">
+                {cap(s.role)}
+              </span>
+              {canManage ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Remove"
+                  onClick={() => handleRemove(s)}
+                  className="h-7 w-7"
+                >
+                  <IconTrash size={14} />
+                </Button>
+              ) : null}
+            </li>
+          ))}
+          {!shares.length && !data?.ownerEmail ? (
+            <li className="px-1 py-1.5 text-sm text-muted-foreground">
+              No one has access yet.
+            </li>
+          ) : null}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/templates/clips/app/routes/_app.meetings.$meetingId.tsx
+++ b/templates/clips/app/routes/_app.meetings.$meetingId.tsx
@@ -513,6 +513,7 @@ export default function MeetingDetailRoute() {
   const meetingIdForFinalize = meeting?.id;
   const transcriptStatusForFinalize = meeting?.transcriptStatus;
   useEffect(() => {
+    if (!canEdit) return; // viewers can't finalize — would 403
     if (!meetingIdForFinalize) return;
     if (autoFinalizedRef.current) return;
     if (hasNotes) return;
@@ -520,7 +521,13 @@ export default function MeetingDetailRoute() {
     if (transcriptStatusForFinalize !== "ready") return;
     autoFinalizedRef.current = true;
     finalize.mutate({ meetingId: meetingIdForFinalize });
-  }, [meetingIdForFinalize, transcriptStatusForFinalize, hasNotes, finalize]);
+  }, [
+    canEdit,
+    meetingIdForFinalize,
+    transcriptStatusForFinalize,
+    hasNotes,
+    finalize,
+  ]);
 
   if (isLoading || !meeting) {
     return (

--- a/templates/clips/app/routes/_app.meetings.$meetingId.tsx
+++ b/templates/clips/app/routes/_app.meetings.$meetingId.tsx
@@ -12,6 +12,7 @@ import {
   IconExternalLink,
   IconLoader2,
   IconNotes,
+  IconShare3,
   IconTrash,
   IconUsers,
   IconWand,
@@ -46,6 +47,7 @@ import {
   type AttendeeStackParticipant,
 } from "@/components/meetings/attendee-stack";
 import { PageHeader } from "@/components/library/page-header";
+import { ShareMeetingPopover } from "@/components/meetings/share-meeting-dialog";
 import {
   TranscriptBubbles,
   type TranscriptSegment,
@@ -125,10 +127,12 @@ function TitleEditor({
   value,
   onChange,
   compact = false,
+  readOnly = false,
 }: {
   value: string;
   onChange: (next: string) => void;
   compact?: boolean;
+  readOnly?: boolean;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
@@ -146,6 +150,12 @@ function TitleEditor({
     ? "text-base font-semibold tracking-tight truncate"
     : "text-2xl font-semibold tracking-tight";
   const editIconCls = compact ? "h-3.5 w-3.5" : "h-4 w-4";
+
+  if (readOnly) {
+    return (
+      <h1 className={cn(textCls, "min-w-0")}>{value || "Untitled meeting"}</h1>
+    );
+  }
 
   if (!editing) {
     return (
@@ -198,9 +208,11 @@ function TitleEditor({
 function ActionItemsByPerson({
   items,
   onToggle,
+  readOnly = false,
 }: {
   items: ActionItem[];
   onToggle: (index: number, completed: boolean) => void;
+  readOnly?: boolean;
 }) {
   // Preserve original index for toggle callback while grouping.
   const grouped = useMemo(() => {
@@ -251,12 +263,18 @@ function ActionItemsByPerson({
                     type="button"
                     role="checkbox"
                     aria-checked={done}
-                    onClick={() => onToggle(index, !done)}
+                    disabled={readOnly}
+                    onClick={() => {
+                      if (!readOnly) onToggle(index, !done);
+                    }}
                     className={cn(
-                      "mt-0.5 h-3.5 w-3.5 shrink-0 rounded border flex items-center justify-center cursor-pointer transition-colors",
+                      "mt-0.5 h-3.5 w-3.5 shrink-0 rounded border flex items-center justify-center transition-colors",
+                      readOnly ? "cursor-default" : "cursor-pointer",
                       done
                         ? "bg-foreground border-foreground"
-                        : "border-border hover:border-foreground/60",
+                        : readOnly
+                          ? "border-border"
+                          : "border-border hover:border-foreground/60",
                     )}
                   >
                     {done && (
@@ -292,6 +310,7 @@ export default function MeetingDetailRoute() {
     actionItems?: ActionItem[];
     transcript?: { segmentsJson?: TranscriptSegment[] | null } | null;
     recording?: { id: string; durationMs?: number | null } | null;
+    role?: "owner" | "admin" | "editor" | "viewer";
   };
 
   const { data, isLoading, isError } = useActionQuery<GetMeetingResp>(
@@ -357,6 +376,11 @@ export default function MeetingDetailRoute() {
     ((meeting.actualStart && !meeting.actualEnd) ||
       meeting.transcriptStatus === "in_progress")
   );
+
+  // Viewer-role shares are read-only: gate every edit affordance. Server
+  // actions also enforce an `editor` minimum, so this is purely UX.
+  const canEdit =
+    data?.role === "owner" || data?.role === "admin" || data?.role === "editor";
 
   const hasNotes =
     !!meeting?.summaryMd ||
@@ -426,23 +450,6 @@ export default function MeetingDetailRoute() {
     updateMeeting.mutate({ id: meeting.id, userNotesMd: next });
   };
 
-  /**
-   * Granola-signature behavior: when the user edits an AI block, "promote"
-   * its content into userNotesMd so it survives re-generation. The AI block
-   * is cleared on the server in the same mutation.
-   */
-  const handleTransferAiToUser = (transferred: string) => {
-    if (!meeting) return;
-    const merged =
-      [meeting.userNotesMd, transferred].filter(Boolean).join("\n\n") || "";
-    patchCachedMeeting({ userNotesMd: merged, summaryMd: "" });
-    updateMeeting.mutate({
-      id: meeting.id,
-      userNotesMd: merged,
-      summaryMd: "",
-    });
-  };
-
   const handleToggleActionItem = (index: number, completed: boolean) => {
     if (!meeting) return;
     const items = meeting.actionItemsJson ?? [];
@@ -471,11 +478,11 @@ export default function MeetingDetailRoute() {
 
   const handleFinalize = () => {
     if (!meeting) return;
-    // Notes the user edited are promoted to userNotesMd (see
-    // handleTransferAiToUser) and survive regeneration, so this stays
-    // one-click — we just reassure the user their own notes are kept.
+    // "My notes" (userNotesMd) is a separate field and is untouched by
+    // regeneration; only the AI summary/bullets are overwritten. Reassure
+    // the user their own notes are kept.
     if (hasNotes) {
-      toast.info("Regenerating notes — your own edits are kept");
+      toast.info("Regenerating notes — your own notes are kept");
     }
     autoFinalizedRef.current = true;
     finalize.mutate({ meetingId: meeting.id });
@@ -582,6 +589,7 @@ export default function MeetingDetailRoute() {
             value={meeting.title || ""}
             onChange={handleTitleChange}
             compact
+            readOnly={!canEdit}
           />
           {isLive && (
             <Badge
@@ -597,7 +605,7 @@ export default function MeetingDetailRoute() {
           )}
         </div>
         <div className="ml-auto flex items-center gap-2">
-          {finalize.isPending ? (
+          {!canEdit ? null : finalize.isPending ? (
             <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
               <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
               Generating notes…
@@ -612,56 +620,67 @@ export default function MeetingDetailRoute() {
               Regenerate notes
             </Button>
           ) : null}
-          <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="h-8 w-8 cursor-pointer"
-                  aria-label="Meeting options"
-                >
-                  <IconDots className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-44">
-                <DropdownMenuItem
-                  onSelect={(event) => {
-                    event.preventDefault();
-                    setDeleteOpen(true);
-                  }}
-                  className="text-destructive focus:text-destructive"
-                >
-                  <IconTrash className="mr-2 h-4 w-4" />
-                  Remove meeting
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Remove this meeting?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This removes the meeting from Clips. It will not delete any
-                  linked transcript or change your Google Calendar.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel disabled={deleteMeeting.isPending}>
-                  Cancel
-                </AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={(event) => {
-                    event.preventDefault();
-                    handleDeleteMeeting();
-                  }}
-                  disabled={deleteMeeting.isPending}
-                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                >
-                  {deleteMeeting.isPending ? "Removing..." : "Remove"}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+          <ShareMeetingPopover
+            meetingId={meeting.id}
+            meetingTitle={meeting.title}
+          >
+            <Button size="sm" className="shrink-0 gap-1.5">
+              <IconShare3 className="h-4 w-4" />
+              Share
+            </Button>
+          </ShareMeetingPopover>
+          {canEdit && (
+            <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8 cursor-pointer"
+                    aria-label="Meeting options"
+                  >
+                    <IconDots className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-44">
+                  <DropdownMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      setDeleteOpen(true);
+                    }}
+                    className="text-destructive focus:text-destructive"
+                  >
+                    <IconTrash className="mr-2 h-4 w-4" />
+                    Remove meeting
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Remove this meeting?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This removes the meeting from Clips. It will not delete any
+                    linked transcript or change your Google Calendar.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={deleteMeeting.isPending}>
+                    Cancel
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={(event) => {
+                      event.preventDefault();
+                      handleDeleteMeeting();
+                    }}
+                    disabled={deleteMeeting.isPending}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    {deleteMeeting.isPending ? "Removing..." : "Remove"}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
         </div>
       </PageHeader>
 
@@ -782,6 +801,7 @@ export default function MeetingDetailRoute() {
                 view="user"
                 userNotesMd={meeting.userNotesMd ?? ""}
                 onUserNotesChange={handleUserNotesChange}
+                readOnly={!canEdit}
               />
             </TabsContent>
 
@@ -794,7 +814,7 @@ export default function MeetingDetailRoute() {
                 summaryMd={meeting.summaryMd ?? ""}
                 bullets={bullets.map((b) => b.text)}
                 onSummaryChange={handleSummaryChange}
-                onTransferAiToUser={handleTransferAiToUser}
+                readOnly={!canEdit}
                 renderBullet={(b) => (
                   <BulletLink
                     bullet={b}
@@ -818,6 +838,7 @@ export default function MeetingDetailRoute() {
                 <ActionItemsByPerson
                   items={actionItems}
                   onToggle={handleToggleActionItem}
+                  readOnly={!canEdit}
                 />
               ) : (
                 <p className="text-sm leading-relaxed text-muted-foreground/50 italic">

--- a/templates/clips/app/routes/share.meeting.$meetingId.tsx
+++ b/templates/clips/app/routes/share.meeting.$meetingId.tsx
@@ -7,7 +7,7 @@ import {
   IconUsers,
   IconWand,
 } from "@tabler/icons-react";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { PoweredByBadge, appPath } from "@agent-native/core/client";
 import { getRequestUserEmail } from "@agent-native/core/server";
 import { resolveAccess } from "@agent-native/core/sharing";
@@ -66,7 +66,7 @@ export async function loader({
       bulletsJson: schema.meetings.bulletsJson,
     })
     .from(schema.meetings)
-    .where(eq(schema.meetings.id, id))
+    .where(and(eq(schema.meetings.id, id), isNull(schema.meetings.trashedAt)))
     .limit(1);
 
   if (!row) return { meeting: null };

--- a/templates/clips/app/routes/share.meeting.$meetingId.tsx
+++ b/templates/clips/app/routes/share.meeting.$meetingId.tsx
@@ -1,0 +1,289 @@
+import type { LoaderFunctionArgs, MetaFunction } from "react-router";
+import { useLoaderData } from "react-router";
+import {
+  IconCalendar,
+  IconExternalLink,
+  IconListCheck,
+  IconUsers,
+  IconWand,
+} from "@tabler/icons-react";
+import { eq } from "drizzle-orm";
+import { PoweredByBadge, appPath } from "@agent-native/core/client";
+import { getRequestUserEmail } from "@agent-native/core/server";
+import { resolveAccess } from "@agent-native/core/sharing";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  AttendeeStack,
+  type AttendeeStackParticipant,
+} from "@/components/meetings/attendee-stack";
+import { getDb, schema } from "../../server/db";
+
+interface ActionItem {
+  id: string;
+  text: string;
+  assigneeEmail: string | null;
+  completedAt: string | null;
+}
+
+interface Participant {
+  email: string;
+  name: string | null;
+  isOrganizer: boolean;
+}
+
+interface Bullet {
+  text: string;
+}
+
+type LoaderData =
+  | {
+      meeting: {
+        id: string;
+        title: string;
+        scheduledStart: string | null;
+        summaryMd: string;
+        bullets: Bullet[];
+        participants: Participant[];
+        actionItems: ActionItem[];
+      };
+    }
+  | { meeting: null };
+
+export async function loader({
+  params,
+}: LoaderFunctionArgs): Promise<LoaderData> {
+  const id = params.meetingId;
+  if (!id) return { meeting: null };
+
+  const [row] = await getDb()
+    .select({
+      id: schema.meetings.id,
+      title: schema.meetings.title,
+      scheduledStart: schema.meetings.scheduledStart,
+      visibility: schema.meetings.visibility,
+      summaryMd: schema.meetings.summaryMd,
+      bulletsJson: schema.meetings.bulletsJson,
+    })
+    .from(schema.meetings)
+    .where(eq(schema.meetings.id, id))
+    .limit(1);
+
+  if (!row) return { meeting: null };
+
+  if (row.visibility !== "public") {
+    const userEmail = getRequestUserEmail();
+    const access = userEmail ? await resolveAccess("meeting", id) : null;
+    if (!access) return { meeting: null };
+  }
+
+  const [participants, actionItems] = await Promise.all([
+    getDb()
+      .select({
+        email: schema.meetingParticipants.email,
+        name: schema.meetingParticipants.name,
+        isOrganizer: schema.meetingParticipants.isOrganizer,
+      })
+      .from(schema.meetingParticipants)
+      .where(eq(schema.meetingParticipants.meetingId, id)),
+    getDb()
+      .select({
+        id: schema.meetingActionItems.id,
+        text: schema.meetingActionItems.text,
+        assigneeEmail: schema.meetingActionItems.assigneeEmail,
+        completedAt: schema.meetingActionItems.completedAt,
+      })
+      .from(schema.meetingActionItems)
+      .where(eq(schema.meetingActionItems.meetingId, id)),
+  ]);
+
+  let bullets: Bullet[] = [];
+  try {
+    const parsed = JSON.parse(row.bulletsJson);
+    if (Array.isArray(parsed)) bullets = parsed as Bullet[];
+  } catch {}
+
+  return {
+    meeting: {
+      id: row.id,
+      title: row.title,
+      scheduledStart: row.scheduledStart,
+      summaryMd: row.summaryMd,
+      bullets,
+      participants,
+      actionItems,
+    },
+  };
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const m = data?.meeting;
+  const title = m?.title ? `${m.title} · Clips` : "Meeting notes · Clips";
+  const description = m?.title
+    ? `AI meeting notes for "${m.title}"`
+    : "AI meeting notes shared via Clips.";
+  return [
+    { title },
+    { name: "description", content: description },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+  ];
+};
+
+export function HydrateFallback() {
+  return (
+    <div className="flex items-center justify-center h-screen w-full bg-background">
+      <Spinner className="h-8 w-8 text-muted-foreground" />
+    </div>
+  );
+}
+
+function formatDateTime(iso?: string | null): string {
+  if (!iso) return "";
+  try {
+    return new Date(iso).toLocaleString([], {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return "";
+  }
+}
+
+export default function ShareMeetingRoute() {
+  const data = useLoaderData<LoaderData>();
+
+  if (!data.meeting) {
+    return (
+      <div className="flex flex-col items-center justify-center h-screen w-full gap-3 text-center px-4 bg-background">
+        <p className="text-sm text-muted-foreground">
+          This meeting is private or no longer available.
+        </p>
+        <PoweredByBadge />
+      </div>
+    );
+  }
+
+  const { meeting } = data;
+  const { bullets } = meeting;
+  const hasNotes =
+    !!meeting.summaryMd || bullets.length > 0 || meeting.actionItems.length > 0;
+
+  const attendees: AttendeeStackParticipant[] = meeting.participants.map(
+    (p) => ({ email: p.email, name: p.name ?? undefined }),
+  );
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b border-border">
+        <div className="max-w-2xl mx-auto flex items-center gap-3 px-4 py-3">
+          <h1 className="min-w-0 flex-1 truncate text-sm font-medium">
+            {meeting.title || "Untitled meeting"}
+          </h1>
+          <Button variant="ghost" size="sm" asChild className="shrink-0">
+            <a href={appPath("/")} className="gap-1.5">
+              Try Clips
+              <IconExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </Button>
+        </div>
+      </header>
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground mb-8">
+          {meeting.scheduledStart && (
+            <span className="inline-flex items-center gap-1">
+              <IconCalendar className="h-3.5 w-3.5" />
+              {formatDateTime(meeting.scheduledStart)}
+            </span>
+          )}
+          {attendees.length > 0 && (
+            <span className="inline-flex items-center gap-1.5">
+              <IconUsers className="h-3.5 w-3.5" />
+              <AttendeeStack participants={attendees} max={5} size="xs" />
+              <span>
+                {attendees.length} attendee
+                {attendees.length === 1 ? "" : "s"}
+              </span>
+            </span>
+          )}
+        </div>
+
+        {!hasNotes ? (
+          <p className="text-sm text-muted-foreground italic">
+            AI notes haven't been generated yet for this meeting.
+          </p>
+        ) : (
+          <div className="space-y-8">
+            {meeting.summaryMd && (
+              <section>
+                <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+                  <IconWand className="h-3.5 w-3.5" />
+                  Summary
+                </div>
+                <div className="text-sm leading-relaxed whitespace-pre-wrap">
+                  {meeting.summaryMd}
+                </div>
+              </section>
+            )}
+
+            {bullets.length > 0 && (
+              <section>
+                <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+                  <IconWand className="h-3.5 w-3.5" />
+                  Key points
+                </div>
+                <ul className="space-y-2">
+                  {bullets.map((b, i) => (
+                    <li
+                      key={i}
+                      className="flex gap-2 text-sm leading-relaxed text-muted-foreground"
+                    >
+                      <span>•</span>
+                      <span className="flex-1">{b.text}</span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            {meeting.actionItems.length > 0 && (
+              <section>
+                <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+                  <IconListCheck className="h-3.5 w-3.5" />
+                  Action items
+                </div>
+                <ul className="space-y-2">
+                  {meeting.actionItems.map((item, i) => (
+                    <li key={i} className="flex gap-2 text-sm leading-relaxed">
+                      <span
+                        className={
+                          item.completedAt
+                            ? "line-through text-muted-foreground"
+                            : ""
+                        }
+                      >
+                        {item.assigneeEmail ? (
+                          <span className="font-medium">
+                            {item.assigneeEmail.split("@")[0]}:{" "}
+                          </span>
+                        ) : null}
+                        {item.text}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+          </div>
+        )}
+
+        <div className="mt-12">
+          <PoweredByBadge />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- **Share a meeting.** Meetings can now be shared the same way recordings are: a share dialog with a public link and the option to invite specific people by email as viewers, editors, or admins.

- **Public meeting page.** Shared meetings open on a public page showing the meeting title, time, attendees, and AI notes, with a "Try Clips" link in the header.

- **Viewer access is read-only.** People given _viewer_ access can read a meeting but can't change the title, notes, AI summary, or action items, and don't see the regenerate or delete controls. Editors, admins, and owners are unaffected. (Also enforced on the server.)

- **Consistent header spacing.** The meetings header now matches the recordings header.

- **Shared share dialog.** The meeting and recording share dialogs now reuse one set of components for consistency and easier maintenance — no change to how either looks or behaves.
<img width="1467" height="854" alt="image" src="https://github.com/user-attachments/assets/7c7524c6-5339-4b32-9e64-01f03db658f6" />

