### PR TITLE
fix: durable -background function needs background:true for Netlify's 15-min async budget

### DIFF
--- a/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
+++ b/.agents/plugins/agent-native-visual-plans/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-native-visual-plans",
-  "version": "1.0.0+codex.9d5271d22be4",
+  "version": "1.0.0+codex.d67302c46128",
   "description": "Create rich interactive visual plans and recaps with diagrams, file maps, annotated code and diffs, API/schema summaries, feedback, and HTML export.",
   "author": { "name": "Agent-Native", "url": "https://agent-native.com" },
   "homepage": "https://plan.agent-native.com",

--- a/.agents/plugins/agent-native-visual-plans/skills/visual-plan/SKILL.md
+++ b/.agents/plugins/agent-native-visual-plans/skills/visual-plan/SKILL.md
@@ -489,14 +489,16 @@ sign-in at setup — this is intended), so the first tool call in that client do
 not hit an OAuth wall:
 
 ```bash
-npx @agent-native/core@latest skills add visual-plan
+npx @agent-native/core@latest skills add visual-plans
 ```
 
 After that, `/visual-plan` and `/visual-recap` are the two installed slash
-commands. The other planning modes (`create-ui-plan`, `create-prototype-plan`,
-`create-plan-design`, `create-visual-questions`) are MCP tools reachable from
-`/visual-plan`, not separate slash commands. Pass `--no-connect` to register
-the connector without authenticating, then run
+commands. If you only need one command, use `skills add visual-plan` or
+`skills add visual-recap` instead. The other planning modes
+(`create-ui-plan`, `create-prototype-plan`, `create-plan-design`,
+`create-visual-questions`) are MCP tools reachable from `/visual-plan`, not
+separate slash commands. Pass `--no-connect` to register the connector without
+authenticating, then run
 `npx @agent-native/core@latest connect https://plan.agent-native.com --client all`
 whenever you are ready, or choose a narrower `--client`. Auth and MCP tool
 loading are per client config/session.

--- a/.changeset/durable-background-async-202.md
+++ b/.changeset/durable-background-async-202.md
@@ -1,0 +1,15 @@
+---
+"@agent-native/core": patch
+---
+
+Durable background agent-chat runs now actually receive Netlify's 15-min async
+budget. The emitted `-background` function declared a custom `config.path` but
+omitted `background: true`, so Netlify served it SYNCHRONOUSLY (~60s) — the
+`config` object overrides the legacy `-background` filename convention — and the
+durable worker was capped at the 60s wall (it degraded to 40s-chunked runs and
+never used the 15-min budget). The emit now sets `background: true` (immediate
+202 ack + 15-min execution) and force-marks the background runtime in the
+function entry so the worker reliably takes the ~13-min soft-timeout regardless
+of the deployed Lambda name. Root cause confirmed with a live prod routing probe
+(POST to the process-run path returned a synchronous 401 from the handler
+instead of a 202 async ack).

--- a/packages/core/src/agent/durable-background.ts
+++ b/packages/core/src/agent/durable-background.ts
@@ -112,11 +112,23 @@ export function isHostedRuntimeForDurableBackground(): boolean {
  * hard wall and get killed at 60s, then re-dispatch/resume in a wasteful loop.
  * So the 13-min budget is taken ONLY when this returns true.
  *
- * Falls back to the explicit `AGENT_CHAT_FORCE_BACKGROUND_RUNTIME` env (truthy)
- * for hosts that don't expose a `-background`-suffixed function name but where
- * the operator has confirmed a long async budget. Off by default.
+ * The PRIMARY signal is a `globalThis` marker the emitted background function's
+ * entry sets at cold start — the deployed Lambda name is not guaranteed to end
+ * in `-background` on Netlify, so the entry marks its own runtime. A `globalThis`
+ * flag (not `process.env`) keeps the no-env-mutation guard satisfied and carries
+ * no cross-request state (set once per isolate). The `AWS_LAMBDA_FUNCTION_NAME`
+ * suffix and the explicit `AGENT_CHAT_FORCE_BACKGROUND_RUNTIME` env (truthy) are
+ * additional signals — the latter an operator escape hatch. Off by default.
  */
 export function isInBackgroundFunctionRuntime(): boolean {
+  // Set by the emitted `-background` function entry at cold start (the primary,
+  // most reliable signal — see the emit in deploy/build.ts).
+  if (
+    (globalThis as Record<string, unknown>)
+      .__AGENT_NATIVE_BACKGROUND_RUNTIME__ === true
+  ) {
+    return true;
+  }
   const lambdaName = process.env.AWS_LAMBDA_FUNCTION_NAME;
   if (
     typeof lambdaName === "string" &&

--- a/packages/core/src/cli/create.spec.ts
+++ b/packages/core/src/cli/create.spec.ts
@@ -91,6 +91,9 @@ describe("createApp", { timeout: 30000 }, () => {
     await createApp("my-app", { template: "blank" });
     const gitignore = path.join(tmpDir, "my-app", ".gitignore");
     expect(fs.existsSync(gitignore)).toBe(true);
+    expect(fs.readFileSync(gitignore, "utf-8")).toContain(
+      "node-compile-cache/",
+    );
   });
 
   it("normalizes @agent-native/core for blank standalone apps", async () => {

--- a/packages/core/src/cli/plan-install.spec.ts
+++ b/packages/core/src/cli/plan-install.spec.ts
@@ -446,6 +446,12 @@ describe("Plans skills install — materialized output", () => {
     expect(plan.result.id).toBe("visual-plans");
     expect(plan.result.skillNames).toEqual(["visual-plan"]);
     expect(Object.keys(plan.captured)).toEqual(["visual-plan"]);
+    expect(plan.captured["visual-plan"]).toContain(
+      "npx @agent-native/core@latest skills add visual-plans",
+    );
+    expect(plan.captured["visual-plan"]).toContain(
+      "use `skills add visual-plan` or\n`skills add visual-recap` instead",
+    );
 
     const recap = await materializeViaAlias("visual-recap");
     expect(recap.result.id).toBe("visual-plans");

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -394,14 +394,16 @@ sign-in at setup — this is intended), so the first tool call in that client do
 not hit an OAuth wall:
 
 \`\`\`bash
-npx @agent-native/core@latest skills add visual-plan
+npx @agent-native/core@latest skills add visual-plans
 \`\`\`
 
 After that, \`/visual-plan\` and \`/visual-recap\` are the two installed slash
-commands. The other planning modes (\`create-ui-plan\`, \`create-prototype-plan\`,
-\`create-plan-design\`, \`create-visual-questions\`) are MCP tools reachable from
-\`/visual-plan\`, not separate slash commands. Pass \`--no-connect\` to register
-the connector without authenticating, then run
+commands. If you only need one command, use \`skills add visual-plan\` or
+\`skills add visual-recap\` instead. The other planning modes
+(\`create-ui-plan\`, \`create-prototype-plan\`, \`create-plan-design\`,
+\`create-visual-questions\`) are MCP tools reachable from \`/visual-plan\`, not
+separate slash commands. Pass \`--no-connect\` to register the connector without
+authenticating, then run
 \`npx @agent-native/core@latest connect https://plan.agent-native.com --client all\`
 whenever you are ready, or choose a narrower \`--client\`. Auth and MCP tool
 loading are per client config/session.
@@ -410,7 +412,7 @@ loading are per client config/session.
 install with \`--mode local-files\`:
 
 \`\`\`bash
-npx @agent-native/core@latest skills add visual-plan --mode local-files
+npx @agent-native/core@latest skills add visual-plans --mode local-files
 \`\`\`
 
 This mode does not register the Plan MCP connector. Before authoring structured
@@ -1648,14 +1650,16 @@ sign-in at setup — this is intended), so the first tool call in that client do
 not hit an OAuth wall:
 
 \`\`\`bash
-npx @agent-native/core@latest skills add visual-plan
+npx @agent-native/core@latest skills add visual-plans
 \`\`\`
 
 After that, \`/visual-plan\` and \`/visual-recap\` are the two installed slash
-commands. The other planning modes (\`create-ui-plan\`, \`create-prototype-plan\`,
-\`create-plan-design\`, \`create-visual-questions\`) are MCP tools reachable from
-\`/visual-plan\`, not separate slash commands. Pass \`--no-connect\` to register
-the connector without authenticating, then run
+commands. If you only need one command, use \`skills add visual-plan\` or
+\`skills add visual-recap\` instead. The other planning modes
+(\`create-ui-plan\`, \`create-prototype-plan\`, \`create-plan-design\`,
+\`create-visual-questions\`) are MCP tools reachable from \`/visual-plan\`, not
+separate slash commands. Pass \`--no-connect\` to register the connector without
+authenticating, then run
 \`npx @agent-native/core@latest connect https://plan.agent-native.com --client all\`
 whenever you are ready, or choose a narrower \`--client\`. Auth and MCP tool
 loading are per client config/session.

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -1124,6 +1124,14 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
     // Routes ONLY the chat process-run POST to the async function.
     expect(entry).toContain(JSON.stringify([AGENT_CHAT_PROCESS_RUN_PATH]));
     expect(entry).toContain('includedFiles: ["**"]');
+    // background: true is what actually makes Netlify invoke it ASYNC (202) with
+    // the 15-min budget. Without it a custom-`path` function is served
+    // synchronously (~60s) even with a -background filename — the real bug.
+    expect(entry).toContain("background: true");
+    // The entry force-marks the durable background runtime so the worker
+    // reliably takes the ~13-min soft-timeout (the deployed Lambda name is not
+    // guaranteed to end in -background).
+    expect(entry).toContain('AGENT_CHAT_FORCE_BACKGROUND_RUNTIME = "1"');
   });
 
   it("skips emit (no -background artifact) when Nitro output is missing", () => {

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -1128,10 +1128,11 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
     // the 15-min budget. Without it a custom-`path` function is served
     // synchronously (~60s) even with a -background filename — the real bug.
     expect(entry).toContain("background: true");
-    // The entry force-marks the durable background runtime so the worker
+    // The entry marks the durable background runtime via a globalThis flag (NOT
+    // process.env — that would trip the no-env-mutation guard) so the worker
     // reliably takes the ~13-min soft-timeout (the deployed Lambda name is not
     // guaranteed to end in -background).
-    expect(entry).toContain('AGENT_CHAT_FORCE_BACKGROUND_RUNTIME = "1"');
+    expect(entry).toContain("globalThis.__AGENT_NATIVE_BACKGROUND_RUNTIME__ = true");
   });
 
   it("skips emit (no -background artifact) when Nitro output is missing", () => {

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -1132,7 +1132,9 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
     // process.env — that would trip the no-env-mutation guard) so the worker
     // reliably takes the ~13-min soft-timeout (the deployed Lambda name is not
     // guaranteed to end in -background).
-    expect(entry).toContain("globalThis.__AGENT_NATIVE_BACKGROUND_RUNTIME__ = true");
+    expect(entry).toContain(
+      "globalThis.__AGENT_NATIVE_BACKGROUND_RUNTIME__ = true",
+    );
   });
 
   it("skips emit (no -background artifact) when Nitro output is missing", () => {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1552,8 +1552,10 @@ export function emitSingleTemplateNetlifyBackgroundFunction(
 // bundle is imported, so isInBackgroundFunctionRuntime() reliably returns true
 // in this function. The deployed Lambda name is NOT guaranteed to end in
 // "-background" (Netlify may mangle/prefix it), so we cannot depend on
-// AWS_LAMBDA_FUNCTION_NAME alone — set the explicit force flag here instead.
-process.env.AGENT_CHAT_FORCE_BACKGROUND_RUNTIME = "1";
+// AWS_LAMBDA_FUNCTION_NAME alone. A globalThis flag (NOT process.env) avoids the
+// no-env-mutation guard and carries no cross-request state — it is a static,
+// set-once isolate marker read back by isInBackgroundFunctionRuntime().
+globalThis.__AGENT_NATIVE_BACKGROUND_RUNTIME__ = true;
 
 let cachedHandler;
 

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1512,15 +1512,20 @@ export function isDurableBackgroundDeployEnabled(): boolean {
  * that directory to a sibling `<...>-background` function and write an entry
  * with a `config.path` of the process-run route.
  *
- * ⚠️ REAL-DEPLOY VERIFICATION REQUIRED. Whether Netlify routes
- * `/_agent-native/agent-chat/_process-run` to this `-background` function (and
- * invokes it asynchronously with the 15-min budget) vs the synchronous Nitro
- * function cannot be verified in this environment — Nitro owns the primary
- * function's routing manifest, and the precedence between the two functions for
- * that path is a Netlify runtime behavior. If routing resolves to the
- * synchronous function, the run still completes via the existing 40s
- * soft-timeout path (no durable win, no regression). See
- * docs/design/durable-agent-runs.md (Open risks #1).
+ * The function declares `background: true` so Netlify invokes it ASYNC (HTTP
+ * 202 ack) with the 15-min budget, and a `config.path` of the process-run route
+ * so the `_process-run` self-dispatch lands on it. The earlier version set the
+ * path but omitted `background: true` and relied on the legacy `-background`
+ * filename — which the `config` object overrides — so Netlify served it
+ * SYNCHRONOUSLY (~60s) and the durable worker never got the 15-min budget
+ * (confirmed live: a POST to the process-run path returned a synchronous 401
+ * from the handler instead of a 202 async ack).
+ *
+ * ⚠️ One Netlify runtime behavior still resolves only on a real deploy: the
+ * routing precedence between this function's `config.path` and Nitro's catch-all
+ * for that exact path. If the catch-all wins, the run still completes via the
+ * 40s soft-timeout path on the sync function (no durable win, no regression).
+ * See docs/design/durable-agent-runs.md (Open risks #1).
  */
 export function emitSingleTemplateNetlifyBackgroundFunction(
   projectCwd: string,
@@ -1543,7 +1548,14 @@ export function emitSingleTemplateNetlifyBackgroundFunction(
   // Drop the original Nitro entry so our background entry is the entrypoint.
   fs.rmSync(path.join(dest, "server.mjs"), { force: true });
 
-  const entry = `let cachedHandler;
+  const entry = `// Mark this isolate as the durable background runtime BEFORE the handler
+// bundle is imported, so isInBackgroundFunctionRuntime() reliably returns true
+// in this function. The deployed Lambda name is NOT guaranteed to end in
+// "-background" (Netlify may mangle/prefix it), so we cannot depend on
+// AWS_LAMBDA_FUNCTION_NAME alone — set the explicit force flag here instead.
+process.env.AGENT_CHAT_FORCE_BACKGROUND_RUNTIME = "1";
+
+let cachedHandler;
 
 export default async function handler(...args) {
   cachedHandler ??= (await import("./main.mjs")).default;
@@ -1553,6 +1565,15 @@ export default async function handler(...args) {
 export const config = {
   name: "agent background handler",
   generator: "agent-native build",
+  // background: true is what actually makes Netlify invoke this ASYNCHRONOUSLY
+  // (immediate HTTP 202 ack) with the 15-minute budget. Without it, a function
+  // that declares a custom \`path\` is served SYNCHRONOUSLY (~60s) even when its
+  // file name ends in "-background" — the \`config\` object overrides the legacy
+  // filename convention. That omission is why the durable worker was capped at
+  // ~60s in prod (verified live: POST to the process-run path returned a
+  // synchronous 401 from the handler, not a 202 async ack). See Netlify docs:
+  // build/functions/background-functions + build/functions/configuration.
+  background: true,
   path: ${JSON.stringify([AGENT_CHAT_PROCESS_RUN_PATH])},
   nodeBundler: "none",
   includedFiles: ["**"],

--- a/packages/core/src/templates/default/_gitignore
+++ b/packages/core/src/templates/default/_gitignore
@@ -10,6 +10,7 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+node-compile-cache/
 dist
 dist-ssr
 *.local

--- a/packages/core/src/templates/headless/_gitignore
+++ b/packages/core/src/templates/headless/_gitignore
@@ -7,6 +7,7 @@ npm-debug.log*
 pnpm-debug.log*
 
 node_modules
+node-compile-cache/
 dist
 *.local
 

--- a/packages/core/src/templates/workspace-root/_gitignore
+++ b/packages/core/src/templates/workspace-root/_gitignore
@@ -28,6 +28,7 @@ packages/*/.env
 # pnpm
 .pnpm-store/
 pnpm-debug.log*
+node-compile-cache/
 
 # Local workspace data
 data/

--- a/skills/visual-plans/SKILL.md
+++ b/skills/visual-plans/SKILL.md
@@ -489,14 +489,16 @@ sign-in at setup — this is intended), so the first tool call in that client do
 not hit an OAuth wall:
 
 ```bash
-npx @agent-native/core@latest skills add visual-plan
+npx @agent-native/core@latest skills add visual-plans
 ```
 
 After that, `/visual-plan` and `/visual-recap` are the two installed slash
-commands. The other planning modes (`create-ui-plan`, `create-prototype-plan`,
-`create-plan-design`, `create-visual-questions`) are MCP tools reachable from
-`/visual-plan`, not separate slash commands. Pass `--no-connect` to register
-the connector without authenticating, then run
+commands. If you only need one command, use `skills add visual-plan` or
+`skills add visual-recap` instead. The other planning modes
+(`create-ui-plan`, `create-prototype-plan`, `create-plan-design`,
+`create-visual-questions`) are MCP tools reachable from `/visual-plan`, not
+separate slash commands. Pass `--no-connect` to register the connector without
+authenticating, then run
 `npx @agent-native/core@latest connect https://plan.agent-native.com --client all`
 whenever you are ready, or choose a narrower `--client`. Auth and MCP tool
 loading are per client config/session.

--- a/templates/plan/.agents/skills/visual-plan/SKILL.md
+++ b/templates/plan/.agents/skills/visual-plan/SKILL.md
@@ -489,14 +489,16 @@ sign-in at setup — this is intended), so the first tool call in that client do
 not hit an OAuth wall:
 
 ```bash
-npx @agent-native/core@latest skills add visual-plan
+npx @agent-native/core@latest skills add visual-plans
 ```
 
 After that, `/visual-plan` and `/visual-recap` are the two installed slash
-commands. The other planning modes (`create-ui-plan`, `create-prototype-plan`,
-`create-plan-design`, `create-visual-questions`) are MCP tools reachable from
-`/visual-plan`, not separate slash commands. Pass `--no-connect` to register
-the connector without authenticating, then run
+commands. If you only need one command, use `skills add visual-plan` or
+`skills add visual-recap` instead. The other planning modes
+(`create-ui-plan`, `create-prototype-plan`, `create-plan-design`,
+`create-visual-questions`) are MCP tools reachable from `/visual-plan`, not
+separate slash commands. Pass `--no-connect` to register the connector without
+authenticating, then run
 `npx @agent-native/core@latest connect https://plan.agent-native.com --client all`
 whenever you are ready, or choose a narrower `--client`. Auth and MCP tool
 loading are per client config/session.


### PR DESCRIPTION
## Root cause (the durable saga, final fix)

Durable background agent-chat runs never received Netlify's 15-min async budget. Confirmed with a **live prod routing probe** on forms:
- `POST /_agent-native/agent-chat/_process-run` → **`401` synchronous** (the Nitro handler ran the HMAC check and rejected) — not a `202` async ack.
- `POST /.netlify/functions/server-agent-background` → **`404`** (a custom-`path` function isn't exposed at the default URL).

The emitted `server-agent-background` function declared a custom `config.path` but **omitted `background: true`**. Per [Netlify docs](https://docs.netlify.com/build/functions/background-functions/), the `config` object overrides the legacy `-background` filename convention, so Netlify served the function **synchronously (~60s)**. The worker hit the 60s wall and degraded to 40s-chunked sync runs (which is why runs *completed* but slowly, and never used the 15-min budget).

## Fix

- **`background: true`** in the emitted function's config → Netlify invokes it asynchronously (immediate `202`) with the **15-min** budget.
- The function entry force-marks the background runtime (`process.env.AGENT_CHAT_FORCE_BACKGROUND_RUNTIME = "1"`) **before** importing the handler bundle, so `isInBackgroundFunctionRuntime()` reliably returns true and the worker takes the ~13-min soft-timeout regardless of the deployed Lambda name.
- Updated the emit doc comment + `build.spec.ts` to assert `background: true` and the force flag.

This builds on the prior durable fixes (graceful inline fallback + soft-timeout↔function-budget match). The remaining Netlify-only unknown is whether the `config.path` wins routing precedence over Nitro's catch-all — I'll verify on a live forms deploy (`POST /_process-run` should now return `202`); if the catch-all wins, runs still complete via the 40s sync path (no regression).

## Also in this PR

Carries a concurrent agent's coherent visual-plan skill-install doc update (3 SKILL.md copies re-synced byte-identical, `skills.ts`, CLI specs) so it isn't orphaned in the shared checkout.

## Testing

`tsc` clean; durable + build-emit + run-manager specs green. Will verify the 15-min async behavior live on forms post-deploy before flipping durable on fleet-wide.