### PR TITLE
Refine Plan, Clips, and setup layouts

### DIFF
--- a/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
+++ b/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-native-visual-plans",
-  "version": "1.0.0+codex.f6a793b4f900",
+  "version": "1.0.0+codex.f94d10704ef1",
   "description": "Create rich interactive visual plans and recaps with diagrams, file maps, annotated code and diffs, API/schema summaries, feedback, and HTML export.",
   "author": { "name": "Agent-Native", "url": "https://agent-native.com" },
   "homepage": "https://plan.agent-native.com",

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-plan/SKILL.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-plan/SKILL.md
@@ -166,6 +166,12 @@ is reachable. Local-files privacy mode (after Tool Guidance) is the exception.
    and put `diagram`, `data-model`,
    `api-endpoint`, `diff`, `file-tree`, `code`, and `annotated-code` blocks
    directly next to the relevant prose.
+   Wide document layout is renderer-owned and intentionally allowlisted: only
+   literal code-review surfaces (`diff`, `annotated-code`) and `tabs` blocks
+   with vertical orientation or diff-like children break out wider than prose.
+   Keep `api-endpoint`, `openapi-spec`, `data-model`, `json-explorer`,
+   `wireframe`, question, and `custom-html` blocks in normal document flow unless
+   their own renderer says otherwise.
 4. Surface the returned Plans link or inline MCP App and ask the user to review.
    Always include the actual URL in chat so the next step is a click in CLI or
    other text-only hosts. When the host exposes an embedded browser/preview panel

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-plan/references/document-quality.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-plan/references/document-quality.md
@@ -165,6 +165,11 @@ blocks for normal plans. For architecture/code reviews, use `diagram`
 requested mockup, UI state, or visual comparison. If UI fidelity requires
 HTML/CSS, image capture, or real React/CSS, the product fix is canvas support
 for that artifact type, not moving the mockup into the document.
+When `custom-html` is genuinely needed, author it against the sandbox-provided
+theme tokens (`--wf-paper`, `--wf-card`, `--wf-ink`, `--wf-muted`,
+`--wf-line`, `--wf-radius`, and the matching `--plan-*` aliases). Do not hardcode
+hex/rgb/hsl light palettes such as white cards with dark ink; the same fragment
+must read in dark mode without a plan-specific patch.
 
 **Before handoff, open the plan and check it.** Fix overlap, excessive
 whitespace, clipped fragments, misleading inactive controls, poor contrast, and

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-recap/SKILL.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-recap/SKILL.md
@@ -411,6 +411,11 @@ tags — resolve every conceptual name to its exact tag + prop schema with the
   full document width. Let that heading label the section — do NOT also set a
   `title` on the `tabs` block. Keep each tab label to the file path or a short
   basename plus directory hint.
+  The renderer's wide document layout is intentionally allowlisted: `diff`,
+  `annotated-code`, vertical `tabs`, and `tabs` containing diff-like children
+  break out wider than prose. Do not put API endpoints, OpenAPI specs, data
+  models, JSON explorers, wireframes, question forms, or custom HTML into tabs
+  merely to make them wide.
   If the recap ends with more than one supporting diff, that trailing diff
   appendix should be one horizontal `tabs` block under its own `## Key changes`
   heading, not a stack of separate `diff` blocks.

--- a/.changeset/question-form-preview-width.md
+++ b/.changeset/question-form-preview-width.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix question-form visual previews so single wireframe previews use the available option width instead of collapsing into a tiny grid column.

--- a/.changeset/question-form-preview-width.md
+++ b/.changeset/question-form-preview-width.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Fix question-form visual previews so single wireframe previews use the available option width instead of collapsing into a tiny grid column.
+Fix visual plan layout polish: compact question previews, mark wide-eligible tabs for diff-like content, align drag handles with wide blocks, and theme custom HTML iframes for dark mode.

--- a/.changeset/sidebar-connect-ai-layout.md
+++ b/.changeset/sidebar-connect-ai-layout.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Move the sidebar Connect AI setup card above the composer and stack its actions.

--- a/.changeset/wireframe-style-toggle-rough-scope.md
+++ b/.changeset/wireframe-style-toggle-rough-scope.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the wireframe style toggle outside the Rough.js measurement scope so sketch mode no longer draws a ghost outline for the hidden Clean button.

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,8 @@ dist
 .netlify
 out
 .video-bakeoff
+.video-bakeoff-recording
+packages/vscode-extension/.vscode-test
 pnpm-lock.yaml
 **/SKILL.md
 **/routeTree.gen.ts

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -903,6 +903,11 @@ blocks for normal plans. For architecture/code reviews, use \`diagram\`
 requested mockup, UI state, or visual comparison. If UI fidelity requires
 HTML/CSS, image capture, or real React/CSS, the product fix is canvas support
 for that artifact type, not moving the mockup into the document.
+When \`custom-html\` is genuinely needed, author it against the sandbox-provided
+theme tokens (\`--wf-paper\`, \`--wf-card\`, \`--wf-ink\`, \`--wf-muted\`,
+\`--wf-line\`, \`--wf-radius\`, and the matching \`--plan-*\` aliases). Do not hardcode
+hex/rgb/hsl light palettes such as white cards with dark ink; the same fragment
+must read in dark mode without a plan-specific patch.
 
 **Before handoff, open the plan and check it.** Fix overlap, excessive
 whitespace, clipped fragments, misleading inactive controls, poor contrast, and
@@ -1195,6 +1200,12 @@ is reachable. Local-files privacy mode (after Tool Guidance) is the exception.
    and put \`diagram\`, \`data-model\`,
    \`api-endpoint\`, \`diff\`, \`file-tree\`, \`code\`, and \`annotated-code\` blocks
    directly next to the relevant prose.
+   Wide document layout is renderer-owned and intentionally allowlisted: only
+   literal code-review surfaces (\`diff\`, \`annotated-code\`) and \`tabs\` blocks
+   with vertical orientation or diff-like children break out wider than prose.
+   Keep \`api-endpoint\`, \`openapi-spec\`, \`data-model\`, \`json-explorer\`,
+   \`wireframe\`, question, and \`custom-html\` blocks in normal document flow unless
+   their own renderer says otherwise.
 4. Surface the returned Plans link or inline MCP App and ask the user to review.
    Always include the actual URL in chat so the next step is a click in CLI or
    other text-only hosts. When the host exposes an embedded browser/preview panel
@@ -1950,6 +1961,11 @@ tags — resolve every conceptual name to its exact tag + prop schema with the
   full document width. Let that heading label the section — do NOT also set a
   \`title\` on the \`tabs\` block. Keep each tab label to the file path or a short
   basename plus directory hint.
+  The renderer's wide document layout is intentionally allowlisted: \`diff\`,
+  \`annotated-code\`, vertical \`tabs\`, and \`tabs\` containing diff-like children
+  break out wider than prose. Do not put API endpoints, OpenAPI specs, data
+  models, JSON explorers, wireframes, question forms, or custom HTML into tabs
+  merely to make them wide.
   If the recap ends with more than one supporting diff, that trailing diff
   appendix should be one horizontal \`tabs\` block under its own \`## Key changes\`
   heading, not a stack of separate \`diff\` blocks.

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -2662,6 +2662,7 @@ export function AgentSidebar({
           emptyStateText={emptyStateText}
           suggestions={suggestions}
           dynamicSuggestions={dynamicSuggestions}
+          missingApiKeySetupLayout="sidebar"
           onCollapse={() => setOpenPersisted(false)}
           isFullscreen={effectiveFullscreen}
           onToggleFullscreen={

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -136,6 +136,7 @@ import {
   getLoopLimitMetadata,
   getRunErrorMetadata,
   getRequestModeMetadata,
+  type BuilderSetupCardLayout,
   type LoopLimitInfo,
   type RunErrorInfo,
 } from "./chat/run-recovery.js";
@@ -659,6 +660,8 @@ export interface AssistantChatProps {
   composerAreaClassName?: string;
   /** Placeholder for the shared composer in its normal idle state. */
   composerPlaceholder?: string;
+  /** Sidebar uses a compact setup CTA above the composer; page chat keeps the default below-composer CTA. */
+  missingApiKeySetupLayout?: BuilderSetupCardLayout;
   /** Visual density for the shared composer shell. */
   composerLayoutVariant?: AgentComposerLayoutVariant;
   /** Center the composer on a fresh empty chat instead of pinning it low. */
@@ -949,6 +952,7 @@ const AssistantChatInner = forwardRef<
     composerSlot,
     composerAreaClassName,
     composerPlaceholder,
+    missingApiKeySetupLayout = "default",
     composerLayoutVariant = "default",
     centerComposerWhenEmpty = false,
     emptyStateDisplay = "default",
@@ -1104,6 +1108,8 @@ const AssistantChatInner = forwardRef<
     providerStatusChecksEnabled,
   ).missing;
   const isComposerDisabled = missingApiKey || composerDisabled;
+  const missingApiKeySetupAboveComposer =
+    missingApiKeySetupLayout === "sidebar";
   // Increments each time the user clicks the (disabled) composer while no LLM
   // is connected — `BuilderSetupCard` watches this to replay a one-shot bounce.
   const [missingKeyBouncePulse, setMissingKeyBouncePulse] = useState(0);
@@ -3249,6 +3255,15 @@ const AssistantChatInner = forwardRef<
                     </button>
                   </div>
                 )}
+                {missingApiKey &&
+                !authError &&
+                missingApiKeySetupAboveComposer ? (
+                  <BuilderSetupCard
+                    onConnected={handleBuilderConnected}
+                    bouncePulse={missingKeyBouncePulse}
+                    layout={missingApiKeySetupLayout}
+                  />
+                ) : null}
                 {/* Input area */}
                 <AgentComposerFrame
                   layoutVariant={composerLayoutVariant}
@@ -3269,7 +3284,9 @@ const AssistantChatInner = forwardRef<
                     disabled={isComposerDisabled}
                     placeholder={
                       missingApiKey
-                        ? "Connect AI below to start chatting..."
+                        ? missingApiKeySetupAboveComposer
+                          ? "Connect AI above to start chatting..."
+                          : "Connect AI below to start chatting..."
                         : composerDisabled
                           ? (composerDisabledPlaceholder ??
                             "Open Desktop to use this chat.")
@@ -3345,10 +3362,13 @@ const AssistantChatInner = forwardRef<
                     }
                   />
                 </AgentComposerFrame>
-                {missingApiKey && !authError ? (
+                {missingApiKey &&
+                !authError &&
+                !missingApiKeySetupAboveComposer ? (
                   <BuilderSetupCard
                     onConnected={handleBuilderConnected}
                     bouncePulse={missingKeyBouncePulse}
+                    layout={missingApiKeySetupLayout}
                   />
                 ) : null}
               </div>

--- a/packages/core/src/client/blocks/BlockView.tsx
+++ b/packages/core/src/client/blocks/BlockView.tsx
@@ -36,6 +36,7 @@ export function BlockView({
   editable = true,
   onChange,
   ctx,
+  compactVisuals,
 }: {
   spec: BlockSpec<any>;
   block: { id: string; title?: string; summary?: string; data: unknown };
@@ -46,6 +47,7 @@ export function BlockView({
   /** Commit a new `data` value for the block. */
   onChange?: (nextData: unknown, meta?: BlockDataChangeMeta) => void;
   ctx: BlockRenderContext;
+  compactVisuals?: boolean;
 }) {
   const [panelHovered, setPanelHovered] = useState(false);
   const Read = spec.Read;
@@ -56,6 +58,7 @@ export function BlockView({
       title={block.title}
       summary={block.summary}
       ctx={ctx}
+      compactVisuals={compactVisuals}
     />
   );
 

--- a/packages/core/src/client/blocks/library/diagram.tsx
+++ b/packages/core/src/client/blocks/library/diagram.tsx
@@ -617,9 +617,11 @@ export function DiagramLightbox({
 function ExpandableDiagramBody({
   data,
   ctx,
+  compact,
 }: {
   data: DiagramData;
   ctx: BlockRenderContext;
+  compact?: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const supportsStyleToggle = Boolean(data.html);
@@ -633,7 +635,7 @@ function ExpandableDiagramBody({
     : "Clean diagrams - switch to hand-drawn";
   return (
     <div className="group/diagram relative">
-      <DiagramBody data={data} ctx={ctx} />
+      <DiagramBody data={data} ctx={ctx} compact={compact} />
       <TooltipProvider delayDuration={100} skipDelayDuration={0}>
         <div className="absolute right-2 top-2 z-10 flex items-center gap-1.5">
           {supportsStyleToggle && (
@@ -693,6 +695,7 @@ export function DiagramRead({
   title,
   summary,
   ctx,
+  compactVisuals,
 }: BlockReadProps<DiagramData>) {
   return (
     <section
@@ -701,7 +704,7 @@ export function DiagramRead({
       data-block-id={blockId}
     >
       {title && <div className="an-block-label plan-block-label">{title}</div>}
-      <ExpandableDiagramBody data={data} ctx={ctx} />
+      <ExpandableDiagramBody data={data} ctx={ctx} compact={compactVisuals} />
       {summary && <p className="mt-5 text-muted-foreground">{summary}</p>}
     </section>
   );

--- a/packages/core/src/client/blocks/library/html.tsx
+++ b/packages/core/src/client/blocks/library/html.tsx
@@ -4,6 +4,7 @@ import { defineBlock } from "../types.js";
 import type { BlockReadProps, BlockEditProps } from "../types.js";
 import { AiEditableFieldLabel } from "../AiEditableField.js";
 import { htmlSchema, htmlMdx, type HtmlBlockData } from "./html.config.js";
+import { useIsDark } from "./wireframe-kit.js";
 
 /**
  * Standard library HTML / Tailwind block. The registry form of the plan
@@ -24,13 +25,15 @@ import { htmlSchema, htmlMdx, type HtmlBlockData } from "./html.config.js";
 /** Build the iframe document for a fragment, applying app sanitization if given. */
 function buildSrcDoc(
   data: HtmlBlockData,
+  theme: "light" | "dark",
   sanitize?: (html: string, css?: string) => string,
 ): string {
   const css = data.css ?? "";
   const body = sanitize ? sanitize(data.html, data.css) : data.html;
-  // Use prefers-color-scheme so the iframe ink matches the host theme even
-  // though the iframe document is isolated and can't inherit CSS variables.
-  return `<!doctype html><html><head><style>body{margin:0;min-height:100%;font-family:Inter,system-ui,sans-serif;color:#1f1f1d;background:transparent;}*{box-sizing:border-box}@media(prefers-color-scheme:dark){body{color:#e8e8e6}}${css}</style></head><body>${body}</body></html>`;
+  // The iframe is isolated from the host's `.dark` class and CSS variables, so
+  // bridge the current theme explicitly and expose the same semantic tokens that
+  // generated wireframe/diagram HTML already uses.
+  return `<!doctype html><html data-theme="${theme}"><head><style>:root{color-scheme:light;--wf-paper:#fbfaf6;--wf-card:#ffffff;--wf-ink:#1f1f1d;--wf-muted:#6f6a63;--wf-line:#ded8ce;--wf-radius:12px;--plan-document:var(--wf-paper);--plan-block:var(--wf-card);--plan-text:var(--wf-ink);--plan-muted:var(--wf-muted);--plan-line:var(--wf-line)}:root[data-theme="dark"]{color-scheme:dark;--wf-paper:#201f1c;--wf-card:#2a2825;--wf-ink:#ece8e1;--wf-muted:#9a948b;--wf-line:#43403a;--plan-document:var(--wf-paper);--plan-block:var(--wf-card);--plan-text:var(--wf-ink);--plan-muted:var(--wf-muted);--plan-line:var(--wf-line)}html,body{margin:0;min-height:100%;font-family:Inter,system-ui,sans-serif;color:var(--wf-ink);background:var(--wf-paper)}*{box-sizing:border-box}${css}</style></head><body>${body}</body></html>`;
 }
 
 function HtmlPreview({
@@ -42,11 +45,13 @@ function HtmlPreview({
   title?: string;
   sanitize?: (html: string, css?: string) => string;
 }) {
+  const isDark = useIsDark();
+  const theme = isDark ? "dark" : "light";
   return (
     <>
       <iframe
         title={title || "Custom HTML block"}
-        srcDoc={buildSrcDoc(data, sanitize)}
+        srcDoc={buildSrcDoc(data, theme, sanitize)}
         sandbox="allow-same-origin"
         referrerPolicy="no-referrer"
         className="mt-4 h-[360px] w-full rounded-xl border bg-muted"

--- a/packages/core/src/client/blocks/library/question-form.tsx
+++ b/packages/core/src/client/blocks/library/question-form.tsx
@@ -246,7 +246,7 @@ function QuestionView({
                       // keyboard behaviour clean.
                       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
                       <div
-                        className="ml-8 grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]"
+                        className="ml-8 grid min-w-0 max-w-full gap-4"
                         onClick={(e) => e.stopPropagation()}
                         onKeyDown={(e) => {
                           if (e.key === "Enter" || e.key === " ")

--- a/packages/core/src/client/blocks/library/tabs.tsx
+++ b/packages/core/src/client/blocks/library/tabs.tsx
@@ -62,6 +62,46 @@ function tabOrientation(data: Pick<TabsData, "orientation">): TabsOrientation {
   return data.orientation === "vertical" ? "vertical" : "horizontal";
 }
 
+function tabsUseWideLayout(data: TabsData): boolean {
+  return (
+    tabOrientation(data) === "vertical" ||
+    data.tabs.some((tab) => nestedBlocksContainDiffLike(tab.blocks))
+  );
+}
+
+function nestedBlocksContainDiffLike(blocks: NestedBlock[]): boolean {
+  return blocks.some(nestedBlockContainsDiffLike);
+}
+
+function nestedBlockContainsDiffLike(block: NestedBlock): boolean {
+  if (block.type === "diff" || block.type === "annotated-code") return true;
+
+  const data = (block as { data?: unknown }).data;
+  if (!data || typeof data !== "object") return false;
+
+  const tabs = (data as { tabs?: unknown }).tabs;
+  if (Array.isArray(tabs)) {
+    return tabs.some((tab) => {
+      const blocks = (tab as { blocks?: unknown }).blocks;
+      return Array.isArray(blocks)
+        ? nestedBlocksContainDiffLike(blocks as NestedBlock[])
+        : false;
+    });
+  }
+
+  const columns = (data as { columns?: unknown }).columns;
+  if (Array.isArray(columns)) {
+    return columns.some((column) => {
+      const blocks = (column as { blocks?: unknown }).blocks;
+      return Array.isArray(blocks)
+        ? nestedBlocksContainDiffLike(blocks as NestedBlock[])
+        : false;
+    });
+  }
+
+  return false;
+}
+
 function tabsWith(data: TabsData, tabs: TabsTab[]): TabsData {
   return { ...data, tabs };
 }
@@ -140,8 +180,14 @@ export function TabsBlockReader({
   const compact = isCompact(title);
   const orientation = tabOrientation(data);
   const vertical = orientation === "vertical";
+  const wideLayout = tabsUseWideLayout(data);
   return (
-    <section className="plan-block" data-block-id={blockId}>
+    <section
+      className="plan-block"
+      data-block-id={blockId}
+      data-tabs-orientation={orientation}
+      data-wide-layout-block={wideLayout ? "" : undefined}
+    >
       {title && <div className="plan-block-label">{title}</div>}
       <div className={cn("min-w-0 max-w-full", vertical && "@container/tabs")}>
         <div
@@ -211,6 +257,7 @@ export function TabsBlockEditor({
   const compact = isCompact(title);
   const orientation = tabOrientation(data);
   const vertical = orientation === "vertical";
+  const wideLayout = tabsUseWideLayout(data);
 
   const commit = (tabs: TabsTab[]) => onChange(tabsWith(data, tabs));
 
@@ -263,6 +310,8 @@ export function TabsBlockEditor({
     <div
       className={cn("min-w-0", vertical && "@container/tabs")}
       data-tabs-edit-block={blockId}
+      data-tabs-orientation={orientation}
+      data-wide-layout-block={wideLayout ? "" : undefined}
     >
       <div
         className={cn(

--- a/packages/core/src/client/blocks/library/wireframe.render.spec.tsx
+++ b/packages/core/src/client/blocks/library/wireframe.render.spec.tsx
@@ -55,6 +55,28 @@ function fitWrapperStyle(html: string): string {
   return innerTag.match(/style="([^"]*)"/)?.[1] ?? "";
 }
 
+function roughScopeInnerHtml(html: string): string {
+  const marker = 'data-rough-scope="wireframe"';
+  const markerIndex = html.indexOf(marker);
+  if (markerIndex < 0) return "";
+  const tagEnd = html.indexOf(">", markerIndex);
+  if (tagEnd < 0) return "";
+
+  let depth = 1;
+  const tagRe = /<\/?div\b[^>]*>/g;
+  tagRe.lastIndex = tagEnd + 1;
+  for (let match = tagRe.exec(html); match; match = tagRe.exec(html)) {
+    const tag = match[0];
+    if (tag.startsWith("</")) {
+      depth -= 1;
+      if (depth === 0) return html.slice(tagEnd + 1, match.index);
+    } else if (!tag.endsWith("/>")) {
+      depth += 1;
+    }
+  }
+  return "";
+}
+
 describe("wireframe auto-height frame", () => {
   it("floors the artboard with min-height and sets no fixed height (kit tree)", () => {
     const html = render({
@@ -130,6 +152,19 @@ describe("wireframe auto-height frame", () => {
 
     expect(html).toContain('aria-label="Switch to clean visual style"');
     expect(html).toContain(">Clean</span>");
+  });
+
+  it("keeps the visual style toggle outside the rough.js measurement scope", () => {
+    const html = render({
+      surface: "browser",
+      html: "<button>Authored mock button</button>",
+    });
+
+    const buttonMarker = 'data-wireframe-style-toggle="true"';
+    expect(html).toContain('data-rough-scope="wireframe"');
+    expect(html).toContain(buttonMarker);
+    expect(html).toContain('data-rough="none"');
+    expect(roughScopeInnerHtml(html)).not.toContain(buttonMarker);
   });
 
   it("renders allowlisted icon markers as inline Tabler-style SVG icons", () => {

--- a/packages/core/src/client/blocks/library/wireframe.tsx
+++ b/packages/core/src/client/blocks/library/wireframe.tsx
@@ -223,6 +223,7 @@ function ArtboardFrame({
       }}
     >
       <div
+        className="group/wireframe-artboard relative"
         style={{
           width: "100%",
           maxWidth: maxFrameWidth,
@@ -232,7 +233,8 @@ function ArtboardFrame({
       >
         <div
           ref={ref}
-          className="group/wireframe-artboard plan-kit-artboard relative"
+          className="plan-kit-artboard relative"
+          data-rough-scope="wireframe"
           style={{
             width,
             // Auto-height by default (content-driven, floored at `minHeight`);
@@ -277,8 +279,8 @@ function ArtboardFrame({
             frameRadius={preset.radius}
             selector={selector}
           />
-          {!designMode && !skeleton && <WireframeStyleToggleButton />}
         </div>
+        {!designMode && !skeleton && <WireframeStyleToggleButton />}
       </div>
       {caption && (
         <p className="mt-2 text-center text-xs text-plan-muted">{caption}</p>
@@ -297,6 +299,8 @@ function WireframeStyleToggleButton() {
     <button
       type="button"
       data-plan-interactive
+      data-rough="none"
+      data-wireframe-style-toggle
       aria-label={description}
       title={description}
       onClick={(event) => {

--- a/packages/core/src/client/blocks/library/wireframe.tsx
+++ b/packages/core/src/client/blocks/library/wireframe.tsx
@@ -446,6 +446,7 @@ export function WireframeBlock({
   title,
   summary,
   ctx,
+  compactVisuals,
 }: BlockReadProps<WireframeData>) {
   return (
     <section
@@ -454,7 +455,7 @@ export function WireframeBlock({
       data-block-id={blockId}
     >
       {title && <div className="an-block-label plan-block-label">{title}</div>}
-      <WireframeSurfaceView data={data} ctx={ctx} />
+      <WireframeSurfaceView data={data} ctx={ctx} compact={compactVisuals} />
       {summary && <p className="mt-5 text-plan-muted">{summary}</p>}
     </section>
   );

--- a/packages/core/src/client/blocks/types.ts
+++ b/packages/core/src/client/blocks/types.ts
@@ -307,6 +307,8 @@ export interface BlockReadProps<TData> {
   summary?: string;
   /** Injected app capabilities. */
   ctx: BlockRenderContext;
+  /** Tighten embedded visuals in dense contexts such as tabs and question cards. */
+  compactVisuals?: boolean;
 }
 
 /** Props passed to a block's editor (custom or schema-generated). */

--- a/packages/core/src/client/chat/run-recovery.tsx
+++ b/packages/core/src/client/chat/run-recovery.tsx
@@ -397,18 +397,23 @@ export function ApiKeyConnect({ onConnected }: { onConnected?: () => void }) {
 
 // ─── BuilderSetupCard ─────────────────────────────────────────────────────────
 
+export type BuilderSetupCardLayout = "default" | "sidebar";
+
 export function BuilderSetupCard({
   onConnected,
   bouncePulse,
   fullWidth,
+  layout = "default",
 }: {
   onConnected?: () => void;
   bouncePulse?: number;
   fullWidth?: boolean;
+  layout?: BuilderSetupCardLayout;
 }) {
   // Progressive disclosure: the card leads with one-click Builder connect while
   // keeping the bring-your-own-key path close by.
   const [keyOpen, setKeyOpen] = useState(false);
+  const sidebarLayout = layout === "sidebar";
 
   const cardRef = useRef<HTMLDivElement>(null);
   // Replay the bounce keyframe each time bouncePulse increments. Toggling the
@@ -426,11 +431,13 @@ export function BuilderSetupCard({
   return (
     <div
       ref={cardRef}
-      className={
+      className={cn(
         fullWidth
           ? "w-full pb-2"
-          : "mx-auto w-full max-w-[42rem] px-3 pb-2 sm:w-fit"
-      }
+          : sidebarLayout
+            ? "mx-auto w-full max-w-[42rem] px-3 pb-2"
+            : "mx-auto w-full max-w-[42rem] px-3 pb-2 sm:w-fit",
+      )}
     >
       <div className="rounded-lg border border-border/80 bg-background/80 p-3 shadow-sm backdrop-blur">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -442,15 +449,27 @@ export function BuilderSetupCard({
               Use Builder.io (free credits), or add an Anthropic/OpenAI key.
             </p>
           </div>
-          <div className="flex shrink-0 flex-nowrap items-center gap-2">
+          <div
+            className={cn(
+              "flex shrink-0",
+              sidebarLayout
+                ? "flex-col items-start gap-0 sm:items-center"
+                : "flex-nowrap items-center gap-2",
+            )}
+          >
             <BuilderConnectCta variant="compact" onConnected={onConnected} />
             <button
               type="button"
               onClick={() => setKeyOpen((open) => !open)}
-              className="inline-flex h-8 shrink-0 items-center whitespace-nowrap rounded-md border border-border bg-background px-3 text-[11px] font-medium text-foreground hover:bg-accent"
+              className={cn(
+                "inline-flex shrink-0 items-center whitespace-nowrap rounded-md text-[11px] font-medium",
+                sidebarLayout
+                  ? "h-7 border-0 bg-transparent px-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
+                  : "h-8 border border-border bg-background px-3 text-foreground hover:bg-accent",
+              )}
               aria-expanded={keyOpen}
             >
-              Use API key
+              {sidebarLayout ? "Or, use API key" : "Use API key"}
             </button>
           </div>
         </div>

--- a/packages/core/src/client/rich-markdown-editor/DragHandle.ts
+++ b/packages/core/src/client/rich-markdown-editor/DragHandle.ts
@@ -580,10 +580,11 @@ export const DragHandle = Extension.create<DragHandleOptions>({
       }
 
       const wrapperRect = wrapper.getBoundingClientRect();
+      const handleLeft = block.rect.left - wrapperRect.left - 24;
 
       handle.style.display = "flex";
       handle.style.top = `${block.rect.top - wrapperRect.top + 2}px`;
-      handle.style.left = "-24px";
+      handle.style.left = `${handleLeft}px`;
     };
 
     const selectBlockAt = (editorView: EditorView, pos: number) => {

--- a/scripts/guard-no-localhost-fallback.mjs
+++ b/scripts/guard-no-localhost-fallback.mjs
@@ -94,6 +94,9 @@ const SKIP_DIRS = new Set([
   ".react-router",
   ".generated",
   ".claude",
+  ".video-bakeoff",
+  ".video-bakeoff-recording",
+  ".vscode-test",
   "out",
   "coverage",
 ]);

--- a/skills/visual-plans/SKILL.md
+++ b/skills/visual-plans/SKILL.md
@@ -166,6 +166,12 @@ is reachable. Local-files privacy mode (after Tool Guidance) is the exception.
    and put `diagram`, `data-model`,
    `api-endpoint`, `diff`, `file-tree`, `code`, and `annotated-code` blocks
    directly next to the relevant prose.
+   Wide document layout is renderer-owned and intentionally allowlisted: only
+   literal code-review surfaces (`diff`, `annotated-code`) and `tabs` blocks
+   with vertical orientation or diff-like children break out wider than prose.
+   Keep `api-endpoint`, `openapi-spec`, `data-model`, `json-explorer`,
+   `wireframe`, question, and `custom-html` blocks in normal document flow unless
+   their own renderer says otherwise.
 4. Surface the returned Plans link or inline MCP App and ask the user to review.
    Always include the actual URL in chat so the next step is a click in CLI or
    other text-only hosts. When the host exposes an embedded browser/preview panel

--- a/skills/visual-plans/references/document-quality.md
+++ b/skills/visual-plans/references/document-quality.md
@@ -165,6 +165,11 @@ blocks for normal plans. For architecture/code reviews, use `diagram`
 requested mockup, UI state, or visual comparison. If UI fidelity requires
 HTML/CSS, image capture, or real React/CSS, the product fix is canvas support
 for that artifact type, not moving the mockup into the document.
+When `custom-html` is genuinely needed, author it against the sandbox-provided
+theme tokens (`--wf-paper`, `--wf-card`, `--wf-ink`, `--wf-muted`,
+`--wf-line`, `--wf-radius`, and the matching `--plan-*` aliases). Do not hardcode
+hex/rgb/hsl light palettes such as white cards with dark ink; the same fragment
+must read in dark mode without a plan-specific patch.
 
 **Before handoff, open the plan and check it.** Fix overlap, excessive
 whitespace, clipped fragments, misleading inactive controls, poor contrast, and

--- a/skills/visual-recap/SKILL.md
+++ b/skills/visual-recap/SKILL.md
@@ -411,6 +411,11 @@ tags — resolve every conceptual name to its exact tag + prop schema with the
   full document width. Let that heading label the section — do NOT also set a
   `title` on the `tabs` block. Keep each tab label to the file path or a short
   basename plus directory hint.
+  The renderer's wide document layout is intentionally allowlisted: `diff`,
+  `annotated-code`, vertical `tabs`, and `tabs` containing diff-like children
+  break out wider than prose. Do not put API endpoints, OpenAPI specs, data
+  models, JSON explorers, wireframes, question forms, or custom HTML into tabs
+  merely to make them wide.
   If the recap ends with more than one supporting diff, that trailing diff
   appendix should be one horizontal `tabs` block under its own `## Key changes`
   heading, not a stack of separate `diff` blocks.

--- a/templates/clips/app/components/recorder/camera-positioner.ts
+++ b/templates/clips/app/components/recorder/camera-positioner.ts
@@ -67,11 +67,30 @@ export function clampToViewport(
   viewport: { width: number; height: number },
   gutter = GUTTER_PX,
 ): { left: number; top: number } {
+  return clampRectToViewport(
+    left,
+    top,
+    { width: bubbleSize, height: bubbleSize },
+    viewport,
+    gutter,
+  );
+}
+
+export function clampRectToViewport(
+  left: number,
+  top: number,
+  rect: { width: number; height: number },
+  viewport: { width: number; height: number },
+  gutter = GUTTER_PX,
+): { left: number; top: number } {
   return {
     left: Math.max(
       gutter,
-      Math.min(viewport.width - bubbleSize - gutter, left),
+      Math.min(viewport.width - rect.width - gutter, left),
     ),
-    top: Math.max(gutter, Math.min(viewport.height - bubbleSize - gutter, top)),
+    top: Math.max(
+      gutter,
+      Math.min(viewport.height - rect.height - gutter, top),
+    ),
   };
 }

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -1322,15 +1322,7 @@ export class RecorderEngine {
 
   private buildCombinedStream(): MediaStream {
     if (this.opts.mode === "screen") {
-      const combined = new MediaStream();
-      for (const t of this.displayStream!.getVideoTracks())
-        combined.addTrack(t);
-      const audio = this.buildMixedAudioTrack([
-        this.micStream,
-        this.displayStream,
-      ]);
-      if (audio) combined.addTrack(audio);
-      return combined;
+      return this.buildDisplayRecordingStream();
     }
 
     // Camera-only: camera video + mic.
@@ -1340,6 +1332,14 @@ export class RecorderEngine {
       const audio = this.buildMixedAudioTrack([this.micStream]);
       if (audio) combined.addTrack(audio);
       return combined;
+    }
+
+    // Full-screen capture records the Clips page itself, including the visible
+    // camera bubble. Baking in another canvas bubble would duplicate the face.
+    if (this.isFullScreenDisplayCapture()) {
+      this.cameraComposite?.cleanup();
+      this.cameraComposite = null;
+      return this.buildDisplayRecordingStream();
     }
 
     // Screen + camera: selected-window capture does not include our separate
@@ -1360,6 +1360,26 @@ export class RecorderEngine {
     ]);
     if (audio) combined.addTrack(audio);
     return combined;
+  }
+
+  private buildDisplayRecordingStream(): MediaStream {
+    const combined = new MediaStream();
+    for (const track of this.displayStream!.getVideoTracks()) {
+      combined.addTrack(track);
+    }
+    const audio = this.buildMixedAudioTrack([
+      this.micStream,
+      this.displayStream,
+    ]);
+    if (audio) combined.addTrack(audio);
+    return combined;
+  }
+
+  private isFullScreenDisplayCapture(): boolean {
+    const actualDisplaySurface = this.displayStream
+      ?.getVideoTracks()[0]
+      ?.getSettings().displaySurface;
+    return actualDisplaySurface === "monitor";
   }
 
   private cameraBubbleSizeRatio(): number {

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -1334,17 +1334,9 @@ export class RecorderEngine {
       return combined;
     }
 
-    // Full-screen capture records the Clips page itself, including the visible
-    // camera bubble. Baking in another canvas bubble would duplicate the face.
-    if (this.isFullScreenDisplayCapture()) {
-      this.cameraComposite?.cleanup();
-      this.cameraComposite = null;
-      return this.buildDisplayRecordingStream();
-    }
-
-    // Screen + camera: selected-window capture does not include our separate
-    // DOM bubble, so the saved recording must composite the camera feed into
-    // the video stream before MediaRecorder sees it.
+    // Screen + camera: display capture does not reliably include our separate
+    // DOM bubble once the user records another app/window, so the saved
+    // recording must composite the camera feed before MediaRecorder sees it.
     this.cameraComposite?.cleanup();
     this.cameraComposite = createCameraCompositeStream({
       displayStream: this.displayStream!,
@@ -1373,13 +1365,6 @@ export class RecorderEngine {
     ]);
     if (audio) combined.addTrack(audio);
     return combined;
-  }
-
-  private isFullScreenDisplayCapture(): boolean {
-    const actualDisplaySurface = this.displayStream
-      ?.getVideoTracks()[0]
-      ?.getSettings().displaySurface;
-    return actualDisplaySurface === "monitor";
   }
 
   private cameraBubbleSizeRatio(): number {

--- a/templates/clips/app/components/recorder/recording-toolbar.tsx
+++ b/templates/clips/app/components/recorder/recording-toolbar.tsx
@@ -6,11 +6,7 @@ import {
   IconPlayerStop,
   IconX,
 } from "@tabler/icons-react";
-import {
-  clampToViewport,
-  snapToCorner,
-  type BubblePosition,
-} from "./camera-positioner";
+import { clampToViewport, type BubblePosition } from "./camera-positioner";
 import {
   Tooltip,
   TooltipContent,
@@ -51,8 +47,8 @@ export function RecordingToolbar({
       ? { left: 16, top: 16, corner: "tl" }
       : {
           left: Math.max(16, (window.innerWidth - TOOLBAR_WIDTH) / 2),
-          top: window.innerHeight - TOOLBAR_HEIGHT - 32,
-          corner: "bl",
+          top: Math.max(16, (window.innerHeight - TOOLBAR_HEIGHT) / 2),
+          corner: "tl",
         },
   );
   const [dragging, setDragging] = useState(false);
@@ -60,14 +56,25 @@ export function RecordingToolbar({
 
   useEffect(() => {
     function onResize() {
-      setPos((p) =>
-        snapToCorner(p.left, p.top, Math.max(TOOLBAR_WIDTH, TOOLBAR_HEIGHT), {
-          width: window.innerWidth,
-          height: window.innerHeight,
-        }),
-      );
+      setPos((p) => {
+        const clamped = clampToViewport(
+          p.left,
+          p.top,
+          Math.max(TOOLBAR_WIDTH, TOOLBAR_HEIGHT),
+          {
+            width: window.innerWidth,
+            height: window.innerHeight,
+          },
+        );
+        return {
+          ...p,
+          left: clamped.left,
+          top: clamped.top,
+        };
+      });
     }
     window.addEventListener("resize", onResize);
+    onResize();
     return () => window.removeEventListener("resize", onResize);
   }, []);
 

--- a/templates/clips/app/components/recorder/recording-toolbar.tsx
+++ b/templates/clips/app/components/recorder/recording-toolbar.tsx
@@ -6,7 +6,7 @@ import {
   IconPlayerStop,
   IconX,
 } from "@tabler/icons-react";
-import { clampToViewport, type BubblePosition } from "./camera-positioner";
+import { clampRectToViewport, type BubblePosition } from "./camera-positioner";
 import {
   Tooltip,
   TooltipContent,
@@ -57,10 +57,10 @@ export function RecordingToolbar({
   useEffect(() => {
     function onResize() {
       setPos((p) => {
-        const clamped = clampToViewport(
+        const clamped = clampRectToViewport(
           p.left,
           p.top,
-          Math.max(TOOLBAR_WIDTH, TOOLBAR_HEIGHT),
+          { width: TOOLBAR_WIDTH, height: TOOLBAR_HEIGHT },
           {
             width: window.innerWidth,
             height: window.innerHeight,
@@ -96,10 +96,10 @@ export function RecordingToolbar({
     const { dx, dy } = dragOffsetRef.current;
     const left = e.clientX - dx;
     const top = e.clientY - dy;
-    const clamped = clampToViewport(
+    const clamped = clampRectToViewport(
       left,
       top,
-      Math.max(TOOLBAR_WIDTH, TOOLBAR_HEIGHT),
+      { width: TOOLBAR_WIDTH, height: TOOLBAR_HEIGHT },
       { width: window.innerWidth, height: window.innerHeight },
     );
     setPos((prev) => ({ ...prev, left: clamped.left, top: clamped.top }));

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -60,16 +60,6 @@ async function writeAppState(key: string, value: unknown): Promise<void> {
     },
   );
 }
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { toast } from "sonner";
@@ -679,7 +669,6 @@ export default function RecordRoute() {
   const [error, setError] = useState<string | null>(null);
   const [isPaused, setIsPaused] = useState(false);
   const [elapsedMs, setElapsedMs] = useState(0);
-  const [showStopConfirm, setShowStopConfirm] = useState(false);
   const [cameraStream, setCameraStream] = useState<MediaStream | null>(null);
   const [cameraSize, setCameraSize] = useState<CameraBubbleSize>("md");
   const [previewStream, setPreviewStream] = useState<MediaStream | null>(null);
@@ -743,10 +732,6 @@ export default function RecordRoute() {
   // Stable ref to doStop so engine callbacks created during startFlow always
   // call the latest version (avoids stale-closure problems with useCallback deps).
   const doStopRef = useRef<() => Promise<void>>(async () => {});
-  // Tracks whether opening the stop-confirm dialog auto-paused a live
-  // recording — so closing the dialog without choosing an action resumes
-  // it, but doesn't unpause a recording the user had paused themselves.
-  const autoPausedForStopConfirmRef = useRef(false);
   const pendingStartOptsRef = useRef<{
     mode: RecordingMode;
     displaySurface: DisplaySurface;
@@ -1640,30 +1625,6 @@ export default function RecordRoute() {
     toast.success("Recording download started");
   }, []);
 
-  const requestStop = useCallback(() => {
-    const engine = engineRef.current;
-    if (engine && engine.getState() === "recording") {
-      engine.pause();
-      setIsPaused(true);
-      autoPausedForStopConfirmRef.current = true;
-    } else {
-      autoPausedForStopConfirmRef.current = false;
-    }
-    setShowStopConfirm(true);
-  }, []);
-
-  const onStopConfirmOpenChange = useCallback((open: boolean) => {
-    setShowStopConfirm(open);
-    if (!open && autoPausedForStopConfirmRef.current) {
-      const engine = engineRef.current;
-      if (engine && engine.getState() === "paused") {
-        engine.resume();
-        setIsPaused(false);
-      }
-      autoPausedForStopConfirmRef.current = false;
-    }
-  }, []);
-
   const doCancel = useCallback(async () => {
     // Invalidate any in-flight startFlow().
     startSessionRef.current += 1;
@@ -1731,8 +1692,8 @@ export default function RecordRoute() {
       const ctrl = e.ctrlKey;
       const k = e.key.toLowerCase();
 
-      // Esc cancels the pre-record countdown. Once recording is live, it opens
-      // the stop confirmation instead.
+      // Esc cancels the pre-record countdown. Once recording is live, it
+      // finishes the clip just like the stop button.
       if (e.key === "Escape") {
         if (uiState === "countdown") {
           e.preventDefault();
@@ -1740,14 +1701,10 @@ export default function RecordRoute() {
           void doCancel();
           return;
         }
-        if (!showStopConfirm && uiState === "recording") {
+        if (uiState === "recording") {
           e.preventDefault();
-          // Stop propagation so the same Esc keydown doesn't also trigger
-          // the AlertDialog's built-in Esc-to-close handler, which would
-          // immediately dismiss the dialog the moment it opens — leaving
-          // the user trapped in recording state with a flickering dialog.
           e.stopPropagation();
-          requestStop();
+          void doStop();
           return;
         }
       }
@@ -1790,15 +1747,7 @@ export default function RecordRoute() {
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [
-    uiState,
-    showStopConfirm,
-    togglePause,
-    doCancel,
-    restart,
-    fireConfetti,
-    requestStop,
-  ]);
+  }, [uiState, togglePause, doCancel, doStop, restart, fireConfetti]);
 
   // Query params can preselect recorder controls, but browser capture must
   // still start from the user's Start click. Calling getDisplayMedia from an
@@ -2002,9 +1951,9 @@ export default function RecordRoute() {
           elapsedMs={elapsedMs}
           isPaused={isPaused}
           onTogglePause={togglePause}
-          onStop={requestStop}
+          onStop={() => void doStop()}
           onConfetti={fireConfetti}
-          onCancel={requestStop}
+          onCancel={() => void doCancel()}
         />
       )}
 
@@ -2099,54 +2048,6 @@ export default function RecordRoute() {
           )}
         </div>
       )}
-
-      {/* Stop confirmation */}
-      <AlertDialog
-        open={showStopConfirm}
-        onOpenChange={onStopConfirmOpenChange}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Stop recording?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Save this recording to your library, discard it, or keep going.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter className="flex-col sm:flex-row gap-2">
-            <AlertDialogCancel>Keep recording</AlertDialogCancel>
-            <Button
-              variant="outline"
-              onClick={() => {
-                autoPausedForStopConfirmRef.current = false;
-                setShowStopConfirm(false);
-                void doCancel();
-              }}
-            >
-              Discard
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => {
-                autoPausedForStopConfirmRef.current = false;
-                setShowStopConfirm(false);
-                void restart();
-              }}
-            >
-              Restart
-            </Button>
-            <AlertDialogAction
-              onClick={() => {
-                autoPausedForStopConfirmRef.current = false;
-                setShowStopConfirm(false);
-                void doStop();
-              }}
-              className="bg-primary text-primary-foreground hover:bg-primary/90"
-            >
-              Stop and save
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   );
 }

--- a/templates/plan/.agents/skills/visual-plan/SKILL.md
+++ b/templates/plan/.agents/skills/visual-plan/SKILL.md
@@ -166,6 +166,12 @@ is reachable. Local-files privacy mode (after Tool Guidance) is the exception.
    and put `diagram`, `data-model`,
    `api-endpoint`, `diff`, `file-tree`, `code`, and `annotated-code` blocks
    directly next to the relevant prose.
+   Wide document layout is renderer-owned and intentionally allowlisted: only
+   literal code-review surfaces (`diff`, `annotated-code`) and `tabs` blocks
+   with vertical orientation or diff-like children break out wider than prose.
+   Keep `api-endpoint`, `openapi-spec`, `data-model`, `json-explorer`,
+   `wireframe`, question, and `custom-html` blocks in normal document flow unless
+   their own renderer says otherwise.
 4. Surface the returned Plans link or inline MCP App and ask the user to review.
    Always include the actual URL in chat so the next step is a click in CLI or
    other text-only hosts. When the host exposes an embedded browser/preview panel

--- a/templates/plan/.agents/skills/visual-plan/references/document-quality.md
+++ b/templates/plan/.agents/skills/visual-plan/references/document-quality.md
@@ -165,6 +165,11 @@ blocks for normal plans. For architecture/code reviews, use `diagram`
 requested mockup, UI state, or visual comparison. If UI fidelity requires
 HTML/CSS, image capture, or real React/CSS, the product fix is canvas support
 for that artifact type, not moving the mockup into the document.
+When `custom-html` is genuinely needed, author it against the sandbox-provided
+theme tokens (`--wf-paper`, `--wf-card`, `--wf-ink`, `--wf-muted`,
+`--wf-line`, `--wf-radius`, and the matching `--plan-*` aliases). Do not hardcode
+hex/rgb/hsl light palettes such as white cards with dark ink; the same fragment
+must read in dark mode without a plan-specific patch.
 
 **Before handoff, open the plan and check it.** Fix overlap, excessive
 whitespace, clipped fragments, misleading inactive controls, poor contrast, and

--- a/templates/plan/.agents/skills/visual-recap/SKILL.md
+++ b/templates/plan/.agents/skills/visual-recap/SKILL.md
@@ -411,6 +411,11 @@ tags — resolve every conceptual name to its exact tag + prop schema with the
   full document width. Let that heading label the section — do NOT also set a
   `title` on the `tabs` block. Keep each tab label to the file path or a short
   basename plus directory hint.
+  The renderer's wide document layout is intentionally allowlisted: `diff`,
+  `annotated-code`, vertical `tabs`, and `tabs` containing diff-like children
+  break out wider than prose. Do not put API endpoints, OpenAPI specs, data
+  models, JSON explorers, wireframes, question forms, or custom HTML into tabs
+  merely to make them wide.
   If the recap ends with more than one supporting diff, that trailing diff
   appendix should be one horizontal `tabs` block under its own `## Key changes`
   heading, not a stack of separate `diff` blocks.

--- a/templates/plan/app/components/plan/DocumentArea.tsx
+++ b/templates/plan/app/components/plan/DocumentArea.tsx
@@ -192,6 +192,7 @@ function PlanBlockViewInner({
           } as PlanBlock)
         }
         ctx={blockRegistry.ctx}
+        compactVisuals={compactVisuals}
       />
     );
     // In INLINE / CONTAINER edit mode the auto-editor / custom Edit often renders
@@ -670,8 +671,14 @@ function TabsBlock({
   const orientation =
     block.data.orientation === "vertical" ? "vertical" : "horizontal";
   const vertical = orientation === "vertical";
+  const wideLayout = tabsBlockUsesWideLayout(block);
   return (
-    <section className="plan-block" data-block-id={block.id}>
+    <section
+      className="plan-block"
+      data-block-id={block.id}
+      data-tabs-orientation={orientation}
+      data-wide-layout-block={wideLayout ? "" : undefined}
+    >
       {block.title && <div className="plan-block-label">{block.title}</div>}
       <div
         className={cn(
@@ -755,6 +762,32 @@ function TabsBlock({
       </div>
     </section>
   );
+}
+
+function tabsBlockUsesWideLayout(
+  block: Extract<PlanBlock, { type: "tabs" }>,
+): boolean {
+  return (
+    block.data.orientation === "vertical" ||
+    block.data.tabs.some((tab) => blocksContainDiff(tab.blocks))
+  );
+}
+
+function blocksContainDiff(blocks: PlanBlock[]): boolean {
+  return blocks.some(blockContainsDiff);
+}
+
+function blockContainsDiff(block: PlanBlock): boolean {
+  if (block.type === "diff") return true;
+  if (block.type === "tabs") {
+    return block.data.tabs.some((tab) => blocksContainDiff(tab.blocks));
+  }
+  if (block.type === "columns") {
+    return block.data.columns.some((column) =>
+      blocksContainDiff(column.blocks),
+    );
+  }
+  return false;
 }
 
 function CustomHtmlBlock({

--- a/templates/plan/app/components/plan/DocumentArea.tsx
+++ b/templates/plan/app/components/plan/DocumentArea.tsx
@@ -769,22 +769,22 @@ function tabsBlockUsesWideLayout(
 ): boolean {
   return (
     block.data.orientation === "vertical" ||
-    block.data.tabs.some((tab) => blocksContainDiff(tab.blocks))
+    block.data.tabs.some((tab) => blocksContainDiffLike(tab.blocks))
   );
 }
 
-function blocksContainDiff(blocks: PlanBlock[]): boolean {
-  return blocks.some(blockContainsDiff);
+function blocksContainDiffLike(blocks: PlanBlock[]): boolean {
+  return blocks.some(blockContainsDiffLike);
 }
 
-function blockContainsDiff(block: PlanBlock): boolean {
-  if (block.type === "diff") return true;
+function blockContainsDiffLike(block: PlanBlock): boolean {
+  if (block.type === "diff" || block.type === "annotated-code") return true;
   if (block.type === "tabs") {
-    return block.data.tabs.some((tab) => blocksContainDiff(tab.blocks));
+    return block.data.tabs.some((tab) => blocksContainDiffLike(tab.blocks));
   }
   if (block.type === "columns") {
     return block.data.columns.some((column) =>
-      blocksContainDiff(column.blocks),
+      blocksContainDiffLike(column.blocks),
     );
   }
   return false;

--- a/templates/plan/app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx
@@ -630,7 +630,7 @@ describe("PlanContentRenderer recap files sidebar", () => {
     expect(container.querySelector(".plan-document-toc-inline")).toBeNull();
   });
 
-  it("moves file-tree blocks into the sidebar for non-recap wide plans too", () => {
+  it("leaves non-recap plans editable in-flow instead of moving file trees to a read-only rail", () => {
     act(() => {
       root.render(
         <PlanContentRenderer
@@ -642,17 +642,13 @@ describe("PlanContentRenderer recap files sidebar", () => {
       );
     });
 
-    const aside = container.querySelector(".plan-document-files");
-    expect(aside).not.toBeNull();
-    expect(
-      aside?.querySelector(".plan-document-files__label")?.textContent?.trim(),
-    ).toBe("Files changed");
+    expect(container.querySelector(".plan-document-files")).toBeNull();
     const flow = container.querySelector(".plan-document-flow");
     expect(flow?.querySelector('[data-block-id="tree-1"]')).not.toBeNull();
     const styles = Array.from(container.querySelectorAll("style"))
       .map((node) => node.textContent ?? "")
       .join("\n");
-    expect(styles).toContain('[data-block-id="tree-1"]');
+    expect(styles).not.toContain('[data-block-id="tree-1"]');
   });
 
   it("can hide recap chrome, changed files, and contents for screenshot mode", () => {

--- a/templates/plan/app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx
@@ -11,17 +11,10 @@ import {
 } from "./wireframe/use-wireframe-style";
 
 /**
- * Recap "Files touched" sidebar wiring. On wide recap screens the first
- * `file-tree` block is mirrored into a permanent left sidebar
- * (`.plan-document-files`) while the in-flow copy is hidden via an injected,
- * breakpoint-scoped rule — so the block stays the editable source of truth and is
- * never dropped on save. The mirror carries a distinct `…__aside` id so it never
- * collides with (or gets hidden by) the original, and the relocated block drops
- * out of the contents rail (its in-flow anchor is hidden and unscrollable).
- *
- * Read-mode is rendered here (no persistence handler ⇒ no Tiptap editor), which
- * is the per-block path; the editable path hides the same block via the same
- * descendant rule.
+ * Recap changed-files wiring. The first `file-tree` block stays inline in the
+ * document so it remains the editable source of truth and is never dropped on
+ * save. Screenshot/export mode can still hide the changed-files block and its
+ * standalone heading so generated PR recap screenshots stay focused.
  */
 
 function recapContent(): PlanContent {
@@ -217,7 +210,7 @@ class MockResizeObserver {
   disconnect() {}
 }
 
-describe("PlanContentRenderer recap files sidebar", () => {
+describe("PlanContentRenderer recap changed files", () => {
   let container: HTMLDivElement;
   let root: Root;
 
@@ -311,7 +304,7 @@ describe("PlanContentRenderer recap files sidebar", () => {
     );
   });
 
-  it("mirrors the first file-tree into a left sidebar and omits it from the contents", () => {
+  it("keeps the first file-tree inline and does not render a read-only files rail", () => {
     act(() => {
       root.render(
         <PlanContentRenderer
@@ -324,56 +317,25 @@ describe("PlanContentRenderer recap files sidebar", () => {
       );
     });
 
-    // The left sidebar exists and shows the relocated block.
-    const aside = container.querySelector(".plan-document-files");
-    expect(aside).not.toBeNull();
-
-    // The sidebar shows exactly ONE file-tree heading, and it reads the fixed
-    // "Files changed" label — NOT the authored title and NOT the stats suffix.
-    // The two heading sources are: the eyebrow `.plan-block-label` (from
-    // `block.title`) and the file-tree's bold summary header (from `data.title`).
-    // Both must be stripped from the mirrored block; only the sidebar's own
-    // `.plan-document-files__label` remains.
-    expect(aside?.querySelectorAll(".plan-block-label").length).toBe(0);
-    const sidebarLabels = aside?.querySelectorAll(
-      ".plan-document-files__label",
-    );
-    expect(sidebarLabels?.length).toBe(1);
-    expect(sidebarLabels?.[0]?.textContent?.trim()).toBe("Files changed");
-    // No stats suffix anywhere in the sidebar heading text.
-    expect(aside?.textContent).not.toContain("+1529");
-    expect(aside?.textContent).not.toContain("9 files)");
-    // The authored title string never appears verbatim in the sidebar.
-    expect(aside?.textContent).not.toContain(
-      "Files changed (+1529 / -534, 9 files)",
-    );
-
-    // The mirror uses a distinct id so it never duplicates / collides with the
-    // original's `data-block-id`.
+    expect(container.querySelector(".plan-document-files")).toBeNull();
     expect(
       container.querySelector('[data-block-id="tree-1__aside"]'),
-    ).not.toBeNull();
+    ).toBeNull();
 
     // The original stays in the document flow (editable source of truth).
     const flow = container.querySelector(".plan-document-flow");
     expect(flow?.querySelector('[data-block-id="tree-1"]')).not.toBeNull();
-
-    // A container-query-scoped rule hides the in-flow copy when the rail shows
-    // (keyed off the surface container, not the viewport).
     const styles = Array.from(container.querySelectorAll("style"))
       .map((node) => node.textContent ?? "")
       .join("\n");
-    expect(styles).toContain('[data-block-id="tree-1"]');
-    expect(styles).toContain("display:none");
-    expect(styles).toContain("@container plan-doc");
-    expect(styles).toContain("min-width: 58rem");
+    expect(styles).not.toContain('[data-block-id="tree-1"]');
 
-    // The contents rail drops the relocated block but keeps the prose sections.
+    // The contents rail keeps the inline file tree and prose sections.
     const toc = container.querySelector(".plan-document-toc");
     expect(toc).not.toBeNull();
+    expect(toc?.textContent).toContain("Files changed");
     expect(toc?.textContent).toContain("Section A");
     expect(toc?.textContent).toContain("Section B");
-    expect(toc?.textContent).not.toContain("Files changed");
   });
 
   it("defaults to wide layout and moves blocks from the first wide component into a breakout zone", () => {
@@ -583,11 +545,11 @@ describe("PlanContentRenderer recap files sidebar", () => {
     expect(sourceLink?.parentElement).toBe(stats?.parentElement);
   });
 
-  it("does not reserve a contents rail when only the files heading + one section remain", () => {
-    // A "Files changed" heading + file-tree both relocate to the left rail, so
-    // the contents nav should count what's LEFT (one real section) — not enough
-    // for a rail. `data-has-toc` must stay absent so the grid reserves no empty
-    // TOC column, and PlanTableOfContents renders neither rail nor accordion.
+  it("does not reserve a contents rail when hidden changed-files content leaves one section", () => {
+    // Screenshot/export mode hides the "Files changed" heading + file-tree. The
+    // contents nav should count what's LEFT (one real section) — not enough for a
+    // rail. `data-has-toc` must stay absent so the grid reserves no empty TOC
+    // column, and PlanTableOfContents renders neither rail nor accordion.
     const content = {
       version: 2,
       title: "Recap",
@@ -618,6 +580,7 @@ describe("PlanContentRenderer recap files sidebar", () => {
           content={content}
           isRecap
           editingDisabled
+          hideChangedFiles
           fallbackTitle="Untitled plan"
           fallbackBrief=""
         />,

--- a/templates/plan/app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx
@@ -86,7 +86,14 @@ function recapWideLayoutContent(): PlanContent {
         title: "Files changed",
         data: {
           title: "Files changed",
-          entries: [{ path: "packages/core/src/a.ts", change: "modified" }],
+          entries: [
+            { path: "packages/core/src/a.ts", change: "modified" },
+            {
+              path: "templates/plan/app/pages/PlansPage.tsx",
+              change: "modified",
+              note: "Updated the document layout.",
+            },
+          ],
         },
       },
       {
@@ -405,6 +412,56 @@ describe("PlanContentRenderer recap changed files", () => {
     });
 
     expect(scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("scrolls inline recap file rows to matching wide diff blocks", () => {
+    const scrolledElements: HTMLElement[] = [];
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value(this: HTMLElement) {
+        scrolledElements.push(this);
+      },
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({
+        matches: false,
+        media: "(prefers-reduced-motion: reduce)",
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    act(() => {
+      root.render(
+        <PlanContentRenderer
+          content={recapWideLayoutContent()}
+          isRecap
+          editingDisabled
+          fallbackTitle="Untitled plan"
+          fallbackBrief=""
+        />,
+      );
+    });
+
+    const fileRow = container.querySelector<HTMLButtonElement>(
+      'button[data-file-path="templates/plan/app/pages/PlansPage.tsx"]',
+    );
+    expect(fileRow).not.toBeNull();
+    expect(fileRow?.disabled).toBe(false);
+
+    act(() => {
+      fileRow?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    const target = scrolledElements[scrolledElements.length - 1];
+    expect(target?.getAttribute("data-block-id")).toBe("diff-1");
+    expect(target?.closest(".plan-document-flow--wide-zone")).not.toBeNull();
   });
 
   it("resolves direct hash links into the wide breakout zone", async () => {

--- a/templates/plan/app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx
@@ -81,6 +81,55 @@ function recapWireframeContent(): PlanContent {
   } as unknown as PlanContent;
 }
 
+function recapWideLayoutContent(): PlanContent {
+  return {
+    version: 2,
+    title: "Visual recap",
+    brief: "brief",
+    blocks: [
+      {
+        id: "tree-1",
+        type: "file-tree",
+        title: "Files changed",
+        data: {
+          title: "Files changed",
+          entries: [{ path: "packages/core/src/a.ts", change: "modified" }],
+        },
+      },
+      {
+        id: "intro",
+        type: "rich-text",
+        data: { markdown: "## Intro\n\nThe narrow reading copy stays here." },
+      },
+      {
+        id: "api-1",
+        type: "api-endpoint",
+        title: "Plan generation action",
+        data: {
+          method: "POST",
+          path: "/_agent-native/actions/create-visual-plan",
+          summary: "API blocks stay in the standard document column.",
+        },
+      },
+      {
+        id: "diff-1",
+        type: "diff",
+        title: "Key diff",
+        data: {
+          filename: "templates/plan/app/pages/PlansPage.tsx",
+          before: "const layout = 'narrow';\n",
+          after: "const layout = 'wide';\n",
+        },
+      },
+      {
+        id: "after-wide",
+        type: "rich-text",
+        data: { markdown: "## After wide\n\nLinks still resolve down here." },
+      },
+    ],
+  } as unknown as PlanContent;
+}
+
 function rtlContent(): PlanContent {
   return {
     version: 2,
@@ -323,6 +372,108 @@ describe("PlanContentRenderer recap files sidebar", () => {
     expect(toc?.textContent).toContain("Section A");
     expect(toc?.textContent).toContain("Section B");
     expect(toc?.textContent).not.toContain("Files changed");
+  });
+
+  it("defaults to wide layout and moves blocks from the first wide component into a breakout zone", () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    act(() => {
+      root.render(
+        <PlanContentRenderer
+          content={recapWideLayoutContent()}
+          isRecap
+          editingDisabled
+          fallbackTitle="Untitled plan"
+          fallbackBrief=""
+        />,
+      );
+    });
+
+    const article = container.querySelector<HTMLElement>(
+      "[data-plan-document]",
+    );
+    expect(article?.dataset.planLayout).toBe("wide");
+
+    const body = container.querySelector<HTMLElement>(".plan-document-body");
+    const wideZone = container.querySelector<HTMLElement>(
+      ".plan-document-flow--wide-zone",
+    );
+    expect(body).not.toBeNull();
+    expect(wideZone).not.toBeNull();
+
+    const mainFlow = container.querySelector<HTMLElement>(
+      ".plan-document-flow:not(.plan-document-flow--wide-zone)",
+    );
+    expect(mainFlow).not.toBeNull();
+    expect(mainFlow?.querySelector('[data-block-id="tree-1"]')).not.toBeNull();
+    expect(mainFlow?.querySelector('[data-block-id="intro"]')).not.toBeNull();
+    expect(mainFlow?.querySelector('[data-block-id="api-1"]')).not.toBeNull();
+    expect(
+      mainFlow?.querySelector(
+        '.plan-document-flow-block[data-block-type="api-endpoint"][data-wide-layout-block]',
+      ),
+    ).toBeNull();
+    expect(mainFlow?.querySelector('[data-block-id="diff-1"]')).toBeNull();
+    expect(wideZone?.closest(".plan-document-body")).toBe(body);
+    expect(wideZone?.querySelector('[data-block-id="diff-1"]')).not.toBeNull();
+    expect(
+      wideZone?.querySelector(
+        '.plan-document-flow-block[data-block-type="diff"][data-wide-layout-block]',
+      ),
+    ).not.toBeNull();
+    expect(
+      wideZone?.querySelector('[data-block-id="after-wide"]'),
+    ).not.toBeNull();
+
+    const afterWideLink = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>(".plan-document-toc__link"),
+    ).find((link) => link.textContent?.trim() === "After wide");
+    expect(afterWideLink).toBeDefined();
+
+    act(() => {
+      afterWideLink?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("resolves direct hash links into the wide breakout zone", async () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    window.location.hash = "#plan-heading-after-wide-0";
+
+    act(() => {
+      root.render(
+        <PlanContentRenderer
+          content={recapWideLayoutContent()}
+          isRecap
+          editingDisabled
+          fallbackTitle="Untitled plan"
+          fallbackBrief=""
+        />,
+      );
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 150));
+    });
+
+    const target = container.querySelector<HTMLElement>(
+      "#plan-heading-after-wide-0",
+    );
+    expect(target?.textContent).toContain("After wide");
+    expect(target?.closest(".plan-document-flow--wide-zone")).not.toBeNull();
+    expect(scrollIntoView).toHaveBeenCalled();
+    window.location.hash = "";
   });
 
   it("syncs the clean/sketchy preference into core-rendered recap wireframes", () => {

--- a/templates/plan/app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx
@@ -630,7 +630,7 @@ describe("PlanContentRenderer recap files sidebar", () => {
     expect(container.querySelector(".plan-document-toc-inline")).toBeNull();
   });
 
-  it("leaves non-recap plans unchanged (no files sidebar, no hide style)", () => {
+  it("moves file-tree blocks into the sidebar for non-recap wide plans too", () => {
     act(() => {
       root.render(
         <PlanContentRenderer
@@ -642,13 +642,17 @@ describe("PlanContentRenderer recap files sidebar", () => {
       );
     });
 
-    expect(container.querySelector(".plan-document-files")).toBeNull();
+    const aside = container.querySelector(".plan-document-files");
+    expect(aside).not.toBeNull();
+    expect(
+      aside?.querySelector(".plan-document-files__label")?.textContent?.trim(),
+    ).toBe("Files changed");
     const flow = container.querySelector(".plan-document-flow");
     expect(flow?.querySelector('[data-block-id="tree-1"]')).not.toBeNull();
     const styles = Array.from(container.querySelectorAll("style"))
       .map((node) => node.textContent ?? "")
       .join("\n");
-    expect(styles).not.toContain('[data-block-id="tree-1"]');
+    expect(styles).toContain('[data-block-id="tree-1"]');
   });
 
   it("can hide recap chrome, changed files, and contents for screenshot mode", () => {

--- a/templates/plan/app/components/plan/PlanContentRenderer.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.tsx
@@ -528,18 +528,19 @@ export function PlanContentRenderer({
     ],
   );
 
-  // In wide layout, the first file-tree block moves to a permanent left sidebar
-  // (mirroring the right-hand contents rail) instead of sitting in the document
-  // body. Keep the block in the document so it stays the editable source of
-  // truth and is never dropped on save; render a read-only mirror in the aside,
-  // and hide the in-flow copy at the same breakpoint the rail appears (see
-  // `filesSidebarHideCss`).
+  // On wide recap screens the "Files changed" tree moves to a permanent left
+  // sidebar (mirroring the right-hand contents rail) instead of sitting in the
+  // document body. Keep the block in the document so it stays the editable
+  // source of truth and is never dropped on save; render a read-only mirror in
+  // the aside, and hide the in-flow copy at the same breakpoint the rail appears
+  // (see `filesSidebarHideCss`). Gated to recaps so editable ordinary plans keep
+  // their real file-tree block visible in the document.
   const filesSidebarBlockIndex = useMemo(
     () =>
-      documentLayout === "wide"
+      isRecap && documentLayout === "wide"
         ? content.blocks.findIndex((block) => block.type === "file-tree")
         : -1,
-    [documentLayout, content.blocks],
+    [isRecap, documentLayout, content.blocks],
   );
   const filesSidebarBlock =
     filesSidebarBlockIndex >= 0

--- a/templates/plan/app/components/plan/PlanContentRenderer.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.tsx
@@ -936,29 +936,30 @@ function renderFlowBlockFrame(block: PlanBlock, node: ReactNode) {
 function isWideLayoutBlock(block: PlanBlock): boolean {
   switch (block.type) {
     case "diff":
+    case "annotated-code":
       return true;
     case "tabs":
       return (
         block.data.orientation === "vertical" ||
-        block.data.tabs.some((tab) => blocksContainDiff(tab.blocks))
+        block.data.tabs.some((tab) => blocksContainDiffLike(tab.blocks))
       );
     default:
       return false;
   }
 }
 
-function blocksContainDiff(blocks: PlanBlock[]): boolean {
-  return blocks.some(blockContainsDiff);
+function blocksContainDiffLike(blocks: PlanBlock[]): boolean {
+  return blocks.some(blockContainsDiffLike);
 }
 
-function blockContainsDiff(block: PlanBlock): boolean {
-  if (block.type === "diff") return true;
+function blockContainsDiffLike(block: PlanBlock): boolean {
+  if (block.type === "diff" || block.type === "annotated-code") return true;
   if (block.type === "tabs") {
-    return block.data.tabs.some((tab) => blocksContainDiff(tab.blocks));
+    return block.data.tabs.some((tab) => blocksContainDiffLike(tab.blocks));
   }
   if (block.type === "columns") {
     return block.data.columns.some((column) =>
-      blocksContainDiff(column.blocks),
+      blocksContainDiffLike(column.blocks),
     );
   }
   return false;

--- a/templates/plan/app/components/plan/PlanContentRenderer.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.tsx
@@ -678,7 +678,7 @@ export function PlanContentRenderer({
           // (not canvas) so its containment can't disturb fixed canvas chrome.
           <div className="plan-document-region">
             <div
-              className="plan-document-shell relative mx-auto w-full max-w-[1035px] px-6 pb-12 pt-16 sm:px-10 sm:py-12 lg:py-14"
+              className="plan-document-shell relative mx-auto w-full max-w-[1040px] px-6 pb-12 pt-16 sm:px-10 sm:py-12 lg:py-14"
               data-plan-direction={documentDirection}
               dir={documentDirection}
             >

--- a/templates/plan/app/components/plan/PlanContentRenderer.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.tsx
@@ -8,6 +8,7 @@ import {
   type ClipboardEvent,
   type FormEvent,
   type KeyboardEvent,
+  type MouseEvent,
   type ReactNode,
 } from "react";
 import { IconBrandGithub } from "@tabler/icons-react";
@@ -590,6 +591,43 @@ export function PlanContentRenderer({
     () => new Map(content.blocks.map((block) => [block.id, block])),
     [content.blocks],
   );
+  const fileToBlockIdMap = useMemo<Map<string, string>>(() => {
+    if (!isRecap) return new Map();
+    const map = new Map<string, string>();
+    for (const block of content.blocks) {
+      if (
+        (block.type === "annotated-code" ||
+          block.type === "diff" ||
+          block.type === "code") &&
+        block.data.filename &&
+        !map.has(block.data.filename)
+      ) {
+        map.set(block.data.filename, block.id);
+      }
+    }
+    return map;
+  }, [content.blocks, isRecap]);
+  const handleRecapFileTreeClick = useMemo(() => {
+    if (!isRecap || fileToBlockIdMap.size === 0) return undefined;
+    return (event: MouseEvent<HTMLElement>) => {
+      const filePath = (event.target as HTMLElement)
+        .closest("[data-file-path]")
+        ?.getAttribute("data-file-path");
+      if (!filePath) return;
+      const blockId = fileToBlockIdMap.get(filePath);
+      if (!blockId) return;
+      const el = document.querySelector<HTMLElement>(
+        `[data-block-id="${CSS.escape(blockId)}"]`,
+      );
+      if (!el) return;
+      el.scrollIntoView({
+        behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches
+          ? "auto"
+          : "smooth",
+        block: "start",
+      });
+    };
+  }, [fileToBlockIdMap, isRecap]);
   const firstWideLayoutBlockIndex = useMemo(
     () =>
       documentLayout === "wide"
@@ -742,7 +780,10 @@ export function PlanContentRenderer({
                   />
                 )}
 
-                <div className="plan-document-flow-stack">
+                <div
+                  className="plan-document-flow-stack"
+                  onClick={handleRecapFileTreeClick}
+                >
                   <div className="plan-document-flow">
                     {documentEditable ? (
                       // The whole body is ONE editable rich-markdown document; custom

--- a/templates/plan/app/components/plan/PlanContentRenderer.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.tsx
@@ -528,50 +528,45 @@ export function PlanContentRenderer({
     ],
   );
 
-  // On wide recap screens the "Files changed" tree moves to a permanent left
-  // sidebar (mirroring the right-hand contents rail) instead of sitting in the
-  // document body. Keep the block in the document so it stays the editable
-  // source of truth and is never dropped on save; render a read-only mirror in
-  // the aside, and hide the in-flow copy at the same breakpoint the rail appears
-  // (see `filesSidebarHideCss`). Gated to recaps so editable ordinary plans keep
-  // their real file-tree block visible in the document.
-  const filesSidebarBlockIndex = useMemo(
+  // The first recap file tree remains inline in the document. Screenshot/export
+  // paths can still hide it through `hideChangedFiles`, so generated PR recap
+  // screenshots stay focused on the visual recap content.
+  const changedFilesBlockIndex = useMemo(
     () =>
-      isRecap && documentLayout === "wide"
+      isRecap
         ? content.blocks.findIndex((block) => block.type === "file-tree")
         : -1,
-    [isRecap, documentLayout, content.blocks],
+    [isRecap, content.blocks],
   );
-  const filesSidebarBlock =
-    filesSidebarBlockIndex >= 0
-      ? content.blocks[filesSidebarBlockIndex]
+  const changedFilesBlock =
+    changedFilesBlockIndex >= 0
+      ? content.blocks[changedFilesBlockIndex]
       : undefined;
-  const filesSidebarHeadingBlock =
-    filesSidebarBlockIndex > 0
-      ? content.blocks[filesSidebarBlockIndex - 1]
+  const changedFilesHeadingCandidate =
+    changedFilesBlockIndex > 0
+      ? content.blocks[changedFilesBlockIndex - 1]
       : undefined;
   const changedFilesHeadingBlock = isChangedFilesHeadingBlock(
-    filesSidebarHeadingBlock,
+    changedFilesHeadingCandidate,
   )
-    ? filesSidebarHeadingBlock
+    ? changedFilesHeadingCandidate
     : undefined;
-  const filesSidebarLabel = fileTreeSidebarLabel(filesSidebarBlock, isRecap);
-  // Drop the relocated file-tree and its heading from the contents nav (both are
-  // hidden in the rail layout), so no contents link points at a hidden element.
   const tocOmitBlockIds = useMemo(
     () =>
-      [filesSidebarBlock?.id, changedFilesHeadingBlock?.id].filter(
-        (id): id is string => Boolean(id),
-      ),
-    [filesSidebarBlock?.id, changedFilesHeadingBlock?.id],
+      hideChangedFiles
+        ? [changedFilesBlock?.id, changedFilesHeadingBlock?.id].filter(
+            (id): id is string => Boolean(id),
+          )
+        : [],
+    [changedFilesBlock?.id, changedFilesHeadingBlock?.id, hideChangedFiles],
   );
   const hiddenChangedFileBlockIds = useMemo(() => {
     const ids = new Set<string>();
     if (!hideChangedFiles) return ids;
-    if (filesSidebarBlock) ids.add(filesSidebarBlock.id);
+    if (changedFilesBlock) ids.add(changedFilesBlock.id);
     if (changedFilesHeadingBlock) ids.add(changedFilesHeadingBlock.id);
     return ids;
-  }, [changedFilesHeadingBlock, filesSidebarBlock, hideChangedFiles]);
+  }, [changedFilesBlock, changedFilesHeadingBlock, hideChangedFiles]);
   const renderedBlocks = useMemo(() => {
     const visible =
       hiddenChangedFileBlockIds.size > 0
@@ -579,15 +574,15 @@ export function PlanContentRenderer({
             (block) => !hiddenChangedFileBlockIds.has(block.id),
           )
         : content.blocks;
-    if (!hideChangedFiles || !filesSidebarHeadingBlock) return visible;
+    if (!hideChangedFiles || !changedFilesHeadingCandidate) return visible;
     return visible.map((block) =>
-      block.id === filesSidebarHeadingBlock.id
+      block.id === changedFilesHeadingCandidate.id
         ? stripTrailingChangedFilesHeading(block)
         : block,
     );
   }, [
     content.blocks,
-    filesSidebarHeadingBlock,
+    changedFilesHeadingCandidate,
     hiddenChangedFileBlockIds,
     hideChangedFiles,
   ]);
@@ -609,73 +604,27 @@ export function PlanContentRenderer({
   const breakoutBlocks = splitWideLayout
     ? renderedBlocks.slice(firstWideLayoutBlockIndex)
     : [];
+  const tocContent = useMemo(
+    () =>
+      hideChangedFiles
+        ? {
+            ...content,
+            blocks: renderedBlocks,
+          }
+        : content,
+    [content, hideChangedFiles, renderedBlocks],
+  );
 
   // Which rails exist, mirrored onto the body as data attributes so the grid
   // (global.css) reserves a track only for a rail that renders.
-  const hasFilesRail = Boolean(filesSidebarBlock) && !hideChangedFiles;
-  // Mirror PlanTableOfContents' own omission set (file-tree AND its relocated
-  // heading) so data-has-toc is set iff the rail actually renders ≥2 items —
-  // otherwise a recap with one section left would reserve an empty TOC column.
   const hasTocRail = useMemo(
     () =>
       !hideRecapChrome &&
-      collectPlanTocItems(content.blocks).filter(
+      collectPlanTocItems(tocContent.blocks).filter(
         (item) => !tocOmitBlockIds.includes(item.blockId),
       ).length >= 2,
-    [content.blocks, tocOmitBlockIds, hideRecapChrome],
+    [tocContent.blocks, tocOmitBlockIds, hideRecapChrome],
   );
-
-  /**
-   * Map from file path → first block id that references the file. Built from
-   * annotated-code, diff, and code blocks in the document. Used by the recap
-   * files rail to scroll to the matching block when a file row is clicked.
-   */
-  const fileToBlockIdMap = useMemo<Map<string, string>>(() => {
-    if (!isRecap) return new Map();
-    const map = new Map<string, string>();
-    for (const block of content.blocks) {
-      if (
-        (block.type === "annotated-code" ||
-          block.type === "diff" ||
-          block.type === "code") &&
-        block.data.filename
-      ) {
-        if (!map.has(block.data.filename)) {
-          map.set(block.data.filename, block.id);
-        }
-      }
-    }
-    return map;
-  }, [isRecap, content.blocks]);
-
-  /**
-   * Click handler for the recap files rail aside. When a file row (carrying
-   * `data-file-path`) is clicked, scroll to the matching block in the document
-   * if one exists. The file tree's own expansion click still fires; this only
-   * adds the scroll as a side effect (no event.preventDefault so expansion
-   * still works).
-   */
-  const handleFilesRailClick = useMemo(() => {
-    if (!isRecap || fileToBlockIdMap.size === 0) return undefined;
-    return (event: React.MouseEvent<HTMLElement>) => {
-      const filePath = (event.target as HTMLElement)
-        .closest("[data-file-path]")
-        ?.getAttribute("data-file-path");
-      if (!filePath) return;
-      const blockId = fileToBlockIdMap.get(filePath);
-      if (!blockId) return;
-      const el = document.querySelector<HTMLElement>(
-        `[data-block-id="${CSS.escape(blockId)}"]`,
-      );
-      if (!el) return;
-      el.scrollIntoView({
-        behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches
-          ? "auto"
-          : "smooth",
-        block: "start",
-      });
-    };
-  }, [isRecap, fileToBlockIdMap]);
 
   return (
     <BlockRegistryProvider
@@ -729,7 +678,7 @@ export function PlanContentRenderer({
           // (not canvas) so its containment can't disturb fixed canvas chrome.
           <div className="plan-document-region">
             <div
-              className="plan-document-shell relative mx-auto w-full max-w-[900px] px-6 pb-12 pt-16 sm:px-10 sm:py-12 lg:py-14"
+              className="plan-document-shell relative mx-auto w-full max-w-[1035px] px-6 pb-12 pt-16 sm:px-10 sm:py-12 lg:py-14"
               data-plan-direction={documentDirection}
               dir={documentDirection}
             >
@@ -737,7 +686,6 @@ export function PlanContentRenderer({
                   see global.css. */}
               <div
                 className="plan-document-body"
-                data-has-files={hasFilesRail ? "" : undefined}
                 data-has-toc={hasTocRail ? "" : undefined}
               >
                 <header className="border-b border-plan-line pb-8">
@@ -777,7 +725,7 @@ export function PlanContentRenderer({
                         fileTreeBlock={
                           hideChangedFiles
                             ? undefined
-                            : (filesSidebarBlock as
+                            : (changedFilesBlock as
                                 | PlanFileTreeBlock
                                 | undefined)
                         }
@@ -788,47 +736,10 @@ export function PlanContentRenderer({
 
                 {!hideRecapChrome && (
                   <PlanTableOfContents
-                    content={content}
+                    content={tocContent}
                     isRecap={isRecap}
                     omitBlockIds={tocOmitBlockIds}
                   />
-                )}
-                {filesSidebarBlock && !hideChangedFiles && (
-                  <>
-                    <style>
-                      {filesSidebarHideCss(
-                        filesSidebarBlock.id,
-                        changedFilesHeadingBlock?.id,
-                      )}
-                    </style>
-                    <aside
-                      className="plan-document-files"
-                      aria-label={filesSidebarLabel}
-                      onClick={handleFilesRailClick}
-                    >
-                      <div className="plan-document-files__nav">
-                        {/* The sidebar owns the heading. Strip BOTH the block-level
-                          `title` (the eyebrow `plan-block-label`) and the
-                          file-tree's own `data.title` (the bold summary-header
-                          heading) from the mirrored block so the file-tree renders
-                          heading-free and the label is never duplicated. The
-                          in-flow source block keeps both titles untouched. */}
-                        <div className="plan-document-files__label">
-                          {filesSidebarLabel}
-                        </div>
-                        <PlanBlockView
-                          block={stripFileTreeTitles({
-                            ...filesSidebarBlock,
-                            id: `${filesSidebarBlock.id}__aside`,
-                          })}
-                          editingDisabled
-                          contentUpdatedAt={contentUpdatedAt}
-                          planId={planId}
-                          collabUser={collabUser}
-                        />
-                      </div>
-                    </aside>
-                  </>
                 )}
 
                 <div className="plan-document-flow-stack">
@@ -962,24 +873,9 @@ function blockContainsDiffLike(block: PlanBlock): boolean {
   return false;
 }
 
-/**
- * Strip both heading sources (`title` eyebrow and `data.title` summary header)
- * from a file-tree block so it renders heading-free in the rail, which supplies
- * its own "Files changed" label. Non-file-tree blocks pass through unchanged.
- */
-function stripFileTreeTitles(block: PlanBlock): PlanBlock {
-  if (block.type !== "file-tree") return block;
-  return {
-    ...block,
-    title: undefined,
-    data: { ...block.data, title: undefined },
-  };
-}
-
 // Matches a standalone heading that titles the files section ("Files changed",
-// "Files added", "Files", …) so it can travel with the relocated file-tree
-// instead of stranding an empty section. Anchored, so headings with body text
-// are never hit.
+// "Files added", "Files", ...). Screenshot mode hides the file-tree and should
+// hide that standalone heading too, without touching body sections.
 function isChangedFilesHeadingBlock(block: PlanBlock | undefined): boolean {
   if (!block || block.type !== "rich-text") return false;
   return /^#{1,6}\s+(?:(?:changed|added|removed|touched|modified)\s+files|files(?:\s+(?:changed|added|removed|touched|modified))?)\s*$/i.test(
@@ -995,69 +891,6 @@ function stripTrailingChangedFilesHeading(block: PlanBlock): PlanBlock {
   );
   if (markdown === block.data.markdown) return block;
   return { ...block, data: { ...block.data, markdown: markdown.trimEnd() } };
-}
-
-function fileTreeSidebarLabel(
-  block: PlanBlock | undefined,
-  isRecap: boolean,
-): string {
-  if (!block || block.type !== "file-tree") {
-    return isRecap ? "Files changed" : "Files";
-  }
-  const label = block.title?.trim() || block.data.title?.trim();
-  return stripFileTreeStatsSuffix(
-    label || (isRecap ? "Files changed" : "Files"),
-  );
-}
-
-function stripFileTreeStatsSuffix(label: string): string {
-  return label
-    .replace(/\s*\((?=[^)]*(?:\+|-|−|\d+\s+files?))[^)]*\)\s*$/i, "")
-    .trim();
-}
-
-function filesSidebarHideCss(blockId: string, headingBlockId?: string): string {
-  const id = blockId.replace(/["\\]/g, "\\$&");
-  // Hide the in-flow files block (and its heading) once its rail shows, at the
-  // same thresholds as the grid's files variants (global.css). The next block
-  // reclaims the gap; screenshot capture keeps the inline copy.
-  const hideIds = [id];
-  if (headingBlockId) hideIds.push(headingBlockId.replace(/["\\]/g, "\\$&"));
-  const leadResetSelectors = [
-    ".plan-block",
-    ".plan-callout",
-    ".plan-questions-block",
-    ".an-block-panel",
-    ".plan-block-node",
-    ".plan-document-flow-block",
-  ];
-  const variants = [
-    { min: "48rem", body: "[data-has-files]:not([data-has-toc])" },
-    { min: "58rem", body: "[data-has-files][data-has-toc]" },
-  ];
-  return variants
-    .map(({ min, body }) => {
-      const scope = `.plan-content-surface:not([data-recap-screenshot-theme]) .plan-document-body${body}`;
-      const hide = hideIds.flatMap((hid) => [
-        `${scope} .plan-document-flow [data-block-id="${hid}"]`,
-        `${scope} .plan-document-flow > .plan-document-flow-block:has([data-block-id="${hid}"])`,
-      ]);
-      const leadReset = [
-        ...leadResetSelectors.map(
-          (sel) =>
-            `${scope} .plan-document-flow > [data-block-id="${id}"] + ${sel}`,
-        ),
-        ...leadResetSelectors.map(
-          (sel) =>
-            `${scope} .plan-document-flow > .plan-document-flow-block:has([data-block-id="${id}"]) + ${sel}`,
-        ),
-      ].join(",\n");
-      return `@container plan-doc (min-width: ${min}){
-${hide.join(",\n")}{display:none}
-${leadReset}{margin-top:2.25rem;padding-top:0}
-}`;
-    })
-    .join("\n");
 }
 
 const GITHUB_PR_REFERENCE_RE =

--- a/templates/plan/app/components/plan/PlanContentRenderer.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.tsx
@@ -41,6 +41,10 @@ import { usePlanHashScroll } from "./usePlanHashScroll";
 import { planBlockRegistry, createPlanBlockRenderContext } from "./planBlocks";
 import { getPlanContentDirection } from "./planTextDirection";
 
+type PlanDocumentLayout = "wide" | "narrow";
+
+const DEFAULT_PLAN_DOCUMENT_LAYOUT: PlanDocumentLayout = "wide";
+
 const loadPlanDocumentEditor = () => import("../editor/PlanDocumentEditor");
 const LazyPlanDocumentEditor = lazy(() =>
   loadPlanDocumentEditor().then((mod) => ({ default: mod.PlanDocumentEditor })),
@@ -440,6 +444,7 @@ export function PlanContentRenderer({
     () => getPlanContentDirection(content, fallbackTitle, fallbackBrief),
     [content, fallbackBrief, fallbackTitle],
   );
+  const documentLayout = DEFAULT_PLAN_DOCUMENT_LAYOUT;
 
   const blockRenderContext = useMemo(
     () =>
@@ -580,6 +585,20 @@ export function PlanContentRenderer({
     () => new Map(content.blocks.map((block) => [block.id, block])),
     [content.blocks],
   );
+  const firstWideLayoutBlockIndex = useMemo(
+    () =>
+      documentLayout === "wide"
+        ? renderedBlocks.findIndex(isWideLayoutBlock)
+        : -1,
+    [documentLayout, renderedBlocks],
+  );
+  const splitWideLayout = firstWideLayoutBlockIndex >= 0 && !documentEditable;
+  const railScopedBlocks = splitWideLayout
+    ? renderedBlocks.slice(0, firstWideLayoutBlockIndex)
+    : renderedBlocks;
+  const breakoutBlocks = splitWideLayout
+    ? renderedBlocks.slice(firstWideLayoutBlockIndex)
+    : [];
 
   /**
    * Map from file path → first block id that references the file. Built from
@@ -642,6 +661,7 @@ export function PlanContentRenderer({
         className="plan-content-surface relative min-h-full bg-plan-document text-plan-text"
         data-plan-document
         data-plan-direction={documentDirection}
+        data-plan-layout={documentLayout}
         data-recap-screenshot-theme={recapScreenshotTheme ?? undefined}
       >
         {autosaveFailed && (
@@ -785,17 +805,19 @@ export function PlanContentRenderer({
                   // blocks are inline `planBlock` NodeViews. Read-only / review /
                   // SSR keeps the per-block render below (no Tiptap server-side).
                   <Suspense
-                    fallback={renderedBlocks.map((block) => (
-                      <PlanBlockView
-                        key={block.id}
-                        block={block}
-                        onVisualQuestionsSubmit={onVisualQuestionsSubmit}
-                        contentUpdatedAt={contentUpdatedAt}
-                        editingDisabled
-                        planId={planId}
-                        collabUser={collabUser}
-                      />
-                    ))}
+                    fallback={renderedBlocks.map((block) =>
+                      renderFlowBlockFrame(
+                        block,
+                        <PlanBlockView
+                          block={block}
+                          onVisualQuestionsSubmit={onVisualQuestionsSubmit}
+                          contentUpdatedAt={contentUpdatedAt}
+                          editingDisabled
+                          planId={planId}
+                          collabUser={collabUser}
+                        />,
+                      ),
+                    )}
                   >
                     <LazyPlanDocumentEditor
                       content={content}
@@ -808,27 +830,100 @@ export function PlanContentRenderer({
                     />
                   </Suspense>
                 ) : (
-                  renderedBlocks.map((block) => (
-                    <PlanBlockView
-                      key={block.id}
-                      block={block}
-                      onChange={(nextBlock) => updateBlock(block.id, nextBlock)}
-                      onRichTextChange={updateRichTextBlock}
-                      onVisualQuestionsSubmit={onVisualQuestionsSubmit}
-                      contentUpdatedAt={contentUpdatedAt}
-                      editingDisabled={editingDisabled}
-                      planId={planId}
-                      collabUser={collabUser}
-                    />
-                  ))
+                  railScopedBlocks.map((block) =>
+                    renderFlowBlockFrame(
+                      block,
+                      <PlanBlockView
+                        block={block}
+                        onChange={(nextBlock) =>
+                          updateBlock(block.id, nextBlock)
+                        }
+                        onRichTextChange={updateRichTextBlock}
+                        onVisualQuestionsSubmit={onVisualQuestionsSubmit}
+                        contentUpdatedAt={contentUpdatedAt}
+                        editingDisabled={editingDisabled}
+                        planId={planId}
+                        collabUser={collabUser}
+                      />,
+                    ),
+                  )
                 )}
               </div>
+              {!documentEditable && breakoutBlocks.length > 0 && (
+                <div className="plan-document-flow plan-document-flow--wide-zone">
+                  {breakoutBlocks.map((block) =>
+                    renderFlowBlockFrame(
+                      block,
+                      <PlanBlockView
+                        block={block}
+                        onChange={(nextBlock) =>
+                          updateBlock(block.id, nextBlock)
+                        }
+                        onRichTextChange={updateRichTextBlock}
+                        onVisualQuestionsSubmit={onVisualQuestionsSubmit}
+                        contentUpdatedAt={contentUpdatedAt}
+                        editingDisabled={editingDisabled}
+                        planId={planId}
+                        collabUser={collabUser}
+                      />,
+                    ),
+                  )}
+                </div>
+              )}
             </div>
           </div>
         )}
       </article>
     </BlockRegistryProvider>
   );
+}
+
+function renderFlowBlockFrame(block: PlanBlock, node: ReactNode) {
+  const wide = isWideLayoutBlock(block);
+  return (
+    <div
+      key={block.id}
+      className={cn(
+        "plan-document-flow-block",
+        wide && "plan-document-flow-block--wide",
+      )}
+      data-block-type={block.type}
+      data-wide-layout-block={wide ? "" : undefined}
+    >
+      {node}
+    </div>
+  );
+}
+
+function isWideLayoutBlock(block: PlanBlock): boolean {
+  switch (block.type) {
+    case "diff":
+      return true;
+    case "tabs":
+      return (
+        block.data.orientation === "vertical" ||
+        block.data.tabs.some((tab) => blocksContainDiff(tab.blocks))
+      );
+    default:
+      return false;
+  }
+}
+
+function blocksContainDiff(blocks: PlanBlock[]): boolean {
+  return blocks.some(blockContainsDiff);
+}
+
+function blockContainsDiff(block: PlanBlock): boolean {
+  if (block.type === "diff") return true;
+  if (block.type === "tabs") {
+    return block.data.tabs.some((tab) => blocksContainDiff(tab.blocks));
+  }
+  if (block.type === "columns") {
+    return block.data.columns.some((column) =>
+      blocksContainDiff(column.blocks),
+    );
+  }
+  return false;
 }
 
 /**
@@ -880,17 +975,26 @@ function stripTrailingChangedFilesHeading(block: PlanBlock): PlanBlock {
 
 function filesSidebarHideCss(blockId: string): string {
   const id = blockId.replace(/["\\]/g, "\\$&");
-  const leadReset = [
+  const leadResetSelectors = [
     ".plan-block",
     ".plan-callout",
     ".plan-questions-block",
     ".an-block-panel",
     ".plan-block-node",
-  ]
-    .map((sel) => `.plan-document-flow > [data-block-id="${id}"] + ${sel}`)
-    .join(",\n");
+    ".plan-document-flow-block",
+  ];
+  const leadReset = [
+    ...leadResetSelectors.map(
+      (sel) => `.plan-document-flow > [data-block-id="${id}"] + ${sel}`,
+    ),
+    ...leadResetSelectors.map(
+      (sel) =>
+        `.plan-document-flow > .plan-document-flow-block:has([data-block-id="${id}"]) + ${sel}`,
+    ),
+  ].join(",\n");
   return `@media (min-width: 1400px){
 .plan-document-flow [data-block-id="${id}"]{display:none}
+.plan-document-flow > .plan-document-flow-block:has([data-block-id="${id}"]){display:none}
 ${leadReset}{margin-top:2.25rem;padding-top:0}
 }`;
 }

--- a/templates/plan/app/components/plan/PlanContentRenderer.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.tsx
@@ -528,20 +528,18 @@ export function PlanContentRenderer({
     ],
   );
 
-  // On wide recap screens the "Files touched" tree moves to a permanent left
-  // sidebar (mirroring the right-hand contents rail) instead of sitting in the
-  // document body. Keep the block in the document so it stays the editable
-  // source of truth and is never dropped on save; render a read-only mirror in
-  // the aside, and hide the in-flow copy at the same breakpoint the rail appears
-  // (see `filesSidebarHideCss`). Gated to recaps so ordinary plans are
-  // unaffected, and to the first file-tree block (the conventional files-touched
-  // summary).
+  // In wide layout, the first file-tree block moves to a permanent left sidebar
+  // (mirroring the right-hand contents rail) instead of sitting in the document
+  // body. Keep the block in the document so it stays the editable source of
+  // truth and is never dropped on save; render a read-only mirror in the aside,
+  // and hide the in-flow copy at the same breakpoint the rail appears (see
+  // `filesSidebarHideCss`).
   const filesSidebarBlockIndex = useMemo(
     () =>
-      isRecap
+      documentLayout === "wide"
         ? content.blocks.findIndex((block) => block.type === "file-tree")
         : -1,
-    [isRecap, content.blocks],
+    [documentLayout, content.blocks],
   );
   const filesSidebarBlock =
     filesSidebarBlockIndex >= 0
@@ -556,6 +554,7 @@ export function PlanContentRenderer({
   )
     ? filesSidebarHeadingBlock
     : undefined;
+  const filesSidebarLabel = fileTreeSidebarLabel(filesSidebarBlock, isRecap);
   // Drop the relocated file-tree and its heading from the contents nav (both are
   // hidden in the rail layout), so no contents link points at a hidden element.
   const tocOmitBlockIds = useMemo(
@@ -803,21 +802,18 @@ export function PlanContentRenderer({
                     </style>
                     <aside
                       className="plan-document-files"
-                      aria-label="Files changed"
+                      aria-label={filesSidebarLabel}
                       onClick={handleFilesRailClick}
                     >
                       <div className="plan-document-files__nav">
-                        {/* The sidebar owns the heading: a single fixed "Files
-                          changed" label. Strip BOTH the block-level `title` (the
-                          eyebrow `plan-block-label`) and the file-tree's own
-                          `data.title` (the bold summary-header heading) from the
-                          mirrored block so the file-tree renders heading-free and
-                          the label is never duplicated — regardless of what title
-                          the block was authored with (e.g. one carrying a
-                          "(+N / −M, K files)" stats suffix). The in-flow source
-                          block keeps both titles untouched. */}
+                        {/* The sidebar owns the heading. Strip BOTH the block-level
+                          `title` (the eyebrow `plan-block-label`) and the
+                          file-tree's own `data.title` (the bold summary-header
+                          heading) from the mirrored block so the file-tree renders
+                          heading-free and the label is never duplicated. The
+                          in-flow source block keeps both titles untouched. */}
                         <div className="plan-document-files__label">
-                          Files changed
+                          {filesSidebarLabel}
                         </div>
                         <PlanBlockView
                           block={stripFileTreeTitles({
@@ -998,6 +994,25 @@ function stripTrailingChangedFilesHeading(block: PlanBlock): PlanBlock {
   );
   if (markdown === block.data.markdown) return block;
   return { ...block, data: { ...block.data, markdown: markdown.trimEnd() } };
+}
+
+function fileTreeSidebarLabel(
+  block: PlanBlock | undefined,
+  isRecap: boolean,
+): string {
+  if (!block || block.type !== "file-tree") {
+    return isRecap ? "Files changed" : "Files";
+  }
+  const label = block.title?.trim() || block.data.title?.trim();
+  return stripFileTreeStatsSuffix(
+    label || (isRecap ? "Files changed" : "Files"),
+  );
+}
+
+function stripFileTreeStatsSuffix(label: string): string {
+  return label
+    .replace(/\s*\((?=[^)]*(?:\+|-|−|\d+\s+files?))[^)]*\)\s*$/i, "")
+    .trim();
 }
 
 function filesSidebarHideCss(blockId: string, headingBlockId?: string): string {

--- a/templates/plan/app/components/plan/PlanTableOfContents.tsx
+++ b/templates/plan/app/components/plan/PlanTableOfContents.tsx
@@ -27,11 +27,7 @@ function findScrollParent(el: HTMLElement | null): HTMLElement | Window {
 }
 
 function findDocumentFlow(nav: HTMLElement | null) {
-  return (
-    nav
-      ?.closest(".plan-document-shell")
-      ?.querySelector<HTMLElement>(".plan-document-flow") ?? null
-  );
+  return nav?.closest<HTMLElement>(".plan-document-shell") ?? null;
 }
 
 export function PlanTableOfContents({

--- a/templates/plan/app/components/plan/usePlanHashScroll.ts
+++ b/templates/plan/app/components/plan/usePlanHashScroll.ts
@@ -6,13 +6,12 @@ import {
   type PlanTocItem,
 } from "./PlanTableOfContents.utils";
 
-// Query the flow directly (not via the TOC nav) so deep links still resolve
-// when the contents rail is hidden.
-function findDocumentFlowRoot(): HTMLElement | null {
+// Query the whole shell (not via the TOC nav) so deep links still resolve when
+// the contents rail is hidden and when wide blocks render in a breakout flow.
+function findDocumentRoot(): HTMLElement | null {
   return (
-    document.querySelector<HTMLElement>(
-      ".plan-document-shell .plan-document-flow",
-    ) ?? document.querySelector<HTMLElement>(".plan-document-flow")
+    document.querySelector<HTMLElement>(".plan-document-shell") ??
+    document.querySelector<HTMLElement>(".plan-document-flow")
   );
 }
 
@@ -74,7 +73,7 @@ export function usePlanHashScroll(blocks: PlanBlock[]) {
       const id = readHashTarget();
       const item = itemFor(id);
       if (!item) return null;
-      const root = findDocumentFlowRoot();
+      const root = findDocumentRoot();
       if (!root) return null;
       const target = resolvePlanTocElements(root, [item]).get(id) ?? null;
       if (target && !target.id) target.id = id;

--- a/templates/plan/app/components/plan/wireframe/Wireframe.tsx
+++ b/templates/plan/app/components/plan/wireframe/Wireframe.tsx
@@ -234,6 +234,7 @@ function ArtboardFrame({
       }}
     >
       <div
+        className="group/wireframe-artboard relative"
         style={{
           width: "100%",
           maxWidth: maxFrameWidth,
@@ -243,7 +244,8 @@ function ArtboardFrame({
       >
         <div
           ref={ref}
-          className="group/wireframe-artboard plan-kit-artboard relative"
+          className="plan-kit-artboard relative"
+          data-rough-scope="wireframe"
           style={{
             width,
             height,
@@ -282,8 +284,8 @@ function ArtboardFrame({
             frameRadius={preset.radius}
             selector={selector}
           />
-          {!designMode && !skeleton && <WireframeStyleToggleButton />}
         </div>
+        {!designMode && !skeleton && <WireframeStyleToggleButton />}
       </div>
       {caption && (
         <p className="mt-2 text-center text-xs text-plan-muted">{caption}</p>
@@ -303,6 +305,7 @@ function WireframeStyleToggleButton() {
       type="button"
       data-plan-interactive
       data-rough="none"
+      data-wireframe-style-toggle
       aria-label={description}
       title={description}
       onClick={(event) => {

--- a/templates/plan/app/global.css
+++ b/templates/plan/app/global.css
@@ -376,7 +376,7 @@
 .plan-document-body {
   position: relative;
   --toc-rail-width: 11rem;
-  --doc-col-width: 53rem;
+  --doc-col-width: 60rem;
   --rail-gap: 2rem;
 }
 
@@ -654,7 +654,7 @@
 }
 
 .plan-copy {
-  max-width: 989px;
+  max-width: 60rem;
   color: var(--plan-muted);
   font-size: 1.125rem;
   line-height: 1.8;
@@ -677,7 +677,7 @@
 
 /* ── Notion-like rich-text prose ─────────────────────────────────────── */
 .plan-rich-markdown-editor {
-  max-width: 943px;
+  max-width: 60rem;
   color: var(--plan-text);
 }
 
@@ -860,7 +860,7 @@
 }
 
 .plan-prose {
-  max-width: 943px;
+  max-width: 60rem;
   color: var(--plan-text);
   font-size: var(--plan-body-size);
   line-height: 1.75;
@@ -1490,7 +1490,7 @@
 }
 
 .plan-callout {
-  max-width: 989px;
+  max-width: 60rem;
   border-inline-start: 3px solid hsl(var(--ring));
   border-start-start-radius: 0;
   border-end-start-radius: 0;

--- a/templates/plan/app/global.css
+++ b/templates/plan/app/global.css
@@ -371,13 +371,12 @@
   container: plan-doc / inline-size;
 }
 
-/* Header + flow + rails. Wide: a 3-col grid (files · doc · contents) via the
- * container queries below; narrow: a single column. */
+/* Header + flow + contents rail. Wide: a balanced 3-col grid via the container
+ * queries below; narrow: a single column. */
 .plan-document-body {
   position: relative;
-  --files-rail-width: 13rem;
   --toc-rail-width: 11rem;
-  --doc-col-width: 46rem;
+  --doc-col-width: 53rem;
   --rail-gap: 2rem;
 }
 
@@ -434,13 +433,16 @@
 /* Contents rail. Hidden until a query below reveals it as the `toc` column. */
 .plan-document-toc {
   display: none;
+  position: sticky;
+  top: 1.25rem;
+  z-index: 2;
+  align-self: start;
+  max-height: calc(100vh - 2.5rem);
+  overflow-y: auto;
 }
 
 .plan-document-toc__nav {
-  position: sticky;
-  top: 1.25rem;
-  max-height: calc(100vh - 2.5rem);
-  overflow-y: auto;
+  position: static;
   padding: 0.25rem 0 1.5rem;
 }
 
@@ -546,127 +548,22 @@
   list-style: none;
 }
 
-/* Hide the accordion once its rail shows (toc-only 48rem, toc+files 58rem), and in
- * screenshot capture. */
+/* Hide the accordion once its rail shows, and in screenshot capture. */
 .plan-content-surface[data-recap-screenshot-theme] .plan-document-toc-inline {
   display: none;
 }
 @container plan-doc (min-width: 48rem) {
   .plan-content-surface:not([data-recap-screenshot-theme])
-    .plan-document-body[data-has-toc]:not([data-has-files])
-    > .plan-document-toc-inline {
-    display: none;
-  }
-}
-@container plan-doc (min-width: 58rem) {
-  .plan-content-surface:not([data-recap-screenshot-theme])
-    .plan-document-body[data-has-toc][data-has-files]
+    .plan-document-body[data-has-toc]
     > .plan-document-toc-inline {
     display: none;
   }
 }
 
-/* Recap "Files changed" rail. Hidden until a query below reveals it as the `files`
- * column; the in-flow copy is then hidden too (see `filesSidebarHideCss`). */
-.plan-document-files {
-  display: none;
-}
+/* Wide layout: the contents rail is a real grid column. A matching empty left
+ * column balances the rail so the document itself remains visually centered. */
 
-.plan-document-files__nav {
-  position: sticky;
-  top: 1.25rem;
-  max-height: calc(100vh - 2.5rem);
-  overflow-y: auto;
-  padding: 0.25rem 0 1.5rem;
-  pointer-events: auto;
-  /* Low-prominence until hover/focus/expand. */
-  opacity: 0.7;
-  transition:
-    opacity 0.18s ease,
-    width 0.18s ease;
-}
-
-.plan-document-files__nav:hover,
-.plan-document-files__nav:focus-within,
-.plan-document-files:has(.plan-block[data-files-expanded])
-  .plan-document-files__nav {
-  opacity: 1;
-}
-
-/* On focus the nav widens rightward over the document as a flyout (never left). */
-.plan-document-files:has(.plan-block[data-files-expanded])
-  .plan-document-files__nav {
-  width: 26rem;
-  z-index: 30;
-  background-color: var(--plan-document);
-}
-
-/* Drop the mirrored block's inherited top spacing so its label sits flush. */
-.plan-document-files__nav > .plan-block,
-.plan-document-files__nav .plan-block {
-  margin-top: 0;
-  padding-top: 0;
-  border-top: 0;
-}
-
-/* The rail's fixed "Files changed" heading (the mirror is heading-free). */
-.plan-document-files__label {
-  margin: 0 0 0.75rem;
-  color: var(--plan-muted);
-  font-size: 0.8rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  line-height: 1.3;
-}
-
-/* In the rail the file-tree sheds its card: only a slim right divider. Borders
- * stay 1px (color transparent → line) so expanding animates color, not width. */
-.plan-document-files__nav .plan-block > .rounded-xl {
-  border-radius: 0;
-  border-color: transparent;
-  border-right-color: var(--plan-line);
-  background-color: transparent;
-  transition:
-    border-color 0.18s ease,
-    border-radius 0.18s ease,
-    background-color 0.18s ease;
-}
-
-/* Summary header drops its tint + divider while collapsed. */
-.plan-document-files__nav .plan-block > .rounded-xl > :first-child {
-  background-color: transparent;
-  border-bottom-color: transparent;
-  transition:
-    background-color 0.18s ease,
-    border-color 0.18s ease;
-}
-
-/* Expanded flyout restores full border + radius, on the page surface. */
-.plan-document-files:has(.plan-block[data-files-expanded])
-  .plan-block
-  > .rounded-xl {
-  border-radius: 0.75rem;
-  border-top-color: var(--plan-line);
-  border-left-color: var(--plan-line);
-  border-right-color: var(--plan-line);
-  border-bottom-color: var(--plan-line);
-  background-color: var(--plan-document);
-}
-
-.plan-document-files:has(.plan-block[data-files-expanded])
-  .plan-block
-  > .rounded-xl
-  > :first-child {
-  background-color: hsl(var(--accent) / 0.2);
-  border-bottom-color: var(--plan-line);
-}
-
-/* Wide layout: side rails as real grid columns. Container-query driven, so they
- * appear only when the doc column has room. `data-has-files`/`data-has-toc` mark
- * which rails exist; screenshot capture keeps the single-column layout. */
-
-/* Shared cell placement (header/flow in `doc`, each rail its own; rails on row 2
- * so they start below the header divider). Inert until the parent is a grid. */
+/* Shared cell placement. Inert until the parent is a grid. */
 @container plan-doc (min-width: 48rem) {
   .plan-content-surface:not([data-recap-screenshot-theme])
     .plan-document-body
@@ -685,98 +582,38 @@
   }
   .plan-content-surface:not([data-recap-screenshot-theme])
     .plan-document-body
-    > .plan-document-files {
-    grid-area: files;
-  }
-  .plan-content-surface:not([data-recap-screenshot-theme])
-    .plan-document-body
     > .plan-document-toc {
     grid-area: toc;
   }
 }
 
-/* Document + contents rail (the common plan / single-rail recap shape). */
+/* Document + contents rail. The empty first column balances the right rail. */
 @container plan-doc (min-width: 48rem) {
   .plan-content-surface:not([data-recap-screenshot-theme])
-    .plan-document-body[data-has-toc]:not([data-has-files]) {
+    .plan-document-body[data-has-toc] {
     display: grid;
     grid-template-columns:
+      minmax(0, var(--toc-rail-width))
       minmax(0, var(--doc-col-width))
-      var(--toc-rail-width);
+      minmax(0, var(--toc-rail-width));
     grid-template-areas:
-      "header ."
-      "flow   toc";
+      ". header ."
+      ". flow   toc";
     justify-content: center;
     column-gap: var(--rail-gap);
   }
   .plan-content-surface:not([data-recap-screenshot-theme])
-    .plan-document-body[data-has-toc]:not([data-has-files])
+    .plan-document-body[data-has-toc]
     > .plan-document-toc {
     display: block;
   }
   .plan-content-surface:not([data-recap-screenshot-theme]):has(
-      .plan-document-body[data-has-toc]:not([data-has-files])
+      .plan-document-body[data-has-toc]
     )
     .plan-document-shell {
-    max-width: 72rem;
-  }
-}
-
-/* Files rail + document (recap whose contents rail is absent). */
-@container plan-doc (min-width: 48rem) {
-  .plan-content-surface:not([data-recap-screenshot-theme])
-    .plan-document-body[data-has-files]:not([data-has-toc]) {
-    display: grid;
-    grid-template-columns:
-      var(--files-rail-width)
-      minmax(0, var(--doc-col-width));
-    grid-template-areas:
-      ".     header"
-      "files flow";
-    justify-content: center;
-    column-gap: var(--rail-gap);
-  }
-  .plan-content-surface:not([data-recap-screenshot-theme])
-    .plan-document-body[data-has-files]:not([data-has-toc])
-    > .plan-document-files {
-    display: block;
-  }
-  .plan-content-surface:not([data-recap-screenshot-theme]):has(
-      .plan-document-body[data-has-files]:not([data-has-toc])
-    )
-    .plan-document-shell {
-    max-width: 72rem;
-  }
-}
-
-/* Files · document · contents (full recap layout); needs a wider threshold. */
-@container plan-doc (min-width: 58rem) {
-  .plan-content-surface:not([data-recap-screenshot-theme])
-    .plan-document-body[data-has-files][data-has-toc] {
-    display: grid;
-    grid-template-columns:
-      var(--files-rail-width)
-      minmax(0, var(--doc-col-width))
-      var(--toc-rail-width);
-    grid-template-areas:
-      ".     header ."
-      "files flow   toc";
-    justify-content: center;
-    column-gap: var(--rail-gap);
-  }
-  .plan-content-surface:not([data-recap-screenshot-theme])
-    .plan-document-body[data-has-files][data-has-toc]
-    > .plan-document-files,
-  .plan-content-surface:not([data-recap-screenshot-theme])
-    .plan-document-body[data-has-files][data-has-toc]
-    > .plan-document-toc {
-    display: block;
-  }
-  .plan-content-surface:not([data-recap-screenshot-theme]):has(
-      .plan-document-body[data-has-files][data-has-toc]
-    )
-    .plan-document-shell {
-    max-width: 86rem;
+    max-width: calc(
+      var(--doc-col-width) + (var(--toc-rail-width) * 2) + (var(--rail-gap) * 2)
+    );
   }
 }
 
@@ -817,7 +654,7 @@
 }
 
 .plan-copy {
-  max-width: 860px;
+  max-width: 989px;
   color: var(--plan-muted);
   font-size: 1.125rem;
   line-height: 1.8;
@@ -840,7 +677,7 @@
 
 /* ── Notion-like rich-text prose ─────────────────────────────────────── */
 .plan-rich-markdown-editor {
-  max-width: 820px;
+  max-width: 943px;
   color: var(--plan-text);
 }
 
@@ -1023,7 +860,7 @@
 }
 
 .plan-prose {
-  max-width: 820px;
+  max-width: 943px;
   color: var(--plan-text);
   font-size: var(--plan-body-size);
   line-height: 1.75;
@@ -1653,7 +1490,7 @@
 }
 
 .plan-callout {
-  max-width: 860px;
+  max-width: 989px;
   border-inline-start: 3px solid hsl(var(--ring));
   border-start-start-radius: 0;
   border-end-start-radius: 0;

--- a/templates/plan/app/global.css
+++ b/templates/plan/app/global.css
@@ -386,13 +386,12 @@
     --plan-wide-component-width: min(1560px, calc(100vw - 5rem));
   }
 
-  .plan-content-surface[data-plan-layout="wide"]
-    .plan-document-flow-block--wide {
-    width: var(--plan-wide-component-width);
-    max-width: var(--plan-wide-component-width);
-    margin-inline: calc((100% - var(--plan-wide-component-width)) / 2);
+  .plan-content-surface[data-plan-layout="wide"] .plan-document-flow-stack {
+    min-width: 0;
   }
 
+  .plan-content-surface[data-plan-layout="wide"]
+    .plan-document-flow-block--wide,
   .plan-content-surface[data-plan-layout="wide"]
     .plan-document-editor
     .ProseMirror:not(.plan-nested-document-editor-prose)
@@ -403,11 +402,23 @@
     .plan-document-editor
     .ProseMirror:not(.plan-nested-document-editor-prose)
     > .react-renderer.node-planBlock:has(
+      > .plan-block-node[data-block-type="annotated-code"]
+    ),
+  .plan-content-surface[data-plan-layout="wide"]
+    .plan-document-editor
+    .ProseMirror:not(.plan-nested-document-editor-prose)
+    > .react-renderer.node-planBlock:has(
       > .plan-block-node[data-block-type="tabs"] [data-wide-layout-block]
     ) {
+    position: relative;
+    z-index: 4;
     width: var(--plan-wide-component-width);
     max-width: var(--plan-wide-component-width);
     margin-inline: calc((100% - var(--plan-wide-component-width)) / 2);
+    background-color: var(--plan-document);
+    box-shadow:
+      -1.5rem 0 1.5rem var(--plan-document),
+      1.5rem 0 1.5rem var(--plan-document);
   }
 
   .plan-content-surface[data-plan-layout="wide"]

--- a/templates/plan/app/global.css
+++ b/templates/plan/app/global.css
@@ -292,14 +292,27 @@
 .plan-document-flow > .plan-callout,
 .plan-document-flow > .plan-questions-block,
 .plan-document-flow > .an-block-panel,
-.plan-document-flow > .plan-block-node {
+.plan-document-flow > .plan-block-node,
+.plan-document-flow > .plan-document-flow-block {
   margin-top: 1.25rem;
+}
+
+.plan-document-flow > .plan-document-flow-block > .plan-block,
+.plan-document-flow > .plan-document-flow-block > .plan-callout,
+.plan-document-flow > .plan-document-flow-block > .plan-questions-block,
+.plan-document-flow > .plan-document-flow-block > .an-block-panel,
+.plan-document-flow > .plan-document-flow-block > .plan-block-node {
+  margin-top: 0;
 }
 
 /* The header already owns a bottom divider + spacing; the first block sits a
  * touch closer to it (no need for the full inter-block gap). */
 .plan-document-flow > :first-child {
   margin-top: 1rem;
+}
+
+.plan-document-flow--wide-zone > :first-child {
+  margin-top: 1.75rem;
 }
 
 .plan-document-flow .plan-questions-block > .sticky {
@@ -357,6 +370,45 @@
  * title. */
 .plan-document-body {
   position: relative;
+}
+
+@media (min-width: 1024px) {
+  .plan-content-surface[data-plan-layout="wide"] .plan-document-shell {
+    --plan-wide-component-width: min(1560px, calc(100vw - 5rem));
+  }
+
+  .plan-content-surface[data-plan-layout="wide"]
+    .plan-document-flow-block--wide {
+    width: var(--plan-wide-component-width);
+    max-width: var(--plan-wide-component-width);
+    margin-inline: calc((100% - var(--plan-wide-component-width)) / 2);
+  }
+
+  .plan-content-surface[data-plan-layout="wide"]
+    .plan-document-editor
+    .ProseMirror:not(.plan-nested-document-editor-prose)
+    > .react-renderer.node-planBlock:has(
+      > .plan-block-node[data-block-type="diff"]
+    ),
+  .plan-content-surface[data-plan-layout="wide"]
+    .plan-document-editor
+    .ProseMirror:not(.plan-nested-document-editor-prose)
+    > .react-renderer.node-planBlock:has(
+      > .plan-block-node[data-block-type="tabs"] [data-wide-layout-block]
+    ) {
+    width: var(--plan-wide-component-width);
+    max-width: var(--plan-wide-component-width);
+    margin-inline: calc((100% - var(--plan-wide-component-width)) / 2);
+  }
+
+  .plan-content-surface[data-plan-layout="wide"]
+    .plan-block-node[data-block-type="wireframe"]
+    .plan-kit-wireframe,
+  .plan-content-surface[data-plan-layout="wide"]
+    .plan-block-node[data-block-type="wireframe"]
+    .plan-html-frame {
+    margin-inline: auto;
+  }
 }
 
 @media (min-width: 1400px) {

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -3106,6 +3106,12 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
   const localPlanSuggestedRepoPath =
     localPlanBundle?.suggestedRepoPath ??
     (localPlanSlug ? `plans/${localPlanSlug}` : "plans");
+  const localPlanMenuPath =
+    localPlanRepoPath ??
+    localPlanBundle?.repoPath ??
+    localPlanSuggestedRepoPath ??
+    localPlanSlug ??
+    "local plan files";
   const planAccessStatusQuery = usePlanAccessStatus(
     selectedId,
     Boolean(selectedId && !bundle && !localPlanMode),
@@ -5691,8 +5697,11 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
                           Local files
                         </DropdownMenuLabel>
                         <div className="px-2 pb-1 text-xs leading-5 text-muted-foreground">
-                          <div className="break-words text-foreground">
-                            {localPlanDisplayFolder}
+                          <div
+                            className="truncate text-foreground"
+                            title={localPlanDisplayFolder}
+                          >
+                            {localPlanMenuPath}
                           </div>
                           <div>No hosted database writes or sharing.</div>
                         </div>


### PR DESCRIPTION
## Summary
- move the missing-AI setup card above the sidebar composer and add compact setup layout support
- widen Plan recap/visual preview rendering, keep breakout anchors and rails working, and tidy local-file menu copy
- simplify Clips recorder stop/cancel behavior and avoid duplicate camera compositing for true monitor captures

## Validation
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- pnpm --filter plan typecheck
- pnpm --filter plan test -- app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx
- pnpm --filter plan build
- pnpm --filter clips typecheck
- pnpm --filter clips test
- pnpm --filter clips build
- pnpm exec prettier --check <changed files>
- git diff --check

Note: pnpm run prep was attempted locally but this checkout is contaminated by unrelated ignored workspace artifacts and pre-existing failures: .video-bakeoff localhost guard hit, packages/vscode-extension/.vscode-test Prettier warnings, packages/embedding typecheck errors, and one packages/core action-discovery test timeout. GitHub Actions should be the clean full gate.