### PR TITLE
Auto-open popover on manual app launch

### DIFF
--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -155,6 +155,9 @@ pub fn run() {
         .plugin(
             tauri_plugin_autostart::Builder::new()
                 .app_name("Clips")
+                // Tag login-launched processes so startup can stay quiet in the
+                // tray, while a manual launch auto-opens the popover.
+                .args(["--autostart"])
                 .build(),
         )
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -302,6 +305,14 @@ pub fn run() {
                         }
                     }
                 });
+            }
+
+            // Auto-open the popover on a manual launch so the app doesn't sit
+            // silently in the tray waiting for a click. Skipped when launched at
+            // login (tagged with `--autostart`) so it doesn't pop up every boot.
+            let launched_at_login = std::env::args().any(|arg| arg == "--autostart");
+            if !launched_at_login {
+                toggle_popover(app.handle());
             }
 
             Ok(())


### PR DESCRIPTION
### Summary
This PR makes the Clips desktop app automatically open its popover menu when launched manually, so users don't have to click the tray icon to interact with it.

### Problem
When the Clips app was first opened, it would silently appear in the system tray without showing its menu. Users had to manually click the tray icon or reopen the app to access it, which was unintuitive.

### Solution
On app setup, detect whether the app was launched manually or at login, and auto-open the popover only for manual launches. Login-launched processes are tagged with an `--autostart` argument (via the autostart plugin) so the popover is suppressed at boot time.

### Key Changes
- Added `--args(["--autostart"])` to the `tauri_plugin_autostart` builder so login-launched instances are identifiable
- On app setup, checks `std::env::args()` for the `--autostart` flag
- Calls `toggle_popover` automatically when the app is launched manually (i.e., without the `--autostart` flag)


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/pixel-lock-yve6uph4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-pixel-lock-yve6uph4.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1324`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>pixel-lock-yve6uph4</branchName>-->