### PR TITLE
docs: fix broken cd path in DEVELOPMENT.md quickstart

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,7 @@
 
 ```bash
 git clone https://github.com/BuilderIO/agent-native.git
-cd agent-native/framework
+cd agent-native
 pnpm install
 ```
 


### PR DESCRIPTION
## Problem

The **Getting Started** snippet in `DEVELOPMENT.md` tells a new contributor to:

```bash
git clone https://github.com/BuilderIO/agent-native.git
cd agent-native/framework
pnpm install
```

There is no `framework/` directory anywhere in the repo, so `cd agent-native/framework` fails with `No such file or directory` — a first-time contributor is blocked on the very first command of the guide.

## Fix

`cd agent-native/framework` → `cd agent-native` (one word).

The repo root **is** the pnpm workspace: `pnpm-workspace.yaml`, the root `package.json`, and the `postinstall` workspace build all live at the top level, so `pnpm install` is meant to run from `agent-native/` itself. The rest of `DEVELOPMENT.md` ("Run these from the repo root") is consistent with this.

## Notes

- Docs-only, no `packages/**` source touched → no changeset required.
- `git clone ... agent-native` clones into `agent-native/`, and this was the only `agent-native/framework` reference in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)