### PR TITLE
fix(core): stop injecting removed-in-TS7 baseUrl into scaffolded tsconfig

### DIFF
--- a/.changeset/remove-baseurl-from-scaffolded-tsconfig.md
+++ b/.changeset/remove-baseurl-from-scaffolded-tsconfig.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stop injecting the `baseUrl` compiler option into scaffolded app tsconfigs. `baseUrl` is deprecated and errors in TypeScript 6 (TS5101/TS5102) and removed in TypeScript 7. The `create` CLI now relies on `paths` (including the `"*": ["./*"]` catch-all) which resolve relative to the project's own tsconfig, fixing `error TS5102: Option 'baseUrl' has been removed` under tsgo / `@typescript/native-preview` in generated starters.

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1089,13 +1089,12 @@ function fixStandaloneTsconfig(targetDir: string, templateName?: string): void {
     if (hasUiApp) {
       paths["@/*"] ??= ["./app/*"];
       paths["@shared/*"] ??= ["./shared/*"];
-      // Child baseUrl anchors @/* for apps extending legacy core tsconfig bases
-      // that still ship baseUrl. Headless scaffolds omit it so raw tsgo --noEmit
-      // keeps working under TS 6.
-      tsconfig.compilerOptions.baseUrl = ".";
-    } else {
-      delete tsconfig.compilerOptions.baseUrl;
     }
+    // baseUrl is deprecated/errors in TS 6 (TS5101/TS5102) and removed in TS 7
+    // (tsgo, which CI runs). paths already resolve relative to this tsconfig,
+    // and the "*": ["./*"] entry replaces baseUrl's bare-specifier resolution,
+    // so never emit baseUrl into scaffolds.
+    delete tsconfig.compilerOptions.baseUrl;
     tsconfig.compilerOptions.paths = paths;
     fs.writeFileSync(tsconfigPath, `${JSON.stringify(tsconfig, null, 2)}\n`);
   } catch {}

--- a/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
+++ b/packages/core/src/cli/sync-builder-starter-manifest.spec.ts
@@ -63,7 +63,7 @@ describe("sync-builder-starter-manifest", () => {
             paths?: Record<string, string[]>;
           };
         };
-        expect(tsconfig.compilerOptions?.baseUrl).toBe(".");
+        expect(tsconfig.compilerOptions?.baseUrl).toBeUndefined();
         expect(tsconfig.compilerOptions?.paths?.["*"]).toEqual(["./*"]);
         expect(
           fs.readFileSync(

--- a/packages/migrate/src/adapters/agent-native-target.ts
+++ b/packages/migrate/src/adapters/agent-native-target.ts
@@ -209,8 +209,8 @@ function tsconfigJson(): string {
   "compilerOptions": {
     "ignoreDeprecations": "6.0",
     "rootDirs": [".", "./.react-router/types"],
-    "baseUrl": ".",
     "paths": {
+      "*": ["./*"],
       "@/*": ["./app/*"]
     }
   },


### PR DESCRIPTION
## What

Stop the scaffolding generator from injecting the `baseUrl` compiler option into
generated app `tsconfig.json` files. `baseUrl` is deprecated/errors in
TypeScript 6 (TS5101/TS5102) and fully removed in TypeScript 7.

## Why

`builder-agent-native-starter` CI was failing. Its `update-agent-native-packages`
automation bumps `@agent-native/core` and regenerates the starter's toolchain
files (including `tsconfig.json`) from this repo's `templates/chat`, then runs
`pnpm typecheck` — which uses tsgo (`@typescript/native-preview`, TS 7). tsgo
errored with:

tsconfig.json: error TS5102: Option 'baseUrl' has been removed.
Please remove it from your configuration. Use '"paths": {"": ["./"]}' instead.


The root cause is upstream here, not in the starter: `templates/chat/tsconfig.json`
has no `baseUrl`, but `fixStandaloneTsconfig` in the `create` CLI was *re-adding*
`"baseUrl": "."` to every standalone UI scaffold. Because the automation
regenerates the file from this generator on each run, patching the starter's own
`tsconfig.json` never stuck.


## Change

- **`packages/core/src/cli/create.ts`** — `fixStandaloneTsconfig` now deletes
  `baseUrl` instead of injecting it. The unconditional `"*": ["./*"]` path entry
  (the TS-recommended replacement for `baseUrl`'s bare-specifier resolution) is
  retained, so `@/*`, `@shared/*`, and bare imports still resolve — now relative
  to the project's own tsconfig.
- **`packages/migrate/src/adapters/agent-native-target.ts`** — the migration
  target tsconfig generator no longer emits `baseUrl`; adds `"*": ["./*"]`.
- **`packages/core/src/cli/sync-builder-starter-manifest.spec.ts`** — updated to
  assert the regenerated starter tsconfig has no `baseUrl` (regression guard).
- **`.changeset/`** — `@agent-native/core` patch.

## Impact / safety

Only standalone UI scaffolds change. Resolution is equivalent (`"*": ["./*"]`
covers what `baseUrl: "."` did for bare specifiers).

- Headless scaffolds: unchanged (already deleted `baseUrl`).
- Workspace `add-app`: unchanged (never ran this generator; templates are already
  `baseUrl`-free).
- Existing `templates/*`: unchanged (no `baseUrl` to begin with).

## Testing

- `@agent-native/core` unit: 5800 passed, 1 skipped.
- `@agent-native/migrate` unit: 15 passed.
- `qa-cli-smoke` (CLI scaffold e2e): clean.
- tsgo repro: old output (`baseUrl`) → `TS5102`; new output → exit 0.
- Live scaffold of a chat app → generated tsconfig has no `baseUrl`,
  `"*": ["./*"]` present.