### PR TITLE
Turn the camera off as soon as recording stops

### DIFF
--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -807,6 +807,7 @@ pub async fn hide_recording_chrome(app: AppHandle) -> Result<(), String> {
 /// MediaRecorder doesn't touch the camera after start.
 #[tauri::command]
 pub async fn close_bubble(app: AppHandle) -> Result<(), String> {
+    let _ = app.emit("clips:release-camera", ());
     if let Some(w) = app.get_webview_window(BUBBLE_LABEL) {
         dlog!("[clips-tray] close_bubble — destroying bubble webview");
         let _ = w.close();

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -1042,13 +1042,16 @@ export function App() {
       }),
     );
     // The bubble window emits `clips:bubble-closed` when the user clicks
-    // the X on the hover controls. Treat that as "camera off" — the
-    // bubble-session effect then tears down the stream + pump.
+    // the X on the hover controls. Treat that as "camera off": stop the
+    // popover-owned camera track now so the hardware light goes off
+    // immediately, and clear `cameraOn` so the bubble-session effect tears
+    // down the rest (pump/window) and the toggle reflects the new state.
     track(
       listen("clips:bubble-closed", () => {
         console.log(
-          "[clips-popover] bubble-closed received — clearing cameraOn",
+          "[clips-popover] bubble-closed received — stopping camera + clearing cameraOn",
         );
+        bubbleStreamRef.current?.getTracks().forEach((t) => t.stop());
         setCameraOn(false);
       }),
     );
@@ -1324,6 +1327,24 @@ export function App() {
       }
     };
   }, [bubbleActive, cameraId]);
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    listen("clips:release-camera", () => {
+      console.log(`[popover] releasing camera`);
+      bubbleStreamRef.current?.getTracks().forEach((t) => t.stop());
+    })
+      .then((u) => {
+        if (cancelled) u();
+        else unlisten = u;
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
 
   // ---- auto-size popover to content --------------------------------------
   // The Tauri window is fixed-size via tauri.conf.json, but our content

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -2923,6 +2923,11 @@ async function startRecordingInner(
       }
       await thumbnailUploadPromise;
 
+      if (popoverOwnsCamera) {
+        console.log("[clips-recorder] releasing popover camera");
+        emit("clips:release-camera").catch(() => {});
+      }
+
       const videoSettings = uploadPrimaryVideo.stream
         .getVideoTracks()[0]
         ?.getSettings();


### PR DESCRIPTION
In the Clips desktop app, the camera could keep running after a recording was stopped. The webcam stayed active (and the macOS recording light stayed on) until the clip finished uploading, which made it look like recording was still in progress. This change releases the camera the moment recording ends, instead of when the upload finishes.

It covers the cases where this could happen: stopping a native full-screen recording, stopping a browser-based recording, and closing the camera bubble by hand. In each case the camera now turns off right away.