### PR TITLE
Fix chat navigation reliability and queued follow-ups

### DIFF
--- a/.agents/skills/client-side-routing/SKILL.md
+++ b/.agents/skills/client-side-routing/SKILL.md
@@ -66,6 +66,15 @@ export default function Settings() {
 
 If a page needs per-route data (e.g. sidebar highlighting the active document), derive it inside the layout from `useParams()` / `useLocation()` — don't pass it as a prop through every route file.
 
+## Chat-First Routes
+
+If `/` is a full-page chat such as `AgentChatHome`, keep the app shell mounted
+around it when possible so `AgentSidebar` URL sync and route warmup stay active.
+If the chat route intentionally lives outside the shell, add a tiny app-owned
+prewarm for the routes agents commonly open from that chat. In local dev,
+React Router can update the address bar before a cold Vite route chunk commits,
+which makes navigation look broken even when the URL is correct.
+
 ## Adding a New Route
 
 - **Pattern #1** (AppLayout in `root.tsx`): just render page content — nothing else.

--- a/.agents/skills/context-awareness/SKILL.md
+++ b/.agents/skills/context-awareness/SKILL.md
@@ -125,6 +125,15 @@ await writeAppState("navigate", { view: "inbox", threadId: "abc123" });
 **UI side** — use `useAgentRouteState`, shown above. It polls command keys,
 dedupes `_writeId`, deletes consumed commands, and applies app-local routing.
 
+When a destination has a real URL, let the `navigate` command carry that local
+`path` (plus semantic fields when useful) and have the UI prefer `path` before
+falling back to semantic routing. Keep app navigation single-channel: do not
+also write `__set_url__` for the same navigation. `__set_url__` belongs to the
+framework URL tools (`set-url-path`, `set-search-params`) and URL-only filter
+changes. If a command can arrive while a chat stream is rendering, prefer
+`navigate(path, { replace: true, flushSync: true })` over a view-transition
+wrapper so the URL and visible route commit together.
+
 ## Jitter Prevention
 
 When the agent writes to application-state via script helpers (`writeAppState`), the write is tagged with `requestSource: "agent"`. The UI uses the `ignoreSource` option on `useDbSync()` with a per-tab ID so it ignores its own writes while still picking up changes from agents, other tabs, and scripts.
@@ -171,7 +180,7 @@ The mail template demonstrates these patterns working together:
 - Keep shareable filters in URL query params so `<current-url>` and `set-search-params` work
 - Update `view-screen` when adding new features — it should return data for every view
 - Use `useAgentRouteState` or `useSemanticNavigationState` for UI-side navigation sync and command consumption
-- Use the one-shot `navigate` command pattern for semantic agent-initiated navigation
+- Use the one-shot `navigate` command pattern for app navigation; include a same-origin `path` when the target URL is known
 - Tag agent writes with `requestSource: "agent"` (the script helpers do this automatically)
 
 ## Don't
@@ -179,6 +188,7 @@ The mail template demonstrates these patterns working together:
 - Don't assume the user is on a specific page — always check navigation state
 - Don't hardcode navigation paths in scripts — read the current state and branch
 - Don't write to the `navigation` key from the agent — it belongs to the UI. Use `navigate` instead.
+- Don't write both `navigate` and `__set_url__` for one app navigation; competing consumers can make the browser URL change before React Router commits the page.
 - Don't ignore the `<current-screen>` block — it tells you where the user is
 - Don't duplicate whole URL query strings into `navigation` when `<current-url>` already exposes them
 - Don't store fetched data in navigation state — it holds IDs and semantic UI state only. The `view-screen` script fetches the actual data.

--- a/.changeset/fix-chat-queue-followups.md
+++ b/.changeset/fix-chat-queue-followups.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Fix active chat follow-up queueing so ordinary sends during a running turn stay queued, keep the thinking indicator attached to the active response, and stabilize built-in data widget renderers to avoid chart remount loops.
+Fix active chat follow-up queueing so ordinary sends during a running turn stay queued, keep the thinking indicator attached to the active response, retry any fresh user turn — queued follow-ups and normal sends fired shortly after the previous run finished — through transient 409 active-run conflicts instead of reconnecting to the prior run (which replayed its answer, dropped the new message, and corrupted thread history), while still letting genuine internal continuations resume the active run, and stabilize built-in data widget renderers to avoid chart remount loops.

--- a/.changeset/notifications-popover-iframe.md
+++ b/.changeset/notifications-popover-iframe.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Close the notifications popover correctly over extension iframes.

--- a/.changeset/quiet-domain-auto-join.md
+++ b/.changeset/quiet-domain-auto-join.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Auto-join existing signed-in users into organizations whose allowed domain matches their email, and activate the newly joined org immediately.

--- a/.changeset/warm-core-client-deps.md
+++ b/.changeset/warm-core-client-deps.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Pre-optimize core client dependencies during monorepo dev so chat-heavy apps avoid Vite optimized-dependency reloads during navigation.

--- a/packages/core/docs/content/context-awareness.md
+++ b/packages/core/docs/content/context-awareness.md
@@ -305,6 +305,15 @@ On the UI side you never poll or delete this key by hand. Both directions -- wri
 
 The `navigation` key belongs to the UI; the agent must never write to it directly. The agent writes `navigate`, the UI performs the move, and that move is what updates `navigation`.
 
+When the destination has a real URL, include a same-origin `path` on the
+`navigate` command and have the UI prefer that path before falling back to
+semantic fields. Keep app navigation single-channel: do not write both
+`navigate` and `__set_url__` for the same move. `__set_url__` is for the
+framework URL tools (`set-url-path`, `set-search-params`) and URL-only filter
+changes. For commands that can arrive while chat is streaming, commit the route
+with `navigate(path, { replace: true, flushSync: true })` instead of wrapping it
+in a view transition so the address bar and visible page stay together.
+
 ## The useNavigationState hook {#use-navigation-state}
 
 `useNavigationState` is **your app's hook, not a framework import.** Every template ships one at `app/hooks/use-navigation-state.ts` and calls it once from the app shell (`root.tsx`). It is the single place that wires navigation in both directions:
@@ -322,6 +331,7 @@ import { TAB_ID } from "@/lib/tab-id";
 interface NavigationState {
   view: "inbox" | "thread";
   threadId?: string;
+  path?: string;
 }
 
 export function useNavigationState() {
@@ -337,9 +347,11 @@ export function useNavigationState() {
 
     // agent → UI: turn a `navigate` command into a route to push.
     getCommandPath: (command) =>
-      command.view === "thread" && command.threadId
+      command.path ??
+      (command.view === "thread" && command.threadId
         ? `/thread/${command.threadId}`
-        : "/",
+        : "/"),
+    navigateOptions: { replace: true, flushSync: true },
   });
 }
 ```

--- a/packages/core/docs/content/creating-templates.md
+++ b/packages/core/docs/content/creating-templates.md
@@ -234,11 +234,16 @@ export function useNavigationState() {
       selectedId: searchParams.get("id"),
     }),
     getCommandPath: (command: any) => command.path ?? "/",
+    navigateOptions: { replace: true, flushSync: true },
   });
 }
 ```
 
 Keep shareable filters in URL query params. The framework exposes them to the agent as `<current-url>` and the built-in agent can change them with `set-search-params`; `navigation` should hold semantic IDs and aliases, not a second copy of the full query string.
+
+For app navigation, prefer one `navigate` command that includes a same-origin
+`path` when the URL is known. Do not also write `__set_url__` for the same move;
+that key is reserved for the framework URL tools and URL-only filter changes.
 
 ```ts
 // actions/navigate.ts
@@ -251,6 +256,7 @@ export default defineAction({
   schema: z.object({
     view: z.enum(["home", "project"]),
     projectId: z.string().optional(),
+    path: z.string().optional(),
   }),
   run: async (args) => {
     await writeAppState("navigate", args);

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1911,7 +1911,7 @@ function URLSync({ browserTabId }: { browserTabId?: string }) {
       // Replace rather than push so repeated agent URL updates don't
       // clutter the history stack and can't trigger extra remounts from
       // router navigation lifecycle.
-      navigate(url, { replace: true });
+      navigate(url, { replace: true, flushSync: true });
     } catch {
       // Malformed command — ignore.
     }

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -172,11 +172,13 @@ function createUserMessageRunConfig(
   recoveryAction?: AgentRecoveryAction,
   trackInRunsTray?: boolean,
   approvedToolCalls?: string[],
+  queuedMessageId?: string,
 ) {
   const custom: {
     references?: Reference[];
     requestMode?: AgentRequestMode;
     trackInRunsTray?: boolean;
+    agentNativeQueuedMessageId?: string;
     approvedToolCalls?: string[];
   } = {};
   if (references && references.length > 0) {
@@ -187,6 +189,9 @@ function createUserMessageRunConfig(
   }
   if (trackInRunsTray) {
     custom.trackInRunsTray = true;
+  }
+  if (queuedMessageId) {
+    custom.agentNativeQueuedMessageId = queuedMessageId;
   }
   if (approvedToolCalls && approvedToolCalls.length > 0) {
     custom.approvedToolCalls = approvedToolCalls;
@@ -1089,6 +1094,9 @@ const AssistantChatInner = forwardRef<
             return original(fallbackParent, message);
           }
           return original(null, message);
+        }
+        if (msg.includes("same id already exists")) {
+          return;
         }
         throw err;
       }
@@ -2225,6 +2233,8 @@ const AssistantChatInner = forwardRef<
               next.requestMode,
               next.recoveryAction,
               next.trackInRunsTray,
+              undefined,
+              next.id,
             ),
           } as Parameters<typeof threadRuntime.append>[0]);
           appended = true;

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -1416,6 +1416,159 @@ describe("createAgentChatAdapter", () => {
     expect(last.content.at(-1).text).toBe("recovered from active run");
   });
 
+  it("retries queued message conflicts instead of binding the old run", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        postCount += 1;
+        return postCount === 1
+          ? jsonResponse({ activeRunId: "run-old" }, 409)
+          : sseResponse([
+              { type: "text", text: "queued answer" },
+              { type: "done" },
+            ]);
+      }
+      if (url.includes("/runs/run-old/events")) {
+        return sseResponse([
+          { type: "text", text: "old answer" },
+          { type: "done" },
+        ]);
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-queued-conflict",
+      threadId: "thread-queued-conflict",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "hello" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+        runConfig: {
+          custom: { agentNativeQueuedMessageId: "queued-1" },
+        },
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(500);
+    const results = await promise;
+
+    expect(postCount).toBe(2);
+    expect(
+      fetchSpy.mock.calls.some(([url]) =>
+        String(url).includes("/runs/run-old/events"),
+      ),
+    ).toBe(false);
+    const chatPosts = fetchSpy.mock.calls.filter(
+      ([url, init]) =>
+        url === "/_agent-native/agent-chat" && init?.method === "POST",
+    );
+    expect(
+      chatPosts.map(([, init]) => JSON.parse(init.body as string).message),
+    ).toEqual(["hello", "hello"]);
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toBe("queued answer");
+  });
+
+  it("retries a normal send that conflicts with a just-finished run instead of replaying it", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        postCount += 1;
+        // First send collides with the previous run, which the server still
+        // reports as active for a beat after it finished. No queue marker here:
+        // this is an ordinary send fired shortly after the prior turn.
+        return postCount === 1
+          ? jsonResponse({ activeRunId: "run-old" }, 409)
+          : sseResponse([
+              { type: "text", text: "fresh answer" },
+              { type: "done" },
+            ]);
+      }
+      if (url.includes("/runs/run-old/events")) {
+        return sseResponse([
+          { type: "text", text: "old answer" },
+          { type: "done" },
+        ]);
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-normal-conflict",
+      threadId: "thread-normal-conflict",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "follow up" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(500);
+    const results = await promise;
+
+    // It must retry its own prompt, never fetch the old run's events (replay).
+    expect(postCount).toBe(2);
+    expect(
+      fetchSpy.mock.calls.some(([url]) =>
+        String(url).includes("/runs/run-old/events"),
+      ),
+    ).toBe(false);
+    const chatPosts = fetchSpy.mock.calls.filter(
+      ([url, init]) =>
+        url === "/_agent-native/agent-chat" && init?.method === "POST",
+    );
+    expect(
+      chatPosts.map(([, init]) => JSON.parse(init.body as string).message),
+    ).toEqual(["follow up", "follow up"]);
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toBe("fresh answer");
+  });
+
   it("continues automatically when an SSE stream closes before any terminal event", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("window", { dispatchEvent: vi.fn() });

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -1492,6 +1492,139 @@ describe("createAgentChatAdapter", () => {
     expect(last.content.at(-1).text).toBe("queued answer");
   });
 
+  it("fails a fresh conflicting turn after retry exhaustion instead of binding the old run", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        postCount += 1;
+        return jsonResponse({ activeRunId: "run-old" }, 409);
+      }
+      if (url.includes("/runs/run-old/events")) {
+        return sseResponse([
+          { type: "text", text: "old answer" },
+          { type: "done" },
+        ]);
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-queued-conflict-exhausted",
+      threadId: "thread-queued-conflict-exhausted",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "hello" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+        runConfig: {
+          custom: { agentNativeQueuedMessageId: "queued-1" },
+        },
+      } as any),
+    );
+
+    await vi.runAllTimersAsync();
+    const results = await promise;
+
+    expect(postCount).toBe(121);
+    expect(
+      fetchSpy.mock.calls.some(([url]) =>
+        String(url).includes("/runs/run-old/events"),
+      ),
+    ).toBe(false);
+    const last = results.at(-1) as any;
+    expect(last.status).toEqual({ type: "incomplete", reason: "error" });
+    expect(last.metadata.custom.runError.errorCode).toBe("active_run_conflict");
+    expect(last.content.at(-1).text).toContain(
+      "previous response is still finishing",
+    );
+  });
+
+  it("fails a normal conflicting send after retry exhaustion instead of replaying the old run", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        postCount += 1;
+        return jsonResponse({ activeRunId: "run-old" }, 409);
+      }
+      if (url.includes("/runs/run-old/events")) {
+        return sseResponse([
+          { type: "text", text: "old answer" },
+          { type: "done" },
+        ]);
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-normal-conflict-exhausted",
+      threadId: "thread-normal-conflict-exhausted",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "hello" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.runAllTimersAsync();
+    const results = await promise;
+
+    expect(postCount).toBe(121);
+    expect(
+      fetchSpy.mock.calls.some(([url]) =>
+        String(url).includes("/runs/run-old/events"),
+      ),
+    ).toBe(false);
+    const last = results.at(-1) as any;
+    expect(last.status).toEqual({ type: "incomplete", reason: "error" });
+    expect(last.metadata.custom.runError.errorCode).toBe("active_run_conflict");
+    expect(last.content.at(-1).text).toContain(
+      "previous response is still finishing",
+    );
+  });
+
   it("retries a normal send that conflicts with a just-finished run instead of replaying it", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("window", { dispatchEvent: vi.fn() });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -70,6 +70,7 @@ const AUTO_CONTINUE_COMPLETION_GUARD =
   "Before doing more work, inspect the prior partial assistant output in history. If it already gives a coherent answer, summary, artifact, coverage note, or next-step recommendation, finish with at most one short closing sentence and do not call tools, scan more data, or expand the search. Continue only genuinely unfinished work.";
 const MAX_RECONNECT_ATTEMPTS = 5;
 const MAX_STARTUP_RECOVERY_ATTEMPTS = 8;
+const MAX_QUEUED_CONFLICT_RETRIES = 120;
 const MAX_STALE_RUN_CONTINUATIONS = 3;
 const MAX_STALLED_TRANSIENT_CONTINUATIONS = 8;
 const MAX_TOTAL_TRANSIENT_CONTINUATIONS = 32;
@@ -1285,6 +1286,7 @@ export function createAgentChatAdapter(
       let includeReferences = Boolean(runConfig?.custom?.references);
       let internalContinuationRequest = false;
       let startupRecoveryAttempts = 0;
+      let queuedConflictRetries = 0;
       let staleRunContinuationAttempts = 0;
       let stalledTransientContinuationAttempts = 0;
       let emptyTransientContinuationAttempts = 0;
@@ -1903,12 +1905,36 @@ export function createAgentChatAdapter(
 
             if (!res.ok) {
               if (res.status === 409) {
-                let handledConflict = false;
+                let activeRunId: string | null = null;
                 try {
                   const body = await res.json();
                   if (body?.activeRunId) {
-                    handledConflict = true;
-                    runId = String(body.activeRunId);
+                    activeRunId = String(body.activeRunId);
+                  }
+                } catch {
+                  // Fall through to the generic response handling below.
+                }
+                // A 409 means the server still has an active run for this
+                // thread. For a fresh user turn — a queued follow-up OR a normal
+                // send fired shortly after the previous run finished (the server
+                // can report a just-finished run as active for up to
+                // RUN_STALE_MS while its terminal status write lands) — adopting
+                // `activeRunId` below would reconnect to that prior run, replay
+                // its final answer, and silently drop this turn. Wait for the
+                // run to clear and retry THIS prompt instead. Only genuine
+                // internal continuations (deliberate resumes of the active run)
+                // fall through to the reconnect path.
+                if (!internalContinuationRequest && activeRunId) {
+                  queuedConflictRetries += 1;
+                  if (queuedConflictRetries <= MAX_QUEUED_CONFLICT_RETRIES) {
+                    await delay(500, abortSignal);
+                    if (abortSignal.aborted) return;
+                    continue;
+                  }
+                }
+                if (activeRunId) {
+                  try {
+                    runId = activeRunId;
                     if (!attemptedRunIds.includes(runId)) {
                       attemptedRunIds.push(runId);
                     }
@@ -1918,14 +1944,12 @@ export function createAgentChatAdapter(
                     }
                     const reconnected = yield* reconnectCurrentRun();
                     if (reconnected) return;
+                    await delay(1000, abortSignal);
+                    if (abortSignal.aborted) return;
+                    continue;
+                  } catch {
+                    // Fall through to the generic response handling below.
                   }
-                } catch {
-                  // Fall through to the generic response handling below.
-                }
-                if (handledConflict) {
-                  await delay(1000, abortSignal);
-                  if (abortSignal.aborted) return;
-                  continue;
                 }
               }
 

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -1931,6 +1931,36 @@ export function createAgentChatAdapter(
                     if (abortSignal.aborted) return;
                     continue;
                   }
+                  const message =
+                    "The previous response is still finishing and the new message could not start yet. Please try again.";
+                  const runError = {
+                    message,
+                    details: `The server kept reporting active run ${activeRunId} for this thread after ${MAX_QUEUED_CONFLICT_RETRIES} retries.`,
+                    errorCode: "active_run_conflict",
+                    recoverable: true,
+                    runId: activeRunId,
+                  };
+                  if (typeof window !== "undefined") {
+                    window.dispatchEvent(
+                      new CustomEvent("agent-chat:run-error", {
+                        detail: { ...runError, tabId },
+                      }),
+                    );
+                  }
+                  content.push({
+                    type: "text",
+                    text: `Something went wrong: ${message}`,
+                  });
+                  yield {
+                    content: [...content],
+                    status: {
+                      type: "incomplete" as const,
+                      reason: "error" as const,
+                    },
+                    metadata: { custom: { runError } },
+                  } as ChatModelRunResult;
+                  clearActiveRun();
+                  return;
                 }
                 if (activeRunId) {
                   try {

--- a/packages/core/src/client/extensions/ExtensionViewer.spec.tsx
+++ b/packages/core/src/client/extensions/ExtensionViewer.spec.tsx
@@ -22,7 +22,20 @@ vi.mock("../AgentPanel.js", () => ({
 }));
 
 vi.mock("../notifications/NotificationsBell.js", () => ({
-  NotificationsBell: () => <button type="button">Notifications</button>,
+  NotificationsBell: ({
+    onOpenChange,
+  }: {
+    onOpenChange?: (open: boolean) => void;
+  }) => (
+    <>
+      <button type="button" onClick={() => onOpenChange?.(true)}>
+        Notifications
+      </button>
+      <button type="button" onClick={() => onOpenChange?.(false)}>
+        Close notifications
+      </button>
+    </>
+  ),
 }));
 
 vi.mock("../composer/PromptComposer.js", () => ({
@@ -161,5 +174,27 @@ describe("ExtensionViewer MCP embeds", () => {
     await vi.waitFor(() => {
       expect(container.querySelector("iframe")).toBeTruthy();
     });
+  });
+
+  it("lets the notifications popover take outside clicks over the extension iframe", async () => {
+    const iframe = await renderViewer();
+    const buttonNamed = (label: string) =>
+      Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === label,
+      );
+
+    expect(iframe.style.pointerEvents).toBe("auto");
+
+    await act(async () => {
+      buttonNamed("Notifications")?.click();
+    });
+
+    expect(iframe.style.pointerEvents).toBe("none");
+
+    await act(async () => {
+      buttonNamed("Close notifications")?.click();
+    });
+
+    expect(iframe.style.pointerEvents).toBe("auto");
   });
 });

--- a/packages/core/src/client/extensions/ExtensionViewer.tsx
+++ b/packages/core/src/client/extensions/ExtensionViewer.tsx
@@ -1162,7 +1162,7 @@ export function ExtensionViewer({ extensionId }: ExtensionViewerProps) {
               sourceMode={extension.source?.mode}
               onOpenChange={onPopoverOpenChange}
             />
-            <NotificationsBell />
+            <NotificationsBell onOpenChange={onPopoverOpenChange} />
             <AgentToggleButton />
           </div>
         </div>

--- a/packages/core/src/client/notifications/NotificationsBell.tsx
+++ b/packages/core/src/client/notifications/NotificationsBell.tsx
@@ -33,6 +33,8 @@ interface NotificationsBellProps {
   emptyTitle?: string;
   /** Optional empty-state detail text. */
   emptyDescription?: string;
+  /** Optional notification for parent shells that need to coordinate overlays. */
+  onOpenChange?: (open: boolean) => void;
 }
 
 const POLL_MS_DEFAULT = 10_000;
@@ -52,6 +54,7 @@ export function NotificationsBell({
   browserNotifications = false,
   emptyTitle = "No app notifications yet.",
   emptyDescription,
+  onOpenChange,
 }: NotificationsBellProps) {
   const [unreadCount, setUnreadCount] = useState(0);
   const [open, setOpen] = useState(false);
@@ -219,9 +222,13 @@ export function NotificationsBell({
 
   const hasUnread = unreadCount > 0;
   const Icon = hasUnread ? IconBellRinging : IconBell;
+  const setOpenAndNotify = (value: boolean) => {
+    setOpen(value);
+    onOpenChange?.(value);
+  };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={setOpenAndNotify}>
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -291,7 +298,7 @@ export function NotificationsBell({
               const onItemClick = () => {
                 if (!n.readAt) void markRead(n.id);
                 if (link) {
-                  setOpen(false);
+                  setOpenAndNotify(false);
                   window.location.assign(link);
                 }
               };

--- a/packages/core/src/org/auto-join-domain.spec.ts
+++ b/packages/core/src/org/auto-join-domain.spec.ts
@@ -79,6 +79,26 @@ describe("autoJoinDomainMatchingOrgs", () => {
     expect(mockPutUserSetting).not.toHaveBeenCalled();
   });
 
+  it("can activate a newly joined domain org for request-time resolution", async () => {
+    queueSelect(
+      [{ orgId: "builder_io" }],
+      [], // INSERT org_members
+    );
+    mockGetUserSetting.mockResolvedValueOnce({ orgId: "personal_org" });
+
+    const out = await autoJoinDomainMatchingOrgs("existing@builder.io", {
+      activateJoinedOrg: "always",
+    });
+
+    expect(out.joined).toEqual([{ orgId: "builder_io" }]);
+    expect(out.activeOrgId).toBe("builder_io");
+    expect(mockPutUserSetting).toHaveBeenCalledWith(
+      "existing@builder.io",
+      "active-org-id",
+      { orgId: "builder_io" },
+    );
+  });
+
   it("excludes orgs the user is already a member of (NOT EXISTS)", async () => {
     // The query itself filters via NOT EXISTS, so we just confirm we
     // call it correctly. When the query returns empty (because the user

--- a/packages/core/src/org/auto-join-domain.ts
+++ b/packages/core/src/org/auto-join-domain.ts
@@ -31,8 +31,8 @@ export interface AutoJoinDomainOptions {
  * "Join your team" UI in the picker; we use the same opt-in to drive
  * automatic join.
  *
- * Idempotent — skips orgs the user is already a member of and never
- * overwrites an existing `active-org-id` setting.
+ * Idempotent — skips orgs the user is already a member of and, by default,
+ * never overwrites an existing `active-org-id` setting.
  *
  * Safe to call when the org tables don't exist (some templates don't use
  * the org module): it swallows the "no such table" error and returns

--- a/packages/core/src/org/auto-join-domain.ts
+++ b/packages/core/src/org/auto-join-domain.ts
@@ -10,6 +10,15 @@ export interface AutoJoinDomainResult {
   activeOrgId: string | null;
 }
 
+export interface AutoJoinDomainOptions {
+  /**
+   * The signup hook should not clobber an org selected by an invite flow, but
+   * request-time org resolution may need to move an existing account from a
+   * personal workspace into its newly matched company org.
+   */
+  activateJoinedOrg?: "if-missing" | "always";
+}
+
 /**
  * Auto-join a newly-signed-up user into every org whose `allowed_domain`
  * matches their email domain.
@@ -32,6 +41,7 @@ export interface AutoJoinDomainResult {
  */
 export async function autoJoinDomainMatchingOrgs(
   rawEmail: string,
+  options: AutoJoinDomainOptions = {},
 ): Promise<AutoJoinDomainResult> {
   const email = rawEmail.trim().toLowerCase();
   if (!email) return { joined: [], activeOrgId: null };
@@ -82,14 +92,15 @@ export async function autoJoinDomainMatchingOrgs(
     }
   }
 
-  // Set active-org-id to the first match only if the user doesn't
-  // already have one (a pending invite that ran first may have set it).
+  // Set active-org-id to the first match only if the user doesn't already have
+  // one, unless the caller is request-time org resolution intentionally moving
+  // an existing account into its newly matched company org.
   let activeOrgId: string | null = null;
   if (joined[0]) {
     try {
       const existing = await getUserSetting(email, "active-org-id");
       const hasActive = Boolean(existing?.orgId);
-      if (!hasActive) {
+      if (options.activateJoinedOrg === "always" || !hasActive) {
         activeOrgId = joined[0].orgId;
         await putUserSetting(email, "active-org-id", { orgId: activeOrgId });
       }

--- a/packages/core/src/org/context.spec.ts
+++ b/packages/core/src/org/context.spec.ts
@@ -162,6 +162,7 @@ describe("getOrgContext", () => {
     expect(ctx.orgId).toBe("second");
     expect(ctx.role).toBe("member");
     expect(mockGetUserSetting).toHaveBeenCalledWith("a@b.com", "active-org-id");
+    expect(mockExecute).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to first membership when active-org-id points to a non-membership", async () => {
@@ -181,6 +182,23 @@ describe("getOrgContext", () => {
     const ctx = await getOrgContext(EVENT);
     expect(ctx.orgId).toBe("only");
     expect(mockGetUserSetting).not.toHaveBeenCalled();
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run domain auto-join for a single non-personal org", async () => {
+    mockGetSession.mockResolvedValue({ email: "member@builder.io" });
+    queueSelect([{ orgId: "builder", role: "member", orgName: "Builder.io" }]);
+
+    const ctx = await getOrgContext(EVENT);
+
+    expect(ctx).toEqual({
+      email: "member@builder.io",
+      orgId: "builder",
+      orgName: "Builder.io",
+      role: "member",
+    });
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(mockPutUserSetting).not.toHaveBeenCalled();
   });
 
   it("returns null org for an authenticated user with zero memberships (no auto-create)", async () => {
@@ -367,9 +385,9 @@ describe("getOrgContext", () => {
 
       // Both calls return the same resolved value.
       expect(ctx1).toBe(ctx2); // identical reference, not just deep-equal
-      // Only one membership lookup and one domain auto-join lookup, not two of
-      // either.
-      expect(mockExecute).toHaveBeenCalledTimes(2);
+      // Only one membership lookup, with no request-time domain scan for an
+      // existing non-personal org.
+      expect(mockExecute).toHaveBeenCalledTimes(1);
     });
 
     it("does NOT share the cache between two different event objects", async () => {
@@ -391,7 +409,7 @@ describe("getOrgContext", () => {
 
       expect(ctxA.orgId).toBe("org-a");
       expect(ctxB.orgId).toBe("org-b");
-      expect(mockExecute).toHaveBeenCalledTimes(4);
+      expect(mockExecute).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/core/src/org/context.spec.ts
+++ b/packages/core/src/org/context.spec.ts
@@ -185,7 +185,7 @@ describe("getOrgContext", () => {
 
   it("returns null org for an authenticated user with zero memberships (no auto-create)", async () => {
     mockGetSession.mockResolvedValue({ email: "loner@b.com" });
-    queueSelect([]);
+    queueSelect([], []); // memberships, domain auto-join lookup
     const ctx = await getOrgContext(EVENT);
     expect(ctx).toEqual({
       email: "loner@b.com",
@@ -194,6 +194,82 @@ describe("getOrgContext", () => {
       role: null,
     });
     expect(mockPutUserSetting).not.toHaveBeenCalled();
+  });
+
+  it("auto-joins an existing zero-membership user into their domain org", async () => {
+    mockGetSession.mockResolvedValue({ email: "existing@Builder.IO" });
+    mockExecute.mockResolvedValueOnce({ rows: [] }); // memberships
+    mockExecute.mockResolvedValueOnce({
+      rows: [{ orgId: "builder_io" }],
+    }); // domain auto-join lookup
+    mockExecute.mockResolvedValueOnce({ rows: [] }); // INSERT org_members
+    mockExecute.mockResolvedValueOnce({
+      rows: [{ orgId: "builder_io", role: "member", orgName: "Builder.io" }],
+    }); // refreshed memberships
+
+    const ctx = await getOrgContext(EVENT);
+
+    expect(ctx).toEqual({
+      email: "existing@Builder.IO",
+      orgId: "builder_io",
+      orgName: "Builder.io",
+      role: "member",
+    });
+    expect(mockPutUserSetting).toHaveBeenCalledWith(
+      "existing@builder.io",
+      "active-org-id",
+      { orgId: "builder_io" },
+    );
+
+    const calls = mockExecute.mock.calls.map((c) => c[0]);
+    expect(calls[1].sql).toContain("LOWER(o.allowed_domain)");
+    expect(calls[1].args).toEqual(["builder.io", "existing@builder.io"]);
+    expect(calls[2].sql).toContain("INSERT INTO org_members");
+    expect(calls.some((c) => c.sql.includes("INSERT INTO organizations"))).toBe(
+      false,
+    );
+  });
+
+  it("activates a newly joined domain org over an existing personal org", async () => {
+    mockGetSession.mockResolvedValue({ email: "teammate@builder.io" });
+    mockGetUserSetting.mockResolvedValueOnce({ orgId: "personal_org" });
+    mockExecute.mockResolvedValueOnce({
+      rows: [
+        {
+          orgId: "personal_org",
+          role: "owner",
+          orgName: "Teammate's workspace",
+        },
+      ],
+    }); // memberships
+    mockExecute.mockResolvedValueOnce({
+      rows: [{ orgId: "builder_io" }],
+    }); // domain auto-join lookup
+    mockExecute.mockResolvedValueOnce({ rows: [] }); // INSERT org_members
+    mockExecute.mockResolvedValueOnce({
+      rows: [
+        {
+          orgId: "personal_org",
+          role: "owner",
+          orgName: "Teammate's workspace",
+        },
+        { orgId: "builder_io", role: "member", orgName: "Builder.io" },
+      ],
+    }); // refreshed memberships
+
+    const ctx = await getOrgContext(EVENT);
+
+    expect(ctx).toEqual({
+      email: "teammate@builder.io",
+      orgId: "builder_io",
+      orgName: "Builder.io",
+      role: "member",
+    });
+    expect(mockPutUserSetting).toHaveBeenCalledWith(
+      "teammate@builder.io",
+      "active-org-id",
+      { orgId: "builder_io" },
+    );
   });
 
   describe("membership-lookup failure (tables missing before migrations)", () => {
@@ -246,8 +322,9 @@ describe("getOrgContext", () => {
 
       // Both calls return the same resolved value.
       expect(ctx1).toBe(ctx2); // identical reference, not just deep-equal
-      // Only one DB round trip, not two.
-      expect(mockExecute).toHaveBeenCalledTimes(1);
+      // Only one membership lookup and one domain auto-join lookup, not two of
+      // either.
+      expect(mockExecute).toHaveBeenCalledTimes(2);
     });
 
     it("does NOT share the cache between two different event objects", async () => {
@@ -269,7 +346,7 @@ describe("getOrgContext", () => {
 
       expect(ctxA.orgId).toBe("org-a");
       expect(ctxB.orgId).toBe("org-b");
-      expect(mockExecute).toHaveBeenCalledTimes(2);
+      expect(mockExecute).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -285,13 +362,15 @@ describe("getOrgContext", () => {
         name: "Jane Doe",
       });
       // 1) memberships lookup -> empty
-      // 2) acquireClaim INSERT into settings -> succeeds (no throw)
-      // 3) hasPendingInvitation -> none
-      // 4) hasDomainMatch -> none
-      // 5) INSERT organizations
-      // 6) INSERT org_members
+      // 2) domain auto-join lookup -> no matching org
+      // 3) acquireClaim INSERT into settings -> succeeds (no throw)
+      // 4) hasPendingInvitation -> none
+      // 5) hasDomainMatch -> none
+      // 6) INSERT organizations
+      // 7) INSERT org_members
       queueSelect(
         [], // memberships
+        [], // domain auto-join lookup
         [], // acquireClaim INSERT settings (resolves -> claim acquired)
         [], // hasPendingInvitation
         [], // hasDomainMatch
@@ -313,7 +392,7 @@ describe("getOrgContext", () => {
     it("derives the workspace name from the email local-part when session has no name", async () => {
       process.env.AUTO_CREATE_DEFAULT_ORG = "1";
       mockGetSession.mockResolvedValue({ email: "john.q-public@startup.dev" });
-      queueSelect([], [], [], [], [], []);
+      queueSelect([], [], [], [], [], [], []);
       const ctx = await getOrgContext(EVENT);
       expect(ctx.orgName).toBe("John Q Public's workspace");
     });
@@ -323,6 +402,7 @@ describe("getOrgContext", () => {
       mockGetSession.mockResolvedValue({ email: "invited@startup.dev" });
       queueSelect(
         [], // memberships
+        [], // domain auto-join lookup
         [], // acquireClaim INSERT settings
         [{ "1": 1 }], // hasPendingInvitation -> has one
       );
@@ -339,19 +419,31 @@ describe("getOrgContext", () => {
       );
     });
 
-    it("does NOT auto-create when the email domain already matches an org", async () => {
+    it("joins instead of auto-creating when the email domain already matches an org", async () => {
       process.env.AUTO_CREATE_DEFAULT_ORG = "1";
       mockGetSession.mockResolvedValue({ email: "new@builder.io" });
       queueSelect(
         [], // memberships
-        [], // acquireClaim INSERT settings
-        [], // hasPendingInvitation -> none
-        [{ "1": 1 }], // hasDomainMatch -> match
+        [{ orgId: "builder_io" }], // domain auto-join lookup
+        [], // INSERT org_members
+        [{ orgId: "builder_io", role: "member", orgName: "Builder.io" }],
       );
-      mockExecute.mockResolvedValueOnce({ rows: [] }); // releaseClaim DELETE
       const ctx = await getOrgContext(EVENT);
-      expect(ctx.orgId).toBeNull();
-      expect(mockPutUserSetting).not.toHaveBeenCalled();
+      expect(ctx).toMatchObject({
+        email: "new@builder.io",
+        orgId: "builder_io",
+        orgName: "Builder.io",
+        role: "member",
+      });
+      expect(mockPutUserSetting).toHaveBeenCalledWith(
+        "new@builder.io",
+        "active-org-id",
+        { orgId: "builder_io" },
+      );
+      const sqls = mockExecute.mock.calls.map((c) => c[0].sql);
+      expect(sqls.some((s) => s.includes("INSERT INTO organizations"))).toBe(
+        false,
+      );
     });
 
     it("bails (null org) when the auto-create claim is lost to a concurrent request", async () => {
@@ -360,6 +452,7 @@ describe("getOrgContext", () => {
       // memberships empty, then acquireClaim INSERT throws (key exists), then
       // the stale-takeover UPDATE matches zero rows -> claim NOT acquired.
       mockExecute.mockResolvedValueOnce({ rows: [] }); // memberships
+      mockExecute.mockResolvedValueOnce({ rows: [] }); // domain auto-join lookup
       mockExecute.mockRejectedValueOnce(
         new Error("UNIQUE constraint failed: settings.key"),
       );
@@ -380,6 +473,7 @@ describe("getOrgContext", () => {
         name: "Stuck User",
       });
       mockExecute.mockResolvedValueOnce({ rows: [] }); // memberships
+      mockExecute.mockResolvedValueOnce({ rows: [] }); // domain auto-join lookup
       mockExecute.mockRejectedValueOnce(
         new Error("UNIQUE constraint failed: settings.key"),
       ); // acquireClaim INSERT conflicts
@@ -405,6 +499,7 @@ describe("getOrgContext", () => {
       process.env.AUTO_CREATE_DEFAULT_ORG = "1";
       mockGetSession.mockResolvedValue({ email: "maybe-invited@startup.dev" });
       mockExecute.mockResolvedValueOnce({ rows: [] }); // memberships
+      mockExecute.mockResolvedValueOnce({ rows: [] }); // domain auto-join lookup
       mockExecute.mockResolvedValueOnce({ rows: [] }); // acquireClaim INSERT
       mockExecute.mockRejectedValueOnce(
         new Error("no such table: org_invitations"),
@@ -421,7 +516,7 @@ describe("getOrgContext", () => {
 
     it("does NOT auto-create when the flag is unset, even for a zero-membership user", async () => {
       mockGetSession.mockResolvedValue({ email: "loner@startup.dev" });
-      queueSelect([]); // memberships only
+      queueSelect([], []); // memberships, domain auto-join lookup
       const ctx = await getOrgContext(EVENT);
       expect(ctx.orgId).toBeNull();
       expect(mockGetSetting).not.toHaveBeenCalled();

--- a/packages/core/src/org/context.spec.ts
+++ b/packages/core/src/org/context.spec.ts
@@ -272,6 +272,51 @@ describe("getOrgContext", () => {
     );
   });
 
+  it("prefers a newly joined domain org over a backfilled session org", async () => {
+    mockGetSession.mockResolvedValue({
+      email: "teammate@builder.io",
+      orgId: "personal_org",
+    });
+    mockGetUserSetting.mockResolvedValueOnce({ orgId: "personal_org" });
+    mockExecute.mockResolvedValueOnce({
+      rows: [
+        {
+          orgId: "personal_org",
+          role: "owner",
+          orgName: "Teammate's workspace",
+        },
+      ],
+    }); // memberships
+    mockExecute.mockResolvedValueOnce({
+      rows: [{ orgId: "builder_io" }],
+    }); // domain auto-join lookup
+    mockExecute.mockResolvedValueOnce({ rows: [] }); // INSERT org_members
+    mockExecute.mockResolvedValueOnce({
+      rows: [
+        {
+          orgId: "personal_org",
+          role: "owner",
+          orgName: "Teammate's workspace",
+        },
+        { orgId: "builder_io", role: "member", orgName: "Builder.io" },
+      ],
+    }); // refreshed memberships
+
+    const ctx = await getOrgContext(EVENT);
+
+    expect(ctx).toEqual({
+      email: "teammate@builder.io",
+      orgId: "builder_io",
+      orgName: "Builder.io",
+      role: "member",
+    });
+    expect(mockPutUserSetting).toHaveBeenCalledWith(
+      "teammate@builder.io",
+      "active-org-id",
+      { orgId: "builder_io" },
+    );
+  });
+
   describe("membership-lookup failure (tables missing before migrations)", () => {
     it("returns the session orgId when present", async () => {
       mockGetSession.mockResolvedValue({

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -19,6 +19,14 @@ function normalizeOrgRole(value: unknown): OrgRole | null {
     : null;
 }
 
+function isLikelyPersonalWorkspace(
+  membership: { orgName: string },
+  email: string,
+  session: { name?: string } | null,
+): boolean {
+  return membership.orgName.trim() === defaultOrgName(email, session);
+}
+
 const nanoid = (): string =>
   globalThis.crypto?.randomUUID?.().replace(/-/g, "") ??
   Math.random().toString(36).slice(2) + Date.now().toString(36);
@@ -61,7 +69,6 @@ async function resolveOrgContextUncached(event: H3Event): Promise<OrgContext> {
   const exec = getDbExec();
 
   let memberships = await loadMemberships(exec, email);
-  let preferredJoinedOrgId: string | null = null;
   if (memberships === null) {
     if (sessionOrgId) {
       return {
@@ -74,29 +81,58 @@ async function resolveOrgContextUncached(event: H3Event): Promise<OrgContext> {
     return { email, orgId: null, orgName: null, role: null };
   }
 
-  const joined = await autoJoinDomainMatchingOrgs(email, {
-    activateJoinedOrg: "always",
-  });
-  preferredJoinedOrgId = joined.activeOrgId;
-  if (joined.joined.length > 0) {
-    const refreshed = await loadMemberships(exec, email);
-    if (refreshed !== null) memberships = refreshed;
+  if (memberships.length > 1) {
+    const activeOrgSetting = (await getUserSetting(email, "active-org-id")) as {
+      orgId: string;
+    } | null;
+    if (activeOrgSetting?.orgId) {
+      const active = memberships.find(
+        (m) => m.orgId === activeOrgSetting.orgId,
+      );
+      if (active) {
+        return {
+          email,
+          orgId: active.orgId,
+          orgName: active.orgName,
+          role: active.role,
+        };
+      }
+    }
   }
 
-  if (preferredJoinedOrgId) {
-    const active = memberships.find((m) => m.orgId === preferredJoinedOrgId);
-    if (active) {
-      return {
-        email,
-        orgId: active.orgId,
-        orgName: active.orgName,
-        role: active.role,
-      };
+  const sessionMembership = sessionOrgId
+    ? memberships.find((m) => m.orgId === sessionOrgId)
+    : null;
+  const shouldTryDomainAutoJoin =
+    memberships.length === 0 ||
+    (memberships.length === 1 &&
+      isLikelyPersonalWorkspace(memberships[0], email, session));
+
+  if (shouldTryDomainAutoJoin) {
+    const joined = await autoJoinDomainMatchingOrgs(email, {
+      activateJoinedOrg: "always",
+    });
+    if (joined.joined.length > 0) {
+      const refreshed = await loadMemberships(exec, email);
+      if (refreshed !== null) memberships = refreshed;
+    }
+
+    if (joined.activeOrgId) {
+      const active = memberships.find((m) => m.orgId === joined.activeOrgId);
+      if (active) {
+        return {
+          email,
+          orgId: active.orgId,
+          orgName: active.orgName,
+          role: active.role,
+        };
+      }
     }
   }
 
   if (sessionOrgId) {
-    const active = memberships.find((m) => m.orgId === sessionOrgId);
+    const active =
+      sessionMembership ?? memberships.find((m) => m.orgId === sessionOrgId);
     if (active) {
       return {
         email,
@@ -122,25 +158,6 @@ async function resolveOrgContextUncached(event: H3Event): Promise<OrgContext> {
 
   if (memberships.length === 0) {
     return { email, orgId: null, orgName: null, role: null };
-  }
-
-  if (memberships.length > 1) {
-    const activeOrgSetting = (await getUserSetting(email, "active-org-id")) as {
-      orgId: string;
-    } | null;
-    if (activeOrgSetting?.orgId) {
-      const active = memberships.find(
-        (m) => m.orgId === activeOrgSetting.orgId,
-      );
-      if (active) {
-        return {
-          email,
-          orgId: active.orgId,
-          orgName: active.orgName,
-          role: active.role,
-        };
-      }
-    }
   }
 
   return {

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -74,14 +74,24 @@ async function resolveOrgContextUncached(event: H3Event): Promise<OrgContext> {
     return { email, orgId: null, orgName: null, role: null };
   }
 
-  if (!sessionOrgId) {
-    const joined = await autoJoinDomainMatchingOrgs(email, {
-      activateJoinedOrg: "always",
-    });
-    preferredJoinedOrgId = joined.activeOrgId;
-    if (joined.joined.length > 0) {
-      const refreshed = await loadMemberships(exec, email);
-      if (refreshed !== null) memberships = refreshed;
+  const joined = await autoJoinDomainMatchingOrgs(email, {
+    activateJoinedOrg: "always",
+  });
+  preferredJoinedOrgId = joined.activeOrgId;
+  if (joined.joined.length > 0) {
+    const refreshed = await loadMemberships(exec, email);
+    if (refreshed !== null) memberships = refreshed;
+  }
+
+  if (preferredJoinedOrgId) {
+    const active = memberships.find((m) => m.orgId === preferredJoinedOrgId);
+    if (active) {
+      return {
+        email,
+        orgId: active.orgId,
+        orgName: active.orgName,
+        role: active.role,
+      };
     }
   }
 
@@ -101,18 +111,6 @@ async function resolveOrgContextUncached(event: H3Event): Promise<OrgContext> {
       orgName: null,
       role: sessionOrgRole,
     };
-  }
-
-  if (preferredJoinedOrgId) {
-    const active = memberships.find((m) => m.orgId === preferredJoinedOrgId);
-    if (active) {
-      return {
-        email,
-        orgId: active.orgId,
-        orgName: active.orgName,
-        role: active.role,
-      };
-    }
   }
 
   if (memberships.length === 0 && process.env.AUTO_CREATE_DEFAULT_ORG) {

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -156,14 +156,11 @@ async function resolveOrgContextUncached(event: H3Event): Promise<OrgContext> {
 async function loadMemberships(
   exec: ReturnType<typeof getDbExec>,
   email: string,
-): Promise<
-  | Array<{
-      orgId: string;
-      role: OrgRole;
-      orgName: string;
-    }>
-  | null
-> {
+): Promise<Array<{
+  orgId: string;
+  role: OrgRole;
+  orgName: string;
+}> | null> {
   try {
     const { rows } = await exec.execute({
       sql: `SELECT m.org_id AS "orgId", m.role AS role, o.name AS "orgName"

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -3,6 +3,7 @@ import { getSession } from "../server/auth.js";
 import { getUserSetting, putUserSetting } from "../settings/user-settings.js";
 import { getDbExec } from "../db/client.js";
 import { getSetting } from "../settings/store.js";
+import { autoJoinDomainMatchingOrgs } from "./auto-join-domain.js";
 import type { OrgContext, OrgRole } from "./types.js";
 
 const EMPTY_CONTEXT: OrgContext = {
@@ -59,26 +60,9 @@ async function resolveOrgContextUncached(event: H3Event): Promise<OrgContext> {
 
   const exec = getDbExec();
 
-  let memberships: Array<{
-    orgId: string;
-    role: OrgRole;
-    orgName: string;
-  }> = [];
-  try {
-    const { rows } = await exec.execute({
-      sql: `SELECT m.org_id AS "orgId", m.role AS role, o.name AS "orgName"
-            FROM org_members m
-            INNER JOIN organizations o ON m.org_id = o.id
-            WHERE LOWER(m.email) = ?`,
-      args: [email.toLowerCase()],
-    });
-    memberships = rows.map((r: any) => ({
-      orgId: String(r.orgId ?? r.org_id),
-      role: String(r.role) as OrgRole,
-      orgName: String(r.orgName ?? r.org_name),
-    }));
-  } catch {
-    // Tables may not exist yet on first boot before migrations finish.
+  let memberships = await loadMemberships(exec, email);
+  let preferredJoinedOrgId: string | null = null;
+  if (memberships === null) {
     if (sessionOrgId) {
       return {
         email,
@@ -88,6 +72,17 @@ async function resolveOrgContextUncached(event: H3Event): Promise<OrgContext> {
       };
     }
     return { email, orgId: null, orgName: null, role: null };
+  }
+
+  if (!sessionOrgId) {
+    const joined = await autoJoinDomainMatchingOrgs(email, {
+      activateJoinedOrg: "always",
+    });
+    preferredJoinedOrgId = joined.activeOrgId;
+    if (joined.joined.length > 0) {
+      const refreshed = await loadMemberships(exec, email);
+      if (refreshed !== null) memberships = refreshed;
+    }
   }
 
   if (sessionOrgId) {
@@ -106,6 +101,18 @@ async function resolveOrgContextUncached(event: H3Event): Promise<OrgContext> {
       orgName: null,
       role: sessionOrgRole,
     };
+  }
+
+  if (preferredJoinedOrgId) {
+    const active = memberships.find((m) => m.orgId === preferredJoinedOrgId);
+    if (active) {
+      return {
+        email,
+        orgId: active.orgId,
+        orgName: active.orgName,
+        role: active.role,
+      };
+    }
   }
 
   if (memberships.length === 0 && process.env.AUTO_CREATE_DEFAULT_ORG) {
@@ -144,6 +151,36 @@ async function resolveOrgContextUncached(event: H3Event): Promise<OrgContext> {
     orgName: memberships[0].orgName,
     role: memberships[0].role,
   };
+}
+
+async function loadMemberships(
+  exec: ReturnType<typeof getDbExec>,
+  email: string,
+): Promise<
+  | Array<{
+      orgId: string;
+      role: OrgRole;
+      orgName: string;
+    }>
+  | null
+> {
+  try {
+    const { rows } = await exec.execute({
+      sql: `SELECT m.org_id AS "orgId", m.role AS role, o.name AS "orgName"
+            FROM org_members m
+            INNER JOIN organizations o ON m.org_id = o.id
+            WHERE LOWER(m.email) = ?`,
+      args: [email.toLowerCase()],
+    });
+    return rows.map((r: any) => ({
+      orgId: String(r.orgId ?? r.org_id),
+      role: String(r.role) as OrgRole,
+      orgName: String(r.orgName ?? r.org_name),
+    }));
+  } catch {
+    // Tables may not exist yet on first boot before migrations finish.
+    return null;
+  }
 }
 
 /**

--- a/packages/core/src/org/migrations.spec.ts
+++ b/packages/core/src/org/migrations.spec.ts
@@ -17,6 +17,18 @@ describe("ORG_MIGRATIONS", () => {
     expect(indexMigration?.version).toBeGreaterThan(1006);
   });
 
+  it("includes a LOWER(allowed_domain) expression index on organizations", () => {
+    const indexMigration = ORG_MIGRATIONS.find((m) => {
+      const sql =
+        typeof m.sql === "string"
+          ? m.sql
+          : (m.sql.postgres ?? m.sql.sqlite ?? "");
+      return /CREATE INDEX.*organizations.*LOWER\(allowed_domain\)/i.test(sql);
+    });
+    expect(indexMigration).toBeDefined();
+    expect(indexMigration?.version).toBeGreaterThan(1007);
+  });
+
   it("has strictly ascending version numbers with no gaps", () => {
     const versions = ORG_MIGRATIONS.map((m) => m.version);
     for (let i = 1; i < versions.length; i++) {

--- a/packages/core/src/org/migrations.ts
+++ b/packages/core/src/org/migrations.ts
@@ -55,4 +55,10 @@ export const ORG_MIGRATIONS = [
     version: 1007,
     sql: `CREATE INDEX IF NOT EXISTS org_members_lower_email_idx ON org_members (LOWER(email))`,
   },
+  {
+    // Domain join and org resolution query `LOWER(allowed_domain)`.
+    // Keep that opt-in lookup indexed before it appears on any request path.
+    version: 1008,
+    sql: `CREATE INDEX IF NOT EXISTS organizations_lower_allowed_domain_idx ON organizations (LOWER(allowed_domain))`,
+  },
 ];

--- a/packages/core/src/templates/workspace-core/.agents/skills/client-side-routing/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/client-side-routing/SKILL.md
@@ -66,6 +66,15 @@ export default function Settings() {
 
 If a page needs per-route data (e.g. sidebar highlighting the active document), derive it inside the layout from `useParams()` / `useLocation()` — don't pass it as a prop through every route file.
 
+## Chat-First Routes
+
+If `/` is a full-page chat such as `AgentChatHome`, keep the app shell mounted
+around it when possible so `AgentSidebar` URL sync and route warmup stay active.
+If the chat route intentionally lives outside the shell, add a tiny app-owned
+prewarm for the routes agents commonly open from that chat. In local dev,
+React Router can update the address bar before a cold Vite route chunk commits,
+which makes navigation look broken even when the URL is correct.
+
 ## Adding a New Route
 
 - **Pattern #1** (AppLayout in `root.tsx`): just render page content — nothing else.

--- a/packages/core/src/templates/workspace-core/.agents/skills/context-awareness/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/context-awareness/SKILL.md
@@ -125,6 +125,15 @@ await writeAppState("navigate", { view: "inbox", threadId: "abc123" });
 **UI side** — use `useAgentRouteState`, shown above. It polls command keys,
 dedupes `_writeId`, deletes consumed commands, and applies app-local routing.
 
+When a destination has a real URL, let the `navigate` command carry that local
+`path` (plus semantic fields when useful) and have the UI prefer `path` before
+falling back to semantic routing. Keep app navigation single-channel: do not
+also write `__set_url__` for the same navigation. `__set_url__` belongs to the
+framework URL tools (`set-url-path`, `set-search-params`) and URL-only filter
+changes. If a command can arrive while a chat stream is rendering, prefer
+`navigate(path, { replace: true, flushSync: true })` over a view-transition
+wrapper so the URL and visible route commit together.
+
 ## Jitter Prevention
 
 When the agent writes to application-state via script helpers (`writeAppState`), the write is tagged with `requestSource: "agent"`. The UI uses the `ignoreSource` option on `useDbSync()` with a per-tab ID so it ignores its own writes while still picking up changes from agents, other tabs, and scripts.
@@ -171,7 +180,7 @@ The mail template demonstrates these patterns working together:
 - Keep shareable filters in URL query params so `<current-url>` and `set-search-params` work
 - Update `view-screen` when adding new features — it should return data for every view
 - Use `useAgentRouteState` or `useSemanticNavigationState` for UI-side navigation sync and command consumption
-- Use the one-shot `navigate` command pattern for semantic agent-initiated navigation
+- Use the one-shot `navigate` command pattern for app navigation; include a same-origin `path` when the target URL is known
 - Tag agent writes with `requestSource: "agent"` (the script helpers do this automatically)
 
 ## Don't
@@ -179,6 +188,7 @@ The mail template demonstrates these patterns working together:
 - Don't assume the user is on a specific page — always check navigation state
 - Don't hardcode navigation paths in scripts — read the current state and branch
 - Don't write to the `navigation` key from the agent — it belongs to the UI. Use `navigate` instead.
+- Don't write both `navigate` and `__set_url__` for one app navigation; competing consumers can make the browser URL change before React Router commits the page.
 - Don't ignore the `<current-screen>` block — it tells you where the user is
 - Don't duplicate whole URL query strings into `navigation` when `<current-url>` already exposes them
 - Don't store fetched data in navigation state — it holds IDs and semantic UI state only. The `view-screen` script fetches the actual data.

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   _findCorePackageRoot,
   _getClientDedupe,
+  _getDefaultOptimizeDeps,
   _getReactRouterAliases,
   defineConfig,
   isFrameworkDevPath,
@@ -582,6 +583,29 @@ describe("local-core dev aliases and router dedupe", () => {
     const dedupe = _getClientDedupe(tmpDir);
     expect(dedupe).toContain("react-router");
     expect(dedupe).toContain("react-router/dom");
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("pre-optimizes core client deps when core is source-aliased", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "an-vite-optimize-"));
+    const coreRoot = path.resolve(import.meta.dirname, "../..");
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({
+        dependencies: {
+          "@agent-native/core": pathToFileURL(coreRoot).href,
+          "react-router": "^7.16.0",
+        },
+      }),
+    );
+
+    const deps = _getDefaultOptimizeDeps(tmpDir);
+    expect(deps).not.toContain("@agent-native/core/client");
+    expect(deps).toContain("@assistant-ui/react");
+    expect(deps).toContain("@tiptap/react");
+    expect(deps).toContain("@xterm/xterm");
+    expect(deps).toContain("shiki/core");
 
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -610,6 +610,43 @@ describe("local-core dev aliases and router dedupe", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it("does not pre-optimize packages that are only optional core peers", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "an-vite-optimize-peer-"),
+    );
+    const fakeCore = fs.mkdtempSync(
+      path.join(os.tmpdir(), "an-vite-fake-core-"),
+    );
+    fs.mkdirSync(path.join(fakeCore, "src"));
+    fs.writeFileSync(path.join(fakeCore, "src/index.ts"), "export {};\n");
+    fs.writeFileSync(
+      path.join(fakeCore, "package.json"),
+      JSON.stringify({
+        name: "@agent-native/core",
+        peerDependencies: {
+          sonner: "^2.0.0",
+        },
+        peerDependenciesMeta: {
+          sonner: { optional: true },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({
+        dependencies: {
+          "@agent-native/core": pathToFileURL(fakeCore).href,
+        },
+      }),
+    );
+
+    const deps = _getDefaultOptimizeDeps(tmpDir);
+    expect(deps).not.toContain("sonner");
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(fakeCore, { recursive: true, force: true });
+  });
+
   it("keeps react-router inside the dev SSR graph so dedupe applies", () => {
     const previousCwd = process.cwd();
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "an-vite-ssr-"));

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -136,11 +136,7 @@ function hasCoreDep(pkg: string, cwd: string): boolean {
     const pkgJson = JSON.parse(
       fs.readFileSync(path.join(coreRoot, "package.json"), "utf-8"),
     );
-    return !!(
-      pkgJson.dependencies?.[pkg] ||
-      pkgJson.devDependencies?.[pkg] ||
-      pkgJson.peerDependencies?.[pkg]
-    );
+    return !!(pkgJson.dependencies?.[pkg] || pkgJson.devDependencies?.[pkg]);
   } catch {
     return false;
   }

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -129,6 +129,27 @@ function hasDep(pkg: string, cwd: string): boolean {
   }
 }
 
+function hasCoreDep(pkg: string, cwd: string): boolean {
+  const coreRoot = findCorePackageRoot(cwd);
+  if (!coreRoot) return false;
+  try {
+    const pkgJson = JSON.parse(
+      fs.readFileSync(path.join(coreRoot, "package.json"), "utf-8"),
+    );
+    return !!(
+      pkgJson.dependencies?.[pkg] ||
+      pkgJson.devDependencies?.[pkg] ||
+      pkgJson.peerDependencies?.[pkg]
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasOptimizeDep(pkg: string, cwd: string): boolean {
+  return hasDep(pkg, cwd) || hasCoreDep(pkg, cwd);
+}
+
 /**
  * Build the `resolve.dedupe` list dynamically. Reads core's package.json and
  * collects every peerDependency that the consuming app also declares. This
@@ -361,8 +382,17 @@ function getDefaultOptimizeDeps(cwd: string): string[] {
           },
         ] as Array<{ specifier: string; packageName?: string }>)),
     { specifier: "@libsql/client" },
+    { specifier: "@amplitude/analytics-browser" },
+    { specifier: "@assistant-ui/react" },
+    { specifier: "@excalidraw/excalidraw" },
+    { specifier: "@excalidraw/mermaid-to-excalidraw" },
+    {
+      specifier: "@modelcontextprotocol/ext-apps/app-bridge",
+      packageName: "@modelcontextprotocol/ext-apps",
+    },
     { specifier: "@radix-ui/react-accordion" },
     { specifier: "@radix-ui/react-alert-dialog" },
+    { specifier: "@radix-ui/react-aspect-ratio" },
     { specifier: "@radix-ui/react-avatar" },
     { specifier: "@radix-ui/react-checkbox" },
     { specifier: "@radix-ui/react-collapsible" },
@@ -389,29 +419,124 @@ function getDefaultOptimizeDeps(cwd: string): string[] {
     { specifier: "@radix-ui/react-tooltip" },
     { specifier: "@tanstack/react-query" },
     { specifier: "@tabler/icons-react" },
+    { specifier: "@tiptap/core" },
+    { specifier: "@tiptap/extension-code-block-lowlight" },
+    { specifier: "@tiptap/extension-collaboration" },
+    { specifier: "@tiptap/extension-collaboration-caret" },
+    { specifier: "@tiptap/extension-image" },
+    { specifier: "@tiptap/extension-link" },
+    { specifier: "@tiptap/extension-placeholder" },
+    { specifier: "@tiptap/extension-table" },
+    { specifier: "@tiptap/extension-table-cell" },
+    { specifier: "@tiptap/extension-table-header" },
+    { specifier: "@tiptap/extension-table-row" },
+    { specifier: "@tiptap/extension-task-item" },
+    { specifier: "@tiptap/extension-task-list" },
+    { specifier: "@tiptap/pm/state", packageName: "@tiptap/pm" },
+    { specifier: "@tiptap/react" },
+    { specifier: "@tiptap/starter-kit" },
+    { specifier: "@xterm/addon-fit" },
+    { specifier: "@xterm/addon-web-links" },
+    { specifier: "@xterm/xterm" },
     { specifier: "class-variance-authority" },
     { specifier: "clsx" },
     { specifier: "cmdk" },
+    { specifier: "date-fns" },
     { specifier: "drizzle-orm" },
     { specifier: "drizzle-orm/pg-core", packageName: "drizzle-orm" },
     { specifier: "drizzle-orm/sqlite-core", packageName: "drizzle-orm" },
+    { specifier: "embla-carousel-react" },
     { specifier: "h3" },
+    {
+      specifier: "highlight.js/lib/languages/bash",
+      packageName: "highlight.js",
+    },
+    {
+      specifier: "highlight.js/lib/languages/css",
+      packageName: "highlight.js",
+    },
+    {
+      specifier: "highlight.js/lib/languages/javascript",
+      packageName: "highlight.js",
+    },
+    {
+      specifier: "highlight.js/lib/languages/json",
+      packageName: "highlight.js",
+    },
+    {
+      specifier: "highlight.js/lib/languages/markdown",
+      packageName: "highlight.js",
+    },
+    {
+      specifier: "highlight.js/lib/languages/python",
+      packageName: "highlight.js",
+    },
+    {
+      specifier: "highlight.js/lib/languages/sql",
+      packageName: "highlight.js",
+    },
+    {
+      specifier: "highlight.js/lib/languages/typescript",
+      packageName: "highlight.js",
+    },
+    {
+      specifier: "highlight.js/lib/languages/xml",
+      packageName: "highlight.js",
+    },
+    {
+      specifier: "highlight.js/lib/languages/yaml",
+      packageName: "highlight.js",
+    },
+    { specifier: "input-otp" },
+    { specifier: "lowlight" },
+    { specifier: "mermaid" },
+    { specifier: "nanoid" },
     { specifier: "next-themes" },
     { specifier: "react-hook-form" },
+    { specifier: "react-day-picker" },
+    { specifier: "react-markdown" },
+    { specifier: "react-resizable-panels" },
+    { specifier: "recharts" },
     ...(hasDep("react-router", cwd)
       ? [
           { specifier: "react-router" },
           { specifier: "react-router/dom", packageName: "react-router" },
         ]
       : []),
+    { specifier: "remark-gfm" },
+    { specifier: "roughjs" },
+    { specifier: "shiki/core", packageName: "shiki" },
+    { specifier: "shiki/engine/javascript", packageName: "shiki" },
+    { specifier: "shiki/langs/bash.mjs", packageName: "shiki" },
+    { specifier: "shiki/langs/css.mjs", packageName: "shiki" },
+    { specifier: "shiki/langs/html.mjs", packageName: "shiki" },
+    { specifier: "shiki/langs/javascript.mjs", packageName: "shiki" },
+    { specifier: "shiki/langs/json.mjs", packageName: "shiki" },
+    { specifier: "shiki/langs/jsx.mjs", packageName: "shiki" },
+    { specifier: "shiki/langs/markdown.mjs", packageName: "shiki" },
+    { specifier: "shiki/langs/python.mjs", packageName: "shiki" },
+    { specifier: "shiki/langs/shellscript.mjs", packageName: "shiki" },
+    { specifier: "shiki/langs/sql.mjs", packageName: "shiki" },
+    { specifier: "shiki/langs/tsx.mjs", packageName: "shiki" },
+    { specifier: "shiki/langs/typescript.mjs", packageName: "shiki" },
+    { specifier: "shiki/langs/yaml.mjs", packageName: "shiki" },
+    { specifier: "shiki/themes/github-dark-default.mjs", packageName: "shiki" },
+    {
+      specifier: "shiki/themes/github-light-default.mjs",
+      packageName: "shiki",
+    },
     { specifier: "sonner" },
     { specifier: "tailwind-merge" },
+    { specifier: "tiptap-markdown" },
+    { specifier: "vaul" },
+    { specifier: "y-protocols/awareness", packageName: "y-protocols" },
+    { specifier: "yjs" },
     { specifier: "zod" },
   ];
 
   return entries
     .filter(({ specifier, packageName }) =>
-      hasDep(packageName ?? specifier, cwd),
+      hasOptimizeDep(packageName ?? specifier, cwd),
     )
     .map(({ specifier }) => specifier);
 }
@@ -1663,6 +1788,7 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
 
 export {
   getClientDedupe as _getClientDedupe,
+  getDefaultOptimizeDeps as _getDefaultOptimizeDeps,
   findCorePackageRoot as _findCorePackageRoot,
   getReactRouterAliases as _getReactRouterAliases,
 };

--- a/templates/forms/actions/navigate.spec.ts
+++ b/templates/forms/actions/navigate.spec.ts
@@ -35,9 +35,12 @@ describe("navigate action", () => {
       expect.objectContaining({
         view: "responses",
         formId: "form_1",
+        path: "/forms/form_1/responses",
         _writeId: expect.any(String),
       }),
     );
+    // Single navigation channel: the `navigate` command is the only write.
+    expect(appState.writeAppState).toHaveBeenCalledTimes(1);
   });
 
   it("rejects response navigation without a current or explicit form", async () => {
@@ -64,6 +67,7 @@ describe("navigate action", () => {
         view: "form",
         formId: "CSVP7Bz6dC",
         tab: "edit",
+        path: "/forms/CSVP7Bz6dC?tab=edit",
         _writeId: expect.any(String),
       }),
     );
@@ -92,6 +96,7 @@ describe("navigate action", () => {
       expect.objectContaining({
         view: "responses",
         formId: "form_tab",
+        path: "/forms/form_tab/responses",
       }),
     );
   });

--- a/templates/forms/actions/navigate.ts
+++ b/templates/forms/actions/navigate.ts
@@ -4,6 +4,10 @@ import {
   readAppStateForCurrentTab,
   writeAppStateForCurrentTab,
 } from "./_tab-state.js";
+import {
+  FORMS_NAVIGATION_VIEWS,
+  formsRoutePath,
+} from "../shared/navigation.js";
 
 interface NavigationState {
   formId?: string;
@@ -18,16 +22,7 @@ export default defineAction({
     "Navigate the UI to a view or form. Views: home, forms, form, responses, response-insights, team, extensions, form-preview. Use view=responses with a formId when the user asks to see/open all responses for a form. Use view=form with tab=edit|responses|settings|integrations to open a form builder sub-tab.",
   schema: z.object({
     view: z
-      .enum([
-        "home",
-        "forms",
-        "form",
-        "responses",
-        "response-insights",
-        "team",
-        "extensions",
-        "form-preview",
-      ])
+      .enum(FORMS_NAVIGATION_VIEWS)
       .optional()
       .describe(
         "View to navigate to (home, forms, form, responses, response-insights, team, extensions, form-preview)",
@@ -71,13 +66,23 @@ export default defineAction({
       throw new Error(`${resolvedView} navigation requires a formId.`);
     }
 
+    const path = formsRoutePath({
+      view: resolvedView,
+      formId: resolvedFormId,
+      tab,
+    });
+    if (!path) {
+      throw new Error(`Unsupported navigation target: ${resolvedView}.`);
+    }
+
     const nav: Record<string, string> = {};
     if (resolvedView) nav.view = resolvedView;
     if (resolvedFormId) nav.formId = resolvedFormId;
     if (tab) nav.tab = tab;
+    nav.path = path;
     nav._writeId = writeId();
 
     await writeAppStateForCurrentTab("navigate", nav);
-    return `Navigating to ${resolvedView || "form"}${resolvedFormId ? ` (form: ${resolvedFormId})` : ""}${tab ? ` tab: ${tab}` : ""}`;
+    return `Navigating to ${resolvedView || "form"}${resolvedFormId ? ` (form: ${resolvedFormId})` : ""}${tab ? ` tab: ${tab}` : ""} at ${path}`;
   },
 });

--- a/templates/forms/app/entry.client.tsx
+++ b/templates/forms/app/entry.client.tsx
@@ -16,4 +16,15 @@ if (context) {
   context.basename = routerBasePath;
 }
 
-hydrateRoot(document, <HydratedRouter />);
+// useTransitions={false}: React Router wraps route-swap commits in
+// React.startTransition by default. The agent navigates mid-response, while
+// chat tokens are still streaming — those high-frequency urgent re-renders
+// starve the low-priority transition, so the URL changes immediately
+// (flushSync) but the new page doesn't actually render until the stream ends
+// (10s+). The per-navigation `flushSync` option only covers the initial
+// loading commit, not the async route-swap commit (react-router calls its
+// final completeNavigation without flushSync for any non-hash navigation).
+// Disabling transitions makes every router commit a plain setState that can't
+// be starved, so navigation lands instantly. Forms has no route loaders and no
+// Suspense data-fetching, so there is no pending-UI or fallback flash to lose.
+hydrateRoot(document, <HydratedRouter useTransitions={false} />);

--- a/templates/forms/app/hooks/use-navigation-state.test.ts
+++ b/templates/forms/app/hooks/use-navigation-state.test.ts
@@ -1,10 +1,14 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { formsNavigateCommandPath } from "./use-navigation-state";
 
 describe("formsNavigateCommandPath", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("prefers a command URL path over semantic fallback fields", () => {
     expect(
       formsNavigateCommandPath({
@@ -21,6 +25,45 @@ describe("formsNavigateCommandPath", () => {
         url: "http://localhost:3000/forms/CSVP7Bz6dC?tab=settings",
       }),
     ).toBe("/forms/CSVP7Bz6dC?tab=settings");
+  });
+
+  it("strips the router basename from command paths", () => {
+    vi.stubEnv("VITE_APP_BASE_PATH", "/acme");
+
+    expect(
+      formsNavigateCommandPath({
+        view: "home",
+        path: "/acme/forms/CSVP7Bz6dC?tab=edit",
+      }),
+    ).toBe("/forms/CSVP7Bz6dC?tab=edit");
+  });
+
+  it("strips the router basename from same-origin command URLs", () => {
+    vi.stubEnv("VITE_APP_BASE_PATH", "/acme");
+
+    expect(
+      formsNavigateCommandPath({
+        view: "home",
+        url: "http://localhost:3000/acme/forms/CSVP7Bz6dC?tab=settings",
+      }),
+    ).toBe("/forms/CSVP7Bz6dC?tab=settings");
+  });
+
+  it("normalizes exact and repeated basename command paths", () => {
+    vi.stubEnv("VITE_APP_BASE_PATH", "/acme");
+
+    expect(
+      formsNavigateCommandPath({
+        view: "home",
+        path: "/acme?x=1#top",
+      }),
+    ).toBe("/?x=1#top");
+    expect(
+      formsNavigateCommandPath({
+        view: "home",
+        path: "/acme/acme/forms/CSVP7Bz6dC",
+      }),
+    ).toBe("/forms/CSVP7Bz6dC");
   });
 
   it("falls back to semantic navigation when the URL is not local", () => {

--- a/templates/forms/app/hooks/use-navigation-state.test.ts
+++ b/templates/forms/app/hooks/use-navigation-state.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from "vitest";
+
+import { formsNavigateCommandPath } from "./use-navigation-state";
+
+describe("formsNavigateCommandPath", () => {
+  it("prefers a command URL path over semantic fallback fields", () => {
+    expect(
+      formsNavigateCommandPath({
+        view: "home",
+        path: "/forms/CSVP7Bz6dC?tab=edit",
+      }),
+    ).toBe("/forms/CSVP7Bz6dC?tab=edit");
+  });
+
+  it("accepts same-origin absolute URLs", () => {
+    expect(
+      formsNavigateCommandPath({
+        view: "home",
+        url: "http://localhost:3000/forms/CSVP7Bz6dC?tab=settings",
+      }),
+    ).toBe("/forms/CSVP7Bz6dC?tab=settings");
+  });
+
+  it("falls back to semantic navigation when the URL is not local", () => {
+    expect(
+      formsNavigateCommandPath({
+        view: "form",
+        formId: "CSVP7Bz6dC",
+        tab: "responses",
+        url: "https://example.com/forms/CSVP7Bz6dC",
+      }),
+    ).toBe("/forms/CSVP7Bz6dC?tab=responses");
+  });
+});

--- a/templates/forms/app/hooks/use-navigation-state.ts
+++ b/templates/forms/app/hooks/use-navigation-state.ts
@@ -1,4 +1,4 @@
-import { useAgentRouteState } from "@agent-native/core/client";
+import { appBasePath, useAgentRouteState } from "@agent-native/core/client";
 import { useLocation } from "react-router";
 import { markFormsChatHomeHandoff } from "@/lib/chat-home-handoff";
 import {
@@ -40,11 +40,35 @@ function localPathFromCommandUrl(value: unknown): string | null {
 }
 
 export function formsNavigateCommandPath(cmd: NavigateCommand): string | null {
-  return (
+  const path =
     localPathFromCommandUrl(cmd.path) ??
     localPathFromCommandUrl(cmd.url) ??
-    formsRoutePath(cmd)
-  );
+    formsRoutePath(cmd);
+  return path ? routerPath(path) : null;
+}
+
+function routerPath(path: string): string {
+  const basePath = appBasePath();
+  if (!basePath) return path;
+  let result = path;
+  // React Router is already scoped to the app basename. Strip mounted URLs so
+  // navigate() receives router-local paths and does not duplicate the prefix.
+  for (let i = 0; i < 4; i += 1) {
+    if (result === basePath) return "/";
+    if (result.startsWith(`${basePath}/`)) {
+      result = result.slice(basePath.length) || "/";
+      continue;
+    }
+    if (
+      result.startsWith(`${basePath}?`) ||
+      result.startsWith(`${basePath}#`)
+    ) {
+      result = `/${result.slice(basePath.length)}`;
+      continue;
+    }
+    break;
+  }
+  return result;
 }
 
 export function useNavigationState() {

--- a/templates/forms/app/hooks/use-navigation-state.ts
+++ b/templates/forms/app/hooks/use-navigation-state.ts
@@ -2,10 +2,11 @@ import { useAgentRouteState } from "@agent-native/core/client";
 import { useLocation } from "react-router";
 import { markFormsChatHomeHandoff } from "@/lib/chat-home-handoff";
 import {
-  formBuilderTabSearchParam,
+  formsRoutePath,
   normalizeFormBuilderTab,
   type FormBuilderTab,
 } from "@/lib/form-builder-tabs";
+import { prewarmFormsRoutePath } from "@/lib/route-prewarm";
 import { TAB_ID } from "@/lib/tab-id";
 
 interface NavigationState {
@@ -15,14 +16,41 @@ interface NavigationState {
   tab?: FormBuilderTab;
 }
 
-function formBuilderPath(formId: string, tab: FormBuilderTab = "edit") {
-  return `/forms/${encodeURIComponent(formId)}?tab=${formBuilderTabSearchParam(tab)}`;
+interface NavigateCommand extends NavigationState {
+  path?: string;
+  url?: string;
+}
+
+function localPathFromCommandUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  try {
+    const origin =
+      typeof window !== "undefined"
+        ? window.location.origin
+        : "http://localhost";
+    const url = new URL(trimmed, origin);
+    if (url.origin !== origin) return null;
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return null;
+  }
+}
+
+export function formsNavigateCommandPath(cmd: NavigateCommand): string | null {
+  return (
+    localPathFromCommandUrl(cmd.path) ??
+    localPathFromCommandUrl(cmd.url) ??
+    formsRoutePath(cmd)
+  );
 }
 
 export function useNavigationState() {
   const location = useLocation();
 
-  useAgentRouteState<NavigationState, NavigationState>({
+  useAgentRouteState<NavigationState, NavigateCommand>({
     browserTabId: TAB_ID,
     requestSource: TAB_ID,
     getNavigationState: ({ pathname, searchParams }) => {
@@ -63,27 +91,19 @@ export function useNavigationState() {
       return state;
     },
     getCommandPath: (cmd) => {
-      const tab = normalizeFormBuilderTab(cmd.tab ?? cmd.activeTab);
-      if (!cmd.view && cmd.formId) return formBuilderPath(cmd.formId, tab);
-      if (cmd.view === "home") return "/";
-      if (cmd.view === "form" && cmd.formId)
-        return formBuilderPath(cmd.formId, tab);
-      if (cmd.view === "responses" && cmd.formId)
-        return `/forms/${encodeURIComponent(cmd.formId)}/responses`;
-      if (cmd.view === "response-insights") {
-        return cmd.formId
-          ? `/response-insights?formId=${encodeURIComponent(cmd.formId)}`
-          : "/response-insights";
-      }
-      if (cmd.view === "forms") return "/forms";
-      if (cmd.view === "team") return "/team";
-      if (cmd.view === "extensions") return "/extensions";
-      if (cmd.view === "form-preview") return "/form-preview";
-      return "/forms";
+      return formsNavigateCommandPath(cmd);
     },
     refetchInterval: 500,
-    agentChatViewTransition: true,
+    // The agent fires navigate commands mid-response, while chat tokens are
+    // still streaming. React Router wraps navigate() in React.startTransition
+    // by default, and the high-frequency streaming re-renders starve that
+    // transition — so the URL would not change until the stream finished (and
+    // sometimes not at all). Keep command navigation plain and synchronous:
+    // route correctness matters more than the chat morph here, and view
+    // transitions can leave the old home chat visible while the new route loads.
+    navigateOptions: { flushSync: true, replace: true },
     onNavigate: (_command, path) => {
+      void prewarmFormsRoutePath(path);
       if (location.pathname === "/" && path !== "/") {
         markFormsChatHomeHandoff();
       }

--- a/templates/forms/app/lib/form-builder-tabs.ts
+++ b/templates/forms/app/lib/form-builder-tabs.ts
@@ -1,24 +1,10 @@
-export const FORM_BUILDER_TABS = [
-  "edit",
-  "responses",
-  "settings",
-  "integrations",
-] as const;
-
-export type FormBuilderTab = (typeof FORM_BUILDER_TABS)[number];
-
-const FORM_BUILDER_TAB_SET = new Set<string>(FORM_BUILDER_TABS);
-
-export function normalizeFormBuilderTab(
-  value: string | null | undefined,
-): FormBuilderTab {
-  if (value === "results") return "responses";
-  if (value && FORM_BUILDER_TAB_SET.has(value)) {
-    return value as FormBuilderTab;
-  }
-  return "edit";
-}
-
-export function formBuilderTabSearchParam(tab: FormBuilderTab): string {
-  return tab;
-}
+export {
+  FORM_BUILDER_TABS,
+  formBuilderPath,
+  formBuilderTabSearchParam,
+  formsRoutePath,
+  normalizeFormBuilderTab,
+  type FormBuilderTab,
+  type FormsNavigationTarget,
+  type FormsNavigationView,
+} from "@shared/navigation";

--- a/templates/forms/app/lib/route-prewarm.ts
+++ b/templates/forms/app/lib/route-prewarm.ts
@@ -62,8 +62,23 @@ export function prewarmFormsRoutePath(path: string) {
   if (pathname.startsWith("/extensions")) {
     jobs.push(
       prewarm("layout", () => import("@/routes/_app")),
-      prewarm("extensions", () => import("@/routes/_app.extensions._index")),
+      prewarm("extensions-layout", () => import("@/routes/_app.extensions")),
     );
+    if (/^\/extensions\/[^/]+\/?$/.test(pathname)) {
+      jobs.push(
+        prewarm(
+          "extension-detail",
+          () => import("@/routes/_app.extensions.$id"),
+        ),
+      );
+    } else {
+      jobs.push(
+        prewarm(
+          "extensions-index",
+          () => import("@/routes/_app.extensions._index"),
+        ),
+      );
+    }
   }
 
   return Promise.all(jobs);

--- a/templates/forms/app/lib/route-prewarm.ts
+++ b/templates/forms/app/lib/route-prewarm.ts
@@ -1,0 +1,103 @@
+const prewarmPromises = new Map<string, Promise<unknown>>();
+
+type Importer = () => Promise<unknown>;
+
+function prewarm(key: string, importer: Importer) {
+  let promise = prewarmPromises.get(key);
+  if (!promise) {
+    promise = importer().catch(() => null);
+    prewarmPromises.set(key, promise);
+  }
+  return promise;
+}
+
+function parsePath(path: string): string {
+  try {
+    return new URL(path, "http://localhost").pathname;
+  } catch {
+    return path;
+  }
+}
+
+export function prewarmFormsRoutePath(path: string) {
+  const pathname = parsePath(path);
+  const jobs: Promise<unknown>[] = [];
+
+  if (pathname === "/" || pathname === "/forms") {
+    jobs.push(
+      prewarm("layout", () => import("@/routes/_app")),
+      prewarm("forms-index", () => import("@/routes/_app.forms._index")),
+    );
+  }
+
+  if (/^\/forms\/[^/]+\/responses\/?$/.test(pathname)) {
+    jobs.push(
+      prewarm("layout", () => import("@/routes/_app")),
+      prewarm("responses", () => import("@/routes/_app.forms.$id_.responses")),
+    );
+  } else if (/^\/forms\/[^/]+\/?$/.test(pathname)) {
+    jobs.push(
+      prewarm("layout", () => import("@/routes/_app")),
+      prewarm("form-builder", () => import("@/routes/_app.forms.$id")),
+    );
+  }
+
+  if (pathname === "/response-insights") {
+    jobs.push(
+      prewarm("layout", () => import("@/routes/_app")),
+      prewarm(
+        "response-insights",
+        () => import("@/routes/_app.response-insights"),
+      ),
+    );
+  }
+
+  if (pathname === "/team") {
+    jobs.push(
+      prewarm("layout", () => import("@/routes/_app")),
+      prewarm("team", () => import("@/routes/_app.team")),
+    );
+  }
+
+  if (pathname.startsWith("/extensions")) {
+    jobs.push(
+      prewarm("layout", () => import("@/routes/_app")),
+      prewarm("extensions", () => import("@/routes/_app.extensions._index")),
+    );
+  }
+
+  return Promise.all(jobs);
+}
+
+export function prewarmCommonFormsRoutes() {
+  return Promise.all([
+    prewarmFormsRoutePath("/forms"),
+    prewarmFormsRoutePath("/forms/__route_prewarm__?tab=edit"),
+    prewarmFormsRoutePath("/forms/__route_prewarm__/responses"),
+    prewarmFormsRoutePath("/response-insights"),
+  ]);
+}
+
+export function scheduleFormsRoutePrewarm() {
+  if (typeof window === "undefined") return () => {};
+
+  const run = () => {
+    void prewarmCommonFormsRoutes();
+  };
+
+  const idleWindow = window as Window & {
+    requestIdleCallback?: (
+      callback: IdleRequestCallback,
+      options?: IdleRequestOptions,
+    ) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  };
+
+  if (typeof idleWindow.requestIdleCallback === "function") {
+    const handle = idleWindow.requestIdleCallback(run, { timeout: 1_500 });
+    return () => idleWindow.cancelIdleCallback?.(handle);
+  }
+
+  const handle = window.setTimeout(run, 250);
+  return () => window.clearTimeout(handle);
+}

--- a/templates/forms/app/lib/tab-id.test.ts
+++ b/templates/forms/app/lib/tab-id.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const STORAGE_KEY = "agent-native.forms.tab-id";
+
+async function loadTabId() {
+  vi.resetModules();
+  return import("./tab-id.js");
+}
+
+describe("Forms tab id", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("persists the generated id for reloads in the same browser tab", async () => {
+    const first = await loadTabId();
+    const stored = window.sessionStorage.getItem(STORAGE_KEY);
+
+    expect(first.TAB_ID).toBeTruthy();
+    expect(stored).toBe(first.TAB_ID);
+
+    const second = await loadTabId();
+
+    expect(second.TAB_ID).toBe(first.TAB_ID);
+  });
+
+  it("reuses an existing safe id", async () => {
+    window.sessionStorage.setItem(STORAGE_KEY, "forms-tab-a");
+
+    const { TAB_ID } = await loadTabId();
+
+    expect(TAB_ID).toBe("forms-tab-a");
+  });
+});

--- a/templates/forms/app/lib/tab-id.test.ts
+++ b/templates/forms/app/lib/tab-id.test.ts
@@ -1,20 +1,39 @@
 // @vitest-environment happy-dom
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const STORAGE_KEY = "agent-native.forms.tab-id";
+const originalGetEntriesByType = performance.getEntriesByType;
 
 async function loadTabId() {
   vi.resetModules();
   return import("./tab-id.js");
 }
 
+function stubNavigationType(type: PerformanceNavigationTiming["type"]) {
+  vi.spyOn(performance, "getEntriesByType").mockImplementation((entryType) => {
+    if (entryType !== "navigation") return [];
+    return [{ type } as PerformanceNavigationTiming];
+  });
+}
+
 describe("Forms tab id", () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     window.sessionStorage.clear();
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(performance, "getEntriesByType", {
+      configurable: true,
+      value: originalGetEntriesByType,
+    });
+  });
+
   it("persists the generated id for reloads in the same browser tab", async () => {
+    stubNavigationType("reload");
+
     const first = await loadTabId();
     const stored = window.sessionStorage.getItem(STORAGE_KEY);
 
@@ -26,11 +45,22 @@ describe("Forms tab id", () => {
     expect(second.TAB_ID).toBe(first.TAB_ID);
   });
 
-  it("reuses an existing safe id", async () => {
+  it("reuses an existing safe id on reload", async () => {
+    stubNavigationType("reload");
     window.sessionStorage.setItem(STORAGE_KEY, "forms-tab-a");
 
     const { TAB_ID } = await loadTabId();
 
     expect(TAB_ID).toBe("forms-tab-a");
+  });
+
+  it("generates a fresh id for duplicated tabs with copied session storage", async () => {
+    stubNavigationType("navigate");
+    window.sessionStorage.setItem(STORAGE_KEY, "forms-tab-a");
+
+    const { TAB_ID } = await loadTabId();
+
+    expect(TAB_ID).not.toBe("forms-tab-a");
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe(TAB_ID);
   });
 });

--- a/templates/forms/app/lib/tab-id.ts
+++ b/templates/forms/app/lib/tab-id.ts
@@ -1,1 +1,35 @@
-export const TAB_ID = Math.random().toString(36).slice(2, 10);
+const STORAGE_KEY = "agent-native.forms.tab-id";
+const SAFE_TAB_ID_RE = /^[A-Za-z0-9_-]{1,96}$/;
+
+function randomTabId() {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function readStoredTabId(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const stored = window.sessionStorage.getItem(STORAGE_KEY);
+    return stored && SAFE_TAB_ID_RE.test(stored) ? stored : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredTabId(tabId: string) {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, tabId);
+  } catch {
+    // Storage may be unavailable in privacy modes; the in-memory id still works.
+  }
+}
+
+function createTabId() {
+  const stored = readStoredTabId();
+  if (stored) return stored;
+  const tabId = randomTabId();
+  writeStoredTabId(tabId);
+  return tabId;
+}
+
+export const TAB_ID = createTabId();

--- a/templates/forms/app/lib/tab-id.ts
+++ b/templates/forms/app/lib/tab-id.ts
@@ -2,6 +2,9 @@ const STORAGE_KEY = "agent-native.forms.tab-id";
 const SAFE_TAB_ID_RE = /^[A-Za-z0-9_-]{1,96}$/;
 
 function randomTabId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
   return Math.random().toString(36).slice(2, 10);
 }
 
@@ -24,9 +27,18 @@ function writeStoredTabId(tabId: string) {
   }
 }
 
+function shouldReuseStoredTabId(): boolean {
+  if (typeof performance === "undefined") return true;
+  const navigation = performance.getEntriesByType?.("navigation")?.[0] as
+    | PerformanceNavigationTiming
+    | undefined;
+  if (!navigation) return true;
+  return navigation.type === "reload" || navigation.type === "back_forward";
+}
+
 function createTabId() {
   const stored = readStoredTabId();
-  if (stored) return stored;
+  if (stored && shouldReuseStoredTabId()) return stored;
   const tabId = randomTabId();
   writeStoredTabId(tabId);
   return tabId;

--- a/templates/forms/app/root.tsx
+++ b/templates/forms/app/root.tsx
@@ -10,10 +10,7 @@ import {
 import { useCallback, useEffect, useState } from "react";
 import { useNavigationState } from "@/hooks/use-navigation-state";
 import { markFormsChatHomeHandoff } from "@/lib/chat-home-handoff";
-import {
-  formBuilderTabSearchParam,
-  normalizeFormBuilderTab,
-} from "@/lib/form-builder-tabs";
+import { formsRoutePath } from "@/lib/form-builder-tabs";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTheme } from "next-themes";
 import { IconSun, IconMoon } from "@tabler/icons-react";
@@ -140,23 +137,11 @@ function formsOpenPath(url: URL): string | null {
 
   const view = url.searchParams.get("view");
   const formId = url.searchParams.get("formId") ?? url.searchParams.get("id");
-  if (view === "home") return "/";
-  if (view === "forms") return "/forms";
-  if (view === "form" && formId) {
-    const tab = normalizeFormBuilderTab(
-      url.searchParams.get("tab") ?? url.searchParams.get("activeTab"),
-    );
-    return `/forms/${encodeURIComponent(formId)}?tab=${formBuilderTabSearchParam(tab)}`;
-  }
-  if (view === "responses" && formId) {
-    return `/forms/${encodeURIComponent(formId)}/responses`;
-  }
-  if (view === "response-insights") {
-    return formId
-      ? `/response-insights?formId=${encodeURIComponent(formId)}`
-      : "/response-insights";
-  }
-  return null;
+  return formsRoutePath({
+    view,
+    formId,
+    tab: url.searchParams.get("tab") ?? url.searchParams.get("activeTab"),
+  });
 }
 
 function OpenLinkInterceptor() {

--- a/templates/forms/app/routes/_index.tsx
+++ b/templates/forms/app/routes/_index.tsx
@@ -20,6 +20,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { markFormsChatHomeHandoff } from "@/lib/chat-home-handoff";
+import { scheduleFormsRoutePrewarm } from "@/lib/route-prewarm";
 import { TAB_ID } from "@/lib/tab-id";
 
 export function meta() {
@@ -42,9 +43,12 @@ export default function Index() {
       if (detail?.isRunning === true) markFormsChatHomeHandoff();
     }
 
+    const cancelRoutePrewarm = scheduleFormsRoutePrewarm();
     window.addEventListener("agentNative.chatRunning", handleChatRunning);
-    return () =>
+    return () => {
+      cancelRoutePrewarm();
       window.removeEventListener("agentNative.chatRunning", handleChatRunning);
+    };
   }, []);
 
   function openForms() {

--- a/templates/forms/shared/navigation.ts
+++ b/templates/forms/shared/navigation.ts
@@ -1,0 +1,82 @@
+export const FORM_BUILDER_TABS = [
+  "edit",
+  "responses",
+  "settings",
+  "integrations",
+] as const;
+
+export type FormBuilderTab = (typeof FORM_BUILDER_TABS)[number];
+
+export const FORMS_NAVIGATION_VIEWS = [
+  "home",
+  "forms",
+  "form",
+  "responses",
+  "response-insights",
+  "team",
+  "extensions",
+  "form-preview",
+] as const;
+
+export type FormsNavigationView = (typeof FORMS_NAVIGATION_VIEWS)[number];
+
+export interface FormsNavigationTarget {
+  view?: FormsNavigationView | string | null;
+  formId?: string | null;
+  tab?: string | null;
+  activeTab?: string | null;
+}
+
+const FORM_BUILDER_TAB_SET = new Set<string>(FORM_BUILDER_TABS);
+
+export function normalizeFormBuilderTab(
+  value: string | null | undefined,
+): FormBuilderTab {
+  if (value === "results") return "responses";
+  if (value && FORM_BUILDER_TAB_SET.has(value)) {
+    return value as FormBuilderTab;
+  }
+  return "edit";
+}
+
+export function formBuilderTabSearchParam(tab: FormBuilderTab): string {
+  return tab;
+}
+
+export function formBuilderPath(
+  formId: string,
+  tab: string | null | undefined = "edit",
+): string {
+  const normalizedTab = normalizeFormBuilderTab(tab);
+  return `/forms/${encodeURIComponent(formId)}?tab=${formBuilderTabSearchParam(normalizedTab)}`;
+}
+
+export function formsRoutePath(target: FormsNavigationTarget): string | null {
+  const formId = target.formId ?? undefined;
+  const tab = target.tab ?? target.activeTab;
+
+  if (!target.view && formId) return formBuilderPath(formId, tab);
+
+  switch (target.view) {
+    case "home":
+      return "/";
+    case "forms":
+      return "/forms";
+    case "form":
+      return formId ? formBuilderPath(formId, tab) : null;
+    case "responses":
+      return formId ? `/forms/${encodeURIComponent(formId)}/responses` : null;
+    case "response-insights":
+      return formId
+        ? `/response-insights?formId=${encodeURIComponent(formId)}`
+        : "/response-insights";
+    case "team":
+      return "/team";
+    case "extensions":
+      return "/extensions";
+    case "form-preview":
+      return "/form-preview";
+    default:
+      return null;
+  }
+}

--- a/templates/forms/vite.config.ts
+++ b/templates/forms/vite.config.ts
@@ -3,6 +3,20 @@ import { defineConfig } from "@agent-native/core/vite";
 
 export default defineConfig({
   plugins: [reactRouter()],
+  optimizeDeps: {
+    include: [
+      "@hookform/resolvers",
+      "@radix-ui/react-aspect-ratio",
+      "date-fns",
+      "embla-carousel-react",
+      "input-otp",
+      "nanoid",
+      "react-day-picker",
+      "react-resizable-panels",
+      "recharts",
+      "vaul",
+    ],
+  },
   // shiki only runs in AssistantChat's useEffect — keep it out of the
   // CF Pages Functions bundle (25 MiB limit).
   ssrStubs: ["shiki"],

--- a/templates/plan/actions/navigate.ts
+++ b/templates/plan/actions/navigate.ts
@@ -36,17 +36,22 @@ export default defineAction({
       .string()
       .optional()
       .describe("Optional repo-relative folder path for a local MDX plan"),
+    path: z
+      .string()
+      .optional()
+      .describe("Optional same-origin URL path to navigate to directly"),
   }),
   http: false,
   run: async (args) => {
-    if (!args.view && !args.planId && !args.localPlanSlug) {
-      return "Error: At least --view, --planId, or --localPlanSlug is required.";
+    if (!args.view && !args.planId && !args.localPlanSlug && !args.path) {
+      return "Error: At least --view, --planId, --localPlanSlug, or --path is required.";
     }
     const nav: Record<string, string> = {};
     nav.view = args.view ?? "plan";
     if (args.planId) nav.planId = args.planId;
     if (args.localPlanSlug) nav.localPlanSlug = args.localPlanSlug;
     if (args.localPlanPath) nav.localPlanPath = args.localPlanPath;
+    if (args.path) nav.path = args.path;
     nav._writeId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await writeAppState("navigate", nav);
     return `Navigating to ${nav.view}${
@@ -55,6 +60,6 @@ export default defineAction({
         : args.planId
           ? ` (${args.planId})`
           : ""
-    }`;
+    }${args.path ? ` at ${args.path}` : ""}`;
   },
 });

--- a/templates/plan/app/entry.client.tsx
+++ b/templates/plan/app/entry.client.tsx
@@ -16,4 +16,4 @@ if (context) {
   context.basename = routerBasePath;
 }
 
-hydrateRoot(document, <HydratedRouter />);
+hydrateRoot(document, <HydratedRouter useTransitions={false} />);

--- a/templates/plan/app/hooks/use-navigation-state.test.ts
+++ b/templates/plan/app/hooks/use-navigation-state.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { planNavigateCommandPath } from "./use-navigation-state";
+
+describe("planNavigateCommandPath", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("prefers a command URL path over semantic fallback fields", () => {
+    expect(
+      planNavigateCommandPath({
+        view: "plans",
+        path: "/plans/plan-123",
+      }),
+    ).toBe("/plans/plan-123");
+  });
+
+  it("strips the router basename from same-origin command URLs", () => {
+    vi.stubEnv("VITE_APP_BASE_PATH", "/acme");
+
+    expect(
+      planNavigateCommandPath({
+        view: "plans",
+        path: "http://localhost:3000/acme/plans/plan-123?tab=diff",
+      }),
+    ).toBe("/plans/plan-123?tab=diff");
+  });
+
+  it("normalizes exact and repeated basename command paths", () => {
+    vi.stubEnv("VITE_APP_BASE_PATH", "/acme");
+
+    expect(
+      planNavigateCommandPath({
+        view: "plans",
+        path: "/acme?x=1#top",
+      }),
+    ).toBe("/?x=1#top");
+    expect(
+      planNavigateCommandPath({
+        view: "plans",
+        path: "/acme/acme/recaps/recap-123",
+      }),
+    ).toBe("/recaps/recap-123");
+  });
+
+  it("falls back to semantic navigation when the URL is not local", () => {
+    expect(
+      planNavigateCommandPath({
+        view: "plan",
+        planId: "plan-123",
+        path: "https://example.com/plans/plan-123",
+      }),
+    ).toBe("/plans/plan-123");
+  });
+});

--- a/templates/plan/app/hooks/use-navigation-state.ts
+++ b/templates/plan/app/hooks/use-navigation-state.ts
@@ -1,12 +1,9 @@
 import { useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  agentNativePath,
-  appBasePath,
-  navigateWithAgentChatViewTransition,
-} from "@agent-native/core/client";
+import { agentNativePath, appBasePath } from "@agent-native/core/client";
 import { markPlanChatHomeHandoff } from "@/lib/chat-home-handoff";
+import { prewarmPlanRoutePath } from "@/lib/route-prewarm";
 import { TAB_ID } from "@/lib/tab-id";
 
 export interface NavigationState {
@@ -14,6 +11,7 @@ export interface NavigationState {
   planId?: string;
   localPlanSlug?: string;
   localPlanPath?: string;
+  path?: string;
   _writeId?: string;
 }
 
@@ -102,8 +100,9 @@ export function useNavigationState() {
     // Delete the one-shot command AFTER reading it.
     deleteCommand();
     const path = routerPath(pathForCommand(cmd));
+    void prewarmPlanRoutePath(path);
     if (path !== "/") markPlanChatHomeHandoff();
-    navigateWithAgentChatViewTransition(navigate, path);
+    navigate(path, { replace: true, flushSync: true });
     qc.setQueryData(["navigate-command"], null);
   }, [navCommand, navigate, qc]);
 }
@@ -134,6 +133,8 @@ function viewForPath(pathname: string): string {
 }
 
 function pathForCommand(command: NavigationState): string {
+  const commandPath = localPathFromCommandPath(command.path);
+  if (commandPath) return commandPath;
   if (command.localPlanSlug) {
     const path = `/local-plans/${encodeURIComponent(command.localPlanSlug)}`;
     if (!command.localPlanPath) return path;
@@ -145,6 +146,24 @@ function pathForCommand(command: NavigationState): string {
     return `/plans/${encodeURIComponent(command.planId)}`;
   }
   return pathForView(command.view);
+}
+
+function localPathFromCommandPath(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  try {
+    const origin =
+      typeof window !== "undefined"
+        ? window.location.origin
+        : "http://localhost";
+    const url = new URL(trimmed, origin);
+    if (url.origin !== origin) return null;
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return null;
+  }
 }
 
 function pathForView(view?: string): string {

--- a/templates/plan/app/hooks/use-navigation-state.ts
+++ b/templates/plan/app/hooks/use-navigation-state.ts
@@ -99,7 +99,7 @@ export function useNavigationState() {
 
     // Delete the one-shot command AFTER reading it.
     deleteCommand();
-    const path = routerPath(pathForCommand(cmd));
+    const path = planNavigateCommandPath(cmd);
     void prewarmPlanRoutePath(path);
     if (path !== "/") markPlanChatHomeHandoff();
     navigate(path, { replace: true, flushSync: true });
@@ -130,6 +130,10 @@ function viewForPath(pathname: string): string {
   if (pathname.startsWith("/extensions")) return "extensions";
   if (pathname.startsWith("/team")) return "team";
   return "plans";
+}
+
+export function planNavigateCommandPath(command: NavigationState): string {
+  return routerPath(pathForCommand(command));
 }
 
 function pathForCommand(command: NavigationState): string {
@@ -185,9 +189,23 @@ function pathForView(view?: string): string {
 function routerPath(path: string): string {
   const basePath = appBasePath();
   if (!basePath) return path;
-  if (path === basePath) return "/";
-  if (path.startsWith(`${basePath}/`)) {
-    return path.slice(basePath.length) || "/";
+  let result = path;
+  // React Router is already scoped to the app basename. Strip mounted URLs so
+  // navigate() receives router-local paths and does not duplicate the prefix.
+  for (let i = 0; i < 4; i += 1) {
+    if (result === basePath) return "/";
+    if (result.startsWith(`${basePath}/`)) {
+      result = result.slice(basePath.length) || "/";
+      continue;
+    }
+    if (
+      result.startsWith(`${basePath}?`) ||
+      result.startsWith(`${basePath}#`)
+    ) {
+      result = `/${result.slice(basePath.length)}`;
+      continue;
+    }
+    break;
   }
-  return path;
+  return result;
 }

--- a/templates/plan/app/lib/route-prewarm.ts
+++ b/templates/plan/app/lib/route-prewarm.ts
@@ -43,7 +43,8 @@ export function prewarmPlanRoutePath(path: string) {
 
   if (pathname.startsWith("/extensions")) {
     jobs.push(
-      prewarm("extensions", () => import("@/routes/extensions._index")),
+      prewarm("extensions-layout", () => import("@/routes/extensions")),
+      prewarm("extensions-index", () => import("@/routes/extensions._index")),
     );
   }
 

--- a/templates/plan/app/lib/route-prewarm.ts
+++ b/templates/plan/app/lib/route-prewarm.ts
@@ -1,0 +1,89 @@
+const prewarmPromises = new Map<string, Promise<unknown>>();
+
+type Importer = () => Promise<unknown>;
+
+function prewarm(key: string, importer: Importer) {
+  let promise = prewarmPromises.get(key);
+  if (!promise) {
+    promise = importer().catch(() => null);
+    prewarmPromises.set(key, promise);
+  }
+  return promise;
+}
+
+function parsePath(path: string): string {
+  try {
+    return new URL(path, "http://localhost").pathname;
+  } catch {
+    return path;
+  }
+}
+
+export function prewarmPlanRoutePath(path: string) {
+  const pathname = parsePath(path);
+  const jobs: Promise<unknown>[] = [];
+
+  if (pathname === "/plans") {
+    jobs.push(prewarm("plans", () => import("@/routes/plans")));
+  } else if (/^\/plans\/[^/]+\/?$/.test(pathname)) {
+    jobs.push(prewarm("plan-detail", () => import("@/routes/plans.$id")));
+  }
+
+  if (pathname === "/recaps") {
+    jobs.push(prewarm("recaps", () => import("@/routes/recaps")));
+  } else if (/^\/recaps\/[^/]+\/?$/.test(pathname)) {
+    jobs.push(prewarm("recap-detail", () => import("@/routes/recaps.$id")));
+  }
+
+  if (/^\/local-plans\/[^/]+\/?$/.test(pathname)) {
+    jobs.push(
+      prewarm("local-plan-detail", () => import("@/routes/local-plans.$slug")),
+    );
+  }
+
+  if (pathname.startsWith("/extensions")) {
+    jobs.push(
+      prewarm("extensions", () => import("@/routes/extensions._index")),
+    );
+  }
+
+  if (pathname === "/team") {
+    jobs.push(prewarm("team", () => import("@/routes/team")));
+  }
+
+  return Promise.all(jobs);
+}
+
+export function prewarmCommonPlanRoutes() {
+  return Promise.all([
+    prewarmPlanRoutePath("/plans"),
+    prewarmPlanRoutePath("/plans/__route_prewarm__"),
+    prewarmPlanRoutePath("/recaps"),
+    prewarmPlanRoutePath("/recaps/__route_prewarm__"),
+    prewarmPlanRoutePath("/local-plans/__route_prewarm__"),
+  ]);
+}
+
+export function schedulePlanRoutePrewarm() {
+  if (typeof window === "undefined") return () => {};
+
+  const run = () => {
+    void prewarmCommonPlanRoutes();
+  };
+
+  const idleWindow = window as Window & {
+    requestIdleCallback?: (
+      callback: IdleRequestCallback,
+      options?: IdleRequestOptions,
+    ) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  };
+
+  if (typeof idleWindow.requestIdleCallback === "function") {
+    const handle = idleWindow.requestIdleCallback(run, { timeout: 1_500 });
+    return () => idleWindow.cancelIdleCallback?.(handle);
+  }
+
+  const handle = window.setTimeout(run, 250);
+  return () => window.clearTimeout(handle);
+}

--- a/templates/plan/app/pages/PlanChatPage.tsx
+++ b/templates/plan/app/pages/PlanChatPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { AgentChatHome } from "@agent-native/core/client";
 import { markPlanChatHomeHandoff } from "@/lib/chat-home-handoff";
+import { schedulePlanRoutePrewarm } from "@/lib/route-prewarm";
 
 const PLAN_CHAT_SUGGESTIONS = [
   "What shipped in the last week?",
@@ -16,9 +17,12 @@ export function PlanChatPage() {
       if (detail?.isRunning === true) markPlanChatHomeHandoff();
     }
 
+    const cancelRoutePrewarm = schedulePlanRoutePrewarm();
     window.addEventListener("agentNative.chatRunning", handleChatRunning);
-    return () =>
+    return () => {
+      cancelRoutePrewarm();
       window.removeEventListener("agentNative.chatRunning", handleChatRunning);
+    };
   }, []);
 
   return (

--- a/templates/plan/app/pages/PlansPage.comments.test.ts
+++ b/templates/plan/app/pages/PlansPage.comments.test.ts
@@ -21,6 +21,7 @@ import {
   shouldRetryLocalPlanBridgeBundle,
   shouldShowPlanLoadError,
   shouldKeepCommentPopoverOpenForTarget,
+  resolvePlanOrgAccessPrompt,
 } from "./PlansPage";
 import { planBundleQueryKey } from "@/hooks/use-plans";
 import type { PlanBundle } from "@shared/types";
@@ -974,6 +975,101 @@ describe("plan comment thread UI model", () => {
     expect(shouldShowPlanLoadError({ ...base, hasSelectedId: false })).toBe(
       false,
     );
+  });
+
+  it("prefers accepting an existing org invite on the plan access wall", () => {
+    const prompt = resolvePlanOrgAccessPrompt({
+      accessStatus: {
+        exists: true,
+        hasAccess: false,
+        signedIn: true,
+        viewerEmail: "sami@builder.io",
+        viewerName: "Sami",
+        role: null,
+        orgId: "org_builder",
+        orgName: "Builder.io",
+        visibility: "org",
+      },
+      org: {
+        email: "sami@builder.io",
+        pendingInvitations: [
+          {
+            id: "invite_1",
+            orgId: "org_builder",
+            orgName: "Builder.io",
+            invitedBy: "Milos",
+          },
+        ],
+        domainMatches: [{ orgId: "org_builder", orgName: "Builder.io" }],
+      },
+    });
+
+    expect(prompt).toMatchObject({
+      kind: "invitation",
+      invitationId: "invite_1",
+      buttonLabel: "Accept invite",
+      message:
+        "You already have an invite to Builder.io. Accept it to open this plan.",
+    });
+  });
+
+  it("offers domain join for org plan access when no invite is pending", () => {
+    const prompt = resolvePlanOrgAccessPrompt({
+      accessStatus: {
+        exists: true,
+        hasAccess: false,
+        signedIn: true,
+        viewerEmail: "sami@builder.io",
+        viewerName: "Sami",
+        role: null,
+        orgId: "org_builder",
+        orgName: "Builder.io",
+        visibility: "org",
+      },
+      org: {
+        email: "sami@builder.io",
+        pendingInvitations: [],
+        domainMatches: [{ orgId: "org_builder", orgName: "Builder.io" }],
+      },
+    });
+
+    expect(prompt).toMatchObject({
+      kind: "domain",
+      organizationId: "org_builder",
+      buttonLabel: "Join Builder.io",
+      message:
+        "Your @builder.io email can join Builder.io. Join it to open this plan.",
+    });
+  });
+
+  it("keeps private plan denials on the existing request-access path", () => {
+    const prompt = resolvePlanOrgAccessPrompt({
+      accessStatus: {
+        exists: true,
+        hasAccess: false,
+        signedIn: true,
+        viewerEmail: "sami@builder.io",
+        viewerName: "Sami",
+        role: null,
+        orgId: null,
+        orgName: null,
+        visibility: "private",
+      },
+      org: {
+        email: "sami@builder.io",
+        pendingInvitations: [
+          {
+            id: "invite_1",
+            orgId: "org_builder",
+            orgName: "Builder.io",
+            invitedBy: "Milos",
+          },
+        ],
+        domainMatches: [{ orgId: "org_builder", orgName: "Builder.io" }],
+      },
+    });
+
+    expect(prompt).toBeNull();
   });
 
   it("detects mention queries when Chrome splits typed content into text nodes", () => {

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -70,6 +70,14 @@ import {
   type AgentSidebarStateChangeDetail,
   type RichMarkdownCollabUser,
 } from "@agent-native/core/client";
+import {
+  useAcceptInvitation,
+  useJoinByDomain,
+  useOrg,
+  type OrgInfo,
+  type OrgInvitationSummary,
+  type DomainMatchOrg,
+} from "@agent-native/core/client/org";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -590,6 +598,75 @@ export function shouldShowPlanLoadError(input: {
   if (input.planQueryPaused || input.accessStatusPaused) return true;
   if (!input.accessStatusPending && input.accessDenied) return true;
   return false;
+}
+
+export type PlanOrgAccessPrompt =
+  | {
+      kind: "invitation";
+      organizationId: string;
+      organizationName: string;
+      invitationId: string;
+      invitedBy: string;
+      buttonLabel: string;
+      message: string;
+    }
+  | {
+      kind: "domain";
+      organizationId: string;
+      organizationName: string;
+      domain: string | null;
+      buttonLabel: string;
+      message: string;
+    };
+
+export function resolvePlanOrgAccessPrompt(input: {
+  accessStatus?: PlanAccessStatusResponse | null;
+  org?: Pick<OrgInfo, "email" | "pendingInvitations" | "domainMatches"> | null;
+}): PlanOrgAccessPrompt | null {
+  const orgId = input.accessStatus?.orgId;
+  const orgName = input.accessStatus?.orgName?.trim();
+  if (
+    !orgId ||
+    !orgName ||
+    input.accessStatus?.visibility !== "org" ||
+    input.accessStatus.hasAccess
+  ) {
+    return null;
+  }
+
+  const pendingInvitation = input.org?.pendingInvitations?.find(
+    (inv: OrgInvitationSummary) => inv.orgId === orgId,
+  );
+  if (pendingInvitation) {
+    return {
+      kind: "invitation",
+      organizationId: orgId,
+      organizationName: orgName,
+      invitationId: pendingInvitation.id,
+      invitedBy: pendingInvitation.invitedBy,
+      buttonLabel: "Accept invite",
+      message: `You already have an invite to ${orgName}. Accept it to open this plan.`,
+    };
+  }
+
+  const domainMatch = input.org?.domainMatches?.find(
+    (match: DomainMatchOrg) => match.orgId === orgId,
+  );
+  if (domainMatch) {
+    const domain = input.org?.email?.split("@")[1]?.toLowerCase() || null;
+    return {
+      kind: "domain",
+      organizationId: orgId,
+      organizationName: orgName,
+      domain,
+      buttonLabel: `Join ${orgName}`,
+      message: domain
+        ? `Your @${domain} email can join ${orgName}. Join it to open this plan.`
+        : `You can join ${orgName} to open this plan.`,
+    };
+  }
+
+  return null;
 }
 
 function localPlanRoutePath(slug: string, repoPath?: string | null): string {
@@ -7073,6 +7150,10 @@ function PlanLoadError({
     orgName && accessStatus?.visibility === "org"
       ? `This plan belongs to ${orgName}. You need to be a member of ${orgName} to view it.`
       : null;
+  const orgAccessTitle =
+    orgName && accessStatus?.visibility === "org"
+      ? `Join ${orgName} to view this plan`
+      : null;
 
   const returnPath = () =>
     window.location.pathname + window.location.search + window.location.hash;
@@ -7155,7 +7236,7 @@ function PlanLoadError({
     ? "Plan not found"
     : showAccessHelp
       ? signedIn
-        ? "Request access to this plan"
+        ? (orgAccessTitle ?? "Request access to this plan")
         : "Sign in to view this plan"
       : "Plan did not load";
   const body = planMissing
@@ -7215,18 +7296,13 @@ function PlanLoadError({
             {showAccessHelp ? (
               <>
                 {signedIn ? (
-                  <Button
-                    type="button"
-                    onClick={onRequestAccess}
-                    disabled={requestAccessPending || accessRequestSent}
-                  >
-                    {requestAccessPending ? (
-                      <IconLoader2 className="size-4 animate-spin" />
-                    ) : (
-                      <IconUserPlus className="size-4" />
-                    )}
-                    {accessRequestSent ? "Request sent" : "Request access"}
-                  </Button>
+                  <SignedInPlanAccessActions
+                    accessStatus={accessStatus}
+                    onRequestAccess={onRequestAccess}
+                    onAccessResolved={onRetry}
+                    requestAccessPending={requestAccessPending}
+                    accessRequestSent={accessRequestSent}
+                  />
                 ) : (
                   <Button
                     type="button"
@@ -7369,6 +7445,87 @@ function PlanLoadError({
         Retry
       </Button>
     </div>
+  );
+}
+
+function SignedInPlanAccessActions({
+  accessStatus,
+  onRequestAccess,
+  onAccessResolved,
+  requestAccessPending,
+  accessRequestSent,
+}: {
+  accessStatus?: PlanAccessStatusResponse | null;
+  onRequestAccess: () => void;
+  onAccessResolved: () => void;
+  requestAccessPending?: boolean;
+  accessRequestSent?: boolean;
+}) {
+  const { data: org } = useOrg();
+  const acceptInvitation = useAcceptInvitation();
+  const joinByDomain = useJoinByDomain();
+  const orgAccessPrompt = resolvePlanOrgAccessPrompt({ accessStatus, org });
+  const orgAccessPending = acceptInvitation.isPending || joinByDomain.isPending;
+  const orgAccessError = acceptInvitation.error || joinByDomain.error;
+
+  const handleOrgAccess = () => {
+    if (!orgAccessPrompt) {
+      onRequestAccess();
+      return;
+    }
+
+    const onSuccess = () => {
+      toast.success(
+        `Joined ${orgAccessPrompt.organizationName}. Opening plan…`,
+      );
+      onAccessResolved();
+    };
+
+    if (orgAccessPrompt.kind === "invitation") {
+      acceptInvitation.mutate(orgAccessPrompt.invitationId, { onSuccess });
+      return;
+    }
+
+    joinByDomain.mutate(orgAccessPrompt.organizationId, { onSuccess });
+  };
+
+  const pending = orgAccessPrompt ? orgAccessPending : requestAccessPending;
+  const disabled = orgAccessPrompt
+    ? orgAccessPending
+    : requestAccessPending || accessRequestSent;
+  const label = orgAccessPrompt
+    ? orgAccessPending
+      ? orgAccessPrompt.kind === "invitation"
+        ? "Accepting invite"
+        : "Joining organization"
+      : orgAccessPrompt.buttonLabel
+    : accessRequestSent
+      ? "Request sent"
+      : "Request access";
+
+  return (
+    <>
+      {orgAccessPrompt ? (
+        <div className="rounded-md border border-border bg-muted/35 px-3 py-2 text-sm leading-5 text-muted-foreground">
+          {orgAccessPrompt.message}
+        </div>
+      ) : null}
+      <Button type="button" onClick={handleOrgAccess} disabled={disabled}>
+        {pending ? (
+          <IconLoader2 className="size-4 animate-spin" />
+        ) : orgAccessPrompt?.kind === "domain" ? (
+          <IconAt className="size-4" />
+        ) : (
+          <IconUserPlus className="size-4" />
+        )}
+        {label}
+      </Button>
+      {orgAccessError ? (
+        <p className="text-xs leading-5 text-destructive">
+          {(orgAccessError as Error).message}
+        </p>
+      ) : null}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- make Forms and Plan agent navigation prefer explicit URL paths, commit router moves synchronously, and prewarm chat-first destination routes
- pre-optimize core client dependencies in monorepo dev so chat-heavy templates avoid Vite optimized-dependency reloads
- improve queued chat follow-up handling through transient active-run conflicts and keep skill/docs guidance in sync

## Validation
- pnpm --filter forms test
- pnpm --filter forms typecheck
- pnpm --filter plan test
- pnpm --filter plan typecheck
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core exec vitest --run src/client/agent-chat-adapter.spec.ts src/vite/client.spec.ts src/client/route-state.spec.tsx
- pnpm guards
- pnpm run prep (format/typecheck/test passed; first run guard failed on skill mirror sync, then sync + guards passed)
