### PR TITLE
Show aspect ratio alongside image dimensions

### DIFF
--- a/templates/assets/app/routes/asset.$id.tsx
+++ b/templates/assets/app/routes/asset.$id.tsx
@@ -392,7 +392,7 @@ function Field({
   multiline,
 }: {
   label: string;
-  value: string;
+  value: ReactNode;
   multiline?: boolean;
 }) {
   return (
@@ -411,7 +411,13 @@ function formatDimensions(width?: number | null, height?: number | null) {
   const dimensions = `${width || "?"} x ${height || "?"}`;
   if (!width || !height) return dimensions;
   const divisor = gcd(width, height);
-  return `${dimensions} | ${width / divisor}:${height / divisor}`;
+  return (
+    <span className="flex items-center gap-2">
+      {dimensions}
+      <span className="h-4 w-px bg-border" />
+      {`${width / divisor}:${height / divisor}`}
+    </span>
+  );
 }
 
 function gcd(a: number, b: number): number {

--- a/templates/assets/app/routes/asset.$id.tsx
+++ b/templates/assets/app/routes/asset.$id.tsx
@@ -411,7 +411,7 @@ function formatDimensions(width?: number | null, height?: number | null) {
   const dimensions = `${width || "?"} x ${height || "?"}`;
   if (!width || !height) return dimensions;
   const divisor = gcd(width, height);
-  return `${dimensions} (${width / divisor}:${height / divisor})`;
+  return `${dimensions} | ${width / divisor}:${height / divisor}`;
 }
 
 function gcd(a: number, b: number): number {

--- a/templates/assets/app/routes/asset.$id.tsx
+++ b/templates/assets/app/routes/asset.$id.tsx
@@ -163,7 +163,7 @@ export default function AssetDetailPage() {
           ) : (
             <Field
               label="Dimensions"
-              value={`${asset.width || "?"} x ${asset.height || "?"}`}
+              value={formatDimensions(asset.width, asset.height)}
             />
           )}
           <Field label="MIME" value={asset.mimeType || "n/a"} />
@@ -405,4 +405,15 @@ function Field({
       </div>
     </div>
   );
+}
+
+function formatDimensions(width?: number | null, height?: number | null) {
+  const dimensions = `${width || "?"} x ${height || "?"}`;
+  if (!width || !height) return dimensions;
+  const divisor = gcd(width, height);
+  return `${dimensions} (${width / divisor}:${height / divisor})`;
+}
+
+function gcd(a: number, b: number): number {
+  return b === 0 ? a : gcd(b, a % b);
 }

--- a/templates/assets/app/routes/asset.$id.tsx
+++ b/templates/assets/app/routes/asset.$id.tsx
@@ -414,7 +414,7 @@ function formatDimensions(width?: number | null, height?: number | null) {
   return (
     <span className="flex items-center gap-2">
       {dimensions}
-      <span className="h-4 w-px bg-border" />
+      <span className="h-4 w-px bg-[rgb(56,56,61)]" />
       {`${width / divisor}:${height / divisor}`}
     </span>
   );


### PR DESCRIPTION
### Summary
Enhances the asset detail page to display the image aspect ratio alongside its pixel dimensions, formatted as `900 x 900 | 1:1` using a visual divider.

### Problem
The Dimensions field on the asset detail page only showed the raw pixel dimensions (e.g. `900 x 900`), giving no quick visual indication of the image's aspect ratio.

### Solution
Extracted dimension rendering into a dedicated `formatDimensions` helper that computes the aspect ratio using a GCD function and returns a React element with a vertical divider separating the dimensions from the ratio.

### Key Changes
- Added `formatDimensions(width, height)` function that computes the simplified aspect ratio using a recursive `gcd` helper and renders dimensions and ratio separated by a styled vertical divider (`<span className="h-4 w-px bg-[rgb(56,56,61)]" />`)
- Added `gcd(a, b)` utility function for computing the greatest common divisor
- Updated the `Field` component's `value` prop type from `string` to `ReactNode` to support the new JSX output
- Replaced the inline dimension string in the asset detail route with a call to `formatDimensions`


<img width="348" height="126" alt="image" src="https://github.com/user-attachments/assets/646b331c-cdae-4177-b026-25e8998e6055" />

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/ranger-token-83rri7ah"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-ranger-token-83rri7ah.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1371`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>ranger-token-83rri7ah</branchName>-->