### PR TITLE
Slim down and restructure main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ export default defineAction({
 - **Agent runtime**: Chat, tools, skills, memory, jobs, observability, and handoffs ship together.
 - **Backend agnostic**: Plug in any Drizzle-supported SQL database and Nitro-compatible host.
 
+## Agents and UIs, Fully Connected
+
+The agent and the UI are equal citizens of one system. Every action works both ways: click it or ask for it.
+
+![Agents and UIs fully connected](https://cdn.builder.io/api/v1/file/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fadc1e9e9368e4a8cb1b4dbb5aae5aaa2)
+
+- **Everything syncs**: One database, one state. Changes from either side show up instantly on the other.
+- **Real-time multiplayer**: Humans and agents edit the same document together, with the agent as a first-class peer.
+- **Context-aware**: The agent knows what you're looking at. Select text, hit Cmd+I, and tell it what to do.
+- **Agents call agents**: Tag another agent from any app and they coordinate over A2A.
+- **Self-improving**: The agent can add features, fix bugs, and refine the UI over time.
+
 ## Templates
 
 Start with a full featured template. Each one is a complete, 100% free and open-source SaaS app: cloneable, not scaffolded, except you own the code and can customize everything.
@@ -134,19 +146,6 @@ Want a single app instead of a monorepo? Add `--standalone`. The picker leads wi
 
 - **Headless**: an action-first app with one primitive and no UI shell. The CLI walks you through calling your first action and agent, and you can add a UI later.
 - **Chat**: a minimal chat UI with the browser shell already wired, the simplest starting point when you want a UI.
-
-## Agents and UIs, Fully Connected
-
-The agent and the UI are equal citizens of the same system. Every action works both ways: click it or ask for it.
-
-![Agents and UIs fully connected](https://cdn.builder.io/api/v1/file/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fadc1e9e9368e4a8cb1b4dbb5aae5aaa2)
-
-- **Everything syncs**: Agent and UI share one database and one state. Changes from either side show up instantly on the other.
-- **Real-time multiplayer**: Humans and agents collaborate in the same document with CRDT merging, live presence, and the agent as a first-class peer editor. Works on any SQL database and any host.
-- **Context-aware**: The agent knows what you're looking at. Select text, hit Cmd+I, and tell it what to do.
-- **Agents call agents**: Tag another agent from any app. They discover each other over A2A and take action across your stack.
-- **Apps that improve themselves**: The agent can add features, fix bugs, and refine the UI over time.
-- **Any database, any host**: Any SQL database Drizzle supports. Any host Nitro supports. No lock-in.
 
 ## The Best of Both Worlds
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Don't want to scaffold a whole app yet? Add visual planning and PR recaps to Cla
 npx @agent-native/core@latest skills add visual-plan
 ```
 
-![Visual plan review surface](https://raw.githubusercontent.com/builderio/skills/main/media/visual-plan.png)
+![Visual plan and recap in action](https://raw.githubusercontent.com/builderio/skills/main/media/visual-recap.gif)
 
 You get two slash commands:
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # Agent-Native
 
-### Open-source framework for agentic applications you own.
-
-Don't choose between rich user interfaces and autonomous agents. Every Agent-Native app is both.
-
 ## The framework for agent-native apps
 
-Agent-Native is an open-source framework for building robust agents that act inside real apps, not just chat next to them. It gives you primitives for product-grade agentic software — shared actions, SQL-backed state, identity, tools, skills, jobs, observability, and UI surfaces — that all work together. Bring your own database, hosting provider, model stack, and app code.
+Agent-Native is an open-source framework for building robust agents that act inside real apps, not just chat next to them. It gives you primitives for product-grade agentic software: shared actions, SQL-backed state, identity, tools, skills, jobs, observability, and UI surfaces that all work together. Bring your own database, hosting provider, model stack, and app code.
 
 ```ts
 // One action powers UI, agent, HTTP, MCP, A2A, and CLI.
@@ -21,13 +17,13 @@ export default defineAction({
 });
 ```
 
-- **Actions** — Define work once. Use it from UI, agent, API, MCP, A2A, and CLI.
-- **Agent runtime** — Chat, tools, skills, memory, jobs, observability, and handoffs ship together.
-- **Backend agnostic** — Plug in any Drizzle-supported SQL database and Nitro-compatible host.
+- **Actions**: Define work once. Use it from UI, agent, API, MCP, A2A, and CLI.
+- **Agent runtime**: Chat, tools, skills, memory, jobs, observability, and handoffs ship together.
+- **Backend agnostic**: Plug in any Drizzle-supported SQL database and Nitro-compatible host.
 
 ## Templates
 
-Start with a full featured template. Each one is a complete, 100% free and open-source SaaS app — cloneable, not scaffolded — except you own the code and can customize everything.
+Start with a full featured template. Each one is a complete, 100% free and open-source SaaS app: cloneable, not scaffolded, except you own the code and can customize everything.
 
 <table>
 <tr>
@@ -61,7 +57,7 @@ Edit local Markdown/MDX files, generate rich interactive custom blocks, and draf
 
 **Visual plan mode for coding agents**
 
-Install `/visual-plan` and `/visual-recap` so your coding agent can plan before it builds and recap changes after they land — high-level code reviews with diagrams, wireframes, annotations, and review links.
+Install `/visual-plan` and `/visual-recap` so your coding agent can plan before it builds and recap changes after they land. High-level code reviews with diagrams, wireframes, annotations, and review links.
 
 </td>
 </tr>
@@ -112,12 +108,12 @@ Don't want to scaffold a whole app yet? Add visual planning and PR recaps to Cla
 npx @agent-native/core@latest skills add visual-plan
 ```
 
-![Example of a visual plan posted to a PR](https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fcf9bac396cf24a4ba976fc331af6fc5d)
+![Visual plan review surface](https://raw.githubusercontent.com/builderio/skills/main/media/visual-plan.png)
 
 You get two slash commands:
 
-- **`/visual-plan`** — before the agent writes code, it opens a structured, reviewable plan: inline diagrams, UI wireframes, file-by-file implementation maps, and annotations you can comment on and approve.
-- **`/visual-recap`** — after changes land, it turns a PR or git diff into a high-altitude visual recap with a shareable review link instead of a raw diff.
+- **`/visual-plan`**: before the agent writes code, it opens a structured, reviewable plan with inline diagrams, UI wireframes, file-by-file implementation maps, and annotations you can comment on and approve.
+- **`/visual-recap`**: after changes land, it turns a PR or git diff into a high-altitude visual recap with a shareable review link instead of a raw diff.
 
 See the **[Skills Guide](https://agent-native.com/docs/skills-guide#app-backed-skills)** for more.
 
@@ -132,20 +128,25 @@ pnpm install
 pnpm dev
 ```
 
-The CLI shows a multi-select picker so you can include as many templates as you want in one workspace — pick Mail + Calendar + Forms and you get all three wired up and sharing auth. Want a single app, no monorepo? Add `--standalone --template mail`.
+`create` scaffolds a workspace with a multi-select picker, so you can include as many apps as you want in one place. Pick Mail + Calendar + Forms and you get all three wired up and sharing auth.
 
-## Agents and UIs — Fully Connected
+Want a single app instead of a monorepo? Add `--standalone`. The picker leads with two on-ramps:
 
-The agent and the UI are equal citizens of the same system. Every action works both ways — click it or ask for it.
+- **Headless**: an action-first app with one primitive and no UI shell. The CLI walks you through calling your first action and agent, and you can add a UI later.
+- **Chat**: a minimal chat UI with the browser shell already wired, the simplest starting point when you want a UI.
+
+## Agents and UIs, Fully Connected
+
+The agent and the UI are equal citizens of the same system. Every action works both ways: click it or ask for it.
 
 ![Agents and UIs fully connected](https://cdn.builder.io/api/v1/file/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fadc1e9e9368e4a8cb1b4dbb5aae5aaa2)
 
-- **Everything syncs** — Agent and UI share one database and one state. Changes from either side show up instantly on the other.
-- **Real-time multiplayer** — Humans and agents collaborate in the same document: CRDT merging, live presence, and the agent as a first-class peer editor. Works on any SQL database and any host.
-- **Context-aware** — The agent knows what you're looking at. Select text, hit Cmd+I, and tell it what to do.
-- **Agents call agents** — Tag another agent from any app. They discover each other over A2A and take action across your stack.
-- **Apps that improve themselves** — The agent can add features, fix bugs, and refine the UI over time.
-- **Any database, any host** — Any SQL database Drizzle supports. Any host Nitro supports. No lock-in.
+- **Everything syncs**: Agent and UI share one database and one state. Changes from either side show up instantly on the other.
+- **Real-time multiplayer**: Humans and agents collaborate in the same document with CRDT merging, live presence, and the agent as a first-class peer editor. Works on any SQL database and any host.
+- **Context-aware**: The agent knows what you're looking at. Select text, hit Cmd+I, and tell it what to do.
+- **Agents call agents**: Tag another agent from any app. They discover each other over A2A and take action across your stack.
+- **Apps that improve themselves**: The agent can add features, fix bugs, and refine the UI over time.
+- **Any database, any host**: Any SQL database Drizzle supports. Any host Nitro supports. No lock-in.
 
 ## The Best of Both Worlds
 

--- a/README.md
+++ b/README.md
@@ -4,30 +4,9 @@
 
 Don't choose between rich user interfaces and autonomous agents. Every Agent-Native app is both.
 
-## Agents and UIs — Fully Connected
-
-The agent and the UI are equal citizens of the same system. Every action works both ways — click it or ask for it.
-
-![Agents and UIs fully connected](https://cdn.builder.io/api/v1/file/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fadc1e9e9368e4a8cb1b4dbb5aae5aaa2)
-
-- **Everything syncs** — Agent and UI share one database and one state. Changes from either side show up instantly on the other.
-- **Real-time multiplayer** — Humans and agents collaborate in the same document simultaneously: CRDT merging, live presence (cursors, selection rings, who's on which slide), and the agent as a first-class peer editor. Works on any SQL database and any host, including serverless.
-- **Context-aware** — The agent knows what you're looking at. Select text, hit Cmd+I, and tell it what to do.
-- **Per-user workspace** — Skills, memory, instructions, sub-agents, and MCP servers — SQL-backed, customizable per user. Claude-Code-level flexibility, SaaS-grade economics.
-- **Agents call agents** — Tag another agent from any app. They discover each other over A2A and take action across your stack.
-- **Reusable integrations** — Connect a provider once in Dispatch, keep secret values in the vault, then grant apps like Brain, Analytics, Mail, and Dispatch access to the shared account metadata and credential refs.
-- **Three shapes** — Build the same agent as a headless API, a rich chat experience, or a full application where agent and UI stay in sync.
-- **Apps that improve themselves** — Your apps get better on their own. The agent can add features, fix bugs, and refine the UI over time.
-- **Any database, any host** — Any SQL database Drizzle supports. Any hosting target Nitro supports. No lock-in.
-- **Bring the agent surface you need** — MCP-compatible hosts can call your apps, coding agents can install skills, native chat renders reusable app outputs, and BYO agent runtimes can stream into the Agent-Native chat shell.
-
 ## The framework for agent-native apps
 
-Agent-Native is an open-source framework for building robust agents that can act inside real apps, not just chat next to them.
-
-It gives you primitives for product-grade agentic software: shared actions, SQL-backed state, identity, tools, skills, jobs, observability, and UI surfaces that all work together.
-
-Backend agnostic: bring your own database, hosting provider, model stack, and app code.
+Agent-Native is an open-source framework for building robust agents that act inside real apps, not just chat next to them. It gives you primitives for product-grade agentic software — shared actions, SQL-backed state, identity, tools, skills, jobs, observability, and UI surfaces — that all work together. Bring your own database, hosting provider, model stack, and app code.
 
 ```ts
 // One action powers UI, agent, HTTP, MCP, A2A, and CLI.
@@ -45,37 +24,6 @@ export default defineAction({
 - **Actions** — Define work once. Use it from UI, agent, API, MCP, A2A, and CLI.
 - **Agent runtime** — Chat, tools, skills, memory, jobs, observability, and handoffs ship together.
 - **Backend agnostic** — Plug in any Drizzle-supported SQL database and Nitro-compatible host.
-
-## One agent, three product shapes
-
-Agent-Native primitives let you choose how much UI to put around an agent without rebuilding the agent contract:
-
-| Shape         | What you ship                                                                                             | Same primitives underneath                                                  |
-| ------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| **Headless**  | Call the agent and actions from code, CLI, HTTP, MCP, or A2A.                                             | `defineAction`, auth, skills, memory, jobs, observability                   |
-| **Rich chat** | A standalone or embedded chat with native tables, charts, approvals, setup flows, and tool results.       | Shared chat runtime, BYO runtime adapters, action-declared native renderers |
-| **Whole app** | A full SaaS/product UI where chat can start central, move to the sidebar, and stay synced with app state. | SQL state, actions, context awareness, deep links, live sync                |
-
-Protocols come with the framework instead of becoming separate integrations per feature. Today that means A2A, MCP, MCP Apps, standard remote MCP OAuth, MCP clients, HTTP/CLI action calls, native chat widgets, `AgentChatRuntime` adapters, standard OpenAI, AG-UI, Claude Agent SDK, and Vercel AI SDK chat runtime connectors, and deep links all hang off the same action surface. ACP is best understood as the coding-agent/editor interoperability protocol, not the general BYO app-chat runtime.
-
-For the full decision guide — headless, rich chat on the built-in agent, rich chat on your own agent, embedded sidecar, or full app — see [Agent Surfaces](https://agent-native.com/docs/agent-surfaces).
-
-To connect Claude, ChatGPT, Codex, Cursor, OpenCode, GitHub Copilot / VS Code, or another MCP host to your hosted app, see the [External Agents guide](https://agent-native.com/docs/external-agents).
-
-## Try it with a skill
-
-Don't want to scaffold a whole app yet? Add visual planning and PR recaps to Claude Code, Codex, Cursor, Pi, OpenCode, GitHub Copilot / VS Code, and similar agents with one command:
-
-```bash
-npx @agent-native/core@latest skills add visual-plan
-```
-
-You get two slash commands that upgrade how your agent plans and reports its work:
-
-- **`/visual-plan`** — before the agent writes code, it opens a structured, reviewable plan document instead of a wall of text: inline diagrams, UI wireframes and prototypes, file-by-file implementation maps, and annotations you can comment on and approve.
-- **`/visual-recap`** — after changes land, it turns a PR or git diff into a high-altitude visual recap: schema, API, and file changes rendered as grounded before/after blocks with a shareable review link, instead of scrolling a raw diff.
-
-See the **[Skills Guide](https://agent-native.com/docs/skills-guide#app-backed-skills)** for more skills and local installs.
 
 ## Templates
 
@@ -137,7 +85,7 @@ Generate and edit React-based presentations via prompt or point-and-click.
 
 **Agent-Native Amplitude, Mixpanel**
 
-Connect analytics data sources, prompt for real charts, and build reusable dashboards. Shared workspace connections can provide provider credentials, while Analytics still owns metrics, source-of-truth choices, and saved analyses.
+Connect analytics data sources, prompt for real charts, and build reusable dashboards.
 
 </td>
 <td width="33%" align="center" valign="top">
@@ -154,9 +102,24 @@ Record your screen with auto-transcripts, shareable links, and an agent that sum
 </tr>
 </table>
 
-Every template is a complete cloneable SaaS — fork it, customize it with the agent, own it. Try them with example data before connecting your own sources.
-
 View the full template gallery at **[agent-native.com/templates](https://agent-native.com/templates)**.
+
+## Try it with a skill
+
+Don't want to scaffold a whole app yet? Add visual planning and PR recaps to Claude Code, Codex, Cursor, Pi, OpenCode, GitHub Copilot / VS Code, and similar agents with one command:
+
+```bash
+npx @agent-native/core@latest skills add visual-plan
+```
+
+![Example of a visual plan posted to a PR](https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fcf9bac396cf24a4ba976fc331af6fc5d)
+
+You get two slash commands:
+
+- **`/visual-plan`** — before the agent writes code, it opens a structured, reviewable plan: inline diagrams, UI wireframes, file-by-file implementation maps, and annotations you can comment on and approve.
+- **`/visual-recap`** — after changes land, it turns a PR or git diff into a high-altitude visual recap with a shareable review link instead of a raw diff.
+
+See the **[Skills Guide](https://agent-native.com/docs/skills-guide#app-backed-skills)** for more.
 
 ## Quick Start
 
@@ -169,47 +132,20 @@ pnpm install
 pnpm dev
 ```
 
-The CLI shows a multi-select picker so you can include as many templates as you want in one workspace. Pick Mail + Calendar + Forms and you get all three apps wired up and sharing auth in one go. Or browse the **[template gallery](https://agent-native.com/templates)** for live demos.
+The CLI shows a multi-select picker so you can include as many templates as you want in one workspace — pick Mail + Calendar + Forms and you get all three wired up and sharing auth. Want a single app, no monorepo? Add `--standalone --template mail`.
 
-Want a single app, no monorepo? Use `--standalone`:
+## Agents and UIs — Fully Connected
 
-```bash
-npx @agent-native/core@latest create my-app --standalone --template mail
-```
+The agent and the UI are equal citizens of the same system. Every action works both ways — click it or ask for it.
 
-## Workspaces (Monorepo)
+![Agents and UIs fully connected](https://cdn.builder.io/api/v1/file/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fadc1e9e9368e4a8cb1b4dbb5aae5aaa2)
 
-A workspace is the default shape of an agent-native project. Every app sits under `apps/`, and `packages/shared/` is available for the small amount of code, instructions, skills, or branding that should truly apply to every app.
-
-```
-my-platform/
-├── package.json                   # declares `agent-native.workspaceCore`
-├── pnpm-workspace.yaml
-├── .env                           # shared secrets: ANTHROPIC_API_KEY, BUILDER_PRIVATE_KEY, A2A_SECRET, ...
-├── packages/
-│   └── shared/                    # optional shared custom code
-└── apps/
-    ├── mail/
-    ├── calendar/
-    └── forms/
-```
-
-Add another app later:
-
-```bash
-npx @agent-native/core@latest add-app notes --template content
-```
-
-Deploy every app behind one origin:
-
-```bash
-npx @agent-native/core@latest deploy
-# https://your-agents.com/mail/*       → mail
-# https://your-agents.com/calendar/*   → calendar
-# https://your-agents.com/forms/*      → forms
-```
-
-Same-origin deploy means a **shared login session** across every app and **zero-config cross-app A2A** — tag `@mail` from the calendar's agent chat and it just works (no JWT signing, no CORS). Full details at **[agent-native.com/docs/multi-app-workspace](https://agent-native.com/docs/multi-app-workspace)**.
+- **Everything syncs** — Agent and UI share one database and one state. Changes from either side show up instantly on the other.
+- **Real-time multiplayer** — Humans and agents collaborate in the same document: CRDT merging, live presence, and the agent as a first-class peer editor. Works on any SQL database and any host.
+- **Context-aware** — The agent knows what you're looking at. Select text, hit Cmd+I, and tell it what to do.
+- **Agents call agents** — Tag another agent from any app. They discover each other over A2A and take action across your stack.
+- **Apps that improve themselves** — The agent can add features, fix bugs, and refine the UI over time.
+- **Any database, any host** — Any SQL database Drizzle supports. Any host Nitro supports. No lock-in.
 
 ## The Best of Both Worlds
 


### PR DESCRIPTION
Trims the main README (~40% fewer words overall; far more than that outside the mandatory templates table) and reorders sections for a tighter top-to-bottom read.

## Changes
- **Framework section now leads** — condensed the three intro paragraphs to one; kept the action code example and the three bullets.
- **Templates list kept** — full template table retained as-is.
- **New "Try it with a skill" section below templates** — includes the visual-plan gif pulled from the `builderio/skills` main README.
- **"Agents and UIs — Fully Connected" moved down** and trimmed from 10 bullets to 6.
- **Removed the Workspaces (Monorepo) section** and the bloated "One agent, three product shapes" table/protocols paragraph.

Docs-only change (`README.md`); no template or package source touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LiJHRP5zCDM56rEEoiMMr2)_