### PR TITLE
Harden core tool validation and error handling

### DIFF
--- a/.changeset/core-tool-hardening.md
+++ b/.changeset/core-tool-hardening.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Harden core tool argument parsing, JSON Schema handling, and tool error surfacing.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -210,6 +210,7 @@
     "@tiptap/starter-kit": "^3.26.0",
     "@tiptap/y-tiptap": "^3.0.4",
     "@uiw/react-codemirror": "^4.25.10",
+    "ajv": "^8.20.0",
     "better-auth": "1.6.16",
     "better-sqlite3": "^12.8.0",
     "clsx": "^2.1.1",

--- a/packages/core/src/agent/engine/translate-ai-sdk.spec.ts
+++ b/packages/core/src/agent/engine/translate-ai-sdk.spec.ts
@@ -51,6 +51,34 @@ describe("engineToolsToAISDK", () => {
     expect(result.greet.inputSchema).toHaveProperty("_aiSdkWrapped", true);
     expect(result.greet.inputSchema.properties).toHaveProperty("name");
   });
+
+  it("preserves full JSON Schema constraints when translating tools", () => {
+    const tools: EngineTool[] = [
+      {
+        name: "write",
+        description: "Write something",
+        inputSchema: {
+          type: "object",
+          properties: {
+            sql: { type: "string", minLength: 1 },
+            statements: { type: "string", pattern: "^\\[" },
+          },
+          additionalProperties: false,
+          oneOf: [{ required: ["sql"] }, { required: ["statements"] }],
+        },
+      },
+    ];
+
+    const result = engineToolsToAISDK(tools);
+
+    expect(result.write.inputSchema).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+      oneOf: [{ required: ["sql"] }, { required: ["statements"] }],
+    });
+    expect(result.write.inputSchema.properties.sql.minLength).toBe(1);
+    expect(result.write.inputSchema.properties.statements.pattern).toBe("^\\[");
+  });
 });
 
 describe("engineMessagesToAISDK", () => {

--- a/packages/core/src/agent/engine/translate-ai-sdk.ts
+++ b/packages/core/src/agent/engine/translate-ai-sdk.ts
@@ -34,6 +34,7 @@ export function engineToolsToAISDK(
   const result: Record<string, any> = {};
   for (const tool of tools) {
     const rawSchema: Record<string, unknown> = {
+      ...tool.inputSchema,
       type: "object",
       properties: tool.inputSchema.properties ?? {},
       required: tool.inputSchema.required ?? [],

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1086,6 +1086,406 @@ describe("runAgentLoop", () => {
     expect(events).toContainEqual({ type: "text", text: "reported the gap" });
   });
 
+  it("redacts sensitive fields in normal action exception tool results", async () => {
+    let streamCalls = 0;
+    const seenMessages: any[] = [];
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(opts): AsyncIterable<EngineEvent> {
+        seenMessages.push(opts.messages);
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "tool-redact",
+                name: "write-secret",
+                input: { id: "row-1" },
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text", text: "done" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "write-secret": {
+          ...actionEntry({ readOnly: true }),
+          run: async () => {
+            throw new Error("DB failed: token=SENSITIVE_VALUE");
+          },
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    const toolDone = events.find(
+      (event) => event.type === "tool_done" && event.tool === "write-secret",
+    );
+    expect(toolDone?.result).toContain("DB failed");
+    expect(toolDone?.result).toContain("token=[REDACTED]");
+    expect(toolDone?.result).not.toContain("SENSITIVE_VALUE");
+    expect(JSON.stringify(seenMessages.at(-1))).not.toContain(
+      "SENSITIVE_VALUE",
+    );
+  });
+
+  it("redacts AgentActionStopError message and tool result", async () => {
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "assistant-content",
+          parts: [
+            {
+              type: "tool-call" as const,
+              id: "tool-stop-redact",
+              name: "stop-action",
+              input: {},
+            },
+          ],
+        };
+        yield { type: "stop", reason: "tool_use" };
+      },
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "stop-action": {
+          ...actionEntry({ readOnly: true }),
+          run: async () => {
+            throw new AgentActionStopError("Stop: password=SENSITIVE_VALUE", {
+              toolResult: "Tool failed: token=SENSITIVE_VALUE",
+            });
+          },
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(JSON.stringify(events)).not.toContain("SENSITIVE_VALUE");
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        result: expect.stringContaining("token=[REDACTED]"),
+      }),
+    );
+    expect(events).toContainEqual({
+      type: "text",
+      text: "Stop: password=[REDACTED]",
+    });
+  });
+
+  it("validates raw JSON Schema parameters before running an action", async () => {
+    let streamCalls = 0;
+    const run = vi.fn(async () => "should not run");
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "tool-schema",
+                name: "write-sql",
+                input: { sql: "UPDATE notes SET title = ?", statements: "[]" },
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text", text: "done" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "write-sql": {
+          tool: {
+            description: "Write SQL",
+            parameters: {
+              type: "object",
+              properties: {
+                sql: { type: "string" },
+                statements: { type: "string" },
+              },
+              oneOf: [{ required: ["sql"] }, { required: ["statements"] }],
+            },
+          },
+          run,
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(run).not.toHaveBeenCalled();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "write-sql",
+        result: expect.stringContaining(
+          "must match exactly one schema in oneOf",
+        ),
+      }),
+    );
+  });
+
+  it("rejects null raw JSON Schema parameters instead of validating as an empty object", async () => {
+    const run = vi.fn(async () => "should not run");
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield {
+          type: "assistant-content",
+          parts: [
+            {
+              type: "tool-call" as const,
+              id: "tool-schema-null",
+              name: "no-args",
+              input: null,
+            },
+          ],
+        };
+        yield { type: "stop", reason: "tool_use" };
+      },
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "no-args": {
+          tool: {
+            description: "No args",
+            parameters: { type: "object", properties: {} },
+          },
+          run,
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(run).not.toHaveBeenCalled();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "no-args",
+        result: expect.stringContaining("must be object"),
+      }),
+    );
+  });
+
+  it("stops after repeated identical tool errors", async () => {
+    let streamCalls = 0;
+    const run = vi.fn(async () => {
+      throw new Error("DB failed: token=SENSITIVE_VALUE");
+    });
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        yield {
+          type: "assistant-content",
+          parts: [
+            {
+              type: "tool-call" as const,
+              id: `tool-repeat-${streamCalls}`,
+              name: "flaky-write",
+              input: { id: "row-1" },
+            },
+          ],
+        };
+        yield { type: "stop", reason: "tool_use" };
+      },
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "flaky-write": {
+          ...actionEntry({ readOnly: true }),
+          run,
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(JSON.stringify(events)).not.toContain("SENSITIVE_VALUE");
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "flaky-write",
+        result: expect.stringContaining("Stopped after 3 identical errors"),
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringContaining("failed 3 times"),
+      }),
+    );
+  });
+
+  it("stops after repeated identical unknown-tool errors", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        yield {
+          type: "assistant-content",
+          parts: [
+            {
+              type: "tool-call" as const,
+              id: `tool-unknown-${streamCalls}`,
+              name: "missing-tool",
+              input: { id: "row-1" },
+            },
+          ],
+        };
+        yield { type: "stop", reason: "tool_use" };
+      },
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {},
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(streamCalls).toBe(3);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "missing-tool",
+        result: expect.stringContaining("Stopped after 3 identical errors"),
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringContaining("failed 3 times"),
+      }),
+    );
+  });
+
   it("detects repeated read-only source sweeps but ignores ordinary helpers", () => {
     const priorToolCalls = Array.from({ length: 12 }, (_, i) => ({
       name: "gong-calls",

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -4,6 +4,7 @@ import {
   setResponseStatus,
   getMethod,
 } from "h3";
+import Ajv, { type ValidateFunction } from "ajv";
 import {
   isDeployCredentialFallbackAllowed,
   readDeployCredentialEnv,
@@ -11,6 +12,7 @@ import {
 import type { EventHandler as H3EventHandler } from "h3";
 import type {
   ActionTool,
+  AgentNativeJsonSchema,
   AgentChatAttachment,
   AgentChatRequest,
   AgentChatEvent,
@@ -47,6 +49,11 @@ import { PROVIDER_TO_ENV } from "./engine/provider-env-vars.js";
 import { readAppState } from "../application-state/script-helpers.js";
 import { isDemoModeEnabled } from "../demo/config.js";
 import { redactDemoData, redactDemoString } from "../demo/redact.js";
+import {
+  redactSensitiveFields,
+  sanitizeToolErrorText,
+  sanitizeToolErrorValue,
+} from "./tool-error-redaction.js";
 import {
   startRun,
   subscribeToRun,
@@ -309,6 +316,8 @@ export interface ActionEntry {
     args: any,
     context?: import("../action.js").ActionRunContext,
   ) => Promise<any> | any;
+  /** Standard Schema input validator when declared through defineAction. */
+  schema?: unknown;
   /** HTTP exposure config. `false` = agent-only. Omitted = auto-inferred from name. */
   http?: import("../action.js").ActionHttpConfig | false;
   /** Whether HTTP/frontend action calls must have an authenticated owner.
@@ -1764,6 +1773,7 @@ function isReusableReadOnlyToolResult(part: EngineToolResultPart): boolean {
 const INTERRUPTED_TOOL_RESULT_MARKER =
   "Interrupted before this tool returned a result.";
 const MAX_WRITE_TOOL_INTERRUPTIONS = 2;
+const MAX_IDENTICAL_TOOL_ERRORS = 3;
 
 function seedWriteToolInterruptionsFromHistory(
   messages: EngineMessage[],
@@ -1847,7 +1857,7 @@ function normalizeToolInputSchema(
 
 function stringifyToolInput(input: unknown): string {
   try {
-    const str = JSON.stringify(input);
+    const str = JSON.stringify(redactSensitiveFields(input));
     if (!str) return String(input);
     return str.length > 500 ? `${str.slice(0, 500)}…` : str;
   } catch {
@@ -1871,6 +1881,10 @@ function stableStringify(value: unknown): string {
 
 function toolCallCacheKey(toolName: string, input: unknown): string {
   return `${toolName}:${stableStringify(normalizeToolCallInputForHistory(input))}`;
+}
+
+function normalizeToolErrorForBreaker(error: string): string {
+  return error.replace(/\s+/g, " ").trim();
 }
 
 function rateLimitRecoveryHint(message: string): string {
@@ -2094,10 +2108,58 @@ function toolInputSchemaErrorResult(
   error: string,
 ): string {
   return (
-    `Invalid action parameters for ${toolName}: ${error}. ` +
+    `Invalid action parameters for ${toolName}: ${sanitizeToolErrorText(error)}. ` +
     `Received: ${stringifyToolInput(input)}. ` +
     "The tool was not executed; retry with arguments that match the tool schema."
   );
+}
+
+type RawJsonSchema = AgentNativeJsonSchema;
+
+const rawToolInputAjv = new Ajv({
+  strict: false,
+  allErrors: true,
+  coerceTypes: false,
+  useDefaults: false,
+  removeAdditional: false,
+});
+
+const rawToolInputValidatorCache = new WeakMap<object, ValidateFunction>();
+
+function getRawToolInputValidator(schema: RawJsonSchema): ValidateFunction {
+  const cached = rawToolInputValidatorCache.get(schema);
+  if (cached) return cached;
+  const validator = rawToolInputAjv.compile(schema);
+  rawToolInputValidatorCache.set(schema, validator);
+  return validator;
+}
+
+function shouldValidateRawToolParameters(entry: ActionEntry): boolean {
+  const maybeSchema = entry.schema as
+    | { "~standard"?: unknown }
+    | null
+    | undefined;
+  return !maybeSchema?.["~standard"] && Boolean(entry.tool.parameters);
+}
+
+function validateRawToolInput(
+  entry: ActionEntry,
+  input: unknown,
+): string | null {
+  if (!shouldValidateRawToolParameters(entry)) return null;
+  const parameters = entry.tool.parameters;
+  if (!parameters) return null;
+  let validator: ValidateFunction;
+  try {
+    validator = getRawToolInputValidator(parameters);
+  } catch (err) {
+    return `tool schema is invalid: ${sanitizeToolErrorValue(err)}`;
+  }
+  if (validator(input === undefined ? {} : input)) return null;
+  return rawToolInputAjv.errorsText(validator.errors, {
+    separator: "; ",
+    dataVar: "input",
+  });
 }
 
 /**
@@ -2208,6 +2270,7 @@ export async function runAgentLoop(opts: {
     messages,
     actions,
   );
+  const repeatedToolErrors = new Map<string, number>();
 
   // Tool-call journal hard-block (resume safety). Snapshot the per-turn journal
   // ONCE here, before any tool runs in this chunk, so it reflects only PRIOR
@@ -2670,6 +2733,26 @@ export async function runAgentLoop(opts: {
           isError,
         });
       };
+      const finalizeToolErrorResult = (rawResult: string): string => {
+        const sanitizedResult = sanitizeToolErrorText(rawResult);
+        const errorKey = `${toolCallCacheKey(
+          toolCall.name,
+          toolCall.input,
+        )}:${normalizeToolErrorForBreaker(sanitizedResult)}`;
+        const count = (repeatedToolErrors.get(errorKey) ?? 0) + 1;
+        repeatedToolErrors.set(errorKey, count);
+        if (count < MAX_IDENTICAL_TOOL_ERRORS) return sanitizedResult;
+        const result =
+          `Stopped after ${count} identical errors from ${toolCall.name} with the same arguments. ` +
+          `Last error: ${sanitizedResult}`;
+        requestedActionStop ??= {
+          message:
+            `Stopped because ${toolCall.name} failed ${count} times with the same arguments and error. ` +
+            "Fix the underlying issue or change the arguments before retrying.",
+          errorCode: "repeated_identical_tool_error",
+        };
+        return result;
+      };
       if (sourceSweepGuard) {
         sourceSweepDelegationGuardActive = true;
         const result = sourceSweepGuard.message;
@@ -2708,7 +2791,9 @@ export async function runAgentLoop(opts: {
       }
 
       if (!actionEntry) {
-        const result = `Error: Unknown tool "${toolCall.name}"`;
+        const result = finalizeToolErrorResult(
+          `Error: Unknown tool "${toolCall.name}"`,
+        );
         send({
           type: "tool_start",
           tool: toolCall.name,
@@ -2944,10 +3029,36 @@ export async function runAgentLoop(opts: {
 
       const toolCallSchemaError = toolCallErrors.get(toolCall.id);
       if (toolCallSchemaError) {
-        const result = toolInputSchemaErrorResult(
-          toolCall.name,
-          toolCallSchemaError.input,
-          toolCallSchemaError.error,
+        const result = finalizeToolErrorResult(
+          toolInputSchemaErrorResult(
+            toolCall.name,
+            toolCallSchemaError.input,
+            toolCallSchemaError.error,
+          ),
+        );
+        send({ type: "tool_done", tool: toolCall.name, result });
+        recordToolResult(result, true);
+        return {
+          type: "tool-result" as const,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          toolInput: wireToolInput,
+          content: result,
+          isError: true,
+        };
+      }
+
+      const rawToolInputError = validateRawToolInput(
+        actionEntry,
+        toolCall.input,
+      );
+      if (rawToolInputError) {
+        const result = finalizeToolErrorResult(
+          toolInputSchemaErrorResult(
+            toolCall.name,
+            toolCall.input,
+            rawToolInputError,
+          ),
         );
         send({ type: "tool_done", tool: toolCall.name, result });
         recordToolResult(result, true);
@@ -3107,17 +3218,21 @@ export async function runAgentLoop(opts: {
       } catch (err: any) {
         if (isAgentActionStopError(err)) {
           const message =
-            err.message || `Stopped after ${toolCall.name} failed.`;
-          result = err.toolResult || message;
+            sanitizeToolErrorValue(err.message) ||
+            `Stopped after ${toolCall.name} failed.`;
+          result = sanitizeToolErrorValue(err.toolResult || message);
           requestedActionStop ??= {
             message,
             ...(err.errorCode ? { errorCode: err.errorCode } : {}),
           };
         } else {
-          const message = err?.message ?? String(err);
+          const message = sanitizeToolErrorValue(err);
           result = `Error running ${toolCall.name}: ${message}${rateLimitRecoveryHint(message)}`;
         }
         isError = true;
+      }
+      if (isError) {
+        result = finalizeToolErrorResult(result);
       }
 
       // Auto-refresh the UI after a successful mutating tool call. Any action

--- a/packages/core/src/agent/tool-error-redaction.spec.ts
+++ b/packages/core/src/agent/tool-error-redaction.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  sanitizeToolErrorText,
+  sanitizeToolErrorValue,
+} from "./tool-error-redaction.js";
+
+const fakeKey = (prefix: string) => `${prefix}${"x".repeat(24)}`;
+
+describe("tool error redaction", () => {
+  it("redacts bare sk-style secret placeholders in text", () => {
+    const bare = fakeKey("sk-");
+    const project = fakeKey("sk-proj-");
+    const service = fakeKey("sk-svcacct-");
+    const trailingHyphen = `${fakeKey("sk-")}-`;
+
+    const redacted = sanitizeToolErrorText(
+      `failed with ${bare}, ${project}, ${service}, and ${trailingHyphen}`,
+    );
+
+    expect(redacted).toBe(
+      "failed with [REDACTED], [REDACTED], [REDACTED], and [REDACTED]",
+    );
+    expect(redacted).not.toContain(bare);
+    expect(redacted).not.toContain(project);
+    expect(redacted).not.toContain(service);
+    expect(redacted).not.toContain(trailingHyphen);
+  });
+
+  it("redacts bare sk-style values inside structured error values", () => {
+    const project = fakeKey("sk-proj-");
+
+    const redacted = sanitizeToolErrorValue({
+      message: `provider rejected ${project}`,
+    });
+
+    expect(redacted).toContain("[REDACTED]");
+    expect(redacted).not.toContain(project);
+  });
+
+  it("preserves short placeholders and non-sensitive field names", () => {
+    const redacted = sanitizeToolErrorValue({
+      message: "use sk-example as a placeholder",
+      tokenizer: "keep",
+      passwordHash: "keep",
+      secretsCount: 2,
+      mySecret: "keep",
+    });
+
+    expect(redacted).toContain("sk-example");
+    expect(redacted).toContain('"tokenizer": "keep"');
+    expect(redacted).toContain('"passwordHash": "keep"');
+    expect(redacted).toContain('"secretsCount": 2');
+    expect(redacted).toContain('"mySecret": "keep"');
+  });
+});

--- a/packages/core/src/agent/tool-error-redaction.ts
+++ b/packages/core/src/agent/tool-error-redaction.ts
@@ -1,0 +1,52 @@
+const REDACTED = "[REDACTED]";
+
+const SENSITIVE_FIELD_PATTERN =
+  /^(authorization|cookie|api[_-]?key|password|secret|token|access[_-]?token|refresh[_-]?token|bearer)$/i;
+
+const OPENAI_LIKE_SECRET_PATTERN =
+  /(^|[^A-Za-z0-9_-])(sk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{24,})(?=$|[^A-Za-z0-9_-])/g;
+
+export function redactSensitiveFields(value: unknown): unknown {
+  return redactWalk(value, new WeakSet<object>());
+}
+
+function redactWalk(value: unknown, seen: WeakSet<object>): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value as object)) return "[Circular]";
+  seen.add(value as object);
+  if (Array.isArray(value)) return value.map((v) => redactWalk(v, seen));
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = SENSITIVE_FIELD_PATTERN.test(key)
+      ? REDACTED
+      : redactWalk(entry, seen);
+  }
+  return out;
+}
+
+export function sanitizeToolErrorText(value: string): string {
+  let out = value;
+  out = out.replace(/\bBearer\s+[^,\s;)}\]]+/gi, `Bearer ${REDACTED}`);
+  out = out.replace(OPENAI_LIKE_SECRET_PATTERN, `$1${REDACTED}`);
+  out = out.replace(
+    /([?&](?:authorization|cookie|api[_-]?key|password|secret|token|access[_-]?token|refresh[_-]?token|bearer)=)[^&#\s]+/gi,
+    `$1${REDACTED}`,
+  );
+  out = out.replace(
+    /((?:^|[^A-Za-z0-9_-])(?:"|')?(?:authorization|cookie|api[_-]?key|password|secret|token|access[_-]?token|refresh[_-]?token|bearer)(?:"|')?\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^,\s;)}\]]+)/gi,
+    (_match, prefix: string) => `${prefix}${REDACTED}`,
+  );
+  return out;
+}
+
+export function sanitizeToolErrorValue(value: unknown): string {
+  if (value instanceof Error) return sanitizeToolErrorText(value.message);
+  if (typeof value === "string") return sanitizeToolErrorText(value);
+  try {
+    return sanitizeToolErrorText(
+      JSON.stringify(redactSensitiveFields(value), null, 2),
+    );
+  } catch {
+    return sanitizeToolErrorText(String(value));
+  }
+}

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -2,18 +2,33 @@ import type { ReasoningEffort } from "../shared/reasoning-effort.js";
 import type { AgentMcpAppPayload } from "../mcp-client/app-result.js";
 import type { ActionChatUIConfig } from "../action-ui.js";
 
+export interface AgentNativeJsonSchema {
+  type?: string | string[];
+  description?: string;
+  enum?: unknown[];
+  const?: unknown;
+  properties?: Record<string, AgentNativeJsonSchema>;
+  required?: string[];
+  additionalProperties?: boolean | AgentNativeJsonSchema;
+  items?: AgentNativeJsonSchema;
+  oneOf?: AgentNativeJsonSchema[];
+  anyOf?: AgentNativeJsonSchema[];
+  allOf?: AgentNativeJsonSchema[];
+  not?: AgentNativeJsonSchema;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  minimum?: number;
+  maximum?: number;
+  minItems?: number;
+  maxItems?: number;
+}
+
 export interface ActionTool {
   description: string;
-  parameters?: {
+  parameters?: AgentNativeJsonSchema & {
     type: "object";
-    properties: Record<
-      string,
-      {
-        type: string;
-        description?: string;
-        enum?: string[];
-      }
-    >;
+    properties: Record<string, AgentNativeJsonSchema>;
     required?: string[];
   };
 }

--- a/packages/core/src/coding-tools/index.spec.ts
+++ b/packages/core/src/coding-tools/index.spec.ts
@@ -85,6 +85,15 @@ describe("shared coding tools", () => {
     expect(registry["search-files"]).toBeUndefined();
   });
 
+  it("uses an exclusive db-exec write-mode schema in dev mode", async () => {
+    const registry = await createDevScriptRegistry();
+
+    expect(registry["db-exec"]?.tool.parameters).toMatchObject({
+      additionalProperties: false,
+      oneOf: [{ required: ["sql"] }, { required: ["statements"] }],
+    });
+  });
+
   it("can disable raw database tools without removing coding tools", async () => {
     const registry = await createDevScriptRegistry({ databaseTools: false });
 

--- a/packages/core/src/scripts/db/tool-schemas.spec.ts
+++ b/packages/core/src/scripts/db/tool-schemas.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { dbExecToolParameters } from "./tool-schemas.js";
+
+describe("dbExecToolParameters", () => {
+  it("requires exactly one write mode", () => {
+    expect(dbExecToolParameters()).toMatchObject({
+      additionalProperties: false,
+      oneOf: [{ required: ["sql"] }, { required: ["statements"] }],
+    });
+  });
+});

--- a/packages/core/src/scripts/db/tool-schemas.ts
+++ b/packages/core/src/scripts/db/tool-schemas.ts
@@ -1,0 +1,31 @@
+import type { ActionTool } from "../../agent/types.js";
+
+export function dbExecToolParameters(): NonNullable<ActionTool["parameters"]> {
+  return {
+    type: "object",
+    properties: {
+      sql: {
+        type: "string",
+        description:
+          "Single INSERT / UPDATE / DELETE / REPLACE statement. Use parameterized placeholders (?) where possible.",
+      },
+      args: {
+        type: "string",
+        description:
+          'Optional JSON array of positional bind args for `sql`. Example: \'["published","form-123"]\'',
+      },
+      statements: {
+        type: "string",
+        description:
+          'Optional JSON array of write statements to execute in one transaction. Prefer this over multiple db-exec calls. Example: \'[{"sql":"INSERT INTO notes (id,title) VALUES (?,?)","args":["n1","One"]},{"sql":"UPDATE counters SET value = value + 1 WHERE key = ?","args":["notes"]}]\'',
+      },
+      format: {
+        type: "string",
+        description: 'Output format: "json" or "text" (default: text)',
+        enum: ["json", "text"],
+      },
+    },
+    additionalProperties: false,
+    oneOf: [{ required: ["sql"] }, { required: ["statements"] }],
+  };
+}

--- a/packages/core/src/scripts/dev/index.ts
+++ b/packages/core/src/scripts/dev/index.ts
@@ -9,6 +9,7 @@
 import type { ActionTool } from "../../agent/types.js";
 import type { ActionEntry } from "../../agent/production-agent.js";
 import { createCodingToolRegistry } from "../../coding-tools/index.js";
+import { dbExecToolParameters } from "../db/tool-schemas.js";
 import { tool as readFileTool, run as readFileRun } from "./read-file.js";
 import { tool as writeFileTool, run as writeFileRun } from "./write-file.js";
 import { tool as listFilesTool, run as listFilesRun } from "./list-files.js";
@@ -136,32 +137,7 @@ export async function createDevScriptRegistry(
           {
             description:
               "Execute app-database write SQL (INSERT, UPDATE, DELETE, REPLACE). For multiple related writes, pass `statements` so they run sequentially in one transaction instead of issuing several db-exec calls. Schema changes (CREATE/ALTER/DROP) are blocked. Never use this to backfill missing data for a read/analysis request or to create/modify users, members, roles, permissions, admin flags, or ownership; use a dedicated app action or reviewed code.",
-            parameters: {
-              type: "object",
-              properties: {
-                sql: {
-                  type: "string",
-                  description:
-                    "Single INSERT / UPDATE / DELETE / REPLACE statement. Use parameterized placeholders (?) where possible.",
-                },
-                args: {
-                  type: "string",
-                  description:
-                    'Optional JSON array of positional bind args for `sql`. Example: \'["published","form-123"]\'',
-                },
-                statements: {
-                  type: "string",
-                  description:
-                    'Optional JSON array of write statements to execute in one transaction. Prefer this over multiple db-exec calls. Example: \'[{"sql":"INSERT INTO notes (id,title) VALUES (?,?)","args":["n1","One"]},{"sql":"UPDATE counters SET value = value + 1 WHERE key = ?","args":["notes"]}]\'',
-                },
-                format: {
-                  type: "string",
-                  description:
-                    'Output format: "json" or "text" (default: text)',
-                  enum: ["json", "text"],
-                },
-              },
-            },
+            parameters: dbExecToolParameters(),
           },
           dbExec.default,
         ),

--- a/packages/core/src/scripts/parse-args.ts
+++ b/packages/core/src/scripts/parse-args.ts
@@ -20,7 +20,7 @@ export function parseArgs(args: string[]): Record<string, string> {
     } else {
       const key = arg.slice(2);
       const next = args[i + 1];
-      if (next && !next.startsWith("--")) {
+      if (next !== undefined && !next.startsWith("--")) {
         result[key] = next;
         i++;
       } else {

--- a/packages/core/src/scripts/runner.spec.ts
+++ b/packages/core/src/scripts/runner.spec.ts
@@ -148,4 +148,27 @@ describe("runScript package actions", () => {
       limit: "8",
     });
   }, 20_000);
+
+  it("preserves empty package action arguments", () => {
+    const result = spawnSync(
+      tsxCommand,
+      [...tsxLeadingArgs, "actions/run.ts", "package-action", "--label", ""],
+      {
+        cwd: tmpDir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          AGENT_USER_EMAIL: "owner@example.test",
+        },
+        timeout: spawnTimeoutMs,
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(tmpDir, "package-output.json"), "utf8"),
+      ),
+    ).toEqual({ label: "" });
+  }, 20_000);
 });

--- a/packages/core/src/scripts/runner.ts
+++ b/packages/core/src/scripts/runner.ts
@@ -173,7 +173,7 @@ function parseActionArgs(
     } else {
       const key = arg.slice(2);
       const next = args[i + 1];
-      if (next && !next.startsWith("--")) {
+      if (next !== undefined && !next.startsWith("--")) {
         setParsedArg(parsed, key, coerceCliValue(next, coerceBooleans));
         i++;
       } else {

--- a/packages/core/src/scripts/utils.spec.ts
+++ b/packages/core/src/scripts/utils.spec.ts
@@ -11,6 +11,10 @@ describe("parseArgs", () => {
     expect(parseArgs(["--name", "hello"])).toEqual({ name: "hello" });
   });
 
+  it("preserves empty --key value format", () => {
+    expect(parseArgs(["--name", ""])).toEqual({ name: "" });
+  });
+
   it("parses --key=value format", () => {
     expect(parseArgs(["--name=hello"])).toEqual({ name: "hello" });
   });

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -7,6 +7,7 @@ import {
 } from "./request-context.js";
 import { getSetting, putSetting } from "../settings/store.js";
 import { createDbAdminAgentTools } from "../db-admin/agent-tools.js";
+import { dbExecToolParameters } from "../scripts/db/tool-schemas.js";
 import {
   getH3App,
   markDefaultPluginProvided,
@@ -1060,31 +1061,7 @@ async function createDbScriptEntries(): Promise<Record<string, ActionEntry>> {
         {
           description:
             "Write to the app's own SQL database ONLY. Runs INSERT / UPDATE / DELETE / REPLACE against the app's internal tables. For multiple related writes, pass `statements` so they run sequentially in one transaction instead of issuing several db-exec calls. Writes are auto-scoped to the current user/org, and `owner_email` / `org_id` are auto-injected on INSERT. Schema changes (CREATE/ALTER/DROP) are blocked. Never use this to backfill missing data for a read/analysis request or to create/modify users, members, roles, permissions, admin flags, or ownership; use a dedicated app action or reviewed code. IMPORTANT: This tool CANNOT write to external data sources like BigQuery, HubSpot, etc. For external services, use the appropriate template action.",
-          parameters: {
-            type: "object",
-            properties: {
-              sql: {
-                type: "string",
-                description:
-                  "Single INSERT / UPDATE / DELETE / REPLACE statement. Use parameterized placeholders (?) where possible.",
-              },
-              args: {
-                type: "string",
-                description:
-                  'Optional JSON array of positional bind args for `sql`. Example: \'["published","form-123"]\'',
-              },
-              statements: {
-                type: "string",
-                description:
-                  'Optional JSON array of write statements to execute in one transaction. Prefer this over multiple db-exec calls. Example: \'[{"sql":"INSERT INTO notes (id,title) VALUES (?,?)","args":["n1","One"]},{"sql":"UPDATE counters SET value = value + 1 WHERE key = ?","args":["notes"]}]\'',
-              },
-              format: {
-                type: "string",
-                description: 'Output format: "json" or "text" (default: text)',
-                enum: ["json", "text"],
-              },
-            },
-          },
+          parameters: dbExecToolParameters(),
         },
         execMod.default,
       ),

--- a/packages/core/src/server/cli-capture.spec.ts
+++ b/packages/core/src/server/cli-capture.spec.ts
@@ -41,4 +41,15 @@ describe("cli-capture", () => {
     expect(exited).toContain("before exit");
     expect(sibling).toContain("sibling survived");
   });
+
+  it("redacts swallowed CLI exception messages", async () => {
+    const fakeSecret = `sk-${"x".repeat(24)}`;
+
+    const output = await captureCliOutput(async () => {
+      throw new Error(`failed with ${fakeSecret}`);
+    });
+
+    expect(output).toContain("Error: failed with [REDACTED]");
+    expect(output).not.toContain(fakeSecret);
+  });
 });

--- a/packages/core/src/server/cli-capture.ts
+++ b/packages/core/src/server/cli-capture.ts
@@ -15,6 +15,7 @@
  * idempotent and safe under any number of concurrent runs.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
+import { sanitizeToolErrorText } from "../agent/tool-error-redaction.js";
 
 interface CaptureStore {
   logs: string[];
@@ -120,7 +121,7 @@ export async function captureCliOutput(
       // process.exit() is treated as a clean termination of the CLI action.
     } else if (swallowErrors) {
       const msg = (err as Error)?.message ?? String(err);
-      store.logs.push(`Error: ${msg}`);
+      store.logs.push(sanitizeToolErrorText(`Error: ${msg}`));
     } else {
       throw err;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,9 @@ importers:
       ai-sdk-ollama:
         specifier: '>=3'
         version: 3.8.3(ai@6.0.168(zod@4.4.3))(zod@4.4.3)
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
       better-auth:
         specifier: 1.6.16
         version: 1.6.16(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.12)(vitest@4.1.8)
@@ -11243,8 +11246,8 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -20872,8 +20875,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.12(hono@4.12.10)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -25186,9 +25189,9 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.4.3
 
-  ajv-formats@3.0.1(ajv@8.18.0):
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   ajv-keywords@3.5.2(ajv@6.14.0):
     dependencies:
@@ -25201,7 +25204,7 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.18.0:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0


### PR DESCRIPTION
## Summary
- replace the custom raw JSON Schema tool-argument validator with AJV, while leaving Standard Schema/Zod action validation authoritative
- redact bare OpenAI-style `sk-*` tool-error secrets, including projected/service-account shapes and CLI-captured errors
- route repeated unknown-tool failures through the generic identical tool-error breaker
- add regressions for AJV validation, null raw inputs, unknown-tool breaker behavior, and redaction edge cases

## Validation
- `pnpm view ajv version` -> `8.20.0`
- `pnpm --dir /Users/thomascarney/Projects/agent-native/packages/core test` -> 439 files, 5247 tests passed
- `pnpm --dir /Users/thomascarney/Projects/agent-native/packages/core typecheck`
- `pnpm --dir /Users/thomascarney/Projects/agent-native/packages/core build`
- `git diff --check`

## Notes
- AJV is configured with `strict: false`, `allErrors: true`, and no coercion/default/removal options so tool inputs are not mutated.
- Raw schema validators are cached by schema object with `WeakMap`.