### PR TITLE
Render wireframe icon markers

### DIFF
--- a/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
+++ b/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-native-visual-plans",
-  "version": "1.0.0+codex.dd4119030c99",
+  "version": "1.0.0+codex.c55f22c8b7b9",
   "description": "Create rich interactive visual plans and recaps with diagrams, file maps, annotated code and diffs, API/schema summaries, feedback, and HTML export.",
   "author": { "name": "Agent-Native", "url": "https://agent-native.com" },
   "homepage": "https://plan.agent-native.com",

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-plan/references/wireframe.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-plan/references/wireframe.md
@@ -35,6 +35,18 @@ are auto-themed — no classes needed. Helper classes carry the rest:
 - `button.primary` or any element with `[data-primary]` — the accent-filled
   primary button.
 
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading
+icons inside fields, chips, menu items, and toolbars, write an empty marker such
+as `<span data-icon="mail" aria-label="Email"></span>` or
+`<i data-icon="lock"></i>`. The renderer replaces it with a Tabler-style SVG and
+the `.wf-icon` class sizes it to the surrounding text. Supported names and
+aliases: `mail`/`email`, `lock`/`password`, `search`, `plus`/`add`, `x`/`close`,
+`check`, `chevronDown`, `chevronUp`, `chevronLeft`, `chevronRight`, `dots`/`more`,
+`chevron`/`caret`/`dropdown` (down chevron), `user`, `settings`, `calendar`,
+`bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do not put visible words
+like "email", "lock", "search", "chevron", or "more" where the product UI would
+show an icon; use text only when it is a real label a user would read.
+
 **Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips
 these on light/dark, so reading them is what keeps a mockup correct in both
 themes. For any inline border, background, or text color, reference a token:

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-recap/references/wireframe.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-recap/references/wireframe.md
@@ -35,6 +35,18 @@ are auto-themed — no classes needed. Helper classes carry the rest:
 - `button.primary` or any element with `[data-primary]` — the accent-filled
   primary button.
 
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading
+icons inside fields, chips, menu items, and toolbars, write an empty marker such
+as `<span data-icon="mail" aria-label="Email"></span>` or
+`<i data-icon="lock"></i>`. The renderer replaces it with a Tabler-style SVG and
+the `.wf-icon` class sizes it to the surrounding text. Supported names and
+aliases: `mail`/`email`, `lock`/`password`, `search`, `plus`/`add`, `x`/`close`,
+`check`, `chevronDown`, `chevronUp`, `chevronLeft`, `chevronRight`, `dots`/`more`,
+`chevron`/`caret`/`dropdown` (down chevron), `user`, `settings`, `calendar`,
+`bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do not put visible words
+like "email", "lock", "search", "chevron", or "more" where the product UI would
+show an icon; use text only when it is a real label a user would read.
+
 **Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips
 these on light/dark, so reading them is what keeps a mockup correct in both
 themes. For any inline border, background, or text color, reference a token:

--- a/.changeset/wireframe-icons-private-plan-copy.md
+++ b/.changeset/wireframe-icons-private-plan-copy.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add allowlisted wireframe icon markers for visual plans/recaps and trim private plan sign-in copy.

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -343,6 +343,18 @@ are auto-themed — no classes needed. Helper classes carry the rest:
 - \`button.primary\` or any element with \`[data-primary]\` — the accent-filled
   primary button.
 
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading
+icons inside fields, chips, menu items, and toolbars, write an empty marker such
+as \`<span data-icon="mail" aria-label="Email"></span>\` or
+\`<i data-icon="lock"></i>\`. The renderer replaces it with a Tabler-style SVG and
+the \`.wf-icon\` class sizes it to the surrounding text. Supported names and
+aliases: \`mail\`/\`email\`, \`lock\`/\`password\`, \`search\`, \`plus\`/\`add\`, \`x\`/\`close\`,
+\`check\`, \`chevronDown\`, \`chevronUp\`, \`chevronLeft\`, \`chevronRight\`, \`dots\`/\`more\`,
+\`chevron\`/\`caret\`/\`dropdown\` (down chevron), \`user\`, \`settings\`, \`calendar\`,
+\`bell\`, \`send\`, \`edit\`, \`arrowLeft\`, and \`arrowRight\`. Do not put visible words
+like "email", "lock", "search", "chevron", or "more" where the product UI would
+show an icon; use text only when it is a real label a user would read.
+
 **Use the \`--wf-*\` tokens for any custom color, never hex.** The renderer flips
 these on light/dark, so reading them is what keeps a mockup correct in both
 themes. For any inline border, background, or text color, reference a token:

--- a/packages/core/src/client/blocks/index.ts
+++ b/packages/core/src/client/blocks/index.ts
@@ -215,6 +215,7 @@ export {
   useIsDark,
   type WireframeStyle,
 } from "./library/wireframe-kit.js";
+export { renderWireframeIconHtml } from "./library/wireframe-icons.js";
 
 // Dev-doc block library (React `Read`/`Edit` renderers + their React-free
 // schema/MDX config). Apps register these alongside their own blocks, supplying

--- a/packages/core/src/client/blocks/library/wireframe-icons.ts
+++ b/packages/core/src/client/blocks/library/wireframe-icons.ts
@@ -87,7 +87,7 @@ const ICON_ALIASES: Record<string, keyof typeof ICON_PATHS> = {
 };
 
 const ICON_MARKER_RE =
-  /<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]+)"|'([^']+)'|([^\s"'=<>`]+))([^>]*)>(?:\s*)<\/\1>|<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]+)"|'([^']+)'|([^\s"'=<>`]+))([^>]*)\/>/gi;
+  /<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]*)"|'([^']*)'|([^\s"'=<>`]+))([^>]*)>(?:\s*)<\/\1>|<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]*)"|'([^']*)'|([^\s"'=<>`]+))([^>]*)\/>/gi;
 
 function normalizeIconName(value: string): keyof typeof ICON_PATHS | null {
   const normalized = value
@@ -112,7 +112,37 @@ function readAttribute(attrs: string, name: string): string | null {
   );
   if (!match) return null;
   const raw = match[1] ?? "";
-  return raw.replace(/^["']|["']$/g, "");
+  return decodeAttrEntities(raw.replace(/^["']|["']$/g, ""));
+}
+
+function decodeAttrEntities(value: string): string {
+  return value.replace(
+    /&(#x[0-9a-f]+|#\d+|amp|apos|quot|lt|gt);/gi,
+    (entity, body: string) => {
+      const normalized = body.toLowerCase();
+      if (normalized === "amp") return "&";
+      if (normalized === "apos") return "'";
+      if (normalized === "quot") return '"';
+      if (normalized === "lt") return "<";
+      if (normalized === "gt") return ">";
+
+      const isHex = normalized.startsWith("#x");
+      const digits = normalized.slice(isHex ? 2 : 1);
+      const codePoint = Number.parseInt(digits, isHex ? 16 : 10);
+      if (
+        !Number.isFinite(codePoint) ||
+        codePoint < 0 ||
+        codePoint > 0x10ffff
+      ) {
+        return entity;
+      }
+      try {
+        return String.fromCodePoint(codePoint);
+      } catch {
+        return entity;
+      }
+    },
+  );
 }
 
 function escapeAttr(value: string): string {

--- a/packages/core/src/client/blocks/library/wireframe-icons.ts
+++ b/packages/core/src/client/blocks/library/wireframe-icons.ts
@@ -1,0 +1,171 @@
+const ICON_PATHS = {
+  arrowLeft: [
+    '<path d="M5 12l14 0" />',
+    '<path d="M5 12l6 6" />',
+    '<path d="M5 12l6 -6" />',
+  ],
+  arrowRight: [
+    '<path d="M5 12l14 0" />',
+    '<path d="M13 18l6 -6" />',
+    '<path d="M13 6l6 6" />',
+  ],
+  bell: [
+    '<path d="M10 5a2 2 0 1 1 4 0a7 7 0 0 1 4 6v3a4 4 0 0 0 2 3h-16a4 4 0 0 0 2 -3v-3a7 7 0 0 1 4 -6" />',
+    '<path d="M9 17v1a3 3 0 0 0 6 0v-1" />',
+  ],
+  calendar: [
+    '<path d="M4 7a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12z" />',
+    '<path d="M16 3v4" />',
+    '<path d="M8 3v4" />',
+    '<path d="M4 11h16" />',
+  ],
+  check: ['<path d="M5 12l5 5l10 -10" />'],
+  chevronDown: ['<path d="M6 9l6 6l6 -6" />'],
+  chevronLeft: ['<path d="M15 6l-6 6l6 6" />'],
+  chevronRight: ['<path d="M9 6l6 6l-6 6" />'],
+  chevronUp: ['<path d="M6 15l6 -6l6 6" />'],
+  dots: [
+    '<path d="M5 12m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />',
+    '<path d="M12 12m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />',
+    '<path d="M19 12m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />',
+  ],
+  edit: [
+    '<path d="M4 20h4l10.5 -10.5a2.8 2.8 0 1 0 -4 -4l-10.5 10.5v4" />',
+    '<path d="M13.5 6.5l4 4" />',
+  ],
+  lock: [
+    '<path d="M5 13a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v6a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2 -2v-6z" />',
+    '<path d="M8 11v-4a4 4 0 1 1 8 0v4" />',
+    '<path d="M12 16l0 .01" />',
+  ],
+  mail: [
+    '<path d="M3 7a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-10z" />',
+    '<path d="M3 7l9 6l9 -6" />',
+  ],
+  plus: ['<path d="M12 5l0 14" />', '<path d="M5 12l14 0" />'],
+  search: [
+    '<path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" />',
+    '<path d="M21 21l-6 -6" />',
+  ],
+  send: [
+    '<path d="M10 14l11 -11" />',
+    '<path d="M21 3l-6.5 18a.55 .55 0 0 1 -1 0l-3.5 -7l-7 -3.5a.55 .55 0 0 1 0 -1l18 -6.5" />',
+  ],
+  settings: [
+    '<path d="M10.3 4.3a1 1 0 0 1 1.4 0l.6 .6a1 1 0 0 0 1 .24l.84 -.28a1 1 0 0 1 1.25 .6l.31 .9a1 1 0 0 0 .76 .65l.95 .16a1 1 0 0 1 .84 1.08l-.08 .98a1 1 0 0 0 .48 .9l.82 .52a1 1 0 0 1 .34 1.34l-.49 .86a1 1 0 0 0 0 1l.49 .86a1 1 0 0 1 -.34 1.34l-.82 .52a1 1 0 0 0 -.48 .9l.08 .98a1 1 0 0 1 -.84 1.08l-.95 .16a1 1 0 0 0 -.76 .65l-.31 .9a1 1 0 0 1 -1.25 .6l-.84 -.28a1 1 0 0 0 -1 .24l-.6 .6a1 1 0 0 1 -1.4 0l-.6 -.6a1 1 0 0 0 -1 -.24l-.84 .28a1 1 0 0 1 -1.25 -.6l-.31 -.9a1 1 0 0 0 -.76 -.65l-.95 -.16a1 1 0 0 1 -.84 -1.08l.08 -.98a1 1 0 0 0 -.48 -.9l-.82 -.52a1 1 0 0 1 -.34 -1.34l.49 -.86a1 1 0 0 0 0 -1l-.49 -.86a1 1 0 0 1 .34 -1.34l.82 -.52a1 1 0 0 0 .48 -.9l-.08 -.98a1 1 0 0 1 .84 -1.08l.95 -.16a1 1 0 0 0 .76 -.65l.31 -.9a1 1 0 0 1 1.25 -.6l.84 .28a1 1 0 0 0 1 -.24l.6 -.6z" />',
+    '<path d="M9 12a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" />',
+  ],
+  user: [
+    '<path d="M8 7a4 4 0 1 0 8 0a4 4 0 0 0 -8 0" />',
+    '<path d="M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />',
+  ],
+  x: ['<path d="M18 6l-12 12" />', '<path d="M6 6l12 12" />'],
+} as const;
+
+const ICON_ALIASES: Record<string, keyof typeof ICON_PATHS> = {
+  add: "plus",
+  back: "arrowLeft",
+  close: "x",
+  collapse: "chevronUp",
+  caret: "chevronDown",
+  chevron: "chevronDown",
+  dropdown: "chevronDown",
+  down: "chevronDown",
+  email: "mail",
+  expand: "chevronDown",
+  forward: "arrowRight",
+  gear: "settings",
+  menu: "dots",
+  more: "dots",
+  next: "chevronRight",
+  password: "lock",
+  previous: "chevronLeft",
+  profile: "user",
+  right: "chevronRight",
+  submit: "send",
+  up: "chevronUp",
+};
+
+const ICON_MARKER_RE =
+  /<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]+)"|'([^']+)'|([^\s"'=<>`]+))([^>]*)>(?:\s*)<\/\1>|<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]+)"|'([^']+)'|([^\s"'=<>`]+))([^>]*)\/>/gi;
+
+function normalizeIconName(value: string): keyof typeof ICON_PATHS | null {
+  const normalized = value
+    .trim()
+    .replace(/^icon/i, "")
+    .replace(/[^a-z0-9]+/gi, " ")
+    .trim()
+    .replace(/\s+([a-z0-9])/gi, (_match, char: string) => char.toUpperCase())
+    .replace(/^./, (char) => char.toLowerCase());
+  return normalized in ICON_PATHS
+    ? (normalized as keyof typeof ICON_PATHS)
+    : (ICON_ALIASES[normalized] ?? null);
+}
+
+function readAttribute(attrs: string, name: string): string | null {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = attrs.match(
+    new RegExp(
+      `\\b${escaped}\\s*=\\s*("[^"]*"|'[^']*'|[^\\s"'=<>` + "`" + `]+)`,
+      "i",
+    ),
+  );
+  if (!match) return null;
+  const raw = match[1] ?? "";
+  return raw.replace(/^["']|["']$/g, "");
+}
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function iconSvg(name: keyof typeof ICON_PATHS, label: string | null): string {
+  const accessibility = label
+    ? `role="img" aria-label="${escapeAttr(label)}"`
+    : 'aria-hidden="true"';
+  return `<svg class="wf-icon" data-icon="${name}" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" ${accessibility}>${ICON_PATHS[name].join("")}</svg>`;
+}
+
+export function renderWireframeIconHtml(html: string): string {
+  return html.replace(
+    ICON_MARKER_RE,
+    (
+      match,
+      _tagA,
+      beforeA,
+      quotedA,
+      doubleA,
+      singleA,
+      bareA,
+      afterA,
+      _tagB,
+      beforeB,
+      quotedB,
+      doubleB,
+      singleB,
+      bareB,
+      afterB,
+    ) => {
+      const rawName =
+        doubleA ??
+        singleA ??
+        bareA ??
+        doubleB ??
+        singleB ??
+        bareB ??
+        quotedA ??
+        quotedB ??
+        "";
+      const name = normalizeIconName(rawName);
+      if (!name) return match;
+      const attrs = `${beforeA ?? ""}${afterA ?? ""}${beforeB ?? ""}${afterB ?? ""}`;
+      const label =
+        readAttribute(attrs, "aria-label") ?? readAttribute(attrs, "title");
+      return iconSvg(name, label);
+    },
+  );
+}

--- a/packages/core/src/client/blocks/library/wireframe-icons.ts
+++ b/packages/core/src/client/blocks/library/wireframe-icons.ts
@@ -123,18 +123,28 @@ function escapeAttr(value: string): string {
     .replace(/>/g, "&gt;");
 }
 
-function iconSvg(name: keyof typeof ICON_PATHS, label: string | null): string {
-  const accessibility = label
-    ? `role="img" aria-label="${escapeAttr(label)}"`
+function iconAccessibility(label: string | null): string {
+  const accessibleLabel = label?.trim();
+  return accessibleLabel
+    ? `role="img" aria-label="${escapeAttr(accessibleLabel)}"`
     : 'aria-hidden="true"';
-  return `<svg class="wf-icon" data-icon="${name}" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" ${accessibility}>${ICON_PATHS[name].join("")}</svg>`;
+}
+
+function iconSvg(name: keyof typeof ICON_PATHS, label: string | null): string {
+  return `<svg class="wf-icon" data-icon="${name}" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" ${iconAccessibility(label)}>${ICON_PATHS[name].join("")}</svg>`;
+}
+
+function iconFallback(rawName: string, label: string | null): string {
+  const iconName = rawName.trim() || "unknown";
+  const accessibleLabel = label?.trim() || `Unsupported icon: ${iconName}`;
+  return `<span class="wf-icon wf-icon-fallback" data-icon="unknown" data-icon-name="${escapeAttr(iconName)}" role="img" aria-label="${escapeAttr(accessibleLabel)}">?</span>`;
 }
 
 export function renderWireframeIconHtml(html: string): string {
   return html.replace(
     ICON_MARKER_RE,
     (
-      match,
+      _match,
       _tagA,
       beforeA,
       quotedA,
@@ -161,11 +171,10 @@ export function renderWireframeIconHtml(html: string): string {
         quotedB ??
         "";
       const name = normalizeIconName(rawName);
-      if (!name) return match;
       const attrs = `${beforeA ?? ""}${afterA ?? ""}${beforeB ?? ""}${afterB ?? ""}`;
       const label =
         readAttribute(attrs, "aria-label") ?? readAttribute(attrs, "title");
-      return iconSvg(name, label);
+      return name ? iconSvg(name, label) : iconFallback(rawName, label);
     },
   );
 }

--- a/packages/core/src/client/blocks/library/wireframe.render.spec.tsx
+++ b/packages/core/src/client/blocks/library/wireframe.render.spec.tsx
@@ -81,6 +81,22 @@ describe("wireframe auto-height frame", () => {
     expect(style).toMatch(/width\s*:\s*900px/);
   });
 
+  it("renders allowlisted icon markers as inline Tabler-style SVG icons", () => {
+    const html = render({
+      surface: "popover",
+      html: '<button aria-label="Email"><span data-icon="email" aria-label="Email"></span></button><button><i data-icon="lock"></i></button><span data-icon="chevron"></span>',
+    });
+
+    expect(html).toContain('class="wf-icon"');
+    expect(html).toContain('data-icon="mail"');
+    expect(html).toContain('data-icon="lock"');
+    expect(html).toContain('data-icon="chevronDown"');
+    expect(html).toContain('aria-label="Email"');
+    expect(html).toContain("<svg");
+    expect(html).not.toContain(">email<");
+    expect(html).not.toContain(">lock<");
+  });
+
   it("applies a taller floor to a phone surface than a popover", () => {
     const mobileStyle = artboardStyle(
       render({ surface: "mobile", html: "<div>x</div>" }),

--- a/packages/core/src/client/blocks/library/wireframe.render.spec.tsx
+++ b/packages/core/src/client/blocks/library/wireframe.render.spec.tsx
@@ -97,6 +97,19 @@ describe("wireframe auto-height frame", () => {
     expect(html).not.toContain(">lock<");
   });
 
+  it("renders unknown icon markers as a visible fallback", () => {
+    const html = render({
+      surface: "popover",
+      html: '<span data-icon="made-up" aria-label="Mystery icon"></span>',
+    });
+
+    expect(html).toContain('class="wf-icon wf-icon-fallback"');
+    expect(html).toContain('data-icon="unknown"');
+    expect(html).toContain('data-icon-name="made-up"');
+    expect(html).toContain('aria-label="Mystery icon"');
+    expect(html).toContain(">?</span>");
+  });
+
   it("applies a taller floor to a phone surface than a popover", () => {
     const mobileStyle = artboardStyle(
       render({ surface: "mobile", html: "<div>x</div>" }),

--- a/packages/core/src/client/blocks/library/wireframe.render.spec.tsx
+++ b/packages/core/src/client/blocks/library/wireframe.render.spec.tsx
@@ -110,6 +110,27 @@ describe("wireframe auto-height frame", () => {
     expect(html).toContain(">?</span>");
   });
 
+  it("normalizes sanitized icon labels without double escaping", () => {
+    const html = render({
+      surface: "popover",
+      html: '<span data-icon="mail" aria-label="A & B"></span>',
+    });
+
+    expect(html).toContain('aria-label="A &amp; B"');
+    expect(html).not.toContain("A &amp;amp; B");
+  });
+
+  it("renders empty icon names as a visible fallback", () => {
+    const html = render({
+      surface: "popover",
+      html: '<span data-icon="" aria-label=""></span>',
+    });
+
+    expect(html).toContain('class="wf-icon wf-icon-fallback"');
+    expect(html).toContain('data-icon-name="unknown"');
+    expect(html).toContain('aria-label="Unsupported icon: unknown"');
+  });
+
   it("applies a taller floor to a phone surface than a popover", () => {
     const mobileStyle = artboardStyle(
       render({ surface: "mobile", html: "<div>x</div>" }),

--- a/packages/core/src/client/blocks/library/wireframe.tsx
+++ b/packages/core/src/client/blocks/library/wireframe.tsx
@@ -32,6 +32,7 @@ import {
   sanitizeWireframeHtml,
   scopeDesignCss,
 } from "./sanitize-html.js";
+import { renderWireframeIconHtml } from "./wireframe-icons.js";
 
 /**
  * Shared `wireframe` block — a hand-drawn low-fi mockup of one screen, rendered
@@ -300,7 +301,10 @@ function HtmlArtboard({
   // XSS). Self-contained in core via the shared block sanitizer (DOM-based in the
   // browser, regex fallback on the server) so the HTML mockup path renders in any
   // app without the host wiring a sanitizer hook.
-  const safeHtml = useMemo(() => sanitizeWireframeHtml(data.html), [data.html]);
+  const safeHtml = useMemo(
+    () => renderWireframeIconHtml(sanitizeWireframeHtml(data.html)),
+    [data.html],
+  );
   const scopeId = useId().replace(/[^a-zA-Z0-9_-]/g, "");
   const scopedCss = useMemo(() => {
     const safeCss = sanitizeWireframeCss(data.css);

--- a/packages/core/src/styles/blocks.css
+++ b/packages/core/src/styles/blocks.css
@@ -1067,6 +1067,15 @@
   margin: 10px 0;
 }
 
+.plan-html-frame:not([data-render-mode="design"]) .wf-icon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  flex: 0 0 auto;
+  color: currentColor;
+  vertical-align: -0.16em;
+}
+
 .plan-html-frame:not([data-render-mode="design"]) button,
 .plan-html-frame:not([data-render-mode="design"]) .wf-btn {
   display: inline-flex;

--- a/packages/core/src/styles/blocks.css
+++ b/packages/core/src/styles/blocks.css
@@ -1076,6 +1076,17 @@
   vertical-align: -0.16em;
 }
 
+.plan-html-frame:not([data-render-mode="design"]) .wf-icon-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1.2px solid currentColor;
+  border-radius: 999px;
+  font-size: 0.72em;
+  font-weight: 700;
+  line-height: 1;
+}
+
 .plan-html-frame:not([data-render-mode="design"]) button,
 .plan-html-frame:not([data-render-mode="design"]) .wf-btn {
   display: inline-flex;

--- a/skills/visual-plans/references/wireframe.md
+++ b/skills/visual-plans/references/wireframe.md
@@ -35,6 +35,18 @@ are auto-themed — no classes needed. Helper classes carry the rest:
 - `button.primary` or any element with `[data-primary]` — the accent-filled
   primary button.
 
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading
+icons inside fields, chips, menu items, and toolbars, write an empty marker such
+as `<span data-icon="mail" aria-label="Email"></span>` or
+`<i data-icon="lock"></i>`. The renderer replaces it with a Tabler-style SVG and
+the `.wf-icon` class sizes it to the surrounding text. Supported names and
+aliases: `mail`/`email`, `lock`/`password`, `search`, `plus`/`add`, `x`/`close`,
+`check`, `chevronDown`, `chevronUp`, `chevronLeft`, `chevronRight`, `dots`/`more`,
+`chevron`/`caret`/`dropdown` (down chevron), `user`, `settings`, `calendar`,
+`bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do not put visible words
+like "email", "lock", "search", "chevron", or "more" where the product UI would
+show an icon; use text only when it is a real label a user would read.
+
 **Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips
 these on light/dark, so reading them is what keeps a mockup correct in both
 themes. For any inline border, background, or text color, reference a token:

--- a/skills/visual-recap/references/wireframe.md
+++ b/skills/visual-recap/references/wireframe.md
@@ -35,6 +35,18 @@ are auto-themed — no classes needed. Helper classes carry the rest:
 - `button.primary` or any element with `[data-primary]` — the accent-filled
   primary button.
 
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading
+icons inside fields, chips, menu items, and toolbars, write an empty marker such
+as `<span data-icon="mail" aria-label="Email"></span>` or
+`<i data-icon="lock"></i>`. The renderer replaces it with a Tabler-style SVG and
+the `.wf-icon` class sizes it to the surrounding text. Supported names and
+aliases: `mail`/`email`, `lock`/`password`, `search`, `plus`/`add`, `x`/`close`,
+`check`, `chevronDown`, `chevronUp`, `chevronLeft`, `chevronRight`, `dots`/`more`,
+`chevron`/`caret`/`dropdown` (down chevron), `user`, `settings`, `calendar`,
+`bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do not put visible words
+like "email", "lock", "search", "chevron", or "more" where the product UI would
+show an icon; use text only when it is a real label a user would read.
+
 **Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips
 these on light/dark, so reading them is what keeps a mockup correct in both
 themes. For any inline border, background, or text color, reference a token:

--- a/templates/plan/.agents/skills/visual-plan/references/wireframe.md
+++ b/templates/plan/.agents/skills/visual-plan/references/wireframe.md
@@ -35,6 +35,18 @@ are auto-themed — no classes needed. Helper classes carry the rest:
 - `button.primary` or any element with `[data-primary]` — the accent-filled
   primary button.
 
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading
+icons inside fields, chips, menu items, and toolbars, write an empty marker such
+as `<span data-icon="mail" aria-label="Email"></span>` or
+`<i data-icon="lock"></i>`. The renderer replaces it with a Tabler-style SVG and
+the `.wf-icon` class sizes it to the surrounding text. Supported names and
+aliases: `mail`/`email`, `lock`/`password`, `search`, `plus`/`add`, `x`/`close`,
+`check`, `chevronDown`, `chevronUp`, `chevronLeft`, `chevronRight`, `dots`/`more`,
+`chevron`/`caret`/`dropdown` (down chevron), `user`, `settings`, `calendar`,
+`bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do not put visible words
+like "email", "lock", "search", "chevron", or "more" where the product UI would
+show an icon; use text only when it is a real label a user would read.
+
 **Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips
 these on light/dark, so reading them is what keeps a mockup correct in both
 themes. For any inline border, background, or text color, reference a token:

--- a/templates/plan/.agents/skills/visual-recap/references/wireframe.md
+++ b/templates/plan/.agents/skills/visual-recap/references/wireframe.md
@@ -35,6 +35,18 @@ are auto-themed — no classes needed. Helper classes carry the rest:
 - `button.primary` or any element with `[data-primary]` — the accent-filled
   primary button.
 
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading
+icons inside fields, chips, menu items, and toolbars, write an empty marker such
+as `<span data-icon="mail" aria-label="Email"></span>` or
+`<i data-icon="lock"></i>`. The renderer replaces it with a Tabler-style SVG and
+the `.wf-icon` class sizes it to the surrounding text. Supported names and
+aliases: `mail`/`email`, `lock`/`password`, `search`, `plus`/`add`, `x`/`close`,
+`check`, `chevronDown`, `chevronUp`, `chevronLeft`, `chevronRight`, `dots`/`more`,
+`chevron`/`caret`/`dropdown` (down chevron), `user`, `settings`, `calendar`,
+`bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do not put visible words
+like "email", "lock", "search", "chevron", or "more" where the product UI would
+show an icon; use text only when it is a real label a user would read.
+
 **Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips
 these on light/dark, so reading them is what keeps a mockup correct in both
 themes. For any inline border, background, or text color, reference a token:

--- a/templates/plan/app/components/plan/wireframe/Wireframe.tsx
+++ b/templates/plan/app/components/plan/wireframe/Wireframe.tsx
@@ -35,6 +35,7 @@ import {
   RUNTIME_SENTINEL_ATTR,
   mountPrototypeRuntime,
 } from "./prototype-runtime";
+import { renderWireframeIconHtml } from "./wireframe-icons";
 import "./html-artboard.css";
 
 /**
@@ -318,7 +319,10 @@ function HtmlArtboard({
   // Sanitize model-authored HTML at the render point (defense-in-depth against
   // stored XSS) — see sanitize-html.ts. Memoized so it only re-runs when the
   // html changes, not on every theme/zoom re-render.
-  const safeHtml = useMemo(() => sanitizeWireframeHtml(data.html), [data.html]);
+  const safeHtml = useMemo(
+    () => renderWireframeIconHtml(sanitizeWireframeHtml(data.html)),
+    [data.html],
+  );
   const renderMode = data.renderMode ?? "wireframe";
   const designMode = renderMode === "design";
   const scopeId = useId().replace(/[^a-zA-Z0-9_-]/g, "");

--- a/templates/plan/app/components/plan/wireframe/html-artboard.css
+++ b/templates/plan/app/components/plan/wireframe/html-artboard.css
@@ -145,6 +145,17 @@
   vertical-align: -0.16em;
 }
 
+.plan-html-frame:not([data-render-mode="design"]) .wf-icon-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1.2px solid currentColor;
+  border-radius: 999px;
+  font-size: 0.72em;
+  font-weight: 700;
+  line-height: 1;
+}
+
 .plan-html-frame:not([data-render-mode="design"]) button,
 .plan-html-frame:not([data-render-mode="design"]) .wf-btn {
   display: inline-flex;

--- a/templates/plan/app/components/plan/wireframe/html-artboard.css
+++ b/templates/plan/app/components/plan/wireframe/html-artboard.css
@@ -136,6 +136,15 @@
   margin: 10px 0;
 }
 
+.plan-html-frame:not([data-render-mode="design"]) .wf-icon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  flex: 0 0 auto;
+  color: currentColor;
+  vertical-align: -0.16em;
+}
+
 .plan-html-frame:not([data-render-mode="design"]) button,
 .plan-html-frame:not([data-render-mode="design"]) .wf-btn {
   display: inline-flex;

--- a/templates/plan/app/components/plan/wireframe/wireframe-icons.ts
+++ b/templates/plan/app/components/plan/wireframe/wireframe-icons.ts
@@ -87,7 +87,7 @@ const ICON_ALIASES: Record<string, keyof typeof ICON_PATHS> = {
 };
 
 const ICON_MARKER_RE =
-  /<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]+)"|'([^']+)'|([^\s"'=<>`]+))([^>]*)>(?:\s*)<\/\1>|<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]+)"|'([^']+)'|([^\s"'=<>`]+))([^>]*)\/>/gi;
+  /<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]*)"|'([^']*)'|([^\s"'=<>`]+))([^>]*)>(?:\s*)<\/\1>|<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]*)"|'([^']*)'|([^\s"'=<>`]+))([^>]*)\/>/gi;
 
 function normalizeIconName(value: string): keyof typeof ICON_PATHS | null {
   const normalized = value
@@ -112,7 +112,37 @@ function readAttribute(attrs: string, name: string): string | null {
   );
   if (!match) return null;
   const raw = match[1] ?? "";
-  return raw.replace(/^["']|["']$/g, "");
+  return decodeAttrEntities(raw.replace(/^["']|["']$/g, ""));
+}
+
+function decodeAttrEntities(value: string): string {
+  return value.replace(
+    /&(#x[0-9a-f]+|#\d+|amp|apos|quot|lt|gt);/gi,
+    (entity, body: string) => {
+      const normalized = body.toLowerCase();
+      if (normalized === "amp") return "&";
+      if (normalized === "apos") return "'";
+      if (normalized === "quot") return '"';
+      if (normalized === "lt") return "<";
+      if (normalized === "gt") return ">";
+
+      const isHex = normalized.startsWith("#x");
+      const digits = normalized.slice(isHex ? 2 : 1);
+      const codePoint = Number.parseInt(digits, isHex ? 16 : 10);
+      if (
+        !Number.isFinite(codePoint) ||
+        codePoint < 0 ||
+        codePoint > 0x10ffff
+      ) {
+        return entity;
+      }
+      try {
+        return String.fromCodePoint(codePoint);
+      } catch {
+        return entity;
+      }
+    },
+  );
 }
 
 function escapeAttr(value: string): string {

--- a/templates/plan/app/components/plan/wireframe/wireframe-icons.ts
+++ b/templates/plan/app/components/plan/wireframe/wireframe-icons.ts
@@ -1,0 +1,171 @@
+const ICON_PATHS = {
+  arrowLeft: [
+    '<path d="M5 12l14 0" />',
+    '<path d="M5 12l6 6" />',
+    '<path d="M5 12l6 -6" />',
+  ],
+  arrowRight: [
+    '<path d="M5 12l14 0" />',
+    '<path d="M13 18l6 -6" />',
+    '<path d="M13 6l6 6" />',
+  ],
+  bell: [
+    '<path d="M10 5a2 2 0 1 1 4 0a7 7 0 0 1 4 6v3a4 4 0 0 0 2 3h-16a4 4 0 0 0 2 -3v-3a7 7 0 0 1 4 -6" />',
+    '<path d="M9 17v1a3 3 0 0 0 6 0v-1" />',
+  ],
+  calendar: [
+    '<path d="M4 7a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12z" />',
+    '<path d="M16 3v4" />',
+    '<path d="M8 3v4" />',
+    '<path d="M4 11h16" />',
+  ],
+  check: ['<path d="M5 12l5 5l10 -10" />'],
+  chevronDown: ['<path d="M6 9l6 6l6 -6" />'],
+  chevronLeft: ['<path d="M15 6l-6 6l6 6" />'],
+  chevronRight: ['<path d="M9 6l6 6l-6 6" />'],
+  chevronUp: ['<path d="M6 15l6 -6l6 6" />'],
+  dots: [
+    '<path d="M5 12m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />',
+    '<path d="M12 12m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />',
+    '<path d="M19 12m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />',
+  ],
+  edit: [
+    '<path d="M4 20h4l10.5 -10.5a2.8 2.8 0 1 0 -4 -4l-10.5 10.5v4" />',
+    '<path d="M13.5 6.5l4 4" />',
+  ],
+  lock: [
+    '<path d="M5 13a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v6a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2 -2v-6z" />',
+    '<path d="M8 11v-4a4 4 0 1 1 8 0v4" />',
+    '<path d="M12 16l0 .01" />',
+  ],
+  mail: [
+    '<path d="M3 7a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-10z" />',
+    '<path d="M3 7l9 6l9 -6" />',
+  ],
+  plus: ['<path d="M12 5l0 14" />', '<path d="M5 12l14 0" />'],
+  search: [
+    '<path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" />',
+    '<path d="M21 21l-6 -6" />',
+  ],
+  send: [
+    '<path d="M10 14l11 -11" />',
+    '<path d="M21 3l-6.5 18a.55 .55 0 0 1 -1 0l-3.5 -7l-7 -3.5a.55 .55 0 0 1 0 -1l18 -6.5" />',
+  ],
+  settings: [
+    '<path d="M10.3 4.3a1 1 0 0 1 1.4 0l.6 .6a1 1 0 0 0 1 .24l.84 -.28a1 1 0 0 1 1.25 .6l.31 .9a1 1 0 0 0 .76 .65l.95 .16a1 1 0 0 1 .84 1.08l-.08 .98a1 1 0 0 0 .48 .9l.82 .52a1 1 0 0 1 .34 1.34l-.49 .86a1 1 0 0 0 0 1l.49 .86a1 1 0 0 1 -.34 1.34l-.82 .52a1 1 0 0 0 -.48 .9l.08 .98a1 1 0 0 1 -.84 1.08l-.95 .16a1 1 0 0 0 -.76 .65l-.31 .9a1 1 0 0 1 -1.25 .6l-.84 -.28a1 1 0 0 0 -1 .24l-.6 .6a1 1 0 0 1 -1.4 0l-.6 -.6a1 1 0 0 0 -1 -.24l-.84 .28a1 1 0 0 1 -1.25 -.6l-.31 -.9a1 1 0 0 0 -.76 -.65l-.95 -.16a1 1 0 0 1 -.84 -1.08l.08 -.98a1 1 0 0 0 -.48 -.9l-.82 -.52a1 1 0 0 1 -.34 -1.34l.49 -.86a1 1 0 0 0 0 -1l-.49 -.86a1 1 0 0 1 .34 -1.34l.82 -.52a1 1 0 0 0 .48 -.9l-.08 -.98a1 1 0 0 1 .84 -1.08l.95 -.16a1 1 0 0 0 .76 -.65l.31 -.9a1 1 0 0 1 1.25 -.6l.84 .28a1 1 0 0 0 1 -.24l.6 -.6z" />',
+    '<path d="M9 12a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" />',
+  ],
+  user: [
+    '<path d="M8 7a4 4 0 1 0 8 0a4 4 0 0 0 -8 0" />',
+    '<path d="M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />',
+  ],
+  x: ['<path d="M18 6l-12 12" />', '<path d="M6 6l12 12" />'],
+} as const;
+
+const ICON_ALIASES: Record<string, keyof typeof ICON_PATHS> = {
+  add: "plus",
+  back: "arrowLeft",
+  caret: "chevronDown",
+  chevron: "chevronDown",
+  close: "x",
+  collapse: "chevronUp",
+  down: "chevronDown",
+  dropdown: "chevronDown",
+  email: "mail",
+  expand: "chevronDown",
+  forward: "arrowRight",
+  gear: "settings",
+  menu: "dots",
+  more: "dots",
+  next: "chevronRight",
+  password: "lock",
+  previous: "chevronLeft",
+  profile: "user",
+  right: "chevronRight",
+  submit: "send",
+  up: "chevronUp",
+};
+
+const ICON_MARKER_RE =
+  /<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]+)"|'([^']+)'|([^\s"'=<>`]+))([^>]*)>(?:\s*)<\/\1>|<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]+)"|'([^']+)'|([^\s"'=<>`]+))([^>]*)\/>/gi;
+
+function normalizeIconName(value: string): keyof typeof ICON_PATHS | null {
+  const normalized = value
+    .trim()
+    .replace(/^icon/i, "")
+    .replace(/[^a-z0-9]+/gi, " ")
+    .trim()
+    .replace(/\s+([a-z0-9])/gi, (_match, char: string) => char.toUpperCase())
+    .replace(/^./, (char) => char.toLowerCase());
+  return normalized in ICON_PATHS
+    ? (normalized as keyof typeof ICON_PATHS)
+    : (ICON_ALIASES[normalized] ?? null);
+}
+
+function readAttribute(attrs: string, name: string): string | null {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = attrs.match(
+    new RegExp(
+      `\\b${escaped}\\s*=\\s*("[^"]*"|'[^']*'|[^\\s"'=<>` + "`" + `]+)`,
+      "i",
+    ),
+  );
+  if (!match) return null;
+  const raw = match[1] ?? "";
+  return raw.replace(/^["']|["']$/g, "");
+}
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function iconSvg(name: keyof typeof ICON_PATHS, label: string | null): string {
+  const accessibility = label
+    ? `role="img" aria-label="${escapeAttr(label)}"`
+    : 'aria-hidden="true"';
+  return `<svg class="wf-icon" data-icon="${name}" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" ${accessibility}>${ICON_PATHS[name].join("")}</svg>`;
+}
+
+export function renderWireframeIconHtml(html: string): string {
+  return html.replace(
+    ICON_MARKER_RE,
+    (
+      match,
+      _tagA,
+      beforeA,
+      quotedA,
+      doubleA,
+      singleA,
+      bareA,
+      afterA,
+      _tagB,
+      beforeB,
+      quotedB,
+      doubleB,
+      singleB,
+      bareB,
+      afterB,
+    ) => {
+      const rawName =
+        doubleA ??
+        singleA ??
+        bareA ??
+        doubleB ??
+        singleB ??
+        bareB ??
+        quotedA ??
+        quotedB ??
+        "";
+      const name = normalizeIconName(rawName);
+      if (!name) return match;
+      const attrs = `${beforeA ?? ""}${afterA ?? ""}${beforeB ?? ""}${afterB ?? ""}`;
+      const label =
+        readAttribute(attrs, "aria-label") ?? readAttribute(attrs, "title");
+      return iconSvg(name, label);
+    },
+  );
+}

--- a/templates/plan/app/components/plan/wireframe/wireframe-icons.ts
+++ b/templates/plan/app/components/plan/wireframe/wireframe-icons.ts
@@ -123,18 +123,28 @@ function escapeAttr(value: string): string {
     .replace(/>/g, "&gt;");
 }
 
-function iconSvg(name: keyof typeof ICON_PATHS, label: string | null): string {
-  const accessibility = label
-    ? `role="img" aria-label="${escapeAttr(label)}"`
+function iconAccessibility(label: string | null): string {
+  const accessibleLabel = label?.trim();
+  return accessibleLabel
+    ? `role="img" aria-label="${escapeAttr(accessibleLabel)}"`
     : 'aria-hidden="true"';
-  return `<svg class="wf-icon" data-icon="${name}" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" ${accessibility}>${ICON_PATHS[name].join("")}</svg>`;
+}
+
+function iconSvg(name: keyof typeof ICON_PATHS, label: string | null): string {
+  return `<svg class="wf-icon" data-icon="${name}" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" ${iconAccessibility(label)}>${ICON_PATHS[name].join("")}</svg>`;
+}
+
+function iconFallback(rawName: string, label: string | null): string {
+  const iconName = rawName.trim() || "unknown";
+  const accessibleLabel = label?.trim() || `Unsupported icon: ${iconName}`;
+  return `<span class="wf-icon wf-icon-fallback" data-icon="unknown" data-icon-name="${escapeAttr(iconName)}" role="img" aria-label="${escapeAttr(accessibleLabel)}">?</span>`;
 }
 
 export function renderWireframeIconHtml(html: string): string {
   return html.replace(
     ICON_MARKER_RE,
     (
-      match,
+      _match,
       _tagA,
       beforeA,
       quotedA,
@@ -161,11 +171,10 @@ export function renderWireframeIconHtml(html: string): string {
         quotedB ??
         "";
       const name = normalizeIconName(rawName);
-      if (!name) return match;
       const attrs = `${beforeA ?? ""}${afterA ?? ""}${beforeB ?? ""}${afterB ?? ""}`;
       const label =
         readAttribute(attrs, "aria-label") ?? readAttribute(attrs, "title");
-      return iconSvg(name, label);
+      return name ? iconSvg(name, label) : iconFallback(rawName, label);
     },
   );
 }

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -5664,7 +5664,8 @@ function PlanLoadError({
             ) : null}
             {showAccessHelp && !signedIn ? (
               <p className="mt-3 text-xs leading-5 text-muted-foreground">
-                Builder.io PR recaps require a Builder.io org account.
+                Builder.io PR recaps need a Builder.io org account or one shared
+                on the plan.
               </p>
             ) : null}
             {!showAccessHelp && !planMissing ? (

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -5613,8 +5613,8 @@ function PlanLoadError({
           ? "This plan exists, but this account is not on the access list."
           : "This looks like a private plan link, and this account may not have access."
         : planExists
-          ? "This plan exists, but it is private. Sign in with an account that belongs to the right organization or has been shared on the plan."
-          : "This looks like a private plan link. Sign in with an account that belongs to the right organization or has been shared on the plan."
+          ? "This plan is private. Sign in with the right organization account or one shared on the plan."
+          : "This may be a private plan. Sign in with the right organization account or one shared on the plan."
       : message;
   const icon = planMissing ? (
     <IconSearch className="size-5" />
@@ -5664,8 +5664,7 @@ function PlanLoadError({
             ) : null}
             {showAccessHelp && !signedIn ? (
               <p className="mt-3 text-xs leading-5 text-muted-foreground">
-                For Builder.io PR recaps, use an account in the Builder.io
-                organization or one explicitly shared on the plan.
+                Builder.io PR recaps require a Builder.io org account.
               </p>
             ) : null}
             {!showAccessHelp && !planMissing ? (


### PR DESCRIPTION
## Summary
- Trim private-plan sign-in and Builder.io PR recap access copy
- Add allowlisted `data-icon` markers that render Tabler-style SVGs in wireframes
- Update visual plan/recap guidance so agents emit icons instead of literal words like email/lock/chevron

## Visual recap
- Hosted: https://plan.agent-native.com/_agent-native/open?app=plan&view=plan&to=%2Frecaps%2Frecap-3316f9131e264897&planId=recap-3316f9131e264897&agentSidebar=closed
- Local renderer proof: http://127.0.0.1:4173/local-plans/wireframe-icons-private-plan-copy

## Validation
- `pnpm --filter @agent-native/core exec vitest --run src/client/blocks/library/wireframe.render.spec.tsx`
- `pnpm --filter @agent-native/core typecheck`
- `pnpm --filter plan typecheck`
- Local Chrome render confirmed SVG icons for `lock`, `mail`, and `chevronDown` with no visible icon words in the after frame
