### PR TITLE
Add select-all toggle to Clips Trash selection toolbar

### DIFF
--- a/templates/clips/app/routes/_app.trash.tsx
+++ b/templates/clips/app/routes/_app.trash.tsx
@@ -88,6 +88,16 @@ export default function TrashRoute() {
   };
 
   const selectedIds = Array.from(selected);
+  const allSelected =
+    recordings.length > 0 && selected.size === recordings.length;
+
+  const toggleSelectAll = () => {
+    setSelected((prev) =>
+      prev.size === recordings.length
+        ? new Set()
+        : new Set(recordings.map((r) => r.id)),
+    );
+  };
 
   return (
     <div className="flex flex-1 flex-col min-h-0">
@@ -96,6 +106,17 @@ export default function TrashRoute() {
         <div className="ml-auto flex items-center gap-2">
           {selectedIds.length > 0 && (
             <>
+              <span className="text-sm text-muted-foreground">
+                {selectedIds.length} selected
+              </span>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="gap-1.5"
+                onClick={toggleSelectAll}
+              >
+                {allSelected ? "Deselect all" : "Select all"}
+              </Button>
               <Button
                 size="sm"
                 variant="outline"


### PR DESCRIPTION
## What

Adds a **Select all / Deselect all** toggle to the Clips Trash view's selection toolbar.

When one or more trashed clips are selected, the header now shows:
- a `N selected` count, and
- a **Select all** button that selects every clip in trash, flipping to **Deselect all** once all are selected.

This sits alongside the existing Restore and Delete forever actions and reuses the existing `recordings` list and `selected` state — no new data wiring.

## Why

Selecting many trashed clips one-by-one to bulk Restore or Delete forever is tedious. A select-all shortcut makes bulk cleanup quick.

## Testing

- Verified the diff is scoped to `_app.trash.tsx`.
- Prettier run on the modified file (no formatting changes).

https://claude.ai/code/session_01FeWN1TESoX7LFU4G4XWYYd