### PR TITLE
Simplify content New property picker to type search only

### DIFF
--- a/templates/content/app/components/editor/DocumentProperties.layout.test.ts
+++ b/templates/content/app/components/editor/DocumentProperties.layout.test.ts
@@ -79,11 +79,11 @@ describe("document property layout", () => {
     const source = readPropertiesSource();
 
     expect(source).toContain(
-      "const addPropertyNameInputRef = useRef<HTMLInputElement>",
+      "const addPropertySearchInputRef = useRef<HTMLInputElement>",
     );
-    expect(source).toContain("addPropertyNameInputRef.current?.focus()");
-    expect(source).toContain("addPropertyNameInputRef.current?.select()");
-    expect(source).toContain('aria-label="New property name"');
+    expect(source).toContain("addPropertySearchInputRef.current?.focus()");
+    expect(source).toContain("addPropertySearchInputRef.current?.select()");
+    expect(source).toContain('aria-label="Search property types"');
     expect(source).toContain("const firstFilteredPropertyType");
     expect(source).toContain("void add(firstFilteredPropertyType)");
   });

--- a/templates/content/app/components/editor/DocumentProperties.tsx
+++ b/templates/content/app/components/editor/DocumentProperties.tsx
@@ -2349,7 +2349,6 @@ export function AddProperty({
     },
   });
   const [open, setOpen] = useState(false);
-  const [name, setName] = useState("");
   const [typeQuery, setTypeQuery] = useState("");
   const filteredPropertyTypes = filterDocumentPropertyTypes(typeQuery);
   const firstFilteredPropertyType = filteredPropertyTypes[0] ?? null;
@@ -2377,19 +2376,18 @@ export function AddProperty({
         }),
     }))
     .filter((group) => group.fields.length > 0);
-  const addPropertyNameInputRef = useRef<HTMLInputElement>(null);
+  const addPropertySearchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!open) return;
     const frame = requestAnimationFrame(() => {
-      addPropertyNameInputRef.current?.focus();
-      addPropertyNameInputRef.current?.select();
+      addPropertySearchInputRef.current?.focus();
+      addPropertySearchInputRef.current?.select();
     });
     return () => cancelAnimationFrame(frame);
   }, [open]);
 
   function closeAddPropertyPicker() {
-    setName("");
     setTypeQuery("");
     setOpen(false);
   }
@@ -2398,7 +2396,7 @@ export function AddProperty({
     const label = DOCUMENT_PROPERTY_TYPE_LABELS[type];
     await configure.mutateAsync({
       documentId,
-      name: name.trim() || label,
+      name: label,
       type,
       options: defaultPropertyOptions(type),
     });
@@ -2445,23 +2443,11 @@ export function AddProperty({
         className="w-80 p-2"
       >
         <div className="grid gap-2">
-          <Input
-            ref={addPropertyNameInputRef}
-            aria-label="New property name"
-            autoFocus
-            value={name}
-            placeholder="Property name"
-            onChange={(event) => setName(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Escape") {
-                event.preventDefault();
-                closeAddPropertyPicker();
-              }
-            }}
-          />
           <div className="flex h-8 items-center gap-1 rounded border border-border bg-background px-2">
             <IconSearch className="size-3.5 shrink-0 text-muted-foreground" />
             <Input
+              ref={addPropertySearchInputRef}
+              autoFocus
               value={typeQuery}
               placeholder="Search property types"
               aria-label="Search property types"


### PR DESCRIPTION
## What

Removes the separate **"Property name"** text input from the content template's *New property* picker. The picker now opens directly to the **"Search property types"** field, followed by the type list.

## Why

The previous picker showed two inputs stacked — a name field and a type search field — which is redundant and doesn't match the expected (Notion-style) flow. You should pick the property type first, then name it. The name can always be set afterward via the existing property-settings / column-header rename UI.

## Changes

In `templates/content/app/components/editor/DocumentProperties.tsx` (`AddProperty` component):

- Removed the `name` text `<Input>` and its `name` / `setName` state.
- Renamed the focus ref to `addPropertySearchInputRef` and moved `autoFocus` onto the search input, so typing immediately filters types on open.
- `add(type)` now names the new property with the chosen type's default label (e.g. "Text", "Number"); users rename through the existing property-settings popover.
- Enter on the search bar still creates the first matching type; Escape still closes the picker.

## Notes for reviewers

- No behavior change to property renaming — that flow already lives in the property-settings component.
- I could not run the content dev server to verify visually: it fails to boot on an unrelated pre-existing error (`Cannot find module 'ajv'` from `packages/core/src/agent/production-agent.ts`). The change is a self-contained component edit; verified by inspection and Prettier.