### PR TITLE
Prevent repeated provider sweeps from looping

### DIFF
--- a/.changeset/source-sweep-convergence.md
+++ b/.changeset/source-sweep-convergence.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stop repeated read-only source sweeps from looping indefinitely by forcing a final coverage summary after the same provider/search tool is called many times in one turn.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -9,6 +9,7 @@ import {
   isRetryableError,
   resolveAgentOwnerEmail,
   runAgentLoop,
+  shouldGuardRepeatedSourceSweep,
   structuredHistoryToEngineMessages,
   trimOldToolResults,
   type ActionEntry,
@@ -1014,6 +1015,141 @@ describe("runAgentLoop", () => {
       }),
     );
     expect(events).toContainEqual({ type: "text", text: "reported the gap" });
+  });
+
+  it("detects repeated read-only source sweeps but ignores ordinary helpers", () => {
+    const priorToolCalls = Array.from({ length: 12 }, (_, i) => ({
+      name: "gong-calls",
+      input: { company: `Account ${i + 1}` },
+    }));
+
+    expect(
+      shouldGuardRepeatedSourceSweep({
+        toolName: "gong-calls",
+        entry: actionEntry({ readOnly: true }),
+        priorToolCalls,
+      }),
+    ).toMatchObject({
+      toolName: "gong-calls",
+      priorCalls: 12,
+      message: expect.stringContaining("Finaliz"),
+    });
+
+    expect(
+      shouldGuardRepeatedSourceSweep({
+        toolName: "read-attachment",
+        entry: actionEntry({ readOnly: true }),
+        priorToolCalls: priorToolCalls.map((call) => ({
+          ...call,
+          name: "read-attachment",
+        })),
+      }),
+    ).toBeNull();
+
+    expect(
+      shouldGuardRepeatedSourceSweep({
+        toolName: "search-records",
+        entry: actionEntry({ readOnly: false }),
+        priorToolCalls: priorToolCalls.map((call) => ({
+          ...call,
+          name: "search-records",
+        })),
+      }),
+    ).toBeNull();
+  });
+
+  it("forces a final coverage summary instead of continuing a repeated source sweep", async () => {
+    let streamCalls = 0;
+    const seenMessages: unknown[] = [];
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(opts): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        seenMessages.push(opts.messages);
+        const serializedMessages = JSON.stringify(opts.messages);
+        if (serializedMessages.includes("convergence budget")) {
+          yield {
+            type: "text-delta",
+            text: "Partial coverage: report the hits and gaps.",
+          };
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "text" as const,
+                text: "Partial coverage: report the hits and gaps.",
+              },
+            ],
+          };
+          yield { type: "stop", reason: "end_turn" };
+          return;
+        }
+        yield {
+          type: "assistant-content",
+          parts: [
+            {
+              type: "tool-call" as const,
+              id: `gong-${streamCalls}`,
+              name: "gong-calls",
+              input: { company: `Account ${streamCalls}` },
+            },
+          ],
+        };
+        yield { type: "stop", reason: "tool_use" };
+      },
+    };
+    const gongCalls = vi.fn(async (args) => ({
+      company: args.company,
+      transcriptSearch: { matchingCalls: 0, inspectedCalls: 5 },
+    }));
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "scan this provider cohort" }],
+        },
+      ],
+      actions: {
+        "gong-calls": {
+          ...actionEntry({ readOnly: true }),
+          run: gongCalls,
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(gongCalls).toHaveBeenCalledTimes(12);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "gong-calls",
+        result: expect.stringContaining("convergence budget"),
+      }),
+    );
+    expect(events).toContainEqual({
+      type: "text",
+      text: "Partial coverage: report the hits and gaps.",
+    });
+    expect(JSON.stringify(seenMessages.at(-1))).toContain(
+      "Do not call more tools",
+    );
   });
 
   it("retries identical read-only tools when the continuation history result was aborted", async () => {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -711,6 +711,7 @@ const MAX_SELECTION_CONTEXT_CHARS = 8_000;
 const MAX_RESOURCE_INVENTORY_ITEMS = 40;
 const MAX_RESOURCE_INVENTORY_DESCRIPTION_CHARS = 160;
 const MAX_INLINE_SKILL_REFERENCE_CHARS = 40_000;
+const SOURCE_SWEEP_TOOL_CALL_THRESHOLD = 12;
 
 /**
  * Hard cap on the `<current-screen>` block injected into EVERY user message.
@@ -1730,6 +1731,87 @@ function rateLimitRecoveryHint(message: string): string {
   return "\n\nProvider rate-limit guidance: stop retrying this provider in this turn. Report the rate limit as a coverage gap, include any evidence already gathered, and ask the user to retry after the provider quota resets if full coverage is required.";
 }
 
+const SOURCE_SWEEP_TOOL_NAME =
+  /\b(?:api|calls?|deals?|events?|issues?|messages?|metrics?|provider|query|records?|request|search|tickets?|transcripts?)\b/i;
+
+const SOURCE_SWEEP_PROVIDER_TOKEN =
+  /\b(?:amplitude|apollo|bigquery|commonroom|data-source|ga4|github|gong|grafana|hubspot|jira|mixpanel|notion|posthog|postgres|postgresql|pylon|sentry|slack|stripe)\b/i;
+
+const SOURCE_SWEEP_EXCLUDED_TOOLS = new Set([
+  "chat-history",
+  "list-staged-datasets",
+  "manage-agent-engine",
+  "manage-agent-loop-settings",
+  "manage-automations",
+  "manage-jobs",
+  "manage-notifications",
+  "manage-progress",
+  "read-attachment",
+  "refresh-screen",
+  "resources",
+  "tool-search",
+  "view-screen",
+]);
+
+function normalizeToolNameForHeuristics(name: string): string {
+  return name.replace(/[_-]+/g, " ");
+}
+
+function isLikelySourceSweepTool(
+  name: string,
+  entry: ActionEntry | undefined,
+): boolean {
+  if (!entry || entry.readOnly !== true) return false;
+  const lower = name.toLowerCase();
+  if (SOURCE_SWEEP_EXCLUDED_TOOLS.has(lower)) return false;
+  const normalized = normalizeToolNameForHeuristics(lower);
+  return (
+    SOURCE_SWEEP_PROVIDER_TOKEN.test(normalized) ||
+    SOURCE_SWEEP_TOOL_NAME.test(normalized)
+  );
+}
+
+export function repeatedSourceSweepGuardMessage(opts: {
+  toolName: string;
+  priorCalls: number;
+  threshold?: number;
+}): string {
+  const threshold = opts.threshold ?? SOURCE_SWEEP_TOOL_CALL_THRESHOLD;
+  return (
+    `Skipped ${opts.toolName}: this turn already made ${opts.priorCalls} ` +
+    `call(s) to the same read-only source/search tool, which exceeds the ` +
+    `${threshold}-call convergence budget. Do not call more tools for this ` +
+    `sweep. Finalize now from the evidence already gathered: answer the user, ` +
+    `state the source filters, count what was inspected, list confirmed hits, ` +
+    `and explicitly name remaining gaps, timeouts, quotas, or uninspected ` +
+    `records. If complete coverage is still required, recommend a bulk/corpus ` +
+    `workflow or a follow-up retry instead of continuing one source call at a time.`
+  );
+}
+
+export function shouldGuardRepeatedSourceSweep(opts: {
+  toolName: string;
+  entry: ActionEntry | undefined;
+  priorToolCalls: readonly AgentLoopToolCallSummary[];
+  threshold?: number;
+}): { toolName: string; priorCalls: number; message: string } | null {
+  if (!isLikelySourceSweepTool(opts.toolName, opts.entry)) return null;
+  const threshold = opts.threshold ?? SOURCE_SWEEP_TOOL_CALL_THRESHOLD;
+  const priorCalls = opts.priorToolCalls.filter(
+    (call) => call.name === opts.toolName,
+  ).length;
+  if (priorCalls < threshold) return null;
+  return {
+    toolName: opts.toolName,
+    priorCalls,
+    message: repeatedSourceSweepGuardMessage({
+      toolName: opts.toolName,
+      priorCalls,
+      threshold,
+    }),
+  };
+}
+
 function normalizeToolCallInputForHistory(
   input: unknown,
 ): Record<string, unknown> {
@@ -2140,9 +2222,18 @@ export async function runAgentLoop(opts: {
       toolCall: import("./engine/types.js").EngineToolCallPart,
     ): Promise<EngineContentPart> => {
       const wireToolInput = JSON.stringify(toolCall.input ?? {});
+      const normalizedToolInput = normalizeToolCallInputForHistory(
+        toolCall.input,
+      );
+      const actionEntry = actions[toolCall.name];
+      const sourceSweepGuard = shouldGuardRepeatedSourceSweep({
+        toolName: toolCall.name,
+        entry: actionEntry,
+        priorToolCalls: toolCallHistory,
+      });
       toolCallHistory.push({
         name: toolCall.name,
-        input: normalizeToolCallInputForHistory(toolCall.input),
+        input: normalizedToolInput,
       });
       const recordToolResult = (content: string, isError: boolean) => {
         toolResultHistory.push({
@@ -2151,7 +2242,24 @@ export async function runAgentLoop(opts: {
           isError,
         });
       };
-      const actionEntry = actions[toolCall.name];
+      if (sourceSweepGuard) {
+        const result = sourceSweepGuard.message;
+        send({
+          type: "tool_start",
+          tool: toolCall.name,
+          input: toolCall.input as Record<string, string>,
+        });
+        send({ type: "tool_done", tool: toolCall.name, result });
+        recordToolResult(result, false);
+        return {
+          type: "tool-result" as const,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          toolInput: wireToolInput,
+          content: result,
+        };
+      }
+
       if (!actionEntry) {
         const result = `Error: Unknown tool "${toolCall.name}"`;
         send({


### PR DESCRIPTION
## Summary
- add a framework-level guard that stops repeated read-only source/search sweeps from looping indefinitely
- return a synthetic tool result that tells the agent to finalize with inspected counts, hits, and coverage gaps
- add regression coverage for repeated source sweeps and normal helper exclusions

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/agent/production-agent.spec.ts
- pnpm --filter @agent-native/core exec vitest --run src/agent/production-agent.spec.ts src/provider-api/quota-governor.spec.ts src/provider-api/staging.spec.ts src/coding-tools/run-code.spec.ts
- pnpm --filter analytics exec vitest --run actions/provider-api-request.spec.ts server/lib/real-data-actions.spec.ts actions/gong-calls.spec.ts
- pnpm prep