### PR TITLE
Fix recording start lag, timer, and duration in Clips desktop

### DIFF
--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -212,6 +212,31 @@ pub fn run() {
                         match whisper_model::ensure_model(&app_handle).await {
                             Ok(_) => {
                                 let _ = app_handle.emit("whisper:model-ready", ());
+                                // Warm the in-memory whisper context now, off
+                                // the recording-start path, so the first
+                                // recording doesn't block ~hundreds of ms
+                                // loading the model into memory. Blocking work
+                                // → spawn_blocking.
+                                let warm_handle = app_handle.clone();
+                                let _ = tauri::async_runtime::spawn_blocking(move || {
+                                    match whisper_speech::prewarm_context(&warm_handle) {
+                                        Ok(_) => {
+                                            println!("[clips-tray] whisper context prewarm finished");
+                                            let _ = warm_handle
+                                                .emit("whisper:context-ready", ());
+                                        }
+                                        Err(e) => {
+                                            eprintln!(
+                                                "[clips-tray] whisper context prewarm failed: {e}"
+                                            );
+                                            let _ = warm_handle.emit(
+                                                "whisper:context-error",
+                                                serde_json::json!({ "error": e }),
+                                            );
+                                        }
+                                    }
+                                })
+                                .await;
                             }
                             Err(e) => {
                                 eprintln!("[clips-tray] startup model download failed: {e}");

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -216,14 +216,15 @@ pub fn run() {
                                 // the recording-start path, so the first
                                 // recording doesn't block ~hundreds of ms
                                 // loading the model into memory. Blocking work
-                                // → spawn_blocking.
+                                // → spawn_blocking
                                 let warm_handle = app_handle.clone();
                                 let _ = tauri::async_runtime::spawn_blocking(move || {
                                     match whisper_speech::prewarm_context(&warm_handle) {
                                         Ok(_) => {
-                                            println!("[clips-tray] whisper context prewarm finished");
-                                            let _ = warm_handle
-                                                .emit("whisper:context-ready", ());
+                                            println!(
+                                                "[clips-tray] whisper context prewarm finished"
+                                            );
+                                            let _ = warm_handle.emit("whisper:context-ready", ());
                                         }
                                         Err(e) => {
                                             eprintln!(

--- a/templates/clips/desktop/src-tauri/src/whisper_speech.rs
+++ b/templates/clips/desktop/src-tauri/src/whisper_speech.rs
@@ -49,6 +49,25 @@ pub async fn whisper_transcription_start(
     }
 }
 
+/// Warm the process-wide whisper context off the recording-start path.
+///
+/// Loading the ~142 MB model into memory (`WhisperContext::new`) is synchronous
+/// and costs hundreds of ms on first use. Without this, the very first
+/// recording pays that cost between the user's Record gesture and audio
+/// actually capturing — the perceived "start lag". Call this at app startup
+/// (after the model file is downloaded) so the context is already cached.
+///
+/// Blocking work — call from a `spawn_blocking` context, not the async runtime.
+#[cfg(target_os = "macos")]
+pub fn prewarm_context(app: &AppHandle) -> Result<(), String> {
+    macos::prewarm(app)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn prewarm_context(_app: &AppHandle) -> Result<(), String> {
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn whisper_transcription_stop(app: AppHandle) -> Result<(), String> {
     #[cfg(target_os = "macos")]
@@ -120,6 +139,13 @@ mod macos {
         let ctx = Arc::new(ctx);
         *guard = Some(ctx.clone());
         Ok(ctx)
+    }
+
+    pub fn prewarm(app: &AppHandle) -> Result<(), String> {
+        let ctx = context(app)?;
+        ctx.create_state()
+            .map_err(|e| format!("whisper state init failed: {e}"))?;
+        Ok(())
     }
 
     // ---- resampling -------------------------------------------------------

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -1332,6 +1332,9 @@ export function App() {
       isRecording ||
       recordingFlowActive ||
       recordingFlowGateRef.current);
+
+  const bubbleActiveRef = useRef(false);
+  bubbleActiveRef.current = bubbleActive;
   // The toolbar is recording chrome, not pre-record chrome. Showing it while
   // the popover is merely open leaves a disabled 0:00 Stop/Pause pill on the
   // desktop, which reads as a stuck recorder and can trap accessibility clicks.
@@ -1455,10 +1458,13 @@ export function App() {
         emit("clips:bubble-stop-local-camera", {}).catch(() => {});
         const recordingInFlight = recordingFlowGateRef.current;
         console.log(
-          "[clips-popover] local bubble session end — recordingInFlight=%o",
+          "[clips-popover] local bubble session end — recordingInFlight=%o stillActive=%o",
           recordingInFlight,
+          bubbleActiveRef.current,
         );
-        if (!recordingInFlight) {
+        // Skip teardown when the bubble is still wanted (only the capture
+        // source changed). Hiding here would race the re-run's show_bubble.
+        if (!recordingInFlight && !bubbleActiveRef.current) {
           invoke("hide_overlays").catch(() => {});
         }
       };
@@ -1466,7 +1472,11 @@ export function App() {
 
     navigator.mediaDevices
       .getUserMedia({
-        video: cameraId ? { deviceId: { exact: cameraId } } : true,
+        video: {
+          width: { ideal: 1280 },
+          height: { ideal: 720 },
+          ...(cameraId ? { deviceId: { exact: cameraId } } : {}),
+        },
         audio: false,
       })
       .then(async (s) => {
@@ -1576,7 +1586,11 @@ export function App() {
       // recorder's stop flow calls `hide_recording_chrome` which handles
       // the bubble correctly). Hiding here mid-flow would kill the
       // on-screen bubble window the user sees during the recording.
-      if (!recordingInFlight) {
+      // Also skip when the bubble is still wanted and only the capture
+      // source changed (window ↔ full-screen flips `bubbleUsesLocalCamera`,
+      // re-running this effect): hiding would race the re-run's show_bubble
+      // and close the window out from under it.
+      if (!recordingInFlight && !bubbleActiveRef.current) {
         invoke("hide_overlays").catch(() => {});
       }
     };

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -1410,6 +1410,11 @@ async function startNativeFullscreenRecording(
   let localOwnsCameraStream = false;
   let bubbleCaptureExcluded = false;
   let transcriptionCapture: TranscriptionCapture | null = null;
+  // Timer baseline for the toolbar/pill elapsed clock. Stamped the instant
+  // native capture goes live (right after the start invoke resolves), not after
+  // the region-guide / transcription spin-up — which would push the displayed
+  // clock and the toolbar-enable behind the real recording start.
+  let startedAt = 0;
   let nativeTranscriptFailureSaved = false;
   const saveTranscriptFailure = async (failureReason: string) => {
     if (!wantsAudio || nativeTranscriptFailureSaved || !id) return;
@@ -1503,27 +1508,11 @@ async function startNativeFullscreenRecording(
       micDeviceId: params.micId || null,
       micDeviceLabel: params.micLabel || null,
     });
+    // Capture is now live — stamp the timer baseline before any further awaits
+    // so the toolbar clock and toolbar-enable line up with the real start.
+    startedAt = Date.now();
     localCameraExport?.start(2_000);
-
-    if (!localOnly) {
-      await showRegionGuidesForRecording(true);
-      transcriptionCapture = wantsAudio
-        ? await startTranscriptionCapture(
-            {
-              deviceId: params.micId,
-              label: params.micLabel,
-            },
-            wantsSystemAudio,
-          )
-        : null;
-      if (wantsAudio && !transcriptionCapture) {
-        void saveTranscriptFailure(
-          "macOS Speech recognition could not start for this recording. Check Speech Recognition and Microphone permissions, then retry transcription.",
-        );
-      }
-    }
   } catch (err) {
-    await transcriptionCapture?.cancel().catch(() => {});
     await localCameraExport?.cancel().catch(() => {});
     if (bubbleCaptureExcluded) {
       await invoke("set_bubble_capture_excluded", {
@@ -1544,7 +1533,6 @@ async function startNativeFullscreenRecording(
     throw err;
   }
 
-  const startedAt = Date.now();
   let stopped = false;
   let stopPromise: Promise<RecorderStopResult> | null = null;
   let cancelPromise: Promise<void> | null = null;
@@ -1817,6 +1805,25 @@ async function startNativeFullscreenRecording(
   tickHandle = setInterval(emitState, 500);
   emit("clips:toolbar-enabled", true).catch(() => {});
   emitState();
+
+  if (!localOnly) {
+    await showRegionGuidesForRecording(true);
+    const wantsSystemAudio = wantsAudio && params.systemAudioOn !== false;
+    transcriptionCapture = wantsAudio
+      ? await startTranscriptionCapture(
+          {
+            deviceId: params.micId,
+            label: params.micLabel,
+          },
+          wantsSystemAudio,
+        )
+      : null;
+    if (wantsAudio && !transcriptionCapture) {
+      void saveTranscriptFailure(
+        "macOS Speech recognition could not start for this recording. Check Speech Recognition and Microphone permissions, then retry transcription.",
+      );
+    }
+  }
 
   return handle;
 }
@@ -2242,11 +2249,15 @@ async function startRecordingInner(
     }
 
     const id = `local-${Date.now().toString(36)}`;
-    let startedAt = Date.now();
+    // Stamped at the real capture start below — kept 0 until then so the tick
+    // never reports an elapsed time against a stale baseline (which showed the
+    // clock counting up and then resetting to 0 when start finally fired).
+    let startedAt = 0;
     let pausedAt: number | null = null;
     let accumulatedPauseMs = 0;
     let stopped = false;
     let stateUnlistens: UnlistenFn[] = [];
+    let tickHandle: ReturnType<typeof setInterval> | null = null;
 
     function emitState(paused: boolean) {
       const now = Date.now();
@@ -2257,7 +2268,6 @@ async function startRecordingInner(
         elapsedMs,
       }).catch(() => {});
     }
-    const tickHandle = setInterval(() => emitState(pausedAt != null), 500);
 
     const toolbarUnlistens = await Promise.all([
       listen("clips:recorder-pause", () => {
@@ -2290,6 +2300,7 @@ async function startRecordingInner(
     await audioCue.playBeforeCapture();
     localExport.start(2_000);
     startedAt = Date.now();
+    tickHandle = setInterval(() => emitState(pausedAt != null), 500);
     emit("clips:toolbar-enabled", true).catch(() => {});
     emitState(false);
 
@@ -2341,7 +2352,7 @@ async function startRecordingInner(
           };
         }
         stopped = true;
-        clearInterval(tickHandle);
+        if (tickHandle) clearInterval(tickHandle);
         stateUnlistens.forEach((unlisten) => unlisten());
         stateUnlistens = [];
         const durationMs = Math.max(
@@ -2368,7 +2379,7 @@ async function startRecordingInner(
       async cancel() {
         if (stopped) return;
         stopped = true;
-        clearInterval(tickHandle);
+        if (tickHandle) clearInterval(tickHandle);
         stateUnlistens.forEach((unlisten) => unlisten());
         stateUnlistens = [];
         await localExport.cancel();
@@ -2527,11 +2538,15 @@ async function startRecordingInner(
     inflight.add(p);
   };
 
-  let startedAt = Date.now();
+  // Stamped at the real capture start below — kept 0 until then so the tick
+  // never reports elapsed against a stale baseline (which showed the clock
+  // counting up and then resetting to 0 when recorder.start finally fired).
+  let startedAt = 0;
   let pausedAt: number | null = null;
   let accumulatedPauseMs = 0;
   let stopped = false;
   let stateUnlistens: UnlistenFn[] = [];
+  let tickHandle: ReturnType<typeof setInterval> | null = null;
 
   function emitState(paused: boolean) {
     const now = Date.now();
@@ -2551,8 +2566,6 @@ async function startRecordingInner(
       console.error("[clips-recorder] openExternal failed:", err);
     }
   }
-
-  const tickHandle = setInterval(() => emitState(pausedAt != null), 500);
 
   // 5. Wire toolbar events.
   const toolbarUnlistens = await Promise.all([
@@ -2594,6 +2607,25 @@ async function startRecordingInner(
   ]);
   stateUnlistens = toolbarUnlistens;
 
+  await showRegionGuidesForRecording(wantsScreen);
+  await audioCue.playBeforeCapture();
+  recorder.start(LIVE_UPLOAD_CHUNK_MS);
+  startedAt = Date.now();
+  tickHandle = setInterval(() => emitState(pausedAt != null), 500);
+  // The toolbar is already open (the popover's bubble-session effect
+  // spawns it alongside the bubble in its pre-record, disabled state).
+  // Now that MediaRecorder is actually ticking, flip the toolbar's
+  // Stop / Pause buttons to enabled so the user can drive the recorder.
+  emit("clips:toolbar-enabled", true).catch(() => {});
+  // Seed the initial recorder-state so the time / paused styling match
+  // MediaRecorder's real state (before the first 500ms tick).
+  emitState(false);
+
+  // Live transcription capture starts AFTER the recorder is live. Its mic +
+  // ScreenCaptureKit spin-up takes ~1s; awaiting it before recorder.start was
+  // delaying capture, so the first ~1s the user expected to record was lost
+  // (and the recording felt cut at the end). It's a separate capture from the
+  // recorded audio tracks, so starting it slightly late is safe.
   transcriptionCapture = wantsAudio
     ? await startTranscriptionCapture(
         {
@@ -2608,18 +2640,6 @@ async function startRecordingInner(
       "macOS Speech recognition could not start for this recording. Check Speech Recognition and Microphone permissions, then retry transcription.",
     );
   }
-  await showRegionGuidesForRecording(wantsScreen);
-  await audioCue.playBeforeCapture();
-  recorder.start(LIVE_UPLOAD_CHUNK_MS);
-  startedAt = Date.now();
-  // The toolbar is already open (the popover's bubble-session effect
-  // spawns it alongside the bubble in its pre-record, disabled state).
-  // Now that MediaRecorder is actually ticking, flip the toolbar's
-  // Stop / Pause buttons to enabled so the user can drive the recorder.
-  emit("clips:toolbar-enabled", true).catch(() => {});
-  // Seed the initial recorder-state so the time / paused styling match
-  // MediaRecorder's real state (before the first 500ms tick).
-  emitState(false);
 
   // 6. Bubble + toolbar visibility are owned by the popover's session
   // effect (see app.tsx + bubble-pump.ts) — not the recorder. Both open
@@ -2631,9 +2651,14 @@ async function startRecordingInner(
     async stop() {
       if (stopped) return { recordingId: id, viewUrl: `/r/${id}` };
       stopped = true;
+      // Stamped right after the recorder fully stops below (see stoppedAt).
+      // Duration must measure recorded content — through the final flushed
+      // chunk — but NOT the transcript-finalize + thumbnail + upload awaits that
+      // follow, which add ~seconds and would overstate the saved duration.
+      let stoppedAt = 0;
       console.log("[clips-recorder] stop requested");
       showFinalizingFeedback();
-      clearInterval(tickHandle);
+      if (tickHandle) clearInterval(tickHandle);
       stateUnlistens.forEach((u) => u());
       stateUnlistens = [];
 
@@ -2665,6 +2690,10 @@ async function startRecordingInner(
           // ignore
         }
       });
+      // Recorder has fully stopped and flushed its trailing chunk — this is the
+      // true end of recorded content. Everything after (transcript, thumbnail,
+      // upload) is post-processing and must not count toward duration.
+      stoppedAt = Date.now();
 
       const thumbnailUploadPromise = captureAndUploadRecordingThumbnail({
         serverUrl: params.serverUrl,
@@ -2701,7 +2730,7 @@ async function startRecordingInner(
       const displaySettings = displayStream?.getVideoTracks()[0]?.getSettings();
       const durationMs = Math.max(
         0,
-        Math.round(Date.now() - startedAt - accumulatedPauseMs),
+        Math.round(stoppedAt - startedAt - accumulatedPauseMs),
       );
       const width =
         typeof videoSettings?.width === "number"
@@ -2866,7 +2895,7 @@ async function startRecordingInner(
     async cancel() {
       if (stopped) return;
       stopped = true;
-      clearInterval(tickHandle);
+      if (tickHandle) clearInterval(tickHandle);
       stateUnlistens.forEach((u) => u());
       stateUnlistens = [];
       transcriptionCapture?.cancel().catch(() => {});

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -1818,7 +1818,13 @@ async function startNativeFullscreenRecording(
           wantsSystemAudio,
         )
       : null;
-    if (wantsAudio && !transcriptionCapture) {
+    // Stop/Cancel can fire during the await above — at that point stop()/cancel()
+    // ran while transcriptionCapture was still null, so it never tore this down.
+    // Cancel the freshly-started session here so it doesn't keep running.
+    if (stopped && transcriptionCapture) {
+      void transcriptionCapture.cancel().catch(() => {});
+      transcriptionCapture = null;
+    } else if (wantsAudio && !transcriptionCapture) {
       void saveTranscriptFailure(
         "macOS Speech recognition could not start for this recording. Check Speech Recognition and Microphone permissions, then retry transcription.",
       );
@@ -2635,7 +2641,13 @@ async function startRecordingInner(
         wantsSystemAudio,
       )
     : null;
-  if (wantsAudio && !transcriptionCapture) {
+  // Stop/Cancel can fire during the await above — at that point stop()/cancel()
+  // ran while transcriptionCapture was still null, so it never tore this down.
+  // Cancel the freshly-started session here so it doesn't keep running.
+  if (stopped && transcriptionCapture) {
+    void transcriptionCapture.cancel().catch(() => {});
+    transcriptionCapture = null;
+  } else if (wantsAudio && !transcriptionCapture) {
     void saveTranscriptFailure(
       "macOS Speech recognition could not start for this recording. Check Speech Recognition and Microphone permissions, then retry transcription.",
     );


### PR DESCRIPTION
Fixes several issues when recording in the Clips desktop app.

## What's fixed

- **Faster start.** Recording now begins the moment the countdown ends. Before, it waited about a second for speech-to-text and the mic to warm up.

- **Speech-to-text warms up early.** The transcription model now loads in the background when the app starts, so the first recording isn't slowed down by it.

- **Toolbar timer starts on time.** The timer pill now appears and starts counting right when recording starts, instead of a moment later.

- **Timer no longer jumps back to 0.** For window and screen recordings, the timer used to count up and then reset. It now counts smoothly from the start.

- **Correct video length.** A clip you record for 5 seconds is now saved as 5 seconds. Before, the saved length was too long, and the end of the video could get cut off.

- **Camera bubble stays put.** Switching between window and full-screen capture no longer makes the camera bubble flicker or disappear.

- **Sharper camera bubble.** The camera bubble now captures at a higher resolution.
