### PR TITLE
Extend builder starter sync to include toolchain files

### DIFF
--- a/.changeset/starter-toolchain-sync.md
+++ b/.changeset/starter-toolchain-sync.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Sync builder-agent-native-starter toolchain files (React Router config, Vite config, server plugins, etc.) alongside the manifest so dependency bumps from templates/chat do not leave the starter in a broken state. Standalone scaffolds now pin tsconfig `baseUrl` to the app root for correct `@/*` path resolution.
+Sync builder-agent-native-starter toolchain files (React Router config, Vite config, server plugins, etc.) alongside the manifest so dependency bumps from templates/chat do not leave the starter in a broken state. Standalone scaffolds now re-declare tsconfig `paths` anchored to the app root for correct `@/*` resolution under TypeScript 6.

--- a/.changeset/starter-toolchain-sync.md
+++ b/.changeset/starter-toolchain-sync.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Sync builder-agent-native-starter toolchain files (React Router config, Vite config, server plugins, etc.) alongside the manifest so dependency bumps from templates/chat do not leave the starter in a broken state. Standalone scaffolds now re-declare tsconfig `paths` anchored to the app root for correct `@/*` resolution under TypeScript 6.
+Sync builder-agent-native-starter toolchain files (React Router config, Vite config, server plugins, etc.) alongside the manifest so dependency bumps from templates/chat do not leave the starter in a broken state. Standalone UI scaffolds re-declare tsconfig `paths` and `baseUrl` for `@/*` resolution; headless scaffolds omit `baseUrl` for TS 6 tsgo compatibility. Netlify post-process now rewrites unindented template build commands.

--- a/.changeset/starter-toolchain-sync.md
+++ b/.changeset/starter-toolchain-sync.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Sync builder-agent-native-starter toolchain files (React Router config, Vite config, server plugins, etc.) alongside the manifest so dependency bumps from templates/chat do not leave the starter in a broken state. Standalone scaffolds now pin tsconfig `baseUrl` to the app root for correct `@/*` path resolution.

--- a/.github/workflows/sync-builder-starter.yml
+++ b/.github/workflows/sync-builder-starter.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
     paths:
       - "templates/chat/package.json"
+      - "templates/chat/react-router.config.ts"
+      - "templates/chat/vite.config.ts"
+      - "templates/chat/tsconfig.json"
+      - "templates/chat/ssr-entry.ts"
+      - "templates/chat/app/vite-env.d.ts"
+      - "templates/chat/app/routes.ts"
+      - "templates/chat/server/**"
+      - "templates/chat/components.json"
+      - "templates/chat/.oxfmtrc.json"
       - "pnpm-workspace.yaml"
       - "packages/core/src/cli/create.ts"
       - "packages/core/src/cli/sync-builder-starter-manifest.ts"

--- a/.github/workflows/sync-builder-starter.yml
+++ b/.github/workflows/sync-builder-starter.yml
@@ -4,19 +4,12 @@ on:
   push:
     branches: [main]
     paths:
-      - "templates/chat/package.json"
-      - "templates/chat/react-router.config.ts"
-      - "templates/chat/vite.config.ts"
-      - "templates/chat/tsconfig.json"
-      - "templates/chat/ssr-entry.ts"
-      - "templates/chat/app/vite-env.d.ts"
-      - "templates/chat/app/routes.ts"
-      - "templates/chat/server/**"
-      - "templates/chat/components.json"
-      - "templates/chat/.oxfmtrc.json"
+      # Broad trigger: starter sync is idempotent and only opens a PR when synced
+      # paths actually drift. Toolchain file list lives in sync-builder-starter-manifest.ts.
+      - "templates/chat/**"
       - "pnpm-workspace.yaml"
       - "packages/core/src/cli/create.ts"
-      - "packages/core/src/cli/sync-builder-starter-manifest.ts"
+      - "packages/core/src/cli/sync-builder-starter-manifest*"
       - "scripts/sync-builder-starter-manifest.ts"
       - ".github/workflows/sync-builder-starter.yml"
   workflow_dispatch:

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -324,6 +324,8 @@ describe("headless onboarding guards", { timeout: 60000 }, () => {
     ).toBeDefined();
     expect(types).not.toContain("vite/client");
     expect(types).toContain("node");
+    expect(tsconfig.compilerOptions?.baseUrl).toBeUndefined();
+    expect(tsconfig.compilerOptions?.paths?.["*"]).toEqual(["./*"]);
   });
 
   it("keeps the package root (Node default) entry free of the React client barrel", () => {

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -1040,6 +1040,28 @@ describe("Netlify scaffold rewrite", () => {
     expect(netlify).toContain('functions = ".netlify/functions-internal"');
   });
 
+  it("keeps unpooled database overrides for unindented template netlify commands", () => {
+    const appDir = path.join(tmpDir, "unpooled-unindented-app");
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, "netlify.toml"),
+      [
+        "[build]",
+        'command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && DATABASE_URL=${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL} NITRO_PRESET=netlify pnpm --filter mail build"',
+        'publish = "templates/mail/dist"',
+        'functions = "templates/mail/.netlify/functions-internal"',
+        "",
+      ].join("\n"),
+    );
+
+    _rewriteNetlifyToml(appDir, "mail", "standalone");
+
+    const netlify = fs.readFileSync(path.join(appDir, "netlify.toml"), "utf-8");
+    expect(netlify).toContain("NETLIFY_DATABASE_URL_UNPOOLED");
+    expect(netlify).toContain("NITRO_PRESET=netlify pnpm build");
+    expect(netlify).not.toContain("pnpm install");
+  });
+
   it("rewrites unindented chat template netlify build commands for standalone apps", () => {
     const appDir = path.join(tmpDir, "chat-standalone-netlify");
     fs.mkdirSync(appDir, { recursive: true });

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -1040,6 +1040,29 @@ describe("Netlify scaffold rewrite", () => {
     expect(netlify).toContain('functions = ".netlify/functions-internal"');
   });
 
+  it("rewrites unindented chat template netlify build commands for standalone apps", () => {
+    const appDir = path.join(tmpDir, "chat-standalone-netlify");
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, "netlify.toml"),
+      [
+        "[build]",
+        'command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter chat build"',
+        'publish = "templates/chat/dist"',
+        'functions = "templates/chat/.netlify/functions-internal"',
+        "",
+      ].join("\n"),
+    );
+
+    _rewriteNetlifyToml(appDir, "builder-agent-native-starter", "standalone");
+
+    const netlify = fs.readFileSync(path.join(appDir, "netlify.toml"), "utf-8");
+    expect(netlify).toContain("NITRO_PRESET=netlify pnpm build");
+    expect(netlify).not.toContain("--filter chat");
+    expect(netlify).not.toContain("pnpm install");
+    expect(netlify).toContain('publish = "dist"');
+  });
+
   it("does not add Dispatch root redirects to other workspace apps", () => {
     const appDir = path.join(tmpDir, "chat-app");
     fs.mkdirSync(appDir, { recursive: true });

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -282,7 +282,7 @@ describe("standalone scaffold — headless template", { timeout: 60000 }, () => 
     );
     expect(workspaceYaml).toContain("allowBuilds:");
     expect(workspaceYaml).toContain("minimumReleaseAgeExclude:");
-    expect(workspaceYaml).toContain('"@sentry/node"');
+    expect(workspaceYaml).toContain('"@sentry/*"');
     expect(workspaceYaml).not.toContain("@assistant-ui");
   });
 });

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1080,10 +1080,17 @@ function fixStandaloneTsconfig(targetDir: string): void {
       compilerOptions?: Record<string, unknown>;
     };
     tsconfig.compilerOptions ??= {};
-    // Standalone apps extend @agent-native/core/tsconfig.base.json, whose
-    // paths resolve relative to the package install dir unless baseUrl is set
-    // to the app root.
-    tsconfig.compilerOptions.baseUrl = ".";
+    // TS 6 removed baseUrl. Standalone apps extend @agent-native/core's base
+    // config, whose paths resolve from the package install dir unless the app
+    // re-declares paths anchored to the app root.
+    delete tsconfig.compilerOptions.baseUrl;
+    const paths = {
+      ...((tsconfig.compilerOptions.paths as Record<string, string[]>) ?? {}),
+    };
+    paths["*"] ??= ["./*"];
+    paths["@/*"] ??= ["./app/*"];
+    paths["@shared/*"] ??= ["./shared/*"];
+    tsconfig.compilerOptions.paths = paths;
     fs.writeFileSync(tsconfigPath, `${JSON.stringify(tsconfig, null, 2)}\n`);
   } catch {}
 }

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1072,10 +1072,7 @@ function postProcessStandalone(
   setupAgentSymlinks(targetDir);
 }
 
-function fixStandaloneTsconfig(
-  targetDir: string,
-  templateName?: string,
-): void {
+function fixStandaloneTsconfig(targetDir: string, templateName?: string): void {
   const tsconfigPath = path.join(targetDir, "tsconfig.json");
   if (!fs.existsSync(tsconfigPath)) return;
   try {
@@ -1084,8 +1081,7 @@ function fixStandaloneTsconfig(
     };
     tsconfig.compilerOptions ??= {};
     const hasUiApp =
-      templateName !== "headless" &&
-      fs.existsSync(path.join(targetDir, "app"));
+      templateName !== "headless" && fs.existsSync(path.join(targetDir, "app"));
     const paths = {
       ...((tsconfig.compilerOptions.paths as Record<string, string[]>) ?? {}),
     };
@@ -1758,7 +1754,7 @@ function rewriteNetlifyToml(
 
   try {
     let content = fs.readFileSync(netlifyPath, "utf-8");
-    const originalCommand = content.match(/^  command = "([^"]*)"$/m)?.[1];
+    const originalCommand = content.match(/^\s*command = "([^"]*)"$/m)?.[1];
     const usesUnpooledDatabase =
       originalCommand?.includes("NETLIFY_DATABASE_URL_UNPOOLED") ?? false;
     const buildCommand =

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1067,12 +1067,15 @@ function postProcessStandalone(
     }
   } catch {}
 
-  fixStandaloneTsconfig(targetDir);
+  fixStandaloneTsconfig(targetDir, templateName);
 
   setupAgentSymlinks(targetDir);
 }
 
-function fixStandaloneTsconfig(targetDir: string): void {
+function fixStandaloneTsconfig(
+  targetDir: string,
+  templateName?: string,
+): void {
   const tsconfigPath = path.join(targetDir, "tsconfig.json");
   if (!fs.existsSync(tsconfigPath)) return;
   try {
@@ -1080,16 +1083,23 @@ function fixStandaloneTsconfig(targetDir: string): void {
       compilerOptions?: Record<string, unknown>;
     };
     tsconfig.compilerOptions ??= {};
-    // TS 6 removed baseUrl. Standalone apps extend @agent-native/core's base
-    // config, whose paths resolve from the package install dir unless the app
-    // re-declares paths anchored to the app root.
-    delete tsconfig.compilerOptions.baseUrl;
+    const hasUiApp =
+      templateName !== "headless" &&
+      fs.existsSync(path.join(targetDir, "app"));
     const paths = {
       ...((tsconfig.compilerOptions.paths as Record<string, string[]>) ?? {}),
     };
     paths["*"] ??= ["./*"];
-    paths["@/*"] ??= ["./app/*"];
-    paths["@shared/*"] ??= ["./shared/*"];
+    if (hasUiApp) {
+      paths["@/*"] ??= ["./app/*"];
+      paths["@shared/*"] ??= ["./shared/*"];
+      // Child baseUrl anchors @/* for apps extending legacy core tsconfig bases
+      // that still ship baseUrl. Headless scaffolds omit it so raw tsgo --noEmit
+      // keeps working under TS 6.
+      tsconfig.compilerOptions.baseUrl = ".";
+    } else {
+      delete tsconfig.compilerOptions.baseUrl;
+    }
     tsconfig.compilerOptions.paths = paths;
     fs.writeFileSync(tsconfigPath, `${JSON.stringify(tsconfig, null, 2)}\n`);
   } catch {}
@@ -1768,7 +1778,7 @@ function rewriteNetlifyToml(
         : ".netlify/functions-internal";
 
     content = content
-      .replace(/^  command = ".*"$/m, `  command = "${command}"`)
+      .replace(/^(\s*)command = ".*"$/m, `$1command = "${command}"`)
       .replace(
         /publish = "templates\/[^"]+\/dist"/g,
         `publish = "${publishPath}"`,

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -969,6 +969,7 @@ function postProcessStandalone(
   const appTitle = appTitleForScaffold(name);
   replacePlaceholders(targetDir, name, appTitle);
   rewriteTrackingAppId(targetDir, name, templateName);
+  rewriteAgentChatAppId(targetDir, name, templateName);
   fixPackageJsonName(targetDir, name, templateName);
   fixWebManifestName(targetDir, name, templateName);
   rewriteNetlifyToml(targetDir, name, "standalone");
@@ -1069,7 +1070,25 @@ function postProcessStandalone(
     }
   } catch {}
 
+  fixStandaloneTsconfig(targetDir);
+
   setupAgentSymlinks(targetDir);
+}
+
+function fixStandaloneTsconfig(targetDir: string): void {
+  const tsconfigPath = path.join(targetDir, "tsconfig.json");
+  if (!fs.existsSync(tsconfigPath)) return;
+  try {
+    const tsconfig = JSON.parse(fs.readFileSync(tsconfigPath, "utf-8")) as {
+      compilerOptions?: Record<string, unknown>;
+    };
+    tsconfig.compilerOptions ??= {};
+    // Standalone apps extend @agent-native/core/tsconfig.base.json, whose
+    // paths resolve relative to the package install dir unless baseUrl is set
+    // to the app root.
+    tsconfig.compilerOptions.baseUrl = ".";
+    fs.writeFileSync(tsconfigPath, `${JSON.stringify(tsconfig, null, 2)}\n`);
+  } catch {}
 }
 
 /* ─────────────────────────────────────────────────────────────────────────
@@ -1764,6 +1783,36 @@ function rewriteNetlifyToml(
     }
 
     fs.writeFileSync(netlifyPath, content);
+  } catch {}
+}
+
+function rewriteAgentChatAppId(
+  appDir: string,
+  appName: string,
+  templateName?: string,
+): void {
+  const pluginPath = path.join(appDir, "server", "plugins", "agent-chat.ts");
+  if (!fs.existsSync(pluginPath)) return;
+
+  try {
+    const content = fs.readFileSync(pluginPath, "utf-8");
+    const sourceAppIds = ["chat", "starter"];
+    if (templateName && templateName !== appName) {
+      sourceAppIds.push(templateName);
+    }
+    const pattern = new RegExp(
+      `(appId:\\s*)(["'])(${sourceAppIds.map(escapeRegExp).join("|")})\\2`,
+    );
+    if (!pattern.test(content)) return;
+
+    const next = content.replace(
+      pattern,
+      (_match, prefix: string, quote: string) =>
+        `${prefix}${quote}${appName}${quote}`,
+    );
+    if (next !== content) {
+      fs.writeFileSync(pluginPath, next);
+    }
   } catch {}
 }
 

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -27,10 +27,7 @@ const STANDALONE_EXACT_DEPENDENCY_OVERRIDES: Record<string, string> = {
   "@react-router/fs-routes": "8.0.1",
   "react-router": "8.0.1",
 };
-const SENTRY_MINIMUM_RELEASE_AGE_EXCLUDES = [
-  '"@sentry/browser"',
-  '"@sentry/node"',
-];
+const SENTRY_MINIMUM_RELEASE_AGE_EXCLUDES = ['"@sentry/*"'];
 const FIRST_PARTY_TARBALL_SYMLINK_EXCLUDES = [
   "*/CLAUDE.md",
   "*/.claude/skills",

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -57,9 +57,10 @@ describe("sync-builder-starter-manifest", () => {
           "v8_viteEnvironmentApi",
         );
         const tsconfig = JSON.parse(files.get("tsconfig.json") ?? "{}") as {
-          compilerOptions?: { baseUrl?: string };
+          compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> };
         };
-        expect(tsconfig.compilerOptions?.baseUrl).toBe(".");
+        expect(tsconfig.compilerOptions?.baseUrl).toBeUndefined();
+        expect(tsconfig.compilerOptions?.paths?.["*"]).toEqual(["./*"]);
         expect(
           fs.readFileSync(
             path.join(snapshot.dir, "server/plugins/agent-chat.ts"),

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -5,9 +5,11 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  applyStarterToolchainSync,
   applyWorkspaceFileSync,
   collectStarterToolchainFiles,
   createStandaloneChatSnapshot,
+  diffStarterToolchainFiles,
   generateStandaloneChatManifest,
   mergeStarterManifest,
   STARTER_TOOLCHAIN_SYNC_PATHS,
@@ -61,6 +63,8 @@ describe("sync-builder-starter-manifest", () => {
         expect(files.get("server/plugins/agent-chat.ts")).toContain(
           'appId: "builder-agent-native-starter"',
         );
+        expect(files.get("netlify.toml")).toContain('publish = "dist"');
+        expect(files.get("netlify.toml")).not.toContain("templates/chat");
       } finally {
         snapshot.cleanup();
       }
@@ -248,6 +252,32 @@ describe("sync-builder-starter-manifest", () => {
             "utf-8",
           ),
         ).not.toContain("v8_viteEnvironmentApi");
+      },
+      STARTER_MANIFEST_TIMEOUT_MS,
+    );
+
+    it(
+      "deletes stale starter toolchain files removed from templates/chat",
+      () => {
+        tempDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), "an-starter-sync-spec-"),
+        );
+        fs.writeFileSync(
+          path.join(tempDir, "components.json"),
+          '{"stale":true}\n',
+        );
+
+        const changes = diffStarterToolchainFiles(tempDir, new Map());
+        expect(
+          changes.find((change) => change.relativePath === "components.json")
+            ?.changed,
+        ).toBe(true);
+
+        applyStarterToolchainSync(tempDir, new Map());
+
+        expect(fs.existsSync(path.join(tempDir, "components.json"))).toBe(
+          false,
+        );
       },
       STARTER_MANIFEST_TIMEOUT_MS,
     );

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -73,7 +73,9 @@ describe("sync-builder-starter-manifest", () => {
         ).toContain('appId: "builder-agent-native-starter"');
         expect(files.get("netlify.toml")).toContain('publish = "dist"');
         expect(files.get("netlify.toml")).not.toContain("templates/chat");
-        expect(files.get("netlify.toml")).toContain("NITRO_PRESET=netlify pnpm build");
+        expect(files.get("netlify.toml")).toContain(
+          "NITRO_PRESET=netlify pnpm build",
+        );
         expect(files.get("netlify.toml")).not.toContain("--filter chat");
       } finally {
         snapshot.cleanup();

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -63,7 +63,7 @@ describe("sync-builder-starter-manifest", () => {
             paths?: Record<string, string[]>;
           };
         };
-        expect(tsconfig.compilerOptions?.baseUrl).toBeUndefined();
+        expect(tsconfig.compilerOptions?.baseUrl).toBe(".");
         expect(tsconfig.compilerOptions?.paths?.["*"]).toEqual(["./*"]);
         expect(
           fs.readFileSync(
@@ -73,6 +73,8 @@ describe("sync-builder-starter-manifest", () => {
         ).toContain('appId: "builder-agent-native-starter"');
         expect(files.get("netlify.toml")).toContain('publish = "dist"');
         expect(files.get("netlify.toml")).not.toContain("templates/chat");
+        expect(files.get("netlify.toml")).toContain("NITRO_PRESET=netlify pnpm build");
+        expect(files.get("netlify.toml")).not.toContain("--filter chat");
       } finally {
         snapshot.cleanup();
       }

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -60,9 +60,12 @@ describe("sync-builder-starter-manifest", () => {
           compilerOptions?: { baseUrl?: string };
         };
         expect(tsconfig.compilerOptions?.baseUrl).toBe(".");
-        expect(files.get("server/plugins/agent-chat.ts")).toContain(
-          'appId: "builder-agent-native-starter"',
-        );
+        expect(
+          fs.readFileSync(
+            path.join(snapshot.dir, "server/plugins/agent-chat.ts"),
+            "utf-8",
+          ),
+        ).toContain('appId: "builder-agent-native-starter"');
         expect(files.get("netlify.toml")).toContain('publish = "dist"');
         expect(files.get("netlify.toml")).not.toContain("templates/chat");
       } finally {
@@ -71,6 +74,15 @@ describe("sync-builder-starter-manifest", () => {
     },
     STARTER_MANIFEST_TIMEOUT_MS,
   );
+
+  it("does not sync starter-owned plugin prompt and marketing files", () => {
+    expect(STARTER_TOOLCHAIN_SYNC_PATHS).not.toContain(
+      "server/plugins/agent-chat.ts",
+    );
+    expect(STARTER_TOOLCHAIN_SYNC_PATHS).not.toContain(
+      "server/plugins/auth.ts",
+    );
+  });
 
   it(
     "preserves starter identity fields and pinned core when merging",

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -6,8 +6,11 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   applyWorkspaceFileSync,
+  collectStarterToolchainFiles,
+  createStandaloneChatSnapshot,
   generateStandaloneChatManifest,
   mergeStarterManifest,
+  STARTER_TOOLCHAIN_SYNC_PATHS,
   syncStarterManifestFiles,
   workspaceFileSyncChanged,
 } from "./sync-builder-starter-manifest.js";
@@ -34,6 +37,33 @@ describe("sync-builder-starter-manifest", () => {
       expect(Object.values(deps).some((value) => value === "catalog:")).toBe(
         false,
       );
+    },
+    STARTER_MANIFEST_TIMEOUT_MS,
+  );
+
+  it(
+    "collects toolchain files from the post-processed standalone snapshot",
+    () => {
+      const snapshot = createStandaloneChatSnapshot(repoRoot);
+      try {
+        const files = collectStarterToolchainFiles(snapshot.dir);
+        for (const relativePath of STARTER_TOOLCHAIN_SYNC_PATHS) {
+          if (relativePath === ".oxfmtrc.json") continue;
+          expect(files.has(relativePath), relativePath).toBe(true);
+        }
+        expect(files.get("react-router.config.ts")).not.toContain(
+          "v8_viteEnvironmentApi",
+        );
+        const tsconfig = JSON.parse(files.get("tsconfig.json") ?? "{}") as {
+          compilerOptions?: { baseUrl?: string };
+        };
+        expect(tsconfig.compilerOptions?.baseUrl).toBe(".");
+        expect(files.get("server/plugins/agent-chat.ts")).toContain(
+          'appId: "builder-agent-native-starter"',
+        );
+      } finally {
+        snapshot.cleanup();
+      }
     },
     STARTER_MANIFEST_TIMEOUT_MS,
   );
@@ -71,43 +101,48 @@ describe("sync-builder-starter-manifest", () => {
     STARTER_MANIFEST_TIMEOUT_MS,
   );
 
-  it("preserves starter-only manifest fields not present in templates/chat", () => {
-    const { packageJson: canonical } = generateStandaloneChatManifest(repoRoot);
-    const merged = mergeStarterManifest(
-      {
-        packageManager: "pnpm@10.14.0",
-        scripts: {
-          dev: "node scripts/maybe-migrate.mjs && agent-native dev --open",
-          "db:generate": "drizzle-kit generate",
-          "db:migrate": "drizzle-kit migrate",
+  it(
+    "preserves starter-only manifest fields not present in templates/chat",
+    () => {
+      const { packageJson: canonical } =
+        generateStandaloneChatManifest(repoRoot);
+      const merged = mergeStarterManifest(
+        {
+          packageManager: "pnpm@10.14.0",
+          scripts: {
+            dev: "node scripts/maybe-migrate.mjs && agent-native dev --open",
+            "db:generate": "drizzle-kit generate",
+            "db:migrate": "drizzle-kit migrate",
+          },
+          dependencies: {
+            "@agent-native/core": "0.72.1",
+            "@neondatabase/serverless": "^1.0.2",
+            "drizzle-orm": "0.45.2",
+          },
+          devDependencies: {
+            "drizzle-kit": "0.31.10",
+            dotenv: "^17.2.1",
+          },
         },
-        dependencies: {
-          "@agent-native/core": "0.72.1",
-          "@neondatabase/serverless": "^1.0.2",
-          "drizzle-orm": "0.45.2",
-        },
-        devDependencies: {
-          "drizzle-kit": "0.31.10",
-          dotenv: "^17.2.1",
-        },
-      },
-      canonical,
-    );
+        canonical,
+      );
 
-    const deps = merged.dependencies as Record<string, string>;
-    const devDeps = merged.devDependencies as Record<string, string>;
-    const scripts = merged.scripts as Record<string, string>;
+      const deps = merged.dependencies as Record<string, string>;
+      const devDeps = merged.devDependencies as Record<string, string>;
+      const scripts = merged.scripts as Record<string, string>;
 
-    expect(deps["@agent-native/core"]).toBe("0.72.1");
-    expect(deps["@neondatabase/serverless"]).toBe("^1.0.2");
-    expect(deps["drizzle-orm"]).toBe("0.45.2");
-    expect(deps.postgres).toBe("^3.4.9");
-    expect(devDeps["drizzle-kit"]).toBe("0.31.10");
-    expect(devDeps.dotenv).toBe("^17.2.1");
-    expect(scripts["db:generate"]).toBe("drizzle-kit generate");
-    expect(scripts["db:migrate"]).toBe("drizzle-kit migrate");
-    expect(merged.packageManager).toBe("pnpm@10.14.0");
-  }, 15000);
+      expect(deps["@agent-native/core"]).toBe("0.72.1");
+      expect(deps["@neondatabase/serverless"]).toBe("^1.0.2");
+      expect(deps["drizzle-orm"]).toBe("0.45.2");
+      expect(deps.postgres).toBe("^3.4.9");
+      expect(devDeps["drizzle-kit"]).toBe("0.31.10");
+      expect(devDeps.dotenv).toBe("^17.2.1");
+      expect(scripts["db:generate"]).toBe("drizzle-kit generate");
+      expect(scripts["db:migrate"]).toBe("drizzle-kit migrate");
+      expect(merged.packageManager).toBe("pnpm@10.14.0");
+    },
+    STARTER_MANIFEST_TIMEOUT_MS,
+  );
 
   describe("syncStarterManifestFiles", () => {
     let tempDir: string;
@@ -118,32 +153,104 @@ describe("sync-builder-starter-manifest", () => {
       }
     });
 
-    it("reports no changes when starter already matches the canonical manifest", () => {
-      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "an-starter-sync-spec-"));
-      const { packageJson, pnpmWorkspaceYaml } =
-        generateStandaloneChatManifest(repoRoot);
-      const starterPackageJsonPath = path.join(tempDir, "package.json");
-      const starterPnpmWorkspacePath = path.join(
-        tempDir,
-        "pnpm-workspace.yaml",
-      );
+    it(
+      "reports no changes when starter already matches the canonical manifest",
+      () => {
+        tempDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), "an-starter-sync-spec-"),
+        );
+        const snapshot = createStandaloneChatSnapshot(repoRoot);
+        try {
+          const starterPackageJsonPath = path.join(tempDir, "package.json");
+          const starterPnpmWorkspacePath = path.join(
+            tempDir,
+            "pnpm-workspace.yaml",
+          );
 
-      fs.writeFileSync(
-        starterPackageJsonPath,
-        `${JSON.stringify(packageJson, null, 2)}\n`,
-      );
-      if (pnpmWorkspaceYaml) {
-        fs.writeFileSync(starterPnpmWorkspacePath, pnpmWorkspaceYaml);
-      }
+          fs.writeFileSync(
+            starterPackageJsonPath,
+            `${JSON.stringify(snapshot.packageJson, null, 2)}\n`,
+          );
+          if (snapshot.pnpmWorkspaceYaml) {
+            fs.writeFileSync(
+              starterPnpmWorkspacePath,
+              snapshot.pnpmWorkspaceYaml,
+            );
+          }
+          for (const [relativePath, content] of snapshot.toolchainFiles) {
+            const targetPath = path.join(tempDir, relativePath);
+            fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+            fs.writeFileSync(targetPath, content);
+          }
 
-      const result = syncStarterManifestFiles({
-        starterPackageJsonPath,
-        starterPnpmWorkspacePath,
-        repoRoot,
-      });
+          const result = syncStarterManifestFiles({
+            starterDir: tempDir,
+            repoRoot,
+          });
 
-      expect(result.changed).toBe(false);
-    }, 15_000);
+          expect(result.changed).toBe(false);
+        } finally {
+          snapshot.cleanup();
+        }
+      },
+      STARTER_MANIFEST_TIMEOUT_MS,
+    );
+
+    it(
+      "syncs toolchain files when starter config drifts from templates/chat",
+      () => {
+        tempDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), "an-starter-sync-spec-"),
+        );
+        const { packageJson, pnpmWorkspaceYaml } =
+          generateStandaloneChatManifest(repoRoot);
+
+        fs.writeFileSync(
+          path.join(tempDir, "package.json"),
+          `${JSON.stringify(packageJson, null, 2)}\n`,
+        );
+        if (pnpmWorkspaceYaml) {
+          fs.writeFileSync(
+            path.join(tempDir, "pnpm-workspace.yaml"),
+            pnpmWorkspaceYaml,
+          );
+        }
+        fs.writeFileSync(
+          path.join(tempDir, "react-router.config.ts"),
+          [
+            'import type { Config } from "@react-router/dev/config";',
+            "",
+            "export default {",
+            '  appDirectory: "app",',
+            "  ssr: true,",
+            '  routeDiscovery: { mode: "initial" },',
+            "  future: {",
+            "    v8_viteEnvironmentApi: true,",
+            "  },",
+            "} satisfies Config;",
+            "",
+          ].join("\n"),
+        );
+
+        const result = syncStarterManifestFiles({
+          starterDir: tempDir,
+          repoRoot,
+          write: true,
+        });
+
+        expect(result.changed).toBe(true);
+        expect(result.changedToolchainPaths).toContain(
+          "react-router.config.ts",
+        );
+        expect(
+          fs.readFileSync(
+            path.join(tempDir, "react-router.config.ts"),
+            "utf-8",
+          ),
+        ).not.toContain("v8_viteEnvironmentApi");
+      },
+      STARTER_MANIFEST_TIMEOUT_MS,
+    );
   });
 
   describe("workspaceFileSyncChanged", () => {

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -11,6 +11,7 @@ import {
   createStandaloneChatSnapshot,
   diffStarterToolchainFiles,
   generateStandaloneChatManifest,
+  listStarterSyncPaths,
   mergeStarterManifest,
   STARTER_TOOLCHAIN_SYNC_PATHS,
   syncStarterManifestFiles,
@@ -57,7 +58,10 @@ describe("sync-builder-starter-manifest", () => {
           "v8_viteEnvironmentApi",
         );
         const tsconfig = JSON.parse(files.get("tsconfig.json") ?? "{}") as {
-          compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> };
+          compilerOptions?: {
+            baseUrl?: string;
+            paths?: Record<string, string[]>;
+          };
         };
         expect(tsconfig.compilerOptions?.baseUrl).toBeUndefined();
         expect(tsconfig.compilerOptions?.paths?.["*"]).toEqual(["./*"]);
@@ -83,6 +87,10 @@ describe("sync-builder-starter-manifest", () => {
     expect(STARTER_TOOLCHAIN_SYNC_PATHS).not.toContain(
       "server/plugins/auth.ts",
     );
+  });
+
+  it("includes pnpm-lock.yaml in starter CI staging paths", () => {
+    expect(listStarterSyncPaths()).toContain("pnpm-lock.yaml");
   });
 
   it(

--- a/packages/core/src/cli/sync-builder-starter-manifest.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.ts
@@ -22,6 +22,7 @@ export const STARTER_TOOLCHAIN_SYNC_PATHS = [
   "server/middleware/auth.ts",
   "components.json",
   ".oxfmtrc.json",
+  "netlify.toml",
 ] as const;
 
 export type StarterToolchainSyncPath =
@@ -218,18 +219,17 @@ export function diffStarterToolchainFiles(
   starterDir: string,
   canonicalFiles: Map<StarterToolchainSyncPath, string>,
 ): StarterToolchainSyncChange[] {
-  return [...canonicalFiles.entries()].map(
-    ([relativePath, canonicalContent]) => {
-      const targetPath = path.join(starterDir, relativePath);
-      const existingContent = fs.existsSync(targetPath)
-        ? fs.readFileSync(targetPath, "utf-8")
-        : null;
-      return {
-        relativePath,
-        changed: existingContent !== canonicalContent,
-      };
-    },
-  );
+  return STARTER_TOOLCHAIN_SYNC_PATHS.map((relativePath) => {
+    const canonicalContent = canonicalFiles.get(relativePath) ?? null;
+    const targetPath = path.join(starterDir, relativePath);
+    const existingContent = fs.existsSync(targetPath)
+      ? fs.readFileSync(targetPath, "utf-8")
+      : null;
+    return {
+      relativePath,
+      changed: existingContent !== canonicalContent,
+    };
+  });
 }
 
 export function applyStarterToolchainSync(
@@ -237,15 +237,22 @@ export function applyStarterToolchainSync(
   canonicalFiles: Map<StarterToolchainSyncPath, string>,
 ): StarterToolchainSyncChange[] {
   const changes: StarterToolchainSyncChange[] = [];
-  for (const [relativePath, canonicalContent] of canonicalFiles.entries()) {
+  for (const relativePath of STARTER_TOOLCHAIN_SYNC_PATHS) {
+    const canonicalContent = canonicalFiles.get(relativePath) ?? null;
     const targetPath = path.join(starterDir, relativePath);
     const existingContent = fs.existsSync(targetPath)
       ? fs.readFileSync(targetPath, "utf-8")
       : null;
     const changed = existingContent !== canonicalContent;
     if (changed) {
-      fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-      fs.writeFileSync(targetPath, canonicalContent);
+      if (canonicalContent === null) {
+        if (fs.existsSync(targetPath)) {
+          fs.unlinkSync(targetPath);
+        }
+      } else {
+        fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+        fs.writeFileSync(targetPath, canonicalContent);
+      }
     }
     changes.push({ relativePath, changed });
   }

--- a/packages/core/src/cli/sync-builder-starter-manifest.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.ts
@@ -17,8 +17,8 @@ export const STARTER_TOOLCHAIN_SYNC_PATHS = [
   "app/vite-env.d.ts",
   "app/routes.ts",
   "server/routes/[...page].get.ts",
-  "server/plugins/agent-chat.ts",
-  "server/plugins/auth.ts",
+  // server/plugins/* are intentionally excluded: starter keeps its own
+  // systemPrompt and auth marketing copy; post-process only rewrites appId/title.
   "server/middleware/auth.ts",
   "components.json",
   ".oxfmtrc.json",

--- a/packages/core/src/cli/sync-builder-starter-manifest.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.ts
@@ -8,7 +8,42 @@ import { _postProcessStandalone } from "./create.js";
 export const STARTER_APP_NAME = "builder-agent-native-starter";
 export const CHAT_TEMPLATE = "chat";
 
+/** Toolchain files that must track templates/chat or typecheck/build drift. */
+export const STARTER_TOOLCHAIN_SYNC_PATHS = [
+  "react-router.config.ts",
+  "vite.config.ts",
+  "tsconfig.json",
+  "ssr-entry.ts",
+  "app/vite-env.d.ts",
+  "app/routes.ts",
+  "server/routes/[...page].get.ts",
+  "server/plugins/agent-chat.ts",
+  "server/plugins/auth.ts",
+  "server/middleware/auth.ts",
+  "components.json",
+  ".oxfmtrc.json",
+] as const;
+
+export type StarterToolchainSyncPath =
+  (typeof STARTER_TOOLCHAIN_SYNC_PATHS)[number];
+
 type PackageJson = Record<string, unknown>;
+
+export type StandaloneChatSnapshot = {
+  cleanup: () => void;
+  dir: string;
+  packageJson: PackageJson;
+  pnpmWorkspaceYaml: string | null;
+  toolchainFiles: Map<StarterToolchainSyncPath, string>;
+};
+
+export function listStarterSyncPaths(): string[] {
+  return [
+    "package.json",
+    "pnpm-workspace.yaml",
+    ...STARTER_TOOLCHAIN_SYNC_PATHS,
+  ];
+}
 
 export function findAgentNativeRoot(startDir = process.cwd()): string {
   let dir = path.resolve(startDir);
@@ -31,32 +66,62 @@ export function findAgentNativeRoot(startDir = process.cwd()): string {
   );
 }
 
-export function generateStandaloneChatManifest(repoRoot?: string): {
-  packageJson: PackageJson;
-  pnpmWorkspaceYaml: string | null;
-} {
+export function collectStarterToolchainFiles(
+  canonicalDir: string,
+): Map<StarterToolchainSyncPath, string> {
+  const files = new Map<StarterToolchainSyncPath, string>();
+  for (const relativePath of STARTER_TOOLCHAIN_SYNC_PATHS) {
+    const absolutePath = path.join(canonicalDir, relativePath);
+    if (!fs.existsSync(absolutePath)) continue;
+    files.set(relativePath, fs.readFileSync(absolutePath, "utf-8"));
+  }
+  return files;
+}
+
+export function createStandaloneChatSnapshot(
+  repoRoot?: string,
+): StandaloneChatSnapshot {
   const root = repoRoot ?? findAgentNativeRoot();
   const chatTemplateDir = path.join(root, "templates", CHAT_TEMPLATE);
   const tempDir = fs.mkdtempSync(
     path.join(os.tmpdir(), "an-builder-starter-sync-"),
   );
 
+  fs.cpSync(chatTemplateDir, tempDir, { recursive: true });
+  _postProcessStandalone(STARTER_APP_NAME, tempDir, CHAT_TEMPLATE);
+
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(tempDir, "package.json"), "utf-8"),
+  ) as PackageJson;
+
+  const workspacePath = path.join(tempDir, "pnpm-workspace.yaml");
+  const pnpmWorkspaceYaml = fs.existsSync(workspacePath)
+    ? fs.readFileSync(workspacePath, "utf-8")
+    : null;
+
+  return {
+    cleanup: () => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    },
+    dir: tempDir,
+    packageJson,
+    pnpmWorkspaceYaml,
+    toolchainFiles: collectStarterToolchainFiles(tempDir),
+  };
+}
+
+export function generateStandaloneChatManifest(repoRoot?: string): {
+  packageJson: PackageJson;
+  pnpmWorkspaceYaml: string | null;
+} {
+  const snapshot = createStandaloneChatSnapshot(repoRoot);
   try {
-    fs.cpSync(chatTemplateDir, tempDir, { recursive: true });
-    _postProcessStandalone(STARTER_APP_NAME, tempDir, CHAT_TEMPLATE);
-
-    const packageJson = JSON.parse(
-      fs.readFileSync(path.join(tempDir, "package.json"), "utf-8"),
-    ) as PackageJson;
-
-    const workspacePath = path.join(tempDir, "pnpm-workspace.yaml");
-    const pnpmWorkspaceYaml = fs.existsSync(workspacePath)
-      ? fs.readFileSync(workspacePath, "utf-8")
-      : null;
-
-    return { packageJson, pnpmWorkspaceYaml };
+    return {
+      packageJson: snapshot.packageJson,
+      pnpmWorkspaceYaml: snapshot.pnpmWorkspaceYaml,
+    };
   } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    snapshot.cleanup();
   }
 }
 
@@ -144,73 +209,179 @@ function stableJson(value: unknown): string {
   return `${JSON.stringify(value, null, 2)}\n`;
 }
 
-export type SyncStarterManifestResult = {
+export type StarterToolchainSyncChange = {
+  relativePath: StarterToolchainSyncPath;
   changed: boolean;
-  packageJson: PackageJson;
-  pnpmWorkspaceYaml: string | null;
 };
 
-export function syncStarterManifestFiles(options: {
+export function diffStarterToolchainFiles(
+  starterDir: string,
+  canonicalFiles: Map<StarterToolchainSyncPath, string>,
+): StarterToolchainSyncChange[] {
+  return [...canonicalFiles.entries()].map(
+    ([relativePath, canonicalContent]) => {
+      const targetPath = path.join(starterDir, relativePath);
+      const existingContent = fs.existsSync(targetPath)
+        ? fs.readFileSync(targetPath, "utf-8")
+        : null;
+      return {
+        relativePath,
+        changed: existingContent !== canonicalContent,
+      };
+    },
+  );
+}
+
+export function applyStarterToolchainSync(
+  starterDir: string,
+  canonicalFiles: Map<StarterToolchainSyncPath, string>,
+): StarterToolchainSyncChange[] {
+  const changes: StarterToolchainSyncChange[] = [];
+  for (const [relativePath, canonicalContent] of canonicalFiles.entries()) {
+    const targetPath = path.join(starterDir, relativePath);
+    const existingContent = fs.existsSync(targetPath)
+      ? fs.readFileSync(targetPath, "utf-8")
+      : null;
+    const changed = existingContent !== canonicalContent;
+    if (changed) {
+      fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+      fs.writeFileSync(targetPath, canonicalContent);
+    }
+    changes.push({ relativePath, changed });
+  }
+  return changes;
+}
+
+export type SyncStarterManifestResult = {
+  changed: boolean;
+  packageChanged: boolean;
+  workspaceChanged: boolean;
+  packageJson: PackageJson;
+  pnpmWorkspaceYaml: string | null;
+  toolchainChanges: StarterToolchainSyncChange[];
+  changedToolchainPaths: StarterToolchainSyncPath[];
+};
+
+export function resolveStarterPaths(options: {
+  starterDir?: string;
+  starterPackageJsonPath?: string;
+  starterPnpmWorkspacePath?: string;
+}): {
+  starterDir: string;
   starterPackageJsonPath: string;
+  starterPnpmWorkspacePath: string;
+} {
+  if (options.starterDir) {
+    return {
+      starterDir: path.resolve(options.starterDir),
+      starterPackageJsonPath: path.join(
+        path.resolve(options.starterDir),
+        "package.json",
+      ),
+      starterPnpmWorkspacePath: path.join(
+        path.resolve(options.starterDir),
+        "pnpm-workspace.yaml",
+      ),
+    };
+  }
+  if (!options.starterPackageJsonPath) {
+    throw new Error("Provide --starter-dir or --starter-package-json.");
+  }
+  const starterPackageJsonPath = path.resolve(options.starterPackageJsonPath);
+  return {
+    starterDir: path.dirname(starterPackageJsonPath),
+    starterPackageJsonPath,
+    starterPnpmWorkspacePath:
+      options.starterPnpmWorkspacePath ??
+      path.join(path.dirname(starterPackageJsonPath), "pnpm-workspace.yaml"),
+  };
+}
+
+export function syncStarterManifestFiles(options: {
+  starterDir?: string;
+  starterPackageJsonPath?: string;
   starterPnpmWorkspacePath?: string;
   repoRoot?: string;
   write?: boolean;
 }): SyncStarterManifestResult {
-  const { packageJson: canonical, pnpmWorkspaceYaml } =
-    generateStandaloneChatManifest(options.repoRoot);
+  const { starterDir, starterPackageJsonPath, starterPnpmWorkspacePath } =
+    resolveStarterPaths(options);
+  const snapshot = createStandaloneChatSnapshot(options.repoRoot);
 
-  const starterPackageJson = JSON.parse(
-    fs.readFileSync(options.starterPackageJsonPath, "utf-8"),
-  ) as PackageJson;
-  const mergedPackageJson = mergeStarterManifest(starterPackageJson, canonical);
+  try {
+    const starterPackageJson = JSON.parse(
+      fs.readFileSync(starterPackageJsonPath, "utf-8"),
+    ) as PackageJson;
+    const mergedPackageJson = mergeStarterManifest(
+      starterPackageJson,
+      snapshot.packageJson,
+    );
 
-  let workspaceChanged = false;
-  const existingWorkspace =
-    options.starterPnpmWorkspacePath &&
-    fs.existsSync(options.starterPnpmWorkspacePath)
-      ? fs.readFileSync(options.starterPnpmWorkspacePath, "utf-8")
+    const existingWorkspace = fs.existsSync(starterPnpmWorkspacePath)
+      ? fs.readFileSync(starterPnpmWorkspacePath, "utf-8")
       : null;
 
-  workspaceChanged = workspaceFileSyncChanged(
-    existingWorkspace,
-    pnpmWorkspaceYaml,
-  );
+    const workspaceChanged = workspaceFileSyncChanged(
+      existingWorkspace,
+      snapshot.pnpmWorkspaceYaml,
+    );
+    const packageChanged =
+      stableJson(starterPackageJson) !== stableJson(mergedPackageJson);
+    const toolchainChanges = diffStarterToolchainFiles(
+      starterDir,
+      snapshot.toolchainFiles,
+    );
+    const changedToolchainPaths = toolchainChanges
+      .filter((change) => change.changed)
+      .map((change) => change.relativePath);
+    const changed =
+      packageChanged || workspaceChanged || changedToolchainPaths.length > 0;
 
-  const packageChanged =
-    stableJson(starterPackageJson) !== stableJson(mergedPackageJson);
-  const changed = packageChanged || workspaceChanged;
+    if (options.write && changed) {
+      if (packageChanged) {
+        fs.writeFileSync(starterPackageJsonPath, stableJson(mergedPackageJson));
+      }
+      if (workspaceChanged) {
+        applyWorkspaceFileSync(
+          starterPnpmWorkspacePath,
+          snapshot.pnpmWorkspaceYaml,
+        );
+      }
+      if (changedToolchainPaths.length > 0) {
+        applyStarterToolchainSync(starterDir, snapshot.toolchainFiles);
+      }
+    }
 
-  if (options.write && changed) {
-    if (packageChanged) {
-      fs.writeFileSync(
-        options.starterPackageJsonPath,
-        stableJson(mergedPackageJson),
-      );
-    }
-    if (workspaceChanged && options.starterPnpmWorkspacePath) {
-      applyWorkspaceFileSync(
-        options.starterPnpmWorkspacePath,
-        pnpmWorkspaceYaml,
-      );
-    }
+    return {
+      changed,
+      packageChanged,
+      workspaceChanged,
+      packageJson: mergedPackageJson,
+      pnpmWorkspaceYaml: snapshot.pnpmWorkspaceYaml,
+      toolchainChanges,
+      changedToolchainPaths,
+    };
+  } finally {
+    snapshot.cleanup();
   }
-
-  return {
-    changed,
-    packageJson: mergedPackageJson,
-    pnpmWorkspaceYaml,
-  };
 }
 
 export function parseSyncStarterManifestArgs(argv: string[]): {
-  command: "merge" | "generate";
+  command: "merge" | "generate" | "paths";
+  starterDir?: string;
   starterPackageJsonPath?: string;
   starterPnpmWorkspacePath?: string;
   write: boolean;
   repoRoot?: string;
 } {
   const [commandRaw, ...rest] = argv;
-  const command = commandRaw === "generate" ? "generate" : "merge";
+  const command =
+    commandRaw === "generate"
+      ? "generate"
+      : commandRaw === "paths"
+        ? "paths"
+        : "merge";
+  let starterDir: string | undefined;
   let starterPackageJsonPath: string | undefined;
   let starterPnpmWorkspacePath: string | undefined;
   let write = false;
@@ -220,6 +391,10 @@ export function parseSyncStarterManifestArgs(argv: string[]): {
     const arg = rest[i];
     if (arg === "--write") {
       write = true;
+      continue;
+    }
+    if (arg === "--starter-dir") {
+      starterDir = rest[++i];
       continue;
     }
     if (arg === "--starter-package-json") {
@@ -237,14 +412,15 @@ export function parseSyncStarterManifestArgs(argv: string[]): {
     throw new Error(`Unknown argument: ${arg}`);
   }
 
-  if (command === "merge" && !starterPackageJsonPath) {
+  if (command === "merge" && !starterDir && !starterPackageJsonPath) {
     throw new Error(
-      "merge requires --starter-package-json <path> [--starter-pnpm-workspace <path>] [--write] [--repo-root <path>]",
+      "merge requires --starter-dir <path> or --starter-package-json <path> [--starter-pnpm-workspace <path>] [--write] [--repo-root <path>]",
     );
   }
 
   return {
     command,
+    starterDir,
     starterPackageJsonPath,
     starterPnpmWorkspacePath,
     write,
@@ -267,25 +443,37 @@ export function runSyncStarterManifestCli(argv: string[]): number {
     return 0;
   }
 
+  if (args.command === "paths") {
+    for (const syncPath of listStarterSyncPaths()) {
+      process.stdout.write(`${syncPath}\n`);
+    }
+    return 0;
+  }
+
   const result = syncStarterManifestFiles({
-    starterPackageJsonPath: args.starterPackageJsonPath!,
+    starterDir: args.starterDir,
+    starterPackageJsonPath: args.starterPackageJsonPath,
     starterPnpmWorkspacePath: args.starterPnpmWorkspacePath,
     repoRoot: args.repoRoot,
     write: args.write,
   });
 
   if (result.changed) {
+    const updatedPaths = [
+      ...(result.packageChanged ? ["package.json"] : []),
+      ...(result.workspaceChanged ? ["pnpm-workspace.yaml"] : []),
+      ...result.changedToolchainPaths,
+    ];
+    const summary = updatedPaths.length ? ` (${updatedPaths.join(", ")})` : "";
     console.log(
       args.write
-        ? "Updated builder-agent-native-starter manifest from templates/chat."
-        : "builder-agent-native-starter manifest is out of date with templates/chat.",
+        ? `Updated builder-agent-native-starter from templates/chat${summary}.`
+        : `builder-agent-native-starter is out of date with templates/chat${summary}.`,
     );
     return args.write ? 0 : 1;
   }
 
-  console.log(
-    "builder-agent-native-starter manifest already matches templates/chat.",
-  );
+  console.log("builder-agent-native-starter already matches templates/chat.");
   return 0;
 }
 

--- a/packages/core/src/cli/sync-builder-starter-manifest.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.ts
@@ -41,6 +41,7 @@ export type StandaloneChatSnapshot = {
 export function listStarterSyncPaths(): string[] {
   return [
     "package.json",
+    "pnpm-lock.yaml",
     "pnpm-workspace.yaml",
     ...STARTER_TOOLCHAIN_SYNC_PATHS,
   ];


### PR DESCRIPTION
## Summary
- Extend `sync-builder-starter-manifest` to sync toolchain files (react-router, vite, tsconfig, server plugins, etc.) alongside `package.json`, preventing starter CI from breaking when `templates/chat` dependency bumps outpace config changes.
- Run standalone post-process during snapshot generation so synced files get correct `appId` and `tsconfig` `baseUrl`.
- Add a `paths` subcommand for starter CI to stage exactly the synced files, and expand `sync-builder-starter.yml` triggers to cover toolchain paths.

## Test plan
- [x] `pnpm exec vitest run packages/core/src/cli/sync-builder-starter-manifest.spec.ts` (11 tests pass)
- [ ] Merge this PR first, then merge the companion `builder-agent-native-starter` PR (`fix/sync-from-templates-chat`) to apply the one-time starter fix and updated CI workflows
- [ ] After both merge, confirm starter automation sync stays green on the next dispatch or scheduled run


Made with [Cursor](https://cursor.com)