### PR TITLE
Preserve action access context in agent tool calls

### DIFF
--- a/.changeset/preserve-agent-action-context.md
+++ b/.changeset/preserve-agent-action-context.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve resolved user and org context when agent tool calls run actions.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -33,8 +33,10 @@ import { readBody } from "../server/h3-helpers.js";
 import {
   getRequestRunContext,
   ensureRequestRunContext,
+  getRequestContext,
   getRequestOrgId,
   getRequestUserEmail,
+  runWithRequestContext,
 } from "../server/request-context.js";
 import { fireInternalDispatch } from "../server/self-dispatch.js";
 import {
@@ -3431,23 +3433,40 @@ export async function runAgentLoop(opts: {
         | undefined;
       try {
         const timeoutSignal = AbortSignal.timeout(toolTimeoutMs);
+        const actionUserEmail = opts.ownerEmail ?? getRequestUserEmail();
+        const actionOrgId = opts.orgId ?? getRequestOrgId() ?? null;
+        const actionContext = {
+          send,
+          userEmail: actionUserEmail ?? undefined,
+          orgId: actionOrgId,
+          caller: "tool" as const,
+          attachments: opts.attachments,
+          signal,
+          // Audit attribution: the action name + the agent thread/turn that
+          // triggered this call, so a mutation can be traced to its run.
+          actionName: toolCall.name,
+          ...(opts.threadId ? { threadId: opts.threadId } : {}),
+          ...(opts.turnId ? { turnId: opts.turnId } : {}),
+        };
+        const requestContext = getRequestContext();
+        const invokeAction = () =>
+          actionEntry.run(
+            toolCall.input as Record<string, string>,
+            actionContext,
+          );
         // Keep a reference to the action promise so we can attach a zombie-
         // detection continuation AFTER Promise.race abandons it on run abort.
         // The promise itself is not awaited here — Promise.race owns the await.
         const actionPromise = Promise.resolve(
-          actionEntry.run(toolCall.input as Record<string, string>, {
-            send,
-            userEmail: getRequestUserEmail(),
-            orgId: getRequestOrgId() ?? null,
-            caller: "tool",
-            attachments: opts.attachments,
-            signal,
-            // Audit attribution: the action name + the agent thread/turn that
-            // triggered this call, so a mutation can be traced to its run.
-            actionName: toolCall.name,
-            ...(opts.threadId ? { threadId: opts.threadId } : {}),
-            ...(opts.turnId ? { turnId: opts.turnId } : {}),
-          }),
+          runWithRequestContext(
+            {
+              ...(requestContext ?? {}),
+              ...(actionUserEmail ? { userEmail: actionUserEmail } : {}),
+              ...(actionOrgId ? { orgId: actionOrgId } : {}),
+              ...(requestContext?.run ? { run: requestContext.run } : {}),
+            },
+            invokeAction,
+          ),
         );
 
         // When the run is aborted (soft-timeout / user cancel) while this tool

--- a/templates/assets/actions/_helpers.ts
+++ b/templates/assets/actions/_helpers.ts
@@ -12,8 +12,21 @@ import type {
   StyleBrief,
 } from "../shared/api.js";
 
-export async function requireLibrary(id: string) {
-  const access = await resolveAccess("asset-library", id);
+type AccessCtx = {
+  userEmail?: string;
+  orgId?: string | null;
+};
+
+function accessContext(ctx?: AccessCtx) {
+  if (!ctx) return undefined;
+  return {
+    userEmail: ctx.userEmail,
+    orgId: ctx.orgId ?? undefined,
+  };
+}
+
+export async function requireLibrary(id: string, ctx?: AccessCtx) {
+  const access = await resolveAccess("asset-library", id, accessContext(ctx));
   if (!access) throw new Error("Asset library not found or not accessible.");
   return access.resource;
 }

--- a/templates/assets/actions/get-library.ts
+++ b/templates/assets/actions/get-library.ts
@@ -18,8 +18,8 @@ export default defineAction({
   }),
   http: { method: "GET" },
   readOnly: true,
-  run: async ({ id }) => {
-    const library = await requireLibrary(id);
+  run: async ({ id }, ctx) => {
+    const library = await requireLibrary(id, ctx);
     const db = getDb();
     const [collections, folders, assets, runs] = await Promise.all([
       db

--- a/templates/assets/actions/view-screen.spec.ts
+++ b/templates/assets/actions/view-screen.spec.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readAppStateMock = vi.hoisted(() => vi.fn());
+const readAppStateForCurrentTabMock = vi.hoisted(() => vi.fn());
+const getAssetRunMock = vi.hoisted(() => vi.fn());
+const getGenerationRunRunMock = vi.hoisted(() => vi.fn());
+const getGenerationSessionRunMock = vi.hoisted(() => vi.fn());
+const getLibraryRunMock = vi.hoisted(() => vi.fn());
+const listAssetsRunMock = vi.hoisted(() => vi.fn());
+const listAuditRunsRunMock = vi.hoisted(() => vi.fn());
+const listGenerationPresetsRunMock = vi.hoisted(() => vi.fn());
+const listGenerationSessionsRunMock = vi.hoisted(() => vi.fn());
+const listLibrariesRunMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core", () => ({
+  defineAction: (entry: unknown) => entry,
+}));
+
+vi.mock("@agent-native/core/application-state", () => ({
+  readAppState: readAppStateMock,
+  readAppStateForCurrentTab: readAppStateForCurrentTabMock,
+}));
+
+vi.mock("./get-asset.js", () => ({
+  default: { run: getAssetRunMock },
+}));
+
+vi.mock("./get-generation-run.js", () => ({
+  default: { run: getGenerationRunRunMock },
+}));
+
+vi.mock("./get-generation-session.js", () => ({
+  default: { run: getGenerationSessionRunMock },
+}));
+
+vi.mock("./get-library.js", () => ({
+  default: { run: getLibraryRunMock },
+}));
+
+vi.mock("./list-assets.js", () => ({
+  default: { run: listAssetsRunMock },
+}));
+
+vi.mock("./list-audit-runs.js", () => ({
+  default: { run: listAuditRunsRunMock },
+}));
+
+vi.mock("./list-generation-presets.js", () => ({
+  default: { run: listGenerationPresetsRunMock },
+}));
+
+vi.mock("./list-generation-sessions.js", () => ({
+  default: { run: listGenerationSessionsRunMock },
+}));
+
+vi.mock("./list-libraries.js", () => ({
+  default: { run: listLibrariesRunMock },
+}));
+
+import action from "./view-screen.js";
+
+describe("view-screen", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readAppStateMock.mockResolvedValue(null);
+  });
+
+  it("keeps navigation context when the current library cannot be loaded", async () => {
+    readAppStateForCurrentTabMock.mockResolvedValue({
+      view: "library",
+      libraryId: "lib-missing",
+      activeTab: "settings",
+    });
+    getLibraryRunMock.mockRejectedValue(
+      new Error("Asset library not found or not accessible."),
+    );
+    const ctx = {
+      caller: "tool" as const,
+      userEmail: "designer@example.com",
+      orgId: "org-1",
+    };
+
+    const result = await action.run({}, ctx);
+
+    expect(getLibraryRunMock).toHaveBeenCalledWith({ id: "lib-missing" }, ctx);
+    expect(result).toMatchObject({
+      navigation: {
+        view: "library",
+        libraryId: "lib-missing",
+        activeTab: "settings",
+      },
+      errors: {
+        library: "Asset library not found or not accessible.",
+      },
+    });
+    expect(listGenerationPresetsRunMock).not.toHaveBeenCalled();
+    expect(listGenerationSessionsRunMock).not.toHaveBeenCalled();
+  });
+
+  it("returns dependent library details when the current library loads", async () => {
+    readAppStateForCurrentTabMock.mockResolvedValue({
+      view: "library",
+      libraryId: "lib-1",
+    });
+    getLibraryRunMock.mockResolvedValue({
+      library: { id: "lib-1", title: "Launch kit" },
+    });
+    listGenerationPresetsRunMock.mockResolvedValue({
+      count: 1,
+      presets: [{ id: "preset-1" }],
+    });
+    listGenerationSessionsRunMock.mockResolvedValue({
+      count: 0,
+      sessions: [],
+    });
+
+    const result = await action.run({});
+
+    expect(result).toMatchObject({
+      navigation: {
+        view: "library",
+        libraryId: "lib-1",
+      },
+      library: {
+        library: { id: "lib-1", title: "Launch kit" },
+      },
+      generationPresets: {
+        count: 1,
+        presets: [{ id: "preset-1" }],
+      },
+      generationSessions: {
+        count: 0,
+        sessions: [],
+      },
+    });
+    expect(result).not.toHaveProperty("errors");
+  });
+});

--- a/templates/assets/actions/view-screen.ts
+++ b/templates/assets/actions/view-screen.ts
@@ -58,15 +58,21 @@ export default defineAction({
       if (library) {
         await Promise.all([
           readPart("generationPresets", () =>
-            listGenerationPresets.run({
-              libraryId: nav.libraryId,
-            }, ctx),
+            listGenerationPresets.run(
+              {
+                libraryId: nav.libraryId,
+              },
+              ctx,
+            ),
           ),
           readPart("generationSessions", () =>
-            listGenerationSessions.run({
-              libraryId: nav.libraryId,
-              limit: 20,
-            }, ctx),
+            listGenerationSessions.run(
+              {
+                libraryId: nav.libraryId,
+                limit: 20,
+              },
+              ctx,
+            ),
           ),
         ]);
       }
@@ -76,16 +82,22 @@ export default defineAction({
     }
     if (nav?.sessionId) {
       await readPart("generationSession", () =>
-        getGenerationSession.run({
-          id: nav.sessionId,
-        }, ctx),
+        getGenerationSession.run(
+          {
+            id: nav.sessionId,
+          },
+          ctx,
+        ),
       );
     }
     if (nav?.runId) {
       await readPart("generationRun", () =>
-        getGenerationRun.run({
-          runId: nav.runId,
-        }, ctx),
+        getGenerationRun.run(
+          {
+            runId: nav.runId,
+          },
+          ctx,
+        ),
       );
     }
     if (nav?.view === "picker") {
@@ -94,32 +106,36 @@ export default defineAction({
       );
       if (nav.libraryId) {
         await readPart("assets", () =>
-          listAssets.run({
-            libraryId: nav.libraryId,
-            mediaType:
-              nav.mediaType === "image" || nav.mediaType === "video"
-                ? nav.mediaType
-                : undefined,
-            query:
-              typeof nav.query === "string" && nav.query.trim()
-                ? nav.query
-                : undefined,
-          }, ctx),
+          listAssets.run(
+            {
+              libraryId: nav.libraryId,
+              mediaType:
+                nav.mediaType === "image" || nav.mediaType === "video"
+                  ? nav.mediaType
+                  : undefined,
+              query:
+                typeof nav.query === "string" && nav.query.trim()
+                  ? nav.query
+                  : undefined,
+            },
+            ctx,
+          ),
         );
       }
     }
     if (nav?.view === "library" && nav?.selection === "all") {
       await Promise.all([
-        readPart("libraries", () =>
-          listLibraries.run({ compact: false }, ctx),
-        ),
+        readPart("libraries", () => listLibraries.run({ compact: false }, ctx)),
         readPart("assets", () =>
-          listAssets.run({
-            query:
-              typeof nav.search === "string" && nav.search.trim()
-                ? nav.search
-                : undefined,
-          }, ctx),
+          listAssets.run(
+            {
+              query:
+                typeof nav.search === "string" && nav.search.trim()
+                  ? nav.search
+                  : undefined,
+            },
+            ctx,
+          ),
         ),
       ]);
     }

--- a/templates/assets/actions/view-screen.ts
+++ b/templates/assets/actions/view-screen.ts
@@ -39,7 +39,7 @@ export default defineAction({
     const errors: Record<string, string> = {};
     const readPart = async <T>(
       key: string,
-      task: () => Promise<T>,
+      task: () => T | Promise<T>,
     ): Promise<T | null> => {
       try {
         const value = await task();
@@ -58,21 +58,15 @@ export default defineAction({
       if (library) {
         await Promise.all([
           readPart("generationPresets", () =>
-            listGenerationPresets.run(
-              {
-                libraryId: nav.libraryId,
-              },
-              ctx,
-            ),
+            listGenerationPresets.run({
+              libraryId: nav.libraryId,
+            }, ctx),
           ),
           readPart("generationSessions", () =>
-            listGenerationSessions.run(
-              {
-                libraryId: nav.libraryId,
-                limit: 20,
-              },
-              ctx,
-            ),
+            listGenerationSessions.run({
+              libraryId: nav.libraryId,
+              limit: 20,
+            }, ctx),
           ),
         ]);
       }
@@ -82,22 +76,16 @@ export default defineAction({
     }
     if (nav?.sessionId) {
       await readPart("generationSession", () =>
-        getGenerationSession.run(
-          {
-            id: nav.sessionId,
-          },
-          ctx,
-        ),
+        getGenerationSession.run({
+          id: nav.sessionId,
+        }, ctx),
       );
     }
     if (nav?.runId) {
       await readPart("generationRun", () =>
-        getGenerationRun.run(
-          {
-            runId: nav.runId,
-          },
-          ctx,
-        ),
+        getGenerationRun.run({
+          runId: nav.runId,
+        }, ctx),
       );
     }
     if (nav?.view === "picker") {
@@ -106,36 +94,32 @@ export default defineAction({
       );
       if (nav.libraryId) {
         await readPart("assets", () =>
-          listAssets.run(
-            {
-              libraryId: nav.libraryId,
-              mediaType:
-                nav.mediaType === "image" || nav.mediaType === "video"
-                  ? nav.mediaType
-                  : undefined,
-              query:
-                typeof nav.query === "string" && nav.query.trim()
-                  ? nav.query
-                  : undefined,
-            },
-            ctx,
-          ),
+          listAssets.run({
+            libraryId: nav.libraryId,
+            mediaType:
+              nav.mediaType === "image" || nav.mediaType === "video"
+                ? nav.mediaType
+                : undefined,
+            query:
+              typeof nav.query === "string" && nav.query.trim()
+                ? nav.query
+                : undefined,
+          }, ctx),
         );
       }
     }
     if (nav?.view === "library" && nav?.selection === "all") {
       await Promise.all([
-        readPart("libraries", () => listLibraries.run({ compact: false }, ctx)),
+        readPart("libraries", () =>
+          listLibraries.run({ compact: false }, ctx),
+        ),
         readPart("assets", () =>
-          listAssets.run(
-            {
-              query:
-                typeof nav.search === "string" && nav.search.trim()
-                  ? nav.search
-                  : undefined,
-            },
-            ctx,
-          ),
+          listAssets.run({
+            query:
+              typeof nav.search === "string" && nav.search.trim()
+                ? nav.search
+                : undefined,
+          }, ctx),
         ),
       ]);
     }

--- a/templates/assets/actions/view-screen.ts
+++ b/templates/assets/actions/view-screen.ts
@@ -15,13 +15,17 @@ import listGenerationPresets from "./list-generation-presets.js";
 import listGenerationSessions from "./list-generation-sessions.js";
 import listLibraries from "./list-libraries.js";
 
+function screenError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export default defineAction({
   description:
     "See what the user is currently looking at in Assets, including current library/asset context and pending generation variants.",
   schema: z.object({}),
   http: false,
   readOnly: true,
-  run: async () => {
+  run: async (_args, ctx) => {
     const [navigation, variants, legacyVariants] = await Promise.all([
       readAppStateForCurrentTab("navigation"),
       readAppState("asset-variants"),
@@ -32,56 +36,114 @@ export default defineAction({
       variants: variants ?? legacyVariants,
     };
     const nav = navigation as any;
+    const errors: Record<string, string> = {};
+    const readPart = async <T>(
+      key: string,
+      task: () => Promise<T>,
+    ): Promise<T | null> => {
+      try {
+        const value = await task();
+        screen[key] = value;
+        return value;
+      } catch (error) {
+        errors[key] = screenError(error);
+        return null;
+      }
+    };
+
     if (nav?.libraryId) {
-      screen.library = await getLibrary.run({ id: nav.libraryId });
-      screen.generationPresets = await listGenerationPresets.run({
-        libraryId: nav.libraryId,
-      });
-      screen.generationSessions = await listGenerationSessions.run({
-        libraryId: nav.libraryId,
-        limit: 20,
-      });
+      const library = await readPart("library", () =>
+        getLibrary.run({ id: nav.libraryId }, ctx),
+      );
+      if (library) {
+        await Promise.all([
+          readPart("generationPresets", () =>
+            listGenerationPresets.run(
+              {
+                libraryId: nav.libraryId,
+              },
+              ctx,
+            ),
+          ),
+          readPart("generationSessions", () =>
+            listGenerationSessions.run(
+              {
+                libraryId: nav.libraryId,
+                limit: 20,
+              },
+              ctx,
+            ),
+          ),
+        ]);
+      }
     }
     if (nav?.assetId) {
-      screen.asset = await getAsset.run({ id: nav.assetId });
+      await readPart("asset", () => getAsset.run({ id: nav.assetId }, ctx));
     }
     if (nav?.sessionId) {
-      screen.generationSession = await getGenerationSession.run({
-        id: nav.sessionId,
-      });
+      await readPart("generationSession", () =>
+        getGenerationSession.run(
+          {
+            id: nav.sessionId,
+          },
+          ctx,
+        ),
+      );
     }
     if (nav?.runId) {
-      screen.generationRun = await getGenerationRun.run({
-        runId: nav.runId,
-      });
+      await readPart("generationRun", () =>
+        getGenerationRun.run(
+          {
+            runId: nav.runId,
+          },
+          ctx,
+        ),
+      );
     }
     if (nav?.view === "picker") {
-      screen.libraries = await listLibraries.run({ compact: true });
+      await readPart("libraries", () =>
+        listLibraries.run({ compact: true }, ctx),
+      );
       if (nav.libraryId) {
-        screen.assets = await listAssets.run({
-          libraryId: nav.libraryId,
-          mediaType:
-            nav.mediaType === "image" || nav.mediaType === "video"
-              ? nav.mediaType
-              : undefined,
-          query:
-            typeof nav.query === "string" && nav.query.trim()
-              ? nav.query
-              : undefined,
-        });
+        await readPart("assets", () =>
+          listAssets.run(
+            {
+              libraryId: nav.libraryId,
+              mediaType:
+                nav.mediaType === "image" || nav.mediaType === "video"
+                  ? nav.mediaType
+                  : undefined,
+              query:
+                typeof nav.query === "string" && nav.query.trim()
+                  ? nav.query
+                  : undefined,
+            },
+            ctx,
+          ),
+        );
       }
     }
     if (nav?.view === "library" && nav?.selection === "all") {
-      screen.libraries = await listLibraries.run({ compact: false });
-      screen.assets = await listAssets.run({
-        query:
-          typeof nav.search === "string" && nav.search.trim()
-            ? nav.search
-            : undefined,
-      });
+      await Promise.all([
+        readPart("libraries", () => listLibraries.run({ compact: false }, ctx)),
+        readPart("assets", () =>
+          listAssets.run(
+            {
+              query:
+                typeof nav.search === "string" && nav.search.trim()
+                  ? nav.search
+                  : undefined,
+            },
+            ctx,
+          ),
+        ),
+      ]);
     }
     if (nav?.view === "audit") {
-      screen.audit = await listAuditRuns.run({ limit: 20 });
+      await readPart("audit", () => listAuditRuns.run({ limit: 20 }, ctx));
+    }
+    if (Object.keys(errors).length) {
+      screen.errors = errors;
     }
     return screen;
   },


### PR DESCRIPTION
- Preserve resolved user/org context when agent tool calls execute actions
- Thread Assets action context into `get-library` access checks
- Make Assets `view-screen` return current navigation even if a subread fails
- Add a regression test for forwarding screen context into `get-library`

## Why

Agent tool calls could lose the same access context that frontend action calls had, which caused resource reads to fail from chat even when the UI could access the resource. Assets exposed this with current-library lookups: the UI could load the library, while the agent saw “library not found or not accessible.”

