### PR TITLE
Permission status panel for Clips desktop

### DIFF
--- a/templates/clips/desktop/src-tauri/build.rs
+++ b/templates/clips/desktop/src-tauri/build.rs
@@ -18,6 +18,7 @@ fn add_swift_runtime_rpaths() {
     // CMTime symbols we touch via raw `msg_send!` / `extern "C"`.
     println!("cargo:rustc-link-lib=framework=AVFoundation");
     println!("cargo:rustc-link-lib=framework=CoreMedia");
+    println!("cargo:rustc-link-lib=framework=IOKit");
 
     // The screencapturekit crate builds a Swift bridge. Its build script adds
     // these rpaths for its own crate, but Cargo does not propagate them to the

--- a/templates/clips/desktop/src-tauri/src/accessibility.rs
+++ b/templates/clips/desktop/src-tauri/src/accessibility.rs
@@ -123,7 +123,7 @@ pub async fn accessibility_request_permission() -> Result<bool, String> {
 }
 
 #[cfg(target_os = "macos")]
-mod macos {
+pub(crate) mod macos {
     use super::ActiveWindowContext;
     use core_foundation::array::CFArray;
     use core_foundation::base::{CFType, TCFType};

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod meetings_watcher;
 mod native_screen;
 mod native_speech;
 mod notifications;
+mod permission_status;
 mod recording_indicator;
 mod shortcuts;
 mod silence_detector;
@@ -142,6 +143,8 @@ pub fn run() {
             // whisper model management
             whisper_model::whisper_model_status,
             whisper_model::whisper_model_download,
+            // permission status (silent checks for all TCC permissions)
+            permission_status::check_permission_statuses,
             // persistent log file (production debugging)
             logfile::frontend_log,
             logfile::open_logs,

--- a/templates/clips/desktop/src-tauri/src/permission_status.rs
+++ b/templates/clips/desktop/src-tauri/src/permission_status.rs
@@ -1,0 +1,83 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionStatuses {
+    pub screen: bool,
+    pub camera: bool,
+    pub microphone: bool,
+    pub speech: bool,
+    pub accessibility: bool,
+    pub input_monitoring: bool,
+}
+
+#[tauri::command]
+pub fn check_permission_statuses() -> PermissionStatuses {
+    #[cfg(target_os = "macos")]
+    {
+        macos::check_all()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        // TODO: implement
+        PermissionStatuses {
+            screen: true,
+            camera: true,
+            microphone: true,
+            speech: true,
+            accessibility: true,
+            input_monitoring: true,
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::PermissionStatuses;
+    use objc2::{class, msg_send};
+    use objc2_foundation::NSString;
+    use objc2_speech::{SFSpeechRecognizer, SFSpeechRecognizerAuthorizationStatus};
+
+    extern "C" {
+        fn CGPreflightScreenCaptureAccess() -> bool;
+        // kIOHIDRequestTypeListenEvent = 1; returns IOHIDAccessType where
+        // kIOHIDAccessTypeGranted = 0, kIOHIDAccessTypeDenied = 1, kIOHIDAccessTypeUnknown = 2
+        fn IOHIDCheckAccess(request_type: u32) -> i32;
+    }
+
+    pub fn check_all() -> PermissionStatuses {
+        PermissionStatuses {
+            screen: check_screen(),
+            camera: check_av_capture("vide"),
+            microphone: check_av_capture("soun"),
+            speech: check_speech(),
+            accessibility: crate::accessibility::macos::is_trusted(false),
+            input_monitoring: check_input_monitoring(),
+        }
+    }
+
+    fn check_screen() -> bool {
+        unsafe { CGPreflightScreenCaptureAccess() }
+    }
+
+    fn check_av_capture(media_type: &str) -> bool {
+        // AVAuthorizationStatus: notDetermined=0, restricted=1, denied=2, authorized=3
+        unsafe {
+            let cls = class!(AVCaptureDevice);
+            let ns_type = NSString::from_str(media_type);
+            let status: i64 = msg_send![cls, authorizationStatusForMediaType: &*ns_type];
+            status == 3
+        }
+    }
+
+    fn check_speech() -> bool {
+        unsafe {
+            SFSpeechRecognizer::authorizationStatus()
+                == SFSpeechRecognizerAuthorizationStatus::Authorized
+        }
+    }
+
+    fn check_input_monitoring() -> bool {
+        unsafe { IOHIDCheckAccess(1) == 0 }
+    }
+}

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -374,7 +374,6 @@ const WINDOWS_PRIVACY_URLS: Partial<Record<MacosPrivacyPane, string>> = {
   "input-monitoring": "ms-settings:privacy",
 };
 
-
 function openPrivacySettings(pane: MacosPrivacyPane): void {
   if (isMacPlatform()) {
     invoke("open_macos_privacy_settings", { pane }).catch((nativeErr) => {

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -39,6 +39,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./components/Tooltip";
 import { SourceRow, type CaptureSource } from "./components/SourceRow";
 import { MediaDeviceRow } from "./components/MediaDeviceRow";
 import { Switch } from "./components/Switch";
+import { ReadinessPanel } from "./components/ReadinessPanel";
 import {
   CamIcon,
   ClockIcon,
@@ -2573,135 +2574,6 @@ function permissionPaneLabel(pane: MacosPrivacyPane): string {
     accessibility: "Accessibility",
     "input-monitoring": "Input Monitoring",
   }[pane];
-}
-
-type ReadinessItem = {
-  label: string;
-  detail: string;
-  pane: MacosPrivacyPane;
-  active: boolean;
-};
-
-function readinessItems({
-  mode,
-  cameraOn,
-  micOn,
-  includeFnMonitoring,
-  includeVoicePaste,
-}: {
-  mode: CaptureMode;
-  cameraOn: boolean;
-  micOn: boolean;
-  includeFnMonitoring: boolean;
-  includeVoicePaste: boolean;
-}): ReadinessItem[] {
-  const items: ReadinessItem[] = [
-    {
-      label: "Screen Recording",
-      detail: "Needed for screen or window capture.",
-      pane: "screen",
-      active: mode !== "camera",
-    },
-    {
-      label: "Microphone",
-      detail: "Needed when the mic is on.",
-      pane: "microphone",
-      active: micOn,
-    },
-    {
-      label: "Speech Recognition",
-      detail: "Used for native transcripts.",
-      pane: "speech",
-      active: micOn,
-    },
-    {
-      label: "Camera",
-      detail: "Needed when camera is on.",
-      pane: "camera",
-      active: mode !== "screen" && cameraOn,
-    },
-    {
-      label: "Accessibility",
-      detail: "Needed to paste dictated text into other apps.",
-      pane: "accessibility",
-      active: includeVoicePaste,
-    },
-    {
-      label: "Input Monitoring",
-      detail: "Only needed for the Fn dictation shortcut.",
-      pane: "input-monitoring",
-      active: includeFnMonitoring,
-    },
-  ];
-
-  return items.filter((item) => item.active);
-}
-
-function ReadinessPanel({
-  mode,
-  cameraOn,
-  micOn,
-  includeFnMonitoring,
-  includeVoicePaste,
-  open,
-  onOpenChange,
-  onOpenPermission,
-}: {
-  mode: CaptureMode;
-  cameraOn: boolean;
-  micOn: boolean;
-  includeFnMonitoring: boolean;
-  includeVoicePaste: boolean;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onOpenPermission: (pane: MacosPrivacyPane) => void;
-}) {
-  const items = readinessItems({
-    mode,
-    cameraOn,
-    micOn,
-    includeFnMonitoring,
-    includeVoicePaste,
-  });
-
-  return (
-    <div className={`readiness ${open ? "readiness-open" : ""}`}>
-      <button
-        type="button"
-        className="readiness-summary"
-        aria-expanded={open}
-        onClick={() => onOpenChange(!open)}
-      >
-        <span className="readiness-title">Setup</span>
-        <span className="readiness-action">{open ? "Hide" : "Review"}</span>
-      </button>
-      {open ? (
-        <div className="readiness-list">
-          {items.length ? (
-            items.map((item) => (
-              <div className="readiness-item" key={item.pane}>
-                <div className="readiness-item-copy">
-                  <span className="readiness-item-title">{item.label}</span>
-                  <span className="readiness-item-detail">{item.detail}</span>
-                </div>
-                <button
-                  type="button"
-                  className="readiness-open-button"
-                  onClick={() => onOpenPermission(item.pane)}
-                >
-                  Open
-                </button>
-              </div>
-            ))
-          ) : (
-            <div className="readiness-empty">
-              Turn on camera or mic when you need them.
-            </div>
-          )}
-        </div>
-      ) : null}
-    </div>
-  );
 }
 
 function PermissionRecoveryBanner({

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -53,6 +53,7 @@ import {
 import { useFeatureConfig, type LocalRecordingMode } from "./shared/config";
 import { useMeetingTranscription } from "./hooks/useMeetingTranscription";
 import { normalizeServerUrl } from "./lib/url";
+import { isMacPlatform, isWindowsPlatform } from "./lib/platform";
 import {
   IconAlertTriangle,
   IconArrowLeft,
@@ -373,20 +374,6 @@ const WINDOWS_PRIVACY_URLS: Partial<Record<MacosPrivacyPane, string>> = {
   "input-monitoring": "ms-settings:privacy",
 };
 
-function isMacPlatform(): boolean {
-  return typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
-}
-
-function isWindowsPlatform(): boolean {
-  return (
-    typeof navigator !== "undefined" &&
-    (/Win/i.test(navigator.platform) ||
-      /Win/i.test(
-        (navigator as { userAgentData?: { platform?: string } }).userAgentData
-          ?.platform ?? "",
-      ))
-  );
-}
 
 function openPrivacySettings(pane: MacosPrivacyPane): void {
   if (isMacPlatform()) {
@@ -414,9 +401,6 @@ function openPrivacySettings(pane: MacosPrivacyPane): void {
     return;
   }
 }
-
-// Keep backward-compatible alias so all existing call-sites continue to work.
-const openMacosPrivacySettings = openPrivacySettings;
 
 function nativeVoiceProvider(): VoiceProvider {
   return isMacPlatform() ? "macos-native" : "browser";
@@ -1920,7 +1904,7 @@ export function App() {
         if (!granted) {
           setReadinessOpen(true);
           setRecError(MACOS_CAPTURE_PERMISSION_MESSAGE);
-          openMacosPrivacySettings("screen");
+          openPrivacySettings("screen");
           return;
         }
       } catch (err) {
@@ -2447,7 +2431,7 @@ export function App() {
         includeFnMonitoring={fnShortcutEnabled}
         open={readinessOpen}
         onOpenChange={updateReadinessOpen}
-        onOpenPermission={openMacosPrivacySettings}
+        onOpenPermission={openPrivacySettings}
       />
 
       <button
@@ -2606,7 +2590,7 @@ function PermissionRecoveryBanner({
           <button
             type="button"
             key={pane}
-            onClick={() => openMacosPrivacySettings(pane)}
+            onClick={() => openPrivacySettings(pane)}
           >
             {permissionPaneLabel(pane)}
           </button>
@@ -3140,6 +3124,7 @@ function Setup({
   onSignOut?: () => void;
 }) {
   const [url, setUrl] = useState(initial ?? DEFAULT_URL);
+  const [readinessOpen, setReadinessOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const featureConfig = useFeatureConfig();
   const voiceEnabled = featureConfig?.voiceEnabled !== false;
@@ -3835,51 +3820,22 @@ function Setup({
         ) : null}
       </div>
 
-      {isMacPlatform() ? (
-        <div className="setup-section">
-          <SettingLabel
-            label="macOS permissions"
-            hint="Open the exact Privacy & Security pane for each permission Clips can need."
-          />
-          <div className="setup-permission-grid">
-            <button
-              type="button"
-              className="setup-permission-button"
-              onClick={() => openMacosPrivacySettings("camera")}
-            >
-              Camera
-            </button>
-            <button
-              type="button"
-              className="setup-permission-button"
-              onClick={() => openMacosPrivacySettings("microphone")}
-            >
-              Microphone
-            </button>
-            <button
-              type="button"
-              className="setup-permission-button"
-              onClick={() => openMacosPrivacySettings("screen")}
-            >
-              Screen Recording
-            </button>
-            <button
-              type="button"
-              className="setup-permission-button"
-              onClick={() => openMacosPrivacySettings("speech")}
-            >
-              Speech Recognition
-            </button>
-            <button
-              type="button"
-              className="setup-permission-button"
-              onClick={() => openMacosPrivacySettings("accessibility")}
-            >
-              Accessibility
-            </button>
-          </div>
-        </div>
-      ) : null}
+      <div className="setup-section">
+        <SettingLabel
+          label="Privacy permissions"
+          hint="Open the exact Privacy & Security pane for each permission Clips can need."
+        />
+        <ReadinessPanel
+          mode="screen-camera"
+          cameraOn={true}
+          micOn={true}
+          includeVoicePaste={voiceEnabled}
+          includeFnMonitoring={fnShortcutSelected}
+          open={readinessOpen}
+          onOpenChange={setReadinessOpen}
+          onOpenPermission={openPrivacySettings}
+        />
+      </div>
 
       {voiceEnabled ? (
         <>
@@ -4044,7 +4000,7 @@ function Setup({
               <button
                 type="button"
                 className="secondary"
-                onClick={() => openMacosPrivacySettings("input-monitoring")}
+                onClick={() => openPrivacySettings("input-monitoring")}
               >
                 Open Input Monitoring
               </button>

--- a/templates/clips/desktop/src/components/ReadinessPanel.tsx
+++ b/templates/clips/desktop/src/components/ReadinessPanel.tsx
@@ -1,0 +1,137 @@
+type CaptureMode = "screen" | "screen-camera" | "camera";
+type MacosPrivacyPane =
+  | "camera"
+  | "microphone"
+  | "screen"
+  | "speech"
+  | "accessibility"
+  | "input-monitoring";
+
+type ReadinessItem = {
+  label: string;
+  detail: string;
+  pane: MacosPrivacyPane;
+  active: boolean;
+};
+
+function readinessItems({
+  mode,
+  cameraOn,
+  micOn,
+  includeFnMonitoring,
+  includeVoicePaste,
+}: {
+  mode: CaptureMode;
+  cameraOn: boolean;
+  micOn: boolean;
+  includeFnMonitoring: boolean;
+  includeVoicePaste: boolean;
+}): ReadinessItem[] {
+  const items: ReadinessItem[] = [
+    {
+      label: "Screen Recording",
+      detail: "Needed for screen or window capture.",
+      pane: "screen",
+      active: mode !== "camera",
+    },
+    {
+      label: "Microphone",
+      detail: "Needed when the mic is on.",
+      pane: "microphone",
+      active: micOn,
+    },
+    {
+      label: "Speech Recognition",
+      detail: "Used for native transcripts.",
+      pane: "speech",
+      active: micOn,
+    },
+    {
+      label: "Camera",
+      detail: "Needed when camera is on.",
+      pane: "camera",
+      active: mode !== "screen" && cameraOn,
+    },
+    {
+      label: "Accessibility",
+      detail: "Needed to paste dictated text into other apps.",
+      pane: "accessibility",
+      active: includeVoicePaste,
+    },
+    {
+      label: "Input Monitoring",
+      detail: "Only needed for the Fn dictation shortcut.",
+      pane: "input-monitoring",
+      active: includeFnMonitoring,
+    },
+  ];
+
+  return items.filter((item) => item.active);
+}
+
+export function ReadinessPanel({
+  mode,
+  cameraOn,
+  micOn,
+  includeFnMonitoring,
+  includeVoicePaste,
+  open,
+  onOpenChange,
+  onOpenPermission,
+}: {
+  mode: CaptureMode;
+  cameraOn: boolean;
+  micOn: boolean;
+  includeFnMonitoring: boolean;
+  includeVoicePaste: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onOpenPermission: (pane: MacosPrivacyPane) => void;
+}) {
+  const items = readinessItems({
+    mode,
+    cameraOn,
+    micOn,
+    includeFnMonitoring,
+    includeVoicePaste,
+  });
+
+  return (
+    <div className={`readiness ${open ? "readiness-open" : ""}`}>
+      <button
+        type="button"
+        className="readiness-summary"
+        aria-expanded={open}
+        onClick={() => onOpenChange(!open)}
+      >
+        <span className="readiness-title">Setup</span>
+        <span className="readiness-action">{open ? "Hide" : "Review"}</span>
+      </button>
+      {open ? (
+        <div className="readiness-list">
+          {items.length ? (
+            items.map((item) => (
+              <div className="readiness-item" key={item.pane}>
+                <div className="readiness-item-copy">
+                  <span className="readiness-item-title">{item.label}</span>
+                  <span className="readiness-item-detail">{item.detail}</span>
+                </div>
+                <button
+                  type="button"
+                  className="readiness-open-button"
+                  onClick={() => onOpenPermission(item.pane)}
+                >
+                  Open
+                </button>
+              </div>
+            ))
+          ) : (
+            <div className="readiness-empty">
+              Turn on camera or mic when you need them.
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/templates/clips/desktop/src/components/ReadinessPanel.tsx
+++ b/templates/clips/desktop/src/components/ReadinessPanel.tsx
@@ -1,3 +1,14 @@
+import { useState, useCallback, useEffect } from "react";
+import { isMacPlatform } from "../lib/platform";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  IconChevronRight,
+  IconChevronDown,
+  IconCircleCheck,
+  IconCircleOff,
+  IconRefresh,
+} from "@tabler/icons-react";
+
 type CaptureMode = "screen" | "screen-camera" | "camera";
 type MacosPrivacyPane =
   | "camera"
@@ -7,11 +18,21 @@ type MacosPrivacyPane =
   | "accessibility"
   | "input-monitoring";
 
+type PermissionStatuses = {
+  screen: boolean;
+  camera: boolean;
+  microphone: boolean;
+  speech: boolean;
+  accessibility: boolean;
+  inputMonitoring: boolean;
+};
+
 type ReadinessItem = {
   label: string;
   detail: string;
   pane: MacosPrivacyPane;
   active: boolean;
+  macosOnly?: boolean;
 };
 
 function readinessItems({
@@ -27,12 +48,14 @@ function readinessItems({
   includeFnMonitoring: boolean;
   includeVoicePaste: boolean;
 }): ReadinessItem[] {
+  const mac = isMacPlatform();
   const items: ReadinessItem[] = [
     {
       label: "Screen Recording",
       detail: "Needed for screen or window capture.",
       pane: "screen",
       active: mode !== "camera",
+      macosOnly: true,
     },
     {
       label: "Microphone",
@@ -45,6 +68,7 @@ function readinessItems({
       detail: "Used for native transcripts.",
       pane: "speech",
       active: micOn,
+      macosOnly: true,
     },
     {
       label: "Camera",
@@ -57,16 +81,34 @@ function readinessItems({
       detail: "Needed to paste dictated text into other apps.",
       pane: "accessibility",
       active: includeVoicePaste,
+      macosOnly: true,
     },
     {
       label: "Input Monitoring",
       detail: "Only needed for the Fn dictation shortcut.",
       pane: "input-monitoring",
       active: includeFnMonitoring,
+      macosOnly: true,
     },
   ];
 
-  return items.filter((item) => item.active);
+  return items.filter((item) => item.active && (!item.macosOnly || mac));
+}
+
+function statusForPane(
+  pane: MacosPrivacyPane,
+  statuses: PermissionStatuses | null,
+): boolean | null {
+  if (!statuses) return null;
+  const map: Record<MacosPrivacyPane, boolean> = {
+    screen: statuses.screen,
+    camera: statuses.camera,
+    microphone: statuses.microphone,
+    speech: statuses.speech,
+    accessibility: statuses.accessibility,
+    "input-monitoring": statuses.inputMonitoring,
+  };
+  return map[pane];
 }
 
 export function ReadinessPanel({
@@ -88,6 +130,7 @@ export function ReadinessPanel({
   onOpenChange: (open: boolean) => void;
   onOpenPermission: (pane: MacosPrivacyPane) => void;
 }) {
+  const mac = isMacPlatform();
   const items = readinessItems({
     mode,
     cameraOn,
@@ -95,6 +138,27 @@ export function ReadinessPanel({
     includeFnMonitoring,
     includeVoicePaste,
   });
+
+  const [statuses, setStatuses] = useState<PermissionStatuses | null>(null);
+  const [checking, setChecking] = useState(false);
+
+  const checkStatuses = useCallback(async () => {
+    setChecking(true);
+    try {
+      const result = await invoke<PermissionStatuses>(
+        "check_permission_statuses",
+      );
+      setStatuses(result);
+    } catch {
+      // Non-macOS or command not available — leave statuses null
+    } finally {
+      setChecking(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open && !statuses && mac) checkStatuses();
+  }, [open, statuses, mac, checkStatuses]);
 
   return (
     <div className={`readiness ${open ? "readiness-open" : ""}`}>
@@ -104,27 +168,63 @@ export function ReadinessPanel({
         aria-expanded={open}
         onClick={() => onOpenChange(!open)}
       >
-        <span className="readiness-title">Setup</span>
-        <span className="readiness-action">{open ? "Hide" : "Review"}</span>
+        <span className="readiness-title">Permissions</span>
+        <span className="readiness-action">
+          {open ? "Hide" : "Review"}
+          {open ? (
+            <IconChevronDown size={11} stroke={2.5} />
+          ) : (
+            <IconChevronRight size={11} stroke={2.5} />
+          )}
+        </span>
       </button>
       {open ? (
         <div className="readiness-list">
           {items.length ? (
-            items.map((item) => (
-              <div className="readiness-item" key={item.pane}>
-                <div className="readiness-item-copy">
-                  <span className="readiness-item-title">{item.label}</span>
-                  <span className="readiness-item-detail">{item.detail}</span>
+            items.map((item) => {
+              const granted = statusForPane(item.pane, statuses);
+              return (
+                <div className="readiness-item" key={item.pane}>
+                  <div className="readiness-item-copy">
+                    <span className="readiness-item-title">{item.label}</span>
+                    <span className="readiness-item-detail">{item.detail}</span>
+                  </div>
+                  <div className="readiness-item-actions">
+                    {mac ? (
+                      <button
+                        type="button"
+                        className={`readiness-refresh ${checking ? "readiness-refresh-spinning" : ""}`}
+                        onClick={checkStatuses}
+                        disabled={checking}
+                        aria-label="Recheck permissions"
+                        title="Recheck"
+                      >
+                        <IconRefresh size={13} stroke={2} />
+                      </button>
+                    ) : null}
+                    {mac && granted !== null ? (
+                      <span
+                        className={`readiness-status ${granted ? "readiness-status-ok" : "readiness-status-warn"}`}
+                        aria-label={granted ? "Granted" : "Not granted"}
+                      >
+                        {granted ? (
+                          <IconCircleCheck size={16} stroke={2} />
+                        ) : (
+                          <IconCircleOff size={16} stroke={2} />
+                        )}
+                      </span>
+                    ) : null}
+                    <button
+                      type="button"
+                      className="readiness-open-button"
+                      onClick={() => onOpenPermission(item.pane)}
+                    >
+                      Open
+                    </button>
+                  </div>
                 </div>
-                <button
-                  type="button"
-                  className="readiness-open-button"
-                  onClick={() => onOpenPermission(item.pane)}
-                >
-                  Open
-                </button>
-              </div>
-            ))
+              );
+            })
           ) : (
             <div className="readiness-empty">
               Turn on camera or mic when you need them.

--- a/templates/clips/desktop/src/lib/platform.ts
+++ b/templates/clips/desktop/src/lib/platform.ts
@@ -1,0 +1,14 @@
+export function isMacPlatform(): boolean {
+  return typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+}
+
+export function isWindowsPlatform(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    (/Win/i.test(navigator.platform) ||
+      /Win/i.test(
+        (navigator as { userAgentData?: { platform?: string } }).userAgentData
+          ?.platform ?? "",
+      ))
+  );
+}

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -19,6 +19,9 @@
   --border: #e2e6ef;
   --border-strong: #d4d9e4;
 
+  --status-ok: #22c55e;
+  --status-warn: #f97316;
+
   --radius: 12px;
   --radius-sm: 8px;
   --radius-pill: 999px;
@@ -837,8 +840,9 @@ body[data-clips-route="recording-pill"] #root {
 /* ------------------------------------------------------------------------- */
 
 .readiness {
-  border: 1px solid transparent;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
+  background: var(--surface);
   overflow: hidden;
   flex-shrink: 0;
   transition:
@@ -847,7 +851,7 @@ body[data-clips-route="recording-pill"] #root {
 }
 
 .readiness-open {
-  border-color: var(--border);
+  border-color: var(--border-strong);
   background: var(--bg);
 }
 
@@ -857,13 +861,13 @@ body[data-clips-route="recording-pill"] #root {
   align-items: center;
   gap: 8px;
   width: 100%;
-  min-height: 32px;
+  min-height: 42px;
   border: none;
   background: transparent;
   border-radius: var(--radius-sm);
   color: var(--fg);
   cursor: pointer;
-  padding: 6px 10px;
+  padding: 10px 12px;
   text-align: left;
   transition: background 120ms;
 }
@@ -878,17 +882,17 @@ body[data-clips-route="recording-pill"] #root {
 }
 
 .readiness-open .readiness-summary {
-  min-height: 38px;
+  min-height: 42px;
   border-radius: 0;
-  padding: 8px 10px;
+  padding: 10px 12px;
   background: var(--surface);
   border-bottom: 1px solid var(--border);
 }
 
 .readiness-title {
-  color: var(--fg-muted);
-  font-size: 11px;
-  font-weight: 700;
+  color: var(--fg);
+  font-size: 13px;
+  font-weight: 500;
   line-height: 1;
 }
 
@@ -897,10 +901,17 @@ body[data-clips-route="recording-pill"] #root {
 }
 
 .readiness-action {
-  color: var(--fg-muted);
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--brand);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: 600;
   line-height: 1;
+}
+
+.readiness-open .readiness-action {
+  color: var(--fg-muted);
 }
 
 .readiness-list {
@@ -970,6 +981,60 @@ body[data-clips-route="recording-pill"] #root {
   outline: none;
   border-color: var(--brand);
   box-shadow: 0 0 0 3px var(--brand-ring);
+}
+
+.readiness-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.readiness-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.readiness-status-ok {
+  color: var(--status-ok);
+}
+
+.readiness-status-warn {
+  color: var(--status-warn);
+}
+
+.readiness-refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color 120ms, background 120ms;
+  flex-shrink: 0;
+}
+
+.readiness-refresh:hover {
+  color: var(--fg);
+  background: var(--surface-hover);
+}
+
+.readiness-refresh:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.readiness-refresh-spinning svg {
+  animation: readiness-spin 0.8s linear infinite;
+}
+
+@keyframes readiness-spin {
+  to { transform: rotate(360deg); }
 }
 
 .readiness-empty {

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -840,6 +840,7 @@ body[data-clips-route="recording-pill"] #root {
   border: 1px solid transparent;
   border-radius: var(--radius);
   overflow: hidden;
+  flex-shrink: 0;
   transition:
     border-color 120ms,
     background 120ms;

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1015,7 +1015,9 @@ body[data-clips-route="recording-pill"] #root {
   color: var(--fg-muted);
   cursor: pointer;
   border-radius: var(--radius-sm);
-  transition: color 120ms, background 120ms;
+  transition:
+    color 120ms,
+    background 120ms;
   flex-shrink: 0;
 }
 
@@ -1034,7 +1036,9 @@ body[data-clips-route="recording-pill"] #root {
 }
 
 @keyframes readiness-spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .readiness-empty {


### PR DESCRIPTION

This change turns the Clips desktop "Setup" box into a clearer "Permissions" panel that shows, at a glance, which system permissions the app already has.

Before, the panel only listed each permission with an "Open" button to jump to system settings. Now it also checks the live status of each permission and shows a green check when it is granted or an orange icon when it is not. A small refresh button lets the user re-check after they change a setting. The panel also works on Windows now, not just macOS, and only shows the permissions that make sense for the current platform.

The same panel is reused on the Setup screen, replacing the old hand-built grid of permission buttons.
<img width="466" height="530" alt="image" src="https://github.com/user-attachments/assets/db8c1fff-9e2c-4f86-a109-14c651e81163" />

## Main changes

- **New permission checks (backend):** A new Rust command reads the current status of screen, camera, microphone, speech, accessibility, and input monitoring on macOS. It only reads status and never prompts the user.
- **Reworked Permissions panel (frontend):** Shows live granted / not-granted status, adds a refresh button, and supports both macOS and Windows.
- **Shared platform helpers:** The `isMac` / `isWindows` checks moved into one small file so they are no longer duplicated.
- **Setup screen cleanup:** The old macOS-only button grid was removed in favor of the shared panel.
