### PR TITLE
fix(durable): circuit-breaker for dead background workers + harden bg-fn wrapper

### DIFF
--- a/.changeset/durable-bg-worker-circuit-breaker.md
+++ b/.changeset/durable-bg-worker-circuit-breaker.md
@@ -1,0 +1,18 @@
+---
+"@agent-native/core": patch
+---
+
+Durable background agent runs: add a foreground **circuit-breaker** so a dead
+background worker can no longer break chat. A Netlify async background function
+returns `202` the instant it enqueues the invocation, but the worker may never
+execute — e.g. the generated function wrapper fails to import `./main.mjs` or
+hand off to the Nitro `_process-run` route, so it never reaches
+`claimBackgroundRun` and the run is reaped as "worker never claimed the run".
+After a successful dispatch the foreground now polls briefly for the worker to
+actually claim the run; if it doesn't within the grace window, the turn is
+recovered **inline** (the same safe atomic-claim path used for a fast dispatch
+failure), so a dead worker degrades to a working synchronous turn instead of a
+reaped failure. Also harden the generated background-function wrapper to pass
+Netlify's `context` through to the Nitro handler and wrap the handoff in
+try/catch so a pre-route failure is logged loudly instead of silently swallowed
+behind the async 202.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -13,6 +13,7 @@ import {
   actionsToEngineTools,
   MAX_BACKGROUND_RUN_CONTINUATIONS,
   resolveAgentOwnerEmail,
+  resolveBackgroundDispatchOutcome,
   resolveSkillReferenceContent,
   runAgentLoop,
   shouldChainBackgroundContinuation,
@@ -4063,5 +4064,92 @@ describe("shouldChainBackgroundContinuation (server-driven background chain)", (
         continuationCount: MAX_BACKGROUND_RUN_CONTINUATIONS - 1,
       }),
     ).toBe(true);
+  });
+});
+
+describe("resolveBackgroundDispatchOutcome (durable circuit-breaker)", () => {
+  // Deterministic clock so the grace loop terminates without real time: each
+  // now() call advances 10ms; with graceMs=25 the loop polls ~3 times.
+  function makeClock() {
+    let t = 0;
+    return () => (t += 10);
+  }
+  const base = {
+    runId: "run-x",
+    graceMs: 25,
+    pollIntervalMs: 5,
+    sleep: async () => {},
+  };
+
+  it("202 + worker claims within grace -> stream, no inline claim", async () => {
+    const claim = vi.fn();
+    const readClaim = vi
+      .fn()
+      .mockResolvedValueOnce({ dispatchMode: "background", status: "running" })
+      .mockResolvedValueOnce({
+        dispatchMode: "background-processing",
+        status: "running",
+      });
+    const outcome = await resolveBackgroundDispatchOutcome({
+      ...base,
+      dispatched: true,
+      backgroundRowInserted: true,
+      readClaim,
+      claim,
+      now: makeClock(),
+    });
+    expect(outcome).toEqual({ action: "stream" });
+    expect(claim).not.toHaveBeenCalled();
+  });
+
+  it("202 + no claim within grace -> foreground claims and runs inline", async () => {
+    const readClaim = vi
+      .fn()
+      .mockResolvedValue({ dispatchMode: "background", status: "running" });
+    const claim = vi.fn().mockResolvedValue(true);
+    const outcome = await resolveBackgroundDispatchOutcome({
+      ...base,
+      dispatched: true,
+      backgroundRowInserted: true,
+      readClaim,
+      claim,
+      now: makeClock(),
+    });
+    expect(outcome).toEqual({
+      action: "inline",
+      reason: "worker-never-claimed",
+    });
+    expect(claim).toHaveBeenCalledWith("run-x");
+  });
+
+  it("delayed worker wins the claim race after grace -> subscribe (no double-run)", async () => {
+    const readClaim = vi
+      .fn()
+      .mockResolvedValue({ dispatchMode: "background", status: "running" });
+    const claim = vi.fn().mockResolvedValue(false);
+    const outcome = await resolveBackgroundDispatchOutcome({
+      ...base,
+      dispatched: true,
+      backgroundRowInserted: true,
+      readClaim,
+      claim,
+      now: makeClock(),
+    });
+    expect(outcome).toEqual({ action: "subscribe" });
+  });
+
+  it("fast dispatch failure -> inline without polling for a claim", async () => {
+    const readClaim = vi.fn();
+    const claim = vi.fn().mockResolvedValue(true);
+    const outcome = await resolveBackgroundDispatchOutcome({
+      ...base,
+      dispatched: false,
+      backgroundRowInserted: true,
+      readClaim,
+      claim,
+      now: makeClock(),
+    });
+    expect(outcome).toEqual({ action: "inline", reason: "dispatch-failed" });
+    expect(readClaim).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -150,6 +150,96 @@ registerBuiltinEngines();
 
 export { PROVIDER_TO_ENV };
 
+/**
+ * Grace window + poll interval for the foreground circuit-breaker that confirms
+ * a background worker actually CLAIMED a 202-dispatched run before recovering
+ * inline. The grace is long enough for a cold-start worker to win the claim
+ * (~1-2s typical) and short enough to recover quickly within the foreground's
+ * ~40s soft-timeout.
+ */
+export const BACKGROUND_CLAIM_GRACE_MS = 8_000;
+export const BACKGROUND_CLAIM_POLL_MS = 400;
+
+export type BackgroundDispatchOutcome =
+  | { action: "stream" }
+  | { action: "subscribe" }
+  | {
+      action: "inline";
+      reason: "dispatch-failed" | "worker-never-claimed" | "no-row";
+    };
+
+/**
+ * Decide what the foreground should do after attempting a durable background
+ * dispatch. A Netlify async background function returns 202 the instant it
+ * ENQUEUES the invocation — that is NOT proof the worker executed. If the
+ * generated wrapper fails to import/hand off to the route, the worker never
+ * reaches `claimBackgroundRun` and the run is reaped as "worker never claimed".
+ *
+ * So after a successful dispatch we poll briefly for the worker to CLAIM the run:
+ *   - claimed within grace        → "stream"    (subscribe to the worker)
+ *   - dispatch failed OR no claim  → recover inline by atomically claiming the
+ *       run ourselves: if we win → "inline"; if a (delayed) worker already won
+ *       it → "subscribe" (never double-run).
+ *
+ * Pure except for the injected `readClaim`/`claim`/`now`/`sleep` deps, so each
+ * branch is unit-testable.
+ */
+export async function resolveBackgroundDispatchOutcome(opts: {
+  dispatched: boolean;
+  backgroundRowInserted: boolean;
+  runId: string;
+  graceMs: number;
+  pollIntervalMs: number;
+  readClaim: (
+    runId: string,
+  ) => Promise<{ dispatchMode: string | null; status: string | null } | null>;
+  claim: (runId: string) => Promise<boolean>;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<BackgroundDispatchOutcome> {
+  const now = opts.now ?? (() => Date.now());
+  const sleep =
+    opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+
+  if (opts.dispatched) {
+    const deadline = now() + opts.graceMs;
+    for (;;) {
+      const claim = await opts.readClaim(opts.runId).catch(() => null);
+      if (
+        claim &&
+        ((claim.dispatchMode && claim.dispatchMode !== "background") ||
+          (claim.status && claim.status !== "running"))
+      ) {
+        return { action: "stream" };
+      }
+      if (now() >= deadline) break;
+      await sleep(opts.pollIntervalMs);
+    }
+  }
+
+  // Dispatch fast-failed OR no worker claimed within grace → recover inline.
+  if (!opts.backgroundRowInserted) {
+    // No row to reconcile (insert failed / non-duplicate) — run a fresh inline
+    // turn; `startRun` inserts the row.
+    return { action: "inline", reason: "no-row" };
+  }
+  let claimedInline = false;
+  try {
+    claimedInline = await opts.claim(opts.runId);
+  } catch {
+    claimedInline = false;
+  }
+  if (claimedInline) {
+    return {
+      action: "inline",
+      reason: opts.dispatched ? "worker-never-claimed" : "dispatch-failed",
+    };
+  }
+  // The atomic claim was lost: a (delayed) background worker already owns the
+  // run — subscribe to it, never run a second copy.
+  return { action: "subscribe" };
+}
+
 const SAFE_BROWSER_TAB_ID_RE = /^[A-Za-z0-9_-]{1,96}$/;
 
 function normalizeBrowserTabId(value: unknown): string | undefined {
@@ -4426,52 +4516,33 @@ export function createProductionAgentHandler(
         );
       }
 
-      // ─── Circuit-breaker: confirm the worker actually CLAIMED the run ───────
-      // A Netlify async background function returns 202 the instant it ENQUEUES
-      // the invocation — that is NOT proof the worker ran. If the generated
-      // background-function wrapper fails to import `./main.mjs` or hand off to
-      // the Nitro `_process-run` route, the worker never reaches
-      // `claimBackgroundRun`: the row sits at `dispatch_mode='background'` until
-      // the reaper errors it ("worker never claimed the run"). So after a
-      // successful dispatch we poll briefly for the claim; if no worker claims
-      // within the grace window we treat it exactly like a fast dispatch failure
-      // and recover with an inline run below — a dead worker degrades to a
-      // working synchronous turn instead of a reaped failure.
-      let workerClaimed = false;
-      if (dispatched) {
-        // Long enough for a cold-start worker to win the claim (~1-2s typical),
-        // short enough to recover quickly and stay well within the foreground's
-        // ~40s soft-timeout.
-        const BACKGROUND_CLAIM_GRACE_MS = 8_000;
-        const claimDeadline = Date.now() + BACKGROUND_CLAIM_GRACE_MS;
-        for (;;) {
-          const claim = await readBackgroundRunClaim(runId).catch(() => null);
-          if (
-            claim &&
-            ((claim.dispatchMode && claim.dispatchMode !== "background") ||
-              (claim.status && claim.status !== "running"))
-          ) {
-            workerClaimed = true;
-            break;
-          }
-          if (Date.now() >= claimDeadline) break;
-          await new Promise((resolve) => setTimeout(resolve, 400));
-        }
-        if (!workerClaimed) {
-          console.error(
-            "[agent-chat] background worker did not claim the 202-dispatched " +
-              "run within grace; recovering inline:",
-            runId,
-          );
-          await recordRunDiagnostic(
-            runId,
-            RUN_DIAG_STAGE.foregroundInlineRecovery,
-            "202 dispatched but no worker claimed within the foreground grace window",
-          ).catch(() => {});
-        }
-      }
+      // ─── Circuit-breaker: a 202 only ENQUEUES the background invocation ─────
+      // It is NOT proof the worker executed. If the generated background-function
+      // wrapper fails to import `./main.mjs` or hand off to the Nitro
+      // `_process-run` route, the worker never reaches `claimBackgroundRun`: the
+      // row sits at `dispatch_mode='background'` until the reaper errors it
+      // ("worker never claimed the run"). `resolveBackgroundDispatchOutcome`
+      // polls briefly for the claim and decides:
+      //   - "stream":    a worker claimed the run → subscribe to it.
+      //   - "subscribe": a (delayed) worker already owns it → subscribe, NEVER
+      //                  run a second copy.
+      //   - "inline":    dispatch failed OR no worker claimed within grace → we
+      //                  atomically own the run; recover by running it inline so a
+      //                  dead worker degrades to a working synchronous turn.
+      const backgroundOutcome = await resolveBackgroundDispatchOutcome({
+        dispatched,
+        backgroundRowInserted,
+        runId,
+        graceMs: BACKGROUND_CLAIM_GRACE_MS,
+        pollIntervalMs: BACKGROUND_CLAIM_POLL_MS,
+        readClaim: readBackgroundRunClaim,
+        claim: claimBackgroundRun,
+      });
 
-      if (dispatched && workerClaimed) {
+      if (
+        backgroundOutcome.action === "stream" ||
+        backgroundOutcome.action === "subscribe"
+      ) {
         const stream = subscribeToRun(runId, 0);
         if (stream) {
           setResponseHeader(event, "Content-Type", "text/event-stream");
@@ -4480,69 +4551,39 @@ export function createProductionAgentHandler(
           setResponseHeader(event, "X-Run-Id", runId);
           return stream;
         }
-        // Subscription failed even though dispatch landed — surface an error
-        // rather than silently running inline (the background worker is already
-        // processing this runId, so an inline second run would double-execute).
+        // A background worker owns this run but we cannot subscribe — surface an
+        // error rather than risk a double-run by falling through to inline.
+        await updateRunStatusIfRunning(runId, "errored").catch(() => {});
         setResponseStatus(event, 500);
-        return { error: "Failed to subscribe to background run" };
+        return {
+          error:
+            backgroundOutcome.action === "stream"
+              ? "Failed to subscribe to background run"
+              : "Failed to dispatch background run",
+        };
       }
 
-      // ─── Dispatch failed OR worker never claimed → inline recovery ─────────
-      // We reach here when EITHER the dispatch fast-failed (fireInternalDispatch
-      // threw) OR it returned a 202 but no worker claimed the run within the
-      // circuit-breaker's grace window above. In both cases NO background worker
-      // owns this run, so the atomic claim below cannot double-execute.
-      // `fireInternalDispatch` throws ONLY when the self-POST failed *fast*
-      // (rejected the connection, or returned a non-2xx within the ~250ms settle
-      // race). The `_process-run` route verifies the HMAC token and validates
-      // the body BEFORE it ever reaches the SQL atomic claim, so a fast throw
-      // means NO background worker claimed this run — there is nothing to
-      // double-execute. Rather than break the chat with "Failed to dispatch
-      // background run", we run the turn inline (the same synchronous path the
-      // flag-off branch below takes), reusing the already-inserted run row.
-      //
-      // Safety against a (very improbable) delayed background delivery: claim the
-      // run atomically here via `claimBackgroundRun`, which flips the row's
-      // dispatch_mode `background → background-processing` in one conditional
-      // UPDATE. If a delayed dispatch DID land and a worker already won the
-      // claim, our claim returns false and we must NOT run inline (that would
-      // double-execute) — fall back to subscribing to the worker's run instead.
-      // The SQL atomic claim is the single source of truth for ownership, so at
-      // most one of {inline fallback, background worker} ever executes this run.
-      if (backgroundRowInserted) {
-        let claimedInline = false;
-        try {
-          claimedInline = await claimBackgroundRun(runId);
-        } catch (err) {
-          console.error(
-            "[agent-chat] inline-fallback claim failed:",
-            err instanceof Error ? err.message : err,
-          );
-        }
-        if (!claimedInline) {
-          // A background worker already owns this run (a delayed delivery landed
-          // after our fast throw). Stream its events instead of running a second
-          // copy. If we somehow can't subscribe, surface an error rather than
-          // risk a double-run.
-          const stream = subscribeToRun(runId, 0);
-          if (stream) {
-            setResponseHeader(event, "Content-Type", "text/event-stream");
-            setResponseHeader(event, "Cache-Control", "no-cache");
-            setResponseHeader(event, "Connection", "keep-alive");
-            setResponseHeader(event, "X-Run-Id", runId);
-            return stream;
-          }
-          await updateRunStatusIfRunning(runId, "errored").catch(() => {});
-          setResponseStatus(event, 500);
-          return { error: "Failed to dispatch background run" };
-        }
-        // We own the run. `startRun` (below) calls `insertRun` again, but its
-        // duplicate-PK collision is swallowed (`insertRun(...).catch(() => {})`),
-        // so the existing `background-processing` row is reused — no double row.
+      // backgroundOutcome.action === "inline": we atomically own the run (or
+      // there was no row to reconcile), so falling through to the inline
+      // `startRun` path below cannot double-execute. `startRun` calls `insertRun`
+      // again, but its duplicate-PK collision is swallowed, so an existing
+      // `background-processing` row is reused — no double row.
+      if (backgroundOutcome.reason === "worker-never-claimed") {
+        // The async 202 landed but no worker claimed within grace — the generated
+        // wrapper never reached the route. Record it so the failure is visible on
+        // the run even though the user still gets a working (inline) turn.
+        console.error(
+          "[agent-chat] background worker did not claim the 202-dispatched run " +
+            "within grace; recovering inline:",
+          runId,
+        );
+        await recordRunDiagnostic(
+          runId,
+          RUN_DIAG_STAGE.foregroundInlineRecovery,
+          "202 dispatched but no worker claimed within the foreground grace window",
+        ).catch(() => {});
       }
-      // Fall through to the inline `startRun` path below (the same one the
-      // flag-off branch uses). If the row was never inserted, `startRun` inserts
-      // it fresh; if it was, the claim above made us the sole owner.
+      // Fall through to the inline `startRun` path below.
     }
 
     const trackedProgressOwner =

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -109,6 +109,7 @@ import {
   updateRunHeartbeat,
   updateRunStatusIfRunning,
   claimBackgroundRun,
+  readBackgroundRunClaim,
   recordRunDiagnostic,
   RUN_DIAG_STAGE,
 } from "./run-store.js";
@@ -4425,7 +4426,52 @@ export function createProductionAgentHandler(
         );
       }
 
+      // ─── Circuit-breaker: confirm the worker actually CLAIMED the run ───────
+      // A Netlify async background function returns 202 the instant it ENQUEUES
+      // the invocation — that is NOT proof the worker ran. If the generated
+      // background-function wrapper fails to import `./main.mjs` or hand off to
+      // the Nitro `_process-run` route, the worker never reaches
+      // `claimBackgroundRun`: the row sits at `dispatch_mode='background'` until
+      // the reaper errors it ("worker never claimed the run"). So after a
+      // successful dispatch we poll briefly for the claim; if no worker claims
+      // within the grace window we treat it exactly like a fast dispatch failure
+      // and recover with an inline run below — a dead worker degrades to a
+      // working synchronous turn instead of a reaped failure.
+      let workerClaimed = false;
       if (dispatched) {
+        // Long enough for a cold-start worker to win the claim (~1-2s typical),
+        // short enough to recover quickly and stay well within the foreground's
+        // ~40s soft-timeout.
+        const BACKGROUND_CLAIM_GRACE_MS = 8_000;
+        const claimDeadline = Date.now() + BACKGROUND_CLAIM_GRACE_MS;
+        for (;;) {
+          const claim = await readBackgroundRunClaim(runId).catch(() => null);
+          if (
+            claim &&
+            ((claim.dispatchMode && claim.dispatchMode !== "background") ||
+              (claim.status && claim.status !== "running"))
+          ) {
+            workerClaimed = true;
+            break;
+          }
+          if (Date.now() >= claimDeadline) break;
+          await new Promise((resolve) => setTimeout(resolve, 400));
+        }
+        if (!workerClaimed) {
+          console.error(
+            "[agent-chat] background worker did not claim the 202-dispatched " +
+              "run within grace; recovering inline:",
+            runId,
+          );
+          await recordRunDiagnostic(
+            runId,
+            RUN_DIAG_STAGE.foregroundInlineRecovery,
+            "202 dispatched but no worker claimed within the foreground grace window",
+          ).catch(() => {});
+        }
+      }
+
+      if (dispatched && workerClaimed) {
         const stream = subscribeToRun(runId, 0);
         if (stream) {
           setResponseHeader(event, "Content-Type", "text/event-stream");
@@ -4441,7 +4487,11 @@ export function createProductionAgentHandler(
         return { error: "Failed to subscribe to background run" };
       }
 
-      // ─── Dispatch failed → degrade to a normal synchronous (inline) run ────
+      // ─── Dispatch failed OR worker never claimed → inline recovery ─────────
+      // We reach here when EITHER the dispatch fast-failed (fireInternalDispatch
+      // threw) OR it returned a 202 but no worker claimed the run within the
+      // circuit-breaker's grace window above. In both cases NO background worker
+      // owns this run, so the atomic claim below cannot double-execute.
       // `fireInternalDispatch` throws ONLY when the self-POST failed *fast*
       // (rejected the connection, or returned a non-2xx within the ~250ms settle
       // race). The `_process-run` route verifies the HMAC token and validates

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -10,6 +10,10 @@ let latestEventRows: Array<{ seq: number; event_data: string }> = [];
 let staleSelectRows: Array<{ id: string }> = [];
 let claimSlotRows: Array<{ id: string }> = [];
 let runStatusRows: Array<{ status: string }> = [];
+let claimStateRows: Array<{
+  dispatch_mode: string | null;
+  status: string | null;
+}> = [];
 let insertEventBehavior: () => void = () => {};
 
 const mockDb = {
@@ -36,6 +40,10 @@ const mockDb = {
     // getRunStatus: SELECT status FROM agent_runs WHERE id = ?
     if (/SELECT status FROM agent_runs WHERE id/i.test(rawSql)) {
       return { rows: runStatusRows, rowsAffected: 0 };
+    }
+    // readBackgroundRunClaim: SELECT dispatch_mode, status FROM agent_runs WHERE id = ?
+    if (/SELECT dispatch_mode, status FROM agent_runs WHERE id/i.test(rawSql)) {
+      return { rows: claimStateRows, rowsAffected: 0 };
     }
     if (/INSERT INTO agent_run_events/i.test(rawSql)) {
       insertEventBehavior();
@@ -74,6 +82,7 @@ const {
   tryClaimRunSlot,
   updateRunStatusIfRunning,
   getRunStatus,
+  readBackgroundRunClaim,
   writeLedgerEntry,
   readLedgerEntry,
   clearLedgerForThread,
@@ -89,9 +98,29 @@ describe("run store", () => {
     staleSelectRows = [];
     claimSlotRows = [];
     runStatusRows = [];
+    claimStateRows = [];
     ledgerRows = [];
     insertEventBehavior = () => {};
     vi.clearAllMocks();
+  });
+
+  it("readBackgroundRunClaim parses dispatch_mode + status, or null when missing", async () => {
+    claimStateRows = [{ dispatch_mode: "background", status: "running" }];
+    expect(await readBackgroundRunClaim("run-bg")).toEqual({
+      dispatchMode: "background",
+      status: "running",
+    });
+
+    claimStateRows = [
+      { dispatch_mode: "background-processing", status: "running" },
+    ];
+    expect(await readBackgroundRunClaim("run-claimed")).toEqual({
+      dispatchMode: "background-processing",
+      status: "running",
+    });
+
+    claimStateRows = [];
+    expect(await readBackgroundRunClaim("run-missing")).toBeNull();
   });
 
   it("persists a terminal event when marking a run aborted", async () => {

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -379,6 +379,35 @@ export async function claimBackgroundRun(runId: string): Promise<boolean> {
 }
 
 /**
+ * Read the claim/lifecycle state of a single run by id — for the foreground
+ * circuit-breaker that confirms a background worker actually CLAIMED a run that
+ * was dispatched with a Netlify async 202. A 202 only means the invocation was
+ * ENQUEUED; if the generated background-function wrapper fails to import/hand off
+ * to the route it never reaches `claimBackgroundRun`, leaving the row stuck at
+ * `dispatch_mode = 'background'`. `'background-processing'` means a worker won
+ * the claim; a terminal `status` means the run already resolved. Returns null if
+ * the row is missing.
+ */
+export async function readBackgroundRunClaim(
+  runId: string,
+): Promise<{ dispatchMode: string | null; status: string | null } | null> {
+  await ensureRunTables();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT dispatch_mode, status FROM agent_runs WHERE id = ? LIMIT 1`,
+    args: [runId],
+  });
+  const row = rows?.[0] as
+    | { dispatch_mode?: string | null; status?: string | null }
+    | undefined;
+  if (!row) return null;
+  return {
+    dispatchMode: row.dispatch_mode ?? null,
+    status: row.status ?? null,
+  };
+}
+
+/**
  * Atomically acquire a run lease for a thread. Succeeds (returns true) only
  * when no other run for the same thread is currently status='running' with a
  * fresh heartbeat. Works for both Postgres and SQLite: the stale-cutoff
@@ -481,6 +510,13 @@ export const RUN_DIAG_STAGE = {
   workerThrew: "worker_threw",
   /** The route handler caught an error from the worker invocation. */
   routeThrew: "route_threw",
+  /**
+   * The foreground circuit-breaker fired: a Netlify async 202 was returned but
+   * no background worker CLAIMED the run within the foreground grace window
+   * (the generated function wrapper never reached the route), so the foreground
+   * recovered by running the turn inline. The run still completes for the user.
+   */
+  foregroundInlineRecovery: "foreground_inline_recovery",
 } as const;
 
 export type RunDiagStage = (typeof RUN_DIAG_STAGE)[keyof typeof RUN_DIAG_STAGE];

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -1191,6 +1191,13 @@ describe("durable-background Netlify function emit (single-template, flag-gated)
     expect(entry).toContain(
       "globalThis.__AGENT_NATIVE_BACKGROUND_RUNTIME__ = true",
     );
+    // The wrapper passes Netlify's (request, context) through to the Nitro
+    // handler and guards the handoff so a pre-route failure is logged loudly
+    // instead of silently swallowed behind the async 202.
+    expect(entry).toContain("async function handler(request, context)");
+    expect(entry).toContain("cachedHandler(rewritten, context)");
+    expect(entry).toMatch(/try\s*\{/);
+    expect(entry).toContain("wrapper failed before reaching the route");
   });
 
   it("does NOT touch the server /* catch-all (no excludedPath patch — default url is never shadowed)", () => {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1617,20 +1617,37 @@ let cachedHandler;
 // PROCESS_RUN_PATH before delegating. Method, ALL headers (the HMAC
 // Authorization: Bearer MUST survive — the plugin verifies it) and the body are
 // preserved by cloning the incoming Request with only its URL pathname set.
-export default async function handler(request) {
-  cachedHandler ??= (await import("./main.mjs")).default;
-  const url = new URL(request.url);
-  url.pathname = PROCESS_RUN_PATH;
-  // Read the body once and pass it through. GET/HEAD have no body.
-  const method = request.method || "POST";
-  const hasBody = method !== "GET" && method !== "HEAD";
-  const body = hasBody ? await request.text() : undefined;
-  const rewritten = new Request(url.toString(), {
-    method,
-    headers: request.headers,
-    body,
-  });
-  return cachedHandler(rewritten);
+export default async function handler(request, context) {
+  try {
+    cachedHandler ??= (await import("./main.mjs")).default;
+    const url = new URL(request.url);
+    url.pathname = PROCESS_RUN_PATH;
+    // Read the body once and pass it through. GET/HEAD have no body.
+    const method = request.method || "POST";
+    const hasBody = method !== "GET" && method !== "HEAD";
+    const body = hasBody ? await request.text() : undefined;
+    const rewritten = new Request(url.toString(), {
+      method,
+      headers: request.headers,
+      body,
+    });
+    // Netlify Functions v2 invokes the handler as (request, context); the Nitro
+    // netlify handler accepts (request[, context]). Pass context through so a
+    // handler that uses it (e.g. waitUntil) does not trip over an undefined arg
+    // before it ever routes the request.
+    return await cachedHandler(rewritten, context);
+  } catch (err) {
+    // Netlify already returned 202 for this background invocation and DISCARDS
+    // this return, so a throw here is otherwise INVISIBLE — it would only surface
+    // downstream as the reaper's "worker never claimed the run". Log it loudly
+    // for the function log; the FOREGROUND circuit-breaker (production-agent.ts)
+    // is what recovers the run by executing it inline when no worker claims.
+    console.error(
+      "[agent-background] wrapper failed before reaching the route:",
+      (err && err.stack) || err,
+    );
+    throw err;
+  }
 }
 
 export const config = {


### PR DESCRIPTION
## Problem (diagnosed live on Forms)
Durable background is dispatching correctly — Forms has `server-agent-background`, Netlify returns `202`, and `dispatchMode=background`. But every run **errors**:

```
status: errored
diagStage: { stage: "worker_threw", detail: "unclaimed background dispatch reaped (worker never claimed the run)" }
```

The worker never records even its first diagnostic (`worker_entered`, before `claimBackgroundRun`), so **the bg-function handler never reaches the agent code** — the generated wrapper's import / route handoff dies *before* the Nitro `_process-run` route. A Netlify async **202 only means the invocation was enqueued, not executed** — so the foreground's "return the SSE on 202 and trust the worker" path leaves a dead-worker run to be reaped, which the user sees as "resuming forever / reconnecting then exited".

## Fix
1. **Foreground circuit-breaker** (`production-agent.ts`): after a successful dispatch, poll briefly (8s grace) for the worker to actually *claim* the run. If it doesn't, recover the turn **inline** (reusing the existing atomic-claim fallback that already handles a fast dispatch failure). A dead worker now degrades to a working synchronous turn instead of a reaped failure — chat never breaks, even while the root wrapper bug is still being chased. New `readBackgroundRunClaim` read in `run-store.ts` + `foreground_inline_recovery` diag stage.
2. **Harden the generated wrapper** (`build.ts`): pass Netlify's `context` through to the Nitro handler (v2 handlers are `(request, context)`) and wrap the import/handoff in try/catch so a pre-route failure is logged loudly instead of swallowed behind the 202.

## Tests
- `run-store.spec` covers `readBackgroundRunClaim`; `build.spec` asserts the wrapper passes `context` + guards the handoff; 98 specs pass. Core typecheck clean (the one unrelated error is concurrent localization WIP, not in this PR).

Next: redeploy Forms (kept opt-in `=true`) and verify a run completes via the circuit-breaker.