### PR TITLE
[codex] Add skills install startup feedback

### DIFF
--- a/.changeset/quiet-skills-startup-feedback.md
+++ b/.changeset/quiet-skills-startup-feedback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/skills": patch
+---
+
+Print early interactive startup feedback before delegating skills installs to the shared core flow.

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -22,6 +22,11 @@ sharing, local-file workflows, or your own app. Add `--update-instructions` to
 append an idempotent managed block to `AGENTS.md` and/or `CLAUDE.md` for
 instruction-style skills.
 
+On first run, `npx` itself may be quiet while it downloads the package before
+this CLI can print anything. For unattended installs, pass explicit flags such
+as `--skill`, `--client`, `--scope`, and `--no-connect` to skip prompts and
+leave MCP authentication for a later `connect` command.
+
 Skill content comes from `BuilderIO/skills@main` at install/list time for plain
 skill installs. Explicit app-backed installs such as `visual-plan`,
 `visual-recap`, and `content` delegate to `@agent-native/core` so mode

--- a/packages/skills/src/index.spec.ts
+++ b/packages/skills/src/index.spec.ts
@@ -295,6 +295,7 @@ describe("@agent-native/skills", () => {
     writeSkill(repo, "quick-recap");
     writeSkill(repo, "efficient-fable");
     let skillContext: SkillsPromptContext | undefined;
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
     await runSkillsCli(["add", "--copy", repo], {
       baseDir: project,
@@ -342,6 +343,66 @@ describe("@agent-native/skills", () => {
       initialSkills: ["visual-plan", "visual-recap"],
       options: [{ value: "quick-recap" }],
     });
+  });
+
+  it("prints startup progress before interactive delegated installs", async () => {
+    const repo = tmpDir();
+    const project = tmpDir();
+    writeSkill(repo, "quick-recap");
+    const stderr: string[] = [];
+    const previousDirect = process.env.AGENT_NATIVE_SKILLS_DIRECT;
+    delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    try {
+      await runSkillsCli(["add", "--copy", repo], {
+        baseDir: project,
+        isInteractive: () => true,
+      });
+    } finally {
+      if (previousDirect === undefined)
+        delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
+      else process.env.AGENT_NATIVE_SKILLS_DIRECT = previousDirect;
+    }
+
+    expect(stderr.join("")).toContain("Preparing Agent Native skills");
+  });
+
+  it("keeps delegated startup progress out of machine-readable and non-interactive output", async () => {
+    const repo = tmpDir();
+    const project = tmpDir();
+    writeSkill(repo, "quick-recap");
+    const stderr: string[] = [];
+    const previousDirect = process.env.AGENT_NATIVE_SKILLS_DIRECT;
+    delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    try {
+      await runSkillsCli(["add", "--copy", repo, "--json"], {
+        baseDir: project,
+        isInteractive: () => true,
+      });
+      await runSkillsCli(["add", "--copy", repo, "--quiet"], {
+        baseDir: project,
+        isInteractive: () => true,
+      });
+      await runSkillsCli(["add", "--copy", repo], {
+        baseDir: project,
+        isInteractive: () => false,
+      });
+    } finally {
+      if (previousDirect === undefined)
+        delete process.env.AGENT_NATIVE_SKILLS_DIRECT;
+      else process.env.AGENT_NATIVE_SKILLS_DIRECT = previousDirect;
+    }
+
+    expect(stderr.join("")).toBe("");
   });
 
   it("installs copied source skills headlessly in direct mode", async () => {

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -395,6 +395,18 @@ const HIDDEN_STANDALONE_BUILT_INS = [
   "context-xray",
 ];
 
+function shouldShowDelegatedStartupProgress(
+  parsed: ParsedArgs,
+  options: Pick<InstallSkillsOptions, "isInteractive">,
+): boolean {
+  return (
+    parsed.command !== "help" &&
+    !parsed.printJson &&
+    !parsed.quiet &&
+    cliInteractive(parsed, options)
+  );
+}
+
 export async function runSkillsCli(
   argv: string[],
   options: Pick<
@@ -422,6 +434,9 @@ export async function runSkillsCli(
     if (parsed.command === "help") {
       process.stdout.write(`${HELP}\n`);
       return;
+    }
+    if (shouldShowDelegatedStartupProgress(parsed, options)) {
+      process.stderr.write("Preparing Agent Native skills...\n");
     }
     const loadedSource = shouldLoadPublicCatalog(parsed)
       ? await materializeSource(parsed.source ?? DEFAULT_SKILLS_SOURCE)


### PR DESCRIPTION
## Summary
- Add early interactive startup feedback before @agent-native/skills delegates to the shared core install flow.
- Keep JSON, quiet, and non-interactive paths free of the new progress text.
- Document that first-run npx downloads can still be quiet before package code starts.

## Root cause
The standalone skills package delegates normal installs to @agent-native/core, but it may first materialize the public skills catalog and load the core flow without visible output. The package also cannot print anything during npm/npx's initial package download.

## Validation
- pnpm --filter @agent-native/skills test
- pnpm --filter @agent-native/skills typecheck
- pnpm --filter @agent-native/skills build
- pnpm exec prettier --check packages/skills/src/index.ts packages/skills/src/index.spec.ts packages/skills/README.md .changeset/quiet-skills-startup-feedback.md
- node scripts/check-changeset.mjs