### PR TITLE
Fix local-core Vite dev SSR for standalone starter apps

### DIFF
--- a/.changeset/fix-local-core-vite-ssr.md
+++ b/.changeset/fix-local-core-vite-ssr.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix Vite dev SSR for standalone apps using `file:@agent-native/core` by aliasing monorepo core source and deduping `react-router`. Add a Playwright dev smoke test that catches HydratedRouter/Meta render failures after auto-login.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,21 +187,13 @@ jobs:
       # cache hit); no separate `pnpm build` step needed.
       - run: pnpm install --frozen-lockfile
 
-      - name: Scaffold standalone app (starter) and verify pnpm install
-        run: |
-          cd "$(mktemp -d)"
-          node "$GITHUB_WORKSPACE/packages/core/dist/cli/index.js" create test-standalone --template starter
-          cd test-standalone
-          # Fail fast if any workspace: or catalog: refs leaked
-          if grep -r '"workspace:' package.json; then
-            echo "::error::workspace:* ref found in standalone scaffold"
-            exit 1
-          fi
-          if grep -r '"catalog:' package.json; then
-            echo "::error::catalog: ref found in standalone scaffold"
-            exit 1
-          fi
-          pnpm install
+      - name: Install Playwright Chromium for dev smoke
+        run: pnpm exec playwright install chromium
+
+      - name: Standalone starter dev smoke (auto-login + SSR render)
+        # Catches Vite dev SSR failures (e.g. Meta outside HydratedRouter) that
+        # production build alone does not surface. Also scaffolds + pnpm install.
+        run: pnpm qa:standalone-starter-dev
 
       - name: Scaffold workspace (starter + calendar + dispatch) and verify pnpm install + build
         # Dispatch is in the combo because it exercises the

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "pnpm -r --workspace-concurrency=4 test",
     "test:brain-evals": "pnpm --filter brain eval:ci",
     "qa:cli": "tsx scripts/qa-cli-smoke.ts",
+    "qa:standalone-starter-dev": "tsx scripts/qa-standalone-starter-dev-smoke.ts",
     "qa:composer-geometry": "tsx scripts/qa-composer-geometry-smoke.ts",
     "qa:dispatch-workspace-resources": "tsx scripts/qa-dispatch-workspace-resources-smoke.ts",
     "qa:template-routes": "tsx scripts/qa-template-route-matrix.ts",

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -1,5 +1,11 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  _findCorePackageRoot,
+  _getClientDedupe,
   defineConfig,
   isFrameworkDevPath,
   stripMountedDevApiPath,
@@ -559,5 +565,40 @@ describe("Vite CSS build defaults", () => {
       cssMinify: "esbuild",
       cssTarget: ["es2020", "safari18"],
     });
+  });
+});
+
+describe("local-core dev aliases and router dedupe", () => {
+  it("dedupes react-router when the app depends on react-router", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "an-vite-dedupe-"));
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({
+        dependencies: { "react-router": "^7.16.0" },
+      }),
+    );
+
+    const dedupe = _getClientDedupe(tmpDir);
+    expect(dedupe).toContain("react-router");
+    expect(dedupe).toContain("react-router/dom");
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("resolves file:@agent-native/core to a package root with src/index.ts", () => {
+    const coreRoot = path.resolve(import.meta.dirname, "../..");
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "an-vite-core-root-"));
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({
+        dependencies: {
+          "@agent-native/core": pathToFileURL(coreRoot).href,
+        },
+      }),
+    );
+
+    expect(_findCorePackageRoot(tmpDir)).toBe(coreRoot);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -137,7 +137,16 @@ function hasDep(pkg: string, cwd: string): boolean {
  */
 function getClientDedupe(cwd: string): string[] {
   // Always dedupe React internals (sub-path exports aren't in peerDeps)
-  const always = new Set(["react", "react-dom", "react-dom/client"]);
+  const always = new Set([
+    "react",
+    "react-dom",
+    "react-dom/client",
+    // Framework routers must share one react-router instance so
+    // FrameworkContext (Meta/Links/Scripts) matches ServerRouter/HydratedRouter.
+    ...(hasDep("react-router", cwd)
+      ? ["react-router", "react-router/dom"]
+      : []),
+  ]);
 
   // Server-only packages that never run in the browser — no point deduping.
   const serverOnly = new Set([
@@ -199,17 +208,45 @@ function getClientDedupe(cwd: string): string[] {
  * the alias is active — otherwise the prebundle is built from a snapshot
  * of dist/ at startup and never picks up new exports).
  */
-function findCoreSrcDir(cwd: string): string | null {
+function findCorePackageRoot(cwd: string): string | null {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(cwd, "package.json"), "utf-8"),
+    ) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const spec =
+      pkg.dependencies?.["@agent-native/core"] ??
+      pkg.devDependencies?.["@agent-native/core"];
+    if (typeof spec === "string" && spec.startsWith("file:")) {
+      const rooted = fileURLToPath(spec);
+      if (fs.existsSync(path.join(rooted, "src/index.ts"))) return rooted;
+    }
+  } catch {
+    // package.json missing or unreadable — fall through to path heuristics.
+  }
+
   const candidates = [
     path.resolve(cwd, "../../packages/core"), // templates/<name>/
     path.resolve(cwd, "../core"), // packages/<name>/
+    path.resolve(cwd, "node_modules/@agent-native/core"),
   ];
   for (const candidate of candidates) {
-    if (fs.existsSync(path.join(candidate, "src/index.ts"))) {
-      return path.join(candidate, "src");
+    try {
+      if (!fs.existsSync(candidate)) continue;
+      const root = fs.realpathSync(candidate);
+      if (fs.existsSync(path.join(root, "src/index.ts"))) return root;
+    } catch {
+      continue;
     }
   }
   return null;
+}
+
+function findCoreSrcDir(cwd: string): string | null {
+  const root = findCorePackageRoot(cwd);
+  return root ? path.join(root, "src") : null;
 }
 
 /**
@@ -337,6 +374,12 @@ function getDefaultOptimizeDeps(cwd: string): string[] {
     { specifier: "h3" },
     { specifier: "next-themes" },
     { specifier: "react-hook-form" },
+    ...(hasDep("react-router", cwd)
+      ? [
+          { specifier: "react-router" },
+          { specifier: "react-router/dom", packageName: "react-router" },
+        ]
+      : []),
     { specifier: "sonner" },
     { specifier: "tailwind-merge" },
     { specifier: "zod" },
@@ -1585,3 +1628,8 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
     },
   };
 }
+
+export {
+  getClientDedupe as _getClientDedupe,
+  findCorePackageRoot as _findCorePackageRoot,
+};

--- a/scripts/qa-standalone-starter-dev-smoke.ts
+++ b/scripts/qa-standalone-starter-dev-smoke.ts
@@ -1,0 +1,622 @@
+#!/usr/bin/env node
+/**
+ * Dev-server smoke for the public standalone Starter create flow:
+ *
+ *   npx @agent-native/core@latest create <name> --standalone --template starter
+ *   cd <name> && pnpm install && pnpm dev
+ *
+ * Starts a real Vite dev server, hits the same auto-login redirect path local
+ * developers use, and fails on SSR/runtime errors such as:
+ *
+ *   "You must render this element inside a <HydratedRouter> element"
+ *   → browser shows "Unexpected Server Error"
+ *
+ * Production `pnpm build` does not catch this class of bug because it exercises
+ * a different SSR pipeline than Vite dev + React Router's environment API.
+ */
+import assert from "node:assert/strict";
+import {
+  execFileSync,
+  spawn,
+  type ChildProcessWithoutNullStreams,
+  type ExecFileSyncOptions,
+} from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type { Browser, Page } from "playwright";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const requireFromCore = createRequire(
+  path.join(repoRoot, "packages/core/package.json"),
+);
+const { chromium } = requireFromCore(
+  "playwright",
+) as typeof import("playwright");
+
+const port = Number(process.env.STANDALONE_STARTER_DEV_SMOKE_PORT || 9327);
+const appName =
+  process.env.STANDALONE_STARTER_DEV_SMOKE_APP || "test-standalone";
+const scaffoldParent =
+  process.env.STANDALONE_STARTER_DEV_SMOKE_DIR?.trim() ||
+  fs.mkdtempSync(path.join(os.tmpdir(), "an-standalone-dev-smoke-"));
+const appDir = path.join(scaffoldParent, appName);
+const skipScaffold =
+  process.env.STANDALONE_STARTER_DEV_SMOKE_SKIP_CREATE === "1";
+const verbose = process.env.STANDALONE_STARTER_DEV_SMOKE_VERBOSE === "1";
+const headed = process.env.STANDALONE_STARTER_DEV_SMOKE_HEADED === "1";
+
+function log(step: string): void {
+  if (verbose) console.log(`[standalone-dev-smoke] ${step}`);
+}
+
+const cliEntry = path.join(repoRoot, "packages/core/dist/cli/index.js");
+const nodeBin = process.execPath;
+
+interface RunningDev {
+  baseUrl: string;
+  child: ChildProcessWithoutNullStreams;
+  logs: string[];
+  dbPath: string;
+}
+
+function run(
+  cmd: string,
+  args: string[],
+  opts: ExecFileSyncOptions & { cwd: string },
+): string {
+  return execFileSync(cmd, args, {
+    ...opts,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NO_COLOR: "1",
+      ...opts.env,
+    },
+  }) as string;
+}
+
+function scaffoldStandaloneStarter(): void {
+  log(`scaffolding ${appName} into ${scaffoldParent}`);
+  if (!fs.existsSync(cliEntry)) {
+    throw new Error(
+      `Missing ${cliEntry}. Run pnpm --filter @agent-native/core build first.`,
+    );
+  }
+  run(
+    nodeBin,
+    [cliEntry, "create", appName, "--standalone", "--template", "starter"],
+    {
+      cwd: scaffoldParent,
+    },
+  );
+  assert.equal(fs.existsSync(path.join(appDir, "package.json")), true);
+}
+
+function installApp(): void {
+  log(`pnpm install in ${appDir}`);
+  run("pnpm", ["install"], { cwd: appDir });
+}
+
+function assertStandalonePackageJson(): void {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(appDir, "package.json"), "utf8"),
+  );
+  for (const depType of [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+  ] as const) {
+    for (const [name, value] of Object.entries(pkg[depType] ?? {})) {
+      if (typeof value !== "string") continue;
+      assert.ok(
+        !value.startsWith("workspace:"),
+        `${depType}.${name} must not be workspace:*`,
+      );
+      assert.ok(
+        !value.startsWith("catalog:"),
+        `${depType}.${name} must not be catalog:* (${value})`,
+      );
+    }
+  }
+}
+
+function tryFreePort(targetPort: number): void {
+  try {
+    const pids = execFileSync("lsof", ["-ti", `:${targetPort}`], {
+      encoding: "utf8",
+    })
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    for (const pid of pids) {
+      try {
+        process.kill(Number(pid), "SIGKILL");
+      } catch {
+        // ignore stale pid
+      }
+    }
+    if (pids.length > 0) {
+      log(`freed port ${targetPort} (killed ${pids.length} stale process(es))`);
+    }
+  } catch {
+    // port was free
+  }
+}
+
+function prepareIsolatedDataDir(): string {
+  const dataDir = path.join(appDir, ".data");
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  return path.join(dataDir, "smoke.db");
+}
+
+function devEnv(baseUrl: string, dbPath: string): NodeJS.ProcessEnv {
+  const databaseUrl = `file:${dbPath}`;
+  return {
+    ...process.env,
+    NODE_ENV: "development",
+    APP_URL: baseUrl,
+    BETTER_AUTH_URL: baseUrl,
+    BETTER_AUTH_SECRET: "standalone-starter-dev-smoke-secret",
+    DATABASE_URL: databaseUrl,
+    DATABASE_AUTH_TOKEN: "",
+    AUTH_SKIP_EMAIL_VERIFICATION: "1",
+    NETLIFY: "",
+    VERCEL: "",
+    CF_PAGES: "",
+    DEPLOY_URL: "",
+    URL: "",
+    RENDER: "",
+    FLY_APP_NAME: "",
+    NO_COLOR: "1",
+  };
+}
+
+function logTail(logs: string[], maxLines = 120): string {
+  return logs.slice(-maxLines).join("");
+}
+
+function hasStarterMigrations(logs: string[]): boolean {
+  return logTail(logs).includes("Applied migration v1007");
+}
+
+function hasAuthLockFailure(logs: string[]): boolean {
+  return logTail(logs).includes(
+    "Auth guard registered despite init failure — app is locked.",
+  );
+}
+
+function hasRecentDatabaseLock(logs: string[]): boolean {
+  const tail = logTail(logs, 40);
+  return tail.includes("database is locked") || tail.includes("SQLITE_BUSY");
+}
+
+async function waitForDevStable(
+  baseUrl: string,
+  logs: string[],
+): Promise<void> {
+  const deadline = Date.now() + 180_000;
+  let lastError = "";
+
+  while (Date.now() < deadline) {
+    if (hasAuthLockFailure(logs)) {
+      throw new Error(
+        "Dev server auth init failed (app locked). Recent logs:\n" +
+          logTail(logs),
+      );
+    }
+
+    try {
+      const ping = await fetch(`${baseUrl}/_agent-native/ping`, {
+        redirect: "manual",
+        signal: AbortSignal.timeout(3_000),
+      });
+      if (ping.status >= 500) {
+        lastError = `ping HTTP ${ping.status}`;
+        await sleep(750);
+        continue;
+      }
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+      await sleep(750);
+      continue;
+    }
+
+    if (!hasStarterMigrations(logs)) {
+      lastError = "migrations still running";
+      await sleep(750);
+      continue;
+    }
+
+    if (hasRecentDatabaseLock(logs)) {
+      lastError = "database is locked (startup race)";
+      await sleep(2_000);
+      continue;
+    }
+
+    // Do not fetch `/` here — Node fetch would consume the one-time auto-login
+    // cookie before Playwright opens. Let the browser be the first client.
+    await sleep(2_000);
+    return;
+  }
+
+  throw new Error(
+    `Dev server did not stabilize at ${baseUrl}: ${lastError}\n${logTail(logs)}`,
+  );
+}
+
+async function startDev(): Promise<RunningDev> {
+  tryFreePort(port);
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const dbPath = prepareIsolatedDataDir();
+  log(`database: file:${dbPath}`);
+  const logs: string[] = [];
+  const child = spawn(
+    "pnpm",
+    [
+      "exec",
+      "agent-native",
+      "dev",
+      "--",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--strictPort",
+    ],
+    {
+      cwd: appDir,
+      env: devEnv(baseUrl, dbPath),
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  child.stdout.on("data", (chunk) => logs.push(chunk.toString()));
+  child.stderr.on("data", (chunk) => logs.push(chunk.toString()));
+  child.on("exit", (code, signal) => {
+    logs.push(`\n[dev] exited code=${code} signal=${signal}\n`);
+  });
+
+  await waitForDevStable(baseUrl, logs);
+  log(`dev server stable at ${baseUrl}`);
+  return { baseUrl, child, logs, dbPath };
+}
+
+async function stopDev(running: RunningDev): Promise<void> {
+  if (running.child.exitCode != null) return;
+  running.child.kill("SIGTERM");
+  await Promise.race([
+    new Promise<void>((resolve) => running.child.once("exit", () => resolve())),
+    new Promise<void>((resolve) =>
+      setTimeout(() => {
+        if (running.child.exitCode == null) running.child.kill("SIGKILL");
+        resolve();
+      }, 8_000),
+    ),
+  ]);
+}
+
+async function launchBrowser(): Promise<Browser> {
+  const channel = process.env.PLAYWRIGHT_CHANNEL || "chrome";
+  try {
+    return await chromium.launch({ channel, headless: !headed });
+  } catch (channelError) {
+    if (process.env.PLAYWRIGHT_CHANNEL) throw channelError;
+    try {
+      return await chromium.launch({ headless: !headed });
+    } catch (bundledError) {
+      throw new Error(
+        [
+          "Could not launch Playwright Chromium.",
+          `Chrome channel error: ${
+            channelError instanceof Error
+              ? channelError.message.split("\n")[0]
+              : String(channelError)
+          }`,
+          `Bundled Chromium error: ${
+            bundledError instanceof Error
+              ? bundledError.message.split("\n")[0]
+              : String(bundledError)
+          }`,
+          "Install a browser with `pnpm exec playwright install chromium` or set PLAYWRIGHT_CHANNEL.",
+        ].join("\n"),
+      );
+    }
+  }
+}
+
+async function gotoCommitted(page: Page, url: string): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      await page.goto(url, { waitUntil: "commit", timeout: 90_000 });
+      return;
+    } catch (err) {
+      lastError = err;
+      const message = err instanceof Error ? err.message : String(err);
+      const retryable =
+        message.includes("net::ERR_ABORTED") ||
+        message.includes("Vite environment") ||
+        message.includes("503");
+      if (!retryable || attempt === 4) throw err;
+      await page.waitForTimeout(750 * (attempt + 1));
+    }
+  }
+  throw lastError;
+}
+
+function isBenignConsoleError(text: string): boolean {
+  if (text.startsWith("Failed to load resource:")) return true;
+  if (text.includes("favicon")) return true;
+  return false;
+}
+
+function isBenignHttpError(status: number, url: string): boolean {
+  if (status === 404 && url.includes("/_agent-native/agent-chat/threads/")) {
+    return true;
+  }
+  // First dev load optimizes deps and may 504/503 while Vite/Nitro warm up.
+  if (
+    (status === 504 || status === 503) &&
+    (url.includes("/node_modules/.vite/") || url.includes("/@fs/"))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+async function signInViaAuthApi(
+  page: Page,
+  email: string,
+  password: string,
+): Promise<void> {
+  await page.evaluate(
+    async ({ email, password }) => {
+      const post = async (path: string, body: Record<string, unknown>) => {
+        const response = await fetch(path, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        const text = await response.text();
+        return { ok: response.ok, status: response.status, text };
+      };
+
+      let login = await post("/_agent-native/auth/login", { email, password });
+      if (!login.ok) {
+        const register = await post("/_agent-native/auth/register", {
+          email,
+          password,
+          name: "Smoke Tester",
+          callbackURL: "/",
+        });
+        if (!register.ok && register.status !== 409) {
+          throw new Error(
+            `register failed with HTTP ${register.status}: ${register.text}`,
+          );
+        }
+        login = await post("/_agent-native/auth/login", { email, password });
+      }
+      if (!login.ok) {
+        throw new Error(
+          `login failed with HTTP ${login.status}: ${login.text}`,
+        );
+      }
+    },
+    { email, password },
+  );
+}
+
+async function waitForAuthenticatedShell(
+  page: Page,
+  baseUrl: string,
+): Promise<string> {
+  const qaEmail =
+    process.env.STANDALONE_STARTER_DEV_SMOKE_EMAIL ||
+    `standalone-smoke-${Date.now()}@example.test`;
+  const qaPassword =
+    process.env.STANDALONE_STARTER_DEV_SMOKE_PASSWORD ||
+    "standalone-starter-smoke-password";
+
+  log(`navigating to ${baseUrl}/ (auto-login path)`);
+  let lastBody = "";
+  let lastUrl = baseUrl;
+
+  for (let attempt = 0; attempt < 4; attempt++) {
+    await gotoCommitted(page, `${baseUrl}/`);
+    lastUrl = page.url();
+    lastBody = await page.locator("body").innerText({ timeout: 10_000 });
+
+    if (/unexpected server error/i.test(lastBody)) {
+      throw new Error(
+        `page rendered server error text at ${lastUrl}: ${lastBody.slice(0, 240)}`,
+      );
+    }
+
+    const homeLink = page.getByRole("link", { name: "Home" });
+    if (await homeLink.isVisible().catch(() => false)) break;
+
+    if (
+      /create an account to get started/i.test(lastBody) ||
+      /sign in/i.test(lastBody)
+    ) {
+      log(
+        `still logged out (attempt ${attempt + 1}/4) — trying auth API login`,
+      );
+      await signInViaAuthApi(page, qaEmail, qaPassword);
+      continue;
+    }
+
+    try {
+      await homeLink.waitFor({ state: "visible", timeout: 15_000 });
+      break;
+    } catch (err) {
+      if (attempt === 3) {
+        throw new Error(
+          `Home link never appeared at ${lastUrl} after login.\n` +
+            `Body preview: ${lastBody.slice(0, 400)}\n` +
+            (err instanceof Error ? err.message : String(err)),
+        );
+      }
+      log(`Home not visible yet (attempt ${attempt + 1}/4), retrying…`);
+      await sleep(3_000);
+    }
+  }
+
+  const session = await page.evaluate(async () => {
+    const response = await fetch("/_agent-native/auth/session", {
+      headers: { Accept: "application/json" },
+      credentials: "include",
+    });
+    const text = await response.text();
+    return text ? JSON.parse(text) : null;
+  });
+  const sessionEmail =
+    typeof session?.email === "string"
+      ? session.email
+      : typeof session?.user?.email === "string"
+        ? session.user.email
+        : "";
+  assert.ok(
+    sessionEmail.length > 0,
+    `expected authenticated session after auto-login, got ${JSON.stringify(session)}`,
+  );
+  log(`authenticated session: ${sessionEmail}`);
+  return sessionEmail;
+}
+
+async function runBrowserSmoke(
+  page: Page,
+  baseUrl: string,
+  browserErrors: string[],
+  httpErrors: string[],
+): Promise<void> {
+  // Warmup: auto-login redirect + first Vite dep optimization (noisy HTTP).
+  log("warmup: first load + Vite dep optimization");
+  await waitForAuthenticatedShell(page, baseUrl);
+  await page.waitForTimeout(6_000);
+
+  browserErrors.length = 0;
+  httpErrors.length = 0;
+
+  log("assertion pass: / and /observability after warmup");
+  await waitForAuthenticatedShell(page, baseUrl);
+  log(`navigating to ${baseUrl}/observability`);
+  await gotoCommitted(page, `${baseUrl}/observability`);
+  await page
+    .getByRole("link", { name: "Observability" })
+    .waitFor({ state: "visible", timeout: 20_000 });
+
+  assert.deepEqual(browserErrors, [], "browser console/page errors");
+  assert.deepEqual(httpErrors, [], "browser HTTP errors on app origin");
+}
+
+function assertCleanServerLogs(logs: string[]): void {
+  const text = logs.join("");
+  const offenders: string[] = [];
+  if (text.includes("HydratedRouter")) offenders.push("HydratedRouter");
+  if (text.includes("Unexpected Server Error"))
+    offenders.push("Unexpected Server Error");
+  if (text.includes("You must render this element inside a")) {
+    offenders.push("render outside router context");
+  }
+  if (hasAuthLockFailure(logs))
+    offenders.push("auth init failure (app locked)");
+  assert.deepEqual(
+    offenders,
+    [],
+    `dev server logs contained SSR errors: ${offenders.join(", ")}`,
+  );
+}
+
+async function main(): Promise<void> {
+  if (!skipScaffold) {
+    scaffoldStandaloneStarter();
+    installApp();
+    assertStandalonePackageJson();
+  } else {
+    assert.equal(
+      fs.existsSync(path.join(appDir, "package.json")),
+      true,
+      `STANDALONE_STARTER_DEV_SMOKE_SKIP_CREATE=1 requires ${appDir}/package.json`,
+    );
+  }
+
+  const running = await startDev();
+  let browser: Browser | null = null;
+  const browserErrors: string[] = [];
+  const httpErrors: string[] = [];
+
+  try {
+    browser = await launchBrowser();
+    const context = await browser.newContext({
+      viewport: { width: 1280, height: 900 },
+    });
+    const page = await context.newPage();
+
+    page.on("pageerror", (error) => browserErrors.push(error.message));
+    page.on("console", (message) => {
+      if (message.type() !== "error") return;
+      const text = message.text();
+      if (isBenignConsoleError(text)) return;
+      browserErrors.push(text);
+    });
+    page.on("response", (response) => {
+      const status = response.status();
+      if (status < 400) return;
+      const url = response.url();
+      if (!url.startsWith(running.baseUrl)) return;
+      if (isBenignHttpError(status, url)) return;
+      httpErrors.push(`${status} ${url}`);
+    });
+
+    await runBrowserSmoke(page, running.baseUrl, browserErrors, httpErrors);
+    assertCleanServerLogs(running.logs);
+
+    console.log("qa-standalone-starter-dev-smoke: clean");
+    console.log(`  url:      ${running.baseUrl}`);
+    console.log(`  app:      ${appDir}`);
+    console.log(
+      "  checked:  scaffold → install → dev server → auto-login → / → /observability",
+    );
+    console.log(
+      "  checked:  no Unexpected Server Error, no HydratedRouter in dev logs",
+    );
+    console.log("  checked:  no browser console/page errors after warmup");
+  } catch (err) {
+    const logs = running.logs.slice(-160).join("");
+    const message =
+      err instanceof Error ? err.stack || err.message : String(err);
+    const browserBlock =
+      browserErrors.length > 0
+        ? `\n\nBrowser errors:\n${browserErrors.join("\n")}`
+        : "";
+    const httpBlock =
+      httpErrors.length > 0
+        ? `\n\nBrowser HTTP errors:\n${httpErrors.join("\n")}`
+        : "";
+    throw new Error(
+      `${message}${browserBlock}${httpBlock}\n\nRecent dev logs:\n${logs}`,
+    );
+  } finally {
+    if (browser) await browser.close();
+    await stopDev(running);
+    if (!process.env.STANDALONE_STARTER_DEV_SMOKE_DIR && !skipScaffold) {
+      fs.rmSync(scaffoldParent, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+      });
+    }
+  }
+}
+
+await main();

--- a/scripts/qa-standalone-starter-dev-smoke.ts
+++ b/scripts/qa-standalone-starter-dev-smoke.ts
@@ -51,6 +51,10 @@ const skipScaffold =
   process.env.STANDALONE_STARTER_DEV_SMOKE_SKIP_CREATE === "1";
 const verbose = process.env.STANDALONE_STARTER_DEV_SMOKE_VERBOSE === "1";
 const headed = process.env.STANDALONE_STARTER_DEV_SMOKE_HEADED === "1";
+const isCi = Boolean(process.env.CI || process.env.GITHUB_ACTIONS);
+const shellTimeoutMs = isCi ? 120_000 : 60_000;
+const viteWarmupMs = isCi ? 15_000 : 6_000;
+const devStartAttempts = 3;
 
 function log(step: string): void {
   if (verbose) console.log(`[standalone-dev-smoke] ${step}`);
@@ -198,6 +202,26 @@ function hasRecentDatabaseLock(logs: string[]): boolean {
   return tail.includes("database is locked") || tail.includes("SQLITE_BUSY");
 }
 
+function parseDevAutoLoginCredentials(logs: string[]): {
+  email: string;
+  password: string;
+} | null {
+  const text = logs.join("");
+  const match = text.match(
+    /Local dev auto-login ready\.\s+email:\s+([^\s]+)\s+password:\s+([^\s]+)/,
+  );
+  if (!match) return null;
+  return { email: match[1], password: match[2] };
+}
+
+function isLoggedOutBody(body: string): boolean {
+  return (
+    /create an account to get started/i.test(body) ||
+    /sign in/i.test(body) ||
+    /log in/i.test(body)
+  );
+}
+
 async function waitForDevStable(
   baseUrl: string,
   logs: string[],
@@ -252,7 +276,7 @@ async function waitForDevStable(
   );
 }
 
-async function startDev(): Promise<RunningDev> {
+async function startDevOnce(): Promise<RunningDev> {
   tryFreePort(port);
   const baseUrl = `http://127.0.0.1:${port}`;
   const dbPath = prepareIsolatedDataDir();
@@ -284,9 +308,37 @@ async function startDev(): Promise<RunningDev> {
     logs.push(`\n[dev] exited code=${code} signal=${signal}\n`);
   });
 
-  await waitForDevStable(baseUrl, logs);
-  log(`dev server stable at ${baseUrl}`);
-  return { baseUrl, child, logs, dbPath };
+  const running = { baseUrl, child, logs, dbPath };
+  try {
+    await waitForDevStable(baseUrl, logs);
+    log(`dev server stable at ${baseUrl}`);
+    return running;
+  } catch (err) {
+    await stopDev(running);
+    throw err;
+  }
+}
+
+async function startDev(): Promise<RunningDev> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < devStartAttempts; attempt++) {
+    try {
+      return await startDevOnce();
+    } catch (err) {
+      lastError = err;
+      const message = err instanceof Error ? err.message : String(err);
+      const retryable =
+        message.includes("app locked") ||
+        message.includes("database is locked") ||
+        message.includes("SQLITE_BUSY");
+      if (!retryable || attempt === devStartAttempts - 1) throw err;
+      log(
+        `dev startup race (attempt ${attempt + 1}/${devStartAttempts}), retrying…`,
+      );
+      await sleep(2_000);
+    }
+  }
+  throw lastError;
 }
 
 async function stopDev(running: RunningDev): Promise<void> {
@@ -454,31 +506,68 @@ async function signInViaAuthApi(
   );
 }
 
-async function waitForHomeLink(page: Page, timeoutMs = 60_000): Promise<void> {
+async function waitForHomeLink(
+  page: Page,
+  timeoutMs = shellTimeoutMs,
+  baseUrl?: string,
+): Promise<void> {
   const homeLink = page.getByRole("link", { name: "Home" });
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
+    if (await homeLink.isVisible().catch(() => false)) return;
+
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+
     try {
       await homeLink.waitFor({
         state: "visible",
-        timeout: Math.min(15_000, deadline - Date.now()),
+        timeout: Math.min(5_000, remaining),
       });
       return;
     } catch (err) {
-      if (isNavigationContextError(err) && Date.now() < deadline) {
+      const stillHaveTime = Date.now() < deadline;
+      if (!stillHaveTime) break;
+      if (
+        baseUrl &&
+        (isNavigationContextError(err) ||
+          (err instanceof Error && err.message.includes("Timeout")))
+      ) {
+        log("Home not visible — re-navigating after Vite reload");
+        await gotoCommitted(page, `${baseUrl}/`);
+        await sleep(1_500);
+        continue;
+      }
+      if (isNavigationContextError(err)) {
+        await sleep(1_000);
+        continue;
+      }
+      if (stillHaveTime) {
         await sleep(1_000);
         continue;
       }
       throw err;
     }
   }
+
+  const bodyPreview = await page
+    .locator("body")
+    .innerText({ timeout: 5_000 })
+    .catch(() => "");
+  throw new Error(
+    `Home link not visible within ${timeoutMs}ms at ${page.url()}.\n` +
+      `Body preview: ${bodyPreview.slice(0, 400)}`,
+  );
 }
 
-async function readAuthenticatedSessionEmail(page: Page): Promise<string> {
+async function readAuthenticatedSessionEmail(
+  page: Page,
+  baseUrl: string,
+): Promise<string> {
   return retryAfterNavigation(
     "session read",
     async () => {
-      await waitForHomeLink(page, 20_000);
+      await waitForHomeLink(page, shellTimeoutMs, baseUrl);
       const session = await page.evaluate(async () => {
         const response = await fetch("/_agent-native/auth/session", {
           headers: { Accept: "application/json" },
@@ -506,23 +595,28 @@ async function readAuthenticatedSessionEmail(page: Page): Promise<string> {
 async function waitForAuthenticatedShell(
   page: Page,
   baseUrl: string,
+  serverLogs: string[],
 ): Promise<string> {
-  const qaEmail =
+  const devCreds = parseDevAutoLoginCredentials(serverLogs);
+  const fallbackEmail =
     process.env.STANDALONE_STARTER_DEV_SMOKE_EMAIL ||
     `standalone-smoke-${Date.now()}@example.test`;
-  const qaPassword =
+  const fallbackPassword =
     process.env.STANDALONE_STARTER_DEV_SMOKE_PASSWORD ||
     "standalone-starter-smoke-password";
+  const loginEmail = devCreds?.email ?? fallbackEmail;
+  const loginPassword = devCreds?.password ?? fallbackPassword;
 
   log(`navigating to ${baseUrl}/ (auto-login path)`);
   let lastBody = "";
   let lastUrl = baseUrl;
+  const shellAttempts = isCi ? 10 : 6;
 
-  for (let attempt = 0; attempt < 4; attempt++) {
+  for (let attempt = 0; attempt < shellAttempts; attempt++) {
     await gotoCommitted(page, `${baseUrl}/`);
     lastUrl = page.url();
     lastBody = await retryAfterNavigation("body read", () =>
-      page.locator("body").innerText({ timeout: 10_000 }),
+      page.locator("body").innerText({ timeout: 15_000 }),
     );
 
     if (/unexpected server error/i.test(lastBody)) {
@@ -534,34 +628,34 @@ async function waitForAuthenticatedShell(
     const homeLink = page.getByRole("link", { name: "Home" });
     if (await homeLink.isVisible().catch(() => false)) break;
 
-    if (
-      /create an account to get started/i.test(lastBody) ||
-      /sign in/i.test(lastBody)
-    ) {
+    const devCredsNow = parseDevAutoLoginCredentials(serverLogs);
+    const authEmail = devCredsNow?.email ?? loginEmail;
+    const authPassword = devCredsNow?.password ?? loginPassword;
+
+    if (isLoggedOutBody(lastBody)) {
+      if (!devCredsNow && attempt < shellAttempts - 2) {
+        log(
+          `logged out before auto-login creds printed (attempt ${attempt + 1}/${shellAttempts}) — retrying /`,
+        );
+        await sleep(isCi ? 4_000 : 2_500);
+        continue;
+      }
       log(
-        `still logged out (attempt ${attempt + 1}/4) — trying auth API login`,
+        `still logged out (attempt ${attempt + 1}/${shellAttempts}) — auth API login as ${authEmail}`,
       );
-      await signInViaAuthApi(page, qaEmail, qaPassword);
+      await signInViaAuthApi(page, authEmail, authPassword);
       continue;
     }
 
-    try {
-      await waitForHomeLink(page, 15_000);
-      break;
-    } catch (err) {
-      if (attempt === 3) {
-        throw new Error(
-          `Home link never appeared at ${lastUrl} after login.\n` +
-            `Body preview: ${lastBody.slice(0, 400)}\n` +
-            (err instanceof Error ? err.message : String(err)),
-        );
-      }
-      log(`Home not visible yet (attempt ${attempt + 1}/4), retrying…`);
-      await sleep(3_000);
-    }
+    log(
+      `authenticated shell not ready (attempt ${attempt + 1}/${shellAttempts}) — Vite may still be optimizing deps`,
+    );
+    await sleep(isCi ? 4_000 : 2_500);
   }
 
-  const sessionEmail = await readAuthenticatedSessionEmail(page);
+  await waitForHomeLink(page, shellTimeoutMs, baseUrl);
+
+  const sessionEmail = await readAuthenticatedSessionEmail(page, baseUrl);
   log(`authenticated session: ${sessionEmail}`);
   return sessionEmail;
 }
@@ -569,21 +663,22 @@ async function waitForAuthenticatedShell(
 async function runBrowserSmoke(
   page: Page,
   baseUrl: string,
+  serverLogs: string[],
   browserErrors: string[],
   httpErrors: string[],
 ): Promise<void> {
   // Warmup: auto-login redirect + first Vite dep optimization (noisy HTTP).
   log("warmup: first load + Vite dep optimization");
-  await waitForAuthenticatedShell(page, baseUrl);
-  await page.waitForTimeout(6_000);
+  await waitForAuthenticatedShell(page, baseUrl, serverLogs);
+  await page.waitForTimeout(viteWarmupMs);
 
   browserErrors.length = 0;
   httpErrors.length = 0;
 
   log("assertion pass: / and /observability after warmup");
   await gotoCommitted(page, `${baseUrl}/`);
-  await waitForHomeLink(page);
-  await readAuthenticatedSessionEmail(page);
+  await waitForHomeLink(page, shellTimeoutMs, baseUrl);
+  await readAuthenticatedSessionEmail(page, baseUrl);
   log(`navigating to ${baseUrl}/observability`);
   await gotoCommitted(page, `${baseUrl}/observability`);
   await page
@@ -653,7 +748,13 @@ async function main(): Promise<void> {
       httpErrors.push(`${status} ${url}`);
     });
 
-    await runBrowserSmoke(page, running.baseUrl, browserErrors, httpErrors);
+    await runBrowserSmoke(
+      page,
+      running.baseUrl,
+      running.logs,
+      browserErrors,
+      httpErrors,
+    );
     assertCleanServerLogs(running.logs);
 
     console.log("qa-standalone-starter-dev-smoke: clean");

--- a/scripts/qa-standalone-starter-dev-smoke.ts
+++ b/scripts/qa-standalone-starter-dev-smoke.ts
@@ -304,32 +304,66 @@ async function stopDev(running: RunningDev): Promise<void> {
 }
 
 async function launchBrowser(): Promise<Browser> {
-  const channel = process.env.PLAYWRIGHT_CHANNEL || "chrome";
-  try {
-    return await chromium.launch({ channel, headless: !headed });
-  } catch (channelError) {
-    if (process.env.PLAYWRIGHT_CHANNEL) throw channelError;
+  const channel =
+    process.env.PLAYWRIGHT_CHANNEL ||
+    (process.env.CI || process.env.GITHUB_ACTIONS ? undefined : "chrome");
+  if (channel) {
     try {
-      return await chromium.launch({ headless: !headed });
-    } catch (bundledError) {
-      throw new Error(
-        [
-          "Could not launch Playwright Chromium.",
-          `Chrome channel error: ${
-            channelError instanceof Error
-              ? channelError.message.split("\n")[0]
-              : String(channelError)
-          }`,
-          `Bundled Chromium error: ${
-            bundledError instanceof Error
-              ? bundledError.message.split("\n")[0]
-              : String(bundledError)
-          }`,
-          "Install a browser with `pnpm exec playwright install chromium` or set PLAYWRIGHT_CHANNEL.",
-        ].join("\n"),
+      return await chromium.launch({ channel, headless: !headed });
+    } catch (channelError) {
+      if (process.env.PLAYWRIGHT_CHANNEL) throw channelError;
+      log(
+        `Chrome channel launch failed (${channelError instanceof Error ? channelError.message.split("\n")[0] : String(channelError)}); using bundled Chromium`,
       );
     }
   }
+  try {
+    return await chromium.launch({ headless: !headed });
+  } catch (bundledError) {
+    throw new Error(
+      [
+        "Could not launch Playwright Chromium.",
+        `Bundled Chromium error: ${
+          bundledError instanceof Error
+            ? bundledError.message.split("\n")[0]
+            : String(bundledError)
+        }`,
+        "Install a browser with `pnpm exec playwright install chromium` or set PLAYWRIGHT_CHANNEL.",
+      ].join("\n"),
+    );
+  }
+}
+
+function isNavigationContextError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    message.includes("Execution context was destroyed") ||
+    message.includes("context was destroyed") ||
+    message.includes("net::ERR_ABORTED")
+  );
+}
+
+async function retryAfterNavigation<T>(
+  label: string,
+  fn: () => Promise<T>,
+  options: { attempts?: number; delayMs?: number } = {},
+): Promise<T> {
+  const attempts = options.attempts ?? 12;
+  const delayMs = options.delayMs ?? 1_500;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (!isNavigationContextError(err) || attempt === attempts - 1) throw err;
+      log(
+        `${label} interrupted by navigation (attempt ${attempt + 1}/${attempts}), retrying…`,
+      );
+      await sleep(delayMs);
+    }
+  }
+  throw lastError;
 }
 
 async function gotoCommitted(page: Page, url: string): Promise<void> {
@@ -377,41 +411,95 @@ async function signInViaAuthApi(
   email: string,
   password: string,
 ): Promise<void> {
-  await page.evaluate(
-    async ({ email, password }) => {
-      const post = async (path: string, body: Record<string, unknown>) => {
-        const response = await fetch(path, {
-          method: "POST",
-          credentials: "include",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
-        });
-        const text = await response.text();
-        return { ok: response.ok, status: response.status, text };
-      };
+  await retryAfterNavigation("auth API login", () =>
+    page.evaluate(
+      async ({ email, password }) => {
+        const post = async (path: string, body: Record<string, unknown>) => {
+          const response = await fetch(path, {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          });
+          const text = await response.text();
+          return { ok: response.ok, status: response.status, text };
+        };
 
-      let login = await post("/_agent-native/auth/login", { email, password });
-      if (!login.ok) {
-        const register = await post("/_agent-native/auth/register", {
+        let login = await post("/_agent-native/auth/login", {
           email,
           password,
-          name: "Smoke Tester",
-          callbackURL: "/",
         });
-        if (!register.ok && register.status !== 409) {
+        if (!login.ok) {
+          const register = await post("/_agent-native/auth/register", {
+            email,
+            password,
+            name: "Smoke Tester",
+            callbackURL: "/",
+          });
+          if (!register.ok && register.status !== 409) {
+            throw new Error(
+              `register failed with HTTP ${register.status}: ${register.text}`,
+            );
+          }
+          login = await post("/_agent-native/auth/login", { email, password });
+        }
+        if (!login.ok) {
           throw new Error(
-            `register failed with HTTP ${register.status}: ${register.text}`,
+            `login failed with HTTP ${login.status}: ${login.text}`,
           );
         }
-        login = await post("/_agent-native/auth/login", { email, password });
+      },
+      { email, password },
+    ),
+  );
+}
+
+async function waitForHomeLink(page: Page, timeoutMs = 60_000): Promise<void> {
+  const homeLink = page.getByRole("link", { name: "Home" });
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await homeLink.waitFor({
+        state: "visible",
+        timeout: Math.min(15_000, deadline - Date.now()),
+      });
+      return;
+    } catch (err) {
+      if (isNavigationContextError(err) && Date.now() < deadline) {
+        await sleep(1_000);
+        continue;
       }
-      if (!login.ok) {
-        throw new Error(
-          `login failed with HTTP ${login.status}: ${login.text}`,
-        );
-      }
+      throw err;
+    }
+  }
+}
+
+async function readAuthenticatedSessionEmail(page: Page): Promise<string> {
+  return retryAfterNavigation(
+    "session read",
+    async () => {
+      await waitForHomeLink(page, 20_000);
+      const session = await page.evaluate(async () => {
+        const response = await fetch("/_agent-native/auth/session", {
+          headers: { Accept: "application/json" },
+          credentials: "include",
+        });
+        const text = await response.text();
+        return text ? JSON.parse(text) : null;
+      });
+      const sessionEmail =
+        typeof session?.email === "string"
+          ? session.email
+          : typeof session?.user?.email === "string"
+            ? session.user.email
+            : "";
+      assert.ok(
+        sessionEmail.length > 0,
+        `expected authenticated session, got ${JSON.stringify(session)}`,
+      );
+      return sessionEmail;
     },
-    { email, password },
+    { attempts: 20, delayMs: 2_000 },
   );
 }
 
@@ -433,7 +521,9 @@ async function waitForAuthenticatedShell(
   for (let attempt = 0; attempt < 4; attempt++) {
     await gotoCommitted(page, `${baseUrl}/`);
     lastUrl = page.url();
-    lastBody = await page.locator("body").innerText({ timeout: 10_000 });
+    lastBody = await retryAfterNavigation("body read", () =>
+      page.locator("body").innerText({ timeout: 10_000 }),
+    );
 
     if (/unexpected server error/i.test(lastBody)) {
       throw new Error(
@@ -456,7 +546,7 @@ async function waitForAuthenticatedShell(
     }
 
     try {
-      await homeLink.waitFor({ state: "visible", timeout: 15_000 });
+      await waitForHomeLink(page, 15_000);
       break;
     } catch (err) {
       if (attempt === 3) {
@@ -471,24 +561,7 @@ async function waitForAuthenticatedShell(
     }
   }
 
-  const session = await page.evaluate(async () => {
-    const response = await fetch("/_agent-native/auth/session", {
-      headers: { Accept: "application/json" },
-      credentials: "include",
-    });
-    const text = await response.text();
-    return text ? JSON.parse(text) : null;
-  });
-  const sessionEmail =
-    typeof session?.email === "string"
-      ? session.email
-      : typeof session?.user?.email === "string"
-        ? session.user.email
-        : "";
-  assert.ok(
-    sessionEmail.length > 0,
-    `expected authenticated session after auto-login, got ${JSON.stringify(session)}`,
-  );
+  const sessionEmail = await readAuthenticatedSessionEmail(page);
   log(`authenticated session: ${sessionEmail}`);
   return sessionEmail;
 }
@@ -508,7 +581,9 @@ async function runBrowserSmoke(
   httpErrors.length = 0;
 
   log("assertion pass: / and /observability after warmup");
-  await waitForAuthenticatedShell(page, baseUrl);
+  await gotoCommitted(page, `${baseUrl}/`);
+  await waitForHomeLink(page);
+  await readAuthenticatedSessionEmail(page);
   log(`navigating to ${baseUrl}/observability`);
   await gotoCommitted(page, `${baseUrl}/observability`);
   await page

--- a/scripts/qa-standalone-starter-dev-smoke.ts
+++ b/scripts/qa-standalone-starter-dev-smoke.ts
@@ -13,6 +13,12 @@
  *
  * Production `pnpm build` does not catch this class of bug because it exercises
  * a different SSR pipeline than Vite dev + React Router's environment API.
+ *
+ * CI flake strategy (do not fight Vite first-load dep optimization):
+ * 1. One page.goto to `/` so auto-login runs in the browser.
+ * 2. Poll for Home / auth — never re-goto during active Vite reloads.
+ * 3. waitForViteDepsQuiet(server logs) before strict assertions.
+ * 4. Retry goto/evaluate only for transient Playwright navigation errors.
  */
 import assert from "node:assert/strict";
 import {
@@ -26,7 +32,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import type { Browser, Page } from "playwright";
 
 const repoRoot = path.resolve(
@@ -53,7 +59,6 @@ const verbose = process.env.STANDALONE_STARTER_DEV_SMOKE_VERBOSE === "1";
 const headed = process.env.STANDALONE_STARTER_DEV_SMOKE_HEADED === "1";
 const isCi = Boolean(process.env.CI || process.env.GITHUB_ACTIONS);
 const shellTimeoutMs = isCi ? 120_000 : 60_000;
-const viteWarmupMs = isCi ? 15_000 : 6_000;
 const devStartAttempts = 3;
 
 function log(step: string): void {
@@ -63,11 +68,31 @@ function log(step: string): void {
 const cliEntry = path.join(repoRoot, "packages/core/dist/cli/index.js");
 const nodeBin = process.execPath;
 
+interface ViteReloadTracker {
+  /** Wall-clock ms when the latest Vite full-page reload log chunk arrived. */
+  lastReloadAt: number;
+}
+
 interface RunningDev {
   baseUrl: string;
   child: ChildProcessWithoutNullStreams;
   logs: string[];
   dbPath: string;
+  viteReload: ViteReloadTracker;
+}
+
+function appendDevLog(
+  logs: string[],
+  chunk: string,
+  viteReload: ViteReloadTracker,
+): void {
+  logs.push(chunk);
+  if (
+    chunk.includes("reloading the page") ||
+    chunk.includes("optimized dependencies changed")
+  ) {
+    viteReload.lastReloadAt = Date.now();
+  }
 }
 
 function run(
@@ -217,8 +242,43 @@ function parseDevAutoLoginCredentials(logs: string[]): {
 function isLoggedOutBody(body: string): boolean {
   return (
     /create an account to get started/i.test(body) ||
-    /sign in/i.test(body) ||
-    /log in/i.test(body)
+    /sign in to your account/i.test(body) ||
+    /log in to your account/i.test(body)
+  );
+}
+
+/**
+ * Wait until no Vite full-page reload log chunk has arrived for `quietMs`.
+ * Uses chunk timestamps — old "reloading" text in the log buffer never clears.
+ */
+async function waitForViteDepsQuiet(
+  viteReload: ViteReloadTracker,
+  logs: string[],
+  options: { quietMs?: number; timeoutMs?: number } = {},
+): Promise<void> {
+  const quietMs = options.quietMs ?? (isCi ? 8_000 : 4_000);
+  const timeoutMs = options.timeoutMs ?? 120_000;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (viteReload.lastReloadAt === 0) {
+      await sleep(500);
+      continue;
+    }
+    if (Date.now() - viteReload.lastReloadAt >= quietMs) return;
+    await sleep(500);
+  }
+
+  if (viteReload.lastReloadAt === 0) {
+    console.warn(
+      "[standalone-dev-smoke] no Vite reload logs seen before timeout; continuing",
+    );
+    return;
+  }
+
+  throw new Error(
+    `Vite dep optimization did not settle within ${timeoutMs}ms ` +
+      `(lastReloadAt=${viteReload.lastReloadAt}).\n${logTail(logs)}`,
   );
 }
 
@@ -282,6 +342,7 @@ async function startDevOnce(): Promise<RunningDev> {
   const dbPath = prepareIsolatedDataDir();
   log(`database: file:${dbPath}`);
   const logs: string[] = [];
+  const viteReload: ViteReloadTracker = { lastReloadAt: 0 };
   const child = spawn(
     "pnpm",
     [
@@ -302,13 +363,21 @@ async function startDevOnce(): Promise<RunningDev> {
     },
   );
 
-  child.stdout.on("data", (chunk) => logs.push(chunk.toString()));
-  child.stderr.on("data", (chunk) => logs.push(chunk.toString()));
+  child.stdout.on("data", (chunk) =>
+    appendDevLog(logs, chunk.toString(), viteReload),
+  );
+  child.stderr.on("data", (chunk) =>
+    appendDevLog(logs, chunk.toString(), viteReload),
+  );
   child.on("exit", (code, signal) => {
-    logs.push(`\n[dev] exited code=${code} signal=${signal}\n`);
+    appendDevLog(
+      logs,
+      `\n[dev] exited code=${code} signal=${signal}\n`,
+      viteReload,
+    );
   });
 
-  const running = { baseUrl, child, logs, dbPath };
+  const running = { baseUrl, child, logs, dbPath, viteReload };
   try {
     await waitForDevStable(baseUrl, logs);
     log(`dev server stable at ${baseUrl}`);
@@ -391,7 +460,17 @@ function isNavigationContextError(err: unknown): boolean {
   return (
     message.includes("Execution context was destroyed") ||
     message.includes("context was destroyed") ||
-    message.includes("net::ERR_ABORTED")
+    message.includes("net::ERR_ABORTED") ||
+    message.includes("interrupted by another navigation")
+  );
+}
+
+function isRetryableGotoError(message: string): boolean {
+  return (
+    message.includes("net::ERR_ABORTED") ||
+    message.includes("Vite environment") ||
+    message.includes("503") ||
+    message.includes("interrupted by another navigation")
   );
 }
 
@@ -419,19 +498,21 @@ async function retryAfterNavigation<T>(
 }
 
 async function gotoCommitted(page: Page, url: string): Promise<void> {
+  const attempts = isCi ? 12 : 6;
   let lastError: unknown;
-  for (let attempt = 0; attempt < 5; attempt++) {
+  for (let attempt = 0; attempt < attempts; attempt++) {
     try {
       await page.goto(url, { waitUntil: "commit", timeout: 90_000 });
       return;
     } catch (err) {
       lastError = err;
       const message = err instanceof Error ? err.message : String(err);
-      const retryable =
-        message.includes("net::ERR_ABORTED") ||
-        message.includes("Vite environment") ||
-        message.includes("503");
-      if (!retryable || attempt === 4) throw err;
+      if (!isRetryableGotoError(message) || attempt === attempts - 1) throw err;
+      if (isCi || verbose) {
+        console.warn(
+          `[standalone-dev-smoke] goto retry ${attempt + 1}/${attempts}: ${message.split("\n")[0]}`,
+        );
+      }
       await page.waitForTimeout(750 * (attempt + 1));
     }
   }
@@ -506,13 +587,21 @@ async function signInViaAuthApi(
   );
 }
 
+interface WaitForHomeLinkOptions {
+  baseUrl?: string;
+  /** Only safe after Vite deps are quiet — re-goto races active reloads. */
+  renavigateOnTimeout?: boolean;
+}
+
 async function waitForHomeLink(
   page: Page,
   timeoutMs = shellTimeoutMs,
-  baseUrl?: string,
+  options: WaitForHomeLinkOptions = {},
 ): Promise<void> {
+  const { baseUrl, renavigateOnTimeout = false } = options;
   const homeLink = page.getByRole("link", { name: "Home" });
   const deadline = Date.now() + timeoutMs;
+
   while (Date.now() < deadline) {
     if (await homeLink.isVisible().catch(() => false)) return;
 
@@ -522,31 +611,26 @@ async function waitForHomeLink(
     try {
       await homeLink.waitFor({
         state: "visible",
-        timeout: Math.min(5_000, remaining),
+        timeout: Math.min(3_000, remaining),
       });
       return;
     } catch (err) {
-      const stillHaveTime = Date.now() < deadline;
-      if (!stillHaveTime) break;
+      if (Date.now() >= deadline) break;
       if (
+        renavigateOnTimeout &&
         baseUrl &&
-        (isNavigationContextError(err) ||
-          (err instanceof Error && err.message.includes("Timeout")))
+        err instanceof Error &&
+        err.message.includes("Timeout")
       ) {
-        log("Home not visible — re-navigating after Vite reload");
         await gotoCommitted(page, `${baseUrl}/`);
-        await sleep(1_500);
+        await sleep(1_000);
         continue;
       }
       if (isNavigationContextError(err)) {
         await sleep(1_000);
         continue;
       }
-      if (stillHaveTime) {
-        await sleep(1_000);
-        continue;
-      }
-      throw err;
+      await sleep(1_000);
     }
   }
 
@@ -560,14 +644,10 @@ async function waitForHomeLink(
   );
 }
 
-async function readAuthenticatedSessionEmail(
-  page: Page,
-  baseUrl: string,
-): Promise<string> {
+async function readAuthenticatedSessionEmail(page: Page): Promise<string> {
   return retryAfterNavigation(
     "session read",
     async () => {
-      await waitForHomeLink(page, shellTimeoutMs, baseUrl);
       const session = await page.evaluate(async () => {
         const response = await fetch("/_agent-native/auth/session", {
           headers: { Accept: "application/json" },
@@ -588,35 +668,35 @@ async function readAuthenticatedSessionEmail(
       );
       return sessionEmail;
     },
-    { attempts: 20, delayMs: 2_000 },
+    { attempts: 10, delayMs: 1_500 },
   );
 }
 
 async function waitForAuthenticatedShell(
   page: Page,
   baseUrl: string,
-  serverLogs: string[],
+  running: RunningDev,
 ): Promise<string> {
-  const devCreds = parseDevAutoLoginCredentials(serverLogs);
+  const serverLogs = running.logs;
   const fallbackEmail =
     process.env.STANDALONE_STARTER_DEV_SMOKE_EMAIL ||
     `standalone-smoke-${Date.now()}@example.test`;
   const fallbackPassword =
     process.env.STANDALONE_STARTER_DEV_SMOKE_PASSWORD ||
     "standalone-starter-smoke-password";
-  const loginEmail = devCreds?.email ?? fallbackEmail;
-  const loginPassword = devCreds?.password ?? fallbackPassword;
 
   log(`navigating to ${baseUrl}/ (auto-login path)`);
-  let lastBody = "";
-  let lastUrl = baseUrl;
-  const shellAttempts = isCi ? 10 : 6;
+  await gotoCommitted(page, `${baseUrl}/`);
 
-  for (let attempt = 0; attempt < shellAttempts; attempt++) {
-    await gotoCommitted(page, `${baseUrl}/`);
-    lastUrl = page.url();
-    lastBody = await retryAfterNavigation("body read", () =>
-      page.locator("body").innerText({ timeout: 15_000 }),
+  const homeLink = page.getByRole("link", { name: "Home" });
+  const shellDeadline = Date.now() + shellTimeoutMs;
+
+  while (Date.now() < shellDeadline) {
+    if (await homeLink.isVisible().catch(() => false)) break;
+
+    const lastUrl = page.url();
+    const lastBody = await retryAfterNavigation("body read", () =>
+      page.locator("body").innerText({ timeout: 10_000 }),
     );
 
     if (/unexpected server error/i.test(lastBody)) {
@@ -625,61 +705,46 @@ async function waitForAuthenticatedShell(
       );
     }
 
-    const homeLink = page.getByRole("link", { name: "Home" });
     if (await homeLink.isVisible().catch(() => false)) break;
 
-    const devCredsNow = parseDevAutoLoginCredentials(serverLogs);
-    const authEmail = devCredsNow?.email ?? loginEmail;
-    const authPassword = devCredsNow?.password ?? loginPassword;
+    const devCreds = parseDevAutoLoginCredentials(serverLogs);
+    const authEmail = devCreds?.email ?? fallbackEmail;
+    const authPassword = devCreds?.password ?? fallbackPassword;
 
-    if (isLoggedOutBody(lastBody)) {
-      if (!devCredsNow && attempt < shellAttempts - 2) {
-        log(
-          `logged out before auto-login creds printed (attempt ${attempt + 1}/${shellAttempts}) — retrying /`,
-        );
-        await sleep(isCi ? 4_000 : 2_500);
-        continue;
-      }
-      log(
-        `still logged out (attempt ${attempt + 1}/${shellAttempts}) — auth API login as ${authEmail}`,
-      );
+    if (isLoggedOutBody(lastBody) && devCreds) {
+      log(`auth API login as ${authEmail}`);
       await signInViaAuthApi(page, authEmail, authPassword);
+      await sleep(2_000);
       continue;
     }
 
-    log(
-      `authenticated shell not ready (attempt ${attempt + 1}/${shellAttempts}) — Vite may still be optimizing deps`,
-    );
-    await sleep(isCi ? 4_000 : 2_500);
+    // Auto-login redirect or Vite reload in progress — poll, do not page.goto again.
+    await sleep(2_000);
   }
 
-  await waitForHomeLink(page, shellTimeoutMs, baseUrl);
+  await waitForViteDepsQuiet(running.viteReload, serverLogs);
+  await waitForHomeLink(page, Math.max(15_000, shellDeadline - Date.now()));
 
-  const sessionEmail = await readAuthenticatedSessionEmail(page, baseUrl);
+  const sessionEmail = await readAuthenticatedSessionEmail(page);
   log(`authenticated session: ${sessionEmail}`);
   return sessionEmail;
 }
 
 async function runBrowserSmoke(
   page: Page,
-  baseUrl: string,
-  serverLogs: string[],
+  running: RunningDev,
   browserErrors: string[],
   httpErrors: string[],
 ): Promise<void> {
-  // Warmup: auto-login redirect + first Vite dep optimization (noisy HTTP).
-  log("warmup: first load + Vite dep optimization");
-  await waitForAuthenticatedShell(page, baseUrl, serverLogs);
-  await page.waitForTimeout(viteWarmupMs);
+  const baseUrl = running.baseUrl;
+  // Warmup covers `/` + auto-login + Vite quiet + authenticated session.
+  log("warmup: auto-login, Vite dep quiet, authenticated /");
+  await waitForAuthenticatedShell(page, baseUrl, running);
 
   browserErrors.length = 0;
   httpErrors.length = 0;
 
-  log("assertion pass: / and /observability after warmup");
-  await gotoCommitted(page, `${baseUrl}/`);
-  await waitForHomeLink(page, shellTimeoutMs, baseUrl);
-  await readAuthenticatedSessionEmail(page, baseUrl);
-  log(`navigating to ${baseUrl}/observability`);
+  log("assertion pass: /observability after warmup");
   await gotoCommitted(page, `${baseUrl}/observability`);
   await page
     .getByRole("link", { name: "Observability" })
@@ -748,13 +813,7 @@ async function main(): Promise<void> {
       httpErrors.push(`${status} ${url}`);
     });
 
-    await runBrowserSmoke(
-      page,
-      running.baseUrl,
-      running.logs,
-      browserErrors,
-      httpErrors,
-    );
+    await runBrowserSmoke(page, running, browserErrors, httpErrors);
     assertCleanServerLogs(running.logs);
 
     console.log("qa-standalone-starter-dev-smoke: clean");


### PR DESCRIPTION
## Summary
- Fix `Meta` / `HydratedRouter` SSR failures when developing standalone apps scaffolded with `AGENT_NATIVE_CREATE_USE_LOCAL_CORE=1` (or `file:@agent-native/core`): resolve the linked core package to full monorepo `src/`, dedupe `react-router` + `react-router/dom`, and prebundle react-router in `optimizeDeps`.
- Add `pnpm qa:standalone-starter-dev`: scaffold `create --standalone --template starter`, `pnpm install`, start a real dev server, exercise auto-login, and assert the app shell loads without SSR errors (`HydratedRouter`, "Unexpected Server Error") or browser console errors.
<img width="872" height="205" alt="image" src="https://github.com/user-attachments/assets/52d60e6a-39f9-4991-8c07-2511d995b0b1" />

- Wire the dev smoke into **scaffold-e2e** CI (replaces the old standalone scaffold + `grep` install check; package.json validation for `workspace:*` and `catalog:*` lives in the smoke script).
- Unit tests for router dedupe and `file:` core root resolution in `client.spec.ts`.


## Why

`pnpm build` did not catch this bug. Vite dev SSR broke after auto-login because core `entry-server` and the app could load different `react-router` instances / incomplete core `src` from pnpm’s `file:` copy — surfacing as:

`You must render this element inside a <HydratedRouter> element` (Meta).

## Test plan

- [x] `pnpm --filter @agent-native/core exec vitest --run src/vite/client.spec.ts`
- [x] `AGENT_NATIVE_CREATE_USE_LOCAL_CORE=1 pnpm qa:standalone-starter-dev`
- [ ] CI scaffold-e2e job (Playwright + dev smoke)