### PR TITLE
Support builder large uploads

### DIFF
--- a/.changeset/large-file-uploads.md
+++ b/.changeset/large-file-uploads.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Builder file upload provider now routes files over 30 MB through a signed-URL flow (request URL → direct storage PUT → register asset), so large uploads no longer hit the ~32 MB request cap. Smaller files keep the existing direct-POST path with retries.

--- a/packages/core/src/file-upload/builder.ts
+++ b/packages/core/src/file-upload/builder.ts
@@ -71,16 +71,19 @@ async function uploadLargeFileViaSignedUrl(
   );
   await assertOk(step1Res, "Builder.io signed-URL request failed");
 
-  const { uploadUrl, assetId, expiresAt, requiredHeaders } =
-    (await step1Res.json()) as {
-      uploadUrl: string;
-      assetId: string;
-      expiresAt: string;
-      requiredHeaders: Record<string, string>;
-    };
-  console.log(
-    `[builder-upload] step 1 ok: assetId=${assetId} expiresAt=${expiresAt}`,
-  );
+  const step1Json = (await step1Res.json()) as {
+    uploadUrl?: string;
+    assetId?: string;
+    expiresAt?: string;
+    requiredHeaders?: Record<string, string>;
+  };
+  const { uploadUrl, assetId, requiredHeaders } = step1Json;
+  if (!uploadUrl || !assetId || !requiredHeaders) {
+    throw new Error(
+      `Builder.io signed-URL response missing required fields: ${JSON.stringify(Object.keys(step1Json))}`,
+    );
+  }
+  console.log(`[builder-upload] step 1 ok: assetId=${assetId}`);
 
   // Step 2 — PUT bytes directly to GCS. Only requiredHeaders; no Authorization
   // (signed URL carries its own auth — extra signed headers break the signature).

--- a/packages/core/src/file-upload/builder.ts
+++ b/packages/core/src/file-upload/builder.ts
@@ -84,7 +84,7 @@ async function uploadLargeFileViaSignedUrl(
 
   // Step 2 — PUT bytes directly to GCS. Only requiredHeaders; no Authorization
   // (signed URL carries its own auth — extra signed headers break the signature).
-  console.log(`[builder-upload] step 2: PUT ${mb}MB to GCS`);
+  console.log(`[builder-upload] step 2 [${assetId}]: PUT ${mb}MB to GCS`);
   const step2Res = await fetchWithTimeout(uploadUrl, {
     method: "PUT",
     headers: requiredHeaders,
@@ -92,7 +92,7 @@ async function uploadLargeFileViaSignedUrl(
   });
   await assertOk(step2Res, "GCS upload failed");
   console.log(
-    `[builder-upload] step 2 ok: GCS ${step2Res.status} etag=${step2Res.headers.get("etag") ?? "none"}`,
+    `[builder-upload] step 2 ok [${assetId}]: GCS ${step2Res.status} etag=${step2Res.headers.get("etag") ?? "none"}`,
   );
 
   // Step 3 — register the asset and get the CDN URL.
@@ -112,7 +112,7 @@ async function uploadLargeFileViaSignedUrl(
   const { url, id } = (await step3Res.json()) as { url?: string; id?: string };
   if (!url) throw new Error("Builder.io upload/complete returned no URL");
 
-  console.log(`[builder-upload] done: ${url}`);
+  console.log(`[builder-upload] done [${assetId}]: ${url}`);
   return { url, id, provider: "builder" };
 }
 

--- a/packages/core/src/file-upload/builder.ts
+++ b/packages/core/src/file-upload/builder.ts
@@ -1,12 +1,152 @@
-import type { FileUploadProvider } from "./types.js";
+import type {
+  FileUploadProvider,
+  FileUploadInput,
+  FileUploadResult,
+} from "./types.js";
 
 const DEFAULT_BUILDER_APP_HOST = "https://builder.io";
+
+/** Files larger than this are routed through the GCS signed-URL flow. */
+const LARGE_FILE_THRESHOLD_BYTES = 30 * 1024 * 1024;
+const UPLOAD_TIMEOUT_MS = 120_000;
+const SMALL_FILE_RETRY_DELAYS_MS = [600, 1800];
 
 function builderUploadHost(): string {
   return (
     process.env.BUILDER_APP_HOST ||
     process.env.BUILDER_PUBLIC_APP_HOST ||
     DEFAULT_BUILDER_APP_HOST
+  );
+}
+
+function makeBody(bytes: Uint8Array, mimeType: string): BodyInit {
+  return typeof Blob !== "undefined"
+    ? new Blob([bytes as unknown as BlobPart], { type: mimeType })
+    : (bytes as unknown as BodyInit);
+}
+
+function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), UPLOAD_TIMEOUT_MS);
+  return fetch(url, { ...init, signal: controller.signal }).finally(() =>
+    clearTimeout(timer),
+  );
+}
+
+async function assertOk(res: Response, label: string): Promise<void> {
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`${label} (${res.status}): ${body || res.statusText}`);
+  }
+}
+
+async function uploadLargeFileViaSignedUrl(
+  input: FileUploadInput,
+  privateKey: string,
+  bareMimeType: string,
+  bytes: Uint8Array,
+): Promise<FileUploadResult> {
+  const host = builderUploadHost();
+  const authHeader = { Authorization: `Bearer ${privateKey}` };
+  const name = input.filename ?? "upload";
+  const mb = (bytes.byteLength / (1024 * 1024)).toFixed(1);
+
+  console.log(
+    `[builder-upload] large-file path: ${name} ${mb}MB ${bareMimeType}`,
+  );
+
+  // Step 1 — request a signed URL.
+  console.log(`[builder-upload] step 1: requesting signed URL`);
+  const step1Res = await fetchWithTimeout(
+    new URL("/api/v1/upload/signed-url", host).toString(),
+    {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fileName: name,
+        contentType: bareMimeType,
+        size: bytes.byteLength,
+      }),
+    },
+  );
+  await assertOk(step1Res, "Builder.io signed-URL request failed");
+
+  const { uploadUrl, assetId, expiresAt, requiredHeaders } =
+    (await step1Res.json()) as {
+      uploadUrl: string;
+      assetId: string;
+      expiresAt: string;
+      requiredHeaders: Record<string, string>;
+    };
+  console.log(
+    `[builder-upload] step 1 ok: assetId=${assetId} expiresAt=${expiresAt}`,
+  );
+
+  // Step 2 — PUT bytes directly to GCS. Only requiredHeaders; no Authorization
+  // (signed URL carries its own auth — extra signed headers break the signature).
+  console.log(`[builder-upload] step 2: PUT ${mb}MB to GCS`);
+  const step2Res = await fetchWithTimeout(uploadUrl, {
+    method: "PUT",
+    headers: requiredHeaders,
+    body: makeBody(bytes, bareMimeType),
+  });
+  await assertOk(step2Res, "GCS upload failed");
+  console.log(
+    `[builder-upload] step 2 ok: GCS ${step2Res.status} etag=${step2Res.headers.get("etag") ?? "none"}`,
+  );
+
+  // Step 3 — register the asset and get the CDN URL.
+  console.log(
+    `[builder-upload] step 3: registering asset - ${assetId}, ${input.filename}`,
+  );
+  const step3Res = await fetchWithTimeout(
+    new URL("/api/v1/upload/complete", host).toString(),
+    {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ assetId, name: input.filename }),
+    },
+  );
+  await assertOk(step3Res, "Builder.io upload complete failed");
+
+  const { url, id } = (await step3Res.json()) as { url?: string; id?: string };
+  if (!url) throw new Error("Builder.io upload/complete returned no URL");
+
+  console.log(`[builder-upload] done: ${url}`);
+  return { url, id, provider: "builder" };
+}
+
+// Retry transient 5xx once with backoff. Builder.io's upload service
+// occasionally returns a bodyless 500 ("Internal Error") on the first
+// attempt — usually GCS write hiccups that succeed on retry.
+async function uploadSmallFile(url: URL, init: RequestInit): Promise<Response> {
+  let response: Response | null = null;
+  let lastErrorBody = "";
+
+  for (
+    let attempt = 0;
+    attempt <= SMALL_FILE_RETRY_DELAYS_MS.length;
+    attempt++
+  ) {
+    const retryDelay = SMALL_FILE_RETRY_DELAYS_MS[attempt]; // undefined on last attempt
+    try {
+      response = await fetchWithTimeout(url.toString(), init);
+    } catch (err) {
+      if (!retryDelay) throw err;
+      await new Promise((r) => setTimeout(r, retryDelay));
+      continue;
+    }
+    if (response.ok) return response;
+    lastErrorBody = await response.text().catch(() => "");
+    const isTransient = response.status >= 500 && response.status !== 501;
+    if (!isTransient || !retryDelay) break;
+    await new Promise((r) => setTimeout(r, retryDelay));
+  }
+
+  const status = response?.status ?? 0;
+  const statusText = response?.statusText ?? "no response";
+  throw new Error(
+    `Builder.io upload failed (${status}): ${lastErrorBody || statusText}`,
   );
 }
 
@@ -22,16 +162,13 @@ export const builderFileUploadProvider: FileUploadProvider = {
   id: "builder",
   name: "Builder.io",
   isConfigured: () => !!process.env.BUILDER_PRIVATE_KEY,
-  upload: async ({ data, filename, mimeType }) => {
+  upload: async ({ data, filename, mimeType }: FileUploadInput) => {
     const { resolveBuilderPrivateKey } =
       await import("../server/credential-provider.js");
     const privateKey = await resolveBuilderPrivateKey();
     if (!privateKey) {
       throw new Error("BUILDER_PRIVATE_KEY is not set");
     }
-
-    const url = new URL("/api/v1/upload", builderUploadHost());
-    if (filename) url.searchParams.set("name", filename);
 
     // Strip any media-type parameters (e.g. `;codecs=avc1,opus` from
     // MediaRecorder blobs) — Builder's upload API parses the body as raw
@@ -43,74 +180,42 @@ export const builderFileUploadProvider: FileUploadProvider = {
       .split(";")[0]
       .trim();
 
-    const buffer =
+    const bytes =
       data instanceof Uint8Array ? data : new Uint8Array(data as any);
-    const bytes = new Uint8Array(
-      buffer.buffer,
-      buffer.byteOffset,
-      buffer.byteLength,
-    );
-    const body =
-      typeof Blob !== "undefined"
-        ? new Blob([bytes], { type: bareMimeType })
-        : (bytes as unknown as BodyInit);
+    const mb = (bytes.byteLength / (1024 * 1024)).toFixed(1);
 
-    // Retry transient 5xx once with backoff. Builder.io's upload service
-    // occasionally returns a bodyless 500 ("Internal Error") on the first
-    // attempt — usually GCS write hiccups that succeed on retry. We bound
-    // it tight so a deterministic 500 surfaces quickly to the caller.
-    const RETRY_DELAYS_MS = [600, 1800];
-    const UPLOAD_TIMEOUT_MS = 120_000; // 2 minutes per attempt
-    let response: Response | null = null;
-    let lastErrorBody = "";
-    for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), UPLOAD_TIMEOUT_MS);
-      try {
-        response = await fetch(url, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${privateKey}`,
-            "Content-Type": bareMimeType,
-          },
-          body,
-          signal: controller.signal,
-        });
-      } catch (err) {
-        clearTimeout(timer);
-        const isLastAttempt = attempt === RETRY_DELAYS_MS.length;
-        if (isLastAttempt) throw err;
-        await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt]));
-        continue;
-      }
-      clearTimeout(timer);
-      if (response.ok) break;
-      const isTransient = response.status >= 500 && response.status !== 501;
-      const isLastAttempt = attempt === RETRY_DELAYS_MS.length;
-      if (!isTransient || isLastAttempt) {
-        lastErrorBody = await response.text().catch(() => "");
-        break;
-      }
-      lastErrorBody = await response.text().catch(() => "");
-      await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt]));
-    }
-
-    if (!response || !response.ok) {
-      const status = response?.status ?? 0;
-      const statusText = response?.statusText ?? "no response";
-      throw new Error(
-        `Builder.io upload failed (${status}): ${lastErrorBody || statusText}`,
+    if (bytes.byteLength > LARGE_FILE_THRESHOLD_BYTES) {
+      return uploadLargeFileViaSignedUrl(
+        { data, filename, mimeType },
+        privateKey,
+        bareMimeType,
+        bytes,
       );
     }
+
+    console.log(
+      `[builder-upload] small-file path: ${filename ?? "upload"} ${mb}MB ${bareMimeType}`,
+    );
+
+    const url = new URL("/api/v1/upload", builderUploadHost());
+    if (filename) url.searchParams.set("name", filename);
+
+    const response = await uploadSmallFile(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${privateKey}`,
+        "Content-Type": bareMimeType,
+      },
+      body: makeBody(bytes, bareMimeType),
+    });
 
     const json = (await response.json().catch(() => ({}))) as {
       url?: string;
       id?: string;
     };
-    if (!json.url) {
-      throw new Error("Builder.io upload returned no URL");
-    }
+    if (!json.url) throw new Error("Builder.io upload returned no URL");
 
+    console.log(`[builder-upload] done: ${json.url}`);
     return { url: json.url, id: json.id, provider: "builder" };
   },
 };

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -28,6 +28,7 @@ import {
 } from "../server/lib/faststart.js";
 import { debugLog } from "../server/lib/debug.js";
 import requestTranscript from "./request-transcript.js";
+import { MAX_UPLOAD_BYTES as MAX_RECORDING_UPLOAD_BYTES } from "@shared/upload-limits.js";
 
 /**
  * Decode a base64 string back into a Uint8Array.
@@ -74,7 +75,6 @@ function chunkIndexFromKey(key: string): number {
 
 const STORAGE_SETUP_REQUIRED_REASON =
   "Video storage is not connected yet. Connect Builder.io or configure S3-compatible storage to upload and finish saving this clip.";
-const MAX_RECORDING_UPLOAD_BYTES = 64 * 1024 * 1024;
 const RECORDING_TOO_LARGE_REASON =
   "Recording is too large to process after automatic compression. Please update the app and try again, or record a shorter clip.";
 

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -9,6 +9,7 @@
 import { appBasePath, captureClientException } from "@agent-native/core/client";
 import {
   COMPRESS_THRESHOLD_BYTES,
+  COMPRESSION_ENABLED,
   MAX_UPLOAD_BYTES,
   compressBlobIfTooLarge,
   formatMb,
@@ -930,7 +931,10 @@ export class RecorderEngine {
     let result: Record<string, unknown> | undefined;
     let completed = false;
     try {
-      if (this.totalRecordedBytes > COMPRESS_THRESHOLD_BYTES) {
+      if (
+        COMPRESSION_ENABLED &&
+        this.totalRecordedBytes > COMPRESS_THRESHOLD_BYTES
+      ) {
         // Compress before the first server upload so large recordings don't
         // stage their uncompressed source in SQL.
         result = await this.compressAndReupload(finalizeMeta);
@@ -1044,7 +1048,10 @@ export class RecorderEngine {
     meta: RecordingFinalizeMeta,
     signal?: AbortSignal,
   ): Promise<Record<string, unknown> | undefined> {
-    if (this.totalRecordedBytes > COMPRESS_THRESHOLD_BYTES) {
+    if (
+      COMPRESSION_ENABLED &&
+      this.totalRecordedBytes > COMPRESS_THRESHOLD_BYTES
+    ) {
       return this.compressAndReupload(meta);
     }
 

--- a/templates/clips/app/lib/compress.ts
+++ b/templates/clips/app/lib/compress.ts
@@ -46,16 +46,29 @@ import {
   resetFfmpegInstance,
 } from "./ffmpeg-export";
 
+/**
+ * Master switch for browser-side compression.
+ *
+ * Builder's upload provider now handles large files directly (>30 MB go
+ * through the GCS signed-URL flow in `packages/core/src/file-upload/builder.ts`),
+ * so we no longer need to shrink recordings client-side. ffmpeg.wasm transcode
+ * is slow, so it stays off.
+ *
+ * Flip to `true` to re-enable the threshold-based compression path. When off,
+ * `compressBlobIfTooLarge` is a pass-through and the `MAX_UPLOAD_BYTES`
+ * hard-stop is skipped so large recordings upload as-is.
+ */
+export const COMPRESSION_ENABLED = false;
+
 /** Start compressing at 24 MB. Below this, the upload clears Builder's ~32 MB
  * Cloud Run edge cap and we don't pay for ffmpeg.wasm load + transcode. */
 export const COMPRESS_THRESHOLD_BYTES = 24 * 1024 * 1024;
 
-/** Clips' effective per-recording upload limit. Builder's upload endpoint is
- * fronted by a Gen-2 Cloud Function (Cloud Run) with a hard ~32 MB inbound
- * request cap that the app config can't raise, so we hard-stop just under it.
- * Anything larger needs an S3-compatible provider or a resumable Builder flow
- * (separate work) — failing fast here beats an opaque Builder 500. */
-export const MAX_UPLOAD_BYTES = 30 * 1024 * 1024;
+// The per-recording upload ceiling lives in `@shared/upload-limits`
+// (MAX_UPLOAD_BYTES) — it's shared with the server routes and actions and is
+// env-overridable. Re-exported here so existing `@/lib/compress` importers
+// keep working.
+export { MAX_UPLOAD_BYTES } from "@shared/upload-limits";
 
 /** Preferred compressed output size. The hard cap above leaves room for
  * encoder variance and container overhead. */
@@ -346,7 +359,7 @@ export async function compressBlobIfTooLarge(
   const threshold = opts.thresholdBytes ?? COMPRESS_THRESHOLD_BYTES;
   const originalBytes = input.size;
 
-  if (originalBytes <= threshold) {
+  if (!COMPRESSION_ENABLED || originalBytes <= threshold) {
     return {
       blob: input,
       compressed: false,

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/lib/recording-title";
 import {
   COMPRESS_THRESHOLD_BYTES,
+  COMPRESSION_ENABLED,
   MAX_UPLOAD_BYTES,
   compressBlobIfTooLarge,
   formatMb,
@@ -582,11 +583,20 @@ function RecordingErrorCard({
       )}
 
       <div className="space-y-3 p-6">
-        {uploadFailure && canDownloadRecording && (
-          <Button onClick={onDownloadRecording} className="w-full gap-2">
-            <IconDownload className="h-4 w-4" />
-            Download recording
-          </Button>
+        {/* Offer the download whenever local recording data survives, no matter
+            why the upload failed — the user should never lose their video. They
+            can re-import the saved file later via "Upload a video file". */}
+        {canDownloadRecording && (
+          <>
+            <Button onClick={onDownloadRecording} className="w-full gap-2">
+              <IconDownload className="h-4 w-4" />
+              Download recording
+            </Button>
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              Your recording is safe on this device. Download it now and upload
+              the file later from the recorder if it still won&apos;t save.
+            </p>
+          </>
         )}
         <Button variant="outline" onClick={onTryAgain} className="w-full gap-2">
           <IconRefresh className="h-4 w-4" />
@@ -1164,7 +1174,7 @@ export default function RecordRoute() {
         } | null = null;
         let uploadTooLargeDetail: string | undefined;
 
-        if (file.size > COMPRESS_THRESHOLD_BYTES) {
+        if (COMPRESSION_ENABLED && file.size > COMPRESS_THRESHOLD_BYTES) {
           setUiState("compressing");
           const compression = await compressBlobIfTooLarge(file, mimeType, {
             width: meta.width,
@@ -1216,7 +1226,7 @@ export default function RecordRoute() {
           }
           setCompressionProgress(null);
         }
-        if (uploadBlob.size > MAX_UPLOAD_BYTES) {
+        if (COMPRESSION_ENABLED && uploadBlob.size > MAX_UPLOAD_BYTES) {
           throw new Error(
             uploadTooLargeMessage(uploadBlob.size, uploadTooLargeDetail),
           );

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -28,11 +28,8 @@ const QUICKTIME_RECORDING_MIME_TYPE: &str = "video/quicktime";
 const MP4_RECORDING_MIME_TYPE: &str = "video/mp4";
 // Keep native chunks comfortably under serverless request/event limits.
 const UPLOAD_CHUNK_BYTES: usize = 3 * 1024 * 1024;
-// Master switch for native transcoding/compression. Builder's upload provider
-// now handles large files directly (signed-URL flow), so we upload native
-// recordings as-is instead of paying the slow ffmpeg/avconvert transcode.
-// Flip to `true` to re-enable the threshold-based transcode path below.
-const COMPRESSION_ENABLED: bool = false;
+// Master switch for native transcoding/compression.
+const COMPRESSION_ENABLED: bool = true;
 const TRANSCODE_THRESHOLD_BYTES: u64 = 24 * 1024 * 1024;
 const TARGET_UPLOAD_BYTES: u64 = 18 * 1024 * 1024;
 // Mirror of the shared `MAX_UPLOAD_BYTES` limit (see

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -28,9 +28,17 @@ const QUICKTIME_RECORDING_MIME_TYPE: &str = "video/quicktime";
 const MP4_RECORDING_MIME_TYPE: &str = "video/mp4";
 // Keep native chunks comfortably under serverless request/event limits.
 const UPLOAD_CHUNK_BYTES: usize = 3 * 1024 * 1024;
+// Master switch for native transcoding/compression. Builder's upload provider
+// now handles large files directly (signed-URL flow), so we upload native
+// recordings as-is instead of paying the slow ffmpeg/avconvert transcode.
+// Flip to `true` to re-enable the threshold-based transcode path below.
+const COMPRESSION_ENABLED: bool = false;
 const TRANSCODE_THRESHOLD_BYTES: u64 = 24 * 1024 * 1024;
 const TARGET_UPLOAD_BYTES: u64 = 18 * 1024 * 1024;
-const SERVER_STAGING_LIMIT_BYTES: u64 = 30 * 1024 * 1024;
+// Mirror of the shared `MAX_UPLOAD_BYTES` limit (see
+// `templates/clips/shared/upload-limits.ts`). Same default (256 MB) and same
+// env var (CLIPS_MAX_UPLOAD_BYTES) so desktop and web stay in lockstep.
+const DEFAULT_MAX_UPLOAD_BYTES: u64 = 256 * 1024 * 1024;
 const MIN_TRANSCODE_VIDEO_RATE_KBPS: u32 = 350;
 const TRANSCODE_RATE_LIMIT_OVERHEAD_KBPS: f64 = 64.0;
 const TRANSCODE_FRAME_RATE_LIMIT: u32 = 30;
@@ -2154,7 +2162,7 @@ fn prepare_recording_file(
         temporary: false,
     };
 
-    if source_bytes < TRANSCODE_THRESHOLD_BYTES {
+    if !COMPRESSION_ENABLED || source_bytes < TRANSCODE_THRESHOLD_BYTES {
         return Ok(original);
     }
 
@@ -2206,7 +2214,7 @@ fn prepare_recording_file(
                         );
                         continue;
                     }
-                    if compressed_bytes > SERVER_STAGING_LIMIT_BYTES {
+                    if compressed_bytes > max_upload_bytes() {
                         let _ = std::fs::remove_file(&compressed_path);
                         eprintln!(
                             "[clips-tray] ffmpeg {} still above server staging limit ({} bytes)",
@@ -2288,7 +2296,7 @@ fn prepare_recording_file(
                         );
                         continue;
                     }
-                    if compressed_bytes > SERVER_STAGING_LIMIT_BYTES {
+                    if compressed_bytes > max_upload_bytes() {
                         let _ = std::fs::remove_file(&compressed_path);
                         eprintln!(
                             "[clips-tray] avconvert {} still above server staging limit ({} bytes)",
@@ -2331,14 +2339,14 @@ fn prepare_recording_file(
     } else {
         eprintln!("[clips-tray] avconvert unavailable");
     }
-    if source_bytes > SERVER_STAGING_LIMIT_BYTES {
+    if source_bytes > max_upload_bytes() {
         let attempt_detail = smallest_attempt_bytes
             .map(|bytes| format!(", smallest compressed result was {}", format_mb(bytes)))
             .unwrap_or_default();
         return Err(format!(
             "Native recording is too large to upload after automatic compression (source {}, limit is {}{}). Try a shorter recording.",
             format_mb(source_bytes),
-            format_mb(SERVER_STAGING_LIMIT_BYTES),
+            format_mb(max_upload_bytes()),
             attempt_detail
         ));
     }
@@ -2364,6 +2372,16 @@ struct FfmpegTranscodePreset {
     encoder_preset: &'static str,
     audio_bitrate_kbps: u32,
     max_video_rate_kbps: u32,
+}
+
+/// Maximum total bytes a recording upload may be. Overridable per-deployment
+/// with the `CLIPS_MAX_UPLOAD_BYTES` env var; falls back to 256 MB.
+fn max_upload_bytes() -> u64 {
+    std::env::var("CLIPS_MAX_UPLOAD_BYTES")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|&bytes| bytes > 0)
+        .unwrap_or(DEFAULT_MAX_UPLOAD_BYTES)
 }
 
 fn resolve_ffmpeg_path() -> Option<String> {

--- a/templates/clips/server/routes/api/uploads/[recordingId]/chunk.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/chunk.post.ts
@@ -34,8 +34,7 @@ import {
   writeAppState,
 } from "@agent-native/core/application-state";
 import finalizeRecording from "../../../../../actions/finalize-recording.js";
-
-const MAX_RECORDING_UPLOAD_BYTES = 64 * 1024 * 1024;
+import { MAX_UPLOAD_BYTES as MAX_RECORDING_UPLOAD_BYTES } from "@shared/upload-limits.js";
 const RECORDING_TOO_LARGE_REASON =
   "Recording is too large to process after automatic compression. Please update the app and try again, or record a shorter clip.";
 

--- a/templates/clips/server/routes/api/uploads/[recordingId]/chunk.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/chunk.post.ts
@@ -35,8 +35,7 @@ import {
 } from "@agent-native/core/application-state";
 import finalizeRecording from "../../../../../actions/finalize-recording.js";
 import { MAX_UPLOAD_BYTES as MAX_RECORDING_UPLOAD_BYTES } from "@shared/upload-limits.js";
-const RECORDING_TOO_LARGE_REASON =
-  "Recording is too large to process after automatic compression. Please update the app and try again, or record a shorter clip.";
+const RECORDING_TOO_LARGE_REASON = `Recording exceeds the ${Math.round(MAX_RECORDING_UPLOAD_BYTES / (1024 * 1024))} MB size limit. Please record a shorter clip.`;
 
 const ALLOWED_RECORDING_MIME_TYPES = new Set([
   "video/webm",

--- a/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
@@ -39,8 +39,7 @@ import {
   writeAppState,
   deleteAppStateByPrefix,
 } from "@agent-native/core/application-state";
-
-const MAX_RECORDING_UPLOAD_BYTES = 64 * 1024 * 1024;
+import { MAX_UPLOAD_BYTES as MAX_RECORDING_UPLOAD_BYTES } from "@shared/upload-limits.js";
 
 interface CompressionMeta {
   originalBytes?: number;

--- a/templates/clips/shared/upload-limits.ts
+++ b/templates/clips/shared/upload-limits.ts
@@ -1,0 +1,35 @@
+/**
+ * Single source of truth for the maximum recording / file upload size.
+ *
+ * Override per-deployment with the `CLIPS_MAX_UPLOAD_BYTES` env var (a byte
+ * count). This is read server-side and at build time; the browser pre-flight
+ * check falls back to the default when `process.env` is unavailable, but the
+ * server routes (chunk / reset-chunks / finalize) are the authoritative gate.
+ *
+ * Importable from the client (`@shared/upload-limits`), server routes, and
+ * actions. The Rust desktop app mirrors this limit independently in
+ * `desktop/src-tauri/src/native_screen.rs` (same env var, same default).
+ */
+
+/** Default maximum upload size: 256 MB. */
+export const DEFAULT_MAX_UPLOAD_BYTES = 256 * 1024 * 1024;
+
+/** Env var that overrides the upload ceiling, in bytes. */
+export const MAX_UPLOAD_BYTES_ENV = "CLIPS_MAX_UPLOAD_BYTES";
+
+function resolveMaxUploadBytes(): number {
+  const raw =
+    typeof process !== "undefined"
+      ? process.env?.[MAX_UPLOAD_BYTES_ENV]
+      : undefined;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.floor(parsed);
+    }
+  }
+  return DEFAULT_MAX_UPLOAD_BYTES;
+}
+
+/** Maximum total bytes a single recording / file upload may be. */
+export const MAX_UPLOAD_BYTES = resolveMaxUploadBytes();


### PR DESCRIPTION
Clips recordings can now upload at full quality up to **256 MB**, without the slow in-browser/native compression step that used to run on every large clip.

Builder's old upload endpoint sat behind a ~32 MB request cap, so anything bigger had to be shrunk first with ffmpeg. That transcode is slow and lossy, and very large clips would still fail.

Builder's upload provider can now send large files straight to storage via a signed-URL flow, so we no longer need to compress before uploading.

## Changes

- **Builder upload provider** (`packages/core`): files over 30 MB now use a 3-step signed-URL flow (request URL → upload directly to storage → register the asset). Smaller files keep the existing direct-POST path with its retry logic. Both paths share the same timeout and request helpers.
- **Compression turned off** behind a single `COMPRESSION_ENABLED` flag in the web recorder (`compress.ts`) Flip it back to `true` to restore the old behavior — nothing was deleted.
- **One shared upload limit**: new `shared/upload-limits.ts` exports `MAX_UPLOAD_BYTES` (default 256 MB, override with `CLIPS_MAX_UPLOAD_BYTES`). The server routes, finalize action, and web client all import it; the Rust desktop app mirrors the same default and env var.
- **Better failure UX**: the "Download recording" button on the error card now shows whenever the recording still exists locally, regardless of why the upload failed - so users never lose a clip. Added a short note telling them they can re-upload the file later.