### PR TITLE
fix: preserve starter-only manifest fields during builder starter sync

### DIFF
--- a/.changeset/preserve-starter-only-manifest-fields.md
+++ b/.changeset/preserve-starter-only-manifest-fields.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve starter-only manifest fields when syncing builder-agent-native-starter from templates/chat.

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -59,6 +59,44 @@ describe("sync-builder-starter-manifest", () => {
     );
   });
 
+  it("preserves starter-only manifest fields not present in templates/chat", () => {
+    const { packageJson: canonical } = generateStandaloneChatManifest(repoRoot);
+    const merged = mergeStarterManifest(
+      {
+        packageManager: "pnpm@10.14.0",
+        scripts: {
+          dev: "node scripts/maybe-migrate.mjs && agent-native dev --open",
+          "db:generate": "drizzle-kit generate",
+          "db:migrate": "drizzle-kit migrate",
+        },
+        dependencies: {
+          "@agent-native/core": "0.72.1",
+          "@neondatabase/serverless": "^1.0.2",
+          "drizzle-orm": "0.45.2",
+        },
+        devDependencies: {
+          "drizzle-kit": "0.31.10",
+          dotenv: "^17.2.1",
+        },
+      },
+      canonical,
+    );
+
+    const deps = merged.dependencies as Record<string, string>;
+    const devDeps = merged.devDependencies as Record<string, string>;
+    const scripts = merged.scripts as Record<string, string>;
+
+    expect(deps["@agent-native/core"]).toBe("0.72.1");
+    expect(deps["@neondatabase/serverless"]).toBe("^1.0.2");
+    expect(deps["drizzle-orm"]).toBe("0.45.2");
+    expect(deps.postgres).toBe("^3.4.9");
+    expect(devDeps["drizzle-kit"]).toBe("0.31.10");
+    expect(devDeps.dotenv).toBe("^17.2.1");
+    expect(scripts["db:generate"]).toBe("drizzle-kit generate");
+    expect(scripts["db:migrate"]).toBe("drizzle-kit migrate");
+    expect(merged.packageManager).toBe("pnpm@10.14.0");
+  });
+
   describe("syncStarterManifestFiles", () => {
     let tempDir: string;
 

--- a/packages/core/src/cli/sync-builder-starter-manifest.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.ts
@@ -59,6 +59,26 @@ export function generateStandaloneChatManifest(repoRoot?: string): {
   }
 }
 
+function mergePackageJsonRecords(
+  canonical: Record<string, string> | undefined,
+  starter: Record<string, string> | undefined,
+  starterPinnedKeys: string[] = [],
+): Record<string, string> {
+  const merged = { ...(canonical ?? {}) };
+  for (const [key, value] of Object.entries(starter ?? {})) {
+    if (!(key in merged)) {
+      merged[key] = value;
+    }
+  }
+  for (const key of starterPinnedKeys) {
+    const pinned = starter?.[key];
+    if (pinned) {
+      merged[key] = pinned;
+    }
+  }
+  return merged;
+}
+
 export function mergeStarterManifest(
   starterPackageJson: PackageJson,
   canonicalPackageJson: PackageJson,
@@ -75,19 +95,23 @@ export function mergeStarterManifest(
   if (starterPackageJson.private !== undefined) {
     merged.private = starterPackageJson.private;
   }
+  if (typeof starterPackageJson.packageManager === "string") {
+    merged.packageManager = starterPackageJson.packageManager;
+  }
 
-  const starterDeps =
-    (starterPackageJson.dependencies as Record<string, string> | undefined) ??
-    {};
-  const canonicalDeps =
-    (canonicalPackageJson.dependencies as Record<string, string> | undefined) ??
-    {};
-  merged.dependencies = {
-    ...canonicalDeps,
-    ...(starterDeps["@agent-native/core"]
-      ? { "@agent-native/core": starterDeps["@agent-native/core"] }
-      : {}),
-  };
+  merged.dependencies = mergePackageJsonRecords(
+    canonicalPackageJson.dependencies as Record<string, string> | undefined,
+    starterPackageJson.dependencies as Record<string, string> | undefined,
+    ["@agent-native/core"],
+  );
+  merged.devDependencies = mergePackageJsonRecords(
+    canonicalPackageJson.devDependencies as Record<string, string> | undefined,
+    starterPackageJson.devDependencies as Record<string, string> | undefined,
+  );
+  merged.scripts = mergePackageJsonRecords(
+    canonicalPackageJson.scripts as Record<string, string> | undefined,
+    starterPackageJson.scripts as Record<string, string> | undefined,
+  );
 
   return merged;
 }


### PR DESCRIPTION
## Summary
- When syncing `builder-agent-native-starter` from `templates/chat`, preserve starter-only `dependencies`, `devDependencies`, `scripts`, and `packageManager` entries that are not in the canonical chat manifest.
- Still treat `templates/chat` as source of truth for shared keys, while keeping the pinned `@agent-native/core` semver from starter.

## Why
Starter automation runs the sync CLI before `pnpm typecheck`. A Fusion PR added starter source that imports `drizzle-orm` and `@neondatabase/serverless`, plus starter-only scripts like `db:migrate`. The previous merge logic replaced the entire dependency set with the chat template manifest, so CI installed without those packages and typecheck failed with TS2307.

## Test plan
- [x] `vitest run packages/core/src/cli/sync-builder-starter-manifest.spec.ts`
- [ ] Merge to `main`
- [ ] Re-run **Update agent-native packages** / **Sync agent-native starter manifest** on starter — typecheck should pass with drizzle/neon deps intact


Made with [Cursor](https://cursor.com)