### PR TITLE
Fix audio channel and sample rate issues in native recordings

### DIFF
--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -46,6 +46,22 @@ const TRANSCODE_RATE_LIMIT_OVERHEAD_KBPS: f64 = 64.0;
 const TRANSCODE_FRAME_RATE_LIMIT: u32 = 30;
 const NORMALIZED_AUDIO_BITRATE_KBPS: u32 = 160;
 const AUDIO_LOUDNESS_FILTER: &str = "loudnorm=I=-16:TP=-1.5:LRA=11";
+// ScreenCaptureKit can lay mic + system audio out as the left/right channels of
+// a single stereo track. Force the input to stereo (mono sources duplicate),
+// then sum both channels into each output so audio is centered instead of
+// stuck on one speaker. Runs before loudnorm so level is normalized on the
+// corrected signal.
+const AUDIO_DOWNMIX_FILTER: &str =
+    "aformat=channel_layouts=stereo,pan=stereo|FL=0.5*FL+0.5*FR|FR=0.5*FL+0.5*FR";
+// loudnorm operates internally at 192 kHz and emits at 192 kHz; without an
+// explicit output rate the AAC track ends up at 192 kHz and plays back slow.
+const AUDIO_OUTPUT_SAMPLE_RATE: u32 = 48000;
+
+// Centered-stereo downmix followed by loudness normalization. Pair with
+// `-ar AUDIO_OUTPUT_SAMPLE_RATE` so loudnorm's 192 kHz output is resampled back.
+fn audio_filter_chain() -> String {
+    format!("{AUDIO_DOWNMIX_FILTER},{AUDIO_LOUDNESS_FILTER}")
+}
 const NATIVE_CAPTURE_MAX_LONG_EDGE: u32 = 1280;
 const NATIVE_CAPTURE_FPS: u32 = 24;
 const AVCONVERT_PATH: &str = "/usr/bin/avconvert";
@@ -2988,9 +3004,11 @@ fn normalize_audio_with_ffmpeg(
         .arg("-b:a")
         .arg(audio_bitrate)
         .arg("-af")
-        .arg(AUDIO_LOUDNESS_FILTER)
+        .arg(audio_filter_chain())
         .arg("-ac")
         .arg("2")
+        .arg("-ar")
+        .arg(AUDIO_OUTPUT_SAMPLE_RATE.to_string())
         .arg("-movflags")
         .arg("+faststart")
         .arg("-f")
@@ -3072,7 +3090,7 @@ fn transcode_with_ffmpeg(
     }
 
     if normalize_audio {
-        command.arg("-af").arg(AUDIO_LOUDNESS_FILTER);
+        command.arg("-af").arg(audio_filter_chain());
     }
 
     let duration_rate_limit =
@@ -3111,6 +3129,8 @@ fn transcode_with_ffmpeg(
         .arg(audio_bitrate)
         .arg("-ac")
         .arg("2")
+        .arg("-ar")
+        .arg(AUDIO_OUTPUT_SAMPLE_RATE.to_string())
         .arg("-movflags")
         .arg("+faststart")
         .arg("-f")

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -46,21 +46,28 @@ const TRANSCODE_RATE_LIMIT_OVERHEAD_KBPS: f64 = 64.0;
 const TRANSCODE_FRAME_RATE_LIMIT: u32 = 30;
 const NORMALIZED_AUDIO_BITRATE_KBPS: u32 = 160;
 const AUDIO_LOUDNESS_FILTER: &str = "loudnorm=I=-16:TP=-1.5:LRA=11";
-// ScreenCaptureKit can lay mic + system audio out as the left/right channels of
-// a single stereo track. Force the input to stereo (mono sources duplicate),
-// then sum both channels into each output so audio is centered instead of
-// stuck on one speaker. Runs before loudnorm so level is normalized on the
-// corrected signal.
+// When the mic is captured alongside system audio, ScreenCaptureKit lays the
+// two sources out as the left/right channels of a single stereo track, which
+// plays back stuck on one speaker. Force the input to stereo (mono sources
+// duplicate), then sum both channels into each output so audio is centered.
+// Runs before loudnorm so level is normalized on the corrected signal. Only
+// applied when the mic was captured — a system-audio-only recording has real
+// stereo content that must not be flattened.
 const AUDIO_DOWNMIX_FILTER: &str =
     "aformat=channel_layouts=stereo,pan=stereo|FL=0.5*FL+0.5*FR|FR=0.5*FL+0.5*FR";
 // loudnorm operates internally at 192 kHz and emits at 192 kHz; without an
 // explicit output rate the AAC track ends up at 192 kHz and plays back slow.
 const AUDIO_OUTPUT_SAMPLE_RATE: u32 = 48000;
 
-// Centered-stereo downmix followed by loudness normalization. Pair with
-// `-ar AUDIO_OUTPUT_SAMPLE_RATE` so loudnorm's 192 kHz output is resampled back.
-fn audio_filter_chain() -> String {
-    format!("{AUDIO_DOWNMIX_FILTER},{AUDIO_LOUDNESS_FILTER}")
+// Loudness normalization, optionally preceded by the centered-stereo downmix
+// that repairs the mic+system L/R split. Pair with `-ar AUDIO_OUTPUT_SAMPLE_RATE`
+// so loudnorm's 192 kHz output is resampled back.
+fn audio_filter_chain(downmix: bool) -> String {
+    if downmix {
+        format!("{AUDIO_DOWNMIX_FILTER},{AUDIO_LOUDNESS_FILTER}")
+    } else {
+        AUDIO_LOUDNESS_FILTER.to_string()
+    }
 }
 const NATIVE_CAPTURE_MAX_LONG_EDGE: u32 = 1280;
 const NATIVE_CAPTURE_FPS: u32 = 24;
@@ -268,6 +275,11 @@ struct SavedNativeRecording {
     height: Option<u32>,
     bytes: u64,
     has_audio: bool,
+    // Whether the mic was captured. Drives the centered-stereo downmix repair
+    // for the mic+system L/R split. Defaults to false for recordings queued
+    // before this field existed so their audio is left untouched.
+    #[serde(default)]
+    mic_captured: bool,
     has_camera: bool,
     saved_at: String,
     last_attempt_at: Option<String>,
@@ -1762,6 +1774,7 @@ fn saved_recording_from_session(
         height: session.height,
         bytes,
         has_audio,
+        mic_captured: session.restart.include_audio,
         has_camera,
         saved_at: now_iso(),
         last_attempt_at: None,
@@ -2227,6 +2240,7 @@ async fn upload_recording_file(
         session.height,
         Some(duration_ms),
         has_audio,
+        session.restart.include_audio,
     )?;
     let upload_result = upload_prepared_recording_file(
         app,
@@ -2263,6 +2277,7 @@ async fn upload_saved_recording_file(
         saved.height,
         Some(saved.duration_ms),
         saved.has_audio,
+        saved.mic_captured,
     )?;
     let upload_result = upload_prepared_recording_file(
         app,
@@ -2576,6 +2591,7 @@ fn prepare_recording_file(
     height: Option<u32>,
     duration_ms: Option<u128>,
     has_audio: bool,
+    downmix_audio: bool,
 ) -> Result<PreparedRecordingFile, String> {
     let metadata = std::fs::metadata(path).map_err(|e| {
         let diag = describe_recording_path(path);
@@ -2607,7 +2623,8 @@ fn prepare_recording_file(
             if let Some(ffmpeg_path) = ffmpeg_path.as_deref() {
                 let normalized_path = normalized_recording_path(path);
                 let _ = std::fs::remove_file(&normalized_path);
-                match normalize_audio_with_ffmpeg(ffmpeg_path, path, &normalized_path) {
+                match normalize_audio_with_ffmpeg(ffmpeg_path, path, &normalized_path, downmix_audio)
+                {
                     Ok(()) => {
                         let normalized_bytes = std::fs::metadata(&normalized_path)
                             .map_err(|e| format!("normalized recording file missing: {e}"))?
@@ -2665,6 +2682,7 @@ fn prepare_recording_file(
                 height,
                 duration_ms,
                 has_audio,
+                downmix_audio,
             ) {
                 Ok(()) => {
                     let compressed_bytes = std::fs::metadata(&compressed_path)
@@ -2983,6 +3001,7 @@ fn normalize_audio_with_ffmpeg(
     ffmpeg_path: &str,
     source: &Path,
     output: &Path,
+    downmix_audio: bool,
 ) -> Result<(), String> {
     let audio_bitrate = format!("{NORMALIZED_AUDIO_BITRATE_KBPS}k");
     let mut command = Command::new(ffmpeg_path);
@@ -3004,7 +3023,7 @@ fn normalize_audio_with_ffmpeg(
         .arg("-b:a")
         .arg(audio_bitrate)
         .arg("-af")
-        .arg(audio_filter_chain())
+        .arg(audio_filter_chain(downmix_audio))
         .arg("-ac")
         .arg("2")
         .arg("-ar")
@@ -3067,6 +3086,7 @@ fn transcode_with_ffmpeg(
     height: Option<u32>,
     duration_ms: Option<u128>,
     normalize_audio: bool,
+    downmix_audio: bool,
 ) -> Result<(), String> {
     let mut command = Command::new(ffmpeg_path);
     command
@@ -3090,7 +3110,7 @@ fn transcode_with_ffmpeg(
     }
 
     if normalize_audio {
-        command.arg("-af").arg(audio_filter_chain());
+        command.arg("-af").arg(audio_filter_chain(downmix_audio));
     }
 
     let duration_rate_limit =


### PR DESCRIPTION
### Summary
Fixes two audio bugs in fullscreen native screen recordings: audio being stuck on one speaker, and audio playing back at the wrong speed (too slow).

### Problem
ScreenCaptureKit can mix microphone and system audio as the left and right channels of a single stereo track, causing audio to only come from one speaker. Additionally, the `loudnorm` FFmpeg filter operates internally at 192 kHz and emits at that rate — without an explicit output sample rate, the resulting AAC track plays back at the wrong speed (too slow).

### Solution
A stereo downmix filter is applied before loudness normalization to center the audio across both channels. An explicit output sample rate of 48 kHz is also set to resample `loudnorm`'s 192 kHz output back to a standard playback rate. Both fixes are applied consistently across the `normalize_audio_with_ffmpeg` and `transcode_with_ffmpeg` paths.

### Key Changes
- Added `AUDIO_DOWNMIX_FILTER` constant: forces input to stereo and sums both channels equally into FL and FR, centering audio that was previously isolated to one speaker
- Added `AUDIO_OUTPUT_SAMPLE_RATE` constant (`48000` Hz) to resample `loudnorm`'s 192 kHz output to a standard rate, fixing slow playback
- Added `audio_filter_chain()` helper that composes the downmix and loudnorm filters into a single FFmpeg `-af` argument
- Applied `audio_filter_chain()` and `-ar 48000` in both `normalize_audio_with_ffmpeg` and `transcode_with_ffmpeg` functions, replacing the previous bare `AUDIO_LOUDNESS_FILTER` usage

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/mist-velocity-gzefnh8n"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-mist-velocity-gzefnh8n.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1393`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>mist-velocity-gzefnh8n</branchName>-->