### PR TITLE
fix(core): cast agent_runs stale-cutoff param to BIGINT to stop int4 overflow aborting chat

### DIFF
--- a/.changeset/fix-agent-runs-stale-cutoff-int4-param.md
+++ b/.changeset/fix-agent-runs-stale-cutoff-int4-param.md
@@ -1,0 +1,21 @@
+---
+"@agent-native/core": patch
+---
+
+Fix `value "<ms epoch>" is out of range for type integer` aborting agent chat on
+Postgres/Neon at the start of every turn.
+
+The background-aware stale-run cutoff built SQL like
+`COALESCE(heartbeat_at, started_at) >= (? - CASE WHEN dispatch_mode LIKE
+'background%' THEN 90000 ELSE 15000 END)` and bound `Date.now()` to the
+parameter. Postgres infers an untyped parameter's type from its surrounding
+expression, and because the `15000`/`90000` window literals are `int4`, it typed
+the parameter as `int4` too — so a millisecond epoch like `1782295529106`
+overflowed even though every column involved is already `BIGINT`. This is a
+query-level type-inference bug, independent of column types, which is why the
+`widenIntColumnsToBigInt()` shim could never fix it.
+
+The cutoff now wraps the parameter in `CAST(? AS BIGINT)`, pinning it to int8 so
+the subtraction stays 64-bit. SQLite treats `CAST(x AS BIGINT)` as INTEGER
+affinity, so it is a no-op there. Fixes `tryClaimRunSlot`, `reapIfStale`,
+`reapAllStaleRuns`, and `cleanupOldRuns`, which all share the cutoff.

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -190,10 +190,12 @@ describe("run store", () => {
       (call) =>
         /SELECT id FROM agent_runs/i.test(call.sql) &&
         // The heartbeat predicate now uses the background-aware cutoff fragment
-        // `(? - CASE WHEN dispatch_mode LIKE 'background%' THEN ... END)` so a
-        // slow background cold-start isn't reaped early. Still one query, still
-        // covering both predicates.
-        /COALESCE\(heartbeat_at, started_at\) < \(\? -/.test(call.sql) &&
+        // `(CAST(? AS BIGINT) - CASE WHEN dispatch_mode LIKE 'background%' THEN
+        // ... END)` so a slow background cold-start isn't reaped early. Still one
+        // query, still covering both predicates.
+        /COALESCE\(heartbeat_at, started_at\) < \(CAST\(\? AS BIGINT\) -/.test(
+          call.sql,
+        ) &&
         /dispatch_mode LIKE 'background%'/.test(call.sql) &&
         /OR started_at < \?/.test(call.sql),
     );
@@ -276,6 +278,23 @@ describe("run store", () => {
     expect(select).toBeDefined();
     // The heartbeat cutoff arg must be a recent timestamp
     expect(Number(select?.args[1])).toBeGreaterThan(Date.now() - 60_000);
+  });
+
+  it("tryClaimRunSlot casts the now param to BIGINT so a ms epoch can't be typed as int4", async () => {
+    // Regression: the default (background-aware) cutoff does `? - <int4
+    // literal>` in SQL. Without an explicit cast Postgres infers the parameter
+    // as int4 from the literal windows, and Date.now() overflows with
+    // `value "…" is out of range for type integer`, failing every chat turn.
+    claimSlotRows = [];
+    await tryClaimRunSlot("thread-cast");
+    const select = execCalls.find(
+      (call) =>
+        /SELECT id FROM agent_runs\s*WHERE thread_id/i.test(call.sql) &&
+        /COALESCE\(heartbeat_at, started_at\) >=/i.test(call.sql),
+    );
+    expect(select?.sql).toMatch(/CAST\(\?\s+AS\s+BIGINT\)\s*-\s*CASE/i);
+    // And the bound value is a full ms epoch (would overflow int4).
+    expect(Number(select?.args[1])).toBeGreaterThan(2_147_483_647);
   });
 
   // Fix 1c: conditional terminal status write

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -306,7 +306,10 @@ export async function insertRun(
  * states get the wider window via a LIKE-prefix match.
  */
 function backgroundAwareStaleCutoffSql(): string {
-  return `(? - CASE WHEN dispatch_mode LIKE 'background%' THEN ${BACKGROUND_RUN_STALE_MS} ELSE ${RUN_STALE_MS} END)`;
+  // `CAST(? AS BIGINT)` is required: without it Postgres infers the param as
+  // int4 from the int4 window literals, so the bound `Date.now()` ms epoch
+  // overflows int4. The cast keeps the subtraction 64-bit; a no-op on SQLite.
+  return `(CAST(? AS BIGINT) - CASE WHEN dispatch_mode LIKE 'background%' THEN ${BACKGROUND_RUN_STALE_MS} ELSE ${RUN_STALE_MS} END)`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Agent chat aborted on every turn on Postgres/Neon with:

> `{"error":"value "1782295529106" is out of range for type integer"}` (code: `connection_error`)

`tryClaimRunSlot` runs at the start of each turn and built its stale-run cutoff as:

​```sql
COALESCE(heartbeat_at, started_at) >= (? - CASE WHEN dispatch_mode LIKE 'background%' THEN 90000 ELSE 15000 END)
-- bound: Date.now()  e.g. 1782295529106
​```

Postgres infers an untyped parameter's type from its surrounding expression. Because the `15000`/`90000` window literals are `int4`, it typed the `?` param as `int4` too, so the bound `Date.now()` ms epoch overflowed — **even though every column involved (`started_at`, `heartbeat_at`, …) is already `BIGINT`**. This is a query-level type-inference bug, independent of column width, which is why column-widening could never address it.

## Fix

Wrap the parameter in `CAST(? AS BIGINT)` in `backgroundAwareStaleCutoffSql()` so the subtraction stays 64-bit. SQLite treats `CAST(x AS BIGINT)` as INTEGER affinity, so it's a no-op there. The fragment is shared by `tryClaimRunSlot`, `reapIfStale`, `reapAllStaleRuns`, and `cleanupOldRuns`, so all are fixed at once.

## Test plan

- [x] `vitest run src/agent/run-store.spec.ts` — 23/23 pass
- [x] Added regression test asserting the cutoff SQL uses `CAST(? AS BIGINT)` and binds a full ms epoch (> int4 max)
- [x] Updated the existing reaper test regex for the new cutoff form
- [x] `tsc --noEmit` clean; core rebuilt
- [x] Verified on localhost against Neon: chat no longer 500s