### PR TITLE
feat(diag): worker-side stage diagnostics to localize bg-worker hang

### DIFF
--- a/.changeset/durable-bg-worker-stage-diag.md
+++ b/.changeset/durable-bg-worker-stage-diag.md
@@ -1,0 +1,12 @@
+---
+"@agent-native/core": patch
+---
+
+Add diagnostic-only worker-side progressive setup-stage diagnostics
+(`worker_setup_step`) to localize where a durable background worker hangs between
+`auth_passed` and `claimBackgroundRun`. For the background worker only (gated on
+`isBackgroundWorker`, using the marker's early-available runId), emit the last
+setup stage reached — `db_request_ctx`, `env_config`, `context_all`,
+`action_tool_setup`, `owner_thread`, `prestart` — as the run's `diag_stage`, so a
+worker that stalls leaves a breadcrumb at the stage it stopped in. Best-effort and
+fire-and-forget; no control-flow change.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -3934,6 +3934,22 @@ export function createProductionAgentHandler(
         ? body[AGENT_CHAT_BACKGROUND_RUN_FIELD]!
         : null;
     const isBackgroundWorker = backgroundRunMarker !== null;
+    // DIAGNOSTIC-ONLY: progressive per-stage hang localizer for the bg worker.
+    // The worker's runId is available EARLY on the marker (the general `runId`
+    // var resolves much later), so capture it now and emit the LAST setup stage
+    // reached as the run's `diag_stage`. Best-effort, gated on the worker, never
+    // blocks or alters control flow.
+    const bgRunId = isBackgroundWorker
+      ? (backgroundRunMarker?.runId as string)
+      : null;
+    const workerStep = (s: string) => {
+      if (bgRunId)
+        void recordRunDiagnostic(
+          bgRunId,
+          RUN_DIAG_STAGE.workerSetupStep,
+          `${s}=${Date.now() - setupT0}ms`,
+        ).catch(() => {});
+    };
     // Whether this worker is REALLY executing inside a 15-min Netlify
     // `-background` function (proven by the runtime function name), not merely a
     // `_process-run` re-entry that may have landed on the ~60s synchronous
@@ -4002,6 +4018,10 @@ export function createProductionAgentHandler(
         requestAttachments = preparedRequest.attachments;
       }
     }
+    // DIAGNOSTIC-ONLY: owner/request context prep (resolveAgentOwnerEmail +
+    // prepareRequest) finished. A worker stuck before this points at the
+    // owner/request-context awaits.
+    workerStep("db_request_ctx");
 
     // Pre-upload chat attachments (images AND files/PDFs) through the framework
     // file-upload provider (Builder.io by default). The model still sees the
@@ -4164,6 +4184,10 @@ export function createProductionAgentHandler(
     }
 
     setupMark("prepDone");
+    // DIAGNOSTIC-ONLY: engine/model/api-key resolution finished. A worker that
+    // reached db_request_ctx but not env_config hung in attachment upload or
+    // engine/model resolution.
+    workerStep("env_config");
     // Run all independent pre-send steps in parallel. Each of these hits
     // the DB or invokes an action; running them sequentially was the
     // single biggest contributor to pre-LLM latency.
@@ -4418,6 +4442,9 @@ export function createProductionAgentHandler(
       enrichedMessagePromise,
     ]);
     setupMark("ctxAll");
+    // DIAGNOSTIC-ONLY: all parallel context gathering (system prompt, screen,
+    // files, loop settings, enriched message) resolved.
+    workerStep("context_all");
 
     if (systemPromptError) {
       setResponseHeader(event, "Content-Type", "text/event-stream");
@@ -4446,6 +4473,8 @@ export function createProductionAgentHandler(
       options.initialToolNames,
     );
     setupMark("actions");
+    // DIAGNOSTIC-ONLY: action/tool resolution + engine-tool filtering finished.
+    workerStep("action_tool_setup");
     const requestSystemPrompt =
       requestMode === "plan"
         ? `${systemPrompt}\n\n${PLAN_MODE_SYSTEM_PROMPT}`
@@ -4557,6 +4586,9 @@ export function createProductionAgentHandler(
       }
     }
     setupMark("depsThread");
+    // DIAGNOSTIC-ONLY: owner/thread resolution + runId/effectiveThreadId +
+    // chained-continuation thread fetch finished.
+    workerStep("owner_thread");
 
     // Persist the user's turn exactly once. The foreground POST does this
     // before dispatching; the background worker must NOT repeat it (it re-enters
@@ -4971,6 +5003,9 @@ export function createProductionAgentHandler(
     // startRun's callback below — the run row does not exist until startRun
     // inserts it, so a pre-startRun write would no-op on the inline path.
     setupMark("preStart");
+    // DIAGNOSTIC-ONLY: last stage before startRun fires. A worker that reaches
+    // prestart but never workerStarted is hanging inside startRun itself.
+    workerStep("prestart");
     const setupDetail =
       Object.entries(setupMarks)
         .map(([k, v]) => `${k}=${v}`)

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -540,6 +540,8 @@ export const RUN_DIAG_STAGE = {
   workerClaimLost: "worker_claim_lost",
   /** The agent loop started (startRun fired). */
   workerStarted: "worker_started",
+  /** Last worker setup stage reached before startRun (progressive hang localizer). */
+  workerSetupStep: "worker_setup_step",
   /** Pre-claim setup timing breakdown (diagnostic). */
   setupTimings: "setup_timings",
   /** The worker threw before/while running the loop (message carried in detail). */


### PR DESCRIPTION
Diagnostic-only follow-up to #1498. The analytics bg worker reaches `auth_passed` then never claims; `setup_timings` (emitted at startRun) can't see it. This emits the **last setup stage reached** as `diag_stage` for the bg worker only, so a controlled durable-on test turn reveals exactly where it stalls. Gated on `isBackgroundWorker`, best-effort, no control-flow change. typecheck + 182 specs green.