### PR TITLE
Add group booking links to calendar

### DIFF
--- a/templates/calendar/.agents/skills/availability-booking/SKILL.md
+++ b/templates/calendar/.agents/skills/availability-booking/SKILL.md
@@ -53,6 +53,28 @@ Optional: `--duration` (minimum slot length in minutes, default 30).
 
 Booking links are stored in SQL via Drizzle ORM. Each link has a slug, duration, and associated availability.
 
+Booking links can also have required co-hosts. The owner is always included;
+`hosts` stores additional required co-hosts:
+
+```bash
+pnpm action create-booking-link \
+  --title "Steve + Brent" \
+  --slug "steve-brent-30" \
+  --duration 30 \
+  --hosts "brent@example.com"
+```
+
+Use `update-booking-link` to add or remove co-hosts on an existing link. Group
+booking links only show slots when the owner and every co-host can be checked as
+free. When a booking is confirmed, the app creates the Google Calendar event on
+the owner's connected account and adds co-hosts as invited attendees.
+
+Management sharing is separate from public booking access:
+
+- Use framework sharing actions / the share dialog to grant management access to
+  people or the organization.
+- The public booking URL and `isActive` decide whether visitors can book.
+
 The UI manages booking links at `/booking-links`. The public booking URL pattern is:
 
 ```

--- a/templates/calendar/AGENTS.md
+++ b/templates/calendar/AGENTS.md
@@ -22,6 +22,12 @@ Detailed event, availability, booking, storage, and UI rules live in
   reauth-needed, or fetch failures.
 - Use framework sharing actions for calendars/events/booking resources when
   applicable.
+- Booking-link sharing controls who can manage the link. Public booking access
+  is still controlled by the `/book/{username}/{slug}` URL and `isActive`.
+- `create-booking-link` and `update-booking-link` accept `hosts` for required
+  co-hosts besides the owner, e.g. `hosts: ["brent@example.com"]`. Group links
+  only offer times when the owner and all co-hosts are free, then invite
+  co-hosts to the created Google Calendar event.
 - Keep scheduling answers concrete: exact dates, time zones, conflicts, and
   assumptions.
 - Use `rsvp-event` for invitation responses. Pass `note` when the user wants a

--- a/templates/calendar/actions/duplicate-booking-link.ts
+++ b/templates/calendar/actions/duplicate-booking-link.ts
@@ -10,6 +10,7 @@ import { accessFilter } from "@agent-native/core/sharing";
 import type { BookingLink } from "../shared/api.js";
 import { getDb, schema } from "../server/db/index.js";
 import { normalizeBookingDurationInput } from "../server/lib/booking-durations.js";
+import { rowToBookingLink } from "../server/lib/booking-link-utils.js";
 
 const durationSchema = z.coerce
   .number()
@@ -40,32 +41,6 @@ function parseJson<T>(value: string | null, fallback: T): T {
   } catch {
     return fallback;
   }
-}
-
-function rowToBookingLink(
-  row: typeof schema.bookingLinks.$inferSelect,
-): BookingLink {
-  return {
-    id: row.id,
-    slug: row.slug,
-    title: row.title,
-    description: row.description ?? undefined,
-    duration: row.duration,
-    durations: parseJson<number[] | undefined>(row.durations, undefined),
-    customFields: parseJson<BookingLink["customFields"]>(
-      row.customFields,
-      undefined,
-    ),
-    conferencing: parseJson<BookingLink["conferencing"]>(
-      row.conferencing,
-      undefined,
-    ),
-    color: row.color ?? undefined,
-    isActive: row.isActive,
-    visibility: row.visibility,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
 }
 
 function slugify(value: string): string {
@@ -198,6 +173,7 @@ export default defineAction({
           durations: durationInput.durations
             ? JSON.stringify(durationInput.durations)
             : null,
+          hosts: source.hosts,
           customFields: source.customFields,
           conferencing: source.conferencing,
           color: source.color,

--- a/templates/calendar/actions/list-booking-links.ts
+++ b/templates/calendar/actions/list-booking-links.ts
@@ -2,46 +2,8 @@ import { defineAction } from "@agent-native/core";
 import { desc } from "drizzle-orm";
 import { accessFilter } from "@agent-native/core/sharing";
 import { z } from "zod";
-import type { BookingLink } from "../shared/api.js";
 import { getDb, schema } from "../server/db/index.js";
-
-function rowToBookingLink(
-  row: typeof schema.bookingLinks.$inferSelect,
-): BookingLink {
-  let durations: number[] | undefined;
-  if (row.durations) {
-    try {
-      durations = JSON.parse(row.durations);
-    } catch {}
-  }
-  let customFields: BookingLink["customFields"];
-  if (row.customFields) {
-    try {
-      customFields = JSON.parse(row.customFields);
-    } catch {}
-  }
-  let conferencing: BookingLink["conferencing"];
-  if (row.conferencing) {
-    try {
-      conferencing = JSON.parse(row.conferencing);
-    } catch {}
-  }
-  return {
-    id: row.id,
-    slug: row.slug,
-    title: row.title,
-    description: row.description ?? undefined,
-    duration: row.duration,
-    durations,
-    customFields,
-    conferencing,
-    color: row.color ?? undefined,
-    isActive: row.isActive,
-    visibility: row.visibility,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
-}
+import { rowToBookingLink } from "../server/lib/booking-link-utils.js";
 
 export default defineAction({
   description: "List all booking links",

--- a/templates/calendar/actions/update-booking-link.ts
+++ b/templates/calendar/actions/update-booking-link.ts
@@ -1,17 +1,19 @@
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
-import { nanoid } from "nanoid";
 import { eq } from "drizzle-orm";
-import {
-  getRequestUserEmail,
-  getRequestOrgId,
-} from "@agent-native/core/server/request-context";
+import { assertAccess } from "@agent-native/core/sharing";
 import { getDb, schema } from "../server/db/index.js";
 import { normalizeBookingDurationInput } from "../server/lib/booking-durations.js";
 import {
   rowToBookingLink,
   serializeBookingHosts,
 } from "../server/lib/booking-link-utils.js";
+
+const durationSchema = z.coerce
+  .number()
+  .int()
+  .min(5)
+  .max(24 * 60);
 
 const hostsSchema = z
   .union([
@@ -30,29 +32,19 @@ const hostsSchema = z
 
 export default defineAction({
   description:
-    "Create a new booking link/event type. Use this instead of raw SQL for booking links.",
+    "Update an existing booking link/event type, including required co-hosts.",
   schema: z.object({
+    id: z.string().describe("Booking link id"),
     title: z.string().min(1).describe("Booking link title"),
     slug: z
       .string()
       .min(1)
       .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
       .describe("URL slug, lowercase words separated by hyphens"),
-    duration: z.coerce
-      .number()
-      .int()
-      .min(5)
-      .max(24 * 60)
-      .describe("Default duration in minutes"),
+    duration: durationSchema.describe("Default duration in minutes"),
     description: z.string().optional().describe("Description"),
     durations: z
-      .array(
-        z.coerce
-          .number()
-          .int()
-          .min(5)
-          .max(24 * 60),
-      )
+      .array(durationSchema)
       .optional()
       .describe("Optional duration choices, e.g. [30,45,60]"),
     hosts: hostsSchema.describe(
@@ -64,16 +56,18 @@ export default defineAction({
     isActive: z.boolean().optional().describe("Whether the link is active"),
   }),
   run: async (args) => {
-    const body = args as Record<string, any>;
+    await assertAccess("booking-link", args.id, "editor");
+
     const durationInput = normalizeBookingDurationInput({
-      duration: body.duration,
-      durations: body.durations,
+      duration: args.duration,
+      durations: args.durations,
     });
     if ("error" in durationInput) {
       throw new Error(durationInput.error);
     }
-    const slug = String(body.slug).trim().toLowerCase();
-    const [existingLink, existingRedirect] = await Promise.all([
+
+    const slug = args.slug.trim().toLowerCase();
+    const [existingSlug, existingRedirect] = await Promise.all([
       getDb()
         .select({ id: schema.bookingLinks.id })
         .from(schema.bookingLinks)
@@ -84,47 +78,67 @@ export default defineAction({
         .where(eq(schema.bookingSlugRedirects.oldSlug, slug)),
     ]);
 
-    if (existingLink.length > 0 || existingRedirect.length > 0) {
+    if (existingSlug.some((row) => row.id !== args.id)) {
+      throw new Error("A booking link with this slug already exists");
+    }
+    if (existingRedirect.length > 0) {
       throw new Error("A booking link with this slug already exists");
     }
 
-    const now = new Date().toISOString();
-    const id = nanoid();
-    const ownerEmail = (() => {
-      const e = getRequestUserEmail();
-      if (!e) throw new Error("no authenticated user");
-      return e;
-    })();
+    const [current] = await getDb()
+      .select({
+        slug: schema.bookingLinks.slug,
+        ownerEmail: schema.bookingLinks.ownerEmail,
+      })
+      .from(schema.bookingLinks)
+      .where(eq(schema.bookingLinks.id, args.id));
+
+    if (!current) throw new Error("Booking link not found");
+    const oldSlug = current.slug;
+    const slugChanged = oldSlug !== slug;
+
     await getDb()
-      .insert(schema.bookingLinks)
-      .values({
-        id,
+      .update(schema.bookingLinks)
+      .set({
         slug,
-        title: String(body.title).trim(),
-        description: body.description ? String(body.description).trim() : null,
+        title: args.title.trim(),
+        description: args.description ? args.description.trim() : null,
         duration: durationInput.duration,
         durations: durationInput.durations
           ? JSON.stringify(durationInput.durations)
           : null,
-        hosts: serializeBookingHosts(body.hosts, ownerEmail),
-        customFields: body.customFields
-          ? JSON.stringify(body.customFields)
+        hosts: serializeBookingHosts(args.hosts, current.ownerEmail),
+        customFields: args.customFields
+          ? JSON.stringify(args.customFields)
           : null,
-        conferencing: body.conferencing
-          ? JSON.stringify(body.conferencing)
+        conferencing: args.conferencing
+          ? JSON.stringify(args.conferencing)
           : null,
-        color: body.color ? String(body.color).trim() : null,
-        isActive: body.isActive ?? true,
-        ownerEmail,
-        orgId: getRequestOrgId(),
-        createdAt: now,
-        updatedAt: now,
-      });
+        color: args.color ? args.color.trim() : null,
+        isActive: args.isActive ?? true,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(schema.bookingLinks.id, args.id));
 
-    const created = await getDb()
+    if (slugChanged) {
+      const now = new Date().toISOString();
+      await getDb().insert(schema.bookingSlugRedirects).values({
+        oldSlug,
+        newSlug: slug,
+        createdAt: now,
+      });
+      await getDb()
+        .update(schema.bookingSlugRedirects)
+        .set({ newSlug: slug })
+        .where(eq(schema.bookingSlugRedirects.newSlug, oldSlug));
+    }
+
+    const [updated] = await getDb()
       .select()
       .from(schema.bookingLinks)
-      .where(eq(schema.bookingLinks.id, id));
-    return rowToBookingLink(created[0]);
+      .where(eq(schema.bookingLinks.id, args.id));
+
+    if (!updated) throw new Error("Booking link not found");
+    return rowToBookingLink(updated);
   },
 });

--- a/templates/calendar/actions/view-screen.ts
+++ b/templates/calendar/actions/view-screen.ts
@@ -1,9 +1,12 @@
 import { defineAction } from "@agent-native/core";
 import { readAppState } from "@agent-native/core/application-state";
 import { getRequestUserEmail } from "@agent-native/core/server";
+import { accessFilter } from "@agent-native/core/sharing";
 import { z } from "zod";
 import { extractVideoLink } from "./event-action-helpers.js";
 import { listCalendarEvents } from "./list-events.js";
+import { getDb, schema } from "../server/db/index.js";
+import { rowToBookingLink } from "../server/lib/booking-link-utils.js";
 import {
   CALENDAR_VIEW_PREFERENCES_KEY,
   normalizeCalendarViewPreferences,
@@ -133,6 +136,26 @@ export default defineAction({
     } else if (nav?.view === "booking-links") {
       screen.page = "booking-links";
       if (nav?.bookingLinkId) screen.bookingLinkId = nav.bookingLinkId;
+      const rows = await getDb()
+        .select()
+        .from(schema.bookingLinks)
+        .where(accessFilter(schema.bookingLinks, schema.bookingLinkShares));
+      const links = rows.map(rowToBookingLink);
+      screen.bookingLinks = links.slice(0, 50).map((link) => ({
+        id: link.id,
+        title: link.title,
+        slug: link.slug,
+        duration: link.duration,
+        durations: link.durations,
+        hosts: link.hosts,
+        visibility: link.visibility,
+        isActive: link.isActive,
+      }));
+      if (nav?.bookingLinkId) {
+        screen.selectedBookingLink = links.find(
+          (link) => link.id === nav.bookingLinkId,
+        );
+      }
     } else if (nav?.view === "bookings") {
       screen.page = "bookings";
     } else if (nav?.view === "settings") {

--- a/templates/calendar/app/hooks/use-booking-links.ts
+++ b/templates/calendar/app/hooks/use-booking-links.ts
@@ -2,7 +2,12 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { nanoid } from "nanoid";
 import { useActionQuery, useActionMutation } from "@agent-native/core/client";
 import { appApiPath } from "@/lib/api-path";
-import type { BookingLink, ConferencingConfig, CustomField } from "@shared/api";
+import type {
+  BookingHost,
+  BookingLink,
+  ConferencingConfig,
+  CustomField,
+} from "@shared/api";
 
 const LIST_KEY = ["action", "list-booking-links", undefined] as const;
 
@@ -35,6 +40,7 @@ export function useCreateBookingLink() {
     Pick<BookingLink, "title" | "slug" | "duration"> & {
       description?: string;
       durations?: number[];
+      hosts?: BookingHost[];
       customFields?: CustomField[];
       conferencing?: ConferencingConfig;
       color?: string;
@@ -56,6 +62,7 @@ export function useCreateBookingLink() {
         description: input.description,
         duration: input.duration,
         durations: input.durations,
+        hosts: input.hosts,
         customFields: input.customFields,
         conferencing: input.conferencing,
         color: input.color,
@@ -91,27 +98,17 @@ export function useCreateBookingLink() {
 
 export function useUpdateBookingLink() {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: async (
-      data: Pick<
-        BookingLink,
-        "id" | "title" | "slug" | "duration" | "isActive"
-      > & {
-        description?: string;
-        durations?: number[];
-        customFields?: CustomField[];
-        conferencing?: ConferencingConfig;
-        color?: string;
-      },
-    ) => {
-      const res = await fetch(appApiPath(`/api/booking-links/${data.id}`), {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data),
-      });
-      if (!res.ok) throw new Error("Failed to update booking link");
-      return res.json() as Promise<BookingLink>;
-    },
+  return useActionMutation<
+    BookingLink,
+    Pick<BookingLink, "id" | "title" | "slug" | "duration" | "isActive"> & {
+      description?: string;
+      durations?: number[];
+      hosts?: BookingHost[];
+      customFields?: CustomField[];
+      conferencing?: ConferencingConfig;
+      color?: string;
+    }
+  >("update-booking-link", {
     onSuccess: (updated) => {
       queryClient.setQueryData<BookingLink[]>(LIST_KEY, (current = []) =>
         current.map((link) => (link.id === updated.id ? updated : link)),

--- a/templates/calendar/app/pages/BookingLinksPage.tsx
+++ b/templates/calendar/app/pages/BookingLinksPage.tsx
@@ -13,8 +13,10 @@ import {
   IconDotsVertical,
   IconPlus,
   IconTrash,
+  IconUsers,
   IconVideo,
   IconVideoOff,
+  IconX,
 } from "@tabler/icons-react";
 import { nanoid } from "nanoid";
 import { toast } from "sonner";
@@ -87,7 +89,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { VisibilityBadge } from "@agent-native/core/client";
+import { ShareButton, VisibilityBadge } from "@agent-native/core/client";
 import { useAppHeaderControls } from "@/components/layout/AppLayout";
 import {
   useBookingLinks,
@@ -105,6 +107,7 @@ import { TimezoneCombobox } from "@/components/TimezoneCombobox";
 import BookingsList from "./BookingsList";
 import type {
   AvailabilityConfig,
+  BookingHost,
   BookingLink,
   ConferencingConfig,
   CustomField,
@@ -128,6 +131,7 @@ const BRAND_ICON_LINK_CLASS =
   "text-[#00B5FF] hover:bg-[#00B5FF]/10 hover:text-[#33C4FF]";
 const BRAND_PILL_LINK_CLASS =
   "border-[#00B5FF]/35 bg-[#00B5FF]/10 font-semibold text-[#00B5FF] hover:border-[#00B5FF]/55 hover:bg-[#00B5FF]/15 hover:text-[#33C4FF]";
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type DraftLink = {
   id?: string;
@@ -136,6 +140,7 @@ type DraftLink = {
   description: string;
   duration: number;
   durations: number[];
+  hosts: BookingHost[];
   customFields: CustomField[];
   conferencing: ConferencingConfig;
   isActive: boolean;
@@ -178,6 +183,7 @@ function createEmptyDraft(): DraftLink {
     description: "",
     duration: 30,
     durations: [30],
+    hosts: [],
     customFields: [],
     conferencing: { type: "none" },
     isActive: true,
@@ -199,6 +205,7 @@ function draftFromBookingLink(link: BookingLink): DraftLink {
     description: link.description || "",
     duration: primaryDuration,
     durations,
+    hosts: link.hosts || [],
     customFields: link.customFields || [],
     conferencing: link.conferencing || { type: "none" },
     isActive: link.isActive,
@@ -215,10 +222,16 @@ function getDraftSignature(draft: DraftLink) {
     description: draft.description.trim(),
     duration: draft.duration,
     durations: draft.durations,
+    hosts: draft.hosts,
     customFields: draft.customFields,
     conferencing: draft.conferencing,
     isActive: draft.isActive,
   });
+}
+
+function normalizeHostEmail(value: string) {
+  const email = value.trim().toLowerCase();
+  return EMAIL_RE.test(email) ? email : null;
 }
 
 /** Format "09:00" → "9 am", "17:00" → "5 pm" */
@@ -459,6 +472,111 @@ function BookingConferencingSelect({
             placeholder="https://meet.example.com/room"
           />
         </div>
+      )}
+    </div>
+  );
+}
+
+function BookingHostsEditor({
+  hosts,
+  onChange,
+}: {
+  hosts: BookingHost[];
+  onChange: (hosts: BookingHost[]) => void;
+}) {
+  const [input, setInput] = useState("");
+
+  function addHosts() {
+    const entries = input
+      .split(/[\s,;]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    if (entries.length === 0) return;
+
+    const existing = new Set(hosts.map((host) => host.email.toLowerCase()));
+    const next = [...hosts];
+    const invalid: string[] = [];
+
+    for (const entry of entries) {
+      const email = normalizeHostEmail(entry);
+      if (!email) {
+        invalid.push(entry);
+        continue;
+      }
+      if (existing.has(email)) continue;
+      existing.add(email);
+      next.push({ email });
+    }
+
+    if (invalid.length > 0) {
+      toast.error(`Invalid email: ${invalid[0]}`);
+    }
+    if (next.length !== hosts.length) {
+      onChange(next);
+      setInput("");
+    }
+  }
+
+  function removeHost(email: string) {
+    onChange(hosts.filter((host) => host.email !== email));
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <Label className="flex items-center gap-1.5">
+          <IconUsers className="h-4 w-4" />
+          Required hosts
+        </Label>
+        <p className="text-xs text-muted-foreground">
+          You are included automatically. Add teammates who must also be free.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Input
+          type="email"
+          value={input}
+          onChange={(event) => setInput(event.currentTarget.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              addHosts();
+            }
+          }}
+          placeholder="teammate@example.com"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          onClick={addHosts}
+          disabled={!input.trim()}
+          className="shrink-0"
+        >
+          Add
+        </Button>
+      </div>
+      {hosts.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {hosts.map((host) => (
+            <Badge
+              key={host.email}
+              variant="secondary"
+              className="gap-1.5 pr-1"
+            >
+              {host.displayName || host.email}
+              <button
+                type="button"
+                onClick={() => removeHost(host.email)}
+                className="rounded-sm p-0.5 text-muted-foreground hover:bg-background hover:text-foreground"
+                aria-label={`Remove ${host.email}`}
+              >
+                <IconX className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">Only you are required.</p>
       )}
     </div>
   );
@@ -718,6 +836,7 @@ export default function BookingLinksPage({
         description: draft.description.trim() || undefined,
         duration: draft.durations[0] ?? draft.duration,
         durations: draft.durations.length > 1 ? draft.durations : undefined,
+        hosts: draft.hosts.length > 0 ? draft.hosts : undefined,
         customFields:
           draft.customFields.length > 0 ? draft.customFields : undefined,
         conferencing: draft.conferencing,
@@ -812,6 +931,35 @@ export default function BookingLinksPage({
       ),
       right: selectedLink ? (
         <div className="flex items-center gap-1.5">
+          {!selectedLink.id.startsWith(OPTIMISTIC_PREFIX) && (
+            <ShareButton
+              resourceType="booking-link"
+              resourceId={selectedLink.id}
+              resourceTitle={draft.title || selectedLink.title}
+              variant="compact"
+              shareUrl={previewUrl}
+              shareUrlLabel="Public booking link"
+              shareUrlDescription="Bookers use this URL to pick a time. Sharing controls who can manage this booking link."
+              shareUrlPlacement="top"
+              peopleAccessLabel="People with management access"
+              generalAccessLabel="General management access"
+              visibilityCopy={{
+                private: {
+                  description:
+                    "Only invited people can manage this booking link",
+                },
+                org: {
+                  description:
+                    "Anyone in your organization can open and manage this booking link",
+                },
+                public: {
+                  label: "Public management access",
+                  description:
+                    "Anyone with the app link can view this booking link setup",
+                },
+              }}
+            />
+          )}
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -863,7 +1011,9 @@ export default function BookingLinksPage({
   }, [
     selectedId,
     selectedLink,
+    draft.title,
     draft.slug,
+    previewUrl,
     updateBookingLink.isPending,
     hasUnsavedChanges,
     navigate,
@@ -1192,6 +1342,11 @@ export default function BookingLinksPage({
                   zoomPending={connectZoom.isPending}
                 />
 
+                <BookingHostsEditor
+                  hosts={draft.hosts}
+                  onChange={(hosts) => setDraft((prev) => ({ ...prev, hosts }))}
+                />
+
                 {/* Custom fields editor — shared package component */}
                 <SharedCustomFieldsEditor
                   fields={draft.customFields}
@@ -1274,6 +1429,7 @@ export default function BookingLinksPage({
                   title={draft.title}
                   description={draft.description}
                   durations={draft.durations}
+                  hosts={draft.hosts}
                   customFields={draft.customFields}
                   isActive={draft.isActive}
                   availability={availability ?? undefined}
@@ -1332,6 +1488,11 @@ export default function BookingLinksPage({
                   const durationLabel = durations
                     .map((d) => (d >= 60 ? `${d / 60} hr` : `${d} min`))
                     .join(", ");
+                  const hostCount = (link.hosts?.length ?? 0) + 1;
+                  const hostLabel =
+                    hostCount > 1
+                      ? `${hostCount} required hosts`
+                      : "One-on-One";
 
                   return (
                     <div
@@ -1362,7 +1523,7 @@ export default function BookingLinksPage({
                             <VisibilityBadge visibility={link.visibility} />
                           </div>
                           <p className="mt-0.5 text-xs text-muted-foreground truncate">
-                            {durationLabel} • One-on-One
+                            {durationLabel} • {hostLabel}
                           </p>
                           {availability && (
                             <p className="mt-0.5 text-xs text-muted-foreground truncate">
@@ -1433,6 +1594,7 @@ export default function BookingLinksPage({
                                       slug: link.slug,
                                       duration: durations[0] ?? link.duration,
                                       durations: link.durations,
+                                      hosts: link.hosts,
                                       description: link.description,
                                       customFields: link.customFields,
                                       conferencing: link.conferencing,
@@ -1667,6 +1829,7 @@ function BookingPreview({
   title,
   description,
   durations,
+  hosts = [],
   customFields = [],
   isActive,
   availability,
@@ -1678,6 +1841,7 @@ function BookingPreview({
   title: string;
   description: string;
   durations: number[];
+  hosts?: BookingHost[];
   customFields?: CustomField[];
   isActive: boolean;
   availability?: AvailabilityConfig;
@@ -1891,10 +2055,19 @@ function BookingPreview({
               {description}
             </p>
           )}
-          {!hasDurationChoice && (
-            <span className="inline-flex rounded-full border border-border px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground">
-              {primaryDuration} minute meeting
-            </span>
+          {(!hasDurationChoice || hosts.length > 0) && (
+            <div className="flex flex-wrap justify-center gap-2">
+              {!hasDurationChoice && (
+                <span className="inline-flex rounded-full border border-border px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+                  {primaryDuration} minute meeting
+                </span>
+              )}
+              {hosts.length > 0 && (
+                <span className="inline-flex rounded-full border border-border px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+                  {hosts.length + 1} required hosts
+                </span>
+              )}
+            </div>
           )}
         </div>
 

--- a/templates/calendar/app/pages/BookingPage.tsx
+++ b/templates/calendar/app/pages/BookingPage.tsx
@@ -230,6 +230,7 @@ export default function BookingPage() {
   const isLegacyBookingPage = !!slug && availability?.bookingPageSlug === slug;
   const pageTitle = bookingLink?.title || title;
   const pageDescription = bookingLink?.description || description;
+  const requiredHostCount = (bookingLink?.hosts?.length ?? 0) + 1;
 
   useEffect(() => {
     if (hasDurationChoice && step === "date" && selectedDuration === null) {
@@ -282,10 +283,19 @@ export default function BookingPage() {
           <p className="mt-1 text-sm text-muted-foreground">
             {pageDescription}
           </p>
-          {!hasDurationChoice && (
-            <p className="mt-3 inline-flex rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground">
-              {duration} minute meeting
-            </p>
+          {(!hasDurationChoice || requiredHostCount > 1) && (
+            <div className="mt-3 flex flex-wrap justify-center gap-2">
+              {!hasDurationChoice && (
+                <span className="inline-flex rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground">
+                  {duration} minute meeting
+                </span>
+              )}
+              {requiredHostCount > 1 && (
+                <span className="inline-flex rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground">
+                  {requiredHostCount} required hosts
+                </span>
+              )}
+            </div>
           )}
         </div>
 

--- a/templates/calendar/server/db/schema.ts
+++ b/templates/calendar/server/db/schema.ts
@@ -39,6 +39,8 @@ export const bookingLinks = table("booking_links", {
   duration: integer("duration").notNull().default(30),
   /** JSON array of additional duration options, e.g. [15, 30, 60] */
   durations: text("durations"),
+  /** JSON array of required co-hosts, excluding the owner */
+  hosts: text("hosts"),
   /** JSON array of custom field definitions */
   customFields: text("custom_fields"),
   /** JSON conferencing config (type + optional URL) */

--- a/templates/calendar/server/handlers/booking-links.ts
+++ b/templates/calendar/server/handlers/booking-links.ts
@@ -13,7 +13,6 @@ import {
   getRequestUserEmail,
   getRequestOrgId,
 } from "@agent-native/core/server/request-context";
-import type { BookingLink } from "../../shared/api.js";
 import { getDb, schema } from "../db/index.js";
 import {
   getSession,
@@ -22,6 +21,10 @@ import {
 } from "@agent-native/core/server";
 import { ensureBookingUsername } from "./booking-usernames.js";
 import { normalizeBookingDurationInput } from "../lib/booking-durations.js";
+import {
+  rowToBookingLink,
+  serializeBookingHosts,
+} from "../lib/booking-link-utils.js";
 
 async function requireRequestContext<T>(
   event: H3Event,
@@ -35,44 +38,6 @@ async function requireRequestContext<T>(
     { userEmail: session.email, orgId: session.orgId },
     fn,
   );
-}
-
-function rowToBookingLink(
-  row: typeof schema.bookingLinks.$inferSelect,
-): BookingLink {
-  let durations: number[] | undefined;
-  if (row.durations) {
-    try {
-      durations = JSON.parse(row.durations);
-    } catch {}
-  }
-  let customFields: BookingLink["customFields"];
-  if (row.customFields) {
-    try {
-      customFields = JSON.parse(row.customFields);
-    } catch {}
-  }
-  let conferencing: BookingLink["conferencing"];
-  if (row.conferencing) {
-    try {
-      conferencing = JSON.parse(row.conferencing);
-    } catch {}
-  }
-  return {
-    id: row.id,
-    slug: row.slug,
-    title: row.title,
-    description: row.description ?? undefined,
-    duration: row.duration,
-    durations,
-    customFields,
-    conferencing,
-    color: row.color ?? undefined,
-    isActive: row.isActive,
-    visibility: row.visibility,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
 }
 
 export const listBookingLinks = defineEventHandler(async (event: H3Event) => {
@@ -128,6 +93,11 @@ export const createBookingLink = defineEventHandler(async (event: H3Event) => {
 
       const now = new Date().toISOString();
       const id = nanoid();
+      const ownerEmail = (() => {
+        const e = getRequestUserEmail();
+        if (!e) throw new Error("no authenticated user");
+        return e;
+      })();
       await getDb()
         .insert(schema.bookingLinks)
         .values({
@@ -141,6 +111,7 @@ export const createBookingLink = defineEventHandler(async (event: H3Event) => {
           durations: durationInput.durations
             ? JSON.stringify(durationInput.durations)
             : null,
+          hosts: serializeBookingHosts(body.hosts, ownerEmail),
           customFields: body.customFields
             ? JSON.stringify(body.customFields)
             : null,
@@ -149,11 +120,7 @@ export const createBookingLink = defineEventHandler(async (event: H3Event) => {
             : null,
           color: body.color ? String(body.color).trim() : null,
           isActive: body.isActive ?? true,
-          ownerEmail: (() => {
-            const e = getRequestUserEmail();
-            if (!e) throw new Error("no authenticated user");
-            return e;
-          })(),
+          ownerEmail,
           orgId: getRequestOrgId(),
           createdAt: now,
           updatedAt: now,
@@ -166,125 +133,6 @@ export const createBookingLink = defineEventHandler(async (event: H3Event) => {
       return rowToBookingLink(created[0]);
     } catch (error: any) {
       setResponseStatus(event, error?.statusCode ?? 500);
-      return { error: error.message };
-    }
-  });
-});
-
-export const updateBookingLink = defineEventHandler(async (event: H3Event) => {
-  return requireRequestContext(event, async () => {
-    try {
-      const id = getRouterParam(event, "id");
-      if (!id) {
-        setResponseStatus(event, 400);
-        return { error: "id is required" };
-      }
-
-      const body = await readBody(event);
-      if (!body.title || !body.slug || !body.duration) {
-        setResponseStatus(event, 400);
-        return { error: "title, slug, and duration are required" };
-      }
-      const durationInput = normalizeBookingDurationInput({
-        duration: body.duration,
-        durations: body.durations,
-      });
-      if ("error" in durationInput) {
-        setResponseStatus(event, 400);
-        return { error: durationInput.error };
-      }
-
-      // Sharing: only owner / editor / admin can update.
-      await assertAccess("booking-link", id, "editor");
-
-      const slug = String(body.slug).trim().toLowerCase();
-      const [existingSlug, existingRedirect] = await Promise.all([
-        getDb()
-          .select({ id: schema.bookingLinks.id })
-          .from(schema.bookingLinks)
-          .where(eq(schema.bookingLinks.slug, slug)),
-        getDb()
-          .select({ oldSlug: schema.bookingSlugRedirects.oldSlug })
-          .from(schema.bookingSlugRedirects)
-          .where(eq(schema.bookingSlugRedirects.oldSlug, slug)),
-      ]);
-
-      if (existingSlug.some((row) => row.id !== id)) {
-        setResponseStatus(event, 409);
-        return { error: "A booking link with this slug already exists" };
-      }
-      if (existingRedirect.length > 0) {
-        setResponseStatus(event, 409);
-        return { error: "A booking link with this slug already exists" };
-      }
-
-      // Fetch current slug to detect changes
-      const current = await getDb()
-        .select({ slug: schema.bookingLinks.slug })
-        .from(schema.bookingLinks)
-        .where(eq(schema.bookingLinks.id, id));
-
-      if (current.length === 0) {
-        setResponseStatus(event, 404);
-        return { error: "Booking link not found" };
-      }
-
-      const oldSlug = current[0].slug;
-      const slugChanged = oldSlug !== slug;
-
-      await getDb()
-        .update(schema.bookingLinks)
-        .set({
-          slug,
-          title: String(body.title).trim(),
-          description: body.description
-            ? String(body.description).trim()
-            : null,
-          duration: durationInput.duration,
-          durations: durationInput.durations
-            ? JSON.stringify(durationInput.durations)
-            : null,
-          customFields: body.customFields
-            ? JSON.stringify(body.customFields)
-            : null,
-          conferencing: body.conferencing
-            ? JSON.stringify(body.conferencing)
-            : null,
-          color: body.color ? String(body.color).trim() : null,
-          isActive: body.isActive ?? true,
-          updatedAt: new Date().toISOString(),
-        })
-        .where(eq(schema.bookingLinks.id, id));
-
-      // Create redirect from old slug and repoint any existing redirects
-      if (slugChanged) {
-        const now = new Date().toISOString();
-        await getDb().insert(schema.bookingSlugRedirects).values({
-          oldSlug,
-          newSlug: slug,
-          createdAt: now,
-        });
-        // Chain: any redirects pointing to the old slug now point to the new one
-        await getDb()
-          .update(schema.bookingSlugRedirects)
-          .set({ newSlug: slug })
-          .where(eq(schema.bookingSlugRedirects.newSlug, oldSlug));
-      }
-
-      const updated = await getDb()
-        .select()
-        .from(schema.bookingLinks)
-        .where(eq(schema.bookingLinks.id, id));
-
-      if (updated.length === 0) {
-        setResponseStatus(event, 404);
-        return { error: "Booking link not found" };
-      }
-
-      return rowToBookingLink(updated[0]);
-    } catch (error: any) {
-      const status = error?.statusCode ?? 500;
-      setResponseStatus(event, status);
       return { error: error.message };
     }
   });

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -44,6 +44,10 @@ import {
   buildBookingEventAttendees,
   buildBookingEventTitle,
 } from "../lib/booking-event-details.js";
+import {
+  getBookingLinkCoHostEmails,
+  getBookingLinkRequiredHostEmails,
+} from "../lib/booking-link-utils.js";
 
 async function requireRequestContext<T>(
   event: H3Event,
@@ -68,6 +72,19 @@ async function getBookingLinkSlugsForOwner(
     .from(schema.bookingLinks)
     .where(eq(schema.bookingLinks.ownerEmail, ownerEmail));
   return rows.map((row) => row.slug);
+}
+
+async function getBookingLinkSlugsForOwners(
+  ownerEmails: string[],
+  db: ConflictDb = getDb(),
+): Promise<string[]> {
+  const slugs = new Set<string>();
+  for (const ownerEmail of ownerEmails) {
+    for (const slug of await getBookingLinkSlugsForOwner(ownerEmail, db)) {
+      slugs.add(slug);
+    }
+  }
+  return Array.from(slugs);
 }
 
 async function getBookingLinkOwnerEmail(
@@ -135,12 +152,14 @@ function recordBookingsChanged(owner?: string) {
 type AvailabilityContext = {
   effectiveConfig: AvailabilityConfig | null;
   ownerEmail?: string;
+  hostEmails: string[];
   slug: string;
   bookingLink?: BookingLinkRow;
   conflictSlugs: string[];
 };
 
 type ConflictItem = { start: string; end: string };
+type ConflictResult = { items: ConflictItem[]; unavailableReason?: string };
 type BookingLinkRow = typeof schema.bookingLinks.$inferSelect;
 type ConflictDb = Pick<ReturnType<typeof getDb>, "select">;
 
@@ -350,8 +369,13 @@ async function resolveAvailabilityContext({
         timezone?: string;
       } | null)
     : null;
+  const hostEmails = bookingLink
+    ? getBookingLinkRequiredHostEmails(bookingLink)
+    : ownerEmail
+      ? [ownerEmail]
+      : [];
   const conflictSlugs = ownerEmail
-    ? await getBookingLinkSlugsForOwner(ownerEmail, db)
+    ? await getBookingLinkSlugsForOwners(hostEmails, db)
     : slug
       ? [slug]
       : [];
@@ -365,6 +389,7 @@ async function resolveAvailabilityContext({
           )
         : config),
     ownerEmail,
+    hostEmails,
     slug,
     bookingLink,
     conflictSlugs,
@@ -374,20 +399,54 @@ async function resolveAvailabilityContext({
 async function getConflictItems({
   db = getDb(),
   ownerEmail,
+  hostEmails,
   conflictSlugs,
   rangeStartIso,
   rangeEndIso,
+  timezone,
 }: {
   db?: ConflictDb;
   ownerEmail?: string;
+  hostEmails: string[];
   conflictSlugs: string[];
   rangeStartIso: string;
   rangeEndIso: string;
-}): Promise<ConflictItem[]> {
+  timezone: string;
+}): Promise<ConflictResult> {
   const conflictItems: ConflictItem[] = [];
+  const requiredHosts = Array.from(
+    new Set(
+      hostEmails
+        .map((email) => email.trim().toLowerCase())
+        .filter((email) => email.length > 0),
+    ),
+  );
+  const freeBusyResolvedHosts = new Set<string>();
 
   if (await googleCalendar.isConnected(ownerEmail)) {
     try {
+      if (requiredHosts.length > 0) {
+        const freeBusy = await googleCalendar.getFreeBusy(
+          rangeStartIso,
+          rangeEndIso,
+          requiredHosts,
+          ownerEmail,
+          timezone,
+        );
+        for (const [email, calendar] of Object.entries(freeBusy.calendars)) {
+          const normalizedEmail = email.toLowerCase();
+          if (!calendar.errors || calendar.errors.length === 0) {
+            freeBusyResolvedHosts.add(normalizedEmail);
+          }
+          conflictItems.push(
+            ...calendar.busy.map((busy) => ({
+              start: busy.start,
+              end: busy.end,
+            })),
+          );
+        }
+      }
+
       const { events: googleEvents } = await googleCalendar.listEvents(
         rangeStartIso,
         rangeEndIso,
@@ -401,6 +460,19 @@ async function getConflictItems({
       );
     } catch {
       // Continue without Google events if API fails
+    }
+  }
+
+  if (requiredHosts.length > 1) {
+    const owner = ownerEmail?.toLowerCase();
+    const unresolvedCoHosts = requiredHosts.filter(
+      (email) => email !== owner && !freeBusyResolvedHosts.has(email),
+    );
+    if (unresolvedCoHosts.length > 0) {
+      return {
+        items: conflictItems,
+        unavailableReason: `Availability unavailable for ${unresolvedCoHosts.join(", ")}`,
+      };
     }
   }
 
@@ -425,7 +497,7 @@ async function getConflictItems({
     })),
   );
 
-  return conflictItems;
+  return { items: conflictItems };
 }
 
 function generateAvailableSlotsForDate({
@@ -550,18 +622,21 @@ async function requestedSlotIsCurrentlyAvailable({
 
   const timezone = context.effectiveConfig.timezone || "UTC";
   const date = formatLocalDateInTimezone(start, timezone);
-  const conflictItems = await getConflictItems({
+  const conflictResult = await getConflictItems({
     db,
     ownerEmail: context.ownerEmail,
+    hostEmails: context.hostEmails,
     conflictSlugs: context.conflictSlugs,
     rangeStartIso: dateStartIso(date, timezone),
     rangeEndIso: dateEndIso(date, timezone),
+    timezone,
   });
+  if (conflictResult.unavailableReason) return false;
   const slots = generateAvailableSlotsForDate({
     date,
     duration,
     config: context.effectiveConfig,
-    conflictItems,
+    conflictItems: conflictResult.items,
   });
   const startMs = start.getTime();
   const endMs = end.getTime();
@@ -646,6 +721,10 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
       setResponseStatus(event, 500);
       return { error: "Booking link has no host email" };
     }
+    const coHostEmails = link ? getBookingLinkCoHostEmails(link) : [];
+    const requiredHostEmails = link
+      ? getBookingLinkRequiredHostEmails(link)
+      : [hostEmail];
     const requestedRange = requestedBookingRange(body.start, body.end);
     if (!requestedRange) {
       setResponseStatus(event, 400);
@@ -668,6 +747,7 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
     const eventTitle = buildBookingEventTitle({
       explicitTitle: body.eventTitle,
       hostEmail,
+      hostEmails: requiredHostEmails,
       attendeeName,
     });
 
@@ -755,15 +835,17 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
     // Check for conflicts + insert atomically in a transaction
     const db = getDb();
     const insertResult = await db.transaction(async (tx) => {
-      // Serialize booking creation per host. The no-op write takes a row lock
-      // on all of the host's booking links without changing user-visible data.
-      await tx
-        .update(schema.bookingLinks)
-        .set({ ownerEmail: hostEmail })
-        .where(eq(schema.bookingLinks.ownerEmail, hostEmail));
+      // Serialize booking creation per required host. The no-op write takes row
+      // locks on each host's booking links without changing user-visible data.
+      for (const email of requiredHostEmails) {
+        await tx
+          .update(schema.bookingLinks)
+          .set({ ownerEmail: email })
+          .where(eq(schema.bookingLinks.ownerEmail, email));
+      }
 
       const conflictSlugs = link?.ownerEmail
-        ? await getBookingLinkSlugsForOwner(link.ownerEmail, tx)
+        ? await getBookingLinkSlugsForOwners(requiredHostEmails, tx)
         : requestedSlug
           ? [requestedSlug]
           : [];
@@ -884,6 +966,9 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
         if (link?.title) {
           descParts.push(`Meeting type: ${link.title}`);
         }
+        if (coHostEmails.length > 0) {
+          descParts.push(`Required hosts: ${requiredHostEmails.join(", ")}`);
+        }
         if (notes) descParts.push(`Notes: ${notes}`);
         if (customFields.length > 0 && Object.keys(fieldResponses).length > 0) {
           const fieldLines = customFields
@@ -913,6 +998,7 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
           attendees: buildBookingEventAttendees({
             attendeeEmail,
             attendeeName,
+            hostEmails: coHostEmails,
           }),
           createdAt: now,
           updatedAt: now,
@@ -1052,12 +1138,15 @@ export const getAvailableSlots = defineEventHandler(async (event: H3Event) => {
       const rangeStart = formatDateOnly(from!);
       const rangeEnd = formatDateOnly(to!);
       const timezone = context.effectiveConfig.timezone || "UTC";
-      const conflictItems = await getConflictItems({
+      const conflictResult = await getConflictItems({
         ownerEmail: context.ownerEmail,
+        hostEmails: context.hostEmails,
         conflictSlugs: context.conflictSlugs,
         rangeStartIso: dateStartIso(rangeStart, timezone),
         rangeEndIso: dateEndIso(rangeEnd, timezone),
+        timezone,
       });
+      if (conflictResult.unavailableReason) return { dates: [] };
       const dates: string[] = [];
       for (
         let cursor = new Date(from!);
@@ -1069,7 +1158,7 @@ export const getAvailableSlots = defineEventHandler(async (event: H3Event) => {
           date: day,
           duration,
           config: context.effectiveConfig,
-          conflictItems,
+          conflictItems: conflictResult.items,
         });
         if (slots.length > 0) {
           dates.push(day);
@@ -1079,17 +1168,20 @@ export const getAvailableSlots = defineEventHandler(async (event: H3Event) => {
     }
 
     const timezone = context.effectiveConfig.timezone || "UTC";
-    const conflictItems = await getConflictItems({
+    const conflictResult = await getConflictItems({
       ownerEmail: context.ownerEmail,
+      hostEmails: context.hostEmails,
       conflictSlugs: context.conflictSlugs,
       rangeStartIso: dateStartIso(date, timezone),
       rangeEndIso: dateEndIso(date, timezone),
+      timezone,
     });
+    if (conflictResult.unavailableReason) return { slots: [] };
     const availableSlots = generateAvailableSlotsForDate({
       date,
       duration,
       config: context.effectiveConfig,
-      conflictItems,
+      conflictItems: conflictResult.items,
     });
 
     return { slots: availableSlots };

--- a/templates/calendar/server/lib/booking-event-details.spec.ts
+++ b/templates/calendar/server/lib/booking-event-details.spec.ts
@@ -15,6 +15,16 @@ describe("booking event details", () => {
     ).toBe("Steve + Rakesh");
   });
 
+  it("includes co-host first names in group booking titles", () => {
+    expect(
+      buildBookingEventTitle({
+        hostEmail: "steve@example.com",
+        hostEmails: ["brent@example.com"],
+        attendeeName: "Rakesh Rachamalla",
+      }),
+    ).toBe("Steve + Brent + Rakesh");
+  });
+
   it("still honors an explicit event title override", () => {
     expect(
       buildBookingEventTitle({
@@ -35,6 +45,25 @@ describe("booking event details", () => {
       {
         email: "rakesh.rachamalla@walmart.com",
         displayName: "Rakesh Rachamalla",
+      },
+    ]);
+  });
+
+  it("adds co-hosts as Google Calendar attendees", () => {
+    expect(
+      buildBookingEventAttendees({
+        attendeeEmail: "rakesh.rachamalla@walmart.com",
+        attendeeName: "Rakesh Rachamalla",
+        hostEmails: ["brent@example.com"],
+      }),
+    ).toEqual([
+      {
+        email: "rakesh.rachamalla@walmart.com",
+        displayName: "Rakesh Rachamalla",
+      },
+      {
+        email: "brent@example.com",
+        displayName: "Brent",
       },
     ]);
   });

--- a/templates/calendar/server/lib/booking-event-details.ts
+++ b/templates/calendar/server/lib/booking-event-details.ts
@@ -24,34 +24,59 @@ function firstNameForTitle(value: string): string {
   return value.trim().split(/\s+/)[0] ?? value.trim();
 }
 
+function uniqueEmails(emails: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const email of emails) {
+    const normalized = stripCrlf(email).toLowerCase();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
 export function buildBookingEventTitle({
   explicitTitle,
   hostEmail,
+  hostEmails,
   attendeeName,
 }: {
   explicitTitle?: unknown;
   hostEmail: string;
+  hostEmails?: string[];
   attendeeName: unknown;
 }) {
   const explicit = stripCrlf(explicitTitle);
   if (explicit) return explicit;
 
-  const hostName = firstNameForTitle(displayNameFromEmail(hostEmail));
+  const hostNames = uniqueEmails([hostEmail, ...(hostEmails ?? [])]).map(
+    (email) => firstNameForTitle(displayNameFromEmail(email)),
+  );
   const guestName = firstNameForTitle(stripCrlf(attendeeName)) || "Guest";
-  return `${hostName} + ${guestName}`;
+  return `${hostNames.join(" + ")} + ${guestName}`;
 }
 
 export function buildBookingEventAttendees({
   attendeeEmail,
   attendeeName,
+  hostEmails = [],
 }: {
   attendeeEmail: string;
   attendeeName: string;
+  hostEmails?: string[];
 }) {
+  const attendee = stripCrlf(attendeeEmail).toLowerCase();
   return [
     {
-      email: attendeeEmail,
+      email: attendee,
       displayName: attendeeName,
     },
+    ...uniqueEmails(hostEmails)
+      .filter((email) => email !== attendee)
+      .map((email) => ({
+        email,
+        displayName: displayNameFromEmail(email),
+      })),
   ];
 }

--- a/templates/calendar/server/lib/booking-link-utils.spec.ts
+++ b/templates/calendar/server/lib/booking-link-utils.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getBookingLinkRequiredHostEmails,
+  normalizeBookingHosts,
+  serializeBookingHosts,
+} from "./booking-link-utils";
+
+describe("booking link host utilities", () => {
+  it("normalizes co-hosts, removes duplicates, and excludes the owner", () => {
+    expect(
+      normalizeBookingHosts(
+        [
+          "BRENT@example.com",
+          { email: "brent@example.com", displayName: "Brent" },
+          "steve@example.com",
+          "bad-email",
+        ],
+        "steve@example.com",
+      ),
+    ).toEqual([{ email: "brent@example.com" }]);
+  });
+
+  it("serializes empty host lists as null", () => {
+    expect(
+      serializeBookingHosts(["steve@example.com"], "steve@example.com"),
+    ).toBe(null);
+  });
+
+  it("returns the owner and co-hosts as required hosts", () => {
+    expect(
+      getBookingLinkRequiredHostEmails({
+        ownerEmail: "steve@example.com",
+        hosts: JSON.stringify([{ email: "brent@example.com" }]),
+      }),
+    ).toEqual(["steve@example.com", "brent@example.com"]);
+  });
+});

--- a/templates/calendar/server/lib/booking-link-utils.ts
+++ b/templates/calendar/server/lib/booking-link-utils.ts
@@ -1,0 +1,123 @@
+import type { BookingHost, BookingLink } from "../../shared/api.js";
+import { schema } from "../db/index.js";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function stripCrlf(value: unknown): string {
+  return String(value ?? "")
+    .replace(/[\r\n]+/g, " ")
+    .trim();
+}
+
+export function normalizeBookingHostEmail(value: unknown): string | null {
+  const email = stripCrlf(value).toLowerCase();
+  return EMAIL_RE.test(email) ? email : null;
+}
+
+function parseJson<T>(value: string | null, fallback: T): T {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function normalizeBookingHosts(
+  input: unknown,
+  ownerEmail?: string | null,
+): BookingHost[] {
+  const owner = normalizeBookingHostEmail(ownerEmail);
+  const rawItems =
+    typeof input === "string"
+      ? input
+          .split(/[\s,;]+/)
+          .map((email) => ({ email }))
+          .filter((item) => item.email)
+      : Array.isArray(input)
+        ? input
+        : [];
+
+  const seen = new Set<string>();
+  const hosts: BookingHost[] = [];
+  for (const item of rawItems) {
+    const email =
+      typeof item === "string"
+        ? normalizeBookingHostEmail(item)
+        : item && typeof item === "object" && "email" in item
+          ? normalizeBookingHostEmail((item as { email?: unknown }).email)
+          : null;
+    if (!email || email === owner || seen.has(email)) continue;
+    seen.add(email);
+    const displayName =
+      item && typeof item === "object" && "displayName" in item
+        ? stripCrlf((item as { displayName?: unknown }).displayName)
+        : "";
+    hosts.push({
+      email,
+      ...(displayName ? { displayName } : {}),
+    });
+  }
+  return hosts;
+}
+
+export function parseBookingHosts(
+  value: string | null,
+  ownerEmail?: string | null,
+): BookingHost[] {
+  return normalizeBookingHosts(parseJson<unknown>(value, []), ownerEmail);
+}
+
+export function serializeBookingHosts(
+  input: unknown,
+  ownerEmail?: string | null,
+): string | null {
+  const hosts = normalizeBookingHosts(input, ownerEmail);
+  return hosts.length > 0 ? JSON.stringify(hosts) : null;
+}
+
+export function getBookingLinkCoHostEmails(
+  row: Pick<typeof schema.bookingLinks.$inferSelect, "hosts" | "ownerEmail">,
+): string[] {
+  return parseBookingHosts(row.hosts, row.ownerEmail).map((host) => host.email);
+}
+
+export function getBookingLinkRequiredHostEmails(
+  row: Pick<typeof schema.bookingLinks.$inferSelect, "hosts" | "ownerEmail">,
+): string[] {
+  const emails: string[] = [];
+  const owner = normalizeBookingHostEmail(row.ownerEmail);
+  if (owner) emails.push(owner);
+  for (const host of parseBookingHosts(row.hosts, owner)) {
+    if (!emails.includes(host.email)) emails.push(host.email);
+  }
+  return emails;
+}
+
+export function rowToBookingLink(
+  row: typeof schema.bookingLinks.$inferSelect,
+): BookingLink {
+  const hosts = parseBookingHosts(row.hosts, row.ownerEmail);
+  return {
+    id: row.id,
+    slug: row.slug,
+    title: row.title,
+    description: row.description ?? undefined,
+    duration: row.duration,
+    durations: parseJson<number[] | undefined>(row.durations, undefined),
+    hosts: hosts.length > 0 ? hosts : undefined,
+    customFields: parseJson<BookingLink["customFields"]>(
+      row.customFields,
+      undefined,
+    ),
+    conferencing: parseJson<BookingLink["conferencing"]>(
+      row.conferencing,
+      undefined,
+    ),
+    color: row.color ?? undefined,
+    isActive: row.isActive,
+    visibility: row.visibility,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/templates/calendar/server/plugins/agent-chat.ts
+++ b/templates/calendar/server/plugins/agent-chat.ts
@@ -82,7 +82,8 @@ Google Calendar events are NOT stored in the local database. They are fetched li
 - \`pnpm action update-calendar-visual-preferences --colorMode single --singleColor '#5B9BD5'\` — Use one local display color for the user's Google events
 - \`pnpm action check-availability --date YYYY-MM-DD --duration 60\` — Check free slots
 - \`pnpm action list-booking-links\` — List existing booking links
-- \`pnpm action create-booking-link --title "Meeting" --slug meeting --duration 30\` — Create a booking link
+- \`pnpm action create-booking-link --title "Meeting" --slug meeting --duration 30 --hosts "brent@example.com"\` — Create a booking link; hosts are optional required co-hosts besides the owner
+- \`pnpm action update-booking-link --id <id> --title "Meeting" --slug meeting --duration 30 --hosts "brent@example.com"\` — Update a booking link, including required co-hosts
 - \`pnpm action duplicate-booking-link --sourceSlug meeting --copies '[...]'\` — Duplicate one booking link into one or more variants
 
 ## Local UI Visual Preferences vs Google Calendar Event Color
@@ -103,6 +104,7 @@ When the user says "show me", "go to", "open", or "switch to" a view or date, AL
       await import("../db/schema.js");
     const { like, desc, and, inArray } = await import("drizzle-orm");
     const { accessFilter } = await import("@agent-native/core/sharing");
+    const { parseBookingHosts } = await import("../lib/booking-link-utils.js");
     return {
       bookings: {
         label: "Bookings",
@@ -157,14 +159,20 @@ When the user says "show me", "go to", "open", or "switch to" a view or date, AL
                 .where(access)
                 .orderBy(desc(bookingLinks.updatedAt))
                 .limit(15);
-          return rows.map((link) => ({
-            id: link.id,
-            label: link.title,
-            description: `${link.duration}min · /${link.slug}`,
-            icon: "document" as const,
-            refType: "booking-link",
-            refId: link.id,
-          }));
+          return rows.map((link) => {
+            const hostCount =
+              parseBookingHosts(link.hosts, link.ownerEmail).length + 1;
+            const hostLabel =
+              hostCount > 1 ? `${hostCount} required hosts` : "one-on-one";
+            return {
+              id: link.id,
+              label: link.title,
+              description: `${link.duration}min · ${hostLabel} · /${link.slug}`,
+              icon: "document" as const,
+              refType: "booking-link",
+              refId: link.id,
+            };
+          });
         },
       },
     };

--- a/templates/calendar/server/plugins/db.ts
+++ b/templates/calendar/server/plugins/db.ts
@@ -1,3 +1,4 @@
+import "../db/index.js";
 import { runMigrations } from "@agent-native/core/db";
 
 const LEGACY_DEV_OWNER_SQL = "'local@localhost'"; // guard:allow-localhost-fallback - migration marker for legacy dev-owned rows, not an auth fallback
@@ -171,6 +172,10 @@ WHERE owner_email = ${LEGACY_DEV_OWNER_SQL}`,
       sql: `CREATE INDEX IF NOT EXISTS idx_booking_links_owner ON booking_links (owner_email, org_id, updated_at);
 CREATE INDEX IF NOT EXISTS idx_booking_link_shares_lookup ON booking_link_shares (resource_id, principal_type, principal_id);
 CREATE INDEX IF NOT EXISTS idx_bookings_slug_start ON bookings (slug, "start");`,
+    },
+    {
+      version: 20,
+      sql: `ALTER TABLE booking_links ADD COLUMN IF NOT EXISTS hosts TEXT`,
     },
   ],
   { table: "calendar_migrations" },

--- a/templates/calendar/server/routes/api/booking-links/[id].put.ts
+++ b/templates/calendar/server/routes/api/booking-links/[id].put.ts
@@ -1,1 +1,0 @@
-export { updateBookingLink as default } from "../../../handlers/booking-links";

--- a/templates/calendar/shared/api.ts
+++ b/templates/calendar/shared/api.ts
@@ -245,6 +245,11 @@ export interface ConferencingConfig {
   url?: string;
 }
 
+export interface BookingHost {
+  email: string;
+  displayName?: string;
+}
+
 export interface Booking {
   id: string;
   name: string;
@@ -274,6 +279,8 @@ export interface BookingLink {
   duration: number;
   /** Additional duration options the booker can choose from */
   durations?: number[];
+  /** Required co-hosts in addition to the booking link owner */
+  hosts?: BookingHost[];
   /** Custom fields shown on the booking form */
   customFields?: CustomField[];
   /** Video conferencing configuration */


### PR DESCRIPTION
Summary:
- Add required co-hosts to calendar booking links and booking events
- Check availability across all required hosts for group booking links
- Add the standard share controls to booking-link management and keep public booking URLs separate
- Move booking-link updates to the action surface and remove the duplicate PUT route

Tests:
- pnpm --dir templates/calendar exec vitest --run server/lib/booking-link-utils.spec.ts server/lib/booking-event-details.spec.ts
- pnpm --dir templates/calendar typecheck
- pnpm guards
- pnpm fmt:check