### PR TITLE
fix(plan): keep code-like blocks LTR in RTL plans, add Vazirmatn font

### DIFF
--- a/.changeset/rtl-code-blocks-ltr.md
+++ b/.changeset/rtl-code-blocks-ltr.md
@@ -1,0 +1,10 @@
+---
+"@agent-native/core": patch
+---
+
+Keep code-like blocks left-to-right inside RTL plans. Code, code-tabs, diff,
+file-tree, annotated-code, API endpoint, OpenAPI spec, JSON explorer,
+data-model, schema-editor, diagram, mermaid, and wireframe blocks now pin their
+outermost element to `dir="ltr"` (via a shared `ltrCodeBlockProps` helper) so
+they no longer inherit a Persian/Arabic plan document's RTL direction and render
+reversed. Prose, rich-text, and callout blocks intentionally stay RTL.

--- a/packages/core/src/client/blocks/SchemaBlockEditor.tsx
+++ b/packages/core/src/client/blocks/SchemaBlockEditor.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import type { ZodType } from "zod";
 import { IconPlus, IconTrash } from "@tabler/icons-react";
 import { cn } from "../utils.js";
+import { ltrCodeBlockProps } from "./code-block-direction.js";
 import type { BlockRenderContext } from "./types.js";
 import { introspect, type FieldDescriptor } from "./schema-form/introspect.js";
 
@@ -49,7 +50,10 @@ export function SchemaBlockEditor<T>({
   const optional = fields.filter((field) => field.optional);
 
   return (
-    <div className="an-schema-block-editor flex flex-col gap-3">
+    <div
+      {...ltrCodeBlockProps}
+      className="an-schema-block-editor flex flex-col gap-3"
+    >
       {required.map((field) => (
         <FieldControl
           key={field.key}

--- a/packages/core/src/client/blocks/code-block-direction.ts
+++ b/packages/core/src/client/blocks/code-block-direction.ts
@@ -1,0 +1,21 @@
+import type { CSSProperties } from "react";
+
+/**
+ * Props that pin a block to left-to-right with left-aligned text. Spread onto
+ * the OUTERMOST element of a code-like read block — code, diffs, file trees,
+ * annotated code, API endpoints, JSON / data-model / schema editors, diagrams,
+ * mermaid, and wireframes.
+ *
+ * These surfaces are inherently LTR: glyph order, line numbers, gutters, and
+ * ASCII layout only read correctly left-to-right. When a plan document is
+ * Persian/Arabic the renderer sets `dir="rtl"` on the document shell so prose
+ * flows RTL; without this, these blocks would inherit that and render reversed.
+ * Prose, rich-text, and callout blocks intentionally omit it so they stay RTL.
+ *
+ * `textAlign: "left"` overrides any inherited RTL text-alignment; with
+ * `dir="ltr"` it is equivalent to `text-align: start`.
+ */
+export const ltrCodeBlockProps: { dir: "ltr"; style: CSSProperties } = {
+  dir: "ltr",
+  style: { textAlign: "left" },
+};

--- a/packages/core/src/client/blocks/library/AnnotatedCodeBlock.tsx
+++ b/packages/core/src/client/blocks/library/AnnotatedCodeBlock.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import { IconCode, IconPlus, IconTrash } from "@tabler/icons-react";
 import { cn } from "../../utils.js";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 import type { BlockEditProps, BlockReadProps } from "../types.js";
 import type {
   AnnotatedCodeAnnotation,
@@ -427,7 +428,11 @@ function AnnotatedCodeRead({
   );
 
   return (
-    <section className="plan-block relative" data-block-id={blockId}>
+    <section
+      {...ltrCodeBlockProps}
+      className="plan-block relative"
+      data-block-id={blockId}
+    >
       {title && <div className="plan-block-label">{title}</div>}
       {/* The code keeps its full width — no persistent annotation column. Notes
           live in a visually-hidden stack (a11y + tests) and surface ONE at a

--- a/packages/core/src/client/blocks/library/ApiEndpointBlock.tsx
+++ b/packages/core/src/client/blocks/library/ApiEndpointBlock.tsx
@@ -7,6 +7,7 @@ import {
   IconTrash,
 } from "@tabler/icons-react";
 import { cn } from "../../utils.js";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 import type { BlockEditProps, BlockReadProps } from "../types.js";
 import type {
   ApiEndpointChange,
@@ -422,6 +423,7 @@ export function ApiEndpointRead({
     // full-width cards. `an-api-endpoint-card` is the flush-able card surface
     // those rules round/merge at the run's edges.
     <section
+      {...ltrCodeBlockProps}
       className="plan-block"
       data-block-id={blockId}
       data-block-type="api-endpoint"

--- a/packages/core/src/client/blocks/library/DataModelBlock.tsx
+++ b/packages/core/src/client/blocks/library/DataModelBlock.tsx
@@ -9,6 +9,7 @@ import {
   IconTrash,
 } from "@tabler/icons-react";
 import { cn } from "../../utils.js";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 import type { BlockEditProps, BlockReadProps } from "../types.js";
 import type {
   DataModelChange,
@@ -226,7 +227,11 @@ export function DataModelRead({
   );
 
   return (
-    <section className="plan-block" data-block-id={blockId}>
+    <section
+      {...ltrCodeBlockProps}
+      className="plan-block"
+      data-block-id={blockId}
+    >
       {title && <div className="plan-block-label">{title}</div>}
 
       <div className="flex flex-col gap-3">

--- a/packages/core/src/client/blocks/library/DiffBlock.tsx
+++ b/packages/core/src/client/blocks/library/DiffBlock.tsx
@@ -18,6 +18,7 @@ import {
 } from "@tabler/icons-react";
 import { common, createLowlight } from "lowlight";
 import { cn } from "../../utils.js";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 import type {
   BlockEditProps,
   BlockReadProps,
@@ -968,6 +969,7 @@ function DiffRead({
 
   return (
     <section
+      {...ltrCodeBlockProps}
       ref={containerRef}
       className="relative plan-block group/diff-block"
       data-block-id={blockId}

--- a/packages/core/src/client/blocks/library/FileTreeBlock.tsx
+++ b/packages/core/src/client/blocks/library/FileTreeBlock.tsx
@@ -8,6 +8,7 @@ import {
   IconTrash,
 } from "@tabler/icons-react";
 import { cn } from "../../utils.js";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 import type { BlockEditProps, BlockReadProps } from "../types.js";
 import type {
   FileTreeChange,
@@ -472,6 +473,7 @@ export function FileTreeRead({
 
   return (
     <section
+      {...ltrCodeBlockProps}
       ref={rootRef}
       className="plan-block"
       data-block-id={blockId}

--- a/packages/core/src/client/blocks/library/HighlightedCode.tsx
+++ b/packages/core/src/client/blocks/library/HighlightedCode.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import { cn } from "../../utils.js";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 
 type ShikiHighlighter = {
   codeToHtml: (
@@ -219,6 +220,7 @@ export function CodeSurface({
 
   return (
     <div
+      {...ltrCodeBlockProps}
       className={cn("plan-code-surface", className ?? "mt-5")}
       data-collapsed={collapsed ? "true" : undefined}
     >

--- a/packages/core/src/client/blocks/library/JsonExplorerBlock.tsx
+++ b/packages/core/src/client/blocks/library/JsonExplorerBlock.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { IconChevronRight } from "@tabler/icons-react";
 import { cn } from "../../utils.js";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 import type { BlockEditProps, BlockReadProps } from "../types.js";
 import {
   JSON_EXPLORER_DEFAULT_COLLAPSED_DEPTH,
@@ -325,7 +326,11 @@ export function JsonExplorerRead({
   const heading = data.title ?? title;
 
   return (
-    <section className="plan-block" data-block-id={blockId}>
+    <section
+      {...ltrCodeBlockProps}
+      className="plan-block"
+      data-block-id={blockId}
+    >
       {heading && <div className="plan-block-label">{heading}</div>}
       <JsonExplorerSurface data={data} />
       {summary && <p className="mt-5 text-plan-muted">{summary}</p>}

--- a/packages/core/src/client/blocks/library/MermaidBlock.tsx
+++ b/packages/core/src/client/blocks/library/MermaidBlock.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useMemo, useState } from "react";
 import { IconArrowsMaximize } from "@tabler/icons-react";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 import type { BlockEditProps, BlockReadProps } from "../types.js";
 import type { MermaidData } from "./mermaid.config.js";
 import { DevInput, DevLabel } from "./dev-doc-ui.js";
@@ -289,7 +290,11 @@ export function MermaidRead({
   summary,
 }: BlockReadProps<MermaidData>) {
   return (
-    <section className="plan-block" data-block-id={blockId}>
+    <section
+      {...ltrCodeBlockProps}
+      className="plan-block"
+      data-block-id={blockId}
+    >
       {title && <div className="plan-block-label">{title}</div>}
       <MermaidDiagram source={data.source} idSeed={blockId} />
       {data.caption && (

--- a/packages/core/src/client/blocks/library/OpenApiSpecBlock.tsx
+++ b/packages/core/src/client/blocks/library/OpenApiSpecBlock.tsx
@@ -1,6 +1,7 @@
 import { useId, useMemo, useState } from "react";
 import { IconChevronRight, IconLock } from "@tabler/icons-react";
 import { cn } from "../../utils.js";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 import type { BlockEditProps, BlockReadProps } from "../types.js";
 import type { OpenApiSpecData } from "./openapi-spec.config.js";
 import { DevInput, DevLabel, DevTextarea } from "./dev-doc-ui.js";
@@ -826,7 +827,11 @@ export function OpenApiSpecRead({
   const renderMarkdown = ctx.renderMarkdown;
 
   return (
-    <section className="plan-block" data-block-id={blockId}>
+    <section
+      {...ltrCodeBlockProps}
+      className="plan-block"
+      data-block-id={blockId}
+    >
       {heading && <div className="plan-block-label">{heading}</div>}
 
       {parsed.ok && parsed.spec ? (

--- a/packages/core/src/client/blocks/library/annotation-rail.tsx
+++ b/packages/core/src/client/blocks/library/annotation-rail.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "../../utils.js";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 import type { BlockRenderContext } from "../types.js";
 
 /**
@@ -179,6 +180,7 @@ export function AnnotationCard<A extends RailAnnotation>({
 }) {
   return (
     <div
+      {...ltrCodeBlockProps}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className={cn(

--- a/packages/core/src/client/blocks/library/code-tabs.tsx
+++ b/packages/core/src/client/blocks/library/code-tabs.tsx
@@ -11,6 +11,7 @@ import { common, createLowlight } from "lowlight";
 import { cn } from "../../utils.js";
 import { defineBlock } from "../types.js";
 import type { BlockReadProps, BlockEditProps } from "../types.js";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 import {
   Popover,
   PopoverContent,
@@ -189,7 +190,11 @@ function CodeTabsRead({ data, blockId, title }: BlockReadProps<CodeTabsData>) {
   const [activeId, setActiveId] = useState(data.tabs[0]?.id ?? "");
   const active = data.tabs.find((tab) => tab.id === activeId) ?? data.tabs[0];
   return (
-    <section className="plan-block" data-block-id={blockId}>
+    <section
+      {...ltrCodeBlockProps}
+      className="plan-block"
+      data-block-id={blockId}
+    >
       {title && <div className="plan-block-label">{title}</div>}
       <div className="grid overflow-hidden border-y border-plan-line md:grid-cols-[300px_minmax(0,1fr)]">
         <div className="border-plan-line md:border-r">

--- a/packages/core/src/client/blocks/library/code.tsx
+++ b/packages/core/src/client/blocks/library/code.tsx
@@ -16,6 +16,7 @@ import {
 } from "../../components/ui/popover.js";
 import { defineBlock } from "../types.js";
 import type { BlockReadProps, BlockEditProps } from "../types.js";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 import { CodeSurface, DEFAULT_CODE_MAX_LINES } from "./HighlightedCode.js";
 import {
   highlightCode,
@@ -95,7 +96,11 @@ function CodeRead({ data, blockId }: BlockReadProps<CodeData>) {
     undefined;
   const hasFilename = Boolean(data.filename?.trim());
   return (
-    <section className="plan-block" data-block-id={blockId}>
+    <section
+      {...ltrCodeBlockProps}
+      className="plan-block"
+      data-block-id={blockId}
+    >
       <div className="plan-code group relative">
         {hasFilename && (
           <div className="plan-code-head">
@@ -318,6 +323,7 @@ function CodeEditorSurface({
 
   return (
     <div
+      {...ltrCodeBlockProps}
       className={cn(
         "plan-code plan-code-editing group relative",
         !hasFilename && "plan-code-editing--unlabeled",

--- a/packages/core/src/client/blocks/library/diagram.tsx
+++ b/packages/core/src/client/blocks/library/diagram.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { IconArrowsMaximize, IconX } from "@tabler/icons-react";
 import { cn } from "../../utils.js";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 import { defineBlock } from "../types.js";
 import type {
   BlockReadProps,
@@ -640,7 +641,11 @@ export function DiagramRead({
   ctx,
 }: BlockReadProps<DiagramData>) {
   return (
-    <section className="an-block plan-block" data-block-id={blockId}>
+    <section
+      {...ltrCodeBlockProps}
+      className="an-block plan-block"
+      data-block-id={blockId}
+    >
       {title && <div className="an-block-label plan-block-label">{title}</div>}
       <ExpandableDiagramBody data={data} ctx={ctx} />
       {summary && <p className="mt-5 text-muted-foreground">{summary}</p>}

--- a/packages/core/src/client/blocks/library/wireframe.tsx
+++ b/packages/core/src/client/blocks/library/wireframe.tsx
@@ -7,6 +7,7 @@ import {
   type ReactNode,
 } from "react";
 import { defineBlock } from "../types.js";
+import { ltrCodeBlockProps } from "../code-block-direction.js";
 import type {
   BlockReadProps,
   BlockEditProps,
@@ -420,6 +421,7 @@ export function WireframeBlock({
 }: BlockReadProps<WireframeData>) {
   return (
     <section
+      {...ltrCodeBlockProps}
       className="an-block plan-block an-wireframe"
       data-block-id={blockId}
     >

--- a/templates/plan/app/global.css
+++ b/templates/plan/app/global.css
@@ -1,4 +1,8 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
+/* Vazirmatn — open-source (OFL) Persian/Arabic face, scoped to RTL plan content
+ * below via `[data-plan-direction="rtl"]`. @fontsource/vazirmatn is not in the
+ * workspace, so this matches the Inter CDN @import pattern above. */
+@import url("https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;500;600;700&display=swap");
 
 @import "tailwindcss";
 @import "@agent-native/core/styles/agent-native.css";
@@ -110,6 +114,17 @@
     font-family: "Inter", sans-serif;
     font-feature-settings: "cv02", "cv03", "cv04", "cv11";
   }
+}
+
+/* RTL plan content (Persian/Arabic) renders in Vazirmatn; LTR content keeps
+ * Inter. Scoped to the document shell's `data-plan-direction="rtl"` attribute
+ * (set by PlanContentRenderer) so only RTL plans pick it up. Code surfaces and
+ * `font-mono` utilities declare their own monospace stack ("JetBrains Mono", …),
+ * which is a direct font-family on the element and so always beats this inherited
+ * face — code never renders in Vazirmatn (code-like blocks are also pinned to
+ * dir="ltr"). */
+[data-plan-direction="rtl"] {
+  font-family: "Vazirmatn", "Inter", sans-serif;
 }
 
 @layer utilities {


### PR DESCRIPTION
Persian/Arabic plans set dir="rtl" on the document shell so prose flows RTL, but code-like blocks inherited that and rendered reversed.

FIX 1: pin code, code-tabs, diff, file-tree, annotated-code, API endpoint, OpenAPI spec, JSON explorer, data-model, schema-editor, diagram, mermaid, and wireframe blocks (plus the shared CodeSurface and annotation cards) to dir="ltr" with left-aligned text via a shared ltrCodeBlockProps helper. Each block's outermost element is pinned; prose/rich-text/callout stay RTL.

FIX 2: load Vazirmatn (CDN, OFL) scoped to [data-plan-direction="rtl"] in the plan template so RTL content uses it while LTR keeps Inter; code keeps its existing monospace stack.

Issue: #1295 

## Before:
<img width="996" height="1016" alt="Screenshot 2026-06-19 at 02 32 04" src="https://github.com/user-attachments/assets/30680f57-a5ee-493c-b1f9-9cd689e098ca" />

## After:
<img width="992" height="1062" alt="Screenshot 2026-06-19 at 02 31 29" src="https://github.com/user-attachments/assets/2102bb23-fce3-44e4-9ee8-e2318c414f41" />

---

ps - it's 2:46am here and it's my girlfriend's birthday, i'm seeing her in a few hours 😅 still couldn't make myself leave this one for tomorrow, really enjoy this project.