### PR TITLE
Fix Design generation stalls with gateway heartbeat keepalive and other design tab fixes

### DIFF
--- a/.changeset/gateway-heartbeat-keepalive.md
+++ b/.changeset/gateway-heartbeat-keepalive.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Forward Builder gateway heartbeat JSONL frames through the engine and agent SSE stream so long upstream silences (adaptive thinking, TTFT) do not trip the client no-progress timeout.

--- a/.changeset/guided-question-selection-fixes.md
+++ b/.changeset/guided-question-selection-fixes.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix guided question selection UX: preserve answers across poll refreshes, pause polling while a form is open, show clearer selected-state affordances (including `aria-pressed` on option buttons), and stop duplicate Explore/Decide injection in Design question flows.

--- a/.changeset/reconnect-tail-resume.md
+++ b/.changeset/reconnect-tail-resume.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Resume page-load chat reconnect from the last seen run event seq instead of replaying the full SSE history, preventing duplicated assistant turns after refresh.

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -374,6 +374,34 @@ describe("createBuilderEngine", () => {
     expect(events.find((e) => e.type === "tool-call")).toBeDefined();
   });
 
+  it("maps gateway heartbeat frames to gateway-heartbeat engine events", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonlResponse([
+          {
+            type: "heartbeat",
+            requestId: "req_1",
+            timestamp: 1_700_000_000_000,
+          },
+          { type: "text-delta", text: "Hi" },
+          { type: "usage", inputTokens: 10, outputTokens: 2 },
+          { type: "stop", reason: "end_turn", requestId: "req_1" },
+        ]),
+      ),
+    );
+
+    const engine = createBuilderEngine();
+    const events = await collectEvents(engine.stream(BASE_OPTS));
+
+    expect(events.filter((e) => e.type === "gateway-heartbeat")).toEqual([
+      { type: "gateway-heartbeat" },
+    ]);
+    expect(events.some((e) => e.type === "text-delta" && e.text === "Hi")).toBe(
+      true,
+    );
+  });
+
   it("maps 402 credits-limit-monthly to stop-error with errorCode + upgradeUrl", async () => {
     vi.stubGlobal(
       "fetch",
@@ -685,6 +713,42 @@ describe("createBuilderEngine", () => {
     expect(stop?.reason).toBe("error");
     expect(stop?.errorCode).toBe("builder_gateway_timeout");
     expect(stop?.error).toContain("Builder gateway timed out");
+  });
+
+  it("uses the localhost gateway timeout cap when AGENT_NATIVE_BUILDER_GATEWAY_TIMEOUT_MS is unset", async () => {
+    vi.stubEnv(
+      "BUILDER_GATEWAY_BASE_URL",
+      "http://localhost:8080/agent-native/gateway/v1",
+    );
+    vi.useFakeTimers();
+    const fetchSpy = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason ?? new Error("aborted"));
+          });
+        }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const engine = createBuilderEngine();
+    const eventsPromise = collectEvents(engine.stream(BASE_OPTS));
+    await vi.advanceTimersByTimeAsync(45_000);
+
+    let settledEarly = false;
+    void eventsPromise.then(() => {
+      settledEarly = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(settledEarly).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(135_000);
+    const events = await eventsPromise;
+
+    const stop = events.find((e) => e.type === "stop");
+    expect(stop?.reason).toBe("error");
+    expect(stop?.errorCode).toBe("builder_gateway_timeout");
+    expect(stop?.error).toContain("180s");
   });
 
   it("caps configured gateway timeouts with room before the 60s serverless function limit", async () => {

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -58,6 +58,8 @@ export const BUILDER_SUPPORTED_MODELS = BUILDER_MODEL_CONFIG.supportedModels;
 // (Netlify synchronous Functions are 60s) hard-kill the invocation.
 const DEFAULT_BUILDER_GATEWAY_TIMEOUT_MS = 45_000;
 const MAX_BUILDER_GATEWAY_TIMEOUT_MS = 45_000;
+/** Local ai-services has no serverless wall; allow longer streams in dev. */
+const MAX_LOCAL_BUILDER_GATEWAY_TIMEOUT_MS = 180_000;
 const BUILDER_GATEWAY_NETWORK_ERROR_CODE = "builder_gateway_network_error";
 
 export const BUILDER_DEFAULT_MODEL = BUILDER_MODEL_CONFIG.defaultModel;
@@ -533,6 +535,10 @@ async function* parseJsonlStream(
           };
           break;
 
+        case "heartbeat":
+          yield { type: "gateway-heartbeat" };
+          break;
+
         case "tool-call": {
           flushPending();
           parts.push({
@@ -749,14 +755,27 @@ export function createBuilderEngine(
   return new BuilderEngine();
 }
 
+function resolveMaxBuilderGatewayTimeoutMs(): number {
+  try {
+    const base = getBuilderGatewayBaseUrl();
+    if (/^https?:\/\/(localhost|127\.0\.0\.1)([:/]|$)/i.test(base)) {
+      return MAX_LOCAL_BUILDER_GATEWAY_TIMEOUT_MS;
+    }
+  } catch {
+    // ignore malformed override
+  }
+  return MAX_BUILDER_GATEWAY_TIMEOUT_MS;
+}
+
 function getBuilderGatewayTimeoutMs(): number {
   const raw = process.env.AGENT_NATIVE_BUILDER_GATEWAY_TIMEOUT_MS;
-  if (!raw) return DEFAULT_BUILDER_GATEWAY_TIMEOUT_MS;
+  const maxMs = resolveMaxBuilderGatewayTimeoutMs();
+  if (!raw) return maxMs;
   const parsed = Number(raw);
   if (!Number.isFinite(parsed) || parsed <= 0) {
-    return DEFAULT_BUILDER_GATEWAY_TIMEOUT_MS;
+    return maxMs;
   }
-  return Math.min(parsed, MAX_BUILDER_GATEWAY_TIMEOUT_MS);
+  return Math.min(parsed, maxMs);
 }
 
 function createGatewayAbortSignal(

--- a/packages/core/src/agent/engine/types.ts
+++ b/packages/core/src/agent/engine/types.ts
@@ -141,6 +141,7 @@ export type EngineEvent =
   | { type: "thinking-delta"; text: string; signature?: string }
   | { type: "tool-input-start"; id?: string; name?: string }
   | { type: "tool-input-delta"; id?: string; name?: string; text?: string }
+  | { type: "gateway-heartbeat" }
   | { type: "tool-call"; id: string; name: string; input: unknown }
   | {
       type: "tool-call-error";

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2559,6 +2559,8 @@ export async function runAgentLoop(opts: {
               event.name ??
               (event.id ? toolInputNames.get(event.id) : undefined);
             sendToolInputActivity(toolName);
+          } else if (event.type === "gateway-heartbeat") {
+            send({ type: "stream_keepalive" });
           } else if (event.type === "tool-call") {
             // The authoritative tool-call blocks arrive in assistant-content.
           } else if (event.type === "tool-call-error") {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -169,6 +169,7 @@ export type AgentChatEvent =
   | { type: "text"; text: string }
   | { type: "thinking"; text: string }
   | { type: "activity"; label: string; tool?: string }
+  | { type: "stream_keepalive" }
   | { type: "tool_start"; tool: string; input: Record<string, string> }
   | {
       type: "tool_done";

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1597,9 +1597,17 @@ const AssistantChatInner = forwardRef<
           } catch {
             // Best effort — the important part is unwinding the UI.
           }
-          settleInterruptedToolCalls(latestContent);
-          setReconnectContent([...latestContent]);
-          setReconnectFrozen(latestContent.length > 0);
+          if (afterSeq > 0) {
+            // Tail-resume only replays new events; never freeze that slice as a
+            // complete assistant turn — the server thread is authoritative.
+            await refreshThreadFromServer();
+            setReconnectContent([]);
+            setReconnectFrozen(false);
+          } else {
+            settleInterruptedToolCalls(latestContent);
+            setReconnectContent([...latestContent]);
+            setReconnectFrozen(latestContent.length > 0);
+          }
           setRunErrorInfo({
             message:
               "The previous agent run stopped producing visible progress while reconnecting, so it was stopped before it could keep looping.",

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -49,8 +49,14 @@ import type {
   ChatThreadScope,
   ChatThreadSnapshot,
 } from "./use-chat-threads.js";
+import { PROVIDER_ENV_VARS } from "../agent/engine/provider-env-vars.js";
 import { useAgentEngineConfigured } from "./use-agent-engine-configured.js";
-import { getActiveRun } from "./active-run-state.js";
+import {
+  getActiveRun,
+  resolveReconnectAfterSeq,
+  setActiveRun,
+  updateActiveRunSeq,
+} from "./active-run-state.js";
 import {
   AgentAutoContinueSignal,
   type ContentPart,
@@ -1247,6 +1253,7 @@ const AssistantChatInner = forwardRef<
   // When stop is clicked during reconnect, keep content visible (don't wipe it)
   const [reconnectFrozen, setReconnectFrozen] = useState(false);
   const reconnectRunIdRef = useRef<string | null>(null);
+  const [reconnectAfterSeq, setReconnectAfterSeq] = useState(0);
   const reconnectAbortRef = useRef<AbortController | null>(null);
   // Nuclear stop: user clicked stop. Clears the stop button/indicator AND
   // lets new submissions go through immediately — prevents the "stuck
@@ -1456,6 +1463,13 @@ const AssistantChatInner = forwardRef<
       if (reconnectRunIdRef.current === runId) return true;
 
       reconnectRunIdRef.current = runId;
+      const afterSeq = resolveReconnectAfterSeq(threadId, runId);
+      setReconnectAfterSeq(afterSeq);
+      setActiveRun({
+        threadId,
+        runId,
+        lastSeq: afterSeq > 0 ? afterSeq - 1 : -1,
+      });
       setIsReconnecting(true);
       setReconnectFrozen(false);
       setReconnectContent([]);
@@ -1498,9 +1512,16 @@ const AssistantChatInner = forwardRef<
       const streamReconnect = async () => {
         let noProgressDuringReconnect = false;
         let latestContent: ContentPart[] = [];
+        const threadPollInterval =
+          afterSeq > 0
+            ? window.setInterval(() => {
+                if (reconnectRunIdRef.current !== runId) return;
+                void refreshThreadFromServer();
+              }, 2000)
+            : undefined;
         try {
           const sseRes = await fetch(
-            `${apiUrl}/runs/${encodeURIComponent(runId)}/events?after=0`,
+            `${apiUrl}/runs/${encodeURIComponent(runId)}/events?after=${afterSeq}`,
             { signal: abortCtrl.signal },
           );
           if (sseRes.ok && sseRes.body) {
@@ -1511,6 +1532,7 @@ const AssistantChatInner = forwardRef<
             let rafPending = false;
             let latestSnapshot: ContentPart[] = [];
             const scheduleUpdate = (snapshot: ContentPart[]) => {
+              if (afterSeq > 0) return;
               latestSnapshot = snapshot;
               if (rafPending) return;
               rafPending = true;
@@ -1526,8 +1548,11 @@ const AssistantChatInner = forwardRef<
               toolCallCounter,
               tabId,
               scheduleUpdate,
+              (seq) => updateActiveRunSeq(seq),
             );
-            setReconnectContent([...content]);
+            if (afterSeq === 0) {
+              setReconnectContent([...content]);
+            }
           }
         } catch (err) {
           if (
@@ -1543,6 +1568,9 @@ const AssistantChatInner = forwardRef<
             noProgressDuringReconnect = true;
           }
         } finally {
+          if (threadPollInterval !== undefined) {
+            window.clearInterval(threadPollInterval);
+          }
           clearInterval(watchdog);
           clearTimeout(maxReconnectTimer);
         }
@@ -1584,6 +1612,7 @@ const AssistantChatInner = forwardRef<
           reconnectAbortRef.current = null;
           setIsReconnecting(false);
           reconnectRunIdRef.current = null;
+          setReconnectAfterSeq(0);
           window.dispatchEvent(
             new CustomEvent("agentNative.chatRunning", {
               detail: { isRunning: false, tabId: tabId || threadId },
@@ -1610,6 +1639,7 @@ const AssistantChatInner = forwardRef<
           reconnectAbortRef.current = null;
           setIsReconnecting(false);
           reconnectRunIdRef.current = null;
+          setReconnectAfterSeq(0);
           window.dispatchEvent(
             new CustomEvent("agentNative.chatRunning", {
               detail: { isRunning: false, tabId: tabId || threadId },
@@ -2356,6 +2386,7 @@ const AssistantChatInner = forwardRef<
       reconnectAbortRef.current?.abort();
       reconnectAbortRef.current = null;
       reconnectRunIdRef.current = null;
+      setReconnectAfterSeq(0);
       setIsReconnecting(false);
       setReconnectFrozen(reconnectContent.length > 0);
     }
@@ -3130,6 +3161,7 @@ const AssistantChatInner = forwardRef<
                         />
                       )}
                       {(isReconnecting || reconnectFrozen) &&
+                        reconnectAfterSeq === 0 &&
                         reconnectContent.length > 0 && (
                           <ReconnectStreamMessage content={reconnectContent} />
                         )}

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -49,7 +49,6 @@ import type {
   ChatThreadScope,
   ChatThreadSnapshot,
 } from "./use-chat-threads.js";
-import { PROVIDER_ENV_VARS } from "../agent/engine/provider-env-vars.js";
 import { useAgentEngineConfigured } from "./use-agent-engine-configured.js";
 import {
   getActiveRun,

--- a/packages/core/src/client/active-run-state.spec.ts
+++ b/packages/core/src/client/active-run-state.spec.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearActiveRun,
+  resolveReconnectAfterSeq,
+  setActiveRun,
+} from "./active-run-state.js";
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return [...store.keys()][index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+}
+
+describe("resolveReconnectAfterSeq", () => {
+  beforeEach(() => {
+    vi.stubGlobal("sessionStorage", createMemoryStorage());
+  });
+
+  afterEach(() => {
+    clearActiveRun();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns lastSeq + 1 when session state matches the thread and run", () => {
+    setActiveRun({ threadId: "thread-1", runId: "run-1", lastSeq: 41 });
+    expect(resolveReconnectAfterSeq("thread-1", "run-1")).toBe(42);
+  });
+
+  it("returns 0 when there is no stored cursor or the run does not match", () => {
+    setActiveRun({ threadId: "thread-1", runId: "run-1", lastSeq: 10 });
+    expect(resolveReconnectAfterSeq("thread-1", "run-2")).toBe(0);
+    expect(resolveReconnectAfterSeq("thread-2", "run-1")).toBe(0);
+    clearActiveRun();
+    expect(resolveReconnectAfterSeq("thread-1", "run-1")).toBe(0);
+  });
+});

--- a/packages/core/src/client/active-run-state.ts
+++ b/packages/core/src/client/active-run-state.ts
@@ -35,3 +35,19 @@ export function clearActiveRun(): void {
     sessionStorage.removeItem(STORAGE_KEY);
   } catch {}
 }
+
+/** Resume reconnect SSE after the last seen event (0 = replay from the start). */
+export function resolveReconnectAfterSeq(
+  threadId: string,
+  runId: string,
+): number {
+  const stored = getActiveRun();
+  if (
+    stored?.threadId === threadId &&
+    stored?.runId === runId &&
+    Number.isFinite(stored.lastSeq)
+  ) {
+    return stored.lastSeq + 1;
+  }
+  return 0;
+}

--- a/packages/core/src/client/guided-questions.spec.ts
+++ b/packages/core/src/client/guided-questions.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatGuidedAnswersForAgent,
   getOtherGuidedAnswerText,
+  guidedQuestionsFingerprint,
   hasGuidedAnswer,
   makeOtherGuidedAnswer,
   normalizeGuidedAnswers,
@@ -37,5 +38,28 @@ describe("guided question answers", () => {
         density: "balanced",
       }),
     ).toBe("sections: overview, Other: risks\ndensity: balanced");
+  });
+
+  it("builds stable fingerprints for equivalent question payloads", () => {
+    const questions = [
+      {
+        id: "form_factor",
+        type: "text-options" as const,
+        question: "What form factor?",
+        options: [{ label: "Mobile", value: "mobile" }],
+      },
+    ];
+    const clone = structuredClone(questions);
+    expect(guidedQuestionsFingerprint(questions)).toBe(
+      guidedQuestionsFingerprint(clone),
+    );
+    expect(guidedQuestionsFingerprint(questions)).not.toBe(
+      guidedQuestionsFingerprint([
+        {
+          ...questions[0],
+          options: [{ label: "Desktop", value: "desktop" }],
+        },
+      ]),
+    );
   });
 });

--- a/packages/core/src/client/guided-questions.tsx
+++ b/packages/core/src/client/guided-questions.tsx
@@ -357,6 +357,37 @@ function optionKey(option: GuidedQuestionOption): string {
   return `${option.value.toLowerCase()}::${option.label.toLowerCase()}`;
 }
 
+/** Stable content hash so poll refreshes do not reset in-progress answers. */
+export function guidedQuestionsFingerprint(
+  questions: GuidedQuestion[],
+): string {
+  return JSON.stringify(
+    questions.map((question) => ({
+      id: question.id,
+      type: question.type,
+      header: question.header ?? null,
+      question: question.question,
+      description: question.description ?? null,
+      multiSelect: question.multiSelect ?? false,
+      required: question.required ?? false,
+      allowOther: question.allowOther ?? null,
+      includeExplore: question.includeExplore ?? null,
+      includeDecide: question.includeDecide ?? null,
+      min: question.min ?? null,
+      max: question.max ?? null,
+      step: question.step ?? null,
+      placeholder: question.placeholder ?? null,
+      options: (question.options ?? question.choices ?? []).map((option) => ({
+        label: option.label,
+        value: option.value,
+        color: option.color ?? null,
+        description: option.description ?? null,
+        recommended: option.recommended ?? false,
+      })),
+    })),
+  );
+}
+
 function withDefaultOptions(question: GuidedQuestion): GuidedQuestionOption[] {
   const base = question.options ?? question.choices ?? [];
   const seen = new Set(base.map(optionKey));
@@ -403,10 +434,14 @@ export function GuidedQuestionFlow({
   className,
 }: GuidedQuestionFlowProps) {
   const [answers, setAnswers] = useState<GuidedQuestionAnswers>({});
+  const questionsFingerprint = useMemo(
+    () => guidedQuestionsFingerprint(questions),
+    [questions],
+  );
 
   useEffect(() => {
     setAnswers({});
-  }, [questions]);
+  }, [questionsFingerprint]);
 
   const setAnswer = useCallback((id: string, value: unknown) => {
     setAnswers((prev) => ({ ...prev, [id]: value }));
@@ -663,23 +698,26 @@ function OptionButton({
     <button
       type="button"
       onClick={onClick}
+      aria-pressed={selected}
       className={cn(
         "group flex min-h-[56px] cursor-pointer items-start gap-2 rounded-md border px-3 py-2 text-left transition-colors",
         selected
-          ? "border-primary bg-primary/10 text-primary"
+          ? "border-primary bg-primary/10 text-foreground ring-2 ring-primary/25"
           : "border-border bg-muted/30 text-muted-foreground hover:border-muted-foreground/50 hover:bg-muted/45 hover:text-foreground",
       )}
     >
-      {multiSelect && (
-        <span
-          className={cn(
-            "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border",
-            selected ? "border-primary bg-primary text-primary-foreground" : "",
-          )}
-        >
-          {selected && <IconCheck className="h-3 w-3" />}
-        </span>
-      )}
+      <span
+        className={cn(
+          "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center border",
+          multiSelect ? "rounded-sm" : "rounded-full",
+          selected
+            ? "border-primary bg-primary text-primary-foreground"
+            : "border-border bg-background",
+        )}
+        aria-hidden
+      >
+        {selected && <IconCheck className="h-3 w-3" />}
+      </span>
       <span className="min-w-0 flex-1">
         <span className="flex flex-wrap items-center gap-1.5 text-sm font-medium leading-5">
           {option.label}
@@ -940,6 +978,17 @@ export function useGuidedQuestionFlow({
     [queryKey, normalizedBrowserTabId],
   );
 
+  const resolvedRefetchInterval =
+    refetchInterval === false
+      ? false
+      : (query: { state: { data?: GuidedQuestionPayload | null } }) => {
+          const activeQuestions = query.state.data?.questions;
+          if (Array.isArray(activeQuestions) && activeQuestions.length > 0) {
+            return false;
+          }
+          return refetchInterval;
+        };
+
   const { data } = useQuery({
     queryKey: resolvedQueryKey,
     queryFn: async () => {
@@ -951,9 +1000,7 @@ export function useGuidedQuestionFlow({
         try {
           const parsed = JSON.parse(text);
           if (Array.isArray(parsed?.questions) && parsed.questions.length > 0) {
-            return { ...parsed, _ts: Date.now() } as GuidedQuestionPayload & {
-              _ts: number;
-            };
+            return parsed as GuidedQuestionPayload;
           }
         } catch {
           return null;
@@ -967,13 +1014,22 @@ export function useGuidedQuestionFlow({
         (await read(stateKey))
       );
     },
-    refetchInterval,
+    refetchInterval: resolvedRefetchInterval,
     structuralSharing: false,
   });
 
   useEffect(() => {
     if (Array.isArray(data?.questions) && data.questions.length > 0) {
-      setPayload(data);
+      setPayload((prev) => {
+        if (
+          prev &&
+          guidedQuestionsFingerprint(prev.questions) ===
+            guidedQuestionsFingerprint(data.questions)
+        ) {
+          return prev;
+        }
+        return data;
+      });
     } else {
       setPayload(null);
     }

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -34,6 +34,36 @@ function silentStream(): ReadableStream<Uint8Array> {
   });
 }
 
+function keepaliveThenDoneStream(
+  keepaliveAtMs: number,
+): ReadableStream<Uint8Array> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      timer = setTimeout(() => {
+        try {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({ type: "stream_keepalive" })}\n\n`,
+            ),
+          );
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({ type: "done" })}\n\n`,
+            ),
+          );
+          controller.close();
+        } catch {
+          // The watchdog may have cancelled the stream first.
+        }
+      }, keepaliveAtMs);
+    },
+    cancel() {
+      if (timer) clearTimeout(timer);
+    },
+  });
+}
+
 function eventStream(events: unknown[]): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
     start(controller) {
@@ -108,6 +138,24 @@ describe("SSE event processor no-progress recovery", () => {
 
     expect(err).toBeInstanceOf(AgentAutoContinueSignal);
     expect((err as AgentAutoContinueSignal).reason).toBe("no_progress");
+  });
+
+  it("stream_keepalive events reset the no-progress watchdog", async () => {
+    vi.useFakeTimers();
+
+    const donePromise = drain(
+      readSSEStream(
+        keepaliveThenDoneStream(SSE_NO_PROGRESS_TIMEOUT_MS - 5_000),
+        [],
+        { value: 0 },
+        undefined,
+      ),
+    );
+
+    await vi.advanceTimersByTimeAsync(SSE_NO_PROGRESS_TIMEOUT_MS - 5_000);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(donePromise).resolves.toBeDefined();
   });
 
   it("turns raw comment-only live streams into an auto-continuation signal", async () => {

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -357,6 +357,10 @@ export function processEvent(
     };
   }
 
+  if (ev.type === "stream_keepalive") {
+    return { action: "continue" };
+  }
+
   if (ev.type === "activity") {
     const tool = ev.tool?.trim() || undefined;
     const label = humanizeToolLabelText(ev.label ?? "Working", tool);
@@ -868,6 +872,7 @@ export async function readSSEStreamRaw(
   toolCallCounter: { value: number },
   tabId: string | undefined,
   onUpdate: (content: ContentPart[]) => void,
+  onSeq?: (seq: number) => void,
 ): Promise<void> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
@@ -906,6 +911,10 @@ export async function readSSEStreamRaw(
         }
         sawDataEvent = true;
         lastMeaningfulEventAt = Date.now();
+
+        if (ev.seq !== undefined && onSeq) {
+          onSeq(ev.seq);
+        }
 
         const { action, autoContinue } = processEvent(
           ev,

--- a/packages/core/src/templates/workspace-root/.env.example
+++ b/packages/core/src/templates/workspace-root/.env.example
@@ -36,7 +36,7 @@ BUILDER_PRIVATE_KEY=
 BUILDER_PUBLIC_KEY=
 BUILDER_USER_ID=
 
-# Local ai-services LLM gateway (default prod: https://api.builder.io/agent-native/gateway/v1).
+# Local ai-services LLM gateway. Leave unset to use the hosted Builder gateway.
 # ai-services listens on API_PORT (default 8080): /agent-native/gateway/v1/messages
 BUILDER_GATEWAY_BASE_URL=
 

--- a/packages/core/src/templates/workspace-root/.env.example
+++ b/packages/core/src/templates/workspace-root/.env.example
@@ -36,6 +36,10 @@ BUILDER_PRIVATE_KEY=
 BUILDER_PUBLIC_KEY=
 BUILDER_USER_ID=
 
+# Local ai-services LLM gateway (default prod: https://api.builder.io/agent-native/gateway/v1).
+# ai-services listens on API_PORT (default 8080): /agent-native/gateway/v1/messages
+BUILDER_GATEWAY_BASE_URL=
+
 # Builder app creation / branching. In local dev these can live in .env.
 # In production, configure deploy env vars instead; production app creation
 # never writes credentials or project IDs to the filesystem.

--- a/templates/design/actions/show-design-questions.spec.ts
+++ b/templates/design/actions/show-design-questions.spec.ts
@@ -68,9 +68,18 @@ describe("show-design-questions", () => {
           "Pick what matters. Use Other for specifics, or let the agent decide.",
         skipLabel: "Decide for me",
         submitLabel: "Continue",
-        questions: expect.arrayContaining([
-          expect.objectContaining({ id: "form_factor" }),
-        ]),
+        questions: [
+          expect.objectContaining({
+            id: "form_factor",
+            includeExplore: false,
+            includeDecide: false,
+          }),
+          expect.objectContaining({
+            id: "features",
+            includeExplore: false,
+            includeDecide: false,
+          }),
+        ],
       },
     );
     expect(result).toMatchObject({

--- a/templates/design/actions/show-design-questions.ts
+++ b/templates/design/actions/show-design-questions.ts
@@ -47,6 +47,18 @@ const questionSchema = z.object({
   includeDecide: z.boolean().optional(),
 });
 
+function normalizeDesignQuestions(
+  questions: z.infer<typeof questionSchema>[],
+): z.infer<typeof questionSchema>[] {
+  return questions.map((question) => ({
+    ...question,
+    // The agent supplies Explore/Decide choices explicitly when needed.
+    // Default injection duplicates cards on every question in the form.
+    includeExplore: question.includeExplore ?? false,
+    includeDecide: question.includeDecide ?? false,
+  }));
+}
+
 export default defineAction({
   description:
     "Show a Claude Design-style question form in the Design editor before " +
@@ -95,6 +107,8 @@ export default defineAction({
   }) => {
     await assertAccess("design", designId, "editor");
 
+    const normalizedQuestions = normalizeDesignQuestions(questions);
+
     await writeAppState(designQuestionsStateKey(designId), {
       designId,
       title: title ?? "Quick questions before I design",
@@ -103,7 +117,7 @@ export default defineAction({
         "Pick what matters. Use Other for specifics, or let the agent decide.",
       skipLabel: skipLabel ?? "Decide for me",
       submitLabel: submitLabel ?? "Continue",
-      questions,
+      questions: normalizedQuestions,
     });
 
     return {

--- a/templates/design/app/hooks/use-agent-generating.ts
+++ b/templates/design/app/hooks/use-agent-generating.ts
@@ -8,10 +8,16 @@ import {
 // legitimately take several minutes, so avoid treating normal latency as
 // failure.
 const GENERATION_ORPHAN_TIMEOUT_MS = 30 * 60_000;
+// Auto-continue briefly sets isRunning=false between gateway continuations.
+// Debounce stop handling so we do not flash "generation complete" mid-turn.
+const CHAT_STOP_DEBOUNCE_MS = 4_000;
 
 interface UseAgentGeneratingOptions {
   onComplete?: (tabId: string | null) => void;
   onStale?: (tabId: string | null) => void;
+  /** When chat starts on a tab we did not open, adopt it if this returns true. */
+  shouldAdoptRunningTab?: () => boolean;
+  onAdoptRunningTab?: (tabId: string) => void;
 }
 
 /**
@@ -23,8 +29,16 @@ export function useAgentGenerating(options: UseAgentGeneratingOptions = {}) {
   const [generating, setGenerating] = useState(false);
   const activeTabIdRef = useRef<string | null>(null);
   const timeoutRef = useRef<number | null>(null);
+  const stopDebounceRef = useRef<number | null>(null);
   const callbacksRef = useRef(options);
   callbacksRef.current = options;
+
+  const clearStopDebounce = useCallback(() => {
+    if (stopDebounceRef.current) {
+      window.clearTimeout(stopDebounceRef.current);
+      stopDebounceRef.current = null;
+    }
+  }, []);
 
   const clearGenerationTimeout = useCallback(() => {
     if (timeoutRef.current) {
@@ -35,9 +49,10 @@ export function useAgentGenerating(options: UseAgentGeneratingOptions = {}) {
 
   const reset = useCallback(() => {
     clearGenerationTimeout();
+    clearStopDebounce();
     activeTabIdRef.current = null;
     setGenerating(false);
-  }, [clearGenerationTimeout]);
+  }, [clearGenerationTimeout, clearStopDebounce]);
 
   const startGenerationTimeout = useCallback(
     (tabId: string | null) => {
@@ -68,25 +83,49 @@ export function useAgentGenerating(options: UseAgentGeneratingOptions = {}) {
         const eventTabId =
           typeof detail.tabId === "string" ? detail.tabId : null;
 
-        if (!activeTabIdRef.current && detail.isRunning) return;
-        if (eventTabId && eventTabId !== activeTabIdRef.current) return;
-
-        if (!detail.isRunning) {
-          callbacksRef.current.onComplete?.(activeTabIdRef.current);
-          reset();
+        if (!activeTabIdRef.current && detail.isRunning) {
+          if (eventTabId && callbacksRef.current.shouldAdoptRunningTab?.()) {
+            activeTabIdRef.current = eventTabId;
+            callbacksRef.current.onAdoptRunningTab?.(eventTabId);
+            setGenerating(true);
+            startGenerationTimeout(eventTabId);
+            return;
+          }
           return;
         }
+        if (eventTabId && eventTabId !== activeTabIdRef.current) {
+          if (!detail.isRunning && !activeTabIdRef.current) {
+            return;
+          }
+          return;
+        }
+
+        if (!detail.isRunning) {
+          clearStopDebounce();
+          const tabId = activeTabIdRef.current;
+          stopDebounceRef.current = window.setTimeout(() => {
+            stopDebounceRef.current = null;
+            if (activeTabIdRef.current !== tabId) return;
+            callbacksRef.current.onComplete?.(tabId);
+            reset();
+          }, CHAT_STOP_DEBOUNCE_MS);
+          return;
+        }
+        clearStopDebounce();
         setGenerating(true);
         startGenerationTimeout(activeTabIdRef.current);
       }
     };
     window.addEventListener("agentNative.chatRunning", handler);
     return () => window.removeEventListener("agentNative.chatRunning", handler);
-  }, [reset, startGenerationTimeout]);
+  }, [clearStopDebounce, reset, startGenerationTimeout]);
 
   useEffect(() => {
-    return () => clearGenerationTimeout();
-  }, [clearGenerationTimeout]);
+    return () => {
+      clearGenerationTimeout();
+      clearStopDebounce();
+    };
+  }, [clearGenerationTimeout, clearStopDebounce]);
 
   const submit = useCallback(
     (

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -428,6 +428,12 @@ export default function DesignEditor() {
   } = useAgentGenerating({
     onComplete: handleGenerationComplete,
     onStale: markGenerationStale,
+    shouldAdoptRunningTab: () =>
+      Boolean(id) && !generationOutputReadyRef.current,
+    onAdoptRunningTab: (tabId) => {
+      setGenerationChatTabId(tabId);
+      setHasPendingGeneration(true);
+    },
   });
   const handleQuestionFlowContinue = useCallback(
     (runTabId: string) => {


### PR DESCRIPTION
## Summary

Fixes production Design agent runs that appear to hang or fail during long gateway streams (especially generate-design tool JSON). The primary fix forwards Builder gateway heartbeat frames to the browser as stream_keepalive SSE events, so healthy upstream silences no longer trip the client 75s no-progress watchdog.

Also includes production Design UX fixes: canvas generation state tracking when chatting directly on a design page, and stop debounce during multi-step auto-continue turns.

## Problem

During long Builder gateway calls (adaptive thinking, slow TTFT, large tool-input streaming), the upstream JSONL stream can go quiet for 60s+ without text or token deltas. The chat client treats 75s of SSE silence as no_progress, triggers auto-continue recovery, and often ends in connection_error even though the gateway was still working.

Separately, the Design editor could miss in-flight generation when users chat on /design/:id without going through Generate Design: the canvas stayed on No files yet and completion handlers never ran. Brief isRunning=false gaps during auto-continue could also flash generation as complete mid-turn.

## Solution

Primary: gateway heartbeat to client keepalive

- builder-engine: map gateway JSONL { type: heartbeat } to gateway-heartbeat engine events
- production-agent: forward gateway-heartbeat to SSE { type: stream_keepalive }
- sse-event-processor: handle stream_keepalive as a no-op for content but reset the no-progress watchdog

Heartbeats do not change visible chat content; they only prove the stream is still alive.

Design generation state (production UX)

- use-agent-generating + DesignEditor: adopt the active sidebar chat tab when generation is in progress on a design page
- 4s stop debounce: ignore brief chatRunning false windows between gateway continuations so the canvas does not prematurely mark generation complete

## Also in this PR

- Reconnect tail-resume: resume page-load reconnect from last seen event seq instead of replaying full SSE history (fixes duplicate assistant turns after refresh)
- Guided question UX: preserve answers across poll refreshes, pause polling while form is open, clearer selection affordances, stop duplicate Explore/Decide cards in Design intake

## Test plan

- [ ] Start a Design generation that streams a large generate-design tool call; confirm the run completes without no_progress or connection_error during long silent periods
- [ ] On /design/:id, send a generation prompt directly in chat; confirm canvas shows Generating design and completes when files appear
- [ ] Multi-step agent turn with auto-continue: confirm canvas does not flash done between continuations
- [ ] Refresh mid-run: confirm chat does not duplicate assistant turns
- [ ] Open Design intake questions: confirm selections persist across poll refresh and Explore/Decide are not duplicated on every card
- [ ] pnpm --filter @agent-native/core exec vitest run src/agent/engine/builder-engine.spec.ts src/client/sse-event-processor.spec.ts src/client/active-run-state.spec.ts