### PR TITLE
Fix Netlify production deploys silently skipped by shared deploy-preview cache

### DIFF
--- a/scripts/netlify-ignore-build.mjs
+++ b/scripts/netlify-ignore-build.mjs
@@ -145,19 +145,61 @@ function commitExists(ref) {
   }
 }
 
+function isAncestor(ancestorRef, descendantRef) {
+  try {
+    git(["merge-base", "--is-ancestor", ancestorRef, descendantRef]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function firstParent(ref) {
+  try {
+    return git(["rev-parse", `${ref}^1`]);
+  } catch {
+    return null;
+  }
+}
+
 function changedFiles() {
   const cachedRef = process.env.CACHED_COMMIT_REF;
   const commitRef = process.env.COMMIT_REF;
 
-  if (!commitExists(cachedRef) || !commitExists(commitRef)) {
+  if (!commitExists(commitRef)) {
     console.log(
-      "[netlify-ignore] Build required: Netlify did not provide comparable commit refs.",
+      "[netlify-ignore] Build required: Netlify did not provide a comparable commit ref.",
     );
     return null;
   }
 
+  // Pick the base commit to diff against. Normally that's CACHED_COMMIT_REF
+  // (the last commit Netlify built for this site). BUT Netlify shares the build
+  // cache across deploy contexts: after a PR's deploy-preview builds, the
+  // production deploy of the squash-merge commit inherits CACHED_COMMIT_REF =
+  // the preview head. That commit has an identical tree to the merge commit, so
+  // the diff comes back empty and the site is wrongly skipped ("no content
+  // change") even though the change really did land on main. Detect that case —
+  // the cached ref is missing or is NOT an ancestor of the commit being built —
+  // and diff against the commit's first parent instead (the true previous state
+  // on this branch), so per-site change detection stays correct on production.
+  let baseRef = cachedRef;
+  if (!commitExists(cachedRef) || !isAncestor(cachedRef, commitRef)) {
+    const parent = firstParent(commitRef);
+    if (!parent) {
+      console.log(
+        "[netlify-ignore] Build required: no usable comparison base (cached ref unusable and commit has no parent).",
+      );
+      return null;
+    }
+    console.log(
+      `[netlify-ignore] CACHED_COMMIT_REF ${cachedRef || "(unset)"} is not an ancestor of ${commitRef} (shared deploy-preview cache); diffing against parent ${parent.slice(0, 8)} instead.`,
+    );
+    baseRef = parent;
+  }
+
   try {
-    return git(["diff", "--name-only", cachedRef, commitRef])
+    return git(["diff", "--name-only", baseRef, commitRef])
       .split("\n")
       .map((file) => normalizePath(file.trim()))
       .filter(Boolean);


### PR DESCRIPTION
## The incident

Production deploys on \`main\` have been silently **canceled** across many agent-native sites (mail, calendar, and others) with the status **"Canceled build due to no content change."** The sites are stuck on stale builds — e.g. mail never picked up its env vars or the merged SSR fix, so the app is broken.

## Root cause

Netlify shares its **per-site build cache across deploy contexts**. When a PR's deploy-preview builds successfully, it caches the PR head commit. After the PR squash-merges, the **production deploy of the merge commit inherits `CACHED_COMMIT_REF` = the preview head**.

The squash-merge commit has an **identical file tree** to the preview head, so `scripts/netlify-ignore-build.mjs` computes an empty `git diff` → decides "no content change" → Netlify cancels the production deploy. Every PR that got a green deploy-preview skips its own production deploy.

Reproduced exactly:
```
$ git diff --name-only <pr-head> <squash-merge-commit>   # → 0 files
$ git merge-base --is-ancestor <pr-head> <squash-merge>  # → NO (cross-branch)
$ CACHED_COMMIT_REF=<pr-head> COMMIT_REF=<squash-merge> node scripts/netlify-ignore-build.mjs mail
[netlify-ignore] Skipping mail: no changes in ...   # ← the bug
```

## The fix

When `CACHED_COMMIT_REF` is missing or **is not an ancestor** of the commit being built (the preview-cache case), diff against the commit's **first parent** — the true previous state on the branch — instead of the polluted cache ref. Genuine sequential production deploys (cached ref is a real ancestor) keep the per-site skip optimization unchanged.

Verified:
- Preview-cache case → site now **builds** (was wrongly skipped)
- Unaffected site on a single-template commit → still **skips** (optimization preserved)
- Affected site → **builds**

## Bonus

This commit touches `scripts/netlify-ignore-build.mjs`, which is in the global watched-paths list for **every** site — so merging it triggers a correct full-fleet redeploy, clearing all the currently-stuck sites in one go.