### PR TITLE
Fix hosted signup tracking

### DIFF
--- a/.changeset/server-signup-tracking-flush.md
+++ b/.changeset/server-signup-tracking-flush.md
@@ -1,0 +1,7 @@
+---
+"@agent-native/core": patch
+---
+
+Track first-time Google OAuth signups and flush server-side signup tracking
+before auth returns so low-volume events are delivered reliably from serverless
+deployments.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -3227,6 +3227,101 @@ describe("server/auth", () => {
       expect(setCookie).toContain("an_session_slides=");
     });
 
+    it("tracks a first-time Google OAuth session as a signup", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("APP_NAME", "plan");
+
+      const mockExecute = vi.fn(async (query: { sql?: string } | string) => {
+        const sql = typeof query === "string" ? query : query.sql || "";
+        if (/SELECT 1 FROM sessions WHERE email = \?/i.test(sql)) {
+          return { rows: [] };
+        }
+        return { rows: [] };
+      });
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => false,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+
+      const trackSignupEvent = vi.fn(async () => {});
+      const hasBetterAuthUserEmail = vi.fn(async () => false);
+      vi.doMock("./better-auth-instance.js", () => ({
+        getBetterAuth: vi.fn(),
+        getBetterAuthSync: vi.fn(),
+        hasBetterAuthUserEmail,
+        trackSignupEvent,
+      }));
+
+      const { createOAuthSession } = await import("./google-oauth.js");
+      const event = createMockEvent({
+        headers: { "x-forwarded-proto": "https" },
+      });
+
+      await createOAuthSession(event, "user@gmail.com", {
+        hasProductionSession: false,
+        trackSignup: {
+          authProvider: "google",
+          authUserId: "google-user-1",
+          name: "Google User",
+        },
+      });
+
+      expect(hasBetterAuthUserEmail).toHaveBeenCalledWith("user@gmail.com");
+      expect(trackSignupEvent).toHaveBeenCalledWith({
+        authProvider: "google",
+        authUserId: "google-user-1",
+        email: "user@gmail.com",
+        name: "Google User",
+      });
+    });
+
+    it("does not track Google OAuth signup for an existing legacy session email", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+
+      const mockExecute = vi.fn(async (query: { sql?: string } | string) => {
+        const sql = typeof query === "string" ? query : query.sql || "";
+        if (/SELECT 1 FROM sessions WHERE email = \?/i.test(sql)) {
+          return { rows: [{ exists: 1 }] };
+        }
+        return { rows: [] };
+      });
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => false,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+
+      const trackSignupEvent = vi.fn(async () => {});
+      const hasBetterAuthUserEmail = vi.fn(async () => false);
+      vi.doMock("./better-auth-instance.js", () => ({
+        getBetterAuth: vi.fn(),
+        getBetterAuthSync: vi.fn(),
+        hasBetterAuthUserEmail,
+        trackSignupEvent,
+      }));
+
+      const { createOAuthSession } = await import("./google-oauth.js");
+      const event = createMockEvent({
+        headers: { "x-forwarded-proto": "https" },
+      });
+
+      await createOAuthSession(event, "user@gmail.com", {
+        hasProductionSession: false,
+        trackSignup: {
+          authProvider: "google",
+          authUserId: "google-user-1",
+          name: "Google User",
+        },
+      });
+
+      expect(trackSignupEvent).not.toHaveBeenCalled();
+    });
+
     it("ignores first-party shared cookie domains and sets an isolated app session", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("COOKIE_DOMAIN", ".agent-native.com");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -914,6 +914,20 @@ export async function addSession(token: string, email?: string): Promise<void> {
   );
 }
 
+export async function hasLegacySessionForEmail(
+  email: string,
+): Promise<boolean> {
+  await ensureSessionTable();
+  const client = getDbExec();
+  const result = await retryIfSessionsMissing(() =>
+    client.execute({
+      sql: `SELECT 1 FROM sessions WHERE email = ? LIMIT 1`,
+      args: [email],
+    }),
+  );
+  return result.rows.length > 0;
+}
+
 /** Remove a session from the legacy sessions table. */
 export async function removeSession(token: string): Promise<void> {
   await ensureSessionTable();
@@ -2682,6 +2696,11 @@ async function mountBetterAuthRoutes(
           const { sessionToken } = await createOAuthSession(event, email, {
             hasProductionSession: false,
             desktop,
+            trackSignup: {
+              authProvider: "google",
+              authUserId: typeof user.id === "string" ? user.id : undefined,
+              name: typeof user.name === "string" ? user.name : undefined,
+            },
           });
           logGoogleOAuthDebug(event, "callback-session-created", {
             flowId,

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -22,7 +22,7 @@ import { getDbExec, isPostgres } from "../db/client.js";
 import { acceptPendingInvitationsForEmail } from "../org/accept-pending.js";
 import { autoJoinDomainMatchingOrgs } from "../org/auto-join-domain.js";
 import { saveOAuthTokens } from "../oauth-tokens/store.js";
-import { identify, track } from "../tracking/index.js";
+import { flushTracking, identify, track } from "../tracking/index.js";
 import { TEMPLATES } from "../cli/templates-meta.js";
 import { resolveAuthCookieNamespace } from "./cookie-namespace.js";
 import { getWorkspaceA2ADerivedSecret } from "./derived-secret.js";
@@ -45,6 +45,54 @@ import {
   text as sqliteText,
   integer as sqliteInteger,
 } from "drizzle-orm/sqlite-core";
+
+async function flushSignupTracking(): Promise<void> {
+  try {
+    await Promise.race([
+      flushTracking(),
+      new Promise<void>((resolve) => setTimeout(resolve, 1500)),
+    ]);
+  } catch {
+    // Signup should never fail because analytics delivery did.
+  }
+}
+
+export async function hasBetterAuthUserEmail(email: string): Promise<boolean> {
+  const adapter = await getBetterAuthInternalAdapter().catch(() => undefined);
+  if (!adapter) return false;
+  const existing = await adapter
+    .findUserByEmail(email, { includeAccounts: false })
+    .catch(() => null);
+  return !!existing?.user?.email;
+}
+
+export async function trackSignupEvent({
+  authProvider,
+  authUserId,
+  email,
+  name,
+}: {
+  authProvider: string;
+  authUserId?: string;
+  email: string;
+  name?: string | null;
+}): Promise<void> {
+  identify(email, {
+    email,
+    name: name ?? undefined,
+    authUserId,
+  });
+  track(
+    "signup",
+    {
+      ...resolveSignupTrackingProperties(),
+      auth_provider: authProvider,
+      ...(authUserId ? { auth_user_id: authUserId } : {}),
+    },
+    { userId: email },
+  );
+  await flushSignupTracking();
+}
 
 // ---------------------------------------------------------------------------
 // Persistent auth secret
@@ -879,20 +927,12 @@ async function createBetterAuthInstance(
             // first page load instead of a blank-slate workspace.
             const email = user?.email;
             if (!email) return;
-            identify(email, {
-              email,
-              name: user.name ?? undefined,
+            await trackSignupEvent({
+              authProvider: "better-auth",
               authUserId: user.id,
+              email,
+              name: user.name,
             });
-            track(
-              "signup",
-              {
-                ...resolveSignupTrackingProperties(),
-                auth_provider: "better-auth",
-                auth_user_id: user.id,
-              },
-              { userId: email },
-            );
             try {
               await acceptPendingInvitationsForEmail(email);
             } catch (err) {

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -19,9 +19,14 @@ import {
   addSession,
   getSession,
   getSessionMaxAge,
+  hasLegacySessionForEmail,
   setFrameworkSessionCookie,
 } from "./auth.js";
 import { getAppName } from "./app-name.js";
+import {
+  hasBetterAuthUserEmail,
+  trackSignupEvent,
+} from "./better-auth-instance.js";
 import { getWorkspaceA2ADerivedSecret } from "./derived-secret.js";
 import { writeDesktopSso } from "./desktop-sso.js";
 import { appendSessionToOAuthReturnUrl } from "./oauth-return-url.js";
@@ -664,6 +669,11 @@ export async function createOAuthSession(
   opts: {
     hasProductionSession: boolean;
     desktop?: boolean;
+    trackSignup?: {
+      authProvider: string;
+      authUserId?: string;
+      name?: string | null;
+    };
   },
 ): Promise<OAuthSessionResult> {
   const mobile = isMobile(event);
@@ -671,10 +681,27 @@ export async function createOAuthSession(
   const maxAge = getSessionMaxAge();
 
   let sessionToken: string | undefined;
+  let shouldTrackSignup = false;
   if (!opts.hasProductionSession || needsDeepLink) {
+    if (opts.trackSignup && !opts.hasProductionSession) {
+      const [hasLegacySession, hasBetterAuthUser] = await Promise.all([
+        hasLegacySessionForEmail(email).catch(() => true),
+        hasBetterAuthUserEmail(email).catch(() => true),
+      ]);
+      shouldTrackSignup = !hasLegacySession && !hasBetterAuthUser;
+    }
+
     sessionToken = crypto.randomBytes(32).toString("hex");
     await addSession(sessionToken, email);
     setFrameworkSessionCookie(event, sessionToken);
+    if (shouldTrackSignup && opts.trackSignup) {
+      await trackSignupEvent({
+        authProvider: opts.trackSignup.authProvider,
+        authUserId: opts.trackSignup.authUserId,
+        email,
+        name: opts.trackSignup.name,
+      });
+    }
     // Desktop SSO: record this session in the home-dir broker file so
     // sibling templates (each with its own database) can resolve the
     // same token without a DB row of their own. Only the PRIMARY

--- a/packages/core/src/tracking/providers.spec.ts
+++ b/packages/core/src/tracking/providers.spec.ts
@@ -56,6 +56,40 @@ describe("tracking providers", () => {
     });
   });
 
+  it("waits for queued provider sends when flushing", async () => {
+    let resolveFetch: (() => void) | undefined;
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = () => resolve(new Response("{}"));
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("AGENT_NATIVE_ANALYTICS_PUBLIC_KEY", "anpk_test");
+    vi.stubEnv(
+      "AGENT_NATIVE_ANALYTICS_ENDPOINT",
+      "https://analytics.example.test/track",
+    );
+    const { flushTracking, registerBuiltinProviders, track } =
+      await freshTrackingModules();
+
+    registerBuiltinProviders();
+    track("qa.event", { app: "qa" }, { userId: "u1" });
+    let flushed = false;
+    const flushPromise = flushTracking().then(() => {
+      flushed = true;
+    });
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(flushed).toBe(false);
+
+    resolveFetch?.();
+    await flushPromise;
+
+    expect(flushed).toBe(true);
+  });
+
   it("does not register Agent Native Analytics for localhost app URLs", async () => {
     vi.stubEnv("AGENT_NATIVE_ANALYTICS_PUBLIC_KEY", "anpk_test");
     vi.stubEnv("APP_URL", "http://localhost:3000");

--- a/packages/core/src/tracking/providers.ts
+++ b/packages/core/src/tracking/providers.ts
@@ -63,15 +63,17 @@ function enqueue(
   const queue = getQueue();
   queue.push({ url, body, headers });
   if (queue.length >= MAX_BATCH_SIZE) {
-    drainQueue();
+    void drainQueue();
   } else if (!getTimer()) {
-    const timer = setTimeout(drainQueue, BATCH_INTERVAL_MS);
+    const timer = setTimeout(() => {
+      void drainQueue();
+    }, BATCH_INTERVAL_MS);
     if (timer.unref) timer.unref();
     setTimer(timer);
   }
 }
 
-function drainQueue(): void {
+function drainQueue(): Promise<void[]> {
   const t = getTimer();
   if (t) {
     clearTimeout(t);
@@ -79,13 +81,18 @@ function drainQueue(): void {
   }
   const queue = getQueue();
   const batch = queue.splice(0, queue.length);
-  for (const item of batch) {
-    fetch(item.url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...item.headers },
-      body: item.body,
-    }).catch(() => {});
-  }
+  return Promise.all(
+    batch.map((item) =>
+      fetch(item.url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...item.headers },
+        body: item.body,
+      }).then(
+        () => undefined,
+        () => undefined,
+      ),
+    ),
+  );
 }
 
 function isLocalhostUrl(value: string | undefined): boolean {
@@ -156,8 +163,7 @@ function createPostHogProvider(apiKey: string, host: string): TrackingProvider {
       );
     },
     flush: () => {
-      drainQueue();
-      return Promise.resolve();
+      return drainQueue().then(() => undefined);
     },
   };
 }
@@ -190,8 +196,7 @@ function createMixpanelProvider(token: string): TrackingProvider {
       enqueue("https://api.mixpanel.com/engage", JSON.stringify([data]));
     },
     flush: () => {
-      drainQueue();
-      return Promise.resolve();
+      return drainQueue().then(() => undefined);
     },
   };
 }
@@ -231,8 +236,7 @@ function createAmplitudeProvider(apiKey: string): TrackingProvider {
       enqueue("https://api2.amplitude.com/2/httpapi", JSON.stringify(data));
     },
     flush: () => {
-      drainQueue();
-      return Promise.resolve();
+      return drainQueue().then(() => undefined);
     },
   };
 }
@@ -271,8 +275,7 @@ function createWebhookProvider(
       );
     },
     flush: () => {
-      drainQueue();
-      return Promise.resolve();
+      return drainQueue().then(() => undefined);
     },
   };
 }
@@ -310,8 +313,7 @@ function createAgentNativeAnalyticsProvider(
       );
     },
     flush: () => {
-      drainQueue();
-      return Promise.resolve();
+      return drainQueue().then(() => undefined);
     },
   };
 }

--- a/templates/clips/server/routes/_agent-native/google/callback.get.ts
+++ b/templates/clips/server/routes/_agent-native/google/callback.get.ts
@@ -98,6 +98,11 @@ async function handleGoogleSignInCallback(
     const { sessionToken } = await createOAuthSession(event, email, {
       hasProductionSession,
       desktop,
+      trackSignup: {
+        authProvider: "google",
+        authUserId: typeof user.id === "string" ? user.id : undefined,
+        name: typeof user.name === "string" ? user.name : undefined,
+      },
     });
 
     if (flowId && sessionToken) {


### PR DESCRIPTION
## Summary
- track first-time Google OAuth signups through the same signup analytics path as Better Auth
- flush server-side signup analytics before auth returns so low-volume serverless events are delivered reliably
- wire Clips custom Google callback into the shared signup tracking option

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/tracking/providers.spec.ts src/server/auth.spec.ts
- pnpm --filter @agent-native/core exec tsc --noEmit
- pnpm --filter @agent-native/core build
- pnpm --filter clips typecheck
- pnpm --filter plan typecheck
- pnpm fmt:check
- pnpm prep (typecheck/test/guards passed; initial fmt lane failed on generated Tauri schema cache and passed after formatting named files)