### PR TITLE
Ask start shape (template/chat/headless) before the template picker

### DIFF
--- a/.changeset/create-start-shape-prompt.md
+++ b/.changeset/create-start-shape-prompt.md
@@ -1,0 +1,8 @@
+---
+"@agent-native/core": minor
+---
+
+`create` now asks how you want to start (Full template / Chat / Headless) before
+the template picker. Chat and Headless scaffold a single standalone app; Full
+template continues into the workspace multi-select. Flag-driven paths
+(`--template`, `--headless`, `--standalone`) skip the prompt and are unchanged.

--- a/README.md
+++ b/README.md
@@ -140,12 +140,13 @@ pnpm install
 pnpm dev
 ```
 
-`create` scaffolds a workspace with a multi-select picker, so you can include as many apps as you want in one place. Pick Mail + Calendar + Forms and you get all three wired up and sharing auth.
+`create` first asks how you want to start:
 
-Want a single app instead of a monorepo? Add `--standalone`. The picker leads with two on-ramps:
+- **Full template(s)**: clone one or more complete apps into a workspace. Pick Mail + Calendar + Forms and you get all three wired up and sharing auth.
+- **Chat**: a single app with a minimal chat UI and the browser shell already wired, the simplest way to get a UI.
+- **Headless**: a single action-first app with no UI shell. The CLI walks you through calling your first action and agent, and you can add a UI later.
 
-- **Headless**: an action-first app with one primitive and no UI shell. The CLI walks you through calling your first action and agent, and you can add a UI later.
-- **Chat**: a minimal chat UI with the browser shell already wired, the simplest starting point when you want a UI.
+Prefer flags? `create my-app --template mail`, `--headless`, or `--standalone` skip the prompt.
 
 ## The Best of Both Worlds
 

--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ See the **[Skills Guide](https://agent-native.com/docs/skills-guide#app-backed-s
 
 ## Quick Start
 
-One command to fork a template and start building locally.
+One command to start a new project locally.
 
 ```bash
-npx @agent-native/core@latest create my-platform
-cd my-platform
+npx @agent-native/core@latest create my-app
+cd my-app
 pnpm install
 pnpm dev
 ```

--- a/packages/core/docs/content/getting-started.md
+++ b/packages/core/docs/content/getting-started.md
@@ -28,8 +28,8 @@ everything after (defining actions, running the agent) is the same either way.
 
 You'll need [Node.js 22+](https://nodejs.org) and [pnpm](https://pnpm.io).
 
-Run `create` with no flags and it asks how you want to start — a full template,
-Chat, or Headless — before anything else:
+Run `create` with no flags and it asks how you want to start (a full template,
+Chat, or Headless) before anything else:
 
 ```bash
 npx @agent-native/core@latest create my-app

--- a/packages/core/docs/content/getting-started.md
+++ b/packages/core/docs/content/getting-started.md
@@ -28,6 +28,15 @@ everything after (defining actions, running the agent) is the same either way.
 
 You'll need [Node.js 22+](https://nodejs.org) and [pnpm](https://pnpm.io).
 
+Run `create` with no flags and it asks how you want to start — a full template,
+Chat, or Headless — before anything else:
+
+```bash
+npx @agent-native/core@latest create my-app
+```
+
+Or pass a flag to skip the prompt:
+
 **Want a UI?** Start from the Chat template. You get a working agent plus a
 customizable chat UI, and every action you add shows up in it automatically:
 

--- a/packages/core/src/cli/create-workspace.ts
+++ b/packages/core/src/cli/create-workspace.ts
@@ -22,6 +22,9 @@ export async function createWorkspace(
   const passthrough: CreateAppOptions = {
     template: opts.template,
     noInstall: opts.noInstall,
+    // Preserve the alias's contract: always scaffold a workspace, never the
+    // new start-shape prompt that could route to a standalone app.
+    forceWorkspace: true,
   };
   await createApp(opts.name, passthrough);
 }

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -126,13 +126,21 @@ export async function createApp(
   // Use `--template a,b` or pass no --template to opt into the workspace
   // flow with the multi-select picker.
   const parsed = parseTemplateList(opts?.template);
-  if (parsed.includes("headless") && parsed.length > 1) {
+  // Headless can't live in a workspace, so reject it when more than one
+  // template is requested or when workspace semantics are forced.
+  if (
+    parsed.includes("headless") &&
+    (parsed.length > 1 || opts?.forceWorkspace)
+  ) {
     clack.cancel(
       "The headless scaffold is standalone-only. Use `agent-native create my-app --headless`, or use the Chat template when adding a UI app to a workspace.",
     );
     process.exit(1);
   }
-  if (parsed.length === 1) {
+  // A single explicit template scaffolds a standalone app, unless the caller
+  // forces workspace semantics (the deprecated `create-workspace` alias), in
+  // which case the template is preselected in the workspace picker below.
+  if (parsed.length === 1 && !opts?.forceWorkspace) {
     await createStandaloneApp(name, opts, clack);
     return;
   }

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -78,6 +78,12 @@ export interface CreateAppOptions {
   standalone?: boolean;
   /** Internal: skip pnpm install at the end (for tests). */
   noInstall?: boolean;
+  /**
+   * Internal: always scaffold a workspace and skip the start-shape prompt.
+   * Used by the deprecated `create-workspace` alias, whose contract is an
+   * unconditional workspace scaffold.
+   */
+  forceWorkspace?: boolean;
 }
 
 /**
@@ -138,6 +144,12 @@ export async function createApp(
   // cannot live in a workspace), while Template continues into the workspace
   // multi-select.
   if (parsed.length === 0) {
+    // The deprecated `create-workspace` alias forces workspace semantics, so
+    // it must skip the start-shape prompt and scaffold a workspace directly.
+    if (opts?.forceWorkspace) {
+      await createWorkspaceInteractive(name, opts, clack);
+      return;
+    }
     const shape = await promptStartShape(clack);
     if (shape === "headless" || shape === "chat") {
       await createStandaloneApp(name, { ...opts, template: shape }, clack);

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -95,6 +95,12 @@ export async function createApp(
 ): Promise<void> {
   const clack = await import("@clack/prompts");
 
+  // Reject an invalid provided name before any interactive prompt so bad input
+  // fails fast instead of blocking on the start-shape picker below.
+  if (name !== undefined) {
+    assertValidProjectName(name, clack);
+  }
+
   // If we're already inside a workspace, the meaning of `create <name>` is
   // "add a new app to this workspace". Delegate to add-app.
   const workspace = detectWorkspace(process.cwd());
@@ -125,8 +131,83 @@ export async function createApp(
     return;
   }
 
-  // Default: create a workspace.
+  // No template specified: ask what shape to start from before diving into
+  // "which templates?". The on-ramp choice implies the project structure, so
+  // we don't ask a separate "workspace or standalone?" question — Chat and
+  // Headless scaffold a single standalone app (the lightest starts; headless
+  // cannot live in a workspace), while Template continues into the workspace
+  // multi-select.
+  if (parsed.length === 0) {
+    const shape = await promptStartShape(clack);
+    if (shape === "headless" || shape === "chat") {
+      await createStandaloneApp(name, { ...opts, template: shape }, clack);
+      return;
+    }
+    // shape === "template" → full app(s) in a workspace.
+    await createWorkspaceInteractive(name, opts, clack);
+    return;
+  }
+
+  // Multiple explicit templates: create a workspace with them.
   await createWorkspaceInteractive(name, opts, clack);
+}
+
+/**
+ * Top-level on-ramp shown by the bare `create <name>` command (no flags). The
+ * choice made here implies the project structure, so we deliberately avoid a
+ * separate "workspace or standalone?" question:
+ *   - "template" → full app(s) in a workspace (the multi-select picker)
+ *   - "chat"     → a single standalone chat UI app
+ *   - "headless" → a single standalone action-first app with no UI shell
+ * Chat and headless are standalone on purpose: a monorepo is unnecessary
+ * ceremony for the lightest on-ramps, and headless cannot be a workspace
+ * member. Either can grow into a workspace later via `add-app`.
+ */
+async function promptStartShape(
+  clack: typeof import("@clack/prompts"),
+): Promise<"template" | "chat" | "headless"> {
+  const choice = await clack.select({
+    message: "How do you want to start?",
+    options: [
+      {
+        value: "template",
+        label: "Full template(s)",
+        hint: "Clone complete apps (Mail, Calendar, Slides, ...) into a workspace",
+      },
+      {
+        value: "chat",
+        label: "Chat",
+        hint: "A single app with a minimal chat UI and the browser shell wired up",
+      },
+      {
+        value: "headless",
+        label: "Headless",
+        hint: "A single action-first app with one primitive and no UI shell",
+      },
+    ],
+  });
+  if (clack.isCancel(choice)) {
+    clack.cancel("Cancelled.");
+    process.exit(0);
+  }
+  return choice as "template" | "chat" | "headless";
+}
+
+/**
+ * Validate a project name supplied on the command line. Mirrors the rule in
+ * `promptNameIfMissing` so an invalid name is rejected before any interactive
+ * prompt runs (the sub-flows re-validate, which is a harmless no-op).
+ */
+function assertValidProjectName(
+  name: string,
+  clack: typeof import("@clack/prompts"),
+): void {
+  if (!/^[a-z][a-z0-9-]*$/.test(name)) {
+    clack.cancel(
+      `Invalid name "${name}". Use lowercase letters, numbers, and hyphens (must start with a letter).`,
+    );
+    process.exit(1);
+  }
 }
 
 /* ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
The bare `create <name>` (no flags) now opens a top-level prompt asking how you want to start, before diving into "which templates?".

## Behavior
`create my-app` → **How do you want to start?**
- **Full template(s)** → continues into the workspace multi-select (today's flow)
- **Chat** → scaffolds a single standalone chat-UI app
- **Headless** → scaffolds a single standalone action-first app (no UI)

The on-ramp choice implies the project structure, so there's no separate "workspace or standalone?" question. Chat and Headless are standalone on purpose: a monorepo is unnecessary ceremony for the lightest starts, and headless can't be a workspace member. Either can grow into a workspace later via `add-app`.

Flag-driven paths are unchanged and skip the prompt: `--template <name>`, `--headless`, `--standalone`. Invalid names now fail fast *before* the prompt rather than blocking on it.

## Files
- `packages/core/src/cli/create.ts` — new `promptStartShape`, routing for the no-flags path, and an early name-validation guard.
- `README.md` — Quick Start now describes the prompt; example made shape-neutral.
- `packages/core/docs/content/getting-started.md` — step 1 mentions the interactive prompt alongside the flag commands.
- `.changeset/` — `minor` bump for `@agent-native/core`.

## Validation
`create.spec.ts` 13/13 · `tsc --noEmit` clean · Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiJHRP5zCDM56rEEoiMMr2)_