### PR TITLE
fix(db): generalize ensureTable DDL guard across all schema-init paths

### DIFF
--- a/.changeset/ddl-guard-generalize.md
+++ b/.changeset/ddl-guard-generalize.md
@@ -1,0 +1,22 @@
+---
+"@agent-native/core": patch
+---
+
+Generalize the `ensureTable()` DDL guard to ALL on-demand schema-init paths
+(~36 stores: agent run-store, application-state, chat-threads, usage,
+oauth-tokens, resources, observability, integrations, provider-api, mcp,
+workspace-connections, extensions, audit, harness, a2a, notifications,
+browser-sessions, auth/sessions, agent-teams run-queue, better-auth, and more).
+
+Every `ensureTable` now probes `information_schema`/`pg_indexes` before issuing
+`CREATE TABLE`/`ALTER TABLE ADD COLUMN`/`CREATE INDEX`, so the already-migrated
+hot path takes NO `ACCESS EXCLUSIVE` lock on Postgres. Any DDL that must run is
+wrapped in a transaction-scoped `SET LOCAL lock_timeout` (never leaks onto the
+pooled connection), and a swallowed lock-timeout triggers a RE-PROBE: if the
+schema is still missing it throws (so the per-store init memo rejects and retries)
+rather than memoizing init success against absent schema. This fixes
+background-function (durable agent-chat) workers hanging indefinitely on the
+first-touch DDL lock of any table on shared Neon. Shared helpers live in
+`db/ddl-guard.ts` (`ensureSchemaObject`/`ensureTableExists`/`ensureColumnExists`/
+`ensureIndexExists`). SQLite (local dev) behavior is unchanged. CREATE SQL that
+references `intType()` is built at runtime, not module scope.

--- a/packages/core/src/a2a/task-store.ts
+++ b/packages/core/src/a2a/task-store.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto";
 
-import { getDbExec, intType } from "../db/client.js";
+import { getDbExec, intType, isPostgres } from "../db/client.js";
+import { ensureTableExists, ensureColumnExists } from "../db/ddl-guard.js";
 import type { Task, Message, TaskState, Artifact } from "./types.js";
 
 let _initPromise: Promise<void> | undefined;
@@ -9,7 +10,7 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await client.execute(`
+      const createSql = `
         CREATE TABLE IF NOT EXISTS a2a_tasks (
           id TEXT PRIMARY KEY,
           context_id TEXT,
@@ -22,7 +23,28 @@ async function ensureTable(): Promise<void> {
           created_at ${intType()} NOT NULL,
           updated_at ${intType()} NOT NULL
         )
-      `);
+      `;
+
+      if (isPostgres()) {
+        // PG-guard: probe information_schema before issuing DDL to avoid ACCESS
+        // EXCLUSIVE lock contention in fresh background-worker processes.
+        await ensureTableExists("a2a_tasks", createSql);
+        // Additive migration: owner_email column. Bound to the JWT-verified
+        // caller at task-creation time so handleGet / handleCancel can reject
+        // mismatched callers (the IDOR class fixed in PR #369). Existing rows
+        // have NULL owner_email and remain accessible to legacy callers via
+        // the legacy-token apiKeyEnv path; new rows are scoped from this point
+        // forward.
+        await ensureColumnExists(
+          "a2a_tasks",
+          "owner_email",
+          `ALTER TABLE a2a_tasks ADD COLUMN IF NOT EXISTS owner_email TEXT`,
+        );
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      await client.execute(createSql);
       // Additive migration: owner_email column. Bound to the JWT-verified
       // caller at task-creation time so handleGet / handleCancel can reject
       // mismatched callers (the IDOR class fixed in PR #369). Existing rows

--- a/packages/core/src/agent/harness/store.ts
+++ b/packages/core/src/agent/harness/store.ts
@@ -1,9 +1,9 @@
+import { getDbExec, intType, isPostgres } from "../../db/client.js";
 import {
-  getDbExec,
-  intType,
-  isPostgres,
-  retryOnDdlRace,
-} from "../../db/client.js";
+  ensureColumnExists,
+  ensureIndexExists,
+  ensureTableExists,
+} from "../../db/ddl-guard.js";
 
 export type AgentHarnessSessionStatus =
   | "running"
@@ -50,26 +50,66 @@ export async function ensureAgentHarnessSessionTables(): Promise<void> {
   if (!initPromise) {
     initPromise = (async () => {
       const client = getDbExec();
-      await retryOnDdlRace(() =>
-        client.execute(`
-          CREATE TABLE IF NOT EXISTS agent_harness_sessions (
-            id TEXT PRIMARY KEY,
-            harness_name TEXT NOT NULL,
-            thread_id TEXT NOT NULL,
-            run_id TEXT,
-            provider_session_id TEXT,
-            status TEXT NOT NULL DEFAULT 'idle',
-            resume_state TEXT,
-            workspace_ref TEXT,
-            pending_approval TEXT,
-            owner_email TEXT,
-            org_id TEXT,
-            created_at ${intType()} NOT NULL,
-            updated_at ${intType()} NOT NULL,
-            stopped_at ${intType()}
-          )
-        `),
-      );
+      const createSql = `
+        CREATE TABLE IF NOT EXISTS agent_harness_sessions (
+          id TEXT PRIMARY KEY,
+          harness_name TEXT NOT NULL,
+          thread_id TEXT NOT NULL,
+          run_id TEXT,
+          provider_session_id TEXT,
+          status TEXT NOT NULL DEFAULT 'idle',
+          resume_state TEXT,
+          workspace_ref TEXT,
+          pending_approval TEXT,
+          owner_email TEXT,
+          org_id TEXT,
+          created_at ${intType()} NOT NULL,
+          updated_at ${intType()} NOT NULL,
+          stopped_at ${intType()}
+        )
+      `;
+
+      if (isPostgres()) {
+        // PG-guard: probe information_schema / pg_indexes before issuing DDL to
+        // avoid ACCESS EXCLUSIVE lock contention in fresh background-worker processes.
+        await ensureTableExists("agent_harness_sessions", createSql);
+        for (const col of [
+          "run_id",
+          "provider_session_id",
+          "resume_state",
+          "workspace_ref",
+          "pending_approval",
+          "owner_email",
+          "org_id",
+        ] as const) {
+          await ensureColumnExists(
+            "agent_harness_sessions",
+            col,
+            `ALTER TABLE agent_harness_sessions ADD COLUMN IF NOT EXISTS ${col} TEXT`,
+          );
+        }
+        await ensureColumnExists(
+          "agent_harness_sessions",
+          "stopped_at",
+          `ALTER TABLE agent_harness_sessions ADD COLUMN IF NOT EXISTS stopped_at ${intType()}`,
+        );
+        await ensureIndexExists(
+          "idx_agent_harness_sessions_thread",
+          `CREATE INDEX IF NOT EXISTS idx_agent_harness_sessions_thread ON agent_harness_sessions(thread_id, updated_at)`,
+        );
+        await ensureIndexExists(
+          "idx_agent_harness_sessions_status",
+          `CREATE INDEX IF NOT EXISTS idx_agent_harness_sessions_status ON agent_harness_sessions(status, updated_at)`,
+        );
+        await ensureIndexExists(
+          "idx_agent_harness_sessions_owner",
+          `CREATE INDEX IF NOT EXISTS idx_agent_harness_sessions_owner ON agent_harness_sessions(owner_email, updated_at)`,
+        );
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      await client.execute(createSql);
       for (const col of [
         "run_id",
         "provider_session_id",
@@ -80,47 +120,41 @@ export async function ensureAgentHarnessSessionTables(): Promise<void> {
         "org_id",
       ] as const) {
         try {
-          if (isPostgres()) {
-            await client.execute(
-              `ALTER TABLE agent_harness_sessions ADD COLUMN IF NOT EXISTS ${col} TEXT`,
-            );
-          } else {
-            await client.execute(
-              `ALTER TABLE agent_harness_sessions ADD COLUMN ${col} TEXT`,
-            );
-          }
+          await client.execute(
+            `ALTER TABLE agent_harness_sessions ADD COLUMN ${col} TEXT`,
+          );
         } catch {
           // Column already exists.
         }
       }
       try {
-        if (isPostgres()) {
-          await client.execute(
-            `ALTER TABLE agent_harness_sessions ADD COLUMN IF NOT EXISTS stopped_at ${intType()}`,
-          );
-        } else {
-          await client.execute(
-            `ALTER TABLE agent_harness_sessions ADD COLUMN stopped_at ${intType()}`,
-          );
-        }
+        await client.execute(
+          `ALTER TABLE agent_harness_sessions ADD COLUMN stopped_at ${intType()}`,
+        );
       } catch {
         // Column already exists.
       }
-      await retryOnDdlRace(() =>
-        client.execute(
+      try {
+        await client.execute(
           `CREATE INDEX IF NOT EXISTS idx_agent_harness_sessions_thread ON agent_harness_sessions(thread_id, updated_at)`,
-        ),
-      );
-      await retryOnDdlRace(() =>
-        client.execute(
+        );
+      } catch {
+        // Index already exists.
+      }
+      try {
+        await client.execute(
           `CREATE INDEX IF NOT EXISTS idx_agent_harness_sessions_status ON agent_harness_sessions(status, updated_at)`,
-        ),
-      );
-      await retryOnDdlRace(() =>
-        client.execute(
+        );
+      } catch {
+        // Index already exists.
+      }
+      try {
+        await client.execute(
           `CREATE INDEX IF NOT EXISTS idx_agent_harness_sessions_owner ON agent_harness_sessions(owner_email, updated_at)`,
-        ),
-      );
+        );
+      } catch {
+        // Index already exists.
+      }
     })().catch((err) => {
       initPromise = undefined;
       throw err;

--- a/packages/core/src/agent/observational-memory/store.ts
+++ b/packages/core/src/agent/observational-memory/store.ts
@@ -12,8 +12,8 @@
  * runtime even before the migration plugin is registered.
  */
 
-import { getDbExec } from "../../db/client.js";
-import { isPostgres } from "../../db/client.js";
+import { getDbExec, isPostgres } from "../../db/client.js";
+import { ensureTableExists, ensureIndexExists } from "../../db/ddl-guard.js";
 import type {
   ObservationalMemoryEntry,
   ObservationalMemoryOwner,
@@ -27,8 +27,7 @@ async function ensureTable(): Promise<void> {
   tableReady = (async () => {
     const client = getDbExec();
     const intType = isPostgres() ? "BIGINT" : "INTEGER";
-    await client.execute(
-      `CREATE TABLE IF NOT EXISTS observational_memory (
+    const createSql = `CREATE TABLE IF NOT EXISTS observational_memory (
         id TEXT PRIMARY KEY,
         thread_id TEXT NOT NULL,
         tier TEXT NOT NULL,
@@ -42,16 +41,43 @@ async function ensureTable(): Promise<void> {
         owner_email TEXT NOT NULL,
         org_id TEXT,
         visibility TEXT NOT NULL DEFAULT 'private'
-      )`,
-    );
-    await client.execute(
-      `CREATE INDEX IF NOT EXISTS observational_memory_thread_tier_idx
-        ON observational_memory(thread_id, tier, created_at)`,
-    );
-    await client.execute(
-      `CREATE INDEX IF NOT EXISTS observational_memory_thread_owner_idx
-        ON observational_memory(thread_id, owner_email)`,
-    );
+      )`;
+
+    if (isPostgres()) {
+      // PG-guard: probe information_schema / pg_indexes before issuing DDL to
+      // avoid ACCESS EXCLUSIVE lock contention in fresh background-worker processes.
+      await ensureTableExists("observational_memory", createSql);
+      await ensureIndexExists(
+        "observational_memory_thread_tier_idx",
+        `CREATE INDEX IF NOT EXISTS observational_memory_thread_tier_idx
+          ON observational_memory(thread_id, tier, created_at)`,
+      );
+      await ensureIndexExists(
+        "observational_memory_thread_owner_idx",
+        `CREATE INDEX IF NOT EXISTS observational_memory_thread_owner_idx
+          ON observational_memory(thread_id, owner_email)`,
+      );
+      return;
+    }
+
+    // SQLite (local dev): no lock problem — keep the original behaviour.
+    await client.execute(createSql);
+    try {
+      await client.execute(
+        `CREATE INDEX IF NOT EXISTS observational_memory_thread_tier_idx
+          ON observational_memory(thread_id, tier, created_at)`,
+      );
+    } catch {
+      // Index already exists.
+    }
+    try {
+      await client.execute(
+        `CREATE INDEX IF NOT EXISTS observational_memory_thread_owner_idx
+          ON observational_memory(thread_id, owner_email)`,
+      );
+    } catch {
+      // Index already exists.
+    }
   })().catch((err) => {
     // Reset so a transient failure (e.g. SQLITE_BUSY on HMR) can retry.
     tableReady = null;

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -4,6 +4,7 @@
  * reliable reconnection after page refreshes.
  */
 import { getDbExec, intType, isPostgres } from "../db/client.js";
+import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
 import { captureError } from "../server/capture-error.js";
 import type { AgentChatEvent } from "./types.js";
@@ -82,7 +83,10 @@ async function ensureRunTables(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await client.execute(`
+
+      // Shared CREATE SQL strings — referenced by both the Postgres and SQLite
+      // branches so the column definitions stay in one place.
+      const agentRunsCreateSql = `
         CREATE TABLE IF NOT EXISTS agent_runs (
           id TEXT PRIMARY KEY,
           thread_id TEXT NOT NULL,
@@ -98,30 +102,117 @@ async function ensureRunTables(): Promise<void> {
           dispatch_mode TEXT,
           diag_stage TEXT
         )
-      `);
-      // Backfill heartbeat_at on older deployments.
-      try {
-        if (isPostgres()) {
-          await client.execute(
-            `ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS heartbeat_at ${intType()}`,
-          );
-          await client.execute(
-            `ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS abort_reason TEXT`,
-          );
-        } else {
-          await client.execute(
-            `ALTER TABLE agent_runs ADD COLUMN heartbeat_at ${intType()}`,
+      `;
+      const agentRunEventsCreateSql = `
+        CREATE TABLE IF NOT EXISTS agent_run_events (
+          run_id TEXT NOT NULL,
+          seq ${intType()} NOT NULL,
+          event_data TEXT NOT NULL,
+          PRIMARY KEY (run_id, seq)
+        )
+      `;
+      // Tool-call result ledger: persists the outcome of write tool calls that
+      // completed AFTER their chunk was abandoned (zombie completions). A
+      // resumed continuation can recover the real result by matching
+      // thread_id + tool_key (name:stableInputHash) instead of re-executing
+      // the side effect. Entries are scoped to the thread and expire with it.
+      const agentToolLedgerCreateSql = `
+        CREATE TABLE IF NOT EXISTS agent_tool_ledger (
+          thread_id TEXT NOT NULL,
+          tool_key TEXT NOT NULL,
+          result_summary TEXT NOT NULL,
+          completed_at ${intType()} NOT NULL,
+          PRIMARY KEY (thread_id, tool_key)
+        )
+      `;
+
+      if (isPostgres()) {
+        // Hot path: in production the tables and all additive columns are
+        // virtually always already present. Issuing `CREATE TABLE`/`ALTER TABLE
+        // ADD COLUMN` still takes an ACCESS EXCLUSIVE lock — which, in a fresh
+        // background-worker process behind a concurrent connection on the shared
+        // Neon DB, can block ~indefinitely. So check `information_schema` first
+        // (plain reads, no lock) and run DDL ONLY for what is actually missing.
+        // The `ensureTableExists` / `ensureColumnExists` wrappers probe →
+        // guarded-DDL (bounded `lock_timeout`) → re-probe, and THROW if the
+        // schema is still missing after a swallowed lock-timeout so a poisoned
+        // init never memoizes success against absent schema (the `_initPromise`
+        // rejects and the next call retries).
+        await ensureTableExists("agent_runs", agentRunsCreateSql);
+        // Additive columns — all listed in the CREATE TABLE above, so on a
+        // fresh DB they already exist after the CREATE and these checks are
+        // instant short-circuits. On an older deployment that predates a
+        // column, the wrapper issues one bounded ALTER.
+        //
+        // Backfill heartbeat_at on older deployments.
+        // heartbeat_at = "the producer process is alive" (bumped on a timer).
+        // last_progress_at = "the agent is actually emitting events" (bumped on
+        // each emit). The gap between them is the stuck-detector signal.
+        for (const [col, colType] of [
+          ["heartbeat_at", intType()],
+          ["abort_reason", "TEXT"],
+          ["last_progress_at", intType()],
+          // Backfill turn_id / error_code / error_detail.
+          //   turn_id    = stable identity for one logical assistant turn that may
+          //                span several continuation runs, so the durable record
+          //                can be folded across runs instead of dropped per-run.
+          //   error_code / error_detail = terminal failure classification captured
+          //                at completion so errored/cut-off runs are queryable for
+          //                pattern analysis (see listErroredRuns).
+          // dispatch_mode marks how a run was started: NULL/"foreground" for the
+          // normal synchronous path, "background" for a run dispatched into a
+          // Netlify background function. The reaper/claim widen the stale window
+          // for background rows so a slow cold-start isn't falsely reaped.
+          // diag_stage records the last reached pipeline stage (+ any error) for a
+          // background-dispatched run so a silent worker death is DIAGNOSABLE from
+          // the client (/runs/active surfaces it) without reading the unreadable
+          // Netlify background-function logs. See recordRunDiagnostic.
+          ["turn_id", "TEXT"],
+          ["error_code", "TEXT"],
+          ["error_detail", "TEXT"],
+          ["dispatch_mode", "TEXT"],
+          ["diag_stage", "TEXT"],
+        ] as const) {
+          await ensureColumnExists(
+            "agent_runs",
+            col,
+            `ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS ${col} ${colType}`,
           );
         }
+        await ensureTableExists("agent_run_events", agentRunEventsCreateSql);
+        await ensureTableExists("agent_tool_ledger", agentToolLedgerCreateSql);
+        // Widen millisecond-timestamp columns that older deployments created as
+        // 32-bit `INTEGER`. `insertRun()` writes `Date.now()` into `started_at`
+        // on every turn, so an int4 column makes every agent prompt fail on
+        // Postgres with "value … is out of range for type integer". No-op once
+        // widened (and on fresh DBs that already use BIGINT). See
+        // widenIntColumnsToBigInt.
+        await widenIntColumnsToBigInt("agent_runs", [
+          "started_at",
+          "completed_at",
+          "heartbeat_at",
+          "last_progress_at",
+        ]);
+        await widenIntColumnsToBigInt("agent_tool_ledger", ["completed_at"]);
+        return;
+      }
+
+      // SQLite (local dev): no ACCESS EXCLUSIVE lock problem — keep the
+      // original create-then-additive-alter behaviour. SQLite has no
+      // `ADD COLUMN IF NOT EXISTS`, so the ALTERs stay wrapped in try/catch.
+      await client.execute(agentRunsCreateSql);
+      // Backfill heartbeat_at on older deployments.
+      try {
+        await client.execute(
+          `ALTER TABLE agent_runs ADD COLUMN heartbeat_at ${intType()}`,
+        );
       } catch {
         // Column already exists — ignore
       }
       try {
-        if (!isPostgres()) {
-          await client.execute(
-            `ALTER TABLE agent_runs ADD COLUMN abort_reason TEXT`,
-          );
-        }
+        await client.execute(
+          `ALTER TABLE agent_runs ADD COLUMN abort_reason TEXT`,
+        );
       } catch {
         // Column already exists — ignore
       }
@@ -130,15 +221,9 @@ async function ensureRunTables(): Promise<void> {
       // last_progress_at = "the agent is actually emitting events" (bumped on
       // each emit). The gap between them is the stuck-detector signal.
       try {
-        if (isPostgres()) {
-          await client.execute(
-            `ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS last_progress_at ${intType()}`,
-          );
-        } else {
-          await client.execute(
-            `ALTER TABLE agent_runs ADD COLUMN last_progress_at ${intType()}`,
-          );
-        }
+        await client.execute(
+          `ALTER TABLE agent_runs ADD COLUMN last_progress_at ${intType()}`,
+        );
       } catch {
         // Column already exists — ignore
       }
@@ -165,41 +250,13 @@ async function ensureRunTables(): Promise<void> {
         "diag_stage",
       ] as const) {
         try {
-          if (isPostgres()) {
-            await client.execute(
-              `ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS ${col} TEXT`,
-            );
-          } else {
-            await client.execute(
-              `ALTER TABLE agent_runs ADD COLUMN ${col} TEXT`,
-            );
-          }
+          await client.execute(`ALTER TABLE agent_runs ADD COLUMN ${col} TEXT`);
         } catch {
           // Column already exists — ignore
         }
       }
-      await client.execute(`
-        CREATE TABLE IF NOT EXISTS agent_run_events (
-          run_id TEXT NOT NULL,
-          seq ${intType()} NOT NULL,
-          event_data TEXT NOT NULL,
-          PRIMARY KEY (run_id, seq)
-        )
-      `);
-      // Tool-call result ledger: persists the outcome of write tool calls that
-      // completed AFTER their chunk was abandoned (zombie completions). A
-      // resumed continuation can recover the real result by matching
-      // thread_id + tool_key (name:stableInputHash) instead of re-executing
-      // the side effect. Entries are scoped to the thread and expire with it.
-      await client.execute(`
-        CREATE TABLE IF NOT EXISTS agent_tool_ledger (
-          thread_id TEXT NOT NULL,
-          tool_key TEXT NOT NULL,
-          result_summary TEXT NOT NULL,
-          completed_at ${intType()} NOT NULL,
-          PRIMARY KEY (thread_id, tool_key)
-        )
-      `);
+      await client.execute(agentRunEventsCreateSql);
+      await client.execute(agentToolLedgerCreateSql);
       // Widen millisecond-timestamp columns that older deployments created as
       // 32-bit `INTEGER`. `insertRun()` writes `Date.now()` into `started_at`
       // on every turn, so an int4 column makes every agent prompt fail on

--- a/packages/core/src/application-state/store.ts
+++ b/packages/core/src/application-state/store.ts
@@ -4,6 +4,7 @@ import {
   isPostgres,
   intType,
 } from "../db/client.js";
+import { ensureIndexExists, ensureTableExists } from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
 import type { StoreWriteOptions } from "../settings/store.js";
 import { emitAppStateChange, emitAppStateDelete } from "./emitter.js";
@@ -22,7 +23,7 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await client.execute(`
+      const createSql = `
         CREATE TABLE IF NOT EXISTS application_state (
           session_id TEXT NOT NULL,
           key TEXT NOT NULL,
@@ -30,7 +31,40 @@ async function ensureTable(): Promise<void> {
           updated_at ${intType()} NOT NULL,
           PRIMARY KEY (session_id, key)
         )
-      `);
+      `;
+
+      if (isPostgres()) {
+        // Hot path: the `application_state` table and its poll indexes are
+        // virtually always already present in production. Issuing `CREATE
+        // TABLE`/ `CREATE INDEX` still takes a lock that, in a fresh
+        // background-worker process behind a concurrent connection on the
+        // shared Neon DB, can block ~indefinitely (ACCESS EXCLUSIVE for CREATE
+        // TABLE; a write-blocking SHARE lock for CREATE INDEX). The ensure*
+        // wrappers probe `information_schema`/`pg_indexes` first (plain reads,
+        // no lock) and run DDL ONLY for what is actually missing, bounded by a
+        // transaction-scoped `lock_timeout`. If a swallowed lock-timeout leaves
+        // the schema still missing they RE-PROBE and THROW rather than letting
+        // init memoize success against absent schema.
+        await ensureTableExists("application_state", createSql);
+        // Older deployments created `updated_at` as 32-bit `INTEGER`; on Postgres
+        // the `Date.now()` written by appStatePut() on every turn overflows int4.
+        // Widen it in place (no-op once done / on fresh BIGINT databases).
+        await widenIntColumnsToBigInt("application_state", ["updated_at"]);
+        // Indexes for the two hot poll paths. Probe pg_indexes first (no lock)
+        // and skip the SHARE-locking CREATE INDEX when already present.
+        await ensureIndexExists(
+          "app_state_updated_at_idx",
+          `CREATE INDEX IF NOT EXISTS app_state_updated_at_idx ON application_state (updated_at)`,
+        );
+        await ensureIndexExists(
+          "app_state_key_updated_idx",
+          `CREATE INDEX IF NOT EXISTS app_state_key_updated_idx ON application_state (key, updated_at)`,
+        );
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      await client.execute(createSql);
       // Older deployments created `updated_at` as 32-bit `INTEGER`; on Postgres
       // the `Date.now()` written by appStatePut() on every turn overflows int4.
       // Widen it in place (no-op once done / on fresh BIGINT databases).

--- a/packages/core/src/audit/store.ts
+++ b/packages/core/src/audit/store.ts
@@ -7,7 +7,8 @@
  * `agent_audit_log`; reads are scoped to the caller's identity in SQL (no
  * shares table — audit rows are never individually shared).
  */
-import { getDbExec, intType, retryOnDdlRace } from "../db/client.js";
+import { getDbExec, intType, isPostgres } from "../db/client.js";
+import { ensureTableExists, ensureIndexExists } from "../db/ddl-guard.js";
 import type {
   AuditEvent,
   AuditQueryFilters,
@@ -20,9 +21,7 @@ export async function ensureAuditTables(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-
-      await retryOnDdlRace(() =>
-        client.execute(`
+      const createSql = `
         CREATE TABLE IF NOT EXISTS agent_audit_log (
           id TEXT PRIMARY KEY,
           created_at ${intType()} NOT NULL,
@@ -42,9 +41,41 @@ export async function ensureAuditTables(): Promise<void> {
           owner_email TEXT,
           visibility TEXT NOT NULL DEFAULT 'private'
         )
-      `),
-      );
+      `;
 
+      if (isPostgres()) {
+        // PG-guard: probe information_schema / pg_indexes before issuing DDL to
+        // avoid ACCESS EXCLUSIVE lock contention in fresh background-worker processes.
+        await ensureTableExists("agent_audit_log", createSql);
+        await ensureIndexExists(
+          "idx_audit_owner",
+          `CREATE INDEX IF NOT EXISTS idx_audit_owner ON agent_audit_log (owner_email, created_at)`,
+        );
+        await ensureIndexExists(
+          "idx_audit_org",
+          `CREATE INDEX IF NOT EXISTS idx_audit_org ON agent_audit_log (org_id, created_at)`,
+        );
+        await ensureIndexExists(
+          "idx_audit_target",
+          `CREATE INDEX IF NOT EXISTS idx_audit_target ON agent_audit_log (target_type, target_id, created_at)`,
+        );
+        await ensureIndexExists(
+          "idx_audit_turn",
+          `CREATE INDEX IF NOT EXISTS idx_audit_turn ON agent_audit_log (turn_id)`,
+        );
+        await ensureIndexExists(
+          "idx_audit_actor",
+          `CREATE INDEX IF NOT EXISTS idx_audit_actor ON agent_audit_log (actor_email, created_at)`,
+        );
+        await ensureIndexExists(
+          "idx_audit_created",
+          `CREATE INDEX IF NOT EXISTS idx_audit_created ON agent_audit_log (created_at)`,
+        );
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      await client.execute(createSql);
       const indexes = [
         `CREATE INDEX IF NOT EXISTS idx_audit_owner ON agent_audit_log (owner_email, created_at)`,
         `CREATE INDEX IF NOT EXISTS idx_audit_org ON agent_audit_log (org_id, created_at)`,

--- a/packages/core/src/browser-sessions/store.ts
+++ b/packages/core/src/browser-sessions/store.ts
@@ -5,6 +5,7 @@ import {
   retryOnDdlRace,
   safeJsonParse,
 } from "../db/client.js";
+import { ensureIndexExists, ensureTableExists } from "../db/ddl-guard.js";
 import type {
   AgentNativeBrowserSession,
   AgentNativeBrowserSessionAction,
@@ -38,8 +39,7 @@ async function ensureTables(): Promise<void> {
   if (!initPromise) {
     initPromise = (async () => {
       const client = getDbExec();
-      await retryOnDdlRace(() =>
-        client.execute(`
+      const createSessionsSql = `
           CREATE TABLE IF NOT EXISTS ${SESSION_TABLE} (
             owner_email TEXT NOT NULL,
             session_id TEXT NOT NULL,
@@ -53,16 +53,8 @@ async function ensureTables(): Promise<void> {
             expires_at ${intType()} NOT NULL,
             PRIMARY KEY (owner_email, session_id)
           )
-        `),
-      );
-      await retryOnDdlRace(() =>
-        client.execute(`
-          CREATE INDEX IF NOT EXISTS agent_native_browser_sessions_owner_seen_idx
-          ON ${SESSION_TABLE} (owner_email, last_seen_at)
-        `),
-      );
-      await retryOnDdlRace(() =>
-        client.execute(`
+        `;
+      const createRequestsSql = `
           CREATE TABLE IF NOT EXISTS ${REQUEST_TABLE} (
             owner_email TEXT NOT NULL,
             session_id TEXT NOT NULL,
@@ -80,8 +72,35 @@ async function ensureTables(): Promise<void> {
             error TEXT,
             PRIMARY KEY (owner_email, request_id)
           )
+        `;
+
+      if (isPostgres()) {
+        // PG-guard: probe information_schema / pg_indexes first (no lock) and
+        // only issue DDL when the table/index is actually missing, wrapped in
+        // a transaction-scoped lock_timeout so a contended lock fails fast.
+        await ensureTableExists(SESSION_TABLE, createSessionsSql);
+        await ensureIndexExists(
+          "agent_native_browser_sessions_owner_seen_idx",
+          `CREATE INDEX IF NOT EXISTS agent_native_browser_sessions_owner_seen_idx ON ${SESSION_TABLE} (owner_email, last_seen_at)`,
+        );
+        await ensureTableExists(REQUEST_TABLE, createRequestsSql);
+        await ensureIndexExists(
+          "agent_native_browser_session_requests_pending_idx",
+          `CREATE INDEX IF NOT EXISTS agent_native_browser_session_requests_pending_idx ON ${REQUEST_TABLE} (owner_email, session_id, status, created_at)`,
+        );
+        return;
+      }
+
+      // SQLite (local dev): no ACCESS EXCLUSIVE lock problem — keep existing
+      // retryOnDdlRace behaviour.
+      await retryOnDdlRace(() => client.execute(createSessionsSql));
+      await retryOnDdlRace(() =>
+        client.execute(`
+          CREATE INDEX IF NOT EXISTS agent_native_browser_sessions_owner_seen_idx
+          ON ${SESSION_TABLE} (owner_email, last_seen_at)
         `),
       );
+      await retryOnDdlRace(() => client.execute(createRequestsSql));
       await retryOnDdlRace(() =>
         client.execute(`
           CREATE INDEX IF NOT EXISTS agent_native_browser_session_requests_pending_idx

--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -5,7 +5,12 @@ import {
   normalizeThreadRepository,
   normalizeThreadTitle,
 } from "../agent/thread-data-builder.js";
-import { getDbExec, intType } from "../db/client.js";
+import { getDbExec, intType, isPostgres } from "../db/client.js";
+import {
+  ensureColumnExists,
+  ensureIndexExists,
+  ensureTableExists,
+} from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
 import { emitChatThreadChange } from "./emitter.js";
 
@@ -53,7 +58,7 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await client.execute(`
+      const createSql = `
         CREATE TABLE IF NOT EXISTS chat_threads (
           id TEXT PRIMARY KEY,
           owner_email TEXT NOT NULL,
@@ -69,7 +74,66 @@ async function ensureTable(): Promise<void> {
           pinned_at ${intType()},
           archived_at ${intType()}
         )
-      `);
+      `;
+
+      if (isPostgres()) {
+        // Hot path: the `chat_threads` table and its indexes are virtually
+        // always already present in production. Issuing `CREATE TABLE`/
+        // `CREATE INDEX` still takes a lock that, in a fresh background-worker
+        // process behind a concurrent connection on the shared Neon DB, can
+        // block ~indefinitely (ACCESS EXCLUSIVE for CREATE TABLE; a write-
+        // blocking SHARE lock for CREATE INDEX). The ensure* wrappers probe
+        // `information_schema`/`pg_indexes` first (plain reads, no lock) and
+        // run DDL ONLY for what is actually missing, bounded by a transaction-
+        // scoped `lock_timeout`. If a swallowed lock-timeout leaves the schema
+        // still missing they RE-PROBE and THROW rather than letting init
+        // memoize success against absent schema. `chat_threads` is the
+        // unqualified name even though the table lives in `public`.
+        await ensureTableExists("chat_threads", createSql);
+        // Additive columns — guarded so the hot path (columns already present)
+        // skips the ACCESS EXCLUSIVE ALTER entirely.
+        for (const [col, type] of [
+          ["scope_type", "TEXT"],
+          ["scope_id", "TEXT"],
+          ["scope_label", "TEXT"],
+          ["pinned_at", intType()],
+          ["archived_at", intType()],
+        ] as const) {
+          await ensureColumnExists(
+            "chat_threads",
+            col,
+            `ALTER TABLE chat_threads ADD COLUMN IF NOT EXISTS ${col} ${type}`,
+          );
+        }
+        // Widen millisecond-timestamp columns that older deployments created as
+        // 32-bit `INTEGER`; on Postgres the `Date.now()` written on every turn
+        // overflows int4. No-op once widened / on fresh BIGINT databases.
+        await widenIntColumnsToBigInt("chat_threads", [
+          "created_at",
+          "updated_at",
+          "pinned_at",
+          "archived_at",
+        ]);
+        // Indexes for the hot read paths. Both the sidebar list and the
+        // scoped/per-resource list filter on owner_email (and optionally
+        // scope) and sort by updated_at. Probe pg_indexes first (no lock)
+        // and skip the SHARE-locking CREATE INDEX when already present.
+        await ensureIndexExists(
+          "chat_threads_owner_updated_idx",
+          `CREATE INDEX IF NOT EXISTS chat_threads_owner_updated_idx ON chat_threads (owner_email, updated_at)`,
+        );
+        await ensureIndexExists(
+          "chat_threads_scope_updated_idx",
+          `CREATE INDEX IF NOT EXISTS chat_threads_scope_updated_idx ON chat_threads (scope_type, scope_id, updated_at)`,
+        );
+        // One-time backfill of message_count for legacy rows written before
+        // the column was maintained.
+        await backfillLegacyMessageCounts(client);
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      await client.execute(createSql);
       // Additive migration for existing tables. Both SQLite and Postgres
       // accept `ALTER TABLE ADD COLUMN` and will raise when the column
       // already exists; the try/catch makes the call idempotent across

--- a/packages/core/src/checkpoints/store.ts
+++ b/packages/core/src/checkpoints/store.ts
@@ -1,4 +1,5 @@
-import { getDbExec, intType } from "../db/client.js";
+import { getDbExec, intType, isPostgres } from "../db/client.js";
+import { ensureTableExists } from "../db/ddl-guard.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -6,7 +7,7 @@ async function ensureCheckpointTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await client.execute(`
+      const createSql = `
         CREATE TABLE IF NOT EXISTS agent_checkpoints (
           id TEXT PRIMARY KEY,
           thread_id TEXT NOT NULL,
@@ -15,7 +16,17 @@ async function ensureCheckpointTable(): Promise<void> {
           message TEXT NOT NULL DEFAULT '',
           created_at ${intType()} NOT NULL
         )
-      `);
+      `;
+
+      if (isPostgres()) {
+        // PG-guard: probe information_schema before issuing DDL to avoid ACCESS
+        // EXCLUSIVE lock contention in fresh background-worker processes.
+        await ensureTableExists("agent_checkpoints", createSql);
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      await client.execute(createSql);
     })().catch((err) => {
       // Retry init on the next call after a failed startup.
       _initPromise = undefined;

--- a/packages/core/src/collab/storage.ts
+++ b/packages/core/src/collab/storage.ts
@@ -6,6 +6,7 @@
  */
 
 import { getDbExec, isPostgres } from "../db/client.js";
+import { ensureTableExists, ensureColumnExists } from "../db/ddl-guard.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -14,7 +15,7 @@ async function ensureTable(): Promise<void> {
     _initPromise = (async () => {
       const client = getDbExec();
       const nowDefault = isPostgres() ? "NOW()::text" : "datetime('now')";
-      await client.execute(`
+      const createSql = `
         CREATE TABLE IF NOT EXISTS _collab_docs (
           doc_id TEXT PRIMARY KEY,
           yjs_state TEXT NOT NULL,
@@ -22,7 +23,24 @@ async function ensureTable(): Promise<void> {
           version INTEGER NOT NULL DEFAULT 0,
           updated_at TEXT NOT NULL DEFAULT (${nowDefault})
         )
-      `);
+      `;
+
+      if (isPostgres()) {
+        // PG-guard: probe information_schema first (no lock) and only issue
+        // DDL when the table/column is actually missing, wrapped in a
+        // transaction-scoped lock_timeout so a contended lock fails fast.
+        await ensureTableExists("_collab_docs", createSql);
+        await ensureColumnExists(
+          "_collab_docs",
+          "version",
+          `ALTER TABLE _collab_docs ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 0`,
+        );
+        return;
+      }
+
+      // SQLite (local dev): no ACCESS EXCLUSIVE lock problem — keep existing
+      // create-then-additive-alter behaviour.
+      await client.execute(createSql);
       try {
         await client.execute(
           `ALTER TABLE _collab_docs ADD COLUMN version INTEGER NOT NULL DEFAULT 0`,

--- a/packages/core/src/db/ddl-guard.spec.ts
+++ b/packages/core/src/db/ddl-guard.spec.ts
@@ -202,6 +202,167 @@ describe("ddl-guard", () => {
     });
   });
 
+  describe("ensureSchemaObject (probe → guarded DDL → re-probe)", () => {
+    it("skips DDL entirely when the object already exists (returns false)", async () => {
+      vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+      const { ensureSchemaObject } = await import("./ddl-guard.js");
+      const ddlCalls: string[] = [];
+      const ran = await ensureSchemaObject({
+        probe: async () => true,
+        ddl: "CREATE TABLE foo (id TEXT)",
+        label: "table foo",
+        injectedClient: {
+          execute: async (sql: string | { sql: string }) => {
+            ddlCalls.push(typeof sql === "string" ? sql : sql.sql);
+            return { rows: [], rowsAffected: 0 };
+          },
+          transaction: async (fn: (tx: any) => Promise<unknown>) => fn({}),
+        } as any,
+      });
+      expect(ran).toBe(false);
+      // No DDL was issued on the already-present hot path → no lock taken.
+      expect(ddlCalls).toEqual([]);
+    });
+
+    it("runs DDL and resolves true when the object is missing", async () => {
+      vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+      const { ensureSchemaObject } = await import("./ddl-guard.js");
+      const { client, calls } = recordingClient();
+      const ran = await ensureSchemaObject({
+        probe: async () => false,
+        ddl: "CREATE TABLE foo (id TEXT)",
+        label: "table foo",
+        injectedClient: client,
+      });
+      expect(ran).toBe(true);
+      expect(calls).toContain("CREATE TABLE foo (id TEXT)");
+    });
+
+    it("resolves true when DDL lock-times out but a re-probe finds it present (race)", async () => {
+      vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+      const { ensureSchemaObject } = await import("./ddl-guard.js");
+      const lockErr = Object.assign(
+        new Error("canceling statement due to lock timeout"),
+        { code: "55P03" },
+      );
+      // First probe: missing. After the swallowed timeout, re-probe: present
+      // (a concurrent connection created it meanwhile).
+      let probeCount = 0;
+      const probe = async () => {
+        probeCount += 1;
+        return probeCount > 1; // false first, true on re-probe
+      };
+      const client = {
+        execute: async () => ({ rows: [], rowsAffected: 0 }),
+        transaction: async (fn: (tx: any) => Promise<unknown>) =>
+          fn({
+            execute: async (sql: string | { sql: string }) => {
+              const text = typeof sql === "string" ? sql : sql.sql;
+              if (/CREATE TABLE/i.test(text)) throw lockErr;
+              return { rows: [], rowsAffected: 0 };
+            },
+          }),
+      } as any;
+      const ran = await ensureSchemaObject({
+        probe,
+        ddl: "CREATE TABLE foo (id TEXT)",
+        label: "table foo",
+        injectedClient: client,
+      });
+      expect(ran).toBe(true);
+      expect(probeCount).toBe(2);
+    });
+
+    it("THROWS (does not memoize success) when DDL lock-times out and the object is STILL missing", async () => {
+      vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+      const { ensureSchemaObject } = await import("./ddl-guard.js");
+      const lockErr = Object.assign(
+        new Error("canceling statement due to lock timeout"),
+        { code: "55P03" },
+      );
+      // Probe always reports missing — the lock-timed-out DDL truly didn't land.
+      const client = {
+        execute: async () => ({ rows: [], rowsAffected: 0 }),
+        transaction: async (fn: (tx: any) => Promise<unknown>) =>
+          fn({
+            execute: async (sql: string | { sql: string }) => {
+              const text = typeof sql === "string" ? sql : sql.sql;
+              if (/CREATE TABLE/i.test(text)) throw lockErr;
+              return { rows: [], rowsAffected: 0 };
+            },
+          }),
+      } as any;
+      await expect(
+        ensureSchemaObject({
+          probe: async () => false,
+          ddl: "CREATE TABLE foo (id TEXT)",
+          label: "table foo",
+          injectedClient: client,
+        }),
+      ).rejects.toThrow(/still missing after a lock-timed-out DDL/);
+    });
+
+    it("rethrows a non-lock-timeout DDL error without re-probing", async () => {
+      vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+      const { ensureSchemaObject } = await import("./ddl-guard.js");
+      let probeCount = 0;
+      const client = {
+        execute: async () => ({ rows: [], rowsAffected: 0 }),
+        transaction: async (fn: (tx: any) => Promise<unknown>) =>
+          fn({
+            execute: async (sql: string | { sql: string }) => {
+              const text = typeof sql === "string" ? sql : sql.sql;
+              if (/CREATE TABLE/i.test(text)) {
+                throw new Error("syntax error at or near");
+              }
+              return { rows: [], rowsAffected: 0 };
+            },
+          }),
+      } as any;
+      await expect(
+        ensureSchemaObject({
+          probe: async () => {
+            probeCount += 1;
+            return false;
+          },
+          ddl: "CREATE TABLE foo (id TEXT)",
+          label: "table foo",
+          injectedClient: client,
+        }),
+      ).rejects.toThrow("syntax error");
+      // Only the initial probe ran; a hard DDL error doesn't trigger a re-probe.
+      expect(probeCount).toBe(1);
+    });
+
+    it("ensureTableExists / ensureColumnExists / ensureIndexExists are no-ops on SQLite", async () => {
+      vi.stubEnv("DATABASE_URL", "file:./data/app.db");
+      const { ensureTableExists, ensureColumnExists, ensureIndexExists } =
+        await import("./ddl-guard.js");
+      // On SQLite the probes return false, so the wrappers run the DDL through
+      // runGuardedDdl, which on SQLite just executes it directly (returns true).
+      const { client, calls } = recordingClient();
+      expect(
+        await ensureTableExists("foo", "CREATE TABLE foo (id TEXT)", {
+          injectedClient: client,
+        }),
+      ).toBe(true);
+      expect(calls).toEqual(["CREATE TABLE foo (id TEXT)"]);
+      expect(
+        await ensureColumnExists(
+          "foo",
+          "bar",
+          "ALTER TABLE foo ADD COLUMN bar TEXT",
+          { injectedClient: client },
+        ),
+      ).toBe(true);
+      expect(
+        await ensureIndexExists("foo_idx", "CREATE INDEX foo_idx ON foo (id)", {
+          injectedClient: client,
+        }),
+      ).toBe(true);
+    });
+  });
+
   describe("isLockTimeoutError", () => {
     it("matches SQLSTATE 55P03 and lock-timeout messages", async () => {
       const { isLockTimeoutError } = await import("./ddl-guard.js");

--- a/packages/core/src/db/ddl-guard.ts
+++ b/packages/core/src/db/ddl-guard.ts
@@ -121,6 +121,118 @@ export async function pgIndexExists(
   }
 }
 
+/**
+ * Probe → guarded-DDL → re-probe sequence for one piece of on-demand schema.
+ *
+ * This is the single safe primitive every `ensureTable()` should use so a
+ * swallowed `lock_timeout` can NEVER poison a store's init memo with missing
+ * schema. The flow:
+ *
+ *   1. `probe()` — cheap, lock-free existence check (pgTableExists / etc.).
+ *      Already present → return `false` (nothing to do; the hot path takes NO
+ *      lock).
+ *   2. Missing → run `ddl` through `runGuardedDdl` (bounded `lock_timeout`).
+ *      - DDL completed → return `true`.
+ *      - DDL was swallowed by a lock-timeout (`runGuardedDdl` returned `false`)
+ *        → RE-PROBE. A concurrent connection virtually always created the
+ *        object meanwhile, so the re-probe usually now reports it present →
+ *        return `true`. But if it is STILL missing, the required schema does
+ *        NOT exist and we must NOT let the caller memoize success — so THROW.
+ *        The caller's `_initPromise` rejects and the next call retries instead
+ *        of running forever against absent schema.
+ *
+ * On SQLite the probe is always `false` (helpers no-op there) and the SQLite
+ * branch of each store keeps its own create-then-catch behaviour, so this is a
+ * Postgres-path primitive in practice. Returns `true` when the object exists
+ * after this call (either pre-existing-after-timeout-race or freshly created),
+ * `false` only when it already existed up front (no DDL issued).
+ */
+export async function ensureSchemaObject(options: {
+  /** Lock-free existence check; `true` ⇒ already present, skip DDL. */
+  probe: () => Promise<boolean>;
+  /** DDL to run only when `probe()` reports the object missing. */
+  ddl: string;
+  /** Human-readable name of what's being ensured, for the error message. */
+  label: string;
+  /** Forwarded to `runGuardedDdl`. */
+  lockTimeout?: string;
+  /** Injectable client for tests. */
+  injectedClient?: DbExec;
+}): Promise<boolean> {
+  const { probe, ddl, label, lockTimeout, injectedClient } = options;
+  if (await probe()) return false;
+  const ran = await runGuardedDdl(ddl, { lockTimeout, injectedClient });
+  if (ran) return true;
+  // The DDL was swallowed by a lock-timeout. The object is virtually always
+  // already correct by the time a contended boot retries (a concurrent
+  // connection created it), so re-probe before giving up.
+  if (await probe()) return true;
+  // Still missing after a swallowed timeout: do NOT memoize success with absent
+  // schema. Throw so the caller's init promise rejects and the next call
+  // retries, rather than leaving ensureTable "initialized" against a table/
+  // column/index that does not exist.
+  throw new Error(
+    `ensureSchemaObject: required schema "${label}" is still missing after a ` +
+      `lock-timed-out DDL; refusing to memoize init success. The next call will retry.`,
+  );
+}
+
+/**
+ * Convenience wrapper: ensure a TABLE exists (probe via `pgTableExists`).
+ * No-op-returns `false` on SQLite (probe is always false there) — callers run
+ * the SQLite create on their own branch, so this is used on the Postgres path.
+ */
+export async function ensureTableExists(
+  table: string,
+  createSql: string,
+  options: { lockTimeout?: string; injectedClient?: DbExec } = {},
+): Promise<boolean> {
+  return ensureSchemaObject({
+    probe: () => pgTableExists(table, options.injectedClient),
+    ddl: createSql,
+    label: `table ${table}`,
+    lockTimeout: options.lockTimeout,
+    injectedClient: options.injectedClient,
+  });
+}
+
+/**
+ * Convenience wrapper: ensure a COLUMN exists (probe via `pgColumnExists`).
+ * `addColumnSql` should be the full `ALTER TABLE … ADD COLUMN IF NOT EXISTS …`.
+ */
+export async function ensureColumnExists(
+  table: string,
+  column: string,
+  addColumnSql: string,
+  options: { lockTimeout?: string; injectedClient?: DbExec } = {},
+): Promise<boolean> {
+  return ensureSchemaObject({
+    probe: () => pgColumnExists(table, column, options.injectedClient),
+    ddl: addColumnSql,
+    label: `column ${table}.${column}`,
+    lockTimeout: options.lockTimeout,
+    injectedClient: options.injectedClient,
+  });
+}
+
+/**
+ * Convenience wrapper: ensure an INDEX exists (probe via `pgIndexExists`).
+ * `createIndexSql` should be the full `CREATE INDEX IF NOT EXISTS <name> …`.
+ */
+export async function ensureIndexExists(
+  indexName: string,
+  createIndexSql: string,
+  options: { lockTimeout?: string; injectedClient?: DbExec } = {},
+): Promise<boolean> {
+  return ensureSchemaObject({
+    probe: () => pgIndexExists(indexName, options.injectedClient),
+    ddl: createIndexSql,
+    label: `index ${indexName}`,
+    lockTimeout: options.lockTimeout,
+    injectedClient: options.injectedClient,
+  });
+}
+
 /** True when an error looks like a Postgres `lock_timeout` (SQLSTATE 55P03). */
 export function isLockTimeoutError(err: unknown): boolean {
   const anyErr = err as { code?: unknown; message?: unknown } | null;

--- a/packages/core/src/extensions/store.ts
+++ b/packages/core/src/extensions/store.ts
@@ -4,6 +4,11 @@ import { and, eq, gte, isNull } from "drizzle-orm";
 
 import { appStatePut } from "../application-state/store.js";
 import { getDbExec, isPostgres, retryOnDdlRace } from "../db/client.js";
+import {
+  ensureTableExists,
+  ensureColumnExists,
+  ensureIndexExists,
+} from "../db/ddl-guard.js";
 import { createGetDb } from "../db/create-get-db.js";
 import { recordChange } from "../server/poll.js";
 import {
@@ -77,6 +82,70 @@ export async function ensureExtensionsTables(): Promise<void> {
     _initPromise = (async () => {
       const client = getDbExec();
       const pg = isPostgres();
+      if (pg) {
+        // PG guard: probe via information_schema, only issue DDL if missing, bounded lock_timeout
+        await ensureTableExists("tools", EXTENSIONS_CREATE_SQL_PG);
+        await migrateMisnamedExtensionsTable(client, pg); // data migration, not DDL — unchanged
+        await ensureTableExists("tool_shares", EXTENSION_SHARES_CREATE_SQL_PG);
+        await ensureTableExists("tool_data", EXTENSION_DATA_CREATE_SQL_PG);
+        await ensureExtensionDataItemId(client, pg); // ADD COLUMN — guarded inside
+        await ensureExtensionDataScope(client, pg); // ADD COLUMN — guarded inside
+        // DROP INDEX (for old index) — safe DDL, runs via client.execute; keep on both paths
+        await client.execute(EXTENSION_DATA_DROP_OLD_INDEX_SQL_PG);
+        await ensureIndexExists(
+          "tool_data_scoped_item_idx",
+          EXTENSION_DATA_ITEM_INDEX_SQL_PG,
+        );
+        await ensureIndexExists("tools_owner_idx", EXTENSIONS_OWNER_INDEX_SQL);
+        await ensureIndexExists("tools_org_idx", EXTENSIONS_ORG_INDEX_SQL);
+        await ensureIndexExists(
+          "tools_updated_at_idx",
+          EXTENSIONS_UPDATED_INDEX_SQL,
+        );
+        await ensureExtensionsGlobalHideColumns(client, pg); // ADD COLUMN — guarded inside
+        await ensureIndexExists(
+          "tools_hidden_at_idx",
+          EXTENSIONS_HIDDEN_AT_INDEX_SQL,
+        );
+        await ensureIndexExists(
+          "tool_shares_resource_idx",
+          EXTENSION_SHARES_RESOURCE_INDEX_SQL,
+        );
+        await ensureTableExists(
+          "tool_hidden_extensions",
+          EXTENSION_HIDES_CREATE_SQL_PG,
+        );
+        await ensureIndexExists(
+          "tool_hidden_extensions_user_tool_idx",
+          EXTENSION_HIDES_UNIQUE_INDEX_SQL,
+        );
+        await ensureIndexExists(
+          "tool_hidden_extensions_owner_idx",
+          EXTENSION_HIDES_OWNER_INDEX_SQL,
+        );
+        await ensureTableExists(
+          "tool_history",
+          EXTENSION_HISTORY_CREATE_SQL_PG,
+        );
+        await ensureIndexExists(
+          "tool_history_tool_version_idx",
+          EXTENSION_HISTORY_VERSION_INDEX_SQL,
+        );
+        await ensureIndexExists(
+          "tool_history_tool_created_idx",
+          EXTENSION_HISTORY_CREATED_INDEX_SQL,
+        );
+        await ensureTableExists(
+          "tool_consents",
+          EXTENSION_CONSENTS_CREATE_SQL_PG,
+        );
+        await ensureIndexExists(
+          "tool_consents_viewer_idx",
+          EXTENSION_CONSENTS_VIEWER_INDEX_SQL,
+        );
+        return;
+      }
+      // SQLite (local dev): keep existing behavior
       await retryOnDdlRace(() =>
         client.execute(pg ? EXTENSIONS_CREATE_SQL_PG : EXTENSIONS_CREATE_SQL),
       );
@@ -192,7 +261,9 @@ async function ensureExtensionDataItemId(
   pg: boolean,
 ): Promise<void> {
   if (pg) {
-    await client.execute(
+    await ensureColumnExists(
+      "tool_data",
+      "item_id",
       `ALTER TABLE tool_data ADD COLUMN IF NOT EXISTS item_id TEXT`,
     );
     return;
@@ -219,7 +290,9 @@ async function ensureExtensionDataScope(
 ): Promise<void> {
   const addCol = (name: string, def: string) => {
     if (pg) {
-      return client.execute(
+      return ensureColumnExists(
+        "tool_data",
+        name,
         `ALTER TABLE tool_data ADD COLUMN IF NOT EXISTS ${name} ${def}`,
       );
     }
@@ -255,7 +328,7 @@ async function ensureExtensionsGlobalHideColumns(
   // does not, so we drop the clause and swallow the duplicate-column error.
   const addCol = (pgSql: string, name: string, def: string) => {
     if (pg) {
-      return retryOnDdlRace(() => client.execute(pgSql));
+      return ensureColumnExists("tools", name, pgSql);
     }
     return client
       .execute(`ALTER TABLE tools ADD COLUMN ${name} ${def}`)

--- a/packages/core/src/extensions/store.ts
+++ b/packages/core/src/extensions/store.ts
@@ -4,12 +4,12 @@ import { and, eq, gte, isNull } from "drizzle-orm";
 
 import { appStatePut } from "../application-state/store.js";
 import { getDbExec, isPostgres, retryOnDdlRace } from "../db/client.js";
+import { createGetDb } from "../db/create-get-db.js";
 import {
   ensureTableExists,
   ensureColumnExists,
   ensureIndexExists,
 } from "../db/ddl-guard.js";
-import { createGetDb } from "../db/create-get-db.js";
 import { recordChange } from "../server/poll.js";
 import {
   getRequestUserEmail,

--- a/packages/core/src/integrations/a2a-continuations-store.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.ts
@@ -5,42 +5,85 @@ import {
   retryOnDdlRace,
 } from "../db/client.js";
 import { isDuplicateColumnError } from "../db/migrations.js";
+import {
+  ensureTableExists,
+  ensureColumnExists,
+  ensureIndexExists,
+} from "../db/ddl-guard.js";
 import type { IncomingMessage } from "./types.js";
 
 let _initPromise: Promise<void> | undefined;
 const PROCESSING_STUCK_AFTER_MS = 5 * 60 * 1000;
 const PROCESSING_NEXT_CHECK_STALE_AFTER_MS = 60 * 1000;
 
+// Build the CREATE SQL lazily (not at module scope) so intType() runs at
+// RUNTIME, not import time — a module-scope call breaks any consumer whose
+// db/client mock doesn't stub intType (e.g. db-admin specs).
+function buildCreateSql(): string {
+  return `
+  CREATE TABLE IF NOT EXISTS integration_a2a_continuations (
+    id TEXT PRIMARY KEY,
+    integration_task_id TEXT NOT NULL,
+    platform TEXT NOT NULL,
+    external_thread_id TEXT NOT NULL,
+    incoming_payload TEXT NOT NULL,
+    placeholder_ref TEXT,
+    owner_email TEXT NOT NULL,
+    org_id TEXT,
+    agent_name TEXT NOT NULL,
+    agent_url TEXT NOT NULL,
+    dedupe_key TEXT,
+    a2a_task_id TEXT NOT NULL,
+    a2a_auth_token TEXT,
+    status TEXT NOT NULL,
+    attempts ${intType()} NOT NULL DEFAULT 0,
+    next_check_at ${intType()} NOT NULL,
+    error_message TEXT,
+    created_at ${intType()} NOT NULL,
+    updated_at ${intType()} NOT NULL,
+    completed_at ${intType()}
+  )
+`;
+}
+
 async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await retryOnDdlRace(() =>
-        client.execute(`
-        CREATE TABLE IF NOT EXISTS integration_a2a_continuations (
-          id TEXT PRIMARY KEY,
-          integration_task_id TEXT NOT NULL,
-          platform TEXT NOT NULL,
-          external_thread_id TEXT NOT NULL,
-          incoming_payload TEXT NOT NULL,
-          placeholder_ref TEXT,
-          owner_email TEXT NOT NULL,
-          org_id TEXT,
-          agent_name TEXT NOT NULL,
-          agent_url TEXT NOT NULL,
-          dedupe_key TEXT,
-          a2a_task_id TEXT NOT NULL,
-          a2a_auth_token TEXT,
-          status TEXT NOT NULL,
-          attempts ${intType()} NOT NULL DEFAULT 0,
-          next_check_at ${intType()} NOT NULL,
-          error_message TEXT,
-          created_at ${intType()} NOT NULL,
-          updated_at ${intType()} NOT NULL,
-          completed_at ${intType()}
-        )
-      `),
-      );
+      const createSql = buildCreateSql();
+      if (isPostgres()) {
+        // PG guard: probe via information_schema, only issue DDL if missing, bounded lock_timeout
+        await ensureTableExists("integration_a2a_continuations", createSql);
+        await ensureIndexExists(
+          "idx_a2a_continuations_status_next",
+          `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_status_next ON integration_a2a_continuations(status, next_check_at)`,
+        );
+        await ensureIndexExists(
+          "idx_a2a_continuations_integration_task",
+          `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_integration_task ON integration_a2a_continuations(integration_task_id)`,
+        );
+        await ensureIndexExists(
+          "idx_a2a_continuations_remote_task",
+          `CREATE UNIQUE INDEX IF NOT EXISTS idx_a2a_continuations_remote_task ON integration_a2a_continuations(integration_task_id, agent_url, a2a_task_id)`,
+        );
+        await ensureColumnExists(
+          "integration_a2a_continuations",
+          "a2a_auth_token",
+          `ALTER TABLE integration_a2a_continuations ADD COLUMN IF NOT EXISTS a2a_auth_token TEXT`,
+        );
+        await ensureColumnExists(
+          "integration_a2a_continuations",
+          "dedupe_key",
+          `ALTER TABLE integration_a2a_continuations ADD COLUMN IF NOT EXISTS dedupe_key TEXT`,
+        );
+        await ensureIndexExists(
+          "idx_a2a_continuations_dedupe_key",
+          `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_dedupe_key ON integration_a2a_continuations(integration_task_id, agent_url, dedupe_key)`,
+        );
+        return;
+      }
+      // SQLite (local dev): keep existing behavior
+      await retryOnDdlRace(() => client.execute(createSql));
       await retryOnDdlRace(() =>
         client.execute(
           `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_status_next ON integration_a2a_continuations(status, next_check_at)`,

--- a/packages/core/src/integrations/a2a-continuations-store.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.ts
@@ -4,12 +4,12 @@ import {
   intType,
   retryOnDdlRace,
 } from "../db/client.js";
-import { isDuplicateColumnError } from "../db/migrations.js";
 import {
   ensureTableExists,
   ensureColumnExists,
   ensureIndexExists,
 } from "../db/ddl-guard.js";
+import { isDuplicateColumnError } from "../db/migrations.js";
 import type { IncomingMessage } from "./types.js";
 
 let _initPromise: Promise<void> | undefined;

--- a/packages/core/src/integrations/config-store.ts
+++ b/packages/core/src/integrations/config-store.ts
@@ -1,9 +1,5 @@
-import {
-  getDbExec,
-  isPostgres,
-  intType,
-  retryOnDdlRace,
-} from "../db/client.js";
+import { getDbExec, isPostgres, intType } from "../db/client.js";
+import { ensureTableExists } from "../db/ddl-guard.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -11,18 +7,23 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await retryOnDdlRace(() =>
-        client.execute(`
-          CREATE TABLE IF NOT EXISTS integration_configs (
-            platform TEXT NOT NULL,
-            config_key TEXT NOT NULL,
-            config_data TEXT NOT NULL,
-            owner TEXT,
-            updated_at ${intType()} NOT NULL,
-            PRIMARY KEY (platform, config_key)
-          )
-        `),
-      );
+      const createSql = `CREATE TABLE IF NOT EXISTS integration_configs (
+  platform TEXT NOT NULL,
+  config_key TEXT NOT NULL,
+  config_data TEXT NOT NULL,
+  owner TEXT,
+  updated_at ${intType()} NOT NULL,
+  PRIMARY KEY (platform, config_key)
+)`;
+
+      if (isPostgres()) {
+        // PG guard: probe via information_schema, only issue DDL if missing, bounded lock_timeout
+        await ensureTableExists("integration_configs", createSql);
+        return;
+      }
+
+      // SQLite (local dev): keep existing behavior
+      await client.execute(createSql);
     })().catch((err) => {
       // Don't cache the rejection — let the next caller retry a fresh init.
       _initPromise = undefined;

--- a/packages/core/src/integrations/pending-tasks-store.ts
+++ b/packages/core/src/integrations/pending-tasks-store.ts
@@ -11,6 +11,11 @@
  * invocation gets its own fresh function timeout budget.
  */
 import { getDbExec, isPostgres, intType } from "../db/client.js";
+import {
+  ensureTableExists,
+  ensureColumnExists,
+  ensureIndexExists,
+} from "../db/ddl-guard.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -18,22 +23,41 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await client.execute(`
-        CREATE TABLE IF NOT EXISTS integration_pending_tasks (
-          id TEXT PRIMARY KEY,
-          platform TEXT NOT NULL,
-          external_thread_id TEXT NOT NULL,
-          payload TEXT NOT NULL,
-          owner_email TEXT NOT NULL,
-          org_id TEXT,
-          status TEXT NOT NULL,
-          attempts ${intType()} NOT NULL DEFAULT 0,
-          error_message TEXT,
-          created_at ${intType()} NOT NULL,
-          updated_at ${intType()} NOT NULL,
-          completed_at ${intType()}
-        )
-      `);
+      const createSql = `CREATE TABLE IF NOT EXISTS integration_pending_tasks (
+  id TEXT PRIMARY KEY,
+  platform TEXT NOT NULL,
+  external_thread_id TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  owner_email TEXT NOT NULL,
+  org_id TEXT,
+  status TEXT NOT NULL,
+  attempts ${intType()} NOT NULL DEFAULT 0,
+  error_message TEXT,
+  created_at ${intType()} NOT NULL,
+  updated_at ${intType()} NOT NULL,
+  completed_at ${intType()}
+)`;
+
+      if (isPostgres()) {
+        // PG guard: probe via information_schema, only issue DDL if missing, bounded lock_timeout
+        await ensureTableExists("integration_pending_tasks", createSql);
+        await ensureColumnExists(
+          "integration_pending_tasks",
+          "external_event_key",
+          `ALTER TABLE integration_pending_tasks ADD COLUMN IF NOT EXISTS external_event_key TEXT`,
+        );
+        await ensureIndexExists(
+          "idx_pending_tasks_status_created",
+          `CREATE INDEX IF NOT EXISTS idx_pending_tasks_status_created ON integration_pending_tasks(status, created_at)`,
+        );
+        await ensureIndexExists(
+          "idx_pending_tasks_event_key",
+          `CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_tasks_event_key ON integration_pending_tasks(platform, external_event_key)`,
+        );
+        return;
+      }
+
+      await client.execute(createSql);
       await client.execute(
         `CREATE INDEX IF NOT EXISTS idx_pending_tasks_status_created ON integration_pending_tasks(status, created_at)`,
       );

--- a/packages/core/src/integrations/remote-commands-store.ts
+++ b/packages/core/src/integrations/remote-commands-store.ts
@@ -4,6 +4,7 @@ import {
   isPostgres,
   retryOnDdlRace,
 } from "../db/client.js";
+import { ensureTableExists, ensureIndexExists } from "../db/ddl-guard.js";
 import type {
   RemoteCommand,
   RemoteCommandKind,
@@ -29,29 +30,42 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await retryOnDdlRace(() =>
-        client.execute(`
-          CREATE TABLE IF NOT EXISTS integration_remote_commands (
-            id TEXT PRIMARY KEY,
-            device_id TEXT NOT NULL,
-            owner_email TEXT NOT NULL,
-            org_id TEXT,
-            kind TEXT NOT NULL,
-            params_json TEXT NOT NULL,
-            status TEXT NOT NULL,
-            result_json TEXT,
-            platform TEXT,
-            external_thread_id TEXT,
-            attempts ${intType()} NOT NULL DEFAULT 0,
-            next_check_at ${intType()} NOT NULL,
-            claimed_at ${intType()},
-            completed_at ${intType()},
-            error_message TEXT,
-            created_at ${intType()} NOT NULL,
-            updated_at ${intType()} NOT NULL
-          )
-        `),
-      );
+      const createSql = `CREATE TABLE IF NOT EXISTS integration_remote_commands (
+  id TEXT PRIMARY KEY,
+  device_id TEXT NOT NULL,
+  owner_email TEXT NOT NULL,
+  org_id TEXT,
+  kind TEXT NOT NULL,
+  params_json TEXT NOT NULL,
+  status TEXT NOT NULL,
+  result_json TEXT,
+  platform TEXT,
+  external_thread_id TEXT,
+  attempts ${intType()} NOT NULL DEFAULT 0,
+  next_check_at ${intType()} NOT NULL,
+  claimed_at ${intType()},
+  completed_at ${intType()},
+  error_message TEXT,
+  created_at ${intType()} NOT NULL,
+  updated_at ${intType()} NOT NULL
+)`;
+
+      if (isPostgres()) {
+        // PG guard: probe via information_schema, only issue DDL if missing, bounded lock_timeout
+        await ensureTableExists("integration_remote_commands", createSql);
+        await ensureIndexExists(
+          "idx_remote_commands_device_status_next",
+          `CREATE INDEX IF NOT EXISTS idx_remote_commands_device_status_next ON integration_remote_commands(device_id, status, next_check_at)`,
+        );
+        await ensureIndexExists(
+          "idx_remote_commands_owner",
+          `CREATE INDEX IF NOT EXISTS idx_remote_commands_owner ON integration_remote_commands(owner_email, org_id)`,
+        );
+        return;
+      }
+
+      // SQLite: keep existing behavior
+      await retryOnDdlRace(() => client.execute(createSql));
       await retryOnDdlRace(() =>
         client.execute(
           `CREATE INDEX IF NOT EXISTS idx_remote_commands_device_status_next ON integration_remote_commands(device_id, status, next_check_at)`,

--- a/packages/core/src/integrations/remote-devices-store.ts
+++ b/packages/core/src/integrations/remote-devices-store.ts
@@ -4,6 +4,11 @@ import {
   isPostgres,
   retryOnDdlRace,
 } from "../db/client.js";
+import {
+  ensureColumnExists,
+  ensureIndexExists,
+  ensureTableExists,
+} from "../db/ddl-guard.js";
 import type { PublicRemoteDevice, RemoteDevice } from "./remote-types.js";
 
 let _initPromise: Promise<void> | undefined;
@@ -12,26 +17,65 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await retryOnDdlRace(() =>
-        client.execute(`
-          CREATE TABLE IF NOT EXISTS integration_remote_devices (
-            id TEXT PRIMARY KEY,
-            owner_email TEXT NOT NULL,
-            org_id TEXT,
-            label TEXT NOT NULL,
-            platform TEXT,
-            app_version TEXT,
-            host_name TEXT,
-            metadata_json TEXT,
-            device_token_hash TEXT NOT NULL,
-            last_seen_at ${intType()},
-            status TEXT NOT NULL,
-            revoked_at ${intType()},
-            created_at ${intType()} NOT NULL,
-            updated_at ${intType()} NOT NULL
-          )
-        `),
-      );
+      const createSql = `
+        CREATE TABLE IF NOT EXISTS integration_remote_devices (
+          id TEXT PRIMARY KEY,
+          owner_email TEXT NOT NULL,
+          org_id TEXT,
+          label TEXT NOT NULL,
+          platform TEXT,
+          app_version TEXT,
+          host_name TEXT,
+          metadata_json TEXT,
+          device_token_hash TEXT NOT NULL,
+          last_seen_at ${intType()},
+          status TEXT NOT NULL,
+          revoked_at ${intType()},
+          created_at ${intType()} NOT NULL,
+          updated_at ${intType()} NOT NULL
+        )
+      `;
+
+      if (isPostgres()) {
+        // PG guard: probe via information_schema, only issue DDL if missing, bounded lock_timeout
+        await ensureTableExists("integration_remote_devices", createSql);
+        await ensureColumnExists(
+          "integration_remote_devices",
+          "platform",
+          `ALTER TABLE integration_remote_devices ADD COLUMN IF NOT EXISTS platform TEXT`,
+        );
+        await ensureColumnExists(
+          "integration_remote_devices",
+          "app_version",
+          `ALTER TABLE integration_remote_devices ADD COLUMN IF NOT EXISTS app_version TEXT`,
+        );
+        await ensureColumnExists(
+          "integration_remote_devices",
+          "host_name",
+          `ALTER TABLE integration_remote_devices ADD COLUMN IF NOT EXISTS host_name TEXT`,
+        );
+        await ensureColumnExists(
+          "integration_remote_devices",
+          "metadata_json",
+          `ALTER TABLE integration_remote_devices ADD COLUMN IF NOT EXISTS metadata_json TEXT`,
+        );
+        await ensureColumnExists(
+          "integration_remote_devices",
+          "revoked_at",
+          `ALTER TABLE integration_remote_devices ADD COLUMN IF NOT EXISTS revoked_at ${intType()}`,
+        );
+        await ensureIndexExists(
+          "idx_remote_devices_token_hash",
+          `CREATE UNIQUE INDEX IF NOT EXISTS idx_remote_devices_token_hash ON integration_remote_devices(device_token_hash)`,
+        );
+        await ensureIndexExists(
+          "idx_remote_devices_owner",
+          `CREATE INDEX IF NOT EXISTS idx_remote_devices_owner ON integration_remote_devices(owner_email, org_id)`,
+        );
+        return;
+      }
+      // SQLite (local dev): keep existing behavior verbatim
+      await retryOnDdlRace(() => client.execute(createSql));
       await addColumnIfMissing("platform", "TEXT");
       await addColumnIfMissing("app_version", "TEXT");
       await addColumnIfMissing("host_name", "TEXT");

--- a/packages/core/src/integrations/remote-push-store.ts
+++ b/packages/core/src/integrations/remote-push-store.ts
@@ -1,4 +1,10 @@
-import { getDbExec, intType, retryOnDdlRace } from "../db/client.js";
+import {
+  getDbExec,
+  isPostgres,
+  intType,
+  retryOnDdlRace,
+} from "../db/client.js";
+import { ensureTableExists, ensureIndexExists } from "../db/ddl-guard.js";
 import type {
   PublicRemotePushRegistration,
   RemotePushNotification,
@@ -7,29 +13,77 @@ import type {
 
 let _initPromise: Promise<void> | undefined;
 
+// Build the CREATE SQL lazily (not at module scope) so intType() runs at
+// RUNTIME, not import time — a module-scope call breaks any consumer whose
+// db/client mock doesn't stub intType (e.g. db-admin specs).
+function buildCreateRegistrationsSql(): string {
+  return `
+  CREATE TABLE IF NOT EXISTS integration_remote_push_registrations (
+    id TEXT PRIMARY KEY,
+    owner_email TEXT NOT NULL,
+    org_id TEXT,
+    provider TEXT NOT NULL,
+    platform TEXT,
+    client_device_id TEXT,
+    label TEXT,
+    token TEXT NOT NULL,
+    token_hash TEXT NOT NULL,
+    status TEXT NOT NULL,
+    last_seen_at ${intType()},
+    created_at ${intType()} NOT NULL,
+    updated_at ${intType()} NOT NULL
+  )
+`;
+}
+
+function buildCreateNotificationsSql(): string {
+  return `
+  CREATE TABLE IF NOT EXISTS integration_remote_push_notifications (
+    id TEXT PRIMARY KEY,
+    owner_email TEXT NOT NULL,
+    org_id TEXT,
+    registration_id TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    status TEXT NOT NULL,
+    attempts ${intType()} NOT NULL DEFAULT 0,
+    created_at ${intType()} NOT NULL,
+    updated_at ${intType()} NOT NULL
+  )
+`;
+}
+
 async function ensureTables(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await retryOnDdlRace(() =>
-        client.execute(`
-          CREATE TABLE IF NOT EXISTS integration_remote_push_registrations (
-            id TEXT PRIMARY KEY,
-            owner_email TEXT NOT NULL,
-            org_id TEXT,
-            provider TEXT NOT NULL,
-            platform TEXT,
-            client_device_id TEXT,
-            label TEXT,
-            token TEXT NOT NULL,
-            token_hash TEXT NOT NULL,
-            status TEXT NOT NULL,
-            last_seen_at ${intType()},
-            created_at ${intType()} NOT NULL,
-            updated_at ${intType()} NOT NULL
-          )
-        `),
-      );
+      const createRegistrationsSql = buildCreateRegistrationsSql();
+      const createNotificationsSql = buildCreateNotificationsSql();
+      if (isPostgres()) {
+        // PG guard: probe via information_schema, only issue DDL if missing, bounded lock_timeout
+        await ensureTableExists(
+          "integration_remote_push_registrations",
+          createRegistrationsSql,
+        );
+        await ensureIndexExists(
+          "idx_remote_push_token_hash",
+          `CREATE UNIQUE INDEX IF NOT EXISTS idx_remote_push_token_hash ON integration_remote_push_registrations(token_hash)`,
+        );
+        await ensureIndexExists(
+          "idx_remote_push_owner",
+          `CREATE INDEX IF NOT EXISTS idx_remote_push_owner ON integration_remote_push_registrations(owner_email, org_id, status)`,
+        );
+        await ensureTableExists(
+          "integration_remote_push_notifications",
+          createNotificationsSql,
+        );
+        await ensureIndexExists(
+          "idx_remote_push_notifications_owner",
+          `CREATE INDEX IF NOT EXISTS idx_remote_push_notifications_owner ON integration_remote_push_notifications(owner_email, org_id, status, created_at)`,
+        );
+        return;
+      }
+      // SQLite (local dev): keep existing behavior
+      await retryOnDdlRace(() => client.execute(createRegistrationsSql));
       await retryOnDdlRace(() =>
         client.execute(
           `CREATE UNIQUE INDEX IF NOT EXISTS idx_remote_push_token_hash ON integration_remote_push_registrations(token_hash)`,
@@ -41,21 +95,7 @@ async function ensureTables(): Promise<void> {
         ),
       );
 
-      await retryOnDdlRace(() =>
-        client.execute(`
-          CREATE TABLE IF NOT EXISTS integration_remote_push_notifications (
-            id TEXT PRIMARY KEY,
-            owner_email TEXT NOT NULL,
-            org_id TEXT,
-            registration_id TEXT NOT NULL,
-            payload_json TEXT NOT NULL,
-            status TEXT NOT NULL,
-            attempts ${intType()} NOT NULL DEFAULT 0,
-            created_at ${intType()} NOT NULL,
-            updated_at ${intType()} NOT NULL
-          )
-        `),
-      );
+      await retryOnDdlRace(() => client.execute(createNotificationsSql));
       await retryOnDdlRace(() =>
         client.execute(
           `CREATE INDEX IF NOT EXISTS idx_remote_push_notifications_owner ON integration_remote_push_notifications(owner_email, org_id, status, created_at)`,

--- a/packages/core/src/integrations/remote-run-events-store.ts
+++ b/packages/core/src/integrations/remote-run-events-store.ts
@@ -1,23 +1,49 @@
-import { getDbExec, intType, retryOnDdlRace } from "../db/client.js";
+import {
+  getDbExec,
+  isPostgres,
+  intType,
+  retryOnDdlRace,
+} from "../db/client.js";
+import { ensureTableExists, ensureIndexExists } from "../db/ddl-guard.js";
 import type { RemoteRunEvent } from "./remote-types.js";
 
 let _initPromise: Promise<void> | undefined;
+
+// Build the CREATE SQL lazily (not at module scope) so intType() runs at
+// RUNTIME, not import time — a module-scope call breaks any consumer whose
+// db/client mock doesn't stub intType (e.g. db-admin specs).
+function buildCreateSql(): string {
+  return `
+  CREATE TABLE IF NOT EXISTS integration_remote_run_events (
+    device_id TEXT NOT NULL,
+    remote_run_id TEXT NOT NULL,
+    seq ${intType()} NOT NULL,
+    event_json TEXT NOT NULL,
+    created_at ${intType()} NOT NULL
+  )
+`;
+}
 
 async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await retryOnDdlRace(() =>
-        client.execute(`
-          CREATE TABLE IF NOT EXISTS integration_remote_run_events (
-            device_id TEXT NOT NULL,
-            remote_run_id TEXT NOT NULL,
-            seq ${intType()} NOT NULL,
-            event_json TEXT NOT NULL,
-            created_at ${intType()} NOT NULL
-          )
-        `),
-      );
+      const createSql = buildCreateSql();
+      if (isPostgres()) {
+        // PG guard: probe via information_schema, only issue DDL if missing, bounded lock_timeout
+        await ensureTableExists("integration_remote_run_events", createSql);
+        await ensureIndexExists(
+          "idx_remote_run_events_unique",
+          `CREATE UNIQUE INDEX IF NOT EXISTS idx_remote_run_events_unique ON integration_remote_run_events(device_id, remote_run_id, seq)`,
+        );
+        await ensureIndexExists(
+          "idx_remote_run_events_run",
+          `CREATE INDEX IF NOT EXISTS idx_remote_run_events_run ON integration_remote_run_events(device_id, remote_run_id, seq)`,
+        );
+        return;
+      }
+      // SQLite (local dev): keep existing behavior
+      await retryOnDdlRace(() => client.execute(createSql));
       await retryOnDdlRace(() =>
         client.execute(
           `CREATE UNIQUE INDEX IF NOT EXISTS idx_remote_run_events_unique ON integration_remote_run_events(device_id, remote_run_id, seq)`,

--- a/packages/core/src/integrations/thread-mapping-store.ts
+++ b/packages/core/src/integrations/thread-mapping-store.ts
@@ -1,4 +1,5 @@
 import { getDbExec, isPostgres, intType } from "../db/client.js";
+import { ensureTableExists } from "../db/ddl-guard.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -6,7 +7,7 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await client.execute(`
+      const createSql = `
         CREATE TABLE IF NOT EXISTS integration_thread_mappings (
           platform TEXT NOT NULL,
           external_thread_id TEXT NOT NULL,
@@ -16,7 +17,15 @@ async function ensureTable(): Promise<void> {
           updated_at ${intType()} NOT NULL,
           PRIMARY KEY (platform, external_thread_id)
         )
-      `);
+      `;
+
+      if (isPostgres()) {
+        // PG guard: probe via information_schema, only issue DDL if missing, bounded lock_timeout
+        await ensureTableExists("integration_thread_mappings", createSql);
+        return;
+      }
+      // SQLite (local dev): keep existing behavior
+      await client.execute(createSql);
     })().catch((err) => {
       // Retry init on the next call after a failed startup.
       _initPromise = undefined;

--- a/packages/core/src/mcp/connect-store.ts
+++ b/packages/core/src/mcp/connect-store.ts
@@ -19,7 +19,13 @@
 
 import { randomBytes, randomUUID } from "node:crypto";
 
-import { getDbExec, isConnectionError, intType } from "../db/client.js";
+import {
+  getDbExec,
+  isConnectionError,
+  intType,
+  isPostgres,
+} from "../db/client.js";
+import { ensureTableExists, ensureColumnExists } from "../db/ddl-guard.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -59,7 +65,7 @@ async function ensureTable(): Promise<void> {
       const client = getDbExec();
       // Additive only. Never DROP / ALTER — this DB is shared across every
       // deploy context (preview/branch/prod) for hosted templates.
-      await client.execute(`
+      const createTokensSql = `
         CREATE TABLE IF NOT EXISTS mcp_connect_tokens (
           id TEXT PRIMARY KEY,
           jti TEXT UNIQUE NOT NULL,
@@ -73,7 +79,50 @@ async function ensureTable(): Promise<void> {
           last_used_at ${intType()},
           revoked_at ${intType()}
         )
-      `);
+      `;
+      const createDeviceCodesSql = `
+        CREATE TABLE IF NOT EXISTS mcp_device_codes (
+          device_code TEXT PRIMARY KEY,
+          user_code TEXT NOT NULL,
+          owner_email TEXT,
+          org_id TEXT,
+          status TEXT NOT NULL DEFAULT 'pending',
+          token_jti TEXT,
+          created_at ${intType()},
+          expires_at ${intType()},
+          consumed_at ${intType()}
+        )
+      `;
+
+      if (isPostgres()) {
+        // PG-guard: probe information_schema first (no lock) and only issue
+        // DDL when the table/column is actually missing, wrapped in a
+        // transaction-scoped lock_timeout so a contended lock fails fast.
+        await ensureTableExists("mcp_connect_tokens", createTokensSql);
+        // Additive columns for org service tokens — added after initial
+        // deployment; ensureColumnExists probes before ALTERing.
+        await ensureColumnExists(
+          "mcp_connect_tokens",
+          "kind",
+          `ALTER TABLE mcp_connect_tokens ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'personal'`,
+        );
+        await ensureColumnExists(
+          "mcp_connect_tokens",
+          "service_name",
+          `ALTER TABLE mcp_connect_tokens ADD COLUMN IF NOT EXISTS service_name TEXT`,
+        );
+        await ensureColumnExists(
+          "mcp_connect_tokens",
+          "created_by",
+          `ALTER TABLE mcp_connect_tokens ADD COLUMN IF NOT EXISTS created_by TEXT`,
+        );
+        await ensureTableExists("mcp_device_codes", createDeviceCodesSql);
+        return;
+      }
+
+      // SQLite (local dev): no ACCESS EXCLUSIVE lock problem — keep existing
+      // create-then-additive-alter behaviour.
+      await client.execute(createTokensSql);
       // Additive columns for org service tokens (deployments that created the
       // table before these columns existed; fresh DBs get them via the CREATE
       // TABLE above). kind='personal' (default) preserves the original
@@ -107,19 +156,7 @@ async function ensureTable(): Promise<void> {
           }
         }
       }
-      await client.execute(`
-        CREATE TABLE IF NOT EXISTS mcp_device_codes (
-          device_code TEXT PRIMARY KEY,
-          user_code TEXT NOT NULL,
-          owner_email TEXT,
-          org_id TEXT,
-          status TEXT NOT NULL DEFAULT 'pending',
-          token_jti TEXT,
-          created_at ${intType()},
-          expires_at ${intType()},
-          consumed_at ${intType()}
-        )
-      `);
+      await client.execute(createDeviceCodesSql);
     })().catch((err) => {
       // Don't cache a rejected init. A transient DB blip should let the next
       // connect/mint/revoke call retry rather than wedging the process.

--- a/packages/core/src/mcp/oauth-store.spec.ts
+++ b/packages/core/src/mcp/oauth-store.spec.ts
@@ -46,6 +46,7 @@ vi.mock("../db/client.js", () => ({
   getDbExec: () => exec,
   isConnectionError: (err: any) => err?.message === "CONNECTION_LOST",
   intType: () => "INTEGER",
+  isPostgres: () => false,
 }));
 
 beforeEach(() => {

--- a/packages/core/src/mcp/oauth-store.ts
+++ b/packages/core/src/mcp/oauth-store.ts
@@ -8,7 +8,13 @@
 
 import { randomBytes, randomUUID, createHash } from "node:crypto";
 
-import { getDbExec, isConnectionError, intType } from "../db/client.js";
+import {
+  getDbExec,
+  isConnectionError,
+  intType,
+  isPostgres,
+} from "../db/client.js";
+import { ensureTableExists } from "../db/ddl-guard.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -79,7 +85,7 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await client.execute(`
+      const createClientsSql = `
         CREATE TABLE IF NOT EXISTS mcp_oauth_clients (
           client_id TEXT PRIMARY KEY,
           client_name TEXT,
@@ -89,8 +95,8 @@ async function ensureTable(): Promise<void> {
           token_endpoint_auth_method TEXT,
           created_at ${intType()}
         )
-      `);
-      await client.execute(`
+      `;
+      const createCodesSql = `
         CREATE TABLE IF NOT EXISTS mcp_oauth_codes (
           code TEXT PRIMARY KEY,
           client_id TEXT NOT NULL,
@@ -106,8 +112,8 @@ async function ensureTable(): Promise<void> {
           expires_at ${intType()},
           consumed_at ${intType()}
         )
-      `);
-      await client.execute(`
+      `;
+      const createRefreshTokensSql = `
         CREATE TABLE IF NOT EXISTS mcp_oauth_refresh_tokens (
           id TEXT PRIMARY KEY,
           token_hash TEXT UNIQUE NOT NULL,
@@ -123,7 +129,26 @@ async function ensureTable(): Promise<void> {
           revoked_at ${intType()},
           replaced_by_hash TEXT
         )
-      `);
+      `;
+
+      if (isPostgres()) {
+        // PG-guard: probe information_schema first (no lock) and only issue
+        // DDL when the table is actually missing, wrapped in a
+        // transaction-scoped lock_timeout so a contended lock fails fast.
+        await ensureTableExists("mcp_oauth_clients", createClientsSql);
+        await ensureTableExists("mcp_oauth_codes", createCodesSql);
+        await ensureTableExists(
+          "mcp_oauth_refresh_tokens",
+          createRefreshTokensSql,
+        );
+        return;
+      }
+
+      // SQLite (local dev): no ACCESS EXCLUSIVE lock problem — keep existing
+      // create-then-execute behaviour.
+      await client.execute(createClientsSql);
+      await client.execute(createCodesSql);
+      await client.execute(createRefreshTokensSql);
     })().catch((err) => {
       _initPromise = undefined;
       throw err;

--- a/packages/core/src/notifications/store.spec.ts
+++ b/packages/core/src/notifications/store.spec.ts
@@ -27,6 +27,7 @@ const recordChange = vi.fn();
 vi.mock("../db/client.js", () => ({
   getDbExec: () => rawClient,
   intType: () => "INTEGER",
+  isPostgres: () => false,
   retryOnDdlRace: <T>(fn: () => Promise<T>) => fn(),
   safeJsonParse: (value: unknown, fallback: unknown) => {
     if (value == null) return fallback;

--- a/packages/core/src/notifications/store.ts
+++ b/packages/core/src/notifications/store.ts
@@ -3,9 +3,11 @@ import { randomUUID } from "node:crypto";
 import {
   getDbExec,
   intType,
+  isPostgres,
   retryOnDdlRace,
   safeJsonParse,
 } from "../db/client.js";
+import { ensureIndexExists, ensureTableExists } from "../db/ddl-guard.js";
 import { recordChange } from "../server/poll.js";
 import type { Notification, NotificationSeverity } from "./types.js";
 
@@ -24,8 +26,7 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await retryOnDdlRace(() =>
-        client.execute(`
+      const createSql = `
           CREATE TABLE IF NOT EXISTS notifications (
             id TEXT PRIMARY KEY,
             owner TEXT NOT NULL,
@@ -37,8 +38,23 @@ async function ensureTable(): Promise<void> {
             created_at ${intType()} NOT NULL,
             read_at ${intType()}
           )
-        `),
-      );
+        `;
+
+      if (isPostgres()) {
+        // PG-guard: probe information_schema / pg_indexes first (no lock) and
+        // only issue DDL when the table/index is actually missing, wrapped in
+        // a transaction-scoped lock_timeout so a contended lock fails fast.
+        await ensureTableExists("notifications", createSql);
+        await ensureIndexExists(
+          "idx_notifications_owner_unread",
+          `CREATE INDEX IF NOT EXISTS idx_notifications_owner_unread ON notifications (owner, read_at)`,
+        );
+        return;
+      }
+
+      // SQLite (local dev): no ACCESS EXCLUSIVE lock problem — keep existing
+      // retryOnDdlRace behaviour.
+      await retryOnDdlRace(() => client.execute(createSql));
       await retryOnDdlRace(() =>
         client.execute(
           `CREATE INDEX IF NOT EXISTS idx_notifications_owner_unread ON notifications (owner, read_at)`,

--- a/packages/core/src/oauth-tokens/store.ts
+++ b/packages/core/src/oauth-tokens/store.ts
@@ -1,4 +1,5 @@
 import { getDbExec, isPostgres, intType } from "../db/client.js";
+import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
 import {
   encryptSecretValue,
@@ -54,7 +55,7 @@ async function ensureTable(): Promise<void> {
     _initPromise = (async () => {
       const client = getDbExec();
       const table = oauthTokensTable();
-      await client.execute(`
+      const createSql = `
         CREATE TABLE IF NOT EXISTS ${table} (
           provider TEXT NOT NULL,
           account_id TEXT NOT NULL,
@@ -63,7 +64,49 @@ async function ensureTable(): Promise<void> {
           updated_at ${intType()} NOT NULL,
           PRIMARY KEY (provider, account_id)
         )
-      `);
+      `;
+
+      if (isPostgres()) {
+        // Hot path: the `oauth_tokens` table and its additive columns are
+        // virtually always already present in production. Issuing `CREATE
+        // TABLE`/`ALTER TABLE` still takes an ACCESS EXCLUSIVE lock that, in a
+        // fresh background-worker process behind a concurrent connection on the
+        // shared Neon DB, can block ~indefinitely. The ensure* wrappers probe
+        // `information_schema` first (plain reads, no lock) and run DDL ONLY for
+        // what is actually missing, bounded by a transaction-scoped
+        // `lock_timeout`. If a swallowed lock-timeout leaves the schema still
+        // missing they RE-PROBE and THROW rather than letting init memoize
+        // success against absent schema. `oauthTokensTable()` is
+        // `public.oauth_tokens` on Postgres; the wrappers take the unqualified
+        // table name.
+        await ensureTableExists("oauth_tokens", createSql);
+        // Migration: add owner column to existing tables — guarded so the hot
+        // path (column already present) skips the ACCESS EXCLUSIVE ALTER.
+        await ensureColumnExists(
+          "oauth_tokens",
+          "owner",
+          `ALTER TABLE ${table} ADD COLUMN IF NOT EXISTS owner TEXT`,
+        );
+        // Migration: add display_name column
+        await ensureColumnExists(
+          "oauth_tokens",
+          "display_name",
+          `ALTER TABLE ${table} ADD COLUMN IF NOT EXISTS display_name TEXT`,
+        );
+        // Backfill: set owner = account_id for existing rows without an owner
+        await client.execute(
+          `UPDATE ${table} SET owner = account_id WHERE owner IS NULL`,
+        );
+        // Older deployments have a 32-bit `updated_at`; on Postgres the
+        // `Date.now()` written on every token save overflows int4. Widen in place
+        // (no-op once done / on fresh DBs). Unqualified name — the helper scopes
+        // to the `public` schema.
+        await widenIntColumnsToBigInt("oauth_tokens", ["updated_at"]);
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      await client.execute(createSql);
       // Migration: add owner column to existing tables
       try {
         await client.execute(`ALTER TABLE ${table} ADD COLUMN owner TEXT`);

--- a/packages/core/src/observability/store.ts
+++ b/packages/core/src/observability/store.ts
@@ -12,6 +12,11 @@ import {
   isPostgres,
   retryOnDdlRace,
 } from "../db/client.js";
+import {
+  ensureTableExists,
+  ensureColumnExists,
+  ensureIndexExists,
+} from "../db/ddl-guard.js";
 import { isDuplicateColumnError } from "../db/migrations.js";
 import type {
   TraceSpan,
@@ -70,8 +75,7 @@ export async function ensureObservabilityTables(): Promise<void> {
     _initPromise = (async () => {
       const client = getDbExec();
 
-      await retryOnDdlRace(() =>
-        client.execute(`
+      const traceSpansCreateSql = `
         CREATE TABLE IF NOT EXISTS agent_trace_spans (
           id TEXT PRIMARY KEY,
           run_id TEXT NOT NULL,
@@ -91,11 +95,9 @@ export async function ensureObservabilityTables(): Promise<void> {
           metadata TEXT,
           created_at ${intType()} NOT NULL
         )
-      `),
-      );
+      `;
 
-      await retryOnDdlRace(() =>
-        client.execute(`
+      const traceSummariesCreateSql = `
         CREATE TABLE IF NOT EXISTS agent_trace_summaries (
           run_id TEXT PRIMARY KEY,
           thread_id TEXT,
@@ -112,11 +114,9 @@ export async function ensureObservabilityTables(): Promise<void> {
           model TEXT NOT NULL DEFAULT '',
           created_at ${intType()} NOT NULL
         )
-      `),
-      );
+      `;
 
-      await retryOnDdlRace(() =>
-        client.execute(`
+      const feedbackCreateSql = `
         CREATE TABLE IF NOT EXISTS agent_feedback (
           id TEXT PRIMARY KEY,
           run_id TEXT,
@@ -127,11 +127,9 @@ export async function ensureObservabilityTables(): Promise<void> {
           user_id TEXT,
           created_at ${intType()} NOT NULL
         )
-      `),
-      );
+      `;
 
-      await retryOnDdlRace(() =>
-        client.execute(`
+      const satisfactionScoresCreateSql = `
         CREATE TABLE IF NOT EXISTS agent_satisfaction_scores (
           id TEXT PRIMARY KEY,
           thread_id TEXT NOT NULL,
@@ -143,11 +141,9 @@ export async function ensureObservabilityTables(): Promise<void> {
           length_trend_score REAL NOT NULL DEFAULT 0,
           computed_at ${intType()} NOT NULL
         )
-      `),
-      );
+      `;
 
-      await retryOnDdlRace(() =>
-        client.execute(`
+      const evalsCreateSql = `
         CREATE TABLE IF NOT EXISTS agent_evals (
           id TEXT PRIMARY KEY,
           run_id TEXT NOT NULL,
@@ -160,11 +156,9 @@ export async function ensureObservabilityTables(): Promise<void> {
           metadata TEXT,
           created_at ${intType()} NOT NULL
         )
-      `),
-      );
+      `;
 
-      await retryOnDdlRace(() =>
-        client.execute(`
+      const evalDatasetsCreateSql = `
         CREATE TABLE IF NOT EXISTS agent_eval_datasets (
           id TEXT PRIMARY KEY,
           name TEXT NOT NULL,
@@ -173,11 +167,9 @@ export async function ensureObservabilityTables(): Promise<void> {
           created_at ${intType()} NOT NULL,
           updated_at ${intType()} NOT NULL
         )
-      `),
-      );
+      `;
 
-      await retryOnDdlRace(() =>
-        client.execute(`
+      const experimentsCreateSql = `
         CREATE TABLE IF NOT EXISTS agent_experiments (
           id TEXT PRIMARY KEY,
           name TEXT NOT NULL,
@@ -190,8 +182,145 @@ export async function ensureObservabilityTables(): Promise<void> {
           created_at ${intType()} NOT NULL,
           owner_email TEXT
         )
-      `),
-      );
+      `;
+
+      const experimentAssignmentsCreateSql = `
+        CREATE TABLE IF NOT EXISTS agent_experiment_assignments (
+          experiment_id TEXT NOT NULL,
+          user_id TEXT NOT NULL,
+          variant_id TEXT NOT NULL,
+          assigned_at ${intType()} NOT NULL,
+          PRIMARY KEY (experiment_id, user_id)
+        )
+      `;
+
+      const experimentResultsCreateSql = `
+        CREATE TABLE IF NOT EXISTS agent_experiment_results (
+          id TEXT PRIMARY KEY,
+          experiment_id TEXT NOT NULL,
+          variant_id TEXT NOT NULL,
+          metric TEXT NOT NULL,
+          value REAL NOT NULL DEFAULT 0,
+          sample_size ${intType()} NOT NULL DEFAULT 0,
+          confidence_low REAL NOT NULL DEFAULT 0,
+          confidence_high REAL NOT NULL DEFAULT 0,
+          computed_at ${intType()} NOT NULL
+        )
+      `;
+
+      if (isPostgres()) {
+        // PG guard: probe → guarded DDL → re-probe; skips lock on already-migrated path
+        await ensureTableExists("agent_trace_spans", traceSpansCreateSql);
+        await ensureTableExists(
+          "agent_trace_summaries",
+          traceSummariesCreateSql,
+        );
+        await ensureTableExists("agent_feedback", feedbackCreateSql);
+        await ensureTableExists(
+          "agent_satisfaction_scores",
+          satisfactionScoresCreateSql,
+        );
+        await ensureTableExists("agent_evals", evalsCreateSql);
+        await ensureTableExists("agent_eval_datasets", evalDatasetsCreateSql);
+        await ensureTableExists("agent_experiments", experimentsCreateSql);
+        await ensureTableExists(
+          "agent_experiment_assignments",
+          experimentAssignmentsCreateSql,
+        );
+        await ensureTableExists(
+          "agent_experiment_results",
+          experimentResultsCreateSql,
+        );
+        await ensureColumnExists(
+          "agent_experiments",
+          "owner_email",
+          `ALTER TABLE agent_experiments ADD COLUMN IF NOT EXISTS owner_email TEXT`,
+        );
+        for (const table of USER_SCOPED_TABLES) {
+          await ensureColumnExists(
+            table,
+            "user_id",
+            `ALTER TABLE ${table} ADD COLUMN IF NOT EXISTS user_id TEXT`,
+          );
+        }
+        await ensureIndexExists(
+          "idx_trace_spans_run",
+          `CREATE INDEX IF NOT EXISTS idx_trace_spans_run ON agent_trace_spans (run_id)`,
+        );
+        await ensureIndexExists(
+          "idx_trace_spans_thread",
+          `CREATE INDEX IF NOT EXISTS idx_trace_spans_thread ON agent_trace_spans (thread_id)`,
+        );
+        await ensureIndexExists(
+          "idx_trace_spans_created",
+          `CREATE INDEX IF NOT EXISTS idx_trace_spans_created ON agent_trace_spans (created_at)`,
+        );
+        await ensureIndexExists(
+          "idx_trace_summaries_created",
+          `CREATE INDEX IF NOT EXISTS idx_trace_summaries_created ON agent_trace_summaries (created_at)`,
+        );
+        await ensureIndexExists(
+          "idx_trace_summaries_user",
+          `CREATE INDEX IF NOT EXISTS idx_trace_summaries_user ON agent_trace_summaries (user_id, created_at)`,
+        );
+        await ensureIndexExists(
+          "idx_trace_spans_user",
+          `CREATE INDEX IF NOT EXISTS idx_trace_spans_user ON agent_trace_spans (user_id)`,
+        );
+        await ensureIndexExists(
+          "idx_feedback_thread",
+          `CREATE INDEX IF NOT EXISTS idx_feedback_thread ON agent_feedback (thread_id)`,
+        );
+        await ensureIndexExists(
+          "idx_feedback_created",
+          `CREATE INDEX IF NOT EXISTS idx_feedback_created ON agent_feedback (created_at)`,
+        );
+        await ensureIndexExists(
+          "idx_feedback_user",
+          `CREATE INDEX IF NOT EXISTS idx_feedback_user ON agent_feedback (user_id, created_at)`,
+        );
+        await ensureIndexExists(
+          "idx_satisfaction_thread",
+          `CREATE INDEX IF NOT EXISTS idx_satisfaction_thread ON agent_satisfaction_scores (thread_id)`,
+        );
+        await ensureIndexExists(
+          "idx_satisfaction_user",
+          `CREATE INDEX IF NOT EXISTS idx_satisfaction_user ON agent_satisfaction_scores (user_id, computed_at)`,
+        );
+        await ensureIndexExists(
+          "idx_evals_run",
+          `CREATE INDEX IF NOT EXISTS idx_evals_run ON agent_evals (run_id)`,
+        );
+        await ensureIndexExists(
+          "idx_evals_created",
+          `CREATE INDEX IF NOT EXISTS idx_evals_created ON agent_evals (created_at)`,
+        );
+        await ensureIndexExists(
+          "idx_evals_user",
+          `CREATE INDEX IF NOT EXISTS idx_evals_user ON agent_evals (user_id, created_at)`,
+        );
+        await ensureIndexExists(
+          "idx_experiment_results_exp",
+          `CREATE INDEX IF NOT EXISTS idx_experiment_results_exp ON agent_experiment_results (experiment_id)`,
+        );
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      await retryOnDdlRace(() => client.execute(traceSpansCreateSql));
+
+      await retryOnDdlRace(() => client.execute(traceSummariesCreateSql));
+
+      await retryOnDdlRace(() => client.execute(feedbackCreateSql));
+
+      await retryOnDdlRace(() => client.execute(satisfactionScoresCreateSql));
+
+      await retryOnDdlRace(() => client.execute(evalsCreateSql));
+
+      await retryOnDdlRace(() => client.execute(evalDatasetsCreateSql));
+
+      await retryOnDdlRace(() => client.execute(experimentsCreateSql));
+
       // Additive migration for DBs created before the owner column shipped
       // (any pre-existing rows have NULL owner — see `updateExperiment` for
       // the migration semantics). Mutations on those rows fall back to the
@@ -206,32 +335,10 @@ export async function ensureObservabilityTables(): Promise<void> {
       }
 
       await retryOnDdlRace(() =>
-        client.execute(`
-        CREATE TABLE IF NOT EXISTS agent_experiment_assignments (
-          experiment_id TEXT NOT NULL,
-          user_id TEXT NOT NULL,
-          variant_id TEXT NOT NULL,
-          assigned_at ${intType()} NOT NULL,
-          PRIMARY KEY (experiment_id, user_id)
-        )
-      `),
+        client.execute(experimentAssignmentsCreateSql),
       );
 
-      await retryOnDdlRace(() =>
-        client.execute(`
-        CREATE TABLE IF NOT EXISTS agent_experiment_results (
-          id TEXT PRIMARY KEY,
-          experiment_id TEXT NOT NULL,
-          variant_id TEXT NOT NULL,
-          metric TEXT NOT NULL,
-          value REAL NOT NULL DEFAULT 0,
-          sample_size ${intType()} NOT NULL DEFAULT 0,
-          confidence_low REAL NOT NULL DEFAULT 0,
-          confidence_high REAL NOT NULL DEFAULT 0,
-          computed_at ${intType()} NOT NULL
-        )
-      `),
-      );
+      await retryOnDdlRace(() => client.execute(experimentResultsCreateSql));
 
       // Idempotent column upgrades for DBs created before per-user
       // isolation. SQLite has no `ADD COLUMN IF NOT EXISTS`; Postgres

--- a/packages/core/src/progress/store.spec.ts
+++ b/packages/core/src/progress/store.spec.ts
@@ -23,6 +23,7 @@ const mockDb = {
 vi.mock("../db/client.js", () => ({
   getDbExec: () => mockDb,
   intType: () => "INTEGER",
+  isPostgres: () => false,
   isUniqueViolation: () => false,
   retryOnDdlRace: (fn: () => unknown) => fn(),
   safeJsonParse: (value: string, fallback: unknown) => {

--- a/packages/core/src/progress/store.ts
+++ b/packages/core/src/progress/store.ts
@@ -3,10 +3,11 @@ import { randomUUID } from "node:crypto";
 import {
   getDbExec,
   intType,
+  isPostgres,
   isUniqueViolation,
-  retryOnDdlRace,
   safeJsonParse,
 } from "../db/client.js";
+import { ensureIndexExists, ensureTableExists } from "../db/ddl-guard.js";
 import { recordChange } from "../server/poll.js";
 import type {
   AgentRun,
@@ -42,32 +43,46 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await retryOnDdlRace(() =>
-        client.execute(`
-          CREATE TABLE IF NOT EXISTS progress_runs (
-            id TEXT PRIMARY KEY,
-            owner TEXT NOT NULL,
-            title TEXT NOT NULL,
-            step TEXT,
-            percent ${intType()},
-            status TEXT NOT NULL DEFAULT 'running',
-            metadata TEXT,
-            started_at ${intType()} NOT NULL,
-            updated_at ${intType()} NOT NULL,
-            completed_at ${intType()}
-          )
-        `),
-      );
-      await retryOnDdlRace(() =>
-        client.execute(
+      const createSql = `
+        CREATE TABLE IF NOT EXISTS progress_runs (
+          id TEXT PRIMARY KEY,
+          owner TEXT NOT NULL,
+          title TEXT NOT NULL,
+          step TEXT,
+          percent ${intType()},
+          status TEXT NOT NULL DEFAULT 'running',
+          metadata TEXT,
+          started_at ${intType()} NOT NULL,
+          updated_at ${intType()} NOT NULL,
+          completed_at ${intType()}
+        )
+      `;
+
+      if (isPostgres()) {
+        // PG-guard: probe information_schema / pg_indexes before issuing DDL to
+        // avoid ACCESS EXCLUSIVE lock contention in fresh background-worker processes.
+        await ensureTableExists("progress_runs", createSql);
+        await ensureIndexExists(
+          "idx_progress_runs_owner_status",
           `CREATE INDEX IF NOT EXISTS idx_progress_runs_owner_status ON progress_runs (owner, status, started_at)`,
-        ),
-      );
+        );
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
       // NOTE: table name is `progress_runs` (not `agent_runs`) to avoid
       // colliding with core's existing agent/run-store.ts which uses
       // `agent_runs` for agent-chat turn lifecycle tracking. These are
       // separate concerns — progress = user-facing task status, agent_runs =
       // internal chat turn bookkeeping.
+      await client.execute(createSql);
+      try {
+        await client.execute(
+          `CREATE INDEX IF NOT EXISTS idx_progress_runs_owner_status ON progress_runs (owner, status, started_at)`,
+        );
+      } catch {
+        // Index already exists or the dialect rejected a duplicate.
+      }
     })().catch((err) => {
       // Reset on failure so a transient DB outage doesn't poison the cached
       // promise and reject every future insert/update call for the lifetime

--- a/packages/core/src/provider-api/corpus-jobs-store.ts
+++ b/packages/core/src/provider-api/corpus-jobs-store.ts
@@ -8,6 +8,7 @@
  */
 
 import { getDbExec, intType, isPostgres, type DbExec } from "../db/client.js";
+import { ensureTableExists, ensureIndexExists } from "../db/ddl-guard.js";
 
 export type ProviderCorpusJobStatus =
   | "running"
@@ -81,7 +82,7 @@ async function ensureTables(): Promise<void> {
     initPromise = (async () => {
       const db = getDbExec();
       const integerType = intType();
-      await db.execute(`
+      const createJobsSql = `
         CREATE TABLE IF NOT EXISTS provider_corpus_jobs (
           id TEXT NOT NULL,
           app_id TEXT NOT NULL,
@@ -108,18 +109,37 @@ async function ensureTables(): Promise<void> {
           updated_at ${integerType} NOT NULL,
           PRIMARY KEY (id)
         )
-      `);
-      await db.execute(`
+      `;
+      const createHitsSql = `
         CREATE TABLE IF NOT EXISTS provider_corpus_job_hits (
           job_id TEXT NOT NULL,
           hit_index ${integerType} NOT NULL,
           hit_data TEXT NOT NULL,
           PRIMARY KEY (job_id, hit_index)
         )
-      `);
+      `;
       if (isPostgres()) {
-        await widenPostgresIntegerColumns(db);
+        // PG guard: probe via information_schema, only issue DDL if missing, bounded lock_timeout
+        await ensureTableExists("provider_corpus_jobs", createJobsSql);
+        await ensureTableExists("provider_corpus_job_hits", createHitsSql);
+        await widenPostgresIntegerColumns(db); // best-effort type widening — unchanged
+        await ensureIndexExists(
+          "provider_corpus_jobs_scope_idx",
+          `CREATE INDEX IF NOT EXISTS provider_corpus_jobs_scope_idx ON provider_corpus_jobs (app_id, owner_email, updated_at)`,
+        );
+        await ensureIndexExists(
+          "provider_corpus_jobs_status_idx",
+          `CREATE INDEX IF NOT EXISTS provider_corpus_jobs_status_idx ON provider_corpus_jobs (app_id, owner_email, status)`,
+        );
+        await ensureIndexExists(
+          "provider_corpus_job_hits_job_idx",
+          `CREATE INDEX IF NOT EXISTS provider_corpus_job_hits_job_idx ON provider_corpus_job_hits (job_id)`,
+        );
+        return;
       }
+      // SQLite (local dev): keep existing behavior
+      await db.execute(createJobsSql);
+      await db.execute(createHitsSql);
       for (const ddl of [
         `CREATE INDEX IF NOT EXISTS provider_corpus_jobs_scope_idx ON provider_corpus_jobs (app_id, owner_email, updated_at)`,
         `CREATE INDEX IF NOT EXISTS provider_corpus_jobs_status_idx ON provider_corpus_jobs (app_id, owner_email, status)`,

--- a/packages/core/src/provider-api/custom-registry.ts
+++ b/packages/core/src/provider-api/custom-registry.ts
@@ -21,6 +21,7 @@
  */
 
 import { getDbExec, isPostgres } from "../db/client.js";
+import { ensureTableExists } from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
 import { isBlockedExtensionUrlWithDns } from "../extensions/url-safety.js";
 
@@ -91,10 +92,20 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      const sql = isPostgres()
-        ? CREATE_SQL.replace(/\bINTEGER\b/g, "BIGINT")
-        : CREATE_SQL;
-      await client.execute(sql);
+
+      if (isPostgres()) {
+        const pgSql = CREATE_SQL.replace(/\bINTEGER\b/g, "BIGINT");
+        // PG guard: probe via information_schema, only issue DDL if missing, bounded lock_timeout
+        await ensureTableExists("custom_api_providers", pgSql);
+        // Widen any pre-existing int4 timestamp columns to BIGINT (no-op once done)
+        await widenIntColumnsToBigInt("custom_api_providers", [
+          "created_at",
+          "updated_at",
+        ]);
+        return;
+      }
+      // SQLite (local dev): keep existing behavior
+      await client.execute(CREATE_SQL);
       // Fresh Postgres tables get BIGINT via the replace above, but tables
       // created before that compat existed kept int4 timestamp columns; widen
       // them so `Date.now()` writes don't overflow. No-op once done.

--- a/packages/core/src/provider-api/quota-governor.spec.ts
+++ b/packages/core/src/provider-api/quota-governor.spec.ts
@@ -4,6 +4,7 @@ const cooldownRows = new Map<string, Record<string, unknown>>();
 
 vi.mock("../db/client.js", () => ({
   intType: () => "INTEGER",
+  isPostgres: () => false,
   getDbExec: () => ({
     execute: async (input: string | { sql: string; args?: unknown[] }) => {
       const sql = typeof input === "string" ? input : input.sql;

--- a/packages/core/src/provider-api/quota-governor.ts
+++ b/packages/core/src/provider-api/quota-governor.ts
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
 
 import type { CredentialContext } from "../credentials/index.js";
-import { getDbExec, intType } from "../db/client.js";
+import { getDbExec, intType, isPostgres } from "../db/client.js";
+import { ensureTableExists, ensureIndexExists } from "../db/ddl-guard.js";
 
 export interface ProviderQuotaIdentityInput {
   appId: string;
@@ -398,7 +399,7 @@ async function ensureCooldownTable(): Promise<void> {
     state.initPromise = (async () => {
       const db = getDbExec();
       const integerType = intType();
-      await db.execute(`
+      const createSql = `
         CREATE TABLE IF NOT EXISTS provider_api_cooldowns (
           quota_key TEXT NOT NULL,
           provider_id TEXT NOT NULL,
@@ -409,7 +410,18 @@ async function ensureCooldownTable(): Promise<void> {
           updated_at ${integerType} NOT NULL,
           PRIMARY KEY (quota_key)
         )
-      `);
+      `;
+      if (isPostgres()) {
+        // PG guard: probe via information_schema, only issue DDL if missing, bounded lock_timeout
+        await ensureTableExists("provider_api_cooldowns", createSql);
+        await ensureIndexExists(
+          "provider_api_cooldowns_provider_idx",
+          `CREATE INDEX IF NOT EXISTS provider_api_cooldowns_provider_idx ON provider_api_cooldowns (provider_id, cooldown_until)`,
+        );
+        return;
+      }
+      // SQLite (local dev): keep existing behavior
+      await db.execute(createSql);
       try {
         await db.execute(
           `CREATE INDEX IF NOT EXISTS provider_api_cooldowns_provider_idx ON provider_api_cooldowns (provider_id, cooldown_until)`,

--- a/packages/core/src/provider-api/staged-datasets-store.ts
+++ b/packages/core/src/provider-api/staged-datasets-store.ts
@@ -14,6 +14,7 @@
  */
 
 import { getDbExec, intType, isPostgres, type DbExec } from "../db/client.js";
+import { ensureTableExists, ensureIndexExists } from "../db/ddl-guard.js";
 
 // ---------------------------------------------------------------------------
 // Caps
@@ -32,7 +33,7 @@ async function ensureTables(): Promise<void> {
     _initPromise = (async () => {
       const db = getDbExec();
       const integerType = intType();
-      await db.execute(`
+      const createDatasetsSql = `
         CREATE TABLE IF NOT EXISTS staged_datasets (
           id TEXT NOT NULL,
           app_id TEXT NOT NULL,
@@ -45,18 +46,34 @@ async function ensureTables(): Promise<void> {
           updated_at ${integerType} NOT NULL,
           PRIMARY KEY (id)
         )
-      `);
-      await db.execute(`
+      `;
+      const createRowsSql = `
         CREATE TABLE IF NOT EXISTS staged_dataset_rows (
           dataset_id TEXT NOT NULL,
           row_index ${integerType} NOT NULL,
           row_data TEXT NOT NULL,
           PRIMARY KEY (dataset_id, row_index)
         )
-      `);
+      `;
       if (isPostgres()) {
-        await widenPostgresIntegerColumns(db);
+        // PG guard: probe via information_schema, only issue DDL if missing, bounded lock_timeout
+        await ensureTableExists("staged_datasets", createDatasetsSql);
+        await ensureTableExists("staged_dataset_rows", createRowsSql);
+        await widenPostgresIntegerColumns(db); // best-effort type widening — unchanged
+        await ensureIndexExists(
+          "staged_datasets_scope_idx",
+          `CREATE INDEX IF NOT EXISTS staged_datasets_scope_idx ON staged_datasets (app_id, owner_email)`,
+        );
+        await ensureIndexExists(
+          "staged_dataset_rows_dataset_idx",
+          `CREATE INDEX IF NOT EXISTS staged_dataset_rows_dataset_idx ON staged_dataset_rows (dataset_id)`,
+        );
+        return;
       }
+      // SQLite (local dev): keep existing behavior
+      await db.execute(createDatasetsSql);
+      await db.execute(createRowsSql);
+      // Note: widenPostgresIntegerColumns is Postgres-only, skip on SQLite
       for (const ddl of [
         `CREATE INDEX IF NOT EXISTS staged_datasets_scope_idx ON staged_datasets (app_id, owner_email)`,
         `CREATE INDEX IF NOT EXISTS staged_dataset_rows_dataset_idx ON staged_dataset_rows (dataset_id)`,

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -1539,9 +1539,9 @@ export async function resourceListAllOwners(
   });
   const localResources = (
     await Promise.all(
-      (await localWorkspaceResourceMetas(pathPrefix)).map((resource) =>
-        resourceGet(resource.id),
-      ),
+      (
+        await localWorkspaceResourceMetas(pathPrefix)
+      ).map((resource) => resourceGet(resource.id)),
     )
   ).filter((resource): resource is Resource => !!resource);
   const localPaths = new Set(localResources.map((resource) => resource.path));

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -7,6 +7,7 @@ import {
   retryOnDdlRace,
   type DbExec,
 } from "../db/client.js";
+import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
 import {
   canUseLocalWorkspaceResourcePath,
@@ -751,37 +752,71 @@ async function ensureTable(): Promise<void> {
 
 async function _doEnsureTable(): Promise<void> {
   const client = getDbExec();
-  await retryOnDdlRace(() =>
-    client.execute(`
-      CREATE TABLE IF NOT EXISTS resources (
-        id TEXT PRIMARY KEY,
-        path TEXT NOT NULL,
-        owner TEXT NOT NULL,
-        content TEXT NOT NULL DEFAULT '',
-        mime_type TEXT NOT NULL DEFAULT 'text/markdown',
-        size ${intType()} NOT NULL DEFAULT 0,
-        created_at ${intType()} NOT NULL,
-        updated_at ${intType()} NOT NULL,
-        created_by TEXT NOT NULL DEFAULT 'user',
-        visibility TEXT NOT NULL DEFAULT 'workspace',
-        thread_id TEXT,
-        run_id TEXT,
-        expires_at ${intType()},
-        metadata TEXT,
-        UNIQUE(path, owner)
-      )
-    `),
-  );
+  const createSql = `
+    CREATE TABLE IF NOT EXISTS resources (
+      id TEXT PRIMARY KEY,
+      path TEXT NOT NULL,
+      owner TEXT NOT NULL,
+      content TEXT NOT NULL DEFAULT '',
+      mime_type TEXT NOT NULL DEFAULT 'text/markdown',
+      size ${intType()} NOT NULL DEFAULT 0,
+      created_at ${intType()} NOT NULL,
+      updated_at ${intType()} NOT NULL,
+      created_by TEXT NOT NULL DEFAULT 'user',
+      visibility TEXT NOT NULL DEFAULT 'workspace',
+      thread_id TEXT,
+      run_id TEXT,
+      expires_at ${intType()},
+      metadata TEXT,
+      UNIQUE(path, owner)
+    )
+  `;
 
-  await ensureResourceColumn(client, "created_by TEXT NOT NULL DEFAULT 'user'");
-  await ensureResourceColumn(
-    client,
-    "visibility TEXT NOT NULL DEFAULT 'workspace'",
-  );
-  await ensureResourceColumn(client, "thread_id TEXT");
-  await ensureResourceColumn(client, "run_id TEXT");
-  await ensureResourceColumn(client, `expires_at ${intType()}`);
-  await ensureResourceColumn(client, "metadata TEXT");
+  if (isPostgres()) {
+    // Hot path: the `resources` table and its additive columns are virtually
+    // always already present in production. Issuing `CREATE TABLE`/`ALTER
+    // TABLE` still takes an ACCESS EXCLUSIVE lock that, in a fresh
+    // background-worker process behind a concurrent connection on the shared
+    // Neon DB, can block ~indefinitely. The ensure* wrappers probe
+    // `information_schema` first (plain reads, no lock) and run DDL ONLY for
+    // what is actually missing, bounded by a transaction-scoped `lock_timeout`.
+    // If a swallowed lock-timeout leaves the schema still missing they RE-PROBE
+    // and THROW rather than letting init memoize success against absent schema.
+    await ensureTableExists("resources", createSql);
+    // Additive columns — guarded so the hot path (columns already present)
+    // skips the ACCESS EXCLUSIVE ALTER entirely.
+    const pgColumns: Array<[string, string]> = [
+      ["created_by", "TEXT NOT NULL DEFAULT 'user'"],
+      ["visibility", "TEXT NOT NULL DEFAULT 'workspace'"],
+      ["thread_id", "TEXT"],
+      ["run_id", "TEXT"],
+      ["expires_at", intType()],
+      ["metadata", "TEXT"],
+    ];
+    for (const [col, def] of pgColumns) {
+      await ensureColumnExists(
+        "resources",
+        col,
+        `ALTER TABLE resources ADD COLUMN IF NOT EXISTS ${col} ${def}`,
+      );
+    }
+  } else {
+    // SQLite (local dev): no lock problem — keep the original behaviour using
+    // `retryOnDdlRace` + `ensureResourceColumn` (duplicate-column catch).
+    await retryOnDdlRace(() => client.execute(createSql));
+    await ensureResourceColumn(
+      client,
+      "created_by TEXT NOT NULL DEFAULT 'user'",
+    );
+    await ensureResourceColumn(
+      client,
+      "visibility TEXT NOT NULL DEFAULT 'workspace'",
+    );
+    await ensureResourceColumn(client, "thread_id TEXT");
+    await ensureResourceColumn(client, "run_id TEXT");
+    await ensureResourceColumn(client, `expires_at ${intType()}`);
+    await ensureResourceColumn(client, "metadata TEXT");
+  }
 
   // Older deployments have 32-bit timestamp columns; on Postgres the
   // `Date.now()` written on insert/update overflows int4. Widen in place
@@ -1504,9 +1539,9 @@ export async function resourceListAllOwners(
   });
   const localResources = (
     await Promise.all(
-      (
-        await localWorkspaceResourceMetas(pathPrefix)
-      ).map((resource) => resourceGet(resource.id)),
+      (await localWorkspaceResourceMetas(pathPrefix)).map((resource) =>
+        resourceGet(resource.id),
+      ),
     )
   ).filter((resource): resource is Resource => !!resource);
   const localPaths = new Set(localResources.map((resource) => resource.path));

--- a/packages/core/src/secrets/storage.ts
+++ b/packages/core/src/secrets/storage.ts
@@ -15,11 +15,7 @@
 import { randomUUID } from "node:crypto";
 
 import { getDbExec, isPostgres } from "../db/client.js";
-import {
-  pgColumnExists,
-  pgTableExists,
-  runGuardedDdl,
-} from "../db/ddl-guard.js";
+import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
 import {
   encryptSecretValue as encryptValue,
   decryptSecretValue as decryptValue,
@@ -48,23 +44,23 @@ async function ensureTable(): Promise<void> {
         // virtually always already present. Issuing `CREATE`/`ALTER` would
         // still take an ACCESS EXCLUSIVE lock — which, in a fresh background
         // worker process behind a concurrent connection on the shared Neon DB,
-        // can block ~indefinitely. So check `information_schema` first (a plain
-        // read, no lock) and run DDL ONLY for what is actually missing. When
-        // DDL must run, `runGuardedDdl` wraps it in a transaction-scoped
-        // `lock_timeout` so a contended lock fails fast instead of hanging.
-        if (!(await pgTableExists("app_secrets"))) {
-          await runGuardedDdl(createSql);
-        }
-        if (!(await pgColumnExists("app_secrets", "description"))) {
-          await runGuardedDdl(
-            `ALTER TABLE app_secrets ADD COLUMN IF NOT EXISTS description TEXT`,
-          );
-        }
-        if (!(await pgColumnExists("app_secrets", "url_allowlist"))) {
-          await runGuardedDdl(
-            `ALTER TABLE app_secrets ADD COLUMN IF NOT EXISTS url_allowlist TEXT`,
-          );
-        }
+        // can block ~indefinitely. `ensureTableExists` / `ensureColumnExists`
+        // check `information_schema` first (a plain read, no lock) and run DDL
+        // ONLY for what is actually missing, wrapping any DDL that must run in a
+        // transaction-scoped `lock_timeout` so a contended lock fails fast. They
+        // also re-probe after a swallowed lock-timeout and THROW if the schema
+        // is still missing, so a timed-out DDL never poisons this init memo.
+        await ensureTableExists("app_secrets", createSql);
+        await ensureColumnExists(
+          "app_secrets",
+          "description",
+          `ALTER TABLE app_secrets ADD COLUMN IF NOT EXISTS description TEXT`,
+        );
+        await ensureColumnExists(
+          "app_secrets",
+          "url_allowlist",
+          `ALTER TABLE app_secrets ADD COLUMN IF NOT EXISTS url_allowlist TEXT`,
+        );
         return;
       }
 

--- a/packages/core/src/server/agent-teams-process-run.spec.ts
+++ b/packages/core/src/server/agent-teams-process-run.spec.ts
@@ -120,6 +120,7 @@ const queueDb = {
 vi.mock("../db/client.js", () => ({
   getDbExec: () => queueDb,
   intType: () => "INTEGER",
+  isPostgres: () => false,
   retryOnDdlRace: (fn: () => unknown) => fn(),
 }));
 

--- a/packages/core/src/server/agent-teams-run-queue.spec.ts
+++ b/packages/core/src/server/agent-teams-run-queue.spec.ts
@@ -130,6 +130,7 @@ const mockDb = {
 vi.mock("../db/client.js", () => ({
   getDbExec: () => mockDb,
   intType: () => "INTEGER",
+  isPostgres: () => false,
   retryOnDdlRace: (fn: () => unknown) => fn(),
 }));
 

--- a/packages/core/src/server/agent-teams-run-queue.ts
+++ b/packages/core/src/server/agent-teams-run-queue.ts
@@ -14,7 +14,13 @@
  * for UI/status; this table only drives dispatch, idempotent claiming, and
  * cross-invocation continuation.
  */
-import { getDbExec, intType, retryOnDdlRace } from "../db/client.js";
+import {
+  getDbExec,
+  intType,
+  isPostgres,
+  retryOnDdlRace,
+} from "../db/client.js";
+import { ensureIndexExists, ensureTableExists } from "../db/ddl-guard.js";
 
 /** Max cross-invocation continuations for one sub-agent run. Each continuation
  * is one ~40s soft-timeout chunk, so ~60 ≈ ~40 minutes of wall-clock work. Two
@@ -77,8 +83,7 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await retryOnDdlRace(() =>
-        client.execute(`
+      const createSql = `
           CREATE TABLE IF NOT EXISTS agent_team_run_queue (
             task_id TEXT PRIMARY KEY,
             thread_id TEXT NOT NULL,
@@ -92,13 +97,20 @@ async function ensureTable(): Promise<void> {
             created_at ${intType()} NOT NULL,
             updated_at ${intType()} NOT NULL
           )
-        `),
-      );
-      await retryOnDdlRace(() =>
-        client.execute(
-          `CREATE INDEX IF NOT EXISTS idx_agent_team_run_queue_status ON agent_team_run_queue (status, updated_at)`,
-        ),
-      );
+        `;
+      const indexSql = `CREATE INDEX IF NOT EXISTS idx_agent_team_run_queue_status ON agent_team_run_queue (status, updated_at)`;
+
+      // PG guard: probe information_schema / pg_indexes first (no lock), run
+      // DDL only when missing, bounded by a transaction-scoped lock_timeout.
+      if (isPostgres()) {
+        await ensureTableExists("agent_team_run_queue", createSql);
+        await ensureIndexExists("idx_agent_team_run_queue_status", indexSql);
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      await retryOnDdlRace(() => client.execute(createSql));
+      await retryOnDdlRace(() => client.execute(indexSql));
     })().catch((err) => {
       _initPromise = undefined;
       throw err;

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -72,6 +72,7 @@ import {
   retryOnDdlRace,
   describeDbError,
 } from "../db/client.js";
+import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
 import { readBody } from "../server/h3-helpers.js";
 import { putSetting } from "../settings/store.js";
@@ -865,15 +866,32 @@ async function ensureSessionTable(): Promise<void> {
   if (!_sessionInitPromise) {
     _sessionInitPromise = (async () => {
       const client = getDbExec();
-      await retryOnDdlRace(() =>
-        client.execute(`
+      const createSql = `
           CREATE TABLE IF NOT EXISTS sessions (
             token TEXT PRIMARY KEY,
             email TEXT,
             created_at ${intType()} NOT NULL
           )
-        `),
-      );
+        `;
+
+      // PG guard: probe information_schema first (no lock), run DDL only when
+      // missing, bounded by a transaction-scoped lock_timeout.
+      if (isPostgres()) {
+        await ensureTableExists("sessions", createSql);
+        await ensureColumnExists(
+          "sessions",
+          "email",
+          `ALTER TABLE sessions ADD COLUMN IF NOT EXISTS email TEXT`,
+        );
+        // Older deployments have a 32-bit `created_at`; on Postgres the
+        // `Date.now()` written on session create overflows int4. Widen in place
+        // (no-op once done / on fresh DBs).
+        await widenIntColumnsToBigInt("sessions", ["created_at"]);
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      await retryOnDdlRace(() => client.execute(createSql));
       try {
         await client.execute(`ALTER TABLE sessions ADD COLUMN email TEXT`);
       } catch {

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -39,6 +39,7 @@ import {
   neonPoolMax,
   attachNeonPoolErrorLogger,
 } from "../db/client.js";
+import { ensureTableExists } from "../db/ddl-guard.js";
 import { saveOAuthTokens } from "../oauth-tokens/store.js";
 import { acceptPendingInvitationsForEmail } from "../org/accept-pending.js";
 import { autoJoinDomainMatchingOrgs } from "../org/auto-join-domain.js";
@@ -693,29 +694,62 @@ async function mirrorGoogleAccountToOAuthTokens(account: {
 
 async function ensureBetterAuthTables(): Promise<void> {
   const db = getDbExec();
-  const statements = isPostgres()
-    ? [
-        `CREATE TABLE IF NOT EXISTS "user" (id TEXT PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE, email_verified BOOLEAN NOT NULL DEFAULT FALSE, image TEXT, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL)`,
-        `CREATE TABLE IF NOT EXISTS "session" (id TEXT PRIMARY KEY, expires_at TIMESTAMPTZ NOT NULL, token TEXT NOT NULL UNIQUE, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL, ip_address TEXT, user_agent TEXT, user_id TEXT NOT NULL, active_organization_id TEXT)`,
-        `CREATE TABLE IF NOT EXISTS "account" (id TEXT PRIMARY KEY, account_id TEXT NOT NULL, provider_id TEXT NOT NULL, user_id TEXT NOT NULL, access_token TEXT, refresh_token TEXT, id_token TEXT, access_token_expires_at TIMESTAMPTZ, refresh_token_expires_at TIMESTAMPTZ, scope TEXT, password TEXT, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL)`,
-        `CREATE TABLE IF NOT EXISTS "verification" (id TEXT PRIMARY KEY, identifier TEXT NOT NULL, value TEXT NOT NULL, expires_at TIMESTAMPTZ NOT NULL, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL)`,
-        `CREATE TABLE IF NOT EXISTS "organization" (id TEXT PRIMARY KEY, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, logo TEXT, metadata TEXT, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL)`,
-        `CREATE TABLE IF NOT EXISTS "member" (id TEXT PRIMARY KEY, organization_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member', created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL)`,
-        `CREATE TABLE IF NOT EXISTS "invitation" (id TEXT PRIMARY KEY, organization_id TEXT NOT NULL, email TEXT NOT NULL, role TEXT, status TEXT NOT NULL DEFAULT 'pending', expires_at TIMESTAMPTZ NOT NULL, inviter_id TEXT NOT NULL, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL)`,
-        `CREATE TABLE IF NOT EXISTS "jwks" (id TEXT PRIMARY KEY, public_key TEXT NOT NULL, private_key TEXT NOT NULL, created_at TIMESTAMPTZ NOT NULL, expires_at TIMESTAMPTZ)`,
-      ]
-    : [
-        `CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE, email_verified INTEGER NOT NULL DEFAULT 0, image TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
-        `CREATE TABLE IF NOT EXISTS session (id TEXT PRIMARY KEY, expires_at INTEGER NOT NULL, token TEXT NOT NULL UNIQUE, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, ip_address TEXT, user_agent TEXT, user_id TEXT NOT NULL, active_organization_id TEXT)`,
-        `CREATE TABLE IF NOT EXISTS account (id TEXT PRIMARY KEY, account_id TEXT NOT NULL, provider_id TEXT NOT NULL, user_id TEXT NOT NULL, access_token TEXT, refresh_token TEXT, id_token TEXT, access_token_expires_at INTEGER, refresh_token_expires_at INTEGER, scope TEXT, password TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
-        `CREATE TABLE IF NOT EXISTS verification (id TEXT PRIMARY KEY, identifier TEXT NOT NULL, value TEXT NOT NULL, expires_at INTEGER NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
-        `CREATE TABLE IF NOT EXISTS organization (id TEXT PRIMARY KEY, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, logo TEXT, metadata TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
-        `CREATE TABLE IF NOT EXISTS member (id TEXT PRIMARY KEY, organization_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
-        `CREATE TABLE IF NOT EXISTS invitation (id TEXT PRIMARY KEY, organization_id TEXT NOT NULL, email TEXT NOT NULL, role TEXT, status TEXT NOT NULL DEFAULT 'pending', expires_at INTEGER NOT NULL, inviter_id TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
-        `CREATE TABLE IF NOT EXISTS jwks (id TEXT PRIMARY KEY, public_key TEXT NOT NULL, private_key TEXT NOT NULL, created_at INTEGER NOT NULL, expires_at INTEGER)`,
-      ];
 
-  for (const sql of statements) await db.execute(sql);
+  // PG guard: probe information_schema first (no lock) for each table; run
+  // DDL only when missing, bounded by a transaction-scoped lock_timeout.
+  // Probe names are UNQUOTED (what information_schema.tables.table_name stores);
+  // createSql keeps the QUOTED "user"/"session"/… form required by Postgres.
+  if (isPostgres()) {
+    const pgTables: Array<[name: string, createSql: string]> = [
+      [
+        "user",
+        `CREATE TABLE IF NOT EXISTS "user" (id TEXT PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE, email_verified BOOLEAN NOT NULL DEFAULT FALSE, image TEXT, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL)`,
+      ],
+      [
+        "session",
+        `CREATE TABLE IF NOT EXISTS "session" (id TEXT PRIMARY KEY, expires_at TIMESTAMPTZ NOT NULL, token TEXT NOT NULL UNIQUE, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL, ip_address TEXT, user_agent TEXT, user_id TEXT NOT NULL, active_organization_id TEXT)`,
+      ],
+      [
+        "account",
+        `CREATE TABLE IF NOT EXISTS "account" (id TEXT PRIMARY KEY, account_id TEXT NOT NULL, provider_id TEXT NOT NULL, user_id TEXT NOT NULL, access_token TEXT, refresh_token TEXT, id_token TEXT, access_token_expires_at TIMESTAMPTZ, refresh_token_expires_at TIMESTAMPTZ, scope TEXT, password TEXT, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL)`,
+      ],
+      [
+        "verification",
+        `CREATE TABLE IF NOT EXISTS "verification" (id TEXT PRIMARY KEY, identifier TEXT NOT NULL, value TEXT NOT NULL, expires_at TIMESTAMPTZ NOT NULL, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL)`,
+      ],
+      [
+        "organization",
+        `CREATE TABLE IF NOT EXISTS "organization" (id TEXT PRIMARY KEY, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, logo TEXT, metadata TEXT, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL)`,
+      ],
+      [
+        "member",
+        `CREATE TABLE IF NOT EXISTS "member" (id TEXT PRIMARY KEY, organization_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member', created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL)`,
+      ],
+      [
+        "invitation",
+        `CREATE TABLE IF NOT EXISTS "invitation" (id TEXT PRIMARY KEY, organization_id TEXT NOT NULL, email TEXT NOT NULL, role TEXT, status TEXT NOT NULL DEFAULT 'pending', expires_at TIMESTAMPTZ NOT NULL, inviter_id TEXT NOT NULL, created_at TIMESTAMPTZ NOT NULL, updated_at TIMESTAMPTZ NOT NULL)`,
+      ],
+      [
+        "jwks",
+        `CREATE TABLE IF NOT EXISTS "jwks" (id TEXT PRIMARY KEY, public_key TEXT NOT NULL, private_key TEXT NOT NULL, created_at TIMESTAMPTZ NOT NULL, expires_at TIMESTAMPTZ)`,
+      ],
+    ];
+    for (const [name, sql] of pgTables) await ensureTableExists(name, sql);
+    return;
+  }
+
+  // SQLite (local dev): no lock problem — keep the original behaviour.
+  const sqliteStatements = [
+    `CREATE TABLE IF NOT EXISTS user (id TEXT PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE, email_verified INTEGER NOT NULL DEFAULT 0, image TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+    `CREATE TABLE IF NOT EXISTS session (id TEXT PRIMARY KEY, expires_at INTEGER NOT NULL, token TEXT NOT NULL UNIQUE, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, ip_address TEXT, user_agent TEXT, user_id TEXT NOT NULL, active_organization_id TEXT)`,
+    `CREATE TABLE IF NOT EXISTS account (id TEXT PRIMARY KEY, account_id TEXT NOT NULL, provider_id TEXT NOT NULL, user_id TEXT NOT NULL, access_token TEXT, refresh_token TEXT, id_token TEXT, access_token_expires_at INTEGER, refresh_token_expires_at INTEGER, scope TEXT, password TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+    `CREATE TABLE IF NOT EXISTS verification (id TEXT PRIMARY KEY, identifier TEXT NOT NULL, value TEXT NOT NULL, expires_at INTEGER NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+    `CREATE TABLE IF NOT EXISTS organization (id TEXT PRIMARY KEY, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, logo TEXT, metadata TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+    `CREATE TABLE IF NOT EXISTS member (id TEXT PRIMARY KEY, organization_id TEXT NOT NULL, user_id TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+    `CREATE TABLE IF NOT EXISTS invitation (id TEXT PRIMARY KEY, organization_id TEXT NOT NULL, email TEXT NOT NULL, role TEXT, status TEXT NOT NULL DEFAULT 'pending', expires_at INTEGER NOT NULL, inviter_id TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+    `CREATE TABLE IF NOT EXISTS jwks (id TEXT PRIMARY KEY, public_key TEXT NOT NULL, private_key TEXT NOT NULL, created_at INTEGER NOT NULL, expires_at INTEGER)`,
+  ];
+  for (const sql of sqliteStatements) await db.execute(sql);
 }
 
 /**

--- a/packages/core/src/server/embed-session.ts
+++ b/packages/core/src/server/embed-session.ts
@@ -9,7 +9,8 @@ import {
   setResponseHeader,
 } from "h3";
 
-import { getDbExec, intType } from "../db/client.js";
+import { getDbExec, intType, isPostgres } from "../db/client.js";
+import { ensureTableExists } from "../db/ddl-guard.js";
 import {
   EMBED_MODE_QUERY_PARAM,
   EMBED_SESSION_COOKIE,
@@ -103,8 +104,10 @@ export type ResolvedEmbedSession = {
 async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
-      const client = getDbExec();
-      await client.execute(`
+      // Build the CREATE SQL here (not at module scope) so intType() runs at
+      // RUNTIME, not import time — a module-scope call breaks any consumer whose
+      // db/client mock doesn't stub intType (e.g. db-admin specs).
+      const embedTicketsCreateSql = `
         CREATE TABLE IF NOT EXISTS agent_native_embed_tickets (
           ticket_hash TEXT PRIMARY KEY,
           owner_email TEXT NOT NULL,
@@ -115,7 +118,19 @@ async function ensureTable(): Promise<void> {
           expires_at ${intType()} NOT NULL,
           consumed_at ${intType()}
         )
-      `);
+      `;
+      if (isPostgres()) {
+        // PG guard: probe → guarded DDL → re-probe; skips lock on already-migrated path
+        await ensureTableExists(
+          "agent_native_embed_tickets",
+          embedTicketsCreateSql,
+        );
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      const client = getDbExec();
+      await client.execute(embedTicketsCreateSql);
     })().catch((err) => {
       _initPromise = undefined;
       throw err;

--- a/packages/core/src/server/identity-sso-store.spec.ts
+++ b/packages/core/src/server/identity-sso-store.spec.ts
@@ -89,6 +89,9 @@ vi.mock("../db/client.js", () => ({
   getDbExec: () => ({ execute: exec }),
   isConnectionError: () => false,
   intType: () => "INTEGER",
+  // isPostgres is false in tests so the SQLite branch runs (no lock plumbing
+  // needed) and the ddl-guard helpers imported by the store become no-ops.
+  isPostgres: () => false,
 }));
 
 const store = await import("./identity-sso-store.js");

--- a/packages/core/src/server/identity-sso-store.ts
+++ b/packages/core/src/server/identity-sso-store.ts
@@ -24,7 +24,13 @@
 
 import { randomBytes } from "node:crypto";
 
-import { getDbExec, isConnectionError, intType } from "../db/client.js";
+import {
+  getDbExec,
+  isConnectionError,
+  intType,
+  isPostgres,
+} from "../db/client.js";
+import { ensureTableExists } from "../db/ddl-guard.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -98,13 +104,11 @@ export const SSO_STATE_TTL_MS = 10 * 60_000;
 export const SSO_LOGIN_MAX = 60;
 export const SSO_LOGIN_WINDOW_MS = 60_000;
 
-async function ensureTable(): Promise<void> {
-  if (!_initPromise) {
-    _initPromise = (async () => {
-      const client = getDbExec();
-      // Additive only. Never DROP / ALTER — this DB is shared across every
-      // deploy context (preview/branch/prod) for hosted templates.
-      await client.execute(`
+// Build the CREATE SQL lazily (not at module scope) so intType() runs at
+// RUNTIME, not import time — a module-scope call breaks any consumer whose
+// db/client mock doesn't stub intType (e.g. db-admin specs).
+function buildIdentitySsoStateCreateSql(): string {
+  return `
         CREATE TABLE IF NOT EXISTS identity_sso_state (
           state TEXT PRIMARY KEY,
           return_path TEXT,
@@ -112,13 +116,38 @@ async function ensureTable(): Promise<void> {
           expires_at ${intType()},
           consumed_at ${intType()}
         )
-      `);
-      await client.execute(`
+      `;
+}
+function buildIdentitySsoJtiCreateSql(): string {
+  return `
         CREATE TABLE IF NOT EXISTS identity_sso_jti (
           jti TEXT PRIMARY KEY,
           seen_at ${intType()}
         )
-      `);
+      `;
+}
+
+async function ensureTable(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = (async () => {
+      const client = getDbExec();
+      const identitySsoStateCreateSql = buildIdentitySsoStateCreateSql();
+      const identitySsoJtiCreateSql = buildIdentitySsoJtiCreateSql();
+      // Additive only. Never DROP / ALTER — this DB is shared across every
+      // deploy context (preview/branch/prod) for hosted templates.
+      if (isPostgres()) {
+        // PG guard: probe → guarded DDL → re-probe; skips lock on already-migrated path
+        await ensureTableExists(
+          "identity_sso_state",
+          identitySsoStateCreateSql,
+        );
+        await ensureTableExists("identity_sso_jti", identitySsoJtiCreateSql);
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      await client.execute(identitySsoStateCreateSql);
+      await client.execute(identitySsoJtiCreateSql);
     })().catch((err) => {
       // Don't cache a rejection — let the next caller retry a fresh init.
       _initPromise = undefined;

--- a/packages/core/src/server/recap-image-store.ts
+++ b/packages/core/src/server/recap-image-store.ts
@@ -19,7 +19,13 @@
  */
 import { randomBytes } from "node:crypto";
 
-import { getDbExec, intType, retryOnDdlRace } from "../db/client.js";
+import {
+  getDbExec,
+  intType,
+  isPostgres,
+  retryOnDdlRace,
+} from "../db/client.js";
+import { ensureTableExists } from "../db/ddl-guard.js";
 
 /** Maximum stored image size (~5 MB of raw PNG bytes). */
 export const RECAP_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
@@ -44,12 +50,11 @@ const TOKEN_PATTERN = /^[0-9a-f]{32,128}$/;
 
 let _initPromise: Promise<void> | undefined;
 
-export async function ensureRecapImageTable(): Promise<void> {
-  if (!_initPromise) {
-    _initPromise = (async () => {
-      const client = getDbExec();
-      await retryOnDdlRace(() =>
-        client.execute(`
+// Build the CREATE SQL lazily (not at module scope) so intType() runs at
+// RUNTIME, not import time — a module-scope call breaks any consumer whose
+// db/client mock doesn't stub intType (e.g. db-admin specs).
+function buildRecapImagesCreateSql(): string {
+  return `
         CREATE TABLE IF NOT EXISTS recap_images (
           token TEXT PRIMARY KEY,
           png_base64 TEXT NOT NULL,
@@ -58,8 +63,22 @@ export async function ensureRecapImageTable(): Promise<void> {
           owner_email TEXT,
           created_at ${intType()} NOT NULL
         )
-      `),
-      );
+      `;
+}
+
+export async function ensureRecapImageTable(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = (async () => {
+      const recapImagesCreateSql = buildRecapImagesCreateSql();
+      if (isPostgres()) {
+        // PG guard: probe → guarded DDL → re-probe; skips lock on already-migrated path
+        await ensureTableExists("recap_images", recapImagesCreateSql);
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      const client = getDbExec();
+      await retryOnDdlRace(() => client.execute(recapImagesCreateSql));
     })().catch((error) => {
       // Allow a later call to retry if the first init lost a DDL race.
       _initPromise = undefined;

--- a/packages/core/src/settings/store.ts
+++ b/packages/core/src/settings/store.ts
@@ -1,11 +1,7 @@
 import { EventEmitter } from "events";
 
 import { getDbExec, isPostgres, intType } from "../db/client.js";
-import {
-  pgIndexExists,
-  pgTableExists,
-  runGuardedDdl,
-} from "../db/ddl-guard.js";
+import { ensureIndexExists, ensureTableExists } from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
 
 let _initPromise: Promise<void> | undefined;
@@ -39,26 +35,25 @@ async function ensureTable(): Promise<void> {
         // `CREATE INDEX` still takes a lock that, in a fresh background-worker
         // process behind a concurrent connection on the shared Neon DB, can
         // block ~indefinitely (ACCESS EXCLUSIVE for CREATE TABLE; a write-
-        // blocking SHARE lock for CREATE INDEX). So check `information_schema`/
-        // `pg_indexes` first (plain reads, no lock) and run DDL ONLY for what
-        // is actually missing. `runGuardedDdl` bounds any DDL that must run
-        // with a transaction-scoped `lock_timeout` so a contended lock fails
-        // fast instead of hanging. `settingsTable()` is `public.settings` on
-        // Postgres; the existence checks use the unqualified table name.
-        if (!(await pgTableExists("settings"))) {
-          await runGuardedDdl(createSql);
-        }
+        // blocking SHARE lock for CREATE INDEX). `ensureTableExists` /
+        // `ensureIndexExists` probe `information_schema`/`pg_indexes` first
+        // (plain reads, no lock) and run DDL ONLY for what is actually missing,
+        // bounding any DDL with a transaction-scoped `lock_timeout`. They also
+        // re-probe after a swallowed lock-timeout and THROW if the schema is
+        // still missing, so a timed-out DDL never poisons this init memo with
+        // missing schema. `settingsTable()` is `public.settings` on Postgres;
+        // the existence checks use the unqualified table name.
+        await ensureTableExists("settings", createSql);
         // Older deployments (pre BIGINT-compat) have a 32-bit `updated_at`; on
         // Postgres the `Date.now()` written on every setSetting overflows int4.
         // widenIntColumnsToBigInt already probes information_schema and only
         // ALTERs columns that are still int4 — a no-op on fresh/widened DBs.
         await widenIntColumnsToBigInt("settings", ["updated_at"]);
         // Index for the poll watermark query: `SELECT MAX(updated_at)`.
-        if (!(await pgIndexExists("settings_updated_at_idx"))) {
-          await runGuardedDdl(
-            `CREATE INDEX IF NOT EXISTS settings_updated_at_idx ON ${table} (updated_at)`,
-          );
-        }
+        await ensureIndexExists(
+          "settings_updated_at_idx",
+          `CREATE INDEX IF NOT EXISTS settings_updated_at_idx ON ${table} (updated_at)`,
+        );
         return;
       }
 

--- a/packages/core/src/usage/store.ts
+++ b/packages/core/src/usage/store.ts
@@ -8,6 +8,11 @@
  * Cost is stored as "centicents" (1/100th of a cent) for integer precision.
  */
 import { getDbExec, intType, isPostgres } from "../db/client.js";
+import {
+  ensureColumnExists,
+  ensureIndexExists,
+  ensureTableExists,
+} from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
 
 /**
@@ -191,7 +196,7 @@ async function ensureUsageTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await client.execute(`
+      const createSql = `
         CREATE TABLE IF NOT EXISTS token_usage (
           id ${intType()} PRIMARY KEY,
           owner_email TEXT NOT NULL,
@@ -206,11 +211,9 @@ async function ensureUsageTable(): Promise<void> {
           ref_id TEXT NOT NULL DEFAULT '',
           created_at ${intType()} NOT NULL
         )
-      `);
+      `;
 
-      // Add columns on older deployments that pre-date the label/cache
-      // fields. Each ALTER is wrapped so a dialect without IF NOT EXISTS
-      // (SQLite) still makes progress if only some columns are missing.
+      // Additive columns for older deployments that pre-date the label/cache fields.
       const additions: Array<[string, string]> = [
         ["cache_read_tokens", `${intType()} NOT NULL DEFAULT 0`],
         ["cache_write_tokens", `${intType()} NOT NULL DEFAULT 0`],
@@ -218,27 +221,59 @@ async function ensureUsageTable(): Promise<void> {
         ["app", `TEXT NOT NULL DEFAULT ''`],
         ["ref_id", `TEXT NOT NULL DEFAULT ''`],
       ];
+
+      if (isPostgres()) {
+        // Hot path: the `token_usage` table and its index are virtually always
+        // already present in production. Issuing `CREATE TABLE`/`ALTER TABLE`/
+        // `CREATE INDEX` still takes a lock that, in a fresh background-worker
+        // process behind a concurrent connection on the shared Neon DB, can
+        // block ~indefinitely. The ensure* wrappers probe `information_schema`/
+        // `pg_indexes` first (plain reads, no lock) and run DDL ONLY for what is
+        // actually missing, bounded by a transaction-scoped `lock_timeout`. If a
+        // swallowed lock-timeout leaves the schema still missing they RE-PROBE
+        // and THROW rather than letting init memoize success against absent
+        // schema.
+        await ensureTableExists("token_usage", createSql);
+        // Add columns on older deployments — guarded so the hot path (columns
+        // already present) skips the ACCESS EXCLUSIVE ALTER.
+        for (const [col, def] of additions) {
+          await ensureColumnExists(
+            "token_usage",
+            col,
+            `ALTER TABLE token_usage ADD COLUMN IF NOT EXISTS ${col} ${def}`,
+          );
+        }
+        // Older deployments created `created_at` as 32-bit `INTEGER`; on Postgres
+        // the `Date.now()` written per run by recordUsage() overflows int4. Widen
+        // it in place (no-op once done / on fresh BIGINT databases).
+        await widenIntColumnsToBigInt("token_usage", ["created_at"]);
+        // Probe pg_indexes first (no lock) and skip the SHARE-locking CREATE
+        // INDEX when the index is already present.
+        await ensureIndexExists(
+          "idx_token_usage_owner_created",
+          `CREATE INDEX IF NOT EXISTS idx_token_usage_owner_created ON token_usage (owner_email, created_at)`,
+        );
+        return;
+      }
+
+      // SQLite (local dev): no lock problem — keep the original behaviour.
+      await client.execute(createSql);
+      // Add columns on older deployments that pre-date the label/cache
+      // fields. Each ALTER is wrapped so a dialect without IF NOT EXISTS
+      // (SQLite) still makes progress if only some columns are missing.
       for (const [col, def] of additions) {
         try {
-          if (isPostgres()) {
-            await client.execute(
-              `ALTER TABLE token_usage ADD COLUMN IF NOT EXISTS ${col} ${def}`,
-            );
-          } else {
-            await client.execute(
-              `ALTER TABLE token_usage ADD COLUMN ${col} ${def}`,
-            );
-          }
+          await client.execute(
+            `ALTER TABLE token_usage ADD COLUMN ${col} ${def}`,
+          );
         } catch {
           // Column already exists — ignore
         }
       }
-
       // Older deployments created `created_at` as 32-bit `INTEGER`; on Postgres
       // the `Date.now()` written per run by recordUsage() overflows int4. Widen
       // it in place (no-op once done / on fresh BIGINT databases).
       await widenIntColumnsToBigInt("token_usage", ["created_at"]);
-
       try {
         await client.execute(
           `CREATE INDEX IF NOT EXISTS idx_token_usage_owner_created ON token_usage (owner_email, created_at)`,

--- a/packages/core/src/workspace-connections/store.ts
+++ b/packages/core/src/workspace-connections/store.ts
@@ -16,6 +16,11 @@ import {
   type DbExec,
 } from "../db/client.js";
 import {
+  ensureColumnExists,
+  ensureIndexExists,
+  ensureTableExists,
+} from "../db/ddl-guard.js";
+import {
   getRequestOrgId,
   getRequestUserEmail,
 } from "../server/request-context.js";
@@ -459,8 +464,8 @@ export async function ensureWorkspaceConnectionsTable(): Promise<void> {
       const client = getDbExec();
       const table = workspaceConnectionsTable();
       const grantsTable = workspaceConnectionGrantsTable();
-      await retryOnDdlRace(() =>
-        client.execute(`
+
+      const createConnectionsSql = `
           CREATE TABLE IF NOT EXISTS ${table} (
             id TEXT PRIMARY KEY,
             provider TEXT NOT NULL DEFAULT '',
@@ -480,23 +485,8 @@ export async function ensureWorkspaceConnectionsTable(): Promise<void> {
             last_checked_at ${intType()},
             last_error TEXT
           )
-        `),
-      );
-
-      await ensureWorkspaceConnectionColumns(client, table);
-
-      await retryOnDdlRace(() =>
-        client.execute(
-          `CREATE INDEX IF NOT EXISTS idx_workspace_connections_scope_provider ON ${table} (org_id, owner_email, provider)`,
-        ),
-      );
-      await retryOnDdlRace(() =>
-        client.execute(
-          `CREATE INDEX IF NOT EXISTS idx_workspace_connections_updated_at ON ${table} (updated_at)`,
-        ),
-      );
-      await retryOnDdlRace(() =>
-        client.execute(`
+        `;
+      const createGrantsSql = `
           CREATE TABLE IF NOT EXISTS ${grantsTable} (
             id TEXT PRIMARY KEY,
             connection_id TEXT NOT NULL DEFAULT '',
@@ -512,11 +502,199 @@ export async function ensureWorkspaceConnectionsTable(): Promise<void> {
             updated_at ${intType()} NOT NULL DEFAULT 0,
             last_used_at ${intType()}
           )
-        `),
+        `;
+
+      if (isPostgres()) {
+        // PG-guard: probe information_schema / pg_indexes first (no lock) and
+        // only issue DDL when the table/column/index is actually missing,
+        // wrapped in a transaction-scoped lock_timeout so a contended lock
+        // fails fast. Uses unqualified table names for the probe (the helpers
+        // always search the `public` schema).
+
+        // --- workspace_connections ---
+        await ensureTableExists("workspace_connections", createConnectionsSql);
+        await ensureColumnExists(
+          "workspace_connections",
+          "provider",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS provider TEXT NOT NULL DEFAULT ''`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "label",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS label TEXT NOT NULL DEFAULT ''`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "account_id",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS account_id TEXT`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "account_label",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS account_label TEXT`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "status",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'connected'`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "scopes_json",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS scopes_json TEXT NOT NULL DEFAULT '[]'`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "config_json",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS config_json TEXT NOT NULL DEFAULT '{}'`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "allowed_apps_json",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS allowed_apps_json TEXT NOT NULL DEFAULT '[]'`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "credential_refs_json",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS credential_refs_json TEXT NOT NULL DEFAULT '[]'`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "owner_email",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS owner_email TEXT NOT NULL DEFAULT ''`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "org_id",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS org_id TEXT`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "created_at",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS created_at ${intType()} NOT NULL DEFAULT 0`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "updated_at",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS updated_at ${intType()} NOT NULL DEFAULT 0`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "last_checked_at",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS last_checked_at ${intType()}`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "last_used_at",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS last_used_at ${intType()}`,
+        );
+        await ensureColumnExists(
+          "workspace_connections",
+          "last_error",
+          `ALTER TABLE workspace_connections ADD COLUMN IF NOT EXISTS last_error TEXT`,
+        );
+        await ensureIndexExists(
+          "idx_workspace_connections_scope_provider",
+          `CREATE INDEX IF NOT EXISTS idx_workspace_connections_scope_provider ON ${table} (org_id, owner_email, provider)`,
+        );
+        await ensureIndexExists(
+          "idx_workspace_connections_updated_at",
+          `CREATE INDEX IF NOT EXISTS idx_workspace_connections_updated_at ON ${table} (updated_at)`,
+        );
+
+        // --- workspace_connection_grants ---
+        await ensureTableExists("workspace_connection_grants", createGrantsSql);
+        await ensureColumnExists(
+          "workspace_connection_grants",
+          "connection_id",
+          `ALTER TABLE workspace_connection_grants ADD COLUMN IF NOT EXISTS connection_id TEXT NOT NULL DEFAULT ''`,
+        );
+        await ensureColumnExists(
+          "workspace_connection_grants",
+          "provider",
+          `ALTER TABLE workspace_connection_grants ADD COLUMN IF NOT EXISTS provider TEXT NOT NULL DEFAULT ''`,
+        );
+        await ensureColumnExists(
+          "workspace_connection_grants",
+          "app_id",
+          `ALTER TABLE workspace_connection_grants ADD COLUMN IF NOT EXISTS app_id TEXT NOT NULL DEFAULT ''`,
+        );
+        await ensureColumnExists(
+          "workspace_connection_grants",
+          "scopes_json",
+          `ALTER TABLE workspace_connection_grants ADD COLUMN IF NOT EXISTS scopes_json TEXT NOT NULL DEFAULT '[]'`,
+        );
+        await ensureColumnExists(
+          "workspace_connection_grants",
+          "config_json",
+          `ALTER TABLE workspace_connection_grants ADD COLUMN IF NOT EXISTS config_json TEXT NOT NULL DEFAULT '{}'`,
+        );
+        await ensureColumnExists(
+          "workspace_connection_grants",
+          "credential_refs_json",
+          `ALTER TABLE workspace_connection_grants ADD COLUMN IF NOT EXISTS credential_refs_json TEXT NOT NULL DEFAULT '[]'`,
+        );
+        await ensureColumnExists(
+          "workspace_connection_grants",
+          "granted_by_email",
+          `ALTER TABLE workspace_connection_grants ADD COLUMN IF NOT EXISTS granted_by_email TEXT NOT NULL DEFAULT ''`,
+        );
+        await ensureColumnExists(
+          "workspace_connection_grants",
+          "owner_email",
+          `ALTER TABLE workspace_connection_grants ADD COLUMN IF NOT EXISTS owner_email TEXT NOT NULL DEFAULT ''`,
+        );
+        await ensureColumnExists(
+          "workspace_connection_grants",
+          "org_id",
+          `ALTER TABLE workspace_connection_grants ADD COLUMN IF NOT EXISTS org_id TEXT`,
+        );
+        await ensureColumnExists(
+          "workspace_connection_grants",
+          "created_at",
+          `ALTER TABLE workspace_connection_grants ADD COLUMN IF NOT EXISTS created_at ${intType()} NOT NULL DEFAULT 0`,
+        );
+        await ensureColumnExists(
+          "workspace_connection_grants",
+          "updated_at",
+          `ALTER TABLE workspace_connection_grants ADD COLUMN IF NOT EXISTS updated_at ${intType()} NOT NULL DEFAULT 0`,
+        );
+        await ensureColumnExists(
+          "workspace_connection_grants",
+          "last_used_at",
+          `ALTER TABLE workspace_connection_grants ADD COLUMN IF NOT EXISTS last_used_at ${intType()}`,
+        );
+        await ensureIndexExists(
+          "idx_workspace_connection_grants_connection_app",
+          `CREATE UNIQUE INDEX IF NOT EXISTS idx_workspace_connection_grants_connection_app ON ${grantsTable} (connection_id, app_id)`,
+        );
+        await ensureIndexExists(
+          "idx_workspace_connection_grants_scope_app",
+          `CREATE INDEX IF NOT EXISTS idx_workspace_connection_grants_scope_app ON ${grantsTable} (org_id, owner_email, app_id)`,
+        );
+        await ensureIndexExists(
+          "idx_workspace_connection_grants_updated_at",
+          `CREATE INDEX IF NOT EXISTS idx_workspace_connection_grants_updated_at ON ${grantsTable} (updated_at)`,
+        );
+        return;
+      }
+
+      // SQLite (local dev): no ACCESS EXCLUSIVE lock problem — keep existing
+      // retryOnDdlRace + ensureColumn behaviour.
+      await retryOnDdlRace(() => client.execute(createConnectionsSql));
+      await ensureWorkspaceConnectionColumns(client, table);
+      await retryOnDdlRace(() =>
+        client.execute(
+          `CREATE INDEX IF NOT EXISTS idx_workspace_connections_scope_provider ON ${table} (org_id, owner_email, provider)`,
+        ),
       );
-
+      await retryOnDdlRace(() =>
+        client.execute(
+          `CREATE INDEX IF NOT EXISTS idx_workspace_connections_updated_at ON ${table} (updated_at)`,
+        ),
+      );
+      await retryOnDdlRace(() => client.execute(createGrantsSql));
       await ensureWorkspaceConnectionGrantColumns(client, grantsTable);
-
       await retryOnDdlRace(() =>
         client.execute(
           `CREATE UNIQUE INDEX IF NOT EXISTS idx_workspace_connection_grants_connection_app ON ${grantsTable} (connection_id, app_id)`,


### PR DESCRIPTION
Extends #1510 from app_secrets/settings to **every** on-demand `ensureTable` in packages/core (~36 stores). Each now probes `information_schema`/`pg_indexes` before any `CREATE`/`ALTER`/`CREATE INDEX` (zero DDL / no `ACCESS EXCLUSIVE` lock on the already-migrated path), runs required DDL under a transaction-scoped `SET LOCAL lock_timeout` (no leak onto the pooled connection), and **re-probes after a swallowed timeout — throwing rather than memoizing init success if schema is still missing** (no poisoned memo). Fixes durable bg workers hanging on the first-touch DDL lock of any table on shared Neon. Shared helpers in `db/ddl-guard.ts`; SQLite unchanged; `intType()` built at runtime. **Full core suite: 5790 pass, typecheck clean.**