### PR TITLE
Fix plan template: migration crash loop and test file in routes

### DIFF
--- a/templates/plan/app/plan-detail-meta.test.ts
+++ b/templates/plan/app/plan-detail-meta.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("../../server/lib/plan-meta.server", () => ({
+vi.mock("../server/lib/plan-meta.server", () => ({
   fetchPublicPlanMeta: vi.fn(),
 }));
 
-import { meta as planMeta } from "./plans.$id";
-import { meta as recapMeta } from "./recaps.$id";
+import { meta as planMeta } from "./routes/plans.$id";
+import { meta as recapMeta } from "./routes/recaps.$id";
 
 type MetaEntry = Record<string, string>;
 

--- a/templates/plan/server/plugins/db.ts
+++ b/templates/plan/server/plugins/db.ts
@@ -270,17 +270,9 @@ CREATE INDEX IF NOT EXISTS plan_reports_status_updated_idx ON plan_reports(statu
     },
     {
       version: 28,
-      sql: {
-        postgres: `ALTER TABLE plan_comments ADD COLUMN IF NOT EXISTS deleted_at TEXT;
+      sql: `ALTER TABLE plan_comments ADD COLUMN IF NOT EXISTS deleted_at TEXT;
 ALTER TABLE plan_comments ADD COLUMN IF NOT EXISTS deleted_by TEXT;
 CREATE INDEX IF NOT EXISTS plan_comments_plan_deleted_created_idx ON plan_comments(plan_id, deleted_at, created_at)`,
-        // SQLite has no ADD COLUMN IF NOT EXISTS. runMigrations only executes a
-        // version once per database, so plain ADD COLUMN is the established
-        // additive pattern here.
-        sqlite: `ALTER TABLE plan_comments ADD COLUMN deleted_at TEXT;
-ALTER TABLE plan_comments ADD COLUMN deleted_by TEXT;
-CREATE INDEX IF NOT EXISTS plan_comments_plan_deleted_created_idx ON plan_comments(plan_id, deleted_at, created_at)`,
-      },
     },
     {
       version: 29,


### PR DESCRIPTION
### Fix 'Plan' template migration v28 crash loop

The SQLite implementation of migration v28 used a plain `ADD COLUMN` statement without idempotency. If the migration successfully added the column but crashed before recording the migration version, every subsequent startup would retry v28 and fail with a `duplicate column name` error, resulting in an infinite restart loop.

This change unifies both database dialects to use `ADD COLUMN IF NOT EXISTS`. `runMigrations` already emulates this behavior for SQLite by stripping the clause and ignoring duplicate-column errors for statements that originally included it.

### Fix Vitest mocker error during dev startup

`plan-detail-meta.test.ts` was located under `app/routes/`, causing React Router's file-based router to treat it as a route module. During development, Vite loaded the file in its SSR module runner environment, where `vi.mock()` and `vi.queueMock()` are not initialized, triggering startup errors.

The test has been moved to `app/plan-detail-meta.test.ts`, and imports were updated accordingly. Vitest continues to discover the file through the existing `**/*.test.ts` glob pattern.
