### PR TITLE
Fix Cloudflare Pages worker bundles

### DIFF
--- a/.changeset/cloudflare-worker-browser-externals.md
+++ b/.changeset/cloudflare-worker-browser-externals.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix Cloudflare Pages worker builds for apps with browser screenshot helpers.

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "../shared/social-meta.js";
 import {
   addImmutableAssetRouteRulesForClientBuild,
+  CLOUDFLARE_WORKER_ESBUILD_EXTERNALS,
   copyDir,
   emitSingleTemplateNetlifyBackgroundFunction,
   findInstalledFfmpegStaticPackage,
@@ -626,6 +627,17 @@ export default {
       {},
     );
     expect(byName.status).toBe(404);
+  });
+});
+
+describe("CLOUDFLARE_WORKER_ESBUILD_EXTERNALS", () => {
+  it("externalizes browser screenshot packages with native dependencies", () => {
+    expect(CLOUDFLARE_WORKER_ESBUILD_EXTERNALS).toContain("playwright-core");
+    expect(CLOUDFLARE_WORKER_ESBUILD_EXTERNALS).toContain("chromium-bidi/*");
+    expect(CLOUDFLARE_WORKER_ESBUILD_EXTERNALS).toContain(
+      "@sparticuz/chromium-min",
+    );
+    expect(CLOUDFLARE_WORKER_ESBUILD_EXTERNALS).toContain("fsevents");
   });
 });
 

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -82,6 +82,25 @@ export const NITRO_RUNTIME_IGNORE_PATTERNS = [
   "**/*.test.cjs",
 ];
 
+export const CLOUDFLARE_WORKER_ESBUILD_EXTERNALS = [
+  "mermaid",
+  "@excalidraw/excalidraw",
+  "@excalidraw/mermaid-to-excalidraw",
+  "pdf-parse",
+  "pdfjs-dist",
+  "@google/genai",
+  "chartjs-node-canvas",
+  "@napi-rs/canvas",
+  "@anthropic-ai/tokenizer",
+  "@resvg/resvg-js",
+  "playwright",
+  "playwright-core",
+  "chromium-bidi",
+  "chromium-bidi/*",
+  "@sparticuz/chromium-min",
+  "fsevents",
+];
+
 function normalizeConfiguredAppBasePath(): string {
   return normalizeAppBasePath(
     process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH,
@@ -946,18 +965,9 @@ async function buildCloudflarePages() {
   // files. Both import sites degrade gracefully when the runtime import
   // fails: context-xray token counts fall back to char/4 estimates and the
   // OG image route falls back to SVG.
-  const heavyClientExternals = [
-    "mermaid",
-    "@excalidraw/excalidraw",
-    "@excalidraw/mermaid-to-excalidraw",
-    "pdf-parse",
-    "pdfjs-dist",
-    "@google/genai",
-    "chartjs-node-canvas",
-    "@napi-rs/canvas",
-    "@anthropic-ai/tokenizer",
-    "@resvg/resvg-js",
-  ].map((p) => `--external:${p}`);
+  const heavyClientExternals = CLOUDFLARE_WORKER_ESBUILD_EXTERNALS.map(
+    (p) => `--external:${p}`,
+  );
 
   execFileSync(
     esbuildBin,


### PR DESCRIPTION
## Summary
- externalize browser screenshot and native-only dependencies from Cloudflare Pages worker bundles
- add a deploy regression check for the Cloudflare external list
- add a core patch changeset

## Validation
- pnpm --filter @agent-native/core exec vitest run src/deploy/build.spec.ts
- NITRO_PRESET=cloudflare_pages pnpm --filter analytics build
- NITRO_PRESET=cloudflare_pages pnpm --filter mail build
- pnpm prep