### PR TITLE
Refresh CLI docs commands, RequireSession gate, service-token org fallback, calendar optimistic UI

### DIFF
--- a/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
+++ b/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-native-visual-plans",
-  "version": "1.0.0+codex.564f47b511e8",
+  "version": "1.0.0+codex.2a338e75e299",
   "description": "Generate and review coding-agent plans as structured documents with inline diagrams, annotated code walkthroughs, file trees, annotations, feedback, and HTML export.",
   "author": { "name": "Agent-Native", "url": "https://agent-native.com" },
   "homepage": "https://plan.agent-native.com",

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-plan/SKILL.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-plan/SKILL.md
@@ -89,7 +89,7 @@ inline output: the usual cause is a connector that did not finish connecting
 this session (it registers zero tools), not auth. Stop and give the user the
 exact restore step — reconnect via `/mcp` (or restart the session); only if
 genuinely unauthenticated, run
-`agent-native connect https://plan.agent-native.com`. Publish once the tool is
+`npx @agent-native/core@latest connect https://plan.agent-native.com`. Publish once the tool is
 reachable. Local-files privacy mode (after Tool Guidance) is the only
 exception.
 
@@ -282,7 +282,7 @@ The local-files contract is:
 - Write the plan as a local MDX folder under `plans/<slug>/`: `plan.mdx`,
   optional `canvas.mdx`, optional `prototype.mdx`, and optional
   `.plan-state.json`.
-- Run `agent-native plan local preview --dir plans/<slug> --kind plan` after
+- Run `npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind plan` after
   writing or updating the folder. Report the returned local URL or the
   `/local-plans/<slug>` route if the local Plan app is running with the same
   `PLAN_LOCAL_DIR`.
@@ -347,7 +347,7 @@ authenticates it in the same step (a one-time browser sign-in at setup — this 
 intended), so the first tool call does not hit an OAuth wall:
 
 ```bash
-agent-native skills add visual-plan
+npx @agent-native/core@latest skills add visual-plan
 ```
 
 After that, `/visual-plan` and `/visual-recap` are the two installed slash
@@ -355,7 +355,7 @@ commands. The other planning modes (`create-ui-plan`, `create-prototype-plan`,
 `create-plan-design`, `create-visual-questions`) are MCP tools reachable from
 `/visual-plan`, not separate slash commands. Pass `--no-connect` to register
 the connector without authenticating, then run
-`agent-native connect https://plan.agent-native.com` whenever you are ready.
+`npx @agent-native/core@latest connect https://plan.agent-native.com` whenever you are ready.
 
 **Browser (people you share with).** Open the Plans editor and create & edit
 with no sign-up — you work as a guest. Sign in only when you want to save or
@@ -370,7 +370,7 @@ hosted flow.
 
 If a Plans tool returns `needs auth`, `Unauthorized`, or `Session terminated`,
 do not keep retrying the tool. Authenticate the connector with
-`agent-native connect https://plan.agent-native.com` (OAuth-capable hosts can
+`npx @agent-native/core@latest connect https://plan.agent-native.com` (OAuth-capable hosts can
 instead re-run /mcp and choose Authenticate), then continue once the connector
 is available.
 

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-recap/SKILL.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-recap/SKILL.md
@@ -29,14 +29,14 @@ exception to the hosted publish rule below.
 In local-files mode:
 
 - Read the diff/stat/source context from local files and shell commands only.
-  The existing `agent-native recap collect-diff`, `scan`, and
+  The existing `npx @agent-native/core@latest recap collect-diff`, `scan`, and
   `build-prompt --local-files` helpers are safe to use because they operate on
   local files and do not write to the Plan database.
 - Write the recap as a local MDX folder under `plans/<slug>/`: `plan.mdx`,
   optional `canvas.mdx`, optional `prototype.mdx`, and optional
   `.plan-state.json`. Set `kind: "recap"` and `localOnly: true` in
   frontmatter/state when authoring the source.
-- Run `agent-native plan local preview --dir plans/<slug> --kind recap` after
+- Run `npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind recap` after
   writing or updating the folder. Report the returned local URL or the
   `/local-plans/<slug>` route if the local Plan app is running with the same
   `PLAN_LOCAL_DIR`.
@@ -74,7 +74,7 @@ connector that did not finish connecting this session (it registers zero tools),
 NOT necessarily an auth problem — so do not assume the user must authenticate.
 Stop and tell the user how to restore it: reconnect the Plan MCP connector (in
 Claude Code, run `/mcp` and reconnect, or restart the session); only if it is
-genuinely unauthenticated, run `agent-native connect <plan-app-url>` or
+genuinely unauthenticated, run `npx @agent-native/core@latest connect <plan-app-url>` or
 re-authenticate via `/mcp`. Then publish once the tool is reachable. Falling
 back to inline content is a defect, not a degraded mode.
 
@@ -251,7 +251,7 @@ a headless CI agent), state that in the recap handoff instead.
 ## Open And Report The Recap
 
 In local-files privacy mode, report the local preview URL/path from
-`agent-native plan local preview` or the `/local-plans/<slug>` route for a local
+`npx @agent-native/core@latest plan local preview` or the `/local-plans/<slug>` route for a local
 Plan app using the same `PLAN_LOCAL_DIR`. Do not invent a hosted URL and do not
 publish just to get an absolute Plan link.
 

--- a/.agents/skills/authentication/SKILL.md
+++ b/.agents/skills/authentication/SKILL.md
@@ -119,7 +119,42 @@ window.location.href =
 
 After successful sign-in (token / email-password / Google OAuth), the framework 302s to `return`. The path is validated as same-origin via the URL parser — open-redirect / header-injection inputs fall back to `/`.
 
-Bookmarked private paths already work without any plumbing — the framework's login page is served at the requested URL, and post-login reload returns the user there.
+Bookmarked private paths already work _when the request reaches the server_ — the auth guard serves the login page at the requested URL and post-login reload returns the user there.
+
+## Gating the App Shell (avoid the logged-out infinite spinner)
+
+The server auth guard only protects requests that actually reach the Nitro
+function. A statically-served / CDN-cached SPA shell, or a client-side (React
+Router) navigation made after the session expired, never re-hits the guard — so
+the app boots with **no session**, every data query 401s, and the UI sticks on
+its loading state forever. Server-side protection alone is not enough; gate on
+the client too.
+
+For a fully private app (every page requires auth, like mail), wrap the routed
+shell with the framework's `RequireSession`. It resolves the session on the
+client and redirects signed-out visitors to `/_agent-native/sign-in?return=…`
+instead of spinning:
+
+```tsx
+import { AppProviders, RequireSession } from "@agent-native/core/client";
+
+<AppProviders queryClient={queryClient}>
+  <RequireSession bypass={isMcpEmbedSurface()}>
+    <AppLayout>
+      <Outlet />
+    </AppLayout>
+  </RequireSession>
+</AppProviders>;
+```
+
+- Place it **inside** `AppProviders` (so the loading fallback is themed) and
+  **around** the layout/outlet — also around any always-mounted effects (poll,
+  automation trigger) so they don't fire 401s for logged-out visitors.
+- Pass `bypass` for surfaces that authenticate by another mechanism (embed /
+  popout iframes carrying their own token) so they are never bounced to sign-in.
+- Apps with public/anonymous routes (share pages) must **not** wrap the whole
+  app — gate only the private subtree, or use the `redirect={false}` +
+  `signedOut` props to render an inline call-to-action instead of redirecting.
 
 ## Related Skills
 

--- a/.changeset/mail-logged-out-spinner.md
+++ b/.changeset/mail-logged-out-spinner.md
@@ -1,0 +1,12 @@
+---
+"@agent-native/core": patch
+---
+
+Add a reusable `RequireSession` client gate that redirects unauthenticated
+visitors to the framework sign-in page instead of leaving a protected app shell
+stuck on an infinite loading spinner. The server-side auth guard only protects
+requests that reach the Nitro function; a statically-served/cached SPA shell or
+a client-side navigation after the session expired never re-hits it, so the app
+boots with no session and every data query 401s into a permanent loading state.
+Wrap a private app shell with `<RequireSession>` (with optional `bypass` for
+embed/popout surfaces that authenticate by another mechanism) to close that gap.

--- a/.changeset/service-token-org-fallback.md
+++ b/.changeset/service-token-org-fallback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Service token mint auto-resolves org from membership when bearer token has no org context

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Every template is a complete cloneable SaaS — fork it, customize it with the a
 ## Quick Start
 
 ```bash
-npx @agent-native/core create my-platform
+npx @agent-native/core@latest create my-platform
 cd my-platform
 pnpm install
 pnpm dev
@@ -211,7 +211,7 @@ The CLI shows a multi-select picker so you can include as many templates as you 
 Want a single app, no monorepo? Use `--standalone`:
 
 ```bash
-npx @agent-native/core create my-app --standalone --template mail
+npx @agent-native/core@latest create my-app --standalone --template mail
 ```
 
 ## Workspaces (Monorepo)
@@ -234,13 +234,13 @@ my-platform/
 Add another app later:
 
 ```bash
-npx @agent-native/core add-app notes --template content
+npx @agent-native/core@latest add-app notes --template content
 ```
 
 Deploy every app behind one origin:
 
 ```bash
-agent-native deploy
+npx @agent-native/core@latest deploy
 # https://your-agents.com/mail/*       → mail
 # https://your-agents.com/calendar/*   → calendar
 # https://your-agents.com/forms/*      → forms

--- a/packages/core/docs/content/agent-web-surfaces.md
+++ b/packages/core/docs/content/agent-web-surfaces.md
@@ -15,7 +15,7 @@ The docs site is the reference implementation. Today it ships:
 - Markdown mirrors such as `/docs/getting-started.md`.
 - `Accept: text/markdown` responses for public docs pages after a production build.
 - JSON-LD for base organization, website, and page metadata.
-- An audit CLI (`agent-native audit-agent-web`) that checks all of the above.
+- An audit CLI (`npx @agent-native/core@latest audit-agent-web`) that checks all of the above.
 
 Setting `publicMcp: true` additionally exposes opted-in actions as a public MCP endpoint, allowing external agents to call them directly (see [MCP Protocol](/docs/mcp-protocol)).
 
@@ -128,7 +128,7 @@ Vite apps can use `createAgentWebVitePlugin` from `@agent-native/core/vite` to w
 Use the CLI audit against a deployed site or a local production server:
 
 ```bash
-agent-native audit-agent-web --url https://www.agent-native.com
+npx @agent-native/core@latest audit-agent-web --url https://www.agent-native.com
 ```
 
 The audit checks for:

--- a/packages/core/docs/content/authentication.md
+++ b/packages/core/docs/content/authentication.md
@@ -130,7 +130,7 @@ Unauthenticated MCP requests return a `WWW-Authenticate` challenge pointing at `
 
 Access tokens are signed with `A2A_SECRET` when set, otherwise `BETTER_AUTH_SECRET`. They carry the signed user/org identity and the `mcp:read`, `mcp:write`, and/or `mcp:apps` scopes, and are audience-bound to the exact MCP resource URL. Refresh tokens are stored only as hashes and rotate on every refresh. Tool calls and MCP Apps resource reads run inside the same request context as the signed-in user; the embedded MCP App iframe never receives raw OAuth tokens.
 
-`agent-native connect <url> --client claude-code` writes the URL-only MCP entry for this standard flow. For clients that cannot perform remote MCP OAuth, use the Connect page or `agent-native connect --token <token>` fallback to write an explicit bearer-token entry.
+`npx @agent-native/core@latest connect <url> --client claude-code` writes the URL-only MCP entry for this standard flow. For clients that cannot perform remote MCP OAuth, use the Connect page or `npx @agent-native/core@latest connect --token <token>` fallback to write an explicit bearer-token entry.
 
 ## Bring Your Own Auth {#byoa}
 

--- a/packages/core/docs/content/cloneable-saas.md
+++ b/packages/core/docs/content/cloneable-saas.md
@@ -87,13 +87,13 @@ Not ready to scaffold? You can add agent-native superpowers to a coding agent yo
 If you're scaffolding now, the CLI command is:
 
 ```bash
-npx @agent-native/core create my-platform
+npx @agent-native/core@latest create my-platform
 ```
 
 You'll get a multi-select picker. Pick one app (standalone) or several (workspace — apps share auth, brand, agent config, and database). Each picked template is scaffolded into `apps/<name>/` with every file you need.
 
 Fill in `.env` (mostly `ANTHROPIC_API_KEY` and `DATABASE_URL`), `pnpm install`, `pnpm dev`, and it works. No "TODO: implement login," no placeholder routes.
 
-Deploy targets: any Nitro-compatible host (Node, Cloudflare, Netlify, Vercel, Deno, Lambda, Bun) and any Drizzle-compatible SQL database (SQLite, Postgres, Turso, D1, Supabase, Neon). For workspaces, `agent-native deploy` builds every app at once and ships them behind a single origin. See [Deployment](/docs/deployment).
+Deploy targets: any Nitro-compatible host (Node, Cloudflare, Netlify, Vercel, Deno, Lambda, Bun) and any Drizzle-compatible SQL database (SQLite, Postgres, Turso, D1, Supabase, Neon). For workspaces, `npx @agent-native/core@latest deploy` builds every app at once and ships them behind a single origin. See [Deployment](/docs/deployment).
 
 To author and publish your own template, see [Creating Templates](/docs/creating-templates).

--- a/packages/core/docs/content/code-agents-ui.md
+++ b/packages/core/docs/content/code-agents-ui.md
@@ -5,11 +5,11 @@ description: "Build and customize Agent-Native Code surfaces with the shared UI 
 
 # Agent-Native Code UI
 
-Agent-Native Code is the Agent-Native coding surface: a local Claude Code/Codex-style workspace for coding sessions, slash commands, migrations, audits, transcripts, run controls, and follow-ups. A bare `npx @agent-native/core@latest` or installed `agent-native` command opens this workspace; `agent-native code` is the explicit subcommand for the same experience.
+Agent-Native Code is the Agent-Native coding surface: a local Claude Code/Codex-style workspace for coding sessions, slash commands, migrations, audits, transcripts, run controls, and follow-ups. A bare `npx @agent-native/core@latest` command opens this workspace; `npx @agent-native/core@latest code` is the explicit subcommand for the same experience.
 
 There are three layers:
 
-- **CLI**: `npx @agent-native/core@latest`, `agent-native`, and `agent-native code` start, resume, inspect, and stop runs.
+- **CLI**: `npx @agent-native/core@latest` and `npx @agent-native/core@latest code` start, resume, inspect, and stop runs.
 - **Desktop**: the left-sidebar Code tab adds native terminal launch, app webviews, and desktop deep links while using the same run model.
 - **Shared UI**: `@agent-native/code-agents-ui` renders the reusable React surface.
 
@@ -95,19 +95,18 @@ The top-level CLI behaves like Claude Code or Codex:
 
 ```bash
 npx @agent-native/core@latest
-agent-native
-agent-native "fix the failing auth tests"
-agent-native code
+npx @agent-native/core@latest "fix the failing auth tests"
+npx @agent-native/core@latest code
 ```
 
-Use `agent-native code` when you want the explicit namespace. Built-in slash
+Use `npx @agent-native/core@latest code` when you want the explicit namespace. Built-in slash
 goals and project commands can run inside the interactive workspace or directly
 from the shell:
 
 ```bash
-agent-native code /migrate ./legacy-app --emit ./migration-dossier
-agent-native code /audit --url https://example.com
-agent-native code /release-check
+npx @agent-native/core@latest code /migrate ./legacy-app --emit ./migration-dossier
+npx @agent-native/core@latest code /audit --url https://example.com
+npx @agent-native/core@latest code /release-check
 ```
 
 Here `/migrate` and `/audit` are built-in goals (the built-in goals are
@@ -118,13 +117,13 @@ commands come from `.agents/commands/*.md`; project skills come from
 records that the Desktop Code tab and shared UI display:
 
 ```bash
-agent-native code list
-agent-native code status --last
-agent-native code attach --last
-agent-native code logs --last
-agent-native code resume --last
-agent-native code stop --last
-agent-native code ui
+npx @agent-native/core@latest code list
+npx @agent-native/core@latest code status --last
+npx @agent-native/core@latest code attach --last
+npx @agent-native/core@latest code logs --last
+npx @agent-native/core@latest code resume --last
+npx @agent-native/core@latest code stop --last
+npx @agent-native/core@latest code ui
 ```
 
 `resume` appends context and continues a run, `status` reports the latest run
@@ -267,7 +266,7 @@ Project skills live in:
 .agents/skills/*/SKILL.md
 ```
 
-When the host implements `listCodePacks`, the shared UI shows project commands and skills in the rail. Command rows insert `/<command>`, and skill rows insert a focused “Use the <skill> skill…” prompt so the rail stays actionable. The built-in slash goals `/migrate` and `/audit` stay reserved for the global Agent-Native Code controls, as do run-control names such as `status` and `resume` — those are subcommands invoked without a slash (`agent-native code status`, `agent-native code resume`), not slash goals.
+When the host implements `listCodePacks`, the shared UI shows project commands and skills in the rail. Command rows insert `/<command>`, and skill rows insert a focused “Use the <skill> skill…” prompt so the rail stays actionable. The built-in slash goals `/migrate` and `/audit` stay reserved for the global Agent-Native Code controls, as do run-control names such as `status` and `resume` — those are subcommands invoked without a slash (`npx @agent-native/core@latest code status`, `npx @agent-native/core@latest code resume`), not slash goals.
 
 Do not create a separate slash-command registry for a new Code host. Project
 commands and skills are discovered from `.agents/commands/*.md` and

--- a/packages/core/docs/content/creating-templates.md
+++ b/packages/core/docs/content/creating-templates.md
@@ -22,13 +22,13 @@ A good template:
 Use the CLI-only Starter scaffold when you want a blank app with the framework wiring already in place:
 
 ```bash
-pnpm dlx @agent-native/core create my-template --template starter --standalone
+npx @agent-native/core@latest create my-template --template starter --standalone
 ```
 
 For a workspace with multiple apps, run the picker and include Starter with any domain templates you want:
 
 ```bash
-pnpm dlx @agent-native/core create my-platform
+npx @agent-native/core@latest create my-platform
 ```
 
 Starter gives you auth, the agent sidebar, SQL-backed resources, tools, application state, actions, and polling sync. You add the domain model and product UI.
@@ -388,7 +388,7 @@ Before sharing:
 Community templates can be created from a GitHub repo:
 
 ```bash
-pnpm dlx @agent-native/core create my-app --template github:user/repo
+npx @agent-native/core@latest create my-app --template github:user/repo
 ```
 
 ## Contributing to the framework monorepo {#contributing}

--- a/packages/core/docs/content/deployment.md
+++ b/packages/core/docs/content/deployment.md
@@ -20,7 +20,7 @@ Use `DATABASE_AUTH_TOKEN` only when your database provider requires a separate t
 If your project is a [workspace](/docs/multi-app-workspace), you can ship every app in it to a single origin with one command:
 
 ```bash
-agent-native deploy
+npx @agent-native/core@latest deploy
 # https://your-agents.com/mail/*       → apps/mail
 # https://your-agents.com/calendar/*   → apps/calendar
 # https://your-agents.com/forms/*      → apps/forms
@@ -42,26 +42,26 @@ wrangler pages deploy dist
 For Netlify unified deploys, use the Netlify preset:
 
 ```bash
-agent-native deploy --preset netlify
+npx @agent-native/core@latest deploy --preset netlify
 ```
 
 For Vercel unified deploys, use the Vercel preset:
 
 ```bash
-agent-native deploy --preset vercel
+npx @agent-native/core@latest deploy --preset vercel
 ```
 
-When configuring a provider build command, use the same command with `--build-only`. Vercel should run `pnpm exec agent-native deploy --preset vercel --build-only`; the command writes `.vercel/output` directly, so no `vercel.json` is required for workspace routing.
+When configuring a provider build command, use the same command with `--build-only`. Vercel should run `npx @agent-native/core@latest deploy --preset vercel --build-only`; the command writes `.vercel/output` directly, so no `vercel.json` is required for workspace routing.
 
 Hosted workspace builds require `A2A_SECRET` in the deploy provider environment.
 This makes Slack, inbound webhooks, and cross-app A2A resume work through signed
 background processors. Local `--build-only` artifact checks still run without it.
 
-Per-app independent deploy is still supported — just `cd apps/<name> && agent-native build` like a standalone scaffold.
+Per-app independent deploy is still supported — just `cd apps/<name> && npx @agent-native/core@latest build` like a standalone scaffold.
 
 ## How It Works {#how-it-works}
 
-When you run `agent-native build`, Nitro builds both the client SPA and the server API into `.output/`:
+When you run `npx @agent-native/core@latest build`, Nitro builds both the client SPA and the server API into `.output/`:
 
 ```text
 .output/
@@ -90,7 +90,7 @@ export default defineConfig({
 Or use the `NITRO_PRESET` environment variable at build time:
 
 ```bash
-NITRO_PRESET=netlify agent-native build
+NITRO_PRESET=netlify npx @agent-native/core@latest build
 ```
 
 ## Node.js (Default) {#nodejs}
@@ -98,7 +98,7 @@ NITRO_PRESET=netlify agent-native build
 The default preset. Build and run:
 
 ```bash
-agent-native build
+npx @agent-native/core@latest build
 node .output/server/index.mjs
 ```
 
@@ -147,13 +147,13 @@ vercel deploy
 For a workspace, build every app into one Vercel Build Output API bundle:
 
 ```bash
-agent-native deploy --preset vercel
+npx @agent-native/core@latest deploy --preset vercel
 ```
 
 For Vercel Git deployments, set the build command to:
 
 ```bash
-pnpm exec agent-native deploy --preset vercel --build-only
+npx @agent-native/core@latest deploy --preset vercel --build-only
 ```
 
 The workspace build copies each app's Nitro `vercel` output into the root `.vercel/output`, gives each function its own mount-path environment, and writes the route config that serves apps at `/<app-id>`.
@@ -174,7 +174,7 @@ export default defineConfig({
 For a workspace, deploy every app from one Netlify site by running:
 
 ```bash
-agent-native deploy --preset netlify
+npx @agent-native/core@latest deploy --preset netlify
 ```
 
 The workspace build writes static assets under `dist/_workspace_static/` and routes each app to its own Netlify function without forced asset redirects, so files like `/mail/assets/...` are served statically before the server function handles app routes.
@@ -210,13 +210,13 @@ export default defineConfig({
 
 ### Build / Runtime {#env-runtime}
 
-| Variable              | Description                                                                                                                          |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `PORT`                | Server port (Node.js only)                                                                                                           |
-| `NITRO_PRESET`        | Override build preset at build time                                                                                                  |
-| `APP_BASE_PATH`       | Mount the app under a prefix (e.g. `/mail`). Set automatically by `agent-native deploy`; leave unset for standalone.                 |
-| `DATABASE_URL`        | Persistent SQL connection string. Required in production. See [Database](/docs/database#production) for adapter and dialect details. |
-| `DATABASE_AUTH_TOKEN` | Auth token for providers that require a separate token, such as Turso/libSQL.                                                        |
+| Variable              | Description                                                                                                                           |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                | Server port (Node.js only)                                                                                                            |
+| `NITRO_PRESET`        | Override build preset at build time                                                                                                   |
+| `APP_BASE_PATH`       | Mount the app under a prefix (e.g. `/mail`). Set automatically by `npx @agent-native/core@latest deploy`; leave unset for standalone. |
+| `DATABASE_URL`        | Persistent SQL connection string. Required in production. See [Database](/docs/database#production) for adapter and dialect details.  |
+| `DATABASE_AUTH_TOKEN` | Auth token for providers that require a separate token, such as Turso/libSQL.                                                         |
 
 ### Required in Production {#env-required-prod}
 

--- a/packages/core/docs/content/dispatch.md
+++ b/packages/core/docs/content/dispatch.md
@@ -115,9 +115,9 @@ The whole pipeline is built to survive on every serverless host (Netlify, Vercel
 
 Three short steps:
 
-1. **Scaffold a workspace that includes Dispatch.** Run `pnpm dlx @agent-native/core create my-company-platform` and pick `dispatch` alongside whatever domain templates you want. Dispatch lives at `apps/dispatch` and the rest of the apps sit beside it. See [Multi-App Workspace](/docs/multi-app-workspace).
+1. **Scaffold a workspace that includes Dispatch.** Run `npx @agent-native/core@latest create my-company-platform` and pick `dispatch` alongside whatever domain templates you want. Dispatch lives at `apps/dispatch` and the rest of the apps sit beside it. See [Multi-App Workspace](/docs/multi-app-workspace).
 2. **Connect messaging.** Open **Settings → Messaging** in Dispatch and click connect for Slack, Email, Telegram, or WhatsApp. The form fields match the env vars in the [Messaging](/docs/messaging) doc — refer there for what each platform needs.
-3. **Add other apps.** Run `npx @agent-native/core add-app` from the workspace root for each domain app. They auto-appear as A2A peers in Dispatch's `list-workspace-apps` — no manual registration, no agent-card editing. Dispatch will start delegating to them as soon as their agent cards are reachable.
+3. **Add other apps.** Run `npx @agent-native/core@latest add-app` from the workspace root for each domain app. They auto-appear as A2A peers in Dispatch's `list-workspace-apps` — no manual registration, no agent-card editing. Dispatch will start delegating to them as soon as their agent cards are reachable.
 
 Then add credentials to the vault and (optionally) author global workspace resources under **Resources**. Vault keys can still be synced or granted depending on access mode; All-app workspace resources are inherited automatically. If you need per-app secret isolation, switch the vault access setting to manual before granting individual apps.
 

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -85,16 +85,10 @@ In hosts that support MCP Apps, Analytics can render real dashboard and analysis
 
 Use this flow for local agent clients on your machine — Claude Code, Claude Code CLI, Codex, and Claude Cowork. (Cursor uses the paste-URL flow above; it does not need this CLI path.)
 
-If you have the Agent-Native CLI installed, run:
+Run the connect command through npm:
 
 ```bash
-agent-native connect https://dispatch.agent-native.com
-```
-
-Or run the same command through npm without installing anything globally:
-
-```bash
-npx @agent-native/core connect https://dispatch.agent-native.com
+npx @agent-native/core@latest connect https://dispatch.agent-native.com
 ```
 
 The command asks which local agent clients should receive MCP config. All clients are preselected the first time; after you choose, the selection is saved to `~/.agent-native/connect.json` so the next run can reuse it with Enter, or you can edit the checked items.
@@ -105,7 +99,7 @@ Keep the `connect` command running until the browser approval completes. If the
 waiting process is stopped early, the approval can succeed in the browser but
 the local client config will not receive the token.
 
-If you previously connected Claude Code through the old bearer-token flow, just run the same `agent-native connect ... --client claude-code` command again. The CLI replaces the legacy `Authorization` headers with the URL-only OAuth entry and tells you to re-authenticate from `/mcp`.
+If you previously connected Claude Code through the old bearer-token flow, just run the same `npx @agent-native/core@latest connect ... --client claude-code` command again. The CLI replaces the legacy `Authorization` headers with the URL-only OAuth entry and tells you to re-authenticate from `/mcp`.
 
 | Local client                  | Config written by `connect`                             | Auth flow                                       |
 | ----------------------------- | ------------------------------------------------------- | ----------------------------------------------- |
@@ -136,8 +130,7 @@ npx skills add BuilderIO/agent-native --skill assets
 ```
 
 The raw `skills` CLI installs `SKILL.md` files only; local MCP clients still
-need a connector such as `npx @agent-native/core@latest connect
-https://assets.agent-native.com`.
+need a connector such as `npx @agent-native/core@latest connect https://assets.agent-native.com`.
 
 | Skill    | Alias              | For                    |
 | -------- | ------------------ | ---------------------- |
@@ -149,7 +142,7 @@ When you truly need an isolated app instead of Dispatch's workspace gateway,
 run the same command with that app's host:
 
 ```bash
-npx @agent-native/core connect https://mail.agent-native.com
+npx @agent-native/core@latest connect https://mail.agent-native.com
 ```
 
 `connect --all` still exists for legacy per-app client setups, but new
@@ -187,7 +180,7 @@ claude mcp add --transport http agent-native \
   https://dispatch.agent-native.com/_agent-native/mcp
 ```
 
-This is the same URL-only entry that `agent-native connect https://dispatch.agent-native.com --client claude-code` writes for you. Then run `/mcp` in Claude Code and choose **Authenticate**. The client discovers auth from the MCP server's `401 WWW-Authenticate` challenge, fetches `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`, dynamically registers a public OAuth client, opens the app's authorization page, and stores the resulting token securely. ChatGPT developer-mode connectors use the same server URL:
+This is the same URL-only entry that `npx @agent-native/core@latest connect https://dispatch.agent-native.com --client claude-code` writes for you. Then run `/mcp` in Claude Code and choose **Authenticate**. The client discovers auth from the MCP server's `401 WWW-Authenticate` challenge, fetches `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`, dynamically registers a public OAuth client, opens the app's authorization page, and stores the resulting token securely. ChatGPT developer-mode connectors use the same server URL:
 
 ```text
 https://dispatch.agent-native.com/_agent-native/mcp
@@ -203,7 +196,7 @@ Current scopes are:
 | `mcp:write` | mutating actions and the `ask-agent` meta-tool                            |
 | `mcp:apps`  | MCP Apps resource listing/reading and inline UI rendering where supported |
 
-When the client requests no explicit scope, the app grants all three so the connector behaves like the browser-authorized Connect flow. Keep the bearer-token Connect page and `agent-native connect --token <token>` fallback around for local dev, fallback hosts, and clients where you need a ready-to-paste config block.
+When the client requests no explicit scope, the app grants all three so the connector behaves like the browser-authorized Connect flow. Keep the bearer-token Connect page and `npx @agent-native/core@latest connect --token <token>` fallback around for local dev, fallback hosts, and clients where you need a ready-to-paste config block.
 
 ## Catalog tiers {#catalog-tiers}
 
@@ -233,7 +226,7 @@ always serve the full action surface. When the env flag is set, individual
 callers can still opt up by minting their token with `--full-catalog`:
 
 ```bash
-agent-native connect https://plan.agent-native.com --full-catalog
+npx @agent-native/core@latest connect https://plan.agent-native.com --full-catalog
 ```
 
 This embeds a `catalog_scope: "full"` claim in the minted JWT. On subsequent
@@ -453,10 +446,10 @@ The hosted `connect` flow above is the recommended path. The options below are f
 
 ### Local development {#local-dev}
 
-Run your app locally (`pnpm dev` / `agent-native dev`), then point a local agent at it with one command:
+Run your app locally (`pnpm dev` / `npx @agent-native/core@latest dev`), then point a local agent at it with one command:
 
 ```bash
-agent-native mcp install --client claude-code|claude-code-cli|codex|cowork \
+npx @agent-native/core@latest mcp install --client claude-code|claude-code-cli|codex|cowork \
   [--app <id>] [--scope user|project]
 ```
 
@@ -466,17 +459,17 @@ It provisions a token (a random `ACCESS_TOKEN` into the workspace `.env` for loc
 - **cowork** — the same Claude Code JSON shape in `~/.cowork/mcp.json`.
 - **codex** — an `[mcp_servers.<name>]` block in `~/.codex/config.toml`.
 
-The entry runs `agent-native mcp serve --app <id>`, which by default is a **thin stdio proxy** to the running local app's `/_agent-native/mcp` — so the live action registry, HMR, and correct deep links stay the single source of truth. Pass `--standalone` to build the registry in-process instead. When `agent-native mcp install` detects a hosted origin (a non-localhost `APP_URL` / `BETTER_AUTH_URL` / `AGENT_NATIVE_MCP_URL` in the workspace `.env`), it writes an `http` client entry pointing at `<origin>/_agent-native/mcp` with a `Bearer` JWT instead of a stdio entry.
+The entry runs `npx @agent-native/core@latest mcp serve --app <id>`, which by default is a **thin stdio proxy** to the running local app's `/_agent-native/mcp` — so the live action registry, HMR, and correct deep links stay the single source of truth. Pass `--standalone` to build the registry in-process instead. When `npx @agent-native/core@latest mcp install` detects a hosted origin (a non-localhost `APP_URL` / `BETTER_AUTH_URL` / `AGENT_NATIVE_MCP_URL` in the workspace `.env`), it writes an `http` client entry pointing at `<origin>/_agent-native/mcp` with a `Bearer` JWT instead of a stdio entry.
 
 Companion subcommands:
 
-| Command                                   | What it does                                                        |
-| ----------------------------------------- | ------------------------------------------------------------------- |
-| `agent-native mcp serve [--app <id>]`     | Run the MCP stdio transport (what client configs spawn).            |
-| `agent-native mcp install --client <c>`   | Provision a token + write the client's MCP config (idempotent).     |
-| `agent-native mcp uninstall --client <c>` | Remove the named MCP entry from a client's config (idempotent).     |
-| `agent-native mcp status`                 | Show resolved MCP URL/port, token state, and per-client entries.    |
-| `agent-native mcp token [--rotate]`       | Print (or rotate) the local `ACCESS_TOKEN` in the workspace `.env`. |
+| Command                                                    | What it does                                                        |
+| ---------------------------------------------------------- | ------------------------------------------------------------------- |
+| `npx @agent-native/core@latest mcp serve [--app <id>]`     | Run the MCP stdio transport (what client configs spawn).            |
+| `npx @agent-native/core@latest mcp install --client <c>`   | Provision a token + write the client's MCP config (idempotent).     |
+| `npx @agent-native/core@latest mcp uninstall --client <c>` | Remove the named MCP entry from a client's config (idempotent).     |
+| `npx @agent-native/core@latest mcp status`                 | Show resolved MCP URL/port, token state, and per-client entries.    |
+| `npx @agent-native/core@latest mcp token [--rotate]`       | Print (or rotate) the local `ACCESS_TOKEN` in the workspace `.env`. |
 
 Restart the client after `install` so it picks up the new MCP server.
 
@@ -510,7 +503,7 @@ When you already have first-party hosted apps connected and want to test local f
 ```bash
 pnpm dev:lazy -- --apps mail,calendar,analytics
 
-agent-native connect dev --apps mail,calendar,analytics --client codex
+npx @agent-native/core@latest connect dev --apps mail,calendar,analytics --client codex
 ```
 
 `connect dev` rewrites the same stable MCP server names (`agent-native-mail`, `agent-native-calendar`, etc.) to the local dev-lazy gateway, so tool names do not change. It backs up the current production entries in `~/.agent-native/connect-profiles.json` before writing dev entries. The default gateway is `http://127.0.0.1:8080`; use `--gateway <url>` or `--port <n>` if your gateway moved.
@@ -518,7 +511,7 @@ agent-native connect dev --apps mail,calendar,analytics --client codex
 Switch back with:
 
 ```bash
-agent-native connect prod --apps mail,calendar,analytics --client codex
+npx @agent-native/core@latest connect prod --apps mail,calendar,analytics --client codex
 ```
 
 If `connect dev` cannot infer your local owner identity from an existing connected JWT, pass `--owner-email you@example.com`; this keeps local dev tools on the full authenticated MCP surface instead of the sparse unauthenticated dev surface.
@@ -540,7 +533,7 @@ The fallback hosted `connect` flow never copies the deployment's shared secret. 
 
 **Do**
 
-- Connect your own agent to Dispatch with `npx @agent-native/core connect https://dispatch.agent-native.com`; use a direct app URL only when you want one isolated app.
+- Connect your own agent to Dispatch with `npx @agent-native/core@latest connect https://dispatch.agent-native.com`; use a direct app URL only when you want one isolated app.
 - Add a `link` builder to any action that produces or lists a navigable resource (draft, event, dashboard, document).
 - Build the URL with `buildDeepLink(...)` — the single source of truth for the open-route format.
 - Keep `link` pure and synchronous; return `null` when there's nothing to open.

--- a/packages/core/docs/content/faq.md
+++ b/packages/core/docs/content/faq.md
@@ -66,7 +66,7 @@ That's the whole point. Fork a template and customize it by asking the agent. "A
 
 ### Can I build something the templates don't cover? {#build-from-scratch}
 
-Yes. Run `npx @agent-native/core create my-app` and accept the default **Starter** selection in the picker (or pass `--template starter`) — you get the framework scaffolding (frontend, backend, agent panel, database) but no domain-specific code. See [Getting Started](/docs/getting-started). For agent-first products with no traditional UI, see [Pure-Agent Apps](/docs/pure-agent-apps).
+Yes. Run `npx @agent-native/core@latest create my-app` and accept the default **Starter** selection in the picker (or pass `--template starter`) — you get the framework scaffolding (frontend, backend, agent panel, database) but no domain-specific code. See [Getting Started](/docs/getting-started). For agent-first products with no traditional UI, see [Pure-Agent Apps](/docs/pure-agent-apps).
 
 ### Can I try it without forking a template? {#try-with-a-skill}
 

--- a/packages/core/docs/content/frames.md
+++ b/packages/core/docs/content/frames.md
@@ -122,7 +122,7 @@ The embedded agent panel is part of every app — scaffold a template and it's
 already there:
 
 ```bash
-pnpm dlx @agent-native/core create my-app --template mail --standalone
+npx @agent-native/core@latest create my-app --template mail --standalone
 cd my-app
 pnpm dev
 ```

--- a/packages/core/docs/content/getting-started.md
+++ b/packages/core/docs/content/getting-started.md
@@ -22,7 +22,7 @@ Not sure which path? If you've never written code, the hosted version is for you
 Three commands and you're up:
 
 ```bash
-npx @agent-native/core create my-platform
+npx @agent-native/core@latest create my-platform
 cd my-platform
 pnpm install && pnpm dev
 ```
@@ -73,14 +73,14 @@ Run `create` from the folder where you want a brand-new workspace:
 
 ```bash
 cd ~/projects
-npx @agent-native/core create my-platform
+npx @agent-native/core@latest create my-platform
 ```
 
 After a workspace exists, run app commands from the workspace root:
 
 ```bash
 cd my-platform
-npx @agent-native/core add-app
+npx @agent-native/core@latest add-app
 pnpm install
 pnpm dev
 ```
@@ -90,7 +90,7 @@ If your terminal is inside `apps/content` or another app folder, the CLI still d
 To make a second app from the same template, give it a new app name:
 
 ```bash
-npx @agent-native/core add-app design-lab --template design
+npx @agent-native/core@latest add-app design-lab --template design
 ```
 
 ## Try it with a skill {#try-with-a-skill}
@@ -136,10 +136,10 @@ Good first moves:
 - **Open Agent-Native Code** — run `npx @agent-native/core@latest` or `npx @agent-native/core@latest code` from the project. A bare command opens the local Claude Code/Codex-like workspace; a bare prompt such as `npx @agent-native/core@latest "rename the app"` starts a Code task directly.
 - **Ask the built-in agent what it sees** — open the agent panel and type "what app am I looking at, and what can you do here?" This verifies the app, UI state, and agent loop are all talking to each other.
 - **Make a tiny customization** — ask your coding tool to rename the app, change the first screen copy, or add one field to a form. It will read `AGENTS.md` for the framework conventions.
-- **Add another app to the same workspace** — use `npx @agent-native/core add-app` from inside the workspace folder. The command starts at `npx`.
-- **Single app instead of a monorepo?** Pass `--standalone` when creating: `npx @agent-native/core create my-app --standalone --template mail`.
+- **Add another app to the same workspace** — use `npx @agent-native/core@latest add-app` from inside the workspace folder. The command starts at `npx`.
+- **Single app instead of a monorepo?** Pass `--standalone` when creating: `npx @agent-native/core@latest create my-app --standalone --template mail`.
 
-Agent-Native Code understands built-in slash goals such as `/migrate` and `/audit`, plus project commands in `.agents/commands/*.md`. Use `agent-native code list`, `status`, `resume`, `stop`, or `ui` to inspect and control the same run from the CLI, the local UI, or the Desktop Code tab.
+Agent-Native Code understands built-in slash goals such as `/migrate` and `/audit`, plus project commands in `.agents/commands/*.md`. Use `npx @agent-native/core@latest code list`, `status`, `resume`, `stop`, or `ui` to inspect and control the same run from the CLI, the local UI, or the Desktop Code tab.
 
 ## Architecture principles {#architecture-principles}
 

--- a/packages/core/docs/content/mcp-apps.md
+++ b/packages/core/docs/content/mcp-apps.md
@@ -63,7 +63,7 @@ The resource shell owns the outer host size. `embedApp({ height })` defaults to 
 
 Claude uses the single-frame transplant path by default. You can also force it in other hosts with `embedMode: "transplant"` or `frame: "transplant"` when debugging host module-loading behavior. You can force the nested diagnostic iframe with `embedMode: "iframe"`, `renderMode: "iframe"`, `nested: true`, or `frame: "iframe"`. If the iframe is blocked, `embedApp()` replaces it with an open-app fallback: the user can retry inline, open a freshly minted embed session through the host, or use the visible route URL. Keep the action's `link` target useful on its own because it is still the universal escape hatch.
 
-When testing Claude through ngrok, use a production build (`agent-native build` then `agent-native start`) or a deployed preview/production URL. Claude's single-frame transplant path works with production asset chunks; raw Vite dev modules such as `/app/root.tsx` can be protected by app auth and fail dynamic imports from the Claude resource origin.
+When testing Claude through ngrok, use a production build (`npx @agent-native/core@latest build` then `npx @agent-native/core@latest start`) or a deployed preview/production URL. Claude's single-frame transplant path works with production asset chunks; raw Vite dev modules such as `/app/root.tsx` can be protected by app auth and fail dynamic imports from the Claude resource origin.
 
 ## Host bridge API {#host-bridge}
 

--- a/packages/core/docs/content/mcp-protocol.md
+++ b/packages/core/docs/content/mcp-protocol.md
@@ -149,7 +149,7 @@ The MCP endpoint supports standard remote MCP OAuth plus the existing bearer-tok
 | Mode                        | How it works                                                                                                          |
 | --------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | Standard MCP OAuth          | Client discovers auth from `WWW-Authenticate`, registers, runs PKCE, and sends `Authorization: Bearer <access-token>` |
-| Connect-minted JWT          | `agent-native connect` / the Connect page mints a per-user, revocable JWT                                             |
+| Connect-minted JWT          | `npx @agent-native/core@latest connect` / the Connect page mints a per-user, revocable JWT                            |
 | `ACCESS_TOKEN`              | Static bearer token — client sends `Authorization: Bearer <token>`                                                    |
 | `ACCESS_TOKENS`             | Comma-separated list of valid static bearer tokens                                                                    |
 | `A2A_SECRET`                | JWT-based auth — tokens are verified cryptographically                                                                |
@@ -186,7 +186,7 @@ Access tokens are signed JWTs whose audience is the exact MCP resource URL. The 
 | `mcp:write` | mutating actions and `ask-agent`            |
 | `mcp:apps`  | MCP Apps resources (`ui://` HTML resources) |
 
-Refresh tokens are stored only as hashes and are rotated on every refresh. `agent-native connect` writes this URL-only OAuth entry for Claude Code clients by default; keep the Connect page, `agent-native connect --token <token>`, and static bearer config for local stdio proxying, older clients, and emergency/debug flows.
+Refresh tokens are stored only as hashes and are rotated on every refresh. `npx @agent-native/core@latest connect` writes this URL-only OAuth entry for Claude Code clients by default; keep the Connect page, `npx @agent-native/core@latest connect --token <token>`, and static bearer config for local stdio proxying, older clients, and emergency/debug flows.
 
 ## Custom MCP setup {#custom-setup}
 

--- a/packages/core/docs/content/migration-workbench.md
+++ b/packages/core/docs/content/migration-workbench.md
@@ -16,7 +16,7 @@ npx @agent-native/core@latest code attach --last
 npx @agent-native/core@latest code /migrate ./my-next-app --out ../migrated-app
 ```
 
-**Agent-Native Code** is the open-source Claude Code/Codex-like workspace for coding work in Agent-Native. `agent-native` or `agent-native code` launches it with no prompt required, and a bare prompt starts a generic coding task directly. `/migrate` is one built-in capability for moving an existing app, URL, or described product into agent-native. It uses the same session store, transcript, and desktop hub as the CLI `code` command, so migration behaves like a goal you can resume, attach to, inspect, and stop rather than a separate one-off product.
+**Agent-Native Code** is the open-source Claude Code/Codex-like workspace for coding work in Agent-Native. `npx @agent-native/core@latest` or `npx @agent-native/core@latest code` launches it with no prompt required, and a bare prompt starts a generic coding task directly. `/migrate` is one built-in capability for moving an existing app, URL, or described product into agent-native. It uses the same session store, transcript, and desktop hub as the CLI `code` command, so migration behaves like a goal you can resume, attach to, inspect, and stop rather than a separate one-off product.
 
 See [Agent-Native Code UI](/docs/code-agents-ui) for the shared CLI run controls (`list`/`attach`/`logs`/`resume`/`status`/`stop`/`ui`) and the file-backed, long-running background-run model that `/migrate` sessions use.
 
@@ -35,7 +35,7 @@ full run-control command set).
 
 ## Code Workspace
 
-`agent-native code` opens the interactive Agent-Native Code shell. Inside the shell, `/migrate` is a slash goal alongside `/audit` and other built-in commands. Projects can also define custom migration variants in `.agents/commands/*.md`. The CLI and Desktop hub share the same run store — start in one and continue in the other using the standard `list`/`attach`/`logs`/`resume`/`approve`/`stop` controls.
+`npx @agent-native/core@latest code` opens the interactive Agent-Native Code shell. Inside the shell, `/migrate` is a slash goal alongside `/audit` and other built-in commands. Projects can also define custom migration variants in `.agents/commands/*.md`. The CLI and Desktop hub share the same run store — start in one and continue in the other using the standard `list`/`attach`/`logs`/`resume`/`approve`/`stop` controls.
 
 See [Agent-Native Code UI](/docs/code-agents-ui) for the full shell, run controls, Plan/Auto modes, slash-goal discovery, and Desktop hub integration.
 

--- a/packages/core/docs/content/multi-app-workspace.md
+++ b/packages/core/docs/content/multi-app-workspace.md
@@ -38,7 +38,7 @@ That same boundary applies when your app wants to use another first-party app. A
 Workspace is the default shape of an agent-native project. Scaffold one with:
 
 ```bash
-pnpm dlx @agent-native/core create my-company-platform
+npx @agent-native/core@latest create my-company-platform
 ```
 
 The CLI shows a multi-select picker of every first-party template. Pick as many as you want — Mail + Calendar + Forms, for example — and they all get scaffolded into the same workspace sharing auth and database defaults.
@@ -88,13 +88,13 @@ Every app already knows how to log in, share the same database, and load the wor
 From anywhere inside the workspace:
 
 ```bash
-npx @agent-native/core add-app
+npx @agent-native/core@latest add-app
 ```
 
 The CLI shows the template picker again with apps you've already installed filtered out. Pick one or more and they get scaffolded under `apps/`. Non-interactive variant:
 
 ```bash
-npx @agent-native/core add-app crm --template content
+npx @agent-native/core@latest add-app crm --template content
 ```
 
 Any first-party template works as a workspace app — the CLI runs a small **workspacify** transform on the template that adds the shared package as a dep and resolves `workspace:*` references. No parallel "workspace-app" scaffold to maintain.
@@ -211,13 +211,13 @@ You have two options: **unified deploy** (the default for workspaces) or per-app
 One command builds every app in the workspace and ships them behind a single origin, one path per app:
 
 ```bash
-agent-native deploy
+npx @agent-native/core@latest deploy
 # https://your-agents.com/mail/*       → apps/mail
 # https://your-agents.com/calendar/*   → apps/calendar
 # https://your-agents.com/forms/*      → apps/forms
 ```
 
-Each app is built with `APP_BASE_PATH=/<name>` and `VITE_APP_BASE_PATH=/<name>` and emitted through the selected Nitro preset. Cloudflare Pages is the default preset and uses a dispatcher worker at `dist/_worker.js` plus `_routes.json`. Netlify is supported with `agent-native deploy --preset netlify`; it emits app functions under `.netlify/functions-internal/<app>-server` and generated redirects that leave static assets unforced so the CDN serves files first. Vercel is supported with `agent-native deploy --preset vercel`; it writes a root `.vercel/output` bundle using Vercel's Build Output API.
+Each app is built with `APP_BASE_PATH=/<name>` and `VITE_APP_BASE_PATH=/<name>` and emitted through the selected Nitro preset. Cloudflare Pages is the default preset and uses a dispatcher worker at `dist/_worker.js` plus `_routes.json`. Netlify is supported with `npx @agent-native/core@latest deploy --preset netlify`; it emits app functions under `.netlify/functions-internal/<app>-server` and generated redirects that leave static assets unforced so the CDN serves files first. Vercel is supported with `npx @agent-native/core@latest deploy --preset vercel`; it writes a root `.vercel/output` bundle using Vercel's Build Output API.
 
 Being on the **same origin** is where the real payoff lives:
 
@@ -234,13 +234,13 @@ wrangler pages deploy dist
 For Netlify:
 
 ```bash
-agent-native deploy --preset netlify --build-only
+npx @agent-native/core@latest deploy --preset netlify --build-only
 ```
 
 For Vercel Git deployments, set the build command to:
 
 ```bash
-pnpm exec agent-native deploy --preset vercel --build-only
+npx @agent-native/core@latest deploy --preset vercel --build-only
 ```
 
 ### Public app routes
@@ -274,7 +274,7 @@ These settings only affect read-only page navigation. Framework tools, agent cha
 
 ### Per-app independent deploy
 
-Prefer each app on its own domain (`mail.company.com`, `calendar.company.com`)? Every app in the workspace is still an independent deployable — `cd apps/mail && agent-native build` behaves exactly like a standalone scaffold. Cross-app A2A then goes through the standard JWT-signed path with a shared `A2A_SECRET`. Cross-domain SSO between separately-deployed apps is handled by identity federation with Dispatch as the hub — see [Cross-App SSO](/docs/cross-app-sso); the unified single-origin deploy avoids needing it.
+Prefer each app on its own domain (`mail.company.com`, `calendar.company.com`)? Every app in the workspace is still an independent deployable — `cd apps/mail && npx @agent-native/core@latest build` behaves exactly like a standalone scaffold. Cross-app A2A then goes through the standard JWT-signed path with a shared `A2A_SECRET`. Cross-domain SSO between separately-deployed apps is handled by identity federation with Dispatch as the hub — see [Cross-App SSO](/docs/cross-app-sso); the unified single-origin deploy avoids needing it.
 
 ### Shared database, shared credentials
 

--- a/packages/core/docs/content/multi-tenancy.md
+++ b/packages/core/docs/content/multi-tenancy.md
@@ -50,7 +50,7 @@ This is the same pipeline used for per-user scoping. For the SQL-level mechanics
 
 ## No configuration needed {#zero-config}
 
-Multi-tenancy is not a feature you enable — it's the default architecture. A fresh `agent-native create` scaffold already has:
+Multi-tenancy is not a feature you enable — it's the default architecture. A fresh `npx @agent-native/core@latest create` scaffold already has:
 
 - User registration and login
 - Organization creation and management

--- a/packages/core/docs/content/plan-plugin.md
+++ b/packages/core/docs/content/plan-plugin.md
@@ -26,7 +26,7 @@ the Plan MCP connector. They write `plans/<slug>/plan.mdx` plus optional
 `canvas.mdx`, `prototype.mdx`, and `.plan-state.json`, then preview locally with:
 
 ```bash
-agent-native plan local preview --dir plans/<slug> --kind plan
+npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind plan
 ```
 
 This keeps plan content out of the Agent-Native Plan database. Hosted sharing,
@@ -45,14 +45,12 @@ Works for any host — Claude Code, Codex, Cursor, Cline, Goose, ChatGPT custom 
 
 ```bash
 npx @agent-native/core@latest skills add visual-plan
-# or, if the CLI is already on PATH:
-agent-native skills add visual-plan
 ```
 
 This installs `visual-plan` plus the companion `visual-recap` skill, then registers the `plan` connector and its legacy `agent-native-plans` alias, then runs auth (OAuth prompt for hosted/account-backed sharing). Useful flags:
 
 - `--client codex|claude-code|claude-code-cli|cowork|all` — which local agents to write the MCP config for (default `codex`).
-- `--no-connect` — register the connector without authenticating; run `agent-native connect https://plan.agent-native.com` later.
+- `--no-connect` — register the connector without authenticating; run `npx @agent-native/core@latest connect https://plan.agent-native.com` later.
 - `--mcp-url <url>` — point the connector at a custom origin (an ngrok tunnel, a local dev server, or a self-hosted deployment) instead of the hosted default.
 - `--with-github-action` — also write the PR Visual Recap GitHub Action (see [PR Visual Recap](/docs/pr-visual-recap)).
 
@@ -61,8 +59,8 @@ present. Say yes to add it during skill setup, or run the command above later
 with `--with-github-action`. After the workflow is written, run:
 
 ```bash
-agent-native recap setup
-agent-native recap doctor
+npx @agent-native/core@latest recap setup
+npx @agent-native/core@latest recap doctor
 ```
 
 `recap setup` configures the GitHub Action secrets and variables where possible,
@@ -100,7 +98,7 @@ codex mcp login plan   # OAuth in the browser
 codex mcp login agent-native-plans
 ```
 
-After install, **start a new Codex thread** so the skills and MCP tools load into the session. The plugin ships URL-only connectors (`[mcp_servers.plan]` and legacy `[mcp_servers.agent-native-plans]` → `https://plan.agent-native.com/_agent-native/mcp`); `codex mcp login` runs the OAuth flow. The universal CLI route above also works for Codex (`agent-native skills add visual-plan --client codex`) if you prefer one command that installs and authenticates together.
+After install, **start a new Codex thread** so the skills and MCP tools load into the session. The plugin ships URL-only connectors (`[mcp_servers.plan]` and legacy `[mcp_servers.agent-native-plans]` → `https://plan.agent-native.com/_agent-native/mcp`); `codex mcp login` runs the OAuth flow. The universal CLI route above also works for Codex (`npx @agent-native/core@latest skills add visual-plan --client codex`) if you prefer one command that installs and authenticates together.
 
 ## Updates {#updates}
 
@@ -129,7 +127,7 @@ In short: ship it as a self-hosted/public git marketplace and users install dire
 
 A **skill** is a single `SKILL.md` instruction file the agent reads when a task matches. A **plugin** (Claude Code marketplace plugin or Codex plugin) is a package that bundles one or more skills **plus** an MCP connector and metadata, so a host can install everything in one step.
 
-Under the hood, all three routes are produced from the same source by the `agent-native app-skill` CLI: `app-skill pack` builds the marketplace/plugin adapters, and `skills add` is the friendly one-step installer that also registers and authenticates the MCP connector. See [Skills Guide](/docs/skills-guide) for the app-skill manifest format, and [External Agents](/docs/external-agents) for connecting any MCP host and the `agent-native connect` flow.
+Under the hood, all three routes are produced from the same source by the `npx @agent-native/core@latest app-skill` CLI: `app-skill pack` builds the marketplace/plugin adapters, and `skills add` is the friendly one-step installer that also registers and authenticates the MCP connector. See [Skills Guide](/docs/skills-guide) for the app-skill manifest format, and [External Agents](/docs/external-agents) for connecting any MCP host and the `npx @agent-native/core@latest connect` flow.
 
 ## What's next {#whats-next}
 

--- a/packages/core/docs/content/pr-visual-recap.md
+++ b/packages/core/docs/content/pr-visual-recap.md
@@ -33,16 +33,16 @@ automatic PR Visual Recaps. Say yes to write the GitHub Action, or add it
 explicitly at any time:
 
 ```bash
-agent-native skills add visual-plan --with-github-action
+npx @agent-native/core@latest skills add visual-plan --with-github-action
 ```
 
-This installs the `visual-plan` skill (which includes the `visual-recap` skill the action runs) and writes `.github/workflows/pr-visual-recap.yml` into your repo. The workflow calls **published CLI subcommands** — `agent-native recap gate|collect-diff|mcp-config|scan|build-prompt|shot|comment|check|usage` — so nothing is copied into your repo as helper scripts. `setup` and `doctor` are the interactive helpers you run locally; `gate` is the security-gate step the workflow runs before every recap.
+This installs the `visual-plan` skill (which includes the `visual-recap` skill the action runs) and writes `.github/workflows/pr-visual-recap.yml` into your repo. The workflow calls **published CLI subcommands** through `npx @agent-native/core@latest recap <subcommand>` — including `gate`, `collect-diff`, `mcp-config`, `scan`, `build-prompt`, `shot`, `comment`, `check`, and `usage` — so nothing is copied into your repo as helper scripts. `setup` and `doctor` are the interactive helpers you run locally; `gate` is the security-gate step the workflow runs before every recap.
 
 Then run the guided setup helper:
 
 ```bash
-agent-native recap setup
-agent-native recap doctor
+npx @agent-native/core@latest recap setup
+npx @agent-native/core@latest recap doctor
 ```
 
 `recap setup` refreshes the workflow, uses `gh` to set GitHub Actions
@@ -84,10 +84,10 @@ Set these in your repository's **Settings → Secrets and variables → Actions*
 
 ### Secrets (only two required)
 
-| Secret              | Purpose                                                                                                           |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `PLAN_RECAP_TOKEN`  | Revocable token minted by `agent-native connect`. Authorizes publishing the recap plan and the screenshot upload. |
-| `ANTHROPIC_API_KEY` | The LLM key for the default Claude Code backend.                                                                  |
+| Secret              | Purpose                                                                                                                            |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `PLAN_RECAP_TOKEN`  | Revocable token minted by `npx @agent-native/core@latest connect`. Authorizes publishing the recap plan and the screenshot upload. |
+| `ANTHROPIC_API_KEY` | The LLM key for the default Claude Code backend.                                                                                   |
 
 **Teams: use an org service token.** A personal token is bound to the person
 who minted it — if they leave the org or revoke their tokens, every repo using
@@ -98,7 +98,7 @@ survives any individual leaving, the recaps it publishes are org-visible, and
 any org owner or admin can list or revoke it. Mint one (org owner/admin only):
 
 ```bash
-agent-native connect https://plan.agent-native.com --service-token pr-recap
+npx @agent-native/core@latest connect https://plan.agent-native.com --service-token pr-recap
 ```
 
 The command authenticates you in the browser, then prints the service token
@@ -106,13 +106,13 @@ exactly once — store it as the `PLAN_RECAP_TOKEN` secret. Manage it later with
 the `list-org-service-tokens` and `revoke-org-service-token` actions on the
 Plans app.
 
-**Solo: a personal token still works.** Mint it with `agent-native connect`
+**Solo: a personal token still works.** Mint it with `npx @agent-native/core@latest connect`
 against your Plans app. For the hosted app, this also writes a local
-publish-token file that `agent-native recap setup` can read:
+publish-token file that `npx @agent-native/core@latest recap setup` can read:
 
 ```bash
-agent-native connect https://plan.agent-native.com --client codex
-agent-native recap setup
+npx @agent-native/core@latest connect https://plan.agent-native.com --client codex
+npx @agent-native/core@latest recap setup
 ```
 
 If you prefer manual setup, paste the token into the GitHub secret. Use a
@@ -207,9 +207,9 @@ recap without sending recap content to the Agent-Native Plan database, run the
 same helper flow locally in local-files mode instead:
 
 ```bash
-agent-native recap collect-diff --base main --head HEAD --out recap.diff --stat recap.stat
-agent-native recap scan --diff recap.diff
-agent-native recap build-prompt --pr 123 --diff recap.diff --stat recap.stat --local-files --local-dir plans/pr-123-visual-recap
+npx @agent-native/core@latest recap collect-diff --base main --head HEAD --out recap.diff --stat recap.stat
+npx @agent-native/core@latest recap scan --diff recap.diff
+npx @agent-native/core@latest recap build-prompt --pr 123 --diff recap.diff --stat recap.stat --local-files --local-dir plans/pr-123-visual-recap
 ```
 
 Give the generated `recap-prompt.md` to your coding agent. In local-files mode
@@ -217,7 +217,7 @@ the prompt instructs the agent to write `plans/pr-123-visual-recap/plan.mdx`
 plus optional visual files and then run:
 
 ```bash
-agent-native plan local preview --dir plans/pr-123-visual-recap --kind recap
+npx @agent-native/core@latest plan local preview --dir plans/pr-123-visual-recap --kind recap
 ```
 
 The returned `file://` preview, or `/local-plans/pr-123-visual-recap` in a local
@@ -246,7 +246,7 @@ For the reusable-caller variant, use the `cli-version` input instead (see [Versi
 
 ## Secret-scan allowlist
 
-Before publishing a recap the workflow runs `agent-native recap scan` to detect likely secrets in the diff. Any PR whose diff matches a known-secret pattern is blocked with an explanatory comment — the recap is not published, and no diff content is sent to the coding agent.
+Before publishing a recap the workflow runs `npx @agent-native/core@latest recap scan` to detect likely secrets in the diff. Any PR whose diff matches a known-secret pattern is blocked with an explanatory comment — the recap is not published, and no diff content is sent to the coding agent.
 
 In rare cases a repo has intentional test fixtures or non-secret strings that superficially resemble secret patterns (e.g., a fixture key in a test file). To suppress a false positive, create `.github/recap-scan-allowlist` in the root of your repository.
 
@@ -280,7 +280,7 @@ The allowlist is only consulted by the secret-scan gate. It does not affect what
 
 ### Why use the reusable variant?
 
-The default installer copies the full ~360-line workflow YAML into your repo (the **copy** option). This is the right choice for air-gapped repos or repos that need to audit every line of what runs. The downside is that bug fixes and improvements never reach you — you need to re-run `agent-native recap setup` manually after each release.
+The default installer copies the full ~360-line workflow YAML into your repo (the **copy** option). This is the right choice for air-gapped repos or repos that need to audit every line of what runs. The downside is that bug fixes and improvements never reach you — you need to re-run `npx @agent-native/core@latest recap setup` manually after each release.
 
 The **reusable** option writes a thin ~20-line caller instead. It delegates to `BuilderIO/agent-native/.github/workflows/pr-visual-recap-reusable.yml` via `uses:`. Every caller automatically picks up the latest logic when the workflow runs, with no local update needed.
 
@@ -293,7 +293,7 @@ The **reusable** option writes a thin ~20-line caller instead. It delegates to `
 
 ### Caller snippet
 
-This is what `agent-native recap setup --reusable` writes (or you can paste it manually):
+This is what `npx @agent-native/core@latest recap setup --reusable` writes (or you can paste it manually):
 
 ```yaml
 name: PR Visual Recap
@@ -327,15 +327,15 @@ The same secrets and variables described in [Secrets and variables](#secrets-and
 
 ```bash
 # Write the thin caller instead of the full copy:
-agent-native recap setup --reusable
+npx @agent-native/core@latest recap setup --reusable
 
 # Or with a pinned ref for reproducibility:
-agent-native recap setup --reusable --ref v1.2.3
+npx @agent-native/core@latest recap setup --reusable --ref v1.2.3
 ```
 
 Both variants write the workflow to `.github/workflows/pr-visual-recap.yml`. If an existing workflow is already there and differs, the command refuses and tells you to pass `--force` to overwrite.
 
-After writing, run `agent-native recap doctor` as usual to confirm secrets are configured.
+After writing, run `npx @agent-native/core@latest recap doctor` as usual to confirm secrets are configured.
 
 ### Version pinning
 

--- a/packages/core/docs/content/pure-agent-apps.md
+++ b/packages/core/docs/content/pure-agent-apps.md
@@ -65,7 +65,7 @@ If you're not a developer, you can usually start with the [Dispatch template](/d
 For developers who want the absolute minimum, start from the **Starter** template:
 
 ```bash
-npx @agent-native/core create my-agent --template starter
+npx @agent-native/core@latest create my-agent --template starter
 ```
 
 Starter gives you the architecture, the agent panel, the workspace, auth, polling, and one example action — and nothing else. Add your own actions in `actions/`, connect any MCP servers you need, write the relevant skills into the workspace, and you're done.

--- a/packages/core/docs/content/skills-guide.md
+++ b/packages/core/docs/content/skills-guide.md
@@ -219,14 +219,14 @@ npx @agent-native/core@latest skills add assets
 npx skills add BuilderIO/agent-native --skill assets
 
 # Register a hosted MCP connector for local agent clients.
-agent-native app-skill ensure --manifest templates/assets/agent-native.app-skill.json
+npx @agent-native/core@latest app-skill ensure --manifest templates/assets/agent-native.app-skill.json
 
 # Materialize and run editable local source.
-agent-native app-skill launch --manifest templates/assets/agent-native.app-skill.json --local --into ./assets-local
+npx @agent-native/core@latest app-skill launch --manifest templates/assets/agent-native.app-skill.json --local --into ./assets-local
 
 # Build marketplace adapters: Codex plugin, Claude marketplace, Vercel skills,
 # plain/Claude skills, and MCP configs.
-agent-native app-skill pack --manifest templates/assets/agent-native.app-skill.json --out ./dist/assets-skill
+npx @agent-native/core@latest app-skill pack --manifest templates/assets/agent-native.app-skill.json --out ./dist/assets-skill
 
 # Install a local exported bundle with the Vercel/open Skills CLI.
 npx skills add ./dist/assets-skill --skill assets -a codex -y

--- a/packages/core/docs/content/template-analytics.md
+++ b/packages/core/docs/content/template-analytics.md
@@ -84,7 +84,7 @@ The rest of this doc is for anyone forking the Analytics template or extending i
 Create a new Analytics app from the CLI:
 
 ```bash
-npx @agent-native/core create my-analytics --standalone --template analytics
+npx @agent-native/core@latest create my-analytics --standalone --template analytics
 ```
 
 Local dev:

--- a/packages/core/docs/content/template-assets.md
+++ b/packages/core/docs/content/template-assets.md
@@ -96,7 +96,7 @@ The rest of this doc is for anyone forking the Assets template or extending it.
 ### Scaffolding
 
 ```bash
-npx @agent-native/core create my-assets --standalone --template assets
+npx @agent-native/core@latest create my-assets --standalone --template assets
 ```
 
 ### Data model
@@ -184,13 +184,13 @@ npx @agent-native/core@latest skills add assets
 npx skills add BuilderIO/agent-native --skill assets
 
 # Hosted install: URL-only MCP connector, no shared secrets in skill files.
-agent-native app-skill ensure --manifest templates/assets/agent-native.app-skill.json
+npx @agent-native/core@latest app-skill ensure --manifest templates/assets/agent-native.app-skill.json
 
 # Local editable launch.
-agent-native app-skill launch --manifest templates/assets/agent-native.app-skill.json --local --into ./assets-local
+npx @agent-native/core@latest app-skill launch --manifest templates/assets/agent-native.app-skill.json --local --into ./assets-local
 
 # Marketplace package, including Claude Code marketplace and Vercel Labs skills adapters.
-agent-native app-skill pack --manifest templates/assets/agent-native.app-skill.json --out ./dist/assets-skill
+npx @agent-native/core@latest app-skill pack --manifest templates/assets/agent-native.app-skill.json --out ./dist/assets-skill
 
 # Install a local exported Assets bundle with the open skills CLI.
 npx skills add ./dist/assets-skill --skill assets -a codex -y

--- a/packages/core/docs/content/template-brain.md
+++ b/packages/core/docs/content/template-brain.md
@@ -94,7 +94,7 @@ The rest of this section is for anyone forking or extending the Brain template.
 ### Quick start
 
 ```bash
-npx @agent-native/core create my-brain --standalone --template brain
+npx @agent-native/core@latest create my-brain --standalone --template brain
 cd my-brain
 pnpm install
 pnpm dev

--- a/packages/core/docs/content/template-calendar.md
+++ b/packages/core/docs/content/template-calendar.md
@@ -78,7 +78,7 @@ The rest of this doc is for anyone forking the Calendar template or extending it
 Create a new workspace with the Calendar template:
 
 ```bash
-npx @agent-native/core create my-app --standalone --template calendar
+npx @agent-native/core@latest create my-app --standalone --template calendar
 cd my-app
 pnpm install
 pnpm dev

--- a/packages/core/docs/content/template-clips.md
+++ b/packages/core/docs/content/template-clips.md
@@ -66,7 +66,7 @@ The rest of this doc is for anyone forking the Clips template or extending it.
 ### Scaffolding
 
 ```bash
-npx @agent-native/core create my-clips --standalone --template clips
+npx @agent-native/core@latest create my-clips --standalone --template clips
 cd my-clips
 pnpm install
 pnpm dev

--- a/packages/core/docs/content/template-content.md
+++ b/packages/core/docs/content/template-content.md
@@ -60,7 +60,7 @@ The rest of this doc is for anyone forking the Content template or extending it.
 Scaffold a new workspace with the Content template:
 
 ```bash
-npx @agent-native/core create my-workspace --standalone --template content
+npx @agent-native/core@latest create my-workspace --standalone --template content
 cd my-workspace
 pnpm install
 pnpm dev

--- a/packages/core/docs/content/template-design.md
+++ b/packages/core/docs/content/template-design.md
@@ -54,7 +54,7 @@ The rest of this doc is for anyone forking the Design template or extending it.
 ### Scaffolding
 
 ```bash
-npx @agent-native/core create my-design --standalone --template design
+npx @agent-native/core@latest create my-design --standalone --template design
 ```
 
 ### Data model

--- a/packages/core/docs/content/template-dispatch.md
+++ b/packages/core/docs/content/template-dispatch.md
@@ -119,7 +119,7 @@ pnpm action create-dream-report --allSources true --sourceTimeoutMs 30000 --limi
 ## Scaffolding {#scaffolding}
 
 ```bash
-npx @agent-native/core create my-platform
+npx @agent-native/core@latest create my-platform
 # pick "Dispatch" in the multi-select picker, plus whichever domain apps you want
 ```
 

--- a/packages/core/docs/content/template-forms.md
+++ b/packages/core/docs/content/template-forms.md
@@ -64,13 +64,13 @@ See [What is agent-native?](/docs/what-is-agent-native) for the broader framewor
 ### Scaffolding
 
 ```bash
-npx @agent-native/core create my-forms --standalone --template forms
+npx @agent-native/core@latest create my-forms --standalone --template forms
 ```
 
 For a workspace with Forms alongside other apps:
 
 ```bash
-npx @agent-native/core create my-platform
+npx @agent-native/core@latest create my-platform
 ```
 
 Pick Forms and any other templates you want during the workspace setup.

--- a/packages/core/docs/content/template-mail.md
+++ b/packages/core/docs/content/template-mail.md
@@ -99,7 +99,7 @@ The rest of this doc is for anyone forking the Mail template or extending it.
 Create a new workspace with the Mail template:
 
 ```bash
-npx @agent-native/core create my-mail --standalone --template mail
+npx @agent-native/core@latest create my-mail --standalone --template mail
 cd my-mail
 pnpm install
 pnpm dev
@@ -108,7 +108,7 @@ pnpm dev
 Or add Mail to an existing agent-native workspace:
 
 ```bash
-npx @agent-native/core add-app
+npx @agent-native/core@latest add-app
 ```
 
 To connect Gmail in dev, you need a Google OAuth client:

--- a/packages/core/docs/content/template-plan.md
+++ b/packages/core/docs/content/template-plan.md
@@ -37,12 +37,6 @@ hit an OAuth wall:
 npx @agent-native/core@latest skills add visual-plan
 ```
 
-If you already have the CLI installed, the shorter command is equivalent:
-
-```bash
-agent-native skills add visual-plan
-```
-
 The command installs both commands: `/visual-plan` and `/visual-recap`.
 
 If you are using a chat-based host that accepts MCP connector URLs directly
@@ -68,7 +62,7 @@ npx @agent-native/core@latest skills add visual-plan --client all
 ```
 
 Pass `--no-connect` to register the connector without authenticating, then run
-`agent-native connect https://plan.agent-native.com` whenever you are ready:
+`npx @agent-native/core@latest connect https://plan.agent-native.com` whenever you are ready:
 
 ```bash
 npx @agent-native/core@latest skills add visual-plan --no-connect
@@ -83,8 +77,8 @@ see [PR Visual Recap](/docs/pr-visual-recap).
 npx @agent-native/core@latest skills add visual-plan --with-github-action
 ```
 
-After the workflow is written, run `agent-native recap setup` to configure
-GitHub Actions secrets/variables where possible and `agent-native recap doctor`
+After the workflow is written, run `npx @agent-native/core@latest recap setup` to configure
+GitHub Actions secrets/variables where possible and `npx @agent-native/core@latest recap doctor`
 to verify the repo is ready.
 
 If you only want the portable instruction file through the open Skills CLI, use:
@@ -195,7 +189,7 @@ not call the hosted Plan MCP tools. The durable files are:
 After writing the folder, the agent validates and previews it locally:
 
 ```bash
-agent-native plan local preview --dir plans/<slug> --kind plan
+npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind plan
 ```
 
 If you run the Plan app locally with the same `PLAN_LOCAL_DIR`, you can open the
@@ -227,7 +221,7 @@ model if that privacy boundary matters too.
 
 If a Plans tool ever returns `needs auth`, `Unauthorized`, or `Session
 terminated`, do not keep retrying it. Authenticate the connector with
-`agent-native connect https://plan.agent-native.com` (or re-run `/mcp` →
+`npx @agent-native/core@latest connect https://plan.agent-native.com` (or re-run `/mcp` →
 **Authenticate** in an OAuth-capable host), then continue once the connector is
 available.
 
@@ -239,7 +233,7 @@ Most users should install the skill with the CLI instead of scaffolding the app.
 ### Quick start
 
 ```bash
-npx @agent-native/core create my-plans --standalone --template plan
+npx @agent-native/core@latest create my-plans --standalone --template plan
 cd my-plans
 pnpm install
 pnpm dev

--- a/packages/core/docs/content/template-slides.md
+++ b/packages/core/docs/content/template-slides.md
@@ -71,7 +71,7 @@ The rest of this doc is for anyone forking the Slides template or extending it.
 Create a new Slides app from the CLI:
 
 ```bash
-npx @agent-native/core create my-slides --standalone --template slides
+npx @agent-native/core@latest create my-slides --standalone --template slides
 cd my-slides
 pnpm install
 pnpm dev

--- a/packages/core/docs/content/template-starter.md
+++ b/packages/core/docs/content/template-starter.md
@@ -51,13 +51,13 @@ Pick a domain template ([Mail](/docs/template-mail), [Calendar](/docs/template-c
 ## Scaffolding {#scaffolding}
 
 ```bash
-npx @agent-native/core create my-app --standalone --template starter
+npx @agent-native/core@latest create my-app --standalone --template starter
 ```
 
 Or, in a workspace:
 
 ```bash
-npx @agent-native/core create my-platform  # pick "Starter" (pre-selected by default) plus any others
+npx @agent-native/core@latest create my-platform  # pick "Starter" (pre-selected by default) plus any others
 ```
 
 ## First edits {#first-edits}

--- a/packages/core/docs/content/template-videos.md
+++ b/packages/core/docs/content/template-videos.md
@@ -75,7 +75,7 @@ The studio runs on Remotion's `<Player>` for preview and the Remotion CLI for fi
 Scaffold a new Video app from the CLI:
 
 ```bash
-npx @agent-native/core create my-video-app --standalone --template videos
+npx @agent-native/core@latest create my-video-app --standalone --template videos
 cd my-video-app
 pnpm install
 pnpm dev

--- a/packages/core/docs/content/workspace-management.md
+++ b/packages/core/docs/content/workspace-management.md
@@ -127,7 +127,7 @@ For the resource model and canonical paths, see [Workspace — Global resources]
 
 ## Setup Checklist
 
-For a new workspace, after running `agent-native create`:
+For a new workspace, after running `npx @agent-native/core@latest create`:
 
 **Git & GitHub:**
 

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -876,7 +876,9 @@ describe("agent-native skills", () => {
     expect(fs.existsSync(workflow)).toBe(true);
     expect(fs.readFileSync(workflow, "utf-8")).toContain("PR Visual Recap");
     expect(stdout.join("")).toContain("PR Visual Recap workflow: wrote");
-    expect(stdout.join("")).toContain("agent-native recap setup");
+    expect(stdout.join("")).toContain(
+      "npx @agent-native/core@latest recap setup",
+    );
   });
 
   it("prints a later command when the optional recap workflow prompt is declined", async () => {
@@ -909,7 +911,7 @@ describe("agent-native skills", () => {
     expect(promptGithubAction).toHaveBeenCalledTimes(1);
     expect(fs.existsSync(path.join(root, ".github"))).toBe(false);
     expect(stdout.join("")).toContain(
-      "agent-native skills add visual-plan --with-github-action",
+      "npx @agent-native/core@latest skills add visual-plan --with-github-action",
     );
   });
 

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -144,7 +144,7 @@ of using a generic image generator.
   browser approved but the local MCP config unwritten. Restart or reload the
   agent client after installing or connecting if Assets tools do not appear in
   the live session.
-- Local customization: use \`agent-native app-skill launch --local\` from an
+- Local customization: use \`npx @agent-native/core@latest app-skill launch --local\` from an
   Assets app-skill manifest, or pass \`--into <path>\` for editable source.
 - Do not call image/video providers directly from another app. Assets owns
   generation, picker UI, search/list/export, and asset context.
@@ -249,7 +249,7 @@ authenticates it in the same step (a one-time browser sign-in at setup — this 
 intended), so the first tool call does not hit an OAuth wall:
 
 \`\`\`bash
-agent-native skills add visual-plan
+npx @agent-native/core@latest skills add visual-plan
 \`\`\`
 
 After that, \`/visual-plan\` and \`/visual-recap\` are the two installed slash
@@ -257,7 +257,7 @@ commands. The other planning modes (\`create-ui-plan\`, \`create-prototype-plan\
 \`create-plan-design\`, \`create-visual-questions\`) are MCP tools reachable from
 \`/visual-plan\`, not separate slash commands. Pass \`--no-connect\` to register
 the connector without authenticating, then run
-\`agent-native connect https://plan.agent-native.com\` whenever you are ready.
+\`npx @agent-native/core@latest connect https://plan.agent-native.com\` whenever you are ready.
 
 **Browser (people you share with).** Open the Plans editor and create & edit
 with no sign-up — you work as a guest. Sign in only when you want to save or
@@ -272,7 +272,7 @@ hosted flow.
 
 If a Plans tool returns \`needs auth\`, \`Unauthorized\`, or \`Session terminated\`,
 do not keep retrying the tool. Authenticate the connector with
-\`agent-native connect https://plan.agent-native.com\` (OAuth-capable hosts can
+\`npx @agent-native/core@latest connect https://plan.agent-native.com\` (OAuth-capable hosts can
 instead re-run /mcp and choose Authenticate), then continue once the connector
 is available.
 
@@ -952,7 +952,7 @@ inline output: the usual cause is a connector that did not finish connecting
 this session (it registers zero tools), not auth. Stop and give the user the
 exact restore step — reconnect via \`/mcp\` (or restart the session); only if
 genuinely unauthenticated, run
-\`agent-native connect https://plan.agent-native.com\`. Publish once the tool is
+\`npx @agent-native/core@latest connect https://plan.agent-native.com\`. Publish once the tool is
 reachable. Local-files privacy mode (after Tool Guidance) is the only
 exception.
 
@@ -1126,7 +1126,7 @@ The local-files contract is:
 - Write the plan as a local MDX folder under \`plans/<slug>/\`: \`plan.mdx\`,
   optional \`canvas.mdx\`, optional \`prototype.mdx\`, and optional
   \`.plan-state.json\`.
-- Run \`agent-native plan local preview --dir plans/<slug> --kind plan\` after
+- Run \`npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind plan\` after
   writing or updating the folder. Report the returned local URL or the
   \`/local-plans/<slug>\` route if the local Plan app is running with the same
   \`PLAN_LOCAL_DIR\`.
@@ -1215,14 +1215,14 @@ exception to the hosted publish rule below.
 In local-files mode:
 
 - Read the diff/stat/source context from local files and shell commands only.
-  The existing \`agent-native recap collect-diff\`, \`scan\`, and
+  The existing \`npx @agent-native/core@latest recap collect-diff\`, \`scan\`, and
   \`build-prompt --local-files\` helpers are safe to use because they operate on
   local files and do not write to the Plan database.
 - Write the recap as a local MDX folder under \`plans/<slug>/\`: \`plan.mdx\`,
   optional \`canvas.mdx\`, optional \`prototype.mdx\`, and optional
   \`.plan-state.json\`. Set \`kind: "recap"\` and \`localOnly: true\` in
   frontmatter/state when authoring the source.
-- Run \`agent-native plan local preview --dir plans/<slug> --kind recap\` after
+- Run \`npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind recap\` after
   writing or updating the folder. Report the returned local URL or the
   \`/local-plans/<slug>\` route if the local Plan app is running with the same
   \`PLAN_LOCAL_DIR\`.
@@ -1260,7 +1260,7 @@ connector that did not finish connecting this session (it registers zero tools),
 NOT necessarily an auth problem — so do not assume the user must authenticate.
 Stop and tell the user how to restore it: reconnect the Plan MCP connector (in
 Claude Code, run \`/mcp\` and reconnect, or restart the session); only if it is
-genuinely unauthenticated, run \`agent-native connect <plan-app-url>\` or
+genuinely unauthenticated, run \`npx @agent-native/core@latest connect <plan-app-url>\` or
 re-authenticate via \`/mcp\`. Then publish once the tool is reachable. Falling
 back to inline content is a defect, not a degraded mode.
 
@@ -1437,7 +1437,7 @@ a headless CI agent), state that in the recap handoff instead.
 ## Open And Report The Recap
 
 In local-files privacy mode, report the local preview URL/path from
-\`agent-native plan local preview\` or the \`/local-plans/<slug>\` route for a local
+\`npx @agent-native/core@latest plan local preview\` or the \`/local-plans/<slug>\` route for a local
 Plan app using the same \`PLAN_LOCAL_DIR\`. Do not invent a hosted URL and do not
 publish just to get an absolute Plan link.
 
@@ -2059,7 +2059,7 @@ export interface SkillsAddResult {
    */
   connected?: boolean;
   /**
-   * The exact `agent-native connect <url>` command to run when interactive auth
+   * The exact `npx @agent-native/core@latest connect <url>` command to run when interactive auth
    * was skipped (non-interactive shell / CI). Empty when connect ran inline or
    * was not needed.
    */
@@ -2542,11 +2542,11 @@ function prVisualRecapWorkflowDisplayPath(): string {
 }
 
 function prVisualRecapInstallCommand(): string {
-  return "agent-native skills add visual-plan --with-github-action";
+  return "npx @agent-native/core@latest skills add visual-plan --with-github-action";
 }
 
 function prVisualRecapSetupCommand(): string {
-  return "agent-native recap setup";
+  return "npx @agent-native/core@latest recap setup";
 }
 
 async function promptForGithubAction(
@@ -3075,7 +3075,7 @@ function canRunInteractiveConnect(options: RunSkillsOptions): boolean {
   return !!process.stdin.isTTY && !!process.stdout.isTTY;
 }
 
-/** Build the `agent-native connect <url> --client … --scope …` command. */
+/** Build the `npx @agent-native/core@latest connect <url> --client … --scope …` command. */
 function connectCommandFor(
   hostedUrl: string,
   clients: ClientId[],
@@ -3285,7 +3285,7 @@ export async function addAgentNativeSkill(
 
     if (parsed.mcp) {
       commands.push(
-        `agent-native app-skill ensure --manifest ${installTarget.loaded.file} --client ${parsed.client} --scope ${parsed.scope} --yes`,
+        `npx @agent-native/core@latest app-skill ensure --manifest ${installTarget.loaded.file} --client ${parsed.client} --scope ${parsed.scope} --yes`,
       );
       if (!parsed.dryRun) {
         await ensureAppSkill(installTarget.loaded, {

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -233,6 +233,11 @@ export type { JSONContent } from "@tiptap/core";
 export { ApiKeySettings } from "./components/ApiKeySettings.js";
 export { useSession, type AuthSession } from "./use-session.js";
 export {
+  RequireSession,
+  buildSignInReturnHref,
+  type RequireSessionProps,
+} from "./require-session.js";
+export {
   sendToFrame,
   onFrameMessage,
   requestUserInfo,

--- a/packages/core/src/client/require-session.spec.tsx
+++ b/packages/core/src/client/require-session.spec.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Control the session state directly so the gate's behaviour is tested in
+// isolation from the session-fetch plumbing.
+const useSessionMock = vi.fn();
+vi.mock("./use-session.js", () => ({
+  useSession: () => useSessionMock(),
+}));
+
+import { RequireSession } from "./require-session.js";
+
+let container: HTMLDivElement;
+let root: Root;
+let replaceMock: ReturnType<typeof vi.fn>;
+let originalLocation: Location;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  replaceMock = vi.fn();
+  originalLocation = window.location;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      pathname: "/inbox",
+      search: "?label=important",
+      hash: "",
+      origin: "https://mail.example.com",
+      href: "https://mail.example.com/inbox?label=important",
+      replace: replaceMock,
+      assign: vi.fn(),
+    },
+  });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
+  vi.clearAllMocks();
+});
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+const Child = () => <div data-testid="protected">inbox</div>;
+
+describe("RequireSession", () => {
+  it("shows a loading fallback while the session resolves and never redirects", () => {
+    useSessionMock.mockReturnValue({ session: null, isLoading: true });
+    render(
+      <RequireSession>
+        <Child />
+      </RequireSession>,
+    );
+    expect(container.querySelector('[data-testid="protected"]')).toBeNull();
+    expect(container.querySelector('[aria-label="Loading"]')).not.toBeNull();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("renders children once a session is present", () => {
+    useSessionMock.mockReturnValue({
+      session: { userId: "u1", email: "a@b.com" },
+      isLoading: false,
+    });
+    render(
+      <RequireSession>
+        <Child />
+      </RequireSession>,
+    );
+    expect(container.querySelector('[data-testid="protected"]')).not.toBeNull();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects to the framework sign-in page with a return path when signed out", () => {
+    useSessionMock.mockReturnValue({ session: null, isLoading: false });
+    render(
+      <RequireSession>
+        <Child />
+      </RequireSession>,
+    );
+    // Shows the fallback rather than flashing app chrome the visitor can't use.
+    expect(container.querySelector('[data-testid="protected"]')).toBeNull();
+    expect(replaceMock).toHaveBeenCalledTimes(1);
+    const href = replaceMock.mock.calls[0][0] as string;
+    expect(href).toContain("/_agent-native/sign-in?return=");
+    expect(href).toContain(encodeURIComponent("/inbox?label=important"));
+  });
+
+  it("does not redirect twice across re-renders", () => {
+    useSessionMock.mockReturnValue({ session: null, isLoading: false });
+    render(
+      <RequireSession>
+        <Child />
+      </RequireSession>,
+    );
+    render(
+      <RequireSession>
+        <Child />
+      </RequireSession>,
+    );
+    expect(replaceMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders `signedOut` instead of redirecting when redirect is disabled", () => {
+    useSessionMock.mockReturnValue({ session: null, isLoading: false });
+    render(
+      <RequireSession redirect={false} signedOut={<div>please sign in</div>}>
+        <Child />
+      </RequireSession>,
+    );
+    expect(container.textContent).toContain("please sign in");
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("bypass renders children even with no session", () => {
+    useSessionMock.mockReturnValue({ session: null, isLoading: false });
+    render(
+      <RequireSession bypass>
+        <Child />
+      </RequireSession>,
+    );
+    expect(container.querySelector('[data-testid="protected"]')).not.toBeNull();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/client/require-session.tsx
+++ b/packages/core/src/client/require-session.tsx
@@ -1,0 +1,106 @@
+/**
+ * Client-side session gate for an authenticated app shell.
+ *
+ * Wrap a template's private app shell with <RequireSession> so a logged-out
+ * visitor is sent to the framework sign-in page instead of being left staring
+ * at an infinite loading spinner.
+ *
+ * Why this exists in addition to the server-side auth guard (`runAuthGuard`,
+ * which serves the onboarding/sign-in HTML for unauthenticated requests):
+ * the server guard only protects requests that actually reach the Nitro
+ * function. A statically-served / CDN-cached SPA shell, or a client-side
+ * (React Router) navigation made after the session expired, never re-hits the
+ * guard — so the app boots with no session, every data query 401s, and the UI
+ * sticks on its loading state forever. This component closes that gap by
+ * resolving the session on the client and redirecting when there is none.
+ *
+ * Place it INSIDE your providers (so the fallback is themed) but AROUND the
+ * routed app layout:
+ *
+ *   <AppProviders ...>
+ *     <RequireSession>
+ *       <AppLayout><Outlet /></AppLayout>
+ *     </RequireSession>
+ *   </AppProviders>
+ *
+ * Templates with public/anonymous routes (share pages, embeds) must NOT wrap
+ * their whole app — gate only the private subtree, or pass `bypass` for the
+ * surfaces that authenticate by another mechanism.
+ */
+import React, { useEffect, useRef } from "react";
+import { useSession } from "./use-session.js";
+import { DefaultSpinner } from "./DefaultSpinner.js";
+import { agentNativePath } from "./api-path.js";
+
+export interface RequireSessionProps {
+  children: React.ReactNode;
+  /**
+   * Rendered while the session is being resolved and while a redirect is in
+   * flight. Defaults to the framework `<DefaultSpinner />`.
+   */
+  fallback?: React.ReactNode;
+  /**
+   * When true (default), unauthenticated visitors are redirected to the
+   * framework sign-in entry point (`/_agent-native/sign-in`) with a `return`
+   * query pointing back at the current URL — so they land back here once
+   * signed in. When false, `signedOut` is rendered instead and no navigation
+   * happens.
+   */
+  redirect?: boolean;
+  /**
+   * Rendered for unauthenticated visitors when `redirect` is false. Ignored
+   * when `redirect` is true.
+   */
+  signedOut?: React.ReactNode;
+  /**
+   * Skip the gate entirely and always render children. Use for surfaces that
+   * authenticate by another mechanism (e.g. an embed/popout iframe carrying
+   * its own token) so they are never bounced to the sign-in page.
+   */
+  bypass?: boolean;
+}
+
+/** Build the framework sign-in URL that returns to the current location. */
+export function buildSignInReturnHref(): string {
+  const base = agentNativePath("/_agent-native/sign-in");
+  if (typeof window === "undefined") return base;
+  const ret =
+    window.location.pathname + window.location.search + window.location.hash;
+  return `${base}?return=${encodeURIComponent(ret)}`;
+}
+
+export function RequireSession({
+  children,
+  fallback,
+  redirect = true,
+  signedOut,
+  bypass = false,
+}: RequireSessionProps) {
+  const { session, isLoading } = useSession();
+  // Guard against firing the redirect more than once (effect re-runs, React
+  // StrictMode double-invoke) — a second navigation while the first is in
+  // flight is harmless but noisy.
+  const redirectedRef = useRef(false);
+
+  const mustRedirect = !bypass && !isLoading && !session && redirect;
+
+  useEffect(() => {
+    if (!mustRedirect) return;
+    if (redirectedRef.current) return;
+    if (typeof window === "undefined") return;
+    redirectedRef.current = true;
+    // `replace` (not `assign`) so the dead authenticated URL doesn't land in
+    // history — pressing Back after signing in shouldn't bounce here again.
+    window.location.replace(buildSignInReturnHref());
+  }, [mustRedirect]);
+
+  if (bypass) return <>{children}</>;
+  // Still resolving, or redirect already in flight: show the loading fallback
+  // rather than flashing app chrome the visitor can't use.
+  if (isLoading) return <>{fallback ?? <DefaultSpinner />}</>;
+  if (!session) {
+    if (redirect) return <>{fallback ?? <DefaultSpinner />}</>;
+    return <>{signedOut ?? null}</>;
+  }
+  return <>{children}</>;
+}

--- a/packages/core/src/mcp/actions/org-service-tokens.spec.ts
+++ b/packages/core/src/mcp/actions/org-service-tokens.spec.ts
@@ -20,9 +20,17 @@ vi.mock("../connect-store.js", () => ({
   revokeOrgServiceToken: (...a: any[]) => revokeOrgServiceTokenMock(...a),
 }));
 
-// org_members role lookup used by the gating helper.
+// org_members lookups used by the gating helper. Two distinct queries hit the
+// same mock: the role lookup (`SELECT role ...`) and the membership lookup
+// (`SELECT org_id ...`) used to auto-resolve an org when the token carries no
+// org context. Route by the selected column so each returns the right rows.
 const roleRows: Array<{ role: string }> = [];
-const dbExecuteMock = vi.fn(async () => ({ rows: roleRows, rowsAffected: 0 }));
+const memberOrgRows: Array<{ org_id: string }> = [];
+const dbExecuteMock = vi.fn(async (query: { sql: string }) =>
+  /select\s+org_id/i.test(query.sql)
+    ? { rows: memberOrgRows, rowsAffected: 0 }
+    : { rows: roleRows, rowsAffected: 0 },
+);
 vi.mock("../../db/client.js", () => ({
   getDbExec: () => ({ execute: dbExecuteMock }),
 }));
@@ -51,9 +59,15 @@ function setRole(role: string | null) {
   if (role) roleRows.push({ role });
 }
 
+function setMemberOrgs(...orgIds: string[]) {
+  memberOrgRows.length = 0;
+  for (const org_id of orgIds) memberOrgRows.push({ org_id });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   setRole("admin");
+  setMemberOrgs();
   mintOrgServiceTokenMock.mockResolvedValue({
     token: "svc-secret-value",
     jti: "jti-1",
@@ -119,7 +133,8 @@ describe("create-org-service-token", () => {
     ).rejects.toMatchObject({ statusCode: 401 });
   });
 
-  it("rejects a caller without an active org with 400", async () => {
+  it("rejects a caller without an active org and no memberships with 400", async () => {
+    setMemberOrgs();
     await expect(
       createAction.run({ name: "ci" }, {
         userEmail: "admin@example.com",
@@ -127,6 +142,33 @@ describe("create-org-service-token", () => {
         caller: "http",
       } as any),
     ).rejects.toMatchObject({ statusCode: 400 });
+    expect(mintOrgServiceTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("auto-resolves the single member org when the token carries no org context", async () => {
+    setMemberOrgs("org-7");
+    setRole("admin");
+    const res = await createAction.run({ name: "ci" }, {
+      userEmail: "admin@example.com",
+      orgId: null,
+      caller: "http",
+    } as any);
+    expect(res.token).toBe("svc-secret-value");
+    expect(mintOrgServiceTokenMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: "org-7" }),
+    );
+  });
+
+  it("rejects with 400 when the token has no org context and the caller belongs to multiple orgs", async () => {
+    setMemberOrgs("org-1", "org-2");
+    await expect(
+      createAction.run({ name: "ci" }, {
+        userEmail: "admin@example.com",
+        orgId: null,
+        caller: "http",
+      } as any),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    expect(mintOrgServiceTokenMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/mcp/actions/service-token-access.ts
+++ b/packages/core/src/mcp/actions/service-token-access.ts
@@ -43,6 +43,22 @@ export async function getOrgRoleForEmail(
   }
 }
 
+/**
+ * Return all org IDs the email belongs to, or [] when the org tables are
+ * absent (template without orgs).
+ */
+async function getOrgIdsForEmail(email: string): Promise<string[]> {
+  try {
+    const { rows } = await getDbExec().execute({
+      sql: `SELECT org_id FROM org_members WHERE LOWER(email) = ?`,
+      args: [email.toLowerCase()],
+    });
+    return rows.map((r) => String(r.org_id)).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
 export interface ServiceTokenCallerContext {
   email: string;
   orgId: string;
@@ -64,13 +80,30 @@ export async function requireServiceTokenCaller(params: {
   if (!email) {
     throw new ServiceTokenError("Sign in to manage org service tokens.", 401);
   }
-  const orgId = params.orgId?.trim();
+
+  // Prefer the org ID from the token's claims; fall back to looking up the
+  // user's org membership when the token was minted without org context (e.g.
+  // a personal connect token created before the user joined an org, or one
+  // created from a session that had no active org at the time).
+  let orgId = params.orgId?.trim() || "";
   if (!orgId) {
-    throw new ServiceTokenError(
-      "No active organization. Service tokens are org-scoped — join or create an organization first.",
-      400,
-    );
+    const memberOrgs = await getOrgIdsForEmail(email);
+    if (memberOrgs.length === 0) {
+      throw new ServiceTokenError(
+        "No active organization. Service tokens are org-scoped — join or create an organization first.",
+        400,
+      );
+    }
+    if (memberOrgs.length > 1) {
+      throw new ServiceTokenError(
+        "Your session is not scoped to a specific organization and you belong to multiple orgs. " +
+          "Re-authenticate with an org-scoped session to disambiguate.",
+        400,
+      );
+    }
+    orgId = memberOrgs[0];
   }
+
   const role = await getOrgRoleForEmail(orgId, email);
   if (!role) {
     throw new ServiceTokenError(

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1,19 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const LOGIN_HTML_CACHE_CONTROL =
-  "public, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
-const LOGIN_HTML_CDN_CACHE_CONTROL = LOGIN_HTML_CACHE_CONTROL;
-const LOGIN_HTML_NETLIFY_CDN_CACHE_CONTROL =
-  "public, durable, max-age=5, stale-while-revalidate=604800, stale-if-error=3600";
+// The login HTML is never CDN-cached: its content reflects live server config
+// (e.g. whether GOOGLE_CLIENT_ID is set), so a stale cached copy would show the
+// wrong UI even after env vars are corrected. It must be `private, no-store`
+// with no CDN cache-control headers at all.
+const LOGIN_HTML_CACHE_CONTROL = "private, no-store";
 
 function expectLoginHtmlCacheHeaders(response: Response) {
   expect(response.headers.get("Cache-Control")).toBe(LOGIN_HTML_CACHE_CONTROL);
-  expect(response.headers.get("CDN-Cache-Control")).toBe(
-    LOGIN_HTML_CDN_CACHE_CONTROL,
-  );
-  expect(response.headers.get("Netlify-CDN-Cache-Control")).toBe(
-    LOGIN_HTML_NETLIFY_CDN_CACHE_CONTROL,
-  );
+  expect(response.headers.get("CDN-Cache-Control")).toBe(null);
+  expect(response.headers.get("Netlify-CDN-Cache-Control")).toBe(null);
 }
 
 describe("server/auth", () => {

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -112,7 +112,6 @@ import {
   AGENT_NATIVE_SOCIAL_IMAGE_TYPE,
   AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
 } from "../shared/social-meta.js";
-import { DEFAULT_SSR_CACHE_HEADERS } from "../shared/cache-control.js";
 import {
   normalizeWorkspaceAppAudience,
   workspaceAppAudienceFromEnv,
@@ -1460,10 +1459,11 @@ function loginHtmlResponse(loginHtml: string, event: H3Event): Response {
     status: 200,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
-      // The sign-in document is part of the public server shell. Keep it on the
-      // same short-fresh/long-SWR CDN policy as React Router SSR so hosted
-      // template roots do not invoke origin just to render anonymous login UI.
-      ...DEFAULT_SSR_CACHE_HEADERS,
+      // Never CDN-cache the login page — its content reflects live server
+      // config (e.g. whether GOOGLE_CLIENT_ID is set). A stale cached response
+      // would show the wrong UI (missing Google button, error message) even
+      // after env vars are correctly configured.
+      "cache-control": "private, no-store",
       "X-Robots-Tag": "noindex, nofollow",
     },
   });

--- a/packages/core/src/templates/workspace-core/.agents/skills/authentication/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/authentication/SKILL.md
@@ -119,7 +119,42 @@ window.location.href =
 
 After successful sign-in (token / email-password / Google OAuth), the framework 302s to `return`. The path is validated as same-origin via the URL parser — open-redirect / header-injection inputs fall back to `/`.
 
-Bookmarked private paths already work without any plumbing — the framework's login page is served at the requested URL, and post-login reload returns the user there.
+Bookmarked private paths already work _when the request reaches the server_ — the auth guard serves the login page at the requested URL and post-login reload returns the user there.
+
+## Gating the App Shell (avoid the logged-out infinite spinner)
+
+The server auth guard only protects requests that actually reach the Nitro
+function. A statically-served / CDN-cached SPA shell, or a client-side (React
+Router) navigation made after the session expired, never re-hits the guard — so
+the app boots with **no session**, every data query 401s, and the UI sticks on
+its loading state forever. Server-side protection alone is not enough; gate on
+the client too.
+
+For a fully private app (every page requires auth, like mail), wrap the routed
+shell with the framework's `RequireSession`. It resolves the session on the
+client and redirects signed-out visitors to `/_agent-native/sign-in?return=…`
+instead of spinning:
+
+```tsx
+import { AppProviders, RequireSession } from "@agent-native/core/client";
+
+<AppProviders queryClient={queryClient}>
+  <RequireSession bypass={isMcpEmbedSurface()}>
+    <AppLayout>
+      <Outlet />
+    </AppLayout>
+  </RequireSession>
+</AppProviders>;
+```
+
+- Place it **inside** `AppProviders` (so the loading fallback is themed) and
+  **around** the layout/outlet — also around any always-mounted effects (poll,
+  automation trigger) so they don't fire 401s for logged-out visitors.
+- Pass `bypass` for surfaces that authenticate by another mechanism (embed /
+  popout iframes carrying their own token) so they are never bounced to sign-in.
+- Apps with public/anonymous routes (share pages) must **not** wrap the whole
+  app — gate only the private subtree, or use the `redirect={false}` +
+  `signedOut` props to render an inline call-to-action instead of redirecting.
 
 ## Related Skills
 

--- a/packages/docs/app/components/TemplateCard.tsx
+++ b/packages/docs/app/components/TemplateCard.tsx
@@ -12,7 +12,7 @@ export const templates = [
     slug: "calendar",
     replaces: "Replaces or augments Google Calendar, Calendly",
     cliCommand:
-      "npx @agent-native/core create my-calendar-app --template calendar",
+      "npx @agent-native/core@latest create my-calendar-app --template calendar",
     demoUrl: "https://calendar.agent-native.com",
     description:
       "Full calendar with Google sync, availability management, and a public booking page. The agent finds open slots, creates events, and manages your schedule.",
@@ -25,7 +25,7 @@ export const templates = [
     slug: "content",
     replaces: "Replaces or augments Notion, Google Docs",
     cliCommand:
-      "npx @agent-native/core create my-content-app --template content",
+      "npx @agent-native/core@latest create my-content-app --template content",
     demoUrl: "https://content.agent-native.com",
     description:
       "Write and organize documents with a rich editor, Notion import/export, and an AI agent that drafts, rewrites, and publishes to any CMS.",
@@ -49,7 +49,8 @@ export const templates = [
     name: "Slides",
     slug: "slides",
     replaces: "Replaces or augments Google Slides, Pitch",
-    cliCommand: "npx @agent-native/core create my-slides-app --template slides",
+    cliCommand:
+      "npx @agent-native/core@latest create my-slides-app --template slides",
     demoUrl: "https://slides.agent-native.com",
     description:
       "Generate full presentations from a prompt. Edit visually or conversationally. AI image generation, 8 layouts, and presentation mode built in.",
@@ -61,7 +62,8 @@ export const templates = [
     name: "Video",
     slug: "video",
     replaces: "Replaces or augments video editing",
-    cliCommand: "npx @agent-native/core create my-video-app --template videos",
+    cliCommand:
+      "npx @agent-native/core@latest create my-video-app --template videos",
     demoUrl: "https://videos.agent-native.com",
     description:
       "Build React-based video compositions with Remotion. Keyframe animation, 30+ easing curves, camera controls, and agent-assisted editing.",
@@ -74,7 +76,7 @@ export const templates = [
     slug: "analytics",
     replaces: "Replaces or augments Amplitude, Mixpanel, Looker",
     cliCommand:
-      "npx @agent-native/core create my-analytics-app --template analytics",
+      "npx @agent-native/core@latest create my-analytics-app --template analytics",
     demoUrl: "https://analytics.agent-native.com",
     description:
       "Connect any data source, prompt for any chart, build reusable dashboards. The agent writes SQL, generates visualizations, and evolves the app.",
@@ -86,7 +88,8 @@ export const templates = [
     name: "Mail",
     slug: "mail",
     replaces: "Replaces or augments Superhuman, Gmail",
-    cliCommand: "npx @agent-native/core create my-mail-app --template mail",
+    cliCommand:
+      "npx @agent-native/core@latest create my-mail-app --template mail",
     demoUrl: "https://mail.agent-native.com",
     description:
       "Superhuman-style email client with keyboard shortcuts, AI triage, multi-account support, and email automations. Own your inbox workflow.",
@@ -98,7 +101,8 @@ export const templates = [
     name: "Forms",
     slug: "forms",
     replaces: "Replaces or augments Typeform, Google Forms",
-    cliCommand: "npx @agent-native/core create my-forms-app --template forms",
+    cliCommand:
+      "npx @agent-native/core@latest create my-forms-app --template forms",
     demoUrl: "https://forms.agent-native.com",
     description:
       "Agent-native form builder. Generate forms from a prompt, edit fields visually or conversationally, and send submissions to Slack, Discord, Google Sheets, or webhooks.",
@@ -110,7 +114,8 @@ export const templates = [
     name: "Clips",
     slug: "clips",
     replaces: "Replaces or augments Loom, Granola, and Wisprflow",
-    cliCommand: "npx @agent-native/core create my-clips-app --template clips",
+    cliCommand:
+      "npx @agent-native/core@latest create my-clips-app --template clips",
     demoUrl: "https://clips.agent-native.com",
     description:
       "Screen recordings, calendar-synced meeting notes, and Fn-hold voice dictation — all transcribed, summarized, and searchable, with an agent that can edit any of it.",
@@ -123,7 +128,8 @@ export const templates = [
     slug: "brain",
     replaces:
       "Replaces or augments team wikis, Glean-style recall, and institutional memory tools",
-    cliCommand: "npx @agent-native/core create my-brain-app --template brain",
+    cliCommand:
+      "npx @agent-native/core@latest create my-brain-app --template brain",
     demoUrl: "https://brain.agent-native.com",
     description:
       "Full-page company chat over cited memory from approved Slack, Clips, Granola, GitHub, and transcript sources, with review gates, evals, and shared connection readiness built in.",
@@ -136,7 +142,8 @@ export const templates = [
     slug: "assets",
     replaces:
       "Replaces or augments DAMs, brand asset libraries, and AI media generators",
-    cliCommand: "npx @agent-native/core create my-assets-app --template assets",
+    cliCommand:
+      "npx @agent-native/core@latest create my-assets-app --template assets",
     demoUrl: "https://assets.agent-native.com",
     description:
       "Digital asset manager for uploads, brand libraries, searchable references, and on-brand image/video generation that other apps can call through A2A or embed as a picker.",
@@ -148,7 +155,8 @@ export const templates = [
     name: "Design",
     slug: "design",
     replaces: "Replaces or augments design prototyping tools",
-    cliCommand: "npx @agent-native/core create my-design-app --template design",
+    cliCommand:
+      "npx @agent-native/core@latest create my-design-app --template design",
     demoUrl: "https://design.agent-native.com",
     description:
       "Agent-native HTML prototyping studio. Generate interactive Alpine/Tailwind designs, compare variants, refine live tweak controls, and export the result.",
@@ -161,7 +169,7 @@ export const templates = [
     slug: "dispatch",
     replaces: "Mission control for your agent-native apps",
     cliCommand:
-      "npx @agent-native/core create my-dispatch-app --template dispatch",
+      "npx @agent-native/core@latest create my-dispatch-app --template dispatch",
     demoUrl: "https://dispatch.agent-native.com",
     description:
       "Centralized messaging and management for every agent in your stack. Talk to your agents from Slack, Telegram, or the web; route jobs, hold memory, approve actions, and delegate across apps over A2A.",

--- a/packages/docs/app/routes/download.tsx
+++ b/packages/docs/app/routes/download.tsx
@@ -345,7 +345,7 @@ export default function DownloadPage() {
             Linux.
           </p>
           <pre className="overflow-x-auto rounded-md bg-[var(--docs-code-bg,rgba(0,0,0,0.04))] px-4 py-3 text-xs">
-            <code>{`npx @agent-native/core create my-platform
+            <code>{`npx @agent-native/core@latest create my-platform
 cd my-platform
 pnpm install && pnpm dev`}</code>
           </pre>

--- a/packages/docs/app/routes/skills.tsx
+++ b/packages/docs/app/routes/skills.tsx
@@ -351,9 +351,14 @@ export default function SkillsPage() {
           <p className="mt-4 max-w-2xl text-sm leading-relaxed text-[var(--fg-secondary)]">
             The interactive install also offers this Action when no workflow is
             present. After the workflow is written, run{" "}
-            <code className="font-mono">agent-native recap setup</code> and{" "}
-            <code className="font-mono">agent-native recap doctor</code> to
-            configure and verify GitHub Actions.
+            <code className="font-mono">
+              npx @agent-native/core@latest recap setup
+            </code>{" "}
+            and{" "}
+            <code className="font-mono">
+              npx @agent-native/core@latest recap doctor
+            </code>{" "}
+            to configure and verify GitHub Actions.
           </p>
           <Link
             data-an-prefetch="render"

--- a/skills/visual-plans/SKILL.md
+++ b/skills/visual-plans/SKILL.md
@@ -89,7 +89,7 @@ inline output: the usual cause is a connector that did not finish connecting
 this session (it registers zero tools), not auth. Stop and give the user the
 exact restore step — reconnect via `/mcp` (or restart the session); only if
 genuinely unauthenticated, run
-`agent-native connect https://plan.agent-native.com`. Publish once the tool is
+`npx @agent-native/core@latest connect https://plan.agent-native.com`. Publish once the tool is
 reachable. Local-files privacy mode (after Tool Guidance) is the only
 exception.
 
@@ -282,7 +282,7 @@ The local-files contract is:
 - Write the plan as a local MDX folder under `plans/<slug>/`: `plan.mdx`,
   optional `canvas.mdx`, optional `prototype.mdx`, and optional
   `.plan-state.json`.
-- Run `agent-native plan local preview --dir plans/<slug> --kind plan` after
+- Run `npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind plan` after
   writing or updating the folder. Report the returned local URL or the
   `/local-plans/<slug>` route if the local Plan app is running with the same
   `PLAN_LOCAL_DIR`.
@@ -347,7 +347,7 @@ authenticates it in the same step (a one-time browser sign-in at setup — this 
 intended), so the first tool call does not hit an OAuth wall:
 
 ```bash
-agent-native skills add visual-plan
+npx @agent-native/core@latest skills add visual-plan
 ```
 
 After that, `/visual-plan` and `/visual-recap` are the two installed slash
@@ -355,7 +355,7 @@ commands. The other planning modes (`create-ui-plan`, `create-prototype-plan`,
 `create-plan-design`, `create-visual-questions`) are MCP tools reachable from
 `/visual-plan`, not separate slash commands. Pass `--no-connect` to register
 the connector without authenticating, then run
-`agent-native connect https://plan.agent-native.com` whenever you are ready.
+`npx @agent-native/core@latest connect https://plan.agent-native.com` whenever you are ready.
 
 **Browser (people you share with).** Open the Plans editor and create & edit
 with no sign-up — you work as a guest. Sign in only when you want to save or
@@ -370,7 +370,7 @@ hosted flow.
 
 If a Plans tool returns `needs auth`, `Unauthorized`, or `Session terminated`,
 do not keep retrying the tool. Authenticate the connector with
-`agent-native connect https://plan.agent-native.com` (OAuth-capable hosts can
+`npx @agent-native/core@latest connect https://plan.agent-native.com` (OAuth-capable hosts can
 instead re-run /mcp and choose Authenticate), then continue once the connector
 is available.
 

--- a/skills/visual-recap/SKILL.md
+++ b/skills/visual-recap/SKILL.md
@@ -29,14 +29,14 @@ exception to the hosted publish rule below.
 In local-files mode:
 
 - Read the diff/stat/source context from local files and shell commands only.
-  The existing `agent-native recap collect-diff`, `scan`, and
+  The existing `npx @agent-native/core@latest recap collect-diff`, `scan`, and
   `build-prompt --local-files` helpers are safe to use because they operate on
   local files and do not write to the Plan database.
 - Write the recap as a local MDX folder under `plans/<slug>/`: `plan.mdx`,
   optional `canvas.mdx`, optional `prototype.mdx`, and optional
   `.plan-state.json`. Set `kind: "recap"` and `localOnly: true` in
   frontmatter/state when authoring the source.
-- Run `agent-native plan local preview --dir plans/<slug> --kind recap` after
+- Run `npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind recap` after
   writing or updating the folder. Report the returned local URL or the
   `/local-plans/<slug>` route if the local Plan app is running with the same
   `PLAN_LOCAL_DIR`.
@@ -74,7 +74,7 @@ connector that did not finish connecting this session (it registers zero tools),
 NOT necessarily an auth problem — so do not assume the user must authenticate.
 Stop and tell the user how to restore it: reconnect the Plan MCP connector (in
 Claude Code, run `/mcp` and reconnect, or restart the session); only if it is
-genuinely unauthenticated, run `agent-native connect <plan-app-url>` or
+genuinely unauthenticated, run `npx @agent-native/core@latest connect <plan-app-url>` or
 re-authenticate via `/mcp`. Then publish once the tool is reachable. Falling
 back to inline content is a defect, not a degraded mode.
 
@@ -251,7 +251,7 @@ a headless CI agent), state that in the recap handoff instead.
 ## Open And Report The Recap
 
 In local-files privacy mode, report the local preview URL/path from
-`agent-native plan local preview` or the `/local-plans/<slug>` route for a local
+`npx @agent-native/core@latest plan local preview` or the `/local-plans/<slug>` route for a local
 Plan app using the same `PLAN_LOCAL_DIR`. Do not invent a hosted URL and do not
 publish just to get an absolute Plan link.
 

--- a/templates/calendar/app/hooks/use-events.test.ts
+++ b/templates/calendar/app/hooks/use-events.test.ts
@@ -6,6 +6,7 @@ import {
   mergeCalendarEventIntoList,
   removeOptimisticCalendarEventFromList,
 } from "./event-list-cache";
+import { shouldShowEventsSkeleton } from "./use-events";
 
 function calendarEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
   return {
@@ -214,5 +215,59 @@ describe("calendar event list cache helpers", () => {
       ["future", "tentative"],
       ["other-series", "accepted"],
     ]);
+  });
+});
+
+describe("shouldShowEventsSkeleton", () => {
+  const week = "2026-05-18T00:00:00.000Z|2026-05-24T23:59:59.999Z";
+  const nextWeek = "2026-05-25T00:00:00.000Z|2026-05-31T23:59:59.999Z";
+
+  it("shows the skeleton on the very first load (pending, no data)", () => {
+    expect(
+      shouldShowEventsSkeleton({
+        isLoading: true,
+        isPlaceholderData: false,
+        settledRangeKey: null,
+        rangeKey: week,
+      }),
+    ).toBe(true);
+  });
+
+  it("shows the skeleton when navigating to a new, unfetched date range", () => {
+    // keepPreviousData serves last week's events as placeholder while next week
+    // loads — showing them in next week's grid would be wrong, so we skeleton.
+    expect(
+      shouldShowEventsSkeleton({
+        isLoading: false,
+        isPlaceholderData: true,
+        settledRangeKey: week,
+        rangeKey: nextWeek,
+      }),
+    ).toBe(true);
+  });
+
+  it("does NOT show the skeleton when only the calendar set changes (the bug)", () => {
+    // Removing/adding a feed or person overlay changes the query key but not the
+    // date range. keepPreviousData keeps the user's events on screen, so we must
+    // keep showing them rather than wiping the calendar behind a skeleton.
+    expect(
+      shouldShowEventsSkeleton({
+        isLoading: false,
+        isPlaceholderData: true,
+        settledRangeKey: week,
+        rangeKey: week,
+      }),
+    ).toBe(false);
+  });
+
+  it("does NOT show the skeleton during a same-range background refetch", () => {
+    expect(
+      shouldShowEventsSkeleton({
+        isLoading: false,
+        isPlaceholderData: false,
+        settledRangeKey: week,
+        rangeKey: week,
+      }),
+    ).toBe(false);
   });
 });

--- a/templates/calendar/app/hooks/use-events.ts
+++ b/templates/calendar/app/hooks/use-events.ts
@@ -127,6 +127,37 @@ function updateListEventQueries(
   }
 }
 
+/**
+ * Decide whether to show the full-page events skeleton.
+ *
+ * The skeleton should appear only when there is nothing meaningful to show for
+ * the *current date range* — the very first load, or navigating to a range we
+ * have not fetched yet. When only the *set* of calendars or person overlays
+ * changes (adding/removing a feed or person), the events query key changes and
+ * `keepPreviousData` keeps the user's existing events on screen as placeholder
+ * data; flashing a skeleton over them — wiping the calendar for several seconds
+ * — is the bug we are avoiding. In that case we keep the events visible and let
+ * the refreshed set merge in.
+ *
+ * `settledRangeKey` is the date range we last had real (non-placeholder) data
+ * for; comparing it to the current `rangeKey` tells a genuine range change
+ * apart from a same-range refetch triggered by a calendar toggle.
+ */
+export function shouldShowEventsSkeleton({
+  isLoading,
+  isPlaceholderData,
+  settledRangeKey,
+  rangeKey,
+}: {
+  isLoading: boolean;
+  isPlaceholderData: boolean;
+  settledRangeKey: string | null;
+  rangeKey: string;
+}): boolean {
+  if (isLoading) return true;
+  return isPlaceholderData && settledRangeKey !== rangeKey;
+}
+
 export function useEvents(
   from?: string,
   to?: string,

--- a/templates/calendar/app/hooks/use-external-calendars.ts
+++ b/templates/calendar/app/hooks/use-external-calendars.ts
@@ -1,6 +1,12 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { callAction, useActionQuery } from "@agent-native/core/client";
-import type { ExternalCalendar } from "@shared/api";
+import type { CalendarEvent, ExternalCalendar } from "@shared/api";
+
+const EXTERNAL_CALENDARS_KEY = [
+  "action",
+  "list-external-calendars",
+  undefined,
+] as const;
 
 export function useExternalCalendars() {
   return useActionQuery<ExternalCalendar[]>("list-external-calendars");
@@ -16,7 +22,17 @@ export function useAddExternalCalendar() {
         throw new Error("Failed to add calendar");
       }
     },
-    onSuccess: () => {
+    onSuccess: (created) => {
+      // Surface the new calendar in the sidebar immediately, then let the
+      // events query refetch in the background. The calendar view keeps the
+      // user's existing events visible and shows a small spinner while the new
+      // feed's events stream in — no skeleton over everything.
+      if (created) {
+        queryClient.setQueryData<ExternalCalendar[]>(
+          EXTERNAL_CALENDARS_KEY,
+          (old) => (old ? [...old, created] : [created]),
+        );
+      }
       queryClient.invalidateQueries({
         queryKey: ["action", "list-external-calendars"],
       });
@@ -67,11 +83,55 @@ export function useRemoveExternalCalendar() {
         throw new Error("Failed to remove calendar");
       }
     },
-    onSuccess: () => {
+    // Removal is instant: drop the calendar from the sidebar and strip just its
+    // events out of every cached range. The user's own events stay exactly
+    // where they are — no skeleton, and we deliberately do NOT invalidate
+    // `list-events` (a full multi-source refetch is what made everything blink
+    // out for several seconds). The cache is already correct; later navigation
+    // refetches naturally.
+    onMutate: async (id: string) => {
+      await queryClient.cancelQueries({ queryKey: ["action", "list-events"] });
+      const previousCalendars = queryClient.getQueryData<ExternalCalendar[]>(
+        EXTERNAL_CALENDARS_KEY,
+      );
+      const previousEvents = queryClient.getQueriesData<CalendarEvent[]>({
+        queryKey: ["action", "list-events"],
+      });
+
+      queryClient.setQueryData<ExternalCalendar[]>(
+        EXTERNAL_CALENDARS_KEY,
+        (old) => old?.filter((c) => c.id !== id),
+      );
+      const prefix = `ical-${id}-`;
+      queryClient.setQueriesData<CalendarEvent[]>(
+        { queryKey: ["action", "list-events"] },
+        (old) => old?.filter((e) => !e.id.startsWith(prefix)),
+      );
+
+      return { previousCalendars, previousEvents };
+    },
+    onError: (_err, _id, context) => {
+      const ctx = context as
+        | {
+            previousCalendars?: ExternalCalendar[];
+            previousEvents?: Array<
+              [readonly unknown[], CalendarEvent[] | undefined]
+            >;
+          }
+        | undefined;
+      if (ctx?.previousCalendars) {
+        queryClient.setQueryData(EXTERNAL_CALENDARS_KEY, ctx.previousCalendars);
+      }
+      if (ctx?.previousEvents) {
+        for (const [key, data] of ctx.previousEvents) {
+          queryClient.setQueryData(key, data);
+        }
+      }
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: ["action", "list-external-calendars"],
       });
-      queryClient.invalidateQueries({ queryKey: ["action", "list-events"] });
     },
   });
 }

--- a/templates/calendar/app/hooks/use-overlay-people.ts
+++ b/templates/calendar/app/hooks/use-overlay-people.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { callAction, useActionQuery } from "@agent-native/core/client";
-import type { OverlayPerson } from "@shared/api";
+import type { CalendarEvent, OverlayPerson } from "@shared/api";
 import { getNextOverlayColor } from "@/lib/overlay-colors";
+
+const OVERLAY_PEOPLE_KEY = ["action", "get-overlay-people", undefined] as const;
 
 export function useOverlayPeople() {
   return useActionQuery<OverlayPerson[]>("get-overlay-people");
@@ -74,8 +76,7 @@ export function useRemoveOverlayPerson() {
   return useMutation({
     mutationFn: async (email: string) => {
       const current: OverlayPerson[] =
-        queryClient.getQueryData(["action", "get-overlay-people", undefined]) ??
-        [];
+        queryClient.getQueryData(OVERLAY_PEOPLE_KEY) ?? [];
       const updated = current.filter((p) => p.email !== email);
       try {
         await callAction<OverlayPerson[]>(
@@ -88,12 +89,49 @@ export function useRemoveOverlayPerson() {
       }
       return updated;
     },
-    onSuccess: (data) => {
-      queryClient.setQueryData(
-        ["action", "get-overlay-people", undefined],
-        data,
+    // Removal is instant. Dropping a person changes the events query key
+    // (overlayEmails), so the calendar shows the previous range's data as a
+    // placeholder while it refetches — we strip this person's events out of
+    // every cached range up front so they vanish immediately instead of
+    // lingering until the refetch lands. The user's own events stay put.
+    onMutate: async (email: string) => {
+      await queryClient.cancelQueries({ queryKey: ["action", "list-events"] });
+      const previousPeople =
+        queryClient.getQueryData<OverlayPerson[]>(OVERLAY_PEOPLE_KEY);
+      const previousEvents = queryClient.getQueriesData<CalendarEvent[]>({
+        queryKey: ["action", "list-events"],
+      });
+
+      queryClient.setQueryData<OverlayPerson[]>(OVERLAY_PEOPLE_KEY, (old) =>
+        old?.filter((p) => p.email !== email),
       );
-      queryClient.invalidateQueries({ queryKey: ["action", "list-events"] });
+      queryClient.setQueriesData<CalendarEvent[]>(
+        { queryKey: ["action", "list-events"] },
+        (old) => old?.filter((e) => e.overlayEmail !== email),
+      );
+
+      return { previousPeople, previousEvents };
+    },
+    onError: (_err, _email, context) => {
+      const ctx = context as
+        | {
+            previousPeople?: OverlayPerson[];
+            previousEvents?: Array<
+              [readonly unknown[], CalendarEvent[] | undefined]
+            >;
+          }
+        | undefined;
+      if (ctx?.previousPeople) {
+        queryClient.setQueryData(OVERLAY_PEOPLE_KEY, ctx.previousPeople);
+      }
+      if (ctx?.previousEvents) {
+        for (const [key, data] of ctx.previousEvents) {
+          queryClient.setQueryData(key, data);
+        }
+      }
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(OVERLAY_PEOPLE_KEY, data);
     },
   });
 }

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -40,6 +40,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { Spinner } from "@/components/ui/spinner";
 import { MonthView } from "@/components/calendar/MonthView";
 import { WeekView } from "@/components/calendar/WeekView";
 import { DayView } from "@/components/calendar/DayView";
@@ -60,6 +61,7 @@ import {
   useUpdateEvent,
   useDeleteEvent,
   prefetchEvents,
+  shouldShowEventsSkeleton,
 } from "@/hooks/use-events";
 import { useOverlayPeople } from "@/hooks/use-overlay-people";
 import { useGoogleAuthStatus } from "@/hooks/use-google-auth";
@@ -361,6 +363,7 @@ export default function CalendarView() {
     data: rawEventsData,
     error: eventsError,
     isLoading,
+    isFetching,
     isPlaceholderData,
   } = useEvents(from, to, overlayEmails);
   const rawEvents = Array.isArray(rawEventsData) ? rawEventsData : [];
@@ -418,9 +421,32 @@ export default function CalendarView() {
     }
   }, [isLoading, viewMode, selectedDate, overlayEmails, queryClient]);
 
-  // Show skeleton only when loading with no cached data (new date range).
-  // Tab refocus keeps cached data visible and refetches in background.
-  const eventsLoading = isLoading || isPlaceholderData;
+  // Show the skeleton only when there is genuinely nothing to show for the
+  // current date range — the first load, or navigating to a range we have not
+  // fetched yet. Crucially, do NOT show it when only the *set* of calendars
+  // changes (adding/removing a feed or person overlay). Those swaps change the
+  // query key, so `keepPreviousData` keeps the user's existing events on screen
+  // as placeholder data; flashing a skeleton over them is the bug. Instead we
+  // keep the events visible and let the refreshed set merge in. We track the
+  // last date range we settled real (non-placeholder) data for, so a skeleton
+  // only appears when the range itself differs.
+  const rangeKey = `${from}|${to}`;
+  const settledRangeRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isLoading && !isPlaceholderData) {
+      settledRangeRef.current = rangeKey;
+    }
+  }, [isLoading, isPlaceholderData, rangeKey]);
+  const eventsLoading = shouldShowEventsSkeleton({
+    isLoading,
+    isPlaceholderData,
+    settledRangeKey: settledRangeRef.current,
+    rangeKey,
+  });
+  // A quiet background refresh is in flight (e.g. a newly added calendar's
+  // events are still loading) while the existing events stay visible. Drives a
+  // small non-blocking spinner instead of hiding everything behind a skeleton.
+  const eventsRefreshing = isFetching && !eventsLoading;
 
   // Apply overlay colors and filter hidden calendars
   const events = useMemo(() => {
@@ -1320,6 +1346,13 @@ export default function CalendarView() {
               <span className="ml-0.5 min-w-0 flex-1 truncate whitespace-nowrap text-center text-xs font-semibold sm:ml-1 sm:text-sm">
                 {headerLabel}
               </span>
+
+              {eventsRefreshing && (
+                <Spinner
+                  className="ml-1 size-3.5 shrink-0 text-muted-foreground"
+                  aria-label="Loading calendars"
+                />
+              )}
             </div>
 
             {/* Right: search, new event */}

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -421,6 +421,14 @@ pub async fn native_fullscreen_recording_stop_and_upload(
         multi_segment,
     } = take_and_finalize_active_session(&state)?;
 
+    // The camera bubble is the ONE overlay we deliberately leave
+    // capture-included (see `show_bubble`), so it has to stay on-screen
+    // until the SCStream stops. Now that capture is finalized, tear it
+    // down immediately — otherwise the user's face keeps floating in the
+    // corner through the (multi-second) finalize + upload phase, reading
+    // as "still recording" while the bottom-left card says "processing".
+    let _ = crate::clips::close_bubble(app.clone()).await;
+
     let mut saved = saved_recording_from_session(
         &session,
         &server_url,
@@ -506,6 +514,9 @@ pub async fn native_fullscreen_recording_stop_and_save(
         consolidate_outcome,
         multi_segment,
     } = take_and_finalize_active_session(&state)?;
+    // Capture is finalized — drop the camera bubble now so the face
+    // doesn't linger while the clip saves (mirrors the upload path).
+    let _ = crate::clips::close_bubble(app.clone()).await;
     if let Err(err) = &stop_outcome {
         eprintln!(
             "[clips-tray] native local recording stop reported an error; attempting to save file anyway: {err}"

--- a/templates/mail/app/root.tsx
+++ b/templates/mail/app/root.tsx
@@ -14,12 +14,14 @@ import { AppLayout } from "@/components/layout/AppLayout";
 import { useDbSync } from "@agent-native/core";
 import {
   AppProviders,
+  RequireSession,
   appPath,
   appApiPath,
   createAgentNativeQueryClient,
   getThemeInitScript,
 } from "@agent-native/core/client";
 import { TAB_ID } from "@/lib/tab-id";
+import { isMcpEmbedSurface } from "@/lib/mcp-embed";
 import { markExternalEmailRefresh } from "@/hooks/use-emails";
 import { Button } from "@/components/ui/button";
 import type { LinksFunction } from "react-router";
@@ -261,13 +263,15 @@ export default function Root() {
       tooltipDelayDuration={300}
       toaster={MAIL_TOASTER}
     >
-      <AutoFocus />
-      <AutomationTrigger />
-      <VisibilityRefresh />
-      <DbSyncSetup />
-      <AppLayout>
-        <Outlet />
-      </AppLayout>
+      <RequireSession bypass={isMcpEmbedSurface()}>
+        <AutoFocus />
+        <AutomationTrigger />
+        <VisibilityRefresh />
+        <DbSyncSetup />
+        <AppLayout>
+          <Outlet />
+        </AppLayout>
+      </RequireSession>
     </AppProviders>
   );
 }

--- a/templates/plan/.agents/skills/visual-plan/SKILL.md
+++ b/templates/plan/.agents/skills/visual-plan/SKILL.md
@@ -89,7 +89,7 @@ inline output: the usual cause is a connector that did not finish connecting
 this session (it registers zero tools), not auth. Stop and give the user the
 exact restore step — reconnect via `/mcp` (or restart the session); only if
 genuinely unauthenticated, run
-`agent-native connect https://plan.agent-native.com`. Publish once the tool is
+`npx @agent-native/core@latest connect https://plan.agent-native.com`. Publish once the tool is
 reachable. Local-files privacy mode (after Tool Guidance) is the only
 exception.
 
@@ -282,7 +282,7 @@ The local-files contract is:
 - Write the plan as a local MDX folder under `plans/<slug>/`: `plan.mdx`,
   optional `canvas.mdx`, optional `prototype.mdx`, and optional
   `.plan-state.json`.
-- Run `agent-native plan local preview --dir plans/<slug> --kind plan` after
+- Run `npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind plan` after
   writing or updating the folder. Report the returned local URL or the
   `/local-plans/<slug>` route if the local Plan app is running with the same
   `PLAN_LOCAL_DIR`.
@@ -347,7 +347,7 @@ authenticates it in the same step (a one-time browser sign-in at setup — this 
 intended), so the first tool call does not hit an OAuth wall:
 
 ```bash
-agent-native skills add visual-plan
+npx @agent-native/core@latest skills add visual-plan
 ```
 
 After that, `/visual-plan` and `/visual-recap` are the two installed slash
@@ -355,7 +355,7 @@ commands. The other planning modes (`create-ui-plan`, `create-prototype-plan`,
 `create-plan-design`, `create-visual-questions`) are MCP tools reachable from
 `/visual-plan`, not separate slash commands. Pass `--no-connect` to register
 the connector without authenticating, then run
-`agent-native connect https://plan.agent-native.com` whenever you are ready.
+`npx @agent-native/core@latest connect https://plan.agent-native.com` whenever you are ready.
 
 **Browser (people you share with).** Open the Plans editor and create & edit
 with no sign-up — you work as a guest. Sign in only when you want to save or
@@ -370,7 +370,7 @@ hosted flow.
 
 If a Plans tool returns `needs auth`, `Unauthorized`, or `Session terminated`,
 do not keep retrying the tool. Authenticate the connector with
-`agent-native connect https://plan.agent-native.com` (OAuth-capable hosts can
+`npx @agent-native/core@latest connect https://plan.agent-native.com` (OAuth-capable hosts can
 instead re-run /mcp and choose Authenticate), then continue once the connector
 is available.
 

--- a/templates/plan/.agents/skills/visual-recap/SKILL.md
+++ b/templates/plan/.agents/skills/visual-recap/SKILL.md
@@ -29,14 +29,14 @@ exception to the hosted publish rule below.
 In local-files mode:
 
 - Read the diff/stat/source context from local files and shell commands only.
-  The existing `agent-native recap collect-diff`, `scan`, and
+  The existing `npx @agent-native/core@latest recap collect-diff`, `scan`, and
   `build-prompt --local-files` helpers are safe to use because they operate on
   local files and do not write to the Plan database.
 - Write the recap as a local MDX folder under `plans/<slug>/`: `plan.mdx`,
   optional `canvas.mdx`, optional `prototype.mdx`, and optional
   `.plan-state.json`. Set `kind: "recap"` and `localOnly: true` in
   frontmatter/state when authoring the source.
-- Run `agent-native plan local preview --dir plans/<slug> --kind recap` after
+- Run `npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind recap` after
   writing or updating the folder. Report the returned local URL or the
   `/local-plans/<slug>` route if the local Plan app is running with the same
   `PLAN_LOCAL_DIR`.
@@ -74,7 +74,7 @@ connector that did not finish connecting this session (it registers zero tools),
 NOT necessarily an auth problem — so do not assume the user must authenticate.
 Stop and tell the user how to restore it: reconnect the Plan MCP connector (in
 Claude Code, run `/mcp` and reconnect, or restart the session); only if it is
-genuinely unauthenticated, run `agent-native connect <plan-app-url>` or
+genuinely unauthenticated, run `npx @agent-native/core@latest connect <plan-app-url>` or
 re-authenticate via `/mcp`. Then publish once the tool is reachable. Falling
 back to inline content is a defect, not a degraded mode.
 
@@ -251,7 +251,7 @@ a headless CI agent), state that in the recap handoff instead.
 ## Open And Report The Recap
 
 In local-files privacy mode, report the local preview URL/path from
-`agent-native plan local preview` or the `/local-plans/<slug>` route for a local
+`npx @agent-native/core@latest plan local preview` or the `/local-plans/<slug>` route for a local
 Plan app using the same `PLAN_LOCAL_DIR`. Do not invent a hosted URL and do not
 publish just to get an absolute Plan link.
 

--- a/templates/plan/README.md
+++ b/templates/plan/README.md
@@ -16,12 +16,6 @@ client-specific auth/setup flow in one step:
 npx @agent-native/core@latest skills add visual-plan
 ```
 
-If you already have the CLI installed, the shorter command is equivalent:
-
-```sh
-agent-native skills add visual-plan
-```
-
 You do not need to wire the MCP server separately.
 
 Supported aliases include:
@@ -116,7 +110,7 @@ When you install Plans interactively, the CLI asks whether you also want the PR
 Visual Recap GitHub Action. You can add it explicitly at any time:
 
 ```sh
-agent-native skills add visual-plan --with-github-action
+npx @agent-native/core@latest skills add visual-plan --with-github-action
 ```
 
 That writes `.github/workflows/pr-visual-recap.yml`. Then run the setup helper to
@@ -124,8 +118,8 @@ configure GitHub Actions secrets/variables where possible and print any missing
 manual steps:
 
 ```sh
-agent-native recap setup
-agent-native recap doctor
+npx @agent-native/core@latest recap setup
+npx @agent-native/core@latest recap doctor
 ```
 
 The hosted default needs `PLAN_RECAP_TOKEN` plus `ANTHROPIC_API_KEY` for the


### PR DESCRIPTION
Ships the current local changes on `changes-230` as one batch.

## Docs & skills — CLI command refresh
Replace bare `agent-native …` invocations with `npx @agent-native/core@latest …` across `skills.ts`, the mirrored `SKILL.md` copies, `README.md`, and `packages/core/docs/content/*`. Copy-paste commands now work without a global install. The workspace-core skill mirror is re-synced so the `guard:workspace-skills` byte-identity check passes.

## core — `RequireSession` client gate (`@agent-native/core`, patch)
New reusable client gate so a logged-out visitor on a **cached / statically-served SPA shell** (or a client-side navigation after the session expired) is redirected to the framework sign-in page instead of being stuck on an infinite loading spinner. The server-side auth guard only protects requests that actually reach the Nitro function, so that path was uncovered.

- Exported from `@agent-native/core/client` (`RequireSession`, `buildSignInReturnHref`).
- Supports `bypass` for embed/popout surfaces that authenticate by another mechanism.
- Mail wraps its private shell with `<RequireSession bypass={isMcpEmbedSurface()}>`.
- Login HTML is no longer CDN-cached (`private, no-store`) so it always reflects live server config (e.g. whether `GOOGLE_CLIENT_ID` is set). Cache-header tests updated to match.

## core — service-token org fallback (`@agent-native/core`, patch)
Service-token mint now auto-resolves the org from the caller's membership when the bearer token carries no org context (e.g. a personal connect token minted before the user joined an org). Errors clearly on **0 orgs** (400, "join or create an organization") and **multiple orgs** (400, "re-authenticate with an org-scoped session"). Added test coverage for both new paths plus the single-org resolution.

## calendar — optimistic add/remove of external calendars
Adding a feed surfaces it in the sidebar immediately and lets events stream in the background; removing a feed drops it from the sidebar and strips just its events from every cached range instead of a full multi-source `list-events` refetch that blanked the whole grid for several seconds. Optimistic state rolls back on error.

## docs site
`TemplateCard` / `download` / `skills` route polish.

## Verification
`pnpm run prep` (fmt + typecheck + full test suite + all guards) passes locally.