### PR TITLE
docs(remotion skill): trim SKILL.md index to the rule files that exist

### DIFF
--- a/templates/videos/.builder/skills/remotion/SKILL.md
+++ b/templates/videos/.builder/skills/remotion/SKILL.md
@@ -9,49 +9,21 @@ metadata:
 
 Use this skills whenever you are dealing with Remotion code to obtain the domain-specific knowledge.
 
-## Captions
-
-When dealing with captions or subtitles, load the [./rules/subtitles.md](./rules/subtitles.md) file for more information.
-
-## Using FFmpeg
-
-For some video operations, such as trimming videos or detecting silence, FFmpeg should be used. Load the [./rules/ffmpeg.md](./rules/ffmpeg.md) file for more information.
-
-## Audio visualization
-
-When needing to visualize audio (spectrum bars, waveforms, bass-reactive effects), load the [./rules/audio-visualization.md](./rules/audio-visualization.md) file for more information.
-
 ## How to use
 
 Read individual rule files for detailed explanations and code examples:
 
-- [rules/3d.md](rules/3d.md) - 3D content in Remotion using Three.js and React Three Fiber
 - [rules/animations.md](rules/animations.md) - Fundamental animation skills for Remotion
 - [rules/assets.md](rules/assets.md) - Importing images, videos, audio, and fonts into Remotion
 - [rules/audio.md](rules/audio.md) - Using audio and sound in Remotion - importing, trimming, volume, speed, pitch
-- [rules/calculate-metadata.md](rules/calculate-metadata.md) - Dynamically set composition duration, dimensions, and props
-- [rules/can-decode.md](rules/can-decode.md) - Check if a video can be decoded by the browser using Mediabunny
-- [rules/charts.md](rules/charts.md) - Chart and data visualization patterns for Remotion (bar, pie, line, stock charts)
 - [rules/compositions.md](rules/compositions.md) - Defining compositions, stills, folders, default props and dynamic metadata
-- [rules/extract-frames.md](rules/extract-frames.md) - Extract frames from videos at specific timestamps using Mediabunny
 - [rules/fonts.md](rules/fonts.md) - Loading Google Fonts and local fonts in Remotion
-- [rules/get-audio-duration.md](rules/get-audio-duration.md) - Getting the duration of an audio file in seconds with Mediabunny
-- [rules/get-video-dimensions.md](rules/get-video-dimensions.md) - Getting the width and height of a video file with Mediabunny
-- [rules/get-video-duration.md](rules/get-video-duration.md) - Getting the duration of a video file in seconds with Mediabunny
-- [rules/gifs.md](rules/gifs.md) - Displaying GIFs synchronized with Remotion's timeline
 - [rules/images.md](rules/images.md) - Embedding images in Remotion using the Img component
-- [rules/light-leaks.md](rules/light-leaks.md) - Light leak overlay effects using @remotion/light-leaks
-- [rules/lottie.md](rules/lottie.md) - Embedding Lottie animations in Remotion
-- [rules/measuring-dom-nodes.md](rules/measuring-dom-nodes.md) - Measuring DOM element dimensions in Remotion
-- [rules/measuring-text.md](rules/measuring-text.md) - Measuring text dimensions, fitting text to containers, and checking overflow
 - [rules/sequencing.md](rules/sequencing.md) - Sequencing patterns for Remotion - delay, trim, limit duration of items
 - [rules/tailwind.md](rules/tailwind.md) - Using TailwindCSS in Remotion
 - [rules/text-animations.md](rules/text-animations.md) - Typography and text animation patterns for Remotion
 - [rules/timing.md](rules/timing.md) - Interpolation curves in Remotion - linear, easing, spring animations
-- [rules/transitions.md](rules/transitions.md) - Scene transition patterns for Remotion
 - [rules/transparent-videos.md](rules/transparent-videos.md) - Rendering out a video with transparency
 - [rules/trimming.md](rules/trimming.md) - Trimming patterns for Remotion - cut the beginning or end of animations
 - [rules/videos.md](rules/videos.md) - Embedding videos in Remotion - trimming, volume, speed, looping, pitch
 - [rules/parameters.md](rules/parameters.md) - Make a video parametrizable by adding a Zod schema
-- [rules/maps.md](rules/maps.md) - Add a map using Mapbox and animate it
-- [rules/voiceover.md](rules/voiceover.md) - Adding AI-generated voiceover to Remotion compositions using ElevenLabs TTS


### PR DESCRIPTION
## Problem

`templates/videos/.builder/skills/remotion/SKILL.md` instructs an agent to load **19 `rules/*.md` files that do not exist** in the vendored `rules/` directory. That directory ships **14** rule files; the SKILL.md index references **33**.

The 19 dangling references:

- **3 prose callouts** — `## Captions` → `rules/subtitles.md`, `## Using FFmpeg` → `rules/ffmpeg.md`, `## Audio visualization` → `rules/audio-visualization.md`
- **16 "How to use" entries** — `3d`, `calculate-metadata`, `can-decode`, `charts`, `extract-frames`, `get-audio-duration`, `get-video-dimensions`, `get-video-duration`, `gifs`, `light-leaks`, `lottie`, `measuring-dom-nodes`, `measuring-text`, `transitions`, `maps`, `voiceover`

An agent following this skill is told to read files that aren't there.

## This PR (conservative fix)

Trim the index so it lists **only the 14 rule files that actually exist** (`animations`, `assets`, `audio`, `compositions`, `fonts`, `images`, `sequencing`, `tailwind`, `text-animations`, `timing`, `transparent-videos`, `trimming`, `videos`, `parameters`). After the change every link in `SKILL.md` resolves to a real file, and every file in `rules/` is indexed — a clean 14 ↔ 14 mapping. No other files touched; `templates/**` needs no changeset.

## Alternative (maintainer's call)

If those 19 rules were *meant* to ship (e.g. the `rules/` dir was trimmed but the index wasn't), the better fix is to **restore the missing files** rather than drop the links. I went with trimming because it's the non-speculative repair against the current tree — happy to swap to restoring the files (or a subset) if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)