### PR TITLE
Host Loom imports as Clips media and clarify agent docs

### DIFF
--- a/.changeset/agent-building-block-docs.md
+++ b/.changeset/agent-building-block-docs.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+---
+
+Clarify in the docs how instructions, skills, and actions work together as the
+core building blocks of Agent Native agents.

--- a/.changeset/short-feedback-placeholder.md
+++ b/.changeset/short-feedback-placeholder.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Shorten the default feedback popover placeholder.

--- a/packages/core/docs/content/getting-started.md
+++ b/packages/core/docs/content/getting-started.md
@@ -1,12 +1,13 @@
 ---
 title: "Getting Started"
-description: "Create an agent app — with a chat UI or headless — add an action, and watch the agent call it."
+description: "Create an agent app, understand instructions, skills, and actions, then watch the agent call its first action."
 ---
 
 # Getting Started
 
 Agent-Native apps give an AI agent and your UI the same actions, data, and
-state. The smallest useful app is a single action.
+state. A basic agent is made from instructions that guide it, skills that teach
+repeatable behavior, and actions that let it do real work.
 
 **Want a complete app to start from?** Clone one of our rich templates —
 [Chat](/docs/template-chat), [Mail](/docs/template-mail),
@@ -15,14 +16,22 @@ state. The smallest useful app is a single action.
 each a full-featured app you customize.
 
 Building from scratch? The only choice up front is whether you want a UI —
-everything after (defining actions, running the agent) is the same either way.
+everything after (writing instructions, adding skills, defining actions, running
+the agent) is the same either way.
 
-```an-diagram title="The three-step on-ramp" summary="Create an app, add one action, run it. The action is then reachable from every surface."
+```an-file-tree title="A basic Agent-Native agent"
 {
-  "html": "<div class=\"diagram-flow\"><div class=\"diagram-card\"><span class=\"diagram-pill\">1</span><strong>Create</strong><small class=\"diagram-muted\">chat template or headless</small></div><div class=\"diagram-arrow diagram-muted\" aria-hidden=\"true\">&rarr;</div><div class=\"diagram-card\"><span class=\"diagram-pill\">2</span><strong>Add an action</strong><small class=\"diagram-muted\">one defineAction file</small></div><div class=\"diagram-arrow diagram-muted\" aria-hidden=\"true\">&rarr;</div><div class=\"diagram-card\"><span class=\"diagram-pill accent\">3</span><strong>Run it</strong><small class=\"diagram-muted\">CLI, agent, or browser</small></div></div>",
-  "css": ".diagram-flow{display:flex;align-items:center;gap:12px;flex-wrap:wrap}.diagram-flow .diagram-card{display:flex;flex-direction:column;gap:6px;padding:14px 16px;min-width:140px}.diagram-flow .diagram-arrow{font-size:22px;line-height:1}"
+  "entries": [
+    { "path": "AGENTS.md", "note": "always-on instructions: purpose, rules, tone, and the map of what the agent can do" },
+    { "path": ".agents/skills/customer-research/SKILL.md", "note": "a reusable playbook the agent loads when the task matches" },
+    { "path": "actions/summarize-week.ts", "note": "typed code the agent, UI, CLI, HTTP, MCP, A2A, jobs, and webhooks can run" }
+  ]
 }
 ```
+
+This is true whether you start with a chat UI, a headless agent, or a full app.
+The UI changes the surface; instructions, skills, and actions give the agent its
+guidance and behavior.
 
 ## 1. Create your app
 
@@ -42,10 +51,10 @@ loop, no UI shell:
 npx @agent-native/core@latest create my-agent --headless
 ```
 
-Then install:
+Then install from the folder you created:
 
 ```bash
-cd my-app
+cd my-agent # or my-app if you chose the Chat template
 pnpm install
 ```
 
@@ -71,8 +80,13 @@ ship with this example:
 }
 ```
 
-Replace `hello` with the smallest real operation in your domain. You define it
-once; every surface picks it up.
+Replace `hello` with the first real operation in your domain. You define it once;
+every surface picks it up.
+
+Use `AGENTS.md` for guidance that should apply every turn. Use a skill when the
+agent needs a reusable workflow or domain procedure. Use an action when the
+agent needs a typed, testable way to read data, write data, call an API, or
+perform an approval.
 
 ## 3. Run it
 
@@ -173,7 +187,8 @@ my-app/
   actions/         # Agent-callable actions
   app/             # React frontend (UI templates only; omitted when headless)
   server/          # Nitro API server (routes, plugins)
-  .agents/         # Agent instructions and skills
+  AGENTS.md        # Always-on agent instructions
+  .agents/         # Skills the agent can pull in when relevant
   data/app.db      # Local SQLite state when DATABASE_URL is unset
 ```
 

--- a/packages/core/docs/content/key-concepts.md
+++ b/packages/core/docs/content/key-concepts.md
@@ -26,6 +26,33 @@ Every agent-native app is three things working together:
 
 Headless apps can run the same production app-agent loop from the folder with `pnpm agent`, while UI apps mount the embedded agent panel and run locally with `pnpm dev`. In the cloud, Builder.io provides a managed frame — the environment that hosts the agent next to your app — with collaboration, visual editing, and managed infrastructure for teams.
 
+## Agent building blocks {#agent-building-blocks}
+
+Every agent-native app has the same agent building blocks, regardless of whether
+the product surface is headless, chat-first, or a full UI:
+
+```an-file-tree title="Guidance and behavior"
+{
+  "entries": [
+    { "path": "AGENTS.md", "note": "always-on instructions: purpose, core rules, state keys, action index, skills index" },
+    { "path": ".agents/skills/<name>/SKILL.md", "note": "reusable behavior: workflow steps, policies, examples, references, and do/don't lists" },
+    { "path": "actions/<name>.ts", "note": "executable capability: typed operation exposed to the agent, UI, CLI, HTTP, MCP, A2A, jobs, and webhooks" }
+  ]
+}
+```
+
+| Building block   | Use it for                                                                                          | Loaded when                                           |
+| ---------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| **Instructions** | Stable guidance the agent should carry into every task: what the app is, invariants, tone, indexes  | Every turn                                            |
+| **Skills**       | Reusable behavior: how to follow a workflow, apply a policy, inspect evidence, or verify an output  | On demand when the skill description matches the task |
+| **Actions**      | Real operations: read or write data, call APIs, send messages, run approvals, produce typed results | Listed as tools every turn; executed only when called |
+
+Skills and actions work together. A skill teaches the agent how to do a class of
+work; an action is the code path it can call while doing that work. For example,
+a `customer-research` skill might tell the agent which sources to inspect and
+how to summarize evidence, while `search-crm` and `create-brief` actions fetch
+and write the actual data.
+
 Six rules govern the architecture:
 
 1. **Data lives in SQL** — all app state lives in the database via Drizzle ORM

--- a/packages/core/docs/content/writing-agent-instructions.md
+++ b/packages/core/docs/content/writing-agent-instructions.md
@@ -114,6 +114,26 @@ defineAction({
 });
 ```
 
+## Skills vs actions {#skills-vs-actions}
+
+Skills and actions are complementary. A skill is guidance the agent reads; an
+action is code the agent can run.
+
+| Need                                                                   | Use                                |
+| ---------------------------------------------------------------------- | ---------------------------------- |
+| The agent needs to follow a workflow, policy, checklist, or rubric     | **Skill**                          |
+| The agent needs examples, reference material, or domain-specific rules | **Skill**                          |
+| The agent needs to read or write app data                              | **Action**                         |
+| The agent needs to call an external API or perform an approval         | **Action**                         |
+| The agent calls the right operation but in the wrong way               | Improve the **skill**              |
+| The agent cannot reliably invoke the operation                         | Improve the **action**             |
+| The agent chooses the wrong tool                                       | Improve the **action description** |
+
+Most real features use both: the skill explains how to approach the task, and
+the action provides the typed operation. For example, an `invoice-review` skill
+can explain the review policy and escalation rules, while `list-invoices`,
+`flag-invoice`, and `approve-invoice` actions do the actual reads and writes.
+
 ## Bake in anti-fabrication and verify-before-done {#anti-fabrication}
 
 App instructions should make honesty and verification the default behavior:

--- a/packages/core/src/client/FeedbackButton.tsx
+++ b/packages/core/src/client/FeedbackButton.tsx
@@ -28,7 +28,7 @@ interface FormSchema {
 }
 
 const DEFAULT_PLACEHOLDER =
-  'What\'s working, what\'s broken, or what would you change?\n\ne.g. "The Send button isn\'t obvious", "I wish I could change the theme", "Search is slow when…"';
+  "What's working, what's broken, or what would you change?";
 const DEFAULT_SUBMIT_TEXT = "Send feedback";
 const DEFAULT_SUCCESS_MESSAGE = "Thanks for the feedback!";
 

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -15,10 +15,11 @@ Detailed media, meeting, dictation, editing, and sharing rules live in
 - Recording start/stop/pause are UI gestures because browser media capture needs
   user activation; navigate the user to the recording view instead of trying a
   server action.
-- Use `import-loom-recording` for Loom share/embed URLs. It creates a ready,
-  playable Loom-backed recording and imports Loom's public transcript when the
-  share page exposes one. Use "Upload video" instead when Clips-native editing,
-  frame extraction, or upload-based transcription is required.
+- Use `import-loom-recording` for Loom share/embed URLs. It downloads Loom's
+  public MP4, reuploads it to Clips storage, creates a ready playable
+  Clips-hosted recording, and imports Loom's public transcript when the share
+  page exposes one. If Loom does not expose a downloadable MP4, ask the user to
+  download the original from Loom and use "Upload video".
 - Native transcript first. Cleanup and title generation can run in the
   background; do not hide a usable native transcript behind a failed cleanup.
 - Cloud transcription is fallback-only for Clips recordings and should use the

--- a/templates/clips/actions/get-recording-player-data.ts
+++ b/templates/clips/actions/get-recording-player-data.ts
@@ -150,7 +150,10 @@ export default defineAction({
     // Normalize the dev-fallback videoUrl:
     //   1. Rewrite legacy `/api/uploads/:id/blob` to `/api/video/:id` so old
     //      rows keep playing after the route move.
-    //   2. For password-protected recordings, mint a short-lived HMAC token
+    //   2. Keep Loom imports behind the same-origin `/api/video/:id` access
+    //      gate. Legacy Loom rows render an iframe inside that route; reuploaded
+    //      Loom rows proxy their stored provider URL from the server.
+    //   3. For password-protected recordings, mint a short-lived HMAC token
     //      bound to this recording id and pass it via `?t=<token>` instead of
     //      the plaintext password. Sticking the password in the URL leaks it
     //      into browser history, CDN logs, the Referer header on outbound
@@ -161,7 +164,7 @@ export default defineAction({
     //      `?password=<pw>` (legacy fallback) so old share pages keep
     //      working during rollout. (audit 11 F-07)
     //      Owners are skipped — the blob route bypasses the password gate
-    //      for them, so they don't need the token. Real provider URLs
+    //      for them, so they don't need the token. Non-Loom provider URLs
     //      (R2/S3/Builder) are left untouched; those are already signed.
     const resolvedVideoUrl = resolvePlayerVideoUrl(rec, {
       addPasswordToken: access.role !== "owner",

--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -3,11 +3,13 @@ import { writeAppState } from "@agent-native/core/application-state";
 import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
 import { uploadFile } from "@agent-native/core/file-upload";
 import { buildDeepLink } from "@agent-native/core/server";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import {
   getCurrentOwnerEmail,
   nanoid,
+  parseSpaceIds,
   requireOrganizationAccess,
   stringifySpaceIds,
 } from "../server/lib/recordings.js";
@@ -65,7 +67,16 @@ const ImportLoomRecordingSchema = z.object({
     .enum(["private", "org", "public"])
     .optional()
     .describe("Initial share visibility for the recording"),
+  recordingId: z
+    .string()
+    .optional()
+    .describe(
+      "Existing waiting Loom recording ID to retry after storage is connected",
+    ),
 });
+
+const LOOM_STORAGE_SETUP_REQUIRED_REASON =
+  "Video storage is not connected yet. Connect Builder.io or configure S3-compatible storage, then retry this Loom import.";
 
 function recordingDeepLink(recordingId: string): string {
   return buildDeepLink({
@@ -116,7 +127,7 @@ async function fetchLoomOembed(shareUrl: string) {
 
 export default defineAction({
   description:
-    "Import a public Loom share URL into Clips as a playable recording. Downloads Loom's public MP4, reuploads it to the configured Clips storage provider, and imports Loom's public transcript when available.",
+    "Import a public Loom share URL into Clips as a playable recording. Downloads Loom's public MP4, reuploads it to the configured Clips storage provider, and imports Loom's public transcript when available. If storage is not connected, creates a waiting recording that can be retried after storage setup.",
   schema: ImportLoomRecordingSchema,
   run: async (args) => {
     const shareUrl = normalizeLoomShareUrl(args.url);
@@ -127,63 +138,168 @@ export default defineAction({
 
     const db = getDb();
     const ownerEmail = getCurrentOwnerEmail();
+    let existingRecording: typeof schema.recordings.$inferSelect | null = null;
+    if (args.recordingId) {
+      [existingRecording] = await db
+        .select()
+        .from(schema.recordings)
+        .where(
+          and(
+            eq(schema.recordings.id, args.recordingId),
+            eq(schema.recordings.ownerEmail, ownerEmail),
+          ),
+        );
+      if (!existingRecording) {
+        throw new Error("Waiting Loom recording not found.");
+      }
+      if (existingRecording.sourceAppName?.trim().toLowerCase() !== "loom") {
+        throw new Error("Only Loom recordings can be retried this way.");
+      }
+    }
+
     const { organizationId } = await requireOrganizationAccess(
-      args.organizationId,
+      existingRecording?.organizationId ?? args.organizationId,
     );
 
     const oembed = await fetchLoomOembed(shareUrl);
     const media = await downloadLoomVideo({ loomId, shareUrl });
     const now = new Date().toISOString();
-    const id = nanoid();
+    const id = existingRecording?.id ?? nanoid();
     const upload = await uploadFile({
       data: media.bytes,
       filename: `${id}.mp4`,
       mimeType: media.mimeType,
       ownerEmail,
     });
+
+    const spaceIds = (
+      args.spaceIds ?? parseSpaceIds(existingRecording?.spaceIds)
+    ).filter((value, index, arr) => value && arr.indexOf(value) === index);
+    const title =
+      args.title?.trim() ||
+      (existingRecording?.title &&
+      existingRecording.title !== "Untitled recording"
+        ? existingRecording.title
+        : null) ||
+      oembed.title?.trim() ||
+      `Loom recording ${loomId.slice(0, 8)}`;
+    const durationMs = boundedDurationMs(oembed.duration);
+    const width = boundedDimension(oembed.width ?? oembed.thumbnail_width);
+    const height = boundedDimension(oembed.height ?? oembed.thumbnail_height);
+    const folderId = args.folderId ?? existingRecording?.folderId ?? null;
+    const visibility =
+      args.visibility ?? existingRecording?.visibility ?? "public";
+    const titleSource = args.title
+      ? "manual"
+      : (existingRecording?.titleSource ?? "upload");
+
+    const recordingValues = {
+      organizationId,
+      orgId: organizationId,
+      folderId,
+      spaceIds: stringifySpaceIds(spaceIds),
+      title,
+      titleSource,
+      sourceAppName: "Loom",
+      sourceWindowTitle: shareUrl,
+      description: existingRecording?.description ?? "",
+      thumbnailUrl:
+        oembed.thumbnail_url ?? existingRecording?.thumbnailUrl ?? null,
+      durationMs,
+      videoFormat: "mp4" as const,
+      videoSizeBytes: media.sizeBytes,
+      width,
+      height,
+      hasAudio: true,
+      hasCamera: false,
+      uploadProgress: 100,
+      visibility,
+      updatedAt: now,
+    };
+
+    if (upload === null) {
+      if (existingRecording) {
+        await db
+          .update(schema.recordings)
+          .set({
+            ...recordingValues,
+            status: "uploading",
+            videoUrl: null,
+            failureReason: LOOM_STORAGE_SETUP_REQUIRED_REASON,
+          })
+          .where(eq(schema.recordings.id, id));
+      } else {
+        await db.insert(schema.recordings).values({
+          id,
+          ...recordingValues,
+          videoUrl: null,
+          status: "uploading",
+          failureReason: LOOM_STORAGE_SETUP_REQUIRED_REASON,
+          ownerEmail,
+          createdAt: now,
+        });
+      }
+
+      await writeAppState(`recording-upload-${id}`, {
+        recordingId: id,
+        status: "waiting_storage",
+        failureReason: LOOM_STORAGE_SETUP_REQUIRED_REASON,
+        progress: 100,
+        provider: "loom",
+        sourceUrl: shareUrl,
+        durationMs,
+        width,
+        height,
+        hasAudio: true,
+        hasCamera: false,
+        updatedAt: now,
+      });
+      await writeAppState("refresh-signal", { ts: Date.now() });
+      await writeAppState("navigate", { view: "recording", recordingId: id });
+
+      return {
+        recordingId: id,
+        title,
+        status: "waiting_storage" as const,
+        storageSetupRequired: true,
+        provider: "loom" as const,
+        sourceUrl: shareUrl,
+        thumbnailUrl: oembed.thumbnail_url ?? null,
+        durationMs,
+        importMode: "reuploaded" as const,
+        videoSizeBytes: media.sizeBytes,
+        note: LOOM_STORAGE_SETUP_REQUIRED_REASON,
+      };
+    }
+
     if (!upload?.url) {
       throw new Error(
-        "Video storage is not connected yet. Connect Builder.io or configure S3-compatible storage before importing Loom videos.",
+        "File upload returned no URL. Check your storage provider configuration.",
       );
     }
 
     const videoUrl = upload.url;
-    const spaceIds = (args.spaceIds ?? []).filter(
-      (value, index, arr) => value && arr.indexOf(value) === index,
-    );
-    const title =
-      args.title?.trim() ||
-      oembed.title?.trim() ||
-      `Loom recording ${loomId.slice(0, 8)}`;
-    const durationMs = boundedDurationMs(oembed.duration);
-
-    await db.insert(schema.recordings).values({
-      id,
-      organizationId,
-      orgId: organizationId,
-      folderId: args.folderId ?? null,
-      spaceIds: stringifySpaceIds(spaceIds),
-      title,
-      titleSource: args.title ? "manual" : "upload",
-      sourceAppName: "Loom",
-      sourceWindowTitle: shareUrl,
-      description: "",
-      thumbnailUrl: oembed.thumbnail_url ?? null,
-      durationMs,
-      videoUrl,
-      videoFormat: "mp4",
-      videoSizeBytes: media.sizeBytes,
-      width: boundedDimension(oembed.width ?? oembed.thumbnail_width),
-      height: boundedDimension(oembed.height ?? oembed.thumbnail_height),
-      hasAudio: true,
-      hasCamera: false,
-      status: "ready",
-      uploadProgress: 100,
-      visibility: args.visibility ?? "public",
-      ownerEmail,
-      createdAt: now,
-      updatedAt: now,
-    });
+    if (existingRecording) {
+      await db
+        .update(schema.recordings)
+        .set({
+          ...recordingValues,
+          videoUrl,
+          status: "ready",
+          failureReason: null,
+        })
+        .where(eq(schema.recordings.id, id));
+    } else {
+      await db.insert(schema.recordings).values({
+        id,
+        ...recordingValues,
+        videoUrl,
+        status: "ready",
+        failureReason: null,
+        ownerEmail,
+        createdAt: now,
+      });
+    }
     let transcript: Awaited<ReturnType<typeof fetchLoomTranscript>> = null;
     try {
       transcript = await fetchLoomTranscript({ shareUrl, durationMs });
@@ -194,17 +310,31 @@ export default defineAction({
       );
     }
 
-    await db.insert(schema.recordingTranscripts).values({
-      recordingId: id,
+    const transcriptValues = {
       ownerEmail,
       language: transcript?.language ?? "en",
       segmentsJson: transcript ? JSON.stringify(transcript.segments) : "[]",
       fullText: transcript?.fullText ?? "",
-      status: transcript ? "ready" : "failed",
+      status: transcript ? ("ready" as const) : ("failed" as const),
       failureReason: transcript ? null : loomTranscriptUnavailableMessage(),
-      createdAt: now,
       updatedAt: now,
-    });
+    };
+    const [existingTranscript] = await db
+      .select({ recordingId: schema.recordingTranscripts.recordingId })
+      .from(schema.recordingTranscripts)
+      .where(eq(schema.recordingTranscripts.recordingId, id));
+    if (existingTranscript) {
+      await db
+        .update(schema.recordingTranscripts)
+        .set(transcriptValues)
+        .where(eq(schema.recordingTranscripts.recordingId, id));
+    } else {
+      await db.insert(schema.recordingTranscripts).values({
+        recordingId: id,
+        ...transcriptValues,
+        createdAt: now,
+      });
+    }
 
     await writeAppState("refresh-signal", { ts: Date.now() });
     await writeAppState("navigate", { view: "recording", recordingId: id });

--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -1,6 +1,7 @@
 import { defineAction } from "@agent-native/core";
 import { writeAppState } from "@agent-native/core/application-state";
 import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
+import { uploadFile } from "@agent-native/core/file-upload";
 import { buildDeepLink } from "@agent-native/core/server";
 import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
@@ -10,17 +11,12 @@ import {
   requireOrganizationAccess,
   stringifySpaceIds,
 } from "../server/lib/recordings.js";
-import {
-  extractLoomEmbedUrlFromHtml,
-  extractLoomVideoId,
-  loomEmbedUrlForId,
-  normalizeLoomShareUrl,
-} from "@shared/loom.js";
+import { extractLoomVideoId, normalizeLoomShareUrl } from "@shared/loom.js";
 import {
   fetchLoomTranscript,
   loomTranscriptUnavailableMessage,
 } from "./lib/loom-transcript.js";
-import { localRecordingVideoRoute } from "../server/lib/player-video-url.js";
+import { downloadLoomVideo } from "./lib/loom-video.js";
 
 const LoomOembedSchema = z
   .object({
@@ -120,7 +116,7 @@ async function fetchLoomOembed(shareUrl: string) {
 
 export default defineAction({
   description:
-    "Import a public Loom share URL into Clips as a playable recording. Creates a ready recording that uses Loom's embedded player, thumbnail, title, duration metadata, and a public Loom transcript when available. Loom imports are embed-backed; upload the original video file instead when Clips-native editing or upload-based transcription is required.",
+    "Import a public Loom share URL into Clips as a playable recording. Downloads Loom's public MP4, reuploads it to the configured Clips storage provider, and imports Loom's public transcript when available.",
   schema: ImportLoomRecordingSchema,
   run: async (args) => {
     const shareUrl = normalizeLoomShareUrl(args.url);
@@ -129,17 +125,29 @@ export default defineAction({
       throw new Error("Paste a Loom share or embed URL.");
     }
 
-    const oembed = await fetchLoomOembed(shareUrl);
-    const embedUrl =
-      extractLoomEmbedUrlFromHtml(oembed.html) ?? loomEmbedUrlForId(loomId);
-    const now = new Date().toISOString();
-    const id = nanoid();
-    const videoUrl = localRecordingVideoRoute(id);
     const db = getDb();
     const ownerEmail = getCurrentOwnerEmail();
     const { organizationId } = await requireOrganizationAccess(
       args.organizationId,
     );
+
+    const oembed = await fetchLoomOembed(shareUrl);
+    const media = await downloadLoomVideo({ loomId, shareUrl });
+    const now = new Date().toISOString();
+    const id = nanoid();
+    const upload = await uploadFile({
+      data: media.bytes,
+      filename: `${id}.mp4`,
+      mimeType: media.mimeType,
+      ownerEmail,
+    });
+    if (!upload?.url) {
+      throw new Error(
+        "Video storage is not connected yet. Connect Builder.io or configure S3-compatible storage before importing Loom videos.",
+      );
+    }
+
+    const videoUrl = upload.url;
     const spaceIds = (args.spaceIds ?? []).filter(
       (value, index, arr) => value && arr.indexOf(value) === index,
     );
@@ -164,7 +172,7 @@ export default defineAction({
       durationMs,
       videoUrl,
       videoFormat: "mp4",
-      videoSizeBytes: 0,
+      videoSizeBytes: media.sizeBytes,
       width: boundedDimension(oembed.width ?? oembed.thumbnail_width),
       height: boundedDimension(oembed.height ?? oembed.thumbnail_height),
       hasAudio: true,
@@ -207,15 +215,19 @@ export default defineAction({
       status: "ready" as const,
       provider: "loom" as const,
       sourceUrl: shareUrl,
+      videoUrl,
       embedUrl: videoUrl,
       thumbnailUrl: oembed.thumbnail_url ?? null,
       durationMs,
       transcriptStatus: transcript
         ? ("ready" as const)
         : ("unavailable" as const),
+      importMode: "reuploaded" as const,
+      storageProvider: upload.provider,
+      videoSizeBytes: media.sizeBytes,
       note: transcript
-        ? "Imported as a Loom embed with Loom's public transcript. Upload the original video file when Clips-native editing or upload-based transcription is required."
-        : "Imported as a Loom embed. Loom did not expose an importable transcript; upload the original video file when Clips-native editing or transcription is required.",
+        ? "Imported as a Clips-hosted MP4 with Loom's public transcript."
+        : "Imported as a Clips-hosted MP4. Loom did not expose an importable transcript; use request-transcript to transcribe the uploaded media.",
     };
   },
   link: ({ result }) => {

--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -1,8 +1,14 @@
 import { defineAction } from "@agent-native/core";
 import { writeAppState } from "@agent-native/core/application-state";
 import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
-import { uploadFile } from "@agent-native/core/file-upload";
-import { buildDeepLink } from "@agent-native/core/server";
+import {
+  getActiveFileUploadProvider,
+  uploadFile,
+} from "@agent-native/core/file-upload";
+import {
+  buildDeepLink,
+  resolveBuilderPrivateKey,
+} from "@agent-native/core/server";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
@@ -77,6 +83,22 @@ const ImportLoomRecordingSchema = z.object({
 
 const LOOM_STORAGE_SETUP_REQUIRED_REASON =
   "Video storage is not connected yet. Connect Builder.io or configure S3-compatible storage, then retry this Loom import.";
+
+async function hasConfiguredUploadStorage(): Promise<boolean> {
+  const provider = getActiveFileUploadProvider();
+  if (!provider) return false;
+  if (provider.id !== "builder") return true;
+
+  try {
+    return Boolean(await resolveBuilderPrivateKey());
+  } catch (err) {
+    console.warn(
+      "[clips] Builder storage credential check failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return false;
+  }
+}
 
 function recordingDeepLink(recordingId: string): string {
   return buildDeepLink({
@@ -155,22 +177,29 @@ export default defineAction({
       if (existingRecording.sourceAppName?.trim().toLowerCase() !== "loom") {
         throw new Error("Only Loom recordings can be retried this way.");
       }
+      const existingSourceUrl = normalizeLoomShareUrl(
+        existingRecording.sourceWindowTitle ?? "",
+      );
+      const isWaitingStorageRetry =
+        existingRecording.status === "uploading" &&
+        !existingRecording.videoUrl &&
+        existingRecording.failureReason ===
+          LOOM_STORAGE_SETUP_REQUIRED_REASON &&
+        existingSourceUrl === shareUrl;
+      if (!isWaitingStorageRetry) {
+        throw new Error(
+          "Only a waiting-storage Loom import can be retried in place.",
+        );
+      }
     }
 
     const { organizationId } = await requireOrganizationAccess(
       existingRecording?.organizationId ?? args.organizationId,
     );
 
-    const oembed = await fetchLoomOembed(shareUrl);
-    const media = await downloadLoomVideo({ loomId, shareUrl });
     const now = new Date().toISOString();
     const id = existingRecording?.id ?? nanoid();
-    const upload = await uploadFile({
-      data: media.bytes,
-      filename: `${id}.mp4`,
-      mimeType: media.mimeType,
-      ownerEmail,
-    });
+    const oembed = await fetchLoomOembed(shareUrl);
 
     const spaceIds = (
       args.spaceIds ?? parseSpaceIds(existingRecording?.spaceIds)
@@ -193,7 +222,7 @@ export default defineAction({
       ? "manual"
       : (existingRecording?.titleSource ?? "upload");
 
-    const recordingValues = {
+    const buildRecordingValues = (videoSizeBytes: number) => ({
       organizationId,
       orgId: organizationId,
       folderId,
@@ -207,7 +236,7 @@ export default defineAction({
         oembed.thumbnail_url ?? existingRecording?.thumbnailUrl ?? null,
       durationMs,
       videoFormat: "mp4" as const,
-      videoSizeBytes: media.sizeBytes,
+      videoSizeBytes,
       width,
       height,
       hasAudio: true,
@@ -215,9 +244,10 @@ export default defineAction({
       uploadProgress: 100,
       visibility,
       updatedAt: now,
-    };
+    });
 
-    if (upload === null) {
+    const saveWaitingForStorage = async (videoSizeBytes: number) => {
+      const recordingValues = buildRecordingValues(videoSizeBytes);
       if (existingRecording) {
         await db
           .update(schema.recordings)
@@ -267,9 +297,28 @@ export default defineAction({
         thumbnailUrl: oembed.thumbnail_url ?? null,
         durationMs,
         importMode: "reuploaded" as const,
-        videoSizeBytes: media.sizeBytes,
+        videoSizeBytes,
         note: LOOM_STORAGE_SETUP_REQUIRED_REASON,
       };
+    };
+
+    if (!(await hasConfiguredUploadStorage())) {
+      return await saveWaitingForStorage(
+        existingRecording?.videoSizeBytes ?? 0,
+      );
+    }
+
+    const media = await downloadLoomVideo({ loomId, shareUrl });
+    const upload = await uploadFile({
+      data: media.bytes,
+      filename: `${id}.mp4`,
+      mimeType: media.mimeType,
+      ownerEmail,
+    });
+
+    const recordingValues = buildRecordingValues(media.sizeBytes);
+    if (upload === null) {
+      return await saveWaitingForStorage(media.sizeBytes);
     }
 
     if (!upload?.url) {

--- a/templates/clips/actions/lib/loom-video.test.ts
+++ b/templates/clips/actions/lib/loom-video.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_UPLOAD_BYTES } from "@shared/upload-limits.js";
+
+const mockSsrfSafeFetch = vi.fn();
+
+vi.mock("@agent-native/core/extensions/url-safety", () => ({
+  ssrfSafeFetch: (...args: unknown[]) => mockSsrfSafeFetch(...args),
+}));
+
+import { downloadLoomVideo } from "./loom-video";
+
+describe("downloadLoomVideo", () => {
+  beforeEach(() => {
+    mockSsrfSafeFetch.mockReset();
+  });
+
+  it("fetches Loom's signed MP4 URL and downloads bounded bytes", async () => {
+    mockSsrfSafeFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            url: "https://cdn.loom.com/sessions/transcoded/video-id.mp4?Policy=signed",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: {
+            "content-length": "3",
+            "content-type": "video/mp4",
+          },
+        }),
+      );
+
+    const result = await downloadLoomVideo({
+      loomId: "abcDEF_123456",
+      shareUrl: "https://www.loom.com/share/abcDEF_123456",
+    });
+
+    expect(result).toMatchObject({
+      mimeType: "video/mp4",
+      sizeBytes: 3,
+      sourceUrl:
+        "https://cdn.loom.com/sessions/transcoded/video-id.mp4?Policy=signed",
+    });
+    expect([...result.bytes]).toEqual([1, 2, 3]);
+    expect(mockSsrfSafeFetch).toHaveBeenNthCalledWith(
+      1,
+      "https://www.loom.com/api/campaigns/sessions/abcDEF_123456/transcoded-url",
+      expect.objectContaining({ method: "POST" }),
+      { maxRedirects: 2 },
+    );
+  });
+
+  it("rejects non-Loom download hosts", async () => {
+    mockSsrfSafeFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ url: "https://example.com/video.mp4" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(
+      downloadLoomVideo({
+        loomId: "abcDEF_123456",
+        shareUrl: "https://www.loom.com/share/abcDEF_123456",
+      }),
+    ).rejects.toThrow(/cannot import safely/i);
+  });
+
+  it("rejects videos larger than the Clips upload limit", async () => {
+    mockSsrfSafeFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            url: "https://cdn.loom.com/sessions/transcoded/video-id.mp4",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array(), {
+          status: 200,
+          headers: {
+            "content-length": String(MAX_UPLOAD_BYTES + 1),
+            "content-type": "video/mp4",
+          },
+        }),
+      );
+
+    await expect(
+      downloadLoomVideo({
+        loomId: "abcDEF_123456",
+        shareUrl: "https://www.loom.com/share/abcDEF_123456",
+      }),
+    ).rejects.toThrow(/too large/i);
+  });
+});

--- a/templates/clips/actions/lib/loom-video.ts
+++ b/templates/clips/actions/lib/loom-video.ts
@@ -1,0 +1,189 @@
+import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
+import { MAX_UPLOAD_BYTES } from "@shared/upload-limits.js";
+import { z } from "zod";
+
+const LOOM_DOWNLOAD_TIMEOUT_MS = 120_000;
+const LOOM_VIDEO_USER_AGENT =
+  "Mozilla/5.0 (compatible; AgentNativeClips/1.0; +https://agent-native.com)";
+
+const LoomTranscodedUrlSchema = z.object({
+  url: z.string().url(),
+});
+
+export type LoomVideoDownload = {
+  bytes: Uint8Array;
+  mimeType: string;
+  sizeBytes: number;
+  sourceUrl: string;
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${bytes} bytes`;
+}
+
+function assertUploadSize(sizeBytes: number | null | undefined): void {
+  if (!Number.isFinite(sizeBytes ?? NaN) || (sizeBytes ?? 0) <= 0) return;
+  if ((sizeBytes ?? 0) > MAX_UPLOAD_BYTES) {
+    throw new Error(
+      `Loom video is too large to import (${formatBytes(sizeBytes ?? 0)}, max ${formatBytes(MAX_UPLOAD_BYTES)}). Download a shorter or compressed copy and upload it directly.`,
+    );
+  }
+}
+
+function parseContentLength(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : null;
+}
+
+function safeLoomDownloadUrl(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "https:") return null;
+    if (parsed.hostname !== "cdn.loom.com") return null;
+    if (!parsed.pathname.startsWith("/sessions/transcoded/")) return null;
+    if (!parsed.pathname.endsWith(".mp4")) return null;
+    return parsed.href;
+  } catch {
+    return null;
+  }
+}
+
+async function readResponseBytesWithLimit(
+  response: Response,
+): Promise<Uint8Array> {
+  const contentLength = parseContentLength(
+    response.headers.get("content-length"),
+  );
+  assertUploadSize(contentLength);
+
+  if (!response.body) {
+    const arrayBuffer = await response.arrayBuffer();
+    assertUploadSize(arrayBuffer.byteLength);
+    return new Uint8Array(arrayBuffer);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      totalBytes += value.byteLength;
+      assertUploadSize(totalBytes);
+      chunks.push(
+        Buffer.from(value.buffer, value.byteOffset, value.byteLength),
+      );
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const buffer = Buffer.concat(chunks, totalBytes);
+  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+}
+
+function normalizeVideoMimeType(value: string | null): string {
+  const mimeType = (value ?? "").split(";")[0]?.trim().toLowerCase() ?? "";
+  if (!mimeType || mimeType === "application/octet-stream") return "video/mp4";
+  if (mimeType !== "video/mp4") {
+    throw new Error(
+      `Loom returned ${mimeType || "unknown"} instead of MP4 video.`,
+    );
+  }
+  return "video/mp4";
+}
+
+async function fetchTranscodedVideoUrl({
+  loomId,
+  shareUrl,
+}: {
+  loomId: string;
+  shareUrl: string;
+}): Promise<string> {
+  const endpoint = `https://www.loom.com/api/campaigns/sessions/${encodeURIComponent(
+    loomId,
+  )}/transcoded-url`;
+  const response = await ssrfSafeFetch(
+    endpoint,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Origin: "https://www.loom.com",
+        Referer: shareUrl,
+        "User-Agent": LOOM_VIDEO_USER_AGENT,
+        "X-Loom-Request-Source": "loom_web",
+      },
+      signal: AbortSignal.timeout(15_000),
+    },
+    { maxRedirects: 2 },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Loom did not provide a downloadable MP4 (${response.status} ${response.statusText}). Make sure the link is public and allows playback.`,
+    );
+  }
+
+  const parsed = LoomTranscodedUrlSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error("Loom returned an unexpected video download response.");
+  }
+
+  const sourceUrl = safeLoomDownloadUrl(parsed.data.url);
+  if (!sourceUrl) {
+    throw new Error(
+      "Loom returned a video URL that Clips cannot import safely.",
+    );
+  }
+  return sourceUrl;
+}
+
+export async function downloadLoomVideo({
+  loomId,
+  shareUrl,
+}: {
+  loomId: string;
+  shareUrl: string;
+}): Promise<LoomVideoDownload> {
+  const sourceUrl = await fetchTranscodedVideoUrl({ loomId, shareUrl });
+  const response = await ssrfSafeFetch(
+    sourceUrl,
+    {
+      headers: {
+        Accept: "video/mp4,video/*;q=0.9,*/*;q=0.1",
+        "User-Agent": LOOM_VIDEO_USER_AGENT,
+      },
+      signal: AbortSignal.timeout(LOOM_DOWNLOAD_TIMEOUT_MS),
+    },
+    { maxRedirects: 3 },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Loom video download failed (${response.status} ${response.statusText}).`,
+    );
+  }
+
+  const mimeType = normalizeVideoMimeType(response.headers.get("content-type"));
+  const bytes = await readResponseBytesWithLimit(response);
+  if (bytes.byteLength <= 0) {
+    throw new Error("Loom returned an empty video file.");
+  }
+  return {
+    bytes,
+    mimeType,
+    sizeBytes: bytes.byteLength,
+    sourceUrl,
+  };
+}

--- a/templates/clips/actions/lib/native-media.ts
+++ b/templates/clips/actions/lib/native-media.ts
@@ -1,4 +1,4 @@
-import { isLoomRecordingSource } from "../../shared/loom.js";
+import { isLoomEmbedBackedRecording } from "../../shared/loom.js";
 
 type RecordingMediaLike = {
   sourceAppName?: string | null;
@@ -6,10 +6,10 @@ type RecordingMediaLike = {
 };
 
 const LOOM_NATIVE_MEDIA_MESSAGE =
-  "This action requires a native Clips video. Loom imports are embed-backed; upload the original video file to use native editing, frame extraction, stitching, or upload-based transcription.";
+  "This action requires a Clips-hosted video. This Loom import is embed-backed; reimport it so Clips can store the video file before using native editing, frame extraction, stitching, or upload-based transcription.";
 
 export function isLoomRecording(recording: RecordingMediaLike): boolean {
-  return isLoomRecordingSource(recording);
+  return isLoomEmbedBackedRecording(recording);
 }
 
 export function assertNativeRecordingMedia(

--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -439,16 +439,13 @@ function EmptyCommentsState({
     );
   }
 
-  if (!isSharePresentation) {
-    return (
-      <div className="p-6 text-center text-sm text-muted-foreground">
-        No comments yet. Add one at the current timestamp.
-      </div>
-    );
-  }
-
   return (
-    <div className="flex flex-1 flex-col items-center justify-center px-8 py-12 text-center">
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center px-8 py-12 text-center",
+        isSharePresentation ? "flex-1" : "min-h-full",
+      )}
+    >
       <div className="relative mb-5 flex size-16 items-center justify-center text-muted-foreground/40">
         <IconMessageCircle className="size-16 stroke-[1.35]" />
         <span className="absolute -right-1 top-1 flex size-7 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-sm">
@@ -459,7 +456,9 @@ function EmptyCommentsState({
         Be the first to comment
       </p>
       <p className="mt-2 max-w-[240px] text-sm leading-5 text-muted-foreground">
-        Leave a note at the top of this panel.
+        {isSharePresentation
+          ? "Leave a note at the top of this panel."
+          : "Leave a note at the current timestamp."}
       </p>
     </div>
   );

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -46,7 +46,11 @@ import {
 function resolveLocalUrl(url: string | null | undefined): string | undefined {
   if (!url) return undefined;
   if (url.startsWith("/") && !url.startsWith("//")) {
-    return `${appBasePath()}${url}`;
+    const basePath = appBasePath();
+    if (basePath && (url === basePath || url.startsWith(`${basePath}/`))) {
+      return url;
+    }
+    return `${basePath}${url}`;
   }
   return url;
 }

--- a/templates/clips/app/routes/embed.$shareId.tsx
+++ b/templates/clips/app/routes/embed.$shareId.tsx
@@ -10,7 +10,7 @@ import { AccessPasswordPrompt } from "@/components/player/access-password-prompt
 import { Spinner } from "@/components/ui/spinner";
 import { useViewTracking } from "@/hooks/use-view-tracking";
 import { parsePlaybackSpeed } from "@/lib/playback-speed";
-import { isLoomRecordingSource } from "../../shared/loom";
+import { isLoomEmbedBackedRecording } from "../../shared/loom";
 
 export function meta() {
   return [{ title: "Clip" }];
@@ -96,7 +96,7 @@ export default function EmbedRoute() {
   const chapters = dataQ.data?.data?.chapters ?? [];
   const ctas = dataQ.data?.data?.ctas ?? [];
   const firstCta = ctas[0] ?? null;
-  const isLoomRecording = isLoomRecordingSource(recording);
+  const isLoomEmbedBacked = isLoomEmbedBackedRecording(recording);
 
   const tracking = useViewTracking({
     recordingId: shareId ?? "",
@@ -106,7 +106,7 @@ export default function EmbedRoute() {
       },
     } as any,
     durationMs: recording?.durationMs ?? 0,
-    trackOpenWithoutVideo: isLoomRecording,
+    trackOpenWithoutVideo: isLoomEmbedBacked,
   });
 
   const needsPassword =
@@ -162,7 +162,7 @@ export default function EmbedRoute() {
         ref={playerRef}
         recordingId={recording.id}
         videoUrl={recording.videoUrl}
-        embedProvider={isLoomRecording ? "loom" : null}
+        embedProvider={isLoomEmbedBacked ? "loom" : null}
         durationMs={recording.durationMs}
         editsJson={recording.editsJson}
         thumbnailUrl={recording.thumbnailUrl}

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -47,7 +47,7 @@ import { usePlayerShortcuts } from "@/hooks/use-player-shortcuts";
 import { useViewTracking } from "@/hooks/use-view-tracking";
 import { parsePlaybackSpeed } from "@/lib/playback-speed";
 import { isStorageSetupFailureReason } from "@/lib/storage-failures";
-import { isLoomRecordingSource } from "@shared/loom";
+import { isLoomEmbedBackedRecording } from "@shared/loom";
 
 export function meta() {
   return [{ title: "Clip recording · Clips" }];
@@ -200,8 +200,8 @@ export default function RecordingPage() {
     : "Untitled Clip";
 
   const canEdit = role === "owner" || role === "admin" || role === "editor";
-  const isLoomRecording = isLoomRecordingSource(recording);
-  const canUseNativeEditor = canEdit && !isLoomRecording;
+  const isLoomEmbedBacked = isLoomEmbedBackedRecording(recording);
+  const canUseNativeEditor = canEdit && !isLoomEmbedBacked;
   const canDelete = role === "owner";
   const retryFinalizeAfterStorage = useCallback(async () => {
     if (!recordingId) return;
@@ -678,7 +678,7 @@ export default function RecordingPage() {
             recordingTitle={recording.title}
             videoUrl={recording.videoUrl}
             animatedThumbnailUrl={recording.animatedThumbnailUrl}
-            isLoomRecording={isLoomRecording}
+            isLoomRecording={isLoomEmbedBacked}
             hasPassword={Boolean(recording.hasPassword)}
           >
             <Button
@@ -713,7 +713,7 @@ export default function RecordingPage() {
                   ref={playerRef}
                   recordingId={recording.id}
                   videoUrl={recording.videoUrl}
-                  embedProvider={isLoomRecording ? "loom" : null}
+                  embedProvider={isLoomEmbedBacked ? "loom" : null}
                   durationMs={recording.durationMs}
                   editsJson={recording.editsJson}
                   thumbnailUrl={recording.thumbnailUrl}

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -47,7 +47,10 @@ import { usePlayerShortcuts } from "@/hooks/use-player-shortcuts";
 import { useViewTracking } from "@/hooks/use-view-tracking";
 import { parsePlaybackSpeed } from "@/lib/playback-speed";
 import { isStorageSetupFailureReason } from "@/lib/storage-failures";
-import { isLoomEmbedBackedRecording } from "@shared/loom";
+import {
+  isLoomEmbedBackedRecording,
+  isLoomRecordingSource,
+} from "@shared/loom";
 
 export function meta() {
   return [{ title: "Clip recording · Clips" }];
@@ -201,6 +204,7 @@ export default function RecordingPage() {
 
   const canEdit = role === "owner" || role === "admin" || role === "editor";
   const isLoomEmbedBacked = isLoomEmbedBackedRecording(recording);
+  const isLoomRecording = isLoomRecordingSource(recording);
   const canUseNativeEditor = canEdit && !isLoomEmbedBacked;
   const canDelete = role === "owner";
   const retryFinalizeAfterStorage = useCallback(async () => {
@@ -208,14 +212,25 @@ export default function RecordingPage() {
     setRetryingFinalize(true);
     setProcessingTimeout(false);
     try {
-      const res = await fetch(
-        agentNativePath("/_agent-native/actions/finalize-recording"),
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ id: recordingId }),
-        },
-      );
+      const retryingLoomImport = isLoomRecording;
+      const actionPath = retryingLoomImport
+        ? "/_agent-native/actions/import-loom-recording"
+        : "/_agent-native/actions/finalize-recording";
+      if (retryingLoomImport && !recording?.sourceWindowTitle) {
+        throw new Error("This Loom recording is missing its source URL.");
+      }
+      const res = await fetch(agentNativePath(actionPath), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          retryingLoomImport
+            ? {
+                recordingId,
+                url: recording?.sourceWindowTitle,
+              }
+            : { id: recordingId },
+        ),
+      });
       const body = (await res.json().catch(() => null)) as {
         error?: string;
         result?: { status?: string; storageSetupRequired?: boolean };
@@ -236,19 +251,26 @@ export default function RecordingPage() {
         });
         return;
       }
-      toast.success("Clip upload resumed");
+      toast.success(
+        retryingLoomImport ? "Loom import resumed" : "Clip upload resumed",
+      );
       await playerDataQ.refetch();
     } catch (err) {
-      toast.error("Couldn't resume upload", {
-        description:
-          err instanceof Error ? err.message : "Try again in a moment.",
-        duration: 12_000,
-      });
+      toast.error(
+        isLoomRecording
+          ? "Couldn't retry Loom import"
+          : "Couldn't resume upload",
+        {
+          description:
+            err instanceof Error ? err.message : "Try again in a moment.",
+          duration: 12_000,
+        },
+      );
     } finally {
       setRetryingFinalize(false);
       void playerDataQ.refetch();
     }
-  }, [playerDataQ, recordingId]);
+  }, [isLoomRecording, playerDataQ, recording?.sourceWindowTitle, recordingId]);
   const firstCta = ctas[0] ?? null;
   const handleAiError = (err: Error) =>
     toast.error(err?.message ?? "AI request failed");
@@ -410,6 +432,7 @@ export default function RecordingPage() {
     const rawFailureReason =
       ((recording as any).failureReason as string | null | undefined) ?? null;
     const waitingForStorage = isStorageSetupFailureReason(rawFailureReason);
+    const loomStorageSetupFailure = waitingForStorage && isLoomRecording;
     const nativeSaveFailed =
       searchParams.get("saveFailed") === "1" ||
       isNativeSaveFailureReason(rawFailureReason);
@@ -428,14 +451,18 @@ export default function RecordingPage() {
           : "Uploading and assembling your video — this usually takes just a few seconds.";
     const storageSetupFailure = waitingForStorage;
     const label = storageSetupFailure
-      ? "Connect storage to finish saving this clip."
+      ? loomStorageSetupFailure
+        ? "Connect storage to import this Loom."
+        : "Connect storage to finish saving this clip."
       : nativeSaveFailed
         ? "Upload paused; clip saved locally."
         : isFailure
           ? "Something went wrong while saving this clip."
           : "Finishing up your clip…";
     const failureReason = storageSetupFailure
-      ? "Your clip data is still preserved. Connect Builder.io or S3 storage and Clips will upload it automatically."
+      ? loomStorageSetupFailure
+        ? "The Loom source link is preserved. Connect Builder.io or S3 storage and Clips will retry saving its own copy."
+        : "Your clip data is still preserved. Connect Builder.io or S3 storage and Clips will upload it automatically."
       : displayReason;
     const detail = failureDetail(rawFailureReason);
     return (
@@ -478,16 +505,34 @@ export default function RecordingPage() {
             {retryingFinalize ? (
               <div className="mx-auto flex w-full max-w-md flex-col items-center gap-3 rounded-2xl border border-border bg-card p-6 shadow-lg">
                 <Spinner className="h-8 w-8 text-muted-foreground" />
-                <div className="text-sm font-medium">Uploading saved clip…</div>
+                <div className="text-sm font-medium">
+                  {loomStorageSetupFailure
+                    ? "Importing Loom..."
+                    : "Uploading saved clip…"}
+                </div>
                 <p className="text-sm text-muted-foreground">
-                  Storage is connected. Clips is finishing the upload now.
+                  {loomStorageSetupFailure
+                    ? "Storage is connected. Clips is saving its own copy now."
+                    : "Storage is connected. Clips is finishing the upload now."}
                 </p>
               </div>
             ) : (
               <StorageSetupCard
-                title="Connect storage to finish saving"
-                description="Choose where Clips should store videos. After it connects, this saved clip will upload automatically."
-                connectedDescription="Storage connected. Uploading this clip..."
+                title={
+                  loomStorageSetupFailure
+                    ? "Connect storage to import Loom"
+                    : "Connect storage to finish saving"
+                }
+                description={
+                  loomStorageSetupFailure
+                    ? "Choose where Clips should store videos. After it connects, Clips will retry this Loom import."
+                    : "Choose where Clips should store videos. After it connects, this saved clip will upload automatically."
+                }
+                connectedDescription={
+                  loomStorageSetupFailure
+                    ? "Storage connected. Importing Loom..."
+                    : "Storage connected. Uploading this clip..."
+                }
                 onConfigured={retryFinalizeAfterStorage}
               />
             )}
@@ -507,7 +552,11 @@ export default function RecordingPage() {
             size="sm"
             disabled={retryingFinalize}
           >
-            {storageSetupFailure ? "Retry upload" : "Check again"}
+            {storageSetupFailure
+              ? loomStorageSetupFailure
+                ? "Retry import"
+                : "Retry upload"
+              : "Check again"}
           </Button>
           <Button onClick={() => navigate("/")} variant="ghost" size="sm">
             Back to library

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -1410,13 +1410,28 @@ export default function RecordRoute() {
             spaceIds: spaceIdFromUrl ? [spaceIdFromUrl] : undefined,
             folderId: folderIdFromUrl ?? undefined,
           } as any,
-        )) as { recordingId?: string };
+        )) as {
+          recordingId?: string;
+          status?: string;
+          storageSetupRequired?: boolean;
+        };
         const recordingId = result?.recordingId;
         if (!recordingId) {
           throw new Error("Loom import did not return a recording id.");
         }
 
-        toast.success("Loom imported");
+        if (
+          result?.storageSetupRequired ||
+          result?.status === "waiting_storage"
+        ) {
+          toast.info("Storage needed to finish Loom import", {
+            description:
+              "Connect Builder.io or S3 storage on the next screen and Clips will retry the import.",
+            duration: 12_000,
+          });
+        } else {
+          toast.success("Loom imported");
+        }
         await writeAppState("navigate", {
           view: "recording",
           recordingId,

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -47,12 +47,6 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { isDefaultTitle } from "@/hooks/use-auto-title";
 import { getDb, schema } from "../../server/db";
 import {
@@ -922,70 +916,60 @@ function PublicAgentEmptyState() {
         : "Download desktop app";
 
   return (
-    <TooltipProvider delayDuration={150}>
-      <div className="flex h-full flex-col items-center justify-center px-8 py-12 text-center">
-        <div className="mb-6 flex flex-col items-center gap-3">
-          <img
-            src={appPath("/agent-native-icon-light.svg")}
-            alt="Agent-Native"
-            className="block h-8 w-auto dark:hidden"
-          />
-          <img
-            src={appPath("/agent-native-icon-dark.svg")}
-            alt="Agent-Native"
-            className="hidden h-8 w-auto dark:block"
-          />
-        </div>
-        <p className="max-w-[280px] text-sm leading-6 text-muted-foreground">
-          <a
-            href={CLIPS_TEMPLATE_URL}
-            target="_blank"
-            rel="noreferrer"
-            className="font-medium text-foreground underline decoration-border underline-offset-4 hover:decoration-foreground"
-          >
-            Agent-Native Clips
-          </a>{" "}
-          is a free,{" "}
-          <a
-            href={CLIPS_SOURCE_URL}
-            target="_blank"
-            rel="noreferrer"
-            className="font-medium text-foreground underline decoration-border underline-offset-4 hover:decoration-foreground"
-          >
-            open-source
-          </a>
-          ,{" "}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <a
-                href={CLIPS_AGENT_DOCS_URL}
-                target="_blank"
-                rel="noreferrer"
-                className="font-medium text-foreground underline decoration-border underline-offset-4 hover:decoration-foreground"
-              >
-                agent-friendly
-              </a>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-[260px] text-left text-xs leading-5">
-              Paste a Clips link into an agent and it can see timestamped
-              screenshots, hear the transcript, and fetch the context it needs.
-            </TooltipContent>
-          </Tooltip>{" "}
-          Loom alternative
-        </p>
-        <div className="mt-7 flex w-full max-w-[220px] flex-col gap-2">
-          <Button asChild className="w-full gap-2">
-            <a href={appPath("/download")}>
-              <IconDownload className="h-4 w-4" />
-              {downloadLabel}
-            </a>
-          </Button>
-          <Button asChild variant="outline" className="w-full">
-            <a href={appPath("/signup")}>Sign up</a>
-          </Button>
-        </div>
+    <div className="flex h-full flex-col items-center justify-center px-8 py-12 text-center">
+      <div className="mb-6 flex flex-col items-center gap-3">
+        <img
+          src={appPath("/agent-native-icon-light.svg")}
+          alt="Agent-Native"
+          className="block h-8 w-auto dark:hidden"
+        />
+        <img
+          src={appPath("/agent-native-icon-dark.svg")}
+          alt="Agent-Native"
+          className="hidden h-8 w-auto dark:block"
+        />
       </div>
-    </TooltipProvider>
+      <p className="max-w-[280px] text-sm leading-6 text-muted-foreground">
+        <a
+          href={CLIPS_TEMPLATE_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="font-medium text-foreground underline decoration-border underline-offset-4 hover:decoration-foreground"
+        >
+          Agent-Native Clips
+        </a>{" "}
+        is a free,{" "}
+        <a
+          href={CLIPS_SOURCE_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="font-medium text-foreground underline decoration-border underline-offset-4 hover:decoration-foreground"
+        >
+          open-source
+        </a>
+        ,{" "}
+        <a
+          href={CLIPS_AGENT_DOCS_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="font-medium text-foreground underline decoration-border underline-offset-4 hover:decoration-foreground"
+        >
+          agent-friendly
+        </a>{" "}
+        Loom alternative
+      </p>
+      <div className="mt-7 flex w-full max-w-[220px] flex-col gap-2">
+        <Button asChild className="w-full gap-2">
+          <a href={appPath("/download")}>
+            <IconDownload className="h-4 w-4" />
+            {downloadLabel}
+          </a>
+        </Button>
+        <Button asChild variant="outline" className="w-full">
+          <a href={appPath("/signup")}>Sign up</a>
+        </Button>
+      </div>
+    </div>
   );
 }
 

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -57,7 +57,10 @@ import { resolveAccess } from "@agent-native/core/sharing";
 import { parsePlaybackSpeed } from "@/lib/playback-speed";
 import { isStorageSetupFailureReason } from "@/lib/storage-failures";
 import { buildAgentApiUrls, safeJsonForHtml } from "../../shared/agent-context";
-import { isLoomEmbedBackedRecording } from "../../shared/loom";
+import {
+  isLoomEmbedBackedRecording,
+  isLoomRecordingSource,
+} from "../../shared/loom";
 
 type SharePageMetaRecording = {
   id: string;
@@ -517,6 +520,8 @@ export default function ShareRoute() {
     const rawFailureReason =
       ((recording as any).failureReason as string | null | undefined) ?? null;
     const storageSetupFailure = isStorageSetupFailureReason(rawFailureReason);
+    const loomStorageSetupFailure =
+      storageSetupFailure && isLoomRecordingSource(recording);
     const stuckFailure = !explicitFailure && processingTimeout;
     const isFailure = explicitFailure || storageSetupFailure || stuckFailure;
     const canManageStorage = viewerCanEdit;
@@ -531,7 +536,9 @@ export default function ShareRoute() {
           : "Finishing up this clip...";
     const message = storageSetupFailure
       ? canManageStorage
-        ? "The video is preserved. Connect Builder.io or S3 storage and Clips will finish uploading it."
+        ? loomStorageSetupFailure
+          ? "The Loom source link is preserved. Connect Builder.io or S3 storage, then retry the import."
+          : "The video is preserved. Connect Builder.io or S3 storage and Clips will finish uploading it."
         : session
           ? "The creator needs to connect Builder.io or S3 storage before this clip can finish."
           : "If this is your clip, sign in here to connect Builder.io or S3 storage and finish the upload."

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -11,6 +11,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   IconAlertTriangle,
   IconDownload,
+  IconDots,
   IconExternalLink,
   IconLogin2,
   IconShare3,
@@ -37,6 +38,12 @@ import { DeleteRecordingMenu } from "@/components/player/delete-recording-menu";
 import { usePlayerShortcuts } from "@/hooks/use-player-shortcuts";
 import { useViewTracking } from "@/hooks/use-view-tracking";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -56,7 +63,7 @@ import { resolveAccess } from "@agent-native/core/sharing";
 import { parsePlaybackSpeed } from "@/lib/playback-speed";
 import { isStorageSetupFailureReason } from "@/lib/storage-failures";
 import { buildAgentApiUrls, safeJsonForHtml } from "../../shared/agent-context";
-import { isLoomRecordingSource } from "../../shared/loom";
+import { isLoomEmbedBackedRecording } from "../../shared/loom";
 
 type SharePageMetaRecording = {
   id: string;
@@ -338,7 +345,7 @@ export default function ShareRoute() {
   const visibleTitle = recording
     ? displayRecordingTitle(recording.title)
     : "Untitled Clip";
-  const isLoomRecording = isLoomRecordingSource(recording);
+  const isLoomEmbedBacked = isLoomEmbedBackedRecording(recording);
   const unlockedAgentContextUrl =
     typeof dataQ.data?.data?.agentContextUrl === "string"
       ? dataQ.data.data.agentContextUrl
@@ -391,7 +398,7 @@ export default function ShareRoute() {
       },
     } as any,
     durationMs: recording?.durationMs ?? 0,
-    trackOpenWithoutVideo: isLoomRecording,
+    trackOpenWithoutVideo: isLoomEmbedBacked,
   });
 
   // If the backend returned 401 with passwordRequired, prompt.
@@ -624,6 +631,10 @@ export default function ShareRoute() {
     );
   }
 
+  const canDownloadRecording = Boolean(
+    recording.enableDownloads && recording.videoUrl && !isLoomEmbedBacked,
+  );
+
   return (
     <div className="flex min-h-screen flex-col bg-background text-foreground lg:h-screen lg:flex-row lg:overflow-hidden">
       {agentDiscovery}
@@ -659,6 +670,31 @@ export default function ShareRoute() {
                 </a>
               </Button>
             )}
+            {!viewerCanEdit && canDownloadRecording ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-9 w-9 shrink-0 px-0"
+                    aria-label="Clip options"
+                  >
+                    <IconDots className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-44">
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      void downloadRecording();
+                    }}
+                    disabled={downloading}
+                  >
+                    <IconDownload className="h-4 w-4" />
+                    {downloading ? "Downloading..." : "Download MP4"}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
             {viewerIsOwner ? (
               <DeleteRecordingMenu
                 recordingId={recording.id}
@@ -671,7 +707,7 @@ export default function ShareRoute() {
                 recordingTitle={recording.title}
                 videoUrl={recording.videoUrl}
                 animatedThumbnailUrl={recording.animatedThumbnailUrl}
-                isLoomRecording={isLoomRecording}
+                isLoomRecording={isLoomEmbedBacked}
                 hasPassword={Boolean(recording.hasPassword)}
               >
                 <Button size="sm" className="shrink-0 gap-1.5">
@@ -689,7 +725,7 @@ export default function ShareRoute() {
               ref={playerRef}
               recordingId={recording.id}
               videoUrl={recording.videoUrl}
-              embedProvider={isLoomRecording ? "loom" : null}
+              embedProvider={isLoomEmbedBacked ? "loom" : null}
               durationMs={recording.durationMs}
               editsJson={recording.editsJson}
               thumbnailUrl={recording.thumbnailUrl}
@@ -733,7 +769,7 @@ export default function ShareRoute() {
                       return;
                     }
                     tracking.reportReaction(emoji);
-                    const liveCt = isLoomRecording
+                    const liveCt = isLoomEmbedBacked
                       ? null
                       : playerRef.current?.video?.currentTime;
                     const liveMs =
@@ -762,9 +798,7 @@ export default function ShareRoute() {
                   }}
                 />
               ) : null}
-              {recording.enableDownloads &&
-              recording.videoUrl &&
-              !isLoomRecording ? (
+              {viewerCanEdit && canDownloadRecording ? (
                 <Button
                   variant="outline"
                   size="sm"

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -107,6 +107,102 @@ fn bubble_window_height_for(size: u32) -> u32 {
     size + BUBBLE_CONTROLS_BUDGET_PX
 }
 
+fn bubble_window_size_for(app: &AppHandle, size: u32) -> (u32, u32) {
+    let gutter = overlay_shadow_gutter_physical(app);
+    let content_h = bubble_window_height_for(size);
+    (size + gutter * 2, content_h + gutter * 2)
+}
+
+fn monitor_rects_for_bubble(app: &AppHandle) -> Vec<(i32, i32, u32, u32)> {
+    app.get_webview_window(BUBBLE_LABEL)
+        .or_else(|| app.get_webview_window("popover"))
+        .and_then(|window| window.available_monitors().ok())
+        .map(|monitors| {
+            monitors
+                .into_iter()
+                .map(|monitor| {
+                    let pos = monitor.position();
+                    let size = monitor.size();
+                    (pos.x, pos.y, size.width, size.height)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn distance_to_rect_squared(cx: i32, cy: i32, rect: (i32, i32, u32, u32)) -> i64 {
+    let (rx, ry, rw, rh) = rect;
+    let right = rx + rw as i32;
+    let bottom = ry + rh as i32;
+    let dx = i64::from(if cx < rx {
+        rx - cx
+    } else if cx > right {
+        cx - right
+    } else {
+        0
+    });
+    let dy = i64::from(if cy < ry {
+        ry - cy
+    } else if cy > bottom {
+        cy - bottom
+    } else {
+        0
+    });
+    dx * dx + dy * dy
+}
+
+fn bubble_target_monitor_rect(
+    app: &AppHandle,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+) -> (i32, i32, u32, u32) {
+    let cx = x + width as i32 / 2;
+    let cy = y + height as i32 / 2;
+    let rects = monitor_rects_for_bubble(app);
+
+    rects
+        .iter()
+        .copied()
+        .find(|(rx, ry, rw, rh)| {
+            cx >= *rx && cx < *rx + *rw as i32 && cy >= *ry && cy < *ry + *rh as i32
+        })
+        .or_else(|| {
+            rects
+                .iter()
+                .copied()
+                .min_by_key(|rect| distance_to_rect_squared(cx, cy, *rect))
+        })
+        .unwrap_or_else(|| tray_monitor_physical_rect(app))
+}
+
+fn clamp_bubble_window_position(
+    app: &AppHandle,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+) -> (i32, i32) {
+    let (mx, my, mw, mh) = bubble_target_monitor_rect(app, x, y, width, height);
+    let max_x = (mx + mw as i32 - width as i32).max(mx);
+    let max_y = (my + mh as i32 - height as i32).max(my);
+    (x.clamp(mx, max_x), y.clamp(my, max_y))
+}
+
+fn clamp_existing_bubble_window(app: &AppHandle, window: &WebviewWindow) {
+    let Ok(pos) = window.outer_position() else {
+        return;
+    };
+    let Ok(size) = window.outer_size() else {
+        return;
+    };
+    let (x, y) = clamp_bubble_window_position(app, pos.x, pos.y, size.width, size.height);
+    if x != pos.x || y != pos.y {
+        let _ = window.set_position(PhysicalPosition::new(x, y));
+    }
+}
+
 /// Path to the JSON blob that stores the last-known bubble position on disk.
 /// Lives in the Tauri app-data dir (platform-specific — `~/Library/Application
 /// Support/<bundle-id>/` on macOS). Returns None if the app-data dir cannot be
@@ -495,6 +591,7 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
     // macOS permission dialog that steals focus from the popover.
     mark_popover_shown(&app);
     if let Some(existing) = app.get_webview_window(BUBBLE_LABEL) {
+        clamp_existing_bubble_window(&app, &existing);
         let _ = existing.show();
         dlog!("[clips-tray] bubble reused");
         return Ok(());
@@ -505,10 +602,9 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
     let size: u32 = bubble_size_for_name(&size_name);
     // The actual window is TALLER than the circle — see
     // `BUBBLE_CONTROLS_BUDGET_PX` — to give the hover controls pill room.
-    let content_h: u32 = bubble_window_height_for(size);
     let gutter = overlay_shadow_gutter_physical(&app);
-    let win_w: u32 = size + gutter * 2;
-    let win_h: u32 = content_h + gutter * 2;
+    let content_h: u32 = bubble_window_height_for(size);
+    let (win_w, win_h) = bubble_window_size_for(&app, size);
 
     let (mon_x, mon_y, mon_w, mon_h) = tray_monitor_physical_rect(&app);
 
@@ -517,15 +613,19 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
     // physical-px offset maps to ~30 logical px.
     let default_x: i32 = mon_x + 48 - gutter as i32;
     let default_y: i32 = mon_y + mon_h as i32 - content_h as i32 - 60 - gutter as i32;
-    // Clamp bounds within the target monitor.
-    let max_x = (mon_x + mon_w as i32 - win_w as i32).max(mon_x);
-    let max_y = (mon_y + mon_h as i32 - win_h as i32).max(mon_y);
-    // Use the saved position only if it already falls on the target monitor.
-    // A position from a previous session on a different display would strand
-    // the bubble off-screen, so fall back to the default anchor instead.
+    let (default_x, default_y) =
+        clamp_bubble_window_position(&app, default_x, default_y, win_w, win_h);
+    // Keep saved positions, but normalize them against the current display
+    // layout and bubble size so a stale drag can never revive half off-screen.
     let (x, y, source) = match load_bubble_position(&app) {
-        Some((sx, sy)) if sx >= mon_x && sx <= max_x && sy >= mon_y && sy <= max_y => {
-            (sx, sy, "saved")
+        Some((sx, sy)) => {
+            let (cx, cy) = clamp_bubble_window_position(&app, sx, sy, win_w, win_h);
+            let source = if cx == sx && cy == sy {
+                "saved"
+            } else {
+                "saved-clamped"
+            };
+            (cx, cy, source)
         }
         _ => (default_x, default_y, "default"),
     };
@@ -560,6 +660,18 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
     })?;
     let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(win_w, win_h)));
     let _ = win.set_position(PhysicalPosition::new(x, y));
+    let app_for_bounds = app.clone();
+    let win_for_bounds = win.clone();
+    win.on_window_event(move |event| {
+        if matches!(
+            event,
+            tauri::WindowEvent::Moved(_)
+                | tauri::WindowEvent::Resized(_)
+                | tauri::WindowEvent::ScaleFactorChanged { .. }
+        ) {
+            clamp_existing_bubble_window(&app_for_bounds, &win_for_bounds);
+        }
+    });
     // NOTE: intentionally NOT calling `set_capture_excluded` on the bubble.
     // The bubble is the user's face — Loom's behavior is that the camera
     // PiP IS composited into the final recording (that's the whole point of
@@ -1302,7 +1414,7 @@ pub async fn reset_state(app: AppHandle) -> Result<(), String> {
 }
 
 /// Load the saved bubble size and return it to the frontend. Default is
-/// "medium". Exposed to JS via `invoke("load_bubble_size")`.
+/// "small". Exposed to JS via `invoke("load_bubble_size")`.
 #[tauri::command]
 pub async fn load_bubble_size(app: AppHandle) -> Result<String, String> {
     Ok(load_bubble_size_name(&app))
@@ -1310,7 +1422,7 @@ pub async fn load_bubble_size(app: AppHandle) -> Result<String, String> {
 
 /// Resize the bubble window to match the named size ("small" | "medium") and
 /// persist the choice. Clamps to valid names silently — unknown values fall
-/// back to medium so a typo in the frontend doesn't brick persistence.
+/// back to small so a typo in the frontend doesn't brick persistence.
 #[tauri::command]
 pub async fn set_bubble_size(app: AppHandle, size: String) -> Result<(), String> {
     let name = match size.as_str() {
@@ -1319,8 +1431,7 @@ pub async fn set_bubble_size(app: AppHandle, size: String) -> Result<(), String>
     };
     let px = bubble_size_for_name(name);
     let gutter = overlay_shadow_gutter_physical(&app);
-    let win_w = px + gutter * 2;
-    let win_h = bubble_window_height_for(px) + gutter * 2;
+    let (win_w, win_h) = bubble_window_size_for(&app, px);
     if let Some(win) = app.get_webview_window(BUBBLE_LABEL) {
         // Re-center the resize around the current circle's center so the
         // bubble visually grows / shrinks around its current spot instead of
@@ -1343,6 +1454,7 @@ pub async fn set_bubble_size(app: AppHandle, size: String) -> Result<(), String>
         let delta = (current_circle_size - new_px) / 2;
         let new_x = current_pos.0 + delta;
         let new_y = current_pos.1 + delta;
+        let (new_x, new_y) = clamp_bubble_window_position(&app, new_x, new_y, win_w, win_h);
         let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(win_w, win_h)));
         let _ = win.set_position(PhysicalPosition::new(new_x, new_y));
     }
@@ -1360,6 +1472,24 @@ pub async fn save_bubble_position(app: AppHandle, x: i32, y: i32) -> Result<(), 
         // treat this as a fatal error.
         eprintln!("[clips-tray] save_bubble_position: no app_data_dir, skipping");
         return Ok(());
+    };
+    let (x, y) = if let Some(win) = app.get_webview_window(BUBBLE_LABEL) {
+        let size = win.outer_size().ok().unwrap_or_else(|| {
+            let size_name = load_bubble_size_name(&app);
+            let px = bubble_size_for_name(&size_name);
+            let (width, height) = bubble_window_size_for(&app, px);
+            PhysicalSize::new(width, height)
+        });
+        let (cx, cy) = clamp_bubble_window_position(&app, x, y, size.width, size.height);
+        if cx != x || cy != y {
+            let _ = win.set_position(PhysicalPosition::new(cx, cy));
+        }
+        (cx, cy)
+    } else {
+        let size_name = load_bubble_size_name(&app);
+        let px = bubble_size_for_name(&size_name);
+        let (width, height) = bubble_window_size_for(&app, px);
+        clamp_bubble_window_position(&app, x, y, width, height)
     };
     let body = serde_json::to_vec(&serde_json::json!({ "x": x, "y": y }))
         .map_err(|e| format!("serialize: {e}"))?;

--- a/templates/clips/server/lib/player-video-url.test.ts
+++ b/templates/clips/server/lib/player-video-url.test.ts
@@ -18,12 +18,22 @@ describe("resolvePlayerVideoUrl", () => {
     ).toBe("/api/video/rec-1");
   });
 
-  it("keeps reuploaded Loom imports on their Clips-hosted media URL", () => {
+  it("keeps reuploaded Loom imports behind the same-origin video route", () => {
     expect(
       resolvePlayerVideoUrl({
         id: "rec-1",
         sourceAppName: "Loom",
         sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+        videoUrl: "https://cdn.example.com/reuploaded.mp4",
+      }),
+    ).toBe("/api/video/rec-1");
+  });
+
+  it("keeps non-Loom provider URLs direct", () => {
+    expect(
+      resolvePlayerVideoUrl({
+        id: "rec-1",
+        sourceAppName: "Screen Recorder",
         videoUrl: "https://cdn.example.com/reuploaded.mp4",
       }),
     ).toBe("https://cdn.example.com/reuploaded.mp4");
@@ -51,5 +61,18 @@ describe("resolvePlayerVideoUrl", () => {
         { addPasswordToken: true },
       ),
     ).toBe("https://cdn.example.com/clip.mp4");
+
+    expect(
+      resolvePlayerVideoUrl(
+        {
+          id: "rec-3",
+          password: "encrypted",
+          sourceAppName: "Loom",
+          sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+          videoUrl: "https://cdn.example.com/loom.mp4",
+        },
+        { addPasswordToken: true },
+      ),
+    ).toBe("/api/video/rec-3?t=signed-token");
   });
 });

--- a/templates/clips/server/lib/player-video-url.test.ts
+++ b/templates/clips/server/lib/player-video-url.test.ts
@@ -18,6 +18,17 @@ describe("resolvePlayerVideoUrl", () => {
     ).toBe("/api/video/rec-1");
   });
 
+  it("keeps reuploaded Loom imports on their Clips-hosted media URL", () => {
+    expect(
+      resolvePlayerVideoUrl({
+        id: "rec-1",
+        sourceAppName: "Loom",
+        sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+        videoUrl: "https://cdn.example.com/reuploaded.mp4",
+      }),
+    ).toBe("https://cdn.example.com/reuploaded.mp4");
+  });
+
   it("adds short-lived password tokens only to same-origin video routes", () => {
     expect(
       resolvePlayerVideoUrl(

--- a/templates/clips/server/lib/player-video-url.test.ts
+++ b/templates/clips/server/lib/player-video-url.test.ts
@@ -29,6 +29,20 @@ describe("resolvePlayerVideoUrl", () => {
     ).toBe("/api/video/rec-1?loomMedia=1");
   });
 
+  it("can app-prefix reuploaded Loom media routes once", () => {
+    expect(
+      resolvePlayerVideoUrl(
+        {
+          id: "rec-1",
+          sourceAppName: "Loom",
+          sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+          videoUrl: "https://cdn.example.com/reuploaded.mp4",
+        },
+        { appPath: (path) => `/clips${path}` },
+      ),
+    ).toBe("/clips/api/video/rec-1?loomMedia=1");
+  });
+
   it("keeps non-Loom provider URLs direct", () => {
     expect(
       resolvePlayerVideoUrl({

--- a/templates/clips/server/lib/player-video-url.test.ts
+++ b/templates/clips/server/lib/player-video-url.test.ts
@@ -26,7 +26,7 @@ describe("resolvePlayerVideoUrl", () => {
         sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
         videoUrl: "https://cdn.example.com/reuploaded.mp4",
       }),
-    ).toBe("/api/video/rec-1");
+    ).toBe("/api/video/rec-1?loomMedia=1");
   });
 
   it("keeps non-Loom provider URLs direct", () => {
@@ -73,6 +73,6 @@ describe("resolvePlayerVideoUrl", () => {
         },
         { addPasswordToken: true },
       ),
-    ).toBe("/api/video/rec-3?t=signed-token");
+    ).toBe("/api/video/rec-3?loomMedia=1&t=signed-token");
   });
 });

--- a/templates/clips/server/lib/player-video-url.ts
+++ b/templates/clips/server/lib/player-video-url.ts
@@ -1,5 +1,9 @@
 import { signShortLivedToken } from "@agent-native/core/server";
-import { isLoomRecordingSource } from "../../shared/loom.js";
+import {
+  LOOM_NATIVE_MEDIA_QUERY_PARAM,
+  isLoomEmbedBackedRecording,
+  isLoomRecordingSource,
+} from "../../shared/loom.js";
 
 type PlayerVideoRecording = {
   id: string;
@@ -13,6 +17,11 @@ export function localRecordingVideoRoute(recordingId: string): string {
   return `/api/video/${encodeURIComponent(recordingId)}`;
 }
 
+function appendQueryParam(url: string, key: string, value: string): string {
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+}
+
 export function resolvePlayerVideoUrl(
   recording: PlayerVideoRecording,
   options: {
@@ -23,8 +32,19 @@ export function resolvePlayerVideoUrl(
   let resolvedVideoUrl = recording.videoUrl ?? null;
   if (!resolvedVideoUrl) return null;
 
-  if (isLoomRecordingSource(recording)) {
+  const isLoomSource = isLoomRecordingSource(recording);
+  const isLoomNativeMedia =
+    isLoomSource && !isLoomEmbedBackedRecording(recording);
+
+  if (isLoomSource) {
     resolvedVideoUrl = localRecordingVideoRoute(recording.id);
+    if (isLoomNativeMedia) {
+      resolvedVideoUrl = appendQueryParam(
+        resolvedVideoUrl,
+        LOOM_NATIVE_MEDIA_QUERY_PARAM,
+        "1",
+      );
+    }
   } else {
     const legacyMatch = resolvedVideoUrl.match(
       /^\/api\/uploads\/([^/]+)\/blob$/,
@@ -40,8 +60,7 @@ export function resolvePlayerVideoUrl(
     resolvedVideoUrl.startsWith("/api/video/")
   ) {
     const token = signShortLivedToken({ resourceId: recording.id });
-    const sep = resolvedVideoUrl.includes("?") ? "&" : "?";
-    resolvedVideoUrl = `${resolvedVideoUrl}${sep}t=${encodeURIComponent(token)}`;
+    resolvedVideoUrl = appendQueryParam(resolvedVideoUrl, "t", token);
   }
 
   if (options.appPath && resolvedVideoUrl.startsWith("/")) {

--- a/templates/clips/server/lib/player-video-url.ts
+++ b/templates/clips/server/lib/player-video-url.ts
@@ -1,5 +1,5 @@
 import { signShortLivedToken } from "@agent-native/core/server";
-import { isLoomEmbedBackedRecording } from "../../shared/loom.js";
+import { isLoomRecordingSource } from "../../shared/loom.js";
 
 type PlayerVideoRecording = {
   id: string;
@@ -23,7 +23,7 @@ export function resolvePlayerVideoUrl(
   let resolvedVideoUrl = recording.videoUrl ?? null;
   if (!resolvedVideoUrl) return null;
 
-  if (isLoomEmbedBackedRecording(recording)) {
+  if (isLoomRecordingSource(recording)) {
     resolvedVideoUrl = localRecordingVideoRoute(recording.id);
   } else {
     const legacyMatch = resolvedVideoUrl.match(

--- a/templates/clips/server/lib/player-video-url.ts
+++ b/templates/clips/server/lib/player-video-url.ts
@@ -1,5 +1,5 @@
 import { signShortLivedToken } from "@agent-native/core/server";
-import { isLoomRecordingSource } from "../../shared/loom.js";
+import { isLoomEmbedBackedRecording } from "../../shared/loom.js";
 
 type PlayerVideoRecording = {
   id: string;
@@ -23,7 +23,7 @@ export function resolvePlayerVideoUrl(
   let resolvedVideoUrl = recording.videoUrl ?? null;
   if (!resolvedVideoUrl) return null;
 
-  if (isLoomRecordingSource(recording)) {
+  if (isLoomEmbedBackedRecording(recording)) {
     resolvedVideoUrl = localRecordingVideoRoute(recording.id);
   } else {
     const legacyMatch = resolvedVideoUrl.match(

--- a/templates/clips/server/lib/public-agent-context.test.ts
+++ b/templates/clips/server/lib/public-agent-context.test.ts
@@ -181,7 +181,7 @@ describe("loadRecordingMediaBytes", () => {
     ).rejects.toThrow(/too large/i);
   });
 
-  it("does not fetch bytes for Loom embed imports", async () => {
+  it("does not fetch bytes for legacy Loom embed imports", async () => {
     await expect(
       loadRecordingMediaBytes(
         makeRecording({
@@ -191,13 +191,13 @@ describe("loadRecordingMediaBytes", () => {
           videoFormat: "mp4",
         }) as any,
       ),
-    ).rejects.toThrow(/Loom embed/i);
+    ).rejects.toThrow(/legacy Loom embed/i);
     expect(mockSsrfSafeFetch).not.toHaveBeenCalled();
   });
 });
 
 describe("buildPublicAgentContext", () => {
-  it("omits frame APIs and recommended frames for Loom embed imports", () => {
+  it("omits frame APIs and recommended frames for legacy Loom embed imports", () => {
     const context = buildPublicAgentContext({
       event: {
         url: new URL(
@@ -229,5 +229,37 @@ describe("buildPublicAgentContext", () => {
     expect(context.instructions.join(" ")).toMatch(
       /frame extraction is not available/i,
     );
+  });
+
+  it("keeps frame APIs for reuploaded Loom source recordings", () => {
+    const context = buildPublicAgentContext({
+      event: {
+        url: new URL(
+          "https://clips.example.com/api/agent-context.json?id=rec-1",
+        ),
+        req: {
+          headers: new Headers(),
+        },
+      } as any,
+      access: {
+        recording: makeRecording({
+          sourceAppName: "Loom",
+          sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+          videoUrl: "https://cdn.example.com/reuploaded.mp4",
+          videoFormat: "mp4",
+          videoSizeBytes: 1024,
+        }) as any,
+        viewerIsOwner: false,
+        apiToken: "signed-token",
+      },
+      transcript: null,
+      agentSegments: [],
+      chapters: [{ startMs: 1000, title: "Chapter" }],
+      ctas: [],
+    });
+
+    expect(context.clip.sourceProvider).toBe("loom");
+    expect(context.apis).toHaveProperty("frame");
+    expect(context.recommendedFrames.length).toBeGreaterThan(0);
   });
 });

--- a/templates/clips/server/lib/public-agent-context.ts
+++ b/templates/clips/server/lib/public-agent-context.ts
@@ -17,7 +17,10 @@ import {
   normalizeTranscriptSegments,
   parseTranscriptSegments,
 } from "../../shared/transcript-segments.js";
-import { isLoomRecordingSource } from "../../shared/loom.js";
+import {
+  isLoomEmbedBackedRecording,
+  isLoomRecordingSource,
+} from "../../shared/loom.js";
 import { getDb, schema } from "../db/index.js";
 import { verifySharePassword } from "./share-password.js";
 
@@ -326,8 +329,9 @@ export function buildPublicAgentContext({
     token: access.apiToken,
   });
   const publicPageUrl = `${requestUrl.origin}${getServerAppBasePath()}/share/${encodeURIComponent(recording.id)}`;
-  const isLoomRecording = isLoomRecordingSource(recording);
-  const suggestedFrames = isLoomRecording
+  const isLoomSource = isLoomRecordingSource(recording);
+  const isLoomEmbedBacked = isLoomEmbedBackedRecording(recording);
+  const suggestedFrames = isLoomEmbedBacked
     ? []
     : buildRecommendedFrames({
         durationMs: recording.durationMs,
@@ -339,9 +343,9 @@ export function buildPublicAgentContext({
       }));
   const instructions = [
     "Use transcript.segments for timestamped spoken context.",
-    ...(isLoomRecording
+    ...(isLoomEmbedBacked
       ? [
-          "This clip is imported from Loom and uses Loom embedded playback; frame extraction is not available through Clips.",
+          "This clip is a legacy Loom embed import; frame extraction is not available through Clips until it is reimported as a Clips-hosted video.",
         ]
       : [
           "Use apis.frame.urlTemplate with atMs to fetch a JPEG frame when the spoken transcript references something visible on screen.",
@@ -358,7 +362,7 @@ export function buildPublicAgentContext({
       title: recording.title,
       description: recording.description,
       publicPageUrl,
-      sourceProvider: isLoomRecording ? "loom" : null,
+      sourceProvider: isLoomSource ? "loom" : null,
       thumbnailUrl: recording.thumbnailUrl,
       animatedThumbnailUrl: recording.animatedThumbnailUrl,
       durationMs: recording.durationMs,
@@ -376,7 +380,7 @@ export function buildPublicAgentContext({
     apis: {
       context: { method: "GET", url: api.contextUrl },
       transcript: { method: "GET", url: api.transcriptUrl },
-      ...(isLoomRecording
+      ...(isLoomEmbedBacked
         ? {}
         : {
             frame: {
@@ -425,9 +429,9 @@ export async function loadRecordingMediaBytes(
 ): Promise<{ bytes: Uint8Array; mimeType: string }> {
   const videoUrl = recording.videoUrl ?? "";
   if (!videoUrl) throw new Error("Recording has no videoUrl");
-  if (isLoomRecordingSource(recording)) {
+  if (isLoomEmbedBackedRecording(recording)) {
     throw new Error(
-      "Frame extraction is not available for Loom embed imports.",
+      "Frame extraction is not available for legacy Loom embed imports.",
     );
   }
   assertFrameMediaSize(recording.videoSizeBytes);

--- a/templates/clips/server/routes/api/agent-transcript.json.get.ts
+++ b/templates/clips/server/routes/api/agent-transcript.json.get.ts
@@ -19,7 +19,7 @@ import {
   loadPublicAgentAccess,
   queryString,
 } from "../../lib/public-agent-context.js";
-import { isLoomRecordingSource } from "../../../shared/loom.js";
+import { isLoomEmbedBackedRecording } from "../../../shared/loom.js";
 
 export default defineEventHandler(async (event: H3Event) => {
   applyAgentJsonHeaders(event);
@@ -46,7 +46,7 @@ export default defineEventHandler(async (event: H3Event) => {
     basePath: getServerAppBasePath(),
     token: accessResult.access.apiToken,
   });
-  const isLoomRecording = isLoomRecordingSource(recording);
+  const isLoomEmbedBacked = isLoomEmbedBackedRecording(recording);
 
   return {
     type: "agent-native.clip.transcript",
@@ -57,7 +57,7 @@ export default defineEventHandler(async (event: H3Event) => {
     },
     apis: {
       context: { method: "GET", url: api.contextUrl },
-      ...(isLoomRecording
+      ...(isLoomEmbedBacked
         ? {}
         : {
             frame: {

--- a/templates/clips/server/routes/api/public-recording.get.ts
+++ b/templates/clips/server/routes/api/public-recording.get.ts
@@ -145,10 +145,9 @@ export default defineEventHandler(async (event) => {
   // Normalize the player videoUrl:
   //   1. Rewrite the legacy `/api/uploads/:id/blob` shape to the current
   //      `/api/video/:id` endpoint so old rows keep playing after the move.
-  //   2. Keep legacy Loom embed imports behind the same-origin
-  //      `/api/video/:id` access gate instead of returning the underlying
-  //      public Loom embed URL. New Loom imports are reuploaded and keep their
-  //      provider URL.
+  //   2. Keep all Loom imports behind the same-origin `/api/video/:id` access
+  //      gate. Legacy Loom rows render an iframe inside that route; reuploaded
+  //      Loom rows proxy their stored provider URL from the server.
   //   3. For password-protected recordings, mint a short-lived HMAC token
   //      bound to this recording id and pass it via `?t=<token>` instead of
   //      the plaintext password. Sticking the password in the URL leaks it
@@ -156,7 +155,7 @@ export default defineEventHandler(async (event) => {
   //      requests. The downstream `/api/video/:id` route accepts either
   //      `?t=<token>` (preferred) or `?password=<pw>` (legacy fallback) so
   //      old share pages keep working during rollout. (audit 11 F-07)
-  //      Real provider URLs (R2/S3/Builder) are left untouched; those are
+  //      Non-Loom provider URLs (R2/S3/Builder) are left untouched; those are
   //      already signed.
   const resolvedVideoUrl = resolvePlayerVideoUrl(rec, {
     addPasswordToken: true,

--- a/templates/clips/server/routes/api/public-recording.get.ts
+++ b/templates/clips/server/routes/api/public-recording.get.ts
@@ -145,8 +145,10 @@ export default defineEventHandler(async (event) => {
   // Normalize the player videoUrl:
   //   1. Rewrite the legacy `/api/uploads/:id/blob` shape to the current
   //      `/api/video/:id` endpoint so old rows keep playing after the move.
-  //   2. Keep Loom imports behind the same-origin `/api/video/:id` access
-  //      gate instead of returning the underlying public Loom embed URL.
+  //   2. Keep legacy Loom embed imports behind the same-origin
+  //      `/api/video/:id` access gate instead of returning the underlying
+  //      public Loom embed URL. New Loom imports are reuploaded and keep their
+  //      provider URL.
   //   3. For password-protected recordings, mint a short-lived HMAC token
   //      bound to this recording id and pass it via `?t=<token>` instead of
   //      the plaintext password. Sticking the password in the URL leaks it

--- a/templates/clips/server/routes/api/video/[recordingId].get.ts
+++ b/templates/clips/server/routes/api/video/[recordingId].get.ts
@@ -52,7 +52,7 @@ import {
 } from "@agent-native/core/server";
 import {
   LOOM_START_MS_QUERY_PARAM,
-  isLoomRecordingSource,
+  isLoomEmbedBackedRecording,
   loomEmbedUrlWithTimestamp,
   loomEmbedUrlForRecording,
 } from "../../../../shared/loom.js";
@@ -268,7 +268,7 @@ export default defineEventHandler(async (event: H3Event) => {
         }
       }
 
-      if (isLoomRecordingSource(rec)) {
+      if (isLoomEmbedBackedRecording(rec)) {
         let embedUrl = loomEmbedUrlForRecording(rec);
         if (!embedUrl) {
           setResponseStatus(event, 404);

--- a/templates/clips/shared/loom.test.ts
+++ b/templates/clips/shared/loom.test.ts
@@ -80,6 +80,17 @@ describe("Loom URL helpers", () => {
     );
   });
 
+  it("recognizes base-prefixed legacy Loom video routes as iframe-backed", () => {
+    const recording = {
+      sourceAppName: "Loom",
+      sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+      videoUrl: "/clips/api/video/rec-1?t=signed-token",
+    };
+
+    expect(isLoomRecordingSource(recording)).toBe(true);
+    expect(isLoomEmbedBackedRecording(recording)).toBe(true);
+  });
+
   it("does not treat reuploaded Loom source recordings as iframe-backed", () => {
     const recording = {
       sourceAppName: "Loom",
@@ -96,6 +107,17 @@ describe("Loom URL helpers", () => {
       sourceAppName: "Loom",
       sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
       videoUrl: "/api/video/rec-1?loomMedia=1&t=signed-token",
+    };
+
+    expect(isLoomRecordingSource(recording)).toBe(true);
+    expect(isLoomEmbedBackedRecording(recording)).toBe(false);
+  });
+
+  it("does not treat base-prefixed proxied native Loom media as iframe-backed", () => {
+    const recording = {
+      sourceAppName: "Loom",
+      sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+      videoUrl: "/clips/api/video/rec-1?loomMedia=1&t=signed-token",
     };
 
     expect(isLoomRecordingSource(recording)).toBe(true);

--- a/templates/clips/shared/loom.test.ts
+++ b/templates/clips/shared/loom.test.ts
@@ -91,6 +91,17 @@ describe("Loom URL helpers", () => {
     expect(isLoomEmbedBackedRecording(recording)).toBe(false);
   });
 
+  it("does not treat proxied native Loom media as iframe-backed", () => {
+    const recording = {
+      sourceAppName: "Loom",
+      sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+      videoUrl: "/api/video/rec-1?loomMedia=1&t=signed-token",
+    };
+
+    expect(isLoomRecordingSource(recording)).toBe(true);
+    expect(isLoomEmbedBackedRecording(recording)).toBe(false);
+  });
+
   it("rejects unsupported protocols, hosts, paths, and IDs", () => {
     expect(normalizeLoomShareUrl("javascript:alert(1)")).toBeNull();
     expect(

--- a/templates/clips/shared/loom.test.ts
+++ b/templates/clips/shared/loom.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractLoomEmbedUrlFromHtml,
   extractLoomVideoId,
+  isLoomEmbedBackedRecording,
   isLoomEmbedUrl,
   isLoomRecordingSource,
   loomEmbedUrlWithTimestamp,
@@ -65,7 +66,7 @@ describe("Loom URL helpers", () => {
     ).toBe(null);
   });
 
-  it("recognizes Loom recording metadata after Clips proxies the player URL", () => {
+  it("recognizes legacy Loom embed metadata after Clips proxies the player URL", () => {
     const recording = {
       sourceAppName: "Loom",
       sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
@@ -73,9 +74,21 @@ describe("Loom URL helpers", () => {
     };
 
     expect(isLoomRecordingSource(recording)).toBe(true);
+    expect(isLoomEmbedBackedRecording(recording)).toBe(true);
     expect(loomEmbedUrlForRecording(recording)).toBe(
       "https://www.loom.com/embed/abcDEF_123456",
     );
+  });
+
+  it("does not treat reuploaded Loom source recordings as iframe-backed", () => {
+    const recording = {
+      sourceAppName: "Loom",
+      sourceWindowTitle: "https://www.loom.com/share/abcDEF_123456",
+      videoUrl: "https://cdn.example.com/reuploaded.mp4",
+    };
+
+    expect(isLoomRecordingSource(recording)).toBe(true);
+    expect(isLoomEmbedBackedRecording(recording)).toBe(false);
   });
 
   it("rejects unsupported protocols, hosts, paths, and IDs", () => {

--- a/templates/clips/shared/loom.ts
+++ b/templates/clips/shared/loom.ts
@@ -85,7 +85,7 @@ export function isLoomEmbedUrl(value: string | null | undefined): boolean {
 function isLocalVideoRoute(value: string): boolean {
   try {
     const parsed = new URL(value, "http://local.test");
-    return /^\/api\/video\/[^/]+$/.test(parsed.pathname);
+    return /(?:^|\/)api\/video\/[^/]+$/.test(parsed.pathname);
   } catch {
     return false;
   }

--- a/templates/clips/shared/loom.ts
+++ b/templates/clips/shared/loom.ts
@@ -101,6 +101,17 @@ export function isLoomRecordingSource(
   );
 }
 
+export function isLoomEmbedBackedRecording(
+  recording: LoomRecordingLike | null | undefined,
+): boolean {
+  if (!recording) return false;
+  if (isLoomEmbedUrl(recording.videoUrl)) return true;
+  if (!isLoomSourceName(recording.sourceAppName)) return false;
+
+  const videoUrl = recording.videoUrl?.trim() ?? "";
+  return !videoUrl || /^\/api\/video\/[^/?#]+(?:[?#].*)?$/.test(videoUrl);
+}
+
 export function loomEmbedUrlForId(id: string): string {
   return `https://www.loom.com/embed/${encodeURIComponent(id)}`;
 }

--- a/templates/clips/shared/loom.ts
+++ b/templates/clips/shared/loom.ts
@@ -2,6 +2,7 @@ const LOOM_HOST_RE = /(^|\.)loom\.com$/i;
 const LOOM_VIDEO_ID_RE = /^[A-Za-z0-9_-]{8,120}$/;
 const LOOM_VIDEO_PATHS = new Set(["share", "embed"]);
 export const LOOM_START_MS_QUERY_PARAM = "loomStartMs";
+export const LOOM_NATIVE_MEDIA_QUERY_PARAM = "loomMedia";
 
 function parsePublicUrl(value: string): URL | null {
   try {
@@ -81,6 +82,24 @@ export function isLoomEmbedUrl(value: string | null | undefined): boolean {
   return typeof value === "string" && Boolean(sanitizeLoomEmbedUrl(value));
 }
 
+function isLocalVideoRoute(value: string): boolean {
+  try {
+    const parsed = new URL(value, "http://local.test");
+    return /^\/api\/video\/[^/]+$/.test(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
+function isMarkedLoomNativeMedia(value: string): boolean {
+  try {
+    const parsed = new URL(value, "http://local.test");
+    return parsed.searchParams.get(LOOM_NATIVE_MEDIA_QUERY_PARAM) === "1";
+  } catch {
+    return false;
+  }
+}
+
 export function isLoomSourceName(value: string | null | undefined): boolean {
   return value?.trim().toLowerCase() === "loom";
 }
@@ -109,7 +128,9 @@ export function isLoomEmbedBackedRecording(
   if (!isLoomSourceName(recording.sourceAppName)) return false;
 
   const videoUrl = recording.videoUrl?.trim() ?? "";
-  return !videoUrl || /^\/api\/video\/[^/?#]+(?:[?#].*)?$/.test(videoUrl);
+  if (!videoUrl) return true;
+  if (isMarkedLoomNativeMedia(videoUrl)) return false;
+  return isLocalVideoRoute(videoUrl);
 }
 
 export function loomEmbedUrlForId(id: string): string {


### PR DESCRIPTION
## Summary
- download public Loom MP4s during Clips import and reupload them to configured Clips storage
- keep legacy Loom embed-backed handling explicit for native media guards and public/player routes
- clamp the Clips desktop bubble to the current monitor bounds when restored, moved, or resized
- clarify in docs that agents are built from instructions, skills, and actions across headless, chat, and full UI surfaces

## Validation
- pnpm --filter @agent-native/docs test
- pnpm --filter clips test
- pnpm --filter clips typecheck
- git diff --check
- cargo fmt --check in templates/clips/desktop/src-tauri
- cargo test in templates/clips/desktop/src-tauri (blocked locally: cmake is not installed; whisper-rs-sys build script requires it)
