### PR TITLE
Stabilize content vitest full suite

### DIFF
--- a/templates/content/app/hooks/use-local-storage.test.tsx
+++ b/templates/content/app/hooks/use-local-storage.test.tsx
@@ -1,13 +1,45 @@
 // @vitest-environment happy-dom
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { useLocalStorage } from "./use-local-storage";
 
+function createTestStorage(): Storage {
+  const values = new Map<string, string>();
+
+  return {
+    get length() {
+      return values.size;
+    },
+    clear() {
+      values.clear();
+    },
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(values.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      values.delete(key);
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+  };
+}
+
 describe("useLocalStorage", () => {
   let container: HTMLDivElement | null = null;
   let root: Root | null = null;
+
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createTestStorage(),
+    });
+  });
 
   afterEach(() => {
     if (root) {

--- a/templates/content/vitest.config.ts
+++ b/templates/content/vitest.config.ts
@@ -13,5 +13,8 @@ export default defineConfig({
   test: {
     include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
     exclude: ["**/node_modules/**", "**/.git/**", "**/dist/**", "**/e2e/**"],
+    hookTimeout: 60_000,
+    testTimeout: 60_000,
+    maxWorkers: "50%",
   },
 });


### PR DESCRIPTION
## Summary
- raise the content template Vitest hook/test timeouts to cover cold imports under full-suite contention
- cap content Vitest workers at 50% so heavy module graphs do not starve each other
- make the `useLocalStorage` test provide its own test-local Storage object instead of depending on Node experimental localStorage behavior

## Validation
- `pnpm exec vitest run app/hooks/use-local-storage.test.tsx --reporter verbose`
- `pnpm exec vitest run` passed 3 consecutive full-suite runs in `templates/content`
