### PR TITLE
Fix recap MCP smoke HTTP instrumentation

### DIFF
--- a/.changeset/steady-recap-smoke.md
+++ b/.changeset/steady-recap-smoke.md
@@ -1,0 +1,4 @@
+## "@agent-native/core": patch
+
+Avoid Sentry HTTP instrumentation in the CLI so visual recap MCP smoke checks
+reach hosted Plan MCP routes reliably.

--- a/.changeset/steady-recap-smoke.md
+++ b/.changeset/steady-recap-smoke.md
@@ -1,4 +1,6 @@
-## "@agent-native/core": patch
+---
+"@agent-native/core": patch
+---
 
 Avoid Sentry HTTP instrumentation in the CLI so visual recap MCP smoke checks
 reach hosted Plan MCP routes reliably.

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -69,6 +69,10 @@ function buildRedactedCommandTag(argv: string[]): string {
 Sentry.init({
   dsn: "https://0d384e9eff2f6542af468b92769f2f5b@o117565.ingest.us.sentry.io/4511270386466816",
   release: `agent-native-cli@${_version}`,
+  // Sentry's Http integration wraps outgoing fetch in a way that breaks the
+  // hosted Plan MCP route negotiation used by recap CI smoke checks.
+  integrations: (integrations) =>
+    integrations.filter((integration) => integration.name !== "Http"),
   // sendDefaultPii MUST stay false — the CLI runs in third-party developer
   // environments and we never want to ship request headers, IPs, cookies,
   // or process env contents to Sentry without explicit consent.


### PR DESCRIPTION
## Summary
- disable Sentry Http instrumentation in the CLI so recap MCP smoke requests reach hosted Plan MCP routes
- add a core patch changeset

## Verification
- PLAN_RECAP_TOKEN=bogus pnpm --silent dev:cli recap mcp-smoke --app-url https://plan.agent-native.com returned HTTP 401 instead of the previous Netlify 404
- pnpm --filter @agent-native/core exec vitest --run src/cli/recap.spec.ts
- pnpm --filter @agent-native/core exec tsc --noEmit