### PR TITLE
Add local component workspace bridge

### DIFF
--- a/.changeset/local-component-workspaces.md
+++ b/.changeset/local-component-workspaces.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Document local component workspace support for Content local file mode.

--- a/packages/core/docs/content/local-file-mode.md
+++ b/packages/core/docs/content/local-file-mode.md
@@ -228,6 +228,24 @@ components render inside the editor and appear in the slash menu under
 **Local components**. Slash insertion creates a minimal tag such as
 `<ImpactCounter />`; add props in the MDX source when needed.
 
+Component execution is intentionally a local-dev/Desktop bridge capability, not
+plain hosted browser folder access. If you open `content.agent-native.com`,
+choose **Local files**, and pick a folder in Chrome, the app can read and write
+the `.md` and `.mdx` files through the browser File System Access API, but
+Chrome does not expose an absolute folder path for Vite to compile
+`components/*.tsx`. To preview and hot reload custom React components, run
+Content locally or use Agent Native Desktop so the trusted local bridge can
+register the picked workspace with the local Content dev server. In that mode,
+edits to existing component files hot reload through Vite, and adding or
+removing component files reloads the component registry and slash menu.
+
+Agents can also work with those registered component files. Use
+`list-local-component-files` to find the registered workspace id, then
+`write-local-component-file` to create or update `.tsx`, `.jsx`, `.ts`, or
+`.js` files under the workspace's `components/` folder. The MDX files remain the
+source of truth for component usage; the component files remain normal repo
+source files reviewed with Git.
+
 If a component exports input metadata, selecting the component in the editor
 shows an edit button in the component's top-right corner. Supported input types
 are `string`, `textarea`, `number`, `boolean`, and `select`. The form writes

--- a/packages/core/docs/content/template-content.md
+++ b/packages/core/docs/content/template-content.md
@@ -205,6 +205,15 @@ menu under Local components. When input metadata is exported, selecting the
 component in the editor shows a corner edit button that rewrites the MDX props
 in the local file.
 
+The browser **Local files** picker can read and write `.md` and `.mdx` files on
+its own, but executable React component previews require a local compiler. Run
+Content locally or use Agent Native Desktop so the selected workspace path can
+be registered with the local Content dev server. Vite then imports
+`components/*.tsx`, hot reloads edits to existing component files, and reloads
+the component registry when files are added or removed. Agents can use
+`list-local-component-files` and `write-local-component-file` to inspect or
+update registered component files while the editor updates from the same source.
+
 ### Comments
 
 Threaded comments on documents with quoted-text anchors, replies, and resolve state. Backed by the `document_comments` table and `app/components/editor/CommentsSidebar.tsx`. Actions: `list-comments`, `add-comment`. Notion comments can sync both ways via `sync-notion-comments`.

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -95,6 +95,8 @@ cd templates/content && pnpm action <name> [args]
 | `edit-document`                | `--id <id> --edits <json>`                                                                                                   | Batch surgical text edits                                                             |
 | `update-document`              | `--id <id> [--title] [--content] [--icon]`                                                                                   | Full rewrite of document fields                                                       |
 | `share-local-file-document`    | `--id <local-file-document-id>`                                                                                              | Create or refresh a DB-backed shareable copy of a local file document                 |
+| `list-local-component-files`   |                                                                                                                              | List registered local MDX component source files                                      |
+| `write-local-component-file`   | `--workspaceId <id> --path <relative-component-path> --content <source>`                                                     | Create or update a file in a registered local `components/` folder                    |
 | `create-content-database`      | `[--documentId <id>] [--parentId <id>] [--title <text>]`                                                                     | Create a database page or convert an existing page into a database                    |
 | `get-content-database`         | `--databaseId <id>` or `--documentId <id>`                                                                                   | Get a database table with property schema and item pages                              |
 | `add-database-item`            | `--databaseId <id> [--title <text>] [--propertyValues <json>]`                                                               | Add a page row to a database, optionally seeding property values                      |
@@ -169,6 +171,17 @@ Content has two file workflows:
   `select` fields; selecting the component in the editor shows a corner edit
   button that rewrites the MDX props. JSX expression props are preserved in
   source but shown as an unsupported preview.
+- **Picked folders and components:** browser-picked folders can be the
+  source of truth for `.md`/`.mdx` files, but the browser does not expose an
+  absolute path that Vite can compile. Component previews from a picked
+  `components/` folder require Agent Native Desktop or a local Content dev
+  server. Desktop-selected folders register their workspace path with the local
+  dev server so Vite can import and hot reload `components/*.tsx`.
+- **Agent component edits:** use `list-local-component-files` to find the
+  registered workspace id, then `write-local-component-file` to add or edit
+  `.tsx`, `.jsx`, `.ts`, or `.js` files under that workspace's `components/`
+  folder. The Vite component registry reloads after file additions/removals;
+  edits to already-loaded files hot reload through Vite.
 
 Minimal `agent-native.json`:
 

--- a/templates/content/actions/list-local-component-files.ts
+++ b/templates/content/actions/list-local-component-files.ts
@@ -1,0 +1,69 @@
+import { defineAction } from "@agent-native/core";
+import { getLocalArtifactApp } from "@agent-native/core/local-artifacts";
+import { z } from "zod";
+import {
+  listLocalComponentFiles,
+  localComponentWorkspaceId,
+  type LocalComponentWorkspace,
+  readLocalComponentWorkspacesSync,
+} from "../shared/local-component-workspaces.js";
+
+const CONTENT_LOCAL_DEFAULTS = {
+  roots: [
+    { name: "Docs", path: "docs", kind: "docs", extensions: [".md", ".mdx"] },
+    { name: "Blog", path: "blog", kind: "blog", extensions: [".md", ".mdx"] },
+    {
+      name: "Content",
+      path: "content",
+      kind: "content",
+      extensions: [".md", ".mdx"],
+    },
+    {
+      name: "Resources",
+      path: "resources",
+      kind: "resources",
+      extensions: [".md", ".mdx"],
+    },
+  ],
+  components: "components",
+  hide: ["**/_*.md", "**/_*.mdx"],
+};
+
+async function localFileModeComponentWorkspace(): Promise<LocalComponentWorkspace | null> {
+  const app = await getLocalArtifactApp({
+    appId: "content",
+    defaults: CONTENT_LOCAL_DEFAULTS,
+  });
+  if (app.mode !== "local-files" || app.components.length === 0) return null;
+  return {
+    id: localComponentWorkspaceId(app.workspaceRoot),
+    workspacePath: app.workspaceRoot,
+    componentPaths: app.components,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export default defineAction({
+  description:
+    "List component source files in local Content component workspaces registered from Local File Mode or Desktop folder picks.",
+  readOnly: true,
+  http: { method: "GET" },
+  schema: z.object({}),
+  run: async () => {
+    const workspaces = readLocalComponentWorkspacesSync();
+    const localFileModeWorkspace = await localFileModeComponentWorkspace();
+    const allWorkspaces = localFileModeWorkspace
+      ? [
+          localFileModeWorkspace,
+          ...workspaces.filter(
+            (workspace) => workspace.id !== localFileModeWorkspace.id,
+          ),
+        ]
+      : workspaces;
+    const files = await listLocalComponentFiles({ workspaces: allWorkspaces });
+    return {
+      workspaces: allWorkspaces,
+      files,
+    };
+  },
+});

--- a/templates/content/actions/list-local-component-files.ts
+++ b/templates/content/actions/list-local-component-files.ts
@@ -67,6 +67,7 @@ export default defineAction({
           ]
         : workspaces;
       const files = await listLocalComponentFiles({
+        scope,
         workspaces: allWorkspaces,
       });
       return {

--- a/templates/content/actions/list-local-component-files.ts
+++ b/templates/content/actions/list-local-component-files.ts
@@ -2,6 +2,7 @@ import { defineAction } from "@agent-native/core";
 import { getLocalArtifactApp } from "@agent-native/core/local-artifacts";
 import { z } from "zod";
 import {
+  isLocalComponentAccessError,
   listLocalComponentFiles,
   localComponentWorkspaceId,
   type LocalComponentWorkspace,
@@ -50,20 +51,32 @@ export default defineAction({
   http: { method: "GET" },
   schema: z.object({}),
   run: async () => {
-    const workspaces = readLocalComponentWorkspacesSync();
-    const localFileModeWorkspace = await localFileModeComponentWorkspace();
-    const allWorkspaces = localFileModeWorkspace
-      ? [
-          localFileModeWorkspace,
-          ...workspaces.filter(
-            (workspace) => workspace.id !== localFileModeWorkspace.id,
-          ),
-        ]
-      : workspaces;
-    const files = await listLocalComponentFiles({ workspaces: allWorkspaces });
-    return {
-      workspaces: allWorkspaces,
-      files,
-    };
+    try {
+      const workspaces = readLocalComponentWorkspacesSync();
+      const localFileModeWorkspace = await localFileModeComponentWorkspace();
+      const allWorkspaces = localFileModeWorkspace
+        ? [
+            localFileModeWorkspace,
+            ...workspaces.filter(
+              (workspace) => workspace.id !== localFileModeWorkspace.id,
+            ),
+          ]
+        : workspaces;
+      const files = await listLocalComponentFiles({
+        workspaces: allWorkspaces,
+      });
+      return {
+        workspaces: allWorkspaces,
+        files,
+      };
+    } catch (error) {
+      if (isLocalComponentAccessError(error)) {
+        return {
+          workspaces: [],
+          files: [],
+        };
+      }
+      throw error;
+    }
   },
 });

--- a/templates/content/actions/list-local-component-files.ts
+++ b/templates/content/actions/list-local-component-files.ts
@@ -5,8 +5,10 @@ import {
   isLocalComponentAccessError,
   listLocalComponentFiles,
   localComponentWorkspaceId,
+  localComponentWorkspaceScope,
   type LocalComponentWorkspace,
   readLocalComponentWorkspacesSync,
+  resolveLocalComponentWorkspacePath,
 } from "../shared/local-component-workspaces.js";
 
 const CONTENT_LOCAL_DEFAULTS = {
@@ -36,9 +38,10 @@ async function localFileModeComponentWorkspace(): Promise<LocalComponentWorkspac
     defaults: CONTENT_LOCAL_DEFAULTS,
   });
   if (app.mode !== "local-files" || app.components.length === 0) return null;
+  const workspacePath = resolveLocalComponentWorkspacePath(app.workspaceRoot);
   return {
-    id: localComponentWorkspaceId(app.workspaceRoot),
-    workspacePath: app.workspaceRoot,
+    id: localComponentWorkspaceId(workspacePath),
+    workspacePath,
     componentPaths: app.components,
     updatedAt: new Date().toISOString(),
   };
@@ -50,9 +53,10 @@ export default defineAction({
   readOnly: true,
   http: { method: "GET" },
   schema: z.object({}),
-  run: async () => {
+  run: async (_args, context) => {
     try {
-      const workspaces = readLocalComponentWorkspacesSync();
+      const scope = localComponentWorkspaceScope(context?.userEmail);
+      const workspaces = readLocalComponentWorkspacesSync(undefined, scope);
       const localFileModeWorkspace = await localFileModeComponentWorkspace();
       const allWorkspaces = localFileModeWorkspace
         ? [

--- a/templates/content/actions/register-local-component-workspace.ts
+++ b/templates/content/actions/register-local-component-workspace.ts
@@ -1,0 +1,25 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import { registerLocalComponentWorkspace } from "../shared/local-component-workspaces.js";
+
+export default defineAction({
+  description:
+    "Register a local workspace's components folder for Content MDX previews. This is used by the Local files UI after a trusted Desktop folder pick.",
+  agentTool: false,
+  schema: z.object({
+    workspacePath: z
+      .string()
+      .min(1)
+      .describe("Absolute local workspace folder path selected by Desktop"),
+  }),
+  run: async ({ workspacePath }) => {
+    const result = await registerLocalComponentWorkspace({ workspacePath });
+    return {
+      ok: true,
+      workspace: result.workspace,
+      componentDirs: result.componentDirs,
+      componentCount: result.componentDirs.length,
+      reloadRequired: true,
+    };
+  },
+});

--- a/templates/content/actions/register-local-component-workspace.ts
+++ b/templates/content/actions/register-local-component-workspace.ts
@@ -1,6 +1,9 @@
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
-import { registerLocalComponentWorkspace } from "../shared/local-component-workspaces.js";
+import {
+  localComponentWorkspaceScope,
+  registerLocalComponentWorkspace,
+} from "../shared/local-component-workspaces.js";
 
 export default defineAction({
   description:
@@ -12,8 +15,11 @@ export default defineAction({
       .min(1)
       .describe("Absolute local workspace folder path selected by Desktop"),
   }),
-  run: async ({ workspacePath }) => {
-    const result = await registerLocalComponentWorkspace({ workspacePath });
+  run: async ({ workspacePath }, context) => {
+    const result = await registerLocalComponentWorkspace({
+      workspacePath,
+      scope: localComponentWorkspaceScope(context?.userEmail),
+    });
     return {
       ok: true,
       workspace: result.workspace,

--- a/templates/content/actions/write-local-component-file.ts
+++ b/templates/content/actions/write-local-component-file.ts
@@ -3,8 +3,10 @@ import { getLocalArtifactApp } from "@agent-native/core/local-artifacts";
 import { z } from "zod";
 import {
   localComponentWorkspaceId,
+  localComponentWorkspaceScope,
   readLocalComponentWorkspacesSync,
   registerLocalComponentWorkspace,
+  resolveLocalComponentWorkspacePath,
   type LocalComponentWorkspace,
   writeLocalComponentFile,
 } from "../shared/local-component-workspaces.js";
@@ -30,8 +32,10 @@ const CONTENT_LOCAL_DEFAULTS = {
   hide: ["**/_*.md", "**/_*.mdx"],
 };
 
-async function componentWorkspaces(): Promise<LocalComponentWorkspace[]> {
-  const registered = readLocalComponentWorkspacesSync();
+async function componentWorkspaces(
+  scope: string,
+): Promise<LocalComponentWorkspace[]> {
+  const registered = readLocalComponentWorkspacesSync(undefined, scope);
   const app = await getLocalArtifactApp({
     appId: "content",
     defaults: CONTENT_LOCAL_DEFAULTS,
@@ -39,9 +43,10 @@ async function componentWorkspaces(): Promise<LocalComponentWorkspace[]> {
   if (app.mode !== "local-files" || app.components.length === 0) {
     return registered;
   }
+  const workspacePath = resolveLocalComponentWorkspacePath(app.workspaceRoot);
   const localFileWorkspace: LocalComponentWorkspace = {
-    id: localComponentWorkspaceId(app.workspaceRoot),
-    workspacePath: app.workspaceRoot,
+    id: localComponentWorkspaceId(workspacePath),
+    workspacePath,
     componentPaths: app.components,
     updatedAt: new Date().toISOString(),
   };
@@ -65,15 +70,17 @@ export default defineAction({
       .describe("Relative path under the workspace components folder"),
     content: z.string().describe("Full .tsx/.jsx/.ts/.js source to write"),
   }),
-  run: async ({ workspaceId, path: filePath, content }) => {
+  run: async ({ workspaceId, path: filePath, content }, context) => {
+    const scope = localComponentWorkspaceScope(context?.userEmail);
     const file = await writeLocalComponentFile({
       workspaceId,
       filePath,
       content,
-      workspaces: await componentWorkspaces(),
+      workspaces: await componentWorkspaces(scope),
     });
     await registerLocalComponentWorkspace({
       workspacePath: file.workspacePath,
+      scope,
     });
     return {
       ok: true,

--- a/templates/content/actions/write-local-component-file.ts
+++ b/templates/content/actions/write-local-component-file.ts
@@ -65,10 +65,10 @@ export default defineAction({
       .describe("Relative path under the workspace components folder"),
     content: z.string().describe("Full .tsx/.jsx/.ts/.js source to write"),
   }),
-  run: async ({ workspaceId, path, content }) => {
+  run: async ({ workspaceId, path: filePath, content }) => {
     const file = await writeLocalComponentFile({
       workspaceId,
-      filePath: path,
+      filePath,
       content,
       workspaces: await componentWorkspaces(),
     });

--- a/templates/content/actions/write-local-component-file.ts
+++ b/templates/content/actions/write-local-component-file.ts
@@ -1,0 +1,83 @@
+import { defineAction } from "@agent-native/core";
+import { getLocalArtifactApp } from "@agent-native/core/local-artifacts";
+import { z } from "zod";
+import {
+  localComponentWorkspaceId,
+  readLocalComponentWorkspacesSync,
+  registerLocalComponentWorkspace,
+  type LocalComponentWorkspace,
+  writeLocalComponentFile,
+} from "../shared/local-component-workspaces.js";
+
+const CONTENT_LOCAL_DEFAULTS = {
+  roots: [
+    { name: "Docs", path: "docs", kind: "docs", extensions: [".md", ".mdx"] },
+    { name: "Blog", path: "blog", kind: "blog", extensions: [".md", ".mdx"] },
+    {
+      name: "Content",
+      path: "content",
+      kind: "content",
+      extensions: [".md", ".mdx"],
+    },
+    {
+      name: "Resources",
+      path: "resources",
+      kind: "resources",
+      extensions: [".md", ".mdx"],
+    },
+  ],
+  components: "components",
+  hide: ["**/_*.md", "**/_*.mdx"],
+};
+
+async function componentWorkspaces(): Promise<LocalComponentWorkspace[]> {
+  const registered = readLocalComponentWorkspacesSync();
+  const app = await getLocalArtifactApp({
+    appId: "content",
+    defaults: CONTENT_LOCAL_DEFAULTS,
+  });
+  if (app.mode !== "local-files" || app.components.length === 0) {
+    return registered;
+  }
+  const localFileWorkspace: LocalComponentWorkspace = {
+    id: localComponentWorkspaceId(app.workspaceRoot),
+    workspacePath: app.workspaceRoot,
+    componentPaths: app.components,
+    updatedAt: new Date().toISOString(),
+  };
+  return [
+    localFileWorkspace,
+    ...registered.filter((workspace) => workspace.id !== localFileWorkspace.id),
+  ];
+}
+
+export default defineAction({
+  description:
+    "Create or update a React component file in a registered local Content components folder. Use after list-local-component-files identifies the workspaceId.",
+  schema: z.object({
+    workspaceId: z
+      .string()
+      .min(1)
+      .describe("Workspace ID returned by list-local-component-files"),
+    path: z
+      .string()
+      .min(1)
+      .describe("Relative path under the workspace components folder"),
+    content: z.string().describe("Full .tsx/.jsx/.ts/.js source to write"),
+  }),
+  run: async ({ workspaceId, path, content }) => {
+    const file = await writeLocalComponentFile({
+      workspaceId,
+      filePath: path,
+      content,
+      workspaces: await componentWorkspaces(),
+    });
+    await registerLocalComponentWorkspace({
+      workspacePath: file.workspacePath,
+    });
+    return {
+      ok: true,
+      file,
+    };
+  },
+});

--- a/templates/content/actions/write-local-component-file.ts
+++ b/templates/content/actions/write-local-component-file.ts
@@ -5,7 +5,6 @@ import {
   localComponentWorkspaceId,
   localComponentWorkspaceScope,
   readLocalComponentWorkspacesSync,
-  registerLocalComponentWorkspace,
   resolveLocalComponentWorkspacePath,
   type LocalComponentWorkspace,
   writeLocalComponentFile,
@@ -68,19 +67,25 @@ export default defineAction({
       .string()
       .min(1)
       .describe("Relative path under the workspace components folder"),
+    componentRoot: z
+      .string()
+      .optional()
+      .describe(
+        "Optional absolute component root returned by list-local-component-files. Use when writing a new file into a non-default component root.",
+      ),
     content: z.string().describe("Full .tsx/.jsx/.ts/.js source to write"),
   }),
-  run: async ({ workspaceId, path: filePath, content }, context) => {
+  run: async (
+    { workspaceId, path: filePath, componentRoot, content },
+    context,
+  ) => {
     const scope = localComponentWorkspaceScope(context?.userEmail);
     const file = await writeLocalComponentFile({
       workspaceId,
       filePath,
+      componentRoot,
       content,
       workspaces: await componentWorkspaces(scope),
-    });
-    await registerLocalComponentWorkspace({
-      workspacePath: file.workspacePath,
-      scope,
     });
     return {
       ok: true,

--- a/templates/content/app/routes/_app.local-files.tsx
+++ b/templates/content/app/routes/_app.local-files.tsx
@@ -108,6 +108,18 @@ interface ImportContentSourceResult {
   errors: Array<{ path: string; reason: string }>;
 }
 
+interface RegisterLocalComponentWorkspaceResult {
+  ok: true;
+  workspace: {
+    id: string;
+    workspacePath: string;
+    componentPaths: string[];
+  };
+  componentDirs: string[];
+  componentCount: number;
+  reloadRequired: boolean;
+}
+
 type SyncStatus =
   | { kind: "idle" }
   | { kind: "success"; title: string; detail: string }
@@ -358,6 +370,15 @@ async function ensureReadWritePermission(handle: LocalDirectoryHandle) {
   const descriptor = { mode: "readwrite" as const };
   if ((await handle.queryPermission?.(descriptor)) === "granted") return true;
   return (await handle.requestPermission?.(descriptor)) === "granted";
+}
+
+async function hasBrowserComponentsDirectory(handle: LocalDirectoryHandle) {
+  try {
+    await handle.getDirectoryHandle("components");
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function chooseDirectory(
@@ -613,6 +634,9 @@ export default function LocalFilesRoute() {
           detail: `${restoredDirectories.length} linked`,
         });
         await pullDirectories(restoredDirectories, { showToast: false });
+        await connectLocalComponentWorkspaces(restoredDirectories, {
+          showToast: false,
+        });
         return;
       }
 
@@ -626,6 +650,9 @@ export default function LocalFilesRoute() {
         detail: `${restoredDirectories.length} linked`,
       });
       await pullDirectories(restoredDirectories, { showToast: false });
+      await connectLocalComponentWorkspaces(restoredDirectories, {
+        showToast: false,
+      });
     };
     restoreDirectories()
       .catch((err) => {
@@ -727,6 +754,51 @@ export default function LocalFilesRoute() {
     }
   }
 
+  async function connectLocalComponentWorkspaces(
+    selectedDirectories: SelectedDirectory[],
+    { showToast = true }: { showToast?: boolean } = {},
+  ) {
+    for (const directory of selectedDirectories) {
+      if (directory.kind === "desktop") {
+        const workspacePath = directory.folder.path;
+        if (!workspacePath) continue;
+        try {
+          const result =
+            await callAction<RegisterLocalComponentWorkspaceResult>(
+              "register-local-component-workspace" as never,
+              { workspacePath } as never,
+            );
+          if (result.componentCount > 0 && showToast) {
+            toast.success("Local components connected", {
+              description:
+                "Component previews and the slash menu will reload from this folder.",
+            });
+          }
+        } catch (error) {
+          if (showToast) {
+            toast.info("Local files linked", {
+              description:
+                error instanceof Error
+                  ? error.message
+                  : "Component previews need the local dev bridge.",
+            });
+          }
+        }
+        continue;
+      }
+
+      if (
+        showToast &&
+        (await hasBrowserComponentsDirectory(directory.handle))
+      ) {
+        toast.info("MDX files linked", {
+          description:
+            "This browser can edit the files, but React component previews need Agent Native Desktop or a local dev server.",
+        });
+      }
+    }
+  }
+
   async function handleChooseFolder() {
     setBusy("choose");
     try {
@@ -748,6 +820,7 @@ export default function LocalFilesRoute() {
 
       setBusy(`pull:${selected.id}`);
       await pullDirectories(nextDirectories);
+      await connectLocalComponentWorkspaces([selected]);
     } catch (err) {
       setStatus({
         kind: "error",

--- a/templates/content/shared/local-component-workspaces.test.ts
+++ b/templates/content/shared/local-component-workspaces.test.ts
@@ -1,0 +1,157 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  listLocalComponentFiles,
+  registerLocalComponentWorkspace,
+  writeLocalComponentFile,
+} from "./local-component-workspaces";
+
+const tmpRoots: string[] = [];
+
+function mkdtemp(prefix: string) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpRoots.push(root);
+  return root;
+}
+
+function writeFile(root: string, filePath: string, content: string) {
+  const absolutePath = path.join(root, filePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, content, "utf8");
+}
+
+afterEach(() => {
+  for (const root of tmpRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("local component workspaces", () => {
+  it("registers, lists, and writes component files inside a workspace", async () => {
+    const cwd = mkdtemp("an-content-components-cwd-");
+    const workspace = mkdtemp("an-content-components-workspace-");
+    writeFile(
+      workspace,
+      "components/ImpactCounter.tsx",
+      "export function ImpactCounter() { return null; }\n",
+    );
+
+    const registered = await registerLocalComponentWorkspace({
+      cwd,
+      workspacePath: workspace,
+    });
+
+    expect(registered.componentDirs).toEqual([
+      path.join(workspace, "components"),
+    ]);
+
+    await expect(listLocalComponentFiles({ cwd })).resolves.toMatchObject([
+      {
+        workspaceId: registered.workspace.id,
+        path: "ImpactCounter.tsx",
+        absolutePath: path.join(workspace, "components/ImpactCounter.tsx"),
+      },
+    ]);
+
+    await writeLocalComponentFile({
+      cwd,
+      workspaceId: registered.workspace.id,
+      filePath: "Nested/Callout.tsx",
+      content: "export function Callout() { return null; }\n",
+    });
+
+    expect(
+      fs.readFileSync(
+        path.join(workspace, "components/Nested/Callout.tsx"),
+        "utf8",
+      ),
+    ).toContain("Callout");
+  });
+
+  it("honors agent-native.json component paths", async () => {
+    const cwd = mkdtemp("an-content-components-cwd-");
+    const workspace = mkdtemp("an-content-components-workspace-");
+    writeFile(
+      workspace,
+      "agent-native.json",
+      JSON.stringify({
+        apps: { content: { components: ["mdx-blocks"] } },
+      }),
+    );
+    writeFile(
+      workspace,
+      "mdx-blocks/Hero.tsx",
+      "export function Hero() { return null; }\n",
+    );
+
+    const registered = await registerLocalComponentWorkspace({
+      cwd,
+      workspacePath: workspace,
+    });
+
+    expect(registered.workspace.componentPaths).toEqual(["mdx-blocks"]);
+    await expect(listLocalComponentFiles({ cwd })).resolves.toMatchObject([
+      {
+        componentRoot: path.join(workspace, "mdx-blocks"),
+        path: "Hero.tsx",
+      },
+    ]);
+  });
+
+  it("creates the configured component folder when writing the first file", async () => {
+    const cwd = mkdtemp("an-content-components-cwd-");
+    const workspace = mkdtemp("an-content-components-workspace-");
+    const registered = await registerLocalComponentWorkspace({
+      cwd,
+      workspacePath: workspace,
+    });
+
+    await writeLocalComponentFile({
+      cwd,
+      workspaceId: registered.workspace.id,
+      filePath: "FirstBlock.tsx",
+      content: "export function FirstBlock() { return null; }\n",
+    });
+
+    expect(
+      fs.readFileSync(
+        path.join(workspace, "components/FirstBlock.tsx"),
+        "utf8",
+      ),
+    ).toContain("FirstBlock");
+  });
+
+  it("rejects writes that escape or use non-component extensions", async () => {
+    const cwd = mkdtemp("an-content-components-cwd-");
+    const workspace = mkdtemp("an-content-components-workspace-");
+    writeFile(
+      workspace,
+      "components/ImpactCounter.tsx",
+      "export function ImpactCounter() { return null; }\n",
+    );
+    const registered = await registerLocalComponentWorkspace({
+      cwd,
+      workspacePath: workspace,
+    });
+
+    await expect(
+      writeLocalComponentFile({
+        cwd,
+        workspaceId: registered.workspace.id,
+        filePath: "../Escape.tsx",
+        content: "export const x = 1;\n",
+      }),
+    ).rejects.toThrow(/safe relative path/);
+
+    await expect(
+      writeLocalComponentFile({
+        cwd,
+        workspaceId: registered.workspace.id,
+        filePath: "notes.md",
+        content: "# nope\n",
+      }),
+    ).rejects.toThrow(/Component files must be/);
+  });
+});

--- a/templates/content/shared/local-component-workspaces.test.ts
+++ b/templates/content/shared/local-component-workspaces.test.ts
@@ -114,6 +114,97 @@ describe("local component workspaces", () => {
     ]);
   });
 
+  it("does not rewrite the registry when registering the same workspace", async () => {
+    const cwd = mkdtemp("an-content-components-cwd-");
+    const workspace = mkdtemp("an-content-components-workspace-");
+    writeFile(
+      workspace,
+      "components/StableBlock.tsx",
+      "export function StableBlock() { return null; }\n",
+    );
+
+    const first = await registerLocalComponentWorkspace({
+      cwd,
+      workspacePath: workspace,
+      scope: "editor@example.com",
+    });
+    const second = await registerLocalComponentWorkspace({
+      cwd,
+      workspacePath: workspace,
+      scope: "editor@example.com",
+    });
+
+    expect(second.workspace.updatedAt).toBe(first.workspace.updatedAt);
+  });
+
+  it("updates existing files in non-first component roots", async () => {
+    const cwd = mkdtemp("an-content-components-cwd-");
+    const workspace = mkdtemp("an-content-components-workspace-");
+    writeFile(
+      workspace,
+      "agent-native.json",
+      JSON.stringify({
+        apps: { content: { components: ["components", "blocks"] } },
+      }),
+    );
+    writeFile(
+      workspace,
+      "blocks/Hero.tsx",
+      "export function Hero() { return 'old'; }\n",
+    );
+    const registered = await registerLocalComponentWorkspace({
+      cwd,
+      workspacePath: workspace,
+    });
+
+    await writeLocalComponentFile({
+      cwd,
+      workspaceId: registered.workspace.id,
+      filePath: "Hero.tsx",
+      content: "export function Hero() { return 'new'; }\n",
+    });
+
+    expect(fs.existsSync(path.join(workspace, "components/Hero.tsx"))).toBe(
+      false,
+    );
+    expect(
+      fs.readFileSync(path.join(workspace, "blocks/Hero.tsx"), "utf8"),
+    ).toContain("new");
+  });
+
+  it("can create files in a requested non-first component root", async () => {
+    const cwd = mkdtemp("an-content-components-cwd-");
+    const workspace = mkdtemp("an-content-components-workspace-");
+    writeFile(
+      workspace,
+      "agent-native.json",
+      JSON.stringify({
+        apps: { content: { components: ["components", "blocks"] } },
+      }),
+    );
+    fs.mkdirSync(path.join(workspace, "blocks"), { recursive: true });
+    const registered = await registerLocalComponentWorkspace({
+      cwd,
+      workspacePath: workspace,
+    });
+    const realWorkspace = fs.realpathSync(workspace);
+
+    await writeLocalComponentFile({
+      cwd,
+      workspaceId: registered.workspace.id,
+      componentRoot: path.join(realWorkspace, "blocks"),
+      filePath: "NewHero.tsx",
+      content: "export function NewHero() { return null; }\n",
+    });
+
+    expect(fs.existsSync(path.join(workspace, "components/NewHero.tsx"))).toBe(
+      false,
+    );
+    expect(fs.existsSync(path.join(workspace, "blocks/NewHero.tsx"))).toBe(
+      true,
+    );
+  });
+
   it("scopes registered workspaces while aggregating roots for dev previews", async () => {
     const cwd = mkdtemp("an-content-components-cwd-");
     const aliceWorkspace = mkdtemp("an-content-components-alice-");

--- a/templates/content/shared/local-component-workspaces.test.ts
+++ b/templates/content/shared/local-component-workspaces.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   listLocalComponentFiles,
   registerLocalComponentWorkspace,
+  registeredLocalComponentRootsSync,
+  resolveLocalComponentWorkspacePath,
   writeLocalComponentFile,
 } from "./local-component-workspaces";
 
@@ -110,6 +112,56 @@ describe("local component workspaces", () => {
         path: "Hero.tsx",
       },
     ]);
+  });
+
+  it("scopes registered workspaces while aggregating roots for dev previews", async () => {
+    const cwd = mkdtemp("an-content-components-cwd-");
+    const aliceWorkspace = mkdtemp("an-content-components-alice-");
+    const bobWorkspace = mkdtemp("an-content-components-bob-");
+    writeFile(
+      aliceWorkspace,
+      "components/AliceBlock.tsx",
+      "export function AliceBlock() { return null; }\n",
+    );
+    writeFile(
+      bobWorkspace,
+      "components/BobBlock.tsx",
+      "export function BobBlock() { return null; }\n",
+    );
+
+    const alice = await registerLocalComponentWorkspace({
+      cwd,
+      workspacePath: aliceWorkspace,
+      scope: "alice@example.com",
+    });
+    const bob = await registerLocalComponentWorkspace({
+      cwd,
+      workspacePath: bobWorkspace,
+      scope: "bob@example.com",
+    });
+
+    await expect(
+      listLocalComponentFiles({ cwd, scope: "alice@example.com" }),
+    ).resolves.toMatchObject([
+      {
+        workspaceId: alice.workspace.id,
+        path: "AliceBlock.tsx",
+      },
+    ]);
+    await expect(
+      listLocalComponentFiles({ cwd, scope: "bob@example.com" }),
+    ).resolves.toMatchObject([
+      {
+        workspaceId: bob.workspace.id,
+        path: "BobBlock.tsx",
+      },
+    ]);
+    expect(new Set(registeredLocalComponentRootsSync(cwd))).toEqual(
+      new Set([
+        path.join(fs.realpathSync(aliceWorkspace), "components"),
+        path.join(fs.realpathSync(bobWorkspace), "components"),
+      ]),
+    );
   });
 
   it("creates the configured component folder when writing the first file", async () => {
@@ -219,5 +271,20 @@ describe("local component workspaces", () => {
         content: "# nope\n",
       }),
     ).rejects.toThrow(/Component files must be/);
+  });
+
+  it("canonicalizes symlinked local file workspaces", async () => {
+    const realWorkspace = mkdtemp("an-content-components-real-");
+    const symlinkWorkspace = path.join(
+      mkdtemp("an-content-components-links-"),
+      "workspace",
+    );
+    if (!symlinkDirectory(realWorkspace, symlinkWorkspace)) {
+      return;
+    }
+
+    expect(resolveLocalComponentWorkspacePath(symlinkWorkspace)).toBe(
+      fs.realpathSync(realWorkspace),
+    );
   });
 });

--- a/templates/content/shared/local-component-workspaces.test.ts
+++ b/templates/content/shared/local-component-workspaces.test.ts
@@ -164,6 +164,41 @@ describe("local component workspaces", () => {
     );
   });
 
+  it("preserves concurrent workspace registrations in the same scope", async () => {
+    const cwd = mkdtemp("an-content-components-cwd-");
+    const workspaces = ["AlphaBlock", "BetaBlock", "GammaBlock"].map(
+      (componentName) => {
+        const workspace = mkdtemp("an-content-components-concurrent-");
+        writeFile(
+          workspace,
+          `components/${componentName}.tsx`,
+          `export function ${componentName}() { return null; }\n`,
+        );
+        return workspace;
+      },
+    );
+
+    await Promise.all(
+      workspaces.map((workspacePath) =>
+        registerLocalComponentWorkspace({
+          cwd,
+          workspacePath,
+          scope: "editor@example.com",
+        }),
+      ),
+    );
+
+    await expect(
+      listLocalComponentFiles({ cwd, scope: "editor@example.com" }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "AlphaBlock.tsx" }),
+        expect.objectContaining({ path: "BetaBlock.tsx" }),
+        expect.objectContaining({ path: "GammaBlock.tsx" }),
+      ]),
+    );
+  });
+
   it("creates the configured component folder when writing the first file", async () => {
     const cwd = mkdtemp("an-content-components-cwd-");
     const workspace = mkdtemp("an-content-components-workspace-");

--- a/templates/content/shared/local-component-workspaces.test.ts
+++ b/templates/content/shared/local-component-workspaces.test.ts
@@ -22,6 +22,16 @@ function writeFile(root: string, filePath: string, content: string) {
   fs.writeFileSync(absolutePath, content, "utf8");
 }
 
+function symlinkDirectory(target: string, linkPath: string) {
+  try {
+    fs.symlinkSync(target, linkPath, "dir");
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EPERM") return false;
+    throw error;
+  }
+}
+
 afterEach(() => {
   for (const root of tmpRoots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
@@ -42,16 +52,17 @@ describe("local component workspaces", () => {
       cwd,
       workspacePath: workspace,
     });
+    const realWorkspace = fs.realpathSync(workspace);
 
     expect(registered.componentDirs).toEqual([
-      path.join(workspace, "components"),
+      path.join(realWorkspace, "components"),
     ]);
 
     await expect(listLocalComponentFiles({ cwd })).resolves.toMatchObject([
       {
         workspaceId: registered.workspace.id,
         path: "ImpactCounter.tsx",
-        absolutePath: path.join(workspace, "components/ImpactCounter.tsx"),
+        absolutePath: path.join(realWorkspace, "components/ImpactCounter.tsx"),
       },
     ]);
 
@@ -90,11 +101,12 @@ describe("local component workspaces", () => {
       cwd,
       workspacePath: workspace,
     });
+    const realWorkspace = fs.realpathSync(workspace);
 
     expect(registered.workspace.componentPaths).toEqual(["mdx-blocks"]);
     await expect(listLocalComponentFiles({ cwd })).resolves.toMatchObject([
       {
-        componentRoot: path.join(workspace, "mdx-blocks"),
+        componentRoot: path.join(realWorkspace, "mdx-blocks"),
         path: "Hero.tsx",
       },
     ]);
@@ -121,6 +133,60 @@ describe("local component workspaces", () => {
         "utf8",
       ),
     ).toContain("FirstBlock");
+  });
+
+  it("rejects writes through symlinked parent directories", async () => {
+    const cwd = mkdtemp("an-content-components-cwd-");
+    const workspace = mkdtemp("an-content-components-workspace-");
+    const outside = mkdtemp("an-content-components-outside-");
+    fs.mkdirSync(path.join(workspace, "components"), { recursive: true });
+    if (
+      !symlinkDirectory(outside, path.join(workspace, "components/Redirected"))
+    ) {
+      return;
+    }
+    const registered = await registerLocalComponentWorkspace({
+      cwd,
+      workspacePath: workspace,
+    });
+
+    await expect(
+      writeLocalComponentFile({
+        cwd,
+        workspaceId: registered.workspace.id,
+        filePath: "Redirected/Escape.tsx",
+        content: "export function Escape() { return null; }\n",
+      }),
+    ).rejects.toThrow(/symlinks/);
+    expect(fs.existsSync(path.join(outside, "Escape.tsx"))).toBe(false);
+  });
+
+  it("does not expose symlinked configured component roots", async () => {
+    const cwd = mkdtemp("an-content-components-cwd-");
+    const workspace = mkdtemp("an-content-components-workspace-");
+    const outside = mkdtemp("an-content-components-outside-");
+    writeFile(
+      workspace,
+      "agent-native.json",
+      JSON.stringify({
+        apps: { content: { components: ["linked-components"] } },
+      }),
+    );
+    writeFile(
+      outside,
+      "OutsideBlock.tsx",
+      "export function OutsideBlock() { return null; }\n",
+    );
+    if (!symlinkDirectory(outside, path.join(workspace, "linked-components"))) {
+      return;
+    }
+    const registered = await registerLocalComponentWorkspace({
+      cwd,
+      workspacePath: workspace,
+    });
+
+    expect(registered.componentDirs).toEqual([]);
+    await expect(listLocalComponentFiles({ cwd })).resolves.toEqual([]);
   });
 
   it("rejects writes that escape or use non-component extensions", async () => {

--- a/templates/content/shared/local-component-workspaces.ts
+++ b/templates/content/shared/local-component-workspaces.ts
@@ -21,10 +21,10 @@ export interface LocalComponentFile {
 }
 
 const STORE_VERSION = 1;
-const STORE_RELATIVE_PATH = path.join(
-  ".agent-native",
-  "content-local-components.json",
-);
+const STORE_DIRECTORY = ".agent-native";
+const STORE_FILE_PREFIX = "content-local-components";
+const STORE_FILE_EXTENSION = ".json";
+const STORE_FILE_NAME = `${STORE_FILE_PREFIX}${STORE_FILE_EXTENSION}`;
 const COMPONENT_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
 const COMPONENT_FILE_MAX_BYTES = 512 * 1024;
 const ALLOW_PRODUCTION_LOCAL_FILES_ENV =
@@ -62,8 +62,41 @@ export function isLocalComponentAccessError(error: unknown) {
   );
 }
 
-export function localComponentWorkspaceStorePath(cwd = process.cwd()) {
-  return path.join(cwd, STORE_RELATIVE_PATH);
+function scopedStoreFileName(scope?: string | null) {
+  const normalizedScope = scope?.trim().toLowerCase();
+  if (!normalizedScope) return STORE_FILE_NAME;
+  const scopeHash = createHash("sha256")
+    .update(normalizedScope)
+    .digest("base64url")
+    .slice(0, 16);
+  return `${STORE_FILE_PREFIX}.${scopeHash}${STORE_FILE_EXTENSION}`;
+}
+
+export function localComponentWorkspaceScope(userEmail?: string | null) {
+  return userEmail?.trim().toLowerCase() || "local";
+}
+
+export function localComponentWorkspaceStoreDir(cwd = process.cwd()) {
+  return path.join(cwd, STORE_DIRECTORY);
+}
+
+export function localComponentWorkspaceStorePath(
+  cwd = process.cwd(),
+  scope?: string | null,
+) {
+  return path.join(
+    localComponentWorkspaceStoreDir(cwd),
+    scopedStoreFileName(scope),
+  );
+}
+
+export function isLocalComponentWorkspaceStoreFile(filePath: string) {
+  const basename = path.basename(filePath);
+  return (
+    basename === STORE_FILE_NAME ||
+    (basename.startsWith(`${STORE_FILE_PREFIX}.`) &&
+      basename.endsWith(STORE_FILE_EXTENSION))
+  );
 }
 
 function safeRelativePath(value: string, label: string) {
@@ -109,6 +142,15 @@ function resolveUsableDirectory(value: string, label: string) {
   const stat = fs.lstatSync(resolved);
   if (stat.isSymbolicLink() || !stat.isDirectory()) {
     throw new Error(`${label} must be an existing non-symlink directory.`);
+  }
+  return fs.realpathSync(resolved);
+}
+
+export function resolveLocalComponentWorkspacePath(workspacePath: string) {
+  const resolved = path.resolve(workspacePath);
+  const stat = fs.statSync(resolved);
+  if (!stat.isDirectory()) {
+    throw new Error("Workspace must be an existing directory.");
   }
   return fs.realpathSync(resolved);
 }
@@ -178,9 +220,16 @@ function normalizeStoredWorkspace(
 
 export function readLocalComponentWorkspacesSync(
   cwd = process.cwd(),
+  scope?: string | null,
 ): LocalComponentWorkspace[] {
   ensureLocalFileAccessAllowed();
-  const storePath = localComponentWorkspaceStorePath(cwd);
+  const storePath = localComponentWorkspaceStorePath(cwd, scope);
+  return readLocalComponentWorkspacesFromStorePath(storePath);
+}
+
+function readLocalComponentWorkspacesFromStorePath(
+  storePath: string,
+): LocalComponentWorkspace[] {
   let raw: unknown;
   try {
     raw = JSON.parse(fs.readFileSync(storePath, "utf8"));
@@ -194,12 +243,32 @@ export function readLocalComponentWorkspacesSync(
     .filter((item): item is LocalComponentWorkspace => Boolean(item));
 }
 
+export function readAllLocalComponentWorkspacesSync(cwd = process.cwd()) {
+  ensureLocalFileAccessAllowed();
+  const storeDir = localComponentWorkspaceStoreDir(cwd);
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(storeDir);
+  } catch {
+    return [];
+  }
+  const workspaces = entries
+    .filter((entry) => isLocalComponentWorkspaceStoreFile(entry))
+    .flatMap((entry) =>
+      readLocalComponentWorkspacesFromStorePath(path.join(storeDir, entry)),
+    );
+  const deduped = new Map<string, LocalComponentWorkspace>();
+  for (const workspace of workspaces) deduped.set(workspace.id, workspace);
+  return [...deduped.values()];
+}
+
 async function writeLocalComponentWorkspaces(
   workspaces: LocalComponentWorkspace[],
   cwd = process.cwd(),
+  scope?: string | null,
 ) {
   ensureLocalFileAccessAllowed();
-  const storePath = localComponentWorkspaceStorePath(cwd);
+  const storePath = localComponentWorkspaceStorePath(cwd, scope);
   await fsp.mkdir(path.dirname(storePath), { recursive: true });
   await fsp.writeFile(
     storePath,
@@ -211,6 +280,7 @@ async function writeLocalComponentWorkspaces(
 export async function registerLocalComponentWorkspace(options: {
   workspacePath: string;
   cwd?: string;
+  scope?: string | null;
 }): Promise<{
   workspace: LocalComponentWorkspace;
   componentDirs: string[];
@@ -227,12 +297,12 @@ export async function registerLocalComponentWorkspace(options: {
     componentPaths,
     updatedAt: new Date().toISOString(),
   };
-  const current = readLocalComponentWorkspacesSync(options.cwd);
+  const current = readLocalComponentWorkspacesSync(options.cwd, options.scope);
   const next = [
     workspace,
     ...current.filter((item) => item.id !== workspace.id),
   ];
-  await writeLocalComponentWorkspaces(next, options.cwd);
+  await writeLocalComponentWorkspaces(next, options.cwd, options.scope);
   return {
     workspace,
     componentDirs: componentDirsForWorkspace(workspace),
@@ -364,13 +434,13 @@ async function ensureSafeDirectoryPath(root: string, directory: string) {
 }
 
 export function registeredLocalComponentDirsSync(cwd = process.cwd()) {
-  return readLocalComponentWorkspacesSync(cwd).flatMap(
+  return readAllLocalComponentWorkspacesSync(cwd).flatMap(
     componentDirsForWorkspace,
   );
 }
 
 export function registeredLocalComponentRootsSync(cwd = process.cwd()) {
-  return readLocalComponentWorkspacesSync(cwd).flatMap(
+  return readAllLocalComponentWorkspacesSync(cwd).flatMap(
     componentRootsForWorkspace,
   );
 }
@@ -378,12 +448,14 @@ export function registeredLocalComponentRootsSync(cwd = process.cwd()) {
 export async function listLocalComponentFiles(
   options: {
     cwd?: string;
+    scope?: string | null;
     workspaces?: LocalComponentWorkspace[];
   } = {},
 ): Promise<LocalComponentFile[]> {
   ensureLocalFileAccessAllowed();
   const workspaces =
-    options.workspaces ?? readLocalComponentWorkspacesSync(options.cwd);
+    options.workspaces ??
+    readLocalComponentWorkspacesSync(options.cwd, options.scope);
   const files: LocalComponentFile[] = [];
   for (const workspace of workspaces) {
     for (const componentRoot of componentDirsForWorkspace(workspace)) {
@@ -452,6 +524,7 @@ export async function writeLocalComponentFile(options: {
   filePath: string;
   content: string;
   cwd?: string;
+  scope?: string | null;
   workspaces?: LocalComponentWorkspace[];
 }) {
   ensureLocalFileAccessAllowed();
@@ -459,7 +532,8 @@ export async function writeLocalComponentFile(options: {
     throw new Error("Component file content is larger than 512 KB.");
   }
   const workspaces =
-    options.workspaces ?? readLocalComponentWorkspacesSync(options.cwd);
+    options.workspaces ??
+    readLocalComponentWorkspacesSync(options.cwd, options.scope);
   const workspace = workspaces.find((item) => item.id === options.workspaceId);
   if (!workspace) throw new Error("Registered component workspace not found.");
   const componentRoot =

--- a/templates/content/shared/local-component-workspaces.ts
+++ b/templates/content/shared/local-component-workspaces.ts
@@ -41,6 +41,13 @@ function normalizeSlash(value: string) {
   return value.replace(/\\/g, "/");
 }
 
+function stringArraysEqual(left: string[], right: string[]) {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
 export function localComponentWorkspaceId(workspacePath: string) {
   return `workspace-${createHash("sha256")
     .update(path.resolve(workspacePath))
@@ -278,7 +285,9 @@ async function writeLocalComponentWorkspacesToStorePath(
 async function updateLocalComponentWorkspaces(options: {
   cwd?: string;
   scope?: string | null;
-  update: (workspaces: LocalComponentWorkspace[]) => LocalComponentWorkspace[];
+  update: (
+    workspaces: LocalComponentWorkspace[],
+  ) => LocalComponentWorkspace[] | null;
 }) {
   ensureLocalFileAccessAllowed();
   const storePath = localComponentWorkspaceStorePath(
@@ -290,7 +299,12 @@ async function updateLocalComponentWorkspaces(options: {
   let nextWorkspaces: LocalComponentWorkspace[] = [];
   const queued = previous.then(async () => {
     const current = readLocalComponentWorkspacesFromStorePath(storePath);
-    nextWorkspaces = options.update(current);
+    const updated = options.update(current);
+    if (!updated) {
+      nextWorkspaces = current;
+      return;
+    }
+    nextWorkspaces = updated;
     await writeLocalComponentWorkspacesToStorePath(nextWorkspaces, storePath);
   });
   const stored = queued
@@ -325,17 +339,26 @@ export async function registerLocalComponentWorkspace(options: {
     componentPaths,
     updatedAt: new Date().toISOString(),
   };
+  let registeredWorkspace = workspace;
   await updateLocalComponentWorkspaces({
     cwd: options.cwd,
     scope: options.scope,
-    update: (current) => [
-      workspace,
-      ...current.filter((item) => item.id !== workspace.id),
-    ],
+    update: (current) => {
+      const existing = current.find((item) => item.id === workspace.id);
+      if (
+        existing &&
+        existing.workspacePath === workspace.workspacePath &&
+        stringArraysEqual(existing.componentPaths, workspace.componentPaths)
+      ) {
+        registeredWorkspace = existing;
+        return null;
+      }
+      return [workspace, ...current.filter((item) => item.id !== workspace.id)];
+    },
   });
   return {
-    workspace,
-    componentDirs: componentDirsForWorkspace(workspace),
+    workspace: registeredWorkspace,
+    componentDirs: componentDirsForWorkspace(registeredWorkspace),
   };
 }
 
@@ -367,6 +390,39 @@ function firstComponentRootForWorkspace(workspace: LocalComponentWorkspace) {
     throw new Error("Registered workspace does not have a component root.");
   }
   return componentRoot;
+}
+
+function componentRootForWrite(
+  workspace: LocalComponentWorkspace,
+  filePath: string,
+  requestedComponentRoot?: string | null,
+) {
+  const componentRoots = componentRootsForWorkspace(workspace);
+  if (requestedComponentRoot?.trim()) {
+    const resolvedRequestedRoot = path.resolve(requestedComponentRoot);
+    const matchingRoot = componentRoots.find(
+      (componentRoot) => path.resolve(componentRoot) === resolvedRequestedRoot,
+    );
+    if (!matchingRoot) {
+      throw new Error("Target component root is not registered for workspace.");
+    }
+    return matchingRoot;
+  }
+
+  for (const componentRoot of componentRoots) {
+    const absolutePath = resolveInside(componentRoot, filePath);
+    try {
+      const stat = fs.lstatSync(absolutePath);
+      if (stat.isFile() && !stat.isSymbolicLink()) return componentRoot;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+
+  return (
+    componentDirsForWorkspace(workspace)[0] ??
+    firstComponentRootForWorkspace(workspace)
+  );
 }
 
 function safeComponentRootForWorkspace(
@@ -552,6 +608,7 @@ async function collectComponentFiles(
 export async function writeLocalComponentFile(options: {
   workspaceId: string;
   filePath: string;
+  componentRoot?: string | null;
   content: string;
   cwd?: string;
   scope?: string | null;
@@ -566,10 +623,12 @@ export async function writeLocalComponentFile(options: {
     readLocalComponentWorkspacesSync(options.cwd, options.scope);
   const workspace = workspaces.find((item) => item.id === options.workspaceId);
   if (!workspace) throw new Error("Registered component workspace not found.");
-  const componentRoot =
-    componentDirsForWorkspace(workspace)[0] ??
-    firstComponentRootForWorkspace(workspace);
   const filePath = safeComponentFilePath(options.filePath);
+  const componentRoot = componentRootForWrite(
+    workspace,
+    filePath,
+    options.componentRoot,
+  );
   const absolutePath = resolveInside(componentRoot, filePath);
   await ensureSafeDirectoryPath(workspace.workspacePath, componentRoot);
   await ensureSafeDirectoryPath(componentRoot, path.dirname(absolutePath));

--- a/templates/content/shared/local-component-workspaces.ts
+++ b/templates/content/shared/local-component-workspaces.ts
@@ -31,6 +31,7 @@ const ALLOW_PRODUCTION_LOCAL_FILES_ENV =
   "AGENT_NATIVE_ALLOW_LOCAL_FILES_IN_PRODUCTION";
 const LOCAL_COMPONENT_ACCESS_ERROR =
   "Local component workspaces are only available in local development or a trusted local file bridge.";
+const localComponentWorkspaceWriteQueues = new Map<string, Promise<void>>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -262,19 +263,46 @@ export function readAllLocalComponentWorkspacesSync(cwd = process.cwd()) {
   return [...deduped.values()];
 }
 
-async function writeLocalComponentWorkspaces(
+async function writeLocalComponentWorkspacesToStorePath(
   workspaces: LocalComponentWorkspace[],
-  cwd = process.cwd(),
-  scope?: string | null,
+  storePath: string,
 ) {
-  ensureLocalFileAccessAllowed();
-  const storePath = localComponentWorkspaceStorePath(cwd, scope);
   await fsp.mkdir(path.dirname(storePath), { recursive: true });
   await fsp.writeFile(
     storePath,
     `${JSON.stringify({ version: STORE_VERSION, workspaces }, null, 2)}\n`,
     "utf8",
   );
+}
+
+async function updateLocalComponentWorkspaces(options: {
+  cwd?: string;
+  scope?: string | null;
+  update: (workspaces: LocalComponentWorkspace[]) => LocalComponentWorkspace[];
+}) {
+  ensureLocalFileAccessAllowed();
+  const storePath = localComponentWorkspaceStorePath(
+    options.cwd,
+    options.scope,
+  );
+  const previous =
+    localComponentWorkspaceWriteQueues.get(storePath) ?? Promise.resolve();
+  let nextWorkspaces: LocalComponentWorkspace[] = [];
+  const queued = previous.then(async () => {
+    const current = readLocalComponentWorkspacesFromStorePath(storePath);
+    nextWorkspaces = options.update(current);
+    await writeLocalComponentWorkspacesToStorePath(nextWorkspaces, storePath);
+  });
+  const stored = queued
+    .catch(() => undefined)
+    .finally(() => {
+      if (localComponentWorkspaceWriteQueues.get(storePath) === stored) {
+        localComponentWorkspaceWriteQueues.delete(storePath);
+      }
+    });
+  localComponentWorkspaceWriteQueues.set(storePath, stored);
+  await queued;
+  return nextWorkspaces;
 }
 
 export async function registerLocalComponentWorkspace(options: {
@@ -297,12 +325,14 @@ export async function registerLocalComponentWorkspace(options: {
     componentPaths,
     updatedAt: new Date().toISOString(),
   };
-  const current = readLocalComponentWorkspacesSync(options.cwd, options.scope);
-  const next = [
-    workspace,
-    ...current.filter((item) => item.id !== workspace.id),
-  ];
-  await writeLocalComponentWorkspaces(next, options.cwd, options.scope);
+  await updateLocalComponentWorkspaces({
+    cwd: options.cwd,
+    scope: options.scope,
+    update: (current) => [
+      workspace,
+      ...current.filter((item) => item.id !== workspace.id),
+    ],
+  });
   return {
     workspace,
     componentDirs: componentDirsForWorkspace(workspace),

--- a/templates/content/shared/local-component-workspaces.ts
+++ b/templates/content/shared/local-component-workspaces.ts
@@ -1,0 +1,389 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { createHash } from "node:crypto";
+
+export interface LocalComponentWorkspace {
+  id: string;
+  workspacePath: string;
+  componentPaths: string[];
+  updatedAt: string;
+}
+
+export interface LocalComponentFile {
+  workspaceId: string;
+  workspacePath: string;
+  componentRoot: string;
+  path: string;
+  absolutePath: string;
+  sizeBytes: number;
+  updatedAt: string;
+}
+
+const STORE_VERSION = 1;
+const STORE_RELATIVE_PATH = path.join(
+  ".agent-native",
+  "content-local-components.json",
+);
+const COMPONENT_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
+const COMPONENT_FILE_MAX_BYTES = 512 * 1024;
+const ALLOW_PRODUCTION_LOCAL_FILES_ENV =
+  "AGENT_NATIVE_ALLOW_LOCAL_FILES_IN_PRODUCTION";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeSlash(value: string) {
+  return value.replace(/\\/g, "/");
+}
+
+export function localComponentWorkspaceId(workspacePath: string) {
+  return `workspace-${createHash("sha256")
+    .update(path.resolve(workspacePath))
+    .digest("base64url")
+    .slice(0, 24)}`;
+}
+
+function ensureLocalFileAccessAllowed() {
+  if (
+    process.env.NODE_ENV === "production" &&
+    process.env[ALLOW_PRODUCTION_LOCAL_FILES_ENV] !== "true"
+  ) {
+    throw new Error(
+      "Local component workspaces are only available in local development or a trusted local file bridge.",
+    );
+  }
+}
+
+export function localComponentWorkspaceStorePath(cwd = process.cwd()) {
+  return path.join(cwd, STORE_RELATIVE_PATH);
+}
+
+function safeRelativePath(value: string, label: string) {
+  const normalized = normalizeSlash(
+    path.posix.normalize(normalizeSlash(value)),
+  );
+  if (
+    !normalized ||
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.includes("\0") ||
+    normalized.split("/").some((part) => !part || part === "." || part === "..")
+  ) {
+    throw new Error(`${label} must be a safe relative path.`);
+  }
+  return normalized;
+}
+
+function safeComponentFilePath(value: string) {
+  const normalized = safeRelativePath(value, "Component file path");
+  if (!COMPONENT_EXTENSIONS.has(path.posix.extname(normalized).toLowerCase())) {
+    throw new Error("Component files must be .tsx, .jsx, .ts, or .js.");
+  }
+  return normalized;
+}
+
+function resolveInside(root: string, candidate: string) {
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, candidate);
+  const relative = path.relative(resolvedRoot, resolved);
+  if (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  ) {
+    return resolved;
+  }
+  throw new Error("Path escaped the registered component workspace.");
+}
+
+function resolveUsableDirectory(value: string, label: string) {
+  const resolved = path.resolve(value);
+  const stat = fs.lstatSync(resolved);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`${label} must be an existing non-symlink directory.`);
+  }
+  return resolved;
+}
+
+function componentPathsFromManifest(workspacePath: string) {
+  const manifestPath = path.join(workspacePath, "agent-native.json");
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch {
+    return ["components"];
+  }
+
+  const app = isRecord(manifest)
+    ? isRecord(manifest.apps)
+      ? manifest.apps.content
+      : undefined
+    : undefined;
+  const components = isRecord(app) ? app.components : undefined;
+  const values =
+    typeof components === "string"
+      ? [components]
+      : Array.isArray(components)
+        ? components.filter((item): item is string => typeof item === "string")
+        : ["components"];
+  return values.length > 0
+    ? values.map((item) => safeRelativePath(item, "components path"))
+    : ["components"];
+}
+
+function normalizeStoredWorkspace(
+  value: unknown,
+): LocalComponentWorkspace | null {
+  if (!isRecord(value)) return null;
+  const workspacePath =
+    typeof value.workspacePath === "string" ? value.workspacePath : "";
+  if (!workspacePath) return null;
+  let resolvedWorkspace: string;
+  try {
+    resolvedWorkspace = resolveUsableDirectory(workspacePath, "Workspace");
+  } catch {
+    return null;
+  }
+
+  const storedComponentPaths = Array.isArray(value.componentPaths)
+    ? value.componentPaths
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => safeRelativePath(item, "components path"))
+    : [];
+  const componentPaths =
+    storedComponentPaths.length > 0
+      ? storedComponentPaths
+      : componentPathsFromManifest(resolvedWorkspace);
+  return {
+    id:
+      typeof value.id === "string" && value.id
+        ? value.id
+        : localComponentWorkspaceId(resolvedWorkspace),
+    workspacePath: resolvedWorkspace,
+    componentPaths,
+    updatedAt:
+      typeof value.updatedAt === "string"
+        ? value.updatedAt
+        : new Date().toISOString(),
+  };
+}
+
+export function readLocalComponentWorkspacesSync(
+  cwd = process.cwd(),
+): LocalComponentWorkspace[] {
+  ensureLocalFileAccessAllowed();
+  const storePath = localComponentWorkspaceStorePath(cwd);
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(storePath, "utf8"));
+  } catch {
+    return [];
+  }
+  const workspaces =
+    isRecord(raw) && Array.isArray(raw.workspaces) ? raw.workspaces : [];
+  return workspaces
+    .map(normalizeStoredWorkspace)
+    .filter((item): item is LocalComponentWorkspace => Boolean(item));
+}
+
+async function writeLocalComponentWorkspaces(
+  workspaces: LocalComponentWorkspace[],
+  cwd = process.cwd(),
+) {
+  ensureLocalFileAccessAllowed();
+  const storePath = localComponentWorkspaceStorePath(cwd);
+  await fsp.mkdir(path.dirname(storePath), { recursive: true });
+  await fsp.writeFile(
+    storePath,
+    `${JSON.stringify({ version: STORE_VERSION, workspaces }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+export async function registerLocalComponentWorkspace(options: {
+  workspacePath: string;
+  cwd?: string;
+}): Promise<{
+  workspace: LocalComponentWorkspace;
+  componentDirs: string[];
+}> {
+  ensureLocalFileAccessAllowed();
+  const workspacePath = resolveUsableDirectory(
+    options.workspacePath,
+    "Workspace",
+  );
+  const componentPaths = componentPathsFromManifest(workspacePath);
+  const workspace: LocalComponentWorkspace = {
+    id: localComponentWorkspaceId(workspacePath),
+    workspacePath,
+    componentPaths,
+    updatedAt: new Date().toISOString(),
+  };
+  const current = readLocalComponentWorkspacesSync(options.cwd);
+  const next = [
+    workspace,
+    ...current.filter((item) => item.id !== workspace.id),
+  ];
+  await writeLocalComponentWorkspaces(next, options.cwd);
+  return {
+    workspace,
+    componentDirs: componentDirsForWorkspace(workspace),
+  };
+}
+
+export function componentRootsForWorkspace(workspace: LocalComponentWorkspace) {
+  return workspace.componentPaths
+    .map((componentPath) =>
+      resolveInside(workspace.workspacePath, componentPath),
+    )
+    .map((componentRoot) => path.resolve(componentRoot));
+}
+
+export function componentDirsForWorkspace(workspace: LocalComponentWorkspace) {
+  return componentRootsForWorkspace(workspace).filter((componentDir) => {
+    try {
+      const stat = fs.lstatSync(componentDir);
+      return !stat.isSymbolicLink() && stat.isDirectory();
+    } catch {
+      return false;
+    }
+  });
+}
+
+function firstComponentRootForWorkspace(workspace: LocalComponentWorkspace) {
+  const componentRoot = componentRootsForWorkspace(workspace)[0];
+  if (!componentRoot) {
+    throw new Error("Registered workspace does not have a component root.");
+  }
+  return componentRoot;
+}
+
+export function registeredLocalComponentDirsSync(cwd = process.cwd()) {
+  return readLocalComponentWorkspacesSync(cwd).flatMap(
+    componentDirsForWorkspace,
+  );
+}
+
+export function registeredLocalComponentRootsSync(cwd = process.cwd()) {
+  return readLocalComponentWorkspacesSync(cwd).flatMap(
+    componentRootsForWorkspace,
+  );
+}
+
+export async function listLocalComponentFiles(
+  options: {
+    cwd?: string;
+    workspaces?: LocalComponentWorkspace[];
+  } = {},
+): Promise<LocalComponentFile[]> {
+  ensureLocalFileAccessAllowed();
+  const workspaces =
+    options.workspaces ?? readLocalComponentWorkspacesSync(options.cwd);
+  const files: LocalComponentFile[] = [];
+  for (const workspace of workspaces) {
+    for (const componentRoot of componentDirsForWorkspace(workspace)) {
+      await collectComponentFiles(
+        workspace,
+        componentRoot,
+        componentRoot,
+        files,
+      );
+    }
+  }
+  return files.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+async function collectComponentFiles(
+  workspace: LocalComponentWorkspace,
+  componentRoot: string,
+  directory: string,
+  files: LocalComponentFile[],
+  prefix = "",
+) {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fsp.readdir(directory, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".") || entry.isSymbolicLink()) continue;
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    const absolutePath = resolveInside(componentRoot, relativePath);
+    if (entry.isDirectory()) {
+      if (["node_modules", "dist", "build"].includes(entry.name)) continue;
+      await collectComponentFiles(
+        workspace,
+        componentRoot,
+        absolutePath,
+        files,
+        relativePath,
+      );
+      continue;
+    }
+    if (
+      !entry.isFile() ||
+      !COMPONENT_EXTENSIONS.has(path.extname(entry.name).toLowerCase())
+    ) {
+      continue;
+    }
+    const stat = await fsp.stat(absolutePath);
+    if (stat.size > COMPONENT_FILE_MAX_BYTES) continue;
+    files.push({
+      workspaceId: workspace.id,
+      workspacePath: workspace.workspacePath,
+      componentRoot,
+      path: relativePath,
+      absolutePath,
+      sizeBytes: stat.size,
+      updatedAt: stat.mtime.toISOString(),
+    });
+  }
+}
+
+export async function writeLocalComponentFile(options: {
+  workspaceId: string;
+  filePath: string;
+  content: string;
+  cwd?: string;
+  workspaces?: LocalComponentWorkspace[];
+}) {
+  ensureLocalFileAccessAllowed();
+  if (Buffer.byteLength(options.content, "utf8") > COMPONENT_FILE_MAX_BYTES) {
+    throw new Error("Component file content is larger than 512 KB.");
+  }
+  const workspaces =
+    options.workspaces ?? readLocalComponentWorkspacesSync(options.cwd);
+  const workspace = workspaces.find((item) => item.id === options.workspaceId);
+  if (!workspace) throw new Error("Registered component workspace not found.");
+  const componentRoot =
+    componentDirsForWorkspace(workspace)[0] ??
+    firstComponentRootForWorkspace(workspace);
+  await fsp.mkdir(componentRoot, { recursive: true });
+  const rootStat = await fsp.lstat(componentRoot);
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+    throw new Error("Component root must be a non-symlink directory.");
+  }
+  const filePath = safeComponentFilePath(options.filePath);
+  const absolutePath = resolveInside(componentRoot, filePath);
+  await fsp.mkdir(path.dirname(absolutePath), { recursive: true });
+  try {
+    const stat = await fsp.lstat(absolutePath);
+    if (stat.isSymbolicLink()) {
+      throw new Error("Cannot write through symlinked component files.");
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  await fsp.writeFile(absolutePath, options.content, "utf8");
+  return {
+    workspaceId: workspace.id,
+    workspacePath: workspace.workspacePath,
+    componentRoot,
+    path: filePath,
+    absolutePath,
+  };
+}

--- a/templates/content/shared/local-component-workspaces.ts
+++ b/templates/content/shared/local-component-workspaces.ts
@@ -29,6 +29,8 @@ const COMPONENT_EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
 const COMPONENT_FILE_MAX_BYTES = 512 * 1024;
 const ALLOW_PRODUCTION_LOCAL_FILES_ENV =
   "AGENT_NATIVE_ALLOW_LOCAL_FILES_IN_PRODUCTION";
+const LOCAL_COMPONENT_ACCESS_ERROR =
+  "Local component workspaces are only available in local development or a trusted local file bridge.";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -50,10 +52,14 @@ function ensureLocalFileAccessAllowed() {
     process.env.NODE_ENV === "production" &&
     process.env[ALLOW_PRODUCTION_LOCAL_FILES_ENV] !== "true"
   ) {
-    throw new Error(
-      "Local component workspaces are only available in local development or a trusted local file bridge.",
-    );
+    throw new Error(LOCAL_COMPONENT_ACCESS_ERROR);
   }
+}
+
+export function isLocalComponentAccessError(error: unknown) {
+  return (
+    error instanceof Error && error.message === LOCAL_COMPONENT_ACCESS_ERROR
+  );
 }
 
 export function localComponentWorkspaceStorePath(cwd = process.cwd()) {
@@ -104,7 +110,7 @@ function resolveUsableDirectory(value: string, label: string) {
   if (stat.isSymbolicLink() || !stat.isDirectory()) {
     throw new Error(`${label} must be an existing non-symlink directory.`);
   }
-  return resolved;
+  return fs.realpathSync(resolved);
 }
 
 function componentPathsFromManifest(workspacePath: string) {
@@ -238,7 +244,10 @@ export function componentRootsForWorkspace(workspace: LocalComponentWorkspace) {
     .map((componentPath) =>
       resolveInside(workspace.workspacePath, componentPath),
     )
-    .map((componentRoot) => path.resolve(componentRoot));
+    .map((componentRoot) =>
+      safeComponentRootForWorkspace(workspace.workspacePath, componentRoot),
+    )
+    .filter((componentRoot): componentRoot is string => Boolean(componentRoot));
 }
 
 export function componentDirsForWorkspace(workspace: LocalComponentWorkspace) {
@@ -258,6 +267,94 @@ function firstComponentRootForWorkspace(workspace: LocalComponentWorkspace) {
     throw new Error("Registered workspace does not have a component root.");
   }
   return componentRoot;
+}
+
+function safeComponentRootForWorkspace(
+  workspacePath: string,
+  componentRoot: string,
+) {
+  const resolvedRoot = resolveInside(workspacePath, ".");
+  const resolvedComponentRoot = resolveInside(resolvedRoot, componentRoot);
+  try {
+    return validateSafeDirectoryPathSync(resolvedRoot, resolvedComponentRoot, {
+      allowMissing: true,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function validateSafeDirectoryPathSync(
+  root: string,
+  directory: string,
+  { allowMissing = false }: { allowMissing?: boolean } = {},
+) {
+  const resolvedRoot = path.resolve(root);
+  const resolvedDirectory = resolveInside(resolvedRoot, directory);
+  const rootStat = fs.lstatSync(resolvedRoot);
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+    throw new Error(
+      "Component workspace root must be a non-symlink directory.",
+    );
+  }
+  const realRoot = fs.realpathSync(resolvedRoot);
+  const relativePath = path.relative(resolvedRoot, resolvedDirectory);
+  const segments = relativePath
+    ? relativePath.split(path.sep).filter(Boolean)
+    : [];
+  let current = resolvedRoot;
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(current);
+    } catch (error) {
+      if (allowMissing && (error as NodeJS.ErrnoException).code === "ENOENT") {
+        return resolvedDirectory;
+      }
+      throw error;
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      throw new Error("Component paths must not contain symlinks.");
+    }
+  }
+  const realDirectory = fs.realpathSync(resolvedDirectory);
+  const realRelativePath = path.relative(realRoot, realDirectory);
+  if (realRelativePath.startsWith("..") || path.isAbsolute(realRelativePath)) {
+    throw new Error("Component path escaped the registered workspace.");
+  }
+  return realDirectory;
+}
+
+async function ensureSafeDirectoryPath(root: string, directory: string) {
+  const resolvedRoot = path.resolve(root);
+  const resolvedDirectory = resolveInside(resolvedRoot, directory);
+  const rootStat = await fsp.lstat(resolvedRoot);
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+    throw new Error("Component root must be a non-symlink directory.");
+  }
+
+  const relativePath = path.relative(resolvedRoot, resolvedDirectory);
+  const segments = relativePath
+    ? relativePath.split(path.sep).filter(Boolean)
+    : [];
+  let current = resolvedRoot;
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    try {
+      const stat = await fsp.lstat(current);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        throw new Error("Component paths must not contain symlinks.");
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      await fsp.mkdir(current);
+      const stat = await fsp.lstat(current);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        throw new Error("Component paths must not contain symlinks.");
+      }
+    }
+  }
 }
 
 export function registeredLocalComponentDirsSync(cwd = process.cwd()) {
@@ -362,14 +459,10 @@ export async function writeLocalComponentFile(options: {
   const componentRoot =
     componentDirsForWorkspace(workspace)[0] ??
     firstComponentRootForWorkspace(workspace);
-  await fsp.mkdir(componentRoot, { recursive: true });
-  const rootStat = await fsp.lstat(componentRoot);
-  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
-    throw new Error("Component root must be a non-symlink directory.");
-  }
   const filePath = safeComponentFilePath(options.filePath);
   const absolutePath = resolveInside(componentRoot, filePath);
-  await fsp.mkdir(path.dirname(absolutePath), { recursive: true });
+  await ensureSafeDirectoryPath(workspace.workspacePath, componentRoot);
+  await ensureSafeDirectoryPath(componentRoot, path.dirname(absolutePath));
   try {
     const stat = await fsp.lstat(absolutePath);
     if (stat.isSymbolicLink()) {

--- a/templates/content/shared/local-component-workspaces.ts
+++ b/templates/content/shared/local-component-workspaces.ts
@@ -355,6 +355,12 @@ async function ensureSafeDirectoryPath(root: string, directory: string) {
       }
     }
   }
+  const realRoot = await fsp.realpath(resolvedRoot);
+  const realDirectory = await fsp.realpath(resolvedDirectory);
+  const realRelativePath = path.relative(realRoot, realDirectory);
+  if (realRelativePath.startsWith("..") || path.isAbsolute(realRelativePath)) {
+    throw new Error("Component path escaped the registered workspace.");
+  }
 }
 
 export function registeredLocalComponentDirsSync(cwd = process.cwd()) {

--- a/templates/content/vite.config.ts
+++ b/templates/content/vite.config.ts
@@ -255,7 +255,9 @@ function contentLocalComponentsPlugin(): Plugin {
     async configureServer(server) {
       const registryPath = localComponentWorkspaceStorePath();
       let dirs = new Set<string>();
-      const refreshDirs = async () => {
+      let refreshPromise: Promise<void> | null = null;
+      let refreshAgain = false;
+      const runRefreshDirs = async () => {
         const nextDirs = new Set(await localComponentDirs());
         const newDirs = [...nextDirs].filter((dir) => !dirs.has(dir));
         if (newDirs.length > 0) {
@@ -266,6 +268,21 @@ function contentLocalComponentsPlugin(): Plugin {
           }
         }
         dirs = nextDirs;
+      };
+      const refreshDirs = async () => {
+        if (refreshPromise) {
+          refreshAgain = true;
+          return refreshPromise;
+        }
+        refreshPromise = (async () => {
+          do {
+            refreshAgain = false;
+            await runRefreshDirs();
+          } while (refreshAgain);
+        })().finally(() => {
+          refreshPromise = null;
+        });
+        return refreshPromise;
       };
       const invalidateComponents = (fullReload = false) => {
         const mod = server.moduleGraph.getModuleById(

--- a/templates/content/vite.config.ts
+++ b/templates/content/vite.config.ts
@@ -9,6 +9,8 @@ import {
 } from "@agent-native/core/local-artifacts";
 import type { Plugin } from "vite";
 import {
+  isLocalComponentWorkspaceStoreFile,
+  localComponentWorkspaceStoreDir,
   localComponentWorkspaceStorePath,
   registeredLocalComponentRootsSync,
 } from "./shared/local-component-workspaces";
@@ -58,7 +60,12 @@ function envManifestPath() {
 function localWorkspaceRootSync() {
   const manifestPath = envManifestPath() || findAgentNativeManifest();
   if (!manifestPath) return null;
-  return path.dirname(path.resolve(process.cwd(), manifestPath));
+  const workspaceRoot = path.dirname(path.resolve(process.cwd(), manifestPath));
+  try {
+    return fs.realpathSync(workspaceRoot);
+  } catch {
+    return workspaceRoot;
+  }
 }
 
 function normalizeRelativePath(filePath: string, label: string) {
@@ -133,7 +140,7 @@ async function walkComponentFiles(directory: string): Promise<string[]> {
     }
     if (
       !entry.isFile() ||
-      !COMPONENT_EXTENSIONS.has(path.extname(entry.name))
+      !COMPONENT_EXTENSIONS.has(path.extname(entry.name).toLowerCase())
     ) {
       continue;
     }
@@ -150,10 +157,11 @@ async function localComponentDirs() {
 
   const dirs: string[] = [];
   if (app.mode === "local-files") {
+    const workspaceRoot = fs.realpathSync(app.workspaceRoot);
     for (const componentPath of app.components) {
       const safePath = normalizeRelativePath(componentPath, "components path");
-      const absolutePath = path.resolve(app.workspaceRoot, safePath);
-      const relative = path.relative(app.workspaceRoot, absolutePath);
+      const absolutePath = path.resolve(workspaceRoot, safePath);
+      const relative = path.relative(workspaceRoot, absolutePath);
       if (relative.startsWith("..") || path.isAbsolute(relative)) {
         throw new Error(
           `components path "${componentPath}" is outside workspace`,
@@ -253,7 +261,8 @@ function contentLocalComponentsPlugin(): Plugin {
     name: "agent-native-content-local-components",
     enforce: "pre",
     async configureServer(server) {
-      const registryPath = localComponentWorkspaceStorePath();
+      const registryDir = localComponentWorkspaceStoreDir();
+      const legacyRegistryPath = localComponentWorkspaceStorePath();
       let dirs = new Set<string>();
       let refreshPromise: Promise<void> | null = null;
       let refreshAgain = false;
@@ -292,20 +301,22 @@ function contentLocalComponentsPlugin(): Plugin {
         if (fullReload) server.ws.send({ type: "full-reload" });
       };
 
-      await fs.promises.mkdir(path.dirname(registryPath), { recursive: true });
-      server.watcher.add(registryPath);
+      await fs.promises.mkdir(registryDir, { recursive: true });
+      server.watcher.add([registryDir, legacyRegistryPath]);
       await refreshDirs();
       server.watcher.on("all", async (eventName, changedPath) => {
-        if (path.resolve(changedPath) === path.resolve(registryPath)) {
+        const resolvedChangedPath = path.resolve(changedPath);
+        if (
+          path.dirname(resolvedChangedPath) === path.resolve(registryDir) &&
+          isLocalComponentWorkspaceStoreFile(resolvedChangedPath)
+        ) {
           await refreshDirs();
           invalidateComponents(true);
           return;
         }
         if (
           !["add", "unlink", "addDir", "unlinkDir"].includes(eventName) ||
-          ![...dirs].some((dir) =>
-            isInsideDirectory(dir, path.resolve(changedPath)),
-          )
+          ![...dirs].some((dir) => isInsideDirectory(dir, resolvedChangedPath))
         ) {
           return;
         }

--- a/templates/content/vite.config.ts
+++ b/templates/content/vite.config.ts
@@ -8,6 +8,10 @@ import {
   type LocalArtifactOptions,
 } from "@agent-native/core/local-artifacts";
 import type { Plugin } from "vite";
+import {
+  localComponentWorkspaceStorePath,
+  registeredLocalComponentRootsSync,
+} from "./shared/local-component-workspaces";
 
 const CONTENT_APP_ID = "content";
 const LOCAL_COMPONENTS_MODULE_ID =
@@ -143,21 +147,30 @@ async function localComponentDirs() {
     appId: CONTENT_APP_ID,
     defaults: CONTENT_LOCAL_DEFAULTS,
   });
-  if (app.mode !== "local-files") return [];
 
   const dirs: string[] = [];
-  for (const componentPath of app.components) {
-    const safePath = normalizeRelativePath(componentPath, "components path");
-    const absolutePath = path.resolve(app.workspaceRoot, safePath);
-    const relative = path.relative(app.workspaceRoot, absolutePath);
-    if (relative.startsWith("..") || path.isAbsolute(relative)) {
-      throw new Error(
-        `components path "${componentPath}" is outside workspace`,
-      );
+  if (app.mode === "local-files") {
+    for (const componentPath of app.components) {
+      const safePath = normalizeRelativePath(componentPath, "components path");
+      const absolutePath = path.resolve(app.workspaceRoot, safePath);
+      const relative = path.relative(app.workspaceRoot, absolutePath);
+      if (relative.startsWith("..") || path.isAbsolute(relative)) {
+        throw new Error(
+          `components path "${componentPath}" is outside workspace`,
+        );
+      }
+      dirs.push(absolutePath);
     }
-    dirs.push(absolutePath);
   }
-  return dirs;
+
+  try {
+    dirs.push(...registeredLocalComponentRootsSync());
+  } catch {
+    // Dynamic local component folders are a local-dev bridge only. Ignore them
+    // when the runtime disallows local file access, such as normal production.
+  }
+
+  return [...new Set(dirs.map((dir) => path.resolve(dir)))];
 }
 
 async function loadLocalComponentFiles() {
@@ -240,20 +253,47 @@ function contentLocalComponentsPlugin(): Plugin {
     name: "agent-native-content-local-components",
     enforce: "pre",
     async configureServer(server) {
-      const dirs = await localComponentDirs();
-      if (!dirs.length) return;
-      server.watcher.add(dirs);
-      server.watcher.on("all", (eventName, changedPath) => {
-        if (
-          !["add", "unlink", "addDir", "unlinkDir"].includes(eventName) ||
-          !dirs.some((dir) => isInsideDirectory(dir, path.resolve(changedPath)))
-        ) {
-          return;
+      const registryPath = localComponentWorkspaceStorePath();
+      let dirs = new Set<string>();
+      const refreshDirs = async () => {
+        const nextDirs = new Set(await localComponentDirs());
+        const newDirs = [...nextDirs].filter((dir) => !dirs.has(dir));
+        if (newDirs.length > 0) {
+          server.watcher.add(newDirs);
+          const allow = server.config.server.fs.allow ?? [];
+          for (const dir of newDirs) {
+            if (!allow.includes(dir)) allow.push(dir);
+          }
         }
+        dirs = nextDirs;
+      };
+      const invalidateComponents = (fullReload = false) => {
         const mod = server.moduleGraph.getModuleById(
           RESOLVED_LOCAL_COMPONENTS_MODULE_ID,
         );
         if (mod) server.moduleGraph.invalidateModule(mod);
+        if (fullReload) server.ws.send({ type: "full-reload" });
+      };
+
+      await fs.promises.mkdir(path.dirname(registryPath), { recursive: true });
+      server.watcher.add(registryPath);
+      await refreshDirs();
+      server.watcher.on("all", async (eventName, changedPath) => {
+        if (path.resolve(changedPath) === path.resolve(registryPath)) {
+          await refreshDirs();
+          invalidateComponents(true);
+          return;
+        }
+        if (
+          !["add", "unlink", "addDir", "unlinkDir"].includes(eventName) ||
+          ![...dirs].some((dir) =>
+            isInsideDirectory(dir, path.resolve(changedPath)),
+          )
+        ) {
+          return;
+        }
+        await refreshDirs();
+        invalidateComponents(true);
       });
     },
     resolveId(id, importer) {
@@ -270,10 +310,20 @@ function contentLocalComponentsPlugin(): Plugin {
 }
 
 const localWorkspaceRoot = localWorkspaceRootSync();
+const dynamicLocalComponentDirs = (() => {
+  try {
+    return registeredLocalComponentRootsSync();
+  } catch {
+    return [];
+  }
+})();
 
 export default defineConfig({
   plugins: [contentLocalComponentsPlugin(), reactRouter()],
-  fsAllow: localWorkspaceRoot ? [localWorkspaceRoot] : [],
+  fsAllow: [
+    ...(localWorkspaceRoot ? [localWorkspaceRoot] : []),
+    ...dynamicLocalComponentDirs,
+  ],
   // shiki only runs in AssistantChat's useEffect — keep it out of the
   // CF Pages Functions bundle (25 MiB limit).
   ssrStubs: ["shiki"],


### PR DESCRIPTION
## Summary
- register Desktop/local Content folders as component workspaces for MDX previews and slash-menu discovery
- add agent-facing actions to list and write local component files safely inside registered component roots
- watch registered component roots in Vite so edits, new files, and newly created component folders reload into Content
- document local-file custom component behavior and browser-vs-local-dev constraints

## Validation
- pnpm -r --filter ./templates/content test -- shared/local-component-workspaces.test.ts app/components/editor/localComponentSlashItems.test.ts app/local-component-config.test.ts
- pnpm -r --filter ./templates/content typecheck
- pnpm fmt:check
- pnpm run prep (tests/typecheck/guards passed; initial fmt failure was from ignored local Playwright report artifact templates/content/e2e/.report.json, removed locally and reran fmt:check)
- Browser smoke on localhost:8080: registered a local folder, rendered a custom component from components/, edited it through write-local-component-file and saw hot reload, then added a new component file and rendered it in MDX
