### PR TITLE
docs: fix duplicate word in core README

### DIFF
--- a/.changeset/docs-fix-core-readme-duplicate-word.md
+++ b/.changeset/docs-fix-core-readme-duplicate-word.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix a duplicate word in the core README.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -193,7 +193,7 @@ Don't want to scaffold a whole app yet? Add agent-native superpowers to a coding
 npx @agent-native/core@latest skills add visual-plan
 ```
 
-It installs the skill, registers the hosted MCP connector, and signs you in in one step — then run `/visual-plan`. See the **[Skills Guide](https://agent-native.com/docs/skills-guide#app-backed-skills)** for more skills and local installs.
+It installs the skill, registers the hosted MCP connector, and signs you in one step — then run `/visual-plan`. See the **[Skills Guide](https://agent-native.com/docs/skills-guide#app-backed-skills)** for more skills and local installs.
 
 ## Workspaces (Monorepo)
 


### PR DESCRIPTION
Removes a duplicated word in the core README: `in in` → `in`.

This is a documentation-only change.