### PR TITLE
fix: 404 embed on claude ai

### DIFF
--- a/.changeset/mcp-transplant-redirect-route.md
+++ b/.changeset/mcp-transplant-redirect-route.md
@@ -1,0 +1,13 @@
+---
+"@agent-native/core": patch
+---
+
+Fix MCP App transplant (Claude) rendering the app's 404 page instead of the
+target route. The embed ticket's `targetPath` is `/_agent-native/open?...&to=/plans/<id>`,
+which 302-redirects to the real app route. The transplant followed that redirect
+to fetch the correct SSR HTML, but then called `history.replaceState` with the
+**pre-redirect** location (`/_agent-native/open`) — a server-only framework route
+React Router has no client route for — so hydration threw
+`No route matches URL "/_agent-native/open"` and rendered the app's 404 boundary.
+The transplant now uses the post-redirect `response.url` (the resolved app route,
+e.g. `/plans/<id>`) for `replaceState`, so the hydrated router matches the route.

--- a/packages/core/src/client/mcp-apps/McpAppRenderer.spec.ts
+++ b/packages/core/src/client/mcp-apps/McpAppRenderer.spec.ts
@@ -212,7 +212,7 @@ function mcpAppPayload({
     serverId: "plan",
     toolName: "open_app",
     originalToolName: "open_app",
-    resourceUri: "ui://plan/open_app/shell-v52",
+    resourceUri: "ui://plan/open_app/shell-v53",
     toolInput: { embed: true },
     toolResult: {
       structuredContent: {
@@ -220,7 +220,7 @@ function mcpAppPayload({
       },
     },
     resource: {
-      uri: "ui://plan/open_app/shell-v52",
+      uri: "ui://plan/open_app/shell-v53",
       mimeType: "text/html;profile=mcp-app",
       text: resourceHtml,
     },

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -750,7 +750,7 @@ function safeUiSegment(value: string | undefined, fallback: string): string {
 
 // ChatGPT and Claude cache MCP App resource HTML by `ui://` URI. Bump this
 // when the shared shell changes in a way that must invalidate host caches.
-const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v52";
+const MCP_APP_RESOURCE_SHELL_VERSION = "shell-v53";
 
 function legacyDefaultMcpAppUri(config: MCPConfig, actionName: string): string {
   const app = safeUiSegment(config.appId ?? config.name, "agent-native");

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -936,7 +936,17 @@ export function embedApp(
         throw new Error("Embedded app returned HTTP " + response.status + ".");
       }
       const html = await response.text();
-      const appUrl = source.url || new URL(response.url || src);
+      // Use the FINAL URL the fetch landed on after following redirects, NOT
+      // the pre-redirect embed-start location. The embed ticket's targetPath is
+      // /_agent-native/open?...&to=/plans/<id>, which 302-redirects to the real
+      // app route; we render that route's HTML. If we replaceState to the
+      // pre-redirect /_agent-native/open (a server-only framework route), the
+      // hydrated React Router has no matching client route and throws a 404
+      // ("No route matches URL /_agent-native/open"). response.url is the
+      // resolved app route (/plans/<id>) the router can actually match.
+      const appUrl = new URL(
+        response.url || (source.url ? source.url.href : src),
+      );
       try {
         window.history.replaceState(window.history.state, "", localPathFromUrl(appUrl, false));
       } catch {}

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -612,20 +612,20 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     // is the OpenAI/ChatGPT equivalent and is the only one that also rides on
     // the result — MCP Apps has no result-level linkage key.
     expect(echo._meta?.["ui/resourceUri"]).toBe(
-      "ui://mail/echo-thing/shell-v52",
+      "ui://mail/echo-thing/shell-v53",
     );
     expect(echo._meta?.["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v52",
+      "ui://mail/echo-thing/shell-v53",
     );
     expect(echo._meta?.["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v52",
+      "ui://mail/echo-thing/shell-v53",
     );
     expect(echo._meta?.["openai/widgetAccessible"]).toBe(true);
     expect(echo._meta?.["openai/widgetCSP"]).toEqual({
       connect_domains: ["https://mail.agent-native.com"],
     });
     expect(echo._meta?.ui).toEqual({
-      resourceUri: "ui://mail/echo-thing/shell-v52",
+      resourceUri: "ui://mail/echo-thing/shell-v53",
       visibility: ["model", "app"],
     });
     expect(echo._meta?.ui?.csp).toBeUndefined();
@@ -708,7 +708,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
 
     expect(resourcesOut.error).toBeUndefined();
     expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
-      "ui://mail/open_app/shell-v52",
+      "ui://mail/open_app/shell-v53",
     ]);
     expect(JSON.stringify(resourcesOut)).not.toContain(
       "INTERNAL_TOOL_BLOAT_SENTINEL",
@@ -734,7 +734,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(templatesOut.error).toBeUndefined();
     expect(
       templatesOut.result.resourceTemplates.map((r: any) => r.uriTemplate),
-    ).toEqual(["ui://mail/open_app/shell-v52"]);
+    ).toEqual(["ui://mail/open_app/shell-v53"]);
     expect(JSON.stringify(templatesOut)).not.toContain(
       "INTERNAL_TOOL_BLOAT_SENTINEL",
     );
@@ -748,7 +748,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 123,
         method: "resources/read",
-        params: { uri: "ui://mail/review-draft/shell-v52" },
+        params: { uri: "ui://mail/review-draft/shell-v53" },
       },
       {
         headers: await mcpAppsAuthHeaders(),
@@ -763,7 +763,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 126,
         method: "resources/read",
-        params: { uri: "ui://mail/bloated-widget/shell-v52" },
+        params: { uri: "ui://mail/bloated-widget/shell-v53" },
       },
       {
         headers: await mcpAppsAuthHeaders(),
@@ -834,8 +834,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
 
     expect(resourcesOut.error).toBeUndefined();
     expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
-      "ui://mail/open_app/shell-v52",
-      "ui://mail/status-panel/shell-v52",
+      "ui://mail/open_app/shell-v53",
+      "ui://mail/status-panel/shell-v53",
     ]);
   });
 
@@ -935,7 +935,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
 
     expect(resourcesOut.error).toBeUndefined();
     expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
-      "ui://mail/open_app/shell-v52",
+      "ui://mail/open_app/shell-v53",
     ]);
     expect(JSON.stringify(resourcesOut)).not.toContain(
       "MCP_APP_RESOURCE_BLOAT_SENTINEL",
@@ -1000,9 +1000,9 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
 
     expect(resourcesOut.error).toBeUndefined();
     expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
-      "ui://mail/echo-thing/shell-v52",
-      "ui://mail/review-draft/shell-v52",
-      "ui://mail/private-widget/shell-v52",
+      "ui://mail/echo-thing/shell-v53",
+      "ui://mail/review-draft/shell-v53",
+      "ui://mail/private-widget/shell-v53",
     ]);
 
     const templatesOut = await callWeb(
@@ -1022,9 +1022,9 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(
       templatesOut.result.resourceTemplates.map((r: any) => r.uriTemplate),
     ).toEqual([
-      "ui://mail/echo-thing/shell-v52",
-      "ui://mail/review-draft/shell-v52",
-      "ui://mail/private-widget/shell-v52",
+      "ui://mail/echo-thing/shell-v53",
+      "ui://mail/review-draft/shell-v53",
+      "ui://mail/private-widget/shell-v53",
     ]);
 
     const readOut = await callWeb(
@@ -1032,7 +1032,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 132,
         method: "resources/read",
-        params: { uri: "ui://mail/private-widget/shell-v52" },
+        params: { uri: "ui://mail/private-widget/shell-v53" },
       },
       {
         headers: await mcpAppsAuthHeaders(),
@@ -1043,7 +1043,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(readOut.error).toBeUndefined();
     expect(readOut.result.contents).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/private-widget/shell-v52",
+        uri: "ui://mail/private-widget/shell-v53",
         text: expect.stringContaining("Private"),
       }),
     ]);
@@ -1129,8 +1129,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
 
     expect(out.error).toBeUndefined();
     expect(out.result.resources.map((r: any) => r.uri)).toEqual([
-      "ui://mail/echo-thing/shell-v52",
-      "ui://mail/review-draft/shell-v52",
+      "ui://mail/echo-thing/shell-v53",
+      "ui://mail/review-draft/shell-v53",
     ]);
   });
 
@@ -1295,7 +1295,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
 
     expect(resourcesOut.error).toBeUndefined();
     expect(resourcesOut.result.resources.map((r: any) => r.uri)).toEqual([
-      "ui://mail/open_app/shell-v52",
+      "ui://mail/open_app/shell-v53",
     ]);
     expect(JSON.stringify(resourcesOut)).not.toContain(
       "MCP_APP_RESOURCE_BLOAT_SENTINEL",
@@ -1395,7 +1395,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v52",
+        uri: "ui://mail/echo-thing/shell-v53",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -1462,7 +1462,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     );
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
-      expect.objectContaining({ uri: "ui://mail/echo-thing/shell-v52" }),
+      expect.objectContaining({ uri: "ui://mail/echo-thing/shell-v53" }),
     ]);
 
     const call = await callWeb(
@@ -1490,7 +1490,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     );
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
-      expect.objectContaining({ uri: "ui://mail/echo-thing/shell-v52" }),
+      expect.objectContaining({ uri: "ui://mail/echo-thing/shell-v53" }),
     ]);
   });
 
@@ -1507,7 +1507,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(out.error).toBeUndefined();
     expect(out.result.resourceTemplates).toEqual([
       expect.objectContaining({
-        uriTemplate: "ui://mail/echo-thing/shell-v52",
+        uriTemplate: "ui://mail/echo-thing/shell-v53",
         name: "echo-thing",
         title: "Mail Review",
         description: "Review the echoed thing in an inline MCP App.",
@@ -1522,14 +1522,14 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 6,
         method: "resources/read",
-        params: { uri: "ui://mail/echo-thing/shell-v52" },
+        params: { uri: "ui://mail/echo-thing/shell-v53" },
       },
       { headers: await mcpAppsFullCatalogHeaders() },
     );
     expect(out.error).toBeUndefined();
     expect(out.result.contents).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/echo-thing/shell-v52",
+        uri: "ui://mail/echo-thing/shell-v53",
         mimeType: "text/html;profile=mcp-app",
         text: expect.stringContaining('data-action="echo-thing"'),
         _meta: expect.objectContaining({
@@ -1642,7 +1642,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         jsonrpc: "2.0",
         id: 37,
         method: "resources/read",
-        params: { uri: "ui://mail/dynamic-review/shell-v52" },
+        params: { uri: "ui://mail/dynamic-review/shell-v53" },
       },
       { headers: await mcpAppsFullCatalogHeaders(), config: dynamicCspConfig },
     );
@@ -1740,7 +1740,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       );
       expect(brokenTool._meta?.["openai/outputTemplate"]).toBeUndefined();
       expect(healthyTool._meta["openai/outputTemplate"]).toBe(
-        "ui://mail/healthy-review/shell-v52",
+        "ui://mail/healthy-review/shell-v53",
       );
 
       const brokenCall = await callWeb(
@@ -1795,7 +1795,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       expect(resources.error).toBeUndefined();
       expect(
         resources.result.resources.map((resource: any) => resource.uri),
-      ).toEqual(["ui://mail/healthy-review/shell-v52"]);
+      ).toEqual(["ui://mail/healthy-review/shell-v53"]);
 
       const templates = await callWeb(
         {
@@ -1814,7 +1814,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         templates.result.resourceTemplates.map(
           (template: any) => template.uriTemplate,
         ),
-      ).toEqual(["ui://mail/healthy-review/shell-v52"]);
+      ).toEqual(["ui://mail/healthy-review/shell-v53"]);
 
       const warnCallsBeforeRead = warn.mock.calls.length;
       const read = await callWeb(
@@ -1822,7 +1822,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
           jsonrpc: "2.0",
           id: 43,
           method: "resources/read",
-          params: { uri: "ui://mail/healthy-review/shell-v52" },
+          params: { uri: "ui://mail/healthy-review/shell-v53" },
         },
         {
           headers: await mcpAppsFullCatalogHeaders(),
@@ -1832,7 +1832,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
       expect(read.error).toBeUndefined();
       expect(read.result.contents[0]).toEqual(
         expect.objectContaining({
-          uri: "ui://mail/healthy-review/shell-v52",
+          uri: "ui://mail/healthy-review/shell-v53",
           text: expect.stringContaining("Healthy"),
         }),
       );
@@ -1924,7 +1924,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v52",
+        uri: "ui://mail/custom-review/shell-v53",
         name: "custom-review",
       }),
     ]);
@@ -1987,7 +1987,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v52",
+        uri: "ui://mail/custom-review/shell-v53",
         name: "custom-review",
       }),
     ]);
@@ -2050,7 +2050,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(list.error).toBeUndefined();
     expect(list.result.resources).toEqual([
       expect.objectContaining({
-        uri: "ui://mail/custom-review/shell-v52?mode=compact#preview",
+        uri: "ui://mail/custom-review/shell-v53?mode=compact#preview",
         name: "custom-review",
       }),
     ]);
@@ -2106,7 +2106,7 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
         "https://mail.agent-native.com/_agent-native/open?view=thing&id=thing-42&agentSidebar=closed",
     });
     expect(out.result._meta["openai/outputTemplate"]).toBe(
-      "ui://mail/echo-thing/shell-v52",
+      "ui://mail/echo-thing/shell-v53",
     );
     expect(out.result._meta["openai/widgetCSP"]).toEqual({
       connect_domains: ["https://mail.agent-native.com"],


### PR DESCRIPTION
Fixed MCP App transplant hydration by replacing the pre-redirect URL with the resolved app route from `response.url`, preventing React Router from rendering the 404 page.

Prev
<img width="1818" height="1282" alt="image" src="https://github.com/user-attachments/assets/2dd30e45-cf59-4d63-b564-ac52922face6" />

Now
<img width="664" height="733" alt="image" src="https://github.com/user-attachments/assets/e33c11fc-c29a-431a-8672-06fc41bf417f" />
