### PR TITLE
Unify skills CLI flow

### DIFF
--- a/.changeset/unified-skills-cli-flow.md
+++ b/.changeset/unified-skills-cli-flow.md
@@ -1,0 +1,8 @@
+---
+"@agent-native/core": patch
+"@agent-native/skills": patch
+---
+
+Unify the skills CLI flow so `@agent-native/skills` delegates normal user-facing
+list/add flows to the core skills CLI with an expanded public skills catalog,
+while `agent-native skills` keeps the Agent Native-only catalog.

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ wrangler.toml
 # Builder writing agent scratch (edit-plan.md, edit-state.json)
 **/.builder-writing/
 
+# Local scratch files from ad hoc repo/video tooling
+**/scratch/
+
 # Regenerable plan artifacts (plan.mdx/canvas.mdx are kept; these are not)
 plans/*/preview.html
 plans/*/.plan-state.json

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -991,7 +991,7 @@ describe("agent-native skills", () => {
     }
   });
 
-  it("offers only the two plan skills, both selected by default", async () => {
+  it("offers all Agent Native skills while defaulting the two plan skills", async () => {
     const root = tmpDir();
     let context:
       | { initialTargets: string[]; options: { value: string }[] }
@@ -1014,8 +1014,11 @@ describe("agent-native skills", () => {
 
     expect(promptSkills).toHaveBeenCalledTimes(1);
     expect(context?.options.map((o) => o.value)).toEqual([
+      "assets",
+      "design-exploration",
       "visual-plan",
       "visual-recap",
+      "context-xray",
     ]);
     expect(context?.initialTargets).toEqual(["visual-plan", "visual-recap"]);
     // Both selected installs the whole plan bundle (one shared MCP connector).
@@ -1029,6 +1032,121 @@ describe("agent-native skills", () => {
         path.join(root, ".agents", "skills", "visual-recap", "SKILL.md"),
       ),
     ).toBe(true);
+  });
+
+  it("appends public skills only when the shared flow runs in all-catalog mode", async () => {
+    const root = tmpDir();
+    let coreContext:
+      | { initialTargets: string[]; options: { value: string }[] }
+      | undefined;
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runSkills(["add", "--client", "codex", "--scope", "project"], {
+      baseDir: root,
+      isInteractive: () => true,
+      promptSkills: async (ctx: typeof coreContext) => {
+        coreContext = ctx;
+        return ["visual-plan"];
+      },
+      promptPlanMode: async () => "local-files",
+      promptGithubAction: async () => false,
+      runConnect: async () => {},
+      runCommand: async () => 0,
+    });
+
+    expect(coreContext?.options.map((option) => option.value)).not.toContain(
+      "quick-recap",
+    );
+
+    let allContext:
+      | { initialTargets: string[]; options: { value: string }[] }
+      | undefined;
+    await runSkills(["add", "--client", "codex", "--scope", "project"], {
+      baseDir: root,
+      catalogMode: "all",
+      publicSkillSource: "BuilderIO/skills",
+      publicSkillEntries: [
+        {
+          name: "quick-recap",
+          description: "Use final response status blocks.",
+        },
+      ],
+      isInteractive: () => true,
+      promptSkills: async (ctx: typeof allContext) => {
+        allContext = ctx;
+        return ["quick-recap"];
+      },
+      promptUpdateInstructions: async () => false,
+      runCommand: async () => 0,
+    });
+
+    expect(allContext?.options.map((option) => option.value)).toEqual([
+      "assets",
+      "design-exploration",
+      "visual-plan",
+      "visual-recap",
+      "context-xray",
+      "quick-recap",
+    ]);
+    expect(allContext?.initialTargets).toEqual(["visual-plan", "visual-recap"]);
+  });
+
+  it("runs public skills through the same prompt flow before delegating the copy", async () => {
+    const root = tmpDir();
+    const calls: string[] = [];
+    const commands: { cmd: string; args: string[] }[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runSkills(["add"], {
+      baseDir: root,
+      catalogMode: "all",
+      publicSkillSource: "BuilderIO/skills",
+      publicSkillEntries: [
+        {
+          name: "quick-recap",
+          description: "Use final response status blocks.",
+        },
+      ],
+      isInteractive: () => true,
+      promptSkills: async () => {
+        calls.push("skills");
+        return ["quick-recap"];
+      },
+      promptClients: async () => {
+        calls.push("clients");
+        return ["codex"];
+      },
+      promptScope: async () => {
+        calls.push("scope");
+        return "project";
+      },
+      promptUpdateInstructions: async () => {
+        calls.push("instructions");
+        return true;
+      },
+      runCommand: async (cmd, args) => {
+        commands.push({ cmd, args });
+        return 0;
+      },
+    });
+
+    expect(calls).toEqual(["skills", "clients", "scope", "instructions"]);
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toMatchObject({ cmd: "npx" });
+    expect(commands[0].args).toEqual(
+      expect.arrayContaining([
+        "@agent-native/skills@latest",
+        "add",
+        "BuilderIO/skills",
+        "--skill",
+        "quick-recap",
+        "--client",
+        "codex",
+        "--scope",
+        "project",
+        "--update-instructions",
+      ]),
+    );
   });
 
   it("installs only visual-recap when only it is selected", async () => {

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -2320,6 +2320,7 @@ type PlanInstallMode = "hosted" | "local-files" | "self-hosted";
 export interface ParsedSkillsArgs {
   command: SkillsCommand;
   target?: string;
+  baseDir?: string;
   client: string;
   clientExplicit: boolean;
   clients?: ClientId[];
@@ -2465,8 +2466,31 @@ interface RunCommandOptions {
   stdio?: "inherit" | "stderr" | "silent";
 }
 
-interface RunSkillsOptions {
+export type SkillsCatalogMode = "agent-native" | "all";
+
+export interface PublicSkillCatalogEntry {
+  name: string;
+  description?: string;
+}
+
+export interface RunSkillsOptions {
   baseDir?: string;
+  /**
+   * Which skills appear in the shared add/list picker. `agent-native` is the
+   * core CLI surface; `all` is used by @agent-native/skills to append public
+   * skill-repo entries while keeping every prompt and install decision here.
+   */
+  catalogMode?: SkillsCatalogMode;
+  /**
+   * The plain skills repo/source to install when a public catalog entry is
+   * selected. @agent-native/skills usually passes the materialized source root.
+   */
+  publicSkillSource?: string;
+  /**
+   * Public skill-repo entries discovered by @agent-native/skills. Core owns the
+   * user-facing flow; the wrapper owns materializing the broader catalog.
+   */
+  publicSkillEntries?: PublicSkillCatalogEntry[];
   isInteractive?: () => boolean;
   log?: (message: string) => void;
   promptClients?: (
@@ -2485,6 +2509,7 @@ interface RunSkillsOptions {
     context: SkillsPlanModePromptContext,
   ) => Promise<PlanInstallMode | null>;
   promptPlanMcpUrl?: () => Promise<string | null>;
+  promptUpdateInstructions?: () => Promise<boolean | null>;
   runCommand?: (
     cmd: string,
     args: string[],
@@ -3038,12 +3063,20 @@ function clientPromptOptions(): SkillsClientPromptContext["options"] {
   }));
 }
 
-// For now the interactive installer offers only the two plan skills, each as
-// an independently selectable entry (uncheck one to install just the other).
-// The other built-in skills stay installable via `agent-native skills add
-// <name>` but are hidden from the default checklist. The values are the real
-// slash-command names so users see exactly what they are installing.
-const PLAN_SKILL_PROMPT_OPTIONS: SkillsTargetPromptContext["options"] = [
+const DEFAULT_PUBLIC_SKILLS_SOURCE = "BuilderIO/skills";
+const PUBLIC_SKILL_TARGET_PREFIX = "public-skills:";
+
+const BUILT_IN_SKILL_PROMPT_OPTIONS: SkillsTargetPromptContext["options"] = [
+  {
+    value: "assets",
+    label: "assets",
+    hint: BUILT_IN_APP_SKILLS.assets.manifest.description,
+  },
+  {
+    value: "design-exploration",
+    label: "design-exploration",
+    hint: BUILT_IN_APP_SKILLS.design.manifest.description,
+  },
   {
     value: "visual-plan",
     label: "visual-plan",
@@ -3054,10 +3087,70 @@ const PLAN_SKILL_PROMPT_OPTIONS: SkillsTargetPromptContext["options"] = [
     label: "visual-recap",
     hint: "Interactive visual recap that maps PRs/diffs with diagrams, annotated diffs, API/schema summaries, and review notes.",
   },
+  {
+    value: "context-xray",
+    label: "context-xray",
+    hint: BUILT_IN_APP_SKILLS["context-xray"].manifest.description,
+  },
 ];
 
-function skillPromptOptions(): SkillsTargetPromptContext["options"] {
-  return PLAN_SKILL_PROMPT_OPTIONS;
+const DEFAULT_SKILL_PROMPT_TARGETS = ["visual-plan", "visual-recap"];
+
+function publicSkillEntries(
+  options: RunSkillsOptions,
+): PublicSkillCatalogEntry[] {
+  if (options.catalogMode !== "all") return [];
+  const seen = new Set<string>();
+  return (options.publicSkillEntries ?? [])
+    .map((entry) => ({
+      name: entry.name.trim().toLowerCase(),
+      description: entry.description,
+    }))
+    .filter((entry) => {
+      if (!entry.name || isKnownSkill(entry.name) || seen.has(entry.name)) {
+        return false;
+      }
+      seen.add(entry.name);
+      return true;
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function publicSkillNames(options: RunSkillsOptions): Set<string> {
+  return new Set(publicSkillEntries(options).map((entry) => entry.name));
+}
+
+function publicSkillPromptOptions(
+  options: RunSkillsOptions,
+): SkillsTargetPromptContext["options"] {
+  return publicSkillEntries(options).map((entry) => ({
+    value: entry.name,
+    label: entry.name,
+    hint:
+      entry.description ?? "Public skill from the BuilderIO skills catalog.",
+  }));
+}
+
+function skillPromptOptions(
+  options: RunSkillsOptions = {},
+): SkillsTargetPromptContext["options"] {
+  return [
+    ...BUILT_IN_SKILL_PROMPT_OPTIONS,
+    ...publicSkillPromptOptions(options),
+  ];
+}
+
+function publicSkillSelectionTarget(skillNames: string[]): string {
+  return `${PUBLIC_SKILL_TARGET_PREFIX}${skillNames.join(",")}`;
+}
+
+function publicSkillSelectionNames(target: string): string[] | null {
+  if (!target.startsWith(PUBLIC_SKILL_TARGET_PREFIX)) return null;
+  return target
+    .slice(PUBLIC_SKILL_TARGET_PREFIX.length)
+    .split(",")
+    .map((name) => name.trim().toLowerCase())
+    .filter(Boolean);
 }
 
 function prVisualRecapWorkflowPath(baseDir: string): string {
@@ -3203,6 +3296,20 @@ async function promptForPlanMcpUrl(): Promise<string | null> {
   return String(result).trim();
 }
 
+async function promptForUpdateInstructions(): Promise<boolean | null> {
+  const clack = await import("@clack/prompts");
+  const result = await clack.confirm({
+    message:
+      "Add managed AGENTS.md / CLAUDE.md instructions for always-on skill behavior?",
+    initialValue: true,
+  });
+  if (clack.isCancel(result)) {
+    clack.cancel("Skipped managed instruction updates.");
+    return null;
+  }
+  return Boolean(result);
+}
+
 async function promptForSkills(
   context: SkillsTargetPromptContext,
 ): Promise<string[] | null> {
@@ -3279,15 +3386,90 @@ function targetsIncludePlans(targets: string[]): boolean {
   return targets.some(targetIncludesPlans);
 }
 
+function planSkillNamesSelected(skillNames: string[] | undefined): boolean {
+  return Boolean(
+    skillNames?.some(
+      (name) => normalizeKnownSkillTarget(name) === "visual-plans",
+    ),
+  );
+}
+
+function recapSkillNamesSelected(skillNames: string[] | undefined): boolean {
+  return Boolean(
+    skillNames?.some((name) => {
+      const normalized = name.trim().toLowerCase();
+      return (
+        normalized === "visual-recap" ||
+        normalized === "visual-recaps" ||
+        normalizeKnownSkillTarget(normalized) === "visual-plans"
+      );
+    }),
+  );
+}
+
+function resolveSelectedSkillTargets(
+  selected: string[],
+  options: RunSkillsOptions,
+): string[] {
+  const publicNames = publicSkillNames(options);
+  const builtInSelections: string[] = [];
+  const publicSelections: string[] = [];
+
+  for (const raw of selected) {
+    const skill = raw.trim().toLowerCase();
+    if (!skill) continue;
+    if (isKnownSkill(skill)) {
+      builtInSelections.push(skill);
+      continue;
+    }
+    if (publicNames.has(skill)) {
+      publicSelections.push(skill);
+      continue;
+    }
+    throw new Error(
+      `Unknown skill: ${raw}. Run "npx @agent-native/core@latest skills list".`,
+    );
+  }
+
+  const out: string[] = [];
+  const planSubskills = ["visual-plan", "visual-recap"];
+  const selectedPlanSubskills = planSubskills.filter((skill) =>
+    builtInSelections.includes(skill),
+  );
+  if (selectedPlanSubskills.length === planSubskills.length) {
+    out.push("visual-plans");
+  } else {
+    out.push(...selectedPlanSubskills);
+  }
+  out.push(
+    ...builtInSelections.filter(
+      (skill) => !planSubskills.includes(skill) && !out.includes(skill),
+    ),
+  );
+  if (publicSelections.length > 0) {
+    out.push(publicSkillSelectionTarget([...new Set(publicSelections)]));
+  }
+  return out;
+}
+
 async function resolveSkillTargets(
   parsed: ParsedSkillsArgs,
   options: RunSkillsOptions,
 ): Promise<string[] | null> {
+  if (!parsed.target && parsed.plainSkillNames?.length) {
+    return resolveSelectedSkillTargets(parsed.plainSkillNames, options);
+  }
   if (parsed.target || !shouldPrompt(parsed, options)) {
-    return [parsed.target ?? "assets"];
+    const target = parsed.target ?? "assets";
+    if (!parsed.target) return [target];
+    const normalizedTarget = target.trim().toLowerCase();
+    if (publicSkillNames(options).has(normalizedTarget)) {
+      return [publicSkillSelectionTarget([normalizedTarget])];
+    }
+    return [target];
   }
   const prompt = options.promptSkills ?? promptForSkills;
-  const promptOptions = skillPromptOptions();
+  const promptOptions = skillPromptOptions(options);
   // The interactive multiselect skill picker is about to be shown (no --skill /
   // target passed and we are interactive) — record the funnel "prompted" step.
   options.telemetry?.track("skills_cli skills prompted", {
@@ -3295,21 +3477,11 @@ async function resolveSkillTargets(
     available: promptOptions.map((option) => option.value).join(","),
   });
   const selected = await prompt({
-    initialTargets: ["visual-plan", "visual-recap"],
+    initialTargets: DEFAULT_SKILL_PROMPT_TARGETS,
     options: promptOptions,
   });
   if (!selected || selected.length === 0) return null;
-  // Both plan skills share one MCP connector, so when both are selected install
-  // them through the bundle target — that registers/authenticates the connector
-  // once instead of twice.
-  const planSubskills = ["visual-plan", "visual-recap"];
-  if (planSubskills.every((skill) => selected.includes(skill))) {
-    return [
-      "visual-plans",
-      ...selected.filter((s) => !planSubskills.includes(s)),
-    ];
-  }
-  return selected;
+  return resolveSelectedSkillTargets(selected, options);
 }
 
 export function parseSkillsArgs(argv: string[]): ParsedSkillsArgs {
@@ -3366,6 +3538,12 @@ export function parseSkillsArgs(argv: string[]): ParsedSkillsArgs {
     if ((value = eat("--client")) !== undefined) {
       out.client = value;
       out.clientExplicit = true;
+    } else if ((value = eat("--agent")) !== undefined) {
+      out.client = value;
+      out.clientExplicit = true;
+    } else if ((value = eat("-a")) !== undefined) {
+      out.client = value;
+      out.clientExplicit = true;
     } else if ((value = eat("--skill")) !== undefined) {
       out.plainSkillNames = [...(out.plainSkillNames ?? []), value];
     } else if ((value = eat("-s")) !== undefined) {
@@ -3373,7 +3551,8 @@ export function parseSkillsArgs(argv: string[]): ParsedSkillsArgs {
     } else if ((value = eat("--scope")) !== undefined) {
       out.scope = value;
       out.scopeExplicit = true;
-    } else if ((value = eat("--mcp-url")) !== undefined) out.mcpUrl = value;
+    } else if ((value = eat("--cwd")) !== undefined) out.baseDir = value;
+    else if ((value = eat("--mcp-url")) !== undefined) out.mcpUrl = value;
     else if ((value = eat("--mode")) !== undefined)
       out.planMode = normalizePlanInstallMode(value);
     else if (arg === "--hosted") out.planMode = "hosted";
@@ -3384,7 +3563,16 @@ export function parseSkillsArgs(argv: string[]): ParsedSkillsArgs {
     else if (arg === "--yes" || arg === "-y") out.yes = true;
     else if (arg === "--dry-run") out.dryRun = true;
     else if (arg === "--json") out.printJson = true;
-    else if (arg === "--mcp-only") out.instructions = false;
+    else if (arg === "-g" || arg === "--global") {
+      out.scope = "user";
+      out.scopeExplicit = true;
+    } else if (arg === "--project") {
+      out.scope = "project";
+      out.scopeExplicit = true;
+    } else if (arg === "--copy") {
+      // Compatibility with @agent-native/skills. Core always copies skill
+      // instructions instead of linking to the source repo.
+    } else if (arg === "--mcp-only") out.instructions = false;
     else if (arg === "--instructions-only" || arg === "--no-mcp")
       out.mcp = false;
     else if (arg === "--no-connect" || arg === "--skip-connect")
@@ -3687,6 +3875,9 @@ function agentNativeSkillsInstallArgs(
   ];
   if (parsed.withGithubAction) args.push("--with-github-action");
   if (parsed.force) args.push("--force");
+  if (parsed.planMode) args.push("--mode", parsed.planMode);
+  if (parsed.mcpUrl) args.push("--mcp-url", parsed.mcpUrl);
+  if (!parsed.mcp) args.push("--no-mcp");
   if (!parsed.connect) args.push("--no-connect");
   for (const skill of parsed.plainSkillNames ?? []) {
     args.push("--skill", skill);
@@ -3695,6 +3886,7 @@ function agentNativeSkillsInstallArgs(
   if (parsed.updateInstructions === false)
     args.push("--no-update-instructions");
   if (parsed.yes) args.push("--yes");
+  if (parsed.dryRun) args.push("--dry-run");
   return args;
 }
 
@@ -3708,7 +3900,7 @@ async function addPlainSkillRepo(
       "Plain skill repositories only install skill instructions. Run without --mcp-only.",
     );
   }
-  if (parsed.mcpUrl) {
+  if (parsed.mcpUrl && !planSkillNamesSelected(parsed.plainSkillNames)) {
     throw new Error(
       "--mcp-url only applies to app-backed Agent Native skills.",
     );
@@ -3716,6 +3908,7 @@ async function addPlainSkillRepo(
 
   const clients = parsed.clients ?? resolveClients(parsed.client);
   const skillsAgents = skillsAgentsForClients(clients);
+  const selectedSkillNames = parsed.plainSkillNames ?? [];
   if (skillsAgents.length === 0) {
     throw new Error(
       "Plain skill repositories can only install instructions for Codex or Claude Code clients.",
@@ -3732,15 +3925,17 @@ async function addPlainSkillRepo(
       );
   }
   options.telemetry?.track("skills_cli install completed", {
-    skills: target,
+    skills: selectedSkillNames.length ? selectedSkillNames.join(",") : target,
     clients: clients.join(","),
     scope: parsed.scope,
     dryRun: Boolean(parsed.dryRun),
   });
   return {
     id: target,
-    displayName: target,
-    skillNames: [],
+    displayName: selectedSkillNames.length
+      ? selectedSkillNames.join(", ")
+      : target,
+    skillNames: selectedSkillNames,
     skillsAgents,
     mcpUrl: "",
     mcpClients: [],
@@ -3842,6 +4037,17 @@ export async function addAgentNativeSkill(
   options: RunSkillsOptions = {},
 ): Promise<SkillsAddResult> {
   const target = parsed.target ?? "assets";
+  const publicSelection = publicSkillSelectionNames(target);
+  if (publicSelection) {
+    return addPlainSkillRepo(
+      {
+        ...parsed,
+        target: options.publicSkillSource ?? DEFAULT_PUBLIC_SKILLS_SOURCE,
+        plainSkillNames: publicSelection,
+      },
+      options,
+    );
+  }
   const knownTarget = normalizeKnownSkillTarget(target);
   const planMode =
     knownTarget === "visual-plans"
@@ -4168,18 +4374,33 @@ export async function addAgentNativeSkill(
   }
 }
 
-function listSkills() {
-  return Object.values(BUILT_IN_APP_SKILLS).map((entry) => ({
-    id: entry.manifest.id,
-    aliases:
-      BUILT_IN_APP_SKILL_DISPLAY_ALIASES[
-        entry.manifest.id as BuiltInAppSkillId
-      ] ?? [],
-    name: entry.manifest.displayName,
-    description: entry.manifest.description,
-    mcpUrl: isLocalOnlyBuiltInSkill(entry) ? "" : entry.manifest.hosted.mcpUrl,
-    local: isLocalOnlyBuiltInSkill(entry),
-  }));
+function listSkills(options: RunSkillsOptions = {}) {
+  return [
+    ...Object.values(BUILT_IN_APP_SKILLS).map((entry) => ({
+      id: entry.manifest.id,
+      aliases:
+        BUILT_IN_APP_SKILL_DISPLAY_ALIASES[
+          entry.manifest.id as BuiltInAppSkillId
+        ] ?? [],
+      name: entry.manifest.displayName,
+      description: entry.manifest.description,
+      mcpUrl: isLocalOnlyBuiltInSkill(entry)
+        ? ""
+        : entry.manifest.hosted.mcpUrl,
+      local: isLocalOnlyBuiltInSkill(entry),
+      source: "agent-native",
+    })),
+    ...publicSkillEntries(options).map((entry) => ({
+      id: entry.name,
+      aliases: [] as string[],
+      name: entry.name,
+      description:
+        entry.description ?? "Public skill from the BuilderIO skills catalog.",
+      mcpUrl: "",
+      local: true,
+      source: options.publicSkillSource ?? DEFAULT_PUBLIC_SKILLS_SOURCE,
+    })),
+  ];
 }
 
 function skillStateJson(state: SkillInstallState) {
@@ -4213,6 +4434,45 @@ function planModeSummary(mode: PlanInstallMode): string {
   if (mode === "local-files") return "Local files - No sharing, all local.";
   if (mode === "self-hosted") return "Self-hosted/custom Plan app";
   return "Hosted Plans - shareable links and comments";
+}
+
+function instructionContentForSkill(skillName: string): string | null {
+  if (skillName === "quick-recap") {
+    return "When writing final response status indicators, use the /quick-recap skill always.";
+  }
+  if (skillName === "efficient-fable") {
+    return "When operating as Claude Fable, use the /efficient-fable skill always.";
+  }
+  if (skillName === "efficient-frontier") {
+    return "When using a high-cost frontier model for codebase-heavy work, use the /efficient-frontier skill always.";
+  }
+  if (skillName === "stay-within-limits") {
+    return "When long-running or parallel work needs usage-limit checks, use the /stay-within-limits skill always.";
+  }
+  if (skillName === "visual-plan") {
+    return "When work needs an interactive visual plan before implementation, use the /visual-plan skill always.";
+  }
+  if (skillName === "visual-recap") {
+    return "When a PR, branch, commit, or diff needs an interactive visual recap, use the /visual-recap skill always.";
+  }
+  return null;
+}
+
+function selectedPlainSkillNamesForInstructionPrompt(
+  targets: string[],
+  parsed: ParsedSkillsArgs,
+): string[] {
+  const names = new Set<string>(parsed.plainSkillNames ?? []);
+  for (const target of targets) {
+    for (const name of publicSkillSelectionNames(target) ?? []) {
+      names.add(name);
+    }
+  }
+  return [...names];
+}
+
+function hasManagedInstructionBlock(skillNames: string[]): boolean {
+  return skillNames.some((name) => Boolean(instructionContentForSkill(name)));
 }
 
 function runSkillsStatusOrUpdate(
@@ -4297,6 +4557,9 @@ export async function runSkills(
   options: RunSkillsOptions = {},
 ): Promise<void> {
   const parsed = parseSkillsArgs(argv);
+  if (parsed.baseDir) {
+    options = { ...options, baseDir: path.resolve(parsed.baseDir) };
+  }
   const log = parsed.printJson
     ? undefined
     : (message: string) => process.stdout.write(`${message}\n`);
@@ -4311,6 +4574,7 @@ export async function runSkills(
   // `npx @agent-native/skills@latest add …`; this env guard tells that child process
   // to run its OWN headless installer instead of bouncing back into core,
   // which would otherwise be an infinite skills → core → skills loop.
+  const previousDirect = process.env.AGENT_NATIVE_SKILLS_DIRECT;
   process.env.AGENT_NATIVE_SKILLS_DIRECT = "1";
 
   // Best-effort install-funnel telemetry. Created once per run and flushed in a
@@ -4331,7 +4595,7 @@ export async function runSkills(
     telemetry.track("skills_cli started");
 
     if (parsed.command === "list") {
-      const skills = listSkills();
+      const skills = listSkills(optionsWithTelemetry);
       telemetry.track("skills_cli skills listed", {
         availableCount: skills.length,
         available: skills.map((skill) => skill.id).join(","),
@@ -4370,11 +4634,13 @@ export async function runSkills(
       // Best-effort "took everything offered" signal: compare against the
       // interactive picker's option count (the plan sub-skills collapse into a
       // single bundle target, so this is approximate, like the standalone CLI).
-      selectedAll: targets.length === skillPromptOptions().length,
+      selectedAll: targets.length === skillPromptOptions(options).length,
       preselected,
     });
 
-    const includesPlans = targetsIncludePlans(targets);
+    const includesPlans =
+      targetsIncludePlans(targets) ||
+      planSkillNamesSelected(parsed.plainSkillNames);
     if (parsed.planMode && !includesPlans) {
       throw new Error("--mode only applies to visual-plan / visual-recap.");
     }
@@ -4437,16 +4703,38 @@ export async function runSkills(
     }
     telemetry.track("skills_cli scope selected", { scope: parsed.scope });
 
+    const instructionSkillNames = selectedPlainSkillNamesForInstructionPrompt(
+      targets,
+      parsed,
+    );
+    if (
+      parsed.updateInstructions === undefined &&
+      hasManagedInstructionBlock(instructionSkillNames) &&
+      shouldPrompt(parsed, options)
+    ) {
+      const prompt =
+        options.promptUpdateInstructions ?? promptForUpdateInstructions;
+      const choice = await prompt();
+      if (choice === null) {
+        telemetry.track("skills_cli cancelled", {
+          step: "managed-instructions",
+        });
+        return;
+      }
+      parsed.updateInstructions = choice === true;
+    }
+
     // Decide the optional PR Visual Recap GitHub Action UP FRONT — before any
     // install or MCP registration — so every prompt is answered before we touch
     // disk. The choice is threaded into each install via `withGithubAction` +
     // `githubActionResolved` (so addAgentNativeSkill doesn't re-prompt mid-flow).
     const recapBaseDir = options.baseDir ?? process.cwd();
-    const anyRecapTarget = targets.some((target) => {
-      if (normalizeKnownSkillTarget(target) !== "visual-plans") return false;
-      const only = builtInOnlySkillNames(target);
-      return !only || only.includes("visual-recap");
-    });
+    const anyRecapTarget =
+      targets.some((target) => {
+        if (normalizeKnownSkillTarget(target) !== "visual-plans") return false;
+        const only = builtInOnlySkillNames(target);
+        return !only || only.includes("visual-recap");
+      }) || recapSkillNamesSelected(parsed.plainSkillNames);
     if (
       anyRecapTarget &&
       !parsed.withGithubAction &&
@@ -4627,5 +4915,10 @@ export async function runSkills(
     throw error;
   } finally {
     await telemetry.flush();
+    if (previousDirect === undefined) {
+      delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
+    } else {
+      process.env.AGENT_NATIVE_SKILLS_DIRECT = previousDirect;
+    }
   }
 }

--- a/packages/skills/src/index.spec.ts
+++ b/packages/skills/src/index.spec.ts
@@ -42,6 +42,16 @@ function writeSkill(repo: string, name: string, body = "Body"): void {
   );
 }
 
+function enableDirectSkillsMode(): () => void {
+  const previousDirect = process.env.AGENT_NATIVE_SKILLS_DIRECT;
+  process.env.AGENT_NATIVE_SKILLS_DIRECT = "1";
+  return () => {
+    if (previousDirect === undefined)
+      delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
+    else process.env.AGENT_NATIVE_SKILLS_DIRECT = previousDirect;
+  };
+}
+
 describe("@agent-native/skills", () => {
   it("parses the no-source BuilderIO skills install command", () => {
     const parsed = parseSkillsCliArgs([
@@ -171,8 +181,7 @@ describe("@agent-native/skills", () => {
       stdout.push(String(chunk));
       return true;
     });
-    const previousDirect = process.env.AGENT_NATIVE_SKILLS_DIRECT;
-    delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
+    const restoreDirect = enableDirectSkillsMode();
 
     try {
       await runSkillsCli(
@@ -190,9 +199,7 @@ describe("@agent-native/skills", () => {
         { baseDir: project, isInteractive: () => false },
       );
     } finally {
-      if (previousDirect === undefined)
-        delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
-      else process.env.AGENT_NATIVE_SKILLS_DIRECT = previousDirect;
+      restoreDirect();
     }
 
     expect(runCoreSkills).not.toHaveBeenCalled();
@@ -219,17 +226,14 @@ describe("@agent-native/skills", () => {
       stdout.push(String(chunk));
       return true;
     });
-    const previousDirect = process.env.AGENT_NATIVE_SKILLS_DIRECT;
-    delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
+    const restoreDirect = enableDirectSkillsMode();
 
     try {
       await runSkillsCli(["list", "--copy", repo, "--json"], {
         isInteractive: () => false,
       });
     } finally {
-      if (previousDirect === undefined)
-        delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
-      else process.env.AGENT_NATIVE_SKILLS_DIRECT = previousDirect;
+      restoreDirect();
     }
 
     expect(runCoreSkills).not.toHaveBeenCalled();
@@ -238,6 +242,55 @@ describe("@agent-native/skills", () => {
       "efficient-fable",
       "quick-recap",
     ]);
+  });
+
+  it("delegates normal copied-source installs to core with the public catalog", async () => {
+    const repo = tmpDir();
+    const project = tmpDir();
+    writeSkill(repo, "quick-recap");
+    writeSkill(repo, "efficient-fable");
+    let skillContext: SkillsPromptContext | undefined;
+
+    await runSkillsCli(["add", "--copy", repo], {
+      baseDir: project,
+      isInteractive: () => true,
+      promptSkills: async (context) => {
+        skillContext = context;
+        return ["quick-recap"];
+      },
+      promptClients: async () => ["codex"],
+      promptScope: async () => "project",
+      promptUpdateInstructions: async () => false,
+    });
+
+    expect(runCoreSkills).toHaveBeenCalledTimes(1);
+    const [argv, options] = vi.mocked(runCoreSkills).mock.calls[0];
+    expect(argv).toEqual(["add"]);
+    expect(options).toMatchObject({
+      baseDir: project,
+      catalogMode: "all",
+      publicSkillSource: repo,
+      publicSkillEntries: [
+        {
+          name: "efficient-fable",
+          description: "Use when testing efficient-fable.",
+        },
+        {
+          name: "quick-recap",
+          description: "Use when testing quick-recap.",
+        },
+      ],
+    });
+
+    const selected = await (options as any).promptSkills({
+      initialTargets: ["visual-plan", "visual-recap"],
+      options: [{ value: "quick-recap", label: "quick-recap", hint: "Recap" }],
+    });
+    expect(selected).toEqual(["quick-recap"]);
+    expect(skillContext).toMatchObject({
+      initialSkills: ["visual-plan", "visual-recap"],
+      options: [{ value: "quick-recap" }],
+    });
   });
 
   it("prompts with the clack-style picker using every discovered repo skill", async () => {
@@ -253,15 +306,20 @@ describe("@agent-native/skills", () => {
     const promptClients = vi.fn(async () => ["codex" as const]);
     const promptScope = vi.fn(async () => "project" as const);
     vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const restoreDirect = enableDirectSkillsMode();
 
-    await runSkillsCli(["add", "--copy", repo], {
-      baseDir: project,
-      isInteractive: () => true,
-      promptSkills,
-      promptClients,
-      promptScope,
-      promptUpdateInstructions: async () => false,
-    });
+    try {
+      await runSkillsCli(["add", "--copy", repo], {
+        baseDir: project,
+        isInteractive: () => true,
+        promptSkills,
+        promptClients,
+        promptScope,
+        promptUpdateInstructions: async () => false,
+      });
+    } finally {
+      restoreDirect();
+    }
 
     expect(runCoreSkills).not.toHaveBeenCalled();
     expect(promptSkills).toHaveBeenCalledTimes(1);
@@ -298,19 +356,24 @@ describe("@agent-native/skills", () => {
     fs.writeFileSync(path.join(project, "AGENTS.md"), "# Existing\n", "utf-8");
     const promptUpdateInstructions = vi.fn(async () => true);
     vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const restoreDirect = enableDirectSkillsMode();
 
-    await runSkillsCli(["add", "--copy", repo], {
-      baseDir: project,
-      isInteractive: () => true,
-      promptSkills: async () => [
-        "efficient-fable",
-        "efficient-frontier",
-        "quick-recap",
-      ],
-      promptClients: async () => ["codex"],
-      promptScope: async () => "project",
-      promptUpdateInstructions,
-    });
+    try {
+      await runSkillsCli(["add", "--copy", repo], {
+        baseDir: project,
+        isInteractive: () => true,
+        promptSkills: async () => [
+          "efficient-fable",
+          "efficient-frontier",
+          "quick-recap",
+        ],
+        promptClients: async () => ["codex"],
+        promptScope: async () => "project",
+        promptUpdateInstructions,
+      });
+    } finally {
+      restoreDirect();
+    }
 
     expect(promptUpdateInstructions).toHaveBeenCalledTimes(1);
     const agents = fs.readFileSync(path.join(project, "AGENTS.md"), "utf-8");
@@ -331,17 +394,22 @@ describe("@agent-native/skills", () => {
     writeSkill(repo, "visual-recap");
     const promptGithubAction = vi.fn(async () => true);
     vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const restoreDirect = enableDirectSkillsMode();
 
-    await runSkillsCli(["add", "--copy", repo, "--no-mcp"], {
-      baseDir: project,
-      isInteractive: () => true,
-      promptSkills: async () => ["visual-recap"],
-      promptClients: async () => ["codex"],
-      promptScope: async () => "project",
-      promptPlanMode: async () => "hosted",
-      promptUpdateInstructions: async () => false,
-      promptGithubAction,
-    });
+    try {
+      await runSkillsCli(["add", "--copy", repo, "--no-mcp"], {
+        baseDir: project,
+        isInteractive: () => true,
+        promptSkills: async () => ["visual-recap"],
+        promptClients: async () => ["codex"],
+        promptScope: async () => "project",
+        promptPlanMode: async () => "hosted",
+        promptUpdateInstructions: async () => false,
+        promptGithubAction,
+      });
+    } finally {
+      restoreDirect();
+    }
 
     expect(promptGithubAction).toHaveBeenCalledWith({
       workflowPath: path.join(".github", "workflows", "pr-visual-recap.yml"),
@@ -362,8 +430,7 @@ describe("@agent-native/skills", () => {
       stdout.push(String(chunk));
       return true;
     });
-    const previousDirect = process.env.AGENT_NATIVE_SKILLS_DIRECT;
-    delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
+    const restoreDirect = enableDirectSkillsMode();
 
     try {
       await runSkillsCli(
@@ -384,9 +451,7 @@ describe("@agent-native/skills", () => {
         { baseDir: project, isInteractive: () => false },
       );
     } finally {
-      if (previousDirect === undefined)
-        delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
-      else process.env.AGENT_NATIVE_SKILLS_DIRECT = previousDirect;
+      restoreDirect();
     }
 
     expect(runCoreSkills).not.toHaveBeenCalled();
@@ -441,10 +506,13 @@ describe("@agent-native/skills", () => {
         "--mode",
         "local-files",
       ],
-      {
+      expect.objectContaining({
         baseDir: project,
+        catalogMode: "all",
         isInteractive: expect.any(Function),
-      },
+        publicSkillEntries: [],
+        publicSkillSource: "BuilderIO/skills",
+      }),
     );
   });
 
@@ -508,24 +576,29 @@ describe("@agent-native/skills", () => {
       stdout.push(String(chunk));
       return true;
     });
+    const restoreDirect = enableDirectSkillsMode();
 
-    await runSkillsCli(
-      [
-        "add",
-        "--copy",
-        repo,
-        "--skill",
-        "visual-plan",
-        "--client",
-        "codex",
-        "--scope",
-        "project",
-        "--yes",
-        "--no-connect",
-        "--no-update-instructions",
-      ],
-      { baseDir: project, isInteractive: () => false },
-    );
+    try {
+      await runSkillsCli(
+        [
+          "add",
+          "--copy",
+          repo,
+          "--skill",
+          "visual-plan",
+          "--client",
+          "codex",
+          "--scope",
+          "project",
+          "--yes",
+          "--no-connect",
+          "--no-update-instructions",
+        ],
+        { baseDir: project, isInteractive: () => false },
+      );
+    } finally {
+      restoreDirect();
+    }
 
     const output = stdout.join("");
     expect(output).toContain("authentication pending");
@@ -571,10 +644,13 @@ describe("@agent-native/skills", () => {
         "--yes",
         "--json",
       ],
-      {
+      expect.objectContaining({
         baseDir: project,
+        catalogMode: "all",
         isInteractive: expect.any(Function),
-      },
+        publicSkillEntries: [],
+        publicSkillSource: "BuilderIO/skills",
+      }),
     );
   });
 
@@ -730,19 +806,24 @@ describe("@agent-native/skills", () => {
     );
     let skillContext: SkillsPromptContext | undefined;
     vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const restoreDirect = enableDirectSkillsMode();
 
-    await runSkillsCli(["add", "--copy", repo, "--no-mcp"], {
-      baseDir: project,
-      isInteractive: () => true,
-      promptSkills: async (context) => {
-        skillContext = context;
-        return ["visual-plan"];
-      },
-      promptClients: async () => ["codex"],
-      promptScope: async () => "project",
-      promptPlanMode: async () => "hosted",
-      promptUpdateInstructions: async () => false,
-    });
+    try {
+      await runSkillsCli(["add", "--copy", repo, "--no-mcp"], {
+        baseDir: project,
+        isInteractive: () => true,
+        promptSkills: async (context) => {
+          skillContext = context;
+          return ["visual-plan"];
+        },
+        promptClients: async () => ["codex"],
+        promptScope: async () => "project",
+        promptPlanMode: async () => "hosted",
+        promptUpdateInstructions: async () => false,
+      });
+    } finally {
+      restoreDirect();
+    }
 
     expect(skillContext?.options[0]?.hint).toContain(
       "interactive visual plans",

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -275,31 +275,60 @@ export function parseSkillsCliArgs(argv: string[]): ParsedArgs {
  */
 function toCoreSkillsArgv(parsed: ParsedArgs): string[] {
   const out: string[] = [parsed.command];
-  if (parsed.command !== "add") return out;
-  if (parsed.skillNames.length === 1) {
-    out.push(parsed.skillNames[0]);
-  } else if (parsed.skillNames.length > 1) {
-    const appIds = unique(
-      parsed.skillNames
-        .map((name) => resolveAppForSkill(name)?.appId)
-        .filter((appId): appId is string => Boolean(appId)),
-    );
-    if (appIds.length === 1) out.push(appIds[0]);
-  } else if (parsed.copySource && parsed.source) out.push(parsed.source);
-  if (parsed.clients.length) out.push("--client", parsed.clients.join(","));
-  if (parsed.scopeExplicit) out.push("--scope", parsed.scope);
-  if (parsed.yes) out.push("--yes");
+  if (parsed.command === "add") {
+    if (parsed.copySource && parsed.source && parsed.skillNames.length > 0) {
+      out.push(parsed.source);
+      for (const skill of parsed.skillNames) out.push("--skill", skill);
+    } else if (parsed.skillNames.length === 1) {
+      out.push(parsed.skillNames[0]);
+    } else if (parsed.skillNames.length > 1) {
+      const appIds = unique(
+        parsed.skillNames
+          .map((name) => resolveAppForSkill(name)?.appId)
+          .filter((appId): appId is string => Boolean(appId)),
+      );
+      if (
+        appIds.length === 1 &&
+        parsed.skillNames.every((name) => resolveAppForSkill(name))
+      ) {
+        out.push(appIds[0]);
+      } else {
+        for (const skill of parsed.skillNames) out.push("--skill", skill);
+      }
+    }
+  }
+  if (parsed.command === "add" && parsed.clients.length) {
+    out.push("--client", parsed.clients.join(","));
+  }
+  if (parsed.command === "add" && parsed.scopeExplicit) {
+    out.push("--scope", parsed.scope);
+  }
+  if (parsed.command === "add" && parsed.yes) out.push("--yes");
   if (parsed.dryRun) out.push("--dry-run");
   if (parsed.printJson) out.push("--json");
-  if (parsed.withGithubAction) out.push("--with-github-action");
-  if (parsed.planMode) out.push("--mode", parsed.planMode);
-  if (parsed.mcpUrl) out.push("--mcp-url", parsed.mcpUrl);
-  if (parsed.force) out.push("--force");
-  if (parsed.mcp === false) out.push("--no-mcp");
-  if (parsed.connect === false) out.push("--no-connect");
-  if (parsed.updateInstructions === true) out.push("--update-instructions");
-  if (parsed.updateInstructions === false) out.push("--no-update-instructions");
+  if (parsed.command === "add" && parsed.withGithubAction)
+    out.push("--with-github-action");
+  if (parsed.command === "add" && parsed.planMode)
+    out.push("--mode", parsed.planMode);
+  if (parsed.command === "add" && parsed.mcpUrl)
+    out.push("--mcp-url", parsed.mcpUrl);
+  if (parsed.command === "add" && parsed.force) out.push("--force");
+  if (parsed.command === "add" && parsed.mcp === false) out.push("--no-mcp");
+  if (parsed.command === "add" && parsed.connect === false)
+    out.push("--no-connect");
+  if (parsed.command === "add" && parsed.updateInstructions === true)
+    out.push("--update-instructions");
+  if (parsed.command === "add" && parsed.updateInstructions === false)
+    out.push("--no-update-instructions");
   return out;
+}
+
+function shouldLoadPublicCatalog(parsed: ParsedArgs): boolean {
+  if (parsed.command === "list") return true;
+  if (parsed.command !== "add") return false;
+  if (parsed.copySource && parsed.source) return true;
+  if (parsed.skillNames.length === 0) return true;
+  return parsed.skillNames.some((name) => !resolveAppForSkill(name));
 }
 
 export async function runSkillsCli(
@@ -320,33 +349,62 @@ export async function runSkillsCli(
 ): Promise<void> {
   const parsed = parseSkillsCliArgs(argv);
 
-  // PIVOT: `@agent-native/skills` delegates explicitly selected built-in
-  // app-backed installs to `@agent-native/core` when using the default source,
-  // so app-specific flows like Plan modes stay canonical. The default add/list
-  // flow and explicit copied/plain sources stay here so they can install live
-  // BuilderIO/skills content and arbitrary skill repos.
-  // AGENT_NATIVE_SKILLS_DIRECT=1 (set when core delegates a plain repo back to us)
-  // always forces the direct path and breaks the skills → core → skills loop.
+  // `@agent-native/skills` normally uses the exact same core flow as
+  // `agent-native skills`; it only passes a broader public skill catalog.
+  // AGENT_NATIVE_SKILLS_DIRECT=1 is set by core when it shells out to this
+  // package as a headless file-copy worker for public/plain skill repos. That
+  // direct mode is intentionally non-user-facing prompt plumbing.
   if (process.env.AGENT_NATIVE_SKILLS_DIRECT !== "1") {
-    const selectedAppIds = unique(
-      parsed.skillNames
-        .map((name) => resolveAppForSkill(name)?.appId)
-        .filter((appId): appId is string => Boolean(appId)),
-    );
-    const coreOnlyAppSkills =
-      parsed.skillNames.length > 0 &&
-      parsed.skillNames.every(
-        (name) => resolveAppForSkill(name) !== undefined,
-      ) &&
-      selectedAppIds.length === 1;
-    const defaultSource = !parsed.copySource && !parsed.source;
-    if (parsed.command === "add" && coreOnlyAppSkills && defaultSource) {
-      const { runSkills } = await import("@agent-native/core/cli/skills");
+    if (parsed.command === "help") {
+      process.stdout.write(`${HELP}\n`);
+      return;
+    }
+    const loadedSource = shouldLoadPublicCatalog(parsed)
+      ? await materializeSource(parsed.source ?? DEFAULT_SKILLS_SOURCE)
+      : null;
+    try {
+      const { runSkills } = (await import("@agent-native/core/cli/skills")) as {
+        runSkills: (
+          argv: string[],
+          options: Record<string, unknown>,
+        ) => Promise<void>;
+      };
+      const publicSkillEntries = loadedSource
+        ? discoverSkills(loadedSource.root).map((entry) => ({
+            name: entry.name,
+            description: entry.description,
+          }))
+        : [];
       await runSkills(toCoreSkillsArgv(parsed), {
+        log: options.log,
         isInteractive: options.isInteractive,
         baseDir: parsed.baseDir ?? options.baseDir,
+        catalogMode: "all",
+        publicSkillSource:
+          loadedSource?.root ?? parsed.source ?? DEFAULT_SKILLS_SOURCE,
+        publicSkillEntries,
+        promptSkills: options.promptSkills
+          ? async (context: any) =>
+              options.promptSkills?.({
+                initialSkills: context.initialTargets,
+                options: context.options,
+              }) ?? null
+          : undefined,
+        promptClients: options.promptClients as any,
+        promptScope: options.promptScope,
+        promptGithubAction: options.promptGithubAction
+          ? async (context: any) =>
+              options.promptGithubAction?.({
+                workflowPath: context.workflowPath,
+              }) ?? null
+          : undefined,
+        promptPlanMode: options.promptPlanMode,
+        promptPlanMcpUrl: options.promptPlanMcpUrl,
+        promptUpdateInstructions: options.promptUpdateInstructions,
       });
       return;
+    } finally {
+      loadedSource?.cleanup?.();
     }
   }
 


### PR DESCRIPTION
## Summary
- Route normal @agent-native/skills list/add flows through the core skills CLI with catalogMode=all
- Keep agent-native/core skills on the Agent Native-only catalog while sharing the same Clack prompts and install decisions
- Add tests for catalog filtering, public-skill prompt order, and the direct headless copy fallback

## Validation
- pnpm prep
- pnpm --filter @agent-native/core build
- pnpm --filter @agent-native/skills build
- node packages/core/bin/agent-native.js skills list --json
- node packages/skills/dist/cli.js list --copy .agents/skills --json
- node packages/skills/dist/cli.js add --copy <tmp repo> --skill quick-recap --client codex --scope project --yes --dry-run --json
- node packages/core/bin/agent-native.js skills add visual-plan --mode local-files --client codex --scope project --dry-run --json
