### PR TITLE
Add local file sync surfaces

### DIFF
--- a/.changeset/core-local-file-sync-docs.md
+++ b/.changeset/core-local-file-sync-docs.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Document deployment code-execution settings and local file sync surfaces.

--- a/docs/neon-netlify-integration.md
+++ b/docs/neon-netlify-integration.md
@@ -32,6 +32,24 @@ The Neon/Netlify specifics live in the workflow and each template's
 | `NETLIFY_AUTH_TOKEN` | Netlify User Settings → Personal Access Token |
 | `NETLIFY_ACCOUNT_ID` | Netlify team settings → Team ID               |
 
+## Restoring production env vars
+
+Preview DB overrides are managed by GitHub Actions, but production template
+secrets are not. If a Netlify project loses its env vars during a migration,
+restore them from the local ignored template env files:
+
+```bash
+pnpm sync:netlify-env -- --template clips
+NETLIFY_AUTH_TOKEN=... NETLIFY_ACCOUNT_ID=... pnpm sync:netlify-env -- --template clips --write
+```
+
+The script is dry-run by default, logs key names only, writes the production
+context, and marks real secrets as Netlify secret values while leaving public
+deployment metadata plain so Netlify's secret scanner does not block deploys.
+It merges `templates/<name>/.env` and `templates/<name>/.env.local` because
+some deploy-relevant auth keys, such as `BETTER_AUTH_SECRET`, currently live in
+`.env.local`. Pass `--all` to restore every known template site.
+
 ## Site ↔ Neon project mapping
 
 Defined in the workflow's matrix. Update it when adding a new hosted template.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "guard:no-error-string-returns": "node scripts/guard-no-error-string-returns.mjs",
     "guard:no-action-twin-routes": "node scripts/guard-no-action-twin-routes.mjs",
     "guards": "pnpm guard:no-drizzle-push && pnpm guard:no-unscoped-queries && pnpm guard:no-env-credentials && pnpm guard:no-unscoped-credentials && pnpm guard:no-env-mutation && pnpm guard:no-localhost-fallback && pnpm guard:google-auth-redirects && pnpm guard:db-tool-scoping && pnpm guard:template-list && pnpm guard:workspace-skills && pnpm guard:public-packages && pnpm guard:no-generated-artifacts && pnpm guard:extension-no-public && pnpm guard:no-one-off-mcp-app-html && pnpm guard:plan-marketplace && pnpm guard:no-error-string-returns && pnpm guard:no-action-twin-routes",
+    "sync:netlify-env": "tsx scripts/sync-template-netlify-env.ts",
     "sync:workspace-skills": "tsx scripts/sync-workspace-core-skills.ts",
     "sync:plan-marketplace": "tsx scripts/sync-plan-marketplace.ts",
     "changeset": "changeset",

--- a/packages/core/docs/content/deployment.md
+++ b/packages/core/docs/content/deployment.md
@@ -210,13 +210,14 @@ export default defineConfig({
 
 ### Build / Runtime {#env-runtime}
 
-| Variable              | Description                                                                                                                           |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `PORT`                | Server port (Node.js only)                                                                                                            |
-| `NITRO_PRESET`        | Override build preset at build time                                                                                                   |
-| `APP_BASE_PATH`       | Mount the app under a prefix (e.g. `/mail`). Set automatically by `npx @agent-native/core@latest deploy`; leave unset for standalone. |
-| `DATABASE_URL`        | Persistent SQL connection string. Required in production. See [Database](/docs/database#production) for adapter and dialect details.  |
-| `DATABASE_AUTH_TOKEN` | Auth token for providers that require a separate token, such as Turso/libSQL.                                                         |
+| Variable                    | Description                                                                                                                                       |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                      | Server port (Node.js only)                                                                                                                        |
+| `NITRO_PRESET`              | Override build preset at build time                                                                                                               |
+| `APP_BASE_PATH`             | Mount the app under a prefix (e.g. `/mail`). Set automatically by `npx @agent-native/core@latest deploy`; leave unset for standalone.             |
+| `DATABASE_URL`              | Persistent SQL connection string. Required in production. See [Database](/docs/database#production) for adapter and dialect details.              |
+| `DATABASE_AUTH_TOKEN`       | Auth token for providers that require a separate token, such as Turso/libSQL.                                                                     |
+| `AGENT_PROD_CODE_EXECUTION` | Optional production code-execution mode: `off` (default), `sandboxed`, or `trusted`. See [Production Code Execution](#production-code-execution). |
 
 ### Required in Production {#env-required-prod}
 
@@ -289,11 +290,34 @@ openssl rand -hex 32
 
 Rotate them by replacing the env var on every instance and redeploying — sessions / OAuth state envelopes signed under the old key become invalid, so users may need to sign in again.
 
+## Production Code Execution {#production-code-execution}
+
+By default, production agents run without code-execution tools. They can call app actions, database tools, MCP tools, browser/session tools, and other registered framework tools, but they do not get shell or filesystem access.
+
+Node-compatible deployments can opt into production code execution through the agent chat plugin or an environment override:
+
+```ts
+// server/plugins/agent-chat.ts
+export default createAgentChatPlugin({
+  codeExecution: { production: "sandboxed" },
+});
+```
+
+The available modes are:
+
+- `off` — the default. No code-execution tools are registered in production.
+- `sandboxed` — registers `run-code`, an isolated Node.js JavaScript runner with a scrubbed environment, a fresh temp directory, output/time limits, and a localhost bridge to allowlisted registered tools such as `provider-api-request`, `provider-api-docs`, `provider-api-catalog`, `web-request`, and `workspace-files`.
+- `trusted` — registers `run-code` plus the full coding tool registry (`bash`, `read`, `edit`, `write`). Use this only for single-tenant or operator-controlled deployments where full shell access to the host is intentional.
+
+Set `AGENT_PROD_CODE_EXECUTION=sandboxed` or `AGENT_PROD_CODE_EXECUTION=trusted` to override the plugin option for a specific deployment without a code change. `AGENT_PROD_CODE_EXECUTION=off` forces code execution off even when the plugin option enables it.
+
+The `run-code` sandbox is process-level isolation, not an OS container. It strips app secrets from the child process environment and uses the Node permission model when available, but outbound network is not blocked by Node itself; authenticated calls should go through the bridge helpers the tool exposes.
+
 ## Updating UI in Production {#updating-ui-in-production}
 
 One of agent-native's core features is that the agent can modify your app's source code — components, routes, styles, actions. During local development this works seamlessly because the agent has full filesystem access.
 
-In a standard production deployment, however, the agent runs in **production mode** with access to app tools (actions, database, MCP) but **not** the filesystem. This means the agent can read and write data, run actions, and interact with external services — but it can't edit your React components or add new routes on a deployed instance.
+In a standard production deployment with [production code execution](#production-code-execution) left off, the agent has access to app tools (actions, database, MCP) but not the filesystem. This means the agent can read and write data, run actions, and interact with external services — but it can't edit your React components or add new routes on a deployed instance.
 
 ### Builder.io: Visual Editing in Production {#builderio}
 

--- a/packages/core/docs/content/drop-in-agent.md
+++ b/packages/core/docs/content/drop-in-agent.md
@@ -15,24 +15,27 @@ You don't need to build agent-native from scratch. The agent chat, workspace tab
 
 ## The components at a glance {#components}
 
-| Component             | What it is                                                             | Use it when                                                     |
-| --------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `<AgentSidebar>`      | Wraps your app, adds a toggleable side panel containing the full agent | You want the agent available alongside your app on every screen |
-| `<AgentToggleButton>` | Opens/closes `<AgentSidebar>` (put it in your header)                  | Pair with `<AgentSidebar>`                                      |
-| `<AgentPanel>`        | The raw panel itself — chat + CLI + workspace tabs                     | You want full control over layout, or a dedicated agent page    |
-| `<AgentChatSurface>`  | A pre-wired panel/page chat surface                                    | You want chat without the sidebar wrapper                       |
-| `<AssistantChat>`     | Lower-level chat renderer with composer/history hooks                  | You need custom chrome around the standard conversation UI      |
-| `sendToAgentChat()`   | Programmatically send a message to the chat                            | A button that hands work to the agent instead of running inline |
-| `useActionMutation()` | Typesafe frontend wrapper around an action                             | The UI needs to run the same operation an agent tool would run  |
+| Component             | What it is                                                                            | Use it when                                                     |
+| --------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `<AgentSidebar>`      | Wraps your root app layout and adds a toggleable side panel containing the full agent | You want the agent available alongside your app on every screen |
+| `<AgentToggleButton>` | Opens/closes `<AgentSidebar>` (put it in your header)                                 | Pair with `<AgentSidebar>`                                      |
+| `<AgentPanel>`        | The raw panel itself — chat + CLI + workspace tabs                                    | You want full control over layout, or a dedicated agent page    |
+| `<AgentChatSurface>`  | A pre-wired panel/page chat surface                                                   | You want chat without the sidebar wrapper                       |
+| `<AssistantChat>`     | Lower-level chat renderer with composer/history hooks                                 | You need custom chrome around the standard conversation UI      |
+| `sendToAgentChat()`   | Programmatically send a message to the chat                                           | A button that hands work to the agent instead of running inline |
+| `useActionMutation()` | Typesafe frontend wrapper around an action                                            | The UI needs to run the same operation an agent tool would run  |
 
 All of these are exported from `@agent-native/core/client`.
 
 ## The 80% case: `<AgentSidebar>` {#sidebar}
 
-The most common setup is a sidebar that slides in from the right on any screen. Two pieces — the wrapper and a header button:
+The most common setup is a sidebar that opens from the right on any screen.
+Wrap your existing root layout with `<AgentSidebar>`; whatever you pass as
+children stays in the main app area. The agent chat is the side panel.
 
 ```tsx
 // app/root.tsx
+import { Outlet } from "react-router";
 import { AgentSidebar, AgentToggleButton } from "@agent-native/core/client";
 
 export default function Root() {
@@ -48,20 +51,23 @@ export default function Root() {
       defaultSidebarWidth={420}
       position="right"
     >
-      <YourApp />
+      <header>
+        <AgentToggleButton />
+      </header>
+
+      <main>
+        <Outlet />
+      </main>
     </AgentSidebar>
   );
 }
-
-// somewhere in your header / navbar
-<AgentToggleButton />;
 ```
 
 That's it. The user now has a toggleable agent on every page — with chat history, workspace tab, CLI terminal, voice input, and a fullscreen mode. State persists across reloads via `localStorage`.
 
 ### Props
 
-- **`children`** — your app. Rendered in the main area; the sidebar overlays from the chosen side.
+- **`children`** — your app's normal layout and routes. Rendered in the main area; the agent panel mounts beside it on desktop and over it on mobile/fullscreen.
 - **`emptyStateText`** — greeting shown when the chat has no messages. Default: `"How can I help you?"`.
 - **`suggestions`** — starter prompts rendered as clickable chips when empty.
 - **`dynamicSuggestions`** — context-aware prompt chips merged with `suggestions`. Enabled by default; pass `false` to show only static suggestions, or `{ max, includeStatic, getSuggestions }` to customize.
@@ -188,8 +194,9 @@ first so client code does not learn a second, ad hoc transport.
 
 ### Build your own sidebar from pieces {#build-your-own-sidebar}
 
-The stock sidebar is optional. A custom sidebar can keep your own layout and
-still reuse the framework runtime:
+The stock sidebar is optional. This example builds the agent-side UI itself.
+Render it inside your own shell, drawer, split pane, or route when you want to
+own the layout around the agent runtime:
 
 ```tsx
 import { AssistantChat, useChatThreads } from "@agent-native/core/client/chat";

--- a/packages/core/docs/content/plan-plugin.md
+++ b/packages/core/docs/content/plan-plugin.md
@@ -42,6 +42,12 @@ This keeps plan content out of the Agent-Native Plan database. Hosted sharing,
 comments, screenshots, and plan history are unavailable until you explicitly
 publish later.
 
+Agent Native Desktop has a separate local-file sync path for hosted plans: the
+Desktop app can mirror a hosted plan to local MDX files and import edits back
+without cloning the Plan app or running a CLI. That workflow keeps the hosted
+Plan database as the source of truth; use local-files privacy mode when the goal
+is no Plan DB writes.
+
 > The plugin (`agent-native-visual-plans`) carries app id `visual-plans`, which is why the Claude Code plugin name and Codex plugin name are both `agent-native-visual-plans`. The Plan app's display name is "Agent-Native Plan".
 
 ## Install routes {#install}

--- a/packages/core/docs/content/template-content.md
+++ b/packages/core/docs/content/template-content.md
@@ -24,6 +24,9 @@ When you open the app, you'll see a sidebar tree of pages on the left, the edito
 - **Write rich text** with headings, lists, tables, code blocks, images, and links. Slash commands (`/`) insert blocks; selecting text pops up a formatting toolbar.
 - **Organize pages in a tree** — nest infinitely, drag to reorder, favorite pages you use often.
 - **Search across everything** with full-text search across titles and content.
+- **Sync with local Markdown/MDX files.** Use the `/local-files` view to export
+  your workspace to files, edit them in your own tools, preview changes, and
+  import them back.
 - **Sync with Notion.** Link a local doc to a Notion page and pull or push content in either direction. Comments sync both ways too.
 - **Collaborate in real time.** Multiple people (and the agent) can edit the same doc at the same time.
 - **Share docs** with teammates or make them public — private by default, with viewer / editor / admin roles.
@@ -42,6 +45,24 @@ When you open the app, click **+ New page** in the sidebar, give it a title, and
 - "Pull the latest from Notion." (after linking a Notion page)
 
 Select text and hit Cmd+I to focus the agent with that selection pre-loaded — "make this punchier" then operates on exactly what you highlighted.
+
+## Local Markdown files {#local-files}
+
+Content can round-trip documents through local files without cloning or running
+the Content app locally. Open `/local-files`, choose a folder in your browser or
+Agent Native Desktop, and export the current document tree as Markdown/MDX under
+`content/`.
+
+Each exported file contains frontmatter for document metadata (`id`, `title`,
+`parentId`, `position`, favorite/search/visibility flags, and `updatedAt`) plus
+the document body as Markdown. You can edit those files in your normal editor,
+then return to `/local-files` to preview and import changes back into Content.
+
+This workflow is useful when you want content in source control, want to batch
+edit docs with local tools, or want a no-clone path for teams that prefer files
+as the review surface. The hosted app remains the source of truth for sharing,
+comments, permissions, and live collaboration; the local folder is an explicit
+sync surface.
 
 ## Why it's interesting
 
@@ -110,6 +131,21 @@ Documents can be linked to a Notion page and synced in either direction:
 - `sync-notion-comments` — bidirectionally sync comment threads
 
 Sync state is tracked in the `document_sync_links` table (last synced time, conflict flag, last error). Markdown-to-Notion block conversion lives in `shared/notion-markdown.ts`. Conflict and status UI is in `app/components/editor/NotionConflictBanner.tsx` and `NotionSyncBar.tsx`. See the `notion-integration` skill for the full flow.
+
+### Local file sync
+
+The protected `/local-files` route uses the browser File System Access API (or
+the same Chromium capability inside Agent Native Desktop) to read and write
+Markdown/MDX files from a user-chosen folder. It calls:
+
+- `export-content-source` — reads the accessible document tree and returns a
+  deterministic `content/` file bundle.
+- `import-content-source` — validates files, creates new private documents,
+  updates documents where the caller has editor access, preserves version
+  history, and rejects invalid parent cycles.
+
+The source format lives in `shared/content-source.ts`. Keep that file as the
+single contract for filenames, frontmatter, parsing, and serialization.
 
 ### Comments
 

--- a/packages/core/docs/content/template-plan.md
+++ b/packages/core/docs/content/template-plan.md
@@ -208,6 +208,28 @@ and commenting, and returns the hosted URL. It does
 not automatically make your coding agent's LLM local; choose a local or approved
 model if that privacy boundary matters too.
 
+## Desktop local file sync {#desktop-local-sync}
+
+Agent Native Desktop also gives hosted Plans a native local-folder bridge. This
+is different from local-files privacy mode: the hosted Plan database remains the
+source of truth for sharing, comments, history, and live review, while Desktop
+can mirror the current plan's source files to a folder you choose.
+
+Open a plan in Agent Native Desktop, use the plan menu's **Local files** actions,
+then:
+
+- **Link local folder** — choose the folder for that plan's MDX source.
+- **Sync to local folder** — write `plan.mdx`, optional `canvas.mdx`,
+  optional `prototype.mdx`, optional `.plan-state.json`, and image assets.
+- **Import local edits** — read the folder and apply it through
+  `import-visual-plan-source` with the plan's current update timestamp.
+- **Auto-sync changes** — keep exporting the hosted plan's latest source after
+  edits made in the app.
+
+This path does not require cloning the Plan app or running a CLI. It is for
+file-first review/editing around a hosted plan, not for keeping plan content out
+of the hosted database.
+
 ## Useful prompts
 
 - "Use `/visual-plan` before changing the auth flow."

--- a/packages/desktop-app/electron.vite.config.ts
+++ b/packages/desktop-app/electron.vite.config.ts
@@ -45,6 +45,14 @@ export default defineConfig({
         "@shared": resolve("shared"),
       },
     },
+    build: {
+      rollupOptions: {
+        input: {
+          index: resolve("src/preload/index.ts"),
+          webview: resolve("src/preload/webview.ts"),
+        },
+      },
+    },
   },
   renderer: {
     optimizeDeps: {

--- a/packages/desktop-app/electron.vite.config.ts
+++ b/packages/desktop-app/electron.vite.config.ts
@@ -51,6 +51,11 @@ export default defineConfig({
           index: resolve("src/preload/index.ts"),
           webview: resolve("src/preload/webview.ts"),
         },
+        output: {
+          format: "cjs",
+          entryFileNames: "[name].js",
+          chunkFileNames: "chunks/[name]-[hash].js",
+        },
       },
     },
   },

--- a/packages/desktop-app/shared/ipc-channels.ts
+++ b/packages/desktop-app/shared/ipc-channels.ts
@@ -148,7 +148,6 @@ export interface DesktopPlanMdxFolder {
 }
 
 export interface DesktopPlanFilesFolder {
-  path: string;
   name: string;
   planId: string;
   title?: string;

--- a/packages/desktop-app/shared/ipc-channels.ts
+++ b/packages/desktop-app/shared/ipc-channels.ts
@@ -33,6 +33,13 @@ export const IPC = {
   APPS_RESET: "apps:reset",
   APPS_CHOOSE_LOCAL_FOLDER: "apps:choose-local-folder",
 
+  /** Hosted Plan app local-file sync (Plan webview ↔ main) */
+  PLAN_FILES_GET_FOLDER: "plan-files:get-folder",
+  PLAN_FILES_CHOOSE_FOLDER: "plan-files:choose-folder",
+  PLAN_FILES_WRITE: "plan-files:write",
+  PLAN_FILES_READ: "plan-files:read",
+  PLAN_FILES_CLEAR_FOLDER: "plan-files:clear-folder",
+
   /** Active webview tracking (renderer → main) */
   SET_ACTIVE_APP: "webview:set-active-app",
   SET_ACTIVE_WEBVIEW: "webview:set-active-webview",
@@ -131,6 +138,59 @@ export interface LocalAppFolderSelectResult {
   folder?: LocalAppFolderInfo;
   error?: string;
 }
+
+export interface DesktopPlanMdxFolder {
+  "plan.mdx": string;
+  "canvas.mdx"?: string;
+  "prototype.mdx"?: string;
+  ".plan-state.json"?: string;
+  "assets/"?: Record<string, string>;
+}
+
+export interface DesktopPlanFilesFolder {
+  path: string;
+  name: string;
+  planId: string;
+  title?: string;
+  updatedAt?: string;
+}
+
+export interface DesktopPlanFilesFolderRequest {
+  planId: string;
+}
+
+export interface DesktopPlanFilesChooseFolderRequest {
+  planId: string;
+  title?: string;
+}
+
+export interface DesktopPlanFilesWriteRequest {
+  planId: string;
+  title?: string;
+  mdx: DesktopPlanMdxFolder;
+}
+
+export interface DesktopPlanFilesReadRequest {
+  planId: string;
+}
+
+export interface DesktopPlanFilesClearFolderRequest {
+  planId: string;
+}
+
+export type DesktopPlanFilesResult =
+  | {
+      ok: true;
+      folder: DesktopPlanFilesFolder;
+      files?: string[];
+      mdx?: DesktopPlanMdxFolder;
+    }
+  | {
+      ok: false;
+      error: string;
+      canceled?: boolean;
+      folder?: DesktopPlanFilesFolder;
+    };
 
 export type CodeAgentRunStatus =
   | "queued"

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -4618,7 +4618,7 @@ function loadPlanFilesStore(): PlanFilesStore {
       for (const [planId, grant] of Object.entries(raw.grants)) {
         if (!isValidPlanFilePlanId(planId)) continue;
         if (!isObject(grant)) continue;
-        const folder = resolveUsableDirectory(firstStringValue(grant.path));
+        const folder = resolveUsablePlanFolder(firstStringValue(grant.path));
         if (!folder) continue;
         grants[planId] = {
           path: folder,
@@ -4773,6 +4773,18 @@ function assertInsidePlanFolder(folder: string, target: string): string {
     return resolvedTarget;
   }
   throw new Error("Plan file path escaped the linked folder.");
+}
+
+function resolveUsablePlanFolder(value: unknown): string | null {
+  const folder = resolveUsableDirectory(value);
+  if (!folder) return null;
+  try {
+    const stat = fs.lstatSync(folder);
+    if (stat.isSymbolicLink() || !stat.isDirectory()) return null;
+    return folder;
+  } catch {
+    return null;
+  }
 }
 
 async function assertUsablePlanFolder(folder: string): Promise<void> {
@@ -4981,7 +4993,7 @@ function getRequiredPlanFilesGrant(planId: string): PlanFilesGrant {
   if (!grant) {
     throw new Error("Choose a local folder before syncing this plan.");
   }
-  const folder = resolveUsableDirectory(grant.path);
+  const folder = resolveUsablePlanFolder(grant.path);
   if (!folder) {
     throw new Error("The linked local folder no longer exists.");
   }
@@ -5002,8 +5014,13 @@ async function choosePlanFilesFolder(
   if (result.canceled || result.filePaths.length === 0) {
     return { ok: false, canceled: true, error: "No folder selected." };
   }
-  const folder = resolveUsableDirectory(result.filePaths[0]);
-  if (!folder) return { ok: false, error: "Choose an existing folder." };
+  const folder = resolveUsablePlanFolder(result.filePaths[0]);
+  if (!folder) {
+    return {
+      ok: false,
+      error: "Choose an existing folder that is not a symlink.",
+    };
+  }
 
   const grant = setPlanFilesGrant(planId, {
     path: folder,

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -70,6 +70,14 @@ import {
   type InterAppMessage,
   type LocalAppFolderInfo,
   type LocalAppFolderSelectResult,
+  type DesktopPlanFilesChooseFolderRequest,
+  type DesktopPlanFilesClearFolderRequest,
+  type DesktopPlanFilesFolder,
+  type DesktopPlanFilesFolderRequest,
+  type DesktopPlanFilesReadRequest,
+  type DesktopPlanFilesResult,
+  type DesktopPlanFilesWriteRequest,
+  type DesktopPlanMdxFolder,
   type UpdateStatus,
 } from "@shared/ipc-channels";
 import {
@@ -4567,6 +4575,461 @@ async function chooseLocalAppFolder(): Promise<LocalAppFolderSelectResult> {
   };
 }
 
+const PLAN_FILES_STORE_FILE = "plan-file-sync.json";
+const PLAN_TEXT_FILE_NAMES = [
+  "plan.mdx",
+  "canvas.mdx",
+  "prototype.mdx",
+  ".plan-state.json",
+] as const;
+const PLAN_OPTIONAL_TEXT_FILE_NAMES = [
+  "canvas.mdx",
+  "prototype.mdx",
+  ".plan-state.json",
+] as const;
+const PLAN_TEXT_FILE_MAX_BYTES = 2 * 1024 * 1024;
+const PLAN_ASSET_MAX_BYTES = 2 * 1024 * 1024;
+const PLAN_ASSETS_MAX_TOTAL_BYTES = 10 * 1024 * 1024;
+const PLAN_ASSET_FILENAME_PATTERN =
+  /^[A-Za-z0-9][A-Za-z0-9._-]*\.(png|jpe?g|gif|webp|svg)$/i;
+
+interface PlanFilesGrant {
+  path: string;
+  title?: string;
+  updatedAt?: string;
+}
+
+interface PlanFilesStore {
+  version: 1;
+  grants: Record<string, PlanFilesGrant>;
+}
+
+function planFilesStorePath(): string {
+  return path.join(app.getPath("userData"), PLAN_FILES_STORE_FILE);
+}
+
+function loadPlanFilesStore(): PlanFilesStore {
+  try {
+    const raw = JSON.parse(
+      fs.readFileSync(planFilesStorePath(), "utf-8"),
+    ) as Partial<PlanFilesStore>;
+    const grants: Record<string, PlanFilesGrant> = {};
+    if (raw.grants && typeof raw.grants === "object") {
+      for (const [planId, grant] of Object.entries(raw.grants)) {
+        if (!isValidPlanFilePlanId(planId)) continue;
+        if (!isObject(grant)) continue;
+        const folder = resolveUsableDirectory(firstStringValue(grant.path));
+        if (!folder) continue;
+        grants[planId] = {
+          path: folder,
+          title: firstStringValue(grant.title),
+          updatedAt: firstStringValue(grant.updatedAt),
+        };
+      }
+    }
+    return { version: 1, grants };
+  } catch {
+    return { version: 1, grants: {} };
+  }
+}
+
+function savePlanFilesStore(store: PlanFilesStore): void {
+  writeJsonFileAtomic(planFilesStorePath(), store);
+}
+
+function isValidPlanFilePlanId(value: unknown): value is string {
+  return (
+    typeof value === "string" && /^[A-Za-z0-9._:-]{1,200}$/.test(value.trim())
+  );
+}
+
+function sanitizePlanFilesTitle(value: unknown): string | undefined {
+  const title = firstStringValue(value)?.trim();
+  return title ? title.slice(0, 200) : undefined;
+}
+
+function planFilesFolderInfo(
+  planId: string,
+  grant: PlanFilesGrant,
+): DesktopPlanFilesFolder {
+  return {
+    path: grant.path,
+    name: path.basename(grant.path) || grant.path,
+    planId,
+    title: grant.title,
+    updatedAt: grant.updatedAt,
+  };
+}
+
+function getPlanFilesGrant(planId: string): PlanFilesGrant | null {
+  return loadPlanFilesStore().grants[planId] ?? null;
+}
+
+function setPlanFilesGrant(
+  planId: string,
+  grant: Omit<PlanFilesGrant, "updatedAt"> & { updatedAt?: string },
+): PlanFilesGrant {
+  const store = loadPlanFilesStore();
+  const next = {
+    path: grant.path,
+    title: grant.title,
+    updatedAt: grant.updatedAt ?? new Date().toISOString(),
+  };
+  store.grants[planId] = next;
+  savePlanFilesStore(store);
+  return next;
+}
+
+function clearPlanFilesGrant(planId: string): DesktopPlanFilesResult {
+  const store = loadPlanFilesStore();
+  const existing = store.grants[planId];
+  delete store.grants[planId];
+  savePlanFilesStore(store);
+  if (!existing) return { ok: false, error: "No local folder is linked." };
+  return {
+    ok: true,
+    folder: planFilesFolderInfo(planId, existing),
+  };
+}
+
+function normalizePlanFilesRequestPlanId(request: unknown): string | null {
+  if (!isObject(request)) return null;
+  const planId = firstStringValue(request.planId)?.trim();
+  return isValidPlanFilePlanId(planId) ? planId : null;
+}
+
+function isPlanFilesWebviewSender(event: IpcMainInvokeEvent): boolean {
+  const sender = event.sender;
+  if (sender.getType() !== "webview") return false;
+  const appConfig = findAppForSourceUrl(sender.getURL());
+  return appConfig?.id === "plan";
+}
+
+function requirePlanFilesWebviewAccess(
+  event: IpcMainInvokeEvent,
+): DesktopPlanFilesResult | null {
+  if (isPlanFilesWebviewSender(event)) return null;
+  return {
+    ok: false,
+    error: "Plan local files are only available to the Plan desktop app.",
+  };
+}
+
+function isDesktopPlanMdxFolder(value: unknown): value is DesktopPlanMdxFolder {
+  if (!isObject(value)) return false;
+  if (typeof value["plan.mdx"] !== "string" || !value["plan.mdx"].trim()) {
+    return false;
+  }
+  for (const file of PLAN_OPTIONAL_TEXT_FILE_NAMES) {
+    if (value[file] !== undefined && typeof value[file] !== "string") {
+      return false;
+    }
+  }
+  const assets = value["assets/"];
+  if (assets !== undefined) {
+    if (!isObject(assets)) return false;
+    for (const [filename, base64] of Object.entries(assets)) {
+      if (!PLAN_ASSET_FILENAME_PATTERN.test(filename)) return false;
+      if (typeof base64 !== "string") return false;
+    }
+  }
+  return true;
+}
+
+function assertPlanFileTextSize(file: string, content: string): void {
+  if (Buffer.byteLength(content, "utf-8") > PLAN_TEXT_FILE_MAX_BYTES) {
+    throw new Error(`${file} is larger than 2 MB.`);
+  }
+}
+
+function assertInsidePlanFolder(folder: string, target: string): string {
+  const resolvedFolder = path.resolve(folder);
+  const resolvedTarget = path.resolve(target);
+  const relative = path.relative(resolvedFolder, resolvedTarget);
+  if (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  ) {
+    return resolvedTarget;
+  }
+  throw new Error("Plan file path escaped the linked folder.");
+}
+
+async function assertNoSymlink(filePath: string): Promise<void> {
+  try {
+    const stat = await fs.promises.lstat(filePath);
+    if (stat.isSymbolicLink()) {
+      throw new Error("Linked plan folders cannot contain symlinked files.");
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return;
+    throw err;
+  }
+}
+
+async function writePlanTextFile(
+  folder: string,
+  file: (typeof PLAN_TEXT_FILE_NAMES)[number],
+  content: string,
+): Promise<void> {
+  assertPlanFileTextSize(file, content);
+  const filePath = assertInsidePlanFolder(folder, path.join(folder, file));
+  await assertNoSymlink(filePath);
+  await fs.promises.writeFile(filePath, content, "utf-8");
+}
+
+async function removePlanTextFile(
+  folder: string,
+  file: (typeof PLAN_OPTIONAL_TEXT_FILE_NAMES)[number],
+): Promise<void> {
+  const filePath = assertInsidePlanFolder(folder, path.join(folder, file));
+  await assertNoSymlink(filePath);
+  await fs.promises.rm(filePath, { force: true });
+}
+
+async function writePlanAssets(
+  folder: string,
+  assets: Record<string, string> | undefined,
+): Promise<string[]> {
+  const assetsPath = assertInsidePlanFolder(
+    folder,
+    path.join(folder, "assets"),
+  );
+  await assertNoSymlink(assetsPath);
+
+  if (!assets || Object.keys(assets).length === 0) {
+    await fs.promises.rm(assetsPath, { recursive: true, force: true });
+    return [];
+  }
+
+  await fs.promises.mkdir(assetsPath, { recursive: true });
+  const written: string[] = [];
+  let totalBytes = 0;
+  const expected = new Set<string>();
+
+  for (const [filename, base64] of Object.entries(assets)) {
+    if (!PLAN_ASSET_FILENAME_PATTERN.test(filename)) continue;
+    expected.add(filename);
+    const filePath = assertInsidePlanFolder(
+      assetsPath,
+      path.join(assetsPath, filename),
+    );
+    await assertNoSymlink(filePath);
+    const bytes = Buffer.from(base64, "base64");
+    if (bytes.byteLength > PLAN_ASSET_MAX_BYTES) {
+      throw new Error(`${filename} is larger than 2 MB.`);
+    }
+    totalBytes += bytes.byteLength;
+    if (totalBytes > PLAN_ASSETS_MAX_TOTAL_BYTES) {
+      throw new Error("Plan assets are larger than 10 MB total.");
+    }
+    await fs.promises.writeFile(filePath, bytes);
+    written.push(`assets/${filename}`);
+  }
+
+  try {
+    const entries = await fs.promises.readdir(assetsPath, {
+      withFileTypes: true,
+    });
+    await Promise.all(
+      entries.map(async (entry) => {
+        if (!entry.isFile() || expected.has(entry.name)) return;
+        const stalePath = assertInsidePlanFolder(
+          assetsPath,
+          path.join(assetsPath, entry.name),
+        );
+        await assertNoSymlink(stalePath);
+        await fs.promises.rm(stalePath, { force: true });
+      }),
+    );
+  } catch {
+    // Stale asset cleanup is best-effort.
+  }
+
+  return written;
+}
+
+async function writePlanMdxFolder(
+  folder: string,
+  mdx: DesktopPlanMdxFolder,
+): Promise<string[]> {
+  await fs.promises.mkdir(folder, { recursive: true });
+  await writePlanTextFile(folder, "plan.mdx", mdx["plan.mdx"]);
+  const written = ["plan.mdx"];
+
+  for (const file of PLAN_OPTIONAL_TEXT_FILE_NAMES) {
+    const content = mdx[file];
+    if (typeof content === "string" && content.length > 0) {
+      await writePlanTextFile(folder, file, content);
+      written.push(file);
+    } else {
+      await removePlanTextFile(folder, file);
+    }
+  }
+
+  written.push(...(await writePlanAssets(folder, mdx["assets/"])));
+  return written;
+}
+
+async function readOptionalPlanTextFile(
+  folder: string,
+  file: (typeof PLAN_TEXT_FILE_NAMES)[number],
+): Promise<string | undefined> {
+  const filePath = assertInsidePlanFolder(folder, path.join(folder, file));
+  await assertNoSymlink(filePath);
+  try {
+    const stat = await fs.promises.stat(filePath);
+    if (!stat.isFile()) return undefined;
+    if (stat.size > PLAN_TEXT_FILE_MAX_BYTES) {
+      throw new Error(`${file} is larger than 2 MB.`);
+    }
+    return await fs.promises.readFile(filePath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return undefined;
+    throw err;
+  }
+}
+
+async function readPlanAssets(
+  folder: string,
+): Promise<Record<string, string> | undefined> {
+  const assetsPath = assertInsidePlanFolder(
+    folder,
+    path.join(folder, "assets"),
+  );
+  await assertNoSymlink(assetsPath);
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(assetsPath, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+
+  const assets: Record<string, string> = {};
+  let totalBytes = 0;
+  for (const entry of entries) {
+    if (!entry.isFile() || !PLAN_ASSET_FILENAME_PATTERN.test(entry.name)) {
+      continue;
+    }
+    const filePath = assertInsidePlanFolder(
+      assetsPath,
+      path.join(assetsPath, entry.name),
+    );
+    await assertNoSymlink(filePath);
+    const stat = await fs.promises.stat(filePath);
+    if (stat.size > PLAN_ASSET_MAX_BYTES) continue;
+    totalBytes += stat.size;
+    if (totalBytes > PLAN_ASSETS_MAX_TOTAL_BYTES) break;
+    const bytes = await fs.promises.readFile(filePath);
+    assets[entry.name] = bytes.toString("base64");
+  }
+
+  return Object.keys(assets).length > 0 ? assets : undefined;
+}
+
+async function readPlanMdxFolder(
+  folder: string,
+): Promise<DesktopPlanMdxFolder> {
+  const plan = await readOptionalPlanTextFile(folder, "plan.mdx");
+  if (!plan) throw new Error("The linked folder does not contain plan.mdx.");
+  const mdx: DesktopPlanMdxFolder = { "plan.mdx": plan };
+  for (const file of PLAN_OPTIONAL_TEXT_FILE_NAMES) {
+    const content = await readOptionalPlanTextFile(folder, file);
+    if (content !== undefined) mdx[file] = content;
+  }
+  const assets = await readPlanAssets(folder);
+  if (assets) mdx["assets/"] = assets;
+  return mdx;
+}
+
+function getRequiredPlanFilesGrant(planId: string): PlanFilesGrant {
+  const grant = getPlanFilesGrant(planId);
+  if (!grant) {
+    throw new Error("Choose a local folder before syncing this plan.");
+  }
+  const folder = resolveUsableDirectory(grant.path);
+  if (!folder) {
+    throw new Error("The linked local folder no longer exists.");
+  }
+  return { ...grant, path: folder };
+}
+
+async function choosePlanFilesFolder(
+  request: DesktopPlanFilesChooseFolderRequest,
+): Promise<DesktopPlanFilesResult> {
+  const planId = normalizePlanFilesRequestPlanId(request);
+  if (!planId) return { ok: false, error: "Invalid plan ID." };
+
+  const result = await dialog.showOpenDialog({
+    title: "Choose local plan folder",
+    message: "Choose the folder that contains this plan's MDX files.",
+    properties: ["openDirectory", "createDirectory"],
+  });
+  if (result.canceled || result.filePaths.length === 0) {
+    return { ok: false, canceled: true, error: "No folder selected." };
+  }
+  const folder = resolveUsableDirectory(result.filePaths[0]);
+  if (!folder) return { ok: false, error: "Choose an existing folder." };
+
+  const grant = setPlanFilesGrant(planId, {
+    path: folder,
+    title: sanitizePlanFilesTitle(request.title),
+  });
+  return { ok: true, folder: planFilesFolderInfo(planId, grant) };
+}
+
+async function writePlanFilesForRequest(
+  request: DesktopPlanFilesWriteRequest,
+): Promise<DesktopPlanFilesResult> {
+  const planId = normalizePlanFilesRequestPlanId(request);
+  if (!planId) return { ok: false, error: "Invalid plan ID." };
+  if (!isDesktopPlanMdxFolder(request.mdx)) {
+    return { ok: false, error: "Invalid Plan MDX folder." };
+  }
+
+  try {
+    const grant = getRequiredPlanFilesGrant(planId);
+    const files = await writePlanMdxFolder(grant.path, request.mdx);
+    const updatedGrant = setPlanFilesGrant(planId, {
+      path: grant.path,
+      title: sanitizePlanFilesTitle(request.title) ?? grant.title,
+    });
+    return {
+      ok: true,
+      folder: planFilesFolderInfo(planId, updatedGrant),
+      files,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function readPlanFilesForRequest(
+  request: DesktopPlanFilesReadRequest,
+): Promise<DesktopPlanFilesResult> {
+  const planId = normalizePlanFilesRequestPlanId(request);
+  if (!planId) return { ok: false, error: "Invalid plan ID." };
+
+  try {
+    const grant = getRequiredPlanFilesGrant(planId);
+    return {
+      ok: true,
+      folder: planFilesFolderInfo(planId, grant),
+      mdx: await readPlanMdxFolder(grant.path),
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 function quoteWindowsCmdPath(value: string): string {
   return `"${value.replaceAll('"', '""')}"`;
 }
@@ -5766,6 +6229,72 @@ ipcMain.handle(IPC.APPS_RESET, (): AppConfig[] => {
 ipcMain.handle(
   IPC.APPS_CHOOSE_LOCAL_FOLDER,
   (): Promise<LocalAppFolderSelectResult> => chooseLocalAppFolder(),
+);
+
+ipcMain.handle(
+  IPC.PLAN_FILES_GET_FOLDER,
+  (
+    event: IpcMainInvokeEvent,
+    request: DesktopPlanFilesFolderRequest,
+  ): DesktopPlanFilesResult => {
+    const denied = requirePlanFilesWebviewAccess(event);
+    if (denied) return denied;
+    const planId = normalizePlanFilesRequestPlanId(request);
+    if (!planId) return { ok: false, error: "Invalid plan ID." };
+    const grant = getPlanFilesGrant(planId);
+    if (!grant) return { ok: false, error: "No local folder is linked." };
+    return { ok: true, folder: planFilesFolderInfo(planId, grant) };
+  },
+);
+
+ipcMain.handle(
+  IPC.PLAN_FILES_CHOOSE_FOLDER,
+  (
+    event: IpcMainInvokeEvent,
+    request: DesktopPlanFilesChooseFolderRequest,
+  ): Promise<DesktopPlanFilesResult> => {
+    const denied = requirePlanFilesWebviewAccess(event);
+    if (denied) return Promise.resolve(denied);
+    return choosePlanFilesFolder(request);
+  },
+);
+
+ipcMain.handle(
+  IPC.PLAN_FILES_WRITE,
+  (
+    event: IpcMainInvokeEvent,
+    request: DesktopPlanFilesWriteRequest,
+  ): Promise<DesktopPlanFilesResult> => {
+    const denied = requirePlanFilesWebviewAccess(event);
+    if (denied) return Promise.resolve(denied);
+    return writePlanFilesForRequest(request);
+  },
+);
+
+ipcMain.handle(
+  IPC.PLAN_FILES_READ,
+  (
+    event: IpcMainInvokeEvent,
+    request: DesktopPlanFilesReadRequest,
+  ): Promise<DesktopPlanFilesResult> => {
+    const denied = requirePlanFilesWebviewAccess(event);
+    if (denied) return Promise.resolve(denied);
+    return readPlanFilesForRequest(request);
+  },
+);
+
+ipcMain.handle(
+  IPC.PLAN_FILES_CLEAR_FOLDER,
+  (
+    event: IpcMainInvokeEvent,
+    request: DesktopPlanFilesClearFolderRequest,
+  ): DesktopPlanFilesResult => {
+    const denied = requirePlanFilesWebviewAccess(event);
+    if (denied) return denied;
+    const planId = normalizePlanFilesRequestPlanId(request);
+    if (!planId) return { ok: false, error: "Invalid plan ID." };
+    return clearPlanFilesGrant(planId);
+  },
 );
 
 // ---------- IPC: Frame settings ----------

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -4653,7 +4653,6 @@ function planFilesFolderInfo(
   grant: PlanFilesGrant,
 ): DesktopPlanFilesFolder {
   return {
-    path: grant.path,
     name: path.basename(grant.path) || grant.path,
     planId,
     title: grant.title,
@@ -4701,8 +4700,29 @@ function normalizePlanFilesRequestPlanId(request: unknown): string | null {
 function isPlanFilesWebviewSender(event: IpcMainInvokeEvent): boolean {
   const sender = event.sender;
   if (sender.getType() !== "webview") return false;
-  const appConfig = findAppForSourceUrl(sender.getURL());
-  return appConfig?.id === "plan";
+  if (activeAppId !== "plan") return false;
+  if (!activeWebviewContentsId || activeWebviewContentsId !== sender.id) {
+    return false;
+  }
+  const planApp = loadAppsForAuthContext().find(
+    (candidate) => candidate.id === "plan" && candidate.enabled !== false,
+  );
+  if (!planApp) return false;
+
+  let url: URL;
+  try {
+    url = new URL(sender.getURL());
+  } catch {
+    return false;
+  }
+
+  const trustedOrigin = getAppOrigin(planApp);
+  if (trustedOrigin && url.origin === trustedOrigin) return true;
+  return (
+    IS_DEV &&
+    url.origin === `http://localhost:${FRAME_PORT}` &&
+    url.searchParams.get("app") === "plan"
+  );
 }
 
 function requirePlanFilesWebviewAccess(

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -4775,6 +4775,16 @@ function assertInsidePlanFolder(folder: string, target: string): string {
   throw new Error("Plan file path escaped the linked folder.");
 }
 
+async function assertUsablePlanFolder(folder: string): Promise<void> {
+  const stat = await fs.promises.lstat(folder);
+  if (stat.isSymbolicLink()) {
+    throw new Error("Linked plan folders cannot be symlinks.");
+  }
+  if (!stat.isDirectory()) {
+    throw new Error("The linked plan folder is not a directory.");
+  }
+}
+
 async function assertNoSymlink(filePath: string): Promise<void> {
   try {
     const stat = await fs.promises.lstat(filePath);
@@ -4874,6 +4884,7 @@ async function writePlanMdxFolder(
   folder: string,
   mdx: DesktopPlanMdxFolder,
 ): Promise<string[]> {
+  await assertUsablePlanFolder(folder);
   await fs.promises.mkdir(folder, { recursive: true });
   await writePlanTextFile(folder, "plan.mdx", mdx["plan.mdx"]);
   const written = ["plan.mdx"];
@@ -4952,6 +4963,7 @@ async function readPlanAssets(
 async function readPlanMdxFolder(
   folder: string,
 ): Promise<DesktopPlanMdxFolder> {
+  await assertUsablePlanFolder(folder);
   const plan = await readOptionalPlanTextFile(folder, "plan.mdx");
   if (!plan) throw new Error("The linked folder does not contain plan.mdx.");
   const mdx: DesktopPlanMdxFolder = { "plan.mdx": plan };

--- a/packages/desktop-app/src/preload/index.ts
+++ b/packages/desktop-app/src/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron";
+import path from "node:path";
 import {
   IPC,
   type ActiveWebviewTarget,
@@ -58,6 +59,9 @@ type CodeAgentTranscriptSubscriptionBatch = CodeAgentTranscriptResult & {
 const electronAPI = {
   /** Current OS platform — used by renderer to adapt UI (e.g. traffic lights vs custom controls) */
   platform: process.platform as string,
+
+  /** Dedicated preload for hosted app webviews. Exposes only app-safe bridges. */
+  webviewPreloadPath: path.join(__dirname, "webview.js"),
 
   /** Window chrome controls */
   windowControls: {

--- a/packages/desktop-app/src/preload/webview.ts
+++ b/packages/desktop-app/src/preload/webview.ts
@@ -1,0 +1,37 @@
+import { contextBridge, ipcRenderer } from "electron";
+import {
+  IPC,
+  type DesktopPlanFilesChooseFolderRequest,
+  type DesktopPlanFilesClearFolderRequest,
+  type DesktopPlanFilesFolderRequest,
+  type DesktopPlanFilesReadRequest,
+  type DesktopPlanFilesResult,
+  type DesktopPlanFilesWriteRequest,
+} from "@shared/ipc-channels";
+
+const agentNativeDesktop = {
+  planFiles: {
+    getFolder: (
+      request: DesktopPlanFilesFolderRequest,
+    ): Promise<DesktopPlanFilesResult> =>
+      ipcRenderer.invoke(IPC.PLAN_FILES_GET_FOLDER, request),
+    chooseFolder: (
+      request: DesktopPlanFilesChooseFolderRequest,
+    ): Promise<DesktopPlanFilesResult> =>
+      ipcRenderer.invoke(IPC.PLAN_FILES_CHOOSE_FOLDER, request),
+    writePlan: (
+      request: DesktopPlanFilesWriteRequest,
+    ): Promise<DesktopPlanFilesResult> =>
+      ipcRenderer.invoke(IPC.PLAN_FILES_WRITE, request),
+    readPlan: (
+      request: DesktopPlanFilesReadRequest,
+    ): Promise<DesktopPlanFilesResult> =>
+      ipcRenderer.invoke(IPC.PLAN_FILES_READ, request),
+    clearFolder: (
+      request: DesktopPlanFilesClearFolderRequest,
+    ): Promise<DesktopPlanFilesResult> =>
+      ipcRenderer.invoke(IPC.PLAN_FILES_CLEAR_FOLDER, request),
+  },
+};
+
+contextBridge.exposeInMainWorld("agentNativeDesktop", agentNativeDesktop);

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -592,7 +592,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
               ) as ElectronWebviewElement;
               wv.className = "app-webview";
               wv.setAttribute("allowpopups", "");
-              if (window.electronAPI?.webviewPreloadPath) {
+              if (app.id === "plan" && window.electronAPI?.webviewPreloadPath) {
                 wv.setAttribute(
                   "preload",
                   window.electronAPI.webviewPreloadPath,

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -592,6 +592,12 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
               ) as ElectronWebviewElement;
               wv.className = "app-webview";
               wv.setAttribute("allowpopups", "");
+              if (window.electronAPI?.webviewPreloadPath) {
+                wv.setAttribute(
+                  "preload",
+                  window.electronAPI.webviewPreloadPath,
+                );
+              }
               wv.setAttribute(
                 "webpreferences",
                 "contextIsolation=true,nodeIntegration=false,sandbox=true,backgroundThrottling=false",

--- a/packages/desktop-app/src/renderer/global.d.ts
+++ b/packages/desktop-app/src/renderer/global.d.ts
@@ -537,6 +537,7 @@ type LocalAppFolderSelectResult = {
 /** Electron APIs exposed to the renderer via the preload contextBridge */
 interface ElectronAPI {
   platform: string;
+  webviewPreloadPath: string;
 
   windowControls: {
     minimize(): void;

--- a/packages/docs/app/routes/templates.content.tsx
+++ b/packages/docs/app/routes/templates.content.tsx
@@ -283,9 +283,7 @@ export default function ContentTemplate() {
             </p>
           </div>
           <div className="rounded-xl border border-[var(--docs-border)] bg-[var(--bg-secondary)] p-5">
-            <h3 className="mb-1 text-sm font-semibold">
-              Local Markdown Files
-            </h3>
+            <h3 className="mb-1 text-sm font-semibold">Local Markdown Files</h3>
             <p className="m-0 text-sm text-[var(--fg-secondary)]">
               Export docs to a local content folder, edit in your own tools,
               preview changes, and import them back.

--- a/packages/docs/app/routes/templates.content.tsx
+++ b/packages/docs/app/routes/templates.content.tsx
@@ -284,6 +284,15 @@ export default function ContentTemplate() {
           </div>
           <div className="rounded-xl border border-[var(--docs-border)] bg-[var(--bg-secondary)] p-5">
             <h3 className="mb-1 text-sm font-semibold">
+              Local Markdown Files
+            </h3>
+            <p className="m-0 text-sm text-[var(--fg-secondary)]">
+              Export docs to a local content folder, edit in your own tools,
+              preview changes, and import them back.
+            </p>
+          </div>
+          <div className="rounded-xl border border-[var(--docs-border)] bg-[var(--bg-secondary)] p-5">
+            <h3 className="mb-1 text-sm font-semibold">
               Code Block Syntax Highlighting
             </h3>
             <p className="m-0 text-sm text-[var(--fg-secondary)]">
@@ -381,7 +390,7 @@ export default function ContentTemplate() {
                 >
                   <polyline points="20 6 9 17 4 12" />
                 </svg>
-                All content stored as files you own
+                Optional local Markdown/MDX sync for file-first workflows
               </li>
             </ul>
           </div>

--- a/packages/docs/app/routes/templates.plan.tsx
+++ b/packages/docs/app/routes/templates.plan.tsx
@@ -307,6 +307,29 @@ export default function PlanTemplate() {
               review, comments, and approvals.
             </p>
           </div>
+          <div className="rounded-xl border border-[var(--docs-border)] bg-[var(--bg-secondary)] p-5">
+            <div className="mb-3 text-[var(--docs-accent)]">
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M4 4h6l2 3h8v13H4z" />
+                <path d="M8 13h8" />
+                <path d="M12 9v8" />
+              </svg>
+            </div>
+            <h3 className="mb-1 text-sm font-semibold">Desktop File Sync</h3>
+            <p className="m-0 text-sm text-[var(--fg-secondary)]">
+              Mirror hosted plans to local MDX files from Agent Native Desktop
+              without cloning the app or running a CLI.
+            </p>
+          </div>
         </div>
       </section>
 

--- a/scripts/sync-template-netlify-env.ts
+++ b/scripts/sync-template-netlify-env.ts
@@ -1,0 +1,483 @@
+#!/usr/bin/env tsx
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+type TemplateSite = {
+  name: string;
+  siteId: string;
+};
+
+type Options = {
+  accountId: string | undefined;
+  context: string;
+  scopes: string[];
+  sources: string[];
+  templates: string[];
+  write: boolean;
+};
+
+type ApiResult = {
+  ok: boolean;
+  status: number;
+};
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const TEMPLATE_SITES: TemplateSite[] = [
+  { name: "analytics", siteId: "ba983662-dac4-478d-a481-5079e67e4d33" },
+  { name: "assets", siteId: "5868670b-649a-4a45-9e34-45ef3e75f3fd" },
+  { name: "brain", siteId: "af978d13-aa58-44f3-9b5c-f12568467079" },
+  { name: "calendar", siteId: "954fe53b-052e-4401-aac2-2e973e498af8" },
+  { name: "clips", siteId: "7e3f4fee-258d-4d16-9aaf-154a714e87e2" },
+  { name: "content", siteId: "5c2198f5-bee4-41c3-8a6d-4869f400eec2" },
+  { name: "design", siteId: "1e6bd63d-2972-4272-86bd-7b33f493606d" },
+  { name: "dispatch", siteId: "1171ef84-ed50-418b-bced-e19470475e49" },
+  { name: "forms", siteId: "aa0b2020-9983-4d6c-8fb0-65462f960fc4" },
+  { name: "macros", siteId: "0700a8ac-6a9f-4834-80dd-734102228132" },
+  { name: "mail", siteId: "dee98bb0-6143-4205-8c04-afe7bf83d5b5" },
+  { name: "plan", siteId: "9d0d7a73-385d-4da1-ba10-1581ffc4d413" },
+  { name: "slides", siteId: "fd5deb5b-5539-47e1-830c-e5fb5e105efd" },
+  { name: "starter", siteId: "864ab6ba-0889-4265-99c0-7a18d1888585" },
+  { name: "videos", siteId: "3f0c2cd2-06cd-4ab8-bfb4-c199430d1dac" },
+];
+
+const SITE_BY_NAME = new Map(TEMPLATE_SITES.map((site) => [site.name, site]));
+const DEFAULT_SOURCES = [".env", ".env.local"];
+const DEFAULT_SCOPES = ["builds", "functions", "runtime"];
+const DEFAULT_CONTEXT = "production";
+const PUBLIC_KEY_EXACT = new Set([
+  "APP_URL",
+  "BETTER_AUTH_URL",
+  "BUILDER_ORG_KIND",
+  "BUILDER_ORG_NAME",
+  "BUILDER_PUBLIC_KEY",
+  "BUILDER_USER_ID",
+  "EMAIL_FROM",
+  "ENABLE_BUILDER",
+  "GOOGLE_CLIENT_ID",
+  "GOOGLE_PICKER_API_KEY",
+  "GOOGLE_PICKER_APP_ID",
+  "NEON_AUTH_BASE_URL",
+]);
+const PUBLIC_KEY_PREFIXES = ["VITE_"];
+
+function usage(): string {
+  const names = TEMPLATE_SITES.map((site) => site.name).join(", ");
+  return `Usage:
+  pnpm exec tsx scripts/sync-template-netlify-env.ts --template clips
+  NETLIFY_AUTH_TOKEN=... NETLIFY_ACCOUNT_ID=... pnpm exec tsx scripts/sync-template-netlify-env.ts --template clips --write
+
+Options:
+  --template <name>       Template to sync. Can be repeated.
+  --templates <a,b>       Comma-separated templates to sync.
+  --all                   Sync all known template Netlify sites.
+  --write                 Apply changes. Omit for a key-only dry run.
+  --account <id-or-slug>  Netlify account/team id. Defaults to NETLIFY_ACCOUNT_ID.
+  --context <context>     Netlify deploy context. Defaults to "${DEFAULT_CONTEXT}".
+  --scope <scope>         Scope to set. Can be repeated. Defaults to ${DEFAULT_SCOPES.join(",")}.
+  --source <file>         Env file inside each template. Can be repeated.
+                           Defaults to ${DEFAULT_SOURCES.join(", ")}.
+  --help                  Show this help.
+
+Known templates:
+  ${names}
+`;
+}
+
+function parseArgs(argv: string[]): Options {
+  const templates: string[] = [];
+  const scopes: string[] = [];
+  const sources: string[] = [];
+  let accountId = process.env.NETLIFY_ACCOUNT_ID;
+  let context = DEFAULT_CONTEXT;
+  let all = false;
+  let write = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`${arg} requires a value`);
+      }
+      i += 1;
+      return value;
+    };
+
+    if (arg === "--") {
+      continue;
+    } else if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    } else if (arg === "--template") {
+      templates.push(next());
+    } else if (arg === "--templates") {
+      templates.push(...splitCsv(next()));
+    } else if (arg === "--all") {
+      all = true;
+    } else if (arg === "--write") {
+      write = true;
+    } else if (arg === "--dry-run") {
+      write = false;
+    } else if (arg === "--account") {
+      accountId = next();
+    } else if (arg === "--context") {
+      context = next();
+    } else if (arg === "--scope") {
+      scopes.push(next());
+    } else if (arg === "--source") {
+      sources.push(next());
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  const selected = all ? TEMPLATE_SITES.map((site) => site.name) : templates;
+  const uniqueTemplates = [...new Set(selected.map((name) => name.trim()))]
+    .filter(Boolean)
+    .sort();
+
+  if (uniqueTemplates.length === 0) {
+    throw new Error("Select at least one template with --template or --all.");
+  }
+
+  const unknownTemplates = uniqueTemplates.filter(
+    (name) => !SITE_BY_NAME.has(name),
+  );
+  if (unknownTemplates.length > 0) {
+    throw new Error(`Unknown template(s): ${unknownTemplates.join(", ")}`);
+  }
+
+  return {
+    accountId,
+    context,
+    scopes: scopes.length > 0 ? scopes : DEFAULT_SCOPES,
+    sources: sources.length > 0 ? sources : DEFAULT_SOURCES,
+    templates: uniqueTemplates,
+    write,
+  };
+}
+
+function splitCsv(value: string): string[] {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function parseEnvFile(filePath: string): Map<string, string> {
+  const env = new Map<string, string>();
+  const lines = readFileSync(filePath, "utf8").split(/\r?\n/);
+
+  for (const rawLine of lines) {
+    const trimmed = rawLine.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const match = trimmed.match(
+      /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/,
+    );
+    if (!match) continue;
+
+    const [, key, rawValue] = match;
+    env.set(key, parseEnvValue(rawValue));
+  }
+
+  return env;
+}
+
+function parseEnvValue(rawValue: string): string {
+  const value = rawValue.trim();
+  if (!value) return "";
+
+  if (value.startsWith("'")) {
+    const end = value.lastIndexOf("'");
+    return end > 0 ? value.slice(1, end) : value.slice(1);
+  }
+
+  if (value.startsWith('"')) {
+    const end = findClosingDoubleQuote(value);
+    const quoted = end > 0 ? value.slice(1, end) : value.slice(1);
+    return quoted.replace(/\\([nrtbf"\\])/g, (_, escaped: string) => {
+      switch (escaped) {
+        case "n":
+          return "\n";
+        case "r":
+          return "\r";
+        case "t":
+          return "\t";
+        case "b":
+          return "\b";
+        case "f":
+          return "\f";
+        default:
+          return escaped;
+      }
+    });
+  }
+
+  return value.replace(/\s+#.*$/, "").trimEnd();
+}
+
+function findClosingDoubleQuote(value: string): number {
+  for (let i = value.length - 1; i > 0; i -= 1) {
+    if (value[i] !== '"') continue;
+    let slashCount = 0;
+    for (let j = i - 1; j >= 0 && value[j] === "\\"; j -= 1) {
+      slashCount += 1;
+    }
+    if (slashCount % 2 === 0) return i;
+  }
+  return -1;
+}
+
+function loadTemplateEnv(template: string, sources: string[]) {
+  const values = new Map<string, string>();
+  const foundSources: string[] = [];
+
+  for (const source of sources) {
+    const filePath = path.join(REPO_ROOT, "templates", template, source);
+    if (!existsSync(filePath)) continue;
+
+    foundSources.push(path.relative(REPO_ROOT, filePath));
+    for (const [key, value] of parseEnvFile(filePath)) {
+      values.set(key, value);
+    }
+  }
+
+  return { foundSources, values };
+}
+
+function redactedKeyList(keys: string[]): string {
+  return keys.length > 0 ? keys.join(", ") : "(none)";
+}
+
+function netlifyEnvUrl(
+  accountId: string,
+  siteId: string,
+  key?: string,
+): string {
+  const encodedAccount = encodeURIComponent(accountId);
+  const encodedSite = encodeURIComponent(siteId);
+  const keyPath = key ? `/${encodeURIComponent(key)}` : "";
+  return `https://api.netlify.com/api/v1/accounts/${encodedAccount}/env${keyPath}?site_id=${encodedSite}`;
+}
+
+async function requestNetlifyEnv(
+  token: string,
+  method: "POST" | "PUT",
+  url: string,
+  body: unknown,
+): Promise<ApiResult> {
+  const response = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "agent-native-template-env-sync",
+    },
+    body: JSON.stringify(body),
+  });
+
+  await response.arrayBuffer();
+  return { ok: response.ok, status: response.status };
+}
+
+async function deleteNetlifyEnv(
+  token: string,
+  accountId: string,
+  siteId: string,
+  key: string,
+): Promise<ApiResult> {
+  const response = await fetch(netlifyEnvUrl(accountId, siteId, key), {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "User-Agent": "agent-native-template-env-sync",
+    },
+  });
+
+  await response.arrayBuffer();
+  return { ok: response.ok, status: response.status };
+}
+
+function isSecretKey(key: string): boolean {
+  if (PUBLIC_KEY_EXACT.has(key)) return false;
+  if (PUBLIC_KEY_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+    return false;
+  }
+  return true;
+}
+
+async function syncKey({
+  accountId,
+  context,
+  key,
+  scopes,
+  siteId,
+  token,
+  value,
+}: {
+  accountId: string;
+  context: string;
+  key: string;
+  scopes: string[];
+  siteId: string;
+  token: string;
+  value: string;
+}): Promise<"created" | "updated"> {
+  const is_secret = isSecretKey(key);
+  const create = await requestNetlifyEnv(
+    token,
+    "POST",
+    netlifyEnvUrl(accountId, siteId),
+    [
+      {
+        key,
+        is_secret,
+        scopes,
+        values: [{ context, value }],
+      },
+    ],
+  );
+
+  if (create.ok) return "created";
+
+  if (![400, 409, 422].includes(create.status)) {
+    throw new Error(`${key}: create failed with HTTP ${create.status}`);
+  }
+
+  if (!is_secret) {
+    const deleted = await deleteNetlifyEnv(token, accountId, siteId, key);
+    if (!deleted.ok && deleted.status !== 404) {
+      throw new Error(
+        `${key}: delete before recreate failed with HTTP ${deleted.status}`,
+      );
+    }
+
+    const recreated = await requestNetlifyEnv(
+      token,
+      "POST",
+      netlifyEnvUrl(accountId, siteId),
+      [
+        {
+          key,
+          is_secret,
+          scopes,
+          values: [{ context, value }],
+        },
+      ],
+    );
+    if (recreated.ok) return "updated";
+    throw new Error(
+      `${key}: recreate as plain env var failed with HTTP ${recreated.status}`,
+    );
+  }
+
+  const update = await requestNetlifyEnv(
+    token,
+    "PUT",
+    netlifyEnvUrl(accountId, siteId, key),
+    {
+      key,
+      is_secret,
+      scopes,
+      values: [{ context, value }],
+    },
+  );
+
+  if (update.ok) return "updated";
+  throw new Error(
+    `${key}: create returned HTTP ${create.status}; update returned HTTP ${update.status}`,
+  );
+}
+
+async function main() {
+  const options = parseOptionsOrExit(process.argv.slice(2));
+
+  const token = process.env.NETLIFY_AUTH_TOKEN;
+  if (options.write && !token) {
+    throw new Error("NETLIFY_AUTH_TOKEN must be set when using --write.");
+  }
+  if (options.write && !options.accountId) {
+    throw new Error(
+      "NETLIFY_ACCOUNT_ID must be set, or pass --account, when using --write.",
+    );
+  }
+
+  console.log(
+    options.write
+      ? `Writing Netlify env vars for context=${options.context} scopes=${options.scopes.join(",")}`
+      : `Dry run: no Netlify changes will be made. Add --write to apply.`,
+  );
+
+  for (const template of options.templates) {
+    const site = SITE_BY_NAME.get(template);
+    if (!site) throw new Error(`Missing site mapping for ${template}.`);
+
+    const { foundSources, values } = loadTemplateEnv(template, options.sources);
+    const entries = [...values.entries()].filter(([, value]) => value !== "");
+    const keys = entries.map(([key]) => key).sort();
+
+    console.log("");
+    console.log(`[${template}] site=${site.siteId}`);
+    console.log(
+      `  sources: ${foundSources.length > 0 ? foundSources.join(", ") : "(none)"}`,
+    );
+    console.log(`  keys: ${redactedKeyList(keys)}`);
+
+    if (entries.length === 0) {
+      console.log("  skipped: no non-empty env values found");
+      continue;
+    }
+
+    if (!options.write) {
+      console.log(`  would sync ${entries.length} key(s)`);
+      continue;
+    }
+
+    let created = 0;
+    let updated = 0;
+
+    for (const [key, value] of entries.sort(([left], [right]) =>
+      left.localeCompare(right),
+    )) {
+      const result = await syncKey({
+        accountId: options.accountId!,
+        context: options.context,
+        key,
+        scopes: options.scopes,
+        siteId: site.siteId,
+        token: token!,
+        value,
+      });
+      if (result === "created") created += 1;
+      else updated += 1;
+      console.log(`  ${result}: ${key}`);
+    }
+
+    console.log(
+      `  synced ${entries.length} key(s): ${created} created, ${updated} updated`,
+    );
+  }
+}
+
+function parseOptionsOrExit(argv: string[]): Options {
+  try {
+    return parseArgs(argv);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    console.error("");
+    console.error(usage());
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -84,6 +84,8 @@ cd templates/content && pnpm action <name> [args]
 | Action                         | Args                                                                                                                         | Purpose                                                                               |
 | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | `list-documents`               | `[--format json]`                                                                                                            | List document metadata/tree; no full bodies                                           |
+| `export-content-source`        | `[--format json]`                                                                                                            | Export editable docs as `content/*.mdx` source files                                  |
+| `import-content-source`        | `--files <json> [--dryRun true\|false]`                                                                                      | Import `.md`/`.mdx` source files into editable docs                                   |
 | `navigate`                     | `--path <path>` or `--documentId <id>` or `--databaseId <id>`                                                                | Open a route, document page, or database page in the UI                               |
 | `search-documents`             | `--query <text> [--format json]`                                                                                             | Search by title/content and return snippets                                           |
 | `get-document`                 | `--id <id> [--format json]`                                                                                                  | Get a single document with content                                                    |
@@ -127,6 +129,17 @@ skipped. It is GET + read-only + public-agent exposed (`requiresAuth: true`),
 returns `{ id, title, content, format, deepLink }`, and surfaces an
 "Open document" deep link for external agents. Use `--format text` for a
 plain-text strip of the markdown.
+
+### Local Source Files
+
+The `/local-files` view syncs Content documents with Markdown/MDX files. Export
+uses `export-content-source` and writes one file per document under `content/`.
+Each file has frontmatter (`id`, `title`, `parentId`, `position`,
+`isFavorite`, `hideFromSearch`) followed by the document markdown body. Import
+uses `import-content-source`; files with known `id` values update existing docs
+only when the caller has editor access, and files without ids create new private
+docs for the current user. Use `--dryRun true` before a large import when the
+source folder may contain unexpected files.
 
 ### Notion Integration
 

--- a/templates/content/actions/export-content-source.ts
+++ b/templates/content/actions/export-content-source.ts
@@ -1,0 +1,54 @@
+import { defineAction } from "@agent-native/core";
+import { accessFilter } from "@agent-native/core/sharing";
+import { asc } from "drizzle-orm";
+import { z } from "zod";
+import { getDb, schema } from "../server/db/index.js";
+import {
+  buildContentSourceBundle,
+  type ContentSourceDocument,
+} from "../shared/content-source.js";
+import {
+  parseDocumentFavorite,
+  parseDocumentHideFromSearch,
+} from "../server/lib/documents.js";
+
+export default defineAction({
+  description:
+    "Export editable Content documents as source-control friendly Markdown/MDX files with frontmatter.",
+  schema: z.object({}),
+  http: { method: "GET" },
+  readOnly: true,
+  publicAgent: {
+    expose: true,
+    readOnly: true,
+    requiresAuth: true,
+    title: "Export Content Source",
+    description:
+      "Export Content documents as a local-file source bundle for MDX workflows.",
+  },
+  run: async () => {
+    const rows = await getDb()
+      .select()
+      .from(schema.documents)
+      .where(accessFilter(schema.documents, schema.documentShares))
+      .orderBy(asc(schema.documents.position), asc(schema.documents.title));
+
+    const documents: ContentSourceDocument[] = rows.map((doc) => ({
+      id: doc.id,
+      parentId: doc.parentId,
+      title: doc.title,
+      content: doc.content,
+      icon: doc.icon,
+      position: doc.position,
+      isFavorite: parseDocumentFavorite(doc.isFavorite),
+      hideFromSearch: parseDocumentHideFromSearch(doc.hideFromSearch),
+      visibility: doc.visibility,
+      updatedAt: doc.updatedAt,
+    }));
+
+    return {
+      ...buildContentSourceBundle(documents),
+      count: documents.length,
+    };
+  },
+});

--- a/templates/content/actions/import-content-source.ts
+++ b/templates/content/actions/import-content-source.ts
@@ -1,0 +1,393 @@
+import { defineAction } from "@agent-native/core";
+import {
+  getRequestOrgId,
+  getRequestUserEmail,
+} from "@agent-native/core/server/request-context";
+import { writeAppState } from "@agent-native/core/application-state";
+import { ROLE_RANK, resolveAccess } from "@agent-native/core/sharing";
+import { and, desc, eq } from "drizzle-orm";
+import { z } from "zod";
+import { getDb, schema } from "../server/db/index.js";
+import {
+  isContentSourcePath,
+  parseContentSourceFile,
+  type ParsedContentSourceFile,
+} from "../shared/content-source.js";
+
+const MAX_SOURCE_FILES = 500;
+const MAX_SOURCE_FILE_BYTES = 2 * 1024 * 1024;
+const SNAPSHOT_INTERVAL_MS = 5 * 60 * 1000;
+
+function nanoid(size = 12): string {
+  const chars =
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  let id = "";
+  const bytes = crypto.getRandomValues(new Uint8Array(size));
+  for (const byte of bytes) id += chars[byte % chars.length];
+  return id;
+}
+
+function boolToInt(value: boolean | undefined) {
+  return value ? 1 : 0;
+}
+
+function canEditRole(role: string) {
+  return ROLE_RANK[role as keyof typeof ROLE_RANK] >= ROLE_RANK.editor;
+}
+
+function normalizedFileEntries(files: Record<string, string>) {
+  return Object.entries(files)
+    .filter(([filePath]) => isContentSourcePath(filePath))
+    .sort(([a], [b]) => a.localeCompare(b));
+}
+
+async function maybeSnapshotExistingDocument(input: {
+  documentId: string;
+  ownerEmail: string;
+  title: string;
+  content: string;
+}) {
+  const db = getDb();
+  const [latestVersion] = await db
+    .select({ createdAt: schema.documentVersions.createdAt })
+    .from(schema.documentVersions)
+    .where(
+      and(
+        eq(schema.documentVersions.documentId, input.documentId),
+        eq(schema.documentVersions.ownerEmail, input.ownerEmail),
+      ),
+    )
+    .orderBy(desc(schema.documentVersions.createdAt))
+    .limit(1);
+
+  const shouldSnapshot =
+    !latestVersion ||
+    Date.now() - new Date(latestVersion.createdAt).getTime() >
+      SNAPSHOT_INTERVAL_MS;
+  if (!shouldSnapshot) return;
+
+  await db.insert(schema.documentVersions).values({
+    id: nanoid(),
+    ownerEmail: input.ownerEmail,
+    documentId: input.documentId,
+    title: input.title,
+    content: input.content,
+    createdAt: new Date().toISOString(),
+  });
+}
+
+function hasParentCycle(
+  id: string,
+  desiredParentById: Map<string, string | null>,
+) {
+  const seen = new Set([id]);
+  let parentId = desiredParentById.get(id) ?? null;
+  while (parentId) {
+    if (seen.has(parentId)) return true;
+    seen.add(parentId);
+    parentId = desiredParentById.get(parentId) ?? null;
+  }
+  return false;
+}
+
+async function assertParentIsNotDescendant(input: {
+  ownerEmail: string;
+  id: string;
+  parentId: string | null;
+}) {
+  if (!input.parentId) return;
+  const db = getDb();
+  const queue = [input.id];
+  const visited = new Set<string>();
+
+  while (queue.length > 0) {
+    const currentId = queue.shift()!;
+    if (visited.has(currentId)) continue;
+    visited.add(currentId);
+
+    const children = await db
+      .select({ id: schema.documents.id })
+      .from(schema.documents)
+      .where(
+        and(
+          eq(schema.documents.ownerEmail, input.ownerEmail),
+          eq(schema.documents.parentId, currentId),
+        ),
+      );
+
+    for (const child of children) {
+      if (child.id === input.parentId) {
+        throw new Error("Skipped parent update: cycle.");
+      }
+      queue.push(child.id);
+    }
+  }
+}
+
+export default defineAction({
+  description:
+    "Import Markdown/MDX source files into Content documents. Files with frontmatter ids update existing editable documents; files without ids create new private documents.",
+  schema: z.object({
+    files: z
+      .record(z.string(), z.string().max(MAX_SOURCE_FILE_BYTES))
+      .refine((files) => Object.keys(files).length <= MAX_SOURCE_FILES, {
+        message: `Import is limited to ${MAX_SOURCE_FILES} files.`,
+      })
+      .describe("Map of relative file path to UTF-8 markdown/MDX contents."),
+    dryRun: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe("Preview creates/updates without writing changes."),
+  }),
+  publicAgent: {
+    expose: true,
+    readOnly: false,
+    requiresAuth: true,
+    isConsequential: true,
+    title: "Import Content Source",
+    description:
+      "Import local Markdown/MDX source files into editable Content documents.",
+  },
+  run: async ({ files, dryRun }) => {
+    const entries = normalizedFileEntries(files);
+    if (entries.length === 0) {
+      throw new Error("No .md or .mdx files were provided.");
+    }
+
+    const currentUserEmail = getRequestUserEmail();
+    if (!currentUserEmail) throw new Error("no authenticated user");
+    const currentOrgId = getRequestOrgId() ?? null;
+    const db = getDb();
+    const now = new Date().toISOString();
+    const parsed: ParsedContentSourceFile[] = entries.map(
+      ([filePath, source]) => parseContentSourceFile(filePath, source),
+    );
+
+    const seenIds = new Set<string>();
+    const duplicateIds = new Set<string>();
+    for (const file of parsed) {
+      if (!file.id) continue;
+      if (seenIds.has(file.id)) duplicateIds.add(file.id);
+      seenIds.add(file.id);
+    }
+
+    const created: Array<{ id: string; path: string; title: string }> = [];
+    const updated: Array<{ id: string; path: string; title: string }> = [];
+    const unchanged: Array<{ id: string; path: string; title: string }> = [];
+    const skipped: Array<{ path: string; reason: string }> = [];
+    const errors: Array<{ path: string; reason: string }> = [];
+    const idByPath = new Map<string, string>();
+    const pathById = new Map<string, string>();
+    const ownerById = new Map<string, string>();
+    const desiredParentById = new Map<string, string | null>();
+    const desiredPositionById = new Map<string, number>();
+    const currentParentById = new Map<string, string | null>();
+    const currentPositionById = new Map<string, number>();
+
+    for (let index = 0; index < parsed.length; index += 1) {
+      const file = parsed[index];
+      if (file.id && duplicateIds.has(file.id)) {
+        errors.push({
+          path: file.path,
+          reason: `Duplicate source id "${file.id}".`,
+        });
+        continue;
+      }
+
+      const id = file.id ?? nanoid();
+      idByPath.set(file.path, id);
+      pathById.set(id, file.path);
+
+      const access = file.id ? await resolveAccess("document", file.id) : null;
+      if (access && !canEditRole(access.role)) {
+        skipped.push({
+          path: file.path,
+          reason: `Requires editor access to update document "${file.id}".`,
+        });
+        continue;
+      }
+
+      if (access) {
+        const existing = access.resource;
+        ownerById.set(id, existing.ownerEmail as string);
+        currentParentById.set(id, existing.parentId ?? null);
+        currentPositionById.set(id, existing.position ?? 0);
+        if (file.parentId !== undefined) {
+          desiredParentById.set(id, file.parentId);
+        }
+        if (file.position !== undefined) {
+          desiredPositionById.set(id, file.position);
+        }
+        const titleChanged = file.title !== existing.title;
+        const contentChanged = file.content !== existing.content;
+        const iconChanged =
+          file.icon !== undefined && file.icon !== existing.icon;
+        const favoriteChanged =
+          file.isFavorite !== undefined &&
+          boolToInt(file.isFavorite) !== (existing.isFavorite ?? 0);
+        const discoverabilityChanged =
+          file.hideFromSearch !== undefined &&
+          boolToInt(file.hideFromSearch) !== (existing.hideFromSearch ?? 0);
+        const anyChange =
+          titleChanged ||
+          contentChanged ||
+          iconChanged ||
+          favoriteChanged ||
+          discoverabilityChanged;
+
+        if (!anyChange) {
+          unchanged.push({ id, path: file.path, title: existing.title });
+          continue;
+        }
+
+        if (!dryRun) {
+          if (titleChanged || contentChanged) {
+            await maybeSnapshotExistingDocument({
+              documentId: id,
+              ownerEmail: existing.ownerEmail as string,
+              title: existing.title,
+              content: existing.content,
+            });
+          }
+
+          const updates: Record<string, unknown> = { updatedAt: now };
+          if (titleChanged) updates.title = file.title;
+          if (contentChanged) updates.content = file.content;
+          if (iconChanged) updates.icon = file.icon ?? null;
+          if (favoriteChanged) updates.isFavorite = boolToInt(file.isFavorite);
+          if (discoverabilityChanged) {
+            updates.hideFromSearch = boolToInt(file.hideFromSearch);
+          }
+
+          await db
+            .update(schema.documents)
+            .set(updates)
+            .where(eq(schema.documents.id, id));
+        }
+
+        updated.push({ id, path: file.path, title: file.title });
+        continue;
+      }
+
+      if (!dryRun) {
+        try {
+          await db.insert(schema.documents).values({
+            id,
+            ownerEmail: currentUserEmail,
+            orgId: currentOrgId,
+            parentId: null,
+            title: file.title,
+            content: file.content,
+            icon: file.icon ?? null,
+            position: file.position ?? index,
+            isFavorite: boolToInt(file.isFavorite),
+            hideFromSearch: boolToInt(file.hideFromSearch),
+            visibility: "private",
+            createdAt: now,
+            updatedAt: now,
+          });
+        } catch (err) {
+          errors.push({
+            path: file.path,
+            reason:
+              err instanceof Error
+                ? err.message
+                : `Could not create document "${id}".`,
+          });
+          desiredParentById.delete(id);
+          desiredPositionById.delete(id);
+          pathById.delete(id);
+          continue;
+        }
+      }
+      currentParentById.set(id, null);
+      currentPositionById.set(id, file.position ?? index);
+      desiredParentById.set(id, file.parentId ?? null);
+      desiredPositionById.set(id, file.position ?? index);
+      ownerById.set(id, currentUserEmail);
+      created.push({ id, path: file.path, title: file.title });
+    }
+
+    if (!dryRun) {
+      const layoutIds = new Set([
+        ...desiredParentById.keys(),
+        ...desiredPositionById.keys(),
+      ]);
+      for (const id of layoutIds) {
+        const parentId = desiredParentById.has(id)
+          ? (desiredParentById.get(id) ?? null)
+          : (currentParentById.get(id) ?? null);
+        if (hasParentCycle(id, desiredParentById)) {
+          skipped.push({
+            path: pathById.get(id) ?? id,
+            reason: "Skipped parent update: cycle.",
+          });
+          continue;
+        }
+
+        const ownerEmail = ownerById.get(id);
+        if (!ownerEmail) continue;
+
+        let safeParentId: string | null = null;
+        if (parentId) {
+          const parentAccess = await resolveAccess("document", parentId);
+          if (
+            parentAccess &&
+            (parentAccess.resource.ownerEmail as string) === ownerEmail
+          ) {
+            try {
+              await assertParentIsNotDescendant({ ownerEmail, id, parentId });
+              safeParentId = parentId;
+            } catch (err) {
+              skipped.push({
+                path: pathById.get(id) ?? id,
+                reason:
+                  err instanceof Error
+                    ? err.message
+                    : "Skipped parent update: cycle.",
+              });
+              continue;
+            }
+          } else {
+            skipped.push({
+              path: pathById.get(id) ?? id,
+              reason: `Skipped parent "${parentId}" because it is not editable in the same owner scope.`,
+            });
+          }
+        }
+
+        const nextPosition =
+          desiredPositionById.get(id) ?? currentPositionById.get(id) ?? 0;
+        if (
+          safeParentId === (currentParentById.get(id) ?? null) &&
+          nextPosition === (currentPositionById.get(id) ?? 0)
+        ) {
+          continue;
+        }
+
+        await db
+          .update(schema.documents)
+          .set({
+            parentId: safeParentId,
+            position: nextPosition,
+            updatedAt: now,
+          })
+          .where(eq(schema.documents.id, id));
+      }
+
+      await writeAppState("refresh-signal", { ts: Date.now() });
+    }
+
+    return {
+      dryRun,
+      filesSeen: entries.length,
+      created,
+      updated,
+      unchanged,
+      skipped,
+      errors,
+      idByPath: Object.fromEntries(idByPath),
+    };
+  },
+});

--- a/templates/content/actions/import-content-source.ts
+++ b/templates/content/actions/import-content-source.ts
@@ -187,6 +187,13 @@ export default defineAction({
 
     for (let index = 0; index < parsed.length; index += 1) {
       const file = parsed[index];
+      if (file.errors && file.errors.length > 0) {
+        errors.push({
+          path: file.path,
+          reason: file.errors.join(" "),
+        });
+        continue;
+      }
       if (file.id && duplicateIds.has(file.id)) {
         errors.push({
           path: file.path,

--- a/templates/content/actions/view-screen.ts
+++ b/templates/content/actions/view-screen.ts
@@ -649,6 +649,15 @@ export default defineAction({
     const nav = navigation as NavigationState | null;
     const db = getDb();
 
+    if (nav?.view === "local-files") {
+      screen.localFiles = {
+        view: "local-files",
+        actions: ["export-content-source", "import-content-source"],
+        sourceRoot: "content/",
+        fileTypes: [".md", ".mdx"],
+      };
+    }
+
     if (nav?.documentId) {
       const access = await resolveAccess("document", nav.documentId);
       if (access) {

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   closestCenter,
@@ -23,6 +23,7 @@ import {
   IconStar,
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
+  IconFolderOpen,
 } from "@tabler/icons-react";
 import { toast } from "sonner";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -113,6 +114,7 @@ export function DocumentSidebar({
   onResize,
 }: DocumentSidebarProps) {
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const { data: documents = [], isLoading } = useDocuments();
   const createDocument = useCreateDocument();
@@ -126,6 +128,7 @@ export function DocumentSidebar({
   const expandedIdsRef = useRef(new Set<string>());
   const [, forceUpdate] = useState(0);
   const [isResizing, setIsResizing] = useState(false);
+  const localFilesActive = location.pathname.startsWith("/local-files");
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: { distance: 6 },
@@ -490,6 +493,22 @@ export function DocumentSidebar({
           </TooltipTrigger>
           <TooltipContent>New page</TooltipContent>
         </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              className={cn(
+                "w-10 h-10 flex items-center justify-center rounded-lg hover:bg-accent",
+                localFilesActive
+                  ? "bg-accent text-accent-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+              onClick={() => navigate("/local-files")}
+            >
+              <IconFolderOpen size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Local files</TooltipContent>
+        </Tooltip>
       </div>
     );
   }
@@ -713,6 +732,18 @@ export function DocumentSidebar({
       {/* Footer */}
       <div className="shrink-0 space-y-2 border-t border-border px-3 py-2">
         <OrgSwitcher />
+        <button
+          className={cn(
+            "flex h-8 w-full items-center gap-2 rounded-md px-2 text-sm",
+            localFilesActive
+              ? "bg-accent text-accent-foreground"
+              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+          )}
+          onClick={() => navigate("/local-files")}
+        >
+          <IconFolderOpen size={15} className="shrink-0" />
+          <span className="min-w-0 flex-1 truncate text-left">Local files</span>
+        </button>
         <DevDatabaseLink />
         <div className="flex items-center gap-1">
           <FeedbackButton className="h-8 min-w-0 flex-1 gap-2 rounded-md px-2 py-0" />

--- a/templates/content/app/hooks/use-navigation-state.ts
+++ b/templates/content/app/hooks/use-navigation-state.ts
@@ -22,6 +22,7 @@ export function useNavigationState() {
   useAgentRouteState<NavigationState>({
     getNavigationState: ({ pathname }) => {
       if (pathname === "/" || pathname === "") return { view: "list" };
+      if (pathname.startsWith("/local-files")) return { view: "local-files" };
 
       // Document editor: /:id or /page/:id
       const pageMatch = pathname.match(/^\/page\/(.+)/);
@@ -34,6 +35,7 @@ export function useNavigationState() {
     getCommandPath: (cmd) => {
       if (cmd.path) return cmd.path;
       if (cmd.documentId) return `/page/${cmd.documentId}`;
+      if (cmd.view === "local-files") return "/local-files";
       if (cmd.view === "list") return "/";
       return null;
     },

--- a/templates/content/app/routes/_app.local-files.tsx
+++ b/templates/content/app/routes/_app.local-files.tsx
@@ -1,0 +1,420 @@
+import { useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { callAction } from "@agent-native/core/client";
+import {
+  IconAlertCircle,
+  IconDownload,
+  IconFileText,
+  IconFolderOpen,
+  IconRefresh,
+  IconUpload,
+} from "@tabler/icons-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { useSetPageTitle } from "@/components/layout/HeaderActions";
+import { CONTENT_SOURCE_ROOT } from "@shared/content-source";
+
+type PermissionState = "granted" | "denied" | "prompt";
+type LocalWritable = {
+  write(data: string): Promise<void>;
+  close(): Promise<void>;
+};
+type LocalFileHandle = {
+  kind: "file";
+  name: string;
+  getFile(): Promise<File>;
+  createWritable(): Promise<LocalWritable>;
+};
+type LocalDirectoryHandle = {
+  kind: "directory";
+  name: string;
+  values(): AsyncIterable<LocalFileHandle | LocalDirectoryHandle>;
+  getDirectoryHandle(
+    name: string,
+    options?: { create?: boolean },
+  ): Promise<LocalDirectoryHandle>;
+  getFileHandle(
+    name: string,
+    options?: { create?: boolean },
+  ): Promise<LocalFileHandle>;
+  queryPermission?(descriptor: {
+    mode: "read" | "readwrite";
+  }): Promise<PermissionState>;
+  requestPermission?(descriptor: {
+    mode: "read" | "readwrite";
+  }): Promise<PermissionState>;
+};
+type WindowWithDirectoryPicker = Window & {
+  showDirectoryPicker?: (options?: {
+    mode?: "read" | "readwrite";
+  }) => Promise<LocalDirectoryHandle>;
+};
+
+interface ExportContentSourceResult {
+  count: number;
+  files: Record<string, string>;
+  exportedAt: string;
+}
+
+interface ImportContentSourceResult {
+  dryRun: boolean;
+  filesSeen: number;
+  created: Array<{ id: string; path: string; title: string }>;
+  updated: Array<{ id: string; path: string; title: string }>;
+  unchanged: Array<{ id: string; path: string; title: string }>;
+  skipped: Array<{ path: string; reason: string }>;
+  errors: Array<{ path: string; reason: string }>;
+}
+
+type SyncStatus =
+  | { kind: "idle" }
+  | { kind: "success"; title: string; detail: string }
+  | { kind: "error"; title: string; detail: string }
+  | { kind: "preview"; result: ImportContentSourceResult };
+
+const IGNORED_DIRECTORIES = new Set([
+  ".git",
+  ".next",
+  ".turbo",
+  "build",
+  "dist",
+  "node_modules",
+]);
+
+function supportsDirectoryPicker() {
+  return typeof window !== "undefined" && "showDirectoryPicker" in window;
+}
+
+function isMarkdownPath(path: string) {
+  return /\.(md|mdx)$/i.test(path);
+}
+
+async function ensureReadWritePermission(handle: LocalDirectoryHandle) {
+  const descriptor = { mode: "readwrite" as const };
+  if ((await handle.queryPermission?.(descriptor)) === "granted") return true;
+  return (await handle.requestPermission?.(descriptor)) === "granted";
+}
+
+async function chooseDirectory() {
+  const picker = (window as WindowWithDirectoryPicker).showDirectoryPicker;
+  if (!picker) throw new Error("Folder access is not available here.");
+  return picker({ mode: "readwrite" });
+}
+
+async function sourceReadRoot(handle: LocalDirectoryHandle): Promise<{
+  handle: LocalDirectoryHandle;
+  prefix: string;
+}> {
+  if (handle.name === CONTENT_SOURCE_ROOT) {
+    return { handle, prefix: `${CONTENT_SOURCE_ROOT}/` };
+  }
+  try {
+    const contentHandle = await handle.getDirectoryHandle(CONTENT_SOURCE_ROOT);
+    return { handle: contentHandle, prefix: `${CONTENT_SOURCE_ROOT}/` };
+  } catch {
+    return { handle, prefix: "" };
+  }
+}
+
+async function collectMarkdownFiles(
+  handle: LocalDirectoryHandle,
+  prefix = "",
+): Promise<Record<string, string>> {
+  const files: Record<string, string> = {};
+  for await (const entry of handle.values()) {
+    const path = `${prefix}${entry.name}`;
+    if (entry.kind === "directory") {
+      if (IGNORED_DIRECTORIES.has(entry.name)) continue;
+      Object.assign(files, await collectMarkdownFiles(entry, `${path}/`));
+      continue;
+    }
+
+    if (!isMarkdownPath(path)) continue;
+    const file = await entry.getFile();
+    if (file.size > 2 * 1024 * 1024) continue;
+    files[path] = await file.text();
+  }
+  return files;
+}
+
+async function writeFile(
+  root: LocalDirectoryHandle,
+  filePath: string,
+  content: string,
+) {
+  const writePath =
+    root.name === CONTENT_SOURCE_ROOT &&
+    filePath.startsWith(`${CONTENT_SOURCE_ROOT}/`)
+      ? filePath.slice(CONTENT_SOURCE_ROOT.length + 1)
+      : filePath;
+  const parts = writePath.split("/").filter(Boolean);
+  const filename = parts.pop();
+  if (!filename) return;
+
+  let dir = root;
+  for (const part of parts) {
+    dir = await dir.getDirectoryHandle(part, { create: true });
+  }
+  const file = await dir.getFileHandle(filename, { create: true });
+  const writable = await file.createWritable();
+  await writable.write(content);
+  await writable.close();
+}
+
+function resultSummary(result: ImportContentSourceResult) {
+  return [
+    `${result.created.length} created`,
+    `${result.updated.length} updated`,
+    `${result.unchanged.length} unchanged`,
+    `${result.skipped.length} skipped`,
+    `${result.errors.length} errors`,
+  ].join(" | ");
+}
+
+export function meta() {
+  return [{ title: "Local files - Content" }];
+}
+
+export default function LocalFilesRoute() {
+  const queryClient = useQueryClient();
+  const [directory, setDirectory] = useState<LocalDirectoryHandle | null>(null);
+  const [status, setStatus] = useState<SyncStatus>({ kind: "idle" });
+  const [busy, setBusy] = useState<
+    "choose" | "export" | "preview" | "import" | null
+  >(null);
+  const supported = useMemo(supportsDirectoryPicker, []);
+
+  useSetPageTitle(
+    <h1 className="text-lg font-semibold tracking-tight truncate">
+      Local files
+    </h1>,
+  );
+
+  async function handleChooseFolder() {
+    setBusy("choose");
+    try {
+      const handle = await chooseDirectory();
+      setDirectory(handle);
+      setStatus({
+        kind: "success",
+        title: "Folder selected",
+        detail: handle.name,
+      });
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        title: "Folder selection failed",
+        detail: err instanceof Error ? err.message : "Choose another folder.",
+      });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleExport() {
+    if (!directory) return;
+    setBusy("export");
+    try {
+      if (!(await ensureReadWritePermission(directory))) {
+        throw new Error("Write permission was not granted.");
+      }
+      const bundle = await callAction<ExportContentSourceResult>(
+        "export-content-source" as never,
+        {} as never,
+        { method: "GET" },
+      );
+      await Promise.all(
+        Object.entries(bundle.files).map(([path, content]) =>
+          writeFile(directory, path, content),
+        ),
+      );
+      setStatus({
+        kind: "success",
+        title: "Export complete",
+        detail: `${bundle.count} documents written at ${new Date(
+          bundle.exportedAt,
+        ).toLocaleTimeString()}`,
+      });
+      toast.success("Exported local files");
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        title: "Export failed",
+        detail: err instanceof Error ? err.message : "Try again.",
+      });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function readSelectedSourceFiles() {
+    if (!directory) throw new Error("Choose a folder first.");
+    const root = await sourceReadRoot(directory);
+    return collectMarkdownFiles(root.handle, root.prefix);
+  }
+
+  async function handlePreviewImport() {
+    setBusy("preview");
+    try {
+      const files = await readSelectedSourceFiles();
+      const result = await callAction<ImportContentSourceResult>(
+        "import-content-source" as never,
+        { files, dryRun: true } as never,
+      );
+      setStatus({ kind: "preview", result });
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        title: "Preview failed",
+        detail: err instanceof Error ? err.message : "Try again.",
+      });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleImport() {
+    setBusy("import");
+    try {
+      const files = await readSelectedSourceFiles();
+      const result = await callAction<ImportContentSourceResult>(
+        "import-content-source" as never,
+        { files, dryRun: false } as never,
+      );
+      setStatus({
+        kind: "success",
+        title: "Import complete",
+        detail: resultSummary(result),
+      });
+      queryClient.invalidateQueries({ queryKey: ["action", "list-documents"] });
+      toast.success("Imported local files");
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        title: "Import failed",
+        detail: err instanceof Error ? err.message : "Try again.",
+      });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const disabled = !directory || busy !== null;
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-6 sm:px-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0">
+            <h2 className="text-2xl font-bold tracking-tight">Source folder</h2>
+            <p className="mt-1 truncate text-sm text-muted-foreground">
+              {directory ? directory.name : "No folder selected"}
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            onClick={handleChooseFolder}
+            disabled={!supported || busy !== null}
+          >
+            <IconFolderOpen />
+            {busy === "choose" ? "Choosing..." : "Choose folder"}
+          </Button>
+        </div>
+
+        {!supported && (
+          <div className="rounded-md border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+            Folder access is unavailable in this browser.
+          </div>
+        )}
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Button onClick={handleExport} disabled={disabled}>
+            <IconDownload />
+            {busy === "export" ? "Exporting..." : "Export"}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={handlePreviewImport}
+            disabled={disabled}
+          >
+            <IconRefresh />
+            {busy === "preview" ? "Previewing..." : "Preview"}
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={handleImport}
+            disabled={disabled}
+          >
+            <IconUpload />
+            {busy === "import" ? "Importing..." : "Import"}
+          </Button>
+        </div>
+
+        <Separator />
+
+        <div className="rounded-md border border-border bg-background p-4">
+          {status.kind === "idle" && (
+            <div className="flex items-start gap-3 text-sm text-muted-foreground">
+              <IconFileText className="mt-0.5 size-4" />
+              <span>Pick a folder to sync Markdown source files.</span>
+            </div>
+          )}
+          {status.kind === "success" && (
+            <div className="flex items-start gap-3 text-sm">
+              <IconFileText className="mt-0.5 size-4 text-primary" />
+              <div>
+                <div className="font-medium">{status.title}</div>
+                <div className="mt-1 text-muted-foreground">
+                  {status.detail}
+                </div>
+              </div>
+            </div>
+          )}
+          {status.kind === "error" && (
+            <div className="flex items-start gap-3 text-sm">
+              <IconAlertCircle className="mt-0.5 size-4 text-destructive" />
+              <div>
+                <div className="font-medium text-destructive">
+                  {status.title}
+                </div>
+                <div className="mt-1 text-muted-foreground">
+                  {status.detail}
+                </div>
+              </div>
+            </div>
+          )}
+          {status.kind === "preview" && (
+            <div className="space-y-4 text-sm">
+              <div className="flex items-start gap-3">
+                <IconFileText className="mt-0.5 size-4 text-primary" />
+                <div>
+                  <div className="font-medium">Preview ready</div>
+                  <div className="mt-1 text-muted-foreground">
+                    {resultSummary(status.result)}
+                  </div>
+                </div>
+              </div>
+              {(status.result.skipped.length > 0 ||
+                status.result.errors.length > 0) && (
+                <div className="space-y-2 rounded-md bg-muted/40 p-3">
+                  {[...status.result.errors, ...status.result.skipped]
+                    .slice(0, 6)
+                    .map((item) => (
+                      <div key={`${item.path}:${item.reason}`}>
+                        <span className="font-medium">{item.path}</span>
+                        <span className="text-muted-foreground">
+                          {" "}
+                          - {item.reason}
+                        </span>
+                      </div>
+                    ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/templates/content/app/routes/_app.local-files.tsx
+++ b/templates/content/app/routes/_app.local-files.tsx
@@ -38,6 +38,7 @@ type LocalDirectoryHandle = {
     name: string,
     options?: { create?: boolean },
   ): Promise<LocalFileHandle>;
+  removeEntry(name: string, options?: { recursive?: boolean }): Promise<void>;
   queryPermission?(descriptor: {
     mode: "read" | "readwrite";
   }): Promise<PermissionState>;
@@ -162,6 +163,37 @@ async function writeFile(
   await writable.close();
 }
 
+async function sourceWriteRoot(
+  handle: LocalDirectoryHandle,
+): Promise<{ handle: LocalDirectoryHandle; prefix: string }> {
+  if (handle.name === CONTENT_SOURCE_ROOT) {
+    return { handle, prefix: `${CONTENT_SOURCE_ROOT}/` };
+  }
+  const contentHandle = await handle.getDirectoryHandle(CONTENT_SOURCE_ROOT, {
+    create: true,
+  });
+  return { handle: contentHandle, prefix: `${CONTENT_SOURCE_ROOT}/` };
+}
+
+async function removeStaleMarkdownFiles(
+  handle: LocalDirectoryHandle,
+  prefix: string,
+  expectedPaths: Set<string>,
+) {
+  for await (const entry of handle.values()) {
+    const path = `${prefix}${entry.name}`;
+    if (entry.kind === "directory") {
+      if (IGNORED_DIRECTORIES.has(entry.name)) continue;
+      await removeStaleMarkdownFiles(entry, `${path}/`, expectedPaths);
+      continue;
+    }
+
+    if (isMarkdownPath(path) && !expectedPaths.has(path)) {
+      await handle.removeEntry(entry.name);
+    }
+  }
+}
+
 function resultSummary(result: ImportContentSourceResult) {
   return [
     `${result.created.length} created`,
@@ -224,10 +256,17 @@ export default function LocalFilesRoute() {
         {} as never,
         { method: "GET" },
       );
+      const expectedPaths = new Set(Object.keys(bundle.files));
       await Promise.all(
         Object.entries(bundle.files).map(([path, content]) =>
           writeFile(directory, path, content),
         ),
+      );
+      const writeRoot = await sourceWriteRoot(directory);
+      await removeStaleMarkdownFiles(
+        writeRoot.handle,
+        writeRoot.prefix,
+        expectedPaths,
       );
       setStatus({
         kind: "success",

--- a/templates/content/shared/content-source.spec.ts
+++ b/templates/content/shared/content-source.spec.ts
@@ -74,6 +74,19 @@ describe("content source files", () => {
     });
   });
 
+  it("reports invalid parent frontmatter instead of reparenting", () => {
+    expect(
+      parseContentSourceFile(
+        "content/pricing-page.mdx",
+        '---\nid: "doc_1234"\ntitle: "Pricing"\nparentId: "bad id"\n---\n\nBody',
+      ),
+    ).toMatchObject({
+      id: "doc_1234",
+      parentId: undefined,
+      errors: ["Invalid parentId frontmatter."],
+    });
+  });
+
   it("builds a deterministic content bundle path per document", () => {
     const doc = {
       id: "abc123",

--- a/templates/content/shared/content-source.spec.ts
+++ b/templates/content/shared/content-source.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildContentSourceBundle,
+  contentSourcePathForDocument,
+  parseContentSourceFile,
+  serializeContentSourceDocument,
+} from "./content-source";
+
+describe("content source files", () => {
+  it("serializes documents as frontmatter plus markdown body", () => {
+    const source = serializeContentSourceDocument({
+      id: "doc_1234",
+      parentId: "parent_1234",
+      title: "Launch Plan",
+      content: "## Goals\n\nShip the thing.",
+      icon: "rocket",
+      position: 2,
+      isFavorite: true,
+      hideFromSearch: false,
+      visibility: "private",
+      updatedAt: "2026-06-11T12:00:00.000Z",
+    });
+
+    expect(source).toContain('id: "doc_1234"');
+    expect(source).toContain('title: "Launch Plan"');
+    expect(source).toContain("isFavorite: true");
+    expect(source.endsWith("## Goals\n\nShip the thing.")).toBe(true);
+  });
+
+  it("parses exported source without adding a leading blank line", () => {
+    const source = serializeContentSourceDocument({
+      id: "doc_1234",
+      parentId: null,
+      title: "Launch Plan",
+      content: "First line\n\nSecond line",
+      icon: null,
+      position: 0,
+      isFavorite: false,
+      hideFromSearch: false,
+      visibility: "private",
+    });
+
+    expect(
+      parseContentSourceFile("content/launch-plan--doc_1234.mdx", source),
+    ).toMatchObject({
+      id: "doc_1234",
+      parentId: null,
+      title: "Launch Plan",
+      content: "First line\n\nSecond line",
+    });
+  });
+
+  it("falls back to the filename when a file has no frontmatter", () => {
+    expect(
+      parseContentSourceFile("content/pricing-page.mdx", "# Pricing"),
+    ).toMatchObject({
+      id: undefined,
+      title: "Pricing Page",
+      content: "# Pricing",
+    });
+  });
+
+  it("leaves optional metadata undefined when omitted from frontmatter", () => {
+    expect(
+      parseContentSourceFile(
+        "content/pricing-page.mdx",
+        '---\nid: "doc_1234"\ntitle: "Pricing"\n---\n\nBody',
+      ),
+    ).toMatchObject({
+      id: "doc_1234",
+      title: "Pricing",
+      parentId: undefined,
+      icon: undefined,
+    });
+  });
+
+  it("builds a deterministic content bundle path per document", () => {
+    const doc = {
+      id: "abc123",
+      parentId: null,
+      title: "Hello, World!",
+      content: "Body",
+      icon: null,
+      position: 0,
+      isFavorite: false,
+      hideFromSearch: false,
+      visibility: "private" as const,
+    };
+
+    const bundle = buildContentSourceBundle([doc]);
+
+    expect(contentSourcePathForDocument(doc)).toBe(
+      "content/hello-world--abc123.mdx",
+    );
+    expect(Object.keys(bundle.files)).toEqual([
+      "content/hello-world--abc123.mdx",
+    ]);
+  });
+});

--- a/templates/content/shared/content-source.ts
+++ b/templates/content/shared/content-source.ts
@@ -1,0 +1,229 @@
+export const CONTENT_SOURCE_ROOT = "content";
+export const CONTENT_SOURCE_EXTENSIONS = [".md", ".mdx"] as const;
+
+export interface ContentSourceDocument {
+  id: string;
+  parentId: string | null;
+  title: string;
+  content: string;
+  icon: string | null;
+  position: number;
+  isFavorite: boolean;
+  hideFromSearch: boolean;
+  visibility?: "private" | "org" | "public";
+  updatedAt?: string;
+}
+
+export interface ContentSourceFile {
+  path: string;
+  document: ContentSourceDocument;
+}
+
+export interface ContentSourceBundle {
+  root: typeof CONTENT_SOURCE_ROOT;
+  exportedAt: string;
+  files: Record<string, string>;
+}
+
+export interface ParsedContentSourceFile {
+  path: string;
+  id?: string;
+  parentId?: string | null;
+  title: string;
+  content: string;
+  icon?: string | null;
+  position?: number;
+  isFavorite?: boolean;
+  hideFromSearch?: boolean;
+}
+
+const FRONTMATTER_RE =
+  /^---\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n\r?\n|\r?\n|$)/;
+const VALID_SOURCE_ID_RE = /^[A-Za-z0-9_-]{4,128}$/;
+
+function basename(filePath: string): string {
+  return filePath.split("/").pop() ?? filePath;
+}
+
+function stripExtension(name: string): string {
+  return name.replace(/\.(mdx?|markdown)$/i, "");
+}
+
+function titleFromPath(filePath: string): string {
+  return stripExtension(basename(filePath))
+    .replace(/--[A-Za-z0-9_-]{4,128}$/, "")
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function slugifyTitle(title: string): string {
+  const slug = title
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 72)
+    .replace(/-+$/g, "");
+  return slug || "untitled";
+}
+
+function parseFrontmatterValue(value: string): unknown {
+  const trimmed = value.trim();
+  if (trimmed === "") return "";
+  if (trimmed === "null") return null;
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (/^-?\d+$/.test(trimmed)) return Number(trimmed);
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return trimmed.replace(/^['"]|['"]$/g, "");
+  }
+}
+
+function parseFrontmatter(raw: string): Record<string, unknown> {
+  const data: Record<string, unknown> = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const match = trimmed.match(/^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/);
+    if (!match) continue;
+    data[match[1]] = parseFrontmatterValue(match[2] ?? "");
+  }
+  return data;
+}
+
+function hasOwn(data: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(data, key);
+}
+
+function frontmatterLine(key: string, value: unknown): string {
+  if (value === undefined) return "";
+  if (value === null) return `${key}: null`;
+  if (typeof value === "boolean" || typeof value === "number") {
+    return `${key}: ${String(value)}`;
+  }
+  return `${key}: ${JSON.stringify(String(value))}`;
+}
+
+function normalizeSourcePath(filePath: string): string | null {
+  const normalized = filePath.replace(/\\/g, "/").replace(/^\/+/, "");
+  if (
+    !normalized ||
+    normalized.includes("\0") ||
+    normalized.split("/").some((part) => !part || part === "." || part === "..")
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+export function isContentSourcePath(filePath: string): boolean {
+  const normalized = normalizeSourcePath(filePath);
+  if (!normalized) return false;
+  return CONTENT_SOURCE_EXTENSIONS.some((ext) =>
+    normalized.toLowerCase().endsWith(ext),
+  );
+}
+
+export function isValidContentSourceId(id: string | null | undefined): boolean {
+  return !!id && VALID_SOURCE_ID_RE.test(id);
+}
+
+export function contentSourcePathForDocument(
+  doc: Pick<ContentSourceDocument, "id" | "title">,
+): string {
+  return `${CONTENT_SOURCE_ROOT}/${slugifyTitle(doc.title)}--${doc.id}.mdx`;
+}
+
+export function serializeContentSourceDocument(
+  doc: ContentSourceDocument,
+): string {
+  const frontmatter = [
+    frontmatterLine("id", doc.id),
+    frontmatterLine("title", doc.title || "Untitled"),
+    frontmatterLine("parentId", doc.parentId),
+    frontmatterLine("icon", doc.icon),
+    frontmatterLine("position", doc.position),
+    frontmatterLine("isFavorite", doc.isFavorite),
+    frontmatterLine("hideFromSearch", doc.hideFromSearch),
+    frontmatterLine("visibility", doc.visibility),
+    frontmatterLine("updatedAt", doc.updatedAt),
+  ].filter(Boolean);
+  return `---\n${frontmatter.join("\n")}\n---\n\n${doc.content ?? ""}`;
+}
+
+export function parseContentSourceFile(
+  filePath: string,
+  source: string,
+): ParsedContentSourceFile {
+  const match = source.match(FRONTMATTER_RE);
+  const metadata = match ? parseFrontmatter(match[1]) : {};
+  const content = match ? source.slice(match[0].length) : source;
+  const rawId = typeof metadata.id === "string" ? metadata.id : undefined;
+  const id = isValidContentSourceId(rawId) ? rawId : undefined;
+  const rawParentId = hasOwn(metadata, "parentId")
+    ? typeof metadata.parentId === "string"
+      ? metadata.parentId
+      : null
+    : undefined;
+  const parentId =
+    rawParentId === undefined
+      ? undefined
+      : rawParentId && isValidContentSourceId(rawParentId)
+        ? rawParentId
+        : null;
+  const rawTitle = typeof metadata.title === "string" ? metadata.title : "";
+  const title = rawTitle.trim() || titleFromPath(filePath) || "Untitled";
+  const rawPosition = metadata.position;
+
+  return {
+    path: filePath,
+    id,
+    parentId,
+    title,
+    content,
+    icon: hasOwn(metadata, "icon")
+      ? typeof metadata.icon === "string"
+        ? metadata.icon
+        : null
+      : undefined,
+    position:
+      typeof rawPosition === "number" && Number.isFinite(rawPosition)
+        ? rawPosition
+        : undefined,
+    isFavorite:
+      typeof metadata.isFavorite === "boolean"
+        ? metadata.isFavorite
+        : undefined,
+    hideFromSearch:
+      typeof metadata.hideFromSearch === "boolean"
+        ? metadata.hideFromSearch
+        : undefined,
+  };
+}
+
+export function buildContentSourceBundle(
+  documents: ContentSourceDocument[],
+): ContentSourceBundle {
+  const files: Record<string, string> = {};
+  const usedPaths = new Set<string>();
+
+  for (const doc of documents) {
+    let filePath = contentSourcePathForDocument(doc);
+    if (usedPaths.has(filePath)) {
+      filePath = `${CONTENT_SOURCE_ROOT}/${slugifyTitle(doc.title)}--${doc.id}.mdx`;
+    }
+    usedPaths.add(filePath);
+    files[filePath] = serializeContentSourceDocument(doc);
+  }
+
+  return {
+    root: CONTENT_SOURCE_ROOT,
+    exportedAt: new Date().toISOString(),
+    files,
+  };
+}

--- a/templates/content/shared/content-source.ts
+++ b/templates/content/shared/content-source.ts
@@ -35,6 +35,7 @@ export interface ParsedContentSourceFile {
   position?: number;
   isFavorite?: boolean;
   hideFromSearch?: boolean;
+  errors?: string[];
 }
 
 const FRONTMATTER_RE =
@@ -163,19 +164,22 @@ export function parseContentSourceFile(
   const match = source.match(FRONTMATTER_RE);
   const metadata = match ? parseFrontmatter(match[1]) : {};
   const content = match ? source.slice(match[0].length) : source;
+  const errors: string[] = [];
   const rawId = typeof metadata.id === "string" ? metadata.id : undefined;
   const id = isValidContentSourceId(rawId) ? rawId : undefined;
-  const rawParentId = hasOwn(metadata, "parentId")
-    ? typeof metadata.parentId === "string"
-      ? metadata.parentId
-      : null
-    : undefined;
-  const parentId =
-    rawParentId === undefined
-      ? undefined
-      : rawParentId && isValidContentSourceId(rawParentId)
-        ? rawParentId
-        : null;
+  let parentId: string | null | undefined;
+  if (hasOwn(metadata, "parentId")) {
+    if (metadata.parentId === null) {
+      parentId = null;
+    } else if (
+      typeof metadata.parentId === "string" &&
+      isValidContentSourceId(metadata.parentId)
+    ) {
+      parentId = metadata.parentId;
+    } else {
+      errors.push("Invalid parentId frontmatter.");
+    }
+  }
   const rawTitle = typeof metadata.title === "string" ? metadata.title : "";
   const title = rawTitle.trim() || titleFromPath(filePath) || "Untitled";
   const rawPosition = metadata.position;
@@ -203,6 +207,7 @@ export function parseContentSourceFile(
       typeof metadata.hideFromSearch === "boolean"
         ? metadata.hideFromSearch
         : undefined,
+    errors: errors.length > 0 ? errors : undefined,
   };
 }
 

--- a/templates/plan/AGENTS.md
+++ b/templates/plan/AGENTS.md
@@ -130,6 +130,11 @@ sync-guarded skills (not just one stored plan) so the improvement sticks.
   persists the runtime model. Prefer this over regenerating a whole plan when the
   requested change is a few lines, one annotation, one artboard, or one
   wireframe node.
+- In Agent Native Desktop, the Plan menu can link a user-chosen local folder for
+  the current plan, write the exported MDX files to it, import local edits back
+  through `import-visual-plan-source`, and optionally auto-export whenever the
+  hosted plan changes. This is a native desktop bridge; it does not require a
+  cloned Plan app or CLI process.
 - Do not fork the vocabulary. MDX components must map to the same runtime terms:
   `DesignBoard`, `Section`, `Artboard`, `Screen`, `Annotation`, `Connector`, and
   the wireframe kit primitives from `shared/plan-content.ts`.

--- a/templates/plan/app/hooks/use-plans.ts
+++ b/templates/plan/app/hooks/use-plans.ts
@@ -2,6 +2,7 @@ import { useQueryClient, type UseQueryOptions } from "@tanstack/react-query";
 import type { RefObject } from "react";
 import { toast } from "sonner";
 import { useActionMutation, useActionQuery } from "@agent-native/core/client";
+import type { PlanMdxFolder } from "@/lib/desktop-plan-files";
 import type {
   PlanAuthor,
   PlanBundle,
@@ -9,6 +10,7 @@ import type {
   PlanCommentMention,
   PlanCommentResolutionTarget,
   PlanCommentStatus,
+  PlanKind,
   PlanSectionType,
   PlanSource,
   PlanStatus,
@@ -396,11 +398,36 @@ export function usePublishVisualPlan() {
   );
 }
 
+export type ImportPlanSourceInput = {
+  planId?: string;
+  expectedUpdatedAt?: string;
+  title?: string;
+  brief?: string;
+  kind?: PlanKind;
+  source?: PlanSource;
+  repoPath?: string;
+  currentFocus?: string;
+  status?: PlanStatus;
+  mdx: PlanMdxFolder;
+};
+
+export function useImportPlanSource() {
+  const invalidate = usePlanInvalidation();
+  return useActionMutation<
+    PlanBundle & { path?: string; url?: string; html?: string },
+    ImportPlanSourceInput
+  >("import-visual-plan-source", {
+    onSuccess: invalidate,
+    onError: showActionError("Failed to import plan source"),
+  });
+}
+
 export function useExportPlan(planId?: string) {
   return useActionQuery<{
     markdown: string;
     html: string;
     json: PlanBundle;
+    mdx: PlanMdxFolder;
     path: string;
     url: string;
   }>("export-visual-plan", { planId: planId ?? "" }, { enabled: false });

--- a/templates/plan/app/lib/desktop-plan-files.ts
+++ b/templates/plan/app/lib/desktop-plan-files.ts
@@ -1,0 +1,57 @@
+export interface PlanMdxFolder {
+  "plan.mdx": string;
+  "canvas.mdx"?: string;
+  "prototype.mdx"?: string;
+  ".plan-state.json"?: string;
+  "assets/"?: Record<string, string>;
+}
+
+export interface DesktopPlanFilesFolder {
+  path: string;
+  name: string;
+  planId: string;
+  title?: string;
+  updatedAt?: string;
+}
+
+export type DesktopPlanFilesResult =
+  | {
+      ok: true;
+      folder: DesktopPlanFilesFolder;
+      files?: string[];
+      mdx?: PlanMdxFolder;
+    }
+  | {
+      ok: false;
+      error: string;
+      canceled?: boolean;
+      folder?: DesktopPlanFilesFolder;
+    };
+
+export interface DesktopPlanFilesApi {
+  getFolder(request: { planId: string }): Promise<DesktopPlanFilesResult>;
+  chooseFolder(request: {
+    planId: string;
+    title?: string;
+  }): Promise<DesktopPlanFilesResult>;
+  writePlan(request: {
+    planId: string;
+    title?: string;
+    mdx: PlanMdxFolder;
+  }): Promise<DesktopPlanFilesResult>;
+  readPlan(request: { planId: string }): Promise<DesktopPlanFilesResult>;
+  clearFolder(request: { planId: string }): Promise<DesktopPlanFilesResult>;
+}
+
+declare global {
+  interface Window {
+    agentNativeDesktop?: {
+      planFiles?: DesktopPlanFilesApi;
+    };
+  }
+}
+
+export function getDesktopPlanFiles(): DesktopPlanFilesApi | null {
+  if (typeof window === "undefined") return null;
+  return window.agentNativeDesktop?.planFiles ?? null;
+}

--- a/templates/plan/app/lib/desktop-plan-files.ts
+++ b/templates/plan/app/lib/desktop-plan-files.ts
@@ -7,7 +7,6 @@ export interface PlanMdxFolder {
 }
 
 export interface DesktopPlanFilesFolder {
-  path: string;
   name: string;
   planId: string;
   title?: string;

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -26,6 +26,7 @@ import {
   IconDownload,
   IconExternalLink,
   IconFileZip,
+  IconFolder,
   IconDotsVertical,
   IconHistory,
   IconLayoutSidebarRight,
@@ -78,6 +79,7 @@ import {
 } from "@/components/ui/dialog";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
@@ -148,10 +150,15 @@ import {
   useUpdatePlanComments,
   useUpdatePlanStatus,
   useExportPlan,
+  useImportPlanSource,
   type PlanCommentInput,
   type PublishVisualPlanResult,
 } from "@/hooks/use-plans";
 import { cn } from "@/lib/utils";
+import {
+  getDesktopPlanFiles,
+  type DesktopPlanFilesFolder,
+} from "@/lib/desktop-plan-files";
 import {
   type PlanBundle,
   type PlanKind,
@@ -209,6 +216,8 @@ type PreferredEditor =
   | "xcode";
 
 const PREFERRED_EDITOR_STORAGE_KEY = "agent-native-plans.preferredEditor";
+const DESKTOP_PLAN_SYNC_AUTO_KEY_PREFIX =
+  "agent-native-plans.desktopSync.auto.";
 const PREFERRED_EDITOR_VALUES: PreferredEditor[] = [
   "vscode",
   "cursor",
@@ -242,6 +251,15 @@ function readPreferredEditor(): PreferredEditor {
   return PREFERRED_EDITOR_VALUES.includes(stored as PreferredEditor)
     ? (stored as PreferredEditor)
     : "vscode";
+}
+
+function desktopPlanAutoSyncKey(planId: string): string {
+  return `${DESKTOP_PLAN_SYNC_AUTO_KEY_PREFIX}${planId}`;
+}
+
+function readDesktopPlanAutoSync(planId: string | undefined): boolean {
+  if (typeof window === "undefined" || !planId) return false;
+  return window.localStorage.getItem(desktopPlanAutoSyncKey(planId)) === "1";
 }
 
 type PlanAnnotationAnchor = PlanCommentAnchor & { x: number; y: number };
@@ -2358,6 +2376,16 @@ export function PlansPage() {
   );
 
   const exportPlan = useExportPlan(selectedId);
+  const importPlanSource = useImportPlanSource();
+  const [desktopPlanFolder, setDesktopPlanFolder] =
+    useState<DesktopPlanFilesFolder | null>(null);
+  const [desktopPlanSyncing, setDesktopPlanSyncing] = useState(false);
+  const [desktopPlanImporting, setDesktopPlanImporting] = useState(false);
+  const [desktopPlanAutoSync, setDesktopPlanAutoSync] = useState(() =>
+    readDesktopPlanAutoSync(selectedId),
+  );
+  const desktopAutoSyncedVersionRef = useRef<Record<string, string>>({});
+  const desktopPlanFilesAvailable = Boolean(getDesktopPlanFiles());
   const { resolvedTheme, setTheme } = useTheme();
   const isDarkTheme = resolvedTheme !== "light";
   const wireframeStyle = useWireframeStyle();
@@ -2399,6 +2427,22 @@ export function PlansPage() {
       </Button>
     ) : null,
   );
+
+  useEffect(() => {
+    setDesktopPlanFolder(null);
+    setDesktopPlanAutoSync(readDesktopPlanAutoSync(selectedId));
+    const planFiles = getDesktopPlanFiles();
+    if (!planFiles || !selectedId) return;
+
+    let cancelled = false;
+    void planFiles.getFolder({ planId: selectedId }).then((result) => {
+      if (cancelled) return;
+      setDesktopPlanFolder(result.ok ? result.folder : null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId]);
 
   useEffect(() => {
     if (!selectedId) return;
@@ -2796,14 +2840,138 @@ export function PlansPage() {
     toast.success("Prototype plan ready");
   };
 
-  const readPlanExport = async () => {
+  const readPlanExport = useCallback(async () => {
     const result = await exportPlan.refetch();
     const data = result.data ?? exportPlan.data;
     if (!data) {
       throw new Error("Plan export was not available yet.");
     }
     return data;
-  };
+  }, [exportPlan]);
+
+  const syncPlanToDesktopFolder = useCallback(
+    async (options: { choose?: boolean; quiet?: boolean } = {}) => {
+      const plan = bundle?.plan;
+      const planFiles = getDesktopPlanFiles();
+      if (!plan || !planFiles) {
+        throw new Error("Desktop local file sync is not available.");
+      }
+
+      setDesktopPlanSyncing(true);
+      try {
+        let folder = desktopPlanFolder;
+        if (options.choose || !folder) {
+          const chosen = await planFiles.chooseFolder({
+            planId: plan.id,
+            title: plan.title,
+          });
+          if (!chosen.ok) {
+            if (chosen.canceled) return null;
+            throw new Error(chosen.error);
+          }
+          folder = chosen.folder;
+          setDesktopPlanFolder(folder);
+        }
+
+        const data = await readPlanExport();
+        if (!data.mdx || !data.mdx["plan.mdx"]) {
+          throw new Error("Plan source files were not available yet.");
+        }
+        const written = await planFiles.writePlan({
+          planId: plan.id,
+          title: plan.title,
+          mdx: data.mdx,
+        });
+        if (!written.ok) throw new Error(written.error);
+        setDesktopPlanFolder(written.folder);
+        desktopAutoSyncedVersionRef.current[plan.id] = plan.updatedAt;
+        if (!options.quiet) {
+          toast.success(`Synced ${written.files?.length ?? 0} local files`);
+        }
+        return written.folder;
+      } finally {
+        setDesktopPlanSyncing(false);
+      }
+    },
+    [bundle?.plan, desktopPlanFolder, readPlanExport],
+  );
+
+  const importPlanFromDesktopFolder = useCallback(async () => {
+    const plan = bundle?.plan;
+    const planFiles = getDesktopPlanFiles();
+    if (!plan || !planFiles) {
+      throw new Error("Desktop local file sync is not available.");
+    }
+
+    setDesktopPlanImporting(true);
+    try {
+      const result = await planFiles.readPlan({ planId: plan.id });
+      if (!result.ok) throw new Error(result.error);
+      if (!result.mdx) throw new Error("No Plan source files were found.");
+      const imported = await importPlanSource.mutateAsync({
+        planId: plan.id,
+        expectedUpdatedAt: plan.updatedAt,
+        mdx: result.mdx,
+        repoPath: result.folder.path,
+        currentFocus: "desktop local files sync",
+      });
+      setDesktopPlanFolder(result.folder);
+      toast.success("Imported local source files");
+      const updatedAt = imported.plan?.updatedAt;
+      if (updatedAt) {
+        desktopAutoSyncedVersionRef.current[plan.id] = updatedAt;
+      }
+    } finally {
+      setDesktopPlanImporting(false);
+    }
+  }, [bundle?.plan, importPlanSource]);
+
+  const setDesktopPlanAutoSyncEnabled = useCallback(
+    (enabled: boolean) => {
+      if (!selectedId) return;
+      setDesktopPlanAutoSync(enabled);
+      if (enabled) {
+        window.localStorage.setItem(desktopPlanAutoSyncKey(selectedId), "1");
+        void syncPlanToDesktopFolder({ choose: !desktopPlanFolder }).catch(
+          (error) => {
+            setDesktopPlanAutoSync(false);
+            window.localStorage.removeItem(desktopPlanAutoSyncKey(selectedId));
+            toast.error(
+              error instanceof Error
+                ? error.message
+                : "Could not enable local file sync.",
+            );
+          },
+        );
+      } else {
+        window.localStorage.removeItem(desktopPlanAutoSyncKey(selectedId));
+      }
+    },
+    [desktopPlanFolder, selectedId, syncPlanToDesktopFolder],
+  );
+
+  useEffect(() => {
+    const plan = bundle?.plan;
+    if (!plan || !desktopPlanAutoSync || !desktopPlanFolder) return;
+    if (desktopAutoSyncedVersionRef.current[plan.id] === plan.updatedAt) {
+      return;
+    }
+    desktopAutoSyncedVersionRef.current[plan.id] = plan.updatedAt;
+    void syncPlanToDesktopFolder({ quiet: true }).catch((error) => {
+      setDesktopPlanAutoSync(false);
+      window.localStorage.removeItem(desktopPlanAutoSyncKey(plan.id));
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Could not sync plan to local files.",
+      );
+    });
+  }, [
+    bundle?.plan,
+    desktopPlanAutoSync,
+    desktopPlanFolder,
+    syncPlanToDesktopFolder,
+  ]);
 
   const copyPlanHtml = async () => {
     const data = await readPlanExport();
@@ -2833,7 +3001,7 @@ export function PlansPage() {
 
   const downloadPlanSource = async () => {
     const data = await readPlanExport();
-    const files = (data as { mdx?: Record<string, unknown> }).mdx;
+    const files = data.mdx;
     if (!files || Object.keys(files).length === 0) {
       throw new Error("Plan source files were not available yet.");
     }

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -2865,7 +2865,7 @@ export function PlansPage() {
             planId: plan.id,
             title: plan.title,
           });
-          if (!chosen.ok) {
+          if (chosen.ok === false) {
             if (chosen.canceled) return null;
             throw new Error(chosen.error);
           }
@@ -2882,7 +2882,7 @@ export function PlansPage() {
           title: plan.title,
           mdx: data.mdx,
         });
-        if (!written.ok) throw new Error(written.error);
+        if (written.ok === false) throw new Error(written.error);
         setDesktopPlanFolder(written.folder);
         desktopAutoSyncedVersionRef.current[plan.id] = plan.updatedAt;
         if (!options.quiet) {
@@ -2906,7 +2906,7 @@ export function PlansPage() {
     setDesktopPlanImporting(true);
     try {
       const result = await planFiles.readPlan({ planId: plan.id });
-      if (!result.ok) throw new Error(result.error);
+      if (result.ok === false) throw new Error(result.error);
       if (!result.mdx) throw new Error("No Plan source files were found.");
       const imported = await importPlanSource.mutateAsync({
         planId: plan.id,
@@ -4173,6 +4173,77 @@ export function PlansPage() {
                         <IconFileZip className="size-4" />
                         Download source (.zip)
                       </DropdownMenuItem>
+                      {desktopPlanFilesAvailable && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuLabel className="text-xs font-medium text-muted-foreground">
+                            Local files
+                          </DropdownMenuLabel>
+                          <DropdownMenuItem
+                            onClick={() =>
+                              runPlanExportAction(async () => {
+                                await syncPlanToDesktopFolder({
+                                  choose: true,
+                                });
+                              })
+                            }
+                            disabled={desktopPlanSyncing}
+                            className="gap-2"
+                          >
+                            {desktopPlanSyncing ? (
+                              <IconLoader2 className="size-4 animate-spin" />
+                            ) : (
+                              <IconFolder className="size-4" />
+                            )}
+                            {desktopPlanFolder
+                              ? "Change local folder"
+                              : "Link local folder"}
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() =>
+                              runPlanExportAction(async () => {
+                                await syncPlanToDesktopFolder();
+                              })
+                            }
+                            disabled={!desktopPlanFolder || desktopPlanSyncing}
+                            className="gap-2"
+                          >
+                            {desktopPlanSyncing ? (
+                              <IconLoader2 className="size-4 animate-spin" />
+                            ) : (
+                              <IconRefresh className="size-4" />
+                            )}
+                            Sync to local folder
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() =>
+                              runPlanExportAction(importPlanFromDesktopFolder)
+                            }
+                            disabled={
+                              !desktopPlanFolder ||
+                              desktopPlanImporting ||
+                              !canEditPlanContent
+                            }
+                            className="gap-2"
+                          >
+                            {desktopPlanImporting ? (
+                              <IconLoader2 className="size-4 animate-spin" />
+                            ) : (
+                              <IconDownload className="size-4" />
+                            )}
+                            Import local edits
+                          </DropdownMenuItem>
+                          <DropdownMenuCheckboxItem
+                            checked={desktopPlanAutoSync}
+                            disabled={desktopPlanSyncing}
+                            onCheckedChange={(checked) =>
+                              setDesktopPlanAutoSyncEnabled(checked === true)
+                            }
+                          >
+                            Auto-sync changes
+                          </DropdownMenuCheckboxItem>
+                        </>
+                      )}
                       <DropdownMenuSub>
                         <DropdownMenuSubTrigger className="gap-2">
                           <IconDownload className="size-4" />

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -2912,7 +2912,6 @@ export function PlansPage() {
         planId: plan.id,
         expectedUpdatedAt: plan.updatedAt,
         mdx: result.mdx,
-        repoPath: result.folder.path,
         currentFocus: "desktop local files sync",
       });
       setDesktopPlanFolder(result.folder);


### PR DESCRIPTION
## Summary
- add Content local Markdown/MDX export/import actions, local-files route, and sidebar navigation
- add desktop Plan local-file IPC bridge and hosted webview preload plumbing
- add Netlify template env sync script and deployment docs updates

## Validation
- pnpm --filter plan typecheck
- pnpm --filter content typecheck
- pnpm --filter content test -- shared/content-source.spec.ts
- pnpm --filter @agent-native/desktop-app typecheck
- pnpm exec prettier --check <changed files>