### PR TITLE
Fix package release build

### DIFF
--- a/.changeset/linkedom-worker-build.md
+++ b/.changeset/linkedom-worker-build.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Avoid bundling native canvas from web content extraction in template SSR builds.

--- a/.changeset/signup-template-tracking.md
+++ b/.changeset/signup-template-tracking.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Add app and template properties to Better Auth signup tracking events.
+Add app/template and agent-native-specific app/template properties to Better Auth signup tracking events.

--- a/packages/core/src/extensions/web-content.ts
+++ b/packages/core/src/extensions/web-content.ts
@@ -1,5 +1,5 @@
 import { Readability } from "@mozilla/readability";
-import { parseHTML } from "linkedom";
+import { parseHTML } from "linkedom/worker";
 import safeRegex from "safe-regex2";
 import TurndownService from "turndown";
 

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -83,12 +83,18 @@ describe("server/auth", () => {
     it("uses explicit app and template environment values", async () => {
       vi.stubEnv("AGENT_NATIVE_APP", "agent-native-mail");
       vi.stubEnv("AGENT_NATIVE_TEMPLATE", "mail");
-      const { resolveSignupTrackingIdentity } =
+      const { resolveSignupTrackingIdentity, resolveSignupTrackingProperties } =
         await import("./better-auth-instance.js");
 
       expect(resolveSignupTrackingIdentity()).toEqual({
         app: "agent-native-mail",
         template: "mail",
+      });
+      expect(resolveSignupTrackingProperties()).toEqual({
+        app: "agent-native-mail",
+        template: "mail",
+        agent_native_app: "agent-native-mail",
+        agent_native_template: "mail",
       });
     });
 

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -272,6 +272,16 @@ export function resolveSignupTrackingIdentity(): {
   };
 }
 
+/** @internal */
+export function resolveSignupTrackingProperties(): Record<string, string> {
+  const identity = resolveSignupTrackingIdentity();
+  return {
+    ...identity,
+    ...(identity.app ? { agent_native_app: identity.app } : {}),
+    ...(identity.template ? { agent_native_template: identity.template } : {}),
+  };
+}
+
 export function shouldSkipEmailVerification(): boolean {
   const value = process.env.AUTH_SKIP_EMAIL_VERIFICATION;
   if (value == null) {
@@ -877,7 +887,7 @@ async function createBetterAuthInstance(
             track(
               "signup",
               {
-                ...resolveSignupTrackingIdentity(),
+                ...resolveSignupTrackingProperties(),
                 auth_provider: "better-auth",
                 auth_user_id: user.id,
               },

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -2681,14 +2681,13 @@ function LocalModeBadge() {
       </TooltipTrigger>
       <TooltipContent align="end" side="bottom" className="max-w-xs p-3">
         <div className="grid gap-1.5">
-          <p className="font-medium leading-5">Private local preview</p>
+          <p className="font-medium leading-5">100% private local mode</p>
           <p className="text-xs leading-5 text-muted-foreground">
-            Nothing is saved to the hosted Plan database. Your plan content
-            stays in local MDX files and this page reads it from your local
-            bridge or local Plan server.
+            Your data is never saved to our backend or seen by us. This page
+            only renders and edits your local MDX files.
           </p>
           <p className="text-xs font-medium leading-5 text-foreground">
-            Click to open the docs.
+            Open docs.
           </p>
         </div>
       </TooltipContent>


### PR DESCRIPTION
## Summary
- switch web content extraction to the canvas-free linkedom worker entry so template SSR builds do not load native canvas
- keep signup tracking properties explicit for both generic and agent-native-specific app/template keys
- preserve the local mode badge with clearer privacy copy

## Verification
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- pnpm --filter clips build
- pnpm -r build
- pnpm prep