### PR TITLE
feat(core): vendor-neutral render capability for web-request (draft)

### DIFF
--- a/.changeset/web-request-render.md
+++ b/.changeset/web-request-render.md
@@ -1,0 +1,7 @@
+---
+"@agent-native/core": minor
+---
+
+Add a vendor-neutral `render` capability to the `web-request` tool. Setting `render: true` (GET only) executes the page through a configured page renderer before extraction, so JavaScript-rendered SPAs and anti-bot-protected pages — which the built-in fetch + Readability path returns empty or blocked — extract correctly.
+
+The tool surface stays neutral: callers pass `render: true`, never a vendor name. Renderer backends are pluggable behind a `PageRenderer` abstraction (`web-render.ts`) and resolved at call time. This change ships one backend (Firecrawl, via `FIRECRAWL_API_KEY`); a browser-automation renderer (chrome-devtools / playwright) is the natural second backend and slots in at `RENDERER_FACTORIES` without touching the tool. The rendered HTML flows through the existing extraction pipeline, so all `responseMode`/`search`/`links`/`saveToFile` behavior is unchanged.

--- a/packages/core/src/extensions/fetch-tool.spec.ts
+++ b/packages/core/src/extensions/fetch-tool.spec.ts
@@ -49,6 +49,72 @@ describe("createFetchToolEntry", () => {
     );
   });
 
+  it("errors when render:true is requested with no configured renderer", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const entry = createFetchToolEntry({
+      resolveSecret: vi.fn().mockResolvedValue(null),
+    })["web-request"];
+
+    await expect(
+      entry.run({ url: "https://93.184.216.34/spa", render: true }),
+    ).resolves.toContain("render:true requires a configured page renderer");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects render for non-GET methods", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const entry = createFetchToolEntry({
+      resolveSecret: vi.fn(async () => "fc-key"),
+    })["web-request"];
+
+    await expect(
+      entry.run({
+        url: "https://93.184.216.34/api",
+        method: "POST",
+        render: true,
+      }),
+    ).resolves.toContain("render is supported for GET requests only");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders via a configured renderer and extracts the page when render:true", async () => {
+    // The Firecrawl backend is the configured renderer here (FIRECRAWL_API_KEY
+    // resolves); the tool surface stays neutral (render:true), and the rendered
+    // HTML flows through the normal extraction pipeline.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            html: "<html><body><article><h1>Rendered</h1><p>JS content.</p></article></body></html>",
+            metadata: { statusCode: 200 },
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const entry = createFetchToolEntry({
+      resolveSecret: vi.fn(async (key: string) =>
+        key === "FIRECRAWL_API_KEY" ? "fc-key" : null,
+      ),
+    })["web-request"];
+
+    const result = await entry.run({
+      url: "https://93.184.216.34/spa",
+      render: true,
+    });
+
+    // Routed through the renderer backend, not a direct fetch of the page.
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(String(fetchSpy.mock.calls[0][0])).toBe(
+      "https://api.firecrawl.dev/v2/scrape",
+    );
+    // Rendered HTML flowed through the normal extraction pipeline.
+    expect(result).toContain("HTTP 200");
+    expect(result).toContain("Rendered");
+    expect(result).toContain("JS content.");
+  });
+
   it("blocks redirects to private/internal addresses", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(null, {

--- a/packages/core/src/extensions/fetch-tool.ts
+++ b/packages/core/src/extensions/fetch-tool.ts
@@ -29,6 +29,7 @@ import {
   parseWebContentSearchOptions,
   processWebContent,
 } from "./web-content.js";
+import { resolvePageRenderer } from "./web-render.js";
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 
@@ -80,6 +81,11 @@ export interface FetchToolOptions {
   }>;
   /** Validate URL against per-key allowlists. */
   validateUrl?: (url: string, usedKeys: string[]) => Promise<boolean>;
+  /**
+   * Resolve a request-scoped secret by key. Used by the `render` capability to
+   * find a configured page-renderer backend (e.g. a backend's API key).
+   */
+  resolveSecret?: (key: string) => Promise<string | null>;
 }
 
 /**
@@ -91,7 +97,7 @@ export function createFetchToolEntry(
   return {
     "web-request": {
       tool: {
-        description: `Make an outbound HTTP request to any EXTERNAL URL — APIs, webhooks, and arbitrary web pages (HTML, RSS, JSON, etc.). Use this to fetch the contents of a URL the user pastes in chat. Sends realistic Chrome-on-macOS headers by default (User-Agent, Accept, Sec-Fetch-*) so most sites that block obvious bots will respond normally; pass an explicit header to override any default. Supports \${keys.NAME} placeholders in url, headers, and body — these are resolved server-side from the user's saved keys (the raw value never enters your context). Example: \${keys.SLACK_WEBHOOK} in the url field. IMPORTANT: Never use this to call internal /_agent-native/ endpoints or localhost action URLs — use the registered actions directly (e.g. \`search-records\`, \`provider-api-request\`, \`update-resource\`). Actions are already available as native tools; calling them via HTTP is slower and bypasses validation.`,
+        description: `Make an outbound HTTP request to any EXTERNAL URL — APIs, webhooks, and arbitrary web pages (HTML, RSS, JSON, etc.). Use this to fetch the contents of a URL the user pastes in chat. Sends realistic Chrome-on-macOS headers by default (User-Agent, Accept, Sec-Fetch-*) so most sites that block obvious bots will respond normally; pass an explicit header to override any default. For JavaScript-rendered SPAs or pages that come back empty/blocked with a normal request, set render:true to execute the page first (GET only; requires a configured page renderer). Supports \${keys.NAME} placeholders in url, headers, and body — these are resolved server-side from the user's saved keys (the raw value never enters your context). Example: \${keys.SLACK_WEBHOOK} in the url field. IMPORTANT: Never use this to call internal /_agent-native/ endpoints or localhost action URLs — use the registered actions directly (e.g. \`search-records\`, \`provider-api-request\`, \`update-resource\`). Actions are already available as native tools; calling them via HTTP is slower and bypasses validation.`,
         parameters: {
           type: "object" as const,
           properties: {
@@ -118,6 +124,11 @@ export function createFetchToolEntry(
             timeout_ms: {
               type: "number",
               description: `Timeout in milliseconds. Default: ${DEFAULT_TIMEOUT_MS}. Max: 30000.`,
+            },
+            render: {
+              type: "boolean",
+              description:
+                "Execute JavaScript and bypass anti-bot before extracting, using a configured page renderer. Default: false. Use for SPAs or pages that return empty/blocked content with a normal request. GET only.",
             },
             maxChars: {
               type: "number",
@@ -237,6 +248,23 @@ export function createFetchToolEntry(
           return `Requests to private/internal addresses are not allowed: "${rawUrl}".`;
         }
 
+        // Optional render capability. Vendor-neutral: pick whatever page
+        // renderer is configured. GET only — rendering a POST/PUT body is not
+        // meaningful, so those stay on the built-in fetch path.
+        const renderWanted = parseBooleanArg(args.render);
+        let renderer: Awaited<ReturnType<typeof resolvePageRenderer>> = null;
+        if (renderWanted) {
+          if (method !== "GET") {
+            return "render is supported for GET requests only. Retry without render, or use GET.";
+          }
+          renderer = await resolvePageRenderer({
+            resolveSecret: opts.resolveSecret,
+          });
+          if (!renderer) {
+            return "render:true requires a configured page renderer. Add a renderer backend (e.g. set FIRECRAWL_API_KEY in Settings), or retry without render.";
+          }
+        }
+
         // Validate URL against per-key allowlists
         if (opts.validateUrl && allUsedKeys.length > 0) {
           try {
@@ -268,22 +296,34 @@ export function createFetchToolEntry(
         const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
         try {
-          const dispatcher = (await createSsrfSafeDispatcher()) ?? undefined;
-          const fetchOpts: RequestInit & { dispatcher?: unknown } = {
-            method,
-            headers,
-            signal: controller.signal,
-            redirect: "manual",
-          };
-          if (dispatcher) fetchOpts.dispatcher = dispatcher;
-          if (resolvedBody && ["POST", "PUT", "PATCH"].includes(method)) {
-            fetchOpts.body = resolvedBody;
-            if (!headers["content-type"] && !headers["Content-Type"]) {
-              headers["Content-Type"] = "application/json";
+          let response: Response;
+          if (renderer) {
+            // Renderer executes the page and returns HTML; the synthetic
+            // Response flows through the same post-processing pipeline as a
+            // normal fetch (extraction, markdown/links/matches, saveToFile).
+            const page = await renderer.render(resolvedUrl, { timeoutMs });
+            response = new Response(page.html, {
+              status: page.status,
+              headers: { "Content-Type": "text/html; charset=utf-8" },
+            });
+          } else {
+            const dispatcher = (await createSsrfSafeDispatcher()) ?? undefined;
+            const fetchOpts: RequestInit & { dispatcher?: unknown } = {
+              method,
+              headers,
+              signal: controller.signal,
+              redirect: "manual",
+            };
+            if (dispatcher) fetchOpts.dispatcher = dispatcher;
+            if (resolvedBody && ["POST", "PUT", "PATCH"].includes(method)) {
+              fetchOpts.body = resolvedBody;
+              if (!headers["content-type"] && !headers["Content-Type"]) {
+                headers["Content-Type"] = "application/json";
+              }
             }
-          }
 
-          const response = await fetch(resolvedUrl, fetchOpts);
+            response = await fetch(resolvedUrl, fetchOpts);
+          }
           const elapsed = Date.now() - startTime;
 
           if (response.status >= 300 && response.status < 400) {
@@ -353,7 +393,7 @@ export function createFetchToolEntry(
 
           // Audit log
           console.log(
-            `[fetch-tool] ${method} ${rawUrl} → ${response.status} (${elapsed}ms, keys: ${allUsedKeys.join(",") || "none"})`,
+            `[fetch-tool] ${method}${renderer ? ` (render:${renderer.id})` : ""} ${rawUrl} → ${response.status} (${elapsed}ms, keys: ${allUsedKeys.join(",") || "none"})`,
           );
 
           // saveToFile: write full body to workspace and return compact summary.

--- a/packages/core/src/extensions/web-render.spec.ts
+++ b/packages/core/src/extensions/web-render.spec.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolvePageRenderer } from "./web-render.js";
+
+describe("resolvePageRenderer", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("returns null when no backend is configured", async () => {
+    const renderer = await resolvePageRenderer({
+      resolveSecret: vi.fn().mockResolvedValue(null),
+    });
+    expect(renderer).toBeNull();
+  });
+
+  it("resolves the Firecrawl backend when FIRECRAWL_API_KEY is present", async () => {
+    const renderer = await resolvePageRenderer({
+      resolveSecret: vi.fn(async (key: string) =>
+        key === "FIRECRAWL_API_KEY" ? "fc-key" : null,
+      ),
+    });
+    expect(renderer?.id).toBe("firecrawl");
+  });
+
+  it("honors the resolveSecret policy and does not fall back to env when a resolver is wired", async () => {
+    vi.stubEnv("FIRECRAWL_API_KEY", "env-fc-key");
+    const renderer = await resolvePageRenderer({
+      resolveSecret: vi.fn().mockResolvedValue(null),
+    });
+    expect(renderer).toBeNull();
+  });
+
+  it("renders HTML and preserves a body-safe upstream status", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            html: "<html><body><p>hi</p></body></html>",
+            metadata: { statusCode: 203 },
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const renderer = await resolvePageRenderer({
+      resolveSecret: vi.fn(async () => "fc-key"),
+    });
+    const page = await renderer!.render("https://example.com/spa", {
+      timeoutMs: 15_000,
+    });
+    expect(page.rendererId).toBe("firecrawl");
+    expect(page.status).toBe(203);
+    expect(page.html).toContain("<p>hi</p>");
+  });
+});

--- a/packages/core/src/extensions/web-render.ts
+++ b/packages/core/src/extensions/web-render.ts
@@ -1,0 +1,146 @@
+/**
+ * Page rendering — a vendor-neutral capability behind the `web-request` tool's
+ * `render` flag.
+ *
+ * The built-in `web-request` path is a plain header-spoofed fetch + Readability,
+ * which returns empty/blocked content on JavaScript-rendered SPAs and pages
+ * behind anti-bot middleware (Cloudflare, PerimeterX, Akamai). Rendering solves
+ * that by executing the page before extraction.
+ *
+ * The tool surface stays neutral: callers pass `render: true`, never a vendor
+ * name. A renderer is resolved at call time from whatever backend is configured.
+ * Backends are pluggable — Firecrawl is one; a browser-automation renderer
+ * (chrome-devtools / playwright, which the framework already ships) is the
+ * natural second backend and slots in at `RENDERER_FACTORIES` without touching
+ * the tool.
+ */
+
+export interface RenderedPage {
+  /** Fully-rendered HTML, ready for the normal extraction pipeline. */
+  html: string;
+  /** Upstream status when known; otherwise 200 (we did get rendered content). */
+  status: number;
+  /** Which backend produced this — for audit logging, not the agent surface. */
+  rendererId: string;
+}
+
+export interface PageRenderOptions {
+  timeoutMs: number;
+}
+
+export interface PageRenderer {
+  /** Stable id for logs (e.g. "firecrawl", "browser"). Never shown to the agent. */
+  id: string;
+  /** True when this backend has the credentials/runtime it needs. */
+  isConfigured(): Promise<boolean>;
+  render(url: string, opts: PageRenderOptions): Promise<RenderedPage>;
+}
+
+export interface RenderResolutionContext {
+  /** Resolve a request-scoped secret (e.g. a backend's API key). */
+  resolveSecret?: (key: string) => Promise<string | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Firecrawl backend
+// ---------------------------------------------------------------------------
+
+async function resolveBackendSecret(
+  key: string,
+  ctx: RenderResolutionContext,
+): Promise<string | null> {
+  // Mirror web-search's resolveSearchKey policy: when a request-scoped resolver
+  // is wired, its decision (including null) is final — no server-wide env
+  // override. Only fall back to env when no resolver is supplied (CLI/local).
+  if (ctx.resolveSecret) {
+    try {
+      return await ctx.resolveSecret(key);
+    } catch {
+      return null;
+    }
+  }
+  return process.env[key] || null;
+}
+
+function createFirecrawlRenderer(ctx: RenderResolutionContext): PageRenderer {
+  return {
+    id: "firecrawl",
+    async isConfigured() {
+      return Boolean(await resolveBackendSecret("FIRECRAWL_API_KEY", ctx));
+    },
+    async render(url, opts) {
+      const apiKey = await resolveBackendSecret("FIRECRAWL_API_KEY", ctx);
+      if (!apiKey) throw new Error("FIRECRAWL_API_KEY is not configured.");
+      const res = await fetch("https://api.firecrawl.dev/v2/scrape", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          url,
+          formats: ["html"],
+          onlyMainContent: false,
+        }),
+        // Rendering is slower than a raw fetch; give it at least 30s.
+        signal: AbortSignal.timeout(Math.max(opts.timeoutMs, 30_000)),
+      });
+      if (!res.ok) {
+        throw new Error(
+          `Firecrawl scrape error ${res.status}: ${await res.text()}`,
+        );
+      }
+      const data = (await res.json()) as {
+        success?: boolean;
+        error?: string;
+        data?: {
+          html?: string;
+          rawHtml?: string;
+          metadata?: { statusCode?: number };
+        };
+      };
+      if (data.success === false) {
+        throw new Error(
+          `Firecrawl scrape failed: ${data.error ?? "unknown error"}`,
+        );
+      }
+      const html = data.data?.html ?? data.data?.rawHtml ?? "";
+      // Preserve the upstream status when body-safe; otherwise 200. 204/304 and
+      // 1xx cannot carry a body.
+      const upstream = data.data?.metadata?.statusCode;
+      const status =
+        typeof upstream === "number" &&
+        upstream >= 200 &&
+        upstream <= 599 &&
+        upstream !== 204 &&
+        upstream !== 304
+          ? upstream
+          : 200;
+      return { html, status, rendererId: "firecrawl" };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Backends in priority order. Add a browser-automation renderer
+ * (chrome-devtools / playwright) here to make it the default and demote
+ * Firecrawl to a fallback, without changing the tool.
+ */
+const RENDERER_FACTORIES: Array<
+  (ctx: RenderResolutionContext) => PageRenderer
+> = [createFirecrawlRenderer];
+
+/** First configured renderer, or null when none is available. */
+export async function resolvePageRenderer(
+  ctx: RenderResolutionContext = {},
+): Promise<PageRenderer | null> {
+  for (const factory of RENDERER_FACTORIES) {
+    const renderer = factory(ctx);
+    if (await renderer.isConfigured()) return renderer;
+  }
+  return null;
+}

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -4047,7 +4047,10 @@ export function createAgentChatPlugin(
           await import("../extensions/fetch-tool.js");
         const { resolveKeyReferences, validateUrlAllowlist, getKeyAllowlist } =
           await import("../secrets/substitution.js");
+        const { resolveSecret: resolveFetchSecret } =
+          await import("./credential-provider.js");
         fetchTool = createFetchToolEntry({
+          resolveSecret: resolveFetchSecret,
           resolveKeys: async (text) =>
             resolveKeyReferences(
               text,


### PR DESCRIPTION
> **Draft — for design feedback, follow-up to #1351.** Opening this to show the vendor-neutral shape you described in the #1351 review before polishing. Happy to adjust the abstraction, backend priority, or how this should interplay with the existing browser automation.

## What

Adds a **vendor-neutral `render` capability** to the `web-request` tool. `render: true` (GET only) executes the page through a configured **page renderer** before extraction, so JavaScript-rendered SPAs and anti-bot-protected pages — which the built-in fetch + Readability path returns empty or blocked — extract correctly.

## Design — capability, not a brand

Per your review feedback, the tool surface stays neutral:

- The agent-facing parameter is `render: boolean`. **No vendor name** appears in the tool's parameters or the agent's vocabulary.
- Renderer backends are pluggable behind a `PageRenderer` abstraction (`web-render.ts`), resolved at call time via `resolvePageRenderer()`.
- This PR ships **one backend** (Firecrawl, via `FIRECRAWL_API_KEY`). A **browser-automation renderer** (chrome-devtools / playwright — the capability you noted the framework already has) is the natural second backend: it slots into `RENDERER_FACTORIES` without touching the tool, and putting it first there makes it the default with other backends as fallback.
- The rendered HTML is wrapped in a synthetic `Response` and flows through the **existing** extraction pipeline, so all `responseMode` / `search` / `links` / `saveToFile` behavior is unchanged.

```
web-request { render: true }  →  resolvePageRenderer()  →  [ firecrawl, …browser-automation ]
                                                            first configured wins
```

## Open questions for you

1. **Default backend.** Should the browser-automation renderer be the default (Firecrawl as opt-in fallback), or selected by availability? Right now resolution is first-configured-wins over `RENDERER_FACTORIES`; I left Firecrawl as the only entry since I didn't want to wire into the browser-automation internals speculatively.
2. **Backend selection surface.** If multiple renderers are configured, do you want an explicit (still-neutral) selector — e.g. a `renderer` enum, or a workspace setting — or is first-available fine?
3. **Capability parity.** You noted Firecrawl should match the browser-automation capabilities to qualify as a backend. Happy to align the `PageRenderer` interface with whatever that contract should expose (computed styles, screenshots, etc.).

## Changes

- `web-render.ts` (new) — `PageRenderer` abstraction, Firecrawl backend, `resolvePageRenderer()`. Honors the `resolveSecret` policy (no env override when a resolver is wired).
- `fetch-tool.ts` — neutral `render` param; resolves a renderer; GET-only guard; renderer output flows through the existing pipeline. Preserves body-safe upstream status.
- `agent-chat-plugin.ts` — passes the existing `resolveSecret` credential provider into the fetch tool.
- Specs: `web-render.spec.ts` (resolver + backend) and `fetch-tool.spec.ts` (no-renderer error, non-GET rejection, render-and-extract path).
- Changeset (`@agent-native/core`, minor).

## Test plan

- `vitest run src/extensions/fetch-tool.spec.ts src/extensions/web-render.spec.ts` → **30/30 pass**.
- `prettier --write` + `tsc` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
