### PR TITLE
Close dropdown when disabling media device

### DIFF
--- a/templates/clips/desktop/src/components/MediaDeviceRow.tsx
+++ b/templates/clips/desktop/src/components/MediaDeviceRow.tsx
@@ -135,7 +135,10 @@ export function MediaDeviceRow({
       </button>
       <Toggle
         on={on}
-        onChange={onToggle}
+        onChange={(v) => {
+          if (!v) setOpen(false);
+          onToggle(v);
+        }}
         label={kind === "camera" ? "Camera" : "Microphone"}
       />
       {open ? (


### PR DESCRIPTION
### Summary
This PR fixes a visual glitch in the `MediaDeviceRow` component where toggling a device off while its dropdown was open caused overlapping text artifacts.

### Problem
In the clips desktop template, if a user opened a dropdown (for mic or camera) and then clicked the disable/toggle button while the dropdown was still open, a buggy view appeared where letters from the dropdown were rendered over the popover, resulting in a broken UI.

### Key Changes
- In `MediaDeviceRow.tsx`, the `Toggle` component's `onChange` handler now calls `setOpen(false)` when the toggle is turned off, ensuring the dropdown is closed before the device is disabled.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/pixel-vessel-nqjqlh6u"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-pixel-vessel-nqjqlh6u.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1370`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>pixel-vessel-nqjqlh6u</branchName>-->