### PR TITLE
Add All/Generated/References tabs to library view

### DIFF
--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -34,7 +34,21 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DEFAULT_LIBRARY_PRESETS } from "../../shared/library-presets";
+
+type AssetTab = "all" | "generated" | "references";
+
+function isGeneratedAsset(asset: Asset) {
+  const role = asset.role ?? "";
+  return role === "generated" || role === "active" || role === "candidate";
+}
+
+function assetMatchesTab(asset: Asset, tab: AssetTab) {
+  if (tab === "all") return true;
+  if (tab === "generated") return isGeneratedAsset(asset);
+  return !isGeneratedAsset(asset);
+}
 
 const ASPECT_RATIOS = ["16:9", "1:1", "9:16", "4:3", "3:4", "21:9"] as const;
 const GENERATION_COUNTS = [1, 2, 3, 4, 6] as const;
@@ -47,6 +61,7 @@ type PickerMediaType = "image" | "video";
 type Asset = {
   id: string;
   libraryId: string;
+  role?: string | null;
   title?: string | null;
   description?: string | null;
   altText?: string | null;
@@ -571,6 +586,7 @@ export default function AssetPicker() {
   );
   const [presetId, setPresetId] = useState(() => hostConfig.presetId ?? "none");
   const [count, setCount] = useState(() => hostConfig.count ?? 3);
+  const [assetTab, setAssetTab] = useState<AssetTab>("all");
   const [selectedLibraryId, setSelectedLibraryId] = useState(
     () => hostConfig.libraryId ?? "",
   );
@@ -752,11 +768,15 @@ export default function AssetPicker() {
         .some((value) => String(value).toLowerCase().includes(needle)),
     );
   }, [query, starterAssets]);
-  const assets = usingStarterLibrary
+  const allAssets = usingStarterLibrary
     ? mediaType === "image"
       ? visibleStarterAssets
       : []
     : (assetData?.assets ?? []);
+  const assets = useMemo(
+    () => allAssets.filter((asset) => assetMatchesTab(asset, assetTab)),
+    [allAssets, assetTab],
+  );
   const [standaloneSelection, setStandaloneSelection] = useState<ReturnType<
     typeof assetPayload
   > | null>(null);
@@ -1248,6 +1268,20 @@ export default function AssetPicker() {
       )}
 
       <main className="min-h-0 flex-1 overflow-y-auto p-3">
+        {selectedLibraryId && (
+          <Tabs
+            value={assetTab}
+            onValueChange={(value) => setAssetTab(value as AssetTab)}
+            className="mb-3"
+          >
+            <TabsList>
+              <TabsTrigger value="all">All</TabsTrigger>
+              <TabsTrigger value="generated">Generated</TabsTrigger>
+              <TabsTrigger value="references">References</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        )}
+
         {!selectedLibraryId && (
           <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
             <Button asChild variant="outline">

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -549,7 +549,7 @@ function AssetThumbnail({ asset }: { asset: Asset }) {
       src={displayUrl}
       crossOrigin={isCrossOriginPreview(displayUrl) ? "anonymous" : undefined}
       alt={asset.altText ?? asset.title ?? ""}
-      className="h-full w-full object-cover transition group-hover:scale-[1.02]"
+      className="h-full w-full object-contain transition group-hover:scale-[1.02]"
       onError={tryNextSource}
     />
   );


### PR DESCRIPTION
### Summary
Adds three filter tabs ("All", "Generated", "References") to the library asset picker and changes asset thumbnails to use `object-contain` instead of `object-cover`.

### Problem
The library displayed all assets in a single flat list with no way to distinguish between AI-generated assets and reference/uploaded assets. Users had no quick way to filter by asset origin.

### Solution
Introduce a tab bar above the asset grid that filters assets by their `role` field. Assets with roles `generated`, `active`, or `candidate` are classified as "Generated"; all others fall under "References". The "All" tab shows everything unfiltered.

### Old UI
<img width="1419" height="865" alt="image" src="https://github.com/user-attachments/assets/bda03666-93bb-45eb-81e3-35bbc033dfed" />


### New UI
<img width="952" height="379" alt="image" src="https://github.com/user-attachments/assets/898a9b34-1eb7-4aac-9ea9-46885e9a9a04" />




### Key Changes
- Added `AssetTab` type (`"all" | "generated" | "references"`) and helper functions `isGeneratedAsset` and `assetMatchesTab` to classify assets by role
- Added `role` field to the `Asset` type
- Introduced `assetTab` state and a `useMemo`-filtered `assets` list derived from `allAssets`
- Rendered a `Tabs` / `TabsList` / `TabsTrigger` component above the asset grid (only shown when a library is selected)
- Changed asset thumbnail image from `object-cover` to `object-contain` so images are fully visible within their containers


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/ice-bridge-cp92znbi"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-ice-bridge-cp92znbi_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1150`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>ice-bridge-cp92znbi</branchName>-->