### PR TITLE
Fix visual recap retries and plan comment pins

### DIFF
--- a/.changeset/chat-recap-bridges.md
+++ b/.changeset/chat-recap-bridges.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve agent chat request modes across bridges.

--- a/packages/core/src/cli/recap.spec.ts
+++ b/packages/core/src/cli/recap.spec.ts
@@ -425,13 +425,18 @@ describe("recap direct publish", () => {
       );
 
       const bodies: any[] = [];
+      const idempotencyKeys: string[] = [];
       const fetchFn: typeof fetch = (async (input, init) => {
         expect(String(input)).toBe(
           "https://plan.agent-native.com/_agent-native/actions/create-visual-recap",
         );
-        expect((init?.headers as Record<string, string>).authorization).toBe(
-          "Bearer plan-token",
+        const headers = init?.headers as Record<string, string>;
+        expect(headers.authorization).toBe("Bearer plan-token");
+        expect(headers["Idempotency-Key"]).toMatch(
+          /^visual-recap-[a-f0-9]{64}$/,
         );
+        expect(headers["X-Idempotency-Key"]).toBe(headers["Idempotency-Key"]);
+        idempotencyKeys.push(headers["Idempotency-Key"]);
         bodies.push(JSON.parse(String(init?.body ?? "{}")));
         return jsonResponse({
           planId: "recap-abc123",
@@ -457,6 +462,7 @@ describe("recap direct publish", () => {
       expect(fs.readFileSync(out, "utf8").trim()).toBe(result.url);
       expect(bodies[0]).toMatchObject({
         planId: "recap-prev",
+        idempotencyKey: idempotencyKeys[0],
         title: "Visual recap - auth changes",
         brief: "Shows the API and UI changes.",
         visibility: "org",
@@ -467,6 +473,58 @@ describe("recap direct publish", () => {
         status: "review",
       });
       expect(bodies[0].mdx["plan.mdx"]).toContain("Auth recap");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reuses the same idempotency key across publish retries", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "an-recap-retry-"));
+    try {
+      const source = path.join(dir, "recap-source.json");
+      const out = path.join(dir, "recap-url.txt");
+      fs.writeFileSync(
+        source,
+        JSON.stringify({
+          mdx: {
+            "plan.mdx": "---\ntitle: Retry recap\n---\n\n# Retry\n",
+          },
+        }),
+      );
+
+      const bodies: any[] = [];
+      const keys: string[] = [];
+      const fetchFn: typeof fetch = (async (_input, init) => {
+        const headers = init?.headers as Record<string, string>;
+        keys.push(headers["Idempotency-Key"]);
+        bodies.push(JSON.parse(String(init?.body ?? "{}")));
+        if (keys.length === 1) return textResponse("try again", 500);
+        return jsonResponse({
+          planId: "recap-retry",
+          url: "/recaps/recap-retry",
+        });
+      }) as typeof fetch;
+
+      const result = await publishRecapSource({
+        appUrl: "https://plan.agent-native.com",
+        token: "plan-token",
+        sourcePath: source,
+        out,
+        repo: "BuilderIO/agent-native",
+        pr: "1209",
+        fetchFn,
+        cwd: dir,
+      });
+
+      expect(result.url).toBe(
+        "https://plan.agent-native.com/recaps/recap-retry",
+      );
+      expect(keys).toHaveLength(2);
+      expect(new Set(keys).size).toBe(1);
+      expect(bodies.map((body) => body.idempotencyKey)).toEqual([
+        keys[0],
+        keys[0],
+      ]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/core/src/cli/recap.ts
+++ b/packages/core/src/cli/recap.ts
@@ -35,6 +35,7 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -2220,6 +2221,23 @@ function shouldRetryRecapPublish(status: number): boolean {
   );
 }
 
+function recapPublishIdempotencyKey(input: {
+  prevPlanId?: string;
+  repo?: string;
+  pr?: string;
+  sourcePath: string;
+  sourceUrl?: string;
+}): string {
+  const identity = input.prevPlanId
+    ? `plan:${input.prevPlanId}`
+    : input.repo && input.pr
+      ? `github-pr:${input.repo}:${input.pr}`
+      : input.sourceUrl
+        ? `source-url:${input.sourceUrl}`
+        : `source-path:${path.resolve(input.sourcePath)}`;
+  return `visual-recap-${createHash("sha256").update(identity).digest("hex")}`;
+}
+
 export async function publishRecapSource(input: {
   appUrl: string;
   token: string;
@@ -2244,8 +2262,16 @@ export async function publishRecapSource(input: {
     (input.repo && input.pr
       ? `https://github.com/${input.repo}/pull/${input.pr}`
       : undefined);
+  const idempotencyKey = recapPublishIdempotencyKey({
+    prevPlanId: input.prevPlanId,
+    repo: input.repo,
+    pr: input.pr,
+    sourcePath,
+    sourceUrl,
+  });
   const body = {
     ...(input.prevPlanId ? { planId: input.prevPlanId } : {}),
+    idempotencyKey,
     ...(source.title ? { title: source.title } : {}),
     ...(source.brief ? { brief: source.brief } : {}),
     visibility: "org",
@@ -2270,6 +2296,8 @@ export async function publishRecapSource(input: {
             accept: "application/json",
             "content-type": "application/json",
             authorization: `Bearer ${token}`,
+            "Idempotency-Key": idempotencyKey,
+            "X-Idempotency-Key": idempotencyKey,
           },
           body: JSON.stringify(body),
         },

--- a/packages/core/src/client/agent-chat.spec.ts
+++ b/packages/core/src/client/agent-chat.spec.ts
@@ -158,6 +158,21 @@ describe("sendToAgentChat", () => {
     expect(payload.data.requestMode).toBe("plan");
   });
 
+  it("does not guess from ambiguous namespaced stored modes", () => {
+    window.localStorage.setItem("agent-native-exec-mode:workspace-app", "plan");
+    window.localStorage.setItem("agent-native-exec-mode:builder", "build");
+
+    sendToAgentChat({
+      message: "use the current explicit mode only",
+      submit: true,
+    });
+
+    expect(parentPostMessageSpy).toHaveBeenCalledOnce();
+    const payload = parentPostMessageSpy.mock.calls[0][0];
+    expect(payload.data.mode).toBeUndefined();
+    expect(payload.data.requestMode).toBeUndefined();
+  });
+
   it("lets an explicit submitted mode override stored mode", () => {
     window.localStorage.setItem("agent-native-exec-mode", "build");
 

--- a/packages/core/src/client/agent-chat.spec.ts
+++ b/packages/core/src/client/agent-chat.spec.ts
@@ -144,6 +144,20 @@ describe("sendToAgentChat", () => {
     expect(payload.data.requestMode).toBe("plan");
   });
 
+  it("snapshots namespaced stored plan mode into the postMessage payload", () => {
+    window.localStorage.setItem("agent-native-exec-mode:workspace-app", "plan");
+
+    sendToAgentChat({
+      message: "plan this workspace app",
+      submit: true,
+    });
+
+    expect(parentPostMessageSpy).toHaveBeenCalledOnce();
+    const payload = parentPostMessageSpy.mock.calls[0][0];
+    expect(payload.data.mode).toBe("plan");
+    expect(payload.data.requestMode).toBe("plan");
+  });
+
   it("lets an explicit submitted mode override stored mode", () => {
     window.localStorage.setItem("agent-native-exec-mode", "build");
 
@@ -215,6 +229,7 @@ describe("sendToAgentChat", () => {
 
   it("routes Builder-frame code prompts to Builder chat", () => {
     frameState.inBuilderFrame = true;
+    window.localStorage.setItem("agent-native-exec-mode:builder", "plan");
 
     sendToAgentChat({
       message: "change this app",
@@ -229,6 +244,8 @@ describe("sendToAgentChat", () => {
       message: "change this app",
       context: "code context",
       submit: true,
+      mode: "plan",
+      requestMode: "plan",
     });
   });
 
@@ -284,6 +301,7 @@ describe("sendToAgentChat", () => {
     window.location.search =
       "?embedded=1&__an_embed_token=signed-token&__an_mcp_chat_bridge=1";
     sendMcpAppHostMessageMock.mockReturnValue(Promise.resolve(true));
+    window.localStorage.setItem("agent-native-exec-mode:mcp-app", "plan");
 
     sendToAgentChat({
       message: "rewrite this",
@@ -294,6 +312,8 @@ describe("sendToAgentChat", () => {
     expect(sendMcpAppHostMessageMock).toHaveBeenCalledWith({
       message: "rewrite this",
       context: "Hidden draft context",
+      mode: "plan",
+      requestMode: "plan",
     });
     expect(parentPostMessageSpy).not.toHaveBeenCalled();
   });

--- a/packages/core/src/client/agent-chat.ts
+++ b/packages/core/src/client/agent-chat.ts
@@ -428,14 +428,16 @@ function readStoredAgentChatRequestMode(): AgentChatRequestMode | undefined {
       storage.getItem(AGENT_CHAT_EXEC_MODE_KEY),
     );
     if (saved) return saved;
+    const scopedModes: AgentChatRequestMode[] = [];
     for (let index = 0; index < storage.length; index += 1) {
       const key = storage.key(index);
       if (!key?.startsWith(`${AGENT_CHAT_EXEC_MODE_KEY}:`)) continue;
       const scopedSaved = normalizeStoredAgentChatExecMode(
         storage.getItem(key),
       );
-      if (scopedSaved) return scopedSaved;
+      if (scopedSaved) scopedModes.push(scopedSaved);
     }
+    if (scopedModes.length === 1) return scopedModes[0];
   } catch {}
   return undefined;
 }

--- a/packages/core/src/client/agent-chat.ts
+++ b/packages/core/src/client/agent-chat.ts
@@ -412,12 +412,30 @@ function normalizeAgentChatRequestMode(
   return value === "act" || value === "plan" ? value : undefined;
 }
 
+function normalizeStoredAgentChatExecMode(
+  value: string | null,
+): AgentChatRequestMode | undefined {
+  if (value === "plan") return "plan";
+  if (value === "build" || value === "act") return "act";
+  return undefined;
+}
+
 function readStoredAgentChatRequestMode(): AgentChatRequestMode | undefined {
   if (typeof window === "undefined") return undefined;
   try {
-    const saved = window.localStorage.getItem(AGENT_CHAT_EXEC_MODE_KEY);
-    if (saved === "plan") return "plan";
-    if (saved === "build") return "act";
+    const storage = window.localStorage;
+    const saved = normalizeStoredAgentChatExecMode(
+      storage.getItem(AGENT_CHAT_EXEC_MODE_KEY),
+    );
+    if (saved) return saved;
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (!key?.startsWith(`${AGENT_CHAT_EXEC_MODE_KEY}:`)) continue;
+      const scopedSaved = normalizeStoredAgentChatExecMode(
+        storage.getItem(key),
+      );
+      if (scopedSaved) return scopedSaved;
+    }
   } catch {}
   return undefined;
 }
@@ -429,17 +447,18 @@ function readStoredAgentChatRequestMode(): AgentChatRequestMode | undefined {
 export function sendToAgentChat(opts: AgentChatMessage): string {
   const tabId = opts.tabId ?? generateTabId();
   const isCodeRequest = opts.type === "code" || opts.requiresCode === true;
+  const requestMode =
+    normalizeAgentChatRequestMode(opts.requestMode ?? opts.mode) ??
+    readStoredAgentChatRequestMode();
   if (isCodeRequest && isInBuilderFrame()) {
     sendToBuilderChat({
       message: opts.message,
       context: opts.context,
       submit: opts.submit,
+      ...(requestMode ? { mode: requestMode, requestMode } : {}),
     });
     return tabId;
   }
-  const requestMode =
-    normalizeAgentChatRequestMode(opts.requestMode ?? opts.mode) ??
-    readStoredAgentChatRequestMode();
 
   const payload = {
     type: AGENT_CHAT_MESSAGE_TYPE,
@@ -454,6 +473,7 @@ export function sendToAgentChat(opts: AgentChatMessage): string {
     const directHostMessage = sendMcpAppHostMessage({
       message: opts.message,
       context: opts.context,
+      ...(requestMode ? { mode: requestMode, requestMode } : {}),
     });
     if (directHostMessage) {
       void Promise.resolve(directHostMessage)

--- a/packages/core/src/client/builder-frame.spec.ts
+++ b/packages/core/src/client/builder-frame.spec.ts
@@ -118,6 +118,34 @@ describe("sendToBuilderChat", () => {
     expect(consoleLog).not.toHaveBeenCalled();
   });
 
+  it("preserves request mode in Builder chat payloads", () => {
+    const parentPostMessage = vi.fn();
+    setParentWindow({ postMessage: parentPostMessage });
+    setAncestorOrigin("https://builder.io");
+
+    const sent = sendToBuilderChat({
+      message: "plan before changing this app",
+      submit: true,
+      mode: "plan",
+      requestMode: "plan",
+    });
+
+    expect(sent).toBe(true);
+    expect(parentPostMessage).toHaveBeenCalledWith(
+      {
+        type: "builder.submitChat",
+        data: {
+          message: "plan before changing this app",
+          context: undefined,
+          submit: true,
+          mode: "plan",
+          requestMode: "plan",
+        },
+      },
+      "https://builder.io",
+    );
+  });
+
   it("keeps the console relay for top-level Builder webviews", () => {
     const windowPostMessage = vi.spyOn(window, "postMessage");
     const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});

--- a/packages/core/src/client/builder-frame.ts
+++ b/packages/core/src/client/builder-frame.ts
@@ -115,6 +115,8 @@ export interface BuilderChatMessage {
   message: string;
   context?: string;
   submit?: boolean;
+  mode?: "act" | "plan";
+  requestMode?: "act" | "plan";
 }
 
 export function sendToBuilderChat(opts: BuilderChatMessage): boolean {
@@ -127,6 +129,8 @@ export function sendToBuilderChat(opts: BuilderChatMessage): boolean {
       message: opts.message,
       context: opts.context,
       submit: opts.submit,
+      ...(opts.mode ? { mode: opts.mode } : {}),
+      ...(opts.requestMode ? { requestMode: opts.requestMode } : {}),
     },
   };
 

--- a/packages/core/src/client/mcp-app-host.spec.ts
+++ b/packages/core/src/client/mcp-app-host.spec.ts
@@ -320,6 +320,7 @@ describe("MCP app host client helpers", () => {
     const result = sendMcpAppHostMessage({
       context: "Selected row ids: a, b",
       message: "Continue with this selection",
+      mode: "plan",
     });
     await flushMicrotasks();
 
@@ -339,6 +340,8 @@ describe("MCP app host client helpers", () => {
     expect(contextCall).toMatchObject({
       params: {
         content: [{ type: "text", text: "Selected row ids: a, b" }],
+        mode: "plan",
+        requestMode: "plan",
       },
     });
     dispatchHostMessage({
@@ -354,6 +357,8 @@ describe("MCP app host client helpers", () => {
       params: {
         role: "user",
         content: [{ type: "text", text: "Continue with this selection" }],
+        mode: "plan",
+        requestMode: "plan",
       },
     });
 
@@ -425,6 +430,7 @@ describe("MCP app host client helpers", () => {
       context:
         "Hidden draft context. Do not ask to read application-state/compose.json.",
       message: "Rewrite the selected sentence",
+      requestMode: "plan",
     });
 
     await expect(result).resolves.toBe(true);
@@ -439,11 +445,15 @@ describe("MCP app host client helpers", () => {
             text: "Hidden draft context. Do not ask to read application-state/compose.json.",
           },
         ],
+        mode: "plan",
+        requestMode: "plan",
       },
     });
     expect(sendFollowUpMessage).toHaveBeenCalledWith({
       prompt: "Rewrite the selected sentence",
       scrollToBottom: true,
+      mode: "plan",
+      requestMode: "plan",
     });
     expect(JSON.stringify(sendFollowUpMessage.mock.calls)).not.toContain(
       "application-state/compose.json",
@@ -464,6 +474,7 @@ describe("MCP app host client helpers", () => {
     const result = sendMcpAppHostMessage({
       context: "Hidden selected asset context",
       message: "Use the selected Assets image",
+      mode: "plan",
       structuredContent: {
         selectedAsset: {
           assetId: "asset-123",
@@ -485,6 +496,8 @@ describe("MCP app host client helpers", () => {
           { type: "text", text: "Hidden selected asset context" },
           { type: "image", data: "ZmFrZS1pbWFnZQ==", mimeType: "image/webp" },
         ],
+        mode: "plan",
+        requestMode: "plan",
         structuredContent: {
           selectedAsset: {
             assetId: "asset-123",
@@ -496,6 +509,8 @@ describe("MCP app host client helpers", () => {
     expect(sendFollowUpMessage).toHaveBeenCalledWith({
       prompt: "Use the selected Assets image",
       scrollToBottom: true,
+      mode: "plan",
+      requestMode: "plan",
     });
   });
 
@@ -506,6 +521,7 @@ describe("MCP app host client helpers", () => {
     const result = sendMcpAppHostMessage({
       context: "Hidden selected asset context",
       message: "Use the selected Assets image",
+      mode: "plan",
       structuredContent: {
         selectedAsset: {
           assetId: "asset-123",
@@ -527,6 +543,8 @@ describe("MCP app host client helpers", () => {
           requestId: expect.any(String),
           context: "Hidden selected asset context",
           message: "Use the selected Assets image",
+          mode: "plan",
+          requestMode: "plan",
           content: [
             { type: "text", text: "Use the selected Assets image" },
             { type: "image", data: "ZmFrZS1pbWFnZQ==", mimeType: "image/webp" },

--- a/packages/core/src/client/mcp-app-host.ts
+++ b/packages/core/src/client/mcp-app-host.ts
@@ -36,11 +36,15 @@ export interface McpAppModelContextUpdate {
   structuredContent?: unknown;
 }
 
+export type McpAppHostRequestMode = "act" | "plan";
+
 export interface McpAppHostChatMessage {
   message: string;
   context?: string;
   content?: McpAppModelContextContentPart[];
   structuredContent?: unknown;
+  mode?: McpAppHostRequestMode;
+  requestMode?: McpAppHostRequestMode;
 }
 
 export interface McpAppHostCapabilities {
@@ -347,6 +351,9 @@ function postHostRequest(
 function postWrapperHostChat(chat: McpAppHostChatMessage): Promise<boolean> {
   ensureListener();
   const id = requestId();
+  const requestMode = normalizeMcpAppHostRequestMode(
+    chat.requestMode ?? chat.mode,
+  );
   return new Promise((resolve) => {
     const timeout = setTimeout(() => {
       pending.delete(id);
@@ -363,6 +370,7 @@ function postWrapperHostChat(chat: McpAppHostChatMessage): Promise<boolean> {
             message: chat.message,
             context: chat.context?.trim() || "",
             submit: true,
+            ...(requestMode ? { mode: requestMode, requestMode } : {}),
             ...(chat.content?.length ? { content: chat.content } : {}),
             ...(chat.structuredContent !== undefined
               ? { structuredContent: chat.structuredContent }
@@ -391,6 +399,8 @@ interface OpenAiAppBridge {
   sendFollowUpMessage?: (args: {
     prompt: string;
     scrollToBottom?: boolean;
+    mode?: McpAppHostRequestMode;
+    requestMode?: McpAppHostRequestMode;
   }) => unknown | Promise<unknown>;
   openExternal?: (args: {
     href: string;
@@ -411,6 +421,12 @@ function readOpenAiBridge(): OpenAiAppBridge | null {
 
 function objectValue(value: unknown): Record<string, unknown> {
   return isRecord(value) ? value : {};
+}
+
+function normalizeMcpAppHostRequestMode(
+  value: unknown,
+): McpAppHostRequestMode | undefined {
+  return value === "act" || value === "plan" ? value : undefined;
 }
 
 function postJsonRpcNotification(method: string, params?: unknown): void {
@@ -557,6 +573,12 @@ export function sendMcpAppHostMessage(
   return (async () => {
     const openAiBridge = readOpenAiBridge();
     const context = chat.context?.trim() || null;
+    const requestMode = normalizeMcpAppHostRequestMode(
+      chat.requestMode ?? chat.mode,
+    );
+    const requestModePayload = requestMode
+      ? { mode: requestMode, requestMode }
+      : {};
     const content = chat.content?.length
       ? chat.content
       : [{ type: "text", text: chat.message }];
@@ -577,6 +599,7 @@ export function sendMcpAppHostMessage(
           agentNativeChatContext: context,
           agentNativeModelContext: {
             content: contextContent,
+            ...requestModePayload,
             ...(chat.structuredContent !== undefined
               ? { structuredContent: chat.structuredContent }
               : {}),
@@ -586,6 +609,7 @@ export function sendMcpAppHostMessage(
       await openAiBridge.sendFollowUpMessage({
         prompt: chat.message,
         scrollToBottom: true,
+        ...requestModePayload,
       });
       return true;
     }
@@ -594,6 +618,7 @@ export function sendMcpAppHostMessage(
     try {
       await postJsonRpcRequest("ui/update-model-context", {
         content: contextContent,
+        ...requestModePayload,
         ...(chat.structuredContent !== undefined
           ? { structuredContent: chat.structuredContent }
           : {}),
@@ -605,6 +630,7 @@ export function sendMcpAppHostMessage(
     await postJsonRpcRequest("ui/message", {
       role: "user",
       content,
+      ...requestModePayload,
     });
     return true;
   })().catch(() => false);

--- a/templates/plan/actions/create-visual-recap.sourceUrl.spec.ts
+++ b/templates/plan/actions/create-visual-recap.sourceUrl.spec.ts
@@ -127,6 +127,9 @@ beforeAll(async () => {
     CREATE TABLE plan_events (id TEXT PRIMARY KEY, plan_id TEXT NOT NULL, type TEXT NOT NULL, message TEXT NOT NULL, payload TEXT, created_by TEXT NOT NULL DEFAULT 'agent', created_at TEXT NOT NULL);
     CREATE TABLE plan_versions (id TEXT PRIMARY KEY, owner_email TEXT NOT NULL DEFAULT 'local@localhost', plan_id TEXT NOT NULL, title TEXT NOT NULL, snapshot_json TEXT NOT NULL, change_label TEXT, created_by TEXT NOT NULL DEFAULT 'agent', created_at TEXT NOT NULL);
     CREATE TABLE plan_shares (id TEXT PRIMARY KEY, resource_id TEXT NOT NULL, principal_type TEXT NOT NULL, principal_id TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'viewer', created_by TEXT NOT NULL, created_at TEXT NOT NULL);
+    CREATE UNIQUE INDEX plans_recap_idempotency_key_unique_idx
+      ON plans(owner_email, COALESCE(org_id, ''), recap_idempotency_key)
+      WHERE kind = 'recap' AND recap_idempotency_key IS NOT NULL;
   `);
 
   registerShareableResource({
@@ -209,6 +212,32 @@ describe("create-visual-recap: sourceUrl", () => {
         recapIdempotencyKey: idempotencyKey,
       },
     ]);
+
+    await expect(
+      client.execute({
+        sql: `
+          INSERT INTO plans (
+            id, title, brief, kind, status, source, created_at, updated_at,
+            owner_email, org_id, visibility, recap_idempotency_key
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+        args: [
+          "duplicate-recap",
+          "Duplicate Recap",
+          "Duplicate key should be rejected.",
+          "recap",
+          "review",
+          "imported",
+          new Date().toISOString(),
+          new Date().toISOString(),
+          OWNER,
+          ORG,
+          "private",
+          idempotencyKey,
+        ],
+      }),
+    ).rejects.toThrow();
   });
 
   it("leaves sourceUrl null when not provided on create", async () => {

--- a/templates/plan/actions/create-visual-recap.sourceUrl.spec.ts
+++ b/templates/plan/actions/create-visual-recap.sourceUrl.spec.ts
@@ -119,7 +119,7 @@ beforeAll(async () => {
       usage_input_tokens INTEGER, usage_output_tokens INTEGER,
       usage_cache_read_tokens INTEGER, usage_cache_write_tokens INTEGER,
       usage_cost_cents_x100 INTEGER, usage_cost_source TEXT, usage_recorded_at TEXT,
-      source_url TEXT,
+      source_url TEXT, recap_idempotency_key TEXT,
       owner_email TEXT NOT NULL, org_id TEXT, visibility TEXT NOT NULL DEFAULT 'private'
     );
     CREATE TABLE plan_sections (id TEXT PRIMARY KEY, plan_id TEXT NOT NULL, type TEXT NOT NULL DEFAULT 'custom', title TEXT NOT NULL, body TEXT NOT NULL DEFAULT '', html TEXT, sort_order INTEGER NOT NULL DEFAULT 0, created_by TEXT NOT NULL DEFAULT 'agent', created_at TEXT NOT NULL, updated_at TEXT NOT NULL);
@@ -168,6 +168,47 @@ describe("create-visual-recap: sourceUrl", () => {
     expect(result.planId).toBeTruthy();
     const row = await rawPlan(result.planId as string);
     expect(row?.sourceUrl).toBe(PR_URL);
+  });
+
+  it("reuses a recap with the same idempotency key", async () => {
+    const idempotencyKey = "visual-recap-test-key";
+    const first = await asOwner(() =>
+      createVisualRecap.run({
+        mdx: MINIMAL_MDX,
+        visibility: "org",
+        sourceUrl: PR_URL,
+        idempotencyKey,
+      }),
+    );
+    const planId = first.planId as string;
+
+    const second = await asOwner(() =>
+      createVisualRecap.run({
+        mdx: {
+          "plan.mdx":
+            "---\ntitle: Retried Recap\nbrief: Reused by idempotency.\n---\n\n# Retried\n",
+        },
+        visibility: "org",
+        sourceUrl: PR_URL,
+        idempotencyKey,
+      }),
+    );
+
+    expect(second.planId).toBe(planId);
+    const rows = await db
+      .select({
+        id: planSchema.plans.id,
+        title: planSchema.plans.title,
+        recapIdempotencyKey: planSchema.plans.recapIdempotencyKey,
+      })
+      .from(planSchema.plans);
+    expect(rows).toEqual([
+      {
+        id: planId,
+        title: "Retried Recap",
+        recapIdempotencyKey: idempotencyKey,
+      },
+    ]);
   });
 
   it("leaves sourceUrl null when not provided on create", async () => {

--- a/templates/plan/actions/create-visual-recap.ts
+++ b/templates/plan/actions/create-visual-recap.ts
@@ -1,6 +1,15 @@
 import { defineAction, embedApp } from "@agent-native/core";
+import {
+  getRequestOrgId,
+  getRequestUserEmail,
+} from "@agent-native/core/server/request-context";
+import {
+  accessFilter,
+  assertAccess,
+  currentAccess,
+} from "@agent-native/core/sharing";
 import setResourceVisibilityAction from "@agent-native/core/sharing/actions/set-resource-visibility";
-import { eq } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import importVisualPlanSourceAction from "./import-visual-plan-source.js";
 import { planMdxFileSchema } from "../server/plan-mdx.js";
@@ -10,6 +19,11 @@ import {
   planStatusSchema,
 } from "../server/plans.js";
 import { getDb, schema } from "../server/db/index.js";
+import {
+  requirePlanOwnerEmailForWrite,
+  resolvePlanAccessContext,
+  resolvePlanOrgIdForWrite,
+} from "../server/lib/local-identity.js";
 
 const sourceUrlSchema = z
   .string()
@@ -18,6 +32,45 @@ const sourceUrlSchema = z
     message: "sourceUrl must be an http or https URL",
   })
   .optional();
+
+async function findExistingRecapForIdempotencyKey(
+  idempotencyKey: string | undefined,
+): Promise<string | undefined> {
+  if (!idempotencyKey) return undefined;
+
+  const requesterEmail = getRequestUserEmail();
+  const ownerEmail = requirePlanOwnerEmailForWrite(
+    requesterEmail,
+    "Creating a visual recap",
+  );
+  const ownerOrgId = resolvePlanOrgIdForWrite(
+    requesterEmail,
+    getRequestOrgId(),
+  );
+  const accessWhere = accessFilter(
+    schema.plans,
+    schema.planShares,
+    resolvePlanAccessContext(currentAccess()),
+  );
+  const [row] = await getDb()
+    .select({ id: schema.plans.id })
+    .from(schema.plans)
+    .where(
+      and(
+        accessWhere,
+        eq(schema.plans.kind, "recap"),
+        eq(schema.plans.recapIdempotencyKey, idempotencyKey),
+        eq(schema.plans.ownerEmail, ownerEmail),
+        ownerOrgId
+          ? eq(schema.plans.orgId, ownerOrgId)
+          : isNull(schema.plans.orgId),
+      ),
+    )
+    .orderBy(desc(schema.plans.updatedAt))
+    .limit(1);
+
+  return row?.id;
+}
 
 export default defineAction({
   description:
@@ -46,6 +99,15 @@ export default defineAction({
     sourceUrl: sourceUrlSchema.describe(
       "URL of the pull request, issue, or commit that this recap covers. Must be an http(s) URL. When set, the hosted recap page shows a 'View PR' link back to the source.",
     ),
+    idempotencyKey: z
+      .string()
+      .trim()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe(
+        "Stable client-generated key for retrying the same recap publish without creating duplicate recap rows.",
+      ),
     currentFocus: z
       .string()
       .optional()
@@ -77,8 +139,13 @@ export default defineAction({
     }),
   },
   run: async (args) => {
+    const { idempotencyKey, ...importArgs } = args;
+    const existingPlanId = args.planId
+      ? undefined
+      : await findExistingRecapForIdempotencyKey(idempotencyKey);
     const result = await importVisualPlanSourceAction.run({
-      ...args,
+      ...importArgs,
+      planId: args.planId ?? existingPlanId,
       kind: "recap",
       source: args.source ?? "imported",
       currentFocus: args.currentFocus ?? "visual recap review",
@@ -92,11 +159,23 @@ export default defineAction({
     const planId = (result as { planId?: string } | null)?.planId;
     const visibility = args.visibility ?? "org";
     if (planId) {
-      if (args.sourceUrl !== undefined) {
+      await assertAccess(
+        "plan",
+        planId,
+        "editor",
+        resolvePlanAccessContext(currentAccess()),
+      );
+      const planPatch = {
+        ...(args.sourceUrl !== undefined
+          ? { sourceUrl: args.sourceUrl ?? null }
+          : {}),
+        ...(idempotencyKey ? { recapIdempotencyKey: idempotencyKey } : {}),
+      };
+      if (Object.keys(planPatch).length > 0) {
         const db = getDb();
         await db
           .update(schema.plans)
-          .set({ sourceUrl: args.sourceUrl ?? null })
+          .set(planPatch)
           .where(eq(schema.plans.id, planId));
       }
       await setResourceVisibilityAction.run({

--- a/templates/plan/actions/create-visual-recap.ts
+++ b/templates/plan/actions/create-visual-recap.ts
@@ -143,14 +143,26 @@ export default defineAction({
     const existingPlanId = args.planId
       ? undefined
       : await findExistingRecapForIdempotencyKey(idempotencyKey);
-    const result = await importVisualPlanSourceAction.run({
-      ...importArgs,
-      planId: args.planId ?? existingPlanId,
-      kind: "recap",
-      source: args.source ?? "imported",
-      currentFocus: args.currentFocus ?? "visual recap review",
-      status: args.status ?? "review",
-    });
+    const importRecap = (planId: string | undefined) =>
+      importVisualPlanSourceAction.run({
+        ...importArgs,
+        planId,
+        kind: "recap",
+        ...(idempotencyKey ? { recapIdempotencyKey: idempotencyKey } : {}),
+        source: args.source ?? "imported",
+        currentFocus: args.currentFocus ?? "visual recap review",
+        status: args.status ?? "review",
+      });
+    let result;
+    try {
+      result = await importRecap(args.planId ?? existingPlanId);
+    } catch (error) {
+      if (args.planId || existingPlanId || !idempotencyKey) throw error;
+      const replayPlanId =
+        await findExistingRecapForIdempotencyKey(idempotencyKey);
+      if (!replayPlanId) throw error;
+      result = await importRecap(replayPlanId);
+    }
     // Apply requested visibility server-side so the recap is never left private
     // (the import action always creates with visibility='private'). Route this
     // through the shared visibility action instead of updating the row directly:

--- a/templates/plan/actions/import-visual-plan-source.ts
+++ b/templates/plan/actions/import-visual-plan-source.ts
@@ -64,6 +64,12 @@ export default defineAction({
       .optional()
       .describe("Current plan focus for the review surface."),
     status: planStatusSchema.optional().default("review"),
+    recapIdempotencyKey: z
+      .string()
+      .optional()
+      .describe(
+        "Stable recap retry key. Only used when kind='recap' so create-visual-recap can reserve the key during initial insert.",
+      ),
     mdx: planMdxFileSchema.describe(
       "Plan source files. plan.mdx holds frontmatter plus markdown/document blocks; canvas.mdx holds optional DesignBoard/Section/Artboard/Screen/Annotation/Connector components. Optional assets/ holds base64-encoded image assets keyed by filename (png, jpg, gif, webp, svg). Size caps: 2 MB per asset, 10 MB total per plan.",
     ),
@@ -149,6 +155,9 @@ export default defineAction({
           source: args.source,
           repoPath: args.repoPath ?? null,
           currentFocus: args.currentFocus ?? "source review",
+          ...(args.kind === "recap" && args.recapIdempotencyKey
+            ? { recapIdempotencyKey: args.recapIdempotencyKey }
+            : {}),
           status: args.status,
           markdown: args.mdx["plan.mdx"],
           content: serializePlanContent(content),
@@ -217,6 +226,9 @@ export default defineAction({
       ownerEmail,
       orgId: ownerOrgId,
       visibility: "private",
+      ...(kind === "recap" && args.recapIdempotencyKey
+        ? { recapIdempotencyKey: args.recapIdempotencyKey }
+        : {}),
     });
 
     // Import assets now that the plan row exists (FK on plan_assets.plan_id).

--- a/templates/plan/actions/plan-versions.spec.ts
+++ b/templates/plan/actions/plan-versions.spec.ts
@@ -204,7 +204,7 @@ beforeAll(async () => {
       usage_cost_cents_x100 INTEGER,
       usage_cost_source TEXT,
       usage_recorded_at TEXT,
-      source_url TEXT,
+      source_url TEXT, recap_idempotency_key TEXT,
       owner_email TEXT NOT NULL,
       org_id TEXT,
       visibility TEXT NOT NULL DEFAULT 'private'

--- a/templates/plan/actions/prototype-actions.access.spec.ts
+++ b/templates/plan/actions/prototype-actions.access.spec.ts
@@ -165,7 +165,7 @@ beforeAll(async () => {
       usage_input_tokens INTEGER, usage_output_tokens INTEGER,
       usage_cache_read_tokens INTEGER, usage_cache_write_tokens INTEGER,
       usage_cost_cents_x100 INTEGER, usage_cost_source TEXT, usage_recorded_at TEXT,
-      source_url TEXT,
+      source_url TEXT, recap_idempotency_key TEXT,
       owner_email TEXT NOT NULL, org_id TEXT, visibility TEXT NOT NULL DEFAULT 'private'
     );
     CREATE TABLE plan_sections (id TEXT PRIMARY KEY, plan_id TEXT NOT NULL, type TEXT NOT NULL DEFAULT 'custom', title TEXT NOT NULL, body TEXT NOT NULL DEFAULT '', html TEXT, sort_order INTEGER NOT NULL DEFAULT 0, created_by TEXT NOT NULL DEFAULT 'agent', created_at TEXT NOT NULL, updated_at TEXT NOT NULL);

--- a/templates/plan/actions/publish-visual-plan.access.spec.ts
+++ b/templates/plan/actions/publish-visual-plan.access.spec.ts
@@ -139,6 +139,7 @@ beforeAll(async () => {
       status TEXT NOT NULL DEFAULT 'draft', source TEXT NOT NULL DEFAULT 'manual',
       repo_path TEXT, current_focus TEXT, html TEXT, markdown TEXT, content TEXT,
       hosted_plan_id TEXT, hosted_plan_url TEXT, source_url TEXT,
+      recap_idempotency_key TEXT,
       created_at TEXT NOT NULL, updated_at TEXT NOT NULL, approved_at TEXT,
       usage_agent TEXT, usage_model TEXT,
       usage_input_tokens INTEGER, usage_output_tokens INTEGER,

--- a/templates/plan/actions/report-visual-plan.spec.ts
+++ b/templates/plan/actions/report-visual-plan.spec.ts
@@ -90,6 +90,7 @@ beforeAll(async () => {
       status TEXT NOT NULL DEFAULT 'draft', source TEXT NOT NULL DEFAULT 'manual',
       repo_path TEXT, current_focus TEXT, html TEXT, markdown TEXT, content TEXT,
       hosted_plan_id TEXT, hosted_plan_url TEXT, source_url TEXT,
+      recap_idempotency_key TEXT,
       created_at TEXT NOT NULL, updated_at TEXT NOT NULL, approved_at TEXT,
       usage_agent TEXT, usage_model TEXT,
       usage_input_tokens INTEGER, usage_output_tokens INTEGER,

--- a/templates/plan/app/pages/PlansPage.comments.test.ts
+++ b/templates/plan/app/pages/PlansPage.comments.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import {
   addPlanCommentToBundle,
+  buildNativeAnchorFromElement,
   buildCommentThreads,
   canEditPlanContentRole,
   commentAuthorEmails,
@@ -647,6 +648,62 @@ describe("plan comment thread UI model", () => {
     expect(nativePointForAnchor(anchor as any, reader)).toEqual({
       left: 140,
       top: 256,
+    });
+
+    reader.remove();
+  });
+
+  it("measures wireframe element clicks against the stored node target", () => {
+    const reader = document.createElement("div");
+    reader.innerHTML = `
+      <div data-block-id="canvas-block">
+        <div data-canvas-frame="frame_1">
+          <div id="card" data-wire-node-id="card" data-wire-node-el="card">
+            <button id="target">Save</button>
+          </div>
+        </div>
+      </div>
+    `;
+    document.body.append(reader);
+
+    const card = reader.querySelector<HTMLElement>("#card")!;
+    const target = reader.querySelector<HTMLElement>("#target")!;
+    Object.defineProperties(reader, {
+      scrollWidth: { value: 1000, configurable: true },
+      scrollHeight: { value: 1000, configurable: true },
+      scrollLeft: { value: 0, configurable: true },
+      scrollTop: { value: 0, configurable: true },
+      getBoundingClientRect: {
+        value: () => rect(0, 0, 1000, 1000),
+        configurable: true,
+      },
+    });
+    Object.defineProperty(card, "getBoundingClientRect", {
+      value: () => rect(100, 200, 300, 200),
+    });
+    Object.defineProperty(target, "getBoundingClientRect", {
+      value: () => rect(200, 260, 100, 40),
+    });
+
+    const anchor = buildNativeAnchorFromElement({
+      reader,
+      target,
+      pointX: 250,
+      pointY: 280,
+      planTitle: "Wireframe",
+    });
+
+    expect(anchor.sectionId).toBe("frame_1");
+    expect(anchor.targetNodeId).toBe("card");
+    expect(anchor.targetSelector).toBe(
+      '[data-canvas-frame="frame_1"] [data-wire-node-id="card"]',
+    );
+    expect(anchor.targetX).toBeCloseTo(50);
+    expect(anchor.targetY).toBeCloseTo(40);
+    expect(resolveNativeAnchorTarget(anchor, reader)).toBe(card);
+    expect(nativePointForAnchor(anchor, reader)).toEqual({
+      left: 250,
+      top: 280,
     });
 
     reader.remove();

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -1491,10 +1491,9 @@ export function selectorForElementWithin(
   const prototypeScope = prototype?.dataset.prototypeScreen
     ? dataSelector("data-prototype-screen", prototype.dataset.prototypeScreen)
     : undefined;
-  const prototypeStableSelector = stableDataSelectorForElement(
-    element,
-    prototypeScope,
-  );
+  const prototypeStableSelector = prototypeScope
+    ? stableDataSelectorForElement(element, prototypeScope)
+    : undefined;
   if (prototypeStableSelector) return prototypeStableSelector;
   if (prototype && prototypeScope) {
     return selectorForElementInScope(prototype, prototypeScope, element);
@@ -1503,7 +1502,9 @@ export function selectorForElementWithin(
   const frameScope = frame?.dataset.canvasFrame
     ? dataSelector("data-canvas-frame", frame.dataset.canvasFrame)
     : undefined;
-  const frameStableSelector = stableDataSelectorForElement(element, frameScope);
+  const frameStableSelector = frameScope
+    ? stableDataSelectorForElement(element, frameScope)
+    : undefined;
   if (frameStableSelector) return frameStableSelector;
   if (frame && frameScope) {
     return selectorForElementInScope(frame, frameScope, element);
@@ -1643,7 +1644,7 @@ function targetKindForElement(
   return "unknown";
 }
 
-function buildNativeAnchorFromElement(input: {
+export function buildNativeAnchorFromElement(input: {
   reader: HTMLElement;
   target: HTMLElement;
   pointX: number;
@@ -1665,10 +1666,15 @@ function buildNativeAnchorFromElement(input: {
   const visualElement = target.closest<HTMLElement>(
     PLAN_VISUAL_TARGET_SELECTOR,
   );
+  const wireNodeEl = target.closest<HTMLElement>("[data-wire-node-id]");
+  const designNodeEl = target.closest<HTMLElement>("[data-design-id]");
+  const planDesignNodeEl = target.closest<HTMLElement>("[data-plan-design-id]");
+  const stableVisualElement = wireNodeEl ?? designNodeEl ?? planDesignNodeEl;
   const anchorElement =
-    textElement && textSnippetFromElement(textElement)
+    stableVisualElement ??
+    (textElement && textSnippetFromElement(textElement)
       ? textElement
-      : (visualElement ?? target);
+      : (visualElement ?? target));
   const rect = anchorElement.getBoundingClientRect();
   const readerRect = reader.getBoundingClientRect();
   const localX = pointX + readerRect.left;
@@ -1704,13 +1710,10 @@ function buildNativeAnchorFromElement(input: {
             ? `Inside canvas frame ${frame.dataset.canvasFrame}`
             : undefined;
 
-  // Capture wireframe/design node identity from data attributes.
-  const wireNodeEl = target.closest<HTMLElement>("[data-wire-node-id]");
   const targetNodeId =
     wireNodeEl?.dataset.wireNodeId ||
-    target.closest<HTMLElement>("[data-design-id]")?.dataset.designId ||
-    target.closest<HTMLElement>("[data-plan-design-id]")?.dataset
-      .planDesignId ||
+    designNodeEl?.dataset.designId ||
+    planDesignNodeEl?.dataset.planDesignId ||
     undefined;
 
   // Build a short human-readable node path from the frame root down to the
@@ -1746,9 +1749,9 @@ function buildNativeAnchorFromElement(input: {
   return {
     ...base,
     sectionId:
-      block?.dataset.blockId ??
       prototype?.dataset.prototypeScreen ??
-      frame?.dataset.canvasFrame,
+      frame?.dataset.canvasFrame ??
+      block?.dataset.blockId,
     screenId: prototype?.dataset.prototypeScreen,
     sectionTitle,
     targetSelector: selectorForElementWithin(reader, anchorElement),

--- a/templates/plan/server/db/schema.ts
+++ b/templates/plan/server/db/schema.ts
@@ -51,6 +51,9 @@ export const plans = table("plans", {
   // URL of the source PR, issue, or page that triggered this recap (e.g. the
   // GitHub PR URL). Nullable — only populated when the caller supplies it.
   sourceUrl: text("source_url"),
+  // Stable key used by PR Visual Recap publish retries to replace the recap
+  // created by an earlier attempt instead of creating duplicate recap rows.
+  recapIdempotencyKey: text("recap_idempotency_key"),
   ...ownableColumns(),
 });
 

--- a/templates/plan/server/lib/plan-versions.coalesce.spec.ts
+++ b/templates/plan/server/lib/plan-versions.coalesce.spec.ts
@@ -169,7 +169,7 @@ beforeAll(async () => {
       usage_cost_cents_x100 INTEGER,
       usage_cost_source TEXT,
       usage_recorded_at TEXT,
-      source_url TEXT,
+      source_url TEXT, recap_idempotency_key TEXT,
       owner_email TEXT NOT NULL,
       org_id TEXT,
       visibility TEXT NOT NULL DEFAULT 'private'

--- a/templates/plan/server/plan-assets.spec.ts
+++ b/templates/plan/server/plan-assets.spec.ts
@@ -113,7 +113,7 @@ beforeAll(async () => {
       usage_cost_cents_x100 INTEGER,
       usage_cost_source TEXT,
       usage_recorded_at TEXT,
-      source_url TEXT,
+      source_url TEXT, recap_idempotency_key TEXT,
       owner_email TEXT NOT NULL,
       org_id TEXT,
       visibility TEXT NOT NULL DEFAULT 'private'

--- a/templates/plan/server/plugins/db.ts
+++ b/templates/plan/server/plugins/db.ts
@@ -1,3 +1,5 @@
+// guard:allow-unscoped -- schema migrations and data backfills run system-wide
+// during startup, not in a user-scoped request path.
 import { runMigrations } from "@agent-native/core/db";
 
 export default runMigrations(
@@ -288,6 +290,12 @@ CREATE INDEX IF NOT EXISTS plans_recap_idempotency_key_idx ON plans(recap_idempo
         sqlite: `ALTER TABLE plans ADD COLUMN recap_idempotency_key TEXT;
 CREATE INDEX IF NOT EXISTS plans_recap_idempotency_key_idx ON plans(recap_idempotency_key)`,
       },
+    },
+    {
+      version: 30,
+      sql: `CREATE UNIQUE INDEX IF NOT EXISTS plans_recap_idempotency_key_unique_idx
+ON plans(owner_email, COALESCE(org_id, ''), recap_idempotency_key)
+WHERE kind = 'recap' AND recap_idempotency_key IS NOT NULL`,
     },
   ],
   { table: "plans_migrations" },

--- a/templates/plan/server/plugins/db.ts
+++ b/templates/plan/server/plugins/db.ts
@@ -280,6 +280,15 @@ ALTER TABLE plan_comments ADD COLUMN deleted_by TEXT;
 CREATE INDEX IF NOT EXISTS plan_comments_plan_deleted_created_idx ON plan_comments(plan_id, deleted_at, created_at)`,
       },
     },
+    {
+      version: 29,
+      sql: {
+        postgres: `ALTER TABLE plans ADD COLUMN IF NOT EXISTS recap_idempotency_key TEXT;
+CREATE INDEX IF NOT EXISTS plans_recap_idempotency_key_idx ON plans(recap_idempotency_key)`,
+        sqlite: `ALTER TABLE plans ADD COLUMN recap_idempotency_key TEXT;
+CREATE INDEX IF NOT EXISTS plans_recap_idempotency_key_idx ON plans(recap_idempotency_key)`,
+      },
+    },
   ],
   { table: "plans_migrations" },
 );

--- a/templates/plan/server/sharing-access-matrix.spec.ts
+++ b/templates/plan/server/sharing-access-matrix.spec.ts
@@ -207,7 +207,7 @@ beforeAll(async () => {
       usage_cost_cents_x100 INTEGER,
       usage_cost_source TEXT,
       usage_recorded_at TEXT,
-      source_url TEXT,
+      source_url TEXT, recap_idempotency_key TEXT,
       owner_email TEXT NOT NULL,
       org_id TEXT,
       visibility TEXT NOT NULL DEFAULT 'private'


### PR DESCRIPTION
## Summary
- preserve Plan/Act request mode when Builder-frame and MCP App chat bridges submit prompts
- add stable recap publish idempotency keys and plan-side reuse for retry safety
- fix Plan comment pin placement for wireframe element clicks by anchoring to stable frame-scoped nodes
- add focused coverage for request-mode forwarding, recap retry reuse, and wireframe comment pin coordinates

## Validation
- pnpm --dir templates/plan exec vitest --run app/pages/PlansPage.comments.test.ts
- pnpm --dir templates/plan typecheck
- pnpm run prep