### PR TITLE
Remove person-specific name references from agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,10 @@ read the relevant skill before changing that area.
 ## Always-On Rules
 
 - Stay on the current git branch. Never create, switch, delete, reset, rebase,
-  stash, or otherwise move branches unless Steve explicitly asks for that exact
+  stash, or otherwise move branches unless the user explicitly asks for that exact
   branch operation in the current task.
 - Never add `Co-Authored-By` or other agent attribution to commits.
-- PRs use the current branch unless Steve explicitly requests a new branch.
+- PRs use the current branch unless the user explicitly requests a new branch.
   PRs are ready for review by default, not drafts, unless requested.
 - Never use `[codex]`, `codex`, or similar agent labels in user-visible GitHub
   metadata unless explicitly requested.

--- a/packages/core/docs/content/agent-teams.md
+++ b/packages/core/docs/content/agent-teams.md
@@ -71,7 +71,7 @@ import { spawnTask } from "@agent-native/core/server";
 
 const task = await spawnTask({
   description: "Draft an outreach email to this lead",
-  instructions: "Match Steve's voice from memory/MEMORY.md.",
+  instructions: "Match the user's voice from memory/MEMORY.md.",
   ownerEmail: user.email,
   systemPrompt: mailAgentSystemPrompt,
   actions: mailActions,

--- a/packages/core/docs/content/locales/ar-SA/agent-teams.md
+++ b/packages/core/docs/content/locales/ar-SA/agent-teams.md
@@ -71,7 +71,7 @@ import { spawnTask } from "@agent-native/core/server";
 
 const task = await spawnTask({
   description: "Draft an outreach email to this lead",
-  instructions: "Match Steve's voice from memory/MEMORY.md.",
+  instructions: "Match the user's voice from memory/MEMORY.md.",
   ownerEmail: user.email,
   systemPrompt: mailAgentSystemPrompt,
   actions: mailActions,

--- a/packages/core/docs/content/locales/de-DE/agent-teams.md
+++ b/packages/core/docs/content/locales/de-DE/agent-teams.md
@@ -71,7 +71,7 @@ import { spawnTask } from "@agent-native/core/server";
 
 const task = await spawnTask({
   description: "Draft an outreach email to this lead",
-  instructions: "Match Steve's voice from memory/MEMORY.md.",
+  instructions: "Match the user's voice from memory/MEMORY.md.",
   ownerEmail: user.email,
   systemPrompt: mailAgentSystemPrompt,
   actions: mailActions,

--- a/packages/core/docs/content/locales/es-ES/agent-teams.md
+++ b/packages/core/docs/content/locales/es-ES/agent-teams.md
@@ -71,7 +71,7 @@ import { spawnTask } from "@agent-native/core/server";
 
 const task = await spawnTask({
   description: "Draft an outreach email to this lead",
-  instructions: "Match Steve's voice from memory/MEMORY.md.",
+  instructions: "Match the user's voice from memory/MEMORY.md.",
   ownerEmail: user.email,
   systemPrompt: mailAgentSystemPrompt,
   actions: mailActions,

--- a/packages/core/docs/content/locales/fr-FR/agent-teams.md
+++ b/packages/core/docs/content/locales/fr-FR/agent-teams.md
@@ -71,7 +71,7 @@ import { spawnTask } from "@agent-native/core/server";
 
 const task = await spawnTask({
   description: "Draft an outreach email to this lead",
-  instructions: "Match Steve's voice from memory/MEMORY.md.",
+  instructions: "Match the user's voice from memory/MEMORY.md.",
   ownerEmail: user.email,
   systemPrompt: mailAgentSystemPrompt,
   actions: mailActions,

--- a/packages/core/docs/content/locales/hi-IN/agent-teams.md
+++ b/packages/core/docs/content/locales/hi-IN/agent-teams.md
@@ -71,7 +71,7 @@ import { spawnTask } from "@agent-native/core/server";
 
 const task = await spawnTask({
   description: "Draft an outreach email to this lead",
-  instructions: "Match Steve's voice from memory/MEMORY.md.",
+  instructions: "Match the user's voice from memory/MEMORY.md.",
   ownerEmail: user.email,
   systemPrompt: mailAgentSystemPrompt,
   actions: mailActions,

--- a/packages/core/docs/content/locales/ja-JP/agent-teams.md
+++ b/packages/core/docs/content/locales/ja-JP/agent-teams.md
@@ -71,7 +71,7 @@ import { spawnTask } from "@agent-native/core/server";
 
 const task = await spawnTask({
   description: "Draft an outreach email to this lead",
-  instructions: "Match Steve's voice from memory/MEMORY.md.",
+  instructions: "Match the user's voice from memory/MEMORY.md.",
   ownerEmail: user.email,
   systemPrompt: mailAgentSystemPrompt,
   actions: mailActions,

--- a/packages/core/docs/content/locales/ko-KR/agent-teams.md
+++ b/packages/core/docs/content/locales/ko-KR/agent-teams.md
@@ -71,7 +71,7 @@ import { spawnTask } from "@agent-native/core/server";
 
 const task = await spawnTask({
   description: "Draft an outreach email to this lead",
-  instructions: "Match Steve's voice from memory/MEMORY.md.",
+  instructions: "Match the user's voice from memory/MEMORY.md.",
   ownerEmail: user.email,
   systemPrompt: mailAgentSystemPrompt,
   actions: mailActions,

--- a/packages/core/docs/content/locales/pt-BR/agent-teams.md
+++ b/packages/core/docs/content/locales/pt-BR/agent-teams.md
@@ -71,7 +71,7 @@ import { spawnTask } from "@agent-native/core/server";
 
 const task = await spawnTask({
   description: "Draft an outreach email to this lead",
-  instructions: "Match Steve's voice from memory/MEMORY.md.",
+  instructions: "Match the user's voice from memory/MEMORY.md.",
   ownerEmail: user.email,
   systemPrompt: mailAgentSystemPrompt,
   actions: mailActions,

--- a/packages/core/docs/content/locales/zh-CN/agent-teams.md
+++ b/packages/core/docs/content/locales/zh-CN/agent-teams.md
@@ -71,7 +71,7 @@ import { spawnTask } from "@agent-native/core/server";
 
 const task = await spawnTask({
   description: "Draft an outreach email to this lead",
-  instructions: "Match Steve's voice from memory/MEMORY.md.",
+  instructions: "Match the user's voice from memory/MEMORY.md.",
   ownerEmail: user.email,
   systemPrompt: mailAgentSystemPrompt,
   actions: mailActions,


### PR DESCRIPTION
### Summary
Replaces hardcoded references to "Steve" in agent-consumed guidance files with generic, role-based language so the agent does not incorrectly assume a specific user identity.

### Problem
`AGENTS.md` and the `agent-teams.md` documentation (across all locales) contained references to a specific person's name ("Steve"). When these files were surfaced to the agent as repo/project context, the agent would treat any user as that named individual, leaking a personal identity into unrelated sessions.

### Key Changes
- **`AGENTS.md`**: Replaced two occurrences of "Steve" with "the user" in the always-on branch and PR rules.
- **`packages/core/docs/content/agent-teams.md`** and all locale variants (`ar-SA`, `de-DE`, `es-ES`, `fr-FR`, `hi-IN`, `ja-JP`, `ko-KR`, `pt-BR`, `zh-CN`): Changed the example `spawnTask` instruction from `"Match Steve's voice from memory/MEMORY.md."` to `"Match the user's voice from memory/MEMORY.md."`.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/polygon-orbit-dxrajvih"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-polygon-orbit-dxrajvih.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1564`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>polygon-orbit-dxrajvih</branchName>-->