### PR TITLE
Mark public homepage media tokens

### DIFF
--- a/packages/docs/app/components/AgentNativeDemoVideo.tsx
+++ b/packages/docs/app/components/AgentNativeDemoVideo.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 const DEMO_VIDEO_URL =
-  "https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2F99ec814b12784b1885742a1c82d9dcf5?alt=media&token=e164a53f-ae25-41f9-b8fb-a58937a4d370";
+  "https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2F99ec814b12784b1885742a1c82d9dcf5?alt=media&token=e164a53f-ae25-41f9-b8fb-a58937a4d370"; // ggignore: public Builder CDN media token
 
 export function AgentNativeDemoVideo({
   className = "",

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -97,28 +97,28 @@ const bidirectionalTabs = [
     description:
       "It can read and update any UI, any data, any state in the application.",
     video:
-      "https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fa7b4e0fca8154ab6a82414178d3a4521%2Fcompressed?token=a7b4e0fca8154ab6a82414178d3a4521&alt=media&optimized=true",
+      "https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fa7b4e0fca8154ab6a82414178d3a4521%2Fcompressed?token=a7b4e0fca8154ab6a82414178d3a4521&alt=media&optimized=true", // ggignore: public Builder CDN media token
   },
   {
     title: "The UI talks to the agent",
     description:
       "Buttons, forms, and workflows push structured content to the agent, giving you guided flows that all go through the agent — including skills, rules, and instructions.",
     video:
-      "https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2F02f0369cc97345aa89311d0909b24611%2Fcompressed?token=02f0369cc97345aa89311d0909b24611&alt=media&optimized=true",
+      "https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2F02f0369cc97345aa89311d0909b24611%2Fcompressed?token=02f0369cc97345aa89311d0909b24611&alt=media&optimized=true", // ggignore: public Builder CDN media token
   },
   {
     title: "The agent updates its own code",
     description:
       "It can modify the app itself to change features and functionality. Your tools get better over time.",
     video:
-      "https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2F1aade099ff6d4e9ca04f8534d3314383%2Fcompressed?token=1aade099ff6d4e9ca04f8534d3314383&alt=media&optimized=true",
+      "https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2F1aade099ff6d4e9ca04f8534d3314383%2Fcompressed?token=1aade099ff6d4e9ca04f8534d3314383&alt=media&optimized=true", // ggignore: public Builder CDN media token
   },
   {
     title: "Everything works both ways",
     description:
       "Every action available in the UI is also available to the agent. You can click to do something, or ask the agent to do it.",
     video:
-      "https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2F39c6b297895843708938b097d8e3eb2c?alt=media&token=c5fdf84c-d4fb-45b0-b220-ef7aab01e99f",
+      "https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2F39c6b297895843708938b097d8e3eb2c?alt=media&token=c5fdf84c-d4fb-45b0-b220-ef7aab01e99f", // ggignore: public Builder CDN media token
   },
 ];
 


### PR DESCRIPTION
## Summary
- add GitGuardian ignore markers to the hardcoded public Builder CDN media URLs
- keep the restored homepage videos hardcoded and loading from the same CDN assets

## Context
- Follow-up to #1395 after GitGuardian flagged the public media token query params as generic high-entropy secrets.
- Builder CDN returned 403 without those query tokens, so this keeps the working video URLs and marks the values as intentional/public.

## Testing
- pnpm --filter @agent-native/docs test
- pnpm --filter @agent-native/docs typecheck