### PR TITLE
Add persistent log file for production debugging

### DIFF
--- a/templates/clips/desktop/src-tauri/Cargo.lock
+++ b/templates/clips/desktop/src-tauri/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "chrono",
  "core-foundation",
  "core-graphics",
+ "libc",
  "objc2",
  "objc2-audio-toolbox",
  "objc2-avf-audio",

--- a/templates/clips/desktop/src-tauri/Cargo.toml
+++ b/templates/clips/desktop/src-tauri/Cargo.toml
@@ -56,6 +56,10 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "sync"] }
 chrono = { version = "0.4", features = ["serde"] }
 # Verify the integrity of the Whisper model we download from HuggingFace.
 sha2 = "0.10"
+# Low-level dup2/open so we can redirect stdout+stderr into a persistent log
+# file in release builds (see logfile.rs). Tauri already pulls libc in
+# transitively; declaring it here just makes the API available directly.
+libc = "0.2"
 
 # macOS-only: raw Objective-C messaging so we can flip NSWindow's sharingType
 # to NSWindowSharingNone and hide every overlay window (popover, bubble,

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod clips;
 mod config;
 mod debug;
 mod eventkit;
+mod logfile;
 mod meetings_watcher;
 mod native_screen;
 mod native_speech;
@@ -141,6 +142,9 @@ pub fn run() {
             // whisper model management
             whisper_model::whisper_model_status,
             whisper_model::whisper_model_download,
+            // persistent log file (production debugging)
+            logfile::frontend_log,
+            logfile::open_logs,
         ])
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_process::init())
@@ -168,6 +172,10 @@ pub fn run() {
         .manage(notifications::MeetingNotificationState::default())
         .manage(silence_detector::DetectorState::default())
         .setup(|app| {
+            // Capture stdout/stderr to a persistent log file before anything
+            // else runs so startup errors and panics land on disk too.
+            logfile::init(app.handle());
+
             // Keeps the app from yanking the user out of fullscreen when the
             // popover appears. Production bundles reinforce this with LSUIElement=1.
             #[cfg(target_os = "macos")]

--- a/templates/clips/desktop/src-tauri/src/logfile.rs
+++ b/templates/clips/desktop/src-tauri/src/logfile.rs
@@ -112,13 +112,20 @@ fn redirect_std_streams(path: &Path) {
 
 #[cfg(all(not(debug_assertions), windows))]
 fn redirect_std_streams(path: &Path) {
-    use std::ffi::CString;
+    use std::os::windows::ffi::OsStrExt;
 
-    let Some(s) = path.to_str() else { return };
-    let Ok(cpath) = CString::new(s) else { return };
+    // libc::open maps to the narrow CRT _open, which interprets the path in
+    // the active ANSI code page — a profile path with non-ASCII characters
+    // (e.g. C:\Users\Müller) then fails to open and silently disables logging.
+    // Build a NUL-terminated UTF-16 path and use the wide _wopen instead.
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
     unsafe {
-        let fd = libc::open(
-            cpath.as_ptr(),
+        let fd = libc::_wopen(
+            wide.as_ptr(),
             libc::O_WRONLY | libc::O_CREAT | libc::O_APPEND,
             libc::S_IWRITE,
         );

--- a/templates/clips/desktop/src-tauri/src/logfile.rs
+++ b/templates/clips/desktop/src-tauri/src/logfile.rs
@@ -117,14 +117,14 @@ fn redirect_std_streams(path: &Path) {
     // libc::open maps to the narrow CRT _open, which interprets the path in
     // the active ANSI code page — a profile path with non-ASCII characters
     // (e.g. C:\Users\Müller) then fails to open and silently disables logging.
-    // Build a NUL-terminated UTF-16 path and use the wide _wopen instead.
+    // Build a NUL-terminated UTF-16 path and use the wide wopen instead.
     let wide: Vec<u16> = path
         .as_os_str()
         .encode_wide()
         .chain(std::iter::once(0))
         .collect();
     unsafe {
-        let fd = libc::_wopen(
+        let fd = libc::wopen(
             wide.as_ptr(),
             libc::O_WRONLY | libc::O_CREAT | libc::O_APPEND,
             libc::S_IWRITE,

--- a/templates/clips/desktop/src-tauri/src/logfile.rs
+++ b/templates/clips/desktop/src-tauri/src/logfile.rs
@@ -1,0 +1,203 @@
+//! Persistent log file for production debugging.
+//!
+//! Release builds detach from a terminal, so every `println!` / `eprintln!`
+//! / `dlog!` and Rust panic normally vanishes — there's nothing to send to
+//! support when a user hits a bug. To capture all of it without touching the
+//! hundreds of existing log call sites, we redirect the process stdout/stderr
+//! file descriptors to a rotating file under the OS log dir
+//! (`~/Library/Logs/<bundle-id>/clips-tray.log` on macOS). The frontend tees
+//! its `console.*` output here too via the `frontend_log` command, so a single
+//! file holds both Rust and webview logs.
+//!
+//! In debug builds we leave the streams alone so `tauri dev` keeps printing to
+//! the terminal; only the log path + startup banner are set up.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use tauri::{AppHandle, Manager};
+
+static LOG_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Rotate once the active log passes this size so the file can't grow without
+/// bound across long-lived sessions.
+const MAX_BYTES: u64 = 5 * 1024 * 1024;
+
+/// Path of the active log file, once [`init`] has resolved it.
+pub fn log_path() -> Option<PathBuf> {
+    LOG_PATH.get().cloned()
+}
+
+/// Resolve the log file, rotate it if needed, and (release only) redirect
+/// stdout/stderr into it. Safe to call once during app setup.
+pub fn init(app: &AppHandle) {
+    let dir = match app.path().app_log_dir() {
+        Ok(dir) => dir,
+        Err(err) => {
+            eprintln!("[clips-tray] could not resolve log dir: {err}");
+            return;
+        }
+    };
+    if let Err(err) = fs::create_dir_all(&dir) {
+        eprintln!("[clips-tray] could not create log dir {dir:?}: {err}");
+        return;
+    }
+
+    let path = dir.join("clips-tray.log");
+    rotate_if_needed(&path);
+    let _ = LOG_PATH.set(path.clone());
+
+    // In release, point fd 1 + 2 at the file so every existing println!,
+    // eprintln!, dlog!, and panic message is captured with no call-site
+    // changes. Done before the banner so the banner lands in the file too.
+    #[cfg(not(debug_assertions))]
+    redirect_std_streams(&path);
+
+    // Always write a startup marker — guarantees the file exists (even in dev)
+    // and stamps each run so support can tell session boundaries apart.
+    let banner = format!(
+        "[clips-tray] === log start {} v{} ===",
+        chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
+        env!("CARGO_PKG_VERSION"),
+    );
+    #[cfg(not(debug_assertions))]
+    println!("{banner}");
+    #[cfg(debug_assertions)]
+    append_line(&path, &banner);
+}
+
+fn rotate_if_needed(path: &Path) {
+    if let Ok(meta) = fs::metadata(path) {
+        if meta.len() > MAX_BYTES {
+            // Single previous generation is enough for debugging; the rename
+            // replaces any earlier `.1`.
+            let _ = fs::rename(path, path.with_extension("log.1"));
+        }
+    }
+}
+
+#[allow(dead_code)] // unused in release where stdout/stderr are redirected
+fn append_line(path: &Path, line: &str) {
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(file, "{line}");
+    }
+}
+
+#[cfg(all(not(debug_assertions), unix))]
+fn redirect_std_streams(path: &Path) {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let Ok(cpath) = CString::new(path.as_os_str().as_bytes()) else {
+        return;
+    };
+    unsafe {
+        let fd = libc::open(
+            cpath.as_ptr(),
+            libc::O_WRONLY | libc::O_CREAT | libc::O_APPEND,
+            0o644,
+        );
+        if fd < 0 {
+            return;
+        }
+        libc::dup2(fd, libc::STDOUT_FILENO);
+        libc::dup2(fd, libc::STDERR_FILENO);
+        if fd > 2 {
+            libc::close(fd);
+        }
+    }
+}
+
+#[cfg(all(not(debug_assertions), windows))]
+fn redirect_std_streams(path: &Path) {
+    use std::ffi::CString;
+
+    let Some(s) = path.to_str() else { return };
+    let Ok(cpath) = CString::new(s) else { return };
+    unsafe {
+        let fd = libc::open(
+            cpath.as_ptr(),
+            libc::O_WRONLY | libc::O_CREAT | libc::O_APPEND,
+            libc::S_IWRITE,
+        );
+        if fd < 0 {
+            return;
+        }
+        // 1 = stdout, 2 = stderr (libc on Windows omits STD*_FILENO).
+        libc::dup2(fd, 1);
+        libc::dup2(fd, 2);
+        if fd > 2 {
+            libc::close(fd);
+        }
+    }
+}
+
+// Exotic release targets (neither unix nor windows) keep their default
+// streams — there's no portable fd redirect to fall back on.
+#[cfg(all(not(debug_assertions), not(unix), not(windows)))]
+fn redirect_std_streams(_path: &Path) {}
+
+/// Forward a webview `console.*` line into the same log file. Called from the
+/// frontend console tee (see `src/main.tsx`).
+#[tauri::command]
+pub fn frontend_log(level: String, message: String) {
+    // In release this println! is redirected into the log file; in dev it
+    // simply echoes to the terminal.
+    println!("[webview][{level}] {message}");
+    // In dev there is no fd redirect, so also append directly to keep the file
+    // useful when a developer opens it.
+    #[cfg(debug_assertions)]
+    if let Some(path) = log_path() {
+        append_line(&path, &format!("[webview][{level}] {message}"));
+    }
+}
+
+/// Reveal the log file in the system file manager so users/support can grab it.
+#[tauri::command]
+pub fn open_logs() -> Result<(), String> {
+    let path = log_path().ok_or_else(|| "log file is not initialized yet".to_string())?;
+    reveal_in_file_manager(&path)
+}
+
+#[cfg(target_os = "macos")]
+fn reveal_in_file_manager(path: &Path) -> Result<(), String> {
+    let status = std::process::Command::new("open")
+        .arg("-R")
+        .arg(path)
+        .status()
+        .map_err(|e| format!("failed to reveal log file: {e}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("open exited with {status}"))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn reveal_in_file_manager(path: &Path) -> Result<(), String> {
+    let status = std::process::Command::new("explorer")
+        .arg("/select,")
+        .arg(path)
+        .status()
+        .map_err(|e| format!("failed to reveal log file: {e}"))?;
+    // explorer.exe returns a non-zero exit code even on success, so don't gate
+    // on status here.
+    let _ = status;
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn reveal_in_file_manager(path: &Path) -> Result<(), String> {
+    let dir = path.parent().unwrap_or(path);
+    let status = std::process::Command::new("xdg-open")
+        .arg(dir)
+        .status()
+        .map_err(|e| format!("failed to open log folder: {e}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("xdg-open exited with {status}"))
+    }
+}

--- a/templates/clips/desktop/src-tauri/src/logfile.rs
+++ b/templates/clips/desktop/src-tauri/src/logfile.rs
@@ -23,7 +23,7 @@ static LOG_PATH: OnceLock<PathBuf> = OnceLock::new();
 
 /// Rotate once the active log passes this size so the file can't grow without
 /// bound across long-lived sessions.
-const MAX_BYTES: u64 = 5 * 1024 * 1024;
+const MAX_BYTES: u64 = 10 * 1024 * 1024;
 
 /// Path of the active log file, once [`init`] has resolved it.
 pub fn log_path() -> Option<PathBuf> {

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -676,6 +676,11 @@ fn take_and_finalize_active_session(
     // playable. The caller persists recovery metadata so a finalize
     // failure doesn't orphan the file.
     let stop_outcome = finalize_active_backend(&mut session, true);
+    println!(
+        "[clips-tray] finalize backend done (ok={}); {}",
+        stop_outcome.is_ok(),
+        describe_recording_path(&session.path)
+    );
     // With one segment this is a cheap rename. With multiple segments a
     // failure would silently lose everything after the first pause, so
     // callers check `multi_segment` and surface the merge error.
@@ -684,6 +689,12 @@ fn take_and_finalize_active_session(
     if let Err(err) = &consolidate_outcome {
         eprintln!("[clips-tray] segment consolidation failed: {err}");
     }
+    println!(
+        "[clips-tray] consolidate done (ok={}, segments={}, multi={multi_segment}); {}",
+        consolidate_outcome.is_ok(),
+        session.segments.len(),
+        describe_recording_path(&session.path)
+    );
     let duration_ms = session
         .started_at
         .elapsed()
@@ -1088,6 +1099,16 @@ fn now_iso() -> String {
     Utc::now().to_rfc3339()
 }
 
+fn describe_recording_path(path: &Path) -> String {
+    let exists = path.exists();
+    let size = std::fs::metadata(path).map(|m| m.len()).ok();
+    format!(
+        "path={} exists={exists} size={}",
+        path.display(),
+        size.map(|b| b.to_string()).unwrap_or_else(|| "n/a".into()),
+    )
+}
+
 fn pending_uploads_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = app
         .path()
@@ -1382,9 +1403,21 @@ fn saved_recording_from_session(
     has_camera: bool,
 ) -> Result<SavedNativeRecording, String> {
     let bytes = std::fs::metadata(&session.path)
-        .map_err(|e| format!("native recording file missing: {e}"))?
+        .map_err(|e| {
+            let diag = describe_recording_path(&session.path);
+            eprintln!(
+                "[clips-tray] native recording file missing at save: {e}; backend={}, segments={}, {diag}",
+                session.mime_type,
+                session.segments.len(),
+            );
+            format!("native recording file missing: {e} ({diag})")
+        })?
         .len();
     if bytes == 0 {
+        eprintln!(
+            "[clips-tray] native recording empty at save: {}",
+            describe_recording_path(&session.path)
+        );
         return Err("Native recording produced an empty file.".into());
     }
 
@@ -1529,6 +1562,10 @@ fn start_screencapturekit_recording(
     let target_display_id = tray_display_id(app);
     let path = pending_recording_path(app, safe_id, "mp4")?;
     let _ = std::fs::remove_file(&path);
+    eprintln!(
+        "[clips-tray] starting ScreenCaptureKit recording -> {}",
+        path.display()
+    );
     let (backend, width, height) = start_screencapturekit_backend_at(
         &path,
         include_audio,
@@ -1566,6 +1603,10 @@ fn start_screencapture_recording(
     let target_display_id = tray_display_id(app);
     let path = pending_recording_path(app, safe_id, "mov")?;
     let _ = std::fs::remove_file(&path);
+    eprintln!(
+        "[clips-tray] starting screencapture (fallback) recording -> {}",
+        path.display()
+    );
     let (backend, _w, _h) =
         start_screencapture_backend_at(&path, include_audio, target_display_id)?;
     let (width, height) = primary_monitor_size(app);
@@ -2144,10 +2185,17 @@ fn prepare_recording_file(
     height: Option<u32>,
     duration_ms: Option<u128>,
 ) -> Result<PreparedRecordingFile, String> {
-    let metadata =
-        std::fs::metadata(path).map_err(|e| format!("native recording file missing: {e}"))?;
+    let metadata = std::fs::metadata(path).map_err(|e| {
+        let diag = describe_recording_path(path);
+        eprintln!("[clips-tray] native recording file missing at prepare: {e}; {diag}");
+        format!("native recording file missing: {e} ({diag})")
+    })?;
     let source_bytes = metadata.len();
     if source_bytes == 0 {
+        eprintln!(
+            "[clips-tray] native recording empty at prepare: {}",
+            describe_recording_path(path)
+        );
         return Err("Native recording produced an empty file.".into());
     }
     emit_native_upload_progress(app, "preparing", "Optimizing clip", None, None);

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -1410,7 +1410,7 @@ fn saved_recording_from_session(
                 session.mime_type,
                 session.segments.len(),
             );
-            format!("native recording file missing: {e} ({diag})")
+            format!("native recording file missing: {e}")
         })?
         .len();
     if bytes == 0 {
@@ -2188,7 +2188,7 @@ fn prepare_recording_file(
     let metadata = std::fs::metadata(path).map_err(|e| {
         let diag = describe_recording_path(path);
         eprintln!("[clips-tray] native recording file missing at prepare: {e}; {diag}");
-        format!("native recording file missing: {e} ({diag})")
+        format!("native recording file missing: {e}")
     })?;
     let source_bytes = metadata.len();
     if source_bytes == 0 {

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -4092,6 +4092,20 @@ function Setup({
           </div>
         </>
       ) : null}
+      <div className="setup-account">
+        <button
+          type="button"
+          className="link-button"
+          onClick={() => {
+            invoke("open_logs").catch((err) => {
+              console.error("[clips-tray] open logs failed:", err);
+            });
+          }}
+          style={{ background: "transparent", border: "none" }}
+        >
+          Open logs
+        </button>
+      </div>
       {signedInAs && onSignOut ? (
         <div className="setup-account">
           <span className="setup-account-email">{signedInAs}</span>

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -4101,8 +4101,9 @@ function Setup({
               console.error("[clips-tray] open logs failed:", err);
             });
           }}
-          style={{ background: "transparent", border: "none" }}
+          style={{ display: "flex", alignItems: "center", gap: 6 }}
         >
+          <IconFolderOpen size={14} />
           Open logs
         </button>
       </div>

--- a/templates/clips/desktop/src/main.tsx
+++ b/templates/clips/desktop/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { invoke } from "@tauri-apps/api/core";
 import { App } from "./app";
 import { Countdown } from "./overlays/countdown";
 import { Toolbar } from "./overlays/toolbar";
@@ -145,10 +146,65 @@ function installHeapDebugLog(): void {
   }, 30_000);
 }
 
+/**
+ * Tee the webview console into the persistent backend log file.
+ *
+ * In production the webview has no devtools and `console.*` output is lost, so
+ * frontend errors can't be debugged after the fact. We wrap each console method
+ * to also forward its message to the Rust `frontend_log` command, which prints
+ * it into the same redirected stdout/stderr that backs `clips-tray.log`. The
+ * original console behavior is preserved (tee, not replace). Dev keeps the raw
+ * console untouched since devtools + the terminal already cover it.
+ */
+function installConsoleCapture(route: string): void {
+  if (import.meta.env.DEV) return;
+
+  const serialize = (value: unknown): string => {
+    if (typeof value === "string") return value;
+    if (value instanceof Error) return value.stack || `${value.name}: ${value.message}`;
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  };
+
+  const forward = (level: string, args: unknown[]): void => {
+    try {
+      const message = `[${route}] ${args.map(serialize).join(" ")}`;
+      // Swallow failures — logging must never throw into the app, and we must
+      // not call console here or we'd recurse.
+      void invoke("frontend_log", { level, message }).catch(() => {});
+    } catch {
+      // ignore
+    }
+  };
+
+  const levels = ["log", "info", "warn", "error", "debug"] as const;
+  for (const level of levels) {
+    const original = console[level].bind(console);
+    console[level] = (...args: unknown[]) => {
+      original(...args);
+      forward(level, args);
+    };
+  }
+
+  window.addEventListener("error", (event) => {
+    forward("error", [
+      `uncaught: ${event.message}`,
+      event.error instanceof Error ? event.error : `${event.filename}:${event.lineno}`,
+    ]);
+  });
+  window.addEventListener("unhandledrejection", (event) => {
+    forward("error", ["unhandledrejection:", event.reason]);
+  });
+}
+
 const rootEl = document.getElementById("root");
 if (rootEl) {
   const route = currentRoute();
   installRouteAttributes(route);
+  installConsoleCapture(route);
   installBeforeUnloadCleanup();
   installHeapDebugLog();
   // NOTE: intentionally NOT wrapping in React.StrictMode. StrictMode

--- a/templates/clips/desktop/src/main.tsx
+++ b/templates/clips/desktop/src/main.tsx
@@ -153,12 +153,9 @@ function installHeapDebugLog(): void {
  * frontend errors can't be debugged after the fact. We wrap each console method
  * to also forward its message to the Rust `frontend_log` command, which prints
  * it into the same redirected stdout/stderr that backs `clips-tray.log`. The
- * original console behavior is preserved (tee, not replace). Dev keeps the raw
- * console untouched since devtools + the terminal already cover it.
+ * original console behavior is preserved (tee, not replace)
  */
 function installConsoleCapture(route: string): void {
-  if (import.meta.env.DEV) return;
-
   const serialize = (value: unknown): string => {
     if (typeof value === "string") return value;
     if (value instanceof Error)

--- a/templates/clips/desktop/src/main.tsx
+++ b/templates/clips/desktop/src/main.tsx
@@ -161,7 +161,8 @@ function installConsoleCapture(route: string): void {
 
   const serialize = (value: unknown): string => {
     if (typeof value === "string") return value;
-    if (value instanceof Error) return value.stack || `${value.name}: ${value.message}`;
+    if (value instanceof Error)
+      return value.stack || `${value.name}: ${value.message}`;
     try {
       return JSON.stringify(value);
     } catch {
@@ -192,7 +193,9 @@ function installConsoleCapture(route: string): void {
   window.addEventListener("error", (event) => {
     forward("error", [
       `uncaught: ${event.message}`,
-      event.error instanceof Error ? event.error : `${event.filename}:${event.lineno}`,
+      event.error instanceof Error
+        ? event.error
+        : `${event.filename}:${event.lineno}`,
     ]);
   });
   window.addEventListener("unhandledrejection", (event) => {


### PR DESCRIPTION
### Summary
Adds a persistent log file for the clips desktop app in production builds, capturing both Rust (stdout/stderr) and frontend (console.*) output to a single rotating file on disk.

### Problem
In production, the app detaches from a terminal, so all `println!`, `eprintln!`, `dlog!`, Rust panics, and frontend `console.*` output were silently discarded. There was no way to retrieve logs from a user's machine to debug issues after the fact.
<img width="612" height="890" alt="image" src="https://github.com/user-attachments/assets/4b11bc64-b395-4e53-b48a-01eba1260f88" />

### Solution
A new `logfile` Rust module redirects the process stdout/stderr file descriptors to a rotating log file (`clips-tray.log`) under the OS log directory at startup. The frontend tees its `console.*` output to the same file via a new `frontend_log` Tauri command. An "Open logs" button in the Setup UI lets users/support easily reveal the log file in the system file manager.

### Key Changes
- **`src-tauri/src/logfile.rs`** — New module that:
  - Resolves the log path via Tauri's `app_log_dir()` (`~/Library/Logs/<bundle-id>/clips-tray.log` on macOS)
  - Rotates the log file at 5 MB (keeping one previous generation)
  - In release builds, uses `libc::dup2` to redirect fd 1 (stdout) and fd 2 (stderr) into the log file on Unix and Windows; dev builds leave streams untouched
  - Writes a timestamped startup banner on each run to mark session boundaries
  - Exposes `frontend_log` Tauri command to receive forwarded webview console messages
  - Exposes `open_logs` Tauri command to reveal the log file in Finder / Explorer / xdg-open
- **`src-tauri/src/lib.rs`** — Calls `logfile::init()` early in app setup and registers the two new commands
- **`src-tauri/Cargo.toml`** — Adds `libc = "0.2"` dependency for low-level fd redirection
- **`src/main.tsx`** — Adds `installConsoleCapture()` which wraps all `console.*` methods in production to forward messages to `frontend_log`, and also captures uncaught errors and unhandled promise rejections
- **`src/app.tsx`** — Adds an "Open logs" button in the Setup panel that invokes `open_logs`


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/knit-circuit-ow7aorgn"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-knit-circuit-ow7aorgn.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1288`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>knit-circuit-ow7aorgn</branchName>-->