### PR TITLE
fix(db): guard ensureTable DDL — no lock on migrated path, scoped lock_timeout

### DIFF
--- a/.changeset/ensuretable-ddl-guard.md
+++ b/.changeset/ensuretable-ddl-guard.md
@@ -1,0 +1,16 @@
+---
+"@agent-native/core": patch
+---
+
+Guard on-demand `ensureTable()` schema-init so the already-migrated path takes no
+`ACCESS EXCLUSIVE` lock on Postgres. The app-secrets (`app_secrets`) and `settings`
+stores now probe `information_schema`/`pg_indexes` first (plain reads, no lock) and
+issue `CREATE`/`ALTER`/`CREATE INDEX` only when something is actually missing; any
+DDL that must run is wrapped in a transaction-scoped `SET LOCAL lock_timeout` so a
+contended lock fails fast instead of hanging (and never leaks onto the pooled
+connection). This fixes background-function workers hanging indefinitely on
+first-touch schema DDL behind a concurrent connection on shared Neon — observed as
+durable agent-chat workers stalling right after auth and never claiming the run.
+SQLite (local dev) behavior is unchanged. Adds a shared `db/ddl-guard.ts` helper
+(`pgTableExists`/`pgColumnExists`/`pgIndexExists`/`runGuardedDdl`). Also adds
+diagnostic-only worker setup sub-stage breadcrumbs to localize such stalls.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -4023,6 +4023,8 @@ export function createProductionAgentHandler(
     // owner/request-context awaits.
     workerStep("db_request_ctx");
 
+    // DIAGNOSTIC-ONLY: bracket attachment upload + text-attachment persistence.
+    workerStep("attach_start");
     // Pre-upload chat attachments (images AND files/PDFs) through the framework
     // file-upload provider (Builder.io by default). The model still sees the
     // base64 multimodal content for the current turn; each uploaded attachment
@@ -4085,9 +4087,13 @@ export function createProductionAgentHandler(
         );
       }
     }
+    // DIAGNOSTIC-ONLY: attachment upload + persistence finished.
+    workerStep("attach_done");
 
     // When a per-request engine override is specified, resolve the API key
     // for that provider instead of the global active engine's provider.
+    // DIAGNOSTIC-ONLY: bracket per-owner API-key resolution (settings/app_secrets reads).
+    workerStep("apikey_start");
     let userApiKey: string | undefined;
     if (requestEngine) {
       const provider = engineToProvider(requestEngine);
@@ -4103,6 +4109,8 @@ export function createProductionAgentHandler(
     } else {
       userApiKey = await getOwnerActiveApiKey(ownerEmail);
     }
+    // DIAGNOSTIC-ONLY: API-key resolution finished.
+    workerStep("apikey_done");
 
     // `options.apiKey` is the value the template constructed the plugin with
     // (e.g. wired from a deployment env var). On a shared hosted deploy this
@@ -4117,6 +4125,9 @@ export function createProductionAgentHandler(
         readDeployCredentialEnv("ANTHROPIC_API_KEY"));
 
     // Resolve engine — per-request engine override takes priority
+    // DIAGNOSTIC-ONLY: bracket engine resolution (Builder credential / app-default
+    // settings reads inside resolveEngine).
+    workerStep("engine_start");
     let engine: AgentEngine;
     try {
       engine = await resolveEngine({
@@ -4131,17 +4142,24 @@ export function createProductionAgentHandler(
         appId: options.appId,
       });
     }
+    // DIAGNOSTIC-ONLY: engine resolution finished.
+    workerStep("engine_done");
 
     // Honor the model the user picked in the settings UI (written via
     // `manage-agent-engine` action="set"), but only when the caller hasn't overridden it for
     // this request or at plugin construction time. Read per-request so a
     // dropdown change in the UI takes effect without a server restart. Skip
     // the DB read entirely when a higher-precedence value is set.
+    // DIAGNOSTIC-ONLY: bracket stored-model resolution (getStoredModelForEngine
+    // settings read).
+    workerStep("model_start");
     const modelCandidate =
       requestModel ??
       configuredModel ??
       (await getStoredModelForEngine(engine, { appId: options.appId })) ??
       engine.defaultModel;
+    // DIAGNOSTIC-ONLY: stored-model resolution finished.
+    workerStep("model_done");
     const model = normalizeModelForEngine(engine, modelCandidate);
     const reasoningEffort = normalizeReasoningEffortForModel(
       model,

--- a/packages/core/src/db/ddl-guard.spec.ts
+++ b/packages/core/src/db/ddl-guard.spec.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// These helpers resolve `isPostgres()` through `./client.js`, which derives the
+// dialect from `process.env.DATABASE_URL`. The tests stub that env and pass an
+// injected fake client, so no real database is required.
+
+describe("ddl-guard", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    process.env = originalEnv;
+    vi.resetModules();
+  });
+
+  function recordingClient(
+    handler: (sql: string) => { rows: unknown[] } | undefined = () => undefined,
+  ) {
+    const calls: string[] = [];
+    const client = {
+      execute: async (sql: string | { sql: string; args?: unknown[] }) => {
+        const text = typeof sql === "string" ? sql : sql.sql;
+        calls.push(text);
+        return handler(text) ?? { rows: [], rowsAffected: 0 };
+      },
+      transaction: async (fn: (tx: any) => Promise<unknown>) => {
+        calls.push("BEGIN");
+        try {
+          const result = await fn(client);
+          calls.push("COMMIT");
+          return result;
+        } catch (err) {
+          calls.push("ROLLBACK");
+          throw err;
+        }
+      },
+    } as any;
+    return { client, calls };
+  }
+
+  describe("pgTableExists / pgColumnExists / pgIndexExists", () => {
+    it("are no-ops on SQLite (never query)", async () => {
+      vi.stubEnv("DATABASE_URL", "file:./data/app.db");
+      const { pgTableExists, pgColumnExists, pgIndexExists } =
+        await import("./ddl-guard.js");
+      const { client, calls } = recordingClient();
+      expect(await pgTableExists("settings", client)).toBe(false);
+      expect(await pgColumnExists("settings", "x", client)).toBe(false);
+      expect(await pgIndexExists("settings_idx", client)).toBe(false);
+      expect(calls).toEqual([]);
+    });
+
+    it("report existence on Postgres from information_schema / pg_indexes", async () => {
+      vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+      const { pgTableExists, pgColumnExists, pgIndexExists } =
+        await import("./ddl-guard.js");
+      const present = recordingClient(() => ({ rows: [{ ok: 1 }] }));
+      expect(await pgTableExists("app_secrets", present.client)).toBe(true);
+      expect(
+        await pgColumnExists("app_secrets", "description", present.client),
+      ).toBe(true);
+      expect(
+        await pgIndexExists("settings_updated_at_idx", present.client),
+      ).toBe(true);
+
+      const absent = recordingClient(() => ({ rows: [] }));
+      expect(await pgTableExists("app_secrets", absent.client)).toBe(false);
+      expect(
+        await pgColumnExists("app_secrets", "description", absent.client),
+      ).toBe(false);
+    });
+
+    it("reject non-identifier names without querying", async () => {
+      vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+      const { pgTableExists, pgColumnExists } = await import("./ddl-guard.js");
+      const { client, calls } = recordingClient(() => ({ rows: [{ ok: 1 }] }));
+      expect(await pgTableExists("app_secrets; DROP TABLE x", client)).toBe(
+        false,
+      );
+      expect(await pgColumnExists("app_secrets", "bad name", client)).toBe(
+        false,
+      );
+      expect(calls).toEqual([]);
+    });
+
+    it("treat an unreadable information_schema as 'unknown' (false)", async () => {
+      vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+      const { pgTableExists } = await import("./ddl-guard.js");
+      const throwing = {
+        execute: async () => {
+          throw new Error("permission denied for relation");
+        },
+      } as any;
+      expect(await pgTableExists("app_secrets", throwing)).toBe(false);
+    });
+  });
+
+  describe("runGuardedDdl", () => {
+    it("runs DDL directly on SQLite (no transaction / lock_timeout)", async () => {
+      vi.stubEnv("DATABASE_URL", "file:./data/app.db");
+      const { runGuardedDdl } = await import("./ddl-guard.js");
+      const { client, calls } = recordingClient();
+      const ran = await runGuardedDdl("CREATE TABLE foo (id TEXT)", {
+        injectedClient: client,
+      });
+      expect(ran).toBe(true);
+      expect(calls).toEqual(["CREATE TABLE foo (id TEXT)"]);
+    });
+
+    it("wraps Postgres DDL in a transaction with SET LOCAL lock_timeout", async () => {
+      vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+      const { runGuardedDdl } = await import("./ddl-guard.js");
+      const { client, calls } = recordingClient();
+      const ran = await runGuardedDdl("CREATE TABLE foo (id TEXT)", {
+        injectedClient: client,
+        lockTimeout: "3s",
+      });
+      expect(ran).toBe(true);
+      expect(calls).toEqual([
+        "BEGIN",
+        "SET LOCAL lock_timeout = '3s'",
+        "CREATE TABLE foo (id TEXT)",
+        "COMMIT",
+      ]);
+      // The lock_timeout is transaction-scoped (SET LOCAL) — no session-level
+      // SET or RESET leaks onto the pooled connection.
+      expect(calls.some((c) => /^SET lock_timeout/.test(c))).toBe(false);
+      expect(calls.some((c) => /RESET lock_timeout/.test(c))).toBe(false);
+    });
+
+    it("swallows a lock-timeout error and returns false (still resolves)", async () => {
+      vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+      const { runGuardedDdl } = await import("./ddl-guard.js");
+      const lockErr = Object.assign(
+        new Error("canceling statement due to lock timeout"),
+        {
+          code: "55P03",
+        },
+      );
+      const client = {
+        execute: async () => ({ rows: [], rowsAffected: 0 }),
+        transaction: async (fn: (tx: any) => Promise<unknown>) => {
+          // Simulate the DDL inside the tx hitting a lock timeout.
+          return fn({
+            execute: async (sql: string | { sql: string }) => {
+              const text = typeof sql === "string" ? sql : sql.sql;
+              if (/CREATE TABLE/i.test(text)) throw lockErr;
+              return { rows: [], rowsAffected: 0 };
+            },
+          });
+        },
+      } as any;
+      const ran = await runGuardedDdl("CREATE TABLE foo (id TEXT)", {
+        injectedClient: client,
+      });
+      expect(ran).toBe(false);
+    });
+
+    it("rethrows non-lock-timeout errors", async () => {
+      vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+      const { runGuardedDdl } = await import("./ddl-guard.js");
+      const client = {
+        execute: async () => ({ rows: [], rowsAffected: 0 }),
+        transaction: async (fn: (tx: any) => Promise<unknown>) =>
+          fn({
+            execute: async (sql: string | { sql: string }) => {
+              const text = typeof sql === "string" ? sql : sql.sql;
+              if (/CREATE TABLE/i.test(text)) {
+                throw new Error("syntax error at or near");
+              }
+              return { rows: [], rowsAffected: 0 };
+            },
+          }),
+      } as any;
+      await expect(
+        runGuardedDdl("CREATE TABLE foo (id TEXT)", { injectedClient: client }),
+      ).rejects.toThrow("syntax error");
+    });
+
+    it("falls back to session SET + RESET when no transaction is available", async () => {
+      vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+      const { runGuardedDdl } = await import("./ddl-guard.js");
+      const calls: string[] = [];
+      const client = {
+        execute: async (sql: string | { sql: string }) => {
+          calls.push(typeof sql === "string" ? sql : sql.sql);
+          return { rows: [], rowsAffected: 0 };
+        },
+        // no transaction
+      } as any;
+      const ran = await runGuardedDdl("CREATE TABLE foo (id TEXT)", {
+        injectedClient: client,
+      });
+      expect(ran).toBe(true);
+      expect(calls).toEqual([
+        "SET lock_timeout = '3s'",
+        "CREATE TABLE foo (id TEXT)",
+        "RESET lock_timeout",
+      ]);
+    });
+  });
+
+  describe("isLockTimeoutError", () => {
+    it("matches SQLSTATE 55P03 and lock-timeout messages", async () => {
+      const { isLockTimeoutError } = await import("./ddl-guard.js");
+      expect(isLockTimeoutError({ code: "55P03" })).toBe(true);
+      expect(
+        isLockTimeoutError(
+          new Error("canceling statement due to lock timeout"),
+        ),
+      ).toBe(true);
+      expect(isLockTimeoutError(new Error("syntax error"))).toBe(false);
+      expect(isLockTimeoutError(null)).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/db/ddl-guard.ts
+++ b/packages/core/src/db/ddl-guard.ts
@@ -1,0 +1,190 @@
+/**
+ * Guards for on-demand `ensureTable()` DDL so the common already-migrated path
+ * takes NO `ACCESS EXCLUSIVE` lock on Postgres.
+ *
+ * Lives in its own module (like `./widen-columns.js`) so stores can import it
+ * without every `vi.mock("../db/client.js")` test needing to stub it: the
+ * helpers resolve `isPostgres()` / `getDbExec()` through `client.js`, so a test
+ * that mocks the client to SQLite (`isPostgres: () => false`) makes the
+ * Postgres-only existence checks no-ops automatically.
+ *
+ * ## Why
+ *
+ * `ensureTable()` runs once per process on first DB touch. In a long-lived Node
+ * server the cost is paid once and is invisible. In a Netlify `-background`
+ * function the process is fresh, so this is the FIRST touch — and the
+ * `CREATE TABLE`/`ALTER TABLE ... ADD COLUMN` DDL it issues takes an
+ * `ACCESS EXCLUSIVE` lock on the shared Neon Postgres database. Behind a
+ * concurrent connection that already holds a conflicting lock, that DDL can
+ * block ~indefinitely (observed >16s hangs in the bg worker vs ~1s inline).
+ *
+ * The tables/columns are essentially always already present in production, so
+ * the DDL is redundant in the hot path. These helpers let a store cheaply check
+ * `information_schema` first and only issue DDL when something is actually
+ * missing — and when DDL must run, wrap it in a short `lock_timeout` so a
+ * contended lock fails fast instead of hanging.
+ *
+ * All of this is Postgres-only behaviour gated on `isPostgres()`. On SQLite
+ * (local dev) there is no such lock problem, so callers keep their existing
+ * behaviour there.
+ */
+
+import { isPostgres, getDbExec, type DbExec } from "./client.js";
+
+const PLAIN_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * True when running against Postgres AND the given table already exists in the
+ * `public` schema. Returns `false` on SQLite (callers gate their own behaviour
+ * there), for invalid identifiers, or when `information_schema` is unreadable —
+ * the conservative answer "not known to exist" makes the caller fall through to
+ * its idempotent `CREATE TABLE IF NOT EXISTS`, preserving today's behaviour.
+ *
+ * This is a plain read (no lock), so it never blocks on an `ACCESS EXCLUSIVE`
+ * lock the way `CREATE`/`ALTER` would.
+ */
+export async function pgTableExists(
+  table: string,
+  injectedClient?: DbExec,
+): Promise<boolean> {
+  if (!isPostgres() || !PLAIN_IDENTIFIER.test(table)) return false;
+  const client = injectedClient ?? getDbExec();
+  try {
+    const { rows } = await client.execute({
+      sql: `SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name = ? LIMIT 1`,
+      args: [table],
+    });
+    return rows.length > 0;
+  } catch {
+    // information_schema unreadable (permissions / non-standard backend) —
+    // report "unknown" so the caller falls back to IF NOT EXISTS.
+    return false;
+  }
+}
+
+/**
+ * True when running against Postgres AND the given column already exists on the
+ * given table in the `public` schema. Returns `false` on SQLite, for invalid
+ * identifiers, or when `information_schema` is unreadable.
+ *
+ * Plain read — no lock taken.
+ */
+export async function pgColumnExists(
+  table: string,
+  column: string,
+  injectedClient?: DbExec,
+): Promise<boolean> {
+  if (!isPostgres()) return false;
+  if (!PLAIN_IDENTIFIER.test(table) || !PLAIN_IDENTIFIER.test(column)) {
+    return false;
+  }
+  const client = injectedClient ?? getDbExec();
+  try {
+    const { rows } = await client.execute({
+      sql: `SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public' AND table_name = ? AND column_name = ?
+            LIMIT 1`,
+      args: [table, column],
+    });
+    return rows.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True when running against Postgres AND an index with the given name already
+ * exists in the `public` schema. Returns `false` on SQLite, for invalid
+ * identifiers, or when `pg_indexes` is unreadable.
+ *
+ * `CREATE INDEX` (without CONCURRENTLY) takes a `SHARE` lock that blocks
+ * writes, so on a fresh background-worker process behind a concurrent
+ * connection this can hang just like a `CREATE`/`ALTER` would; checking first
+ * skips the lock on the already-migrated hot path.
+ */
+export async function pgIndexExists(
+  indexName: string,
+  injectedClient?: DbExec,
+): Promise<boolean> {
+  if (!isPostgres() || !PLAIN_IDENTIFIER.test(indexName)) return false;
+  const client = injectedClient ?? getDbExec();
+  try {
+    const { rows } = await client.execute({
+      sql: `SELECT 1 FROM pg_indexes
+            WHERE schemaname = 'public' AND indexname = ? LIMIT 1`,
+      args: [indexName],
+    });
+    return rows.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** True when an error looks like a Postgres `lock_timeout` (SQLSTATE 55P03). */
+export function isLockTimeoutError(err: unknown): boolean {
+  const anyErr = err as { code?: unknown; message?: unknown } | null;
+  if (anyErr?.code === "55P03") return true;
+  const msg = String(anyErr?.message ?? anyErr ?? "");
+  return /lock[_ ]?timeout|canceling statement due to lock timeout/i.test(msg);
+}
+
+/**
+ * Run a DDL statement that MUST execute (the schema is actually missing), with
+ * a short `lock_timeout` so a contended `ACCESS EXCLUSIVE` lock fails fast
+ * instead of hanging the whole process.
+ *
+ * Postgres path: wrap the DDL in an explicit transaction and set
+ * `SET LOCAL lock_timeout` so the timeout is scoped to THIS transaction only
+ * and reset automatically on COMMIT/ROLLBACK — it never leaks onto the pooled
+ * (session-reused) connection the way a bare `SET lock_timeout` would. If the
+ * DbExec has no `transaction` (shouldn't happen for Postgres, but defensively),
+ * fall back to a session `SET` + `RESET` in a finally. A lock-timeout error is
+ * swallowed: the table/column is virtually always already correct by the time a
+ * contended boot retries, and the caller's memoization should still resolve so
+ * the path isn't retried in a tight loop. Any non-lock-timeout error rethrows.
+ *
+ * SQLite path: no lock problem — just run the DDL directly.
+ *
+ * @returns `true` if the DDL ran to completion, `false` if it was skipped due to
+ *          a lock-timeout (so the caller can decide whether to log).
+ */
+export async function runGuardedDdl(
+  ddl: string,
+  options: { lockTimeout?: string; injectedClient?: DbExec } = {},
+): Promise<boolean> {
+  const client = options.injectedClient ?? getDbExec();
+  if (!isPostgres()) {
+    await client.execute(ddl);
+    return true;
+  }
+
+  const lockTimeout = options.lockTimeout ?? "3s";
+  try {
+    if (typeof client.transaction === "function") {
+      await client.transaction(async (tx) => {
+        // SET LOCAL is transaction-scoped: it reverts on COMMIT/ROLLBACK and
+        // never persists on the pooled connection.
+        await tx.execute(`SET LOCAL lock_timeout = '${lockTimeout}'`);
+        await tx.execute(ddl);
+      });
+    } else {
+      // Defensive fallback: no transaction support. Use a session SET and
+      // guarantee a RESET so the timeout never leaks onto a reused connection.
+      try {
+        await client.execute(`SET lock_timeout = '${lockTimeout}'`);
+        await client.execute(ddl);
+      } finally {
+        await client.execute(`RESET lock_timeout`).catch(() => {});
+      }
+    }
+    return true;
+  } catch (err) {
+    if (isLockTimeoutError(err)) {
+      // Contended lock — the schema is virtually always already correct by now.
+      // Proceed; the caller's memoization still resolves so we don't loop.
+      return false;
+    }
+    throw err;
+  }
+}

--- a/packages/core/src/secrets/storage.spec.ts
+++ b/packages/core/src/secrets/storage.spec.ts
@@ -105,10 +105,52 @@ describe("secrets storage bootstrap", () => {
     const { readAppSecret } = await import("./storage.js");
     await readAppSecret(userRef);
 
-    const createSql = String(execute.mock.calls[0]?.[0]);
-    expect(createSql).toContain("CREATE TABLE IF NOT EXISTS app_secrets");
+    // On Postgres ensureTable now probes information_schema first (no lock) and
+    // only issues DDL for what is missing. With an empty fake DB every probe
+    // reports "missing", so the CREATE TABLE still runs — just not as call[0].
+    // Existence probes are passed as { sql, args }; DDL as a raw string.
+    const allSql = execute.mock.calls.map((c) => {
+      const input = c[0] as string | { sql: string };
+      return typeof input === "string" ? input : input.sql;
+    });
+    const createSql = allSql.find((s) =>
+      s.includes("CREATE TABLE IF NOT EXISTS app_secrets"),
+    );
+    expect(createSql).toBeDefined();
     expect(createSql).toContain("BIGINT");
     expect(createSql).not.toMatch(/\bINTEGER\b/);
+
+    // The first statement is the cheap existence probe, not DDL — proving the
+    // hot path takes no ACCESS EXCLUSIVE lock when the schema already exists.
+    expect(allSql[0]).toContain("information_schema.tables");
+  });
+
+  it("skips all DDL on Postgres when the table and columns already exist", async () => {
+    // information_schema probes report the table and both additive columns as
+    // present, so NO CREATE / ALTER should run (no ACCESS EXCLUSIVE lock).
+    const execute = vi.fn(async (input: unknown) => {
+      const sql = typeof input === "string" ? input : (input as any).sql;
+      if (/information_schema/i.test(String(sql))) {
+        return { rows: [{ "?column?": 1 }] as unknown[] };
+      }
+      return { rows: [] as unknown[] };
+    });
+
+    vi.doMock("../db/client.js", () => ({
+      getDialect: () => "postgres",
+      getDbExec: () => ({ execute }),
+      isPostgres: () => true,
+    }));
+
+    const { readAppSecret } = await import("./storage.js");
+    await readAppSecret(userRef);
+
+    const allSql = execute.mock.calls.map((c) => {
+      const input = c[0] as string | { sql: string };
+      return typeof input === "string" ? input : input.sql;
+    });
+    expect(allSql.some((s) => /CREATE TABLE/i.test(s))).toBe(false);
+    expect(allSql.some((s) => /ALTER TABLE/i.test(s))).toBe(false);
   });
 });
 

--- a/packages/core/src/secrets/storage.ts
+++ b/packages/core/src/secrets/storage.ts
@@ -16,6 +16,11 @@ import { randomUUID } from "node:crypto";
 
 import { getDbExec, isPostgres } from "../db/client.js";
 import {
+  pgColumnExists,
+  pgTableExists,
+  runGuardedDdl,
+} from "../db/ddl-guard.js";
+import {
   encryptSecretValue as encryptValue,
   decryptSecretValue as decryptValue,
 } from "./crypto.js";
@@ -34,10 +39,39 @@ async function ensureTable(): Promise<void> {
       const client = getDbExec();
       // Postgres version of the CREATE TABLE — the generic `INTEGER` maps to
       // BIGINT on Postgres, which we need for millisecond timestamps.
-      const sql = isPostgres()
+      const createSql = isPostgres()
         ? APP_SECRETS_CREATE_SQL.replace(/\bINTEGER\b/g, "BIGINT")
         : APP_SECRETS_CREATE_SQL;
-      await client.execute(sql);
+
+      if (isPostgres()) {
+        // Hot path: in production the table and both additive columns are
+        // virtually always already present. Issuing `CREATE`/`ALTER` would
+        // still take an ACCESS EXCLUSIVE lock — which, in a fresh background
+        // worker process behind a concurrent connection on the shared Neon DB,
+        // can block ~indefinitely. So check `information_schema` first (a plain
+        // read, no lock) and run DDL ONLY for what is actually missing. When
+        // DDL must run, `runGuardedDdl` wraps it in a transaction-scoped
+        // `lock_timeout` so a contended lock fails fast instead of hanging.
+        if (!(await pgTableExists("app_secrets"))) {
+          await runGuardedDdl(createSql);
+        }
+        if (!(await pgColumnExists("app_secrets", "description"))) {
+          await runGuardedDdl(
+            `ALTER TABLE app_secrets ADD COLUMN IF NOT EXISTS description TEXT`,
+          );
+        }
+        if (!(await pgColumnExists("app_secrets", "url_allowlist"))) {
+          await runGuardedDdl(
+            `ALTER TABLE app_secrets ADD COLUMN IF NOT EXISTS url_allowlist TEXT`,
+          );
+        }
+        return;
+      }
+
+      // SQLite (local dev): no ACCESS EXCLUSIVE lock problem, keep the original
+      // create-then-additive-alter behaviour. SQLite has no
+      // `ADD COLUMN IF NOT EXISTS`, so the ALTERs stay wrapped in try/catch.
+      await client.execute(createSql);
 
       // Additive migration: description column (for ad-hoc keys)
       try {

--- a/packages/core/src/settings/store.ts
+++ b/packages/core/src/settings/store.ts
@@ -1,6 +1,11 @@
 import { EventEmitter } from "events";
 
 import { getDbExec, isPostgres, intType } from "../db/client.js";
+import {
+  pgIndexExists,
+  pgTableExists,
+  runGuardedDdl,
+} from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
 
 let _initPromise: Promise<void> | undefined;
@@ -20,17 +25,46 @@ async function ensureTable(): Promise<void> {
     _initPromise = (async () => {
       const client = getDbExec();
       const table = settingsTable();
-      await client.execute(`
+      const createSql = `
         CREATE TABLE IF NOT EXISTS ${table} (
           key TEXT PRIMARY KEY,
           value TEXT NOT NULL,
           updated_at ${intType()} NOT NULL
         )
-      `);
-      // Older deployments (pre BIGINT-compat) have a 32-bit `updated_at`; on
-      // Postgres the `Date.now()` written on every setSetting overflows int4.
-      // Widen in place (no-op once done / on fresh DBs). Pass the unqualified
-      // name — the helper scopes to the `public` schema.
+      `;
+
+      if (isPostgres()) {
+        // Hot path: the `settings` table and its poll index are virtually
+        // always already present in production. Issuing `CREATE TABLE`/
+        // `CREATE INDEX` still takes a lock that, in a fresh background-worker
+        // process behind a concurrent connection on the shared Neon DB, can
+        // block ~indefinitely (ACCESS EXCLUSIVE for CREATE TABLE; a write-
+        // blocking SHARE lock for CREATE INDEX). So check `information_schema`/
+        // `pg_indexes` first (plain reads, no lock) and run DDL ONLY for what
+        // is actually missing. `runGuardedDdl` bounds any DDL that must run
+        // with a transaction-scoped `lock_timeout` so a contended lock fails
+        // fast instead of hanging. `settingsTable()` is `public.settings` on
+        // Postgres; the existence checks use the unqualified table name.
+        if (!(await pgTableExists("settings"))) {
+          await runGuardedDdl(createSql);
+        }
+        // Older deployments (pre BIGINT-compat) have a 32-bit `updated_at`; on
+        // Postgres the `Date.now()` written on every setSetting overflows int4.
+        // widenIntColumnsToBigInt already probes information_schema and only
+        // ALTERs columns that are still int4 — a no-op on fresh/widened DBs.
+        await widenIntColumnsToBigInt("settings", ["updated_at"]);
+        // Index for the poll watermark query: `SELECT MAX(updated_at)`.
+        if (!(await pgIndexExists("settings_updated_at_idx"))) {
+          await runGuardedDdl(
+            `CREATE INDEX IF NOT EXISTS settings_updated_at_idx ON ${table} (updated_at)`,
+          );
+        }
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      await client.execute(createSql);
+      // No-op on SQLite (INTEGER is already 64-bit).
       await widenIntColumnsToBigInt("settings", ["updated_at"]);
       // Index for the poll watermark query: `SELECT MAX(updated_at) FROM settings`.
       // MAX on an indexed column avoids a full-table scan on every poll cycle.


### PR DESCRIPTION
Root-causes + fixes the durable bg-worker hang. The worker stalled right after auth on the first touch of `app_secrets`/`settings`, where `ensureTable()` issues `CREATE`/`ALTER` DDL that takes an `ACCESS EXCLUSIVE` lock — behind a concurrent connection on shared Neon it blocks ~indefinitely (>16s in bg vs ~1s inline). Shared-infra fix: probe `information_schema`/`pg_indexes` first (no lock) and only run DDL when actually missing; wrap any required DDL in a transaction-scoped `SET LOCAL lock_timeout` (no leak onto the pooled connection). SQLite unchanged. New `db/ddl-guard.ts` + worker sub-step diagnostics. 182 targeted tests (ddl-guard/storage/settings/schema-init/production-agent/run-store) + typecheck green.