### PR TITLE
add auth bypass as env var to make using it as fusion template starter easier

### DIFF
--- a/.agents/skills/authentication/SKILL.md
+++ b/.agents/skills/authentication/SKILL.md
@@ -22,7 +22,7 @@ Auth is powered by **Better Auth** with account-first design. Every new user cre
 | **Production (default)**  | Better Auth with email/password + social providers (Google, GitHub). Organizations built in.                                             |
 | **`AUTH_MODE=local`**     | **Not** a browser auth bypass, and never returns `local@localhost`. It only affects CLI/agent identity: it lets `pnpm action` / the local agent loop auto-bind to the single real signed-in dev user from the `sessions` table (see `scripts/dev-session.ts`). Browser login is unchanged. |
 | **`AUTH_SKIP_EMAIL_VERIFICATION=1`** | QA/preview escape hatch for real email/password accounts. Signup skips email verification and does not send the signup verification email. Local dev/test skips verification by default; set `AUTH_SKIP_EMAIL_VERIFICATION=0` only when testing verification itself. Use `+qa` emails for test accounts. |
-| **`AGENT_NATIVE_SKIP_AUTH=1`** | Skip login/signup entirely — every request runs as one shared user (`AGENT_NATIVE_SKIP_AUTH_EMAIL`, default `dev@local.test`). For cloud previews and internal demos only; not for production with real users. |
+| **`AUTH_DISABLED=true`** | Skip login/signup entirely — every request runs as `dev@local.test`. For local dev, cloud previews, and internal demos only; not for production with real users. |
 | **`ACCESS_TOKEN` / `ACCESS_TOKENS`** | Static bearer fallback for MCP/connect clients that cannot use OAuth. Not browser auth and never a token login page.         |
 | **Custom**                | Pass your own `getSession` to `autoMountAuth(app, { getSession })`.                                                                     |
 

--- a/.agents/skills/authentication/SKILL.md
+++ b/.agents/skills/authentication/SKILL.md
@@ -22,8 +22,8 @@ Auth is powered by **Better Auth** with account-first design. Every new user cre
 | **Production (default)**  | Better Auth with email/password + social providers (Google, GitHub). Organizations built in.                                             |
 | **`AUTH_MODE=local`**     | **Not** a browser auth bypass, and never returns `local@localhost`. It only affects CLI/agent identity: it lets `pnpm action` / the local agent loop auto-bind to the single real signed-in dev user from the `sessions` table (see `scripts/dev-session.ts`). Browser login is unchanged. |
 | **`AUTH_SKIP_EMAIL_VERIFICATION=1`** | QA/preview escape hatch for real email/password accounts. Signup skips email verification and does not send the signup verification email. Local dev/test skips verification by default; set `AUTH_SKIP_EMAIL_VERIFICATION=0` only when testing verification itself. Use `+qa` emails for test accounts. |
+| **`AGENT_NATIVE_SKIP_AUTH=1`** | Skip login/signup entirely — every request runs as one shared user (`AGENT_NATIVE_SKIP_AUTH_EMAIL`, default `dev@local.test`). For cloud previews and internal demos only; not for production with real users. |
 | **`ACCESS_TOKEN` / `ACCESS_TOKENS`** | Static bearer fallback for MCP/connect clients that cannot use OAuth. Not browser auth and never a token login page.         |
-| **`AUTH_DISABLED=true`**  | Skip auth entirely (for apps behind infrastructure-level auth like Cloudflare Access).                                                   |
 | **Custom**                | Pass your own `getSession` to `autoMountAuth(app, { getSession })`.                                                                     |
 
 > **Never** use `local@localhost` as a fallback identity in app code

--- a/.changeset/auth-disabled-bypass.md
+++ b/.changeset/auth-disabled-bypass.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Implement `AUTH_DISABLED` so local dev, preview, and demo deployments can skip login/signup and run all requests as a shared `dev@local.test` user.

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ templates/*/.env.local
 templates/*/.env.*.local
 test-reports/
 *.tsbuildinfo
+
+# Local scaffold/test apps created during development
+my-standalone-app/

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,3 @@ templates/*/.env.local
 templates/*/.env.*.local
 test-reports/
 *.tsbuildinfo
-
-# Local scaffold/test apps created during development
-my-standalone-app/

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -14,12 +14,12 @@ Agent-native uses **Better Auth** by default — every visitor creates an accoun
 
 Auth modes:
 
-| Mode                | When to use                                                             |
-| ------------------- | ----------------------------------------------------------------------- |
-| Better Auth         | Default. Email/password + Google / GitHub social + organizations.       |
-| `AUTH_MODE=local`   | Solo local dev. Forces `getSession()` → `{ email: "local@localhost" }`. |
-| `ACCESS_TOKEN(S)`   | Static MCP/connect bearer fallback only; not browser auth.              |
-| `AGENT_NATIVE_SKIP_AUTH=1` | Skip login/signup; all requests run as one shared user (preview/demo only). |
-| Custom `getSession` | BYOA — Auth.js, Clerk, Lucia, WorkOS, etc.                              |
+| Mode                 | When to use                                                                      |
+| -------------------- | -------------------------------------------------------------------------------- |
+| Better Auth          | Default. Email/password + Google / GitHub social + organizations.                |
+| `AUTH_MODE=local`    | Solo local dev. Forces `getSession()` → `{ email: "local@localhost" }`.          |
+| `ACCESS_TOKEN(S)`    | Static MCP/connect bearer fallback only; not browser auth.                       |
+| `AUTH_DISABLED=true` | Skip login/signup; all requests run as one shared user (local dev/preview only). |
+| Custom `getSession`  | BYOA — Auth.js, Clerk, Lucia, WorkOS, etc.                                       |
 
 See the canonical docs above for the full configuration reference, environment variables (`BETTER_AUTH_SECRET`, `GOOGLE_CLIENT_ID/SECRET`, `GITHUB_CLIENT_ID/SECRET`, `OAUTH_STATE_SECRET`, `A2A_SECRET`, …), the BYOA contract, organizations / orgs, the sign-in-with-return-URL flow, and access-control patterns (`ownableColumns`, `accessFilter`, `resolveAccess`, `assertAccess`).

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -19,7 +19,7 @@ Auth modes:
 | Better Auth         | Default. Email/password + Google / GitHub social + organizations.       |
 | `AUTH_MODE=local`   | Solo local dev. Forces `getSession()` → `{ email: "local@localhost" }`. |
 | `ACCESS_TOKEN(S)`   | Static MCP/connect bearer fallback only; not browser auth.              |
-| `AUTH_DISABLED=1`   | Apps behind infrastructure auth (Cloudflare Access, VPN, etc.).         |
+| `AGENT_NATIVE_SKIP_AUTH=1` | Skip login/signup; all requests run as one shared user (preview/demo only). |
 | Custom `getSession` | BYOA — Auth.js, Clerk, Lucia, WorkOS, etc.                              |
 
 See the canonical docs above for the full configuration reference, environment variables (`BETTER_AUTH_SECRET`, `GOOGLE_CLIENT_ID/SECRET`, `GITHUB_CLIENT_ID/SECRET`, `OAUTH_STATE_SECRET`, `A2A_SECRET`, …), the BYOA contract, organizations / orgs, the sign-in-with-return-URL flow, and access-control patterns (`ownableColumns`, `accessFilter`, `resolveAccess`, `assertAccess`).

--- a/packages/core/docs/content/authentication.md
+++ b/packages/core/docs/content/authentication.md
@@ -15,7 +15,7 @@ Auth is configured automatically via `autoMountAuth(app)` in the auth server plu
 - **Remote MCP OAuth:** Standard OAuth 2.1 for MCP hosts such as Claude Code and ChatGPT connectors.
 - **Custom:** Bring your own auth via `getSession` callback.
 
-Local development uses the same Better Auth flow as production — there is no dev auth bypass, and `getSession()` never falls back to a `local@localhost` sentinel. The first time you load a template the framework auto-creates a throwaway dev account and signs you in, so you are not stuck at a login wall (disable with `AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT=1` to use the normal signup page). Set `AGENT_NATIVE_SKIP_AUTH=1` to skip login/signup entirely and run every request as a shared user — for cloud previews and internal demos only, not production with real users. `AUTH_MODE=local` only affects CLI/agent identity resolution (which signed-in dev user `pnpm action` runs as) — it is not a browser login bypass. Email verification is skipped by default in development (and when no email provider is configured), so signup is just an email + password.
+Local development uses the same Better Auth flow as production — there is no dev auth bypass, and `getSession()` never falls back to a `local@localhost` sentinel. The first time you load a template the framework auto-creates a throwaway dev account and signs you in, so you are not stuck at a login wall (disable with `AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT=1` to use the normal signup page). Set `AUTH_DISABLED=true` (or `AUTH_DISABLED=1`) to skip login/signup entirely and run every request as a shared user — for local dev, cloud previews, and internal demos only, not production with real users. `AUTH_MODE=local` only affects CLI/agent identity resolution (which signed-in dev user `pnpm action` runs as) — it is not a browser login bypass. Email verification is skipped by default in development (and when no email provider is configured), so signup is just an email + password.
 
 ## Better Auth (Default) {#better-auth}
 
@@ -266,17 +266,16 @@ The default `/_agent-native/google/auth-url` route does this automatically — o
 
 ## Environment Variables {#environment-variables}
 
-| Variable                       | Purpose                                                                                                                           |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| `BETTER_AUTH_SECRET`           | Signing key for Better Auth (auto-generated if not set)                                                                           |
-| `AUTH_SKIP_EMAIL_VERIFICATION` | Set to `1` in QA/preview environments to let email/password signups proceed without verification; local dev/test skips by default |
-| `AGENT_NATIVE_SKIP_AUTH`       | Set to `1` to skip login/signup; all requests run as one shared user (preview/demo only — not for production with real users)     |
-| `AGENT_NATIVE_SKIP_AUTH_EMAIL` | Email for the shared user when `AGENT_NATIVE_SKIP_AUTH=1` (default: `dev@local.test`)                                            |
-| `AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT` | Set to `1` to disable localhost auto-sign-in on a fresh dev database                                                    |
-| `GOOGLE_CLIENT_ID`             | Enable Google OAuth                                                                                                               |
-| `GOOGLE_CLIENT_SECRET`         | Google OAuth secret                                                                                                               |
-| `GITHUB_CLIENT_ID`             | Enable GitHub OAuth                                                                                                               |
-| `GITHUB_CLIENT_SECRET`         | GitHub OAuth secret                                                                                                               |
-| `ACCESS_TOKEN`                 | Static bearer fallback for MCP/connect clients; not browser auth                                                                  |
-| `ACCESS_TOKENS`                | Comma-separated static bearer fallbacks for MCP/connect clients; not browser auth                                                 |
-| `A2A_SECRET`                   | Shared secret for JWT-signed A2A cross-app identity verification and, when present, MCP OAuth access-token signing                |
+| Variable                                | Purpose                                                                                                                                      |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET`                    | Signing key for Better Auth (auto-generated if not set)                                                                                      |
+| `AUTH_SKIP_EMAIL_VERIFICATION`          | Set to `1` in QA/preview environments to let email/password signups proceed without verification; local dev/test skips by default            |
+| `AUTH_DISABLED`                         | Set to `true` or `1` to skip login/signup; all requests run as one shared user (local dev/preview only — not for production with real users) |
+| `AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT` | Set to `1` to disable localhost auto-sign-in on a fresh dev database                                                                         |
+| `GOOGLE_CLIENT_ID`                      | Enable Google OAuth                                                                                                                          |
+| `GOOGLE_CLIENT_SECRET`                  | Google OAuth secret                                                                                                                          |
+| `GITHUB_CLIENT_ID`                      | Enable GitHub OAuth                                                                                                                          |
+| `GITHUB_CLIENT_SECRET`                  | GitHub OAuth secret                                                                                                                          |
+| `ACCESS_TOKEN`                          | Static bearer fallback for MCP/connect clients; not browser auth                                                                             |
+| `ACCESS_TOKENS`                         | Comma-separated static bearer fallbacks for MCP/connect clients; not browser auth                                                            |
+| `A2A_SECRET`                            | Shared secret for JWT-signed A2A cross-app identity verification and, when present, MCP OAuth access-token signing                           |

--- a/packages/core/docs/content/authentication.md
+++ b/packages/core/docs/content/authentication.md
@@ -15,7 +15,7 @@ Auth is configured automatically via `autoMountAuth(app)` in the auth server plu
 - **Remote MCP OAuth:** Standard OAuth 2.1 for MCP hosts such as Claude Code and ChatGPT connectors.
 - **Custom:** Bring your own auth via `getSession` callback.
 
-Local development uses the same Better Auth flow as production — there is no dev auth bypass, and `getSession()` never falls back to a `local@localhost` sentinel. The first time you load a template the framework auto-creates a throwaway dev account and signs you in, so you are not stuck at a login wall (disable with `AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT=1` to use the normal signup page). `AUTH_MODE=local` only affects CLI/agent identity resolution (which signed-in dev user `pnpm action` runs as) — it is not a browser login bypass. Email verification is skipped by default in development (and when no email provider is configured), so signup is just an email + password.
+Local development uses the same Better Auth flow as production — there is no dev auth bypass, and `getSession()` never falls back to a `local@localhost` sentinel. The first time you load a template the framework auto-creates a throwaway dev account and signs you in, so you are not stuck at a login wall (disable with `AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT=1` to use the normal signup page). Set `AGENT_NATIVE_SKIP_AUTH=1` to skip login/signup entirely and run every request as a shared user — for cloud previews and internal demos only, not production with real users. `AUTH_MODE=local` only affects CLI/agent identity resolution (which signed-in dev user `pnpm action` runs as) — it is not a browser login bypass. Email verification is skipped by default in development (and when no email provider is configured), so signup is just an email + password.
 
 ## Better Auth (Default) {#better-auth}
 
@@ -270,6 +270,9 @@ The default `/_agent-native/google/auth-url` route does this automatically — o
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
 | `BETTER_AUTH_SECRET`           | Signing key for Better Auth (auto-generated if not set)                                                                           |
 | `AUTH_SKIP_EMAIL_VERIFICATION` | Set to `1` in QA/preview environments to let email/password signups proceed without verification; local dev/test skips by default |
+| `AGENT_NATIVE_SKIP_AUTH`       | Set to `1` to skip login/signup; all requests run as one shared user (preview/demo only — not for production with real users)     |
+| `AGENT_NATIVE_SKIP_AUTH_EMAIL` | Email for the shared user when `AGENT_NATIVE_SKIP_AUTH=1` (default: `dev@local.test`)                                            |
+| `AGENT_NATIVE_DISABLE_AUTO_DEV_ACCOUNT` | Set to `1` to disable localhost auto-sign-in on a fresh dev database                                                    |
 | `GOOGLE_CLIENT_ID`             | Enable Google OAuth                                                                                                               |
 | `GOOGLE_CLIENT_SECRET`         | Google OAuth secret                                                                                                               |
 | `GITHUB_CLIENT_ID`             | Enable GitHub OAuth                                                                                                               |

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1887,10 +1887,9 @@ describe("server/auth", () => {
   });
 
   describe("getSession", () => {
-    it("returns a shared session when AGENT_NATIVE_SKIP_AUTH=1", async () => {
+    it("returns a shared session when AUTH_DISABLED=1", async () => {
       vi.stubEnv("NODE_ENV", "production");
-      vi.stubEnv("AGENT_NATIVE_SKIP_AUTH", "1");
-      delete process.env.AGENT_NATIVE_SKIP_AUTH_EMAIL;
+      vi.stubEnv("AUTH_DISABLED", "1");
       delete process.env.ACCESS_TOKEN;
       delete process.env.ACCESS_TOKENS;
 
@@ -1913,10 +1912,9 @@ describe("server/auth", () => {
       expect(await getSession(event)).toEqual({ email: "dev@local.test" });
     });
 
-    it("honors AGENT_NATIVE_SKIP_AUTH_EMAIL", async () => {
+    it("returns a shared session when AUTH_DISABLED=true", async () => {
       vi.stubEnv("NODE_ENV", "production");
-      vi.stubEnv("AGENT_NATIVE_SKIP_AUTH", "1");
-      vi.stubEnv("AGENT_NATIVE_SKIP_AUTH_EMAIL", "preview@example.com");
+      vi.stubEnv("AUTH_DISABLED", "true");
       delete process.env.ACCESS_TOKEN;
       delete process.env.ACCESS_TOKENS;
 
@@ -1936,7 +1934,7 @@ describe("server/auth", () => {
       const { getSession } = await import("./auth.js");
       const event = createMockEvent();
 
-      expect(await getSession(event)).toEqual({ email: "preview@example.com" });
+      expect(await getSession(event)).toEqual({ email: "dev@local.test" });
     });
 
     it("resolves bearer legacy session tokens for desktop clients", async () => {

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1937,6 +1937,55 @@ describe("server/auth", () => {
       expect(await getSession(event)).toEqual({ email: "dev@local.test" });
     });
 
+    it("prefers custom getSession over AUTH_DISABLED", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("AUTH_DISABLED", "1");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+
+      const authModule = await import("./auth.js");
+      const app = createMockApp();
+      await authModule.autoMountAuth(app, {
+        getSession: async () => ({ email: "custom@auth.com" }),
+      });
+
+      const event = createMockEvent();
+      expect(await authModule.getSession(event)).toEqual({
+        email: "custom@auth.com",
+      });
+    });
+
+    it("falls back to AUTH_DISABLED when custom getSession returns null", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("AUTH_DISABLED", "1");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+
+      const mockExecute = vi.fn().mockResolvedValue({ rows: [] });
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => true,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+      vi.doMock("./better-auth-instance.js", async (importOriginal) => ({
+        ...(await importOriginal<object>()),
+        getBetterAuthSync: () => null,
+      }));
+
+      const authModule = await import("./auth.js");
+      const app = createMockApp();
+      await authModule.autoMountAuth(app, {
+        getSession: async () => null,
+      });
+
+      const event = createMockEvent();
+      expect(await authModule.getSession(event)).toEqual({
+        email: "dev@local.test",
+      });
+    });
+
     it("resolves bearer legacy session tokens for desktop clients", async () => {
       vi.stubEnv("NODE_ENV", "production");
       delete process.env.ACCESS_TOKEN;

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1887,6 +1887,58 @@ describe("server/auth", () => {
   });
 
   describe("getSession", () => {
+    it("returns a shared session when AGENT_NATIVE_SKIP_AUTH=1", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("AGENT_NATIVE_SKIP_AUTH", "1");
+      delete process.env.AGENT_NATIVE_SKIP_AUTH_EMAIL;
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+
+      const mockExecute = vi.fn().mockResolvedValue({ rows: [] });
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => true,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+      vi.doMock("./better-auth-instance.js", async (importOriginal) => ({
+        ...(await importOriginal<object>()),
+        getBetterAuthSync: () => null,
+      }));
+
+      const { getSession } = await import("./auth.js");
+      const event = createMockEvent();
+
+      expect(await getSession(event)).toEqual({ email: "dev@local.test" });
+    });
+
+    it("honors AGENT_NATIVE_SKIP_AUTH_EMAIL", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("AGENT_NATIVE_SKIP_AUTH", "1");
+      vi.stubEnv("AGENT_NATIVE_SKIP_AUTH_EMAIL", "preview@example.com");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+
+      const mockExecute = vi.fn().mockResolvedValue({ rows: [] });
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => true,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+      vi.doMock("./better-auth-instance.js", async (importOriginal) => ({
+        ...(await importOriginal<object>()),
+        getBetterAuthSync: () => null,
+      }));
+
+      const { getSession } = await import("./auth.js");
+      const event = createMockEvent();
+
+      expect(await getSession(event)).toEqual({ email: "preview@example.com" });
+    });
+
     it("resolves bearer legacy session tokens for desktop clients", async () => {
       vi.stubEnv("NODE_ENV", "production");
       delete process.env.ACCESS_TOKEN;

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1783,27 +1783,22 @@ const AUTO_DEV_ACCOUNT_EMAIL = "dev@local.test";
 // permanently disable auto-create) and the post-logout guard still fires.
 const LEGACY_AUTO_DEV_ACCOUNT_EMAIL = "dev@local";
 
-let skipAuthWarningLogged = false;
+let authDisabledWarningLogged = false;
 
-function isSkipAuthEnabled(): boolean {
-  return process.env.AGENT_NATIVE_SKIP_AUTH === "1";
+function isAuthDisabled(): boolean {
+  const value = process.env.AUTH_DISABLED?.trim().toLowerCase();
+  return value === "1" || value === "true";
 }
 
-function getSkipAuthEmail(): string {
-  return (
-    process.env.AGENT_NATIVE_SKIP_AUTH_EMAIL?.trim() || AUTO_DEV_ACCOUNT_EMAIL
-  );
-}
-
-function getSkipAuthSession(): AuthSession | null {
-  if (!isSkipAuthEnabled()) return null;
-  if (!skipAuthWarningLogged) {
-    skipAuthWarningLogged = true;
+function getAuthDisabledSession(): AuthSession | null {
+  if (!isAuthDisabled()) return null;
+  if (!authDisabledWarningLogged) {
+    authDisabledWarningLogged = true;
     console.warn(
-      `[agent-native] AGENT_NATIVE_SKIP_AUTH=1 — login/signup disabled; all requests run as ${getSkipAuthEmail()}`,
+      `[agent-native] AUTH_DISABLED — login/signup disabled; all requests run as ${AUTO_DEV_ACCOUNT_EMAIL}`,
     );
   }
-  return { email: getSkipAuthEmail() };
+  return { email: AUTO_DEV_ACCOUNT_EMAIL };
 }
 
 async function hasAutoDevAccountUser(
@@ -2067,9 +2062,9 @@ async function resolveSessionUncached(
     };
   }
 
-  // 2. Preview/demo bypass — opt-in via AGENT_NATIVE_SKIP_AUTH=1.
-  const skipAuthSession = getSkipAuthSession();
-  if (skipAuthSession) return skipAuthSession;
+  // 2. AUTH_DISABLED bypass — skip login/signup; all requests share one user.
+  const authDisabledSession = getAuthDisabledSession();
+  if (authDisabledSession) return authDisabledSession;
 
   // 3. ACCESS_TOKEN check (programmatic/agent access)
   const accessTokens = getAccessTokens();

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -2062,18 +2062,14 @@ async function resolveSessionUncached(
     };
   }
 
-  // 2. AUTH_DISABLED bypass — skip login/signup; all requests share one user.
-  const authDisabledSession = getAuthDisabledSession();
-  if (authDisabledSession) return authDisabledSession;
-
-  // 3. ACCESS_TOKEN check (programmatic/agent access)
+  // 2. ACCESS_TOKEN check (programmatic/agent access)
   const accessTokens = getAccessTokens();
   if (accessTokens.length > 0) {
     const cookieSession = await getLegacyCookieSession(event);
     if (cookieSession) return cookieSession;
   }
 
-  // 4. BYOA custom getSession
+  // 3. BYOA custom getSession
   if (customGetSession) {
     const session = await customGetSession(event);
     if (session) return session;
@@ -2090,14 +2086,14 @@ async function resolveSessionUncached(
     if (sso?.email) return { email: sso.email, token: sso.token };
     // Fall through to mobile _session check
   } else {
-    // 5. Bearer session. Desktop/native clients can persist a legacy session
+    // 4. Bearer session. Desktop/native clients can persist a legacy session
     // token outside the WebView cookie jar and attach it to all app requests.
     // `agent-native connect` clients may present a connect-minted MCP OAuth
     // token, but only the framework action route accepts that fallback.
     const bearerSession = await getBearerSession(event);
     if (bearerSession) return bearerSession;
 
-    // 6. Better Auth session (cookie or Bearer token)
+    // 5. Better Auth session (cookie or Bearer token)
     try {
       const ba = getBetterAuthSync();
       if (ba) {
@@ -2112,11 +2108,11 @@ async function resolveSessionUncached(
       console.error("[auth] ba.api.getSession error:", e);
     }
 
-    // 7. Legacy cookie fallback (for sessions created before migration)
+    // 6. Legacy cookie fallback (for sessions created before migration)
     const cookieSession = await getLegacyCookieSession(event);
     if (cookieSession) return cookieSession;
 
-    // 8. Desktop SSO broker fallback.
+    // 7. Desktop SSO broker fallback.
     // Each template in the Electron desktop app has its own database, so
     // a session token created by one template doesn't resolve in another.
     // When an Electron request has no resolvable session, trust the
@@ -2134,6 +2130,12 @@ async function resolveSessionUncached(
   // 8. Mobile WebView bridge — _session query param
   const querySession = await promoteQuerySession(event);
   if (querySession) return querySession;
+
+  // 9. AUTH_DISABLED fallback — only when no session resolved above.
+  // Must run after BYOA customGetSession so infrastructure/custom auth keeps
+  // caller identity instead of collapsing to the shared preview user.
+  const authDisabledSession = getAuthDisabledSession();
+  if (authDisabledSession) return authDisabledSession;
 
   return null;
 }

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1783,6 +1783,29 @@ const AUTO_DEV_ACCOUNT_EMAIL = "dev@local.test";
 // permanently disable auto-create) and the post-logout guard still fires.
 const LEGACY_AUTO_DEV_ACCOUNT_EMAIL = "dev@local";
 
+let skipAuthWarningLogged = false;
+
+function isSkipAuthEnabled(): boolean {
+  return process.env.AGENT_NATIVE_SKIP_AUTH === "1";
+}
+
+function getSkipAuthEmail(): string {
+  return (
+    process.env.AGENT_NATIVE_SKIP_AUTH_EMAIL?.trim() || AUTO_DEV_ACCOUNT_EMAIL
+  );
+}
+
+function getSkipAuthSession(): AuthSession | null {
+  if (!isSkipAuthEnabled()) return null;
+  if (!skipAuthWarningLogged) {
+    skipAuthWarningLogged = true;
+    console.warn(
+      `[agent-native] AGENT_NATIVE_SKIP_AUTH=1 — login/signup disabled; all requests run as ${getSkipAuthEmail()}`,
+    );
+  }
+  return { email: getSkipAuthEmail() };
+}
+
 async function hasAutoDevAccountUser(
   db: ReturnType<typeof getDbExec>,
 ): Promise<boolean> {
@@ -2044,14 +2067,18 @@ async function resolveSessionUncached(
     };
   }
 
-  // 2. ACCESS_TOKEN check (programmatic/agent access)
+  // 2. Preview/demo bypass — opt-in via AGENT_NATIVE_SKIP_AUTH=1.
+  const skipAuthSession = getSkipAuthSession();
+  if (skipAuthSession) return skipAuthSession;
+
+  // 3. ACCESS_TOKEN check (programmatic/agent access)
   const accessTokens = getAccessTokens();
   if (accessTokens.length > 0) {
     const cookieSession = await getLegacyCookieSession(event);
     if (cookieSession) return cookieSession;
   }
 
-  // 3. BYOA custom getSession
+  // 4. BYOA custom getSession
   if (customGetSession) {
     const session = await customGetSession(event);
     if (session) return session;
@@ -2068,14 +2095,14 @@ async function resolveSessionUncached(
     if (sso?.email) return { email: sso.email, token: sso.token };
     // Fall through to mobile _session check
   } else {
-    // 4. Bearer session. Desktop/native clients can persist a legacy session
+    // 5. Bearer session. Desktop/native clients can persist a legacy session
     // token outside the WebView cookie jar and attach it to all app requests.
     // `agent-native connect` clients may present a connect-minted MCP OAuth
     // token, but only the framework action route accepts that fallback.
     const bearerSession = await getBearerSession(event);
     if (bearerSession) return bearerSession;
 
-    // 5. Better Auth session (cookie or Bearer token)
+    // 6. Better Auth session (cookie or Bearer token)
     try {
       const ba = getBetterAuthSync();
       if (ba) {
@@ -2090,11 +2117,11 @@ async function resolveSessionUncached(
       console.error("[auth] ba.api.getSession error:", e);
     }
 
-    // 6. Legacy cookie fallback (for sessions created before migration)
+    // 7. Legacy cookie fallback (for sessions created before migration)
     const cookieSession = await getLegacyCookieSession(event);
     if (cookieSession) return cookieSession;
 
-    // 7. Desktop SSO broker fallback.
+    // 8. Desktop SSO broker fallback.
     // Each template in the Electron desktop app has its own database, so
     // a session token created by one template doesn't resolve in another.
     // When an Electron request has no resolvable session, trust the

--- a/packages/core/src/templates/workspace-core/.agents/skills/authentication/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/authentication/SKILL.md
@@ -22,7 +22,7 @@ Auth is powered by **Better Auth** with account-first design. Every new user cre
 | **Production (default)**  | Better Auth with email/password + social providers (Google, GitHub). Organizations built in.                                             |
 | **`AUTH_MODE=local`**     | **Not** a browser auth bypass, and never returns `local@localhost`. It only affects CLI/agent identity: it lets `pnpm action` / the local agent loop auto-bind to the single real signed-in dev user from the `sessions` table (see `scripts/dev-session.ts`). Browser login is unchanged. |
 | **`AUTH_SKIP_EMAIL_VERIFICATION=1`** | QA/preview escape hatch for real email/password accounts. Signup skips email verification and does not send the signup verification email. Local dev/test skips verification by default; set `AUTH_SKIP_EMAIL_VERIFICATION=0` only when testing verification itself. Use `+qa` emails for test accounts. |
-| **`AGENT_NATIVE_SKIP_AUTH=1`** | Skip login/signup entirely — every request runs as one shared user (`AGENT_NATIVE_SKIP_AUTH_EMAIL`, default `dev@local.test`). For cloud previews and internal demos only; not for production with real users. |
+| **`AUTH_DISABLED=true`** | Skip login/signup entirely — every request runs as `dev@local.test`. For local dev, cloud previews, and internal demos only; not for production with real users. |
 | **`ACCESS_TOKEN` / `ACCESS_TOKENS`** | Static bearer fallback for MCP/connect clients that cannot use OAuth. Not browser auth and never a token login page.         |
 | **Custom**                | Pass your own `getSession` to `autoMountAuth(app, { getSession })`.                                                                     |
 

--- a/packages/core/src/templates/workspace-core/.agents/skills/authentication/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/authentication/SKILL.md
@@ -22,8 +22,8 @@ Auth is powered by **Better Auth** with account-first design. Every new user cre
 | **Production (default)**  | Better Auth with email/password + social providers (Google, GitHub). Organizations built in.                                             |
 | **`AUTH_MODE=local`**     | **Not** a browser auth bypass, and never returns `local@localhost`. It only affects CLI/agent identity: it lets `pnpm action` / the local agent loop auto-bind to the single real signed-in dev user from the `sessions` table (see `scripts/dev-session.ts`). Browser login is unchanged. |
 | **`AUTH_SKIP_EMAIL_VERIFICATION=1`** | QA/preview escape hatch for real email/password accounts. Signup skips email verification and does not send the signup verification email. Local dev/test skips verification by default; set `AUTH_SKIP_EMAIL_VERIFICATION=0` only when testing verification itself. Use `+qa` emails for test accounts. |
+| **`AGENT_NATIVE_SKIP_AUTH=1`** | Skip login/signup entirely — every request runs as one shared user (`AGENT_NATIVE_SKIP_AUTH_EMAIL`, default `dev@local.test`). For cloud previews and internal demos only; not for production with real users. |
 | **`ACCESS_TOKEN` / `ACCESS_TOKENS`** | Static bearer fallback for MCP/connect clients that cannot use OAuth. Not browser auth and never a token login page.         |
-| **`AUTH_DISABLED=true`**  | Skip auth entirely (for apps behind infrastructure-level auth like Cloudflare Access).                                                   |
 | **Custom**                | Pass your own `getSession` to `autoMountAuth(app, { getSession })`.                                                                     |
 
 > **Never** use `local@localhost` as a fallback identity in app code

--- a/templates/starter/.env.example
+++ b/templates/starter/.env.example
@@ -1,5 +1,5 @@
 # Custom health check message
 PING_MESSAGE=pong
 
-# Skip login/signup (preview/demo only)
-# AGENT_NATIVE_SKIP_AUTH=1
+# Skip login/signup (local dev / preview only)
+# AUTH_DISABLED=true

--- a/templates/starter/.env.example
+++ b/templates/starter/.env.example
@@ -1,2 +1,5 @@
 # Custom health check message
 PING_MESSAGE=pong
+
+# Skip login/signup (preview/demo only)
+# AGENT_NATIVE_SKIP_AUTH=1

--- a/templates/starter/DEVELOPING.md
+++ b/templates/starter/DEVELOPING.md
@@ -156,7 +156,7 @@ When adding app data, define tables with `@agent-native/core/db/schema` helpers 
 | --------------------- | ------------------------------- | -------------------------------------------------------------------------- |
 | `DATABASE_URL`        | Production yes, local dev no    | Persistent SQL connection string (local dev default: `file:./data/app.db`) |
 | `DATABASE_AUTH_TOKEN` | Only when the provider needs it | Auth token for providers such as Turso/libSQL                              |
-| `AGENT_NATIVE_SKIP_AUTH` | Optional                     | Set to `1` to skip login/signup (preview/demo only)                        |
+| `AUTH_DISABLED`       | Optional                        | Set to `true` or `1` to skip login/signup (local dev/preview only)         |
 
 ## Extensions (Framework Feature)
 

--- a/templates/starter/DEVELOPING.md
+++ b/templates/starter/DEVELOPING.md
@@ -156,6 +156,7 @@ When adding app data, define tables with `@agent-native/core/db/schema` helpers 
 | --------------------- | ------------------------------- | -------------------------------------------------------------------------- |
 | `DATABASE_URL`        | Production yes, local dev no    | Persistent SQL connection string (local dev default: `file:./data/app.db`) |
 | `DATABASE_AUTH_TOKEN` | Only when the provider needs it | Auth token for providers such as Turso/libSQL                              |
+| `AGENT_NATIVE_SKIP_AUTH` | Optional                     | Set to `1` to skip login/signup (preview/demo only)                        |
 
 ## Extensions (Framework Feature)
 


### PR DESCRIPTION
## Summary

Implements the previously documented-but-unimplemented `AUTH_DISABLED` auth bypass for local dev, cloud previews, and internal demos.

When `AUTH_DISABLED=true` or `AUTH_DISABLED=1`, `getSession()` skips login/signup and returns a single shared user (`dev@local.test`) for every request.

- Adds `isAuthDisabled()` / `getAuthDisabledSession()` in `packages/core/src/server/auth.ts`
- Runs the bypass early in `resolveSessionUncached()`, after embed auth and before `ACCESS_TOKEN` / Better Auth resolution
- Logs a one-time server warning when the bypass is active
- Updates docs/skills to describe the real behavior (replacing the old “infrastructure auth” wording)
- Documents the flag in starter `.env.example` and `DEVELOPING.md`
- Adds unit tests for `AUTH_DISABLED=1` and `AUTH_DISABLED=true`

**Intended use:** local development, preview deployments, and internal demos where a login wall is unnecessary.

**Not intended for:** production apps with real users or multi-tenant data.

## Motivation

`AUTH_DISABLED` was already referenced in docs, but the framework did not implement it. Preview/demo setups still hit Better Auth login/signup even when auth was not needed. This adds an explicit, opt-in bypass without changing default production behavior.

## Usage

```bash
# .env
AUTH_DISABLED=true
# or
AUTH_DISABLED=1