### PR TITLE
Align Plan skill CLI modes

### DIFF
--- a/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
+++ b/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-native-visual-plans",
-  "version": "1.0.0+codex.238f3a29430e",
+  "version": "1.0.0+codex.a1d73c6d59b4",
   "description": "Create rich interactive visual plans and recaps with diagrams, file maps, annotated code and diffs, API/schema summaries, feedback, and HTML export.",
   "author": { "name": "Agent-Native", "url": "https://agent-native.com" },
   "homepage": "https://plan.agent-native.com",

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-recap/SKILL.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-recap/SKILL.md
@@ -448,6 +448,10 @@ A few recap-specific authoring rules the registry table cannot encode:
   shared optional `summary` / `editable` envelope; give a block a heading by
   placing a `rich-text` block with a Markdown `###` heading directly above it
   (blocks no longer take a `title`).
+- Every capitalized block component must be self-closing (`<RichText ... />`) or
+  explicitly closed around children (`<RichText ...>...</RichText>`). Never
+  leave a bare opening tag like `<RichText ...>` in a paragraph; MDX treats it
+  as unclosed JSX and import fails before the recap can render.
 - `Endpoint`: prose `description` is the MDX **children** (body between the
   tags), not an attribute; for a WebSocket upgrade use `method="GET"`. Each
   request/response `example` is a JSON **string** (the renderer parses it into

--- a/.changeset/local-plan-cli-modes.md
+++ b/.changeset/local-plan-cli-modes.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/skills": patch
+---
+
+Harden local Plan block authoring guidance and align the standalone skills CLI with hosted, local-files, and self-hosted Plan modes.

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -804,8 +804,9 @@ Usage:
                                 Recap workflow into .github/workflows/.
   agent-native recap <cmd>      PR visual recap setup and GitHub Action helpers.
                                 Run 'agent-native recap help' for subcommands.
-  agent-native plan local <cmd> DB-free local plan helpers.
-                                cmds: init | check | preview
+  agent-native plan <cmd>       Plan helpers for block catalogs and local files.
+                                cmds: blocks | local init | local check |
+                                local preview
   agent-native migrate <source> Create an Agent-Native Code /migrate session, or use
                                 --emit for a portable own-agent dossier.
   agent-native add-app [name]   Add one or more apps to the current workspace

--- a/packages/core/src/cli/plan-local.ts
+++ b/packages/core/src/cli/plan-local.ts
@@ -550,29 +550,69 @@ async function runBlocks(
   args: Record<string, string | boolean>,
 ): Promise<void> {
   const format = normalizePlanBlockFormat(optionalArg(args, "format"));
-  const result = await fetchPlanBlockCatalog({
-    appUrl:
-      optionalArg(args, "app-url") ||
-      process.env.PLAN_BLOCKS_APP_URL ||
-      process.env.PLAN_RECAP_APP_URL ||
-      DEFAULT_PLAN_APP_URL,
-    format,
-    out: optionalArg(args, "out") || defaultPlanBlocksOut(format),
-  });
-  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  const appUrl =
+    optionalArg(args, "app-url") ||
+    process.env.PLAN_BLOCKS_APP_URL ||
+    process.env.PLAN_RECAP_APP_URL ||
+    DEFAULT_PLAN_APP_URL;
+  const out = optionalArg(args, "out") || defaultPlanBlocksOut(format);
+  const useClack = Boolean(process.stdout.isTTY) && !boolArg(args, "json");
+  let stopSpinner: ((message?: string) => void) | undefined;
+  let clack: typeof import("@clack/prompts") | undefined;
+
+  if (useClack) {
+    clack = await import("@clack/prompts");
+    const spinner = clack.spinner();
+    spinner.start("Fetching Plan block catalog");
+    stopSpinner = (message?: string) => spinner.stop(message);
+  }
+
+  try {
+    const result = await fetchPlanBlockCatalog({
+      appUrl,
+      format,
+      out,
+    });
+    if (!useClack || !clack) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return;
+    }
+    stopSpinner?.("Fetched Plan block catalog");
+    clack.note(
+      [
+        `Output   ${path.resolve(result.out)}`,
+        `Format   ${result.format}`,
+        typeof result.count === "number" ? `Blocks   ${result.count}` : "",
+        "Privacy  No plan content sent",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+      "Plan block catalog",
+    );
+    clack.outro(`Wrote ${result.out}`);
+  } catch (error) {
+    if (useClack && clack) {
+      stopSpinner?.("Plan block catalog fetch failed");
+      clack.cancel(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+    throw error;
+  }
 }
 
 const HELP = `agent-native plan — local Agent-Native Plan helpers
 
 Usage:
-  agent-native plan blocks [--format reference|schema] [--app-url <url>] [--out <file>]
+  agent-native plan blocks [--format reference|schema] [--app-url <url>] [--out <file>] [--json]
   agent-native plan local init --title <title> [--brief <text>] [--kind plan|recap] [--dir <folder>] [--force]
   agent-native plan local check --dir <folder>
   agent-native plan local preview --dir <folder> [--out preview.html] [--kind plan|recap]
 
 The blocks command fetches the no-auth, read-only get-plan-blocks catalog from
 the Plan app and writes plan-blocks.md (or plan-blocks.schema.json). It sends no
-plan content and is safe for local-files authoring before writing MDX.
+plan content and is safe for local-files authoring before writing MDX. It uses a
+clack UI in interactive terminals and prints JSON for non-interactive shells or
+when --json is passed.
 
 The local subcommands are the privacy-focused no-DB path. They only read and
 write local files: plan.mdx, optional canvas.mdx, optional prototype.mdx, and

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -1924,6 +1924,10 @@ A few recap-specific authoring rules the registry table cannot encode:
   shared optional \`summary\` / \`editable\` envelope; give a block a heading by
   placing a \`rich-text\` block with a Markdown \`###\` heading directly above it
   (blocks no longer take a \`title\`).
+- Every capitalized block component must be self-closing (\`<RichText ... />\`) or
+  explicitly closed around children (\`<RichText ...>...</RichText>\`). Never
+  leave a bare opening tag like \`<RichText ...>\` in a paragraph; MDX treats it
+  as unclosed JSX and import fails before the recap can render.
 - \`Endpoint\`: prose \`description\` is the MDX **children** (body between the
   tags), not an attribute; for a WebSocket upgrade use \`method="GET"\`. Each
   request/response \`example\` is a JSON **string** (the renderer parses it into

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -6,18 +6,19 @@ Install BuilderIO skill folders into Codex and Claude skill directories.
 npx @agent-native/skills@latest add
 npx @agent-native/skills@latest add --skill quick-recap --client codex --scope project --update-instructions
 npx @agent-native/skills@latest add --skill visual-recap --client all --with-github-action
+npx @agent-native/skills@latest add --skill visual-plan --mode local-files
 ```
 
 Use `--skill <name>` one or more times to select specific skills, or omit it in
 an interactive terminal to choose from a prompt. Use `--client codex`,
 `--client claude-code`, or `--client all` to choose install targets; omitted
-`--client` defaults to all supported clients. Add `--update-instructions` to
-append an idempotent managed block to `AGENTS.md` and/or `CLAUDE.md` for
-instruction-style skills.
+`--client` defaults to all supported clients. For `visual-plan` and
+`visual-recap`, use `--mode hosted`, `--mode local-files`, or
+`--mode self-hosted --mcp-url <url>` to choose hosted sharing, all-local text
+files, or your own Plan app. Add `--update-instructions` to append an idempotent
+managed block to `AGENTS.md` and/or `CLAUDE.md` for instruction-style skills.
 
-Skill content comes from `BuilderIO/skills@main` at install/list time. That
-means adding or updating public skills such as `quick-recap` or
-`efficient-fable` in the skills repo is picked up by this CLI without publishing
-a new `@agent-native/skills` package. `visual-plan` and `visual-recap` are also
-installed from `BuilderIO/skills`; Agent Native syncs those two into the public
-repo from the framework source of truth.
+Skill content comes from `BuilderIO/skills@main` at install/list time for plain
+skill installs. Explicit `visual-plan` / `visual-recap` installs delegate to
+`@agent-native/core` so Plan mode selection, MCP registration, and local-files
+instructions stay in one framework-owned flow.

--- a/packages/skills/src/index.spec.ts
+++ b/packages/skills/src/index.spec.ts
@@ -97,6 +97,36 @@ describe("@agent-native/skills", () => {
     });
   });
 
+  it("parses Plan mode flags", () => {
+    expect(
+      parseSkillsCliArgs([
+        "add",
+        "--skill",
+        "visual-plan",
+        "--mode",
+        "self-hosted",
+        "--mcp-url",
+        "https://plans.example.com",
+      ]),
+    ).toMatchObject({
+      skillNames: ["visual-plan"],
+      planMode: "self-hosted",
+      mcpUrl: "https://plans.example.com",
+    });
+
+    expect(() =>
+      parseSkillsCliArgs([
+        "add",
+        "--skill",
+        "visual-plan",
+        "--mode",
+        "local-files",
+        "--mcp-url",
+        "https://plans.example.com",
+      ]),
+    ).toThrow("--mcp-url can only be used with --mode self-hosted");
+  });
+
   it("copies selected local skills into project client folders", async () => {
     const repo = tmpDir();
     const project = tmpDir();
@@ -308,6 +338,7 @@ describe("@agent-native/skills", () => {
       promptSkills: async () => ["visual-recap"],
       promptClients: async () => ["codex"],
       promptScope: async () => "project",
+      promptPlanMode: async () => "hosted",
       promptUpdateInstructions: async () => false,
       promptGithubAction,
     });
@@ -322,7 +353,7 @@ describe("@agent-native/skills", () => {
     ).toBe(true);
   });
 
-  it("installs public-repo-backed app skills directly when explicitly selected", async () => {
+  it("installs copied public-repo-backed app skills directly when explicitly selected", async () => {
     const repo = tmpDir();
     const project = tmpDir();
     writeSkill(repo, "visual-plan", "Live visual plan body");
@@ -367,6 +398,105 @@ describe("@agent-native/skills", () => {
         "utf-8",
       ),
     ).toContain("Live visual plan body");
+  });
+
+  it("delegates default visual-plan installs to agent-native core", async () => {
+    const project = tmpDir();
+    const previousDirect = process.env.AGENT_NATIVE_SKILLS_DIRECT;
+    delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
+
+    try {
+      await runSkillsCli(
+        [
+          "add",
+          "--skill",
+          "visual-plan",
+          "--client",
+          "codex",
+          "--scope",
+          "project",
+          "--mode",
+          "local-files",
+          "--yes",
+          "--json",
+        ],
+        { baseDir: project, isInteractive: () => false },
+      );
+    } finally {
+      if (previousDirect === undefined)
+        delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
+      else process.env.AGENT_NATIVE_SKILLS_DIRECT = previousDirect;
+    }
+
+    expect(runCoreSkills).toHaveBeenCalledWith(
+      [
+        "add",
+        "visual-plan",
+        "--client",
+        "codex",
+        "--scope",
+        "project",
+        "--yes",
+        "--json",
+        "--mode",
+        "local-files",
+      ],
+      {
+        baseDir: project,
+        isInteractive: expect.any(Function),
+      },
+    );
+  });
+
+  it("skips MCP registration for direct visual-plan local-files mode", async () => {
+    const repo = tmpDir();
+    const project = tmpDir();
+    writeSkill(repo, "visual-plan");
+
+    const result = await installSkills({
+      source: repo,
+      skillNames: ["visual-plan"],
+      clients: ["codex"],
+      scope: "project",
+      baseDir: project,
+      planMode: "local-files",
+      updateInstructions: false,
+      yes: true,
+    });
+
+    expect(result.planMode).toBe("local-files");
+    expect(result.mcpServers).toEqual([]);
+    expect(
+      fs.existsSync(
+        path.join(project, ".agents", "skills", "visual-plan", "SKILL.md"),
+      ),
+    ).toBe(true);
+  });
+
+  it("registers direct visual-plan installs against a self-hosted MCP URL", async () => {
+    const repo = tmpDir();
+    const project = tmpDir();
+    writeSkill(repo, "visual-plan");
+
+    const result = await installSkills({
+      source: repo,
+      skillNames: ["visual-plan"],
+      clients: ["claude-code"],
+      scope: "project",
+      baseDir: project,
+      planMode: "self-hosted",
+      mcpUrl: "https://plans.example.com/team",
+      updateInstructions: false,
+      connect: false,
+      yes: true,
+    });
+
+    expect(result.planMode).toBe("self-hosted");
+    expect(result.mcpServers).toHaveLength(1);
+    expect(result.mcpServers[0]).toMatchObject({
+      serverName: "plan",
+      mcpUrl: "https://plans.example.com/team/_agent-native/mcp",
+    });
   });
 
   it("describes skipped codex MCP auth as pending in the final output", async () => {
@@ -610,6 +740,7 @@ describe("@agent-native/skills", () => {
       },
       promptClients: async () => ["codex"],
       promptScope: async () => "project",
+      promptPlanMode: async () => "hosted",
       promptUpdateInstructions: async () => false,
     });
 

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -12,6 +12,7 @@ import { createCliTelemetry, type CliTelemetry } from "./telemetry.js";
 
 export type SkillClient = "codex" | "claude-code";
 export type SkillScope = "project" | "user";
+export type PlanMode = "hosted" | "local-files" | "self-hosted";
 
 export interface SkillEntry {
   name: string;
@@ -46,12 +47,16 @@ export interface InstallSkillsOptions {
   promptGithubAction?: (
     context: GithubActionPromptContext,
   ) => Promise<boolean | null>;
+  promptPlanMode?: (context: PlanModePromptContext) => Promise<PlanMode | null>;
+  promptPlanMcpUrl?: () => Promise<string | null>;
   /**
    * Register the hosted MCP server for app-backed skills (e.g. visual-plan /
    * visual-recap → the Agent-Native Plan MCP). Defaults to `true`; pass
    * `false` (CLI `--no-mcp`) to install the skill files only.
    */
   mcp?: boolean;
+  planMode?: PlanMode;
+  mcpUrl?: string;
 }
 
 export interface InstalledMcpServer {
@@ -73,6 +78,7 @@ export interface InstallSkillsResult {
   instructionFiles: string[];
   githubActionPath?: string;
   mcpServers: InstalledMcpServer[];
+  planMode?: PlanMode;
   dryRun: boolean;
 }
 
@@ -94,6 +100,8 @@ interface ParsedArgs {
   connect: boolean;
   baseDir?: string;
   mcp: boolean;
+  planMode?: PlanMode;
+  mcpUrl?: string;
 }
 
 interface PromptOption<T extends string> {
@@ -120,6 +128,10 @@ export interface GithubActionPromptContext {
   workflowPath: string;
 }
 
+export interface PlanModePromptContext {
+  initialMode: PlanMode;
+}
+
 const HELP = `@agent-native/skills
 
 Usage:
@@ -136,6 +148,8 @@ Options:
   --no-update-instructions    Skip managed instruction file updates
   --instructions-file <path>  File to receive managed instructions (repeatable)
   --with-github-action        Add .github/workflows/pr-visual-recap.yml when visual-recap is installed
+  --mode <mode>               visual-plan/visual-recap mode: hosted, local-files, or self-hosted
+  --mcp-url <url>             Self-hosted app/MCP URL for visual-plan/visual-recap
   --force                     Overwrite a different existing PR Visual Recap workflow
   --no-mcp                    Install skill files only; skip registering the app's MCP server
   --no-connect                Register MCP where possible but skip inline browser/device authentication
@@ -146,6 +160,8 @@ Options:
 App-backed skills (visual-plan, visual-recap, assets, design-exploration)
 register their hosted MCP server in your agent config by default so the agent
 can actually use them. Use --no-mcp to skip that and copy the files only.
+For visual-plan/visual-recap, choose --mode local-files for no sharing and all
+local files, or --mode self-hosted --mcp-url <url> for your own Plan app.
 
 Examples:
   npx @agent-native/skills@latest add
@@ -155,7 +171,6 @@ Examples:
 
 const CLIENTS: SkillClient[] = ["codex", "claude-code"];
 const DEFAULT_SKILLS_SOURCE = "BuilderIO/skills";
-const PUBLIC_SKILLS_REPO_APP_SKILLS = new Set(["visual-plan", "visual-recap"]);
 const MANAGED_INSTRUCTIONS_START = "<!-- BEGIN @agent-native/skills -->";
 const MANAGED_INSTRUCTIONS_END = "<!-- END @agent-native/skills -->";
 
@@ -218,7 +233,11 @@ export function parseSkillsCliArgs(argv: string[]): ParsedArgs {
     else if (arg === "--no-update-instructions") out.updateInstructions = false;
     else if (arg === "--with-github-action" || arg === "--with-github-actions")
       out.withGithubAction = true;
-    else if (arg === "--force") out.force = true;
+    else if ((value = eat("--mode")) !== undefined) {
+      out.planMode = parsePlanMode(value);
+    } else if ((value = eat("--mcp-url")) !== undefined) {
+      out.mcpUrl = value;
+    } else if (arg === "--force") out.force = true;
     else if (arg === "--no-mcp") out.mcp = false;
     else if (arg === "--mcp") out.mcp = true;
     else if (arg === "--no-connect" || arg === "--skip-connect")
@@ -241,6 +260,10 @@ export function parseSkillsCliArgs(argv: string[]): ParsedArgs {
   out.skillNames = unique(out.skillNames.map(normalizeSkillName));
   out.clients = unique(out.clients);
   out.instructionFiles = unique(out.instructionFiles);
+  if (out.planMode && out.mcpUrl && out.planMode !== "self-hosted") {
+    throw new Error("--mcp-url can only be used with --mode self-hosted.");
+  }
+  if (out.mcpUrl && !out.planMode) out.planMode = "self-hosted";
   return out;
 }
 
@@ -253,14 +276,24 @@ export function parseSkillsCliArgs(argv: string[]): ParsedArgs {
 function toCoreSkillsArgv(parsed: ParsedArgs): string[] {
   const out: string[] = [parsed.command];
   if (parsed.command !== "add") return out;
-  if (parsed.skillNames.length === 1) out.push(parsed.skillNames[0]);
-  else if (parsed.copySource && parsed.source) out.push(parsed.source);
+  if (parsed.skillNames.length === 1) {
+    out.push(parsed.skillNames[0]);
+  } else if (parsed.skillNames.length > 1) {
+    const appIds = unique(
+      parsed.skillNames
+        .map((name) => resolveAppForSkill(name)?.appId)
+        .filter((appId): appId is string => Boolean(appId)),
+    );
+    if (appIds.length === 1) out.push(appIds[0]);
+  } else if (parsed.copySource && parsed.source) out.push(parsed.source);
   if (parsed.clients.length) out.push("--client", parsed.clients.join(","));
   if (parsed.scopeExplicit) out.push("--scope", parsed.scope);
   if (parsed.yes) out.push("--yes");
   if (parsed.dryRun) out.push("--dry-run");
   if (parsed.printJson) out.push("--json");
   if (parsed.withGithubAction) out.push("--with-github-action");
+  if (parsed.planMode) out.push("--mode", parsed.planMode);
+  if (parsed.mcpUrl) out.push("--mcp-url", parsed.mcpUrl);
   if (parsed.force) out.push("--force");
   if (parsed.mcp === false) out.push("--no-mcp");
   if (parsed.connect === false) out.push("--no-connect");
@@ -281,25 +314,33 @@ export async function runSkillsCli(
     | "promptScope"
     | "promptUpdateInstructions"
     | "promptGithubAction"
+    | "promptPlanMode"
+    | "promptPlanMcpUrl"
   > = {},
 ): Promise<void> {
   const parsed = parseSkillsCliArgs(argv);
 
-  // PIVOT: `@agent-native/skills` delegates explicitly selected core-only
-  // app-backed installs to `@agent-native/core` for app setup. The default
-  // add/list flow, plain skills, and public-repo-backed app skills stay here so
-  // they always come from the live BuilderIO skills collection (quick-recap,
-  // efficient-fable, visual-plan, visual-recap, …), which core does not own.
+  // PIVOT: `@agent-native/skills` delegates explicitly selected built-in
+  // app-backed installs to `@agent-native/core` when using the default source,
+  // so app-specific flows like Plan modes stay canonical. The default add/list
+  // flow and explicit copied/plain sources stay here so they can install live
+  // BuilderIO/skills content and arbitrary skill repos.
   // AGENT_NATIVE_SKILLS_DIRECT=1 (set when core delegates a plain repo back to us)
   // always forces the direct path and breaks the skills → core → skills loop.
   if (process.env.AGENT_NATIVE_SKILLS_DIRECT !== "1") {
+    const selectedAppIds = unique(
+      parsed.skillNames
+        .map((name) => resolveAppForSkill(name)?.appId)
+        .filter((appId): appId is string => Boolean(appId)),
+    );
     const coreOnlyAppSkills =
       parsed.skillNames.length > 0 &&
       parsed.skillNames.every(
         (name) => resolveAppForSkill(name) !== undefined,
       ) &&
-      parsed.skillNames.every((name) => !skillComesFromPublicSkillsRepo(name));
-    if (parsed.command === "add" && coreOnlyAppSkills) {
+      selectedAppIds.length === 1;
+    const defaultSource = !parsed.copySource && !parsed.source;
+    if (parsed.command === "add" && coreOnlyAppSkills && defaultSource) {
       const { runSkills } = await import("@agent-native/core/cli/skills");
       await runSkills(toCoreSkillsArgv(parsed), {
         isInteractive: options.isInteractive,
@@ -376,8 +417,12 @@ export async function runSkillsCli(
       promptScope: options.promptScope,
       promptUpdateInstructions: options.promptUpdateInstructions,
       promptGithubAction: options.promptGithubAction,
+      promptPlanMode: options.promptPlanMode,
+      promptPlanMcpUrl: options.promptPlanMcpUrl,
       telemetry,
       mcp: parsed.mcp,
+      planMode: parsed.planMode,
+      mcpUrl: parsed.mcpUrl,
     });
 
     telemetry.track("skills_cli completed", {
@@ -407,10 +452,6 @@ export async function runSkillsCli(
   } finally {
     await telemetry.flush();
   }
-}
-
-function skillComesFromPublicSkillsRepo(name: string): boolean {
-  return PUBLIC_SKILLS_REPO_APP_SKILLS.has(normalizeSkillName(name));
 }
 
 function readCliVersion(): string {
@@ -470,6 +511,13 @@ export async function installSkills(
       preselected,
     });
 
+    const skillNames = selected.map((skill) => skill.name);
+    const planMode = await resolvePlanModeForSkills(skillNames, options);
+    const planMcpOverride = await resolvePlanMcpOverrideForMode(
+      planMode,
+      options,
+    );
+
     const clients = await resolveSelectedClients(options);
     options.telemetry?.track("skills_cli clients selected", {
       clients: clients.join(","),
@@ -479,7 +527,6 @@ export async function installSkills(
     const scope = await resolveSelectedScope(options);
     options.telemetry?.track("skills_cli scope selected", { scope });
 
-    const skillNames = selected.map((skill) => skill.name);
     const instructionBlocks = managedInstructionBlocksForSkills(skillNames);
     const shouldUpdateInstructions = await shouldUpdateManagedInstructions(
       instructionBlocks,
@@ -489,7 +536,10 @@ export async function installSkills(
       selected.some((skill) => skill.name === "visual-recap") &&
       (options.withGithubAction ||
         (await shouldPromptGithubAction(options, baseDir)));
-    const mcpApps = options.mcp === false ? [] : mcpAppsForSkills(skillNames);
+    const mcpApps =
+      options.mcp === false || planMode === "local-files"
+        ? []
+        : mcpAppsForSkills(skillNames, planMcpOverride);
     const progress = await createInstallProgress(
       options,
       1 +
@@ -629,6 +679,7 @@ export async function installSkills(
       instructionFiles,
       githubActionPath,
       mcpServers,
+      planMode,
       dryRun: Boolean(options.dryRun),
     };
   } finally {
@@ -653,6 +704,90 @@ function defaultArgs(command: ParsedArgs["command"]): ParsedArgs {
     connect: true,
     mcp: true,
   };
+}
+
+function selectedPlanApp(skillNames: string[]): BuiltInAppMcp | undefined {
+  return skillNames
+    .map((skillName) => resolveAppForSkill(skillName))
+    .find((app): app is BuiltInAppMcp => app?.appId === "visual-plans");
+}
+
+async function resolvePlanModeForSkills(
+  skillNames: string[],
+  options: InstallSkillsOptions,
+): Promise<PlanMode | undefined> {
+  const includesPlans = Boolean(selectedPlanApp(skillNames));
+  if (options.planMode && !includesPlans) {
+    throw new Error("--mode only applies to visual-plan / visual-recap.");
+  }
+  if (options.mcpUrl && !includesPlans) {
+    throw new Error("--mcp-url only applies to visual-plan / visual-recap.");
+  }
+  if (!includesPlans) return undefined;
+
+  if (options.mcpUrl && !options.planMode) return "self-hosted";
+  if (options.planMode) return options.planMode;
+  if (isInteractive(options) && !options.yes) {
+    const prompt = options.promptPlanMode ?? promptForPlanMode;
+    const mode = await prompt({ initialMode: "hosted" });
+    if (!mode) throw new Error("Cancelled.");
+    return mode;
+  }
+  return "hosted";
+}
+
+function resolvePlanMcpUrlOverride(input: string): {
+  hostedUrl: string;
+  mcpUrl: string;
+} {
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    throw new Error(`--mcp-url must be a valid URL (got "${input}").`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("--mcp-url must use http:// or https://.");
+  }
+  const mcpSuffix = "/_agent-native/mcp";
+  const trimmedPath = parsed.pathname.replace(/\/+$/, "");
+  const appPath = trimmedPath.endsWith(mcpSuffix)
+    ? trimmedPath.slice(0, -mcpSuffix.length)
+    : trimmedPath;
+  const mcpPath = trimmedPath.endsWith(mcpSuffix)
+    ? trimmedPath
+    : `${trimmedPath || ""}${mcpSuffix}`;
+  return {
+    hostedUrl: `${parsed.origin}${appPath}`,
+    mcpUrl: `${parsed.origin}${mcpPath}`,
+  };
+}
+
+async function resolvePlanMcpOverrideForMode(
+  planMode: PlanMode | undefined,
+  options: InstallSkillsOptions,
+): Promise<{ hostedUrl: string; mcpUrl: string } | undefined> {
+  if (planMode === "local-files" && options.mcpUrl) {
+    throw new Error("--mode local-files cannot be combined with --mcp-url.");
+  }
+  if (planMode !== "self-hosted") return undefined;
+  let mcpUrl = options.mcpUrl;
+  if (!mcpUrl && isInteractive(options) && !options.yes) {
+    const prompt = options.promptPlanMcpUrl ?? promptForPlanMcpUrl;
+    mcpUrl = (await prompt()) ?? undefined;
+  }
+  if (!mcpUrl) {
+    throw new Error(
+      "--mode self-hosted requires --mcp-url <url> in non-interactive mode.",
+    );
+  }
+  return resolvePlanMcpUrlOverride(mcpUrl);
+}
+
+function parsePlanMode(value: string): PlanMode {
+  if (value === "hosted" || value === "local-files" || value === "self-hosted")
+    return value;
+  throw new Error('--mode must be "hosted", "local-files", or "self-hosted".');
 }
 
 function parseScope(value: string): SkillScope {
@@ -749,14 +884,25 @@ async function createInstallProgress(
   };
 }
 
-function mcpAppsForSkills(skillNames: string[]): BuiltInAppMcp[] {
+function mcpAppsForSkills(
+  skillNames: string[],
+  planOverride?: { hostedUrl: string; mcpUrl: string },
+): BuiltInAppMcp[] {
   const apps: BuiltInAppMcp[] = [];
   const seen = new Set<string>();
   for (const skillName of skillNames) {
     const app = resolveAppForSkill(skillName);
     if (!app || seen.has(app.appId)) continue;
     seen.add(app.appId);
-    apps.push(app);
+    if (app.appId === "visual-plans" && planOverride) {
+      apps.push({
+        ...app,
+        hostedUrl: planOverride.hostedUrl,
+        mcpUrl: planOverride.mcpUrl,
+      });
+    } else {
+      apps.push(app);
+    }
   }
   return apps;
 }
@@ -793,6 +939,7 @@ async function printInstallResult(
     `Skills        ${result.skills.join(", ") || "none"}`,
     `Agents        ${result.clients.join(", ") || "none"}`,
     `Scope         ${result.scope}`,
+    result.planMode ? `Plan mode     ${result.planMode}` : "",
     result.written.length
       ? `Skill folders ${plural(result.written.length, "folder")} (${summarizePaths(
           result.written,
@@ -831,6 +978,17 @@ async function printInstallResult(
     if (guidance.length) {
       clack.note(guidance.join("\n"), "Next steps");
     }
+  }
+
+  if (result.planMode === "local-files") {
+    clack.note(
+      [
+        "No sharing, all local.",
+        "Run: npx @agent-native/core@latest plan blocks --out plan-blocks.md",
+        "Preview: npx @agent-native/core@latest plan local preview --dir plans/<slug>",
+      ].join("\n"),
+      "Local Plan files",
+    );
   }
 
   if (!options.dryRun) {
@@ -875,6 +1033,59 @@ async function promptForSkills(
   }
   if (!Array.isArray(result)) return [];
   return result.filter((value): value is string => typeof value === "string");
+}
+
+async function promptForPlanMode(
+  context: PlanModePromptContext,
+): Promise<PlanMode | null> {
+  const clack = await import("@clack/prompts");
+  const result = await clack.select({
+    message: "How should visual-plan / visual-recap run?",
+    options: [
+      {
+        value: "hosted",
+        label: "Hosted",
+        hint: "Shareable Plan app with MCP tools, auth, comments, and hosted storage.",
+      },
+      {
+        value: "local-files",
+        label: "Local files",
+        hint: "No sharing, all local. Installs text skills and skips MCP/auth.",
+      },
+      {
+        value: "self-hosted",
+        label: "Self-hosted",
+        hint: "Use your own deployed Plan app MCP URL.",
+      },
+    ],
+    initialValue: context.initialMode,
+  });
+  if (clack.isCancel(result)) {
+    clack.cancel("Cancelled.");
+    return null;
+  }
+  return typeof result === "string" ? parsePlanMode(result) : null;
+}
+
+async function promptForPlanMcpUrl(): Promise<string | null> {
+  const clack = await import("@clack/prompts");
+  const result = await clack.text({
+    message: "What is your self-hosted Plan app or MCP URL?",
+    placeholder: "https://plans.example.com",
+    validate(value) {
+      try {
+        resolvePlanMcpUrlOverride(String(value));
+        return undefined;
+      } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+      }
+    },
+  });
+  if (clack.isCancel(result)) {
+    clack.cancel("Cancelled.");
+    return null;
+  }
+  return typeof result === "string" ? result : null;
 }
 
 async function resolveSelectedSkills(

--- a/skills/visual-recap/SKILL.md
+++ b/skills/visual-recap/SKILL.md
@@ -448,6 +448,10 @@ A few recap-specific authoring rules the registry table cannot encode:
   shared optional `summary` / `editable` envelope; give a block a heading by
   placing a `rich-text` block with a Markdown `###` heading directly above it
   (blocks no longer take a `title`).
+- Every capitalized block component must be self-closing (`<RichText ... />`) or
+  explicitly closed around children (`<RichText ...>...</RichText>`). Never
+  leave a bare opening tag like `<RichText ...>` in a paragraph; MDX treats it
+  as unclosed JSX and import fails before the recap can render.
 - `Endpoint`: prose `description` is the MDX **children** (body between the
   tags), not an attribute; for a WebSocket upgrade use `method="GET"`. Each
   request/response `example` is a JSON **string** (the renderer parses it into

--- a/templates/plan/.agents/skills/visual-recap/SKILL.md
+++ b/templates/plan/.agents/skills/visual-recap/SKILL.md
@@ -448,6 +448,10 @@ A few recap-specific authoring rules the registry table cannot encode:
   shared optional `summary` / `editable` envelope; give a block a heading by
   placing a `rich-text` block with a Markdown `###` heading directly above it
   (blocks no longer take a `title`).
+- Every capitalized block component must be self-closing (`<RichText ... />`) or
+  explicitly closed around children (`<RichText ...>...</RichText>`). Never
+  leave a bare opening tag like `<RichText ...>` in a paragraph; MDX treats it
+  as unclosed JSX and import fails before the recap can render.
 - `Endpoint`: prose `description` is the MDX **children** (body between the
   tags), not an attribute; for a WebSocket upgrade use `method="GET"`. Each
   request/response `example` is a JSON **string** (the renderer parses it into

--- a/templates/plan/actions/get-plan-blocks.spec.ts
+++ b/templates/plan/actions/get-plan-blocks.spec.ts
@@ -12,4 +12,17 @@ describe("get-plan-blocks action", () => {
       compactCatalog: true,
     });
   });
+
+  it("teaches valid MDX component closing syntax", async () => {
+    const result = (await (
+      getPlanBlocksAction.run as (args: {
+        format: "reference";
+      }) => Promise<unknown>
+    )({ format: "reference" })) as { reference: string };
+
+    expect(result.reference).toContain("MDX component syntax");
+    expect(result.reference).toContain(
+      "Never write a bare opening tag like `<RichText ...>`",
+    );
+  });
 });

--- a/templates/plan/actions/get-plan-blocks.ts
+++ b/templates/plan/actions/get-plan-blocks.ts
@@ -34,6 +34,8 @@ const AUTHORING_RULES_NOTE = `
 
 **Before/After columns**: compose a \`columns\` block from \`<Column>\` CHILDREN — never a \`columns=\` attribute or inline JSON array. Author it as \`<Columns><Column label="Before">…child block(s)…</Column><Column label="After">…child block(s)…</Column></Columns>\`. Each \`<Column>\` wraps real nested blocks (e.g. a \`Wireframe\`); the parser fills in column ids and child-block \`data\` from that markup, whereas a \`columns=\` attribute array leaves them missing and FAILS schema validation. For UI state comparisons put one \`wireframe\` block in each side and label the columns \`Before\` and \`After\`; the renderer draws labels as headings and lays narrow surfaces side by side. Never bake Before/After labels inside the wireframe HTML or hand-stack the pair.
 
+**MDX component syntax**: every capitalized block component must be either self-closing (\`<RichText id="..." data={{ ... }} />\`) or have a matching closing tag around children (\`<RichText id="...">…</RichText>\`). Never write a bare opening tag like \`<RichText ...>\` as a paragraph; the MDX parser treats it as unclosed JSX and import fails before the plan can render.
+
 **File maps**: prefer \`annotated-code\` blocks (real code + line-anchored notes) grouped in a vertical \`tabs\` block, one tab per key file. Drop to a plain \`code\` block only for throwaway snippets with nothing to call out.
 
 **Tabs grouping**: use horizontal \`TabsBlock\` groups for multiple related diffs so each split diff gets full document width.


### PR DESCRIPTION
## Summary
- make `agent-native plan blocks` use clack interactively while preserving JSON for automation
- align `@agent-native/skills` Plan mode flags with the core skills flow for hosted, local-files, and self-hosted installs
- harden Plan block catalog and visual-recap skill guidance against unclosed MDX component tags

## Validation
- `pnpm prep`
- `pnpm --filter @agent-native/skills exec vitest --run src/index.spec.ts src/mcp-install.spec.ts src/sync-with-core.spec.ts`
- `pnpm --filter @agent-native/core exec vitest --run src/cli/plan-local.spec.ts src/cli/skills.spec.ts`
- `pnpm --filter plan exec vitest --run actions/get-plan-blocks.spec.ts server/block-authoring-examples.spec.ts`
- CLI smoke: `agent-native plan blocks --json` and `@agent-native/skills add --skill visual-plan --mode local-files --json`