### PR TITLE
Fix microphone selection when recording

### DIFF
--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -1156,9 +1156,14 @@ fn native_extension_for_mime_type(mime_type: &str) -> &'static str {
 
 #[cfg(target_os = "macos")]
 fn normalize_audio_device_name(value: &str) -> String {
+    // Collapse to lowercase alphanumeric tokens so WebKit labels and CoreAudio
+    // names compare equal despite punctuation/possessive differences
+    // (e.g. "User's AirPods" vs "User AirPods", "Mic (Default)" vs "Mic").
     value
         .to_lowercase()
-        .replace("(default)", "")
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { ' ' })
+        .collect::<String>()
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
@@ -1168,7 +1173,23 @@ fn normalize_audio_device_name(value: &str) -> String {
 fn names_match(a: &str, b: &str) -> bool {
     let a = normalize_audio_device_name(a);
     let b = normalize_audio_device_name(b);
-    !a.is_empty() && !b.is_empty() && (a == b || a.contains(&b) || b.contains(&a))
+    if a.is_empty() || b.is_empty() {
+        return false;
+    }
+    if a == b || a.contains(&b) || b.contains(&a) {
+        return true;
+    }
+    // Token-subset fallback: every token of the shorter name must appear in the
+    // longer one (covers reordering and dropped possessives that substring
+    // matching misses, e.g. "User's AirPods" -> "User s airpods").
+    let a_tokens: Vec<&str> = a.split(' ').collect();
+    let b_tokens: Vec<&str> = b.split(' ').collect();
+    let (short, long) = if a_tokens.len() <= b_tokens.len() {
+        (&a_tokens, &b_tokens)
+    } else {
+        (&b_tokens, &a_tokens)
+    };
+    short.iter().all(|token| long.contains(token))
 }
 
 #[cfg(target_os = "macos")]
@@ -1182,10 +1203,18 @@ fn resolve_microphone_capture_device(
         .filter(|value| !value.is_empty());
 
     if device_id.is_none() && device_label.is_none() {
+        eprintln!("[clips-tray] audio input devices not provided");
         return Ok(None);
     }
 
     let devices = AudioInputDevice::list();
+    devices.iter().for_each(|device| {
+        eprintln!(
+            "[clips-tray] audio input device: id={} name={}",
+            device.id, device.name
+        );
+    });
+
     let resolved = device_id
         .and_then(|id| devices.iter().find(|device| device.id == id))
         .or_else(|| {
@@ -1196,6 +1225,14 @@ fn resolve_microphone_capture_device(
             })
         })
         .cloned();
+
+    eprintln!(
+        "[clips-tray] mic resolve: requested id={device_id:?} label={device_label:?} -> {}",
+        match &resolved {
+            Some(device) => format!("matched {} ({})", device.name, device.id),
+            None => "NO MATCH".to_string(),
+        }
+    );
 
     resolved.map(Some).ok_or_else(|| {
         let requested = device_label.or(device_id).unwrap_or("selected microphone");

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -1637,7 +1637,11 @@ export function App() {
         source,
         cameraId,
         micId: selectedMicId || undefined,
-        micLabel: selectedMicLabel || undefined,
+        // Live label is empty when the stored hashed deviceId no longer
+        // resolves in the current device list; fall back to the persisted label
+        // so the native recorder always has a name to match. recorder.ts also
+        // probes the live track.label at start as the authoritative source.
+        micLabel: selectedMicLabel || micLabel || undefined,
         authToken: loadDesktopAuthToken(serverUrl),
         cookie: typeof document !== "undefined" ? document.cookie || "" : "",
         cameraOn,

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -1501,12 +1501,41 @@ async function startNativeFullscreenRecording(
 
     await audioCue.playBeforeCapture();
     const wantsSystemAudio = wantsAudio && params.systemAudioOn !== false;
+    // Resolve the mic's REAL device name for the native recorder. WebKit's
+    // deviceId is a salted hash that never equals ScreenCaptureKit's CoreAudio
+    // device UID, so the Rust side can only pin the input by NAME. The stored
+    // label can be stale or empty (device list locked when picked, or a rotated
+    // deviceId salt after an app update) — that's what makes "only Default
+    // works": the hash matches nothing and there's no name to fall back to.
+    // A one-shot getUserMedia gives the exact current device name, the same
+    // string ScreenCaptureKit exposes, so name resolution succeeds.
+    let micDeviceLabel = params.micLabel || null;
+    if (wantsAudio && params.micId) {
+      try {
+        const probe = await navigator.mediaDevices.getUserMedia({
+          audio: { deviceId: { exact: params.micId } },
+          video: false,
+        });
+        const liveLabel = probe.getAudioTracks()[0]?.label?.trim();
+        probe.getTracks().forEach((track) => track.stop());
+        if (liveLabel) micDeviceLabel = liveLabel;
+        console.log(
+          `[clips-recorder] mic resolve: id=${params.micId} storedLabel=${JSON.stringify(params.micLabel ?? null)} liveLabel=${JSON.stringify(liveLabel ?? null)} -> using=${JSON.stringify(micDeviceLabel)}`,
+        );
+      } catch (probeErr) {
+        // Probe failed (rotated/stale deviceId, device unplugged, or denied) —
+        // fall back to the stored label, which the Rust side name-matches.
+        console.warn(
+          `[clips-recorder] mic probe failed: id=${params.micId} storedLabel=${JSON.stringify(params.micLabel ?? null)} err=${probeErr instanceof Error ? probeErr.name : String(probeErr)} -> falling back to stored label`,
+        );
+      }
+    }
     await invoke("native_fullscreen_recording_start", {
       recordingId: id,
       includeAudio: wantsAudio,
       captureSystemAudio: wantsSystemAudio,
       micDeviceId: params.micId || null,
-      micDeviceLabel: params.micLabel || null,
+      micDeviceLabel,
     });
     // Capture is now live — stamp the timer baseline before any further awaits
     // so the toolbar clock and toolbar-enable line up with the real start.


### PR DESCRIPTION
Fixes a Clips desktop bug where picking any mic failed and only "Default" worked.

## Changes

- **`recorder.ts`** — main fix. Looks up the chosen mic's real name at record start and passes it to the recorder, instead of a stored name that could be empty or stale. Falls back to the old name if the lookup fails.
- **`app.tsx`** — backup. Uses the last remembered mic name when the live one is missing.
- **`native_screen.rs`** — more forgiving name matching, so small differences ("User's AirPods" vs "User AirPods") no longer cause a mismatch.
