### PR TITLE
Fix voice dictation "No speech detected" by calling engine.prepare() before reading input format

### DIFF
--- a/templates/clips/desktop/src-tauri/src/native_speech.rs
+++ b/templates/clips/desktop/src-tauri/src/native_speech.rs
@@ -597,6 +597,15 @@ pub(crate) mod macos {
             mic_device_label.as_deref(),
         )?;
         let input_node = unsafe { engine.inputNode() };
+        // Finalize input-device format negotiation before reading the format.
+        // When `configure_engine_input_device` pins a specific mic, the AUHAL's
+        // current device is switched; the input node's `outputFormatForBus(0)`
+        // only reflects the new device after `prepare()` runs. Reading it first
+        // returns a stale format, so the tap gets installed with a mismatched
+        // format and forwards no usable audio to the recognizer — the user
+        // speaks but SFSpeechRecognizer reports "No speech detected". Mirrors
+        // the working `start_raw_mic_capture` ordering.
+        unsafe { engine.prepare() };
         let format = unsafe { input_node.outputFormatForBus(0) };
 
         // Install a tap that forwards every PCM buffer into the recognition


### PR DESCRIPTION
### Summary
Fixes voice dictation silently failing with "No speech detected" in the clips/desktop template by calling `engine.prepare()` before reading the input node's audio format.

### Problem
Users reported that voice dictation consistently failed — they would speak but the native `SFSpeechRecognizer` would report "No speech detected" and produce no transcript. The logs showed the recognizer starting and stopping correctly, but never capturing any audio.

### Solution
When `configure_engine_input_device` pins a specific microphone, the AUHAL's current device is switched internally. However, `inputNode.outputFormatForBus(0)` only reflects the new device's format *after* `engine.prepare()` has been called. Reading the format before `prepare()` returns a stale format from the previous device, causing the tap to be installed with a mismatched format — forwarding no usable audio to the recognizer. The fix is to call `engine.prepare()` before reading the format, mirroring the ordering already used in the working `start_raw_mic_capture` path.

### Key Changes
- In `native_speech.rs` (macOS), added `unsafe { engine.prepare() }` immediately after configuring the input device and before calling `input_node.outputFormatForBus(0)`, ensuring the audio tap is installed with the correct post-device-switch format.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/tiny-tooth-vntocirv"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-tiny-tooth-vntocirv.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1425`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>tiny-tooth-vntocirv</branchName>-->