### PR TITLE
Broaden provider API access for integrations

### DIFF
--- a/.agents/skills/actions/SKILL.md
+++ b/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/.agents/skills/adding-a-feature/SKILL.md
+++ b/.agents/skills/adding-a-feature/SKILL.md
@@ -59,7 +59,13 @@ For provider-backed analysis/query/reporting integrations, do not turn every
 provider endpoint or filter into a rigid action. Prefer the shared
 `provider-api-catalog` / `provider-api-docs` / `provider-api-request` pattern
 from `@agent-native/core/provider-api`, then add narrow convenience actions only
-for workflows that truly deserve a first-class shortcut.
+for workflows that truly deserve a first-class shortcut. Treat this as a
+capability requirement, not a nice-to-have: convenience actions must not become
+the ceiling of what the agent can ask the provider to do. Pair broad provider
+access with staging or sandboxed code execution when responses may be too large
+for chat context. If provider credentials live on resource/share rows, add the
+scoped resolver first so broad access preserves the same ownership boundary as
+the app UI.
 
 If the feature needs credentials, design the credential path in the same change.
 Never hardcode API keys, tokens, webhook URLs, signing secrets, private

--- a/.changeset/provider-api-integration-access.md
+++ b/.changeset/provider-api-integration-access.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Broaden provider API integration access and preserve provider base paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,12 @@ step is still pending. Use `🔴` only when blocked on user input.
   cross-source research, prefer the shared `provider-api-catalog`,
   `provider-api-docs`, and `provider-api-request` action pattern from
   `@agent-native/core/provider-api` instead of hardcoding one action per
-  provider endpoint/filter.
+  provider endpoint/filter. This is a framework tenet: first-class actions are
+  ergonomic shortcuts, not artificial capability limits. When the upstream API
+  can express an endpoint, filter, pagination mode, or payload, agents should
+  have a safe way to call it directly through the provider API substrate. If an
+  app stores provider credentials on resource/share rows, add a scoped resolver
+  that preserves those access checks before exposing raw provider requests.
 - All AI work goes through the agent chat. UIs do not call LLMs directly.
 - Application state belongs in SQL `application_state` so the agent can know
   the current navigation, selection, and focused object.

--- a/packages/core/src/provider-api/index.spec.ts
+++ b/packages/core/src/provider-api/index.spec.ts
@@ -5,6 +5,7 @@ const isBlockedExtensionUrlWithDns = vi.fn();
 const createSsrfSafeDispatcher = vi.fn();
 const listOAuthAccountsByOwner = vi.fn();
 const saveOAuthTokens = vi.fn();
+const deleteOAuthTokens = vi.fn();
 
 vi.mock("../credentials/index.js", () => ({
   resolveCredential,
@@ -16,6 +17,7 @@ vi.mock("../extensions/url-safety.js", () => ({
 }));
 
 vi.mock("../oauth-tokens/index.js", () => ({
+  deleteOAuthTokens,
   listOAuthAccountsByOwner,
   saveOAuthTokens,
 }));
@@ -35,6 +37,8 @@ describe("provider API runtime", () => {
     createSsrfSafeDispatcher.mockReset();
     listOAuthAccountsByOwner.mockReset();
     saveOAuthTokens.mockReset();
+    deleteOAuthTokens.mockReset();
+    vi.unstubAllEnvs();
     isBlockedExtensionUrlWithDns.mockResolvedValue(false);
     createSsrfSafeDispatcher.mockResolvedValue(null);
     resolveCredential.mockResolvedValue(null);
@@ -117,5 +121,48 @@ describe("provider API runtime", () => {
         }),
       }),
     );
+  });
+
+  it("deletes stale Google OAuth grants after permanent refresh failures", async () => {
+    vi.stubEnv("GOOGLE_CLIENT_ID", "google-client-id");
+    vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-client-secret");
+    listOAuthAccountsByOwner.mockResolvedValue([
+      {
+        accountId: "docs@example.com",
+        displayName: "Docs Account",
+        tokens: {
+          access_token: "expired-docs-access-token",
+          refresh_token: "dead-refresh-token",
+          expiry_date: Date.now() - 60_000,
+        },
+      },
+    ]);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "invalid_grant" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const runtime = createProviderApiRuntime({
+      appId: "slides",
+      providerIds: ["google_drive"],
+      getCredentialContext: () => credentialContext,
+      oauthProviderOverrides: {
+        google_drive: "google-docs",
+      },
+    });
+
+    await expect(
+      runtime.executeRequest({
+        provider: "google_drive",
+        path: "/files",
+      }),
+    ).rejects.toThrow(/Google OAuth refresh failed: invalid_grant/);
+
+    expect(deleteOAuthTokens).toHaveBeenCalledWith(
+      "google-docs",
+      "docs@example.com",
+    );
+    expect(saveOAuthTokens).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/provider-api/index.spec.ts
+++ b/packages/core/src/provider-api/index.spec.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const resolveCredential = vi.fn();
 const isBlockedExtensionUrlWithDns = vi.fn();
 const createSsrfSafeDispatcher = vi.fn();
+const listOAuthAccountsByOwner = vi.fn();
+const saveOAuthTokens = vi.fn();
 
 vi.mock("../credentials/index.js", () => ({
   resolveCredential,
@@ -11,6 +13,11 @@ vi.mock("../credentials/index.js", () => ({
 vi.mock("../extensions/url-safety.js", () => ({
   createSsrfSafeDispatcher,
   isBlockedExtensionUrlWithDns,
+}));
+
+vi.mock("../oauth-tokens/index.js", () => ({
+  listOAuthAccountsByOwner,
+  saveOAuthTokens,
 }));
 
 const { createProviderApiRuntime } = await import("./index.js");
@@ -26,9 +33,17 @@ describe("provider API runtime", () => {
     resolveCredential.mockReset();
     isBlockedExtensionUrlWithDns.mockReset();
     createSsrfSafeDispatcher.mockReset();
+    listOAuthAccountsByOwner.mockReset();
+    saveOAuthTokens.mockReset();
     isBlockedExtensionUrlWithDns.mockResolvedValue(false);
     createSsrfSafeDispatcher.mockResolvedValue(null);
     resolveCredential.mockResolvedValue(null);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ files: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
   });
 
   it("enforces provider allowlists for specific catalog lookups", async () => {
@@ -62,5 +77,45 @@ describe("provider API runtime", () => {
 
     expect(resolveCredential).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("allows templates to override the OAuth provider for built-in provider APIs", async () => {
+    listOAuthAccountsByOwner.mockResolvedValue([
+      {
+        accountId: "docs@example.com",
+        displayName: "Docs Account",
+        tokens: {
+          access_token: "docs-access-token",
+          expiry_date: Date.now() + 60_000,
+        },
+      },
+    ]);
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const runtime = createProviderApiRuntime({
+      appId: "slides",
+      providerIds: ["google_drive"],
+      getCredentialContext: () => credentialContext,
+      oauthProviderOverrides: {
+        google_drive: "google-docs",
+      },
+    });
+
+    await runtime.executeRequest({
+      provider: "google_drive",
+      path: "/files",
+    });
+
+    expect(listOAuthAccountsByOwner).toHaveBeenCalledWith(
+      "google-docs",
+      credentialContext.userEmail,
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://www.googleapis.com/drive/v3/files",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer docs-access-token",
+        }),
+      }),
+    );
   });
 });

--- a/packages/core/src/provider-api/index.ts
+++ b/packages/core/src/provider-api/index.ts
@@ -8,6 +8,7 @@ import {
   isBlockedExtensionUrlWithDns,
 } from "../extensions/url-safety.js";
 import {
+  deleteOAuthTokens,
   listOAuthAccountsByOwner,
   saveOAuthTokens,
 } from "../oauth-tokens/index.js";
@@ -263,6 +264,12 @@ interface OAuthTokens {
   token_type?: string;
   scope?: string;
 }
+
+const PERMANENT_GOOGLE_OAUTH_REFRESH_ERRORS = new Set([
+  "invalid_grant",
+  "unauthorized_client",
+  "invalid_client",
+]);
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_TIMEOUT_MS = 120_000;
@@ -2327,6 +2334,9 @@ async function refreshGoogleOAuthToken(
     error_description?: string;
   };
   if (!res.ok || !data.access_token) {
+    if (data.error && PERMANENT_GOOGLE_OAUTH_REFRESH_ERRORS.has(data.error)) {
+      await deleteOAuthTokens(options.oauthProvider, options.accountId);
+    }
     const detail = data.error_description ?? data.error ?? res.statusText;
     throw new Error(`Google OAuth refresh failed: ${detail}`);
   }

--- a/packages/core/src/provider-api/index.ts
+++ b/packages/core/src/provider-api/index.ts
@@ -220,6 +220,12 @@ export interface ProviderApiRuntimeOptions {
   getCredentialContext?: () => CredentialContext | null;
   resolveCredential?: ProviderApiCredentialResolver;
   /**
+   * Template-specific OAuth token provider overrides for built-in provider API
+   * configs. Use when an app stores a provider's OAuth grant under a narrower
+   * local provider id, e.g. Google Drive scoped to a "google-docs" connection.
+   */
+  oauthProviderOverrides?: Record<string, string>;
+  /**
    * Optional loader for custom providers registered at runtime. When provided,
    * custom providers are merged with the static built-in registry for catalog,
    * docs, and request operations. Custom providers cannot shadow built-in ids.
@@ -321,7 +327,7 @@ const PROVIDER_CONFIGS: Record<ProviderApiId, ProviderApiConfig> = {
     },
     credentialKeys: ["APOLLO_API_KEY"],
     docsUrls: ["https://docs.apollo.io/reference/api-reference"],
-    templateUses: ["analytics"],
+    templateUses: ["analytics", "calendar"],
     examples: [
       {
         label: "Search people",
@@ -497,7 +503,7 @@ const PROVIDER_CONFIGS: Record<ProviderApiId, ProviderApiConfig> = {
       Accept: "application/vnd.github+json",
       "X-GitHub-Api-Version": "2022-11-28",
     },
-    templateUses: ["analytics", "brain", "dispatch"],
+    templateUses: ["analytics", "brain", "design", "dispatch"],
     examples: [
       { label: "Authenticated user", method: "GET", path: "/user" },
       { label: "Search issues", method: "GET", path: "/search/issues" },
@@ -546,7 +552,7 @@ const PROVIDER_CONFIGS: Record<ProviderApiId, ProviderApiConfig> = {
     },
     credentialKeys: ["GONG_ACCESS_KEY", "GONG_ACCESS_SECRET", "GONG_API_BASE"],
     docsUrls: ["https://gong.app.gong.io/settings/api/documentation"],
-    templateUses: ["analytics"],
+    templateUses: ["analytics", "calendar"],
     examples: [
       { label: "List calls", method: "GET", path: "/calls" },
       {
@@ -570,7 +576,7 @@ const PROVIDER_CONFIGS: Record<ProviderApiId, ProviderApiConfig> = {
     docsUrls: ["https://developers.google.com/calendar/api/v3/reference"],
     specUrls: ["https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest"],
     allowedHostSuffixes: ["googleapis.com"],
-    templateUses: ["brain", "calendar", "dispatch"],
+    templateUses: ["brain", "calendar", "dispatch", "mail"],
     examples: [
       {
         label: "List calendars",
@@ -653,7 +659,7 @@ const PROVIDER_CONFIGS: Record<ProviderApiId, ProviderApiConfig> = {
     },
     credentialKeys: ["HUBSPOT_PRIVATE_APP_TOKEN", "HUBSPOT_ACCESS_TOKEN"],
     docsUrls: ["https://developers.hubspot.com/docs/api/overview"],
-    templateUses: ["analytics", "brain", "mail", "dispatch"],
+    templateUses: ["analytics", "brain", "calendar", "mail", "dispatch"],
     examples: [
       {
         label: "Search deals with any HubSpot CRM filter",
@@ -812,7 +818,7 @@ const PROVIDER_CONFIGS: Record<ProviderApiId, ProviderApiConfig> = {
     },
     credentialKeys: ["PYLON_API_KEY"],
     docsUrls: ["https://docs.usepylon.com/pylon-docs/developer/api-reference"],
-    templateUses: ["analytics"],
+    templateUses: ["analytics", "calendar"],
     examples: [{ label: "List issues", method: "GET", path: "/issues" }],
   },
   sentry: {
@@ -1833,7 +1839,7 @@ function buildProviderUrl(options: {
   const rawPath = options.rawPath.trim();
   const url = /^https?:\/\//i.test(rawPath)
     ? new URL(rawPath)
-    : new URL(rawPath.startsWith("/") ? rawPath : `/${rawPath}`, base);
+    : new URL(joinProviderUrlPath(base, rawPath), base.origin);
 
   if (!isAllowedProviderUrl(url, base, options.config)) {
     throw new Error(
@@ -1846,6 +1852,13 @@ function buildProviderUrl(options: {
   }
 
   return url;
+}
+
+function joinProviderUrlPath(base: URL, rawPath: string): string {
+  const basePath = base.pathname.replace(/\/+$/, "");
+  const providerPath = rawPath.replace(/^\/+/, "");
+  if (!providerPath) return basePath || "/";
+  return `${basePath}/${providerPath}`;
 }
 
 function isAllowedProviderUrl(
@@ -1984,8 +1997,10 @@ async function resolveAuth(
     };
   }
   if (auth.type === "oauth-bearer") {
+    const oauthProvider =
+      runtime.oauthProviderOverrides?.[config.id] ?? auth.oauthProvider;
     const credential = await resolveOAuthBearerToken({
-      auth,
+      auth: { ...auth, oauthProvider },
       ctx,
       accountId: args.accountId,
     });
@@ -2266,7 +2281,10 @@ async function getValidOAuthAccessToken(options: {
   const refreshToken =
     options.tokens.refresh_token ?? options.tokens.refreshToken;
   if (!refreshToken) return accessToken;
-  if (options.oauthProvider === "google") {
+  if (
+    options.oauthProvider === "google" ||
+    options.oauthProvider === "google-docs"
+  ) {
     return refreshGoogleOAuthToken(options, refreshToken);
   }
   throw new Error(

--- a/packages/core/src/templates/default/.agents/skills/actions/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/packages/core/src/templates/default/.agents/skills/adding-a-feature/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/adding-a-feature/SKILL.md
@@ -59,7 +59,13 @@ For provider-backed analysis/query/reporting integrations, do not turn every
 provider endpoint or filter into a rigid action. Prefer the shared
 `provider-api-catalog` / `provider-api-docs` / `provider-api-request` pattern
 from `@agent-native/core/provider-api`, then add narrow convenience actions only
-for workflows that truly deserve a first-class shortcut.
+for workflows that truly deserve a first-class shortcut. Treat this as a
+capability requirement, not a nice-to-have: convenience actions must not become
+the ceiling of what the agent can ask the provider to do. Pair broad provider
+access with staging or sandboxed code execution when responses may be too large
+for chat context. If provider credentials live on resource/share rows, add the
+scoped resolver first so broad access preserves the same ownership boundary as
+the app UI.
 
 If the feature needs credentials, design the credential path in the same change.
 Never hardcode API keys, tokens, webhook URLs, signing secrets, private

--- a/packages/core/src/templates/workspace-core/.agents/skills/actions/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/packages/core/src/templates/workspace-core/.agents/skills/adding-a-feature/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/adding-a-feature/SKILL.md
@@ -59,7 +59,13 @@ For provider-backed analysis/query/reporting integrations, do not turn every
 provider endpoint or filter into a rigid action. Prefer the shared
 `provider-api-catalog` / `provider-api-docs` / `provider-api-request` pattern
 from `@agent-native/core/provider-api`, then add narrow convenience actions only
-for workflows that truly deserve a first-class shortcut.
+for workflows that truly deserve a first-class shortcut. Treat this as a
+capability requirement, not a nice-to-have: convenience actions must not become
+the ceiling of what the agent can ask the provider to do. Pair broad provider
+access with staging or sandboxed code execution when responses may be too large
+for chat context. If provider credentials live on resource/share rows, add the
+scoped resolver first so broad access preserves the same ownership boundary as
+the app UI.
 
 If the feature needs credentials, design the credential path in the same change.
 Never hardcode API keys, tokens, webhook URLs, signing secrets, private

--- a/templates/analytics/.agents/skills/actions/SKILL.md
+++ b/templates/analytics/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/templates/assets/.agents/skills/actions/SKILL.md
+++ b/templates/assets/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/templates/brain/.agents/skills/actions/SKILL.md
+++ b/templates/brain/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/templates/brain/.agents/skills/adding-a-feature/SKILL.md
+++ b/templates/brain/.agents/skills/adding-a-feature/SKILL.md
@@ -59,7 +59,13 @@ For provider-backed analysis/query/reporting integrations, do not turn every
 provider endpoint or filter into a rigid action. Prefer the shared
 `provider-api-catalog` / `provider-api-docs` / `provider-api-request` pattern
 from `@agent-native/core/provider-api`, then add narrow convenience actions only
-for workflows that truly deserve a first-class shortcut.
+for workflows that truly deserve a first-class shortcut. Treat this as a
+capability requirement, not a nice-to-have: convenience actions must not become
+the ceiling of what the agent can ask the provider to do. Pair broad provider
+access with staging or sandboxed code execution when responses may be too large
+for chat context. If provider credentials live on resource/share rows, add the
+scoped resolver first so broad access preserves the same ownership boundary as
+the app UI.
 
 If the feature needs credentials, design the credential path in the same change.
 Never hardcode API keys, tokens, webhook URLs, signing secrets, private

--- a/templates/calendar/.agents/skills/actions/SKILL.md
+++ b/templates/calendar/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/templates/calendar/AGENTS.md
+++ b/templates/calendar/AGENTS.md
@@ -18,6 +18,15 @@ Detailed event, availability, booking, storage, and UI rules live in
   the user says today/tomorrow/yesterday.
 - Use `view-screen` when the active date range, selected event, booking link, or
   connected-calendar health is unclear.
+- Treat provider-specific actions as shortcuts, not capability limits. When the
+  exact Google Calendar, CRM, or enrichment endpoint/filter/pagination/API
+  version matters, use `provider-api-catalog`, `provider-api-docs`, and
+  `provider-api-request` against the real provider API instead of weakening the
+  answer around a narrow action.
+- For relationship-history searches, prefer raw Google Calendar API calls via
+  `provider-api-request` so the agent controls `calendarId`, `timeMin`,
+  `timeMax`, `q`, `maxResults`, and pagination. For large scans, stage results
+  with `stageAs` and analyze them with `query-staged-dataset`.
 - For Google Calendar, distinguish an empty calendar from missing auth,
   reauth-needed, or fetch failures.
 - Use framework sharing actions for calendars/events/booking resources when

--- a/templates/calendar/actions/delete-staged-dataset.ts
+++ b/templates/calendar/actions/delete-staged-dataset.ts
@@ -1,0 +1,42 @@
+/**
+ * Thin calendar re-export of staged dataset deletion, pre-bound to appId="calendar".
+ */
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { deleteStagedDataset } from "@agent-native/core/provider-api/staged-datasets-store";
+import { z } from "zod";
+import { CALENDAR_APP_ID } from "../server/lib/provider-api.js";
+
+export default defineAction({
+  description:
+    "Delete a staged dataset by id, freeing its scratch storage. Use after analysis is complete or before re-staging under the same name. Only the owner who staged the dataset can delete it.",
+  schema: z.object({
+    datasetId: z
+      .string()
+      .min(1)
+      .describe(
+        "Dataset id to delete (from list-staged-datasets or provider-api-request stageAs result).",
+      ),
+  }),
+  http: false,
+  run: async (args) => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for delete-staged-dataset.");
+    }
+
+    const deleted = await deleteStagedDataset({
+      id: args.datasetId,
+      appId: CALENDAR_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    if (!deleted) {
+      throw new Error(
+        `Dataset ${args.datasetId} not found (or belongs to a different owner/app).`,
+      );
+    }
+
+    return { deleted: true, datasetId: args.datasetId };
+  },
+});

--- a/templates/calendar/actions/event-search.test.ts
+++ b/templates/calendar/actions/event-search.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { CalendarEvent } from "../shared/api.js";
+import {
+  calendarEventMatchesQuery,
+  calendarSearchTokens,
+} from "./event-search";
+
+function event(overrides: Partial<CalendarEvent>): CalendarEvent {
+  return {
+    id: "event-1",
+    title: "David Popowitz and Steve Sewell",
+    description: "",
+    start: "2025-03-11T23:00:00Z",
+    end: "2025-03-11T23:30:00Z",
+    location: "",
+    allDay: false,
+    source: "google",
+    attendees: [{ email: "poppy@adobe.com", displayName: "David Popowitz" }],
+    createdAt: "2025-03-01T00:00:00Z",
+    updatedAt: "2025-03-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("calendar event search", () => {
+  it("drops meeting filler words so company-history queries match attendee domains", () => {
+    expect(calendarSearchTokens("my Adobe-related meetings")).toEqual([
+      "adobe",
+    ]);
+
+    expect(calendarEventMatchesQuery(event({}), "my Adobe meetings")).toBe(
+      true,
+    );
+  });
+
+  it("matches multi-token people queries across title and attendee metadata", () => {
+    expect(calendarEventMatchesQuery(event({}), "David Popowitz")).toBe(true);
+  });
+
+  it("does not match unrelated company queries", () => {
+    expect(calendarEventMatchesQuery(event({}), "Figma meetings")).toBe(false);
+  });
+});

--- a/templates/calendar/actions/event-search.ts
+++ b/templates/calendar/actions/event-search.ts
@@ -1,0 +1,76 @@
+import type { CalendarEvent } from "../shared/api.js";
+
+const SEARCH_STOPWORDS = new Set([
+  "a",
+  "about",
+  "all",
+  "and",
+  "at",
+  "call",
+  "calls",
+  "calendar",
+  "event",
+  "events",
+  "for",
+  "from",
+  "history",
+  "meeting",
+  "meetings",
+  "my",
+  "of",
+  "on",
+  "related",
+  "the",
+  "to",
+  "with",
+]);
+
+export function calendarEventSearchText(event: CalendarEvent): string {
+  return [
+    event.title,
+    event.description,
+    event.location,
+    event.organizer?.email,
+    event.organizer?.displayName,
+    ...(event.attendees ?? []).flatMap((attendee) => [
+      attendee.email,
+      attendee.displayName,
+    ]),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+export function calendarSearchTokens(query: string): string[] {
+  const normalized = query
+    .toLowerCase()
+    .replace(/['’]s\b/g, "")
+    .replace(/[^a-z0-9@._]+/g, " ");
+
+  return Array.from(
+    new Set(
+      (
+        normalized.match(
+          /[a-z0-9._%+]+@[a-z0-9.-]+|[a-z0-9]+(?:\.[a-z0-9]+)*/g,
+        ) ?? []
+      )
+        .map((token) => token.trim())
+        .filter((token) => token.length > 1 && !SEARCH_STOPWORDS.has(token)),
+    ),
+  );
+}
+
+export function calendarEventMatchesQuery(
+  event: CalendarEvent,
+  query: string,
+): boolean {
+  const haystack = calendarEventSearchText(event);
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+  if (haystack.includes(normalizedQuery)) return true;
+
+  const tokens = calendarSearchTokens(query);
+  if (tokens.length === 0) return false;
+  return tokens.every((token) => haystack.includes(token));
+}

--- a/templates/calendar/actions/list-events.test.ts
+++ b/templates/calendar/actions/list-events.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { resolveCalendarEventRange } from "./list-events.js";
+
+describe("resolveCalendarEventRange", () => {
+  it("uses the requested timezone when resolving date-only bounds", () => {
+    const range = resolveCalendarEventRange({
+      from: "2026-05-26",
+      to: "2026-05-27",
+      timezone: "America/Los_Angeles",
+    });
+
+    expect(range.from).toBe("2026-05-26T07:00:00.000Z");
+    expect(range.to).toBe("2026-05-27T07:00:00.000Z");
+  });
+});

--- a/templates/calendar/actions/list-events.ts
+++ b/templates/calendar/actions/list-events.ts
@@ -11,6 +11,7 @@ import * as googleCalendar from "../server/lib/google-calendar.js";
 import { fetchICalEvents } from "../server/lib/ical-fetcher.js";
 import { getUserSetting } from "@agent-native/core/settings";
 import { getDb, schema } from "../server/db/index.js";
+import { calendarEventMatchesQuery } from "./event-search.js";
 
 const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -314,24 +315,9 @@ export async function listCalendarEvents(
 
   let events = [...googleEvents, ...icalEvents, ...bookingEvents];
   if (args.query) {
-    const query = args.query.toLowerCase();
-    events = events.filter((event) => {
-      const haystack = [
-        event.title,
-        event.description,
-        event.location,
-        event.organizer?.email,
-        event.organizer?.displayName,
-        ...(event.attendees ?? []).flatMap((attendee) => [
-          attendee.email,
-          attendee.displayName,
-        ]),
-      ]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase();
-      return haystack.includes(query);
-    });
+    events = events.filter((event) =>
+      calendarEventMatchesQuery(event, args.query!),
+    );
   }
   const fromDate = new Date(range.from);
   events = events.filter((e) => new Date(e.end) >= fromDate);

--- a/templates/calendar/actions/list-staged-datasets.ts
+++ b/templates/calendar/actions/list-staged-datasets.ts
@@ -1,0 +1,39 @@
+/**
+ * Thin calendar re-export of staged dataset listing, pre-bound to appId="calendar".
+ */
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { listStagedDatasets } from "@agent-native/core/provider-api/staged-datasets-store";
+import { z } from "zod";
+import { CALENDAR_APP_ID } from "../server/lib/provider-api.js";
+
+export default defineAction({
+  description:
+    "List staged datasets stored by provider-api-request (stageAs) for the current user. Returns dataset ids, names, row counts, columns, and sizes. Use dataset ids with query-staged-dataset to aggregate, or with delete-staged-dataset to free scratch storage.",
+  schema: z.object({}),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async () => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for list-staged-datasets.");
+    }
+
+    const datasets = await listStagedDatasets({
+      appId: CALENDAR_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    return {
+      datasets: datasets.map((d) => ({
+        id: d.id,
+        name: d.name,
+        rowCount: d.rowCount,
+        columns: d.columns,
+        byteSize: d.byteSize,
+        updatedAt: new Date(d.updatedAt).toISOString(),
+      })),
+      total: datasets.length,
+    };
+  },
+});

--- a/templates/calendar/actions/provider-api-catalog.ts
+++ b/templates/calendar/actions/provider-api-catalog.ts
@@ -1,0 +1,27 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import {
+  CALENDAR_PROVIDER_API_IDS,
+  listProviderApiCatalog,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(CALENDAR_PROVIDER_API_IDS);
+
+export default defineAction({
+  description:
+    "List raw HTTP API capabilities for Calendar-connected providers. Use before provider-api-request when calendar/event/CRM convenience actions are too narrow. Returns provider base URLs, auth style, credential key names, docs/spec URLs, placeholders, and examples; never returns secret values.",
+  schema: z.object({
+    provider: ProviderSchema.optional().describe(
+      "Optional provider id to inspect. Omit to list every Calendar provider API escape hatch.",
+    ),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async ({ provider }) => {
+    return {
+      providers: await listProviderApiCatalog(provider),
+      guidance:
+        "Calendar actions like list-events, search-events, and CRM contact lookups are convenience shortcuts, not capability limits. When the provider API can answer the question with a better endpoint, query, body, pagination mode, or API version, inspect docs/spec URLs and call provider-api-request directly.",
+    };
+  },
+});

--- a/templates/calendar/actions/provider-api-docs.ts
+++ b/templates/calendar/actions/provider-api-docs.ts
@@ -1,0 +1,35 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import {
+  CALENDAR_PROVIDER_API_IDS,
+  fetchProviderApiDocs,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(CALENDAR_PROVIDER_API_IDS);
+
+export default defineAction({
+  description:
+    "Inspect provider API docs/spec metadata, or fetch any public API documentation page, OpenAPI spec, changelog, or web page. Use this before provider-api-request when the exact Google Calendar/CRM endpoint, filter operator, payload shape, pagination, or API version is uncertain.",
+  schema: z.object({
+    provider: ProviderSchema.describe(
+      "Provider whose API docs/spec to inspect.",
+    ),
+    url: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        "Optional public docs/spec URL to fetch. Registered docs/spec URLs from provider-api-catalog are curated starting points, but any public http(s) API documentation URL is allowed.",
+      ),
+    maxBytes: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(4 * 1024 * 1024)
+      .optional()
+      .describe("Maximum response bytes to read. Default 1MB, max 4MB."),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async (args) => fetchProviderApiDocs(args),
+});

--- a/templates/calendar/actions/provider-api-request.ts
+++ b/templates/calendar/actions/provider-api-request.ts
@@ -1,0 +1,223 @@
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { stagingExecuteRequest } from "@agent-native/core/provider-api/staging";
+import { z } from "zod";
+import {
+  CALENDAR_APP_ID,
+  CALENDAR_PROVIDER_API_IDS,
+  executeProviderApiRequest,
+  getCalendarProviderApiRuntime,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(CALENDAR_PROVIDER_API_IDS);
+const MethodSchema = z.enum(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]);
+
+const PaginationSchema = z
+  .object({
+    nextCursorPath: z
+      .string()
+      .optional()
+      .describe(
+        "Dot-path in the response JSON where the next cursor/token lives, e.g. 'nextPageToken'.",
+      ),
+    cursorParam: z
+      .string()
+      .optional()
+      .describe(
+        "Query parameter name to inject the cursor into the next request. Required when nextCursorPath is set.",
+      ),
+    pageParam: z
+      .string()
+      .optional()
+      .describe(
+        "Use page-number mode: this query param is incremented on each page.",
+      ),
+    startPage: z.coerce
+      .number()
+      .int()
+      .optional()
+      .describe("Starting page number for pageParam mode (default 1)."),
+    offsetParam: z
+      .string()
+      .optional()
+      .describe(
+        "Use offset mode: this query param is incremented by pageSize on each request.",
+      ),
+    pageSize: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        "Expected page size for offset increments. Defaults to the actual item count of the first page.",
+      ),
+    maxPages: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe("Maximum pages to fetch server-side (default 50, max 200)."),
+  })
+  .optional();
+
+export default defineAction({
+  description:
+    "Make an arbitrary authenticated HTTP request to a Calendar-connected provider API. " +
+    "Use this as the flexible escape hatch when a convenience action cannot express the needed endpoint, event filter, attendee search, calendar list, CRM object, pagination mode, payload, or API version. " +
+    "The request is constrained to the provider host, uses configured credentials automatically, blocks private/internal URLs, and redacts secrets from responses. " +
+    "\n\nSTAGING MODE (preferred for large responses): Pass stageAs to write response items into a scratch dataset instead of returning the raw body. " +
+    "Returns { dataset, rowCount, columns, sampleRows } so only a compact summary enters context. Use query-staged-dataset to aggregate, filter, and project the data without re-fetching. " +
+    "\n\nPAGINATION: When stageAs is set, pass pagination config to fetch all pages server-side into the same dataset. For Google Calendar events.list, use nextCursorPath='nextPageToken', cursorParam='pageToken', and itemsPath='items'.",
+  schema: z.object({
+    provider: ProviderSchema.describe(
+      "Configured provider API to call, e.g. google_calendar, apollo, gong, hubspot, or pylon.",
+    ),
+    method: MethodSchema.default("GET").describe("HTTP method to use."),
+    path: z
+      .string()
+      .min(1)
+      .describe(
+        "Provider API path such as /calendars/primary/events, /users/me/calendarList, /crm/v3/objects/contacts/search, or a full URL on an allowed provider host. Use placeholders from provider-api-catalog when provided.",
+      ),
+    query: z
+      .unknown()
+      .optional()
+      .describe(
+        "Optional query params as a JSON object/string. Array values produce repeated query params.",
+      ),
+    headers: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe(
+        "Optional extra headers. Unsafe hop-by-hop headers are ignored. Auth headers are injected from stored credentials.",
+      ),
+    body: z
+      .unknown()
+      .optional()
+      .describe(
+        "Optional request body. Objects/arrays are JSON encoded; strings are sent as-is.",
+      ),
+    auth: z
+      .enum(["default", "none"])
+      .default("default")
+      .describe(
+        "Use default to inject configured provider auth. Use none only for public provider endpoints that intentionally require no auth.",
+      ),
+    connectionId: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe(
+        "Optional workspace connection ID to use for provider credentials. When set, credentials must resolve from that connection.",
+      ),
+    accountId: z
+      .string()
+      .optional()
+      .describe(
+        "Optional OAuth account id to use for OAuth-backed providers such as Google Calendar.",
+      ),
+    timeoutMs: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(120_000)
+      .optional()
+      .describe("Request timeout in milliseconds. Default 30000, max 120000."),
+    maxBytes: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(4 * 1024 * 1024)
+      .optional()
+      .describe(
+        "Maximum response bytes to read. Default 1MB, max 4MB. Ignored when saveToFile is set (allows up to 20MB).",
+      ),
+    stageAs: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "When set, parse the response as an array of records and write them into a staged dataset with this name. Returns a compact summary instead of the raw body. Re-staging the same name replaces the previous dataset.",
+      ),
+    itemsPath: z
+      .string()
+      .optional()
+      .describe(
+        "Dot-path to the items array in the response JSON, e.g. 'items' for Google Calendar events.list or 'results' for CRM searches. Omit for auto-detection.",
+      ),
+    pagination: PaginationSchema.describe(
+      "Pagination config for server-side fetchAll when stageAs is set. Supports cursor, page, and offset modes.",
+    ),
+    saveToFile: z
+      .string()
+      .optional()
+      .describe(
+        "Workspace file path to save the full response body to instead of returning it in context, e.g. 'calendar/adobe-events.json'. When set, returns only a compact summary and allows up to 20MB response.",
+      ),
+    fetchAllPages: z
+      .object({
+        cursorPath: z
+          .string()
+          .describe(
+            "Dot-path in the JSON response body where the next-page cursor lives, e.g. 'nextPageToken'.",
+          ),
+        cursorParam: z
+          .string()
+          .describe(
+            "Query parameter name to pass the cursor on subsequent pages, e.g. 'pageToken'.",
+          ),
+        itemsPath: z
+          .string()
+          .optional()
+          .describe(
+            "Dot-path to the items array in each response, e.g. 'items' or 'results'. When omitted, the whole response body is appended per page.",
+          ),
+        maxPages: z.coerce
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .describe(
+            "Maximum pages to fetch. Default 10, max 50. Stops early when cursor is empty.",
+          ),
+      })
+      .optional()
+      .describe(
+        "Enable cursor-based pagination. For Google Calendar events.list, use { cursorPath: 'nextPageToken', cursorParam: 'pageToken', itemsPath: 'items' }.",
+      ),
+  }),
+  http: false,
+  run: async (args) => {
+    if (args.stageAs) {
+      const ctx = getCredentialContext();
+      if (!ctx) {
+        throw new Error("No authenticated context for provider API staging.");
+      }
+      const providerRuntime = getCalendarProviderApiRuntime();
+      return stagingExecuteRequest(
+        {
+          provider: args.provider,
+          method: args.method,
+          path: args.path,
+          query: args.query,
+          headers: args.headers,
+          body: args.body,
+          auth: args.auth,
+          connectionId: args.connectionId,
+          accountId: args.accountId,
+          timeoutMs: args.timeoutMs,
+          maxBytes: args.maxBytes,
+          stageAs: args.stageAs,
+          itemsPath: args.itemsPath,
+          pagination: args.pagination,
+        },
+        (reqArgs) => providerRuntime.executeRequest(reqArgs),
+        { appId: CALENDAR_APP_ID, ownerEmail: ctx.userEmail },
+      );
+    }
+    return executeProviderApiRequest(args);
+  },
+});

--- a/templates/calendar/actions/query-staged-dataset.ts
+++ b/templates/calendar/actions/query-staged-dataset.ts
@@ -1,0 +1,127 @@
+/**
+ * Thin calendar re-export of the staged dataset query helper, pre-bound to appId="calendar".
+ */
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { runAggregateQuery } from "@agent-native/core/provider-api/staged-datasets-aggregate";
+import {
+  getStagedDatasetMeta,
+  getStagedDatasetRows,
+} from "@agent-native/core/provider-api/staged-datasets-store";
+import { z } from "zod";
+import { CALENDAR_APP_ID } from "../server/lib/provider-api.js";
+
+const WhereSchema = z.object({
+  column: z.string().min(1),
+  op: z.enum([
+    "equals",
+    "not_equals",
+    "contains",
+    "not_contains",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "exists",
+    "not_exists",
+  ]),
+  value: z.unknown().optional(),
+});
+
+const AggregateFieldSchema = z.object({
+  column: z.string().min(1).describe("Column to aggregate."),
+  op: z
+    .enum(["sum", "avg", "count", "min", "max", "count_distinct"])
+    .describe("Aggregation function."),
+  as: z
+    .string()
+    .optional()
+    .describe("Output column name. Default: {op}_{column}."),
+});
+
+export default defineAction({
+  description:
+    "Run a filter/aggregate/project query over a staged dataset previously written by provider-api-request (stageAs). Use after staging Google Calendar events, calendar lists, attendee searches, or CRM records to count, group, filter, or project rows without re-fetching provider APIs.",
+  schema: z.object({
+    datasetId: z
+      .string()
+      .min(1)
+      .describe(
+        "Dataset id from provider-api-request stageAs result, or from list-staged-datasets.",
+      ),
+    where: z
+      .array(WhereSchema)
+      .optional()
+      .describe(
+        "Row-level filters (AND). Ops: equals, not_equals, contains, not_contains, gt, gte, lt, lte, exists, not_exists.",
+      ),
+    groupBy: z
+      .array(z.string().min(1))
+      .optional()
+      .describe(
+        "Column(s) to group by. Omit for a single aggregate over all rows.",
+      ),
+    aggregate: z
+      .array(AggregateFieldSchema)
+      .optional()
+      .describe(
+        "Aggregation operations. When set, non-group columns are aggregated. Omit to return raw rows.",
+      ),
+    select: z
+      .array(z.string().min(1))
+      .optional()
+      .describe("Column projection when aggregate is empty."),
+    orderBy: z.string().optional().describe("Sort output by this column."),
+    orderDir: z
+      .enum(["asc", "desc"])
+      .optional()
+      .describe("Sort direction (default asc)."),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(10_000)
+      .optional()
+      .describe("Maximum rows to return (default all, max 10000)."),
+  }),
+  http: false,
+  run: async (args) => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for query-staged-dataset.");
+    }
+
+    const meta = await getStagedDatasetMeta({
+      id: args.datasetId,
+      appId: CALENDAR_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+    if (!meta) {
+      throw new Error(
+        `Dataset ${args.datasetId} not found (or belongs to a different owner/app).`,
+      );
+    }
+
+    const rows = await getStagedDatasetRows({
+      id: args.datasetId,
+      appId: CALENDAR_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    const result = runAggregateQuery(rows, {
+      where: args.where,
+      groupBy: args.groupBy,
+      aggregate: args.aggregate,
+      select: args.select,
+      orderBy: args.orderBy,
+      orderDir: args.orderDir,
+      limit: args.limit,
+    });
+
+    return {
+      dataset: { id: meta.id, name: meta.name, totalRows: meta.rowCount },
+      rowCount: result.length,
+      rows: result,
+    };
+  },
+});

--- a/templates/calendar/actions/search-events.ts
+++ b/templates/calendar/actions/search-events.ts
@@ -3,6 +3,7 @@ import { getRequestUserEmail } from "@agent-native/core/server";
 import { z } from "zod";
 import * as googleCalendar from "../server/lib/google-calendar.js";
 import { calendarEventMatchesQuery } from "./event-search.js";
+import { resolveCalendarEventRange } from "./list-events.js";
 
 export default defineAction({
   description:
@@ -14,6 +15,12 @@ export default defineAction({
       .describe("Search term (case-insensitive token/substr match)"),
     from: z.string().describe("Start date/time filter (ISO date or datetime)"),
     to: z.string().describe("End date/time filter (ISO date or datetime)"),
+    timezone: z
+      .string()
+      .optional()
+      .describe(
+        "IANA timezone for date-only bounds, e.g. America/Los_Angeles. Defaults to the request timezone.",
+      ),
   }),
   http: false,
   readOnly: true,
@@ -22,8 +29,12 @@ export default defineAction({
     if (!email) throw new Error("no authenticated user");
 
     const query = args.query;
-    const from = new Date(args.from).toISOString();
-    const to = new Date(args.to).toISOString();
+    const range = resolveCalendarEventRange({
+      from: args.from,
+      to: args.to,
+      timezone: args.timezone,
+    });
+    const { from, to } = range;
 
     if (!(await googleCalendar.isConnected(email))) {
       return "Google Calendar is not connected. Connect via the Settings page first.";

--- a/templates/calendar/actions/search-events.ts
+++ b/templates/calendar/actions/search-events.ts
@@ -2,44 +2,28 @@ import { defineAction } from "@agent-native/core";
 import { getRequestUserEmail } from "@agent-native/core/server";
 import { z } from "zod";
 import * as googleCalendar from "../server/lib/google-calendar.js";
+import { calendarEventMatchesQuery } from "./event-search.js";
 
 export default defineAction({
   description:
-    "Search calendar events by title, attendees, organizer, location, or description. Defaults to a broad one-year lookback and one-year lookahead so recurring meetings and relationship-frequency questions are not missed.",
+    "Convenience search for calendar events by title, attendees, organizer, location, or description inside an explicit date range. For arbitrary Google Calendar API queries, all-calendar discovery, provider-native filters, or custom pagination, use provider-api-catalog/provider-api-docs/provider-api-request with provider=google_calendar.",
   schema: z.object({
     query: z
       .string()
-      .optional()
-      .describe("Search term (case-insensitive substring match, required)"),
-    from: z
-      .string()
-      .optional()
-      .describe("Start date filter (ISO date, default: 1 year ago)"),
-    to: z
-      .string()
-      .optional()
-      .describe("End date filter (ISO date, default: 1 year forward)"),
+      .min(1)
+      .describe("Search term (case-insensitive token/substr match)"),
+    from: z.string().describe("Start date/time filter (ISO date or datetime)"),
+    to: z.string().describe("End date/time filter (ISO date or datetime)"),
   }),
   http: false,
+  readOnly: true,
   run: async (args) => {
     const email = getRequestUserEmail();
     if (!email) throw new Error("no authenticated user");
 
     const query = args.query;
-    if (!query) throw new Error("query is required");
-
-    const now = new Date();
-    const defaultFrom = new Date(now);
-    defaultFrom.setFullYear(defaultFrom.getFullYear() - 1);
-    const defaultTo = new Date(now);
-    defaultTo.setFullYear(defaultTo.getFullYear() + 1);
-
-    const from = args.from
-      ? new Date(args.from).toISOString()
-      : defaultFrom.toISOString();
-    const to = args.to
-      ? new Date(args.to).toISOString()
-      : defaultTo.toISOString();
+    const from = new Date(args.from).toISOString();
+    const to = new Date(args.to).toISOString();
 
     if (!(await googleCalendar.isConnected(email))) {
       return "Google Calendar is not connected. Connect via the Settings page first.";
@@ -56,27 +40,10 @@ export default defineAction({
       }
     }
 
-    const queryLower = query.toLowerCase();
-    const matches = events.filter((e) => {
-      const haystack = [
-        e.title,
-        e.description,
-        e.location,
-        e.organizer?.email,
-        e.organizer?.displayName,
-        ...(e.attendees ?? []).flatMap((attendee) => [
-          attendee.email,
-          attendee.displayName,
-        ]),
-      ]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase();
-      return haystack.includes(queryLower);
-    });
+    const matches = events.filter((e) => calendarEventMatchesQuery(e, query));
 
     if (matches.length === 0) {
-      return `No events matching "${query}" found.`;
+      return `No events matching "${query}" found between ${from.slice(0, 10)} and ${to.slice(0, 10)}. Try an older --from date or an alternate person, company, or email-domain query if this should exist.`;
     }
 
     return matches.map((e) => ({

--- a/templates/calendar/server/lib/google-api.ts
+++ b/templates/calendar/server/lib/google-api.ts
@@ -349,6 +349,7 @@ export function calendarListEvents(
     singleEvents?: boolean;
     orderBy?: string;
     maxResults?: number;
+    pageToken?: string;
     eventTypes?: string[];
   } = {},
 ) {

--- a/templates/calendar/server/lib/google-calendar.spec.ts
+++ b/templates/calendar/server/lib/google-calendar.spec.ts
@@ -8,6 +8,7 @@ const createOAuth2ClientMock = vi.hoisted(() => vi.fn());
 const oauth2GetUserInfoMock = vi.hoisted(() => vi.fn());
 const peopleGetProfileMock = vi.hoisted(() => vi.fn());
 const calendarGetEventMock = vi.hoisted(() => vi.fn());
+const calendarListEventsMock = vi.hoisted(() => vi.fn());
 const calendarFreeBusyMock = vi.hoisted(() => vi.fn());
 const calendarPatchEventMock = vi.hoisted(() => vi.fn());
 const dbExecuteMock = vi.hoisted(() => vi.fn());
@@ -33,7 +34,7 @@ vi.mock("./google-api.js", () => ({
   createOAuth2Client: createOAuth2ClientMock,
   oauth2GetUserInfo: oauth2GetUserInfoMock,
   peopleGetProfile: peopleGetProfileMock,
-  calendarListEvents: vi.fn(),
+  calendarListEvents: calendarListEventsMock,
   calendarGetEvent: calendarGetEventMock,
   calendarInsertEvent: vi.fn(),
   calendarDeleteEvent: vi.fn(),
@@ -46,6 +47,7 @@ import {
   getAuthStatus,
   getFreeBusy,
   getPrimaryAccountPhotoUrl,
+  listEvents,
   rsvpEvent,
   updateEvent,
 } from "./google-calendar";
@@ -154,6 +156,77 @@ describe("calendar Google auth status", () => {
 
     await expect(getPrimaryAccountPhotoUrl("steve@example.com")).resolves.toBe(
       "https://lh3.googleusercontent.com/a/auth-photo",
+    );
+  });
+});
+
+describe("calendar event listing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    calendarListEventsMock.mockReset();
+    listOAuthAccountsByOwnerMock.mockResolvedValue([
+      {
+        accountId: "steve@example.com",
+        tokens: {
+          access_token: "access-token",
+          expiry_date: Date.now() + 10 * 60_000,
+        },
+      },
+    ]);
+  });
+
+  it("paginates Google events so broad searches can see later matches", async () => {
+    calendarListEventsMock
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: "routine-1",
+            summary: "Routine check-in",
+            start: { dateTime: "2026-01-05T17:00:00Z" },
+            end: { dateTime: "2026-01-05T17:30:00Z" },
+          },
+        ],
+        nextPageToken: "page-2",
+      })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: "adobe-1",
+            summary: "Adobe Corp Dev",
+            start: { dateTime: "2026-02-05T17:00:00Z" },
+            end: { dateTime: "2026-02-05T17:30:00Z" },
+            attendees: [{ email: "poppy@adobe.com" }],
+          },
+        ],
+      });
+
+    const result = await listEvents(
+      "2026-01-01T00:00:00Z",
+      "2026-03-01T00:00:00Z",
+      "owner@example.com",
+    );
+
+    expect(result.events.map((event) => event.googleEventId)).toEqual([
+      "routine-1",
+      "adobe-1",
+    ]);
+    expect(calendarListEventsMock).toHaveBeenNthCalledWith(
+      1,
+      "access-token",
+      "primary",
+      expect.objectContaining({
+        maxResults: 2500,
+        pageToken: undefined,
+      }),
+    );
+    expect(calendarListEventsMock).toHaveBeenNthCalledWith(
+      2,
+      "access-token",
+      "primary",
+      expect.objectContaining({
+        maxResults: 2500,
+        pageToken: "page-2",
+      }),
     );
   });
 });

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -600,15 +600,25 @@ export async function listEvents(
   const allResults = await Promise.all(
     clients.map(async ({ email, accessToken }) => {
       try {
-        const response = await calendarListEvents(accessToken, "primary", {
-          timeMin,
-          timeMax,
-          singleEvents: true,
-          orderBy: "startTime",
-          eventTypes: LIST_EVENT_TYPES,
-        });
+        const events: any[] = [];
+        let pageToken: string | undefined;
+        do {
+          const response = await calendarListEvents(accessToken, "primary", {
+            timeMin,
+            timeMax,
+            singleEvents: true,
+            orderBy: "startTime",
+            maxResults: 2500,
+            pageToken,
+            eventTypes: LIST_EVENT_TYPES,
+          });
+          events.push(...(response.items || []));
+          pageToken =
+            typeof response.nextPageToken === "string"
+              ? response.nextPageToken
+              : undefined;
+        } while (pageToken);
 
-        const events = response.items || [];
         return events.map((event: any) => {
           // Find the current user's RSVP status from attendees
           const selfAttendee = event.attendees?.find(

--- a/templates/calendar/server/lib/integration-credentials.spec.ts
+++ b/templates/calendar/server/lib/integration-credentials.spec.ts
@@ -167,6 +167,34 @@ describe("integration-credentials per-user vault", () => {
     expect(removed).toBe(true);
     expect(await getIntegrationKey(fakeEvent, "hubspot")).toBeUndefined();
   });
+
+  it("does not treat a lone Gong access key as connected", async () => {
+    saveCredentialMock.mockImplementation(
+      async (key: string, value: string, ctx: { userEmail: string }) => {
+        const scope = scopeOf(ctx);
+        store.set(`${scope}::${key}`, { scope, key, value });
+      },
+    );
+
+    await saveCredentialMock("GONG_ACCESS_KEY", "gong-access", {
+      userEmail: USER_EMAIL,
+    });
+
+    expect(await getIntegrationKey(fakeEvent, "gong")).toBeUndefined();
+  });
+
+  it("resolves Gong access key and secret as a complete basic-auth key", async () => {
+    await saveCredentialMock("GONG_ACCESS_KEY", "gong-access", {
+      userEmail: USER_EMAIL,
+    });
+    await saveCredentialMock("GONG_ACCESS_SECRET", "gong-secret", {
+      userEmail: USER_EMAIL,
+    });
+
+    expect(await getIntegrationKey(fakeEvent, "gong")).toBe(
+      "gong-access:gong-secret",
+    );
+  });
 });
 
 describe("status read path never exposes the raw key", () => {

--- a/templates/calendar/server/lib/integration-credentials.ts
+++ b/templates/calendar/server/lib/integration-credentials.ts
@@ -28,7 +28,25 @@ export type IntegrationProvider = "apollo" | "hubspot" | "gong" | "pylon";
 
 /** Vault credential key for a provider's API key. */
 function credentialKey(provider: IntegrationProvider): string {
-  return `${provider.toUpperCase()}_API_KEY`;
+  return credentialKeys(provider)[0]!;
+}
+
+/** Current provider-api-aligned key first, legacy Calendar key fallbacks after. */
+export function credentialKeys(provider: IntegrationProvider): string[] {
+  switch (provider) {
+    case "apollo":
+      return ["APOLLO_API_KEY"];
+    case "hubspot":
+      return [
+        "HUBSPOT_PRIVATE_APP_TOKEN",
+        "HUBSPOT_ACCESS_TOKEN",
+        "HUBSPOT_API_KEY",
+      ];
+    case "gong":
+      return ["GONG_API_KEY", "GONG_ACCESS_KEY"];
+    case "pylon":
+      return ["PYLON_API_KEY"];
+  }
 }
 
 /**
@@ -56,7 +74,11 @@ export async function getIntegrationKey(
 ): Promise<string | undefined> {
   const ctx = await getIntegrationContext(event);
   if (!ctx) return undefined;
-  return resolveCredential(credentialKey(provider), ctx);
+  for (const key of credentialKeys(provider)) {
+    const value = await resolveCredential(key, ctx);
+    if (value) return value;
+  }
+  return undefined;
 }
 
 /** Persist a provider's API key in the encrypted vault, scoped to the user. */

--- a/templates/calendar/server/lib/integration-credentials.ts
+++ b/templates/calendar/server/lib/integration-credentials.ts
@@ -43,7 +43,7 @@ export function credentialKeys(provider: IntegrationProvider): string[] {
         "HUBSPOT_API_KEY",
       ];
     case "gong":
-      return ["GONG_API_KEY", "GONG_ACCESS_KEY"];
+      return ["GONG_API_KEY", "GONG_ACCESS_KEY", "GONG_ACCESS_SECRET"];
     case "pylon":
       return ["PYLON_API_KEY"];
   }
@@ -74,6 +74,15 @@ export async function getIntegrationKey(
 ): Promise<string | undefined> {
   const ctx = await getIntegrationContext(event);
   if (!ctx) return undefined;
+  if (provider === "gong") {
+    const legacyValue = await resolveCredential("GONG_API_KEY", ctx);
+    if (legacyValue) return legacyValue;
+    const accessKey = await resolveCredential("GONG_ACCESS_KEY", ctx);
+    const accessSecret = await resolveCredential("GONG_ACCESS_SECRET", ctx);
+    return accessKey && accessSecret
+      ? `${accessKey}:${accessSecret}`
+      : undefined;
+  }
   for (const key of credentialKeys(provider)) {
     const value = await resolveCredential(key, ctx);
     if (value) return value;

--- a/templates/calendar/server/lib/provider-api.ts
+++ b/templates/calendar/server/lib/provider-api.ts
@@ -1,0 +1,127 @@
+import {
+  createProviderApiRuntime,
+  defaultProviderApiCredentialResolver,
+  listProviderApiIdsForTemplateUse,
+  type ProviderApiCredentialLookupOptions,
+  type ProviderApiCredentialResolver,
+  type ProviderApiId,
+  type ProviderApiMethod,
+  type ProviderApiRequestArgs,
+  type ProviderApiResolvedCredential,
+} from "@agent-native/core/provider-api";
+import { resolveCredential } from "@agent-native/core/credentials";
+import { getCredentialContext } from "@agent-native/core/server";
+
+export const CALENDAR_APP_ID = "calendar";
+export const CALENDAR_PROVIDER_API_IDS = listProviderApiIdsForTemplateUse(
+  "calendar",
+) as [ProviderApiId, ...ProviderApiId[]];
+export type CalendarProviderApiId = ProviderApiId;
+export type { ProviderApiMethod, ProviderApiRequestArgs };
+
+function legacyCredential(
+  options: ProviderApiCredentialLookupOptions,
+  key: string,
+  value: string,
+): ProviderApiResolvedCredential {
+  return {
+    key,
+    value,
+    source: `${CALENDAR_APP_ID}_legacy_credentials`,
+    provider: options.provider,
+  };
+}
+
+async function resolveLegacyHubSpotCredential(
+  options: ProviderApiCredentialLookupOptions,
+): Promise<ProviderApiResolvedCredential | null> {
+  if (
+    options.provider !== "hubspot" ||
+    (options.key !== "HUBSPOT_PRIVATE_APP_TOKEN" &&
+      options.key !== "HUBSPOT_ACCESS_TOKEN")
+  ) {
+    return null;
+  }
+  const value = await resolveCredential("HUBSPOT_API_KEY", options.ctx);
+  return value ? legacyCredential(options, "HUBSPOT_API_KEY", value) : null;
+}
+
+function parseLegacyGongApiKey(value: string): {
+  accessKey: string;
+  accessSecret: string;
+} | null {
+  const separator = value.indexOf(":");
+  if (separator <= 0) return null;
+  const accessKey = value.slice(0, separator).trim();
+  const accessSecret = value.slice(separator + 1).trim();
+  return accessKey && accessSecret ? { accessKey, accessSecret } : null;
+}
+
+async function resolveLegacyGongCredential(
+  options: ProviderApiCredentialLookupOptions,
+): Promise<ProviderApiResolvedCredential | null> {
+  if (
+    options.provider !== "gong" ||
+    (options.key !== "GONG_ACCESS_KEY" && options.key !== "GONG_ACCESS_SECRET")
+  ) {
+    return null;
+  }
+  const legacyValue = await resolveCredential("GONG_API_KEY", options.ctx);
+  if (!legacyValue) return null;
+  const parsed = parseLegacyGongApiKey(legacyValue);
+  if (!parsed) return null;
+  return legacyCredential(
+    options,
+    "GONG_API_KEY",
+    options.key === "GONG_ACCESS_SECRET"
+      ? parsed.accessSecret
+      : parsed.accessKey,
+  );
+}
+
+const resolveCalendarCredential: ProviderApiCredentialResolver = async (
+  options,
+) => {
+  const direct = await defaultProviderApiCredentialResolver(options);
+  if (direct) return direct;
+  return (
+    (await resolveLegacyHubSpotCredential(options)) ??
+    (await resolveLegacyGongCredential(options))
+  );
+};
+
+const runtime = createProviderApiRuntime({
+  appId: CALENDAR_APP_ID,
+  providerIds: CALENDAR_PROVIDER_API_IDS,
+  localCredentialSource: `${CALENDAR_APP_ID}_local`,
+  getCredentialContext: () => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error(
+        "Calendar provider API requests require an authenticated request context.",
+      );
+    }
+    return ctx;
+  },
+  resolveCredential: resolveCalendarCredential,
+});
+
+export function getCalendarProviderApiRuntime() {
+  return runtime;
+}
+
+export function listProviderApiCatalog(provider?: CalendarProviderApiId) {
+  return runtime.listCatalog(provider);
+}
+
+export function fetchProviderApiDocs(options: {
+  provider: CalendarProviderApiId;
+  url?: string;
+  maxBytes?: number;
+}) {
+  return runtime.fetchDocs(options);
+}
+
+export function executeProviderApiRequest(args: ProviderApiRequestArgs) {
+  return runtime.executeRequest(args);
+}

--- a/templates/calendar/server/plugins/agent-chat.ts
+++ b/templates/calendar/server/plugins/agent-chat.ts
@@ -58,20 +58,27 @@ registerEvent({
 
 export default createAgentChatPlugin({
   appId: "calendar",
+  // Enable sandboxed JavaScript execution so Calendar agents can fetch,
+  // paginate, and reduce provider data through providerFetch() without us
+  // hardcoding one action per Google Calendar / CRM endpoint.
+  codeExecution: { production: "sandboxed" },
   resolveOrgId: async (event) => {
     const ctx = await getOrgContext(event);
     return ctx.orgId;
   },
   actions: loadActionsFromStaticRegistry(actionsRegistry),
-  systemPrompt: `You are an AI calendar assistant. You manage the user's Google Calendar events, bookings, and availability.
+  systemPrompt: `You are an AI calendar assistant. You manage the user's Google Calendar events, bookings, availability, and connected provider data.
 
-## CRITICAL: Use Scripts, Not Raw SQL
+## Critical: Use Actions And Provider APIs, Not Raw SQL
 
-Google Calendar events are NOT stored in the local database. They are fetched live from Google Calendar API via scripts. You MUST use the following scripts — never use db-query or db-exec for calendar operations:
+Google Calendar events are NOT stored in the local database. They are fetched live from Google Calendar API via actions. Never use db-query or db-exec for calendar operations.
+
+Provider-specific Calendar actions are shortcuts, not limits. If a first-class action cannot express the exact Google Calendar/CRM endpoint, calendar id, filter, request body, pagination mode, attendee search, recurrence field, or API version needed, call \`provider-api-catalog\` and \`provider-api-docs\` as needed, then call \`provider-api-request\` against the provider's real HTTP API. Use this raw provider API escape hatch instead of weakening the answer, broadening filters, or claiming Calendar cannot do something the underlying API can do.
 
 - \`pnpm action view-screen\` — See what the user is looking at (current view, date, events). ALWAYS run this first.
 - \`pnpm action list-events --from YYYY-MM-DD --to YYYY-MM-DD\` — List events from Google Calendar. The --to date is exclusive, so use tomorrow for today's events.
-- \`pnpm action search-events --query "term"\` — Search events by title, people, organizer, location, or description across a broad one-year past/future window. Use this for recurring meetings and "how often do I meet with X?" questions.
+- \`pnpm action search-events --query "term" --from YYYY-MM-DD --to YYYY-MM-DD\` — Convenience bounded search by title, attendees, organizer, location, or description. For relationship history, all-calendar discovery, exact attendee/domain search, or custom pagination, prefer provider-api-request with provider=google_calendar.
+- \`pnpm action provider-api-catalog\` / \`provider-api-docs\` / \`provider-api-request\` — Inspect and call the real Google Calendar, Apollo, Gong, HubSpot, and Pylon APIs directly. For Google Calendar events.list pagination use provider=google_calendar, path=/calendars/primary/events, query={...}, fetchAllPages={cursorPath:"nextPageToken",cursorParam:"pageToken",itemsPath:"items"}. For large relationship-history scans, pass stageAs and pagination={nextCursorPath:"nextPageToken",cursorParam:"pageToken",maxPages:N} with itemsPath="items", then use query-staged-dataset.
 - \`pnpm action create-event --title "..." --start "ISO" --end "ISO"\` — Create a new event. Use \`--eventType outOfOffice\` for OOO, \`--eventType focusTime\` for focus time, \`--eventType workingLocation\` for working location, \`--transparency transparent\` to show as Free, \`--visibility private\` for private events, \`--startTimeZone America/Los_Angeles\` for timezone anchoring, \`--colorId 9\` for Google event color, \`--reminders '[{"method":"popup","minutes":10}]'\` for alerts, and \`--attachments '[{"fileUrl":"https://...","title":"Agenda"}]'\` for Drive/HTTPS file links.
 - \`pnpm action update-event --id "google-..." --transparency opaque|transparent --visibility default|public|private --reminderMinutes 10 --scope single|all\` — Update event availability, visibility, reminders, timezone, color, attachments, recurrence, or generated video links. Use \`--scope all\` to update an entire recurring series from one occurrence.
 - \`pnpm action navigate --view=calendar --calendarViewMode=day\` — Navigate the UI (day/week/month views, dates)
@@ -92,7 +99,7 @@ Use \`create-event\` or \`update-event --colorId 1..11\` when the user wants one
 ## Google Connection Check
 Before answering schedule questions, run view-screen first for context, then use list-events for the requested date range even if the user is currently on Settings, Booking Links, or another non-calendar page. Do not infer a Google Calendar connection problem just because the current page is Settings. Only ask the user to reconnect Google if list-events or the explicit Google status reports an auth/connection error.
 
-For relationship-frequency questions such as "how often do I meet with Mattel?", use search-events with the person's or company's name so recurring series outside the current visible range are included. Do not conclude there are no recurring meetings from a narrow date window alone.
+For relationship-history or frequency questions such as "who have I met at Adobe?" or "how often do I meet with Mattel?", prefer the raw Google Calendar API through provider-api-request so you can choose the exact timeMin/timeMax, q, calendarId, maxResults, and pageToken behavior. Stage large paginated results before analysis. Do not conclude there are no recurring meetings from the visible range or from a convenience action alone.
 
 ## Context Awareness
 The UI writes navigation state including the current view, date, view mode (day/week/month), and selected event ID. Always check view-screen to know what the user sees before responding.

--- a/templates/clips/.agents/skills/actions/SKILL.md
+++ b/templates/clips/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -21,6 +21,12 @@ Detailed media, meeting, dictation, editing, and sharing rules live in
   configured Builder/Gemini or Groq paths, not OpenAI.
 - Use `view-screen` when the active recording, transcript segment, meeting, or
   share context is unclear.
+- Calendar-sourced meeting actions are shortcuts, but do not add raw
+  `provider-api-request` for Google Calendar until the provider API runtime can
+  resolve Clips `calendar_accounts` through sharing/access checks and read their
+  encrypted `app_secrets` token refs. Clips calendar grants are not stored in
+  core `oauth_tokens`, and bypassing that model would break the account
+  sharing/status boundary.
 - Use framework sharing actions for recordings. Password and expiry are extra
   controls on top of visibility/share grants.
 - After mutations, rely on the app refresh/polling path; do not invent a second

--- a/templates/content/.agents/skills/actions/SKILL.md
+++ b/templates/content/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -17,6 +17,12 @@ Detailed document editing, Notion, storage, and UI rules live in
   from `process.env`, never save a user-entered Notion token through
   `/_agent-native/env-vars`, and require editor access for routes that pull or
   push Notion content.
+- Treat Notion workflow actions as shortcuts, not capability limits. When the
+  exact Notion endpoint/filter/pagination/API version matters, use
+  `provider-api-catalog`, `provider-api-docs`, and `provider-api-request`
+  against the real Notion API. The provider API resolves auth from the user's
+  Notion OAuth connection, never from `NOTION_API_KEY`. For large scans, stage
+  results with `stageAs` and analyze them with `query-staged-dataset`.
 - Preserve user-authored content. Prefer targeted edits over wholesale rewrites
   unless requested.
 - For cross-app or Slack artifact requests, create/update the document artifact
@@ -224,6 +230,11 @@ explicit sync action.
 | `pull-notion-page`      | `--documentId <id>`                     | Pull content from Notion                  |
 | `push-notion-page`      | `--documentId <id>`                     | Push content to Notion                    |
 | `sync-notion-comments`  | `--documentId <id>`                     | Sync comments with Notion (bidirectional) |
+
+Use `provider-api-catalog`, `provider-api-docs`, and `provider-api-request`
+for Notion endpoints, filters, pagination modes, payload shapes, or API
+versions that these workflow actions do not model. Use `stageAs` plus
+`query-staged-dataset` for large Notion searches or database queries.
 
 ### Comments
 

--- a/templates/content/actions/delete-staged-dataset.ts
+++ b/templates/content/actions/delete-staged-dataset.ts
@@ -1,0 +1,42 @@
+/**
+ * Thin content re-export of staged dataset deletion, pre-bound to appId="content".
+ */
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { deleteStagedDataset } from "@agent-native/core/provider-api/staged-datasets-store";
+import { z } from "zod";
+import { CONTENT_APP_ID } from "../server/lib/provider-api.js";
+
+export default defineAction({
+  description:
+    "Delete a staged dataset by id, freeing its scratch storage. Use after analysis is complete or before re-staging under the same name. Only the owner who staged the dataset can delete it.",
+  schema: z.object({
+    datasetId: z
+      .string()
+      .min(1)
+      .describe(
+        "Dataset id to delete (from list-staged-datasets or provider-api-request stageAs result).",
+      ),
+  }),
+  http: false,
+  run: async (args) => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for delete-staged-dataset.");
+    }
+
+    const deleted = await deleteStagedDataset({
+      id: args.datasetId,
+      appId: CONTENT_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    if (!deleted) {
+      throw new Error(
+        `Dataset ${args.datasetId} not found (or belongs to a different owner/app).`,
+      );
+    }
+
+    return { deleted: true, datasetId: args.datasetId };
+  },
+});

--- a/templates/content/actions/list-staged-datasets.ts
+++ b/templates/content/actions/list-staged-datasets.ts
@@ -1,0 +1,39 @@
+/**
+ * Thin content re-export of staged dataset listing, pre-bound to appId="content".
+ */
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { listStagedDatasets } from "@agent-native/core/provider-api/staged-datasets-store";
+import { z } from "zod";
+import { CONTENT_APP_ID } from "../server/lib/provider-api.js";
+
+export default defineAction({
+  description:
+    "List staged datasets stored by provider-api-request (stageAs) for the current user. Returns dataset ids, names, row counts, columns, and sizes. Use dataset ids with query-staged-dataset to aggregate, or with delete-staged-dataset to free scratch storage.",
+  schema: z.object({}),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async () => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for list-staged-datasets.");
+    }
+
+    const datasets = await listStagedDatasets({
+      appId: CONTENT_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    return {
+      datasets: datasets.map((d) => ({
+        id: d.id,
+        name: d.name,
+        rowCount: d.rowCount,
+        columns: d.columns,
+        byteSize: d.byteSize,
+        updatedAt: new Date(d.updatedAt).toISOString(),
+      })),
+      total: datasets.length,
+    };
+  },
+});

--- a/templates/content/actions/provider-api-catalog.ts
+++ b/templates/content/actions/provider-api-catalog.ts
@@ -1,0 +1,27 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import {
+  CONTENT_PROVIDER_API_IDS,
+  listProviderApiCatalog,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(CONTENT_PROVIDER_API_IDS);
+
+export default defineAction({
+  description:
+    "List raw HTTP API capabilities for Content-connected providers. Use before provider-api-request when Notion convenience actions are too narrow. Returns provider base URLs, auth style, credential key names, docs/spec URLs, placeholders, and examples; never returns secret values.",
+  schema: z.object({
+    provider: ProviderSchema.optional().describe(
+      "Optional provider id to inspect. Omit to list every Content provider API escape hatch.",
+    ),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async ({ provider }) => {
+    return {
+      providers: await listProviderApiCatalog(provider),
+      guidance:
+        "Content actions like pull-notion-page, push-notion-page, sync-notion-comments, and link-notion-page are workflow shortcuts, not capability limits. When the Notion API can answer the question with a better endpoint, query, body, pagination mode, or API version, inspect docs/spec URLs and call provider-api-request directly with the user's OAuth connection. The built-in catalog may name NOTION_API_KEY as the generic bearer slot; Content intentionally resolves that slot from the user's per-user Notion OAuth token instead of env/user-entered API keys.",
+    };
+  },
+});

--- a/templates/content/actions/provider-api-docs.ts
+++ b/templates/content/actions/provider-api-docs.ts
@@ -1,0 +1,35 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import {
+  CONTENT_PROVIDER_API_IDS,
+  fetchProviderApiDocs,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(CONTENT_PROVIDER_API_IDS);
+
+export default defineAction({
+  description:
+    "Inspect provider API docs/spec metadata, or fetch any public API documentation page, OpenAPI spec, changelog, or web page. Use this before provider-api-request when the exact Notion endpoint, filter operator, payload shape, pagination, or API version is uncertain.",
+  schema: z.object({
+    provider: ProviderSchema.describe(
+      "Provider whose API docs/spec to inspect.",
+    ),
+    url: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        "Optional public docs/spec URL to fetch. Registered docs/spec URLs from provider-api-catalog are curated starting points, but any public http(s) API documentation URL is allowed.",
+      ),
+    maxBytes: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(4 * 1024 * 1024)
+      .optional()
+      .describe("Maximum response bytes to read. Default 1MB, max 4MB."),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async (args) => fetchProviderApiDocs(args),
+});

--- a/templates/content/actions/provider-api-request.ts
+++ b/templates/content/actions/provider-api-request.ts
@@ -1,0 +1,221 @@
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { stagingExecuteRequest } from "@agent-native/core/provider-api/staging";
+import { z } from "zod";
+import {
+  CONTENT_APP_ID,
+  CONTENT_PROVIDER_API_IDS,
+  executeProviderApiRequest,
+  getContentProviderApiRuntime,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(CONTENT_PROVIDER_API_IDS);
+const MethodSchema = z.enum(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]);
+
+const PaginationSchema = z
+  .object({
+    nextCursorPath: z
+      .string()
+      .optional()
+      .describe(
+        "Dot-path in the response JSON where the next cursor/token lives, e.g. 'next_cursor'.",
+      ),
+    cursorParam: z
+      .string()
+      .optional()
+      .describe(
+        "Query/body parameter name to inject the cursor into the next request. Required when nextCursorPath is set.",
+      ),
+    pageParam: z
+      .string()
+      .optional()
+      .describe(
+        "Use page-number mode: this query param is incremented on each page.",
+      ),
+    startPage: z.coerce
+      .number()
+      .int()
+      .optional()
+      .describe("Starting page number for pageParam mode (default 1)."),
+    offsetParam: z
+      .string()
+      .optional()
+      .describe(
+        "Use offset mode: this query param is incremented by pageSize on each request.",
+      ),
+    pageSize: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        "Expected page size for offset increments. Defaults to the actual item count of the first page.",
+      ),
+    maxPages: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe("Maximum pages to fetch server-side (default 50, max 200)."),
+  })
+  .optional();
+
+export default defineAction({
+  description:
+    "Make an arbitrary authenticated HTTP request to a Content-connected provider API. " +
+    "Use this as the flexible escape hatch when a convenience action cannot express the needed Notion endpoint, page/database/comment object, filter, request body, pagination mode, markdown endpoint, payload shape, or API version. " +
+    "The request is constrained to the provider host, uses the user's configured OAuth connection automatically, blocks private/internal URLs, and redacts secrets from responses. " +
+    "\n\nSTAGING MODE (preferred for large responses): Pass stageAs to write response items into a scratch dataset instead of returning the raw body. " +
+    "Returns { dataset, rowCount, columns, sampleRows } so only a compact summary enters context. Use query-staged-dataset to aggregate, filter, and project the data without re-fetching. " +
+    "\n\nPAGINATION: When stageAs is set, pass pagination config to fetch pages server-side into the same dataset. For Notion list/search endpoints, use nextCursorPath='next_cursor', cursorParam='start_cursor', and itemsPath='results'.",
+  schema: z.object({
+    provider: ProviderSchema.describe(
+      "Configured provider API to call, e.g. notion.",
+    ),
+    method: MethodSchema.default("GET").describe("HTTP method to use."),
+    path: z
+      .string()
+      .min(1)
+      .describe(
+        "Provider API path such as /search, /pages/{pageId}, /databases/{databaseId}/query, /comments, or a full URL on an allowed provider host. Use placeholders from provider-api-catalog when provided.",
+      ),
+    query: z
+      .unknown()
+      .optional()
+      .describe(
+        "Optional query params as a JSON object/string. Array values produce repeated query params.",
+      ),
+    headers: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe(
+        "Optional extra headers. Unsafe hop-by-hop headers are ignored. Auth headers are injected from stored credentials. For Content's Notion markdown endpoints use { 'Notion-Version': '2026-03-11' } when needed.",
+      ),
+    body: z
+      .unknown()
+      .optional()
+      .describe(
+        "Optional request body. Objects/arrays are JSON encoded; strings are sent as-is.",
+      ),
+    auth: z
+      .enum(["default", "none"])
+      .default("default")
+      .describe(
+        "Use default to inject configured provider auth. Use none only for public provider endpoints that intentionally require no auth.",
+      ),
+    connectionId: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe("Unused for Content Notion OAuth; reserved for shared grants."),
+    accountId: z
+      .string()
+      .optional()
+      .describe(
+        "Unused for Content Notion OAuth; the user's Notion grant is used.",
+      ),
+    timeoutMs: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(120_000)
+      .optional()
+      .describe("Request timeout in milliseconds. Default 30000, max 120000."),
+    maxBytes: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(4 * 1024 * 1024)
+      .optional()
+      .describe(
+        "Maximum response bytes to read. Default 1MB, max 4MB. Ignored when saveToFile is set (allows up to 20MB).",
+      ),
+    stageAs: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "When set, parse the response as an array of records and write them into a staged dataset with this name. Returns a compact summary instead of the raw body. Re-staging the same name replaces the previous dataset.",
+      ),
+    itemsPath: z
+      .string()
+      .optional()
+      .describe(
+        "Dot-path to the items array in the response JSON, e.g. 'results' for Notion search/database query responses. Omit for auto-detection.",
+      ),
+    pagination: PaginationSchema.describe(
+      "Pagination config for server-side fetchAll when stageAs is set. Supports cursor, page, and offset modes.",
+    ),
+    saveToFile: z
+      .string()
+      .optional()
+      .describe(
+        "Workspace file path to save the full response body to instead of returning it in context, e.g. 'content/notion-search.json'. When set, returns only a compact summary and allows up to 20MB response.",
+      ),
+    fetchAllPages: z
+      .object({
+        cursorPath: z
+          .string()
+          .describe(
+            "Dot-path in the JSON response body where the next-page cursor lives, e.g. 'next_cursor'.",
+          ),
+        cursorParam: z
+          .string()
+          .describe(
+            "Parameter name to pass the cursor on subsequent pages, e.g. 'start_cursor'.",
+          ),
+        itemsPath: z
+          .string()
+          .optional()
+          .describe(
+            "Dot-path to the items array in each response, e.g. 'results'. When omitted, the whole response body is appended per page.",
+          ),
+        maxPages: z.coerce
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .describe(
+            "Maximum pages to fetch. Default 10, max 50. Stops early when cursor is empty.",
+          ),
+      })
+      .optional()
+      .describe(
+        "Enable cursor-based pagination. For Notion list/search endpoints use { cursorPath: 'next_cursor', cursorParam: 'start_cursor', itemsPath: 'results' }.",
+      ),
+  }),
+  http: false,
+  run: async (args) => {
+    if (args.stageAs) {
+      const ctx = getCredentialContext();
+      if (!ctx) {
+        throw new Error("No authenticated context for provider API staging.");
+      }
+      const providerRuntime = getContentProviderApiRuntime();
+      return stagingExecuteRequest(
+        {
+          provider: args.provider,
+          method: args.method,
+          path: args.path,
+          query: args.query,
+          headers: args.headers,
+          body: args.body,
+          auth: args.auth,
+          connectionId: args.connectionId,
+          accountId: args.accountId,
+          timeoutMs: args.timeoutMs,
+          maxBytes: args.maxBytes,
+          stageAs: args.stageAs,
+          itemsPath: args.itemsPath,
+          pagination: args.pagination,
+        },
+        (reqArgs) => providerRuntime.executeRequest(reqArgs),
+        { appId: CONTENT_APP_ID, ownerEmail: ctx.userEmail },
+      );
+    }
+    return executeProviderApiRequest(args);
+  },
+});

--- a/templates/content/actions/query-staged-dataset.ts
+++ b/templates/content/actions/query-staged-dataset.ts
@@ -1,0 +1,127 @@
+/**
+ * Thin content re-export of the staged dataset query helper, pre-bound to appId="content".
+ */
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { runAggregateQuery } from "@agent-native/core/provider-api/staged-datasets-aggregate";
+import {
+  getStagedDatasetMeta,
+  getStagedDatasetRows,
+} from "@agent-native/core/provider-api/staged-datasets-store";
+import { z } from "zod";
+import { CONTENT_APP_ID } from "../server/lib/provider-api.js";
+
+const WhereSchema = z.object({
+  column: z.string().min(1),
+  op: z.enum([
+    "equals",
+    "not_equals",
+    "contains",
+    "not_contains",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "exists",
+    "not_exists",
+  ]),
+  value: z.unknown().optional(),
+});
+
+const AggregateFieldSchema = z.object({
+  column: z.string().min(1).describe("Column to aggregate."),
+  op: z
+    .enum(["sum", "avg", "count", "min", "max", "count_distinct"])
+    .describe("Aggregation function."),
+  as: z
+    .string()
+    .optional()
+    .describe("Output column name. Default: {op}_{column}."),
+});
+
+export default defineAction({
+  description:
+    "Run a filter/aggregate/project query over a staged dataset previously written by provider-api-request (stageAs). Use after staging Notion search, database query, page, or comment records to count, group, filter, or project rows without re-fetching provider APIs.",
+  schema: z.object({
+    datasetId: z
+      .string()
+      .min(1)
+      .describe(
+        "Dataset id from provider-api-request stageAs result, or from list-staged-datasets.",
+      ),
+    where: z
+      .array(WhereSchema)
+      .optional()
+      .describe(
+        "Row-level filters (AND). Ops: equals, not_equals, contains, not_contains, gt, gte, lt, lte, exists, not_exists.",
+      ),
+    groupBy: z
+      .array(z.string().min(1))
+      .optional()
+      .describe(
+        "Column(s) to group by. Omit for a single aggregate over all rows.",
+      ),
+    aggregate: z
+      .array(AggregateFieldSchema)
+      .optional()
+      .describe(
+        "Aggregation operations. When set, non-group columns are aggregated. Omit to return raw rows.",
+      ),
+    select: z
+      .array(z.string().min(1))
+      .optional()
+      .describe("Column projection when aggregate is empty."),
+    orderBy: z.string().optional().describe("Sort output by this column."),
+    orderDir: z
+      .enum(["asc", "desc"])
+      .optional()
+      .describe("Sort direction (default asc)."),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(10_000)
+      .optional()
+      .describe("Maximum rows to return (default all, max 10000)."),
+  }),
+  http: false,
+  run: async (args) => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for query-staged-dataset.");
+    }
+
+    const meta = await getStagedDatasetMeta({
+      id: args.datasetId,
+      appId: CONTENT_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+    if (!meta) {
+      throw new Error(
+        `Dataset ${args.datasetId} not found (or belongs to a different owner/app).`,
+      );
+    }
+
+    const rows = await getStagedDatasetRows({
+      id: args.datasetId,
+      appId: CONTENT_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    const result = runAggregateQuery(rows, {
+      where: args.where,
+      groupBy: args.groupBy,
+      aggregate: args.aggregate,
+      select: args.select,
+      orderBy: args.orderBy,
+      orderDir: args.orderDir,
+      limit: args.limit,
+    });
+
+    return {
+      dataset: { id: meta.id, name: meta.name, totalRows: meta.rowCount },
+      rowCount: result.length,
+      rows: result,
+    };
+  },
+});

--- a/templates/content/server/lib/provider-api.ts
+++ b/templates/content/server/lib/provider-api.ts
@@ -1,0 +1,73 @@
+import {
+  createProviderApiRuntime,
+  type ProviderApiCredentialResolver,
+  type ProviderApiId,
+  type ProviderApiMethod,
+  type ProviderApiRequestArgs,
+} from "@agent-native/core/provider-api";
+import { getCredentialContext } from "@agent-native/core/server";
+import { getNotionConnectionForOwner } from "./notion.js";
+
+export const CONTENT_APP_ID = "content";
+export const CONTENT_PROVIDER_API_IDS = ["notion"] as [
+  ProviderApiId,
+  ...ProviderApiId[],
+];
+export type ContentProviderApiId = (typeof CONTENT_PROVIDER_API_IDS)[number];
+export type { ProviderApiMethod, ProviderApiRequestArgs };
+
+const resolveContentCredential: ProviderApiCredentialResolver = async (
+  options,
+) => {
+  if (options.provider !== "notion" || options.key !== "NOTION_API_KEY") {
+    return null;
+  }
+
+  const connection = await getNotionConnectionForOwner(options.ctx.userEmail);
+  if (!connection?.accessToken) return null;
+
+  return {
+    key: "NOTION_OAUTH_TOKEN",
+    value: connection.accessToken,
+    source: `${CONTENT_APP_ID}_notion_oauth`,
+    provider: "notion",
+    accountId: connection.accountId,
+    accountLabel: connection.workspaceName,
+  };
+};
+
+const runtime = createProviderApiRuntime({
+  appId: CONTENT_APP_ID,
+  providerIds: CONTENT_PROVIDER_API_IDS,
+  localCredentialSource: `${CONTENT_APP_ID}_local`,
+  getCredentialContext: () => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error(
+        "Content provider API requests require an authenticated request context.",
+      );
+    }
+    return ctx;
+  },
+  resolveCredential: resolveContentCredential,
+});
+
+export function getContentProviderApiRuntime() {
+  return runtime;
+}
+
+export function listProviderApiCatalog(provider?: ContentProviderApiId) {
+  return runtime.listCatalog(provider);
+}
+
+export function fetchProviderApiDocs(options: {
+  provider: ContentProviderApiId;
+  url?: string;
+  maxBytes?: number;
+}) {
+  return runtime.fetchDocs(options);
+}
+
+export function executeProviderApiRequest(args: ProviderApiRequestArgs) {
+  return runtime.executeRequest(args);
+}

--- a/templates/content/server/plugins/agent-chat.ts
+++ b/templates/content/server/plugins/agent-chat.ts
@@ -14,7 +14,16 @@ export default createAgentChatPlugin({
   actions: loadActionsFromStaticRegistry(actionsRegistry),
   anonymousOwner: resolvePublicViewerOwner,
   extraContext: publicDocumentExtraContext,
+  // Enable sandboxed JavaScript execution so Content agents can fetch,
+  // paginate, and reduce provider data through providerFetch() without us
+  // hardcoding one action per Notion endpoint.
+  codeExecution: { production: "sandboxed" },
   resolveOrgId: async (event) => (await getOrgContext(event)).orgId,
+  systemPrompt: `You are an AI document assistant. You manage documents, comments, media blocks, sharing, and connected Notion content through actions and shared application state.
+
+Provider-specific Content actions are shortcuts, not limits. If a first-class action cannot express the exact Notion endpoint, page/database/comment object, filter, request body, pagination mode, markdown endpoint, payload shape, or API version needed, call provider-api-catalog and provider-api-docs as needed, then call provider-api-request against the real Notion API. Use the raw provider API escape hatch instead of weakening the answer, broadening filters, or claiming Content cannot do something the underlying Notion API can do.
+
+Content's Notion access is per-user OAuth only. Never ask for or use NOTION_API_KEY. provider-api-request resolves Notion auth from the user's connected Notion OAuth account. For large Notion searches or database queries, pass stageAs and pagination options to provider-api-request, then use query-staged-dataset to count, filter, group, or project the staged rows.`,
   mentionProviders: async () => {
     const { getDb } = await import("../db/index.js");
     const { documents } = await import("../db/schema.js");

--- a/templates/design/.agents/skills/actions/SKILL.md
+++ b/templates/design/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -12,6 +12,13 @@ patterns live in `.agents/skills/`.
 - Never hardcode API keys, tokens, webhook URLs, signing secrets, private Builder/internal data, customer data, or credential-looking literals. Use secrets/OAuth/runtime configuration and obvious placeholders in examples.
 - Use the app actions for designs, files, versions, design systems, variants,
   export, and sharing. Do not write design rows directly with SQL.
+- Treat repository import actions as shortcuts, not capability limits. When the
+  exact GitHub endpoint, search query, request body, pagination mode, metadata
+  field, or API version matters, use `provider-api-catalog`,
+  `provider-api-docs`, and `provider-api-request` against the real GitHub API.
+  The provider API resolves auth from the saved `GITHUB_TOKEN` secret and never
+  exposes the token value. For large scans, stage results with `stageAs` and
+  analyze them with `query-staged-dataset`.
 - In dev, call actions with `pnpm action <name>`; in production, call the native
   tool. The action schema is the source of truth for parameters.
 - Call `view-screen` before editing a specific design if the current design or

--- a/templates/design/actions/delete-staged-dataset.ts
+++ b/templates/design/actions/delete-staged-dataset.ts
@@ -1,0 +1,42 @@
+/**
+ * Thin Design re-export of staged dataset deletion, pre-bound to appId="design".
+ */
+import { defineAction } from "@agent-native/core";
+import { deleteStagedDataset } from "@agent-native/core/provider-api/staged-datasets-store";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { z } from "zod";
+import { DESIGN_APP_ID } from "../server/lib/provider-api.js";
+
+export default defineAction({
+  description:
+    "Delete a staged dataset by id, freeing its scratch storage. Use after analysis is complete or before re-staging under the same name. Only the owner who staged the dataset can delete it.",
+  schema: z.object({
+    datasetId: z
+      .string()
+      .min(1)
+      .describe(
+        "Dataset id to delete (from list-staged-datasets or provider-api-request stageAs result).",
+      ),
+  }),
+  http: false,
+  run: async (args) => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for delete-staged-dataset.");
+    }
+
+    const deleted = await deleteStagedDataset({
+      id: args.datasetId,
+      appId: DESIGN_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    if (!deleted) {
+      throw new Error(
+        `Dataset ${args.datasetId} not found (or belongs to a different owner/app).`,
+      );
+    }
+
+    return { deleted: true, datasetId: args.datasetId };
+  },
+});

--- a/templates/design/actions/list-staged-datasets.ts
+++ b/templates/design/actions/list-staged-datasets.ts
@@ -1,0 +1,39 @@
+/**
+ * Thin Design re-export of staged dataset listing, pre-bound to appId="design".
+ */
+import { defineAction } from "@agent-native/core";
+import { listStagedDatasets } from "@agent-native/core/provider-api/staged-datasets-store";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { z } from "zod";
+import { DESIGN_APP_ID } from "../server/lib/provider-api.js";
+
+export default defineAction({
+  description:
+    "List staged datasets stored by provider-api-request (stageAs) for the current user. Returns dataset ids, names, row counts, columns, and sizes. Use dataset ids with query-staged-dataset to aggregate, or with delete-staged-dataset to free scratch storage.",
+  schema: z.object({}),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async () => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for list-staged-datasets.");
+    }
+
+    const datasets = await listStagedDatasets({
+      appId: DESIGN_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    return {
+      datasets: datasets.map((d) => ({
+        id: d.id,
+        name: d.name,
+        rowCount: d.rowCount,
+        columns: d.columns,
+        byteSize: d.byteSize,
+        updatedAt: new Date(d.updatedAt).toISOString(),
+      })),
+      total: datasets.length,
+    };
+  },
+});

--- a/templates/design/actions/provider-api-catalog.ts
+++ b/templates/design/actions/provider-api-catalog.ts
@@ -1,0 +1,27 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import {
+  DESIGN_PROVIDER_API_IDS,
+  listProviderApiCatalog,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(DESIGN_PROVIDER_API_IDS);
+
+export default defineAction({
+  description:
+    "List raw HTTP API capabilities for Design-connected providers. Use before provider-api-request when design-token import convenience actions are too narrow. Returns provider base URLs, auth style, credential key names, docs/spec URLs, placeholders, and examples; never returns secret values.",
+  schema: z.object({
+    provider: ProviderSchema.optional().describe(
+      "Optional provider id to inspect. Omit to list every Design provider API escape hatch.",
+    ),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async ({ provider }) => {
+    return {
+      providers: await listProviderApiCatalog(provider),
+      guidance:
+        "Design actions like import-github are workflow shortcuts, not capability limits. When the GitHub API can answer the question with a better endpoint, query, body, pagination mode, metadata field, or API version, inspect docs/spec URLs and call provider-api-request directly. GitHub auth uses the saved GITHUB_TOKEN secret and never exposes the token value.",
+    };
+  },
+});

--- a/templates/design/actions/provider-api-docs.ts
+++ b/templates/design/actions/provider-api-docs.ts
@@ -1,0 +1,35 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import {
+  DESIGN_PROVIDER_API_IDS,
+  fetchProviderApiDocs,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(DESIGN_PROVIDER_API_IDS);
+
+export default defineAction({
+  description:
+    "Inspect provider API docs/spec metadata, or fetch any public API documentation page, OpenAPI spec, changelog, or web page. Use this before provider-api-request when the exact GitHub endpoint, payload shape, pagination, or API version is uncertain.",
+  schema: z.object({
+    provider: ProviderSchema.describe(
+      "Provider whose API docs/spec to inspect.",
+    ),
+    url: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        "Optional public docs/spec URL to fetch. Registered docs/spec URLs from provider-api-catalog are curated starting points, but any public http(s) API documentation URL is allowed.",
+      ),
+    maxBytes: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(4 * 1024 * 1024)
+      .optional()
+      .describe("Maximum response bytes to read. Default 1MB, max 4MB."),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async (args) => fetchProviderApiDocs(args),
+});

--- a/templates/design/actions/provider-api-request.ts
+++ b/templates/design/actions/provider-api-request.ts
@@ -1,0 +1,212 @@
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { stagingExecuteRequest } from "@agent-native/core/provider-api/staging";
+import { z } from "zod";
+import {
+  DESIGN_APP_ID,
+  DESIGN_PROVIDER_API_IDS,
+  executeProviderApiRequest,
+  getDesignProviderApiRuntime,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(DESIGN_PROVIDER_API_IDS);
+const MethodSchema = z.enum(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]);
+
+const PaginationSchema = z
+  .object({
+    nextCursorPath: z
+      .string()
+      .optional()
+      .describe(
+        "Dot-path in the response JSON where the next cursor/token lives, e.g. 'next'.",
+      ),
+    cursorParam: z
+      .string()
+      .optional()
+      .describe(
+        "Query parameter name to inject the cursor into the next request. Required when nextCursorPath is set.",
+      ),
+    pageParam: z
+      .string()
+      .optional()
+      .describe(
+        "Use page-number mode: this query param is incremented on each page.",
+      ),
+    startPage: z.coerce
+      .number()
+      .int()
+      .optional()
+      .describe("Starting page number for pageParam mode (default 1)."),
+    offsetParam: z
+      .string()
+      .optional()
+      .describe(
+        "Use offset mode: this query param is incremented by pageSize on each request.",
+      ),
+    pageSize: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        "Expected page size for offset increments. Defaults to the actual item count of the first page.",
+      ),
+    maxPages: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe("Maximum pages to fetch server-side (default 50, max 200)."),
+  })
+  .optional();
+
+export default defineAction({
+  description:
+    "Make an arbitrary authenticated HTTP request to a Design-connected provider API. " +
+    "Use this as the flexible escape hatch when a convenience action cannot express the needed GitHub endpoint, file tree query, issue/search query, request body, pagination mode, payload shape, or API version. " +
+    "The request is constrained to the provider host, uses the saved GITHUB_TOKEN automatically, blocks private/internal URLs, and redacts secrets from responses. " +
+    "\n\nSTAGING MODE (preferred for large responses): Pass stageAs to write response items into a scratch dataset instead of returning the raw body. " +
+    "Returns { dataset, rowCount, columns, sampleRows } so only a compact summary enters context. Use query-staged-dataset to aggregate, filter, and project the data without re-fetching. " +
+    "\n\nPAGINATION: When stageAs is set, pass pagination config to fetch all pages server-side into the same dataset. For GitHub page pagination, use pageParam='page', pageSize from per_page, and itemsPath when the response object contains an items array.",
+  schema: z.object({
+    provider: ProviderSchema.describe("Configured provider API to call."),
+    method: MethodSchema.default("GET").describe("HTTP method to use."),
+    path: z
+      .string()
+      .min(1)
+      .describe(
+        "Provider API path such as /repos/{owner}/{repo}/contents/{path}, /search/code, /issues, or a full URL on an allowed provider host. Use placeholders from provider-api-catalog when provided.",
+      ),
+    query: z
+      .unknown()
+      .optional()
+      .describe(
+        "Optional query params as a JSON object/string. Array values produce repeated query params.",
+      ),
+    headers: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe(
+        "Optional extra headers. Unsafe hop-by-hop headers are ignored. Auth headers are injected from stored credentials.",
+      ),
+    body: z
+      .unknown()
+      .optional()
+      .describe(
+        "Optional request body. Objects/arrays are JSON encoded; strings are sent as-is.",
+      ),
+    auth: z
+      .enum(["default", "none"])
+      .default("default")
+      .describe(
+        "Use default to inject configured provider auth. Use none only for public provider endpoints that intentionally require no auth.",
+      ),
+    connectionId: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe("Reserved for shared workspace grants."),
+    accountId: z.string().optional().describe("Reserved for OAuth providers."),
+    timeoutMs: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(120_000)
+      .optional()
+      .describe("Request timeout in milliseconds. Default 30000, max 120000."),
+    maxBytes: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(4 * 1024 * 1024)
+      .optional()
+      .describe(
+        "Maximum response bytes to read. Default 1MB, max 4MB. Ignored when saveToFile is set (allows up to 20MB).",
+      ),
+    stageAs: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "When set, parse the response as an array of records and write them into a staged dataset with this name. Returns a compact summary instead of the raw body. Re-staging the same name replaces the previous dataset.",
+      ),
+    itemsPath: z
+      .string()
+      .optional()
+      .describe(
+        "Dot-path to the items array in the response JSON, e.g. 'items' for GitHub search results. Omit for auto-detection.",
+      ),
+    pagination: PaginationSchema.describe(
+      "Pagination config for server-side fetchAll when stageAs is set. Supports cursor, page, and offset modes.",
+    ),
+    saveToFile: z
+      .string()
+      .optional()
+      .describe(
+        "Workspace file path to save the full response body to instead of returning it in context, e.g. 'design/github-search.json'. When set, returns only a compact summary and allows up to 20MB response.",
+      ),
+    fetchAllPages: z
+      .object({
+        cursorPath: z
+          .string()
+          .describe(
+            "Dot-path in the JSON response body where the next-page cursor lives.",
+          ),
+        cursorParam: z
+          .string()
+          .describe(
+            "Query parameter name to pass the cursor on subsequent pages.",
+          ),
+        itemsPath: z
+          .string()
+          .optional()
+          .describe(
+            "Dot-path to the items array in each response. When omitted, the whole response body is appended per page.",
+          ),
+        maxPages: z.coerce
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .describe(
+            "Maximum pages to fetch. Default 10, max 50. Stops early when cursor is empty.",
+          ),
+      })
+      .optional()
+      .describe("Enable cursor-based pagination for APIs that expose cursors."),
+  }),
+  http: false,
+  run: async (args) => {
+    if (args.stageAs) {
+      const ctx = getCredentialContext();
+      if (!ctx) {
+        throw new Error("No authenticated context for provider API staging.");
+      }
+      const providerRuntime = getDesignProviderApiRuntime();
+      return stagingExecuteRequest(
+        {
+          provider: args.provider,
+          method: args.method,
+          path: args.path,
+          query: args.query,
+          headers: args.headers,
+          body: args.body,
+          auth: args.auth,
+          connectionId: args.connectionId,
+          accountId: args.accountId,
+          timeoutMs: args.timeoutMs,
+          maxBytes: args.maxBytes,
+          stageAs: args.stageAs,
+          itemsPath: args.itemsPath,
+          pagination: args.pagination,
+        },
+        (reqArgs) => providerRuntime.executeRequest(reqArgs),
+        { appId: DESIGN_APP_ID, ownerEmail: ctx.userEmail },
+      );
+    }
+    return executeProviderApiRequest(args);
+  },
+});

--- a/templates/design/actions/query-staged-dataset.ts
+++ b/templates/design/actions/query-staged-dataset.ts
@@ -1,0 +1,127 @@
+/**
+ * Thin Design re-export of the staged dataset query helper, pre-bound to appId="design".
+ */
+import { defineAction } from "@agent-native/core";
+import { runAggregateQuery } from "@agent-native/core/provider-api/staged-datasets-aggregate";
+import {
+  getStagedDatasetMeta,
+  getStagedDatasetRows,
+} from "@agent-native/core/provider-api/staged-datasets-store";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { z } from "zod";
+import { DESIGN_APP_ID } from "../server/lib/provider-api.js";
+
+const WhereSchema = z.object({
+  column: z.string().min(1),
+  op: z.enum([
+    "equals",
+    "not_equals",
+    "contains",
+    "not_contains",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "exists",
+    "not_exists",
+  ]),
+  value: z.unknown().optional(),
+});
+
+const AggregateFieldSchema = z.object({
+  column: z.string().min(1).describe("Column to aggregate."),
+  op: z
+    .enum(["sum", "avg", "count", "min", "max", "count_distinct"])
+    .describe("Aggregation function."),
+  as: z
+    .string()
+    .optional()
+    .describe("Output column name. Default: {op}_{column}."),
+});
+
+export default defineAction({
+  description:
+    "Run a filter/aggregate/project query over a staged dataset previously written by provider-api-request (stageAs). Use after staging GitHub repository, file tree, issue, pull request, or search records to count, group, filter, or project rows without re-fetching provider APIs.",
+  schema: z.object({
+    datasetId: z
+      .string()
+      .min(1)
+      .describe(
+        "Dataset id from provider-api-request stageAs result, or from list-staged-datasets.",
+      ),
+    where: z
+      .array(WhereSchema)
+      .optional()
+      .describe(
+        "Row-level filters (AND). Ops: equals, not_equals, contains, not_contains, gt, gte, lt, lte, exists, not_exists.",
+      ),
+    groupBy: z
+      .array(z.string().min(1))
+      .optional()
+      .describe(
+        "Column(s) to group by. Omit for a single aggregate over all rows.",
+      ),
+    aggregate: z
+      .array(AggregateFieldSchema)
+      .optional()
+      .describe(
+        "Aggregation operations. When set, non-group columns are aggregated. Omit to return raw rows.",
+      ),
+    select: z
+      .array(z.string().min(1))
+      .optional()
+      .describe("Column projection when aggregate is empty."),
+    orderBy: z.string().optional().describe("Sort output by this column."),
+    orderDir: z
+      .enum(["asc", "desc"])
+      .optional()
+      .describe("Sort direction (default asc)."),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(10_000)
+      .optional()
+      .describe("Maximum rows to return (default all, max 10000)."),
+  }),
+  http: false,
+  run: async (args) => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for query-staged-dataset.");
+    }
+
+    const meta = await getStagedDatasetMeta({
+      id: args.datasetId,
+      appId: DESIGN_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+    if (!meta) {
+      throw new Error(
+        `Dataset ${args.datasetId} not found (or belongs to a different owner/app).`,
+      );
+    }
+
+    const rows = await getStagedDatasetRows({
+      id: args.datasetId,
+      appId: DESIGN_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    const result = runAggregateQuery(rows, {
+      where: args.where,
+      groupBy: args.groupBy,
+      aggregate: args.aggregate,
+      select: args.select,
+      orderBy: args.orderBy,
+      orderDir: args.orderDir,
+      limit: args.limit,
+    });
+
+    return {
+      dataset: { id: meta.id, name: meta.name, totalRows: meta.rowCount },
+      rowCount: result.length,
+      rows: result,
+    };
+  },
+});

--- a/templates/design/server/lib/provider-api.ts
+++ b/templates/design/server/lib/provider-api.ts
@@ -1,0 +1,71 @@
+import {
+  createProviderApiRuntime,
+  listProviderApiIdsForTemplateUse,
+  type ProviderApiCredentialResolver,
+  type ProviderApiId,
+  type ProviderApiMethod,
+  type ProviderApiRequestArgs,
+} from "@agent-native/core/provider-api";
+import { getCredentialContext, resolveSecret } from "@agent-native/core/server";
+
+export const DESIGN_APP_ID = "design";
+export const DESIGN_PROVIDER_API_IDS = listProviderApiIdsForTemplateUse(
+  "design",
+) as [ProviderApiId, ...ProviderApiId[]];
+export type DesignProviderApiId = (typeof DESIGN_PROVIDER_API_IDS)[number];
+export type { ProviderApiMethod, ProviderApiRequestArgs };
+
+const resolveDesignCredential: ProviderApiCredentialResolver = async (
+  options,
+) => {
+  if (options.provider !== "github" || options.key !== "GITHUB_TOKEN") {
+    return null;
+  }
+
+  const value = await resolveSecret("GITHUB_TOKEN");
+  if (!value) return null;
+
+  return {
+    key: "GITHUB_TOKEN",
+    value,
+    source: `${DESIGN_APP_ID}_secret`,
+    provider: "github",
+    scope: "request",
+  };
+};
+
+const runtime = createProviderApiRuntime({
+  appId: DESIGN_APP_ID,
+  providerIds: DESIGN_PROVIDER_API_IDS,
+  localCredentialSource: `${DESIGN_APP_ID}_local`,
+  getCredentialContext: () => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error(
+        "Design provider API requests require an authenticated request context.",
+      );
+    }
+    return ctx;
+  },
+  resolveCredential: resolveDesignCredential,
+});
+
+export function getDesignProviderApiRuntime() {
+  return runtime;
+}
+
+export function listProviderApiCatalog(provider?: DesignProviderApiId) {
+  return runtime.listCatalog(provider);
+}
+
+export function fetchProviderApiDocs(options: {
+  provider: DesignProviderApiId;
+  url?: string;
+  maxBytes?: number;
+}) {
+  return runtime.fetchDocs(options);
+}
+
+export function executeProviderApiRequest(args: ProviderApiRequestArgs) {
+  return runtime.executeRequest(args);
+}

--- a/templates/design/server/plugins/agent-chat.ts
+++ b/templates/design/server/plugins/agent-chat.ts
@@ -9,5 +9,14 @@ import "../register-secrets.js";
 export default createAgentChatPlugin({
   appId: "design",
   actions: loadActionsFromStaticRegistry(actionsRegistry),
+  // Enable sandboxed JavaScript execution so Design agents can fetch,
+  // paginate, and reduce provider data through providerFetch() without us
+  // hardcoding one action per GitHub endpoint.
+  codeExecution: { production: "sandboxed" },
   resolveOrgId: async (event) => (await getOrgContext(event)).orgId,
+  systemPrompt: `You are an AI prototyping assistant. You create and edit designs, files, design systems, variants, exports, sharing, and connected repository context through actions and shared application state.
+
+Provider-specific Design actions are shortcuts, not limits. If a first-class action cannot express the exact GitHub endpoint, repository tree query, code search, issue or pull request query, request body, pagination mode, payload shape, metadata field, or API version needed, call provider-api-catalog and provider-api-docs as needed, then call provider-api-request against the real GitHub API. Use the raw provider API escape hatch instead of weakening the answer or claiming Design cannot do something the underlying GitHub API can do.
+
+Design's GitHub provider API uses the saved GITHUB_TOKEN secret when present. Never ask the user to paste tokens into chat. For large GitHub search results or repository scans, pass stageAs and pagination options to provider-api-request, then use query-staged-dataset to count, filter, group, or project the staged rows.`,
 });

--- a/templates/dispatch/.agents/skills/actions/SKILL.md
+++ b/templates/dispatch/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/templates/forms/.agents/skills/actions/SKILL.md
+++ b/templates/forms/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/templates/mail/.agents/skills/actions/SKILL.md
+++ b/templates/mail/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/templates/mail/AGENTS.md
+++ b/templates/mail/AGENTS.md
@@ -12,6 +12,11 @@ Detailed draft, queue, storage, sync, and UI patterns live in `.agents/skills/`.
 - Use actions for email reads, labels, settings, drafts, queued drafts, filters,
   scheduling, refresh, and CRM context. Do not edit mail SQL directly unless a
   skill/action explicitly calls for it.
+- Treat provider-specific actions as shortcuts, not capability limits. When the
+  exact Gmail, Google Calendar, or CRM endpoint/filter/pagination/API version
+  matters, use `provider-api-catalog`, `provider-api-docs`, and
+  `provider-api-request` against the real provider API. For large scans, stage
+  results with `stageAs` and analyze them with `query-staged-dataset`.
 - Never send mail unless the user explicitly asks to send. Draft or queue review
   by default.
 - When drafting, first read mail settings for signature and writing style. Use

--- a/templates/mail/actions/delete-staged-dataset.ts
+++ b/templates/mail/actions/delete-staged-dataset.ts
@@ -1,0 +1,42 @@
+/**
+ * Thin mail re-export of staged dataset deletion, pre-bound to appId="mail".
+ */
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { deleteStagedDataset } from "@agent-native/core/provider-api/staged-datasets-store";
+import { z } from "zod";
+import { MAIL_APP_ID } from "../server/lib/provider-api.js";
+
+export default defineAction({
+  description:
+    "Delete a staged dataset by id, freeing its scratch storage. Use after analysis is complete or before re-staging under the same name. Only the owner who staged the dataset can delete it.",
+  schema: z.object({
+    datasetId: z
+      .string()
+      .min(1)
+      .describe(
+        "Dataset id to delete (from list-staged-datasets or provider-api-request stageAs result).",
+      ),
+  }),
+  http: false,
+  run: async (args) => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for delete-staged-dataset.");
+    }
+
+    const deleted = await deleteStagedDataset({
+      id: args.datasetId,
+      appId: MAIL_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    if (!deleted) {
+      throw new Error(
+        `Dataset ${args.datasetId} not found (or belongs to a different owner/app).`,
+      );
+    }
+
+    return { deleted: true, datasetId: args.datasetId };
+  },
+});

--- a/templates/mail/actions/list-staged-datasets.ts
+++ b/templates/mail/actions/list-staged-datasets.ts
@@ -1,0 +1,39 @@
+/**
+ * Thin mail re-export of staged dataset listing, pre-bound to appId="mail".
+ */
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { listStagedDatasets } from "@agent-native/core/provider-api/staged-datasets-store";
+import { z } from "zod";
+import { MAIL_APP_ID } from "../server/lib/provider-api.js";
+
+export default defineAction({
+  description:
+    "List staged datasets stored by provider-api-request (stageAs) for the current user. Returns dataset ids, names, row counts, columns, and sizes. Use dataset ids with query-staged-dataset to aggregate, or with delete-staged-dataset to free scratch storage.",
+  schema: z.object({}),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async () => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for list-staged-datasets.");
+    }
+
+    const datasets = await listStagedDatasets({
+      appId: MAIL_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    return {
+      datasets: datasets.map((d) => ({
+        id: d.id,
+        name: d.name,
+        rowCount: d.rowCount,
+        columns: d.columns,
+        byteSize: d.byteSize,
+        updatedAt: new Date(d.updatedAt).toISOString(),
+      })),
+      total: datasets.length,
+    };
+  },
+});

--- a/templates/mail/actions/provider-api-catalog.ts
+++ b/templates/mail/actions/provider-api-catalog.ts
@@ -1,0 +1,27 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import {
+  MAIL_PROVIDER_API_IDS,
+  listProviderApiCatalog,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(MAIL_PROVIDER_API_IDS);
+
+export default defineAction({
+  description:
+    "List raw HTTP API capabilities for Mail-connected providers. Use before provider-api-request when mail/calendar/CRM convenience actions are too narrow. Returns provider base URLs, auth style, credential key names, docs/spec URLs, placeholders, and examples; never returns secret values.",
+  schema: z.object({
+    provider: ProviderSchema.optional().describe(
+      "Optional provider id to inspect. Omit to list every Mail provider API escape hatch.",
+    ),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async ({ provider }) => {
+    return {
+      providers: await listProviderApiCatalog(provider),
+      guidance:
+        "Mail actions like search-emails, list-emails, get-thread, Gmail filters, calendar RSVP, and HubSpot lookups are convenience shortcuts, not capability limits. When the provider API can answer the question with a better endpoint, query, body, pagination mode, or API version, inspect docs/spec URLs and call provider-api-request directly.",
+    };
+  },
+});

--- a/templates/mail/actions/provider-api-docs.ts
+++ b/templates/mail/actions/provider-api-docs.ts
@@ -1,0 +1,35 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import {
+  MAIL_PROVIDER_API_IDS,
+  fetchProviderApiDocs,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(MAIL_PROVIDER_API_IDS);
+
+export default defineAction({
+  description:
+    "Inspect provider API docs/spec metadata, or fetch any public API documentation page, OpenAPI spec, changelog, or web page. Use this before provider-api-request when the exact Gmail, Google Calendar, or CRM endpoint, filter operator, payload shape, pagination, or API version is uncertain.",
+  schema: z.object({
+    provider: ProviderSchema.describe(
+      "Provider whose API docs/spec to inspect.",
+    ),
+    url: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        "Optional public docs/spec URL to fetch. Registered docs/spec URLs from provider-api-catalog are curated starting points, but any public http(s) API documentation URL is allowed.",
+      ),
+    maxBytes: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(4 * 1024 * 1024)
+      .optional()
+      .describe("Maximum response bytes to read. Default 1MB, max 4MB."),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async (args) => fetchProviderApiDocs(args),
+});

--- a/templates/mail/actions/provider-api-request.ts
+++ b/templates/mail/actions/provider-api-request.ts
@@ -1,0 +1,223 @@
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { stagingExecuteRequest } from "@agent-native/core/provider-api/staging";
+import { z } from "zod";
+import {
+  MAIL_APP_ID,
+  MAIL_PROVIDER_API_IDS,
+  executeProviderApiRequest,
+  getMailProviderApiRuntime,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(MAIL_PROVIDER_API_IDS);
+const MethodSchema = z.enum(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]);
+
+const PaginationSchema = z
+  .object({
+    nextCursorPath: z
+      .string()
+      .optional()
+      .describe(
+        "Dot-path in the response JSON where the next cursor/token lives, e.g. 'nextPageToken'.",
+      ),
+    cursorParam: z
+      .string()
+      .optional()
+      .describe(
+        "Query parameter name to inject the cursor into the next request. Required when nextCursorPath is set.",
+      ),
+    pageParam: z
+      .string()
+      .optional()
+      .describe(
+        "Use page-number mode: this query param is incremented on each page.",
+      ),
+    startPage: z.coerce
+      .number()
+      .int()
+      .optional()
+      .describe("Starting page number for pageParam mode (default 1)."),
+    offsetParam: z
+      .string()
+      .optional()
+      .describe(
+        "Use offset mode: this query param is incremented by pageSize on each request.",
+      ),
+    pageSize: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        "Expected page size for offset increments. Defaults to the actual item count of the first page.",
+      ),
+    maxPages: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe("Maximum pages to fetch server-side (default 50, max 200)."),
+  })
+  .optional();
+
+export default defineAction({
+  description:
+    "Make an arbitrary authenticated HTTP request to a Mail-connected provider API. " +
+    "Use this as the flexible escape hatch when a convenience action cannot express the needed Gmail endpoint, search query, filter setting, thread/message format, Google Calendar endpoint, CRM object, pagination mode, payload, or API version. " +
+    "The request is constrained to the provider host, uses configured credentials automatically, blocks private/internal URLs, and redacts secrets from responses. " +
+    "\n\nSTAGING MODE (preferred for large responses): Pass stageAs to write response items into a scratch dataset instead of returning the raw body. " +
+    "Returns { dataset, rowCount, columns, sampleRows } so only a compact summary enters context. Use query-staged-dataset to aggregate, filter, and project the data without re-fetching. " +
+    "\n\nPAGINATION: When stageAs is set, pass pagination config to fetch all pages server-side into the same dataset. For Gmail list endpoints and Google Calendar events.list, use nextCursorPath='nextPageToken', cursorParam='pageToken', and itemsPath='messages', 'threads', or 'items'.",
+  schema: z.object({
+    provider: ProviderSchema.describe(
+      "Configured provider API to call, e.g. gmail, google_calendar, or hubspot.",
+    ),
+    method: MethodSchema.default("GET").describe("HTTP method to use."),
+    path: z
+      .string()
+      .min(1)
+      .describe(
+        "Provider API path such as /users/me/messages, /users/me/settings/filters, /calendars/primary/events, /crm/v3/objects/contacts/search, or a full URL on an allowed provider host. Use placeholders from provider-api-catalog when provided.",
+      ),
+    query: z
+      .unknown()
+      .optional()
+      .describe(
+        "Optional query params as a JSON object/string. Array values produce repeated query params.",
+      ),
+    headers: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe(
+        "Optional extra headers. Unsafe hop-by-hop headers are ignored. Auth headers are injected from stored credentials.",
+      ),
+    body: z
+      .unknown()
+      .optional()
+      .describe(
+        "Optional request body. Objects/arrays are JSON encoded; strings are sent as-is.",
+      ),
+    auth: z
+      .enum(["default", "none"])
+      .default("default")
+      .describe(
+        "Use default to inject configured provider auth. Use none only for public provider endpoints that intentionally require no auth.",
+      ),
+    connectionId: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe(
+        "Optional workspace connection ID to use for provider credentials. When set, credentials must resolve from that connection.",
+      ),
+    accountId: z
+      .string()
+      .optional()
+      .describe(
+        "Optional OAuth account id to use for OAuth-backed providers such as Gmail or Google Calendar.",
+      ),
+    timeoutMs: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(120_000)
+      .optional()
+      .describe("Request timeout in milliseconds. Default 30000, max 120000."),
+    maxBytes: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(4 * 1024 * 1024)
+      .optional()
+      .describe(
+        "Maximum response bytes to read. Default 1MB, max 4MB. Ignored when saveToFile is set (allows up to 20MB).",
+      ),
+    stageAs: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "When set, parse the response as an array of records and write them into a staged dataset with this name. Returns a compact summary instead of the raw body. Re-staging the same name replaces the previous dataset.",
+      ),
+    itemsPath: z
+      .string()
+      .optional()
+      .describe(
+        "Dot-path to the items array in the response JSON, e.g. 'messages' for Gmail messages.list, 'threads' for Gmail threads.list, 'items' for Google Calendar events.list, or 'results' for CRM searches. Omit for auto-detection.",
+      ),
+    pagination: PaginationSchema.describe(
+      "Pagination config for server-side fetchAll when stageAs is set. Supports cursor, page, and offset modes.",
+    ),
+    saveToFile: z
+      .string()
+      .optional()
+      .describe(
+        "Workspace file path to save the full response body to instead of returning it in context, e.g. 'mail/provider-response.json'. When set, returns only a compact summary and allows up to 20MB response.",
+      ),
+    fetchAllPages: z
+      .object({
+        cursorPath: z
+          .string()
+          .describe(
+            "Dot-path in the JSON response body where the next-page cursor lives, e.g. 'nextPageToken'.",
+          ),
+        cursorParam: z
+          .string()
+          .describe(
+            "Query parameter name to pass the cursor on subsequent pages, e.g. 'pageToken'.",
+          ),
+        itemsPath: z
+          .string()
+          .optional()
+          .describe(
+            "Dot-path to the items array in each response, e.g. 'messages', 'threads', 'items', or 'results'. When omitted, the whole response body is appended per page.",
+          ),
+        maxPages: z.coerce
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .describe(
+            "Maximum pages to fetch. Default 10, max 50. Stops early when cursor is empty.",
+          ),
+      })
+      .optional()
+      .describe(
+        "Enable cursor-based pagination. For Gmail or Google Calendar list endpoints, use { cursorPath: 'nextPageToken', cursorParam: 'pageToken', itemsPath: '<messages|threads|items>' }.",
+      ),
+  }),
+  http: false,
+  run: async (args) => {
+    if (args.stageAs) {
+      const ctx = getCredentialContext();
+      if (!ctx) {
+        throw new Error("No authenticated context for provider API staging.");
+      }
+      const providerRuntime = getMailProviderApiRuntime();
+      return stagingExecuteRequest(
+        {
+          provider: args.provider,
+          method: args.method,
+          path: args.path,
+          query: args.query,
+          headers: args.headers,
+          body: args.body,
+          auth: args.auth,
+          connectionId: args.connectionId,
+          accountId: args.accountId,
+          timeoutMs: args.timeoutMs,
+          maxBytes: args.maxBytes,
+          stageAs: args.stageAs,
+          itemsPath: args.itemsPath,
+          pagination: args.pagination,
+        },
+        (reqArgs) => providerRuntime.executeRequest(reqArgs),
+        { appId: MAIL_APP_ID, ownerEmail: ctx.userEmail },
+      );
+    }
+    return executeProviderApiRequest(args);
+  },
+});

--- a/templates/mail/actions/query-staged-dataset.ts
+++ b/templates/mail/actions/query-staged-dataset.ts
@@ -1,0 +1,127 @@
+/**
+ * Thin mail re-export of the staged dataset query helper, pre-bound to appId="mail".
+ */
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { runAggregateQuery } from "@agent-native/core/provider-api/staged-datasets-aggregate";
+import {
+  getStagedDatasetMeta,
+  getStagedDatasetRows,
+} from "@agent-native/core/provider-api/staged-datasets-store";
+import { z } from "zod";
+import { MAIL_APP_ID } from "../server/lib/provider-api.js";
+
+const WhereSchema = z.object({
+  column: z.string().min(1),
+  op: z.enum([
+    "equals",
+    "not_equals",
+    "contains",
+    "not_contains",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "exists",
+    "not_exists",
+  ]),
+  value: z.unknown().optional(),
+});
+
+const AggregateFieldSchema = z.object({
+  column: z.string().min(1).describe("Column to aggregate."),
+  op: z
+    .enum(["sum", "avg", "count", "min", "max", "count_distinct"])
+    .describe("Aggregation function."),
+  as: z
+    .string()
+    .optional()
+    .describe("Output column name. Default: {op}_{column}."),
+});
+
+export default defineAction({
+  description:
+    "Run a filter/aggregate/project query over a staged dataset previously written by provider-api-request (stageAs). Use after staging Gmail messages, Gmail threads, Google Calendar events, or CRM records to count, group, filter, or project rows without re-fetching provider APIs.",
+  schema: z.object({
+    datasetId: z
+      .string()
+      .min(1)
+      .describe(
+        "Dataset id from provider-api-request stageAs result, or from list-staged-datasets.",
+      ),
+    where: z
+      .array(WhereSchema)
+      .optional()
+      .describe(
+        "Row-level filters (AND). Ops: equals, not_equals, contains, not_contains, gt, gte, lt, lte, exists, not_exists.",
+      ),
+    groupBy: z
+      .array(z.string().min(1))
+      .optional()
+      .describe(
+        "Column(s) to group by. Omit for a single aggregate over all rows.",
+      ),
+    aggregate: z
+      .array(AggregateFieldSchema)
+      .optional()
+      .describe(
+        "Aggregation operations. When set, non-group columns are aggregated. Omit to return raw rows.",
+      ),
+    select: z
+      .array(z.string().min(1))
+      .optional()
+      .describe("Column projection when aggregate is empty."),
+    orderBy: z.string().optional().describe("Sort output by this column."),
+    orderDir: z
+      .enum(["asc", "desc"])
+      .optional()
+      .describe("Sort direction (default asc)."),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(10_000)
+      .optional()
+      .describe("Maximum rows to return (default all, max 10000)."),
+  }),
+  http: false,
+  run: async (args) => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for query-staged-dataset.");
+    }
+
+    const meta = await getStagedDatasetMeta({
+      id: args.datasetId,
+      appId: MAIL_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+    if (!meta) {
+      throw new Error(
+        `Dataset ${args.datasetId} not found (or belongs to a different owner/app).`,
+      );
+    }
+
+    const rows = await getStagedDatasetRows({
+      id: args.datasetId,
+      appId: MAIL_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    const result = runAggregateQuery(rows, {
+      where: args.where,
+      groupBy: args.groupBy,
+      aggregate: args.aggregate,
+      select: args.select,
+      orderBy: args.orderBy,
+      orderDir: args.orderDir,
+      limit: args.limit,
+    });
+
+    return {
+      dataset: { id: meta.id, name: meta.name, totalRows: meta.rowCount },
+      rowCount: result.length,
+      rows: result,
+    };
+  },
+});

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -33,6 +33,7 @@ const SCOPES = [
   "https://www.googleapis.com/auth/userinfo.profile",
   "https://www.googleapis.com/auth/contacts.readonly",
   "https://www.googleapis.com/auth/contacts.other.readonly",
+  "https://www.googleapis.com/auth/calendar.readonly",
   "https://www.googleapis.com/auth/calendar.events",
 ];
 

--- a/templates/mail/server/lib/provider-api.ts
+++ b/templates/mail/server/lib/provider-api.ts
@@ -1,0 +1,92 @@
+import {
+  createProviderApiRuntime,
+  defaultProviderApiCredentialResolver,
+  listProviderApiIdsForTemplateUse,
+  type ProviderApiCredentialLookupOptions,
+  type ProviderApiCredentialResolver,
+  type ProviderApiId,
+  type ProviderApiMethod,
+  type ProviderApiRequestArgs,
+  type ProviderApiResolvedCredential,
+} from "@agent-native/core/provider-api";
+import { getCredentialContext } from "@agent-native/core/server";
+import { getHubSpotApiKey } from "./hubspot.js";
+
+export const MAIL_APP_ID = "mail";
+export const MAIL_PROVIDER_API_IDS = listProviderApiIdsForTemplateUse(
+  "mail",
+) as [ProviderApiId, ...ProviderApiId[]];
+export type MailProviderApiId = ProviderApiId;
+export type { ProviderApiMethod, ProviderApiRequestArgs };
+
+function legacyCredential(
+  options: ProviderApiCredentialLookupOptions,
+  key: string,
+  value: string,
+): ProviderApiResolvedCredential {
+  return {
+    key,
+    value,
+    source: `${MAIL_APP_ID}_legacy_credentials`,
+    provider: options.provider,
+  };
+}
+
+async function resolveLegacyHubSpotCredential(
+  options: ProviderApiCredentialLookupOptions,
+): Promise<ProviderApiResolvedCredential | null> {
+  if (
+    options.provider !== "hubspot" ||
+    (options.key !== "HUBSPOT_PRIVATE_APP_TOKEN" &&
+      options.key !== "HUBSPOT_ACCESS_TOKEN")
+  ) {
+    return null;
+  }
+
+  const value = await getHubSpotApiKey(options.ctx.userEmail);
+  return value ? legacyCredential(options, "HUBSPOT_API_KEY", value) : null;
+}
+
+const resolveMailCredential: ProviderApiCredentialResolver = async (
+  options,
+) => {
+  const direct = await defaultProviderApiCredentialResolver(options);
+  if (direct) return direct;
+  return resolveLegacyHubSpotCredential(options);
+};
+
+const runtime = createProviderApiRuntime({
+  appId: MAIL_APP_ID,
+  providerIds: MAIL_PROVIDER_API_IDS,
+  localCredentialSource: `${MAIL_APP_ID}_local`,
+  getCredentialContext: () => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error(
+        "Mail provider API requests require an authenticated request context.",
+      );
+    }
+    return ctx;
+  },
+  resolveCredential: resolveMailCredential,
+});
+
+export function getMailProviderApiRuntime() {
+  return runtime;
+}
+
+export function listProviderApiCatalog(provider?: MailProviderApiId) {
+  return runtime.listCatalog(provider);
+}
+
+export function fetchProviderApiDocs(options: {
+  provider: MailProviderApiId;
+  url?: string;
+  maxBytes?: number;
+}) {
+  return runtime.fetchDocs(options);
+}
+
+export function executeProviderApiRequest(args: ProviderApiRequestArgs) {
+  return runtime.executeRequest(args);
+}

--- a/templates/mail/server/plugins/agent-chat.ts
+++ b/templates/mail/server/plugins/agent-chat.ts
@@ -13,6 +13,10 @@ export default createAgentChatPlugin({
     const ctx = await getOrgContext(event);
     return ctx.orgId;
   },
+  // Enable sandboxed JavaScript execution so Mail agents can fetch, paginate,
+  // and reduce provider data through providerFetch() without us hardcoding one
+  // action per Gmail, Google Calendar, or CRM endpoint.
+  codeExecution: { production: "sandboxed" },
   mentionProviders: {
     emails: {
       label: "Emails",
@@ -80,6 +84,12 @@ Available operations:
 - Queue teammate-requested drafts for organization members to review and send
 - Navigate the UI to specific views or threads
 
+## Provider APIs Are Escape Hatches, Not Limits
+
+Provider-specific Mail actions are shortcuts, not limits. If a first-class action cannot express the exact Gmail, Google Calendar, or CRM endpoint, search query, label/filter setting, request body, pagination mode, account id, payload shape, or API version needed, call \`provider-api-catalog\` and \`provider-api-docs\` as needed, then call \`provider-api-request\` against the provider's real HTTP API.
+
+Use this raw provider API escape hatch instead of weakening the answer, broadening filters, or claiming Mail cannot do something the underlying provider API can do. For large Gmail, calendar, or CRM scans, pass \`stageAs\` and pagination options to \`provider-api-request\`, then use \`query-staged-dataset\` to count, filter, group, or project the staged rows.
+
 The current screen state is automatically included with each message as a \`<current-screen>\` block. You don't need to call view-screen before every action — use it only when you need a refreshed snapshot mid-conversation.
 After any change (archive, trash, star, mark-read, send), run refresh-list to update the UI.
 
@@ -89,7 +99,7 @@ When the user asks to "show" a view (sent, starred, drafts, etc.), ALWAYS naviga
 
 If a mail question depends on schedule facts, use \`call-agent\` with agent "calendar" instead of guessing from invite emails alone.
 Use this for questions like "am I free for this?", "does this invite conflict?", "which meeting did I miss?", "did I attend?", or "when should I reply based on my calendar?"
-Keep the message narrow and include exact dates, times, people, and the email thread context when available. If the Calendar agent is unavailable, state that limitation and separate calendar facts from mail-only inference.
+Keep the message narrow and include exact dates, times, people, and the email thread context when available. If the Calendar agent is unavailable or the task needs an exact Google Calendar endpoint/filter/pagination shape, use \`provider-api-request\` with provider "google_calendar" rather than guessing from mail-only context.
 
 ## Draft Queue
 

--- a/templates/mail/server/plugins/auth.ts
+++ b/templates/mail/server/plugins/auth.ts
@@ -22,6 +22,7 @@ export default createAuthPlugin({
     "https://www.googleapis.com/auth/userinfo.profile",
     "https://www.googleapis.com/auth/contacts.readonly",
     "https://www.googleapis.com/auth/contacts.other.readonly",
+    "https://www.googleapis.com/auth/calendar.readonly",
     "https://www.googleapis.com/auth/calendar.events",
   ],
   marketing: {

--- a/templates/plan/.agents/skills/actions/SKILL.md
+++ b/templates/plan/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/templates/plan/.agents/skills/adding-a-feature/SKILL.md
+++ b/templates/plan/.agents/skills/adding-a-feature/SKILL.md
@@ -59,7 +59,13 @@ For provider-backed analysis/query/reporting integrations, do not turn every
 provider endpoint or filter into a rigid action. Prefer the shared
 `provider-api-catalog` / `provider-api-docs` / `provider-api-request` pattern
 from `@agent-native/core/provider-api`, then add narrow convenience actions only
-for workflows that truly deserve a first-class shortcut.
+for workflows that truly deserve a first-class shortcut. Treat this as a
+capability requirement, not a nice-to-have: convenience actions must not become
+the ceiling of what the agent can ask the provider to do. Pair broad provider
+access with staging or sandboxed code execution when responses may be too large
+for chat context. If provider credentials live on resource/share rows, add the
+scoped resolver first so broad access preserves the same ownership boundary as
+the app UI.
 
 If the feature needs credentials, design the credential path in the same change.
 Never hardcode API keys, tokens, webhook URLs, signing secrets, private

--- a/templates/slides/.agents/skills/actions/SKILL.md
+++ b/templates/slides/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -21,6 +21,13 @@ Detailed deck, slide-editing, image, design-system, and export workflows live in
 - Follow linked design-system tokens and custom instructions.
 - For raw Figma `.fig` uploads, call `import-file --format fig`, then create a
   design system from the returned `designSystem` and `customInstructions`.
+- Treat import/export actions as shortcuts, not capability limits. When the
+  exact Google Drive endpoint, file metadata field, export format, pagination
+  mode, or API version matters, use `provider-api-catalog`,
+  `provider-api-docs`, and `provider-api-request` against the real provider
+  API. Slides resolves Google Drive auth from the user's connected Google Docs
+  OAuth account. For large scans, stage results with `stageAs` and analyze them
+  with `query-staged-dataset`.
 - Use image-generation and image-selection actions only when the deck genuinely
   needs imagery; keep citations/asset provenance when available.
 - Use framework sharing actions for deck visibility and grants.

--- a/templates/slides/actions/delete-staged-dataset.ts
+++ b/templates/slides/actions/delete-staged-dataset.ts
@@ -1,0 +1,42 @@
+/**
+ * Thin slides re-export of staged dataset deletion, pre-bound to appId="slides".
+ */
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { deleteStagedDataset } from "@agent-native/core/provider-api/staged-datasets-store";
+import { z } from "zod";
+import { SLIDES_APP_ID } from "../server/lib/provider-api.js";
+
+export default defineAction({
+  description:
+    "Delete a staged dataset by id, freeing its scratch storage. Use after analysis is complete or before re-staging under the same name. Only the owner who staged the dataset can delete it.",
+  schema: z.object({
+    datasetId: z
+      .string()
+      .min(1)
+      .describe(
+        "Dataset id to delete (from list-staged-datasets or provider-api-request stageAs result).",
+      ),
+  }),
+  http: false,
+  run: async (args) => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for delete-staged-dataset.");
+    }
+
+    const deleted = await deleteStagedDataset({
+      id: args.datasetId,
+      appId: SLIDES_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    if (!deleted) {
+      throw new Error(
+        `Dataset ${args.datasetId} not found (or belongs to a different owner/app).`,
+      );
+    }
+
+    return { deleted: true, datasetId: args.datasetId };
+  },
+});

--- a/templates/slides/actions/list-staged-datasets.ts
+++ b/templates/slides/actions/list-staged-datasets.ts
@@ -1,0 +1,39 @@
+/**
+ * Thin slides re-export of staged dataset listing, pre-bound to appId="slides".
+ */
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { listStagedDatasets } from "@agent-native/core/provider-api/staged-datasets-store";
+import { z } from "zod";
+import { SLIDES_APP_ID } from "../server/lib/provider-api.js";
+
+export default defineAction({
+  description:
+    "List staged datasets stored by provider-api-request (stageAs) for the current user. Returns dataset ids, names, row counts, columns, and sizes. Use dataset ids with query-staged-dataset to aggregate, or with delete-staged-dataset to free scratch storage.",
+  schema: z.object({}),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async () => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for list-staged-datasets.");
+    }
+
+    const datasets = await listStagedDatasets({
+      appId: SLIDES_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    return {
+      datasets: datasets.map((d) => ({
+        id: d.id,
+        name: d.name,
+        rowCount: d.rowCount,
+        columns: d.columns,
+        byteSize: d.byteSize,
+        updatedAt: new Date(d.updatedAt).toISOString(),
+      })),
+      total: datasets.length,
+    };
+  },
+});

--- a/templates/slides/actions/provider-api-catalog.ts
+++ b/templates/slides/actions/provider-api-catalog.ts
@@ -1,0 +1,27 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import {
+  SLIDES_PROVIDER_API_IDS,
+  listProviderApiCatalog,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(SLIDES_PROVIDER_API_IDS);
+
+export default defineAction({
+  description:
+    "List raw HTTP API capabilities for Slides-connected providers. Use before provider-api-request when deck/import convenience actions are too narrow. Returns provider base URLs, auth style, credential key names, docs/spec URLs, placeholders, and examples; never returns secret values.",
+  schema: z.object({
+    provider: ProviderSchema.optional().describe(
+      "Optional provider id to inspect. Omit to list every Slides provider API escape hatch.",
+    ),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async ({ provider }) => {
+    return {
+      providers: await listProviderApiCatalog(provider),
+      guidance:
+        "Slides actions like import-google-doc and export-google-slides are workflow shortcuts, not capability limits. When the provider API can answer the question with a better endpoint, query, body, pagination mode, metadata field, export format, or API version, inspect docs/spec URLs and call provider-api-request directly.",
+    };
+  },
+});

--- a/templates/slides/actions/provider-api-docs.ts
+++ b/templates/slides/actions/provider-api-docs.ts
@@ -1,0 +1,35 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import {
+  SLIDES_PROVIDER_API_IDS,
+  fetchProviderApiDocs,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(SLIDES_PROVIDER_API_IDS);
+
+export default defineAction({
+  description:
+    "Inspect provider API docs/spec metadata, or fetch any public API documentation page, OpenAPI spec, changelog, or web page. Use this before provider-api-request when the exact Google Drive endpoint, export format, payload shape, pagination, or API version is uncertain.",
+  schema: z.object({
+    provider: ProviderSchema.describe(
+      "Provider whose API docs/spec to inspect.",
+    ),
+    url: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        "Optional public docs/spec URL to fetch. Registered docs/spec URLs from provider-api-catalog are curated starting points, but any public http(s) API documentation URL is allowed.",
+      ),
+    maxBytes: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(4 * 1024 * 1024)
+      .optional()
+      .describe("Maximum response bytes to read. Default 1MB, max 4MB."),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async (args) => fetchProviderApiDocs(args),
+});

--- a/templates/slides/actions/provider-api-request.ts
+++ b/templates/slides/actions/provider-api-request.ts
@@ -1,0 +1,223 @@
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { stagingExecuteRequest } from "@agent-native/core/provider-api/staging";
+import { z } from "zod";
+import {
+  SLIDES_APP_ID,
+  SLIDES_PROVIDER_API_IDS,
+  executeProviderApiRequest,
+  getSlidesProviderApiRuntime,
+} from "../server/lib/provider-api.js";
+
+const ProviderSchema = z.enum(SLIDES_PROVIDER_API_IDS);
+const MethodSchema = z.enum(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"]);
+
+const PaginationSchema = z
+  .object({
+    nextCursorPath: z
+      .string()
+      .optional()
+      .describe(
+        "Dot-path in the response JSON where the next cursor/token lives, e.g. 'nextPageToken'.",
+      ),
+    cursorParam: z
+      .string()
+      .optional()
+      .describe(
+        "Query parameter name to inject the cursor into the next request. Required when nextCursorPath is set.",
+      ),
+    pageParam: z
+      .string()
+      .optional()
+      .describe(
+        "Use page-number mode: this query param is incremented on each page.",
+      ),
+    startPage: z.coerce
+      .number()
+      .int()
+      .optional()
+      .describe("Starting page number for pageParam mode (default 1)."),
+    offsetParam: z
+      .string()
+      .optional()
+      .describe(
+        "Use offset mode: this query param is incremented by pageSize on each request.",
+      ),
+    pageSize: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        "Expected page size for offset increments. Defaults to the actual item count of the first page.",
+      ),
+    maxPages: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe("Maximum pages to fetch server-side (default 50, max 200)."),
+  })
+  .optional();
+
+export default defineAction({
+  description:
+    "Make an arbitrary authenticated HTTP request to a Slides-connected provider API. " +
+    "Use this as the flexible escape hatch when a convenience action cannot express the needed Google Drive endpoint, file metadata field, export format, query, request body, pagination mode, payload shape, or API version. " +
+    "The request is constrained to the provider host, uses the user's configured Google Docs/Drive OAuth connection automatically, blocks private/internal URLs, and redacts secrets from responses. " +
+    "\n\nSTAGING MODE (preferred for large responses): Pass stageAs to write response items into a scratch dataset instead of returning the raw body. " +
+    "Returns { dataset, rowCount, columns, sampleRows } so only a compact summary enters context. Use query-staged-dataset to aggregate, filter, and project the data without re-fetching. " +
+    "\n\nPAGINATION: When stageAs is set, pass pagination config to fetch all pages server-side into the same dataset. For Google Drive files.list, use nextCursorPath='nextPageToken', cursorParam='pageToken', and itemsPath='files'.",
+  schema: z.object({
+    provider: ProviderSchema.describe(
+      "Configured provider API to call, e.g. google_drive.",
+    ),
+    method: MethodSchema.default("GET").describe("HTTP method to use."),
+    path: z
+      .string()
+      .min(1)
+      .describe(
+        "Provider API path such as /files, /files/{fileId}, /files/{fileId}/export, or a full URL on an allowed provider host. Use placeholders from provider-api-catalog when provided.",
+      ),
+    query: z
+      .unknown()
+      .optional()
+      .describe(
+        "Optional query params as a JSON object/string. Array values produce repeated query params.",
+      ),
+    headers: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe(
+        "Optional extra headers. Unsafe hop-by-hop headers are ignored. Auth headers are injected from stored credentials.",
+      ),
+    body: z
+      .unknown()
+      .optional()
+      .describe(
+        "Optional request body. Objects/arrays are JSON encoded; strings are sent as-is.",
+      ),
+    auth: z
+      .enum(["default", "none"])
+      .default("default")
+      .describe(
+        "Use default to inject configured provider auth. Use none only for public provider endpoints that intentionally require no auth.",
+      ),
+    connectionId: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe(
+        "Unused for Slides Google Docs OAuth; reserved for shared grants.",
+      ),
+    accountId: z
+      .string()
+      .optional()
+      .describe(
+        "Optional Google Docs OAuth account email when multiple accounts are connected.",
+      ),
+    timeoutMs: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(120_000)
+      .optional()
+      .describe("Request timeout in milliseconds. Default 30000, max 120000."),
+    maxBytes: z.coerce
+      .number()
+      .int()
+      .min(1_000)
+      .max(4 * 1024 * 1024)
+      .optional()
+      .describe(
+        "Maximum response bytes to read. Default 1MB, max 4MB. Ignored when saveToFile is set (allows up to 20MB).",
+      ),
+    stageAs: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "When set, parse the response as an array of records and write them into a staged dataset with this name. Returns a compact summary instead of the raw body. Re-staging the same name replaces the previous dataset.",
+      ),
+    itemsPath: z
+      .string()
+      .optional()
+      .describe(
+        "Dot-path to the items array in the response JSON, e.g. 'files' for Google Drive files.list. Omit for auto-detection.",
+      ),
+    pagination: PaginationSchema.describe(
+      "Pagination config for server-side fetchAll when stageAs is set. Supports cursor, page, and offset modes.",
+    ),
+    saveToFile: z
+      .string()
+      .optional()
+      .describe(
+        "Workspace file path to save the full response body to instead of returning it in context, e.g. 'slides/google-drive-files.json'. When set, returns only a compact summary and allows up to 20MB response.",
+      ),
+    fetchAllPages: z
+      .object({
+        cursorPath: z
+          .string()
+          .describe(
+            "Dot-path in the JSON response body where the next-page cursor lives, e.g. 'nextPageToken'.",
+          ),
+        cursorParam: z
+          .string()
+          .describe(
+            "Query parameter name to pass the cursor on subsequent pages, e.g. 'pageToken'.",
+          ),
+        itemsPath: z
+          .string()
+          .optional()
+          .describe(
+            "Dot-path to the items array in each response, e.g. 'files'. When omitted, the whole response body is appended per page.",
+          ),
+        maxPages: z.coerce
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .describe(
+            "Maximum pages to fetch. Default 10, max 50. Stops early when cursor is empty.",
+          ),
+      })
+      .optional()
+      .describe(
+        "Enable cursor-based pagination. For Google Drive files.list use { cursorPath: 'nextPageToken', cursorParam: 'pageToken', itemsPath: 'files' }.",
+      ),
+  }),
+  http: false,
+  run: async (args) => {
+    if (args.stageAs) {
+      const ctx = getCredentialContext();
+      if (!ctx) {
+        throw new Error("No authenticated context for provider API staging.");
+      }
+      const providerRuntime = getSlidesProviderApiRuntime();
+      return stagingExecuteRequest(
+        {
+          provider: args.provider,
+          method: args.method,
+          path: args.path,
+          query: args.query,
+          headers: args.headers,
+          body: args.body,
+          auth: args.auth,
+          connectionId: args.connectionId,
+          accountId: args.accountId,
+          timeoutMs: args.timeoutMs,
+          maxBytes: args.maxBytes,
+          stageAs: args.stageAs,
+          itemsPath: args.itemsPath,
+          pagination: args.pagination,
+        },
+        (reqArgs) => providerRuntime.executeRequest(reqArgs),
+        { appId: SLIDES_APP_ID, ownerEmail: ctx.userEmail },
+      );
+    }
+    return executeProviderApiRequest(args);
+  },
+});

--- a/templates/slides/actions/query-staged-dataset.ts
+++ b/templates/slides/actions/query-staged-dataset.ts
@@ -1,0 +1,127 @@
+/**
+ * Thin slides re-export of the staged dataset query helper, pre-bound to appId="slides".
+ */
+import { defineAction } from "@agent-native/core";
+import { getCredentialContext } from "@agent-native/core/server/request-context";
+import { runAggregateQuery } from "@agent-native/core/provider-api/staged-datasets-aggregate";
+import {
+  getStagedDatasetMeta,
+  getStagedDatasetRows,
+} from "@agent-native/core/provider-api/staged-datasets-store";
+import { z } from "zod";
+import { SLIDES_APP_ID } from "../server/lib/provider-api.js";
+
+const WhereSchema = z.object({
+  column: z.string().min(1),
+  op: z.enum([
+    "equals",
+    "not_equals",
+    "contains",
+    "not_contains",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "exists",
+    "not_exists",
+  ]),
+  value: z.unknown().optional(),
+});
+
+const AggregateFieldSchema = z.object({
+  column: z.string().min(1).describe("Column to aggregate."),
+  op: z
+    .enum(["sum", "avg", "count", "min", "max", "count_distinct"])
+    .describe("Aggregation function."),
+  as: z
+    .string()
+    .optional()
+    .describe("Output column name. Default: {op}_{column}."),
+});
+
+export default defineAction({
+  description:
+    "Run a filter/aggregate/project query over a staged dataset previously written by provider-api-request (stageAs). Use after staging Google Drive file lists, metadata, or export records to count, group, filter, or project rows without re-fetching provider APIs.",
+  schema: z.object({
+    datasetId: z
+      .string()
+      .min(1)
+      .describe(
+        "Dataset id from provider-api-request stageAs result, or from list-staged-datasets.",
+      ),
+    where: z
+      .array(WhereSchema)
+      .optional()
+      .describe(
+        "Row-level filters (AND). Ops: equals, not_equals, contains, not_contains, gt, gte, lt, lte, exists, not_exists.",
+      ),
+    groupBy: z
+      .array(z.string().min(1))
+      .optional()
+      .describe(
+        "Column(s) to group by. Omit for a single aggregate over all rows.",
+      ),
+    aggregate: z
+      .array(AggregateFieldSchema)
+      .optional()
+      .describe(
+        "Aggregation operations. When set, non-group columns are aggregated. Omit to return raw rows.",
+      ),
+    select: z
+      .array(z.string().min(1))
+      .optional()
+      .describe("Column projection when aggregate is empty."),
+    orderBy: z.string().optional().describe("Sort output by this column."),
+    orderDir: z
+      .enum(["asc", "desc"])
+      .optional()
+      .describe("Sort direction (default asc)."),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(10_000)
+      .optional()
+      .describe("Maximum rows to return (default all, max 10000)."),
+  }),
+  http: false,
+  run: async (args) => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error("No authenticated context for query-staged-dataset.");
+    }
+
+    const meta = await getStagedDatasetMeta({
+      id: args.datasetId,
+      appId: SLIDES_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+    if (!meta) {
+      throw new Error(
+        `Dataset ${args.datasetId} not found (or belongs to a different owner/app).`,
+      );
+    }
+
+    const rows = await getStagedDatasetRows({
+      id: args.datasetId,
+      appId: SLIDES_APP_ID,
+      ownerEmail: ctx.userEmail,
+    });
+
+    const result = runAggregateQuery(rows, {
+      where: args.where,
+      groupBy: args.groupBy,
+      aggregate: args.aggregate,
+      select: args.select,
+      orderBy: args.orderBy,
+      orderDir: args.orderDir,
+      limit: args.limit,
+    });
+
+    return {
+      dataset: { id: meta.id, name: meta.name, totalRows: meta.rowCount },
+      rowCount: result.length,
+      rows: result,
+    };
+  },
+});

--- a/templates/slides/server/lib/provider-api.ts
+++ b/templates/slides/server/lib/provider-api.ts
@@ -1,0 +1,54 @@
+import {
+  createProviderApiRuntime,
+  listProviderApiIdsForTemplateUse,
+  type ProviderApiId,
+  type ProviderApiMethod,
+  type ProviderApiRequestArgs,
+} from "@agent-native/core/provider-api";
+import { getCredentialContext } from "@agent-native/core/server";
+import { GOOGLE_DOCS_PROVIDER } from "./google-docs-oauth.js";
+
+export const SLIDES_APP_ID = "slides";
+export const SLIDES_PROVIDER_API_IDS = listProviderApiIdsForTemplateUse(
+  "slides",
+) as [ProviderApiId, ...ProviderApiId[]];
+export type SlidesProviderApiId = (typeof SLIDES_PROVIDER_API_IDS)[number];
+export type { ProviderApiMethod, ProviderApiRequestArgs };
+
+const runtime = createProviderApiRuntime({
+  appId: SLIDES_APP_ID,
+  providerIds: SLIDES_PROVIDER_API_IDS,
+  localCredentialSource: `${SLIDES_APP_ID}_local`,
+  getCredentialContext: () => {
+    const ctx = getCredentialContext();
+    if (!ctx) {
+      throw new Error(
+        "Slides provider API requests require an authenticated request context.",
+      );
+    }
+    return ctx;
+  },
+  oauthProviderOverrides: {
+    google_drive: GOOGLE_DOCS_PROVIDER,
+  },
+});
+
+export function getSlidesProviderApiRuntime() {
+  return runtime;
+}
+
+export function listProviderApiCatalog(provider?: SlidesProviderApiId) {
+  return runtime.listCatalog(provider);
+}
+
+export function fetchProviderApiDocs(options: {
+  provider: SlidesProviderApiId;
+  url?: string;
+  maxBytes?: number;
+}) {
+  return runtime.fetchDocs(options);
+}
+
+export function executeProviderApiRequest(args: ProviderApiRequestArgs) {
+  return runtime.executeRequest(args);
+}

--- a/templates/slides/server/plugins/agent-chat.ts
+++ b/templates/slides/server/plugins/agent-chat.ts
@@ -11,8 +11,17 @@ export default createAgentChatPlugin({
   appId: "slides",
   actions: loadActionsFromStaticRegistry(actionsRegistry),
   runSoftTimeoutMs: 240_000,
+  // Enable sandboxed JavaScript execution so Slides agents can fetch,
+  // paginate, and reduce provider data through providerFetch() without us
+  // hardcoding one action per Google Drive endpoint.
+  codeExecution: { production: "sandboxed" },
   resolveOrgId: async (event) => (await getOrgContext(event)).orgId,
   prepareRequest: prepareSlidesChatAttachments,
+  systemPrompt: `You are an AI deck assistant. You create, edit, import, export, style, share, and navigate decks through actions and shared application state.
+
+Provider-specific Slides actions are shortcuts, not limits. If a first-class action cannot express the exact Google Drive endpoint, file metadata field, export format, query, request body, pagination mode, payload shape, or API version needed, call provider-api-catalog and provider-api-docs as needed, then call provider-api-request against the real provider API. Use the raw provider API escape hatch instead of weakening the answer or claiming Slides cannot do something the underlying Google Drive API can do.
+
+Slides' Google Drive provider API uses the user's connected Google Docs OAuth account. The drive.file scope is intentionally limited to files the user selected or the app created. For large Drive file lists or metadata sweeps, pass stageAs and pagination options to provider-api-request, then use query-staged-dataset to count, filter, group, or project the staged rows.`,
   mentionProviders: async () => {
     const { getDb } = await import("../db/index.js");
     const { decks, deckShares } = await import("../db/schema.js");

--- a/templates/starter/.agents/skills/actions/SKILL.md
+++ b/templates/starter/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 

--- a/templates/starter/.agents/skills/adding-a-feature/SKILL.md
+++ b/templates/starter/.agents/skills/adding-a-feature/SKILL.md
@@ -59,7 +59,13 @@ For provider-backed analysis/query/reporting integrations, do not turn every
 provider endpoint or filter into a rigid action. Prefer the shared
 `provider-api-catalog` / `provider-api-docs` / `provider-api-request` pattern
 from `@agent-native/core/provider-api`, then add narrow convenience actions only
-for workflows that truly deserve a first-class shortcut.
+for workflows that truly deserve a first-class shortcut. Treat this as a
+capability requirement, not a nice-to-have: convenience actions must not become
+the ceiling of what the agent can ask the provider to do. Pair broad provider
+access with staging or sandboxed code execution when responses may be too large
+for chat context. If provider credentials live on resource/share rows, add the
+scoped resolver first so broad access preserves the same ownership boundary as
+the app UI.
 
 If the feature needs credentials, design the credential path in the same change.
 Never hardcode API keys, tokens, webhook URLs, signing secrets, private

--- a/templates/videos/.agents/skills/actions/SKILL.md
+++ b/templates/videos/.agents/skills/actions/SKILL.md
@@ -104,7 +104,9 @@ Do not build an umbrella REST API to make actions "easier" to call. Actions are 
 
 For provider integrations used in ad hoc analysis, querying, reporting, or
 cross-source research, do not hardcode every provider endpoint as a separate
-rigid action. Expose the shared provider API action trio instead:
+rigid action and do not encode one lookback window, filter shape, or pagination
+strategy as the only path the agent can take. Expose the shared provider API
+action trio instead:
 
 - `provider-api-catalog`: lists provider base URLs, auth style, credential keys,
   docs/spec URLs, placeholders, and examples without exposing secrets.
@@ -117,11 +119,25 @@ rigid action. Expose the shared provider API action trio instead:
 
 Use `@agent-native/core/provider-api` as the shared substrate. A template should
 only add a thin credential adapter when it has app-specific credential lookup
-rules. Keep `provider-api-request` `http: false` unless you have a separate UI
-permission model for arbitrary provider writes. Specific actions such as
-`hubspot-deals`, `search-emails`, or `sync-source` are convenience shortcuts,
-not capability limits; agents should fall back to the provider API trio when a
-question requires an endpoint or filter that the shortcut does not model.
+rules. If the app stores a built-in provider's OAuth grant under a narrower
+local provider id, use the runtime's `oauthProviderOverrides` instead of
+duplicating the provider config. If credentials are stored on shareable/resource
+rows rather than in the shared credential or OAuth-token stores, build a resolver
+that enforces those access checks before exposing raw provider requests. Keep
+`provider-api-request` `http: false` unless you have a separate UI permission
+model for arbitrary provider writes. Specific actions such as `hubspot-deals`,
+`search-emails`, or `sync-source` are convenience shortcuts, not capability
+limits; agents should fall back to the provider API trio when a question
+requires an endpoint or filter that the shortcut does not model.
+
+This is a framework tenet. The safety boundary should be provider host
+allow-listing, credential scoping, auth injection, private-network blocking,
+secret redaction, and user/org access checks, not an artificially small set of
+hand-authored read actions. If the upstream provider API supports a capability,
+the agent should normally be able to reach it through `provider-api-request`
+with the user's configured credentials. For large responses, expose staging
+(`stageAs`, `itemsPath`, pagination, and `query-staged-dataset`) or sandboxed
+code execution so the agent can reduce data without flooding context.
 
 ### The `http` Option
 


### PR DESCRIPTION
## Summary
- add provider-api catalog/docs/request plus staged dataset helpers across Calendar, Mail, Content, Slides, and Design
- update framework instructions so first-class integration actions are shortcuts, not capability ceilings
- fix provider API URL joining for base paths and add OAuth provider overrides for app-specific grants
- make Calendar event search bounded/explicit while adding pagination and token matching for reliable relationship history

## Verification
- pnpm --filter @agent-native/core exec vitest run src/provider-api/index.spec.ts src/provider-api/staging.spec.ts
- pnpm --filter @agent-native/core exec tsc --noEmit --pretty false --lib es2023,dom,dom.iterable
- pnpm --dir templates/calendar exec vitest run actions/event-search.test.ts server/lib/google-calendar.spec.ts
- pnpm --dir templates/design exec vitest run server/agent-card.test.ts
- pnpm --dir templates/content exec vitest run server/agent-card.test.ts
- pnpm --dir templates/slides exec vitest run server/agent-card.test.ts
- pnpm --filter design build
- pnpm --filter content build
- pnpm --filter slides build
- pnpm --filter calendar build
- pnpm --filter mail build