### PR TITLE
Fix recharts/es-toolkit default export error in dev

### DIFF
--- a/.changeset/hungry-mirrors-hide.md
+++ b/.changeset/hungry-mirrors-hide.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix recharts/es-toolkit default export error in dev

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -1492,17 +1492,6 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
       // serves stale code even after the source / dist is updated.
       exclude: [
         ...(findCoreSrcDir(cwd) !== null ? CORE_CLIENT_SUBPATHS : []),
-        // Vite 8's Rolldown dep optimizer can mis-bundle recharts' nested
-        // es-toolkit compat CJS (require_isUnsafeProperty is not a function),
-        // leaving the app stuck on the ClientOnly spinner after sign-in.
-        // Serve them as native ESM instead; workspaceNodeModulesAllow above
-        // lets pnpm-resolved transitive deps load in workspace apps.
-        // recharts is also a direct dep of @agent-native/core, so apps that
-        // depend on core transitively carry recharts even if they don't list
-        // it directly. Check both to cover the transitive case.
-        ...(hasDep("recharts", cwd) || hasDep("@agent-native/core", cwd)
-          ? ["recharts", "es-toolkit"]
-          : []),
         ...(options.optimizeDeps?.exclude ?? []),
       ],
     },


### PR DESCRIPTION
This PR will:
- fix the recharts/es-toolkit default export error in dev
- When opening some pages locally (e.g. a meeting page) the page would break with the following error:
```
 Uncaught SyntaxError: The requested module
  '/clips/@fs/.../es-toolkit@1.46.0/.../compat/get.js?v=...' does not provide an export named 'default' (at DataUtils.js:1:8)
```

How has this been tested:
- build the core cli locally using `pnpm --filter @agent-native/core build`
- created a template app using `AGENT_NATIVE_CREATE_USE_LOCAL_CORE=1 node /Users/milospetrovic/dev/agent-native/packages/core/dist/cli/index.js create pr-test --template starter`
- confirmed that the login/signup works, and that there is no infinity loader