### PR TITLE
fix: make durable background agent runs opt-in (default-off)

### DIFF
--- a/.changeset/durable-bg-default-off.md
+++ b/.changeset/durable-bg-default-off.md
@@ -1,0 +1,14 @@
+---
+"@agent-native/core": patch
+---
+
+Make durable background agent runs opt-in (default-off) again. Both the runtime
+gate (`isFlagEnabled` in durable-background.ts) and the deploy-time `-background`
+emit gate (`isDurableBackgroundDeployEnabled` in deploy/build.ts) now default to
+OFF when `AGENT_CHAT_DURABLE_BACKGROUND` is unset; an app opts in only with an
+explicit truthy value (`true`/`1`/`yes`/`on`). A premature fleet-wide default-on
+caused real-user incidents (apps hit "Failed to dispatch background run" + chat
+stalls) because the async background-function worker path is not yet proven
+end-to-end and the deploy-time env opt-out is not reliably baked into a given
+deploy. Re-enable default-on only after the 15-min background-function worker is
+verified live in production.

--- a/packages/core/src/agent/durable-background.spec.ts
+++ b/packages/core/src/agent/durable-background.spec.ts
@@ -65,51 +65,60 @@ describe("durable-background constants", () => {
   });
 });
 
-describe("isAgentChatDurableBackgroundEnabled (default-on gate)", () => {
+describe("isAgentChatDurableBackgroundEnabled (default-off opt-in gate)", () => {
   it("is OFF with nothing configured (not hosted, no secret — gates compose)", () => {
     expect(isAgentChatDurableBackgroundEnabled()).toBe(false);
   });
 
-  it("is ON BY DEFAULT (flag unset) when hosted + secret are present", () => {
+  it("is OFF BY DEFAULT (flag unset) even when hosted + secret are present", () => {
     makeHosted();
     process.env.A2A_SECRET = "shhh";
     delete process.env.AGENT_CHAT_DURABLE_BACKGROUND;
-    expect(isAgentChatDurableBackgroundEnabled()).toBe(true);
+    expect(isAgentChatDurableBackgroundEnabled()).toBe(false);
   });
 
-  it("is OFF only when explicitly opted out via a falsy flag", () => {
+  it("is ON only when explicitly opted in via a truthy flag (hosted + secret)", () => {
     makeHosted();
     process.env.A2A_SECRET = "shhh";
-    for (const val of ["0", "false", "no", "off", "FALSE", " Off "]) {
-      process.env.AGENT_CHAT_DURABLE_BACKGROUND = val;
-      expect(isAgentChatDurableBackgroundEnabled()).toBe(false);
-    }
-  });
-
-  it("is ON for truthy, unrecognized, or empty flag values (default-on)", () => {
-    makeHosted();
-    process.env.A2A_SECRET = "shhh";
-    for (const val of ["1", "true", "yes", "on", " TRUE ", "", "maybe"]) {
+    for (const val of ["1", "true", "yes", "on", " TRUE "]) {
       process.env.AGENT_CHAT_DURABLE_BACKGROUND = val;
       expect(isAgentChatDurableBackgroundEnabled()).toBe(true);
     }
   });
 
-  it("stays OFF when default-on but NOT hosted (local dev keeps inline path)", () => {
-    delete process.env.AGENT_CHAT_DURABLE_BACKGROUND;
+  it("is OFF for falsy, unrecognized, or empty flag values (default-off)", () => {
+    makeHosted();
+    process.env.A2A_SECRET = "shhh";
+    for (const val of [
+      "0",
+      "false",
+      "no",
+      "off",
+      "FALSE",
+      " Off ",
+      "",
+      "maybe",
+    ]) {
+      process.env.AGENT_CHAT_DURABLE_BACKGROUND = val;
+      expect(isAgentChatDurableBackgroundEnabled()).toBe(false);
+    }
+  });
+
+  it("stays OFF when opted in but NOT hosted (local dev keeps inline path)", () => {
+    process.env.AGENT_CHAT_DURABLE_BACKGROUND = "true";
     process.env.A2A_SECRET = "shhh";
     expect(isHostedRuntimeForDurableBackground()).toBe(false);
     expect(isAgentChatDurableBackgroundEnabled()).toBe(false);
   });
 
-  it("stays OFF when default-on + hosted but A2A_SECRET is missing", () => {
-    delete process.env.AGENT_CHAT_DURABLE_BACKGROUND;
+  it("stays OFF when opted in + hosted but A2A_SECRET is missing", () => {
+    process.env.AGENT_CHAT_DURABLE_BACKGROUND = "true";
     makeHosted();
     expect(isAgentChatDurableBackgroundEnabled()).toBe(false);
   });
 
-  it("treats NETLIFY_LOCAL=true as NOT hosted (netlify dev), even default-on", () => {
-    delete process.env.AGENT_CHAT_DURABLE_BACKGROUND;
+  it("treats NETLIFY_LOCAL=true as NOT hosted (netlify dev), even when opted in", () => {
+    process.env.AGENT_CHAT_DURABLE_BACKGROUND = "true";
     process.env.A2A_SECRET = "shhh";
     process.env.NETLIFY = "true";
     process.env.NETLIFY_LOCAL = "true";

--- a/packages/core/src/agent/durable-background.ts
+++ b/packages/core/src/agent/durable-background.ts
@@ -237,30 +237,34 @@ function isFlagEnabled(): boolean {
   // can statically verify it against the allowlisted `AGENT_*` prefix. Keep this
   // in sync with AGENT_CHAT_DURABLE_BACKGROUND_ENV.
   //
-  // DEFAULT-ON: durable background runs are the desired behavior for every
-  // hosted app. So an unset/empty/unknown flag means ON; an app opts OUT only
-  // with an explicit falsy value. This still composes with the hosted +
-  // A2A_SECRET gates below, so non-hosted / unconfigured apps stay synchronous.
-  // Safety net: a failed dispatch degrades to a synchronous inline run (see
-  // production-agent.ts), so default-on cannot break chat even if the
-  // self-dispatch can't be delivered on a given app.
+  // DEFAULT-OFF (opt-in): durable background runs are still being hardened. A
+  // premature fleet-wide default-on caused real-user incidents (Assets/Analytics
+  // hit "Failed to dispatch" + stalls, 2026-06-24) because the async background
+  // worker path is not yet proven end-to-end and the deploy-time env opt-out is
+  // not reliably baked into a given deploy. So an unset/empty/unknown flag means
+  // OFF; an app opts IN only with an explicit truthy value
+  // (AGENT_CHAT_DURABLE_BACKGROUND=true). This still composes with the hosted +
+  // A2A_SECRET gates below. Flip back to default-on only after the 15-min
+  // background-function worker is verified live in production (see the
+  // project_durable_bg_prod_verified memory).
   const raw = process.env.AGENT_CHAT_DURABLE_BACKGROUND;
-  if (raw == null) return true;
+  if (raw == null) return false;
   const normalized = raw.trim().toLowerCase();
-  return !(
-    normalized === "0" ||
-    normalized === "false" ||
-    normalized === "no" ||
-    normalized === "off"
+  return (
+    normalized === "1" ||
+    normalized === "true" ||
+    normalized === "yes" ||
+    normalized === "on"
   );
 }
 
 /**
- * The single gate. True when the flag is not explicitly disabled (default-on)
+ * The single gate. True when the flag is explicitly enabled (opt-in/default-off)
  * AND the runtime is hosted AND A2A_SECRET is configured. False otherwise — and
  * false means the current synchronous behavior is used, unchanged. So a local /
- * non-hosted / unconfigured app stays synchronous even with the flag defaulting
- * on; durable only engages where the runtime actually supports it.
+ * non-hosted / unconfigured app stays synchronous, and an app that has not opted
+ * in stays synchronous; durable only engages where it is explicitly enabled and
+ * the runtime actually supports it.
  */
 export function isAgentChatDurableBackgroundEnabled(): boolean {
   return (

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -1106,22 +1106,31 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
     );
   }
 
-  it("is ON BY DEFAULT (flag unset) so the -background function is emitted", () => {
-    // Default-on matches the runtime gate (isFlagEnabled) — the 15-min
-    // `-background` function MUST be emitted by default so the worker gets the
-    // real long budget instead of overshooting the ~60s synchronous wall.
-    expect(isDurableBackgroundDeployEnabled()).toBe(true);
+  it("is OFF BY DEFAULT (flag unset) so the -background function is NOT emitted", () => {
+    // Default-off (opt-in) matches the runtime gate (isFlagEnabled) — durable is
+    // opt-in until the async worker path is proven live, so the 15-min
+    // `-background` function is emitted only when an app explicitly opts in.
+    expect(isDurableBackgroundDeployEnabled()).toBe(false);
   });
 
-  it("is ON for truthy, unrecognized, or empty flag values (default-on)", () => {
-    for (const value of ["1", "true", "TRUE", " yes ", "on", "", "maybe"]) {
+  it("is ON only when explicitly opted in via a truthy flag", () => {
+    for (const value of ["1", "true", "TRUE", " yes ", "on"]) {
       process.env.AGENT_CHAT_DURABLE_BACKGROUND = value;
       expect(isDurableBackgroundDeployEnabled()).toBe(true);
     }
   });
 
-  it("is OFF only when explicitly opted out via a falsy flag", () => {
-    for (const value of ["0", "false", "no", "off", "FALSE", " Off "]) {
+  it("is OFF for falsy, unrecognized, or empty flag values (default-off)", () => {
+    for (const value of [
+      "0",
+      "false",
+      "no",
+      "off",
+      "FALSE",
+      " Off ",
+      "",
+      "maybe",
+    ]) {
       process.env.AGENT_CHAT_DURABLE_BACKGROUND = value;
       expect(isDurableBackgroundDeployEnabled()).toBe(false);
     }

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1485,10 +1485,12 @@ export function findInstalledResvgPackages(
  * Reads the same env flag the runtime gate uses
  * (`AGENT_CHAT_DURABLE_BACKGROUND`).
  *
- * DEFAULT-ON, matching the runtime gate (`isFlagEnabled` in
- * durable-background.ts): unset/empty/unknown means enabled; an app opts OUT
- * only with an explicit falsy value (`false`/`0`/`no`/`off`). This is what
- * actually emits the 15-min `-background` function so the `_process-run`
+ * DEFAULT-OFF (opt-in), matching the runtime gate (`isFlagEnabled` in
+ * durable-background.ts): unset/empty/unknown means DISABLED; an app opts IN
+ * only with an explicit truthy value (`true`/`1`/`yes`/`on`). A premature
+ * fleet-wide default-on caused real-user incidents (2026-06-24) before the
+ * async worker path was proven, so durable is opt-in until verified live. This
+ * gate is what emits the 15-min `-background` function so the `_process-run`
  * dispatch lands on it (async 202 → the worker runs with the real 15-min budget
  * → its ~13-min soft-timeout fits). The deploy gate and runtime gate MUST agree:
  * if the deploy emitted no `-background` function but the runtime still routed
@@ -1499,9 +1501,9 @@ export function findInstalledResvgPackages(
  */
 export function isDurableBackgroundDeployEnabled(): boolean {
   const raw = process.env.AGENT_CHAT_DURABLE_BACKGROUND;
-  if (raw == null) return true;
+  if (raw == null) return false;
   const v = raw.trim().toLowerCase();
-  return !(v === "0" || v === "false" || v === "no" || v === "off");
+  return v === "1" || v === "true" || v === "yes" || v === "on";
 }
 
 /**

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -778,7 +778,10 @@ html.dark .shiki span {
 
 .batteries-orbit {
   isolation: isolate;
-  box-shadow: inset 0 0 80px color-mix(in srgb, var(--fg) 4%, transparent);
+  background: #000;
+  border-color: rgba(255, 255, 255, 0.12);
+  color: #f5f5f5;
+  box-shadow: inset 0 0 90px rgba(255, 255, 255, 0.035);
 }
 
 .batteries-orbit::after {
@@ -790,12 +793,12 @@ html.dark .shiki span {
   background:
     radial-gradient(
       circle at 50% 50%,
-      color-mix(in srgb, var(--docs-accent) 10%, transparent),
+      rgba(82, 168, 255, 0.1),
       transparent 34%
     ),
     radial-gradient(
       circle at 20% 78%,
-      color-mix(in srgb, var(--fg) 7%, transparent),
+      rgba(255, 255, 255, 0.05),
       transparent 28%
     );
 }
@@ -844,6 +847,47 @@ html.dark .shiki span {
   transform-origin: center;
   transition: transform 1100ms cubic-bezier(0.2, 0.75, 0.2, 1);
   will-change: transform;
+}
+
+.orbit-ring {
+  border-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+.orbit-center-card {
+  background: #000;
+  color: #fff;
+  box-shadow:
+    0 18px 70px rgba(0, 0, 0, 0.96),
+    0 0 70px rgba(82, 168, 255, 0.12);
+}
+
+.orbit-center-copy {
+  color: rgba(255, 255, 255, 0.66);
+}
+
+.orbit-word {
+  border: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: rgba(255, 255, 255, 0.62);
+  pointer-events: none;
+  white-space: nowrap;
+  text-shadow:
+    0 1px 18px rgba(0, 0, 0, 0.88),
+    0 0 1px #000;
+}
+
+.orbit-word--primary {
+  color: rgba(255, 255, 255, 0.96);
+  filter: drop-shadow(0 10px 26px rgba(0, 0, 0, 0.78));
+}
+
+.orbit-word--secondary {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.orbit-word--tertiary {
+  color: rgba(255, 255, 255, 0.28);
 }
 
 .batteries-orbit:hover .orbit-ring--outer,

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -165,116 +165,128 @@ const orbitPrimaryCapabilities = [
   {
     label: "Actions",
     detail: "source of truth",
-    className: "left-1/2 top-[6%] -translate-x-1/2",
+    className: "left-1/2 top-[12%] -translate-x-1/2 text-center",
   },
   {
     label: "SQL state",
     detail: "shared context",
-    className: "right-[8%] top-[18%]",
+    className: "right-[9%] top-[27%] text-right",
   },
   {
     label: "MCP + A2A",
     detail: "protocols included",
-    className: "right-[3%] top-1/2 -translate-y-1/2",
+    className: "right-[2%] top-1/2 -translate-y-1/2 text-right",
   },
   {
     label: "Jobs",
     detail: "scheduled work",
-    className: "bottom-[18%] right-[9%]",
+    className: "bottom-[18%] right-[9%] text-right",
   },
   {
     label: "Templates",
     detail: "production-refined",
-    className: "bottom-[6%] left-1/2 -translate-x-1/2",
+    className: "bottom-[11%] left-1/2 -translate-x-1/2 text-center",
   },
   {
     label: "Auth",
     detail: "orgs and sharing",
-    className: "bottom-[18%] left-[8%]",
+    className: "bottom-[17%] left-[10%]",
   },
   {
     label: "i18n",
     detail: "global-ready UI",
-    className: "left-[3%] top-1/2 -translate-y-1/2",
+    className: "left-[4%] top-1/2 -translate-y-1/2",
   },
   {
     label: "Observability",
     detail: "audit and tracking",
-    className: "left-[8%] top-[18%]",
+    className: "left-[9%] top-[27%]",
   },
 ];
 
 const orbitSecondaryCapabilities = [
   {
-    label: "Sharing",
-    className: "left-[32%] top-[19%]",
+    label: "Security",
+    className: "left-[28%] top-[33%]",
   },
   {
-    label: "Audit log",
-    className: "right-[30%] top-[24%]",
+    label: "Sharing & privacy",
+    className: "left-[24%] top-[42%]",
   },
   {
-    label: "Tracking",
-    className: "right-[19%] top-[37%]",
+    label: "Audit logs",
+    className: "right-[31%] top-[33%]",
+  },
+  {
+    label: "Real-time collab",
+    className: "right-[19%] top-[42%]",
+  },
+  {
+    label: "Governance",
+    className: "right-[18%] top-[62%]",
   },
   {
     label: "Provider APIs",
-    className: "right-[24%] bottom-[32%]",
+    className: "right-[22%] bottom-[29%]",
+  },
+  {
+    label: "Automations",
+    className: "right-[34%] bottom-[17%]",
   },
   {
     label: "Approvals",
-    className: "left-[31%] bottom-[24%]",
+    className: "left-[29%] bottom-[20%]",
   },
   {
     label: "Extensions",
-    className: "left-[16%] bottom-[38%]",
+    className: "left-[18%] bottom-[31%]",
   },
   {
-    label: "Skills",
-    className: "left-[22%] top-[34%]",
+    label: "MCP Auth",
+    className: "left-[15%] top-[62%]",
   },
   {
-    label: "OAuth",
-    className: "right-[18%] bottom-[47%]",
+    label: "SSO",
+    className: "right-[11%] bottom-[39%]",
   },
   {
-    label: "Memory",
-    className: "left-[43%] bottom-[18%]",
+    label: "Evals",
+    className: "left-[40%] bottom-[28%]",
   },
   {
-    label: "Webhooks",
-    className: "right-[35%] bottom-[18%]",
-  },
-  {
-    label: "Voice",
-    className: "left-[37%] top-[31%]",
-  },
-  {
-    label: "Realtime sync",
-    className: "right-[34%] top-[35%]",
+    label: "Workspaces",
+    className: "left-[47%] top-[35%] -translate-x-1/2 text-center",
   },
 ];
 
 const orbitTertiaryCapabilities = [
   {
     label: "recurring jobs",
-    className: "left-[16%] top-[9%]",
+    className: "left-[18%] top-[13%]",
   },
   {
-    label: "evals",
-    className: "left-[42%] top-[18%]",
+    label: "tracking",
+    className: "left-[43%] top-[26%]",
   },
   {
-    label: "workspace",
+    label: "monorepos",
     className: "right-[17%] top-[8%]",
   },
   {
     label: "MCP apps",
-    className: "right-[-8px] top-[27%]",
+    className: "right-[-10px] top-[33%]",
   },
   {
     label: "external agents",
-    className: "right-[-34px] top-[43%]",
+    className: "right-[-44px] top-[46%]",
+  },
+  {
+    label: "AG-UI",
+    className: "right-[4%] top-[60%]",
+  },
+  {
+    label: "ACP",
+    className: "right-[19%] top-[57%]",
   },
   {
     label: "CLI",
@@ -286,7 +298,7 @@ const orbitTertiaryCapabilities = [
   },
   {
     label: "native chat UI",
-    className: "left-[36%] bottom-[-10px]",
+    className: "left-[44%] bottom-[-10px]",
   },
   {
     label: "file uploads",
@@ -294,7 +306,7 @@ const orbitTertiaryCapabilities = [
   },
   {
     label: "sandbox adapters",
-    className: "left-[-32px] bottom-[27%]",
+    className: "left-[-36px] bottom-[28%]",
   },
   {
     label: "durable resume",
@@ -302,7 +314,7 @@ const orbitTertiaryCapabilities = [
   },
   {
     label: "context awareness",
-    className: "left-[-42px] top-[16%]",
+    className: "left-[-54px] top-[25%]",
   },
   {
     label: "notifications",
@@ -321,20 +333,44 @@ const orbitTertiaryCapabilities = [
     className: "right-[-44px] bottom-[26%]",
   },
   {
+    label: "OAuth",
+    className: "right-[8%] bottom-[32%]",
+  },
+  {
+    label: "webhooks",
+    className: "right-[42%] bottom-[7%]",
+  },
+  {
+    label: "memory",
+    className: "left-[31%] bottom-[8%]",
+  },
+  {
+    label: "skills",
+    className: "left-[20%] top-[31%]",
+  },
+  {
+    label: "voice input",
+    className: "left-[43%] top-[38%]",
+  },
+  {
+    label: "realtime sync",
+    className: "right-[39%] top-[25%]",
+  },
+  {
     label: "local file mode",
     className: "left-[21%] bottom-[4%]",
   },
   {
     label: "DB adapters",
-    className: "left-[9%] top-[66%]",
+    className: "left-[13%] top-[72%]",
   },
   {
     label: "self-editing code",
-    className: "right-[12%] top-[66%]",
+    className: "right-[17%] top-[72%]",
   },
   {
     label: "agent web surfaces",
-    className: "right-[20%] top-[82%]",
+    className: "right-[28%] top-[82%]",
   },
 ];
 
@@ -518,8 +554,9 @@ function BatteriesIncludedOrbit() {
               practices they need to build real app software.
             </p>
             <p className="mb-7 max-w-xl text-base leading-relaxed text-[var(--fg-secondary)]">
-              Actions, SQL state, auth, i18n, protocols, jobs, templates, audit,
-              and observability all ship as UI-ready and agent-ready defaults,
+              Actions, SQL state, auth, i18n, protocols, jobs, templates,
+              real-time collaboration, security, audit logs, evals, sharing, and
+              observability all ship as UI-ready and agent-ready defaults,
               refined through production template apps and feedback.
             </p>
             <div className="flex flex-wrap gap-2">
@@ -536,7 +573,7 @@ function BatteriesIncludedOrbit() {
 
           <div
             ref={orbitRef}
-            className={`batteries-orbit relative mx-auto aspect-square w-full max-w-[560px] overflow-hidden rounded-2xl border border-[var(--docs-border)] bg-[var(--bg-secondary)] p-5 sm:p-8 ${
+            className={`batteries-orbit relative mx-auto aspect-square w-full max-w-[560px] overflow-hidden rounded-2xl border p-5 sm:p-8 ${
               orbitActive ? "batteries-orbit--active" : ""
             }`}
           >
@@ -545,14 +582,14 @@ function BatteriesIncludedOrbit() {
             <div className="orbit-ring orbit-ring--middle absolute inset-16 rounded-full border border-[var(--docs-border)] opacity-70" />
             <div className="orbit-ring orbit-ring--inner absolute inset-24 rounded-full border border-[var(--docs-border)] opacity-50" />
 
-            <div className="absolute left-1/2 top-1/2 z-10 w-[46%] -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-[var(--docs-accent)] bg-[var(--bg)] p-4 text-center sm:p-5">
+            <div className="orbit-center-card absolute left-1/2 top-1/2 z-40 w-[46%] -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-[var(--docs-accent)] bg-[var(--bg)] p-4 text-center sm:p-5">
               <p className="mb-2 text-xs font-semibold uppercase tracking-[0.08em] text-[var(--docs-accent)]">
                 Shared substrate
               </p>
               <h3 className="m-0 text-xl font-semibold leading-tight">
                 One app surface
               </h3>
-              <p className="m-0 mt-2 text-sm leading-relaxed text-[var(--fg-secondary)]">
+              <p className="orbit-center-copy m-0 mt-2 text-sm leading-relaxed">
                 UI, agent, protocols, jobs, and audit call the same operations.
               </p>
             </div>
@@ -561,7 +598,7 @@ function BatteriesIncludedOrbit() {
               {orbitTertiaryCapabilities.map((capability) => (
                 <span
                   key={capability.label}
-                  className={`absolute max-w-[118px] truncate rounded-full border border-[var(--docs-border)] bg-[var(--bg)]/35 px-2 py-1 text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--fg-secondary)] opacity-45 backdrop-blur-sm ${capability.className}`}
+                  className={`orbit-word orbit-word--tertiary absolute max-w-[140px] truncate text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--fg-secondary)] opacity-35 ${capability.className}`}
                 >
                   {capability.label}
                 </span>
@@ -572,7 +609,7 @@ function BatteriesIncludedOrbit() {
               {orbitSecondaryCapabilities.map((capability) => (
                 <span
                   key={capability.label}
-                  className={`absolute rounded-full border border-[var(--docs-border)] bg-[var(--bg)]/70 px-2.5 py-1 text-[11px] font-semibold text-[var(--fg-secondary)] shadow-sm backdrop-blur-sm ${capability.className}`}
+                  className={`orbit-word orbit-word--secondary absolute max-w-[168px] truncate text-sm font-semibold text-[var(--fg-secondary)] opacity-75 ${capability.className}`}
                 >
                   {capability.label}
                 </span>
@@ -583,19 +620,88 @@ function BatteriesIncludedOrbit() {
               {orbitPrimaryCapabilities.map((capability) => (
                 <div
                   key={capability.label}
-                  className={`absolute max-w-[112px] rounded-xl border border-[var(--docs-border)] bg-[var(--bg)] px-2 py-1.5 sm:max-w-[132px] sm:px-3 sm:py-2 ${capability.className}`}
+                  className={`orbit-word orbit-word--primary absolute max-w-[132px] ${capability.className}`}
                 >
-                  <div className="truncate text-sm font-semibold text-[var(--fg)]">
+                  <div className="truncate text-lg font-semibold leading-tight text-[var(--fg)]">
                     {capability.label}
-                  </div>
-                  <div className="hidden truncate text-xs text-[var(--fg-secondary)] sm:block">
-                    {capability.detail}
                   </div>
                 </div>
               ))}
             </div>
           </div>
         </div>
+      </div>
+    </section>
+  );
+}
+
+function TrySkillSection() {
+  return (
+    <section className="border-t border-[var(--docs-border)] px-6 py-16">
+      <div className="mx-auto grid min-w-0 max-w-[1200px] gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.82fr)] lg:items-center">
+        <div className="min-w-0">
+          <h2 className="mb-3 text-3xl font-bold tracking-tight md:text-4xl">
+            Try it with a skill
+          </h2>
+          <p className="mb-5 max-w-xl text-base leading-relaxed text-[var(--fg-secondary)]">
+            Add visual planning and PR recaps to Claude Code, Codex, Cursor, Pi,
+            OpenCode, or VS Code with one command.
+          </p>
+
+          <CodeBlock code={skillInstallCode} lang="bash" />
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            <div className="rounded-xl border border-[var(--docs-border)] p-5">
+              <h3 className="mb-2 font-mono text-sm font-semibold text-[var(--docs-accent)]">
+                /visual-plan
+              </h3>
+              <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
+                Reviewable plans with diagrams, wireframes, file maps, and
+                comments before code changes.
+              </p>
+            </div>
+            <div className="rounded-xl border border-[var(--docs-border)] p-5">
+              <h3 className="mb-2 font-mono text-sm font-semibold text-[var(--docs-accent)]">
+                /visual-recap
+              </h3>
+              <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
+                A visual summary of a PR or diff so reviewers see the shape
+                before the raw lines.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <Link
+              data-an-prefetch="render"
+              to="/docs/skills-guide"
+              className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-5 py-2.5 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
+              onClick={() =>
+                trackEvent("click cta", {
+                  label: "skills_guide",
+                  location: "skills_section",
+                })
+              }
+            >
+              Browse the Skills Guide
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="5" y1="12" x2="19" y2="12" />
+                <polyline points="12 5 19 12 12 19" />
+              </svg>
+            </Link>
+          </div>
+        </div>
+
+        <AgentNativeDemoVideo className="aspect-square w-full" />
       </div>
     </section>
   );
@@ -871,75 +977,6 @@ export default function Home() {
 
         <BatteriesIncludedOrbit />
 
-        {/* Try it with a skill */}
-        <section className="border-t border-[var(--docs-border)] px-6 py-16">
-          <div className="mx-auto grid min-w-0 max-w-[1200px] gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.82fr)] lg:items-center">
-            <div className="min-w-0">
-              <h2 className="mb-3 text-3xl font-bold tracking-tight md:text-4xl">
-                Try it with a skill
-              </h2>
-              <p className="mb-5 max-w-xl text-base leading-relaxed text-[var(--fg-secondary)]">
-                Add visual planning and PR recaps to Claude Code, Codex, Cursor,
-                Pi, OpenCode, or VS Code with one command.
-              </p>
-
-              <CodeBlock code={skillInstallCode} lang="bash" />
-
-              <div className="mt-6 grid gap-3 sm:grid-cols-2">
-                <div className="rounded-xl border border-[var(--docs-border)] p-5">
-                  <h3 className="mb-2 font-mono text-sm font-semibold text-[var(--docs-accent)]">
-                    /visual-plan
-                  </h3>
-                  <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
-                    Reviewable plans with diagrams, wireframes, file maps, and
-                    comments before code changes.
-                  </p>
-                </div>
-                <div className="rounded-xl border border-[var(--docs-border)] p-5">
-                  <h3 className="mb-2 font-mono text-sm font-semibold text-[var(--docs-accent)]">
-                    /visual-recap
-                  </h3>
-                  <p className="m-0 text-sm leading-relaxed text-[var(--fg-secondary)]">
-                    A visual summary of a PR or diff so reviewers see the shape
-                    before the raw lines.
-                  </p>
-                </div>
-              </div>
-
-              <div className="mt-6">
-                <Link
-                  data-an-prefetch="render"
-                  to="/docs/skills-guide"
-                  className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-5 py-2.5 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
-                  onClick={() =>
-                    trackEvent("click cta", {
-                      label: "skills_guide",
-                      location: "skills_section",
-                    })
-                  }
-                >
-                  Browse the Skills Guide
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <line x1="5" y1="12" x2="19" y2="12" />
-                    <polyline points="12 5 19 12 12 19" />
-                  </svg>
-                </Link>
-              </div>
-            </div>
-
-            <AgentNativeDemoVideo className="aspect-square w-full" />
-          </div>
-        </section>
-
         {/* Bidirectional Awareness */}
         <section className="border-t border-[var(--docs-border)] px-6 py-20">
           <div className="mb-12 text-center">
@@ -956,6 +993,8 @@ export default function Home() {
             <BidirectionalTabs />
           </div>
         </section>
+
+        <TrySkillSection />
 
         <div className="mx-auto max-w-[1200px] px-6">
           {/* The best of both worlds */}

--- a/templates/dispatch/app/routes/integrations.tsx
+++ b/templates/dispatch/app/routes/integrations.tsx
@@ -1072,7 +1072,7 @@ function Modal({
   return (
     <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
       <DialogContent className="max-h-[92vh] max-w-2xl overflow-y-auto p-0">
-        <DialogHeader className="border-b p-4 pr-10">
+        <DialogHeader className="border-b p-4 pe-10">
           <DialogTitle className="text-base">{title}</DialogTitle>
           {description ? (
             <DialogDescription>{description}</DialogDescription>
@@ -1784,7 +1784,7 @@ function SetupWizard({
             onClick={() => onStepChange(step - 1)}
             disabled={saving}
           >
-            <IconArrowLeft size={14} />
+            <IconArrowLeft size={14} className="rtl:-scale-x-100" />
             Back
           </Button>
         ) : null}
@@ -1795,7 +1795,7 @@ function SetupWizard({
             disabled={!canAdvance || loading || saving}
           >
             Next
-            <IconArrowRight size={14} />
+            <IconArrowRight size={14} className="rtl:-scale-x-100" />
           </Button>
         ) : (
           <Button

--- a/templates/mail/app/components/email/EmailThread.tsx
+++ b/templates/mail/app/components/email/EmailThread.tsx
@@ -1119,7 +1119,7 @@ export function EmailThread({
                 onClick={goBack}
                 className="mt-0.5 flex h-9 w-9 sm:h-7 sm:w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
               >
-                <IconArrowLeft className="h-[14px] w-[14px]" />
+                <IconArrowLeft className="h-[14px] w-[14px] rtl:-scale-x-100" />
               </button>
             </TooltipTrigger>
             <TooltipContent>Back (Esc)</TooltipContent>
@@ -1166,7 +1166,7 @@ export function EmailThread({
                 )}
                 <button
                   onClick={() => goToSibling(-1)}
-                  className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors ml-1"
+                  className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors ms-1"
                 >
                   <IconChevronUp className="h-3.5 w-3.5" />
                 </button>
@@ -1181,7 +1181,7 @@ export function EmailThread({
                     <TooltipTrigger asChild>
                       <button
                         onClick={onToggleMaximize}
-                        className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors ml-1"
+                        className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors ms-1"
                         aria-label={isMaximized ? "Minimize" : "Maximize"}
                         aria-pressed={isMaximized}
                       >
@@ -1498,7 +1498,7 @@ function ThreadLoadingState({
                 onClick={onBack}
                 className="mt-0.5 flex h-9 w-9 sm:h-7 sm:w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
               >
-                <IconArrowLeft className="h-[14px] w-[14px]" />
+                <IconArrowLeft className="h-[14px] w-[14px] rtl:-scale-x-100" />
               </button>
             </TooltipTrigger>
             <TooltipContent>Back (Esc)</TooltipContent>
@@ -1639,7 +1639,7 @@ const CollapsedMessageRow = forwardRef<
       <span className="text-[13px] text-muted-foreground truncate flex-1">
         {email.snippet}
       </span>
-      <span className="text-[12px] text-muted-foreground/60 tabular-nums shrink-0 ml-2">
+      <span className="text-[12px] text-muted-foreground/60 tabular-nums shrink-0 ms-2">
         {formatEmailDate(email.date)}
       </span>
     </div>
@@ -1795,7 +1795,7 @@ const ExpandedMessageCard = forwardRef<
                 e.stopPropagation();
                 setShowDetails(true);
               }}
-              className="text-[12px] text-muted-foreground/50 hover:text-muted-foreground transition-colors truncate text-left"
+              className="text-[12px] text-muted-foreground/50 hover:text-muted-foreground transition-colors truncate text-start"
             >
               to {recipients}
             </button>
@@ -1812,7 +1812,7 @@ const ExpandedMessageCard = forwardRef<
                   }}
                   className="flex h-9 w-9 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground transition-colors"
                 >
-                  <IconArrowBackUp className="h-4 w-4 sm:h-[14px] sm:w-[14px]" />
+                  <IconArrowBackUp className="h-4 w-4 sm:h-[14px] sm:w-[14px] rtl:-scale-x-100" />
                 </button>
               </TooltipTrigger>
               <TooltipContent>Reply</TooltipContent>
@@ -1826,7 +1826,7 @@ const ExpandedMessageCard = forwardRef<
                   }}
                   className="flex h-9 w-9 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground transition-colors"
                 >
-                  <IconArrowBackUpDouble className="h-4 w-4 sm:h-[14px] sm:w-[14px]" />
+                  <IconArrowBackUpDouble className="h-4 w-4 sm:h-[14px] sm:w-[14px] rtl:-scale-x-100" />
                 </button>
               </TooltipTrigger>
               <TooltipContent>Reply All</TooltipContent>
@@ -1840,7 +1840,7 @@ const ExpandedMessageCard = forwardRef<
                   }}
                   className="flex h-9 w-9 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground transition-colors"
                 >
-                  <IconArrowForwardUp className="h-4 w-4 sm:h-[14px] sm:w-[14px]" />
+                  <IconArrowForwardUp className="h-4 w-4 sm:h-[14px] sm:w-[14px] rtl:-scale-x-100" />
                 </button>
               </TooltipTrigger>
               <TooltipContent>Forward</TooltipContent>
@@ -3409,7 +3409,7 @@ function ThreadSearchBar({
           <TooltipTrigger asChild>
             <button
               onClick={onClose}
-              className="flex h-8 w-8 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors ml-1"
+              className="flex h-8 w-8 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors ms-1"
             >
               <IconX className="h-3.5 w-3.5 sm:h-3 sm:w-3" />
             </button>

--- a/templates/mail/app/pages/DraftQueuePage.tsx
+++ b/templates/mail/app/pages/DraftQueuePage.tsx
@@ -303,7 +303,7 @@ function QueueList({
             key={draft.id}
             onClick={() => onSelect(draft.id)}
             className={cn(
-              "mb-1.5 w-full rounded-md border px-3 py-2.5 text-left transition-colors",
+              "mb-1.5 w-full rounded-md border px-3 py-2.5 text-start transition-colors",
               isActive
                 ? "border-primary/40 bg-primary/10"
                 : "border-border/20 bg-card/40 hover:border-border/50 hover:bg-accent/30",
@@ -488,7 +488,7 @@ function DraftDetail({
                 {sendDraft.isPending ? (
                   <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
                 ) : (
-                  <IconSend className="h-3.5 w-3.5" />
+                  <IconSend className="h-3.5 w-3.5 rtl:-scale-x-100" />
                 )}
                 Send
               </Button>
@@ -718,7 +718,7 @@ export function DraftQueuePage() {
         </div>
       ) : (
         <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
-          <aside className="h-[34dvh] shrink-0 border-b border-border/30 sm:h-auto sm:w-[340px] sm:border-b-0 sm:border-r">
+          <aside className="h-[34dvh] shrink-0 border-b border-border/30 sm:h-auto sm:w-[340px] sm:border-b-0 sm:border-e">
             <QueueList
               drafts={queue.drafts}
               selectedId={selectedId}

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -125,7 +125,7 @@ function ThreadListSidebar({
   useKeyboardShortcuts([{ key: "a", meta: true, handler: selectAllThreads }]);
 
   return (
-    <div className="flex h-full w-[220px] min-w-0 shrink-0 flex-col overflow-hidden border-r border-border/30 bg-muted/50 dark:bg-[hsl(220,6%,5%)]">
+    <div className="flex h-full w-[220px] min-w-0 shrink-0 flex-col overflow-hidden border-e border-border/30 bg-muted/50 dark:bg-[hsl(220,6%,5%)]">
       <div className="flex-1 overflow-y-auto">
         {threads.map((thread) => {
           const email = thread.latestMessage;
@@ -151,7 +151,7 @@ function ThreadListSidebar({
                 navigate(`/${view}/${threadKey}${routeSearchSuffix}`);
               }}
               className={cn(
-                "w-full text-left px-3 h-[38px] flex items-center border-b border-border/10 transition-colors",
+                "w-full text-start px-3 h-[38px] flex items-center border-b border-border/10 transition-colors",
                 isMultiSelected
                   ? "bg-primary/20 ring-1 ring-inset ring-primary/40"
                   : isActive
@@ -682,7 +682,7 @@ export function InboxPage() {
 
       {/* Right contact panel — hidden during initial load or when maximized */}
       {!emailListLoading && !(hasThread && isMaximized) && (
-        <div className="hidden lg:flex w-[260px] shrink-0 flex-col border-l border-border/30 bg-muted/50 dark:bg-[hsl(220,6%,5%)]">
+        <div className="hidden lg:flex w-[260px] shrink-0 flex-col border-s border-border/30 bg-muted/50 dark:bg-[hsl(220,6%,5%)]">
           <ContactPanel
             emailId={contactEmailId}
             contactEmail={sidebarContactEmail}

--- a/templates/mail/app/pages/SettingsPage.tsx
+++ b/templates/mail/app/pages/SettingsPage.tsx
@@ -1510,7 +1510,7 @@ export function SettingsPage() {
   return (
     <div className="flex flex-1 flex-col sm:flex-row overflow-hidden">
       {/* Top tabs on mobile, left sidebar on desktop */}
-      <div className="sm:w-[200px] shrink-0 sm:border-r border-b sm:border-b-0 border-border/30 bg-muted/50 dark:bg-[hsl(220,6%,5%)] sm:p-3 flex sm:flex-col gap-0.5 overflow-x-auto">
+      <div className="sm:w-[200px] shrink-0 sm:border-e border-b sm:border-b-0 border-border/30 bg-muted/50 dark:bg-[hsl(220,6%,5%)] sm:p-3 flex sm:flex-col gap-0.5 overflow-x-auto">
         <p className="hidden sm:block px-2 py-1.5 text-[10px] font-medium text-muted-foreground/40 uppercase tracking-wider mb-1">
           {t("settings.title")}
         </p>
@@ -1523,7 +1523,7 @@ export function SettingsPage() {
               key={item.id}
               onClick={() => setActiveSection(item.id)}
               className={cn(
-                "flex items-center gap-2.5 sm:w-full rounded-md px-3 sm:px-2.5 py-2.5 sm:py-2 text-[13px] transition-colors text-left whitespace-nowrap",
+                "flex items-center gap-2.5 sm:w-full rounded-md px-3 sm:px-2.5 py-2.5 sm:py-2 text-[13px] transition-colors text-start whitespace-nowrap",
                 isActive
                   ? "bg-indigo-500/15 text-indigo-300 font-medium"
                   : "text-muted-foreground hover:text-foreground hover:bg-accent/50",

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -7271,12 +7271,12 @@ function LocalPlanLoadError({
         </div>
         <div className="mt-5 flex flex-wrap gap-2">
           <Button type="button" variant="outline" onClick={onRetry}>
-            <IconRefresh className="mr-2 size-4" />
+            <IconRefresh className="me-2 size-4" />
             Retry
           </Button>
           <Button asChild type="button" variant="ghost">
             <Link to="/plans">
-              <IconArrowLeft className="mr-2 size-4" />
+              <IconArrowLeft className="me-2 size-4 rtl:-scale-x-100" />
               Plans
             </Link>
           </Button>
@@ -7443,7 +7443,7 @@ function PlanLoadError({
 
   return (
     <div className="flex h-full flex-col items-center justify-center bg-background p-8">
-      <div className="w-full max-w-md rounded-lg border border-border bg-background p-5 text-left shadow-sm">
+      <div className="w-full max-w-md rounded-lg border border-border bg-background p-5 text-start shadow-sm">
         <div className={cn("flex items-start", !showAccessHelp && "gap-3")}>
           {!showAccessHelp && !planMissing && (
             <div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-amber-500/25 bg-amber-500/10 text-amber-600 dark:text-amber-300">

--- a/templates/slides/app/components/deck/DeckCard.tsx
+++ b/templates/slides/app/components/deck/DeckCard.tsx
@@ -139,7 +139,7 @@ export default function DeckCard({
       </Link>
 
       {/* Menu Button - always visible on touch devices */}
-      <div className="absolute top-2 right-2 sm:opacity-0 sm:group-hover:opacity-100">
+      <div className="absolute top-2 end-2 sm:opacity-0 sm:group-hover:opacity-100">
         <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
           <DropdownMenuTrigger asChild>
             <button
@@ -170,7 +170,7 @@ export default function DeckCard({
                 startRename();
               }}
             >
-              <IconPencil className="w-3.5 h-3.5 mr-2" />
+              <IconPencil className="w-3.5 h-3.5 me-2" />
               Rename
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -182,7 +182,7 @@ export default function DeckCard({
               }}
               disabled={isDuplicating}
             >
-              <IconCopy className="w-3.5 h-3.5 mr-2" />
+              <IconCopy className="w-3.5 h-3.5 me-2" />
               {isDuplicating ? "Duplicating..." : "Duplicate"}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
@@ -194,7 +194,7 @@ export default function DeckCard({
               }}
               className="text-red-400 focus:text-red-400"
             >
-              <IconTrash className="w-3.5 h-3.5 mr-2" />
+              <IconTrash className="w-3.5 h-3.5 me-2" />
               Delete
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/templates/slides/app/components/layout/Layout.tsx
+++ b/templates/slides/app/components/layout/Layout.tsx
@@ -85,7 +85,7 @@ export function Layout({ children }: LayoutProps) {
           )}
           <div
             className={cn(
-              "fixed inset-y-0 left-0 z-50 md:static md:z-auto",
+              "fixed inset-y-0 start-0 z-50 md:static md:z-auto",
               sidebarOpen
                 ? "translate-x-0"
                 : "-translate-x-full md:translate-x-0",

--- a/templates/slides/app/components/layout/Sidebar.tsx
+++ b/templates/slides/app/components/layout/Sidebar.tsx
@@ -51,7 +51,7 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
 
   if (collapsed) {
     return (
-      <aside className="flex h-full w-12 shrink-0 flex-col items-center gap-1 overflow-hidden border-r border-border bg-sidebar py-2 text-sidebar-foreground">
+      <aside className="flex h-full w-12 shrink-0 flex-col items-center gap-1 overflow-hidden border-e border-border bg-sidebar py-2 text-sidebar-foreground">
         {onToggleCollapsed && (
           <Tooltip delayDuration={0}>
             <TooltipTrigger asChild>
@@ -60,7 +60,7 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
                 aria-label={t("sidebar.expandSidebar")}
                 className="flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground"
               >
-                <IconLayoutSidebarLeftExpand className="h-4 w-4" />
+                <IconLayoutSidebarLeftExpand className="h-4 w-4 rtl:-scale-x-100" />
               </button>
             </TooltipTrigger>
             <TooltipContent side="right">
@@ -98,7 +98,7 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
   }
 
   return (
-    <aside className="flex h-full w-56 min-w-0 shrink-0 flex-col overflow-hidden border-r border-border bg-sidebar text-sidebar-foreground">
+    <aside className="flex h-full w-56 min-w-0 shrink-0 flex-col overflow-hidden border-e border-border bg-sidebar text-sidebar-foreground">
       <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
         <div className="flex items-center gap-2">
           <img
@@ -125,7 +125,7 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
                 aria-label={t("sidebar.collapseSidebar")}
                 className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground"
               >
-                <IconLayoutSidebarLeftCollapse className="h-4 w-4" />
+                <IconLayoutSidebarLeftCollapse className="h-4 w-4 rtl:-scale-x-100" />
               </button>
             </TooltipTrigger>
             <TooltipContent>{t("sidebar.collapseSidebar")}</TooltipContent>

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -506,7 +506,7 @@ export default function Index() {
                 aria-label="Show all decks"
                 className="h-7 rounded-md px-3 text-xs data-[state=on]:bg-accent"
               >
-                <IconStack2 className="mr-1.5 h-3.5 w-3.5" />
+                <IconStack2 className="me-1.5 h-3.5 w-3.5" />
                 All
               </ToggleGroupItem>
               <ToggleGroupItem
@@ -514,7 +514,7 @@ export default function Index() {
                 aria-label="Show decks created by me"
                 className="h-7 rounded-md px-3 text-xs data-[state=on]:bg-accent"
               >
-                <IconUserCircle className="mr-1.5 h-3.5 w-3.5" />
+                <IconUserCircle className="me-1.5 h-3.5 w-3.5" />
                 Mine
               </ToggleGroupItem>
             </ToggleGroup>
@@ -533,7 +533,7 @@ export default function Index() {
             {/* New deck card */}
             <button
               onClick={openNewDeck}
-              className="group relative rounded-xl border border-dashed border-border bg-card hover:border-foreground/15 overflow-hidden text-left cursor-pointer"
+              className="group relative rounded-xl border border-dashed border-border bg-card hover:border-foreground/15 overflow-hidden text-start cursor-pointer"
             >
               <div className="aspect-video flex items-center justify-center bg-muted/30">
                 <div className="w-12 h-12 rounded-xl bg-accent/50 flex items-center justify-center group-hover:bg-accent">

--- a/templates/videos/app/components/layout/NavSidebar.tsx
+++ b/templates/videos/app/components/layout/NavSidebar.tsx
@@ -37,7 +37,7 @@ export function NavSidebar() {
   const t = useT();
 
   return (
-    <aside className="flex h-full w-56 shrink-0 flex-col border-r border-border bg-sidebar text-sidebar-foreground">
+    <aside className="flex h-full w-56 shrink-0 flex-col border-e border-border bg-sidebar text-sidebar-foreground">
       <div className="flex h-12 shrink-0 items-center gap-2 px-4 border-b border-border">
         <img
           src={appPath("/agent-native-icon-light.svg")}

--- a/templates/videos/app/pages/ComponentLibraryView.tsx
+++ b/templates/videos/app/pages/ComponentLibraryView.tsx
@@ -302,7 +302,7 @@ export function ComponentLibraryView({
                 Press <strong>Play</strong> to see the cursor demonstrate hover
                 and click interactions:
               </p>
-              <ul className="text-xs text-muted-foreground space-y-1 ml-4 list-disc">
+              <ul className="text-xs text-muted-foreground space-y-1 ms-4 list-disc">
                 <li>
                   <strong>0.0s - 1.3s</strong>: Cursor approaches
                 </li>

--- a/templates/videos/app/pages/DesignSystems.tsx
+++ b/templates/videos/app/pages/DesignSystems.tsx
@@ -106,7 +106,7 @@ export default function DesignSystems() {
                   setEditingId(null);
                   setShowSetup(true);
                 }}
-                className="group relative rounded-xl border border-dashed border-border bg-card hover:border-foreground/15 overflow-hidden text-left cursor-pointer"
+                className="group relative rounded-xl border border-dashed border-border bg-card hover:border-foreground/15 overflow-hidden text-start cursor-pointer"
               >
                 <div className="aspect-video flex items-center justify-center bg-muted/30">
                   <div className="w-12 h-12 rounded-xl bg-accent/50 flex items-center justify-center group-hover:bg-accent">


### PR DESCRIPTION
## What
Revert durable background agent runs to **opt-in (default-off)**. Both gates for `AGENT_CHAT_DURABLE_BACKGROUND` default OFF when unset; an app opts in only with an explicit truthy value (`true`/`1`/`yes`/`on`):
- runtime gate `isFlagEnabled` (durable-background.ts)
- deploy-time `-background` emit gate `isDurableBackgroundDeployEnabled` (deploy/build.ts)

## Why
A premature fleet-wide default-on caused **real-user incidents** (2026-06-24): apps auto-deploying from main got durable on while the async background-function worker path is still unproven, so users hit "Failed to dispatch background run" + chat stalls (Assets, Analytics). The deploy-time env opt-out is also not reliably baked into a given deploy, so per-app `=false` was insufficient — default-off in code is the reliable fix.

Forms keeps an explicit `=true` for continued prod verification of the 15-min worker. Re-enable default-on only after that's proven live.

## Tests
74 specs pass (durable-background.spec.ts + build.spec.ts updated to assert default-off/opt-in).

Also bundles concurrent template + docs UI changes from other agents on this branch.