### PR TITLE
feat(diag): pre-startRun setup-timing breakdown to localize slow agent setup

### DIFF
--- a/.changeset/durable-bg-setup-timings.md
+++ b/.changeset/durable-bg-setup-timings.md
@@ -1,0 +1,14 @@
+---
+"@agent-native/core": patch
+---
+
+Add diagnostic-only pre-`startRun` setup-timing instrumentation to the agent-chat
+handler. Captures wall-clock offsets from handler entry through the work done
+before the agent loop starts — body parse, request prep, system-prompt build,
+screen context, the parallel context-collection `Promise.all`, action/tool
+conversion, and thread data — and emits them as a `setup_timings` run diagnostic
+(readable via the run's `diag_stage`). No behavior change; best-effort and
+fire-and-forget. It lets us localize which setup bucket dominates pre-run latency
+on heavy apps — e.g. analytics, whose >25s setup currently exceeds the durable
+claim grace — and runs on both the inline and background-worker paths, so the
+breakdown can be measured with durable left OFF.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -3872,6 +3872,14 @@ export function createProductionAgentHandler(
   };
 
   return defineEventHandler(async (event) => {
+    // Diagnostic-only setup-timing instrumentation. Captures wall-clock offsets
+    // from handler entry through the work done BEFORE startRun so a slow pre-run
+    // setup phase is visible in the run diagnostics. Never alters control flow.
+    const setupT0 = Date.now();
+    const setupMarks: Record<string, number> = {};
+    const setupMark = (k: string) => {
+      setupMarks[k] = Date.now() - setupT0;
+    };
     if (getMethod(event) !== "POST") {
       setResponseStatus(event, 405);
       return { error: "Method not allowed" };
@@ -3912,6 +3920,7 @@ export function createProductionAgentHandler(
       scope,
       trackInRunsTray,
     } = body;
+    setupMark("bodyParsed");
 
     // Durable-background marker. Present ONLY when this handler was re-entered
     // as the Netlify background worker via the `_process-run` self-dispatch
@@ -4154,6 +4163,7 @@ export function createProductionAgentHandler(
       });
     }
 
+    setupMark("prepDone");
     // Run all independent pre-send steps in parallel. Each of these hits
     // the DB or invokes an action; running them sequentially was the
     // single biggest contributor to pre-LLM latency.
@@ -4165,6 +4175,7 @@ export function createProductionAgentHandler(
 
     let systemPromptError: any = null;
     const systemPromptPromise = (async (): Promise<string> => {
+      const sysPromptStart = Date.now();
       try {
         return typeof options.systemPrompt === "function"
           ? await options.systemPrompt(event)
@@ -4172,10 +4183,13 @@ export function createProductionAgentHandler(
       } catch (error) {
         systemPromptError = error;
         return "";
+      } finally {
+        setupMarks.sysPromptMs = Date.now() - sysPromptStart;
       }
     })();
 
     const screenContextPromise = (async (): Promise<string> => {
+      const screenStart = Date.now();
       try {
         const viewScreenAction = resolvedActions["view-screen"];
         if (viewScreenAction) {
@@ -4205,6 +4219,8 @@ export function createProductionAgentHandler(
         }
       } catch {
         // DB not ready or no navigation state — skip silently
+      } finally {
+        setupMarks.screenMs = Date.now() - screenStart;
       }
       return "";
     })();
@@ -4401,6 +4417,7 @@ export function createProductionAgentHandler(
       loopSettingsPromise,
       enrichedMessagePromise,
     ]);
+    setupMark("ctxAll");
 
     if (systemPromptError) {
       setResponseHeader(event, "Content-Type", "text/event-stream");
@@ -4428,6 +4445,7 @@ export function createProductionAgentHandler(
       availableRequestTools,
       options.initialToolNames,
     );
+    setupMark("actions");
     const requestSystemPrompt =
       requestMode === "plan"
         ? `${systemPrompt}\n\n${PLAN_MODE_SYSTEM_PROMPT}`
@@ -4538,6 +4556,7 @@ export function createProductionAgentHandler(
         // Keep the body-derived messages — never drop the run.
       }
     }
+    setupMark("depsThread");
 
     // Persist the user's turn exactly once. The foreground POST does this
     // before dispatching; the background worker must NOT repeat it (it re-enters
@@ -4946,6 +4965,20 @@ export function createProductionAgentHandler(
       );
       await updateRunHeartbeat(runId).catch(() => {});
     }
+
+    // DIAGNOSTIC-ONLY: emit the pre-startRun setup-timing breakdown. Best-effort
+    // and fire-and-forget — never blocks or throws. Runs for both the inline and
+    // background-worker paths since it sits just before the single startRun call.
+    setupMark("preStart");
+    const setupDetail =
+      Object.entries(setupMarks)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(" ") + ` total=${Date.now() - setupT0}`;
+    void recordRunDiagnostic(
+      runId,
+      RUN_DIAG_STAGE.setupTimings,
+      setupDetail,
+    ).catch(() => {});
 
     startRun(
       runId,

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -4987,23 +4987,27 @@ export function createProductionAgentHandler(
 
         send({ type: "activity", label: "Starting agent" });
 
-        // DIAGNOSTIC-ONLY: emit the pre-startRun setup-timing breakdown now that
-        // the run row exists (startRun has inserted it), so it persists on the
-        // inline path too. Awaited and recorded BEFORE worker_started so it can
-        // never land after and clobber the true last stage on background runs.
-        await recordRunDiagnostic(
-          runId,
-          RUN_DIAG_STAGE.setupTimings,
-          setupDetail,
-        ).catch(() => {});
-
         // DIAGNOSTIC: the agent loop body actually started running. For a
         // background worker, a run that is claimed but never reaches this stage
-        // died between claiming and loop start. Best-effort, background only.
+        // died between claiming and loop start. The pre-startRun setup-timing
+        // breakdown rides along here so it persists now that the run row exists
+        // (startRun inserted it), WITHOUT adding a separate DB hop to the
+        // run-start path: on the worker it is folded into this same
+        // already-awaited worker_started write (one hop, correctly ordered, no
+        // clobber); on the inline path there is no later diag stage to overwrite,
+        // so it is fire-and-forget to keep run-start non-blocking. Best-effort.
         if (isBackgroundWorker) {
-          await recordRunDiagnostic(runId, RUN_DIAG_STAGE.workerStarted).catch(
-            () => {},
-          );
+          await recordRunDiagnostic(
+            runId,
+            RUN_DIAG_STAGE.workerStarted,
+            setupDetail,
+          ).catch(() => {});
+        } else {
+          void recordRunDiagnostic(
+            runId,
+            RUN_DIAG_STAGE.setupTimings,
+            setupDetail,
+          ).catch(() => {});
         }
 
         // Notify listeners that a run has started (used by agent teams)

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -4966,19 +4966,15 @@ export function createProductionAgentHandler(
       await updateRunHeartbeat(runId).catch(() => {});
     }
 
-    // DIAGNOSTIC-ONLY: emit the pre-startRun setup-timing breakdown. Best-effort
-    // and fire-and-forget — never blocks or throws. Runs for both the inline and
-    // background-worker paths since it sits just before the single startRun call.
+    // DIAGNOSTIC-ONLY: build the pre-startRun setup-timing breakdown now (so the
+    // marks reflect the work done BEFORE the loop), but EMIT it from inside
+    // startRun's callback below — the run row does not exist until startRun
+    // inserts it, so a pre-startRun write would no-op on the inline path.
     setupMark("preStart");
     const setupDetail =
       Object.entries(setupMarks)
         .map(([k, v]) => `${k}=${v}`)
         .join(" ") + ` total=${Date.now() - setupT0}`;
-    void recordRunDiagnostic(
-      runId,
-      RUN_DIAG_STAGE.setupTimings,
-      setupDetail,
-    ).catch(() => {});
 
     startRun(
       runId,
@@ -4990,6 +4986,16 @@ export function createProductionAgentHandler(
         };
 
         send({ type: "activity", label: "Starting agent" });
+
+        // DIAGNOSTIC-ONLY: emit the pre-startRun setup-timing breakdown now that
+        // the run row exists (startRun has inserted it), so it persists on the
+        // inline path too. Awaited and recorded BEFORE worker_started so it can
+        // never land after and clobber the true last stage on background runs.
+        await recordRunDiagnostic(
+          runId,
+          RUN_DIAG_STAGE.setupTimings,
+          setupDetail,
+        ).catch(() => {});
 
         // DIAGNOSTIC: the agent loop body actually started running. For a
         // background worker, a run that is claimed but never reaches this stage

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -540,6 +540,8 @@ export const RUN_DIAG_STAGE = {
   workerClaimLost: "worker_claim_lost",
   /** The agent loop started (startRun fired). */
   workerStarted: "worker_started",
+  /** Pre-claim setup timing breakdown (diagnostic). */
+  setupTimings: "setup_timings",
   /** The worker threw before/while running the loop (message carried in detail). */
   workerThrew: "worker_threw",
   /** The route handler caught an error from the worker invocation. */


### PR DESCRIPTION
## What

Diagnostic-only instrumentation that records the agent-chat handler's **pre-`startRun` setup timing** and emits it as a `setup_timings` run diagnostic (in `diag_stage`).

## Why

Follow-up to #1491. The adaptive claim-grace is merged and verified working, but the live analytics E2E showed the real blocker: analytics' **agent setup itself takes >25s** (the worker sits at `auth_passed` building the system prompt + loading the action surface) — longer than the grace's hard ceiling (the unclaimed-reaper), so it still falls back to inline. To fix that we need to know *which* setup bucket dominates.

## How

Captures `Date.now()` offsets from handler entry at: `bodyParsed`, `prepDone`, `sysPromptMs` (the system-prompt build's own duration), `screenMs` (view-screen), `ctxAll` (after the parallel context `Promise.all`), `actions` (action registry + tool conversion), `depsThread` (thread data), `preStart`, and `total`. Emits them as one best-effort, fire-and-forget `recordRunDiagnostic` right before `startRun` — **unconditional**, so it runs on the inline path too. This means the breakdown can be read with **durable left OFF** (the slow setup runs inline identically), so measuring analytics needs no durable penalty.

No behavior change: only `Date.now()` reads + one `void ...catch(() => {})` diagnostic write.

## Test

- typecheck clean; prettier clean.
- 288 specs pass across `production-agent` / `run-store` / durable-background / run-manager / the run-store-mocking specs.

## Verify (after merge)

Deploy reaches analytics (durable stays OFF), run one normal chat turn, read the run's `diag_stage` → the `setup_timings` breakdown → optimize the largest bucket toward <~20s pre-claim.

Builds on #1491.
