### PR TITLE
Fix Calendar Cloudflare deploy bundle

### DIFF
--- a/.changeset/loud-rings-check.md
+++ b/.changeset/loud-rings-check.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve native chat widget registrations when packaged apps are bundled for deployment.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -141,7 +141,9 @@
     "./tsconfig.base.json": "./tsconfig.base.json"
   },
   "sideEffects": [
-    "*.css"
+    "*.css",
+    "dist/client/chat/widgets/builtin-tool-renderers.js",
+    "dist/client/dev-overlay/builtins.js"
   ],
   "files": [
     "bin",

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -868,6 +868,26 @@ async function buildCloudflarePages() {
     generateRequireShim(),
   );
 
+  const nitroServerAssetsStub = path.join(
+    tmpDir,
+    "_nitro-server-assets-stub.js",
+  );
+  fs.writeFileSync(
+    nitroServerAssetsStub,
+    [
+      "const empty = async () => undefined;",
+      "export const assets = {",
+      "  getItem: empty,",
+      "  getItemRaw: empty,",
+      "  getKeys: async () => [],",
+      "  getMeta: async () => undefined,",
+      "  hasItem: async () => false,",
+      "};",
+      "export default assets;",
+      "",
+    ].join("\n"),
+  );
+
   // Create stub modules for native/Node-only deps that can't run on Workers.
   // These get resolved by esbuild instead of the real modules, avoiding bundling
   // native code that would fail on the Workers runtime.
@@ -952,6 +972,7 @@ async function buildCloudflarePages() {
       "--conditions=workerd,worker,import",
       // The ssr-handler imports a virtual module that only exists at dev time
       "--external:virtual:react-router/server-build",
+      `--alias:#nitro/virtual/server-assets=${nitroServerAssetsStub}`,
       // Banner: override the __require shim that esbuild generates for CJS modules.
       // This provides a real require() backed by ESM imports of node builtins.
       // Without this, CF Workers rejects the bundle because esbuild's default

--- a/templates/calendar/server/lib/booking-og-fonts.ts
+++ b/templates/calendar/server/lib/booking-og-fonts.ts
@@ -43,8 +43,12 @@ export function bytesFromStorageValue(value: unknown): Buffer | undefined {
 }
 
 function sourceFontFiles(): string[] | undefined {
-  const files = BOOKING_OG_FONT_ASSETS.map((font) => font.sourcePath);
-  return files.every((fontFile) => existsSync(fontFile)) ? files : undefined;
+  try {
+    const files = BOOKING_OG_FONT_ASSETS.map((font) => font.sourcePath);
+    return files.every((fontFile) => existsSync(fontFile)) ? files : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 async function readFontBytes(
@@ -59,7 +63,7 @@ async function readFontBytes(
 }
 
 export async function loadBundledOgFontFiles(
-  storage: BookingOgAssetStorage,
+  storage?: BookingOgAssetStorage,
   options: {
     preferSourceFiles?: boolean;
     tmpRoot?: string;
@@ -70,6 +74,8 @@ export async function loadBundledOgFontFiles(
     const sourceFiles = sourceFontFiles();
     if (sourceFiles) return sourceFiles;
   }
+
+  if (!storage) return undefined;
 
   try {
     const fonts = [];

--- a/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
+++ b/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
@@ -9,6 +9,7 @@ import {
 } from "h3";
 import { eq } from "drizzle-orm";
 import { getUserSetting } from "@agent-native/core/settings";
+import { assets as serverAssets } from "#nitro/virtual/server-assets";
 import { getDb, schema } from "../../../../../db/index.js";
 import { getBookingUsername } from "../../../../../handlers/booking-usernames.js";
 import { loadBundledOgFontFiles } from "../../../../../lib/booking-og-fonts.js";
@@ -142,7 +143,7 @@ export default defineEventHandler(async (event: H3Event) => {
     bookingPageTitle: ownerSettings?.bookingPageTitle,
     profileImageDataUrl,
   };
-  const fontFiles = await loadBundledOgFontFiles();
+  const fontFiles = await loadBundledOgFontFiles(serverAssets);
   let png: Uint8Array;
   try {
     png = await renderBookingOgImagePng(

--- a/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
+++ b/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
@@ -9,7 +9,6 @@ import {
 } from "h3";
 import { eq } from "drizzle-orm";
 import { getUserSetting } from "@agent-native/core/settings";
-import { assets as serverAssets } from "#nitro/virtual/server-assets";
 import { getDb, schema } from "../../../../../db/index.js";
 import { getBookingUsername } from "../../../../../handlers/booking-usernames.js";
 import { loadBundledOgFontFiles } from "../../../../../lib/booking-og-fonts.js";
@@ -143,7 +142,7 @@ export default defineEventHandler(async (event: H3Event) => {
     bookingPageTitle: ownerSettings?.bookingPageTitle,
     profileImageDataUrl,
   };
-  const fontFiles = await loadBundledOgFontFiles(serverAssets);
+  const fontFiles = await loadBundledOgFontFiles();
   let png: Uint8Array;
   try {
     png = await renderBookingOgImagePng(


### PR DESCRIPTION
## Summary
- remove Calendar booking OG route dependency on Nitro virtual server assets so the Cloudflare worker bundle resolves cleanly
- make bundled OG font loading tolerate missing storage/filesystem sources
- preserve core native chat widget registration modules during app bundling

## Validation
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- pnpm --dir templates/calendar exec tsc --noEmit --pretty false --project tsconfig.json
- pnpm --dir templates/calendar exec vitest --run server/lib/booking-og-image.spec.ts server/lib/booking-og-response.spec.ts
- NITRO_PRESET=cloudflare_pages pnpm --dir templates/calendar build
- pnpm prep