### PR TITLE
Fix Oauth redirect losing app prefix

### DIFF
--- a/.changeset/workspace-dev-redirect-prefix.md
+++ b/.changeset/workspace-dev-redirect-prefix.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix workspace dev gateway losing the app prefix on root-relative redirects (e.g. Google OAuth flows). Path-only redirect `Location` headers are now rewritten to include the `/{app.id}` mount prefix, matching the repo `dev-lazy` gateway.

--- a/packages/core/src/cli/gateway-helpers.ts
+++ b/packages/core/src/cli/gateway-helpers.ts
@@ -1,0 +1,53 @@
+/**
+ * When an app returns a redirect to a root-relative path that doesn't already
+ * include the app prefix, prepend it. This handles the common case where a
+ * framework server-side redirect uses a plain path like "/" or "/login"
+ * without knowing it's mounted at "/{appId}" by the gateway.
+ *
+ * Only rewrites path-only locations (starting with "/") to avoid touching
+ * absolute URLs (e.g. redirects to Google OAuth or external sites).
+ */
+export function rewriteRedirectLocation(
+  app: { id: string },
+  location: string | undefined,
+): string | undefined {
+  // Leave absolute URLs and protocol-relative URLs (//host/path) untouched.
+  if (!location || !location.startsWith("/") || location.startsWith("//"))
+    return location;
+  const prefix = `/${app.id}`;
+  // Strip query/hash before checking the prefix so "/clips?preview=1" and
+  // "/clips#section" are correctly identified as already-prefixed.
+  const suffixStart = location.search(/[?#]/);
+  const pathname =
+    suffixStart === -1 ? location : location.slice(0, suffixStart);
+  const suffix = suffixStart === -1 ? "" : location.slice(suffixStart);
+  if (pathname === prefix || pathname.startsWith(`${prefix}/`)) return location;
+  // Avoid double-slash when the pathname is exactly "/" (e.g. "/?foo=1").
+  return pathname === "/" ? `${prefix}${suffix}` : `${prefix}${location}`;
+}
+
+export function normalizeOrigin(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+export function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -9,6 +9,11 @@ import { fileURLToPath } from "node:url";
 import * as Sentry from "@sentry/node";
 import { extractOAuthStateAppId } from "../shared/oauth-state.js";
 import {
+  normalizeOrigin,
+  rewriteRedirectLocation,
+  escapeHtml,
+} from "./gateway-helpers.js";
+import {
   DEFAULT_WORKSPACE_APP_AUDIENCE,
   workspaceAppAudienceFromPackageJson,
   workspaceAppRouteAccessFromPackageJson,
@@ -81,15 +86,6 @@ const STARTING_APP_RESPONSE_HEADERS: http.OutgoingHttpHeaders = {
   pragma: "no-cache",
   expires: "0",
 };
-
-function normalizeOrigin(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-  try {
-    return new URL(value).origin;
-  } catch {
-    return undefined;
-  }
-}
 
 function workspaceOAuthOrigin(
   env: NodeJS.ProcessEnv,
@@ -529,23 +525,6 @@ function renderStartingApp(app: WorkspaceApp): string {
     </main>
   </body>
 </html>`;
-}
-
-function escapeHtml(value: string): string {
-  return value.replace(/[&<>"']/g, (char) => {
-    switch (char) {
-      case "&":
-        return "&amp;";
-      case "<":
-        return "&lt;";
-      case ">":
-        return "&gt;";
-      case '"':
-        return "&quot;";
-      default:
-        return "&#39;";
-    }
-  });
 }
 
 function renderIndex(apps: WorkspaceApp[]): string {
@@ -1057,7 +1036,16 @@ export async function runWorkspaceDev(
           settled = true;
           clearTimeout(responseTimer);
           app.ready = true;
-          res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+          const statusCode = proxyRes.statusCode ?? 502;
+          const responseHeaders = { ...proxyRes.headers };
+          if (statusCode >= 300 && statusCode < 400) {
+            const rewritten = rewriteRedirectLocation(
+              app,
+              firstHeaderValue(responseHeaders.location),
+            );
+            if (rewritten) responseHeaders.location = rewritten;
+          }
+          res.writeHead(statusCode, responseHeaders);
           proxyRes.pipe(res);
         },
       );

--- a/scripts/dev-lazy.ts
+++ b/scripts/dev-lazy.ts
@@ -12,6 +12,11 @@ import http from "node:http";
 import net from "node:net";
 import path from "node:path";
 import type { Duplex } from "node:stream";
+import {
+  escapeHtml,
+  normalizeOrigin,
+  rewriteRedirectLocation,
+} from "../packages/core/src/cli/gateway-helpers.ts";
 
 interface TemplateApp {
   id: string;
@@ -322,15 +327,6 @@ function devWatcherEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return env;
 }
 
-function normalizeOrigin(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-  try {
-    return new URL(value).origin;
-  } catch {
-    return undefined;
-  }
-}
-
 function workspaceOAuthOrigin(
   env: NodeJS.ProcessEnv,
   gatewayUrl: string,
@@ -415,34 +411,6 @@ function appendAppOutputTail(app: TemplateApp, output: string): void {
       : next;
 }
 
-/**
- * When a template app returns a redirect to a root-relative path that doesn't
- * already include the app prefix, prepend it. This handles the common case
- * where a framework server-side redirect uses a plain path like "/" or
- * "/login" without knowing it's mounted at "/{app.id}" by the gateway.
- *
- * Only rewrites path-only locations (starting with "/") to avoid touching
- * absolute URLs (e.g. redirects to Google OAuth or external sites).
- */
-function rewriteRedirectLocation(
-  app: TemplateApp,
-  location: string | undefined,
-): string | undefined {
-  // Leave absolute URLs and protocol-relative URLs (//host/path) untouched.
-  if (!location || !location.startsWith("/") || location.startsWith("//"))
-    return location;
-  const prefix = `/${app.id}`;
-  // Strip query/hash before checking the prefix so "/clips?preview=1" and
-  // "/clips#section" are correctly identified as already-prefixed.
-  const suffixStart = location.search(/[?#]/);
-  const pathname =
-    suffixStart === -1 ? location : location.slice(0, suffixStart);
-  const suffix = suffixStart === -1 ? "" : location.slice(suffixStart);
-  if (pathname === prefix || pathname.startsWith(`${prefix}/`)) return location;
-  // Avoid double-slash when the pathname is exactly "/" (e.g. "/?foo=1").
-  return pathname === "/" ? `${prefix}${suffix}` : `${prefix}${location}`;
-}
-
 function firstHeaderValue(
   value: string | string[] | number | undefined,
 ): string | undefined {
@@ -456,23 +424,6 @@ function wantsHtml(req: http.IncomingMessage): boolean {
   const accept = firstHeaderValue(req.headers.accept);
   if (!accept) return false;
   return accept.includes("text/html");
-}
-
-function escapeHtml(value: string): string {
-  return value.replace(/[&<>"']/g, (char) => {
-    switch (char) {
-      case "&":
-        return "&amp;";
-      case "<":
-        return "&lt;";
-      case ">":
-        return "&gt;";
-      case '"':
-        return "&quot;";
-      default:
-        return "&#39;";
-    }
-  });
 }
 
 function renderStartingApp(app: TemplateApp): string {


### PR DESCRIPTION
Same fix as https://github.com/BuilderIO/agent-native/pull/1062 but for `packages/core/src/cli/workspace-dev.ts`. Plus extracted some function that had the same code 