### PR TITLE
Harden interrupted agent runs

### DIFF
--- a/.changeset/fix-stale-agent-tool-runs.md
+++ b/.changeset/fix-stale-agent-tool-runs.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prevent stale interrupted agent tool calls from appearing as live running tools after chat stream recovery.

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -794,6 +794,7 @@ describe("run manager soft timeout", () => {
     expect(result).toMatchObject({
       runId: "run-recent-completed",
       threadId: "thread-recent",
+      turnId: "run-recent-completed",
       status: "completed",
       heartbeatAt: expect.any(Number),
     });

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -911,6 +911,7 @@ export function getActiveRunForThread(threadId: string): ActiveRun | null {
 export async function getActiveRunForThreadAsync(threadId: string): Promise<{
   runId: string;
   threadId: string;
+  turnId: string;
   status: string;
   heartbeatAt: number;
   lastProgressAt: number | null;
@@ -923,6 +924,7 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
     return {
       runId: memRun.runId,
       threadId: memRun.threadId,
+      turnId: memRun.turnId,
       status: memRun.status,
       // In-memory means this isolate is the producer. By definition, the
       // heartbeat is fresh as of "now" — the client can trust this.
@@ -954,6 +956,7 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
       return {
         runId: sqlRun.id,
         threadId: sqlRun.threadId,
+        turnId: sqlRun.turnId ?? sqlRun.id,
         status: sqlRun.status,
         heartbeatAt: sqlRun.heartbeatAt ?? sqlRun.startedAt,
         lastProgressAt: sqlRun.lastProgressAt,
@@ -978,6 +981,7 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
       return {
         runId: sqlRun.id,
         threadId: sqlRun.threadId,
+        turnId: sqlRun.turnId ?? sqlRun.id,
         status: sqlRun.status,
         heartbeatAt: sqlRun.heartbeatAt ?? sqlRun.startedAt,
         lastProgressAt: sqlRun.lastProgressAt,

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -516,6 +516,7 @@ export async function getRunByThread(
 ): Promise<{
   id: string;
   threadId: string;
+  turnId?: string | null;
   status: string;
   startedAt: number;
   heartbeatAt: number | null;
@@ -525,13 +526,14 @@ export async function getRunByThread(
   await ensureRunTables();
   const client = getDbExec();
   const sql = options?.includeTerminal
-    ? `SELECT id, thread_id, status, started_at, heartbeat_at, completed_at, last_progress_at FROM agent_runs WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`
-    : `SELECT id, thread_id, status, started_at, heartbeat_at, completed_at, last_progress_at FROM agent_runs WHERE thread_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`;
+    ? `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at FROM agent_runs WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`
+    : `SELECT id, thread_id, turn_id, status, started_at, heartbeat_at, completed_at, last_progress_at FROM agent_runs WHERE thread_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`;
   const { rows } = await client.execute({ sql, args: [threadId] });
   if (rows.length === 0) return null;
   const r = rows[0] as {
     id: string;
     thread_id: string;
+    turn_id?: string | null;
     status: string;
     started_at: number | string;
     heartbeat_at: number | string | null;
@@ -541,6 +543,7 @@ export async function getRunByThread(
   return {
     id: r.id,
     threadId: r.thread_id,
+    turnId: r.turn_id ?? null,
     status: r.status,
     startedAt: Number(r.started_at),
     heartbeatAt: r.heartbeat_at == null ? null : Number(r.heartbeat_at),

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -107,6 +107,57 @@ describe("buildAssistantMessage", () => {
     ]);
   });
 
+  it("settles unresolved tool calls on terminal rebuilt messages", () => {
+    const message = buildAssistantMessage(
+      [
+        {
+          seq: 0,
+          event: {
+            type: "tool_start",
+            tool: "save-analysis",
+            input: { id: "stale-analysis" },
+          },
+        },
+        { seq: 1, event: { type: "done" } },
+      ],
+      "run-stale-tool",
+      { turnId: "turn-stale-tool" },
+    );
+
+    expect(message?.content).toEqual([
+      expect.objectContaining({
+        type: "tool-call",
+        toolName: "save-analysis",
+        result: "Interrupted before this tool returned a result.",
+      }),
+    ]);
+  });
+
+  it("keeps unresolved tool calls pending at internal continuation boundaries", () => {
+    const message = buildAssistantMessage(
+      [
+        {
+          seq: 0,
+          event: {
+            type: "tool_start",
+            tool: "save-analysis",
+            input: { id: "continuing-analysis" },
+          },
+        },
+        { seq: 1, event: { type: "auto_continue", reason: "run_timeout" } },
+      ],
+      "run-continuing-tool",
+      { suppressInternalContinuation: true, turnId: "turn-continuing-tool" },
+    );
+
+    expect(message?.content).toEqual([
+      expect.not.objectContaining({ result: expect.any(String) }),
+    ]);
+    expect(message?.metadata).toMatchObject({
+      custom: { continued: true },
+    });
+  });
+
   it("persists partial output from recoverable gateway errors when suppressed", () => {
     const events: RunEvent[] = [
       { seq: 0, event: { type: "text", text: "checking..." } },

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -32,6 +32,9 @@ interface BuildAssistantMessageOptions {
 type AssistantMessage = NonNullable<ReturnType<typeof buildAssistantMessage>>;
 type UserMessage = ReturnType<typeof buildUserMessage>;
 
+const INTERRUPTED_TOOL_RESULT =
+  "Interrupted before this tool returned a result.";
+
 const MAX_STORED_ATTACHMENT_CHARS = 60_000;
 /**
  * When no file-upload provider is configured we fall back to storing base64
@@ -206,6 +209,9 @@ export function buildAssistantMessage(
   if (content.length === 0) return null;
 
   const continued = endedAtInternalContinuationBoundary;
+  if (!continued) {
+    settleInterruptedToolCalls(content);
+  }
 
   const custom: Record<string, unknown> = {};
   if (options.turnId) custom.turnId = options.turnId;
@@ -279,6 +285,14 @@ function messageText(content: unknown): string {
     )
     .map((part: any) => part.text)
     .join("");
+}
+
+function settleInterruptedToolCalls(content: ContentPart[]): void {
+  for (const part of content) {
+    if (part.type === "tool-call" && part.result === undefined) {
+      part.result = INTERRUPTED_TOOL_RESULT;
+    }
+  }
 }
 
 function isTerminalAssistantStatus(status: unknown): boolean {

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -50,6 +50,7 @@ import {
   AgentAutoContinueSignal,
   type ContentPart,
   readSSEStreamRaw,
+  settleInterruptedToolCalls,
 } from "./sse-event-processor.js";
 import { captureError } from "./analytics.js";
 import {
@@ -724,6 +725,14 @@ function ensureMessageMetadata(repo: any): any {
           ? { type: "incomplete", reason: "error" }
           : { type: "complete", reason: "stop" };
       }
+      if (
+        Array.isArray(msg.content) &&
+        (isTerminal ||
+          msg.status?.type === "complete" ||
+          msg.status?.type === "incomplete")
+      ) {
+        settleInterruptedToolCalls(msg.content);
+      }
     }
   }
   return repo;
@@ -1374,6 +1383,7 @@ const AssistantChatInner = forwardRef<
           } catch {
             // Best effort — the important part is unwinding the UI.
           }
+          settleInterruptedToolCalls(latestContent);
           setReconnectContent([...latestContent]);
           setReconnectFrozen(latestContent.length > 0);
           setRunErrorInfo({
@@ -2014,6 +2024,8 @@ const AssistantChatInner = forwardRef<
   const materializeFrozenReconnectContent = useCallback(() => {
     if (!reconnectFrozen || reconnectContent.length === 0) return;
     try {
+      const frozenContent = cloneContentParts(reconnectContent);
+      settleInterruptedToolCalls(frozenContent);
       const repo = normalizeThreadRepository(threadRuntime.export());
       const messages = getRepoMessages(repo);
       const lastEntry = messages[messages.length - 1];
@@ -2035,7 +2047,7 @@ const AssistantChatInner = forwardRef<
             id,
             role: "assistant",
             createdAt: new Date(),
-            content: cloneContentParts(reconnectContent),
+            content: frozenContent,
             status: { type: "complete", reason: "stop" },
             metadata: {
               custom: {

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -1347,6 +1347,85 @@ describe("createAgentChatAdapter", () => {
     );
   });
 
+  it("ignores recent terminal active runs from a previous turn during recovery", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        postCount += 1;
+        return postCount === 1
+          ? emptySseResponse("run-current-empty")
+          : sseResponse([
+              { type: "text", text: "finished the new turn" },
+              { type: "done" },
+            ]);
+      }
+      if (url.includes("/runs/run-current-empty/events")) {
+        return jsonResponse({ error: "gone" }, 404);
+      }
+      if (url.includes("/runs/active")) {
+        return jsonResponse({
+          active: true,
+          runId: "run-old-completed",
+          threadId: "thread-terminal-mismatch",
+          turnId: "turn-old",
+          status: "completed",
+          heartbeatAt: Date.now(),
+        });
+      }
+      if (url.includes("/runs/run-old-completed/events")) {
+        return sseResponse([
+          { type: "text", text: "old completed turn" },
+          { type: "done" },
+        ]);
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-terminal-mismatch",
+      threadId: "thread-terminal-mismatch",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "answer the new request" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const results = await promise;
+
+    expect(postCount).toBe(2);
+    expect(
+      fetchSpy.mock.calls.some(([url]) =>
+        String(url).includes("/runs/run-old-completed/events"),
+      ),
+    ).toBe(false);
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toBe("finished the new turn");
+  });
+
   it("aborts and continues automatically when an SSE stream stays alive without progress", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("window", { dispatchEvent: vi.fn() });
@@ -2608,6 +2687,15 @@ describe("createAgentChatAdapter", () => {
       ([ev]) => ev?.type === "agent-chat:run-error",
     );
     expect(errorEvent).toBeDefined();
+    const last = results.at(-1) as any;
+    const stalledTools = last.content.filter(
+      (part: any) =>
+        part.type === "tool-call" && part.toolName === "create-extension",
+    );
+    expect(stalledTools.length).toBeGreaterThan(0);
+    expect(stalledTools.every((part: any) => part.result !== undefined)).toBe(
+      true,
+    );
   });
 
   it("does NOT bail when create-extension is retried with a CHANGED payload after stream_ended", async () => {

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -9,6 +9,7 @@ import {
   type AgentActivityTrailEntry,
   type ContentPart,
   readSSEStream,
+  settleInterruptedToolCalls,
 } from "./sse-event-processor.js";
 import { agentNativePath } from "./api-path.js";
 import { formatChatErrorText, normalizeChatError } from "./error-format.js";
@@ -1475,6 +1476,13 @@ export function createAgentChatAdapter(
               }
               const active = await activeRes.json();
               if (active?.active && active.runId) {
+                const activeStatus =
+                  typeof active.status === "string" ? active.status : "";
+                const activeTurnId =
+                  typeof active.turnId === "string" ? active.turnId : "";
+                if (activeStatus !== "running" && activeTurnId !== turnId) {
+                  return false;
+                }
                 const activeRunId = String(active.runId);
                 runId = activeRunId;
                 if (!attemptedRunIds.includes(activeRunId)) {
@@ -1976,6 +1984,7 @@ export function createAgentChatAdapter(
                     }),
                   );
                 }
+                settleInterruptedToolCalls(content);
                 content.push({
                   type: "text",
                   text: `Something went wrong: ${message}`,
@@ -2122,6 +2131,7 @@ export function createAgentChatAdapter(
                     }),
                   );
                 }
+                settleInterruptedToolCalls(content);
                 content.push({
                   type: "text",
                   text: `Something went wrong: ${message}`,

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -708,6 +708,38 @@ describe("SSE event processor error classification", () => {
     expect(second.done).toBe(true);
   });
 
+  it("settles pending tool calls when a terminal stream error arrives", async () => {
+    const results = await drain(
+      readSSEStream(
+        eventStream([
+          {
+            type: "tool_start",
+            tool: "save-analysis",
+            input: { id: "plane-analysis" },
+          },
+          {
+            type: "error",
+            error: "Gateway error",
+            errorCode: "builder_gateway_error",
+          },
+        ]),
+        [],
+        { value: 0 },
+        "tab-terminal-error",
+      ),
+    );
+
+    const last = results.at(-1) as any;
+    const tool = last.content.find(
+      (part: any) =>
+        part.type === "tool-call" && part.toolName === "save-analysis",
+    );
+    expect(tool?.result).toBe(
+      "Interrupted before this tool returned a result.",
+    );
+    expect(last.status).toEqual({ type: "incomplete", reason: "error" });
+  });
+
   it("surfaces daily gateway caps instead of looping auto-continuation", async () => {
     const iter = readSSEStream(
       eventStream([

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -62,6 +62,27 @@ export type AgentAutoContinueReason =
 
 export type AgentActivityTrailEntry = { label: string; tool?: string };
 
+const INTERRUPTED_TOOL_RESULT =
+  "Interrupted before this tool returned a result.";
+
+export function settleInterruptedToolCalls(
+  content: ContentPart[],
+  result = INTERRUPTED_TOOL_RESULT,
+): boolean {
+  let changed = false;
+  for (const part of content) {
+    if (
+      part.type === "tool-call" &&
+      part.result === undefined &&
+      part.activity !== true
+    ) {
+      part.result = result;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
 export class AgentAutoContinueSignal extends Error {
   readonly reason: AgentAutoContinueReason;
   readonly maxIterations?: number;
@@ -616,6 +637,7 @@ export function processEvent(
         }),
       );
     }
+    settleInterruptedToolCalls(content);
     content.push({
       type: "text",
       text: formatChatErrorText(errMsg, ev.upgradeUrl, ev.errorCode),

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -6452,6 +6452,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
               active: true,
               runId: run.runId,
               threadId: run.threadId,
+              turnId: run.turnId,
               status: run.status,
               heartbeatAt: run.heartbeatAt,
               lastProgressAt: run.lastProgressAt,

--- a/templates/calendar/app/components/calendar/AttendeeAutocomplete.tsx
+++ b/templates/calendar/app/components/calendar/AttendeeAutocomplete.tsx
@@ -63,6 +63,7 @@ interface AttendeeAutocompleteProps {
   className?: string;
   inputClassName?: string;
   onEscape?: () => void;
+  onEmptyEnter?: () => void;
 }
 
 function parseEmails(value: string): string[] {
@@ -125,6 +126,7 @@ export const AttendeeAutocomplete = forwardRef<
     className,
     inputClassName,
     onEscape,
+    onEmptyEnter,
   },
   ref,
 ) {
@@ -295,6 +297,11 @@ export const AttendeeAutocomplete = forwardRef<
       if (shouldShowPopover || inputValue.trim()) {
         event.preventDefault();
         commitActiveOrManual();
+        return;
+      }
+      if (event.key === "Enter" && onEmptyEnter) {
+        event.preventDefault();
+        onEmptyEnter();
       }
       return;
     }

--- a/templates/calendar/app/components/calendar/CreateEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/CreateEventDialog.tsx
@@ -71,7 +71,6 @@ import {
   validateAttachmentDrafts,
 } from "@/lib/event-form-utils";
 import { getGoogleEventColorHex } from "@/lib/event-colors";
-import { shortcutModifierLabel } from "@/lib/utils";
 
 type VideoProvider = "none" | "google_meet" | "zoom";
 type EventType = "default" | "outOfOffice" | "focusTime" | "workingLocation";
@@ -516,7 +515,8 @@ Write a short, useful meeting description. Keep it paste-ready and avoid adding 
     toast("Time selected");
   }
 
-  // ⌘+Enter to submit
+  // Keep the global shortcut for long-form fields while regular inputs submit
+  // through the form-level Enter handler below.
   useEffect(() => {
     if (!open) return;
     function onKey(e: KeyboardEvent) {
@@ -529,6 +529,17 @@ Write a short, useful meeting description. Keep it paste-ready and avoid adding 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [findTimeOpen, open]);
+
+  function handleFormKeyDown(e: React.KeyboardEvent<HTMLFormElement>) {
+    if (e.key !== "Enter" || e.defaultPrevented || e.nativeEvent.isComposing) {
+      return;
+    }
+
+    if (!(e.target instanceof HTMLInputElement)) return;
+
+    e.preventDefault();
+    formRef.current?.requestSubmit();
+  }
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -584,70 +595,66 @@ Write a short, useful meeting description. Keep it paste-ready and avoid adding 
               workingLocationType === "customLocation" ? location : undefined,
           };
 
-    createEvent.mutate(
-      {
-        title: title.trim(),
-        description,
-        start: startISO,
-        end: endISO,
-        startTimeZone: effectiveAllDay ? undefined : timezone,
-        endTimeZone: effectiveAllDay ? undefined : timezone,
-        location,
-        accountEmail: draft?.accountEmail,
-        allDay: effectiveAllDay,
-        transparency:
-          eventType === "workingLocation"
-            ? "transparent"
-            : eventType === "default"
-              ? availability
-              : "opaque",
-        visibility: eventType === "workingLocation" ? "public" : visibility,
-        ...reminderPatch,
-        ...statusPatch,
-        addGoogleMeet: videoProvider === "google_meet",
-        addZoom: videoProvider === "zoom",
-        color: colorId ? getGoogleEventColorHex(colorId) : undefined,
-        colorId,
-        attachments:
-          (attachmentResult.attachments?.length ?? 0) > 0
-            ? attachmentResult.attachments
-            : undefined,
-        attendees:
-          finalAttendees.length > 0
-            ? finalAttendees.map((attendee) => ({
-                email: attendee.email,
-                displayName: attendee.displayName,
-              }))
-            : undefined,
+    const payload: Parameters<typeof createEvent.mutate>[0] = {
+      title: title.trim(),
+      description,
+      start: startISO,
+      end: endISO,
+      startTimeZone: effectiveAllDay ? undefined : timezone,
+      endTimeZone: effectiveAllDay ? undefined : timezone,
+      location,
+      accountEmail: draft?.accountEmail,
+      allDay: effectiveAllDay,
+      transparency:
+        eventType === "workingLocation"
+          ? "transparent"
+          : eventType === "default"
+            ? availability
+            : "opaque",
+      visibility: eventType === "workingLocation" ? "public" : visibility,
+      ...reminderPatch,
+      ...statusPatch,
+      addGoogleMeet: videoProvider === "google_meet",
+      addZoom: videoProvider === "zoom",
+      color: colorId ? getGoogleEventColorHex(colorId) : undefined,
+      colorId,
+      attachments:
+        (attachmentResult.attachments?.length ?? 0) > 0
+          ? attachmentResult.attachments
+          : undefined,
+      attendees:
+        finalAttendees.length > 0
+          ? finalAttendees.map((attendee) => ({
+              email: attendee.email,
+              displayName: attendee.displayName,
+            }))
+          : undefined,
+    };
+
+    onOpenChange(false);
+    createEvent.mutate(payload, {
+      onSuccess: (result) => {
+        if (activeDraftId) {
+          deletePersistedDraft(activeDraftId);
+          onDraftCreated?.(activeDraftId);
+        }
+        const eventId = result?.id;
+        const undo = eventId
+          ? () => {
+              delEvent.mutate({
+                id: eventId,
+                scope: "single",
+                sendUpdates: "none",
+              });
+            }
+          : undefined;
+        if (undo) setUndoAction(undo);
       },
-      {
-        onSuccess: (result) => {
-          if (activeDraftId) {
-            deletePersistedDraft(activeDraftId);
-            onDraftCreated?.(activeDraftId);
-          }
-          onOpenChange(false);
-          const eventId = result?.id;
-          const undo = eventId
-            ? () => {
-                delEvent.mutate({
-                  id: eventId,
-                  scope: "single",
-                  sendUpdates: "none",
-                });
-              }
-            : undefined;
-          if (undo) setUndoAction(undo);
-          toast("Event created", {
-            action: undo ? { label: "Undo", onClick: undo } : undefined,
-          });
-        },
-        onError: (error) =>
-          toast.error(
-            error instanceof Error ? error.message : "Failed to create event",
-          ),
-      },
-    );
+      onError: (error) =>
+        toast.error(
+          error instanceof Error ? error.message : "Failed to create event",
+        ),
+    });
   }
 
   return (
@@ -677,7 +684,12 @@ Write a short, useful meeting description. Keep it paste-ready and avoid adding 
         <div className="mb-3 text-sm font-semibold">
           {draft ? "Review Invite" : "New Event"}
         </div>
-        <form ref={formRef} onSubmit={handleSubmit} className="space-y-3">
+        <form
+          ref={formRef}
+          onSubmit={handleSubmit}
+          onKeyDown={handleFormKeyDown}
+          className="space-y-3"
+        >
           <div className="space-y-3">
             <div className="space-y-1.5">
               <Label htmlFor="event-title" className="text-xs">
@@ -891,6 +903,7 @@ Write a short, useful meeting description. Keep it paste-ready and avoid adding 
                 onRemove={removeAttendee}
                 inputId="event-attendees"
                 placeholder="Search contacts or type an email"
+                onEmptyEnter={() => formRef.current?.requestSubmit()}
               />
               {attendees.length > 0 && (
                 <p className="flex items-center gap-1 text-[10px] text-muted-foreground">
@@ -1122,7 +1135,7 @@ Write a short, useful meeting description. Keep it paste-ready and avoid adding 
           <div className="flex items-center justify-between pt-1">
             <p className="text-[10px] text-muted-foreground/60">
               <kbd className="rounded border border-border bg-muted px-1 font-mono text-[10px]">
-                {shortcutModifierLabel()}+↵
+                ↵
               </kbd>{" "}
               to save
             </p>

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -587,81 +587,75 @@ export default function CalendarView() {
                   : draft.workingLocationLabel,
             };
 
-      createEvent.mutate(
-        {
-          _tempId: eventId,
-          title,
-          description: draft.description ?? "",
-          start: start.toISOString(),
-          end: end.toISOString(),
-          startTimeZone: draft.allDay ? undefined : timezone,
-          endTimeZone: draft.allDay
-            ? undefined
-            : (draft.endTimeZone ?? draft.startTimeZone ?? timezone),
-          location,
-          accountEmail: draft.accountEmail,
-          allDay: draft.allDay ?? false,
-          transparency:
-            eventType === "workingLocation"
-              ? "transparent"
-              : eventType === "default"
-                ? draft.transparency
-                : "opaque",
-          visibility:
-            eventType === "workingLocation" ? "public" : draft.visibility,
-          reminders: draft.reminders,
-          remindersUseDefault: draft.remindersUseDefault,
-          ...statusPatch,
-          addGoogleMeet: draft.addGoogleMeet,
-          addZoom: draft.addZoom,
-          color: draft.colorId
-            ? getGoogleEventColorHex(draft.colorId)
-            : undefined,
-          colorId: draft.colorId,
-          attachments: draft.attachments,
-          attendees: draft.attendees,
-        },
-        {
-          onSuccess: (result) => {
-            discardedCommittingDraftsRef.current.delete(draftId);
-            deletePersistedCalendarDraft(draftId);
-            setEventDraft(null);
-            setQuickEditEventId(null);
-            const createdEventId = result?.id;
-            if (createdEventId) {
-              const undo = () => {
-                deleteEvent.mutate({
-                  id: createdEventId,
-                  scope: "single",
-                  sendUpdates: "none",
-                });
-              };
-              setUndoAction(undo);
-              toast("Event created", {
-                action: { label: "Undo", onClick: undo },
+      const payload: Parameters<typeof createEvent.mutate>[0] = {
+        _tempId: eventId,
+        title,
+        description: draft.description ?? "",
+        start: start.toISOString(),
+        end: end.toISOString(),
+        startTimeZone: draft.allDay ? undefined : timezone,
+        endTimeZone: draft.allDay
+          ? undefined
+          : (draft.endTimeZone ?? draft.startTimeZone ?? timezone),
+        location,
+        accountEmail: draft.accountEmail,
+        allDay: draft.allDay ?? false,
+        transparency:
+          eventType === "workingLocation"
+            ? "transparent"
+            : eventType === "default"
+              ? draft.transparency
+              : "opaque",
+        visibility:
+          eventType === "workingLocation" ? "public" : draft.visibility,
+        reminders: draft.reminders,
+        remindersUseDefault: draft.remindersUseDefault,
+        ...statusPatch,
+        addGoogleMeet: draft.addGoogleMeet,
+        addZoom: draft.addZoom,
+        color: draft.colorId
+          ? getGoogleEventColorHex(draft.colorId)
+          : undefined,
+        colorId: draft.colorId,
+        attachments: draft.attachments,
+        attendees: draft.attendees,
+      };
+
+      deletePersistedCalendarDraft(draftId);
+      setEventDraft(null);
+      setQuickEditEventId(null);
+      createEvent.mutate(payload, {
+        onSuccess: (result) => {
+          discardedCommittingDraftsRef.current.delete(draftId);
+          const createdEventId = result?.id;
+          if (createdEventId) {
+            const undo = () => {
+              deleteEvent.mutate({
+                id: createdEventId,
+                scope: "single",
+                sendUpdates: "none",
               });
-              return;
-            }
-            toast("Event created");
-          },
-          onError: (error) => {
-            const discardedDraft =
-              discardedCommittingDraftsRef.current.get(draftId);
-            if (discardedDraft) {
-              discardedCommittingDraftsRef.current.delete(draftId);
-              persistCalendarDraft(discardedDraft);
-              setEventDraft(discardedDraft);
-              setQuickEditEventId(calendarDraftEventId(draftId));
-            }
-            toast.error(
-              error instanceof Error ? error.message : "Failed to create event",
-            );
-          },
-          onSettled: () => {
-            committingDraftIdsRef.current.delete(draftId);
-          },
+            };
+            setUndoAction(undo);
+          }
         },
-      );
+        onError: (error) => {
+          const restoreDraft =
+            discardedCommittingDraftsRef.current.get(draftId) ?? draft;
+          if (restoreDraft) {
+            discardedCommittingDraftsRef.current.delete(draftId);
+            persistCalendarDraft(restoreDraft);
+            setEventDraft(restoreDraft);
+            setQuickEditEventId(calendarDraftEventId(draftId));
+          }
+          toast.error(
+            error instanceof Error ? error.message : "Failed to create event",
+          );
+        },
+        onSettled: () => {
+          committingDraftIdsRef.current.delete(draftId);
+        },
+      });
     },
     [createEvent, deleteEvent, eventDraft, selectedDate, setEventDraft],
   );

--- a/templates/clips/actions/cleanup-transcript.ts
+++ b/templates/clips/actions/cleanup-transcript.ts
@@ -385,8 +385,8 @@ function buildPrompt({
 
   if (task === "title") {
     return {
-      system: `${CLIPS_TRANSCRIPT_AGENT_INSTRUCTIONS}\n\nYou produce one short, descriptive title for a Clip. If AGENTS.md resources are included in <context>, use them only for relevant naming, terminology, style, and personal/team preferences; personal instructions win over organization instructions. Output the title only — no quotes, no preamble, no markdown. Keep it under 80 characters.${langHint}`,
-      user: `Pick a concise, specific title for this transcript:${ctxBlock}\n\n<transcript>\n${transcript}\n</transcript>`,
+      system: `${CLIPS_TRANSCRIPT_AGENT_INSTRUCTIONS}\n\nYou produce one short, descriptive title for a Clip. The title must summarize the main subject covered in the transcript, not quote an opening aside. Ignore conversational setup and filler such as "let me walk through this", "real quick", "regarding your question", "there are two things", greetings, hesitation, and other meta commentary. Prefer the concrete topic, named entities, numbers, product names, and business terms that explain what the Clip is actually about. Do not use vague titles built from words like "quick", "thing", "question", "walkthrough", "scenario", or "discussion" unless they are the real topic. If AGENTS.md resources are included in <context>, use them only for relevant naming, terminology, style, and personal/team preferences; personal instructions win over organization instructions. Output the title only — no quotes, no preamble, no markdown. Keep it 4-9 words and under 80 characters.${langHint}`,
+      user: `Pick a concise, specific title that summarizes the main subject of this transcript:${ctxBlock}\n\n<transcript>\n${transcript}\n</transcript>`,
     };
   }
 

--- a/templates/clips/actions/lib/title-fallback.ts
+++ b/templates/clips/actions/lib/title-fallback.ts
@@ -1,0 +1,247 @@
+export function cleanGeneratedTitle(
+  raw: string | null | undefined,
+): string | null {
+  const title = (raw ?? "")
+    .replace(/^["'“”]+|["'“”]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!title) return null;
+  return title.slice(0, 80);
+}
+
+const TITLE_STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "about",
+  "be",
+  "because",
+  "but",
+  "by",
+  "can",
+  "could",
+  "do",
+  "does",
+  "for",
+  "from",
+  "has",
+  "have",
+  "i",
+  "if",
+  "in",
+  "into",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "our",
+  "so",
+  "that",
+  "the",
+  "their",
+  "there",
+  "this",
+  "to",
+  "was",
+  "we",
+  "were",
+  "what",
+  "when",
+  "where",
+  "which",
+  "who",
+  "will",
+  "with",
+  "would",
+  "you",
+  "your",
+]);
+
+const TITLE_FILLER_WORDS = new Set([
+  "actually",
+  "basically",
+  "discussion",
+  "easier",
+  "essentially",
+  "first",
+  "gonna",
+  "going",
+  "here",
+  "just",
+  "kind",
+  "maybe",
+  "obviously",
+  "okay",
+  "question",
+  "questions",
+  "quick",
+  "quickly",
+  "rather",
+  "real",
+  "really",
+  "reason",
+  "reasons",
+  "regarding",
+  "right",
+  "scenario",
+  "scenarios",
+  "second",
+  "sort",
+  "stuff",
+  "talk",
+  "thing",
+  "things",
+  "through",
+  "walk",
+  "walkthrough",
+  "yeah",
+]);
+
+const OPENING_FILLER_RE =
+  /\b(?:walk through this|walk through it|talk through this|real quick|quick walkthrough|quickly walk through|go through this|let'?s walk through)\b/i;
+
+function titleCaseWord(word: string, index: number): string {
+  const lower = word.toLowerCase();
+  if (index > 0 && TITLE_STOPWORDS.has(lower)) return lower;
+  if (/^\$?\d/.test(word)) return word;
+  if (/^[A-Z0-9]{2,}(?:['’-]?[A-Z0-9]+)*$/.test(word)) return word;
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
+
+function titleCaseWords(words: string[]): string {
+  return words.map((word, index) => titleCaseWord(word, index)).join(" ");
+}
+
+function cleanTitleWord(word: string): string {
+  return word.replace(/^[^\p{L}\p{N}$]+|[^\p{L}\p{N}$%.'’-]+$/gu, "");
+}
+
+function titleWords(value: string, maxWords = 9): string[] {
+  const words = value
+    .split(/\s+/)
+    .map(cleanTitleWord)
+    .filter(Boolean)
+    .slice(0, maxWords);
+
+  while (words.length > 2) {
+    const last = words[words.length - 1]?.toLowerCase() ?? "";
+    if (!TITLE_STOPWORDS.has(last) && !TITLE_FILLER_WORDS.has(last)) break;
+    words.pop();
+  }
+
+  const first = words[0]?.toLowerCase() ?? "";
+  if (
+    words.length > 3 &&
+    (first === "the" || first === "a" || first === "an")
+  ) {
+    words.shift();
+  }
+
+  return words;
+}
+
+function contentTerms(value: string): string[] {
+  return value
+    .split(/\s+/)
+    .map((word) => cleanTitleWord(word).toLowerCase())
+    .filter((word) => {
+      if (!word) return false;
+      if (/^\$?\d/.test(word)) return true;
+      return (
+        word.length > 2 &&
+        !TITLE_STOPWORDS.has(word) &&
+        !TITLE_FILLER_WORDS.has(word)
+      );
+    });
+}
+
+function extractQuestionTopic(chunk: string): string | null {
+  const match = chunk.match(
+    /\b(?:regarding|about|for|on)?\s*(?:your\s+|the\s+)?question\s+about\s+(.+?)(?:[,.;:]|$)/i,
+  );
+  const topic = match?.[1]?.trim();
+  if (!topic) return null;
+  return topic
+    .replace(/^(?:the|a|an)\s+/i, "")
+    .replace(/\bcosting\s+(\$?\d[\d,.]*(?:%|[a-z]+)?)/i, "cost $1")
+    .trim();
+}
+
+function normalizeTitleCandidate(chunk: string): {
+  text: string;
+  source: "question-topic" | "sentence";
+} | null {
+  const withoutOpener = chunk
+    .replace(/^(ok|okay|yeah|yep|so|um|uh|alright|all right|now)[,\s]+/i, "")
+    .trim();
+  const questionTopic = extractQuestionTopic(withoutOpener);
+  if (questionTopic) return { text: questionTopic, source: "question-topic" };
+
+  const text = withoutOpener
+    .replace(/^(?:it['’]?s\s+)?(?:easier\s+to\s+)?(?:just\s+)?/i, "")
+    .replace(
+      /\b(?:there\s+(?:are|could be)|it(?:'|’)s)\s+(?:two|three|several)\s+(?:things?|reasons?|scenarios?)(?:\s+at play)?\b.*$/i,
+      "",
+    )
+    .trim();
+
+  if (!text || OPENING_FILLER_RE.test(text)) return null;
+  if (contentTerms(text).length < 2) return null;
+  return { text, source: "sentence" };
+}
+
+export function fallbackTitleFromTranscript(text: string): string | null {
+  const normalized = text
+    .replace(/\[[^\]]+\]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!normalized) return null;
+  const chunks = normalized.split(/(?<=[.!?])\s+|(?:\s+[-—]\s+)/);
+  const termFrequency = new Map<string, number>();
+  for (const term of contentTerms(normalized)) {
+    termFrequency.set(term, (termFrequency.get(term) ?? 0) + 1);
+  }
+
+  const candidates = chunks
+    .slice(0, 24)
+    .map((chunk, index) => {
+      const candidate = normalizeTitleCandidate(chunk);
+      if (!candidate) return null;
+
+      const words = titleWords(candidate.text);
+      const signalTerms = contentTerms(words.join(" "));
+      const signal = signalTerms.reduce(
+        (score, term) => score + Math.min(termFrequency.get(term) ?? 0, 4),
+        0,
+      );
+      const numberBonus =
+        words.filter((word) => /^\$?\d/.test(word)).length * 8;
+      const acronymBonus =
+        words.filter((word) => /^[A-Z0-9]{2,}$/.test(word)).length * 4;
+      const sourceBonus = candidate.source === "question-topic" ? 50 : 0;
+      const positionPenalty = index * 0.25;
+      return {
+        words,
+        score:
+          sourceBonus +
+          signal * 10 +
+          numberBonus +
+          acronymBonus +
+          Math.min(words.length, 9) -
+          positionPenalty,
+      };
+    })
+    .filter((candidate): candidate is { words: string[]; score: number } =>
+      Boolean(candidate),
+    );
+
+  const best = candidates.sort((a, b) => b.score - a.score)[0];
+  const words = best?.words ?? [];
+  if (words.length < 2) return null;
+  const title = titleCaseWords(words);
+  return cleanGeneratedTitle(title);
+}

--- a/templates/clips/actions/regenerate-title.test.ts
+++ b/templates/clips/actions/regenerate-title.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { fallbackTitleFromTranscript } from "./lib/title-fallback";
+
+describe("fallbackTitleFromTranscript", () => {
+  it("ignores opening filler and titles the transcript topic", () => {
+    const title = fallbackTitleFromTranscript(`
+      It’s easier to just walk through this real quick.
+      Regarding your question about the agent credits costing $63, there are two reasons—or rather, two scenarios.
+      First, this is essentially a hack because we don't have a good CPQ tool or mechanism.
+      Any dollar spent on builders is going to have an SLA support fee that is a percentage of the dollars spent.
+    `);
+
+    expect(title).toBe("Agent Credits Cost $63");
+  });
+
+  it("preserves acronyms in extracted titles", () => {
+    const title = fallbackTitleFromTranscript(`
+      Let me walk through this quickly.
+      The CPQ tool cannot show the SLA fee as a separate line item today.
+    `);
+
+    expect(title).toBe("CPQ Tool Cannot Show the SLA Fee");
+  });
+});

--- a/templates/clips/actions/regenerate-title.ts
+++ b/templates/clips/actions/regenerate-title.ts
@@ -19,6 +19,10 @@ import { assertAccess } from "@agent-native/core/sharing";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import cleanupTranscript from "./cleanup-transcript.js";
 import { loadAgentsMdContext } from "./lib/agents-md-context.js";
+import {
+  cleanGeneratedTitle,
+  fallbackTitleFromTranscript,
+} from "./lib/title-fallback.js";
 import { isAutoTitleReplaceable, isDefaultTitle } from "./lib/title-source.js";
 
 function transcriptTextFromSegments(raw: string | null | undefined): string {
@@ -35,82 +39,6 @@ function transcriptTextFromSegments(raw: string | null | undefined): string {
   } catch {
     return "";
   }
-}
-
-function cleanGeneratedTitle(raw: string | null | undefined): string | null {
-  const title = (raw ?? "")
-    .replace(/^["'“”]+|["'“”]+$/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (!title) return null;
-  return title.slice(0, 80);
-}
-
-const TITLE_STOPWORDS = new Set([
-  "a",
-  "an",
-  "and",
-  "are",
-  "as",
-  "at",
-  "be",
-  "but",
-  "by",
-  "for",
-  "from",
-  "i",
-  "in",
-  "is",
-  "it",
-  "of",
-  "on",
-  "or",
-  "so",
-  "that",
-  "the",
-  "this",
-  "to",
-  "we",
-  "with",
-  "you",
-]);
-
-function titleCaseWord(word: string): string {
-  const lower = word.toLowerCase();
-  if (TITLE_STOPWORDS.has(lower)) return lower;
-  return lower.charAt(0).toUpperCase() + lower.slice(1);
-}
-
-function fallbackTitleFromTranscript(text: string): string | null {
-  const normalized = text
-    .replace(/\[[^\]]+\]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (!normalized) return null;
-  const chunks = normalized
-    .split(/(?<=[.!?])\s+|(?:\s+-\s+)|(?:\s+—\s+)/)
-    .map((chunk) =>
-      chunk
-        .replace(/^(ok|okay|yeah|yep|so|um|uh|alright|all right)[,\s]+/i, "")
-        .trim(),
-    )
-    .filter(Boolean);
-  const candidates = chunks.slice(0, 4).map((chunk) => {
-    const words = chunk
-      .split(/\s+/)
-      .map((word) => word.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}'-]+$/gu, ""))
-      .filter(Boolean)
-      .slice(0, 9);
-    const signal = words.filter(
-      (word) => !TITLE_STOPWORDS.has(word.toLowerCase()),
-    ).length;
-    return { words, score: signal * 10 + Math.min(words.length, 9) };
-  });
-  const best = candidates.sort((a, b) => b.score - a.score)[0];
-  const words = best?.words ?? [];
-  if (words.length < 2) return null;
-  const title = words.map(titleCaseWord).join(" ");
-  return cleanGeneratedTitle(title);
 }
 
 function buildTitleContext({


### PR DESCRIPTION
## Summary
- settle interrupted tool calls during terminal stream recovery and persisted assistant rebuilds
- expose run turn IDs so recovery ignores terminal runs from earlier turns
- improve calendar draft submission behavior and clips title fallback generation

## Tests
- pnpm --filter @agent-native/core test -- run-manager.spec.ts thread-data-builder.spec.ts agent-chat-adapter.spec.ts sse-event-processor.spec.ts
- pnpm --filter clips test -- regenerate-title.test.ts