### PR TITLE
fix(cli): route AGENT_ENGINE=codex-cli to the Codex CLI runner instead of crashing

### DIFF
--- a/.changeset/fix-codex-cli-agent-engine.md
+++ b/.changeset/fix-codex-cli-agent-engine.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix `agent-native code` crashing with `Unknown engine: "codex-cli"` when the Codex CLI runner is selected via the `AGENT_ENGINE` environment variable. The Codex branch in `executeCodeAgentRun` now falls back to `AGENT_ENGINE` the same way `resolveExecutorEngine` already does, so `AGENT_ENGINE=codex-cli` routes to the Codex CLI runner instead of being handed to the LLM-provider engine resolver (which only knows the AI-SDK providers).

--- a/packages/core/src/cli/code-agent-executor.spec.ts
+++ b/packages/core/src/cli/code-agent-executor.spec.ts
@@ -40,11 +40,14 @@ const originalProviderEnv = new Map(
   providerEnvKeys.map((key) => [key, process.env[key]]),
 );
 const originalPath = process.env.PATH;
+const originalAgentEngine = process.env.AGENT_ENGINE;
 
 afterEach(() => {
   delete process.env.AGENT_NATIVE_CODE_AGENTS_HOME;
   delete process.env.AGENT_NATIVE_CODE_AGENT_FAKE_RESPONSE;
   process.env.PATH = originalPath;
+  if (originalAgentEngine === undefined) delete process.env.AGENT_ENGINE;
+  else process.env.AGENT_ENGINE = originalAgentEngine;
   for (const key of providerEnvKeys) {
     const original = originalProviderEnv.get(key);
     if (original === undefined) delete process.env[key];
@@ -169,6 +172,59 @@ describe("executeCodeAgentRun", () => {
         }),
       ]),
     );
+  });
+
+  it("routes AGENT_ENGINE=codex-cli to the Codex CLI runner without engine metadata", async () => {
+    const root = useTempCodeAgentsHome();
+    for (const key of providerEnvKeys) delete process.env[key];
+    process.env.AGENT_ENGINE = "codex-cli";
+    const binDir = path.join(root, "bin");
+    const promptPath = path.join(root, "codex-prompt.txt");
+    fs.mkdirSync(binDir, { recursive: true });
+    const codexBin = path.join(binDir, "codex");
+    fs.writeFileSync(
+      codexBin,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('fs');",
+        "const args = process.argv.slice(2);",
+        "const outIndex = args.indexOf('--output-last-message');",
+        "const outPath = outIndex === -1 ? '' : args[outIndex + 1];",
+        "let input = '';",
+        "process.stdin.on('data', (chunk) => { input += chunk.toString(); });",
+        "process.stdin.on('end', () => {",
+        `  fs.writeFileSync(${JSON.stringify(promptPath)}, input);`,
+        "  if (outPath) fs.writeFileSync(outPath, 'Codex final answer');",
+        "  process.stdout.write('Codex streamed output');",
+        "});",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+    const output = createStringOutput();
+    // No `engine` in metadata — the Codex CLI runner must be selected purely
+    // from AGENT_ENGINE, the same fallback resolveExecutorEngine already uses.
+    const run = createCodeAgentRunRecord({
+      goalId: "task",
+      title: "Use Codex via AGENT_ENGINE",
+      status: "queued",
+      cwd: process.cwd(),
+      metadata: {},
+    });
+
+    await executeCodeAgentRun({
+      runId: run.id,
+      prompt: "fix auth tests",
+      stdout: output.stream,
+    });
+
+    expect(getCodeAgentRunRecord(run.id)).toMatchObject({
+      status: "completed",
+      phase: "complete",
+      metadata: { engine: "codex-cli", model: "codex-default" },
+    });
+    expect(output.read()).toContain("Codex streamed output");
+    expect(fs.readFileSync(promptPath, "utf-8")).toContain("fix auth tests");
   });
 
   it("can execute a run whose initial prompt was written by Desktop", async () => {

--- a/packages/core/src/cli/code-agent-executor.ts
+++ b/packages/core/src/cli/code-agent-executor.ts
@@ -183,8 +183,11 @@ export async function executeCodeAgentRun(
     metadata: { status: "running", phase: "executing" },
   });
 
+  // Fall back to AGENT_ENGINE here too, mirroring resolveExecutorEngine below.
+  // Without it, `AGENT_ENGINE=codex-cli` skips this Codex branch and is handed
+  // to resolveEngine (LLM providers only), which throws `Unknown engine`.
   const requestedEngine = normalizeRequestedEngine(
-    metadataString(existing, "engine"),
+    metadataString(existing, "engine") ?? process.env.AGENT_ENGINE,
   );
   if (requestedEngine === CODEX_CLI_ENGINE_NAME) {
     return executeCodexCliRun({


### PR DESCRIPTION
## Bug

Selecting the Codex CLI runner via `AGENT_ENGINE` crashes `agent-native code`:

```bash
AGENT_ENGINE=codex-cli pnpm exec agent-native code --auto "anything"
# Failed to load the scaffolder: [agent-engine] Unknown engine: "codex-cli".
# Registered: builder, anthropic, ai-sdk:anthropic, ai-sdk:openai, …
#   at resolveEngine (agent/engine/registry.ts)
#   at resolveExecutorEngine (cli/code-agent-executor.ts)
#   at executeCodeAgentRun (cli/code-agent-executor.ts)
```

(The CLI itself prints *"Report this bug"*, hence this PR.)

## Root cause

`codex-cli` isn't an LLM-provider engine in the registry — it's dispatched by a special branch in `executeCodeAgentRun`:

```ts
const requestedEngine = normalizeRequestedEngine(metadataString(existing, "engine"));
if (requestedEngine === CODEX_CLI_ENGINE_NAME) {
  return executeCodexCliRun({ ... });   // spawn("codex", …)
}
```

That branch reads the engine from **run metadata only**, but `resolveExecutorEngine` (same file, ~940 lines later) falls back to `process.env.AGENT_ENGINE`:

```ts
return resolveEngine({ engineOption: requestedEngine ?? process.env.AGENT_ENGINE });
```

So with `AGENT_ENGINE=codex-cli` and no engine metadata (the headless `agent-native code` path — the Desktop UI *does* write engine metadata, so it's unaffected), the Codex branch is skipped and `codex-cli` is handed to `resolveEngine`, which only knows the AI-SDK providers → it throws. `hasAnyProviderCredential()` also returns `true` for any `AGENT_ENGINE`, so the run isn't short-circuited earlier either.

## Fix

Give the Codex branch the **same `AGENT_ENGINE` fallback** `resolveExecutorEngine` already uses:

```ts
const requestedEngine = normalizeRequestedEngine(
  metadataString(existing, "engine") ?? process.env.AGENT_ENGINE,
);
```

Behavior is **identical for every other engine selection** — I walked all four cases (metadata set / `AGENT_ENGINE` non-codex / `AGENT_ENGINE=codex-cli` / neither) and only `AGENT_ENGINE=codex-cli` changes, from a crash to correctly dispatching to `executeCodexCliRun`.

Adds a regression test that drives selection purely through `AGENT_ENGINE` (mirroring the existing fake-`codex`-binary test); it fails on `main` (the crash) and passes with this change. Includes a `@agent-native/core` patch changeset.

## Alternative framing

If routing `AGENT_ENGINE=codex-cli` to the Codex runner is *not* desired here, the minimal alternative is to keep it a no-go but replace the misleading generic `Unknown engine` with an actionable message (e.g. *"codex-cli is the Codex CLI runner, not an LLM engine — select it via …"*). Happy to switch to that if you'd prefer the conservative path. I went with the routing fix because it makes the existing, unit-tested Codex path reachable from the CLI and removes a genuine read-asymmetry between the two `AGENT_ENGINE` sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)