### PR TITLE
Add wave for the recording mic + unify web cameras

### DIFF
--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -151,15 +151,6 @@ function concreteMediaDeviceId(value: string | null | undefined): string {
   return id && !isPseudoMediaDeviceId(id) ? id : "";
 }
 
-// Prefer this page's own enumeration; fall back to the bubble-relayed list
-// when the popover can't see labels itself (local-camera path).
-function preferEnumerated(
-  own: MediaDeviceInfo[],
-  relayed: MediaDeviceInfo[],
-): MediaDeviceInfo[] {
-  return own.length > 0 ? own : relayed;
-}
-
 function isSelectableMediaDevice(device: MediaDeviceInfo): boolean {
   return !!concreteMediaDeviceId(device.deviceId);
 }
@@ -558,12 +549,6 @@ export function App() {
   );
   const [cameras, setCameras] = useState<MediaDeviceInfo[]>([]);
   const [mics, setMics] = useState<MediaDeviceInfo[]>([]);
-  // Device lists relayed from the bubble page when IT owns the camera grant
-  // (full-screen / local-camera path). The popover page can't enumerate device
-  // labels itself there without muting the live bubble, so we use these lists
-  // when our own enumeration comes back empty.
-  const [bubbleCameras, setBubbleCameras] = useState<MediaDeviceInfo[]>([]);
-  const [bubbleMics, setBubbleMics] = useState<MediaDeviceInfo[]>([]);
   const [cameraId, setCameraId] = useState<string>(() =>
     loadString(CAM_KEY, ""),
   );
@@ -662,14 +647,8 @@ export function App() {
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isRecording = recorder !== null;
   const selectedMicId = useMemo(() => concreteMediaDeviceId(micId), [micId]);
-  const cameraDevices = useMemo(
-    () => preferEnumerated(cameras, bubbleCameras),
-    [cameras, bubbleCameras],
-  );
-  const micDevices = useMemo(
-    () => preferEnumerated(mics, bubbleMics),
-    [mics, bubbleMics],
-  );
+  const cameraDevices = cameras;
+  const micDevices = mics;
   const selectedMicLabel = useMemo(
     () =>
       selectedMicId
@@ -1126,10 +1105,7 @@ export function App() {
     // popover. If the user has picked a concrete mic, use that exact device;
     // otherwise leave labels locked until a real user action needs access.
     try {
-      // While the bubble owns the camera, even this audio-only probe trips
-      // WebKit's single-page capture-exclusion and blacks the bubble. Don't
-      // probe — leave mic labels locked until the bubble is gone.
-      if (bubbleActiveRef.current || !selectedMicId) {
+      if (!selectedMicId) {
         await loadDevices();
         return;
       }
@@ -1149,26 +1125,6 @@ export function App() {
       try {
         if (!navigator.mediaDevices?.getUserMedia) {
           throw new Error("Device selection is not available in this WebView.");
-        }
-        // When the camera bubble is live, ANY getUserMedia in this page —
-        // camera OR mic — hits WebKit's single-page capture-exclusion (one
-        // process, one webview): the bubble page's camera stream gets muted
-        // and goes black with no reliable unmute. The exclusion is not
-        // per-kind, so an audio-only probe blacks the bubble just the same.
-        // So we never probe here while the bubble owns the camera. Instead the
-        // bubble page — the only page that can capture without muting its own
-        // camera — does the probe and relays the device list back to us.
-        if (bubbleActiveRef.current) {
-          if (kind === "mic") {
-            // Ask the bubble to probe + relay the mic list (it has no mic
-            // grant of its own, so it must open a transient mic stream).
-            emit("clips:refresh-mics", {
-              micId: selectedMicId || null,
-            }).catch(() => {});
-          }
-          // Cameras are already relayed when the bubble's local camera starts.
-          await loadDevices();
-          return;
         }
         const stream = await navigator.mediaDevices.getUserMedia(
           kind === "camera"
@@ -1263,20 +1219,6 @@ export function App() {
         setCameraOn(false);
       }),
     );
-    // The bubble relays its device lists (it holds the grant in the
-    // local-camera path). Used by the picker when our own enumeration is empty.
-    const trackRelay = (
-      event: string,
-      set: (devices: MediaDeviceInfo[]) => void,
-    ) =>
-      track(
-        listen<{ devices?: Array<{ deviceId: string; label: string }> }>(
-          event,
-          (ev) => set((ev.payload?.devices ?? []) as MediaDeviceInfo[]),
-        ),
-      );
-    trackRelay("clips:camera-devices", setBubbleCameras);
-    trackRelay("clips:mic-devices", setBubbleMics);
     // Query the CURRENT visibility on mount in case the event already
     // fired before React subscribed.
     getCurrentWindow()
@@ -1368,8 +1310,6 @@ export function App() {
   const wantsCamera = mode !== "screen" && cameraOn;
   const nativeFullscreenRecordingActive =
     mode !== "camera" && shouldUseNativeFullscreenRecording(source);
-  const bubbleUsesLocalCamera =
-    nativeFullscreenRecordingActive && localRecordingMode !== "separate";
   // Ref mirror of `isRecording || recordingFlowActive` so cleanup (which
   // captures the dep-snapshot value) can still see the CURRENT flow state
   // at the moment it actually runs. Without this, if `recordingFlowActive`
@@ -1445,85 +1385,6 @@ export function App() {
     console.log(
       "[clips-popover] bubble session start — acquiring camera + showing bubble",
     );
-
-    if (bubbleUsesLocalCamera) {
-      const localStartTimers: Array<ReturnType<typeof setTimeout>> = [];
-      let localReadyUnlisten: (() => void) | null = null;
-      const emitLocalCameraStart = (reason: string) => {
-        if (cancelled) return;
-        console.log(
-          "[clips-popover] starting local bubble camera — %s",
-          reason,
-        );
-        emit("clips:bubble-start-local-camera", {
-          cameraId: cameraId || null,
-        }).catch((err) => {
-          if (!cancelled) {
-            console.warn(
-              "[clips-popover] emit local bubble camera start failed:",
-              err,
-            );
-          }
-        });
-      };
-
-      listen("clips:bubble-ready", () => emitLocalCameraStart("ready"))
-        .then((u) => {
-          if (cancelled) {
-            try {
-              u();
-            } catch {
-              // ignore
-            }
-          } else {
-            localReadyUnlisten = u;
-          }
-        })
-        .catch(() => {});
-
-      invoke("show_bubble")
-        .then(() => {
-          // The bubble's React listener may mount just after the Rust window
-          // reports as shown. Send a few idempotent starts; the bubble ignores
-          // repeats for the same camera but this avoids a first-show race.
-          for (const delay of [100, 500, 1000]) {
-            localStartTimers.push(
-              setTimeout(
-                () => emitLocalCameraStart(`show-bubble+${delay}ms`),
-                delay,
-              ),
-            );
-          }
-        })
-        .catch((err) => {
-          if (!cancelled) {
-            console.error("[clips-popover] local bubble start failed:", err);
-            setCameraError(`Camera unavailable: ${err?.message ?? err}`);
-          }
-        });
-
-      return () => {
-        cancelled = true;
-        for (const timer of localStartTimers) clearTimeout(timer);
-        try {
-          localReadyUnlisten?.();
-        } catch {
-          // ignore
-        }
-        emit("clips:bubble-stop-local-camera", {}).catch(() => {});
-        const recordingInFlight = recordingFlowGateRef.current;
-        console.log(
-          "[clips-popover] local bubble session end — recordingInFlight=%o stillActive=%o",
-          recordingInFlight,
-          bubbleActiveRef.current,
-        );
-        // Skip teardown when the bubble is still wanted (only the capture
-        // source changed). Hiding here would race the re-run's show_bubble.
-        if (!recordingInFlight && !bubbleActiveRef.current) {
-          invoke("hide_overlays").catch(() => {});
-        }
-      };
-    }
 
     navigator.mediaDevices
       .getUserMedia({
@@ -1642,14 +1503,13 @@ export function App() {
       // the bubble correctly). Hiding here mid-flow would kill the
       // on-screen bubble window the user sees during the recording.
       // Also skip when the bubble is still wanted and only the capture
-      // source changed (window ↔ full-screen flips `bubbleUsesLocalCamera`,
-      // re-running this effect): hiding would race the re-run's show_bubble
-      // and close the window out from under it.
+      // source changed (e.g. cameraId flip re-runs this effect): hiding
+      // would race the re-run's show_bubble and close the window out from under it.
       if (!recordingInFlight && !bubbleActiveRef.current) {
         invoke("hide_overlays").catch(() => {});
       }
     };
-  }, [bubbleActive, bubbleUsesLocalCamera, cameraId]);
+  }, [bubbleActive, cameraId]);
 
   // ---- auto-size popover to content --------------------------------------
   // The Tauri window is fixed-size via tauri.conf.json, but our content
@@ -1933,9 +1793,7 @@ export function App() {
     // effect's deps still include `isRecording`, so the stream + bubble
     // + pump stay alive for the entire recording.
     const preAcquiredCameraStream =
-      mode !== "screen" && cameraOn && !bubbleUsesLocalCamera
-        ? bubbleStreamRef.current
-        : null;
+      mode !== "screen" && cameraOn ? bubbleStreamRef.current : null;
     // Flip the ownership flag BEFORE kicking off the recorder. Any
     // bubble-session cleanup that fires after this point must leave the
     // tracks alone — the recorder now owns them. Cleared in the stop /
@@ -2420,13 +2278,6 @@ export function App() {
           systemAudio={systemAudioOn}
           onSystemAudioToggle={setSystemAudioOn}
           meterActive={popoverVisible && !isRecording}
-          // The meter mic must open in whichever page owns the camera, or
-          // WebKit's cross-page capture-exclusion mutes it. The bubble owns the
-          // camera only in native full-screen (`bubbleUsesLocalCamera`); in
-          // window/screen/camera modes the popover owns it, so the meter runs
-          // locally here. Keying off `bubbleActive` alone wrongly relayed window
-          // recordings to a bubble that has no camera → flat bars.
-          meterRelay={bubbleActive && bubbleUsesLocalCamera}
         />
       </div>
 

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2419,6 +2419,14 @@ export function App() {
           onToggle={setMicOn}
           systemAudio={systemAudioOn}
           onSystemAudioToggle={setSystemAudioOn}
+          meterActive={popoverVisible && !isRecording}
+          // The meter mic must open in whichever page owns the camera, or
+          // WebKit's cross-page capture-exclusion mutes it. The bubble owns the
+          // camera only in native full-screen (`bubbleUsesLocalCamera`); in
+          // window/screen/camera modes the popover owns it, so the meter runs
+          // locally here. Keying off `bubbleActive` alone wrongly relayed window
+          // recordings to a bubble that has no camera → flat bars.
+          meterRelay={bubbleActive && bubbleUsesLocalCamera}
         />
       </div>
 

--- a/templates/clips/desktop/src/components/MediaDeviceRow.tsx
+++ b/templates/clips/desktop/src/components/MediaDeviceRow.tsx
@@ -26,20 +26,9 @@ function Toggle({
   );
 }
 
-// Live mic level meter. Drives the bar heights from real audio so users can see
-// their mic is actually picking up sound. When the camera bubble is live the
-// meter relays through the bubble page instead of opening a mic here (see
-// useMicMeter for the WebKit capture-exclusion details).
-function MicWave({
-  deviceId,
-  active,
-  relay,
-}: {
-  deviceId: string;
-  active: boolean;
-  relay: boolean;
-}) {
-  const barsRef = useMicMeter({ deviceId, active, relay });
+// Live mic level meter. Drives the bar heights from real audio.
+function MicWave({ deviceId, active }: { deviceId: string; active: boolean }) {
+  const barsRef = useMicMeter({ deviceId, active });
 
   return (
     <span className="mic-wave" aria-hidden>
@@ -68,7 +57,6 @@ export function MediaDeviceRow({
   systemAudio,
   onSystemAudioToggle,
   meterActive = true,
-  meterRelay = false,
 }: {
   kind: "camera" | "mic";
   devices: MediaDeviceInfo[];
@@ -81,7 +69,6 @@ export function MediaDeviceRow({
   systemAudio?: boolean;
   onSystemAudioToggle?: (v: boolean) => void;
   meterActive?: boolean;
-  meterRelay?: boolean;
 }) {
   const current = useMemo(
     () =>
@@ -142,11 +129,7 @@ export function MediaDeviceRow({
         label={kind === "camera" ? "Camera" : "Microphone"}
       />
       {kind === "mic" && on ? (
-        <MicWave
-          deviceId={selectedId}
-          active={on && meterActive}
-          relay={meterRelay}
-        />
+        <MicWave deviceId={selectedId} active={on && meterActive} />
       ) : null}
       {open ? (
         <div className="row-menu" role="menu">

--- a/templates/clips/desktop/src/components/MediaDeviceRow.tsx
+++ b/templates/clips/desktop/src/components/MediaDeviceRow.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { CameraIcon, CheckIcon, ChevronDown, MicIcon } from "./Icons";
 import { Switch } from "./Switch";
 import { useRowMenu } from "./useRowMenu";
+import { useMicMeter, WAVE_BARS } from "../hooks/useMicMeter";
 
 function Toggle({
   on,
@@ -25,13 +26,32 @@ function Toggle({
   );
 }
 
-function MicWave() {
+// Live mic level meter. Drives the bar heights from real audio so users can see
+// their mic is actually picking up sound. When the camera bubble is live the
+// meter relays through the bubble page instead of opening a mic here (see
+// useMicMeter for the WebKit capture-exclusion details).
+function MicWave({
+  deviceId,
+  active,
+  relay,
+}: {
+  deviceId: string;
+  active: boolean;
+  relay: boolean;
+}) {
+  const barsRef = useMicMeter({ deviceId, active, relay });
+
   return (
     <span className="mic-wave" aria-hidden>
-      <span className="bar b1" />
-      <span className="bar b2" />
-      <span className="bar b3" />
-      <span className="bar b4" />
+      {Array.from({ length: WAVE_BARS }).map((_, i) => (
+        <span
+          key={i}
+          className="bar"
+          ref={(el) => {
+            barsRef.current[i] = el;
+          }}
+        />
+      ))}
     </span>
   );
 }
@@ -47,6 +67,8 @@ export function MediaDeviceRow({
   onToggle,
   systemAudio,
   onSystemAudioToggle,
+  meterActive = true,
+  meterRelay = false,
 }: {
   kind: "camera" | "mic";
   devices: MediaDeviceInfo[];
@@ -58,6 +80,8 @@ export function MediaDeviceRow({
   onToggle: (v: boolean) => void;
   systemAudio?: boolean;
   onSystemAudioToggle?: (v: boolean) => void;
+  meterActive?: boolean;
+  meterRelay?: boolean;
 }) {
   const current = useMemo(
     () =>
@@ -117,7 +141,13 @@ export function MediaDeviceRow({
         onChange={onToggle}
         label={kind === "camera" ? "Camera" : "Microphone"}
       />
-      {kind === "mic" && on ? <MicWave /> : null}
+      {kind === "mic" && on ? (
+        <MicWave
+          deviceId={selectedId}
+          active={on && meterActive}
+          relay={meterRelay}
+        />
+      ) : null}
       {open ? (
         <div className="row-menu" role="menu">
           <button

--- a/templates/clips/desktop/src/components/MediaDeviceRow.tsx
+++ b/templates/clips/desktop/src/components/MediaDeviceRow.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { CameraIcon, CheckIcon, ChevronDown, MicIcon } from "./Icons";
 import { Switch } from "./Switch";
 import { useRowMenu } from "./useRowMenu";
-import { useMicMeter, WAVE_BARS } from "../hooks/useMicMeter";
+import { useMicMeter } from "../hooks/useMicMeter";
 
 function Toggle({
   on,
@@ -26,21 +26,26 @@ function Toggle({
   );
 }
 
-// Live mic level meter. Drives the bar heights from real audio.
+// Live mic level meter — a single wave line driven by real audio. The hook
+// owns the analyser and writes the path's `d`; the line oscillates around the
+// center and flattens when silent.
 function MicWave({ deviceId, active }: { deviceId: string; active: boolean }) {
-  const barsRef = useMicMeter({ deviceId, active });
+  const pathRef = useMicMeter({ deviceId, active });
 
   return (
     <span className="mic-wave" aria-hidden>
-      {Array.from({ length: WAVE_BARS }).map((_, i) => (
-        <span
-          key={i}
-          className="bar"
-          ref={(el) => {
-            barsRef.current[i] = el;
-          }}
+      <svg
+        className="mic-wave-svg"
+        viewBox="0 0 100 24"
+        preserveAspectRatio="none"
+      >
+        <path
+          ref={pathRef}
+          className="mic-wave-path"
+          d="M 0 12 L 100 12"
+          fill="none"
         />
-      ))}
+      </svg>
     </span>
   );
 }
@@ -119,6 +124,11 @@ export function MediaDeviceRow({
         title={label}
       >
         <span className="row-label">{label}</span>
+        {kind === "mic" && on ? (
+          <MicWave deviceId={selectedId} active={on && meterActive} />
+        ) : (
+          <span className="row-flex" aria-hidden />
+        )}
         <span className="row-chev" aria-hidden>
           <ChevronDown />
         </span>
@@ -128,9 +138,6 @@ export function MediaDeviceRow({
         onChange={onToggle}
         label={kind === "camera" ? "Camera" : "Microphone"}
       />
-      {kind === "mic" && on ? (
-        <MicWave deviceId={selectedId} active={on && meterActive} />
-      ) : null}
       {open ? (
         <div className="row-menu" role="menu">
           <button

--- a/templates/clips/desktop/src/hooks/useMicMeter.ts
+++ b/templates/clips/desktop/src/hooks/useMicMeter.ts
@@ -1,0 +1,178 @@
+import { useEffect, useRef, type MutableRefObject } from "react";
+import { emit, listen } from "@tauri-apps/api/event";
+
+// Number of bars in the live mic level meter. The popover sends this to the
+// bubble page in relay mode so both sides agree on the sample count.
+export const WAVE_BARS = 18;
+
+// How often each mode pushes a fresh sample (ms). Both modes share this so the
+// meter feels identical whether it runs locally or relays through the bubble.
+export const METER_INTERVAL_MS = 50;
+
+// Relay keepalive cadence (ms). The popover re-sends `clips:mic-meter-start` on
+// this interval; the bubble treats repeats for the same device as a heartbeat
+// and auto-stops its mic if they ever go quiet (see RELAY_STALE_MS in bubble).
+export const METER_KEEPALIVE_MS = 1000;
+
+// Map a 0..1 level to a bar height. The 10% floor keeps idle bars visible; the
+// 1.3 gain lifts quiet speech to a readable height before the 100% clamp.
+function levelToHeight(level: number): string {
+  return `${Math.max(10, Math.min(100, level * 130))}%`;
+}
+
+function flatten(bars: (HTMLSpanElement | null)[]): void {
+  for (const bar of bars) if (bar) bar.style.height = "10%";
+}
+
+function applyLevels(bars: (HTMLSpanElement | null)[], levels: number[]): void {
+  for (let i = 0; i < bars.length; i++) {
+    const bar = bars[i];
+    if (bar) bar.style.height = levelToHeight(levels[i] ?? 0);
+  }
+}
+
+// Shared analyser config so local and relay modes sample identically.
+export function createMeterAnalyser(
+  ctx: AudioContext,
+  stream: MediaStream,
+): { analyser: AnalyserNode; data: Uint8Array<ArrayBuffer> } {
+  const source = ctx.createMediaStreamSource(stream);
+  const analyser = ctx.createAnalyser();
+  analyser.fftSize = 64;
+  analyser.smoothingTimeConstant = 0.7;
+  source.connect(analyser);
+  return { analyser, data: new Uint8Array(analyser.frequencyBinCount) };
+}
+
+// Read the analyser and bucket the usable FFT bins into `barCount` levels. The
+// top ~30% of bins carry little voice energy, so we only sample the lower 70%.
+export function sampleLevels(
+  analyser: AnalyserNode,
+  data: Uint8Array<ArrayBuffer>,
+  barCount: number,
+): number[] {
+  analyser.getByteFrequencyData(data);
+  const usable = Math.floor(data.length * 0.7);
+  const levels: number[] = [];
+  for (let i = 0; i < barCount; i++) {
+    const idx = Math.min(usable - 1, Math.floor((i / barCount) * usable));
+    levels.push(data[idx] / 255);
+  }
+  return levels;
+}
+
+/**
+ * Drives a row of bars from live mic input so users can validate their mic.
+ *
+ * Two modes, because of WebKit's single-page capture-exclusion (Tauri runs
+ * every webview in one WebKit process; when one page calls getUserMedia, capture
+ * in OTHER pages is muted):
+ *
+ * The mic must open in whichever page owns the camera, or it gets muted:
+ *
+ *  - **local** (`relay === false`): the popover owns the camera (window/screen/
+ *    camera modes) or no camera is live — opening the mic in this same page is
+ *    safe, so we analyse it directly. Mirrors what the recorder does (camera +
+ *    mic captured together in the popover).
+ *  - **relay** (`relay === true`): the camera bubble owns a live capture in
+ *    another page (native full-screen). Opening a mic here would black it out,
+ *    so we ask the bubble page (same page as its camera → no mute) to run the
+ *    analyser and emit level samples, which we just render.
+ */
+export function useMicMeter({
+  active,
+  deviceId,
+  relay,
+}: {
+  active: boolean;
+  deviceId: string;
+  relay: boolean;
+}): MutableRefObject<(HTMLSpanElement | null)[]> {
+  const barsRef = useRef<(HTMLSpanElement | null)[]>([]);
+
+  // Local mode — open the mic in this page and analyse it.
+  useEffect(() => {
+    if (!active || relay) return;
+    let stream: MediaStream | null = null;
+    let audioCtx: AudioContext | null = null;
+    let timer: ReturnType<typeof setInterval> | null = null;
+    let cancelled = false;
+
+    const start = async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: deviceId ? { deviceId: { exact: deviceId } } : true,
+          video: false,
+        });
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          stream = null;
+          return;
+        }
+        audioCtx = new AudioContext();
+        // A context created without a user gesture can start suspended, which
+        // freezes the analyser at zero — resume before reading it.
+        await audioCtx.resume();
+        const { analyser, data } = createMeterAnalyser(audioCtx, stream);
+        timer = setInterval(() => {
+          applyLevels(barsRef.current, sampleLevels(analyser, data, WAVE_BARS));
+        }, METER_INTERVAL_MS);
+      } catch {
+        flatten(barsRef.current);
+      }
+    };
+
+    void start();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearInterval(timer);
+      if (audioCtx) audioCtx.close().catch(() => {});
+      if (stream) stream.getTracks().forEach((t) => t.stop());
+    };
+  }, [active, relay, deviceId]);
+
+  // Relay mode — the bubble page owns the mic and emits level samples.
+  useEffect(() => {
+    if (!active || !relay) return;
+    let stopped = false;
+    let levelUnlisten: (() => void) | null = null;
+
+    const requestStart = () => {
+      emit("clips:mic-meter-start", {
+        micId: deviceId || null,
+        bars: WAVE_BARS,
+      }).catch(() => {});
+    };
+
+    // The first send may lose the race against the bubble webview mounting, and
+    // the bubble auto-stops if these pings go quiet. Re-sending on a timer both
+    // wins the mount race and doubles as the keepalive heartbeat.
+    requestStart();
+    const keepalive = setInterval(requestStart, METER_KEEPALIVE_MS);
+
+    listen<{ levels?: number[] }>("clips:mic-level", (event) => {
+      if (stopped) return;
+      const levels = event.payload?.levels;
+      if (Array.isArray(levels)) applyLevels(barsRef.current, levels);
+    })
+      .then((u) => {
+        if (stopped) {
+          u();
+          return;
+        }
+        levelUnlisten = u;
+      })
+      .catch(() => {});
+
+    return () => {
+      stopped = true;
+      clearInterval(keepalive);
+      if (levelUnlisten) levelUnlisten();
+      emit("clips:mic-meter-stop", {}).catch(() => {});
+      flatten(barsRef.current);
+    };
+  }, [active, relay, deviceId]);
+
+  return barsRef;
+}

--- a/templates/clips/desktop/src/hooks/useMicMeter.ts
+++ b/templates/clips/desktop/src/hooks/useMicMeter.ts
@@ -1,26 +1,50 @@
 import { useEffect, useRef, type MutableRefObject } from "react";
 
-// Number of bars in the live mic level meter.
-export const WAVE_BARS = 18;
+// Number of points sampled across the wave line. Fewer points = wider, bigger
+// waves (each above/below pair is one hump); more = a tighter, busier line.
+export const WAVE_BARS = 10;
 
 // How often the meter pushes a fresh sample (ms).
 export const METER_INTERVAL_MS = 50;
 
-// Map a 0..1 level to a bar height. The 10% floor keeps idle bars visible; the
-// 1.3 gain lifts quiet speech to a readable height before the 100% clamp.
-function levelToHeight(level: number): string {
-  return `${Math.max(10, Math.min(100, level * 130))}%`;
-}
+// SVG path coordinate space. The line is drawn into a 0..VIEW_W × 0..VIEW_H box
+// stretched to the row width; the stroke stays crisp via non-scaling-stroke.
+const VIEW_W = 100;
+const VIEW_H = 24;
+const CENTER_Y = VIEW_H / 2;
+const MAX_AMP = 11; // peak deflection from center, leaves a little headroom
+const FLAT_LINE = `M 0 ${CENTER_Y} L ${VIEW_W} ${CENTER_Y}`;
 
-function flatten(bars: (HTMLSpanElement | null)[]): void {
-  for (const bar of bars) if (bar) bar.style.height = "10%";
-}
-
-function applyLevels(bars: (HTMLSpanElement | null)[], levels: number[]): void {
-  for (let i = 0; i < bars.length; i++) {
-    const bar = bars[i];
-    if (bar) bar.style.height = levelToHeight(levels[i] ?? 0);
+// Build a smooth wave path from 0..1 levels. Points alternate above/below the
+// center line so the result reads as an oscillating waveform (not a one-sided
+// envelope); quadratic curves through the midpoints round off the corners. At
+// rest (levels ~0) it collapses to a flat center line.
+function buildWavePath(levels: number[]): string {
+  const n = levels.length;
+  if (n < 2) return FLAT_LINE;
+  const pts = levels.map((lv, i) => {
+    const x = (i / (n - 1)) * VIEW_W;
+    const sign = i % 2 === 0 ? -1 : 1;
+    const y = CENTER_Y + sign * Math.min(1, lv) * MAX_AMP;
+    return { x, y };
+  });
+  let d = `M ${pts[0].x.toFixed(2)} ${pts[0].y.toFixed(2)}`;
+  for (let i = 0; i < n - 1; i++) {
+    const xc = (pts[i].x + pts[i + 1].x) / 2;
+    const yc = (pts[i].y + pts[i + 1].y) / 2;
+    d += ` Q ${pts[i].x.toFixed(2)} ${pts[i].y.toFixed(2)} ${xc.toFixed(2)} ${yc.toFixed(2)}`;
   }
+  const last = pts[n - 1];
+  d += ` L ${last.x.toFixed(2)} ${last.y.toFixed(2)}`;
+  return d;
+}
+
+function drawWave(path: SVGPathElement | null, levels: number[]): void {
+  if (path) path.setAttribute("d", buildWavePath(levels));
+}
+
+function flatten(path: SVGPathElement | null): void {
+  if (path) path.setAttribute("d", FLAT_LINE);
 }
 
 // Shared analyser config so local and relay modes sample identically.
@@ -59,8 +83,8 @@ export function useMicMeter({
 }: {
   active: boolean;
   deviceId: string;
-}): MutableRefObject<(HTMLSpanElement | null)[]> {
-  const barsRef = useRef<(HTMLSpanElement | null)[]>([]);
+}): MutableRefObject<SVGPathElement | null> {
+  const pathRef = useRef<SVGPathElement | null>(null);
 
   useEffect(() => {
     if (!active) return;
@@ -86,10 +110,10 @@ export function useMicMeter({
         await audioCtx.resume();
         const { analyser, data } = createMeterAnalyser(audioCtx, stream);
         timer = setInterval(() => {
-          applyLevels(barsRef.current, sampleLevels(analyser, data, WAVE_BARS));
+          drawWave(pathRef.current, sampleLevels(analyser, data, WAVE_BARS));
         }, METER_INTERVAL_MS);
       } catch {
-        flatten(barsRef.current);
+        flatten(pathRef.current);
       }
     };
 
@@ -100,8 +124,9 @@ export function useMicMeter({
       if (timer) clearInterval(timer);
       if (audioCtx) audioCtx.close().catch(() => {});
       if (stream) stream.getTracks().forEach((t) => t.stop());
+      flatten(pathRef.current);
     };
   }, [active, deviceId]);
 
-  return barsRef;
+  return pathRef;
 }

--- a/templates/clips/desktop/src/hooks/useMicMeter.ts
+++ b/templates/clips/desktop/src/hooks/useMicMeter.ts
@@ -1,18 +1,10 @@
 import { useEffect, useRef, type MutableRefObject } from "react";
-import { emit, listen } from "@tauri-apps/api/event";
 
-// Number of bars in the live mic level meter. The popover sends this to the
-// bubble page in relay mode so both sides agree on the sample count.
+// Number of bars in the live mic level meter.
 export const WAVE_BARS = 18;
 
-// How often each mode pushes a fresh sample (ms). Both modes share this so the
-// meter feels identical whether it runs locally or relays through the bubble.
+// How often the meter pushes a fresh sample (ms).
 export const METER_INTERVAL_MS = 50;
-
-// Relay keepalive cadence (ms). The popover re-sends `clips:mic-meter-start` on
-// this interval; the bubble treats repeats for the same device as a heartbeat
-// and auto-stops its mic if they ever go quiet (see RELAY_STALE_MS in bubble).
-export const METER_KEEPALIVE_MS = 1000;
 
 // Map a 0..1 level to a bar height. The 10% floor keeps idle bars visible; the
 // 1.3 gain lifts quiet speech to a readable height before the 100% clamp.
@@ -61,38 +53,17 @@ export function sampleLevels(
   return levels;
 }
 
-/**
- * Drives a row of bars from live mic input so users can validate their mic.
- *
- * Two modes, because of WebKit's single-page capture-exclusion (Tauri runs
- * every webview in one WebKit process; when one page calls getUserMedia, capture
- * in OTHER pages is muted):
- *
- * The mic must open in whichever page owns the camera, or it gets muted:
- *
- *  - **local** (`relay === false`): the popover owns the camera (window/screen/
- *    camera modes) or no camera is live — opening the mic in this same page is
- *    safe, so we analyse it directly. Mirrors what the recorder does (camera +
- *    mic captured together in the popover).
- *  - **relay** (`relay === true`): the camera bubble owns a live capture in
- *    another page (native full-screen). Opening a mic here would black it out,
- *    so we ask the bubble page (same page as its camera → no mute) to run the
- *    analyser and emit level samples, which we just render.
- */
 export function useMicMeter({
   active,
   deviceId,
-  relay,
 }: {
   active: boolean;
   deviceId: string;
-  relay: boolean;
 }): MutableRefObject<(HTMLSpanElement | null)[]> {
   const barsRef = useRef<(HTMLSpanElement | null)[]>([]);
 
-  // Local mode — open the mic in this page and analyse it.
   useEffect(() => {
-    if (!active || relay) return;
+    if (!active) return;
     let stream: MediaStream | null = null;
     let audioCtx: AudioContext | null = null;
     let timer: ReturnType<typeof setInterval> | null = null;
@@ -130,49 +101,7 @@ export function useMicMeter({
       if (audioCtx) audioCtx.close().catch(() => {});
       if (stream) stream.getTracks().forEach((t) => t.stop());
     };
-  }, [active, relay, deviceId]);
-
-  // Relay mode — the bubble page owns the mic and emits level samples.
-  useEffect(() => {
-    if (!active || !relay) return;
-    let stopped = false;
-    let levelUnlisten: (() => void) | null = null;
-
-    const requestStart = () => {
-      emit("clips:mic-meter-start", {
-        micId: deviceId || null,
-        bars: WAVE_BARS,
-      }).catch(() => {});
-    };
-
-    // The first send may lose the race against the bubble webview mounting, and
-    // the bubble auto-stops if these pings go quiet. Re-sending on a timer both
-    // wins the mount race and doubles as the keepalive heartbeat.
-    requestStart();
-    const keepalive = setInterval(requestStart, METER_KEEPALIVE_MS);
-
-    listen<{ levels?: number[] }>("clips:mic-level", (event) => {
-      if (stopped) return;
-      const levels = event.payload?.levels;
-      if (Array.isArray(levels)) applyLevels(barsRef.current, levels);
-    })
-      .then((u) => {
-        if (stopped) {
-          u();
-          return;
-        }
-        levelUnlisten = u;
-      })
-      .catch(() => {});
-
-    return () => {
-      stopped = true;
-      clearInterval(keepalive);
-      if (levelUnlisten) levelUnlisten();
-      emit("clips:mic-meter-stop", {}).catch(() => {});
-      flatten(barsRef.current);
-    };
-  }, [active, relay, deviceId]);
+  }, [active, deviceId]);
 
   return barsRef;
 }

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -2216,11 +2216,13 @@ async function startRecordingInner(
   streamCleanups.push(recordingAudio.cleanup);
   recordingAudio.tracks.forEach((t) => combined.addTrack(t));
 
-  // The popover owns the camera stream when we're reusing a pre-acquired
-  // one — its session effect decides when to close the stream + hide the
-  // bubble + stop the pump. The recorder must NOT stop those tracks on
-  // stop/cancel. For camera-only mode (rare path where popover didn't
-  // hand us a stream) we own it ourselves.
+  // The popover owns the camera stream whenever we reused its pre-acquired
+  // preview stream — its session effect decides when to close the stream +
+  // hide the bubble + stop the pump, so the recorder must NOT stop those
+  // tracks on stop/cancel. The rare exception is the fresh-acquire fallback
+  // (preview stream wasn't ready at record start, so we opened the camera
+  // ourselves above) — there we own the tracks and must stop them, or the
+  // camera + macOS recording indicator leak after the recording ends.
   const popoverOwnsCamera = bubbleCameraStream === reusedCameraStream;
 
   if (localRecordingMode !== "off") {
@@ -2338,11 +2340,8 @@ async function startRecordingInner(
     };
 
     const hideChrome = async () => {
-      const chromeCmd = popoverOwnsCamera
-        ? "hide_recording_chrome"
-        : "hide_overlays";
-      await invoke(chromeCmd).catch((err) =>
-        console.error(`[clips-recorder] ${chromeCmd} failed:`, err),
+      await invoke("hide_recording_chrome").catch((err) =>
+        console.error(`[clips-recorder] hide_recording_chrome failed:`, err),
       );
     };
 
@@ -2811,11 +2810,8 @@ async function startRecordingInner(
       // down the bubble. Closing it here would cause a flicker on the
       // cancel path where the popover re-appears with camera still on.
       console.log("[clips-recorder] hiding recording chrome");
-      const chromeCmd = popoverOwnsCamera
-        ? "hide_recording_chrome"
-        : "hide_overlays";
-      await invoke(chromeCmd).catch((err) =>
-        console.error(`[clips-recorder] ${chromeCmd} failed:`, err),
+      await invoke("hide_recording_chrome").catch((err) =>
+        console.error(`[clips-recorder] hide_recording_chrome failed:`, err),
       );
 
       // Wait for any in-flight chunk uploads to settle before sending the
@@ -2946,12 +2942,7 @@ async function startRecordingInner(
       // Blobs via this Set. Combined with the `ondataavailable = null`
       // above, this guarantees no new Blobs latch on during the stop.
       inflight.clear();
-      // Same split as stop(): leave the bubble alone when popover owns
-      // the camera — the popover's session effect handles bubble teardown.
-      const chromeCmd = popoverOwnsCamera
-        ? "hide_recording_chrome"
-        : "hide_overlays";
-      await invoke(chromeCmd).catch(() => {});
+      await invoke("hide_recording_chrome").catch(() => {});
       // Tell the server to abort the partial recording (drops chunks from
       // application_state, flips the recording row to 'failed'). Fire and
       // forget with a short-circuit on failure — we don't want to keep the

--- a/templates/clips/desktop/src/overlays/bubble.tsx
+++ b/templates/clips/desktop/src/overlays/bubble.tsx
@@ -3,6 +3,16 @@ import { emit, listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { IconCameraOff } from "@tabler/icons-react";
+import {
+  createMeterAnalyser,
+  sampleLevels,
+  METER_INTERVAL_MS,
+} from "../hooks/useMicMeter";
+
+// Drop the mic meter if the popover's keepalive pings stop arriving — guards
+// against leaking an open mic (and the macOS recording indicator) when the
+// popover window dies without sending `clips:mic-meter-stop`.
+const RELAY_STALE_MS = 2500;
 
 type BubbleSize = "small" | "medium";
 const LOCAL_CAMERA_TARGET_FPS = 60;
@@ -259,8 +269,40 @@ export function Bubble() {
     let startUnlisten: (() => void) | null = null;
     let stopUnlisten: (() => void) | null = null;
     let refreshMicsUnlisten: (() => void) | null = null;
+    let meterStartUnlisten: (() => void) | null = null;
+    let meterStopUnlisten: (() => void) | null = null;
     let renderedFrames = 0;
     let lastFpsLogAt = 0;
+
+    // Live mic meter session. The popover delegates this to us because opening a
+    // mic in its own page would mute this bubble's camera (WebKit cross-page
+    // capture-exclusion). Opening the mic HERE — same page as our camera — does
+    // not mute it, so we run the analyser and relay level samples to the popover.
+    let meterStream: MediaStream | null = null;
+    let meterCtx: AudioContext | null = null;
+    let meterTimer: ReturnType<typeof setInterval> | null = null;
+    let meterWatchdog: ReturnType<typeof setInterval> | null = null;
+    let meterMicId: string | null = null;
+    let meterLastPing = 0;
+    const stopMicMeter = () => {
+      if (meterTimer) {
+        clearInterval(meterTimer);
+        meterTimer = null;
+      }
+      if (meterWatchdog) {
+        clearInterval(meterWatchdog);
+        meterWatchdog = null;
+      }
+      if (meterCtx) {
+        meterCtx.close().catch(() => {});
+        meterCtx = null;
+      }
+      if (meterStream) {
+        meterStream.getTracks().forEach((t) => t.stop());
+        meterStream = null;
+      }
+      meterMicId = null;
+    };
 
     const stopLocalCanvasRenderer = () => {
       const videoEl = videoRef.current;
@@ -509,8 +551,86 @@ export function Bubble() {
       })
       .catch(() => {});
 
+    // Start the live mic meter on request and emit level samples the popover
+    // renders. We open the mic here (same page as our camera) so the bubble
+    // stays live instead of getting muted.
+    listen<{ micId?: string | null; bars?: number }>(
+      "clips:mic-meter-start",
+      async (event) => {
+        if (stopped) return;
+        const micId = event.payload?.micId?.trim() || null;
+        // Each start also counts as a keepalive ping (the popover re-sends on a
+        // timer); record it so the watchdog below knows the popover is alive.
+        meterLastPing = Date.now();
+        // Ignore idempotent repeats for the same device — already running.
+        if (meterStream && meterMicId === micId) return;
+        stopMicMeter();
+        const barCount = Math.max(1, event.payload?.bars ?? 18);
+        try {
+          const stream = await navigator.mediaDevices.getUserMedia({
+            audio: micId ? { deviceId: { exact: micId } } : true,
+            video: false,
+          });
+          if (stopped) {
+            stream.getTracks().forEach((t) => t.stop());
+            return;
+          }
+          meterStream = stream;
+          meterMicId = micId;
+          const ctx = new AudioContext();
+          meterCtx = ctx;
+          // May start suspended without a user gesture; resume so the analyser
+          // actually advances instead of reporting silence.
+          await ctx.resume();
+          const { analyser, data } = createMeterAnalyser(ctx, stream);
+          meterTimer = setInterval(() => {
+            emit("clips:mic-level", {
+              levels: sampleLevels(analyser, data, barCount),
+            }).catch(() => {});
+          }, METER_INTERVAL_MS);
+          // Stop if the popover stops pinging (window closed/crashed) so we
+          // never hold the mic open in the background.
+          meterWatchdog = setInterval(() => {
+            if (Date.now() - meterLastPing > RELAY_STALE_MS) stopMicMeter();
+          }, RELAY_STALE_MS);
+        } catch (err) {
+          console.warn("[bubble] mic meter failed", err);
+          stopMicMeter();
+        }
+      },
+    )
+      .then((u) => {
+        if (stopped) {
+          try {
+            u();
+          } catch {
+            // ignore
+          }
+        } else {
+          meterStartUnlisten = u;
+        }
+      })
+      .catch(() => {});
+
+    listen("clips:mic-meter-stop", () => {
+      stopMicMeter();
+    })
+      .then((u) => {
+        if (stopped) {
+          try {
+            u();
+          } catch {
+            // ignore
+          }
+        } else {
+          meterStopUnlisten = u;
+        }
+      })
+      .catch(() => {});
+
     return () => {
       stopped = true;
+      stopMicMeter();
       try {
         startUnlisten?.();
       } catch {
@@ -523,6 +643,16 @@ export function Bubble() {
       }
       try {
         refreshMicsUnlisten?.();
+      } catch {
+        // ignore
+      }
+      try {
+        meterStartUnlisten?.();
+      } catch {
+        // ignore
+      }
+      try {
+        meterStopUnlisten?.();
       } catch {
         // ignore
       }

--- a/templates/clips/desktop/src/overlays/bubble.tsx
+++ b/templates/clips/desktop/src/overlays/bubble.tsx
@@ -3,74 +3,7 @@ import { emit, listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { IconCameraOff } from "@tabler/icons-react";
-import {
-  createMeterAnalyser,
-  sampleLevels,
-  METER_INTERVAL_MS,
-} from "../hooks/useMicMeter";
-
-// Drop the mic meter if the popover's keepalive pings stop arriving — guards
-// against leaking an open mic (and the macOS recording indicator) when the
-// popover window dies without sending `clips:mic-meter-stop`.
-const RELAY_STALE_MS = 2500;
-
 type BubbleSize = "small" | "medium";
-const LOCAL_CAMERA_TARGET_FPS = 60;
-const LOCAL_CAMERA_MIN_FPS = 30;
-const LOCAL_CAMERA_FALLBACK_FPS = 30;
-const LOCAL_CAMERA_MIN_CANVAS_PX = 640;
-
-function buildLocalCameraConstraints(
-  cameraId: string | null,
-  strictFps: boolean,
-): MediaStreamConstraints {
-  const video: MediaTrackConstraints = {
-    width: { ideal: 1280 },
-    height: { ideal: 720 },
-    frameRate: strictFps
-      ? {
-          min: LOCAL_CAMERA_MIN_FPS,
-          ideal: LOCAL_CAMERA_TARGET_FPS,
-          max: 60,
-        }
-      : { ideal: LOCAL_CAMERA_TARGET_FPS, max: 60 },
-  };
-  if (cameraId) {
-    video.deviceId = { exact: cameraId };
-  }
-  return { video, audio: false };
-}
-
-// This page holds a capture grant, so it can enumerate the full device list
-// WITH labels — something the popover page can't do without its own
-// getUserMedia (which would mute this bubble via WebKit's single-page
-// capture-exclusion). Relay the labelled list so the popover's picker can show
-// every device
-async function relayDeviceList(
-  kind: MediaDeviceKind,
-  event: string,
-): Promise<void> {
-  const all = await navigator.mediaDevices.enumerateDevices();
-  const devices = all
-    .filter((d) => d.kind === kind && d.deviceId)
-    .map((d) => ({ deviceId: d.deviceId, label: d.label }));
-  emit(event, { devices }).catch(() => {});
-}
-
-async function getLocalCameraStream(
-  cameraId: string | null,
-): Promise<MediaStream> {
-  try {
-    return await navigator.mediaDevices.getUserMedia(
-      buildLocalCameraConstraints(cameraId, true),
-    );
-  } catch (err) {
-    console.warn("[bubble] strict local camera constraints failed", err);
-    return await navigator.mediaDevices.getUserMedia(
-      buildLocalCameraConstraints(cameraId, false),
-    );
-  }
-}
 
 /**
  * Draggable, circular camera bubble — a PURE RENDERER.
@@ -113,11 +46,6 @@ async function getLocalCameraStream(
  * stops trying and the popover starts the canvas pump instead, at
  * which point the canvas path takes over seamlessly.
  *
- * Full-screen capture is the exception. It uses native macOS capture instead
- * of WebKit `getDisplayMedia`, so the bubble can own a local camera stream
- * directly. That avoids the hidden-popover relay during recording and keeps
- * the face bubble live at native camera quality.
- *
  * # Hover controls (Loom-style)
  *
  * On pointerenter, a small horizontal pill fades in under the bubble
@@ -138,18 +66,12 @@ export function Bubble() {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const firstFrameAtRef = useRef<number | null>(null);
-  const localStreamRef = useRef<MediaStream | null>(null);
-  const localCameraIdRef = useRef<string | null>(null);
-  const localVideoFrameCallbackRef = useRef<number | null>(null);
-  const localDrawTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const recordingModeRef = useRef(false);
   // Which transport delivered the most recent usable frame. Starts as
   // "none" — we flip to "webrtc" on ontrack, or "canvas" on the first
   // JPEG frame, whichever lands first.
   const [activePath, setActivePath] = useState<"none" | "webrtc" | "canvas">(
     "none",
   );
-  const [localCameraActive, setLocalCameraActive] = useState(false);
   // Small is the default bubble size — matches the Rust-side default in
   // `load_bubble_size_name`. On mount we `invoke("load_bubble_size")` to
   // read the persisted choice and override this if the user previously
@@ -230,435 +152,6 @@ export function Bubble() {
       console.warn("[bubble] close_bubble failed", err);
     }
   };
-
-  useEffect(() => {
-    let stopped = false;
-    let unlisten: (() => void) | null = null;
-    listen<{ active?: boolean }>("clips:bubble-recording-mode", (event) => {
-      if (stopped) return;
-      recordingModeRef.current = event.payload?.active === true;
-      if (!recordingModeRef.current && videoRef.current?.srcObject) {
-        setActivePath("webrtc");
-      }
-    })
-      .then((u) => {
-        if (stopped) {
-          try {
-            u();
-          } catch {
-            // ignore
-          }
-          return;
-        }
-        unlisten = u;
-      })
-      .catch(() => {});
-    return () => {
-      stopped = true;
-      try {
-        unlisten?.();
-      } catch {
-        // ignore
-      }
-    };
-  }, []);
-
-  // ---- local camera receiver (native full-screen capture path) ------------
-  useEffect(() => {
-    let stopped = false;
-    let startUnlisten: (() => void) | null = null;
-    let stopUnlisten: (() => void) | null = null;
-    let refreshMicsUnlisten: (() => void) | null = null;
-    let meterStartUnlisten: (() => void) | null = null;
-    let meterStopUnlisten: (() => void) | null = null;
-    let renderedFrames = 0;
-    let lastFpsLogAt = 0;
-
-    // Live mic meter session. The popover delegates this to us because opening a
-    // mic in its own page would mute this bubble's camera (WebKit cross-page
-    // capture-exclusion). Opening the mic HERE — same page as our camera — does
-    // not mute it, so we run the analyser and relay level samples to the popover.
-    let meterStream: MediaStream | null = null;
-    let meterCtx: AudioContext | null = null;
-    let meterTimer: ReturnType<typeof setInterval> | null = null;
-    let meterWatchdog: ReturnType<typeof setInterval> | null = null;
-    let meterMicId: string | null = null;
-    let meterLastPing = 0;
-    const stopMicMeter = () => {
-      if (meterTimer) {
-        clearInterval(meterTimer);
-        meterTimer = null;
-      }
-      if (meterWatchdog) {
-        clearInterval(meterWatchdog);
-        meterWatchdog = null;
-      }
-      if (meterCtx) {
-        meterCtx.close().catch(() => {});
-        meterCtx = null;
-      }
-      if (meterStream) {
-        meterStream.getTracks().forEach((t) => t.stop());
-        meterStream = null;
-      }
-      meterMicId = null;
-    };
-
-    const stopLocalCanvasRenderer = () => {
-      const videoEl = videoRef.current;
-      if (
-        localVideoFrameCallbackRef.current != null &&
-        videoEl?.cancelVideoFrameCallback
-      ) {
-        videoEl.cancelVideoFrameCallback(localVideoFrameCallbackRef.current);
-      }
-      localVideoFrameCallbackRef.current = null;
-      if (localDrawTimerRef.current) {
-        clearInterval(localDrawTimerRef.current);
-        localDrawTimerRef.current = null;
-      }
-    };
-
-    const clearLocalCanvas = () => {
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-      const ctx = canvas.getContext("2d");
-      ctx?.clearRect(0, 0, canvas.width, canvas.height);
-    };
-
-    const drawLocalCameraFrame = (stream: MediaStream) => {
-      if (stopped || localStreamRef.current !== stream) return;
-      const videoEl = videoRef.current;
-      const canvas = canvasRef.current;
-      if (!videoEl || !canvas) return;
-      if (videoEl.readyState < 2 || videoEl.videoWidth === 0) return;
-
-      const dpr = window.devicePixelRatio || 1;
-      const rect = canvas.getBoundingClientRect();
-      const canvasSize = Math.max(
-        LOCAL_CAMERA_MIN_CANVAS_PX,
-        Math.round(Math.max(rect.width, rect.height, 1) * dpr),
-      );
-      if (canvas.width !== canvasSize) canvas.width = canvasSize;
-      if (canvas.height !== canvasSize) canvas.height = canvasSize;
-
-      const ctx = canvas.getContext("2d", { willReadFrequently: false });
-      if (!ctx) return;
-
-      const vw = videoEl.videoWidth;
-      const vh = videoEl.videoHeight;
-      const side = Math.min(vw, vh);
-      const sx = (vw - side) / 2;
-      const sy = (vh - side) / 2;
-      ctx.drawImage(videoEl, sx, sy, side, side, 0, 0, canvasSize, canvasSize);
-
-      renderedFrames += 1;
-      const now = performance.now();
-      if (!lastFpsLogAt) lastFpsLogAt = now;
-      if (now - lastFpsLogAt >= 3000) {
-        const fps = Math.round((renderedFrames * 1000) / (now - lastFpsLogAt));
-        renderedFrames = 0;
-        lastFpsLogAt = now;
-        console.log("[bubble] local camera canvas fps =", fps);
-      }
-    };
-
-    const startLocalCanvasRenderer = (stream: MediaStream) => {
-      stopLocalCanvasRenderer();
-      renderedFrames = 0;
-      lastFpsLogAt = performance.now();
-      drawLocalCameraFrame(stream);
-
-      const scheduleVideoFrame = () => {
-        if (stopped || localStreamRef.current !== stream) return;
-        const videoEl = videoRef.current;
-        if (!videoEl?.requestVideoFrameCallback) return;
-        localVideoFrameCallbackRef.current = videoEl.requestVideoFrameCallback(
-          () => {
-            localVideoFrameCallbackRef.current = null;
-            drawLocalCameraFrame(stream);
-            scheduleVideoFrame();
-          },
-        );
-      };
-
-      if (videoRef.current?.requestVideoFrameCallback) {
-        scheduleVideoFrame();
-        return;
-      }
-
-      localDrawTimerRef.current = setInterval(
-        () => drawLocalCameraFrame(stream),
-        Math.round(1000 / LOCAL_CAMERA_FALLBACK_FPS),
-      );
-    };
-
-    const stopLocalCamera = () => {
-      stopLocalCanvasRenderer();
-      const stream = localStreamRef.current;
-      localStreamRef.current = null;
-      localCameraIdRef.current = null;
-      if (!stopped) setLocalCameraActive(false);
-      if (stream) {
-        stream.getTracks().forEach((track) => track.stop());
-      }
-
-      const videoEl = videoRef.current;
-      if (videoEl && (!stream || videoEl.srcObject === stream)) {
-        try {
-          videoEl.pause();
-        } catch {
-          // ignore
-        }
-        videoEl.srcObject = null;
-      }
-      clearLocalCanvas();
-    };
-
-    listen<{ cameraId?: string | null }>(
-      "clips:bubble-start-local-camera",
-      async (event) => {
-        if (stopped) return;
-        const cameraId = event.payload?.cameraId?.trim() || null;
-        if (localStreamRef.current && localCameraIdRef.current === cameraId) {
-          return;
-        }
-
-        stopLocalCamera();
-
-        try {
-          const stream = await getLocalCameraStream(cameraId);
-          if (stopped) {
-            stream.getTracks().forEach((track) => track.stop());
-            return;
-          }
-
-          const videoEl = videoRef.current;
-          if (!videoEl) {
-            stream.getTracks().forEach((track) => track.stop());
-            return;
-          }
-
-          localStreamRef.current = stream;
-          localCameraIdRef.current = cameraId;
-          const track = stream.getVideoTracks()[0];
-          if (track && "contentHint" in track) {
-            try {
-              track.contentHint = "motion";
-            } catch {
-              // ignore
-            }
-          }
-          track
-            ?.applyConstraints({
-              frameRate: { ideal: LOCAL_CAMERA_TARGET_FPS, max: 60 },
-              width: { ideal: 1280 },
-              height: { ideal: 720 },
-            })
-            .catch((err) => {
-              console.warn(
-                "[bubble] local camera applyConstraints failed",
-                err,
-              );
-            });
-          videoEl.srcObject = stream;
-          await videoEl.play().catch((err) => {
-            console.warn("[bubble] local camera video.play() rejected", err);
-          });
-          setLocalCameraActive(true);
-          // The bubble now holds the camera grant — relay the full camera list.
-          relayDeviceList("videoinput", "clips:camera-devices").catch(() => {});
-          startLocalCanvasRenderer(stream);
-          if (firstFrameAtRef.current == null) {
-            firstFrameAtRef.current = Date.now();
-            console.log(
-              "[bubble] local camera started",
-              track?.getSettings?.() ?? {},
-            );
-          }
-          setActivePath("canvas");
-        } catch (err) {
-          console.warn("[bubble] local camera failed", err);
-          stopLocalCamera();
-        }
-      },
-    )
-      .then((u) => {
-        if (stopped) {
-          try {
-            u();
-          } catch {
-            // ignore
-          }
-        } else {
-          startUnlisten = u;
-        }
-      })
-      .catch(() => {});
-
-    listen("clips:bubble-stop-local-camera", () => {
-      if (stopped) return;
-      stopLocalCamera();
-      setActivePath("none");
-    })
-      .then((u) => {
-        if (stopped) {
-          try {
-            u();
-          } catch {
-            // ignore
-          }
-        } else {
-          stopUnlisten = u;
-        }
-      })
-      .catch(() => {});
-
-    // The popover can't probe the mic itself while this bubble is live —
-    // WebKit mutes our camera the moment another page in this process calls
-    // getUserMedia. But THIS page opening a mic doesn't mute its own camera
-    // (the exclusion is cross-page). So when the popover asks, we open a
-    // transient mic stream here to unlock the labels, enumerate, relay the
-    // audioinput list back, then drop the stream. The camera stays live.
-    listen<{ micId?: string | null }>("clips:refresh-mics", async (event) => {
-      if (stopped) return;
-      const micId = event.payload?.micId?.trim() || null;
-      let micStream: MediaStream | null = null;
-      try {
-        micStream = await navigator.mediaDevices.getUserMedia({
-          audio: micId ? { deviceId: { exact: micId } } : true,
-          video: false,
-        });
-        await relayDeviceList("audioinput", "clips:mic-devices");
-      } catch (err) {
-        console.warn("[bubble] mic refresh probe failed", err);
-      } finally {
-        // Drop the probe stream immediately — we only needed the grant to
-        // read labels, not to keep the mic hot.
-        micStream?.getTracks().forEach((t) => t.stop());
-      }
-    })
-      .then((u) => {
-        if (stopped) {
-          try {
-            u();
-          } catch {
-            // ignore
-          }
-        } else {
-          refreshMicsUnlisten = u;
-        }
-      })
-      .catch(() => {});
-
-    // Start the live mic meter on request and emit level samples the popover
-    // renders. We open the mic here (same page as our camera) so the bubble
-    // stays live instead of getting muted.
-    listen<{ micId?: string | null; bars?: number }>(
-      "clips:mic-meter-start",
-      async (event) => {
-        if (stopped) return;
-        const micId = event.payload?.micId?.trim() || null;
-        // Each start also counts as a keepalive ping (the popover re-sends on a
-        // timer); record it so the watchdog below knows the popover is alive.
-        meterLastPing = Date.now();
-        // Ignore idempotent repeats for the same device — already running.
-        if (meterStream && meterMicId === micId) return;
-        stopMicMeter();
-        const barCount = Math.max(1, event.payload?.bars ?? 18);
-        try {
-          const stream = await navigator.mediaDevices.getUserMedia({
-            audio: micId ? { deviceId: { exact: micId } } : true,
-            video: false,
-          });
-          if (stopped) {
-            stream.getTracks().forEach((t) => t.stop());
-            return;
-          }
-          meterStream = stream;
-          meterMicId = micId;
-          const ctx = new AudioContext();
-          meterCtx = ctx;
-          // May start suspended without a user gesture; resume so the analyser
-          // actually advances instead of reporting silence.
-          await ctx.resume();
-          const { analyser, data } = createMeterAnalyser(ctx, stream);
-          meterTimer = setInterval(() => {
-            emit("clips:mic-level", {
-              levels: sampleLevels(analyser, data, barCount),
-            }).catch(() => {});
-          }, METER_INTERVAL_MS);
-          // Stop if the popover stops pinging (window closed/crashed) so we
-          // never hold the mic open in the background.
-          meterWatchdog = setInterval(() => {
-            if (Date.now() - meterLastPing > RELAY_STALE_MS) stopMicMeter();
-          }, RELAY_STALE_MS);
-        } catch (err) {
-          console.warn("[bubble] mic meter failed", err);
-          stopMicMeter();
-        }
-      },
-    )
-      .then((u) => {
-        if (stopped) {
-          try {
-            u();
-          } catch {
-            // ignore
-          }
-        } else {
-          meterStartUnlisten = u;
-        }
-      })
-      .catch(() => {});
-
-    listen("clips:mic-meter-stop", () => {
-      stopMicMeter();
-    })
-      .then((u) => {
-        if (stopped) {
-          try {
-            u();
-          } catch {
-            // ignore
-          }
-        } else {
-          meterStopUnlisten = u;
-        }
-      })
-      .catch(() => {});
-
-    return () => {
-      stopped = true;
-      stopMicMeter();
-      try {
-        startUnlisten?.();
-      } catch {
-        // ignore
-      }
-      try {
-        stopUnlisten?.();
-      } catch {
-        // ignore
-      }
-      try {
-        refreshMicsUnlisten?.();
-      } catch {
-        // ignore
-      }
-      try {
-        meterStartUnlisten?.();
-      } catch {
-        // ignore
-      }
-      try {
-        meterStopUnlisten?.();
-      } catch {
-        // ignore
-      }
-      stopLocalCamera();
-    };
-  }, []);
 
   // ---- WebRTC receiver ----------------------------------------------------
   // Sets up a fresh RTCPeerConnection on mount, emits `bubble-ready`
@@ -774,7 +267,6 @@ export function Bubble() {
 
       localPc.ontrack = (ev) => {
         if (stopped) return;
-        if (localStreamRef.current) return;
         const videoEl = videoRef.current;
         if (!videoEl) return;
         const incomingStream = ev.streams[0];
@@ -790,9 +282,7 @@ export function Bubble() {
           firstFrameAtRef.current = Date.now();
           console.log("[bubble] first webrtc track received");
         }
-        if (!recordingModeRef.current) {
-          setActivePath("webrtc");
-        }
+        setActivePath("webrtc");
       };
 
       try {
@@ -983,7 +473,6 @@ export function Bubble() {
         h: number;
       }>("clips:bubble-frame", async (ev) => {
         if (stopped) return;
-        if (localStreamRef.current) return;
         const { dataUrl, bytes, w, h } = ev.payload;
 
         if (firstFrameAtRef.current == null) {
@@ -1173,13 +662,7 @@ export function Bubble() {
           autoPlay
           playsInline
           muted
-          style={
-            activePath === "canvas"
-              ? localCameraActive
-                ? { opacity: 0.001 }
-                : { display: "none" }
-              : undefined
-          }
+          style={activePath === "canvas" ? { display: "none" } : undefined}
         />
         <canvas
           ref={canvasRef}

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -719,53 +719,26 @@ body[data-clips-route="recording-pill"] #root {
   transform: translateX(14px);
 }
 
-/* Mic level indicator — animated bars under the mic row. */
+/* Live mic level meter — bars driven by real audio input under the mic row. */
 .mic-wave {
   position: absolute;
   left: 12px;
   right: 12px;
   bottom: 4px;
-  height: 3px;
+  height: 14px;
   display: flex;
   gap: 2px;
   align-items: flex-end;
   pointer-events: none;
-  opacity: 0.55;
+  opacity: 0.75;
 }
 
 .mic-wave .bar {
   flex: 1;
   background: var(--brand);
   border-radius: 1px;
-  animation: mic-pulse 1.2s ease-in-out infinite;
-  height: 60%;
-}
-
-.mic-wave .b1 {
-  animation-delay: 0s;
-  height: 40%;
-}
-.mic-wave .b2 {
-  animation-delay: 0.15s;
-  height: 80%;
-}
-.mic-wave .b3 {
-  animation-delay: 0.3s;
-  height: 55%;
-}
-.mic-wave .b4 {
-  animation-delay: 0.45s;
-  height: 70%;
-}
-
-@keyframes mic-pulse {
-  0%,
-  100% {
-    transform: scaleY(1);
-  }
-  50% {
-    transform: scaleY(0.4);
-  }
+  height: 10%;
+  transition: height 0.08s linear;
 }
 
 /* ------------------------------------------------------------------------- */

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -548,11 +548,20 @@ body[data-clips-route="recording-pill"] #root {
 }
 
 .row-label {
-  flex: 1;
-  min-width: 0;
+  /* Never shrink the label — the wave line gives up space first so the device
+     name always stays fully visible. Cap + ellipsis only for pathological
+     long names. */
+  flex: 0 0 auto;
+  max-width: 60%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Flexible filler between the label and the chevron when there's no meter
+   (camera rows / mic off) — keeps the chevron pinned to the right. */
+.row-flex {
+  flex: 1 1 auto;
 }
 
 .row-chev {
@@ -719,26 +728,48 @@ body[data-clips-route="recording-pill"] #root {
   transform: translateX(14px);
 }
 
-/* Live mic level meter — bars driven by real audio input under the mic row. */
+/* Live mic level meter — a single wave line driven by real audio, sitting
+   inline between the device label and the chevron. The ends are masked so the
+   line fades in/out instead of butting against the label or chevron. */
 .mic-wave {
-  position: absolute;
-  left: 12px;
-  right: 12px;
-  bottom: 4px;
-  height: 14px;
-  display: flex;
-  gap: 2px;
-  align-items: flex-end;
+  flex: 1 1 auto;
+  min-width: 0;
+  align-self: stretch;
+  margin: 0 4px;
   pointer-events: none;
-  opacity: 0.75;
+  /* Soft fade at both ends so the line reads as ambient, not boxed-in. */
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 12%,
+    #000 88%,
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 12%,
+    #000 88%,
+    transparent 100%
+  );
 }
 
-.mic-wave .bar {
-  flex: 1;
-  background: var(--brand);
-  border-radius: 1px;
-  height: 10%;
-  transition: height 0.08s linear;
+.mic-wave-svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.mic-wave-path {
+  fill: none;
+  /* Matches the recording pill's mic waveform accent. */
+  stroke: rgba(74, 222, 128, 0.95);
+  stroke-width: 1.75;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  /* Keep the line crisp regardless of the non-uniform x-stretch. */
+  vector-effect: non-scaling-stroke;
 }
 
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
### 1. Removed the "local camera" path in the bubble

The camera bubble previously had two ways to show your face: the normal WebRTC relay from the popover, and a special "local camera" mode that kicked in during native full-screen recording. In local mode, the bubble owned the camera directly and had to relay device lists back to the popover, because WebKit blocks a second page from accessing the camera without muting the first one.

That entire local camera path is gone. The bubble now always receives video through WebRTC or the canvas relay, regardless of recording mode. This removes a large amount of coordination code — no more device list relay events, no more fallback camera/mic state in the popover, no more separate startup and teardown flow for the full-screen case. The recorder also no longer needs to choose between two different "hide chrome" commands based on who owns the camera.

### 2. Mic wave is now driven by real audio

The mic wave indicator was previously a CSS animation — four bars that pulsed on a loop with no connection to what the microphone was actually picking up.

It has been replaced with a real-time SVG wave line. A new `useMicMeter` hook opens an audio analyser on the selected mic, samples it 20 times per second, and draws an oscillating wave that reacts to actual sound — it moves when you speak and flattens when silent. The meter only runs while the popover is open and you are not recording.

The visual design also changed: from bars positioned at the bottom of the row to an inline wave line between the device name and the dropdown arrow, with a soft fade at both ends.
<img width="387" height="418" alt="image" src="https://github.com/user-attachments/assets/ad76f16d-aca1-47cd-b0a9-9d7491640e51" />
