### PR TITLE
Add Content local-file installs and improve template setup

### DIFF
--- a/.changeset/content-local-files-skill.md
+++ b/.changeset/content-local-files-skill.md
@@ -1,0 +1,8 @@
+---
+"@agent-native/core": patch
+"@agent-native/skills": patch
+---
+
+Add the Content app-backed skill and a `skills add content --mode local-files`
+install path that writes Content local-file workspace defaults to
+`agent-native.json`.

--- a/.changeset/fix-codex-cli-approval-flag.md
+++ b/.changeset/fix-codex-cli-approval-flag.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+---
+
+Pass Codex CLI approval policy before the `exec` subcommand so local Code runs
+work with current Codex CLI argument parsing.

--- a/.changeset/json-action-input.md
+++ b/.changeset/json-action-input.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+---
+
+Allow `pnpm action <name> '{"arg":"value"}'` to pass a positional JSON object
+to defineAction and package actions while preserving existing flag arguments.

--- a/.changeset/show-setup-prompt.md
+++ b/.changeset/show-setup-prompt.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Show the onboarding setup prompt in the agent sidebar on normal deployed app surfaces so required Builder/BYOK setup is visible to users.

--- a/.changeset/slides-upload-feedback.md
+++ b/.changeset/slides-upload-feedback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prefer inline Builder connect guidance for chat attachment upload recovery.

--- a/packages/core/docs/content/actions.md
+++ b/packages/core/docs/content/actions.md
@@ -57,6 +57,13 @@ export default defineAction({
 Run it from the same folder:
 
 ```bash
+pnpm action hello '{"name":"Steve"}'
+```
+
+The CLI accepts a JSON object as the action input, which matches the structured
+tool calls agents already make. Simple flags still work for quick manual runs:
+
+```bash
 pnpm action hello --name Steve
 ```
 
@@ -415,10 +422,12 @@ headless, render in chat, or grow into a full screen.
 Every action is runnable via `pnpm action`:
 
 ```bash
-pnpm action reply-to-email --emailId thread-123 --body "Thanks!"
+pnpm action reply-to-email '{"emailId":"thread-123","body":"Thanks!"}'
 ```
 
-Flags are parsed into the shape your schema expects. Useful for agent-dev loops, scripts, and cron.
+JSON input is the preferred shape for agents and complex objects. Flags are
+still parsed into the same schema shape for simple manual runs and existing
+scripts. Useful for agent-dev loops, scripts, and cron.
 
 ## Calling it from another agent (A2A) {#a2a}
 

--- a/packages/core/docs/content/local-file-mode.md
+++ b/packages/core/docs/content/local-file-mode.md
@@ -91,6 +91,31 @@ without requiring you to clone or fork the entire Content app.
 small sandboxed widgets that can render in app slots while their source stays in
 the repo.
 
+## Install Content Into A Repo
+
+For an existing docs, blog, or MDX workspace, install the Content local-files
+skill:
+
+```bash
+npx @agent-native/core@latest skills add content --mode local-files --scope project
+```
+
+This copies the `content` skill into the repo's agent skill folders and writes
+or updates `agent-native.json` with Content defaults:
+
+- `mode: "local-files"` at the workspace level
+- `apps.content.mode: "local-files"`
+- content roots for `docs/`, `blog/`, `content/`, and `resources/`
+- `components/` for local MDX components
+- `extensions/` for local extension widgets
+
+The installed skill tells coding agents to use Content actions
+(`list-documents`, `get-document`, `edit-document`, `update-document`,
+`share-local-file-document`, and component-file actions) when a local Content app
+or Agent Native Desktop bridge exposes them. If no bridge is running, the skill
+falls back to safe direct repo edits while preserving frontmatter, imports, JSX,
+and unknown MDX.
+
 ## Configuration
 
 Add `agent-native.json` to the repo or workspace root:

--- a/packages/core/docs/content/skills-guide.md
+++ b/packages/core/docs/content/skills-guide.md
@@ -202,6 +202,9 @@ offline work, or privacy-sensitive use.
 npx @agent-native/core@latest skills add visual-plan
 npx @agent-native/core@latest skills add assets
 
+# Repo-first Content docs/blog/MDX editing.
+npx @agent-native/core@latest skills add content --mode local-files --scope project
+
 # Vercel/open Skills CLI: exported instructions only, no MCP config.
 npx skills@latest add BuilderIO/agent-native --skill assets
 

--- a/packages/core/docs/content/template-clips.md
+++ b/packages/core/docs/content/template-clips.md
@@ -144,7 +144,7 @@ Clips is a larger template with a native recorder (it ships a desktop companion 
 1. **Video storage (required).** Connect a storage backend through the onboarding wizard. The easiest path is Builder.io (free during beta, one-click). For self-hosted storage, set `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, and optionally `S3_REGION` and `S3_PUBLIC_BASE_URL`. Cloudflare R2 and DigitalOcean Spaces use the same env vars with the `R2_*` prefix.
 2. **Google Calendar (optional).** To sync upcoming meetings, connect a Google Calendar account from Settings. The OAuth callback URL in dev is `http://localhost:8094/_agent-native/google/callback`. Set up a Google OAuth client in [Google Cloud Console](https://console.cloud.google.com/) with the Gmail and Google Calendar APIs enabled.
 3. **Screen-capture permissions.** On macOS, grant Screen Recording permission to the browser (or the desktop companion app) in System Settings → Privacy & Security → Screen Recording.
-4. **Slack previews (optional).** Create a Slack app with `chat:write`, `links:read`, `links:write`, and `links.embed:write`; subscribe to `link_shared`; add your Clips share domain under **App Unfurl Domains**; and set the Request URL to `https://your-clips.example.com/api/slack/unfurl`. Configure `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` in the Clips deployment.
+4. **Slack previews (optional).** Create a Slack app with `links:read`, `links:write`, and `links.embed:write`; subscribe to `link_shared`; add your Clips share domain under **App Unfurl Domains**; and set the Request URL to `https://your-clips.example.com/api/slack/unfurl`. Configure `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` in the Clips deployment.
 
 ### Host your own Clips server
 

--- a/packages/core/docs/content/template-clips.md
+++ b/packages/core/docs/content/template-clips.md
@@ -146,6 +146,53 @@ Clips is a larger template with a native recorder (it ships a desktop companion 
 3. **Screen-capture permissions.** On macOS, grant Screen Recording permission to the browser (or the desktop companion app) in System Settings → Privacy & Security → Screen Recording.
 4. **Slack previews (optional).** Create a Slack app with `chat:write`, `links:read`, `links:write`, and `links.embed:write`; subscribe to `link_shared`; add your Clips share domain under **App Unfurl Domains**; and set the Request URL to `https://your-clips.example.com/api/slack/unfurl`. Configure `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` in the Clips deployment.
 
+### Host your own Clips server
+
+The hosted Clips app at [clips.agent-native.com](https://clips.agent-native.com)
+is just a deployed copy of the Clips template. To run your own server, scaffold
+the template, deploy it like any other agent-native app, then point the desktop
+tray app at your deployment.
+
+1. **Create the app.**
+
+   ```bash
+   npx @agent-native/core@latest create my-clips --standalone --template clips
+   cd my-clips
+   pnpm install
+   ```
+
+2. **Configure production state.** Set a persistent `DATABASE_URL`, the normal
+   production auth/secrets variables from [Deployment](/docs/deployment), and a
+   video storage provider. Builder.io Connect is the easiest storage path; for
+   self-hosted storage, use `S3_*` or `R2_*` variables for an S3-compatible
+   bucket.
+
+3. **Deploy the web app.** For a plain Node deploy:
+
+   ```bash
+   pnpm build
+   node .output/server/index.mjs
+   ```
+
+   You can also use any Nitro target from [Deployment](/docs/deployment), such
+   as Netlify, Vercel, Cloudflare Pages, AWS Lambda, or Deno Deploy. Make sure
+   `BETTER_AUTH_URL` is the public Clips origin, for example
+   `https://clips.example.com`.
+
+4. **Connect the desktop tray app.** Open Clips Desktop settings and set
+   **Clips server URL** to the public base URL of your deployment, for example
+   `https://clips.example.com`. If the app is mounted under a workspace path,
+   include that path, such as `https://example.com/clips`. Click **Connect**,
+   then sign in with an account on that Clips server.
+
+5. **Connect optional integrations.** Google Calendar powers the Meetings tab,
+   `GEMINI_API_KEY` or Builder.io Connect powers transcript cleanup and titles,
+   `GROQ_API_KEY` can provide speech-to-text fallback, and Slack credentials
+   enable playable Slack unfurls.
+
+For local development, run the web app with `pnpm dev` and point the desktop
+tray app at `http://localhost:8094`.
+
 ### Key features
 
 **One library, three capture types.** Screen recordings, calendar meetings, and push-to-talk dictations share one searchable library.

--- a/packages/core/docs/content/template-content.md
+++ b/packages/core/docs/content/template-content.md
@@ -90,6 +90,21 @@ SQL-backed sharing. See [Local File Mode](/docs/local-file-mode) for the
 standalone repo layout, configuration, custom MDX components, local
 `extensions/` widgets, and production safety guide.
 
+To install the Content local-files skill into an existing repo:
+
+```bash
+npx @agent-native/core@latest skills add content --mode local-files --scope project
+```
+
+The installer copies the `content` skill for your coding agent and writes or
+updates `agent-native.json` with Content roots for `docs/`, `blog/`, `content/`,
+and `resources/`. When a local Content app, Agent Native Desktop, or trusted
+local bridge is running, agents should use Content actions such as
+`list-documents`, `get-document`, `edit-document`, `update-document`, and
+`share-local-file-document` instead of raw filesystem writes. Without that local
+bridge, the installed skill still gives the agent the repo-editing contract for
+safe Markdown/MDX edits.
+
 ## For developers
 
 The rest of this doc is for anyone forking the Content template or extending it.

--- a/packages/core/src/cli/code-agent-executor.spec.ts
+++ b/packages/core/src/cli/code-agent-executor.spec.ts
@@ -117,6 +117,7 @@ describe("executeCodeAgentRun", () => {
     for (const key of providerEnvKeys) delete process.env[key];
     const binDir = path.join(root, "bin");
     const promptPath = path.join(root, "codex-prompt.txt");
+    const argsPath = path.join(root, "codex-args.json");
     fs.mkdirSync(binDir, { recursive: true });
     const codexBin = path.join(binDir, "codex");
     fs.writeFileSync(
@@ -125,6 +126,13 @@ describe("executeCodeAgentRun", () => {
         "#!/usr/bin/env node",
         "const fs = require('fs');",
         "const args = process.argv.slice(2);",
+        `fs.writeFileSync(${JSON.stringify(argsPath)}, JSON.stringify(args));`,
+        "const execIndex = args.indexOf('exec');",
+        "const approvalIndex = args.indexOf('--ask-for-approval');",
+        "if (approvalIndex > execIndex) {",
+        "  process.stderr.write(\"unexpected argument '--ask-for-approval' found\");",
+        "  process.exit(2);",
+        "}",
         "const outIndex = args.indexOf('--output-last-message');",
         "const outPath = outIndex === -1 ? '' : args[outIndex + 1];",
         "let input = '';",
@@ -163,6 +171,10 @@ describe("executeCodeAgentRun", () => {
     });
     expect(output.read()).toContain("Codex streamed output");
     expect(fs.readFileSync(promptPath, "utf-8")).toContain("fix auth tests");
+    const args = JSON.parse(fs.readFileSync(argsPath, "utf-8")) as string[];
+    const execIndex = args.indexOf("exec");
+    expect(args.slice(0, 3)).toEqual(["--ask-for-approval", "never", "exec"]);
+    expect(args.slice(execIndex + 1)).not.toContain("--ask-for-approval");
     expect(listCodeAgentTranscriptEvents(run.id)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/packages/core/src/cli/code-agent-executor.ts
+++ b/packages/core/src/cli/code-agent-executor.ts
@@ -549,6 +549,8 @@ async function executeCodexCliRun(options: {
   const outputPath = path.join(outputDir, "last-message.txt");
   const model = normalizeCodexCliModel(options.model);
   const args = [
+    "--ask-for-approval",
+    "never",
     "exec",
     "--cd",
     cwd,
@@ -557,8 +559,6 @@ async function executeCodexCliRun(options: {
     "--skip-git-repo-check",
     "--sandbox",
     codexSandboxForPermissionMode(options.permissionMode),
-    "--ask-for-approval",
-    "never",
     "--output-last-message",
     outputPath,
   ];

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -532,7 +532,9 @@ switch (command) {
     // Run an action from actions/ (or scripts/ for backwards compat)
     const actionName = args[0];
     if (!actionName) {
-      console.error("Usage: agent-native action <name> [--args]");
+      console.error(
+        `Usage: agent-native action <name> ['{"arg":"value"}'] [--args]`,
+      );
       process.exit(1);
     }
     const tsxAction = findTsxBin();
@@ -875,7 +877,7 @@ Usage:
                                 reinstalling app skills/connectors.
   agent-native app-skill <cmd>  Install, launch, or package app-backed skills.
                                 cmds: ensure | launch | pack
-  agent-native skills add assets|design-exploration|visual-plan|visual-recap|context-xray
+  agent-native skills add assets|content|design-exploration|visual-plan|visual-recap|context-xray
                                 Install the skill instructions, register the MCP
                                 connector, AND authenticate it in one step.
                                 --no-connect skips auth (run 'connect' later);

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -27,6 +27,73 @@ function tmpDir(): string {
   return root;
 }
 
+function writeContentAppSkillFixture(root: string): string {
+  const skillRoot = path.join(root, ".agents", "skills", "content");
+  fs.mkdirSync(skillRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillRoot, "SKILL.md"),
+    [
+      "---",
+      "name: content",
+      "description: Use Content for local docs.",
+      "metadata:",
+      "  visibility: exported",
+      "---",
+      "",
+      "# Content",
+      "",
+      "Use Content for docs.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  fs.writeFileSync(
+    path.join(root, "agent-native.app-skill.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        id: "content",
+        displayName: "Content",
+        description: "Edit docs, blogs, resources, and MDX content.",
+        hosted: {
+          url: "https://content.agent-native.com",
+          mcpUrl: "https://content.agent-native.com/_agent-native/mcp",
+        },
+        mcp: {
+          serverName: "agent-native-content",
+        },
+        local: {
+          sourcePath: ".",
+          defaultUrl: "http://127.0.0.1:8083",
+          commands: {
+            install: "pnpm install",
+            dev: "pnpm dev",
+          },
+        },
+        surfaces: [
+          {
+            id: "content-documents",
+            action: "list-documents",
+            path: "/",
+          },
+        ],
+        skills: [
+          {
+            path: ".agents/skills/content",
+            visibility: "both",
+            exportAs: "content",
+          },
+        ],
+        hostAdapters: ["plain-skill", "claude-skill", "generic-mcp"],
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+  return root;
+}
+
 function workspaceRoot(): string {
   let current = process.cwd();
   while (current !== path.dirname(current)) {
@@ -337,7 +404,6 @@ describe("agent-native skills", () => {
     );
     expect(manifest).toMatchObject({
       version: 1,
-      mode: "local-files",
       apps: {
         content: {
           mode: "local-files",
@@ -352,6 +418,7 @@ describe("agent-native skills", () => {
       "content",
       "resources",
     ]);
+    expect(manifest.mode).toBeUndefined();
   });
 
   it("preserves existing Content local-files manifest customizations", async () => {
@@ -361,7 +428,11 @@ describe("agent-native skills", () => {
       `${JSON.stringify(
         {
           version: 1,
+          mode: "workspace",
           apps: {
+            plan: {
+              mode: "hosted",
+            },
             content: {
               roots: [
                 {
@@ -408,6 +479,80 @@ describe("agent-native skills", () => {
     ]);
     expect(manifest.apps.content.components).toEqual(["blocks"]);
     expect(manifest.apps.content.extensions).toBe("extensions");
+    expect(manifest.mode).toBe("workspace");
+    expect(manifest.apps.plan).toEqual({ mode: "hosted" });
+  });
+
+  it("accepts Content app-skill directories with local-files mode", async () => {
+    const root = tmpDir();
+    const appDir = writeContentAppSkillFixture(tmpDir());
+    const commands: { cmd: string; args: string[] }[] = [];
+
+    const result = await addAgentNativeSkill(
+      parseSkillsArgs([
+        "add",
+        appDir,
+        "--mode",
+        "local-files",
+        "--client",
+        "codex",
+        "--scope",
+        "project",
+      ]),
+      {
+        baseDir: root,
+        runCommand: async (cmd, args) => {
+          commands.push({ cmd, args });
+          return 0;
+        },
+      },
+    );
+
+    const manifestPath = path.join(root, "agent-native.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+
+    expect(result.id).toBe("content");
+    expect(result.planMode).toBe("local-files");
+    expect(result.mcpUrl).toBe("");
+    expect(result.mcpClients).toEqual([]);
+    expect(result.localManifestPath).toBe(manifestPath);
+    expect(commands).toHaveLength(1);
+    expect(commands[0].args).toEqual(
+      expect.arrayContaining(["--mode", "local-files"]),
+    );
+    expect(manifest.mode).toBeUndefined();
+    expect(manifest.apps.content.mode).toBe("local-files");
+  });
+
+  it("accepts Content app-skill manifests with local-files mode", async () => {
+    const root = tmpDir();
+    const appDir = writeContentAppSkillFixture(tmpDir());
+    const appManifest = path.join(appDir, "agent-native.app-skill.json");
+
+    const result = await addAgentNativeSkill(
+      parseSkillsArgs([
+        "add",
+        appManifest,
+        "--mode",
+        "local-files",
+        "--client",
+        "codex",
+        "--scope",
+        "project",
+      ]),
+      { baseDir: root, runCommand: async () => 0 },
+    );
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(root, "agent-native.json"), "utf-8"),
+    );
+
+    expect(result.id).toBe("content");
+    expect(result.planMode).toBe("local-files");
+    expect(result.mcpUrl).toBe("");
+    expect(result.mcpClients).toEqual([]);
+    expect(manifest.mode).toBeUndefined();
+    expect(manifest.apps.content.mode).toBe("local-files");
   });
 
   it("accepts design-exploration aliases for the built-in Design skill", async () => {

--- a/packages/core/src/cli/skills.spec.ts
+++ b/packages/core/src/cli/skills.spec.ts
@@ -304,6 +304,112 @@ describe("agent-native skills", () => {
     expect(fs.existsSync(path.join(skillDir, "SKILL.md"))).toBe(true);
   });
 
+  it("installs Content local-files instructions and repo manifest", async () => {
+    const root = tmpDir();
+
+    const result = await addAgentNativeSkill(
+      parseSkillsArgs([
+        "add",
+        "content",
+        "--mode",
+        "local-files",
+        "--client",
+        "codex",
+        "--scope",
+        "project",
+      ]),
+      { baseDir: root, runCommand: async () => 0 },
+    );
+
+    const skillDir = path.join(root, ".agents", "skills", "content");
+    const manifestPath = path.join(root, "agent-native.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+
+    expect(result.id).toBe("content");
+    expect(result.skillNames).toEqual(["content"]);
+    expect(result.planMode).toBe("local-files");
+    expect(result.mcpUrl).toBe("");
+    expect(result.mcpClients).toEqual([]);
+    expect(result.localManifestPath).toBe(manifestPath);
+    expect(result.commands).toContain(`write ${manifestPath}`);
+    expect(fs.readFileSync(path.join(skillDir, "SKILL.md"), "utf-8")).toContain(
+      "Default storage for this installation: Content Local File Mode.",
+    );
+    expect(manifest).toMatchObject({
+      version: 1,
+      mode: "local-files",
+      apps: {
+        content: {
+          mode: "local-files",
+          components: "components",
+          extensions: "extensions",
+        },
+      },
+    });
+    expect(manifest.apps.content.roots.map((root: any) => root.path)).toEqual([
+      "docs",
+      "blog",
+      "content",
+      "resources",
+    ]);
+  });
+
+  it("preserves existing Content local-files manifest customizations", async () => {
+    const root = tmpDir();
+    fs.writeFileSync(
+      path.join(root, "agent-native.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          apps: {
+            content: {
+              roots: [
+                {
+                  name: "Knowledge",
+                  path: "knowledge",
+                  kind: "docs",
+                  extensions: [".mdx"],
+                },
+              ],
+              components: ["blocks"],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+
+    await addAgentNativeSkill(
+      parseSkillsArgs([
+        "add",
+        "content",
+        "--mode",
+        "local-files",
+        "--client",
+        "codex",
+        "--scope",
+        "project",
+      ]),
+      { baseDir: root, runCommand: async () => 0 },
+    );
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(root, "agent-native.json"), "utf-8"),
+    );
+    expect(manifest.apps.content.roots).toEqual([
+      {
+        name: "Knowledge",
+        path: "knowledge",
+        kind: "docs",
+        extensions: [".mdx"],
+      },
+    ]);
+    expect(manifest.apps.content.components).toEqual(["blocks"]);
+    expect(manifest.apps.content.extensions).toBe("extensions");
+  });
+
   it("accepts design-exploration aliases for the built-in Design skill", async () => {
     const root = tmpDir();
 
@@ -1126,6 +1232,7 @@ describe("agent-native skills", () => {
       "visual-plan",
       "visual-recap",
       "assets",
+      "content",
       "design-exploration",
       "context-xray",
     ]);
@@ -1199,6 +1306,7 @@ describe("agent-native skills", () => {
       "visual-plan",
       "visual-recap",
       "assets",
+      "content",
       "design-exploration",
       "context-xray",
       "quick-recap",

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -36,13 +36,14 @@ const HELP = `npx @agent-native/core@latest skills
 
 Usage:
   npx @agent-native/core@latest skills list
-  npx @agent-native/core@latest skills status [assets|design-exploration|visual-plan|visual-recap|context-xray] [--client codex|claude-code|pi|all] [--scope user|project] [--json]
-  npx @agent-native/core@latest skills update [assets|design-exploration|visual-plan|visual-recap|context-xray] [--client codex|claude-code|pi|all] [--scope user|project] [--dry-run] [--json]
-  npx @agent-native/core@latest skills add assets|design-exploration|visual-plan|visual-recap|context-xray [--client codex|claude-code|cowork|cursor|opencode|github-copilot|all] [--scope user|project] [--mode hosted|local-files|self-hosted] [--mcp-url <url>] [--no-connect] [--with-github-action] [--yes] [--dry-run] [--json]
+  npx @agent-native/core@latest skills status [assets|content|design-exploration|visual-plan|visual-recap|context-xray] [--client codex|claude-code|pi|all] [--scope user|project] [--json]
+  npx @agent-native/core@latest skills update [assets|content|design-exploration|visual-plan|visual-recap|context-xray] [--client codex|claude-code|pi|all] [--scope user|project] [--dry-run] [--json]
+  npx @agent-native/core@latest skills add assets|content|design-exploration|visual-plan|visual-recap|context-xray [--client codex|claude-code|cowork|cursor|opencode|github-copilot|all] [--scope user|project] [--mode hosted|local-files|self-hosted] [--mcp-url <url>] [--no-connect] [--with-github-action] [--yes] [--dry-run] [--json]
   npx @agent-native/core@latest skills add <manifest-or-app-dir|skill-repo> [--skill <name>] [--client ...] [--yes]
 
 Examples:
   npx @agent-native/core@latest skills add assets
+  npx @agent-native/core@latest skills add content --mode local-files
   npx @agent-native/core@latest skills add design-exploration
   npx @agent-native/core@latest skills add visual-plan
   npx @agent-native/core@latest skills add visual-recap
@@ -87,6 +88,12 @@ files for "No sharing, all local.", or a self-hosted/custom Plan app URL.
 Pass --mode to choose directly. Local-files mode skips MCP registration and
 auth and installs instructions that default to a no-auth block catalog fetch,
 MDX folders, and the localhost bridge viewer.
+
+When installing content with --mode local-files, the CLI installs Content
+instructions and writes or updates agent-native.json with repo-backed Markdown /
+MDX roots for docs, blog, content, and resources. Use a local Content app, Agent
+Native Desktop, or another trusted local bridge for Content actions to read and
+write those files.
 
 When installing visual-recap interactively, the CLI offers to add the optional PR
 Visual Recap GitHub Action. Pass --with-github-action to write it directly, then
@@ -178,6 +185,117 @@ of using a generic image generator.
   \`count: 1\` only after telling the user the multi-candidate request timed out.
 - If you inspect local MCP config, redact \`Authorization\`, \`http_headers\`,
   and token values. Never paste bearer tokens into chat or logs.
+`;
+
+const CONTENT_SKILL_MD = `---
+name: content
+description: >-
+  Use Content for repo-backed Markdown/MDX docs, blogs, resources, rich
+  document editing, local components, shareable copies, and Content local-file
+  workspaces. Prefer Content actions over raw filesystem writes when available.
+metadata:
+  visibility: exported
+---
+
+# Content
+
+Use the Content app when a workflow is about authoring, editing, reviewing, or
+publishing Markdown/MDX documents: docs sites, blogs, resource libraries,
+marketing pages, internal notes, and local MDX components. Content gives the
+agent a document tree, a rich editor, normal document actions, and optional
+local-file source of truth.
+
+## Choose The Path
+
+- Use Content actions when the Content MCP/action tools are available:
+  \`list-documents\`, \`search-documents\`, \`get-document\`,
+  \`pull-document\`, \`create-document\`, \`edit-document\`,
+  \`update-document\`, \`delete-document\`, \`share-local-file-document\`,
+  \`list-local-component-files\`, and \`write-local-component-file\`.
+- Use \`pull-document\` or \`get-document\` before editing a page. Use
+  \`edit-document\` for precise find/replace changes and \`update-document\`
+  for full rewrites or new content.
+- In Local File Mode, Content actions read and write the repo files declared in
+  \`agent-native.json\`; SQL remains cache/history/search glue, not the source of
+  truth for those pages.
+- If Content tools are not visible and no local Content app or Desktop bridge is
+  running, treat this skill as repo-editing guidance. Edit configured
+  \`.md\`/\`.mdx\` files directly, preserve frontmatter and MDX imports, and tell
+  the user the Content action surface was not available.
+
+## Action Examples
+
+Prefer JSON input for action calls:
+
+\`\`\`bash
+pnpm action list-documents
+pnpm action get-document '{"id":"local-file:..."}'
+pnpm action edit-document '{"id":"local-file:...","find":"old copy","replace":"new copy"}'
+pnpm action update-document '{"id":"local-file:...","content":"# Updated\\n\\nBody"}'
+pnpm action share-local-file-document '{"id":"local-file:..."}'
+\`\`\`
+
+Run \`refresh-list\` after create/update/delete operations when you need the
+open Content UI sidebar to repaint immediately.
+
+## Local File Mode
+
+Install into an existing repo with:
+
+\`\`\`bash
+npx @agent-native/core@latest skills add content --mode local-files --scope project
+\`\`\`
+
+The installer copies this skill and writes or updates \`agent-native.json\` with
+Content roots for \`docs/\`, \`blog/\`, \`content/\`, and \`resources/\`, plus a
+\`components/\` folder for local MDX components. A typical manifest looks like:
+
+\`\`\`json
+{
+  "version": 1,
+  "mode": "local-files",
+  "apps": {
+    "content": {
+      "mode": "local-files",
+      "roots": [
+        { "name": "Docs", "path": "docs", "kind": "docs", "extensions": [".md", ".mdx"] },
+        { "name": "Blog", "path": "blog", "kind": "blog", "extensions": [".md", ".mdx"] },
+        { "name": "Content", "path": "content", "kind": "content", "extensions": [".md", ".mdx"] },
+        { "name": "Resources", "path": "resources", "kind": "resources", "extensions": [".md", ".mdx"] }
+      ],
+      "components": "components",
+      "extensions": "extensions",
+      "hide": ["**/_*.md", "**/_*.mdx"]
+    }
+  }
+}
+\`\`\`
+
+Local File Mode does not make the host language model local, and the hosted
+Content app cannot read private repo files by itself. File access requires a
+local Content app, Agent Native Desktop, or another trusted local bridge.
+
+## MDX And Components
+
+- Preserve frontmatter keys you do not understand. Preserve MDX imports,
+  exports, JSX, and expression props unless the user explicitly asks to change
+  them.
+- Use local components from the configured \`components\` folder. Components
+  should be PascalCase exports from \`.tsx\` files; simple editable input metadata
+  can live next to them as \`ComponentNameInputs\`.
+- Use \`list-local-component-files\` and \`write-local-component-file\` for
+  component source changes when Content tools are available. Otherwise edit the
+  component files directly like normal repo source.
+
+## Boundaries
+
+- Moving, renaming, and reordering local-file pages are not first-class Content
+  UI operations yet. Use normal file operations when the user asks for those,
+  then let Content rediscover the file tree.
+- Do not push/pull Notion, Builder.io, or other provider-backed content unless
+  the user explicitly asks for provider sync.
+- Do not paste secrets, private provider data, or credential-looking values into
+  docs, generated pages, frontmatter, examples, or local components.
 `;
 
 const DESIGN_EXPLORATION_SKILL_MD = `---
@@ -2202,6 +2320,55 @@ export const BUILT_IN_APP_SKILLS = {
     }),
     skillMarkdown: ASSETS_SKILL_MD,
   },
+  content: {
+    skillName: "content",
+    manifest: normalizeAppSkillManifest({
+      schemaVersion: 1,
+      id: "content",
+      displayName: "Content",
+      description:
+        "Edit docs, blogs, resources, and MDX content through the Content app, including repo-backed Local File Mode.",
+      hosted: {
+        url: "https://content.agent-native.com",
+        mcpUrl: "https://content.agent-native.com/_agent-native/mcp",
+      },
+      mcp: { serverName: "agent-native-content" },
+      auth: {
+        mode: "oauth",
+        setup:
+          "Authenticate with the Content MCP connector in the host app. Local File Mode requires a local Content app, Agent Native Desktop, or trusted local bridge for filesystem access.",
+      },
+      surfaces: [
+        {
+          id: "content-documents",
+          action: "list-documents",
+          path: "/",
+        },
+        {
+          id: "content-local-files",
+          action: "share-local-file-document",
+          path: "/local-files",
+        },
+      ],
+      skills: [
+        {
+          path: "skills/content",
+          visibility: "exported",
+          exportAs: "content",
+        },
+      ],
+      hostAdapters: [
+        "codex-plugin",
+        "claude-marketplace",
+        "vercel-skills",
+        "plain-skill",
+        "claude-skill",
+        "chatgpt-mcp",
+        "generic-mcp",
+      ],
+    }),
+    skillMarkdown: CONTENT_SKILL_MD,
+  },
   design: {
     skillName: "design-exploration",
     manifest: normalizeAppSkillManifest({
@@ -2382,6 +2549,12 @@ const BUILT_IN_APP_SKILL_ALIASES = {
   "image-generation": "assets",
   "agent-native-assets": "assets",
   "agent-native-images": "assets",
+  content: "content",
+  docs: "content",
+  documents: "content",
+  "local-content": "content",
+  "content-local-files": "content",
+  "agent-native-content": "content",
   design: "design",
   "ui-design": "design",
   "ux-design": "design",
@@ -2410,6 +2583,13 @@ const BUILT_IN_APP_SKILL_ALIASES = {
 
 const BUILT_IN_APP_SKILL_DISPLAY_ALIASES = {
   assets: ["images", "image-generation", "agent-native-images"],
+  content: [
+    "docs",
+    "documents",
+    "local-content",
+    "content-local-files",
+    "agent-native-content",
+  ],
   design: [
     "design-exploration",
     "ux-exploration",
@@ -2529,9 +2709,9 @@ export interface ParsedSkillsArgs {
    */
   mcpUrl?: string;
   /**
-   * Storage/backend mode for the Plans skills. Hosted is the existing default;
-   * local-files installs instructions that default to DB-free MDX + local
-   * preview and skips MCP registration/auth.
+   * Storage/backend mode for app-backed skills that support install modes. The
+   * field name is kept for CLI/API compatibility with the original Plan-only
+   * implementation.
    */
   planMode?: PlanInstallMode;
   /**
@@ -2593,6 +2773,7 @@ export interface SkillsAddResult {
   githubActionPath?: string;
   githubActionExisted?: boolean;
   githubActionSuggestedCommand?: string;
+  localManifestPath?: string;
   planMode?: PlanInstallMode;
 }
 
@@ -2781,6 +2962,19 @@ function isLocalOnlyBuiltInSkill(
   return Boolean(entry && "localOnly" in entry && entry.localOnly);
 }
 
+function targetSupportsInstallMode(
+  knownTarget: BuiltInAppSkillId | undefined,
+): boolean {
+  return knownTarget === "visual-plans" || knownTarget === "content";
+}
+
+function localFilesModeSkipsMcp(
+  knownTarget: BuiltInAppSkillId | undefined,
+  mode: PlanInstallMode | undefined,
+): boolean {
+  return mode === "local-files" && targetSupportsInstallMode(knownTarget);
+}
+
 function builtInExtraSkills(
   entry: (typeof BUILT_IN_APP_SKILLS)[BuiltInAppSkillId],
 ): Record<string, string> {
@@ -2870,7 +3064,34 @@ for plans and recaps instead of assuming \`https://plan.agent-native.com\`.`;
   return "";
 }
 
-function applyPlanModeToSkillMarkdown(
+function contentModeInstructionBlock(input: {
+  mode: PlanInstallMode | undefined;
+  mcpUrl?: string;
+}): string {
+  if (input.mode === "local-files") {
+    return `## Installed Mode
+
+Default storage for this installation: Content Local File Mode. This repo should
+have an \`agent-native.json\` file with \`mode: "local-files"\` and
+\`apps.content.mode: "local-files"\`; the installer writes one if missing and
+fills in default roots for \`docs/\`, \`blog/\`, \`content/\`, and
+\`resources/\`. Prefer Content document actions when a local Content app,
+Agent Native Desktop, or another trusted local bridge exposes them. If those
+tools are not currently available, edit the configured Markdown/MDX files and
+local components directly, preserving frontmatter, imports, JSX, and unknown MDX
+syntax. The hosted Content app cannot read private repo files by itself.`;
+  }
+  if (input.mode === "self-hosted") {
+    return `## Installed Mode
+
+Default storage for this installation: the configured self-hosted/custom Content
+app${input.mcpUrl ? ` at \`${input.mcpUrl}\`` : ""}. Use that Content MCP
+connector instead of assuming \`https://content.agent-native.com\`.`;
+  }
+  return "";
+}
+
+function applyInstallModeToSkillMarkdown(
   markdown: string,
   input: {
     appSkillId: BuiltInAppSkillId;
@@ -2878,11 +3099,18 @@ function applyPlanModeToSkillMarkdown(
     mcpUrl?: string;
   },
 ): string {
-  if (input.appSkillId !== "visual-plans") return markdown;
-  const block = planModeInstructionBlock({
-    mode: input.mode,
-    mcpUrl: input.mcpUrl,
-  });
+  let block = "";
+  if (input.appSkillId === "visual-plans") {
+    block = planModeInstructionBlock({
+      mode: input.mode,
+      mcpUrl: input.mcpUrl,
+    });
+  } else if (input.appSkillId === "content") {
+    block = contentModeInstructionBlock({
+      mode: input.mode,
+      mcpUrl: input.mcpUrl,
+    });
+  }
   return insertAfterFrontmatter(markdown, block);
 }
 
@@ -2892,7 +3120,7 @@ function skillFilesForBuiltIn(
 ): Record<string, SkillFolderBundle> {
   const entry = BUILT_IN_APP_SKILLS[appSkillId];
   const skills: Record<string, string> = {
-    [entry.skillName]: applyPlanModeToSkillMarkdown(entry.skillMarkdown, {
+    [entry.skillName]: applyInstallModeToSkillMarkdown(entry.skillMarkdown, {
       appSkillId,
       mode: options.planMode,
       mcpUrl: options.mcpUrl,
@@ -2902,7 +3130,7 @@ function skillFilesForBuiltIn(
   for (const [skillName, skillMarkdown] of Object.entries(
     builtInExtraSkills(entry),
   )) {
-    skills[skillName] = applyPlanModeToSkillMarkdown(skillMarkdown, {
+    skills[skillName] = applyInstallModeToSkillMarkdown(skillMarkdown, {
       appSkillId,
       mode: options.planMode,
       mcpUrl: options.mcpUrl,
@@ -2920,7 +3148,8 @@ function skillFilesForBuiltIn(
       displayName: entry.manifest.displayName,
       skillName,
       mcpUrl:
-        isLocalOnlyBuiltInSkill(entry) || options.planMode === "local-files"
+        isLocalOnlyBuiltInSkill(entry) ||
+        localFilesModeSkipsMcp(appSkillId, options.planMode)
           ? ""
           : (options.mcpUrl ?? entry.manifest.hosted.mcpUrl),
       files,
@@ -2970,6 +3199,110 @@ function writeSkillFolder(
     `${JSON.stringify(metadata, null, 2)}\n`,
     "utf-8",
   );
+}
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function defaultContentLocalFilesAppConfig(): Record<string, unknown> {
+  return {
+    mode: "local-files",
+    roots: [
+      {
+        name: "Docs",
+        path: "docs",
+        kind: "docs",
+        extensions: [".md", ".mdx"],
+      },
+      {
+        name: "Blog",
+        path: "blog",
+        kind: "blog",
+        extensions: [".md", ".mdx"],
+      },
+      {
+        name: "Content",
+        path: "content",
+        kind: "content",
+        extensions: [".md", ".mdx"],
+      },
+      {
+        name: "Resources",
+        path: "resources",
+        kind: "resources",
+        extensions: [".md", ".mdx"],
+      },
+    ],
+    components: "components",
+    extensions: "extensions",
+    hide: ["**/_*.md", "**/_*.mdx"],
+  };
+}
+
+function contentLocalFilesManifestPath(baseDir: string): string {
+  return path.join(baseDir, "agent-native.json");
+}
+
+function shouldWriteContentLocalFilesManifest(
+  knownTarget: BuiltInAppSkillId | undefined,
+  mode: PlanInstallMode | undefined,
+): boolean {
+  return knownTarget === "content" && mode === "local-files";
+}
+
+function mergeContentLocalFilesManifest(
+  existing: unknown,
+): Record<string, unknown> {
+  const manifest = isJsonRecord(existing) ? { ...existing } : {};
+  if (manifest.version === undefined) manifest.version = 1;
+  manifest.mode = "local-files";
+
+  const apps = isJsonRecord(manifest.apps) ? { ...manifest.apps } : {};
+  const contentApp = isJsonRecord(apps.content) ? { ...apps.content } : {};
+  const defaults = defaultContentLocalFilesAppConfig();
+  contentApp.mode = "local-files";
+  if (!Array.isArray(contentApp.roots) || contentApp.roots.length === 0) {
+    contentApp.roots = defaults.roots;
+  }
+  if (contentApp.components === undefined) {
+    contentApp.components = defaults.components;
+  }
+  if (contentApp.extensions === undefined) {
+    contentApp.extensions = defaults.extensions;
+  }
+  if (!Array.isArray(contentApp.hide) || contentApp.hide.length === 0) {
+    contentApp.hide = defaults.hide;
+  }
+  apps.content = contentApp;
+  manifest.apps = apps;
+  return manifest;
+}
+
+function writeContentLocalFilesManifest(
+  baseDir: string,
+  options: { dryRun?: boolean } = {},
+): string {
+  const manifestPath = contentLocalFilesManifestPath(baseDir);
+  let existing: unknown = {};
+  if (fs.existsSync(manifestPath)) {
+    try {
+      existing = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+    } catch (error: any) {
+      throw new Error(
+        `Could not parse ${manifestPath}: ${error?.message ?? error}`,
+      );
+    }
+  }
+  const manifest = mergeContentLocalFilesManifest(existing);
+  if (!options.dryRun) {
+    fs.writeFileSync(
+      manifestPath,
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      "utf-8",
+    );
+  }
+  return manifestPath;
 }
 
 /**
@@ -3468,6 +3801,11 @@ const BUILT_IN_SKILL_PROMPT_OPTIONS: SkillsTargetPromptContext["options"] = [
     hint: BUILT_IN_APP_SKILLS.assets.manifest.description,
   },
   {
+    value: "content",
+    label: "content",
+    hint: BUILT_IN_APP_SKILLS.content.manifest.description,
+  },
+  {
     value: "design-exploration",
     label: "design-exploration",
     hint: BUILT_IN_APP_SKILLS.design.manifest.description,
@@ -3815,6 +4153,14 @@ function targetsIncludePlans(targets: string[]): boolean {
   return targets.some(targetIncludesPlans);
 }
 
+function targetIncludesInstallModeSkill(target: string): boolean {
+  return targetSupportsInstallMode(normalizeKnownSkillTarget(target));
+}
+
+function targetsIncludeInstallModeSkills(targets: string[]): boolean {
+  return targets.some(targetIncludesInstallModeSkill);
+}
+
 function planSkillNamesSelected(skillNames: string[] | undefined): boolean {
   return Boolean(
     skillNames?.some(
@@ -3823,11 +4169,24 @@ function planSkillNamesSelected(skillNames: string[] | undefined): boolean {
   );
 }
 
+function installModeSkillNamesSelected(
+  skillNames: string[] | undefined,
+): boolean {
+  return Boolean(
+    skillNames?.some((name) =>
+      targetSupportsInstallMode(normalizeKnownSkillTarget(name)),
+    ),
+  );
+}
+
 function shouldForwardPlanModeFlag(
   target: string,
   skillNames: string[] | undefined,
 ): boolean {
-  return targetIncludesPlans(target) || planSkillNamesSelected(skillNames);
+  return (
+    targetIncludesInstallModeSkill(target) ||
+    installModeSkillNamesSelected(skillNames)
+  );
 }
 
 function recapSkillNamesSelected(skillNames: string[] | undefined): boolean {
@@ -4356,7 +4715,7 @@ async function addPlainSkillRepo(
       "Plain skill repositories only install skill instructions. Run without --mcp-only.",
     );
   }
-  if (parsed.mcpUrl && !planSkillNamesSelected(parsed.plainSkillNames)) {
+  if (parsed.mcpUrl && !installModeSkillNamesSelected(parsed.plainSkillNames)) {
     throw new Error(
       "--mcp-url only applies to app-backed Agent Native skills.",
     );
@@ -4584,12 +4943,18 @@ export async function addAgentNativeSkill(
     );
   }
   const knownTarget = normalizeKnownSkillTarget(target);
-  const planMode =
-    knownTarget === "visual-plans"
-      ? (parsed.planMode ?? (parsed.mcpUrl ? "self-hosted" : "hosted"))
-      : undefined;
-  if (parsed.planMode && knownTarget !== "visual-plans") {
-    throw new Error("--mode only applies to visual-plan / visual-recap.");
+  const planMode = targetSupportsInstallMode(knownTarget)
+    ? (parsed.planMode ??
+      (parsed.mcpUrl
+        ? "self-hosted"
+        : knownTarget === "visual-plans"
+          ? "hosted"
+          : undefined))
+    : undefined;
+  if (parsed.planMode && !targetSupportsInstallMode(knownTarget)) {
+    throw new Error(
+      "--mode only applies to visual-plan / visual-recap / content.",
+    );
   }
   if (planMode === "local-files" && parsed.mcpUrl) {
     throw new Error("--mode local-files cannot be combined with --mcp-url.");
@@ -4598,8 +4963,7 @@ export async function addAgentNativeSkill(
     throw new Error("--mode self-hosted requires --mcp-url <url>.");
   }
   const shouldRegisterMcp =
-    parsed.mcp &&
-    !(knownTarget === "visual-plans" && planMode === "local-files");
+    parsed.mcp && !localFilesModeSkipsMcp(knownTarget, planMode);
   // For multi-skill bundles (the plan bundle), a single-skill target installs
   // only that skill. `installsRecap` controls the PR Visual Recap github-action
   // offer, which is only relevant when the recap skill is part of the install.
@@ -4618,6 +4982,7 @@ export async function addAgentNativeSkill(
     );
   }
   const knownBuiltIn = knownTarget ? BUILT_IN_APP_SKILLS[knownTarget] : null;
+  const baseDir = options.baseDir ?? process.cwd();
   if (isLocalOnlyBuiltInSkill(knownBuiltIn)) {
     if (parsed.mcpUrl) {
       throw new Error(
@@ -4658,7 +5023,7 @@ export async function addAgentNativeSkill(
       };
     }
     const localInstall = installLocalContextXray({
-      baseDir: options.baseDir ?? process.cwd(),
+      baseDir,
       clients,
       scope: parsed.scope,
     });
@@ -4699,6 +5064,12 @@ export async function addAgentNativeSkill(
   const skillsAgents = skillsAgentsForClients(clients);
   if (parsed.dryRun) {
     try {
+      const localManifestPath = shouldWriteContentLocalFilesManifest(
+        knownTarget,
+        planMode,
+      )
+        ? contentLocalFilesManifestPath(baseDir)
+        : undefined;
       const githubActionPath =
         parsed.withGithubAction && installsRecap
           ? prVisualRecapWorkflowDisplayPath()
@@ -4718,16 +5089,19 @@ export async function addAgentNativeSkill(
         displayName: installTarget.displayName,
         skillNames: installTarget.skillNames,
         skillsAgents,
-        mcpUrl:
-          knownTarget === "visual-plans" && planMode === "local-files"
-            ? ""
-            : installTarget.loaded.manifest.hosted.mcpUrl,
+        mcpUrl: localFilesModeSkipsMcp(knownTarget, planMode)
+          ? ""
+          : installTarget.loaded.manifest.hosted.mcpUrl,
         mcpClients: shouldRegisterMcp ? mcpClients : [],
         dryRun: true,
-        commands: [dryRunInstallCommand(parsed, target)],
+        commands: [
+          dryRunInstallCommand(parsed, target),
+          ...(localManifestPath ? [`write ${localManifestPath}`] : []),
+        ],
         githubActionPath,
         githubActionSuggestedCommand,
         planMode,
+        localManifestPath,
       };
     } finally {
       installTarget.cleanup?.();
@@ -4740,6 +5114,7 @@ export async function addAgentNativeSkill(
   let connected = false;
   let connectCommand: string | undefined;
   let registeredMcpClients: ClientId[] = shouldRegisterMcp ? mcpClients : [];
+  let localManifestPath: string | undefined;
 
   try {
     if (parsed.instructions) {
@@ -4759,7 +5134,7 @@ export async function addAgentNativeSkill(
           onlySkillNames,
           skillsAgents,
           scope: parsed.scope as "project" | "user",
-          baseDir: options.baseDir ?? process.cwd(),
+          baseDir,
           dryRun: parsed.dryRun,
           planMode,
           mcpUrl: installTarget.loaded.manifest.hosted.mcpUrl,
@@ -4794,6 +5169,11 @@ export async function addAgentNativeSkill(
             );
         }
       }
+    }
+
+    if (shouldWriteContentLocalFilesManifest(knownTarget, planMode)) {
+      localManifestPath = writeContentLocalFilesManifest(baseDir);
+      commands.push(`write ${localManifestPath}`);
     }
 
     // Skill instructions are now on disk (built-in folders copied or external
@@ -4858,7 +5238,6 @@ export async function addAgentNativeSkill(
 
     // `--with-github-action`: also drop the PR Visual Recap workflow into the
     // repo so PRs get automatic recaps. Only meaningful for the plan family.
-    const baseDir = options.baseDir ?? process.cwd();
     let withGithubAction = Boolean(parsed.withGithubAction);
     let githubActionPath: string | undefined;
     let githubActionExisted: boolean | undefined;
@@ -4916,10 +5295,9 @@ export async function addAgentNativeSkill(
       instructionSource,
       skillNames: installTarget.skillNames,
       skillsAgents,
-      mcpUrl:
-        knownTarget === "visual-plans" && planMode === "local-files"
-          ? ""
-          : installTarget.loaded.manifest.hosted.mcpUrl,
+      mcpUrl: localFilesModeSkipsMcp(knownTarget, planMode)
+        ? ""
+        : installTarget.loaded.manifest.hosted.mcpUrl,
       mcpClients: registeredMcpClients,
       dryRun: parsed.dryRun,
       commands,
@@ -4927,6 +5305,7 @@ export async function addAgentNativeSkill(
       connected,
       connectCommand,
       planMode,
+      localManifestPath,
       githubActionPath,
       githubActionExisted,
       githubActionSuggestedCommand,
@@ -4997,9 +5376,10 @@ function formatSkillState(state: SkillInstallState): string {
 }
 
 function planModeSummary(mode: PlanInstallMode): string {
-  if (mode === "local-files") return "Local files - No sharing, all local.";
-  if (mode === "self-hosted") return "Self-hosted/custom Plan app";
-  return "Hosted Plans - shareable links and comments";
+  if (mode === "local-files")
+    return "Local files - no hosted writes by default";
+  if (mode === "self-hosted") return "Self-hosted/custom app";
+  return "Hosted app";
 }
 
 function skillInstructionAgentLabel(agent: string): string {
@@ -5017,7 +5397,7 @@ function targetInstallsMcp(
   if (!parsed.mcp) return false;
   if (publicSkillSelectionNames(target)) return false;
   const knownTarget = normalizeKnownSkillTarget(target);
-  if (knownTarget === "visual-plans") return parsed.planMode !== "local-files";
+  if (localFilesModeSkipsMcp(knownTarget, parsed.planMode)) return false;
   if (knownTarget) {
     return !isLocalOnlyBuiltInSkill(BUILT_IN_APP_SKILLS[knownTarget]);
   }
@@ -5255,8 +5635,13 @@ export async function runSkills(
     const includesPlans =
       targetsIncludePlans(targets) ||
       planSkillNamesSelected(parsed.plainSkillNames);
-    if (parsed.planMode && !includesPlans) {
-      throw new Error("--mode only applies to visual-plan / visual-recap.");
+    const includesInstallModeSkills =
+      targetsIncludeInstallModeSkills(targets) ||
+      installModeSkillNamesSelected(parsed.plainSkillNames);
+    if (parsed.planMode && !includesInstallModeSkills) {
+      throw new Error(
+        "--mode only applies to visual-plan / visual-recap / content.",
+      );
     }
     if (includesPlans) {
       if (!parsed.planMode && parsed.mcpUrl) {
@@ -5491,7 +5876,7 @@ export async function runSkills(
         : "MCP config           not required",
       mcpUrls.length ? `MCP URL              ${mcpUrls.join(", ")}` : "",
       planModes.length
-        ? `Plan mode            ${planModes.map(planModeSummary).join(", ")}`
+        ? `Install mode         ${planModes.map(planModeSummary).join(", ")}`
         : "",
       authConnected
         ? "Authentication       completed"

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -253,7 +253,6 @@ Content roots for \`docs/\`, \`blog/\`, \`content/\`, and \`resources/\`, plus a
 \`\`\`json
 {
   "version": 1,
-  "mode": "local-files",
   "apps": {
     "content": {
       "mode": "local-files",
@@ -2537,6 +2536,7 @@ export const BUILT_IN_APP_SKILLS = {
 >;
 
 type BuiltInAppSkillId = keyof typeof BUILT_IN_APP_SKILLS;
+type ModeAwareAppSkillId = "visual-plans" | "content";
 
 export const AGENT_NATIVE_SKILL_METADATA_FILE = "agent-native-skill.json";
 
@@ -2822,6 +2822,7 @@ interface SkillInstallTarget {
   displayName: string;
   loaded: LoadedAppSkillManifest;
   skillNames: string[];
+  modeAwareId?: ModeAwareAppSkillId;
   materializeInstructions(outDir: string): string;
   cleanup?: () => void;
 }
@@ -2963,16 +2964,16 @@ function isLocalOnlyBuiltInSkill(
 }
 
 function targetSupportsInstallMode(
-  knownTarget: BuiltInAppSkillId | undefined,
-): boolean {
-  return knownTarget === "visual-plans" || knownTarget === "content";
+  targetId: string | undefined,
+): targetId is ModeAwareAppSkillId {
+  return targetId === "visual-plans" || targetId === "content";
 }
 
 function localFilesModeSkipsMcp(
-  knownTarget: BuiltInAppSkillId | undefined,
+  targetId: string | undefined,
   mode: PlanInstallMode | undefined,
 ): boolean {
-  return mode === "local-files" && targetSupportsInstallMode(knownTarget);
+  return mode === "local-files" && targetSupportsInstallMode(targetId);
 }
 
 function builtInExtraSkills(
@@ -3072,10 +3073,10 @@ function contentModeInstructionBlock(input: {
     return `## Installed Mode
 
 Default storage for this installation: Content Local File Mode. This repo should
-have an \`agent-native.json\` file with \`mode: "local-files"\` and
-\`apps.content.mode: "local-files"\`; the installer writes one if missing and
-fills in default roots for \`docs/\`, \`blog/\`, \`content/\`, and
-\`resources/\`. Prefer Content document actions when a local Content app,
+have an \`agent-native.json\` file with \`apps.content.mode: "local-files"\`;
+the installer writes one if missing and fills in default roots for \`docs/\`,
+\`blog/\`, \`content/\`, and \`resources/\`. Prefer Content document actions
+when a local Content app,
 Agent Native Desktop, or another trusted local bridge exposes them. If those
 tools are not currently available, edit the configured Markdown/MDX files and
 local components directly, preserving frontmatter, imports, JSX, and unknown MDX
@@ -3245,10 +3246,10 @@ function contentLocalFilesManifestPath(baseDir: string): string {
 }
 
 function shouldWriteContentLocalFilesManifest(
-  knownTarget: BuiltInAppSkillId | undefined,
+  targetId: string | undefined,
   mode: PlanInstallMode | undefined,
 ): boolean {
-  return knownTarget === "content" && mode === "local-files";
+  return targetId === "content" && mode === "local-files";
 }
 
 function mergeContentLocalFilesManifest(
@@ -3256,7 +3257,6 @@ function mergeContentLocalFilesManifest(
 ): Record<string, unknown> {
   const manifest = isJsonRecord(existing) ? { ...existing } : {};
   if (manifest.version === undefined) manifest.version = 1;
-  manifest.mode = "local-files";
 
   const apps = isJsonRecord(manifest.apps) ? { ...manifest.apps } : {};
   const contentApp = isJsonRecord(apps.content) ? { ...apps.content } : {};
@@ -4410,6 +4410,9 @@ function loadSkillTarget(
         dir: process.cwd(),
       },
       skillNames,
+      modeAwareId: targetSupportsInstallMode(knownTarget)
+        ? knownTarget
+        : undefined,
       materializeInstructions(outDir) {
         const bundles = skillFilesForBuiltIn(knownTarget);
         for (const bundle of Object.values(bundles)) {
@@ -4441,6 +4444,9 @@ function loadSkillTarget(
           skill.visibility === "exported" || skill.visibility === "both",
       )
       .map((skill) => skill.exportAs ?? path.basename(skill.path)),
+    modeAwareId: targetSupportsInstallMode(loaded.manifest.id)
+      ? loaded.manifest.id
+      : undefined,
     materializeInstructions(outDir) {
       const packed = buildAppSkillPack(loaded, outDir);
       const vercelAdapter = path.join(
@@ -4515,6 +4521,7 @@ function preserveMcpUrlAppPathOverride(
 function dryRunInstallCommand(
   parsed: ParsedSkillsArgs,
   target: string,
+  options: { modeAwareTargetId?: string } = {},
 ): string {
   const clients =
     parsed.clients ??
@@ -4533,7 +4540,9 @@ function dryRunInstallCommand(
     target,
     parsed.plainSkillNames,
   );
-  if (forwardsPlanFlags && parsed.planMode)
+  const forwardsInstallMode =
+    forwardsPlanFlags || targetSupportsInstallMode(options.modeAwareTargetId);
+  if (forwardsInstallMode && parsed.planMode)
     args.push("--mode", parsed.planMode);
   if (parsed.mcpUrl) args.push("--mcp-url", parsed.mcpUrl);
   if (parsed.instructions && !parsed.mcp) args.push("--instructions-only");
@@ -4943,27 +4952,6 @@ export async function addAgentNativeSkill(
     );
   }
   const knownTarget = normalizeKnownSkillTarget(target);
-  const planMode = targetSupportsInstallMode(knownTarget)
-    ? (parsed.planMode ??
-      (parsed.mcpUrl
-        ? "self-hosted"
-        : knownTarget === "visual-plans"
-          ? "hosted"
-          : undefined))
-    : undefined;
-  if (parsed.planMode && !targetSupportsInstallMode(knownTarget)) {
-    throw new Error(
-      "--mode only applies to visual-plan / visual-recap / content.",
-    );
-  }
-  if (planMode === "local-files" && parsed.mcpUrl) {
-    throw new Error("--mode local-files cannot be combined with --mcp-url.");
-  }
-  if (planMode === "self-hosted" && !parsed.mcpUrl) {
-    throw new Error("--mode self-hosted requires --mcp-url <url>.");
-  }
-  const shouldRegisterMcp =
-    parsed.mcp && !localFilesModeSkipsMcp(knownTarget, planMode);
   // For multi-skill bundles (the plan bundle), a single-skill target installs
   // only that skill. `installsRecap` controls the PR Visual Recap github-action
   // offer, which is only relevant when the recap skill is part of the install.
@@ -4984,6 +4972,11 @@ export async function addAgentNativeSkill(
   const knownBuiltIn = knownTarget ? BUILT_IN_APP_SKILLS[knownTarget] : null;
   const baseDir = options.baseDir ?? process.cwd();
   if (isLocalOnlyBuiltInSkill(knownBuiltIn)) {
+    if (parsed.planMode) {
+      throw new Error(
+        "--mode only applies to visual-plan / visual-recap / content.",
+      );
+    }
     if (parsed.mcpUrl) {
       throw new Error(
         "Context X-Ray is installed locally and does not use --mcp-url yet.",
@@ -5049,6 +5042,28 @@ export async function addAgentNativeSkill(
     };
   }
   let installTarget = loadSkillTarget(target, onlySkillNames);
+  const modeAwareTargetId = installTarget.modeAwareId;
+  const planMode = modeAwareTargetId
+    ? (parsed.planMode ??
+      (parsed.mcpUrl
+        ? "self-hosted"
+        : modeAwareTargetId === "visual-plans"
+          ? "hosted"
+          : undefined))
+    : undefined;
+  if (parsed.planMode && !modeAwareTargetId) {
+    throw new Error(
+      "--mode only applies to visual-plan / visual-recap / content.",
+    );
+  }
+  if (planMode === "local-files" && parsed.mcpUrl) {
+    throw new Error("--mode local-files cannot be combined with --mcp-url.");
+  }
+  if (planMode === "self-hosted" && !parsed.mcpUrl) {
+    throw new Error("--mode self-hosted requires --mcp-url <url>.");
+  }
+  const shouldRegisterMcp =
+    parsed.mcp && !localFilesModeSkipsMcp(modeAwareTargetId, planMode);
   if (parsed.mcpUrl) {
     installTarget = withMcpUrlOverride(installTarget, parsed.mcpUrl);
   }
@@ -5065,7 +5080,7 @@ export async function addAgentNativeSkill(
   if (parsed.dryRun) {
     try {
       const localManifestPath = shouldWriteContentLocalFilesManifest(
-        knownTarget,
+        modeAwareTargetId,
         planMode,
       )
         ? contentLocalFilesManifestPath(baseDir)
@@ -5089,13 +5104,13 @@ export async function addAgentNativeSkill(
         displayName: installTarget.displayName,
         skillNames: installTarget.skillNames,
         skillsAgents,
-        mcpUrl: localFilesModeSkipsMcp(knownTarget, planMode)
+        mcpUrl: localFilesModeSkipsMcp(modeAwareTargetId, planMode)
           ? ""
           : installTarget.loaded.manifest.hosted.mcpUrl,
         mcpClients: shouldRegisterMcp ? mcpClients : [],
         dryRun: true,
         commands: [
-          dryRunInstallCommand(parsed, target),
+          dryRunInstallCommand(parsed, target, { modeAwareTargetId }),
           ...(localManifestPath ? [`write ${localManifestPath}`] : []),
         ],
         githubActionPath,
@@ -5156,6 +5171,12 @@ export async function addAgentNativeSkill(
           ...installTarget.skillNames.flatMap((skill) => ["--skill", skill]),
           ...skillsAgents.flatMap((agent) => ["-a", agent]),
           ...(parsed.scope === "user" ? ["-g"] : []),
+          ...(modeAwareTargetId && parsed.planMode
+            ? ["--mode", parsed.planMode]
+            : []),
+          ...(modeAwareTargetId && parsed.mcpUrl
+            ? ["--mcp-url", parsed.mcpUrl]
+            : []),
           ...(parsed.yes || knownTarget ? ["-y"] : []),
         ];
         commands.push(commandString("npx", args));
@@ -5171,7 +5192,7 @@ export async function addAgentNativeSkill(
       }
     }
 
-    if (shouldWriteContentLocalFilesManifest(knownTarget, planMode)) {
+    if (shouldWriteContentLocalFilesManifest(modeAwareTargetId, planMode)) {
       localManifestPath = writeContentLocalFilesManifest(baseDir);
       commands.push(`write ${localManifestPath}`);
     }
@@ -5295,7 +5316,7 @@ export async function addAgentNativeSkill(
       instructionSource,
       skillNames: installTarget.skillNames,
       skillsAgents,
-      mcpUrl: localFilesModeSkipsMcp(knownTarget, planMode)
+      mcpUrl: localFilesModeSkipsMcp(modeAwareTargetId, planMode)
         ? ""
         : installTarget.loaded.manifest.hosted.mcpUrl,
       mcpClients: registeredMcpClients,

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -149,10 +149,9 @@ const SetupButton = lazy(() =>
   })),
 );
 
-// Setup/onboarding widget is hidden until the UX is improved.
-// Flip to `true` to restore the SetupButton in the header and the
-// OnboardingPanel above the chat.
-const SHOW_ONBOARDING = false;
+// Setup/onboarding widget appears above chat until required setup is complete,
+// and can be reopened from the header after dismissal.
+const SHOW_ONBOARDING = true;
 
 const CLI_STORAGE_KEY = "agent-native-cli-command";
 const CLI_DEFAULT = "claude";
@@ -964,7 +963,7 @@ function AgentPanelInner({
       | "toggleHistory"
     > & { activeChatSessionId?: string }) => (
       <div className="relative flex shrink-0 items-center gap-0.5">
-        {SHOW_ONBOARDING && canUseCodeTools && (
+        {SHOW_ONBOARDING && (
           <Suspense fallback={null}>
             <SetupButton />
           </Suspense>
@@ -1482,9 +1481,9 @@ function AgentPanelInner({
       />
       {/* Framework onboarding — appears above the chat/cli/settings tabs
           so it's visible regardless of which tab the user is on. The panel
-          hides itself once all required steps are done or the user
-          dismisses it. Gated by SHOW_ONBOARDING until the UX is improved. */}
-      {SHOW_ONBOARDING && mounted && canUseCodeTools && (
+          hides itself once all required steps are done or the user dismisses
+          it. */}
+      {SHOW_ONBOARDING && mounted && (
         <Suspense fallback={null}>
           <OnboardingPanel />
         </Suspense>

--- a/packages/core/src/file-upload/pre-upload-attachments.spec.ts
+++ b/packages/core/src/file-upload/pre-upload-attachments.spec.ts
@@ -258,6 +258,8 @@ describe("preUploadAttachments", () => {
 
     expect(result.providerMissing).toBe(true);
     expect(result.injectedText).toContain("no file-upload provider");
+    expect(result.injectedText).toContain("connect-builder");
+    expect(result.injectedText).not.toContain("Settings");
   });
 
   it("does not crash when uploadFile throws; keeps base64 for that attachment", async () => {

--- a/packages/core/src/file-upload/pre-upload-attachments.ts
+++ b/packages/core/src/file-upload/pre-upload-attachments.ts
@@ -289,7 +289,7 @@ export async function preUploadAttachments(opts: {
     injectedText = [
       "<chat-image-attachment-upload-error>",
       "The user attached one or more images, but no file-upload provider is configured for this app.",
-      "If `connect-builder` is available, use it to render the inline Builder.io connection card instead of sending the user to Settings. Workspaces with a custom storage provider can also use one registered via registerFileUploadProvider().",
+      "If `connect-builder` is available, use it to render the inline Builder.io connection card. Workspaces with a custom storage provider can also use one registered via registerFileUploadProvider().",
       "Until that's done, you can still SEE the image, but you do NOT have a URL to embed it in HTML or share with other apps.",
       "</chat-image-attachment-upload-error>",
     ].join("\n");

--- a/packages/core/src/file-upload/pre-upload-attachments.ts
+++ b/packages/core/src/file-upload/pre-upload-attachments.ts
@@ -289,7 +289,7 @@ export async function preUploadAttachments(opts: {
     injectedText = [
       "<chat-image-attachment-upload-error>",
       "The user attached one or more images, but no file-upload provider is configured for this app.",
-      "Tell the user to connect or reconnect Builder.io from Settings → File uploads. If `connect-builder` is available, use it to render the inline connection card. Workspaces with a custom storage provider can also use one registered via registerFileUploadProvider().",
+      "If `connect-builder` is available, use it to render the inline Builder.io connection card instead of sending the user to Settings. Workspaces with a custom storage provider can also use one registered via registerFileUploadProvider().",
       "Until that's done, you can still SEE the image, but you do NOT have a URL to embed it in HTML or share with other apps.",
       "</chat-image-attachment-upload-error>",
     ].join("\n");

--- a/packages/core/src/scripts/runner.spec.ts
+++ b/packages/core/src/scripts/runner.spec.ts
@@ -149,6 +149,103 @@ describe("runScript package actions", () => {
     });
   }, 20_000);
 
+  it("runs a package action with a positional JSON object", () => {
+    const result = spawnSync(
+      tsxCommand,
+      [
+        ...tsxLeadingArgs,
+        "actions/run.ts",
+        "package-action",
+        JSON.stringify({
+          enabled: true,
+          limit: 8,
+          cursors: { slack: "next-page" },
+          sourceIds: ["mail", "calendar"],
+        }),
+      ],
+      {
+        cwd: tmpDir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          AGENT_USER_EMAIL: "owner@example.test",
+        },
+        timeout: spawnTimeoutMs,
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("package-ok");
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(tmpDir, "package-output.json"), "utf8"),
+      ),
+    ).toEqual({
+      enabled: true,
+      limit: 8,
+      cursors: { slack: "next-page" },
+      sourceIds: ["mail", "calendar"],
+    });
+  }, 20_000);
+
+  it("lets explicit flags override positional JSON object keys", () => {
+    const result = spawnSync(
+      tsxCommand,
+      [
+        ...tsxLeadingArgs,
+        "actions/run.ts",
+        "package-action",
+        JSON.stringify({
+          enabled: true,
+          limit: 8,
+          cursors: { slack: "next-page" },
+        }),
+        "--enabled=false",
+        "--limit",
+        "12",
+      ],
+      {
+        cwd: tmpDir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          AGENT_USER_EMAIL: "owner@example.test",
+        },
+        timeout: spawnTimeoutMs,
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(tmpDir, "package-output.json"), "utf8"),
+      ),
+    ).toEqual({
+      enabled: false,
+      limit: "12",
+      cursors: { slack: "next-page" },
+    });
+  }, 20_000);
+
+  it("reports invalid positional JSON object input", () => {
+    const result = spawnSync(
+      tsxCommand,
+      [...tsxLeadingArgs, "actions/run.ts", "package-action", "{bad-json"],
+      {
+        cwd: tmpDir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          AGENT_USER_EMAIL: "owner@example.test",
+        },
+        timeout: spawnTimeoutMs,
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Invalid positional JSON argument");
+  }, 20_000);
+
   it("preserves empty package action arguments", () => {
     const result = spawnSync(
       tsxCommand,

--- a/packages/core/src/scripts/runner.ts
+++ b/packages/core/src/scripts/runner.ts
@@ -7,7 +7,7 @@
  *
  * Actions must export a default function: (args: string[]) => Promise<void>
  *
- * Usage: pnpm action <action-name> [--args]
+ * Usage: pnpm action <action-name> ['{"arg":"value"}'] [--args]
  */
 
 import path from "path";
@@ -59,7 +59,9 @@ export async function runScript(options: RunScriptOptions = {}): Promise<void> {
   const actionName = process.argv[2];
 
   if (!actionName || actionName === "--help") {
-    console.log(`Usage: pnpm action <action-name> [--arg value ...]`);
+    console.log(
+      `Usage: pnpm action <action-name> ['{"arg":"value"}'] [--arg value ...]`,
+    );
     console.log(`\nRun any action with --help for usage details.`);
 
     // List local actions (try actions/ first, then scripts/)
@@ -158,7 +160,8 @@ function parseActionArgs(
   args: string[],
   options: { coerceBooleans?: boolean } = {},
 ): Record<string, unknown> {
-  const parsed: Record<string, unknown> = {};
+  const parsed = parsePositionalJsonArg(args);
+  const flagArgs: Record<string, unknown> = {};
   const coerceBooleans = options.coerceBooleans ?? false;
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -166,7 +169,7 @@ function parseActionArgs(
     const eqIdx = arg.indexOf("=");
     if (eqIdx > 0) {
       setParsedArg(
-        parsed,
+        flagArgs,
         arg.slice(2, eqIdx),
         coerceCliValue(arg.slice(eqIdx + 1), coerceBooleans),
       );
@@ -174,14 +177,49 @@ function parseActionArgs(
       const key = arg.slice(2);
       const next = args[i + 1];
       if (next !== undefined && !next.startsWith("--")) {
-        setParsedArg(parsed, key, coerceCliValue(next, coerceBooleans));
+        setParsedArg(flagArgs, key, coerceCliValue(next, coerceBooleans));
         i++;
       } else {
-        setParsedArg(parsed, key, coerceBooleans ? true : "true");
+        setParsedArg(flagArgs, key, coerceBooleans ? true : "true");
       }
     }
   }
-  return parsed;
+  return { ...parsed, ...flagArgs };
+}
+
+function parsePositionalJsonArg(args: string[]): Record<string, unknown> {
+  let jsonArg: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith("--")) {
+      if (!arg.includes("=") && args[i + 1] && !args[i + 1].startsWith("--")) {
+        i++;
+      }
+      continue;
+    }
+
+    const trimmed = arg.trim();
+    if (!trimmed.startsWith("{")) continue;
+    if (jsonArg !== undefined) {
+      throw new Error("Only one positional JSON object argument is supported.");
+    }
+    jsonArg = trimmed;
+  }
+
+  if (jsonArg === undefined) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonArg);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid positional JSON argument: ${message}`);
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Positional JSON argument must be a JSON object.");
+  }
+  return parsed as Record<string, unknown>;
 }
 
 /**

--- a/packages/core/src/templates/headless/AGENTS.md
+++ b/packages/core/src/templates/headless/AGENTS.md
@@ -45,7 +45,7 @@ features. Prefer this app's own `AGENTS.md` for app-specific rules.
 Run actions from this app root:
 
 ```bash
-pnpm action hello --name Builder
+pnpm action hello '{"name":"Builder"}'
 ```
 
 Run the app-agent loop against those actions:

--- a/packages/core/src/templates/headless/DEVELOPING.md
+++ b/packages/core/src/templates/headless/DEVELOPING.md
@@ -4,7 +4,7 @@ Install dependencies, then run the hello action:
 
 ```bash
 pnpm install
-pnpm action hello --name Builder
+pnpm action hello '{"name":"Builder"}'
 ```
 
 `actions/run.ts` is only the shared CLI dispatcher that powers

--- a/packages/docs/app/routes/skills.tsx
+++ b/packages/docs/app/routes/skills.tsx
@@ -7,16 +7,18 @@ import { withDefaultSocialImage } from "../seo";
 export const meta = () =>
   withDefaultSocialImage([
     {
-      title: "Agent Skills — Visual Plan & Visual Recap for coding agents",
+      title:
+        "Agent Skills — Visual Plan, Visual Recap, and Content for coding agents",
     },
     {
       name: "description",
       content:
-        "Install Agent-Native app-backed skills your coding agent runs as slash commands. /visual-plan opens structured plans; /visual-recap turns a PR diff into a high-altitude review.",
+        "Install Agent-Native app-backed skills your coding agent can use for visual planning, PR recaps, and repo-backed MDX content editing.",
     },
     {
       property: "og:title",
-      content: "Agent Skills — Visual Plan & Visual Recap for coding agents",
+      content:
+        "Agent Skills — Visual Plan, Visual Recap, and Content for coding agents",
     },
     {
       property: "og:description",
@@ -26,7 +28,7 @@ export const meta = () =>
     {
       name: "keywords",
       content:
-        "agent skills, visual plan, visual recap, coding agent, Claude Code, Codex, PR review, planning, slash command, agent-native",
+        "agent skills, visual plan, visual recap, content skill, local file mode, coding agent, Claude Code, Codex, PR review, planning, MDX, agent-native",
     },
   ]);
 
@@ -71,6 +73,19 @@ const SKILLS: Skill[] = [
     docsTo: "/docs/pr-visual-recap",
     videoAriaLabel: "Visual Recap skill demo video",
     videoUrl: import.meta.env.VITE_VISUAL_RECAP_SKILL_DEMO_VIDEO_URL,
+  },
+  {
+    command: "content",
+    name: "Content",
+    tagline: "Edit repo MDX",
+    description:
+      "Installs Content as an app-backed skill for local docs, blogs, resources, MDX pages, and local components.",
+    features: [
+      "Writes agent-native.json for Content Local File Mode",
+      "Uses Content actions when a local bridge is available",
+    ],
+    docsTo: "/docs/template-content",
+    videoAriaLabel: "Content skill demo video",
   },
 ];
 
@@ -240,9 +255,9 @@ export default function SkillsPage() {
             </h1>
 
             <p className="mb-6 text-base leading-7 text-[var(--fg-secondary)] sm:text-lg sm:leading-relaxed">
-              Install slash commands powered by Agent-Native apps you can fully
-              customize. Start with visual plans before you build and
-              high-altitude recaps after each diff.
+              Install app-backed skills powered by Agent-Native apps you can
+              fully customize: visual review workflows plus repo-backed Content
+              for local Markdown and MDX editing.
             </p>
 
             <CliCopy command={INSTALL_COMMAND} location="skills_hero" />
@@ -255,14 +270,14 @@ export default function SkillsPage() {
       {/* Skill cards */}
       <section className="border-t border-[var(--docs-border)] py-16">
         <h2 className="mb-3 text-2xl font-bold tracking-tight">
-          Two skills, one install
+          App-backed skills for coding agents
         </h2>
         <p className="mb-8 max-w-2xl text-base text-[var(--fg-secondary)]">
-          Both ship in the same bundle. Use hosted shareable Plan links, local
-          files only, or a self-hosted/custom Plan app, and your agent opens the
-          review surface in the right mode.
+          Use hosted shareable app links, local files, or a self-hosted/custom
+          app, and your agent gets instructions plus the matching MCP surface
+          when one is required.
         </p>
-        <div className="grid gap-6 md:grid-cols-2">
+        <div className="grid gap-6 md:grid-cols-3">
           {SKILLS.map((skill) => (
             <SkillCard key={skill.command} skill={skill} />
           ))}
@@ -285,6 +300,14 @@ export default function SkillsPage() {
             className="inline-flex items-center gap-1 text-sm font-medium text-[var(--fg)] no-underline hover:text-[var(--docs-accent)]"
           >
             Read the Visual Plans docs
+            <span aria-hidden>→</span>
+          </Link>
+          <Link
+            data-an-prefetch="render"
+            to="/docs/template-content"
+            className="inline-flex items-center gap-1 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
+          >
+            Read the Content docs
             <span aria-hidden>→</span>
           </Link>
           <Link

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -7,6 +7,7 @@ npx @agent-native/skills@latest add
 npx @agent-native/skills@latest add --skill quick-recap --client codex --scope project --update-instructions
 npx @agent-native/skills@latest add --skill visual-recap --client all --with-github-action
 npx @agent-native/skills@latest add --skill visual-plan --mode local-files
+npx @agent-native/skills@latest add --skill content --mode local-files --scope project
 ```
 
 Use `--skill <name>` one or more times to select specific skills, or omit it in
@@ -14,12 +15,14 @@ an interactive terminal to choose from a prompt. The prompt puts `visual-plan`
 and `visual-recap` first and preselects only those by default. Use
 `--client codex`, `--client claude-code`, or `--client all` to choose install
 targets; omitted `--client` defaults to all supported clients. For
-`visual-plan` and `visual-recap`, use `--mode hosted`, `--mode local-files`, or
-`--mode self-hosted --mcp-url <url>` to choose hosted sharing, all-local text
-files, or your own Plan app. Add `--update-instructions` to append an idempotent
-managed block to `AGENTS.md` and/or `CLAUDE.md` for instruction-style skills.
+`visual-plan`, `visual-recap`, and `content`, use `--mode hosted`,
+`--mode local-files`, or `--mode self-hosted --mcp-url <url>` to choose hosted
+sharing, local-file workflows, or your own app. Add `--update-instructions` to
+append an idempotent managed block to `AGENTS.md` and/or `CLAUDE.md` for
+instruction-style skills.
 
 Skill content comes from `BuilderIO/skills@main` at install/list time for plain
-skill installs. Explicit `visual-plan` / `visual-recap` installs delegate to
-`@agent-native/core` so Plan mode selection, MCP registration, and local-files
-instructions stay in one framework-owned flow.
+skill installs. Explicit app-backed installs such as `visual-plan`,
+`visual-recap`, and `content` delegate to `@agent-native/core` so mode
+selection, MCP registration, and local-files instructions stay in one
+framework-owned flow.

--- a/packages/skills/src/built-in-apps.spec.ts
+++ b/packages/skills/src/built-in-apps.spec.ts
@@ -39,6 +39,15 @@ describe("resolveAppForSkill", () => {
     expect(app?.authMode).toBe("oauth");
   });
 
+  it("maps content to the agent-native-content server", () => {
+    const app = resolveAppForSkill("content");
+    expect(app?.appId).toBe("content");
+    expect(app?.serverName).toBe("agent-native-content");
+    expect(app?.mcpUrl).toBe(
+      "https://content.agent-native.com/_agent-native/mcp",
+    );
+  });
+
   it("maps design-exploration to the agent-native-design server", () => {
     const app = resolveAppForSkill("design-exploration");
     expect(app?.appId).toBe("design");
@@ -71,6 +80,7 @@ describe("appHasMcp", () => {
     expect(appHasMcp("visual-plan")).toBe(true);
     expect(appHasMcp("visual-recap")).toBe(true);
     expect(appHasMcp("assets")).toBe(true);
+    expect(appHasMcp("content")).toBe(true);
     expect(appHasMcp("design-exploration")).toBe(true);
     expect(appHasMcp("context-xray")).toBe(true);
     expect(appHasMcp("nope")).toBe(false);

--- a/packages/skills/src/built-in-apps.ts
+++ b/packages/skills/src/built-in-apps.ts
@@ -84,6 +84,15 @@ export const BUILT_IN_APP_MCP: BuiltInAppMcp[] = [
     authMode: "oauth",
   },
   {
+    appId: "content",
+    displayName: "Content",
+    skillNames: ["content"],
+    serverName: "agent-native-content",
+    mcpUrl: "https://content.agent-native.com/_agent-native/mcp",
+    hostedUrl: "https://content.agent-native.com",
+    authMode: "oauth",
+  },
+  {
     // core skills.ts:1762 (id), :1763 (displayName)
     appId: "design",
     displayName: "Design",

--- a/packages/skills/src/index.spec.ts
+++ b/packages/skills/src/index.spec.ts
@@ -294,6 +294,7 @@ describe("@agent-native/skills", () => {
       catalogMode: "all",
       hiddenBuiltInSkillTargets: [
         "assets",
+        "content",
         "design-exploration",
         "context-xray",
       ],
@@ -654,6 +655,58 @@ describe("@agent-native/skills", () => {
       expect.objectContaining({
         baseDir: project,
         catalogMode: "all",
+        isInteractive: expect.any(Function),
+        publicSkillEntries: [],
+        publicSkillSource: "BuilderIO/skills",
+      }),
+    );
+  });
+
+  it("delegates content local-files installs to agent-native core", async () => {
+    const project = tmpDir();
+    const previousDirect = process.env.AGENT_NATIVE_SKILLS_DIRECT;
+    delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
+
+    try {
+      await runSkillsCli(
+        [
+          "add",
+          "--skill",
+          "content",
+          "--client",
+          "codex",
+          "--scope",
+          "project",
+          "--mode",
+          "local-files",
+          "--yes",
+          "--json",
+        ],
+        { baseDir: project, isInteractive: () => false },
+      );
+    } finally {
+      if (previousDirect === undefined)
+        delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
+      else process.env.AGENT_NATIVE_SKILLS_DIRECT = previousDirect;
+    }
+
+    expect(runCoreSkills).toHaveBeenCalledWith(
+      [
+        "add",
+        "content",
+        "--client",
+        "codex",
+        "--scope",
+        "project",
+        "--yes",
+        "--json",
+        "--mode",
+        "local-files",
+      ],
+      expect.objectContaining({
+        baseDir: project,
+        catalogMode: "all",
+        hiddenBuiltInSkillTargets: expect.arrayContaining(["content"]),
         isInteractive: expect.any(Function),
         publicSkillEntries: [],
         publicSkillSource: "BuilderIO/skills",

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -159,8 +159,8 @@ Options:
   --no-update-instructions    Skip managed instruction file updates
   --instructions-file <path>  File to receive managed instructions (repeatable)
   --with-github-action        Add .github/workflows/pr-visual-recap.yml when visual-recap is installed
-  --mode <mode>               visual-plan/visual-recap mode: hosted, local-files, or self-hosted
-  --mcp-url <url>             Self-hosted app/MCP URL for visual-plan/visual-recap
+  --mode <mode>               App-backed skill mode: hosted, local-files, or self-hosted
+  --mcp-url <url>             Self-hosted app/MCP URL for app-backed skills
   --force                     Overwrite a different existing PR Visual Recap workflow
   --no-mcp                    Install skill files only; skip registering the app's MCP server
   --no-connect                Register MCP where possible but skip inline browser/device authentication
@@ -168,11 +168,11 @@ Options:
   --dry-run                   Print intended writes without changing files
   --json                      Print the result as JSON
 
-App-backed skills (visual-plan, visual-recap) register their hosted MCP server
-in your agent config by default so the agent can actually use them. Use
+App-backed skills (visual-plan, visual-recap, content) register their hosted MCP
+server in your agent config by default so the agent can actually use them. Use
 --no-mcp to skip that and copy the files only.
-For visual-plan/visual-recap, choose --mode local-files for no sharing and all
-local files, or --mode self-hosted --mcp-url <url> for your own Plan app.
+For visual-plan/visual-recap/content, choose --mode local-files for local-file
+workflows, or --mode self-hosted --mcp-url <url> for your own app.
 
 Examples:
   npx @agent-native/skills@latest add
@@ -353,6 +353,7 @@ function shouldLoadPublicCatalog(parsed: ParsedArgs): boolean {
 
 const HIDDEN_STANDALONE_BUILT_INS = [
   "assets",
+  "content",
   "design-exploration",
   "context-xray",
 ];
@@ -591,10 +592,12 @@ export async function installSkills(
     });
 
     const skillNames = selected.map((skill) => skill.name);
+    const modeAwareApp = selectedModeAwareApp(skillNames);
     const planMode = await resolvePlanModeForSkills(skillNames, options);
     const planMcpOverride = await resolvePlanMcpOverrideForMode(
       planMode,
       options,
+      modeAwareApp?.appId,
     );
 
     const clients = await resolveSelectedClients(options);
@@ -802,28 +805,35 @@ function defaultArgs(command: ParsedArgs["command"]): ParsedArgs {
   };
 }
 
-function selectedPlanApp(skillNames: string[]): BuiltInAppMcp | undefined {
+function selectedModeAwareApp(skillNames: string[]): BuiltInAppMcp | undefined {
   return skillNames
     .map((skillName) => resolveAppForSkill(skillName))
-    .find((app): app is BuiltInAppMcp => app?.appId === "visual-plans");
+    .find(
+      (app): app is BuiltInAppMcp =>
+        app?.appId === "visual-plans" || app?.appId === "content",
+    );
 }
 
 async function resolvePlanModeForSkills(
   skillNames: string[],
   options: InstallSkillsOptions,
 ): Promise<PlanMode | undefined> {
-  const includesPlans = Boolean(selectedPlanApp(skillNames));
-  if (options.planMode && !includesPlans) {
-    throw new Error("--mode only applies to visual-plan / visual-recap.");
+  const modeAwareApp = selectedModeAwareApp(skillNames);
+  if (options.planMode && !modeAwareApp) {
+    throw new Error(
+      "--mode only applies to visual-plan / visual-recap / content.",
+    );
   }
-  if (options.mcpUrl && !includesPlans) {
-    throw new Error("--mcp-url only applies to visual-plan / visual-recap.");
+  if (options.mcpUrl && !modeAwareApp) {
+    throw new Error(
+      "--mcp-url only applies to visual-plan / visual-recap / content.",
+    );
   }
-  if (!includesPlans) return undefined;
+  if (!modeAwareApp) return undefined;
 
   if (options.mcpUrl && !options.planMode) return "self-hosted";
   if (options.planMode) return options.planMode;
-  return "hosted";
+  return modeAwareApp.appId === "visual-plans" ? "hosted" : undefined;
 }
 
 function resolvePlanMcpUrlOverride(input: string): {
@@ -856,7 +866,8 @@ function resolvePlanMcpUrlOverride(input: string): {
 async function resolvePlanMcpOverrideForMode(
   planMode: PlanMode | undefined,
   options: InstallSkillsOptions,
-): Promise<{ hostedUrl: string; mcpUrl: string } | undefined> {
+  appId: string | undefined,
+): Promise<{ appId: string; hostedUrl: string; mcpUrl: string } | undefined> {
   if (planMode === "local-files" && options.mcpUrl) {
     throw new Error("--mode local-files cannot be combined with --mcp-url.");
   }
@@ -866,7 +877,10 @@ async function resolvePlanMcpOverrideForMode(
       "--mode self-hosted requires --mcp-url <url> in direct mode.",
     );
   }
-  return resolvePlanMcpUrlOverride(options.mcpUrl);
+  if (!appId) {
+    throw new Error("--mode self-hosted requires an app-backed skill.");
+  }
+  return { appId, ...resolvePlanMcpUrlOverride(options.mcpUrl) };
 }
 
 function parsePlanMode(value: string): PlanMode {
@@ -997,7 +1011,7 @@ async function createInstallProgress(
 
 function mcpAppsForSkills(
   skillNames: string[],
-  planOverride?: { hostedUrl: string; mcpUrl: string },
+  planOverride?: { appId: string; hostedUrl: string; mcpUrl: string },
 ): BuiltInAppMcp[] {
   const apps: BuiltInAppMcp[] = [];
   const seen = new Set<string>();
@@ -1005,7 +1019,7 @@ function mcpAppsForSkills(
     const app = resolveAppForSkill(skillName);
     if (!app || seen.has(app.appId)) continue;
     seen.add(app.appId);
-    if (app.appId === "visual-plans" && planOverride) {
+    if (app.appId === planOverride?.appId) {
       apps.push({
         ...app,
         hostedUrl: planOverride.hostedUrl,
@@ -1050,7 +1064,7 @@ async function printInstallResult(
     `Skills        ${result.skills.join(", ") || "none"}`,
     `Agents        ${result.clients.join(", ") || "none"}`,
     `Scope         ${result.scope}`,
-    result.planMode ? `Plan mode     ${result.planMode}` : "",
+    result.planMode ? `Install mode  ${result.planMode}` : "",
     result.written.length
       ? `Skill folders ${plural(result.written.length, "folder")} (${summarizePaths(
           result.written,
@@ -1091,7 +1105,12 @@ async function printInstallResult(
     }
   }
 
-  if (result.planMode === "local-files") {
+  if (
+    result.planMode === "local-files" &&
+    result.skills.some((skill) =>
+      ["visual-plan", "visual-recap"].includes(skill),
+    )
+  ) {
     clack.note(
       [
         "No sharing, all local.",

--- a/skills/content/SKILL.md
+++ b/skills/content/SKILL.md
@@ -64,7 +64,6 @@ Content roots for `docs/`, `blog/`, `content/`, and `resources/`, plus a
 ```json
 {
   "version": 1,
-  "mode": "local-files",
   "apps": {
     "content": {
       "mode": "local-files",

--- a/skills/content/SKILL.md
+++ b/skills/content/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: content
+description: >-
+  Use Content for repo-backed Markdown/MDX docs, blogs, resources, rich
+  document editing, local components, shareable copies, and Content local-file
+  workspaces. Prefer Content actions over raw filesystem writes when available.
+metadata:
+  visibility: exported
+---
+
+# Content
+
+Use the Content app when a workflow is about authoring, editing, reviewing, or
+publishing Markdown/MDX documents: docs sites, blogs, resource libraries,
+marketing pages, internal notes, and local MDX components. Content gives the
+agent a document tree, a rich editor, normal document actions, and optional
+local-file source of truth.
+
+## Choose The Path
+
+- Use Content actions when the Content MCP/action tools are available:
+  `list-documents`, `search-documents`, `get-document`, `pull-document`,
+  `create-document`, `edit-document`, `update-document`, `delete-document`,
+  `share-local-file-document`, `list-local-component-files`, and
+  `write-local-component-file`.
+- Use `pull-document` or `get-document` before editing a page. Use
+  `edit-document` for precise find/replace changes and `update-document` for
+  full rewrites or new content.
+- In Local File Mode, Content actions read and write the repo files declared in
+  `agent-native.json`; SQL remains cache/history/search glue, not the source of
+  truth for those pages.
+- If Content tools are not visible and no local Content app or Desktop bridge is
+  running, treat this skill as repo-editing guidance. Edit configured
+  `.md`/`.mdx` files directly, preserve frontmatter and MDX imports, and tell
+  the user the Content action surface was not available.
+
+## Action Examples
+
+Prefer JSON input for action calls:
+
+```bash
+pnpm action list-documents
+pnpm action get-document '{"id":"local-file:..."}'
+pnpm action edit-document '{"id":"local-file:...","find":"old copy","replace":"new copy"}'
+pnpm action update-document '{"id":"local-file:...","content":"# Updated\n\nBody"}'
+pnpm action share-local-file-document '{"id":"local-file:..."}'
+```
+
+Run `refresh-list` after create/update/delete operations when you need the open
+Content UI sidebar to repaint immediately.
+
+## Local File Mode
+
+Install into an existing repo with:
+
+```bash
+npx @agent-native/core@latest skills add content --mode local-files --scope project
+```
+
+The installer copies this skill and writes or updates `agent-native.json` with
+Content roots for `docs/`, `blog/`, `content/`, and `resources/`, plus a
+`components/` folder for local MDX components. A typical manifest looks like:
+
+```json
+{
+  "version": 1,
+  "mode": "local-files",
+  "apps": {
+    "content": {
+      "mode": "local-files",
+      "roots": [
+        {
+          "name": "Docs",
+          "path": "docs",
+          "kind": "docs",
+          "extensions": [".md", ".mdx"]
+        },
+        {
+          "name": "Blog",
+          "path": "blog",
+          "kind": "blog",
+          "extensions": [".md", ".mdx"]
+        },
+        {
+          "name": "Content",
+          "path": "content",
+          "kind": "content",
+          "extensions": [".md", ".mdx"]
+        },
+        {
+          "name": "Resources",
+          "path": "resources",
+          "kind": "resources",
+          "extensions": [".md", ".mdx"]
+        }
+      ],
+      "components": "components",
+      "extensions": "extensions",
+      "hide": ["**/_*.md", "**/_*.mdx"]
+    }
+  }
+}
+```
+
+Local File Mode does not make the host language model local, and the hosted
+Content app cannot read private repo files by itself. File access requires a
+local Content app, Agent Native Desktop, or another trusted local bridge.
+
+## MDX And Components
+
+- Preserve frontmatter keys you do not understand. Preserve MDX imports,
+  exports, JSX, and expression props unless the user explicitly asks to change
+  them.
+- Use local components from the configured `components` folder. Components
+  should be PascalCase exports from `.tsx` files; simple editable input metadata
+  can live next to them as `ComponentNameInputs`.
+- Use `list-local-component-files` and `write-local-component-file` for
+  component source changes when Content tools are available. Otherwise edit the
+  component files directly like normal repo source.
+
+## Boundaries
+
+- Moving, renaming, and reordering local-file pages are not first-class Content
+  UI operations yet. Use normal file operations when the user asks for those,
+  then let Content rediscover the file tree.
+- Do not push/pull Notion, Builder.io, or other provider-backed content unless
+  the user explicitly asks for provider sync.
+- Do not paste secrets, private provider data, or credential-looking values into
+  docs, generated pages, frontmatter, examples, or local components.

--- a/templates/clips/.agents/skills/ai-video-tools/SKILL.md
+++ b/templates/clips/.agents/skills/ai-video-tools/SKILL.md
@@ -13,6 +13,12 @@ description: >-
 
 Every AI feature in Clips goes through the agent chat unless it is the narrow media-pipeline exception below. The UI and server should not add broad shadow agents or inline chat workflows. **Exception:** transcription. Transcription takes audio, not prompts — the `request-transcript` action calls the transcription API directly. Provider priority for transcription: **native** first (browser Web Speech API / desktop macOS SFSpeech, saved via `save-browser-transcript`, no key required) → **cloud fallback** when native text is missing: **Builder.io managed** Gemini (via `BUILDER_PRIVATE_KEY` or a connected Builder account, no extra key needed) → **Groq** `whisper-large-v3-turbo` via `GROQ_API_KEY` (fast, ~$0.04/hr). Clips never routes recording/meeting audio to OpenAI for transcription.
 
+Builder.io is the primary setup path: it brings managed AI credits, object
+storage, uploads, and transcription together. Bring-your-own-key setup belongs
+in the agent sidebar's **API Keys & Connections** panel; Clips settings can
+signpost that existing panel, but should not add a second key-management
+surface.
+
 ## Why
 
 The agent is already the user's primary interface — it has full project context, can chain tool calls, and can ask follow-up questions. Shadow LLM calls inside UI components create a second AI that doesn't know what the agent knows and can't coordinate with it. See the framework `delegate-to-agent` skill for the full argument.
@@ -118,7 +124,7 @@ registerRequiredSecret({
 });
 ```
 
-It is not marked `required: true` — videos still upload and play without a Groq key, since native transcription (and Builder when connected) already cover the common case. The onboarding checklist surfaces it so the user can add the Groq fallback if they want it.
+It is not marked `required: true` — videos still upload and play without a Groq key when video storage is connected, since native transcription (and Builder when connected) already cover the common case. The API Keys & Connections panel surfaces it so the user can add the Groq fallback if they want it.
 
 ## Live transcription during recording
 
@@ -140,4 +146,4 @@ A future pass could add server-side streaming transcription (Deepgram Nova-3 / A
 - `delegate-to-agent` — the framework-wide rule this skill is grounded in.
 - `video-editing` — filler-word removal writes proposed cuts into `editor-draft` for user review.
 - `recording` — transcription kicks off automatically when upload completes.
-- `onboarding` — how the optional Groq fallback key gets collected on first run.
+- `onboarding` — how Builder-first setup and BYOK links are surfaced.

--- a/templates/clips/.agents/skills/video-sharing/SKILL.md
+++ b/templates/clips/.agents/skills/video-sharing/SKILL.md
@@ -141,7 +141,7 @@ The playable Slack embed is deliberately narrower than the share page:
 
 Required Slack app setup:
 
-- Bot scopes: `chat:write`, `links:read`, `links:write`, `links.embed:write`
+- Bot scopes: `links:read`, `links:write`, `links.embed:write`
 - Event subscription: `link_shared`
 - App unfurl domains: the public Clips share domain, for example `clips.agent-native.com`
 - Request URL: `https://<clips-host>/api/slack/unfurl`

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -25,9 +25,14 @@ Detailed media, meeting, dictation, editing, and sharing rules live in
 - Cloud transcription is fallback-only for Clips recordings and should use the
   configured Builder/Gemini or Groq paths, not OpenAI.
 - AI setup must be visible and paid-account-backed: lead with Builder.io Connect
-  for managed credits, and surface BYOK options in Settings → AI providers.
+  for managed credits, object storage, uploads, and transcription. BYOK belongs
+  in the agent sidebar's API Keys & Connections panel; template settings may
+  signpost that panel but should not create a second credential vault.
   Anthropic/OpenAI power the agent chat; Gemini powers cleanup, titles, and
   meeting notes; Groq powers backup speech-to-text.
+- Hosted/shared recording uploads require configured storage. Do not preserve
+  video bytes in SQL as a production fallback; only local SQLite/dev flows may
+  keep scratch chunks while a user connects Builder.io or S3-compatible storage.
 - Use `view-screen` when the active recording, transcript segment, meeting, or
   share context is unclear.
 - Calendar-sourced meeting actions are shortcuts, but do not add raw

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -24,6 +24,10 @@ Detailed media, meeting, dictation, editing, and sharing rules live in
   background; do not hide a usable native transcript behind a failed cleanup.
 - Cloud transcription is fallback-only for Clips recordings and should use the
   configured Builder/Gemini or Groq paths, not OpenAI.
+- AI setup must be visible and paid-account-backed: lead with Builder.io Connect
+  for managed credits, and surface BYOK options in Settings → AI providers.
+  Anthropic/OpenAI power the agent chat; Gemini powers cleanup, titles, and
+  meeting notes; Groq powers backup speech-to-text.
 - Use `view-screen` when the active recording, transcript segment, meeting, or
   share context is unclear.
 - Calendar-sourced meeting actions are shortcuts, but do not add raw

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -26,6 +26,10 @@ import {
   applyFaststart,
   hasPlayableMp4Metadata,
 } from "../server/lib/faststart.js";
+import {
+  requiresConfiguredVideoStorage,
+  STORAGE_SETUP_REQUIRED_REASON,
+} from "../server/lib/video-storage.js";
 import { debugLog } from "../server/lib/debug.js";
 import requestTranscript from "./request-transcript.js";
 import { MAX_UPLOAD_BYTES as MAX_RECORDING_UPLOAD_BYTES } from "@shared/upload-limits.js";
@@ -73,8 +77,6 @@ function chunkIndexFromKey(key: string): number {
   return Number(key.split("-").pop() || 0);
 }
 
-const STORAGE_SETUP_REQUIRED_REASON =
-  "Video storage is not connected yet. Connect Builder.io or configure S3-compatible storage to upload and finish saving this clip.";
 const RECORDING_TOO_LARGE_REASON =
   "Recording is too large to process after automatic compression. Please update the app and try again, or record a shorter clip.";
 
@@ -410,6 +412,41 @@ export default defineAction({
 
       if (upload === null) {
         const now = new Date().toISOString();
+        if (requiresConfiguredVideoStorage()) {
+          await db
+            .update(schema.recordings)
+            .set({
+              status: "failed",
+              failureReason: STORAGE_SETUP_REQUIRED_REASON,
+              durationMs: finalDurationMs,
+              width: finalWidth,
+              height: finalHeight,
+              hasAudio: finalHasAudio,
+              hasCamera: finalHasCamera,
+              uploadProgress: 0,
+              updatedAt: now,
+            })
+            .where(eq(schema.recordings.id, id));
+
+          await writeAppState(`recording-upload-${id}`, {
+            recordingId: id,
+            status: "failed",
+            failureReason: STORAGE_SETUP_REQUIRED_REASON,
+            storageSetupRequired: true,
+            progress: 0,
+            updatedAt: now,
+          });
+          await writeAppState("refresh-signal", { ts: Date.now() });
+
+          return {
+            id,
+            status: "failed" as const,
+            storageSetupRequired: true,
+            failureReason: STORAGE_SETUP_REQUIRED_REASON,
+            durationMs: finalDurationMs,
+          };
+        }
+
         await db
           .update(schema.recordings)
           .set({

--- a/templates/clips/actions/generate-workflow.ts
+++ b/templates/clips/actions/generate-workflow.ts
@@ -99,7 +99,8 @@ export default defineAction({
         `(title: "${rec.title}"). Read the transcript from this request's context. ` +
         `${KIND_PROMPTS[args.kind]} ` +
         `Then write the final markdown to application_state key "${stateKey}" as ` +
-        `\`{ kind: "${args.kind}", status: "ready", content: "...", recordingId: "${args.recordingId}" }\`.`,
+        `\`{ kind: "${args.kind}", status: "ready", content: "...", recordingId: "${args.recordingId}" }\`. ` +
+        `Finish by replying in chat with the same generated markdown so the user can read it immediately.`,
     };
 
     await writeAppState(`clips-ai-request-${args.recordingId}`, request as any);

--- a/templates/clips/actions/import-loom-recording.ts
+++ b/templates/clips/actions/import-loom-recording.ts
@@ -1,14 +1,8 @@
 import { defineAction } from "@agent-native/core";
 import { writeAppState } from "@agent-native/core/application-state";
 import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
-import {
-  getActiveFileUploadProvider,
-  uploadFile,
-} from "@agent-native/core/file-upload";
-import {
-  buildDeepLink,
-  resolveBuilderPrivateKey,
-} from "@agent-native/core/server";
+import { uploadFile } from "@agent-native/core/file-upload";
+import { buildDeepLink } from "@agent-native/core/server";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
@@ -25,6 +19,7 @@ import {
   loomTranscriptUnavailableMessage,
 } from "./lib/loom-transcript.js";
 import { downloadLoomVideo } from "./lib/loom-video.js";
+import { hasRequestVideoStorage } from "../server/lib/video-storage.js";
 
 const LoomOembedSchema = z
   .object({
@@ -83,22 +78,6 @@ const ImportLoomRecordingSchema = z.object({
 
 const LOOM_STORAGE_SETUP_REQUIRED_REASON =
   "Video storage is not connected yet. Connect Builder.io or configure S3-compatible storage, then retry this Loom import.";
-
-async function hasConfiguredUploadStorage(): Promise<boolean> {
-  const provider = getActiveFileUploadProvider();
-  if (!provider) return false;
-  if (provider.id !== "builder") return true;
-
-  try {
-    return Boolean(await resolveBuilderPrivateKey());
-  } catch (err) {
-    console.warn(
-      "[clips] Builder storage credential check failed:",
-      err instanceof Error ? err.message : String(err),
-    );
-    return false;
-  }
-}
 
 function recordingDeepLink(recordingId: string): string {
   return buildDeepLink({
@@ -302,7 +281,7 @@ export default defineAction({
       };
     };
 
-    if (!(await hasConfiguredUploadStorage())) {
+    if (!(await hasRequestVideoStorage())) {
       return await saveWaitingForStorage(
         existingRecording?.videoSizeBytes ?? 0,
       );

--- a/templates/clips/actions/set-organization-branding.ts
+++ b/templates/clips/actions/set-organization-branding.ts
@@ -1,13 +1,14 @@
 /**
- * Update organization branding — brand color, brand logo URL, default
- * visibility — by upserting the Clips-specific `organization_settings`
- * sidecar row. Does NOT change the framework `organizations` row.
+ * Update organization branding — org name, brand color, brand logo URL,
+ * default visibility — by updating the framework `organizations` row for the
+ * name and upserting the Clips-specific `organization_settings` sidecar row.
  *
  * Usage:
  *   pnpm action set-organization-branding --brandColor="#18181B" --brandLogoUrl=/api/media/abc.png
  */
 
 import { defineAction } from "@agent-native/core";
+import { organizations } from "@agent-native/core/org";
 import { writeAppState } from "@agent-native/core/application-state";
 import { z } from "zod";
 import { requireOrganizationAccess } from "../server/lib/recordings.js";
@@ -24,6 +25,13 @@ export default defineAction({
       .string()
       .optional()
       .describe("Organization id (defaults to the caller's active org)"),
+    name: z
+      .string()
+      .trim()
+      .min(1)
+      .max(120)
+      .optional()
+      .describe("Organization display name"),
     brandColor: z
       .string()
       .regex(/^#[0-9a-fA-F]{3,8}$/)
@@ -59,7 +67,16 @@ export default defineAction({
       })
       .onConflictDoNothing();
 
-    // Build the UPDATE dynamically — only patch fields that were passed.
+    let updatedName: string | undefined;
+    if (typeof args.name === "string") {
+      updatedName = args.name.trim();
+      await db
+        .update(organizations)
+        .set({ name: updatedName })
+        .where(eq(organizations.id, organizationId));
+    }
+
+    // Build the settings UPDATE dynamically — only patch fields that were passed.
     const updates: Partial<typeof schema.organizationSettings.$inferInsert> =
       {};
 
@@ -99,6 +116,7 @@ export default defineAction({
 
     return {
       organizationId,
+      name: updatedName,
       brandColor: row?.brandColor ?? "#18181B",
       brandLogoUrl: row?.brandLogoUrl ?? null,
       defaultVisibility: row?.defaultVisibility ?? "private",

--- a/templates/clips/app/routes/_app.settings._index.tsx
+++ b/templates/clips/app/routes/_app.settings._index.tsx
@@ -1,11 +1,20 @@
 import { useEffect, useState } from "react";
 import {
+  IconBrain,
   IconCloud,
+  IconExternalLink,
+  IconKey,
   IconLoader2,
   IconServer,
   IconUser,
 } from "@tabler/icons-react";
-import { useSession, agentNativePath } from "@agent-native/core/client";
+import {
+  useSession,
+  agentNativePath,
+  openBuilderConnectPopup,
+  saveAgentEngineApiKey,
+  type AgentEngineProvider,
+} from "@agent-native/core/client";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -27,6 +36,64 @@ export function meta() {
 }
 
 const SPEEDS = ["1", "1.2", "1.5", "1.75", "2"];
+
+type AiKeyField =
+  | {
+      key: "ANTHROPIC_API_KEY" | "OPENAI_API_KEY";
+      label: string;
+      description: string;
+      placeholder: string;
+      docsUrl: string;
+      kind: "agent-engine";
+      provider: AgentEngineProvider;
+    }
+  | {
+      key: "GEMINI_API_KEY" | "GROQ_API_KEY";
+      label: string;
+      description: string;
+      placeholder: string;
+      docsUrl: string;
+      kind: "registered-secret";
+    };
+
+const AI_KEY_FIELDS: AiKeyField[] = [
+  {
+    key: "ANTHROPIC_API_KEY",
+    label: "Anthropic API key",
+    description: "Runs the agent chat for summaries, chapters, and AI tools.",
+    placeholder: "sk-ant-...",
+    docsUrl: "https://console.anthropic.com/settings/keys",
+    kind: "agent-engine",
+    provider: "anthropic",
+  },
+  {
+    key: "OPENAI_API_KEY",
+    label: "OpenAI API key",
+    description: "Alternate agent-chat provider for AI tools.",
+    placeholder: "sk-...",
+    docsUrl: "https://platform.openai.com/api-keys",
+    kind: "agent-engine",
+    provider: "openai",
+  },
+  {
+    key: "GEMINI_API_KEY",
+    label: "Gemini API key",
+    description:
+      "Cleans transcripts, titles clips, and generates meeting notes.",
+    placeholder: "AIza...",
+    docsUrl: "https://aistudio.google.com/apikey",
+    kind: "registered-secret",
+  },
+  {
+    key: "GROQ_API_KEY",
+    label: "Groq API key",
+    description:
+      "Backup speech-to-text when native or Builder transcription is unavailable.",
+    placeholder: "gsk_...",
+    docsUrl: "https://console.groq.com/keys",
+    kind: "registered-secret",
+  },
+];
 
 const S3_STORAGE_FIELDS = [
   {
@@ -130,6 +197,24 @@ async function saveS3StorageSettings(
   }
 }
 
+async function saveRegisteredSecret(key: string, value: string): Promise<void> {
+  const res = await fetch(
+    agentNativePath(`/_agent-native/secrets/${encodeURIComponent(key)}`),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value }),
+    },
+  );
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new Error(body?.error ?? `Save failed (${res.status})`);
+  }
+}
+
 export default function SettingsIndexRoute() {
   const { session } = useSession();
   const email = session?.email ?? "";
@@ -143,6 +228,8 @@ export default function SettingsIndexRoute() {
   const [transcriptCleanupEnabled, setTranscriptCleanupEnabled] =
     useState(true);
   const [s3Values, setS3Values] = useState<Record<string, string>>({});
+  const [aiKeyValues, setAiKeyValues] = useState<Record<string, string>>({});
+  const [savingAiKey, setSavingAiKey] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -204,6 +291,32 @@ export default function SettingsIndexRoute() {
       toast.error(err instanceof Error ? err.message : "Failed to save");
     } finally {
       setSavingStorage(false);
+    }
+  }
+
+  async function handleSaveAiKey(field: AiKeyField) {
+    const value = (aiKeyValues[field.key] ?? "").trim();
+    if (!value) {
+      toast.error("Paste a key first.");
+      return;
+    }
+
+    setSavingAiKey(field.key);
+    try {
+      if (field.kind === "agent-engine") {
+        await saveAgentEngineApiKey({
+          provider: field.provider,
+          apiKey: value,
+        });
+      } else {
+        await saveRegisteredSecret(field.key, value);
+      }
+      setAiKeyValues((current) => ({ ...current, [field.key]: "" }));
+      toast.success(`${field.label} saved`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to save key");
+    } finally {
+      setSavingAiKey(null);
     }
   }
 
@@ -285,6 +398,105 @@ export default function SettingsIndexRoute() {
                 )}
                 Save storage
               </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card id="ai-providers" className="scroll-mt-16">
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <IconBrain className="size-4 text-primary" />
+              AI providers
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <div className="flex flex-col gap-3 rounded-md border border-border bg-accent/30 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <IconKey className="h-4 w-4 text-muted-foreground" />
+                  Builder.io or bring your own keys
+                </div>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Builder.io uses your Builder credits. BYOK routes usage to
+                  your provider account.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="shrink-0"
+                onClick={() => {
+                  openBuilderConnectPopup({
+                    source: "clips_settings_ai_providers",
+                  });
+                  toast.message("Finish connecting Builder.io in the popup.");
+                }}
+              >
+                <IconExternalLink className="h-4 w-4" />
+                Connect Builder.io
+              </Button>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              {AI_KEY_FIELDS.map((field) => (
+                <div
+                  key={field.key}
+                  className="space-y-2 rounded-md border border-border p-3"
+                >
+                  <div className="min-w-0">
+                    <Label htmlFor={field.key}>{field.label}</Label>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {field.description}
+                    </p>
+                  </div>
+                  <Input
+                    id={field.key}
+                    type="password"
+                    value={aiKeyValues[field.key] ?? ""}
+                    onChange={(event) =>
+                      setAiKeyValues((current) => ({
+                        ...current,
+                        [field.key]: event.target.value,
+                      }))
+                    }
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        void handleSaveAiKey(field);
+                      }
+                    }}
+                    placeholder={field.placeholder}
+                    autoComplete="off"
+                    disabled={savingAiKey === field.key}
+                  />
+                  <div className="flex items-center justify-between gap-2">
+                    <a
+                      href={field.docsUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                    >
+                      Get key
+                      <IconExternalLink className="h-3 w-3" />
+                    </a>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => void handleSaveAiKey(field)}
+                      disabled={
+                        savingAiKey === field.key ||
+                        !(aiKeyValues[field.key] ?? "").trim()
+                      }
+                    >
+                      {savingAiKey === field.key && (
+                        <IconLoader2 className="h-4 w-4 animate-spin" />
+                      )}
+                      Save
+                    </Button>
+                  </div>
+                </div>
+              ))}
             </div>
           </CardContent>
         </Card>

--- a/templates/clips/app/routes/_app.settings._index.tsx
+++ b/templates/clips/app/routes/_app.settings._index.tsx
@@ -12,8 +12,6 @@ import {
   useSession,
   agentNativePath,
   openBuilderConnectPopup,
-  saveAgentEngineApiKey,
-  type AgentEngineProvider,
 } from "@agent-native/core/client";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -36,64 +34,6 @@ export function meta() {
 }
 
 const SPEEDS = ["1", "1.2", "1.5", "1.75", "2"];
-
-type AiKeyField =
-  | {
-      key: "ANTHROPIC_API_KEY" | "OPENAI_API_KEY";
-      label: string;
-      description: string;
-      placeholder: string;
-      docsUrl: string;
-      kind: "agent-engine";
-      provider: AgentEngineProvider;
-    }
-  | {
-      key: "GEMINI_API_KEY" | "GROQ_API_KEY";
-      label: string;
-      description: string;
-      placeholder: string;
-      docsUrl: string;
-      kind: "registered-secret";
-    };
-
-const AI_KEY_FIELDS: AiKeyField[] = [
-  {
-    key: "ANTHROPIC_API_KEY",
-    label: "Anthropic API key",
-    description: "Runs the agent chat for summaries, chapters, and AI tools.",
-    placeholder: "sk-ant-...",
-    docsUrl: "https://console.anthropic.com/settings/keys",
-    kind: "agent-engine",
-    provider: "anthropic",
-  },
-  {
-    key: "OPENAI_API_KEY",
-    label: "OpenAI API key",
-    description: "Alternate agent-chat provider for AI tools.",
-    placeholder: "sk-...",
-    docsUrl: "https://platform.openai.com/api-keys",
-    kind: "agent-engine",
-    provider: "openai",
-  },
-  {
-    key: "GEMINI_API_KEY",
-    label: "Gemini API key",
-    description:
-      "Cleans transcripts, titles clips, and generates meeting notes.",
-    placeholder: "AIza...",
-    docsUrl: "https://aistudio.google.com/apikey",
-    kind: "registered-secret",
-  },
-  {
-    key: "GROQ_API_KEY",
-    label: "Groq API key",
-    description:
-      "Backup speech-to-text when native or Builder transcription is unavailable.",
-    placeholder: "gsk_...",
-    docsUrl: "https://console.groq.com/keys",
-    kind: "registered-secret",
-  },
-];
 
 const S3_STORAGE_FIELDS = [
   {
@@ -197,24 +137,6 @@ async function saveS3StorageSettings(
   }
 }
 
-async function saveRegisteredSecret(key: string, value: string): Promise<void> {
-  const res = await fetch(
-    agentNativePath(`/_agent-native/secrets/${encodeURIComponent(key)}`),
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ value }),
-    },
-  );
-
-  if (!res.ok) {
-    const body = (await res.json().catch(() => null)) as {
-      error?: string;
-    } | null;
-    throw new Error(body?.error ?? `Save failed (${res.status})`);
-  }
-}
-
 export default function SettingsIndexRoute() {
   const { session } = useSession();
   const email = session?.email ?? "";
@@ -228,8 +150,6 @@ export default function SettingsIndexRoute() {
   const [transcriptCleanupEnabled, setTranscriptCleanupEnabled] =
     useState(true);
   const [s3Values, setS3Values] = useState<Record<string, string>>({});
-  const [aiKeyValues, setAiKeyValues] = useState<Record<string, string>>({});
-  const [savingAiKey, setSavingAiKey] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -291,32 +211,6 @@ export default function SettingsIndexRoute() {
       toast.error(err instanceof Error ? err.message : "Failed to save");
     } finally {
       setSavingStorage(false);
-    }
-  }
-
-  async function handleSaveAiKey(field: AiKeyField) {
-    const value = (aiKeyValues[field.key] ?? "").trim();
-    if (!value) {
-      toast.error("Paste a key first.");
-      return;
-    }
-
-    setSavingAiKey(field.key);
-    try {
-      if (field.kind === "agent-engine") {
-        await saveAgentEngineApiKey({
-          provider: field.provider,
-          apiKey: value,
-        });
-      } else {
-        await saveRegisteredSecret(field.key, value);
-      }
-      setAiKeyValues((current) => ({ ...current, [field.key]: "" }));
-      toast.success(`${field.label} saved`);
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to save key");
-    } finally {
-      setSavingAiKey(null);
     }
   }
 
@@ -406,19 +300,20 @@ export default function SettingsIndexRoute() {
           <CardHeader>
             <CardTitle className="text-base flex items-center gap-2">
               <IconBrain className="size-4 text-primary" />
-              AI providers
+              AI setup
             </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-5">
+          <CardContent className="space-y-4">
             <div className="flex flex-col gap-3 rounded-md border border-border bg-accent/30 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="min-w-0">
                 <div className="flex items-center gap-2 text-sm font-medium">
                   <IconKey className="h-4 w-4 text-muted-foreground" />
-                  Builder.io or bring your own keys
+                  Builder.io is the easiest setup
                 </div>
                 <p className="mt-0.5 text-xs text-muted-foreground">
-                  Builder.io uses your Builder credits. BYOK routes usage to
-                  your provider account.
+                  Connect Builder first for included AI credits, object storage,
+                  uploads, and managed transcription. BYOK is still available
+                  from the agent sidebar.
                 </p>
               </div>
               <Button
@@ -438,65 +333,15 @@ export default function SettingsIndexRoute() {
               </Button>
             </div>
 
-            <div className="grid gap-4 sm:grid-cols-2">
-              {AI_KEY_FIELDS.map((field) => (
-                <div
-                  key={field.key}
-                  className="space-y-2 rounded-md border border-border p-3"
-                >
-                  <div className="min-w-0">
-                    <Label htmlFor={field.key}>{field.label}</Label>
-                    <p className="mt-0.5 text-xs text-muted-foreground">
-                      {field.description}
-                    </p>
-                  </div>
-                  <Input
-                    id={field.key}
-                    type="password"
-                    value={aiKeyValues[field.key] ?? ""}
-                    onChange={(event) =>
-                      setAiKeyValues((current) => ({
-                        ...current,
-                        [field.key]: event.target.value,
-                      }))
-                    }
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter") {
-                        void handleSaveAiKey(field);
-                      }
-                    }}
-                    placeholder={field.placeholder}
-                    autoComplete="off"
-                    disabled={savingAiKey === field.key}
-                  />
-                  <div className="flex items-center justify-between gap-2">
-                    <a
-                      href={field.docsUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-                    >
-                      Get key
-                      <IconExternalLink className="h-3 w-3" />
-                    </a>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => void handleSaveAiKey(field)}
-                      disabled={
-                        savingAiKey === field.key ||
-                        !(aiKeyValues[field.key] ?? "").trim()
-                      }
-                    >
-                      {savingAiKey === field.key && (
-                        <IconLoader2 className="h-4 w-4 animate-spin" />
-                      )}
-                      Save
-                    </Button>
-                  </div>
-                </div>
-              ))}
+            <div className="rounded-md border border-border p-3">
+              <div className="text-sm font-medium">
+                Bring your own provider key
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Open the agent sidebar menu, then API Keys & Connections, to add
+                Anthropic, OpenAI, Gemini, Groq, or other supported keys. Usage
+                bills to the provider account you connect.
+              </p>
             </div>
           </CardContent>
         </Card>

--- a/templates/clips/app/routes/_app.settings.organization.tsx
+++ b/templates/clips/app/routes/_app.settings.organization.tsx
@@ -71,7 +71,7 @@ export default function OrganizationSettingsRoute() {
     return "member";
   }, [members, email, isOwner]);
 
-  const isAdmin = currentRole === "admin" || isOwner;
+  const isAdmin = currentRole === "admin" || currentRole === "owner" || isOwner;
 
   if (isLoading) {
     return (

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useNavigate, NavLink, useSearchParams } from "react-router";
+import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
   IconShare3,
@@ -8,6 +9,10 @@ import {
   IconCalendar,
   IconScissors,
   IconAlertTriangle,
+  IconHelpCircle,
+  IconClipboardCopy,
+  IconFileText,
+  IconSparkles,
 } from "@tabler/icons-react";
 import {
   useActionMutation,
@@ -15,8 +20,11 @@ import {
   useSession,
   AgentPanel,
   agentNativePath,
+  readClientAppState,
+  useChangeVersions,
 } from "@agent-native/core/client";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { isDefaultTitle, useAutoTitleBridge } from "@/hooks/use-auto-title";
@@ -29,6 +37,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import {
   VideoPlayer,
@@ -57,6 +70,32 @@ export function meta() {
 }
 
 type SidePanel = "transcript" | "comments" | "insights" | "agent" | "settings";
+type WorkflowKind = "pr" | "sop" | "ticket" | "email";
+
+const WORKFLOW_MENU_ITEMS: Array<{
+  kind: WorkflowKind;
+  label: string;
+  tooltip?: string;
+}> = [
+  { kind: "pr", label: "Generate PR summary" },
+  {
+    kind: "sop",
+    label: "Generate SOP",
+    tooltip:
+      "SOP means Standard Operating Procedure: a reusable step-by-step runbook generated from this clip.",
+  },
+  { kind: "ticket", label: "Generate ticket" },
+  { kind: "email", label: "Generate email" },
+];
+
+interface GeneratedWorkflowState {
+  kind?: WorkflowKind;
+  status?: "generating" | "ready" | "failed" | string;
+  content?: string;
+  recordingId?: string;
+  requestedAt?: string;
+  error?: string;
+}
 
 function isNativeSaveFailureReason(reason: string | null | undefined): boolean {
   return /native recording upload|native fullscreen|screencapture|avconvert/i.test(
@@ -201,6 +240,30 @@ export default function RecordingPage() {
   const visibleTitle = recording
     ? displayRecordingTitle(recording.title)
     : "Untitled Clip";
+  const appStateVersion = useChangeVersions(["app-state", "action"]);
+  const generatedWorkflowQ = useQuery<GeneratedWorkflowState | null>({
+    queryKey: [
+      "app-state",
+      "clips-workflow",
+      recording?.id ?? "",
+      appStateVersion,
+    ],
+    enabled: Boolean(recording?.id),
+    placeholderData: (previous) => previous,
+    refetchInterval: (query) =>
+      query.state.data?.status === "generating" ? 2000 : false,
+    queryFn: async ({ signal }) => {
+      if (!recording?.id) return null;
+      return readClientAppState<GeneratedWorkflowState>(
+        `clips-workflow-${recording.id}`,
+        { signal },
+      );
+    },
+  });
+  const generatedWorkflow =
+    generatedWorkflowQ.data?.recordingId === recording?.id
+      ? generatedWorkflowQ.data
+      : null;
 
   const canEdit = role === "owner" || role === "admin" || role === "editor";
   const isLoomEmbedBacked = isLoomEmbedBackedRecording(recording);
@@ -305,9 +368,24 @@ export default function RecordingPage() {
     onError: handleAiError,
   });
   const generateWorkflow = useActionMutation("generate-workflow" as any, {
-    onSuccess: () => toast.success("Workflow request queued"),
+    onSuccess: () => {
+      toast.success("Workflow request queued");
+      void generatedWorkflowQ.refetch();
+    },
     onError: handleAiError,
   });
+  function handleGenerateWorkflow(kind: WorkflowKind) {
+    if (!recording) return;
+    setEditing(false);
+    setPanel("agent");
+    window.dispatchEvent(
+      new CustomEvent("agent-panel:set-mode", { detail: { mode: "chat" } }),
+    );
+    generateWorkflow.mutate({
+      recordingId: recording.id,
+      kind,
+    } as any);
+  }
 
   useEffect(() => {
     if (recording && panel === "settings" && !canEdit) setPanel("agent");
@@ -674,50 +752,42 @@ export default function RecordingPage() {
                   Remove silences (&gt;1.2s)
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  disabled={generateWorkflow.isPending}
-                  onSelect={() =>
-                    generateWorkflow.mutate({
-                      recordingId: recording.id,
-                      kind: "pr",
-                    } as any)
+                {WORKFLOW_MENU_ITEMS.map((item) => {
+                  const menuItem = (
+                    <DropdownMenuItem
+                      key={item.kind}
+                      disabled={generateWorkflow.isPending}
+                      onSelect={() => handleGenerateWorkflow(item.kind)}
+                      className={
+                        item.tooltip ? "justify-between gap-3" : undefined
+                      }
+                    >
+                      <span>{item.label}</span>
+                      {item.tooltip ? (
+                        <IconHelpCircle
+                          aria-hidden="true"
+                          className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70"
+                        />
+                      ) : null}
+                    </DropdownMenuItem>
+                  );
+
+                  if (!item.tooltip) {
+                    return menuItem;
                   }
-                >
-                  Generate PR summary
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  disabled={generateWorkflow.isPending}
-                  onSelect={() =>
-                    generateWorkflow.mutate({
-                      recordingId: recording.id,
-                      kind: "sop",
-                    } as any)
-                  }
-                >
-                  Generate SOP
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  disabled={generateWorkflow.isPending}
-                  onSelect={() =>
-                    generateWorkflow.mutate({
-                      recordingId: recording.id,
-                      kind: "ticket",
-                    } as any)
-                  }
-                >
-                  Generate ticket
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  disabled={generateWorkflow.isPending}
-                  onSelect={() =>
-                    generateWorkflow.mutate({
-                      recordingId: recording.id,
-                      kind: "email",
-                    } as any)
-                  }
-                >
-                  Generate email
-                </DropdownMenuItem>
+
+                  return (
+                    <Tooltip key={item.kind}>
+                      <TooltipTrigger asChild>{menuItem}</TooltipTrigger>
+                      <TooltipContent
+                        side="left"
+                        className="max-w-64 text-xs leading-5"
+                      >
+                        {item.tooltip}
+                      </TooltipContent>
+                    </Tooltip>
+                  );
+                })}
               </DropdownMenuContent>
             </DropdownMenu>
           ) : null}
@@ -905,6 +975,11 @@ export default function RecordingPage() {
               <AgentPanel
                 emptyStateText="Ask about this clip…"
                 dynamicSuggestions={false}
+                chatNotice={
+                  generatedWorkflow ? (
+                    <GeneratedWorkflowNotice workflow={generatedWorkflow} />
+                  ) : null
+                }
                 suggestions={
                   canEdit
                     ? [
@@ -1017,6 +1092,122 @@ export default function RecordingPage() {
       ) : null}
     </div>
   );
+}
+
+function GeneratedWorkflowNotice({
+  workflow,
+}: {
+  workflow: GeneratedWorkflowState;
+}) {
+  const [copied, setCopied] = useState(false);
+  const status = workflow.status ?? (workflow.content ? "ready" : "generating");
+  const content =
+    typeof workflow.content === "string" ? workflow.content.trim() : "";
+  const isReady = status === "ready" && content.length > 0;
+  const isFailed = status === "failed";
+  const title = workflowTitle(workflow.kind);
+
+  async function handleCopy() {
+    if (!content) return;
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      toast.success(`${title} copied`);
+      setTimeout(() => setCopied(false), 1400);
+    } catch {
+      toast.error("Couldn't copy generated output");
+    }
+  }
+
+  return (
+    <div className="bg-background px-3 py-2.5">
+      <div className="overflow-hidden rounded-md border border-border bg-muted/20">
+        <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground">
+              {isReady ? (
+                <IconFileText className="h-3.5 w-3.5" />
+              ) : (
+                <IconSparkles className="h-3.5 w-3.5" />
+              )}
+            </div>
+            <div className="min-w-0">
+              <p className="truncate text-xs font-medium text-foreground">
+                {title}
+              </p>
+              <p className="truncate text-[11px] text-muted-foreground">
+                {isReady
+                  ? "Generated from this clip"
+                  : isFailed
+                    ? workflow.error ||
+                      "The agent could not finish this output."
+                    : "The agent is writing this output now."}
+              </p>
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-1.5">
+            <Badge
+              variant={
+                isFailed ? "destructive" : isReady ? "secondary" : "outline"
+              }
+              className="px-1.5 py-0 text-[10px] font-medium"
+            >
+              {workflowStatusLabel(status, isReady)}
+            </Badge>
+            {content ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1 px-2 text-[11px]"
+                onClick={handleCopy}
+              >
+                <IconClipboardCopy className="h-3.5 w-3.5" />
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            ) : null}
+          </div>
+        </div>
+        {content ? (
+          <div className="max-h-48 overflow-auto px-3 py-2">
+            <div className="whitespace-pre-wrap break-words text-xs leading-5 text-foreground">
+              {content}
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2 px-3 py-3 text-xs text-muted-foreground">
+            {isFailed ? null : <Spinner className="h-3.5 w-3.5" />}
+            <span>
+              {isFailed
+                ? workflow.error || "No generated output was saved."
+                : "Generated output will appear here when it is ready."}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function workflowTitle(kind: GeneratedWorkflowState["kind"]) {
+  switch (kind) {
+    case "pr":
+      return "Generated PR Summary";
+    case "sop":
+      return "Generated SOP";
+    case "ticket":
+      return "Generated Ticket";
+    case "email":
+      return "Generated Email";
+    default:
+      return "Generated Output";
+  }
+}
+
+function workflowStatusLabel(status: string, isReady: boolean) {
+  if (isReady) return "Ready";
+  if (status === "failed") return "Failed";
+  return "Generating";
 }
 
 function capitalize(s: string) {

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -511,6 +511,48 @@ pub async fn show_region_guide_editor(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Interactive full-screen one-shot selector for choosing the screen region to
+/// record. The React view emits the selected normalized rectangle back to the
+/// recorder and closes itself.
+#[tauri::command]
+pub async fn show_region_capture_selector(app: AppHandle) -> Result<(), String> {
+    if let Some(existing) = app.get_webview_window(REGION_GUIDE_EDITOR_LABEL) {
+        let _ = existing.close();
+    }
+
+    let (mx, my, mw, mh) = tray_monitor_physical_rect(&app);
+    #[allow(unused_mut)]
+    let mut builder = WebviewWindowBuilder::new(
+        &app,
+        REGION_GUIDE_EDITOR_LABEL,
+        build_overlay_url("region-capture-selector"),
+    )
+    .title("Select Clips Recording Region")
+    .decorations(false)
+    .transparent(true)
+    .always_on_top(true)
+    .skip_taskbar(true)
+    .resizable(false)
+    .shadow(false)
+    .visible(false)
+    .focused(true);
+    #[cfg(target_os = "macos")]
+    {
+        builder = builder.accept_first_mouse(true);
+    }
+    let win = builder.build().map_err(|e| {
+        eprintln!("[clips-tray] region capture selector build failed: {}", e);
+        e.to_string()
+    })?;
+    let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(mw, mh)));
+    let _ = win.set_position(PhysicalPosition::new(mx, my));
+    set_capture_excluded_always(&win);
+    configure_overlay_behavior(&win);
+    let _ = win.show();
+    let _ = win.set_focus();
+    Ok(())
+}
+
 /// Vertical recording pill anchored to the left edge. Stop + timer + pause,
 /// with hover-revealed restart/cancel controls matching Loom's left-rail
 /// placement. Draggable, always on top.

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -69,6 +69,7 @@ pub fn run() {
             clips::show_region_guides,
             clips::hide_region_guides,
             clips::show_region_guide_editor,
+            clips::show_region_capture_selector,
             clips::close_bubble,
             clips::show_popover,
             clips::park_popover_offscreen,

--- a/templates/clips/desktop/src-tauri/src/logfile.rs
+++ b/templates/clips/desktop/src-tauri/src/logfile.rs
@@ -127,7 +127,11 @@ fn spawn_log_pump(read_fd: libc::c_int, path: PathBuf) {
         // stderr are already redirected into it, so a pump that stops reading
         // would let the buffer fill and block every later println!. When there
         // is no file we simply discard the bytes.
-        let mut file = OpenOptions::new().create(true).append(true).open(&path).ok();
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .ok();
         let mut buf = [0u8; 4096];
         let mut line: Vec<u8> = Vec::new();
         loop {

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -13,6 +13,8 @@ use core_graphics::display::{CGDisplay, CGPoint};
 #[cfg(target_os = "macos")]
 use screencapturekit::audio_devices::AudioInputDevice;
 #[cfg(target_os = "macos")]
+use screencapturekit::cg::CGRect;
+#[cfg(target_os = "macos")]
 use screencapturekit::recording_output::{
     SCRecordingOutput, SCRecordingOutputCodec, SCRecordingOutputConfiguration,
     SCRecordingOutputDelegate, SCRecordingOutputFileType,
@@ -63,6 +65,14 @@ pub struct NativeFullscreenRecordingState {
     inner: Mutex<Option<NativeFullscreenSession>>,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub struct NativeCaptureRegion {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+}
+
 struct NativeFullscreenSession {
     /// Active capture backend. `None` while paused — pause finalizes the
     /// current segment and tears the backend down so the OS stops capturing.
@@ -104,6 +114,8 @@ struct RestartInfo {
     segment_counter: u32,
     /// CGDirectDisplayID of the display to record. None = first available.
     target_display_id: Option<u32>,
+    /// Normalized display-relative capture rectangle for Region recordings.
+    capture_region: Option<NativeCaptureRegion>,
 }
 
 enum NativeFullscreenBackend {
@@ -336,6 +348,7 @@ pub async fn native_fullscreen_recording_start(
     capture_system_audio: bool,
     mic_device_id: Option<String>,
     mic_device_label: Option<String>,
+    capture_region: Option<NativeCaptureRegion>,
 ) -> Result<NativeFullscreenStartInfo, String> {
     #[cfg(not(target_os = "macos"))]
     {
@@ -347,6 +360,7 @@ pub async fn native_fullscreen_recording_start(
             capture_system_audio,
             mic_device_id,
             mic_device_label,
+            capture_region,
         );
         return Err("Native full-screen recording is currently macOS-only.".into());
     }
@@ -367,6 +381,7 @@ pub async fn native_fullscreen_recording_start(
             capture_system_audio,
             mic_device_id.as_deref(),
             mic_device_label.as_deref(),
+            capture_region,
         ) {
             Ok(session) => session,
             Err(sck_err) => {
@@ -378,7 +393,7 @@ pub async fn native_fullscreen_recording_start(
                 eprintln!(
                     "[clips-tray] ScreenCaptureKit recording unavailable; falling back to screencapture: {sck_err}"
                 );
-                start_screencapture_recording(&app, &safe_id, include_audio, capture_system_audio).map_err(|fallback_err| {
+                start_screencapture_recording(&app, &safe_id, include_audio, capture_system_audio, capture_region).map_err(|fallback_err| {
                     format!(
                         "ScreenCaptureKit recording failed ({sck_err}); screencapture fallback failed ({fallback_err})"
                     )
@@ -630,6 +645,7 @@ pub async fn native_fullscreen_recording_resume(
         restart.mic_device_label.as_deref(),
         &segment_path,
         restart.target_display_id,
+        restart.capture_region,
     )?;
     session.backend = Some(backend);
     session.segments.push(segment_path);
@@ -759,6 +775,7 @@ fn start_segment_backend(
     mic_device_label: Option<&str>,
     segment_path: &Path,
     target_display_id: Option<u32>,
+    capture_region: Option<NativeCaptureRegion>,
 ) -> Result<(NativeFullscreenBackend, Option<u32>, Option<u32>), String> {
     #[cfg(target_os = "macos")]
     {
@@ -773,6 +790,7 @@ fn start_segment_backend(
             mic_device_id,
             mic_device_label,
             target_display_id,
+            capture_region,
         ) {
             Ok((backend, w, h)) => return Ok((backend, w, h)),
             Err(sck_err) => {
@@ -781,13 +799,18 @@ fn start_segment_backend(
                 );
             }
         }
-        let (backend, w, h) =
-            start_screencapture_backend_at(segment_path, include_audio, target_display_id)
-                .map_err(|fallback_err| {
-                    format!(
+        let (backend, w, h) = start_screencapture_backend_at(
+            app,
+            segment_path,
+            include_audio,
+            target_display_id,
+            capture_region,
+        )
+        .map_err(|fallback_err| {
+            format!(
                 "ScreenCaptureKit resume failed; screencapture fallback failed ({fallback_err})"
             )
-                })?;
+        })?;
         Ok((backend, w, h))
     }
     #[cfg(not(target_os = "macos"))]
@@ -800,6 +823,8 @@ fn start_segment_backend(
             mic_device_id,
             mic_device_label,
             segment_path,
+            target_display_id,
+            capture_region,
         );
         Err("Native full-screen recording is currently macOS-only.".into())
     }
@@ -815,6 +840,7 @@ fn start_screencapturekit_backend_at(
     mic_device_id: Option<&str>,
     mic_device_label: Option<&str>,
     target_display_id: Option<u32>,
+    capture_region: Option<NativeCaptureRegion>,
 ) -> Result<(NativeFullscreenBackend, Option<u32>, Option<u32>), String> {
     let content =
         SCShareableContent::get().map_err(|e| format!("shareable content lookup failed: {e:?}"))?;
@@ -826,11 +852,20 @@ fn start_screencapturekit_backend_at(
 
     let source_width = display.width();
     let source_height = display.height();
-    let (width, height) = native_capture_dimensions(source_width, source_height);
-    let filter = SCContentFilter::create()
+    let region_rect = region_source_rect(capture_region, source_width, source_height)?;
+    let (capture_width, capture_height) = region_rect
+        .as_ref()
+        .map(|(_, width, height)| (*width, *height))
+        .unwrap_or((source_width, source_height));
+    let (width, height) = native_capture_dimensions(capture_width, capture_height);
+    let filter_builder = SCContentFilter::create()
         .with_display(display)
-        .with_excluding_windows(&[])
-        .build();
+        .with_excluding_windows(&[]);
+    let filter = if let Some((rect, _, _)) = region_rect {
+        filter_builder.with_content_rect(rect).build()
+    } else {
+        filter_builder.build()
+    };
     let selected_mic = if include_audio {
         resolve_microphone_capture_device(mic_device_id, mic_device_label)?
     } else {
@@ -850,6 +885,9 @@ fn start_screencapturekit_backend_at(
         .with_excludes_current_process_audio(true)
         .with_sample_rate(48000)
         .with_channel_count(2);
+    if let Some((rect, _, _)) = region_rect {
+        config.set_source_rect(rect);
+    }
     if let Some(device) = selected_mic.as_ref() {
         config.set_microphone_capture_device_id(&device.id);
         eprintln!(
@@ -883,7 +921,7 @@ fn start_screencapturekit_backend_at(
         return Err(format!("capture start failed: {err:?}"));
     }
     eprintln!(
-        "[clips-tray] ScreenCaptureKit recording started: {width}x{height} @ {NATIVE_CAPTURE_FPS}fps from {source_width}x{source_height}, mic={include_audio} system_audio={capture_system_audio}"
+        "[clips-tray] ScreenCaptureKit recording started: {width}x{height} @ {NATIVE_CAPTURE_FPS}fps from {capture_width}x{capture_height} (display {source_width}x{source_height}), mic={include_audio} system_audio={capture_system_audio}"
     );
     Ok((
         NativeFullscreenBackend::ScreenCaptureKit {
@@ -900,9 +938,11 @@ fn start_screencapturekit_backend_at(
 /// Shared by the initial start and the resume path.
 #[cfg(target_os = "macos")]
 fn start_screencapture_backend_at(
+    app: &AppHandle,
     output_path: &Path,
     include_audio: bool,
     target_display_id: Option<u32>,
+    capture_region: Option<NativeCaptureRegion>,
 ) -> Result<(NativeFullscreenBackend, Option<u32>, Option<u32>), String> {
     if !std::path::Path::new("/usr/sbin/screencapture").exists() {
         return Err("macOS screencapture is unavailable on this machine.".into());
@@ -917,6 +957,24 @@ fn start_screencapture_backend_at(
             })
         })
         .unwrap_or_else(|| "-D1".to_string());
+    let (region_arg, region_width, region_height) = if let Some(region) = capture_region {
+        let (mx, my, mw, mh) = crate::util::tray_monitor_physical_rect(app);
+        let (rect, width, height) = region_source_rect(Some(region), mw, mh)?
+            .ok_or_else(|| "Recording region is unavailable.".to_string())?;
+        (
+            Some(format!(
+                "{},{},{},{}",
+                mx + rect.x.round() as i32,
+                my + rect.y.round() as i32,
+                rect.width.round() as u32,
+                rect.height.round() as u32
+            )),
+            Some(width),
+            Some(height),
+        )
+    } else {
+        (None, None, None)
+    };
     let mut command = Command::new("/usr/sbin/screencapture");
     command
         .arg("-v")
@@ -928,6 +986,9 @@ fn start_screencapture_backend_at(
         .stderr(Stdio::null());
     if include_audio {
         command.arg("-g");
+    }
+    if let Some(region_arg) = region_arg {
+        command.arg(format!("-R{region_arg}"));
     }
     command.arg(output_path);
     let mut child = command
@@ -944,7 +1005,11 @@ fn start_screencapture_backend_at(
         ));
     }
     eprintln!("[clips-tray] screencapture recording started");
-    Ok((NativeFullscreenBackend::Screencapture { child }, None, None))
+    Ok((
+        NativeFullscreenBackend::Screencapture { child },
+        region_width,
+        region_height,
+    ))
 }
 
 /// After all segments are finalized, make sure `session.path` contains a
@@ -1597,6 +1662,7 @@ fn start_screencapturekit_recording(
     capture_system_audio: bool,
     mic_device_id: Option<&str>,
     mic_device_label: Option<&str>,
+    capture_region: Option<NativeCaptureRegion>,
 ) -> Result<NativeFullscreenSession, String> {
     let target_display_id = tray_display_id(app);
     let path = pending_recording_path(app, safe_id, "mp4")?;
@@ -1612,6 +1678,7 @@ fn start_screencapturekit_recording(
         mic_device_id,
         mic_device_label,
         target_display_id,
+        capture_region,
     )?;
     let (fallback_width, fallback_height) = primary_monitor_size(app);
     Ok(new_fullscreen_session(
@@ -1628,6 +1695,7 @@ fn start_screencapturekit_recording(
             mic_device_label: mic_device_label.map(str::to_string),
             segment_counter: 0,
             target_display_id,
+            capture_region,
         },
     ))
 }
@@ -1638,6 +1706,7 @@ fn start_screencapture_recording(
     safe_id: &str,
     include_audio: bool,
     capture_system_audio: bool,
+    capture_region: Option<NativeCaptureRegion>,
 ) -> Result<NativeFullscreenSession, String> {
     let target_display_id = tray_display_id(app);
     let path = pending_recording_path(app, safe_id, "mov")?;
@@ -1646,15 +1715,20 @@ fn start_screencapture_recording(
         "[clips-tray] starting screencapture (fallback) recording -> {}",
         path.display()
     );
-    let (backend, _w, _h) =
-        start_screencapture_backend_at(&path, include_audio, target_display_id)?;
-    let (width, height) = primary_monitor_size(app);
+    let (backend, w, h) = start_screencapture_backend_at(
+        app,
+        &path,
+        include_audio,
+        target_display_id,
+        capture_region,
+    )?;
+    let (fallback_width, fallback_height) = primary_monitor_size(app);
     Ok(new_fullscreen_session(
         backend,
         path,
         QUICKTIME_RECORDING_MIME_TYPE,
-        width,
-        height,
+        w.or(fallback_width),
+        h.or(fallback_height),
         RestartInfo {
             safe_id: safe_id.to_string(),
             include_audio,
@@ -1665,6 +1739,7 @@ fn start_screencapture_recording(
             mic_device_label: None,
             segment_counter: 0,
             target_display_id,
+            capture_region,
         },
     ))
 }
@@ -1723,6 +1798,48 @@ fn native_capture_dimensions(width: u32, height: u32) -> (u32, u32) {
         even_dimension((width as f64 * scale).floor() as u32),
         even_dimension((height as f64 * scale).floor() as u32),
     )
+}
+
+#[cfg(target_os = "macos")]
+fn region_source_rect(
+    region: Option<NativeCaptureRegion>,
+    source_width: u32,
+    source_height: u32,
+) -> Result<Option<(CGRect, u32, u32)>, String> {
+    let Some(region) = region else {
+        return Ok(None);
+    };
+    let clamp_unit = |value: f64| {
+        if value.is_finite() {
+            value.clamp(0.0, 1.0)
+        } else {
+            0.0
+        }
+    };
+    let source_width = source_width.max(2);
+    let source_height = source_height.max(2);
+    let x = clamp_unit(region.x) * source_width as f64;
+    let y = clamp_unit(region.y) * source_height as f64;
+    let max_width = (source_width as f64 - x).max(1.0);
+    let max_height = (source_height as f64 - y).max(1.0);
+    let width = (clamp_unit(region.width) * source_width as f64)
+        .clamp(1.0, max_width)
+        .floor();
+    let height = (clamp_unit(region.height) * source_height as f64)
+        .clamp(1.0, max_height)
+        .floor();
+
+    let width_u32 = width as u32;
+    let height_u32 = height as u32;
+    if width_u32 < 2 || height_u32 < 2 {
+        return Err("Recording region is too small.".into());
+    }
+
+    Ok(Some((
+        CGRect::new(x.floor(), y.floor(), width, height),
+        width_u32,
+        height_u32,
+    )))
 }
 
 /// How long to wait for `SCRecordingOutput` to flush its trailing fragment

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -160,6 +160,7 @@ function resolveDesktopThumbnailUrl(
 }
 
 function normalizeCaptureSource(value: string): CaptureSource {
+  if (value === "region" && isMacPlatform()) return "region";
   return value === "window" ? "window" : "full-screen";
 }
 
@@ -1732,7 +1733,10 @@ export function App() {
         : "";
     const message =
       startError instanceof Error ? startError.message : String(startError);
-    if (errName === "AbortError" || /was cancelled|dismissed/i.test(message)) {
+    if (
+      errName === "AbortError" ||
+      /was cancelled|dismissed|region selection cancelled/i.test(message)
+    ) {
       return;
     }
     if (
@@ -2044,7 +2048,11 @@ export function App() {
 
       <div className="panel">
         {showSourceRow ? (
-          <SourceRow value={source} onChange={setSource} />
+          <SourceRow
+            value={source}
+            onChange={setSource}
+            includeRegion={isMacPlatform()}
+          />
         ) : null}
 
         {showCameraRow ? (

--- a/templates/clips/desktop/src/components/SourceRow.tsx
+++ b/templates/clips/desktop/src/components/SourceRow.tsx
@@ -1,21 +1,29 @@
 import { CheckIcon, ChevronDown, MonitorIcon } from "./Icons";
 import { useRowMenu } from "./useRowMenu";
 
-export type CaptureSource = "full-screen" | "window";
+export type CaptureSource = "full-screen" | "window" | "region";
 
 const LABELS: Record<CaptureSource, string> = {
   "full-screen": "Full screen",
   window: "Window",
+  region: "Region",
 };
 
 export function SourceRow({
   value,
   onChange,
+  includeRegion = false,
 }: {
   value: CaptureSource;
   onChange: (v: CaptureSource) => void;
+  includeRegion?: boolean;
 }) {
   const { open, setOpen, rowRef } = useRowMenu();
+  const options = (
+    includeRegion
+      ? Object.keys(LABELS)
+      : Object.keys(LABELS).filter((key) => key !== "region")
+  ) as CaptureSource[];
 
   return (
     <div className="row row-on" ref={rowRef}>
@@ -35,7 +43,7 @@ export function SourceRow({
       </button>
       {open ? (
         <div className="row-menu" role="menu">
-          {(Object.keys(LABELS) as CaptureSource[]).map((key) => {
+          {options.map((key) => {
             const isSelected = key === value;
             return (
               <button

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -72,7 +72,14 @@ import type { LocalRecordingMode } from "../shared/config";
 export type { LocalExportedFile } from "./local-export";
 
 export type CaptureMode = "screen" | "screen-camera" | "camera";
-export type CaptureSource = "full-screen" | "window";
+export type CaptureSource = "full-screen" | "window" | "region";
+
+export interface RegionCaptureRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
 
 const NATIVE_FULLSCREEN_RECORDING_FLAG = "clips:native-fullscreen-recording";
 const DEV_SYNTHETIC_CAPTURE_FLAG = "clips:dev-synthetic-capture";
@@ -98,7 +105,7 @@ function isMacPlatform(): boolean {
 export function shouldUseNativeFullscreenRecording(
   source: CaptureSource | undefined,
 ): boolean {
-  if (source !== "full-screen") return false;
+  if (source !== "full-screen" && source !== "region") return false;
   if (typeof localStorage === "undefined") return false;
   const saved = localStorage.getItem(NATIVE_FULLSCREEN_RECORDING_FLAG);
   if (saved !== null) {
@@ -906,7 +913,7 @@ async function captureTitleForRecording(params: {
   return buildCaptureTitle({
     appName: context?.appName,
     windowTitle: context?.windowTitle,
-    displaySurface: params.source === "full-screen" ? "monitor" : "window",
+    displaySurface: params.source === "window" ? "window" : "monitor",
     mode: params.mode,
   });
 }
@@ -1265,12 +1272,126 @@ class CountdownCancelledError extends Error {
   }
 }
 
+class RegionSelectionCancelledError extends Error {
+  constructor() {
+    super("Recording region selection cancelled");
+    this.name = "AbortError";
+  }
+}
+
 function isCountdownCancelledError(err: unknown) {
   return (
     err instanceof Error &&
     err.name === "AbortError" &&
     /countdown/i.test(err.message)
   );
+}
+
+function isRegionSelectionCancelledError(err: unknown) {
+  return (
+    err instanceof Error &&
+    err.name === "AbortError" &&
+    /region selection/i.test(err.message)
+  );
+}
+
+function normalizeRegionCaptureRect(value: unknown): RegionCaptureRect | null {
+  if (!value || typeof value !== "object") return null;
+  const rect = value as Partial<RegionCaptureRect>;
+  const x = Number(rect.x);
+  const y = Number(rect.y);
+  const width = Number(rect.width);
+  const height = Number(rect.height);
+  if (
+    !Number.isFinite(x) ||
+    !Number.isFinite(y) ||
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    return null;
+  }
+  return { x, y, width, height };
+}
+
+function waitForRegionSelection(): {
+  promise: Promise<RegionCaptureRect>;
+  cleanup: () => void;
+} {
+  let settled = false;
+  const unlistens: UnlistenFn[] = [];
+
+  const cleanup = () => {
+    settled = true;
+    for (const unlisten of unlistens.splice(0)) {
+      try {
+        unlisten();
+      } catch {
+        // ignore
+      }
+    }
+  };
+
+  const promise = new Promise<RegionCaptureRect>((resolve, reject) => {
+    const finish = (result: RegionCaptureRect | null) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (result) resolve(result);
+      else reject(new RegionSelectionCancelledError());
+    };
+
+    const track = (listener: Promise<UnlistenFn>) => {
+      listener
+        .then((unlisten) => {
+          if (settled) {
+            try {
+              unlisten();
+            } catch {
+              // ignore
+            }
+            return;
+          }
+          unlistens.push(unlisten);
+        })
+        .catch((err) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          reject(err);
+        });
+    };
+
+    track(
+      listen<unknown>("clips:region-capture-selected", (event) => {
+        const rect = normalizeRegionCaptureRect(event.payload);
+        if (!rect) {
+          finish(null);
+          return;
+        }
+        finish(rect);
+      }),
+    );
+    track(
+      listen("clips:region-capture-cancelled", () => {
+        finish(null);
+      }),
+    );
+  });
+
+  return { promise, cleanup };
+}
+
+async function selectRegionForRecording(): Promise<RegionCaptureRect> {
+  const selection = waitForRegionSelection();
+  try {
+    await invoke("show_region_capture_selector");
+    return await selection.promise;
+  } catch (err) {
+    selection.cleanup();
+    throw err;
+  }
 }
 
 function waitForCountdownEvent(timeoutMs = 4000): Promise<void> {
@@ -1409,6 +1530,7 @@ async function startNativeFullscreenRecording(
   let localCameraStream: MediaStream | null = null;
   let localOwnsCameraStream = false;
   let bubbleCaptureExcluded = false;
+  let captureRegion: RegionCaptureRect | null = null;
   let transcriptionCapture: TranscriptionCapture | null = null;
   // Timer baseline for the toolbar/pill elapsed clock. Stamped the instant
   // native capture goes live (right after the start invoke resolves), not after
@@ -1430,6 +1552,10 @@ async function startNativeFullscreenRecording(
   try {
     await invoke("park_popover_offscreen").catch(() => {});
     emit("clips:popover-visible", false).catch(() => {});
+
+    if (params.source === "region") {
+      captureRegion = await selectRegionForRecording();
+    }
 
     if (localOnly && localRecordingMode === "separate" && wantsCamera) {
       localCameraStream =
@@ -1474,7 +1600,7 @@ async function startNativeFullscreenRecording(
     } else {
       const captureTitle = await captureTitleForRecording({
         mode: params.mode,
-        source: "full-screen",
+        source: params.source,
       });
       console.time("[clips-recorder] createServerRecording duration");
       const recordingPromise = createServerRecording(
@@ -1536,6 +1662,7 @@ async function startNativeFullscreenRecording(
       captureSystemAudio: wantsSystemAudio,
       micDeviceId: params.micId || null,
       micDeviceLabel,
+      captureRegion,
     });
     // Capture is now live — stamp the timer baseline before any further awaits
     // so the toolbar clock and toolbar-enable line up with the real start.

--- a/templates/clips/desktop/src/main.tsx
+++ b/templates/clips/desktop/src/main.tsx
@@ -53,6 +53,8 @@ function pickRoute(route: string): React.ReactElement {
       return <RegionGuides />;
     case "region-guides-editor":
       return <RegionGuideEditor />;
+    case "region-capture-selector":
+      return <RegionGuideEditor mode="capture" />;
     default:
       return <App />;
   }

--- a/templates/clips/desktop/src/overlays/region-guides.tsx
+++ b/templates/clips/desktop/src/overlays/region-guides.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { emit } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   IconDeviceFloppy,
@@ -283,7 +284,12 @@ export function RegionGuides() {
   );
 }
 
-export function RegionGuideEditor() {
+export function RegionGuideEditor({
+  mode = "preset",
+}: {
+  mode?: "preset" | "capture";
+}) {
+  const captureMode = mode === "capture";
   const config = useFeatureConfig();
   const guides = regionGuideConfig(config);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
@@ -308,9 +314,7 @@ export function RegionGuideEditor() {
           setDraft(null);
           return;
         }
-        getCurrentWindow()
-          .close()
-          .catch(() => {});
+        closeEditor();
       }
       if (event.key === "Backspace" || event.key === "Delete") {
         if (!selectedId) return;
@@ -344,6 +348,27 @@ export function RegionGuideEditor() {
     setSelectedId(null);
     setDirty(true);
     setMessage(null);
+  }
+
+  async function useSelectedCaptureRegion() {
+    const selected =
+      (selectedId ? rects.find((rect) => rect.id === selectedId) : null) ??
+      rects[0] ??
+      null;
+    const rect = selected ? normalizeRect(selected) : null;
+    if (!rect) {
+      setMessage("Draw a region first.");
+      return;
+    }
+    await emit("clips:region-capture-selected", {
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+    }).catch(() => {});
+    getCurrentWindow()
+      .close()
+      .catch(() => {});
   }
 
   async function savePreset() {
@@ -382,6 +407,9 @@ export function RegionGuideEditor() {
   }
 
   function closeEditor() {
+    if (captureMode) {
+      emit("clips:region-capture-cancelled").catch(() => {});
+    }
     getCurrentWindow()
       .close()
       .catch(() => {});
@@ -406,6 +434,10 @@ export function RegionGuideEditor() {
     };
     setSelectedId(null);
     setMessage(null);
+    if (captureMode) {
+      setRects([]);
+      setDirty(true);
+    }
     setDraft(null);
     surfaceRef.current?.setPointerCapture(event.pointerId);
   }
@@ -461,7 +493,14 @@ export function RegionGuideEditor() {
 
     if (interaction.kind === "draw") {
       setDraft(
-        squareRectFromPoints(interaction.id, interaction.start, point, size),
+        captureMode
+          ? rectFromPoints(interaction.id, interaction.start, point)
+          : squareRectFromPoints(
+              interaction.id,
+              interaction.start,
+              point,
+              size,
+            ),
       );
       return;
     }
@@ -490,14 +529,18 @@ export function RegionGuideEditor() {
     }
     if (interaction.kind === "draw") {
       const point = pointForEvent(event, surfaceRef.current);
-      const nextRect = squareRectFromPoints(
-        interaction.id,
-        interaction.start,
-        point,
-        surfaceSize(surfaceRef.current),
-      );
+      const nextRect = captureMode
+        ? rectFromPoints(interaction.id, interaction.start, point)
+        : squareRectFromPoints(
+            interaction.id,
+            interaction.start,
+            point,
+            surfaceSize(surfaceRef.current),
+          );
       if (nextRect) {
-        setRects((current) => [...current, nextRect]);
+        setRects((current) =>
+          captureMode ? [nextRect] : [...current, nextRect],
+        );
         setSelectedId(nextRect.id);
         setDirty(true);
       }
@@ -526,7 +569,9 @@ export function RegionGuideEditor() {
       <div className="region-guide-editor-bar" data-region-toolbar>
         <div className="region-guide-editor-title">
           <IconPencil size={16} stroke={1.8} />
-          <span>Region guide preset</span>
+          <span>
+            {captureMode ? "Recording region" : "Region guide preset"}
+          </span>
           <span className="region-guide-editor-count">
             {rects.length} {rects.length === 1 ? "box" : "boxes"}
           </span>
@@ -552,11 +597,13 @@ export function RegionGuideEditor() {
           <button
             type="button"
             className="region-guide-editor-button region-guide-editor-button-primary"
-            onClick={savePreset}
-            disabled={!dirty || saving || !config}
+            onClick={captureMode ? useSelectedCaptureRegion : savePreset}
+            disabled={
+              captureMode ? rects.length === 0 : !dirty || saving || !config
+            }
           >
             <IconDeviceFloppy size={15} stroke={1.9} />
-            {saving ? "Saving" : "Save"}
+            {captureMode ? "Use region" : saving ? "Saving" : "Save"}
           </button>
           <button
             type="button"
@@ -575,7 +622,9 @@ export function RegionGuideEditor() {
       </div>
 
       <div className="region-guide-editor-hint" data-region-toolbar>
-        Square guides. Corners resize. Drag a box to move.
+        {captureMode
+          ? "Draw the area to record. Drag the box to move it, or pull a corner to resize."
+          : "Square guides. Corners resize. Drag a box to move."}
       </div>
 
       {rects.map((rect) => (

--- a/templates/clips/server/lib/video-storage.ts
+++ b/templates/clips/server/lib/video-storage.ts
@@ -1,0 +1,40 @@
+import { listFileUploadProviders } from "@agent-native/core/file-upload";
+import { resolveHasBuilderPrivateKey } from "@agent-native/core/server";
+
+export const STORAGE_SETUP_REQUIRED_REASON =
+  "Video storage is not connected yet. Connect Builder.io or configure S3-compatible storage to upload clips.";
+
+function appDatabaseUrl(): string {
+  const appName = process.env.APP_NAME?.toUpperCase().replace(/-/g, "_");
+  if (appName) {
+    const appUrl = process.env[`${appName}_DATABASE_URL`];
+    if (appUrl) return appUrl;
+  }
+  return process.env.DATABASE_URL || process.env.NETLIFY_DATABASE_URL || "";
+}
+
+function isLikelyLocalDatabase(): boolean {
+  const url = appDatabaseUrl();
+  return url === "" || url.startsWith("file:") || !url.includes("://");
+}
+
+export function requiresConfiguredVideoStorage(): boolean {
+  return process.env.NODE_ENV === "production" || !isLikelyLocalDatabase();
+}
+
+export async function hasRequestVideoStorage(): Promise<boolean> {
+  for (const provider of listFileUploadProviders()) {
+    if (provider.id !== "builder" && provider.isConfigured()) return true;
+  }
+
+  try {
+    return await resolveHasBuilderPrivateKey();
+  } catch {
+    return false;
+  }
+}
+
+export async function shouldRejectVideoUploadWithoutStorage(): Promise<boolean> {
+  if (!requiresConfiguredVideoStorage()) return false;
+  return !(await hasRequestVideoStorage());
+}

--- a/templates/clips/server/plugins/onboarding.ts
+++ b/templates/clips/server/plugins/onboarding.ts
@@ -12,12 +12,9 @@ import {
   createOnboardingPlugin,
   registerOnboardingStep,
 } from "@agent-native/core/onboarding";
-import {
-  getActiveFileUploadProvider,
-  registerFileUploadProvider,
-} from "@agent-native/core/file-upload";
-import { resolveHasBuilderPrivateKey } from "@agent-native/core/server";
+import { registerFileUploadProvider } from "@agent-native/core/file-upload";
 import { s3FileUploadProvider } from "../lib/s3-upload-provider.js";
+import { hasRequestVideoStorage } from "../lib/video-storage.js";
 
 const basePlugin = createOnboardingPlugin();
 
@@ -90,18 +87,6 @@ export default async (nitroApp: any): Promise<void> => {
         },
       },
     ],
-    isComplete: async () => {
-      const active = getActiveFileUploadProvider();
-      if (active && active.id !== "builder") return true;
-      try {
-        if (await resolveHasBuilderPrivateKey()) return true;
-      } catch {
-        // Treat credential lookup failures as incomplete so users can connect.
-      }
-      // Do not let the built-in Builder provider's sync env check complete
-      // onboarding for signed-in hosted users. The actual upload path resolves
-      // Builder credentials request-aware, so this step should do the same.
-      return false;
-    },
+    isComplete: hasRequestVideoStorage,
   });
 };

--- a/templates/clips/server/plugins/onboarding.ts
+++ b/templates/clips/server/plugins/onboarding.ts
@@ -96,9 +96,12 @@ export default async (nitroApp: any): Promise<void> => {
       try {
         if (await resolveHasBuilderPrivateKey()) return true;
       } catch {
-        // Fall back to sync provider status below.
+        // Treat credential lookup failures as incomplete so users can connect.
       }
-      return !!active;
+      // Do not let the built-in Builder provider's sync env check complete
+      // onboarding for signed-in hosted users. The actual upload path resolves
+      // Builder credentials request-aware, so this step should do the same.
+      return false;
     },
   });
 };

--- a/templates/clips/server/routes/api/uploads/[recordingId]/chunk.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/chunk.post.ts
@@ -27,6 +27,10 @@ import { and, eq } from "drizzle-orm";
 import { getDb, schema } from "../../../../db/index.js";
 import { debugLog } from "../../../../lib/debug.js";
 import { getEventOwnerContext } from "../../../../lib/recordings.js";
+import {
+  shouldRejectVideoUploadWithoutStorage,
+  STORAGE_SETUP_REQUIRED_REASON,
+} from "../../../../lib/video-storage.js";
 import { runWithRequestContext } from "@agent-native/core/server";
 import {
   listAppState,
@@ -180,6 +184,31 @@ export default defineEventHandler(async (event: H3Event) => {
       return failedUploadResponse(
         existing.failureReason ?? "Recording upload has already failed.",
       );
+    }
+
+    if (await shouldRejectVideoUploadWithoutStorage()) {
+      const now = new Date().toISOString();
+      await db
+        .update(schema.recordings)
+        .set({
+          status: "failed",
+          failureReason: STORAGE_SETUP_REQUIRED_REASON,
+          updatedAt: now,
+        })
+        .where(eq(schema.recordings.id, recordingId));
+      await writeAppState(`recording-upload-${recordingId}`, {
+        recordingId,
+        status: "failed",
+        failureReason: STORAGE_SETUP_REQUIRED_REASON,
+        storageSetupRequired: true,
+        updatedAt: now,
+      });
+      setResponseStatus(event, 409);
+      return {
+        ok: false,
+        error: STORAGE_SETUP_REQUIRED_REASON,
+        storageSetupRequired: true,
+      };
     }
 
     const raw = await readRawBody(event, false);

--- a/templates/content/.agents/skills/content/SKILL.md
+++ b/templates/content/.agents/skills/content/SKILL.md
@@ -64,7 +64,6 @@ Content roots for `docs/`, `blog/`, `content/`, and `resources/`, plus a
 ```json
 {
   "version": 1,
-  "mode": "local-files",
   "apps": {
     "content": {
       "mode": "local-files",

--- a/templates/content/.agents/skills/content/SKILL.md
+++ b/templates/content/.agents/skills/content/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: content
+description: >-
+  Use Content for repo-backed Markdown/MDX docs, blogs, resources, rich
+  document editing, local components, shareable copies, and Content local-file
+  workspaces. Prefer Content actions over raw filesystem writes when available.
+metadata:
+  visibility: exported
+---
+
+# Content
+
+Use the Content app when a workflow is about authoring, editing, reviewing, or
+publishing Markdown/MDX documents: docs sites, blogs, resource libraries,
+marketing pages, internal notes, and local MDX components. Content gives the
+agent a document tree, a rich editor, normal document actions, and optional
+local-file source of truth.
+
+## Choose The Path
+
+- Use Content actions when the Content MCP/action tools are available:
+  `list-documents`, `search-documents`, `get-document`, `pull-document`,
+  `create-document`, `edit-document`, `update-document`, `delete-document`,
+  `share-local-file-document`, `list-local-component-files`, and
+  `write-local-component-file`.
+- Use `pull-document` or `get-document` before editing a page. Use
+  `edit-document` for precise find/replace changes and `update-document` for
+  full rewrites or new content.
+- In Local File Mode, Content actions read and write the repo files declared in
+  `agent-native.json`; SQL remains cache/history/search glue, not the source of
+  truth for those pages.
+- If Content tools are not visible and no local Content app or Desktop bridge is
+  running, treat this skill as repo-editing guidance. Edit configured
+  `.md`/`.mdx` files directly, preserve frontmatter and MDX imports, and tell
+  the user the Content action surface was not available.
+
+## Action Examples
+
+Prefer JSON input for action calls:
+
+```bash
+pnpm action list-documents
+pnpm action get-document '{"id":"local-file:..."}'
+pnpm action edit-document '{"id":"local-file:...","find":"old copy","replace":"new copy"}'
+pnpm action update-document '{"id":"local-file:...","content":"# Updated\n\nBody"}'
+pnpm action share-local-file-document '{"id":"local-file:..."}'
+```
+
+Run `refresh-list` after create/update/delete operations when you need the open
+Content UI sidebar to repaint immediately.
+
+## Local File Mode
+
+Install into an existing repo with:
+
+```bash
+npx @agent-native/core@latest skills add content --mode local-files --scope project
+```
+
+The installer copies this skill and writes or updates `agent-native.json` with
+Content roots for `docs/`, `blog/`, `content/`, and `resources/`, plus a
+`components/` folder for local MDX components. A typical manifest looks like:
+
+```json
+{
+  "version": 1,
+  "mode": "local-files",
+  "apps": {
+    "content": {
+      "mode": "local-files",
+      "roots": [
+        {
+          "name": "Docs",
+          "path": "docs",
+          "kind": "docs",
+          "extensions": [".md", ".mdx"]
+        },
+        {
+          "name": "Blog",
+          "path": "blog",
+          "kind": "blog",
+          "extensions": [".md", ".mdx"]
+        },
+        {
+          "name": "Content",
+          "path": "content",
+          "kind": "content",
+          "extensions": [".md", ".mdx"]
+        },
+        {
+          "name": "Resources",
+          "path": "resources",
+          "kind": "resources",
+          "extensions": [".md", ".mdx"]
+        }
+      ],
+      "components": "components",
+      "extensions": "extensions",
+      "hide": ["**/_*.md", "**/_*.mdx"]
+    }
+  }
+}
+```
+
+Local File Mode does not make the host language model local, and the hosted
+Content app cannot read private repo files by itself. File access requires a
+local Content app, Agent Native Desktop, or another trusted local bridge.
+
+## MDX And Components
+
+- Preserve frontmatter keys you do not understand. Preserve MDX imports,
+  exports, JSX, and expression props unless the user explicitly asks to change
+  them.
+- Use local components from the configured `components` folder. Components
+  should be PascalCase exports from `.tsx` files; simple editable input metadata
+  can live next to them as `ComponentNameInputs`.
+- Use `list-local-component-files` and `write-local-component-file` for
+  component source changes when Content tools are available. Otherwise edit the
+  component files directly like normal repo source.
+
+## Boundaries
+
+- Moving, renaming, and reordering local-file pages are not first-class Content
+  UI operations yet. Use normal file operations when the user asks for those,
+  then let Content rediscover the file tree.
+- Do not push/pull Notion, Builder.io, or other provider-backed content unless
+  the user explicitly asks for provider sync.
+- Do not paste secrets, private provider data, or credential-looking values into
+  docs, generated pages, frontmatter, examples, or local components.

--- a/templates/content/agent-native.app-skill.json
+++ b/templates/content/agent-native.app-skill.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": 1,
+  "id": "content",
+  "displayName": "Content",
+  "description": "Edit docs, blogs, resources, and MDX content through the Content app, including repo-backed Local File Mode.",
+  "hosted": {
+    "url": "https://content.agent-native.com",
+    "mcpUrl": "https://content.agent-native.com/_agent-native/mcp"
+  },
+  "mcp": {
+    "serverName": "agent-native-content"
+  },
+  "local": {
+    "template": "content",
+    "sourcePath": ".",
+    "defaultUrl": "http://127.0.0.1:8083",
+    "commands": {
+      "install": "pnpm install",
+      "dev": "pnpm dev",
+      "start": "pnpm start"
+    }
+  },
+  "auth": {
+    "mode": "oauth",
+    "setup": "Authenticate with the Content MCP connector in the host app or use agent-native app-skill ensure to register the URL-only connector. Local File Mode requires a local Content app, Agent Native Desktop, or another trusted local bridge for filesystem access."
+  },
+  "surfaces": [
+    {
+      "id": "content-documents",
+      "action": "list-documents",
+      "path": "/"
+    },
+    {
+      "id": "content-local-files",
+      "action": "share-local-file-document",
+      "path": "/local-files"
+    }
+  ],
+  "skills": [
+    {
+      "path": ".agents/skills/content",
+      "visibility": "both",
+      "exportAs": "content"
+    },
+    {
+      "path": ".agents/skills/document-editing",
+      "visibility": "internal"
+    }
+  ],
+  "hostAdapters": [
+    "codex-plugin",
+    "claude-marketplace",
+    "vercel-skills",
+    "plain-skill",
+    "claude-skill",
+    "chatgpt-mcp",
+    "generic-mcp"
+  ]
+}

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -50,7 +50,7 @@ extending the editor's save path, enqueue a granular op (`patch-slide`,
 ## Application State
 
 - `navigation` exposes the current deck, slide, selection, and editor view.
-- `navigate` moves the UI to decks, slides, imports, exports, and settings.
+- `navigate` moves the UI to decks, slides, imports, and exports.
 - Use app actions for full deck/slide data instead of relying on ambient context.
 
 ## Skills

--- a/templates/slides/actions/import-file.test.ts
+++ b/templates/slides/actions/import-file.test.ts
@@ -80,6 +80,32 @@ describe("import-file PDF source extraction", () => {
     expect(result.pages[0].pageNum).toBe(3);
     expect(result.pages[0].text).toBe(fullText);
     expect(result.pages[0].textPreview).toBe(fullText.slice(0, 500));
+    expect(result.truncated).toBe(false);
+  });
+
+  it("caps large PDF extraction output by default", async () => {
+    const firstPage = "A".repeat(40_000);
+    const secondPage = "B".repeat(40_000);
+    mockPdfText.mockResolvedValue({
+      pages: [
+        { num: 1, text: firstPage },
+        { num: 2, text: secondPage },
+      ],
+    });
+
+    const result = (await action.run({
+      filePath: "large-deck.pdf",
+      format: "pdf",
+    })) as any;
+
+    expect(result.totalTextLength).toBe(80_000);
+    expect(result.truncated).toBe(true);
+    expect(result.note).toContain("first 60000 extracted characters");
+    expect(result.pages).toHaveLength(2);
+    expect(result.pages[0].text).toHaveLength(40_000);
+    expect(result.pages[0].truncated).toBe(false);
+    expect(result.pages[1].text).toHaveLength(20_000);
+    expect(result.pages[1].truncated).toBe(true);
   });
 
   it("fails clearly when no PDF text can be extracted", async () => {

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -10,6 +10,8 @@ import { notifyClients } from "../server/handlers/decks.js";
 import { parseSlidesFigDesignSystem } from "../server/lib/fig-design-system.js";
 import { resolveUserUploadedFile } from "./_uploaded-files.js";
 
+const DEFAULT_MAX_SOURCE_CHARS = 60_000;
+
 export default defineAction({
   description:
     "Import a file (PPTX, DOCX, PDF, FIG) and extract content for creating slides or slide design systems. " +
@@ -40,9 +42,19 @@ export default defineAction({
       .describe(
         "If true, replace deckId's slides with slides converted from the file.",
       ),
+    maxChars: z.coerce
+      .number()
+      .int()
+      .min(1000)
+      .max(100_000)
+      .optional()
+      .describe(
+        "Maximum extracted source characters to return when not importing directly into a deck (default 60000).",
+      ),
   }),
-  run: async ({ filePath, format, deckId, importIntoDeck }) => {
+  run: async ({ filePath, format, deckId, importIntoDeck, maxChars }) => {
     const absPath = resolveUserUploadedFile(filePath);
+    const sourceLimit = maxChars ?? DEFAULT_MAX_SOURCE_CHARS;
 
     const fileBuffer = await fs.promises.readFile(absPath);
 
@@ -170,14 +182,14 @@ export default defineAction({
         format: "docx",
         title,
         sectionCount: doc.sections.length,
-        text: doc.text,
-        sections: doc.sections.map((s) => ({
-          heading: s.heading,
-          content: s.content,
-          text: stripTags(s.content),
-          contentPreview: stripTags(s.content).slice(0, 500),
-        })),
+        text: truncateText(doc.text, sourceLimit).text,
+        sections: truncateSections(doc.sections, sourceLimit),
         textLength: doc.text.length,
+        truncated: doc.text.length > sourceLimit,
+        note:
+          doc.text.length > sourceLimit
+            ? `Returned the first ${sourceLimit} extracted characters. Re-run with a higher maxChars value if more source context is needed.`
+            : undefined,
         deckId,
       };
     }
@@ -227,12 +239,14 @@ export default defineAction({
         title: `Imported PDF (${pages.length} pages)`,
         pageCount: pages.length,
         textPageCount: textPages.length,
-        pages: textPages.map((p) => ({
-          pageNum: p.num,
-          text: p.text,
-          textPreview: p.text.slice(0, 500),
-          textLength: p.text.length,
-        })),
+        pages: truncatePages(textPages, sourceLimit),
+        totalTextLength: textPages.reduce((sum, p) => sum + p.text.length, 0),
+        truncated:
+          textPages.reduce((sum, p) => sum + p.text.length, 0) > sourceLimit,
+        note:
+          textPages.reduce((sum, p) => sum + p.text.length, 0) > sourceLimit
+            ? `Returned the first ${sourceLimit} extracted characters. Re-run with a higher maxChars value if more source context is needed.`
+            : undefined,
         deckId,
       };
     }
@@ -267,6 +281,66 @@ function normalizePdfPages(result: unknown): { num: number; text: string }[] {
     num: i + 1,
     text: pageText.trim(),
   }));
+}
+
+function truncateText(
+  text: string,
+  limit: number,
+): { text: string; truncated: boolean } {
+  if (text.length <= limit) return { text, truncated: false };
+  return { text: text.slice(0, limit), truncated: true };
+}
+
+function takeFromBudget(
+  text: string,
+  budget: { remaining: number },
+): { text: string; truncated: boolean } {
+  if (budget.remaining <= 0) {
+    return { text: "", truncated: text.length > 0 };
+  }
+  if (text.length <= budget.remaining) {
+    budget.remaining -= text.length;
+    return { text, truncated: false };
+  }
+  const taken = text.slice(0, budget.remaining);
+  budget.remaining = 0;
+  return { text: taken, truncated: true };
+}
+
+function truncatePages(pages: { num: number; text: string }[], limit: number) {
+  const budget = { remaining: limit };
+  return pages
+    .map((p) => {
+      const truncated = takeFromBudget(p.text, budget);
+      return {
+        pageNum: p.num,
+        text: truncated.text,
+        textPreview: p.text.slice(0, 500),
+        textLength: p.text.length,
+        truncated: truncated.truncated,
+      };
+    })
+    .filter((p) => p.text || p.textLength === 0);
+}
+
+function truncateSections(
+  sections: { heading: string; content: string }[],
+  limit: number,
+) {
+  const budget = { remaining: limit };
+  return sections
+    .map((s) => {
+      const plain = stripTags(s.content);
+      const truncated = takeFromBudget(plain, budget);
+      return {
+        heading: s.heading,
+        text: truncated.text,
+        contentPreview: plain.slice(0, 500),
+        textLength: plain.length,
+        truncated: truncated.truncated,
+      };
+    })
+    .filter((s) => s.text || s.textLength === 0);
 }
 
 async function replaceDeckSlides(

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -183,7 +183,7 @@ export default defineAction({
         title,
         sectionCount: doc.sections.length,
         text: truncateText(doc.text, sourceLimit).text,
-        sections: truncateSections(doc.sections, sourceLimit),
+        sections: summarizeSections(doc.sections),
         textLength: doc.text.length,
         truncated: doc.text.length > sourceLimit,
         note:
@@ -233,6 +233,10 @@ export default defineAction({
           imported: true,
         };
       }
+      const totalTextLength = textPages.reduce(
+        (sum, p) => sum + p.text.length,
+        0,
+      );
 
       return {
         format: "pdf",
@@ -240,11 +244,10 @@ export default defineAction({
         pageCount: pages.length,
         textPageCount: textPages.length,
         pages: truncatePages(textPages, sourceLimit),
-        totalTextLength: textPages.reduce((sum, p) => sum + p.text.length, 0),
-        truncated:
-          textPages.reduce((sum, p) => sum + p.text.length, 0) > sourceLimit,
+        totalTextLength,
+        truncated: totalTextLength > sourceLimit,
         note:
-          textPages.reduce((sum, p) => sum + p.text.length, 0) > sourceLimit
+          totalTextLength > sourceLimit
             ? `Returned the first ${sourceLimit} extracted characters. Re-run with a higher maxChars value if more source context is needed.`
             : undefined,
         deckId,
@@ -323,24 +326,15 @@ function truncatePages(pages: { num: number; text: string }[], limit: number) {
     .filter((p) => p.text || p.textLength === 0);
 }
 
-function truncateSections(
-  sections: { heading: string; content: string }[],
-  limit: number,
-) {
-  const budget = { remaining: limit };
-  return sections
-    .map((s) => {
-      const plain = stripTags(s.content);
-      const truncated = takeFromBudget(plain, budget);
-      return {
-        heading: s.heading,
-        text: truncated.text,
-        contentPreview: plain.slice(0, 500),
-        textLength: plain.length,
-        truncated: truncated.truncated,
-      };
-    })
-    .filter((s) => s.text || s.textLength === 0);
+function summarizeSections(sections: { heading: string; content: string }[]) {
+  return sections.map((s) => {
+    const plain = stripTags(s.content);
+    return {
+      heading: s.heading,
+      textPreview: plain.slice(0, 500),
+      textLength: plain.length,
+    };
+  });
 }
 
 async function replaceDeckSlides(

--- a/templates/slides/actions/navigate.ts
+++ b/templates/slides/actions/navigate.ts
@@ -7,9 +7,9 @@ export default defineAction({
     "Navigate the UI to a specific deck, slide, or view. Writes a navigate command to application state which the UI reads and auto-deletes.",
   schema: z.object({
     view: z
-      .string()
+      .enum(["list", "editor", "present"])
       .optional()
-      .describe("Top-level view to navigate to (list, settings)"),
+      .describe("Top-level view to navigate to (list, editor, present)"),
     deckId: z.string().optional().describe("Deck ID to open in the editor"),
     slideNumber: z.coerce
       .number()

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -82,7 +82,7 @@ function describeUploadedFilesForAgent(
     "",
     "File handling rules:",
     `- PPTX files: call \`import-pptx --filePath "<path>" --deckId ${deckId}\` when the user wants the deck/slides imported, or to extract slide source from a presentation.`,
-    `- PDF and DOCX files: call \`import-file --filePath "<path>" --format auto --deckId ${deckId}\` and use the returned content as source material.`,
+    `- PDF and DOCX files: call \`import-file --filePath "<path>" --format auto --deckId ${deckId}\` and use the returned extracted text as source material. The returned text is capped for reliability; re-run with maxChars only if more context is needed.`,
     "- Text-like files: use the uploaded-text-file blocks already included in the prompt; do not call import-file for them.",
     '- Image files with an embeddable URL can be inserted directly into slide HTML as `<img src="...">` or used as visual references.',
     "- Image files without a URL are visual/reference assets only; do not claim to have processed a PPTX/PDF/DOCX unless the relevant import action succeeds.",

--- a/templates/slides/app/components/editor/ImageDropPromptPopover.tsx
+++ b/templates/slides/app/components/editor/ImageDropPromptPopover.tsx
@@ -125,7 +125,7 @@ export default function ImageDropPromptPopover({
       if (!res.ok || !data?.url) {
         throw new Error(
           data?.error ||
-            "Image upload failed. Connect or reconnect Builder.io in Settings → File uploads, or register a custom provider via registerFileUploadProvider().",
+            "Image upload failed. Connect Builder.io from the agent composer model menu, or register a custom provider via registerFileUploadProvider().",
         );
       }
 

--- a/templates/slides/app/components/layout/Header.tsx
+++ b/templates/slides/app/components/layout/Header.tsx
@@ -8,7 +8,6 @@ const pageTitles: Record<string, string> = {
   "/": "Decks",
   "/design-systems": "Design Systems",
   "/team": "Team",
-  "/settings": "Settings",
   "/extensions": "Extensions",
 };
 

--- a/templates/slides/app/components/layout/Layout.tsx
+++ b/templates/slides/app/components/layout/Layout.tsx
@@ -35,7 +35,7 @@ export function Layout({ children }: LayoutProps) {
   const { getDeck } = useDecks();
 
   // Scope new chats to the deck the user is currently editing. The route
-  // is `/deck/:id`; everywhere else (list, settings, presentation) leaves
+  // is `/deck/:id`; everywhere else (list, presentation) leaves
   // scope null so chats stay in the general pool. Falling back to the
   // raw deck id keeps the chat bound even before the deck object has
   // streamed in — once the title arrives the badge updates in place.

--- a/templates/slides/app/hooks/use-navigation-state.ts
+++ b/templates/slides/app/hooks/use-navigation-state.ts
@@ -53,8 +53,6 @@ export function useNavigationState() {
           state.slideIndex = oneBased - 1;
         }
       }
-    } else if (path.startsWith("/settings")) {
-      state.view = "settings";
     } else if (path.startsWith("/share/")) {
       state.view = "share";
     } else {
@@ -170,8 +168,6 @@ export function useNavigationState() {
           path += `?slide=${internalSlideIndex + 1}`;
         }
       }
-    } else if (cmd.view === "settings") {
-      path = "/settings";
     }
 
     navigate(path);

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -118,7 +118,7 @@ function describeUploadedFilesForAgent(
     "",
     "File handling rules:",
     `- PPTX files: call \`import-pptx --filePath "<path>" --deckId ${deckId}\` before adding or editing slides.`,
-    `- PDF and DOCX files: call \`import-file --filePath "<path>" --format auto --deckId ${deckId}\` and use the returned content as source material.`,
+    `- PDF and DOCX files: call \`import-file --filePath "<path>" --format auto --deckId ${deckId}\` and use the returned extracted text as source material. The returned text is capped for reliability; re-run with maxChars only if more context is needed.`,
     "- Text-like files: use the uploaded-text-file blocks already included in the prompt; do not call import-file for them.",
     '- Image files with an embeddable URL can be inserted directly into slide HTML as `<img src="...">` or used as visual references.',
     "- Image files without a URL are visual/reference assets only; do not claim to have processed a PPTX/PDF/DOCX unless the relevant import action succeeds.",

--- a/templates/slides/server/handlers/assets.ts
+++ b/templates/slides/server/handlers/assets.ts
@@ -130,7 +130,7 @@ export async function uploadImageAsset(args: {
 
   if (!result) {
     const err: Error & { statusCode?: number } = new Error(
-      "No file upload provider is configured. Connect or reconnect Builder.io in Settings → File uploads, or register a custom provider via registerFileUploadProvider().",
+      "No file upload provider is configured. Connect Builder.io from the agent composer model menu, or register a custom provider via registerFileUploadProvider().",
     );
     err.statusCode = 503;
     throw err;

--- a/templates/slides/server/lib/chat-attachments.spec.ts
+++ b/templates/slides/server/lib/chat-attachments.spec.ts
@@ -49,6 +49,13 @@ describe("prepareSlidesChatAttachments", () => {
       "embeddable URL: https://cdn.example.com/editor-ai.jpeg",
     );
     expect(result?.message).toContain("PDF/PPTX/DOCX/FIG/image");
+    expect(result?.attachments?.[0]?.data).toBeUndefined();
+    expect((result?.attachments?.[0] as any)?.url).toBe(
+      "https://cdn.example.com/editor-ai.jpeg",
+    );
+    expect((result?.attachments?.[0] as any)?.slidesUploadPath).toBe(
+      "data/uploads/user/editor-ai.jpeg",
+    );
   });
 
   it("saves SVG attachments from chat as slide reference uploads", async () => {
@@ -82,6 +89,40 @@ describe("prepareSlidesChatAttachments", () => {
     });
     expect(result?.message).toContain("vector.svg");
     expect(result?.message).toContain("data/uploads/user/vector.svg");
+    expect(result?.attachments?.[0]?.data).toBeUndefined();
+    expect((result?.attachments?.[0] as any)?.slidesUploadPath).toBe(
+      "data/uploads/user/vector.svg",
+    );
+  });
+
+  it("strips raw PDF data after saving it as a Slides reference upload", async () => {
+    saveUploadedReferenceFileMock.mockResolvedValue({
+      path: "data/uploads/user/source.pdf",
+      originalName: "source.pdf",
+      filename: "stored.pdf",
+      type: "application/pdf",
+      size: 12,
+    });
+
+    const result = await prepareSlidesChatAttachments({
+      ownerEmail: "adam@builder.io",
+      message: "recreate this deck",
+      attachments: [
+        {
+          type: "file",
+          name: "source.pdf",
+          contentType: "application/pdf",
+          data: "data:application/pdf;base64,JVBERi0x",
+        },
+      ],
+    });
+
+    expect(saveUploadedReferenceFileMock).toHaveBeenCalledTimes(1);
+    expect(result?.message).toContain("data/uploads/user/source.pdf");
+    expect(result?.attachments?.[0]?.data).toBeUndefined();
+    expect((result?.attachments?.[0] as any)?.slidesUploadPath).toBe(
+      "data/uploads/user/source.pdf",
+    );
   });
 
   it("keeps unsupported attachments out of the slides upload context", async () => {

--- a/templates/slides/server/lib/chat-attachments.spec.ts
+++ b/templates/slides/server/lib/chat-attachments.spec.ts
@@ -13,7 +13,7 @@ describe("prepareSlidesChatAttachments", () => {
     saveUploadedReferenceFileMock.mockReset();
   });
 
-  it("saves image attachments from chat as slide reference uploads", async () => {
+  it("strips raw image data when storage returns an embeddable URL", async () => {
     saveUploadedReferenceFileMock.mockResolvedValue({
       path: "data/uploads/user/editor-ai.jpeg",
       url: "https://cdn.example.com/editor-ai.jpeg",
@@ -58,7 +58,42 @@ describe("prepareSlidesChatAttachments", () => {
     );
   });
 
-  it("saves SVG attachments from chat as slide reference uploads", async () => {
+  it("keeps raw raster image data when storage returns no embeddable URL", async () => {
+    saveUploadedReferenceFileMock.mockResolvedValue({
+      path: "data/uploads/user/reference.png",
+      originalName: "reference.png",
+      filename: "stored.png",
+      type: "image/png",
+      size: 4,
+    });
+
+    const result = await prepareSlidesChatAttachments({
+      ownerEmail: "adam@builder.io",
+      message: "use this visual reference",
+      attachments: [
+        {
+          type: "image",
+          name: "reference.png",
+          contentType: "image/png",
+          data: "data:image/png;base64,iVBORw0KGgo=",
+        },
+      ],
+    });
+
+    expect(saveUploadedReferenceFileMock).toHaveBeenCalledTimes(1);
+    expect(result?.message).toContain("reference.png");
+    expect(result?.message).toContain("data/uploads/user/reference.png");
+    expect(result?.message).not.toContain("embeddable URL:");
+    expect(result?.attachments?.[0]?.data).toBe(
+      "data:image/png;base64,iVBORw0KGgo=",
+    );
+    expect((result?.attachments?.[0] as any)?.url).toBeUndefined();
+    expect((result?.attachments?.[0] as any)?.slidesUploadPath).toBe(
+      "data/uploads/user/reference.png",
+    );
+  });
+
+  it("keeps raw image data when storage returns no embeddable URL", async () => {
     saveUploadedReferenceFileMock.mockResolvedValue({
       path: "data/uploads/user/vector.svg",
       originalName: "vector.svg",
@@ -89,7 +124,9 @@ describe("prepareSlidesChatAttachments", () => {
     });
     expect(result?.message).toContain("vector.svg");
     expect(result?.message).toContain("data/uploads/user/vector.svg");
-    expect(result?.attachments?.[0]?.data).toBeUndefined();
+    expect(result?.attachments?.[0]?.data).toBe(
+      "data:image/svg+xml;base64,PHN2Zy8+",
+    );
     expect((result?.attachments?.[0] as any)?.slidesUploadPath).toBe(
       "data/uploads/user/vector.svg",
     );

--- a/templates/slides/server/lib/chat-attachments.ts
+++ b/templates/slides/server/lib/chat-attachments.ts
@@ -100,7 +100,7 @@ export async function prepareSlidesChatAttachments(args: {
           "File handling rules:",
           "- If the request refers to the current or visible deck, call `view-screen` first to confirm the active deckId, then pass that deckId to import or slide-edit actions.",
           '- PPTX files: call `import-pptx --filePath "<path>" --deckId <deckId>` when updating the visible deck, or omit deckId only when the user explicitly wants a new deck.',
-          '- PDF and DOCX files: call `import-file --filePath "<path>" --format auto --deckId <deckId>` and use the returned full text as source material before creating slides. If the user wants a direct replacement import, pass `--importIntoDeck true` as well.',
+          '- PDF and DOCX files: call `import-file --filePath "<path>" --format auto --deckId <deckId>` and use the returned extracted text as source material before creating slides. The returned text is capped for reliability; re-run with maxChars only if more context is needed. If the user wants a direct replacement import, pass `--importIntoDeck true` as well.',
           '- Figma `.fig` files: call `import-file --filePath "<path>" --format fig`, then call `create-design-system` with the returned `designSystem` data and `customInstructions`.',
           "- For deck-generation requests, start mutating promptly: create or update the first slide as soon as source material is extracted, then continue slide-by-slide with add-slide/update-slide.",
           '- Image files with an embeddable URL can be inserted directly into slide HTML as `<img src="...">` or used as visual references.',

--- a/templates/slides/server/lib/chat-attachments.ts
+++ b/templates/slides/server/lib/chat-attachments.ts
@@ -133,10 +133,22 @@ function stripForwardedAttachmentData(
   saved: { path: string; url?: string },
 ): AgentChatAttachment {
   const next = { ...attachment };
-  delete next.data;
+  // Keep image data for the current model turn when storage only gives Slides
+  // an import path. A hosted URL is the replacement that lets us strip it.
+  if (saved.url || !isVisualAttachment(attachment)) {
+    delete next.data;
+  }
   (next as any).slidesUploadPath = saved.path;
   if (saved.url) {
     (next as any).url = saved.url;
   }
   return next;
+}
+
+function isVisualAttachment(attachment: AgentChatAttachment): boolean {
+  return (
+    attachment.type === "image" ||
+    (typeof attachment.contentType === "string" &&
+      attachment.contentType.toLowerCase().startsWith("image/"))
+  );
 }

--- a/templates/slides/server/lib/chat-attachments.ts
+++ b/templates/slides/server/lib/chat-attachments.ts
@@ -33,7 +33,7 @@ export async function prepareSlidesChatAttachments(args: {
   ownerEmail: string | null;
   message: string;
   attachments: AgentChatAttachment[];
-}): Promise<{ message?: string } | void> {
+}): Promise<{ message?: string; attachments?: AgentChatAttachment[] } | void> {
   if (!args.ownerEmail || args.attachments.length === 0) return;
 
   const uploaded: Array<{
@@ -44,8 +44,11 @@ export async function prepareSlidesChatAttachments(args: {
     size: number;
   }> = [];
   const failed: Array<{ name: string; reason: string }> = [];
+  const nextAttachments = [...args.attachments];
 
-  for (const attachment of args.attachments) {
+  for (let index = 0; index < args.attachments.length; index++) {
+    const attachment = args.attachments[index];
+    if (!attachment) continue;
     const dataUrl = attachmentDataUrl(attachment);
     if (!dataUrl) continue;
 
@@ -63,14 +66,14 @@ export async function prepareSlidesChatAttachments(args: {
     }
 
     try {
-      uploaded.push(
-        await saveUploadedReferenceFile({
-          email: args.ownerEmail,
-          originalName: attachment.name,
-          data: decoded.bytes,
-          type: attachment.contentType || decoded.contentType,
-        }),
-      );
+      const saved = await saveUploadedReferenceFile({
+        email: args.ownerEmail,
+        originalName: attachment.name,
+        data: decoded.bytes,
+        type: attachment.contentType || decoded.contentType,
+      });
+      uploaded.push(saved);
+      nextAttachments[index] = stripForwardedAttachmentData(attachment, saved);
     } catch (error) {
       failed.push({
         name: attachment.name,
@@ -119,5 +122,21 @@ export async function prepareSlidesChatAttachments(args: {
     .filter(Boolean)
     .join("\n");
 
-  return { message: `${args.message}\n\n${attachmentContext}` };
+  return {
+    message: `${args.message}\n\n${attachmentContext}`,
+    attachments: nextAttachments,
+  };
+}
+
+function stripForwardedAttachmentData(
+  attachment: AgentChatAttachment,
+  saved: { path: string; url?: string },
+): AgentChatAttachment {
+  const next = { ...attachment };
+  delete next.data;
+  (next as any).slidesUploadPath = saved.path;
+  if (saved.url) {
+    (next as any).url = saved.url;
+  }
+  return next;
 }

--- a/templates/slides/server/plugins/core-routes.ts
+++ b/templates/slides/server/plugins/core-routes.ts
@@ -16,7 +16,6 @@ export default createCoreRoutesPlugin({
         : "";
       return `/deck/${params.deckId}${suffix}${query}`;
     }
-    if (view === "settings") return "/settings";
     if (view === "editor" || view === "present" || view === "list") return "/";
     return null;
   },


### PR DESCRIPTION
## Summary
- add Content as an app-backed skill with local-file install mode and generated agent-native.json defaults
- support positional JSON input for action/script runner calls and fix Codex CLI approval flag ordering
- surface Clips generated workflow output, AI provider setup, and Builder onboarding guidance
- cap Slides imported source text and tighten Slides navigation/import guidance

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/cli/skills.spec.ts src/cli/skills.sync.spec.ts
- pnpm --filter @agent-native/core exec vitest --run src/cli/code-agent-executor.spec.ts src/scripts/runner.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/skills test && pnpm --filter @agent-native/skills typecheck
- pnpm --filter clips typecheck
- pnpm --filter content typecheck
- pnpm --filter @agent-native/docs typecheck
- pnpm --filter slides typecheck
- pnpm --filter slides exec vitest --run --passWithNoTests
- pnpm guard:workspace-skills
- pnpm dev:cli skills add content --mode local-files --client codex --scope project --dry-run --json --yes
- pnpm changeset:status

Note: clips vitest passed all tests but Vite reported known shutdown noise after completion.