### PR TITLE
Polish template docs visuals and block rendering

### DIFF
--- a/.changeset/annotated-code-hover-dots.md
+++ b/.changeset/annotated-code-hover-dots.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Restore subtle glowing hover indicators on annotated code ranges.

--- a/.changeset/fast-docs-diagram-tooltips.md
+++ b/.changeset/fast-docs-diagram-tooltips.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Use fast shadcn tooltips and clearer Tabler icons for diagram style toggles.

--- a/.changeset/preserve-plan-recap-login-return.md
+++ b/.changeset/preserve-plan-recap-login-return.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve deep-link return targets through auth and federated SSO sign-in.

--- a/packages/core/docs/content/template-analytics.md
+++ b/packages/core/docs/content/template-analytics.md
@@ -7,15 +7,12 @@ description: "Ask analytics questions in plain English, get charts and dashboard
 
 Ask analytics questions in plain English, get charts and dashboards back. The agent connects to BigQuery, GA4, Amplitude, the built-in first-party event collector, HubSpot, Jira, and a dozen other sources, writes the query for you, validates it, and renders the answer as a chart, table, or saved dashboard panel.
 
-<!-- screenshot:
-  app: analytics
-  view: /adhoc/<dashboard-id>
-  shows: Adhoc dashboard with 3 KPI cards (Weekly active users 24,318 / New signups 1,842 / Revenue MRR $48,210), Weekly active users line chart and Revenue over time area chart side by side, Signups by source bar chart below
-  account: screenshot-account (dashboard authored on this account against a seeded warehouse)
-  capture: 1400x800 viewport, cropped 90px from bottom (final 1400x710)
--->
-
-![Analytics dashboard with KPIs and charts](/screenshots/analytics.png)
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='display:flex;flex-direction:column;gap:14px;padding:18px;min-height:500px;box-sizing:border-box'><h1 style='margin:0'>Agent-Native Templates</h1><p class='wf-muted' style='margin:0'>Adoption and engagement across the last 12 weeks.</p><div style='display:grid;grid-template-columns:repeat(3,1fr);gap:12px'><div class='wf-card'><small class='wf-muted'>Weekly active users</small><br/><strong>24,318</strong><br/><span class='wf-pill accent'>+12.4%</span></div><div class='wf-card'><small class='wf-muted'>New signups</small><br/><strong>1,842</strong><br/><span class='wf-pill accent'>+8.7%</span></div><div class='wf-card'><small class='wf-muted'>Revenue MRR</small><br/><strong>$48,210</strong><br/><span class='wf-pill accent'>+21.3%</span></div></div><div style='display:grid;grid-template-columns:1fr 1fr;gap:12px;flex:1'><div class='wf-card' style='display:flex;flex-direction:column;gap:10px'><strong>Weekly active users</strong><div style='flex:1;display:flex;align-items:end;gap:8px'><div style='height:38%;flex:1;background:var(--wf-accent-soft)'></div><div style='height:44%;flex:1;background:var(--wf-accent-soft)'></div><div style='height:58%;flex:1;background:var(--wf-accent-soft)'></div><div style='height:74%;flex:1;background:var(--wf-accent-soft)'></div></div></div><div class='wf-card' style='display:flex;flex-direction:column;gap:10px'><strong>Revenue over time</strong><div style='flex:1;display:flex;align-items:end;gap:8px'><div style='height:32%;flex:1;background:var(--wf-accent-soft)'></div><div style='height:48%;flex:1;background:var(--wf-accent-soft)'></div><div style='height:63%;flex:1;background:var(--wf-accent-soft)'></div><div style='height:80%;flex:1;background:var(--wf-accent-soft)'></div></div></div></div><div class='wf-card'><strong>Signups by source</strong><br/><small class='wf-muted'>Lower chart begins below the main charts.</small></div></div>"
+}
+```
 
 It's an open-source replacement for Amplitude, Mixpanel, and Looker — for teams that want to own the code, the queries, and the data.
 
@@ -96,42 +93,15 @@ pnpm dev
 
 The CLI prints the local dev URL. Sign in with Google, then open the **Data Sources** page to connect BigQuery, GA4, first-party tracking, HubSpot, Jira, and the rest.
 
-### Key features (technical)
+### Key features
 
-**Natural-language chart generation.** Ask the agent in plain English. It picks the right data source, writes the SQL, validates it against the warehouse, and renders the chart inline in chat or as a saved panel. Chart types: `line`, `area`, `bar`, `metric`, `table`, `pie`.
+**Ask questions, get charts.** The agent picks a data source, writes and validates SQL, then renders a chart, table, metric, or saved panel.
 
-**Reusable SQL dashboards.** Dashboards are a named config with an array of panels. Each panel has an `id`, `title`, `sql`, `source` (`bigquery` / `ga4` / `amplitude` / `first-party`), `chartType`, and `width` (1 or 2 columns). See the full shape in `templates/analytics/app/pages/adhoc/sql-dashboard/types.ts`.
+**Dashboards and investigations.** Reusable dashboards keep SQL panels, filters, saved views, and sharing; ad-hoc analyses save longer findings with re-run instructions.
 
-Dashboards support:
+**Living data dictionary.** Metric definitions, owners, source tables, and known caveats give the agent the real warehouse vocabulary before it writes queries.
 
-- **Parametric SQL** — declare `variables` and `filters` at the dashboard level; panels reference them with `{{var}}` interpolation.
-- **Saved views** — per-dashboard filter presets stored in the `dashboard_views` table.
-- **Resizable panels** — 1- or 2-column width per panel; the grid fills the rest.
-- **Sharing** — private by default, share with users or orgs (`viewer` / `editor` / `admin`).
-
-**Ad-hoc analyses.** Long-form investigations that cross-reference sources. An analysis saves the original question, step-by-step re-run instructions, the data sources it touched, and the full findings in Markdown. Anyone with access can re-run it against fresh data. Stored in the `analyses` table (see `templates/analytics/server/db/schema.ts`).
-
-**Living data dictionary.** Canonical catalog of metrics — metric name, definition, table, columns, SQL template, known gotchas, owner, and data lag. The agent reads it before writing any SQL, so it uses the real warehouse column names (`hs_is_closed`, not guessed `is_closed`) and knows about caveats like "excludes internal emails". Seeded by asking the agent to import definitions from an existing source (dbt descriptions, a Notion page, a team wiki).
-
-**SQL query explorer.** Direct queries against BigQuery and supported analytics backends from the **Ad-hoc** view. Useful for iterating before saving a dashboard panel.
-
-**First-party analytics collector.** Hosted apps can send product and template events to `/track` with a public write key. Query those events through `query-agent-native-analytics` or dashboard panels with `source: "first-party"`.
-
-**Multiple data connectors.** Built-in actions for common sources:
-
-| Category      | Actions                                                                  |
-| ------------- | ------------------------------------------------------------------------ |
-| Warehouse     | `bigquery`, `bigquery-table-info`, `ga4-report`                          |
-| Product       | `mixpanel-events`, `amplitude-events`, `posthog-events`                  |
-| CRM & Revenue | `hubspot-deals`, `hubspot-metrics`, `hubspot-pipelines`, `apollo-search` |
-| Engineering   | `github-prs`, `jira-search`, `jira-analytics`                            |
-| Support       | `pylon-issues`, `gong-calls`                                             |
-| Community     | `commonroom-members`, `twitter-tweets`                                   |
-| Content & SEO | `seo-top-keywords`, `seo-page-keywords`, `seo-blog-pages`                |
-
-Full list lives in `templates/analytics/actions/`. New sources are added by dropping a new action file — the agent picks them up automatically.
-
-**Organizations and sharing.** Multi-org deployments are wired up by default via `@agent-native/core/org`. Dashboards and analyses are scoped to the active org. The `/team` route manages members and invitations. See `templates/analytics/app/routes/team.tsx`. Sharing uses the framework's `share-resource` primitive. Coarse visibility is `private` / `org` / `public`; fine-grained grants are per-principal with `viewer` / `editor` / `admin` roles.
+**Broad connector surface.** BigQuery, GA4, product analytics, CRM, support, community, GitHub/Jira, SEO, and first-party `/track` events all come through actions the agent can call.
 
 ### Working with the agent
 

--- a/packages/core/docs/content/template-assets.md
+++ b/packages/core/docs/content/template-assets.md
@@ -7,9 +7,14 @@ description: "An agent-native digital asset manager and cross-agent generation s
 
 Assets is an agent-native workspace for creating and managing brand-consistent media. It organizes uploads and generated results into libraries and folders, lets teams collect examples for blog heroes, diagrams, landing pages, product shots, videos, and logos, then routes generation through the agent chat so every asset can be reviewed and refined.
 
-![Assets library for brand media and generated output](https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F769092170a14474f998cbca47384f891?format=webp&width=1200)
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='display:flex;flex-direction:column;gap:14px;padding:18px;min-height:520px;box-sizing:border-box'><div style='display:flex;align-items:center;gap:10px'><h1 style='margin:0'>Launch brand</h1><span class='wf-pill accent'>Blog heroes</span><span class='wf-pill'>Product shots</span><span class='wf-pill'>Logos</span><div style='flex:1'></div><button>Upload</button><button class='primary'>Generate</button></div><div class='wf-card' style='display:flex;flex-direction:column;gap:10px'><strong>Create brand media</strong><div class='wf-box'>Three homepage hero options using the approved logo and product references.</div><div style='display:flex;gap:8px;flex-wrap:wrap'><span class='wf-pill accent'>4 references</span><span class='wf-pill'>16:9</span><span class='wf-pill'>Web export</span></div></div><div style='display:grid;grid-template-columns:repeat(3,1fr);gap:12px;flex:1'><div class='wf-card' style='display:flex;align-items:end;min-height:130px'><span class='wf-pill accent'>Hero A</span></div><div class='wf-card' style='display:flex;align-items:end;min-height:130px'><span class='wf-pill'>Reference set</span></div><div class='wf-card' style='display:flex;align-items:end;min-height:130px'><span class='wf-pill'>Logo safe</span></div></div><div class='wf-card' style='display:grid;grid-template-columns:repeat(4,1fr);gap:8px'><div class='wf-box'>Use</div><div class='wf-box'>Refine</div><div class='wf-box'>Compare</div><div class='wf-box'>Export</div></div></div>"
+}
+```
 
-When you open the app, you see your libraries and folders on the left, the assets in the selected library in the middle, and a chat composer for generating new media. The agent can browse, search, generate, refine, and export every asset through the same actions the UI uses.
+When you open the app, the selected library, prompt, references, and generated candidates stay in one workspace. The agent can browse, search, generate, refine, and export every asset through the same actions the UI uses.
 
 ```an-diagram title="Generate, review, reuse" summary="References and prompts feed a generate-and-choose session; chosen assets land in a library and flow out to other apps via the picker or A2A."
 {
@@ -41,7 +46,7 @@ Live demo: [assets.agent-native.com](https://assets.agent-native.com).
 
 ## Useful prompts
 
-- "Generate three blog hero options using the Acme product screenshots as references."
+- "Generate three blog hero options using the Acme product references."
 - "Create a square social image in the launch-campaign style."
 - "Find all approved assets for the onboarding redesign."
 - "Turn this uploaded diagram into a cleaner product explainer image."

--- a/packages/core/docs/content/template-brain.md
+++ b/packages/core/docs/content/template-brain.md
@@ -26,7 +26,12 @@ surfaces for connecting data, approving proposals, and inspecting cited memory.
 }
 ```
 
-![Brain company chat with cited memory sources](https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9c9fe3b5b9494e33803cd3f494cba356?format=webp&width=1200)
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='display:flex;flex-direction:column;gap:14px;padding:18px;min-height:520px;box-sizing:border-box'><div style='display:flex;align-items:center;gap:10px'><h1 style='margin:0'>Ask company memory</h1><span class='wf-pill accent'>42 approved memories</span><span class='wf-pill'>3 sources</span><div style='flex:1'></div><button>Sources</button><button>Review</button></div><div class='wf-card' style='display:flex;align-items:center;gap:10px'><span data-icon='search' aria-label='Search'></span><strong style='flex:1'>Why did we choose usage pricing?</strong><button class='primary'>Ask</button></div><div class='wf-card' style='display:flex;flex-direction:column;gap:10px'><strong>Answer</strong><p style='margin:0'>The team chose usage pricing after pilots showed seat counts undercounted automation value.</p><div style='display:flex;gap:8px;flex-wrap:wrap'><span class='wf-pill accent'>Pricing RFC</span><span class='wf-pill'>Launch retro</span><span class='wf-pill'>Sales notes</span></div></div><div class='wf-card' style='flex:1;display:flex;flex-direction:column;gap:8px'><strong>Source timeline</strong><div class='wf-box'>May 3 · Decision captured</div><div class='wf-box'>May 8 · Customer evidence added</div><div class='wf-box'>May 12 · Legal note approved</div></div></div>"
+}
+```
 
 When you open the app, **Ask** is front and center — a clean chat over reviewed
 company memory. **Sources**, **Review**, and **Knowledge** sit alongside it as

--- a/packages/core/docs/content/template-calendar.md
+++ b/packages/core/docs/content/template-calendar.md
@@ -7,17 +7,14 @@ description: "An agent-powered calendar with Google Calendar sync and Calendly-s
 
 An agent-powered calendar app. Connect your Google Calendar and the agent can read your schedule, find free slots, create events, and manage Calendly-style booking links — all in plain English. It replaces the Google Calendar + Calendly combo with one app you own.
 
-<!-- screenshot:
-  app: calendar
-  view: / (week)
-  shows: Calendar week view (May 3-9) with ~17 events scattered across the week (All-hands kickoff, Q3 launch sync, Design review, 1:1 with Marcus, Coffee w/ Hannah, Eng standup, Lunch block, Customer call - Acme, Design crit, Focus block, Roadmap planning, Skip-level w/ Priya, Friday demo, All-hands) — events render in the default blue tone — and the agent sidebar with calendar-aware suggestions
-  account: screenshot-account (Google Calendar connected and a representative week populated via create-event)
-  capture: 1400x800 viewport, cropped 90px from bottom (final 1400x710)
--->
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='display:flex;flex-direction:column;min-height:530px;box-sizing:border-box'><div style='display:flex;align-items:center;gap:10px;padding:14px 18px;border-bottom:1.4px solid var(--wf-line)'><button>Week</button><button>Today</button><button>‹</button><button>›</button><div style='flex:1'></div><strong>May 3-9, 2026</strong><div style='flex:1'></div><button class='primary'>New Event</button></div><div style='display:grid;grid-template-columns:56px repeat(7,minmax(0,1fr));grid-template-rows:36px repeat(5,72px);gap:7px;padding:14px;flex:1'><div></div><strong>Sun 3</strong><strong>Mon 4</strong><strong>Tue 5</strong><strong>Wed 6</strong><strong>Thu 7</strong><strong>Fri 8</strong><strong>Sat 9</strong><small class='wf-muted'>7 AM</small><div class='wf-box' style='opacity:.45'></div><div></div><div></div><div></div><div></div><div></div><div></div><small class='wf-muted'>9 AM</small><div class='wf-box'>All-hands</div><div class='wf-box'>Eng standup</div><div class='wf-box'>Eng standup</div><div class='wf-box'>Eng standup</div><div></div><div class='wf-box'>Planning</div><div></div><small class='wf-muted'>11 AM</small><div class='wf-box'>Design review</div><div></div><div class='wf-box'>Design crit</div><div class='wf-box'>Roadmap</div><div class='wf-box'>Friday demo</div><div></div><div></div><small class='wf-muted'>1 PM</small><div></div><div class='wf-box'>1:1</div><div class='wf-box'>Focus block</div><div></div><div></div><div class='wf-box'>All-hands</div><div></div><small class='wf-muted'>3 PM</small><div></div><div></div><div></div><div class='wf-box'>Skip-level</div><div></div><div></div><div></div></div></div>"
+}
+```
 
-![Calendar week view with a populated week and the agent sidebar](/screenshots/calendar.png)
-
-When you open the app, you'll see your calendar in the middle and the agent in the sidebar. The agent always knows which day, week, or event you're looking at, so you can say "schedule a 30-minute call with Alex on this day" without spelling everything out.
+When you open the app, the active calendar view is the primary surface. The agent still knows which day, week, or event you're looking at, so you can say "schedule a 30-minute call with Alex on this day" without spelling everything out.
 
 ```an-diagram title="How a scheduling request flows" summary="Whether you click in the calendar or ask the agent, the same actions read live from Google Calendar and write back to the same view."
 {
@@ -87,60 +84,17 @@ Open `http://localhost:8082` (the default Calendar dev port).
 
 To connect Google Calendar in dev, open the Settings view, paste a `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` from [Google Cloud Console](https://console.cloud.google.com/), and click "Connect Google Calendar". The OAuth redirect URI is `http://localhost:8082/_agent-native/google/callback` in dev. Tokens are stored in the `oauth_tokens` SQL table and refresh automatically.
 
-### Key features (technical)
+### Key features
 
-**Calendar views.** The main view at `/` (route `app/routes/_app._index.tsx`) renders the calendar in day, week, or month mode. Switch views from the toolbar, or ask the agent to switch for you. Events are fetched live from Google Calendar — no local sync step is required to see the latest state.
+**Live calendar views.** Day, week, and month views read directly from connected Google accounts, with optional read-only ICS feeds layered into the same schedule.
 
-**Multi-account Google Calendar sync.** Connect as many Google accounts as you like. Each connection appears in Settings, and events from every connected calendar overlay in the main view. Sync is pull-based, so no webhooks or background workers are required. The `sync-google-calendar` action refetches a date range on demand. Supporting actions: `list-events`, `search-events`, `get-event`, `create-event`, `sync-google-calendar`.
+**Availability and free-slot search.** Weekly availability rules, timezone support, and existing events all feed the same availability action the UI and agent use.
 
-**External calendars (ICS subscriptions).** Subscribe to read-only ICS or `webcal://` feeds — useful for HR time off, conference schedules, or shared team calendars. Feeds are added in Settings and stored per user. Relevant actions: `add-external-calendar`, `list-external-calendars`, `remove-external-calendar`, `update-external-calendars`.
+**Booking links.** Public `/book/{slug}` pages collect name, email, custom fields, conferencing preferences, and cancellation/reschedule tokens.
 
-**Availability rules.** Availability is a weekly schedule of time windows per day, plus a timezone. It is stored in the settings table under the key `calendar-availability`:
+**Shareable management.** Booking links are private by default, but can be shared with teammates through the framework sharing actions.
 
-```json
-{
-  "timezone": "America/Los_Angeles",
-  "schedule": {
-    "monday": [{ "start": "09:00", "end": "17:00" }],
-    "tuesday": [{ "start": "09:00", "end": "17:00" }],
-    "wednesday": [
-      { "start": "09:00", "end": "12:00" },
-      { "start": "13:00", "end": "17:00" }
-    ],
-    "thursday": [{ "start": "09:00", "end": "17:00" }],
-    "friday": [{ "start": "09:00", "end": "16:00" }],
-    "saturday": [],
-    "sunday": []
-  }
-}
-```
-
-Edit it at `/availability` (`app/routes/_app.availability.tsx`) or via the `update-availability` action. The `check-availability` action reads this schedule, subtracts your existing Google Calendar events, and returns free slots of the requested duration.
-
-**Public booking pages.** Booking links are the Calendly replacement. Create one in the UI at `/booking-links` (`app/routes/_app.booking-links._index.tsx`), configure it in the editor at `/booking-links/{id}`, and share the public URL.
-
-Every link has:
-
-- A URL slug, so the public page lives at `/book/{slug}`.
-- A primary duration plus an optional list of alternative durations (for example 15, 30, or 60 minutes).
-- Optional custom fields collected at booking time.
-- A conferencing option (Google Meet, Zoom, or a custom meeting link).
-- An `isActive` toggle to pause bookings without deleting the link.
-
-Visitors land on the public page, pick a date and time from the available slots, fill in name, email, and any custom fields, and receive a confirmation. Bookings are stored in the `bookings` table with a `cancelToken`, which powers the public cancel/reschedule page at `/booking/manage/{token}`.
-
-There is also a per-user public URL at `/meet/{username}/{slug}` for clean personal sharing.
-
-**Sharing booking links with teammates.** Booking links are private by default — only the creator can edit or delete them. To let a teammate manage a link, either change the link's visibility or grant explicit access. The framework ships these actions, auto-mounted for any `booking-link` resource:
-
-- `share-resource` — grant a user or org `viewer`, `editor`, or `admin` access.
-- `unshare-resource` — revoke a grant.
-- `list-resource-shares` — show current visibility plus all grants.
-- `set-resource-visibility` — change the coarse visibility (`private`, `org`, or `public`).
-
-Sharing only controls who can manage the link. The public booking URL always accepts bookings from unauthenticated visitors as long as `isActive` is true.
-
-**Inline event previews in chat.** The `/event` route (`app/routes/event.tsx`) renders a compact, chromeless event card that the agent can embed in chat when you ask about a specific event. Title, time, location, attendees, and a description snippet are shown with a button to jump into the main calendar.
+**Inline event previews.** The agent can embed compact event cards in chat with title, time, location, attendees, and a jump-back button.
 
 ### Working with the agent
 

--- a/packages/core/docs/content/template-chat.md
+++ b/packages/core/docs/content/template-chat.md
@@ -9,15 +9,12 @@ Chat is the basic agent-native app starting point. It gives you a clean ChatGPT-
 
 If you want the smallest action-only runtime with no browser UI, start with [Pure-Agent Apps](/docs/pure-agent-apps). If you want a finished domain product shape, start from [Calendar](/docs/template-calendar), [Mail](/docs/template-mail), [Content](/docs/template-content), [Forms](/docs/template-forms), [Analytics](/docs/template-analytics), or another domain template.
 
-<!-- screenshot:
-  app: chat
-  view: /
-  shows: Full-page chat app with standard left sidebar, centered empty-state composer, model controls, and no domain data
-  account: screenshot-account (no domain data needed — chat ships with no seed schema)
-  capture: 2434x1440 app screenshot
--->
-
-![Chat template with a centered agent composer and app navigation sidebar](/screenshots/chat.png)
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='min-height:560px;box-sizing:border-box;display:flex;align-items:center;justify-content:center;padding:56px 40px'><div style='display:flex;flex-direction:column;align-items:center;justify-content:center;gap:28px;width:min(700px,92%);min-height:430px'><div style='height:34px'></div><div style='text-align:center'><h1 style='margin:0'>How can I help?</h1><p class='wf-muted' style='margin:10px 0 0'>Chat about anything. Add actions, components, pages, jobs, or your own backend.</p></div><div class='wf-card' style='width:100%;min-height:150px;display:flex;flex-direction:column;gap:18px'><span class='wf-muted'>Message the agent...</span><div style='flex:1'></div><div style='display:flex;align-items:center;gap:10px'><span data-icon='plus' aria-label='Attach'></span><div style='flex:1'></div><span class='wf-pill'>Sonnet 4.6 · Auto</span><span class='wf-pill'>Act</span><button class='primary'>↑</button></div></div><div style='height:34px'></div></div></div>"
+}
+```
 
 ## What's in it {#whats-in-it}
 

--- a/packages/core/docs/content/template-clips.md
+++ b/packages/core/docs/content/template-clips.md
@@ -7,15 +7,12 @@ description: "Async screen recording, calendar-synced meeting notes, and push-to
 
 A capture-everything app: screen recordings, meeting notes from your calendar, and Fn-hold voice dictation. The agent transcribes, titles, summarizes, and indexes all of it — then lets you ask "find the clip where we discussed the rollout plan" and searches across every transcript you've ever made.
 
-<!-- screenshot:
-  app: clips
-  view: /library
-  shows: Library with Acme Co. organization, folders (Onboarding videos / Customer calls / Bug repros) and spaces (Engineering / Design / Sales) in the sidebar, six recordings in a 3-column grid (Q3 OKRs review meeting, Walkthrough of new onboarding flow, Eng standup May 4, Dictation - Ideas for landing page copy, Customer call - Acme Corp pricing review, Bug repro - drag-and-drop in Safari)
-  account: screenshot-account (recordings imported into this org via the standard upload + meetings flow)
-  capture: 1400x800 viewport, cropped 90px from bottom (final 1400x710)
--->
-
-![Clips library with recordings, folders, and spaces](/screenshots/clips.png)
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='display:flex;flex-direction:column;gap:14px;padding:18px;min-height:520px;box-sizing:border-box'><div style='display:flex;align-items:center;gap:10px'><h1 style='margin:0'>Engineering clips</h1><span class='wf-pill accent'>Library</span><span class='wf-pill'>Meetings</span><span class='wf-pill'>Dictation</span><div style='flex:1'></div><button>Import</button><button class='primary'>Record</button></div><div style='display:grid;grid-template-columns:repeat(3,1fr);gap:12px'><div class='wf-card' style='height:120px;display:flex;flex-direction:column;justify-content:end'><strong>OKRs review</strong><small>35 min</small></div><div class='wf-card' style='height:120px;display:flex;flex-direction:column;justify-content:end'><strong>Onboarding flow</strong><small>12 min</small></div><div class='wf-card' style='height:120px;display:flex;flex-direction:column;justify-content:end'><strong>Bug repro</strong><small>4 min</small></div></div><div class='wf-card' style='display:flex;gap:10px;align-items:center'><span class='wf-pill accent'>Agent-readable</span><span>Transcript + frames ready for share links</span><div style='flex:1'></div><button>Share</button></div><div class='wf-card' style='flex:1;display:flex;flex-direction:column;gap:8px'><strong>Transcript search</strong><div class='wf-box'>Matched chapter 03:12 · rollout risks and owner handoff</div><div class='wf-box'>Meeting summary and action items</div></div></div>"
+}
+```
 
 Think along the lines of Loom + Granola + Wispr Flow rolled into one app — but the agent is a first-class editor across every surface, and the recordings, meetings, and dictations are yours, not a SaaS vendor's. Clips also makes shared recordings agent-readable: paste a normal Clips share link into an agent, and it can "hear" the transcript and "see" timestamped frames even when the underlying model cannot ingest raw video or audio.
 
@@ -141,17 +138,15 @@ Clips is a larger template with a native recorder (it ships a desktop companion 
 2. **Google Calendar (optional).** To sync upcoming meetings, connect a Google Calendar account from Settings. The OAuth callback URL in dev is `http://localhost:8094/_agent-native/google/callback`. Set up a Google OAuth client in [Google Cloud Console](https://console.cloud.google.com/) with the Gmail and Google Calendar APIs enabled.
 3. **Screen-capture permissions.** On macOS, grant Screen Recording permission to the browser (or the desktop companion app) in System Settings → Privacy & Security → Screen Recording.
 
-### Key features (technical)
+### Key features
 
-**One library, three capture types.** Screen recordings, calendar-sourced meetings, and push-to-talk dictations all live in the same searchable library. Recordings and transcripts are deliberately split into separate tables so the library grid and the transcript view each render fast.
+**One library, three capture types.** Screen recordings, calendar meetings, and push-to-talk dictations share one searchable library.
 
-**Transcript and AI pipeline.** Each recording gets timestamped transcript segments (`{startMs, endMs, text}`), an auto-generated title, summary, and chapter markers. `cleanup-transcript` and `finalize-meeting` are server-side media-pipeline calls; most other AI features (titles, summaries, quotes) delegate to the agent chat.
+**Transcript and AI pipeline.** Recordings get timestamped transcript segments, generated titles, summaries, and chapter markers.
 
-**Non-destructive editing.** Trim, split, filler-word removal, silence removal, and stitching accumulate in a recording's `edits_json` rather than re-encoding. The client concatenates and exports through ffmpeg.wasm, so the original media stays intact.
+**Non-destructive editing.** Trim, split, filler-word removal, silence removal, and stitching stay in `edits_json` so original media remains intact.
 
-**Agent-readable share links.** A public Clips share link advertises a compact agent context URL that points at the transcript and frame APIs, so text- and image-only models can understand a recording without ingesting raw video — see [Agent-readable clips](#agent-readable-clips) above.
-
-**Meetings compose with recordings.** A meeting owns the recording it captures, but the `recordings` row stays the source of truth for the video and per-segment transcript instead of duplicating media.
+**Agent-readable share links.** Public share links expose transcript and frame APIs so agents can understand recordings without ingesting raw video.
 
 ### Data model
 

--- a/packages/core/docs/content/template-content.md
+++ b/packages/core/docs/content/template-content.md
@@ -11,17 +11,14 @@ you. Open a doc, ask "rewrite this paragraph to be more concise" or "create a
 page called Q4 Planning with sub-pages for Goals, Metrics, and Risks" - same
 result whether you do it yourself or ask.
 
-<!-- screenshot:
-  app: content
-  view: /<doc-id>
-  shows: Workspace with sidebar tree (Q3 Roadmap favorited and expanded with Goals/Metrics/Risks, Engineering Wiki with On-call playbook + Architecture overview + Deployment guide, Personal section with Reading list and Ideas, Weekly sync — May 1) and the Q3 Roadmap document open in the editor with the agent sidebar
-  account: screenshot-account (page tree authored on this account; the doc body should NOT begin with the page title — the page chrome already renders it)
-  capture: 1400x800 viewport, cropped 90px from bottom (final 1400x710)
--->
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='display:grid;grid-template-columns:210px 1fr;gap:14px;padding:16px;min-height:500px;box-sizing:border-box'><aside class='wf-card' style='display:flex;flex-direction:column;gap:10px'><strong>Content</strong><span class='wf-pill accent'>Q3 Roadmap</span><span class='wf-pill'>Goals</span><span class='wf-pill'>Metrics</span><span class='wf-pill'>Risks</span><hr/><span class='wf-pill'>Engineering wiki</span><span class='wf-pill'>Reading list</span><span class='wf-pill'>Weekly sync</span></aside><main style='display:flex;flex-direction:column;gap:12px;min-width:0;padding:8px 20px'><div style='display:flex;align-items:center;gap:10px'><h1 style='margin:0'>Q3 Roadmap</h1><div style='flex:1'></div><button>Share</button><button class='primary'>Publish</button></div><div class='wf-card' style='flex:1;display:flex;flex-direction:column;gap:12px;padding:22px'><h2 style='margin:0'>Launch goals</h2><p style='margin:0'>Ship the onboarding flow, reduce setup time, and document owner handoffs.</p><div class='wf-box'>At a glance · owner, window, status</div><div class='wf-box'>Top objectives</div><div class='wf-box'>Workstreams table</div></div></main></div>"
+}
+```
 
-![Content workspace with the page tree, an open document, and the agent sidebar](/screenshots/content.png)
-
-When you open the app, you'll see a sidebar tree of pages on the left, the editor in the middle, and the agent in the sidebar on the right. The agent always knows which page you're viewing and what text you have selected.
+When you open the app, you'll see a page tree next to the editor. The agent always knows which page you're viewing and what text you have selected, so document edits can stay grounded in the current page.
 
 ```an-diagram title="One document, many editors" summary="You and the agent both write through the same Yjs pipeline. SQL is the canonical store; local files and Notion are optional sync surfaces."
 {
@@ -108,50 +105,19 @@ pnpm install
 pnpm dev
 ```
 
-Open `http://localhost:8083` and create your first page. The agent panel is on the right — try asking it to "create a page called Onboarding and add three sub-pages under it".
+Open `http://localhost:8083` and create your first page. Then ask the agent to "create a page called Onboarding and add three sub-pages under it".
 
-### Key features (technical) {#key-features}
+### Key features {#key-features}
 
-### Hierarchical pages
+**Nested pages.** Documents form a draggable tree with favorites, icons, ordering, and page-level sharing.
 
-Documents nest infinitely via a `parent_id` column. The sidebar renders a draggable tree; children move with their parents and ordering uses an integer `position` field. See `app/components/sidebar/DocumentSidebar.tsx` and `app/components/sidebar/DocumentTreeItem.tsx`.
+**Rich MDX editor.** Tiptap powers headings, lists, tables, code blocks, images, links, slash commands, selection toolbars, and local React components.
 
-### Rich-text editor
+**Live collaboration.** Yjs keeps multiple editors and agent edits in sync without clobbering each other.
 
-The editor is built on Tiptap with a custom extension set. It supports headings, lists, tables, code blocks with syntax highlighting, images, and links. Implementation lives in `app/components/editor/DocumentEditor.tsx` and `app/components/editor/VisualEditor.tsx`, with custom nodes under `app/components/editor/extensions/` (`CodeBlockNode.tsx`, `ImageNode.ts`, `DragHandle.tsx`, `NotionExtensions.tsx`).
+**Search and comments.** Full-text search, anchored comments, version history, and restore flows are built into the document surface.
 
-Interactive surfaces include:
-
-- `BubbleToolbar.tsx` — formatting toolbar that appears over a selection
-- `SlashCommandMenu.tsx` — slash-command inserter for blocks
-- `LinkHoverPreview.tsx` — hover previews for inline links
-- `TableHoverControls.tsx` — add/remove table rows and columns
-- `EmojiPicker.tsx` — emoji picker for page icons
-
-### Collaborative editing
-
-Content is edited through Yjs CRDT so multiple users and the agent can type into the same document at once without clobbering each other. The agent's `edit-document` action writes through the same pipeline as a human keystroke, so changes appear live in every open editor. See [Real-time collaboration](/docs/real-time-collaboration) for the sync model.
-
-### Search
-
-Full-text search across titles and markdown content, powered by `actions/search-documents.ts`. The sidebar exposes a search box; the agent uses the same action via `pnpm action search-documents --query "..."`.
-
-### Favorites and icons
-
-Each document can be favorited (`is_favorite`) and given an emoji `icon`. The index route auto-opens your first favorite on load — see `app/routes/_app._index.tsx`.
-
-### Notion sync
-
-Documents can be linked to a Notion page and synced in either direction:
-
-- `connect-notion-status` — check whether a Notion integration is connected
-- `link-notion-page` — link a local doc to a Notion page
-- `pull-notion-page` — overwrite local content from Notion
-- `push-notion-page` — overwrite Notion content from local
-- `list-notion-links` — list all linked documents
-- `sync-notion-comments` — bidirectionally sync comment threads
-
-Sync state is tracked in the `document_sync_links` table (last synced time, conflict flag, last error). Markdown-to-Notion block conversion lives in `shared/notion-markdown.ts`. Conflict and status UI is in `app/components/editor/NotionConflictBanner.tsx` and `NotionSyncBar.tsx`. See the `notion-integration` skill for the full flow.
+**Sync surfaces.** Documents can sync with Notion or local Markdown/MDX folders, with SQL acting as the collaborative cache/history layer.
 
 ### Local file sync
 

--- a/packages/core/docs/content/template-design.md
+++ b/packages/core/docs/content/template-design.md
@@ -7,9 +7,14 @@ description: "An agent-native HTML prototyping studio — generate, refine, prev
 
 Design is an agent-native HTML prototyping studio. Instead of a layered drawing canvas, the agent generates complete self-contained Alpine/Tailwind HTML prototypes, renders them in an iframe, and lets you refine the result with prompts and tweak controls.
 
-![Design studio showing generated HTML prototypes and tweak controls](https://cdn.builder.io/api/v1/image/assets%2F348da13fcd8b414c87de9066196f7266%2F961bedb713a94463b834c1f2f4643bcf?format=webp&width=1200)
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='display:flex;flex-direction:column;gap:14px;padding:18px;min-height:520px;box-sizing:border-box'><div style='display:flex;align-items:center;gap:10px'><h1 style='margin:0'>Product launch page</h1><span class='wf-pill accent'>Desktop</span><span class='wf-pill'>Tablet</span><span class='wf-pill'>Mobile</span><div style='flex:1'></div><button>Preview</button><button class='primary'>Export code</button></div><div class='wf-card' style='flex:1;display:grid;grid-template-rows:auto 1fr auto;gap:12px'><div style='display:flex;gap:8px'><span class='wf-pill accent'>Hero</span><span class='wf-pill'>Pricing</span><span class='wf-pill'>FAQ</span></div><div class='wf-box' style='display:flex;align-items:center;justify-content:center;min-height:230px'><strong>Generated HTML prototype</strong></div><div class='wf-card' style='display:flex;align-items:center;gap:10px'><span class='wf-muted'>Make the hero denser and the CTA clearer.</span><div style='flex:1'></div><button class='primary'>Apply revision</button></div></div></div>"
+}
+```
 
-When you open the app, you see your designs on the left, the generated prototype rendered in an iframe in the middle, and the agent plus tweak controls on the right. Everything the agent produces is real HTML you can refine, export, or hand off.
+When you open the app, the generated prototype is the center of the workspace, with preview modes, prompt revisions, and export controls close at hand. Everything the agent produces is real HTML you can refine, export, or hand off.
 
 ```an-diagram title="One artifact, no translation" summary="The agent generates standalone Alpine/Tailwind HTML; the iframe, the editable source, and every export all read the same files. A linked design system feeds tokens into each pass."
 {

--- a/packages/core/docs/content/template-dispatch.md
+++ b/packages/core/docs/content/template-dispatch.md
@@ -9,15 +9,12 @@ description: "Dispatch is the workspace control plane — central inbox, cross-a
 
 Dispatch is the **workspace control plane**. Where other templates are domain apps (Mail, Calendar, Analytics, Brain), Dispatch is the app you run _alongside_ them to coordinate everything: a central inbox, a secrets vault, scheduled jobs, Slack/Telegram integration, and an orchestrator agent that delegates domain work to the right specialist app over [A2A](/docs/a2a-protocol).
 
-<!-- screenshot:
-  app: dispatch
-  view: /overview
-  shows: Overview with "What should we do next?" composer, prompt suggestions (Create a lightweight customer onboarding app / Ask Slides to draft a board update from our latest metrics / Schedule a Monday morning analytics digest), and the Workspace apps grid (Mail / Calendar / Slides / Analytics / Forms / Content + Create app placeholder) showing each mounted path + description
-  account: screenshot-account (workspace seeded with the six sibling apps registered as A2A peers)
-  capture: 1400x900 viewport, cropped 90px from bottom (final 1400x810)
--->
-
-![Dispatch overview with the orchestrator chat and workspace apps grid](/screenshots/dispatch.png)
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='display:flex;flex-direction:column;gap:14px;padding:18px;min-height:520px;box-sizing:border-box'><div style='display:flex;align-items:center;gap:10px'><h1 style='margin:0'>Dispatch</h1><span class='wf-pill accent'>Overview</span><span class='wf-pill'>Inbox</span><span class='wf-pill'>Secrets</span><span class='wf-pill'>Approvals</span><div style='flex:1'></div><button>Schedules</button></div><div class='wf-card' style='display:flex;flex-direction:column;gap:10px'><strong>What should we do next?</strong><div class='wf-box'>Ask Analytics for this week's signups and draft a Slack update.</div><button class='primary'>Delegate</button></div><div style='display:grid;grid-template-columns:repeat(3,1fr);gap:10px'><div class='wf-card'><strong>Mail</strong><br/><small>/mail</small></div><div class='wf-card'><strong>Calendar</strong><br/><small>/calendar</small></div><div class='wf-card'><strong>Analytics</strong><br/><small>/analytics</small></div><div class='wf-card'><strong>Slides</strong><br/><small>/slides</small></div><div class='wf-card'><strong>Forms</strong><br/><small>/forms</small></div><div class='wf-card'><strong>Create app</strong><br/><small>+</small></div></div><div class='wf-card' style='display:grid;grid-template-columns:repeat(3,1fr);gap:8px'><div class='wf-box'>Slack DM needs reply</div><div class='wf-box'>A2A task completed</div><div class='wf-box'>Approval required</div></div></div>"
+}
+```
 
 If you're running an [multi-app workspace](/docs/multi-app-workspace) with many apps, Dispatch is the glue.
 

--- a/packages/core/docs/content/template-forms.md
+++ b/packages/core/docs/content/template-forms.md
@@ -7,15 +7,12 @@ description: "Agent-native form builder — create, edit, publish, and route for
 
 Forms is an agent-native form builder. Describe the form you want, refine it in the editor, and publish a public form that stores submissions in your own SQL database.
 
-<!-- screenshot:
-  app: forms
-  view: /forms/<id>
-  shows: Editor for a "Beta signup" form — sidebar with 5 forms (Beta signup selected, Customer feedback Q3, Job application Engineering, Event RSVP, New customer onboarding); editor pane with title, description, and field cards (Full name, Work email, Your role, Team size, What problem are you hoping to solve?); Edit/Results/Settings/Integrations tabs and Share + Unpublish buttons; agent sidebar with form-related suggestions
-  account: screenshot-account (forms authored on this account via the standard build flow, with realistic response counts seeded by submitting through the public URL)
-  capture: 1400x800 viewport, cropped 90px from bottom (final 1400x710)
--->
-
-![Forms editor with a form open and the agent sidebar](/screenshots/forms.png)
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='display:flex;flex-direction:column;min-height:520px;box-sizing:border-box'><div style='display:flex;align-items:center;gap:10px;padding:14px 16px;border-bottom:1.4px solid var(--wf-line)'><strong>Beta signup</strong><span class='wf-pill accent'>published</span><div style='flex:1'></div><button>Share</button><button class='primary'>Unpublish</button></div><div style='display:flex;gap:8px;padding:12px 16px;border-bottom:1.4px solid var(--wf-line)'><span class='wf-pill accent'>Edit</span><span class='wf-pill'>Results 187</span><span class='wf-pill'>Settings</span><span class='wf-pill'>Integrations</span></div><div style='display:flex;flex-direction:column;gap:12px;padding:30px 78px;overflow:hidden'><h2 style='margin:0'>Beta signup</h2><p class='wf-muted' style='margin:0'>Reserve a spot in the upcoming private beta cohort.</p><div class='wf-card'><strong>Full name</strong><input value='Ada Lovelace'/></div><div class='wf-card'><strong>Work email</strong><input value='you@company.com'/></div><div class='wf-card'><strong>Your role</strong><input value='Select...'/></div><div class='wf-card'><strong>Team size</strong><input value='Select...'/></div></div></div>"
+}
+```
 
 When you open the app, you see your forms, the current editor, and a live preview. The agent can create a form from a prompt, update field labels and options, change validation, and connect submission destinations using the same actions the UI uses.
 
@@ -77,13 +74,13 @@ npx @agent-native/core@latest create my-platform
 
 Pick Forms and any other templates you want during the workspace setup.
 
-### Key features (technical) {#key-features}
+### Key features {#key-features}
 
-Forms are defined as JSON field arrays (`FormField[]`) and stored in a single `fields` column — no separate table per field type. This makes the schema additive and the agent's edits surgical: changing a field label is a JSON-patch on one column, not a row update across a join table. All field types (text, email, number, long text, select, multi-select, checkbox, radio, date, rating, scale) are handled by the renderer and editor without schema changes.
+**JSON form definitions.** Fields live in one `fields` JSON column, so the agent can make surgical edits without schema changes for every field type.
 
-The public fill page is fully unauthenticated. `toPublicFormSettings` strips integration URLs and other owner-private settings before the form data reaches the browser, so secrets never leak to respondents.
+**Public fill pages.** Respondents can submit unauthenticated forms, while private settings are stripped before data reaches the browser.
 
-Integrations (Slack, Discord, Google Sheets, webhooks) are stored as settings inside the form's `settings` JSON column and executed server-side at submission time.
+**Server-side destinations.** Slack, Discord, Google Sheets, and webhook integrations live in form settings and run after submission.
 
 ### Data model
 

--- a/packages/core/docs/content/template-mail.md
+++ b/packages/core/docs/content/template-mail.md
@@ -7,17 +7,14 @@ description: "An agent-powered email client. Connect your Gmail and the agent ca
 
 An agent-powered email client. Connect your Gmail account and the agent can read, draft, send, and organize email for you — alongside a fast, keyboard-first inbox you can drive yourself. Think Superhuman, but the agent is a first-class citizen and the codebase is yours to own.
 
-<!-- screenshot:
-  app: mail
-  view: /inbox
-  shows: Inbox listing (Priya Mehta, Acme Billing, Marcus Tang, GitHub, Sasha Park, Linear, Hannah Reyes, Acme Recruiting, Notion, Stripe, Vercel, Calendly, Olivia Brennan, AWS Billing, Dan Kim, Figma) with the agent sidebar open and suggestion chips visible
-  account: screenshot-account (seeded with the email set above via the standard inbound flow)
-  capture: 1400x800 viewport, cropped 90px from bottom (final 1400x710)
--->
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='display:flex;flex-direction:column;min-height:500px;box-sizing:border-box'><div style='display:flex;align-items:center;gap:12px;padding:12px 16px;border-bottom:1.4px solid var(--wf-line)'><strong>Inbox 16</strong><div style='flex:1'></div><span data-icon='search' aria-label='Search'></span><span data-icon='edit' aria-label='Compose'></span><span data-icon='bell' aria-label='Notify'></span></div><div style='display:flex;flex-direction:column;padding:8px 14px;gap:6px'><div class='wf-box' style='display:grid;grid-template-columns:155px 1fr auto;gap:12px;align-items:center'><strong>Priya Mehta</strong><span><strong>Q3 launch</strong> — final assets ready for review</span><span>★</span></div><div class='wf-box' style='display:grid;grid-template-columns:155px 1fr auto;gap:12px;align-items:center'><strong>Acme Billing</strong><span>Your monthly invoice is ready</span><span>11:10 AM</span></div><div class='wf-box' style='display:grid;grid-template-columns:155px 1fr auto;gap:12px;align-items:center'><span>Marcus Tang</span><span>Onboarding flow research findings</span><span>Yesterday</span></div><div class='wf-box' style='display:grid;grid-template-columns:155px 1fr auto;gap:12px;align-items:center'><span>GitHub</span><span>[framework] PR ready for review</span><span>Yesterday</span></div><div class='wf-box' style='display:grid;grid-template-columns:155px 1fr auto;gap:12px;align-items:center'><span>Linear</span><span>Issue ENG-1287 assigned to you</span><span>May 2</span></div><div class='wf-box' style='display:grid;grid-template-columns:155px 1fr auto;gap:12px;align-items:center'><span>Stripe</span><span>Weekly payments summary</span><span>Apr 29</span></div><div class='wf-box' style='display:grid;grid-template-columns:155px 1fr auto;gap:12px;align-items:center'><span>Calendly</span><span>New booking confirmed</span><span>Apr 28</span></div></div></div>"
+}
+```
 
-![Mail inbox with the agent sidebar](/screenshots/mail.png)
-
-When you open the app, you'll see your inbox on the left, the open thread in the middle, and the agent in the sidebar on the right. The agent always knows which view you're in and which thread you have open, so you can say "archive this" or "draft a friendly decline" without explaining what "this" is.
+When you open the app, the keyboard-first inbox and thread view stay focused on the mail itself. The agent always knows which view you're in and which thread you have open, so you can say "archive this" or "draft a friendly decline" without explaining what "this" is.
 
 ```an-diagram title="How a mail request flows" summary="Keyboard shortcuts and agent prompts run the same actions. Email lives in Gmail; drafts, automations, and tracking live in SQL and application_state."
 {
@@ -119,27 +116,15 @@ To connect Gmail in dev, you need a Google OAuth client:
 
 Tokens are stored in the `oauth_tokens` SQL table and refresh automatically. You can connect multiple Gmail accounts once the first is set up.
 
-### Key features (technical)
+### Key features
 
-**Gmail sync (multi-account).** Connect one or many Google accounts via OAuth. List and search actions query all connected inboxes by default; results carry an `accountEmail` field so you can tell which inbox each thread came from. Scope to a single account with `--account=user@example.com`. OAuth tokens are stored via `@agent-native/core/oauth-tokens` under the `"google"` provider.
+**Multi-account Gmail.** Connect one or more Google accounts, then list, search, draft, send, label, archive, star, or trash across connected inboxes.
 
-**Multiple compose drafts.** The compose panel supports multiple draft tabs at once. Each draft is stored as an `application_state` entry at `compose-{id}` and syncs live between the agent and the UI. The agent can create a new draft with `manage-draft --action=create`, edit your in-progress draft with `--action=update`, or close tabs with `--action=delete`. Drafts use markdown in the body field; the TipTap editor renders it as rich text and converts to HTML on send.
+**Draft workflows.** Multiple compose drafts sync through application state, and queued SQL drafts let teammates or Slack users request mail for the owner to review and send.
 
-**Queued draft review.** Drafts requested by teammates or Slack are durable SQL rows in `queued_email_drafts`. The agent uses `queue-email-draft` to assign a draft to an org member, returns a review URL such as `/draft-queue/<id>`, and waits for the owner to review or explicitly send. The queue supports listing assigned drafts, editing them, opening one in the compose panel, dismissing it, and sending one or all reviewed drafts.
+**Automations and tracking.** Natural-language triage rules can label, archive, mark read, star, trash, or trigger manually; sent messages can track opens and clicks.
 
-**AI triage via automations.** Mail supports automation rules that run against new inbox email using AI. A rule has a natural-language condition (for example, `"from a newsletter"` or `"subject contains invoice"`) and a list of actions (`label`, `archive`, `mark_read`, `star`, `trash`). Manage them via `pnpm action manage-automations --action=create|list|update|delete|enable|disable`, or through the Settings page. Rules fire automatically and can be triggered manually with `pnpm action trigger-automations`.
-
-**Send tracking.** Sent messages get open-pixel and link-click tracking injected automatically. Settings live under `mail-settings.tracking` with `tracking.opens` and `tracking.clicks` (both default `true`). Only links in the new portion of a reply or forward are rewritten — quoted content is left alone. Pull stats for any sent message with `pnpm action get-tracking --id=<message-id>`, or from `GET /api/emails/:id/tracking`. Open and click events are stored in the `email_tracking` and `email_link_tracking` tables.
-
-**Search.** `pnpm action search-emails --q=<term>` searches across all views and all connected accounts. The UI search bar maps to the same action. Both `search-emails` and `list-emails` take `--compact` for shorter output and `--fields=from,subject,date` to limit returned fields.
-
-**Bulk operations and export.**
-
-- `pnpm action bulk-archive --older-than=30` archives everything older than N days.
-- `pnpm action export-emails --view=inbox --output=file.json` dumps a view to JSON.
-- Archive, trash, mark-read, and star all accept comma-separated IDs (`--id=id1,id2,id3`) for bulk changes.
-
-**Inline thread previews in agent chat.** When the agent answers a question about a specific thread, it can embed a live preview of the thread directly in the chat message via an `embed` code fence. The preview is a sandboxed iframe that shows the full conversation without leaving the chat, with an "Open in app" button that navigates the main window to that thread.
+**Search, bulk actions, and previews.** Shared actions power inbox search, bulk archive/export, and inline thread previews the agent can embed in chat.
 
 ### How the agent sees your context
 

--- a/packages/core/docs/content/template-plan.md
+++ b/packages/core/docs/content/template-plan.md
@@ -30,7 +30,12 @@ agent the same way.
 }
 ```
 
-![Agent-Native Plans review surface](https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fdd73f749f8c54dbcb577420ab1a18788)
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='display:grid;grid-template-columns:1fr 250px;gap:14px;padding:16px;min-height:520px;box-sizing:border-box'><main style='display:flex;flex-direction:column;gap:12px;min-width:0'><div style='display:flex;align-items:center;gap:10px'><h1 style='margin:0'>Checkout redesign plan</h1><div style='flex:1'></div><button>Share</button><button class='primary'>Approve</button></div><div class='wf-card' style='display:grid;grid-template-columns:1fr 1fr;gap:10px;min-height:150px'><div class='wf-box'>Current wireframe</div><div class='wf-box'>Proposed wireframe</div></div><div class='wf-card' style='flex:1;display:flex;flex-direction:column;gap:10px'><strong>Implementation plan</strong><div class='wf-box'>Decision: keep existing checkout shell</div><div class='wf-box'>Annotated code walkthrough</div><div class='wf-box'>Open questions</div></div></main><aside class='wf-card' style='display:flex;flex-direction:column;gap:10px'><strong>Comments</strong><div class='wf-box'>Pin on primary CTA</div><div class='wf-box'>Question for agent</div><div class='wf-box'>Resolved copy note</div><button class='primary'>Hand back feedback</button></aside></div>"
+}
+```
 
 There are two ways into Plans:
 

--- a/packages/core/docs/content/template-slides.md
+++ b/packages/core/docs/content/template-slides.md
@@ -7,17 +7,14 @@ description: "Generate decks from a prompt, edit visually, and present full-scre
 
 Generate full presentation decks from a prompt, edit slides visually, and present full-screen. Ask the agent for "a 10-slide pitch deck for a coffee subscription service" and watch it stream slide-by-slide into the editor in seconds. An open-source replacement for Google Slides, Pitch, and PowerPoint.
 
-<!-- screenshot:
-  app: slides
-  view: /deck/<id>
-  shows: Deck editor with a "Q3 Board Update" deck open — collapsed left icon rail (Decks / Design Systems / Team), slides thumbnail strip (6 slides — title, agenda, metrics, what we shipped, what we're watching), main slide preview showing the title slide by Maya Chen CEO, speaker notes pane, and the agent chat sidebar with deck-aware suggestions
-  account: screenshot-account (deck authored on this account via the standard create-deck + add-slide flow)
-  capture: 1400x800 viewport, cropped 90px from bottom (final 1400x710); collapse the left rail before capture
--->
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='display:flex;flex-direction:column;gap:12px;padding:16px;min-height:530px;box-sizing:border-box'><div style='display:flex;align-items:center;gap:10px'><h1 style='margin:0'>Q3 Board Update</h1><span class='wf-pill accent'>Title slide</span><div style='flex:1'></div><button>Preview</button><button>Present</button><button class='primary'>Share</button></div><main style='display:grid;grid-template-columns:1fr 220px;gap:12px;flex:1;min-height:0'><section class='wf-card' style='display:flex;align-items:center;justify-content:center;text-align:center;padding:36px'><div><strong style='font-size:28px'>Q3 Board Update</strong><br/><small>Maya Chen · CEO</small><div style='height:46px'></div><span class='wf-pill'>Product momentum</span></div></section><section style='display:flex;flex-direction:column;gap:10px'><div class='wf-card'><strong>Slide outline</strong><div class='wf-box'>1 Title</div><div class='wf-box'>2 Agenda</div><div class='wf-box'>3 Metrics</div><div class='wf-box'>4 Shipped</div></div><div class='wf-card' style='flex:1'><strong>Speaker notes</strong><p class='wf-muted' style='margin:8px 0 0'>Open with launch progress and retention story.</p></div></section></main><div style='display:grid;grid-template-columns:repeat(5,1fr);gap:8px'><div class='wf-box'>1 Title</div><div class='wf-box'>2 Agenda</div><div class='wf-box'>3 Metrics</div><div class='wf-box'>4 Shipped</div><div class='wf-box'>5 Risks</div></div></div>"
+}
+```
 
-![Slides deck editor with a deck open and slide thumbnails on the left](/screenshots/slides.png)
-
-When you open a deck, you get a slide editor in the middle, a sidebar of slides on the left, and the agent on the right.
+When you open a deck, the slide canvas, outline, notes, and filmstrip stay in one editor surface while the agent can still create, revise, and navigate slides through actions.
 
 ```an-diagram title="Prompt to deck" summary="Ask for a deck and the agent streams slides in one at a time through the same actions you could call from the CLI."
 {
@@ -46,7 +43,7 @@ Live demo: [slides.agent-native.com](https://slides.agent-native.com).
 When you open the app:
 
 1. Click **New deck**.
-2. In the agent sidebar, ask: "Generate a 10-slide pitch deck for a coffee subscription service, audience is investors."
+2. Ask the agent: "Generate a 10-slide pitch deck for a coffee subscription service, audience is investors."
 3. Watch slides stream in. Click any slide to edit, or keep asking the agent to refine.
 
 ### Useful prompts
@@ -76,75 +73,17 @@ pnpm install
 pnpm dev
 ```
 
-### Key features (technical) {#key-features}
+### Key features {#key-features}
 
-#### Import and export
+**Prompt-to-deck generation.** Ask for a deck and the agent streams slides into the editor using the same create and edit actions you can run yourself.
 
-The template can pull content in from PPTX (`import-pptx`), DOCX (`import-docx`), Google Docs (`import-google-doc`), arbitrary URLs (`import-from-url`), and GitHub repos (`import-github`). Export paths cover PPTX (`export-pptx`), Google Slides (`export-google-slides`), and HTML (`export-html`). Importing uses the same action surface as the rest of the template — no separate pipeline.
+**Editable slide canvas.** Inline text editing, slash inserts, code editing, drag-and-drop ordering, undo/redo, comments, and presentation mode all live in the deck surface.
 
-#### Design systems
+**Import and export.** Bring in PPTX, DOCX, Google Docs, PDFs, URLs, and GitHub repos; export to PPTX, Google Slides, HTML, or a share link.
 
-Reusable brand tokens are stored in the `design_systems` table (colors, typography, spacing, assets, custom instructions, and an `is_default` flag). Sharing is managed via `design_system_shares`. Actions: `create-design-system`, `update-design-system`, `get-design-system`, `list-design-systems`, `set-default-design-system`, `apply-design-system`, and `analyze-brand-assets` (collects brand data before analysis). See the `design-systems` and `image-generation-via-a2a` skills for the full pattern.
+**Design systems and media.** Saved brand systems, image generation, stock search, and logo lookup keep decks closer to the intended visual direction.
 
-#### Deck versions
-
-Every significant deck change is snapshotted in the `deck_versions` table (stores a full copy of title and deck data with an optional `changeLabel`). Actions: `list-deck-versions`, `restore-deck-version`, `get-deck-version`.
-
-#### Prompt-to-deck generation
-
-Ask the agent for a deck and it builds one slide at a time. Slides stream into the editor live as each one is generated — the agent fires parallel `add-slide` calls so you see the deck assemble in seconds.
-
-Under the hood, this is powered by the `add-slide` and `create-deck` actions in `templates/slides/actions/`.
-
-#### Seven slide layouts
-
-Built-in layouts: title, section divider, content with bullets, two-column, statement or quote, metrics or stats, and closing or CTA. Each layout is a pure HTML template with inline styles — the agent picks the right one based on slide purpose. The exact templates live inside `templates/slides/.agents/skills/create-deck/SKILL.md` so the agent can reference them without exploring the codebase.
-
-#### Visual and code editing
-
-- Double-click any text to edit inline.
-- Click a block to open the bubble menu for styles, alignment, and layout.
-- Switch to the code editor (`app/components/editor/CodeEditor.tsx`) to edit raw slide HTML.
-- Use the slash menu (`SlideSlashMenu.tsx`) to insert blocks by typing `/`.
-
-#### AI image generation
-
-Generate images through the Assets app when brand libraries matter; once the managed backend is deployed, that path can use Builder-managed image generation and keep the audit trail with the source library. Direct provider-key generation remains the fallback for standalone decks.
-
-Actions: `generate-image`, `edit-image`, `image-search`, `logo-lookup`. UI panels: `ImageGenPanel.tsx`, `ImageSearchPanel.tsx`, `LogoSearchPanel.tsx`.
-
-#### Logo and stock image search
-
-- `logo-lookup --domain acme.com` fetches a company logo via Logo.dev or Brandfetch.
-- `image-search --query "mountain landscape"` searches Google Images for stock photos.
-
-#### Comments and threads
-
-Leave comments on specific slides, quote selected text, and reply in threads. Stored in the `slide_comments` table. Actions: `add-slide-comment`, `list-slide-comments`.
-
-#### Drag and drop reordering
-
-Reorder slides in the sidebar, duplicate, or delete with hover controls. The sidebar lives in `app/components/editor/EditorSidebar.tsx`.
-
-#### Presentation mode
-
-Full-screen presentation at `/deck/:id/present` with keyboard navigation (arrow keys, space, escape), auto-hiding controls, and speaker notes. See `app/routes/deck.$id_.present.tsx` and `app/components/presentation/PresentationView.tsx`.
-
-#### Share links
-
-Generate a public read-only URL for a deck so reviewers can view without an account. The share page is `app/routes/share.$token.tsx`. Fine-grained sharing (viewer, editor, admin roles, per-user or org-wide) is also available via the framework's `share-resource` action.
-
-#### Real-time collaboration
-
-Multiple people can edit the same deck simultaneously. Text edits sync through Yjs CRDT so there are no conflicts, and the agent sees and edits the same live document via the `update-slide --find/--replace` action.
-
-#### Undo and redo
-
-Cmd+Z and Cmd+Shift+Z work across the whole deck, with a labeled history panel (`HistoryPanel.tsx`) you can scrub through.
-
-#### Extract from PDF
-
-Turn a PDF into a starter deck. The `extract-pdf` action parses the file and hands the content to the agent for layout.
+**Collaboration and history.** Real-time Yjs editing, threaded comments, share roles, and deck version snapshots are built in.
 
 ### Working with the agent
 

--- a/packages/core/docs/content/template-videos.md
+++ b/packages/core/docs/content/template-videos.md
@@ -7,15 +7,12 @@ description: "A programmatic video studio for motion graphics, product demos, an
 
 A programmatic video studio for the kind of motion graphics, product demos, and kinetic-text videos that are a pain to keyframe by hand. Ask the agent for "a 6-second logo reveal that fades in at 2 seconds" and it builds the animation. Tune timing, easing, and camera moves on a timeline, then render to MP4 or WebM.
 
-<!-- screenshot:
-  app: video
-  view: /c/<composition-id>
-  shows: Video studio with 4 compositions (Logo reveal, Q3 product demo, Pricing animation, Onboarding walkthrough) in the sidebar; Logo reveal loaded with timeline + Remotion preview + camera tools and the agent chat sidebar
-  account: screenshot-account (compositions authored on this account)
-  capture: 1400x800 viewport, cropped 90px from bottom (final 1400x710)
--->
-
-![Video studio with timeline, composition, and agent sidebar](/screenshots/videos.png)
+```an-wireframe
+{
+  "surface": "desktop",
+  "html": "<div style='display:flex;flex-direction:column;gap:12px;padding:16px;min-height:530px;box-sizing:border-box'><div style='display:flex;align-items:center;gap:10px'><h1 style='margin:0'>Logo reveal</h1><span class='wf-pill accent'>6 seconds</span><div style='flex:1'></div><button>Preview</button><button class='primary'>Render</button></div><div class='wf-card' style='flex:1;display:flex;align-items:center;justify-content:center;min-height:250px'><div style='text-align:center'><strong>Remotion preview</strong><br/><small class='wf-muted'>logo scales in as the title fades</small></div></div><div class='wf-card' style='display:flex;flex-direction:column;gap:10px'><div style='display:flex;gap:8px;align-items:center'><span class='wf-pill'>0s</span><span class='wf-pill'>2s</span><span class='wf-pill'>4s</span><span class='wf-pill'>6s</span><div style='flex:1'></div><button>New track</button></div><div class='wf-box'>Title fade · 0-48 frames</div><div class='wf-box'>Logo scale · 48-120 frames</div><div class='wf-box'>Camera push · 72-144 frames</div></div></div>"
+}
+```
 
 When you open the studio, you'll see a list of compositions on the home screen. Click into one and you get a player on top, a timeline at the bottom, and a properties panel on the right. The agent always knows which composition you have open.
 
@@ -82,53 +79,15 @@ pnpm dev
 
 Open the studio in your browser, create a composition, and start from blank. Ask the agent something like "add a logo reveal that fades in at 2 seconds" and it will edit the composition for you.
 
-### Key features (technical)
+### Key features
 
-#### React-based compositions
+**React-based compositions.** Videos are Remotion-backed React components, with SQL-backed user compositions and an optional code registry for local defaults.
 
-Every video is a React component built on Remotion primitives (`AbsoluteFill`, `useCurrentFrame`, `useVideoConfig`). The template ships one in-code composition — `BlankComposition` in `app/remotion/compositions/BlankComposition.tsx` — and `app/remotion/registry.ts` exports an empty `compositions` array by default. User and example compositions (kinetic text, logo reveals, particle bursts, interactive UI demos, slideshows) live in SQL and load through `app/hooks/use-database-compositions.ts`. You can still add a code composition by dropping a `.tsx` file in `app/remotion/compositions/` and registering it in `app/remotion/registry.ts`.
+**Timeline-first animation.** Duration tracks, keyframes, easing curves, camera moves, and programmatic expression tracks all edit the same composition data.
 
-#### Timeline tracks
+**Adjustable motion systems.** Parameters, cursor tracks, interactive hover zones, range navigation, and repeat playback make generated animations tunable without code.
 
-Animations are tracks, not hardcoded frame checks. A track has `startFrame`, `endFrame`, `easing`, and a list of `animatedProps` (`opacity`, `translateY`, `scale`, rotation, colors, etc.). Three track shapes:
-
-- **Duration tracks** — bars you can drag and resize in the timeline.
-- **Keyframe tracks** — diamond markers at specific frames for instant state changes (`startFrame === endFrame`).
-- **Expression tracks** — programmatic animations (typing reveals, particle bursts) flagged with `programmatic: true` and shown with a purple `fx` badge.
-
-Helper utilities in `app/remotion/trackAnimation.ts` (`findTrack`, `trackProgress`, `getPropValue`) wire a track's values into a component's render.
-
-#### Easing curves
-
-30+ easing curves ship in `app/types.ts` — linear, power1-4 in/out/inOut, back, bounce, circ, elastic, expo, sine, and Remotion's `spring`. The Properties panel shows a visual preview of the curve shape for each one.
-
-#### Camera controls
-
-Each composition has a dedicated `camera` track with six animatable properties: `translateX`, `translateY`, `scale`, `rotateX`, `rotateY`, `perspective`. The camera toolbar above the player has pan, zoom, and tilt tools — click a tool, drag on the preview, and a keyframe is auto-created at the current frame. `CameraHost` (in `app/remotion/CameraHost.tsx`) applies the chained CSS 3D transform to everything inside.
-
-#### Multi-keyframe editing
-
-Every animated property supports an optional `keyframes` array. Interpolation is linear between keyframes, with hold-at-first and hold-at-last at the edges. In the timeline you can box-select keyframes, shift-click to add or remove, and drag groups while keeping relative timing.
-
-#### Adjustable parameters
-
-Programmatic animations expose internal magic numbers as user-editable `parameters` — character width, drift distance, particle count, stagger delay. Inputs appear in the Properties panel with min/max/step bounds and save to localStorage automatically.
-
-#### Interactive cursor system
-
-The `cursor` track drives a visible cursor that moves across the composition. Hover zones on interactive elements (buttons, tabs, inputs, cards) change the cursor appearance — arrow, pointer, or I-beam. See `app/remotion/hooks/useInteractiveComponent.ts` and `app/remotion/ui-components/InteractiveCard.tsx`.
-
-#### View range and repeat playback
-
-The timeline has a range navigator at the bottom (AE-style triangular handles). Drag to zoom and pan the visible time window. Playback in the player is constrained to that range, with a repeat toggle that loops inside it.
-
-#### Render output
-
-Composition size, fps, and render quality are per-composition in the Properties panel. Render quality is supersampling — 1x, 2x, or 3x internal resolution to keep text and vectors crisp during camera zoom. Final render happens via the Remotion CLI to MP4 or WebM.
-
-#### Composition persistence
-
-User edits (track values, parameter values, prop overrides, composition settings) persist to localStorage per composition. The **Save** button in the top-right of the composition view can write the current state back to `app/remotion/registry.ts` as TypeScript — so new users and sessions pick up the changes. That source-write path runs through `POST /api/save-composition-defaults`, which is gated to local development only; in production it returns a 403, and durable composition state lives in SQL instead.
+**Render and persistence.** Composition settings, quality, fps, track values, and overrides persist per composition and render to MP4 or WebM through Remotion.
 
 ### Working with the agent
 

--- a/packages/core/src/client/blocks/library/AnnotatedCodeBlock.spec.tsx
+++ b/packages/core/src/client/blocks/library/AnnotatedCodeBlock.spec.tsx
@@ -133,6 +133,55 @@ describe("AnnotatedCodeBlock annotations", () => {
     expect(basename?.className).toContain("text-plan-code-text");
   });
 
+  it("renders subtle hover indicators on the first line of each annotated range", () => {
+    act(() => {
+      root.render(
+        <AnnotatedCodeRead
+          blockId="code-annotations"
+          ctx={{}}
+          data={{
+            language: "ts",
+            code: [
+              "const one = 1;",
+              "const two = 2;",
+              "const three = 3;",
+              "const four = 4;",
+            ].join("\n"),
+            annotations: [
+              {
+                lines: "2-3",
+                label: "Middle",
+                note: "This range has a visible marker.",
+              },
+              {
+                lines: "4",
+                label: "End",
+                note: "This single line has another marker.",
+              },
+            ],
+          }}
+        />,
+      );
+    });
+
+    const markers = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-annotated-code-marker]"),
+    );
+    expect(markers).toHaveLength(2);
+    expect(markers.map((marker) => marker.textContent)).toEqual(["", ""]);
+    expect(
+      container.querySelector(
+        '[data-code-line="2"] [data-annotated-code-marker="1"]',
+      ),
+    ).toBeTruthy();
+    expect(
+      container.querySelector(
+        '[data-code-line="3"] [data-annotated-code-marker="1"]',
+      ),
+    ).toBeNull();
+    expect(markers[0]?.className).toContain("cursor-pointer");
+  });
+
   it("anchors a multi-line annotation popover to the first line in the range", () => {
     act(() => {
       root.render(

--- a/packages/core/src/client/blocks/library/AnnotatedCodeBlock.tsx
+++ b/packages/core/src/client/blocks/library/AnnotatedCodeBlock.tsx
@@ -42,6 +42,9 @@ import { DevInput, DevLabel, DevTextarea } from "./dev-doc-ui.js";
  * pairs, so it reads correctly in BOTH light and dark mode. Code lines render as
  * `<span>`s (never one `<pre>` per line) so they don't pick up document
  * code/pre chrome. Lives in core so any app can register the dev-doc block.
+ * Each annotated range also gets a small sticky glowing indicator at the top
+ * right of its first line, making the hover affordance visible without a note
+ * column.
  *
  * Editing is panel-driven (config-style, like the diff/HTML blocks): a monospace
  * code Textarea, filename/language Inputs, and add/remove-able annotation rows.
@@ -278,13 +281,24 @@ function AnnotatedCodeRead({
     const rowHasPersistentAnnotation = Boolean(
       markers?.some((item) => persistentAnnotationIndexes.has(item.index)),
     );
+    const rangeStartMarkers =
+      markers?.filter((item) => item.range?.start === lineNo) ?? [];
 
-    const buildAnchorForRow = (el: HTMLElement) => {
-      if (!markers) return null;
-      const primaryMarker = markers[0];
-      const anchorLine = primaryMarker.range?.start ?? lineNo;
-      const anchorRow = lineRefs.current.get(anchorLine) ?? el;
+    const buildAnchorForItem = (
+      item: ResolvedAnnotation<AnnotatedCodeAnnotation>,
+      fallbackRow: HTMLElement,
+    ) => {
+      const anchorLine = item.range?.start ?? lineNo;
+      const anchorRow = lineRefs.current.get(anchorLine) ?? fallbackRow;
       return anchorFromElements(codeRef.current, anchorRow);
+    };
+
+    const openAnnotation = (
+      item: ResolvedAnnotation<AnnotatedCodeAnnotation>,
+      row: HTMLElement,
+    ) => {
+      const anchor = buildAnchorForItem(item, row);
+      if (anchor) hover.open(item.index, anchor);
     };
 
     return (
@@ -313,8 +327,7 @@ function AnnotatedCodeRead({
         onMouseEnter={
           isAnnotated && markers
             ? (event) => {
-                const anchor = buildAnchorForRow(event.currentTarget);
-                if (anchor) hover.open(markers[0].index, anchor);
+                openAnnotation(markers[0], event.currentTarget);
               }
             : undefined
         }
@@ -322,8 +335,7 @@ function AnnotatedCodeRead({
         onClick={
           isAnnotated && markers
             ? (event) => {
-                const anchor = buildAnchorForRow(event.currentTarget);
-                if (anchor) hover.open(markers[0].index, anchor);
+                openAnnotation(markers[0], event.currentTarget);
               }
             : undefined
         }
@@ -332,16 +344,14 @@ function AnnotatedCodeRead({
             ? (event) => {
                 if (event.key !== "Enter" && event.key !== " ") return;
                 event.preventDefault();
-                const anchor = buildAnchorForRow(event.currentTarget);
-                if (anchor) hover.open(markers[0].index, anchor);
+                openAnnotation(markers[0], event.currentTarget);
               }
             : undefined
         }
         onFocus={
           isAnnotated && markers
             ? (event) => {
-                const anchor = buildAnchorForRow(event.currentTarget);
-                if (anchor) hover.open(markers[0].index, anchor);
+                openAnnotation(markers[0], event.currentTarget);
               }
             : undefined
         }
@@ -366,6 +376,39 @@ function AnnotatedCodeRead({
         <span className="flex-1 whitespace-pre pr-4 text-plan-code-text">
           {highlightedLines[lineNo - 1]}
         </span>
+        {rangeStartMarkers.length > 0 && (
+          <span
+            aria-hidden
+            className="sticky right-0.5 z-10 ml-2 flex h-[22px] shrink-0 items-center gap-1 self-start pr-0.5"
+            data-annotated-code-marker-stack
+          >
+            {rangeStartMarkers.map((item) => (
+              <span
+                key={item.index}
+                title={`Annotation ${item.marker}`}
+                data-annotated-code-marker={item.marker}
+                onMouseEnter={(event) => {
+                  event.stopPropagation();
+                  const row =
+                    event.currentTarget.closest<HTMLElement>(
+                      "[data-code-line]",
+                    ) ?? event.currentTarget;
+                  openAnnotation(item, row);
+                }}
+                className="group inline-flex size-3 cursor-pointer items-center justify-center rounded-full outline-none transition-transform hover:scale-110"
+              >
+                <span
+                  className={cn(
+                    "block rounded-full ring-1 transition-all duration-150",
+                    activeIndex === item.index
+                      ? "size-[6px] bg-yellow-300 ring-yellow-200 shadow-[0_0_0_3px_rgba(250,204,21,0.30),0_0_16px_rgba(250,204,21,0.92)] dark:bg-yellow-200 dark:ring-yellow-100/70 dark:shadow-[0_0_0_3px_rgba(253,224,71,0.26),0_0_16px_rgba(253,224,71,0.76)]"
+                      : "size-1 bg-yellow-300/95 ring-yellow-200/65 shadow-[0_0_0_2px_rgba(250,204,21,0.18),0_0_11px_rgba(250,204,21,0.56)] group-hover:size-[6px] group-hover:bg-yellow-300 group-hover:ring-yellow-200 group-hover:shadow-[0_0_0_3px_rgba(250,204,21,0.30),0_0_16px_rgba(250,204,21,0.90)] dark:bg-yellow-200/78 dark:ring-yellow-100/38 dark:shadow-[0_0_0_2px_rgba(253,224,71,0.16),0_0_11px_rgba(253,224,71,0.46)] dark:group-hover:bg-yellow-200 dark:group-hover:ring-yellow-100/68 dark:group-hover:shadow-[0_0_0_3px_rgba(253,224,71,0.26),0_0_16px_rgba(253,224,71,0.74)]",
+                  )}
+                />
+              </span>
+            ))}
+          </span>
+        )}
         {overlayItems.length > 0 && (
           <AnnotationInlineOverlayStack
             items={overlayItems}

--- a/packages/core/src/client/blocks/library/diagram.spec.tsx
+++ b/packages/core/src/client/blocks/library/diagram.spec.tsx
@@ -35,7 +35,7 @@ describe("DiagramBlock expand affordance", () => {
 
   const styleButton = () =>
     container.querySelector<HTMLButtonElement>(
-      'button[aria-label="Switch to clean visual style"], button[aria-label="Switch to sketchy visual style"]',
+      'button[aria-label="Switch to clean diagrams"], button[aria-label="Switch to hand-drawn diagrams"]',
     );
 
   const lightbox = () =>
@@ -69,7 +69,8 @@ describe("DiagramBlock expand affordance", () => {
 
     const button = styleButton();
     expect(button).toBeTruthy();
-    expect(button?.textContent).toContain("Clean");
+    expect(button?.getAttribute("aria-label")).toBe("Switch to clean diagrams");
+    expect(button?.getAttribute("aria-pressed")).toBe("true");
 
     act(() => {
       button?.dispatchEvent(
@@ -77,7 +78,10 @@ describe("DiagramBlock expand affordance", () => {
       );
     });
 
-    expect(styleButton()?.textContent).toContain("Sketchy");
+    expect(styleButton()?.getAttribute("aria-label")).toBe(
+      "Switch to hand-drawn diagrams",
+    );
+    expect(styleButton()?.getAttribute("aria-pressed")).toBe("false");
   });
 
   it("renders the expand control for the legacy node-graph variant", () => {

--- a/packages/core/src/client/blocks/library/diagram.tsx
+++ b/packages/core/src/client/blocks/library/diagram.tsx
@@ -1,6 +1,17 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
-import { IconArrowsMaximize, IconPencil, IconX } from "@tabler/icons-react";
+import {
+  IconArrowsMaximize,
+  IconScribble,
+  IconShape2,
+  IconX,
+} from "@tabler/icons-react";
 import { cn } from "../../utils.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../../components/ui/tooltip.js";
 import { ltrCodeBlockProps } from "../code-block-direction.js";
 import { defineBlock } from "../types.js";
 import type {
@@ -612,52 +623,62 @@ function ExpandableDiagramBody({
 }) {
   const [expanded, setExpanded] = useState(false);
   const supportsStyleToggle = Boolean(data.html);
+  const style = useWireframeStyle();
+  const sketchy = style === "sketchy";
+  const styleLabel = sketchy
+    ? "Switch to clean diagrams"
+    : "Switch to hand-drawn diagrams";
+  const styleTooltip = sketchy
+    ? "Hand-drawn diagrams - switch to clean"
+    : "Clean diagrams - switch to hand-drawn";
   return (
     <div className="group/diagram relative">
       <DiagramBody data={data} ctx={ctx} />
-      <div className="absolute right-2 top-2 z-10 flex gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover/diagram:opacity-100">
-        {supportsStyleToggle && <DiagramStyleToggleButton />}
-        <button
-          type="button"
-          data-plan-interactive
-          onClick={() => setExpanded(true)}
-          aria-label="Expand diagram"
-          title="Expand diagram"
-          className="an-diagram-expand-trigger flex size-7 items-center justify-center rounded-md border border-border/60 bg-background/90 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-        >
-          <IconArrowsMaximize className="size-4" />
-        </button>
-      </div>
+      <TooltipProvider delayDuration={100} skipDelayDuration={0}>
+        <div className="absolute right-2 top-2 z-10 flex items-center gap-1.5">
+          {supportsStyleToggle && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  data-plan-interactive
+                  onClick={() => toggleWireframeStyle()}
+                  aria-label={styleLabel}
+                  aria-pressed={sketchy}
+                  className="an-diagram-style-trigger flex size-7 items-center justify-center rounded-md border border-border/60 bg-background/90 text-muted-foreground opacity-0 shadow-sm backdrop-blur transition-[color,opacity] hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-hover/diagram:opacity-100"
+                >
+                  {sketchy ? (
+                    <IconScribble className="size-4" />
+                  ) : (
+                    <IconShape2 className="size-4" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="left">{styleTooltip}</TooltipContent>
+            </Tooltip>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                data-plan-interactive
+                onClick={() => setExpanded(true)}
+                aria-label="Expand diagram"
+                className="an-diagram-expand-trigger flex size-7 items-center justify-center rounded-md border border-border/60 bg-background/90 text-muted-foreground opacity-0 shadow-sm backdrop-blur transition-[color,opacity] hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-hover/diagram:opacity-100"
+              >
+                <IconArrowsMaximize className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="left">Expand diagram</TooltipContent>
+          </Tooltip>
+        </div>
+      </TooltipProvider>
       {expanded ? (
         <DiagramLightbox onClose={() => setExpanded(false)}>
           <DiagramBody data={data} ctx={ctx} />
         </DiagramLightbox>
       ) : null}
     </div>
-  );
-}
-
-function DiagramStyleToggleButton() {
-  const style = useWireframeStyle();
-  const nextStyle = style === "sketchy" ? "clean" : "sketchy";
-  const label = nextStyle === "clean" ? "Clean" : "Sketchy";
-  const description = `Switch to ${label.toLowerCase()} visual style`;
-
-  return (
-    <button
-      type="button"
-      data-plan-interactive
-      aria-label={description}
-      title={description}
-      onClick={(event) => {
-        event.stopPropagation();
-        toggleWireframeStyle();
-      }}
-      className="inline-flex h-7 items-center gap-1 rounded-md border border-border/60 bg-background/90 px-2 text-xs font-medium text-muted-foreground shadow-sm backdrop-blur transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-    >
-      <IconPencil className="size-3.5" aria-hidden="true" />
-      <span>{label}</span>
-    </button>
   );
 }
 

--- a/packages/core/src/client/blocks/library/wireframe.render.spec.tsx
+++ b/packages/core/src/client/blocks/library/wireframe.render.spec.tsx
@@ -45,6 +45,16 @@ function artboardStyle(html: string): string {
   return match[1];
 }
 
+/** Pull the inline `style` attribute of the scale-reservation wrapper. */
+function fitWrapperStyle(html: string): string {
+  const outerTag =
+    html.match(/<div[^>]*class="plan-kit-wireframe"[^>]*>/)?.[0] ?? "";
+  const outerEnd = html.indexOf(outerTag) + outerTag.length;
+  const rest = html.slice(Math.max(outerEnd, 0));
+  const innerTag = rest.match(/<div[^>]*style="([^"]*)"[^>]*>/)?.[0] ?? "";
+  return innerTag.match(/style="([^"]*)"/)?.[1] ?? "";
+}
+
 describe("wireframe auto-height frame", () => {
   it("floors the artboard with min-height and sets no fixed height (kit tree)", () => {
     const html = render({
@@ -79,6 +89,27 @@ describe("wireframe auto-height frame", () => {
 
     // browser preset width is 900 — the footprint is preserved.
     expect(style).toMatch(/width\s*:\s*900px/);
+  });
+
+  it("keeps the unscaled auto-height wrapper in natural SSR flow", () => {
+    const html = render({
+      surface: "desktop",
+      html: "<div>Short mockup</div>",
+    });
+    const style = fitWrapperStyle(html);
+
+    expect(style).not.toMatch(/(^|;)\s*height\s*:/);
+  });
+
+  it("renders captions in static markup", () => {
+    const html = render({
+      surface: "desktop",
+      html: "<div>Mockup with caption</div>",
+      caption: "Review the main editor state",
+    });
+
+    expect(html).toContain("Review the main editor state");
+    expect(html).toContain("text-plan-muted");
   });
 
   it("does not add decorative shadows around the artboard", () => {

--- a/packages/core/src/client/blocks/library/wireframe.tsx
+++ b/packages/core/src/client/blocks/library/wireframe.tsx
@@ -211,6 +211,7 @@ function ArtboardFrame({
   // by the fit factor. Falls back to the surface floor before the first measure
   // so SSR / first paint reserves a sensible box rather than collapsing.
   const reservedHeight = (measuredHeight ?? minHeight) * fitScale;
+  const reserveScaledHeight = fixedHeight != null || fitScale !== 1;
 
   return (
     <div
@@ -225,7 +226,7 @@ function ArtboardFrame({
         style={{
           width: "100%",
           maxWidth: maxFrameWidth,
-          height: reservedHeight,
+          ...(reserveScaledHeight ? { height: reservedHeight } : {}),
           marginInline: "auto",
         }}
       >

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1030,6 +1030,28 @@ describe("server/auth", () => {
         expect((result as Response).status).toBe(302);
         expect((result as Response).headers.get("location")).toBe("/dispatch");
       }
+
+      const recapResult = await guard(
+        createMockEvent({
+          path: "/dispatch/login?return=%2Fdispatch%2Frecaps%2Frecap_123",
+        }),
+      );
+      expect(recapResult).toBeInstanceOf(Response);
+      expect((recapResult as Response).status).toBe(302);
+      expect((recapResult as Response).headers.get("location")).toBe(
+        "/dispatch/recaps/recap_123",
+      );
+
+      const unsafeResult = await guard(
+        createMockEvent({
+          path: "/dispatch/login?return=https%3A%2F%2Fevil.example%2Fx",
+        }),
+      );
+      expect(unsafeResult).toBeInstanceOf(Response);
+      expect((unsafeResult as Response).status).toBe(302);
+      expect((unsafeResult as Response).headers.get("location")).toBe(
+        "/dispatch",
+      );
     });
 
     it("quietly falls back when auto dev account signup loses a duplicate-user race", async () => {

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1710,9 +1710,15 @@ function createAuthGuardFn(): (
     if (p === "/login" || p === "/signup") {
       const session = await getSession(event);
       if (session) {
+        const queryStr = queryStart >= 0 ? url.slice(queryStart + 1) : "";
+        const safeReturn = safeReturnPath(
+          new URLSearchParams(queryStr).get("return"),
+        );
         return new Response("", {
           status: 302,
-          headers: { Location: getAppBasePath() || "/" },
+          headers: {
+            Location: safeReturn === "/" ? getAppBasePath() || "/" : safeReturn,
+          },
         });
       }
       return loginHtmlResponse(loginHtml, event);

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -42,8 +42,13 @@ describe("getOnboardingHtml", () => {
       expect(html).toContain('id="identity-sso-btn"');
       expect(html).toContain('href="/_agent-native/identity/login"');
       expect(html).toContain("Sign in with Agent-Native");
-      // Exactly one occurrence — not duplicated across layout branches.
-      expect(html.split("identity-sso-btn").length - 1).toBe(1);
+      expect(html).toContain("function __anIdentitySsoUrl()");
+      expect(html).toContain("params.set('return', __anGetReturnPath())");
+      expect(html).toContain(
+        "identity.addEventListener('click', __anStartIdentitySso)",
+      );
+      // Exactly one rendered element — not duplicated across layout branches.
+      expect(html.split('id="identity-sso-btn"').length - 1).toBe(1);
     });
 
     it("malformed env value is treated as OFF (no button, no throw)", () => {
@@ -110,6 +115,22 @@ describe("getOnboardingHtml", () => {
       "__anPath('/_agent-native/auth/ba/request-password-reset')",
     );
     expect(html).toContain("__anPath('/_agent-native/google/auth-url')");
+  });
+
+  it("normalizes sign-in return targets before redirect and preserves hashes", () => {
+    const html = getOnboardingHtml();
+
+    expect(html).toContain("function __anNormalizeReturnPath(raw)");
+    expect(html).toContain(
+      "if (url.origin !== window.location.origin) return '';",
+    );
+    expect(html).toContain("return url.pathname + url.search + url.hash;");
+    expect(html).toContain(
+      "return window.location.pathname + window.location.search + window.location.hash;",
+    );
+    expect(html).toContain(
+      "if (value.charAt(0) === '/' && (value.charAt(1) === '/' || value.charAt(1) === '\\\\')) return '';",
+    );
   });
 
   it("uses branded first-party marketing from the request host", () => {

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -188,6 +188,26 @@ ${googleNoticeRunLocalHtml}
 ${googleNoticeRunLocalPanelHtml}
   </div>`
       : "";
+  const identitySsoHtml = identitySsoLoginButtonHtml();
+  const identitySsoScript = identitySsoHtml
+    ? `
+    function __anIdentitySsoUrl() {
+      var params = new URLSearchParams();
+      params.set('return', __anGetReturnPath());
+      return __anPath('/_agent-native/identity/login') + '?' + params.toString();
+    }
+    function __anStartIdentitySso(event) {
+      if (event && event.preventDefault) event.preventDefault();
+      window.location.href = __anIdentitySsoUrl();
+      return false;
+    }
+    (function __anPrepareIdentitySsoButton() {
+      var identity = document.getElementById('identity-sso-btn');
+      if (!identity) return;
+      identity.setAttribute('href', __anIdentitySsoUrl());
+      identity.addEventListener('click', __anStartIdentitySso);
+    })();`
+    : "";
 
   const marketingStyles = hasMarketing
     ? `
@@ -985,7 +1005,7 @@ ${marketingPanelHtml}
     id="upgrade-note"
     data-upgrade-copy="Continue signing in to attach this app to your account and migrate local data."
   ></p>
-${identitySsoLoginButtonHtml()}
+${identitySsoHtml}
 ${
   renderGoogleButton
     ? `
@@ -1183,12 +1203,35 @@ ${
       __anSetOAuthDebug('OAuth exchange redeemed; returning to the app', flowId);
       __anRedirectToSignedInApp(ret);
     }
+    function __anHasControlCharacter(value) {
+      for (var i = 0; i < value.length; i++) {
+        if (value.charCodeAt(i) < 32) return true;
+      }
+      return false;
+    }
+    function __anNormalizeReturnPath(raw) {
+      var value = typeof raw === 'string' ? raw : '';
+      if (!value || __anHasControlCharacter(value)) return '';
+      if (value.charAt(0) === '\\\\') return '';
+      if (value.charAt(0) === '/' && (value.charAt(1) === '/' || value.charAt(1) === '\\\\')) return '';
+      try {
+        var url = new URL(value, window.location.origin);
+        if (url.origin !== window.location.origin) return '';
+        return url.pathname + url.search + url.hash;
+      } catch(e) {
+        return '';
+      }
+    }
+    function __anCurrentReturnPath() {
+      return window.location.pathname + window.location.search + window.location.hash;
+    }
     function __anGetReturnPath() {
       try {
         var inner = new URLSearchParams(window.location.search).get('return');
-        if (inner) return inner;
+        var normalized = __anNormalizeReturnPath(inner);
+        if (normalized) return normalized;
       } catch(e) {}
-      return window.location.pathname + window.location.search;
+      return __anCurrentReturnPath();
     }
     function __anMountedPathname(pathname) {
       var base = __anBasePath();
@@ -1203,10 +1246,11 @@ ${
     function __anGetSignedInReturnPath() {
       try {
         var inner = new URLSearchParams(window.location.search).get('return');
-        if (inner) return inner;
+        var normalized = __anNormalizeReturnPath(inner);
+        if (normalized) return normalized;
       } catch(e) {}
       if (__anIsAuthEntryPath(window.location.pathname)) return __anPath('/');
-      return window.location.pathname + window.location.search + window.location.hash;
+      return __anCurrentReturnPath();
     }
     function __anWithAuthCacheBypass(ret) {
       try {
@@ -1225,6 +1269,7 @@ ${
     function __anRedirectToSignedInApp(ret) {
       window.location.replace(__anWithAuthCacheBypass(ret || __anGetSignedInReturnPath()));
     }
+${identitySsoScript}
     (function __anRedirectIfAlreadySignedIn() {
       fetch(__anPath('/_agent-native/auth/session'), {
         headers: { 'Accept': 'application/json' },

--- a/packages/docs/app/components/SketchToggle.tsx
+++ b/packages/docs/app/components/SketchToggle.tsx
@@ -6,31 +6,46 @@
  * hover toggle; this is the always-available global control.
  */
 
-import { IconPencil, IconVectorBezier2 } from "@tabler/icons-react";
+import { IconScribble, IconShape2 } from "@tabler/icons-react";
 import {
   toggleWireframeStyle,
   useWireframeStyle,
 } from "@agent-native/core/blocks";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 
 export default function SketchToggle() {
   const style = useWireframeStyle();
   const sketchy = style === "sketchy";
   const label = sketchy ? "Diagrams: hand-drawn" : "Diagrams: clean";
+  const tooltip = sketchy
+    ? "Hand-drawn diagrams - switch to clean"
+    : "Clean diagrams - switch to hand-drawn";
 
   return (
-    <button
-      type="button"
-      onClick={() => toggleWireframeStyle()}
-      aria-label={label}
-      aria-pressed={sketchy}
-      title={`${label} — click to switch`}
-      className="hidden h-8 w-8 items-center justify-center rounded-md border border-[var(--docs-border)] text-[var(--fg-secondary)] transition hover:border-[var(--fg-secondary)] hover:text-[var(--fg)] sm:flex"
-    >
-      {sketchy ? (
-        <IconPencil size={16} stroke={1.5} />
-      ) : (
-        <IconVectorBezier2 size={16} stroke={1.5} />
-      )}
-    </button>
+    <TooltipProvider delayDuration={100} skipDelayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => toggleWireframeStyle()}
+            aria-label={label}
+            aria-pressed={sketchy}
+            className="hidden h-8 w-8 items-center justify-center rounded-md border border-[var(--docs-border)] text-[var(--fg-secondary)] transition hover:border-[var(--fg-secondary)] hover:text-[var(--fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:flex"
+          >
+            {sketchy ? (
+              <IconScribble size={16} stroke={1.5} />
+            ) : (
+              <IconShape2 size={16} stroke={1.5} />
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/packages/docs/app/components/docBlocks.tsx
+++ b/packages/docs/app/components/docBlocks.tsx
@@ -321,12 +321,21 @@ function DocBlockError({ alias, message }: { alias: string; message: string }) {
   );
 }
 
+function hashDocBlockSource(source: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < source.length; index++) {
+    hash ^= source.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
 /** Render one embedded block from a parsed {@link DocSegment}. */
 export function DocBlock({
   alias,
   attrs,
   body,
-  index = 0,
+  index,
 }: {
   alias: string;
   attrs: Record<string, string>;
@@ -374,8 +383,14 @@ export function DocBlock({
     );
   }
 
+  const generatedId =
+    index == null
+      ? `doc-block-${hashDocBlockSource(
+          JSON.stringify([alias, attrs.title ?? "", attrs.summary ?? "", body]),
+        )}`
+      : `doc-block-${index}`;
   const block = {
-    id: attrs.id || `doc-block-${index}`,
+    id: attrs.id || generatedId,
     title: attrs.title || undefined,
     summary: attrs.summary || undefined,
     data: parsed.data,

--- a/packages/docs/app/components/docBlocks.validate.test.tsx
+++ b/packages/docs/app/components/docBlocks.validate.test.tsx
@@ -114,4 +114,18 @@ describe("docs visual blocks", () => {
     }
     expect(failures, `\n${failures.join("\n")}\n`).toEqual([]);
   });
+
+  it("renders stable fallback ids across repeated SSR renders", () => {
+    const element = (
+      <DocBlocksProvider>
+        <DocBlock
+          alias="an-callout"
+          attrs={{}}
+          body='{ "tone": "info", "body": "Stable id" }'
+        />
+      </DocBlocksProvider>
+    );
+
+    expect(renderToStaticMarkup(element)).toBe(renderToStaticMarkup(element));
+  });
 });

--- a/packages/docs/app/components/ui/tooltip.tsx
+++ b/packages/docs/app/components/ui/tooltip.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+const TooltipProvider = TooltipPrimitive.Provider;
+const Tooltip = TooltipPrimitive.Root;
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-[300] overflow-hidden rounded-md border border-border bg-popover px-2 py-1 text-[11px] text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/templates/plan/server/plan-content.spec.ts
+++ b/templates/plan/server/plan-content.spec.ts
@@ -129,6 +129,45 @@ describe("structured plan content", () => {
     expect(html).toContain("Implementation Map");
   });
 
+  it("renders kit-tree wireframe captions in standalone HTML", () => {
+    const content: PlanContent = {
+      version: 2,
+      title: "Captioned wireframe",
+      blocks: [
+        {
+          id: "wf-1",
+          type: "wireframe",
+          data: {
+            surface: "desktop",
+            caption: "Calendar availability view",
+            screen: [
+              {
+                id: "screen-root",
+                el: "screen",
+                children: [
+                  {
+                    id: "title-1",
+                    el: "title",
+                    text: "Weekly calendar",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const html = buildPlanContentHtml({
+      content,
+      title: "Captioned wireframe",
+      brief: "Render a captioned wireframe in standalone HTML.",
+    });
+
+    expect(html).toContain("kit-wireframe");
+    expect(html).toContain('<p class="caption">Calendar availability view</p>');
+  });
+
   it("anchors component context sidebar actions after a flexible content stack", () => {
     const content = createUiPlanContent({
       title: "Context X-Ray cleanup",

--- a/templates/plan/server/plan-content.ts
+++ b/templates/plan/server/plan-content.ts
@@ -3362,7 +3362,10 @@ function renderDiagramHtml(data: PlanDiagramBlock["data"]) {
 function renderKitWireframeHtml(data: PlanWireframeBlock["data"]): string {
   const surface = escapeHtml(data.surface || "desktop");
   const screen = data.screen.map(renderKitNodeHtml).join("");
-  return `<div class="kit-wireframe surface-${surface}">${screen}</div>`;
+  const caption = data.caption
+    ? `<p class="caption">${escapeHtml(data.caption)}</p>`
+    : "";
+  return `<div class="kit-wireframe surface-${surface}">${screen}</div>${caption}`;
 }
 
 function renderKitNodeHtml(node: PlanWireframeNode): string {


### PR DESCRIPTION
## Summary
- Replace template screenshot treatments with rough.js-style wireframe mockups and tighter standalone docs copy.
- Shorten long Key features sections and remove the technical label.
- Stabilize docs block IDs/captions, polish diagram/annotation controls, and preserve auth/onboarding return state.

## Tests
- pnpm typecheck
- pnpm test
- pnpm exec prettier --check <changed files>
- pnpm --filter @agent-native/docs exec vitest run app/components/docBlocks.test.ts app/components/docBlocks.validate.test.tsx
- pnpm --filter @agent-native/core exec vitest run src/client/blocks/library/wireframe.render.spec.tsx src/client/blocks/library/AnnotatedCodeBlock.spec.tsx src/client/blocks/library/diagram.spec.tsx src/server/auth.spec.ts src/server/onboarding-html.spec.ts
- pnpm --filter plan test -- server/plan-content.spec.ts server/wireframe-block-registry.spec.ts

Note: local pnpm run prep was blocked by ignored generated folders in this checkout (.video-bakeoff and packages/vscode-extension/.vscode-test); the branch-owned type/test failures it exposed were fixed and the clean targeted/workspace checks above pass.