### PR TITLE
fix: TOC last item blinking

### DIFF
--- a/templates/plan/app/components/plan/PlanTableOfContents.tsx
+++ b/templates/plan/app/components/plan/PlanTableOfContents.tsx
@@ -79,7 +79,11 @@ export function PlanTableOfContents({
     const getActiveId = () =>
       getActivePlanTocId(
         ids,
-        (id) => elementsRef.current.get(id) ?? null,
+        // Skip detached nodes; their rect collapses to top 0 and wrongly wins.
+        (id) => {
+          const el = elementsRef.current.get(id);
+          return el && el.isConnected ? el : null;
+        },
         OFFSET,
         scrollTarget instanceof HTMLElement ? scrollTarget : null,
       );
@@ -89,10 +93,17 @@ export function PlanTableOfContents({
       setActiveId((prev) => (prev === next ? prev : next));
     };
 
+    const refreshElements = () => {
+      const root = findDocumentFlow(navRef.current);
+      if (root) elementsRef.current = resolvePlanTocElements(root, items);
+    };
+
     const scheduleUpdateActiveId = () => {
       if (scrollRaf) return;
       scrollRaf = window.requestAnimationFrame(() => {
         scrollRaf = 0;
+        // Re-resolve so scroll reads live nodes, not refs Tiptap has swapped.
+        refreshElements();
         updateActiveId();
       });
     };


### PR DESCRIPTION
clip: https://clips.agent-native.com/r/IQM58AxI7I9g 

The TOC keeps a cached list of the heading elements so it can measure where each section is as you scroll.

But the plan document uses the Tiptap editor, which constantly swaps out its DOM elements (re-renders headings). When that happens, the cached references point to old, detached elements that are no longer on the page.

A detached element reports its position as top: 0. So during scroll, every heading looked like it was at position 0 — all "tied." The tie-breaker rule picks the last one in that case, so the highlight jumped to the last item. Then a background refresh corrected it, scroll undid it again… → blink, blink, blink.