### PR TITLE
Tighten Plan recap screenshot padding

### DIFF
--- a/templates/plan/app/global.css
+++ b/templates/plan/app/global.css
@@ -148,6 +148,15 @@
     --plan-canvas: #0d1117;
   }
 
+  .plan-content-surface[data-recap-screenshot-theme] .plan-document-shell {
+    padding: 10px;
+  }
+
+  .plan-content-surface[data-recap-screenshot-theme] .plan-document-body {
+    margin-inline: 0;
+    padding-inline: 0;
+  }
+
   .bg-plan-document {
     background-color: var(--plan-document);
   }


### PR DESCRIPTION
## Summary
- reduce Plan recap screenshot document padding to 10px
- reset the wide document body inset in screenshot mode

## Testing
- pnpm exec prettier --check templates/plan/app/global.css
- pnpm --filter plan test -- app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx