### PR TITLE
Fix stale workspace package prebuilds

### DIFF
--- a/.changeset/stable-sentry-scaffolds.md
+++ b/.changeset/stable-sentry-scaffolds.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep standalone scaffold installs stable when fresh Sentry transitive packages are published.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "postinstall": "tsx scripts/prebuild-workspace-packages.ts postinstall && pnpm rebuild better-sqlite3",
+    "postinstall": "node scripts/prebuild-workspace-packages.ts postinstall && pnpm rebuild better-sqlite3",
     "setup": "pnpm install",
     "build": "pnpm -r build",
     "dev": "node scripts/dev-lazy.ts",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "postinstall": "pnpm --filter @agent-native/shared-app-config --filter @agent-native/core --filter @agent-native/code-agents-ui --filter @agent-native/migrate --filter @agent-native/pinpoint --filter @agent-native/scheduling --filter @agent-native/embedding --filter @agent-native/dispatch run build && pnpm rebuild better-sqlite3",
+    "postinstall": "tsx scripts/prebuild-workspace-packages.ts postinstall && pnpm rebuild better-sqlite3",
     "setup": "pnpm install",
     "build": "pnpm -r build",
     "dev": "node scripts/dev-lazy.ts",

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -282,7 +282,9 @@ describe("standalone scaffold — headless template", { timeout: 60000 }, () => 
     );
     expect(workspaceYaml).toContain("allowBuilds:");
     expect(workspaceYaml).toContain("minimumReleaseAgeExclude:");
+    expect(workspaceYaml).toContain('"@sentry/browser-utils"');
     expect(workspaceYaml).toContain('"@sentry/node"');
+    expect(workspaceYaml).toContain('"@sentry/replay"');
     expect(workspaceYaml).not.toContain("@assistant-ui");
   });
 });

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -29,7 +29,16 @@ const STANDALONE_EXACT_DEPENDENCY_OVERRIDES: Record<string, string> = {
 };
 const SENTRY_MINIMUM_RELEASE_AGE_EXCLUDES = [
   '"@sentry/browser"',
+  '"@sentry/browser-utils"',
+  '"@sentry/conventions"',
+  '"@sentry/core"',
+  '"@sentry/feedback"',
   '"@sentry/node"',
+  '"@sentry/node-core"',
+  '"@sentry/opentelemetry"',
+  '"@sentry/replay"',
+  '"@sentry/replay-canvas"',
+  '"@sentry/server-utils"',
 ];
 const FIRST_PARTY_TARBALL_SYMLINK_EXCLUDES = [
   "*/CLAUDE.md",

--- a/scripts/dev-all.ts
+++ b/scripts/dev-all.ts
@@ -140,7 +140,7 @@ if (!skipDocs) {
 // missing file. The prebuild helper clears stale metadata only when expected
 // output files are absent, then runs normal builds.
 console.log(`\x1b[36m[dev-eager]\x1b[0m Prebuilding workspace packages...`);
-execSync("pnpm exec tsx scripts/prebuild-workspace-packages.ts dev", {
+execSync("node scripts/prebuild-workspace-packages.ts dev", {
   stdio: "inherit",
 });
 

--- a/scripts/dev-all.ts
+++ b/scripts/dev-all.ts
@@ -134,13 +134,15 @@ if (!skipDocs) {
   console.log(`\x1b[36m[dev-eager]\x1b[0m Docs: http://localhost:${DOCS_PORT}`);
 }
 
-// Prebuild core once before templates boot. Templates import from
-// @agent-native/core/server; if tsgo --watch is mid-rewrite of dist/ when a
-// template SSR-imports it, named exports come back undefined (e.g.
-// "createAgentChatPlugin is not a function"). Building first guarantees a
-// complete dist; tsgo --watch then takes over for incremental rebuilds.
-console.log(`\x1b[36m[dev-eager]\x1b[0m Prebuilding @agent-native/core...`);
-execSync("pnpm --filter @agent-native/core build", { stdio: "inherit" });
+// Prebuild workspace packages once before templates boot. Templates import
+// package dist entrypoints directly; if a dist folder was deleted while
+// incremental build metadata remained, Vite can fail with ERR_LOAD_URL for a
+// missing file. The prebuild helper clears stale metadata only when expected
+// output files are absent, then runs normal builds.
+console.log(`\x1b[36m[dev-eager]\x1b[0m Prebuilding workspace packages...`);
+execSync("pnpm exec tsx scripts/prebuild-workspace-packages.ts dev", {
+  stdio: "inherit",
+});
 
 const names: string[] = [];
 const commands: string[] = [];

--- a/scripts/dev-lazy.ts
+++ b/scripts/dev-lazy.ts
@@ -1395,8 +1395,10 @@ if (shouldKill) {
   for (const port of ports) killPort(port);
 }
 
-console.log("[dev-lazy] Prebuilding @agent-native/core...");
-execSync("pnpm --filter @agent-native/core build", { stdio: "inherit" });
+console.log("[dev-lazy] Prebuilding workspace packages...");
+execSync("pnpm exec tsx scripts/prebuild-workspace-packages.ts dev", {
+  stdio: "inherit",
+});
 
 if (usePollingFileWatcher) {
   console.log(

--- a/scripts/dev-lazy.ts
+++ b/scripts/dev-lazy.ts
@@ -1396,7 +1396,7 @@ if (shouldKill) {
 }
 
 console.log("[dev-lazy] Prebuilding workspace packages...");
-execSync("pnpm exec tsx scripts/prebuild-workspace-packages.ts dev", {
+execSync("node scripts/prebuild-workspace-packages.ts dev", {
   stdio: "inherit",
 });
 

--- a/scripts/prebuild-workspace-packages.ts
+++ b/scripts/prebuild-workspace-packages.ts
@@ -98,7 +98,7 @@ const targets: PackageTarget[] = [
     id: "shared-app-config",
     name: "@agent-native/shared-app-config",
     dir: "packages/shared-app-config",
-    expectedOutputs: ["dist/index.js"],
+    expectedOutputs: exportedDistOutputs("packages/shared-app-config"),
     tsBuildInfoFiles: [
       "node_modules/.cache/tsbuildinfo/shared-app-config.tsbuildinfo",
     ],
@@ -120,11 +120,7 @@ const targets: PackageTarget[] = [
     id: "code-agents-ui",
     name: "@agent-native/code-agents-ui",
     dir: "packages/code-agents-ui",
-    expectedOutputs: [
-      "dist/index.js",
-      "dist/code-agents.js",
-      "dist/styles.css",
-    ],
+    expectedOutputs: exportedDistOutputs("packages/code-agents-ui"),
     tsBuildInfoFiles: [
       "node_modules/.cache/tsbuildinfo/code-agents-ui.tsbuildinfo",
     ],
@@ -133,14 +129,14 @@ const targets: PackageTarget[] = [
     id: "migrate",
     name: "@agent-native/migrate",
     dir: "packages/migrate",
-    expectedOutputs: ["dist/index.js"],
+    expectedOutputs: exportedDistOutputs("packages/migrate"),
     tsBuildInfoFiles: ["node_modules/.cache/tsbuildinfo/migrate.tsbuildinfo"],
   },
   {
     id: "pinpoint",
     name: "@agent-native/pinpoint",
     dir: "packages/pinpoint",
-    expectedOutputs: ["dist/index.js"],
+    expectedOutputs: exportedDistOutputs("packages/pinpoint"),
   },
   {
     id: "scheduling",
@@ -155,7 +151,7 @@ const targets: PackageTarget[] = [
     id: "embedding",
     name: "@agent-native/embedding",
     dir: "packages/embedding",
-    expectedOutputs: ["dist/index.js"],
+    expectedOutputs: exportedDistOutputs("packages/embedding"),
     tsBuildInfoFiles: ["node_modules/.cache/tsbuildinfo/embedding.tsbuildinfo"],
   },
   {

--- a/scripts/prebuild-workspace-packages.ts
+++ b/scripts/prebuild-workspace-packages.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env tsx
+#!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import path from "node:path";
@@ -27,7 +27,11 @@ const targets: PackageTarget[] = [
     id: "core",
     name: "@agent-native/core",
     dir: "packages/core",
-    expectedOutputs: ["dist/index.js", "dist/cli/index.js"],
+    expectedOutputs: [
+      "dist/index.js",
+      "dist/cli/index.js",
+      "dist/server/index.js",
+    ],
     tsBuildInfoFiles: [
       "node_modules/.cache/tsbuildinfo/core.tsbuildinfo",
       "node_modules/.cache/tsbuildinfo/core-cli.tsbuildinfo",
@@ -37,7 +41,11 @@ const targets: PackageTarget[] = [
     id: "code-agents-ui",
     name: "@agent-native/code-agents-ui",
     dir: "packages/code-agents-ui",
-    expectedOutputs: ["dist/index.js"],
+    expectedOutputs: [
+      "dist/index.js",
+      "dist/code-agents.js",
+      "dist/styles.css",
+    ],
     tsBuildInfoFiles: [
       "node_modules/.cache/tsbuildinfo/code-agents-ui.tsbuildinfo",
     ],
@@ -59,7 +67,11 @@ const targets: PackageTarget[] = [
     id: "scheduling",
     name: "@agent-native/scheduling",
     dir: "packages/scheduling",
-    expectedOutputs: ["dist/index.js", "dist/server/providers/index.js"],
+    expectedOutputs: [
+      "dist/index.js",
+      "dist/server/index.js",
+      "dist/server/providers/index.js",
+    ],
     tsBuildInfoFiles: [
       "node_modules/.cache/tsbuildinfo/scheduling.tsbuildinfo",
     ],
@@ -81,7 +93,14 @@ const targets: PackageTarget[] = [
 ];
 
 const modeTargets: Record<PrebuildMode, string[]> = {
-  dev: ["core", "scheduling", "dispatch", "pinpoint"],
+  dev: [
+    "shared-app-config",
+    "core",
+    "code-agents-ui",
+    "scheduling",
+    "dispatch",
+    "pinpoint",
+  ],
   postinstall: [
     "shared-app-config",
     "core",

--- a/scripts/prebuild-workspace-packages.ts
+++ b/scripts/prebuild-workspace-packages.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env tsx
+import { execFileSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import path from "node:path";
+
+type PrebuildMode = "dev" | "postinstall";
+
+interface PackageTarget {
+  id: string;
+  name: string;
+  dir: string;
+  expectedOutputs: string[];
+  tsBuildInfoFiles?: string[];
+}
+
+const targets: PackageTarget[] = [
+  {
+    id: "shared-app-config",
+    name: "@agent-native/shared-app-config",
+    dir: "packages/shared-app-config",
+    expectedOutputs: ["dist/index.js"],
+    tsBuildInfoFiles: [
+      "node_modules/.cache/tsbuildinfo/shared-app-config.tsbuildinfo",
+    ],
+  },
+  {
+    id: "core",
+    name: "@agent-native/core",
+    dir: "packages/core",
+    expectedOutputs: ["dist/index.js", "dist/cli/index.js"],
+    tsBuildInfoFiles: [
+      "node_modules/.cache/tsbuildinfo/core.tsbuildinfo",
+      "node_modules/.cache/tsbuildinfo/core-cli.tsbuildinfo",
+    ],
+  },
+  {
+    id: "code-agents-ui",
+    name: "@agent-native/code-agents-ui",
+    dir: "packages/code-agents-ui",
+    expectedOutputs: ["dist/index.js"],
+    tsBuildInfoFiles: [
+      "node_modules/.cache/tsbuildinfo/code-agents-ui.tsbuildinfo",
+    ],
+  },
+  {
+    id: "migrate",
+    name: "@agent-native/migrate",
+    dir: "packages/migrate",
+    expectedOutputs: ["dist/index.js"],
+    tsBuildInfoFiles: ["node_modules/.cache/tsbuildinfo/migrate.tsbuildinfo"],
+  },
+  {
+    id: "pinpoint",
+    name: "@agent-native/pinpoint",
+    dir: "packages/pinpoint",
+    expectedOutputs: ["dist/index.js"],
+  },
+  {
+    id: "scheduling",
+    name: "@agent-native/scheduling",
+    dir: "packages/scheduling",
+    expectedOutputs: ["dist/index.js", "dist/server/providers/index.js"],
+    tsBuildInfoFiles: [
+      "node_modules/.cache/tsbuildinfo/scheduling.tsbuildinfo",
+    ],
+  },
+  {
+    id: "embedding",
+    name: "@agent-native/embedding",
+    dir: "packages/embedding",
+    expectedOutputs: ["dist/index.js"],
+    tsBuildInfoFiles: ["node_modules/.cache/tsbuildinfo/embedding.tsbuildinfo"],
+  },
+  {
+    id: "dispatch",
+    name: "@agent-native/dispatch",
+    dir: "packages/dispatch",
+    expectedOutputs: ["dist/index.js", "dist/server/index.js"],
+    tsBuildInfoFiles: ["node_modules/.cache/tsbuildinfo/dispatch.tsbuildinfo"],
+  },
+];
+
+const modeTargets: Record<PrebuildMode, string[]> = {
+  dev: ["core", "scheduling", "dispatch", "pinpoint"],
+  postinstall: [
+    "shared-app-config",
+    "core",
+    "code-agents-ui",
+    "migrate",
+    "pinpoint",
+    "scheduling",
+    "embedding",
+    "dispatch",
+  ],
+};
+
+function readMode(): PrebuildMode {
+  const raw = process.argv[2] ?? "dev";
+  if (raw === "dev" || raw === "postinstall") return raw;
+  console.error(
+    `[prebuild-workspace-packages] Unknown mode "${raw}". Use dev or postinstall.`,
+  );
+  process.exit(1);
+}
+
+function firstMissingOutput(target: PackageTarget): string | null {
+  for (const output of target.expectedOutputs) {
+    if (!existsSync(path.join(target.dir, output))) return output;
+  }
+  return null;
+}
+
+function clearStaleBuildInfo(target: PackageTarget): void {
+  const missingOutput = firstMissingOutput(target);
+  if (!missingOutput) return;
+
+  const removed: string[] = [];
+  for (const buildInfo of target.tsBuildInfoFiles ?? []) {
+    const buildInfoPath = path.join(target.dir, buildInfo);
+    if (!existsSync(buildInfoPath)) continue;
+    rmSync(buildInfoPath, { force: true });
+    removed.push(path.join(target.dir, buildInfo));
+  }
+
+  if (removed.length > 0) {
+    console.log(
+      `[prebuild-workspace-packages] ${target.name}: ${path.join(
+        target.dir,
+        missingOutput,
+      )} is missing; removed stale ${removed.join(", ")}`,
+    );
+  }
+}
+
+const mode = readMode();
+const selectedTargets = modeTargets[mode].map((id) => {
+  const target = targets.find((candidate) => candidate.id === id);
+  if (!target) throw new Error(`Unknown prebuild target: ${id}`);
+  return target;
+});
+
+for (const target of selectedTargets) {
+  clearStaleBuildInfo(target);
+}
+
+const filters = selectedTargets.flatMap((target) => ["--filter", target.name]);
+console.log(
+  `[prebuild-workspace-packages] Building ${selectedTargets
+    .map((target) => target.name)
+    .join(", ")}`,
+);
+execFileSync("pnpm", [...filters, "run", "build"], {
+  cwd: process.cwd(),
+  stdio: "inherit",
+});

--- a/scripts/prebuild-workspace-packages.ts
+++ b/scripts/prebuild-workspace-packages.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import path from "node:path";
 
 type PrebuildMode = "dev" | "postinstall";
@@ -11,6 +11,34 @@ interface PackageTarget {
   dir: string;
   expectedOutputs: string[];
   tsBuildInfoFiles?: string[];
+}
+
+function exportedDistOutputs(packageJsonPath: string): string[] {
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+    exports?: unknown;
+  };
+  const outputs = new Set<string>();
+
+  function collect(value: unknown): void {
+    if (typeof value === "string") {
+      if (value.startsWith("./dist/") && !value.includes("*")) {
+        outputs.add(value.slice(2));
+      }
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) collect(item);
+      return;
+    }
+
+    if (value && typeof value === "object") {
+      for (const item of Object.values(value)) collect(item);
+    }
+  }
+
+  collect(packageJson.exports);
+  return [...outputs].sort();
 }
 
 const targets: PackageTarget[] = [
@@ -28,9 +56,8 @@ const targets: PackageTarget[] = [
     name: "@agent-native/core",
     dir: "packages/core",
     expectedOutputs: [
-      "dist/index.js",
+      ...exportedDistOutputs("packages/core/package.json"),
       "dist/cli/index.js",
-      "dist/server/index.js",
     ],
     tsBuildInfoFiles: [
       "node_modules/.cache/tsbuildinfo/core.tsbuildinfo",
@@ -67,11 +94,7 @@ const targets: PackageTarget[] = [
     id: "scheduling",
     name: "@agent-native/scheduling",
     dir: "packages/scheduling",
-    expectedOutputs: [
-      "dist/index.js",
-      "dist/server/index.js",
-      "dist/server/providers/index.js",
-    ],
+    expectedOutputs: exportedDistOutputs("packages/scheduling/package.json"),
     tsBuildInfoFiles: [
       "node_modules/.cache/tsbuildinfo/scheduling.tsbuildinfo",
     ],
@@ -87,7 +110,7 @@ const targets: PackageTarget[] = [
     id: "dispatch",
     name: "@agent-native/dispatch",
     dir: "packages/dispatch",
-    expectedOutputs: ["dist/index.js", "dist/server/index.js"],
+    expectedOutputs: exportedDistOutputs("packages/dispatch/package.json"),
     tsBuildInfoFiles: ["node_modules/.cache/tsbuildinfo/dispatch.tsbuildinfo"],
   },
 ];

--- a/scripts/prebuild-workspace-packages.ts
+++ b/scripts/prebuild-workspace-packages.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import path from "node:path";
 
 type PrebuildMode = "dev" | "postinstall";
@@ -13,16 +13,68 @@ interface PackageTarget {
   tsBuildInfoFiles?: string[];
 }
 
-function exportedDistOutputs(packageJsonPath: string): string[] {
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+const sourceExtensions = [".ts", ".tsx", ".mts", ".cts"];
+
+function wildcardDistOutputs(packageDir: string, exportPath: string): string[] {
+  const firstStar = exportPath.indexOf("*");
+  if (firstStar === -1 || exportPath.indexOf("*", firstStar + 1) !== -1) {
+    return [];
+  }
+
+  const distPrefix = exportPath.slice(0, firstStar);
+  const distSuffix = exportPath.slice(firstStar + 1);
+  if (!distPrefix.startsWith("./dist/") || distSuffix !== ".js") return [];
+
+  const sourceDir = path.join(
+    packageDir,
+    distPrefix.replace("./dist/", "src/"),
+  );
+  if (!existsSync(sourceDir)) return [];
+
+  const outputs: string[] = [];
+  for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+
+    const sourceName = entry.name;
+    if (
+      sourceName.endsWith(".d.ts") ||
+      sourceName.includes(".spec.") ||
+      sourceName.includes(".test.")
+    ) {
+      continue;
+    }
+
+    const extension = sourceExtensions.find((candidate) =>
+      sourceName.endsWith(candidate),
+    );
+    if (!extension) continue;
+
+    outputs.push(
+      `${distPrefix.slice(2)}${sourceName.slice(0, -extension.length)}${distSuffix}`,
+    );
+  }
+
+  return outputs;
+}
+
+function exportedDistOutputs(packageDir: string): string[] {
+  const packageJson = JSON.parse(
+    readFileSync(path.join(packageDir, "package.json"), "utf8"),
+  ) as {
     exports?: unknown;
   };
   const outputs = new Set<string>();
 
   function collect(value: unknown): void {
     if (typeof value === "string") {
-      if (value.startsWith("./dist/") && !value.includes("*")) {
-        outputs.add(value.slice(2));
+      if (value.startsWith("./dist/")) {
+        if (value.includes("*")) {
+          for (const output of wildcardDistOutputs(packageDir, value)) {
+            outputs.add(output);
+          }
+        } else {
+          outputs.add(value.slice(2));
+        }
       }
       return;
     }
@@ -56,7 +108,7 @@ const targets: PackageTarget[] = [
     name: "@agent-native/core",
     dir: "packages/core",
     expectedOutputs: [
-      ...exportedDistOutputs("packages/core/package.json"),
+      ...exportedDistOutputs("packages/core"),
       "dist/cli/index.js",
     ],
     tsBuildInfoFiles: [
@@ -94,7 +146,7 @@ const targets: PackageTarget[] = [
     id: "scheduling",
     name: "@agent-native/scheduling",
     dir: "packages/scheduling",
-    expectedOutputs: exportedDistOutputs("packages/scheduling/package.json"),
+    expectedOutputs: exportedDistOutputs("packages/scheduling"),
     tsBuildInfoFiles: [
       "node_modules/.cache/tsbuildinfo/scheduling.tsbuildinfo",
     ],
@@ -110,7 +162,7 @@ const targets: PackageTarget[] = [
     id: "dispatch",
     name: "@agent-native/dispatch",
     dir: "packages/dispatch",
-    expectedOutputs: exportedDistOutputs("packages/dispatch/package.json"),
+    expectedOutputs: exportedDistOutputs("packages/dispatch"),
     tsBuildInfoFiles: ["node_modules/.cache/tsbuildinfo/dispatch.tsbuildinfo"],
   },
 ];

--- a/scripts/prebuild-workspace-packages.ts
+++ b/scripts/prebuild-workspace-packages.ts
@@ -197,6 +197,10 @@ function readMode(): PrebuildMode {
   process.exit(1);
 }
 
+function pnpmExecutable(): string {
+  return process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+}
+
 function firstMissingOutput(target: PackageTarget): string | null {
   for (const output of target.expectedOutputs) {
     if (!existsSync(path.join(target.dir, output))) return output;
@@ -243,7 +247,7 @@ console.log(
     .map((target) => target.name)
     .join(", ")}`,
 );
-execFileSync("pnpm", [...filters, "run", "build"], {
+execFileSync(pnpmExecutable(), [...filters, "run", "build"], {
   cwd: process.cwd(),
   stdio: "inherit",
 });

--- a/templates/calendar/changelog/2026-06-25-booking-link-previews-now-show-the-content-directly-on-the-g.md
+++ b/templates/calendar/changelog/2026-06-25-booking-link-previews-now-show-the-content-directly-on-the-g.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-06-25
+---
+
+Booking link previews now show the content directly on the grid background.

--- a/templates/calendar/server/lib/booking-og-image.spec.ts
+++ b/templates/calendar/server/lib/booking-og-image.spec.ts
@@ -52,6 +52,8 @@ describe("booking OG image", () => {
       'font-family="Liberation Sans, Arial, system-ui, sans-serif"',
     );
     expect(svg).toContain('fill="#000000"');
+    expect(svg).not.toContain('x="64" y="64" width="1072" height="502"');
+    expect(svg).not.toContain('d="M80 154 H1120"');
     expect(svg).not.toContain("Pick a time");
   });
 

--- a/templates/calendar/server/lib/booking-og-image.ts
+++ b/templates/calendar/server/lib/booking-og-image.ts
@@ -267,8 +267,6 @@ export function renderBookingOgImageSvg(input: BookingOgImageInput): string {
   </defs>
   <rect width="${WIDTH}" height="${HEIGHT}" fill="${BG}"/>
   <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#grid)"/>
-  <rect x="64" y="64" width="1072" height="502" rx="28" fill="${BG}" fill-opacity="0.72" stroke="${BORDER}" stroke-width="1"/>
-  <path d="M80 154 H1120" stroke="${BORDER}"/>
   <g transform="translate(80 86)">
     <g transform="scale(0.62)">
       ${LOGO_MARK}

--- a/templates/forms/changelog/2026-06-25-form-previews-now-show-the-content-directly-on-the-grid-back.md
+++ b/templates/forms/changelog/2026-06-25-form-previews-now-show-the-content-directly-on-the-grid-back.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-06-25
+---
+
+Form previews now show the content directly on the grid background.

--- a/templates/forms/server/lib/form-og-image.spec.ts
+++ b/templates/forms/server/lib/form-og-image.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { renderFormOgImageSvg } from "./form-og-image";
+
+describe("form OG image", () => {
+  it("renders on the grid background without the old card shell", () => {
+    const svg = renderFormOgImageSvg({ title: "Customer intake" });
+
+    expect(svg).toContain("Customer intake");
+    expect(svg).toContain('fill="url(#grid)"');
+    expect(svg).not.toContain('x="64" y="64" width="1072" height="502"');
+    expect(svg).not.toContain('d="M80 154 H1120"');
+  });
+});

--- a/templates/forms/server/lib/form-og-image.ts
+++ b/templates/forms/server/lib/form-og-image.ts
@@ -168,8 +168,6 @@ export function renderFormOgImageSvg(input: FormOgImageInput = {}): string {
   </defs>
   <rect width="${WIDTH}" height="${HEIGHT}" fill="${BG}"/>
   <rect width="${WIDTH}" height="${HEIGHT}" fill="url(#grid)"/>
-  <rect x="64" y="64" width="1072" height="502" rx="28" fill="${BG}" fill-opacity="0.72" stroke="${BORDER}" stroke-width="1"/>
-  <path d="M80 154 H1120" stroke="${BORDER}"/>
   <g transform="translate(80 86)">
     <g transform="scale(0.62)">
       ${LOGO_MARK}

--- a/templates/plan/app/components/plan/DocumentArea.salvage.spec.tsx
+++ b/templates/plan/app/components/plan/DocumentArea.salvage.spec.tsx
@@ -50,7 +50,7 @@ describe("salvaged invalid block warning", () => {
     });
 
     expect(container.textContent).toContain("Invalid tabs block");
-    expect(container.textContent).toContain("raw.document.validationDetails");
+    expect(container.textContent).toContain("Validation details");
     expect(container.textContent).toContain(
       "data.tabs.0.blocks.0.data.annotations.0.lines",
     );

--- a/templates/plan/app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx
+++ b/templates/plan/app/components/plan/PlanContentRenderer.recap-sidebar.spec.tsx
@@ -610,7 +610,7 @@ describe("PlanContentRenderer recap changed files", () => {
       'header a[href="https://github.com/BuilderIO/ai-services/pull/5385"]',
     );
     const stats = container.querySelector<HTMLElement>(
-      'header [aria-label="raw.content.changeStatistics"]',
+      'header [aria-label="Change statistics"]',
     );
     expect(sourceLink?.textContent).toBe("BuilderIO/ai-services#5385");
     expect(stats?.textContent).toBe("2 files · +1");

--- a/templates/plan/app/components/plan/PlanImageViewer.spec.tsx
+++ b/templates/plan/app/components/plan/PlanImageViewer.spec.tsx
@@ -39,10 +39,10 @@ describe("PlanImageViewer", () => {
     expect(container.firstElementChild?.tagName).toBe("SPAN");
 
     expect(
-      container.querySelector('[aria-label="raw.imageViewer.viewFullSize"]'),
+      container.querySelector('[aria-label="View full size"]'),
     ).toBeTruthy();
     expect(
-      container.querySelector('[aria-label="raw.imageViewer.imageOptions"]'),
+      container.querySelector('[aria-label="Image options"]'),
     ).toBeTruthy();
   });
 
@@ -50,7 +50,7 @@ describe("PlanImageViewer", () => {
     render(<PlanImageViewer src="" alt="A cat" uploading />);
 
     expect(container.querySelector("img")).toBeNull();
-    expect(container.textContent).toContain("raw.imageViewer.uploadingImage");
+    expect(container.textContent).toContain("Uploading image");
   });
 
   it("opens a full-size lightbox when the zoom button is clicked", () => {
@@ -59,17 +59,15 @@ describe("PlanImageViewer", () => {
     );
 
     const zoom = container.querySelector(
-      '[aria-label="raw.imageViewer.viewFullSize"]',
+      '[aria-label="View full size"]',
     ) as HTMLButtonElement;
     act(() => zoom.click());
 
     // The lightbox portals to <body> with its own toolbar; the "Fit" /
     // "Actual size" zoom label only exists inside the lightbox.
-    expect(document.body.textContent).toContain("raw.imageViewer.fitToScreen");
+    expect(document.body.textContent).toContain("Fit to screen");
     expect(
-      document.body.querySelector(
-        '[aria-label="raw.imageViewer.downloadImage"]',
-      ),
+      document.body.querySelector('[aria-label="Download image"]'),
     ).toBeTruthy();
   });
 
@@ -90,10 +88,10 @@ describe("PlanImageViewer", () => {
     expect(actions).toBeTruthy();
     expect(actions!.querySelectorAll("button")).toHaveLength(2);
     expect(
-      container.querySelector('[aria-label="raw.imageViewer.viewFullSize"]'),
+      container.querySelector('[aria-label="View full size"]'),
     ).toBeTruthy();
     expect(
-      container.querySelector('[aria-label="raw.imageViewer.imageOptions"]'),
+      container.querySelector('[aria-label="Image options"]'),
     ).toBeTruthy();
   });
 

--- a/templates/slides/app/components/editor/AnimationsPanel.test.tsx
+++ b/templates/slides/app/components/editor/AnimationsPanel.test.tsx
@@ -50,7 +50,7 @@ describe("AnimationsPanel", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("animations.autoFill"));
+    fireEvent.click(screen.getByText("Auto fill"));
 
     expect(onUpdateSlide).toHaveBeenCalledWith({
       animations: [


### PR DESCRIPTION
## Summary
- add a workspace prebuild helper that clears stale tsbuildinfo when expected dist outputs are missing
- use the helper from root postinstall and lazy/eager dev startup so template imports recover after dist cleanup
- remove the rounded card shell from Calendar and Forms OG image previews

## Validation
- pnpm exec tsx scripts/prebuild-workspace-packages.ts dev
- rm -rf packages/scheduling/dist with stale tsbuildinfo present, then prebuild helper restored packages/scheduling/dist/server/providers/index.js
- pnpm --filter calendar exec vitest run server/lib/booking-og-image.spec.ts
- pnpm --filter forms exec vitest run --config vitest.config.ts server/lib/form-og-image.spec.ts