### PR TITLE
Fix Plan access loading and contents rail

### DIFF
--- a/templates/plan/app/global.css
+++ b/templates/plan/app/global.css
@@ -486,8 +486,10 @@
   padding-inline-start: 0.75rem;
 }
 
-/* Narrow-width stand-in for the contents rail; swapped in/out by the queries below. */
+/* Hidden below the rail breakpoint: the document should use the full reading
+ * width instead of replacing the rail with an inline contents widget. */
 .plan-document-toc-inline {
+  display: none;
   margin-top: 1.25rem;
   border: 1px solid var(--plan-line);
   border-radius: 0.75rem;
@@ -548,23 +550,16 @@
   list-style: none;
 }
 
-/* Hide the accordion once its rail shows, and in screenshot capture. */
+/* Hide the accordion in screenshot capture too. */
 .plan-content-surface[data-recap-screenshot-theme] .plan-document-toc-inline {
   display: none;
-}
-@container plan-doc (min-width: 48rem) {
-  .plan-content-surface:not([data-recap-screenshot-theme])
-    .plan-document-body[data-has-toc]
-    > .plan-document-toc-inline {
-    display: none;
-  }
 }
 
 /* Wide layout: the contents rail is a real grid column. A matching empty left
  * column balances the rail so the document itself remains visually centered. */
 
 /* Shared cell placement. Inert until the parent is a grid. */
-@container plan-doc (min-width: 48rem) {
+@container plan-doc (min-width: 1200px) {
   .plan-content-surface:not([data-recap-screenshot-theme])
     .plan-document-body
     > header {
@@ -588,7 +583,7 @@
 }
 
 /* Document + contents rail. The empty first column balances the right rail. */
-@container plan-doc (min-width: 48rem) {
+@container plan-doc (min-width: 1200px) {
   .plan-content-surface:not([data-recap-screenshot-theme])
     .plan-document-body[data-has-toc] {
     display: grid;

--- a/templates/plan/app/pages/PlansPage.comments.test.ts
+++ b/templates/plan/app/pages/PlansPage.comments.test.ts
@@ -932,10 +932,10 @@ describe("plan comment thread UI model", () => {
       hasSelectedId: true,
       localPlanMode: false,
       hasBundle: false,
-      planQueryPending: false,
+      planQueryInitialPending: false,
       planQueryError: false,
       planQueryPaused: false,
-      accessStatusPending: false,
+      accessStatusInitialPending: false,
       accessStatusPaused: false,
       accessDenied: false,
     };
@@ -951,7 +951,7 @@ describe("plan comment thread UI model", () => {
     expect(
       shouldShowPlanLoadError({
         ...base,
-        planQueryPending: true,
+        planQueryInitialPending: true,
         planQueryPaused: true,
       }),
     ).toBe(false);
@@ -960,12 +960,28 @@ describe("plan comment thread UI model", () => {
       true,
     );
     expect(shouldShowPlanLoadError({ ...base, accessDenied: true })).toBe(true);
+    // Background refetches should not replace a settled error/access card with
+    // the first-load skeleton.
+    expect(
+      shouldShowPlanLoadError({
+        ...base,
+        planQueryInitialPending: true,
+        planQueryError: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowPlanLoadError({
+        ...base,
+        planQueryInitialPending: true,
+        accessDenied: true,
+      }),
+    ).toBe(true);
     // An access denial that hasn't settled yet should not flash the card.
     expect(
       shouldShowPlanLoadError({
         ...base,
         accessDenied: true,
-        accessStatusPending: true,
+        accessStatusInitialPending: true,
       }),
     ).toBe(false);
     // Healthy / local / already-loaded states never show the card.

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -593,22 +593,25 @@ export function shouldShowPlanLoadError(input: {
   hasSelectedId: boolean;
   localPlanMode: boolean;
   hasBundle: boolean;
-  planQueryPending: boolean;
+  planQueryInitialPending: boolean;
   planQueryError: boolean;
   planQueryPaused: boolean;
-  accessStatusPending: boolean;
+  accessStatusInitialPending: boolean;
   accessStatusPaused: boolean;
   accessDenied: boolean;
 }): boolean {
   if (!input.hasSelectedId || input.localPlanMode || input.hasBundle) {
     return false;
   }
-  // While a read is actively in flight, keep showing the skeleton.
-  if (input.planQueryPending) return false;
   if (input.planQueryError) return true;
+  if (!input.accessStatusInitialPending && input.accessDenied) return true;
+  // While the first read is actively in flight, keep showing the skeleton.
+  // Background refetches must not hide a settled access/error card.
+  if (input.planQueryInitialPending || input.accessStatusInitialPending) {
+    return false;
+  }
   // Paused/stalled read that will never settle on its own input.
   if (input.planQueryPaused || input.accessStatusPaused) return true;
-  if (!input.accessStatusPending && input.accessDenied) return true;
   return false;
 }
 
@@ -3125,17 +3128,16 @@ export function PlansPage({ localPlanSlug }: { localPlanSlug?: string } = {}) {
     Boolean(selectedId && !bundle && !localPlanMode),
   );
   const planAccessStatus = planAccessStatusQuery.data ?? null;
-  const planQueryPending = planQuery.isLoading || planQuery.isFetching;
-  const planAccessStatusPending =
-    planAccessStatusQuery.isLoading || planAccessStatusQuery.isFetching;
+  const planQueryInitialPending = planQuery.isLoading;
+  const planAccessStatusInitialPending = planAccessStatusQuery.isLoading;
   const showPlanLoadError = shouldShowPlanLoadError({
     hasSelectedId: Boolean(selectedId),
     localPlanMode,
     hasBundle: Boolean(bundle),
-    planQueryPending,
+    planQueryInitialPending,
     planQueryError: planQuery.isError,
     planQueryPaused: planQuery.isPaused,
-    accessStatusPending: planAccessStatusPending,
+    accessStatusInitialPending: planAccessStatusInitialPending,
     accessStatusPaused: planAccessStatusQuery.isPaused,
     accessDenied: Boolean(planAccessStatus && !planAccessStatus.hasAccess),
   });

--- a/templates/plan/changelog/2026-06-25-plan-access-request-pages-stay-visible-during-background-ref.md
+++ b/templates/plan/changelog/2026-06-25-plan-access-request-pages-stay-visible-during-background-ref.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-25
+---
+
+Plan access request pages stay visible during background refreshes instead of flashing back to loading.

--- a/templates/plan/changelog/2026-06-25-plan-documents-keep-their-full-reading-width-below-1200px-an.md
+++ b/templates/plan/changelog/2026-06-25-plan-documents-keep-their-full-reading-width-below-1200px-an.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-06-25
+---
+
+Plan documents keep their full reading width below 1200px and show the contents rail only on wider screens.


### PR DESCRIPTION
## Summary
- keep private/access-request Plan pages mounted during background refreshes instead of flashing back to the skeleton
- hide the inline Plan contents widget and only show the side rail at 1200px or wider
- add pending Plan changelog entries for both visible fixes

## Validation
- pnpm --filter plan exec vitest run app/components/plan/PlanTableOfContents.test.ts app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx app/pages/PlansPage.comments.test.ts
- pnpm --filter plan typecheck