### PR TITLE
Add agent chat runtime and Plan workflow updates

### DIFF
--- a/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
+++ b/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-native-visual-plans",
-  "version": "1.0.0+codex.d0dcd53dd871",
+  "version": "1.0.0+codex.d0b9e254c484",
   "description": "Create rich interactive visual plans and recaps with diagrams, file maps, annotated code and diffs, API/schema summaries, feedback, and HTML export.",
   "author": { "name": "Agent-Native", "url": "https://agent-native.com" },
   "homepage": "https://plan.agent-native.com",

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-plan/SKILL.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-plan/SKILL.md
@@ -361,8 +361,10 @@ The local-files contract is:
   writes only registry metadata to disk; use `--format schema` if exact nested
   fields are needed. If network access is unavailable, use the bundled
   references and rely on `plan local check` / `plan local serve` to catch
-  invalid tags. For `checklist` and `question-form`, copy the catalog examples:
-  checklist items need `id`, and question-form questions/options need `id`.
+  invalid tags. For `checklist` and `question-form`, copy the catalog examples
+  verbatim: checklist items need `id` and `label`; question-form questions need
+  `id`, `title`, and `mode`; and each option needs `id` and `label`. `plan local
+  check` validates these required fields against the renderer schema.
 - Write the plan as a local MDX folder: use `plans/<slug>/` when the user
   wants the artifact checked into the repo, or use a repo-ignored/temporary
   folder such as `.agent-native/plans/<slug>/` or `/tmp/agent-native-plans/<slug>/`

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-recap/SKILL.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-recap/SKILL.md
@@ -38,8 +38,10 @@ In local-files mode:
   `get-plan-blocks` route and sends no recap content. If network access is
   unavailable, use the bundled references and validate with
   `plan local check` / `plan local serve`. For `checklist` and `question-form`,
-  copy the catalog examples: checklist items need `id`, and question-form
-  questions/options need `id`.
+  copy the catalog examples verbatim: checklist items need `id` and `label`;
+  question-form questions need `id`, `title`, and `mode`; and each option needs
+  `id` and `label`. `plan local check` validates these required fields against
+  the renderer schema.
 - Write the recap as a local MDX folder: use `plans/<slug>/` when the user
   wants the artifact checked into the repo, or use a repo-ignored/temporary
   folder such as `.agent-native/plans/<slug>/` or `/tmp/agent-native-plans/<slug>/`

--- a/.changeset/agent-chat-runtime-implementation.md
+++ b/.changeset/agent-chat-runtime-implementation.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": minor
+---
+
+Implement AgentChatRuntime factories and AssistantChat runtime mounting for BYO agent chat transports.

--- a/.changeset/loud-rings-check.md
+++ b/.changeset/loud-rings-check.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve native chat widget registrations when packaged apps are bundled for deployment.

--- a/.changeset/loud-rings-check.md
+++ b/.changeset/loud-rings-check.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-Preserve native chat widget registrations when packaged apps are bundled for deployment.

--- a/.changeset/pi-skill-picker-shared-agents.md
+++ b/.changeset/pi-skill-picker-shared-agents.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Hide Pi from the interactive skill instruction picker because the shared `.agents` target already covers Pi-compatible skills.

--- a/.changeset/plan-local-check-required-fields.md
+++ b/.changeset/plan-local-check-required-fields.md
@@ -1,0 +1,13 @@
+---
+"@agent-native/core": patch
+---
+
+Make `plan local check` catch every required `checklist`/`question-form` field
+the Plan renderer enforces, not just per-item `id`. Previously a local plan
+missing a checklist item `label`, or a question `title`/`mode`, or an option
+`label`, passed `plan local check` with a false green and then got stuck on
+"Loading plan" when the hosted renderer rejected it (`expected string`). The
+lint now validates `id` + `label` on checklist items and options, and `id` +
+`title` + a valid `mode` enum on questions, so authoring mistakes surface
+locally before the browser handoff. The visual-plan/visual-recap skills now
+spell out the full required-field set.

--- a/.changeset/plan-local-serve-alias.md
+++ b/.changeset/plan-local-serve-alias.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Accept `agent-native plan serve` as a compatibility alias for `agent-native plan local serve`.

--- a/.changeset/plan-plugin-local-serve-docs.md
+++ b/.changeset/plan-plugin-local-serve-docs.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix the plan plugin docs to teach the canonical `plan local serve` command for local-files preview (it previously taught `plan local preview`, which runs a different local dev-server route), and note the `plan serve` short alias.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The agent and the UI are equal citizens of the same system. Every action works b
 - **Three shapes** — Build the same agent as a headless API, a rich chat experience, or a full application where agent and UI stay in sync.
 - **Apps that improve themselves** — Your apps get better on their own. The agent can add features, fix bugs, and refine the UI over time.
 - **Any database, any host** — Any SQL database Drizzle supports. Any hosting target Nitro supports. No lock-in.
-- **Bring the agent surface you need** — MCP-compatible hosts can call your apps, coding agents can install skills, native chat renders reusable app outputs, and AG-UI-style adapters can connect external runtimes to Agent-Native UI primitives over time.
+- **Bring the agent surface you need** — MCP-compatible hosts can call your apps, coding agents can install skills, native chat renders reusable app outputs, and BYO agent runtimes can stream into the Agent-Native chat shell.
 
 ## The framework for agent-native apps
 
@@ -50,13 +50,15 @@ export default defineAction({
 
 Agent-Native primitives let you choose how much UI to put around an agent without rebuilding the agent contract:
 
-| Shape         | What you ship                                                                                             | Same primitives underneath                                                         |
-| ------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| **Headless**  | Call the agent and actions from code, CLI, HTTP, MCP, or A2A.                                             | `defineAction`, auth, skills, memory, jobs, observability                          |
-| **Rich chat** | A standalone or embedded chat with native tables, charts, approvals, setup flows, and tool results.       | Shared chat runtime, action-declared native renderers, MCP Apps for external hosts |
-| **Whole app** | A full SaaS/product UI where chat can start central, move to the sidebar, and stay synced with app state. | SQL state, actions, context awareness, deep links, live sync                       |
+| Shape         | What you ship                                                                                             | Same primitives underneath                                                  |
+| ------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **Headless**  | Call the agent and actions from code, CLI, HTTP, MCP, or A2A.                                             | `defineAction`, auth, skills, memory, jobs, observability                   |
+| **Rich chat** | A standalone or embedded chat with native tables, charts, approvals, setup flows, and tool results.       | Shared chat runtime, BYO runtime adapters, action-declared native renderers |
+| **Whole app** | A full SaaS/product UI where chat can start central, move to the sidebar, and stay synced with app state. | SQL state, actions, context awareness, deep links, live sync                |
 
-Protocols come with the framework instead of becoming separate integrations per feature. Today that means A2A, MCP, MCP Apps, standard remote MCP OAuth, MCP clients, HTTP/CLI action calls, native chat widgets, and deep links all hang off the same action surface. AG-UI is a natural adapter path for bring-your-own agent runtimes; ACP is best understood as the coding-agent/editor interoperability protocol, not the general BYO app-chat runtime.
+Protocols come with the framework instead of becoming separate integrations per feature. Today that means A2A, MCP, MCP Apps, standard remote MCP OAuth, MCP clients, HTTP/CLI action calls, native chat widgets, `AgentChatRuntime` adapters, and deep links all hang off the same action surface. AG-UI is a natural future adapter path for bring-your-own agent runtimes; ACP is best understood as the coding-agent/editor interoperability protocol, not the general BYO app-chat runtime.
+
+For the full decision guide — headless, rich chat on the built-in agent, rich chat on your own agent, embedded sidecar, or full app — see [Agent Surfaces](https://agent-native.com/docs/agent-surfaces).
 
 To connect Claude, ChatGPT, Codex, Cursor, OpenCode, GitHub Copilot / VS Code, or another MCP host to your hosted app, see the [External Agents guide](https://agent-native.com/docs/external-agents).
 

--- a/packages/core/docs/content/actions.md
+++ b/packages/core/docs/content/actions.md
@@ -16,6 +16,8 @@ Actions are the single source of truth for anything your app does. Define an act
 - **A CLI command** — `pnpm action <name>` for scripting and dev loops.
 
 One definition, seven consumers. This is rung 3 of the [ladder](/docs/what-is-agent-native#the-ladder).
+If you are deciding whether to expose an operation headlessly, in chat, in an
+embedded sidecar, or as a full app screen, see [Agent Surfaces](/docs/agent-surfaces).
 
 ## Defining an action {#defining}
 
@@ -355,7 +357,9 @@ The built-in discriminants are `"data-table"`, `"data-chart"`, and
 `"data-insights"`. Their server-safe builders and schemas are exported from
 `@agent-native/core/data-widgets`, and native renderer ids are exported from
 `@agent-native/core`. See [Native Chat UI](/docs/native-chat-ui) for the full
-result contract and BYO runtime guidance.
+result contract and BYO runtime guidance, or [Agent Surfaces](/docs/agent-surfaces)
+for how this same action can stay headless, render in chat, or grow into a full
+screen.
 
 ## Calling it from the CLI {#cli}
 

--- a/packages/core/docs/content/agent-surfaces.md
+++ b/packages/core/docs/content/agent-surfaces.md
@@ -1,0 +1,258 @@
+---
+title: "Agent Surfaces"
+description: "Use Agent-Native headlessly, as rich chat, inside an existing app, or as a full agent-native application."
+search: "headless agent rich chat full app BYO agent runtime AgentChatRuntime embed actions MCP A2A HTTP CLI"
+---
+
+# Agent Surfaces
+
+Agent-Native is deliberately composable. You can use the agent without much UI,
+use the UI without the built-in agent runtime, or use both together as a full
+application.
+
+The useful way to choose is not by protocol first. Choose the product surface
+you want, then use the matching primitive.
+
+| Surface                       | Use it when                                                                                                 | Start with                                                         |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| **Headless agent/actions**    | Code, jobs, scripts, another app, or another agent should call the work directly.                           | `defineAction`, HTTP, CLI, MCP, A2A                                |
+| **Rich chat on Agent-Native** | You want a standalone or embedded chat backed by the built-in agent loop.                                   | `<AgentChatSurface>`, `<AssistantChat>`, `createAgentChatPlugin()` |
+| **Rich chat on your agent**   | You built the agent elsewhere and want Agent-Native's composer, transcript, tool cards, and native widgets. | `AgentChatRuntime`, `<AssistantChat runtime={runtime}>`            |
+| **Embedded sidecar**          | You already have a SaaS app and want an agent beside it with page context and host commands.                | `createAgentNativeEmbeddedPlugin()`, `AgentNativeEmbedded`         |
+| **Full application**          | Humans and agents should share durable screens, data, navigation, and collaboration.                        | Templates, actions, SQL state, context awareness                   |
+
+Those are stages, not separate products. A workflow can start as a headless
+action, appear in chat as a table or chart, and later become a full screen in an
+app without changing the operation the agent calls.
+
+## Headless agent/actions {#headless}
+
+Use the headless path when no one needs to stare at a custom app screen while
+the work runs: scheduled jobs, integrations, backend workflows, CLI loops,
+another agent, or an existing product calling into Agent-Native.
+
+Most headless integrations should start with actions:
+
+```ts
+// actions/summarize-week.ts
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+
+export default defineAction({
+  description: "Summarize this week's submissions.",
+  readOnly: true,
+  schema: z.object({ formId: z.string() }),
+  run: async ({ formId }) => {
+    return { formId, summary: "34 submissions, up 18% from last week." };
+  },
+});
+```
+
+One action is then callable as:
+
+- **HTTP** — `POST /_agent-native/actions/summarize-week`
+- **CLI** — `pnpm action summarize-week --formId form_123`
+- **MCP** — from Claude, ChatGPT, Codex, Cursor, OpenCode, Copilot, and other MCP hosts
+- **A2A** — from another agent-native app or agent peer
+- **UI** — through `useActionQuery`, `useActionMutation`, or `callAction`
+- **Agent tool** — from the built-in chat loop
+
+If you need the whole agent loop headlessly, use the server API from a worker,
+job, integration webhook, or custom host. This is lower-level than actions: you
+provide the engine, model, messages, actions, and event sink yourself.
+
+```ts
+import {
+  actionsToEngineTools,
+  resolveEngine,
+  runAgentLoop,
+} from "@agent-native/core/server";
+
+const engine = await resolveEngine({ engineOption: undefined });
+const model = engine.defaultModel;
+const controller = new AbortController();
+
+await runAgentLoop({
+  engine,
+  model,
+  systemPrompt: "You are the reporting agent for this workspace.",
+  actions,
+  tools: actionsToEngineTools(actions),
+  messages: [
+    {
+      role: "user",
+      content: [{ type: "text", text: "Summarize this week's forms." }],
+    },
+  ],
+  send: (event) => {
+    // Persist, log, stream, or translate AgentChatEvent objects.
+  },
+  signal: controller.signal,
+  ownerEmail: user.email,
+  orgId: user.orgId,
+});
+```
+
+For most apps, scheduled prompts and integration webhooks already call this loop
+for you. Reach for direct `runAgentLoop()` when you are building a custom
+headless host, eval runner, or server-side orchestration surface.
+
+## Rich chat on Agent-Native {#rich-chat}
+
+Use the built-in chat when the user should talk to the agent, see tool calls,
+approve work, inspect native results, and keep a durable thread history.
+
+The simplest full-page chat:
+
+```tsx
+import { AgentChatSurface } from "@agent-native/core/client/chat";
+
+export default function ChatRoute() {
+  return <AgentChatSurface mode="page" className="h-screen" />;
+}
+```
+
+The simplest embedded chat with your own chrome:
+
+```tsx
+import { AssistantChat } from "@agent-native/core/client/chat";
+
+export function ProjectChat({ threadId }: { threadId: string }) {
+  return <AssistantChat threadId={threadId} />;
+}
+```
+
+Actions can return explicit native widget results so chat output is not just
+text. Tables, charts, and typed product cards render as first-party React
+components in the chat, without iframes. See [Native Chat UI](/docs/native-chat-ui).
+
+## Rich chat on your agent {#byo-agent}
+
+Use this path when your agent is already built with another framework or
+runtime and you want Agent-Native's chat UI around it.
+
+`AgentChatRuntime` is the boundary. Your runtime streams normalized events;
+Agent-Native renders the composer, transcript, tool calls, approvals, native
+widgets, and app layout.
+
+```tsx
+import {
+  AssistantChat,
+  createHttpAgentChatRuntime,
+} from "@agent-native/core/client/chat";
+
+const runtime = createHttpAgentChatRuntime({
+  id: "external:support-agent",
+  label: "Support agent",
+  endpoint: "/api/support-agent/chat",
+  headers: async () => ({ Authorization: `Bearer ${await getToken()}` }),
+});
+
+export function SupportAgentChat() {
+  return <AssistantChat runtime={runtime} threadId="support" />;
+}
+```
+
+The endpoint can stream SSE or NDJSON events:
+
+```txt
+data: {"type":"message-delta","messageId":"m1","delta":{"type":"text","text":"I found 34 submissions."}}
+data: {"type":"tool-start","toolCall":{"id":"t1","name":"query","input":{"formId":"form_123"}}}
+data: {"type":"tool-done","toolCallId":"t1","toolName":"query","status":"completed","resultText":"34 rows"}
+data: {"type":"done","reason":"complete"}
+```
+
+For a trivial integration, returning `{ "text": "..." }` also works. For richer
+integrations, stream `message-*`, `tool-*`, `approval-request`, `status`,
+`artifact`, `file`, `usage`, `error`, and `done` events. Tool results can carry
+`chatUI` metadata so the same native table/chart/card renderers work with your
+agent too.
+
+This is the right place to adapt Mastra, Flue, Eve, LangGraph, a custom service,
+or an AG-UI-compatible event stream. Do not use ACP as the default end-user app
+chat protocol; ACP is better framed as coding-agent/editor interoperability.
+Agent-Native does not currently claim A2UI support.
+
+## Embedded sidecar {#embedded-sidecar}
+
+Use the embedded sidecar when the main product already exists and you want an
+agent beside it.
+
+The server plugin mounts Agent-Native routes into your host app and resolves
+host identity server-side:
+
+```ts
+import { createAgentNativeEmbeddedPlugin } from "@agent-native/core/server";
+
+export default createAgentNativeEmbeddedPlugin({
+  databaseUrl: process.env.AGENT_NATIVE_DATABASE_URL,
+  auth: getHostSession,
+  actions: hostActions,
+});
+```
+
+The React sidecar passes page context and host commands:
+
+```tsx
+import { AgentNativeEmbedded } from "@agent-native/core/client";
+
+export function AppShell({ children }) {
+  return (
+    <AgentNativeEmbedded
+      getContext={() => ({
+        route: { pathname: window.location.pathname },
+        selection: { text: window.getSelection()?.toString() || undefined },
+      })}
+      onNavigate={(payload) =>
+        router.navigate((payload as { path: string }).path)
+      }
+      onRefresh={() => queryClient.invalidateQueries()}
+    >
+      {children}
+    </AgentNativeEmbedded>
+  );
+}
+```
+
+See [Embedding SDK](/docs/embedding-sdk) for host auth, database isolation,
+iframe/picker mode, and lower-level bridge APIs.
+
+## Full application {#full-application}
+
+Use the full app path when users need durable objects and workflows: forms,
+dashboards, calendars, inboxes, editors, documents, assets, or reports.
+
+Full apps add product UI around the same action and agent contract:
+
+- **SQL state** — app data, navigation, settings, and chat history are durable.
+- **Context awareness** — the agent knows the current route, selection, and focused object.
+- **Live sync** — agent changes update the UI, and UI changes update the agent's context.
+- **Deep links** — action results can open the right app view.
+- **Native chat widgets** — tables, charts, cards, approvals, and typed results appear inline.
+
+Start from a [template](/docs/cloneable-saas) when you want a complete app, or
+from [Starter](/docs/template-starter) when you want only the framework wiring.
+
+## How to choose {#how-to-choose}
+
+| If you are thinking...                                          | Choose                    |
+| --------------------------------------------------------------- | ------------------------- |
+| "I just need a callable tool or workflow."                      | Headless action           |
+| "I want the framework's agent, but chat should be the main UI." | Rich chat on Agent-Native |
+| "I already have an agent; I need a polished chat UI for it."    | Rich chat on your agent   |
+| "I already have a SaaS app; add an agent beside it."            | Embedded sidecar          |
+| "The agent and UI should evolve together as the product."       | Full application          |
+
+Keep the contract small: define durable operations as actions, return explicit
+widget results when chat needs rich UI, and add full screens only when users
+need to browse, compare, configure, or collaborate over persistent objects.
+
+## Related docs {#related-docs}
+
+- [Actions](/docs/actions) — define the headless operation once.
+- [Native Chat UI](/docs/native-chat-ui) — render typed action results in chat.
+- [Drop-in Agent](/docs/drop-in-agent) — mount chat, sidebar, or panel surfaces.
+- [Component API](/docs/components) — lower-level React chat/composer pieces.
+- [Embedding SDK](/docs/embedding-sdk) — add Agent-Native to an existing app.
+- [External Agents](/docs/external-agents) — connect MCP-compatible hosts to an app.
+- [A2A Protocol](/docs/a2a-protocol) — call agents from other agents.

--- a/packages/core/docs/content/components.md
+++ b/packages/core/docs/content/components.md
@@ -27,23 +27,26 @@ so bundlers choose the browser-safe entry.
 
 ## Agent And Chat UI {#agent-chat-ui}
 
-| API                        | Import path                                   | Use when                                                                                         |
-| -------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `<AgentSidebar>`           | `@agent-native/core/client` or `/client/chat` | You want the complete sidebar around your app.                                                   |
-| `<AgentToggleButton>`      | `@agent-native/core/client` or `/client/chat` | You render your own header button for the sidebar.                                               |
-| `<AgentPanel>`             | `@agent-native/core/client` or `/client/chat` | You want the full panel in your own layout, route, dialog, or side column.                       |
-| `<AgentChatSurface>`       | `@agent-native/core/client` or `/client/chat` | You want chat in panel or page mode without the sidebar wrapper.                                 |
-| `<AssistantChat>`          | `@agent-native/core/client` or `/client/chat` | You want to own surrounding chrome while keeping the standard conversation and composer runtime. |
-| `<MultiTabAssistantChat>`  | `@agent-native/core/client` or `/client/chat` | You want the framework's thread tabs without `AgentPanel` chrome.                                |
-| `createAgentChatAdapter()` | `@agent-native/core/client` or `/client/chat` | You are adapting a BYO assistant-ui transport into the Agent-Native chat runtime.                |
-| `useChatThreads()`         | `@agent-native/core/client` or `/client/chat` | You need a custom thread list, history picker, or scoped chat UI.                                |
-| `sendToAgentChat()`        | `@agent-native/core/client` or `/client/chat` | A product action should hand work to the agent chat.                                             |
+| API                               | Import path                                   | Use when                                                                                         |
+| --------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `<AgentSidebar>`                  | `@agent-native/core/client` or `/client/chat` | You want the complete sidebar around your app.                                                   |
+| `<AgentToggleButton>`             | `@agent-native/core/client` or `/client/chat` | You render your own header button for the sidebar.                                               |
+| `<AgentPanel>`                    | `@agent-native/core/client` or `/client/chat` | You want the full panel in your own layout, route, dialog, or side column.                       |
+| `<AgentChatSurface>`              | `@agent-native/core/client` or `/client/chat` | You want chat in panel or page mode without the sidebar wrapper.                                 |
+| `<AssistantChat>`                 | `@agent-native/core/client` or `/client/chat` | You want to own surrounding chrome while keeping the standard conversation and composer runtime. |
+| `<MultiTabAssistantChat>`         | `@agent-native/core/client` or `/client/chat` | You want the framework's thread tabs without `AgentPanel` chrome.                                |
+| `createHttpAgentChatRuntime()`    | `@agent-native/core/client` or `/client/chat` | You have a BYO agent endpoint that streams normalized chat events.                               |
+| `createAgentChatRuntimeAdapter()` | `@agent-native/core/client` or `/client/chat` | You need to adapt an `AgentChatRuntime` into assistant-ui yourself.                              |
+| `createAgentChatAdapter()`        | `@agent-native/core/client` or `/client/chat` | You need the built-in Agent-Native SSE transport as a low-level assistant-ui adapter.            |
+| `useChatThreads()`                | `@agent-native/core/client` or `/client/chat` | You need a custom thread list, history picker, or scoped chat UI.                                |
+| `sendToAgentChat()`               | `@agent-native/core/client` or `/client/chat` | A product action should hand work to the agent chat.                                             |
 
-In docs, `AgentChatRuntime` means this standard runtime posture: assistant-ui
-thread state, Agent-Native streaming, run recovery, attachments, model
-selection, approvals, native tool widgets, and SQL-backed sync. It is not a
-separate protocol replacement. BYO agents should adapt into this runtime with
-`createAgentChatAdapter()` when they want the normal app chat experience.
+`AgentChatRuntime` is the BYO-agent contract for the standard chat shell. Pass
+`runtime` to `<AssistantChat>` when an external agent should power the
+conversation while Agent-Native keeps the composer, transcript, tool cards, and
+native widget rendering. If you are choosing between headless actions, rich
+chat, embedded sidecar, and full app shapes, see
+[Agent Surfaces](/docs/agent-surfaces).
 
 The shortest custom route is still a pre-wired surface:
 
@@ -74,6 +77,24 @@ function CustomChat({ projectSlug }: { projectSlug: string }) {
       <AssistantChat threadId={threadId} />
     </section>
   );
+}
+```
+
+For a bring-your-own agent endpoint:
+
+```tsx
+import {
+  AssistantChat,
+  createHttpAgentChatRuntime,
+} from "@agent-native/core/client/chat";
+
+const runtime = createHttpAgentChatRuntime({
+  endpoint: "/api/my-agent/chat",
+  label: "My agent",
+});
+
+export function MyAgentChat() {
+  return <AssistantChat runtime={runtime} />;
 }
 ```
 

--- a/packages/core/docs/content/drop-in-agent.md
+++ b/packages/core/docs/content/drop-in-agent.md
@@ -184,20 +184,25 @@ framework own the agent runtime:
 - **`@agent-native/core/client/conversation`** — use this for transcript
   rendering without the full chat runtime.
 - **`createAgentChatAdapter()`** — use this only when building a custom
-  assistant-ui transport for the standard Agent-Native chat runtime. It
+  assistant-ui transport for the built-in Agent-Native chat endpoint. It
   connects to the same `/_agent-native/agent-chat` stream and preserves
   run-manager recovery, attachments, model selection, native widgets, and
   thread metadata.
+- **`createHttpAgentChatRuntime()`** — use this when a BYO agent exposes a
+  POST endpoint that streams `AgentChatRuntime` events. Pass the runtime to
+  `<AssistantChat runtime={runtime} />`.
 
 Avoid posting directly to `/_agent-native/agent-chat` from product UI. If a
 lower-level helper is missing for a real custom surface, add that named helper
 first so client code does not learn a second, ad hoc transport.
 
 For BYO agent runtimes, keep actions and SQL-backed app state as the contract.
-Adapt the runtime into `<AssistantChat createAdapter={...} />` when you want
-Agent-Native chat behavior, or use `PromptComposer` by itself only when the
-external runtime owns the transcript and loop. See
-[Native Chat UI](/docs/native-chat-ui#byo-agent-runtimes).
+Adapt the runtime into `<AssistantChat runtime={...} />` when you want
+Agent-Native chat behavior. Use `<AssistantChat createAdapter={...} />` only
+for lower-level assistant-ui transports, or `PromptComposer` by itself only
+when the external runtime owns the transcript and loop. See
+[Native Chat UI](/docs/native-chat-ui#byo-agent-runtimes) and
+[Agent Surfaces](/docs/agent-surfaces#byo-agent).
 
 ### Build your own sidebar from pieces {#build-your-own-sidebar}
 

--- a/packages/core/docs/content/embedding-sdk.md
+++ b/packages/core/docs/content/embedding-sdk.md
@@ -29,6 +29,10 @@ pnpm add @agent-native/core
 
 ## Choosing a mode {#choosing-a-mode}
 
+This page is for embedding Agent-Native into an existing product. If you are
+still deciding between headless actions, rich chat, an embedded sidecar, or a
+full app, start with [Agent Surfaces](/docs/agent-surfaces).
+
 | Mode                                 | Use it when                                                                                         | Package                                                  |
 | ------------------------------------ | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
 | **EmbeddedApp picker**               | Launching a full Agent-Native app as a focused iframe (asset picker, form builder, approval panel). | `@agent-native/embedding`                                |

--- a/packages/core/docs/content/external-agents.md
+++ b/packages/core/docs/content/external-agents.md
@@ -13,6 +13,7 @@ The external-agent bridge closes the loop. First you connect your own agent to a
 ## Which agent path do you need? {#which-agent-path}
 
 - **External MCP host:** use this page when Claude, ChatGPT, Codex, Cursor, OpenCode, GitHub Copilot / VS Code, or another MCP-compatible host should call your hosted agent-native app.
+- **Your own runtime behind Agent-Native chat:** see [Agent Surfaces](/docs/agent-surfaces#byo-agent) and [Native Chat UI](/docs/native-chat-ui#byo-agent-runtimes) when an agent built with another framework should power `<AssistantChat runtime={...}>`.
 - **Your app consuming MCP tools:** see [MCP Clients](/docs/mcp-clients) when an agent-native app needs to call tools exposed by another MCP server.
 - **Another app or agent via A2A:** use [Agent Mentions](/docs/agent-mentions) and [A2A](/docs/a2a-protocol) when agent-native apps should discover and delegate to each other.
 - **Local custom sub-agents:** use [Workspace](/docs/workspace) when you want custom agent profiles inside the agent-native workspace itself.

--- a/packages/core/docs/content/getting-started.md
+++ b/packages/core/docs/content/getting-started.md
@@ -13,6 +13,7 @@ Start with the path that matches what you want to do next:
 
 - **Use a starter app.** Browse the [template gallery](/templates). Hosted apps already include sign-in, data, and the agent sidebar. No install required.
 - **Build or customize your own app.** Continue with [Create a local app](#create-your-app). You'll scaffold a template, run it locally, then change the code, brand, data model, and integrations.
+- **Choose headless, chat, embedded, or full app.** Use [Agent Surfaces](/docs/agent-surfaces) when you know the workflow but not how much UI belongs around it.
 - **Add agent-native skills to a code tool.** Jump to [Try it with a skill](#try-with-a-skill) to add Plans or PR Recaps to Claude Code, Codex, or Cursor without scaffolding an app.
 - **Connect an external agent to an app.** Use [External Agents](/docs/external-agents) to connect Claude, ChatGPT, Codex, Cursor, OpenCode, GitHub Copilot / VS Code, or another MCP host to an existing app.
 
@@ -122,6 +123,7 @@ Once your app is running, the usual next step is small and concrete:
 Useful follow-up docs:
 
 - [Key Concepts](/docs/key-concepts) for the architecture: SQL, actions, polling sync, and context awareness
+- [Agent Surfaces](/docs/agent-surfaces) for choosing headless, rich chat, embedded sidecar, or full app
 - [Workspace](/docs/workspace) for instructions, skills, memory, and per-user MCP connections
 - [Messaging](/docs/messaging) for Slack, email, Telegram, and other ways to reach the agent
 - [FAQ](/docs/faq) for setup and product questions

--- a/packages/core/docs/content/key-concepts.md
+++ b/packages/core/docs/content/key-concepts.md
@@ -194,7 +194,7 @@ Agent-native supports a lot of agent-facing protocols because different hosts st
 | ----------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
 | Agent tool calling      | Shipping            | The in-app agent sees actions as function tools with zod-derived JSON Schema.                                                   | `defineAction()`                        |
 | UI actions              | Shipping            | React calls the same action through `useActionMutation()` / `useActionQuery()`.                                                 | The same action                         |
-| Native chat widgets     | Shipping            | Tool results with explicit widget discriminants can render native tables, charts, approvals, and setup cards in chat.           | Structured action results               |
+| Native chat widgets     | Shipping            | Tool results with explicit widget discriminants can render native tables, charts, and typed app results in chat.                | Structured action results               |
 | HTTP and CLI            | Shipping            | Actions auto-mount at `/_agent-native/actions/:name` and run via `pnpm action <name>`.                                          | The same action                         |
 | MCP server              | Shipping            | External MCP hosts get Streamable HTTP tools, the `ask-agent` meta-tool, and optional MCP Apps resources.                       | The same action, plus optional `mcpApp` |
 | MCP OAuth               | Shipping            | Standard remote MCP OAuth, PKCE, dynamic client registration, refresh tokens, and `mcp:read` / `mcp:write` / `mcp:apps` scopes. | Nothing per action                      |
@@ -222,7 +222,7 @@ Those protocol adapters let the same app grow across three product shapes:
 | **Rich chat agent**   | A standalone or embedded chat can guide setup, call tools, request approvals, and render native tables/charts/results. | Agent-first workflows that still need inspectable output       |
 | **Whole application** | Chat starts central when helpful, then becomes a sidebar next to forms, dashboards, editors, calendars, or documents.  | Durable products where humans and agents share state over time |
 
-You should be able to start with the headless contract, add rich chat, and then grow a full app around the same actions and SQL state instead of rebuilding.
+You should be able to start with the headless contract, add rich chat, and then grow a full app around the same actions and SQL state instead of rebuilding. See [Agent Surfaces](/docs/agent-surfaces) for the concrete choice guide and APIs.
 
 ## Agent modifies code {#agent-modifies-code}
 
@@ -320,5 +320,6 @@ For detailed guidance on specific patterns:
 - [Context Awareness](/docs/context-awareness) — navigation state, view-screen, navigate commands
 - [Skills Guide](/docs/skills-guide) — framework skills, domain skills, creating custom skills
 - [Native Chat UI](/docs/native-chat-ui) — action-declared tables, charts, and BYO runtime posture
+- [Agent Surfaces](/docs/agent-surfaces) — headless, rich chat, embedded sidecar, and full-app paths
 - [A2A Protocol](/docs/a2a-protocol) — agent-to-agent communication
 - [Multi-App Workspace](/docs/multi-app-workspace) — host many apps in one monorepo with shared auth, skills, components, and credentials

--- a/packages/core/docs/content/mcp-apps.md
+++ b/packages/core/docs/content/mcp-apps.md
@@ -9,7 +9,7 @@ MCP Apps are the official `io.modelcontextprotocol/ui` extension that lets compa
 
 For connecting external agents and the broader MCP server setup, see [External Agents](/docs/external-agents) and [MCP Protocol](/docs/mcp-protocol). This page covers authoring MCP App resources and the embed bridge that powers them.
 
-Inside an Agent-Native app's own chat, prefer [native chat renderers](/docs/native-chat-ui) for first-party widgets such as tables, charts, setup cards, and approvals. Use MCP Apps for external/cross-host inline UI in Claude, ChatGPT, Copilot, Cursor, and other compatible hosts, with the action `link` as the universal deep-link fallback.
+Inside an Agent-Native app's own chat, prefer [native chat renderers](/docs/native-chat-ui) for first-party widgets such as tables, charts, typed results, and approval affordances. Use MCP Apps for external/cross-host inline UI in Claude, ChatGPT, Copilot, Cursor, and other compatible hosts, with the action `link` as the universal deep-link fallback.
 
 ## Authoring: optional MCP Apps UI {#mcp-apps}
 

--- a/packages/core/docs/content/native-chat-ui.md
+++ b/packages/core/docs/content/native-chat-ui.md
@@ -178,32 +178,79 @@ arbitrary query execution behind typed read actions rather than raw SQL in chat.
 
 ## BYO agent runtimes {#byo-agent-runtimes}
 
-Agent-Native ships the chat/runtime stack: thread persistence, streaming,
-attachments, tool calls, run recovery, approvals, suggestions, native widgets,
-and SQL-backed app state. In docs, `AgentChatRuntime` refers to that standard
-runtime posture, not a separate package you need to replace.
+`AgentChatRuntime` is the bring-your-own-agent contract for the chat shell. It
+lets an agent you built elsewhere stream normalized events into Agent-Native's
+conversation UI while keeping the shared composer, transcript rendering, tool
+cards, approvals, native widgets, and surrounding app layout. For how this fits
+with headless actions, embedded sidecars, and full applications, see
+[Agent Surfaces](/docs/agent-surfaces).
 
-For bring-your-own agent work, keep the action surface and app state as the
-contract:
+Use the generic HTTP runtime when your agent can expose a POST endpoint that
+returns SSE or NDJSON runtime events:
 
-- Use `createAgentChatAdapter()` or the `<AssistantChat createAdapter={...} />`
-  prop when you need a custom assistant-ui transport while keeping the standard
-  chat runtime.
-- Use `PromptComposer` only when your product owns the full external runtime
-  and wants the Agent-Native composer field without the standard transcript.
-- Treat AG-UI as the likely adapter shape for external event-stream runtimes.
-  It should adapt into Agent-Native actions, context, and native renderers
-  rather than creating a second app API.
-- Treat ACP as coding-agent/editor interoperability. It is useful for IDE
-  agents, but it is not the general BYO chat runtime contract for app users.
+```tsx
+import {
+  AssistantChat,
+  createHttpAgentChatRuntime,
+} from "@agent-native/core/client/chat";
 
-The goal is one operation model: actions, SQL state, context awareness, native
-widgets, MCP Apps, A2A, and MCP all wrap the same app capabilities instead of
-forking behavior per agent surface.
+const runtime = createHttpAgentChatRuntime({
+  id: "external:mastra",
+  label: "Mastra",
+  endpoint: "/api/mastra/chat",
+  headers: async () => ({
+    Authorization: `Bearer ${await getAgentToken()}`,
+  }),
+});
+
+export function SupportChat() {
+  return <AssistantChat runtime={runtime} threadId="support" />;
+}
+```
+
+The endpoint may stream the normalized event shape directly:
+
+```txt
+data: {"type":"message-start","message":{"id":"m1","role":"assistant","content":[]}}
+data: {"type":"message-delta","messageId":"m1","delta":{"type":"text","text":"Hello"}}
+data: {"type":"tool-start","toolCall":{"id":"t1","name":"query","input":{"q":"forms"}}}
+data: {"type":"tool-done","toolCallId":"t1","toolName":"query","status":"completed","resultText":"34 rows"}
+data: {"type":"done","reason":"complete"}
+```
+
+For very simple agents, a JSON response `{ "text": "..." }` is accepted and
+converted into a single assistant message. For richer agents, stream
+`message-*`, `tool-*`, `approval-request`, `status`, `artifact`, `file`,
+`usage`, `error`, and `done` events. Tool results can carry `mcpApp` or
+`chatUI` metadata, so action-declared native widgets still render without
+iframes.
+
+When you want the built-in Agent-Native transport as a runtime object, use:
+
+```ts
+import { createAgentNativeChatRuntime } from "@agent-native/core/client/chat";
+
+const runtime = createAgentNativeChatRuntime({
+  threadId: "forms-chat",
+  mode: "act",
+});
+```
+
+Use `<AssistantChat createAdapter={...} />` only when you need full
+assistant-ui adapter control. Use `PromptComposer` by itself when your product
+owns the entire external transcript and only wants Agent-Native's composer
+field.
+
+AG-UI is still an adapter target: it can be mapped into `AgentChatRuntime`
+events, actions, context, and native renderers over time. ACP remains
+coding-agent/editor interoperability, not the general app-chat runtime for end
+users. A2UI is not claimed as supported here; if it matures, it should adapt
+into this same explicit runtime/widget contract.
 
 ## Related docs {#related-docs}
 
 - [Actions](/docs/actions) — define the operations that return native widget data.
+- [Agent Surfaces](/docs/agent-surfaces) — decide whether you need headless, chat, sidecar, or full app.
 - [Drop-in Agent](/docs/drop-in-agent) — mount the standard chat runtime.
 - [Component API](/docs/components) — custom chat layers and tool renderers.
 - [MCP Apps](/docs/mcp-apps) — inline UI for external MCP hosts.

--- a/packages/core/docs/content/plan-plugin.md
+++ b/packages/core/docs/content/plan-plugin.md
@@ -37,8 +37,34 @@ the Plan MCP connector. They write `plans/<slug>/plan.mdx` plus optional
 `canvas.mdx`, `prototype.mdx`, and `.plan-state.json`, then preview locally with:
 
 ```bash
-npx @agent-native/core@latest plan local preview --dir plans/<slug> --kind plan --open
+npx @agent-native/core@latest plan local serve --dir plans/<slug> --kind plan --open
 ```
+
+This starts a tiny localhost bridge and opens the Plan UI against the local
+folder. (`plan local preview` runs a local Plan dev-server route instead, and
+`plan local preview --out preview.html` is a legacy escape hatch that writes a
+standalone static HTML file. `plan serve` is accepted as a short alias for
+`plan local serve`.)
+
+A few local-files-mode gotchas worth knowing:
+
+- **Use a Chromium browser.** Safari blocks the hosted HTTPS Plan page from
+  reading the `http://127.0.0.1` localhost bridge (mixed-content / private
+  network), so the page hangs on "Loading plan." On macOS `--open` already
+  prefers Chrome/Chromium/Edge/Brave; if Safari opens anyway, reopen the printed
+  URL in a Chromium browser.
+- **The served URL is written to `plans/<slug>/.plan-url`** (override with
+  `--url-file`). A backgrounded or headless agent can read that file instead of
+  scraping the long-running `serve` stdout. Treat it as a local token file and
+  do not commit it.
+- **Verify headlessly** when no browser is available:
+  `npx @agent-native/core@latest plan local verify --dir plans/<slug>` starts the
+  bridge, checks the private-network preflight and JSON payload, prints
+  diagnostics, and exits non-zero on failure — no human eyes required.
+- **Run `plan local check` first.** It validates the MDX against the Plan
+  renderer's block schema (including required fields like `checklist` item
+  `id`/`label` and `question-form` question `id`/`title`/`mode`), so authoring
+  mistakes surface before the browser handoff instead of as a stuck loader.
 
 For folders in the current repo, the direct local route includes `?path=...` so
 the local Plan app can keep browser edits saving to the repo folder. The Plan

--- a/packages/core/docs/content/pure-agent-apps.md
+++ b/packages/core/docs/content/pure-agent-apps.md
@@ -5,7 +5,7 @@ description: "Apps where the agent is the whole product — open it, ask for wha
 
 # Pure-Agent Apps
 
-This is the minimal end of agent-native — for the full-UI end, start from a [template](/docs/cloneable-saas).
+This is the minimal end of agent-native — for the full-UI end, start from a [template](/docs/cloneable-saas). If you are choosing between headless, chat-first, embedded, and full-app shapes, start with [Agent Surfaces](/docs/agent-surfaces).
 
 Imagine opening an app and seeing… just a chat. No dashboard. No sidebar full of menus. No forms. You ask for what you want — "summarize my unread emails," "post the daily metrics to Slack," "find the candidates who replied last week" — and the agent goes off and does it. The output shows up in chat, in Slack, in your inbox, wherever it belongs.
 
@@ -90,6 +90,7 @@ Most pure-agent apps eventually want a little custom UI — not a dashboard, but
 ## What's next
 
 - [**Getting Started**](/docs/getting-started) — clone the Starter template
+- [**Agent Surfaces**](/docs/agent-surfaces) — choose headless, rich chat, embedded sidecar, or full app
 - [**Messaging the agent**](/docs/messaging) — how users talk to the agent across web, Slack, Telegram, email
 - [**Recurring Jobs**](/docs/recurring-jobs) — scheduled prompts the agent runs on its own
 - [**Dispatch**](/docs/template-dispatch) — the workspace template that's a great starting point for pure-agent apps

--- a/packages/core/docs/content/using-your-agent.md
+++ b/packages/core/docs/content/using-your-agent.md
@@ -39,6 +39,7 @@ _For developers building the app._
 The agent isn't a separate app you tab over to. It ships as a handful of React components — a sidebar, a raw panel, and a `sendToAgentChat()` call — that you drop into any app. Render `<AgentSidebar>` to give every screen a toggleable agent, or wire a button to hand a specific task off to the chat instead of running a one-shot LLM call.
 
 → [**Drop-in Agent**](/docs/drop-in-agent) — mount `<AgentPanel>`, `<AgentSidebar>`, and `sendToAgentChat()` into any React app. _(For developers building the app.)_
+→ [**Agent Surfaces**](/docs/agent-surfaces) — choose whether the workflow should be headless, chat-first, embedded, or a full app. _(For developers designing the product shape.)_
 
 ## You can go UI-light {#ui-light}
 

--- a/packages/core/docs/content/what-is-agent-native.md
+++ b/packages/core/docs/content/what-is-agent-native.md
@@ -66,10 +66,10 @@ At minimum, "a UI for the agent" is an observability and management dashboard. A
 There are three useful shapes:
 
 - **Headless** — call the agent and actions from code, HTTP, CLI, MCP, or A2A.
-- **Rich chat** — give the agent a first-class chat UI with native tool widgets such as tables, charts, approvals, setup cards, and links into app views. See [Native Chat UI](/docs/native-chat-ui).
+- **Rich chat** — give the agent a first-class chat UI with native tool widgets such as tables, charts, typed results, approvals, and links into app views. See [Native Chat UI](/docs/native-chat-ui).
 - **Whole app** — put a full application around the agent, with SQL state, context awareness, deep links, and live sync so humans and agents stay in the same workspace.
 
-Agent-native is designed so those are stages, not rewrites. You can start headless, add rich chat, and grow into a full app around the same action surface.
+Agent-native is designed so those are stages, not rewrites. You can start headless, add rich chat, and grow into a full app around the same action surface. See [Agent Surfaces](/docs/agent-surfaces) for the concrete APIs behind each shape.
 
 ## Why every app benefits from an agent {#why-every-app-benefits-from-an-agent}
 
@@ -186,6 +186,7 @@ One action, many surfaces: the agent calls it as a tool, the UI calls it as a ty
 ## What's next {#whats-next}
 
 - [**Getting Started**](/docs) — pick a template and run it
+- [**Agent Surfaces**](/docs/agent-surfaces) — choose headless, rich chat, embedded sidecar, or full app
 - [**Key Concepts**](/docs/key-concepts) — the architecture: SQL, actions, polling sync, context awareness, portability
 - [**Templates**](/docs/cloneable-saas) — templates as complete products you own
 - [**Workspace**](/docs/workspace) — the per-user customization layer (skills, memory, instructions, MCP) backed by SQL, not files

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -141,7 +141,9 @@
     "./tsconfig.base.json": "./tsconfig.base.json"
   },
   "sideEffects": [
-    "*.css"
+    "*.css",
+    "dist/client/chat/widgets/builtin-tool-renderers.js",
+    "dist/client/dev-overlay/builtins.js"
   ],
   "files": [
     "bin",

--- a/packages/core/src/cli/plan-local.spec.ts
+++ b/packages/core/src/cli/plan-local.spec.ts
@@ -7,7 +7,9 @@ import {
   buildLocalPlanPreviewHtml,
   localPlanFolderName,
   readLocalPlanFiles,
+  runPlan,
   startLocalPlanBridge,
+  validateLocalPlanFiles,
   verifyLocalPlanBridge,
   writeLocalPlanPreview,
 } from "./plan-local.js";
@@ -36,6 +38,97 @@ function tmpDir(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "an-plan-local-"));
   tmpRoots.push(root);
   return root;
+}
+
+async function captureRunPlan(argv: string[]) {
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+  const originalExit = process.exit;
+  let stdout = "";
+  let stderr = "";
+  let exitCode: string | number | null | undefined;
+
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdout += chunk.toString();
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += chunk.toString();
+    return true;
+  }) as typeof process.stderr.write;
+  process.exit = ((code?: string | number | null | undefined) => {
+    exitCode = code;
+    throw new Error(`process.exit(${code ?? 0})`);
+  }) as typeof process.exit;
+
+  try {
+    await runPlan(argv);
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      !error.message.startsWith("process.exit(")
+    ) {
+      throw error;
+    }
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    process.exit = originalExit;
+  }
+
+  return { stdout, stderr, exitCode };
+}
+
+async function waitForOutput(
+  predicate: () => boolean,
+  description: string,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > 5_000) {
+      throw new Error(`Timed out waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+async function captureRunningServe(argv: string[]) {
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+  let stdout = "";
+  let stderr = "";
+  let runError: unknown;
+  let stopped = false;
+
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdout += chunk.toString();
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += chunk.toString();
+    return true;
+  }) as typeof process.stderr.write;
+
+  const running = runPlan(argv).catch((error: unknown) => {
+    runError = error;
+  });
+
+  try {
+    await waitForOutput(
+      () => Boolean(runError) || stderr.includes("Local Plan bridge running"),
+      "Plan local bridge startup",
+    );
+    if (runError) throw runError;
+    stopped = process.emit("SIGTERM");
+    await running;
+    if (runError) throw runError;
+  } finally {
+    if (!stopped) process.emit("SIGTERM");
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  return { stdout, stderr };
 }
 
 function writeSamplePlan(dir: string) {
@@ -140,6 +233,63 @@ function writeQuestionFormMissingIds(dir: string) {
   );
 }
 
+function writeChecklistMissingItemLabel(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "plan.mdx"),
+    [
+      "---",
+      'title: "Checklist missing label"',
+      'kind: "plan"',
+      "---",
+      "",
+      "# Checklist missing label",
+      "",
+      '<Checklist items={[{ id: "ship" }]} />',
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+function writeQuestionFormMissingTitleAndMode(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "plan.mdx"),
+    [
+      "---",
+      'title: "Question form missing title/mode"',
+      'kind: "plan"',
+      "---",
+      "",
+      "# Question form missing title and mode",
+      "",
+      '<QuestionForm questions={[{ id: "q1", options: [{ id: "o1" }] }]} />',
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+function writeQuestionFormInvalidMode(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "plan.mdx"),
+    [
+      "---",
+      'title: "Question form invalid mode"',
+      'kind: "plan"',
+      "---",
+      "",
+      "# Question form invalid mode",
+      "",
+      '<QuestionForm questions={[{ id: "q1", title: "Pick", mode: "checkbox" }]} />',
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
 function writeScaffoldExamplePlan(dir: string) {
   // Mirrors the `plan local init` scaffold prose, which documents block usage
   // with an inline-code example. That example must NOT be linted as a real
@@ -167,6 +317,74 @@ function writeScaffoldExamplePlan(dir: string) {
 }
 
 describe("local plan CLI helpers", () => {
+  it("keeps plan serve as a compatibility alias for plan local serve", async () => {
+    const result = await captureRunPlan(["serve", "--help"]);
+
+    expect(result.exitCode).toBeUndefined();
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("agent-native plan serve --dir <folder>");
+    expect(result.stdout).toContain(
+      "compatibility alias for `plan local serve`",
+    );
+    expect(result.stdout).toContain(
+      "agent-native plan local serve --dir <folder>",
+    );
+  });
+
+  it("starts the bridge through both plan serve and plan local serve", async () => {
+    const dir = path.join(tmpDir(), "checkout");
+    writeSamplePlan(dir);
+    const aliasUrlFile = path.join(dir, "alias.plan-url");
+    const localUrlFile = path.join(dir, "local.plan-url");
+
+    const alias = await captureRunningServe([
+      "serve",
+      "--dir",
+      dir,
+      "--app-url",
+      "https://plan.example.com",
+      "--url-file",
+      aliasUrlFile,
+    ]);
+    const local = await captureRunningServe([
+      "local",
+      "serve",
+      "--dir",
+      dir,
+      "--app-url",
+      "https://plan.example.com",
+      "--url-file",
+      localUrlFile,
+    ]);
+
+    for (const [label, captured, urlFile] of [
+      ["alias", alias, aliasUrlFile],
+      ["local", local, localUrlFile],
+    ] as const) {
+      const result = JSON.parse(captured.stdout) as {
+        ok: boolean;
+        url: string;
+        bridgeUrl: string;
+        appUrl: string;
+        urlFile: string;
+      };
+      expect(result.ok, label).toBe(true);
+      expect(result.appUrl, label).toBe("https://plan.example.com");
+      expect(result.bridgeUrl, label).toContain("http://127.0.0.1:");
+      expect(result.url, label).toBe(
+        `https://plan.example.com/local-plans/checkout?bridge=${encodeURIComponent(
+          result.bridgeUrl,
+        )}`,
+      );
+      expect(result.urlFile, label).toBe(urlFile);
+      expect(fs.readFileSync(urlFile, "utf-8"), label).toBe(`${result.url}\n`);
+      expect(captured.stderr, label).toContain("Local Plan bridge running at");
+      expect(captured.stderr, label).toContain(
+        `Open URL written to ${urlFile}`,
+      );
+    }
+  });
+
   it("builds the same safe folder names as the Plan app local mirror", () => {
     expect(localPlanFolderName("Private / no-DB recap!")).toBe(
       "private-no-db-recap",
@@ -303,6 +521,41 @@ describe("local plan CLI helpers", () => {
     );
     await expect(startLocalPlanBridge({ dir })).rejects.toThrow(
       /QuestionForm questions\[0\]\.id is required/,
+    );
+  });
+
+  it("rejects missing checklist item labels (renderer schema parity)", () => {
+    const dir = path.join(tmpDir(), "bad-checklist-label");
+    writeChecklistMissingItemLabel(dir);
+
+    expect(() => writeLocalPlanPreview({ dir })).toThrow(
+      /Checklist items\[0\]\.label is required/,
+    );
+  });
+
+  it("rejects missing question title, mode, and option label", () => {
+    const dir = path.join(tmpDir(), "bad-question-required");
+    writeQuestionFormMissingTitleAndMode(dir);
+
+    const issues = validateLocalPlanFiles(readLocalPlanFiles(dir));
+    const messages = issues.map((issue) => issue.message);
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/questions\[0\]\.title is required/),
+        expect.stringMatching(/questions\[0\]\.mode is required/),
+        expect.stringMatching(
+          /questions\[0\]\.options\[0\]\.label is required/,
+        ),
+      ]),
+    );
+  });
+
+  it("rejects an invalid question mode value", () => {
+    const dir = path.join(tmpDir(), "bad-question-mode");
+    writeQuestionFormInvalidMode(dir);
+
+    expect(() => writeLocalPlanPreview({ dir })).toThrow(
+      /questions\[0\]\.mode is required by the Plan renderer schema/,
     );
   });
 

--- a/packages/core/src/cli/plan-local.ts
+++ b/packages/core/src/cli/plan-local.ts
@@ -1180,9 +1180,28 @@ function isStaticNonEmptyStringLiteral(value: string): boolean {
   return trimmed.slice(1, -1).trim().length > 0;
 }
 
-function hasRequiredStaticId(objectSource: string): boolean {
-  const prop = readTopLevelObjectProperty(objectSource, "id");
+function hasRequiredStaticString(objectSource: string, name: string): boolean {
+  const prop = readTopLevelObjectProperty(objectSource, name);
   return prop ? isStaticNonEmptyStringLiteral(prop.value) : false;
+}
+
+function hasRequiredStaticId(objectSource: string): boolean {
+  return hasRequiredStaticString(objectSource, "id");
+}
+
+function hasRequiredEnumLiteral(
+  objectSource: string,
+  name: string,
+  allowed: readonly string[],
+): boolean {
+  const prop = readTopLevelObjectProperty(objectSource, name);
+  if (!prop) return false;
+  const trimmed = prop.value.trim();
+  const quote = trimmed[0];
+  if (quote !== '"' && quote !== "'" && quote !== "`") return false;
+  if (!trimmed.endsWith(quote)) return false;
+  if (quote === "`" && /\$\{/.test(trimmed)) return false;
+  return allowed.includes(trimmed.slice(1, -1).trim());
 }
 
 function lintChecklistShape(
@@ -1222,14 +1241,25 @@ function lintChecklistShape(
       continue;
     }
     objects.forEach((item, index) => {
-      if (hasRequiredStaticId(item.source)) return;
-      addValidationIssue(
-        issues,
-        file,
-        source,
-        start + items.start + item.start,
-        `Checklist items[${index}].id is required by the Plan renderer schema; add a stable string id.`,
-      );
+      const base = start + items.start + item.start;
+      if (!hasRequiredStaticId(item.source)) {
+        addValidationIssue(
+          issues,
+          file,
+          source,
+          base,
+          `Checklist items[${index}].id is required by the Plan renderer schema; add a stable string id.`,
+        );
+      }
+      if (!hasRequiredStaticString(item.source, "label")) {
+        addValidationIssue(
+          issues,
+          file,
+          source,
+          base,
+          `Checklist items[${index}].label is required by the Plan renderer schema; add a non-empty string label.`,
+        );
+      }
     });
   }
 }
@@ -1281,13 +1311,38 @@ function lintQuestionFormShape(
       continue;
     }
     questionObjects.forEach((question, questionIndex) => {
+      const questionBase = start + questions.start + question.start;
       if (!hasRequiredStaticId(question.source)) {
         addValidationIssue(
           issues,
           file,
           source,
-          start + questions.start + question.start,
+          questionBase,
           `${tag} questions[${questionIndex}].id is required by the Plan renderer schema; add a stable string id.`,
+        );
+      }
+      if (!hasRequiredStaticString(question.source, "title")) {
+        addValidationIssue(
+          issues,
+          file,
+          source,
+          questionBase,
+          `${tag} questions[${questionIndex}].title is required by the Plan renderer schema; add a non-empty string title.`,
+        );
+      }
+      if (
+        !hasRequiredEnumLiteral(question.source, "mode", [
+          "single",
+          "multi",
+          "freeform",
+        ])
+      ) {
+        addValidationIssue(
+          issues,
+          file,
+          source,
+          questionBase,
+          `${tag} questions[${questionIndex}].mode is required by the Plan renderer schema; use "single", "multi", or "freeform".`,
         );
       }
       const options = readTopLevelObjectProperty(question.source, "options");
@@ -1304,18 +1359,30 @@ function lintQuestionFormShape(
         return;
       }
       optionObjects.forEach((option, optionIndex) => {
-        if (hasRequiredStaticId(option.source)) return;
-        addValidationIssue(
-          issues,
-          file,
-          source,
+        const optionBase =
           start +
-            questions.start +
-            question.start +
-            options.valueStart +
-            option.start,
-          `${tag} questions[${questionIndex}].options[${optionIndex}].id is required by the Plan renderer schema; add a stable string id.`,
-        );
+          questions.start +
+          question.start +
+          options.valueStart +
+          option.start;
+        if (!hasRequiredStaticId(option.source)) {
+          addValidationIssue(
+            issues,
+            file,
+            source,
+            optionBase,
+            `${tag} questions[${questionIndex}].options[${optionIndex}].id is required by the Plan renderer schema; add a stable string id.`,
+          );
+        }
+        if (!hasRequiredStaticString(option.source, "label")) {
+          addValidationIssue(
+            issues,
+            file,
+            source,
+            optionBase,
+            `${tag} questions[${questionIndex}].options[${optionIndex}].label is required by the Plan renderer schema; add a non-empty string label.`,
+          );
+        }
       });
     });
   }
@@ -1991,7 +2058,15 @@ async function runServe(args: Record<string, string | boolean>): Promise<void> {
   );
 
   await new Promise<void>((resolve) => {
+    let stopped = false;
+    const cleanup = () => {
+      process.off("SIGINT", stop);
+      process.off("SIGTERM", stop);
+    };
     const stop = () => {
+      if (stopped) return;
+      stopped = true;
+      cleanup();
       bridge.server.close(() => resolve());
     };
     process.once("SIGINT", stop);
@@ -2082,6 +2157,7 @@ const HELP = `agent-native plan — local Agent-Native Plan helpers
 
 Usage:
   agent-native plan blocks [--format reference|schema] [--app-url <url>] [--out <file>] [--json]
+  agent-native plan serve --dir <folder> [--app-url <url>] [--kind plan|recap] [--open] [--port <port>] [--url-file <file>]
   agent-native plan local init --title <title> [--brief <text>] [--kind plan|recap] [--dir <folder>] [--force]
   agent-native plan local check --dir <folder>
   agent-native plan local serve --dir <folder> [--app-url <url>] [--kind plan|recap] [--open] [--port <port>] [--url-file <file>]
@@ -2113,12 +2189,22 @@ Safari may block the hosted HTTPS page from reading the HTTP localhost bridge.
 Use \`plan local verify\` for headless bridge/CORS diagnostics that exit cleanly.
 Use \`plan local preview\` for a local Plan dev server route. \`preview --out\` is
 a legacy/debug escape hatch that writes a standalone static HTML file.
+\`plan serve\` is kept as a compatibility alias for \`plan local serve\`.
 `;
 
 export async function runPlan(argv: string[]): Promise<void> {
   const [area, sub, ...rest] = argv;
   if (area === "blocks") {
     await runBlocks(parseArgs(argv.slice(1)));
+    return;
+  }
+  if (area === "serve") {
+    const args = parseArgs(argv.slice(1));
+    if (args.help === true || args.h === true) {
+      process.stdout.write(HELP);
+      return;
+    }
+    await runServe(args);
     return;
   }
   if (area !== "local") {

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -1255,7 +1255,7 @@ describe("agent-native skills", () => {
     expect(runConnect).not.toHaveBeenCalled();
     expect(
       promptClients.mock.calls[0]?.[0].options.map((o) => o.value),
-    ).toEqual(["codex", "claude-code", "pi"]);
+    ).toEqual(["codex", "claude-code"]);
     expect(fs.existsSync(path.join(root, ".codex", "config.toml"))).toBe(false);
     expect(
       fs.existsSync(

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -1369,8 +1369,10 @@ The local-files contract is:
   writes only registry metadata to disk; use \`--format schema\` if exact nested
   fields are needed. If network access is unavailable, use the bundled
   references and rely on \`plan local check\` / \`plan local serve\` to catch
-  invalid tags. For \`checklist\` and \`question-form\`, copy the catalog examples:
-  checklist items need \`id\`, and question-form questions/options need \`id\`.
+  invalid tags. For \`checklist\` and \`question-form\`, copy the catalog examples
+  verbatim: checklist items need \`id\` and \`label\`; question-form questions need
+  \`id\`, \`title\`, and \`mode\`; and each option needs \`id\` and \`label\`. \`plan local
+  check\` validates these required fields against the renderer schema.
 - Write the plan as a local MDX folder: use \`plans/<slug>/\` when the user
   wants the artifact checked into the repo, or use a repo-ignored/temporary
   folder such as \`.agent-native/plans/<slug>/\` or \`/tmp/agent-native-plans/<slug>/\`
@@ -1535,8 +1537,10 @@ In local-files mode:
   \`get-plan-blocks\` route and sends no recap content. If network access is
   unavailable, use the bundled references and validate with
   \`plan local check\` / \`plan local serve\`. For \`checklist\` and \`question-form\`,
-  copy the catalog examples: checklist items need \`id\`, and question-form
-  questions/options need \`id\`.
+  copy the catalog examples verbatim: checklist items need \`id\` and \`label\`;
+  question-form questions need \`id\`, \`title\`, and \`mode\`; and each option needs
+  \`id\` and \`label\`. \`plan local check\` validates these required fields against
+  the renderer schema.
 - Write the recap as a local MDX folder: use \`plans/<slug>/\` when the user
   wants the artifact checked into the repo, or use a repo-ignored/temporary
   folder such as \`.agent-native/plans/<slug>/\` or \`/tmp/agent-native-plans/<slug>/\`
@@ -2377,6 +2381,10 @@ const SKILL_INSTRUCTION_CLIENTS: SkillInstructionClientId[] = [
   "codex",
   "claude-code",
   "pi",
+];
+const SKILL_INSTRUCTION_PROMPT_CLIENTS: SkillInstructionClientId[] = [
+  "codex",
+  "claude-code",
 ];
 // Clients that don't write their own instruction files but READ the shared
 // `.agents/skills` path the codex install writes. In instructions/local-files
@@ -3317,7 +3325,7 @@ function resolveSkillsClientArg(
 }
 
 function skillsClients(installsMcp: boolean): SkillInstructionClientId[] {
-  return installsMcp ? SKILLS_CLIENTS : SKILL_INSTRUCTION_CLIENTS;
+  return installsMcp ? SKILLS_CLIENTS : SKILL_INSTRUCTION_PROMPT_CLIENTS;
 }
 
 function filterSkillsClients(

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -29,6 +29,10 @@ import {
   type AgentChatSurfaceKind,
 } from "./agent-chat-adapter.js";
 import {
+  createAgentChatRuntimeAdapter,
+  type AgentChatRuntime,
+} from "./chat/runtime.js";
+import {
   appendAgentChatContextToMessage,
   formatAgentChatContextItemsForPrompt,
   normalizeAgentChatContextItem,
@@ -695,6 +699,13 @@ export interface AssistantChatProps {
    * sidebar SSE adapter when omitted.
    */
   createAdapter?: (context: AssistantChatAdapterContext) => ChatModelAdapter;
+  /**
+   * Bring-your-own agent runtime. When supplied, AssistantChat keeps the
+   * standard composer/transcript/tool rendering shell but sends turns through
+   * this runtime instead of the built-in Agent-Native SSE endpoint. If
+   * `createAdapter` is also supplied, the adapter override takes precedence.
+   */
+  runtime?: AgentChatRuntime;
   /**
    * Explicitly recreate an injected adapter when the host transport identity
    * changes. Omit for the production sidebar so parent rerenders do not reset
@@ -3303,6 +3314,8 @@ export const AssistantChat = forwardRef<
   const surface = props.agentChatSurface ?? "app";
   const createAdapterRef = useRef(props.createAdapter);
   createAdapterRef.current = props.createAdapter;
+  const runtimeRef = useRef(props.runtime);
+  runtimeRef.current = props.runtime;
 
   const adapter = useMemo(
     () => {
@@ -3319,14 +3332,30 @@ export const AssistantChat = forwardRef<
         surface,
       };
       const createAdapter = createAdapterRef.current;
-      return createAdapter
-        ? createAdapter(context)
-        : createAgentChatAdapter(context);
+      if (createAdapter) return createAdapter(context);
+      const runtime = runtimeRef.current;
+      if (runtime) {
+        return createAgentChatRuntimeAdapter(runtime, {
+          sessionId: threadId ?? tabId,
+          threadId,
+          modelRef,
+          effortRef,
+        });
+      }
+      return createAgentChatAdapter(context);
     },
     // Adapter factories must be memoized and use refs for changing values.
     // `adapterReloadKey` is an explicit opt-in for embedded hosts whose
     // transport identity can change without changing tab/thread ids.
-    [apiUrl, tabId, threadId, browserTabId, surface, props.adapterReloadKey],
+    [
+      apiUrl,
+      tabId,
+      threadId,
+      browserTabId,
+      surface,
+      props.runtime,
+      props.adapterReloadKey,
+    ],
   );
   const attachmentAdapter = useMemo(
     () =>

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -496,6 +496,57 @@ describe("createAgentChatAdapter", () => {
     });
   });
 
+  it("summarizes bare successful tool results in structured history", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(sseResponse([{ type: "done" }]));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-success-tool-results",
+    });
+
+    await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Sign me up" }],
+          },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolName: "signup",
+                args: {},
+                result: true,
+              },
+            ],
+          },
+          {
+            role: "user",
+            content: [{ type: "text", text: "continue" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    const serialized = JSON.stringify(body.structuredHistory);
+    expect(serialized).not.toContain('"true"');
+    expect(body.structuredHistory).toContainEqual({
+      role: "user",
+      content: [
+        expect.objectContaining({
+          type: "tool-result",
+          toolName: "signup",
+          content: "signup completed.",
+        }),
+      ],
+    });
+  });
+
   it("sends the explicit dev-frame surface for outer frame-hosted chat", async () => {
     const fetchSpy = vi.fn().mockResolvedValue(sseResponse([{ type: "done" }]));
     vi.stubGlobal("fetch", fetchSpy);

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -416,8 +416,39 @@ function isToolCallContentPart(
   );
 }
 
-function toolResultContent(result: unknown): string {
+function isSuccessOnlyToolResult(value: Record<string, unknown>): boolean {
+  const keys = Object.keys(value);
+  if (keys.length === 0) return true;
+  return keys.every((key) => {
+    const item = value[key];
+    if (key === "ok" || key === "success") return item === true;
+    if (key === "status") {
+      return item === "ok" || item === "success" || item === "completed";
+    }
+    return false;
+  });
+}
+
+function toolResultContent(result: unknown, toolName?: string): string {
   if (typeof result === "string") return result;
+  const completed = toolName?.trim()
+    ? `${toolName.trim()} completed.`
+    : "Tool completed.";
+  if (result === true || result == null) return completed;
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    const record = result as Record<string, unknown>;
+    const message = record.message ?? record.summary;
+    if (typeof message === "string" && message.trim()) return message.trim();
+    const title = record.title ?? record.name;
+    if (typeof title === "string" && title.trim()) {
+      return `${title.trim()} is ready.`;
+    }
+    const id = record.id ?? record.planId ?? record.commentId;
+    if (typeof id === "string" && id.trim() && toolName?.trim()) {
+      return `${toolName.trim()} completed for ${id.trim()}.`;
+    }
+    if (isSuccessOnlyToolResult(record)) return completed;
+  }
   try {
     return JSON.stringify(result);
   } catch {
@@ -482,11 +513,11 @@ function contentToStructuredMessages(
           toolInput: JSON.stringify(part.args ?? {}),
           content: truncate
             ? truncateForHistory(
-                toolResultContent(part.result),
+                toolResultContent(part.result, part.toolName),
                 MAX_HISTORY_TOOL_RESULT_CHARS,
                 "Tool result",
               )
-            : toolResultContent(part.result),
+            : toolResultContent(part.result, part.toolName),
         });
       } else {
         pendingToolResults.push({
@@ -563,7 +594,7 @@ function assistantUiMessagesToStructuredHistory(
               ? part.args
               : {},
           ...(part.result !== undefined
-            ? { result: toolResultContent(part.result) }
+            ? { result: toolResultContent(part.result, toolName) }
             : {}),
         });
       }

--- a/packages/core/src/client/chat/index.ts
+++ b/packages/core/src/client/chat/index.ts
@@ -46,7 +46,7 @@ export {
   type CodeAgentChatTranscriptEvent,
   type CreateCodeAgentChatAdapterOptions,
 } from "../code-agent-chat-adapter.js";
-export type * from "./runtime.js";
+export * from "./runtime.js";
 export { sendToAgentChat, type AgentChatMessage } from "../agent-chat.js";
 export { useAgentChatGenerating } from "../use-agent-chat.js";
 export { useSendToAgentChat } from "../use-send-to-agent-chat.js";

--- a/packages/core/src/client/chat/runtime.spec.ts
+++ b/packages/core/src/client/chat/runtime.spec.ts
@@ -1,11 +1,14 @@
-import { describe, expectTypeOf, it } from "vitest";
-import type {
-  AgentChatRuntime,
-  AgentChatRuntimeEvent,
-  AgentChatRuntimeKnownEvent,
-  AgentChatRuntimeMessage,
-  AgentChatRuntimeToolCall,
-  AgentChatRuntimeTurn,
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import {
+  createAgentChatRuntimeAdapter,
+  createAgentNativeChatRuntime,
+  createHttpAgentChatRuntime,
+  type AgentChatRuntime,
+  type AgentChatRuntimeEvent,
+  type AgentChatRuntimeKnownEvent,
+  type AgentChatRuntimeMessage,
+  type AgentChatRuntimeToolCall,
+  type AgentChatRuntimeTurn,
 } from "./runtime.js";
 import type { AgentChatRuntime as AgentChatRuntimeFromChatBarrel } from "./index.js";
 import type { AgentChatRuntime as AgentChatRuntimeFromClientBarrel } from "../index.js";
@@ -32,6 +35,33 @@ async function* streamRuntimeEvents(): AsyncIterable<AgentChatRuntimeEvent> {
     resultText: "Found docs",
   };
   yield { type: "done", reason: "complete" };
+}
+
+function sseResponse(events: unknown[], runId = "run-runtime"): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        const body = events
+          .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+          .join("");
+        controller.enqueue(new TextEncoder().encode(body));
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Run-Id": runId,
+      },
+    },
+  );
+}
+
+async function drain<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iterable) out.push(item);
+  return out;
 }
 
 describe("AgentChatRuntime types", () => {
@@ -101,5 +131,220 @@ describe("AgentChatRuntime types", () => {
   it("exports the runtime contract from client barrels", () => {
     expectTypeOf<AgentChatRuntimeFromChatBarrel>().toEqualTypeOf<AgentChatRuntime>();
     expectTypeOf<AgentChatRuntimeFromClientBarrel>().toEqualTypeOf<AgentChatRuntime>();
+  });
+});
+
+describe("createHttpAgentChatRuntime", () => {
+  it("posts turns, streams runtime events, exposes run id, and cancels", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sseResponse([
+          {
+            type: "message-start",
+            message: { id: "m1", role: "assistant", content: [] },
+          },
+          {
+            type: "message-delta",
+            messageId: "m1",
+            delta: { type: "text", text: "Hello" },
+          },
+          {
+            type: "message-done",
+            message: {
+              id: "m1",
+              role: "assistant",
+              content: [{ type: "text", text: "Hello" }],
+            },
+          },
+          { type: "done", reason: "complete" },
+        ]),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true })));
+
+    const runtime = createHttpAgentChatRuntime({
+      endpoint: "/agent/chat",
+      cancelEndpoint: ({ runId }) => `/agent/runs/${runId}/cancel`,
+      fetch: fetchMock as typeof fetch,
+      headers: { Authorization: "Bearer test" },
+    });
+
+    const session = await runtime.createSession({
+      id: "thread-1",
+      threadId: "thread-1",
+    });
+    const turn = await session.startTurn({ prompt: "Say hello" });
+    const events = await drain(turn.events);
+
+    expect(turn.runId).toBe("run-runtime");
+    expect(events.map((event) => event.type)).toEqual([
+      "message-start",
+      "message-delta",
+      "message-done",
+      "done",
+    ]);
+    expect(fetchMock.mock.calls[0][0]).toBe("/agent/chat");
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toMatchObject({
+      sessionId: "thread-1",
+      threadId: "thread-1",
+      prompt: "Say hello",
+    });
+
+    await turn.cancel?.({ reason: "user" });
+    expect(fetchMock.mock.calls[1][0]).toBe("/agent/runs/run-runtime/cancel");
+  });
+
+  it("accepts JSON response text as a simple assistant turn", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ text: "Done" }), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const runtime = createHttpAgentChatRuntime({
+      endpoint: "/agent/chat",
+      fetch: fetchMock as typeof fetch,
+    });
+
+    const turn = await (
+      await runtime.createSession()
+    ).startTurn({
+      prompt: "finish",
+    });
+    const events = await drain(turn.events);
+
+    expect(events.map((event) => event.type)).toEqual([
+      "message-start",
+      "message-delta",
+      "message-done",
+      "done",
+    ]);
+    expect(
+      (events[1] as Extract<AgentChatRuntimeEvent, { type: "message-delta" }>)
+        .delta,
+    ).toEqual({ type: "text", text: "Done" });
+  });
+});
+
+describe("createAgentNativeChatRuntime", () => {
+  it("wraps the existing Agent Native chat endpoint and normalizes SSE events", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      sseResponse([
+        { type: "text", text: "Looking" },
+        { type: "tool_start", id: "tool-1", tool: "list-forms", input: {} },
+        {
+          type: "tool_done",
+          id: "tool-1",
+          tool: "list-forms",
+          result: "ok",
+        },
+        { type: "done" },
+      ]),
+    );
+    const runtime = createAgentNativeChatRuntime({
+      apiUrl: "/_agent-native/agent-chat",
+      threadId: "thread-forms",
+      mode: "plan",
+      fetch: fetchMock as typeof fetch,
+    });
+
+    const turn = await (
+      await runtime.createSession()
+    ).startTurn({
+      prompt: "How many forms?",
+    });
+    const events = await drain(turn.events);
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toMatchObject({
+      message: "How many forms?",
+      threadId: "thread-forms",
+      mode: "plan",
+      turnId: turn.id,
+    });
+    expect(events.map((event) => event.type)).toEqual([
+      "message-start",
+      "message-delta",
+      "tool-start",
+      "tool-done",
+      "message-done",
+      "done",
+    ]);
+  });
+});
+
+describe("createAgentChatRuntimeAdapter", () => {
+  it("adapts runtime events into assistant-ui content", async () => {
+    const runtime: AgentChatRuntime = {
+      id: "external:test",
+      kind: "external-agent",
+      label: "Test",
+      capabilities: {
+        messages: { streaming: true },
+        sessions: { create: true },
+      },
+      async createSession() {
+        return {
+          id: "session-1",
+          runtimeId: "external:test",
+          async startTurn(input) {
+            async function* events(): AsyncIterable<AgentChatRuntimeEvent> {
+              yield {
+                type: "message-delta",
+                messageId: "m1",
+                delta: { type: "text", text: input.prompt ?? "" },
+              };
+              yield {
+                type: "tool-start",
+                toolCall: {
+                  id: "tool-1",
+                  name: "query",
+                  input: { q: "forms" },
+                },
+              };
+              yield {
+                type: "tool-done",
+                toolCallId: "tool-1",
+                toolName: "query",
+                status: "completed",
+                resultText: "34 rows",
+              };
+              yield { type: "done", reason: "complete" };
+            }
+            return {
+              id: "turn-1",
+              sessionId: "session-1",
+              runId: "run-1",
+              events: events(),
+            };
+          },
+        };
+      },
+    };
+    const adapter = createAgentChatRuntimeAdapter(runtime);
+
+    const results = await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Show forms" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+        runConfig: {},
+      } as any),
+    );
+
+    expect(results.at(-1)).toMatchObject({
+      content: [
+        { type: "text", text: "Show forms" },
+        {
+          type: "tool-call",
+          toolCallId: "tool-1",
+          toolName: "query",
+          result: "34 rows",
+        },
+      ],
+      metadata: { custom: { runtimeId: "external:test", runId: "run-1" } },
+    });
   });
 });

--- a/packages/core/src/client/chat/runtime.spec.ts
+++ b/packages/core/src/client/chat/runtime.spec.ts
@@ -347,4 +347,60 @@ describe("createAgentChatRuntimeAdapter", () => {
       metadata: { custom: { runtimeId: "external:test", runId: "run-1" } },
     });
   });
+
+  it("does not reuse an already-aborted signal for explicit cancel", async () => {
+    const abortController = new AbortController();
+    let cancelInput: Parameters<NonNullable<AgentChatRuntimeTurn["cancel"]>>[0];
+    const abortError = new Error("aborted");
+    abortError.name = "AbortError";
+
+    const runtime: AgentChatRuntime = {
+      id: "external:test",
+      kind: "external-agent",
+      label: "Test runtime",
+      capabilities: {
+        messages: { streaming: true, history: true },
+        cancellation: { abortSignal: true, explicitCancel: true },
+      },
+      async createSession() {
+        return {
+          id: "session-1",
+          runtimeId: "external:test",
+          async startTurn() {
+            async function* events(): AsyncIterable<AgentChatRuntimeEvent> {
+              throw abortError;
+            }
+            return {
+              id: "turn-1",
+              sessionId: "session-1",
+              runId: "run-1",
+              events: events(),
+              cancel: async (input) => {
+                cancelInput = input;
+                return { status: "cancelled" };
+              },
+            };
+          },
+        };
+      },
+    };
+    const adapter = createAgentChatRuntimeAdapter(runtime);
+
+    abortController.abort();
+    const results = await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Stop" }],
+          },
+        ],
+        abortSignal: abortController.signal,
+        runConfig: {},
+      } as any),
+    );
+
+    expect(results).toEqual([]);
+    expect(cancelInput).toEqual({ reason: "abort" });
+  });
 });

--- a/packages/core/src/client/chat/runtime.ts
+++ b/packages/core/src/client/chat/runtime.ts
@@ -1695,7 +1695,7 @@ export function createAgentChatRuntimeAdapter(
         }
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {
-          await turn.cancel?.({ reason: "abort", abortSignal });
+          await turn.cancel?.({ reason: "abort" });
           return;
         }
         throw error;

--- a/packages/core/src/client/chat/runtime.ts
+++ b/packages/core/src/client/chat/runtime.ts
@@ -1,6 +1,13 @@
+import type { ChatModelAdapter, ChatModelRunResult } from "@assistant-ui/react";
 import type { AgentMcpAppPayload } from "../../mcp-client/app-result.js";
 import type { ActionChatUIConfig } from "../../action-ui.js";
 import type { ReasoningEffort } from "../../shared/reasoning-effort.js";
+import { agentNativePath } from "../api-path.js";
+import {
+  settleInterruptedToolCalls,
+  type ContentPart,
+  type SSEEvent,
+} from "../sse-event-processor.js";
 
 export type AgentChatRuntimeId = string;
 export type AgentChatRuntimeSessionId = string;
@@ -272,7 +279,9 @@ export interface AgentChatRuntimeContinueInput {
 }
 
 export interface AgentChatRuntimeCancelInput {
+  readonly sessionId?: AgentChatRuntimeSessionId;
   readonly turnId?: AgentChatRuntimeTurnId;
+  readonly runId?: string;
   readonly reason?: string;
   readonly metadata?: AgentChatRuntimeMetadata;
   readonly abortSignal?: AbortSignal;
@@ -350,6 +359,7 @@ export interface AgentChatRuntimeToolDoneEvent extends AgentChatRuntimeEventBase
   readonly resultText?: string;
   readonly error?: string;
   readonly mcpApp?: AgentMcpAppPayload;
+  readonly chatUI?: ActionChatUIConfig;
 }
 
 export interface AgentChatRuntimeApprovalRequestEvent extends AgentChatRuntimeEventBase<"approval-request"> {
@@ -443,10 +453,29 @@ export interface AgentChatRuntimeTurn<
 > {
   readonly id?: AgentChatRuntimeTurnId;
   readonly sessionId: AgentChatRuntimeSessionId;
+  readonly runId?: string;
+  readonly metadata?: AgentChatRuntimeMetadata;
   readonly events: AsyncIterable<TEvent>;
   cancel?(
     input?: AgentChatRuntimeCancelInput,
   ): Promise<AgentChatRuntimeCancelResult>;
+}
+
+export interface AgentChatRuntimeSendMessageInput extends AgentChatRuntimeTurnInput {
+  readonly sessionId?: AgentChatRuntimeSessionId;
+}
+
+export interface AgentChatRuntimeSubscribeInput {
+  readonly sessionId?: AgentChatRuntimeSessionId;
+  readonly turnId?: AgentChatRuntimeTurnId;
+  readonly runId?: string;
+  readonly after?: number;
+  readonly metadata?: AgentChatRuntimeMetadata;
+  readonly abortSignal?: AbortSignal;
+}
+
+export interface AgentChatRuntimeResumeInput extends AgentChatRuntimeSubscribeInput {
+  readonly prompt?: string;
 }
 
 export interface AgentChatRuntimeSession<
@@ -456,6 +485,9 @@ export interface AgentChatRuntimeSession<
   readonly runtimeId: AgentChatRuntimeId;
   readonly threadId?: string;
   readonly capabilities?: Partial<AgentChatRuntimeCapabilities>;
+  sendMessage?(
+    input: AgentChatRuntimeTurnInput,
+  ): AgentChatRuntimeAwaitable<AgentChatRuntimeTurn<TEvent>>;
   startTurn(
     input: AgentChatRuntimeTurnInput,
   ): AgentChatRuntimeAwaitable<AgentChatRuntimeTurn<TEvent>>;
@@ -490,4 +522,1184 @@ export interface AgentChatRuntime<
   listSessions?(
     input?: AgentChatRuntimeListSessionsInput,
   ): AgentChatRuntimeAwaitable<readonly AgentChatRuntimeSessionSummary[]>;
+  sendMessage?(
+    input: AgentChatRuntimeSendMessageInput,
+  ): AgentChatRuntimeAwaitable<AgentChatRuntimeTurn<TEvent>>;
+  subscribe?(
+    input: AgentChatRuntimeSubscribeInput,
+  ): AgentChatRuntimeAwaitable<AsyncIterable<TEvent>>;
+  resume?(
+    input: AgentChatRuntimeResumeInput,
+  ): AgentChatRuntimeAwaitable<AgentChatRuntimeTurn<TEvent>>;
+  cancel?(
+    input: AgentChatRuntimeCancelInput,
+  ): Promise<AgentChatRuntimeCancelResult>;
+}
+
+type FetchLike = typeof fetch;
+type HeadersFactory =
+  | HeadersInit
+  | ((input: {
+      sessionId?: AgentChatRuntimeSessionId;
+      turnId?: AgentChatRuntimeTurnId;
+      runId?: string;
+    }) => HeadersInit | Promise<HeadersInit>);
+
+export interface CreateHttpAgentChatRuntimeOptions<
+  TEvent extends AgentChatRuntimeEventBase = AgentChatRuntimeKnownEvent,
+> {
+  readonly id?: AgentChatRuntimeId;
+  readonly kind?: AgentChatRuntimeKind;
+  readonly label?: string;
+  readonly description?: string;
+  readonly endpoint:
+    | string
+    | ((input: {
+        session: AgentChatRuntimeSessionSummary;
+        turn: AgentChatRuntimeTurnInput;
+      }) => string | URL);
+  readonly method?: "POST" | "PUT";
+  readonly headers?: HeadersFactory;
+  readonly credentials?: RequestCredentials;
+  readonly fetch?: FetchLike;
+  readonly capabilities?: Partial<AgentChatRuntimeCapabilities>;
+  readonly mapRequest?: (input: {
+    session: AgentChatRuntimeSessionSummary;
+    turn: AgentChatRuntimeTurnInput;
+    turnId: AgentChatRuntimeTurnId;
+  }) => unknown;
+  readonly mapEvent?: (
+    event: unknown,
+    context: {
+      sessionId: AgentChatRuntimeSessionId;
+      turnId?: AgentChatRuntimeTurnId;
+      runId?: string;
+    },
+  ) => TEvent | readonly TEvent[] | null;
+  readonly cancelEndpoint?:
+    | string
+    | ((input: AgentChatRuntimeCancelInput) => string | URL | null);
+  readonly resumeEndpoint?:
+    | string
+    | ((input: AgentChatRuntimeSubscribeInput) => string | URL | null);
+  readonly listSessionsEndpoint?: string | URL;
+  readonly getSessionEndpoint?:
+    | string
+    | ((input: { sessionId: AgentChatRuntimeSessionId }) => string | URL);
+}
+
+export interface CreateAgentNativeChatRuntimeOptions {
+  readonly id?: AgentChatRuntimeId;
+  readonly label?: string;
+  readonly description?: string;
+  readonly apiUrl?: string;
+  readonly headers?: HeadersFactory;
+  readonly fetch?: FetchLike;
+  readonly threadId?: string;
+  readonly browserTabId?: string;
+  readonly surface?: "app" | "dev-frame";
+  readonly mode?: "act" | "plan";
+  readonly model?: string;
+  readonly engine?: string;
+  readonly effort?: ReasoningEffort;
+  readonly scope?: unknown;
+}
+
+export interface CreateAgentChatRuntimeAdapterOptions {
+  readonly sessionId?: AgentChatRuntimeSessionId;
+  readonly threadId?: string;
+  readonly modelRef?: { current: string | undefined };
+  readonly effortRef?: { current: ReasoningEffort | undefined };
+  readonly metadata?: AgentChatRuntimeMetadata;
+}
+
+const DEFAULT_RUNTIME_CAPABILITIES: AgentChatRuntimeCapabilities = {
+  messages: {
+    streaming: true,
+    history: true,
+    structuredContent: true,
+    attachments: true,
+  },
+  tools: {
+    events: true,
+    hostTools: true,
+    resultStreaming: true,
+    mcpApps: true,
+  },
+  sessions: {
+    create: true,
+    restore: true,
+    persistent: true,
+  },
+  cancellation: {
+    abortSignal: true,
+    explicitCancel: true,
+  },
+  models: {
+    selectable: true,
+    reasoningEffort: true,
+  },
+  artifacts: {
+    files: true,
+    links: true,
+    progress: true,
+  },
+};
+
+function mergeCapabilities(
+  overrides?: Partial<AgentChatRuntimeCapabilities>,
+): AgentChatRuntimeCapabilities {
+  return {
+    ...DEFAULT_RUNTIME_CAPABILITIES,
+    ...overrides,
+    messages: {
+      ...DEFAULT_RUNTIME_CAPABILITIES.messages,
+      ...overrides?.messages,
+    },
+    tools: {
+      ...DEFAULT_RUNTIME_CAPABILITIES.tools,
+      ...overrides?.tools,
+      events:
+        overrides?.tools?.events ?? DEFAULT_RUNTIME_CAPABILITIES.tools!.events,
+    },
+    sessions: {
+      ...DEFAULT_RUNTIME_CAPABILITIES.sessions,
+      ...overrides?.sessions,
+      create:
+        overrides?.sessions?.create ??
+        DEFAULT_RUNTIME_CAPABILITIES.sessions!.create,
+    },
+    cancellation: {
+      ...DEFAULT_RUNTIME_CAPABILITIES.cancellation,
+      ...overrides?.cancellation,
+    },
+    models: { ...DEFAULT_RUNTIME_CAPABILITIES.models, ...overrides?.models },
+    artifacts: {
+      ...DEFAULT_RUNTIME_CAPABILITIES.artifacts,
+      ...overrides?.artifacts,
+    },
+  };
+}
+
+function createRuntimeId(prefix: string): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function createAbortController(signal?: AbortSignal): {
+  controller: AbortController;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  if (!signal) return { controller, cleanup: () => {} };
+  if (signal.aborted) controller.abort();
+  const abort = () => controller.abort();
+  signal.addEventListener("abort", abort, { once: true });
+  return {
+    controller,
+    cleanup: () => signal.removeEventListener("abort", abort),
+  };
+}
+
+async function resolveHeaders(
+  headers: HeadersFactory | undefined,
+  input: {
+    sessionId?: AgentChatRuntimeSessionId;
+    turnId?: AgentChatRuntimeTurnId;
+    runId?: string;
+  },
+): Promise<Headers> {
+  const resolved =
+    typeof headers === "function" ? await headers(input) : headers;
+  return new Headers(resolved);
+}
+
+function normalizeEndpoint(value: string | URL): string {
+  return typeof value === "string" ? value : value.toString();
+}
+
+function isRuntimeEvent(value: unknown): value is AgentChatRuntimeEventBase {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    typeof (value as { type?: unknown }).type === "string"
+  );
+}
+
+function parseJsonEvent(raw: string): unknown | null {
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed === "[DONE]") return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+async function* readJsonEventStream(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<unknown> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let pendingSseData: string[] = [];
+
+  const flushSseData = function* (): Generator<unknown> {
+    if (pendingSseData.length === 0) return;
+    const parsed = parseJsonEvent(pendingSseData.join("\n"));
+    pendingSseData = [];
+    if (parsed) yield parsed;
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (line.startsWith("data:")) {
+          pendingSseData.push(line.slice(5).trimStart());
+          continue;
+        }
+        if (line.trim() === "") {
+          yield* flushSseData();
+          continue;
+        }
+        const parsed = parseJsonEvent(line);
+        if (parsed) yield parsed;
+      }
+    }
+
+    if (buffer.trim()) {
+      const parsed = parseJsonEvent(buffer);
+      if (parsed) yield parsed;
+    }
+    yield* flushSseData();
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // Some browser runtimes consider a cancelled stream locked for a tick.
+    }
+  }
+}
+
+function textResponseEvents(
+  text: string,
+  sessionId: AgentChatRuntimeSessionId,
+  turnId?: AgentChatRuntimeTurnId,
+): AgentChatRuntimeKnownEvent[] {
+  const message: AgentChatRuntimeMessage = {
+    id: createRuntimeId("message"),
+    role: "assistant",
+    content: [],
+  };
+  return [
+    { type: "message-start", sessionId, turnId, message },
+    ...(text
+      ? [
+          {
+            type: "message-delta" as const,
+            sessionId,
+            turnId,
+            messageId: message.id,
+            delta: { type: "text" as const, text },
+          },
+        ]
+      : []),
+    { type: "message-done", sessionId, turnId, message },
+    { type: "done", sessionId, turnId, reason: "complete" },
+  ];
+}
+
+async function* eventsFromJsonResponse(
+  value: unknown,
+  sessionId: AgentChatRuntimeSessionId,
+  turnId?: AgentChatRuntimeTurnId,
+): AsyncGenerator<AgentChatRuntimeEvent> {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (isRuntimeEvent(item)) yield item as AgentChatRuntimeEvent;
+    }
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  const record = value as Record<string, unknown>;
+  if (Array.isArray(record.events)) {
+    for (const item of record.events) {
+      if (isRuntimeEvent(item)) yield item as AgentChatRuntimeEvent;
+    }
+    return;
+  }
+  const text =
+    typeof record.message === "string"
+      ? record.message
+      : typeof record.text === "string"
+        ? record.text
+        : "";
+  if (text) {
+    for (const event of textResponseEvents(text, sessionId, turnId)) {
+      yield event;
+    }
+  }
+}
+
+function defaultMapHttpRuntimeEvent(
+  event: unknown,
+  _context?: {
+    sessionId: AgentChatRuntimeSessionId;
+    turnId?: AgentChatRuntimeTurnId;
+    runId?: string;
+  },
+): AgentChatRuntimeEvent | readonly AgentChatRuntimeEvent[] | null {
+  if (!isRuntimeEvent(event)) return null;
+  return event as AgentChatRuntimeEvent;
+}
+
+function normalizeMappedEvents<TEvent extends AgentChatRuntimeEventBase>(
+  mapped: TEvent | readonly TEvent[] | null,
+): readonly TEvent[] {
+  if (!mapped) return [];
+  return Array.isArray(mapped)
+    ? (mapped as readonly TEvent[])
+    : [mapped as TEvent];
+}
+
+async function* streamResponseEvents<TEvent extends AgentChatRuntimeEventBase>(
+  response: Response,
+  input: {
+    sessionId: AgentChatRuntimeSessionId;
+    turnId?: AgentChatRuntimeTurnId;
+    runId?: string;
+    mapEvent: (
+      event: unknown,
+      context: {
+        sessionId: AgentChatRuntimeSessionId;
+        turnId?: AgentChatRuntimeTurnId;
+        runId?: string;
+      },
+    ) => TEvent | readonly TEvent[] | null;
+  },
+): AsyncGenerator<TEvent> {
+  const context = {
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    runId: input.runId,
+  };
+  const contentType = response.headers.get("content-type") ?? "";
+  if (response.body && !contentType.includes("application/json")) {
+    for await (const raw of readJsonEventStream(response.body)) {
+      for (const event of normalizeMappedEvents(input.mapEvent(raw, context))) {
+        yield event;
+      }
+    }
+    return;
+  }
+
+  const json = await response.json().catch(() => null);
+  for await (const event of eventsFromJsonResponse(
+    json,
+    input.sessionId,
+    input.turnId,
+  )) {
+    for (const mapped of normalizeMappedEvents(
+      input.mapEvent(event, context),
+    )) {
+      yield mapped;
+    }
+  }
+}
+
+function defaultHttpRuntimeRequest(input: {
+  session: AgentChatRuntimeSessionSummary;
+  turn: AgentChatRuntimeTurnInput;
+  turnId: AgentChatRuntimeTurnId;
+}) {
+  return {
+    sessionId: input.session.id,
+    threadId: input.session.threadId,
+    turnId: input.turnId,
+    prompt: input.turn.prompt,
+    messages: input.turn.messages,
+    attachments: input.turn.attachments,
+    tools: input.turn.tools,
+    model: input.turn.model,
+    reasoningEffort: input.turn.reasoningEffort,
+    temperature: input.turn.temperature,
+    providerOptions: input.turn.providerOptions,
+    metadata: input.turn.metadata,
+  };
+}
+
+async function readErrorText(response: Response): Promise<string> {
+  const text = await response.text().catch(() => "");
+  if (!text) return `HTTP ${response.status}`;
+  try {
+    const parsed = JSON.parse(text) as { error?: unknown; message?: unknown };
+    if (typeof parsed.error === "string") return parsed.error;
+    if (typeof parsed.message === "string") return parsed.message;
+  } catch {
+    // Keep raw text.
+  }
+  return text.slice(0, 500);
+}
+
+export function createHttpAgentChatRuntime<
+  TEvent extends AgentChatRuntimeEventBase = AgentChatRuntimeKnownEvent,
+>(
+  options: CreateHttpAgentChatRuntimeOptions<TEvent>,
+): AgentChatRuntime<TEvent> {
+  const fetchImpl = options.fetch ?? fetch;
+  const capabilities = mergeCapabilities(options.capabilities);
+  const runtimeId = options.id ?? "external:http";
+  const mapEvent =
+    options.mapEvent ??
+    (defaultMapHttpRuntimeEvent as (
+      event: unknown,
+      context: {
+        sessionId: AgentChatRuntimeSessionId;
+        turnId?: AgentChatRuntimeTurnId;
+        runId?: string;
+      },
+    ) => TEvent | readonly TEvent[] | null);
+
+  const createSessionObject = (
+    input?: AgentChatRuntimeCreateSessionInput,
+  ): AgentChatRuntimeSession<TEvent> => {
+    const sessionId =
+      input?.id ?? input?.threadId ?? createRuntimeId("session");
+    const summary: AgentChatRuntimeSessionSummary = {
+      id: sessionId,
+      runtimeId,
+      threadId: input?.threadId,
+      title: input?.title,
+      status: "idle",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      metadata: input?.metadata,
+    };
+
+    const startTurn = async (
+      turn: AgentChatRuntimeTurnInput,
+    ): Promise<AgentChatRuntimeTurn<TEvent>> => {
+      const turnId = createRuntimeId("turn");
+      const { controller, cleanup } = createAbortController(turn.abortSignal);
+      const endpoint =
+        typeof options.endpoint === "function"
+          ? options.endpoint({ session: summary, turn })
+          : options.endpoint;
+      const headers = await resolveHeaders(options.headers, {
+        sessionId,
+        turnId,
+      });
+      if (!headers.has("Content-Type"))
+        headers.set("Content-Type", "application/json");
+      const response = await fetchImpl(normalizeEndpoint(endpoint), {
+        method: options.method ?? "POST",
+        headers,
+        credentials: options.credentials,
+        body: JSON.stringify(
+          options.mapRequest
+            ? options.mapRequest({ session: summary, turn, turnId })
+            : defaultHttpRuntimeRequest({ session: summary, turn, turnId }),
+        ),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        cleanup();
+        throw new Error(await readErrorText(response));
+      }
+
+      const runId = response.headers.get("X-Run-Id") ?? undefined;
+      const events = (async function* () {
+        try {
+          yield* streamResponseEvents(response, {
+            sessionId,
+            turnId,
+            runId,
+            mapEvent,
+          });
+        } finally {
+          cleanup();
+        }
+      })();
+
+      return {
+        id: turnId,
+        sessionId,
+        runId,
+        events,
+        cancel: async (cancelInput) => {
+          controller.abort();
+          if (!options.cancelEndpoint) return { status: "cancelled" };
+          const endpoint =
+            typeof options.cancelEndpoint === "function"
+              ? options.cancelEndpoint({
+                  ...cancelInput,
+                  sessionId,
+                  turnId,
+                  runId,
+                })
+              : options.cancelEndpoint;
+          if (!endpoint) return { status: "unsupported" };
+          const cancelHeaders = await resolveHeaders(options.headers, {
+            sessionId,
+            turnId,
+          });
+          if (!cancelHeaders.has("Content-Type")) {
+            cancelHeaders.set("Content-Type", "application/json");
+          }
+          const cancelResponse = await fetchImpl(normalizeEndpoint(endpoint), {
+            method: "POST",
+            headers: cancelHeaders,
+            credentials: options.credentials,
+            body: JSON.stringify({
+              sessionId,
+              turnId,
+              runId,
+              reason: cancelInput?.reason ?? "user",
+              metadata: cancelInput?.metadata,
+            }),
+            signal: cancelInput?.abortSignal,
+          });
+          return cancelResponse.ok
+            ? { status: "cancelled" }
+            : {
+                status: "unsupported",
+                message: await readErrorText(cancelResponse),
+              };
+        },
+      };
+    };
+
+    return {
+      id: sessionId,
+      runtimeId,
+      threadId: input?.threadId,
+      capabilities,
+      sendMessage: startTurn,
+      startTurn,
+      snapshot: () => ({
+        ...summary,
+        status: "idle",
+        updatedAt: new Date().toISOString(),
+        messages: input?.messages,
+        resumeState: input?.resumeState,
+      }),
+      dispose: () => undefined,
+    };
+  };
+
+  const runtime: AgentChatRuntime<TEvent> = {
+    id: runtimeId,
+    kind: options.kind ?? "external-agent",
+    label: options.label ?? "External agent",
+    description: options.description,
+    capabilities,
+    createSession: createSessionObject,
+    restoreSession: (snapshot) =>
+      createSessionObject({
+        id: snapshot.id,
+        threadId: snapshot.threadId,
+        title: snapshot.title,
+        messages: snapshot.messages,
+        resumeState: snapshot.resumeState,
+        metadata: snapshot.metadata,
+      }),
+    sendMessage: async (input) => {
+      const session = createSessionObject({
+        id: input.sessionId,
+        threadId: input.sessionId,
+        metadata: input.metadata,
+      });
+      return session.startTurn(input);
+    },
+    subscribe: async (input) => {
+      if (!options.resumeEndpoint) return (async function* () {})();
+      const endpoint =
+        typeof options.resumeEndpoint === "function"
+          ? options.resumeEndpoint(input)
+          : options.resumeEndpoint;
+      if (!endpoint) return (async function* () {})();
+      const headers = await resolveHeaders(options.headers, input);
+      const response = await fetchImpl(normalizeEndpoint(endpoint), {
+        headers,
+        credentials: options.credentials,
+        signal: input.abortSignal,
+      });
+      if (!response.ok) throw new Error(await readErrorText(response));
+      return streamResponseEvents(response, {
+        sessionId: input.sessionId ?? "session",
+        turnId: input.turnId,
+        runId: input.runId,
+        mapEvent,
+      });
+    },
+    resume: async (input) => {
+      const sessionId = input.sessionId ?? createRuntimeId("session");
+      const events = runtime.subscribe
+        ? await runtime.subscribe(input)
+        : (async function* () {})();
+      return {
+        id: input.turnId,
+        sessionId,
+        runId: input.runId,
+        events,
+      };
+    },
+    cancel: async (input) => {
+      if (!options.cancelEndpoint) return { status: "unsupported" };
+      const endpoint =
+        typeof options.cancelEndpoint === "function"
+          ? options.cancelEndpoint(input)
+          : options.cancelEndpoint;
+      if (!endpoint) return { status: "unsupported" };
+      const headers = await resolveHeaders(options.headers, input);
+      if (!headers.has("Content-Type"))
+        headers.set("Content-Type", "application/json");
+      const response = await fetchImpl(normalizeEndpoint(endpoint), {
+        method: "POST",
+        headers,
+        credentials: options.credentials,
+        body: JSON.stringify(input),
+        signal: input.abortSignal,
+      });
+      return response.ok
+        ? { status: "cancelled" }
+        : { status: "unsupported", message: await readErrorText(response) };
+    },
+  };
+
+  return runtime;
+}
+
+function runtimeMessageText(message: AgentChatRuntimeMessage): string {
+  return message.content
+    .map((part) =>
+      part.type === "text" || part.type === "reasoning" ? part.text : "",
+    )
+    .filter(Boolean)
+    .join("\n");
+}
+
+function nativeHistoryFromMessages(
+  messages: readonly AgentChatRuntimeMessage[] | undefined,
+  currentPrompt: string,
+) {
+  const history = (messages ?? [])
+    .filter(
+      (message) => message.role === "user" || message.role === "assistant",
+    )
+    .map((message) => ({
+      role: message.role as "user" | "assistant",
+      content: runtimeMessageText(message),
+    }))
+    .filter((message) => message.content.trim());
+  if (!currentPrompt.trim()) return history;
+  const last = history[history.length - 1];
+  return last?.role === "user" && last.content === currentPrompt
+    ? history.slice(0, -1)
+    : history;
+}
+
+function mapAgentNativeEvent(
+  raw: unknown,
+  input: {
+    sessionId: AgentChatRuntimeSessionId;
+    turnId?: AgentChatRuntimeTurnId;
+    messageId: string;
+    text: { value: string; started: boolean };
+  },
+): AgentChatRuntimeKnownEvent[] {
+  if (!raw || typeof raw !== "object") return [];
+  const ev = raw as SSEEvent;
+  const base = {
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+  };
+  if (ev.seq !== undefined) {
+    (base as { metadata?: AgentChatRuntimeMetadata }).metadata = {
+      seq: ev.seq,
+    };
+  }
+  if (ev.type === "text") {
+    const text = ev.text ?? "";
+    const events: AgentChatRuntimeKnownEvent[] = [];
+    if (!input.text.started) {
+      input.text.started = true;
+      events.push({
+        type: "message-start",
+        ...base,
+        message: {
+          id: input.messageId,
+          role: "assistant",
+          content: [],
+        },
+      });
+    }
+    input.text.value += text;
+    events.push({
+      type: "message-delta",
+      ...base,
+      messageId: input.messageId,
+      delta: { type: "text", text },
+    });
+    return events;
+  }
+  if (ev.type === "activity") {
+    return [
+      {
+        type: "status",
+        ...base,
+        message: ev.label ?? ev.tool ?? "Working",
+        metadata: ev.tool ? { tool: ev.tool } : undefined,
+      },
+    ];
+  }
+  if (ev.type === "tool_start") {
+    return [
+      {
+        type: "tool-start",
+        ...base,
+        toolCall: {
+          id: ev.id ?? createRuntimeId("tool"),
+          name: ev.tool ?? "unknown",
+          input: ev.input,
+          inputText: ev.input ? JSON.stringify(ev.input) : undefined,
+        },
+      },
+    ];
+  }
+  if (ev.type === "tool_done") {
+    return [
+      {
+        type: "tool-done",
+        ...base,
+        toolCallId: ev.id ?? "",
+        toolName: ev.tool ?? "unknown",
+        status: ev.error ? "failed" : "completed",
+        result: ev.result,
+        resultText:
+          typeof ev.result === "string"
+            ? ev.result
+            : ev.result !== undefined
+              ? JSON.stringify(ev.result)
+              : undefined,
+        error: ev.error,
+        mcpApp: ev.mcpApp,
+        chatUI: ev.chatUI,
+      },
+    ];
+  }
+  if (ev.type === "approval_required") {
+    return [
+      {
+        type: "approval-request",
+        ...base,
+        approvalId: ev.approvalKey ?? ev.id ?? createRuntimeId("approval"),
+        toolCallId: ev.id,
+        toolName: ev.tool,
+        message: ev.label ?? "Approve this tool call?",
+        input: ev.input,
+      },
+    ];
+  }
+  if (ev.type === "error" || ev.type === "missing_api_key") {
+    return [
+      {
+        type: "error",
+        ...base,
+        error: ev.error ?? "Agent chat failed.",
+        code: ev.errorCode,
+        recoverable: ev.recoverable,
+      },
+      { type: "done", ...base, reason: "error" },
+    ];
+  }
+  if (ev.type === "done") {
+    const message: AgentChatRuntimeMessage = {
+      id: input.messageId,
+      role: "assistant",
+      content: input.text.value
+        ? [{ type: "text", text: input.text.value }]
+        : [],
+    };
+    return [
+      ...(input.text.started
+        ? [{ type: "message-done" as const, ...base, message }]
+        : []),
+      { type: "done", ...base, reason: "complete" },
+    ];
+  }
+  return [];
+}
+
+export function createAgentNativeChatRuntime(
+  options: CreateAgentNativeChatRuntimeOptions = {},
+): AgentChatRuntime<AgentChatRuntimeKnownEvent> {
+  const apiUrl = options.apiUrl ?? agentNativePath("/_agent-native/agent-chat");
+  const runtimeId = options.id ?? "agent-native";
+  const fetchImpl = options.fetch ?? fetch;
+
+  return createHttpAgentChatRuntime({
+    id: runtimeId,
+    kind: "agent-native",
+    label: options.label ?? "Agent Native",
+    description:
+      options.description ?? "Agent-Native's built-in chat transport.",
+    endpoint: apiUrl,
+    fetch: fetchImpl,
+    headers: async (input) => {
+      const headers = await resolveHeaders(options.headers, input);
+      headers.set("x-agent-native-surface", options.surface ?? "app");
+      return headers;
+    },
+    capabilities: DEFAULT_RUNTIME_CAPABILITIES,
+    mapRequest: ({ session, turn, turnId }) => {
+      const prompt =
+        turn.prompt ??
+        [...(turn.messages ?? [])]
+          .reverse()
+          .find((message) => message.role === "user")
+          ?.content.map((part) => (part.type === "text" ? part.text : ""))
+          .join("\n") ??
+        "";
+      return {
+        message: prompt,
+        displayMessage: prompt,
+        history: nativeHistoryFromMessages(turn.messages, prompt),
+        turnId,
+        threadId: session.threadId ?? options.threadId,
+        ...(options.mode ? { mode: options.mode } : {}),
+        ...((turn.model ?? options.model)
+          ? { model: turn.model ?? options.model }
+          : {}),
+        ...(options.engine ? { engine: options.engine } : {}),
+        ...((turn.reasoningEffort ?? options.effort)
+          ? { effort: turn.reasoningEffort ?? options.effort }
+          : {}),
+        ...(options.browserTabId ? { browserTabId: options.browserTabId } : {}),
+        ...(options.scope ? { scope: options.scope } : {}),
+        ...(turn.attachments?.length ? { attachments: turn.attachments } : {}),
+        ...(turn.metadata ? { metadata: turn.metadata } : {}),
+      };
+    },
+    mapEvent: (() => {
+      const states = new Map<
+        string,
+        { messageId: string; text: { value: string; started: boolean } }
+      >();
+      return (
+        event: unknown,
+        context: {
+          sessionId: AgentChatRuntimeSessionId;
+          turnId?: AgentChatRuntimeTurnId;
+        },
+      ) => {
+        const stateKey = context.turnId ?? context.sessionId;
+        let state = states.get(stateKey);
+        if (!state) {
+          state = {
+            messageId: createRuntimeId("message"),
+            text: { value: "", started: false },
+          };
+          states.set(stateKey, state);
+        }
+        const mapped = mapAgentNativeEvent(event, {
+          sessionId: context.sessionId,
+          turnId: context.turnId,
+          messageId: state.messageId,
+          text: state.text,
+        });
+        const type =
+          event && typeof event === "object"
+            ? (event as { type?: unknown }).type
+            : undefined;
+        if (type === "done" || type === "error" || type === "missing_api_key") {
+          states.delete(stateKey);
+        }
+        return mapped;
+      };
+    })(),
+    cancelEndpoint: (input) =>
+      input.runId
+        ? `${apiUrl}/runs/${encodeURIComponent(input.runId)}/abort`
+        : null,
+    resumeEndpoint: (input) =>
+      input.runId
+        ? `${apiUrl}/runs/${encodeURIComponent(input.runId)}/events?after=${input.after ?? 0}`
+        : null,
+  });
+}
+
+function toContentPartInput(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const out: Record<string, string> = {};
+  for (const [key, item] of Object.entries(value)) {
+    out[key] = typeof item === "string" ? item : JSON.stringify(item);
+  }
+  return out;
+}
+
+function toolResultText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function applyRuntimeEventToContent(
+  event: AgentChatRuntimeEventBase,
+  content: ContentPart[],
+): ChatModelRunResult | null {
+  const typed = event as AgentChatRuntimeKnownEvent;
+  if (typed.type === "message-start") {
+    for (const part of typed.message.content) {
+      if (part.type === "text" && part.text) {
+        content.push({ type: "text", text: part.text });
+      }
+    }
+    return { content: [...content] } as ChatModelRunResult;
+  }
+  if (typed.type === "message-delta") {
+    if (typed.delta.type === "text") {
+      const last = content[content.length - 1];
+      if (last?.type === "text") {
+        last.text += typed.delta.text;
+      } else {
+        content.push({ type: "text", text: typed.delta.text });
+      }
+      return { content: [...content] } as ChatModelRunResult;
+    }
+    return null;
+  }
+  if (typed.type === "message-done") {
+    return { content: [...content] } as ChatModelRunResult;
+  }
+  if (typed.type === "tool-start") {
+    content.push({
+      type: "tool-call",
+      toolCallId: typed.toolCall.id,
+      toolName: typed.toolCall.name,
+      argsText:
+        typed.toolCall.inputText ?? JSON.stringify(typed.toolCall.input ?? {}),
+      args: toContentPartInput(typed.toolCall.input),
+    });
+    return { content: [...content] } as ChatModelRunResult;
+  }
+  if (typed.type === "tool-delta") {
+    const part = [...content]
+      .reverse()
+      .find(
+        (candidate): candidate is Extract<ContentPart, { type: "tool-call" }> =>
+          candidate.type === "tool-call" &&
+          candidate.toolCallId === typed.toolCallId,
+      );
+    if (!part) return null;
+    if (typed.inputTextDelta) {
+      part.argsText += typed.inputTextDelta;
+    }
+    if (typed.resultTextDelta) {
+      part.result = `${part.result ?? ""}${typed.resultTextDelta}`;
+    }
+    return { content: [...content] } as ChatModelRunResult;
+  }
+  if (typed.type === "tool-done") {
+    const part = [...content]
+      .reverse()
+      .find(
+        (candidate): candidate is Extract<ContentPart, { type: "tool-call" }> =>
+          candidate.type === "tool-call" &&
+          candidate.toolCallId === typed.toolCallId,
+      );
+    if (part) {
+      part.result =
+        typed.error ?? typed.resultText ?? toolResultText(typed.result);
+      if (typed.mcpApp) part.mcpApp = typed.mcpApp;
+      if (typed.chatUI) part.chatUI = typed.chatUI;
+    }
+    return { content: [...content] } as ChatModelRunResult;
+  }
+  if (typed.type === "approval-request") {
+    const part = [...content]
+      .reverse()
+      .find(
+        (candidate): candidate is Extract<ContentPart, { type: "tool-call" }> =>
+          candidate.type === "tool-call" &&
+          (candidate.toolCallId === typed.toolCallId ||
+            candidate.toolName === typed.toolName),
+      );
+    if (part) {
+      part.approval = { approvalKey: typed.approvalId };
+    } else {
+      content.push({
+        type: "tool-call",
+        toolCallId: typed.toolCallId ?? typed.approvalId,
+        toolName: typed.toolName ?? "approval",
+        argsText: typed.input ? JSON.stringify(typed.input) : "",
+        args: toContentPartInput(typed.input),
+        approval: { approvalKey: typed.approvalId },
+      });
+    }
+    return { content: [...content] } as ChatModelRunResult;
+  }
+  if (typed.type === "error") {
+    settleInterruptedToolCalls(content);
+    content.push({
+      type: "text",
+      text: `Something went wrong: ${typed.error}`,
+    });
+    return {
+      content: [...content],
+      status: { type: "incomplete", reason: "error" },
+      metadata: {
+        custom: {
+          runError: {
+            message: typed.error,
+            ...(typed.code ? { errorCode: typed.code } : {}),
+            ...(typed.recoverable ? { recoverable: typed.recoverable } : {}),
+          },
+        },
+      },
+    } as ChatModelRunResult;
+  }
+  if (typed.type === "done") {
+    return {
+      content: [...content],
+      status:
+        typed.reason === "error"
+          ? { type: "incomplete", reason: "error" }
+          : { type: "complete", reason: "stop" },
+    } as ChatModelRunResult;
+  }
+  return null;
+}
+
+function assistantMessageText(message: {
+  content?: readonly { type: string; text?: string }[];
+}): string {
+  return (message.content ?? [])
+    .filter(
+      (part): part is { type: string; text: string } => part.type === "text",
+    )
+    .map((part) => part.text)
+    .join("\n");
+}
+
+function assistantMessagesToRuntimeMessages(
+  messages: readonly {
+    role: string;
+    content?: readonly { type: string; text?: string; image?: string }[];
+  }[],
+): AgentChatRuntimeMessage[] {
+  return messages
+    .filter(
+      (message) => message.role === "user" || message.role === "assistant",
+    )
+    .map((message, index) => {
+      const content: AgentChatRuntimeKnownContentPart[] = [];
+      for (const part of message.content ?? []) {
+        if (part.type === "text" && typeof part.text === "string") {
+          content.push({ type: "text", text: part.text });
+        } else if (part.type === "image" && typeof part.image === "string") {
+          content.push({ type: "image", data: part.image });
+        }
+      }
+      return {
+        id: `assistant-ui-${index}`,
+        role: message.role as "user" | "assistant",
+        content,
+      };
+    });
+}
+
+function latestUserPrompt(
+  messages: readonly {
+    role: string;
+    content?: readonly { type: string; text?: string }[];
+  }[],
+): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role !== "user") continue;
+    return assistantMessageText(message);
+  }
+  return "";
+}
+
+export function createAgentChatRuntimeAdapter(
+  runtime: AgentChatRuntime,
+  options: CreateAgentChatRuntimeAdapterOptions = {},
+): ChatModelAdapter {
+  let sessionPromise: Promise<AgentChatRuntimeSession> | null = null;
+  const getSession = () => {
+    sessionPromise ??= Promise.resolve(
+      runtime.createSession({
+        id: options.sessionId ?? options.threadId,
+        threadId: options.threadId,
+        metadata: options.metadata,
+      }),
+    );
+    return sessionPromise;
+  };
+
+  return {
+    async *run({ messages, abortSignal }) {
+      const adapterMessages = messages as readonly {
+        role: string;
+        content?: readonly { type: string; text?: string; image?: string }[];
+      }[];
+      const session = await getSession();
+      const prompt = latestUserPrompt(adapterMessages);
+      const turn = await session.startTurn({
+        prompt,
+        messages: assistantMessagesToRuntimeMessages(adapterMessages),
+        model: options.modelRef?.current,
+        reasoningEffort: options.effortRef?.current,
+        abortSignal,
+        metadata: options.metadata,
+      });
+      const content: ContentPart[] = [];
+      try {
+        for await (const event of turn.events) {
+          const result = applyRuntimeEventToContent(event, content);
+          if (result) {
+            const metadata = (result.metadata ?? {}) as Record<string, unknown>;
+            const custom =
+              metadata.custom && typeof metadata.custom === "object"
+                ? (metadata.custom as Record<string, unknown>)
+                : {};
+            yield {
+              ...result,
+              metadata: {
+                ...metadata,
+                custom: {
+                  ...custom,
+                  runtimeId: runtime.id,
+                  ...(turn.runId ? { runId: turn.runId } : {}),
+                },
+              },
+            } as ChatModelRunResult;
+          }
+        }
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") {
+          await turn.cancel?.({ reason: "abort", abortSignal });
+          return;
+        }
+        throw error;
+      }
+    },
+  };
 }

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -512,7 +512,7 @@ export {
   type ToolRendererProps,
   type ToolRendererRegistration,
 } from "./chat/tool-render-registry.js";
-export type * from "./chat/runtime.js";
+export * from "./chat/runtime.js";
 export {
   ACTION_CHAT_UI_DATA_CHART_RENDERER,
   ACTION_CHAT_UI_DATA_INSIGHTS_RENDERER,

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -868,6 +868,26 @@ async function buildCloudflarePages() {
     generateRequireShim(),
   );
 
+  const nitroServerAssetsStub = path.join(
+    tmpDir,
+    "_nitro-server-assets-stub.js",
+  );
+  fs.writeFileSync(
+    nitroServerAssetsStub,
+    [
+      "const empty = async () => undefined;",
+      "export const assets = {",
+      "  getItem: empty,",
+      "  getItemRaw: empty,",
+      "  getKeys: async () => [],",
+      "  getMeta: async () => undefined,",
+      "  hasItem: async () => false,",
+      "};",
+      "export default assets;",
+      "",
+    ].join("\n"),
+  );
+
   // Create stub modules for native/Node-only deps that can't run on Workers.
   // These get resolved by esbuild instead of the real modules, avoiding bundling
   // native code that would fail on the Workers runtime.
@@ -952,6 +972,7 @@ async function buildCloudflarePages() {
       "--conditions=workerd,worker,import",
       // The ssr-handler imports a virtual module that only exists at dev time
       "--external:virtual:react-router/server-build",
+      `--alias:#nitro/virtual/server-assets=${nitroServerAssetsStub}`,
       // Banner: override the __require shim that esbuild generates for CJS modules.
       // This provides a real require() backed by ESM imports of node builtins.
       // Without this, CF Workers rejects the bundle because esbuild's default

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -1107,6 +1107,50 @@ function conciseMcpAppToolText(
   return `${name} completed.`;
 }
 
+function isSuccessOnlyResult(value: Record<string, unknown>): boolean {
+  const keys = Object.keys(value);
+  if (keys.length === 0) return true;
+  return keys.every((key) => {
+    const item = value[key];
+    if (key === "ok" || key === "success") return item === true;
+    if (key === "status") {
+      return item === "ok" || item === "success" || item === "completed";
+    }
+    return false;
+  });
+}
+
+function conciseToolResultText(name: string, result: unknown): string {
+  const purged = purgeEmbedStartUrls(result);
+  if (typeof purged === "string") return truncateToolText(purged);
+  if (purged === true || purged == null) return `${name} completed.`;
+  if (purged && typeof purged === "object" && !Array.isArray(purged)) {
+    const record = purged as Record<string, unknown>;
+    const message = record.message ?? record.summary;
+    if (typeof message === "string" && message.trim()) {
+      return truncateToolText(message.trim());
+    }
+    const id = record.id ?? record.planId ?? record.commentId;
+    const title = record.title ?? record.name;
+    if (typeof title === "string" && title.trim()) {
+      const titleText = title.trim();
+      return typeof id === "string" && id.trim()
+        ? `${titleText} (${id.trim()}) is ready.`
+        : `${titleText} is ready.`;
+    }
+    if (typeof id === "string" && id.trim()) {
+      return `${name} completed for ${id.trim()}.`;
+    }
+    const link = record.url ?? record.webUrl ?? record.path;
+    if (typeof link === "string" && link.trim()) {
+      return `${name} completed: ${truncateToolText(link.trim(), 500)}`;
+    }
+    if (isSuccessOnlyResult(record)) return `${name} completed.`;
+  }
+  const text = JSON.stringify(purged);
+  return text === undefined ? `${name} completed.` : truncateToolText(text);
+}
+
 // ---------------------------------------------------------------------------
 // MCP Server creation — converts ActionEntry registry to MCP tools
 // ---------------------------------------------------------------------------
@@ -1475,9 +1519,7 @@ export async function createMCPServerForRequest(
             : undefined;
         const text = mcpAppResource
           ? conciseMcpAppToolText(name, resultForClient, structuredContent!)
-          : typeof resultForClient === "string"
-            ? (purgeEmbedStartUrls(resultForClient) as string)
-            : JSON.stringify(purgeEmbedStartUrls(resultForClient));
+          : conciseToolResultText(name, resultForClient);
         const content: any[] = [{ type: "text", text }];
         if (block) content.push(block);
         return {

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -1603,6 +1603,12 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
             },
           },
         },
+        "plain-success": {
+          tool: {
+            description: "Plain success",
+          },
+          run: async () => true,
+        },
       },
     };
 
@@ -1644,10 +1650,29 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         },
       );
       expect(brokenCall.error).toBeUndefined();
-      expect(brokenCall.result.content[0].text).toBe('{"ok":true}');
+      expect(brokenCall.result.content[0].text).toBe(
+        "broken-review completed.",
+      );
       expect(
         brokenCall.result._meta?.["openai/outputTemplate"],
       ).toBeUndefined();
+
+      const plainSuccessCall = await callWeb(
+        {
+          jsonrpc: "2.0",
+          id: 401,
+          method: "tools/call",
+          params: { name: "plain-success", arguments: {} },
+        },
+        {
+          headers: await mcpAppsFullCatalogHeaders(),
+          config: failingCspConfig,
+        },
+      );
+      expect(plainSuccessCall.error).toBeUndefined();
+      expect(plainSuccessCall.result.content[0].text).toBe(
+        "plain-success completed.",
+      );
 
       const resources = await callWeb(
         {

--- a/packages/docs/app/components/docsNavItems.ts
+++ b/packages/docs/app/components/docsNavItems.ts
@@ -10,6 +10,7 @@ export const NAV_SECTIONS: NavSection[] = [
         label: "What Is Agent-Native?",
         to: "/docs/what-is-agent-native" as const,
       },
+      { label: "Agent Surfaces", to: "/docs/agent-surfaces" as const },
       { label: "Key Concepts", to: "/docs/key-concepts" as const },
       { label: "Template Catalog", to: "/docs/cloneable-saas" as const },
       { label: "Pure-Agent Apps", to: "/docs/pure-agent-apps" as const },

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -517,10 +517,10 @@ export default function Home() {
                     ))}
                   </div>
                   <Link
-                    to="/docs/external-agents"
+                    to="/docs/agent-surfaces"
                     className="mt-4 inline-flex items-center rounded-full border border-[var(--docs-border)] bg-[var(--bg)] px-3 py-1.5 text-sm font-medium text-[var(--fg)] no-underline transition-colors hover:border-[var(--docs-accent)]"
                   >
-                    Connect your existing agent
+                    Choose your agent surface
                     <span className="ml-1" aria-hidden="true">
                       →
                     </span>

--- a/skills/visual-plans/SKILL.md
+++ b/skills/visual-plans/SKILL.md
@@ -361,8 +361,10 @@ The local-files contract is:
   writes only registry metadata to disk; use `--format schema` if exact nested
   fields are needed. If network access is unavailable, use the bundled
   references and rely on `plan local check` / `plan local serve` to catch
-  invalid tags. For `checklist` and `question-form`, copy the catalog examples:
-  checklist items need `id`, and question-form questions/options need `id`.
+  invalid tags. For `checklist` and `question-form`, copy the catalog examples
+  verbatim: checklist items need `id` and `label`; question-form questions need
+  `id`, `title`, and `mode`; and each option needs `id` and `label`. `plan local
+  check` validates these required fields against the renderer schema.
 - Write the plan as a local MDX folder: use `plans/<slug>/` when the user
   wants the artifact checked into the repo, or use a repo-ignored/temporary
   folder such as `.agent-native/plans/<slug>/` or `/tmp/agent-native-plans/<slug>/`

--- a/skills/visual-recap/SKILL.md
+++ b/skills/visual-recap/SKILL.md
@@ -38,8 +38,10 @@ In local-files mode:
   `get-plan-blocks` route and sends no recap content. If network access is
   unavailable, use the bundled references and validate with
   `plan local check` / `plan local serve`. For `checklist` and `question-form`,
-  copy the catalog examples: checklist items need `id`, and question-form
-  questions/options need `id`.
+  copy the catalog examples verbatim: checklist items need `id` and `label`;
+  question-form questions need `id`, `title`, and `mode`; and each option needs
+  `id` and `label`. `plan local check` validates these required fields against
+  the renderer schema.
 - Write the recap as a local MDX folder: use `plans/<slug>/` when the user
   wants the artifact checked into the repo, or use a repo-ignored/temporary
   folder such as `.agent-native/plans/<slug>/` or `/tmp/agent-native-plans/<slug>/`

--- a/templates/calendar/server/lib/booking-og-fonts.ts
+++ b/templates/calendar/server/lib/booking-og-fonts.ts
@@ -43,8 +43,12 @@ export function bytesFromStorageValue(value: unknown): Buffer | undefined {
 }
 
 function sourceFontFiles(): string[] | undefined {
-  const files = BOOKING_OG_FONT_ASSETS.map((font) => font.sourcePath);
-  return files.every((fontFile) => existsSync(fontFile)) ? files : undefined;
+  try {
+    const files = BOOKING_OG_FONT_ASSETS.map((font) => font.sourcePath);
+    return files.every((fontFile) => existsSync(fontFile)) ? files : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 async function readFontBytes(
@@ -59,7 +63,7 @@ async function readFontBytes(
 }
 
 export async function loadBundledOgFontFiles(
-  storage: BookingOgAssetStorage,
+  storage?: BookingOgAssetStorage,
   options: {
     preferSourceFiles?: boolean;
     tmpRoot?: string;
@@ -70,6 +74,8 @@ export async function loadBundledOgFontFiles(
     const sourceFiles = sourceFontFiles();
     if (sourceFiles) return sourceFiles;
   }
+
+  if (!storage) return undefined;
 
   try {
     const fonts = [];

--- a/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
+++ b/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
@@ -9,6 +9,7 @@ import {
 } from "h3";
 import { eq } from "drizzle-orm";
 import { getUserSetting } from "@agent-native/core/settings";
+import { assets as serverAssets } from "#nitro/virtual/server-assets";
 import { getDb, schema } from "../../../../../db/index.js";
 import { getBookingUsername } from "../../../../../handlers/booking-usernames.js";
 import { loadBundledOgFontFiles } from "../../../../../lib/booking-og-fonts.js";
@@ -142,7 +143,7 @@ export default defineEventHandler(async (event: H3Event) => {
     bookingPageTitle: ownerSettings?.bookingPageTitle,
     profileImageDataUrl,
   };
-  const fontFiles = await loadBundledOgFontFiles();
+  const fontFiles = await loadBundledOgFontFiles(serverAssets);
   let png: Uint8Array;
   try {
     png = await renderBookingOgImagePng(

--- a/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
+++ b/templates/calendar/server/routes/api/public/booking-links/[slug]/og.png.get.ts
@@ -9,7 +9,6 @@ import {
 } from "h3";
 import { eq } from "drizzle-orm";
 import { getUserSetting } from "@agent-native/core/settings";
-import { assets as serverAssets } from "#nitro/virtual/server-assets";
 import { getDb, schema } from "../../../../../db/index.js";
 import { getBookingUsername } from "../../../../../handlers/booking-usernames.js";
 import { loadBundledOgFontFiles } from "../../../../../lib/booking-og-fonts.js";
@@ -143,7 +142,7 @@ export default defineEventHandler(async (event: H3Event) => {
     bookingPageTitle: ownerSettings?.bookingPageTitle,
     profileImageDataUrl,
   };
-  const fontFiles = await loadBundledOgFontFiles(serverAssets);
+  const fontFiles = await loadBundledOgFontFiles();
   let png: Uint8Array;
   try {
     png = await renderBookingOgImagePng(

--- a/templates/plan/.agents/skills/visual-plan/SKILL.md
+++ b/templates/plan/.agents/skills/visual-plan/SKILL.md
@@ -361,8 +361,10 @@ The local-files contract is:
   writes only registry metadata to disk; use `--format schema` if exact nested
   fields are needed. If network access is unavailable, use the bundled
   references and rely on `plan local check` / `plan local serve` to catch
-  invalid tags. For `checklist` and `question-form`, copy the catalog examples:
-  checklist items need `id`, and question-form questions/options need `id`.
+  invalid tags. For `checklist` and `question-form`, copy the catalog examples
+  verbatim: checklist items need `id` and `label`; question-form questions need
+  `id`, `title`, and `mode`; and each option needs `id` and `label`. `plan local
+  check` validates these required fields against the renderer schema.
 - Write the plan as a local MDX folder: use `plans/<slug>/` when the user
   wants the artifact checked into the repo, or use a repo-ignored/temporary
   folder such as `.agent-native/plans/<slug>/` or `/tmp/agent-native-plans/<slug>/`

--- a/templates/plan/.agents/skills/visual-recap/SKILL.md
+++ b/templates/plan/.agents/skills/visual-recap/SKILL.md
@@ -38,8 +38,10 @@ In local-files mode:
   `get-plan-blocks` route and sends no recap content. If network access is
   unavailable, use the bundled references and validate with
   `plan local check` / `plan local serve`. For `checklist` and `question-form`,
-  copy the catalog examples: checklist items need `id`, and question-form
-  questions/options need `id`.
+  copy the catalog examples verbatim: checklist items need `id` and `label`;
+  question-form questions need `id`, `title`, and `mode`; and each option needs
+  `id` and `label`. `plan local check` validates these required fields against
+  the renderer schema.
 - Write the recap as a local MDX folder: use `plans/<slug>/` when the user
   wants the artifact checked into the repo, or use a repo-ignored/temporary
   folder such as `.agent-native/plans/<slug>/` or `/tmp/agent-native-plans/<slug>/`

--- a/templates/plan/actions/plan-comment-actions.spec.ts
+++ b/templates/plan/actions/plan-comment-actions.spec.ts
@@ -430,6 +430,49 @@ describe("resolve-plan-comment", () => {
     expect(updates[0]?.resolvedAt).toBeNull();
   });
 
+  it("resolves every comment in the thread, not just the root", async () => {
+    const updates: Record<string, unknown>[] = [];
+    const db = makeDb([], updates, [
+      {
+        id: "root_cmt",
+        planId: "plan_1",
+        parentCommentId: null,
+        sectionId: null,
+        kind: "comment",
+        anchor: null,
+        message: "Original feedback",
+        createdBy: "human",
+        authorEmail: "reviewer@example.com",
+        resolutionTarget: "agent",
+        mentionsJson: null,
+        status: "open",
+      },
+    ]);
+    getDbMock.mockReturnValue(db);
+    loadPlanBundleMock.mockResolvedValue({
+      ...BASE_BUNDLE,
+      comments: [
+        BASE_BUNDLE.comments[0]!,
+        {
+          ...BASE_BUNDLE.comments[0]!,
+          id: "reply_cmt",
+          parentCommentId: "root_cmt",
+          message: "Follow-up detail",
+        },
+      ],
+    });
+
+    await runResolve({
+      planId: "plan_1",
+      commentId: "root_cmt",
+      status: "resolved",
+    });
+
+    expect(updates).toHaveLength(2);
+    expect(updates.every((patch) => patch.status === "resolved")).toBe(true);
+    expect(updates.every((patch) => patch.resolvedBy)).toBe(true);
+  });
+
   it("posts a resolutionNote reply before updating the status", async () => {
     const inserts: Record<string, unknown>[] = [];
     const updates: Record<string, unknown>[] = [];
@@ -464,9 +507,11 @@ describe("resolve-plan-comment", () => {
       (row) => row.message === "Fixed in commit abc123.",
     );
     expect(note).toBeDefined();
+    expect(note?.status).toBe("resolved");
     expect(result.resolutionNoteId).toBeDefined();
-    // The status update must have happened.
-    expect(updates[0]?.status).toBe("resolved");
+    // The original thread and the inserted note are both resolved, so the note
+    // cannot keep get-plan-feedback's thread status open.
+    expect(updates.every((patch) => patch.status === "resolved")).toBe(true);
   });
 
   it("throws a friendly error when the comment is not on the plan", async () => {

--- a/templates/plan/actions/resolve-plan-comment.ts
+++ b/templates/plan/actions/resolve-plan-comment.ts
@@ -26,6 +26,46 @@ import {
   nowIso,
   writeEvent,
 } from "../server/plans.js";
+import type { PlanComment } from "../shared/types.js";
+
+function rootCommentIdFor(
+  comment: Pick<PlanComment, "id" | "parentCommentId">,
+  commentsById: Map<string, Pick<PlanComment, "id" | "parentCommentId">>,
+) {
+  let current = comment;
+  const seen = new Set<string>();
+  while (current.parentCommentId && !seen.has(current.id)) {
+    seen.add(current.id);
+    const parent = commentsById.get(current.parentCommentId);
+    if (!parent) break;
+    current = parent;
+  }
+  return current.id;
+}
+
+function threadCommentIdsFor(
+  rootId: string,
+  comments: Array<Pick<PlanComment, "id" | "parentCommentId">>,
+) {
+  const childrenByParent = new Map<string, string[]>();
+  for (const comment of comments) {
+    if (!comment.parentCommentId) continue;
+    const children = childrenByParent.get(comment.parentCommentId) ?? [];
+    children.push(comment.id);
+    childrenByParent.set(comment.parentCommentId, children);
+  }
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  const stack = [rootId];
+  while (stack.length > 0) {
+    const id = stack.pop();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+    stack.push(...(childrenByParent.get(id) ?? []));
+  }
+  return ids;
+}
 
 export default defineAction({
   description:
@@ -145,18 +185,36 @@ export default defineAction({
       requestEmail: commentRequestEmail,
       now,
     });
+    const bundle = await loadPlanBundle(args.planId);
+    const commentsById = new Map(
+      bundle.comments.map((comment) => [
+        comment.id,
+        {
+          id: comment.id,
+          parentCommentId: comment.parentCommentId,
+        },
+      ]),
+    );
+    const threadRootId = rootCommentIdFor(existing, commentsById);
+    const existingThreadCommentIds = threadCommentIdsFor(
+      threadRootId,
+      bundle.comments,
+    );
+    const updatedCommentIds =
+      existingThreadCommentIds.length > 0
+        ? existingThreadCommentIds
+        : [existing.id];
 
     // Optionally post a reply note before updating the status.
     let insertedNoteId: string | undefined;
     if (args.resolutionNote) {
-      const bundle = await loadPlanBundle(args.planId);
       const noteRows = buildUpdatedPlanCommentRows({
         planId: args.planId,
         comments: [
           {
-            parentCommentId: existing.id,
+            parentCommentId: threadRootId,
             kind: existing.kind,
-            status: "open" as const,
+            status: args.status,
             message: args.resolutionNote,
             createdBy: "agent" as const,
           },
@@ -172,36 +230,34 @@ export default defineAction({
         insertedNoteId = noteRow.id;
       }
     }
+    const allUpdatedCommentIds = insertedNoteId
+      ? [...updatedCommentIds, insertedNoteId]
+      : updatedCommentIds;
 
-    // Update the comment status.
-    await db
-      .update(schema.planComments)
-      .set({
-        status: args.status,
-        sectionId: existing.sectionId,
-        kind: existing.kind,
-        anchor: existing.anchor,
-        message: existing.message,
-        resolutionTarget: existing.resolutionTarget,
-        mentionsJson: existing.mentionsJson,
-        resolvedBy: resolution.resolvedBy,
-        resolvedAt: resolution.resolvedAt,
-        updatedAt: now,
-      })
-      .where(
-        and(
-          eq(schema.planComments.id, args.commentId),
-          eq(schema.planComments.planId, args.planId),
-          isNull(schema.planComments.deletedAt),
-        ),
-      );
+    for (const commentId of allUpdatedCommentIds) {
+      await db
+        .update(schema.planComments)
+        .set({
+          status: args.status,
+          resolvedBy: resolution.resolvedBy,
+          resolvedAt: resolution.resolvedAt,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(schema.planComments.id, commentId),
+            eq(schema.planComments.planId, args.planId),
+            isNull(schema.planComments.deletedAt),
+          ),
+        );
+    }
 
     await writeEvent({
       planId: args.planId,
       type: "plan.updated",
       message: `Comment ${args.commentId} ${args.status === "resolved" ? "resolved" : "reopened"}.`,
       payload: {
-        existingCommentIdsUpdated: [args.commentId],
+        existingCommentIdsUpdated: updatedCommentIds,
         insertedCommentIds: insertedNoteId ? [insertedNoteId] : [],
         resolutionNote: args.resolutionNote ?? null,
       },

--- a/templates/plan/app/pages/PlansPage.comments.test.ts
+++ b/templates/plan/app/pages/PlansPage.comments.test.ts
@@ -10,6 +10,7 @@ import {
   commentThreadsForVisualSurfaceMode,
   commentThreadsForVisibility,
   mentionQueryAtCaret,
+  localPlanBridgeRetryDelay,
   nativeMarkerPlacementForAnchor,
   runtimeAnnotationFromThread,
   nativePointForAnchor,
@@ -17,6 +18,8 @@ import {
   removePlanCommentThreadFromBundle,
   resolveNativeAnchorTarget,
   selectorForElementWithin,
+  shouldRetryLocalPlanBridgeBundle,
+  shouldShowPlanLoadError,
   shouldKeepCommentPopoverOpenForTarget,
 } from "./PlansPage";
 import { planBundleQueryKey } from "@/hooks/use-plans";
@@ -887,6 +890,90 @@ describe("plan comment thread UI model", () => {
     expect(canEditPlanContentRole("viewer")).toBe(false);
     expect(canEditPlanContentRole(null)).toBe(false);
     expect(canEditPlanContentRole(undefined)).toBe(false);
+  });
+
+  it("retries transient local plan bridge startup failures only", () => {
+    expect(
+      shouldRetryLocalPlanBridgeBundle(0, new TypeError("fetch failed")),
+    ).toBe(true);
+    expect(
+      shouldRetryLocalPlanBridgeBundle(
+        1,
+        new Error("Local plan bridge returned 503."),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRetryLocalPlanBridgeBundle(
+        5,
+        new Error("Local plan bridge returned 503."),
+      ),
+    ).toBe(false);
+    expect(
+      shouldRetryLocalPlanBridgeBundle(
+        0,
+        new Error("Local plan bridge must point to localhost."),
+      ),
+    ).toBe(false);
+    expect(
+      shouldRetryLocalPlanBridgeBundle(
+        0,
+        new Error("Local plan bridge response was not a Plan MDX folder."),
+      ),
+    ).toBe(false);
+    expect(localPlanBridgeRetryDelay(0)).toBe(500);
+    expect(localPlanBridgeRetryDelay(4)).toBe(2_500);
+  });
+
+  it("surfaces the retry card instead of an endless skeleton for a stalled read", () => {
+    const base = {
+      hasSelectedId: true,
+      localPlanMode: false,
+      hasBundle: false,
+      planQueryPending: false,
+      planQueryError: false,
+      planQueryPaused: false,
+      accessStatusPending: false,
+      accessStatusPaused: false,
+      accessDenied: false,
+    };
+    // A paused read (offline at mount, or tab blurred mid-retry) never errors
+    // and never resolves — must show the retryable card, not the skeleton.
+    expect(shouldShowPlanLoadError({ ...base, planQueryPaused: true })).toBe(
+      true,
+    );
+    expect(shouldShowPlanLoadError({ ...base, accessStatusPaused: true })).toBe(
+      true,
+    );
+    // A genuinely in-flight initial load keeps the skeleton (no regression).
+    expect(
+      shouldShowPlanLoadError({
+        ...base,
+        planQueryPending: true,
+        planQueryPaused: true,
+      }),
+    ).toBe(false);
+    // Real errors and access denials still show the card.
+    expect(shouldShowPlanLoadError({ ...base, planQueryError: true })).toBe(
+      true,
+    );
+    expect(shouldShowPlanLoadError({ ...base, accessDenied: true })).toBe(true);
+    // An access denial that hasn't settled yet should not flash the card.
+    expect(
+      shouldShowPlanLoadError({
+        ...base,
+        accessDenied: true,
+        accessStatusPending: true,
+      }),
+    ).toBe(false);
+    // Healthy / local / already-loaded states never show the card.
+    expect(shouldShowPlanLoadError(base)).toBe(false);
+    expect(shouldShowPlanLoadError({ ...base, hasBundle: true })).toBe(false);
+    expect(shouldShowPlanLoadError({ ...base, localPlanMode: true })).toBe(
+      false,
+    );
+    expect(shouldShowPlanLoadError({ ...base, hasSelectedId: false })).toBe(
+      false,
+    );
   });
 
   it("detects mention queries when Chrome splits typed content into text nodes", () => {

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -535,6 +535,63 @@ function assertLocalBridgeUrl(value: string): string {
   return url.toString();
 }
 
+const LOCAL_PLAN_BRIDGE_MAX_RETRIES = 5;
+
+export function shouldRetryLocalPlanBridgeBundle(
+  failureCount: number,
+  error: unknown,
+) {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  if (
+    message.includes("Local plan bridge URL") ||
+    message.includes("Local plan bridge must") ||
+    message.includes("Local plan bridge response was not")
+  ) {
+    return false;
+  }
+  return failureCount < LOCAL_PLAN_BRIDGE_MAX_RETRIES;
+}
+
+export function localPlanBridgeRetryDelay(attemptIndex: number) {
+  return Math.min(500 * 2 ** attemptIndex, 2_500);
+}
+
+/**
+ * Decide whether the hosted-plan render should surface the retryable load
+ * error card instead of the initial skeleton.
+ *
+ * A React Query read can be *paused* (browser offline, or the tab blurred
+ * during a retry backoff): in that state it never errors and never resolves,
+ * so `isError`/`isLoading`/`isFetching` are all false and `data` stays
+ * undefined. Without treating that as an error-like state the page sits on the
+ * initial skeleton forever until a manual refresh — exactly the "wasn't
+ * loading the content until I do another refresh" report. Surfacing the
+ * retry card lets the user recover; React Query also auto-resumes the paused
+ * fetch when the network/tab returns, which clears the card on its own.
+ */
+export function shouldShowPlanLoadError(input: {
+  hasSelectedId: boolean;
+  localPlanMode: boolean;
+  hasBundle: boolean;
+  planQueryPending: boolean;
+  planQueryError: boolean;
+  planQueryPaused: boolean;
+  accessStatusPending: boolean;
+  accessStatusPaused: boolean;
+  accessDenied: boolean;
+}): boolean {
+  if (!input.hasSelectedId || input.localPlanMode || input.hasBundle) {
+    return false;
+  }
+  // While a read is actively in flight, keep showing the skeleton.
+  if (input.planQueryPending) return false;
+  if (input.planQueryError) return true;
+  // Paused/stalled read that will never settle on its own input.
+  if (input.planQueryPaused || input.accessStatusPaused) return true;
+  if (!input.accessStatusPending && input.accessDenied) return true;
+  return false;
+}
+
 function localPlanRoutePath(slug: string, repoPath?: string | null): string {
   const base = appPath(`/local-plans/${encodeURIComponent(slug)}`);
   if (!repoPath) return base;
@@ -2774,6 +2831,8 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
     queryKey: ["local-plan-bridge", localPlanSlug, localPlanBridgeUrl],
     enabled: localPlanMode && Boolean(localPlanSlug && localPlanBridgeUrl),
     refetchOnWindowFocus: false,
+    retry: shouldRetryLocalPlanBridgeBundle,
+    retryDelay: localPlanBridgeRetryDelay,
     queryFn: () =>
       fetchLocalPlanBridgeBundle(localPlanBridgeUrl ?? "", localPlanSlug ?? ""),
   });
@@ -2929,12 +2988,20 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
     Boolean(selectedId && !bundle && !localPlanMode),
   );
   const planAccessStatus = planAccessStatusQuery.data ?? null;
-  const showPlanLoadError = Boolean(
-    selectedId &&
-    !localPlanMode &&
-    !bundle &&
-    (planQuery.isError || (planAccessStatus && !planAccessStatus.hasAccess)),
-  );
+  const planQueryPending = planQuery.isLoading || planQuery.isFetching;
+  const planAccessStatusPending =
+    planAccessStatusQuery.isLoading || planAccessStatusQuery.isFetching;
+  const showPlanLoadError = shouldShowPlanLoadError({
+    hasSelectedId: Boolean(selectedId),
+    localPlanMode,
+    hasBundle: Boolean(bundle),
+    planQueryPending,
+    planQueryError: planQuery.isError,
+    planQueryPaused: planQuery.isPaused,
+    accessStatusPending: planAccessStatusPending,
+    accessStatusPaused: planAccessStatusQuery.isPaused,
+    accessDenied: Boolean(planAccessStatus && !planAccessStatus.hasAccess),
+  });
   const showLocalPlanLoadError = Boolean(
     localPlanMode &&
     !bundle &&
@@ -4890,7 +4957,10 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
     clearPendingDocumentRestore();
     pendingDocumentRestoreRef.current = documentStateRef.current;
     commentMutationPendingRef.current = true;
-    void queryClient.cancelQueries({ queryKey: selectedPlanQueryKey });
+    // Await the cancel so an in-flight 3s poll can't resolve *after* our
+    // optimistic write and revert it (the "comment lagged / didn't stick"
+    // symptom). cancelQueries reverts outstanding fetches before we patch.
+    await queryClient.cancelQueries({ queryKey: selectedPlanQueryKey });
     queryClient.setQueryData(
       selectedPlanQueryKey,
       (current: PlanBundleWithHtml | undefined) =>
@@ -4899,7 +4969,7 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
     setFailedCommentDraft(null);
     clearInlineCommentDraft();
     setAnnotateMode(true);
-    void updatePlan
+    void updateCommentMutation
       .mutateAsync({
         planId: bundle.plan.id,
         comments: [commentInput],
@@ -5012,7 +5082,10 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
       updatedAt: now,
     };
     commentMutationPendingRef.current = true;
-    void queryClient.cancelQueries({ queryKey: selectedPlanQueryKey });
+    // Await the cancel so an in-flight 3s poll can't resolve *after* our
+    // optimistic write and revert it (the "comment lagged / didn't stick"
+    // symptom). cancelQueries reverts outstanding fetches before we patch.
+    await queryClient.cancelQueries({ queryKey: selectedPlanQueryKey });
     queryClient.setQueryData(
       selectedPlanQueryKey,
       (current: PlanBundleWithHtml | undefined) =>
@@ -5054,7 +5127,7 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
     }
   };
 
-  const setCommentThreadStatus = (
+  const setCommentThreadStatus = async (
     threadRootId: string,
     status: PlanBundle["comments"][number]["status"],
     fallbackAnchor?: PlanAnnotationAnchor | null,
@@ -5069,6 +5142,11 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
     // popover update without waiting for the server round-trip (Issue 3).
     const prevBundle =
       queryClient.getQueryData<PlanBundleWithHtml>(selectedPlanQueryKey);
+    commentMutationPendingRef.current = true;
+    // Await the cancel so an in-flight 3s poll can't resolve *after* our
+    // optimistic write and revert it (the "comment lagged / didn't stick"
+    // symptom). cancelQueries reverts outstanding fetches before we patch.
+    await queryClient.cancelQueries({ queryKey: selectedPlanQueryKey });
     queryClient.setQueryData(
       selectedPlanQueryKey,
       (current: PlanBundleWithHtml | undefined) => {
@@ -5084,7 +5162,6 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
       },
     );
     setActiveAnnotation(null);
-    commentMutationPendingRef.current = true;
     updateCommentMutation.mutate(
       {
         planId: bundle.plan.id,
@@ -5142,7 +5219,10 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
       queryClient.getQueryData<PlanBundleWithHtml>(selectedPlanQueryKey);
     const commentId = request.commentId;
     commentMutationPendingRef.current = true;
-    void queryClient.cancelQueries({ queryKey: selectedPlanQueryKey });
+    // Await the cancel so an in-flight 3s poll can't resolve *after* our
+    // optimistic write and revert it (the "comment lagged / didn't stick"
+    // symptom). cancelQueries reverts outstanding fetches before we patch.
+    await queryClient.cancelQueries({ queryKey: selectedPlanQueryKey });
     queryClient.setQueryData(
       selectedPlanQueryKey,
       (current: PlanBundleWithHtml | undefined) =>
@@ -6011,6 +6091,7 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
                   position={activeAnnotation.position}
                   isPending={updateCommentMutation.isPending}
                   pendingAuthor={pendingCommentAuthor}
+                  canEditRootComment={canEditPlanContent}
                   onSave={(message) =>
                     updateAnnotationComment(
                       activeAnnotation.annotation,
@@ -7339,6 +7420,33 @@ function EmptyPlan({
 }
 
 function LoggedOutEmptyPlan() {
+  const [installCommandCopied, setInstallCommandCopied] = useState(false);
+  const copyResetTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyResetTimeoutRef.current) {
+        window.clearTimeout(copyResetTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const copyInstallCommand = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(PLAN_SKILL_INSTALL_COMMAND);
+      setInstallCommandCopied(true);
+      toast.success("Install command copied");
+      if (copyResetTimeoutRef.current) {
+        window.clearTimeout(copyResetTimeoutRef.current);
+      }
+      copyResetTimeoutRef.current = window.setTimeout(() => {
+        setInstallCommandCopied(false);
+      }, 2200);
+    } catch {
+      toast.error("Could not copy install command");
+    }
+  }, []);
+
   return (
     <div className="flex h-full items-center justify-center p-6 sm:p-8">
       <div className="flex w-full max-w-lg -translate-y-10 flex-col items-center gap-3 text-center sm:-translate-y-16">
@@ -7353,15 +7461,47 @@ function LoggedOutEmptyPlan() {
           <p className="text-xs font-medium text-muted-foreground">
             Install once
           </p>
-          <code className="mt-2 block rounded-md bg-muted/40 px-3 py-2 font-mono text-xs leading-5 text-foreground">
-            {PLAN_SKILL_INSTALL_COMMAND}
-          </code>
+          <div className="mt-2 flex items-center gap-2 rounded-md bg-muted/40 p-1.5">
+            <code className="min-w-0 flex-1 overflow-x-auto px-2 py-1 font-mono text-xs leading-5 text-foreground">
+              {PLAN_SKILL_INSTALL_COMMAND}
+            </code>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={copyInstallCommand}
+              className="h-8 min-w-20 shrink-0 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"
+              aria-label={
+                installCommandCopied
+                  ? "Install command copied"
+                  : "Copy install command"
+              }
+            >
+              {installCommandCopied ? (
+                <IconCircleCheck className="size-3.5 text-emerald-600" />
+              ) : (
+                <IconCopy className="size-3.5" />
+              )}
+              {installCommandCopied ? "Copied" : "Copy"}
+            </Button>
+          </div>
           <p className="mt-3 text-xs leading-5 text-muted-foreground">
             Then ask for <code>/visual-plan</code> to create a plan, or{" "}
             <code>/visual-recap</code> for a PR recap, from Codex, Claude Code,
             or Cursor.
           </p>
         </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          asChild
+          className="mt-1 text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+        >
+          <a href={PLAN_DOCS_URL} target="_blank" rel="noreferrer">
+            <IconExternalLink className="size-4" />
+            View the docs
+          </a>
+        </Button>
       </div>
     </div>
   );
@@ -8952,6 +9092,7 @@ function AnnotationPopover({
   position,
   isPending,
   pendingAuthor,
+  canEditRootComment,
   onSave,
   onReply,
   canResolve,
@@ -8966,6 +9107,7 @@ function AnnotationPopover({
   position: InlineCommentPosition;
   isPending: boolean;
   pendingAuthor: CommentAuthorPresentation;
+  canEditRootComment: boolean;
   onSave: (message: string) => void;
   onReply: (threadRootId: string, message: string) => Promise<void>;
   canResolve: boolean;
@@ -9005,7 +9147,9 @@ function AnnotationPopover({
   const rootDeleteLabel = deleteCommentLabel(
     commentDescendantCount(annotationComments, rootComment.id),
   );
-  const canSave = messageDraft.message.trim().length > 0 && !isPending;
+  const canSave =
+    canEditRootComment && messageDraft.message.trim().length > 0 && !isPending;
+  const hasOptions = canResolve || canEditRootComment || canDelete;
   const resolver = normalizePlanCommentResolutionTarget(
     annotation.anchor.resolutionTarget,
   );
@@ -9074,55 +9218,59 @@ function AnnotationPopover({
           </Badge>
         </div>
         <div className="flex shrink-0 items-center gap-1">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="size-8 shrink-0"
-                aria-label="Comment options"
-              >
-                <IconDotsVertical className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              className="w-48 rounded-xl"
-              data-comment-popover-portal
-            >
-              {canResolve && (
-                <DropdownMenuItem
-                  className="gap-2"
-                  onClick={() =>
-                    onStatusChange(isResolved ? "open" : "resolved")
-                  }
+          {hasOptions && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  className="size-8 shrink-0"
+                  aria-label="Comment options"
                 >
-                  <IconCircleCheck className="size-4" />
-                  {isResolved ? "Reopen thread" : "Mark as resolved"}
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuItem
-                className="gap-2"
-                onClick={() => setEditing(true)}
+                  <IconDotsVertical className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="end"
+                className="w-48 rounded-xl"
+                data-comment-popover-portal
               >
-                <IconPencil className="size-4" />
-                Edit first comment
-              </DropdownMenuItem>
-              {canDelete && (
-                <>
-                  <DropdownMenuSeparator />
+                {canResolve && (
                   <DropdownMenuItem
-                    className="gap-2 text-destructive focus:text-destructive"
-                    onClick={onDelete}
+                    className="gap-2"
+                    onClick={() =>
+                      onStatusChange(isResolved ? "open" : "resolved")
+                    }
                   >
-                    <IconTrash className="size-4" />
-                    {rootDeleteLabel}
+                    <IconCircleCheck className="size-4" />
+                    {isResolved ? "Reopen thread" : "Mark as resolved"}
                   </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+                )}
+                {canEditRootComment && (
+                  <DropdownMenuItem
+                    className="gap-2"
+                    onClick={() => setEditing(true)}
+                  >
+                    <IconPencil className="size-4" />
+                    Edit first comment
+                  </DropdownMenuItem>
+                )}
+                {canDelete && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      className="gap-2 text-destructive focus:text-destructive"
+                      onClick={onDelete}
+                    >
+                      <IconTrash className="size-4" />
+                      {rootDeleteLabel}
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
           {canResolve && (
             <Tooltip>
               <TooltipTrigger asChild>

--- a/templates/plan/e2e/auth-first-paint.guest.spec.ts
+++ b/templates/plan/e2e/auth-first-paint.guest.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+/*
+ * AUTH FIRST PAINT
+ *
+ * Regression coverage for the reviewer report that clicking signup initially
+ * showed a raw `true` message. These entrypoints should always render the
+ * framework auth page, never a bare boolean response.
+ */
+
+const AUTH_ENTRYPOINTS = [
+  { path: "/signup", label: "signup" },
+  { path: "/login", label: "login" },
+  { path: "/_agent-native/sign-in?return=%2Fplans", label: "sign-in" },
+];
+
+for (const entrypoint of AUTH_ENTRYPOINTS) {
+  test(`auth entrypoint ${entrypoint.label} renders a real page, not raw true`, async ({
+    page,
+  }) => {
+    await page.context().clearCookies();
+    await page.goto(entrypoint.path, { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText(/Create account|Sign in/i).first()).toBeVisible(
+      { timeout: 15_000 },
+    );
+
+    const body = await page.locator("body").innerText();
+    expect(
+      body.trim(),
+      `${entrypoint.path} must not render only a raw boolean`,
+    ).not.toBe("true");
+    expect(
+      body,
+      `${entrypoint.path} must not include a standalone raw true line`,
+    ).not.toMatch(/(^|\n)\s*true\s*(\n|$)/i);
+  });
+}

--- a/templates/plan/e2e/auth-state.ts
+++ b/templates/plan/e2e/auth-state.ts
@@ -8,6 +8,10 @@ const PLAN_ROOT = path.resolve(
 );
 export const LOCAL_PLAN_OWNER_EMAIL = "local@agent-native.local";
 
+let generatedAuthRunId: string | undefined;
+let generatedAuthStatePath: string | undefined;
+let generatedAuthEmailPath: string | undefined;
+
 export function planE2eBaseUrl() {
   return process.env.PLAN_BASE_URL || "http://localhost:8081";
 }
@@ -28,9 +32,8 @@ function safeBaseUrlSlug(baseURL: string) {
 function authRunId() {
   const existing = process.env.PLAN_E2E_AUTH_RUN_ID?.trim();
   if (existing) return existing;
-  const generated = `${Date.now().toString(36)}-${process.pid}`;
-  process.env.PLAN_E2E_AUTH_RUN_ID = generated;
-  return generated;
+  generatedAuthRunId ??= `${Date.now().toString(36)}-${process.pid}`;
+  return generatedAuthRunId;
 }
 
 export function planE2eAuthDir(baseURL = planE2eBaseUrl()) {
@@ -47,17 +50,15 @@ export function planE2eAuthDir(baseURL = planE2eBaseUrl()) {
 export function planE2eAuthStatePath(baseURL = planE2eBaseUrl()) {
   const explicit = process.env.PLAN_E2E_AUTH_STATE?.trim();
   if (explicit) return path.resolve(explicit);
-  const generated = path.join(planE2eAuthDir(baseURL), "state.json");
-  process.env.PLAN_E2E_AUTH_STATE = generated;
-  return generated;
+  generatedAuthStatePath ??= path.join(planE2eAuthDir(baseURL), "state.json");
+  return generatedAuthStatePath;
 }
 
 export function planE2eAuthEmailPath(baseURL = planE2eBaseUrl()) {
   const explicit = process.env.PLAN_E2E_EMAIL_FILE?.trim();
   if (explicit) return path.resolve(explicit);
-  const generated = path.join(planE2eAuthDir(baseURL), "email.txt");
-  process.env.PLAN_E2E_EMAIL_FILE = generated;
-  return generated;
+  generatedAuthEmailPath ??= path.join(planE2eAuthDir(baseURL), "email.txt");
+  return generatedAuthEmailPath;
 }
 
 export function planE2eUsesLocalPlanOwner() {

--- a/templates/plan/e2e/auth-state.ts
+++ b/templates/plan/e2e/auth-state.ts
@@ -1,0 +1,78 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PLAN_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+export const LOCAL_PLAN_OWNER_EMAIL = "local@agent-native.local";
+
+export function planE2eBaseUrl() {
+  return process.env.PLAN_BASE_URL || "http://localhost:8081";
+}
+
+function safeBaseUrlSlug(baseURL: string) {
+  const hash = createHash("sha1").update(baseURL).digest("hex").slice(0, 8);
+  try {
+    const url = new URL(baseURL);
+    const protocol = url.protocol.replace(/:$/, "");
+    const host = url.hostname.replace(/[^a-zA-Z0-9.-]/g, "-");
+    const port = url.port || (url.protocol === "https:" ? "443" : "80");
+    return `${protocol}-${host}-${port}-${hash}`;
+  } catch {
+    return `url-${hash}`;
+  }
+}
+
+function authRunId() {
+  const existing = process.env.PLAN_E2E_AUTH_RUN_ID?.trim();
+  if (existing) return existing;
+  const generated = `${Date.now().toString(36)}-${process.pid}`;
+  process.env.PLAN_E2E_AUTH_RUN_ID = generated;
+  return generated;
+}
+
+export function planE2eAuthDir(baseURL = planE2eBaseUrl()) {
+  const explicit = process.env.PLAN_E2E_AUTH_DIR?.trim();
+  if (explicit) return path.resolve(explicit);
+  return path.join(
+    PLAN_ROOT,
+    "e2e",
+    ".auth",
+    `${safeBaseUrlSlug(baseURL)}-${authRunId()}`,
+  );
+}
+
+export function planE2eAuthStatePath(baseURL = planE2eBaseUrl()) {
+  const explicit = process.env.PLAN_E2E_AUTH_STATE?.trim();
+  if (explicit) return path.resolve(explicit);
+  const generated = path.join(planE2eAuthDir(baseURL), "state.json");
+  process.env.PLAN_E2E_AUTH_STATE = generated;
+  return generated;
+}
+
+export function planE2eAuthEmailPath(baseURL = planE2eBaseUrl()) {
+  const explicit = process.env.PLAN_E2E_EMAIL_FILE?.trim();
+  if (explicit) return path.resolve(explicit);
+  const generated = path.join(planE2eAuthDir(baseURL), "email.txt");
+  process.env.PLAN_E2E_EMAIL_FILE = generated;
+  return generated;
+}
+
+export function planE2eUsesLocalPlanOwner() {
+  const nodeEnv = (process.env.NODE_ENV ?? "").trim().toLowerCase();
+  const authMode = process.env.AUTH_MODE;
+  return !(
+    nodeEnv === "production" ||
+    nodeEnv === "prod" ||
+    process.env.PLAN_LOCAL_MODE === "0" ||
+    (authMode && authMode !== "local")
+  );
+}
+
+export function expectedPlanCommentAuthorEmail(reviewerEmail: string) {
+  const explicit = process.env.PLAN_E2E_EXPECT_COMMENT_EMAIL?.trim();
+  if (explicit) return explicit;
+  return planE2eUsesLocalPlanOwner() ? LOCAL_PLAN_OWNER_EMAIL : reviewerEmail;
+}

--- a/templates/plan/e2e/commenting-review.spec.ts
+++ b/templates/plan/e2e/commenting-review.spec.ts
@@ -5,6 +5,10 @@ import {
   type Page,
 } from "@playwright/test";
 import { readFileSync } from "node:fs";
+import {
+  expectedPlanCommentAuthorEmail,
+  planE2eAuthEmailPath,
+} from "./auth-state";
 
 /*
  * COMMENTING + REVIEW MODE — deep, adversarial E2E.
@@ -25,11 +29,13 @@ const REVIEWER_EMAIL =
   (() => {
     try {
       // global-setup writes the actual per-run authed identity here.
-      return readFileSync("e2e/.auth/email.txt", "utf8").trim();
+      return readFileSync(planE2eAuthEmailPath(), "utf8").trim();
     } catch {
       return "e2e-tester@plan.test";
     }
   })();
+const EXPECTED_COMMENT_AUTHOR_EMAIL =
+  expectedPlanCommentAuthorEmail(REVIEWER_EMAIL);
 
 type ActionResult = Record<string, any>;
 
@@ -68,6 +74,10 @@ async function getPlan(
     `/_agent-native/actions/get-visual-plan?id=${encodeURIComponent(planId)}`,
   );
   return (await res.json().catch(() => ({}))) as ActionResult;
+}
+
+function commentsByMessage(comments: any[], message: string): any | undefined {
+  return comments.find((comment) => comment.message === message);
 }
 
 /** Create a fixture plan with a rich-text block (text-quote anchor target) and
@@ -191,8 +201,8 @@ test("each comment kind persists with real reviewer identity and survives reload
     // Identity must be the real reviewer, never the spoofed value.
     expect(
       found.authorEmail,
-      `comment kind "${kind}" must be stamped with the real reviewer email`,
-    ).toBe(REVIEWER_EMAIL);
+      `comment kind "${kind}" must be stamped with the expected plan author email`,
+    ).toBe(EXPECTED_COMMENT_AUTHOR_EMAIL);
     expect(
       String(found.authorEmail).toLowerCase(),
       `comment kind "${kind}" must not accept a spoofed authorEmail`,
@@ -350,7 +360,143 @@ test("replying to a comment thread nests correctly under the root", async ({
 });
 
 /* ------------------------------------------------------------------ */
-/* 4. Resolving a thread removes it from open agent feedback           */
+/* 4. resolve-plan-comment handles replies and resolution notes        */
+/* ------------------------------------------------------------------ */
+test("resolve-plan-comment resolves a replied-to thread and posts its resolution note", async ({
+  page,
+}) => {
+  const req = page.request;
+  const planId = await createFixturePlan(req, "resolve-action");
+  const rootMessage = "Root agent-action comment to resolve.";
+  const replyMessage = "Reviewer reply before resolution.";
+  const resolutionNote = "Fixed the checkout copy and verified the thread.";
+
+  const root = await action(req, "update-visual-plan", {
+    planId,
+    comments: [
+      {
+        kind: "correction",
+        status: "open",
+        message: rootMessage,
+        anchor: visualAnchor("Pay now button"),
+        createdBy: "human",
+      },
+    ],
+  });
+  expect(
+    root.ok,
+    `root comment must succeed (status ${root.status}: ${root.raw.slice(0, 200)})`,
+  ).toBeTruthy();
+  const rootComment = commentsByMessage(root.body.comments ?? [], rootMessage);
+  expect(rootComment?.id, "root comment id").toBeTruthy();
+  const rootId = rootComment.id;
+
+  const reply = await action(req, "update-visual-plan", {
+    planId,
+    comments: [
+      {
+        parentCommentId: rootId,
+        kind: "correction",
+        status: "open",
+        message: replyMessage,
+        createdBy: "human",
+      },
+    ],
+  });
+  expect(
+    reply.ok,
+    `reply must succeed (status ${reply.status}: ${reply.raw.slice(0, 200)})`,
+  ).toBeTruthy();
+  const replyComment = commentsByMessage(
+    reply.body.comments ?? [],
+    replyMessage,
+  );
+  expect(replyComment?.id, "reply comment id").toBeTruthy();
+
+  const resolved = await action(req, "resolve-plan-comment", {
+    planId,
+    // Exercise the server action's root-walking path: callers can pass a reply
+    // id from get-plan-feedback and still resolve the whole thread.
+    commentId: replyComment.id,
+    status: "resolved",
+    resolutionNote,
+  });
+  expect(
+    resolved.ok,
+    `resolve-plan-comment must succeed (status ${resolved.status}: ${resolved.raw.slice(0, 200)})`,
+  ).toBeTruthy();
+  expect(
+    resolved.body.resolutionNoteId,
+    "resolve-plan-comment should return the inserted resolution note id",
+  ).toBeTruthy();
+
+  const plan = await getPlan(req, planId);
+  const comments: any[] = plan.comments ?? [];
+  const note = comments.find(
+    (comment) => comment.id === resolved.body.resolutionNoteId,
+  );
+  expect(note, "resolution note reply must persist").toBeTruthy();
+  expect(note.message).toBe(resolutionNote);
+  expect(note.parentCommentId, "resolution note should reply to the root").toBe(
+    rootId,
+  );
+  expect(note.createdBy, "resolution note should be an agent reply").toBe(
+    "agent",
+  );
+
+  for (const id of [rootId, replyComment.id, note.id]) {
+    const comment = comments.find((item) => item.id === id);
+    expect(comment?.status, `comment ${id} should be resolved`).toBe(
+      "resolved",
+    );
+    expect(
+      comment?.resolvedAt,
+      `comment ${id} should have resolvedAt`,
+    ).toBeTruthy();
+    expect(
+      comment?.resolvedBy,
+      `comment ${id} should have resolvedBy`,
+    ).toBeTruthy();
+  }
+
+  const fb = await getFeedback(req, planId);
+  expect(fb.status, "get-plan-feedback after resolving should return 200").toBe(
+    200,
+  );
+  const thread = (fb.body.threads ?? []).find(
+    (item: any) => item.id === rootId,
+  );
+  expect(
+    thread,
+    "resolved thread should remain visible until consumed",
+  ).toBeTruthy();
+  expect(thread.status, "thread should no longer be open").toBe("resolved");
+  expect(
+    thread.commentCount,
+    "thread should include root, reply, and note",
+  ).toBe(3);
+  const threadMessages = (thread.comments ?? []).map(
+    (comment: any) => comment.message,
+  );
+  expect(threadMessages).toEqual(
+    expect.arrayContaining([rootMessage, replyMessage, resolutionNote]),
+  );
+  expect(
+    fb.body.feedbackSummary?.openThreadCount,
+    "resolved thread should not count as open feedback",
+  ).toBe(0);
+  expect(
+    fb.body.feedbackSummary?.resolvedThreadCount,
+    "resolved thread should count as resolved feedback",
+  ).toBe(1);
+  expect(
+    fb.body.actionableThreads ?? [],
+    "resolved agent-targeted feedback should leave no actionable open threads",
+  ).toHaveLength(0);
+});
+
+/* ------------------------------------------------------------------ */
+/* 5. Resolving a thread removes it from open agent feedback           */
 /* ------------------------------------------------------------------ */
 test("resolving a thread stops it appearing as open feedback", async ({
   page,
@@ -423,7 +569,7 @@ test("resolving a thread stops it appearing as open feedback", async ({
 });
 
 /* ------------------------------------------------------------------ */
-/* 5. EDGE: empty comment is rejected                                  */
+/* 6. EDGE: empty comment is rejected                                  */
 /* ------------------------------------------------------------------ */
 test("empty comment body is rejected (validation), not silently stored", async ({
   page,
@@ -464,7 +610,7 @@ test("empty comment body is rejected (validation), not silently stored", async (
 });
 
 /* ------------------------------------------------------------------ */
-/* 6. EDGE: huge comment body persists intact                          */
+/* 7. EDGE: huge comment body persists intact                          */
 /* ------------------------------------------------------------------ */
 test("a huge comment body persists and round-trips intact", async ({
   page,
@@ -503,7 +649,7 @@ test("a huge comment body persists and round-trips intact", async ({
 });
 
 /* ------------------------------------------------------------------ */
-/* 7. EDGE: comment anchored to a since-removed block stays readable   */
+/* 8. EDGE: comment anchored to a since-removed block stays readable   */
 /* ------------------------------------------------------------------ */
 test("a comment anchored to a removed block remains readable feedback", async ({
   page,
@@ -564,7 +710,7 @@ test("a comment anchored to a removed block remains readable feedback", async ({
 });
 
 /* ------------------------------------------------------------------ */
-/* 8. EDGE: many comments persist collision-free (unique ids)          */
+/* 9. EDGE: many comments persist collision-free (unique ids)          */
 /* ------------------------------------------------------------------ */
 test("many comments persist with unique ids (collision-free pins)", async ({
   page,
@@ -604,7 +750,7 @@ test("many comments persist with unique ids (collision-free pins)", async ({
 });
 
 /* ------------------------------------------------------------------ */
-/* 9. UI: review mode pin → comment composer → persisted thread        */
+/* 10. UI: review mode pin → comment composer → persisted thread       */
 /*    Drives the real browser flow a reviewer would use.               */
 /* ------------------------------------------------------------------ */
 test("UI: enter review mode, pin a comment on the document, and see it persist", async ({
@@ -616,6 +762,7 @@ test("UI: enter review mode, pin a comment on the document, and see it persist",
   // Capture the status of the UI's own update-visual-plan call so the test
   // catches a server error even if the optimistic UI hides it.
   const updateStatuses: number[] = [];
+  const planReadStatuses: number[] = [];
   page.on("requestfinished", async (r) => {
     if (
       r.url().includes("update-visual-plan") &&
@@ -624,6 +771,15 @@ test("UI: enter review mode, pin a comment on the document, and see it persist",
       const resp = await r.response();
       const status = resp?.status();
       if (typeof status === "number") updateStatuses.push(status);
+    }
+  });
+  page.on("response", (resp) => {
+    const url = resp.url();
+    if (
+      url.includes("/_agent-native/actions/get-visual-plan") &&
+      url.includes(planId)
+    ) {
+      planReadStatuses.push(resp.status());
     }
   });
 
@@ -688,7 +844,7 @@ test("UI: enter review mode, pin a comment on the document, and see it persist",
       (c: any) => c.createdBy === "human",
     );
     expect(human.length).toBeGreaterThanOrEqual(1);
-    expect(human[0].authorEmail).toBe(REVIEWER_EMAIL);
+    expect(human[0].authorEmail).toBe(EXPECTED_COMMENT_AUTHOR_EMAIL);
   }).toPass({ timeout: 15000 });
 
   // And the "Send to agent" feedback control should surface once an open
@@ -697,4 +853,41 @@ test("UI: enter review mode, pin a comment on the document, and see it persist",
     page.getByRole("button", { name: /Send to agent/i }),
     "Send to agent control should appear once an open comment exists",
   ).toBeVisible({ timeout: 15000 });
+
+  // A hard browser refresh after adding comments should reload the same plan
+  // cleanly, not flash into an error state or lose the freshly saved thread.
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(
+    page.getByText("quick brown fox", { exact: false }).first(),
+    "plan content should render after hard refresh",
+  ).toBeVisible({ timeout: 15000 });
+  await expect(
+    page.getByRole("button", { name: /Send to agent/i }),
+    "open comment feedback should still be visible after hard refresh",
+  ).toBeVisible({ timeout: 15000 });
+  await expect(
+    page.getByText(/Plan (did not load|not found)|Internal server error/i),
+    "hard refresh after adding a comment must not surface a plan load error",
+  ).toHaveCount(0);
+  expect(
+    planReadStatuses.every((status) => status < 400),
+    `hard refresh should not make get-visual-plan fail (statuses seen: ${planReadStatuses.join(", ")})`,
+  ).toBeTruthy();
+
+  const reloadedPlan = await getPlan(req, planId);
+  const persisted = commentsByMessage(
+    reloadedPlan.comments ?? [],
+    "UI-pinned review comment.",
+  );
+  expect(
+    persisted,
+    "UI-pinned comment should still exist after a hard browser refresh",
+  ).toBeTruthy();
+  expect(persisted.status, "reloaded UI comment should remain open").toBe(
+    "open",
+  );
+  expect(
+    persisted.authorEmail,
+    "reloaded UI comment keeps the expected plan author identity",
+  ).toBe(EXPECTED_COMMENT_AUTHOR_EMAIL);
 });

--- a/templates/plan/e2e/global-setup.ts
+++ b/templates/plan/e2e/global-setup.ts
@@ -1,5 +1,11 @@
 import { chromium, type FullConfig } from "@playwright/test";
 import { mkdirSync, writeFileSync } from "node:fs";
+import {
+  planE2eAuthDir,
+  planE2eAuthEmailPath,
+  planE2eAuthStatePath,
+  planE2eBaseUrl,
+} from "./auth-state";
 
 /*
  * Establish a reusable authed session for the "authed" project.
@@ -8,7 +14,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
  * via a SAME-ORIGIN fetch from a loaded app page — this passes Better Auth's
  * origin check (a bare programmatic call from another origin is rejected).
  * Registers a fixed test account (idempotent: falls back to login if it already
- * exists), then saves the session cookies to e2e/.auth/state.json.
+ * exists), then saves the session cookies to this run's auth-state file.
  *
  * Guest specs opt out of this state via their own empty storageState.
  */
@@ -23,77 +29,88 @@ const EMAIL =
 const PASS =
   process.env.PLAN_E2E_PASS || ["example", "plan", "e2e", "pw"].join("-");
 
+async function sleep(ms: number) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function globalSetup(_config: FullConfig) {
-  const baseURL = process.env.PLAN_BASE_URL || "http://localhost:8081";
-  mkdirSync("e2e/.auth", { recursive: true });
+  const baseURL = planE2eBaseUrl();
+  const authDir = planE2eAuthDir(baseURL);
+  const authStatePath = planE2eAuthStatePath(baseURL);
+  const authEmailPath = planE2eAuthEmailPath(baseURL);
+  mkdirSync(authDir, { recursive: true });
   const browser = await chromium.launch();
   const ctx = await browser.newContext();
   const page = await ctx.newPage();
   let result: Record<string, unknown> = {};
-  try {
-    await page.goto(`${baseURL}/`, { waitUntil: "domcontentloaded" });
-    await page.waitForTimeout(1500);
-    result = await page.evaluate(
-      async ({ email, pass }) => {
-        const post = (path: string, body: unknown) =>
-          fetch(path, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(body),
-          }).then(async (r) => ({
-            ok: r.ok,
-            status: r.status,
-            data: (await r.json().catch(() => ({}))) as Record<string, unknown>,
-          }));
-        let login = await post("/_agent-native/auth/login", {
-          email,
-          password: pass,
-        });
-        let regStatus: number | undefined;
-        let regErr: unknown;
-        if (!login.ok) {
-          const reg = await post("/_agent-native/auth/register", {
-            email,
-            password: pass,
-            name: "E2E Tester",
-            callbackURL: "/plans",
-          });
-          regStatus = reg.status;
-          regErr = reg.data?.error || reg.data?.message;
-          login = await post("/_agent-native/auth/login", {
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      await page.goto(`${baseURL}/`, { waitUntil: "domcontentloaded" });
+      await page.waitForTimeout(500 * attempt);
+      result = await page.evaluate(
+        async ({ email, pass }) => {
+          const post = (path: string, body: unknown) =>
+            fetch(path, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(body),
+            }).then(async (r) => ({
+              ok: r.ok,
+              status: r.status,
+              data: (await r.json().catch(() => ({}))) as Record<
+                string,
+                unknown
+              >,
+            }));
+          let login = await post("/_agent-native/auth/login", {
             email,
             password: pass,
           });
-        }
-        const sess = await fetch("/_agent-native/auth/session", {
-          headers: { Accept: "application/json" },
-        })
-          .then((r) => r.json())
-          .catch(() => ({}));
-        return {
-          loginOk: login.ok,
-          loginStatus: login.status,
-          loginErr: login.data?.error || login.data?.message,
-          regStatus,
-          regErr,
-          sessionEmail: (sess as Record<string, unknown>)?.email,
-        };
-      },
-      { email: EMAIL, pass: PASS },
-    );
-  } catch (error) {
-    result = { error: (error as Error).message };
+          let regStatus: number | undefined;
+          let regErr: unknown;
+          if (!login.ok) {
+            const reg = await post("/_agent-native/auth/register", {
+              email,
+              password: pass,
+              name: "E2E Tester",
+              callbackURL: "/plans",
+            });
+            regStatus = reg.status;
+            regErr = reg.data?.error || reg.data?.message;
+            login = await post("/_agent-native/auth/login", {
+              email,
+              password: pass,
+            });
+          }
+          const sess = await fetch("/_agent-native/auth/session", {
+            headers: { Accept: "application/json" },
+          })
+            .then((r) => r.json())
+            .catch(() => ({}));
+          return {
+            loginOk: login.ok,
+            loginStatus: login.status,
+            loginErr: login.data?.error || login.data?.message,
+            regStatus,
+            regErr,
+            sessionEmail: (sess as Record<string, unknown>)?.email,
+          };
+        },
+        { email: EMAIL, pass: PASS },
+      );
+      if (result.sessionEmail) break;
+    } catch (error) {
+      result = { error: (error as Error).message, attempt };
+    }
+    if (attempt < 8) await sleep(500 * attempt);
   }
   // eslint-disable-next-line no-console
   console.log("[global-setup] auth:", JSON.stringify(result));
-  await ctx.storageState({ path: "e2e/.auth/state.json" });
+  await ctx.storageState({ path: authStatePath });
   // Record the ACTUAL authed identity so specs that assert reviewer/owner email
   // read the real session email (the account email is generated per run to avoid
   // a fixed-account/secret-rotation deadlock) instead of a hardcoded default.
-  writeFileSync(
-    "e2e/.auth/email.txt",
-    String(result.sessionEmail || EMAIL).trim(),
-  );
+  writeFileSync(authEmailPath, String(result.sessionEmail || EMAIL).trim());
   await browser.close();
   if (!result.sessionEmail) {
     // eslint-disable-next-line no-console

--- a/templates/plan/e2e/local-plan-bridge.spec.ts
+++ b/templates/plan/e2e/local-plan-bridge.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, type Page } from "@playwright/test";
+import http from "node:http";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { startLocalPlanBridge } from "../../../packages/core/src/cli/plan-local.js";
+
+async function getAvailablePort(): Promise<number> {
+  const server = http.createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  if (!address || typeof address === "string") {
+    throw new Error("Could not reserve a local bridge test port.");
+  }
+  return address.port;
+}
+
+function writeBridgeFixture(root: string) {
+  const dir = path.join(root, "bridge-reload-fixture");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "plan.mdx"),
+    [
+      "---",
+      'title: "Bridge Reload Fixture"',
+      'brief: "Loads from the local bridge."',
+      'kind: "plan"',
+      "---",
+      "",
+      "# Bridge Reload Fixture",
+      "",
+      "This local bridge content survived startup retry and hard reload.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  return dir;
+}
+
+async function expectLocalPlanContent(page: Page) {
+  await expect(page.locator(".plans-workspace")).toBeVisible({
+    timeout: 25_000,
+  });
+  await expect(
+    page.getByRole("heading", { name: "Bridge Reload Fixture" }).first(),
+  ).toBeVisible({ timeout: 25_000 });
+  await expect(
+    page.getByText(
+      "This local bridge content survived startup retry and hard reload.",
+    ),
+  ).toBeVisible({ timeout: 25_000 });
+}
+
+test("local bridge retries startup and survives a hard reload", async ({
+  page,
+  baseURL,
+}) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "an-plan-bridge-e2e-"));
+  const dir = writeBridgeFixture(root);
+  const port = await getAvailablePort();
+  const token = `bridge-${Date.now().toString(36)}`;
+  const bridgeUrl = `http://127.0.0.1:${port}/local-plan.json?token=${encodeURIComponent(
+    token,
+  )}`;
+  const appUrl =
+    baseURL ?? process.env.PLAN_BASE_URL ?? "http://localhost:8081";
+  const localPlanUrl = new URL(
+    `/local-plans/bridge-reload-fixture?bridge=${encodeURIComponent(
+      bridgeUrl,
+    )}`,
+    appUrl,
+  ).toString();
+  const failedBridgeRequests: string[] = [];
+  page.on("requestfailed", (request) => {
+    if (request.url() === bridgeUrl) {
+      failedBridgeRequests.push(request.failure()?.errorText ?? "failed");
+    }
+  });
+
+  let bridge: Awaited<ReturnType<typeof startLocalPlanBridge>> | undefined =
+    undefined;
+  try {
+    await page.goto(localPlanUrl, { waitUntil: "domcontentloaded" });
+    await expect
+      .poll(() => failedBridgeRequests.length, { timeout: 10_000 })
+      .toBeGreaterThan(0);
+
+    bridge = await startLocalPlanBridge({
+      dir,
+      appUrl,
+      host: "127.0.0.1",
+      port,
+      token,
+      urlFile: false,
+    });
+
+    await expectLocalPlanContent(page);
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expectLocalPlanContent(page);
+  } finally {
+    if (bridge) {
+      await new Promise<void>((resolve) =>
+        bridge.server.close(() => resolve()),
+      );
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/templates/plan/e2e/nav-routing-errors.spec.ts
+++ b/templates/plan/e2e/nav-routing-errors.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { planE2eUsesLocalPlanOwner } from "./auth-state";
 
 function makeE2ePassword(label: string): string {
   return ["example", label, Date.now().toString(36), "pw"].join("-");
@@ -271,7 +272,7 @@ test.describe("nav / routing / error+loading", () => {
     // It must resolve to a graceful error card within a bounded time — not crash
     // to a blank boundary and not spin on a skeleton forever.
     await expect(
-      page.getByText(/Private plan access needed/i),
+      page.getByText(/Plan not found/i),
       "a non-existent or inaccessible plan must resolve to a graceful access card (no infinite skeleton, no crash)",
     ).toBeVisible({ timeout: 25_000 });
 
@@ -518,6 +519,11 @@ test.describe("nav / routing — plan you don't own", () => {
     page,
     browser,
   }) => {
+    test.skip(
+      planE2eUsesLocalPlanOwner(),
+      "default local Plan runtime deliberately maps all browser users to one synthetic local owner; run with PLAN_LOCAL_MODE=0 or AUTH_MODE!=local to test hosted cross-owner isolation",
+    );
+
     const otherCtx = await browser.newContext();
     const otherPage = await otherCtx.newPage();
     const email = `other-${Date.now()}-${Math.random()

--- a/templates/plan/e2e/prototype-plan.spec.ts
+++ b/templates/plan/e2e/prototype-plan.spec.ts
@@ -6,6 +6,10 @@ import {
   type Locator,
 } from "@playwright/test";
 import { readFileSync } from "node:fs";
+import {
+  expectedPlanCommentAuthorEmail,
+  planE2eAuthEmailPath,
+} from "./auth-state";
 
 /*
  * PROTOTYPE PLAN — deep, adversarial E2E for the prototype-first plan feature
@@ -61,11 +65,13 @@ const REVIEWER_EMAIL =
   (() => {
     try {
       // global-setup writes the actual per-run authed identity here.
-      return readFileSync("e2e/.auth/email.txt", "utf8").trim();
+      return readFileSync(planE2eAuthEmailPath(), "utf8").trim();
     } catch {
       return "e2e-tester@plan.test";
     }
   })();
+const EXPECTED_COMMENT_AUTHOR_EMAIL =
+  expectedPlanCommentAuthorEmail(REVIEWER_EMAIL);
 
 type ActionResult = Record<string, any>;
 
@@ -771,7 +777,7 @@ test("comments work in prototype mode: a UI pin on a live screen persists with t
       (c: any) => c.createdBy === "human",
     );
     expect(human.length).toBeGreaterThanOrEqual(1);
-    expect(human[0].authorEmail).toBe(REVIEWER_EMAIL);
+    expect(human[0].authorEmail).toBe(EXPECTED_COMMENT_AUTHOR_EMAIL);
     expect(
       String(human[0].anchor ?? ""),
       "the persisted pin anchors to the prototype surface",
@@ -818,7 +824,7 @@ test("prototype comments route to the agent or a human by resolutionTarget and s
     ).toBeGreaterThanOrEqual(2);
     // Reviewer identity stamped on every human pin.
     for (const c of comments) {
-      expect(c.authorEmail).toBe(REVIEWER_EMAIL);
+      expect(c.authorEmail).toBe(EXPECTED_COMMENT_AUTHOR_EMAIL);
       expect(
         String(c.anchor ?? ""),
         "every prototype pin keeps a prototype anchor",

--- a/templates/plan/e2e/realtime-collab.spec.ts
+++ b/templates/plan/e2e/realtime-collab.spec.ts
@@ -5,6 +5,7 @@ import {
   type BrowserContext,
   type Page,
 } from "@playwright/test";
+import { planE2eAuthStatePath } from "./auth-state";
 
 function makeE2ePassword(label: string): string {
   return ["example", label, Date.now().toString(36), "pw"].join("-");
@@ -52,7 +53,7 @@ const CREATE_ACTION = "/_agent-native/actions/create-visual-plan";
 const GET_ACTION = "/_agent-native/actions/get-visual-plan";
 const UPDATE_ACTION = "/_agent-native/actions/update-visual-plan";
 const RICH_BLOCK_ID = "rt-collab";
-const STATE_FILE = "e2e/.auth/state.json";
+const STATE_FILE = planE2eAuthStatePath();
 
 type PlanContentInput = {
   version: number;

--- a/templates/plan/e2e/sharing-access.spec.ts
+++ b/templates/plan/e2e/sharing-access.spec.ts
@@ -4,6 +4,7 @@ import {
   type APIRequestContext,
   type BrowserContext,
 } from "@playwright/test";
+import { planE2eAuthStatePath } from "./auth-state";
 
 function makeE2ePassword(label: string): string {
   return ["example", label, Date.now().toString(36), "pw"].join("-");
@@ -606,7 +607,7 @@ test.describe("sharing + publish + access control", () => {
     // browser context to drive the UI, so create the fixture with a fresh
     // owner context built from the saved storageState.
     const ownerCtx = await reviewer.context.browser()!.newContext({
-      storageState: "e2e/.auth/state.json",
+      storageState: planE2eAuthStatePath(),
     });
     const ownerPage = await ownerCtx.newPage();
     const planId = await createOwnerPlan(

--- a/templates/plan/playwright.config.ts
+++ b/templates/plan/playwright.config.ts
@@ -1,4 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
+import { planE2eAuthStatePath, planE2eBaseUrl } from "./e2e/auth-state";
+
+const baseURL = planE2eBaseUrl();
+const authStatePath = planE2eAuthStatePath(baseURL);
 
 /*
  * Parallel browser E2E for the Agent-Native Plan app.
@@ -19,7 +23,7 @@ export default defineConfig({
   reporter: [["list"], ["json", { outputFile: "e2e/.report.json" }]],
   globalSetup: "./e2e/global-setup.ts",
   use: {
-    baseURL: process.env.PLAN_BASE_URL || "http://localhost:8081",
+    baseURL,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     actionTimeout: 12_000,
@@ -30,7 +34,7 @@ export default defineConfig({
       name: "authed",
       use: {
         ...devices["Desktop Chrome"],
-        storageState: "e2e/.auth/state.json",
+        storageState: authStatePath,
       },
     },
     {


### PR DESCRIPTION
## Summary
- add the shared agent chat runtime surface and adapter refinements
- expand Plan local CLI validation, serve alias coverage, and docs
- update Plan commenting/auth E2E support plus mirrored visual plan/recap skill assets

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/client/chat/runtime.spec.ts src/client/agent-chat-adapter.spec.ts src/cli/plan-local.spec.ts src/cli/skills.spec.ts src/mcp/server.spec.ts
- pnpm --dir templates/plan exec vitest --run actions/plan-comment-actions.spec.ts app/pages/PlansPage.comments.test.ts
- pnpm guard:workspace-skills
- pnpm guard:plan-marketplace
- pnpm --filter @agent-native/core typecheck
- pnpm --dir templates/plan typecheck
- pnpm exec prettier --check <changed files>