### PR TITLE
Re-enable live transcription after stale-mic fallback in Clips recorder

### DIFF
--- a/templates/clips/app/components/recorder/pre-record-panel.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.tsx
@@ -308,8 +308,9 @@ export function PreRecordPanel({
   }, [cameraId, cameras]);
 
   // Camera-only mode needs a camera — coerce a restored "off" sentinel to
-  // "default" so Start doesn't forward it as an exact deviceId (covers the
-  // ?mode=camera deep-link/restore path the mode buttons already handle).
+  // "default" so Start doesn't forward it as an exact deviceId. This is the
+  // single owner of that coercion: it covers both the mode-button click and the
+  // ?mode=camera deep-link/restore path.
   useEffect(() => {
     if (mode === "camera" && cameraId === NO_CAMERA_DEVICE_ID) {
       setCameraId("default");
@@ -583,15 +584,10 @@ export function PreRecordPanel({
               <button
                 key={opt.value}
                 type="button"
-                onClick={() => {
-                  chooseMode(opt.value);
-                  if (
-                    opt.value === "camera" &&
-                    cameraId === NO_CAMERA_DEVICE_ID
-                  ) {
-                    chooseCamera("default");
-                  }
-                }}
+                // Camera-only mode needs a camera; the [mode, cameraId] effect
+                // below coerces a restored "off" sentinel to "default" for both
+                // this click and the ?mode=camera deep-link path.
+                onClick={() => chooseMode(opt.value)}
                 className={cn(
                   "flex min-h-20 min-w-0 flex-col justify-between rounded-xl border p-3 text-left transition-colors",
                   active

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -420,6 +420,13 @@ export class RecorderEngine {
    */
   private cameraDisconnectNotified = false;
   private micDisconnectNotified = false;
+  /**
+   * Set when a stale/unavailable `micDeviceId` forces a fallback to the system
+   * default mic during `acquire()`. The recording then runs on the default
+   * device, so live transcription (which can only ever use the default mic) is
+   * safe to start even though a specific mic was originally requested.
+   */
+  private micFellBackToDefault = false;
 
   private state: RecorderState = "idle";
 
@@ -446,6 +453,15 @@ export class RecorderEngine {
 
   getCameraStream(): MediaStream | null {
     return this.cameraStream;
+  }
+
+  /**
+   * True when `acquire()` had to fall back from the requested `micDeviceId` to
+   * the system default mic. Lets the UI start live transcription for this
+   * session even though a specific mic was originally selected.
+   */
+  didMicFallBackToDefault(): boolean {
+    return this.micFellBackToDefault;
   }
 
   getPreviewStream(): MediaStream | null {
@@ -515,6 +531,7 @@ export class RecorderEngine {
     const wantsCamera =
       this.opts.mode === "camera" || this.opts.mode === "screen+camera";
     const wantsMic = this.opts.micDeviceId !== NO_MIC_DEVICE_ID;
+    this.micFellBackToDefault = false;
 
     try {
       if (!isBrowserSecureContext()) {
@@ -634,6 +651,9 @@ export class RecorderEngine {
                 audio: voiceFocusedAudioConstraints(),
                 video: false,
               });
+              // Recording is now on the system default mic, so live
+              // transcription can run for this session after all.
+              this.micFellBackToDefault = true;
             } catch (retryErr) {
               throw this.friendlyError(retryErr, "microphone");
             }

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -1024,7 +1024,14 @@ export default function RecordRoute() {
         // chose a specific mic, do not start a parallel system-default mic
         // session for instant transcription; the recorded audio still uses
         // the exact selected device and can be transcribed after upload.
-        if (wantsMic && !opts.micDeviceId && liveTranscription.supported) {
+        //
+        // The one exception is when a stale saved mic forced the engine to
+        // fall back to the system default during acquire(): the recording is
+        // now on the default device, so live transcription would use the same
+        // mic and is safe to start.
+        const usingDefaultMic =
+          !opts.micDeviceId || engine.didMicFallBackToDefault();
+        if (wantsMic && usingDefaultMic && liveTranscription.supported) {
           liveTranscription.start();
         }
 


### PR DESCRIPTION
Addresses the review nitpicks on [#1391](https://github.com/BuilderIO/agent-native/pull/1391) ([review comment](https://github.com/BuilderIO/agent-native/pull/1391#issuecomment-4782419548) and [inline finding](https://github.com/BuilderIO/agent-native/pull/1391#discussion_r3461226357)).

## Fixes

**1. Live transcription stays off after a default-mic fallback** (the open Builder finding + review concern #1)

When a user's saved `micDeviceId` is stale/unavailable, the recorder engine already falls back to the system default mic during `acquire()` so the recording still succeeds. But the live-transcription gate in `RecordRoute` only started instant transcription when `micDeviceId` was empty, so a fallback session recorded with no instant transcript (post-upload transcription still ran).

- `RecorderEngine` now tracks `micFellBackToDefault` and exposes `didMicFallBackToDefault()`.
- `RecordRoute` starts live transcription when the engine fell back to the default mic — that session is on the default device anyway, which is the only mic Web Speech can use.

**2. Redundant camera-off→default coercion** (review concern #2)

The camera-mode button had an inline `onClick` coercion *and* a `[mode, cameraId]` effect doing the same thing. The effect already covers both the button click and the `?mode=camera` deep-link/restore path, so the inline branch was dead weight. Removed it; the effect is now the single owner.

Review concerns #3 (theoretical hydration mismatch on CSR-only pages) and #4 (persisting `displaySurface` is intended behavior) were explicitly flagged as non-issues / deliberate, so no changes there.

## Verification

- `pnpm typecheck` passes clean.