### PR TITLE
Fix plan local access and comment anchors

### DIFF
--- a/templates/analytics/netlify.toml
+++ b/templates/analytics/netlify.toml
@@ -7,6 +7,7 @@
 [build.environment]
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
+  AGENT_PROD_CODE_EXECUTION = "sandboxed"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
 # Hosted agent chat uses a soft timeout before this function timeout so the

--- a/templates/analytics/server/lib/real-data-actions.spec.ts
+++ b/templates/analytics/server/lib/real-data-actions.spec.ts
@@ -4,6 +4,7 @@ import {
   hasDataQueryAttempt,
   hasIncompleteDataEvidence,
   isSafeNoDataAnalyticsResponse,
+  looksLikeCoverageSensitiveAnalyticsRequest,
   looksLikeStrongCoverageClaim,
   looksLikeAnalyticsDataRequest,
   stripInjectedAnalyticsGuardContext,
@@ -132,10 +133,57 @@ describe("analytics data request classification", () => {
     );
   });
 
+  it("does not reject source-record analysis just because it mentions integrations", () => {
+    expect(
+      looksLikeAnalyticsDataRequest(
+        "Search Gong transcripts and Pylon tickets for customers asking for a deeper Figma integration.",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not reject source searches because quoted context mentions sharing", () => {
+    expect(
+      looksLikeAnalyticsDataRequest(
+        'Find any HubSpot deals with product = "fusion" and look through all Gong transcripts for examples of customers asking for the Figma MCP. The partner manager said they can share that with the team.',
+      ),
+    ).toBe(true);
+  });
+
   it("does not classify generic chat/message bug reports as data requests", () => {
     expect(
       looksLikeAnalyticsDataRequest(
         "the chat keeps typing long messages that disappear",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("coverage-sensitive analytics request classification", () => {
+  it("flags broad provider searches where absence matters", () => {
+    expect(
+      looksLikeCoverageSensitiveAnalyticsRequest(
+        'Find any closed won deal in HubSpot where products = "fusion", then for all those deals look through all Gong call transcripts after close and let me know if you surface anything around Figma MCP.',
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeCoverageSensitiveAnalyticsRequest(
+        "Search all Pylon tickets and Gong transcripts for any examples of customers asking for a deeper Figma integration.",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not flag ordinary bounded metric questions as coverage-sensitive", () => {
+    expect(
+      looksLikeCoverageSensitiveAnalyticsRequest(
+        "Show weekly signup trends for the last 30 days.",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps metadata-only questions out of coverage-sensitive handling", () => {
+    expect(
+      looksLikeCoverageSensitiveAnalyticsRequest(
+        "What Gong and HubSpot tables are available?",
       ),
     ).toBe(false);
   });
@@ -277,6 +325,11 @@ describe("incomplete evidence detection", () => {
     expect(
       hasExplicitPartialDisclosure(
         "This is partial: I only inspected the first 20 calls.",
+      ),
+    ).toBe(true);
+    expect(
+      hasExplicitPartialDisclosure(
+        "I reviewed 10 of 25 accounts; the remaining accounts are not covered.",
       ),
     ).toBe(true);
   });

--- a/templates/analytics/server/lib/real-data-actions.ts
+++ b/templates/analytics/server/lib/real-data-actions.ts
@@ -103,6 +103,9 @@ const ANALYTICS_RESULT_TERMS =
 const ANALYTICS_INTENT_TERMS =
   /\b(analy[sz]e|measure|calculate|query|report|summari[sz]e|break ?down|compare|rank|segment|forecast|trend|count|total|average|median|percent(?:age)?|rate|top|bottom|highest|lowest|how many|how much|what (?:is|are|was|were)|which|why)\b/;
 
+const SOURCE_SEARCH_INTENT_TERMS =
+  /\b(find|surface|search|scan|grep|review|inspect|check|look through|go find)\b/;
+
 const ARTIFACT_TERMS = /\b(analysis|dashboard|panel|chart|metric|metrics)\b/;
 
 const ARTIFACT_DATA_INTENT =
@@ -123,14 +126,20 @@ export function looksLikeAnalyticsDataRequest(text: string): boolean {
   if (
     /\b(open|navigate|go to|rename|delete|share|favorite|unfavorite)\b/.test(
       lower,
-    )
+    ) &&
+    !ANALYTICS_INTENT_TERMS.test(lower) &&
+    !SOURCE_SEARCH_INTENT_TERMS.test(lower)
   ) {
     return false;
   }
   if (
-    /\b(fix|bug|layout|style|component|route|code|source code|integration|connect|configure|settings)\b/.test(
-      lower,
-    )
+    /\b(fix|bug|layout|style|component|route|code|source code)\b/.test(lower)
+  ) {
+    return false;
+  }
+  if (
+    /\b(integration|connect|configure|settings)\b/.test(lower) &&
+    !ANALYTICS_RESULT_TERMS.test(lower)
   ) {
     return false;
   }
@@ -266,7 +275,7 @@ function valueHasIncompleteDataFlag(value: unknown): boolean {
 }
 
 const INCOMPLETE_DATA_TEXT =
-  /\b(?:error running|run aborted|tool call timed out|stale_run|connection_error|interrupted before this tool returned|truncated|coverage gap|provider page cap|hit the .* page cap|has more content|call again with offset|full result was|only first)\b/i;
+  /\b(?:error running|run aborted|tool call timed out|timed out|inactivity timeout|stale_run|connection_error|interrupted before this tool returned|truncated|coverage gap|provider page cap|hit the .* page cap|has more content|call again with offset|full result was|default limit|duplicate skipped|only first)\b/i;
 
 export function hasIncompleteDataEvidence(
   toolResults:
@@ -297,7 +306,10 @@ const STRONG_COVERAGE_OR_ABSENCE_CLAIM =
   /\b(?:no|zero|0)\s+(?:mentions?|matches?|results?|records?|calls?|tickets?|issues?|deals?|accounts?|customers?|transcripts?|examples?)\b|\b(?:none|nothing)\b[^.?!]*(?:found|matched|mentioned|returned|showed|surfaced)\b|\b(?:all|every|entire|complete|full|exhaustive)\b[^.?!]*(?:calls?|records?|transcripts?|deals?|accounts?|customers?|dataset|cohort|results?|search)\b|\b(?:did not|didn't|does not|doesn't)\s+(?:mention|include|contain|show|surface)\b/i;
 
 const EXPLICIT_PARTIAL_DISCLOSURE =
-  /\b(?:partial|partially|sample|sampled|subset|bounded|limited|not exhaustive|non-exhaustive|incomplete|truncated|aborted|timed out|coverage gap|could not inspect|only inspected|first \d+|top \d+|returned \d+)\b/i;
+  /\b(?:partial|partially|sample|sampled|subset|bounded|limited|not exhaustive|non-exhaustive|incomplete|truncated|aborted|timed out|coverage gap|could not inspect|only inspected|first \d+|top \d+|returned \d+|remaining|unsearched|uninspected|unreviewed|not covered|uncovered|missing coverage)\b|\b(?:inspected|searched|reviewed|analy[sz]ed)\s+\d+\s+(?:of|out of)\s+\d+\b/i;
+
+const COVERAGE_SENSITIVE_ANALYTICS_REQUEST =
+  /\b(?:all|every|each|entire|complete|full|exhaustive)\b[^.?!]{0,220}\b(?:calls?|records?|transcripts?|deals?|accounts?|customers?|tickets?|issues?|messages?|source records?|cohort|dataset|results?)\b|\b(?:find|surface|search|scan|grep|review|inspect|check|look through)\b[^.?!]{0,220}\b(?:any|all|every|each|mentions?|matches?|examples?|source records?|calls?|records?|transcripts?|deals?|accounts?|customers?|tickets?|issues?|messages?)\b|\b(?:let me know if you surface anything|surface anything|anything around|absence matters|where (?:the )?lack thereof|lack thereof is impacting|no mentions?|zero mentions?)\b/i;
 
 export function looksLikeStrongCoverageClaim(text: string): boolean {
   return STRONG_COVERAGE_OR_ABSENCE_CLAIM.test(text);
@@ -305,6 +317,14 @@ export function looksLikeStrongCoverageClaim(text: string): boolean {
 
 export function hasExplicitPartialDisclosure(text: string): boolean {
   return EXPLICIT_PARTIAL_DISCLOSURE.test(text);
+}
+
+export function looksLikeCoverageSensitiveAnalyticsRequest(
+  text: string,
+): boolean {
+  const requestText = stripInjectedAnalyticsGuardContext(text);
+  if (!looksLikeAnalyticsDataRequest(requestText)) return false;
+  return COVERAGE_SENSITIVE_ANALYTICS_REQUEST.test(requestText);
 }
 
 export function hasDataQueryAttempt(

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -14,6 +14,7 @@ import {
   hasDataQueryAttempt,
   hasIncompleteDataEvidence,
   isSafeNoDataAnalyticsResponse,
+  looksLikeCoverageSensitiveAnalyticsRequest,
   looksLikeStrongCoverageClaim,
   looksLikeAnalyticsDataRequest,
 } from "../lib/real-data-actions";
@@ -42,14 +43,16 @@ function realDataFinalGuard(context: AgentLoopFinalResponseGuardContext) {
   }
   const userText = latestUserText(context.messages ?? []);
   if (!looksLikeAnalyticsDataRequest(userText)) return null;
+  const incompleteEvidence = hasIncompleteDataEvidence(context.toolResults);
   if (
-    hasIncompleteDataEvidence(context.toolResults) &&
-    looksLikeStrongCoverageClaim(context.text) &&
+    incompleteEvidence &&
+    (looksLikeStrongCoverageClaim(context.text) ||
+      looksLikeCoverageSensitiveAnalyticsRequest(userText)) &&
     !hasExplicitPartialDisclosure(context.text)
   ) {
     return {
       retryMessage:
-        "Some source evidence for this analytics answer was aborted, truncated, or indicated more pages, but the draft makes a strong zero/all/exhaustive claim. Recover coverage with provider-api-request/run-code/workspace staging if possible; otherwise finalize with explicit partial-coverage wording, the inspected sample size, and the missing coverage.",
+        "Some source evidence for this analytics answer was aborted, truncated, timed out, or indicated more pages. The user asked a coverage-sensitive provider question, or the draft makes a strong zero/all/exhaustive claim. Recover coverage with provider-api-request/run-code/workspace staging if possible; otherwise finalize with explicit partial-coverage wording, the inspected sample size, and the missing coverage.",
       fallbackMessage:
         "I can't make a confident exhaustive analytics claim yet because part of the source evidence was aborted, truncated, or still paginated. I need to recover the missing coverage or state the answer as partial with the inspected sample size.",
     };

--- a/templates/plan/actions/get-local-plan-folder.ts
+++ b/templates/plan/actions/get-local-plan-folder.ts
@@ -2,7 +2,10 @@ import { defineAction } from "@agent-native/core";
 import { z } from "zod";
 import { exportPlanContentToMdxFolder } from "../server/plan-mdx.js";
 import { buildPlanHtml, nowIso } from "../server/plans.js";
-import { isLocalPlanRuntime } from "../server/lib/local-identity.js";
+import {
+  getLocalPlanOwnerEmail,
+  isLocalPlanRuntime,
+} from "../server/lib/local-identity.js";
 import { readPlanLocalFolder } from "../server/lib/local-plan-files.js";
 import type { PlanBundle, PlanKind } from "../shared/types.js";
 
@@ -63,7 +66,7 @@ export default defineAction({
       },
       access: {
         role: "viewer",
-        ownerEmail: "local@agent-native.local",
+        ownerEmail: getLocalPlanOwnerEmail(),
         orgId: null,
         visibility: "private",
       },

--- a/templates/plan/app/pages/PlansPage.comments.test.ts
+++ b/templates/plan/app/pages/PlansPage.comments.test.ts
@@ -709,6 +709,65 @@ describe("plan comment thread UI model", () => {
     reader.remove();
   });
 
+  it("measures generic wireframe child clicks against the saved selector target", () => {
+    const reader = document.createElement("div");
+    reader.innerHTML = `
+      <section class="plan-canvas">
+        <div data-plan-canvas-viewport>
+          <div data-plan-canvas-world>
+            <div data-canvas-frame="frame_1">
+              <div>
+                <button id="target">New run</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    `;
+    document.body.append(reader);
+
+    const frame = reader.querySelector<HTMLElement>("[data-canvas-frame]")!;
+    const target = reader.querySelector<HTMLElement>("#target")!;
+    Object.defineProperties(reader, {
+      scrollWidth: { value: 1000, configurable: true },
+      scrollHeight: { value: 1000, configurable: true },
+      scrollLeft: { value: 0, configurable: true },
+      scrollTop: { value: 0, configurable: true },
+    });
+    Object.defineProperty(reader, "getBoundingClientRect", {
+      value: () => rect(0, 0, 1000, 800),
+    });
+    Object.defineProperty(frame, "getBoundingClientRect", {
+      value: () => rect(100, 200, 300, 200),
+    });
+    Object.defineProperty(target, "getBoundingClientRect", {
+      value: () => rect(250, 260, 80, 40),
+    });
+
+    const anchor = buildNativeAnchorFromElement({
+      reader,
+      target,
+      pointX: 290,
+      pointY: 280,
+      planTitle: "Wireframe",
+    });
+
+    expect(anchor.sectionId).toBe("frame_1");
+    expect(anchor.targetKind).toBe("wireframe");
+    expect(anchor.targetSelector).toBe(
+      '[data-canvas-frame="frame_1"] > div:nth-of-type(1) > button:nth-of-type(1)',
+    );
+    expect(anchor.targetX).toBeCloseTo(50);
+    expect(anchor.targetY).toBeCloseTo(50);
+    expect(resolveNativeAnchorTarget(anchor, reader)).toBe(target);
+    expect(nativePointForAnchor(anchor, reader)).toEqual({
+      left: 290,
+      top: 280,
+    });
+
+    reader.remove();
+  });
+
   it("clips canvas comment markers to the canvas viewport instead of the document", () => {
     const reader = document.createElement("div");
     reader.innerHTML = `

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -1595,7 +1595,6 @@ function resolveStableVisualAnchorTarget(
       if (target) return target;
     }
   }
-  if (frame && anchor.targetKind === "wireframe") return frame;
   return null;
 }
 
@@ -1635,10 +1634,10 @@ function targetKindForElement(
   if (tag === "pre" || tag === "code") return "code";
   if (tag === "svg") return "diagram";
   if (element.closest("[data-plan-prototype-viewer]")) return "prototype";
-  if (tag === "canvas" || element.closest(".plan-canvas")) return "canvas";
   if (element.closest("[data-canvas-frame],.plan-artboard-frame")) {
     return "wireframe";
   }
+  if (tag === "canvas" || element.closest(".plan-canvas")) return "canvas";
   if (element.matches("button,a,input,textarea,select,label")) return "control";
   if (element.closest("[data-block-id]")) return "block";
   return "unknown";
@@ -1795,16 +1794,6 @@ export function resolveNativeAnchorTarget(
     queryRoot,
   );
   if (stableVisualTarget) return stableVisualTarget;
-  if (
-    anchor.planAnnotationId ||
-    anchor.canvasX !== undefined ||
-    anchor.targetKind === "canvas"
-  ) {
-    const canvasWorld = reader.querySelector<HTMLElement>(
-      "[data-plan-canvas-world], .plan-canvas-world",
-    );
-    if (canvasWorld) return canvasWorld;
-  }
   if (anchor.targetSelector) {
     try {
       const target = queryRoot.matches(anchor.targetSelector)
@@ -1816,8 +1805,24 @@ export function resolveNativeAnchorTarget(
         if (textTarget) return textTarget;
       }
     } catch {
-      // Fall back to quote matching below.
+      // Fall back to broad visual targets or quote matching below.
     }
+  }
+  if (
+    anchor.planAnnotationId ||
+    anchor.canvasX !== undefined ||
+    anchor.targetKind === "canvas"
+  ) {
+    const canvasWorld = reader.querySelector<HTMLElement>(
+      "[data-plan-canvas-world], .plan-canvas-world",
+    );
+    if (canvasWorld) return canvasWorld;
+  }
+  if (anchor.targetKind === "wireframe" && anchor.sectionId) {
+    const frame = reader.querySelector<HTMLElement>(
+      dataSelector("data-canvas-frame", anchor.sectionId),
+    );
+    if (frame) return frame;
   }
   if (!needle) return null;
   const scopes: Element[] = [];

--- a/templates/plan/server/lib/local-identity.adversarial.spec.ts
+++ b/templates/plan/server/lib/local-identity.adversarial.spec.ts
@@ -25,7 +25,12 @@ import {
   resolvePlanOwnerEmailForWrite,
 } from "./local-identity.js";
 
-const ENV_KEYS = ["NODE_ENV", "AUTH_MODE", "PLAN_LOCAL_MODE"] as const;
+const ENV_KEYS = [
+  "NODE_ENV",
+  "AUTH_MODE",
+  "PLAN_LOCAL_MODE",
+  "PLAN_LOCAL_OWNER_EMAIL",
+] as const;
 
 describe("local-identity adversarial", () => {
   let saved: Record<string, string | undefined>;
@@ -122,6 +127,17 @@ describe("local-identity adversarial", () => {
     it("PLAN_LOCAL_MODE=1 CANNOT override the production refusal", () => {
       setEnv({ NODE_ENV: "production", PLAN_LOCAL_MODE: "1" });
       expect(isLocalPlanRuntime()).toBe(false);
+    });
+
+    it("PLAN_LOCAL_OWNER_EMAIL CANNOT override the production refusal", () => {
+      setEnv({
+        NODE_ENV: "production",
+        PLAN_LOCAL_MODE: "1",
+        PLAN_LOCAL_OWNER_EMAIL: "owner@example.com",
+      });
+      expect(isLocalPlanRuntime()).toBe(false);
+      expect(resolvePlanOwnerEmail(undefined)).toBeUndefined();
+      expect(resolvePlanOwnerEmailForWrite(undefined)).toBeUndefined();
     });
 
     it("only the exact string '0' opts out — '00'/'false'/'no' do NOT (they enable local in dev)", () => {

--- a/templates/plan/server/lib/local-identity.spec.ts
+++ b/templates/plan/server/lib/local-identity.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   GUEST_AUTHOR_DOMAIN,
   LOCAL_PLAN_OWNER_EMAIL,
+  getLocalPlanOwnerEmail,
   isAnonymousPublicViewer,
   isGuestAuthorIdentity,
   isLocalPlanRuntime,
@@ -16,7 +17,12 @@ const GUEST_EMAIL = `guest-123e4567-e89b-12d3-a456-426614174000@${GUEST_AUTHOR_D
 const PUBLIC_VIEWER_EMAIL =
   "public-123e4567-e89b-12d3-a456-426614174000@agent-native.local";
 
-const ENV_KEYS = ["NODE_ENV", "AUTH_MODE", "PLAN_LOCAL_MODE"] as const;
+const ENV_KEYS = [
+  "NODE_ENV",
+  "AUTH_MODE",
+  "PLAN_LOCAL_MODE",
+  "PLAN_LOCAL_OWNER_EMAIL",
+] as const;
 
 describe("local-identity", () => {
   let saved: Record<string, string | undefined>;
@@ -106,9 +112,33 @@ describe("local-identity", () => {
       expect(resolvePlanOwnerEmail(undefined)).toBe(LOCAL_PLAN_OWNER_EMAIL);
     });
 
+    it("uses PLAN_LOCAL_OWNER_EMAIL as the local identity override", () => {
+      setEnv({
+        NODE_ENV: "development",
+        PLAN_LOCAL_OWNER_EMAIL: "owner@example.com",
+      });
+      expect(getLocalPlanOwnerEmail()).toBe("owner@example.com");
+      expect(resolvePlanOwnerEmail(undefined)).toBe("owner@example.com");
+      expect(resolvePlanOwnerEmail("user@example.com")).toBe(
+        "owner@example.com",
+      );
+    });
+
     it("returns undefined when hosted and unauthenticated", () => {
       setEnv({ NODE_ENV: "production" });
       expect(resolvePlanOwnerEmail(undefined)).toBeUndefined();
+    });
+
+    it("does not use PLAN_LOCAL_OWNER_EMAIL in production", () => {
+      setEnv({
+        NODE_ENV: "production",
+        PLAN_LOCAL_MODE: "1",
+        PLAN_LOCAL_OWNER_EMAIL: "owner@example.com",
+      });
+      expect(resolvePlanOwnerEmail(undefined)).toBeUndefined();
+      expect(resolvePlanOwnerEmail("user@example.com")).toBe(
+        "user@example.com",
+      );
     });
   });
 
@@ -121,6 +151,19 @@ describe("local-identity", () => {
           orgId: "org_1",
         }),
       ).toEqual({ userEmail: LOCAL_PLAN_OWNER_EMAIL });
+    });
+
+    it("maps local access to PLAN_LOCAL_OWNER_EMAIL when configured", () => {
+      setEnv({
+        NODE_ENV: "development",
+        PLAN_LOCAL_OWNER_EMAIL: "owner@example.com",
+      });
+      expect(
+        resolvePlanAccessContext({
+          userEmail: "user@example.com",
+          orgId: "org_1",
+        }),
+      ).toEqual({ userEmail: "owner@example.com" });
     });
 
     it("does not upgrade public-link viewers to local owner/editor", () => {

--- a/templates/plan/server/lib/local-identity.ts
+++ b/templates/plan/server/lib/local-identity.ts
@@ -25,6 +25,10 @@
  * hosted deploy: a production process always rejects, and a non-local AUTH_MODE
  * always rejects. An optional explicit `PLAN_LOCAL_MODE=1` flag lets a developer
  * force local mode on, but it still cannot override the production refusal.
+ *
+ * `PLAN_LOCAL_OWNER_EMAIL` may override the synthetic owner in local runtime
+ * only. This is useful when pointing localhost at a shared/prod database to
+ * inspect private rows owned by the signed-in hosted account.
  */
 
 /**
@@ -33,6 +37,10 @@
  * and from the anonymous public-viewer identity `public-*@agent-native.local`.
  */
 export const LOCAL_PLAN_OWNER_EMAIL = "local@agent-native.local";
+
+export function getLocalPlanOwnerEmail(): string {
+  return process.env.PLAN_LOCAL_OWNER_EMAIL?.trim() || LOCAL_PLAN_OWNER_EMAIL;
+}
 
 /**
  * Domain used for hosted guest-author identities (`guest-<uuid>@agent-native.guest`).
@@ -123,7 +131,7 @@ export function resolvePlanAccessContext(
   ctx: PlanAccessContext,
 ): PlanAccessContext {
   if (shouldUseLocalPlanOwner(ctx.userEmail)) {
-    return { userEmail: LOCAL_PLAN_OWNER_EMAIL };
+    return { userEmail: getLocalPlanOwnerEmail() };
   }
   return ctx;
 }
@@ -163,7 +171,7 @@ export function resolvePlanOwnerEmail(
   authenticatedEmail: string | undefined,
 ): string | undefined {
   if (shouldUseLocalPlanOwner(authenticatedEmail)) {
-    return LOCAL_PLAN_OWNER_EMAIL;
+    return getLocalPlanOwnerEmail();
   }
   if (authenticatedEmail) return authenticatedEmail;
   return undefined;
@@ -189,7 +197,7 @@ export function resolvePlanOwnerEmailForWrite(
   authenticatedEmail: string | undefined,
 ): string | undefined {
   if (shouldUseLocalPlanOwner(authenticatedEmail)) {
-    return LOCAL_PLAN_OWNER_EMAIL;
+    return getLocalPlanOwnerEmail();
   }
   if (authenticatedEmail && !isGuestAuthorIdentity(authenticatedEmail)) {
     return authenticatedEmail;

--- a/templates/plan/server/lib/public-plans.ts
+++ b/templates/plan/server/lib/public-plans.ts
@@ -10,7 +10,7 @@ import { eq } from "drizzle-orm";
 import { getDb, schema } from "../db/index.js";
 import {
   GUEST_AUTHOR_DOMAIN,
-  LOCAL_PLAN_OWNER_EMAIL,
+  getLocalPlanOwnerEmail,
   isGuestAuthorIdentity,
   isLocalPlanRuntime,
 } from "./local-identity.js";
@@ -137,10 +137,10 @@ function isSecureRequest(event: H3Event): boolean {
  *      viewer can read (but, per the comment gate, not comment) without an
  *      account. Honored in every environment, hosted and local. Read-only.
  *   2. Local single-user identity — in local mode only (`isLocalPlanRuntime()`),
- *      fall back to `LOCAL_PLAN_OWNER_EMAIL` so the no-login local workflow can
- *      create, read, list, and edit its own plans without signing in. This MUST
- *      NOT fire on a hosted/production deploy; `isLocalPlanRuntime()` enforces
- *      the production refusal.
+ *      fall back to the configured local owner so the no-login local workflow
+ *      can create, read, list, and edit its own plans without signing in. This
+ *      MUST NOT fire on a hosted/production deploy; `isLocalPlanRuntime()`
+ *      enforces the production refusal.
  *
  * Returns `null` when none applies, so the caller rejects exactly as before.
  */
@@ -152,7 +152,7 @@ export async function resolvePlanAnonymousOwner(
   }
   const publicViewer = await resolvePublicPlanViewerOwner(event);
   if (publicViewer) return publicViewer;
-  return isLocalPlanRuntime() ? LOCAL_PLAN_OWNER_EMAIL : null;
+  return isLocalPlanRuntime() ? getLocalPlanOwnerEmail() : null;
 }
 
 export async function resolvePublicPlanViewerOwner(


### PR DESCRIPTION
## Summary
- allow local Plan runtime to use an explicit local owner email when localhost points at shared/prod data
- fix visual plan comment anchors so wireframe child controls resolve to the saved selector before falling back to the whole frame/canvas
- tighten analytics coverage-sensitive final-response guarding already present on this branch

## Testing
- pnpm --dir templates/plan exec vitest run app/pages/PlansPage.comments.test.ts server/lib/local-identity.spec.ts server/lib/local-identity.adversarial.spec.ts server/lib/public-plans.spec.ts
- pnpm --dir templates/plan typecheck
- Playwright one-off against http://localhost:8082/plans/plan-44ce80fb8c414f6a verified wireframe button pending pin landed 0.012px from click center
- pnpm prep