### PR TITLE
Fix camera bubble using the actual captured surface, not the request

### DIFF
--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -99,6 +99,17 @@ export interface RecorderEngineOptions {
    */
   onDisplayTrackEnded?: () => void;
   /**
+   * Fired with the *actual* capture surface the user selected in the browser's
+   * native screen picker, read from the resulting display track's settings.
+   * The `displaySurface` we request is only a hint, and `surfaceSwitching:
+   * include` lets the user swap surfaces mid-recording — so this is the
+   * authority for "is the whole screen (this tab included) being captured?".
+   * Fires once right after acquisition and again on `configurationchange` when
+   * the shared surface switches. Reports `null` when the browser doesn't expose
+   * the resolved surface (Firefox/Safari are partial).
+   */
+  onResolvedDisplaySurface?: (surface: DisplaySurface | null) => void;
+  /**
    * Fired with progress updates while ffmpeg.wasm is re-encoding a too-large
    * recording. Stage transitions from `loading-ffmpeg` → `preparing` →
    * `encoding` (with 0..1 progress) → `finalizing`. The engine itself
@@ -604,7 +615,22 @@ export class RecorderEngine {
       // Without it we fall back to stopping the engine directly — but this
       // bypasses all UI side-effects, so always provide the callback.
       if (this.displayStream) {
+        // The requested `displaySurface` is only a hint; report the surface the
+        // user actually picked so the UI can hide its live camera-bubble overlay
+        // only when the whole screen (this tab included) is captured. With
+        // `surfaceSwitching: include` the user can swap surfaces mid-recording
+        // without a re-prompt, so refresh on `configurationchange` too.
+        const reportDisplaySurface = (track: MediaStreamTrack) => {
+          const settings = track.getSettings() as MediaTrackSettings & {
+            displaySurface?: DisplaySurface;
+          };
+          this.opts.onResolvedDisplaySurface?.(settings.displaySurface ?? null);
+        };
         for (const track of this.displayStream.getVideoTracks()) {
+          reportDisplaySurface(track);
+          track.addEventListener("configurationchange", () =>
+            reportDisplaySurface(track),
+          );
           track.addEventListener("ended", () => {
             if (this.state === "recording" || this.state === "paused") {
               if (this.opts.onDisplayTrackEnded) {

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -716,6 +716,11 @@ export default function RecordRoute() {
   const [cameraStream, setCameraStream] = useState<MediaStream | null>(null);
   const [cameraSize, setCameraSize] = useState<CameraBubbleSize>("md");
   const [previewStream, setPreviewStream] = useState<MediaStream | null>(null);
+  // The capture surface the user actually picked in the browser's native screen
+  // picker (authority over the requested `displaySurface` hint). Drives whether
+  // the live camera bubble is hidden during full-screen recording.
+  const [resolvedDisplaySurface, setResolvedDisplaySurface] =
+    useState<DisplaySurface | null>(null);
   const [loomImporting, setLoomImporting] = useState(false);
   const [recordingMode, setRecordingMode] =
     useState<RecordingMode>("screen+camera");
@@ -893,6 +898,9 @@ export default function RecordRoute() {
       setError(null);
       setRecordingMode(opts.mode);
       pendingStartOptsRef.current = opts;
+      // Clear any surface resolved by a previous capture; the engine reports the
+      // new one once the user picks in the browser's screen dialog.
+      setResolvedDisplaySurface(null);
       flushSync(() => {
         setUiState("pickingSources");
       });
@@ -921,6 +929,12 @@ export default function RecordRoute() {
           // recording keeps going; just let the user know what happened.
           onWarning: (message) => {
             toast.warning(message);
+          },
+          // Track the surface the user actually chose (and any mid-recording
+          // switch) so the live camera bubble is hidden only when the full
+          // screen — including this tab's overlay — is being captured.
+          onResolvedDisplaySurface: (surface) => {
+            setResolvedDisplaySurface(surface);
           },
           onState: (state) => {
             // Mirror the engine's compression pass into the UI so the
@@ -1940,12 +1954,19 @@ export default function RecordRoute() {
   const showCameraBubble =
     cameraStream !== null && recordingMode !== "screen" && uiState !== "idle";
   const rememberedRecorderOptions = pendingStartOptsRef.current;
+  // The requested `displaySurface` is only a hint — the user picks the real
+  // surface in the browser's native dialog and can even switch it mid-recording
+  // (`surfaceSwitching: include`). Prefer the surface the engine resolved from
+  // the live track, falling back to the requested one only when the browser
+  // doesn't expose the resolved value (Firefox/Safari are partial).
+  const effectiveDisplaySurface =
+    resolvedDisplaySurface ?? rememberedRecorderOptions?.displaySurface ?? null;
   // Full-screen capture records this tab's own bubble, which the composite
   // already bakes into the video — hide the live overlay while recording so it
   // doesn't appear twice. Countdown isn't recorded; window/tab captures don't
   // include the overlay, so both keep it.
   const hideBubbleForFullScreenCapture =
-    rememberedRecorderOptions?.displaySurface === "monitor" &&
+    effectiveDisplaySurface === "monitor" &&
     recordingMode === "screen+camera" &&
     uiState === "recording";
 


### PR DESCRIPTION
## Problem

Follow-up to #1382. That PR hid the live DOM `<CameraBubble>` during full-screen recording by checking the **requested** surface (`pendingStartOptsRef.current.displaySurface === "monitor"`).

But `displaySurface` passed to `getDisplayMedia` is only a *hint* — the user picks the actual surface in the browser's native screen picker, and `surfaceSwitching: "include"` lets them swap surfaces mid-recording without a re-prompt. So the requested value can disagree with what's really being captured:

- **Bug still reproduces:** select **Window** in the app UI → we request `"window"` → then pick **Entire Screen** in the browser dialog. We think "window," don't hide the overlay, full-screen capture records this tab on top of the composited bubble → **two bubbles.**
- **Minor inverse regression:** request `"monitor"` but actually share a window → live framing overlay needlessly hidden during recording.

## Fix

Gate on the **actual** surface instead of the requested one.

- `recorder-engine.ts`: after acquiring the display stream, read `track.getSettings().displaySurface` and report it via a new `onResolvedDisplaySurface` callback. Re-report on the track's `configurationchange` so mid-recording surface switches stay correct.
- `record.tsx`: store the resolved surface in state and compute `effectiveDisplaySurface = resolved ?? requested`. The overlay is hidden only when the *effective* surface is `"monitor"`. Falls back to the requested value when the browser doesn't expose the resolved one (Firefox/Safari are partial).

## Behavior

- Screen + Camera → Entire screen (however selected) → bubble appears once.
- Window / Browser tab → live bubble kept.
- Switch window → entire screen mid-recording → overlay hides as soon as the switch is reported.
- Countdown still shows the overlay for framing (not recorded).

Browser-only change; the desktop native path already excludes its bubble via `set_bubble_capture_excluded`.
