### PR TITLE
Fix skills CLI picker flow

### DIFF
--- a/.changeset/fix-skills-cli-picker.md
+++ b/.changeset/fix-skills-cli-picker.md
@@ -1,0 +1,8 @@
+---
+"@agent-native/core": patch
+"@agent-native/skills": patch
+---
+
+Fix the shared skills CLI picker so the standalone skills package installs with
+its matching core runtime, defaults public skills visibly, asks the Plan storage
+mode before client setup, and avoids duplicate Claude Code client choices.

--- a/packages/core/src/cli/connect.ts
+++ b/packages/core/src/cli/connect.ts
@@ -99,11 +99,14 @@ const REMOTE_MCP_OAUTH_CLIENTS = new Set<ClientId>([
   "claude-code-cli",
 ]);
 
+let logOutImpl = (msg: string) => process.stdout.write(`${msg}\n`);
+let logErrImpl = (msg: string) => process.stderr.write(`${msg}\n`);
+
 function logOut(msg: string): void {
-  process.stdout.write(`${msg}\n`);
+  logOutImpl(msg);
 }
 function logErr(msg: string): void {
-  process.stderr.write(`${msg}\n`);
+  logErrImpl(msg);
 }
 
 // ---------------------------------------------------------------------------
@@ -644,6 +647,9 @@ export interface ConnectDeps {
   preferencesFile?: string;
   /** Override the saved dev/prod profile file. */
   profilesFile?: string;
+  /** Optional output hooks used when another clack-based command embeds connect. */
+  logOut?: (message: string) => void;
+  logErr?: (message: string) => void;
 }
 
 function realSleep(ms: number): Promise<void> {
@@ -2467,14 +2473,18 @@ export async function runConnect(
   args: string[],
   deps: ConnectDeps = {},
 ): Promise<void> {
-  if (args[0] === "--help" || args[0] === "-h" || args[0] === "help") {
-    logOut(HELP);
-    return;
-  }
-
-  const parsed = parseConnectArgs(args);
-
+  const previousLogOut = logOutImpl;
+  const previousLogErr = logErrImpl;
+  logOutImpl = deps.logOut ?? previousLogOut;
+  logErrImpl = deps.logErr ?? previousLogErr;
   try {
+    if (args[0] === "--help" || args[0] === "-h" || args[0] === "help") {
+      logOut(HELP);
+      return;
+    }
+
+    const parsed = parseConnectArgs(args);
+
     if (parsed.mode) {
       let ok: boolean;
       if (parsed.mode === "reconnect" || parsed.mode === "reauth") {
@@ -2531,5 +2541,8 @@ export async function runConnect(
   } catch (err: any) {
     logErr(`  ${err?.message ?? err}`);
     process.exitCode = 1;
+  } finally {
+    logOutImpl = previousLogOut;
+    logErrImpl = previousLogErr;
   }
 }

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -138,6 +138,43 @@ describe("agent-native skills", () => {
     expect(result.connected).toBe(false);
   });
 
+  it("reports pending connect when --no-connect skips Codex MCP config", async () => {
+    const root = tmpDir();
+    const codexHome = path.join(root, "codex-home");
+    fs.mkdirSync(codexHome, { recursive: true });
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = codexHome;
+
+    try {
+      const result = await addAgentNativeSkill(
+        parseSkillsArgs([
+          "add",
+          "visual-plan",
+          "--client",
+          "codex",
+          "--scope",
+          "user",
+          "--no-connect",
+        ]),
+        {
+          baseDir: root,
+          isInteractive: () => true,
+          promptPlanMode: async () => "hosted",
+          runCommand: async () => 0,
+        },
+      );
+
+      expect(result.mcpClients).toEqual([]);
+      expect(result.connectCommand).toBe(
+        "npx @agent-native/core@latest connect https://plan.agent-native.com --client codex --scope user",
+      );
+      expect(fs.existsSync(path.join(codexHome, "config.toml"))).toBe(false);
+    } finally {
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+    }
+  });
+
   it("prints the connect command instead of auth in a non-interactive shell", async () => {
     const root = tmpDir();
     const runConnect = vi.fn(async () => {});
@@ -184,7 +221,7 @@ describe("agent-native skills", () => {
     expect(runConnect).toHaveBeenCalledWith([
       "https://assets.agent-native.com",
       "--client",
-      "all",
+      "claude-code,codex,cowork",
       "--scope",
       "project",
     ]);
@@ -700,6 +737,8 @@ describe("agent-native skills", () => {
         "codex",
         "--scope",
         "project",
+        "--cwd",
+        root,
         "--update-instructions",
         "--with-github-action",
         "--no-connect",
@@ -723,6 +762,7 @@ describe("agent-native skills", () => {
       expect.arrayContaining([
         "@agent-native/skills@latest",
         "add",
+        "--copy",
         "BuilderIO/skills",
         "--skill",
         "quick-recap",
@@ -776,10 +816,13 @@ describe("agent-native skills", () => {
       expect(promptClients).toHaveBeenCalledTimes(1);
       expect(promptClients.mock.calls[0]?.[0].initialClients).toEqual([
         "claude-code",
-        "claude-code-cli",
         "codex",
         "cowork",
       ]);
+      expect(
+        promptClients.mock.calls[0]?.[0].options.map((o) => o.value),
+      ).toEqual(["claude-code", "codex", "cowork"]);
+      expect(promptClients.mock.calls[0]?.[0].installsMcp).toBe(true);
       // Built-in instructions are written in-process for each selected client.
       expect(
         fs.existsSync(path.join(codexHome, "skills", "assets", "SKILL.md")),
@@ -1088,7 +1131,74 @@ describe("agent-native skills", () => {
       "context-xray",
       "quick-recap",
     ]);
-    expect(allContext?.initialTargets).toEqual(["visual-plan", "visual-recap"]);
+    expect(allContext?.initialTargets).toEqual([
+      "visual-plan",
+      "visual-recap",
+      "quick-recap",
+    ]);
+  });
+
+  it("asks for plan mode before clients and skips MCP for local-files", async () => {
+    const root = tmpDir();
+    const calls: string[] = [];
+    const runConnect = vi.fn(async () => {});
+    const promptClients = vi.fn(
+      async (context: {
+        installsMcp: boolean;
+        options: Array<{ value: string }>;
+      }) => {
+        calls.push(`clients:${context.installsMcp}`);
+        return ["codex" as const];
+      },
+    );
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runSkills(["add"], {
+      baseDir: root,
+      isInteractive: () => true,
+      promptSkills: async () => {
+        calls.push("skills");
+        return ["visual-plan", "visual-recap"];
+      },
+      promptPlanMode: async () => {
+        calls.push("plan-mode");
+        return "local-files";
+      },
+      promptClients,
+      promptScope: async () => {
+        calls.push("scope");
+        return "project";
+      },
+      promptGithubAction: async () => {
+        calls.push("github-action");
+        return false;
+      },
+      runConnect,
+      runCommand: async () => 0,
+    });
+
+    expect(calls).toEqual([
+      "skills",
+      "plan-mode",
+      "clients:false",
+      "scope",
+      "github-action",
+    ]);
+    expect(runConnect).not.toHaveBeenCalled();
+    expect(
+      promptClients.mock.calls[0]?.[0].options.map((o) => o.value),
+    ).toEqual(["claude-code", "codex"]);
+    expect(fs.existsSync(path.join(root, ".codex", "config.toml"))).toBe(false);
+    expect(
+      fs.existsSync(
+        path.join(root, ".agents", "skills", "visual-plan", "SKILL.md"),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(root, ".agents", "skills", "visual-recap", "SKILL.md"),
+      ),
+    ).toBe(true);
   });
 
   it("runs public skills through the same prompt flow before delegating the copy", async () => {
@@ -1137,6 +1247,7 @@ describe("agent-native skills", () => {
       expect.arrayContaining([
         "@agent-native/skills@latest",
         "add",
+        "--copy",
         "BuilderIO/skills",
         "--skill",
         "quick-recap",
@@ -1144,6 +1255,8 @@ describe("agent-native skills", () => {
         "codex",
         "--scope",
         "project",
+        "--cwd",
+        root,
         "--update-instructions",
       ]),
     );
@@ -1230,7 +1343,7 @@ describe("agent-native skills", () => {
     );
 
     expect(result.commands).toEqual([
-      "npx @agent-native/core@latest skills add assets --client all --scope project --yes",
+      "npx @agent-native/core@latest skills add assets --client claude-code,codex,cowork --scope project --yes",
     ]);
     expect(result.commands.join("\n")).not.toContain(os.tmpdir());
     expect(fs.existsSync(path.join(root, ".mcp.json"))).toBe(false);
@@ -1252,7 +1365,7 @@ describe("agent-native skills", () => {
     );
 
     expect(result.commands).toEqual([
-      "npx @agent-native/core@latest skills add visual-recap --client all --scope project --with-github-action --yes",
+      "npx @agent-native/core@latest skills add visual-recap --client claude-code,codex,cowork --scope project --with-github-action --yes",
     ]);
     expect(result.githubActionPath).toBe(
       path.join(".github", "workflows", "pr-visual-recap.yml"),

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -2314,6 +2314,15 @@ const CLIENT_HINTS: Record<ClientId, string> = {
   cowork: "~/.cowork/mcp.json",
 };
 
+const SKILLS_CLIENTS: ClientId[] = ["claude-code", "codex", "cowork"];
+const SKILL_INSTRUCTION_CLIENTS: ClientId[] = ["claude-code", "codex"];
+const SKILL_INSTRUCTION_CLIENT_HINTS: Record<ClientId, string> = {
+  "claude-code": ".claude/skills or .claude/commands",
+  "claude-code-cli": ".claude/skills or .claude/commands",
+  codex: ".agents/skills or ~/.codex/skills",
+  cowork: "MCP only",
+};
+
 type SkillsCommand = "list" | "add" | "status" | "update" | "help";
 type PlanInstallMode = "hosted" | "local-files" | "self-hosted";
 
@@ -2533,6 +2542,7 @@ export interface RunSkillsOptions {
 interface SkillsClientPromptContext {
   initialClients: ClientId[];
   options: Array<{ value: ClientId; label: string; hint: string }>;
+  installsMcp: boolean;
 }
 
 interface SkillsTargetPromptContext {
@@ -3055,11 +3065,43 @@ function normalizeClientIds(values: unknown): ClientId[] {
   return out;
 }
 
-function clientPromptOptions(): SkillsClientPromptContext["options"] {
-  return CLIENTS.map((client) => ({
+function normalizeSkillsClientIds(values: unknown): ClientId[] {
+  const seen = new Set<ClientId>();
+  const out: ClientId[] = [];
+  for (const client of normalizeClientIds(values)) {
+    const normalized = client === "claude-code-cli" ? "claude-code" : client;
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    out.push(normalized);
+  }
+  return out;
+}
+
+function resolveSkillsClientArg(client: string): ClientId[] {
+  return normalizeSkillsClientIds(resolveClients(client));
+}
+
+function skillsClients(installsMcp: boolean): ClientId[] {
+  return installsMcp ? SKILLS_CLIENTS : SKILL_INSTRUCTION_CLIENTS;
+}
+
+function filterSkillsClients(
+  clients: ClientId[],
+  installsMcp: boolean,
+): ClientId[] {
+  if (installsMcp) return clients;
+  return clients.filter((client) => SKILL_INSTRUCTION_CLIENTS.includes(client));
+}
+
+function clientPromptOptions(
+  installsMcp: boolean,
+): SkillsClientPromptContext["options"] {
+  return skillsClients(installsMcp).map((client) => ({
     value: client,
     label: CLIENT_LABELS[client],
-    hint: CLIENT_HINTS[client],
+    hint: installsMcp
+      ? CLIENT_HINTS[client]
+      : SKILL_INSTRUCTION_CLIENT_HINTS[client],
   }));
 }
 
@@ -3140,6 +3182,13 @@ function skillPromptOptions(
   ];
 }
 
+function defaultSkillPromptTargets(options: RunSkillsOptions): string[] {
+  return [
+    ...DEFAULT_SKILL_PROMPT_TARGETS,
+    ...publicSkillEntries(options).map((entry) => entry.name),
+  ];
+}
+
 function publicSkillSelectionTarget(skillNames: string[]): string {
   return `${PUBLIC_SKILL_TARGET_PREFIX}${skillNames.join(",")}`;
 }
@@ -3201,10 +3250,13 @@ async function promptForClients(
   context: SkillsClientPromptContext,
 ): Promise<ClientId[] | null> {
   const clack = await import("@clack/prompts");
+  const message = context.installsMcp
+    ? "Install the MCP connector and skills for which local agents?\n" +
+      "  (space toggles, enter confirms; saved for next time)"
+    : "Install skill instructions for which local agents?\n" +
+      "  (space toggles, enter confirms; saved for next time)";
   const result = await clack.multiselect({
-    message:
-      "Install the MCP connector for which local agents?\n" +
-      "  (space toggles, enter confirms; saved for next time)",
+    message,
     options: context.options,
     initialValues: context.initialClients,
     required: true,
@@ -3333,16 +3385,27 @@ async function promptForSkills(
 async function resolveSkillsClients(
   parsed: ParsedSkillsArgs,
   options: RunSkillsOptions,
+  installsMcp: boolean,
 ): Promise<ClientId[] | null> {
   if (parsed.clientExplicit || !shouldPrompt(parsed, options)) {
-    return resolveClients(parsed.client);
+    const clients = filterSkillsClients(
+      resolveSkillsClientArg(parsed.client),
+      installsMcp,
+    );
+    if (clients.length === 0) {
+      throw new Error(
+        "Local-file skill instructions only support Codex or Claude Code clients.",
+      );
+    }
+    return clients;
   }
-  const initialClients = resolveClients("all");
+  const initialClients = skillsClients(installsMcp);
   const prompt = options.promptClients ?? promptForClients;
-  const selected = normalizeClientIds(
+  const selected = normalizeSkillsClientIds(
     await prompt({
       initialClients,
-      options: clientPromptOptions(),
+      options: clientPromptOptions(installsMcp),
+      installsMcp,
     }),
   );
   if (selected.length === 0) return null;
@@ -3477,7 +3540,7 @@ async function resolveSkillTargets(
     available: promptOptions.map((option) => option.value).join(","),
   });
   const selected = await prompt({
-    initialTargets: DEFAULT_SKILL_PROMPT_TARGETS,
+    initialTargets: defaultSkillPromptTargets(options),
     options: promptOptions,
   });
   if (!selected || selected.length === 0) return null;
@@ -3717,7 +3780,7 @@ function dryRunInstallCommand(
   parsed: ParsedSkillsArgs,
   target: string,
 ): string {
-  const clients = parsed.clients ?? resolveClients(parsed.client);
+  const clients = parsed.clients ?? resolveSkillsClientArg(parsed.client);
   const args = [
     "@agent-native/core@latest",
     "skills",
@@ -3862,17 +3925,20 @@ function agentNativeSkillsInstallArgs(
   parsed: ParsedSkillsArgs,
   target: string,
   clients: ClientId[],
+  baseDir: string | undefined,
 ): string[] {
   const args = [
     "--yes",
     "@agent-native/skills@latest",
     "add",
+    "--copy",
     target,
     "--client",
     clientArgForClients(clients),
     "--scope",
     parsed.scope,
   ];
+  if (baseDir) args.push("--cwd", baseDir);
   if (parsed.withGithubAction) args.push("--with-github-action");
   if (parsed.force) args.push("--force");
   if (parsed.planMode) args.push("--mode", parsed.planMode);
@@ -3906,7 +3972,7 @@ async function addPlainSkillRepo(
     );
   }
 
-  const clients = parsed.clients ?? resolveClients(parsed.client);
+  const clients = parsed.clients ?? resolveSkillsClientArg(parsed.client);
   const skillsAgents = skillsAgentsForClients(clients);
   const selectedSkillNames = parsed.plainSkillNames ?? [];
   if (skillsAgents.length === 0) {
@@ -3914,7 +3980,12 @@ async function addPlainSkillRepo(
       "Plain skill repositories can only install instructions for Codex or Claude Code clients.",
     );
   }
-  const args = agentNativeSkillsInstallArgs(parsed, target, clients);
+  const args = agentNativeSkillsInstallArgs(
+    parsed,
+    target,
+    clients,
+    options.baseDir,
+  );
   if (!parsed.dryRun) {
     const code = await (options.runCommand ?? runCommand)("npx", args, {
       stdio: parsed.yes ? "silent" : "inherit",
@@ -4010,13 +4081,26 @@ async function connectAfterEnsure(
   options.log?.(`Authenticating ${installTarget.displayName}…`);
   options.telemetry?.track("skills_cli connect started");
   try {
-    await (options.runConnect ?? runConnect)([
+    const connectArgs = [
       hostedUrl,
       "--client",
       clientArgForClients(clients),
       "--scope",
       parsed.scope,
-    ]);
+    ];
+    if (options.runConnect) {
+      await options.runConnect(connectArgs);
+    } else {
+      await runConnect(connectArgs, {
+        isInteractive: options.isInteractive,
+        logOut: (message) => {
+          if (message.trim()) options.log?.(message);
+        },
+        logErr: (message) => {
+          if (message.trim()) options.log?.(message);
+        },
+      });
+    }
     options.telemetry?.track("skills_cli connect completed");
     return { connected: true, connectCommand: "" };
   } catch (err: any) {
@@ -4094,7 +4178,7 @@ export async function addAgentNativeSkill(
         "Context X-Ray does not need MCP config yet. Run without --mcp-only.",
       );
     }
-    const clients = parsed.clients ?? resolveClients(parsed.client);
+    const clients = parsed.clients ?? resolveSkillsClientArg(parsed.client);
     const skillsAgents = skillsAgentsForClients(clients);
     if (parsed.dryRun) {
       const githubActionPath =
@@ -4150,7 +4234,7 @@ export async function addAgentNativeSkill(
   if (parsed.mcpUrl) {
     installTarget = withMcpUrlOverride(installTarget, parsed.mcpUrl);
   }
-  const clients = parsed.clients ?? resolveClients(parsed.client);
+  const clients = parsed.clients ?? resolveSkillsClientArg(parsed.client);
   installTarget = preserveMcpUrlAppPathOverride(installTarget, parsed.mcpUrl);
   const skillsAgents = skillsAgentsForClients(clients);
   if (parsed.dryRun) {
@@ -4195,6 +4279,7 @@ export async function addAgentNativeSkill(
   let instructionsWritten: string[] | undefined;
   let connected = false;
   let connectCommand: string | undefined;
+  let registeredMcpClients: ClientId[] = shouldRegisterMcp ? clients : [];
 
   try {
     if (parsed.instructions) {
@@ -4264,7 +4349,7 @@ export async function addAgentNativeSkill(
         `npx @agent-native/core@latest app-skill ensure --manifest ${installTarget.loaded.file} --client ${parsed.client} --scope ${parsed.scope} --yes`,
       );
       if (!parsed.dryRun) {
-        await ensureAppSkill(installTarget.loaded, {
+        const ensureResult = await ensureAppSkill(installTarget.loaded, {
           clients,
           scope: parsed.scope,
           baseDir: options.baseDir,
@@ -4272,6 +4357,9 @@ export async function addAgentNativeSkill(
           confirm: true,
           log: options.log,
         });
+        registeredMcpClients = ensureResult.written.map(
+          (written) => written.client,
+        );
         options.telemetry?.track("skills_cli mcp registered", {
           skills: installTarget.skillNames.join(","),
         });
@@ -4289,7 +4377,20 @@ export async function addAgentNativeSkill(
           );
           connected = result.connected;
           connectCommand = result.connectCommand || undefined;
+          if (connected) registeredMcpClients = clients;
           if (connectCommand) commands.push(connectCommand);
+        } else {
+          const pendingClients = clients.filter(
+            (client) => !registeredMcpClients.includes(client),
+          );
+          if (pendingClients.length > 0) {
+            connectCommand = connectCommandFor(
+              installTarget.loaded.manifest.hosted.url,
+              pendingClients,
+              parsed.scope,
+            );
+            commands.push(connectCommand);
+          }
         }
       }
     }
@@ -4357,7 +4458,7 @@ export async function addAgentNativeSkill(
         knownTarget === "visual-plans" && planMode === "local-files"
           ? ""
           : installTarget.loaded.manifest.hosted.mcpUrl,
-      mcpClients: shouldRegisterMcp ? clients : [],
+      mcpClients: registeredMcpClients,
       dryRun: parsed.dryRun,
       commands,
       written: instructionsWritten,
@@ -4434,6 +4535,27 @@ function planModeSummary(mode: PlanInstallMode): string {
   if (mode === "local-files") return "Local files - No sharing, all local.";
   if (mode === "self-hosted") return "Self-hosted/custom Plan app";
   return "Hosted Plans - shareable links and comments";
+}
+
+function targetInstallsMcp(
+  target: string,
+  parsed: Pick<ParsedSkillsArgs, "mcp" | "planMode">,
+): boolean {
+  if (!parsed.mcp) return false;
+  if (publicSkillSelectionNames(target)) return false;
+  const knownTarget = normalizeKnownSkillTarget(target);
+  if (knownTarget === "visual-plans") return parsed.planMode !== "local-files";
+  if (knownTarget) {
+    return !isLocalOnlyBuiltInSkill(BUILT_IN_APP_SKILLS[knownTarget]);
+  }
+  return true;
+}
+
+function targetsInstallMcp(
+  targets: string[],
+  parsed: ParsedSkillsArgs,
+): boolean {
+  return targets.some((target) => targetInstallsMcp(target, parsed));
 }
 
 function instructionContentForSkill(skillName: string): string | null {
@@ -4560,9 +4682,15 @@ export async function runSkills(
   if (parsed.baseDir) {
     options = { ...options, baseDir: path.resolve(parsed.baseDir) };
   }
+  const clackForLog = parsed.printJson
+    ? undefined
+    : await import("@clack/prompts");
   const log = parsed.printJson
     ? undefined
-    : (message: string) => process.stdout.write(`${message}\n`);
+    : (message: string) => {
+        if (!message.trim()) return;
+        clackForLog?.log.info(message);
+      };
 
   if (parsed.command === "help") {
     process.stdout.write(`${HELP}\n`);
@@ -4680,7 +4808,12 @@ export async function runSkills(
       });
     }
 
-    const clients = await resolveSkillsClients(parsed, optionsWithTelemetry);
+    const installsMcp = targetsInstallMcp(targets, parsed);
+    const clients = await resolveSkillsClients(
+      parsed,
+      optionsWithTelemetry,
+      installsMcp,
+    );
     if (!clients) {
       telemetry.track("skills_cli cancelled", { step: "clients" });
       return;
@@ -4891,11 +5024,11 @@ export async function runSkills(
     for (const line of [githubActionLine, githubActionSuggestionLine].filter(
       Boolean,
     )) {
-      process.stdout.write(`${line}\n`);
+      clack.log.info(line);
     }
 
     const slashCommands = completedSkills.map((name) => `/${name}`).join("  ");
-    const configuredEveryClient = CLIENTS.every((client) =>
+    const configuredEveryClient = SKILLS_CLIENTS.every((client) =>
       clients.includes(client),
     );
     const clientHint = configuredEveryClient

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -36,16 +36,13 @@
     "test": "vitest --run src --passWithNoTests",
     "prepublishOnly": "npm run build"
   },
-  "peerDependencies": {
-    "@agent-native/core": ">=0.48.4"
-  },
   "devDependencies": {
-    "@agent-native/core": "workspace:*",
     "@types/node": "^25.9.2",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "dependencies": {
+    "@agent-native/core": ">=0.51.11",
     "@clack/prompts": "^1.5.1"
   }
 }

--- a/packages/skills/src/index.spec.ts
+++ b/packages/skills/src/index.spec.ts
@@ -32,6 +32,17 @@ function tmpDir(): string {
   return root;
 }
 
+function workspaceRoot(): string {
+  let current = process.cwd();
+  while (current !== path.dirname(current)) {
+    if (fs.existsSync(path.join(current, "pnpm-workspace.yaml"))) {
+      return current;
+    }
+    current = path.dirname(current);
+  }
+  throw new Error("Could not locate workspace root.");
+}
+
 function writeSkill(repo: string, name: string, body = "Body"): void {
   const dir = path.join(repo, "skills", name);
   fs.mkdirSync(dir, { recursive: true });
@@ -53,6 +64,18 @@ function enableDirectSkillsMode(): () => void {
 }
 
 describe("@agent-native/skills", () => {
+  it("declares core as a runtime dependency for npx installs", () => {
+    const pkg = JSON.parse(
+      fs.readFileSync(
+        path.join(workspaceRoot(), "packages", "skills", "package.json"),
+        "utf-8",
+      ),
+    );
+
+    expect(pkg.dependencies["@agent-native/core"]).toBe(">=0.51.11");
+    expect(pkg.peerDependencies?.["@agent-native/core"]).toBeUndefined();
+  });
+
   it("parses the no-source BuilderIO skills install command", () => {
     const parsed = parseSkillsCliArgs([
       "add",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,7 +154,7 @@ importers:
         version: 0.12.22(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
       '@assistant-ui/react-markdown':
         specifier: ^0.12.6
-        version: 0.12.8(@assistant-ui/react@0.12.22(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 0.12.8(@assistant-ui/react@0.12.22(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@assistant-ui/store':
         specifier: '>=0.2.9 <0.2.14'
         version: 0.2.13(@assistant-ui/tap@0.5.14(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)
@@ -1119,13 +1119,13 @@ importers:
 
   packages/skills:
     dependencies:
+      '@agent-native/core':
+        specifier: '>=0.51.11'
+        version: 0.51.11(de9b5d2d1d144f333e9162d483ba7165)
       '@clack/prompts':
         specifier: ^1.5.1
         version: 1.5.1
     devDependencies:
-      '@agent-native/core':
-        specifier: workspace:*
-        version: link:../core
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
@@ -4519,6 +4519,100 @@ packages:
 
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
+
+  '@agent-native/core@0.51.11':
+    resolution: {integrity: sha512-X9x2c6hyafSMYjQcOD3tR6esIK/kH7wVmgUKZcFdvFh6DGATu7TnU8EHjCZPynenc1CLzqxfK28N6/nDv5AEbA==}
+    engines: {node: '>=22'}
+    hasBin: true
+    peerDependencies:
+      '@ai-sdk/anthropic': '>=3'
+      '@ai-sdk/cohere': '>=3'
+      '@ai-sdk/google': '>=3'
+      '@ai-sdk/groq': '>=3'
+      '@ai-sdk/mistral': '>=3'
+      '@ai-sdk/openai': '>=3'
+      '@excalidraw/excalidraw': '>=0.18'
+      '@excalidraw/mermaid-to-excalidraw': '>=2'
+      '@openrouter/ai-sdk-provider': '>=2'
+      '@supabase/supabase-js': '>=2'
+      '@tabler/icons-react': '>=3'
+      '@tailwindcss/vite': '>=4'
+      '@tanstack/react-query': '>=5'
+      '@vitejs/plugin-react-swc': '>=4'
+      '@xterm/addon-fit': '>=0.11'
+      '@xterm/addon-web-links': '>=0.12'
+      '@xterm/xterm': '>=6'
+      ai: '>=6'
+      ai-sdk-ollama: '>=3'
+      convex: '>=1'
+      drizzle-kit: '>=0.31'
+      mermaid: '>=11'
+      node-pty: '>=1'
+      postgres: '>=3'
+      react: 19.2.7
+      react-dom: 19.2.7
+      react-router: '>=7'
+      tailwindcss: '>=4'
+      typescript: '>=5'
+      vite: '>=5'
+      ws: '>=8'
+    peerDependenciesMeta:
+      '@ai-sdk/anthropic':
+        optional: true
+      '@ai-sdk/cohere':
+        optional: true
+      '@ai-sdk/google':
+        optional: true
+      '@ai-sdk/groq':
+        optional: true
+      '@ai-sdk/mistral':
+        optional: true
+      '@ai-sdk/openai':
+        optional: true
+      '@excalidraw/excalidraw':
+        optional: true
+      '@excalidraw/mermaid-to-excalidraw':
+        optional: true
+      '@openrouter/ai-sdk-provider':
+        optional: true
+      '@supabase/supabase-js':
+        optional: true
+      '@tabler/icons-react':
+        optional: true
+      '@tailwindcss/vite':
+        optional: true
+      '@tanstack/react-query':
+        optional: true
+      '@vitejs/plugin-react-swc':
+        optional: true
+      '@xterm/addon-fit':
+        optional: true
+      '@xterm/addon-web-links':
+        optional: true
+      '@xterm/xterm':
+        optional: true
+      ai:
+        optional: true
+      ai-sdk-ollama:
+        optional: true
+      convex:
+        optional: true
+      drizzle-kit:
+        optional: true
+      mermaid:
+        optional: true
+      node-pty:
+        optional: true
+      postgres:
+        optional: true
+      react-router:
+        optional: true
+      tailwindcss:
+        optional: true
+      vite:
+        optional: true
+      ws:
+        optional: true
 
   '@ai-sdk/anthropic@3.0.71':
     resolution: {integrity: sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==}
@@ -17488,6 +17582,225 @@ snapshots:
 
   7zip-bin@5.2.0: {}
 
+  '@agent-native/core@0.51.11(de9b5d2d1d144f333e9162d483ba7165)':
+    dependencies:
+      '@amplitude/analytics-browser': 2.41.1
+      '@anthropic-ai/sdk': 0.90.0(zod@4.4.3)
+      '@anthropic-ai/tokenizer': 0.0.4
+      '@assistant-ui/react': 0.12.22(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+      '@assistant-ui/react-markdown': 0.12.8(@assistant-ui/react@0.12.22(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@assistant-ui/store': 0.2.13(@assistant-ui/tap@0.5.14(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)
+      '@assistant-ui/tap': 0.5.14(@types/react@19.2.14)(react@19.2.7)
+      '@clack/prompts': 1.5.1
+      '@codemirror/lang-sql': 6.10.0
+      '@codemirror/theme-one-dark': 6.1.3
+      '@floating-ui/dom': 1.7.6
+      '@libsql/client': 0.15.15
+      '@modelcontextprotocol/ext-apps': 1.7.2(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@neondatabase/serverless': 1.1.0
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-router/dev': 7.16.0(@types/node@25.9.2)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.81.0)(yaml@2.9.0)
+      '@react-router/fs-routes': 7.16.0(@react-router/dev@7.16.0(@types/node@25.9.2)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.81.0)(yaml@2.9.0))(typescript@6.0.3)
+      '@resvg/resvg-js': 2.6.2
+      '@sentry/browser': 10.50.0
+      '@sentry/node': 10.50.0
+      '@standard-schema/spec': 1.1.0
+      '@tailwindcss/typography': 0.5.19(tailwindcss@4.3.0)
+      '@tanstack/react-table': 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
+      '@tiptap/extension-code-block-lowlight': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/extension-code-block@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(highlight.js@11.11.1)(lowlight@3.3.0)
+      '@tiptap/extension-collaboration': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@tiptap/y-tiptap@3.0.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(yjs@13.6.31)
+      '@tiptap/extension-collaboration-caret': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@tiptap/y-tiptap@3.0.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))
+      '@tiptap/extension-image': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      '@tiptap/extension-link': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+      '@tiptap/extension-placeholder': 3.26.0(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))
+      '@tiptap/extension-table': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
+      '@tiptap/extension-table-cell': 3.26.0(@tiptap/extension-table@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))
+      '@tiptap/extension-table-header': 3.26.0(@tiptap/extension-table@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))
+      '@tiptap/extension-table-row': 3.26.0(@tiptap/extension-table@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))
+      '@tiptap/extension-task-item': 3.26.0(@tiptap/extension-list@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))
+      '@tiptap/extension-task-list': 3.26.0(@tiptap/extension-list@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))
+      '@tiptap/pm': 3.26.0
+      '@tiptap/react': 3.26.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tiptap/starter-kit': 3.26.0
+      '@tiptap/y-tiptap': 3.0.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
+      '@uiw/react-codemirror': 4.25.10(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.2)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.6)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.0)(codemirror@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      better-auth: 1.6.16(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.12)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)))
+      better-sqlite3: 12.8.0
+      clsx: 2.1.1
+      cron-parser: 5.5.0
+      diff-match-patch: 1.0.5
+      dotenv: 17.4.0
+      drizzle-orm: 0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9)
+      fzstd: 0.1.1
+      h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.16))
+      highlight.js: 11.11.1
+      isbot: 5.1.40
+      jiti: 2.6.1
+      jose: 6.2.2
+      kiwi-schema: 0.5.0
+      lowlight: 3.3.0
+      minimatch: 10.2.5
+      nanoid: 5.1.9
+      next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      nitro: 3.0.260415-beta(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(dotenv@17.4.0)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(giget@3.2.0)(jiti@2.6.1)(rollup@4.60.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+      p-limit: 7.3.0
+      pako: 2.1.0
+      prettier: 3.8.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-markdown: 10.1.0(@types/react@19.2.14)(react@19.2.7)
+      recharts: 3.8.1(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.4)(react@19.2.7)(redux@5.0.1)
+      remark-gfm: 4.0.1
+      roughjs: 4.6.6
+      shiki: 4.0.2
+      sonner: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tailwind-merge: 3.6.0
+      tiptap-markdown: 0.9.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))
+      tw-animate-css: 1.4.0
+      typescript: 6.0.3
+      y-protocols: 1.0.7(yjs@13.6.31)
+      yjs: 13.6.31
+      zod: 4.4.3
+    optionalDependencies:
+      '@ai-sdk/anthropic': 3.0.71(zod@4.4.3)
+      '@ai-sdk/cohere': 3.0.30(zod@4.4.3)
+      '@ai-sdk/google': 3.0.64(zod@4.4.3)
+      '@ai-sdk/groq': 3.0.35(zod@4.4.3)
+      '@ai-sdk/mistral': 3.0.30(zod@4.4.3)
+      '@ai-sdk/openai': 3.0.53(zod@4.4.3)
+      '@excalidraw/excalidraw': 0.18.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@excalidraw/mermaid-to-excalidraw': 2.2.2
+      '@openrouter/ai-sdk-provider': 2.8.0(ai@6.0.168(zod@4.4.3))(zod@4.4.3)
+      '@supabase/supabase-js': 2.101.1
+      '@tabler/icons-react': 3.44.0(react@19.2.7)
+      '@tailwindcss/vite': 4.3.0(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@tanstack/react-query': 5.100.10(react@19.2.7)
+      '@vitejs/plugin-react-swc': 4.3.1(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@xterm/addon-fit': 0.11.0
+      '@xterm/addon-web-links': 0.12.0
+      '@xterm/xterm': 6.0.0
+      ai: 6.0.168(zod@4.4.3)
+      ai-sdk-ollama: 3.8.3(ai@6.0.168(zod@4.4.3))(zod@4.4.3)
+      convex: 1.34.1(react@19.2.7)
+      drizzle-kit: 0.31.10
+      mermaid: 11.15.0
+      node-pty: 1.1.0
+      playwright: 1.60.0
+      postgres: 3.4.9
+      react-router: 7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tailwindcss: 4.3.0
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/runtime'
+      - '@capacitor/preferences'
+      - '@cfworker/json-schema'
+      - '@cloudflare/workers-types'
+      - '@codemirror/autocomplete'
+      - '@codemirror/language'
+      - '@codemirror/lint'
+      - '@codemirror/search'
+      - '@codemirror/state'
+      - '@codemirror/view'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client-wasm'
+      - '@lynx-js/react'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@react-router/serve'
+      - '@sveltejs/kit'
+      - '@tanstack/react-start'
+      - '@tanstack/solid-start'
+      - '@tidbcloud/serverless'
+      - '@tiptap/extension-code-block'
+      - '@tiptap/extension-list'
+      - '@tiptap/extensions'
+      - '@types/better-sqlite3'
+      - '@types/node'
+      - '@types/pg'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vercel/postgres'
+      - '@vercel/queue'
+      - '@vitejs/plugin-rsc'
+      - '@xata.io/client'
+      - aws4fetch
+      - babel-plugin-macros
+      - bufferutil
+      - bun-types
+      - chokidar
+      - codemirror
+      - crossws
+      - expo-sqlite
+      - gel
+      - giget
+      - idb-keyval
+      - immer
+      - ioredis
+      - knex
+      - kysely
+      - less
+      - lightningcss
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - next
+      - pg
+      - prisma
+      - prosemirror-model
+      - prosemirror-state
+      - prosemirror-view
+      - react-is
+      - react-server-dom-webpack
+      - redux
+      - rollup
+      - sass
+      - sass-embedded
+      - solid-js
+      - sql.js
+      - sqlite3
+      - stylus
+      - sugarss
+      - supports-color
+      - svelte
+      - terser
+      - tsx
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - vitest
+      - vue
+      - wrangler
+      - xml2js
+      - yaml
+      - zephyr-agent
+
   '@ai-sdk/anthropic@3.0.71(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -17636,7 +17949,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@assistant-ui/core@0.1.10(@assistant-ui/store@0.2.13(@assistant-ui/tap@0.5.14(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@assistant-ui/tap@0.5.14(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(assistant-cloud@0.1.24)(react@19.2.7)(zustand@5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)))':
+  '@assistant-ui/core@0.1.10(@assistant-ui/store@0.2.13(@assistant-ui/tap@0.5.14(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@assistant-ui/tap@0.5.14(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(assistant-cloud@0.1.24)(react@19.2.7)(zustand@5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.7))':
     dependencies:
       '@assistant-ui/store': 0.2.13(@assistant-ui/tap@0.5.14(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)
       '@assistant-ui/tap': 0.5.14(@types/react@19.2.14)(react@19.2.7)
@@ -17648,7 +17961,7 @@ snapshots:
       react: 19.2.7
       zustand: 5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
 
-  '@assistant-ui/react-markdown@0.12.8(@assistant-ui/react@0.12.22(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@assistant-ui/react-markdown@0.12.8(@assistant-ui/react@0.12.22(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@assistant-ui/react': 0.12.22(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -17665,7 +17978,7 @@ snapshots:
 
   '@assistant-ui/react@0.12.22(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))':
     dependencies:
-      '@assistant-ui/core': 0.1.10(@assistant-ui/store@0.2.13(@assistant-ui/tap@0.5.14(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@assistant-ui/tap@0.5.14(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(assistant-cloud@0.1.24)(react@19.2.7)(zustand@5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)))
+      '@assistant-ui/core': 0.1.10(@assistant-ui/store@0.2.13(@assistant-ui/tap@0.5.14(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@assistant-ui/tap@0.5.14(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(assistant-cloud@0.1.24)(react@19.2.7)(zustand@5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.7))
       '@assistant-ui/store': 0.2.13(@assistant-ui/tap@0.5.14(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)
       '@assistant-ui/tap': 0.5.14(@types/react@19.2.14)(react@19.2.7)
       '@radix-ui/primitive': 1.1.3
@@ -22839,6 +23152,56 @@ snapshots:
       - tsx
       - yaml
 
+  '@react-router/dev@7.16.0(@types/node@25.9.2)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.81.0)(yaml@2.9.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.3
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@react-router/node': 7.16.0(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
+      '@remix-run/node-fetch-server': 0.13.0
+      arg: 5.0.2
+      babel-dead-code-elimination: 1.0.12
+      chokidar: 4.0.3
+      dedent: 1.7.2
+      es-module-lexer: 1.7.0
+      exit-hook: 2.2.1
+      isbot: 5.1.40
+      jsesc: 3.0.2
+      lodash: 4.18.1
+      p-map: 7.0.4
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      pkg-types: 2.3.0
+      prettier: 3.8.3
+      react-refresh: 0.14.2
+      react-router: 7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      semver: 7.8.0
+      tinyglobby: 0.2.16
+      valibot: 1.3.1(typescript@6.0.3)
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@25.9.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+    optionalDependencies:
+      typescript: 6.0.3
+      wrangler: 4.81.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   '@react-router/fs-routes@7.16.0(@react-router/dev@7.16.0(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.81.0)(yaml@2.9.0))(typescript@6.0.3)':
     dependencies:
       '@react-router/dev': 7.16.0(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.81.0)(yaml@2.9.0)
@@ -22856,6 +23219,13 @@ snapshots:
   '@react-router/fs-routes@7.16.0(@react-router/dev@7.16.0(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.81.0)(yaml@2.9.0))(typescript@6.0.3)':
     dependencies:
       '@react-router/dev': 7.16.0(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.81.0)(yaml@2.9.0)
+      minimatch: 10.2.5
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@react-router/fs-routes@7.16.0(@react-router/dev@7.16.0(@types/node@25.9.2)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.81.0)(yaml@2.9.0))(typescript@6.0.3)':
+    dependencies:
+      '@react-router/dev': 7.16.0(@types/node@25.9.2)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(wrangler@4.81.0)(yaml@2.9.0)
       minimatch: 10.2.5
     optionalDependencies:
       typescript: 6.0.3
@@ -23953,6 +24323,14 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 8.0.13(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
 
+  '@tailwindcss/vite@4.3.0(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+    optional: true
+
   '@tailwindcss/vite@4.3.0(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
@@ -24785,6 +25163,15 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
+  '@vitejs/plugin-react-swc@4.3.1(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      '@swc/core': 1.15.21
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@swc/helpers'
+    optional: true
+
   '@vitejs/plugin-react-swc@4.3.1(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
@@ -25304,6 +25691,38 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.14: {}
+
+  better-auth@1.6.16(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.12)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))):
+    dependencies:
+      '@better-auth/core': 1.6.16(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.2.2)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.6.16(@better-auth/core@1.6.16(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.2.2)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))
+      '@better-auth/kysely-adapter': 1.6.16(@better-auth/core@1.6.16(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.2.2)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.1)(kysely@0.28.15)
+      '@better-auth/memory-adapter': 1.6.16(@better-auth/core@1.6.16(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.2.2)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.1)
+      '@better-auth/mongo-adapter': 1.6.16(@better-auth/core@1.6.16(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.2.2)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.1)
+      '@better-auth/prisma-adapter': 1.6.16(@better-auth/core@1.6.16(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.2.2)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.1)
+      '@better-auth/telemetry': 1.6.16(@better-auth/core@1.6.16(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.2.2)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.2.2)
+      '@better-auth/utils': 0.4.1
+      '@better-fetch/fetch': 1.2.2
+      '@noble/ciphers': 2.1.1
+      '@noble/hashes': 2.0.1
+      better-call: 1.3.6(zod@4.4.3)
+      defu: 6.1.6
+      jose: 6.2.2
+      kysely: 0.28.15
+      nanostores: 1.2.0
+      zod: 4.4.3
+    optionalDependencies:
+      better-sqlite3: 12.8.0
+      drizzle-kit: 0.31.10
+      drizzle-orm: 0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9)
+      pg: 8.20.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      solid-js: 1.9.12
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1)(canvas@3.2.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
 
   better-auth@1.6.16(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.12)(vitest@4.1.8):
     dependencies:
@@ -29792,6 +30211,59 @@ snapshots:
       - sqlite3
       - uploadthing
 
+  nitro@3.0.260415-beta(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(dotenv@17.4.0)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(giget@3.2.0)(jiti@2.6.1)(rollup@4.60.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      consola: 3.4.2
+      crossws: 0.4.5(srvx@0.11.16)
+      db0: 0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))
+      env-runner: 0.1.11
+      h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.16))
+      hookable: 6.1.1
+      nf3: 0.3.17
+      ocache: 0.1.4
+      ofetch: 2.0.0-alpha.3
+      ohash: 2.0.11
+      rolldown: 1.1.0
+      srvx: 0.11.16
+      unenv: 2.0.0-rc.24
+      unstorage: 2.0.0-alpha.7(chokidar@4.0.3)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9)))(ioredis@5.10.1)(lru-cache@11.3.6)(ofetch@2.0.0-alpha.3)
+    optionalDependencies:
+      dotenv: 17.4.0
+      giget: 3.2.0
+      jiti: 2.6.1
+      rollup: 4.60.1
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - drizzle-orm
+      - idb-keyval
+      - ioredis
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - sqlite3
+      - uploadthing
+
   node-abi@3.89.0:
     dependencies:
       semver: 7.8.0
@@ -32272,6 +32744,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@3.2.4(@types/node@25.9.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.2(@types/node@25.9.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-plugin-solid@2.11.11(solid-js@1.9.12)(vite@8.0.16(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.0
@@ -32329,6 +32822,23 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.8.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      terser: 5.46.1
+      tsx: 4.21.0
+      yaml: 2.9.0
+
+  vite@7.3.2(@types/node@25.9.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.60.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.2
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0


### PR DESCRIPTION
## Summary
- make @agent-native/skills install with the shared core CLI runtime instead of relying on a peer install
- keep the skills CLI on one shared picker flow, with public skills selected by default in the standalone package
- ask Plan storage mode before client setup, skip MCP setup for local-files mode, and remove the duplicate Claude Code CLI choice
- route embedded connect output through clack and make --no-connect results honest about pending MCP config

## Validation
- pnpm prep
- pnpm --filter @agent-native/core exec vitest --run src/cli/skills.spec.ts
- pnpm --filter @agent-native/skills test -- src/index.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/skills typecheck
- pnpm --filter @agent-native/core build && pnpm --filter @agent-native/skills build
- interactive TTY dry-runs for hosted and local-files paths
- real temp installs for local-files visual-plan/visual-recap, efficient-frontier, and hosted --no-connect codex
