### PR TITLE
fix: force process exit and unref telemetry timer to fix CLI hangs #1330

### DIFF
--- a/.changeset/fix-cli-hangs.md
+++ b/.changeset/fix-cli-hangs.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/skills": patch
+---
+
+Fix CLI commands hanging indefinitely on success due to Node.js keep-alive and telemetry timers

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -613,7 +613,7 @@ switch (command) {
     import("./invoke.js")
       .then(async (m) => {
         const code = await m.runInvoke(args);
-        if (code !== 0) process.exit(code);
+        process.exit(code);
       })
       .catch((err) => {
         console.error(err?.message ?? err);
@@ -626,7 +626,7 @@ switch (command) {
     import("./agents.js")
       .then(async (m) => {
         const code = await m.runAgents(args);
-        if (code !== 0) process.exit(code);
+        process.exit(code);
       })
       .catch((err) => {
         console.error(err?.message ?? err);
@@ -667,7 +667,10 @@ switch (command) {
     // browser device-code flow (no token copying). `--all` connects every
     // first-party hosted app; `--token` is the no-browser fallback.
     import("./connect.js")
-      .then((m) => m.runConnect(args))
+      .then(async (m) => {
+        await m.runConnect(args);
+        process.exit(process.exitCode ?? 0);
+      })
       .catch((err) => {
         console.error(err?.message ?? err);
         process.exit(1);
@@ -790,7 +793,7 @@ switch (command) {
     import("./add.js")
       .then((m) => {
         const code = m.runAdd(args);
-        if (code !== 0) process.exit(code);
+        process.exit(code);
       })
       .catch((err) => {
         console.error(err?.message ?? err);

--- a/packages/core/src/tracking/providers.ts
+++ b/packages/core/src/tracking/providers.ts
@@ -65,7 +65,9 @@ function enqueue(
   if (queue.length >= MAX_BATCH_SIZE) {
     drainQueue();
   } else if (!getTimer()) {
-    setTimer(setTimeout(drainQueue, BATCH_INTERVAL_MS));
+    const timer = setTimeout(drainQueue, BATCH_INTERVAL_MS);
+    if (timer.unref) timer.unref();
+    setTimer(timer);
   }
 }
 

--- a/packages/skills/src/cli.ts
+++ b/packages/skills/src/cli.ts
@@ -2,7 +2,11 @@
 
 import { runSkillsCli } from "./index.js";
 
-runSkillsCli(process.argv.slice(2)).catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
-});
+runSkillsCli(process.argv.slice(2))
+  .then(() => {
+    process.exit(process.exitCode ?? 0);
+  })
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });


### PR DESCRIPTION
Closes #1330

**Summary**
This PR fixes an issue where the CLI commands (`connect`, `add`, `invoke`, `agents`, and `skills add`) would hang for several seconds after successfully completing their work.

**Changes**
1. **Telemetry Timer**: Added `.unref()` to the telemetry batch timer in `packages/core/src/tracking/providers.ts` so that it doesn't artificially hold the event loop open for 10 seconds.
2. **Explicit Exit**: Added explicit `process.exit(process.exitCode ?? 0)` calls at the end of the Promise chains in both `packages/core/src/cli/index.ts` and `packages/skills/src/cli.ts` to ensure the process shuts down instantly instead of waiting for Node's global `fetch` keep-alive connections to time out.
