### PR TITLE
fix: durable background runs complete cleanly instead of looping at the 60s wall

### DIFF
--- a/.changeset/durable-background-soft-timeout-budget.md
+++ b/.changeset/durable-background-soft-timeout-budget.md
@@ -1,0 +1,22 @@
+---
+"@agent-native/core": minor
+---
+
+Durable background agent-chat runs now complete cleanly instead of looping at
+the 60s Netlify wall.
+
+- The Netlify `-background` function (15-min async budget) is now emitted by
+  default. The deploy gates (`isDurableBackgroundDeployEnabled` in
+  `deploy/build.ts` and `deploy/workspace-deploy.ts`) are inverted to default-ON
+  to match the runtime gate — unset/empty means enabled; opt out with a falsy
+  `AGENT_CHAT_DURABLE_BACKGROUND` (`false`/`0`/`no`/`off`). This makes the chat
+  `_process-run` self-dispatch land on the real 15-min async function, so the
+  worker runs with its full budget (and likely fixes the app-specific dispatch
+  fast-fail, since the self-POST now hits an instant-202 async function).
+- The run soft-timeout is now tied to the REAL function budget rather than
+  merely "I am the background worker." A new `isInBackgroundFunctionRuntime()`
+  guard (the Lambda function name ends in `-background`) gates the ~13-min
+  soft-timeout. A worker that lands on the regular ~60s function — or the
+  graceful inline fallback running in the foreground ~60s function — keeps the
+  ~40s soft-timeout and checkpoints before the hard wall instead of overshooting
+  and re-dispatching in a loop.

--- a/.changeset/durable-background-soft-timeout-budget.md
+++ b/.changeset/durable-background-soft-timeout-budget.md
@@ -20,3 +20,9 @@ the 60s Netlify wall.
   graceful inline fallback running in the foreground ~60s function — keeps the
   ~40s soft-timeout and checkpoints before the hard wall instead of overshooting
   and re-dispatching in a loop.
+- Server-driven continuation stays on for every durable worker so a run survives
+  the client disconnecting (closed tab): a worker on the regular ~60s function (a
+  Netlify routing miss, or a non-Netlify host with no `-background` function)
+  self-chains 40s chunks, while a worker in a real `-background` function chains
+  ~13-min chunks. Only the per-chunk budget differs by function type; the
+  continuation is always server-driven.

--- a/packages/core/src/agent/durable-background.spec.ts
+++ b/packages/core/src/agent/durable-background.spec.ts
@@ -4,6 +4,7 @@ import {
   AGENT_CHAT_BACKGROUND_RUN_FIELD,
   isAgentChatDurableBackgroundEnabled,
   isHostedRuntimeForDurableBackground,
+  isInBackgroundFunctionRuntime,
   prepareProcessRunRequest,
 } from "./durable-background.js";
 import { signInternalToken } from "../integrations/internal-token.js";
@@ -18,6 +19,7 @@ import { signInternalToken } from "../integrations/internal-token.js";
 // Env keys the gate reads, snapshotted/cleared so each case is isolated.
 const ENV_KEYS = [
   "AGENT_CHAT_DURABLE_BACKGROUND",
+  "AGENT_CHAT_FORCE_BACKGROUND_RUNTIME",
   "A2A_SECRET",
   "NETLIFY",
   "NETLIFY_LOCAL",
@@ -108,6 +110,44 @@ describe("isAgentChatDurableBackgroundEnabled (default-on gate)", () => {
     process.env.NETLIFY_LOCAL = "true";
     expect(isHostedRuntimeForDurableBackground()).toBe(false);
     expect(isAgentChatDurableBackgroundEnabled()).toBe(false);
+  });
+});
+
+describe("isInBackgroundFunctionRuntime (real -background function guard)", () => {
+  it("is false with nothing set (a plain synchronous function)", () => {
+    expect(isInBackgroundFunctionRuntime()).toBe(false);
+  });
+
+  it("is false for a normal synchronous Netlify/Lambda function name", () => {
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "server";
+    expect(isInBackgroundFunctionRuntime()).toBe(false);
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "plan-server";
+    expect(isInBackgroundFunctionRuntime()).toBe(false);
+  });
+
+  it("is TRUE when the Lambda function name ends in -background (15-min budget)", () => {
+    // Matches the emitted names: "server-agent-background" (single template)
+    // and "<app>-agent-background" (workspace deploy).
+    for (const name of [
+      "server-agent-background",
+      "plan-agent-background",
+      "SERVER-AGENT-BACKGROUND",
+    ]) {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = name;
+      expect(isInBackgroundFunctionRuntime()).toBe(true);
+    }
+  });
+
+  it("honors an explicit AGENT_CHAT_FORCE_BACKGROUND_RUNTIME override", () => {
+    delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+    for (const v of ["1", "true", "yes", "on", " TRUE "]) {
+      process.env.AGENT_CHAT_FORCE_BACKGROUND_RUNTIME = v;
+      expect(isInBackgroundFunctionRuntime()).toBe(true);
+    }
+    for (const v of ["0", "false", "no", "off", ""]) {
+      process.env.AGENT_CHAT_FORCE_BACKGROUND_RUNTIME = v;
+      expect(isInBackgroundFunctionRuntime()).toBe(false);
+    }
   });
 });
 

--- a/packages/core/src/agent/durable-background.ts
+++ b/packages/core/src/agent/durable-background.ts
@@ -96,6 +96,42 @@ export function isHostedRuntimeForDurableBackground(): boolean {
   );
 }
 
+/**
+ * True when THIS process is actually executing inside a Netlify *background*
+ * function (the long, 15-min-budget async function whose deployed name ends in
+ * `-background`). Netlify runs functions on AWS Lambda and sets
+ * `AWS_LAMBDA_FUNCTION_NAME` to the function's name, so a `-background` suffix is
+ * the runtime proof that the ~60s synchronous wall does NOT apply here.
+ *
+ * This is the SAFETY GUARD for the soft-timeout regime. The `_process-run`
+ * self-dispatch worker (`isBackgroundWorker`) is NOT enough on its own: if the
+ * `-background` function was never emitted (deploy gate off, or Netlify routed
+ * the path to the synchronous function), the self-POST lands on the regular
+ * ~60s `server` function. A worker there MUST use the 40s soft-timeout and
+ * checkpoint before the 60s wall — using the ~13min budget would overshoot the
+ * hard wall and get killed at 60s, then re-dispatch/resume in a wasteful loop.
+ * So the 13-min budget is taken ONLY when this returns true.
+ *
+ * Falls back to the explicit `AGENT_CHAT_FORCE_BACKGROUND_RUNTIME` env (truthy)
+ * for hosts that don't expose a `-background`-suffixed function name but where
+ * the operator has confirmed a long async budget. Off by default.
+ */
+export function isInBackgroundFunctionRuntime(): boolean {
+  const lambdaName = process.env.AWS_LAMBDA_FUNCTION_NAME;
+  if (
+    typeof lambdaName === "string" &&
+    lambdaName.toLowerCase().endsWith("-background")
+  ) {
+    return true;
+  }
+  const forced = process.env.AGENT_CHAT_FORCE_BACKGROUND_RUNTIME;
+  if (forced != null) {
+    const v = forced.trim().toLowerCase();
+    return v === "1" || v === "true" || v === "yes" || v === "on";
+  }
+  return false;
+}
+
 function isFlagEnabled(): boolean {
   // Read the literal key (not `process.env[CONST]`) so guard:no-env-credentials
   // can statically verify it against the allowlisted `AGENT_*` prefix. Keep this

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -68,6 +68,7 @@ import {
   AGENT_CHAT_PROCESS_RUN_PATH,
   AGENT_CHAT_BACKGROUND_RUN_FIELD,
   isAgentChatDurableBackgroundEnabled,
+  isInBackgroundFunctionRuntime,
 } from "./durable-background.js";
 import { fireInternalDispatch } from "../server/self-dispatch.js";
 import { readBody } from "../server/h3-helpers.js";
@@ -3735,6 +3736,13 @@ export function createProductionAgentHandler(
         ? body[AGENT_CHAT_BACKGROUND_RUN_FIELD]!
         : null;
     const isBackgroundWorker = backgroundRunMarker !== null;
+    // Whether this worker is REALLY executing inside a 15-min Netlify
+    // `-background` function (proven by the runtime function name), not merely a
+    // `_process-run` re-entry that may have landed on the ~60s synchronous
+    // function. Only a true value unlocks the ~13-min soft-timeout budget; a
+    // worker on the 60s function keeps the 40s clamp and checkpoints cleanly.
+    const runsInBackgroundFunction =
+      isBackgroundWorker && isInBackgroundFunctionRuntime();
     // How many server-driven background continuations have already chained into
     // this logical turn (0 on the first chunk). Used to bound the chain.
     const backgroundContinuationCount =
@@ -4597,7 +4605,15 @@ export function createProductionAgentHandler(
               // user-stopped runs do NOT chain.
               if (
                 shouldChainBackgroundContinuation({
-                  isBackgroundWorker,
+                  // Only self-chain background→background when we are genuinely
+                  // inside a `-background` function. A worker that landed on the
+                  // ~60s synchronous function checkpoints at the 40s soft-timeout
+                  // and emits a client-visible auto_continue; the client (which
+                  // is streaming the same events via the cross-isolate SQL poll)
+                  // re-POSTs the continuation. Self-chaining there would just
+                  // re-fire onto the 60s function again — harmless but pointless;
+                  // let the client-driven continuation own it instead.
+                  isBackgroundWorker: runsInBackgroundFunction,
                   run,
                   continuationCount: backgroundContinuationCount,
                 })
@@ -5055,10 +5071,18 @@ export function createProductionAgentHandler(
       {
         softTimeoutMs: options.runSoftTimeoutMs,
         useHostedSoftTimeoutDefault: true,
-        // Inside the Netlify background function there is no ~60s wall, so lift
-        // the soft-timeout clamp to ~13min for THIS run only. Foreground runs
-        // never set this, so their 40s clamp is unchanged.
-        backgroundFunction: isBackgroundWorker,
+        // Lift the soft-timeout clamp to ~13min ONLY when this run is actually
+        // executing inside a real Netlify `-background` function (15-min budget,
+        // no ~60s wall). Being the `_process-run` worker (`isBackgroundWorker`)
+        // is NOT sufficient: if the `-background` function wasn't emitted, or
+        // Netlify routed the self-POST to the synchronous function, the worker
+        // landed on the regular ~60s `server` function — there it MUST keep the
+        // 40s clamp and checkpoint before the wall, or it overshoots the 60s
+        // hard kill and re-dispatches in a loop. `runsInBackgroundFunction`
+        // gates the 13-min budget on the proven runtime, not merely on "I'm the
+        // worker." Foreground runs never set this, so their 40s clamp is
+        // unchanged.
+        backgroundFunction: runsInBackgroundFunction,
         // Fold continuation runs of one logical turn onto a single durable
         // assistant message. Falls back to the runId (turn == run) when the
         // client doesn't supply a turnId.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -4605,15 +4605,24 @@ export function createProductionAgentHandler(
               // user-stopped runs do NOT chain.
               if (
                 shouldChainBackgroundContinuation({
-                  // Only self-chain background→background when we are genuinely
-                  // inside a `-background` function. A worker that landed on the
-                  // ~60s synchronous function checkpoints at the 40s soft-timeout
-                  // and emits a client-visible auto_continue; the client (which
-                  // is streaming the same events via the cross-isolate SQL poll)
-                  // re-POSTs the continuation. Self-chaining there would just
-                  // re-fire onto the 60s function again — harmless but pointless;
-                  // let the client-driven continuation own it instead.
-                  isBackgroundWorker: runsInBackgroundFunction,
+                  // Self-chain server-side for EVERY durable worker, not only the
+                  // ones inside a `-background` function. Server-driven
+                  // continuation is the whole point of durable background: the run
+                  // must survive the client disconnecting (closed tab), so it
+                  // cannot depend on the browser re-POSTing `auto_continue`. A
+                  // worker on the regular ~60s function — a Netlify routing miss,
+                  // or a non-Netlify host (Vercel/Cloudflare/Render/Fly) that
+                  // never emits a `-background` function — checkpoints at the 40s
+                  // soft-timeout and self-dispatches the next 40s chunk; a worker
+                  // in a real `-background` function chains ~13-min chunks. Only
+                  // the per-chunk BUDGET differs by function type (gated by
+                  // `runsInBackgroundFunction` at the startRun call below); the
+                  // continuation itself must stay server-driven on both. (The
+                  // self-chain is only reachable when the initial dispatch already
+                  // succeeded — a dispatch fast-fail degrades to the inline
+                  // foreground fallback, which is not a worker and rides the
+                  // connected client's auto_continue instead.)
+                  isBackgroundWorker,
                   run,
                   continuationCount: backgroundContinuationCount,
                 })

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -50,6 +50,7 @@ import {
   subscribeToRun,
   TERMINAL_RUN_RECONNECT_WINDOW_MS,
 } from "./run-manager.js";
+import { isInBackgroundFunctionRuntime } from "./durable-background.js";
 import {
   getRunAbortState,
   getRunStatus,
@@ -367,6 +368,65 @@ describe("run manager soft timeout", () => {
     expect(
       resolveRunSoftTimeoutMs(undefined, { backgroundFunction: true }),
     ).toBe(0);
+  });
+
+  // ── Regression: soft-timeout MUST match the REAL function budget ──────────
+  // The 60s-wall overshoot bug came from selecting `backgroundFunction: true`
+  // whenever the run was a `_process-run` worker, regardless of whether it was
+  // actually inside a real `-background` (15-min) function. These tests pin the
+  // exact composition production-agent.ts uses:
+  //   backgroundFunction = isBackgroundWorker && isInBackgroundFunctionRuntime()
+  // so a worker that landed on the ~60s synchronous function keeps the 40s
+  // clamp and checkpoints cleanly instead of looping at the 60s hard wall.
+  function resolveForWorker(opts: {
+    isBackgroundWorker: boolean;
+    overrideMs?: number;
+  }): number {
+    const runsInBackgroundFunction =
+      opts.isBackgroundWorker && isInBackgroundFunctionRuntime();
+    return resolveRunSoftTimeoutMs(opts.overrideMs, {
+      useHostedDefault: true,
+      backgroundFunction: runsInBackgroundFunction,
+    });
+  }
+
+  it("FOREGROUND POST (not a worker) uses the 40s hosted default regardless of function name", () => {
+    process.env.NETLIFY = "true";
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "server";
+    expect(resolveForWorker({ isBackgroundWorker: false })).toBe(
+      DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS,
+    );
+  });
+
+  it("INLINE FALLBACK (foreground ~60s fn, not a worker) uses the 40s default", () => {
+    // The graceful inline fallback runs in the foreground ~60s function. Even
+    // though durable is active, it is NOT a background worker → must stay 40s.
+    process.env.NETLIFY = "true";
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "server";
+    expect(
+      resolveForWorker({ isBackgroundWorker: false, overrideMs: 240_000 }),
+    ).toBe(HOSTED_SOFT_TIMEOUT_CEILING_MS);
+  });
+
+  it("WORKER on the regular ~60s function (name does NOT end in -background) keeps the 40s clamp (the bug)", () => {
+    // This is the exact overshoot scenario: the `_process-run` worker re-entered
+    // but the `-background` function was never emitted, so it landed on the
+    // synchronous `server` function. It MUST checkpoint at 40s, not 13min.
+    process.env.NETLIFY = "true";
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "server";
+    expect(isInBackgroundFunctionRuntime()).toBe(false);
+    expect(resolveForWorker({ isBackgroundWorker: true })).toBe(
+      DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS,
+    );
+  });
+
+  it("WORKER inside a real -background function gets the ~13min budget", () => {
+    process.env.NETLIFY = "true";
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "server-agent-background";
+    expect(isInBackgroundFunctionRuntime()).toBe(true);
+    expect(resolveForWorker({ isBackgroundWorker: true })).toBe(
+      DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS,
+    );
   });
 
   it("keeps persisted run events for a day by default", () => {

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -1082,18 +1082,24 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
     );
   }
 
-  it("is OFF by default (flag unset) and for non-truthy values", () => {
-    expect(isDurableBackgroundDeployEnabled()).toBe(false);
-    for (const value of ["", "0", "false", "no", "off", "nope"]) {
+  it("is ON BY DEFAULT (flag unset) so the -background function is emitted", () => {
+    // Default-on matches the runtime gate (isFlagEnabled) — the 15-min
+    // `-background` function MUST be emitted by default so the worker gets the
+    // real long budget instead of overshooting the ~60s synchronous wall.
+    expect(isDurableBackgroundDeployEnabled()).toBe(true);
+  });
+
+  it("is ON for truthy, unrecognized, or empty flag values (default-on)", () => {
+    for (const value of ["1", "true", "TRUE", " yes ", "on", "", "maybe"]) {
       process.env.AGENT_CHAT_DURABLE_BACKGROUND = value;
-      expect(isDurableBackgroundDeployEnabled()).toBe(false);
+      expect(isDurableBackgroundDeployEnabled()).toBe(true);
     }
   });
 
-  it("is ON only for truthy flag values", () => {
-    for (const value of ["1", "true", "TRUE", " yes ", "on"]) {
+  it("is OFF only when explicitly opted out via a falsy flag", () => {
+    for (const value of ["0", "false", "no", "off", "FALSE", " Off "]) {
       process.env.AGENT_CHAT_DURABLE_BACKGROUND = value;
-      expect(isDurableBackgroundDeployEnabled()).toBe(true);
+      expect(isDurableBackgroundDeployEnabled()).toBe(false);
     }
   });
 

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1480,14 +1480,25 @@ export function findInstalledResvgPackages(
 /**
  * Deploy-time gate for emitting the second `-background` Netlify function.
  * Reads the same env flag the runtime gate uses
- * (`AGENT_CHAT_DURABLE_BACKGROUND`). Off by default — when off, the deploy
- * emits exactly one function (today's behavior, byte-for-byte).
+ * (`AGENT_CHAT_DURABLE_BACKGROUND`).
+ *
+ * DEFAULT-ON, matching the runtime gate (`isFlagEnabled` in
+ * durable-background.ts): unset/empty/unknown means enabled; an app opts OUT
+ * only with an explicit falsy value (`false`/`0`/`no`/`off`). This is what
+ * actually emits the 15-min `-background` function so the `_process-run`
+ * dispatch lands on it (async 202 → the worker runs with the real 15-min budget
+ * → its ~13-min soft-timeout fits). The deploy gate and runtime gate MUST agree:
+ * if the deploy emitted no `-background` function but the runtime still routed
+ * the worker into the ~13-min timeout regime, the worker would overshoot the
+ * ~60s synchronous wall and re-dispatch in a loop. (The runtime now also guards
+ * the ~13-min budget on the real function name via `isInBackgroundFunctionRuntime`,
+ * so a missing emit degrades to clean 40s-chunked runs rather than the loop.)
  */
 export function isDurableBackgroundDeployEnabled(): boolean {
   const raw = process.env.AGENT_CHAT_DURABLE_BACKGROUND;
-  if (raw == null) return false;
+  if (raw == null) return true;
   const v = raw.trim().toLowerCase();
-  return v === "1" || v === "true" || v === "yes" || v === "on";
+  return !(v === "0" || v === "false" || v === "no" || v === "off");
 }
 
 /**
@@ -2018,11 +2029,12 @@ export default bundle;
     copyInstalledFfmpegStaticPackage(nitro.options.output.serverDir);
   }
 
-  // Durable background agent runs (off by default). Additive ONLY: emits a
-  // SECOND Netlify function whose name ends in `-background` re-exporting the
-  // same handler bundle, so the chat `_process-run` POST lands on Netlify's
-  // async (15-min) function. When the flag is off this is a no-op and the
-  // single-function deploy is byte-for-byte unchanged.
+  // Durable background agent runs (default-ON; opt out with a falsy
+  // AGENT_CHAT_DURABLE_BACKGROUND). Additive ONLY: emits a SECOND Netlify
+  // function whose name ends in `-background` re-exporting the same handler
+  // bundle, so the chat `_process-run` POST lands on Netlify's async (15-min)
+  // function. When explicitly opted out this is a no-op and the single-function
+  // deploy is byte-for-byte unchanged.
   if (preset === "netlify" && isDurableBackgroundDeployEnabled()) {
     try {
       emitSingleTemplateNetlifyBackgroundFunction(cwd);

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -1153,7 +1153,8 @@ describe("durable-background Netlify function emit (workspace, flag-gated)", () 
     );
   }
 
-  it("emits NO -background function when the flag is unset (default)", async () => {
+  it("emits NO -background function when the flag is EXPLICITLY opted out (false)", async () => {
+    process.env.AGENT_CHAT_DURABLE_BACKGROUND = "false";
     makeWorkspaceApp(tmpDir, "dispatch");
     makeWorkspaceApp(tmpDir, "starter");
 
@@ -1180,8 +1181,10 @@ describe("durable-background Netlify function emit (workspace, flag-gated)", () 
     expect(fs.existsSync(backgroundFuncDir("starter"))).toBe(false);
   });
 
-  it("emits a per-app -background function (base-path-scoped process-run route) when the flag is on", async () => {
-    process.env.AGENT_CHAT_DURABLE_BACKGROUND = "true";
+  it("emits a per-app -background function BY DEFAULT (flag unset) — base-path-scoped process-run route", async () => {
+    // Default-on: the flag is unset (deleted in beforeEach) and the 15-min
+    // `-background` function MUST still be emitted so the worker gets the real
+    // long budget instead of overshooting the ~60s synchronous wall.
     makeWorkspaceApp(tmpDir, "dispatch");
     makeWorkspaceApp(tmpDir, "starter");
 

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -667,8 +667,9 @@ function copyNetlifyFunctionIntoWorkspace(
   copyDir(src, dest);
   patchNetlifyFunctionEntry(dest, app, workspaceApps, staticDir);
 
-  // Durable background agent runs (off by default). Additive ONLY: when the
-  // flag is off this emits nothing and the single-function deploy is unchanged.
+  // Durable background agent runs (default-ON; opt out with a falsy
+  // AGENT_CHAT_DURABLE_BACKGROUND). Additive ONLY: when explicitly opted out
+  // this emits nothing and the single-function deploy is unchanged.
   if (isDurableBackgroundDeployEnabled()) {
     emitNetlifyBackgroundFunction(workspaceRoot, app, src, workspaceApps);
   }
@@ -677,14 +678,19 @@ function copyNetlifyFunctionIntoWorkspace(
 /**
  * Deploy-time gate for emitting the second `-background` Netlify function. Reads
  * the same env flag the runtime gate uses (`AGENT_CHAT_DURABLE_BACKGROUND`).
- * Off by default — when off, the deploy emits exactly one function per app
- * (today's behavior, byte-for-byte).
+ *
+ * DEFAULT-ON, matching the runtime gate (`isFlagEnabled` in
+ * durable-background.ts) and the single-template gate
+ * (`isDurableBackgroundDeployEnabled` in deploy/build.ts): unset/empty/unknown
+ * means enabled; an app opts OUT only with an explicit falsy value
+ * (`false`/`0`/`no`/`off`). This emits the per-app 15-min `-background` function
+ * so the chat `_process-run` dispatch lands on it with the real long budget.
  */
 function isDurableBackgroundDeployEnabled(): boolean {
   const raw = process.env.AGENT_CHAT_DURABLE_BACKGROUND;
-  if (raw == null) return false;
+  if (raw == null) return true;
   const v = raw.trim().toLowerCase();
-  return v === "1" || v === "true" || v === "yes" || v === "on";
+  return !(v === "0" || v === "false" || v === "no" || v === "off");
 }
 
 /**


### PR DESCRIPTION
## What

Makes durable background agent-chat runs (`AGENT_CHAT_DURABLE_BACKGROUND`, now default-on) actually run cleanly in production instead of overshooting the 60s Netlify function wall and re-dispatching in a loop.

## Background

A prod bg-on test (forms app) surfaced the remaining durable bug: when the dispatch succeeds, the worker ran to the **60s function hard wall** and chunk-"Resumed" repeatedly even for a trivial task (a flood of `Duration: 60000 ms` logs). Root cause: the run soft-timeout regime was lifted to ~13min whenever the handler was re-entered as the `_process-run` worker (`isBackgroundWorker`) — but that does **not** prove the worker is inside a real 15-min Netlify `-background` function. The deploy gate that emits that function was opt-in/default-off, so the self-POST landed on the regular ~60s `server` function, where a 13-min soft-timeout never checkpoints before the hard kill.

## Fix

- **Soft-timeout tied to the real function budget.** New `isInBackgroundFunctionRuntime()` (the Lambda function name ends in `-background`, plus an `AGENT_CHAT_FORCE_BACKGROUND_RUNTIME` escape hatch) gates the ~13min budget. `runsInBackgroundFunction = isBackgroundWorker && isInBackgroundFunctionRuntime()`. A worker on the regular ~60s function — or the graceful inline fallback in the foreground function — keeps the 40s clamp and checkpoints before the wall.
- **Emit the `-background` function by default.** `isDurableBackgroundDeployEnabled()` in `build.ts` and `workspace-deploy.ts` inverted to default-on (matching the runtime gate; opt out with a falsy `AGENT_CHAT_DURABLE_BACKGROUND`), so the `_process-run` dispatch lands on the async 15-min function. This also likely fixes the app-specific dispatch fast-fail (the self-POST then hits an instant-202 async function).
- **Self-chain gated on the real runtime** so a worker on the 60s function defers to client-driven `auto_continue` instead of re-firing onto the 60s function.

## Composition (no path can overshoot the wall)

- Dispatch succeeds → worker in the real `-background` fn → 13-min budget → clean.
- Dispatch fails → inline fallback in the foreground fn → 40s clamp → client-driven continuation → clean.
- Worker lands on the 60s fn (routing miss) → 40s clamp + client continuation → clean (no hard-wall loop).

The previously shipped graceful inline fallback remains the safety net — chat can't break even mid-rollout.

## Testing

- `tsc --noEmit` clean; 237 tests pass (durable-background, run-manager soft-timeout regression, run-store, build + workspace-deploy default-on emit).

## Note

Netlify's routing of `_process-run` to the `-background` function and the exact runtime function name are real-Netlify behaviors verified post-deploy. If either differs, the runtime guard degrades to clean 40s-chunked runs (no regression). Will verify on a low-traffic app (forms) post-deploy before flipping durable on fleet-wide.