### PR TITLE
Add timestamps to all log lines in logfile.rs

### DIFF
--- a/templates/clips/desktop/src-tauri/src/logfile.rs
+++ b/templates/clips/desktop/src-tauri/src/logfile.rs
@@ -123,9 +123,11 @@ fn append_line(path: &Path, line: &str) {
 #[cfg(not(debug_assertions))]
 fn spawn_log_pump(read_fd: libc::c_int, path: PathBuf) {
     std::thread::spawn(move || {
-        let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) else {
-            return;
-        };
+        // Keep draining the pipe even if the file can't be opened: stdout and
+        // stderr are already redirected into it, so a pump that stops reading
+        // would let the buffer fill and block every later println!. When there
+        // is no file we simply discard the bytes.
+        let mut file = OpenOptions::new().create(true).append(true).open(&path).ok();
         let mut buf = [0u8; 4096];
         let mut line: Vec<u8> = Vec::new();
         loop {
@@ -148,10 +150,13 @@ fn spawn_log_pump(read_fd: libc::c_int, path: PathBuf) {
             if n == 0 {
                 break; // all writers closed → real EOF
             }
+            // Discard the chunk when there's no destination, but keep looping so
+            // the pipe never fills and blocks writers.
+            let Some(file) = file.as_mut() else { continue };
             for &byte in &buf[..n as usize] {
                 match byte {
                     b'\n' => {
-                        write_stamped_line(&mut file, &line);
+                        write_stamped_line(file, &line);
                         line.clear();
                     }
                     b'\r' => {}
@@ -159,8 +164,10 @@ fn spawn_log_pump(read_fd: libc::c_int, path: PathBuf) {
                 }
             }
         }
-        if !line.is_empty() {
-            write_stamped_line(&mut file, &line);
+        if let Some(file) = file.as_mut() {
+            if !line.is_empty() {
+                write_stamped_line(file, &line);
+            }
         }
     });
 }

--- a/templates/clips/desktop/src-tauri/src/logfile.rs
+++ b/templates/clips/desktop/src-tauri/src/logfile.rs
@@ -136,8 +136,17 @@ fn spawn_log_pump(read_fd: libc::c_int, path: PathBuf) {
                     buf.len() as _,
                 )
             };
-            if n <= 0 {
+            if n < 0 {
+                // A signal can interrupt a blocking read (EINTR); retry rather
+                // than treating it as EOF, which would permanently stop draining
+                // the pipe and eventually block writers once it fills.
+                if std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+                    continue;
+                }
                 break;
+            }
+            if n == 0 {
+                break; // all writers closed → real EOF
             }
             for &byte in &buf[..n as usize] {
                 match byte {
@@ -214,11 +223,17 @@ fn redirect_std_streams(_path: &Path) {}
 #[tauri::command]
 pub fn frontend_log(level: String, message: String) {
     let line = format!("[webview][{level}] {message}");
-    // In release this println! is redirected into the pipe, where the pump
-    // prepends the timestamp as it drains each line — emit it bare to avoid
-    // stamping it twice.
-    #[cfg(not(debug_assertions))]
+    // Release on non-Windows: this println! is redirected into the pipe, where
+    // the pump prepends the timestamp as it drains each line — emit it bare to
+    // avoid stamping it twice.
+    #[cfg(all(not(debug_assertions), not(windows)))]
     println!("{line}");
+    // Release on Windows: windows_subsystem = "windows" means Rust stdio isn't
+    // routed through the redirect pipe, so write straight to the file instead.
+    #[cfg(all(not(debug_assertions), windows))]
+    if let Some(path) = log_path() {
+        append_line(&path, &line);
+    }
     // In dev there is no fd redirect, so stamp the terminal echo and append the
     // same line to the file (append_line stamps it) to keep the file useful.
     #[cfg(debug_assertions)]

--- a/templates/clips/desktop/src-tauri/src/logfile.rs
+++ b/templates/clips/desktop/src-tauri/src/logfile.rs
@@ -195,14 +195,20 @@ fn redirect_std_streams(_path: &Path) {}
 /// frontend console tee (see `src/main.tsx`).
 #[tauri::command]
 pub fn frontend_log(level: String, message: String) {
-    // In release this println! is redirected into the log file; in dev it
-    // simply echoes to the terminal.
-    println!("[webview][{level}] {message}");
-    // In dev there is no fd redirect, so also append directly to keep the file
-    // useful when a developer opens it.
+    let line = format!("[webview][{level}] {message}");
+    // In release this println! is redirected into the pipe, where the pump
+    // prepends the timestamp as it drains each line — emit it bare to avoid
+    // stamping it twice.
+    #[cfg(not(debug_assertions))]
+    println!("{line}");
+    // In dev there is no fd redirect, so stamp the terminal echo and append the
+    // same line to the file (append_line stamps it) to keep the file useful.
     #[cfg(debug_assertions)]
-    if let Some(path) = log_path() {
-        append_line(&path, &format!("[webview][{level}] {message}"));
+    {
+        println!("{} {line}", timestamp());
+        if let Some(path) = log_path() {
+            append_line(&path, &line);
+        }
     }
 }
 

--- a/templates/clips/desktop/src-tauri/src/logfile.rs
+++ b/templates/clips/desktop/src-tauri/src/logfile.rs
@@ -11,6 +11,11 @@
 //!
 //! In debug builds we leave the streams alone so `tauri dev` keeps printing to
 //! the terminal; only the log path + startup banner are set up.
+//!
+//! Every line written to the file is prefixed with a local timestamp so support
+//! and developers can correlate events. In release the redirected fds feed a
+//! pipe whose reader thread stamps each line, which keeps the timestamping in
+//! one place without touching the existing log call sites.
 
 use std::fs::{self, OpenOptions};
 use std::io::Write;
@@ -28,6 +33,14 @@ const MAX_BYTES: u64 = 10 * 1024 * 1024;
 /// Path of the active log file, once [`init`] has resolved it.
 pub fn log_path() -> Option<PathBuf> {
     LOG_PATH.get().cloned()
+}
+
+/// Local wall-clock timestamp prefixed to every log line, with millisecond
+/// precision so closely-spaced events stay distinguishable.
+fn timestamp() -> String {
+    chrono::Local::now()
+        .format("%Y-%m-%d %H:%M:%S%.3f")
+        .to_string()
 }
 
 /// Resolve the log file, rotate it if needed, and (release only) redirect
@@ -56,10 +69,11 @@ pub fn init(app: &AppHandle) {
     redirect_std_streams(&path);
 
     // Always write a startup marker — guarantees the file exists (even in dev)
-    // and stamps each run so support can tell session boundaries apart.
+    // and marks each run so support can tell session boundaries apart. The
+    // per-line timestamp prefix supplies the time, so the banner only carries
+    // the version.
     let banner = format!(
-        "[clips-tray] === log start {} v{} ===",
-        chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
+        "[clips-tray] === log start v{} ===",
         env!("CARGO_PKG_VERSION"),
     );
     #[cfg(not(debug_assertions))]
@@ -81,63 +95,94 @@ fn rotate_if_needed(path: &Path) {
 #[allow(dead_code)] // unused in release where stdout/stderr are redirected
 fn append_line(path: &Path, line: &str) {
     if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
-        let _ = writeln!(file, "{line}");
+        let _ = writeln!(file, "{} {line}", timestamp());
     }
+}
+
+/// Drain the redirected stdout/stderr pipe, prefixing every line with a
+/// timestamp before appending it to the log file. Runs for the life of the
+/// process on its own thread (release only).
+#[cfg(not(debug_assertions))]
+fn spawn_log_pump(read_fd: libc::c_int, path: PathBuf) {
+    std::thread::spawn(move || {
+        let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) else {
+            return;
+        };
+        let mut buf = [0u8; 4096];
+        let mut line: Vec<u8> = Vec::new();
+        loop {
+            let n = unsafe {
+                libc::read(
+                    read_fd,
+                    buf.as_mut_ptr() as *mut libc::c_void,
+                    buf.len() as _,
+                )
+            };
+            if n <= 0 {
+                break;
+            }
+            for &byte in &buf[..n as usize] {
+                match byte {
+                    b'\n' => {
+                        write_stamped_line(&mut file, &line);
+                        line.clear();
+                    }
+                    b'\r' => {}
+                    _ => line.push(byte),
+                }
+            }
+        }
+        if !line.is_empty() {
+            write_stamped_line(&mut file, &line);
+        }
+    });
+}
+
+#[cfg(not(debug_assertions))]
+fn write_stamped_line(file: &mut std::fs::File, line: &[u8]) {
+    let text = String::from_utf8_lossy(line);
+    let _ = writeln!(file, "{} {text}", timestamp());
 }
 
 #[cfg(all(not(debug_assertions), unix))]
 fn redirect_std_streams(path: &Path) {
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt;
-
-    let Ok(cpath) = CString::new(path.as_os_str().as_bytes()) else {
-        return;
-    };
+    // Point fd 1 + 2 at the write end of a pipe and let the pump thread read
+    // the other end, so it can timestamp each line on its way to the file.
+    let mut fds = [0 as libc::c_int; 2];
     unsafe {
-        let fd = libc::open(
-            cpath.as_ptr(),
-            libc::O_WRONLY | libc::O_CREAT | libc::O_APPEND,
-            0o644,
-        );
-        if fd < 0 {
+        if libc::pipe(fds.as_mut_ptr()) != 0 {
             return;
         }
-        libc::dup2(fd, libc::STDOUT_FILENO);
-        libc::dup2(fd, libc::STDERR_FILENO);
-        if fd > 2 {
-            libc::close(fd);
+        let (read_fd, write_fd) = (fds[0], fds[1]);
+        libc::dup2(write_fd, libc::STDOUT_FILENO);
+        libc::dup2(write_fd, libc::STDERR_FILENO);
+        if write_fd > 2 {
+            libc::close(write_fd);
         }
+        spawn_log_pump(read_fd, path.to_path_buf());
     }
 }
 
 #[cfg(all(not(debug_assertions), windows))]
 fn redirect_std_streams(path: &Path) {
-    use std::os::windows::ffi::OsStrExt;
-
-    // libc::open maps to the narrow CRT _open, which interprets the path in
-    // the active ANSI code page — a profile path with non-ASCII characters
-    // (e.g. C:\Users\Müller) then fails to open and silently disables logging.
-    // Build a NUL-terminated UTF-16 path and use the wide wopen instead.
-    let wide: Vec<u16> = path
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect();
+    // Point fd 1 + 2 at the write end of a pipe and let the pump thread read
+    // the other end, so it can timestamp each line on its way to the file. The
+    // pump opens the file through std, which handles non-ASCII profile paths
+    // (e.g. C:\Users\Müller) correctly via UTF-16. O_BINARY keeps the CRT from
+    // rewriting newlines on the pipe.
+    let mut fds = [0 as libc::c_int; 2];
     unsafe {
-        let fd = libc::wopen(
-            wide.as_ptr(),
-            libc::O_WRONLY | libc::O_CREAT | libc::O_APPEND,
-            libc::S_IWRITE,
-        );
-        if fd < 0 {
+        if libc::pipe(fds.as_mut_ptr(), 65536, libc::O_BINARY) != 0 {
             return;
         }
+        let (read_fd, write_fd) = (fds[0], fds[1]);
         // 1 = stdout, 2 = stderr (libc on Windows omits STD*_FILENO).
-        libc::dup2(fd, 1);
-        libc::dup2(fd, 2);
-        if fd > 2 {
-            libc::close(fd);
+        libc::dup2(write_fd, 1);
+        libc::dup2(write_fd, 2);
+        if write_fd > 2 {
+            libc::close(write_fd);
         }
+        spawn_log_pump(read_fd, path.to_path_buf());
     }
 }
 

--- a/templates/clips/desktop/src-tauri/src/logfile.rs
+++ b/templates/clips/desktop/src-tauri/src/logfile.rs
@@ -62,6 +62,11 @@ pub fn init(app: &AppHandle) {
     rotate_if_needed(&path);
     let _ = LOG_PATH.set(path.clone());
 
+    // Write panic output straight to the file before the streams are redirected.
+    // In release (panic = "abort") the process can die before the pump drains
+    // the pipe, so the synchronous write guarantees the crash message survives.
+    install_panic_hook();
+
     // In release, point fd 1 + 2 at the file so every existing println!,
     // eprintln!, dlog!, and panic message is captured with no call-site
     // changes. Done before the banner so the banner lands in the file too.
@@ -82,6 +87,20 @@ pub fn init(app: &AppHandle) {
     append_line(&path, &banner);
 }
 
+/// Persist panic info directly to the log file (bypassing the redirect pipe) so
+/// an aborting release build can't drop the crash message while it's still
+/// buffered in the pipe. Chains the previous hook so terminal/stderr output is
+/// preserved.
+fn install_panic_hook() {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if let Some(path) = log_path() {
+            append_line(&path, &format!("[clips-tray] panic: {info}"));
+        }
+        prev(info);
+    }));
+}
+
 fn rotate_if_needed(path: &Path) {
     if let Ok(meta) = fs::metadata(path) {
         if meta.len() > MAX_BYTES {
@@ -92,7 +111,6 @@ fn rotate_if_needed(path: &Path) {
     }
 }
 
-#[allow(dead_code)] // unused in release where stdout/stderr are redirected
 fn append_line(path: &Path, line: &str) {
     if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
         let _ = writeln!(file, "{} {line}", timestamp());


### PR DESCRIPTION
### Summary
Adds millisecond-precision local timestamps to every line written to the log file, making it easier to correlate and debug events across sessions.

### Problem
Log lines had no timestamps, making it difficult to determine when events occurred or to correlate closely-spaced entries during debugging and support.

### Solution
Introduced a central `timestamp()` helper and rearchitected the stdout/stderr redirect to use a pipe + pump thread (instead of direct fd-to-file redirection), so the pump thread can prepend a timestamp to every line as it drains the pipe. In debug builds, timestamps are added directly in `append_line` and the terminal echo in `frontend_log`.

### Key Changes
- Added `timestamp()` helper returning a formatted local wall-clock string with millisecond precision (`%Y-%m-%d %H:%M:%S%.3f`)
- Replaced direct fd-to-file redirection (Unix and Windows) with a pipe-based approach: stdout/stderr are redirected to the write end of a pipe, and a new `spawn_log_pump` thread reads the read end, stamping each line before writing to the log file
- Added `write_stamped_line` utility used by the pump thread to prepend timestamps
- Updated `append_line` to prefix each line with a timestamp (used in debug builds)
- Updated `frontend_log` to emit a bare line in release (the pump thread stamps it) and a pre-stamped line in debug (both to terminal and log file), avoiding double-stamping
- Simplified the startup banner to remove its inline timestamp, since per-line timestamps now cover that role


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/rainbow-ship-5sdzwwhk"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-rainbow-ship-5sdzwwhk.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1361`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>rainbow-ship-5sdzwwhk</branchName>-->