### PR TITLE
Fix analytics dashboard metadata flicker

### DIFF
--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -1061,6 +1061,10 @@ type PrefetchedSqlDashboard = {
   };
   archivedAt: string | null;
   hiddenAt: string | null;
+  hiddenBy: string | null;
+  visibility: Visibility;
+  ownerEmail: string | null;
+  updatedAt: string | null;
 } & ResourceAccess;
 
 async function fetchSqlDashboardForPrefetch(
@@ -1088,6 +1092,13 @@ async function fetchSqlDashboardForPrefetch(
       },
       archivedAt: typeof data.archivedAt === "string" ? data.archivedAt : null,
       hiddenAt: typeof data.hiddenAt === "string" ? data.hiddenAt : null,
+      hiddenBy: typeof data.hiddenBy === "string" ? data.hiddenBy : null,
+      visibility:
+        data.visibility === "org" || data.visibility === "public"
+          ? data.visibility
+          : "private",
+      ownerEmail: typeof data.ownerEmail === "string" ? data.ownerEmail : null,
+      updatedAt: typeof data.updatedAt === "string" ? data.updatedAt : null,
       role: typeof data.role === "string" ? data.role : undefined,
       canEdit: typeof data.canEdit === "boolean" ? data.canEdit : undefined,
       canManage:
@@ -1851,6 +1862,32 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
       </div>
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden py-2">
         <nav className="grid min-w-0 items-start px-2 text-sm font-medium lg:px-4 space-y-1">
+          {/* Ask link */}
+          <Link
+            to="/ask"
+            onClick={(event) => {
+              if (
+                location.pathname !== "/ask" &&
+                !event.metaKey &&
+                !event.ctrlKey &&
+                !event.shiftKey &&
+                !event.altKey
+              ) {
+                event.preventDefault();
+                navigateWithAgentChatViewTransition(navigate, "/ask");
+              }
+            }}
+            className={cn(
+              "flex items-center gap-3 rounded-lg px-3 py-2 transition-all hover:text-primary",
+              location.pathname === "/ask"
+                ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                : "text-muted-foreground hover:bg-sidebar-accent/50",
+            )}
+          >
+            <IconMessageCircle className="h-4 w-4" />
+            Ask
+          </Link>
+
           {/* Overview link */}
           <Link
             to="/overview"
@@ -1905,32 +1942,6 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
           >
             <IconTemplate className="h-4 w-4" />
             Catalog
-          </Link>
-
-          {/* Ask link */}
-          <Link
-            to="/ask"
-            onClick={(event) => {
-              if (
-                location.pathname !== "/ask" &&
-                !event.metaKey &&
-                !event.ctrlKey &&
-                !event.shiftKey &&
-                !event.altKey
-              ) {
-                event.preventDefault();
-                navigateWithAgentChatViewTransition(navigate, "/ask");
-              }
-            }}
-            className={cn(
-              "flex items-center gap-3 rounded-lg px-3 py-2 transition-all hover:text-primary",
-              location.pathname === "/ask"
-                ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                : "text-muted-foreground hover:bg-sidebar-accent/50",
-            )}
-          >
-            <IconMessageCircle className="h-4 w-4" />
-            Ask
           </Link>
 
           {/* Dashboards section */}

--- a/templates/analytics/app/pages/Index.tsx
+++ b/templates/analytics/app/pages/Index.tsx
@@ -1,99 +1,16 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router";
 import { callAction } from "@agent-native/core/client";
-import { Skeleton } from "@/components/ui/skeleton";
-import { dashboards } from "@/pages/adhoc/registry";
-import { getLastOpenedPath } from "@/lib/last-opened";
-import { withDemoIntro } from "@/lib/demo-dashboard-path";
-
-type EnsureDemoDashboardsResult = {
-  defaultDashboardPath?: string;
-  dashboards?: Array<{ created?: boolean; installed?: boolean }>;
-};
-
-function isSyntheticDefaultDashboardPath(path: string): boolean {
-  return (
-    path === "/adhoc/default" &&
-    !dashboards.some((dashboard) => dashboard.id === "default")
-  );
-}
-
-function isSyntheticDefaultDashboardId(id: string): boolean {
-  return (
-    id === "default" &&
-    !dashboards.some((dashboard) => dashboard.id === "default")
-  );
-}
 
 export default function Index() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    let cancelled = false;
-
-    const ensureDemoDashboards =
-      async (): Promise<EnsureDemoDashboardsResult | null> => {
-        try {
-          return (await callAction(
-            "ensure-demo-dashboards",
-            {},
-          )) as EnsureDemoDashboardsResult | null;
-        } catch (err) {
-          console.warn("[analytics] demo dashboard install failed", err);
-          return null;
-        }
-      };
-
-    const openDefault = async () => {
-      const result = await ensureDemoDashboards();
-      if (cancelled) return;
-
-      const createdDemo =
-        result?.dashboards?.some(
-          (dashboard) => dashboard.installed && dashboard.created,
-        ) ?? false;
-      if (createdDemo && result?.defaultDashboardPath) {
-        navigate(withDemoIntro(result.defaultDashboardPath), { replace: true });
-        return;
-      }
-
-      const lastPath = getLastOpenedPath();
-      if (lastPath && !isSyntheticDefaultDashboardPath(lastPath)) {
-        navigate(lastPath, { replace: true });
-        return;
-      }
-      const lastId = localStorage.getItem("last-dashboard-id");
-      if (lastId && !isSyntheticDefaultDashboardId(lastId)) {
-        navigate(`/adhoc/${lastId}`, { replace: true });
-      } else if (result?.defaultDashboardPath) {
-        navigate(result.defaultDashboardPath, { replace: true });
-      } else if (dashboards.length > 0) {
-        navigate(`/adhoc/${dashboards[0].id}`, { replace: true });
-      } else {
-        try {
-          navigate("/data-sources", { replace: true });
-        } catch {
-          // Navigation can throw if the component unmounted mid-transition.
-        }
-      }
-    };
-
-    void openDefault();
-
-    return () => {
-      cancelled = true;
-    };
+    void callAction("ensure-demo-dashboards", {}).catch((err) => {
+      console.warn("[analytics] demo dashboard install failed", err);
+    });
+    navigate("/ask", { replace: true });
   }, [navigate]);
 
-  return (
-    <div className="space-y-6">
-      <Skeleton className="h-8 w-48" />
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <Skeleton key={i} className="h-24 w-full rounded-xl" />
-        ))}
-      </div>
-      <Skeleton className="h-[300px] w-full rounded-xl" />
-    </div>
-  );
+  return null;
 }

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -257,8 +257,8 @@ export default function SqlDashboardPage() {
   const [hiddenAt, setHiddenAt] = useState<string | null>(null);
   const [hiddenBy, setHiddenBy] = useState<string | null>(null);
   const [dashboardVisibility, setDashboardVisibility] = useState<
-    "private" | "org" | "public"
-  >("private");
+    "private" | "org" | "public" | null
+  >(null);
   const [dashboardOwner, setDashboardOwner] = useState<string | null>(null);
   const [dashboardUpdatedAt, setDashboardUpdatedAt] = useState<string | null>(
     null,
@@ -428,7 +428,7 @@ export default function SqlDashboardPage() {
     setArchivedAt(null);
     setHiddenAt(null);
     setHiddenBy(null);
-    setDashboardVisibility("private");
+    setDashboardVisibility(null);
     setDashboardOwner(null);
     setDashboardUpdatedAt(null);
     setResourceAccess(null);
@@ -439,11 +439,17 @@ export default function SqlDashboardPage() {
     if (!dashboardId || !dashboardQuery.isSuccess) return;
     const fetched = dashboardQuery.data;
     if (fetched && fetched.id !== dashboardId) return;
+    const fetchedVisibility =
+      fetched?.visibility === "private" ||
+      fetched?.visibility === "org" ||
+      fetched?.visibility === "public"
+        ? fetched.visibility
+        : null;
     setDashboard(fetched?.config ?? null);
     setArchivedAt(fetched?.archivedAt ?? null);
     setHiddenAt(fetched?.hiddenAt ?? null);
     setHiddenBy(fetched?.hiddenBy ?? null);
-    setDashboardVisibility(fetched?.visibility ?? "private");
+    setDashboardVisibility(fetchedVisibility);
     setDashboardOwner(fetched?.ownerEmail ?? null);
     setDashboardUpdatedAt(fetched?.updatedAt ?? null);
     setResourceAccess(
@@ -1171,30 +1177,32 @@ export default function SqlDashboardPage() {
             {dashboardOwner.split("@")[0]}
           </span>
         )}
-        <span
-          className={`flex items-center gap-1.5 font-medium ${
-            dashboardVisibility === "public"
-              ? "text-green-600"
-              : dashboardVisibility === "org"
-                ? "text-blue-600"
-                : "text-yellow-600"
-          }`}
-        >
+        {dashboardVisibility ? (
           <span
-            className={`h-1.5 w-1.5 rounded-full ${
+            className={`flex items-center gap-1.5 font-medium ${
               dashboardVisibility === "public"
-                ? "bg-green-500"
+                ? "text-green-600"
                 : dashboardVisibility === "org"
-                  ? "bg-blue-500"
-                  : "bg-yellow-500"
+                  ? "text-blue-600"
+                  : "text-yellow-600"
             }`}
-          />
-          {dashboardVisibility === "public"
-            ? "Public"
-            : dashboardVisibility === "org"
-              ? "Shared with org"
-              : "Private"}
-        </span>
+          >
+            <span
+              className={`h-1.5 w-1.5 rounded-full ${
+                dashboardVisibility === "public"
+                  ? "bg-green-500"
+                  : dashboardVisibility === "org"
+                    ? "bg-blue-500"
+                    : "bg-yellow-500"
+              }`}
+            />
+            {dashboardVisibility === "public"
+              ? "Public"
+              : dashboardVisibility === "org"
+                ? "Shared with org"
+                : "Private"}
+          </span>
+        ) : null}
       </div>
 
       {/* Description (click to edit) */}


### PR DESCRIPTION
## Summary
- include dashboard visibility, owner, updated timestamp, and hidden metadata in the Analytics sidebar prefetch snapshot
- render dashboard visibility only after the fetched data explicitly supplies a visibility value, preventing incomplete snapshots from flashing as Private
- keep the current branch change that opens Analytics at Ask and moves Ask to the top of the sidebar

## Tests
- pnpm --dir templates/analytics typecheck
- pnpm --dir templates/analytics test
