### PR TITLE
Ground plan comment anchors in node identity and explicit coordinates

### DIFF
--- a/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
+++ b/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-native-visual-plans",
-  "version": "1.0.0+codex.0916497541a0",
+  "version": "1.0.0+codex.3e0a1cd78362",
   "description": "Generate and review coding-agent plans as structured documents with inline diagrams, implementation maps, annotations, feedback, and HTML export.",
   "author": { "name": "Agent-Native", "url": "https://agent-native.com" },
   "homepage": "https://plan.agent-native.com",

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-plan/SKILL.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-plan/SKILL.md
@@ -283,6 +283,35 @@ directory before authoring a plan.
 When the user critiques a plan's look or structure, fix the renderer or this
 skill — never hand-edit one stored plan. Turn feedback into better guidance.
 
+## Interpreting comment anchors
+
+`get-plan-feedback` returns rich anchors — read them before acting on any comment.
+
+- **Coordinate frames.** `targetX`/`targetY` are percentages *within* the
+  element named by `targetSelector`/`targetKind`. Bare `x`/`y` are percentages
+  of the whole plan document. `canvasX`/`canvasY` are raw board-world pixels on
+  the design canvas (board size given when available).
+- **Wireframe pins.** Anchors on wireframes include `targetNodeId` and
+  `targetNodePath` (e.g. `card > list > listItem "Acme Inc"`) identifying the
+  exact kit node. Use `targetNodeId` directly with wireframe node patch ops;
+  use `data-design-id` values from design artboards with
+  `update-design-element-style`. Prefer the node id/path over raw coordinates;
+  fall back to coordinates plus the focused screenshot (red ring marks the exact
+  point) only when no node id is present.
+- **Text quotes.** Resolve `textQuote` against current prose using
+  `contextBefore`/`contextAfter` for disambiguation. If `ambiguous: true`, ask
+  the user — do not guess which occurrence is meant.
+- **Detached comments.** `get-plan-feedback` flags threads whose quoted text no
+  longer exists as `detached` (in `detachedThreads`). Reconcile these against
+  rewritten content — never silently drop them.
+- **Routing.** `resolutionTarget` is the only routing signal: act on `agent`,
+  treat `human` as context only. `@mentions` are people to notify, never a
+  routing signal.
+- **Two-axis state.** Mark every ingested comment as consumed
+  (`consumedCommentIds` on `update-visual-plan`). Set `status=resolved` only on
+  agent-targeted comments you actually addressed; leave human-targeted comments
+  open.
+
 ## Visibility & Sharing
 
 Use `set-resource-visibility` to change who can see a plan (e.g. public, login,

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-recap/SKILL.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-recap/SKILL.md
@@ -485,6 +485,10 @@ auto-re-run is the remaining fast-follow.
 - **visual-plan** — the canonical command and the source of the shared Wireframe
   & Canvas and Document Quality cores; a recap follows the same block discipline
   in reverse.
+- **comment anchors** — recap comments use the same anchor rules as forward
+  plans; see "Interpreting comment anchors" in the visual-plan skill for
+  coordinate frames, wireframe node ids, text-quote resolution, detached
+  threads, routing via `resolutionTarget`, and two-axis consumed/resolved state.
 - **security** — data scoping, secret handling, and the hardcoded-secret rule the
   recap's redaction and visibility gating mirror.
 - **sharing** — org/login-gated visibility for the plan that holds the recap.

--- a/.changeset/add-comment-anchor-skill-docs.md
+++ b/.changeset/add-comment-anchor-skill-docs.md
@@ -1,0 +1,8 @@
+---
+"@agent-native/core": patch
+---
+
+Add "Interpreting comment anchors" section to the visual-plan skill and a
+matching pointer in visual-recap, teaching agents how to read coordinate
+frames, wireframe node ids, text-quote disambiguation, detached threads,
+routing via resolutionTarget, and two-axis consumed/resolved state.

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -1129,6 +1129,35 @@ ${EXEMPLAR_REFERENCE_POINTER}
 When the user critiques a plan's look or structure, fix the renderer or this
 skill — never hand-edit one stored plan. Turn feedback into better guidance.
 
+## Interpreting comment anchors
+
+\`get-plan-feedback\` returns rich anchors — read them before acting on any comment.
+
+- **Coordinate frames.** \`targetX\`/\`targetY\` are percentages *within* the
+  element named by \`targetSelector\`/\`targetKind\`. Bare \`x\`/\`y\` are percentages
+  of the whole plan document. \`canvasX\`/\`canvasY\` are raw board-world pixels on
+  the design canvas (board size given when available).
+- **Wireframe pins.** Anchors on wireframes include \`targetNodeId\` and
+  \`targetNodePath\` (e.g. \`card > list > listItem "Acme Inc"\`) identifying the
+  exact kit node. Use \`targetNodeId\` directly with wireframe node patch ops;
+  use \`data-design-id\` values from design artboards with
+  \`update-design-element-style\`. Prefer the node id/path over raw coordinates;
+  fall back to coordinates plus the focused screenshot (red ring marks the exact
+  point) only when no node id is present.
+- **Text quotes.** Resolve \`textQuote\` against current prose using
+  \`contextBefore\`/\`contextAfter\` for disambiguation. If \`ambiguous: true\`, ask
+  the user — do not guess which occurrence is meant.
+- **Detached comments.** \`get-plan-feedback\` flags threads whose quoted text no
+  longer exists as \`detached\` (in \`detachedThreads\`). Reconcile these against
+  rewritten content — never silently drop them.
+- **Routing.** \`resolutionTarget\` is the only routing signal: act on \`agent\`,
+  treat \`human\` as context only. \`@mentions\` are people to notify, never a
+  routing signal.
+- **Two-axis state.** Mark every ingested comment as consumed
+  (\`consumedCommentIds\` on \`update-visual-plan\`). Set \`status=resolved\` only on
+  agent-targeted comments you actually addressed; leave human-targeted comments
+  open.
+
 ## Visibility & Sharing
 
 Use \`set-resource-visibility\` to change who can see a plan (e.g. public, login,
@@ -1666,6 +1695,10 @@ auto-re-run is the remaining fast-follow.
 - **visual-plan** — the canonical command and the source of the shared Wireframe
   & Canvas and Document Quality cores; a recap follows the same block discipline
   in reverse.
+- **comment anchors** — recap comments use the same anchor rules as forward
+  plans; see "Interpreting comment anchors" in the visual-plan skill for
+  coordinate frames, wireframe node ids, text-quote resolution, detached
+  threads, routing via \`resolutionTarget\`, and two-axis consumed/resolved state.
 - **security** — data scoping, secret handling, and the hardcoded-secret rule the
   recap's redaction and visibility gating mirror.
 - **sharing** — org/login-gated visibility for the plan that holds the recap.

--- a/skills/visual-plans/SKILL.md
+++ b/skills/visual-plans/SKILL.md
@@ -283,6 +283,35 @@ directory before authoring a plan.
 When the user critiques a plan's look or structure, fix the renderer or this
 skill — never hand-edit one stored plan. Turn feedback into better guidance.
 
+## Interpreting comment anchors
+
+`get-plan-feedback` returns rich anchors — read them before acting on any comment.
+
+- **Coordinate frames.** `targetX`/`targetY` are percentages *within* the
+  element named by `targetSelector`/`targetKind`. Bare `x`/`y` are percentages
+  of the whole plan document. `canvasX`/`canvasY` are raw board-world pixels on
+  the design canvas (board size given when available).
+- **Wireframe pins.** Anchors on wireframes include `targetNodeId` and
+  `targetNodePath` (e.g. `card > list > listItem "Acme Inc"`) identifying the
+  exact kit node. Use `targetNodeId` directly with wireframe node patch ops;
+  use `data-design-id` values from design artboards with
+  `update-design-element-style`. Prefer the node id/path over raw coordinates;
+  fall back to coordinates plus the focused screenshot (red ring marks the exact
+  point) only when no node id is present.
+- **Text quotes.** Resolve `textQuote` against current prose using
+  `contextBefore`/`contextAfter` for disambiguation. If `ambiguous: true`, ask
+  the user — do not guess which occurrence is meant.
+- **Detached comments.** `get-plan-feedback` flags threads whose quoted text no
+  longer exists as `detached` (in `detachedThreads`). Reconcile these against
+  rewritten content — never silently drop them.
+- **Routing.** `resolutionTarget` is the only routing signal: act on `agent`,
+  treat `human` as context only. `@mentions` are people to notify, never a
+  routing signal.
+- **Two-axis state.** Mark every ingested comment as consumed
+  (`consumedCommentIds` on `update-visual-plan`). Set `status=resolved` only on
+  agent-targeted comments you actually addressed; leave human-targeted comments
+  open.
+
 ## Visibility & Sharing
 
 Use `set-resource-visibility` to change who can see a plan (e.g. public, login,

--- a/skills/visual-recap/SKILL.md
+++ b/skills/visual-recap/SKILL.md
@@ -485,6 +485,10 @@ auto-re-run is the remaining fast-follow.
 - **visual-plan** — the canonical command and the source of the shared Wireframe
   & Canvas and Document Quality cores; a recap follows the same block discipline
   in reverse.
+- **comment anchors** — recap comments use the same anchor rules as forward
+  plans; see "Interpreting comment anchors" in the visual-plan skill for
+  coordinate frames, wireframe node ids, text-quote resolution, detached
+  threads, routing via `resolutionTarget`, and two-axis consumed/resolved state.
 - **security** — data scoping, secret handling, and the hardcoded-secret rule the
   recap's redaction and visibility gating mirror.
 - **sharing** — org/login-gated visibility for the plan that holds the recap.

--- a/templates/plan/.agents/skills/visual-plan/SKILL.md
+++ b/templates/plan/.agents/skills/visual-plan/SKILL.md
@@ -283,6 +283,35 @@ directory before authoring a plan.
 When the user critiques a plan's look or structure, fix the renderer or this
 skill — never hand-edit one stored plan. Turn feedback into better guidance.
 
+## Interpreting comment anchors
+
+`get-plan-feedback` returns rich anchors — read them before acting on any comment.
+
+- **Coordinate frames.** `targetX`/`targetY` are percentages *within* the
+  element named by `targetSelector`/`targetKind`. Bare `x`/`y` are percentages
+  of the whole plan document. `canvasX`/`canvasY` are raw board-world pixels on
+  the design canvas (board size given when available).
+- **Wireframe pins.** Anchors on wireframes include `targetNodeId` and
+  `targetNodePath` (e.g. `card > list > listItem "Acme Inc"`) identifying the
+  exact kit node. Use `targetNodeId` directly with wireframe node patch ops;
+  use `data-design-id` values from design artboards with
+  `update-design-element-style`. Prefer the node id/path over raw coordinates;
+  fall back to coordinates plus the focused screenshot (red ring marks the exact
+  point) only when no node id is present.
+- **Text quotes.** Resolve `textQuote` against current prose using
+  `contextBefore`/`contextAfter` for disambiguation. If `ambiguous: true`, ask
+  the user — do not guess which occurrence is meant.
+- **Detached comments.** `get-plan-feedback` flags threads whose quoted text no
+  longer exists as `detached` (in `detachedThreads`). Reconcile these against
+  rewritten content — never silently drop them.
+- **Routing.** `resolutionTarget` is the only routing signal: act on `agent`,
+  treat `human` as context only. `@mentions` are people to notify, never a
+  routing signal.
+- **Two-axis state.** Mark every ingested comment as consumed
+  (`consumedCommentIds` on `update-visual-plan`). Set `status=resolved` only on
+  agent-targeted comments you actually addressed; leave human-targeted comments
+  open.
+
 ## Visibility & Sharing
 
 Use `set-resource-visibility` to change who can see a plan (e.g. public, login,

--- a/templates/plan/.agents/skills/visual-recap/SKILL.md
+++ b/templates/plan/.agents/skills/visual-recap/SKILL.md
@@ -485,6 +485,10 @@ auto-re-run is the remaining fast-follow.
 - **visual-plan** — the canonical command and the source of the shared Wireframe
   & Canvas and Document Quality cores; a recap follows the same block discipline
   in reverse.
+- **comment anchors** — recap comments use the same anchor rules as forward
+  plans; see "Interpreting comment anchors" in the visual-plan skill for
+  coordinate frames, wireframe node ids, text-quote resolution, detached
+  threads, routing via `resolutionTarget`, and two-axis consumed/resolved state.
 - **security** — data scoping, secret handling, and the hardcoded-secret rule the
   recap's redaction and visibility gating mirror.
 - **sharing** — org/login-gated visibility for the plan that holds the recap.

--- a/templates/plan/AGENTS.md
+++ b/templates/plan/AGENTS.md
@@ -175,6 +175,17 @@ elementId, styles }]`. Elements must have `data-design-id` or
   delta. Use those fields before changing code or updating the plan, especially
   to distinguish comments the agent should act on from comments intended for a
   human reviewer.
+- **Anchor interpretation.** `targetX`/`targetY` are percentages within the
+  named element; bare `x`/`y` are percentages of the whole document;
+  `canvasX`/`canvasY` are board-world pixels. Wireframe anchors carry
+  `targetNodeId`/`targetNodePath` — prefer those over raw coordinates; fall back
+  to coordinates plus the focused screenshot only when no node id is present.
+  Resolve `textQuote` with `contextBefore`/`contextAfter`; if `ambiguous: true`,
+  ask the user. Threads in `detachedThreads` no longer match current prose —
+  reconcile, never drop. Act on `resolutionTarget=agent`; treat `human` as
+  context only; `@mentions` are notification signals, not routing. Mark ingested
+  comments consumed (`consumedCommentIds`); set `status=resolved` only on
+  agent-targeted comments you actually addressed.
 - New human comments send best-effort transactional email when email is
   configured: root comments and replies notify the plan owner, @mentioned
   members, and replies also notify prior human participants in that thread.

--- a/templates/plan/actions/get-plan-feedback.spec.ts
+++ b/templates/plan/actions/get-plan-feedback.spec.ts
@@ -247,12 +247,77 @@ describe("get-plan-feedback action", () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: "visual-8",
-          anchorDetails: expect.arrayContaining(["Canvas point: 80, 40"]),
+          anchorDetails: expect.arrayContaining([
+            "Canvas point: canvas 80, 40 (board px)",
+          ]),
         }),
       ]),
     );
     expect(result.instructions.join("\n")).toContain(
       "Focused screenshot attachments",
+    );
+  });
+
+  it("marks a text-anchor comment detached when the quoted text no longer exists in content", async () => {
+    const attached = comment("attached", "human");
+    attached.anchor = JSON.stringify({
+      anchorKind: "text",
+      textQuote: "Initialize npm project",
+      sectionTitle: "Steps",
+    });
+    const detachedComment = comment("detached", "human");
+    detachedComment.anchor = JSON.stringify({
+      anchorKind: "text",
+      textQuote: "This phrase was deleted",
+      sectionTitle: "Steps",
+    });
+
+    const planWithContent = {
+      ...plan,
+      content: {
+        version: 2,
+        blocks: [
+          {
+            id: "block_1",
+            type: "rich-text" as const,
+            data: {
+              markdown: "## Steps\n\nInitialize npm project\n\nRun the tests",
+            },
+          },
+        ],
+      },
+    };
+
+    loadPlanBundleMock.mockResolvedValueOnce({
+      plan: planWithContent,
+      sections: [section],
+      comments: [attached, detachedComment],
+      events: [],
+      summary: {
+        sectionCounts: { summary: 1 },
+        commentCount: 2,
+        openCommentCount: 2,
+      },
+    });
+
+    const result = (await action.run({ planId: "plan_1" })) as {
+      comments: Array<{ id: string; detached: boolean }>;
+      threads: Array<{ id: string; detached: boolean }>;
+      feedbackSummary: { detachedCount: number };
+      detachedThreads: Array<{ id: string; messageExcerpt: string }>;
+      instructions: string[];
+    };
+
+    const attachedComment = result.comments.find((c) => c.id === "attached");
+    const detachedResult = result.comments.find((c) => c.id === "detached");
+    expect(attachedComment?.detached).toBe(false);
+    expect(detachedResult?.detached).toBe(true);
+    expect(result.feedbackSummary.detachedCount).toBe(1);
+    expect(result.detachedThreads).toEqual([
+      expect.objectContaining({ id: "detached" }),
+    ]);
+    expect(result.instructions.join("\n")).toContain(
+      "Comments marked detached no longer match their quoted text",
     );
   });
 });

--- a/templates/plan/actions/get-plan-feedback.spec.ts
+++ b/templates/plan/actions/get-plan-feedback.spec.ts
@@ -320,4 +320,98 @@ describe("get-plan-feedback action", () => {
       "Comments marked detached no longer match their quoted text",
     );
   });
+
+  it("matches quotes against markdown-formatted prose without false detachment", async () => {
+    const formatted = comment("formatted-quote", "human");
+    formatted.anchor = JSON.stringify({
+      anchorKind: "text",
+      textQuote: "Initialize npm project",
+      sectionTitle: "Steps",
+    });
+
+    loadPlanBundleMock.mockResolvedValueOnce({
+      plan: {
+        ...plan,
+        content: {
+          version: 2,
+          blocks: [
+            {
+              id: "block_1",
+              type: "rich-text" as const,
+              data: {
+                markdown:
+                  "## Steps\n\n**Initialize** [npm](https://npmjs.com) `project`\n\nRun the tests",
+              },
+            },
+          ],
+        },
+      },
+      sections: [section],
+      comments: [formatted],
+      events: [],
+      summary: {
+        sectionCounts: { summary: 1 },
+        commentCount: 1,
+        openCommentCount: 1,
+      },
+    });
+
+    const result = (await action.run({ planId: "plan_1" })) as {
+      comments: Array<{ id: string; detached: boolean }>;
+      feedbackSummary: { detachedCount: number };
+    };
+
+    expect(result.comments[0]?.detached).toBe(false);
+    expect(result.feedbackSummary.detachedCount).toBe(0);
+  });
+
+  it("never marks visual or point anchors detached even when their snippet is not in prose", async () => {
+    const visual = comment("visual-pin", "human");
+    visual.anchor = JSON.stringify({
+      anchorKind: "visual",
+      targetKind: "wireframe",
+      snippet: "Submit button label not present in prose",
+      visualX: 40,
+      visualY: 60,
+    });
+    const point = comment("point-pin", "human");
+    point.anchor = JSON.stringify({
+      anchorKind: "point",
+      snippet: "Some stray snippet",
+      x: 10,
+      y: 20,
+    });
+
+    loadPlanBundleMock.mockResolvedValueOnce({
+      plan: {
+        ...plan,
+        content: {
+          version: 2,
+          blocks: [
+            {
+              id: "block_1",
+              type: "rich-text" as const,
+              data: { markdown: "## Steps\n\nCompletely unrelated prose" },
+            },
+          ],
+        },
+      },
+      sections: [section],
+      comments: [visual, point],
+      events: [],
+      summary: {
+        sectionCounts: { summary: 1 },
+        commentCount: 2,
+        openCommentCount: 2,
+      },
+    });
+
+    const result = (await action.run({ planId: "plan_1" })) as {
+      comments: Array<{ id: string; detached: boolean }>;
+      feedbackSummary: { detachedCount: number };
+    };
+
+    expect(result.comments.every((c) => c.detached === false)).toBe(true);
+    expect(result.feedbackSummary.detachedCount).toBe(0);
+  });
 });

--- a/templates/plan/actions/get-plan-feedback.ts
+++ b/templates/plan/actions/get-plan-feedback.ts
@@ -19,9 +19,22 @@ function commentAnchorContext(anchor: PlanCommentAnchor | null) {
   return context && context !== "Pinned to plan" ? context : null;
 }
 
-/** Normalize whitespace the same way both sides of quote comparisons use. */
-function normalizeWhitespace(text: string): string {
-  return text.replace(/\s+/g, " ").trim();
+/**
+ * Normalize text for quote matching. Quotes are captured from rendered DOM
+ * text while block fragments are raw markdown, so inline markdown syntax
+ * (emphasis markers, code ticks, link wrappers) must be stripped before
+ * comparing. The same normalization is applied to both sides, so aggressive
+ * stripping stays symmetric and safe.
+ */
+function normalizeForQuoteMatch(text: string): string {
+  return text
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/[*_~`]/g, "")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^>\s?/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 /**
@@ -116,7 +129,7 @@ function quoteExistsInContent(
   sectionId: string | null | undefined,
 ): boolean {
   if (!content?.blocks?.length) return true; // can't determine — be conservative
-  const needle = normalizeWhitespace(quote);
+  const needle = normalizeForQuoteMatch(quote);
   if (!needle) return true;
 
   let blocks = content.blocks;
@@ -132,7 +145,7 @@ function quoteExistsInContent(
   for (const block of blocks) {
     const frags = blockTextFragments(block);
     for (const frag of frags) {
-      if (normalizeWhitespace(frag).includes(needle)) return true;
+      if (normalizeForQuoteMatch(frag).includes(needle)) return true;
     }
   }
   return false;
@@ -156,7 +169,13 @@ function withAgentAnchorContext<T extends PlanComment>(
   content?: PlanContent | null,
 ) {
   const anchor = commentAnchorForAgent(comment);
-  const quote = anchor?.textQuote || anchor?.snippet;
+  // Detach detection only applies to text anchors: visual/point anchors carry
+  // a snippet (button labels, section titles) that legitimately may not appear
+  // in prose blocks, so checking them would produce false positives.
+  const quote =
+    anchor?.anchorKind !== "visual" && anchor?.anchorKind !== "point"
+      ? anchor?.textQuote
+      : undefined;
   const detached =
     typeof quote === "string" && quote.length > 0 && content !== undefined
       ? !quoteExistsInContent(quote, content, anchor?.sectionId)

--- a/templates/plan/actions/get-plan-feedback.ts
+++ b/templates/plan/actions/get-plan-feedback.ts
@@ -7,11 +7,135 @@ import {
   planCommentAnchorDetails,
   type PlanCommentAnchor,
 } from "../shared/comment-context.js";
+import type { PlanBlock, PlanContent } from "../shared/plan-content.js";
 import type { PlanComment } from "../shared/types.js";
 
 function commentAnchorContext(anchor: PlanCommentAnchor | null) {
   const context = formatPlanCommentAnchorForAgent(anchor);
+  // Treat the generic fallback ("Pinned to plan" or enriched coordinate variants)
+  // as having no usable anchor context. Only a bare "Pinned to plan" exact match
+  // is filtered here; enriched strings like "Pinned at X%..." pass through as
+  // they carry real location info.
   return context && context !== "Pinned to plan" ? context : null;
+}
+
+/** Normalize whitespace the same way both sides of quote comparisons use. */
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Collect all searchable text strings from a single content block.
+ * Returns an array of normalized text fragments.
+ */
+function blockTextFragments(block: PlanBlock): string[] {
+  const frags: string[] = [];
+  switch (block.type) {
+    case "rich-text":
+      if (block.data.markdown) frags.push(block.data.markdown);
+      break;
+    case "callout":
+      if (block.data.body) frags.push(block.data.body);
+      break;
+    case "checklist":
+      for (const item of block.data.items) {
+        if (item.label) frags.push(item.label);
+        if (item.note) frags.push(item.note);
+      }
+      break;
+    case "table":
+      for (const row of block.data.rows) {
+        for (const cell of row) frags.push(cell);
+      }
+      for (const col of block.data.columns) frags.push(col);
+      break;
+    case "code":
+      if (block.data.code) frags.push(block.data.code);
+      if (block.data.caption) frags.push(block.data.caption);
+      break;
+    case "code-tabs":
+      for (const tab of block.data.tabs) {
+        frags.push(tab.label);
+        frags.push(tab.code);
+        if (tab.caption) frags.push(tab.caption);
+      }
+      break;
+    case "implementation-map":
+      for (const file of block.data.files) {
+        frags.push(file.path);
+        frags.push(file.note);
+        if (file.title) frags.push(file.title);
+        if (file.snippet) frags.push(file.snippet);
+      }
+      break;
+    case "tabs":
+      for (const tab of block.data.tabs) {
+        frags.push(tab.label);
+        for (const child of tab.blocks) {
+          frags.push(...blockTextFragments(child));
+        }
+      }
+      break;
+    case "columns":
+      for (const col of block.data.columns) {
+        if (col.label) frags.push(col.label);
+        for (const child of col.blocks) {
+          frags.push(...blockTextFragments(child));
+        }
+      }
+      break;
+    case "mermaid":
+      if (block.data.source) frags.push(block.data.source);
+      break;
+    case "diff":
+      frags.push(block.data.before, block.data.after);
+      break;
+    case "annotated-code":
+      frags.push(block.data.code);
+      for (const ann of block.data.annotations ?? []) frags.push(ann.note);
+      break;
+    default:
+      // Other block types (wireframe, diagram, image, etc.) have no prose to match.
+      break;
+  }
+  // Also include block-level title/summary
+  if (block.title) frags.push(block.title);
+  if (block.summary) frags.push(block.summary);
+  return frags.filter(Boolean);
+}
+
+/**
+ * Check whether a quoted snippet still exists in the plan content.
+ * Returns true when found, false when definitely gone.
+ * Scopes to a sectionId block when provided; searches all blocks when not.
+ * Returns true (not detached) for ambiguous cases to avoid false positives.
+ */
+function quoteExistsInContent(
+  quote: string,
+  content: PlanContent | null | undefined,
+  sectionId: string | null | undefined,
+): boolean {
+  if (!content?.blocks?.length) return true; // can't determine — be conservative
+  const needle = normalizeWhitespace(quote);
+  if (!needle) return true;
+
+  let blocks = content.blocks;
+  if (sectionId) {
+    const scoped = blocks.filter((b) => b.id === sectionId);
+    // If the sectionId didn't resolve to any block, fall back to all blocks to
+    // avoid marking the quote as detached when the section just changed id.
+    if (scoped.length > 0) {
+      blocks = scoped;
+    }
+  }
+
+  for (const block of blocks) {
+    const frags = blockTextFragments(block);
+    for (const frag of frags) {
+      if (normalizeWhitespace(frag).includes(needle)) return true;
+    }
+  }
+  return false;
 }
 
 function commentAnchorForAgent(comment: PlanComment) {
@@ -27,12 +151,21 @@ function commentAnchorForAgent(comment: PlanComment) {
   };
 }
 
-function withAgentAnchorContext<T extends PlanComment>(comment: T) {
+function withAgentAnchorContext<T extends PlanComment>(
+  comment: T,
+  content?: PlanContent | null,
+) {
   const anchor = commentAnchorForAgent(comment);
+  const quote = anchor?.textQuote || anchor?.snippet;
+  const detached =
+    typeof quote === "string" && quote.length > 0 && content !== undefined
+      ? !quoteExistsInContent(quote, content, anchor?.sectionId)
+      : false;
   return {
     ...comment,
     anchorContext: commentAnchorContext(anchor),
     anchorDetails: planCommentAnchorDetails(anchor),
+    detached,
   };
 }
 
@@ -63,10 +196,13 @@ function threadRootFor(comment: PlanComment, byId: Map<string, PlanComment>) {
 
 function buildFeedbackThreads(
   allComments: PlanComment[],
-  feedbackComments: PlanComment[],
+  feedbackComments: Array<PlanComment & { detached?: boolean }>,
 ) {
   const byId = new Map(allComments.map((comment) => [comment.id, comment]));
   const feedbackIds = new Set(feedbackComments.map((comment) => comment.id));
+  const detachedById = new Map(
+    feedbackComments.filter((c) => c.detached).map((c) => [c.id, true]),
+  );
   const threads = new Map<
     string,
     { root: PlanComment; comments: PlanComment[] }
@@ -94,6 +230,10 @@ function buildFeedbackThreads(
         comments.find((comment) => comment.id === thread.root.id) ??
         thread.root;
       const rootAnchor = commentAnchorForAgent(root);
+      // A thread is detached if the root comment's quoted text no longer exists
+      // in the current plan content. We use the pre-computed map from
+      // feedbackComments; roots not in the feedback set default to false.
+      const detached = detachedById.get(root.id) ?? false;
       return {
         id: root.id,
         root: withAgentAnchorContext(root),
@@ -107,6 +247,7 @@ function buildFeedbackThreads(
         commentCount: comments.length,
         anchorContext: commentAnchorContext(rootAnchor),
         anchorDetails: planCommentAnchorDetails(rootAnchor),
+        detached,
       };
     });
 }
@@ -227,6 +368,7 @@ function feedbackThreadManifest(
     ...thread,
     resolutionTarget: threadResolutionTarget(thread),
     isVisual: isVisualFeedbackThread(thread),
+    detached: thread.detached,
   };
 }
 
@@ -259,9 +401,10 @@ export default defineAction({
   },
   run: async (args) => {
     const bundle = await loadPlanBundle(args.planId);
+    const planContent = bundle.plan.content ?? null;
     const comments = bundle.comments
       .filter((comment) => comment.createdBy === "human" && !comment.consumedAt)
-      .map((comment) => withAgentAnchorContext(comment));
+      .map((comment) => withAgentAnchorContext(comment, planContent));
     const threads = buildFeedbackThreads(bundle.comments, comments).map(
       feedbackThreadManifest,
     );
@@ -274,6 +417,7 @@ export default defineAction({
         thread.status === "open" && thread.resolutionTarget === "human",
     );
     const visualThreads = threads.filter((thread) => thread.isVisual);
+    const detachedThreads = threads.filter((thread) => thread.detached);
     const feedbackImageBudget = 8;
     const overflowVisual = visualThreads
       .slice(feedbackImageBudget)
@@ -311,9 +455,15 @@ export default defineAction({
         actionableThreadCount: actionableThreads.length,
         humanReviewThreadCount: humanReviewThreads.length,
         visualThreadCount: visualThreads.length,
+        detachedCount: detachedThreads.length,
         feedbackImageBudget,
         overflowVisualCount: overflowVisual.length,
       },
+      detachedThreads: detachedThreads.map((thread) => ({
+        id: thread.id,
+        anchorContext: thread.anchorContext,
+        messageExcerpt: thread.root.message.slice(0, 120),
+      })),
       overflowVisual,
       recentReviewEvents,
       instructions: [
@@ -322,6 +472,11 @@ export default defineAction({
         "Focused screenshot attachments, when present in the chat, are ordered to match visual actionable feedback first. Each screenshot includes a red ring around the comment point.",
         "If overflowVisual is non-empty, some visual comments were not screenshotted because of the image budget; use their anchorDetails and ask for more visual context before making pixel-sensitive changes.",
         "Use recentReviewEvents to understand human edits made alongside comments; event payloads include targeted content patch metadata when available.",
+        ...(detachedThreads.length > 0
+          ? [
+              "Comments marked detached no longer match their quoted text (the prose was rewritten); reconcile them against the current content — do not silently drop them.",
+            ]
+          : []),
       ],
       summary: bundle.summary,
     };

--- a/templates/plan/app/components/plan/CanvasArea.tsx
+++ b/templates/plan/app/components/plan/CanvasArea.tsx
@@ -55,6 +55,8 @@ export type CanvasMarkupCreateContext = {
     visualY: number;
     canvasX: number;
     canvasY: number;
+    canvasWidth?: number;
+    canvasHeight?: number;
     markupType: "text" | "callout";
   };
 };
@@ -398,6 +400,8 @@ export function CanvasArea({
           visualY: y,
           canvasX: Math.round(point.x),
           canvasY: Math.round(point.y),
+          canvasWidth: Math.round(board.width),
+          canvasHeight: Math.round(board.height),
           markupType: mode,
         },
       };

--- a/templates/plan/app/components/plan/wireframe/kit/registry.tsx
+++ b/templates/plan/app/components/plan/wireframe/kit/registry.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, isValidElement, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import type {
   PlanWireframeElName,
   PlanWireframeNode,
@@ -202,13 +202,21 @@ export function renderNode(
     return children ? <div key={key}>{children}</div> : null;
   }
   let rendered = renderer(node, children);
-  // Inject stable node identity onto the root DOM element so UI click handlers
-  // can walk ancestors for wireframe comment anchoring.
-  if (node.id && isValidElement(rendered)) {
-    rendered = cloneElement(rendered, {
-      "data-wire-node-id": node.id,
-      "data-wire-node-el": node.el,
-    } as Record<string, string>);
+  // Wrap identified nodes in a layout-transparent element carrying stable node
+  // identity so UI click handlers can walk ancestors for wireframe comment
+  // anchoring. The kit primitives do not forward unknown props to the DOM, so
+  // a real wrapper element (display: contents keeps flex layout intact) is the
+  // only reliable way to land the data attributes.
+  if (node.id && rendered != null) {
+    rendered = (
+      <div
+        style={{ display: "contents" }}
+        data-wire-node-id={node.id}
+        data-wire-node-el={node.el}
+      >
+        {rendered}
+      </div>
+    );
   }
   // Attach a stable key by wrapping in a Fragment.
   return <KeyedNode key={key ?? node.id}>{rendered}</KeyedNode>;

--- a/templates/plan/app/components/plan/wireframe/kit/registry.tsx
+++ b/templates/plan/app/components/plan/wireframe/kit/registry.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { cloneElement, isValidElement, type ReactNode } from "react";
 import type {
   PlanWireframeElName,
   PlanWireframeNode,
@@ -201,7 +201,15 @@ export function renderNode(
     // not blank the whole frame.
     return children ? <div key={key}>{children}</div> : null;
   }
-  const rendered = renderer(node, children);
+  let rendered = renderer(node, children);
+  // Inject stable node identity onto the root DOM element so UI click handlers
+  // can walk ancestors for wireframe comment anchoring.
+  if (node.id && isValidElement(rendered)) {
+    rendered = cloneElement(rendered, {
+      "data-wire-node-id": node.id,
+      "data-wire-node-el": node.el,
+    } as Record<string, string>);
+  }
   // Attach a stable key by wrapping in a Fragment.
   return <KeyedNode key={key ?? node.id}>{rendered}</KeyedNode>;
 }

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -1346,6 +1346,45 @@ function buildNativeAnchorFromElement(input: {
             ? `Inside canvas frame ${frame.dataset.canvasFrame}`
             : undefined;
 
+  // Capture wireframe/design node identity from data attributes.
+  const wireNodeEl = target.closest<HTMLElement>("[data-wire-node-id]");
+  const targetNodeId =
+    wireNodeEl?.dataset.wireNodeId ||
+    target.closest<HTMLElement>("[data-design-id]")?.dataset.designId ||
+    target.closest<HTMLElement>("[data-plan-design-id]")?.dataset
+      .planDesignId ||
+    undefined;
+
+  // Build a short human-readable node path from the frame root down to the
+  // target node, e.g. `card > list > listItem "Acme Inc"`.
+  let targetNodePath: string | undefined;
+  if (wireNodeEl) {
+    const frameRoot =
+      anchorElement.closest<HTMLElement>("[data-canvas-frame]") ??
+      anchorElement.closest<HTMLElement>(".plan-artboard-frame");
+    if (frameRoot) {
+      const pathEls: HTMLElement[] = [];
+      let current: HTMLElement | null = wireNodeEl;
+      while (current && current !== frameRoot && frameRoot.contains(current)) {
+        if (current.dataset.wireNodeId) pathEls.unshift(current);
+        current = current.parentElement;
+      }
+      if (pathEls.length === 0) pathEls.push(wireNodeEl);
+      const segments = pathEls.map((el) => {
+        const elName = el.dataset.wireNodeEl ?? el.tagName.toLowerCase();
+        const directText = Array.from(el.childNodes)
+          .filter((n) => n.nodeType === Node.TEXT_NODE)
+          .map((n) => n.textContent ?? "")
+          .join("")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 40);
+        return directText ? `${elName} "${directText}"` : elName;
+      });
+      if (segments.length > 0) targetNodePath = segments.join(" > ");
+    }
+  }
+
   return {
     ...base,
     sectionId:
@@ -1376,6 +1415,8 @@ function buildNativeAnchorFromElement(input: {
     targetAlt: image?.alt?.trim() || undefined,
     targetSrc: image?.currentSrc || image?.src || undefined,
     visualContext,
+    ...(targetNodeId !== undefined ? { targetNodeId } : {}),
+    ...(targetNodePath !== undefined ? { targetNodePath } : {}),
   };
 }
 
@@ -1529,7 +1570,6 @@ function buildPlanAgentContext(input: {
       .slice(0, input.limit ?? 20)
       .map((thread, index) => {
         const commentNumber = (input.offset ?? 0) + index + 1;
-        const anchorContext = formatAnchorForAgent(thread.anchor);
         const anchorDetails = planCommentAnchorDetails(thread.anchor);
         const messages = thread.comments
           .map((comment, messageIndex) => {
@@ -1542,7 +1582,6 @@ function buildPlanAgentContext(input: {
         return [
           `${commentNumber}. Thread ${thread.id}`,
           messages,
-          anchorContext ? `   Context: ${anchorContext}` : "",
           ...anchorDetails.map((detail) => `   ${detail}`),
         ]
           .filter(Boolean)
@@ -1570,7 +1609,6 @@ function buildPlanAgentContext(input: {
     .filter((thread) => !actionableThreads.includes(thread))
     .slice(0, 4)
     .map((thread, index) => {
-      const anchorContext = formatAnchorForAgent(thread.anchor);
       const anchorDetails = planCommentAnchorDetails(thread.anchor);
       const messages = thread.comments
         .map((comment, messageIndex) => {
@@ -1583,7 +1621,6 @@ function buildPlanAgentContext(input: {
       return [
         `${index + 1}. Thread ${thread.id}`,
         messages,
-        anchorContext ? `   Context: ${anchorContext}` : "",
         ...anchorDetails.map((detail) => `   ${detail}`),
       ]
         .filter(Boolean)

--- a/templates/plan/server/lib/comment-feedback-adversarial.spec.ts
+++ b/templates/plan/server/lib/comment-feedback-adversarial.spec.ts
@@ -276,7 +276,7 @@ describe("get-plan-feedback aggregation", () => {
     loadPlanBundleMock.mockResolvedValueOnce(feedbackBundle([c]));
     const result = await getPlanFeedback.run({ planId: "plan_1" });
     expect(result.comments[0].anchorContext).toBe(
-      "Submit button at 73% across / 13% down",
+      "Submit button at 73% across / 13% down within the target",
     );
   });
 
@@ -294,7 +294,7 @@ describe("get-plan-feedback aggregation", () => {
     loadPlanBundleMock.mockResolvedValueOnce(feedbackBundle([c]));
     const result = await getPlanFeedback.run({ planId: "plan_1" });
     expect(result.comments[0].anchorContext).toBe(
-      "Login screen callout at canvas 121, 240",
+      "Login screen callout at canvas 121, 240 (board px)",
     );
   });
 
@@ -781,14 +781,16 @@ describe("get-plan-feedback anchor + deep thread edges", () => {
     expect(result.comments[0].anchorContext).toBe("Risks");
   });
 
-  it("returns null context for a point anchor with only x/y and no section/quote", async () => {
+  it("returns document coordinates for a point anchor with only x/y and no section/quote", async () => {
     const c = fbComment({
       id: "bare-point",
       anchor: JSON.stringify({ anchorKind: "point", x: 10, y: 20 }),
     });
     loadPlanBundleMock.mockResolvedValueOnce(feedbackBundle([c]));
     const result = await getPlanFeedback.run({ planId: "plan_1" });
-    expect(result.comments[0].anchorContext).toBeNull();
+    expect(result.comments[0].anchorContext).toBe(
+      "Pinned at 10% across / 20% down of the full plan document",
+    );
   });
 
   it("groups a 3-level deep thread under the top-most root", async () => {

--- a/templates/plan/shared/comment-context.spec.ts
+++ b/templates/plan/shared/comment-context.spec.ts
@@ -35,8 +35,86 @@ describe("plan comment context helpers", () => {
       'Target: kind=text, text="Update the run manager copy in the sidebar."',
       "Prototype screen: confirm",
       'Selector: [data-block-id="impl"] p:nth-of-type(2)',
-      "Target point: 18% across / 46% down",
+      "Target point: 18% across / 46% down within the text",
     ]);
+  });
+
+  it("formats a visual anchor with targetNodeId and targetNodePath", () => {
+    const anchor = parsePlanCommentAnchor(
+      JSON.stringify({
+        anchorKind: "visual",
+        targetKind: "wireframe",
+        visualX: 18,
+        visualY: 46,
+        targetNodeId: "node_abc123",
+        targetNodePath: 'card > list > listItem "Acme Inc"',
+        sectionTitle: "Dashboard",
+      }),
+    );
+
+    expect(formatPlanCommentAnchorForAgent(anchor)).toBe(
+      'Dashboard: card > list > listItem "Acme Inc" at 18% across / 46% down within the wireframe',
+    );
+    expect(planCommentAnchorDetails(anchor)).toEqual(
+      expect.arrayContaining([
+        'Wireframe node: id="node_abc123" (addressable by wireframe/design patch ops), path: card > list > listItem "Acme Inc"',
+      ]),
+    );
+  });
+
+  it("formats a canvas anchor with board dimensions", () => {
+    const anchor = parsePlanCommentAnchor(
+      JSON.stringify({
+        anchorKind: "visual",
+        markupType: "callout",
+        planAnnotationId: "ann_xyz",
+        visualLabel: "Login screen",
+        canvasX: 121,
+        canvasY: 240,
+        canvasWidth: 1600,
+        canvasHeight: 900,
+        x: 7,
+        y: 26,
+      }),
+    );
+
+    expect(formatPlanCommentAnchorForAgent(anchor)).toBe(
+      "Login screen callout at canvas 121, 240 of 1600 x 900 board px",
+    );
+    expect(planCommentAnchorDetails(anchor)).toEqual(
+      expect.arrayContaining([
+        "Canvas point: canvas 121, 240 of 1600 x 900 board px",
+      ]),
+    );
+  });
+
+  it("formats an enriched pinned fallback when x/y are present but anchorKind is not point", () => {
+    const anchor = parsePlanCommentAnchor(
+      JSON.stringify({
+        x: 12,
+        y: 40,
+      }),
+    );
+
+    expect(formatPlanCommentAnchorForAgent(anchor)).toBe(
+      "Pinned at 12% across / 40% down of the full plan document",
+    );
+  });
+
+  it("formats document coordinates for a bare point anchor", () => {
+    const anchor = parsePlanCommentAnchor(
+      JSON.stringify({ anchorKind: "point", x: 10, y: 20 }),
+    );
+
+    expect(formatPlanCommentAnchorForAgent(anchor)).toBe(
+      "Pinned at 10% across / 20% down of the full plan document",
+    );
+  });
+
+  it("returns Pinned to plan only for an anchor with no location at all", () => {
+    const anchor = parsePlanCommentAnchor(JSON.stringify({ ambiguous: false }));
+
+    expect(formatPlanCommentAnchorForAgent(anchor)).toBe("Pinned to plan");
   });
 
   it("serializes and extracts mention chips from readable comment text", () => {

--- a/templates/plan/shared/comment-context.ts
+++ b/templates/plan/shared/comment-context.ts
@@ -55,6 +55,14 @@ export type PlanCommentAnchor = {
   blockType?: string;
   ambiguous?: boolean;
   markerSeq?: number;
+  /** Stable wireframe/design node id (addressable by wireframe/design patch ops). */
+  targetNodeId?: string;
+  /** Human-readable path of ancestor wireframe nodes, e.g. `card > list > listItem "Acme Inc"`. */
+  targetNodePath?: string;
+  /** Board world width in px (for canvas comments). */
+  canvasWidth?: number;
+  /** Board world height in px (for canvas comments). */
+  canvasHeight?: number;
 };
 
 const mentionTokenPattern = /@\[([^\]]+)\]\(mailto:([^)]+)\)/g;
@@ -179,20 +187,37 @@ export function formatPlanCommentAnchorForAgent(
         : anchor.markupType === "text"
           ? "note"
           : "markup";
-    const canvasPoint =
-      anchor.canvasX !== undefined && anchor.canvasY !== undefined
-        ? ` at canvas ${Math.round(anchor.canvasX)}, ${Math.round(anchor.canvasY)}`
-        : "";
+    let canvasPoint = "";
+    if (anchor.canvasX !== undefined && anchor.canvasY !== undefined) {
+      const cx = Math.round(anchor.canvasX);
+      const cy = Math.round(anchor.canvasY);
+      canvasPoint =
+        anchor.canvasWidth !== undefined && anchor.canvasHeight !== undefined
+          ? ` at canvas ${cx}, ${cy} of ${Math.round(anchor.canvasWidth)} x ${Math.round(anchor.canvasHeight)} board px`
+          : ` at canvas ${cx}, ${cy} (board px)`;
+    }
     return `${prefix}${target || "canvas"} ${kind}${canvasPoint}`;
   }
 
   if (anchor.anchorKind === "visual") {
     const x = Math.round(anchor.visualX ?? anchor.targetX ?? anchor.x ?? 0);
     const y = Math.round(anchor.visualY ?? anchor.targetY ?? anchor.y ?? 0);
-    return `${prefix}${target || anchor.targetKind || "visual"} at ${x}% across / ${y}% down`;
+    const nodePart = anchor.targetNodePath
+      ? `${anchor.targetNodePath} `
+      : `${target || anchor.targetKind || "visual"} `;
+    const coordPart = `${x}% across / ${y}% down within the ${anchor.targetKind || "target"}`;
+    return `${prefix}${nodePart}at ${coordPart}`;
   }
 
-  return prefix ? prefix.replace(/: $/, "") : "Pinned to plan";
+  if (prefix) return prefix.replace(/: $/, "");
+
+  // Enriched pinned fallback: document-level coordinates are better than a
+  // bare "Pinned to plan" — they at least localize the pin on the page.
+  if (anchor.x !== undefined && anchor.y !== undefined) {
+    return `Pinned at ${Math.round(anchor.x)}% across / ${Math.round(anchor.y)}% down of the full plan document`;
+  }
+
+  return "Pinned to plan";
 }
 
 export function planCommentAnchorDetails(
@@ -226,15 +251,27 @@ export function planCommentAnchorDetails(
     lines.push(
       `Target point: ${Math.round(anchor.targetX)}% across / ${Math.round(
         anchor.targetY,
-      )}% down`,
+      )}% down within the ${anchor.targetKind || "target"}`,
     );
   }
   if (anchor.canvasX !== undefined && anchor.canvasY !== undefined) {
-    lines.push(
-      `Canvas point: ${Math.round(anchor.canvasX)}, ${Math.round(
-        anchor.canvasY,
-      )}`,
-    );
+    const cx = Math.round(anchor.canvasX);
+    const cy = Math.round(anchor.canvasY);
+    const canvasPointLine =
+      anchor.canvasWidth !== undefined && anchor.canvasHeight !== undefined
+        ? `Canvas point: canvas ${cx}, ${cy} of ${Math.round(anchor.canvasWidth)} x ${Math.round(anchor.canvasHeight)} board px`
+        : `Canvas point: canvas ${cx}, ${cy} (board px)`;
+    lines.push(canvasPointLine);
+  }
+  if (anchor.targetNodeId || anchor.targetNodePath) {
+    const idPart = anchor.targetNodeId
+      ? `id="${anchor.targetNodeId}" (addressable by wireframe/design patch ops)`
+      : "";
+    const pathPart = anchor.targetNodePath
+      ? `path: ${anchor.targetNodePath}`
+      : "";
+    const nodeLine = [idPart, pathPart].filter(Boolean).join(", ");
+    lines.push(`Wireframe node: ${nodeLine}`);
   }
   if (anchor.contextBefore) {
     lines.push(`Text before: "${clean(anchor.contextBefore)}"`);


### PR DESCRIPTION
## Summary

- **Wireframe node identity in comment anchors** — the wireframe kit renderer now emits `data-wire-node-id`/`data-wire-node-el` on each rendered node. Click-time anchoring captures `targetNodeId` plus a human-readable `targetNodePath` (e.g. `card > list > listItem "Acme Inc"`) so a pin resolves to the exact patch-addressable node. Also picks up `data-design-id` on design artboards for `update-design-element-style` ops.
- **Self-describing coordinates** — percent coords state which element they're relative to; canvas points include board pixel dimensions; bare document-level pins now emit `Pinned at X% across / Y% down of the full plan document` instead of the unactionable `"Pinned to plan"` string.
- **Detached-comment detection in `get-plan-feedback`** — threads whose quoted text no longer exists in the current plan content are flagged `detached`, surfaced in `detachedThreads`/`detachedCount`, and agents are instructed to reconcile rather than silently drop them.
- **Composer context de-dup** — the anchor location string was duplicated per thread in the send-to-agent context (`Context:` line + `Location:` line from anchorDetails); the redundant `Context:` line is removed.
- **Agent instruction sync** — new "Interpreting comment anchors" section in the triplicated `visual-plan` skill (coordinate frames, node-ID-first resolution, `ambiguous`⇒ask, `detached`⇒reconcile, `resolutionTarget`-only routing, consumed-vs-resolved two-axis state), pointer in `visual-recap`, and aligned `AGENTS.md`/`CLAUDE.md` bullet. Skills sync spec passes (7/7).

## Test plan

- [ ] 61/61 tests pass across `comment-context.spec.ts`, `get-plan-feedback.spec.ts`, `comment-feedback-adversarial.spec.ts`, `update-visual-plan-comment-flow.spec.ts`
- [ ] Skills sync spec passes (`packages/core/src/cli/skills.sync.spec.ts`, 7/7)
- [ ] Pin a comment on a wireframe in review mode → anchor in DB includes `targetNodeId` and `targetNodePath`
- [ ] `get-plan-feedback` on a plan with a comment whose quoted text has been deleted → thread appears in `detachedThreads`
- [ ] Agent receiving send-to-agent context no longer sees duplicate location line per thread

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6tJiKMSLGCQsHB1DrEApt)_