### PR TITLE
Fix Clips desktop device picker

### DIFF
--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -114,6 +114,8 @@ const AUTH_TOKEN_KEY = "clips:auth-token";
 const SOURCE_KEY = "clips:last-source";
 const CAM_KEY = "clips:last-camera-id";
 const MIC_KEY = "clips:last-mic-id";
+const CAM_LABEL_KEY = "clips:last-camera-label";
+const MIC_LABEL_KEY = "clips:last-mic-label";
 const CAM_ON_KEY = "clips:camera-on";
 const MIC_ON_KEY = "clips:mic-on";
 const SYSTEM_AUDIO_KEY = "clips:system-audio";
@@ -145,6 +147,15 @@ function isPseudoMediaDeviceId(value: string | null | undefined): boolean {
 function concreteMediaDeviceId(value: string | null | undefined): string {
   const id = normalizedMediaDeviceId(value);
   return id && !isPseudoMediaDeviceId(id) ? id : "";
+}
+
+// Prefer this page's own enumeration; fall back to the bubble-relayed list
+// when the popover can't see labels itself (local-camera path).
+function preferEnumerated(
+  own: MediaDeviceInfo[],
+  relayed: MediaDeviceInfo[],
+): MediaDeviceInfo[] {
+  return own.length > 0 ? own : relayed;
 }
 
 function isSelectableMediaDevice(device: MediaDeviceInfo): boolean {
@@ -563,10 +574,25 @@ export function App() {
   );
   const [cameras, setCameras] = useState<MediaDeviceInfo[]>([]);
   const [mics, setMics] = useState<MediaDeviceInfo[]>([]);
+  // Device lists relayed from the bubble page when IT owns the camera grant
+  // (full-screen / local-camera path). The popover page can't enumerate device
+  // labels itself there without muting the live bubble, so we use these lists
+  // when our own enumeration comes back empty.
+  const [bubbleCameras, setBubbleCameras] = useState<MediaDeviceInfo[]>([]);
+  const [bubbleMics, setBubbleMics] = useState<MediaDeviceInfo[]>([]);
   const [cameraId, setCameraId] = useState<string>(() =>
     loadString(CAM_KEY, ""),
   );
   const [micId, setMicId] = useState<string>(() => loadString(MIC_KEY, ""));
+  // Remembered human labels for the saved ids, so a cold launch (device list
+  // still locked behind a getUserMedia grant) can show the device by name
+  // instead of "Selected camera unavailable".
+  const [cameraLabel, setCameraLabel] = useState<string>(() =>
+    loadString(CAM_LABEL_KEY, ""),
+  );
+  const [micLabel, setMicLabel] = useState<string>(() =>
+    loadString(MIC_LABEL_KEY, ""),
+  );
   const [cameraOn, setCameraOn] = useState<boolean>(() =>
     loadBool(CAM_ON_KEY, false),
   );
@@ -652,6 +678,14 @@ export function App() {
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isRecording = recorder !== null;
   const selectedMicId = useMemo(() => concreteMediaDeviceId(micId), [micId]);
+  const cameraDevices = useMemo(
+    () => preferEnumerated(cameras, bubbleCameras),
+    [cameras, bubbleCameras],
+  );
+  const micDevices = useMemo(
+    () => preferEnumerated(mics, bubbleMics),
+    [mics, bubbleMics],
+  );
   const selectedMicLabel = useMemo(
     () =>
       selectedMicId
@@ -1108,7 +1142,10 @@ export function App() {
     // popover. If the user has picked a concrete mic, use that exact device;
     // otherwise leave labels locked until a real user action needs access.
     try {
-      if (!selectedMicId) {
+      // While the bubble owns the camera, even this audio-only probe trips
+      // WebKit's single-page capture-exclusion and blacks the bubble. Don't
+      // probe — leave mic labels locked until the bubble is gone.
+      if (bubbleActiveRef.current || !selectedMicId) {
         await loadDevices();
         return;
       }
@@ -1128,6 +1165,26 @@ export function App() {
       try {
         if (!navigator.mediaDevices?.getUserMedia) {
           throw new Error("Device selection is not available in this WebView.");
+        }
+        // When the camera bubble is live, ANY getUserMedia in this page —
+        // camera OR mic — hits WebKit's single-page capture-exclusion (one
+        // process, one webview): the bubble page's camera stream gets muted
+        // and goes black with no reliable unmute. The exclusion is not
+        // per-kind, so an audio-only probe blacks the bubble just the same.
+        // So we never probe here while the bubble owns the camera. Instead the
+        // bubble page — the only page that can capture without muting its own
+        // camera — does the probe and relays the device list back to us.
+        if (bubbleActiveRef.current) {
+          if (kind === "mic") {
+            // Ask the bubble to probe + relay the mic list (it has no mic
+            // grant of its own, so it must open a transient mic stream).
+            emit("clips:refresh-mics", {
+              micId: selectedMicId || null,
+            }).catch(() => {});
+          }
+          // Cameras are already relayed when the bubble's local camera starts.
+          await loadDevices();
+          return;
         }
         const stream = await navigator.mediaDevices.getUserMedia(
           kind === "camera"
@@ -1156,7 +1213,7 @@ export function App() {
         await loadDevices();
       }
     },
-    [loadDevices],
+    [loadDevices, selectedMicId],
   );
 
   // ---- Esc closes the popover --------------------------------------------
@@ -1222,6 +1279,20 @@ export function App() {
         setCameraOn(false);
       }),
     );
+    // The bubble relays its device lists (it holds the grant in the
+    // local-camera path). Used by the picker when our own enumeration is empty.
+    const trackRelay = (
+      event: string,
+      set: (devices: MediaDeviceInfo[]) => void,
+    ) =>
+      track(
+        listen<{ devices?: Array<{ deviceId: string; label: string }> }>(
+          event,
+          (ev) => set((ev.payload?.devices ?? []) as MediaDeviceInfo[]),
+        ),
+      );
+    trackRelay("clips:camera-devices", setBubbleCameras);
+    trackRelay("clips:mic-devices", setBubbleMics);
     // Query the CURRENT visibility on mount in case the event already
     // fired before React subscribed.
     getCurrentWindow()
@@ -1689,9 +1760,24 @@ export function App() {
   useEffect(() => saveString(SOURCE_KEY, source), [source]);
   useEffect(() => saveString(CAM_KEY, cameraId), [cameraId]);
   useEffect(() => saveString(MIC_KEY, micId), [micId]);
+  useEffect(() => saveString(CAM_LABEL_KEY, cameraLabel), [cameraLabel]);
+  useEffect(() => saveString(MIC_LABEL_KEY, micLabel), [micLabel]);
   useEffect(() => saveBool(CAM_ON_KEY, cameraOn), [cameraOn]);
   useEffect(() => saveBool(MIC_ON_KEY, micOn), [micOn]);
   useEffect(() => saveBool(SYSTEM_AUDIO_KEY, systemAudioOn), [systemAudioOn]);
+
+  // Once the device list unlocks (after a grant), refresh the remembered
+  // label for the saved id so the persisted name stays current.
+  useEffect(() => {
+    if (!cameraId) return;
+    const match = cameraDevices.find((d) => d.deviceId === cameraId);
+    if (match?.label) setCameraLabel(match.label);
+  }, [cameraDevices, cameraId]);
+  useEffect(() => {
+    if (!micId) return;
+    const match = micDevices.find((d) => d.deviceId === micId);
+    if (match?.label) setMicLabel(match.label);
+  }, [micDevices, micId]);
 
   // ---- actions -----------------------------------------------------------
 
@@ -2322,9 +2408,13 @@ export function App() {
         {showCameraRow ? (
           <MediaDeviceRow
             kind="camera"
-            devices={cameras}
+            devices={cameraDevices}
             selectedId={cameraId}
-            onSelect={setCameraId}
+            selectedLabel={cameraLabel}
+            onSelect={(id, label) => {
+              setCameraId(id);
+              setCameraLabel(label);
+            }}
             onRefresh={() => requestDeviceAccess("camera")}
             on={cameraOn}
             onToggle={setCameraOn}
@@ -2333,9 +2423,13 @@ export function App() {
 
         <MediaDeviceRow
           kind="mic"
-          devices={mics}
+          devices={micDevices}
           selectedId={selectedMicId}
-          onSelect={setMicId}
+          selectedLabel={micLabel}
+          onSelect={(id, label) => {
+            setMicId(id);
+            setMicLabel(label);
+          }}
           onRefresh={() => requestDeviceAccess("mic")}
           on={micOn}
           onToggle={setMicOn}

--- a/templates/clips/desktop/src/components/MediaDeviceRow.tsx
+++ b/templates/clips/desktop/src/components/MediaDeviceRow.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import { CameraIcon, CheckIcon, ChevronDown, MicIcon } from "./Icons";
 import { Switch } from "./Switch";
+import { useRowMenu } from "./useRowMenu";
 
 function Toggle({
   on,
@@ -39,6 +40,7 @@ export function MediaDeviceRow({
   kind,
   devices,
   selectedId,
+  selectedLabel,
   onSelect,
   onRefresh,
   on,
@@ -49,7 +51,8 @@ export function MediaDeviceRow({
   kind: "camera" | "mic";
   devices: MediaDeviceInfo[];
   selectedId: string;
-  onSelect: (id: string) => void;
+  selectedLabel?: string;
+  onSelect: (id: string, label: string) => void;
   onRefresh: () => void;
   on: boolean;
   onToggle: (v: boolean) => void;
@@ -64,37 +67,24 @@ export function MediaDeviceRow({
     [devices, selectedId],
   );
   const label =
+    // Prefer the live label from the enumerated device.
     current?.label ||
     (selectedId
-      ? kind === "camera"
-        ? "Selected camera unavailable"
-        : "Selected mic unavailable"
+      ? devices.length > 0
+        ? // List is loaded but the saved device isn't in it — genuinely gone.
+          kind === "camera"
+          ? "Selected camera unavailable"
+          : "Selected mic unavailable"
+        : // List is still locked (no getUserMedia grant yet this session,
+          // e.g. a cold launch). Fall back to the label we persisted with
+          // the id last time so the user still sees their device by name.
+          selectedLabel || (kind === "camera" ? "Camera" : "Microphone")
       : kind === "camera"
         ? "Default camera"
         : "Default mic");
   const Icon = kind === "camera" ? CameraIcon : MicIcon;
 
-  const [open, setOpen] = useState(false);
-  const rowRef = useRef<HTMLDivElement | null>(null);
-
-  // Close on outside click — native-feeling popover behavior.
-  useEffect(() => {
-    if (!open) return;
-    function onDoc(ev: MouseEvent) {
-      const el = rowRef.current;
-      if (!el) return;
-      if (!el.contains(ev.target as Node)) setOpen(false);
-    }
-    function onKey(ev: KeyboardEvent) {
-      if (ev.key === "Escape") setOpen(false);
-    }
-    document.addEventListener("mousedown", onDoc);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDoc);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
+  const { open, setOpen, rowRef } = useRowMenu();
 
   const disabled = !on;
   const defaultLabel = kind === "camera" ? "Default camera" : "Default mic";
@@ -136,7 +126,7 @@ export function MediaDeviceRow({
             role="menuitemradio"
             aria-checked={!selectedId}
             onClick={() => {
-              onSelect("");
+              onSelect("", "");
               setOpen(false);
             }}
           >
@@ -170,7 +160,7 @@ export function MediaDeviceRow({
                     role="menuitemradio"
                     aria-checked={isSelected}
                     onClick={() => {
-                      onSelect(d.deviceId);
+                      onSelect(d.deviceId, d.label);
                       setOpen(false);
                     }}
                   >

--- a/templates/clips/desktop/src/components/SourceRow.tsx
+++ b/templates/clips/desktop/src/components/SourceRow.tsx
@@ -1,6 +1,12 @@
-import { MonitorIcon } from "./Icons";
+import { CheckIcon, ChevronDown, MonitorIcon } from "./Icons";
+import { useRowMenu } from "./useRowMenu";
 
 export type CaptureSource = "full-screen" | "window";
+
+const LABELS: Record<CaptureSource, string> = {
+  "full-screen": "Full screen",
+  window: "Window",
+};
 
 export function SourceRow({
   value,
@@ -9,26 +15,49 @@ export function SourceRow({
   value: CaptureSource;
   onChange: (v: CaptureSource) => void;
 }) {
-  const labels: Record<CaptureSource, string> = {
-    "full-screen": "Full screen",
-    window: "Window",
-  };
+  const { open, setOpen, rowRef } = useRowMenu();
+
   return (
-    <label className="row">
+    <div className="row row-on" ref={rowRef}>
       <span className="row-icon">
         <MonitorIcon />
       </span>
-      <select
-        className="row-select"
-        value={value}
-        onChange={(e) => onChange(e.target.value as CaptureSource)}
+      <button
+        type="button"
+        className="row-button"
+        onClick={() => setOpen((v) => !v)}
+        title={LABELS[value]}
       >
-        {Object.entries(labels).map(([k, label]) => (
-          <option key={k} value={k}>
-            {label}
-          </option>
-        ))}
-      </select>
-    </label>
+        <span className="row-label">{LABELS[value]}</span>
+        <span className="row-chev" aria-hidden>
+          <ChevronDown />
+        </span>
+      </button>
+      {open ? (
+        <div className="row-menu" role="menu">
+          {(Object.keys(LABELS) as CaptureSource[]).map((key) => {
+            const isSelected = key === value;
+            return (
+              <button
+                key={key}
+                type="button"
+                className={`row-menu-item ${isSelected ? "selected" : ""}`}
+                role="menuitemradio"
+                aria-checked={isSelected}
+                onClick={() => {
+                  onChange(key);
+                  setOpen(false);
+                }}
+              >
+                <span className="row-menu-check" aria-hidden>
+                  {isSelected ? <CheckIcon /> : null}
+                </span>
+                <span className="row-menu-label">{LABELS[key]}</span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/templates/clips/desktop/src/components/useRowMenu.ts
+++ b/templates/clips/desktop/src/components/useRowMenu.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Open/close state for a settings-row dropdown menu (source, camera, mic
+ * pickers). Closes on outside click and Escape — native-feeling popover
+ * behavior. `rowRef` must be attached to the row container so outside-click
+ * detection knows what "inside" means.
+ */
+export function useRowMenu() {
+  const [open, setOpen] = useState(false);
+  const rowRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(ev: MouseEvent) {
+      const el = rowRef.current;
+      if (!el) return;
+      if (!el.contains(ev.target as Node)) setOpen(false);
+    }
+    function onKey(ev: KeyboardEvent) {
+      if (ev.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return { open, setOpen, rowRef };
+}

--- a/templates/clips/desktop/src/overlays/bubble.tsx
+++ b/templates/clips/desktop/src/overlays/bubble.tsx
@@ -31,6 +31,22 @@ function buildLocalCameraConstraints(
   return { video, audio: false };
 }
 
+// This page holds a capture grant, so it can enumerate the full device list
+// WITH labels — something the popover page can't do without its own
+// getUserMedia (which would mute this bubble via WebKit's single-page
+// capture-exclusion). Relay the labelled list so the popover's picker can show
+// every device
+async function relayDeviceList(
+  kind: MediaDeviceKind,
+  event: string,
+): Promise<void> {
+  const all = await navigator.mediaDevices.enumerateDevices();
+  const devices = all
+    .filter((d) => d.kind === kind && d.deviceId)
+    .map((d) => ({ deviceId: d.deviceId, label: d.label }));
+  emit(event, { devices }).catch(() => {});
+}
+
 async function getLocalCameraStream(
   cameraId: string | null,
 ): Promise<MediaStream> {
@@ -242,6 +258,7 @@ export function Bubble() {
     let stopped = false;
     let startUnlisten: (() => void) | null = null;
     let stopUnlisten: (() => void) | null = null;
+    let refreshMicsUnlisten: (() => void) | null = null;
     let renderedFrames = 0;
     let lastFpsLogAt = 0;
 
@@ -407,6 +424,8 @@ export function Bubble() {
             console.warn("[bubble] local camera video.play() rejected", err);
           });
           setLocalCameraActive(true);
+          // The bubble now holds the camera grant — relay the full camera list.
+          relayDeviceList("videoinput", "clips:camera-devices").catch(() => {});
           startLocalCanvasRenderer(stream);
           if (firstFrameAtRef.current == null) {
             firstFrameAtRef.current = Date.now();
@@ -453,6 +472,43 @@ export function Bubble() {
       })
       .catch(() => {});
 
+    // The popover can't probe the mic itself while this bubble is live —
+    // WebKit mutes our camera the moment another page in this process calls
+    // getUserMedia. But THIS page opening a mic doesn't mute its own camera
+    // (the exclusion is cross-page). So when the popover asks, we open a
+    // transient mic stream here to unlock the labels, enumerate, relay the
+    // audioinput list back, then drop the stream. The camera stays live.
+    listen<{ micId?: string | null }>("clips:refresh-mics", async (event) => {
+      if (stopped) return;
+      const micId = event.payload?.micId?.trim() || null;
+      let micStream: MediaStream | null = null;
+      try {
+        micStream = await navigator.mediaDevices.getUserMedia({
+          audio: micId ? { deviceId: { exact: micId } } : true,
+          video: false,
+        });
+        await relayDeviceList("audioinput", "clips:mic-devices");
+      } catch (err) {
+        console.warn("[bubble] mic refresh probe failed", err);
+      } finally {
+        // Drop the probe stream immediately — we only needed the grant to
+        // read labels, not to keep the mic hot.
+        micStream?.getTracks().forEach((t) => t.stop());
+      }
+    })
+      .then((u) => {
+        if (stopped) {
+          try {
+            u();
+          } catch {
+            // ignore
+          }
+        } else {
+          refreshMicsUnlisten = u;
+        }
+      })
+      .catch(() => {});
+
     return () => {
       stopped = true;
       try {
@@ -462,6 +518,11 @@ export function Bubble() {
       }
       try {
         stopUnlisten?.();
+      } catch {
+        // ignore
+      }
+      try {
+        refreshMicsUnlisten?.();
       } catch {
         // ignore
       }

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -515,34 +515,6 @@ body[data-clips-route="recording-pill"] #root {
   color: var(--fg);
 }
 
-.row-select {
-  flex: 1;
-  min-width: 0;
-  border: none;
-  background: transparent;
-  color: var(--fg);
-  font-size: 13px;
-  font-weight: 500;
-  padding: 0;
-  margin: 0;
-  appearance: none;
-  -webkit-appearance: none;
-  cursor: pointer;
-  outline: none;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.row-select:disabled {
-  cursor: not-allowed;
-}
-
-.row-select:focus-visible {
-  box-shadow: 0 0 0 2px var(--brand-ring);
-  border-radius: 4px;
-}
-
 /* Custom device picker — button + popover menu (replaces native <select>). */
 .row-button {
   flex: 1;


### PR DESCRIPTION
This PR fixes a few problems with the camera and microphone picker in the Clips desktop app, and tidies up the related code.

## What it does

**Remembers your device by name.** We now save the camera and mic label alongside the saved id. On a cold launch the device list is empty until the OS grants access, so the picker used to show "Selected camera unavailable". It now shows the real name you picked last time.

**Keeps the camera bubble from going black.** On macOS, when any page calls `getUserMedia`, the live camera bubble (which runs in a separate page) gets muted and turns black. The picker's "Allow access" and "Refresh" buttons were triggering this. Now, while the bubble is live, the popover never probes the camera itself — it asks the bubble, which already holds the grant, to enumerate the devices and send the list back.

**Makes mic refresh work again.** Same approach for the microphone: the bubble briefly opens a mic stream, reads the labels, sends the list back, then drops the stream. The camera stays live the whole time.

**Cleans up the picker code.** The source picker now uses the same dropdown style as the camera and mic rows. The shared open/close behavior (outside-click and Escape) moved into a small `useRowMenu` hook, the duplicated device-relay logic was pulled into helpers, and the now-unused `.row-select` CSS was removed.
