### PR TITLE
chore: dispatch starter updates on core publish and packages update.

### DIFF
--- a/.changeset/sync-builder-starter-manifest.md
+++ b/.changeset/sync-builder-starter-manifest.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add a sync helper for keeping Builder Agent Native Starter's standalone manifest aligned with the chat template scaffold output.

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -125,7 +125,7 @@ jobs:
           # both npm and pnpm read NPM_CONFIG_PROVENANCE.
           NPM_CONFIG_PROVENANCE: "true"
 
-      - name: Generate Builder workspace app token
+      - name: Generate Builder downstream app token
         if: |
           steps.changesets.outputs.published == 'true' &&
           (
@@ -133,12 +133,16 @@ jobs:
             contains(steps.changesets.outputs.publishedPackages, '@agent-native/dispatch')
           )
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
-        id: builder-workspace-token
+        id: builder-downstream-token
         with:
           app-id: ${{ secrets.BUILDER_BOT_FOR_LINT_APP_ID }}
           private-key: ${{ secrets.BUILDER_BOT_FOR_LINT_PRIVATE_KEY }}
           owner: BuilderIO
-          repositories: builder-agent-native-workspace
+          # List every downstream repo this job dispatches to; workspace and
+          # starter each keep their own consumer workflow in their own repo.
+          repositories: |
+            builder-agent-native-workspace
+            builder-agent-native-starter
 
       - name: Trigger Builder workspace package update
         if: |
@@ -148,10 +152,25 @@ jobs:
             contains(steps.changesets.outputs.publishedPackages, '@agent-native/dispatch')
           )
         env:
-          GH_TOKEN: ${{ steps.builder-workspace-token.outputs.token }}
+          GH_TOKEN: ${{ steps.builder-downstream-token.outputs.token }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
           gh api repos/BuilderIO/builder-agent-native-workspace/dispatches \
+            --method POST \
+            -f event_type=agent-native-packages-published \
+            -f "client_payload[publishedPackages]=$PUBLISHED_PACKAGES" \
+            -f "client_payload[sourceRepository]=${{ github.repository }}" \
+            -f "client_payload[sourceRunUrl]=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Trigger Builder starter package update
+        if: |
+          steps.changesets.outputs.published == 'true' &&
+          contains(steps.changesets.outputs.publishedPackages, '@agent-native/core')
+        env:
+          GH_TOKEN: ${{ steps.builder-downstream-token.outputs.token }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          gh api repos/BuilderIO/builder-agent-native-starter/dispatches \
             --method POST \
             -f event_type=agent-native-packages-published \
             -f "client_payload[publishedPackages]=$PUBLISHED_PACKAGES" \

--- a/.github/workflows/sync-builder-starter.yml
+++ b/.github/workflows/sync-builder-starter.yml
@@ -1,0 +1,43 @@
+name: Sync Builder starter manifest
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "templates/chat/package.json"
+      - "pnpm-workspace.yaml"
+      - "packages/core/src/cli/create.ts"
+      - "packages/core/src/cli/sync-builder-starter-manifest.ts"
+      - "scripts/sync-builder-starter-manifest.ts"
+      - ".github/workflows/sync-builder-starter.yml"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: sync-builder-starter-manifest
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Trigger Builder starter manifest sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.BUILDER_BOT_FOR_LINT_APP_ID }}
+          private-key: ${{ secrets.BUILDER_BOT_FOR_LINT_PRIVATE_KEY }}
+          owner: BuilderIO
+          repositories: builder-agent-native-starter
+
+      - name: Notify builder-agent-native-starter
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/BuilderIO/builder-agent-native-starter/dispatches \
+            --method POST \
+            -f event_type=agent-native-starter-template-changed \
+            -f "client_payload[sourceRepository]=${{ github.repository }}" \
+            -f "client_payload[sourceRunUrl]=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  applyWorkspaceFileSync,
+  generateStandaloneChatManifest,
+  mergeStarterManifest,
+  syncStarterManifestFiles,
+  workspaceFileSyncChanged,
+} from "./sync-builder-starter-manifest.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../../..");
+
+describe("sync-builder-starter-manifest", () => {
+  it("generates a standalone chat manifest without workspace or catalog refs", () => {
+    const { packageJson } = generateStandaloneChatManifest(repoRoot);
+    const deps = {
+      ...(packageJson.dependencies as Record<string, string>),
+      ...(packageJson.devDependencies as Record<string, string>),
+    };
+
+    expect(packageJson.name).toBe("builder-agent-native-starter");
+    expect(deps["@agent-native/core"]).toBe("latest");
+    expect(deps.postgres).toBe("^3.4.9");
+    expect(
+      Object.values(deps).some((value) => value.startsWith("workspace:")),
+    ).toBe(false);
+    expect(Object.values(deps).some((value) => value === "catalog:")).toBe(
+      false,
+    );
+  });
+
+  it("preserves starter identity fields and pinned core when merging", () => {
+    const { packageJson: canonical } = generateStandaloneChatManifest(repoRoot);
+    const merged = mergeStarterManifest(
+      {
+        name: "builder-agent-native-starter",
+        displayName: "Builder Agent Native Starter",
+        description: "Workspace app for Builder Agent Native Starter.",
+        private: true,
+        dependencies: {
+          "@agent-native/core": "0.69.0",
+        },
+      },
+      canonical,
+    );
+
+    expect(merged.name).toBe("builder-agent-native-starter");
+    expect(merged.displayName).toBe("Builder Agent Native Starter");
+    expect(merged.description).toBe(
+      "Workspace app for Builder Agent Native Starter.",
+    );
+    expect(
+      (merged.dependencies as Record<string, string>)["@agent-native/core"],
+    ).toBe("0.69.0");
+    expect((merged.dependencies as Record<string, string>).postgres).toBe(
+      "^3.4.9",
+    );
+  });
+
+  describe("syncStarterManifestFiles", () => {
+    let tempDir: string;
+
+    afterEach(() => {
+      if (tempDir) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it("reports no changes when starter already matches the canonical manifest", () => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "an-starter-sync-spec-"));
+      const { packageJson, pnpmWorkspaceYaml } =
+        generateStandaloneChatManifest(repoRoot);
+      const starterPackageJsonPath = path.join(tempDir, "package.json");
+      const starterPnpmWorkspacePath = path.join(
+        tempDir,
+        "pnpm-workspace.yaml",
+      );
+
+      fs.writeFileSync(
+        starterPackageJsonPath,
+        `${JSON.stringify(packageJson, null, 2)}\n`,
+      );
+      if (pnpmWorkspaceYaml) {
+        fs.writeFileSync(starterPnpmWorkspacePath, pnpmWorkspaceYaml);
+      }
+
+      const result = syncStarterManifestFiles({
+        starterPackageJsonPath,
+        starterPnpmWorkspacePath,
+        repoRoot,
+      });
+
+      expect(result.changed).toBe(false);
+    });
+  });
+
+  describe("workspaceFileSyncChanged", () => {
+    it("detects when a stale starter workspace file should be removed", () => {
+      expect(workspaceFileSyncChanged("allowBuilds:\n", null)).toBe(true);
+    });
+
+    it("detects when a starter workspace file should be added", () => {
+      expect(workspaceFileSyncChanged(null, "allowBuilds:\n")).toBe(true);
+    });
+
+    it("detects when workspace file content changed", () => {
+      expect(workspaceFileSyncChanged("old:\n", "new:\n")).toBe(true);
+    });
+
+    it("reports no change when both sides omit the workspace file", () => {
+      expect(workspaceFileSyncChanged(null, null)).toBe(false);
+    });
+  });
+
+  describe("applyWorkspaceFileSync", () => {
+    let tempDir: string;
+    let workspacePath: string;
+
+    afterEach(() => {
+      if (tempDir) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it("deletes the starter workspace file when canonical omits it", () => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "an-starter-sync-spec-"));
+      workspacePath = path.join(tempDir, "pnpm-workspace.yaml");
+      fs.writeFileSync(workspacePath, "allowBuilds:\n");
+
+      applyWorkspaceFileSync(workspacePath, null);
+
+      expect(fs.existsSync(workspacePath)).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/cli/sync-builder-starter-manifest.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.ts
@@ -1,0 +1,275 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { _postProcessStandalone } from "./create.js";
+
+export const STARTER_APP_NAME = "builder-agent-native-starter";
+export const CHAT_TEMPLATE = "chat";
+
+type PackageJson = Record<string, unknown>;
+
+export function findAgentNativeRoot(startDir = process.cwd()): string {
+  let dir = path.resolve(startDir);
+  for (let i = 0; i < 12; i++) {
+    const chatPackageJson = path.join(
+      dir,
+      "templates",
+      CHAT_TEMPLATE,
+      "package.json",
+    );
+    if (fs.existsSync(chatPackageJson)) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(
+    "Could not find agent-native repo root (expected templates/chat/package.json).",
+  );
+}
+
+export function generateStandaloneChatManifest(repoRoot?: string): {
+  packageJson: PackageJson;
+  pnpmWorkspaceYaml: string | null;
+} {
+  const root = repoRoot ?? findAgentNativeRoot();
+  const chatTemplateDir = path.join(root, "templates", CHAT_TEMPLATE);
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "an-builder-starter-sync-"),
+  );
+
+  try {
+    fs.cpSync(chatTemplateDir, tempDir, { recursive: true });
+    _postProcessStandalone(STARTER_APP_NAME, tempDir, CHAT_TEMPLATE);
+
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(tempDir, "package.json"), "utf-8"),
+    ) as PackageJson;
+
+    const workspacePath = path.join(tempDir, "pnpm-workspace.yaml");
+    const pnpmWorkspaceYaml = fs.existsSync(workspacePath)
+      ? fs.readFileSync(workspacePath, "utf-8")
+      : null;
+
+    return { packageJson, pnpmWorkspaceYaml };
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+export function mergeStarterManifest(
+  starterPackageJson: PackageJson,
+  canonicalPackageJson: PackageJson,
+): PackageJson {
+  const merged = structuredClone(canonicalPackageJson) as PackageJson;
+
+  merged.name = starterPackageJson.name ?? STARTER_APP_NAME;
+  if (typeof starterPackageJson.displayName === "string") {
+    merged.displayName = starterPackageJson.displayName;
+  }
+  if (typeof starterPackageJson.description === "string") {
+    merged.description = starterPackageJson.description;
+  }
+  if (starterPackageJson.private !== undefined) {
+    merged.private = starterPackageJson.private;
+  }
+
+  const starterDeps =
+    (starterPackageJson.dependencies as Record<string, string> | undefined) ??
+    {};
+  const canonicalDeps =
+    (canonicalPackageJson.dependencies as Record<string, string> | undefined) ??
+    {};
+  merged.dependencies = {
+    ...canonicalDeps,
+    ...(starterDeps["@agent-native/core"]
+      ? { "@agent-native/core": starterDeps["@agent-native/core"] }
+      : {}),
+  };
+
+  return merged;
+}
+
+export function workspaceFileSyncChanged(
+  existingWorkspace: string | null,
+  canonicalWorkspace: string | null,
+): boolean {
+  if (canonicalWorkspace === null) {
+    return existingWorkspace !== null;
+  }
+  return existingWorkspace !== canonicalWorkspace;
+}
+
+export function applyWorkspaceFileSync(
+  targetPath: string,
+  canonicalWorkspace: string | null,
+): void {
+  if (canonicalWorkspace === null) {
+    if (fs.existsSync(targetPath)) {
+      fs.unlinkSync(targetPath);
+    }
+    return;
+  }
+  fs.writeFileSync(targetPath, canonicalWorkspace);
+}
+
+function stableJson(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export type SyncStarterManifestResult = {
+  changed: boolean;
+  packageJson: PackageJson;
+  pnpmWorkspaceYaml: string | null;
+};
+
+export function syncStarterManifestFiles(options: {
+  starterPackageJsonPath: string;
+  starterPnpmWorkspacePath?: string;
+  repoRoot?: string;
+  write?: boolean;
+}): SyncStarterManifestResult {
+  const { packageJson: canonical, pnpmWorkspaceYaml } =
+    generateStandaloneChatManifest(options.repoRoot);
+
+  const starterPackageJson = JSON.parse(
+    fs.readFileSync(options.starterPackageJsonPath, "utf-8"),
+  ) as PackageJson;
+  const mergedPackageJson = mergeStarterManifest(starterPackageJson, canonical);
+
+  let workspaceChanged = false;
+  const existingWorkspace =
+    options.starterPnpmWorkspacePath &&
+    fs.existsSync(options.starterPnpmWorkspacePath)
+      ? fs.readFileSync(options.starterPnpmWorkspacePath, "utf-8")
+      : null;
+
+  workspaceChanged = workspaceFileSyncChanged(
+    existingWorkspace,
+    pnpmWorkspaceYaml,
+  );
+
+  const packageChanged =
+    stableJson(starterPackageJson) !== stableJson(mergedPackageJson);
+  const changed = packageChanged || workspaceChanged;
+
+  if (options.write && changed) {
+    if (packageChanged) {
+      fs.writeFileSync(
+        options.starterPackageJsonPath,
+        stableJson(mergedPackageJson),
+      );
+    }
+    if (workspaceChanged && options.starterPnpmWorkspacePath) {
+      applyWorkspaceFileSync(
+        options.starterPnpmWorkspacePath,
+        pnpmWorkspaceYaml,
+      );
+    }
+  }
+
+  return {
+    changed,
+    packageJson: mergedPackageJson,
+    pnpmWorkspaceYaml,
+  };
+}
+
+export function parseSyncStarterManifestArgs(argv: string[]): {
+  command: "merge" | "generate";
+  starterPackageJsonPath?: string;
+  starterPnpmWorkspacePath?: string;
+  write: boolean;
+  repoRoot?: string;
+} {
+  const [commandRaw, ...rest] = argv;
+  const command = commandRaw === "generate" ? "generate" : "merge";
+  let starterPackageJsonPath: string | undefined;
+  let starterPnpmWorkspacePath: string | undefined;
+  let write = false;
+  let repoRoot: string | undefined;
+
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === "--write") {
+      write = true;
+      continue;
+    }
+    if (arg === "--starter-package-json") {
+      starterPackageJsonPath = rest[++i];
+      continue;
+    }
+    if (arg === "--starter-pnpm-workspace") {
+      starterPnpmWorkspacePath = rest[++i];
+      continue;
+    }
+    if (arg === "--repo-root") {
+      repoRoot = rest[++i];
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (command === "merge" && !starterPackageJsonPath) {
+    throw new Error(
+      "merge requires --starter-package-json <path> [--starter-pnpm-workspace <path>] [--write] [--repo-root <path>]",
+    );
+  }
+
+  return {
+    command,
+    starterPackageJsonPath,
+    starterPnpmWorkspacePath,
+    write,
+    repoRoot,
+  };
+}
+
+export function runSyncStarterManifestCli(argv: string[]): number {
+  const args = parseSyncStarterManifestArgs(argv);
+
+  if (args.command === "generate") {
+    const { packageJson, pnpmWorkspaceYaml } = generateStandaloneChatManifest(
+      args.repoRoot,
+    );
+    process.stdout.write(stableJson(packageJson));
+    if (pnpmWorkspaceYaml) {
+      process.stdout.write("\n--- pnpm-workspace.yaml ---\n");
+      process.stdout.write(pnpmWorkspaceYaml);
+    }
+    return 0;
+  }
+
+  const result = syncStarterManifestFiles({
+    starterPackageJsonPath: args.starterPackageJsonPath!,
+    starterPnpmWorkspacePath: args.starterPnpmWorkspacePath,
+    repoRoot: args.repoRoot,
+    write: args.write,
+  });
+
+  if (result.changed) {
+    console.log(
+      args.write
+        ? "Updated builder-agent-native-starter manifest from templates/chat."
+        : "builder-agent-native-starter manifest is out of date with templates/chat.",
+    );
+    return args.write ? 0 : 1;
+  }
+
+  console.log(
+    "builder-agent-native-starter manifest already matches templates/chat.",
+  );
+  return 0;
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) ===
+    path.resolve(fileURLToPath(import.meta.url));
+
+if (isDirectRun) {
+  const exitCode = runSyncStarterManifestCli(process.argv.slice(2));
+  process.exit(exitCode);
+}

--- a/scripts/sync-builder-starter-manifest.ts
+++ b/scripts/sync-builder-starter-manifest.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { runSyncStarterManifestCli } from "../packages/core/src/cli/sync-builder-starter-manifest.js";
+
+process.exit(runSyncStarterManifestCli(process.argv.slice(2)));


### PR DESCRIPTION
## Summary

Automate updates to `builder-agent-native-starter` when `@agent-native/core` publishes or when the chat template manifest changes.

- Dispatch to starter from `auto-publish.yml` on `@agent-native/core` publish (workspace dispatch unchanged)
- Add `sync-builder-starter.yml` to dispatch on `templates/chat` / catalog / scaffold changes
- Add `sync-builder-starter-manifest` script that regenerates the standalone manifest via `postProcessStandalone()` and merges into starter while preserving pinned core + repo identity fields

## Test plan

- [ ] `pnpm exec vitest run packages/core/src/cli/sync-builder-starter-manifest.spec.ts`
- [ ] Merge starter repo workflows, then run **Update agent-native packages** on starter
- [ ] Run **Sync agent-native starter manifest** on starter after this merges