### PR TITLE
Share page improvements for logged-in users

### DIFF
--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -10,6 +10,7 @@ import { useLoaderData, useNavigate, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import {
   IconAlertTriangle,
+  IconArrowLeft,
   IconDownload,
   IconExternalLink,
   IconLogin2,
@@ -21,6 +22,7 @@ import {
   appBasePath,
   appPath,
   useSession,
+  AgentPanel,
 } from "@agent-native/core/client";
 import {
   VideoPlayer,
@@ -629,6 +631,16 @@ export default function ShareRoute() {
       {agentDiscovery}
       <div className="flex min-w-0 flex-1 flex-col">
         <header className="flex shrink-0 flex-wrap items-center gap-3 border-b border-border px-4 py-3 lg:flex-nowrap">
+          {session ? (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => navigate("/")}
+              aria-label="Back to home"
+            >
+              <IconArrowLeft className="h-4 w-4" />
+            </Button>
+          ) : null}
           <div className="min-w-0 flex-1">
             {showTitleSkeleton ? (
               <Skeleton
@@ -651,7 +663,7 @@ export default function ShareRoute() {
                   <IconExternalLink className="h-3.5 w-3.5 shrink-0" />
                 </a>
               </Button>
-            ) : (
+            ) : session ? null : (
               <Button variant="ghost" size="sm" asChild>
                 <a href={appPath("/")} className="gap-1.5">
                   Try Clips
@@ -804,9 +816,22 @@ export default function ShareRoute() {
           </TabsList>
           <TabsContent
             value="agent"
-            className="mt-3 min-h-0 flex-1 data-[state=inactive]:hidden"
+            className="mt-0 flex min-h-0 flex-1 flex-col data-[state=inactive]:hidden"
           >
-            <PublicAgentEmptyState />
+            {sessionLoading ? null : session ? (
+              <AgentPanel
+                emptyStateText="Ask about this clip…"
+                dynamicSuggestions={false}
+                suggestions={[
+                  "Summarize this clip",
+                  "Find the key moments",
+                  "List follow-up actions",
+                  "Draft questions for the author",
+                ]}
+              />
+            ) : (
+              <PublicAgentEmptyState />
+            )}
           </TabsContent>
           <TabsContent
             value="transcript"

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -357,6 +357,25 @@ export default function ShareRoute() {
     document.title = pageTitle(recording.title);
   }, [recording?.title]);
 
+  // The /share/* shell skips DbSyncSetup (and thus useNavigationState), so the
+  // agent mounted in the side panel has no navigation context. Write it
+  // explicitly for signed-in viewers so view-screen grounds the chat to this
+  // clip instead of falling back to a generic library view.
+  useEffect(() => {
+    if (!session || !recording?.id) return;
+    fetch(agentNativePath("/_agent-native/application-state/navigation"), {
+      method: "PUT",
+      keepalive: true,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        view: "share",
+        shareId: recording.id,
+        recordingId: recording.id,
+        path: `/share/${recording.id}`,
+      }),
+    }).catch(() => {});
+  }, [session, recording?.id]);
+
   useEffect(() => {
     if (!recording) {
       setProcessingTimeout(false);


### PR DESCRIPTION
All changes are in `share.$shareId.tsx` and only affect logged-in users.

- **Back button** — adds a back arrow to the header that navigates to the home page
- **Agent tab** — shows the real chat interface with preset suggestions instead of the "sign in" placeholder
- **"Try Clips" CTA** — hidden from logged-in users since they already have an account

Public visitors see no changes.
<img width="1509" height="810" alt="image" src="https://github.com/user-attachments/assets/cb615956-1ad2-4d51-b7b5-3d20678fe3e1" />
