### PR TITLE
Fix duplicate camera bubble in full-screen recordings

### DIFF
--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -1940,6 +1940,14 @@ export default function RecordRoute() {
   const showCameraBubble =
     cameraStream !== null && recordingMode !== "screen" && uiState !== "idle";
   const rememberedRecorderOptions = pendingStartOptsRef.current;
+  // Full-screen capture records this tab's own bubble, which the composite
+  // already bakes into the video — hide the live overlay while recording so it
+  // doesn't appear twice. Countdown isn't recorded; window/tab captures don't
+  // include the overlay, so both keep it.
+  const hideBubbleForFullScreenCapture =
+    rememberedRecorderOptions?.displaySurface === "monitor" &&
+    recordingMode === "screen+camera" &&
+    uiState === "recording";
 
   // `/record` is a fullscreen route outside the `_app` shell, so it has no
   // sidebar back-affordance. Surface a back arrow whenever there's nothing in
@@ -2072,16 +2080,18 @@ export default function RecordRoute() {
         </div>
       )}
 
-      {/* Camera bubble — visible during countdown (so the user can frame
-          themselves) and while actively recording. Hidden during
-          uploading/compressing so the save overlay isn't confused with an
-          ongoing recording. */}
+      {/* Camera bubble — shown during countdown (for framing) and recording.
+          Hidden during uploading/compressing, and during full-screen recording
+          so it isn't captured on top of the composited bubble. */}
       {showCameraBubble && (
         <CameraBubble
           stream={cameraStream}
           size={cameraSize}
           onSizeChange={setCameraSize}
-          hidden={uiState !== "recording" && uiState !== "countdown"}
+          hidden={
+            (uiState !== "recording" && uiState !== "countdown") ||
+            hideBubbleForFullScreenCapture
+          }
         />
       )}
 


### PR DESCRIPTION
## Problem

When recording with **Screen + Camera** and capturing the **entire screen**, the camera bubble showed up in *multiple places* in the saved video.

**Root cause:** in the browser recorder's `screen+camera` mode the camera is composited into the recording (`camera-composite.ts`, always drawn bottom-left). The `/record` route *also* renders a live, draggable `<CameraBubble>` DOM overlay for framing. With entire-screen capture, `getDisplayMedia` captures the whole screen — including this tab's overlay — so the recording got the bubble twice (composited + captured). Window/tab captures don't include the overlay, which is exactly why compositing exists.

## Fix

Hide the live DOM `CameraBubble` while recording when the capture surface is the entire screen (`displaySurface === "monitor"`). The composited bubble still appears once.

- Countdown is **not** recorded, so the overlay still shows then for framing.
- Window and browser-tab captures are unchanged (they keep the live overlay).

## Testing

Verified locally against the Clips dev gateway:
- Screen + Camera → Entire screen → bubble now appears once in the recording (previously twice).
- Window / Browser tab captures → live bubble still shown during recording (no regression).

Browser-only change; the desktop native path already excludes its bubble via `set_bubble_capture_excluded`.