### PR TITLE
Fix desktop Linux release and Mail refreshes

### DIFF
--- a/.changeset/safe-action-string-responses.md
+++ b/.changeset/safe-action-string-responses.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Return plain string action results with a JSON content type so browser action clients can parse successful responses.

--- a/packages/core/src/server/action-routes.spec.ts
+++ b/packages/core/src/server/action-routes.spec.ts
@@ -65,6 +65,29 @@ describe("mountActionRoutes", () => {
     expect(event._status).toBe(403);
   });
 
+  it("serializes plain string action results as JSON strings", async () => {
+    const { mountActionRoutes } = await import("./action-routes.js");
+    const mounted: Array<{ path: string; handler: any }> = [];
+    const nitroApp = {
+      use: vi.fn((path: string, handler: any) =>
+        mounted.push({ path, handler }),
+      ),
+    };
+    const actions: Record<string, ActionEntry> = {
+      "archive-email": {
+        run: vi.fn(async () => "Archived 1 email(s) successfully"),
+      } as any,
+    };
+
+    mountActionRoutes(nitroApp, actions);
+
+    const event = { _method: "POST", req: { json: async () => ({}) } };
+    const result = await mounted[0].handler(event);
+
+    expect(event._responseHeaders["content-type"]).toBe("application/json");
+    expect(JSON.parse(result)).toBe("Archived 1 email(s) successfully");
+  });
+
   it("isolates request context without mutating process.env", async () => {
     const { mountActionRoutes } = await import("./action-routes.js");
     const { getRequestOrgId, getRequestTimezone, getRequestUserEmail } =

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -356,12 +356,16 @@ export function mountActionRoutes(
                 }
               }
 
-              // If the action returned a string, try to parse as JSON for a clean response
+              // If the action returned a string, try to parse as JSON for a
+              // clean response. Plain strings still need to go over the HTTP
+              // action transport as JSON, otherwise H3 sends text/plain and the
+              // browser action client rejects the successful 2xx response.
               if (typeof result === "string") {
                 try {
                   return JSON.parse(result);
                 } catch {
-                  return result;
+                  setResponseHeader(event, "Content-Type", "application/json");
+                  return JSON.stringify(result);
                 }
               }
 

--- a/packages/desktop-app/electron-builder.yml
+++ b/packages/desktop-app/electron-builder.yml
@@ -51,6 +51,7 @@ nsis:
   perMachine: false
 
 linux:
+  executableName: agent-native
   icon: build/icon.png
   target:
     - target: tar.xz

--- a/templates/mail/app/hooks/use-emails.spec.ts
+++ b/templates/mail/app/hooks/use-emails.spec.ts
@@ -1,8 +1,10 @@
 import type { EmailMessage } from "@shared/types";
-import { describe, expect, it, afterEach } from "vitest";
+import { describe, expect, it, afterEach, vi } from "vitest";
 
 import {
+  consumeExternalEmailRefresh,
   filterSuppressedThreads,
+  markExternalEmailRefresh,
   suppressThread,
   unsuppressThread,
 } from "./use-emails";
@@ -28,6 +30,8 @@ function makeEmail(id: string, threadId: string): EmailMessage {
 describe("filterSuppressedThreads", () => {
   afterEach(() => {
     unsuppressThread("thread-archived");
+    consumeExternalEmailRefresh();
+    vi.useRealTimers();
   });
 
   it("keeps an archived thread hidden from stale inbox refetches", () => {
@@ -53,5 +57,33 @@ describe("filterSuppressedThreads", () => {
     );
 
     expect(visible.map((email) => email.id)).toEqual(["msg-archived"]);
+  });
+});
+
+describe("consumeExternalEmailRefresh", () => {
+  afterEach(() => {
+    consumeExternalEmailRefresh();
+    vi.useRealTimers();
+  });
+
+  it("uses each forced Gmail list refresh once", () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-06-26T12:00:00.000Z").getTime();
+    vi.setSystemTime(now);
+
+    markExternalEmailRefresh();
+
+    expect(consumeExternalEmailRefresh()).toBe(now);
+    expect(consumeExternalEmailRefresh()).toBeUndefined();
+  });
+
+  it("drops expired forced Gmail list refreshes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-26T12:00:00.000Z"));
+    markExternalEmailRefresh();
+
+    vi.advanceTimersByTime(5000);
+
+    expect(consumeExternalEmailRefresh()).toBeUndefined();
   });
 });

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -90,6 +90,17 @@ export function markExternalEmailRefresh() {
   externalRefreshAt = Date.now();
 }
 
+export function consumeExternalEmailRefresh(): number | undefined {
+  const refreshAt = externalRefreshAt;
+  if (!refreshAt) return undefined;
+  if (Date.now() - refreshAt >= 5000) {
+    externalRefreshAt = 0;
+    return undefined;
+  }
+  externalRefreshAt = 0;
+  return refreshAt;
+}
+
 function parseRecipients(value?: string): EmailMessage["to"] {
   return (value || "")
     .split(",")
@@ -501,8 +512,11 @@ export function useEmails(
       if (search) params.set("q", search);
       if (label) params.set("label", label);
       if (pageParam) params.set("pageToken", pageParam);
-      if (externalRefreshAt && Date.now() - externalRefreshAt < 5000) {
-        params.set("forceRefresh", String(externalRefreshAt));
+      const forceRefreshAt = !pageParam
+        ? consumeExternalEmailRefresh()
+        : undefined;
+      if (forceRefreshAt) {
+        params.set("forceRefresh", String(forceRefreshAt));
       }
       return apiFetch<EmailsPage>(`/api/emails?${params}`, { signal });
     },
@@ -682,6 +696,7 @@ export function useMarkThreadRead() {
         .map((e) => ({ id: e.id, accountEmail: e.accountEmail }));
       pendingByThread.current.set(threadId, unreadEntries);
       const unreadIds = unreadEntries.map((e) => e.id);
+      const previousThread = getCachedThread(threadId);
       // Set overrides so refetches don't revert read state
       for (const id of unreadIds) {
         setOptimisticOverride(id, { isRead: true });
@@ -694,13 +709,22 @@ export function useMarkThreadRead() {
           ),
         ),
       );
-      return { previous, overrideIds: [...unreadIds] };
+      if (previousThread) {
+        setCachedThread(
+          threadId,
+          previousThread.map((message) => ({ ...message, isRead: true })),
+        );
+      }
+      return { previous, overrideIds: [...unreadIds], previousThread };
     },
-    onError: (_err, _vars, context) => {
+    onError: (_err, threadId, context) => {
       for (const id of context?.overrideIds ?? []) {
         clearOptimisticOverride(id);
       }
       context?.previous.forEach(([key, data]) => qc.setQueryData(key, data));
+      if (context?.previousThread) {
+        setCachedThread(threadId, context.previousThread);
+      }
     },
     onSettled: () => delayedInvalidate(qc, [["emails"], ["labels"]]),
   });

--- a/templates/mail/app/root.tsx
+++ b/templates/mail/app/root.tsx
@@ -74,6 +74,12 @@ function getHydrationStableLocaleInitScript() {
 const THEME_INIT_SCRIPT = getHydrationStableThemeInitScript();
 const LOCALE_INIT_SCRIPT = getHydrationStableLocaleInitScript();
 
+function skipBroadActionInvalidation() {
+  // Mail's Gmail-backed reads are expensive and already refresh through the
+  // explicit app-state refresh-signal that mutating mail actions write.
+  return false;
+}
+
 const MAIL_ERROR_COPY: Record<
   LocaleCode,
   { title: string; fallback: string; back: string; reload: string }
@@ -275,6 +281,7 @@ function DbSyncSetup() {
   useDbSync({
     queryClient: qc,
     queryKeys: [],
+    actionInvalidatePredicate: skipBroadActionInvalidation,
     // Skip events this tab caused — our mutations already handle cache updates
     ignoreSource: TAB_ID,
     onEvent: (data: {
@@ -328,8 +335,13 @@ function DbSyncSetup() {
           invalidateSettingsSurfaces();
         }
       } else if (data.source === "action") {
+        // The core sync hook already refreshes action-backed queries for action
+        // events. Email and label reads are refreshed by the explicit
+        // refresh-signal app-state event so generic action changes do not
+        // cancel and restart Gmail list requests.
+      } else if (data.source === "screen-refresh") {
         if (!isOwnEvent) {
-          qc.invalidateQueries({ queryKey: ["action"] });
+          markExternalEmailRefresh();
           qc.invalidateQueries({ queryKey: ["emails"] });
           qc.invalidateQueries({ queryKey: ["email"] });
           qc.invalidateQueries({ queryKey: ["labels"] });
@@ -337,12 +349,6 @@ function DbSyncSetup() {
         }
       } else if (!isOwnEvent) {
         qc.invalidateQueries({ queryKey: ["action"] });
-        qc.invalidateQueries({ queryKey: ["emails"] });
-        qc.invalidateQueries({ queryKey: ["email"] });
-        qc.invalidateQueries({ queryKey: ["labels"] });
-        qc.invalidateQueries({ queryKey: ["settings"] });
-        qc.invalidateQueries({ queryKey: ["aliases"] });
-        invalidateSettingsSurfaces();
       }
     },
   });

--- a/templates/mail/changelog/2026-06-26-mail-avoids-unnecessary-message-list-reloads-after-backgroun.md
+++ b/templates/mail/changelog/2026-06-26-mail-avoids-unnecessary-message-list-reloads-after-backgroun.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-06-26
+---
+
+Mail avoids unnecessary message list reloads after background updates.


### PR DESCRIPTION
Summary
- Set a Linux-safe desktop executable name so AppImage release builds do not derive one from the scoped package name
- Keep plain string action responses parseable by browser action clients
- Reduce unnecessary Mail list reloads after background refresh events and preserve optimistic thread read state

Validation
- pnpm --filter @agent-native/core exec vitest run src/server/action-routes.spec.ts
- pnpm --filter mail exec vitest run app/hooks/use-emails.spec.ts
- pnpm --filter mail typecheck
- pnpm --filter @agent-native/desktop-app build
- pnpm --filter @agent-native/desktop-app exec electron-builder --linux AppImage --arm64 --config --publish never
- pnpm --filter @agent-native/desktop-app typecheck
- pnpm changeset:status
- pnpm prep