### PR TITLE
fix(core): resolve org from owner email in cookieless background agen…

### DIFF
--- a/.changeset/agent-chat-background-org-scope.md
+++ b/.changeset/agent-chat-background-org-scope.md
@@ -1,0 +1,11 @@
+---
+"@agent-native/core": patch
+---
+
+Fix agent chat resolving a null org in cookieless durable background runs, which
+made the agent see and write only `org_id IS NULL` rows while the UI (carrying
+the session) used the real org. The agent could not list or read resources the
+UI showed, and agent-created rows landed outside the user's org. The background
+run already pre-seeds the owner from the run row; org resolution now falls back
+to `resolveOrgIdForEmail(owner)` when there is no session, so the agent and the
+UI scope to the same org-shared data.

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -7758,6 +7758,28 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
           }
         }
 
+        // DURABLE OWNER CONTEXT, PART 2: ORG.
+        // The cookieless `_process-run` self-dispatch (and any other background
+        // re-entry) resolves the owner from the run row, but has NO session —
+        // every org resolver above ultimately derives identity from
+        // getSession(event), so they all come back null here. That silently
+        // scopes the agent to `org_id IS NULL` rows only: it sees and writes
+        // resources outside the user's org, while the foreground UI — which
+        // carries the session cookie — resolves the real org. The result is the
+        // observed split where the agent can't list/read the same resources the
+        // UI shows and writes new rows with a null org. Resolve the org from the
+        // now-known owner email (the same active-org / membership logic
+        // getOrgContext uses, minus the session) so the agent and the UI operate
+        // over the same org-scoped data.
+        if (!resolvedOrgId && owner && !ownerContext.anonymous) {
+          try {
+            const { resolveOrgIdForEmail } = await import("../org/context.js");
+            resolvedOrgId = (await resolveOrgIdForEmail(owner)) ?? undefined;
+          } catch {
+            // org tables unavailable (first boot) — leave org unscoped
+          }
+        }
+
         // Propagate the caller's IANA timezone from `x-user-timezone` so that
         // tool calls made by the agent (e.g. log-meal with no explicit date)
         // resolve "today" in the user's local timezone instead of server UTC.


### PR DESCRIPTION
…t runs

Agent chat tools could not reliably see resources the UI showed. Across multiple
templates (Assets, Design), the agent's `list-*` and `get-*` actions returned a
different, smaller subset of the user's data than the UI:

- Assets UI showed 9 libraries (`list-libraries` network response: `count: 9`);
  the agent's `list-libraries` returned only 1 — the one the agent itself had
  created. `get-library` on a library open in the UI returned "not found or not
  accessible."
- Design UI showed 3 designs; the agent's `list-designs` returned 0.
- In Neon, agent-created rows had `org_id IS NULL`; UI-created rows had a
  non-null `org_id`. Same `owner_email` on both.

## Root cause

One fact explains every symptom: **agent runs resolved `org_id = NULL` while the
UI resolved the user's real org.**

The durable background agent processor (`_process-run`) is cookieless — an
HMAC-signed self-dispatch, not the user's authenticated request. Owner
resolution was already patched for this (it pre-seeds the owner from the run
row), but org resolution was not: every org resolver bottoms out at
`getOrgContext(event)` → `getSession(event)`, which returns null without a
cookie, yielding `orgId: null`.

With `ctx.orgId = null`, `accessFilter`'s owner branch
(`owner_email = me AND (org_id = ctx.orgId OR org_id IS NULL)`) admits only
`org_id IS NULL` rows, and INSERTs write `org_id = NULL`. The UI, carrying the
session, resolved the real org and saw `= org OR IS NULL` → all rows. Hence the
split. This is framework-level, not template-specific — it affects any ownable,
org-scoped resource read from a background agent run.

## Fix

In `invokeAgentChatHandler`, when org resolution returns nothing and we have a
non-anonymous owner, fall back to `resolveOrgIdForEmail(owner)` — the helper
built for "non-HTTP contexts where we have an email but no session," using the
same active-org/membership logic `getOrgContext` uses. Foreground requests are
unaffected (they resolve a real org first); background runs now scope to the
same org as the UI.

Note:
- Rows the agent already created stay `org_id IS NULL`; they remain visible to
  both via the legacy `OR org_id IS NULL` clause.
