### PR TITLE
fix(durable): preserve bg-fn worker diag_stage to diagnose silent worker death

### DIFF
--- a/.changeset/durable-bg-preserve-diag.md
+++ b/.changeset/durable-bg-preserve-diag.md
@@ -1,0 +1,11 @@
+---
+"@agent-native/core": patch
+---
+
+Durable background diagnostics: preserve the background-function worker's last
+`diag_stage` (`route_entered` / `auth_failed` / etc., or `none` if it never
+reached the route) in the foreground circuit-breaker's
+`foreground_inline_recovery` detail instead of overwriting it. This makes a
+silent worker death diagnosable from `/runs/active` without reading the
+unreadable Netlify background-function logs. `readBackgroundRunClaim` now also
+returns `diagStage`.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -4569,18 +4569,24 @@ export function createProductionAgentHandler(
       // again, but its duplicate-PK collision is swallowed, so an existing
       // `background-processing` row is reused — no double row.
       if (backgroundOutcome.reason === "worker-never-claimed") {
-        // The async 202 landed but no worker claimed within grace — the generated
-        // wrapper never reached the route. Record it so the failure is visible on
-        // the run even though the user still gets a working (inline) turn.
+        // The async 202 landed but no worker claimed within grace. PRESERVE the
+        // bg-fn's last-recorded diag_stage (route_entered / auth_failed / ... or
+        // "none" if it never reached the route) in the recovery detail BEFORE we
+        // overwrite diag_stage — otherwise foreground_inline_recovery clobbers
+        // the only clue to WHY the worker died (its own logs are unreadable).
+        const priorClaim = await readBackgroundRunClaim(runId).catch(
+          () => null,
+        );
+        const priorDiag = priorClaim?.diagStage ?? "none";
         console.error(
           "[agent-chat] background worker did not claim the 202-dispatched run " +
-            "within grace; recovering inline:",
+            `within grace; recovering inline. bgFnPriorDiag=${priorDiag}`,
           runId,
         );
         await recordRunDiagnostic(
           runId,
           RUN_DIAG_STAGE.foregroundInlineRecovery,
-          "202 dispatched but no worker claimed within the foreground grace window",
+          `202 dispatched but no worker claimed within grace; bgFnPriorDiag=${priorDiag}`,
         ).catch(() => {});
       }
       // Fall through to the inline `startRun` path below.

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -13,6 +13,7 @@ let runStatusRows: Array<{ status: string }> = [];
 let claimStateRows: Array<{
   dispatch_mode: string | null;
   status: string | null;
+  diag_stage?: string | null;
 }> = [];
 let insertEventBehavior: () => void = () => {};
 
@@ -41,8 +42,12 @@ const mockDb = {
     if (/SELECT status FROM agent_runs WHERE id/i.test(rawSql)) {
       return { rows: runStatusRows, rowsAffected: 0 };
     }
-    // readBackgroundRunClaim: SELECT dispatch_mode, status FROM agent_runs WHERE id = ?
-    if (/SELECT dispatch_mode, status FROM agent_runs WHERE id/i.test(rawSql)) {
+    // readBackgroundRunClaim: SELECT dispatch_mode, status, diag_stage FROM agent_runs WHERE id = ?
+    if (
+      /SELECT dispatch_mode, status, diag_stage FROM agent_runs WHERE id/i.test(
+        rawSql,
+      )
+    ) {
       return { rows: claimStateRows, rowsAffected: 0 };
     }
     if (/INSERT INTO agent_run_events/i.test(rawSql)) {
@@ -104,11 +109,18 @@ describe("run store", () => {
     vi.clearAllMocks();
   });
 
-  it("readBackgroundRunClaim parses dispatch_mode + status, or null when missing", async () => {
-    claimStateRows = [{ dispatch_mode: "background", status: "running" }];
+  it("readBackgroundRunClaim parses dispatch_mode + status + diag_stage, or null when missing", async () => {
+    claimStateRows = [
+      {
+        dispatch_mode: "background",
+        status: "running",
+        diag_stage: '{"stage":"route_entered"}',
+      },
+    ];
     expect(await readBackgroundRunClaim("run-bg")).toEqual({
       dispatchMode: "background",
       status: "running",
+      diagStage: '{"stage":"route_entered"}',
     });
 
     claimStateRows = [
@@ -117,6 +129,7 @@ describe("run store", () => {
     expect(await readBackgroundRunClaim("run-claimed")).toEqual({
       dispatchMode: "background-processing",
       status: "running",
+      diagStage: null,
     });
 
     claimStateRows = [];

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -388,22 +388,29 @@ export async function claimBackgroundRun(runId: string): Promise<boolean> {
  * the claim; a terminal `status` means the run already resolved. Returns null if
  * the row is missing.
  */
-export async function readBackgroundRunClaim(
-  runId: string,
-): Promise<{ dispatchMode: string | null; status: string | null } | null> {
+export async function readBackgroundRunClaim(runId: string): Promise<{
+  dispatchMode: string | null;
+  status: string | null;
+  diagStage: string | null;
+} | null> {
   await ensureRunTables();
   const client = getDbExec();
   const { rows } = await client.execute({
-    sql: `SELECT dispatch_mode, status FROM agent_runs WHERE id = ? LIMIT 1`,
+    sql: `SELECT dispatch_mode, status, diag_stage FROM agent_runs WHERE id = ? LIMIT 1`,
     args: [runId],
   });
   const row = rows?.[0] as
-    | { dispatch_mode?: string | null; status?: string | null }
+    | {
+        dispatch_mode?: string | null;
+        status?: string | null;
+        diag_stage?: string | null;
+      }
     | undefined;
   if (!row) return null;
   return {
     dispatchMode: row.dispatch_mode ?? null,
     status: row.status ?? null,
+    diagStage: row.diag_stage ?? null,
   };
 }
 

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -524,19 +524,6 @@ export const RUN_DIAG_STAGE = {
    * recovered by running the turn inline. The run still completes for the user.
    */
   foregroundInlineRecovery: "foreground_inline_recovery",
-  /**
-   * bg-fn wrapper self-diagnostics (the generated `server-agent-background`
-   * wrapper reports these via the `_bg-diag` route, since its own logs are
-   * unreadable). `bgfnWrapperEntered`: the wrapper actually ran in the bg-fn
-   * isolate. `bgfnHandoffReturned`: the in-isolate handoff to the Nitro handler
-   * RETURNED — detail carries the HTTP status (404=route mismatch, 401=auth,
-   * 2xx/5xx=route ran). `bgfnWrapperThrew`: the import/handoff THREW before
-   * returning — detail carries the error. Read in the pre-grace window before
-   * the circuit-breaker overwrites diag_stage.
-   */
-  bgfnWrapperEntered: "bgfn_wrapper_entered",
-  bgfnHandoffReturned: "bgfn_handoff_returned",
-  bgfnWrapperThrew: "bgfn_wrapper_threw",
 } as const;
 
 export type RunDiagStage = (typeof RUN_DIAG_STAGE)[keyof typeof RUN_DIAG_STAGE];


### PR DESCRIPTION
Follow-up to #1461, built in a clean worktree off main (shared changes-310 is collided). DIAGNOSTIC, not the root fix. (1) The foreground circuit-breaker's foreground_inline_recovery was overwriting the bg-fn worker's diag_stage (route_entered/auth_failed/auth_passed/route_threw) before it could be read; now it reads + preserves it as bgFnPriorDiag=<stage> in the recovery detail. readBackgroundRunClaim returns diagStage. Netlify logs confirm the bg fn runs ~4.2s + does not throw, so the failure is silent inside _process-run; this surfaces the death stage on the next prod run. (2) Removes the stale unused bgfnWrapper* enum. Tests pass; typecheck clean.