### PR TITLE
Fix plan image editor mount crash

### DIFF
--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -8,6 +8,14 @@ metadata:
 
 Monitor PR #$ARGUMENTS in the current repo. Fix CI failures and human or bot review feedback until everything is green and no new feedback arrives for 30 minutes.
 
+## Non-Negotiable Branch Ownership Rule
+
+During `/babysit-pr`, the PR branch is the unit of ownership. Every tick must
+commit and push **all** non-gitignored local changes on the current branch,
+including changes made by the user or other concurrent agents. Do not limit
+commits to files you personally edited. Do not stash, skip, or leave behind
+local work unless it is `learnings.md` or an ignored/personal file.
+
 **If no PR number is given**, auto-detect it: get the current branch (`git branch --show-current`), find the open PR for it (`gh pr list --head <branch> --state open --json number --limit 1`). If no open PR exists, check recent merged/closed PRs. Only ask the user if no PR can be found.
 
 ## Setup

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -12,6 +12,14 @@ Ship the current branch end-to-end: commit and push all local work, open a
 ready PR, run `/babysit-pr`, merge when the babysit merge gates are satisfied,
 then run `/new-branch` after the merge lands.
 
+## Non-Negotiable Shipping Invariant
+
+`/ship` ships the **branch**, not just the agent's own edits. Commit and push
+all non-gitignored local changes that are present on the current branch,
+including work created by the user or other concurrent agents. Do not leave
+local changes behind because you did not author them. The only routine
+exceptions are `learnings.md` and ignored/personal files.
+
 Invoking `/ship` is explicit authorization to merge this PR once the merge gates
 below pass, unless the user says not to merge. Do not ask again just to merge a
 clean PR. Do not stop after creating the PR; the default `/ship` outcome is a

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ node_modules
 dist
 .netlify
 out
+.video-bakeoff
 pnpm-lock.yaml
 **/SKILL.md
 **/routeTree.gen.ts
@@ -14,6 +15,7 @@ templates/plan/e2e/.auth
 templates/plan/e2e/.report.json
 templates/plan/e2e/smoke.spec.ts
 templates/plan/e2e/zzprobe*.spec.ts
+templates/content/e2e/.report.json
 templates/plan/plans/*
 !templates/plan/plans/plan_2051dec8ca3d4644/
 !templates/plan/plans/plan_2051dec8ca3d4644/**

--- a/templates/plan/app/components/editor/PlanDocumentEditor.repro.spec.tsx
+++ b/templates/plan/app/components/editor/PlanDocumentEditor.repro.spec.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PlanContent } from "@shared/plan-content";
+import { PlanDocumentEditor } from "./PlanDocumentEditor";
+
+const IMAGE_SRC = "https://cdn.example.com/cat.png";
+
+let container: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  document
+    .querySelectorAll("img")
+    .forEach((image) => image.removeAttribute("src"));
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function flushEditorEffects() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe("PlanDocumentEditor image node", () => {
+  it("mounts markdown images without reading editor.view.dom before the view exists", async () => {
+    const content: PlanContent = {
+      version: 2,
+      blocks: [
+        {
+          id: "rich-text-with-image",
+          type: "rich-text",
+          data: {
+            markdown: `Intro copy.\n\n![A cat](${IMAGE_SRC})\n\nDone.`,
+          },
+        },
+      ],
+    };
+
+    expect(() => {
+      act(() => {
+        root.render(
+          <PlanDocumentEditor
+            content={content}
+            editable
+            onBlocksChange={vi.fn()}
+          />,
+        );
+      });
+    }).not.toThrow();
+
+    await flushEditorEffects();
+    await flushEditorEffects();
+
+    const image = container.querySelector(
+      ".plan-image-node img",
+    ) as HTMLImageElement | null;
+    expect(
+      container.querySelector(".plan-document-editor .ProseMirror"),
+    ).toBeTruthy();
+    expect(image?.getAttribute("src")).toBe(IMAGE_SRC);
+    expect(image?.getAttribute("alt")).toBe("A cat");
+  });
+});

--- a/templates/plan/app/components/editor/PlanDocumentEditor.tsx
+++ b/templates/plan/app/components/editor/PlanDocumentEditor.tsx
@@ -78,6 +78,27 @@ function isElementFocused(element: HTMLElement | null): boolean {
   return !!active && element.contains(active);
 }
 
+function getMountedEditorView(editor: Editor): EditorView | null {
+  try {
+    const view = editor.view;
+    void view.dom;
+    return view;
+  } catch {
+    return null;
+  }
+}
+
+function scheduleEditorViewCapture(callback: () => void): void {
+  if (
+    typeof window !== "undefined" &&
+    typeof window.requestAnimationFrame === "function"
+  ) {
+    window.requestAnimationFrame(callback);
+    return;
+  }
+  setTimeout(callback, 0);
+}
+
 function isTransferredPlanBlock(value: unknown): value is PlanBlock {
   return (
     !!value &&
@@ -773,11 +794,21 @@ export function PlanDocumentEditor({
   const editorRef = useRef<Editor | null>(null);
   const wrapperRef = useRef<HTMLElement | null>(null);
   const handleEditorReady = useCallback((editor: Editor) => {
-    rootViewRef.current = editor.view;
     editorRef.current = editor;
-    wrapperRef.current =
-      (editor.view.dom.closest(`.${WRAPPER_CLASS}`) as HTMLElement | null) ??
-      null;
+
+    const captureMountedView = () => {
+      if (editor.isDestroyed) return;
+      const view = getMountedEditorView(editor);
+      if (!view) {
+        scheduleEditorViewCapture(captureMountedView);
+        return;
+      }
+      rootViewRef.current = view;
+      wrapperRef.current =
+        (view.dom.closest(`.${WRAPPER_CLASS}`) as HTMLElement | null) ?? null;
+    };
+
+    captureMountedView();
   }, []);
 
   // Single app-level undo authority over the authoritative `blocks[]` tree. PM

--- a/templates/plan/app/components/plan/PlanImageNode.tsx
+++ b/templates/plan/app/components/plan/PlanImageNode.tsx
@@ -29,7 +29,7 @@ function PlanImageNodeView({
   const src = (node.attrs.src as string) || "";
   const alt = (node.attrs.alt as string) || "";
   const uploading = Boolean(node.attrs.uploadId);
-  const isEditable = editor.isEditable;
+  const isEditable = editor.options.editable !== false;
 
   async function handleReplaceFile(event: ChangeEvent<HTMLInputElement>) {
     const file = event.currentTarget.files?.[0];


### PR DESCRIPTION
## Summary
- defer plan editor DOM capture until Tiptap has mounted a real view
- avoid the live editor view getter while rendering plan image nodes
- add a regression test for rich-text markdown images
- ignore generated local eval/report artifacts during Prettier checks

## Validation
- pnpm prep