### PR TITLE
docs: fix broken references in desktop-app, videos, and core docs

### DIFF
--- a/.changeset/fix-creating-templates-anchor.md
+++ b/.changeset/fix-creating-templates-anchor.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix a broken in-docs anchor in the "creating templates" guide: the headless on-ramp link now points to `/docs/getting-started#1-create-your-app` instead of the stale `#create-your-agent`, which no longer matches any heading on the Getting Started page.

--- a/packages/core/docs/content/creating-templates.md
+++ b/packages/core/docs/content/creating-templates.md
@@ -33,7 +33,7 @@ npx @agent-native/core@latest create my-platform
 
 Chat gives you auth, durable chat threads, SQL-backed resources, tools, application state, actions, and polling sync. You add the domain model and product UI.
 
-If you are not building a reusable UI template yet, use the headless on-ramp in [Getting Started](/docs/getting-started#create-your-agent): define one action, run it with `pnpm agent`, and add UI later when the workflow needs a durable surface.
+If you are not building a reusable UI template yet, use the headless on-ramp in [Getting Started](/docs/getting-started#1-create-your-app): define one action, run it with `pnpm agent`, and add UI later when the workflow needs a durable surface.
 
 ## Project Structure {#project-structure}
 

--- a/packages/desktop-app/README.md
+++ b/packages/desktop-app/README.md
@@ -50,7 +50,7 @@ node scripts/dev-electron.ts --apps calendar,slides
 Or run just the Electron shell (if apps are already running):
 
 ```bash
-pnpm --filter @agent-native/electron-shell dev
+pnpm --filter @agent-native/desktop-app dev
 ```
 
 ---
@@ -58,8 +58,7 @@ pnpm --filter @agent-native/electron-shell dev
 ## Architecture
 
 ```
-packages/electron-shell/
-├── index.html                    # Renderer entry point
+packages/desktop-app/
 ├── electron.vite.config.ts       # Build config (main + preload + renderer)
 ├── shared/
 │   ├── app-registry.ts           # App definitions (id, name, port, color…)
@@ -231,7 +230,7 @@ agentnative://shortcuts/upsert?accelerator=Control%2BAlt%2BV&app=mail&view=inbox
 ## Building for distribution
 
 ```bash
-pnpm --filter @agent-native/electron-shell build
+pnpm --filter @agent-native/desktop-app build
 ```
 
 This outputs:

--- a/templates/videos/README.md
+++ b/templates/videos/README.md
@@ -165,8 +165,8 @@ server/
 ├── routes/                # API endpoints
 └── index.ts              # Express server
 
-scripts/
-└── create-composition.ts  # Example creation script
+docs/examples/
+└── create-composition.example.ts  # Example creation script
 ```
 
 ## 🔧 Development
@@ -179,8 +179,6 @@ pnpm run dev           # Start dev server (http://localhost:8080)
 
 # Build
 pnpm run build         # Build client and server
-pnpm run build:client  # Build client only
-pnpm run build:server  # Build server only
 
 # Production
 pnpm start             # Run production server


### PR DESCRIPTION
Three independent broken/stale documentation references, fixed together. All verified against current `main`; no source or behavior changes.

## 1. `packages/desktop-app/README.md` — wrong package name

The README documents:

```bash
pnpm --filter @agent-native/electron-shell dev    # and the matching build command
```

But the package is named **`@agent-native/desktop-app`** (its own `package.json`), and there is no `packages/electron-shell/` directory — so `--filter` matched zero packages and both documented commands failed. Fixed the two commands and the architecture-tree root path (`packages/electron-shell/` → `packages/desktop-app/`).

## 2. `templates/videos/README.md` — non-existent scripts + wrong example path

- Removed `pnpm run build:client` / `pnpm run build:server`: `package.json` only defines a unified `build` (`agent-native build`), so both errored with "Missing script".
- The example file lives at `docs/examples/create-composition.example.ts`, not `scripts/create-composition.ts` (there is no `scripts/` dir). Updated the project-structure tree.

## 3. `packages/core/docs/content/creating-templates.md` — broken in-docs anchor

The headless on-ramp links to `/docs/getting-started#create-your-agent`, but no heading on that page slugifies to `create-your-agent`, so the in-page jump silently lands at the top. The intended target is `## 1. Create your app`, which `extractHeadings` (`packages/docs/app/components/docs-content.ts`) slugifies to `1-create-your-app`. Updated the anchor.

A changeset is included for `@agent-native/core` (the only publishable package touched — `@agent-native/desktop-app` is changeset-ignored and `videos` is a template), to satisfy the changeset gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)