### PR TITLE
fix(durable-bg): run background worker by resolving owner from run thread

### DIFF
--- a/.changeset/durable-bg-owner-context.md
+++ b/.changeset/durable-bg-owner-context.md
@@ -1,0 +1,14 @@
+---
+"@agent-native/core": patch
+---
+
+Durable background agent-chat: actually run the background worker. The
+self-dispatch into the Netlify background function is cookieless (HMAC-only), so
+the worker had no session and `resolveOwnerContext` threw 401 "Unauthenticated"
+before it could even claim the run — every durable run died at the route
+boundary (`route_threw`) and only completed via the foreground circuit-breaker's
+inline recovery, never using the 15-minute background budget. The `_process-run`
+route now resolves the owner securely from the run's chat thread
+(`getRunOwnerEmail(runId)` — DB-derived from the HMAC-signed run row, not the
+forgeable request body) and pre-seeds the owner context, so the background
+worker runs with the correct authenticated owner and the full background budget.

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -15,6 +15,7 @@ let claimStateRows: Array<{
   status: string | null;
   diag_stage?: string | null;
 }> = [];
+let runOwnerRows: Array<{ owner_email: string | null }> = [];
 let insertEventBehavior: () => void = () => {};
 
 const mockDb = {
@@ -49,6 +50,10 @@ const mockDb = {
       )
     ) {
       return { rows: claimStateRows, rowsAffected: 0 };
+    }
+    // getRunOwnerEmail: SELECT t.owner_email FROM agent_runs r JOIN chat_threads t ...
+    if (/JOIN chat_threads/i.test(rawSql)) {
+      return { rows: runOwnerRows, rowsAffected: 0 };
     }
     if (/INSERT INTO agent_run_events/i.test(rawSql)) {
       insertEventBehavior();
@@ -88,6 +93,7 @@ const {
   updateRunStatusIfRunning,
   getRunStatus,
   readBackgroundRunClaim,
+  getRunOwnerEmail,
   writeLedgerEntry,
   readLedgerEntry,
   clearLedgerForThread,
@@ -104,6 +110,7 @@ describe("run store", () => {
     claimSlotRows = [];
     runStatusRows = [];
     claimStateRows = [];
+    runOwnerRows = [];
     ledgerRows = [];
     insertEventBehavior = () => {};
     vi.clearAllMocks();
@@ -134,6 +141,19 @@ describe("run store", () => {
 
     claimStateRows = [];
     expect(await readBackgroundRunClaim("run-missing")).toBeNull();
+  });
+
+  it("getRunOwnerEmail resolves the thread owner for a run, or null when missing", async () => {
+    runOwnerRows = [{ owner_email: "owner@example.com" }];
+    expect(await getRunOwnerEmail("run-1")).toBe("owner@example.com");
+    // resolves by joining agent_runs to chat_threads, keyed by the runId only —
+    // the caller cannot supply the owner, only select the HMAC-signed run row.
+    const joinCall = execCalls.find((c) => /JOIN chat_threads/i.test(c.sql));
+    expect(joinCall).toBeTruthy();
+    expect(joinCall?.args).toEqual(["run-1"]);
+
+    runOwnerRows = [];
+    expect(await getRunOwnerEmail("run-missing")).toBeNull();
   });
 
   it("persists a terminal event when marking a run aborted", async () => {

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -415,6 +415,27 @@ export async function readBackgroundRunClaim(runId: string): Promise<{
 }
 
 /**
+ * Resolve the authenticated owner email for a run by joining it to its chat
+ * thread. The durable background worker's self-dispatch is cookieless
+ * (HMAC-only — see `AGENT_CHAT_PROCESS_RUN_PATH`), so it has no session for the
+ * normal owner resolution and would otherwise be treated as unauthenticated.
+ * The thread's `owner_email` was written by the authenticated foreground when it
+ * created the thread, so it is a trusted, non-forgeable owner source: only the
+ * HMAC-signed `runId` selects the row, and the caller cannot influence which
+ * owner that row maps to. Returns null when the run (or its thread) is missing.
+ */
+export async function getRunOwnerEmail(runId: string): Promise<string | null> {
+  await ensureRunTables();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT t.owner_email AS owner_email FROM agent_runs r JOIN chat_threads t ON r.thread_id = t.id WHERE r.id = ? LIMIT 1`,
+    args: [runId],
+  });
+  const row = rows?.[0] as { owner_email?: string | null } | undefined;
+  return row?.owner_email ?? null;
+}
+
+/**
  * Atomically acquire a run lease for a thread. Succeeds (returns true) only
  * when no other run for the same thread is currently status='running' with a
  * fresh heartbeat. Works for both Postgres and SQLite: the stale-cutoff

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -7877,6 +7877,32 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
           (event as any).context = (event as any).context ?? {};
           (event as any).context.__agentChatBackgroundBody = prepared.body;
 
+          // DURABLE OWNER CONTEXT: this self-dispatch is cookieless (HMAC-only —
+          // the foreground POST carried the user's session, but this background-
+          // function invocation does not). Without a session, resolveOwnerContext()
+          // falls through to its 401 "Unauthenticated" throw and the worker dies
+          // before it can even claim the run (observed in prod as the `route_threw`
+          // diag stage — every durable run only completed via the foreground
+          // circuit-breaker's inline recovery). The run's chat thread already
+          // records the authenticated owner (written by the foreground under the
+          // signed-in user), so resolve the owner from the run row — NOT from the
+          // request body, which the HMAC does not cover and a caller could forge —
+          // and pre-seed the owner context the handler reads (resolveOwnerContext
+          // returns it before attempting any session lookup).
+          try {
+            const { getRunOwnerEmail } = await import("../agent/run-store.js");
+            const backgroundOwner = await getRunOwnerEmail(prepared.runId);
+            if (backgroundOwner) {
+              (event as any).context[OWNER_CONTEXT_KEY] = {
+                owner: backgroundOwner,
+                anonymous: false,
+              };
+            }
+          } catch {
+            // Best-effort: if the lookup fails, resolveOwnerContext runs as before
+            // and throws its normal 401, surfaced via the route_threw diagnostic.
+          }
+
           try {
             return await invokeAgentChatHandler(event);
           } catch (err: any) {


### PR DESCRIPTION
## Root cause

Durable background agent-chat runs never actually ran the background worker. The foreground POST dispatches into the Netlify background function via an HMAC-signed self-call (`/_agent-native/agent-chat/_process-run`). That dispatch is **cookieless** — the foreground has the user's session, but the background-function invocation does not.

The `_process-run` route re-enters `invokeAgentChatHandler` → `resolveOwnerContext`, which resolves the owner from (1) a pre-set owner context, (2) the session cookie, or (3) anonymous mode — else **throws 401 "Unauthenticated"**. With no session, the worker threw at owner resolution **before it could even claim the run**. Every durable run died at the route boundary (visible as the `route_threw` diagnostic) and only completed because the foreground circuit-breaker (#1461) recovers inline after an 8s grace — so the **15-minute background budget was never used**.

Diagnosed on prod Forms: `bgFnPriorStage = route_threw`, then traced in code to `resolveOwnerContext`'s 401.

## Fix

In `_process-run`, after HMAC auth passes and before invoking the handler, resolve the owner **from the run's chat thread** and pre-seed `event.context[OWNER_CONTEXT_KEY]` (which `resolveOwnerContext` checks first). The worker then runs with the correct authenticated owner, no session needed.

New helper `getRunOwnerEmail(runId)` joins `agent_runs → chat_threads` and returns `owner_email`.

## Security (please review)

The owner is **DB-derived, not caller-supplied**:
- Only the **HMAC-signed `runId`** selects the run row (the dispatch is authenticated with `A2A_SECRET`).
- The thread's `owner_email` was written by the **authenticated foreground** when it created the thread.
- The request **body is deliberately not trusted** for the owner — the existing security comment in `resolveOwnerContext` warns that body/metadata-supplied identity is forgeable, so this fix avoids it entirely and reads the owner from the run row instead.

If the lookup fails for any reason, the route falls through to the prior behavior (`resolveOwnerContext` throws its normal 401, surfaced via `route_threw`) — no silent wrong-owner attribution.

## Test plan

- ✅ `getRunOwnerEmail` unit test (run-store.spec.ts): resolves the thread owner, joins on `runId` only, returns null when missing. 25/25 run-store specs pass.
- ✅ `pnpm --filter @agent-native/core typecheck` clean.
- ✅ Prettier clean.
- ⏳ Deploy Forms (durable-on) and verify the worker now claims + runs the turn end-to-end (`workerClaimed`/`workerStarted` diagnostics, no `route_threw`) using the full background budget.

## Context

Builds on the circuit-breaker (#1461) and preserve-diag (#1469) work — those made durable *safe* (chat never breaks); this makes the worker actually *run* so the long-budget background path works as designed. Forms is the prod test app (durable-on, no users).
