### PR TITLE
Add AGENT_NATIVE_SERVERLESS_FFMPEG_ARCH to clips

### DIFF
--- a/templates/clips/netlify.toml
+++ b/templates/clips/netlify.toml
@@ -7,6 +7,12 @@
 [build.environment]
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
+  # Netlify Functions run on linux/x64 (AWS Lambda). This tells the deploy build
+  # to bundle the matching ffmpeg-static binary into the server bundle so the
+  # server-side audio-only transcription fallback (analyzeAudioSignal / audio
+  # extraction) can spawn ffmpeg. Without it ffmpeg-static is skipped at build
+  # time and request-transcript fails at runtime with FFMPEG_UNAVAILABLE.
+  AGENT_NATIVE_SERVERLESS_FFMPEG_ARCH = "x64"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
 # The framework does not impose a default agent-run timeout; if a template sets


### PR DESCRIPTION
Sets AGENT_NATIVE_SERVERLESS_FFMPEG_ARCH = "x64" in netlify.toml so the build bundles the linux/x64 ffmpeg-static binary into the Netlify Functions server bundle. Without it, ffmpeg-static is skipped at build time and request-transcript fails at runtime with FFMPEG_UNAVAILABLE.