### PR TITLE
Update local Plan flow and agent tooling

### DIFF
--- a/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
+++ b/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-native-visual-plans",
-  "version": "1.0.0+codex.30374d0a7a5c",
+  "version": "1.0.0+codex.01214f24ef46",
   "description": "Create rich interactive visual plans and recaps with diagrams, file maps, annotated code and diffs, API/schema summaries, feedback, and HTML export.",
   "author": { "name": "Agent-Native", "url": "https://agent-native.com" },
   "homepage": "https://plan.agent-native.com",

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-plan/SKILL.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-plan/SKILL.md
@@ -342,7 +342,7 @@ skill — never hand-edit one stored plan. Turn feedback into better guidance.
 ## Local-Files Privacy Mode
 
 Use local-files privacy mode when the user explicitly asks for no DB writes,
-no hosted Plan app, no Plan MCP publish, fully local files, offline/private
+no hosted Plan database writes, no Plan MCP publish, fully local files, offline/private
 planning, repo-owned/source-controlled planning artifacts, or when
 `AGENT_NATIVE_PLANS_MODE=local-files` is set. Also use it when a user or repo
 policy says a plan must stay under their own brand, domain, source control, or
@@ -360,21 +360,24 @@ The local-files contract is:
   `plan blocks` command calls the public no-auth `get-plan-blocks` route and
   writes only registry metadata to disk; use `--format schema` if exact nested
   fields are needed. If network access is unavailable, use the bundled
-  references and rely on `plan local preview` to catch invalid tags.
-- Write the plan as a local MDX folder under `plans/<slug>/`: `plan.mdx`,
-  optional `canvas.mdx`, optional `prototype.mdx`, and optional
-  `.plan-state.json`.
-- Run `npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind plan --open`
-  after writing or updating the folder. Report the returned local URL or the
-  `/local-plans/<slug>` route if the local Plan app is running with the same
-  `PLAN_LOCAL_DIR`.
+  references and rely on `plan local serve` to catch invalid tags.
+- Write the plan as a local MDX folder: use `plans/<slug>/` when the user
+  wants the artifact checked into the repo, or use a repo-ignored/temporary
+  folder such as `.agent-native/plans/<slug>/` or `/tmp/agent-native-plans/<slug>/`
+  when it should not be checked in. The folder contains `plan.mdx`, optional
+  `canvas.mdx`, optional `prototype.mdx`, and optional `.plan-state.json`.
+- Run `npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind plan --open`
+  after writing or updating the folder. Report the returned local bridge URL. It opens the hosted Plan UI but reads
+  from the localhost bridge on this machine, so it is not shareable across
+  machines. If the Plan app itself is running locally with the same
+  `PLAN_LOCAL_DIR`, the `/local-plans/<slug>` route is also valid.
 - Do **not** call `create-visual-plan`, `create-ui-plan`,
   `create-prototype-plan`, `create-plan-design`, `import-visual-plan-source`,
   `update-visual-plan`, `patch-visual-plan-source`, `get-plan-feedback`,
   `export-visual-plan`, or any hosted Plan tool for that plan except the
   schema-only block catalog lookup above.
 - Treat feedback as file or chat feedback: update the MDX files directly, rerun
-  the local preview command, and summarize the new local URL/path. Hosted
+  the local bridge command, and summarize the new local bridge URL. Hosted
   comments, sharing, history, and publish/export receipts are unavailable until
   the user explicitly opts into publishing.
 

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-recap/SKILL.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-recap/SKILL.md
@@ -22,7 +22,7 @@ before spending attention on the literal lines.
 ## Local-Files Privacy Mode Exception
 
 Use local-files privacy mode when the user explicitly asks for no DB writes,
-no hosted Plan app, no Plan MCP publish, fully local files, offline/private
+no hosted Plan database writes, no Plan MCP publish, fully local files, offline/private
 recaps, or when `AGENT_NATIVE_PLANS_MODE=local-files` is set. This is the only
 exception to the hosted publish rule below.
 
@@ -37,22 +37,26 @@ In local-files mode:
   MCP connector is not registered; it calls the public no-auth
   `get-plan-blocks` route and sends no recap content. If network access is
   unavailable, use the bundled references and validate with
-  `plan local preview`.
-- Write the recap as a local MDX folder under `plans/<slug>/`: `plan.mdx`,
-  optional `canvas.mdx`, optional `prototype.mdx`, and optional
-  `.plan-state.json`. Set `kind: "recap"` and `localOnly: true` in
-  frontmatter/state when authoring the source.
-- Run `npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind recap --open`
-  after writing or updating the folder. Report the returned local URL or the
-  `/local-plans/<slug>` route if the local Plan app is running with the same
-  `PLAN_LOCAL_DIR`.
+  `plan local serve`.
+- Write the recap as a local MDX folder: use `plans/<slug>/` when the user
+  wants the artifact checked into the repo, or use a repo-ignored/temporary
+  folder such as `.agent-native/plans/<slug>/` or `/tmp/agent-native-plans/<slug>/`
+  when it should not be checked in. The folder contains `plan.mdx`, optional
+  `canvas.mdx`, optional `prototype.mdx`, and optional `.plan-state.json`. Set
+  `kind: "recap"` and `localOnly: true` in frontmatter/state when authoring
+  the source.
+- Run `npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind recap --open`
+  after writing or updating the folder. Report the returned local bridge URL. It opens the hosted Plan UI but reads
+  from the localhost bridge on this machine, so it is not shareable across
+  machines. If the Plan app itself is running locally with the same
+  `PLAN_LOCAL_DIR`, the `/local-plans/<slug>` route is also valid.
 - Do **not** call `create-visual-recap`, `create-visual-plan`,
   `import-visual-plan-source`, `update-visual-plan`,
   `patch-visual-plan-source`, `get-plan-feedback`, `export-visual-plan`,
   `set-resource-visibility`, or any hosted Plan tool for that recap except the
   schema-only block catalog lookup above.
 - Treat review feedback as file or chat feedback: update the MDX files directly,
-  rerun the local preview command, and summarize the new local URL/path.
+  rerun the local bridge command, and summarize the new local bridge URL.
   Hosted comments, sharing, screenshots, usage attachment, and PR sticky comment
   publishing are unavailable until the user explicitly opts into publishing.
 
@@ -263,10 +267,13 @@ a headless CI agent), state that in the recap handoff instead.
 
 ## Open And Report The Recap
 
-In local-files privacy mode, report the local preview URL/path from
-`npx @agent-native/core@latest plan local preview` or the `/local-plans/<slug>` route for a local
-Plan app using the same `PLAN_LOCAL_DIR`. Do not invent a hosted URL and do not
-publish just to get an absolute Plan link.
+In local-files privacy mode, report the local bridge URL from
+`npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind recap --open`.
+It opens the hosted Plan UI but reads from the localhost bridge on this machine,
+so it is not shareable across machines. If the Plan app itself is running
+locally with the same `PLAN_LOCAL_DIR`, the `/local-plans/<slug>` route is also
+valid. Do not invent a hosted database URL and do not publish just to get an
+absolute Plan link.
 
 After creating the recap, link the reviewer to the rendered plan with an
 **absolute URL on the origin whose database actually holds the plan**. That
@@ -420,7 +427,7 @@ was installed as plain text and no MCP tools are registered, run
 `npx @agent-native/core@latest plan blocks --out plan-blocks.md` and read that
 file first. The CLI command calls the public no-auth `get-plan-blocks` route and
 sends no plan/recap content. If network access is unavailable, use the bundled
-references and validate with `plan local preview`.
+references and validate with `plan local serve`.
 
 The catalog returns the authoritative, always-current block vocabulary generated
 live from the app's own block registry — the same config the renderer and MDX

--- a/.agents/skills/external-agents/SKILL.md
+++ b/.agents/skills/external-agents/SKILL.md
@@ -416,3 +416,13 @@ before telling the user they are unauthenticated.
 - **a2a-protocol** — the `ask-agent` meta-tool and JSON-RPC peer calls
 - **adding-a-feature** — the four-area checklist (add a `link` builder when a
   feature produces a navigable resource)
+
+## Blueprint installer
+
+To add a whole new integration the agent-native way, `agent-native add <kind>
+<name|url>` prints a curated Markdown blueprint to stdout — pipe it into the
+external coding agent you connected (`agent-native add provider stripe |
+claude`) and it applies the changes against the live repo. A URL emits a
+generic research-and-integrate blueprint instead. Seeded kinds:
+`provider` / `channel` / `sandbox` / `action`. Add your own by dropping a
+`.md` in `packages/core/blueprints/<kind>/`. See the Blueprint Installer doc.

--- a/.agents/skills/harness-agents/SKILL.md
+++ b/.agents/skills/harness-agents/SKILL.md
@@ -80,6 +80,26 @@ existing run routes as `goalId=agent-harness`.
   Preserve `defineAction` auth, request context, timeouts, truncation, and
   read-only metadata.
 
+## Code Execution Sandbox
+
+- The `run-code` tool executes through a pluggable `SandboxAdapter`
+  (`packages/core/src/coding-tools/sandbox/`). The default
+  `LocalChildProcessAdapter` spawns a locked-down local Node child process;
+  swap it via `AGENT_NATIVE_SANDBOX` or `registerSandboxAdapter()` for a
+  Docker/remote/durable backend (the lever to exceed the hosted ~40s code-exec
+  ceiling). An adapter only runs the already-prepared, non-secret module source
+  — it never sees app secrets. See the Sandbox Adapters doc; `agent-native add
+  sandbox docker` emits a full Docker-adapter recipe.
+
+## Sub-Agent Delegation Depth
+
+- Sub-agent spawning is capped server-side (default depth `2`) so delegation
+  chains can't fan out indefinitely. Override at deploy time with
+  `AGENT_NATIVE_MAX_SUBAGENT_DEPTH` (`0` disables sub-agents; clamped to `16`).
+  Enforcement is ambient via `evaluateSubagentDepth` in
+  `packages/core/src/server/agent-teams.ts` — independent of any tool-level
+  guard. See the Agent Teams doc for the depth model.
+
 ## Don't
 
 - Don't add Claude Code, Codex, Cursor, Mastra, or Pi as an `AgentEngine`.

--- a/.agents/skills/observability/SKILL.md
+++ b/.agents/skills/observability/SKILL.md
@@ -75,6 +75,26 @@ const criteria: EvalCriteria = {
 };
 ```
 
+#### Evals (CI gate)
+
+The three layers above score *real production runs* after the fact. For an active, deterministic gate, use the first-class `*.eval.ts` primitive from `@agent-native/core/eval` (source: `packages/core/src/eval/*`). It runs the actual agent loop against fixed inputs and exits non-zero below threshold, so it gates CI/deploys.
+
+```ts
+// evals/faq.eval.ts
+import { defineEval, contains, llmJudge } from "@agent-native/core/eval";
+
+export default defineEval({
+  name: "answers the FAQ",
+  input: { prompt: "What is your return policy?" },
+  threshold: 0.7,
+  scorers: [contains("30 days"), llmJudge({ criteria: "accuracy" })],
+});
+```
+
+- Built-in scorers: `exactMatch` / `contains` / `usesTool` (pure JS) and `llmJudge` (provider-agnostic judge).
+- Custom scorers: `createScorer` with the 4-step `preprocess → analyze → generateScore → generateReason` pipeline (only `generateScore` is required).
+- Run as a gate: `agent-native eval [pattern] [--json] [--threshold N]` — discovers `**/*.eval.ts` and `evals/*.ts`, runs the agent, and exits non-zero if any eval is below its threshold. An app with no eval files exits `0`. Complements (does not replace) the post-hoc scoring in `evals.ts`. See the Evals doc.
+
 ### 4. Experiments
 
 A/B testing with sticky user-level assignment:

--- a/.changeset/clean-cowork-connect.md
+++ b/.changeset/clean-cowork-connect.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/skills": patch
+---
+
+Fix hosted skills install flows for Codex plus Claude Cowork client selections and make MCP connect polling handle structured device-code failures consistently.

--- a/.changeset/keen-evals-gate.md
+++ b/.changeset/keen-evals-gate.md
@@ -1,0 +1,16 @@
+---
+"@agent-native/core": minor
+---
+
+Add a first-class evals primitive and an `agent-native eval` CLI runner that
+doubles as a CI deploy gate. Define test cases with `defineEval({ name, input,
+scorers, threshold })` and compose scorers with the Mastra-style 4-step
+pipeline `createScorer({ preprocess, analyze, generateScore, generateReason })`.
+Built-in scorers ship for the common cases — `exactMatch`, `contains`,
+`usesTool`, and a provider-agnostic `llmJudge` (the judge model is resolved
+from the engine registry, never hardcoded). The runner discovers `**/*.eval.ts`
+and `evals/*.ts`, actually runs the agent loop for each input, scores the
+output, prints a readable scored table (or `--json` for CI), and exits
+non-zero when any eval scores below its threshold. Results are written to the
+observability eval store, with a documented seam for future live sampled
+scoring of production traffic through the same scorers.

--- a/.changeset/needs-approval-hitl.md
+++ b/.changeset/needs-approval-hitl.md
@@ -1,0 +1,13 @@
+---
+"@agent-native/core": minor
+---
+
+Add opt-in per-action human-in-the-loop approvals. Actions can now declare
+`needsApproval` (a boolean or an `(args, ctx) => boolean | Promise<boolean>`
+predicate) on `defineAction`. When the gate resolves truthy, the agent loop does
+NOT execute `run()`: it emits an `approval_required` event carrying the tool
+name, a compact view of the input, and a stable `approvalKey`, then pauses the
+turn. A human approves by re-issuing the turn with that key in
+`AgentChatRequest.approvedToolCalls`, which lets the specific call run. The gate
+is default-off and fail-closed (a throwing predicate requires approval). The
+mail template's `send-email` action opts in as the canonical example.

--- a/.changeset/observational-memory-core.md
+++ b/.changeset/observational-memory-core.md
@@ -1,0 +1,21 @@
+---
+"@agent-native/core": minor
+---
+
+Add the core of Observational Memory (OM): background compaction of a long
+agent thread into a dated, three-tier context (recent raw messages → dense
+"observations" → higher-level "reflections") so long-running threads cost far
+fewer tokens and stay prompt-cache stable.
+
+This ships the store (a new ownable, dialect-agnostic `observational_memory`
+table + additive migrations), the Observer and Reflector compaction passes
+(provider-agnostic internal agent calls — no hardcoded model), the
+`maybeCompactThread` compactor entry point, and the `buildObservationalContext`
+read API returning the three tiers ready for prompt injection, all exported
+from `@agent-native/core/agent/observational-memory`.
+
+The read API and compactor are intentionally not yet wired into the agent loop:
+injecting `buildObservationalContext` output into `production-agent.ts` (and
+registering the migration plugin in the default plugin set) is a follow-up so it
+does not collide with concurrent agent-loop changes. The store creates its table
+lazily on first use, so OM is fully functional in the meantime.

--- a/.changeset/om-agent-loop-wiring.md
+++ b/.changeset/om-agent-loop-wiring.md
@@ -1,0 +1,13 @@
+---
+"@agent-native/core": minor
+---
+
+Wire Observational Memory into the agent loop (compaction + long-thread context
+injection). The OM migration plugin is now registered alongside the other
+framework migration plugins so its table is created on startup. After a clean
+turn the loop runs a best-effort, fire-and-forget compaction pass
+(`maybeCompactThread`) so long threads accrue dated observations and
+reflections. On subsequent turns, threads that have already crossed the
+compaction threshold get their reflections+observations folded in as a leading
+context block while the recent raw-message window is preserved verbatim - short
+threads with no OM entries are left byte-for-byte unchanged.

--- a/.changeset/otel-agent-loop-spans.md
+++ b/.changeset/otel-agent-loop-spans.md
@@ -1,0 +1,11 @@
+---
+"@agent-native/core": patch
+---
+
+Add an optional OpenTelemetry export to the agent loop. `instrumentAgentLoop`
+now wraps the run, each tool call, and the model call in OTel spans
+(`agent.run`, `tool.call`, `llm.call`) carrying tool name, model, token usage,
+and error attributes. The export is fully no-op unless a host installs
+`@opentelemetry/api` (a new optional dependency) and registers a tracer
+provider, so there is zero overhead by default and no heavy SDK is added to
+core.

--- a/.changeset/quiet-teams-guard.md
+++ b/.changeset/quiet-teams-guard.md
@@ -1,0 +1,12 @@
+---
+"@agent-native/core": patch
+---
+
+Add a hard delegation-depth guardrail so sub-agents cannot infinitely spawn
+sub-agents. Each sub-agent now carries its delegation depth (top-level chat is
+0); `spawnTask` refuses server-side once a spawn would exceed the cap, returning
+a clear "Delegation depth limit reached" error to the parent agent. Enforcement
+lives in `agent-teams.ts` and reads the spawning agent's depth from the ambient
+run context, so it holds even if the team tool is not stripped. The cap defaults
+to 2 and is configurable via the `AGENT_NATIVE_MAX_SUBAGENT_DEPTH` env var
+(parsed and clamped, falling back to the default on invalid values).

--- a/.changeset/sandbox-evals-blueprint-docs.md
+++ b/.changeset/sandbox-evals-blueprint-docs.md
@@ -1,0 +1,13 @@
+---
+"@agent-native/core": patch
+---
+
+Document four newly-landed framework features in the published docs content:
+pluggable sandbox adapters for the `run-code` tool (`SandboxAdapter`,
+`AGENT_NATIVE_SANDBOX`, `registerSandboxAdapter`), the first-class evals CI gate
+(`defineEval`, `createScorer`, built-in scorers, and the `agent-native eval`
+command), the sub-agent delegation depth guard
+(`AGENT_NATIVE_MAX_SUBAGENT_DEPTH`), and the `agent-native add` blueprint
+installer. Adds `sandbox-adapters`, `evals`, and `blueprint-installer` pages, a
+delegation-depth section in the Agent Teams doc, and surgical pointers in the
+harness-agents, observability, and external-agents skills.

--- a/.changeset/stable-plan-mcp-route.md
+++ b/.changeset/stable-plan-mcp-route.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add an opt-out for agent-chat MCP mounting so apps can provide a dedicated stable MCP route.

--- a/.changeset/subagent-depth-runtime-context.md
+++ b/.changeset/subagent-depth-runtime-context.md
@@ -1,0 +1,9 @@
+---
+"@agent-native/core": patch
+---
+
+Surface the current sub-agent delegation depth in the runtime-context prompt.
+The chat plugin now reads the ambient delegation depth and passes it into
+`buildRuntimeContextPrompt`, so a sub-agent already at the delegation cap is
+told it cannot spawn further sub-agents. The cap was already enforced
+server-side; this only makes it visible to the model.

--- a/.changeset/tool-call-journal-hard-block.md
+++ b/.changeset/tool-call-journal-hard-block.md
@@ -1,0 +1,13 @@
+---
+"@agent-native/core": patch
+---
+
+Tool-call journal hard-block: skip re-executing journaled-complete tool calls on
+resume. The per-turn tool-call journal (derived from the durable run-event
+ledger) previously only added a prompt-level "already completed, don't re-run"
+note. The agent loop now enforces this at the tool layer: when a non-read-only
+tool call's exact (tool name + input) already completed in an earlier
+interrupted chunk of the same turn, `runToolCall` returns the recorded result
+instead of re-executing the side effect, while still emitting the normal
+tool_start/tool_done so the transcript stays coherent. Fresh calls with no prior
+completed journal entry are unaffected.

--- a/.changeset/tool-call-journal-resume.md
+++ b/.changeset/tool-call-journal-resume.md
@@ -1,0 +1,15 @@
+---
+"@agent-native/core": patch
+---
+
+Add a per-turn tool-call journal that hardens the run-resume path against
+duplicate side effects. When a run resumes after an interruption (gateway or
+transport drop, cold start, or soft-timeout auto-continue), the journal is
+derived from the existing run-event ledger and injected into the resume nudge:
+tool calls that already completed are listed with their results and flagged as
+"do NOT re-run", and any tool call that started but never recorded a result is
+surfaced as "interrupted / unknown outcome" so the model can decide rather than
+blindly re-executing (e.g. re-sending an email or re-creating a ticket). The
+journal is read-only over the ledger (no new recording hook), best-effort, and a
+no-op for turns with no completed or interrupted tool calls, so normal resumes
+are unchanged.

--- a/.changeset/witty-blueprints-add.md
+++ b/.changeset/witty-blueprints-add.md
@@ -1,0 +1,11 @@
+---
+"@agent-native/core": minor
+---
+
+Add `agent-native add <kind> [name|url]`, a blueprint installer. Instead of
+scaffolding files, it prints a curated Markdown integration blueprint to stdout
+so you can pipe it into your own coding agent (`agent-native add provider stripe
+| claude`). A URL instead of a name emits a generic research-and-integrate
+blueprint with the URL as the research seed. Ships seeded blueprints for
+provider-api integrations, inbound channel adapters, custom sandbox adapters,
+and multi-surface actions; `--list` browses what's available.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ The agent and the UI are equal citizens of the same system. Every action works b
 
 ## The framework for agent-native apps
 
-Templates and skills are the first products built on the open framework. Agent-Native gives you the primitives for apps where the UI and agent share actions, state, identity, and context.
+Agent-Native is an open-source framework for building robust agents that can act inside real apps, not just chat next to them.
+
+It gives you primitives for product-grade agentic software: shared actions, SQL-backed state, identity, tools, skills, jobs, observability, and UI surfaces that all work together.
+
+Backend agnostic: bring your own database, hosting provider, model stack, and app code.
 
 ```ts
 // One action powers UI, agent, HTTP, MCP, A2A, and CLI.
@@ -64,17 +68,6 @@ Start with a full featured template. Each one is a complete, 100% free and open-
 <tr>
 <td width="33%" align="center" valign="top">
 
-**Mail**
-
-<a href="https://agent-native.com/templates/mail"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F6f49a81c404d4242b33317491eac7575?format=webp&width=800" alt="Mail template" width="100%" /></a>
-
-**Agent-Native Mail, Superhuman**
-
-Superhuman-style email client with keyboard shortcuts, AI triage, and a fully customizable inbox you own.
-
-</td>
-<td width="33%" align="center" valign="top">
-
 **Calendar**
 
 <a href="https://agent-native.com/templates/calendar"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Ffb6c3b483ca24ab3b6c3a758aeceef4c?format=webp&width=800" alt="Calendar template" width="100%" /></a>
@@ -82,6 +75,17 @@ Superhuman-style email client with keyboard shortcuts, AI triage, and a fully cu
 **Agent-Native Google Calendar, Calendly**
 
 Manage events, sync with Google Calendar, and share a public booking page with AI scheduling.
+
+</td>
+<td width="33%" align="center" valign="top">
+
+**Content**
+
+<a href="https://agent-native.com/templates/content"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F89bcfc6106304bfbaf8ec8a7ccd721eb?format=webp&width=800" alt="Content template" width="100%" /></a>
+
+**Open-source Obsidian for MDX**
+
+Edit local Markdown/MDX files, generate rich interactive custom blocks, and draft, rewrite, or publish with an agent.
 
 </td>
 <td width="33%" align="center" valign="top">
@@ -99,17 +103,6 @@ Install `/visual-plan` and `/visual-recap` so your coding agent can plan before 
 <tr>
 <td width="33%" align="center" valign="top">
 
-**Content**
-
-<a href="https://agent-native.com/templates/content"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F89bcfc6106304bfbaf8ec8a7ccd721eb?format=webp&width=800" alt="Content template" width="100%" /></a>
-
-**Open-source Obsidian for MDX**
-
-Edit local Markdown/MDX files, generate rich interactive custom blocks, and draft, rewrite, or publish with an agent.
-
-</td>
-<td width="33%" align="center" valign="top">
-
 **Slides**
 
 <a href="https://agent-native.com/templates/slides"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F2c09b451d40c4a74a89a38d69170c2d8?format=webp&width=800" alt="Slides template" width="100%" /></a>
@@ -119,19 +112,6 @@ Edit local Markdown/MDX files, generate rich interactive custom blocks, and draf
 Generate and edit React-based presentations via prompt or point-and-click.
 
 </td>
-<td width="33%" align="center" valign="top">
-
-**Video**
-
-<a href="https://agent-native.com/templates/video"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F6b8bfcc18a1d4c47a491da3b2d4148a4?format=webp&width=800" alt="Video template" width="100%" /></a>
-
-**Agent-Native video editing**
-
-Create and edit Remotion video compositions with agent assistance.
-
-</td>
-</tr>
-<tr>
 <td width="33%" align="center" valign="top">
 
 **Analytics**
@@ -154,69 +134,12 @@ Connect analytics data sources, prompt for real charts, and build reusable dashb
 Record your screen with auto-transcripts, shareable links, and an agent that summarizes, captions, and edits clips on demand.
 
 </td>
-<td width="33%" align="center" valign="top">
-
-**Design**
-
-<a href="https://agent-native.com/templates/design"><img src="https://cdn.builder.io/api/v1/image/assets%2F348da13fcd8b414c87de9066196f7266%2F961bedb713a94463b834c1f2f4643bcf?format=webp&width=800" alt="Design template" width="100%" /></a>
-
-**Agent-Native Figma, Canva**
-
-Create and edit visual designs by prompt or by hand, with the agent as your co-designer.
-
-</td>
-</tr>
-<tr>
-<td width="33%" align="center" valign="top">
-
-**Dispatch**
-
-<a href="https://agent-native.com/templates/dispatch"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F104b3ad8d1dc461aa33ab9bff37a4482?format=webp&width=800" alt="Dispatch template" width="100%" /></a>
-
-**Mission control for agent-native apps**
-
-Message, manage, and delegate to agents from Slack, Telegram, or the web. Dispatch is also the control plane for vault secrets, reusable provider connections, app grants, routing, memory, and approvals.
-
-</td>
-<td width="33%" align="center" valign="top">
-
-**Forms**
-
-<a href="https://agent-native.com/templates/forms"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F190c3fabd51f4c1bba5aa4e091ad4e9b?format=webp&width=800" alt="Forms template" width="100%" /></a>
-
-**Agent-Native Typeform**
-
-Generate forms from a prompt, branch logic with the agent, and own every response in your own database.
-
-</td>
-<td width="33%" align="center" valign="top">
-
-**Brain**
-
-<a href="https://agent-native.com/templates/brain"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9c9fe3b5b9494e33803cd3f494cba356?format=webp&width=800" alt="Brain template" width="100%" /></a>
-
-**Agent-Native company memory**
-
-Ask questions over cited company knowledge from approved Slack, meetings, transcripts, GitHub, and decisions.
-
-</td>
-</tr>
-<tr>
-<td width="33%" align="center" valign="top">
-
-**Assets**
-
-<a href="https://agent-native.com/templates/assets"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F769092170a14474f998cbca47384f891?format=webp&width=800" alt="Assets template" width="100%" /></a>
-
-**Agent-Native asset library**
-
-Upload, organize, search, and generate on-brand image and video assets that other apps can reuse.
-
-</td>
 </tr>
 </table>
 
 Every template is a complete cloneable SaaS — fork it, customize it with the agent, own it. Try them with example data before connecting your own sources.
+
+View the full template gallery at **[agent-native.com/templates](https://agent-native.com/templates)**.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent-Native
 
-### Agentic applications you own.
+### Open-source framework for agentic applications you own.
 
 Don't choose between rich user interfaces and autonomous agents. Every Agent-Native app is both.
 
@@ -20,15 +20,36 @@ The agent and the UI are equal citizens of the same system. Every action works b
 - **Any database, any host** — Any SQL database Drizzle supports. Any hosting target Nitro supports. No lock-in.
 - **Any AI agent** — Claude Code, Codex, Cursor, Pi, OpenCode, GitHub Copilot / VS Code, or Builder.io. Use whichever agent you prefer.
 
+## The framework for agent-native apps
+
+Templates and skills are the first products built on the open framework. Agent-Native gives you the primitives for apps where the UI and agent share actions, state, identity, and context.
+
+```ts
+// One action powers UI, agent, HTTP, MCP, A2A, and CLI.
+export default defineAction({
+  schema: z.object({
+    emailId: z.string(),
+    body: z.string(),
+  }),
+  run: async ({ emailId, body }) => {
+    await db.insert(replies).values({ emailId, body });
+  },
+});
+```
+
+- **Actions** — Define work once. Use it from UI, agent, API, MCP, A2A, and CLI.
+- **Agent runtime** — Chat, tools, skills, memory, jobs, observability, and handoffs ship together.
+- **Backend agnostic** — Plug in any Drizzle-supported SQL database and Nitro-compatible host.
+
 ## Try it with a skill
 
-Don't want to scaffold a whole app yet? Add agent-native superpowers to a coding agent you already use — Claude Code, Codex, Cursor, Pi, OpenCode, GitHub Copilot / VS Code, and similar agents — with one command:
+Don't want to scaffold a whole app yet? Add visual planning and PR recaps to Claude Code, Codex, Cursor, Pi, OpenCode, GitHub Copilot / VS Code, and similar agents with one command:
 
 ```bash
 npx @agent-native/core@latest skills add visual-plan
 ```
 
-It installs the skills, writes shared `.agents` skill folders for agents that support them, registers the hosted MCP connector for supported local clients, and signs in the selected client(s) in one step. You get two slash commands that upgrade how your agent plans and reports its work:
+You get two slash commands that upgrade how your agent plans and reports its work:
 
 - **`/visual-plan`** — before the agent writes code, it opens a structured, reviewable plan document instead of a wall of text: inline diagrams, UI wireframes and prototypes, file-by-file implementation maps, and annotations you can comment on and approve.
 - **`/visual-recap`** — after changes land, it turns a PR or git diff into a high-altitude visual recap: schema, API, and file changes rendered as grounded before/after blocks with a shareable review link, instead of scrolling a raw diff.
@@ -37,7 +58,7 @@ See the **[Skills Guide](https://agent-native.com/docs/skills-guide#app-backed-s
 
 ## Templates
 
-Start from a complete, production-grade SaaS app — cloneable, not scaffolded. Each one replaces tools you're paying for, except you own everything and can customize it however you want. Not demos; products.
+Start with a full featured template. Each one is a complete, 100% free and open-source SaaS app — cloneable, not scaffolded — except you own the code and can customize everything.
 
 <table>
 <tr>
@@ -82,9 +103,9 @@ Install `/visual-plan` and `/visual-recap` so your coding agent can plan before 
 
 <a href="https://agent-native.com/templates/content"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F89bcfc6106304bfbaf8ec8a7ccd721eb?format=webp&width=800" alt="Content template" width="100%" /></a>
 
-**Agent-Native Notion, Google Docs**
+**Open-source Obsidian for MDX**
 
-Write and organize content with an agent that knows your brand and publishing workflow.
+Edit local Markdown/MDX files, generate rich interactive custom blocks, and draft, rewrite, or publish with an agent.
 
 </td>
 <td width="33%" align="center" valign="top">
@@ -198,6 +219,8 @@ Upload, organize, search, and generate on-brand image and video assets that othe
 Every template is a complete cloneable SaaS — fork it, customize it with the agent, own it. Try them with example data before connecting your own sources.
 
 ## Quick Start
+
+One command to fork a template and start building locally.
 
 ```bash
 npx @agent-native/core@latest create my-platform

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 ### Agentic applications you own.
 
-Don't choose between structured user flows and autonomous agents. Every Agent-Native app is both.
+Don't choose between rich user interfaces and autonomous agents. Every Agent-Native app is both.
 
 ## Agents and UIs — Fully Connected
 
@@ -11,13 +11,29 @@ The agent and the UI are equal citizens of the same system. Every action works b
 ![Agents and UIs fully connected](https://cdn.builder.io/api/v1/file/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fadc1e9e9368e4a8cb1b4dbb5aae5aaa2)
 
 - **Everything syncs** — Agent and UI share one database and one state. Changes from either side show up instantly on the other.
+- **Real-time multiplayer** — Humans and agents collaborate in the same document simultaneously: CRDT merging, live presence (cursors, selection rings, who's on which slide), and the agent as a first-class peer editor. Works on any SQL database and any host, including serverless.
 - **Context-aware** — The agent knows what you're looking at. Select text, hit Cmd+I, and tell it what to do.
 - **Per-user workspace** — Skills, memory, instructions, sub-agents, and MCP servers — SQL-backed, customizable per user. Claude-Code-level flexibility, SaaS-grade economics.
 - **Agents call agents** — Tag another agent from any app. They discover each other over A2A and take action across your stack.
 - **Reusable integrations** — Connect a provider once in Dispatch, keep secret values in the vault, then grant apps like Brain, Analytics, Mail, and Dispatch access to the shared account metadata and credential refs.
 - **Apps that improve themselves** — Your apps get better on their own. The agent can add features, fix bugs, and refine the UI over time.
 - **Any database, any host** — Any SQL database Drizzle supports. Any hosting target Nitro supports. No lock-in.
-- **Any AI agent** — Claude Code, Codex, Gemini CLI, OpenCode, or Builder.io. Use whichever agent you prefer.
+- **Any AI agent** — Claude Code, Codex, Cursor, Pi, OpenCode, GitHub Copilot / VS Code, or Builder.io. Use whichever agent you prefer.
+
+## Try it with a skill
+
+Don't want to scaffold a whole app yet? Add agent-native superpowers to a coding agent you already use — Claude Code, Codex, Cursor, Pi, OpenCode, GitHub Copilot / VS Code, and similar agents — with one command:
+
+```bash
+npx @agent-native/core@latest skills add visual-plan
+```
+
+It installs the skills, writes shared `.agents` skill folders for agents that support them, registers the hosted MCP connector for supported local clients, and signs in the selected client(s) in one step. You get two slash commands that upgrade how your agent plans and reports its work:
+
+- **`/visual-plan`** — before the agent writes code, it opens a structured, reviewable plan document instead of a wall of text: inline diagrams, UI wireframes and prototypes, file-by-file implementation maps, and annotations you can comment on and approve.
+- **`/visual-recap`** — after changes land, it turns a PR or git diff into a high-altitude visual recap: schema, API, and file changes rendered as grounded before/after blocks with a shareable review link, instead of scrolling a raw diff.
+
+See the **[Skills Guide](https://agent-native.com/docs/skills-guide#app-backed-skills)** for more skills and local installs.
 
 ## Templates
 
@@ -49,6 +65,19 @@ Manage events, sync with Google Calendar, and share a public booking page with A
 </td>
 <td width="33%" align="center" valign="top">
 
+**Plans**
+
+<a href="https://agent-native.com/templates/plan"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fb6f4213ac7cc42eeb10c12e8ccda8936?format=webp&width=800" alt="Plans template" width="100%" /></a>
+
+**Visual plan mode for coding agents**
+
+Install `/visual-plan` and `/visual-recap` so your coding agent can plan before it builds and recap changes after they land — high-level code reviews with diagrams, wireframes, annotations, and review links.
+
+</td>
+</tr>
+<tr>
+<td width="33%" align="center" valign="top">
+
 **Content**
 
 <a href="https://agent-native.com/templates/content"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F89bcfc6106304bfbaf8ec8a7ccd721eb?format=webp&width=800" alt="Content template" width="100%" /></a>
@@ -58,8 +87,6 @@ Manage events, sync with Google Calendar, and share a public booking page with A
 Write and organize content with an agent that knows your brand and publishing workflow.
 
 </td>
-</tr>
-<tr>
 <td width="33%" align="center" valign="top">
 
 **Slides**
@@ -82,6 +109,8 @@ Generate and edit React-based presentations via prompt or point-and-click.
 Create and edit Remotion video compositions with agent assistance.
 
 </td>
+</tr>
+<tr>
 <td width="33%" align="center" valign="top">
 
 **Analytics**
@@ -93,8 +122,6 @@ Create and edit Remotion video compositions with agent assistance.
 Connect analytics data sources, prompt for real charts, and build reusable dashboards. Shared workspace connections can provide provider credentials, while Analytics still owns metrics, source-of-truth choices, and saved analyses.
 
 </td>
-</tr>
-<tr>
 <td width="33%" align="center" valign="top">
 
 **Clips**
@@ -117,6 +144,8 @@ Record your screen with auto-transcripts, shareable links, and an agent that sum
 Create and edit visual designs by prompt or by hand, with the agent as your co-designer.
 
 </td>
+</tr>
+<tr>
 <td width="33%" align="center" valign="top">
 
 **Dispatch**
@@ -128,8 +157,6 @@ Create and edit visual designs by prompt or by hand, with the agent as your co-d
 Message, manage, and delegate to agents from Slack, Telegram, or the web. Dispatch is also the control plane for vault secrets, reusable provider connections, app grants, routing, memory, and approvals.
 
 </td>
-</tr>
-<tr>
 <td width="33%" align="center" valign="top">
 
 **Forms**
@@ -145,18 +172,20 @@ Generate forms from a prompt, branch logic with the agent, and own every respons
 
 **Brain**
 
-<a href="https://agent-native.com/templates/brain">Brain template</a>
+<a href="https://agent-native.com/templates/brain"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9c9fe3b5b9494e33803cd3f494cba356?format=webp&width=800" alt="Brain template" width="100%" /></a>
 
 **Agent-Native company memory**
 
 Ask questions over cited company knowledge from approved Slack, meetings, transcripts, GitHub, and decisions.
 
 </td>
+</tr>
+<tr>
 <td width="33%" align="center" valign="top">
 
 **Assets**
 
-<a href="https://agent-native.com/templates/assets">Assets template</a>
+<a href="https://agent-native.com/templates/assets"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F769092170a14474f998cbca47384f891?format=webp&width=800" alt="Assets template" width="100%" /></a>
 
 **Agent-Native asset library**
 
@@ -185,16 +214,6 @@ Want a single app, no monorepo? Use `--standalone`:
 npx @agent-native/core@latest create my-app --standalone --template mail
 ```
 
-### Try it with a skill
-
-Don't want to scaffold a whole app yet? Add agent-native superpowers to a coding agent you already use — Claude Code, Codex, or Cursor — with one command. Installing the **Plans** skill turns the plans your agent writes into structured, reviewable docs with diagrams, wireframes, and inline comments:
-
-```bash
-npx @agent-native/core@latest skills add visual-plan
-```
-
-It installs the skill, registers the hosted MCP connector, and signs you in in one step — then run `/visual-plan`. See the **[Skills Guide](https://agent-native.com/docs/skills-guide#app-backed-skills)** for more skills and local installs.
-
 ## Workspaces (Monorepo)
 
 A workspace is the default shape of an agent-native project. Every app sits under `apps/`, and `packages/shared/` is available for the small amount of code, instructions, skills, or branding that should truly apply to every app.
@@ -221,7 +240,7 @@ npx @agent-native/core@latest add-app notes --template content
 Deploy every app behind one origin:
 
 ```bash
-agent-native deploy
+npx @agent-native/core@latest deploy
 # https://your-agents.com/mail/*       → mail
 # https://your-agents.com/calendar/*   → calendar
 # https://your-agents.com/forms/*      → forms

--- a/packages/core/blueprints/action/crud.md
+++ b/packages/core/blueprints/action/crud.md
@@ -1,0 +1,98 @@
+# Blueprint: add a new multi-surface action
+
+You are a coding agent working inside an **agent-native** app (a repo built on
+`@agent-native/core`). Apply this blueprint as real source changes on the
+current branch. Do not just describe the work — do it, then verify.
+
+## Goal
+
+Add a new app operation as a single `defineAction` so it is callable from **all
+surfaces at once**: the agent uses it as a tool, the frontend calls it through
+`useActionQuery` / `useActionMutation`, and HTTP/MCP/A2A get it for free. One
+implementation, every consumer — no duplicate `/api/*` route.
+
+Use this for a real capability your app is missing (e.g. `create-note`,
+`update-task`, `list-orders`). Replace `<thing>` below with the actual resource.
+
+## Read first
+
+Read the `actions` skill. The rules that matter most here:
+
+- Actions in `actions/` are the **single source of truth**. Before adding one,
+  grep `actions/` and `AGENTS.md` — extend an existing action if it already
+  covers the operation.
+- **Keep the surface small and orthogonal.** Prefer one CRUD-style
+  `update-<thing>` taking a patch of optional fields over N per-field actions.
+  One `create` / one `update` / one `delete` per resource.
+- Reach for a generic query / the provider-api trio before minting another read
+  action.
+
+## Files to touch
+
+1. **`actions/<verb>-<thing>.ts`** — one file, default-exporting a
+   `defineAction` with a **Zod** schema:
+
+   ```ts
+   import { z } from "zod";
+   import { defineAction } from "@agent-native/core";
+   import { getDb } from "../server/db/index.js";
+   import { things } from "../server/db/schema.js";
+
+   export default defineAction({
+     description: "Create a <thing>",
+     schema: z.object({
+       title: z.string().describe("Human-readable title"),
+       notes: z.string().optional(),
+     }),
+     // Omit `http` for the default POST; use { method: "GET" } for reads.
+     run: async (args, ctx) => {
+       const db = getDb();
+       // Return plain objects/arrays — never JSON.stringify().
+       return await db
+         .insert(things)
+         .values({ ...args })
+         .returning();
+     },
+   });
+   ```
+
+   - Use Drizzle's query builder and portable `drizzle-orm` operators — no raw
+     SQL, no dialect-specific imports, no `getDbExec()` for normal actions.
+   - Use `z.coerce.number()` for numeric HTTP params; for booleans use an
+     explicit string parser (not `z.coerce.boolean()`).
+   - If only the UI/HTTP needs it (not the model), set `agentTool: false` to
+     keep the model's tool list lean — it stays callable from the UI and HTTP.
+
+2. **If the resource is user-authored and shareable**, make its table ownable
+   and scope reads/writes. Read the `sharing` and `security` skills: tables with
+   `ownableColumns()` require `accessFilter` / `resolveAccess` / `assertAccess`
+   in the action, never an unscoped `select`/`update`.
+
+3. **Wire the UI** to the shared action surface with `useActionQuery`
+   (reads) / `useActionMutation` (writes). Do **not** hand-write `fetch` to a
+   framework or `/api/*` route — import the client hooks. Keep the UI optimistic:
+   update cache / navigate immediately and roll back on error.
+
+4. **Register the action** in whatever index the app uses (`actions/index.ts`
+   or the auto-discovery glob) and add it to the `AGENTS.md` action table if the
+   app maintains one.
+
+## Framework rules to honor
+
+- No `/api/*` or Nitro pass-through route whose job is to call/repackage this
+  action — that violates the Architecture Contract.
+- Never hardcode secrets/credentials; read them from the secret store at call
+  time. Use placeholders in any example.
+- Validate and scope all input; ownable tables fail closed without access
+  checks.
+- If this edits a publishable package's source, add a `.changeset/*.md`.
+
+## Verify
+
+1. `agent-native typecheck` (or `tsc --noEmit`) passes.
+2. From the agent chat, invoke the new action and confirm structured
+   input/output.
+3. From the UI, confirm the `useActionQuery` / `useActionMutation` path works and
+   stays optimistic.
+4. For ownable resources, confirm a non-owner cannot read or mutate another
+   user's row (access check fails closed).

--- a/packages/core/blueprints/channel/discord.md
+++ b/packages/core/blueprints/channel/discord.md
@@ -1,0 +1,74 @@
+# Blueprint: add a Discord inbound channel adapter
+
+You are a coding agent working inside an **agent-native** app (a repo built on
+`@agent-native/core`). Apply this blueprint as real source changes on the
+current branch. Do not just describe the work — do it, then verify.
+
+## Goal
+
+Let users talk to the agent from Discord: a Discord message hits a webhook, the
+framework enqueues the work, returns `200` fast, and a fresh function execution
+runs the full agent loop and posts the reply back. You implement a
+`PlatformAdapter` for Discord that slots into the existing integration-webhooks
+pipeline — you do **not** invent a new transport.
+
+## Read first
+
+Read the `integration-webhooks` skill end to end. The non-negotiable shape: the
+webhook handler **enqueues to SQL and returns 200 immediately**, then a
+self-fired POST runs the agent loop in a separate execution. Never run the agent
+loop inside the webhook handler; never rely on fire-and-forget `Promise`s after
+returning (serverless freezes the context).
+
+Study the existing adapters as the pattern to copy:
+
+- `packages/core/src/integrations/types.ts` — the `PlatformAdapter`,
+  `IncomingMessage`, `OutgoingMessage` contracts.
+- `packages/core/src/integrations/adapters/slack.ts` — the closest analog
+  (signature verification, parsing, response delivery).
+- `packages/core/src/integrations/adapters/telegram.ts` — a simpler reference.
+- `packages/core/src/integrations/plugin.ts` → `getDefaultAdapters()` — where
+  built-in adapters are registered into the route pipeline.
+
+## Files to touch
+
+1. **`packages/core/src/integrations/adapters/discord.ts`** — implement
+   `discordAdapter(): PlatformAdapter`:
+   - `platform = "discord"`, `label = "Discord"`.
+   - `getRequiredEnvKeys()` — declare `DISCORD_PUBLIC_KEY` (signature
+     verification) and `DISCORD_BOT_TOKEN` (sending), with UI hints so the
+     settings form renders them. Use obviously-fake placeholders in any docs.
+   - `handleVerification(event)` — answer Discord's `PING` interaction
+     (`type: 1`) with a `PONG` (`type: 1`).
+   - `verifyWebhook(event)` — verify the Ed25519 `X-Signature-Ed25519` /
+     `X-Signature-Timestamp` headers against `DISCORD_PUBLIC_KEY`. Fail closed.
+   - `parseMessage(event)` — map the interaction/message payload into a
+     normalized `IncomingMessage` (set `externalThreadId` to the channel/thread
+     id, `text`, `senderName`, `platformContext` with what you need to reply).
+     Return `null` to ignore bot messages and non-message events.
+   - `sendResponse(...)` — POST the agent reply back via the Discord API using
+     `DISCORD_BOT_TOKEN`, read at send time from the secret store.
+2. **Register it** in `getDefaultAdapters()` in
+   `packages/core/src/integrations/plugin.ts` alongside `slackAdapter()` etc.
+3. **Add `discord.spec.ts`** next to the adapter mirroring `slack.spec.ts`:
+   cover signature verification (valid + tampered), the PING/PONG verification
+   path, message parsing, and bot-message filtering.
+
+## Framework rules to honor
+
+- Do the minimum in the webhook handler; the agent loop runs in the
+  `_process-task` execution with its own timeout budget. Don't change that flow.
+- `senderVerified` must reflect real cryptographic sender authentication. Never
+  derive a privileged acting identity from an unverified sender — fail closed.
+- Never hardcode the bot token, public key, or signing secret in source, tests,
+  or fixtures. Use placeholders and read real values from the secret store.
+- This is a publishable `packages/core` source change → add a `.changeset/*.md`.
+
+## Verify
+
+1. `tsc --noEmit` for `@agent-native/core` passes.
+2. `discord.spec.ts` passes (`vitest --run src/integrations/adapters/discord`).
+3. End-to-end smoke: send a signed test interaction to
+   `/_agent-native/integrations/discord/webhook`; confirm a `200` returns
+   immediately, a task is enqueued, the processor runs the agent loop, and a
+   reply is delivered. A tampered signature must be rejected.

--- a/packages/core/blueprints/provider/stripe.md
+++ b/packages/core/blueprints/provider/stripe.md
@@ -1,0 +1,87 @@
+# Blueprint: integrate the Stripe API
+
+You are a coding agent working inside an **agent-native** app (a repo built on
+`@agent-native/core`). Apply this blueprint as real source changes on the
+current branch. Do not just describe the work — do it, then verify.
+
+## Goal
+
+Let the agent (and the UI) talk to the Stripe API for ad-hoc reads — list
+charges, look up a customer, summarize subscriptions — **without minting one
+rigid action per endpoint**. Wire Stripe into the shared **provider-api
+substrate** so any endpoint/filter is reachable through a single, safe surface.
+
+## Why the provider-api substrate (read this first)
+
+The framework tenet (see `CLAUDE.md` → Architecture Contract and the `actions`
+skill): first-class actions are ergonomic shortcuts, **not** capability limits.
+Do not hardcode `list-stripe-charges`, `get-stripe-customer`,
+`list-stripe-subscriptions`, … Instead expose the provider-api trio so the agent
+can hit any Stripe endpoint with the user's configured credentials, behind host
+allow-listing, credential injection, private-network blocking, and secret
+redaction.
+
+The substrate lives in `@agent-native/core/provider-api`:
+
+- `provider-api-catalog` — lists provider base URLs, auth style, credential
+  keys, docs/spec URLs, placeholders, and examples (never secrets).
+- `provider-api-docs` — fetches the registered public docs/spec URLs when the
+  exact endpoint, filter, or payload is uncertain.
+- `provider-api-request` — makes one constrained authenticated request to the
+  provider host, injects the configured credential, blocks internal URLs, and
+  redacts secrets.
+
+## Files to touch
+
+1. **Register the Stripe provider config** wherever this app assembles its
+   provider catalog (grep for `providerApi`, `provider-api`, or `defineProvider`
+   under `actions/`, `server/`, or look at `templates/dispatch/actions/` for the
+   canonical wiring). Add an entry like:
+
+   ```ts
+   {
+     id: "stripe",
+     label: "Stripe",
+     baseUrl: "https://api.stripe.com",
+     auth: { type: "bearer", credentialKey: "STRIPE_SECRET_KEY" },
+     docsUrls: ["https://docs.stripe.com/api"],
+     // Obviously-fake placeholder only — never a real key.
+     placeholders: { STRIPE_SECRET_KEY: "sk_test_PLACEHOLDER_xxx" },
+     examples: [
+       "GET /v1/charges?limit=10",
+       "GET /v1/customers/{id}",
+       "GET /v1/subscriptions?status=active",
+     ],
+   }
+   ```
+
+2. **Expose the three provider-api actions** if the app does not already export
+   them. Re-use `@agent-native/core/provider-api`; do **not** re-implement the
+   request/redaction logic. Keep `provider-api-request` `http: false` unless this
+   app has a separate UI permission model for arbitrary provider writes.
+
+3. **Register the credential** so it shows in the agent settings/onboarding UI.
+   Read the `secrets` and `onboarding` skills. The Stripe secret key is read at
+   request time via `readAppSecret` / the provider credential adapter — never
+   `process.env` for per-user/org secrets, never a literal in source.
+
+## Framework rules to honor
+
+- No `/api/*` or Nitro pass-through routes that just call Stripe — that violates
+  the Architecture Contract. The provider-api actions are already callable from
+  the agent, the UI (`useActionMutation`), HTTP, and MCP.
+- Never hardcode the Stripe key, a webhook signing secret, or any
+  credential-looking literal in source, tests, fixtures, or docs. Use
+  `sk_test_PLACEHOLDER_xxx`-style fakes.
+- If you add a publishable-package source change, add a `.changeset/*.md`.
+- Keep the action surface small and orthogonal — the trio replaces a dozen
+  per-endpoint actions.
+
+## Verify
+
+1. `agent-native typecheck` (or `tsc --noEmit`) passes.
+2. With a placeholder `STRIPE_SECRET_KEY` set, ask the agent: "list my 5 most
+   recent Stripe charges." Confirm it calls `provider-api-catalog` →
+   (optionally) `provider-api-docs` → `provider-api-request` against
+   `api.stripe.com`, and that the response redacts secrets.
+3. Confirm the Stripe credential appears in the settings/onboarding checklist.

--- a/packages/core/blueprints/sandbox/docker.md
+++ b/packages/core/blueprints/sandbox/docker.md
@@ -1,0 +1,78 @@
+# Blueprint: implement a Docker sandbox adapter
+
+You are a coding agent working inside an **agent-native** app (a repo built on
+`@agent-native/core`). Apply this blueprint as real source changes on the
+current branch. Do not just describe the work — do it, then verify.
+
+## Goal
+
+Run the `run-code` tool's agent-supplied JavaScript inside a **Docker
+container** instead of a local child process, without touching the agent loop,
+`run-code.ts`, the localhost bridge, the env scrub, or the output formatting.
+You implement the `SandboxAdapter` seam and select it via
+`AGENT_NATIVE_SANDBOX` / `registerSandboxAdapter()`.
+
+## Read first
+
+Read these three files — they ARE the contract:
+
+- `packages/core/src/coding-tools/sandbox/adapter.ts` — the `SandboxAdapter`
+  interface plus `SandboxRunRequest` / `SandboxRunResult` / `SandboxEnv`.
+- `packages/core/src/coding-tools/sandbox/index.ts` — `getSandboxAdapter()`
+  resolution order (registered → `AGENT_NATIVE_SANDBOX` built-in → local
+  default) and `registerSandboxAdapter()`. Note the `// TODO: remote/durable
+adapter` block — that is exactly this work.
+- `packages/core/src/coding-tools/sandbox/local-child-process-adapter.ts` — the
+  reference implementation to mirror for timeout enforcement and stdout/stderr
+  capture.
+
+Key invariant: the adapter receives an **already-prepared, non-secret**
+`moduleSource` (it already embeds the loopback bridge URL/token and wraps the
+user's code) plus a scrubbed `env`. The adapter only **runs** it. It must never
+augment `env` with the parent's environment and never see app secrets.
+
+## Files to touch
+
+1. **`packages/core/src/coding-tools/sandbox/docker-adapter.ts`** — implement
+   `class DockerSandboxAdapter implements SandboxAdapter`:
+   - `readonly id = "docker"`.
+   - `run(request)`:
+     - Write `request.moduleSource` to a temp ESM file (or pass via stdin).
+     - Spawn `docker run --rm` with a minimal Node image, the file mounted
+       read-only, `--network` configured so the sandbox can still reach the
+       parent's loopback bridge on `request.bridgePort` (use
+       `--add-host=host.docker.internal:host-gateway` and rewrite/allow the
+       bridge host, or `--network=host` where acceptable — document the
+       trade-off in a comment). Pass `request.env` explicitly; do NOT inherit
+       the host env. Apply CPU/memory limits.
+     - Enforce `request.timeoutMs` as a hard wall-clock kill (`docker kill`),
+       and set `timedOut: true` when you kill for timeout.
+     - Capture stdout/stderr and the container exit code into
+       `SandboxRunResult` (`exitCode: null` when terminated by signal).
+2. **Wire selection** in
+   `packages/core/src/coding-tools/sandbox/index.ts` by adding `docker` to the
+   `BUILT_IN_ADAPTERS` map (`docker: () => new DockerSandboxAdapter()`), so
+   `AGENT_NATIVE_SANDBOX=docker` selects it. A host process can also call
+   `registerSandboxAdapter(new DockerSandboxAdapter())` to force it everywhere.
+3. **Add `docker-adapter.spec.ts`** mirroring the existing sandbox
+   `index.spec.ts`: assert `getSandboxAdapter()` returns the Docker adapter when
+   `AGENT_NATIVE_SANDBOX=docker`, that a registered adapter wins over the env
+   var, and that timeout produces `timedOut: true`. Skip the real-`docker`
+   integration path when the Docker daemon is unavailable (guard on a probe).
+
+## Framework rules to honor
+
+- Do not change `run-code.ts`, the agent loop, the bridge, the env scrub, or the
+  output formatting — the whole point of the seam is that they stay untouched.
+- Preserve the security posture: the adapter sees only scrubbed env + prepared
+  module source. Never re-inject the parent env or app secrets.
+- This is a publishable `packages/core` source change → add a `.changeset/*.md`.
+
+## Verify
+
+1. `tsc --noEmit` for `@agent-native/core` passes.
+2. `docker-adapter.spec.ts` passes.
+3. With Docker available, set `AGENT_NATIVE_SANDBOX=docker` and run a `run-code`
+   task that uses `appAction`/`providerFetch` through the loopback bridge;
+   confirm it executes in a container and the bridge round-trips. Confirm a
+   long-running task is killed at `timeoutMs` with `timedOut: true`.

--- a/packages/core/docs/content/agent-teams.md
+++ b/packages/core/docs/content/agent-teams.md
@@ -141,6 +141,38 @@ You are a meticulous code reviewer. Be terse and concrete — cite file:line whe
 
 Store at `agents/code-review.md` in the workspace. It appears in the `@mention` dropdown and is available to the main agent as a delegation target. See [Workspace — Custom Agents](/docs/workspace#custom-agents) for the full format including `tools`, `delegate-default`, and model overrides.
 
+## Delegation depth guard {#depth-guard}
+
+Sub-agents can spawn sub-agents, which is a runaway/cost risk: an unbounded chain of delegations could fan out indefinitely. The framework enforces a **hard cap on delegation depth**, server-side, independent of any tool-level guard.
+
+The top-level chat is depth `0`. A sub-agent it spawns is depth `1`; that sub-agent may spawn once more (depth `2`); a spawn that would create a depth-`3` sub-agent is **refused**. The default cap is **2**.
+
+```txt
+depth 0  top-level chat        (may spawn)
+depth 1  sub-agent             (may spawn)
+depth 2  sub-agent's sub-agent (at the cap — may NOT spawn)
+depth 3  refused
+```
+
+Enforcement is ambient: each sub-agent runs inside an `AsyncLocalStorage` that records its own depth, so any `spawnTask` reached transitively from that run reads its parent's depth and refuses once the cap is hit — even if the `agent-teams` tool was handed to a sub-agent that should not have had it. The decision is exposed as a pure, unit-testable `evaluateSubagentDepth(parentDepth)`. A refused spawn returns a clear error: _"Delegation depth limit reached (max N); cannot spawn another sub-agent."_
+
+### Configuring the cap {#depth-guard-config}
+
+Override the default at deploy time with `AGENT_NATIVE_MAX_SUBAGENT_DEPTH`:
+
+| Value           | Effect                                                                                                                                |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| _(unset)_       | Default cap of `2`.                                                                                                                   |
+| `0`             | **No sub-agents may be spawned** — the top-level agent does all work.                                                                 |
+| `1`…`16`        | That many levels of delegation.                                                                                                       |
+| invalid / `>16` | A non-integer / negative / NaN value falls back to `2`; anything above `16` is clamped to `16` so a typo can never disable the guard. |
+
+```bash
+AGENT_NATIVE_MAX_SUBAGENT_DEPTH=1   # sub-agents allowed, but they can't sub-delegate
+```
+
+When a sub-agent is at or below the cap, the framework injects a line into its runtime context telling it how deep it sits and whether it may delegate further, so the model spends its budget appropriately.
+
 ## What's next
 
 - [**Workspace — Custom Agents**](/docs/workspace#custom-agents) — the profile format

--- a/packages/core/docs/content/blueprint-installer.md
+++ b/packages/core/docs/content/blueprint-installer.md
@@ -1,0 +1,73 @@
+---
+title: "Blueprint Installer"
+description: "agent-native add prints a curated Markdown integration recipe to stdout — pipe it into your coding agent, which applies the changes against your live repo."
+---
+
+# Blueprint Installer
+
+`agent-native add` is **not** a dumb scaffolder that writes files for you. It emits a curated Markdown _integration blueprint_ to stdout. You pipe that blueprint into your own coding agent (Claude Code, Codex, …), which applies the changes against the live repo with full context.
+
+This fits the agent-applies-changes, filesystem-first house style: the framework supplies the recipe (the canonical files to touch, the rules to honor, the verification step), and the coding agent does the editing.
+
+```bash
+agent-native add provider stripe | claude
+agent-native add channel discord  | codex
+```
+
+## Usage {#usage}
+
+```bash
+agent-native add <kind> <name>            # print a curated blueprint
+agent-native add <kind> <https://docs…>   # research-and-integrate from a URL
+agent-native add --list                   # list available kinds and blueprints
+```
+
+- A bare **name** resolves a curated blueprint from `blueprints/<kind>/<name>.md`.
+- A **URL** instead of a name emits a generic _research-and-integrate_ blueprint for that kind, with the URL embedded as the research starting point (a URL is a research seed, not a known recipe).
+- The blueprint goes to **stdout**; diagnostics go to stderr, so `… | claude` only ever receives the blueprint.
+
+## Seeded blueprints {#seeded}
+
+`agent-native add --list` shows what ships in the box:
+
+| Kind       | Name      | What it sets up                                                                    |
+| ---------- | --------- | ---------------------------------------------------------------------------------- |
+| `provider` | `stripe`  | Wire a provider into the `provider-api` substrate (catalog / docs / request trio). |
+| `channel`  | `discord` | Implement a `PlatformAdapter` inbound webhook channel and register it.             |
+| `sandbox`  | `docker`  | Implement the `SandboxAdapter` seam to run `run-code` in a Docker container.       |
+| `action`   | `crud`    | Add a single multi-surface `defineAction` with a Zod schema (one `update` over N). |
+
+Each blueprint is self-contained: the coding agent reading it gets the files to touch, the framework rules to honor (actions are the single source of truth, never hardcode secrets, scope ownable data, add a changeset for `packages/*` source), and a concrete **Verify** section.
+
+## URL → research blueprint {#url}
+
+When you pass a URL the kind doesn't have a curated recipe for (or want a fresh integration), `add` emits a generic "research-and-integrate" blueprint with the URL as the seed:
+
+```bash
+agent-native add provider https://docs.example.com/api | claude
+```
+
+The generated blueprint tells the coding agent to fetch the URL (and the pages it links to) for the real endpoints, auth model, payload shapes, and signature/verification requirements — _not_ to guess from training data — then implement and verify. It also carries kind-specific guidance (e.g. a `provider` URL is steered toward the `provider-api` substrate; a `channel` URL toward a `PlatformAdapter`).
+
+## Adding your own blueprint {#authoring}
+
+Drop a Markdown file into `packages/core/blueprints/<kind>/<name>.md`. The kind is the subdirectory; the name is the filename without `.md`. It is picked up automatically — `--list`, name resolution, and the catalog all read the directory at runtime. No code change is needed to register it.
+
+Blueprint `.md` files ship in the published package via the `blueprints` entry in `package.json` `files`, so they resolve at `node_modules/@agent-native/core/blueprints/**` for end users.
+
+Write each blueprint as an instruction set for a coding agent with no other context. A good blueprint has:
+
+1. **A one-line goal** and a "you are a coding agent in an agent-native app, apply these as real source changes" framing.
+2. **Read first** — the exact files that _are_ the contract.
+3. **Files to touch** — concrete paths and what each change does.
+4. **Framework rules to honor** — actions-first, no hardcoded secrets, scope ownable data, add a changeset for publishable-package source.
+5. **Verify** — typecheck, a focused `*.spec.ts`, and an end-to-end check.
+
+> [!TIP]
+> A new curated blueprint under an existing kind needs no code — but if you create a brand-new kind directory, that kind shows up in `--list` automatically too.
+
+## What's next
+
+- [**Sandbox Adapters**](/docs/sandbox-adapters) — the seam the `add sandbox docker` blueprint targets
+- [**Actions**](/docs/actions) — the single source of truth every blueprint builds on
+- [**External Agents**](/docs/external-agents) — connecting the coding agent you pipe blueprints into

--- a/packages/core/docs/content/evals.md
+++ b/packages/core/docs/content/evals.md
@@ -1,0 +1,141 @@
+---
+title: "Evals (CI Gate)"
+description: "Write *.eval.ts test cases that run the real agent against fixed inputs, score the output with composable scorers, and gate CI/deploys on a threshold."
+---
+
+# Evals (CI Gate)
+
+Evals are a first-class testing primitive: you declare a prompt plus the behavior you expect, the runner **actually runs the agent loop** against that input, scores the output with composable scorers, and exits non-zero if any case scores below its threshold. That non-zero exit makes `agent-native eval` a drop-in CI deploy gate.
+
+This is complementary to the post-hoc scoring in [Observability](/docs/observability):
+
+- **Observability evals** (`observability/evals.ts`) — _"how did this real run do?"_ Passive, sampled, lives next to traces.
+- **`*.eval.ts` (this primitive)** — _"does the agent do the right thing on this fixed input?"_ Active, deterministic, a CI gate run via the CLI.
+
+The runner resolves a provider-agnostic engine/model from the existing registry — no model is hardcoded — so the same suite runs against whatever engine the app is configured for.
+
+## Writing an eval {#writing}
+
+Drop a `*.eval.ts` file anywhere in the app (or an `evals/*.ts` file). Each file `export default defineEval(...)` (or exports an array of them):
+
+```ts
+// evals/greeting.eval.ts
+import { defineEval, contains, llmJudge } from "@agent-native/core/eval";
+
+export default defineEval({
+  name: "greets the user by name",
+  input: { prompt: "Say hi to Ada." },
+  threshold: 0.7, // per-scorer pass bar; default 0.5
+  scorers: [
+    contains("Ada"),
+    llmJudge({ criteria: "friendliness", rubric: "1.0 = warm greeting" }),
+  ],
+});
+```
+
+An eval passes only when **every** scorer meets the threshold. Key `defineEval` fields:
+
+| Field       | Type                  | Notes                                                         |
+| ----------- | --------------------- | ------------------------------------------------------------- |
+| `name`      | string                | Required. Shown in the report.                                |
+| `input`     | `{ prompt, history }` | Required `prompt`; optional prior `{ role, text }` turns.     |
+| `scorers`   | `Scorer[]`            | Required, at least one.                                       |
+| `threshold` | number `0..1`         | Per-scorer pass bar. Default `0.5`; overridable from the CLI. |
+| `run`       | function              | Optional override for custom setup (seed data, multi-turn).   |
+
+The agent run handed to scorers is small and transport-agnostic:
+
+```ts
+interface AgentRunOutput {
+  text: string; // concatenated assistant text
+  toolCalls: readonly string[]; // tool/action names, in call order
+  ok: boolean; // completed without a terminal error
+  error?: string;
+  runId: string;
+  durationMs: number;
+}
+```
+
+## Built-in scorers {#built-in}
+
+Imported from `@agent-native/core/eval`:
+
+| Scorer                   | Score                                                             | Model? |
+| ------------------------ | ----------------------------------------------------------------- | ------ |
+| `exactMatch(expected)`   | `1.0` if text equals `expected` (trimmed, case-insensitive)       | No     |
+| `contains(needles)`      | Fraction of required substrings present (so partial hits surface) | No     |
+| `usesTool(toolName)`     | `1.0` if the agent invoked that tool/action at least once         | No     |
+| `llmJudge({ criteria })` | LLM-as-judge scored against a natural-language rubric, → `0..1`   | Yes    |
+
+`exactMatch` and `contains` take an optional `{ caseSensitive }`. `llmJudge` takes `{ criteria, rubric?, name?, scoreRange? }` — its output is normalized to `[0, 1]`, and the judge model is whatever the runner resolved (never a hardcoded provider).
+
+## Custom scorers: the 4-step pipeline {#custom}
+
+`createScorer` builds a scorer from a Mastra-style 4-step pipeline. Only `generateScore` is required:
+
+```txt
+preprocess(run)     → x          transform the run/output (optional)
+analyze(x, ctx)     → analysis   plain JS OR an LLM judge (optional)
+generateScore(a)    → 0..1       REQUIRED, normalized
+generateReason(...) → string     human-readable why (optional)
+```
+
+`preprocess` and `analyze` default to identity (the scorer sees the raw `AgentRunOutput`). The `analyze` step receives a `ctx` with a provider-agnostic `judge()` helper for LLM-backed scoring:
+
+```ts
+import { createScorer, clamp01 } from "@agent-native/core/eval";
+
+// A scorer that rewards short, tool-using answers.
+const concise = createScorer({
+  name: "concise_with_tool",
+  analyze(run) {
+    return {
+      words: run.text.trim().split(/\s+/).length,
+      usedTool: run.toolCalls.length > 0,
+    };
+  },
+  generateScore({ words, usedTool }) {
+    if (!usedTool) return 0;
+    return clamp01(1 - Math.max(0, words - 40) / 200);
+  },
+  generateReason({ analysis }) {
+    return `${analysis.words} words, tool used: ${analysis.usedTool}`;
+  },
+});
+```
+
+## Running the gate {#cli}
+
+```bash
+agent-native eval                    # run every *.eval.ts; non-zero exit on failure
+agent-native eval billing            # only files whose path contains "billing"
+agent-native eval --json             # machine-readable report (for CI)
+agent-native eval --threshold 0.8    # override every eval's pass threshold (0..1)
+```
+
+The command discovers `**/*.eval.ts` and `evals/*.ts` under the current app, runs the agent for each input, scores it, prints a readable table (or JSON), and **exits non-zero if any eval scores below its threshold**.
+
+Exit codes:
+
+| Code | Meaning                                                         |
+| ---- | --------------------------------------------------------------- |
+| `0`  | All evals passed — _or_ no eval files were found (CI-friendly). |
+| `1`  | At least one eval scored below threshold, or the suite errored. |
+| `2`  | Bad arguments (e.g. `--threshold` outside `[0, 1]`).            |
+
+### As a CI deploy gate {#ci}
+
+Add it to the pipeline that runs before a deploy:
+
+```yaml
+# .github/workflows/deploy.yml (excerpt)
+- run: npx agent-native eval --json
+```
+
+A regression that drops any scorer below threshold fails the step and blocks the deploy. An app with no eval files exits `0`, so adopting evals is opt-in per app.
+
+## What's next
+
+- [**Observability**](/docs/observability) — post-hoc scoring of real production runs (the complementary layer)
+- [**Actions**](/docs/actions) — the tools/actions that show up in `toolCalls`
+- [**Agent Teams**](/docs/agent-teams) — sub-agents an eval might exercise

--- a/packages/core/docs/content/pr-visual-recap.md
+++ b/packages/core/docs/content/pr-visual-recap.md
@@ -216,12 +216,15 @@ the prompt instructs the agent to write `plans/pr-123-visual-recap/plan.mdx`
 plus optional visual files and then run:
 
 ```bash
-npx @agent-native/core@latest plan local preview --dir plans/pr-123-visual-recap --kind recap --open
+npx @agent-native/core@latest plan local serve --dir plans/pr-123-visual-recap --kind recap --open
 ```
 
-The returned `file://` preview, or `/local-plans/pr-123-visual-recap` in a local
-Plan app using the same `PLAN_LOCAL_DIR`, is the review link. This mode disables
-the hosted sticky PR comment, inline screenshot upload, usage attachment, and
+The returned URL opens the hosted Plan UI while the browser reads the recap MDX
+from a localhost bridge. Recap content is not written to the hosted Plan
+database, and the URL only works on the machine running the bridge. If you run
+the Plan app locally with the same `PLAN_LOCAL_DIR`, the
+`/local-plans/pr-123-visual-recap` route is also valid. This mode disables the
+hosted sticky PR comment, inline screenshot upload, usage attachment, and
 browser comments until you explicitly publish.
 
 ## It's informational, not a gate

--- a/packages/core/docs/content/sandbox-adapters.md
+++ b/packages/core/docs/content/sandbox-adapters.md
@@ -1,0 +1,134 @@
+---
+title: "Sandbox Adapters"
+description: "Swap the backend that runs the agent's run-code tool — local child process by default, a remote/durable runner when you need to exceed the hosted code-exec ceiling."
+---
+
+# Sandbox Adapters
+
+The `run-code` tool runs agent-supplied JavaScript in an isolated environment. **Sandbox adapters** factor the _execution_ concern out of that tool so the backend can be swapped — a local child process by default, or a Docker / remote / durable runner — without touching the agent loop, `run-code.ts`, the localhost bridge, the env scrub, or the output formatting.
+
+## Why a seam {#why}
+
+The default backend spawns a locked-down local Node child process. That's bounded by the hosting process: on the hosted platform it shares the agent loop's soft execution ceiling (~40s before timeout/continuation thrash). A remote or durable adapter is the lever to exceed that ceiling — it runs large data jobs to completion independently of the request lifecycle.
+
+Keeping the contract narrow means a remote adapter inherits the same security posture. The parent process keeps ownership of everything secret-bearing: it builds the sandbox module, runs the localhost bridge (which holds the request context and applies host allowlists + SSRF guards), scrubs the env, and formats output. An adapter only receives an already-prepared, **non-secret** module source plus resource limits — it is responsible solely for _running_ it and capturing stdout/stderr/exit status.
+
+## The interface {#interface}
+
+The seam lives in core at `packages/core/src/coding-tools/sandbox/` — `adapter.ts` (the contract), `index.ts` (selection: `getSandboxAdapter()` / `registerSandboxAdapter()`), and `local-child-process-adapter.ts` (the default). It is wired in-package by `run-code.ts`; a host plugs in a different backend through the `index.ts` registration helper (or, for a Docker backend, via the [blueprint](/docs/blueprint-installer) that edits these files directly).
+
+Every backend implements `SandboxAdapter`:
+
+```ts
+interface SandboxAdapter {
+  /** Stable id, surfaced for diagnostics and adapter selection. */
+  readonly id: string;
+  /** Execute one prepared sandbox module and capture its output. */
+  run(request: SandboxRunRequest): Promise<SandboxRunResult>;
+}
+```
+
+The request and result are intentionally small and opaque:
+
+```ts
+interface SandboxRunRequest {
+  /**
+   * The complete ESM module source to execute. Already wraps the user's code
+   * and embeds the loopback bridge URL/token; the adapter does NOT parse or
+   * rewrite it.
+   */
+  moduleSource: string;
+  /**
+   * Scrubbed environment — only safe POSIX vars (PATH/HOME/TMPDIR/…), never app
+   * secrets. Adapters must not augment this with the parent's own environment.
+   */
+  env: Record<string, string>;
+  /** Hard wall-clock timeout in milliseconds. The adapter must enforce it. */
+  timeoutMs: number;
+  /**
+   * Loopback port of the parent's bridge server (reachable over 127.0.0.1). A
+   * remote adapter that can't reach the parent's loopback must tunnel or proxy
+   * this to support bridge-backed globals (`appAction`, `providerFetch`, …).
+   */
+  bridgePort: number;
+}
+
+interface SandboxRunResult {
+  stdout: string;
+  stderr: string;
+  /** `0` on clean exit, non-zero on failure, `null` when killed by a signal. */
+  exitCode: number | null;
+  /** True when the run was killed for exceeding `timeoutMs`. */
+  timedOut: boolean;
+}
+```
+
+## The default: `LocalChildProcessAdapter` {#default}
+
+Out of the box, `getSandboxAdapter()` returns `LocalChildProcessAdapter` (`id: "local-child-process"`). It preserves the historical `run-code` behavior byte-for-byte:
+
+- The prepared module source is written to a fresh temp dir.
+- The child runs with the scrubbed env (no secrets), with `TMPDIR`/`TEMP`/`TMP` pointed inside the sandbox dir.
+- When the Node permission model is available (`--permission`, or `--experimental-permission` on Node 20), the child is denied filesystem access outside its temp dir, plus child processes, workers, and native addons. Outbound network is _not_ blocked by the permission model — but the env scrub means such requests carry no credentials, and all authenticated calls go through the parent's loopback bridge.
+- A timeout sends `SIGTERM`, then `SIGKILL` after a 2s grace period.
+- Temp files are cleaned up best-effort after the run.
+
+> [!WARNING]
+> The default adapter uses `node:child_process`, which does not exist on edge/worker runtimes (Cloudflare Workers, Netlify Edge Functions). Run `run-code` in a standard Node.js environment, or register a remote adapter.
+
+## Selecting an adapter {#selection}
+
+Resolution order — an explicitly registered adapter wins; otherwise the env var selects a built-in; otherwise the local default is used:
+
+```txt
+registerSandboxAdapter(adapter)  →  AGENT_NATIVE_SANDBOX  →  local default
+```
+
+### `AGENT_NATIVE_SANDBOX` env var {#env}
+
+Selects a built-in adapter by id. Currently only `local` (the default) is wired; unknown values fall back to local rather than failing the run.
+
+```bash
+AGENT_NATIVE_SANDBOX=local   # the default — explicit
+```
+
+### `registerSandboxAdapter()` {#register}
+
+A host process overrides the backend for all subsequent `run-code` invocations through the seam's `index.ts` — for example, to run every call in a remote container:
+
+```ts
+import {
+  registerSandboxAdapter,
+  type SandboxAdapter,
+} from "./coding-tools/sandbox/index.js";
+
+class RemoteSandboxAdapter implements SandboxAdapter {
+  readonly id = "remote";
+  async run(request) {
+    // Ship request.moduleSource to the durable runner, enforce request.timeoutMs,
+    // proxy bridge calls back to request.bridgePort, and return stdout/stderr/exitCode.
+  }
+}
+
+registerSandboxAdapter(new RemoteSandboxAdapter());
+// Pass `null` to clear the override and fall back to env-var / default resolution.
+```
+
+## The seam for a durable runner {#durable}
+
+This interface is deliberately the seam for a future remote/durable sandbox. A remote or durable adapter (Docker, a Vercel-Sandbox-style runner, or a queued background worker) would:
+
+1. Implement `SandboxAdapter.run` against an out-of-process runtime.
+2. Tunnel the loopback bridge (or proxy bridge calls back to the parent).
+3. Let large data jobs run to completion independently of the request lifecycle — exceeding the hosted ~40s code-exec ceiling that bounds the local child-process adapter.
+
+Register it under a new `AGENT_NATIVE_SANDBOX` value (e.g. `remote`) and/or via `registerSandboxAdapter()`. The agent loop and `run-code.ts` never change.
+
+> [!TIP]
+> The `agent-native add sandbox docker` blueprint emits a full, self-contained recipe for implementing a Docker adapter against this seam. See [Blueprint Installer](/docs/blueprint-installer).
+
+## What's next
+
+- [**Blueprint Installer**](/docs/blueprint-installer) — `agent-native add sandbox docker` prints a Docker-adapter recipe
+- [**Agent Teams**](/docs/agent-teams) — delegating heavy work to sub-agents
+- [**Security**](/docs/security) — the env scrub and bridge allowlist posture

--- a/packages/core/docs/content/template-plan.md
+++ b/packages/core/docs/content/template-plan.md
@@ -180,22 +180,34 @@ or set the convention for your agent environment:
 export AGENT_NATIVE_PLANS_MODE=local-files
 ```
 
-In this mode the agent writes a local MDX folder under `plans/<slug>/` and must
-not call the hosted Plan MCP tools. The durable files are:
+In this mode the agent writes a local MDX folder and must not call the hosted
+Plan MCP tools. Use a repo folder such as `plans/<slug>/` when you want the plan
+checked in with the code. Use a temp or ignored folder, such as
+`/tmp/agent-native-plans/<slug>/` or `.agent-native/plans/<slug>/`, when the
+plan should stay out of git. The folder contains:
 
 - `plan.mdx`
 - optional `canvas.mdx`
 - optional `prototype.mdx`
 - optional `.plan-state.json`
 
-After writing the folder, the agent validates and previews it locally:
+After writing the folder, the agent starts a tiny localhost bridge and opens the
+hosted Plan UI against that local-only source:
 
 ```bash
-npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind plan --open
+npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind plan --open
 ```
 
-If you run the Plan app locally with the same `PLAN_LOCAL_DIR`, you can open the
-read-only app route:
+The bridge URL looks like
+`https://plan.agent-native.com/local-plans/<slug>?bridge=http://127.0.0.1:...`.
+The page is the normal Plan viewer, but the browser fetches `plan.mdx`,
+`canvas.mdx`, `prototype.mdx`, `.plan-state.json`, and local image assets from
+the localhost bridge. Plan content is not written to the hosted database and is
+not sent through hosted Plan actions. Keep the bridge process running while you
+review; the URL is local to your machine and is not a shareable team link.
+
+If you run the Plan app locally with the same `PLAN_LOCAL_DIR`, you can also
+open the read-only app route:
 
 ```text
 http://localhost:<port>/local-plans/<slug>
@@ -206,8 +218,8 @@ Plan database. It also disables hosted sharing, browser comments, plan history,
 and publish/export receipts until you explicitly opt into publishing. To move a
 local plan into the hosted database, call `publish-visual-plan` with the local
 MDX folder path; this uploads the plan, assigns it a hosted ID, enables sharing
-and commenting, and returns the hosted URL. It does
-not automatically make your coding agent's LLM local; choose a local or approved
+and commenting, and returns the hosted URL. Local-files mode does not
+automatically make your coding agent's LLM local; choose a local or approved
 model if that privacy boundary matters too.
 
 ## Desktop local file sync {#desktop-local-sync}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -275,6 +275,7 @@
     "ws": ">=8"
   },
   "optionalDependencies": {
+    "@opentelemetry/api": "^1.9.1",
     "playwright": "^1.60.0"
   },
   "peerDependenciesMeta": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,6 +74,7 @@
     "./agent/context-xray/actions/context-evict": "./dist/agent/context-xray/actions/context-evict.js",
     "./agent/context-xray/actions/context-restore": "./dist/agent/context-xray/actions/context-restore.js",
     "./agent/context-xray/actions/context-report": "./dist/agent/context-xray/actions/context-report.js",
+    "./agent/observational-memory": "./dist/agent/observational-memory/index.js",
     "./resources": "./dist/resources/index.js",
     "./resources/store": "./dist/resources/store.js",
     "./resources/metadata": "./dist/resources/metadata.js",
@@ -135,6 +136,7 @@
     "./styles/agent-native.css": "./dist/styles/agent-native.css",
     "./agent/engine": "./dist/agent/engine/index.js",
     "./agent/harness": "./dist/agent/harness/index.js",
+    "./eval": "./dist/eval/index.js",
     "./tsconfig.base.json": "./tsconfig.base.json"
   },
   "sideEffects": [
@@ -142,6 +144,7 @@
   ],
   "files": [
     "bin",
+    "blueprints",
     "dist",
     "docs",
     "tsconfig.base.json",

--- a/packages/core/src/action.spec.ts
+++ b/packages/core/src/action.spec.ts
@@ -168,6 +168,46 @@ describe("defineAction", () => {
     });
   });
 
+  it("preserves a boolean needsApproval flag on the returned entry", () => {
+    const action = defineAction({
+      description: "send an email",
+      parameters: { to: { type: "string" } },
+      needsApproval: true,
+      run: async () => "sent",
+    });
+    expect(action.needsApproval).toBe(true);
+  });
+
+  it("preserves a predicate needsApproval gate on the returned entry", () => {
+    const gate = (args: { to: string }) => args.to.endsWith("@external.com");
+    const action = defineAction({
+      description: "send an email",
+      parameters: { to: { type: "string" } },
+      needsApproval: gate,
+      run: async () => "sent",
+    });
+    expect(action.needsApproval).toBe(gate);
+  });
+
+  it("leaves needsApproval undefined when not specified (default off)", () => {
+    const action = defineAction({
+      description: "send an email",
+      parameters: { to: { type: "string" } },
+      run: async () => "sent",
+    });
+    expect(action.needsApproval).toBeUndefined();
+  });
+
+  it("drops a wrong-typed needsApproval value instead of threading it through", () => {
+    const action = defineAction({
+      description: "send an email",
+      parameters: { to: { type: "string" } },
+      needsApproval: "yes" as any,
+      run: async () => "sent",
+    } as any);
+    expect(action.needsApproval).toBeUndefined();
+  });
+
   it("omits http from the entry when http is not specified", () => {
     const action = defineAction({
       description: "no http",

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -325,6 +325,28 @@ interface DefineActionWithSchema<
    *  interactive app iframes. Text/deep-link tool results remain the fallback
    *  for CLI and non-UI hosts. */
   mcpApp?: ActionMcpAppConfig;
+  /**
+   * Opt-in human-in-the-loop approval gate. **Default off** — the framework
+   * intentionally keeps HITL approvals rare; almost every action should run
+   * without one. Set this only for high-consequence, outward-facing,
+   * hard-to-undo operations (the canonical example is actually sending an
+   * email). When `needsApproval` resolves truthy and the agent calls this
+   * action, the loop does NOT execute `run()`: it emits an `approval_required`
+   * event and stops the turn, waiting for a human to approve. The action runs
+   * only once the human re-issues the turn approving this specific call.
+   *
+   * - `true` — always require approval.
+   * - `(args, ctx) => boolean | Promise<boolean>` — require approval only when
+   *   the predicate returns true (e.g. only for external recipients, only
+   *   above a dollar threshold). Keep it pure + fast; thrown errors are treated
+   *   as "approval required" (fail closed).
+   */
+  needsApproval?:
+    | boolean
+    | ((
+        args: StandardSchemaV1.InferOutput<TSchema>,
+        ctx?: ActionRunContext,
+      ) => boolean | Promise<boolean>);
 }
 
 // ---------------------------------------------------------------------------
@@ -371,6 +393,14 @@ interface DefineActionWithParams<
   link?: ActionLinkBuilder;
   /** Optional MCP Apps UI resource. See schema overload above. */
   mcpApp?: ActionMcpAppConfig;
+  /** Opt-in human-in-the-loop approval gate (default off). See the schema
+   *  overload above for full semantics. */
+  needsApproval?:
+    | boolean
+    | ((
+        args: InferParams<TParams>,
+        ctx?: ActionRunContext,
+      ) => boolean | Promise<boolean>);
 }
 
 // ---------------------------------------------------------------------------
@@ -410,6 +440,12 @@ export interface ActionDefinition<TInput, TReturn> {
   readonly publicAgent?: PublicAgentActionConfig;
   readonly link?: ActionLinkBuilder;
   readonly mcpApp?: ActionMcpAppConfig;
+  /** Opt-in human-in-the-loop approval gate (default off). When truthy, the
+   *  agent loop emits `approval_required` and pauses instead of executing this
+   *  action until a human approves the specific call. */
+  readonly needsApproval?:
+    | boolean
+    | ((args: TInput, ctx?: ActionRunContext) => boolean | Promise<boolean>);
 }
 
 // ---------------------------------------------------------------------------
@@ -574,6 +610,10 @@ export function defineAction(options: any) {
     ...(publicAgent ? { publicAgent } : {}),
     ...(link ? { link } : {}),
     ...(mcpApp ? { mcpApp } : {}),
+    ...(typeof options.needsApproval === "boolean" ||
+    typeof options.needsApproval === "function"
+      ? { needsApproval: options.needsApproval }
+      : {}),
   };
 }
 

--- a/packages/core/src/agent/observational-memory/compactor.spec.ts
+++ b/packages/core/src/agent/observational-memory/compactor.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { EngineMessage } from "../engine/types.js";
+
+const observerMod = vi.hoisted(() => ({ runObserver: vi.fn() }));
+const reflectorMod = vi.hoisted(() => ({ runReflector: vi.fn() }));
+const threadStoreMod = vi.hoisted(() => ({ getThread: vi.fn() }));
+const threadBuilderMod = vi.hoisted(() => ({
+  threadDataToEngineMessages: vi.fn(),
+}));
+
+vi.mock("./observer.js", () => observerMod);
+vi.mock("./reflector.js", () => reflectorMod);
+vi.mock("../../chat-threads/store.js", () => threadStoreMod);
+vi.mock("../thread-data-builder.js", () => threadBuilderMod);
+
+const { maybeCompactThread } = await import("./compactor.js");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  observerMod.runObserver.mockResolvedValue({
+    observed: false,
+    unobservedTokens: 0,
+  });
+  reflectorMod.runReflector.mockResolvedValue({
+    reflected: false,
+    observationLogTokens: 0,
+  });
+});
+
+describe("maybeCompactThread", () => {
+  it("runs Observer then Reflector with the supplied messages", async () => {
+    const messages: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ];
+
+    const result = await maybeCompactThread({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+      messages,
+    });
+
+    expect(observerMod.runObserver).toHaveBeenCalledTimes(1);
+    expect(observerMod.runObserver.mock.calls[0][0].messages).toBe(messages);
+    expect(reflectorMod.runReflector).toHaveBeenCalledTimes(1);
+    // Both threaded the same owner scope through.
+    expect(observerMod.runObserver.mock.calls[0][0].ownerEmail).toBe(
+      "alice@example.com",
+    );
+    expect(reflectorMod.runReflector.mock.calls[0][0].ownerEmail).toBe(
+      "alice@example.com",
+    );
+    expect(result.observer.observed).toBe(false);
+    expect(result.reflector.reflected).toBe(false);
+    // No thread load needed when messages are supplied.
+    expect(threadStoreMod.getThread).not.toHaveBeenCalled();
+  });
+
+  it("loads thread messages from the store when none are supplied", async () => {
+    threadStoreMod.getThread.mockResolvedValue({
+      threadData: '{"messages":[]}',
+    });
+    const loaded: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "loaded" }] },
+    ];
+    threadBuilderMod.threadDataToEngineMessages.mockReturnValue(loaded);
+
+    await maybeCompactThread({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+    });
+
+    expect(threadStoreMod.getThread).toHaveBeenCalledWith("t1");
+    expect(threadBuilderMod.threadDataToEngineMessages).toHaveBeenCalledWith(
+      '{"messages":[]}',
+    );
+    expect(observerMod.runObserver.mock.calls[0][0].messages).toBe(loaded);
+  });
+});

--- a/packages/core/src/agent/observational-memory/compactor.ts
+++ b/packages/core/src/agent/observational-memory/compactor.ts
@@ -1,0 +1,78 @@
+/**
+ * Compactor orchestration for Observational Memory.
+ *
+ * `maybeCompactThread` is the single, decoupled entry point the agent loop can
+ * call AFTER a turn: it runs the Observer (which no-ops below the observation
+ * threshold) and then the Reflector (which no-ops below the reflection
+ * threshold). It is intentionally NOT wired into production-agent.ts here — it
+ * is exported so the loop can call it later.
+ *
+ * Messages can be supplied directly (the loop already has them) or loaded from
+ * the chat-threads store by `threadId` via the persisted `thread_data`. Loading
+ * goes through the existing `threadDataToEngineMessages` reader so OM never
+ * reimplements thread parsing.
+ */
+
+import type { EngineMessage } from "../engine/types.js";
+import { getThread } from "../../chat-threads/store.js";
+import { threadDataToEngineMessages } from "../thread-data-builder.js";
+import type { ObservationalMemoryConfig } from "./config.js";
+import { runObserver, type RunObserverResult } from "./observer.js";
+import { runReflector, type RunReflectorResult } from "./reflector.js";
+import type { InternalAgentRunFn } from "./internal-run.js";
+import type { ObservationalMemoryOwner } from "./types.js";
+
+export interface MaybeCompactThreadOptions extends ObservationalMemoryOwner {
+  threadId: string;
+  /**
+   * The full, ordered thread messages. When omitted, they are loaded from the
+   * chat-threads store by `threadId`.
+   */
+  messages?: EngineMessage[];
+  config?: Partial<ObservationalMemoryConfig>;
+  /** Internal-run seam — defaults to the real one; injected in tests. */
+  runInternal?: InternalAgentRunFn;
+}
+
+export interface MaybeCompactThreadResult {
+  observer: RunObserverResult;
+  reflector: RunReflectorResult;
+}
+
+async function loadThreadMessages(threadId: string): Promise<EngineMessage[]> {
+  const thread = await getThread(threadId);
+  if (!thread?.threadData) return [];
+  return threadDataToEngineMessages(thread.threadData);
+}
+
+/**
+ * Run a full compaction pass for a thread. Observer first (may fold the
+ * unobserved tail into an observation), then Reflector (may condense the
+ * observation log into a reflection). Both are no-ops below their thresholds,
+ * so this is cheap to call after every turn.
+ */
+export async function maybeCompactThread(
+  options: MaybeCompactThreadOptions,
+): Promise<MaybeCompactThreadResult> {
+  const messages =
+    options.messages ?? (await loadThreadMessages(options.threadId));
+
+  const observer = await runObserver({
+    ownerEmail: options.ownerEmail,
+    orgId: options.orgId ?? null,
+    threadId: options.threadId,
+    messages,
+    config: options.config,
+    runInternal: options.runInternal,
+  });
+
+  const reflector = await runReflector({
+    ownerEmail: options.ownerEmail,
+    orgId: options.orgId ?? null,
+    threadId: options.threadId,
+    config: options.config,
+    runInternal: options.runInternal,
+  });
+
+  return { observer, reflector };
+}

--- a/packages/core/src/agent/observational-memory/config.ts
+++ b/packages/core/src/agent/observational-memory/config.ts
@@ -1,0 +1,78 @@
+/**
+ * Tunable thresholds for Observational Memory compaction.
+ *
+ * Defaults are conservative and overridable per call. Deploy-level
+ * AGENT_NATIVE_* env overrides let an operator dial compaction without a
+ * redeploy; an invalid/missing value always falls back to the named default.
+ */
+
+/**
+ * Once a thread's UNOBSERVED messages exceed this many tokens, the Observer
+ * compacts them into a single dense, dated observation entry.
+ */
+export const DEFAULT_OBSERVATION_TOKEN_THRESHOLD = 30_000;
+
+/**
+ * Once the persisted observation log itself exceeds this many tokens, the
+ * Reflector condenses the observations into a higher-level reflection.
+ */
+export const DEFAULT_REFLECTION_TOKEN_THRESHOLD = 40_000;
+
+/**
+ * How many of the most-recent thread messages to always keep verbatim in the
+ * read-side context (the "recent raw messages" tier). These are never folded
+ * into an observation, so the agent always sees the latest turns in full.
+ */
+export const DEFAULT_RECENT_RAW_MESSAGE_COUNT = 12;
+
+/** Cap on the Observer's output so one observation can't itself blow the budget. */
+export const DEFAULT_OBSERVATION_MAX_OUTPUT_TOKENS = 4_000;
+
+/** Cap on the Reflector's output. */
+export const DEFAULT_REFLECTION_MAX_OUTPUT_TOKENS = 2_000;
+
+function readEnvInt(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/** Resolved thresholds, applying env overrides over the named defaults. */
+export interface ObservationalMemoryConfig {
+  observationTokenThreshold: number;
+  reflectionTokenThreshold: number;
+  recentRawMessageCount: number;
+  observationMaxOutputTokens: number;
+  reflectionMaxOutputTokens: number;
+}
+
+export function resolveObservationalMemoryConfig(
+  overrides: Partial<ObservationalMemoryConfig> = {},
+): ObservationalMemoryConfig {
+  return {
+    observationTokenThreshold:
+      overrides.observationTokenThreshold ??
+      readEnvInt(
+        process.env.AGENT_NATIVE_OM_OBSERVATION_TOKEN_THRESHOLD,
+        DEFAULT_OBSERVATION_TOKEN_THRESHOLD,
+      ),
+    reflectionTokenThreshold:
+      overrides.reflectionTokenThreshold ??
+      readEnvInt(
+        process.env.AGENT_NATIVE_OM_REFLECTION_TOKEN_THRESHOLD,
+        DEFAULT_REFLECTION_TOKEN_THRESHOLD,
+      ),
+    recentRawMessageCount:
+      overrides.recentRawMessageCount ??
+      readEnvInt(
+        process.env.AGENT_NATIVE_OM_RECENT_RAW_MESSAGE_COUNT,
+        DEFAULT_RECENT_RAW_MESSAGE_COUNT,
+      ),
+    observationMaxOutputTokens:
+      overrides.observationMaxOutputTokens ??
+      DEFAULT_OBSERVATION_MAX_OUTPUT_TOKENS,
+    reflectionMaxOutputTokens:
+      overrides.reflectionMaxOutputTokens ??
+      DEFAULT_REFLECTION_MAX_OUTPUT_TOKENS,
+  };
+}

--- a/packages/core/src/agent/observational-memory/index.ts
+++ b/packages/core/src/agent/observational-memory/index.ts
@@ -1,0 +1,77 @@
+/**
+ * Observational Memory (OM) — background compaction of a long agent thread into
+ * a dated, three-tier context (recent raw messages → dense observations →
+ * higher-level reflections) so long-running threads cost far fewer tokens and
+ * stay prompt-cache stable.
+ *
+ * Public surface:
+ * - `buildObservationalContext` — read API returning the three tiers ready for
+ *   prompt injection. NOT yet wired into production-agent.ts (see the
+ *   TODO(charlie-merge) seam in `read.ts`).
+ * - `maybeCompactThread` — decoupled compactor the agent loop can call after a
+ *   turn; runs the Observer then the Reflector. Wired later, not now.
+ * - `runObserver` / `runReflector` — the individual compaction passes.
+ * - store helpers + the migration plugin factory.
+ */
+
+export {
+  resolveObservationalMemoryConfig,
+  DEFAULT_OBSERVATION_TOKEN_THRESHOLD,
+  DEFAULT_REFLECTION_TOKEN_THRESHOLD,
+  DEFAULT_RECENT_RAW_MESSAGE_COUNT,
+  DEFAULT_OBSERVATION_MAX_OUTPUT_TOKENS,
+  DEFAULT_REFLECTION_MAX_OUTPUT_TOKENS,
+  type ObservationalMemoryConfig,
+} from "./config.js";
+
+export {
+  insertObservationalMemory,
+  listObservationalMemory,
+  getObservedThroughIndex,
+  getObservationLogTokens,
+  __resetObservationalMemoryTableCache,
+  type InsertObservationalMemoryInput,
+  type ListObservationalMemoryOptions,
+} from "./store.js";
+
+export {
+  runInternalAgentCall,
+  type InternalAgentRunOptions,
+  type InternalAgentRunFn,
+} from "./internal-run.js";
+
+export {
+  runObserver,
+  type RunObserverOptions,
+  type RunObserverResult,
+} from "./observer.js";
+export {
+  runReflector,
+  type RunReflectorOptions,
+  type RunReflectorResult,
+} from "./reflector.js";
+
+export {
+  maybeCompactThread,
+  type MaybeCompactThreadOptions,
+  type MaybeCompactThreadResult,
+} from "./compactor.js";
+
+export {
+  buildObservationalContext,
+  type BuildObservationalContextOptions,
+} from "./read.js";
+
+export {
+  createObservationalMemoryPlugin,
+  defaultObservationalMemoryPlugin,
+} from "./plugin.js";
+
+export { OBSERVATIONAL_MEMORY_MIGRATIONS } from "./migrations.js";
+
+export type {
+  ObservationalMemoryTier,
+  ObservationalMemoryEntry,
+  ObservationalMemoryOwner,
+  ObservationalContext,
+} from "./types.js";

--- a/packages/core/src/agent/observational-memory/index.ts
+++ b/packages/core/src/agent/observational-memory/index.ts
@@ -59,6 +59,8 @@ export {
 
 export {
   buildObservationalContext,
+  hasObservationalMemory,
+  serializeObservationalMemoryBlock,
   type BuildObservationalContextOptions,
 } from "./read.js";
 

--- a/packages/core/src/agent/observational-memory/internal-run.ts
+++ b/packages/core/src/agent/observational-memory/internal-run.ts
@@ -1,0 +1,89 @@
+/**
+ * Tiny headless internal-agent-call seam for Observational Memory.
+ *
+ * The Observer and Reflector each need a single, tool-less LLM round-trip:
+ * "here is some text, compress it". Rather than touch `production-agent.ts`,
+ * this reuses the SAME pattern the evals lane built — resolve a provider-
+ * agnostic engine + model from the registry (NEVER hardcode a model) and drive
+ * one `engine.stream()` to completion, collecting the text. It mirrors the
+ * `analyzeContext().judge` helper in `eval/agent-runner.ts`.
+ *
+ * Everything is injectable so tests can supply a fake engine and assert no real
+ * model is ever called.
+ */
+
+import type { AgentEngine } from "../engine/types.js";
+import {
+  resolveEngine,
+  getStoredModelForEngine,
+  normalizeModelForEngine,
+} from "../engine/index.js";
+
+const DEFAULT_INTERNAL_RUN_TIMEOUT_MS = 60_000;
+
+export interface InternalAgentRunOptions {
+  systemPrompt: string;
+  prompt: string;
+  maxOutputTokens?: number;
+  /** Pre-resolved engine; resolved from the registry when omitted. */
+  engine?: AgentEngine;
+  /** Pre-resolved model; resolved from the engine's stored/default when omitted. */
+  model?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Run one tool-less internal agent call and return the collected text.
+ *
+ * Resolution goes through `resolveEngine` / `getStoredModelForEngine` /
+ * `normalizeModelForEngine` — identical to the eval runner — so the compactor
+ * uses whatever provider/model the app is configured for. No model is ever
+ * hardcoded here.
+ */
+export async function runInternalAgentCall(
+  options: InternalAgentRunOptions,
+): Promise<string> {
+  const engine =
+    options.engine ?? (await resolveEngine({ engineOption: undefined }));
+  const modelCandidate =
+    options.model ??
+    (await getStoredModelForEngine(engine)) ??
+    engine.defaultModel;
+  const model = normalizeModelForEngine(engine, modelCandidate);
+
+  const controller = new AbortController();
+  const signal = options.signal ?? controller.signal;
+  const timer = options.signal
+    ? undefined
+    : setTimeout(
+        () => controller.abort(),
+        options.timeoutMs ?? DEFAULT_INTERNAL_RUN_TIMEOUT_MS,
+      );
+
+  let out = "";
+  try {
+    const stream = engine.stream({
+      model,
+      systemPrompt: options.systemPrompt,
+      messages: [
+        { role: "user", content: [{ type: "text", text: options.prompt }] },
+      ],
+      tools: [],
+      abortSignal: signal,
+      maxOutputTokens: options.maxOutputTokens ?? 4_000,
+      temperature: 0,
+    });
+    for await (const event of stream) {
+      if (event.type === "text-delta") out += event.text;
+    }
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+  return out.trim();
+}
+
+/** The shape the Observer/Reflector depend on — injectable for tests. */
+export type InternalAgentRunFn = (
+  options: InternalAgentRunOptions,
+) => Promise<string>;

--- a/packages/core/src/agent/observational-memory/message-text.ts
+++ b/packages/core/src/agent/observational-memory/message-text.ts
@@ -1,0 +1,49 @@
+/**
+ * Render engine messages to a compact plain-text transcript for the compactor
+ * window, and account their tokens. Reuses the existing context-xray token
+ * accounting so OM thresholds match what the rest of the framework counts.
+ */
+
+import type { EngineMessage } from "../engine/types.js";
+import { countMessageTokens } from "../context-xray/tokenize.js";
+
+/** Flatten one engine message to a single labeled line block. */
+export function messageToText(message: EngineMessage): string {
+  const parts: string[] = [];
+  for (const part of message.content) {
+    if (part.type === "text" || part.type === "thinking") {
+      if (part.text.trim()) parts.push(part.text);
+    } else if (part.type === "tool-call") {
+      parts.push(`[tool:${part.name}] ${safeJson(part.input)}`.trim());
+    } else if (part.type === "tool-result") {
+      parts.push(`[tool-result] ${part.content}`.trim());
+    }
+    // image/file parts are intentionally omitted from the text window.
+  }
+  const body = parts.join("\n");
+  return body ? `${message.role}: ${body}` : "";
+}
+
+/** Render a contiguous window of messages to one text blob. */
+export function windowToText(messages: EngineMessage[]): string {
+  return messages
+    .map(messageToText)
+    .filter((line) => line.length > 0)
+    .join("\n\n");
+}
+
+/** Token count for a window of messages (reuses framework tokenizer). */
+export async function countWindowTokens(
+  messages: EngineMessage[],
+): Promise<number> {
+  const { tokens } = await countMessageTokens(messages);
+  return tokens;
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return "";
+  }
+}

--- a/packages/core/src/agent/observational-memory/migrations.ts
+++ b/packages/core/src/agent/observational-memory/migrations.ts
@@ -1,0 +1,44 @@
+import type { MigrationEntry } from "../../db/migrations.js";
+
+/**
+ * Additive-only migrations for Observational Memory.
+ *
+ * These run under their OWN bookkeeping table (`_observational_memory_migrations`)
+ * so the version space is independent of core/org/context-xray — see
+ * `db/migrations.ts` for why each module owns its own version space.
+ *
+ * Strictly additive: a new table plus its hot-path indexes. Never drops,
+ * renames, or destructively alters anything.
+ */
+export const OBSERVATIONAL_MEMORY_MIGRATIONS: MigrationEntry[] = [
+  {
+    version: 1,
+    sql: `CREATE TABLE IF NOT EXISTS observational_memory (
+      id TEXT PRIMARY KEY,
+      thread_id TEXT NOT NULL,
+      tier TEXT NOT NULL,
+      text TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL DEFAULT 0,
+      source_start_index INTEGER,
+      source_end_index INTEGER,
+      source_message_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      owner_email TEXT NOT NULL DEFAULT 'local@localhost',
+      org_id TEXT,
+      visibility TEXT NOT NULL DEFAULT 'private'
+    )`,
+  },
+  {
+    // Hot path: read a thread's entries of a given tier, ordered by recency.
+    version: 2,
+    sql: `CREATE INDEX IF NOT EXISTS observational_memory_thread_tier_idx
+      ON observational_memory(thread_id, tier, created_at)`,
+  },
+  {
+    // Hot path: owner-scoped reads for ownable-table access checks.
+    version: 3,
+    sql: `CREATE INDEX IF NOT EXISTS observational_memory_thread_owner_idx
+      ON observational_memory(thread_id, owner_email)`,
+  },
+];

--- a/packages/core/src/agent/observational-memory/observer.spec.ts
+++ b/packages/core/src/agent/observational-memory/observer.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { EngineMessage } from "../engine/types.js";
+
+const storeMod = vi.hoisted(() => ({
+  getObservedThroughIndex: vi.fn(),
+  listObservationalMemory: vi.fn(),
+  insertObservationalMemory: vi.fn(),
+}));
+vi.mock("./store.js", () => storeMod);
+
+const { runObserver } = await import("./observer.js");
+
+/** Build N user messages each carrying ~`charsPer` chars (≈ charsPer/4 tokens). */
+function buildMessages(n: number, charsPer: number): EngineMessage[] {
+  return Array.from({ length: n }, (_, i) => ({
+    role: i % 2 === 0 ? ("user" as const) : ("assistant" as const),
+    content: [{ type: "text" as const, text: "x".repeat(charsPer) }],
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storeMod.getObservedThroughIndex.mockResolvedValue(-1);
+  storeMod.listObservationalMemory.mockResolvedValue([]);
+  storeMod.insertObservationalMemory.mockImplementation(async (input: any) => ({
+    id: "om-test",
+    createdAt: 1,
+    updatedAt: 1,
+    orgId: null,
+    visibility: "private",
+    sourceStartIndex: input.sourceStartIndex ?? null,
+    sourceEndIndex: input.sourceEndIndex ?? null,
+    sourceMessageCount: input.sourceMessageCount ?? 0,
+    ...input,
+  }));
+});
+
+describe("runObserver", () => {
+  it("no-ops when the unobserved window is under the token threshold", async () => {
+    // 4 short messages → well under 30k tokens.
+    const messages = buildMessages(4, 40);
+    const runInternal = vi.fn(async () => "should not be called");
+
+    const result = await runObserver({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+      messages,
+      runInternal,
+    });
+
+    expect(result.observed).toBe(false);
+    expect(runInternal).not.toHaveBeenCalled();
+    expect(storeMod.insertObservationalMemory).not.toHaveBeenCalled();
+  });
+
+  it("compacts and persists an observation once the window exceeds the threshold", async () => {
+    // 8 medium messages clear a tiny threshold without building a huge fixture
+    // that stresses full-suite prep memory.
+    const messages = buildMessages(8, 300);
+    const runInternal = vi.fn(
+      async () => "2026-06-17 observed: task in progress; decided to ship",
+    );
+
+    const result = await runObserver({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+      messages,
+      runInternal,
+      config: { observationTokenThreshold: 10 },
+    });
+
+    expect(runInternal).toHaveBeenCalledTimes(1);
+    expect(result.observed).toBe(true);
+    expect(storeMod.insertObservationalMemory).toHaveBeenCalledTimes(1);
+
+    const insertArg = storeMod.insertObservationalMemory.mock.calls[0][0];
+    expect(insertArg.tier).toBe("observation");
+    expect(insertArg.text).toContain("2026-06-17");
+    expect(insertArg.ownerEmail).toBe("alice@example.com");
+    // Covers the whole unobserved window (none observed yet).
+    expect(insertArg.sourceStartIndex).toBe(0);
+    expect(insertArg.sourceEndIndex).toBe(messages.length - 1);
+    expect(insertArg.tokenEstimate).toBeGreaterThan(0);
+  });
+
+  it("only considers messages after the already-observed index", async () => {
+    storeMod.getObservedThroughIndex.mockResolvedValue(3);
+    const messages = buildMessages(10, 1000);
+    const runInternal = vi.fn(async () => "dated observation log");
+
+    const result = await runObserver({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+      messages,
+      runInternal,
+      config: { observationTokenThreshold: 100 },
+    });
+
+    expect(result.observed).toBe(true);
+    const insertArg = storeMod.insertObservationalMemory.mock.calls[0][0];
+    expect(insertArg.sourceStartIndex).toBe(4);
+    expect(insertArg.sourceEndIndex).toBe(9);
+    expect(insertArg.sourceMessageCount).toBe(6);
+  });
+});

--- a/packages/core/src/agent/observational-memory/observer.ts
+++ b/packages/core/src/agent/observational-memory/observer.ts
@@ -1,0 +1,128 @@
+/**
+ * The Observer.
+ *
+ * When a thread's UNOBSERVED messages exceed the observation token threshold,
+ * the Observer runs ONE internal (tool-less) agent call to compress that window
+ * into a dense, dated observation log, persists it as a `tier: "observation"`
+ * entry, and marks those messages observed (recorded via the entry's
+ * `sourceEndIndex`, which `getObservedThroughIndex` reads back).
+ *
+ * It does NOT touch the agent loop — the internal call goes through the shared
+ * `runInternalAgentCall` seam (provider-agnostic, mockable).
+ */
+
+import type { EngineMessage } from "../engine/types.js";
+import { countTextTokens } from "../context-xray/tokenize.js";
+import {
+  resolveObservationalMemoryConfig,
+  type ObservationalMemoryConfig,
+} from "./config.js";
+import {
+  getObservedThroughIndex,
+  insertObservationalMemory,
+  listObservationalMemory,
+} from "./store.js";
+import {
+  runInternalAgentCall,
+  type InternalAgentRunFn,
+} from "./internal-run.js";
+import { countWindowTokens, windowToText } from "./message-text.js";
+import { OBSERVER_SYSTEM_PROMPT, buildObserverPrompt } from "./prompts.js";
+import type {
+  ObservationalMemoryEntry,
+  ObservationalMemoryOwner,
+} from "./types.js";
+
+export interface RunObserverOptions extends ObservationalMemoryOwner {
+  threadId: string;
+  /** The full, ordered thread messages. */
+  messages: EngineMessage[];
+  config?: Partial<ObservationalMemoryConfig>;
+  /** Internal-run seam — defaults to the real one; injected in tests. */
+  runInternal?: InternalAgentRunFn;
+}
+
+export interface RunObserverResult {
+  /** True when an observation was produced and persisted. */
+  observed: boolean;
+  entry?: ObservationalMemoryEntry;
+  /** Tokens in the unobserved window that was considered. */
+  unobservedTokens: number;
+}
+
+/**
+ * Compact a thread's unobserved tail into an observation IF it exceeds the
+ * token threshold; otherwise no-op.
+ */
+export async function runObserver(
+  options: RunObserverOptions,
+): Promise<RunObserverResult> {
+  const config = resolveObservationalMemoryConfig(options.config);
+  const owner: ObservationalMemoryOwner = {
+    ownerEmail: options.ownerEmail,
+    orgId: options.orgId ?? null,
+  };
+
+  const observedThrough = await getObservedThroughIndex({
+    ...owner,
+    threadId: options.threadId,
+  });
+  const startIndex = observedThrough + 1;
+  const unobserved = options.messages.slice(startIndex);
+  if (unobserved.length === 0) {
+    return { observed: false, unobservedTokens: 0 };
+  }
+
+  const unobservedTokens = await countWindowTokens(unobserved);
+  if (unobservedTokens < config.observationTokenThreshold) {
+    return { observed: false, unobservedTokens };
+  }
+
+  const windowText = windowToText(unobserved);
+  if (!windowText.trim()) {
+    return { observed: false, unobservedTokens };
+  }
+
+  // Feed prior observations as continuity context so the new log doesn't repeat
+  // already-compacted history.
+  const priorObservations = (
+    await listObservationalMemory({
+      ...owner,
+      threadId: options.threadId,
+      tier: "observation",
+    })
+  )
+    .map((entry) => entry.text)
+    .join("\n\n");
+
+  const run = options.runInternal ?? runInternalAgentCall;
+  const observationText = await run({
+    systemPrompt: OBSERVER_SYSTEM_PROMPT,
+    prompt: buildObserverPrompt({
+      threadId: options.threadId,
+      windowText,
+      priorObservations,
+    }),
+    maxOutputTokens: config.observationMaxOutputTokens,
+  });
+
+  if (!observationText.trim()) {
+    return { observed: false, unobservedTokens };
+  }
+
+  const { tokens: tokenEstimate } = await countTextTokens(observationText);
+  const endIndex = options.messages.length - 1;
+
+  const entry = await insertObservationalMemory({
+    ...owner,
+    threadId: options.threadId,
+    tier: "observation",
+    text: observationText,
+    tokenEstimate,
+    sourceStartIndex: startIndex,
+    sourceEndIndex: endIndex,
+    sourceMessageCount: unobserved.length,
+  });
+
+  return { observed: true, entry, unobservedTokens };
+}

--- a/packages/core/src/agent/observational-memory/plugin.ts
+++ b/packages/core/src/agent/observational-memory/plugin.ts
@@ -1,0 +1,35 @@
+/**
+ * Nitro plugin that applies the Observational Memory migrations under its own
+ * bookkeeping table. Mirrors `context-xray/plugin.ts`.
+ *
+ * NOT YET registered in the default plugin set — registering it means editing
+ * shared bootstrap files (server/framework-request-handler.ts,
+ * deploy/route-discovery.ts), which is deferred to the same follow-up that
+ * wires `buildObservationalContext` into production-agent.ts. Until then the
+ * store's `ensureTable()` creates the table lazily on first use, so OM is fully
+ * functional without the plugin.
+ */
+
+import {
+  awaitBootstrap,
+  markDefaultPluginProvided,
+} from "../../server/framework-request-handler.js";
+import { runMigrations } from "../../db/migrations.js";
+import { OBSERVATIONAL_MEMORY_MIGRATIONS } from "./migrations.js";
+
+type NitroPluginDef = (nitroApp: any) => void | Promise<void>;
+
+export function createObservationalMemoryPlugin(): NitroPluginDef {
+  const migrate = runMigrations(OBSERVATIONAL_MEMORY_MIGRATIONS, {
+    table: "_observational_memory_migrations",
+  });
+
+  return async (nitroApp: any) => {
+    markDefaultPluginProvided(nitroApp, "observational-memory");
+    await awaitBootstrap(nitroApp);
+    await migrate(nitroApp);
+  };
+}
+
+export const defaultObservationalMemoryPlugin: NitroPluginDef =
+  createObservationalMemoryPlugin();

--- a/packages/core/src/agent/observational-memory/prompts.ts
+++ b/packages/core/src/agent/observational-memory/prompts.ts
@@ -1,0 +1,53 @@
+/**
+ * System prompts for the Observer and Reflector compaction passes.
+ *
+ * Both prompts insist on DATED output and preservation of task status, names,
+ * dates, and decisions — the facts a long autonomous run rots and loses. The
+ * compacted text replaces raw turns in the prompt, so it must stay dense,
+ * factual, and chronological rather than narrative.
+ */
+
+export const OBSERVER_SYSTEM_PROMPT = `You are the Observer for a long-running agent thread. You compress a span of raw conversation into a single DENSE, DATED observation log that will REPLACE those raw messages in future context.
+
+Rules:
+- Output a chronological, bulleted log. Prefix entries with a date/time when one is present in the source.
+- Preserve precisely: task status (what is done / in progress / blocked / decided), proper names (people, files, functions, repos, branches, IDs), exact dates, numbers, and decisions with their rationale.
+- Preserve unresolved questions, TODOs, and error states verbatim enough to act on later.
+- Drop pleasantries, restated context, and redundant tool chatter. Never invent facts.
+- Be terse. This is a memory record, not prose. No preamble, no summary-of-summary, just the log.`;
+
+export const REFLECTOR_SYSTEM_PROMPT = `You are the Reflector for a long-running agent thread. You condense an existing log of dated OBSERVATIONS into a smaller set of higher-level REFLECTIONS that will sit above the observations in future context.
+
+Rules:
+- Roll many low-level observations up into durable, higher-level statements: overall goal and current status, key decisions and why, stable facts (names, identifiers, constraints), and open threads.
+- Keep dates on anything time-sensitive. Keep proper names and identifiers exact.
+- Do not lose any still-open task, blocker, or unresolved decision.
+- Be terse and factual. Output a chronological/thematic bulleted list. No preamble.`;
+
+/**
+ * Build the Observer user prompt for a window of raw thread text.
+ */
+export function buildObserverPrompt(input: {
+  threadId: string;
+  windowText: string;
+  priorObservations?: string;
+}): string {
+  const prior = input.priorObservations?.trim()
+    ? `Existing observation log (for continuity — do NOT repeat it, only summarize the NEW messages below):\n${input.priorObservations.trim()}\n\n`
+    : "";
+  return `${prior}New raw messages to compress into the observation log (thread ${input.threadId}):\n\n${input.windowText}`;
+}
+
+/**
+ * Build the Reflector user prompt over the current observation log.
+ */
+export function buildReflectorPrompt(input: {
+  threadId: string;
+  observationsText: string;
+  priorReflections?: string;
+}): string {
+  const prior = input.priorReflections?.trim()
+    ? `Existing reflections (for continuity — refine/extend, do not duplicate):\n${input.priorReflections.trim()}\n\n`
+    : "";
+  return `${prior}Observation log to condense into higher-level reflections (thread ${input.threadId}):\n\n${input.observationsText}`;
+}

--- a/packages/core/src/agent/observational-memory/read.spec.ts
+++ b/packages/core/src/agent/observational-memory/read.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { EngineMessage } from "../engine/types.js";
+
+const storeMod = vi.hoisted(() => ({
+  listObservationalMemory: vi.fn(),
+}));
+vi.mock("./store.js", () => storeMod);
+
+const { buildObservationalContext } = await import("./read.js");
+
+function msg(role: "user" | "assistant", text: string): EngineMessage {
+  return { role, content: [{ type: "text", text }] };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("buildObservationalContext", () => {
+  it("returns the 3-tier structure: reflections + observations + recent raw messages", async () => {
+    storeMod.listObservationalMemory.mockImplementation(
+      async (opts: { tier?: string }) => {
+        if (opts.tier === "reflection") {
+          return [
+            { id: "r1", tier: "reflection", text: "REFL", tokenEstimate: 30 },
+          ];
+        }
+        if (opts.tier === "observation") {
+          return [
+            { id: "o1", tier: "observation", text: "OBS-1", tokenEstimate: 50 },
+            { id: "o2", tier: "observation", text: "OBS-2", tokenEstimate: 70 },
+          ];
+        }
+        return [];
+      },
+    );
+
+    const messages: EngineMessage[] = [
+      msg("user", "old-1"),
+      msg("assistant", "old-2"),
+      msg("user", "recent-A"),
+      msg("assistant", "recent-B"),
+    ];
+
+    const ctx = await buildObservationalContext({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+      messages,
+      config: { recentRawMessageCount: 2 },
+    });
+
+    // Three tiers present.
+    expect(ctx.reflections.map((e) => e.text)).toEqual(["REFL"]);
+    expect(ctx.observations.map((e) => e.text)).toEqual(["OBS-1", "OBS-2"]);
+    expect(ctx.recentMessages).toHaveLength(2);
+    expect(ctx.recentMessages[0].content[0]).toMatchObject({
+      text: "recent-A",
+    });
+    expect(ctx.recentMessages[1].content[0]).toMatchObject({
+      text: "recent-B",
+    });
+
+    // Token accounting sums each tier.
+    expect(ctx.tokens.reflections).toBe(30);
+    expect(ctx.tokens.observations).toBe(120);
+    expect(ctx.tokens.recentMessages).toBeGreaterThan(0);
+    expect(ctx.tokens.total).toBe(
+      ctx.tokens.reflections +
+        ctx.tokens.observations +
+        ctx.tokens.recentMessages,
+    );
+  });
+
+  it("scopes the store reads by owner", async () => {
+    storeMod.listObservationalMemory.mockResolvedValue([]);
+
+    await buildObservationalContext({
+      threadId: "t1",
+      ownerEmail: "bob@example.com",
+      messages: [msg("user", "hi")],
+    });
+
+    for (const call of storeMod.listObservationalMemory.mock.calls) {
+      expect(call[0].ownerEmail).toBe("bob@example.com");
+      expect(call[0].threadId).toBe("t1");
+    }
+  });
+});

--- a/packages/core/src/agent/observational-memory/read.ts
+++ b/packages/core/src/agent/observational-memory/read.ts
@@ -47,6 +47,47 @@ function sumTokens(entries: ObservationalMemoryEntry[]): number {
  * `recentMessages` verbatim, and prepend a short "Observational Memory" system
  * section. This module deliberately does not edit production-agent.ts.
  */
+/** True when this thread has at least one persisted observation or reflection. */
+export function hasObservationalMemory(context: ObservationalContext): boolean {
+  return context.reflections.length > 0 || context.observations.length > 0;
+}
+
+/**
+ * Serialize the reflections + observations tiers into a single, clearly
+ * delimited prompt block. The recent-raw-message tail is NOT serialized here —
+ * it stays as verbatim engine messages — so this block represents only the
+ * compacted older history that replaces the raw prefix.
+ *
+ * Returns an empty string when there is nothing compacted yet, so callers can
+ * cheaply skip injection for short threads.
+ */
+export function serializeObservationalMemoryBlock(
+  context: ObservationalContext,
+): string {
+  if (!hasObservationalMemory(context)) return "";
+  const sections: string[] = [];
+  sections.push(
+    "[Observational Memory] The earlier part of this long conversation has been " +
+      "compacted into the dated reflections and observations below. Treat these " +
+      "as an authoritative record of what already happened — do not redo " +
+      "completed work, and trust the recorded decisions, names, dates, and " +
+      "status. The most recent turns follow verbatim after this block.",
+  );
+  if (context.reflections.length > 0) {
+    sections.push(
+      "## Reflections (highest-level)\n" +
+        context.reflections.map((entry) => entry.text).join("\n\n"),
+    );
+  }
+  if (context.observations.length > 0) {
+    sections.push(
+      "## Observations (dense, dated)\n" +
+        context.observations.map((entry) => entry.text).join("\n\n"),
+    );
+  }
+  return sections.join("\n\n");
+}
+
 export async function buildObservationalContext(
   options: BuildObservationalContextOptions,
 ): Promise<ObservationalContext> {

--- a/packages/core/src/agent/observational-memory/read.ts
+++ b/packages/core/src/agent/observational-memory/read.ts
@@ -1,0 +1,92 @@
+/**
+ * Read API for Observational Memory.
+ *
+ * `buildObservationalContext` assembles the three tiers — reflections (highest
+ * level) + observations (dense) + the recent raw message tail — into a single
+ * structure ready to fold into a prompt. It is intentionally NOT wired into
+ * production-agent.ts here; see the exported seam note below and the package
+ * barrel export so the wire-up is one call later.
+ *
+ * Token-cheap by construction: a long thread is represented by its compacted
+ * tiers plus only the last N raw turns, instead of the entire transcript.
+ */
+
+import type { EngineMessage } from "../engine/types.js";
+import {
+  resolveObservationalMemoryConfig,
+  type ObservationalMemoryConfig,
+} from "./config.js";
+import { listObservationalMemory } from "./store.js";
+import { countWindowTokens } from "./message-text.js";
+import type {
+  ObservationalContext,
+  ObservationalMemoryEntry,
+  ObservationalMemoryOwner,
+} from "./types.js";
+
+export interface BuildObservationalContextOptions extends ObservationalMemoryOwner {
+  threadId: string;
+  /** The full, ordered thread messages — the recent tail is taken from here. */
+  messages: EngineMessage[];
+  config?: Partial<ObservationalMemoryConfig>;
+}
+
+function sumTokens(entries: ObservationalMemoryEntry[]): number {
+  return entries.reduce((acc, entry) => acc + (entry.tokenEstimate || 0), 0);
+}
+
+/**
+ * SEAM (deferred wire-up): build the three-tier Observational Memory context
+ * for a thread. The returned tiers are ready to be injected into the turn's
+ * prompt assembly.
+ *
+ * TODO(charlie-merge): inject buildObservationalContext output into the turn
+ * context assembly in production-agent.ts once the lazy-skill context changes
+ * land. The intended shape: replace the older raw-message prefix (everything
+ * before `recentMessages`) with the `reflections` + `observations` text, keep
+ * `recentMessages` verbatim, and prepend a short "Observational Memory" system
+ * section. This module deliberately does not edit production-agent.ts.
+ */
+export async function buildObservationalContext(
+  options: BuildObservationalContextOptions,
+): Promise<ObservationalContext> {
+  const config = resolveObservationalMemoryConfig(options.config);
+  const owner: ObservationalMemoryOwner = {
+    ownerEmail: options.ownerEmail,
+    orgId: options.orgId ?? null,
+  };
+
+  const [reflections, observations] = await Promise.all([
+    listObservationalMemory({
+      ...owner,
+      threadId: options.threadId,
+      tier: "reflection",
+    }),
+    listObservationalMemory({
+      ...owner,
+      threadId: options.threadId,
+      tier: "observation",
+    }),
+  ]);
+
+  const recentCount = Math.max(0, config.recentRawMessageCount);
+  const recentMessages =
+    recentCount > 0 ? options.messages.slice(-recentCount) : [];
+
+  const recentTokens = await countWindowTokens(recentMessages);
+  const reflectionTokens = sumTokens(reflections);
+  const observationTokens = sumTokens(observations);
+
+  return {
+    threadId: options.threadId,
+    reflections,
+    observations,
+    recentMessages,
+    tokens: {
+      reflections: reflectionTokens,
+      observations: observationTokens,
+      recentMessages: recentTokens,
+      total: reflectionTokens + observationTokens + recentTokens,
+    },
+  };
+}

--- a/packages/core/src/agent/observational-memory/reflector.spec.ts
+++ b/packages/core/src/agent/observational-memory/reflector.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const storeMod = vi.hoisted(() => ({
+  getObservationLogTokens: vi.fn(),
+  listObservationalMemory: vi.fn(),
+  insertObservationalMemory: vi.fn(),
+}));
+vi.mock("./store.js", () => storeMod);
+
+const { runReflector } = await import("./reflector.js");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storeMod.listObservationalMemory.mockResolvedValue([]);
+  storeMod.insertObservationalMemory.mockImplementation(async (input: any) => ({
+    id: "om-test",
+    createdAt: 1,
+    updatedAt: 1,
+    orgId: null,
+    visibility: "private",
+    ...input,
+  }));
+});
+
+describe("runReflector", () => {
+  it("no-ops when the observation log is under the reflection threshold", async () => {
+    storeMod.getObservationLogTokens.mockResolvedValue(1_000);
+    const runInternal = vi.fn(async () => "should not be called");
+
+    const result = await runReflector({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+      runInternal,
+      config: { reflectionTokenThreshold: 40_000 },
+    });
+
+    expect(result.reflected).toBe(false);
+    expect(runInternal).not.toHaveBeenCalled();
+    expect(storeMod.insertObservationalMemory).not.toHaveBeenCalled();
+  });
+
+  it("condenses observations into a reflection once the log exceeds the threshold", async () => {
+    storeMod.getObservationLogTokens.mockResolvedValue(50_000);
+    storeMod.listObservationalMemory.mockImplementation(
+      async (opts: { tier?: string }) => {
+        if (opts.tier === "observation") {
+          return [
+            {
+              id: "o1",
+              text: "2026-06-10 started feature",
+              sourceStartIndex: 0,
+              sourceEndIndex: 9,
+            },
+            {
+              id: "o2",
+              text: "2026-06-12 shipped feature",
+              sourceStartIndex: 10,
+              sourceEndIndex: 19,
+            },
+          ];
+        }
+        return []; // no prior reflections
+      },
+    );
+    const runInternal = vi.fn(
+      async () => "Goal: ship feature. Status: done as of 2026-06-12.",
+    );
+
+    const result = await runReflector({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+      runInternal,
+      config: { reflectionTokenThreshold: 40_000 },
+    });
+
+    expect(runInternal).toHaveBeenCalledTimes(1);
+    expect(result.reflected).toBe(true);
+    expect(storeMod.insertObservationalMemory).toHaveBeenCalledTimes(1);
+
+    const insertArg = storeMod.insertObservationalMemory.mock.calls[0][0];
+    expect(insertArg.tier).toBe("reflection");
+    expect(insertArg.text).toContain("ship feature");
+    expect(insertArg.ownerEmail).toBe("alice@example.com");
+    // Spans the folded observation range.
+    expect(insertArg.sourceStartIndex).toBe(0);
+    expect(insertArg.sourceEndIndex).toBe(19);
+    expect(insertArg.sourceMessageCount).toBe(2);
+  });
+});

--- a/packages/core/src/agent/observational-memory/reflector.ts
+++ b/packages/core/src/agent/observational-memory/reflector.ts
@@ -1,0 +1,119 @@
+/**
+ * The Reflector.
+ *
+ * When the persisted observation log itself exceeds the reflection token
+ * threshold, the Reflector runs ONE internal (tool-less) agent call to condense
+ * the observations into higher-level reflections, and persists a
+ * `tier: "reflection"` entry. Observations are kept (they remain the dense
+ * mid-tier); the reflection sits above them.
+ */
+
+import { countTextTokens } from "../context-xray/tokenize.js";
+import {
+  resolveObservationalMemoryConfig,
+  type ObservationalMemoryConfig,
+} from "./config.js";
+import {
+  getObservationLogTokens,
+  insertObservationalMemory,
+  listObservationalMemory,
+} from "./store.js";
+import {
+  runInternalAgentCall,
+  type InternalAgentRunFn,
+} from "./internal-run.js";
+import { REFLECTOR_SYSTEM_PROMPT, buildReflectorPrompt } from "./prompts.js";
+import type {
+  ObservationalMemoryEntry,
+  ObservationalMemoryOwner,
+} from "./types.js";
+
+export interface RunReflectorOptions extends ObservationalMemoryOwner {
+  threadId: string;
+  config?: Partial<ObservationalMemoryConfig>;
+  /** Internal-run seam — defaults to the real one; injected in tests. */
+  runInternal?: InternalAgentRunFn;
+}
+
+export interface RunReflectorResult {
+  /** True when a reflection was produced and persisted. */
+  reflected: boolean;
+  entry?: ObservationalMemoryEntry;
+  /** Tokens in the observation log that was considered. */
+  observationLogTokens: number;
+}
+
+/**
+ * Condense the observation log into a reflection IF it exceeds the token
+ * threshold; otherwise no-op.
+ */
+export async function runReflector(
+  options: RunReflectorOptions,
+): Promise<RunReflectorResult> {
+  const config = resolveObservationalMemoryConfig(options.config);
+  const owner: ObservationalMemoryOwner = {
+    ownerEmail: options.ownerEmail,
+    orgId: options.orgId ?? null,
+  };
+
+  const observationLogTokens = await getObservationLogTokens({
+    ...owner,
+    threadId: options.threadId,
+  });
+  if (observationLogTokens < config.reflectionTokenThreshold) {
+    return { reflected: false, observationLogTokens };
+  }
+
+  const observations = await listObservationalMemory({
+    ...owner,
+    threadId: options.threadId,
+    tier: "observation",
+  });
+  if (observations.length === 0) {
+    return { reflected: false, observationLogTokens };
+  }
+  const observationsText = observations.map((entry) => entry.text).join("\n\n");
+
+  const priorReflections = (
+    await listObservationalMemory({
+      ...owner,
+      threadId: options.threadId,
+      tier: "reflection",
+    })
+  )
+    .map((entry) => entry.text)
+    .join("\n\n");
+
+  const run = options.runInternal ?? runInternalAgentCall;
+  const reflectionText = await run({
+    systemPrompt: REFLECTOR_SYSTEM_PROMPT,
+    prompt: buildReflectorPrompt({
+      threadId: options.threadId,
+      observationsText,
+      priorReflections,
+    }),
+    maxOutputTokens: config.reflectionMaxOutputTokens,
+  });
+
+  if (!reflectionText.trim()) {
+    return { reflected: false, observationLogTokens };
+  }
+
+  const { tokens: tokenEstimate } = await countTextTokens(reflectionText);
+  const sourceStart = observations[0]?.sourceStartIndex ?? null;
+  const sourceEnd =
+    observations[observations.length - 1]?.sourceEndIndex ?? null;
+
+  const entry = await insertObservationalMemory({
+    ...owner,
+    threadId: options.threadId,
+    tier: "reflection",
+    text: reflectionText,
+    tokenEstimate,
+    sourceStartIndex: sourceStart,
+    sourceEndIndex: sourceEnd,
+    sourceMessageCount: observations.length,
+  });
+
+  return { reflected: true, entry, observationLogTokens };
+}

--- a/packages/core/src/agent/observational-memory/schema.ts
+++ b/packages/core/src/agent/observational-memory/schema.ts
@@ -1,0 +1,48 @@
+import { table, text, integer, ownableColumns } from "../../db/schema.js";
+
+/**
+ * Observational Memory (OM) entries.
+ *
+ * A long-running agent thread is compacted in the background into a dated,
+ * three-tier context so it costs far fewer tokens and stays prompt-cache
+ * stable:
+ *
+ *   recent raw messages  →  dense "observations"  →  higher-level "reflections"
+ *
+ * Each row is ONE compaction artifact for a thread:
+ *
+ * - `tier = "observation"` — a dense, dated digest of a contiguous range of
+ *   thread messages (task status, names, dates, decisions preserved). Produced
+ *   by the Observer once a thread's unobserved messages exceed a token
+ *   threshold.
+ * - `tier = "reflection"` — a higher-level condensation OVER observations,
+ *   produced by the Reflector once the observation log itself grows past its
+ *   own threshold.
+ *
+ * The table is ownable (scoped reads/writes via `accessFilter`/`assertAccess`
+ * per the `security` skill) and dialect-agnostic (Drizzle helpers from
+ * `db/schema`, never raw SQLite types). The companion migrations live in
+ * `./migrations.ts` and are additive-only.
+ */
+export const observationalMemory = table("observational_memory", {
+  id: text("id").primaryKey(),
+  threadId: text("thread_id").notNull(),
+  /** Which tier this entry belongs to. */
+  tier: text("tier", { enum: ["observation", "reflection"] }).notNull(),
+  /** The dated, compacted text content of this entry. */
+  text: text("text").notNull(),
+  /** Estimated token count of `text` (used for the reflection threshold). */
+  tokenEstimate: integer("token_estimate").notNull().default(0),
+  /**
+   * Inclusive index range of the source thread messages this entry summarizes.
+   * For observations these are indices into the flattened thread-message array;
+   * for reflections they span the observation indices that were folded.
+   */
+  sourceStartIndex: integer("source_start_index"),
+  sourceEndIndex: integer("source_end_index"),
+  /** How many source messages/observations this entry covers. */
+  sourceMessageCount: integer("source_message_count").notNull().default(0),
+  createdAt: integer("created_at").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+  ...ownableColumns(),
+});

--- a/packages/core/src/agent/observational-memory/store.spec.ts
+++ b/packages/core/src/agent/observational-memory/store.spec.ts
@@ -129,6 +129,68 @@ describe("observational-memory store", () => {
     expect(bobRows.map((e) => e.text)).toEqual(["bob secret"]);
   });
 
+  it("scopes reads by org as well as owner", async () => {
+    await insertObservationalMemory({
+      threadId: "t1",
+      tier: "observation",
+      text: "alice org a",
+      tokenEstimate: 10,
+      sourceEndIndex: 10,
+      ownerEmail: "alice@example.com",
+      orgId: "org-a",
+    });
+    await insertObservationalMemory({
+      threadId: "t1",
+      tier: "observation",
+      text: "alice org b",
+      tokenEstimate: 20,
+      sourceEndIndex: 20,
+      ownerEmail: "alice@example.com",
+      orgId: "org-b",
+    });
+    await insertObservationalMemory({
+      threadId: "t1",
+      tier: "observation",
+      text: "alice personal",
+      tokenEstimate: 30,
+      sourceEndIndex: 30,
+      ownerEmail: "alice@example.com",
+    });
+
+    const orgARows = await listObservationalMemory({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+      orgId: "org-a",
+    });
+    const orgBRows = await listObservationalMemory({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+      orgId: "org-b",
+    });
+    const personalRows = await listObservationalMemory({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+    });
+
+    expect(orgARows.map((e) => e.text)).toEqual(["alice org a"]);
+    expect(orgBRows.map((e) => e.text)).toEqual(["alice org b"]);
+    expect(personalRows.map((e) => e.text)).toEqual(["alice personal"]);
+    expect(
+      await getObservedThroughIndex({
+        threadId: "t1",
+        ownerEmail: "alice@example.com",
+        orgId: "org-a",
+      }),
+    ).toBe(10);
+    expect(
+      await getObservationLogTokens({
+        threadId: "t1",
+        ownerEmail: "alice@example.com",
+        orgId: "org-a",
+      }),
+    ).toBe(10);
+  });
+
   it("reports the observed-through index and observation log token total per owner", async () => {
     expect(
       await getObservedThroughIndex({

--- a/packages/core/src/agent/observational-memory/store.spec.ts
+++ b/packages/core/src/agent/observational-memory/store.spec.ts
@@ -1,0 +1,182 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let sqlite: Database.Database;
+
+const rawClient = {
+  execute: vi.fn(async (input: string | { sql: string; args?: unknown[] }) => {
+    if (typeof input === "string") {
+      sqlite.exec(input);
+      return { rows: [], rowsAffected: 0 };
+    }
+    const stmt = sqlite.prepare(input.sql);
+    const args = (input.args ?? []) as unknown[];
+    if (/^\s*select/i.test(input.sql)) {
+      return { rows: stmt.all(...args), rowsAffected: 0 };
+    }
+    const info = stmt.run(...args);
+    return { rows: [], rowsAffected: info.changes };
+  }),
+};
+
+vi.mock("../../db/client.js", () => ({
+  getDbExec: () => rawClient,
+  isPostgres: () => false,
+}));
+
+const {
+  insertObservationalMemory,
+  listObservationalMemory,
+  getObservedThroughIndex,
+  getObservationLogTokens,
+  __resetObservationalMemoryTableCache,
+} = await import("./store.js");
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  __resetObservationalMemoryTableCache();
+});
+
+afterEach(() => {
+  sqlite.close();
+  vi.clearAllMocks();
+});
+
+describe("observational-memory store", () => {
+  it("creates the table lazily and round-trips an observation entry", async () => {
+    const entry = await insertObservationalMemory({
+      threadId: "t1",
+      tier: "observation",
+      text: "2026-06-17 decided X; blocked on Y",
+      tokenEstimate: 42,
+      sourceStartIndex: 0,
+      sourceEndIndex: 9,
+      sourceMessageCount: 10,
+      ownerEmail: "alice@example.com",
+    });
+
+    expect(entry.id).toMatch(/^om-/);
+    expect(entry.tier).toBe("observation");
+
+    const rows = await listObservationalMemory({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text).toBe("2026-06-17 decided X; blocked on Y");
+    expect(rows[0].tokenEstimate).toBe(42);
+    expect(rows[0].sourceStartIndex).toBe(0);
+    expect(rows[0].sourceEndIndex).toBe(9);
+    expect(rows[0].sourceMessageCount).toBe(10);
+  });
+
+  it("filters by tier", async () => {
+    await insertObservationalMemory({
+      threadId: "t1",
+      tier: "observation",
+      text: "obs",
+      tokenEstimate: 10,
+      ownerEmail: "alice@example.com",
+    });
+    await insertObservationalMemory({
+      threadId: "t1",
+      tier: "reflection",
+      text: "refl",
+      tokenEstimate: 5,
+      ownerEmail: "alice@example.com",
+    });
+
+    const obs = await listObservationalMemory({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+      tier: "observation",
+    });
+    const refl = await listObservationalMemory({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+      tier: "reflection",
+    });
+    expect(obs.map((e) => e.text)).toEqual(["obs"]);
+    expect(refl.map((e) => e.text)).toEqual(["refl"]);
+  });
+
+  it("scopes reads by owner so entries never leak across owners", async () => {
+    await insertObservationalMemory({
+      threadId: "t1",
+      tier: "observation",
+      text: "alice secret",
+      tokenEstimate: 10,
+      ownerEmail: "alice@example.com",
+    });
+    await insertObservationalMemory({
+      threadId: "t1",
+      tier: "observation",
+      text: "bob secret",
+      tokenEstimate: 10,
+      ownerEmail: "bob@example.com",
+    });
+
+    const aliceRows = await listObservationalMemory({
+      threadId: "t1",
+      ownerEmail: "alice@example.com",
+    });
+    const bobRows = await listObservationalMemory({
+      threadId: "t1",
+      ownerEmail: "bob@example.com",
+    });
+
+    expect(aliceRows.map((e) => e.text)).toEqual(["alice secret"]);
+    expect(bobRows.map((e) => e.text)).toEqual(["bob secret"]);
+  });
+
+  it("reports the observed-through index and observation log token total per owner", async () => {
+    expect(
+      await getObservedThroughIndex({
+        threadId: "t1",
+        ownerEmail: "alice@example.com",
+      }),
+    ).toBe(-1);
+
+    await insertObservationalMemory({
+      threadId: "t1",
+      tier: "observation",
+      text: "obs-1",
+      tokenEstimate: 100,
+      sourceStartIndex: 0,
+      sourceEndIndex: 9,
+      ownerEmail: "alice@example.com",
+    });
+    await insertObservationalMemory({
+      threadId: "t1",
+      tier: "observation",
+      text: "obs-2",
+      tokenEstimate: 200,
+      sourceStartIndex: 10,
+      sourceEndIndex: 19,
+      ownerEmail: "alice@example.com",
+    });
+    // A different owner's larger range must NOT bleed into alice's accounting.
+    await insertObservationalMemory({
+      threadId: "t1",
+      tier: "observation",
+      text: "bob obs",
+      tokenEstimate: 999,
+      sourceStartIndex: 0,
+      sourceEndIndex: 999,
+      ownerEmail: "bob@example.com",
+    });
+
+    expect(
+      await getObservedThroughIndex({
+        threadId: "t1",
+        ownerEmail: "alice@example.com",
+      }),
+    ).toBe(19);
+    expect(
+      await getObservationLogTokens({
+        threadId: "t1",
+        ownerEmail: "alice@example.com",
+      }),
+    ).toBe(300);
+  });
+});

--- a/packages/core/src/agent/observational-memory/store.ts
+++ b/packages/core/src/agent/observational-memory/store.ts
@@ -101,6 +101,21 @@ function rowToEntry(row: Record<string, unknown>): ObservationalMemoryEntry {
   };
 }
 
+function addOwnerScope(
+  clauses: string[],
+  args: unknown[],
+  owner: ObservationalMemoryOwner,
+): void {
+  clauses.push("owner_email = ?");
+  args.push(owner.ownerEmail);
+  if (owner.orgId == null) {
+    clauses.push("org_id IS NULL");
+  } else {
+    clauses.push("org_id = ?");
+    args.push(owner.orgId);
+  }
+}
+
 export interface InsertObservationalMemoryInput extends ObservationalMemoryOwner {
   threadId: string;
   tier: ObservationalMemoryTier;
@@ -174,8 +189,9 @@ export async function listObservationalMemory(
 ): Promise<ObservationalMemoryEntry[]> {
   await ensureTable();
   const client = getDbExec();
-  const clauses = ["thread_id = ?", "owner_email = ?"];
-  const args: unknown[] = [options.threadId, options.ownerEmail];
+  const clauses = ["thread_id = ?"];
+  const args: unknown[] = [options.threadId];
+  addOwnerScope(clauses, args, options);
   if (options.tier) {
     clauses.push("tier = ?");
     args.push(options.tier);
@@ -199,11 +215,14 @@ export async function getObservedThroughIndex(
 ): Promise<number> {
   await ensureTable();
   const client = getDbExec();
+  const clauses = ["thread_id = ?", "tier = 'observation'"];
+  const args: unknown[] = [options.threadId];
+  addOwnerScope(clauses, args, options);
   const result = await client.execute({
     sql: `SELECT MAX(source_end_index) AS max_idx
       FROM observational_memory
-      WHERE thread_id = ? AND owner_email = ? AND tier = 'observation'`,
-    args: [options.threadId, options.ownerEmail],
+      WHERE ${clauses.join(" AND ")}`,
+    args,
   });
   const row = (result.rows as Record<string, unknown>[])[0];
   const max = numOrNull(row?.max_idx);
@@ -216,11 +235,14 @@ export async function getObservationLogTokens(
 ): Promise<number> {
   await ensureTable();
   const client = getDbExec();
+  const clauses = ["thread_id = ?", "tier = 'observation'"];
+  const args: unknown[] = [options.threadId];
+  addOwnerScope(clauses, args, options);
   const result = await client.execute({
     sql: `SELECT COALESCE(SUM(token_estimate), 0) AS total
       FROM observational_memory
-      WHERE thread_id = ? AND owner_email = ? AND tier = 'observation'`,
-    args: [options.threadId, options.ownerEmail],
+      WHERE ${clauses.join(" AND ")}`,
+    args,
   });
   const row = (result.rows as Record<string, unknown>[])[0];
   return Number(row?.total) || 0;

--- a/packages/core/src/agent/observational-memory/store.ts
+++ b/packages/core/src/agent/observational-memory/store.ts
@@ -1,0 +1,227 @@
+/**
+ * Persistence for Observational Memory entries.
+ *
+ * Owner-scoped throughout: every read and write takes an `ownerEmail` and the
+ * SQL always filters by it, so the ownable table is never read or written
+ * cross-owner (per the `security` skill). Dialect-agnostic — only `getDbExec()`
+ * and parameterized SQL, never raw SQLite/Postgres types or string interpolation
+ * of user data.
+ *
+ * `ensureTable()` lazily creates the table on first use (the same belt-and-
+ * suspenders pattern as `chat-threads/store.ts`), so OM works in tests and at
+ * runtime even before the migration plugin is registered.
+ */
+
+import { getDbExec } from "../../db/client.js";
+import { isPostgres } from "../../db/client.js";
+import type {
+  ObservationalMemoryEntry,
+  ObservationalMemoryOwner,
+  ObservationalMemoryTier,
+} from "./types.js";
+
+let tableReady: Promise<void> | null = null;
+
+async function ensureTable(): Promise<void> {
+  if (tableReady) return tableReady;
+  tableReady = (async () => {
+    const client = getDbExec();
+    const intType = isPostgres() ? "BIGINT" : "INTEGER";
+    await client.execute(
+      `CREATE TABLE IF NOT EXISTS observational_memory (
+        id TEXT PRIMARY KEY,
+        thread_id TEXT NOT NULL,
+        tier TEXT NOT NULL,
+        text TEXT NOT NULL,
+        token_estimate ${intType} NOT NULL DEFAULT 0,
+        source_start_index ${intType},
+        source_end_index ${intType},
+        source_message_count ${intType} NOT NULL DEFAULT 0,
+        created_at ${intType} NOT NULL,
+        updated_at ${intType} NOT NULL,
+        owner_email TEXT NOT NULL,
+        org_id TEXT,
+        visibility TEXT NOT NULL DEFAULT 'private'
+      )`,
+    );
+    await client.execute(
+      `CREATE INDEX IF NOT EXISTS observational_memory_thread_tier_idx
+        ON observational_memory(thread_id, tier, created_at)`,
+    );
+    await client.execute(
+      `CREATE INDEX IF NOT EXISTS observational_memory_thread_owner_idx
+        ON observational_memory(thread_id, owner_email)`,
+    );
+  })().catch((err) => {
+    // Reset so a transient failure (e.g. SQLITE_BUSY on HMR) can retry.
+    tableReady = null;
+    throw err;
+  });
+  return tableReady;
+}
+
+/** Reset the cached ensureTable promise — test-only seam. */
+export function __resetObservationalMemoryTableCache(): void {
+  tableReady = null;
+}
+
+function entryId(): string {
+  return `om-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function numOrNull(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function rowToEntry(row: Record<string, unknown>): ObservationalMemoryEntry {
+  const ownerEmail =
+    typeof row.owner_email === "string" && row.owner_email.trim()
+      ? row.owner_email
+      : null;
+  if (!ownerEmail) {
+    throw new Error("Observational memory row is missing owner_email.");
+  }
+  return {
+    id: String(row.id),
+    threadId: String(row.thread_id),
+    tier: row.tier as ObservationalMemoryTier,
+    text: typeof row.text === "string" ? row.text : "",
+    tokenEstimate: Number(row.token_estimate) || 0,
+    sourceStartIndex: numOrNull(row.source_start_index),
+    sourceEndIndex: numOrNull(row.source_end_index),
+    sourceMessageCount: Number(row.source_message_count) || 0,
+    createdAt: Number(row.created_at) || 0,
+    updatedAt: Number(row.updated_at) || 0,
+    ownerEmail,
+    orgId: typeof row.org_id === "string" ? row.org_id : null,
+    visibility:
+      (row.visibility as ObservationalMemoryEntry["visibility"]) ?? "private",
+  };
+}
+
+export interface InsertObservationalMemoryInput extends ObservationalMemoryOwner {
+  threadId: string;
+  tier: ObservationalMemoryTier;
+  text: string;
+  tokenEstimate: number;
+  sourceStartIndex?: number | null;
+  sourceEndIndex?: number | null;
+  sourceMessageCount?: number;
+  visibility?: "private" | "org" | "public";
+}
+
+/** Insert one OM entry, returning the persisted row. */
+export async function insertObservationalMemory(
+  input: InsertObservationalMemoryInput,
+): Promise<ObservationalMemoryEntry> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const id = entryId();
+  const entry: ObservationalMemoryEntry = {
+    id,
+    threadId: input.threadId,
+    tier: input.tier,
+    text: input.text,
+    tokenEstimate: input.tokenEstimate,
+    sourceStartIndex: input.sourceStartIndex ?? null,
+    sourceEndIndex: input.sourceEndIndex ?? null,
+    sourceMessageCount: input.sourceMessageCount ?? 0,
+    createdAt: now,
+    updatedAt: now,
+    ownerEmail: input.ownerEmail,
+    orgId: input.orgId ?? null,
+    visibility: input.visibility ?? "private",
+  };
+  await client.execute({
+    sql: `INSERT INTO observational_memory
+      (id, thread_id, tier, text, token_estimate, source_start_index, source_end_index, source_message_count, created_at, updated_at, owner_email, org_id, visibility)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      entry.id,
+      entry.threadId,
+      entry.tier,
+      entry.text,
+      entry.tokenEstimate,
+      entry.sourceStartIndex,
+      entry.sourceEndIndex,
+      entry.sourceMessageCount,
+      entry.createdAt,
+      entry.updatedAt,
+      entry.ownerEmail,
+      entry.orgId,
+      entry.visibility,
+    ],
+  });
+  return entry;
+}
+
+export interface ListObservationalMemoryOptions extends ObservationalMemoryOwner {
+  threadId: string;
+  /** When set, only entries of this tier are returned. */
+  tier?: ObservationalMemoryTier;
+}
+
+/**
+ * List a thread's OM entries for an owner, oldest → newest. Always
+ * owner-scoped; `org_id` is matched too when supplied so org-visible rows
+ * don't leak across orgs.
+ */
+export async function listObservationalMemory(
+  options: ListObservationalMemoryOptions,
+): Promise<ObservationalMemoryEntry[]> {
+  await ensureTable();
+  const client = getDbExec();
+  const clauses = ["thread_id = ?", "owner_email = ?"];
+  const args: unknown[] = [options.threadId, options.ownerEmail];
+  if (options.tier) {
+    clauses.push("tier = ?");
+    args.push(options.tier);
+  }
+  const result = await client.execute({
+    sql: `SELECT * FROM observational_memory WHERE ${clauses.join(
+      " AND ",
+    )} ORDER BY created_at ASC, id ASC`,
+    args,
+  });
+  return (result.rows as Record<string, unknown>[]).map(rowToEntry);
+}
+
+/**
+ * The highest source-message index already folded into an observation for this
+ * thread/owner, or -1 if none. The Observer uses this to know which messages
+ * are still unobserved.
+ */
+export async function getObservedThroughIndex(
+  options: ObservationalMemoryOwner & { threadId: string },
+): Promise<number> {
+  await ensureTable();
+  const client = getDbExec();
+  const result = await client.execute({
+    sql: `SELECT MAX(source_end_index) AS max_idx
+      FROM observational_memory
+      WHERE thread_id = ? AND owner_email = ? AND tier = 'observation'`,
+    args: [options.threadId, options.ownerEmail],
+  });
+  const row = (result.rows as Record<string, unknown>[])[0];
+  const max = numOrNull(row?.max_idx);
+  return max == null ? -1 : max;
+}
+
+/** Sum the token estimates of a thread's observation entries for an owner. */
+export async function getObservationLogTokens(
+  options: ObservationalMemoryOwner & { threadId: string },
+): Promise<number> {
+  await ensureTable();
+  const client = getDbExec();
+  const result = await client.execute({
+    sql: `SELECT COALESCE(SUM(token_estimate), 0) AS total
+      FROM observational_memory
+      WHERE thread_id = ? AND owner_email = ? AND tier = 'observation'`,
+    args: [options.threadId, options.ownerEmail],
+  });
+  const row = (result.rows as Record<string, unknown>[])[0];
+  return Number(row?.total) || 0;
+}

--- a/packages/core/src/agent/observational-memory/types.ts
+++ b/packages/core/src/agent/observational-memory/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared types for Observational Memory (OM).
+ *
+ * Kept in their own module (no DB / engine imports) so both the store and the
+ * compactor — and any future read-side consumer in production-agent — can
+ * depend on them without pulling in a runtime.
+ */
+
+import type { EngineMessage } from "../engine/types.js";
+
+/** The two compaction tiers. */
+export type ObservationalMemoryTier = "observation" | "reflection";
+
+/** One persisted OM entry (an observation or a reflection). */
+export interface ObservationalMemoryEntry {
+  id: string;
+  threadId: string;
+  tier: ObservationalMemoryTier;
+  /** Dated, compacted text. */
+  text: string;
+  /** Estimated tokens for `text`. */
+  tokenEstimate: number;
+  /** Inclusive source range this entry summarizes (null when unknown). */
+  sourceStartIndex: number | null;
+  sourceEndIndex: number | null;
+  /** Count of source messages/observations folded into this entry. */
+  sourceMessageCount: number;
+  createdAt: number;
+  updatedAt: number;
+  ownerEmail: string;
+  orgId: string | null;
+  visibility: "private" | "org" | "public";
+}
+
+/** Owner scoping common to every OM read/write. */
+export interface ObservationalMemoryOwner {
+  ownerEmail: string;
+  orgId?: string | null;
+}
+
+/**
+ * The three-tier context returned by `buildObservationalContext`, ready to be
+ * folded into a prompt:
+ *
+ *   reflections (highest level)  +  observations (dense)  +  recent raw messages
+ *
+ * The caller decides exactly how to serialize these into the system prompt /
+ * message list; OM only assembles the tiers and their token accounting.
+ */
+export interface ObservationalContext {
+  threadId: string;
+  /** Higher-level reflections, oldest → newest. */
+  reflections: ObservationalMemoryEntry[];
+  /** Dense observations, oldest → newest. */
+  observations: ObservationalMemoryEntry[];
+  /** The tail of raw thread messages kept verbatim (most recent turns). */
+  recentMessages: EngineMessage[];
+  /** Token accounting so the caller can reason about prompt budget. */
+  tokens: {
+    reflections: number;
+    observations: number;
+    recentMessages: number;
+    total: number;
+  };
+}

--- a/packages/core/src/agent/production-agent-journal-hard-block.spec.ts
+++ b/packages/core/src/agent/production-agent-journal-hard-block.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * Specs for the tool-call journal hard-block (tool-layer enforcement):
+ *
+ *   1. A write tool whose exact call already COMPLETED in the per-turn journal
+ *      (derived from the durable run-event ledger of a prior interrupted chunk)
+ *      is NOT re-executed on resume - run() is never called and the journaled
+ *      result is returned, with a coherent tool_start/tool_done transcript.
+ *   2. A FRESH call (empty journal - no prior completion) executes normally.
+ *   3. A different-input call (no journal match) executes normally.
+ *
+ * The run-store ledger reader is mocked so no DB is touched.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock run-store: getCurrentTurnEventsForThread drives the journal.
+const currentTurnEventsMock = vi.hoisted(() =>
+  vi.fn<() => Promise<unknown[]>>(async () => []),
+);
+
+vi.mock("./run-store.js", () => ({
+  writeLedgerEntry: vi.fn(async () => {}),
+  readLedgerEntry: vi.fn(async () => null),
+  clearLedgerForThread: vi.fn(async () => {}),
+  getCurrentTurnEventsForThread: currentTurnEventsMock,
+  insertRun: vi.fn(),
+  updateRunHeartbeat: vi.fn(),
+  getRunAbortState: vi.fn(async () => ({ aborted: false, reason: null })),
+  insertRunEvent: vi.fn(),
+  updateRunStatusIfRunning: vi.fn(),
+  markRunAborted: vi.fn(),
+  reapIfStale: vi.fn(async () => false),
+  bumpRunProgress: vi.fn(),
+  ensureTerminalRunEvent: vi.fn(),
+  setRunError: vi.fn(),
+}));
+
+// Keep OM out of the way. It's gated on ownerEmail anyway, but mock it so the
+// post-turn compaction never touches a DB.
+vi.mock("./observational-memory/index.js", () => ({
+  maybeCompactThread: vi.fn(async () => ({})),
+  buildObservationalContext: vi.fn(async () => ({
+    threadId: "t",
+    reflections: [],
+    observations: [],
+    recentMessages: [],
+    tokens: { reflections: 0, observations: 0, recentMessages: 0, total: 0 },
+  })),
+  hasObservationalMemory: () => false,
+  serializeObservationalMemoryBlock: () => "",
+}));
+
+const { runAgentLoop } = await import("./production-agent.js");
+import type { ActionEntry } from "./production-agent.js";
+import type { AgentEngine, EngineEvent } from "./engine/types.js";
+
+// Helpers.
+
+function makeWriteAction(): ActionEntry {
+  return {
+    tool: {
+      description: "A write action",
+      parameters: { type: "object", properties: {} },
+    },
+    readOnly: false,
+    run: vi.fn(async () => "fresh-execution-result"),
+  };
+}
+
+/** Engine that emits one tool call (with the given input) then ends. */
+function singleToolEngine(
+  toolName: string,
+  input: Record<string, unknown>,
+): AgentEngine {
+  let calls = 0;
+  return {
+    name: "test",
+    label: "Test",
+    defaultModel: "test-model",
+    supportedModels: ["test-model"],
+    capabilities: {
+      thinking: false,
+      promptCaching: false,
+      vision: false,
+      computerUse: false,
+      parallelToolCalls: false,
+    },
+    async *stream(): AsyncIterable<EngineEvent> {
+      calls++;
+      if (calls === 1) {
+        yield {
+          type: "assistant-content",
+          parts: [
+            { type: "tool-call" as const, id: "tc-1", name: toolName, input },
+          ],
+        };
+        yield { type: "stop", reason: "tool_use" };
+        return;
+      }
+      yield {
+        type: "assistant-content",
+        parts: [{ type: "text" as const, text: "done" }],
+      };
+      yield { type: "stop", reason: "end_turn" };
+    },
+  };
+}
+
+/** A prior-chunk ledger where `send-email {to: x}` started AND completed. */
+function completedLedger(
+  tool: string,
+  input: Record<string, string>,
+  result: string,
+): unknown[] {
+  return [
+    { type: "tool_start", tool, input },
+    { type: "tool_done", tool, result },
+  ];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  currentTurnEventsMock.mockResolvedValue([]);
+});
+
+describe("tool-call journal hard-block", () => {
+  it("does NOT re-execute a journaled-complete write call on resume", async () => {
+    const PRIOR_RESULT = "email-sent-id-42";
+    currentTurnEventsMock.mockResolvedValue(
+      completedLedger("send-email", { to: "a@b.com" }, PRIOR_RESULT),
+    );
+
+    const action = makeWriteAction();
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine: singleToolEngine("send-email", { to: "a@b.com" }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "resend" }] }],
+      actions: { "send-email": action },
+      send: (e) => events.push(e),
+      signal: new AbortController().signal,
+      threadId: "thread-resume",
+    });
+
+    // The side effect must NOT have re-fired.
+    expect(action.run).not.toHaveBeenCalled();
+
+    // Transcript stays coherent: both tool_start and tool_done were emitted,
+    // and the journaled result is surfaced.
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "tool_start", tool: "send-email" }),
+    );
+    const toolDone = events.find((e: any) => e.type === "tool_done");
+    expect(toolDone?.result).toContain(PRIOR_RESULT);
+    expect(toolDone?.result).toContain("Already completed");
+  });
+
+  it("executes a fresh call normally when the journal is empty", async () => {
+    currentTurnEventsMock.mockResolvedValue([]); // no prior chunk
+
+    const action = makeWriteAction();
+
+    await runAgentLoop({
+      engine: singleToolEngine("send-email", { to: "a@b.com" }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "send" }] }],
+      actions: { "send-email": action },
+      send: () => {},
+      signal: new AbortController().signal,
+      threadId: "thread-fresh",
+    });
+
+    // Fresh call: the action runs exactly once.
+    expect(action.run).toHaveBeenCalledOnce();
+  });
+
+  it("executes normally when a journaled call has a DIFFERENT input", async () => {
+    currentTurnEventsMock.mockResolvedValue(
+      completedLedger("send-email", { to: "someone-else@b.com" }, "old"),
+    );
+
+    const action = makeWriteAction();
+
+    await runAgentLoop({
+      engine: singleToolEngine("send-email", { to: "a@b.com" }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "send" }] }],
+      actions: { "send-email": action },
+      send: () => {},
+      signal: new AbortController().signal,
+      threadId: "thread-diff-input",
+    });
+
+    // No journal match (different recipient), so it executes.
+    expect(action.run).toHaveBeenCalledOnce();
+  });
+
+  it("never short-circuits a read-only tool via the journal", async () => {
+    currentTurnEventsMock.mockResolvedValue(
+      completedLedger("get-data", { id: "1" }, "old-read"),
+    );
+
+    const readAction: ActionEntry = {
+      tool: {
+        description: "A read action",
+        parameters: { type: "object", properties: {} },
+      },
+      readOnly: true,
+      run: vi.fn(async () => "fresh-read"),
+    };
+
+    await runAgentLoop({
+      engine: singleToolEngine("get-data", { id: "1" }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "read" }] }],
+      actions: { "get-data": readAction },
+      send: () => {},
+      signal: new AbortController().signal,
+      threadId: "thread-read",
+    });
+
+    // Read-only tools are never hard-blocked by the journal; they run.
+    expect(readAction.run).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/agent/production-agent-ledger.spec.ts
+++ b/packages/core/src/agent/production-agent-ledger.spec.ts
@@ -22,11 +22,15 @@ const readLedgerMock = vi.hoisted(() =>
   vi.fn<() => Promise<string | null>>(() => Promise.resolve(null)),
 );
 const clearLedgerMock = vi.hoisted(() => vi.fn<() => Promise<void>>());
+const currentTurnEventsMock = vi.hoisted(() =>
+  vi.fn<() => Promise<any[]>>(() => Promise.resolve([])),
+);
 
 vi.mock("./run-store.js", () => ({
   writeLedgerEntry: writeLedgerMock,
   readLedgerEntry: readLedgerMock,
   clearLedgerForThread: clearLedgerMock,
+  getCurrentTurnEventsForThread: currentTurnEventsMock,
   // Other run-store functions used by production-agent during abort handling:
   insertRun: vi.fn(),
   updateRunHeartbeat: vi.fn(),
@@ -119,6 +123,7 @@ describe("tool-call result ledger", () => {
     readLedgerMock.mockResolvedValue(null);
     clearLedgerMock.mockResolvedValue(undefined);
     writeLedgerMock.mockResolvedValue(undefined);
+    currentTurnEventsMock.mockResolvedValue([]);
   });
 
   it("writes a ledger entry when a zombie write-tool call completes", async () => {
@@ -221,6 +226,47 @@ describe("tool-call result ledger", () => {
     expect(toolDone?.result).toContain(
       "Recovered from prior interrupted chunk",
     );
+  });
+
+  it("returns a completed journal result without re-executing a write tool", async () => {
+    currentTurnEventsMock.mockResolvedValue([
+      {
+        type: "tool_start",
+        tool: "save-data",
+        input: { content: "already-done" },
+      },
+      {
+        type: "tool_done",
+        tool: "save-data",
+        result: "journaled-result",
+      },
+    ]);
+
+    const action = makeWriteAction();
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine: singleToolEngine("save-data", { content: "already-done" }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: { "save-data": action },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+      threadId: "thread-journal-hard-block",
+    });
+
+    expect(action.run).not.toHaveBeenCalled();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "save-data",
+        result: expect.stringContaining("journaled-result"),
+      }),
+    );
+    const toolDone = events.find((e: any) => e.type === "tool_done");
+    expect(toolDone?.result).toContain("Already completed");
   });
 
   it("executes normally when the ledger has no entry for the tool input", async () => {

--- a/packages/core/src/agent/production-agent-observational-memory.spec.ts
+++ b/packages/core/src/agent/production-agent-observational-memory.spec.ts
@@ -1,0 +1,269 @@
+/**
+ * Specs for the Observational Memory (OM) wiring in the agent loop:
+ *
+ *   1. PRODUCER - after a clean turn the post-turn compaction hook
+ *      (`maybeCompactThread`) is invoked for a thread, fire-and-forget.
+ *   2. CONSUMER (long thread) - when the thread HAS persisted observations /
+ *      reflections, the assembled context the engine sees is prefixed with the
+ *      serialized OM memory block.
+ *   3. CONSUMER (short thread) - when the thread has NO OM entries, the engine
+ *      sees the messages unchanged (no OM block injected). Common-path safety.
+ *
+ * The OM module is mocked end-to-end so neither a real model nor a real DB is
+ * touched.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock run-store so DB is never touched.
+vi.mock("./run-store.js", () => ({
+  writeLedgerEntry: vi.fn(async () => {}),
+  readLedgerEntry: vi.fn(async () => null),
+  clearLedgerForThread: vi.fn(async () => {}),
+  insertRun: vi.fn(),
+  updateRunHeartbeat: vi.fn(),
+  getRunAbortState: vi.fn(async () => ({ aborted: false, reason: null })),
+  insertRunEvent: vi.fn(),
+  updateRunStatusIfRunning: vi.fn(),
+  markRunAborted: vi.fn(),
+  reapIfStale: vi.fn(async () => false),
+  bumpRunProgress: vi.fn(),
+  ensureTerminalRunEvent: vi.fn(),
+  setRunError: vi.fn(),
+}));
+
+// Mock the OM module: assert producer + drive the consumer.
+const maybeCompactThreadMock = vi.hoisted(() => vi.fn(async () => ({})));
+const buildObservationalContextMock = vi.hoisted(() => vi.fn());
+
+const OM_BLOCK_TEXT =
+  "[Observational Memory] compacted history\n\n## Reflections (highest-level)\nGoal: ship OM";
+
+vi.mock("./observational-memory/index.js", () => ({
+  maybeCompactThread: maybeCompactThreadMock,
+  buildObservationalContext: buildObservationalContextMock,
+  // Use the real-shaped predicates against the mocked context.
+  hasObservationalMemory: (ctx: any) =>
+    (ctx?.reflections?.length ?? 0) > 0 || (ctx?.observations?.length ?? 0) > 0,
+  serializeObservationalMemoryBlock: (ctx: any) =>
+    (ctx?.reflections?.length ?? 0) > 0 || (ctx?.observations?.length ?? 0) > 0
+      ? OM_BLOCK_TEXT
+      : "",
+}));
+
+// Mock context-xray so the OM injection runs on the raw messages unchanged.
+vi.mock("./context-xray/directives-store.js", () => ({
+  loadContextDirectives: vi.fn(async () => []),
+}));
+vi.mock("./context-xray/manifest.js", () => ({
+  buildManifest: vi.fn(async () => ({})),
+  writeContextManifest: vi.fn(async () => {}),
+}));
+vi.mock("./context-xray/segments.js", () => ({
+  computeProtectedSegmentIds: vi.fn(() => new Set<string>()),
+}));
+vi.mock("./context-xray/apply-directives.js", () => ({
+  applyContextDirectives: (messages: any) => ({
+    messages,
+    appliedStatus: {},
+  }),
+}));
+
+const { runAgentLoop } = await import("./production-agent.js");
+import type {
+  AgentEngine,
+  EngineEvent,
+  EngineMessage,
+} from "./engine/types.js";
+
+// Helpers.
+
+/** Engine that records the messages it was streamed, then ends the turn. */
+function recordingEngine(captured: EngineMessage[][]): AgentEngine {
+  return {
+    name: "test",
+    label: "Test",
+    defaultModel: "test-model",
+    supportedModels: ["test-model"],
+    capabilities: {
+      thinking: false,
+      promptCaching: false,
+      vision: false,
+      computerUse: false,
+      parallelToolCalls: false,
+    },
+    async *stream(opts: any): AsyncIterable<EngineEvent> {
+      // Snapshot the array at stream time; the loop later mutates the original
+      // `messages` reference by pushing the assistant reply.
+      captured.push([...(opts.messages as EngineMessage[])]);
+      yield {
+        type: "assistant-content",
+        parts: [{ type: "text" as const, text: "done" }],
+      };
+      yield { type: "stop", reason: "end_turn" };
+    },
+  };
+}
+
+function blockText(messages: EngineMessage[]): string[] {
+  return messages.flatMap((m) =>
+    m.content
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text),
+  );
+}
+
+const baseMessages: EngineMessage[] = [
+  { role: "user", content: [{ type: "text", text: "hello" }] },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  maybeCompactThreadMock.mockResolvedValue({});
+  // Default: short thread (no OM entries).
+  buildObservationalContextMock.mockResolvedValue({
+    threadId: "t",
+    reflections: [],
+    observations: [],
+    recentMessages: [],
+    tokens: { reflections: 0, observations: 0, recentMessages: 0, total: 0 },
+  });
+});
+
+describe("observational memory wiring", () => {
+  it("invokes the post-turn compaction hook for a thread", async () => {
+    const captured: EngineMessage[][] = [];
+    await runAgentLoop({
+      engine: recordingEngine(captured),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [...baseMessages],
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+      threadId: "thread-om",
+      ownerEmail: "alice@example.com",
+    });
+
+    // Fire-and-forget; let the microtask run.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(maybeCompactThreadMock).toHaveBeenCalledTimes(1);
+    const arg = maybeCompactThreadMock.mock.calls[0][0] as any;
+    expect(arg.threadId).toBe("thread-om");
+    expect(arg.ownerEmail).toBe("alice@example.com");
+  });
+
+  it("does NOT run compaction when there is no threadId", async () => {
+    const captured: EngineMessage[][] = [];
+    await runAgentLoop({
+      engine: recordingEngine(captured),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [...baseMessages],
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+    });
+    await Promise.resolve();
+    expect(maybeCompactThreadMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT run OM when a thread has no authenticated owner", async () => {
+    const captured: EngineMessage[][] = [];
+    await runAgentLoop({
+      engine: recordingEngine(captured),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [...baseMessages],
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+      threadId: "thread-no-owner",
+    });
+    await Promise.resolve();
+
+    expect(buildObservationalContextMock).not.toHaveBeenCalled();
+    expect(maybeCompactThreadMock).not.toHaveBeenCalled();
+    expect(blockText(captured[0])).toEqual(["hello"]);
+  });
+
+  it("injects the OM memory block into context for a thread WITH entries (long thread)", async () => {
+    const recentTail: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "recent turn" }] },
+    ];
+    buildObservationalContextMock.mockResolvedValue({
+      threadId: "thread-long",
+      reflections: [{ text: "Goal: ship OM" }],
+      observations: [{ text: "did stuff" }],
+      recentMessages: recentTail,
+      tokens: {
+        reflections: 5,
+        observations: 5,
+        recentMessages: 5,
+        total: 15,
+      },
+    });
+
+    const captured: EngineMessage[][] = [];
+    await runAgentLoop({
+      engine: recordingEngine(captured),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "old turn" }] },
+        { role: "assistant", content: [{ type: "text", text: "old reply" }] },
+        { role: "user", content: [{ type: "text", text: "recent turn" }] },
+      ],
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+      threadId: "thread-long",
+      ownerEmail: "alice@example.com",
+    });
+
+    expect(captured.length).toBe(1);
+    const sent = captured[0];
+    const texts = blockText(sent);
+    // The serialized OM block must be the leading message.
+    expect(texts[0]).toContain("[Observational Memory]");
+    expect(sent[0].role).toBe("user");
+    // The recent-raw window is preserved verbatim after the block.
+    expect(texts).toContain("recent turn");
+    // The trimmed-away older prefix is no longer replayed.
+    expect(texts).not.toContain("old turn");
+  });
+
+  it("leaves context unchanged for a thread with NO entries (short thread)", async () => {
+    // Default mock = no reflections/observations.
+    const inputMessages: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "first" }] },
+      { role: "assistant", content: [{ type: "text", text: "reply" }] },
+      { role: "user", content: [{ type: "text", text: "second" }] },
+    ];
+
+    const captured: EngineMessage[][] = [];
+    await runAgentLoop({
+      engine: recordingEngine(captured),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: inputMessages,
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+      threadId: "thread-short",
+      ownerEmail: "alice@example.com",
+    });
+
+    const sent = captured[0];
+    const texts = blockText(sent);
+    // No OM block injected; all original turns intact and in order.
+    expect(texts.some((t) => t.includes("[Observational Memory]"))).toBe(false);
+    expect(texts).toEqual(["first", "reply", "second"]);
+  });
+});

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -2852,6 +2852,250 @@ describe("runAgentLoop", () => {
     expect(events).toContainEqual({ type: "clear" });
     expect(events).toContainEqual({ type: "text", text: "Recovered" });
   });
+
+  // ─── Human-in-the-loop approval gate (opt-in needsApproval) ──────────────
+  //
+  // Builds an engine that emits a single tool call to `send-email` on the
+  // first stream, then a plain text completion on every subsequent stream.
+  // The post-tool stream lets an *approved* re-run finish cleanly.
+  const approvalEngine = (
+    toolInput: Record<string, unknown> = { to: "a@b.com" },
+  ): { engine: AgentEngine; streamCalls: () => number } => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "approval-call-1",
+                name: "send-email",
+                input: toolInput,
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield { type: "text-delta", text: "sent the email" };
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "sent the email" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    return { engine, streamCalls: () => streamCalls };
+  };
+
+  it("runs an action WITHOUT needsApproval normally (no approval_required)", async () => {
+    const { engine } = approvalEngine();
+    const run = vi.fn(async () => "delivered");
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "send-email": {
+          ...actionEntry({ readOnly: false }),
+          run,
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(events.some((event) => event.type === "approval_required")).toBe(
+      false,
+    );
+    expect(events.at(-1)).toEqual({ type: "done" });
+  });
+
+  it("needsApproval:true pauses the turn, never runs the action, and emits a stable approvalKey", async () => {
+    const { engine, streamCalls } = approvalEngine();
+    const run = vi.fn(async () => "delivered");
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "send-email": {
+          ...actionEntry({ readOnly: false }),
+          needsApproval: true,
+          run,
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    // The side effect must NOT have happened.
+    expect(run).not.toHaveBeenCalled();
+    // The model was never asked to continue after the pause (only the first
+    // tool-emitting stream ran).
+    expect(streamCalls()).toBe(1);
+
+    const approvalEvent = events.find(
+      (event) => event.type === "approval_required",
+    );
+    expect(approvalEvent).toBeDefined();
+    expect(approvalEvent.tool).toBe("send-email");
+    expect(approvalEvent.input).toEqual({ to: "a@b.com" });
+    // A stable, non-empty key that the client echoes back to approve.
+    expect(typeof approvalEvent.approvalKey).toBe("string");
+    expect(approvalEvent.approvalKey.length).toBeGreaterThan(0);
+    expect(approvalEvent.approvalKey).toContain("send-email");
+    expect(approvalEvent.toolCallId).toBe("approval-call-1");
+
+    // A paused tool_done is emitted explaining the action did NOT execute.
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "send-email",
+        result: expect.stringContaining("did NOT execute"),
+      }),
+    );
+    // The turn stops with the approval-waiting message (how the loop surfaces a
+    // requestedActionStop with errorCode "needs-approval").
+    expect(events).toContainEqual({
+      type: "text",
+      text: "Waiting for your approval to run send-email.",
+    });
+  });
+
+  it("re-running with approvedToolCalls:[approvalKey] DOES run the action", async () => {
+    // Phase 1: capture the approvalKey from the pause.
+    const phase1 = approvalEngine();
+    const run = vi.fn(async () => "delivered");
+    const events1: any[] = [];
+    const actions = {
+      "send-email": {
+        ...actionEntry({ readOnly: false }),
+        needsApproval: true,
+        run,
+      },
+    };
+
+    await runAgentLoop({
+      engine: phase1.engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions,
+      send: (event) => events1.push(event),
+      signal: new AbortController().signal,
+    });
+
+    const approvalKey = events1.find(
+      (event) => event.type === "approval_required",
+    )?.approvalKey as string;
+    expect(approvalKey).toBeTruthy();
+    expect(run).not.toHaveBeenCalled();
+
+    // Phase 2: re-issue the turn approving that specific call.
+    const phase2 = approvalEngine();
+    const events2: any[] = [];
+
+    await runAgentLoop({
+      engine: phase2.engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions,
+      approvedToolCalls: [approvalKey],
+      send: (event) => events2.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(events2.some((event) => event.type === "approval_required")).toBe(
+      false,
+    );
+    expect(events2).toContainEqual({ type: "text", text: "sent the email" });
+    expect(events2.at(-1)).toEqual({ type: "done" });
+  });
+
+  it("predicate needsApproval gates only matching args (non-matching runs normally)", async () => {
+    // Non-matching args run normally.
+    const safe = approvalEngine({ x: "safe" });
+    const safeRun = vi.fn(async () => "ran-safe");
+    const safeEvents: any[] = [];
+    const predicate = (args: { x?: string }) => args.x === "danger";
+
+    await runAgentLoop({
+      engine: safe.engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "send-email": {
+          ...actionEntry({ readOnly: false }),
+          needsApproval: predicate,
+          run: safeRun,
+        },
+      },
+      send: (event) => safeEvents.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(safeRun).toHaveBeenCalledOnce();
+    expect(safeEvents.some((event) => event.type === "approval_required")).toBe(
+      false,
+    );
+
+    // Matching args pause for approval and never run.
+    const danger = approvalEngine({ x: "danger" });
+    const dangerRun = vi.fn(async () => "ran-danger");
+    const dangerEvents: any[] = [];
+
+    await runAgentLoop({
+      engine: danger.engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "send-email": {
+          ...actionEntry({ readOnly: false }),
+          needsApproval: predicate,
+          run: dangerRun,
+        },
+      },
+      send: (event) => dangerEvents.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(dangerRun).not.toHaveBeenCalled();
+    expect(
+      dangerEvents.some((event) => event.type === "approval_required"),
+    ).toBe(true);
+  });
 });
 
 // ─── isContextTooLongError ────────────────────────────────────────────────────

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -86,7 +86,13 @@ import {
   writeLedgerEntry,
   readLedgerEntry,
   clearLedgerForThread,
+  getCurrentTurnEventsForThread,
 } from "./run-store.js";
+import {
+  classifyToolCallJournal,
+  findCompletedJournalEntry,
+  type ToolCallJournal,
+} from "./tool-call-journal.js";
 import { preUploadAttachments } from "../file-upload/pre-upload-attachments.js";
 import { extensionIdFromPathname } from "../extensions/path.js";
 import { applyContextDirectives } from "./context-xray/apply-directives.js";
@@ -2156,6 +2162,31 @@ export async function runAgentLoop(opts: {
     messages,
     actions,
   );
+
+  // Tool-call journal hard-block (resume safety). Snapshot the per-turn journal
+  // ONCE here, before any tool runs in this chunk, so it reflects only PRIOR
+  // run chunks of this logical turn. A write tool whose exact call already
+  // completed in an earlier interrupted chunk must not re-fire its side effect;
+  // when matched, runToolCall returns the journaled result instead of executing.
+  // Loaded eagerly (not lazily mid-loop) so the current chunk's own
+  // asynchronously-persisted tool_done events can never leak in and make a
+  // same-chunk call wrongly short-circuit. Best-effort: any ledger failure
+  // leaves the journal empty and all calls run normally. Fresh first-turn calls
+  // see an empty journal and are unaffected.
+  let toolCallJournal: ToolCallJournal | null = null;
+  const consumedJournalKeys = new Set<string>();
+  if (opts.threadId) {
+    try {
+      const priorEvents = await getCurrentTurnEventsForThread(opts.threadId);
+      if (priorEvents.length > 0) {
+        toolCallJournal = classifyToolCallJournal(priorEvents);
+      }
+    } catch {
+      // Journal is a hardening layer, never a gate — a failed ledger read just
+      // means no hard-block this turn.
+    }
+  }
+
   const bufferTextUntilFinalGuard = Boolean(opts.finalResponseGuard);
   let finalGuardRetries = 0;
   let iterations = 0;
@@ -2675,6 +2706,47 @@ export async function runAgentLoop(opts: {
           toolInput: wireToolInput,
           content: result,
         };
+      }
+
+      // TOOL-CALL JOURNAL HARD-BLOCK (resume safety, tool-layer enforcement).
+      // The prompt-level resume journal already TELLS a resuming model not to
+      // re-run completed tool calls; this enforces it at the tool layer so a
+      // re-dispatched write call whose exact (tool name + input) already
+      // completed in an earlier interrupted chunk of this turn does NOT execute
+      // its side effect again — we return the journaled result instead and emit
+      // the normal tool_start/tool_done so the transcript stays coherent.
+      //
+      // Gated on a non-readOnly tool + an existing prior-chunk journal (so fresh
+      // calls with no completed journal entry are completely unaffected). The
+      // snapshot was taken before this chunk's tools ran, so it can only match a
+      // PRIOR completion, never one from the current chunk.
+      if (!actionEntry.readOnly && toolCallJournal) {
+        const journaled = findCompletedJournalEntry(
+          toolCallJournal,
+          toolCall.name,
+          toolCall.input,
+          consumedJournalKeys,
+        );
+        if (journaled) {
+          const recordedResult = journaled.result ?? "";
+          const result =
+            `(Already completed in an earlier interrupted attempt - not re-run to avoid a duplicate side effect.)\n\n` +
+            recordedResult;
+          send({
+            type: "tool_start",
+            tool: toolCall.name,
+            input: toolCall.input as Record<string, string>,
+          });
+          send({ type: "tool_done", tool: toolCall.name, result });
+          recordToolResult(result, false);
+          return {
+            type: "tool-result" as const,
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            toolInput: wireToolInput,
+            content: result,
+          };
+        }
       }
 
       // Guard against write tools that have been interrupted too many times in

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -338,6 +338,19 @@ export interface ActionEntry {
    * the result to this many characters instead of the global 50 000 cap.
    */
   maxResultChars?: number;
+  /**
+   * Opt-in human-in-the-loop approval gate (default off). When truthy (or a
+   * predicate that resolves truthy for the call's args), the loop emits
+   * `approval_required` and stops the turn instead of executing this action,
+   * until a human approves the specific call. Set by `defineAction`'s
+   * `needsApproval` option. See `packages/core/docs/content/actions.md`.
+   */
+  needsApproval?:
+    | boolean
+    | ((
+        args: any,
+        ctx?: import("../action.js").ActionRunContext,
+      ) => boolean | Promise<boolean>);
 }
 
 /** @deprecated Use `ActionEntry` instead */
@@ -1989,6 +2002,13 @@ export async function runAgentLoop(opts: {
    * ActionEntry overrides them with its own timeoutMs / maxResultChars.
    */
   toolLimits?: { timeoutMs?: number; maxResultChars?: number };
+  /**
+   * Stable approval keys granted by a human for actions declared
+   * `needsApproval`. A call whose key is present here runs even though the
+   * action requires approval; otherwise the loop pauses with
+   * `approval_required`. See `AgentChatRequest.approvedToolCalls`.
+   */
+  approvedToolCalls?: string[];
 }): Promise<AgentLoopUsage> {
   const {
     engine,
@@ -2347,6 +2367,12 @@ export async function runAgentLoop(opts: {
     let requestedActionStop: { message: string; errorCode?: string } | null =
       null;
 
+    // Human-in-the-loop approvals granted by the user for this turn (opt-in;
+    // empty for the overwhelming majority of turns). Keyed by the stable
+    // tool-call approval key so a re-issued continuation can let an approved
+    // call run. The model cannot populate this — it comes from the request.
+    const approvedToolCallKeys = new Set<string>(opts.approvedToolCalls ?? []);
+
     const runToolCall = async (
       toolCall: import("./engine/types.js").EngineToolCallPart,
     ): Promise<EngineContentPart> => {
@@ -2439,6 +2465,63 @@ export async function runAgentLoop(opts: {
           content: result,
           isError: true,
         };
+      }
+
+      // Human-in-the-loop approval gate (opt-in via defineAction
+      // `needsApproval`; default off). When an action requires approval and
+      // this specific call has NOT been approved by a human, pause the turn
+      // instead of executing. The action's side effect never happens until a
+      // human re-issues the turn approving this call's stable key.
+      const approvalKey = toolCallCacheKey(toolCall.name, toolCall.input);
+      if (actionEntry.needsApproval && !approvedToolCallKeys.has(approvalKey)) {
+        let mustApprove = false;
+        try {
+          mustApprove =
+            typeof actionEntry.needsApproval === "function"
+              ? Boolean(
+                  await actionEntry.needsApproval(toolCall.input, {
+                    userEmail: getRequestUserEmail(),
+                    orgId: getRequestOrgId() ?? null,
+                    caller: "tool",
+                  }),
+                )
+              : actionEntry.needsApproval === true;
+        } catch {
+          // Fail closed: a throwing predicate means we require approval rather
+          // than silently running a high-consequence action.
+          mustApprove = true;
+        }
+        if (mustApprove) {
+          send({
+            type: "tool_start",
+            tool: toolCall.name,
+            input: toolCall.input as Record<string, string>,
+          });
+          send({
+            type: "approval_required",
+            tool: toolCall.name,
+            input: toolCall.input as Record<string, string>,
+            approvalKey,
+            ...(toolCall.id ? { toolCallId: toolCall.id } : {}),
+          });
+          const result =
+            `Awaiting human approval to run "${toolCall.name}". This action did ` +
+            `NOT execute — a human must approve this specific call before it ` +
+            `can run. The turn is paused; do not retry.`;
+          send({ type: "tool_done", tool: toolCall.name, result });
+          recordToolResult(result, false);
+          requestedActionStop ??= {
+            message: `Waiting for your approval to run ${toolCall.name}.`,
+            errorCode: "needs-approval",
+          };
+          return {
+            type: "tool-result" as const,
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            toolInput: wireToolInput,
+            content: result,
+          };
+        }
       }
 
       const cacheKey =
@@ -3920,6 +4003,16 @@ export function createProductionAgentHandler(
           ...(options.toolLimits ? { toolLimits: options.toolLimits } : {}),
           ...(threadId
             ? { threadId: effectiveThreadId, turnId: effectiveTurnId }
+            : {}),
+          // Human-in-the-loop approval grants for this turn (sanitized — the
+          // request is untrusted; accept only a bounded list of string keys).
+          ...(Array.isArray(body.approvedToolCalls) &&
+          body.approvedToolCalls.length
+            ? {
+                approvedToolCalls: body.approvedToolCalls
+                  .filter((k: unknown): k is string => typeof k === "string")
+                  .slice(0, 200),
+              }
             : {}),
         };
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -101,6 +101,12 @@ import {
   writeContextManifest,
 } from "./context-xray/manifest.js";
 import { computeProtectedSegmentIds } from "./context-xray/segments.js";
+import {
+  maybeCompactThread,
+  buildObservationalContext,
+  hasObservationalMemory,
+  serializeObservationalMemoryBlock,
+} from "./observational-memory/index.js";
 
 // Register built-in engines on first import
 registerBuiltinEngines();
@@ -1571,6 +1577,99 @@ function findCurrentTurnStartForContinuation(
   return 0;
 }
 
+/**
+ * First message index that is safe to start a trimmed window on. A window must
+ * not begin with a tool-result-only user message — that would orphan it from
+ * the assistant tool-call turn it answers and break Anthropic's tool_use /
+ * tool_result pairing. We walk forward from `desiredStart` to the first
+ * non-orphaned boundary; if none exists we refuse to trim (return -1).
+ */
+function findSafeWindowStart(
+  messages: EngineMessage[],
+  desiredStart: number,
+): number {
+  for (let i = Math.max(0, desiredStart); i < messages.length; i++) {
+    if (!isToolResultOnlyUserMessage(messages[i])) return i;
+  }
+  return -1;
+}
+
+/**
+ * Observational Memory consumer (threshold-gated, conservative).
+ *
+ * Builds the three-tier OM context for a thread and, ONLY when the thread has
+ * already crossed the compaction threshold (i.e. it has at least one persisted
+ * observation/reflection), returns a rewritten message list that:
+ *   - prepends a single system-role "Observational Memory" block holding the
+ *     reflections + observations, and
+ *   - replaces the raw older history with just the recent-raw-message window,
+ *     keeping the current user turn and any pending tool results intact.
+ *
+ * For threads with NO OM entries (every short thread) it returns the input
+ * array unchanged by reference, so the common path is byte-for-byte identical.
+ *
+ * Best-effort: any failure returns the input unchanged so OM can never break a
+ * normal turn.
+ */
+async function applyObservationalMemoryToContext(
+  messages: EngineMessage[],
+  opts: {
+    threadId: string;
+    ownerEmail?: string | null;
+    orgId?: string | null;
+  },
+): Promise<EngineMessage[]> {
+  if (!opts.ownerEmail) return messages;
+
+  try {
+    const context = await buildObservationalContext({
+      threadId: opts.threadId,
+      ownerEmail: opts.ownerEmail,
+      orgId: opts.orgId ?? null,
+      messages,
+    });
+
+    // No compacted memory yet → short thread, leave context untouched.
+    if (!hasObservationalMemory(context)) return messages;
+
+    const block = serializeObservationalMemoryBlock(context);
+    if (!block.trim()) return messages;
+
+    // EngineMessage has no "system" role; the framework injects auxiliary
+    // context as leading user messages (same convention as the continuation
+    // nudge and the resume journal note), and the serialized block is clearly
+    // self-labeled "[Observational Memory]".
+    const omMessage: EngineMessage = {
+      role: "user",
+      content: [{ type: "text", text: block }],
+    };
+
+    // Trim the raw prefix to only the recent-raw window. The window is the tail
+    // of `messages`, so it always contains the latest user turn and any pending
+    // tool results. Guard the boundary so we never start mid tool_use/result
+    // pair; if a safe boundary can't be found, additively inject the memory
+    // block WITHOUT trimming (the conservative fallback) so we never drop a
+    // pending tool result.
+    const recentCount = context.recentMessages.length;
+    if (recentCount === 0 || recentCount >= messages.length) {
+      return [omMessage, ...messages];
+    }
+    const desiredStart = messages.length - recentCount;
+    const safeStart = findSafeWindowStart(messages, desiredStart);
+    if (safeStart < 0) {
+      // Whole tail is tool-result-only (degenerate) — don't trim.
+      return [omMessage, ...messages];
+    }
+    return [omMessage, ...messages.slice(safeStart)];
+  } catch (err) {
+    console.warn(
+      "[observational-memory] context injection skipped:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return messages;
+  }
+}
+
 function seedReadOnlyToolResultsFromHistory(
   messages: EngineMessage[],
   actions: Record<string, ActionEntry>,
@@ -2111,6 +2210,25 @@ export async function runAgentLoop(opts: {
         console.warn(
           "[context-xray] context transform skipped:",
           err instanceof Error ? err.message : String(err),
+        );
+      }
+
+      // Observational Memory (consumer): for long threads that have already been
+      // compacted, fold the reflections+observations in as a leading context
+      // block and prefer the recent-raw-message window over the full raw
+      // history. No-op (returns the same array) for short threads with no OM
+      // entries, so the common path is unchanged. Runs after the context-xray
+      // transform so the two compose; best-effort inside the helper. Gated on an
+      // authenticated owner so anonymous threads never read OM scoped to a
+      // shared default identity.
+      if (opts.ownerEmail) {
+        contextMessages = await applyObservationalMemoryToContext(
+          contextMessages,
+          {
+            threadId: opts.threadId,
+            ownerEmail: opts.ownerEmail,
+            orgId: opts.orgId ?? null,
+          },
         );
       }
     }
@@ -2927,6 +3045,27 @@ export async function runAgentLoop(opts: {
     // intact so the next continuation chunk can still recover from it.
     if (opts.threadId) {
       void clearLedgerForThread(opts.threadId).catch(() => {});
+
+      // Observational Memory (producer): after a clean turn, run a best-effort
+      // compaction pass so long threads accrue observations/reflections that the
+      // consumer above will surface on later turns. Both the Observer and the
+      // Reflector no-op below their token thresholds, so this is cheap for short
+      // threads. Fire-and-forget; any failure is swallowed so OM never affects
+      // the user-visible turn.
+      if (opts.ownerEmail) {
+        const compactThreadId = opts.threadId;
+        void maybeCompactThread({
+          threadId: compactThreadId,
+          ownerEmail: opts.ownerEmail,
+          orgId: opts.orgId ?? null,
+          messages,
+        }).catch((err) => {
+          console.warn(
+            "[observational-memory] post-turn compaction skipped:",
+            err instanceof Error ? err.message : String(err),
+          );
+        });
+      }
     }
   }
   return usage;

--- a/packages/core/src/agent/run-loop-with-resume.spec.ts
+++ b/packages/core/src/agent/run-loop-with-resume.spec.ts
@@ -12,6 +12,8 @@ import {
   runAgentLoopDirectWithSoftTimeout,
   MAX_RUN_LOOP_CONTINUATIONS,
 } from "./run-loop-with-resume.js";
+import { getCurrentTurnEventsForThread } from "./run-store.js";
+import type { AgentChatEvent } from "./types.js";
 
 vi.mock("./production-agent.js", async () => {
   const actual = await vi.importActual<typeof import("./production-agent.js")>(
@@ -23,16 +25,32 @@ vi.mock("./production-agent.js", async () => {
   };
 });
 
+// The journal reads the durable run-event ledger. Mock just the read-only
+// helper used on the resume path so tests don't need a live DB; keep the rest
+// of run-store real (run-manager pulls several other exports from it).
+vi.mock("./run-store.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./run-store.js")>("./run-store.js");
+  return {
+    ...actual,
+    getCurrentTurnEventsForThread: vi.fn(async () => [] as AgentChatEvent[]),
+  };
+});
+
 const mockRunAgentLoop = vi.mocked(runAgentLoop);
+const mockGetCurrentTurnEventsForThread = vi.mocked(
+  getCurrentTurnEventsForThread,
+);
 
 function makeOpts(
   messages: EngineMessage[],
   signal: AbortSignal,
   send?: (event: import("./types.js").AgentChatEvent) => void,
+  threadId?: string,
 ): Parameters<typeof runAgentLoopDirectWithSoftTimeout>[0] {
   return {
-    // The wrapper only inspects messages, signal, and model. Cast the rest —
-    // the mocked runAgentLoop ignores them.
+    // The wrapper only inspects messages, signal, model, and threadId. Cast the
+    // rest — the mocked runAgentLoop ignores them.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     engine: {} as any,
     model: "test-model",
@@ -43,6 +61,7 @@ function makeOpts(
     actions: {},
     send: send ?? (() => {}),
     signal,
+    ...(threadId ? { threadId } : {}),
   } as Parameters<typeof runAgentLoopDirectWithSoftTimeout>[0];
 }
 
@@ -170,6 +189,8 @@ describe("runAgentLoopDirectWithSoftTimeout", () => {
   beforeEach(() => {
     vi.stubEnv("AGENT_RUN_SOFT_TIMEOUT_MS", "60000");
     mockRunAgentLoop.mockReset();
+    mockGetCurrentTurnEventsForThread.mockReset();
+    mockGetCurrentTurnEventsForThread.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -416,5 +437,165 @@ describe("runAgentLoopDirectWithSoftTimeout", () => {
     );
 
     expect(sentEvents.filter((e) => e.type === "clear")).toHaveLength(0);
+  });
+
+  // ─── Per-turn tool-call journal on resume ─────────────────────────────────
+
+  it("injects a structured journal note on resume listing completed and interrupted tool calls", async () => {
+    // Ledger from the interrupted attempt: sendEmail completed, createTicket
+    // started but never recorded a result.
+    mockGetCurrentTurnEventsForThread.mockResolvedValue([
+      { type: "tool_start", tool: "sendEmail", input: { to: "a@example.com" } },
+      { type: "tool_done", tool: "sendEmail", result: "Email sent (msg_123)" },
+      { type: "tool_start", tool: "createTicket", input: { title: "Bug" } },
+    ]);
+
+    let attempts = 0;
+    const messages: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "go" }] },
+    ];
+    mockRunAgentLoop.mockImplementation(async () => {
+      attempts++;
+      if (attempts === 1) {
+        throw new EngineError("Builder gateway timed out", {
+          errorCode: "builder_gateway_timeout",
+        });
+      }
+      return {
+        inputTokens: 1,
+        outputTokens: 1,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        model: "test-model",
+      };
+    });
+
+    await runAgentLoopDirectWithSoftTimeout(
+      makeOpts(messages, new AbortController().signal, undefined, "thread-1"),
+      60_000,
+    );
+
+    expect(attempts).toBe(2);
+    expect(mockGetCurrentTurnEventsForThread).toHaveBeenCalledWith("thread-1");
+
+    const journalNote = messages
+      .map((m) => (m.content[0]?.type === "text" ? m.content[0].text : ""))
+      .find((t) =>
+        t.includes("Tool-call journal from the interrupted attempt"),
+      );
+    expect(journalNote).toBeDefined();
+    const text = journalNote as string;
+    expect(text).toContain("Already completed");
+    expect(text).toContain("do NOT re-run");
+    expect(text).toContain("sendEmail");
+    expect(text).toContain("Email sent (msg_123)");
+    expect(text).toContain("Interrupted / unknown outcome");
+    expect(text).toContain("createTicket");
+
+    // The standard continuation nudge must still be present (journal is additive).
+    const continuationNote = messages
+      .map((m) => (m.content[0]?.type === "text" ? m.content[0].text : ""))
+      .find((t) => t.startsWith(AGENT_INTERNAL_CONTINUE_PROMPT));
+    expect(continuationNote).toBeDefined();
+  });
+
+  it("does not inject a journal note on resume when the turn had no tool calls", async () => {
+    // No tool activity in the ledger → no structured note, so resume behavior is
+    // unchanged from before this feature.
+    mockGetCurrentTurnEventsForThread.mockResolvedValue([
+      { type: "text", text: "partial answer" },
+    ]);
+
+    let attempts = 0;
+    const messages: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "go" }] },
+    ];
+    mockRunAgentLoop.mockImplementation(async () => {
+      attempts++;
+      if (attempts === 1) throw new Error("socket hang up");
+      return {
+        inputTokens: 1,
+        outputTokens: 1,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        model: "test-model",
+      };
+    });
+
+    await runAgentLoopDirectWithSoftTimeout(
+      makeOpts(messages, new AbortController().signal, undefined, "thread-2"),
+      60_000,
+    );
+
+    expect(attempts).toBe(2);
+    const journalNote = messages
+      .map((m) => (m.content[0]?.type === "text" ? m.content[0].text : ""))
+      .find((t) =>
+        t.includes("Tool-call journal from the interrupted attempt"),
+      );
+    expect(journalNote).toBeUndefined();
+
+    // Exactly the standard continuation nudge was appended (one extra message).
+    expect(messages).toHaveLength(2);
+  });
+
+  it("does not read the journal when no threadId is provided", async () => {
+    let attempts = 0;
+    mockRunAgentLoop.mockImplementation(async () => {
+      attempts++;
+      if (attempts === 1) throw new Error("socket hang up");
+      return {
+        inputTokens: 1,
+        outputTokens: 1,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        model: "test-model",
+      };
+    });
+
+    await runAgentLoopDirectWithSoftTimeout(
+      makeOpts(
+        [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        new AbortController().signal,
+      ),
+      60_000,
+    );
+
+    expect(attempts).toBe(2);
+    expect(mockGetCurrentTurnEventsForThread).not.toHaveBeenCalled();
+  });
+
+  it("still resumes when the journal ledger read throws", async () => {
+    mockGetCurrentTurnEventsForThread.mockRejectedValue(
+      new Error("db unavailable"),
+    );
+
+    let attempts = 0;
+    const messages: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "go" }] },
+    ];
+    mockRunAgentLoop.mockImplementation(async () => {
+      attempts++;
+      if (attempts === 1) throw new Error("socket hang up");
+      return {
+        inputTokens: 1,
+        outputTokens: 1,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        model: "test-model",
+      };
+    });
+
+    // A failed ledger read must not break the recovery — the resume still runs.
+    await runAgentLoopDirectWithSoftTimeout(
+      makeOpts(messages, new AbortController().signal, undefined, "thread-3"),
+      60_000,
+    );
+
+    expect(attempts).toBe(2);
+    const continuationNote = messages
+      .map((m) => (m.content[0]?.type === "text" ? m.content[0].text : ""))
+      .find((t) => t.startsWith(AGENT_INTERNAL_CONTINUE_PROMPT));
+    expect(continuationNote).toBeDefined();
   });
 });

--- a/packages/core/src/agent/run-loop-with-resume.ts
+++ b/packages/core/src/agent/run-loop-with-resume.ts
@@ -28,6 +28,56 @@ import {
   continuationReasonForResumableError,
 } from "./production-agent.js";
 import { resolveRunSoftTimeoutMs } from "./run-manager.js";
+import { getCurrentTurnEventsForThread } from "./run-store.js";
+import {
+  classifyToolCallJournal,
+  buildResumeJournalNote,
+} from "./tool-call-journal.js";
+import type { EngineMessage } from "./engine/types.js";
+
+/**
+ * Derive the per-turn tool-call journal from the durable run-event ledger and,
+ * when there is anything to report, append a STRUCTURED note to the message
+ * prefix so the resumed model:
+ *   - does NOT re-execute tool calls that already completed (avoiding duplicate
+ *     side effects like re-sending an email or re-creating a ticket), and
+ *   - is explicitly told about any tool call that started but whose outcome was
+ *     never recorded ("interrupted, unknown outcome") so it can decide.
+ *
+ * This is additive to the existing "continue from where you left off" nudge —
+ * it is appended right after it. When the journal is empty (no completed or
+ * interrupted tool calls — e.g. a turn with no tool activity, or a clean
+ * continuation), nothing extra is appended and resume behavior is byte-for-byte
+ * what it was before. Best-effort: any ledger read/parse failure is swallowed so
+ * a journal hiccup can never block a recovery that would otherwise succeed.
+ *
+ * TODO(charlie-merge): optional hard-block — once CHARLIE's loop edits land,
+ * pair this prompt-level journal with tool-layer enforcement in
+ * production-agent.ts/runToolCall that refuses to re-execute a journaled-
+ * complete tool call (return the journaled result instead). See
+ * `tool-call-journal.ts` for the keying to use.
+ */
+async function appendToolCallJournalNote(
+  messages: EngineMessage[],
+  threadId: string | undefined,
+): Promise<void> {
+  if (!threadId) return;
+  try {
+    const events = await getCurrentTurnEventsForThread(threadId);
+    if (events.length === 0) return;
+    const journal = classifyToolCallJournal(events);
+    const note = buildResumeJournalNote(journal);
+    if (!note) return;
+    messages.push({
+      role: "user",
+      content: [{ type: "text", text: note }],
+    });
+  } catch {
+    // The journal is a hardening layer, never a gate. A failed ledger read or
+    // parse must not break the resume that the continuation nudge already set
+    // up — the model still continues, just without the structured journal.
+  }
+}
 
 /**
  * Cap on continuation iterations inside a single
@@ -102,6 +152,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
       addUsage(nextUsage);
       if (softTimedOut && !upstreamSignal.aborted) {
         appendAgentLoopContinuation(opts.messages, "run_timeout");
+        await appendToolCallJournalNote(opts.messages, opts.threadId);
         continue;
       }
       return usage;
@@ -111,6 +162,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
         // resumed model doesn't re-emit it and produce duplicated output.
         opts.send({ type: "clear" });
         appendAgentLoopContinuation(opts.messages, "run_timeout");
+        await appendToolCallJournalNote(opts.messages, opts.threadId);
         continue;
       }
       // Resumable transport / gateway interruptions: the LLM call was cut off
@@ -132,6 +184,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
           opts.messages,
           continuationReasonForResumableError(err),
         );
+        await appendToolCallJournalNote(opts.messages, opts.threadId);
         continue;
       }
       throw err;

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -5,6 +5,7 @@
  */
 import { getDbExec, intType, isPostgres } from "../db/client.js";
 import { captureError } from "../server/capture-error.js";
+import type { AgentChatEvent } from "./types.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -551,6 +552,61 @@ export async function getRunByThread(
     lastProgressAt:
       r.last_progress_at == null ? null : Number(r.last_progress_at),
   };
+}
+
+/**
+ * Read the current logical turn's recorded events for a thread, parsed into
+ * `AgentChatEvent`s in seq order, for per-turn tool-call journal classification
+ * (see `tool-call-journal.ts`). Read-only and additive — reuses the existing
+ * `agent_runs` / `agent_run_events` ledger with no schema change.
+ *
+ * A logical turn may span several continuation runs (each chunk is its own run
+ * sharing one `turn_id`), so we union the events of every run that belongs to
+ * the latest turn for this thread. Events are ordered by (started_at, seq) so
+ * earlier chunks come before later ones and the positional `tool_start` →
+ * `tool_done` matching in the classifier stays correct across chunk boundaries.
+ *
+ * Returns an empty array when the thread has no run yet or no parseable events.
+ * Best-effort on parse: malformed ledger rows are skipped rather than thrown.
+ */
+export async function getCurrentTurnEventsForThread(
+  threadId: string,
+): Promise<AgentChatEvent[]> {
+  await ensureRunTables();
+  const client = getDbExec();
+  // Find the latest run for this thread (terminal or running) to learn the
+  // logical turn id. The journal is consulted on the resume path, where the
+  // just-interrupted run is typically already terminal.
+  const latest = await client.execute({
+    sql: `SELECT id, turn_id FROM agent_runs WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`,
+    args: [threadId],
+  });
+  if (latest.rows.length === 0) return [];
+  const latestRow = latest.rows[0] as { id: string; turn_id: string | null };
+  const turnId = latestRow.turn_id ?? latestRow.id;
+  // Gather every run that belongs to this logical turn, oldest chunk first, and
+  // read their events in seq order. COALESCE(turn_id, id) folds older rows that
+  // predate the turn_id backfill into a turn keyed by their own run id.
+  const { rows } = await client.execute({
+    sql: `SELECT e.event_data AS event_data
+          FROM agent_run_events e
+          JOIN agent_runs r ON r.id = e.run_id
+          WHERE r.thread_id = ?
+            AND COALESCE(r.turn_id, r.id) = ?
+          ORDER BY r.started_at ASC, e.seq ASC`,
+    args: [threadId, turnId],
+  });
+  const events: AgentChatEvent[] = [];
+  for (const r of rows) {
+    const raw = (r as { event_data?: string }).event_data;
+    if (!raw) continue;
+    try {
+      events.push(JSON.parse(raw) as AgentChatEvent);
+    } catch {
+      // Skip malformed ledger rows — the journal is best-effort.
+    }
+  }
+  return events;
 }
 
 /**

--- a/packages/core/src/agent/runtime-context.spec.ts
+++ b/packages/core/src/agent/runtime-context.spec.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { buildRuntimeContextPrompt } from "./runtime-context.js";
+import {
+  buildRuntimeContextPrompt,
+  MAX_SUBAGENT_DELEGATION_DEPTH,
+  resolveMaxSubagentDelegationDepth,
+} from "./runtime-context.js";
 
 describe("buildRuntimeContextPrompt", () => {
   it("includes authoritative UTC and local dates for relative date resolution", () => {
@@ -25,5 +29,88 @@ describe("buildRuntimeContextPrompt", () => {
 
     expect(prompt).toContain("currentTimezone: UTC");
     expect(prompt).toContain("currentDateInTimezone: 2026-05-03");
+  });
+
+  it("omits delegation lines for the top-level agent (depth 0 / unset)", () => {
+    const prompt = buildRuntimeContextPrompt({
+      now: new Date("2026-05-03T18:30:00Z"),
+    });
+    expect(prompt).not.toContain("delegationDepth:");
+  });
+
+  it("surfaces a sub-agent's delegation depth and remaining headroom", () => {
+    const prompt = buildRuntimeContextPrompt({
+      now: new Date("2026-05-03T18:30:00Z"),
+      delegationDepth: 1,
+    });
+    expect(prompt).toContain("delegationDepth: 1");
+    expect(prompt).toContain(
+      `maxDelegationDepth: ${MAX_SUBAGENT_DELEGATION_DEPTH}`,
+    );
+    expect(prompt).toContain("spawn additional sub-agents only when");
+  });
+
+  it("tells a sub-agent at the cap it cannot delegate further", () => {
+    const prompt = buildRuntimeContextPrompt({
+      now: new Date("2026-05-03T18:30:00Z"),
+      delegationDepth: MAX_SUBAGENT_DELEGATION_DEPTH,
+    });
+    expect(prompt).toContain(
+      `delegationDepth: ${MAX_SUBAGENT_DELEGATION_DEPTH}`,
+    );
+    expect(prompt).toContain("cannot spawn further sub-agents");
+  });
+});
+
+describe("resolveMaxSubagentDelegationDepth", () => {
+  afterEach(() => {
+    delete process.env.AGENT_NATIVE_MAX_SUBAGENT_DEPTH;
+  });
+
+  it("defaults to MAX_SUBAGENT_DELEGATION_DEPTH when unset or blank", () => {
+    expect(resolveMaxSubagentDelegationDepth({})).toBe(
+      MAX_SUBAGENT_DELEGATION_DEPTH,
+    );
+    expect(
+      resolveMaxSubagentDelegationDepth({
+        AGENT_NATIVE_MAX_SUBAGENT_DEPTH: "  ",
+      }),
+    ).toBe(MAX_SUBAGENT_DELEGATION_DEPTH);
+  });
+
+  it("parses a valid non-negative integer override", () => {
+    expect(
+      resolveMaxSubagentDelegationDepth({
+        AGENT_NATIVE_MAX_SUBAGENT_DEPTH: "4",
+      }),
+    ).toBe(4);
+    expect(
+      resolveMaxSubagentDelegationDepth({
+        AGENT_NATIVE_MAX_SUBAGENT_DEPTH: "0",
+      }),
+    ).toBe(0);
+  });
+
+  it("falls back to the default on invalid values", () => {
+    for (const bad of ["abc", "-1", "2.5", "1e3", "0x4", "Infinity", "NaN"]) {
+      expect(
+        resolveMaxSubagentDelegationDepth({
+          AGENT_NATIVE_MAX_SUBAGENT_DEPTH: bad,
+        }),
+      ).toBe(MAX_SUBAGENT_DELEGATION_DEPTH);
+    }
+  });
+
+  it("clamps absurdly large overrides to the ceiling", () => {
+    expect(
+      resolveMaxSubagentDelegationDepth({
+        AGENT_NATIVE_MAX_SUBAGENT_DEPTH: "9999",
+      }),
+    ).toBe(16);
+  });
+
+  it("reads process.env by default", () => {
+    process.env.AGENT_NATIVE_MAX_SUBAGENT_DEPTH = "5";
+    expect(resolveMaxSubagentDelegationDepth()).toBe(5);
   });
 });

--- a/packages/core/src/agent/runtime-context.ts
+++ b/packages/core/src/agent/runtime-context.ts
@@ -1,6 +1,60 @@
 export interface RuntimeContextOptions {
   now?: Date;
   timezone?: string | null;
+  /**
+   * Delegation depth of the agent this prompt is built for. 0 = the top-level
+   * (user-facing) agent, 1 = a sub-agent spawned by the top-level agent, and so
+   * on. Threaded through so a spawned sub-agent knows how deep it sits and
+   * whether it is still allowed to delegate further. Omitted (or 0) for the
+   * top-level chat. See `MAX_SUBAGENT_DELEGATION_DEPTH`.
+   */
+  delegationDepth?: number;
+}
+
+/**
+ * Default hard cap on sub-agent delegation depth. The top-level agent is depth
+ * 0 and may spawn sub-agents (depth 1); those may spawn once more (depth 2);
+ * a spawn that would create a depth-3 sub-agent is refused. Borrowed from the
+ * "sub-agents must not infinitely spawn sub-agents" runaway/cost safety rail.
+ *
+ * Override at deploy time via `AGENT_NATIVE_MAX_SUBAGENT_DEPTH` (see
+ * `resolveMaxSubagentDelegationDepth`).
+ */
+export const MAX_SUBAGENT_DELEGATION_DEPTH = 2;
+
+/**
+ * Upper bound the env override is clamped to. A misconfigured very-large value
+ * would defeat the guardrail entirely, so we cap it at a still-generous depth.
+ */
+const MAX_SUBAGENT_DELEGATION_DEPTH_CEILING = 16;
+
+/** Env var name that overrides the default sub-agent delegation-depth cap. */
+export const MAX_SUBAGENT_DELEGATION_DEPTH_ENV =
+  "AGENT_NATIVE_MAX_SUBAGENT_DEPTH";
+
+/**
+ * Resolve the effective maximum sub-agent delegation depth.
+ *
+ * Reads `AGENT_NATIVE_MAX_SUBAGENT_DEPTH` and, when it parses to a finite
+ * non-negative integer, clamps it to `[0, MAX_SUBAGENT_DELEGATION_DEPTH_CEILING]`.
+ * Any invalid value (non-numeric, negative, NaN, Infinity, fractional) falls
+ * back to `MAX_SUBAGENT_DELEGATION_DEPTH` so a typo can never silently disable
+ * the guardrail. `0` is a valid override meaning "no sub-agents may be spawned".
+ */
+export function resolveMaxSubagentDelegationDepth(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env[MAX_SUBAGENT_DELEGATION_DEPTH_ENV];
+  if (raw === undefined) return MAX_SUBAGENT_DELEGATION_DEPTH;
+  const trimmed = raw.trim();
+  if (trimmed === "") return MAX_SUBAGENT_DELEGATION_DEPTH;
+  // Only accept plain non-negative integers; reject "2.5", "1e3", "0x4", etc.
+  if (!/^\d+$/.test(trimmed)) return MAX_SUBAGENT_DELEGATION_DEPTH;
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    return MAX_SUBAGENT_DELEGATION_DEPTH;
+  }
+  return Math.min(parsed, MAX_SUBAGENT_DELEGATION_DEPTH_CEILING);
 }
 
 function isValidTimezone(timezone: string): boolean {
@@ -48,6 +102,22 @@ export function buildRuntimeContextPrompt(
       ? options.timezone
       : "UTC";
 
+  const depth =
+    typeof options.delegationDepth === "number" &&
+    Number.isFinite(options.delegationDepth) &&
+    options.delegationDepth > 0
+      ? Math.floor(options.delegationDepth)
+      : 0;
+  const maxDepth = resolveMaxSubagentDelegationDepth();
+  const delegationLine =
+    depth > 0
+      ? `\ndelegationDepth: ${depth}\nmaxDelegationDepth: ${maxDepth}\n${
+          depth >= maxDepth
+            ? `You are a sub-agent at the maximum delegation depth (${maxDepth}); you cannot spawn further sub-agents. Do the work yourself.`
+            : `You are a sub-agent at delegation depth ${depth} (limit ${maxDepth}); spawn additional sub-agents only when truly necessary.`
+        }`
+      : "";
+
   return `
 
 <runtime-context>
@@ -55,7 +125,7 @@ currentUtc: ${now.toISOString()}
 currentDateUtc: ${formatDate(now, "UTC")}
 currentTimezone: ${timezone}
 currentDateInTimezone: ${formatDate(now, timezone)}
-currentTimeInTimezone: ${formatDateTime(now, timezone)}
+currentTimeInTimezone: ${formatDateTime(now, timezone)}${delegationLine}
 Use this runtime context as authoritative for relative dates such as today, yesterday, tomorrow, this week, and last month. Resolve relative dates to explicit calendar dates before querying data or creating artifacts, and include the exact date or date range in factual answers.
 </runtime-context>`;
 }

--- a/packages/core/src/agent/tool-call-journal.spec.ts
+++ b/packages/core/src/agent/tool-call-journal.spec.ts
@@ -3,6 +3,7 @@ import type { AgentChatEvent } from "./types.js";
 import {
   classifyToolCallJournal,
   buildResumeJournalNote,
+  findCompletedJournalEntry,
   isJournalEmpty,
 } from "./tool-call-journal.js";
 
@@ -164,5 +165,50 @@ describe("buildResumeJournalNote", () => {
     expect(note).toContain("…");
     // Result summary is capped well under the raw length.
     expect(note.length).toBeLessThan(longResult.length);
+  });
+});
+
+describe("findCompletedJournalEntry", () => {
+  it("matches completed entries by tool and input, and consumes each match once", () => {
+    const journal = classifyToolCallJournal([
+      start("sendEmail", { to: "a@example.com" }),
+      done("sendEmail", "sent A"),
+      start("sendEmail", { to: "b@example.com" }),
+      done("sendEmail", "sent B"),
+    ]);
+    const consumed = new Set<string>();
+
+    const first = findCompletedJournalEntry(
+      journal,
+      "sendEmail",
+      { to: "a@example.com" },
+      consumed,
+    );
+    expect(first?.result).toBe("sent A");
+    expect(
+      findCompletedJournalEntry(
+        journal,
+        "sendEmail",
+        { to: "a@example.com" },
+        consumed,
+      ),
+    ).toBeUndefined();
+
+    expect(
+      findCompletedJournalEntry(
+        journal,
+        "sendEmail",
+        { to: "b@example.com" },
+        consumed,
+      )?.result,
+    ).toBe("sent B");
+    expect(
+      findCompletedJournalEntry(
+        journal,
+        "sendEmail",
+        { to: "c@example.com" },
+        consumed,
+      ),
+    ).toBeUndefined();
   });
 });

--- a/packages/core/src/agent/tool-call-journal.spec.ts
+++ b/packages/core/src/agent/tool-call-journal.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import type { AgentChatEvent } from "./types.js";
+import {
+  classifyToolCallJournal,
+  buildResumeJournalNote,
+  isJournalEmpty,
+} from "./tool-call-journal.js";
+
+function start(tool: string, input?: Record<string, string>): AgentChatEvent {
+  return { type: "tool_start", tool, input: input ?? {} };
+}
+
+function done(tool: string, result: string): AgentChatEvent {
+  return { type: "tool_done", tool, result };
+}
+
+describe("classifyToolCallJournal", () => {
+  it("classifies one completed and one interrupted tool call", () => {
+    // sendEmail completed (has a tool_done); createTicket started but the run
+    // was cut off before its result was recorded.
+    const events: AgentChatEvent[] = [
+      start("sendEmail", { to: "a@example.com" }),
+      done("sendEmail", "Email sent to a@example.com (id msg_123)"),
+      start("createTicket", { title: "Bug" }),
+      // no matching tool_done for createTicket — interrupted
+    ];
+
+    const journal = classifyToolCallJournal(events);
+
+    expect(journal.completed).toHaveLength(1);
+    expect(journal.completed[0].tool).toBe("sendEmail");
+    expect(journal.completed[0].result).toContain("Email sent");
+
+    expect(journal.interrupted).toHaveLength(1);
+    expect(journal.interrupted[0].tool).toBe("createTicket");
+    expect(journal.interrupted[0].result).toBeUndefined();
+
+    expect(isJournalEmpty(journal)).toBe(false);
+  });
+
+  it("matches tool_done to the oldest open start of the same tool (FIFO)", () => {
+    const events: AgentChatEvent[] = [
+      start("readFile", { path: "a.ts" }),
+      start("readFile", { path: "b.ts" }),
+      done("readFile", "contents of a.ts"),
+      // second readFile never completed
+    ];
+
+    const journal = classifyToolCallJournal(events);
+
+    expect(journal.completed).toHaveLength(1);
+    expect(journal.completed[0].input).toEqual({ path: "a.ts" });
+    expect(journal.interrupted).toHaveLength(1);
+    expect(journal.interrupted[0].input).toEqual({ path: "b.ts" });
+  });
+
+  it("treats all tool calls as completed when every start has a done", () => {
+    const events: AgentChatEvent[] = [
+      { type: "text", text: "working on it" },
+      start("listFiles"),
+      done("listFiles", "a.ts\nb.ts"),
+      start("readFile", { path: "a.ts" }),
+      done("readFile", "ok"),
+      { type: "text", text: "done" },
+    ];
+
+    const journal = classifyToolCallJournal(events);
+
+    expect(journal.completed).toHaveLength(2);
+    expect(journal.interrupted).toHaveLength(0);
+  });
+
+  it("returns an empty journal for a turn with no tool calls", () => {
+    const events: AgentChatEvent[] = [
+      { type: "text", text: "hello" },
+      { type: "thinking", text: "considering" },
+      { type: "text", text: "world" },
+    ];
+
+    const journal = classifyToolCallJournal(events);
+
+    expect(journal.completed).toHaveLength(0);
+    expect(journal.interrupted).toHaveLength(0);
+    expect(isJournalEmpty(journal)).toBe(true);
+  });
+
+  it("drops not-yet-completed starts on a clear event (discarded partial output)", () => {
+    const events: AgentChatEvent[] = [
+      start("sendEmail", { to: "a@example.com" }),
+      // partial output discarded on resume — sendEmail start is dropped, not
+      // reported as interrupted.
+      { type: "clear" },
+      start("sendEmail", { to: "a@example.com" }),
+      done("sendEmail", "sent"),
+    ];
+
+    const journal = classifyToolCallJournal(events);
+
+    expect(journal.completed).toHaveLength(1);
+    expect(journal.interrupted).toHaveLength(0);
+  });
+
+  it("ignores a tool_done with no matching open start", () => {
+    const events: AgentChatEvent[] = [done("ghost", "result with no start")];
+    const journal = classifyToolCallJournal(events);
+    expect(journal.completed).toHaveLength(0);
+    expect(journal.interrupted).toHaveLength(0);
+  });
+});
+
+describe("buildResumeJournalNote", () => {
+  it("lists completed (don't re-run) and interrupted/unknown tool calls", () => {
+    const events: AgentChatEvent[] = [
+      start("sendEmail", { to: "a@example.com" }),
+      done("sendEmail", "Email sent (id msg_123)"),
+      start("createTicket", { title: "Bug" }),
+    ];
+
+    const note = buildResumeJournalNote(classifyToolCallJournal(events));
+
+    expect(note).not.toBeNull();
+    const text = note as string;
+    // Completed section instructs not to re-run and surfaces the result.
+    expect(text).toContain("Already completed");
+    expect(text).toContain("do NOT re-run");
+    expect(text).toContain("sendEmail");
+    expect(text).toContain("Email sent (id msg_123)");
+    // Interrupted section flags the unknown outcome.
+    expect(text).toContain("Interrupted / unknown outcome");
+    expect(text).toContain("createTicket");
+  });
+
+  it("returns null when there is nothing to report (no regression for normal resumes)", () => {
+    const events: AgentChatEvent[] = [{ type: "text", text: "no tools here" }];
+    expect(buildResumeJournalNote(classifyToolCallJournal(events))).toBeNull();
+  });
+
+  it("returns null for a clean turn where all tool calls completed", () => {
+    // All tool calls completed → nothing dangerous to flag. The structured note
+    // is suppressed so the existing continuation nudge is the only change to the
+    // prefix, exactly as before this feature.
+    const events: AgentChatEvent[] = [
+      start("listFiles"),
+      done("listFiles", "a.ts"),
+      start("readFile", { path: "a.ts" }),
+      done("readFile", "ok"),
+    ];
+    const journal = classifyToolCallJournal(events);
+    expect(journal.interrupted).toHaveLength(0);
+    // Completed-only still reports (so the model reuses results), but with no
+    // interrupted section.
+    const note = buildResumeJournalNote(journal);
+    expect(note).toContain("Already completed");
+    expect(note).not.toContain("Interrupted / unknown outcome");
+  });
+
+  it("truncates very long results in the summary", () => {
+    const longResult = "x".repeat(2000);
+    const events: AgentChatEvent[] = [
+      start("bigRead"),
+      done("bigRead", longResult),
+    ];
+    const note = buildResumeJournalNote(classifyToolCallJournal(events)) ?? "";
+    expect(note).toContain("…");
+    // Result summary is capped well under the raw length.
+    expect(note.length).toBeLessThan(longResult.length);
+  });
+});

--- a/packages/core/src/agent/tool-call-journal.ts
+++ b/packages/core/src/agent/tool-call-journal.ts
@@ -166,6 +166,51 @@ export function isJournalEmpty(journal: ToolCallJournal): boolean {
   return journal.completed.length === 0 && journal.interrupted.length === 0;
 }
 
+/**
+ * Find a COMPLETED journal entry that matches a tool call about to be
+ * dispatched, by tool name + input signature (position-independent — a resumed
+ * call may sit at a different order than the original). Used by the tool-layer
+ * hard-block in production-agent.ts/runToolCall to skip re-executing a side
+ * effect that already completed in a prior interrupted chunk: when this returns
+ * an entry, the loop returns `entry.result` instead of running the action.
+ *
+ * Returns the FIRST unmatched completed entry for that (name + input); the
+ * caller is expected to claim it (mark it consumed) so two identical fresh
+ * calls in the same turn don't both short-circuit on one journaled completion.
+ * Returns undefined when there is no completed entry for this exact call —
+ * including every fresh call, which must execute normally.
+ */
+export function findCompletedJournalEntry(
+  journal: ToolCallJournal,
+  toolName: string,
+  input: unknown,
+  consumedKeys?: Set<string>,
+): ToolCallJournalEntry | undefined {
+  const wantSig = inputSignature(normalizeInputForSignature(input));
+  for (const entry of journal.completed) {
+    if (entry.tool !== toolName) continue;
+    if (inputSignature(entry.input) !== wantSig) continue;
+    if (consumedKeys?.has(entry.key)) continue;
+    consumedKeys?.add(entry.key);
+    return entry;
+  }
+  return undefined;
+}
+
+/**
+ * Coerce an arbitrary tool input into the `Record<string, string>` shape the
+ * journal recorded at `tool_start` so signatures compare apples-to-apples. The
+ * ledger stores `tool_start.input` as a string map; the live call's `input` is
+ * the parsed object — both pass through `inputSignature`, which sorts keys and
+ * JSON-stringifies, so a plain object compares correctly.
+ */
+function normalizeInputForSignature(
+  input: unknown,
+): Record<string, string> | undefined {
+  if (input == null || typeof input !== "object") return undefined;
+  return input as Record<string, string>;
+}
+
 function summarizeResult(result: string | undefined): string {
   if (!result) return "(no result recorded)";
   const oneLine = result.replace(/\s+/g, " ").trim();

--- a/packages/core/src/agent/tool-call-journal.ts
+++ b/packages/core/src/agent/tool-call-journal.ts
@@ -1,0 +1,229 @@
+/**
+ * Per-turn tool-call journal — derived (not separately recorded) from the
+ * existing run-event ledger. Borrowed from Flue's durable-execution journal:
+ * when an agent run resumes after an interruption (gateway/transport drop, cold
+ * start, soft-timeout auto-continue), we classify the tool calls already in the
+ * ledger so the resumed model does NOT re-execute side effects it already
+ * completed (re-sending an email, re-creating a ticket) and so it is explicitly
+ * told about any tool call that started but whose outcome was never recorded.
+ *
+ * IMPORTANT — this is a pure read-over-the-ledger view. There is no new
+ * recording hook anywhere in the hot path. The classification reuses the exact
+ * positional `tool_start` → `tool_done` matching that `thread-data-builder.ts`
+ * already relies on to rebuild durable turns:
+ *
+ *   - `tool_start` events carry `{ tool, input }` (no tool-call id at this
+ *     layer; the ledger event stream omits it).
+ *   - `tool_done` events carry `{ tool, result }`.
+ *   - A `tool_done` is matched to the OLDEST still-open `tool_start` for the
+ *     same tool name (FIFO per tool), mirroring how the dispatch loop emits a
+ *     start immediately before its matching done.
+ *
+ * A `tool_start` with no matching `tool_done` is the dangerous case: the call
+ * began, its side effect may or may not have landed, and the interruption ate
+ * the result. We surface those as "interrupted / unknown outcome" so the model
+ * decides rather than blindly re-running.
+ *
+ * TODO(charlie-merge): optional hard-block — refuse re-execution of
+ * journaled-complete tool calls at the tool layer in
+ * production-agent.ts/runToolCall (CHARLIE owns that file). The prompt-level
+ * journal here is the shippable first cut; the tool-layer enforcement is the
+ * stronger guarantee and must wait until CHARLIE's loop edits land. When wiring
+ * it, key off `classifyToolCallJournal(...).completed` and short-circuit a
+ * re-dispatched write tool whose (tool name + input + order) matches a
+ * completed entry, returning the journaled result instead of executing.
+ */
+
+import type { AgentChatEvent } from "./types.js";
+
+/** A single recorded tool-call ledger entry, classified by outcome. */
+export interface ToolCallJournalEntry {
+  /**
+   * Stable-ish identity for this tool call within the turn. The ledger event
+   * stream has no tool-call id, so we key by tool name + a short input
+   * signature + positional order, exactly enough to disambiguate repeats of the
+   * same tool within one turn for human/model-readable reporting.
+   */
+  key: string;
+  /** Tool / action name (from the `tool_start` event). */
+  tool: string;
+  /** Tool input captured at `tool_start`, if any. */
+  input?: Record<string, string>;
+  /** 0-based position of the `tool_start` among all tool calls in the turn. */
+  order: number;
+  /** Result text from the matched `tool_done`, when the call completed. */
+  result?: string;
+}
+
+/** Result of classifying one turn's ledger events. */
+export interface ToolCallJournal {
+  /** Tool calls with a matching `tool_done` — already ran, do NOT re-run. */
+  completed: ToolCallJournalEntry[];
+  /**
+   * Tool calls with a `tool_start` but no matching `tool_done` — interrupted,
+   * outcome unknown. The model must decide whether re-running is safe.
+   */
+  interrupted: ToolCallJournalEntry[];
+}
+
+/** Max length of an input signature included in a journal key (debug-readable). */
+const INPUT_SIGNATURE_MAX_CHARS = 120;
+
+/** Max length of a per-tool-call result summary surfaced in the resume note. */
+const RESULT_SUMMARY_MAX_CHARS = 400;
+
+function inputSignature(input: Record<string, string> | undefined): string {
+  if (!input) return "";
+  let sig: string;
+  try {
+    // Stable key order so the same logical input produces the same signature
+    // regardless of how the engine serialized the object.
+    const sorted = Object.keys(input)
+      .sort()
+      .reduce<Record<string, string>>((acc, k) => {
+        acc[k] = input[k];
+        return acc;
+      }, {});
+    sig = JSON.stringify(sorted);
+  } catch {
+    sig = String(input);
+  }
+  return sig.length > INPUT_SIGNATURE_MAX_CHARS
+    ? sig.slice(0, INPUT_SIGNATURE_MAX_CHARS)
+    : sig;
+}
+
+/**
+ * Classify a single turn's recorded events into completed vs interrupted tool
+ * calls. Pure and side-effect free — given the same events it always returns
+ * the same journal. A `clear` event resets the per-turn tally exactly as the
+ * thread rebuild does, so partial streamed output that was discarded on resume
+ * doesn't leave phantom open tool calls.
+ */
+export function classifyToolCallJournal(
+  events: readonly AgentChatEvent[],
+): ToolCallJournal {
+  // Open tool_start entries awaiting a matching tool_done, in FIFO order. We
+  // index by tool name so a tool_done matches the OLDEST open start for that
+  // same tool — the dispatch loop always emits start-then-done per call, so the
+  // first unmatched start of a given name is the one this done belongs to.
+  const openByTool = new Map<string, ToolCallJournalEntry[]>();
+  const completed: ToolCallJournalEntry[] = [];
+  let order = 0;
+
+  for (const event of events) {
+    if (event.type === "clear") {
+      // Discarded partial output: drop any not-yet-completed starts so they
+      // aren't reported as interrupted. Already-completed entries stay.
+      openByTool.clear();
+      continue;
+    }
+
+    if (event.type === "tool_start") {
+      const tool = event.tool ?? "unknown";
+      const input = (event.input ?? undefined) as
+        | Record<string, string>
+        | undefined;
+      const entry: ToolCallJournalEntry = {
+        key: `${tool}#${order}:${inputSignature(input)}`,
+        tool,
+        ...(input ? { input } : {}),
+        order,
+      };
+      order += 1;
+      const queue = openByTool.get(tool);
+      if (queue) queue.push(entry);
+      else openByTool.set(tool, [entry]);
+      continue;
+    }
+
+    if (event.type === "tool_done") {
+      const tool = event.tool ?? "unknown";
+      const queue = openByTool.get(tool);
+      const entry = queue?.shift();
+      if (entry) {
+        entry.result = event.result ?? "";
+        completed.push(entry);
+      }
+      // A tool_done with no open start is ignored — it can't be re-associated
+      // and re-reporting a duplicate done would be noise.
+      continue;
+    }
+  }
+
+  // Anything still open never received a tool_done → interrupted / unknown.
+  const interrupted: ToolCallJournalEntry[] = [];
+  for (const queue of openByTool.values()) {
+    for (const entry of queue) interrupted.push(entry);
+  }
+  interrupted.sort((a, b) => a.order - b.order);
+
+  return { completed, interrupted };
+}
+
+/** True when the journal has nothing worth telling a resuming model about. */
+export function isJournalEmpty(journal: ToolCallJournal): boolean {
+  return journal.completed.length === 0 && journal.interrupted.length === 0;
+}
+
+function summarizeResult(result: string | undefined): string {
+  if (!result) return "(no result recorded)";
+  const oneLine = result.replace(/\s+/g, " ").trim();
+  if (oneLine.length === 0) return "(empty result)";
+  return oneLine.length > RESULT_SUMMARY_MAX_CHARS
+    ? oneLine.slice(0, RESULT_SUMMARY_MAX_CHARS) + "…"
+    : oneLine;
+}
+
+function describeInput(input: Record<string, string> | undefined): string {
+  if (!input) return "";
+  const sig = inputSignature(input);
+  return sig && sig !== "{}" ? ` input: ${sig}` : "";
+}
+
+/**
+ * Build the structured resume note injected on auto-continue. Returns `null`
+ * when there are no completed or interrupted tool calls to report, so the
+ * caller can preserve the exact pre-existing "continue from where you left off"
+ * behavior on normal resumes (no regression for turns with no tool activity).
+ *
+ * The note is intentionally a flat, model-readable block: a list of already-run
+ * tool calls (with short results) the model must NOT re-run, and a separate list
+ * of interrupted calls whose outcome is unknown for the model to decide on.
+ */
+export function buildResumeJournalNote(
+  journal: ToolCallJournal,
+): string | null {
+  if (isJournalEmpty(journal)) return null;
+
+  const lines: string[] = [];
+  lines.push(
+    "Tool-call journal from the interrupted attempt (derived from the durable run ledger):",
+  );
+
+  if (journal.completed.length > 0) {
+    lines.push("");
+    lines.push(
+      "Already completed (do NOT re-run these — their side effects already happened; reuse the results below):",
+    );
+    for (const entry of journal.completed) {
+      lines.push(
+        `- ${entry.tool}${describeInput(entry.input)} → ${summarizeResult(entry.result)}`,
+      );
+    }
+  }
+
+  if (journal.interrupted.length > 0) {
+    lines.push("");
+    lines.push(
+      "Interrupted / unknown outcome (these started but no result was recorded before the cut-off — do not assume they succeeded OR failed; if re-running could duplicate a side effect, verify state first):",
+    );
+    for (const entry of journal.interrupted) {
+      lines.push(
+        `- ${entry.tool}${describeInput(entry.input)} → (no result recorded)`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -137,6 +137,16 @@ export interface AgentChatRequest {
   scope?: AgentChatScope | null;
   /** When true, expose this chat turn as a user-visible run in RunsTray. */
   trackInRunsTray?: boolean;
+  /**
+   * Approval grants for human-in-the-loop actions. Each entry is a stable
+   * approval key (see the `approval_required` event's `approvalKey`). When the
+   * agent calls an action declared `needsApproval`, the loop pauses and emits
+   * `approval_required`; the client re-issues the turn (typically an empty
+   * continuation) with the approved call's key here so the gate lets it run.
+   * Keys not present here keep the action paused. The model never sees or sets
+   * this — it is supplied by the human's approve affordance.
+   */
+  approvedToolCalls?: string[];
 }
 
 export type AgentChatEvent =
@@ -149,6 +159,21 @@ export type AgentChatEvent =
       tool: string;
       result: string;
       mcpApp?: AgentMcpAppPayload;
+    }
+  | {
+      /**
+       * The agent tried to call an action declared `needsApproval` and the loop
+       * paused instead of executing it. The client should surface an
+       * approve/deny affordance; on approve, re-issue the turn with
+       * `approvedToolCalls: [approvalKey]` so the gate lets this call run.
+       */
+      type: "approval_required";
+      tool: string;
+      input: Record<string, string>;
+      /** Stable key the client echoes back in `approvedToolCalls` to approve. */
+      approvalKey: string;
+      /** The model-side tool-call id for this paused call, when available. */
+      toolCallId?: string;
     }
   | {
       type: "agent_call";

--- a/packages/core/src/cli/add.spec.ts
+++ b/packages/core/src/cli/add.spec.ts
@@ -1,0 +1,360 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildGenericUrlBlueprint,
+  formatCatalog,
+  listBlueprintNames,
+  listCatalog,
+  listKinds,
+  looksLikeUrl,
+  parseAddArgs,
+  resolveBlueprint,
+  resolveBlueprintsRoot,
+  runAdd,
+  AddResolutionError,
+} from "./add.js";
+
+/**
+ * The real shipped blueprints directory: `packages/core/blueprints`. This file
+ * lives at `src/cli/add.spec.ts`, so the package root is two levels up.
+ */
+const REPO_BLUEPRINTS = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../blueprints",
+);
+
+/** Capture stdout/stderr passed through the injectable IO shim. */
+function capture() {
+  let out = "";
+  let err = "";
+  return {
+    io: {
+      out: (s: string) => {
+        out += s;
+      },
+      err: (s: string) => {
+        err += s;
+      },
+    },
+    get out() {
+      return out;
+    },
+    get err() {
+      return err;
+    },
+  };
+}
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+function makeTempBlueprints(
+  layout: Record<string, Record<string, string>>,
+): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "an-blueprints-"));
+  tmpDirs.push(root);
+  const blueprints = path.join(root, "blueprints");
+  for (const [kind, files] of Object.entries(layout)) {
+    fs.mkdirSync(path.join(blueprints, kind), { recursive: true });
+    for (const [name, body] of Object.entries(files)) {
+      fs.writeFileSync(
+        path.join(blueprints, kind, `${name}.md`),
+        body,
+        "utf-8",
+      );
+    }
+  }
+  return blueprints;
+}
+
+describe("add — shipped blueprints", () => {
+  it("ships the four seeded kinds with at least one blueprint each", () => {
+    const kinds = listKinds(REPO_BLUEPRINTS);
+    for (const kind of ["provider", "channel", "sandbox", "action"]) {
+      expect(kinds).toContain(kind);
+      expect(listBlueprintNames(REPO_BLUEPRINTS, kind).length).toBeGreaterThan(
+        0,
+      );
+    }
+  });
+
+  it("resolves the canonical seeded blueprints by kind + name", () => {
+    const cases: Array<[string, string]> = [
+      ["provider", "stripe"],
+      ["channel", "discord"],
+      ["sandbox", "docker"],
+      ["action", "crud"],
+    ];
+    for (const [kind, name] of cases) {
+      const resolved = resolveBlueprint({
+        kind,
+        nameOrUrl: name,
+        root: REPO_BLUEPRINTS,
+      });
+      expect(resolved.source).toMatchObject({ kind: "curated", name });
+      expect(resolved.markdown).toContain("# Blueprint:");
+      // Each blueprint must reference the verification step and forbid secrets.
+      expect(resolved.markdown.toLowerCase()).toContain("verify");
+    }
+  });
+});
+
+describe("resolveBlueprintsRoot", () => {
+  it("honors an explicit override", () => {
+    expect(resolveBlueprintsRoot("/tmp/whatever")).toBe("/tmp/whatever");
+  });
+
+  it("resolves the package-root blueprints dir from src/cli (tsx layout)", () => {
+    const root = resolveBlueprintsRoot();
+    expect(fs.existsSync(root)).toBe(true);
+    expect(path.basename(root)).toBe("blueprints");
+    // The source resolver result must equal the real shipped directory.
+    expect(path.resolve(root)).toBe(path.resolve(REPO_BLUEPRINTS));
+  });
+
+  it("works when the module is two levels under the package root (dist layout)", () => {
+    // Simulate the published layout: <pkg>/blueprints + <pkg>/dist/cli, and
+    // confirm the `../../blueprints` resolution (with upward-walk fallback)
+    // finds it. We assert via the override-free upward walk using a temp tree.
+    const pkg = fs.mkdtempSync(path.join(os.tmpdir(), "an-pkg-"));
+    tmpDirs.push(pkg);
+    fs.mkdirSync(path.join(pkg, "blueprints", "provider"), { recursive: true });
+    fs.writeFileSync(
+      path.join(pkg, "blueprints", "provider", "demo.md"),
+      "# Blueprint: demo\nVerify it.\n",
+    );
+    fs.mkdirSync(path.join(pkg, "dist", "cli"), { recursive: true });
+
+    // The resolver walks up from the module dir; emulate by resolving relative
+    // to the simulated dist/cli location.
+    const distCli = path.join(pkg, "dist", "cli");
+    const viaRelative = path.resolve(distCli, "../../blueprints");
+    expect(fs.existsSync(viaRelative)).toBe(true);
+    expect(listBlueprintNames(viaRelative, "provider")).toEqual(["demo"]);
+  });
+});
+
+describe("looksLikeUrl", () => {
+  it("treats http(s) values as URLs and names as names", () => {
+    expect(looksLikeUrl("https://docs.example.com/api")).toBe(true);
+    expect(looksLikeUrl("http://example.com")).toBe(true);
+    expect(looksLikeUrl("  https://x.dev  ")).toBe(true);
+    expect(looksLikeUrl("stripe")).toBe(false);
+    expect(looksLikeUrl("my-provider")).toBe(false);
+  });
+});
+
+describe("resolveBlueprint", () => {
+  const root = () =>
+    makeTempBlueprints({
+      provider: { stripe: "# Blueprint: stripe\nVerify it.\n" },
+      channel: { discord: "# Blueprint: discord\nVerify it.\n" },
+    });
+
+  it("resolves a curated blueprint by kind + name", () => {
+    const resolved = resolveBlueprint({
+      kind: "provider",
+      nameOrUrl: "stripe",
+      root: root(),
+    });
+    expect(resolved.markdown).toContain("# Blueprint: stripe");
+    expect(resolved.source).toMatchObject({
+      kind: "curated",
+      blueprintKind: "provider",
+      name: "stripe",
+    });
+  });
+
+  it("emits a generic research blueprint when given a URL", () => {
+    const url = "https://docs.example.com/v2/api";
+    const resolved = resolveBlueprint({
+      kind: "provider",
+      nameOrUrl: url,
+      root: root(),
+    });
+    expect(resolved.source).toMatchObject({ kind: "generic-url", url });
+    expect(resolved.markdown).toContain(url);
+    expect(resolved.markdown).toContain("Research seed");
+    // The provider generic guidance must mention the provider-api substrate.
+    expect(resolved.markdown).toContain("provider-api");
+  });
+
+  it("auto-selects the only blueprint when a kind has exactly one", () => {
+    const single = makeTempBlueprints({
+      sandbox: { docker: "# Blueprint: docker\nVerify it.\n" },
+    });
+    const resolved = resolveBlueprint({ kind: "sandbox", root: single });
+    expect(resolved.source).toMatchObject({ kind: "curated", name: "docker" });
+  });
+
+  it("throws AddResolutionError for an unknown kind", () => {
+    expect(() =>
+      resolveBlueprint({ kind: "nope", nameOrUrl: "x", root: root() }),
+    ).toThrow(AddResolutionError);
+  });
+
+  it("throws AddResolutionError for an unknown name within a known kind", () => {
+    expect(() =>
+      resolveBlueprint({ kind: "provider", nameOrUrl: "ghost", root: root() }),
+    ).toThrow(AddResolutionError);
+  });
+
+  it("asks the user to pick when a kind has multiple blueprints and no name", () => {
+    const multi = makeTempBlueprints({
+      provider: {
+        stripe: "# a\nVerify.\n",
+        twilio: "# b\nVerify.\n",
+      },
+    });
+    expect(() => resolveBlueprint({ kind: "provider", root: multi })).toThrow(
+      /stripe|twilio/,
+    );
+  });
+});
+
+describe("listKinds / listCatalog / formatCatalog", () => {
+  it("lists kinds and names sorted", () => {
+    const r = makeTempBlueprints({
+      provider: { stripe: "x", twilio: "x" },
+      channel: { discord: "x" },
+    });
+    expect(listKinds(r)).toEqual(["channel", "provider"]);
+    expect(listBlueprintNames(r, "provider")).toEqual(["stripe", "twilio"]);
+    expect(listCatalog(r)).toEqual([
+      { kind: "channel", names: ["discord"] },
+      { kind: "provider", names: ["stripe", "twilio"] },
+    ]);
+  });
+
+  it("formats a human-readable catalog", () => {
+    const r = makeTempBlueprints({ provider: { stripe: "x" } });
+    const text = formatCatalog(r);
+    expect(text).toContain("Available blueprints:");
+    expect(text).toContain("provider");
+    expect(text).toContain("stripe");
+  });
+});
+
+describe("parseAddArgs", () => {
+  it("parses positionals and flags", () => {
+    expect(parseAddArgs(["provider", "stripe"])).toMatchObject({
+      positionals: ["provider", "stripe"],
+      list: false,
+    });
+    expect(parseAddArgs(["--list"]).list).toBe(true);
+    expect(parseAddArgs(["-l"]).list).toBe(true);
+    expect(parseAddArgs(["--print", "provider", "stripe"])).toMatchObject({
+      print: true,
+      positionals: ["provider", "stripe"],
+    });
+    expect(parseAddArgs(["--help"]).help).toBe(true);
+  });
+
+  it("ignores '--' separators and unknown flags", () => {
+    expect(parseAddArgs(["--", "provider", "stripe", "--weird"])).toMatchObject(
+      {
+        positionals: ["provider", "stripe"],
+      },
+    );
+  });
+});
+
+describe("runAdd (CLI entry)", () => {
+  const root = () =>
+    makeTempBlueprints({
+      provider: { stripe: "# Blueprint: stripe\nVerify it.\n" },
+      action: { crud: "# Blueprint: crud\nVerify it.\n" },
+    });
+
+  it("prints a curated blueprint to stdout and exits 0", () => {
+    const c = capture();
+    const code = runAdd(["provider", "stripe"], { ...c.io, root: root() });
+    expect(code).toBe(0);
+    expect(c.out).toContain("# Blueprint: stripe");
+    expect(c.err).toBe("");
+  });
+
+  it("--print is an accepted no-op alias for the default print", () => {
+    const c = capture();
+    const code = runAdd(["--print", "provider", "stripe"], {
+      ...c.io,
+      root: root(),
+    });
+    expect(code).toBe(0);
+    expect(c.out).toContain("# Blueprint: stripe");
+  });
+
+  it("emits the generic blueprint for a URL", () => {
+    const c = capture();
+    const code = runAdd(["provider", "https://docs.example.com/api"], {
+      ...c.io,
+      root: root(),
+    });
+    expect(code).toBe(0);
+    expect(c.out).toContain("https://docs.example.com/api");
+    expect(c.out).toContain("Research seed");
+  });
+
+  it("--list prints the catalog to stdout and exits 0", () => {
+    const c = capture();
+    const code = runAdd(["--list"], { ...c.io, root: root() });
+    expect(code).toBe(0);
+    expect(c.out).toContain("Available blueprints:");
+    expect(c.out).toContain("provider");
+  });
+
+  it("no args prints the catalog and exits 0", () => {
+    const c = capture();
+    const code = runAdd([], { ...c.io, root: root() });
+    expect(code).toBe(0);
+    expect(c.out).toContain("Available blueprints:");
+  });
+
+  it("unknown kind writes to stderr and exits non-zero", () => {
+    const c = capture();
+    const code = runAdd(["bogus", "thing"], { ...c.io, root: root() });
+    expect(code).toBe(1);
+    expect(c.err).toContain("Unknown blueprint kind");
+    // The error must list what IS available.
+    expect(c.err).toContain("provider");
+    expect(c.out).toBe("");
+  });
+
+  it("unknown name within a known kind exits non-zero", () => {
+    const c = capture();
+    const code = runAdd(["provider", "ghost"], { ...c.io, root: root() });
+    expect(code).toBe(1);
+    expect(c.err).toContain("Unknown provider blueprint");
+  });
+
+  it("--help prints usage to stdout and exits 0", () => {
+    const c = capture();
+    const code = runAdd(["--help"], { ...c.io, root: root() });
+    expect(code).toBe(0);
+    expect(c.out).toContain("agent-native add");
+  });
+});
+
+describe("buildGenericUrlBlueprint", () => {
+  it("embeds the URL and kind-specific guidance", () => {
+    const md = buildGenericUrlBlueprint("channel", "https://discord.com/dev");
+    expect(md).toContain("https://discord.com/dev");
+    expect(md).toContain("PlatformAdapter");
+    expect(md).toContain("integration-webhooks");
+  });
+
+  it("falls back to default guidance for an unknown kind", () => {
+    const md = buildGenericUrlBlueprint("widget", "https://x.dev");
+    expect(md).toContain("https://x.dev");
+    expect(md).toContain("provider-api");
+  });
+});

--- a/packages/core/src/cli/add.ts
+++ b/packages/core/src/cli/add.ts
@@ -1,0 +1,425 @@
+/**
+ * `agent-native add <kind> [name|url]` — the **blueprint installer**.
+ *
+ * Borrowed from Flue's `flue add`: instead of being a dumb scaffolder that
+ * writes files for you, this command emits a curated Markdown *integration
+ * blueprint* to stdout. You pipe that blueprint into your own coding agent,
+ * which applies the changes against the live repo:
+ *
+ *   agent-native add provider stripe | claude
+ *   agent-native add channel discord  | codex
+ *
+ * This fits the agent-applies-changes, filesystem-first house style: the
+ * framework supplies the recipe (the canonical files to touch, the rules to
+ * honor, the verification step), and the coding agent does the editing with
+ * full repo context.
+ *
+ * A bare name resolves a curated blueprint from `blueprints/<kind>/<name>.md`.
+ * A URL instead of a name emits a GENERIC "research-and-integrate" blueprint
+ * for that kind with the URL embedded as the research starting point (mirrors
+ * Flue: a URL is a research seed, not a known recipe).
+ *
+ * Blueprint `.md` files ship in the published package via the `blueprints`
+ * entry in `package.json` `files`, so they live at
+ * `node_modules/@agent-native/core/blueprints/**` at runtime. Resolution works
+ * both from source (tsx: `src/cli` → `../../blueprints`) and from the compiled
+ * package (`dist/cli` → `../../blueprints`), with an upward-walk fallback.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** A coarse classification of what `add` resolved for a given invocation. */
+export type AddBlueprintSource =
+  | { kind: "curated"; blueprintKind: string; name: string; path: string }
+  | { kind: "generic-url"; blueprintKind: string; url: string };
+
+export interface ResolvedBlueprint {
+  /** The Markdown to print to stdout (piped into a coding agent). */
+  markdown: string;
+  source: AddBlueprintSource;
+}
+
+/**
+ * Locate the directory that holds the blueprint `.md` recipes.
+ *
+ * Both `src/cli` (tsx/source) and `dist/cli` (published) sit two levels under
+ * the package root, where `blueprints/` lives, so `../../blueprints` from this
+ * module's directory is the primary path. We additionally walk upward looking
+ * for a `blueprints` directory as a resilience fallback (e.g. unusual bundler
+ * layouts). An explicit override is honored for tests.
+ */
+export function resolveBlueprintsRoot(overrideRoot?: string): string {
+  if (overrideRoot) return overrideRoot;
+
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const primary = path.resolve(here, "../../blueprints");
+  if (isDir(primary)) return primary;
+
+  // Fallback: walk up from this module looking for a sibling `blueprints` dir.
+  let dir = here;
+  for (let i = 0; i < 8; i += 1) {
+    const candidate = path.join(dir, "blueprints");
+    if (isDir(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  // Return the primary path even if missing so error messages are concrete.
+  return primary;
+}
+
+function isDir(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** True for an argument that should be treated as a research URL, not a name. */
+export function looksLikeUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value.trim());
+}
+
+/** List the blueprint kinds (subdirectories) available, sorted. */
+export function listKinds(root: string): string[] {
+  if (!isDir(root)) return [];
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+}
+
+/** List the blueprint names available under a kind, sorted (no `.md`). */
+export function listBlueprintNames(root: string, kind: string): string[] {
+  const dir = path.join(root, kind);
+  if (!isDir(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith(".md"))
+    .map((e) => e.name.slice(0, -".md".length))
+    .sort();
+}
+
+/** A flat catalog of every kind and its blueprint names. */
+export function listCatalog(root: string): Array<{
+  kind: string;
+  names: string[];
+}> {
+  return listKinds(root).map((kind) => ({
+    kind,
+    names: listBlueprintNames(root, kind),
+  }));
+}
+
+/** Render the `--list` / no-args catalog text. */
+export function formatCatalog(root: string): string {
+  const catalog = listCatalog(root);
+  const lines: string[] = [];
+  lines.push("Available blueprints:");
+  lines.push("");
+  if (catalog.length === 0) {
+    lines.push("  (none found)");
+  } else {
+    for (const { kind, names } of catalog) {
+      const shown =
+        names.length > 0 ? names.join(", ") : "(generic — pass a URL)";
+      lines.push(`  ${kind.padEnd(10)} ${shown}`);
+    }
+  }
+  lines.push("");
+  lines.push("Usage:");
+  lines.push(
+    "  agent-native add <kind> <name>            Print a curated blueprint",
+  );
+  lines.push(
+    "  agent-native add <kind> <https://docs…>   Research-and-integrate from a URL",
+  );
+  lines.push("  agent-native add --list                   Show this list");
+  lines.push("");
+  lines.push("Pipe a blueprint into your coding agent to apply it:");
+  lines.push("  agent-native add provider stripe | claude");
+  lines.push("  agent-native add channel discord | codex");
+  return lines.join("\n");
+}
+
+/**
+ * Build the generic "research-and-integrate" blueprint emitted when the user
+ * passes a URL instead of a known blueprint name. Mirrors Flue: a URL is a
+ * research seed. We keep this self-contained — the coding agent reading it has
+ * no other context.
+ */
+export function buildGenericUrlBlueprint(kind: string, url: string): string {
+  const kindGuidance = GENERIC_KIND_GUIDANCE[kind] ?? GENERIC_DEFAULT_GUIDANCE;
+  return `# Blueprint: integrate a new ${kind} from a URL
+
+You are a coding agent working inside an **agent-native** app (a repo built on
+\`@agent-native/core\`). Apply this blueprint as real source changes on the
+current branch. Do not just describe the work — research, implement, then verify.
+
+## Research seed
+
+Start from this URL and follow it for the API/protocol/contract you need:
+
+  ${url}
+
+Fetch it (and the pages it links to) to learn the real endpoints, auth model,
+payload shapes, and any signature/verification requirements. Do not guess from
+training data — the docs are the source of truth, and package/API versions
+drift. Confirm the current version before writing code.
+
+## What you're adding
+
+A new **${kind}** integration. ${kindGuidance}
+
+## How agent-native wants it built
+
+- **Actions are the single source of truth.** Add app operations in \`actions/\`
+  with \`defineAction\` (Zod schema). The agent calls them as tools; the frontend
+  calls the same action through \`useActionQuery\` / \`useActionMutation\`. Do NOT
+  add \`/api/*\` or Nitro pass-through routes that just wrap an action.
+- **Prefer the provider-api substrate for external HTTP.** For ad-hoc reads
+  against a third-party API, register the provider with
+  \`@agent-native/core/provider-api\` and expose the
+  \`provider-api-catalog\` / \`provider-api-docs\` / \`provider-api-request\` trio
+  instead of one rigid action per endpoint. First-class actions are shortcuts,
+  not capability limits.
+- **Read the relevant skill before editing** — \`actions\`,
+  \`integration-webhooks\`, \`secrets\`, \`onboarding\`, \`sharing\`, \`security\` —
+  for the area you're touching.
+- **Never hardcode secrets.** Read API keys / tokens / signing secrets from the
+  secret store (\`readAppSecret\`, the provider credential adapter, OAuth token
+  helpers) at call time. Use obviously-fake placeholders in any example
+  (e.g. \`sk_test_PLACEHOLDER_xxx\`), never a real credential.
+- **Scope ownable data.** Tables with \`ownableColumns()\` require
+  \`accessFilter\` / \`resolveAccess\` / \`assertAccess\`; fail closed.
+- **Changeset.** If you edit a publishable package's source
+  (\`packages/core\`, \`packages/dispatch\`, \`packages/scheduling\`,
+  \`packages/pinpoint\`), add a \`.changeset/*.md\`.
+
+## Verify
+
+1. \`agent-native typecheck\` (or \`tsc --noEmit\`) passes.
+2. Add a focused \`*.spec.ts\` for the new surface and run it.
+3. Exercise the real workflow end to end: invoke the new action from the agent
+   chat (and the UI if applicable), and confirm the external call round-trips
+   with credentials injected and secrets redacted.
+`;
+}
+
+const GENERIC_DEFAULT_GUIDANCE =
+  "Identify whether it is best modeled as an action, a provider-api integration, " +
+  "an inbound channel adapter, or a sandbox backend, and follow that area's skill.";
+
+const GENERIC_KIND_GUIDANCE: Record<string, string> = {
+  provider:
+    "Wire it into the provider-api substrate (`@agent-native/core/provider-api`): " +
+    "register the base URL, auth style, credential key, and docs URLs, then expose " +
+    "the `provider-api-catalog` / `provider-api-docs` / `provider-api-request` trio " +
+    "so any endpoint is reachable without one action per endpoint.",
+  channel:
+    "Implement a `PlatformAdapter` (see " +
+    "`packages/core/src/integrations/types.ts` and the adapters under " +
+    "`packages/core/src/integrations/adapters/`) and register it in " +
+    "`getDefaultAdapters()` in `packages/core/src/integrations/plugin.ts`. " +
+    "Enqueue to SQL and return 200 fast; run the agent loop in the separate " +
+    "`_process-task` execution. Read the `integration-webhooks` skill.",
+  sandbox:
+    "Implement the `SandboxAdapter` seam in " +
+    "`packages/core/src/coding-tools/sandbox/` (mirror " +
+    "`local-child-process-adapter.ts`) and select it via `AGENT_NATIVE_SANDBOX` " +
+    "or `registerSandboxAdapter()`. The adapter only runs the already-prepared, " +
+    "non-secret module source — it never sees app secrets.",
+  action:
+    "Add a single multi-surface `defineAction` in `actions/` with a Zod schema. " +
+    "Keep the surface small and orthogonal (one CRUD-style `update` over N " +
+    "per-field actions). Read the `actions` skill.",
+};
+
+/**
+ * Resolve a blueprint for a `kind` + optional `name`/`url`.
+ *
+ * - A known name → the curated `blueprints/<kind>/<name>.md`.
+ * - A URL → the generic research-and-integrate blueprint for the kind.
+ * - Unknown name → throws `AddResolutionError` listing what's available.
+ */
+export function resolveBlueprint(opts: {
+  kind: string;
+  nameOrUrl?: string;
+  root: string;
+}): ResolvedBlueprint {
+  const { kind, nameOrUrl, root } = opts;
+  const kinds = listKinds(root);
+
+  if (!kinds.includes(kind)) {
+    throw new AddResolutionError(
+      `Unknown blueprint kind: ${kind}\n\n${formatCatalog(root)}`,
+    );
+  }
+
+  // A URL seed → generic blueprint for the kind.
+  if (nameOrUrl && looksLikeUrl(nameOrUrl)) {
+    return {
+      markdown: buildGenericUrlBlueprint(kind, nameOrUrl.trim()),
+      source: {
+        kind: "generic-url",
+        blueprintKind: kind,
+        url: nameOrUrl.trim(),
+      },
+    };
+  }
+
+  const names = listBlueprintNames(root, kind);
+
+  // No name given: if exactly one curated blueprint exists, use it; otherwise
+  // ask the user to pick one (or pass a URL for the generic path).
+  if (!nameOrUrl) {
+    if (names.length === 1) {
+      return loadCurated(root, kind, names[0]);
+    }
+    throw new AddResolutionError(
+      `Specify a ${kind} blueprint name or a URL.\n` +
+        `  Available ${kind} blueprints: ${
+          names.length ? names.join(", ") : "(none — pass a URL)"
+        }\n` +
+        `  Or research from a URL: agent-native add ${kind} https://…`,
+    );
+  }
+
+  if (!names.includes(nameOrUrl)) {
+    throw new AddResolutionError(
+      `Unknown ${kind} blueprint: ${nameOrUrl}\n` +
+        `  Available ${kind} blueprints: ${
+          names.length ? names.join(", ") : "(none)"
+        }\n` +
+        `  Or research from a URL: agent-native add ${kind} https://…`,
+    );
+  }
+
+  return loadCurated(root, kind, nameOrUrl);
+}
+
+function loadCurated(
+  root: string,
+  kind: string,
+  name: string,
+): ResolvedBlueprint {
+  const filePath = path.join(root, kind, `${name}.md`);
+  const markdown = fs.readFileSync(filePath, "utf-8");
+  return {
+    markdown,
+    source: { kind: "curated", blueprintKind: kind, name, path: filePath },
+  };
+}
+
+/** Thrown for an unknown kind/name; the CLI prints the message and exits 1. */
+export class AddResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AddResolutionError";
+  }
+}
+
+interface ParsedAddArgs {
+  list: boolean;
+  help: boolean;
+  /** Accepted as an explicit no-op alias for the default print behavior. */
+  print: boolean;
+  positionals: string[];
+}
+
+export function parseAddArgs(argv: string[]): ParsedAddArgs {
+  const out: ParsedAddArgs = {
+    list: false,
+    help: false,
+    print: false,
+    positionals: [],
+  };
+  for (const arg of argv) {
+    if (arg === "--") continue;
+    if (arg === "--list" || arg === "-l") out.list = true;
+    else if (arg === "--help" || arg === "-h") out.help = true;
+    else if (arg === "--print" || arg === "-p") out.print = true;
+    else if (arg.startsWith("-")) {
+      // Ignore unknown flags rather than misparse them as a name.
+      continue;
+    } else out.positionals.push(arg);
+  }
+  return out;
+}
+
+const HELP = `agent-native add — emit an integration blueprint for your coding agent.
+
+Instead of scaffolding files, \`add\` prints a curated Markdown recipe to stdout.
+Pipe it into a coding agent (Claude Code, Codex, …) and it applies the changes
+against your live repo, the agent-native way.
+
+Usage:
+  agent-native add <kind> <name>            Print a curated blueprint
+  agent-native add <kind> <https://docs…>   Research-and-integrate from a URL
+  agent-native add --list                   List available kinds and blueprints
+
+Examples:
+  agent-native add provider stripe | claude
+  agent-native add channel discord | codex
+  agent-native add sandbox docker
+  agent-native add action crud
+  agent-native add provider https://docs.example.com/api | claude
+
+Options:
+  -l, --list     List available blueprint kinds and names
+  -p, --print    Print the blueprint to stdout (the default; explicit no-op)
+  -h, --help     Show this help`;
+
+/**
+ * CLI entry point. Returns the process exit code so the dispatcher / tests can
+ * assert on it. Writes the blueprint Markdown to stdout and diagnostics to
+ * stderr so `... | claude` only receives the blueprint.
+ */
+export function runAdd(
+  argv: string[],
+  io: {
+    out?: (s: string) => void;
+    err?: (s: string) => void;
+    root?: string;
+  } = {},
+): number {
+  const out = io.out ?? ((s: string) => process.stdout.write(s));
+  const err = io.err ?? ((s: string) => process.stderr.write(s));
+  const root = resolveBlueprintsRoot(io.root);
+
+  const parsed = parseAddArgs(argv);
+
+  if (parsed.help) {
+    out(HELP + "\n");
+    return 0;
+  }
+
+  // `--list` or no positionals → show the catalog (to stdout; this is the
+  // requested output, not an error).
+  if (parsed.list || parsed.positionals.length === 0) {
+    out(formatCatalog(root) + "\n");
+    return 0;
+  }
+
+  const [kind, nameOrUrl] = parsed.positionals;
+
+  try {
+    const resolved = resolveBlueprint({ kind, nameOrUrl, root });
+    out(
+      resolved.markdown.endsWith("\n")
+        ? resolved.markdown
+        : resolved.markdown + "\n",
+    );
+    return 0;
+  } catch (e) {
+    if (e instanceof AddResolutionError) {
+      err(e.message + "\n");
+      return 1;
+    }
+    throw e;
+  }
+}

--- a/packages/core/src/cli/connect.spec.ts
+++ b/packages/core/src/cli/connect.spec.ts
@@ -386,7 +386,10 @@ describe("runDeviceFlow", () => {
     expect(grant).toBeNull();
   });
 
-  it("returns null immediately when polling gets a server error", async () => {
+  it("retries transient server errors while polling, then gives up", async () => {
+    // A cold/propagating instance can briefly 5xx (or bare-404) before its
+    // route/DB is ready; the connect flow must ride that out rather than fail
+    // on the first blip. Persistent failure still gives up gracefully.
     const err = vi
       .spyOn(process.stderr, "write")
       .mockImplementation(() => true);
@@ -420,8 +423,57 @@ describe("runDeviceFlow", () => {
     });
 
     expect(grant).toBeNull();
-    expect(pollCount).toBe(1);
-    expect(err.mock.calls.flat().join("")).toContain("database unavailable");
+    // The transient 503 is retried (not fatal on the first poll), then the
+    // flow gives up once the failure streak is exhausted.
+    expect(pollCount).toBeGreaterThan(1);
+    expect(err.mock.calls.flat().join("")).toContain("not responding");
+  });
+
+  it("recovers when a transient poll error is followed by approval", async () => {
+    // The core durable-404 guarantee: a bare-404 / 5xx blip mid-poll must not
+    // kill the connect — the next healthy poll should still complete.
+    let pollCount = 0;
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (String(url).endsWith("/device/start")) {
+        return new Response(
+          JSON.stringify({
+            device_code: "dev-123",
+            user_code: "WXYZ-1234",
+            verification_uri: "https://app.example.com/connect",
+            verification_uri_complete:
+              "https://app.example.com/connect?code=WXYZ-1234",
+            interval: 1,
+            expires_in: 600,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      pollCount++;
+      // First two polls hit a cold/propagating instance (bare 404, no JSON
+      // body) — the exact recurring "Cannot find any route matching" case.
+      if (pollCount <= 2) {
+        return new Response("Cannot find any route matching", { status: 404 });
+      }
+      return new Response(
+        JSON.stringify({
+          status: "approved",
+          token: "tok-after-blip",
+          mcpUrl: "https://app.example.com/_agent-native/mcp",
+          serverName: "app",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const grant = await runDeviceFlow("https://app.example.com", "app", "all", {
+      fetchImpl,
+      sleep: noopSleep,
+      openBrowser: vi.fn(),
+    });
+
+    expect(grant).not.toBeNull();
+    expect(grant?.token).toBe("tok-after-blip");
+    expect(pollCount).toBe(3);
   });
 
   it("returns null immediately when polling returns a terminal error body", async () => {
@@ -447,7 +499,7 @@ describe("runDeviceFlow", () => {
       pollCount++;
       return new Response(
         JSON.stringify({ status: "not_found", message: "unknown code" }),
-        { status: 200, headers: { "content-type": "application/json" } },
+        { status: 404, headers: { "content-type": "application/json" } },
       );
     }) as unknown as typeof fetch;
 

--- a/packages/core/src/cli/connect.spec.ts
+++ b/packages/core/src/cli/connect.spec.ts
@@ -200,10 +200,9 @@ describe("normalizeUrl", () => {
 });
 
 describe("resolveClients", () => {
-  it("expands 'all' to every supported client", () => {
+  it("expands 'all' to every selectable client", () => {
     expect(resolveClients("all")).toEqual([
       "claude-code",
-      "claude-code-cli",
       "codex",
       "cowork",
       "cursor",

--- a/packages/core/src/cli/connect.ts
+++ b/packages/core/src/cli/connect.ts
@@ -5,7 +5,7 @@
  * browser device-code flow: open the verification URL, approve in the browser,
  * and the minted HTTP MCP server entry is written idempotently.
  *
- *   agent-native connect <url> [--client all|claude-code|claude-code-cli|
+ *   agent-native connect <url> [--client all|claude-code|
  *                               codex|cowork|cursor|opencode|github-copilot]
  *                               [--scope user|project]
  *                               [--name <serverName>]
@@ -129,7 +129,7 @@ export interface ParsedConnectArgs {
   mode?: "dev" | "prod" | "reauth" | "reconnect";
   /** Positional URL (the deployed app origin). Undefined for `--all`. */
   url?: string;
-  /** all | claude-code | claude-code-cli | codex | cowork | cursor | opencode | github-copilot (default "all"). */
+  /** all | claude-code | codex | cowork | cursor | opencode | github-copilot (default "all"). claude-code-cli is accepted as a legacy alias for claude-code. */
   client: string;
   /** True when the user passed --client explicitly, so we skip the picker. */
   clientExplicit: boolean;
@@ -251,10 +251,17 @@ export function normalizeUrl(raw: string): string {
   return base;
 }
 
+// Clients offered in the interactive picker and expanded by "all". Excludes
+// the `claude-code-cli` alias so users only ever see a single "Claude Code"
+// option (it still works if passed explicitly via --client).
+const SELECTABLE_CLIENTS: ClientId[] = CLIENTS.filter(
+  (c) => c !== "claude-code-cli",
+);
+
 /** Resolve the requested clients list. "all" → every supported client. */
 export function resolveClients(client: string): ClientId[] {
   const c = normalizeClientAlias(client ?? "all");
-  if (c === "all" || c === "") return [...CLIENTS];
+  if (c === "all" || c === "") return [...SELECTABLE_CLIENTS];
   if (c.includes(",")) {
     const clients = normalizeClientIds(c.split(",").map((part) => part.trim()));
     if (clients.length > 0) return clients;
@@ -267,7 +274,15 @@ export function resolveClients(client: string): ClientId[] {
 
 function normalizeClientAlias(value: string): string {
   const id = value.trim().toLowerCase();
-  if (id === "claude" || id === "claude-code-desktop") return "claude-code";
+  // The Claude Code CLI and desktop share ~/.claude.json, so they are one
+  // client. `claude-code-cli` stays accepted for back-compat but collapses to
+  // the single "Claude Code" option everywhere it surfaces.
+  if (
+    id === "claude" ||
+    id === "claude-code-desktop" ||
+    id === "claude-code-cli"
+  )
+    return "claude-code";
   if (id === "copilot" || id === "vscode" || id === "vs-code") {
     return "github-copilot";
   }
@@ -348,7 +363,7 @@ export interface ConnectHostedAppsPromptContext {
 }
 
 function clientPromptOptions(): ConnectClientPromptContext["options"] {
-  return CLIENTS.map((client) => ({
+  return SELECTABLE_CLIENTS.map((client) => ({
     value: client,
     label: CLIENT_LABELS[client],
     hint: CLIENT_HINTS[client],
@@ -2570,7 +2585,7 @@ Developer:
   npx @agent-native/core@latest connect prod [--apps mail,calendar] [--client <c>]
       Restore production MCP entries saved before the dev switch.
 
-Clients:  all (default), claude-code, claude-code-cli, codex, cowork, cursor, opencode, github-copilot
+Clients:  all (default), claude-code, codex, cowork, cursor, opencode, github-copilot
 Scope:    user (default, ~/.claude.json) or project (.mcp.json)`;
 
 /**

--- a/packages/core/src/cli/connect.ts
+++ b/packages/core/src/cli/connect.ts
@@ -834,33 +834,49 @@ export async function runDeviceFlow(
   const open = deps.openBrowser ?? openInBrowser;
   const now = deps.now ?? (() => Date.now());
 
-  let start: DeviceStartResponse;
-  try {
-    const { status, json } = await postJson(
-      fetchImpl,
-      `${baseUrl}${DEVICE_START_PATH}`,
-      {
-        client: clientArg,
-        app: appSlug,
-        ...(options.fullCatalog ? { fullCatalog: true } : {}),
-      },
-    );
-    if (status < 200 || status >= 300 || !json?.device_code) {
+  let start: DeviceStartResponse | null = null;
+  // A cold/propagating Plan instance can briefly 404/5xx before its connect
+  // route is registered (async plugin init). Retry a few times so a recoverable
+  // blip doesn't kill the connect before polling even begins.
+  const START_ATTEMPTS = 4;
+  for (let attempt = 0; attempt < START_ATTEMPTS; attempt++) {
+    try {
+      const { status, json } = await postJson(
+        fetchImpl,
+        `${baseUrl}${DEVICE_START_PATH}`,
+        {
+          client: clientArg,
+          app: appSlug,
+          ...(options.fullCatalog ? { fullCatalog: true } : {}),
+        },
+      );
+      if (status >= 200 && status < 300 && json?.device_code) {
+        start = json as DeviceStartResponse;
+        break;
+      }
+      if ((status === 404 || status >= 500) && attempt < START_ATTEMPTS - 1) {
+        await sleep(1000 * (attempt + 1));
+        continue;
+      }
       logErr(
         `  Could not start the connect flow on ${baseUrl} ` +
           `(HTTP ${status}). Is this an agent-native app, and is it ` +
           `deployed with the connect endpoint enabled?`,
       );
       return null;
+    } catch (err: any) {
+      if (attempt < START_ATTEMPTS - 1) {
+        await sleep(1000 * (attempt + 1));
+        continue;
+      }
+      logErr(
+        `  Could not reach ${baseUrl} (${err?.message ?? err}). ` +
+          `Check the URL and your network.`,
+      );
+      return null;
     }
-    start = json as DeviceStartResponse;
-  } catch (err: any) {
-    logErr(
-      `  Could not reach ${baseUrl} (${err?.message ?? err}). ` +
-        `Check the URL and your network.`,
-    );
-    return null;
   }
+  if (!start) return null;
 
   const interval = Math.max(1, Number(start.interval) || 5);
   const expiresIn = Math.max(interval, Number(start.expires_in) || 600);
@@ -876,9 +892,15 @@ export async function runDeviceFlow(
   open(start.verification_uri_complete);
 
   let spin = 0;
+  let transientStreak = 0;
+  // Ride out brief cold-instance blips, but don't poll a persistently-dead
+  // endpoint forever: give up after this many consecutive transient (404/5xx
+  // or network-error) polls. Reset as soon as one poll responds normally.
+  const MAX_TRANSIENT_POLLS = 20;
   const isTTY = !!process.stdout.isTTY;
   while (now() < deadline) {
     let poll: DevicePollResponse;
+    let transient = false;
     try {
       const { status, json } = await postJson(
         fetchImpl,
@@ -886,17 +908,45 @@ export async function runDeviceFlow(
         { device_code: start.device_code },
       );
       if (status < 200 || status >= 300) {
+        if (isTerminalPollBody(json)) {
+          poll = json as DevicePollResponse;
+        } else if (status === 404 || status >= 500) {
+          // Transient: a cold/propagating Plan instance can briefly serve a
+          // bare 404 (the MCP route isn't registered until async plugin init
+          // settles) or a 5xx before it's healthy. The next poll usually lands
+          // on a warm instance, so keep polling until the deadline instead of
+          // hard-failing the whole connect on a recoverable blip. (This is the
+          // recurring "Cannot find any route matching [POST] .../mcp" case.)
+          poll = { status: "pending" };
+          transient = true;
+        } else {
+          if (isTTY) process.stdout.write("\r\x1b[K");
+          logErr(
+            `  Connect polling failed (HTTP ${status}): ` +
+              responseMessage(json, "server returned an error."),
+          );
+          return null;
+        }
+      } else {
+        poll = (json ?? { status: "pending" }) as DevicePollResponse;
+      }
+    } catch {
+      // Transient network error — keep polling.
+      poll = { status: "pending" };
+      transient = true;
+    }
+
+    if (transient) {
+      if (++transientStreak > MAX_TRANSIENT_POLLS) {
         if (isTTY) process.stdout.write("\r\x1b[K");
         logErr(
-          `  Connect polling failed (HTTP ${status}): ` +
-            responseMessage(json, "server returned an error."),
+          "  Connect endpoint is not responding (repeated 404/5xx). It may be " +
+            "mid-deploy — wait a minute and run the command again.",
         );
         return null;
       }
-      poll = (json ?? { status: "pending" }) as DevicePollResponse;
-    } catch {
-      // Transient network error — keep polling until the deadline.
-      poll = { status: "pending" };
+    } else {
+      transientStreak = 0;
     }
 
     if (poll.status === "approved") {
@@ -949,6 +999,15 @@ export async function runDeviceFlow(
   if (isTTY) process.stdout.write("\r\x1b[K");
   logErr("  Timed out waiting for approval. Run the command again to retry.");
   return null;
+}
+
+function isTerminalPollBody(json: any): boolean {
+  return (
+    json?.status === "not_found" ||
+    json?.status === "error" ||
+    json?.status === "expired" ||
+    json?.status === "consumed"
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/cli/eval.ts
+++ b/packages/core/src/cli/eval.ts
@@ -1,0 +1,134 @@
+/**
+ * `agent-native eval [pattern] [--json] [--threshold N]`
+ *
+ * Discover the app's `*.eval.ts` / `evals/*.ts` files, actually run the agent
+ * for each eval input, score the output with the eval's scorers, print a
+ * readable scored table, and EXIT NON-ZERO if any eval scores below its
+ * threshold. That non-zero exit makes the command a drop-in CI deploy gate:
+ *
+ *   - run: agent-native eval                 (block deploy on regressions)
+ *   - or:  agent-native eval --json          (machine-readable for CI)
+ *
+ * The runner resolves a provider-agnostic engine/model from the existing
+ * registry — no model is hardcoded — so the same suite runs against whatever
+ * engine the app is configured for.
+ */
+
+import process from "node:process";
+
+/** Parse `[pattern] [--json] [--threshold N]` from the eval argv. */
+function parseEvalArgs(argv: string[]): {
+  pattern?: string;
+  json: boolean;
+  threshold?: number;
+} {
+  let pattern: string | undefined;
+  let json = false;
+  let threshold: number | undefined;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--threshold" && argv[i + 1] !== undefined) {
+      threshold = Number(argv[++i]);
+    } else if (arg.startsWith("--threshold=")) {
+      threshold = Number(arg.slice("--threshold=".length));
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else if (!arg.startsWith("-") && pattern === undefined) {
+      pattern = arg;
+    }
+  }
+
+  if (
+    threshold !== undefined &&
+    (!Number.isFinite(threshold) || threshold < 0 || threshold > 1)
+  ) {
+    console.error("eval: --threshold must be a number in [0, 1]");
+    process.exit(2);
+  }
+
+  return { pattern, json, threshold };
+}
+
+function printHelp(): void {
+  console.log(`agent-native eval — run agent evals as a CI deploy gate
+
+Usage:
+  agent-native eval [pattern] [--json] [--threshold N]
+
+Discovers **/*.eval.ts and evals/*.ts under the current app, runs the agent
+for each eval input, scores the output with the eval's scorers, and exits
+non-zero if any eval scores below its threshold (so it gates CI/deploys).
+
+Arguments:
+  pattern            Only run eval files whose path contains this substring.
+
+Options:
+  --json             Emit a machine-readable JSON report (for CI).
+  --threshold N      Override every eval's pass threshold (0..1).
+  -h, --help         Show this help.
+
+Authoring (evals/example.eval.ts):
+  import { defineEval, contains, llmJudge } from "@agent-native/core/eval";
+  export default defineEval({
+    name: "answers the FAQ",
+    input: { prompt: "What is your return policy?" },
+    threshold: 0.7,
+    scorers: [contains("30 days"), llmJudge({ criteria: "accuracy" })],
+  });`);
+}
+
+export async function runEval(argv: string[]): Promise<void> {
+  const { pattern, json, threshold } = parseEvalArgs(argv);
+
+  // Lazy import: the runner pulls in server-only deps (engine registry, action
+  // discovery) we don't want to load for `--help`.
+  const { runEvalSuite, formatReport } = await import("../eval/index.js");
+
+  let result: Awaited<ReturnType<typeof runEvalSuite>>;
+  try {
+    result = await runEvalSuite({
+      cwd: process.cwd(),
+      pattern,
+      thresholdOverride: threshold,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (json) {
+      console.log(JSON.stringify({ ok: false, error: message }, null, 2));
+    } else {
+      console.error(`\n  eval failed: ${message}\n`);
+    }
+    process.exit(1);
+  }
+
+  const { report, files } = result;
+
+  if (report.total === 0) {
+    const hint =
+      files.length === 0
+        ? "No eval files found (looked for **/*.eval.ts and evals/*.ts)."
+        : `Found ${files.length} eval file(s) but no defineEval() exports.`;
+    if (json) {
+      console.log(JSON.stringify({ ok: true, report, files }, null, 2));
+    } else {
+      console.log(`\n  ${hint}\n`);
+    }
+    // Nothing to gate on — exit clean so an app without evals doesn't fail CI.
+    process.exit(0);
+  }
+
+  if (json) {
+    console.log(
+      JSON.stringify({ ok: report.failed === 0, report, files }, null, 2),
+    );
+  } else {
+    console.log(formatReport(report));
+  }
+
+  // The CI deploy gate: any eval below threshold => non-zero exit.
+  process.exit(report.failed > 0 ? 1 : 0);
+}

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -739,9 +739,39 @@ switch (command) {
     break;
   }
 
+  case "add": {
+    // Blueprint installer (à la Flue's `flue add`): instead of scaffolding
+    // files, emit a curated Markdown integration blueprint to stdout so it can
+    // be piped into a coding agent — `agent-native add provider stripe | claude`.
+    // A URL instead of a name yields a generic research-and-integrate blueprint.
+    import("./add.js")
+      .then((m) => {
+        const code = m.runAdd(args);
+        if (code !== 0) process.exit(code);
+      })
+      .catch((err) => {
+        console.error(err?.message ?? err);
+        process.exit(1);
+      });
+    break;
+  }
+
   case "audit-agent-web": {
     import("./audit-agent-web.js")
       .then((m) => m.runAuditAgentWeb(args))
+      .catch((err) => {
+        console.error(err?.message ?? err);
+        process.exit(1);
+      });
+    break;
+  }
+
+  case "eval": {
+    // Discover and run the app's evals (**/*.eval.ts, evals/*.ts), score the
+    // agent's output, and exit non-zero if any eval falls below its threshold.
+    // Doubles as a CI deploy gate. `--json` emits a machine-readable report.
+    import("./eval.js")
+      .then((m) => m.runEval(args))
       .catch((err) => {
         console.error(err?.message ?? err);
         process.exit(1);
@@ -806,7 +836,7 @@ Usage:
                                 Run 'agent-native recap help' for subcommands.
   agent-native plan <cmd>       Plan helpers for block catalogs and local files.
                                 cmds: blocks | local init | local check |
-                                local preview
+                                local serve | local preview
   agent-native migrate <source> Create an Agent-Native Code /migrate session, or use
                                 --emit for a portable own-agent dossier.
   agent-native add-app [name]   Add one or more apps to the current workspace
@@ -816,7 +846,19 @@ Usage:
   agent-native setup-agents     Create symlinks for all agent tools
   agent-native info <pkg>       Print info about an installed package:
                                 exports, source paths, and docs links.
+  agent-native add <kind> <name|url>
+                                Emit an integration blueprint to stdout for your
+                                coding agent to apply. Pipe it in:
+                                'agent-native add provider stripe | claude'.
+                                kinds: provider | channel | sandbox | action.
+                                Pass a URL instead of a name for a generic
+                                research-and-integrate blueprint. --list to
+                                browse available blueprints.
   agent-native audit-agent-web  Audit a public URL for agent-readable surfaces
+  agent-native eval [pattern]   Run the app's evals (**/*.eval.ts, evals/*.ts)
+                                and exit non-zero if any scores below its
+                                threshold. A CI deploy gate. --json for CI,
+                                --threshold N to override all thresholds.
 
 Options:
   -h, --help                    Show this help message

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -813,8 +813,8 @@ Usage:
   agent-native code serve       Run the Agent-Native Code remote connector.
   agent-native mcp <cmd>        Connect external coding agents over MCP.
                                 cmds: serve | install | uninstall | status |
-                                token (--client claude-code|claude-code-cli|
-                                codex|cowork)
+                                token (--client claude-code|codex|cowork|
+                                cursor|opencode|github-copilot)
   agent-native connect <url>    Authenticate your coding agent to a DEPLOYED app.
                                 OAuth-capable clients (Claude Code) get a /mcp
                                 authenticate prompt; Codex / Cowork use the

--- a/packages/core/src/cli/mcp.ts
+++ b/packages/core/src/cli/mcp.ts
@@ -289,9 +289,20 @@ function serverNameFor(appId: string): string {
   return `${SERVER_NAME_PREFIX}-${appId}`;
 }
 
+// Clients advertised in usage/help and listed by status. Excludes the legacy
+// `claude-code-cli` alias so only a single "Claude Code" appears (it is still
+// accepted via --client and collapses to claude-code).
+const SELECTABLE_CLIENTS: ClientId[] = CLIENTS.filter(
+  (c) => c !== "claude-code-cli",
+);
+
 function normalizeClientId(raw: string | undefined): ClientId | null {
   const value = (raw ?? "").toLowerCase();
-  if (value === "claude" || value === "claude-code-desktop") {
+  if (
+    value === "claude" ||
+    value === "claude-code-desktop" ||
+    value === "claude-code-cli"
+  ) {
     return "claude-code";
   }
   if (value === "open-code") return "opencode";
@@ -376,7 +387,7 @@ async function cmdInstall(p: ParsedArgs): Promise<void> {
   const client = normalizeClientId(p.client);
   if (!client) {
     logErr(
-      `Usage: npx @agent-native/core@latest mcp install --client ${CLIENTS.join("|")} ` +
+      `Usage: npx @agent-native/core@latest mcp install --client ${SELECTABLE_CLIENTS.join("|")} ` +
         `[--app <id>] [--scope user|project]`,
     );
     process.exit(1);
@@ -437,7 +448,7 @@ function cmdUninstall(p: ParsedArgs): void {
   const client = normalizeClientId(p.client);
   if (!client) {
     logErr(
-      `Usage: npx @agent-native/core@latest mcp uninstall --client ${CLIENTS.join("|")} ` +
+      `Usage: npx @agent-native/core@latest mcp uninstall --client ${SELECTABLE_CLIENTS.join("|")} ` +
         `[--app <id>]`,
     );
     process.exit(1);
@@ -489,7 +500,7 @@ async function cmdStatus(): Promise<void> {
   logOut(`  ACCESS_TOKEN: ${hasToken ? "set" : "not set"} (.env)`);
   logOut(`  A2A_SECRET:   ${hasA2A ? "set" : "not set"}`);
   logOut(`  Clients:`);
-  for (const client of CLIENTS) {
+  for (const client of SELECTABLE_CLIENTS) {
     const present = clientHasEntry(client, appId, cwd);
     logOut(`    ${client.padEnd(18)} ${present ? "configured" : "—"}`);
   }
@@ -523,7 +534,7 @@ Usage:
 
   npx @agent-native/core@latest mcp install --client <c> [--app <id>] [--scope user|project]
       Provision a token and write the client's MCP config (idempotent).
-      Clients: claude-code, claude-code-cli, codex, cowork, cursor, opencode, github-copilot
+      Clients: claude-code, codex, cowork, cursor, opencode, github-copilot
 
   npx @agent-native/core@latest mcp uninstall --client <c> [--app <id>]
       Remove the named MCP entry from a client's config (idempotent).

--- a/packages/core/src/cli/plan-install.spec.ts
+++ b/packages/core/src/cli/plan-install.spec.ts
@@ -420,13 +420,13 @@ describe("Plans skills install — materialized output", () => {
         "Default storage for this installation: local files.",
       );
       expect(captured[name], `materialized ${name}/SKILL.md`).toContain(
-        "No sharing, all local.",
+        "no hosted Plan database writes",
       );
       expect(captured[name], `materialized ${name}/SKILL.md`).toContain(
         "plan blocks --out plan-blocks.md",
       );
       expect(captured[name], `materialized ${name}/SKILL.md`).toContain(
-        "plan local preview",
+        "plan local serve",
       );
     }
   });

--- a/packages/core/src/cli/plan-local.spec.ts
+++ b/packages/core/src/cli/plan-local.spec.ts
@@ -7,6 +7,7 @@ import {
   buildLocalPlanPreviewHtml,
   localPlanFolderName,
   readLocalPlanFiles,
+  startLocalPlanBridge,
   writeLocalPlanPreview,
 } from "./plan-local.js";
 import { fetchPlanBlockCatalog } from "./plan-blocks.js";
@@ -139,6 +140,48 @@ describe("local plan CLI helpers", () => {
     expect(openedUrl).toBe(result.url);
     expect(result.opened).toBe(true);
     expect(result.openCommand).toBe("test-open");
+  });
+
+  it("serves a tokened localhost bridge for the hosted local plan UI", async () => {
+    const dir = path.join(tmpDir(), "checkout");
+    writeSamplePlan(dir);
+
+    const bridge = await startLocalPlanBridge({
+      dir,
+      appUrl: "https://plan.example.com",
+      token: "test-token",
+    });
+
+    try {
+      expect(bridge.result.url).toBe(
+        `https://plan.example.com/local-plans/checkout?bridge=${encodeURIComponent(
+          bridge.result.bridgeUrl,
+        )}`,
+      );
+      expect(bridge.result.bridgeUrl).toContain("127.0.0.1");
+      expect(bridge.result.files).toContain("plan.mdx");
+
+      const response = await fetch(bridge.result.bridgeUrl);
+      expect(response.ok).toBe(true);
+      expect(response.headers.get("x-agent-native-local-bridge")).toBe("1");
+      const payload = (await response.json()) as {
+        ok: boolean;
+        source: string;
+        mdx: { "plan.mdx": string };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.source).toBe("agent-native-local-bridge");
+      expect(payload.mdx["plan.mdx"]).toContain("Private Checkout Plan");
+
+      const denied = await fetch(
+        bridge.result.bridgeUrl.replace("test-token", "wrong-token"),
+      );
+      expect(denied.status).toBe(403);
+    } finally {
+      await new Promise<void>((resolve) =>
+        bridge.server.close(() => resolve()),
+      );
+    }
   });
 
   it("fetches the no-auth block catalog for local authoring", async () => {

--- a/packages/core/src/cli/plan-local.spec.ts
+++ b/packages/core/src/cli/plan-local.spec.ts
@@ -41,7 +41,49 @@ function writeSamplePlan(dir: string) {
       "",
       "This plan stays local.",
       "",
-      '<WireframeBlock id="wf" title="Checkout" data={{ surface: "browser", html: "<div>Pay</div>" }} />',
+      '<WireframeBlock id="wf" title="Checkout">',
+      '  <Screen surface="browser" html={`<div>Pay</div>`} />',
+      "</WireframeBlock>",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+function writeInvalidSelfClosingWireframe(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "plan.mdx"),
+    [
+      "---",
+      'title: "Invalid Wireframe"',
+      'kind: "plan"',
+      "---",
+      "",
+      "# Invalid Wireframe",
+      "",
+      '<WireframeBlock id="wf" screens={[{ name: "Checkout", elements: [] }]} />',
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+function writeEmptyWireframe(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "plan.mdx"),
+    [
+      "---",
+      'title: "Empty Wireframe"',
+      'kind: "recap"',
+      "---",
+      "",
+      "# Empty Wireframe",
+      "",
+      '<WireframeBlock id="wf" title="Checkout">',
+      '  <Screen surface="browser" />',
+      "</WireframeBlock>",
       "",
     ].join("\n"),
     "utf-8",
@@ -123,23 +165,26 @@ describe("local plan CLI helpers", () => {
     expect(result.openCommand).toBe("test-open");
   });
 
-  it("can open the generated preview when requested", () => {
-    const dir = path.join(tmpDir(), "checkout");
-    writeSamplePlan(dir);
-    let openedUrl = "";
+  it("rejects self-closing local wireframes before opening a preview", async () => {
+    const dir = path.join(tmpDir(), "bad-wireframe");
+    writeInvalidSelfClosingWireframe(dir);
 
-    const result = writeLocalPlanPreview({
-      dir,
-      open: true,
-      openUrl: (url) => {
-        openedUrl = url;
-        return { ok: true, command: "test-open" };
-      },
-    });
+    expect(() => writeLocalPlanPreview({ dir })).toThrow(
+      /WireframeBlock must wrap a <Screen> child/,
+    );
+    await expect(startLocalPlanBridge({ dir })).rejects.toThrow(
+      /WireframeBlock must wrap a <Screen> child/,
+    );
+  });
 
-    expect(openedUrl).toBe(result.url);
-    expect(result.opened).toBe(true);
-    expect(result.openCommand).toBe("test-open");
+  it("rejects empty local wireframes before opening a preview", async () => {
+    const dir = path.join(tmpDir(), "empty-wireframe");
+    writeEmptyWireframe(dir);
+
+    expect(() => writeLocalPlanPreview({ dir })).toThrow(/empty <Screen>/);
+    await expect(startLocalPlanBridge({ dir })).rejects.toThrow(
+      /empty <Screen>/,
+    );
   });
 
   it("serves a tokened localhost bridge for the hosted local plan UI", async () => {

--- a/packages/core/src/cli/plan-local.ts
+++ b/packages/core/src/cli/plan-local.ts
@@ -2,14 +2,20 @@
  * Plan helper commands.
  *
  * The `plan local` commands are intentionally separate from the Plan app
- * actions. They do not call MCP, HTTP, SQLite, or the Plan template runtime;
- * they only read and write local files so privacy-focused users have an
- * auditable no-DB path. The top-level `plan blocks` command is a schema-only,
- * no-auth helper for fetching the public block catalog before authoring local
- * MDX; it never sends plan content.
+ * actions. They do not call MCP, hosted write actions, SQLite, or hosted
+ * storage; they only read local files or serve them from a localhost bridge so
+ * privacy-focused users have an auditable no-DB path. The top-level
+ * `plan blocks` command is a schema-only, no-auth helper for fetching the
+ * public block catalog before authoring local MDX; it never sends plan content.
  */
 
 import fs from "node:fs";
+import crypto from "node:crypto";
+import http, {
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
@@ -29,6 +35,7 @@ type LocalPlanFiles = {
   canvasMdx?: string;
   prototypeMdx?: string;
   stateJson?: string;
+  assets?: Record<string, string>;
 };
 
 type LocalPlanPreviewInput = {
@@ -52,11 +59,66 @@ type LocalPlanPreviewResult = {
   openError?: string;
 };
 
+type LocalPlanBridgeMdxFolder = {
+  "plan.mdx": string;
+  "canvas.mdx"?: string;
+  "prototype.mdx"?: string;
+  ".plan-state.json"?: string;
+  "assets/"?: Record<string, string>;
+};
+
+export type LocalPlanBridgePayload = {
+  ok: true;
+  version: 1;
+  source: "agent-native-local-bridge";
+  localOnly: true;
+  slug: string;
+  dir: string;
+  title: string;
+  brief: string;
+  kind: LocalPlanKind;
+  updatedAt: string;
+  files: string[];
+  mdx: LocalPlanBridgeMdxFolder;
+};
+
+export type LocalPlanServeResult = {
+  ok: true;
+  dir: string;
+  url: string;
+  bridgeUrl: string;
+  appUrl: string;
+  title: string;
+  kind: LocalPlanKind;
+  files: string[];
+  host: string;
+  port: number;
+  opened?: boolean;
+  openCommand?: string;
+  openError?: string;
+};
+
+export type LocalPlanBridgeServer = {
+  server: Server;
+  result: LocalPlanServeResult;
+};
+
 type OpenLocalUrlResult = {
   ok: boolean;
   command: string;
   error?: string;
 };
+
+const LOCAL_PLAN_ASSET_MAX_SINGLE_BYTES = 2 * 1024 * 1024;
+const LOCAL_PLAN_ASSET_MAX_TOTAL_BYTES = 10 * 1024 * 1024;
+const LOCAL_PLAN_ASSET_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "svg",
+]);
 
 function parseArgs(argv: string[]): Record<string, string | boolean> {
   const out: Record<string, string | boolean> = {};
@@ -127,14 +189,36 @@ function defaultLocalPlanAppUrl(): string {
   );
 }
 
+function defaultLocalPlanBridgeAppUrl(): string {
+  return (
+    process.env.PLAN_LOCAL_BRIDGE_APP_URL ||
+    process.env.PLAN_BASE_URL ||
+    DEFAULT_PLAN_APP_URL
+  );
+}
+
 function normalizeAppUrl(value: string | undefined): string {
   return (value || defaultLocalPlanAppUrl()).replace(/\/+$/, "");
+}
+
+function normalizeBridgeAppUrl(value: string | undefined): string {
+  return (value || defaultLocalPlanBridgeAppUrl()).replace(/\/+$/, "");
 }
 
 function localPlanPreviewUrl(dir: string, appUrl?: string): string {
   return `${normalizeAppUrl(appUrl)}/local-plans/${encodeURIComponent(
     path.basename(path.resolve(dir)),
   )}`;
+}
+
+function localPlanBridgePageUrl(input: {
+  dir: string;
+  bridgeUrl: string;
+  appUrl?: string;
+}): string {
+  return `${normalizeBridgeAppUrl(input.appUrl)}/local-plans/${encodeURIComponent(
+    path.basename(path.resolve(input.dir)),
+  )}?bridge=${encodeURIComponent(input.bridgeUrl)}`;
 }
 
 function openLocalUrl(url: string): OpenLocalUrlResult {
@@ -326,6 +410,32 @@ function renderMarkdownish(source: string): string {
   return html.join("\n");
 }
 
+function readLocalPlanAssets(dir: string): Record<string, string> | undefined {
+  const assetsDir = path.join(dir, "assets");
+  if (!fs.existsSync(assetsDir)) return undefined;
+
+  const assets: Record<string, string> = {};
+  let totalBytes = 0;
+  for (const entry of fs.readdirSync(assetsDir, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    const filename = path.basename(entry.name);
+    if (!filename || filename !== entry.name) continue;
+    const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+    if (!LOCAL_PLAN_ASSET_EXTENSIONS.has(ext)) continue;
+
+    const abs = path.join(assetsDir, filename);
+    const bytes = fs.readFileSync(abs);
+    if (bytes.byteLength > LOCAL_PLAN_ASSET_MAX_SINGLE_BYTES) continue;
+    if (totalBytes + bytes.byteLength > LOCAL_PLAN_ASSET_MAX_TOTAL_BYTES) {
+      continue;
+    }
+    totalBytes += bytes.byteLength;
+    assets[filename] = bytes.toString("base64");
+  }
+
+  return Object.keys(assets).length > 0 ? assets : undefined;
+}
+
 export function readLocalPlanFiles(dir: string): LocalPlanFiles {
   const resolved = path.resolve(dir);
   const planPath = path.join(resolved, "plan.mdx");
@@ -342,7 +452,28 @@ export function readLocalPlanFiles(dir: string): LocalPlanFiles {
     canvasMdx: readOptional("canvas.mdx"),
     prototypeMdx: readOptional("prototype.mdx"),
     stateJson: readOptional(".plan-state.json"),
+    assets: readLocalPlanAssets(resolved),
   };
+}
+
+function localPlanMdxFolder(files: LocalPlanFiles): LocalPlanBridgeMdxFolder {
+  return {
+    "plan.mdx": files.planMdx,
+    ...(files.canvasMdx ? { "canvas.mdx": files.canvasMdx } : {}),
+    ...(files.prototypeMdx ? { "prototype.mdx": files.prototypeMdx } : {}),
+    ...(files.stateJson ? { ".plan-state.json": files.stateJson } : {}),
+    ...(files.assets ? { "assets/": files.assets } : {}),
+  };
+}
+
+function localPlanFileList(files: LocalPlanFiles): string[] {
+  return [
+    "plan.mdx",
+    ...(files.canvasMdx ? ["canvas.mdx"] : []),
+    ...(files.prototypeMdx ? ["prototype.mdx"] : []),
+    ...(files.stateJson ? [".plan-state.json"] : []),
+    ...Object.keys(files.assets ?? {}).map((filename) => `assets/${filename}`),
+  ];
 }
 
 export function buildLocalPlanPreviewHtml(
@@ -467,7 +598,8 @@ export function writeLocalPlanPreview(input: {
   openUrl?: (url: string) => OpenLocalUrlResult;
 }): LocalPlanPreviewResult {
   const dir = path.resolve(input.dir);
-  const parsed = stripFrontmatter(readLocalPlanFiles(dir).planMdx);
+  const files = readLocalPlanFiles(dir);
+  const parsed = stripFrontmatter(files.planMdx);
   const kind = input.kind || normalizeKind(parsed.frontmatter.kind);
   const title =
     input.title ||
@@ -479,12 +611,6 @@ export function writeLocalPlanPreview(input: {
     fs.mkdirSync(path.dirname(out), { recursive: true });
     fs.writeFileSync(out, buildLocalPlanPreviewHtml({ ...input, dir, kind }));
   }
-  const files = [
-    "plan.mdx",
-    "canvas.mdx",
-    "prototype.mdx",
-    ".plan-state.json",
-  ].filter((file) => fs.existsSync(path.join(dir, file)));
   const result: LocalPlanPreviewResult = {
     ok: true,
     dir,
@@ -492,7 +618,7 @@ export function writeLocalPlanPreview(input: {
     url: out ? pathToFileURL(out).href : localPlanPreviewUrl(dir, input.appUrl),
     title,
     kind,
-    files,
+    files: localPlanFileList(files),
   };
   if (!input.open) return result;
 
@@ -502,6 +628,198 @@ export function writeLocalPlanPreview(input: {
     opened: openResult.ok,
     openCommand: openResult.command,
     ...(openResult.error ? { openError: openResult.error } : {}),
+  };
+}
+
+function buildLocalPlanBridgePayload(input: {
+  dir: string;
+  kind?: LocalPlanKind;
+  title?: string;
+  brief?: string;
+}): LocalPlanBridgePayload {
+  const dir = path.resolve(input.dir);
+  const files = readLocalPlanFiles(dir);
+  const parsed = stripFrontmatter(files.planMdx);
+  const kind = input.kind || normalizeKind(parsed.frontmatter.kind);
+  const title =
+    input.title ||
+    parsed.frontmatter.title ||
+    firstHeading(parsed.body) ||
+    path.basename(dir);
+  const brief = input.brief || parsed.frontmatter.brief || "";
+
+  return {
+    ok: true,
+    version: 1,
+    source: "agent-native-local-bridge",
+    localOnly: true,
+    slug: path.basename(dir),
+    dir,
+    title,
+    brief,
+    kind,
+    updatedAt: latestLocalPlanMtime(dir, files),
+    files: localPlanFileList(files),
+    mdx: localPlanMdxFolder(files),
+  };
+}
+
+function latestLocalPlanMtime(dir: string, files: LocalPlanFiles): string {
+  const candidates = [
+    path.join(dir, "plan.mdx"),
+    ...(files.canvasMdx ? [path.join(dir, "canvas.mdx")] : []),
+    ...(files.prototypeMdx ? [path.join(dir, "prototype.mdx")] : []),
+    ...(files.stateJson ? [path.join(dir, ".plan-state.json")] : []),
+    ...Object.keys(files.assets ?? {}).map((filename) =>
+      path.join(dir, "assets", filename),
+    ),
+  ];
+  let latest = 0;
+  for (const file of candidates) {
+    try {
+      latest = Math.max(latest, fs.statSync(file).mtimeMs);
+    } catch {
+      // Ignore files deleted between the read and stat passes.
+    }
+  }
+  return new Date(latest || Date.now()).toISOString();
+}
+
+function sendBridgeJson(
+  res: ServerResponse,
+  status: number,
+  payload: unknown,
+): void {
+  res.writeHead(status, {
+    "access-control-allow-origin": "*",
+    "access-control-allow-methods": "GET, OPTIONS",
+    "access-control-allow-headers": "content-type",
+    "cache-control": "no-store",
+    "content-type": "application/json; charset=utf-8",
+    "x-agent-native-local-bridge": "1",
+  });
+  res.end(`${JSON.stringify(payload)}\n`);
+}
+
+function bridgeRequestUrl(req: IncomingMessage): URL {
+  return new URL(req.url || "/", "http://127.0.0.1");
+}
+
+function bridgeHostForUrl(host: string): string {
+  if (host === "0.0.0.0" || host === "::") return "127.0.0.1";
+  return host;
+}
+
+export async function startLocalPlanBridge(input: {
+  dir: string;
+  kind?: LocalPlanKind;
+  title?: string;
+  brief?: string;
+  appUrl?: string;
+  host?: string;
+  port?: number;
+  token?: string;
+  open?: boolean;
+  openUrl?: (url: string) => OpenLocalUrlResult;
+}): Promise<LocalPlanBridgeServer> {
+  const dir = path.resolve(input.dir);
+  const token = input.token || crypto.randomBytes(24).toString("base64url");
+  const host = input.host || "127.0.0.1";
+  const appUrl = normalizeBridgeAppUrl(input.appUrl);
+  const server = http.createServer((req, res) => {
+    if (req.method === "OPTIONS") {
+      sendBridgeJson(res, 204, "");
+      return;
+    }
+    if (req.method !== "GET") {
+      sendBridgeJson(res, 405, { ok: false, error: "Method not allowed." });
+      return;
+    }
+
+    const url = bridgeRequestUrl(req);
+    if (url.pathname !== "/local-plan.json") {
+      sendBridgeJson(res, 404, { ok: false, error: "Not found." });
+      return;
+    }
+    if (url.searchParams.get("token") !== token) {
+      sendBridgeJson(res, 403, { ok: false, error: "Invalid bridge token." });
+      return;
+    }
+
+    try {
+      sendBridgeJson(
+        res,
+        200,
+        buildLocalPlanBridgePayload({
+          dir,
+          kind: input.kind,
+          title: input.title,
+          brief: input.brief,
+        }),
+      );
+    } catch (error) {
+      sendBridgeJson(res, 500, {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(input.port ?? 0, host);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Local plan bridge did not bind to a TCP port.");
+  }
+
+  const bridgeUrl = `http://${bridgeHostForUrl(host)}:${address.port}/local-plan.json?token=${encodeURIComponent(
+    token,
+  )}`;
+  const payload = buildLocalPlanBridgePayload({
+    dir,
+    kind: input.kind,
+    title: input.title,
+    brief: input.brief,
+  });
+  const url = localPlanBridgePageUrl({ dir, bridgeUrl, appUrl });
+  const openResult = input.open
+    ? (input.openUrl || openLocalUrl)(url)
+    : undefined;
+
+  return {
+    server,
+    result: {
+      ok: true,
+      dir,
+      url,
+      bridgeUrl,
+      appUrl,
+      title: payload.title,
+      kind: payload.kind,
+      files: payload.files,
+      host,
+      port: address.port,
+      ...(openResult
+        ? {
+            opened: openResult.ok,
+            openCommand: openResult.command,
+            ...(openResult.error ? { openError: openResult.error } : {}),
+          }
+        : {}),
+    },
   };
 }
 
@@ -598,6 +916,14 @@ function runCheck(args: Record<string, string | boolean>): void {
       ...(files.stateJson
         ? { ".plan-state.json": Buffer.byteLength(files.stateJson) }
         : {}),
+      ...(files.assets
+        ? Object.fromEntries(
+            Object.entries(files.assets).map(([filename, base64]) => [
+              `assets/${filename}`,
+              Buffer.byteLength(base64, "base64"),
+            ]),
+          )
+        : {}),
     },
   };
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
@@ -616,6 +942,40 @@ function runPreview(args: Record<string, string | boolean>): void {
       : undefined,
   });
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+async function runServe(args: Record<string, string | boolean>): Promise<void> {
+  const portValue = optionalArg(args, "port");
+  const port = portValue ? Number(portValue) : undefined;
+  if (portValue && (!Number.isInteger(port) || port! < 0 || port! > 65535)) {
+    throw new Error("--port must be an integer between 0 and 65535.");
+  }
+
+  const bridge = await startLocalPlanBridge({
+    dir: stringArg(args, "dir"),
+    appUrl: optionalArg(args, "app-url"),
+    title: optionalArg(args, "title"),
+    brief: optionalArg(args, "brief"),
+    host: optionalArg(args, "host"),
+    port,
+    open: boolArg(args, "open"),
+    kind: optionalArg(args, "kind")
+      ? normalizeKind(optionalArg(args, "kind"))
+      : undefined,
+  });
+
+  process.stdout.write(`${JSON.stringify(bridge.result, null, 2)}\n`);
+  process.stderr.write(
+    `Local Plan bridge running at ${bridge.result.bridgeUrl}\nPress Ctrl+C to stop.\n`,
+  );
+
+  await new Promise<void>((resolve) => {
+    const stop = () => {
+      bridge.server.close(() => resolve());
+    };
+    process.once("SIGINT", stop);
+    process.once("SIGTERM", stop);
+  });
 }
 
 async function runBlocks(
@@ -678,6 +1038,7 @@ Usage:
   agent-native plan blocks [--format reference|schema] [--app-url <url>] [--out <file>] [--json]
   agent-native plan local init --title <title> [--brief <text>] [--kind plan|recap] [--dir <folder>] [--force]
   agent-native plan local check --dir <folder>
+  agent-native plan local serve --dir <folder> [--app-url <url>] [--kind plan|recap] [--open] [--port <port>]
   agent-native plan local preview --dir <folder> [--app-url <url>] [--kind plan|recap] [--open] [--out preview.html]
 
 The blocks command fetches the no-auth, read-only get-plan-blocks catalog from
@@ -694,10 +1055,12 @@ write actions, hosted storage, or SQLite.
 Common flow:
   agent-native plan blocks --out plan-blocks.md
   agent-native plan local init --title "Checkout review" --kind plan
-  agent-native plan local preview --dir plans/checkout-review --open
+  agent-native plan local serve --dir plans/checkout-review --open
 
-\`plan local preview\` opens the local Plan app route by default. Pass
-\`--app-url\` when your local Plan app is on a non-default port. \`--out\` is a
+\`plan local serve\` starts a tiny localhost bridge and opens the hosted Plan UI
+against that local-only source. The hosted app fetches the MDX from localhost in
+the browser; it does not write plan content to the hosted database. Use
+\`plan local preview\` for a local Plan dev server route. \`preview --out\` is a
 legacy/debug escape hatch that writes a standalone static HTML file.
 `;
 
@@ -736,6 +1099,9 @@ export async function runPlan(argv: string[]): Promise<void> {
       return;
     case "preview":
       runPreview(args);
+      return;
+    case "serve":
+      await runServe(args);
       return;
     case "help":
     case "--help":

--- a/packages/core/src/cli/plan-local.ts
+++ b/packages/core/src/cli/plan-local.ts
@@ -38,6 +38,12 @@ type LocalPlanFiles = {
   assets?: Record<string, string>;
 };
 
+export type LocalPlanValidationIssue = {
+  file: string;
+  line: number;
+  message: string;
+};
+
 type LocalPlanPreviewInput = {
   dir: string;
   kind?: LocalPlanKind;
@@ -476,10 +482,316 @@ function localPlanFileList(files: LocalPlanFiles): string[] {
   ];
 }
 
+function localPlanSourceEntries(files: LocalPlanFiles): Array<{
+  file: string;
+  source: string;
+}> {
+  return [
+    { file: "plan.mdx", source: files.planMdx },
+    ...(files.canvasMdx
+      ? [{ file: "canvas.mdx", source: files.canvasMdx }]
+      : []),
+    ...(files.prototypeMdx
+      ? [{ file: "prototype.mdx", source: files.prototypeMdx }]
+      : []),
+  ];
+}
+
+function lineNumberAt(source: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index; i += 1) {
+    if (source.charCodeAt(i) === 10) line += 1;
+  }
+  return line;
+}
+
+function maskFencedCode(source: string): string {
+  return source.replace(
+    /(^|\n)(```|~~~)[\s\S]*?(\n\2[^\n]*(?=\n|$))/g,
+    (match) => match.replace(/[^\n]/g, " "),
+  );
+}
+
+function findJsxOpeningTagEnd(source: string, start: number): number {
+  let quote: string | null = null;
+  let braceDepth = 0;
+  for (let i = start; i < source.length; i += 1) {
+    const char = source[i];
+    if (quote) {
+      if (char === "\\" && i + 1 < source.length) {
+        i += 1;
+        continue;
+      }
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "{") {
+      braceDepth += 1;
+      continue;
+    }
+    if (char === "}") {
+      braceDepth = Math.max(0, braceDepth - 1);
+      continue;
+    }
+    if (char === ">" && braceDepth === 0) return i;
+  }
+  return -1;
+}
+
+function addValidationIssue(
+  issues: LocalPlanValidationIssue[],
+  file: string,
+  source: string,
+  index: number,
+  message: string,
+) {
+  issues.push({ file, line: lineNumberAt(source, index), message });
+}
+
+const ENTITY_RE = /&(?:[a-z][a-z0-9]+|#[0-9]+|#x[0-9a-f]+);/gi;
+const HTML_TEXT_ATTR_RE =
+  /\b(?:aria-label|alt|placeholder|title|value)=\s*(?:"([^"]*)"|'([^']*)'|`([^`]*)`)/gi;
+const WIREFRAME_TEXT_ATTR_RE =
+  /\b(?:text|value|label|placeholder|title|note|due)=\s*(?:"([^"]*)"|'([^']*)'|`([^`]*)`)/gi;
+
+function normalizeVisibleText(value: string): string {
+  return value
+    .replace(/&nbsp;|&#160;|&#x0*a0;/gi, " ")
+    .replace(ENTITY_RE, "x")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function meaningfulTextLength(value: string | undefined): number {
+  return normalizeVisibleText(value ?? "").length;
+}
+
+function htmlMeaningfulTextLength(html: string): number {
+  let length = 0;
+  for (const match of html.matchAll(HTML_TEXT_ATTR_RE)) {
+    length += meaningfulTextLength(match[1] ?? match[2] ?? match[3]);
+  }
+
+  const visibleText = html
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<script\b[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ");
+  length += meaningfulTextLength(visibleText);
+
+  return length;
+}
+
+function hasSkeletonGeometry(html: string): boolean {
+  return (
+    /<(?:div|span|section|main|article|ul|li)\b/i.test(html) &&
+    /\b(?:height|width|background|border|padding|wf-card|wf-box|wf-pill|wf-chip)\b/i.test(
+      html,
+    )
+  );
+}
+
+function stringAttributeValues(source: string, name: string): string[] {
+  const values: string[] = [];
+  const re = new RegExp(
+    `\\b${name}\\s*=\\s*(?:\\{\\s*\`([\\s\\S]*?)\`\\s*\\}|\\{\\s*"([^"]*)"\\s*\\}|\\{\\s*'([^']*)'\\s*\\}|"([^"]*)"|'([^']*)')`,
+    "g",
+  );
+  for (const match of source.matchAll(re)) {
+    const value = match[1] ?? match[2] ?? match[3] ?? match[4] ?? match[5];
+    if (value !== undefined) values.push(value);
+  }
+  return values;
+}
+
+function hasUnparsedAttributeExpression(source: string, name: string): boolean {
+  return new RegExp(`\\b${name}\\s*=\\s*\\{`).test(source);
+}
+
+function hasMeaningfulWireframeHtml(screenOpening: string): boolean | null {
+  const htmlValues = stringAttributeValues(screenOpening, "html");
+  if (htmlValues.length === 0) {
+    return hasUnparsedAttributeExpression(screenOpening, "html") ? null : false;
+  }
+  return htmlValues.some(
+    (html) => htmlMeaningfulTextLength(html) >= 2 || hasSkeletonGeometry(html),
+  );
+}
+
+function hasMeaningfulKitScreen(screenSource: string): boolean {
+  for (const match of screenSource.matchAll(WIREFRAME_TEXT_ATTR_RE)) {
+    if (meaningfulTextLength(match[1] ?? match[2] ?? match[3]) >= 2) {
+      return true;
+    }
+  }
+  if (/\bitems\s*=\s*\{[\s\S]*?\blabel\s*:/i.test(screenSource)) return true;
+  if (/\brows\s*=\s*\{[\s\S]*?\b[klv]\s*:/i.test(screenSource)) return true;
+  return false;
+}
+
+function hasMeaningfulWireframeScreen(blockSource: string): boolean | null {
+  const screenMatch = /<Screen\b/.exec(blockSource);
+  if (!screenMatch) return false;
+  const screenStart = screenMatch.index;
+  const screenOpeningEnd = findJsxOpeningTagEnd(blockSource, screenStart);
+  if (screenOpeningEnd < 0) return false;
+  const screenOpening = blockSource.slice(screenStart, screenOpeningEnd + 1);
+  const htmlMeaningful = hasMeaningfulWireframeHtml(screenOpening);
+  if (htmlMeaningful === true) return true;
+
+  const selfClosing = /\/\s*>$/.test(screenOpening);
+  const closeIndex = selfClosing
+    ? -1
+    : blockSource.indexOf("</Screen>", screenOpeningEnd + 1);
+  const screenSource =
+    closeIndex >= 0
+      ? blockSource.slice(screenStart, closeIndex + "</Screen>".length)
+      : screenOpening;
+  if (hasMeaningfulKitScreen(screenSource)) return true;
+
+  return htmlMeaningful === null ? null : false;
+}
+
+function lintWireframeBlocks(
+  file: string,
+  source: string,
+  issues: LocalPlanValidationIssue[],
+) {
+  const scanSource = maskFencedCode(source);
+  const re = /<WireframeBlock\b/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(scanSource))) {
+    const start = match.index;
+    const openingEnd = findJsxOpeningTagEnd(scanSource, start);
+    if (openingEnd < 0) {
+      addValidationIssue(
+        issues,
+        file,
+        source,
+        start,
+        "WireframeBlock opening tag is not closed.",
+      );
+      continue;
+    }
+
+    const opening = scanSource.slice(start, openingEnd + 1);
+    const unsupportedAttr = opening.match(
+      /\b(data|screens|screen|elements)\s*=/,
+    );
+    if (unsupportedAttr) {
+      addValidationIssue(
+        issues,
+        file,
+        source,
+        start,
+        `WireframeBlock uses unsupported "${unsupportedAttr[1]}" prop. Put content inside a <Screen> child instead.`,
+      );
+    }
+
+    const selfClosing = /\/\s*>$/.test(opening);
+    const closeTag = "</WireframeBlock>";
+    const closeIndex = selfClosing
+      ? -1
+      : scanSource.indexOf(closeTag, openingEnd + 1);
+    const blockSource = selfClosing
+      ? opening
+      : closeIndex >= 0
+        ? scanSource.slice(start, closeIndex + closeTag.length)
+        : scanSource.slice(start, openingEnd + 1);
+
+    if (!selfClosing && closeIndex < 0) {
+      addValidationIssue(
+        issues,
+        file,
+        source,
+        start,
+        "WireframeBlock must have a closing </WireframeBlock> tag.",
+      );
+    }
+
+    if (selfClosing || !/<Screen\b/.test(blockSource)) {
+      addValidationIssue(
+        issues,
+        file,
+        source,
+        start,
+        'WireframeBlock must wrap a <Screen> child; self-closing wireframes render empty. Use <WireframeBlock><Screen surface="browser">...</Screen></WireframeBlock>.',
+      );
+      continue;
+    }
+
+    const meaningfulScreen = hasMeaningfulWireframeScreen(blockSource);
+    if (meaningfulScreen === false) {
+      addValidationIssue(
+        issues,
+        file,
+        source,
+        start,
+        'WireframeBlock contains an empty <Screen>; local previews render blank wireframes. Add visible html text/controls or kit nodes such as <Title text="Checkout" /> and <Btn label="Pay" />.',
+      );
+    }
+  }
+}
+
+function lintColumnsBlocks(
+  file: string,
+  source: string,
+  issues: LocalPlanValidationIssue[],
+) {
+  const scanSource = maskFencedCode(source);
+  const re = /<Columns\b/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(scanSource))) {
+    const start = match.index;
+    const openingEnd = findJsxOpeningTagEnd(scanSource, start);
+    if (openingEnd < 0) continue;
+    const opening = scanSource.slice(start, openingEnd + 1);
+    if (/\bcolumns\s*=/.test(opening)) {
+      addValidationIssue(
+        issues,
+        file,
+        source,
+        start,
+        'Columns must use <Column> children, not a columns= prop. Use <Columns><Column label="Before">...</Column><Column label="After">...</Column></Columns>.',
+      );
+    }
+  }
+}
+
+export function validateLocalPlanFiles(
+  files: LocalPlanFiles,
+): LocalPlanValidationIssue[] {
+  const issues: LocalPlanValidationIssue[] = [];
+  for (const entry of localPlanSourceEntries(files)) {
+    lintWireframeBlocks(entry.file, entry.source, issues);
+    lintColumnsBlocks(entry.file, entry.source, issues);
+  }
+  return issues;
+}
+
+export function assertLocalPlanFilesValid(files: LocalPlanFiles): void {
+  const issues = validateLocalPlanFiles(files);
+  if (issues.length === 0) return;
+  const details = issues
+    .slice(0, 8)
+    .map((issue) => `${issue.file}:${issue.line} ${issue.message}`)
+    .join("\n");
+  const overflow =
+    issues.length > 8 ? `\n...plus ${issues.length - 8} more issues` : "";
+  throw new Error(
+    `Local plan source validation failed:\n${details}${overflow}\nRun \`npx @agent-native/core@latest plan blocks --out plan-blocks.md\` and update the MDX to the documented block shapes.`,
+  );
+}
+
 export function buildLocalPlanPreviewHtml(
   input: LocalPlanPreviewInput,
 ): string {
   const files = readLocalPlanFiles(input.dir);
+  assertLocalPlanFilesValid(files);
   const parsed = stripFrontmatter(files.planMdx);
   const title =
     input.title ||
@@ -599,6 +911,7 @@ export function writeLocalPlanPreview(input: {
 }): LocalPlanPreviewResult {
   const dir = path.resolve(input.dir);
   const files = readLocalPlanFiles(dir);
+  assertLocalPlanFilesValid(files);
   const parsed = stripFrontmatter(files.planMdx);
   const kind = input.kind || normalizeKind(parsed.frontmatter.kind);
   const title =
@@ -639,6 +952,7 @@ function buildLocalPlanBridgePayload(input: {
 }): LocalPlanBridgePayload {
   const dir = path.resolve(input.dir);
   const files = readLocalPlanFiles(dir);
+  assertLocalPlanFilesValid(files);
   const parsed = stripFrontmatter(files.planMdx);
   const kind = input.kind || normalizeKind(parsed.frontmatter.kind);
   const title =
@@ -723,6 +1037,12 @@ export async function startLocalPlanBridge(input: {
   openUrl?: (url: string) => OpenLocalUrlResult;
 }): Promise<LocalPlanBridgeServer> {
   const dir = path.resolve(input.dir);
+  const initialPayload = buildLocalPlanBridgePayload({
+    dir,
+    kind: input.kind,
+    title: input.title,
+    brief: input.brief,
+  });
   const token = input.token || crypto.randomBytes(24).toString("base64url");
   const host = input.host || "127.0.0.1";
   const appUrl = normalizeBridgeAppUrl(input.appUrl);
@@ -788,12 +1108,6 @@ export async function startLocalPlanBridge(input: {
   const bridgeUrl = `http://${bridgeHostForUrl(host)}:${address.port}/local-plan.json?token=${encodeURIComponent(
     token,
   )}`;
-  const payload = buildLocalPlanBridgePayload({
-    dir,
-    kind: input.kind,
-    title: input.title,
-    brief: input.brief,
-  });
   const url = localPlanBridgePageUrl({ dir, bridgeUrl, appUrl });
   const openResult = input.open
     ? (input.openUrl || openLocalUrl)(url)
@@ -807,9 +1121,9 @@ export async function startLocalPlanBridge(input: {
       url,
       bridgeUrl,
       appUrl,
-      title: payload.title,
-      kind: payload.kind,
-      files: payload.files,
+      title: initialPayload.title,
+      kind: initialPayload.kind,
+      files: initialPayload.files,
       host,
       port: address.port,
       ...(openResult
@@ -861,9 +1175,9 @@ function writeLocalPlanSkeleton(input: {
     "## Review Surface",
     "",
     "Author the structured plan or recap here. You can add Agent-Native Plan MDX",
-    "blocks such as `<WireframeBlock />`, `<Diagram />`, `<TabsBlock />`,",
-    "`<FileTree />`, or `<Diff />`; the local preview will show the source",
-    "without publishing it to the Plan app.",
+    'blocks such as `<WireframeBlock><Screen surface="browser">...</Screen></WireframeBlock>`,',
+    "`<Diagram />`, `<TabsBlock />`, `<FileTree />`, or `<Diff />`; the local",
+    "preview will show the source without publishing it to the Plan app.",
     "",
   ].join("\n");
   fs.writeFileSync(planPath, mdx, "utf-8");
@@ -898,10 +1212,12 @@ function runInit(args: Record<string, string | boolean>): void {
 function runCheck(args: Record<string, string | boolean>): void {
   const dir = stringArg(args, "dir");
   const files = readLocalPlanFiles(dir);
+  assertLocalPlanFilesValid(files);
   const parsed = stripFrontmatter(files.planMdx);
   const result = {
     ok: true,
     noDb: true,
+    validation: "passed",
     dir: files.dir,
     title: parsed.frontmatter.title || firstHeading(parsed.body),
     kind: normalizeKind(parsed.frontmatter.kind),

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -1082,10 +1082,10 @@ describe("agent-native skills", () => {
 
     expect(promptSkills).toHaveBeenCalledTimes(1);
     expect(context?.options.map((o) => o.value)).toEqual([
-      "assets",
-      "design-exploration",
       "visual-plan",
       "visual-recap",
+      "assets",
+      "design-exploration",
       "context-xray",
     ]);
     expect(context?.initialTargets).toEqual(["visual-plan", "visual-recap"]);
@@ -1155,18 +1155,14 @@ describe("agent-native skills", () => {
     });
 
     expect(allContext?.options.map((option) => option.value)).toEqual([
-      "assets",
-      "design-exploration",
       "visual-plan",
       "visual-recap",
+      "assets",
+      "design-exploration",
       "context-xray",
       "quick-recap",
     ]);
-    expect(allContext?.initialTargets).toEqual([
-      "visual-plan",
-      "visual-recap",
-      "quick-recap",
-    ]);
+    expect(allContext?.initialTargets).toEqual(["visual-plan", "visual-recap"]);
   });
 
   it("asks for plan mode before clients and skips MCP for local-files", async () => {
@@ -1297,6 +1293,52 @@ describe("agent-native skills", () => {
       ]),
     );
     expect(commands[0].options).toMatchObject({ stdio: "silent" });
+  });
+
+  it("does not forward MCP-only Cowork to public skill copy installs", async () => {
+    const root = tmpDir();
+    const commands: { cmd: string; args: string[] }[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runSkills(["add", "--no-connect"], {
+      baseDir: root,
+      catalogMode: "all",
+      publicSkillSource: "BuilderIO/skills",
+      publicSkillEntries: [
+        {
+          name: "quick-recap",
+          description: "Use final response status blocks.",
+        },
+      ],
+      isInteractive: () => true,
+      promptSkills: async () => ["visual-plan", "visual-recap", "quick-recap"],
+      promptPlanMode: async () => "hosted",
+      promptClients: async () => ["codex", "cowork"],
+      promptScope: async () => "project",
+      promptGithubAction: async () => false,
+      promptUpdateInstructions: async () => false,
+      runCommand: async (cmd, args) => {
+        commands.push({ cmd, args });
+        return 0;
+      },
+    });
+
+    const publicCopy = commands.find((command) =>
+      command.args.includes("@agent-native/skills@latest"),
+    );
+    expect(publicCopy?.args).toEqual(
+      expect.arrayContaining([
+        "@agent-native/skills@latest",
+        "add",
+        "--copy",
+        "BuilderIO/skills",
+        "--skill",
+        "quick-recap",
+        "--client",
+        "codex",
+      ]),
+    );
+    expect(publicCopy?.args).not.toContain("codex,cowork");
   });
 
   it("does not forward local plan mode to non-plan public skill copies", async () => {

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -86,7 +86,7 @@ plans and recaps should live: hosted Plans for shareable links/comments, local
 files for "No sharing, all local.", or a self-hosted/custom Plan app URL.
 Pass --mode to choose directly. Local-files mode skips MCP registration and
 auth and installs instructions that default to a no-auth block catalog fetch,
-MDX folders, and local preview.
+MDX folders, and the localhost bridge viewer.
 
 When installing visual-recap interactively, the CLI offers to add the optional PR
 Visual Recap GitHub Action. Pass --with-github-action to write it directly, then
@@ -294,10 +294,10 @@ npx @agent-native/core@latest skills add visual-plan --mode local-files
 This mode does not register the Plan MCP connector. Before authoring structured
 MDX, fetch the no-auth, schema-only block catalog with
 \`npx @agent-native/core@latest plan blocks --out plan-blocks.md\`, read that file,
-write \`plans/<slug>/plan.mdx\` locally, then run \`plan local preview\`. Plain
-text skill installs (Vercel Skills CLI, copied GitHub files, etc.) can follow
-that same local flow if \`@agent-native/core\` is available. Text alone cannot
-register MCP tools; hosted/shareable Plans still need the Agent-Native CLI
+write the MDX folder locally, then run \`plan local serve\`. Plain text skill
+installs (Vercel Skills CLI, copied GitHub files, etc.) can follow that same
+local flow if \`@agent-native/core\` is available. Text alone cannot register
+MCP tools; hosted/shareable Plans still need the Agent-Native CLI
 install/reconnect step above.
 
 **Browser (people you share with).** Open the Plans editor and create & edit
@@ -307,10 +307,10 @@ share; signing in claims the plans you made as a guest into your account.
 Sharing and commenting require an account: public/shared plans are viewable by
 anyone with the link, but commenting on them needs an agent-native account.
 
-For fully offline, no-account use, use local-files mode and the local preview
-command. The optional \`plan blocks\` lookup reads only public schema metadata; if
-network access is unavailable, use the bundled references and validate with
-\`plan local preview\`.
+For no-account, no-DB plan storage, use local-files mode and the local bridge
+command. The optional \`plan blocks\` lookup reads only public schema metadata.
+If network access is unavailable, use the bundled references and a local Plan
+app/runtime for validation.
 
 If a Plans tool returns \`needs auth\`, \`Unauthorized\`, or \`Session terminated\`,
 do not keep retrying the tool. Stop and give the user the reconnect step for the
@@ -1349,7 +1349,7 @@ skill — never hand-edit one stored plan. Turn feedback into better guidance.
 ## Local-Files Privacy Mode
 
 Use local-files privacy mode when the user explicitly asks for no DB writes,
-no hosted Plan app, no Plan MCP publish, fully local files, offline/private
+no hosted Plan database writes, no Plan MCP publish, fully local files, offline/private
 planning, repo-owned/source-controlled planning artifacts, or when
 \`AGENT_NATIVE_PLANS_MODE=local-files\` is set. Also use it when a user or repo
 policy says a plan must stay under their own brand, domain, source control, or
@@ -1367,21 +1367,24 @@ The local-files contract is:
   \`plan blocks\` command calls the public no-auth \`get-plan-blocks\` route and
   writes only registry metadata to disk; use \`--format schema\` if exact nested
   fields are needed. If network access is unavailable, use the bundled
-  references and rely on \`plan local preview\` to catch invalid tags.
-- Write the plan as a local MDX folder under \`plans/<slug>/\`: \`plan.mdx\`,
-  optional \`canvas.mdx\`, optional \`prototype.mdx\`, and optional
-  \`.plan-state.json\`.
-- Run \`npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind plan --open\`
-  after writing or updating the folder. Report the returned local URL or the
-  \`/local-plans/<slug>\` route if the local Plan app is running with the same
-  \`PLAN_LOCAL_DIR\`.
+  references and rely on \`plan local serve\` to catch invalid tags.
+- Write the plan as a local MDX folder: use \`plans/<slug>/\` when the user
+  wants the artifact checked into the repo, or use a repo-ignored/temporary
+  folder such as \`.agent-native/plans/<slug>/\` or \`/tmp/agent-native-plans/<slug>/\`
+  when it should not be checked in. The folder contains \`plan.mdx\`, optional
+  \`canvas.mdx\`, optional \`prototype.mdx\`, and optional \`.plan-state.json\`.
+- Run \`npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind plan --open\`
+  after writing or updating the folder. Report the returned local bridge URL. It opens the hosted Plan UI but reads
+  from the localhost bridge on this machine, so it is not shareable across
+  machines. If the Plan app itself is running locally with the same
+  \`PLAN_LOCAL_DIR\`, the \`/local-plans/<slug>\` route is also valid.
 - Do **not** call \`create-visual-plan\`, \`create-ui-plan\`,
   \`create-prototype-plan\`, \`create-plan-design\`, \`import-visual-plan-source\`,
   \`update-visual-plan\`, \`patch-visual-plan-source\`, \`get-plan-feedback\`,
   \`export-visual-plan\`, or any hosted Plan tool for that plan except the
   schema-only block catalog lookup above.
 - Treat feedback as file or chat feedback: update the MDX files directly, rerun
-  the local preview command, and summarize the new local URL/path. Hosted
+  the local bridge command, and summarize the new local bridge URL. Hosted
   comments, sharing, history, and publish/export receipts are unavailable until
   the user explicitly opts into publishing.
 
@@ -1501,7 +1504,7 @@ before spending attention on the literal lines.
 ## Local-Files Privacy Mode Exception
 
 Use local-files privacy mode when the user explicitly asks for no DB writes,
-no hosted Plan app, no Plan MCP publish, fully local files, offline/private
+no hosted Plan database writes, no Plan MCP publish, fully local files, offline/private
 recaps, or when \`AGENT_NATIVE_PLANS_MODE=local-files\` is set. This is the only
 exception to the hosted publish rule below.
 
@@ -1516,22 +1519,26 @@ In local-files mode:
   MCP connector is not registered; it calls the public no-auth
   \`get-plan-blocks\` route and sends no recap content. If network access is
   unavailable, use the bundled references and validate with
-  \`plan local preview\`.
-- Write the recap as a local MDX folder under \`plans/<slug>/\`: \`plan.mdx\`,
-  optional \`canvas.mdx\`, optional \`prototype.mdx\`, and optional
-  \`.plan-state.json\`. Set \`kind: "recap"\` and \`localOnly: true\` in
-  frontmatter/state when authoring the source.
-- Run \`npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind recap --open\`
-  after writing or updating the folder. Report the returned local URL or the
-  \`/local-plans/<slug>\` route if the local Plan app is running with the same
-  \`PLAN_LOCAL_DIR\`.
+  \`plan local serve\`.
+- Write the recap as a local MDX folder: use \`plans/<slug>/\` when the user
+  wants the artifact checked into the repo, or use a repo-ignored/temporary
+  folder such as \`.agent-native/plans/<slug>/\` or \`/tmp/agent-native-plans/<slug>/\`
+  when it should not be checked in. The folder contains \`plan.mdx\`, optional
+  \`canvas.mdx\`, optional \`prototype.mdx\`, and optional \`.plan-state.json\`. Set
+  \`kind: "recap"\` and \`localOnly: true\` in frontmatter/state when authoring
+  the source.
+- Run \`npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind recap --open\`
+  after writing or updating the folder. Report the returned local bridge URL. It opens the hosted Plan UI but reads
+  from the localhost bridge on this machine, so it is not shareable across
+  machines. If the Plan app itself is running locally with the same
+  \`PLAN_LOCAL_DIR\`, the \`/local-plans/<slug>\` route is also valid.
 - Do **not** call \`create-visual-recap\`, \`create-visual-plan\`,
   \`import-visual-plan-source\`, \`update-visual-plan\`,
   \`patch-visual-plan-source\`, \`get-plan-feedback\`, \`export-visual-plan\`,
   \`set-resource-visibility\`, or any hosted Plan tool for that recap except the
   schema-only block catalog lookup above.
 - Treat review feedback as file or chat feedback: update the MDX files directly,
-  rerun the local preview command, and summarize the new local URL/path.
+  rerun the local bridge command, and summarize the new local bridge URL.
   Hosted comments, sharing, screenshots, usage attachment, and PR sticky comment
   publishing are unavailable until the user explicitly opts into publishing.
 
@@ -1742,10 +1749,13 @@ a headless CI agent), state that in the recap handoff instead.
 
 ## Open And Report The Recap
 
-In local-files privacy mode, report the local preview URL/path from
-\`npx @agent-native/core@latest plan local preview\` or the \`/local-plans/<slug>\` route for a local
-Plan app using the same \`PLAN_LOCAL_DIR\`. Do not invent a hosted URL and do not
-publish just to get an absolute Plan link.
+In local-files privacy mode, report the local bridge URL from
+\`npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind recap --open\`.
+It opens the hosted Plan UI but reads from the localhost bridge on this machine,
+so it is not shareable across machines. If the Plan app itself is running
+locally with the same \`PLAN_LOCAL_DIR\`, the \`/local-plans/<slug>\` route is also
+valid. Do not invent a hosted database URL and do not publish just to get an
+absolute Plan link.
 
 After creating the recap, link the reviewer to the rendered plan with an
 **absolute URL on the origin whose database actually holds the plan**. That
@@ -1899,7 +1909,7 @@ was installed as plain text and no MCP tools are registered, run
 \`npx @agent-native/core@latest plan blocks --out plan-blocks.md\` and read that
 file first. The CLI command calls the public no-auth \`get-plan-blocks\` route and
 sends no plan/recap content. If network access is unavailable, use the bundled
-references and validate with \`plan local preview\`.
+references and validate with \`plan local serve\`.
 
 The catalog returns the authoritative, always-current block vocabulary generated
 live from the app's own block registry — the same config the renderer and MDX
@@ -2692,13 +2702,16 @@ function planModeInstructionBlock(input: {
     return `## Installed Mode
 
 Default storage for this installation: local files. Create and update plans and
-recaps as MDX folders under \`plans/<slug>/\`. Before authoring structured MDX,
-run \`npx @agent-native/core@latest plan blocks --out plan-blocks.md\` and read
-the no-auth block catalog; it sends no plan content. Then run
-\`npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind plan|recap --open\`,
-and report the local preview URL or path. No sharing, all local. Use a hosted
-or self-hosted Plan MCP connector only if the user explicitly asks to publish or
-share.`;
+recaps as MDX folders under \`plans/<slug>/\` when they should be checked in, or
+under a repo-ignored/temp folder when they should stay private scratch. Before
+authoring structured MDX, run
+\`npx @agent-native/core@latest plan blocks --out plan-blocks.md\` and read the
+no-auth block catalog; it sends no plan content. Then run
+\`npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind plan|recap --open\`,
+and report the local bridge URL. It opens the hosted Plan UI but reads from the
+localhost bridge on this machine, so it is not shareable across machines. No
+sharing, all local. Use a hosted or self-hosted Plan MCP connector only if the
+user explicitly asks to publish or share.`;
   }
   if (input.mode === "self-hosted") {
     return `## Installed Mode
@@ -3280,16 +3293,6 @@ const PUBLIC_SKILL_TARGET_PREFIX = "public-skills:";
 
 const BUILT_IN_SKILL_PROMPT_OPTIONS: SkillsTargetPromptContext["options"] = [
   {
-    value: "assets",
-    label: "assets",
-    hint: BUILT_IN_APP_SKILLS.assets.manifest.description,
-  },
-  {
-    value: "design-exploration",
-    label: "design-exploration",
-    hint: BUILT_IN_APP_SKILLS.design.manifest.description,
-  },
-  {
     value: "visual-plan",
     label: "visual-plan",
     hint: "Rich interactive visual plan that turns ordinary text plans into diagrams, file maps, annotated code, questions, and UI/prototype review.",
@@ -3298,6 +3301,16 @@ const BUILT_IN_SKILL_PROMPT_OPTIONS: SkillsTargetPromptContext["options"] = [
     value: "visual-recap",
     label: "visual-recap",
     hint: "Interactive visual recap that maps PRs/diffs with diagrams, annotated diffs, API/schema summaries, and review notes.",
+  },
+  {
+    value: "assets",
+    label: "assets",
+    hint: BUILT_IN_APP_SKILLS.assets.manifest.description,
+  },
+  {
+    value: "design-exploration",
+    label: "design-exploration",
+    hint: BUILT_IN_APP_SKILLS.design.manifest.description,
   },
   {
     value: "context-xray",
@@ -3370,10 +3383,10 @@ function skillPromptOptions(
 }
 
 function defaultSkillPromptTargets(options: RunSkillsOptions): string[] {
-  return [
-    ...DEFAULT_SKILL_PROMPT_TARGETS,
-    ...publicSkillEntries(options).map((entry) => entry.name),
-  ];
+  const available = new Set(
+    skillPromptOptions(options).map((entry) => entry.value),
+  );
+  return DEFAULT_SKILL_PROMPT_TARGETS.filter((target) => available.has(target));
 }
 
 function publicSkillSelectionTarget(skillNames: string[]): string {
@@ -3501,7 +3514,7 @@ async function promptForPlanMode(
       {
         value: "local-files",
         label: "Local files only",
-        hint: "Writes plans/<name>/plan.mdx in this repo and opens a local preview. No sharing, all local.",
+        hint: "Writes local MDX, starts a localhost bridge, and opens the hosted Plan UI. No sharing, all local.",
       },
       {
         value: "self-hosted",
@@ -3921,8 +3934,10 @@ function loadSkillTarget(
   };
 }
 
-function skillsAgentsForClients(clients: SkillInstructionClientId[]): string[] {
-  const agents = new Set<string>();
+function skillsAgentsForClients(
+  clients: SkillInstructionClientId[],
+): SkillInstructionClientId[] {
+  const agents = new Set<SkillInstructionClientId>();
   for (const client of clients) {
     if (client === "codex") agents.add("codex");
     if (client === "claude-code" || client === "claude-code-cli") {
@@ -4198,7 +4213,7 @@ async function addPlainSkillRepo(
   const args = agentNativeSkillsInstallArgs(
     parsed,
     target,
-    clients,
+    skillsAgents,
     options.baseDir,
   );
   if (!parsed.dryRun) {

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -38,7 +38,7 @@ Usage:
   npx @agent-native/core@latest skills list
   npx @agent-native/core@latest skills status [assets|design-exploration|visual-plan|visual-recap|context-xray] [--client codex|claude-code|pi|all] [--scope user|project] [--json]
   npx @agent-native/core@latest skills update [assets|design-exploration|visual-plan|visual-recap|context-xray] [--client codex|claude-code|pi|all] [--scope user|project] [--dry-run] [--json]
-  npx @agent-native/core@latest skills add assets|design-exploration|visual-plan|visual-recap|context-xray [--client codex|claude-code|claude-code-cli|cowork|cursor|opencode|github-copilot|all] [--scope user|project] [--mode hosted|local-files|self-hosted] [--mcp-url <url>] [--no-connect] [--with-github-action] [--yes] [--dry-run] [--json]
+  npx @agent-native/core@latest skills add assets|design-exploration|visual-plan|visual-recap|context-xray [--client codex|claude-code|cowork|cursor|opencode|github-copilot|all] [--scope user|project] [--mode hosted|local-files|self-hosted] [--mcp-url <url>] [--no-connect] [--with-github-action] [--yes] [--dry-run] [--json]
   npx @agent-native/core@latest skills add <manifest-or-app-dir|skill-repo> [--skill <name>] [--client ...] [--yes]
 
 Examples:

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -111,6 +111,8 @@ import {
 import { TextStreamingContext } from "./chat/markdown-renderer.js";
 import {
   ChatRunningContext,
+  ApprovalContext,
+  type ApprovalContextValue,
   ReconnectStreamMessage,
 } from "./chat/tool-call-display.js";
 import {
@@ -161,11 +163,13 @@ function createUserMessageRunConfig(
   requestMode?: AgentRequestMode,
   recoveryAction?: AgentRecoveryAction,
   trackInRunsTray?: boolean,
+  approvedToolCalls?: string[],
 ) {
   const custom: {
     references?: Reference[];
     requestMode?: AgentRequestMode;
     trackInRunsTray?: boolean;
+    approvedToolCalls?: string[];
   } = {};
   if (references && references.length > 0) {
     custom.references = references;
@@ -175,6 +179,9 @@ function createUserMessageRunConfig(
   }
   if (trackInRunsTray) {
     custom.trackInRunsTray = true;
+  }
+  if (approvedToolCalls && approvedToolCalls.length > 0) {
+    custom.approvedToolCalls = approvedToolCalls;
   }
   const options: {
     runConfig?: { custom: typeof custom };
@@ -2600,491 +2607,526 @@ const AssistantChatInner = forwardRef<
     ...(browserTabId ? { browserTabId } : {}),
   });
 
+  // Human-in-the-loop approvals: when the user approves a paused `needsApproval`
+  // tool call, re-issue the turn carrying the call's approval key so the server
+  // gate lets that specific call run. Reuses the same append path as recovery /
+  // queued messages (no hand-written fetch).
+  const approvalCtx = useMemo<ApprovalContextValue>(
+    () => ({
+      onApprove: (approvalKey: string) => {
+        threadRuntime.append({
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Approved. Go ahead and run the requested action.",
+            },
+          ],
+          ...createUserMessageRunConfig(
+            undefined,
+            execMode === "plan"
+              ? "plan"
+              : execMode === "build"
+                ? "act"
+                : undefined,
+            undefined,
+            undefined,
+            [approvalKey],
+          ),
+        } as Parameters<typeof threadRuntime.append>[0]);
+      },
+    }),
+    [threadRuntime, execMode],
+  );
+
   return (
     <CheckpointContext.Provider value={checkpointCtx}>
       <MessageActionsContext.Provider value={messageActionsCtx}>
-        <ChatRunningContext.Provider value={isRunning}>
-          <TextStreamingContext.Provider value={textStreaming}>
-            <div
-              data-agent-empty-state={
-                centeredEmptyState ? "centered" : undefined
-              }
-              className={cn(
-                "relative flex flex-1 flex-col h-full min-h-0 text-foreground",
-                className,
-              )}
-              onDragEnter={handleChatDragEnter}
-              onDragOver={handleChatDragOver}
-              onDragLeave={handleChatDragLeave}
-              onDropCapture={handleChatDropCapture}
-              onDrop={handleChatDrop}
-            >
-              {dropActive && (
-                <div
-                  aria-hidden="true"
-                  className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center rounded-md border-2 border-dashed border-primary/70 bg-primary/5 backdrop-blur-[1px]"
-                >
-                  <span className="rounded-md bg-background/90 px-3 py-1.5 text-xs font-medium text-foreground shadow-sm">
-                    Drop to attach
-                  </span>
-                </div>
-              )}
-              {showHeader && (
-                <div className="flex h-11 shrink-0 items-center justify-between border-b border-border px-4">
-                  <span className="text-[13px] font-medium text-muted-foreground">
-                    Agent
-                  </span>
-                  <div className="flex items-center gap-1">
-                    {onSwitchToCli && (
-                      <TooltipProvider delayDuration={200}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              onClick={onSwitchToCli}
-                              aria-label="Switch to CLI"
-                              className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground px-2 py-1 rounded-md hover:bg-accent"
-                            >
-                              <IconTerminal className="h-3.5 w-3.5" />
-                              CLI
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent>Switch to CLI</TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* Messages area */}
+        <ApprovalContext.Provider value={approvalCtx}>
+          <ChatRunningContext.Provider value={isRunning}>
+            <TextStreamingContext.Provider value={textStreaming}>
               <div
-                ref={scrollRef}
-                className="agent-chat-scroll flex-1 overflow-y-auto overflow-x-hidden min-h-0"
+                data-agent-empty-state={
+                  centeredEmptyState ? "centered" : undefined
+                }
+                className={cn(
+                  "relative flex flex-1 flex-col h-full min-h-0 text-foreground",
+                  className,
+                )}
+                onDragEnter={handleChatDragEnter}
+                onDragOver={handleChatDragOver}
+                onDragLeave={handleChatDragLeave}
+                onDropCapture={handleChatDropCapture}
+                onDrop={handleChatDrop}
               >
-                {authError ? (
-                  <div className="flex flex-col items-center justify-center h-full px-4 gap-3">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
-                      {authSessionAvailable ? (
-                        <IconRefresh className="h-5 w-5 text-muted-foreground" />
-                      ) : (
-                        <IconMessage className="h-5 w-5 text-muted-foreground" />
+                {dropActive && (
+                  <div
+                    aria-hidden="true"
+                    className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center rounded-md border-2 border-dashed border-primary/70 bg-primary/5 backdrop-blur-[1px]"
+                  >
+                    <span className="rounded-md bg-background/90 px-3 py-1.5 text-xs font-medium text-foreground shadow-sm">
+                      Drop to attach
+                    </span>
+                  </div>
+                )}
+                {showHeader && (
+                  <div className="flex h-11 shrink-0 items-center justify-between border-b border-border px-4">
+                    <span className="text-[13px] font-medium text-muted-foreground">
+                      Agent
+                    </span>
+                    <div className="flex items-center gap-1">
+                      {onSwitchToCli && (
+                        <TooltipProvider delayDuration={200}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                onClick={onSwitchToCli}
+                                aria-label="Switch to CLI"
+                                className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground px-2 py-1 rounded-md hover:bg-accent"
+                              >
+                                <IconTerminal className="h-3.5 w-3.5" />
+                                CLI
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent>Switch to CLI</TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
                       )}
                     </div>
-                    <div className="text-center max-w-[280px]">
-                      <p className="text-sm font-medium text-foreground mb-1">
-                        {authSessionAvailable
-                          ? "Chat session needs refresh"
-                          : authError.sessionExpired
-                            ? "Session expired"
-                            : "Authentication required"}
-                      </p>
-                      <p className="text-xs text-muted-foreground leading-relaxed">
-                        {authSessionAvailable
-                          ? "You're signed in, but this chat connection needs to reconnect."
-                          : authError.sessionExpired
-                            ? "Your session may have expired. Log out and log back in to reconnect."
-                            : "You need to log in to use the agent."}
-                      </p>
-                    </div>
-                    <div className="flex gap-2">
-                      {!authError.sessionExpired && !authSessionAvailable && (
+                  </div>
+                )}
+
+                {/* Messages area */}
+                <div
+                  ref={scrollRef}
+                  className="agent-chat-scroll flex-1 overflow-y-auto overflow-x-hidden min-h-0"
+                >
+                  {authError ? (
+                    <div className="flex flex-col items-center justify-center h-full px-4 gap-3">
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+                        {authSessionAvailable ? (
+                          <IconRefresh className="h-5 w-5 text-muted-foreground" />
+                        ) : (
+                          <IconMessage className="h-5 w-5 text-muted-foreground" />
+                        )}
+                      </div>
+                      <div className="text-center max-w-[280px]">
+                        <p className="text-sm font-medium text-foreground mb-1">
+                          {authSessionAvailable
+                            ? "Chat session needs refresh"
+                            : authError.sessionExpired
+                              ? "Session expired"
+                              : "Authentication required"}
+                        </p>
+                        <p className="text-xs text-muted-foreground leading-relaxed">
+                          {authSessionAvailable
+                            ? "You're signed in, but this chat connection needs to reconnect."
+                            : authError.sessionExpired
+                              ? "Your session may have expired. Log out and log back in to reconnect."
+                              : "You need to log in to use the agent."}
+                        </p>
+                      </div>
+                      <div className="flex gap-2">
+                        {!authError.sessionExpired && !authSessionAvailable && (
+                          <button
+                            onClick={() => {
+                              const ret =
+                                window.location.pathname +
+                                window.location.search;
+                              window.location.href =
+                                agentNativePath("/_agent-native/sign-in") +
+                                `?return=${encodeURIComponent(ret)}`;
+                            }}
+                            className="text-xs text-background bg-foreground hover:opacity-90 px-3 py-1.5 rounded-md"
+                          >
+                            Log in
+                          </button>
+                        )}
+                        {authError.sessionExpired && !authSessionAvailable && (
+                          <button
+                            onClick={async () => {
+                              try {
+                                await fetch(
+                                  agentNativePath("/_agent-native/auth/logout"),
+                                  {
+                                    method: "POST",
+                                  },
+                                );
+                              } catch {}
+                              window.location.reload();
+                            }}
+                            className="text-xs text-destructive hover:text-destructive/80 px-3 py-1.5 rounded-md border border-destructive/30 hover:bg-destructive/10"
+                          >
+                            Log out
+                          </button>
+                        )}
                         <button
                           onClick={() => {
-                            const ret =
-                              window.location.pathname + window.location.search;
-                            window.location.href =
-                              agentNativePath("/_agent-native/sign-in") +
-                              `?return=${encodeURIComponent(ret)}`;
-                          }}
-                          className="text-xs text-background bg-foreground hover:opacity-90 px-3 py-1.5 rounded-md"
-                        >
-                          Log in
-                        </button>
-                      )}
-                      {authError.sessionExpired && !authSessionAvailable && (
-                        <button
-                          onClick={async () => {
-                            try {
-                              await fetch(
-                                agentNativePath("/_agent-native/auth/logout"),
-                                {
-                                  method: "POST",
-                                },
-                              );
-                            } catch {}
+                            setAuthError(null);
                             window.location.reload();
                           }}
-                          className="text-xs text-destructive hover:text-destructive/80 px-3 py-1.5 rounded-md border border-destructive/30 hover:bg-destructive/10"
+                          className={
+                            authSessionAvailable
+                              ? "text-xs text-background bg-foreground hover:opacity-90 px-3 py-1.5 rounded-md"
+                              : "text-xs text-muted-foreground hover:text-foreground px-3 py-1.5 rounded-md border border-border hover:bg-accent"
+                          }
                         >
-                          Log out
+                          Refresh chat
                         </button>
-                      )}
-                      <button
-                        onClick={() => {
-                          setAuthError(null);
-                          window.location.reload();
-                        }}
-                        className={
-                          authSessionAvailable
-                            ? "text-xs text-background bg-foreground hover:opacity-90 px-3 py-1.5 rounded-md"
-                            : "text-xs text-muted-foreground hover:text-foreground px-3 py-1.5 rounded-md border border-border hover:bg-accent"
-                        }
-                      >
-                        Refresh chat
-                      </button>
-                    </div>
-                  </div>
-                ) : missingApiKey && messages.length === 0 ? (
-                  <div className="flex flex-col items-center justify-center h-full px-2">
-                    <BuilderSetupCard
-                      onConnected={handleBuilderConnected}
-                      bouncePulse={missingKeyBouncePulse}
-                    />
-                  </div>
-                ) : isRestoring ? (
-                  <div className="flex flex-col gap-3 p-4">
-                    <div className="flex justify-end">
-                      <div className="h-8 w-32 rounded-lg bg-muted animate-pulse" />
-                    </div>
-                    <div className="flex flex-col gap-1.5">
-                      <div className="h-4 w-48 rounded bg-muted animate-pulse" />
-                      <div className="h-4 w-64 rounded bg-muted animate-pulse" />
-                      <div className="h-4 w-40 rounded bg-muted animate-pulse" />
-                    </div>
-                  </div>
-                ) : messages.length === 0 && !isReconnecting ? (
-                  <div
-                    className={cn(
-                      "agent-empty-state",
-                      emptyStateDisplay === "hidden"
-                        ? "sr-only"
-                        : "flex h-full flex-col items-center justify-center gap-4 px-4 py-16",
-                    )}
-                  >
-                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
-                      <IconMessage className="h-5 w-5 text-muted-foreground" />
-                    </div>
-                    <p className="sr-only">
-                      {emptyStateText ?? "How can I help you?"}
-                    </p>
-                    {emptyStateAddon}
-                    {resolvedSuggestions && resolvedSuggestions.length > 0 ? (
-                      <div className="flex flex-col gap-1.5 w-full max-w-[280px]">
-                        {resolvedSuggestions.map((suggestion) => (
-                          <button
-                            key={suggestion}
-                            onClick={() => {
-                              threadRuntime.append({
-                                role: "user",
-                                content: [{ type: "text", text: suggestion }],
-                              });
-                            }}
-                            className="w-full rounded-lg border border-border px-3 py-2 text-left text-[13px] text-muted-foreground hover:bg-accent hover:text-foreground"
-                          >
-                            {suggestion}
-                          </button>
-                        ))}
                       </div>
-                    ) : null}
-                  </div>
-                ) : (
-                  <div className="agent-thread-content flex flex-col gap-4 px-4 py-4">
-                    <AssistantMessageListErrorBoundary
-                      resetKey={messageListResetKey}
-                    >
-                      <ThreadPrimitive.Messages
-                        components={{
-                          UserMessage,
-                          AssistantMessage,
-                        }}
-                      />
-                    </AssistantMessageListErrorBoundary>
-                    {missingApiKey && (
+                    </div>
+                  ) : missingApiKey && messages.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center h-full px-2">
                       <BuilderSetupCard
                         onConnected={handleBuilderConnected}
                         bouncePulse={missingKeyBouncePulse}
                       />
-                    )}
-                    {visibleLoopLimit && !showRunningInUI && (
-                      <LoopLimitContinueCard
-                        info={visibleLoopLimit}
-                        onContinue={() => {
-                          setShowContinue(false);
-                          setLoopLimitInfo(null);
-                          addToQueue(
-                            "Continue from where you left off.",
-                            undefined,
-                            undefined,
-                            undefined,
-                            undefined,
-                            "queued",
-                            "continue",
-                          );
-                        }}
-                      />
-                    )}
-                    {shouldShowRunError && visibleRunError && (
-                      <RunErrorRecoveryCard
-                        info={visibleRunError}
-                        onContinue={() => {
-                          setRunErrorInfo(null);
-                          addToQueue(
-                            "Continue from where you stopped. Use the partial work above, verify what succeeded, and finish the original request. Do not rerun the exact same failed tool input unless the failure was transient or the user explicitly asked for an exact rerun. Prefer dedicated app actions over raw database edits when they exist.",
-                            undefined,
-                            undefined,
-                            undefined,
-                            undefined,
-                            "queued",
-                            "continue",
-                          );
-                        }}
-                        onRetry={() => {
-                          setRunErrorInfo(null);
-                          addToQueue(
-                            lastUserText
-                              ? `Retry the previous request from a clean approach. Do not rerun the exact same failed tool input unless the failure was transient or the user explicitly asked for an exact rerun. If a provider query failed because of schema, syntax, or type mismatch, diagnose the error and adjust the query first.\n\nOriginal request:\n\n${lastUserText}`
-                              : "Retry the previous request from a clean approach. Do not rerun the exact same failed tool input unless the failure was transient or the user explicitly asked for an exact rerun. If a provider query failed because of schema, syntax, or type mismatch, diagnose the error and adjust the query first.",
-                            undefined,
-                            undefined,
-                            undefined,
-                            undefined,
-                            "queued",
-                            "retry",
-                          );
-                        }}
-                        onFork={onForkChat}
-                        onDismiss={() => {
-                          if (visibleRunErrorKey) {
-                            setDismissedRunErrorKey(visibleRunErrorKey);
-                          }
-                          setRunErrorInfo(null);
-                        }}
-                      />
-                    )}
-                    {(isReconnecting || reconnectFrozen) &&
-                      reconnectContent.length > 0 && (
-                        <ReconnectStreamMessage content={reconnectContent} />
+                    </div>
+                  ) : isRestoring ? (
+                    <div className="flex flex-col gap-3 p-4">
+                      <div className="flex justify-end">
+                        <div className="h-8 w-32 rounded-lg bg-muted animate-pulse" />
+                      </div>
+                      <div className="flex flex-col gap-1.5">
+                        <div className="h-4 w-48 rounded bg-muted animate-pulse" />
+                        <div className="h-4 w-64 rounded bg-muted animate-pulse" />
+                        <div className="h-4 w-40 rounded bg-muted animate-pulse" />
+                      </div>
+                    </div>
+                  ) : messages.length === 0 && !isReconnecting ? (
+                    <div
+                      className={cn(
+                        "agent-empty-state",
+                        emptyStateDisplay === "hidden"
+                          ? "sr-only"
+                          : "flex h-full flex-col items-center justify-center gap-4 px-4 py-16",
                       )}
-                    {queuedMessages.map((msg) => {
-                      const displayText = msg.text
-                        .replace(/<context>[\s\S]*?<\/context>\n?/g, "")
-                        .trim();
-                      return (
-                        <div key={msg.id} className="flex justify-end group">
-                          <div className="relative max-w-[85%] rounded-lg bg-accent/50 text-foreground/60 px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words">
-                            <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground mb-1 font-medium uppercase tracking-wide">
-                              <IconClock className="h-3 w-3" />
-                              Queued
-                            </div>
-                            {displayText}
-                            {msg.images && msg.images.length > 0 && (
-                              <div className="flex flex-wrap gap-1.5 mt-1.5">
-                                {msg.images.map((img, j) => (
-                                  <img
-                                    key={j}
-                                    src={img}
-                                    alt=""
-                                    className="h-12 w-12 rounded object-cover border border-border/50"
-                                  />
-                                ))}
-                              </div>
-                            )}
+                    >
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+                        <IconMessage className="h-5 w-5 text-muted-foreground" />
+                      </div>
+                      <p className="sr-only">
+                        {emptyStateText ?? "How can I help you?"}
+                      </p>
+                      {emptyStateAddon}
+                      {resolvedSuggestions && resolvedSuggestions.length > 0 ? (
+                        <div className="flex flex-col gap-1.5 w-full max-w-[280px]">
+                          {resolvedSuggestions.map((suggestion) => (
                             <button
-                              type="button"
-                              onClick={() =>
-                                setQueuedMessages((prev) =>
-                                  prev.filter((m) => m.id !== msg.id),
-                                )
-                              }
-                              aria-label="Remove from queue"
-                              className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full border border-border bg-background text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-foreground hover:bg-accent shadow-sm"
+                              key={suggestion}
+                              onClick={() => {
+                                threadRuntime.append({
+                                  role: "user",
+                                  content: [{ type: "text", text: suggestion }],
+                                });
+                              }}
+                              className="w-full rounded-lg border border-border px-3 py-2 text-left text-[13px] text-muted-foreground hover:bg-accent hover:text-foreground"
                             >
-                              <IconX className="h-3 w-3" />
+                              {suggestion}
                             </button>
-                          </div>
+                          ))}
                         </div>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-
-              {/* Scroll to bottom button */}
-              {showScrollToBottom && (
-                <div className="shrink-0 flex justify-center -mb-1">
-                  <button
-                    type="button"
-                    onClick={scrollToBottom}
-                    className="flex h-7 w-7 items-center justify-center rounded-full border border-border bg-background shadow-sm hover:bg-accent"
-                    aria-label="Scroll to bottom"
-                  >
-                    <IconChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-                  </button>
-                </div>
-              )}
-
-              {composerSlot}
-              {guidedQuestions && guidedQuestions.length > 0 && (
-                <div className="shrink-0 px-3 pb-2 pt-1">
-                  <div className="rounded-lg border border-border bg-card/60 shadow-sm">
-                    <GuidedQuestionFlow
-                      questions={guidedQuestions}
-                      onSubmit={handleGuidedQuestionsSubmit}
-                      onSkip={handleGuidedQuestionsSkip}
-                      {...(guidedQuestionsTitle
-                        ? { title: guidedQuestionsTitle }
-                        : {})}
-                      {...(guidedQuestionsDescription
-                        ? { description: guidedQuestionsDescription }
-                        : {})}
-                      {...(guidedQuestionsSkipLabel
-                        ? { skipLabel: guidedQuestionsSkipLabel }
-                        : {})}
-                      {...(guidedQuestionsSubmitLabel
-                        ? { submitLabel: guidedQuestionsSubmitLabel }
-                        : {})}
-                      className="h-auto items-stretch justify-stretch bg-transparent"
-                    />
-                  </div>
-                </div>
-              )}
-              {showPlanModeCallout && (
-                <PlanModeCallout
-                  canImplementPlan={canImplementPlan}
-                  onImplementPlan={handleImplementPlan}
-                  onSwitchToAct={handleSwitchToAct}
-                />
-              )}
-              <SelectionAttachedPill />
-              {/* Keep live run progress pinned in the composer footer. */}
-              {showRunningInUI && (
-                <RunningActivityStatus
-                  label={
-                    isReconnecting
-                      ? "Reconnecting"
-                      : isAutoResuming
-                        ? "Resuming"
-                        : // Keep a steady "Thinking" while the model works —
-                          // never flip through transient activity labels
-                          // (e.g. "Contacting model", "Preparing X action").
-                          "Thinking"
-                  }
-                />
-              )}
-              {/* Inline attachment / body-size error */}
-              {composerError && (
-                <div
-                  role="alert"
-                  className="shrink-0 mx-3 mb-1.5 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive"
-                >
-                  <IconAlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-                  <span className="flex-1 leading-snug">{composerError}</span>
-                  <button
-                    type="button"
-                    aria-label="Dismiss error"
-                    onClick={() => setComposerError(null)}
-                    className="shrink-0 opacity-70 hover:opacity-100"
-                  >
-                    <IconX className="h-3 w-3" />
-                  </button>
-                </div>
-              )}
-              {/* Input area */}
-              <AgentComposerFrame
-                layoutVariant={composerLayoutVariant}
-                className={cn(
-                  composerAreaClassName,
-                  missingApiKey && "cursor-pointer",
-                  isComposerDisabled && "opacity-70",
-                )}
-                onClick={
-                  missingApiKey
-                    ? () => setMissingKeyBouncePulse((p) => p + 1)
-                    : undefined
-                }
-              >
-                <ComposerAttachmentPreviewStrip />
-                <TiptapComposer
-                  focusRef={tiptapRef}
-                  disabled={isComposerDisabled}
-                  placeholder={
-                    missingApiKey
-                      ? "Connect an AI engine above to start chatting…"
-                      : composerDisabled
-                        ? (composerDisabledPlaceholder ??
-                          "Open Desktop to use this chat.")
-                        : isRunning
-                          ? queuedMessages.length > 0
-                            ? `${queuedMessages.length} queued — send a follow-up...`
-                            : "Send a follow-up..."
-                          : composerPlaceholder
-                  }
-                  onSubmit={
-                    isRunning || composerContextItems.length > 0
-                      ? (text, references, attachments, options) =>
-                          void addToQueue(
-                            text,
-                            undefined,
-                            references.length > 0 ? references : undefined,
-                            attachments,
-                            undefined,
-                            options?.intent ?? "immediate",
-                            undefined,
-                            true,
-                          )
-                      : undefined
-                  }
-                  onSlashCommand={onSlashCommand}
-                  execMode={execMode}
-                  onExecModeChange={onExecModeChange}
-                  planModeDisabled={planModeDisabled}
-                  planModeDisabledReason={planModeDisabledReason}
-                  selectedModel={selectedModel ?? defaultModel}
-                  selectedEffort={selectedEffort}
-                  availableModels={availableModels}
-                  onModelChange={onModelChange}
-                  onEffortChange={onEffortChange}
-                  onConnectProvider={onConnectProvider}
-                  toolbarSlot={composerToolbarSlot}
-                  contextItems={composerContextItems}
-                  onRemoveContextItem={removeComposerContextItem}
-                  plusMenuMode={plusMenuMode}
-                  layoutVariant={composerLayoutVariant}
-                  providerConnectStatusEnabled={providerStatusChecksEnabled}
-                  draftScope={threadId || tabId}
-                  interceptBuildRequestsForBuilder
-                  onAttachmentError={setComposerError}
-                  extraActionButton={
-                    contextXRayEnabled ||
-                    composerExtraActionButton ||
-                    showRunningInUI ? (
-                      <>
-                        {contextXRayEnabled && (
-                          <ContextMeter threadId={threadId} />
+                      ) : null}
+                    </div>
+                  ) : (
+                    <div className="agent-thread-content flex flex-col gap-4 px-4 py-4">
+                      <AssistantMessageListErrorBoundary
+                        resetKey={messageListResetKey}
+                      >
+                        <ThreadPrimitive.Messages
+                          components={{
+                            UserMessage,
+                            AssistantMessage,
+                          }}
+                        />
+                      </AssistantMessageListErrorBoundary>
+                      {missingApiKey && (
+                        <BuilderSetupCard
+                          onConnected={handleBuilderConnected}
+                          bouncePulse={missingKeyBouncePulse}
+                        />
+                      )}
+                      {visibleLoopLimit && !showRunningInUI && (
+                        <LoopLimitContinueCard
+                          info={visibleLoopLimit}
+                          onContinue={() => {
+                            setShowContinue(false);
+                            setLoopLimitInfo(null);
+                            addToQueue(
+                              "Continue from where you left off.",
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              "queued",
+                              "continue",
+                            );
+                          }}
+                        />
+                      )}
+                      {shouldShowRunError && visibleRunError && (
+                        <RunErrorRecoveryCard
+                          info={visibleRunError}
+                          onContinue={() => {
+                            setRunErrorInfo(null);
+                            addToQueue(
+                              "Continue from where you stopped. Use the partial work above, verify what succeeded, and finish the original request. Do not rerun the exact same failed tool input unless the failure was transient or the user explicitly asked for an exact rerun. Prefer dedicated app actions over raw database edits when they exist.",
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              "queued",
+                              "continue",
+                            );
+                          }}
+                          onRetry={() => {
+                            setRunErrorInfo(null);
+                            addToQueue(
+                              lastUserText
+                                ? `Retry the previous request from a clean approach. Do not rerun the exact same failed tool input unless the failure was transient or the user explicitly asked for an exact rerun. If a provider query failed because of schema, syntax, or type mismatch, diagnose the error and adjust the query first.\n\nOriginal request:\n\n${lastUserText}`
+                                : "Retry the previous request from a clean approach. Do not rerun the exact same failed tool input unless the failure was transient or the user explicitly asked for an exact rerun. If a provider query failed because of schema, syntax, or type mismatch, diagnose the error and adjust the query first.",
+                              undefined,
+                              undefined,
+                              undefined,
+                              undefined,
+                              "queued",
+                              "retry",
+                            );
+                          }}
+                          onFork={onForkChat}
+                          onDismiss={() => {
+                            if (visibleRunErrorKey) {
+                              setDismissedRunErrorKey(visibleRunErrorKey);
+                            }
+                            setRunErrorInfo(null);
+                          }}
+                        />
+                      )}
+                      {(isReconnecting || reconnectFrozen) &&
+                        reconnectContent.length > 0 && (
+                          <ReconnectStreamMessage content={reconnectContent} />
                         )}
-                        {composerExtraActionButton}
-                        {showRunningInUI && (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
+                      {queuedMessages.map((msg) => {
+                        const displayText = msg.text
+                          .replace(/<context>[\s\S]*?<\/context>\n?/g, "")
+                          .trim();
+                        return (
+                          <div key={msg.id} className="flex justify-end group">
+                            <div className="relative max-w-[85%] rounded-lg bg-accent/50 text-foreground/60 px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words">
+                              <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground mb-1 font-medium uppercase tracking-wide">
+                                <IconClock className="h-3 w-3" />
+                                Queued
+                              </div>
+                              {displayText}
+                              {msg.images && msg.images.length > 0 && (
+                                <div className="flex flex-wrap gap-1.5 mt-1.5">
+                                  {msg.images.map((img, j) => (
+                                    <img
+                                      key={j}
+                                      src={img}
+                                      alt=""
+                                      className="h-12 w-12 rounded object-cover border border-border/50"
+                                    />
+                                  ))}
+                                </div>
+                              )}
                               <button
                                 type="button"
-                                onClick={stopActiveRun}
-                                className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md bg-muted text-foreground hover:bg-muted/80"
+                                onClick={() =>
+                                  setQueuedMessages((prev) =>
+                                    prev.filter((m) => m.id !== msg.id),
+                                  )
+                                }
+                                aria-label="Remove from queue"
+                                className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full border border-border bg-background text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-foreground hover:bg-accent shadow-sm"
                               >
-                                <IconPlayerStop className="h-3.5 w-3.5" />
+                                <IconX className="h-3 w-3" />
                               </button>
-                            </TooltipTrigger>
-                            <TooltipContent>Stop generating</TooltipContent>
-                          </Tooltip>
-                        )}
-                      </>
-                    ) : undefined
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+
+                {/* Scroll to bottom button */}
+                {showScrollToBottom && (
+                  <div className="shrink-0 flex justify-center -mb-1">
+                    <button
+                      type="button"
+                      onClick={scrollToBottom}
+                      className="flex h-7 w-7 items-center justify-center rounded-full border border-border bg-background shadow-sm hover:bg-accent"
+                      aria-label="Scroll to bottom"
+                    >
+                      <IconChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                    </button>
+                  </div>
+                )}
+
+                {composerSlot}
+                {guidedQuestions && guidedQuestions.length > 0 && (
+                  <div className="shrink-0 px-3 pb-2 pt-1">
+                    <div className="rounded-lg border border-border bg-card/60 shadow-sm">
+                      <GuidedQuestionFlow
+                        questions={guidedQuestions}
+                        onSubmit={handleGuidedQuestionsSubmit}
+                        onSkip={handleGuidedQuestionsSkip}
+                        {...(guidedQuestionsTitle
+                          ? { title: guidedQuestionsTitle }
+                          : {})}
+                        {...(guidedQuestionsDescription
+                          ? { description: guidedQuestionsDescription }
+                          : {})}
+                        {...(guidedQuestionsSkipLabel
+                          ? { skipLabel: guidedQuestionsSkipLabel }
+                          : {})}
+                        {...(guidedQuestionsSubmitLabel
+                          ? { submitLabel: guidedQuestionsSubmitLabel }
+                          : {})}
+                        className="h-auto items-stretch justify-stretch bg-transparent"
+                      />
+                    </div>
+                  </div>
+                )}
+                {showPlanModeCallout && (
+                  <PlanModeCallout
+                    canImplementPlan={canImplementPlan}
+                    onImplementPlan={handleImplementPlan}
+                    onSwitchToAct={handleSwitchToAct}
+                  />
+                )}
+                <SelectionAttachedPill />
+                {/* Keep live run progress pinned in the composer footer. */}
+                {showRunningInUI && (
+                  <RunningActivityStatus
+                    label={
+                      isReconnecting
+                        ? "Reconnecting"
+                        : isAutoResuming
+                          ? "Resuming"
+                          : // Keep a steady "Thinking" while the model works —
+                            // never flip through transient activity labels
+                            // (e.g. "Contacting model", "Preparing X action").
+                            "Thinking"
+                    }
+                  />
+                )}
+                {/* Inline attachment / body-size error */}
+                {composerError && (
+                  <div
+                    role="alert"
+                    className="shrink-0 mx-3 mb-1.5 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+                  >
+                    <IconAlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                    <span className="flex-1 leading-snug">{composerError}</span>
+                    <button
+                      type="button"
+                      aria-label="Dismiss error"
+                      onClick={() => setComposerError(null)}
+                      className="shrink-0 opacity-70 hover:opacity-100"
+                    >
+                      <IconX className="h-3 w-3" />
+                    </button>
+                  </div>
+                )}
+                {/* Input area */}
+                <AgentComposerFrame
+                  layoutVariant={composerLayoutVariant}
+                  className={cn(
+                    composerAreaClassName,
+                    missingApiKey && "cursor-pointer",
+                    isComposerDisabled && "opacity-70",
+                  )}
+                  onClick={
+                    missingApiKey
+                      ? () => setMissingKeyBouncePulse((p) => p + 1)
+                      : undefined
                   }
-                />
-              </AgentComposerFrame>
-            </div>
-          </TextStreamingContext.Provider>
-        </ChatRunningContext.Provider>
+                >
+                  <ComposerAttachmentPreviewStrip />
+                  <TiptapComposer
+                    focusRef={tiptapRef}
+                    disabled={isComposerDisabled}
+                    placeholder={
+                      missingApiKey
+                        ? "Connect an AI engine above to start chatting…"
+                        : composerDisabled
+                          ? (composerDisabledPlaceholder ??
+                            "Open Desktop to use this chat.")
+                          : isRunning
+                            ? queuedMessages.length > 0
+                              ? `${queuedMessages.length} queued — send a follow-up...`
+                              : "Send a follow-up..."
+                            : composerPlaceholder
+                    }
+                    onSubmit={
+                      isRunning || composerContextItems.length > 0
+                        ? (text, references, attachments, options) =>
+                            void addToQueue(
+                              text,
+                              undefined,
+                              references.length > 0 ? references : undefined,
+                              attachments,
+                              undefined,
+                              options?.intent ?? "immediate",
+                              undefined,
+                              true,
+                            )
+                        : undefined
+                    }
+                    onSlashCommand={onSlashCommand}
+                    execMode={execMode}
+                    onExecModeChange={onExecModeChange}
+                    planModeDisabled={planModeDisabled}
+                    planModeDisabledReason={planModeDisabledReason}
+                    selectedModel={selectedModel ?? defaultModel}
+                    selectedEffort={selectedEffort}
+                    availableModels={availableModels}
+                    onModelChange={onModelChange}
+                    onEffortChange={onEffortChange}
+                    onConnectProvider={onConnectProvider}
+                    toolbarSlot={composerToolbarSlot}
+                    contextItems={composerContextItems}
+                    onRemoveContextItem={removeComposerContextItem}
+                    plusMenuMode={plusMenuMode}
+                    layoutVariant={composerLayoutVariant}
+                    providerConnectStatusEnabled={providerStatusChecksEnabled}
+                    draftScope={threadId || tabId}
+                    interceptBuildRequestsForBuilder
+                    onAttachmentError={setComposerError}
+                    extraActionButton={
+                      contextXRayEnabled ||
+                      composerExtraActionButton ||
+                      showRunningInUI ? (
+                        <>
+                          {contextXRayEnabled && (
+                            <ContextMeter threadId={threadId} />
+                          )}
+                          {composerExtraActionButton}
+                          {showRunningInUI && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  onClick={stopActiveRun}
+                                  className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md bg-muted text-foreground hover:bg-muted/80"
+                                >
+                                  <IconPlayerStop className="h-3.5 w-3.5" />
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent>Stop generating</TooltipContent>
+                            </Tooltip>
+                          )}
+                        </>
+                      ) : undefined
+                    }
+                  />
+                </AgentComposerFrame>
+              </div>
+            </TextStreamingContext.Provider>
+          </ChatRunningContext.Provider>
+        </ApprovalContext.Provider>
       </MessageActionsContext.Provider>
     </CheckpointContext.Provider>
   );

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -1125,6 +1125,23 @@ export function createAgentChatAdapter(
         typeof runConfig.custom === "object" &&
         (runConfig.custom as { trackInRunsTray?: unknown }).trackInRunsTray ===
           true;
+      // Human-in-the-loop approval keys (opt-in `needsApproval` actions). When
+      // the user approves a paused tool call, the turn is re-issued with the
+      // approval key so the server lets that specific call run.
+      const approvedToolCalls = (() => {
+        const raw =
+          runConfig?.custom &&
+          typeof runConfig.custom === "object" &&
+          "approvedToolCalls" in runConfig.custom
+            ? (runConfig.custom as { approvedToolCalls?: unknown })
+                .approvedToolCalls
+            : undefined;
+        if (!Array.isArray(raw)) return undefined;
+        const keys = raw.filter(
+          (key): key is string => typeof key === "string" && key.length > 0,
+        );
+        return keys.length > 0 ? keys : undefined;
+      })();
       const requestMode =
         runConfigRequestMode === "act" || runConfigRequestMode === "plan"
           ? runConfigRequestMode
@@ -1789,6 +1806,7 @@ export function createAgentChatAdapter(
                   ...(includeReferences && runConfig?.custom?.references
                     ? { references: runConfig.custom.references }
                     : {}),
+                  ...(approvedToolCalls ? { approvedToolCalls } : {}),
                 }),
               },
               STARTUP_RESPONSE_TIMEOUT_MS,

--- a/packages/core/src/client/chat/tool-call-display.tsx
+++ b/packages/core/src/client/chat/tool-call-display.tsx
@@ -41,10 +41,26 @@ import {
   IconSearch,
   IconArrowsMaximize,
   IconArrowsMinimize,
+  IconShieldCheck,
+  IconX,
 } from "@tabler/icons-react";
 
 // Exported so AssistantChatInner can provide a context value.
 export const ChatRunningContext = React.createContext(false);
+
+/**
+ * Human-in-the-loop approval bridge. `AssistantChatInner` provides a value that
+ * re-issues the turn approving a specific paused tool call (opt-in
+ * `needsApproval` actions). When null, the Approve button is not rendered.
+ * Deny is handled locally in the affordance, so it needs no bridge.
+ */
+export type ApprovalContextValue = {
+  /** Re-issue the turn so the server runs the approved call. */
+  onApprove: (approvalKey: string) => void;
+};
+export const ApprovalContext = React.createContext<ApprovalContextValue | null>(
+  null,
+);
 
 // ─── Tool-payload formatting ──────────────────────────────────────────────────
 
@@ -310,6 +326,78 @@ function ToolDetailViewer({ payload }: { payload: ToolDetailPayload }) {
   );
 }
 
+// ─── Human-in-the-loop approval affordance ────────────────────────────────────
+
+/**
+ * Inline Approve/Deny prompt rendered when a `needsApproval` action paused the
+ * turn. Approve re-issues the turn with the call's `approvalKey`; Deny dismisses
+ * the prompt locally (the action stays un-run).
+ */
+function ApprovalAffordance({
+  toolName,
+  approval,
+}: {
+  toolName: string;
+  approval: { approvalKey: string; dismissed?: boolean };
+}) {
+  const ctx = React.useContext(ApprovalContext);
+  const [approved, setApproved] = useState(false);
+  const [denied, setDenied] = useState(false);
+
+  // Once approved, the turn is re-issued; collapse to a quiet note so the user
+  // can't double-fire the approval.
+  if (approved) {
+    return (
+      <div className="mt-1.5 text-xs text-muted-foreground">
+        Approved. Re-running {toolName}...
+      </div>
+    );
+  }
+  // Deny is local-only: the action simply stays un-run.
+  if (denied) {
+    return (
+      <div className="mt-1.5 text-xs text-muted-foreground">
+        Denied. {toolName} did not run.
+      </div>
+    );
+  }
+  return (
+    <div className="mt-1.5 flex items-center gap-2 rounded-md border border-border bg-muted/40 px-2.5 py-1.5">
+      <IconShieldCheck className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <span className="mr-auto text-xs text-muted-foreground">
+        Approve to run {toolName}?
+      </span>
+      {ctx && (
+        <button
+          type="button"
+          onClick={() => {
+            setApproved(true);
+            ctx.onApprove(approval.approvalKey);
+          }}
+          className={cn(
+            "inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+            "bg-foreground text-background hover:bg-foreground/90",
+          )}
+        >
+          <IconCheck className="h-3.5 w-3.5" />
+          Approve
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={() => setDenied(true)}
+        className={cn(
+          "inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1 text-xs font-medium transition-colors",
+          "text-foreground hover:bg-muted",
+        )}
+      >
+        <IconX className="h-3.5 w-3.5" />
+        Deny
+      </button>
+    </div>
+  );
+}
+
 // ─── ToolCallDisplay ──────────────────────────────────────────────────────────
 
 export function ToolCallDisplay({
@@ -320,6 +408,7 @@ export function ToolCallDisplay({
   mcpApp,
   isRunning,
   structuredMeta,
+  approval,
 }: {
   toolName: string;
   argsText?: string;
@@ -328,6 +417,7 @@ export function ToolCallDisplay({
   mcpApp?: AgentMcpAppPayload;
   isRunning: boolean;
   structuredMeta?: Record<string, unknown>;
+  approval?: { approvalKey: string; dismissed?: boolean };
 }) {
   // Delegate to bespoke cells when structured metadata is present.
   // These must be separate components so hook order in ToolCallDisplayGeneric
@@ -372,6 +462,7 @@ export function ToolCallDisplay({
       result={result}
       mcpApp={mcpApp}
       isRunning={isRunning}
+      approval={approval}
     />
   );
 }
@@ -383,6 +474,7 @@ function ToolCallDisplayGeneric({
   result,
   mcpApp,
   isRunning,
+  approval,
 }: {
   toolName: string;
   argsText?: string;
@@ -390,6 +482,7 @@ function ToolCallDisplayGeneric({
   result?: string;
   mcpApp?: AgentMcpAppPayload;
   isRunning: boolean;
+  approval?: { approvalKey: string; dismissed?: boolean };
 }) {
   const streamRef = useRef<HTMLDivElement>(null);
 
@@ -547,6 +640,9 @@ function ToolCallDisplayGeneric({
           {resultPayload && <ToolDetailViewer payload={resultPayload} />}
         </div>
       )}
+      {approval && (
+        <ApprovalAffordance toolName={toolName} approval={approval} />
+      )}
     </div>
   );
 }
@@ -562,6 +658,7 @@ export function ToolCallFallback({
 }: ToolCallMessagePartProps & {
   mcpApp?: AgentMcpAppPayload;
   structuredMeta?: Record<string, unknown>;
+  approval?: { approvalKey: string; dismissed?: boolean };
 }) {
   const chatRunning = React.useContext(ChatRunningContext);
   const isRunning = result === undefined && chatRunning;
@@ -580,6 +677,7 @@ export function ToolCallFallback({
       mcpApp={rest.mcpApp}
       structuredMeta={rest.structuredMeta}
       isRunning={isRunning}
+      approval={rest.approval}
     />
   );
 }
@@ -621,6 +719,7 @@ export function ReconnectStreamMessage({
                 mcpApp={part.mcpApp}
                 structuredMeta={part.structuredMeta}
                 isRunning={part.result === undefined && chatRunning}
+                approval={part.approval}
               />
             );
           }

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -932,4 +932,46 @@ describe("SSE event processor tool id matching", () => {
     );
     expect(part?.toolCallId).toBe("srv-99");
   });
+
+  it("attaches approval metadata to the matching tool-call on approval_required", async () => {
+    // The server emits tool_start, then approval_required (the gate paused the
+    // turn), then a paused tool_done — the call never executed.
+    const content: any[] = [];
+    await drain(
+      readSSEStream(
+        eventStream([
+          {
+            type: "tool_start",
+            tool: "send-email",
+            id: "approve-1",
+            input: { to: "a@b.com" },
+          },
+          {
+            type: "approval_required",
+            tool: "send-email",
+            id: "approve-1",
+            approvalKey: 'send-email:{"to":"a@b.com"}',
+            input: { to: "a@b.com" },
+          },
+          {
+            type: "tool_done",
+            tool: "send-email",
+            id: "approve-1",
+            result: "Awaiting human approval — did NOT execute.",
+          },
+          { type: "done" },
+        ]),
+        content,
+        { value: 0 },
+        undefined,
+      ),
+    );
+
+    const part = content.find(
+      (p: any) => p.type === "tool-call" && p.toolCallId === "approve-1",
+    );
+    expect(part?.approval).toEqual({
+      approvalKey: 'send-email:{"to":"a@b.com"}',
+    });
+  });
 });

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -19,6 +19,13 @@ export type ContentPart =
       mcpApp?: AgentMcpAppPayload;
       activity?: boolean;
       /**
+       * Set when the server emitted an `approval_required` event for this tool
+       * call (opt-in `needsApproval` actions). The action did NOT run; the UI
+       * renders an Approve/Deny affordance. `approvalKey` is echoed back in
+       * `approvedToolCalls` to approve, `dismissed` records a local Deny.
+       */
+      approval?: { approvalKey: string; dismissed?: boolean };
+      /**
        * Structured metadata from the coding-tools executor side-channel.
        * Present only on code-agent tool calls from executors new enough to
        * emit it.  The `toolKind` discriminant identifies the shape.
@@ -36,6 +43,9 @@ export interface SSEEvent {
   input?: Record<string, string>;
   result?: string;
   mcpApp?: AgentMcpAppPayload;
+  /** Stable key the client echoes back in `approvedToolCalls` to approve a
+   *  paused `needsApproval` tool call. Present on `approval_required` events. */
+  approvalKey?: string;
   error?: string;
   seq?: number;
   agent?: string;
@@ -426,6 +436,28 @@ export function processEvent(
         argsText: JSON.stringify(args),
         args,
       });
+    }
+    return {
+      action: "yield",
+      result: { content: [...content] } as ChatModelRunResult,
+    };
+  }
+
+  if (ev.type === "approval_required") {
+    // Opt-in `needsApproval` gate: the server emitted `tool_start` immediately
+    // before this, so the matching tool-call part already exists. Mark it as
+    // awaiting approval so the UI can render the Approve/Deny affordance. The
+    // action did NOT execute; a paused `tool_done` follows.
+    const approvalTool = ev.tool ?? "unknown";
+    const approvalKey = ev.approvalKey;
+    if (approvalKey) {
+      const idx = findPendingToolCallIndex(content, approvalTool, ev.id);
+      if (idx >= 0) {
+        const part = content[idx];
+        if (part.type === "tool-call") {
+          part.approval = { approvalKey };
+        }
+      }
     }
     return {
       action: "yield",

--- a/packages/core/src/db/client.spec.ts
+++ b/packages/core/src/db/client.spec.ts
@@ -52,6 +52,24 @@ describe("db/client dialect detection", () => {
     const { getDialect } = await import("./client.js");
     expect(getDialect()).toBe("sqlite");
   });
+
+  it("uses Netlify's runtime database URL when DATABASE_URL is not exported", async () => {
+    vi.stubEnv("DATABASE_URL", "");
+    vi.stubEnv("NETLIFY_DATABASE_URL", "postgres://netlify.example/db");
+    const { getDatabaseUrl, getDialect } = await import("./client.js");
+    expect(getDatabaseUrl("file:./data/app.db")).toBe(
+      "postgres://netlify.example/db",
+    );
+    expect(getDialect()).toBe("postgres");
+  });
+
+  it("keeps app-specific database URLs ahead of Netlify's shared env", async () => {
+    vi.stubEnv("APP_NAME", "plan");
+    vi.stubEnv("PLAN_DATABASE_URL", "postgres://plan.example/db");
+    vi.stubEnv("NETLIFY_DATABASE_URL", "postgres://netlify.example/db");
+    const { getDatabaseUrl } = await import("./client.js");
+    expect(getDatabaseUrl()).toBe("postgres://plan.example/db");
+  });
 });
 
 describe("getMigrationDatabaseUrl", () => {

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -47,8 +47,10 @@ export interface DbExecConfig {
  * Resolve the database URL for the current app.
  *
  * Checks for `<APP_NAME>_DATABASE_URL` first (e.g. `MAIL_DATABASE_URL`),
- * then falls back to `DATABASE_URL`. This allows multiple apps to run in the
- * same process group (e.g. eager repo dev or builder.io) with separate databases.
+ * then falls back to `DATABASE_URL`, then Netlify's managed database env. This
+ * allows multiple apps to run in the same process group (e.g. eager repo dev or
+ * builder.io) with separate databases while still using the persistent Netlify
+ * runtime database when `DATABASE_URL` was only exported for the build command.
  *
  * Set `APP_NAME=mail` in the child process env and
  * `MAIL_DATABASE_URL=postgres://...` in the shared env.
@@ -59,7 +61,9 @@ export function getDatabaseUrl(fallback = ""): string {
     const prefixed = process.env[`${appName}_DATABASE_URL`];
     if (prefixed) return prefixed;
   }
-  return process.env.DATABASE_URL || fallback;
+  return (
+    process.env.DATABASE_URL || process.env.NETLIFY_DATABASE_URL || fallback
+  );
 }
 
 /** Same per-app resolution for DATABASE_AUTH_TOKEN (used by Turso/libsql). */
@@ -69,7 +73,9 @@ export function getDatabaseAuthToken(): string | undefined {
     const prefixed = process.env[`${appName}_DATABASE_AUTH_TOKEN`];
     if (prefixed) return prefixed;
   }
-  return process.env.DATABASE_AUTH_TOKEN;
+  return (
+    process.env.DATABASE_AUTH_TOKEN || process.env.NETLIFY_DATABASE_AUTH_TOKEN
+  );
 }
 
 /**

--- a/packages/core/src/deploy/route-discovery.ts
+++ b/packages/core/src/deploy/route-discovery.ts
@@ -148,6 +148,7 @@ export const DEFAULT_PLUGIN_REGISTRY: Record<string, string> = {
   "context-xray": "defaultContextXrayPlugin",
   "core-routes": "defaultCoreRoutesPlugin",
   integrations: "defaultIntegrationsPlugin",
+  "observational-memory": "defaultObservationalMemoryPlugin",
   onboarding: "defaultOnboardingPlugin",
   org: "defaultOrgPlugin",
   resources: "defaultResourcesPlugin",

--- a/packages/core/src/eval/agent-runner.ts
+++ b/packages/core/src/eval/agent-runner.ts
@@ -1,0 +1,210 @@
+/**
+ * The headless agent-run seam used by the evals runner.
+ *
+ * This invokes the real `runAgentLoop` as a *caller* — resolving a provider-
+ * agnostic engine + model from the existing registry, converting the app's
+ * actions into engine tools, and collecting the assistant's text + tool calls
+ * off the `send` event stream into a compact `AgentRunOutput`. It deliberately
+ * does NOT modify `production-agent.ts`: everything it needs (`runAgentLoop`,
+ * `actionsToEngineTools`, `ActionEntry`) is already exported from there.
+ *
+ * The factory shape (`createAgentRunner`) keeps the runner unit-testable: tests
+ * inject a fake `runAgentLoop` and a fake engine so no real model is called,
+ * while production wires in the genuine loop. The same factory builds the
+ * `ScorerAnalyzeContext.judge` helper so LLM-judge scorers stream through the
+ * exact same resolved engine.
+ */
+
+import type { ActionEntry, AgentLoopUsage } from "../agent/production-agent.js";
+import {
+  runAgentLoop,
+  actionsToEngineTools,
+} from "../agent/production-agent.js";
+import type {
+  AgentEngine,
+  EngineMessage,
+  EngineTool,
+} from "../agent/engine/types.js";
+import type { AgentChatEvent } from "../agent/types.js";
+import {
+  resolveEngine,
+  getStoredModelForEngine,
+  normalizeModelForEngine,
+} from "../agent/engine/index.js";
+import type {
+  AgentRunOutput,
+  EvalInput,
+  ScorerAnalyzeContext,
+} from "./types.js";
+
+const JUDGE_TIMEOUT_MS = 30_000;
+const DEFAULT_AGENT_TIMEOUT_MS = 120_000;
+
+/** The slice of `runAgentLoop` the runner depends on — injectable for tests. */
+export type RunAgentLoopFn = (opts: {
+  engine: AgentEngine;
+  model: string;
+  systemPrompt: string;
+  tools: EngineTool[];
+  messages: EngineMessage[];
+  actions: Record<string, ActionEntry>;
+  send: (event: AgentChatEvent) => void;
+  signal: AbortSignal;
+}) => Promise<AgentLoopUsage>;
+
+export interface AgentRunnerConfig {
+  /** App actions to expose to the agent under test. */
+  actions: Record<string, ActionEntry>;
+  /** System prompt for the run. */
+  systemPrompt?: string;
+  /** Pre-resolved engine; resolved from the registry when omitted. */
+  engine?: AgentEngine;
+  /** Pre-resolved model; resolved from the engine's stored/default when omitted. */
+  model?: string;
+  /** Per-run wall-clock budget in ms (default 120s). */
+  timeoutMs?: number;
+  /**
+   * Seam for tests / custom hosts. Defaults to the real `runAgentLoop`. The
+   * runner never imports `runAgentLoop` directly so this can be swapped.
+   */
+  runLoop?: RunAgentLoopFn;
+}
+
+export interface AgentRunner {
+  /** Run the agent loop for one eval input and collect a compact output. */
+  runAgent(input: EvalInput): Promise<AgentRunOutput>;
+  /** Analyze context handed to LLM-judge scorers (shares engine/model). */
+  analyzeContext(): ScorerAnalyzeContext;
+  readonly engine: AgentEngine;
+  readonly model: string;
+}
+
+function toEngineMessages(input: EvalInput): EngineMessage[] {
+  const messages: EngineMessage[] = [];
+  for (const turn of input.history ?? []) {
+    messages.push({
+      role: turn.role,
+      content: [{ type: "text", text: turn.text }],
+    });
+  }
+  messages.push({
+    role: "user",
+    content: [{ type: "text", text: input.prompt }],
+  });
+  return messages;
+}
+
+/**
+ * Build an agent runner, resolving the engine/model once up front so every
+ * eval case (and every LLM-judge scorer) reuses the same provider-agnostic
+ * config. Resolution goes through `resolveEngine` — no model is ever hardcoded.
+ */
+export async function createAgentRunner(
+  config: AgentRunnerConfig,
+): Promise<AgentRunner> {
+  const engine =
+    config.engine ?? (await resolveEngine({ engineOption: undefined }));
+  const modelCandidate =
+    config.model ??
+    (await getStoredModelForEngine(engine)) ??
+    engine.defaultModel;
+  const model = normalizeModelForEngine(engine, modelCandidate);
+  const systemPrompt = config.systemPrompt ?? "";
+  const runLoop = config.runLoop ?? (runAgentLoop as RunAgentLoopFn);
+  const timeoutMs = config.timeoutMs ?? DEFAULT_AGENT_TIMEOUT_MS;
+  const tools = actionsToEngineTools(config.actions);
+
+  async function runAgent(input: EvalInput): Promise<AgentRunOutput> {
+    const runId = `eval:${crypto.randomUUID()}`;
+    const messages = toEngineMessages(input);
+
+    let text = "";
+    const toolCalls: string[] = [];
+    let ok = true;
+    let error: string | undefined;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const started = Date.now();
+
+    const send = (event: AgentChatEvent): void => {
+      switch (event.type) {
+        case "text":
+          text += event.text;
+          break;
+        case "tool_start":
+          toolCalls.push(event.tool);
+          break;
+        case "error":
+          ok = false;
+          error = event.error;
+          break;
+        default:
+          break;
+      }
+    };
+
+    try {
+      await runLoop({
+        engine,
+        model,
+        systemPrompt,
+        tools,
+        messages,
+        actions: config.actions,
+        send,
+        signal: controller.signal,
+      });
+    } catch (err) {
+      ok = false;
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      clearTimeout(timer);
+    }
+
+    return {
+      text,
+      toolCalls,
+      ok,
+      error,
+      runId,
+      durationMs: Date.now() - started,
+    };
+  }
+
+  function analyzeContext(): ScorerAnalyzeContext {
+    return {
+      engine,
+      model,
+      async judge(opts): Promise<string> {
+        const controller = new AbortController();
+        const signal = opts.signal ?? controller.signal;
+        const timer = opts.signal
+          ? undefined
+          : setTimeout(() => controller.abort(), JUDGE_TIMEOUT_MS);
+        let out = "";
+        try {
+          const stream = engine.stream({
+            model,
+            systemPrompt: opts.systemPrompt ?? "",
+            messages: [
+              { role: "user", content: [{ type: "text", text: opts.prompt }] },
+            ],
+            tools: [],
+            abortSignal: signal,
+            maxOutputTokens: opts.maxOutputTokens ?? 512,
+            temperature: 0,
+          });
+          for await (const event of stream) {
+            if (event.type === "text-delta") out += event.text;
+          }
+        } finally {
+          if (timer) clearTimeout(timer);
+        }
+        return out;
+      },
+    };
+  }
+
+  return { runAgent, analyzeContext, engine, model };
+}

--- a/packages/core/src/eval/define-eval.ts
+++ b/packages/core/src/eval/define-eval.ts
@@ -1,0 +1,52 @@
+/**
+ * `defineEval` — declare a named eval test case.
+ *
+ * An eval pairs an input (prompt + optional history/setup) with a list of
+ * scorers and a pass threshold. The runner (see `runner.ts`) actually runs the
+ * agent for the input, scores the output with each scorer, and gates on the
+ * threshold. Authors write `*.eval.ts` files that `export default defineEval(...)`
+ * or export an array of them.
+ *
+ * Example (`evals/greeting.eval.ts`):
+ * ```ts
+ * import { defineEval, contains, llmJudge } from "@agent-native/core/eval";
+ *
+ * export default defineEval({
+ *   name: "greets the user by name",
+ *   input: { prompt: "Say hi to Ada." },
+ *   threshold: 0.7,
+ *   scorers: [
+ *     contains("Ada"),
+ *     llmJudge({ criteria: "friendliness", rubric: "1.0 = warm greeting" }),
+ *   ],
+ * });
+ * ```
+ */
+
+import type { Eval } from "./types.js";
+
+/** Default per-scorer pass threshold when an eval doesn't specify one. */
+export const DEFAULT_EVAL_THRESHOLD = 0.5;
+
+export function defineEval(spec: Eval): Eval {
+  if (!spec.name || typeof spec.name !== "string") {
+    throw new Error("defineEval: `name` is required");
+  }
+  if (!spec.input || typeof spec.input.prompt !== "string") {
+    throw new Error(`defineEval("${spec.name}"): \`input.prompt\` is required`);
+  }
+  if (!Array.isArray(spec.scorers) || spec.scorers.length === 0) {
+    throw new Error(
+      `defineEval("${spec.name}"): at least one scorer is required`,
+    );
+  }
+  if (
+    spec.threshold !== undefined &&
+    (spec.threshold < 0 || spec.threshold > 1)
+  ) {
+    throw new Error(
+      `defineEval("${spec.name}"): \`threshold\` must be in [0, 1]`,
+    );
+  }
+  return spec;
+}

--- a/packages/core/src/eval/index.ts
+++ b/packages/core/src/eval/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Public surface for the first-class evals primitive.
+ *
+ * Authors write `*.eval.ts` (or `evals/*.ts`) files that `export default
+ * defineEval(...)`, compose scorers with `createScorer` / the built-ins, and
+ * run them with `agent-native eval` (which gates CI on the thresholds).
+ *
+ * This is complementary to `@agent-native/core`'s observability run-scoring:
+ * that scores real production runs after the fact; this actively runs the
+ * agent against fixed inputs as a deterministic gate. See `types.ts`.
+ */
+
+export { defineEval, DEFAULT_EVAL_THRESHOLD } from "./define-eval.js";
+export {
+  createScorer,
+  clamp01,
+  exactMatch,
+  contains,
+  usesTool,
+  llmJudge,
+  type LlmJudgeOptions,
+} from "./scorer.js";
+export {
+  createAgentRunner,
+  type AgentRunner,
+  type AgentRunnerConfig,
+  type RunAgentLoopFn,
+} from "./agent-runner.js";
+export {
+  runEvalSuite,
+  runEvals,
+  scoreEval,
+  loadEvals,
+  discoverEvalFiles,
+  type RunEvalSuiteOptions,
+} from "./runner.js";
+export { formatReport } from "./report.js";
+export type {
+  Eval,
+  EvalInput,
+  EvalRunContext,
+  AgentRunOutput,
+  Scorer,
+  ScorerDefinition,
+  ScorerAnalyzeContext,
+  ScorerResult,
+  EvalResultRow,
+  EvalRunReport,
+} from "./types.js";

--- a/packages/core/src/eval/report.ts
+++ b/packages/core/src/eval/report.ts
@@ -1,0 +1,60 @@
+/**
+ * Human-readable formatting for an eval run report. Kept separate from the
+ * runner so the CLI can print a table while CI consumes the JSON shape.
+ */
+
+import type { EvalRunReport } from "./types.js";
+
+function bar(score: number, width = 10): string {
+  const filled = Math.round(clamp01(score) * width);
+  return "█".repeat(filled) + "░".repeat(width - filled);
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+function pct(score: number): string {
+  return `${Math.round(clamp01(score) * 100)}%`.padStart(4);
+}
+
+/** Render a scored table for the terminal. */
+export function formatReport(report: EvalRunReport): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("  Evals");
+  lines.push("  ─────");
+
+  for (const row of report.results) {
+    const mark = row.passed ? "✓" : "✗";
+    lines.push("");
+    lines.push(
+      `  ${mark} ${row.eval}  (avg ${pct(row.avgScore)}, threshold ${pct(
+        row.threshold,
+      )})`,
+    );
+    if (row.error) {
+      lines.push(`      ⚠ run error: ${row.error}`);
+    }
+    for (const s of row.scores) {
+      const smark = s.passed ? "✓" : "✗";
+      const reason = s.reason ? `  — ${s.reason}` : "";
+      lines.push(
+        `      ${smark} ${s.scorer.padEnd(20)} ${bar(s.score)} ${pct(
+          s.score,
+        )}${reason}`,
+      );
+    }
+  }
+
+  lines.push("");
+  lines.push("  ─────");
+  const verdict = report.failed === 0 ? "PASS" : "FAIL";
+  lines.push(
+    `  ${verdict}: ${report.passed}/${report.total} evals passed` +
+      (report.failed > 0 ? `, ${report.failed} below threshold` : ""),
+  );
+  lines.push("");
+  return lines.join("\n");
+}

--- a/packages/core/src/eval/runner.spec.ts
+++ b/packages/core/src/eval/runner.spec.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { AgentEngine } from "../agent/engine/types.js";
+import type { AgentChatEvent } from "../agent/types.js";
+import type { AgentRunner } from "./agent-runner.js";
+import type { AgentRunOutput } from "./types.js";
+
+// The runner has two halves:
+//  1. Pure orchestration (scoreEval/runEvals) over an injected AgentRunner —
+//     fully testable with NO model and NO real agent loop.
+//  2. createAgentRunner, which wraps the real runAgentLoop. We mock
+//     production-agent + the engine registry + the observability store so we
+//     can drive it end-to-end (incl. the LLM-judge path) without a model.
+
+// Mock production-agent: actionsToEngineTools is a no-op, runAgentLoop is
+// injected per-test via the runLoop seam so this default is never hit.
+vi.mock("../agent/production-agent.js", () => ({
+  actionsToEngineTools: () => [],
+  runAgentLoop: vi.fn(),
+}));
+
+const engineMod = vi.hoisted(() => ({
+  resolveEngine: vi.fn(),
+  getStoredModelForEngine: vi.fn(),
+  normalizeModelForEngine: vi.fn(
+    (engine: { defaultModel?: string }, model?: string | null) =>
+      model ?? engine.defaultModel,
+  ),
+}));
+vi.mock("../agent/engine/index.js", () => ({
+  resolveEngine: (...a: unknown[]) => engineMod.resolveEngine(...a),
+  getStoredModelForEngine: (...a: unknown[]) =>
+    engineMod.getStoredModelForEngine(...a),
+  normalizeModelForEngine: (...a: unknown[]) =>
+    engineMod.normalizeModelForEngine(...a),
+}));
+
+const storeMod = vi.hoisted(() => ({ insertEvalResult: vi.fn() }));
+vi.mock("../observability/store.js", () => ({
+  insertEvalResult: (...a: unknown[]) => storeMod.insertEvalResult(...a),
+}));
+
+const { defineEval } = await import("./define-eval.js");
+const { contains, exactMatch, usesTool, llmJudge, createScorer } =
+  await import("./scorer.js");
+const { scoreEval, runEvals } = await import("./runner.js");
+const { createAgentRunner } = await import("./agent-runner.js");
+
+/** A fake runner that returns a fixed output and supplies a judge stub. */
+function fakeRunner(
+  out: Partial<AgentRunOutput>,
+  judgeText = '{"score": 1, "reasoning": "ok"}',
+): AgentRunner {
+  const engine = { defaultModel: "fake-model" } as unknown as AgentEngine;
+  return {
+    engine,
+    model: "fake-model",
+    async runAgent() {
+      return {
+        text: "",
+        toolCalls: [],
+        ok: true,
+        runId: "eval:test",
+        durationMs: 1,
+        ...out,
+      };
+    },
+    analyzeContext() {
+      return {
+        engine,
+        model: "fake-model",
+        async judge() {
+          return judgeText;
+        },
+      };
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storeMod.insertEvalResult.mockResolvedValue(undefined);
+});
+
+describe("scoreEval with a JS scorer", () => {
+  it("passes when a contains scorer is satisfied", async () => {
+    const e = defineEval({
+      name: "says hello",
+      input: { prompt: "greet me" },
+      scorers: [contains("hello")],
+    });
+    const row = await scoreEval(e, fakeRunner({ text: "well hello there" }));
+    expect(row.passed).toBe(true);
+    expect(row.scores).toHaveLength(1);
+    expect(row.scores[0].scorer).toBe("contains");
+    expect(row.scores[0].score).toBe(1);
+    // Stores both the number AND a reason.
+    expect(row.scores[0].reason).toContain("present");
+    expect(row.avgScore).toBe(1);
+  });
+
+  it("fails the case (sub-threshold) and surfaces it as failed in the report", async () => {
+    const e = defineEval({
+      name: "must mention refunds",
+      input: { prompt: "policy?" },
+      threshold: 0.5,
+      scorers: [contains("refund")],
+    });
+    const report = await runEvals([e], fakeRunner({ text: "no match here" }));
+    expect(report.results[0].passed).toBe(false);
+    expect(report.results[0].scores[0].score).toBe(0);
+    // This is the CI gate signal the CLI maps to a non-zero exit code.
+    expect(report.failed).toBe(1);
+    expect(report.passed).toBe(0);
+  });
+
+  it("exact_match and uses_tool JS scorers behave as documented", async () => {
+    const e = defineEval({
+      name: "exact + tool",
+      input: { prompt: "x" },
+      scorers: [exactMatch("DONE"), usesTool("send-email")],
+    });
+    const row = await scoreEval(
+      e,
+      fakeRunner({ text: "  done  ", toolCalls: ["send-email"] }),
+    );
+    // case-insensitive + trimmed exact match
+    expect(row.scores[0].score).toBe(1);
+    // tool was used
+    expect(row.scores[1].score).toBe(1);
+    expect(row.passed).toBe(true);
+  });
+
+  it("a run-level error fails the case even if scorers would pass", async () => {
+    const e = defineEval({
+      name: "errored run",
+      input: { prompt: "x" },
+      scorers: [contains("anything")],
+    });
+    const row = await scoreEval(
+      e,
+      fakeRunner({ text: "anything", ok: false, error: "boom" }),
+    );
+    expect(row.passed).toBe(false);
+    expect(row.error).toBe("boom");
+  });
+
+  it("a scorer that throws degrades to score 0, not a crash", async () => {
+    const explode = createScorer({
+      name: "explode",
+      generateScore() {
+        throw new Error("scorer bug");
+      },
+    });
+    const e = defineEval({
+      name: "bad scorer",
+      input: { prompt: "x" },
+      scorers: [explode],
+    });
+    const row = await scoreEval(e, fakeRunner({ text: "hi" }));
+    expect(row.scores[0].score).toBe(0);
+    expect(row.scores[0].passed).toBe(false);
+    expect(row.scores[0].reason).toContain("scorer bug");
+  });
+
+  it("honors a global threshold override", async () => {
+    const e = defineEval({
+      name: "partial contains",
+      input: { prompt: "x" },
+      // 1 of 2 phrases => score 0.5
+      scorers: [contains(["a", "z"])],
+    });
+    const passing = await scoreEval(e, fakeRunner({ text: "a only" }), {
+      thresholdOverride: 0.5,
+    });
+    expect(passing.scores[0].score).toBe(0.5);
+    expect(passing.passed).toBe(true);
+
+    const failing = await scoreEval(e, fakeRunner({ text: "a only" }), {
+      thresholdOverride: 0.9,
+    });
+    expect(failing.passed).toBe(false);
+  });
+});
+
+describe("llmJudge scorer via the analyze context (mocked engine)", () => {
+  it("parses the judge verdict into a normalized score + reason", async () => {
+    const e = defineEval({
+      name: "judged",
+      input: { prompt: "x" },
+      threshold: 0.7,
+      scorers: [llmJudge({ criteria: "quality" })],
+    });
+    const row = await scoreEval(
+      e,
+      fakeRunner({ text: "great" }, '{"score": 0.9, "reasoning": "solid"}'),
+    );
+    expect(row.scores[0].score).toBe(0.9);
+    expect(row.scores[0].reason).toBe("solid");
+    expect(row.passed).toBe(true);
+  });
+
+  it("normalizes a custom score range and gates correctly", async () => {
+    const e = defineEval({
+      name: "judged-scale",
+      input: { prompt: "x" },
+      threshold: 0.8,
+      scorers: [llmJudge({ criteria: "q", scoreRange: { min: 0, max: 10 } })],
+    });
+    const row = await scoreEval(
+      e,
+      fakeRunner({ text: "x" }, '{"score": 6, "reasoning": "mid"}'),
+    );
+    expect(row.scores[0].score).toBeCloseTo(0.6, 5);
+    expect(row.passed).toBe(false); // 0.6 < 0.8
+  });
+
+  it("treats an unparseable judge verdict as score 0", async () => {
+    const e = defineEval({
+      name: "judged-garbage",
+      input: { prompt: "x" },
+      scorers: [llmJudge({ criteria: "q" })],
+    });
+    const row = await scoreEval(
+      e,
+      fakeRunner({ text: "x" }, "I cannot produce JSON"),
+    );
+    expect(row.scores[0].score).toBe(0);
+    expect(row.scores[0].reason).toContain("parseable");
+  });
+});
+
+describe("createAgentRunner over a mocked runAgentLoop (no real model)", () => {
+  it("collects assistant text + tool calls off the send stream", async () => {
+    // Inject a fake loop that emits a couple of text + tool events.
+    const runLoop = vi.fn(
+      async (opts: { send: (e: AgentChatEvent) => void }) => {
+        opts.send({ type: "text", text: "Hello " });
+        opts.send({ type: "tool_start", tool: "search", input: {} });
+        opts.send({ type: "text", text: "world" });
+        return {
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          model: "fake-model",
+        };
+      },
+    );
+
+    const engine = { defaultModel: "fake-model" } as unknown as AgentEngine;
+    const runner = await createAgentRunner({
+      actions: {},
+      engine,
+      model: "fake-model",
+      runLoop: runLoop as never,
+    });
+
+    const out = await runner.runAgent({ prompt: "hi" });
+    expect(out.text).toBe("Hello world");
+    expect(out.toolCalls).toEqual(["search"]);
+    expect(out.ok).toBe(true);
+
+    // End-to-end: a contains scorer over the real collected text.
+    const e = defineEval({
+      name: "e2e",
+      input: { prompt: "hi" },
+      scorers: [contains("world"), usesTool("search")],
+    });
+    const row = await scoreEval(e, runner);
+    expect(row.passed).toBe(true);
+  });
+
+  it("marks the run not-ok when the loop emits an error event", async () => {
+    const runLoop = vi.fn(
+      async (opts: { send: (e: AgentChatEvent) => void }) => {
+        opts.send({ type: "error", error: "model exploded" });
+        return {
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          model: "fake-model",
+        };
+      },
+    );
+    const engine = { defaultModel: "fake-model" } as unknown as AgentEngine;
+    const runner = await createAgentRunner({
+      actions: {},
+      engine,
+      model: "fake-model",
+      runLoop: runLoop as never,
+    });
+    const out = await runner.runAgent({ prompt: "hi" });
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe("model exploded");
+  });
+
+  it("resolves engine + model from the registry when not supplied", async () => {
+    engineMod.resolveEngine.mockResolvedValue({
+      defaultModel: "registry-model",
+    });
+    engineMod.getStoredModelForEngine.mockResolvedValue(null);
+    const runner = await createAgentRunner({
+      actions: {},
+      runLoop: (async () => ({
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        model: "registry-model",
+      })) as never,
+    });
+    expect(engineMod.resolveEngine).toHaveBeenCalled();
+    expect(runner.model).toBe("registry-model");
+  });
+});
+
+describe("persistence to the observability store", () => {
+  it("writes one row per (eval x scorer) when persist is on", async () => {
+    const e = defineEval({
+      name: "persisted",
+      input: { prompt: "x" },
+      scorers: [contains("a"), exactMatch("a")],
+    });
+    await runEvals([e], fakeRunner({ text: "a" }), { persist: true });
+    // 2 scorers => 2 rows.
+    expect(storeMod.insertEvalResult).toHaveBeenCalledTimes(2);
+    const firstRow = storeMod.insertEvalResult.mock.calls[0][0];
+    expect(firstRow.evalType).toBe("automated");
+    expect(firstRow.criteria).toContain("eval:persisted:");
+    expect(firstRow.metadata).toMatchObject({ source: "cli-eval" });
+  });
+
+  it("does not write when persist is off (default in scoreEval)", async () => {
+    const e = defineEval({
+      name: "unpersisted",
+      input: { prompt: "x" },
+      scorers: [contains("a")],
+    });
+    await runEvals([e], fakeRunner({ text: "a" }), { persist: false });
+    expect(storeMod.insertEvalResult).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/eval/runner.ts
+++ b/packages/core/src/eval/runner.ts
@@ -1,0 +1,335 @@
+/**
+ * The evals runner: discover `*.eval.ts` / `evals/*.ts` files, run each eval
+ * through its scorer pipeline against the *real* agent loop, score, and report.
+ *
+ * It is the engine behind `agent-native eval` — when used as a CI deploy gate
+ * the CLI exits non-zero if any eval scores below its threshold.
+ *
+ * Two layers:
+ *   - `scoreEval` / `runEvals` — pure orchestration over an `AgentRunner` and
+ *     a list of evals. Fully unit-testable with an injected runner (no model).
+ *   - `discoverEvalFiles` / `loadEvals` — filesystem discovery + dynamic import
+ *     of author-written eval modules.
+ *
+ * Results are also (best-effort) written to the observability eval store so a
+ * dashboard can surface CI eval history next to production run evals.
+ */
+
+import nodePath from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { ActionEntry } from "../agent/production-agent.js";
+import { insertEvalResult } from "../observability/store.js";
+import type { EvalResult as ObservabilityEvalResult } from "../observability/types.js";
+
+import { DEFAULT_EVAL_THRESHOLD } from "./define-eval.js";
+import { clamp01 } from "./scorer.js";
+import type { AgentRunner } from "./agent-runner.js";
+import { createAgentRunner } from "./agent-runner.js";
+import type {
+  AgentRunOutput,
+  Eval,
+  EvalResultRow,
+  EvalRunReport,
+  ScorerResult,
+} from "./types.js";
+
+// ─── Scoring orchestration ────────────────────────────────────────────
+
+/** Run one scorer's pipeline (preprocess → analyze → score → reason). */
+async function runScorer(
+  scorer: Eval["scorers"][number],
+  run: AgentRunOutput,
+  runner: AgentRunner,
+  threshold: number,
+): Promise<ScorerResult> {
+  try {
+    const pre = scorer.preprocess ? await scorer.preprocess(run) : run;
+    const analysis = scorer.analyze
+      ? await scorer.analyze(pre as never, runner.analyzeContext())
+      : pre;
+    const rawScore = await scorer.generateScore(analysis as never);
+    const score = clamp01(rawScore);
+    const reason = scorer.generateReason
+      ? await scorer.generateReason({
+          run,
+          analysis: analysis as never,
+          score,
+        })
+      : undefined;
+    return { scorer: scorer.name, score, reason, passed: score >= threshold };
+  } catch (err) {
+    // A scorer that throws is a failed scorer, not a crashed run — degrade
+    // gracefully so one bad scorer can't take down the whole CI gate.
+    return {
+      scorer: scorer.name,
+      score: 0,
+      reason: `Scorer errored: ${err instanceof Error ? err.message : String(err)}`,
+      passed: false,
+    };
+  }
+}
+
+/** Run a single eval: invoke the agent, then score with each scorer. */
+export async function scoreEval(
+  evalCase: Eval,
+  runner: AgentRunner,
+  opts: { thresholdOverride?: number } = {},
+): Promise<EvalResultRow> {
+  const threshold =
+    opts.thresholdOverride ?? evalCase.threshold ?? DEFAULT_EVAL_THRESHOLD;
+
+  let run: AgentRunOutput;
+  if (evalCase.run) {
+    run = await evalCase.run({
+      input: evalCase.input,
+      runAgent: (input) => runner.runAgent(input),
+    });
+  } else {
+    run = await runner.runAgent(evalCase.input);
+  }
+
+  const scores: ScorerResult[] = [];
+  for (const scorer of evalCase.scorers) {
+    scores.push(await runScorer(scorer, run, runner, threshold));
+  }
+
+  const avgScore =
+    scores.length > 0
+      ? scores.reduce((s, r) => s + r.score, 0) / scores.length
+      : 0;
+
+  return {
+    eval: evalCase.name,
+    threshold,
+    scores,
+    // A run that errored, or any sub-threshold scorer, fails the case.
+    passed: run.ok && scores.every((s) => s.passed),
+    avgScore,
+    durationMs: run.durationMs,
+    error: run.ok ? undefined : run.error,
+  };
+}
+
+/** Run a batch of evals against one runner and aggregate a report. */
+export async function runEvals(
+  evals: Eval[],
+  runner: AgentRunner,
+  opts: { thresholdOverride?: number; persist?: boolean } = {},
+): Promise<EvalRunReport> {
+  const results: EvalResultRow[] = [];
+  for (const evalCase of evals) {
+    const row = await scoreEval(evalCase, runner, opts);
+    results.push(row);
+    if (opts.persist) await persistEvalRow(row).catch(() => {});
+  }
+
+  const passed = results.filter((r) => r.passed).length;
+  return {
+    total: results.length,
+    passed,
+    failed: results.length - passed,
+    results,
+  };
+}
+
+/**
+ * Best-effort write of one eval result to the observability eval store so a
+ * dashboard can show CI eval history alongside production run evals. We write
+ * one row per (eval × scorer), tagged `evalType: "automated"` with a synthetic
+ * `eval:` run id.
+ *
+ * TODO(live-sampling): the same scorer list should also run on a sampled
+ * fraction of *real* production runs. That hook belongs in the agent loop's
+ * (not-yet-added) post-run processor seam: when a run finishes, roll the
+ * configured sample rate and, if it hits, replay the run output through these
+ * scorers and write the rows here. Wiring it now would require the in-loop
+ * processor seam another wave is adding — so this is the single intended
+ * attachment point, intentionally left as a note.
+ */
+async function persistEvalRow(row: EvalResultRow): Promise<void> {
+  const runId = `eval:${row.eval}:${Date.now()}`;
+  for (const s of row.scores) {
+    const result: ObservabilityEvalResult = {
+      id: crypto.randomUUID(),
+      runId,
+      threadId: null,
+      userId: null,
+      evalType: "automated",
+      criteria: `eval:${row.eval}:${s.scorer}`,
+      score: s.score,
+      reasoning: s.reason ?? null,
+      metadata: {
+        source: "cli-eval",
+        threshold: row.threshold,
+        passed: s.passed,
+      },
+      createdAt: Date.now(),
+    };
+    await insertEvalResult(result);
+  }
+}
+
+// ─── Discovery + loading ──────────────────────────────────────────────
+
+const EVAL_FILE_RE = /\.eval\.(ts|js|mjs)$/;
+const SKIP_DIRS = new Set(["node_modules", "dist", ".git", ".output", "build"]);
+
+/**
+ * Walk `root` for eval files. Matches two conventions:
+ *   - any `**\/*.eval.ts` (co-located with code), and
+ *   - any `*.ts` directly inside an `evals/` directory.
+ * `pattern` further filters by substring of the relative path.
+ */
+export async function discoverEvalFiles(
+  root: string,
+  pattern?: string,
+): Promise<string[]> {
+  const fs = await import("node:fs");
+  const out: string[] = [];
+
+  function isEvalFile(full: string, parentName: string): boolean {
+    const base = nodePath.basename(full);
+    if (EVAL_FILE_RE.test(base)) return true;
+    if (parentName === "evals" && /\.(ts|js|mjs)$/.test(base)) {
+      // Skip obvious support files inside evals/.
+      return !/\.(spec|test|d)\.(ts|js|mjs)$/.test(base);
+    }
+    return false;
+  }
+
+  function walk(dir: string, parentName: string): void {
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = nodePath.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name) || entry.name.startsWith(".")) continue;
+        walk(full, entry.name);
+      } else if (entry.isFile() && isEvalFile(full, parentName)) {
+        out.push(full);
+      }
+    }
+  }
+
+  walk(root, nodePath.basename(root));
+  out.sort();
+
+  if (!pattern) return out;
+  return out.filter((f) => nodePath.relative(root, f).includes(pattern));
+}
+
+/** Pull `Eval` definitions out of a dynamically-imported eval module. */
+function extractEvals(mod: Record<string, unknown>): Eval[] {
+  const candidates: unknown[] = [];
+  if (mod.default !== undefined) candidates.push(mod.default);
+  for (const [key, value] of Object.entries(mod)) {
+    if (key === "default") continue;
+    candidates.push(value);
+  }
+
+  const evals: Eval[] = [];
+  for (const c of candidates.flat()) {
+    if (
+      c &&
+      typeof c === "object" &&
+      typeof (c as Eval).name === "string" &&
+      Array.isArray((c as Eval).scorers) &&
+      (c as Eval).input
+    ) {
+      evals.push(c as Eval);
+    }
+  }
+  return evals;
+}
+
+/** Discover and import all eval files under `root`, returning their evals. */
+export async function loadEvals(
+  root: string,
+  pattern?: string,
+): Promise<{ files: string[]; evals: Eval[] }> {
+  const files = await discoverEvalFiles(root, pattern);
+  const evals: Eval[] = [];
+  for (const file of files) {
+    const mod = (await import(pathToFileURL(file).href)) as Record<
+      string,
+      unknown
+    >;
+    evals.push(...extractEvals(mod));
+  }
+  return { files, evals };
+}
+
+// ─── High-level entry used by the CLI ─────────────────────────────────
+
+export interface RunEvalSuiteOptions {
+  /** App root to discover eval files + actions under. Defaults to cwd. */
+  cwd?: string;
+  /** Substring filter on the eval file path. */
+  pattern?: string;
+  /** Global threshold override (wins over per-eval thresholds). */
+  thresholdOverride?: number;
+  /** App actions to expose to the agent. Auto-discovered when omitted. */
+  actions?: Record<string, ActionEntry>;
+  /** System prompt for runs. */
+  systemPrompt?: string;
+  /** Write results to the observability eval store (default true). */
+  persist?: boolean;
+  /** Pre-built runner (tests inject this to avoid touching engine/loop). */
+  runner?: AgentRunner;
+  /** Pre-loaded evals (tests inject this to skip filesystem discovery). */
+  evals?: Eval[];
+}
+
+/**
+ * End-to-end: load evals, build a runner, score, report. The CLI wraps this
+ * and maps `report.failed > 0` to a non-zero exit code (the CI gate).
+ */
+export async function runEvalSuite(
+  opts: RunEvalSuiteOptions = {},
+): Promise<{ report: EvalRunReport; files: string[] }> {
+  const cwd = opts.cwd ?? process.cwd();
+
+  let files: string[] = [];
+  let evals = opts.evals;
+  if (!evals) {
+    const loaded = await loadEvals(cwd, opts.pattern);
+    files = loaded.files;
+    evals = loaded.evals;
+  }
+
+  const runner =
+    opts.runner ??
+    (await createAgentRunner({
+      actions: opts.actions ?? (await discoverActions(cwd)),
+      systemPrompt: opts.systemPrompt,
+    }));
+
+  const report = await runEvals(evals, runner, {
+    thresholdOverride: opts.thresholdOverride,
+    persist: opts.persist ?? true,
+  });
+  return { report, files };
+}
+
+/**
+ * Discover the app's actions so the agent under test has the real tool
+ * surface. Lazy-imports `autoDiscoverActions` to keep server-only deps out of
+ * any browser bundle that might touch this module's types.
+ */
+async function discoverActions(
+  cwd: string,
+): Promise<Record<string, ActionEntry>> {
+  try {
+    const { autoDiscoverActions } =
+      await import("../server/action-discovery.js");
+    const actionsDir = nodePath.join(cwd, "actions");
+    return await autoDiscoverActions(pathToFileURL(actionsDir + "/").href);
+  } catch {
+    return {};
+  }
+}

--- a/packages/core/src/eval/scorer.ts
+++ b/packages/core/src/eval/scorer.ts
@@ -1,0 +1,244 @@
+/**
+ * `createScorer` and a batteries-included set of built-in scorers.
+ *
+ * A scorer is a 4-step pipeline (preprocess → analyze → generateScore →
+ * generateReason). `createScorer` is a thin identity-with-validation factory:
+ * it enforces the one hard contract (`generateScore` is required) and returns
+ * a fully-typed `Scorer`. Built-in scorers below show both flavors:
+ *
+ *   - `exactMatch` / `contains` — pure-JS analyze, no model.
+ *   - `llmJudge` — analyze runs an LLM judge through the resolved engine
+ *     (provider-agnostic; the model is whatever the runner resolved).
+ */
+
+import type { AgentRunOutput, Scorer, ScorerDefinition } from "./types.js";
+
+/**
+ * Create a scorer from a 4-step pipeline definition.
+ *
+ * `generateScore` is the only required step. `preprocess`/`analyze` default to
+ * identity (the scorer sees the raw `AgentRunOutput`), and `generateReason` is
+ * optional.
+ */
+export function createScorer<Pre = AgentRunOutput, Ana = Pre>(
+  def: ScorerDefinition<Pre, Ana>,
+): Scorer<Pre, Ana> {
+  if (!def.name || typeof def.name !== "string") {
+    throw new Error("createScorer: `name` is required");
+  }
+  if (typeof def.generateScore !== "function") {
+    throw new Error(
+      `createScorer("${def.name}"): \`generateScore\` is required`,
+    );
+  }
+  return {
+    name: def.name,
+    preprocess: def.preprocess,
+    analyze: def.analyze,
+    generateScore: def.generateScore,
+    generateReason: def.generateReason,
+  };
+}
+
+/** Clamp any number into [0, 1]; coerce non-finite to 0. */
+export function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+// ─── Built-in JS scorers ──────────────────────────────────────────────
+
+/** Normalize for forgiving text comparison (case + surrounding whitespace). */
+function normalize(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+/**
+ * `exactMatch` — 1.0 when the agent's (trimmed, case-insensitive by default)
+ * text equals `expected`, else 0.0. Pure JS, no model.
+ */
+export function exactMatch(
+  expected: string,
+  opts: { caseSensitive?: boolean } = {},
+): Scorer<AgentRunOutput, { match: boolean }> {
+  return createScorer<AgentRunOutput, { match: boolean }>({
+    name: "exact_match",
+    analyze(run) {
+      const actual = opts.caseSensitive ? run.text.trim() : normalize(run.text);
+      const want = opts.caseSensitive ? expected.trim() : normalize(expected);
+      return { match: actual === want };
+    },
+    generateScore({ match }) {
+      return match ? 1 : 0;
+    },
+    generateReason({ analysis }) {
+      return analysis.match
+        ? `Output exactly matched expected text`
+        : `Output did not exactly match expected text`;
+    },
+  });
+}
+
+/**
+ * `contains` — 1.0 when the agent's text contains every required substring
+ * (case-insensitive by default). Score is the fraction matched, so a partial
+ * hit still surfaces signal. Pure JS, no model.
+ */
+export function contains(
+  needles: string | string[],
+  opts: { caseSensitive?: boolean } = {},
+): Scorer<AgentRunOutput, { found: string[]; missing: string[] }> {
+  const list = (Array.isArray(needles) ? needles : [needles]).filter(Boolean);
+  return createScorer<AgentRunOutput, { found: string[]; missing: string[] }>({
+    name: "contains",
+    analyze(run) {
+      const hay = opts.caseSensitive ? run.text : run.text.toLowerCase();
+      const found: string[] = [];
+      const missing: string[] = [];
+      for (const n of list) {
+        const needle = opts.caseSensitive ? n : n.toLowerCase();
+        if (hay.includes(needle)) found.push(n);
+        else missing.push(n);
+      }
+      return { found, missing };
+    },
+    generateScore({ found }) {
+      return list.length === 0 ? 1 : found.length / list.length;
+    },
+    generateReason({ analysis }) {
+      if (analysis.missing.length === 0) {
+        return `All ${list.length} required phrase(s) present`;
+      }
+      return `Missing: ${analysis.missing.join(", ")}`;
+    },
+  });
+}
+
+/**
+ * `usesTool` — 1.0 when the agent invoked the named tool/action at least once.
+ * Useful as a behavioral gate ("the agent must call send-email"). Pure JS.
+ */
+export function usesTool(
+  toolName: string,
+): Scorer<AgentRunOutput, { used: boolean }> {
+  return createScorer<AgentRunOutput, { used: boolean }>({
+    name: `uses_tool:${toolName}`,
+    analyze(run) {
+      return { used: run.toolCalls.includes(toolName) };
+    },
+    generateScore({ used }) {
+      return used ? 1 : 0;
+    },
+    generateReason({ analysis }) {
+      return analysis.used
+        ? `Agent called \`${toolName}\``
+        : `Agent never called \`${toolName}\``;
+    },
+  });
+}
+
+// ─── Built-in LLM-judge scorer ────────────────────────────────────────
+
+interface JudgeVerdict {
+  score: number;
+  reasoning: string;
+}
+
+/**
+ * Pull the first JSON object out of model text (which may be wrapped in prose
+ * or a ```json fence) and parse it into a verdict. Returns null on garbage so
+ * the caller can degrade gracefully instead of throwing.
+ */
+function parseJudgeVerdict(text: string): JudgeVerdict | null {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[0]) as Partial<JudgeVerdict>;
+    if (typeof parsed.score !== "number") return null;
+    return {
+      score: parsed.score,
+      reasoning: typeof parsed.reasoning === "string" ? parsed.reasoning : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export interface LlmJudgeOptions {
+  /** Scorer name (defaults to `llm_judge`). */
+  name?: string;
+  /** What is being judged, e.g. "helpfulness". */
+  criteria: string;
+  /** A rubric describing what 0.0 vs 1.0 means. */
+  rubric?: string;
+  /**
+   * The score scale the judge is told to use. Output is normalized to [0,1].
+   * Defaults to a 0..1 scale.
+   */
+  scoreRange?: { min: number; max: number };
+}
+
+/**
+ * `llmJudge` — an LLM-as-judge scorer. The analyze step asks the resolved
+ * engine to score the agent output against a natural-language rubric and emit
+ * `{ "score": <n>, "reasoning": "<why>" }`. The model is whatever the runner
+ * resolved from the engine registry — this scorer NEVER hardcodes a provider
+ * or model, so evals stay provider-agnostic.
+ */
+export function llmJudge(
+  opts: LlmJudgeOptions,
+): Scorer<
+  AgentRunOutput,
+  { verdict: JudgeVerdict | null; normalized: number }
+> {
+  const min = opts.scoreRange?.min ?? 0;
+  const max = opts.scoreRange?.max ?? 1;
+  const name = opts.name ?? "llm_judge";
+
+  return createScorer<
+    AgentRunOutput,
+    { verdict: JudgeVerdict | null; normalized: number }
+  >({
+    name,
+    async analyze(run, ctx) {
+      const prompt = `You are an expert evaluator. Score the agent output below against the criteria.
+
+## Criteria
+${opts.criteria}${opts.rubric ? `\n\n## Rubric\n${opts.rubric}` : ""}
+
+## Agent Output
+${run.text || "(no text output)"}
+
+## Tools the agent used
+${run.toolCalls.length ? run.toolCalls.join(", ") : "(none)"}
+
+## Instructions
+Respond with ONLY a JSON object (no markdown, no prose outside the JSON):
+{"score": <number between ${min} and ${max}>, "reasoning": "<brief explanation>"}`;
+
+      const text = await ctx.judge({
+        systemPrompt:
+          "You are an evaluation judge. Respond only with valid JSON.",
+        prompt,
+        maxOutputTokens: 512,
+      });
+      const verdict = parseJudgeVerdict(text);
+      const normalized =
+        verdict === null
+          ? 0
+          : max > min
+            ? (verdict.score - min) / (max - min)
+            : verdict.score;
+      return { verdict, normalized };
+    },
+    generateScore({ normalized }) {
+      return clamp01(normalized);
+    },
+    generateReason({ analysis }) {
+      if (analysis.verdict === null) {
+        return "Judge did not return a parseable verdict";
+      }
+      return analysis.verdict.reasoning || "(no reasoning provided)";
+    },
+  });
+}

--- a/packages/core/src/eval/types.ts
+++ b/packages/core/src/eval/types.ts
@@ -1,0 +1,177 @@
+/**
+ * Types for the first-class evals primitive.
+ *
+ * This is a *test-case* eval system (define a prompt + expected behavior,
+ * actually run the agent, score the output) — distinct from the post-hoc
+ * run-scoring engine in `../observability/evals.ts`, which scores already-
+ * completed production runs. The two are complementary:
+ *
+ *   - `observability/evals.ts` — "how did this real run do?" (passive,
+ *     sampled, lives next to traces).
+ *   - `eval/*` (this module) — "does the agent do the right thing on this
+ *     fixed input?" (active, deterministic CI gate, run via the CLI).
+ *
+ * The pipeline shape (preprocess → analyze → generateScore → generateReason)
+ * is borrowed from Mastra's scorer design: each scorer is a small, composable
+ * 4-step pipeline so a single scorer can mix plain-JS checks with an LLM
+ * judge while still producing one normalized 0..1 number plus a reason.
+ */
+
+import type { AgentEngine } from "../agent/engine/types.js";
+
+// ─── Agent run output ─────────────────────────────────────────────────
+
+/**
+ * The result of actually running the agent loop for one eval input. Scorers
+ * receive this as the thing under test. It is intentionally small and
+ * transport-agnostic so a scorer never reaches into framework internals.
+ */
+export interface AgentRunOutput {
+  /** Concatenated assistant text emitted across the run. */
+  readonly text: string;
+  /** Names of tools/actions the agent invoked, in call order. */
+  readonly toolCalls: readonly string[];
+  /** Whether the run completed without a terminal error event. */
+  readonly ok: boolean;
+  /** Terminal error message, if the run errored. */
+  readonly error?: string;
+  /** Synthetic run id, useful for writing eval rows to the observability store. */
+  readonly runId: string;
+  /** Wall-clock duration of the run in milliseconds. */
+  readonly durationMs: number;
+}
+
+// ─── Scorer pipeline ──────────────────────────────────────────────────
+
+/**
+ * Context handed to a scorer's analyze step when it needs an LLM judge. The
+ * engine/model are resolved by the runner from the existing engine registry —
+ * a scorer NEVER hardcodes a provider or model, keeping evals provider-
+ * agnostic. `judge()` is a convenience that streams a single judging turn and
+ * returns the raw model text.
+ */
+export interface ScorerAnalyzeContext {
+  /** The resolved, provider-agnostic engine for LLM-judge scorers. */
+  readonly engine: AgentEngine;
+  /** The resolved model string for the engine. */
+  readonly model: string;
+  /**
+   * Run a single LLM judging turn. Returns the model's raw text output. Used
+   * by `llmJudge` and any custom LLM-backed analyze step. Provider-agnostic —
+   * the engine is whatever the app/CLI resolved.
+   */
+  judge(opts: {
+    systemPrompt?: string;
+    prompt: string;
+    maxOutputTokens?: number;
+    signal?: AbortSignal;
+  }): Promise<string>;
+}
+
+/**
+ * A 4-step scoring pipeline (Mastra-style):
+ *
+ *   preprocess(run)      → x        (transform the run/output; optional)
+ *   analyze(x, ctx)      → analysis (plain JS OR an LLM judge; optional)
+ *   generateScore(a)     → 0..1     (REQUIRED, normalized)
+ *   generateReason(...)  → string   (human-readable why; optional)
+ *
+ * Generics flow `Pre` (preprocess output) → `Ana` (analyze output) so a
+ * single scorer is fully typed end-to-end.
+ */
+export interface Scorer<Pre = AgentRunOutput, Ana = Pre> {
+  readonly name: string;
+  preprocess?(run: AgentRunOutput): Pre | Promise<Pre>;
+  analyze?(input: Pre, ctx: ScorerAnalyzeContext): Ana | Promise<Ana>;
+  /** REQUIRED. Returns a normalized score in [0, 1]. */
+  generateScore(analysis: Ana): number | Promise<number>;
+  generateReason?(args: {
+    run: AgentRunOutput;
+    analysis: Ana;
+    score: number;
+  }): string | Promise<string>;
+}
+
+/** Definition object passed to `createScorer`. */
+export interface ScorerDefinition<Pre = AgentRunOutput, Ana = Pre> {
+  name: string;
+  preprocess?(run: AgentRunOutput): Pre | Promise<Pre>;
+  analyze?(input: Pre, ctx: ScorerAnalyzeContext): Ana | Promise<Ana>;
+  generateScore(analysis: Ana): number | Promise<number>;
+  generateReason?(args: {
+    run: AgentRunOutput;
+    analysis: Ana;
+    score: number;
+  }): string | Promise<string>;
+}
+
+// ─── Eval definition ──────────────────────────────────────────────────
+
+/** The prompt + optional setup that drives one eval case. */
+export interface EvalInput {
+  /** The user prompt / message sent to the agent. */
+  prompt: string;
+  /**
+   * Optional prior conversation turns to seed before `prompt`. Each is a
+   * plain { role, text } pair; the runner converts them to engine messages.
+   */
+  history?: Array<{ role: "user" | "assistant"; text: string }>;
+}
+
+/** Context passed to an eval's optional `run` override. */
+export interface EvalRunContext {
+  readonly input: EvalInput;
+  /** The default agent runner — invoke it to run the agent loop as a caller. */
+  runAgent(input: EvalInput): Promise<AgentRunOutput>;
+}
+
+/**
+ * A named eval = one test case. `scorers` produce per-scorer rows; the case
+ * passes when EVERY scorer meets `threshold` (default 0.5, overridable per
+ * eval and globally from the CLI).
+ */
+export interface Eval {
+  name: string;
+  input: EvalInput;
+  /**
+   * Optional override for how the agent is run for this case. Defaults to the
+   * runner's headless `runAgent`. Use this to do custom setup (seed data,
+   * multi-turn) before/after the agent call.
+   */
+  run?(ctx: EvalRunContext): AgentRunOutput | Promise<AgentRunOutput>;
+  scorers: Scorer<any, any>[];
+  /** Minimum acceptable score (per scorer) in [0, 1]. Default 0.5. */
+  threshold?: number;
+}
+
+// ─── Results ──────────────────────────────────────────────────────────
+
+/** One result row per (eval × scorer). Stores both the number AND the reason. */
+export interface ScorerResult {
+  scorer: string;
+  score: number;
+  reason?: string;
+  passed: boolean;
+}
+
+/** Aggregated result for a single eval (all of its scorers). */
+export interface EvalResultRow {
+  eval: string;
+  threshold: number;
+  scores: ScorerResult[];
+  /** True only when every scorer passed. */
+  passed: boolean;
+  /** Mean of the scorer scores, for at-a-glance ranking. */
+  avgScore: number;
+  durationMs: number;
+  /** Terminal error if the agent run itself failed. */
+  error?: string;
+}
+
+/** The full runner report. */
+export interface EvalRunReport {
+  total: number;
+  passed: number;
+  failed: number;
+  results: EvalResultRow[];
+}

--- a/packages/core/src/observability/traces.spec.ts
+++ b/packages/core/src/observability/traces.spec.ts
@@ -131,3 +131,168 @@ describe("redactSensitiveFields", () => {
     expect(out.self).toBe("[Circular]");
   });
 });
+
+// OpenTelemetry export: instrumentAgentLoop wraps the run, each tool call, and
+// the model call in OTel spans. With no provider registered the api package's
+// no-op tracer means zero spans escape; with a registered (test) provider the
+// spans carry the expected names and attributes.
+
+interface RecordedSpan {
+  name: string;
+  attributes: Record<string, string | number | boolean>;
+  status?: { code: number; message?: string };
+  ended: boolean;
+}
+
+function createRecordingTracer() {
+  const spans: RecordedSpan[] = [];
+  const tracer = {
+    startSpan(
+      name: string,
+      options?: { attributes?: Record<string, string | number | boolean> },
+    ): AgentSpan {
+      const recorded: RecordedSpan = {
+        name,
+        attributes: { ...(options?.attributes ?? {}) },
+        ended: false,
+      };
+      spans.push(recorded);
+      return {
+        setAttribute(key, value) {
+          recorded.attributes[key] = value;
+        },
+        setAttributes(attributes) {
+          Object.assign(recorded.attributes, attributes);
+        },
+        setStatus(status) {
+          recorded.status = status;
+        },
+        recordException() {},
+        end() {
+          recorded.ended = true;
+        },
+      };
+    },
+  };
+  return { tracer, spans };
+}
+
+describe("instrumentAgentLoop OpenTelemetry export", () => {
+  afterEach(() => {
+    __resetAgentTracerCache();
+  });
+
+  it("emits run/tool/llm spans with expected names and attributes", async () => {
+    const { tracer, spans } = createRecordingTracer();
+    __setAgentTracerForTests(tracer as any);
+
+    const loopOpts: any = {
+      engine: {},
+      model: "claude-test",
+      systemPrompt: "",
+      tools: [],
+      messages: [],
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+    };
+
+    await instrumentAgentLoop({
+      runAgentLoop: async ({ send }) => {
+        send({ type: "tool_start", tool: "read", input: { path: "x" } });
+        send({ type: "tool_done", tool: "read", result: "ok" });
+        send({ type: "tool_start", tool: "db-exec", input: {} });
+        send({ type: "tool_done", tool: "db-exec", result: "Error: boom" });
+        return {
+          inputTokens: 100,
+          outputTokens: 20,
+          cacheReadTokens: 5,
+          cacheWriteTokens: 0,
+          model: "claude-test",
+        };
+      },
+      loopOpts,
+      runId: "run-otel-1",
+      threadId: "thread-1",
+      userId: "user@example.com",
+      config: { ...DEFAULT_OBSERVABILITY_CONFIG, enabled: true },
+    });
+
+    // Let the tool-span microtasks settle.
+    await new Promise((r) => setTimeout(r, 0));
+
+    const byName = (n: string) => spans.filter((s) => s.name === n);
+
+    // Run span.
+    const runSpan = byName("agent.run")[0];
+    expect(runSpan).toBeDefined();
+    expect(runSpan.attributes["agent.run_id"]).toBe("run-otel-1");
+    expect(runSpan.attributes["agent.model"]).toBe("claude-test");
+    expect(runSpan.attributes["agent.tool_calls"]).toBe(2);
+    expect(runSpan.attributes["agent.failed_tools"]).toBe(1);
+    expect(runSpan.status?.code).toBe(SPAN_STATUS_OK);
+    expect(runSpan.ended).toBe(true);
+
+    // Tool spans: one success, one error.
+    const toolSpans = byName("tool.call");
+    expect(toolSpans).toHaveLength(2);
+    const readSpan = toolSpans.find(
+      (s) => s.attributes["tool.name"] === "read",
+    );
+    const dbSpan = toolSpans.find(
+      (s) => s.attributes["tool.name"] === "db-exec",
+    );
+    expect(readSpan?.status?.code).toBe(SPAN_STATUS_OK);
+    expect(readSpan?.ended).toBe(true);
+    expect(dbSpan?.status?.code).toBe(SPAN_STATUS_ERROR);
+    expect(dbSpan?.status?.message).toBe("Error: boom");
+    expect(dbSpan?.ended).toBe(true);
+
+    // LLM span carries model + token usage.
+    const llmSpan = byName("llm.call")[0];
+    expect(llmSpan).toBeDefined();
+    expect(llmSpan.attributes["llm.model"]).toBe("claude-test");
+    expect(llmSpan.attributes["llm.input_tokens"]).toBe(100);
+    expect(llmSpan.attributes["llm.output_tokens"]).toBe(20);
+    expect(llmSpan.attributes["llm.cache_read_tokens"]).toBe(5);
+    expect(llmSpan.status?.code).toBe(SPAN_STATUS_OK);
+    expect(llmSpan.ended).toBe(true);
+  });
+
+  it("no-ops (emits no spans) when no provider is registered", async () => {
+    __setAgentTracerForTests(null);
+
+    const loopOpts: any = {
+      engine: {},
+      model: "claude-test",
+      systemPrompt: "",
+      tools: [],
+      messages: [],
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+    };
+
+    // Must complete without throwing even though no tracer is available.
+    const usage = await instrumentAgentLoop({
+      runAgentLoop: async ({ send }) => {
+        send({ type: "tool_start", tool: "read", input: {} });
+        send({ type: "tool_done", tool: "read", result: "ok" });
+        return {
+          inputTokens: 1,
+          outputTokens: 1,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          model: "claude-test",
+        };
+      },
+      loopOpts,
+      runId: "run-otel-2",
+      threadId: null,
+      userId: null,
+      config: { ...DEFAULT_OBSERVABILITY_CONFIG, enabled: true },
+    });
+
+    expect(usage.model).toBe("claude-test");
+  });
+});

--- a/packages/core/src/observability/traces.spec.ts
+++ b/packages/core/src/observability/traces.spec.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from "vitest";
-import { redactSensitiveFields } from "./traces.js";
+import { afterEach, describe, it, expect } from "vitest";
+import { instrumentAgentLoop, redactSensitiveFields } from "./traces.js";
+import {
+  type AgentSpan,
+  SPAN_STATUS_ERROR,
+  SPAN_STATUS_OK,
+  __resetAgentTracerCache,
+  __setAgentTracerForTests,
+} from "./tracing.js";
+import { DEFAULT_OBSERVABILITY_CONFIG } from "./types.js";
 
 // M14 in the MCP/A2A audit: tool inputs persisted into trace spans can
 // include verbatim credentials (e.g. db-exec INSERTs that contain a raw

--- a/packages/core/src/observability/traces.ts
+++ b/packages/core/src/observability/traces.ts
@@ -2,6 +2,7 @@ import type { AgentChatEvent } from "../agent/types.js";
 import type { AgentLoopUsage } from "../agent/production-agent.js";
 import type { TraceSpan, TraceSummary, ObservabilityConfig } from "./types.js";
 import { DEFAULT_OBSERVABILITY_CONFIG } from "./types.js";
+import { type AgentSpan, endAgentSpan, startAgentSpan } from "./tracing.js";
 
 function spanId(): string {
   return `span-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -93,6 +94,18 @@ export async function instrumentAgentLoop(opts: {
   const runStart = Date.now();
   const parentSpanId = spanId();
 
+  // Optional OpenTelemetry root span for this run. No-ops unless a host has
+  // installed `@opentelemetry/api` and registered a provider. The promise is
+  // resolved before the loop runs so child tool/model spans can parent under
+  // it conceptually (we keep them flat in the same tracer, which is enough
+  // for the dashboards an embedding app would build).
+  const otelRunSpanPromise = startAgentSpan("agent.run", {
+    "agent.run_id": runId,
+    "agent.thread_id": threadId ?? undefined,
+    "agent.user_id": userId ?? undefined,
+    "agent.model": loopOpts.model,
+  });
+
   const spans: TraceSpan[] = [];
   let toolInvocationCounter = 0;
   // Keyed by counter to handle concurrent calls to the same tool name
@@ -103,6 +116,8 @@ export async function instrumentAgentLoop(opts: {
       startMs: number;
       toolName: string;
       input: Record<string, string>;
+      otelSpan: AgentSpan | null;
+      endResult?: { status: "success" | "error"; errorMessage: string | null };
     }
   >();
   // Secondary index: tool name → FIFO queue of pending invocation counters.
@@ -116,16 +131,54 @@ export async function instrumentAgentLoop(opts: {
   let successfulTools = 0;
   let failedTools = 0;
 
+  // Track in-flight OTel tool spans so they're all ended even if the loop
+  // throws before a matching `tool_done` arrives.
+  const openOtelToolSpans = new Set<AgentSpan>();
+
   const instrumentedSend = (event: AgentChatEvent): void => {
     try {
       if (event.type === "tool_start") {
         const counter = toolInvocationCounter++;
         const sid = spanId();
-        pendingTools.set(counter, {
+        // Start the OTel tool span synchronously-ish: kick off the async
+        // resolution and stash the span once it lands. Tool spans are short
+        // and the api tracer is synchronous in practice, but we tolerate the
+        // microtask gap by recording the span on the pending entry when ready.
+        const entry: {
+          spanId: string;
+          startMs: number;
+          toolName: string;
+          input: Record<string, string>;
+          otelSpan: AgentSpan | null;
+          // Set by the done handler if it fires before the span promise
+          // resolves, so the resolved span is ended with the correct status.
+          endResult?: {
+            status: "success" | "error";
+            errorMessage: string | null;
+          };
+        } = {
           spanId: sid,
           startMs: Date.now(),
           toolName: event.tool,
           input: event.input,
+          otelSpan: null,
+        };
+        pendingTools.set(counter, entry);
+        void startAgentSpan("tool.call", {
+          "tool.name": event.tool,
+        }).then((span) => {
+          if (!span) return;
+          // If `tool_done` already ran for this call, end the span now with the
+          // status it recorded; otherwise stash it for the done handler.
+          if (entry.endResult) {
+            endAgentSpan(span, {
+              status: entry.endResult.status,
+              errorMessage: entry.endResult.errorMessage,
+            });
+          } else {
+            entry.otelSpan = span;
+            openOtelToolSpans.add(span);
+          }
         });
         const queue = toolNameToCounters.get(event.tool);
         if (queue) queue.push(counter);
@@ -148,6 +201,23 @@ export async function instrumentAgentLoop(opts: {
             event.result.startsWith("Error running "));
         if (isError) failedTools++;
         else successfulTools++;
+
+        // Finalize the OTel tool span. If the span promise hasn't resolved yet
+        // we record the result on the entry so its `.then` handler ends it.
+        const otelEndResult = {
+          status: (isError ? "error" : "success") as "success" | "error",
+          errorMessage: isError ? (event.result as string) : null,
+        };
+        if (pending?.otelSpan) {
+          openOtelToolSpans.delete(pending.otelSpan);
+          endAgentSpan(pending.otelSpan, {
+            status: otelEndResult.status,
+            errorMessage: otelEndResult.errorMessage,
+            attributes: { "tool.name": event.tool },
+          });
+        } else if (pending) {
+          pending.endResult = otelEndResult;
+        }
 
         const span: TraceSpan = {
           id: pending?.spanId ?? spanId(),
@@ -278,6 +348,49 @@ export async function instrumentAgentLoop(opts: {
     };
 
     writeTraceData(spans, summary, runId, config).catch(() => {});
+
+    // OpenTelemetry export (no-op unless a provider is registered). Emit a
+    // self-contained `llm.call` span carrying model + token usage, end any
+    // tool spans still open (loop threw mid-tool), and end the run span. Awaited
+    // so the spans are emitted before the function returns; cheap when no-op.
+    try {
+      if (usage) {
+        endAgentSpan(await startAgentSpan("llm.call", {}), {
+          status: runStatus,
+          errorMessage,
+          attributes: {
+            "llm.model": usage.model,
+            "llm.input_tokens": usage.inputTokens,
+            "llm.output_tokens": usage.outputTokens,
+            "llm.cache_read_tokens": usage.cacheReadTokens,
+            "llm.cache_write_tokens": usage.cacheWriteTokens,
+            "llm.cost_cents_x100": costCentsX100,
+          },
+        });
+      }
+      for (const toolSpan of openOtelToolSpans) {
+        endAgentSpan(toolSpan, {
+          status: "error",
+          errorMessage: "Agent run ended before tool_done.",
+        });
+      }
+      openOtelToolSpans.clear();
+      endAgentSpan(await otelRunSpanPromise, {
+        status: runStatus,
+        errorMessage,
+        attributes: {
+          "agent.tool_calls": toolCallCount,
+          "agent.successful_tools": successfulTools,
+          "agent.failed_tools": failedTools,
+          "agent.duration_ms": totalDurationMs,
+          "agent.input_tokens": usage?.inputTokens ?? 0,
+          "agent.output_tokens": usage?.outputTokens ?? 0,
+          "agent.cost_cents_x100": costCentsX100,
+        },
+      });
+    } catch {
+      // OTel export must never break the run.
+    }
   }
 
   return usage!;

--- a/packages/core/src/observability/tracing.spec.ts
+++ b/packages/core/src/observability/tracing.spec.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type AgentSpan,
+  SPAN_STATUS_ERROR,
+  SPAN_STATUS_OK,
+  __resetAgentTracerCache,
+  __setAgentTracerForTests,
+  endAgentSpan,
+  startAgentSpan,
+} from "./tracing.js";
+
+/**
+ * In-memory test tracer standing in for a registered OpenTelemetry provider.
+ * Records every span and its attributes/status so we can assert the helper
+ * emits the expected span names and attributes when a provider IS present.
+ */
+interface RecordedSpan {
+  name: string;
+  attributes: Record<string, string | number | boolean>;
+  status?: { code: number; message?: string };
+  exceptions: Array<{ name?: string; message: string }>;
+  ended: boolean;
+}
+
+function createTestTracer() {
+  const spans: RecordedSpan[] = [];
+  const tracer = {
+    startSpan(
+      name: string,
+      options?: { attributes?: Record<string, string | number | boolean> },
+    ): AgentSpan {
+      const recorded: RecordedSpan = {
+        name,
+        attributes: { ...(options?.attributes ?? {}) },
+        exceptions: [],
+        ended: false,
+      };
+      spans.push(recorded);
+      return {
+        setAttribute(key, value) {
+          recorded.attributes[key] = value;
+        },
+        setAttributes(attributes) {
+          Object.assign(recorded.attributes, attributes);
+        },
+        setStatus(status) {
+          recorded.status = status;
+        },
+        recordException(exception) {
+          recorded.exceptions.push(exception);
+        },
+        end() {
+          recorded.ended = true;
+        },
+      };
+    },
+  };
+  return { tracer, spans };
+}
+
+afterEach(() => {
+  __resetAgentTracerCache();
+});
+
+describe("tracing helper — no provider registered", () => {
+  it("startAgentSpan returns null when no tracer is available", async () => {
+    __setAgentTracerForTests(null);
+    const span = await startAgentSpan("agent.run", { "agent.model": "x" });
+    expect(span).toBeNull();
+  });
+
+  it("endAgentSpan no-ops safely on a null span", () => {
+    // Must not throw.
+    expect(() =>
+      endAgentSpan(null, { status: "error", errorMessage: "boom" }),
+    ).not.toThrow();
+  });
+});
+
+describe("tracing helper — test provider registered", () => {
+  it("startAgentSpan creates a span with the given name and attributes", async () => {
+    const { tracer, spans } = createTestTracer();
+    __setAgentTracerForTests(tracer as any);
+
+    const span = await startAgentSpan("tool.call", {
+      "tool.name": "read",
+      "agent.run_id": "run-1",
+    });
+    expect(span).not.toBeNull();
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe("tool.call");
+    expect(spans[0].attributes).toEqual({
+      "tool.name": "read",
+      "agent.run_id": "run-1",
+    });
+  });
+
+  it("prunes null/undefined attributes", async () => {
+    const { tracer, spans } = createTestTracer();
+    __setAgentTracerForTests(tracer as any);
+
+    await startAgentSpan("agent.run", {
+      "agent.model": "claude",
+      "agent.thread_id": undefined,
+      "agent.user_id": null,
+    });
+    expect(spans[0].attributes).toEqual({ "agent.model": "claude" });
+  });
+
+  it("endAgentSpan sets OK status and ends the span on success", async () => {
+    const { tracer, spans } = createTestTracer();
+    __setAgentTracerForTests(tracer as any);
+
+    const span = await startAgentSpan("llm.call");
+    endAgentSpan(span, {
+      status: "success",
+      attributes: { "llm.input_tokens": 42 },
+    });
+
+    expect(spans[0].status?.code).toBe(SPAN_STATUS_OK);
+    expect(spans[0].attributes["llm.input_tokens"]).toBe(42);
+    expect(spans[0].ended).toBe(true);
+    expect(spans[0].exceptions).toHaveLength(0);
+  });
+
+  it("endAgentSpan sets ERROR status and records the exception on error", async () => {
+    const { tracer, spans } = createTestTracer();
+    __setAgentTracerForTests(tracer as any);
+
+    const span = await startAgentSpan("tool.call", { "tool.name": "db-exec" });
+    endAgentSpan(span, { status: "error", errorMessage: "Error: failed" });
+
+    expect(spans[0].status?.code).toBe(SPAN_STATUS_ERROR);
+    expect(spans[0].status?.message).toBe("Error: failed");
+    expect(spans[0].exceptions).toEqual([{ message: "Error: failed" }]);
+    expect(spans[0].ended).toBe(true);
+  });
+});

--- a/packages/core/src/observability/tracing.ts
+++ b/packages/core/src/observability/tracing.ts
@@ -1,0 +1,160 @@
+/**
+ * Optional OpenTelemetry layer for the agent loop.
+ *
+ * The framework's primary trace store is the in-house `agent_trace_spans` /
+ * `agent_trace_summaries` tables (see `traces.ts`). This module adds an
+ * OPTIONAL, no-op-unless-configured OpenTelemetry export on top of that, so a
+ * host that already runs an OTel collector can see agent runs, model calls, and
+ * tool calls alongside the rest of their distributed traces.
+ *
+ * Design constraints:
+ *   - `@opentelemetry/api` is an OPTIONAL dependency. If it isn't installed the
+ *     helpers degrade to silent no-ops — nothing here ever throws into the agent
+ *     loop.
+ *   - The API package ships a default NO-OP tracer. Until a host registers a
+ *     real `TracerProvider` (via `@opentelemetry/sdk-node` or similar, which
+ *     core deliberately does NOT depend on), `tracer.startSpan(...)` returns a
+ *     no-op span and the cost is a couple of property reads. We never register a
+ *     provider ourselves — instrumentation is opt-in by the embedding app.
+ *   - Heavy SDK packages (`@opentelemetry/sdk-*`, exporters) are NOT added to
+ *     core. The host owns the provider/exporter wiring; core only emits spans.
+ */
+
+const TRACER_NAME = "@agent-native/core/agent-loop";
+
+/**
+ * Minimal structural subset of the OpenTelemetry `Span` we use. Declared
+ * locally so this module type-checks even when `@opentelemetry/api` isn't
+ * installed (it's an optional dependency).
+ */
+export interface AgentSpan {
+  setAttribute(key: string, value: string | number | boolean): void;
+  setAttributes(attributes: Record<string, string | number | boolean>): void;
+  /** OTel `SpanStatusCode`: 1 = OK, 2 = ERROR. */
+  setStatus(status: { code: number; message?: string }): void;
+  recordException(exception: { name?: string; message: string }): void;
+  end(): void;
+}
+
+/** OTel `SpanStatusCode` values, inlined so we don't need the api types here. */
+export const SPAN_STATUS_OK = 1;
+export const SPAN_STATUS_ERROR = 2;
+
+/**
+ * Cached tracer. `undefined` = not yet resolved; `null` = resolved to
+ * "no tracer available" (api package missing or load failed).
+ */
+let cachedTracer: AgentTracer | null | undefined;
+
+interface AgentTracer {
+  startSpan(
+    name: string,
+    options?: { attributes?: Record<string, string | number | boolean> },
+  ): AgentSpan;
+}
+
+/**
+ * Resolve the OpenTelemetry tracer if `@opentelemetry/api` is installed.
+ * Returns `null` (cached) when the package is unavailable so callers can
+ * branch to a no-op cheaply on every subsequent call.
+ */
+async function resolveTracer(): Promise<AgentTracer | null> {
+  if (cachedTracer !== undefined) return cachedTracer;
+  try {
+    // Optional dependency — guarded import. Absent ⇒ no-op everywhere.
+    const otel: any = await import("@opentelemetry/api");
+    const tracer = otel?.trace?.getTracer?.(TRACER_NAME);
+    cachedTracer = (tracer as AgentTracer) ?? null;
+  } catch {
+    cachedTracer = null;
+  }
+  return cachedTracer;
+}
+
+/** Drop sentinel/zero token counts so spans aren't cluttered with noise. */
+function pruneAttributes(
+  attributes: Record<string, string | number | boolean | null | undefined>,
+): Record<string, string | number | boolean> {
+  const out: Record<string, string | number | boolean> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === null || value === undefined) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Start a span. When OTel isn't installed (or no provider is registered) this
+ * returns `null` and the caller simply skips span bookkeeping — there is no
+ * runtime cost beyond the cached null check.
+ */
+export async function startAgentSpan(
+  name: string,
+  attributes: Record<
+    string,
+    string | number | boolean | null | undefined
+  > = {},
+): Promise<AgentSpan | null> {
+  const tracer = await resolveTracer();
+  if (!tracer) return null;
+  try {
+    return tracer.startSpan(name, {
+      attributes: pruneAttributes(attributes),
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Finish a span, setting OK/ERROR status and recording the error message when
+ * present. Safe to call with `null` (no-op) and never throws.
+ */
+export function endAgentSpan(
+  span: AgentSpan | null,
+  result: {
+    status?: "success" | "error";
+    errorMessage?: string | null;
+    attributes?: Record<string, string | number | boolean | null | undefined>;
+  } = {},
+): void {
+  if (!span) return;
+  try {
+    if (result.attributes) {
+      span.setAttributes(pruneAttributes(result.attributes));
+    }
+    if (result.status === "error") {
+      span.setStatus({
+        code: SPAN_STATUS_ERROR,
+        message: result.errorMessage ?? undefined,
+      });
+      if (result.errorMessage) {
+        span.recordException({ message: result.errorMessage });
+      }
+    } else {
+      span.setStatus({ code: SPAN_STATUS_OK });
+    }
+  } catch {
+    // Never let span finalization break the agent loop.
+  } finally {
+    try {
+      span.end();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/** For tests — reset the cached tracer so a fresh provider can be detected. */
+export function __resetAgentTracerCache(): void {
+  cachedTracer = undefined;
+}
+
+/**
+ * For tests — inject a tracer directly (e.g. an in-memory test provider's
+ * tracer) without going through the `@opentelemetry/api` global. Pass `null`
+ * to simulate "no tracer available".
+ */
+export function __setAgentTracerForTests(tracer: AgentTracer | null): void {
+  cachedTracer = tracer;
+}

--- a/packages/core/src/observability/tracing.ts
+++ b/packages/core/src/observability/tracing.ts
@@ -90,10 +90,7 @@ function pruneAttributes(
  */
 export async function startAgentSpan(
   name: string,
-  attributes: Record<
-    string,
-    string | number | boolean | null | undefined
-  > = {},
+  attributes: Record<string, string | number | boolean | null | undefined> = {},
 ): Promise<AgentSpan | null> {
   const tracer = await resolveTracer();
   if (!tracer) return null;

--- a/packages/core/src/onboarding/default-steps.spec.ts
+++ b/packages/core/src/onboarding/default-steps.spec.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const canUseDeployCredentialFallbackForRequestMock = vi.hoisted(() => vi.fn());
+const readDeployCredentialEnvMock = vi.hoisted(() => vi.fn());
+const resolveHasCompleteBuilderConnectionMock = vi.hoisted(() => vi.fn());
+const detectEngineFromUserSecretsMock = vi.hoisted(() => vi.fn());
+const isAgentEngineSettingConfiguredMock = vi.hoisted(() => vi.fn());
+const getSettingMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../server/credential-provider.js", () => ({
+  canUseDeployCredentialFallbackForRequest: (...args: unknown[]) =>
+    canUseDeployCredentialFallbackForRequestMock(...args),
+  readDeployCredentialEnv: (...args: unknown[]) =>
+    readDeployCredentialEnvMock(...args),
+  resolveHasCompleteBuilderConnection: (...args: unknown[]) =>
+    resolveHasCompleteBuilderConnectionMock(...args),
+}));
+
+vi.mock("../agent/engine/registry.js", () => ({
+  detectEngineFromUserSecrets: (...args: unknown[]) =>
+    detectEngineFromUserSecretsMock(...args),
+  isAgentEngineSettingConfigured: (...args: unknown[]) =>
+    isAgentEngineSettingConfiguredMock(...args),
+}));
+
+vi.mock("../settings/store.js", () => ({
+  getSetting: (...args: unknown[]) => getSettingMock(...args),
+}));
+
+async function loadLlmStep() {
+  const registry = await import("./registry.js");
+  const defaultSteps = await import("./default-steps.js");
+
+  registry.__resetOnboardingRegistry();
+  defaultSteps.registerDefaultOnboardingSteps();
+
+  const step = registry.listOnboardingSteps().find((item) => item.id === "llm");
+  if (!step) throw new Error("Expected default LLM onboarding step");
+  return step;
+}
+
+describe("default onboarding steps", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+    resolveHasCompleteBuilderConnectionMock.mockResolvedValue(false);
+    detectEngineFromUserSecretsMock.mockResolvedValue(null);
+    isAgentEngineSettingConfiguredMock.mockReturnValue(false);
+    getSettingMock.mockResolvedValue(null);
+    readDeployCredentialEnvMock.mockImplementation(
+      (key: string) => process.env[key] || undefined,
+    );
+  });
+
+  it("does not complete LLM setup from provider env when fallback is blocked", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-test-example");
+    canUseDeployCredentialFallbackForRequestMock.mockReturnValue(false);
+
+    const step = await loadLlmStep();
+
+    await expect(step.isComplete()).resolves.toBe(false);
+    expect(canUseDeployCredentialFallbackForRequestMock).toHaveBeenCalled();
+  });
+
+  it("keeps local single-tenant provider env setup working when fallback is allowed", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-test-example");
+    canUseDeployCredentialFallbackForRequestMock.mockReturnValue(true);
+
+    const step = await loadLlmStep();
+
+    await expect(step.isComplete()).resolves.toBe(true);
+  });
+});

--- a/packages/core/src/onboarding/default-steps.ts
+++ b/packages/core/src/onboarding/default-steps.ts
@@ -16,6 +16,10 @@ import {
   detectEngineFromUserSecrets,
   isAgentEngineSettingConfigured,
 } from "../agent/engine/registry.js";
+import {
+  canUseDeployCredentialFallbackForRequest,
+  readDeployCredentialEnv,
+} from "../server/credential-provider.js";
 import { getSetting } from "../settings/store.js";
 
 type LlmKeyMethod = {
@@ -126,7 +130,12 @@ const llmStep: OnboardingStep = {
     } catch {
       // Fall through to legacy/env detection.
     }
-    if (PROVIDER_ENV_VARS.some((k) => !!process.env[k])) return true;
+    if (
+      canUseDeployCredentialFallbackForRequest() &&
+      PROVIDER_ENV_VARS.some((k) => !!readDeployCredentialEnv(k))
+    ) {
+      return true;
+    }
     try {
       return isAgentEngineSettingConfigured(await getSetting("agent-engine"));
     } catch {

--- a/packages/core/src/scripts/agent-engines/list-agent-engines.spec.ts
+++ b/packages/core/src/scripts/agent-engines/list-agent-engines.spec.ts
@@ -5,6 +5,8 @@ describe("list-agent-engines", () => {
     vi.resetModules();
     vi.unstubAllEnvs();
     delete process.env.AGENT_ENGINE;
+    delete process.env.AGENT_NATIVE_WORKSPACE;
+    delete process.env.VITE_AGENT_NATIVE_WORKSPACE;
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.OPENAI_API_KEY;
     delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
@@ -15,6 +17,9 @@ describe("list-agent-engines", () => {
     }));
     vi.doMock("../../agent/app-model-defaults.js", () => ({
       getAgentAppModelDefaultForCurrentRequest: vi.fn().mockResolvedValue(null),
+    }));
+    vi.doMock("../../secrets/storage.js", () => ({
+      readAppSecret: vi.fn().mockResolvedValue(null),
     }));
   });
 
@@ -43,5 +48,65 @@ describe("list-agent-engines", () => {
         (engine: any) => engine.name === "ai-sdk:missing-provider",
       )?.packageInstalled,
     ).toBe(false);
+  });
+
+  it("does not report AGENT_ENGINE as current when only blocked hosted deploy credentials exist", async () => {
+    vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
+    vi.stubEnv("AGENT_ENGINE", "test:openai");
+    vi.stubEnv("OPENAI_API_KEY", "sk-test-example");
+
+    const { registerAgentEngine } = await import("../../agent/engine/index.js");
+    const { runWithRequestContext } =
+      await import("../../server/request-context.js");
+    const { run } = await import("./list-agent-engines.js");
+
+    registerAgentEngine({
+      name: "test:openai",
+      label: "OpenAI Test",
+      description: "",
+      capabilities: {} as any,
+      defaultModel: "gpt-test",
+      supportedModels: ["gpt-test"],
+      requiredEnvVars: ["OPENAI_API_KEY"],
+      create: vi.fn() as any,
+    });
+
+    const result = JSON.parse(
+      await runWithRequestContext({ userEmail: "hosted@example.com" }, () =>
+        run(),
+      ),
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  it("does not auto-detect hosted deploy provider env as the current engine", async () => {
+    vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
+    vi.stubEnv("OPENAI_API_KEY", "sk-test-example");
+
+    const { registerAgentEngine } = await import("../../agent/engine/index.js");
+    const { runWithRequestContext } =
+      await import("../../server/request-context.js");
+    const { run } = await import("./list-agent-engines.js");
+
+    registerAgentEngine({
+      name: "test:openai",
+      label: "OpenAI Test",
+      description: "",
+      capabilities: {} as any,
+      defaultModel: "gpt-test",
+      supportedModels: ["gpt-test"],
+      requiredEnvVars: ["OPENAI_API_KEY"],
+      create: vi.fn() as any,
+    });
+
+    const result = JSON.parse(
+      await runWithRequestContext({ userEmail: "hosted@example.com" }, () =>
+        run(),
+      ),
+    );
+
+    expect(result.current?.engine).not.toBe("test:openai");
+    expect(result.current?.model).not.toBe("gpt-test");
   });
 });

--- a/packages/core/src/scripts/agent-engines/list-agent-engines.ts
+++ b/packages/core/src/scripts/agent-engines/list-agent-engines.ts
@@ -16,6 +16,7 @@ import {
 import { DEFAULT_MODEL } from "../../agent/default-model.js";
 import { getAgentAppModelDefaultForCurrentRequest } from "../../agent/app-model-defaults.js";
 import { getSetting } from "../../settings/index.js";
+import { canUseDeployCredentialFallbackForRequest } from "../../server/credential-provider.js";
 
 export const tool: ActionTool = {
   description:
@@ -60,16 +61,23 @@ export async function run(args: Record<string, string> = {}): Promise<string> {
   const envEntry = process.env.AGENT_ENGINE
     ? getAgentEngineEntry(process.env.AGENT_ENGINE)
     : undefined;
-  const envUnavailable = !!envEntry && !isAgentEnginePackageInstalled(envEntry);
+  const envUsable =
+    !!envEntry &&
+    (await isStoredEngineUsableForRequest({ engine: envEntry.name }, envEntry));
+  const envUnavailable = !!envEntry && !envUsable;
+  const detectedFromEnv = canUseDeployCredentialFallbackForRequest()
+    ? detectEngineFromEnv()
+    : null;
+  const envSelectedEntry = envUsable ? envEntry : undefined;
 
   const currentEntry = envUnavailable
     ? undefined
-    : (envEntry ??
+    : (envSelectedEntry ??
       (appDefaultUsable ? appDefaultEntry : undefined) ??
       (detectedFromUser?.name === "builder" ? detectedFromUser : undefined) ??
       (storedUsable ? storedEntry : undefined) ??
       detectedFromUser ??
-      detectEngineFromEnv() ??
+      detectedFromEnv ??
       undefined);
   const currentModelCandidate =
     appDefaultUsable && currentEntry?.name === appDefault?.engine

--- a/packages/core/src/server/action-discovery.spec.ts
+++ b/packages/core/src/server/action-discovery.spec.ts
@@ -125,6 +125,34 @@ describe("action discovery", () => {
     expect(registry["preview-thing"].mcpApp).toBe(mcpApp);
   });
 
+  it("preserves a boolean needsApproval gate through discovery", () => {
+    const registry = loadActionsFromStaticRegistry({
+      "send-email": {
+        default: {
+          tool: { description: "Send email", parameters: {} },
+          needsApproval: true,
+          run: async () => ({ ok: true }),
+        },
+      },
+    });
+
+    expect(registry["send-email"].needsApproval).toBe(true);
+  });
+
+  it("preserves a predicate needsApproval gate through discovery", () => {
+    const gate = (args: { to?: string }) =>
+      Boolean(args.to?.endsWith("@external.com"));
+    const registry = loadActionsFromStaticRegistry({
+      "send-email-named": {
+        tool: { description: "Send email", parameters: {} },
+        needsApproval: gate,
+        run: async () => ({ ok: true }),
+      },
+    });
+
+    expect(registry["send-email-named"].needsApproval).toBe(gate);
+  });
+
   it("threads the http config through named and default static entries", () => {
     const registry = loadActionsFromStaticRegistry({
       "named-get": {

--- a/packages/core/src/server/action-discovery.ts
+++ b/packages/core/src/server/action-discovery.ts
@@ -208,6 +208,12 @@ function preserveActionFlags(entry: Record<string, any>): Partial<ActionEntry> {
   ) {
     out.mcpApp = entry.mcpApp;
   }
+  if (
+    typeof entry.needsApproval === "boolean" ||
+    typeof entry.needsApproval === "function"
+  ) {
+    out.needsApproval = entry.needsApproval;
+  }
   return out;
 }
 

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2340,6 +2340,16 @@ export interface AgentChatPluginOptions {
   connectorCatalog?: string[];
 
   /**
+   * Skip mounting the remote MCP protocol route.
+   *
+   * Most apps should leave this off so agent chat, A2A, and MCP share one
+   * runtime. Hosted apps with a dedicated early MCP plugin can set this to
+   * true so their external connector does not depend on the heavier chat
+   * plugin initialization path.
+   */
+  disableMcp?: boolean;
+
+  /**
    * Code-execution capability for the production agent.
    *
    * - `"off"` (default) — no code-execution tools in production.
@@ -4310,133 +4320,135 @@ export function createAgentChatPlugin(
       // Keep legacy names for the composition below
       const basePrompt = prodPrompt;
 
-      // Mount MCP remote server — same action registry as A2A + agent chat
-      const { mountMCP } = await import("../mcp/server.js");
-      mountMCP(nitroApp, {
-        name: options?.appId
-          ? options.appId.charAt(0).toUpperCase() + options.appId.slice(1)
-          : "Agent",
-        title: options?.mcpServerInfo?.title,
-        appId: options?.appId,
-        description:
-          options?.mcpServerInfo?.description ??
-          `Agent-native ${options?.appId ?? "app"} agent`,
-        websiteUrl: options?.mcpServerInfo?.websiteUrl,
-        icons: options?.mcpServerInfo?.icons,
-        actions: allScripts,
-        productionActions: mcpFullActions,
-        ...(options?.connectorCatalog
-          ? { connectorCatalog: options.connectorCatalog }
-          : {}),
-        askAgent: async (message: string) => {
-          const mcpEngine = await resolveEngine({
-            engineOption: options?.engine,
-            apiKey: options?.apiKey,
-            appId: options?.appId,
-          });
-          const mcpModelCandidate =
-            options?.model ??
-            (await getStoredModelForEngine(mcpEngine, {
+      if (options?.disableMcp !== true) {
+        // Mount MCP remote server — same action registry as A2A + agent chat
+        const { mountMCP } = await import("../mcp/server.js");
+        mountMCP(nitroApp, {
+          name: options?.appId
+            ? options.appId.charAt(0).toUpperCase() + options.appId.slice(1)
+            : "Agent",
+          title: options?.mcpServerInfo?.title,
+          appId: options?.appId,
+          description:
+            options?.mcpServerInfo?.description ??
+            `Agent-native ${options?.appId ?? "app"} agent`,
+          websiteUrl: options?.mcpServerInfo?.websiteUrl,
+          icons: options?.mcpServerInfo?.icons,
+          actions: allScripts,
+          productionActions: mcpFullActions,
+          ...(options?.connectorCatalog
+            ? { connectorCatalog: options.connectorCatalog }
+            : {}),
+          askAgent: async (message: string) => {
+            const mcpEngine = await resolveEngine({
+              engineOption: options?.engine,
+              apiKey: options?.apiKey,
               appId: options?.appId,
-            })) ??
-            mcpEngine.defaultModel;
-          const model = normalizeModelForEngine(mcpEngine, mcpModelCandidate);
+            });
+            const mcpModelCandidate =
+              options?.model ??
+              (await getStoredModelForEngine(mcpEngine, {
+                appId: options?.appId,
+              })) ??
+              mcpEngine.defaultModel;
+            const model = normalizeModelForEngine(mcpEngine, mcpModelCandidate);
 
-          // Same actions as A2A — without call-agent to prevent loops.
-          // In dev mode, template actions go through bash, not native tools.
-          const devActiveMcp = isDevMode();
-          const mcpActions = attachToolSearch(
-            devActiveMcp
-              ? {
-                  ...resourceScripts,
-                  ...docsScripts,
-                  ...(lazyContext ? frameworkContextTool : {}),
-                  ...urlTools,
-                  ...chatScripts,
-                  ...fetchTool,
-                  ...webSearchTool,
-                  ...workspaceFilesTool,
-                  ...toolActions,
-                  ...mcpActionEntries,
-                  ...devScriptsForA2A,
-                  ...devRunCodeTool,
-                }
-              : {
-                  ...templateScripts,
-                  ...resourceScripts,
-                  ...docsScripts,
-                  ...dbScripts,
-                  ...refreshScreenTool,
-                  ...(lazyContext ? frameworkContextTool : {}),
-                  ...urlTools,
-                  ...chatScripts,
-                  ...fetchTool,
-                  ...webSearchTool,
-                  ...workspaceFilesTool,
-                  ...toolActions,
-                  ...mcpActionEntries,
-                  ...(resolvedProdCodeExec !== "off" ? runCodeTool : {}),
-                  ...prodCodingTools,
+            // Same actions as A2A — without call-agent to prevent loops.
+            // In dev mode, template actions go through bash, not native tools.
+            const devActiveMcp = isDevMode();
+            const mcpActions = attachToolSearch(
+              devActiveMcp
+                ? {
+                    ...resourceScripts,
+                    ...docsScripts,
+                    ...(lazyContext ? frameworkContextTool : {}),
+                    ...urlTools,
+                    ...chatScripts,
+                    ...fetchTool,
+                    ...webSearchTool,
+                    ...workspaceFilesTool,
+                    ...toolActions,
+                    ...mcpActionEntries,
+                    ...devScriptsForA2A,
+                    ...devRunCodeTool,
+                  }
+                : {
+                    ...templateScripts,
+                    ...resourceScripts,
+                    ...docsScripts,
+                    ...dbScripts,
+                    ...refreshScreenTool,
+                    ...(lazyContext ? frameworkContextTool : {}),
+                    ...urlTools,
+                    ...chatScripts,
+                    ...fetchTool,
+                    ...webSearchTool,
+                    ...workspaceFilesTool,
+                    ...toolActions,
+                    ...mcpActionEntries,
+                    ...(resolvedProdCodeExec !== "off" ? runCodeTool : {}),
+                    ...prodCodingTools,
+                  },
+            );
+
+            const mcpTools = actionsToEngineTools(mcpActions);
+
+            const resources = await loadResourcesForPrompt(
+              SHARED_OWNER,
+              lazyContext,
+              options?.appId,
+            );
+            const schemaBlock = lazyContext
+              ? ""
+              : await buildSchemaBlock(SHARED_OWNER, devActiveMcp);
+            // Build the MCP handler's own prompt — always use the bash-based
+            // dev prompt in dev mode because mcpActions routes template actions
+            // through bash (`devScriptsForA2A`), regardless of `nativeActionsInDev`.
+            const mcpDevPrompt =
+              (options?.devSystemPrompt
+                ? options.devSystemPrompt +
+                  (options?.systemPrompt ??
+                    (lazyContext
+                      ? PROD_FRAMEWORK_PROMPT_COMPACT
+                      : PROD_FRAMEWORK_PROMPT))
+                : lazyContext
+                  ? DEV_FRAMEWORK_PROMPT_COMPACT
+                  : DEV_FRAMEWORK_PROMPT) + devActionsPrompt;
+            const systemPrompt = devActiveMcp
+              ? mcpDevPrompt +
+                buildRuntimeContextPrompt() +
+                resources +
+                schemaBlock
+              : basePrompt +
+                buildRuntimeContextPrompt() +
+                resources +
+                schemaBlock;
+
+            let accumulatedText = "";
+            const controller = new AbortController();
+
+            await runAgentLoopDirectWithSoftTimeout(
+              {
+                engine: mcpEngine,
+                model,
+                systemPrompt,
+                tools: mcpTools,
+                messages: [
+                  { role: "user", content: [{ type: "text", text: message }] },
+                ],
+                actions: mcpActions,
+                send: (event) => {
+                  if (event.type === "text") accumulatedText += event.text;
                 },
-          );
-
-          const mcpTools = actionsToEngineTools(mcpActions);
-
-          const resources = await loadResourcesForPrompt(
-            SHARED_OWNER,
-            lazyContext,
-            options?.appId,
-          );
-          const schemaBlock = lazyContext
-            ? ""
-            : await buildSchemaBlock(SHARED_OWNER, devActiveMcp);
-          // Build the MCP handler's own prompt — always use the bash-based
-          // dev prompt in dev mode because mcpActions routes template actions
-          // through bash (`devScriptsForA2A`), regardless of `nativeActionsInDev`.
-          const mcpDevPrompt =
-            (options?.devSystemPrompt
-              ? options.devSystemPrompt +
-                (options?.systemPrompt ??
-                  (lazyContext
-                    ? PROD_FRAMEWORK_PROMPT_COMPACT
-                    : PROD_FRAMEWORK_PROMPT))
-              : lazyContext
-                ? DEV_FRAMEWORK_PROMPT_COMPACT
-                : DEV_FRAMEWORK_PROMPT) + devActionsPrompt;
-          const systemPrompt = devActiveMcp
-            ? mcpDevPrompt +
-              buildRuntimeContextPrompt() +
-              resources +
-              schemaBlock
-            : basePrompt +
-              buildRuntimeContextPrompt() +
-              resources +
-              schemaBlock;
-
-          let accumulatedText = "";
-          const controller = new AbortController();
-
-          await runAgentLoopDirectWithSoftTimeout(
-            {
-              engine: mcpEngine,
-              model,
-              systemPrompt,
-              tools: mcpTools,
-              messages: [
-                { role: "user", content: [{ type: "text", text: message }] },
-              ],
-              actions: mcpActions,
-              send: (event) => {
-                if (event.type === "text") accumulatedText += event.text;
+                signal: controller.signal,
               },
-              signal: controller.signal,
-            },
-            options?.runSoftTimeoutMs,
-          );
+              options?.runSoftTimeoutMs,
+            );
 
-          return accumulatedText || "(no response)";
-        },
-      });
+            return accumulatedText || "(no response)";
+          },
+        });
+      }
 
       type OwnerContext = {
         owner: string;

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -124,6 +124,7 @@ import nodePath from "node:path";
 import { readBody } from "./h3-helpers.js";
 import {
   AGENT_TEAM_PROCESS_RUN_PATH,
+  getCurrentDelegationDepth,
   processAgentTeamRun,
   reconcileAgentTeamRunsForOwner,
 } from "./agent-teams.js";
@@ -5053,7 +5054,13 @@ export function createAgentChatPlugin(
           tzRaw.trim().length < 64
             ? tzRaw.trim()
             : undefined;
-        return buildRuntimeContextPrompt({ timezone });
+        // Thread the ambient sub-agent delegation depth so a sub-agent running
+        // at the depth cap is told in its runtime context that it cannot
+        // delegate further. The depth-guard already enforces the cap
+        // server-side (`evaluateSubagentDepth`); this only surfaces it to the
+        // model. 0 (the top-level chat) emits no delegation line.
+        const delegationDepth = getCurrentDelegationDepth();
+        return buildRuntimeContextPrompt({ timezone, delegationDepth });
       };
 
       // The app-rendered sidebar must never edit the app's source code

--- a/packages/core/src/server/agent-teams-delegation-depth.spec.ts
+++ b/packages/core/src/server/agent-teams-delegation-depth.spec.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── app_state (task records + thread reverse-lookup) ──────────────────────
+const appState = vi.hoisted(() => new Map<string, Record<string, unknown>>());
+
+vi.mock("../application-state/script-helpers.js", () => ({
+  readAppState: vi.fn(async (key: string) => appState.get(key) ?? null),
+  writeAppState: vi.fn(async (key: string, value: Record<string, unknown>) => {
+    appState.set(key, value);
+  }),
+  deleteAppState: vi.fn(async (key: string) => appState.delete(key)),
+  listAppState: vi.fn(async (prefix: string) =>
+    [...appState.entries()]
+      .filter(([key]) => key.startsWith(prefix))
+      .map(([key, value]) => ({ key, value })),
+  ),
+}));
+
+// ── spawn-path collaborators (kept inert; we only assert the depth guard) ──
+vi.mock("../chat-threads/store.js", () => ({
+  createThread: vi.fn(async (_owner: string, opts: { title?: string }) => ({
+    id: `thread-${Math.random().toString(36).slice(2, 8)}`,
+    title: opts?.title ?? "",
+  })),
+  updateThreadData: vi.fn(async () => {}),
+  getThread: vi.fn(async () => null),
+}));
+
+const enqueueAgentTeamRunMock = vi.fn(async () => {});
+vi.mock("./agent-teams-run-queue.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./agent-teams-run-queue.js")>();
+  return { ...actual, enqueueAgentTeamRun: enqueueAgentTeamRunMock };
+});
+
+const fireInternalDispatchMock = vi.fn(async () => {});
+vi.mock("./self-dispatch.js", () => ({
+  fireInternalDispatch: fireInternalDispatchMock,
+}));
+
+vi.mock("../org/context.js", () => ({
+  resolveOrgIdForEmail: vi.fn(async () => null),
+}));
+
+vi.mock("../progress/registry.js", () => ({
+  startRun: vi.fn(async () => ({})),
+  updateRunProgress: vi.fn(async () => ({})),
+  completeRun: vi.fn(async () => ({})),
+}));
+
+vi.mock("./request-context.js", () => ({
+  getRequestUserEmail: () => "owner@example.com",
+  runWithRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}));
+
+const OWNER = "owner@example.com";
+
+function baseSpawnOptions() {
+  return {
+    description: "do the thing",
+    ownerEmail: OWNER,
+    systemPrompt: "base",
+    actions: {},
+    engine: { name: "test", defaultModel: "m" } as any,
+    model: "m",
+    parentSend: () => {},
+  };
+}
+
+describe("agent-teams delegation-depth guardrail", () => {
+  beforeEach(() => {
+    appState.clear();
+    enqueueAgentTeamRunMock.mockClear();
+    fireInternalDispatchMock.mockClear();
+    delete process.env.AGENT_NATIVE_MAX_SUBAGENT_DEPTH;
+  });
+
+  afterEach(() => {
+    delete process.env.AGENT_NATIVE_MAX_SUBAGENT_DEPTH;
+  });
+
+  // (i) within-limit spawn still works ───────────────────────────────────────
+  it("allows a top-level spawn and records the child at depth 1", async () => {
+    const { spawnTask } = await import("./agent-teams.js");
+
+    const task = await spawnTask(baseSpawnOptions());
+
+    expect(task.status).toBe("running");
+    expect(task.delegationDepth).toBe(1);
+    expect(enqueueAgentTeamRunMock).toHaveBeenCalledTimes(1);
+    expect(fireInternalDispatchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a depth-1 sub-agent to spawn a depth-2 sub-agent (still within MAX=2)", async () => {
+    const { spawnTask } = await import("./agent-teams.js");
+
+    const task = await spawnTask({
+      ...baseSpawnOptions(),
+      parentDelegationDepth: 1,
+    });
+
+    expect(task.delegationDepth).toBe(2);
+    expect(enqueueAgentTeamRunMock).toHaveBeenCalledTimes(1);
+  });
+
+  // (ii) spawn at/over MAX is refused with the error result ───────────────────
+  it("refuses a spawn that would exceed MAX with a clear error and no enqueue", async () => {
+    const { spawnTask, SubagentDelegationDepthError } =
+      await import("./agent-teams.js");
+
+    // Parent already at depth 2 → child would be depth 3 > MAX (2).
+    await expect(
+      spawnTask({ ...baseSpawnOptions(), parentDelegationDepth: 2 }),
+    ).rejects.toThrowError(
+      /Delegation depth limit reached \(max 2\); cannot spawn another sub-agent\./,
+    );
+
+    try {
+      await spawnTask({ ...baseSpawnOptions(), parentDelegationDepth: 2 });
+      throw new Error("expected spawnTask to reject");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SubagentDelegationDepthError);
+      expect(
+        (err as InstanceType<typeof SubagentDelegationDepthError>).decision,
+      ).toMatchObject({
+        allowed: false,
+        parentDepth: 2,
+        childDepth: 3,
+        maxDepth: 2,
+      });
+    }
+
+    // Refused spawns must not touch the dispatch queue.
+    expect(enqueueAgentTeamRunMock).not.toHaveBeenCalled();
+    expect(fireInternalDispatchMock).not.toHaveBeenCalled();
+    // No task record should have been persisted.
+    expect([...appState.keys()].some((k) => k.startsWith("agent-task:"))).toBe(
+      false,
+    );
+  });
+
+  it("enforces the cap defensively from the ambient run depth (no tool-stripping needed)", async () => {
+    const { spawnTask, _agentTeamsQueueForTests } =
+      await import("./agent-teams.js");
+
+    // Simulate running inside a depth-2 sub-agent's loop. A nested spawnTask
+    // with NO explicit parentDelegationDepth must read depth 2 from the ambient
+    // store and refuse.
+    await expect(
+      _agentTeamsQueueForTests.runWithDelegationDepth(2, async () => {
+        expect(_agentTeamsQueueForTests.currentAmbientDelegationDepth()).toBe(
+          2,
+        );
+        return spawnTask(baseSpawnOptions());
+      }),
+    ).rejects.toThrowError(/Delegation depth limit reached \(max 2\)/);
+
+    expect(enqueueAgentTeamRunMock).not.toHaveBeenCalled();
+  });
+
+  // (iii) the env override changes the limit ─────────────────────────────────
+  it("raises the cap when AGENT_NATIVE_MAX_SUBAGENT_DEPTH overrides the default", async () => {
+    process.env.AGENT_NATIVE_MAX_SUBAGENT_DEPTH = "4";
+    const { spawnTask } = await import("./agent-teams.js");
+
+    // Parent at depth 3 → child depth 4 ≤ 4 now allowed.
+    const task = await spawnTask({
+      ...baseSpawnOptions(),
+      parentDelegationDepth: 3,
+    });
+    expect(task.delegationDepth).toBe(4);
+    expect(enqueueAgentTeamRunMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("lowers the cap to 0 (no sub-agents) when the env override is 0", async () => {
+    process.env.AGENT_NATIVE_MAX_SUBAGENT_DEPTH = "0";
+    const { spawnTask } = await import("./agent-teams.js");
+
+    // Even a top-level spawn (parent depth 0 → child depth 1 > 0) is refused.
+    await expect(spawnTask(baseSpawnOptions())).rejects.toThrowError(
+      /Delegation depth limit reached \(max 0\)/,
+    );
+    expect(enqueueAgentTeamRunMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("evaluateSubagentDepth", () => {
+  it("permits children up to and including the cap, refuses beyond it", async () => {
+    const { evaluateSubagentDepth } = await import("./agent-teams.js");
+    const env = {} as Record<string, string | undefined>;
+
+    expect(evaluateSubagentDepth(0, env)).toMatchObject({
+      allowed: true,
+      childDepth: 1,
+      maxDepth: 2,
+    });
+    expect(evaluateSubagentDepth(1, env)).toMatchObject({
+      allowed: true,
+      childDepth: 2,
+    });
+    expect(evaluateSubagentDepth(2, env)).toMatchObject({
+      allowed: false,
+      childDepth: 3,
+      error: expect.stringContaining("Delegation depth limit reached (max 2)"),
+    });
+  });
+
+  it("reads the cap from the supplied env and clamps invalid values to the default", async () => {
+    const { evaluateSubagentDepth } = await import("./agent-teams.js");
+
+    expect(
+      evaluateSubagentDepth(2, { AGENT_NATIVE_MAX_SUBAGENT_DEPTH: "3" })
+        .allowed,
+    ).toBe(true);
+    // Invalid override → falls back to default (2), so depth-3 child is refused.
+    expect(
+      evaluateSubagentDepth(2, { AGENT_NATIVE_MAX_SUBAGENT_DEPTH: "abc" })
+        .allowed,
+    ).toBe(false);
+    expect(
+      evaluateSubagentDepth(2, { AGENT_NATIVE_MAX_SUBAGENT_DEPTH: "-5" })
+        .allowed,
+    ).toBe(false);
+  });
+
+  it("normalizes a fractional / negative parent depth before deciding", async () => {
+    const { evaluateSubagentDepth } = await import("./agent-teams.js");
+    const env = {} as Record<string, string | undefined>;
+
+    expect(evaluateSubagentDepth(1.9, env)).toMatchObject({
+      parentDepth: 1,
+      childDepth: 2,
+      allowed: true,
+    });
+    expect(evaluateSubagentDepth(-3, env)).toMatchObject({
+      parentDepth: 0,
+      childDepth: 1,
+      allowed: true,
+    });
+  });
+});

--- a/packages/core/src/server/agent-teams.spec.ts
+++ b/packages/core/src/server/agent-teams.spec.ts
@@ -569,6 +569,32 @@ describe("agent teams message queue", () => {
   });
 });
 
+describe("getCurrentDelegationDepth", () => {
+  it("returns 0 outside any delegation scope (top-level chat)", async () => {
+    const { getCurrentDelegationDepth } = await import("./agent-teams.js");
+    expect(getCurrentDelegationDepth()).toBe(0);
+  });
+
+  it("reflects the ambient depth set by runWithDelegationDepth", async () => {
+    const { getCurrentDelegationDepth, _agentTeamsQueueForTests } =
+      await import("./agent-teams.js");
+    const { runWithDelegationDepth } = _agentTeamsQueueForTests;
+
+    const seen: number[] = [];
+    await runWithDelegationDepth(2, async () => {
+      seen.push(getCurrentDelegationDepth());
+      await runWithDelegationDepth(3, async () => {
+        seen.push(getCurrentDelegationDepth());
+      });
+      seen.push(getCurrentDelegationDepth());
+    });
+    // Back outside the scope it is 0 again.
+    seen.push(getCurrentDelegationDepth());
+
+    expect(seen).toEqual([2, 3, 2, 0]);
+  });
+});
+
 function useTempCodeAgentsHome(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-teams-code-"));
   tmpRoots.push(root);

--- a/packages/core/src/server/agent-teams.ts
+++ b/packages/core/src/server/agent-teams.ts
@@ -86,6 +86,76 @@ import {
   getRequestUserEmail,
   runWithRequestContext,
 } from "./request-context.js";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { resolveMaxSubagentDelegationDepth } from "../agent/runtime-context.js";
+
+/**
+ * Ambient delegation depth for the agent whose run is currently executing.
+ *
+ * `processAgentTeamRun` runs each sub-agent inside `runWithDelegationDepth(d)`
+ * where `d` is that sub-agent's own depth. So if a sub-agent calls `spawnTask`
+ * (e.g. because tool-stripping was bypassed and it was handed the `agent-teams`
+ * tool anyway), the spawn path reads its parent's depth from here and refuses
+ * once the cap is reached — independent of any tool-level guard. The top-level
+ * chat runs outside this storage, so its ambient depth is 0.
+ */
+const delegationDepthStorage = new AsyncLocalStorage<number>();
+
+/**
+ * Run `fn` with `depth` recorded as the ambient delegation depth so any
+ * `spawnTask` call made transitively from `fn` knows the depth of the agent
+ * doing the spawning.
+ */
+function runWithDelegationDepth<T>(
+  depth: number,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  return delegationDepthStorage.run(Math.max(0, Math.floor(depth || 0)), fn);
+}
+
+/** Depth of the agent currently executing (0 = top-level chat). */
+function currentAmbientDelegationDepth(): number {
+  return delegationDepthStorage.getStore() ?? 0;
+}
+
+export interface SubagentDepthDecision {
+  /** Whether the spawn is allowed under the depth cap. */
+  allowed: boolean;
+  /** Depth of the agent doing the spawning (parent). */
+  parentDepth: number;
+  /** Depth the spawned sub-agent would have (parentDepth + 1). */
+  childDepth: number;
+  /** The effective cap (resolved from env, clamped). */
+  maxDepth: number;
+  /** Human-readable refusal message when `allowed` is false. */
+  error?: string;
+}
+
+/**
+ * Decide whether an agent at `parentDepth` may spawn another sub-agent. The
+ * child would sit at `parentDepth + 1`; a child deeper than `maxDepth` is
+ * refused. Pure + exported so the enforcement is unit-testable and reusable.
+ */
+export function evaluateSubagentDepth(
+  parentDepth: number,
+  env: Record<string, string | undefined> = process.env,
+): SubagentDepthDecision {
+  const safeParentDepth = Number.isFinite(parentDepth)
+    ? Math.max(0, Math.floor(parentDepth))
+    : 0;
+  const childDepth = safeParentDepth + 1;
+  const maxDepth = resolveMaxSubagentDelegationDepth(env);
+  const allowed = childDepth <= maxDepth;
+  return {
+    allowed,
+    parentDepth: safeParentDepth,
+    childDepth,
+    maxDepth,
+    error: allowed
+      ? undefined
+      : `Delegation depth limit reached (max ${maxDepth}); cannot spawn another sub-agent.`,
+  };
+}
 
 /** Framework route the self-fire dispatch targets to run a queued sub-agent in
  * a fresh function invocation. Mounted inside the agent-chat plugin (where the
@@ -112,6 +182,12 @@ export interface AgentTask {
   completedAt?: number;
   runId?: string;
   error?: string;
+  /**
+   * Delegation depth of THIS sub-agent: 1 for a sub-agent spawned by the
+   * top-level chat, 2 for a sub-agent spawned by a depth-1 sub-agent, etc.
+   * Drives the runaway-delegation guardrail (see `evaluateSubagentDepth`).
+   */
+  delegationDepth?: number;
 }
 
 export type AgentTeamBackgroundRun = Omit<
@@ -1142,6 +1218,31 @@ export interface SpawnTaskOptions {
   parentThreadId?: string;
   /** Display name for the sub-agent tab (carried into the dispatch payload). */
   name?: string;
+  /**
+   * Delegation depth of the agent doing the spawning (the parent). Top-level
+   * chat is 0. When omitted, the depth is read from the ambient run context
+   * (set by `processAgentTeamRun` when a sub-agent is itself running), so a
+   * sub-agent that reaches `spawnTask` inherits its own depth automatically.
+   * The spawned sub-agent's depth is `parentDelegationDepth + 1`.
+   */
+  parentDelegationDepth?: number;
+}
+
+/**
+ * Error thrown when a spawn is refused because it would exceed the delegation
+ * depth cap. Carries the structured decision so callers (and the tool layer)
+ * can surface a precise message to the parent agent.
+ */
+export class SubagentDelegationDepthError extends Error {
+  readonly decision: SubagentDepthDecision;
+  constructor(decision: SubagentDepthDecision) {
+    super(
+      decision.error ??
+        `Delegation depth limit reached (max ${decision.maxDepth}); cannot spawn another sub-agent.`,
+    );
+    this.name = "SubagentDelegationDepthError";
+    this.decision = decision;
+  }
 }
 
 /**
@@ -1149,6 +1250,21 @@ export interface SpawnTaskOptions {
  * and emits agent_task events to the parent chat stream.
  */
 export async function spawnTask(opts: SpawnTaskOptions): Promise<AgentTask> {
+  // ── Delegation-depth guardrail ────────────────────────────────────────────
+  // Defensive, server-side enforcement that holds regardless of any tool-level
+  // stripping in the agent-chat plugin: a sub-agent cannot infinitely spawn
+  // sub-agents. The spawning agent's depth comes from the explicit option or,
+  // failing that, the ambient depth recorded while a sub-agent run executes.
+  const parentDepth =
+    typeof opts.parentDelegationDepth === "number"
+      ? opts.parentDelegationDepth
+      : currentAmbientDelegationDepth();
+  const decision = evaluateSubagentDepth(parentDepth);
+  if (!decision.allowed) {
+    throw new SubagentDelegationDepthError(decision);
+  }
+  const childDepth = decision.childDepth;
+
   const taskId = generateTaskId();
 
   // Create a dedicated thread for the sub-agent with the task as the first message
@@ -1205,6 +1321,7 @@ export async function spawnTask(opts: SpawnTaskOptions): Promise<AgentTask> {
     updatedAt: createdAt,
     startedAt: createdAt,
     runId,
+    delegationDepth: childDepth,
   };
 
   await saveTask(task);
@@ -1649,19 +1766,28 @@ export async function processAgentTeamRun(
             };
             await runWithRequestContext(
               { userEmail: ownerEmail || undefined, orgId: orgId ?? undefined },
-              async () => {
-                chunkUsage = await runAgentLoop({
-                  engine: config.engine,
-                  model: config.model,
-                  systemPrompt,
-                  tools,
-                  messages,
-                  actions: messageAwareActions,
-                  send: wrappedSend,
-                  signal,
-                  finalResponseGuard: createTaskMessageFinalGuard(opts.taskId),
-                });
-              },
+              // Record THIS sub-agent's own delegation depth as the ambient
+              // depth for the duration of its agent loop. If a tool call from
+              // within the loop reaches `spawnTask` (even with the team tool not
+              // stripped), the spawn path reads this depth and refuses once the
+              // cap is hit. Fall back to depth 1 for legacy tasks persisted
+              // before delegationDepth was tracked.
+              () =>
+                runWithDelegationDepth(task.delegationDepth ?? 1, async () => {
+                  chunkUsage = await runAgentLoop({
+                    engine: config.engine,
+                    model: config.model,
+                    systemPrompt,
+                    tools,
+                    messages,
+                    actions: messageAwareActions,
+                    send: wrappedSend,
+                    signal,
+                    finalResponseGuard: createTaskMessageFinalGuard(
+                      opts.taskId,
+                    ),
+                  });
+                }),
             );
           },
           async (run) => {
@@ -2049,4 +2175,7 @@ export const _agentTeamsQueueForTests = {
   drainQueuedTaskMessages,
   formatQueuedTaskMessages,
   resolveTaskCompletion,
+  evaluateSubagentDepth,
+  runWithDelegationDepth,
+  currentAmbientDelegationDepth,
 };

--- a/packages/core/src/server/agent-teams.ts
+++ b/packages/core/src/server/agent-teams.ts
@@ -118,6 +118,19 @@ function currentAmbientDelegationDepth(): number {
   return delegationDepthStorage.getStore() ?? 0;
 }
 
+/**
+ * Public read of the ambient sub-agent delegation depth for the currently
+ * executing agent. 0 = the top-level (user-facing) chat; 1+ = a spawned
+ * sub-agent. Used by the chat plugin to thread the depth into
+ * `buildRuntimeContextPrompt` so a sub-agent at the cap is told it can't
+ * delegate further. Mirrors `currentAmbientDelegationDepth`; exported under a
+ * descriptive name so callers outside this module don't depend on the private
+ * helper or the test-only export object.
+ */
+export function getCurrentDelegationDepth(): number {
+  return currentAmbientDelegationDepth();
+}
+
 export interface SubagentDepthDecision {
   /** Whether the spawn is allowed under the depth cap. */
   allowed: boolean;

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -2016,7 +2016,7 @@ export function createCoreRoutesPlugin(
             // write here lets one tenant overwrite Stripe / OpenAI / Sentry
             // keys for every other tenant. Disable the endpoint outside of
             // local-dev SQLite or an explicit single-tenant opt-in, and
-            // direct callers to the per-org credential store instead.
+            // direct callers to scoped secret/credential stores instead.
             if (!isEnvVarWriteAllowed()) {
               setResponseStatus(event, 403);
               return {

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -136,7 +136,6 @@ import {
   getAgentEngineEntry,
   detectEngineFromEnv,
   detectEngineFromUserSecrets,
-  isAgentEnginePackageInstalled,
   isStoredEngineUsableForRequest,
 } from "../agent/engine/registry.js";
 import { registerBuiltinEngines } from "../agent/engine/builtin.js";
@@ -212,7 +211,11 @@ async function detectUsageEngineName(
       ? getAgentEngineEntry(process.env.AGENT_ENGINE)
       : undefined;
     if (envEntry) {
-      return isAgentEnginePackageInstalled(envEntry) ? envEntry.name : null;
+      return (await runWithRequestContext({ userEmail, orgId }, () =>
+        isStoredEngineUsableForRequest({ engine: envEntry.name }, envEntry),
+      ))
+        ? envEntry.name
+        : null;
     }
 
     const detectedFromUser = await runWithRequestContext(
@@ -2152,7 +2155,15 @@ export function createCoreRoutesPlugin(
               ? getAgentEngineEntry(process.env.AGENT_ENGINE)
               : undefined;
             if (envEntry) {
-              if (!isAgentEnginePackageInstalled(envEntry)) {
+              const envUsable = await runWithRequestContext(
+                { userEmail, orgId },
+                () =>
+                  isStoredEngineUsableForRequest(
+                    { engine: envEntry.name },
+                    envEntry,
+                  ),
+              );
+              if (!envUsable) {
                 return { configured: false };
               }
               return {

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -439,7 +439,7 @@ describe("resolveBuilderCredential", () => {
     expect(canUseDeployCredentialFallbackForRequest()).toBe(false);
   });
 
-  it("does not use deploy-level Builder keys for signed-in hosted workspace users", async () => {
+  it("does not use deploy-level LLM keys for signed-in hosted workspace users", async () => {
     process.env.NODE_ENV = "development";
     process.env.AGENT_NATIVE_WORKSPACE = "1";
     process.env.BUILDER_PRIVATE_KEY = "deploy-key";
@@ -456,8 +456,8 @@ describe("resolveBuilderCredential", () => {
     expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBeNull();
     expect(await resolveSecret("BUILDER_PRIVATE_KEY")).toBeNull();
     expect(await resolveBuilderCredentialSource()).toBeNull();
-    expect(await resolveSecret("OPENAI_API_KEY")).toBe("openai-deploy-key");
-    expect(canUseDeployCredentialFallbackForRequest()).toBe(true);
+    expect(await resolveSecret("OPENAI_API_KEY")).toBeNull();
+    expect(canUseDeployCredentialFallbackForRequest()).toBe(false);
   });
 
   it("falls back to org scope when no user-scope row exists", async () => {

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -85,6 +85,7 @@ export function isDeployCredentialFallbackAllowed(): boolean {
 
 export function canUseDeployCredentialFallbackForRequest(): boolean {
   const email = getRequestUserEmail();
+  if (email && isHostedWorkspaceRuntime()) return false;
   if (!email) return true;
   return isDeployCredentialFallbackAllowed();
 }

--- a/packages/core/src/server/framework-request-handler.spec.ts
+++ b/packages/core/src/server/framework-request-handler.spec.ts
@@ -338,6 +338,33 @@ describe("framework request handler", () => {
     await expect(pending).resolves.toEqual({ ok: true });
   });
 
+  it("returns a retryable 503 instead of a bare 404 when tracked plugin init fails", async () => {
+    // Reproduces the recurring hosted MCP 404: on a cold/propagating instance
+    // the async plugin init can reject (e.g. DB unreachable) before it ever
+    // registers /_agent-native/mcp. Without the failure fallback the readiness
+    // gate would release into a bare "Cannot find any route matching" 404 that
+    // external MCP clients (pi/codex) can't recover from.
+    const nitroApp = createNitroApp();
+    let fail!: (err: Error) => void;
+    const ready = new Promise<void>((_resolve, reject) => {
+      fail = reject;
+    });
+    trackPluginInit(nitroApp, ready, {
+      paths: ["/_agent-native/mcp"],
+    });
+
+    fail(new Error("db unreachable"));
+    // Let the tracked-init catch record the failure.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const result = await dispatch(nitroApp, "/_agent-native/mcp");
+
+    // Must not fall through to a bare 404; returns a meaningful, retryable body.
+    expect(result).not.toEqual({ fellThrough: true });
+    expect(JSON.stringify(result)).toContain("initializing or unavailable");
+  });
+
   it("does not treat similar non-prefixed paths as framework routes", async () => {
     process.env.APP_BASE_PATH = "/docs";
     const nitroApp = createNitroApp();

--- a/packages/core/src/server/framework-request-handler.spec.ts
+++ b/packages/core/src/server/framework-request-handler.spec.ts
@@ -20,6 +20,9 @@ async function dispatch(nitroApp: any, pathname: string) {
     url: new URL(`http://example.test${pathname}`),
     path: pathname,
     context: {},
+    // Minimal h3-v2 response shape so handlers that call setResponseStatus /
+    // setResponseHeader (e.g. the init-failure 503 fallback) work under test.
+    res: { status: 200, headers: new Headers() },
   };
   let index = 0;
   const next = async (): Promise<unknown> => {

--- a/packages/core/src/server/framework-request-handler.ts
+++ b/packages/core/src/server/framework-request-handler.ts
@@ -577,9 +577,8 @@ async function bootstrapDefaultPlugins(nitroApp: any): Promise<void> {
     const terminalModule = await import("../terminal/terminal-plugin.js");
     const integrationsModule = await import("../integrations/plugin.js");
     const contextXrayModule = await import("../agent/context-xray/plugin.js");
-    const observationalMemoryModule = await import(
-      "../agent/observational-memory/plugin.js"
-    );
+    const observationalMemoryModule =
+      await import("../agent/observational-memory/plugin.js");
     const orgModule = await import("../org/plugin.js");
     const onboardingModule = await import("../onboarding/plugin.js");
 

--- a/packages/core/src/server/framework-request-handler.ts
+++ b/packages/core/src/server/framework-request-handler.ts
@@ -25,6 +25,7 @@ const APP_SHIM_KEY = "_agentNativeH3Shim";
 const BOOTSTRAP_PROMISE_KEY = "_agentNativeBootstrapPromise";
 const PLUGIN_READY_KEY = "_agentNativePluginReadyPromise";
 const PLUGIN_READY_PLACEHOLDERS_KEY = "_agentNativePluginReadyPlaceholders";
+const PLUGIN_FAILED_KEY = "_agentNativePluginInitFailures";
 const PROVIDED_PLUGIN_STEMS_KEY = "_agentNativeProvidedPluginStems";
 const MIDDLEWARE_DISPATCHER_PATCHED_KEY =
   "_agentNativeMiddlewareDispatcherPatched";
@@ -270,6 +271,19 @@ export function trackPluginInit(
       "[agent-native] Plugin init failed:",
       (err as Error).message || err,
     );
+    // Record the failure so the readiness gate can return a retryable 503 for
+    // this plugin's routes instead of letting them fall through to a bare
+    // "Cannot find any route matching" 404. That bare 404 is what kept biting
+    // external MCP clients (pi/codex/claude) and the connect flow on cold /
+    // propagating instances whose async init rejected (e.g. DB not yet
+    // reachable): the route never registered, so the placeholder released into
+    // a 404 the client couldn't recover from. A 503 is at least retryable.
+    const failures = (nitroApp[PLUGIN_FAILED_KEY] ??= new Map<
+      string,
+      string
+    >());
+    const msg = (err as Error)?.message || String(err);
+    for (const p of options.paths?.filter(Boolean) ?? []) failures.set(p, msg);
   });
   const entry: PluginReadyEntry = {
     promise: safe,
@@ -303,10 +317,27 @@ function installPluginReadyPlaceholders(
       path,
       (async (event: H3Event) => {
         const eventAny = event as any;
-        await awaitFrameworkRoutesReadyForRequest(
-          nitroApp,
-          eventAny.context?._mountedPathname ?? event.url?.pathname ?? path,
-        );
+        const reqPath =
+          eventAny.context?._mountedPathname ?? event.url?.pathname ?? path;
+        await awaitFrameworkRoutesReadyForRequest(nitroApp, reqPath);
+        // If this plugin's async init failed, its real route was never
+        // registered. Return a retryable 503 instead of releasing into a bare
+        // 404 (external MCP clients can't recover from a 404; a 503 is at least
+        // a "try again" the client / next instance can act on).
+        const failures = nitroApp[PLUGIN_FAILED_KEY] as
+          | Map<string, string>
+          | undefined;
+        if (failures?.size) {
+          for (const [failedPath, msg] of failures) {
+            if (resolveMountMatch(reqPath, failedPath)) {
+              setResponseStatus(event, 503);
+              setResponseHeader(event, "retry-after", "5");
+              return {
+                error: `agent-native route is initializing or unavailable: ${msg}`,
+              };
+            }
+          }
+        }
         return undefined;
       }) as EventHandler,
       {

--- a/packages/core/src/server/framework-request-handler.ts
+++ b/packages/core/src/server/framework-request-handler.ts
@@ -577,6 +577,9 @@ async function bootstrapDefaultPlugins(nitroApp: any): Promise<void> {
     const terminalModule = await import("../terminal/terminal-plugin.js");
     const integrationsModule = await import("../integrations/plugin.js");
     const contextXrayModule = await import("../agent/context-xray/plugin.js");
+    const observationalMemoryModule = await import(
+      "../agent/observational-memory/plugin.js"
+    );
     const orgModule = await import("../org/plugin.js");
     const onboardingModule = await import("../onboarding/plugin.js");
 
@@ -589,6 +592,8 @@ async function bootstrapDefaultPlugins(nitroApp: any): Promise<void> {
       "context-xray": (contextXrayModule as any).defaultContextXrayPlugin,
       "core-routes": (serverModule as any).defaultCoreRoutesPlugin,
       integrations: (integrationsModule as any).defaultIntegrationsPlugin,
+      "observational-memory": (observationalMemoryModule as any)
+        .defaultObservationalMemoryPlugin,
       onboarding: (onboardingModule as any).defaultOnboardingPlugin,
       org: (orgModule as any).defaultOrgPlugin,
       resources: (serverModule as any).defaultResourcesPlugin,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -149,6 +149,10 @@ export {
   defaultContextXrayPlugin,
 } from "../agent/context-xray/plugin.js";
 export {
+  createObservationalMemoryPlugin,
+  defaultObservationalMemoryPlugin,
+} from "../agent/observational-memory/plugin.js";
+export {
   createGoogleAuthPlugin,
   type GoogleAuthPluginOptions,
 } from "./google-auth-plugin.js";

--- a/packages/core/src/templates/workspace-core/.agents/skills/external-agents/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/external-agents/SKILL.md
@@ -416,3 +416,13 @@ before telling the user they are unauthenticated.
 - **a2a-protocol** — the `ask-agent` meta-tool and JSON-RPC peer calls
 - **adding-a-feature** — the four-area checklist (add a `link` builder when a
   feature produces a navigable resource)
+
+## Blueprint installer
+
+To add a whole new integration the agent-native way, `agent-native add <kind>
+<name|url>` prints a curated Markdown blueprint to stdout — pipe it into the
+external coding agent you connected (`agent-native add provider stripe |
+claude`) and it applies the changes against the live repo. A URL emits a
+generic research-and-integrate blueprint instead. Seeded kinds:
+`provider` / `channel` / `sandbox` / `action`. Add your own by dropping a
+`.md` in `packages/core/blueprints/<kind>/`. See the Blueprint Installer doc.

--- a/packages/core/src/templates/workspace-core/.agents/skills/harness-agents/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/harness-agents/SKILL.md
@@ -80,6 +80,26 @@ existing run routes as `goalId=agent-harness`.
   Preserve `defineAction` auth, request context, timeouts, truncation, and
   read-only metadata.
 
+## Code Execution Sandbox
+
+- The `run-code` tool executes through a pluggable `SandboxAdapter`
+  (`packages/core/src/coding-tools/sandbox/`). The default
+  `LocalChildProcessAdapter` spawns a locked-down local Node child process;
+  swap it via `AGENT_NATIVE_SANDBOX` or `registerSandboxAdapter()` for a
+  Docker/remote/durable backend (the lever to exceed the hosted ~40s code-exec
+  ceiling). An adapter only runs the already-prepared, non-secret module source
+  — it never sees app secrets. See the Sandbox Adapters doc; `agent-native add
+  sandbox docker` emits a full Docker-adapter recipe.
+
+## Sub-Agent Delegation Depth
+
+- Sub-agent spawning is capped server-side (default depth `2`) so delegation
+  chains can't fan out indefinitely. Override at deploy time with
+  `AGENT_NATIVE_MAX_SUBAGENT_DEPTH` (`0` disables sub-agents; clamped to `16`).
+  Enforcement is ambient via `evaluateSubagentDepth` in
+  `packages/core/src/server/agent-teams.ts` — independent of any tool-level
+  guard. See the Agent Teams doc for the depth model.
+
 ## Don't
 
 - Don't add Claude Code, Codex, Cursor, Mastra, or Pi as an `AgentEngine`.

--- a/packages/core/src/templates/workspace-core/.agents/skills/observability/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/observability/SKILL.md
@@ -75,6 +75,26 @@ const criteria: EvalCriteria = {
 };
 ```
 
+#### Evals (CI gate)
+
+The three layers above score *real production runs* after the fact. For an active, deterministic gate, use the first-class `*.eval.ts` primitive from `@agent-native/core/eval` (source: `packages/core/src/eval/*`). It runs the actual agent loop against fixed inputs and exits non-zero below threshold, so it gates CI/deploys.
+
+```ts
+// evals/faq.eval.ts
+import { defineEval, contains, llmJudge } from "@agent-native/core/eval";
+
+export default defineEval({
+  name: "answers the FAQ",
+  input: { prompt: "What is your return policy?" },
+  threshold: 0.7,
+  scorers: [contains("30 days"), llmJudge({ criteria: "accuracy" })],
+});
+```
+
+- Built-in scorers: `exactMatch` / `contains` / `usesTool` (pure JS) and `llmJudge` (provider-agnostic judge).
+- Custom scorers: `createScorer` with the 4-step `preprocess → analyze → generateScore → generateReason` pipeline (only `generateScore` is required).
+- Run as a gate: `agent-native eval [pattern] [--json] [--threshold N]` — discovers `**/*.eval.ts` and `evals/*.ts`, runs the agent, and exits non-zero if any eval is below its threshold. An app with no eval files exits `0`. Complements (does not replace) the post-hoc scoring in `evals.ts`. See the Evals doc.
+
 ### 4. Experiments
 
 A/B testing with sticky user-level assignment:

--- a/packages/docs/app/components/AgentNativeDemoVideo.tsx
+++ b/packages/docs/app/components/AgentNativeDemoVideo.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+
+const DEMO_VIDEO_URL =
+  "https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2F99ec814b12784b1885742a1c82d9dcf5?alt=media&token=e164a53f-ae25-41f9-b8fb-a58937a4d370&apiKey=YJIGb4i01jvw0SRdL5Bt";
+
+export function AgentNativeDemoVideo({
+  className = "",
+}: {
+  className?: string;
+}) {
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  return (
+    <div
+      className={`relative overflow-hidden rounded-xl border border-[var(--docs-border)] bg-black ${className}`}
+    >
+      <video
+        src={DEMO_VIDEO_URL}
+        aria-label="Agent-Native visual planning demo"
+        autoPlay
+        muted
+        loop
+        playsInline
+        controls
+        preload="auto"
+        onPlaying={() => setIsPlaying(true)}
+        onWaiting={() => setIsPlaying(false)}
+        className="block h-full w-full object-cover"
+      />
+      <div
+        aria-hidden
+        className={`pointer-events-none absolute inset-0 bg-[var(--bg-secondary)] transition-opacity duration-300 ${
+          isPlaying ? "opacity-0" : "opacity-100"
+        }`}
+      >
+        <div className="flex h-full w-full animate-pulse flex-col justify-between p-5">
+          <div className="space-y-3">
+            <div className="h-4 w-2/5 rounded-full bg-[var(--docs-border)]" />
+            <div className="h-3 w-3/4 rounded-full bg-[var(--docs-border)]" />
+            <div className="h-3 w-1/2 rounded-full bg-[var(--docs-border)]" />
+          </div>
+          <div className="grid gap-3">
+            <div className="h-28 rounded-lg bg-[var(--docs-border)]/70" />
+            <div className="h-16 rounded-lg bg-[var(--docs-border)]/50" />
+          </div>
+          <div className="h-8 w-1/3 rounded-full bg-[var(--docs-border)]" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/docs/app/components/docsNavItems.ts
+++ b/packages/docs/app/components/docsNavItems.ts
@@ -39,6 +39,7 @@ export const NAV_SECTIONS: NavSection[] = [
       { label: "Sharing & Privacy", to: "/docs/sharing" as const },
       { label: "Tracking & Analytics", to: "/docs/tracking" as const },
       { label: "Observability", to: "/docs/observability" as const },
+      { label: "Evals (CI Gate)", to: "/docs/evals" as const },
     ],
   },
   {
@@ -116,6 +117,11 @@ export const NAV_SECTIONS: NavSection[] = [
       },
       { label: "Agent-Native Code UI", to: "/docs/code-agents-ui" as const },
       { label: "CLI Adapters", to: "/docs/cli-adapters" as const },
+      { label: "Sandbox Adapters", to: "/docs/sandbox-adapters" as const },
+      {
+        label: "Blueprint Installer",
+        to: "/docs/blueprint-installer" as const,
+      },
     ],
   },
   {

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -485,7 +485,7 @@ export default function Home() {
               </div>
             </div>
 
-            <div className="mt-10 grid gap-3 border-t border-[var(--docs-border)] pt-8 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="mt-10 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
               {frameworkPrimitives.map((primitive) => (
                 <div
                   key={primitive.title}

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -136,6 +136,19 @@ const frameworkPrimitives = [
   },
 ];
 
+const homepageTemplateSlugs = [
+  "calendar",
+  "content",
+  "plan",
+  "slides",
+  "analytics",
+  "clips",
+];
+
+const homepageTemplates = homepageTemplateSlugs.flatMap((slug) =>
+  featuredTemplates.filter((template) => template.slug === slug),
+);
+
 function BidirectionalTabs() {
   const [activeTab, setActiveTab] = useState(0);
   const videoRefs = useRef<(HTMLVideoElement | null)[]>([]);
@@ -363,7 +376,83 @@ export default function Home() {
           </div>
         </section>
 
-        {/* Try it with a skill - above templates */}
+        {/* Framework */}
+        <section className="border-t border-[var(--docs-border)] px-6 py-20">
+          <div className="mx-auto max-w-[1200px]">
+            <div className="grid gap-10 lg:grid-cols-[0.92fr_1.08fr] lg:items-center">
+              <div>
+                <p className="mb-3 text-sm font-semibold text-[var(--docs-accent)]">
+                  Open source framework
+                </p>
+                <h2 className="mb-4 text-3xl font-bold tracking-tight md:text-4xl">
+                  The framework for agent-native apps
+                </h2>
+                <p className="mb-5 max-w-xl text-base leading-relaxed text-[var(--fg-secondary)]">
+                  Agent-Native is an open-source framework for building robust
+                  agents that can act inside real apps, not just chat next to
+                  them.
+                </p>
+                <p className="mb-5 max-w-xl text-base leading-relaxed text-[var(--fg-secondary)]">
+                  It gives you primitives for product-grade agentic software:
+                  shared actions, SQL-backed state, identity, tools, skills,
+                  jobs, observability, and UI surfaces that all work together.
+                </p>
+                <p className="mb-6 max-w-xl text-base leading-relaxed text-[var(--fg-secondary)]">
+                  Backend agnostic: bring your own database, hosting provider,
+                  model stack, and app code.
+                </p>
+                <Link
+                  data-an-prefetch="render"
+                  to="/docs/what-is-agent-native"
+                  className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-5 py-2.5 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
+                  onClick={() =>
+                    trackEvent("click cta", {
+                      label: "framework_guide",
+                      location: "framework_section",
+                    })
+                  }
+                >
+                  Read the framework guide
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <line x1="5" y1="12" x2="19" y2="12" />
+                    <polyline points="12 5 19 12 12 19" />
+                  </svg>
+                </Link>
+              </div>
+
+              <div className="min-w-0">
+                <CodeBlock code={frameworkCode} lang="typescript" />
+              </div>
+            </div>
+
+            <div className="mt-10 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              {frameworkPrimitives.map((primitive) => (
+                <div
+                  key={primitive.title}
+                  className="rounded-xl border border-[var(--docs-border)] bg-[var(--bg-secondary)] p-5"
+                >
+                  <h3 className="mb-2 text-base font-semibold">
+                    {primitive.title}
+                  </h3>
+                  <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
+                    {primitive.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Try it with a skill */}
         <section className="border-t border-[var(--docs-border)] px-6 py-16">
           <div className="mx-auto grid max-w-[1100px] gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.82fr)] lg:items-center">
             <div>
@@ -432,77 +521,6 @@ export default function Home() {
           </div>
         </section>
 
-        {/* Framework */}
-        <section className="border-t border-[var(--docs-border)] px-6 py-20">
-          <div className="mx-auto max-w-[1200px]">
-            <div className="grid gap-10 lg:grid-cols-[0.92fr_1.08fr] lg:items-center">
-              <div>
-                <p className="mb-3 text-sm font-semibold text-[var(--docs-accent)]">
-                  Open source framework
-                </p>
-                <h2 className="mb-4 text-3xl font-bold tracking-tight md:text-4xl">
-                  The framework for agent-native apps
-                </h2>
-                <p className="mb-5 max-w-xl text-base leading-relaxed text-[var(--fg-secondary)]">
-                  Templates and skills are the first products built on it.
-                  Agent-Native gives you the primitives for apps where the UI
-                  and agent share actions, state, identity, and context.
-                </p>
-                <p className="mb-6 max-w-xl text-base leading-relaxed text-[var(--fg-secondary)]">
-                  It is backend agnostic: bring your own database, your own
-                  hosting provider, and your own agent stack.
-                </p>
-                <Link
-                  data-an-prefetch="render"
-                  to="/docs/what-is-agent-native"
-                  className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-5 py-2.5 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
-                  onClick={() =>
-                    trackEvent("click cta", {
-                      label: "framework_guide",
-                      location: "framework_section",
-                    })
-                  }
-                >
-                  Read the framework guide
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <line x1="5" y1="12" x2="19" y2="12" />
-                    <polyline points="12 5 19 12 12 19" />
-                  </svg>
-                </Link>
-              </div>
-
-              <div className="min-w-0">
-                <CodeBlock code={frameworkCode} lang="typescript" />
-              </div>
-            </div>
-
-            <div className="mt-10 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-              {frameworkPrimitives.map((primitive) => (
-                <div
-                  key={primitive.title}
-                  className="rounded-xl border border-[var(--docs-border)] bg-[var(--bg-secondary)] p-5"
-                >
-                  <h3 className="mb-2 text-base font-semibold">
-                    {primitive.title}
-                  </h3>
-                  <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
-                    {primitive.description}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
         {/* Templates - breaks out of max-width on ultra-wide screens */}
         <section
           id="templates"
@@ -523,7 +541,7 @@ export default function Home() {
           </div>
 
           <div className="mx-auto grid max-w-[1200px] grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
-            {featuredTemplates.map((t) => (
+            {homepageTemplates.map((t) => (
               <TemplateCard key={t.name} template={t} />
             ))}
           </div>

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router";
 import { useEffect, useRef, useState } from "react";
+import { AgentNativeDemoVideo } from "../components/AgentNativeDemoVideo";
 import CodeBlock from "../components/CodeBlock";
 import Seascape from "../components/Seascape";
 import {
@@ -16,6 +17,17 @@ pnpm dev`;
 
 const skillInstallCode = `# Add agent-native planning to a coding agent you already use
 npx @agent-native/core@latest skills add visual-plan`;
+
+const frameworkCode = `// One action powers UI, agent, HTTP, MCP, A2A, and CLI.
+export default defineAction({
+  schema: z.object({
+    emailId: z.string(),
+    body: z.string(),
+  }),
+  run: async ({ emailId, body }) => {
+    await db.insert(replies).values({ emailId, body });
+  },
+});`;
 
 function TerminalCommand() {
   const [copied, setCopied] = useState(false);
@@ -99,6 +111,28 @@ const bidirectionalTabs = [
       "Every action available in the UI is also available to the agent. You can click to do something, or ask the agent to do it.",
     video:
       "https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2F39c6b297895843708938b097d8e3eb2c?alt=media&token=c5fdf84c-d4fb-45b0-b220-ef7aab01e99f&apiKey=YJIGb4i01jvw0SRdL5Bt",
+  },
+];
+
+const frameworkPrimitives = [
+  {
+    title: "Actions",
+    description: "Define work once. Use it from UI, agent, API, MCP, and A2A.",
+  },
+  {
+    title: "Shared state",
+    description:
+      "SQL-backed app state keeps humans, agents, and sessions in sync.",
+  },
+  {
+    title: "Agent runtime",
+    description:
+      "Chat, tools, skills, memory, jobs, observability, and handoffs ship together.",
+  },
+  {
+    title: "Backend agnostic",
+    description:
+      "Plug in any Drizzle-supported SQL database and Nitro-compatible host.",
   },
 ];
 
@@ -330,83 +364,150 @@ export default function Home() {
         </section>
 
         {/* Try it with a skill - above templates */}
+        <section className="border-t border-[var(--docs-border)] px-6 py-16">
+          <div className="mx-auto grid max-w-[1100px] gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.82fr)] lg:items-center">
+            <div>
+              <h2 className="mb-3 text-3xl font-bold tracking-tight md:text-4xl">
+                Try it with a skill
+              </h2>
+              <p className="mb-5 max-w-xl text-base leading-relaxed text-[var(--fg-secondary)]">
+                Add visual planning and PR recaps to Claude Code, Codex, Cursor,
+                Pi, OpenCode, or VS Code with one command.
+              </p>
+
+              <CodeBlock code={skillInstallCode} lang="bash" />
+
+              <div className="mt-6 grid gap-3 sm:grid-cols-2">
+                <div className="rounded-xl border border-[var(--docs-border)] p-5">
+                  <h3 className="mb-2 font-mono text-sm font-semibold text-[var(--docs-accent)]">
+                    /visual-plan
+                  </h3>
+                  <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
+                    Reviewable plans with diagrams, wireframes, file maps, and
+                    comments before code changes.
+                  </p>
+                </div>
+                <div className="rounded-xl border border-[var(--docs-border)] p-5">
+                  <h3 className="mb-2 font-mono text-sm font-semibold text-[var(--docs-accent)]">
+                    /visual-recap
+                  </h3>
+                  <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
+                    A visual summary of a PR or diff so reviewers see the shape
+                    before the raw lines.
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-6">
+                <Link
+                  data-an-prefetch="render"
+                  to="/docs/skills-guide"
+                  className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-5 py-2.5 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
+                  onClick={() =>
+                    trackEvent("click cta", {
+                      label: "skills_guide",
+                      location: "skills_section",
+                    })
+                  }
+                >
+                  Browse the Skills Guide
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <line x1="5" y1="12" x2="19" y2="12" />
+                    <polyline points="12 5 19 12 12 19" />
+                  </svg>
+                </Link>
+              </div>
+            </div>
+
+            <AgentNativeDemoVideo className="aspect-square w-full" />
+          </div>
+        </section>
+
+        {/* Framework */}
         <section className="border-t border-[var(--docs-border)] px-6 py-20">
-          <div className="mb-12 text-center">
-            <h2 className="mb-3 text-3xl font-bold tracking-tight md:text-4xl">
-              Try it with a skill
-            </h2>
-            <p className="mx-auto max-w-2xl text-base leading-relaxed text-[var(--fg-secondary)]">
-              Not ready to scaffold a whole app? Add agent-native superpowers to
-              a coding agent you already use — Claude Code, Codex, Cursor, Pi,
-              OpenCode, GitHub Copilot / VS Code, and similar agents — with one
-              command. It installs the skills, writes shared .agents skill
-              folders for agents that support them, registers the hosted MCP
-              connector for supported local clients, and signs you in in one
-              step.
-            </p>
-          </div>
+          <div className="mx-auto max-w-[1200px]">
+            <div className="grid gap-10 lg:grid-cols-[0.92fr_1.08fr] lg:items-center">
+              <div>
+                <p className="mb-3 text-sm font-semibold text-[var(--docs-accent)]">
+                  Open source framework
+                </p>
+                <h2 className="mb-4 text-3xl font-bold tracking-tight md:text-4xl">
+                  The framework for agent-native apps
+                </h2>
+                <p className="mb-5 max-w-xl text-base leading-relaxed text-[var(--fg-secondary)]">
+                  Templates and skills are the first products built on it.
+                  Agent-Native gives you the primitives for apps where the UI
+                  and agent share actions, state, identity, and context.
+                </p>
+                <p className="mb-6 max-w-xl text-base leading-relaxed text-[var(--fg-secondary)]">
+                  It is backend agnostic: bring your own database, your own
+                  hosting provider, and your own agent stack.
+                </p>
+                <Link
+                  data-an-prefetch="render"
+                  to="/docs/what-is-agent-native"
+                  className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-5 py-2.5 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
+                  onClick={() =>
+                    trackEvent("click cta", {
+                      label: "framework_guide",
+                      location: "framework_section",
+                    })
+                  }
+                >
+                  Read the framework guide
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <line x1="5" y1="12" x2="19" y2="12" />
+                    <polyline points="12 5 19 12 12 19" />
+                  </svg>
+                </Link>
+              </div>
 
-          <div className="mx-auto max-w-2xl">
-            <CodeBlock code={skillInstallCode} lang="bash" />
-          </div>
-
-          <div className="mx-auto mt-8 grid max-w-3xl gap-5 sm:grid-cols-2">
-            <div className="rounded-xl border border-[var(--docs-border)] p-6">
-              <h3 className="mb-2 font-mono text-base font-semibold text-[var(--docs-accent)]">
-                /visual-plan
-              </h3>
-              <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
-                Before the agent writes code, it opens a structured, reviewable
-                plan instead of a wall of text — inline diagrams, UI wireframes
-                and prototypes, file-by-file implementation maps, and
-                annotations you can comment on and approve.
-              </p>
+              <div className="min-w-0">
+                <CodeBlock code={frameworkCode} lang="typescript" />
+              </div>
             </div>
-            <div className="rounded-xl border border-[var(--docs-border)] p-6">
-              <h3 className="mb-2 font-mono text-base font-semibold text-[var(--docs-accent)]">
-                /visual-recap
-              </h3>
-              <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
-                After changes land, it turns a PR or git diff into a
-                high-altitude visual recap — schema, API, and file changes as
-                grounded before/after blocks with a shareable review link,
-                instead of scrolling a raw diff.
-              </p>
-            </div>
-          </div>
 
-          <div className="mt-8 text-center">
-            <Link
-              data-an-prefetch="render"
-              to="/docs/skills-guide"
-              className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
-              onClick={() =>
-                trackEvent("click cta", {
-                  label: "skills_guide",
-                  location: "skills_section",
-                })
-              }
-            >
-              Browse the Skills Guide
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <line x1="5" y1="12" x2="19" y2="12" />
-                <polyline points="12 5 19 12 12 19" />
-              </svg>
-            </Link>
+            <div className="mt-10 grid gap-3 border-t border-[var(--docs-border)] pt-8 sm:grid-cols-2 lg:grid-cols-4">
+              {frameworkPrimitives.map((primitive) => (
+                <div
+                  key={primitive.title}
+                  className="rounded-xl border border-[var(--docs-border)] bg-[var(--bg-secondary)] p-5"
+                >
+                  <h3 className="mb-2 text-base font-semibold">
+                    {primitive.title}
+                  </h3>
+                  <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
+                    {primitive.description}
+                  </p>
+                </div>
+              ))}
+            </div>
           </div>
         </section>
 
         {/* Templates - breaks out of max-width on ultra-wide screens */}
-        <section id="templates" className="py-20 px-6">
+        <section
+          id="templates"
+          className="border-t border-[var(--docs-border)] py-20 px-6"
+        >
           <div className="mb-12 text-center">
             <h2 className="mb-3 text-3xl font-bold tracking-tight md:text-4xl">
               Start with a full featured template
@@ -558,72 +659,6 @@ export default function Home() {
                     </tbody>
                   </table>
                 </div>
-              </div>
-            </div>
-          </section>
-
-          {/* Value props */}
-          <section className="border-t border-[var(--docs-border)] py-20">
-            <div className="mb-12 text-center">
-              <h2 className="mb-3 text-3xl font-bold tracking-tight md:text-4xl">
-                How it works
-              </h2>
-              <p className="mx-auto max-w-2xl text-base leading-relaxed text-[var(--fg-secondary)]">
-                The agent and the UI are equal partners out of the box.
-                Everything the UI can do, the agent can do — and vice versa.
-              </p>
-            </div>
-
-            <div className="mx-auto grid max-w-4xl gap-6 sm:grid-cols-2 lg:grid-cols-3">
-              <div className="rounded-xl border border-[var(--docs-border)] p-6">
-                <h3 className="mb-2 text-base font-semibold">
-                  Everything syncs
-                </h3>
-                <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
-                  Agent and UI share one database and one state. Changes from
-                  either side show up instantly on the other.
-                </p>
-              </div>
-              <div className="rounded-xl border border-[var(--docs-border)] p-6">
-                <h3 className="mb-2 text-base font-semibold">Context-aware</h3>
-                <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
-                  The agent knows what you're looking at. Select text, hit
-                  Cmd+I, and tell it what to do.
-                </p>
-              </div>
-              <div className="rounded-xl border border-[var(--docs-border)] p-6">
-                <h3 className="mb-2 text-base font-semibold">
-                  Agents call agents
-                </h3>
-                <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
-                  Tag another agent from any app. They discover each other over
-                  A2A and take action across your stack.
-                </p>
-              </div>
-              <div className="rounded-xl border border-[var(--docs-border)] p-6">
-                <h3 className="mb-2 text-base font-semibold">
-                  Any database, any host
-                </h3>
-                <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
-                  Any SQL database Drizzle supports. Any hosting target Nitro
-                  supports. No lock-in.
-                </p>
-              </div>
-              <div className="rounded-xl border border-[var(--docs-border)] p-6">
-                <h3 className="mb-2 text-base font-semibold">Any AI agent</h3>
-                <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
-                  Claude Code, Codex, Cursor, Pi, OpenCode, GitHub Copilot / VS
-                  Code, or Builder.io. Use whichever agent you prefer.
-                </p>
-              </div>
-              <div className="rounded-xl border border-[var(--docs-border)] p-6">
-                <h3 className="mb-2 text-base font-semibold">
-                  Apps that improve themselves
-                </h3>
-                <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
-                  Your apps get better on their own. The agent can add features,
-                  fix bugs, and refine the UI over time.
-                </p>
               </div>
             </div>
           </section>

--- a/packages/docs/app/routes/skills.tsx
+++ b/packages/docs/app/routes/skills.tsx
@@ -12,7 +12,7 @@ export const meta = () =>
     {
       name: "description",
       content:
-        "Install app-backed skills your coding agent runs as slash commands. /visual-plan opens structured visual plans before you build; /visual-recap turns a PR diff into a high-altitude review. One install, free and open source.",
+        "Install Agent-Native app-backed skills your coding agent runs as slash commands. /visual-plan opens structured plans; /visual-recap turns a PR diff into a high-altitude review.",
     },
     {
       property: "og:title",
@@ -21,7 +21,7 @@ export const meta = () =>
     {
       property: "og:description",
       content:
-        "Give your coding agent new superpowers: structured visual plans and high-altitude PR recaps, hosted and shareable. One install, free and open source.",
+        "Give your coding agent slash commands powered by Agent-Native apps you can host, inspect, and customize.",
     },
     {
       name: "keywords",
@@ -31,7 +31,6 @@ export const meta = () =>
   ]);
 
 const INSTALL_COMMAND = "npx @agent-native/core@latest skills add";
-const DEMO_URL = "https://plan.agent-native.com";
 
 type Skill = {
   command: string;
@@ -72,43 +71,6 @@ const SKILLS: Skill[] = [
     docsTo: "/docs/pr-visual-recap",
   },
 ];
-
-function CheckIcon() {
-  return (
-    <svg
-      className="mt-0.5 shrink-0 text-[var(--docs-accent)]"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <polyline points="20 6 9 17 4 12" />
-    </svg>
-  );
-}
-
-function ExternalIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-      <polyline points="15 3 21 3 21 9" />
-      <line x1="10" y1="14" x2="21" y2="3" />
-    </svg>
-  );
-}
 
 function CliCopy({
   command,
@@ -188,12 +150,9 @@ function SkillCard({ skill }: { skill: Skill }) {
         {skill.description}
       </p>
 
-      <ul className="m-0 mb-5 list-none space-y-2 p-0 text-sm text-[var(--fg-secondary)]">
+      <ul className="m-0 mb-5 list-disc space-y-2 pl-5 text-sm text-[var(--fg-secondary)]">
         {skill.features.map((f) => (
-          <li key={f} className="flex items-start gap-2">
-            <CheckIcon />
-            {f}
-          </li>
+          <li key={f}>{f}</li>
         ))}
       </ul>
 
@@ -212,21 +171,6 @@ function SkillCard({ skill }: { skill: Skill }) {
           Read the docs
           <span aria-hidden>→</span>
         </Link>
-        <a
-          href={DEMO_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={() =>
-            trackEvent("skill try demo", {
-              skill: skill.command,
-              location: "skills_card",
-            })
-          }
-          className="inline-flex items-center gap-1 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
-        >
-          Live demo
-          <ExternalIcon />
-        </a>
       </div>
     </article>
   );
@@ -244,9 +188,9 @@ export default function SkillsPage() {
             </h1>
 
             <p className="mb-6 text-base leading-7 text-[var(--fg-secondary)] sm:text-lg sm:leading-relaxed">
-              Install app-backed skills your coding agent runs as slash commands
-              — structured visual plans before you build, and high-altitude
-              recaps of any diff. Hosted, shareable, and 100% open source.
+              Install slash commands powered by Agent-Native apps you can fully
+              customize. Start with visual plans before you build and
+              high-altitude recaps after each diff.
             </p>
 
             <CliCopy command={INSTALL_COMMAND} location="skills_hero" />

--- a/packages/docs/app/routes/skills.tsx
+++ b/packages/docs/app/routes/skills.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router";
 import { useState } from "react";
 import { trackEvent } from "@agent-native/core/client";
+import { AgentNativeDemoVideo } from "../components/AgentNativeDemoVideo";
 import { withDefaultSocialImage } from "../seo";
 
 export const meta = () =>
@@ -251,13 +252,7 @@ export default function SkillsPage() {
             <CliCopy command={INSTALL_COMMAND} location="skills_hero" />
           </div>
 
-          <div className="overflow-hidden rounded-xl border border-[var(--docs-border)] bg-[var(--bg-secondary)]">
-            <img
-              src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fb6f4213ac7cc42eeb10c12e8ccda8936?format=webp&width=1000"
-              alt="An Agent-Native visual plan with inline diagrams and structured blocks"
-              className="w-full object-cover object-top"
-            />
-          </div>
+          <AgentNativeDemoVideo className="aspect-square w-full" />
         </div>
       </section>
 

--- a/packages/docs/app/routes/skills.tsx
+++ b/packages/docs/app/routes/skills.tsx
@@ -45,28 +45,24 @@ const SKILLS: Skill[] = [
   {
     command: "/visual-plan",
     name: "Visual Plan",
-    tagline: "Plan before you implement",
+    tagline: "Review before code",
     description:
-      "Structured visual planning mode for coding agents. The plan you'd normally write in Markdown, but as a scannable document with editable blocks — and an optional visual review surface for anything UI.",
+      "Turns a coding task into a shareable plan with diagrams, file notes, and optional UI sketches.",
     features: [
-      "Inline diagrams and data-model maps near each claim",
-      "Annotated code for the key files you'll touch",
-      "Optional wireframe canvas plus a clickable prototype",
-      "Comments, annotations, and a shareable review link",
+      "See the implementation shape before changes land",
+      "Comment, revise, approve, or hand off",
     ],
     docsTo: "/docs/template-plan",
   },
   {
     command: "/visual-recap",
     name: "Visual Recap",
-    tagline: "Review a diff at a higher altitude",
+    tagline: "Review after changes",
     description:
-      "The reverse of forward planning: turn a PR or git diff into a structured recap — schema, API, file, and before/after changes as grounded blocks instead of a wall of diff a reviewer has to read line by line.",
+      "Turns a PR or git diff into a shareable recap of what changed and why.",
     features: [
-      "Schema, API, file-tree, and diagram blocks built from the diff",
-      "High-altitude shape of the change before the literal lines",
-      "Optional GitHub Action recaps every pull request",
-      "Posts one sticky PR comment with an inline screenshot",
+      "Summarizes schema, API, and file changes",
+      "Optionally posts one sticky PR comment",
     ],
     docsTo: "/docs/pr-visual-recap",
   },
@@ -133,7 +129,7 @@ function CliCopy({
 
 function SkillCard({ skill }: { skill: Skill }) {
   return (
-    <article className="flex flex-col rounded-xl border border-[var(--docs-border)] bg-[var(--bg-secondary)] p-6">
+    <article className="flex flex-col rounded-xl border border-[var(--docs-border)] bg-[var(--bg-secondary)] p-5 sm:p-6">
       <div className="mb-3 flex items-center gap-3">
         <span className="rounded-md border border-[var(--code-border)] bg-[var(--code-bg)] px-2 py-1 font-mono text-sm text-[var(--fg)]">
           {skill.command}
@@ -146,11 +142,11 @@ function SkillCard({ skill }: { skill: Skill }) {
       <h3 className="mb-2 text-lg font-semibold tracking-tight">
         {skill.name}
       </h3>
-      <p className="mb-5 text-sm leading-relaxed text-[var(--fg-secondary)]">
+      <p className="mb-4 text-sm leading-relaxed text-[var(--fg-secondary)]">
         {skill.description}
       </p>
 
-      <ul className="m-0 mb-5 list-disc space-y-2 pl-5 text-sm text-[var(--fg-secondary)]">
+      <ul className="m-0 mb-4 list-disc space-y-1.5 pl-5 text-sm text-[var(--fg-secondary)]">
         {skill.features.map((f) => (
           <li key={f}>{f}</li>
         ))}

--- a/packages/docs/app/vite-sitemap-plugin.spec.ts
+++ b/packages/docs/app/vite-sitemap-plugin.spec.ts
@@ -28,14 +28,18 @@ describe("docs agent web generation", () => {
     AGENT_WEB_GENERATION_TIMEOUT_MS,
   );
 
-  it("generates public paths for docs and templates", () => {
-    const paths = buildSitemapPaths(rootDir);
+  it(
+    "generates public paths for docs and templates",
+    () => {
+      const paths = buildSitemapPaths(rootDir);
 
-    expect(paths).toContain("/");
-    expect(paths).toContain("/docs");
-    expect(paths).toContain("/docs/agent-web-surfaces");
-    expect(paths).toContain("/templates/calendar");
-  });
+      expect(paths).toContain("/");
+      expect(paths).toContain("/docs");
+      expect(paths).toContain("/docs/agent-web-surfaces");
+      expect(paths).toContain("/templates/calendar");
+    },
+    AGENT_WEB_GENERATION_TIMEOUT_MS,
+  );
 
   it("uses the production www canonical origin in sitemap entries", () => {
     const sitemap = buildSitemapXml(["/", "/docs"]);

--- a/packages/docs/react-router.config.ts
+++ b/packages/docs/react-router.config.ts
@@ -4,4 +4,7 @@ export default {
   appDirectory: "app",
   ssr: true,
   routeDiscovery: { mode: "initial" },
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -10,10 +10,11 @@ npx @agent-native/skills@latest add --skill visual-plan --mode local-files
 ```
 
 Use `--skill <name>` one or more times to select specific skills, or omit it in
-an interactive terminal to choose from a prompt. Use `--client codex`,
-`--client claude-code`, or `--client all` to choose install targets; omitted
-`--client` defaults to all supported clients. For `visual-plan` and
-`visual-recap`, use `--mode hosted`, `--mode local-files`, or
+an interactive terminal to choose from a prompt. The prompt puts `visual-plan`
+and `visual-recap` first and preselects only those by default. Use
+`--client codex`, `--client claude-code`, or `--client all` to choose install
+targets; omitted `--client` defaults to all supported clients. For
+`visual-plan` and `visual-recap`, use `--mode hosted`, `--mode local-files`, or
 `--mode self-hosted --mcp-url <url>` to choose hosted sharing, all-local text
 files, or your own Plan app. Add `--update-instructions` to append an idempotent
 managed block to `AGENTS.md` and/or `CLAUDE.md` for instruction-style skills.

--- a/packages/skills/src/connect.spec.ts
+++ b/packages/skills/src/connect.spec.ts
@@ -204,6 +204,112 @@ describe("registerMcpServer", () => {
     expect(result.authenticated).toBe(true);
   });
 
+  it("writes Codex and Cowork bearer entries from one approved device flow", async () => {
+    const { codexHome, home } = isolateHome();
+    const baseDir = tmpDir();
+    const descriptor: McpDescriptor = {
+      serverName: "plan",
+      mcpUrl: "https://plan.agent-native.com/_agent-native/mcp",
+      authMode: "device",
+      hostedUrl: "https://plan.agent-native.com",
+    };
+
+    const fetchImpl = mockFetch([
+      {
+        match: "/device/start",
+        json: {
+          device_code: "dev-123",
+          user_code: "ABCD-EFGH",
+          verification_uri: "https://plan.agent-native.com/connect",
+          verification_uri_complete:
+            "https://plan.agent-native.com/connect?code=ABCD-EFGH",
+          interval: 1,
+          expires_in: 600,
+        },
+      },
+      {
+        match: "/device/poll",
+        json: {
+          status: "approved",
+          token: "minted-bearer-token",
+          mcpUrl: "https://plan.agent-native.com/_agent-native/mcp",
+          serverName: "plan",
+        },
+      },
+    ]);
+
+    const result = await registerMcpServer({
+      descriptor,
+      clients: ["codex", "cowork"],
+      scope: "user",
+      baseDir,
+      interactive: true,
+      deps: { fetchImpl, sleep: noSleep, now: () => 0 },
+    });
+
+    const toml = fs.readFileSync(path.join(codexHome, "config.toml"), "utf-8");
+    expect(toml).toContain('[mcp_servers."plan"]');
+    expect(toml).toContain("Bearer minted-bearer-token");
+
+    const coworkConfig = JSON.parse(
+      fs.readFileSync(path.join(home, ".cowork", "mcp.json"), "utf-8"),
+    );
+    expect(coworkConfig.mcpServers.plan.headers.Authorization).toBe(
+      "Bearer minted-bearer-token",
+    );
+    expect(result.written.map((entry) => entry.client).sort()).toEqual([
+      "codex",
+      "cowork",
+    ]);
+    expect(result.authenticated).toBe(true);
+  });
+
+  it("uses a structured not_found poll body even when the HTTP status is 404", async () => {
+    isolateHome();
+    const baseDir = tmpDir();
+    const logs: string[] = [];
+    const descriptor: McpDescriptor = {
+      serverName: "plan",
+      mcpUrl: "https://plan.agent-native.com/_agent-native/mcp",
+      authMode: "device",
+      hostedUrl: "https://plan.agent-native.com",
+    };
+
+    const fetchImpl = mockFetch([
+      {
+        match: "/device/start",
+        json: {
+          device_code: "dev-123",
+          user_code: "ABCD-EFGH",
+          verification_uri: "https://plan.agent-native.com/connect",
+          verification_uri_complete:
+            "https://plan.agent-native.com/connect?code=ABCD-EFGH",
+          interval: 1,
+          expires_in: 600,
+        },
+      },
+      {
+        match: "/device/poll",
+        status: 404,
+        json: { status: "not_found", message: "unknown code" },
+      },
+    ]);
+
+    const result = await registerMcpServer({
+      descriptor,
+      clients: ["codex"],
+      scope: "user",
+      baseDir,
+      interactive: true,
+      log: (message) => logs.push(message),
+      deps: { fetchImpl, sleep: noSleep, now: () => 0 },
+    });
+
+    expect(result.written).toHaveLength(0);
+    expect(logs.join("\n")).toContain("unknown code");
+    expect(logs.join("\n")).not.toContain("HTTP 404");
+  });
+
   it("stops device polling at the configured timeout without oversleeping", async () => {
     isolateHome();
     const baseDir = tmpDir();

--- a/packages/skills/src/connect.ts
+++ b/packages/skills/src/connect.ts
@@ -428,13 +428,18 @@ async function runDeviceFlow(
         { device_code: start.device_code },
       );
       if (status < 200 || status >= 300) {
-        log(
-          `  Connect polling failed (HTTP ${status}): ` +
-            responseMessage(json, "server returned an error."),
-        );
-        return null;
+        if (isTerminalPollBody(json)) {
+          poll = json as DevicePollResponse;
+        } else {
+          log(
+            `  Connect polling failed (HTTP ${status}): ` +
+              responseMessage(json, "server returned an error."),
+          );
+          return null;
+        }
+      } else {
+        poll = (json ?? { status: "pending" }) as DevicePollResponse;
       }
-      poll = (json ?? { status: "pending" }) as DevicePollResponse;
     } catch {
       // Transient network error — keep polling until the deadline.
       poll = { status: "pending" };
@@ -489,6 +494,15 @@ async function runDeviceFlow(
     log("  Timed out waiting for approval. Run the command again to retry.");
   }
   return null;
+}
+
+function isTerminalPollBody(json: any): boolean {
+  return (
+    json?.status === "not_found" ||
+    json?.status === "error" ||
+    json?.status === "expired" ||
+    json?.status === "consumed"
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/skills/src/index.spec.ts
+++ b/packages/skills/src/index.spec.ts
@@ -82,7 +82,7 @@ describe("@agent-native/skills", () => {
       "--skill",
       "quick-recap",
       "--client",
-      "codex",
+      "codex,cowork",
       "--scope",
       "project",
       "--update-instructions",
@@ -92,7 +92,7 @@ describe("@agent-native/skills", () => {
     expect(parsed).toMatchObject({
       command: "add",
       skillNames: ["quick-recap"],
-      clients: ["codex"],
+      clients: ["codex", "cowork"],
       scope: "project",
       updateInstructions: true,
     });
@@ -370,6 +370,56 @@ describe("@agent-native/skills", () => {
     ).toBe(true);
     expect(
       fs.existsSync(path.join(project, ".agents", "skills", "efficient-fable")),
+    ).toBe(false);
+  });
+
+  it("accepts Cowork in direct mode without writing Claude skill files for it", async () => {
+    const repo = tmpDir();
+    const project = tmpDir();
+    const home = tmpDir();
+    const codexHome = path.join(home, ".codex");
+    const previousHome = process.env.HOME;
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.HOME = home;
+    process.env.CODEX_HOME = codexHome;
+    writeSkill(repo, "quick-recap");
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const restoreDirect = enableDirectSkillsMode();
+
+    try {
+      await runSkillsCli(
+        [
+          "add",
+          "--copy",
+          repo,
+          "--skill",
+          "quick-recap",
+          "--client",
+          "codex,cowork",
+          "--scope",
+          "user",
+          "--no-update-instructions",
+        ],
+        {
+          baseDir: project,
+          isInteractive: () => false,
+        },
+      );
+    } finally {
+      restoreDirect();
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = previousCodexHome;
+    }
+
+    expect(
+      fs.existsSync(path.join(codexHome, "skills", "quick-recap", "SKILL.md")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(home, ".claude", "skills", "quick-recap", "SKILL.md"),
+      ),
     ).toBe(false);
   });
 
@@ -766,6 +816,7 @@ describe("@agent-native/skills", () => {
     expect(result.clients).toEqual([
       "codex",
       "claude-code",
+      "cowork",
       "pi",
       "cursor",
       "opencode",

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -13,6 +13,7 @@ import { createCliTelemetry, type CliTelemetry } from "./telemetry.js";
 export type SkillClient =
   | "codex"
   | "claude-code"
+  | "cowork"
   | "pi"
   | "cursor"
   | "opencode"
@@ -149,7 +150,7 @@ Usage:
 
 Options:
   --skill <name>              Install only this skill (repeatable)
-  --client, -a <client>       codex, claude-code, pi, cursor, opencode, github-copilot, or all
+  --client, -a <client>       codex, claude-code, cowork, pi, cursor, opencode, github-copilot, or all
                               (default: all; repeatable or comma-separated)
   --scope <user|project>      Install globally or into the current project (default: user)
   -g, --global                Alias for --scope user
@@ -182,6 +183,7 @@ Examples:
 const CLIENTS: SkillClient[] = [
   "codex",
   "claude-code",
+  "cowork",
   "pi",
   "cursor",
   "opencode",
@@ -618,6 +620,13 @@ export async function installSkills(
       options.mcp === false || planMode === "local-files"
         ? []
         : mcpAppsForSkills(skillNames, planMcpOverride);
+    const skillFileClients = clients.filter(supportsSkillFiles);
+    if (skillFileClients.length === 0 && mcpApps.length === 0) {
+      throw new Error(
+        "Claude Cowork is MCP-only for Agent Native skills. Choose Codex, Claude Code, Pi, Cursor, OpenCode, or GitHub Copilot for local skill files, or install an app-backed skill with MCP enabled.",
+      );
+    }
+
     const progress = await createInstallProgress(
       options,
       1 +
@@ -634,7 +643,9 @@ export async function installSkills(
     try {
       progress?.start("Installing skill files...");
       for (const root of unique(
-        clients.map((client) => installRootForClient(client, scope, baseDir)),
+        skillFileClients.map((client) =>
+          installRootForClient(client, scope, baseDir),
+        ),
       )) {
         for (const skill of selected) {
           const destination = path.join(root, skill.name);
@@ -661,7 +672,7 @@ export async function installSkills(
         instructionFiles = writeManagedInstructions(
           instructionBlocks,
           baseDir,
-          clients,
+          skillFileClients,
           scope,
           options,
         );
@@ -875,6 +886,9 @@ function normalizeClients(value: string): SkillClient[] {
     if (!client) return [];
     if (client === "all") return CLIENTS;
     if (client === "codex") return ["codex" as const];
+    if (client === "cowork" || client === "claude-cowork") {
+      return ["cowork" as const];
+    }
     if (client === "pi") return ["pi" as const];
     if (client === "cursor") return ["cursor" as const];
     if (client === "opencode" || client === "open-code") {
@@ -896,7 +910,7 @@ function normalizeClients(value: string): SkillClient[] {
       return ["claude-code" as const];
     }
     throw new Error(
-      `Unsupported client "${raw}". Use codex, claude-code, pi, cursor, opencode, github-copilot, or all.`,
+      `Unsupported client "${raw}". Use codex, claude-code, cowork, pi, cursor, opencode, github-copilot, or all.`,
     );
   });
 }
@@ -905,6 +919,10 @@ function skillClientToMcpClient(client: SkillClient): ClientId | null {
   if (client === "pi") return null;
   if (client === "claude-code") return "claude-code";
   return client;
+}
+
+function supportsSkillFiles(client: SkillClient): boolean {
+  return client !== "cowork";
 }
 
 function normalizeSkillName(value: string): string {
@@ -1412,14 +1430,16 @@ function resolveInstructionFiles(
   if (explicit && explicit.length > 0) {
     return explicit.map((file) => path.resolve(baseDir, file));
   }
+  const instructionClients = clients.filter(supportsSkillFiles);
+  if (instructionClients.length === 0) return [];
   if (scope === "user") {
     const home = process.env.HOME || os.homedir();
     const files: string[] = [];
-    if (clients.includes("codex")) {
+    if (instructionClients.includes("codex")) {
       const codexHome = process.env.CODEX_HOME || path.join(home, ".codex");
       files.push(path.join(codexHome, "AGENTS.md"));
     }
-    if (clients.includes("claude-code")) {
+    if (instructionClients.includes("claude-code")) {
       files.push(path.join(home, ".claude", "CLAUDE.md"));
     }
     return unique(files);

--- a/plans/headless-mode/plan.mdx
+++ b/plans/headless-mode/plan.mdx
@@ -1,0 +1,804 @@
+---
+title: "Agent-Native Headless Mode"
+brief: "A first-cut plan for making Agent-Native apps usable as headless agent runtimes while preserving actions, SQL, MCP/A2A, and optional UI parity."
+kind: "plan"
+localOnly: true
+---
+
+# Agent-Native Headless Mode
+
+## Product Snapshot
+
+A developer creates a support triage agent with no product UI:
+
+```bash
+npx @agent-native/core@latest create support-triage --template headless
+cd support-triage
+pnpm dev
+```
+
+The app still gets the Agent-Native runtime contract: actions in `actions/`,
+SQL for durable state, the same agent loop, `/_agent-native/actions/*`,
+`/_agent-native/agent-chat`, `/_agent-native/mcp`, `/_agent-native/a2a`, run
+history, secrets, and skills. What it does not require is a custom React
+product surface on day one. A team can later add a UI route without changing
+how the agent works.
+
+<Callout id="decision-positive-model" tone="decision">
+
+Headless mode is an Agent-Native app profile, not a replacement framework. The
+core capability surface remains `defineAction`; headless apps simply start from
+a server/agent-first scaffold where the product UI is optional.
+
+</Callout>
+
+## Objective
+
+Make Agent-Native credible for Eve/Mastra/Flue-shaped backend agents while
+preserving the framework thesis: actions are the shared capability surface, SQL
+is the source of durable app state, and UI can be added later without rewriting
+the agent.
+
+Done means a developer can scaffold a headless app, define actions and skills,
+call it through CLI/HTTP/MCP/A2A, run it locally and in a workspace, inspect run
+status, read the docs-site guide for the mode, and later add UI without
+migrating the core app contract.
+
+## Research Signals
+
+Flue is useful because it separates ongoing agent sessions from bounded workflow
+runs. Mastra is useful because it treats standalone server/runtime mode as
+normal, with workflows, memory, observability, and external protocol adapters
+around the same agent core. Agent-Native should borrow that shape, not their
+tool APIs.
+
+<Table
+  id="research-to-agent-native"
+  columns={["Signal", "Borrow", "Agent-Native translation"]}
+  rows={[
+    [
+      "Flue continuing agents",
+      "An agent instance has durable identity and session history",
+      "Use existing chat threads, agent_runs, run events, and A2A/MCP endpoints",
+    ],
+    [
+      "Flue/Mastra workflows",
+      "Finite runs are different from open-ended chat",
+      "Model bounded workflow runs as a second headless primitive, initially deferred behind existing runs/progress",
+    ],
+    [
+      "Mastra server adapters",
+      "Agent runtime can be embedded or standalone",
+      "Keep Nitro/plugin architecture; add headless scaffold metadata and docs",
+    ],
+    [
+      "Mastra approvals",
+      "Approvals are useful only for consequential actions",
+      "Keep HITL opt-in; email send/payment/delete remain explicit cases",
+    ],
+    [
+      "Mastra Responses-style routes",
+      "Compatibility adapters lower integration cost",
+      "Defer POST /v1/responses adapter until the headless scaffold is stable",
+    ],
+  ]}
+/>
+
+## Core Shape
+
+The first cut should avoid new primitives where the framework already has them.
+The headless app should mostly be a different scaffold and metadata profile over
+the current runtime.
+
+<Diagram
+  id="headless-runtime-map"
+  data={{
+    html: '<div class="diagram-panel headless-map" data-rough><div class="diagram-card clients"><strong>Callers</strong><span>CLI</span><span>HTTP clients</span><span>MCP hosts</span><span>A2A agents</span><span>Optional React UI</span></div><div class="diagram-card runtime"><strong>Agent-Native server</strong><span>agent-chat plugin</span><span>core routes</span><span>auth/secrets</span><span>run-manager</span></div><div class="diagram-card app"><strong>Headless app code</strong><span>actions/</span><span>.agents/skills/</span><span>server/plugins/</span><span>SQL schema</span></div><div class="diagram-card durable"><strong>Durable state</strong><span>application_state</span><span>chat threads</span><span>agent_runs</span><span>agent_tool_ledger</span><span>progress_runs</span></div></div>',
+    css: ".headless-map { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 14px; align-items: stretch; } .headless-map .diagram-card { display: grid; align-content: start; gap: 8px; min-height: 190px; padding: 14px; } .headless-map strong { font-size: 15px; } .headless-map span { border: 1px solid var(--wf-line); border-radius: 7px; padding: 6px 8px; background: var(--wf-card); color: var(--wf-ink); } .headless-map .runtime { background: var(--wf-accent-soft); } @media (max-width: 860px) { .headless-map { grid-template-columns: 1fr; } }",
+    caption:
+      "Headless mode reuses the existing runtime; the app-specific delta is scaffold shape, metadata, and docs.",
+  }}
+/>
+
+## Key Decisions
+
+<Callout id="decision-scaffold" tone="decision">
+
+Use a hidden, explicit `headless` scaffold plus package metadata for v1. Do not
+overload `agent-native.json`; that file already describes local artifact/data
+mode behavior. The durable app profile belongs in template metadata and
+`package.json["agent-native"]`/workspace app metadata.
+
+</Callout>
+
+<Callout id="decision-no-parallel-tool-surface" tone="decision">
+
+Do not add `defineTool`. Headless apps still define `defineAction` files.
+Actions already supply agent tools, HTTP routes, frontend hooks if a UI appears
+later, MCP/A2A exposure metadata, links, read-only flags, and safety flags.
+
+</Callout>
+
+<Callout id="decision-two-primitives" tone="decision">
+
+Name two headless concepts early, but implement them in phases: continuing agent
+sessions in v1 using existing chat/run infrastructure, bounded workflow runs in
+v2 using the same run/progress substrate instead of a separate store.
+
+</Callout>
+
+## Scope
+
+In v1, ship the headless app profile, not a full workflow DSL.
+
+<Table
+  id="v1-scope-table"
+  columns={["Area", "In v1", "Deferred"]}
+  rows={[
+    [
+      "Scaffold",
+      "templates/headless or a generated headless profile from starter",
+      "Public picker exposure after dogfood",
+    ],
+    [
+      "Runtime",
+      "Existing createAgentChatPlugin, core routes, actions, MCP, A2A",
+      "New standalone runtime package",
+    ],
+    [
+      "UI",
+      "No product UI required; optional minimal status/help page is acceptable",
+      "Rich admin console",
+    ],
+    [
+      "Workflows",
+      "Document the finite-run shape and reuse progress_runs/agent_runs",
+      "defineWorkflow and /workflows/:name/runs",
+    ],
+    [
+      "Protocols",
+      "Existing action HTTP, MCP, A2A, agent chat",
+      "OpenAI Responses-compatible adapter",
+    ],
+    [
+      "Approvals",
+      "Default off; action-level opt-in only for consequential operations",
+      "Global HITL policy layer",
+    ],
+  ]}
+/>
+
+## Current Code Reuse
+
+<FileTree
+  id="current-code-reuse"
+  title="Current surfaces to reuse"
+  entries={[
+    {
+      path: "packages/core/src/action.ts",
+      change: "checked",
+      note: "defineAction already carries HTTP, auth, agent tool, read-only, parallelSafe, MCP App, publicAgent, and link metadata.",
+    },
+    {
+      path: "packages/core/src/server/action-routes.ts",
+      change: "checked",
+      note: "Actions already mount at /_agent-native/actions/:name with method/auth/read-only behavior.",
+    },
+    {
+      path: "packages/core/src/server/agent-chat-plugin.ts",
+      change: "checked",
+      note: "Main plugin already mounts agent chat, filters agent-visible tools, wires MCP/A2A, loads resources, and builds prompts.",
+    },
+    {
+      path: "packages/core/src/agent/production-agent.ts",
+      change: "checked",
+      note: "runAgentLoop is transport-free and actionsToEngineTools is the canonical action-to-tool conversion.",
+    },
+    {
+      path: "packages/core/src/agent/run-manager.ts",
+      change: "checked",
+      note: "Continuing sessions can reuse run IDs, events, soft-timeout continuation, SQL persistence, and cross-isolate reconnect.",
+    },
+    {
+      path: "packages/core/src/agent/run-store.ts",
+      change: "checked",
+      note: "agent_runs, agent_run_events, and agent_tool_ledger already cover durable event history and uncertain tool results.",
+    },
+    {
+      path: "packages/core/src/progress/routes.ts",
+      change: "checked",
+      note: "/_agent-native/runs already exposes user-facing task status for dashboards and headless monitoring.",
+    },
+    {
+      path: "packages/core/src/a2a/server.ts",
+      change: "checked",
+      note: "A2A endpoints and agent-card generation already exist; headless apps should make this path first-class.",
+    },
+    {
+      path: "packages/core/src/mcp/server.ts",
+      change: "checked",
+      note: "mountMCP is already stateless Streamable HTTP and serverless-safe.",
+    },
+    {
+      path: "packages/core/src/mcp/stdio.ts",
+      change: "checked",
+      note: "CLI stdio proxy/standalone MCP mode can be the headless local-connection story.",
+    },
+    {
+      path: "packages/core/src/scripts/runner.ts",
+      change: "checked",
+      note: "Direct action CLI invocation already exists with caller: cli.",
+    },
+    {
+      path: "packages/shared-app-config/templates.ts",
+      change: "modified",
+      note: "First-party template metadata is the right place to add a hidden scaffoldable headless template/profile.",
+    },
+    {
+      path: "packages/core/src/cli/create.ts",
+      change: "modified",
+      note: "Scaffolding already handles hidden explicit templates and workspace/standalone flows.",
+    },
+    {
+      path: "packages/dispatch/src/server/lib/app-creation-store.ts",
+      change: "modified",
+      note: "Dispatch has a separate addable-template list that must not drift if headless apps can be created from Dispatch.",
+    },
+    {
+      path: "packages/core/src/mcp/builtin-tools.ts",
+      change: "modified",
+      note: "MCP create-app tooling currently validates against visible templates, so explicit headless creation needs a safe allow path.",
+    },
+    {
+      path: "packages/core/docs/content/pure-agent-apps.md",
+      change: "modified",
+      note: "Existing concept page should either become the headless-mode guide or point readers to it so terminology does not split.",
+    },
+    {
+      path: "packages/docs/app/components/docsNavItems.ts",
+      change: "modified",
+      note: "Docs sidebar is explicit; add Headless Mode/Pure-Agent Apps navigation intentionally.",
+    },
+    {
+      path: "packages/docs/app/components/docs-content.ts",
+      change: "checked",
+      note: "Markdown docs are loaded by glob today, but verify the new docs page is indexed and searchable.",
+    },
+  ]}
+/>
+
+## Data Model
+
+V1 should avoid a schema migration. The existing tables are enough for continuing
+headless agent sessions and task status.
+
+<DataModel
+  id="headless-existing-data"
+  entities={[
+    {
+      id: "chat_threads",
+      name: "chat_threads",
+      note: "Existing durable conversation identity",
+      fields: [
+        { name: "id", type: "text", pk: true },
+        { name: "owner", type: "text", note: "Scoped to the user/org context" },
+        {
+          name: "data",
+          type: "json/text",
+          note: "Thread messages and metadata",
+        },
+      ],
+    },
+    {
+      id: "agent_runs",
+      name: "agent_runs",
+      note: "Internal agent-chat turn lifecycle",
+      fields: [
+        { name: "id", type: "text", pk: true },
+        { name: "thread_id", type: "text", fk: "chat_threads.id" },
+        { name: "status", type: "text" },
+        { name: "turn_id", type: "text" },
+        { name: "heartbeat_at", type: "int" },
+        { name: "last_progress_at", type: "int" },
+      ],
+    },
+    {
+      id: "agent_run_events",
+      name: "agent_run_events",
+      note: "Ordered persisted event stream",
+      fields: [
+        { name: "run_id", type: "text", fk: "agent_runs.id", pk: true },
+        { name: "seq", type: "int", pk: true },
+        { name: "event_data", type: "text/json" },
+      ],
+    },
+    {
+      id: "agent_tool_ledger",
+      name: "agent_tool_ledger",
+      note: "Recovered write-tool completions after continuation boundaries",
+      fields: [
+        { name: "thread_id", type: "text", pk: true },
+        { name: "tool_key", type: "text", pk: true },
+        { name: "result_summary", type: "text" },
+        { name: "completed_at", type: "int" },
+      ],
+    },
+    {
+      id: "progress_runs",
+      name: "progress_runs",
+      note: "User-facing run/task status",
+      fields: [
+        { name: "id", type: "text", pk: true },
+        { name: "owner", type: "text" },
+        { name: "title", type: "text" },
+        { name: "status", type: "text" },
+        { name: "metadata", type: "text/json" },
+      ],
+    },
+  ]}
+  relations={[
+    {
+      from: "chat_threads",
+      to: "agent_runs",
+      kind: "1-n",
+      label: "thread runs",
+    },
+    {
+      from: "agent_runs",
+      to: "agent_run_events",
+      kind: "1-n",
+      label: "event stream",
+    },
+    {
+      from: "chat_threads",
+      to: "agent_tool_ledger",
+      kind: "1-n",
+      label: "side-effect recovery",
+    },
+  ]}
+/>
+
+## Target Runtime Contract
+
+These are the endpoints a headless app should document and smoke-test. Most
+already exist.
+
+<Endpoint
+  id="endpoint-agent-chat"
+  method="POST"
+  path="/_agent-native/agent-chat"
+  summary="Run or continue a headless agent session"
+  auth="Session or configured external auth"
+>
+
+Continuing session entrypoint. Uses `threadId`/`turnId`, streams events, records
+`agent_runs`, and can auto-continue across hosted timeout boundaries.
+
+</Endpoint>
+
+<Endpoint
+  id="endpoint-actions"
+  method="POST"
+  path="/_agent-native/actions/:name"
+  summary="Invoke an action over HTTP"
+  auth="Action auth policy"
+>
+
+Shared action transport. GET actions remain read-only; writes emit action-change
+events. Headless docs should teach this as the programmatic API instead of
+adding bespoke `/api/*` wrappers.
+
+</Endpoint>
+
+<Endpoint
+  id="endpoint-mcp"
+  method="POST"
+  path="/_agent-native/mcp"
+  summary="Expose the app to MCP hosts"
+  auth="Remote MCP OAuth/session auth"
+>
+
+External coding agents and MCP clients can call the same action surface.
+Headless apps should make this a primary setup path, not a hidden power-user
+path.
+
+</Endpoint>
+
+<Endpoint
+  id="endpoint-a2a"
+  method="POST"
+  path="/_agent-native/a2a"
+  summary="Expose the app to other Agent-Native/A2A agents"
+  auth="A2A_SECRET/JWT or dev-only unauthenticated mode"
+>
+
+Cross-agent protocol entrypoint. Public agent-card skills should remain filtered
+to explicitly public-safe actions.
+
+</Endpoint>
+
+<Endpoint
+  id="endpoint-runs"
+  method="GET"
+  path="/_agent-native/runs"
+  summary="List active or historical progress runs"
+  auth="Session auth"
+>
+
+Monitoring surface for headless work. Existing route supports `active=true` and
+`limit`; v1 should document it and include a CLI smoke.
+
+</Endpoint>
+
+## Implementation Plan
+
+### 1. Add headless metadata without touching `agent-native.json`
+
+Extend template/app metadata so a template can say it has no product UI
+expectation and can use a different dev/display policy.
+
+<AnnotatedCode
+  id="metadata-shape"
+  filename="packages/shared-app-config/templates.ts"
+  language="ts"
+  code={
+    'export interface TemplateMeta {\n  name: string;\n  label: string;\n  hint: string;\n  hidden?: boolean;\n  core?: boolean;\n  defaultAgent?: boolean;\n  /** Server/agent-first app. Product UI is optional and dev tooling should not assume a Vite page is the primary surface. */\n  headless?: boolean;\n  /** Optional command or mode hint for workspace dev when the app is not a standard UI-first template. */\n  devProfile?: "ui" | "headless";\n}\n'
+  }
+  annotations={[
+    {
+      lines: "6-9",
+      label: "New profile",
+      note: "Keep headless in template/package metadata, not agent-native.json, which currently owns local artifact data mode.",
+    },
+    {
+      lines: "10-11",
+      label: "Dev hint",
+      note: "Workspace dev and Dispatch app creation need a non-UI signal without hardcoding template names.",
+    },
+  ]}
+/>
+
+Mirror this in `packages/core/src/cli/templates-meta.ts` and any
+generated/duplicated metadata checks.
+
+### 2. Scaffold a hidden headless template/profile
+
+Create the smallest useful first-party scaffold. It can be a stripped
+starter-derived template, but its source should teach the headless contract
+explicitly:
+
+- `server/plugins/agent-chat.ts` using `createAgentChatPlugin` and static action
+  registry.
+- `server/plugins/auth.ts` or documented auth mode, depending on
+  standalone/workspace target.
+- `actions/hello.ts`, `actions/run.ts`, `actions/view-screen.ts`, and one
+  example long-running/action-backed task.
+- `.agents/skills/headless/SKILL.md` explaining how the agent should treat
+  actions, no-UI state, run IDs, MCP/A2A, and optional UI additions.
+- A minimal route only if required by the current React/Nitro build; it should
+  be a status/help page, not a product dashboard.
+
+### 3. Wire scaffold creation paths consistently
+
+Update all creation surfaces that currently know about template lists.
+
+<FileTree
+  id="scaffold-touch-points"
+  title="Scaffold wiring"
+  entries={[
+    {
+      path: "packages/core/src/cli/create.ts",
+      change: "modified",
+      note: "Allow explicit --template headless; preserve hidden status in interactive pickers.",
+    },
+    {
+      path: "packages/shared-app-config/templates.ts",
+      change: "modified",
+      note: "Add headless metadata and keep it hidden until dogfooded.",
+    },
+    {
+      path: "packages/core/src/cli/templates-meta.ts",
+      change: "modified",
+      note: "Keep CLI template metadata in sync.",
+    },
+    {
+      path: "packages/dispatch/src/server/lib/app-creation-store.ts",
+      change: "modified",
+      note: "Decide whether Dispatch can create headless apps; if yes, add an explicit allow path so hidden does not mean impossible.",
+    },
+    {
+      path: "packages/core/src/mcp/builtin-tools.ts",
+      change: "modified",
+      note: "Let MCP create-app tooling accept hidden-but-explicit templates where safe.",
+    },
+    {
+      path: "scripts/guard-template-list.mjs",
+      change: "modified",
+      note: "Prevent future drift across template lists.",
+    },
+  ]}
+/>
+
+### 4. Add docs-site coverage for headless mode
+
+Ship the docs with the scaffold, not after it. A developer should be able to
+land on `/docs/headless-mode` and understand the mental model, the scaffold
+command, the supported transports, where durable state lives, what auth/safety
+rules apply, and how to add a UI later.
+
+<FileTree
+  id="docs-site-touch-points"
+  title="Docs-site touch points"
+  entries={[
+    {
+      path: "packages/core/docs/content/headless-mode.md",
+      change: "added",
+      note: "Primary docs-site guide for the scaffold command, runtime contract, endpoint map, auth/safety defaults, MCP/A2A setup, and optional UI path.",
+    },
+    {
+      path: "packages/core/docs/content/pure-agent-apps.md",
+      change: "modified",
+      note: "Either fold this into the new guide or keep it as a conceptual page that links clearly to /docs/headless-mode.",
+    },
+    {
+      path: "packages/core/docs/content/creating-templates.md",
+      change: "modified",
+      note: "Explain headless/devProfile metadata for template authors.",
+    },
+    {
+      path: "packages/docs/app/components/docsNavItems.ts",
+      change: "modified",
+      note: "Add Headless Mode to the docs sidebar near Pure-Agent Apps/Getting Started.",
+    },
+    {
+      path: "packages/docs/app/components/docs-content.ts",
+      change: "checked",
+      note: "Confirm the glob-based docs loader indexes the new Markdown page for routes and search.",
+    },
+    {
+      path: "templates/headless/AGENTS.md",
+      change: "added",
+      note: "Tell coding agents there is no default product UI and every new capability should start as a defineAction file.",
+    },
+    {
+      path: "templates/headless/.agents/skills/headless/SKILL.md",
+      change: "added",
+      note: "Teach the app-local pattern: actions first, no-UI state, run IDs, MCP/A2A, and optional UI additions.",
+    },
+  ]}
+/>
+
+The docs page should include one copy-pastable smoke path:
+
+```bash
+npx @agent-native/core@latest create support-triage --template headless
+cd support-triage
+pnpm install
+pnpm dev
+```
+
+Then show the calls a developer can make first: direct action invocation,
+agent-chat continuation, MCP connection, A2A discovery, and run-status
+inspection. Keep the page practical; the conceptual "pure-agent" argument can
+stay in `pure-agent-apps.md` if it still earns its place.
+
+### 5. Add durable workflow language without shipping the DSL yet
+
+In docs and template examples, call out two execution shapes.
+
+<Table
+  id="continuing-vs-finite"
+  columns={["Shape", "Use for", "V1 implementation", "Later"]}
+  rows={[
+    [
+      "Continuing agent session",
+      "Open-ended chat, triage, investigation, async agent work",
+      "/_agent-native/agent-chat + chat_threads + agent_runs",
+      "Optional Responses-compatible adapter",
+    ],
+    [
+      "Finite workflow run",
+      "A known business process: sync inbox, classify leads, publish report",
+      "Action or trigger starts work and records progress in progress_runs",
+      "defineWorkflow and /workflows/:name/runs",
+    ],
+    [
+      "Deterministic action",
+      "Direct API operation or UI parity operation",
+      "defineAction with HTTP/MCP/A2A metadata",
+      "No separate tool API",
+    ],
+  ]}
+/>
+
+This gets the vocabulary right now while keeping v1 implementation
+conservative.
+
+### 6. Verification
+
+V1 should be proven with a fresh scaffold, not only unit tests.
+
+<Checklist
+  id="verification-checklist"
+  items={[
+    {
+      id: "scaffold",
+      label:
+        "Scaffold npx @agent-native/core@latest create support-triage --template headless into a temp dir",
+      checked: false,
+    },
+    {
+      id: "install-build",
+      label: "Run install, typecheck, and build for the scaffolded app",
+      checked: false,
+    },
+    {
+      id: "action-http",
+      label:
+        "Call an example action through /_agent-native/actions/:name and verify auth/read-only behavior",
+      checked: false,
+    },
+    {
+      id: "agent-chat",
+      label:
+        "POST a message to /_agent-native/agent-chat and verify run events land in agent_runs/agent_run_events",
+      checked: false,
+    },
+    {
+      id: "mcp",
+      label:
+        "Connect over /_agent-native/mcp and confirm only agent-visible actions appear",
+      checked: false,
+    },
+    {
+      id: "a2a",
+      label:
+        "Fetch /.well-known/agent-card.json and smoke an A2A call in dev mode",
+      checked: false,
+    },
+    {
+      id: "workspace",
+      label:
+        "Create a workspace with a headless app and confirm Dispatch/app creation surfaces do not drift",
+      checked: false,
+    },
+    {
+      id: "docs-site",
+      label:
+        "Open /docs/headless-mode in the docs site and verify sidebar nav, search indexing, links, and scaffold snippets",
+      checked: false,
+    },
+    {
+      id: "optional-ui",
+      label:
+        "Add one React route later and verify the app can become UI-capable without changing actions",
+      checked: false,
+    },
+  ]}
+/>
+
+## Risks
+
+<Callout id="risk-hidden-template-drift" tone="risk">
+
+Hidden scaffoldable templates can drift from CLI, Dispatch, MCP create-app tools,
+and docs. The implementation should add one explicit hidden-template allow path
+and a guard test, not one-off exceptions in each caller.
+
+</Callout>
+
+<Callout id="risk-fake-headless" tone="risk">
+
+A template that still requires a Vite product page for every dev/build path is
+only cosmetically headless. V1 can keep a tiny status page if the current build
+requires it, but docs and dev tooling should make the agent/server surfaces
+primary.
+
+</Callout>
+
+<Callout id="risk-public-agent-safety" tone="risk">
+
+Headless apps are easier to expose publicly because there is no obvious UI
+boundary. MCP/A2A/OpenAPI surfaces must continue to filter by `agentTool`,
+`publicAgent`, read-only, auth, and consequential-action metadata.
+
+</Callout>
+
+## Non-Goals
+
+- No `defineTool` parallel surface.
+- No new connection/capability-pack system.
+- No runtime manifest work in `agent-native.json`.
+- No default HITL approval policy.
+- No full workflow DSL in the first cut.
+- No public picker placement until the profile has been dogfooded.
+
+## Rollout
+
+1. Internal hidden scaffold: `--template headless` only.
+2. Dogfood with one real app that has actions, scheduled/event work, MCP, and
+   A2A but no product UI.
+3. Ship docs-site coverage with the hidden scaffold; add richer examples once
+   the scaffold survives workspace creation and deploy.
+4. Consider exposing in Dispatch/app creation UI as "Agent runtime" or
+   "Headless agent" after the template no longer needs caveats.
+5. Later: add `defineWorkflow`, Responses-compatible adapter, and a richer run
+   inspector if the v1 contract proves useful.
+
+### Open Questions
+
+<QuestionForm
+  id="open-questions"
+  submitLabel="Submit direction"
+  questions={[
+    {
+      id: "scaffold-shape",
+      title: "How should v1 expose headless creation?",
+      mode: "single",
+      required: true,
+      options: [
+        {
+          id: "hidden-template",
+          label: "Hidden template",
+          detail:
+            "Add explicit --template headless; fastest to prove and easiest to keep out of public pickers.",
+          recommended: true,
+        },
+        {
+          id: "profile-flag",
+          label: "Profile flag",
+          detail:
+            "Add --profile headless or --headless; nicer API but touches more CLI semantics.",
+        },
+        {
+          id: "metadata-only",
+          label: "Metadata only",
+          detail:
+            "No new template; let existing apps mark themselves headless. Smaller runtime change, weaker product story.",
+        },
+      ],
+    },
+    {
+      id: "workflow-scope",
+      title: "Should bounded workflows ship in v1 or v2?",
+      mode: "single",
+      required: true,
+      options: [
+        {
+          id: "v2",
+          label: "Defer to v2",
+          detail:
+            "Document the concept now and reuse actions/progress for v1. Lowest risk.",
+          recommended: true,
+        },
+        {
+          id: "minimal-v1",
+          label: "Minimal v1",
+          detail:
+            "Add file-discovered workflows/*.ts and a run endpoint now. More compelling, more surface area.",
+        },
+      ],
+    },
+    {
+      id: "responses-adapter",
+      title: "When should a Responses-compatible adapter land?",
+      mode: "single",
+      required: true,
+      options: [
+        {
+          id: "after-scaffold",
+          label: "After scaffold",
+          detail:
+            "First prove native agent-chat/MCP/A2A. Then add compatibility once the headless contract is stable.",
+          recommended: true,
+        },
+        {
+          id: "same-cut",
+          label: "Same cut",
+          detail:
+            "Makes headless easier to call from existing clients, but creates a hard-to-reverse public API immediately.",
+        },
+      ],
+    },
+  ]}
+/>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -508,6 +508,9 @@ importers:
         specifier: ^8.18.0
         version: 8.20.0
     optionalDependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
       playwright:
         specifier: ^1.60.0
         version: 1.60.0

--- a/scripts/sync-template-netlify-env.ts
+++ b/scripts/sync-template-netlify-env.ts
@@ -50,6 +50,10 @@ const SITE_BY_NAME = new Map(TEMPLATE_SITES.map((site) => [site.name, site]));
 const DEFAULT_SOURCES = [".env", ".env.local"];
 const DEFAULT_SCOPES = ["builds", "functions", "runtime"];
 const DEFAULT_CONTEXT = "production";
+const BLOCKED_TEMPLATE_ENV_KEYS = new Set([
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+]);
 const PUBLIC_KEY_EXACT = new Set([
   "APP_URL",
   "BETTER_AUTH_URL",
@@ -420,7 +424,12 @@ async function main() {
     if (!site) throw new Error(`Missing site mapping for ${template}.`);
 
     const { foundSources, values } = loadTemplateEnv(template, options.sources);
-    const entries = [...values.entries()].filter(([, value]) => value !== "");
+    const blockedKeys = [...values.keys()]
+      .filter((key) => BLOCKED_TEMPLATE_ENV_KEYS.has(key))
+      .sort();
+    const entries = [...values.entries()].filter(
+      ([key, value]) => value !== "" && !BLOCKED_TEMPLATE_ENV_KEYS.has(key),
+    );
     const keys = entries.map(([key]) => key).sort();
 
     console.log("");
@@ -429,6 +438,11 @@ async function main() {
       `  sources: ${foundSources.length > 0 ? foundSources.join(", ") : "(none)"}`,
     );
     console.log(`  keys: ${redactedKeyList(keys)}`);
+    if (blockedKeys.length > 0) {
+      console.log(
+        `  skipped blocked hosted LLM key(s): ${blockedKeys.join(", ")}`,
+      );
+    }
 
     if (entries.length === 0) {
       console.log("  skipped: no non-empty env values found");

--- a/skills/visual-plans/SKILL.md
+++ b/skills/visual-plans/SKILL.md
@@ -342,7 +342,7 @@ skill — never hand-edit one stored plan. Turn feedback into better guidance.
 ## Local-Files Privacy Mode
 
 Use local-files privacy mode when the user explicitly asks for no DB writes,
-no hosted Plan app, no Plan MCP publish, fully local files, offline/private
+no hosted Plan database writes, no Plan MCP publish, fully local files, offline/private
 planning, repo-owned/source-controlled planning artifacts, or when
 `AGENT_NATIVE_PLANS_MODE=local-files` is set. Also use it when a user or repo
 policy says a plan must stay under their own brand, domain, source control, or
@@ -360,21 +360,24 @@ The local-files contract is:
   `plan blocks` command calls the public no-auth `get-plan-blocks` route and
   writes only registry metadata to disk; use `--format schema` if exact nested
   fields are needed. If network access is unavailable, use the bundled
-  references and rely on `plan local preview` to catch invalid tags.
-- Write the plan as a local MDX folder under `plans/<slug>/`: `plan.mdx`,
-  optional `canvas.mdx`, optional `prototype.mdx`, and optional
-  `.plan-state.json`.
-- Run `npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind plan --open`
-  after writing or updating the folder. Report the returned local URL or the
-  `/local-plans/<slug>` route if the local Plan app is running with the same
-  `PLAN_LOCAL_DIR`.
+  references and rely on `plan local serve` to catch invalid tags.
+- Write the plan as a local MDX folder: use `plans/<slug>/` when the user
+  wants the artifact checked into the repo, or use a repo-ignored/temporary
+  folder such as `.agent-native/plans/<slug>/` or `/tmp/agent-native-plans/<slug>/`
+  when it should not be checked in. The folder contains `plan.mdx`, optional
+  `canvas.mdx`, optional `prototype.mdx`, and optional `.plan-state.json`.
+- Run `npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind plan --open`
+  after writing or updating the folder. Report the returned local bridge URL. It opens the hosted Plan UI but reads
+  from the localhost bridge on this machine, so it is not shareable across
+  machines. If the Plan app itself is running locally with the same
+  `PLAN_LOCAL_DIR`, the `/local-plans/<slug>` route is also valid.
 - Do **not** call `create-visual-plan`, `create-ui-plan`,
   `create-prototype-plan`, `create-plan-design`, `import-visual-plan-source`,
   `update-visual-plan`, `patch-visual-plan-source`, `get-plan-feedback`,
   `export-visual-plan`, or any hosted Plan tool for that plan except the
   schema-only block catalog lookup above.
 - Treat feedback as file or chat feedback: update the MDX files directly, rerun
-  the local preview command, and summarize the new local URL/path. Hosted
+  the local bridge command, and summarize the new local bridge URL. Hosted
   comments, sharing, history, and publish/export receipts are unavailable until
   the user explicitly opts into publishing.
 

--- a/skills/visual-recap/SKILL.md
+++ b/skills/visual-recap/SKILL.md
@@ -22,7 +22,7 @@ before spending attention on the literal lines.
 ## Local-Files Privacy Mode Exception
 
 Use local-files privacy mode when the user explicitly asks for no DB writes,
-no hosted Plan app, no Plan MCP publish, fully local files, offline/private
+no hosted Plan database writes, no Plan MCP publish, fully local files, offline/private
 recaps, or when `AGENT_NATIVE_PLANS_MODE=local-files` is set. This is the only
 exception to the hosted publish rule below.
 
@@ -37,22 +37,26 @@ In local-files mode:
   MCP connector is not registered; it calls the public no-auth
   `get-plan-blocks` route and sends no recap content. If network access is
   unavailable, use the bundled references and validate with
-  `plan local preview`.
-- Write the recap as a local MDX folder under `plans/<slug>/`: `plan.mdx`,
-  optional `canvas.mdx`, optional `prototype.mdx`, and optional
-  `.plan-state.json`. Set `kind: "recap"` and `localOnly: true` in
-  frontmatter/state when authoring the source.
-- Run `npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind recap --open`
-  after writing or updating the folder. Report the returned local URL or the
-  `/local-plans/<slug>` route if the local Plan app is running with the same
-  `PLAN_LOCAL_DIR`.
+  `plan local serve`.
+- Write the recap as a local MDX folder: use `plans/<slug>/` when the user
+  wants the artifact checked into the repo, or use a repo-ignored/temporary
+  folder such as `.agent-native/plans/<slug>/` or `/tmp/agent-native-plans/<slug>/`
+  when it should not be checked in. The folder contains `plan.mdx`, optional
+  `canvas.mdx`, optional `prototype.mdx`, and optional `.plan-state.json`. Set
+  `kind: "recap"` and `localOnly: true` in frontmatter/state when authoring
+  the source.
+- Run `npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind recap --open`
+  after writing or updating the folder. Report the returned local bridge URL. It opens the hosted Plan UI but reads
+  from the localhost bridge on this machine, so it is not shareable across
+  machines. If the Plan app itself is running locally with the same
+  `PLAN_LOCAL_DIR`, the `/local-plans/<slug>` route is also valid.
 - Do **not** call `create-visual-recap`, `create-visual-plan`,
   `import-visual-plan-source`, `update-visual-plan`,
   `patch-visual-plan-source`, `get-plan-feedback`, `export-visual-plan`,
   `set-resource-visibility`, or any hosted Plan tool for that recap except the
   schema-only block catalog lookup above.
 - Treat review feedback as file or chat feedback: update the MDX files directly,
-  rerun the local preview command, and summarize the new local URL/path.
+  rerun the local bridge command, and summarize the new local bridge URL.
   Hosted comments, sharing, screenshots, usage attachment, and PR sticky comment
   publishing are unavailable until the user explicitly opts into publishing.
 
@@ -263,10 +267,13 @@ a headless CI agent), state that in the recap handoff instead.
 
 ## Open And Report The Recap
 
-In local-files privacy mode, report the local preview URL/path from
-`npx @agent-native/core@latest plan local preview` or the `/local-plans/<slug>` route for a local
-Plan app using the same `PLAN_LOCAL_DIR`. Do not invent a hosted URL and do not
-publish just to get an absolute Plan link.
+In local-files privacy mode, report the local bridge URL from
+`npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind recap --open`.
+It opens the hosted Plan UI but reads from the localhost bridge on this machine,
+so it is not shareable across machines. If the Plan app itself is running
+locally with the same `PLAN_LOCAL_DIR`, the `/local-plans/<slug>` route is also
+valid. Do not invent a hosted database URL and do not publish just to get an
+absolute Plan link.
 
 After creating the recap, link the reviewer to the rendered plan with an
 **absolute URL on the origin whose database actually holds the plan**. That
@@ -420,7 +427,7 @@ was installed as plain text and no MCP tools are registered, run
 `npx @agent-native/core@latest plan blocks --out plan-blocks.md` and read that
 file first. The CLI command calls the public no-auth `get-plan-blocks` route and
 sends no plan/recap content. If network access is unavailable, use the bundled
-references and validate with `plan local preview`.
+references and validate with `plan local serve`.
 
 The catalog returns the authoritative, always-current block vocabulary generated
 live from the app's own block registry — the same config the renderer and MDX

--- a/templates/mail/actions/send-email.ts
+++ b/templates/mail/actions/send-email.ts
@@ -122,6 +122,13 @@ export default defineAction({
         "Files to attach. Each entry must reference a previously-uploaded file by its server-side `filename`. The upload must have been created via the media-upload endpoint before calling this action.",
       ),
   }),
+  // Human-in-the-loop gate: actually sending an email is outward-facing and
+  // hard to undo, so the agent can never send without a human approving the
+  // specific call. The loop pauses with `approval_required`; the user approves
+  // before the message goes out. Drafting/queueing is unaffected — only the
+  // real send is gated. This is the canonical (and intentionally rare) use of
+  // `needsApproval` in the framework.
+  needsApproval: true,
   run: async (args) => {
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("no authenticated user");

--- a/templates/plan/.agents/skills/visual-plan/SKILL.md
+++ b/templates/plan/.agents/skills/visual-plan/SKILL.md
@@ -342,7 +342,7 @@ skill — never hand-edit one stored plan. Turn feedback into better guidance.
 ## Local-Files Privacy Mode
 
 Use local-files privacy mode when the user explicitly asks for no DB writes,
-no hosted Plan app, no Plan MCP publish, fully local files, offline/private
+no hosted Plan database writes, no Plan MCP publish, fully local files, offline/private
 planning, repo-owned/source-controlled planning artifacts, or when
 `AGENT_NATIVE_PLANS_MODE=local-files` is set. Also use it when a user or repo
 policy says a plan must stay under their own brand, domain, source control, or
@@ -360,21 +360,24 @@ The local-files contract is:
   `plan blocks` command calls the public no-auth `get-plan-blocks` route and
   writes only registry metadata to disk; use `--format schema` if exact nested
   fields are needed. If network access is unavailable, use the bundled
-  references and rely on `plan local preview` to catch invalid tags.
-- Write the plan as a local MDX folder under `plans/<slug>/`: `plan.mdx`,
-  optional `canvas.mdx`, optional `prototype.mdx`, and optional
-  `.plan-state.json`.
-- Run `npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind plan --open`
-  after writing or updating the folder. Report the returned local URL or the
-  `/local-plans/<slug>` route if the local Plan app is running with the same
-  `PLAN_LOCAL_DIR`.
+  references and rely on `plan local serve` to catch invalid tags.
+- Write the plan as a local MDX folder: use `plans/<slug>/` when the user
+  wants the artifact checked into the repo, or use a repo-ignored/temporary
+  folder such as `.agent-native/plans/<slug>/` or `/tmp/agent-native-plans/<slug>/`
+  when it should not be checked in. The folder contains `plan.mdx`, optional
+  `canvas.mdx`, optional `prototype.mdx`, and optional `.plan-state.json`.
+- Run `npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind plan --open`
+  after writing or updating the folder. Report the returned local bridge URL. It opens the hosted Plan UI but reads
+  from the localhost bridge on this machine, so it is not shareable across
+  machines. If the Plan app itself is running locally with the same
+  `PLAN_LOCAL_DIR`, the `/local-plans/<slug>` route is also valid.
 - Do **not** call `create-visual-plan`, `create-ui-plan`,
   `create-prototype-plan`, `create-plan-design`, `import-visual-plan-source`,
   `update-visual-plan`, `patch-visual-plan-source`, `get-plan-feedback`,
   `export-visual-plan`, or any hosted Plan tool for that plan except the
   schema-only block catalog lookup above.
 - Treat feedback as file or chat feedback: update the MDX files directly, rerun
-  the local preview command, and summarize the new local URL/path. Hosted
+  the local bridge command, and summarize the new local bridge URL. Hosted
   comments, sharing, history, and publish/export receipts are unavailable until
   the user explicitly opts into publishing.
 

--- a/templates/plan/.agents/skills/visual-recap/SKILL.md
+++ b/templates/plan/.agents/skills/visual-recap/SKILL.md
@@ -22,7 +22,7 @@ before spending attention on the literal lines.
 ## Local-Files Privacy Mode Exception
 
 Use local-files privacy mode when the user explicitly asks for no DB writes,
-no hosted Plan app, no Plan MCP publish, fully local files, offline/private
+no hosted Plan database writes, no Plan MCP publish, fully local files, offline/private
 recaps, or when `AGENT_NATIVE_PLANS_MODE=local-files` is set. This is the only
 exception to the hosted publish rule below.
 
@@ -37,22 +37,26 @@ In local-files mode:
   MCP connector is not registered; it calls the public no-auth
   `get-plan-blocks` route and sends no recap content. If network access is
   unavailable, use the bundled references and validate with
-  `plan local preview`.
-- Write the recap as a local MDX folder under `plans/<slug>/`: `plan.mdx`,
-  optional `canvas.mdx`, optional `prototype.mdx`, and optional
-  `.plan-state.json`. Set `kind: "recap"` and `localOnly: true` in
-  frontmatter/state when authoring the source.
-- Run `npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind recap --open`
-  after writing or updating the folder. Report the returned local URL or the
-  `/local-plans/<slug>` route if the local Plan app is running with the same
-  `PLAN_LOCAL_DIR`.
+  `plan local serve`.
+- Write the recap as a local MDX folder: use `plans/<slug>/` when the user
+  wants the artifact checked into the repo, or use a repo-ignored/temporary
+  folder such as `.agent-native/plans/<slug>/` or `/tmp/agent-native-plans/<slug>/`
+  when it should not be checked in. The folder contains `plan.mdx`, optional
+  `canvas.mdx`, optional `prototype.mdx`, and optional `.plan-state.json`. Set
+  `kind: "recap"` and `localOnly: true` in frontmatter/state when authoring
+  the source.
+- Run `npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind recap --open`
+  after writing or updating the folder. Report the returned local bridge URL. It opens the hosted Plan UI but reads
+  from the localhost bridge on this machine, so it is not shareable across
+  machines. If the Plan app itself is running locally with the same
+  `PLAN_LOCAL_DIR`, the `/local-plans/<slug>` route is also valid.
 - Do **not** call `create-visual-recap`, `create-visual-plan`,
   `import-visual-plan-source`, `update-visual-plan`,
   `patch-visual-plan-source`, `get-plan-feedback`, `export-visual-plan`,
   `set-resource-visibility`, or any hosted Plan tool for that recap except the
   schema-only block catalog lookup above.
 - Treat review feedback as file or chat feedback: update the MDX files directly,
-  rerun the local preview command, and summarize the new local URL/path.
+  rerun the local bridge command, and summarize the new local bridge URL.
   Hosted comments, sharing, screenshots, usage attachment, and PR sticky comment
   publishing are unavailable until the user explicitly opts into publishing.
 
@@ -263,10 +267,13 @@ a headless CI agent), state that in the recap handoff instead.
 
 ## Open And Report The Recap
 
-In local-files privacy mode, report the local preview URL/path from
-`npx @agent-native/core@latest plan local preview` or the `/local-plans/<slug>` route for a local
-Plan app using the same `PLAN_LOCAL_DIR`. Do not invent a hosted URL and do not
-publish just to get an absolute Plan link.
+In local-files privacy mode, report the local bridge URL from
+`npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind recap --open`.
+It opens the hosted Plan UI but reads from the localhost bridge on this machine,
+so it is not shareable across machines. If the Plan app itself is running
+locally with the same `PLAN_LOCAL_DIR`, the `/local-plans/<slug>` route is also
+valid. Do not invent a hosted database URL and do not publish just to get an
+absolute Plan link.
 
 After creating the recap, link the reviewer to the rendered plan with an
 **absolute URL on the origin whose database actually holds the plan**. That
@@ -420,7 +427,7 @@ was installed as plain text and no MCP tools are registered, run
 `npx @agent-native/core@latest plan blocks --out plan-blocks.md` and read that
 file first. The CLI command calls the public no-auth `get-plan-blocks` route and
 sends no plan/recap content. If network access is unavailable, use the bundled
-references and validate with `plan local preview`.
+references and validate with `plan local serve`.
 
 The catalog returns the authoritative, always-current block vocabulary generated
 live from the app's own block registry — the same config the renderer and MDX

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -3682,6 +3682,11 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
     toast.success(isRecap ? "Recap link copied" : "Plan link copied");
   };
 
+  const copyLocalPlanFolder = async () => {
+    await navigator.clipboard.writeText(localPlanDisplayFolder);
+    toast.success("Local path copied");
+  };
+
   const openPrototypeWindow = () => {
     if (typeof window === "undefined") return;
     const url = new URL(window.location.href);
@@ -5122,6 +5127,29 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="w-56 rounded-xl">
+                    {localPlanMode && (
+                      <>
+                        <DropdownMenuLabel className="text-xs font-medium text-muted-foreground">
+                          Local files
+                        </DropdownMenuLabel>
+                        <div className="px-2 pb-1 text-xs leading-5 text-muted-foreground">
+                          <div className="break-words text-foreground">
+                            {localPlanDisplayFolder}
+                          </div>
+                          <div>No hosted database writes or sharing.</div>
+                        </div>
+                        <DropdownMenuItem
+                          onClick={() =>
+                            runPlanExportAction(copyLocalPlanFolder)
+                          }
+                          className="gap-2"
+                        >
+                          <IconFolder className="size-4" />
+                          Copy local path
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                      </>
+                    )}
                     <DropdownMenuGroup>
                       {!localPlanMode && (
                         <>
@@ -5423,15 +5451,6 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
                     onPointerDown={handleNativeReaderPointerDown}
                     onPointerUp={handleNativeReaderPointerUp}
                   >
-                    {localPlanMode ? (
-                      <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center gap-2 px-6 pt-6 text-sm text-muted-foreground">
-                        <Badge variant="secondary">Local-files mode</Badge>
-                        <span>
-                          Reading {localPlanDisplayFolder} through localhost. No
-                          hosted database writes or sharing.
-                        </span>
-                      </div>
-                    ) : null}
                     <PlanContentRenderer
                       key={bundle.plan.id}
                       content={bundle.plan.content}

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -494,13 +494,41 @@ function assertLocalBridgeUrl(value: string): string {
     throw new Error("Local plan bridge URL is invalid.");
   }
   const allowedHosts = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
-  if (!["http:", "https:"].includes(url.protocol)) {
+  if (url.protocol !== "http:") {
     throw new Error("Local plan bridge must use HTTP on localhost.");
   }
   if (!allowedHosts.has(url.hostname)) {
     throw new Error("Local plan bridge must point to localhost.");
   }
+  if (!url.port) {
+    throw new Error("Local plan bridge must use an explicit localhost port.");
+  }
+  if (url.username || url.password || url.hash) {
+    throw new Error("Local plan bridge URL contains unsupported credentials.");
+  }
+  if (url.pathname !== "/local-plan.json") {
+    throw new Error("Local plan bridge must point to /local-plan.json.");
+  }
+  const params = Array.from(url.searchParams.keys());
+  if (
+    params.length !== 1 ||
+    params[0] !== "token" ||
+    !url.searchParams.get("token")?.trim()
+  ) {
+    throw new Error("Local plan bridge URL is missing its access token.");
+  }
   return url.toString();
+}
+
+function localPlanRoutePath(slug: string): string {
+  return appPath(`/local-plans/${encodeURIComponent(slug)}`);
+}
+
+function localPlanRouteUrl(slug: string): string {
+  const path = localPlanRoutePath(slug);
+  return typeof window === "undefined"
+    ? path
+    : `${window.location.origin}${path}`;
 }
 
 function localPlanAssetDataUrl(
@@ -611,10 +639,7 @@ async function fetchLocalPlanBridgeBundle(
   const kind = payload.kind === "recap" ? "recap" : "plan";
   const title = content.title || payload.title || slug;
   const brief = content.brief || payload.brief || "Local files preview.";
-  const url =
-    typeof window === "undefined"
-      ? `/local-plans/${slug}`
-      : window.location.href;
+  const url = localPlanRouteUrl(slug);
   const bundle: LocalPlanBundle = {
     plan: {
       id: `local-${slug}`,
@@ -3329,15 +3354,7 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
   const planAgentContext = useMemo(() => {
     if (!bundle) return "";
     if (localPlanMode) {
-      const path = appPath(
-        `/local-plans/${encodeURIComponent(localPlanSlug ?? "")}`,
-      );
-      const url =
-        typeof window !== "undefined" && localPlanBridgeUrl
-          ? window.location.href
-          : typeof window === "undefined"
-            ? path
-            : `${window.location.origin}${path}`;
+      const url = localPlanRouteUrl(localPlanSlug ?? "");
       return buildPlanAgentContext({ bundle, documentHtml, url });
     }
     const base = bundle.plan.kind === "recap" ? "recaps" : "plans";
@@ -3345,22 +3362,15 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
     const url =
       typeof window === "undefined" ? path : `${window.location.origin}${path}`;
     return buildPlanAgentContext({ bundle, documentHtml, url });
-  }, [
-    bundle,
-    documentHtml,
-    localPlanBridgeUrl,
-    localPlanMode,
-    localPlanSlug,
-    selectedId,
-  ]);
+  }, [bundle, documentHtml, localPlanMode, localPlanSlug, selectedId]);
 
   const planShareUrl = useMemo(() => {
     if (typeof window === "undefined") return undefined;
-    if (localPlanMode) return window.location.href;
+    if (localPlanMode) return localPlanRouteUrl(localPlanSlug ?? "");
     if (!selectedId) return undefined;
     const base = bundle?.plan.kind === "recap" ? "recaps" : "plans";
     return `${window.location.origin}${appPath(`/${base}/${selectedId}`)}`;
-  }, [bundle?.plan.kind, localPlanMode, selectedId]);
+  }, [bundle?.plan.kind, localPlanMode, localPlanSlug, selectedId]);
 
   useEffect(() => {
     const onSidebarState = (event: Event) => {
@@ -3727,8 +3737,14 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
         html: localBundle.html || localBundle.plan.html || documentHtml,
         json: localBundle,
         mdx,
-        path: localBundle.path ?? window.location.pathname,
-        url: localBundle.url ?? window.location.href,
+        path:
+          localBundle.path ??
+          (localPlanSlug
+            ? localPlanRoutePath(localPlanSlug)
+            : window.location.pathname),
+        url:
+          localBundle.url ??
+          (localPlanSlug ? localPlanRouteUrl(localPlanSlug) : planShareUrl),
       };
     }
     const result = await exportPlan.refetch();
@@ -3737,7 +3753,14 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
       throw new Error("Plan export was not available yet.");
     }
     return data;
-  }, [bundle, documentHtml, exportPlan, localPlanMode]);
+  }, [
+    bundle,
+    documentHtml,
+    exportPlan,
+    localPlanMode,
+    localPlanSlug,
+    planShareUrl,
+  ]);
 
   const syncPlanToDesktopFolder = useCallback(
     async (options: { choose?: boolean; quiet?: boolean } = {}) => {

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -10,7 +10,7 @@ import {
   type ReactNode,
 } from "react";
 import { Link, useLocation, useNavigate, useParams } from "react-router";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   IconAt,
   IconArrowLeft,
@@ -182,6 +182,7 @@ import { cn } from "@/lib/utils";
 import {
   getDesktopPlanFiles,
   type DesktopPlanFilesFolder,
+  type PlanMdxFolder,
 } from "@/lib/desktop-plan-files";
 import { syncLocalControlResources } from "@/lib/local-control-resources";
 import { planDocumentTitle } from "@/lib/plan-document-title";
@@ -216,6 +217,8 @@ import type {
   PlanContent,
   PlanContentPatch,
 } from "@shared/plan-content";
+import { mimeTypeFromFilename } from "@shared/plan-assets";
+import { parsePlanMdxFolder } from "../../server/plan-mdx";
 
 function GoogleLogoIcon({ className }: { className?: string }) {
   return (
@@ -462,15 +465,196 @@ type LocalPlanBundle = PlanBundle & {
   path?: string;
   url?: string;
   html?: string;
-  mdx?: {
-    "plan.mdx": string;
-    "canvas.mdx"?: string;
-    "prototype.mdx"?: string;
-    ".plan-state.json"?: string;
-  };
+  mdx?: PlanMdxFolder;
 };
 type PlanBundleWithHtml = (PlanBundle & { html?: string }) | LocalPlanBundle;
 type PlanCommentItem = PlanBundle["comments"][number];
+
+type LocalPlanBridgePayload = {
+  ok?: boolean;
+  version?: number;
+  source?: string;
+  localOnly?: boolean;
+  slug?: string;
+  dir?: string;
+  title?: string;
+  brief?: string;
+  kind?: PlanKind;
+  updatedAt?: string;
+  files?: string[];
+  mdx?: PlanMdxFolder;
+  error?: string;
+};
+
+function assertLocalBridgeUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("Local plan bridge URL is invalid.");
+  }
+  const allowedHosts = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+  if (!["http:", "https:"].includes(url.protocol)) {
+    throw new Error("Local plan bridge must use HTTP on localhost.");
+  }
+  if (!allowedHosts.has(url.hostname)) {
+    throw new Error("Local plan bridge must point to localhost.");
+  }
+  return url.toString();
+}
+
+function localPlanAssetDataUrl(
+  url: string | undefined,
+  assets: Record<string, string> | undefined,
+): string | undefined {
+  if (!url || !assets) return url;
+  const match = url.match(/^(?:\.\/)?assets\/(.+)$/);
+  const filename = match?.[1];
+  if (!filename) return url;
+  const base64 = assets[filename];
+  if (!base64) return url;
+  const mime = mimeTypeFromFilename(filename);
+  if (!mime) return url;
+  return `data:${mime};base64,${base64}`;
+}
+
+function inlineLocalPlanAssets(
+  content: PlanContent,
+  assets: Record<string, string> | undefined,
+): PlanContent {
+  if (!assets || Object.keys(assets).length === 0) return content;
+  const rewriteBlocks = (blocks: PlanBlock[]): PlanBlock[] =>
+    blocks.map((block): PlanBlock => {
+      if (block.type === "image") {
+        return {
+          ...block,
+          data: {
+            ...block.data,
+            url: localPlanAssetDataUrl(block.data.url, assets),
+            assetId: undefined,
+          },
+        };
+      }
+      if (block.type === "tabs") {
+        return {
+          ...block,
+          data: {
+            ...block.data,
+            tabs: block.data.tabs.map((tab) => ({
+              ...tab,
+              blocks: rewriteBlocks(tab.blocks),
+            })),
+          },
+        };
+      }
+      if (block.type === "columns") {
+        return {
+          ...block,
+          data: {
+            ...block.data,
+            columns: block.data.columns.map((column) => ({
+              ...column,
+              blocks: rewriteBlocks(column.blocks),
+            })),
+          },
+        };
+      }
+      return block;
+    });
+  return { ...content, blocks: rewriteBlocks(content.blocks) };
+}
+
+function countLocalPlanBlocks(blocks: PlanBlock[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  const visitBlocks = (items: PlanBlock[]) => {
+    for (const block of items) {
+      counts[block.type] = (counts[block.type] ?? 0) + 1;
+      if (block.type === "tabs") {
+        for (const tab of block.data.tabs) visitBlocks(tab.blocks);
+      } else if (block.type === "columns") {
+        for (const column of block.data.columns) visitBlocks(column.blocks);
+      }
+    }
+  };
+  visitBlocks(blocks);
+  return counts;
+}
+
+async function fetchLocalPlanBridgeBundle(
+  bridgeUrl: string,
+  fallbackSlug: string,
+): Promise<LocalPlanBundle> {
+  const safeUrl = assertLocalBridgeUrl(bridgeUrl);
+  const response = await fetch(safeUrl, { cache: "no-store" });
+  const payload = (await response
+    .json()
+    .catch(() => null)) as LocalPlanBridgePayload | null;
+  if (!response.ok || !payload?.ok) {
+    throw new Error(
+      payload?.error ||
+        `Local plan bridge returned ${response.status || "an error"}.`,
+    );
+  }
+  if (
+    payload.source !== "agent-native-local-bridge" ||
+    !payload.mdx?.["plan.mdx"]
+  ) {
+    throw new Error("Local plan bridge response was not a Plan MDX folder.");
+  }
+
+  const rawContent = await parsePlanMdxFolder(payload.mdx, {
+    salvageInvalidBlocks: payload.kind === "recap",
+  });
+  const content = inlineLocalPlanAssets(rawContent, payload.mdx["assets/"]);
+  const now = payload.updatedAt || new Date().toISOString();
+  const slug = payload.slug || fallbackSlug || "local-plan";
+  const kind = payload.kind === "recap" ? "recap" : "plan";
+  const title = content.title || payload.title || slug;
+  const brief = content.brief || payload.brief || "Local files preview.";
+  const url =
+    typeof window === "undefined"
+      ? `/local-plans/${slug}`
+      : window.location.href;
+  const bundle: LocalPlanBundle = {
+    plan: {
+      id: `local-${slug}`,
+      title,
+      brief,
+      kind,
+      status: "review",
+      source: "imported",
+      repoPath: payload.dir ?? null,
+      currentFocus: "local-files preview",
+      html: null,
+      markdown: payload.mdx["plan.mdx"],
+      content,
+      createdAt: now,
+      updatedAt: now,
+      approvedAt: null,
+    },
+    access: {
+      role: "viewer",
+      ownerEmail: null,
+      orgId: null,
+      visibility: "private",
+    },
+    sections: [],
+    comments: [],
+    events: [],
+    summary: {
+      sectionCounts: countLocalPlanBlocks(content.blocks),
+      commentCount: 0,
+      openCommentCount: 0,
+    },
+    localOnly: true,
+    slug,
+    folder: payload.dir ?? slug,
+    path: `/local-plans/${encodeURIComponent(slug)}`,
+    url,
+    mdx: payload.mdx,
+  };
+  return bundle;
+}
 
 type CommentThread = {
   id: string;
@@ -2476,17 +2660,47 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
   const commentMutationPendingRef = useRef(false);
   const { session, isLoading: sessionLoading } = useSession();
   const localPlanMode = Boolean(localPlanSlug);
+  const routeSearchParams = useMemo(
+    () => new URLSearchParams(location.search),
+    [location.search],
+  );
+  const localPlanBridgeUrl = localPlanMode
+    ? routeSearchParams.get("bridge")
+    : null;
   const routeSelectedId = params.id;
+  const localPlanBridgeQuery = useQuery<LocalPlanBundle>({
+    queryKey: ["local-plan-bridge", localPlanSlug, localPlanBridgeUrl],
+    enabled: localPlanMode && Boolean(localPlanSlug && localPlanBridgeUrl),
+    refetchOnWindowFocus: false,
+    queryFn: () =>
+      fetchLocalPlanBridgeBundle(localPlanBridgeUrl ?? "", localPlanSlug ?? ""),
+  });
   const localPlanQuery = useActionQuery<LocalPlanBundle>(
     "get-local-plan-folder",
     { slug: localPlanSlug ?? "" },
     {
-      enabled: localPlanMode && Boolean(localPlanSlug),
+      enabled: localPlanMode && Boolean(localPlanSlug) && !localPlanBridgeUrl,
       refetchInterval: false,
     },
   );
+  const localPlanData = localPlanBridgeUrl
+    ? localPlanBridgeQuery.data
+    : localPlanQuery.data;
+  const localPlanError = localPlanBridgeUrl
+    ? localPlanBridgeQuery.error
+    : localPlanQuery.error;
+  const localPlanLoading = localPlanBridgeUrl
+    ? localPlanBridgeQuery.isLoading
+    : localPlanQuery.isLoading;
+  const localPlanFetching = localPlanBridgeUrl
+    ? localPlanBridgeQuery.isFetching
+    : localPlanQuery.isFetching;
+  const refetchLocalPlan = useCallback(() => {
+    if (localPlanBridgeUrl) return localPlanBridgeQuery.refetch();
+    return localPlanQuery.refetch();
+  }, [localPlanBridgeQuery, localPlanBridgeUrl, localPlanQuery]);
   const selectedId = localPlanMode
-    ? (localPlanQuery.data?.plan.id ??
+    ? (localPlanData?.plan.id ??
       (localPlanSlug ? `local-${localPlanSlug}` : undefined))
     : routeSelectedId;
   const plansQuery = usePlans({
@@ -2560,10 +2774,6 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
     session,
     sessionLoading,
   ]);
-  const routeSearchParams = useMemo(
-    () => new URLSearchParams(location.search),
-    [location.search],
-  );
   const prototypeOnly = useMemo(() => {
     return routeSearchParams.get("prototype") === "1";
   }, [routeSearchParams]);
@@ -2596,7 +2806,15 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
     localPlanMode ? undefined : selectedId,
     commentMutationPendingRef,
   );
-  const bundle = localPlanMode ? localPlanQuery.data : planQuery.data;
+  const bundle = localPlanMode ? localPlanData : planQuery.data;
+  const localPlanDisplayFolder =
+    localPlanMode &&
+    bundle &&
+    "folder" in bundle &&
+    typeof bundle.folder === "string" &&
+    bundle.folder
+      ? bundle.folder
+      : (localPlanSlug ?? "local plan files");
   const planAccessStatusQuery = usePlanAccessStatus(
     selectedId,
     Boolean(selectedId && !bundle && !localPlanMode),
@@ -2611,8 +2829,7 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
   const showLocalPlanLoadError = Boolean(
     localPlanMode &&
     !bundle &&
-    (localPlanQuery.isError ||
-      (!localPlanQuery.isLoading && !localPlanQuery.isFetching)),
+    (Boolean(localPlanError) || (!localPlanLoading && !localPlanFetching)),
   );
   const showInitialPlanSkeleton = Boolean(
     selectedId && !bundle && !showPlanLoadError && !showLocalPlanLoadError,
@@ -3116,9 +3333,11 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
         `/local-plans/${encodeURIComponent(localPlanSlug ?? "")}`,
       );
       const url =
-        typeof window === "undefined"
-          ? path
-          : `${window.location.origin}${path}`;
+        typeof window !== "undefined" && localPlanBridgeUrl
+          ? window.location.href
+          : typeof window === "undefined"
+            ? path
+            : `${window.location.origin}${path}`;
       return buildPlanAgentContext({ bundle, documentHtml, url });
     }
     const base = bundle.plan.kind === "recap" ? "recaps" : "plans";
@@ -3126,7 +3345,14 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
     const url =
       typeof window === "undefined" ? path : `${window.location.origin}${path}`;
     return buildPlanAgentContext({ bundle, documentHtml, url });
-  }, [bundle, documentHtml, localPlanMode, localPlanSlug, selectedId]);
+  }, [
+    bundle,
+    documentHtml,
+    localPlanBridgeUrl,
+    localPlanMode,
+    localPlanSlug,
+    selectedId,
+  ]);
 
   const planShareUrl = useMemo(() => {
     if (typeof window === "undefined") return undefined;
@@ -4694,9 +4920,9 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
             />
           ) : showLocalPlanLoadError ? (
             <LocalPlanLoadError
-              error={localPlanQuery.error}
+              error={localPlanError}
               slug={localPlanSlug ?? ""}
-              onRetry={() => void localPlanQuery.refetch()}
+              onRetry={() => void refetchLocalPlan()}
             />
           ) : showPlanLoadError ? (
             <PlanLoadError
@@ -5197,6 +5423,15 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
                     onPointerDown={handleNativeReaderPointerDown}
                     onPointerUp={handleNativeReaderPointerUp}
                   >
+                    {localPlanMode ? (
+                      <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center gap-2 px-6 pt-6 text-sm text-muted-foreground">
+                        <Badge variant="secondary">Local-files mode</Badge>
+                        <span>
+                          Reading {localPlanDisplayFolder} through localhost. No
+                          hosted database writes or sharing.
+                        </span>
+                      </div>
+                    ) : null}
                     <PlanContentRenderer
                       key={bundle.plan.id}
                       content={bundle.plan.content}

--- a/templates/plan/server/lib/plan-assets.ts
+++ b/templates/plan/server/lib/plan-assets.ts
@@ -16,31 +16,17 @@ import { randomUUID } from "node:crypto";
 import { and, eq, sum } from "drizzle-orm";
 import { getDb, schema } from "../db/index.js";
 import { uploadFile } from "@agent-native/core/file-upload";
+import {
+  PLAN_ASSET_MAX_SINGLE_BYTES,
+  PLAN_ASSET_MAX_TOTAL_BYTES,
+  mimeTypeFromFilename,
+} from "../../shared/plan-assets.js";
 
-/** 2 MB in bytes. */
-export const PLAN_ASSET_MAX_SINGLE_BYTES = 2 * 1024 * 1024;
-
-/** 10 MB in bytes. */
-export const PLAN_ASSET_MAX_TOTAL_BYTES = 10 * 1024 * 1024;
-
-/** Allowed filename extensions → MIME types. */
-const EXT_MIME: Record<string, string> = {
-  png: "image/png",
-  jpg: "image/jpeg",
-  jpeg: "image/jpeg",
-  gif: "image/gif",
-  webp: "image/webp",
-  svg: "image/svg+xml",
-};
-
-/**
- * Derive the MIME type from a filename extension.
- * Returns `null` for unsupported/disallowed extensions (reject on null).
- */
-export function mimeTypeFromFilename(filename: string): string | null {
-  const ext = filename.split(".").pop()?.toLowerCase() ?? "";
-  return EXT_MIME[ext] ?? null;
-}
+export {
+  PLAN_ASSET_MAX_SINGLE_BYTES,
+  PLAN_ASSET_MAX_TOTAL_BYTES,
+  mimeTypeFromFilename,
+} from "../../shared/plan-assets.js";
 
 /** The route prefix under which plan assets are served. */
 export const PLAN_ASSET_ROUTE_PREFIX = "/_agent-native/plan-asset";

--- a/templates/plan/server/lib/plan-connector-catalog.ts
+++ b/templates/plan/server/lib/plan-connector-catalog.ts
@@ -1,0 +1,62 @@
+/**
+ * Curated connector catalog for hosted multi-tenant Plan deployments.
+ *
+ * External coding agents (Claude Code, Codex, Cursor, etc.) connecting via MCP
+ * see only these tools plus the builtin cross-app tools (list_apps, open_app,
+ * ask_app, create_embed_session). Tools outside this list are not callable.
+ *
+ * Callers who need the full surface (db-exec, seed-*, extension tools, etc.)
+ * can opt up with `agent-native connect --full-catalog`.
+ *
+ * EXCLUDED intentionally:
+ *   - seed-kitchen-sink, seed-vertical-tabs  (destructive demo scripts)
+ *   - get-local-plan-folder                  (filesystem path, not useful remotely)
+ *   - context-manifest-get/pin/evict/restore/report  (context-xray internals)
+ *   - visualize-plan                         (internal alias, superseded)
+ */
+export const PLAN_CONNECTOR_CATALOG: string[] = [
+  // Plan CRUD
+  "create-visual-plan",
+  "create-ui-plan",
+  "create-prototype-plan",
+  "create-plan-design",
+  "create-visual-questions",
+  "create-visual-recap",
+  "get-visual-plan",
+  "list-visual-plans",
+  "update-visual-plan",
+  "get-plan-blocks",
+  "get-plan-feedback",
+  "consume-plan-feedback",
+  "reply-to-plan-comment",
+  "resolve-plan-comment",
+  "delete-plan-comment",
+  // Plan versioning
+  "list-plan-versions",
+  "get-plan-version",
+  "restore-plan-version",
+  // Plan source / export
+  "read-visual-plan-source",
+  "export-visual-plan",
+  "import-visual-plan-source",
+  "patch-visual-plan-source",
+  // Plan publish & convert
+  "publish-visual-plan",
+  "convert-visual-plan-to-prototype",
+  // Record recap
+  "record-recap-usage",
+  // Sharing
+  "set-resource-visibility",
+  "share-resource",
+  "unshare-resource",
+  "list-resource-shares",
+  // Media
+  "upload-image",
+  // Navigation & screen
+  "navigate",
+  "view-screen",
+  // Automations (users configure plan event notifications from external agents)
+  "manage-automations",
+  // Tool discovery
+  "tool-search",
+];

--- a/templates/plan/server/lib/plan-connector-catalog.ts
+++ b/templates/plan/server/lib/plan-connector-catalog.ts
@@ -5,8 +5,10 @@
  * see only these tools plus the builtin cross-app tools (list_apps, open_app,
  * ask_app, create_embed_session). Tools outside this list are not callable.
  *
- * Callers who need the full surface (db-exec, seed-*, extension tools, etc.)
- * can opt up with `agent-native connect --full-catalog`.
+ * Callers who need every action registered by this Plan MCP mount can opt up
+ * with `agent-native connect --full-catalog`. That bypasses this curated
+ * catalog tier, but it still does not add generic framework/dev/local tools
+ * that this hosted Plan MCP server intentionally never mounts.
  *
  * EXCLUDED intentionally:
  *   - seed-kitchen-sink, seed-vertical-tabs  (destructive demo scripts)

--- a/templates/plan/server/plan-mcp-pr-visual-recap.spec.ts
+++ b/templates/plan/server/plan-mcp-pr-visual-recap.spec.ts
@@ -11,13 +11,25 @@ const PR_VISUAL_RECAP_MCP_TOOLS = [
 describe("Plan MCP PR visual recap catalog", () => {
   it("keeps the PR visual recap publishing tools registered and exposed", () => {
     const planRoot = process.cwd();
+    const connectorCatalogSource = readFileSync(
+      join(planRoot, "server", "lib", "plan-connector-catalog.ts"),
+      "utf8",
+    );
+    const mcpPluginSource = readFileSync(
+      join(planRoot, "server", "plugins", "00-mcp.ts"),
+      "utf8",
+    );
     const agentChatSource = readFileSync(
       join(planRoot, "server", "plugins", "agent-chat.ts"),
       "utf8",
     );
 
+    expect(mcpPluginSource).toContain("mountMCP");
+    expect(mcpPluginSource).toContain("PLAN_CONNECTOR_CATALOG");
+    expect(agentChatSource).toContain("disableMcp: true");
+
     for (const tool of PR_VISUAL_RECAP_MCP_TOOLS) {
-      expect(agentChatSource).toContain(`"${tool}"`);
+      expect(connectorCatalogSource).toContain(`"${tool}"`);
     }
 
     expect(existsSync(join(planRoot, "actions", "get-plan-blocks.ts"))).toBe(

--- a/templates/plan/server/plan-mdx.ts
+++ b/templates/plan/server/plan-mdx.ts
@@ -1,5 +1,4 @@
 import matter from "gray-matter";
-import prettier from "prettier";
 import { unified } from "unified";
 import remarkMdx from "remark-mdx";
 import remarkParse from "remark-parse";
@@ -38,7 +37,7 @@ import {
   PLAN_ASSET_MAX_SINGLE_BYTES,
   PLAN_ASSET_MAX_TOTAL_BYTES,
   mimeTypeFromFilename,
-} from "./lib/plan-assets.js";
+} from "../shared/plan-assets.js";
 
 // Server-side plan block registry. Registered specs (currently the editable
 // callout) drive serialize/parse via the registry; every other block type still
@@ -340,6 +339,7 @@ function mdxProcessor() {
 
 async function formatMdx(source: string): Promise<string> {
   try {
+    const prettier = await import("prettier");
     return await prettier.format(source.trim() + "\n", { parser: "mdx" });
   } catch {
     return source.trim() + "\n";
@@ -496,6 +496,35 @@ function frontmatter(data: Record<string, unknown>): string {
     );
   }
   return `---\n${lines.join("\n")}\n---\n\n`;
+}
+
+function parseSimpleFrontmatter(source: string): {
+  data: Record<string, unknown>;
+  content: string;
+} {
+  if (!source.startsWith("---\n")) return { data: {}, content: source };
+
+  const end = source.indexOf("\n---", 4);
+  if (end < 0) return { data: {}, content: source };
+
+  const raw = source.slice(4, end).trim();
+  const content = source.slice(end + 4).replace(/^\r?\n/, "");
+  const data: Record<string, unknown> = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!match) continue;
+    const value = match[2].trim();
+    if (!value) {
+      data[match[1]] = "";
+      continue;
+    }
+    try {
+      data[match[1]] = JSON.parse(value);
+    } catch {
+      data[match[1]] = value.replace(/^['"]|['"]$/g, "").trim();
+    }
+  }
+  return { data, content };
 }
 
 function visualUrlForMdx(input: Pick<ExportPlanMdxInput, "planId" | "url">) {
@@ -1340,7 +1369,7 @@ export async function parsePlanMdxFolder(
   options: { salvageInvalidBlocks?: boolean } = {},
 ): Promise<PlanContent> {
   const files = planMdxFileSchema.parse(folder);
-  const parsedMatter = matter(files["plan.mdx"]);
+  const parsedMatter = parseSimpleFrontmatter(files["plan.mdx"]);
   const planTree = parseMdx(parsedMatter.content);
   const blocks = parseBlocksFromNodes(planTree.children, "plan-block");
 

--- a/templates/plan/server/plugins/00-mcp.ts
+++ b/templates/plan/server/plugins/00-mcp.ts
@@ -1,0 +1,20 @@
+import { loadActionsFromStaticRegistry } from "@agent-native/core/server";
+import { mountMCP } from "@agent-native/core/mcp";
+import actionsRegistry from "../../.generated/actions-registry.js";
+import { PLAN_CONNECTOR_CATALOG } from "../lib/plan-connector-catalog.js";
+
+export default function planMcpPlugin(nitroApp: any) {
+  const actions = loadActionsFromStaticRegistry(actionsRegistry);
+
+  mountMCP(nitroApp, {
+    name: "Plan",
+    title: "Agent-Native Plan",
+    appId: "plan",
+    description:
+      "Create, review, update, publish, and export Agent-Native visual plans.",
+    websiteUrl: "https://plan.agent-native.com",
+    actions,
+    productionActions: actions,
+    connectorCatalog: PLAN_CONNECTOR_CATALOG,
+  });
+}

--- a/templates/plan/server/plugins/agent-chat.ts
+++ b/templates/plan/server/plugins/agent-chat.ts
@@ -6,6 +6,7 @@ import { getOrgContext } from "@agent-native/core/org";
 import { registerEvent } from "@agent-native/core/event-bus";
 import { z } from "zod";
 import actionsRegistry from "../../.generated/actions-registry.js";
+import { PLAN_CONNECTOR_CATALOG } from "../lib/plan-connector-catalog.js";
 import { resolvePlanAnonymousOwner } from "../lib/public-plans.js";
 
 // ---------------------------------------------------------------------------
@@ -105,74 +106,13 @@ registerEvent({
   },
 });
 
-/**
- * Curated connector catalog for hosted multi-tenant deployments.
- *
- * Active when AGENT_NATIVE_CONNECTOR_CATALOG=1 is set (hosted plan.agent-native.com).
- * External coding agents (Claude Code, Codex, Cursor, etc.) connecting via MCP
- * see only these tools plus the builtin cross-app tools (list_apps, open_app,
- * ask_app, create_embed_session). Tools outside this list are not callable.
- *
- * Callers who need the full surface (db-exec, seed-*, extension tools, etc.)
- * can opt up with `agent-native connect --full-catalog`.
- *
- * EXCLUDED intentionally:
- *   - seed-kitchen-sink, seed-vertical-tabs  (destructive demo scripts)
- *   - get-local-plan-folder                  (filesystem path, not useful remotely)
- *   - context-manifest-get/pin/evict/restore/report  (context-xray internals)
- *   - visualize-plan                         (internal alias, superseded)
- */
-export const PLAN_CONNECTOR_CATALOG = [
-  // Plan CRUD
-  "create-visual-plan",
-  "create-ui-plan",
-  "create-prototype-plan",
-  "create-plan-design",
-  "create-visual-questions",
-  "create-visual-recap",
-  "get-visual-plan",
-  "list-visual-plans",
-  "update-visual-plan",
-  "get-plan-blocks",
-  "get-plan-feedback",
-  "consume-plan-feedback",
-  "reply-to-plan-comment",
-  "resolve-plan-comment",
-  "delete-plan-comment",
-  // Plan versioning
-  "list-plan-versions",
-  "get-plan-version",
-  "restore-plan-version",
-  // Plan source / export
-  "read-visual-plan-source",
-  "export-visual-plan",
-  "import-visual-plan-source",
-  "patch-visual-plan-source",
-  // Plan publish & convert
-  "publish-visual-plan",
-  "convert-visual-plan-to-prototype",
-  // Record recap
-  "record-recap-usage",
-  // Sharing
-  "set-resource-visibility",
-  "share-resource",
-  "unshare-resource",
-  "list-resource-shares",
-  // Media
-  "upload-image",
-  // Navigation & screen
-  "navigate",
-  "view-screen",
-  // Automations (users configure plan event notifications from external agents)
-  "manage-automations",
-  // Tool discovery
-  "tool-search",
-];
-
-export default createAgentChatPlugin({
+const planAgentChatOptions = {
   appId: "plan",
   actions: loadActionsFromStaticRegistry(actionsRegistry),
   anonymousOwner: resolvePlanAnonymousOwner,
   resolveOrgId: async (event) => (await getOrgContext(event)).orgId,
   connectorCatalog: PLAN_CONNECTOR_CATALOG,
-});
+  disableMcp: true,
+};
+
+export default createAgentChatPlugin(planAgentChatOptions);

--- a/templates/plan/shared/plan-assets.ts
+++ b/templates/plan/shared/plan-assets.ts
@@ -1,0 +1,26 @@
+/** Size and MIME rules for portable Plan image assets. */
+
+/** 2 MB in bytes. */
+export const PLAN_ASSET_MAX_SINGLE_BYTES = 2 * 1024 * 1024;
+
+/** 10 MB in bytes. */
+export const PLAN_ASSET_MAX_TOTAL_BYTES = 10 * 1024 * 1024;
+
+/** Allowed filename extensions -> MIME types. */
+const EXT_MIME: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+};
+
+/**
+ * Derive the MIME type from a filename extension.
+ * Returns `null` for unsupported/disallowed extensions.
+ */
+export function mimeTypeFromFilename(filename: string): string | null {
+  const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+  return EXT_MIME[ext] ?? null;
+}


### PR DESCRIPTION
## Summary
- adds a localhost bridge for local Plan files so hosted Plan UI can render local MDX without hosted database writes
- updates visual plan/recap CLI/docs/skills copy for local vs hosted mode and syncs marketplace/workspace skill bundles
- includes concurrent branch updates for agent tooling, observational memory, eval/blueprint docs, and related package changes

## Validation
- pnpm --dir templates/plan build
- pnpm --dir templates/plan typecheck
- pnpm --dir packages/core exec tsc -p tsconfig.cli.json --noEmit
- pnpm --dir packages/core exec vitest --run src/cli/skills.sync.spec.ts src/cli/plan-local.spec.ts
- pnpm --dir packages/core exec vitest --run src/cli/plan-install.spec.ts src/cli/skills.sync.spec.ts src/cli/plan-local.spec.ts
- pnpm --dir packages/core exec vitest --run src/agent/observational-memory/observer.spec.ts
- pnpm --dir packages/docs exec vitest run app/vite-sitemap-plugin.spec.ts
- pnpm --dir templates/clips test
- pnpm fmt:check
- pnpm guard:no-localhost-fallback
- pnpm guard:no-env-credentials
- pnpm guard:workspace-skills
- pnpm guard:plan-marketplace
- Browser smoke: `plan local serve` route rendered the hosted Plan UI with local-files badge, path, wireframe, and diagram; invalid bridge token returned 403

## Note
- Full local `pnpm prep` did not complete because the packages/core Vitest worker OOMed under the full parallel prep run after typecheck/fmt/guards were clean and 420/421 core test files had passed. Focused checks above passed; CI should be the full gate.

<!-- FUSION_KEEP_START -->
<!-- FUSION_SCREENSHOTS_START -->
### Verified

| agent chat panel opens with composer visible | clean share URL omits bridge and token |
| --- | --- |
| The chat sidebar is open and shows the message composer, suggestion buttons, and toolbar controls without any crash state. | Error state is visible while the evaluated share URL comparison shows the clean route URL without bridge or token parameters. |
| <img src="https://cdn.builder.io/api/v1/image/assets%2FTEMP%2Ftoolu_vrtx_01MZppEgu9nZAmBy4JEzuHCR-frame-00003" width="420" alt="agent chat panel opens with composer visible" /> | <img src="https://cdn.builder.io/api/v1/image/assets%2FTEMP%2Ftoolu_vrtx_01KPUxhePXSPTAwYG2uL2tpo-frame-00000" width="420" alt="clean share URL omits bridge and token" /> |

| bridge without port is rejected | wrong pathname is rejected |
| --- | --- |
| The error message confirms the bridge URL must use an explicit localhost port, with Retry and Plans actions visible. | The page shows the pathname validation message stating the bridge must point to /local-plan.json. |
| <img src="https://cdn.builder.io/api/v1/image/assets%2FTEMP%2Ftoolu_vrtx_01KPUxhePXSPTAwYG2uL2tpo-frame-00003" width="420" alt="bridge without port is rejected" /> | <img src="https://cdn.builder.io/api/v1/image/assets%2FTEMP%2Ftoolu_vrtx_01KPUxhePXSPTAwYG2uL2tpo-frame-00004" width="420" alt="wrong pathname is rejected" /> |

| HTTPS bridge is rejected |  |
| --- | --- |
| The error message confirms the bridge URL must use HTTP on localhost. |  |
| <img src="https://cdn.builder.io/api/v1/image/assets%2FTEMP%2Ftoolu_vrtx_01KPUxhePXSPTAwYG2uL2tpo-frame-00006" width="420" alt="HTTPS bridge is rejected" /> |  |

<!-- FUSION_SCREENSHOTS_END -->
<!-- FUSION_KEEP_END -->