### PR TITLE
Add live mic level meter to clips desktop popover

### DIFF
--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2435,6 +2435,7 @@ export function App() {
           onToggle={setMicOn}
           systemAudio={systemAudioOn}
           onSystemAudioToggle={setSystemAudioOn}
+          meterActive={popoverVisible && !isRecording}
         />
       </div>
 

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2436,6 +2436,7 @@ export function App() {
           systemAudio={systemAudioOn}
           onSystemAudioToggle={setSystemAudioOn}
           meterActive={popoverVisible && !isRecording}
+          meterRelay={bubbleActive}
         />
       </div>
 

--- a/templates/clips/desktop/src/components/MediaDeviceRow.tsx
+++ b/templates/clips/desktop/src/components/MediaDeviceRow.tsx
@@ -1,7 +1,9 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { CameraIcon, CheckIcon, ChevronDown, MicIcon } from "./Icons";
 import { Switch } from "./Switch";
 import { useRowMenu } from "./useRowMenu";
+
+const WAVE_BARS = 18;
 
 function Toggle({
   on,
@@ -25,13 +27,87 @@ function Toggle({
   );
 }
 
-function MicWave() {
+// Live mic level meter. Opens a stream on the selected device, runs it through
+// an AnalyserNode, and drives the bar heights from real audio so users can see
+// their mic is actually picking up sound.
+function MicWave({ deviceId, active }: { deviceId: string; active: boolean }) {
+  const barsRef = useRef<(HTMLSpanElement | null)[]>([]);
+
+  useEffect(() => {
+    if (!active) return;
+    let stream: MediaStream | null = null;
+    let audioCtx: AudioContext | null = null;
+    let raf = 0;
+    let cancelled = false;
+
+    const flatten = () => {
+      for (const bar of barsRef.current) {
+        if (bar) bar.style.height = "10%";
+      }
+    };
+
+    const start = async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: deviceId ? { deviceId: { exact: deviceId } } : true,
+          video: false,
+        });
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          stream = null;
+          return;
+        }
+        audioCtx = new AudioContext();
+        const sourceNode = audioCtx.createMediaStreamSource(stream);
+        const analyser = audioCtx.createAnalyser();
+        analyser.fftSize = 64;
+        analyser.smoothingTimeConstant = 0.7;
+        sourceNode.connect(analyser);
+        const data = new Uint8Array(analyser.frequencyBinCount);
+
+        const tick = () => {
+          analyser.getByteFrequencyData(data);
+          const usable = Math.floor(data.length * 0.7);
+          for (let i = 0; i < WAVE_BARS; i++) {
+            const bar = barsRef.current[i];
+            if (!bar) continue;
+            const idx = Math.min(
+              usable - 1,
+              Math.floor((i / WAVE_BARS) * usable),
+            );
+            const level = data[idx] / 255;
+            bar.style.height = `${Math.max(10, Math.min(100, level * 130))}%`;
+          }
+          raf = requestAnimationFrame(tick);
+        };
+        tick();
+      } catch {
+        // Mic unavailable or access denied — leave the bars flat.
+        flatten();
+      }
+    };
+
+    void start();
+
+    return () => {
+      cancelled = true;
+      if (raf) cancelAnimationFrame(raf);
+      if (audioCtx) audioCtx.close().catch(() => {});
+      if (stream) stream.getTracks().forEach((t) => t.stop());
+    };
+  }, [deviceId, active]);
+
   return (
     <span className="mic-wave" aria-hidden>
-      <span className="bar b1" />
-      <span className="bar b2" />
-      <span className="bar b3" />
-      <span className="bar b4" />
+      {Array.from({ length: WAVE_BARS }).map((_, i) => (
+        <span
+          key={i}
+          className="bar"
+          ref={(el) => {
+            barsRef.current[i] = el;
+          }}
+        />
+      ))}
     </span>
   );
 }
@@ -47,6 +123,7 @@ export function MediaDeviceRow({
   onToggle,
   systemAudio,
   onSystemAudioToggle,
+  meterActive = true,
 }: {
   kind: "camera" | "mic";
   devices: MediaDeviceInfo[];
@@ -58,6 +135,7 @@ export function MediaDeviceRow({
   onToggle: (v: boolean) => void;
   systemAudio?: boolean;
   onSystemAudioToggle?: (v: boolean) => void;
+  meterActive?: boolean;
 }) {
   const current = useMemo(
     () =>
@@ -117,7 +195,9 @@ export function MediaDeviceRow({
         onChange={onToggle}
         label={kind === "camera" ? "Camera" : "Microphone"}
       />
-      {kind === "mic" && on ? <MicWave /> : null}
+      {kind === "mic" && on ? (
+        <MicWave deviceId={selectedId} active={on && meterActive} />
+      ) : null}
       {open ? (
         <div className="row-menu" role="menu">
           <button

--- a/templates/clips/desktop/src/components/MediaDeviceRow.tsx
+++ b/templates/clips/desktop/src/components/MediaDeviceRow.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { CameraIcon, CheckIcon, ChevronDown, MicIcon } from "./Icons";
 import { Switch } from "./Switch";
 import { useRowMenu } from "./useRowMenu";
-
-const WAVE_BARS = 18;
+import { useMicMeter, WAVE_BARS } from "../hooks/useMicMeter";
 
 function Toggle({
   on,
@@ -27,75 +26,20 @@ function Toggle({
   );
 }
 
-// Live mic level meter. Opens a stream on the selected device, runs it through
-// an AnalyserNode, and drives the bar heights from real audio so users can see
-// their mic is actually picking up sound.
-function MicWave({ deviceId, active }: { deviceId: string; active: boolean }) {
-  const barsRef = useRef<(HTMLSpanElement | null)[]>([]);
-
-  useEffect(() => {
-    if (!active) return;
-    let stream: MediaStream | null = null;
-    let audioCtx: AudioContext | null = null;
-    let raf = 0;
-    let cancelled = false;
-
-    const flatten = () => {
-      for (const bar of barsRef.current) {
-        if (bar) bar.style.height = "10%";
-      }
-    };
-
-    const start = async () => {
-      try {
-        stream = await navigator.mediaDevices.getUserMedia({
-          audio: deviceId ? { deviceId: { exact: deviceId } } : true,
-          video: false,
-        });
-        if (cancelled) {
-          stream.getTracks().forEach((t) => t.stop());
-          stream = null;
-          return;
-        }
-        audioCtx = new AudioContext();
-        const sourceNode = audioCtx.createMediaStreamSource(stream);
-        const analyser = audioCtx.createAnalyser();
-        analyser.fftSize = 64;
-        analyser.smoothingTimeConstant = 0.7;
-        sourceNode.connect(analyser);
-        const data = new Uint8Array(analyser.frequencyBinCount);
-
-        const tick = () => {
-          analyser.getByteFrequencyData(data);
-          const usable = Math.floor(data.length * 0.7);
-          for (let i = 0; i < WAVE_BARS; i++) {
-            const bar = barsRef.current[i];
-            if (!bar) continue;
-            const idx = Math.min(
-              usable - 1,
-              Math.floor((i / WAVE_BARS) * usable),
-            );
-            const level = data[idx] / 255;
-            bar.style.height = `${Math.max(10, Math.min(100, level * 130))}%`;
-          }
-          raf = requestAnimationFrame(tick);
-        };
-        tick();
-      } catch {
-        // Mic unavailable or access denied — leave the bars flat.
-        flatten();
-      }
-    };
-
-    void start();
-
-    return () => {
-      cancelled = true;
-      if (raf) cancelAnimationFrame(raf);
-      if (audioCtx) audioCtx.close().catch(() => {});
-      if (stream) stream.getTracks().forEach((t) => t.stop());
-    };
-  }, [deviceId, active]);
+// Live mic level meter. Drives the bar heights from real audio so users can see
+// their mic is actually picking up sound. When the camera bubble is live the
+// meter relays through the bubble page instead of opening a mic here (see
+// useMicMeter for the WebKit capture-exclusion details).
+function MicWave({
+  deviceId,
+  active,
+  relay,
+}: {
+  deviceId: string;
+  active: boolean;
+  relay: boolean;
+}) {
+  const barsRef = useMicMeter({ deviceId, active, relay });
 
   return (
     <span className="mic-wave" aria-hidden>
@@ -124,6 +68,7 @@ export function MediaDeviceRow({
   systemAudio,
   onSystemAudioToggle,
   meterActive = true,
+  meterRelay = false,
 }: {
   kind: "camera" | "mic";
   devices: MediaDeviceInfo[];
@@ -136,6 +81,7 @@ export function MediaDeviceRow({
   systemAudio?: boolean;
   onSystemAudioToggle?: (v: boolean) => void;
   meterActive?: boolean;
+  meterRelay?: boolean;
 }) {
   const current = useMemo(
     () =>
@@ -196,7 +142,11 @@ export function MediaDeviceRow({
         label={kind === "camera" ? "Camera" : "Microphone"}
       />
       {kind === "mic" && on ? (
-        <MicWave deviceId={selectedId} active={on && meterActive} />
+        <MicWave
+          deviceId={selectedId}
+          active={on && meterActive}
+          relay={meterRelay}
+        />
       ) : null}
       {open ? (
         <div className="row-menu" role="menu">

--- a/templates/clips/desktop/src/hooks/useMicMeter.ts
+++ b/templates/clips/desktop/src/hooks/useMicMeter.ts
@@ -1,0 +1,163 @@
+import { useEffect, useRef, type MutableRefObject } from "react";
+import { emit, listen } from "@tauri-apps/api/event";
+
+// Number of bars in the live mic level meter. The popover sends this to the
+// bubble page in relay mode so both sides agree on the sample count.
+export const WAVE_BARS = 18;
+
+function levelToHeight(level: number): string {
+  return `${Math.max(10, Math.min(100, level * 130))}%`;
+}
+
+function flatten(bars: (HTMLSpanElement | null)[]): void {
+  for (const bar of bars) if (bar) bar.style.height = "10%";
+}
+
+function applyLevels(
+  bars: (HTMLSpanElement | null)[],
+  levels: number[],
+): void {
+  for (let i = 0; i < bars.length; i++) {
+    const bar = bars[i];
+    if (bar) bar.style.height = levelToHeight(levels[i] ?? 0);
+  }
+}
+
+/**
+ * Drives a row of bars from live mic input so users can validate their mic.
+ *
+ * Two modes, because of WebKit's single-page capture-exclusion (Tauri runs
+ * every webview in one WebKit process; when one page calls getUserMedia, capture
+ * in OTHER pages is muted):
+ *
+ *  - **local** (`relay === false`): no camera bubble is live, so we can open the
+ *    mic in this page and analyse it directly.
+ *  - **relay** (`relay === true`): the camera bubble owns a live capture in
+ *    another page. Opening a mic here would black it out, so we ask the bubble
+ *    page (same page as its camera → no mute) to run the analyser and emit level
+ *    samples, which we just render.
+ */
+export function useMicMeter({
+  active,
+  deviceId,
+  relay,
+}: {
+  active: boolean;
+  deviceId: string;
+  relay: boolean;
+}): MutableRefObject<(HTMLSpanElement | null)[]> {
+  const barsRef = useRef<(HTMLSpanElement | null)[]>([]);
+
+  // Local mode — open the mic in this page and analyse it.
+  useEffect(() => {
+    if (!active || relay) return;
+    let stream: MediaStream | null = null;
+    let audioCtx: AudioContext | null = null;
+    let raf = 0;
+    let cancelled = false;
+
+    const start = async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: deviceId ? { deviceId: { exact: deviceId } } : true,
+          video: false,
+        });
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          stream = null;
+          return;
+        }
+        audioCtx = new AudioContext();
+        const sourceNode = audioCtx.createMediaStreamSource(stream);
+        const analyser = audioCtx.createAnalyser();
+        analyser.fftSize = 64;
+        analyser.smoothingTimeConstant = 0.7;
+        sourceNode.connect(analyser);
+        const data = new Uint8Array(analyser.frequencyBinCount);
+
+        const tick = () => {
+          analyser.getByteFrequencyData(data);
+          const usable = Math.floor(data.length * 0.7);
+          const levels: number[] = [];
+          for (let i = 0; i < WAVE_BARS; i++) {
+            const idx = Math.min(
+              usable - 1,
+              Math.floor((i / WAVE_BARS) * usable),
+            );
+            levels.push(data[idx] / 255);
+          }
+          applyLevels(barsRef.current, levels);
+          raf = requestAnimationFrame(tick);
+        };
+        tick();
+      } catch {
+        flatten(barsRef.current);
+      }
+    };
+
+    void start();
+
+    return () => {
+      cancelled = true;
+      if (raf) cancelAnimationFrame(raf);
+      if (audioCtx) audioCtx.close().catch(() => {});
+      if (stream) stream.getTracks().forEach((t) => t.stop());
+    };
+  }, [active, relay, deviceId]);
+
+  // Relay mode — the bubble page owns the mic and emits level samples.
+  useEffect(() => {
+    if (!active || !relay) return;
+    let stopped = false;
+    let levelUnlisten: (() => void) | null = null;
+    let readyUnlisten: (() => void) | null = null;
+
+    const requestStart = () => {
+      emit("clips:mic-meter-start", {
+        micId: deviceId || null,
+        bars: WAVE_BARS,
+      }).catch(() => {});
+    };
+
+    requestStart();
+
+    listen<{ levels?: number[] }>("clips:mic-level", (event) => {
+      if (stopped) return;
+      const levels = event.payload?.levels;
+      if (Array.isArray(levels)) applyLevels(barsRef.current, levels);
+    })
+      .then((u) => {
+        if (stopped) {
+          u();
+          return;
+        }
+        levelUnlisten = u;
+      })
+      .catch(() => {});
+
+    // The bubble webview may mount after we first asked. It re-announces with
+    // `clips:bubble-ready`; re-send the start so the meter survives the race
+    // (the bubble ignores repeats for the same device).
+    listen("clips:bubble-ready", () => {
+      if (!stopped) requestStart();
+    })
+      .then((u) => {
+        if (stopped) {
+          u();
+          return;
+        }
+        readyUnlisten = u;
+      })
+      .catch(() => {});
+
+    return () => {
+      stopped = true;
+      if (levelUnlisten) levelUnlisten();
+      if (readyUnlisten) readyUnlisten();
+      emit("clips:mic-meter-stop", {}).catch(() => {});
+      flatten(barsRef.current);
+    };
+  }, [active, relay, deviceId]);
+
+  return barsRef;
+}

--- a/templates/clips/desktop/src/overlays/bubble.tsx
+++ b/templates/clips/desktop/src/overlays/bubble.tsx
@@ -259,8 +259,34 @@ export function Bubble() {
     let startUnlisten: (() => void) | null = null;
     let stopUnlisten: (() => void) | null = null;
     let refreshMicsUnlisten: (() => void) | null = null;
+    let meterStartUnlisten: (() => void) | null = null;
+    let meterStopUnlisten: (() => void) | null = null;
     let renderedFrames = 0;
     let lastFpsLogAt = 0;
+
+    // Live mic meter session. The popover delegates this to us because opening a
+    // mic in its own page would mute this bubble's camera (WebKit cross-page
+    // capture-exclusion). Opening the mic HERE — same page as our camera — does
+    // not mute it, so we run the analyser and relay level samples to the popover.
+    let meterStream: MediaStream | null = null;
+    let meterCtx: AudioContext | null = null;
+    let meterTimer: ReturnType<typeof setInterval> | null = null;
+    let meterMicId: string | null = null;
+    const stopMicMeter = () => {
+      if (meterTimer) {
+        clearInterval(meterTimer);
+        meterTimer = null;
+      }
+      if (meterCtx) {
+        meterCtx.close().catch(() => {});
+        meterCtx = null;
+      }
+      if (meterStream) {
+        meterStream.getTracks().forEach((t) => t.stop());
+        meterStream = null;
+      }
+      meterMicId = null;
+    };
 
     const stopLocalCanvasRenderer = () => {
       const videoEl = videoRef.current;
@@ -509,8 +535,89 @@ export function Bubble() {
       })
       .catch(() => {});
 
+    // Start the live mic meter on request and emit level samples the popover
+    // renders. We open the mic here (same page as our camera) so the bubble
+    // stays live instead of getting muted.
+    listen<{ micId?: string | null; bars?: number }>(
+      "clips:mic-meter-start",
+      async (event) => {
+        if (stopped) return;
+        const micId = event.payload?.micId?.trim() || null;
+        // Ignore idempotent repeats for the same device (the popover re-sends on
+        // bubble-ready and on a show-bubble timer to beat the mount race).
+        if (meterStream && meterMicId === micId) return;
+        stopMicMeter();
+        const barCount = Math.max(1, event.payload?.bars ?? 18);
+        try {
+          const stream = await navigator.mediaDevices.getUserMedia({
+            audio: micId ? { deviceId: { exact: micId } } : true,
+            video: false,
+          });
+          if (stopped) {
+            stream.getTracks().forEach((t) => t.stop());
+            return;
+          }
+          meterStream = stream;
+          meterMicId = micId;
+          const ctx = new AudioContext();
+          meterCtx = ctx;
+          const sourceNode = ctx.createMediaStreamSource(stream);
+          const analyser = ctx.createAnalyser();
+          analyser.fftSize = 64;
+          analyser.smoothingTimeConstant = 0.7;
+          sourceNode.connect(analyser);
+          const data = new Uint8Array(analyser.frequencyBinCount);
+          meterTimer = setInterval(() => {
+            analyser.getByteFrequencyData(data);
+            const usable = Math.floor(data.length * 0.7);
+            const levels: number[] = [];
+            for (let i = 0; i < barCount; i++) {
+              const idx = Math.min(
+                usable - 1,
+                Math.floor((i / barCount) * usable),
+              );
+              levels.push(data[idx] / 255);
+            }
+            emit("clips:mic-level", { levels }).catch(() => {});
+          }, 50);
+        } catch (err) {
+          console.warn("[bubble] mic meter failed", err);
+          stopMicMeter();
+        }
+      },
+    )
+      .then((u) => {
+        if (stopped) {
+          try {
+            u();
+          } catch {
+            // ignore
+          }
+        } else {
+          meterStartUnlisten = u;
+        }
+      })
+      .catch(() => {});
+
+    listen("clips:mic-meter-stop", () => {
+      stopMicMeter();
+    })
+      .then((u) => {
+        if (stopped) {
+          try {
+            u();
+          } catch {
+            // ignore
+          }
+        } else {
+          meterStopUnlisten = u;
+        }
+      })
+      .catch(() => {});
+
     return () => {
       stopped = true;
+      stopMicMeter();
       try {
         startUnlisten?.();
       } catch {
@@ -523,6 +630,16 @@ export function Bubble() {
       }
       try {
         refreshMicsUnlisten?.();
+      } catch {
+        // ignore
+      }
+      try {
+        meterStartUnlisten?.();
+      } catch {
+        // ignore
+      }
+      try {
+        meterStopUnlisten?.();
       } catch {
         // ignore
       }

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -716,53 +716,26 @@ body[data-clips-route="recording-pill"] #root {
   transform: translateX(14px);
 }
 
-/* Mic level indicator — animated bars under the mic row. */
+/* Live mic level meter — bars driven by real audio input under the mic row. */
 .mic-wave {
   position: absolute;
   left: 12px;
   right: 12px;
   bottom: 4px;
-  height: 3px;
+  height: 14px;
   display: flex;
   gap: 2px;
   align-items: flex-end;
   pointer-events: none;
-  opacity: 0.55;
+  opacity: 0.75;
 }
 
 .mic-wave .bar {
   flex: 1;
   background: var(--brand);
   border-radius: 1px;
-  animation: mic-pulse 1.2s ease-in-out infinite;
-  height: 60%;
-}
-
-.mic-wave .b1 {
-  animation-delay: 0s;
-  height: 40%;
-}
-.mic-wave .b2 {
-  animation-delay: 0.15s;
-  height: 80%;
-}
-.mic-wave .b3 {
-  animation-delay: 0.3s;
-  height: 55%;
-}
-.mic-wave .b4 {
-  animation-delay: 0.45s;
-  height: 70%;
-}
-
-@keyframes mic-pulse {
-  0%,
-  100% {
-    transform: scaleY(1);
-  }
-  50% {
-    transform: scaleY(0.4);
-  }
+  height: 10%;
+  transition: height 0.08s linear;
 }
 
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
### Summary
Replaces the static animated mic wave bars in the clips desktop popover with a real-time audio level meter, so users can visually confirm their microphone is actually picking up sound.

### Problem
The existing mic wave indicator was a purely decorative CSS animation — it played regardless of whether the mic was working or even selected. Users had no way to validate that their microphone was actually capturing audio before starting a recording.

### Solution
A new `useMicMeter` hook drives the bar heights from live `AnalyserNode` frequency data. Because Tauri runs all webviews in a single WebKit process (opening `getUserMedia` in one page mutes capture in others), the hook operates in two modes: **local** mode when no camera bubble is active (opens the mic directly in the popover page), and **relay** mode when the bubble is live (delegates mic capture to the bubble page via Tauri events, which then emits level samples back to the popover for rendering).

### Key Changes
- **`useMicMeter` hook** (`src/hooks/useMicMeter.ts`): new hook that manages mic capture and `AudioContext` analysis; supports local and relay modes via Tauri `emit`/`listen` events (`clips:mic-meter-start`, `clips:mic-meter-stop`, `clips:mic-level`, `clips:bubble-ready`).
- **`MicWave` component** (`MediaDeviceRow.tsx`): updated to accept `deviceId`, `active`, and `relay` props; renders `WAVE_BARS` (18) dynamically ref-driven bars instead of 4 hardcoded static ones.
- **`MediaDeviceRow`**: exposes `meterActive` and `meterRelay` props; passes `popoverVisible && !isRecording` and `bubbleActive` from `app.tsx` to control meter lifecycle.
- **Bubble page** (`bubble.tsx`): listens for `clips:mic-meter-start`/`stop` events and runs the analyser in the bubble's page context (same page as the camera), emitting `clips:mic-level` samples at 50 ms intervals to avoid muting the camera feed.
- **CSS** (`styles.css`): removed the `mic-pulse` keyframe animation and per-bar static heights/delays; bars now use `height: 10%` as a baseline with a `0.08s linear` transition, driven entirely by JS.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/oval-route-0r9k2wiy"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-oval-route-0r9k2wiy.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1319`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>oval-route-0r9k2wiy</branchName>-->