### PR TITLE
Fix MCP tool org scope for email-only tokens

### DIFF
--- a/.changeset/quiet-mcp-org-scope.md
+++ b/.changeset/quiet-mcp-org-scope.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Resolve MCP tool caller org scope from the verified user email when a token has no explicit org claim, so org-scoped actions return the same resources agents can see in the UI.

--- a/packages/core/src/mcp/build-server.ts
+++ b/packages/core/src/mcp/build-server.ts
@@ -1340,9 +1340,7 @@ export async function createMCPServerForRequest(
   // in that case we run with no userEmail/orgId, which makes downstream
   // tools that require per-user scope return empty results rather than
   // cross-tenant data (the safe default).
-  const orgIdPromise = effectiveIdentity?.orgId
-    ? Promise.resolve(effectiveIdentity.orgId)
-    : resolveOrgIdFromDomain(effectiveIdentity?.orgDomain);
+  const orgIdPromise = resolveMcpIdentityOrgId(effectiveIdentity);
 
   /**
    * Wrap a callback in
@@ -2062,6 +2060,24 @@ export async function resolveOrgIdFromDomain(
     const { resolveOrgByDomain } = await import("../org/context.js");
     const org = await resolveOrgByDomain(orgDomain);
     return org?.orgId ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function resolveMcpIdentityOrgId(
+  identity: MCPCallerIdentity | undefined,
+): Promise<string | undefined> {
+  if (identity?.orgId) return identity.orgId;
+
+  const orgIdFromDomain = await resolveOrgIdFromDomain(identity?.orgDomain);
+  if (orgIdFromDomain) return orgIdFromDomain;
+
+  const userEmail = identity?.userEmail?.trim();
+  if (!userEmail) return undefined;
+  try {
+    const { resolveOrgIdForEmail } = await import("../org/context.js");
+    return (await resolveOrgIdForEmail(userEmail)) ?? undefined;
   } catch {
     return undefined;
   }

--- a/packages/core/src/mcp/build-server.verify-auth.spec.ts
+++ b/packages/core/src/mcp/build-server.verify-auth.spec.ts
@@ -8,6 +8,8 @@ vi.mock("./builtin-tools.js", () => ({ getBuiltinCrossAppTools: () => ({}) }));
 const isJtiRevokedMock = vi.fn();
 const touchTokenUsedMock = vi.fn(async () => {});
 const getA2ASecretByDomainMock = vi.fn();
+const resolveOrgByDomainMock = vi.fn();
+const resolveOrgIdForEmailMock = vi.fn();
 vi.mock("./connect-store.js", () => ({
   MCP_CONNECT_SCOPE: "mcp-connect",
   MCP_CONNECT_OAUTH_CLIENT_ID: "agent-native-connect",
@@ -16,10 +18,12 @@ vi.mock("./connect-store.js", () => ({
 }));
 vi.mock("../org/context.js", () => ({
   getA2ASecretByDomain: (...a: any[]) => getA2ASecretByDomainMock(...a),
-  resolveOrgByDomain: vi.fn(async () => null),
+  resolveOrgByDomain: (...a: any[]) => resolveOrgByDomainMock(...a),
+  resolveOrgIdForEmail: (...a: any[]) => resolveOrgIdForEmailMock(...a),
 }));
 
-const { verifyAuth } = await import("./build-server.js");
+const { resolveMcpIdentityOrgId, verifyAuth } =
+  await import("./build-server.js");
 const { signMcpOAuthAccessToken } = await import("./oauth-token.js");
 
 const SECRET = "verify-auth-secret";
@@ -41,6 +45,8 @@ describe("verifyAuth — connect-token revoke check", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getA2ASecretByDomainMock.mockResolvedValue(null);
+    resolveOrgByDomainMock.mockResolvedValue(null);
+    resolveOrgIdForEmailMock.mockResolvedValue(null);
     process.env.A2A_SECRET = SECRET;
     delete process.env.BETTER_AUTH_SECRET;
     delete process.env.ACCESS_TOKEN;
@@ -368,6 +374,9 @@ describe("verifyAuth — connect-token revoke check", () => {
 describe("verifyAuth — fullSurface (real-caller → full MCP surface)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getA2ASecretByDomainMock.mockResolvedValue(null);
+    resolveOrgByDomainMock.mockResolvedValue(null);
+    resolveOrgIdForEmailMock.mockResolvedValue(null);
     delete process.env.A2A_SECRET;
     delete process.env.BETTER_AUTH_SECRET;
     delete process.env.ACCESS_TOKEN;
@@ -476,5 +485,54 @@ describe("verifyAuth — fullSurface (real-caller → full MCP surface)", () => 
     });
     expect(res.authed).toBe(true);
     expect(res.identity?.userEmail).toBe("oauth@example.com");
+  });
+});
+
+describe("resolveMcpIdentityOrgId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveOrgByDomainMock.mockResolvedValue(null);
+    resolveOrgIdForEmailMock.mockResolvedValue(null);
+  });
+
+  it("uses an explicit org_id claim without extra lookup", async () => {
+    await expect(
+      resolveMcpIdentityOrgId({
+        userEmail: "alice@example.com",
+        orgId: "org-explicit",
+        orgDomain: "example.com",
+      }),
+    ).resolves.toBe("org-explicit");
+
+    expect(resolveOrgByDomainMock).not.toHaveBeenCalled();
+    expect(resolveOrgIdForEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves verified org_domain before falling back to email membership", async () => {
+    resolveOrgByDomainMock.mockResolvedValue({ orgId: "org-domain" });
+    resolveOrgIdForEmailMock.mockResolvedValue("org-email");
+
+    await expect(
+      resolveMcpIdentityOrgId({
+        userEmail: "alice@example.com",
+        orgDomain: "example.com",
+      }),
+    ).resolves.toBe("org-domain");
+
+    expect(resolveOrgByDomainMock).toHaveBeenCalledWith("example.com");
+    expect(resolveOrgIdForEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the verified user email when a token has no org claim", async () => {
+    resolveOrgIdForEmailMock.mockResolvedValue("org-email");
+
+    await expect(
+      resolveMcpIdentityOrgId({
+        userEmail: "alice@example.com",
+        orgDomain: undefined,
+      }),
+    ).resolves.toBe("org-email");
+
+    expect(resolveOrgIdForEmailMock).toHaveBeenCalledWith("alice@example.com");
   });
 });

--- a/packages/core/src/mcp/server.spec.ts
+++ b/packages/core/src/mcp/server.spec.ts
@@ -102,8 +102,13 @@ vi.mock("./builtin-tools.js", () => ({
     },
   }),
 }));
+const resolveOrgIdForEmailMock = vi.hoisted(() => vi.fn(async () => null));
+
 vi.mock("../org/context.js", () => ({
   resolveOrgByDomain: vi.fn(async () => null),
+  resolveOrgIdForEmail: (
+    ...args: Parameters<typeof resolveOrgIdForEmailMock>
+  ) => resolveOrgIdForEmailMock(...args),
 }));
 
 const embedSessionMocks = vi.hoisted(() => ({
@@ -507,6 +512,8 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     process.env.AGENT_NATIVE_MCP_APPS_INLINE = "1";
     delete process.env.AGENT_NATIVE_MCP_APPS_INLINE_ALLOW_EMAILS;
     mockOAuthClients.clear();
+    resolveOrgIdForEmailMock.mockReset();
+    resolveOrgIdForEmailMock.mockResolvedValue(null);
   });
   afterEach(() => {
     delete process.env.ACCESS_TOKEN;
@@ -2136,6 +2143,56 @@ describe("handleMcpRequest — web-standard runtime fallback (no Node req/res)",
     expect(new URL(openLink.vscodeUrl).searchParams.get("url")).toBe(
       openLink.webUrl,
     );
+  });
+
+  it("runs `tools/call` with org scope resolved from the verified token email", async () => {
+    resolveOrgIdForEmailMock.mockResolvedValue("org-from-email");
+    const scopedConfig = {
+      ...config,
+      actions: {
+        "whoami-scope": {
+          tool: {
+            description: "Return the request context visible to the action",
+            parameters: { type: "object" as const, properties: {} },
+          },
+          readOnly: true,
+          run: async () => {
+            const { getRequestOrgId, getRequestUserEmail } =
+              await import("../server/request-context.js");
+            return {
+              userEmail: getRequestUserEmail(),
+              orgId: getRequestOrgId() ?? null,
+            };
+          },
+          mcpApp: {
+            resource: {
+              title: "Scope probe",
+              html: "<!doctype html><html><body>Scope</body></html>",
+            },
+          },
+        },
+      },
+    };
+
+    const out = await callWeb(
+      {
+        jsonrpc: "2.0",
+        id: 301,
+        method: "tools/call",
+        params: { name: "whoami-scope", arguments: {} },
+      },
+      {
+        headers: await mcpAppsFullCatalogHeaders(),
+        config: scopedConfig,
+      },
+    );
+
+    expect(out.error).toBeUndefined();
+    expect(out.result.structuredContent).toMatchObject({
+      userEmail: "oauth@example.com",
+      orgId: "org-from-email",
+    });
+    expect(resolveOrgIdForEmailMock).toHaveBeenCalledWith("oauth@example.com");
   });
 
   it("preserves MCP action-result errors as errored tools/call responses", async () => {


### PR DESCRIPTION
Fixes a production parity bug that surfaced after the assets overhaul made generation depend on chat-visible library and brand-kit context. The UI still resolved org scope through the normal action route, so libraries appeared there, but MCP/agent tool calls with email-only tokens ran without orgId; accessFilter then filtered out org-scoped libraries and list-libraries returned 0.

Changes:

- Resolve MCP org scope from explicit org claim, org domain, then verified user email membership.
- Add helper and full MCP tools/call regressions for email-only tokens.