### PR TITLE
Improve visual plan annotation margin placement

### DIFF
--- a/.changeset/visual-plan-annotation-margins.md
+++ b/.changeset/visual-plan-annotation-margins.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Improve visual plan code annotation placement with left-first plan hovers and persistent margin notes when space allows.

--- a/packages/core/src/client/blocks/library/AnnotatedCodeBlock.spec.tsx
+++ b/packages/core/src/client/blocks/library/AnnotatedCodeBlock.spec.tsx
@@ -50,9 +50,19 @@ function setViewport(width: number, height = 700) {
 describe("AnnotatedCodeBlock annotations", () => {
   let container: HTMLDivElement;
   let root: Root;
+  let innerWidthDescriptor: PropertyDescriptor | undefined;
+  let innerHeightDescriptor: PropertyDescriptor | undefined;
 
   beforeEach(() => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    innerWidthDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      "innerWidth",
+    );
+    innerHeightDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      "innerHeight",
+    );
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -69,6 +79,12 @@ describe("AnnotatedCodeBlock annotations", () => {
       )
       .forEach((node) => node.remove());
     vi.useRealTimers();
+    if (innerWidthDescriptor) {
+      Object.defineProperty(window, "innerWidth", innerWidthDescriptor);
+    }
+    if (innerHeightDescriptor) {
+      Object.defineProperty(window, "innerHeight", innerHeightDescriptor);
+    }
     vi.unstubAllGlobals();
   });
 

--- a/packages/core/src/client/blocks/library/AnnotatedCodeBlock.spec.tsx
+++ b/packages/core/src/client/blocks/library/AnnotatedCodeBlock.spec.tsx
@@ -36,6 +36,17 @@ function stubRect(element: Element, value: DOMRect) {
   });
 }
 
+function setViewport(width: number, height = 700) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: width,
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    value: height,
+  });
+}
+
 describe("AnnotatedCodeBlock annotations", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -165,6 +176,137 @@ describe("AnnotatedCodeBlock annotations", () => {
     // Line 2 starts at y=122 with a 22px height, so the first-line anchor center
     // is 133px. Hovering line 4 would have produced 177px before this fix.
     expect(card!.style.top).toBe("133px");
+  });
+
+  it("uses the left side for plan-mode annotation hovers when it fits", () => {
+    setViewport(1200);
+    act(() => {
+      root.render(
+        <AnnotatedCodeRead
+          blockId="code-annotations"
+          ctx={{
+            codeAnnotationLayout: {
+              hoverSide: "left",
+              hoverFallbackSide: "right",
+            },
+          }}
+          data={{
+            language: "ts",
+            code: ["const one = 1;", "const two = 2;"].join("\n"),
+            annotations: [
+              {
+                lines: "1",
+                label: "Entry",
+                note: "The first line is annotated.",
+              },
+            ],
+          }}
+        />,
+      );
+    });
+
+    const codeBox = container.querySelector("section > div");
+    expect(codeBox).toBeTruthy();
+    stubRect(codeBox!, rect({ left: 360, top: 80, width: 500, height: 80 }));
+
+    const firstLine = container.querySelector<HTMLElement>(
+      '[data-code-line="1"]',
+    );
+    expect(firstLine).toBeTruthy();
+    stubRect(firstLine!, rect({ left: 360, top: 100, width: 500, height: 22 }));
+
+    act(() => {
+      firstLine!.dispatchEvent(
+        new MouseEvent("mouseover", {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      );
+    });
+
+    const card = document.querySelector<HTMLElement>(
+      "[data-annotation-hover-card]",
+    );
+    expect(card).toBeTruthy();
+    expect(card!.style.left).toBe("68px");
+  });
+
+  it("shows plan-mode annotation cards in the margin when there is room", () => {
+    setViewport(1200);
+    act(() => {
+      root.render(
+        <AnnotatedCodeRead
+          blockId="code-annotations"
+          ctx={{
+            codeAnnotationLayout: {
+              hoverSide: "left",
+              hoverFallbackSide: "right",
+              showByDefaultWhenRoom: true,
+              marginSide: "auto",
+            },
+          }}
+          data={{
+            language: "ts",
+            code: ["const one = 1;", "const two = 2;"].join("\n"),
+            annotations: [
+              {
+                lines: "1",
+                label: "Entry",
+                note: "This note is visible in the margin.",
+              },
+            ],
+          }}
+        />,
+      );
+    });
+
+    const codeBox = container.querySelector("section > div");
+    expect(codeBox).toBeTruthy();
+    stubRect(codeBox!, rect({ left: 360, top: 80, width: 500, height: 80 }));
+
+    const firstLine = container.querySelector<HTMLElement>(
+      '[data-code-line="1"]',
+    );
+    expect(firstLine).toBeTruthy();
+    stubRect(firstLine!, rect({ left: 360, top: 100, width: 500, height: 22 }));
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    const anchor = container.querySelector(
+      "[data-annotation-inline-overlay-anchor]",
+    );
+    expect(anchor).toBeTruthy();
+    stubRect(anchor!, rect({ left: 850, top: 100, width: 0, height: 22 }));
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    const overlay = document.querySelector<HTMLElement>(
+      "[data-annotation-inline-overlay]",
+    );
+    expect(overlay).toBeTruthy();
+    expect(overlay?.getAttribute("data-annotation-inline-overlay-mode")).toBe(
+      "margin",
+    );
+    expect(overlay?.getAttribute("data-annotation-inline-overlay-side")).toBe(
+      "left",
+    );
+    expect(overlay?.textContent).toContain(
+      "This note is visible in the margin.",
+    );
+
+    act(() => {
+      firstLine!.dispatchEvent(
+        new MouseEvent("mouseover", {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      );
+    });
+    expect(document.querySelector("[data-annotation-hover-card]")).toBeNull();
   });
 
   it("renders static annotation overlays when screenshot mode requests them", () => {

--- a/packages/core/src/client/blocks/library/AnnotatedCodeBlock.tsx
+++ b/packages/core/src/client/blocks/library/AnnotatedCodeBlock.tsx
@@ -19,6 +19,7 @@ import {
   buildLineMarkerMap,
   hasRailAnnotations,
   resolveAnnotations,
+  useAnnotationMarginNotesAvailable,
   useAnnotationHover,
   type ResolvedAnnotation,
 } from "./annotation-rail.js";
@@ -195,6 +196,23 @@ function AnnotatedCodeRead({
 
   const hasAnnotations = hasRailAnnotations(resolved);
   const showAnnotationOverlays = Boolean(ctx.showCodeAnnotationOverlays);
+  const annotationLayout = ctx.codeAnnotationLayout;
+  const annotationHoverSide = annotationLayout?.hoverSide ?? "right";
+  const annotationHoverFallbackSide =
+    annotationLayout?.hoverFallbackSide ?? "below";
+  const annotationMarginSide = annotationLayout?.marginSide ?? "auto";
+  const showMarginAnnotations = useAnnotationMarginNotesAvailable({
+    containerRef: codeRef,
+    enabled: Boolean(
+      hasAnnotations &&
+      !showAnnotationOverlays &&
+      annotationLayout?.showByDefaultWhenRoom,
+    ),
+    side: annotationMarginSide,
+    preferredSide: annotationHoverSide,
+  });
+  const showPersistentAnnotations =
+    showAnnotationOverlays || showMarginAnnotations;
   const langChip = data.language?.trim();
   const hasFilename = Boolean(data.filename?.trim());
   const showLangChip = Boolean(langChip && !hasFilename);
@@ -226,7 +244,7 @@ function AnnotatedCodeRead({
     const isActive =
       activeIndex != null && !!markers?.some((m) => m.index === activeIndex);
     const overlayItems =
-      showAnnotationOverlays && markers
+      showPersistentAnnotations && markers
         ? markers.filter((item) => item.range?.start === lineNo)
         : [];
 
@@ -316,7 +334,14 @@ function AnnotatedCodeRead({
           {highlightedLines[lineNo - 1]}
         </span>
         {overlayItems.length > 0 && (
-          <AnnotationInlineOverlayStack items={overlayItems} ctx={ctx} />
+          <AnnotationInlineOverlayStack
+            items={overlayItems}
+            ctx={ctx}
+            containerRef={codeRef}
+            mode={showAnnotationOverlays ? "capture" : "margin"}
+            side={showAnnotationOverlays ? "right" : annotationMarginSide}
+            preferredSide={annotationHoverSide}
+          />
         )}
       </div>
     );
@@ -400,16 +425,21 @@ function AnnotatedCodeRead({
           time as an on-hover popover anchored to the right of the code. */}
       {codeSurface}
       {hasAnnotations && <AnnotationHiddenStack items={resolved} ctx={ctx} />}
-      {hasAnnotations && activeItem && hover.anchor && (
-        <AnnotationHoverCard
-          item={activeItem}
-          anchor={hover.anchor}
-          ctx={ctx}
-          onMouseEnter={hover.cancelClose}
-          onMouseLeave={hover.scheduleClose}
-          onClose={hover.closeForScroll}
-        />
-      )}
+      {hasAnnotations &&
+        !showPersistentAnnotations &&
+        activeItem &&
+        hover.anchor && (
+          <AnnotationHoverCard
+            item={activeItem}
+            anchor={hover.anchor}
+            ctx={ctx}
+            preferredSide={annotationHoverSide}
+            hoverFallbackSide={annotationHoverFallbackSide}
+            onMouseEnter={hover.cancelClose}
+            onMouseLeave={hover.scheduleClose}
+            onClose={hover.closeForScroll}
+          />
+        )}
       {summary && <p className="mt-5 text-plan-muted">{summary}</p>}
     </section>
   );

--- a/packages/core/src/client/blocks/library/DiffBlock.spec.tsx
+++ b/packages/core/src/client/blocks/library/DiffBlock.spec.tsx
@@ -3,6 +3,7 @@
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BlockRenderContext } from "../types.js";
 import { DiffRead, diffLines } from "./DiffBlock.js";
 import { NarrowContainerProvider } from "./narrow-container.js";
 
@@ -36,6 +37,17 @@ function stubRect(element: Element, value: DOMRect) {
   Object.defineProperty(element, "getBoundingClientRect", {
     configurable: true,
     value: () => value,
+  });
+}
+
+function setViewport(width: number, height = 700) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: width,
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    value: height,
   });
 }
 
@@ -344,9 +356,19 @@ describe("DiffBlock", () => {
 describe("DiffBlock annotations", () => {
   let container: HTMLDivElement;
   let root: Root;
+  let innerWidthDescriptor: PropertyDescriptor | undefined;
+  let innerHeightDescriptor: PropertyDescriptor | undefined;
 
   beforeEach(() => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    innerWidthDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      "innerWidth",
+    );
+    innerHeightDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      "innerHeight",
+    );
     window.localStorage.clear();
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -359,9 +381,17 @@ describe("DiffBlock annotations", () => {
     });
     container.remove();
     document
-      .querySelectorAll("[data-annotation-hover-card]")
+      .querySelectorAll(
+        "[data-annotation-hover-card],[data-annotation-inline-overlay]",
+      )
       .forEach((node) => node.remove());
     vi.useRealTimers();
+    if (innerWidthDescriptor) {
+      Object.defineProperty(window, "innerWidth", innerWidthDescriptor);
+    }
+    if (innerHeightDescriptor) {
+      Object.defineProperty(window, "innerHeight", innerHeightDescriptor);
+    }
     vi.unstubAllGlobals();
   });
 
@@ -377,7 +407,10 @@ describe("DiffBlock annotations", () => {
         note: string;
       }>;
     },
-    ctx: { showCodeAnnotationOverlays?: boolean } = {},
+    ctx: Pick<
+      BlockRenderContext,
+      "showCodeAnnotationOverlays" | "codeAnnotationLayout"
+    > = {},
   ) {
     act(() => {
       root.render(
@@ -459,6 +492,82 @@ describe("DiffBlock annotations", () => {
       container.querySelector("[data-annotation-inline-overlay-anchor]"),
     ).toBeTruthy();
     expect(overlay?.textContent).toContain("Visible without hover.");
+    expect(document.querySelector("[data-annotation-hover-card]")).toBeNull();
+  });
+
+  it("shows plan-mode diff annotation cards in the margin when there is room", () => {
+    setViewport(1200);
+    render(
+      {
+        before: "",
+        after: "const a = 1\nconst b = 2",
+        mode: "unified",
+        annotations: [
+          { lines: "2", label: "Changed", note: "Diff note in the margin." },
+        ],
+      },
+      {
+        codeAnnotationLayout: {
+          hoverSide: "left",
+          hoverFallbackSide: "right",
+          showByDefaultWhenRoom: true,
+          marginSide: "auto",
+        },
+      },
+    );
+
+    const codeSurface = container.querySelector("[data-code-surface]");
+    const codeBox = codeSurface?.parentElement;
+    expect(codeBox).toBeTruthy();
+    stubRect(codeBox!, rect({ left: 360, top: 80, width: 500, height: 100 }));
+
+    const rows = Array.from(
+      container.querySelectorAll<HTMLElement>(
+        "[data-code-surface] > div > div",
+      ),
+    );
+    expect(rows).toHaveLength(2);
+    rows.forEach((row, index) => {
+      stubRect(
+        row,
+        rect({ left: 360, top: 100 + index * 20, width: 500, height: 20 }),
+      );
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    const anchor = container.querySelector(
+      "[data-annotation-inline-overlay-anchor]",
+    );
+    expect(anchor).toBeTruthy();
+    stubRect(anchor!, rect({ left: 850, top: 120, width: 0, height: 20 }));
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    const overlay = document.querySelector<HTMLElement>(
+      "[data-annotation-inline-overlay]",
+    );
+    expect(overlay).toBeTruthy();
+    expect(overlay?.getAttribute("data-annotation-inline-overlay-mode")).toBe(
+      "margin",
+    );
+    expect(overlay?.getAttribute("data-annotation-inline-overlay-side")).toBe(
+      "left",
+    );
+    expect(overlay?.textContent).toContain("Diff note in the margin.");
+
+    act(() => {
+      rows[1].dispatchEvent(
+        new MouseEvent("mouseover", {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      );
+    });
     expect(document.querySelector("[data-annotation-hover-card]")).toBeNull();
   });
 

--- a/packages/core/src/client/blocks/library/DiffBlock.tsx
+++ b/packages/core/src/client/blocks/library/DiffBlock.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type RefObject,
   type ReactNode,
 } from "react";
 import {
@@ -32,7 +33,10 @@ import {
   buildLineMarkerMap,
   hasRailAnnotations,
   resolveAnnotations,
+  useAnnotationMarginNotesAvailable,
   useAnnotationHover,
+  type AnnotationMarginSide,
+  type AnnotationSide,
   type ResolvedAnnotation,
 } from "./annotation-rail.js";
 import { DevInput, DevLabel, DevTextarea, DevSelect } from "./dev-doc-ui.js";
@@ -686,6 +690,11 @@ function DiffRead({
   const beforeLineCount = useMemo(() => countLines(data.before), [data.before]);
   const afterLineCount = useMemo(() => countLines(data.after), [data.after]);
   const showAnnotationOverlays = Boolean(ctx.showCodeAnnotationOverlays);
+  const annotationLayout = ctx.codeAnnotationLayout;
+  const annotationHoverSide = annotationLayout?.hoverSide ?? "right";
+  const annotationHoverFallbackSide =
+    annotationLayout?.hoverFallbackSide ?? "below";
+  const annotationMarginSide = annotationLayout?.marginSide ?? "auto";
   const resolved = useMemo(
     () =>
       resolveAnnotations(data.annotations, (annotation) =>
@@ -696,6 +705,18 @@ function DiffRead({
     [data.annotations, beforeLineCount, afterLineCount],
   );
   const hasAnnotations = hasRailAnnotations(resolved);
+  const showMarginAnnotations = useAnnotationMarginNotesAvailable({
+    containerRef: codeRef,
+    enabled: Boolean(
+      hasAnnotations &&
+      !showAnnotationOverlays &&
+      annotationLayout?.showByDefaultWhenRoom,
+    ),
+    side: annotationMarginSide,
+    preferredSide: annotationHoverSide,
+  });
+  const showPersistentAnnotations =
+    showAnnotationOverlays || showMarginAnnotations;
   // Effective render mode. Annotations live in a SEPARATE right-hand rail (not
   // over the code), so they no longer force a mode. When no mode was authored, a
   // truly narrow container still falls back to unified so split's doubled
@@ -886,7 +907,13 @@ function DiffRead({
           onRowEnter={onRowEnter}
           onRowLeave={onRowLeave}
           onRowClick={onRowClick}
-          showAnnotationOverlays={showAnnotationOverlays}
+          showAnnotationOverlays={showPersistentAnnotations}
+          annotationOverlayMode={showAnnotationOverlays ? "capture" : "margin"}
+          annotationOverlaySide={
+            showAnnotationOverlays ? "right" : annotationMarginSide
+          }
+          annotationOverlayPreferredSide={annotationHoverSide}
+          annotationOverlayContainerRef={codeRef}
           ctx={ctx}
         />
       ) : (
@@ -901,7 +928,13 @@ function DiffRead({
           onRowEnter={onRowEnter}
           onRowLeave={onRowLeave}
           onRowClick={onRowClick}
-          showAnnotationOverlays={showAnnotationOverlays}
+          showAnnotationOverlays={showPersistentAnnotations}
+          annotationOverlayMode={showAnnotationOverlays ? "capture" : "margin"}
+          annotationOverlaySide={
+            showAnnotationOverlays ? "right" : annotationMarginSide
+          }
+          annotationOverlayPreferredSide={annotationHoverSide}
+          annotationOverlayContainerRef={codeRef}
           ctx={ctx}
         />
       )}
@@ -947,17 +980,22 @@ function DiffRead({
       {hasAnnotations && (
         <AnnotationHiddenStack items={resolved} ctx={ctx} showMarker />
       )}
-      {hasAnnotations && activeItem && hover.anchor && (
-        <AnnotationHoverCard
-          item={activeItem}
-          anchor={hover.anchor}
-          ctx={ctx}
-          showMarker
-          onMouseEnter={hover.cancelClose}
-          onMouseLeave={hover.scheduleClose}
-          onClose={hover.closeForScroll}
-        />
-      )}
+      {hasAnnotations &&
+        !showPersistentAnnotations &&
+        activeItem &&
+        hover.anchor && (
+          <AnnotationHoverCard
+            item={activeItem}
+            anchor={hover.anchor}
+            ctx={ctx}
+            showMarker
+            preferredSide={annotationHoverSide}
+            hoverFallbackSide={annotationHoverFallbackSide}
+            onMouseEnter={hover.cancelClose}
+            onMouseLeave={hover.scheduleClose}
+            onClose={hover.closeForScroll}
+          />
+        )}
     </section>
   );
 }
@@ -1007,6 +1045,10 @@ interface RowAnnotationProps {
   onRowLeave: () => void;
   /** Clicking/tapping an annotated row toggles its popover (for touch). */
   onRowClick: (index: number, rowEl: HTMLElement) => void;
+  annotationOverlayMode: "capture" | "margin";
+  annotationOverlaySide: AnnotationMarginSide;
+  annotationOverlayPreferredSide: AnnotationSide;
+  annotationOverlayContainerRef: RefObject<HTMLElement | null>;
 }
 
 /**
@@ -1062,6 +1104,10 @@ function UnifiedView({
   onRowLeave,
   onRowClick,
   showAnnotationOverlays,
+  annotationOverlayMode,
+  annotationOverlaySide,
+  annotationOverlayPreferredSide,
+  annotationOverlayContainerRef,
   ctx,
 }: {
   rows: DiffRow[];
@@ -1087,6 +1133,10 @@ function UnifiedView({
     onRowClick,
     showMarkerColumn,
     showAnnotationOverlays,
+    annotationOverlayMode,
+    annotationOverlaySide,
+    annotationOverlayPreferredSide,
+    annotationOverlayContainerRef,
     ctx,
   };
   let runIndex = 0;
@@ -1132,6 +1182,10 @@ function UnifiedRow({
   onRowClick,
   showMarkerColumn,
   showAnnotationOverlays,
+  annotationOverlayMode,
+  annotationOverlaySide,
+  annotationOverlayPreferredSide,
+  annotationOverlayContainerRef,
   ctx,
 }: {
   language: string;
@@ -1143,6 +1197,10 @@ function UnifiedRow({
   onRowClick: (index: number, rowEl: HTMLElement) => void;
   showMarkerColumn: boolean;
   showAnnotationOverlays: boolean;
+  annotationOverlayMode: "capture" | "margin";
+  annotationOverlaySide: AnnotationMarginSide;
+  annotationOverlayPreferredSide: AnnotationSide;
+  annotationOverlayContainerRef: RefObject<HTMLElement | null>;
   ctx: BlockRenderContext;
 }) {
   const markers = markersForRow(row);
@@ -1213,6 +1271,10 @@ function UnifiedRow({
           items={overlayItems}
           ctx={ctx}
           showMarker
+          containerRef={annotationOverlayContainerRef}
+          mode={annotationOverlayMode}
+          side={annotationOverlaySide}
+          preferredSide={annotationOverlayPreferredSide}
         />
       )}
     </div>
@@ -1313,6 +1375,10 @@ function SplitView({
   onRowLeave,
   onRowClick,
   showAnnotationOverlays,
+  annotationOverlayMode,
+  annotationOverlaySide,
+  annotationOverlayPreferredSide,
+  annotationOverlayContainerRef,
   ctx,
 }: {
   language: string;
@@ -1344,6 +1410,10 @@ function SplitView({
     onRowLeave,
     onRowClick,
     showAnnotationOverlays,
+    annotationOverlayMode,
+    annotationOverlaySide,
+    annotationOverlayPreferredSide,
+    annotationOverlayContainerRef,
     ctx,
   };
   return (
@@ -1392,6 +1462,10 @@ function SplitCell({
   onRowClick,
   showMarkerColumn,
   showAnnotationOverlays,
+  annotationOverlayMode,
+  annotationOverlaySide,
+  annotationOverlayPreferredSide,
+  annotationOverlayContainerRef,
   ctx,
 }: {
   language: string;
@@ -1404,6 +1478,10 @@ function SplitCell({
   onRowClick: (index: number, rowEl: HTMLElement) => void;
   showMarkerColumn: boolean;
   showAnnotationOverlays: boolean;
+  annotationOverlayMode: "capture" | "margin";
+  annotationOverlaySide: AnnotationMarginSide;
+  annotationOverlayPreferredSide: AnnotationSide;
+  annotationOverlayContainerRef: RefObject<HTMLElement | null>;
   ctx: BlockRenderContext;
 }) {
   if (!row) {
@@ -1487,6 +1565,10 @@ function SplitCell({
           items={overlayItems}
           ctx={ctx}
           showMarker
+          containerRef={annotationOverlayContainerRef}
+          mode={annotationOverlayMode}
+          side={annotationOverlaySide}
+          preferredSide={annotationOverlayPreferredSide}
         />
       )}
     </div>

--- a/packages/core/src/client/blocks/library/annotation-rail.spec.ts
+++ b/packages/core/src/client/blocks/library/annotation-rail.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveAnnotationInlineOverlayPosition,
+  resolveAnnotationMarginOverlayPosition,
   resolveAnnotationHoverCardPosition,
   type AnnotationAnchor,
 } from "./annotation-rail.js";
@@ -42,6 +43,28 @@ describe("annotation hover card placement", () => {
       ),
     ).toEqual({ left: 100, top: 223 });
   });
+
+  it("can prefer the left gutter for plan-mode hovers", () => {
+    expect(
+      resolveAnnotationHoverCardPosition(
+        anchor,
+        { width: 280, height: 120 },
+        { width: 1200, height: 600 },
+        { preferredSide: "left", hoverFallbackSide: "right" },
+      ),
+    ).toEqual({ left: 68, top: 140 });
+  });
+
+  it("can clamp to the right side in tight plan-mode windows", () => {
+    expect(
+      resolveAnnotationHoverCardPosition(
+        { ...anchor, codeLeft: 100, codeRight: 760 },
+        { width: 280, height: 120 },
+        { width: 900, height: 600 },
+        { preferredSide: "left", hoverFallbackSide: "right" },
+      ),
+    ).toEqual({ left: 612, top: 140 });
+  });
 });
 
 describe("annotation inline overlay placement", () => {
@@ -73,5 +96,40 @@ describe("annotation inline overlay placement", () => {
         { width: 950, height: 700 },
       ),
     ).toEqual({ right: 90, top: 8 });
+  });
+});
+
+describe("annotation margin overlay placement", () => {
+  it("uses the preferred left margin when it has room", () => {
+    expect(
+      resolveAnnotationMarginOverlayPosition(
+        { left: 360, right: 860, top: 120, height: 22 },
+        { width: 320, height: 120 },
+        { width: 1200, height: 700 },
+        { side: "auto", preferredSide: "left" },
+      ),
+    ).toEqual({ left: 28, top: 71, visible: true, side: "left" });
+  });
+
+  it("falls back to the right margin when left is tight", () => {
+    expect(
+      resolveAnnotationMarginOverlayPosition(
+        { left: 100, right: 500, top: 120, height: 22 },
+        { width: 320, height: 120 },
+        { width: 950, height: 700 },
+        { side: "auto", preferredSide: "left" },
+      ),
+    ).toEqual({ left: 512, top: 71, visible: true, side: "right" });
+  });
+
+  it("marks the card hidden when no side margin can hold it", () => {
+    expect(
+      resolveAnnotationMarginOverlayPosition(
+        { left: 100, right: 760, top: 120, height: 22 },
+        { width: 320, height: 120 },
+        { width: 900, height: 700 },
+        { side: "auto", preferredSide: "left" },
+      ),
+    ).toEqual({ left: 8, top: 71, visible: false, side: "left" });
   });
 });

--- a/packages/core/src/client/blocks/library/annotation-rail.tsx
+++ b/packages/core/src/client/blocks/library/annotation-rail.tsx
@@ -4,6 +4,8 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
+  type RefObject,
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
@@ -256,18 +258,33 @@ export function AnnotationInlineOverlayStack<A extends RailAnnotation>({
   items,
   ctx,
   showMarker = false,
+  containerRef,
+  mode = "capture",
+  side = "right",
+  preferredSide = "right",
 }: {
   items: ResolvedAnnotation<A>[];
   ctx: BlockRenderContext;
   showMarker?: boolean;
+  containerRef?: RefObject<HTMLElement | null>;
+  mode?: "capture" | "margin";
+  side?: AnnotationMarginSide;
+  preferredSide?: AnnotationSide;
 }) {
   const resolved = items.filter((item) => item.range);
   const anchorRef = useRef<HTMLDivElement | null>(null);
   const portalRef = useRef<HTMLDivElement | null>(null);
-  const [position, setPosition] = useState<{
-    top: number;
-    right: number;
-  } | null>(null);
+  const [position, setPosition] = useState<
+    | { kind: "capture"; top: number; right: number; visible: boolean }
+    | {
+        kind: "margin";
+        top: number;
+        left: number;
+        visible: boolean;
+        side: AnnotationSide;
+      }
+    | null
+  >(null);
   const positionKey = resolved
     .map(
       (item) =>
@@ -298,8 +315,27 @@ export function AnnotationInlineOverlayStack<A extends RailAnnotation>({
           : Math.min(INLINE_OVERLAY_WIDTH, viewportWidth * 0.45);
       const height =
         portalRect && portalRect.height > 0 ? portalRect.height : 0;
-      setPosition(
-        resolveAnnotationInlineOverlayPosition(
+      if (mode === "margin") {
+        const containerRect =
+          containerRef?.current?.getBoundingClientRect() ?? anchorRect;
+        const next = resolveAnnotationMarginOverlayPosition(
+          {
+            left: containerRect.left,
+            right: containerRect.right,
+            top: anchorRect.top,
+            height: anchorRect.height,
+          },
+          { width, height },
+          { width: viewportWidth, height: viewportHeight },
+          { side, preferredSide },
+        );
+        setPosition({ kind: "margin", ...next });
+        return;
+      }
+      setPosition({
+        kind: "capture",
+        visible: true,
+        ...resolveAnnotationInlineOverlayPosition(
           {
             right: anchorRect.right,
             top: anchorRect.top,
@@ -308,7 +344,7 @@ export function AnnotationInlineOverlayStack<A extends RailAnnotation>({
           { width, height },
           { width: viewportWidth, height: viewportHeight },
         ),
-      );
+      });
     };
 
     updatePosition();
@@ -327,9 +363,31 @@ export function AnnotationInlineOverlayStack<A extends RailAnnotation>({
       window.removeEventListener("resize", updatePosition);
       window.removeEventListener("scroll", updatePosition, { capture: true });
     };
-  }, [positionKey]);
+  }, [containerRef, mode, positionKey, preferredSide, side]);
 
   if (resolved.length === 0) return null;
+
+  const portalStyle: CSSProperties =
+    position?.kind === "margin"
+      ? {
+          top: position.top,
+          left: position.left,
+          visibility:
+            position.visible && position
+              ? ("visible" as const)
+              : ("hidden" as const),
+        }
+      : {
+          top: position?.top ?? VIEWPORT_MARGIN,
+          right:
+            position && position.kind === "capture"
+              ? position.right
+              : VIEWPORT_MARGIN,
+          visibility:
+            position?.kind === "capture" && position.visible
+              ? ("visible" as const)
+              : ("hidden" as const),
+        };
 
   const portal =
     typeof document === "undefined"
@@ -339,12 +397,12 @@ export function AnnotationInlineOverlayStack<A extends RailAnnotation>({
             aria-hidden
             ref={portalRef}
             data-annotation-inline-overlay
+            data-annotation-inline-overlay-mode={mode}
+            data-annotation-inline-overlay-side={
+              position?.kind === "margin" ? position.side : "right"
+            }
             className="pointer-events-none fixed z-50 flex w-[min(20rem,45vw)] flex-col gap-2"
-            style={{
-              top: position?.top ?? VIEWPORT_MARGIN,
-              right: position?.right ?? VIEWPORT_MARGIN,
-              visibility: position ? "visible" : "hidden",
-            }}
+            style={portalStyle}
           >
             {resolved.map((item) => (
               <AnnotationCard
@@ -387,29 +445,82 @@ export interface AnnotationAnchor {
   lineBottom: number;
 }
 
+export type AnnotationSide = "left" | "right";
+export type AnnotationMarginSide = AnnotationSide | "auto";
+
 const HOVER_CARD_WIDTH = 280;
 const INLINE_OVERLAY_WIDTH = 320;
 const HOVER_CARD_GAP = 12;
 const VIEWPORT_MARGIN = 8;
 const SCROLL_HOVER_SUPPRESS_MS = 260;
 
+function oppositeSide(side: AnnotationSide): AnnotationSide {
+  return side === "left" ? "right" : "left";
+}
+
+function clampWithinViewport(
+  value: number,
+  size: number,
+  viewportSize: number,
+): number {
+  return Math.max(
+    VIEWPORT_MARGIN,
+    Math.min(value, viewportSize - size - VIEWPORT_MARGIN),
+  );
+}
+
+function centeredTop(
+  anchor: { top: number; height: number },
+  cardHeight: number,
+  viewportHeight: number,
+): number {
+  const maxTop = Math.max(
+    VIEWPORT_MARGIN,
+    viewportHeight - cardHeight - VIEWPORT_MARGIN,
+  );
+  const raw = anchor.top + anchor.height / 2 - cardHeight / 2;
+  return Math.max(VIEWPORT_MARGIN, Math.min(raw, maxTop));
+}
+
+function inlineOverlayWidthForViewport(viewportWidth: number): number {
+  return Math.min(INLINE_OVERLAY_WIDTH, Math.max(0, viewportWidth * 0.45));
+}
+
+function hoverCardLeftForSide(
+  side: AnnotationSide,
+  anchor: AnnotationAnchor,
+  cardWidth: number,
+): number {
+  return side === "right"
+    ? anchor.codeRight + HOVER_CARD_GAP
+    : anchor.codeLeft - HOVER_CARD_GAP - cardWidth;
+}
+
+function hoverCardFitsSide(
+  side: AnnotationSide,
+  anchor: AnnotationAnchor,
+  cardWidth: number,
+  viewportWidth: number,
+): boolean {
+  const left = hoverCardLeftForSide(side, anchor, cardWidth);
+  return (
+    left >= VIEWPORT_MARGIN &&
+    left + cardWidth + VIEWPORT_MARGIN <= viewportWidth
+  );
+}
+
 export function resolveAnnotationInlineOverlayPosition(
   anchor: { right: number; top: number; height: number },
   card: { width: number; height: number },
   viewport: { width: number; height: number },
 ): { top: number; right: number } {
-  const maxTop = Math.max(
-    VIEWPORT_MARGIN,
-    viewport.height - card.height - VIEWPORT_MARGIN,
-  );
-  const centeredTop = anchor.top + anchor.height / 2 - card.height / 2;
   const maxRight = Math.max(
     VIEWPORT_MARGIN,
     viewport.width - card.width - VIEWPORT_MARGIN,
   );
 
   return {
-    top: Math.max(VIEWPORT_MARGIN, Math.min(centeredTop, maxTop)),
+    top: centeredTop(anchor, card.height, viewport.height),
     right: Math.max(
       VIEWPORT_MARGIN,
       Math.min(viewport.width - anchor.right, maxRight),
@@ -417,25 +528,75 @@ export function resolveAnnotationInlineOverlayPosition(
   };
 }
 
+export function resolveAnnotationMarginOverlayPosition(
+  anchor: { left: number; right: number; top: number; height: number },
+  card: { width: number; height: number },
+  viewport: { width: number; height: number },
+  options: {
+    side?: AnnotationMarginSide;
+    preferredSide?: AnnotationSide;
+  } = {},
+): { top: number; left: number; visible: boolean; side: AnnotationSide } {
+  const preferredSide = options.preferredSide ?? "left";
+  const requestedSide = options.side ?? preferredSide;
+  const sides: AnnotationSide[] =
+    requestedSide === "auto"
+      ? [preferredSide, oppositeSide(preferredSide)]
+      : [requestedSide];
+  const top = centeredTop(anchor, card.height, viewport.height);
+
+  for (const candidate of sides) {
+    const left =
+      candidate === "left"
+        ? anchor.left - HOVER_CARD_GAP - card.width
+        : anchor.right + HOVER_CARD_GAP;
+    const fits =
+      left >= VIEWPORT_MARGIN &&
+      left + card.width + VIEWPORT_MARGIN <= viewport.width;
+    if (fits) return { top, left, visible: true, side: candidate };
+  }
+
+  const fallbackSide = requestedSide === "auto" ? preferredSide : requestedSide;
+  const fallbackLeft =
+    fallbackSide === "left"
+      ? anchor.left - HOVER_CARD_GAP - card.width
+      : anchor.right + HOVER_CARD_GAP;
+  return {
+    top,
+    left: clampWithinViewport(fallbackLeft, card.width, viewport.width),
+    visible: false,
+    side: fallbackSide,
+  };
+}
+
 export function resolveAnnotationHoverCardPosition(
   anchor: AnnotationAnchor,
   card: { width: number; height: number },
   viewport: { width: number; height: number },
+  options: {
+    preferredSide?: AnnotationSide;
+    hoverFallbackSide?: AnnotationSide | "below";
+    allowOppositeSideFallback?: boolean;
+  } = {},
 ): { top: number; left: number } {
-  const rightLeft = anchor.codeRight + HOVER_CARD_GAP;
-  const fitsRight = rightLeft + card.width + VIEWPORT_MARGIN <= viewport.width;
-  const leftLeft = anchor.codeLeft - HOVER_CARD_GAP - card.width;
-  const fitsLeft = leftLeft >= VIEWPORT_MARGIN;
+  const preferredSide = options.preferredSide ?? "right";
+  const hoverFallbackSide = options.hoverFallbackSide ?? "below";
+  const allowOppositeSideFallback = options.allowOppositeSideFallback ?? true;
+  const opposite = oppositeSide(preferredSide);
 
   let left: number;
   let top: number;
-  if (fitsRight) {
-    // Default: to the right of the code, centered on the hovered line.
-    left = rightLeft;
+  if (hoverCardFitsSide(preferredSide, anchor, card.width, viewport.width)) {
+    left = hoverCardLeftForSide(preferredSide, anchor, card.width);
     top = anchor.lineCenter - card.height / 2;
-  } else if (fitsLeft) {
-    // Prefer the left gutter over covering the code below the hovered line.
-    left = leftLeft;
+  } else if (
+    allowOppositeSideFallback &&
+    hoverCardFitsSide(opposite, anchor, card.width, viewport.width)
+  ) {
+    left = hoverCardLeftForSide(opposite, anchor, card.width);
+    top = anchor.lineCenter - card.height / 2;
+  } else if (hoverFallbackSide === "left" || hoverFallbackSide === "right") {
+    left = hoverCardLeftForSide(hoverFallbackSide, anchor, card.width);
     top = anchor.lineCenter - card.height / 2;
   } else {
     // No clean side gutter → drop below the line, aligned to the code's left.
@@ -444,16 +605,79 @@ export function resolveAnnotationHoverCardPosition(
   }
 
   // Clamp within the viewport so the card is never cut off.
-  left = Math.max(
-    VIEWPORT_MARGIN,
-    Math.min(left, viewport.width - card.width - VIEWPORT_MARGIN),
-  );
+  left = clampWithinViewport(left, card.width, viewport.width);
   top = Math.max(
     VIEWPORT_MARGIN,
     Math.min(top, viewport.height - card.height - VIEWPORT_MARGIN),
   );
 
   return { top, left };
+}
+
+export function useAnnotationMarginNotesAvailable({
+  containerRef,
+  enabled,
+  side = "auto",
+  preferredSide = "left",
+}: {
+  containerRef: RefObject<HTMLElement | null>;
+  enabled: boolean;
+  side?: AnnotationMarginSide;
+  preferredSide?: AnnotationSide;
+}) {
+  const [available, setAvailable] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!enabled || typeof window === "undefined") {
+      setAvailable(false);
+      return;
+    }
+
+    const update = () => {
+      const element = containerRef.current;
+      if (!element) {
+        setAvailable(false);
+        return;
+      }
+      const rect = element.getBoundingClientRect();
+      const viewportWidth = Math.max(window.innerWidth || 0, 0);
+      const cardWidth = inlineOverlayWidthForViewport(viewportWidth);
+      const leftFits =
+        rect.left - HOVER_CARD_GAP - cardWidth >= VIEWPORT_MARGIN;
+      const rightFits =
+        rect.right + HOVER_CARD_GAP + cardWidth + VIEWPORT_MARGIN <=
+        viewportWidth;
+      const next =
+        side === "left"
+          ? leftFits
+          : side === "right"
+            ? rightFits
+            : preferredSide === "left"
+              ? leftFits || rightFits
+              : rightFits || leftFits;
+      setAvailable(next);
+    };
+
+    update();
+    const frame =
+      typeof window.requestAnimationFrame === "function"
+        ? window.requestAnimationFrame(update)
+        : null;
+    const observer =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : null;
+    if (containerRef.current && observer)
+      observer.observe(containerRef.current);
+    window.addEventListener("resize", update);
+    return () => {
+      if (frame != null && typeof window.cancelAnimationFrame === "function") {
+        window.cancelAnimationFrame(frame);
+      }
+      observer?.disconnect();
+      window.removeEventListener("resize", update);
+    };
+  }, [containerRef, enabled, preferredSide, side]);
+
+  return available;
 }
 
 /**
@@ -473,6 +697,8 @@ export function AnnotationHoverCard<A extends RailAnnotation>({
   anchor,
   ctx,
   showMarker = false,
+  preferredSide,
+  hoverFallbackSide,
   onMouseEnter,
   onMouseLeave,
   onClose,
@@ -481,6 +707,8 @@ export function AnnotationHoverCard<A extends RailAnnotation>({
   anchor: AnnotationAnchor;
   ctx: BlockRenderContext;
   showMarker?: boolean;
+  preferredSide?: AnnotationSide;
+  hoverFallbackSide?: AnnotationSide | "below";
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
   /** Called when the card should be dismissed (e.g. on scroll). */
@@ -505,6 +733,7 @@ export function AnnotationHoverCard<A extends RailAnnotation>({
         anchor,
         { width, height },
         { width: vw, height: vh },
+        { preferredSide, hoverFallbackSide },
       ),
     );
   }, [
@@ -512,7 +741,9 @@ export function AnnotationHoverCard<A extends RailAnnotation>({
     anchor.codeLeft,
     anchor.lineCenter,
     anchor.lineBottom,
+    hoverFallbackSide,
     item.index,
+    preferredSide,
   ]);
 
   // Close the card when the user scrolls so it doesn't float detached. Scrolls

--- a/packages/core/src/client/blocks/types.ts
+++ b/packages/core/src/client/blocks/types.ts
@@ -118,6 +118,25 @@ export interface BlockRenderContext {
    */
   showCodeAnnotationOverlays?: boolean;
   /**
+   * Optional placement policy for line-anchored code/diff annotations.
+   * Hosts can keep the default right-first hover behavior, or ask annotations to
+   * prefer a margin side and become persistent whenever that margin has room.
+   */
+  codeAnnotationLayout?: {
+    /** Preferred side for hover cards when that side has a clean gutter. */
+    hoverSide?: "left" | "right";
+    /**
+     * Final hover fallback when neither side has a clean gutter. `"below"` keeps
+     * the legacy line-below behavior; `"left"`/`"right"` clamp the card to that
+     * viewport side, even if it overlaps part of the code surface.
+     */
+    hoverFallbackSide?: "left" | "right" | "below";
+    /** Show all annotation cards by default when the requested margin fits. */
+    showByDefaultWhenRoom?: boolean;
+    /** Margin side for persistent cards; `"auto"` tries hoverSide, then the other side. */
+    marginSide?: "left" | "right" | "auto";
+  };
+  /**
    * Render an inline, editable rich-markdown field. The auto-editor calls this
    * for a `markdown()`-tagged field so the app owns the editor wiring (collab,
    * autosave debounce, dialect) rather than core hardcoding it.

--- a/templates/plan/app/components/plan/PlanContentRenderer.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.tsx
@@ -392,6 +392,18 @@ export function PlanContentRenderer({
     onVisualQuestionsSubmit,
     editingDisabled,
   };
+  const codeAnnotationLayout = useMemo(
+    () =>
+      !isRecap && !showCodeAnnotationOverlays
+        ? ({
+            hoverSide: "left",
+            hoverFallbackSide: "right",
+            showByDefaultWhenRoom: true,
+            marginSide: "auto",
+          } as const)
+        : undefined,
+    [isRecap, showCodeAnnotationOverlays],
+  );
 
   const blockRenderContext = useMemo(
     () =>
@@ -442,6 +454,7 @@ export function PlanContentRenderer({
         ),
         editingDisabled,
         showCodeAnnotationOverlays,
+        codeAnnotationLayout,
       }),
     [
       contentUpdatedAt,
@@ -450,6 +463,7 @@ export function PlanContentRenderer({
       editingDisabled,
       notionCompatibleOnly,
       showCodeAnnotationOverlays,
+      codeAnnotationLayout,
     ],
   );
 

--- a/templates/plan/app/components/plan/planBlocks.tsx
+++ b/templates/plan/app/components/plan/planBlocks.tsx
@@ -31,6 +31,7 @@ import { cn } from "@/lib/utils";
 type PlanBlockRenderContextExtras = {
   onQuestionFormSubmit?: (summary: string) => void;
   showCodeAnnotationOverlays?: boolean;
+  codeAnnotationLayout?: BlockRenderContext["codeAnnotationLayout"];
 };
 
 /**
@@ -153,10 +154,12 @@ export function createPlanBlockRenderContext(options: {
   renderBlocksEditor?: BlockRenderContext["renderBlocksEditor"];
   editingDisabled?: boolean;
   showCodeAnnotationOverlays?: boolean;
+  codeAnnotationLayout?: BlockRenderContext["codeAnnotationLayout"];
 }): BlockRenderContext {
   const ctx: BlockRenderContext & PlanBlockRenderContextExtras = {
     dialect: "gfm",
     showCodeAnnotationOverlays: options.showCodeAnnotationOverlays,
+    codeAnnotationLayout: options.codeAnnotationLayout,
     onQuestionFormSubmit: options.onVisualQuestionsSubmit,
     renderMarkdown: (markdown, options) => (
       <PlanMarkdownReader markdown={markdown} className={options?.className} />


### PR DESCRIPTION
## Summary
- add configurable left/right placement for code and diff annotation hover cards
- show persistent margin annotation cards in visual plans when the side gutter has room
- add placement and rendered-behavior regression tests

## Verification
- pnpm --filter @agent-native/core exec vitest --run src/client/blocks/library/annotation-rail.spec.ts src/client/blocks/library/AnnotatedCodeBlock.spec.tsx
- pnpm --filter @agent-native/core typecheck
- pnpm --filter plan typecheck
- git diff --check