### PR TITLE
Add image overlay preview with navigation to library

### DIFF
--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -17,6 +17,8 @@ import {
 import {
   IconArrowUpRight,
   IconCheck,
+  IconChevronLeft,
+  IconChevronRight,
   IconClipboard,
   IconX,
 } from "@tabler/icons-react";
@@ -1419,44 +1421,83 @@ export default function AssetPicker() {
           if (!open) setPreviewAsset(null);
         }}
       >
-        {previewAsset && (
-          <DialogContent
-            hideClose
-            className="max-w-4xl border-0 bg-transparent p-0 shadow-none"
-          >
-            <DialogTitle className="sr-only">
-              {assetDisplayTitle(previewAsset)}
-            </DialogTitle>
-            <DialogDescription className="sr-only">
-              Full-size preview of {assetDisplayTitle(previewAsset)}
-            </DialogDescription>
-            <div className="relative">
-              <DialogClose
-                aria-label="Close preview"
-                className="absolute right-2 top-2 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        {previewAsset &&
+          (() => {
+            const previewIndex = assets.findIndex(
+              (asset) => asset.id === previewAsset.id,
+            );
+            const hasPrev = previewIndex > 0;
+            const hasNext =
+              previewIndex >= 0 && previewIndex < assets.length - 1;
+            const showPreviousAsset = () => {
+              if (hasPrev) setPreviewAsset(assets[previewIndex - 1]);
+            };
+            const showNextAsset = () => {
+              if (hasNext) setPreviewAsset(assets[previewIndex + 1]);
+            };
+            return (
+              <DialogContent
+                hideClose
+                onKeyDown={(event) => {
+                  if (event.key === "ArrowLeft") showPreviousAsset();
+                  if (event.key === "ArrowRight") showNextAsset();
+                }}
+                className="max-w-4xl border-0 bg-transparent p-0 shadow-none"
               >
-                <IconX className="h-5 w-5" />
-              </DialogClose>
-              {previewAsset.mediaType === "video" ||
-              previewAsset.mimeType?.startsWith("video/") ? (
-                <video
-                  src={
-                    previewAsset.previewUrl ??
-                    previewAsset.downloadUrl ??
-                    previewAsset.url
-                  }
-                  poster={previewAsset.thumbnailUrl}
-                  controls
-                  autoPlay
-                  playsInline
-                  className="max-h-[85vh] w-full rounded-lg bg-black object-contain"
-                />
-              ) : (
-                <AssetOverlayImage asset={previewAsset} />
-              )}
-            </div>
-          </DialogContent>
-        )}
+                <DialogTitle className="sr-only">
+                  {assetDisplayTitle(previewAsset)}
+                </DialogTitle>
+                <DialogDescription className="sr-only">
+                  Full-size preview of {assetDisplayTitle(previewAsset)}
+                </DialogDescription>
+                <div className="relative">
+                  <DialogClose
+                    aria-label="Close preview"
+                    className="absolute right-2 top-2 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                  >
+                    <IconX className="h-5 w-5" />
+                  </DialogClose>
+                  {hasPrev && (
+                    <button
+                      type="button"
+                      aria-label="Previous image"
+                      onClick={showPreviousAsset}
+                      className="absolute left-2 top-1/2 z-10 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                    >
+                      <IconChevronLeft className="h-5 w-5" />
+                    </button>
+                  )}
+                  {hasNext && (
+                    <button
+                      type="button"
+                      aria-label="Next image"
+                      onClick={showNextAsset}
+                      className="absolute right-2 top-1/2 z-10 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                    >
+                      <IconChevronRight className="h-5 w-5" />
+                    </button>
+                  )}
+                  {previewAsset.mediaType === "video" ||
+                  previewAsset.mimeType?.startsWith("video/") ? (
+                    <video
+                      src={
+                        previewAsset.previewUrl ??
+                        previewAsset.downloadUrl ??
+                        previewAsset.url
+                      }
+                      poster={previewAsset.thumbnailUrl}
+                      controls
+                      autoPlay
+                      playsInline
+                      className="max-h-[85vh] w-full rounded-lg bg-black object-contain"
+                    />
+                  ) : (
+                    <AssetOverlayImage asset={previewAsset} />
+                  )}
+                </div>
+              </DialogContent>
+            );
+          })()}
       </Dialog>
     </div>
   );

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -1457,25 +1457,27 @@ export default function AssetPicker() {
                   >
                     <IconX className="h-5 w-5" />
                   </DialogClose>
-                  {hasPrev && (
-                    <button
-                      type="button"
-                      aria-label="Previous image"
-                      onClick={showPreviousAsset}
-                      className="absolute left-2 top-1/2 z-10 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-                    >
-                      <IconChevronLeft className="h-5 w-5" />
-                    </button>
-                  )}
-                  {hasNext && (
-                    <button
-                      type="button"
-                      aria-label="Next image"
-                      onClick={showNextAsset}
-                      className="absolute right-2 top-1/2 z-10 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-                    >
-                      <IconChevronRight className="h-5 w-5" />
-                    </button>
+                  {(hasPrev || hasNext) && (
+                    <div className="absolute bottom-2 left-1/2 z-10 flex -translate-x-1/2 gap-2">
+                      <button
+                        type="button"
+                        aria-label="Previous image"
+                        onClick={showPreviousAsset}
+                        disabled={!hasPrev}
+                        className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        <IconChevronLeft className="h-5 w-5" />
+                      </button>
+                      <button
+                        type="button"
+                        aria-label="Next image"
+                        onClick={showNextAsset}
+                        disabled={!hasNext}
+                        className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        <IconChevronRight className="h-5 w-5" />
+                      </button>
+                    </div>
                   )}
                   {previewAsset.mediaType === "video" ||
                   previewAsset.mimeType?.startsWith("video/") ? (

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -1371,8 +1371,11 @@ export default function AssetPicker() {
                   type="button"
                   aria-label={`Open ${assetDisplayTitle(asset)}`}
                   onClick={() => {
-                    chooseAsset(asset);
-                    if (!embedded) setPreviewAsset(asset);
+                    if (embedded) {
+                      chooseAsset(asset);
+                    } else {
+                      setPreviewAsset(asset);
+                    }
                   }}
                   title={assetDisplayTitle(asset)}
                   className="block w-full text-left focus-visible:outline-none"

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -39,6 +39,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogTitle,
 } from "@/components/ui/dialog";
 import { DEFAULT_LIBRARY_PRESETS } from "../../shared/library-presets";
@@ -828,6 +829,7 @@ export default function AssetPicker() {
     [allAssets, assetTab],
   );
   const [previewAsset, setPreviewAsset] = useState<Asset | null>(null);
+  const [copiedAssetId, setCopiedAssetId] = useState<string | null>(null);
   const [standaloneSelection, setStandaloneSelection] = useState<ReturnType<
     typeof assetPayload
   > | null>(null);
@@ -862,6 +864,26 @@ export default function AssetPicker() {
       }
     },
     [],
+  );
+
+  const copyAsset = useCallback(
+    async (asset: Asset) => {
+      const payload = assetPayload(asset, mediaType);
+      const text = selectedAssetClipboardText(payload);
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopiedAssetId(asset.id);
+        toast.success("Asset copied");
+        window.setTimeout(() => {
+          setCopiedAssetId((current) =>
+            current === asset.id ? null : current,
+          );
+        }, 2000);
+      } catch {
+        toast.error("Could not copy asset");
+      }
+    },
+    [mediaType],
   );
 
   const chooseAsset = (asset: Asset) => {
@@ -1362,32 +1384,52 @@ export default function AssetPicker() {
         {assets.length > 0 && (
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
             {assets.map((asset) => (
-              <button
+              <div
                 key={asset.id}
-                type="button"
-                aria-label={`Select ${assetDisplayTitle(asset)}`}
-                onClick={() => {
-                  chooseAsset(asset);
-                  if (!embedded) setPreviewAsset(asset);
-                }}
-                title={assetDisplayTitle(asset)}
-                className="group overflow-hidden rounded-md border border-border bg-card text-left shadow-sm transition hover:border-primary/60 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="group relative overflow-hidden rounded-md border border-border bg-card shadow-sm transition hover:border-primary/60 hover:shadow-md focus-within:ring-2 focus-within:ring-ring"
               >
-                <div className="aspect-square bg-muted">
-                  {asset.mediaType === "video" ||
-                  asset.mimeType?.startsWith("video/") ? (
-                    <video
-                      src={asset.previewUrl ?? asset.downloadUrl ?? asset.url}
-                      poster={asset.thumbnailUrl}
-                      muted
-                      playsInline
-                      className="h-full w-full object-cover transition group-hover:scale-[1.02]"
-                    />
+                <button
+                  type="button"
+                  aria-label={`Open ${assetDisplayTitle(asset)}`}
+                  onClick={() => {
+                    chooseAsset(asset);
+                    if (!embedded) setPreviewAsset(asset);
+                  }}
+                  title={assetDisplayTitle(asset)}
+                  className="block w-full text-left focus-visible:outline-none"
+                >
+                  <div className="aspect-square bg-muted">
+                    {asset.mediaType === "video" ||
+                    asset.mimeType?.startsWith("video/") ? (
+                      <video
+                        src={asset.previewUrl ?? asset.downloadUrl ?? asset.url}
+                        poster={asset.thumbnailUrl}
+                        muted
+                        playsInline
+                        className="h-full w-full object-cover transition group-hover:scale-[1.02]"
+                      />
+                    ) : (
+                      <AssetThumbnail asset={asset} />
+                    )}
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Copy ${assetDisplayTitle(asset)}`}
+                  title="Copy asset"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void copyAsset(asset);
+                  }}
+                  className="absolute right-2 top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/80 text-foreground opacity-0 shadow-sm backdrop-blur transition hover:bg-background focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100"
+                >
+                  {copiedAssetId === asset.id ? (
+                    <IconCheck className="h-4 w-4" />
                   ) : (
-                    <AssetThumbnail asset={asset} />
+                    <IconClipboard className="h-4 w-4" />
                   )}
-                </div>
-              </button>
+                </button>
+              </div>
             ))}
           </div>
         )}
@@ -1407,6 +1449,9 @@ export default function AssetPicker() {
             <DialogTitle className="sr-only">
               {assetDisplayTitle(previewAsset)}
             </DialogTitle>
+            <DialogDescription className="sr-only">
+              Full-size preview of {assetDisplayTitle(previewAsset)}
+            </DialogDescription>
             <div className="relative">
               <DialogClose
                 aria-label="Close preview"

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -35,6 +35,12 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { DEFAULT_LIBRARY_PRESETS } from "../../shared/library-presets";
 
 type AssetTab = "all" | "generated" | "references";
@@ -257,6 +263,17 @@ function assetThumbnailSources(asset: Asset) {
   return uniqueSources(
     [asset.thumbnailUrl, asset.previewUrl, asset.downloadUrl].map((source) =>
       absoluteAssetUrl(source),
+    ),
+  );
+}
+
+function assetOverlaySources(asset: Asset) {
+  if (shouldUseContentProxyForPreview(asset)) {
+    return uniqueSources([assetContentUrl(asset)]);
+  }
+  return uniqueSources(
+    [asset.previewUrl, asset.downloadUrl, asset.url, asset.thumbnailUrl].map(
+      (source) => absoluteAssetUrl(source),
     ),
   );
 }
@@ -555,6 +572,39 @@ function AssetThumbnail({ asset }: { asset: Asset }) {
   );
 }
 
+function AssetOverlayImage({ asset }: { asset: Asset }) {
+  const sources = assetOverlaySources(asset);
+  const sourcesKey = sources.join("\n");
+  const [sourceIndex, setSourceIndex] = useState(0);
+  const source = sources[sourceIndex];
+
+  useEffect(() => {
+    setSourceIndex(0);
+  }, [sourcesKey]);
+
+  if (!source) {
+    return (
+      <div className="flex aspect-square w-full items-center justify-center rounded-lg bg-muted text-sm text-muted-foreground">
+        Preview unavailable
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={source}
+      crossOrigin={isCrossOriginPreview(source) ? "anonymous" : undefined}
+      alt={asset.altText ?? asset.title ?? ""}
+      className="max-h-[85vh] w-full rounded-lg object-contain"
+      onError={() =>
+        setSourceIndex((index) =>
+          index + 1 < sources.length ? index + 1 : index,
+        )
+      }
+    />
+  );
+}
+
 export default function AssetPicker() {
   const [searchParams] = useSearchParams();
   const searchParamsKey = searchParams.toString();
@@ -777,6 +827,7 @@ export default function AssetPicker() {
     () => allAssets.filter((asset) => assetMatchesTab(asset, assetTab)),
     [allAssets, assetTab],
   );
+  const [previewAsset, setPreviewAsset] = useState<Asset | null>(null);
   const [standaloneSelection, setStandaloneSelection] = useState<ReturnType<
     typeof assetPayload
   > | null>(null);
@@ -1315,7 +1366,10 @@ export default function AssetPicker() {
                 key={asset.id}
                 type="button"
                 aria-label={`Select ${assetDisplayTitle(asset)}`}
-                onClick={() => chooseAsset(asset)}
+                onClick={() => {
+                  chooseAsset(asset);
+                  if (!embedded) setPreviewAsset(asset);
+                }}
                 title={assetDisplayTitle(asset)}
                 className="group overflow-hidden rounded-md border border-border bg-card text-left shadow-sm transition hover:border-primary/60 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
@@ -1338,6 +1392,49 @@ export default function AssetPicker() {
           </div>
         )}
       </main>
+
+      <Dialog
+        open={Boolean(previewAsset)}
+        onOpenChange={(open) => {
+          if (!open) setPreviewAsset(null);
+        }}
+      >
+        {previewAsset && (
+          <DialogContent
+            hideClose
+            className="max-w-4xl border-0 bg-transparent p-0 shadow-none"
+          >
+            <DialogTitle className="sr-only">
+              {assetDisplayTitle(previewAsset)}
+            </DialogTitle>
+            <div className="relative">
+              <DialogClose
+                aria-label="Close preview"
+                className="absolute right-2 top-2 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+              >
+                <IconX className="h-5 w-5" />
+              </DialogClose>
+              {previewAsset.mediaType === "video" ||
+              previewAsset.mimeType?.startsWith("video/") ? (
+                <video
+                  src={
+                    previewAsset.previewUrl ??
+                    previewAsset.downloadUrl ??
+                    previewAsset.url
+                  }
+                  poster={previewAsset.thumbnailUrl}
+                  controls
+                  autoPlay
+                  playsInline
+                  className="max-h-[85vh] w-full rounded-lg bg-black object-contain"
+                />
+              ) : (
+                <AssetOverlayImage asset={previewAsset} />
+              )}
+            </div>
+          </DialogContent>
+        )}
+      </Dialog>
     </div>
   );
 }

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -26,6 +26,12 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import {
   Select,
@@ -1397,18 +1403,24 @@ export default function AssetPicker() {
                     )}
                   </div>
                 </button>
-                <button
-                  type="button"
-                  aria-label={`Copy ${assetDisplayTitle(asset)}`}
-                  title="Copy asset"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    chooseAsset(asset);
-                  }}
-                  className="absolute right-2 top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/80 text-foreground opacity-0 shadow-sm backdrop-blur transition hover:bg-background focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100"
-                >
-                  <IconClipboard className="h-4 w-4" />
-                </button>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label={`Copy ${assetDisplayTitle(asset)}`}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          chooseAsset(asset);
+                        }}
+                        className="absolute right-2 top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/80 text-foreground opacity-0 shadow-sm backdrop-blur transition hover:bg-background focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100"
+                      >
+                        <IconClipboard className="h-4 w-4" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>Copy to clipboard</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               </div>
             ))}
           </div>

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -1463,12 +1463,21 @@ export default function AssetPicker() {
                   Full-size preview of {assetDisplayTitle(previewAsset)}
                 </DialogDescription>
                 <div className="relative">
-                  <DialogClose
-                    aria-label="Close preview"
-                    className="absolute right-2 top-2 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-                  >
-                    <IconX className="h-5 w-5" />
-                  </DialogClose>
+                  <div className="absolute right-2 top-2 z-10 flex items-center gap-2">
+                    <Link
+                      to={`/asset/${encodeURIComponent(previewAsset.id)}`}
+                      className="inline-flex h-9 items-center gap-1.5 rounded-full bg-black/60 px-3 text-sm font-medium text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                    >
+                      <IconArrowUpRight className="h-4 w-4" />
+                      View details
+                    </Link>
+                    <DialogClose
+                      aria-label="Close preview"
+                      className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                    >
+                      <IconX className="h-5 w-5" />
+                    </DialogClose>
+                  </div>
                   {previewAsset.mediaType === "video" ||
                   previewAsset.mimeType?.startsWith("video/") ? (
                     <video

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -1457,28 +1457,6 @@ export default function AssetPicker() {
                   >
                     <IconX className="h-5 w-5" />
                   </DialogClose>
-                  {(hasPrev || hasNext) && (
-                    <div className="absolute bottom-2 left-1/2 z-10 flex -translate-x-1/2 gap-2">
-                      <button
-                        type="button"
-                        aria-label="Previous image"
-                        onClick={showPreviousAsset}
-                        disabled={!hasPrev}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-40"
-                      >
-                        <IconChevronLeft className="h-5 w-5" />
-                      </button>
-                      <button
-                        type="button"
-                        aria-label="Next image"
-                        onClick={showNextAsset}
-                        disabled={!hasNext}
-                        className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-40"
-                      >
-                        <IconChevronRight className="h-5 w-5" />
-                      </button>
-                    </div>
-                  )}
                   {previewAsset.mediaType === "video" ||
                   previewAsset.mimeType?.startsWith("video/") ? (
                     <video
@@ -1497,6 +1475,28 @@ export default function AssetPicker() {
                     <AssetOverlayImage asset={previewAsset} />
                   )}
                 </div>
+                {(hasPrev || hasNext) && (
+                  <div className="mt-5 flex justify-center gap-2">
+                    <button
+                      type="button"
+                      aria-label="Previous image"
+                      onClick={showPreviousAsset}
+                      disabled={!hasPrev}
+                      className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      <IconChevronLeft className="h-5 w-5" />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label="Next image"
+                      onClick={showNextAsset}
+                      disabled={!hasNext}
+                      className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      <IconChevronRight className="h-5 w-5" />
+                    </button>
+                  </div>
+                )}
               </DialogContent>
             );
           })()}

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -829,7 +829,6 @@ export default function AssetPicker() {
     [allAssets, assetTab],
   );
   const [previewAsset, setPreviewAsset] = useState<Asset | null>(null);
-  const [copiedAssetId, setCopiedAssetId] = useState<string | null>(null);
   const [standaloneSelection, setStandaloneSelection] = useState<ReturnType<
     typeof assetPayload
   > | null>(null);
@@ -864,26 +863,6 @@ export default function AssetPicker() {
       }
     },
     [],
-  );
-
-  const copyAsset = useCallback(
-    async (asset: Asset) => {
-      const payload = assetPayload(asset, mediaType);
-      const text = selectedAssetClipboardText(payload);
-      try {
-        await navigator.clipboard.writeText(text);
-        setCopiedAssetId(asset.id);
-        toast.success("Asset copied");
-        window.setTimeout(() => {
-          setCopiedAssetId((current) =>
-            current === asset.id ? null : current,
-          );
-        }, 2000);
-      } catch {
-        toast.error("Could not copy asset");
-      }
-    },
-    [mediaType],
   );
 
   const chooseAsset = (asset: Asset) => {
@@ -1419,15 +1398,11 @@ export default function AssetPicker() {
                   title="Copy asset"
                   onClick={(event) => {
                     event.stopPropagation();
-                    void copyAsset(asset);
+                    chooseAsset(asset);
                   }}
                   className="absolute right-2 top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/80 text-foreground opacity-0 shadow-sm backdrop-blur transition hover:bg-background focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100"
                 >
-                  {copiedAssetId === asset.id ? (
-                    <IconCheck className="h-4 w-4" />
-                  ) : (
-                    <IconClipboard className="h-4 w-4" />
-                  )}
+                  <IconClipboard className="h-4 w-4" />
                 </button>
               </div>
             ))}

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -1413,7 +1413,7 @@ export default function AssetPicker() {
                           event.stopPropagation();
                           chooseAsset(asset);
                         }}
-                        className="absolute right-2 top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/80 text-foreground opacity-0 shadow-sm backdrop-blur transition hover:bg-background focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100"
+                        className="absolute right-2 top-2 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/80 text-foreground opacity-0 shadow-sm backdrop-blur transition hover:bg-primary hover:text-primary-foreground focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100"
                       >
                         <IconClipboard className="h-4 w-4" />
                       </button>

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -1464,13 +1464,13 @@ export default function AssetPicker() {
                 </DialogDescription>
                 <div className="relative">
                   <div className="absolute right-2 top-2 z-10 flex items-center gap-2">
-                    <Link
-                      to={`/asset/${encodeURIComponent(previewAsset.id)}`}
-                      className="inline-flex h-9 items-center gap-1.5 rounded-full bg-black/60 px-3 text-sm font-medium text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-                    >
-                      <IconArrowUpRight className="h-4 w-4" />
-                      View details
-                    </Link>
+                    <Button asChild variant="outline" size="sm">
+                      <Link
+                        to={`/asset/${encodeURIComponent(previewAsset.id)}`}
+                      >
+                        View details
+                      </Link>
+                    </Button>
                     <DialogClose
                       aria-label="Close preview"
                       className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"


### PR DESCRIPTION
### Summary
Adds a full-size image overlay (dialog) when clicking a library asset, with left/right navigation between adjacent assets and a copy button on each thumbnail card.

### Problem
Previously, clicking an asset in the library immediately selected/copied it with no way to preview it at full size. Users had no way to inspect an asset before choosing it, and there was no in-place navigation between assets.

### Solution
Wrap each asset card in a `div` with two separate buttons — one that opens a full-size `Dialog` preview and one (copy icon) that calls `chooseAsset` directly. The dialog includes close, previous, and next controls, as well as keyboard arrow-key navigation.

### Key Changes
- **Asset overlay dialog**: New `Dialog` component renders a full-size preview of the selected asset (`AssetOverlayImage` for images, native `<video>` with controls for video).
- **`AssetOverlayImage` component**: Handles fallback source cycling (preview → download → original → thumbnail URLs) for image previews in the overlay.
- **`assetOverlaySources` helper**: Resolves the ordered list of image URLs to try for the overlay, preferring higher-quality sources over thumbnails.
- **Copy icon button**: A clipboard icon button appears on hover in the top-right corner of each card and calls `chooseAsset` directly without opening the overlay.
- **Left/right navigation**: Previous/next chevron buttons are rendered below the overlay image (centered, with 20px top margin) and respond to `ArrowLeft`/`ArrowRight` keyboard events.
- **Embedded mode unchanged**: When the picker is embedded, clicking the card still calls `chooseAsset` directly (no overlay).
- **Close button**: An `X` button in the top-right of the overlay dismisses the dialog.


### Old Flow

https://github.com/user-attachments/assets/31caa47f-55e2-47d6-a776-386f6b7e46c9


### Updated Flow


https://github.com/user-attachments/assets/6d46ca16-1d42-41cc-a5c8-096ad1c2de63






---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/oval-reward-oeleifwr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-oval-reward-oeleifwr.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1164`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>oval-reward-oeleifwr</branchName>-->