### PR TITLE
Fix countdown layout to align cancel and skip buttons

### DIFF
--- a/templates/clips/desktop/src/overlays/countdown.tsx
+++ b/templates/clips/desktop/src/overlays/countdown.tsx
@@ -66,8 +66,10 @@ export function Countdown() {
         >
           <IconX size={30} stroke={2.4} />
         </button>
-        <div className="countdown-number" key={n} aria-live="polite">
-          {n > 0 ? n : ""}
+        <div className="countdown-number-wrap">
+          <div className="countdown-number" key={n} aria-live="polite">
+            {n > 0 ? n : ""}
+          </div>
         </div>
         <button
           type="button"

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -2099,7 +2099,7 @@ body[data-clips-route="recording-pill"] #root {
 
 .countdown-control-skip {
   /* center at +200px from row center: 200 - (64 / 2) = 168px */
-  right: -232px;
+  left: 168px;
 }
 
 .countdown-control:hover {
@@ -2115,6 +2115,20 @@ body[data-clips-route="recording-pill"] #root {
 .countdown-control:focus-visible {
   outline: 2px solid rgba(255, 255, 255, 0.9);
   outline-offset: 2px;
+}
+
+/*
+ * Absolutely centers the number without contributing width to .countdown-controls.
+ * This keeps the controls div at zero width so the cancel/skip button positions
+ * (left: -232px, left: 168px) line up exactly with the Rust cursor-poll hit-rects
+ * (CONTROL_OFFSET_X = 200.0) measured from the window center.
+ */
+.countdown-number-wrap {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
 }
 
 .countdown-number {


### PR DESCRIPTION
### Summary
Fixes the positioning of the cancel and skip buttons in the countdown overlay by wrapping the countdown number in an absolutely positioned element that doesn't contribute to the layout width of the controls container.

### Problem
The countdown number was part of the normal flow inside `.countdown-controls`, causing the container to have non-zero width. This shifted the cancel (X) and skip button positions away from their intended hit-rect locations, making the X button non-functional (misaligned with the Rust cursor-poll hit-rects).

### Solution
Wrap the countdown number in a `.countdown-number-wrap` element that is absolutely positioned and uses `pointer-events: none`, so it doesn't affect the width of `.countdown-controls`. The skip button offset was also corrected from `right: -232px` to `left: 168px` to match the Rust `CONTROL_OFFSET_X = 200.0` measurement from the window center.

### Key Changes
- Wrapped `.countdown-number` in a new `.countdown-number-wrap` div in `countdown.tsx`
- Added `.countdown-number-wrap` CSS rule: `position: absolute`, centered via `transform: translate(-50%, -50%)`, with `pointer-events: none` to avoid interfering with button clicks
- Fixed `.countdown-control-skip` offset from `right: -232px` to `left: 168px` to correctly align with the Rust hit-rect layout


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/orbital-momentum-10tcgvex"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-orbital-momentum-10tcgvex.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1507`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>orbital-momentum-10tcgvex</branchName>-->