### PR TITLE
fix(durable): raise background-claim grace 8s -> 15s for heavy-app cold starts

### DIFF
--- a/.changeset/durable-bg-claim-grace.md
+++ b/.changeset/durable-bg-claim-grace.md
@@ -1,0 +1,11 @@
+---
+"@agent-native/core": patch
+---
+
+Durable background agent-chat: raise the foreground circuit-breaker's claim grace
+from 8s to 15s (`BACKGROUND_CLAIM_GRACE_MS`). Heavy apps (observed on analytics
+in prod) take longer than 8s to cold-start the background function and reach
+`claimBackgroundRun`, so the foreground recovered inline every time — adding ~8s
+latency per turn and never using the 15-minute background budget. 15s lets the
+slow-but-alive workers win the claim while staying well within the foreground's
+~40s soft-timeout; a genuinely dead worker still falls back to inline.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -153,11 +153,14 @@ export { PROVIDER_TO_ENV };
 /**
  * Grace window + poll interval for the foreground circuit-breaker that confirms
  * a background worker actually CLAIMED a 202-dispatched run before recovering
- * inline. The grace is long enough for a cold-start worker to win the claim
- * (~1-2s typical) and short enough to recover quickly within the foreground's
- * ~40s soft-timeout.
+ * inline. The grace must cover the worker's cold-start + per-request init before
+ * it reaches `claimBackgroundRun`: light apps win the claim in ~1-2s, but heavy
+ * apps (e.g. analytics) were observed in prod taking >8s, so an 8s grace made
+ * their worker lose the race every time and always fall back to inline (adding
+ * ~8s latency with no background budget). 15s covers the slow apps while staying
+ * well within the foreground's ~40s soft-timeout.
  */
-export const BACKGROUND_CLAIM_GRACE_MS = 8_000;
+export const BACKGROUND_CLAIM_GRACE_MS = 15_000;
 export const BACKGROUND_CLAIM_POLL_MS = 400;
 
 export type BackgroundDispatchOutcome =


### PR DESCRIPTION
## What

Raise the durable background circuit-breaker's claim grace from 8s to 15s (`BACKGROUND_CLAIM_GRACE_MS`).

## Why

During the durable rollout, **analytics** (a heavy app) consistently failed to claim its background run within the 8s grace: the bg-fn authenticated (`auth_passed`) but didn't reach `claimBackgroundRun` in time, so the foreground recovered inline **every turn** — adding ~8s latency and never using the 15-min background budget (verified 3/3 runs on prod via the `/runs/active` diag: `dispatchMode=background-processing` + `stage=foreground_inline_recovery`, `bgFnPriorDiag=auth_passed`).

Light apps (forms/brain/mail/calendar/design) claim in ~1-2s and are unaffected — they showed `worker_started` well under the grace.

15s covers slow-but-alive heavy-app cold starts while staying within the foreground's ~40s soft-timeout. A genuinely dead worker still falls back to inline (just after a longer wait — the accepted trade-off).

## Test

- `production-agent.spec` (circuit-breaker decision, dep-injected grace): 97 pass
- `@agent-native/core` typecheck clean; prettier clean
- ⏳ Follow-up: redeploy analytics and confirm `worker_started` lands within the new 15s grace.

Builds on the durable system shipped in #1474 / #1461 / #1469.
