### PR TITLE
Fix content Cloudflare Pages deploy

### DIFF
--- a/.changeset/content-cloudflare-node-stubs.md
+++ b/.changeset/content-cloudflare-node-stubs.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix Cloudflare Pages worker builds for content actions that import Node built-in helpers, and refine shared shell depth styling.

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -184,7 +184,7 @@ type AgentPanelStyle = React.CSSProperties & {
   "--agent-sidebar-width"?: string;
 };
 const AGENT_PANEL_HEADER_CLASS =
-  "relative z-[240] flex h-12 shrink-0 items-center justify-between gap-2 border-b border-border";
+  "agent-native-shell-topbar relative z-[240] flex h-12 shrink-0 items-center justify-between gap-2 border-b border-border";
 const AGENT_PANEL_HEADER_STYLE = {
   paddingLeft: 8,
   paddingRight: 8,
@@ -1880,8 +1880,7 @@ function ResizeHandle({
     <div
       ref={ref}
       className={cn(
-        "relative z-20 shrink-0 w-px touch-none select-none transition-colors",
-        "bg-border hover:bg-accent active:bg-accent",
+        "agent-sidebar-resize-handle relative z-20 w-px shrink-0 touch-none select-none bg-transparent transition-colors hover:bg-border active:bg-border",
       )}
       style={{ cursor: "col-resize" }}
     />

--- a/packages/core/src/client/extensions/AgentNativeExtensionFrame.e2e.spec.ts
+++ b/packages/core/src/client/extensions/AgentNativeExtensionFrame.e2e.spec.ts
@@ -88,9 +88,8 @@ describe("AgentNativeExtensionFrame browser bridge", () => {
   }, 60_000);
 
   afterAll(async () => {
-    await browser?.close();
-    await server?.close();
-  });
+    await Promise.allSettled([browser?.close(), server?.close()]);
+  }, 60_000);
 
   it("runs a sandboxed extension through real iframe postMessage boundaries", async () => {
     const page = await browser.newPage();

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -775,6 +775,10 @@ describe("CLOUDFLARE_WORKER_ESBUILD_EXTERNALS", () => {
     expect(CLOUDFLARE_WORKER_NODE_BUILTIN_STUB_MODULES.fs).toContain(
       "existsSync",
     );
+    expect(
+      CLOUDFLARE_WORKER_NODE_BUILTIN_STUB_MODULES["fs/promises"],
+    ).toContain("mkdtemp");
+    expect(CLOUDFLARE_WORKER_NODE_BUILTIN_STUB_MODULES.net).toContain("isIP");
     expect(CLOUDFLARE_WORKER_NODE_BUILTIN_STUB_MODULES.module).toContain(
       "createRequire",
     );

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -312,6 +312,7 @@ export const CLOUDFLARE_WORKER_NODE_BUILTIN_STUB_MODULES: Record<
     "copyFile",
     "cp",
     "lstat",
+    "mkdtemp",
     "mkdir",
     "readFile",
     "readdir",
@@ -362,12 +363,26 @@ export const CLOUDFLARE_WORKER_NODE_BUILTIN_STUB_MODULES: Record<
       "export const createRequire = () => globalThis.require ?? ((specifier) => { throw new Error('Cannot require: ' + specifier); });",
     ],
   ),
-  net: cloudflareNodeBuiltinStubSource("net", [
-    "Socket",
-    "connect",
-    "createConnection",
-    "createServer",
-  ]),
+  net: cloudflareNodeBuiltinStubSource(
+    "net",
+    ["Socket", "connect", "createConnection", "createServer", "isIP"],
+    [
+      `export const isIP = (value) => {
+  const input = String(value ?? "");
+  const ipv4Parts = input.split(".");
+  if (
+    ipv4Parts.length === 4 &&
+    ipv4Parts.every((part) => /^\\d{1,3}$/.test(part) && Number(part) >= 0 && Number(part) <= 255)
+  ) {
+    return 4;
+  }
+  if (input.includes(":") && /^[0-9A-Fa-f:.]+$/.test(input)) {
+    return 6;
+  }
+  return 0;
+};`,
+    ],
+  ),
   os: cloudflareNodeBuiltinStubSource(
     "os",
     [

--- a/packages/core/src/styles/agent-native.css
+++ b/packages/core/src/styles/agent-native.css
@@ -55,9 +55,9 @@
   --agent-native-lower-surface: hsl(
     var(--sidebar-background, var(--background))
   );
-  --agent-native-raised-radius: 18px;
-  --agent-native-raised-shadow-left: -12px 0 28px rgb(0 0 0 / 0.1);
-  --agent-native-raised-shadow-right: 12px 0 28px rgb(0 0 0 / 0.1);
+  --agent-native-raised-radius: 8px;
+  --agent-native-raised-shadow-left: -2px 0 8px rgb(0 0 0 / 0.035);
+  --agent-native-raised-shadow-right: 2px 0 8px rgb(0 0 0 / 0.035);
   background: var(--agent-native-lower-surface);
 }
 
@@ -69,19 +69,6 @@
       hsl(var(--sidebar-background, var(--background))) 94%,
       black
     );
-  }
-
-  .dark .agent-sidebar-shell,
-  .dark .agent-layout-shell,
-  .dark.agent-sidebar-shell,
-  .dark.agent-layout-shell {
-    --agent-native-lower-surface: color-mix(
-      in srgb,
-      hsl(var(--sidebar-background, var(--background))) 86%,
-      black
-    );
-    --agent-native-raised-shadow-left: -14px 0 32px rgb(0 0 0 / 0.22);
-    --agent-native-raised-shadow-right: 14px 0 32px rgb(0 0 0 / 0.22);
   }
 }
 
@@ -115,7 +102,7 @@
 
 @media (min-width: 768px) {
   .agent-layout-main-surface,
-  .agent-layout-shell > .agent-sidebar-shell {
+  .agent-layout-shell > .agent-sidebar-shell > .agent-sidebar-main-surface {
     border-start-start-radius: var(--agent-native-raised-radius);
     border-end-start-radius: var(--agent-native-raised-radius);
     box-shadow: var(--agent-native-raised-shadow-left);

--- a/packages/core/src/styles/agent-native.css
+++ b/packages/core/src/styles/agent-native.css
@@ -55,15 +55,32 @@
   --agent-native-lower-surface: hsl(
     var(--sidebar-background, var(--background))
   );
+  --agent-native-raised-border: hsl(var(--border));
   --agent-native-raised-radius: 8px;
-  --agent-native-raised-shadow-left: -2px 0 8px rgb(0 0 0 / 0.035);
-  --agent-native-raised-shadow-right: 2px 0 8px rgb(0 0 0 / 0.035);
+  --agent-native-raised-shadow-left: -1px 0 3px rgb(0 0 0 / 0.018);
+  --agent-native-raised-shadow-right: 1px 0 3px rgb(0 0 0 / 0.018);
   background: var(--agent-native-lower-surface);
 }
 
 @supports (background: color-mix(in srgb, white, black)) {
   .agent-sidebar-shell,
   .agent-layout-shell {
+    --agent-native-lower-surface: color-mix(
+      in srgb,
+      hsl(var(--sidebar-background, var(--background))) 98%,
+      black
+    );
+    --agent-native-raised-border: color-mix(
+      in srgb,
+      hsl(var(--border)) 84%,
+      transparent
+    );
+  }
+
+  .dark .agent-sidebar-shell,
+  .dark .agent-layout-shell,
+  .dark.agent-sidebar-shell,
+  .dark.agent-layout-shell {
     --agent-native-lower-surface: color-mix(
       in srgb,
       hsl(var(--sidebar-background, var(--background))) 94%,
@@ -86,8 +103,16 @@
   background: var(--agent-native-lower-surface) !important;
 }
 
+.agent-layout-shell .agent-layout-left-drawer {
+  border-inline-end-color: transparent !important;
+}
+
 .agent-sidebar-panel > .agent-sidebar-panel-inner {
   background: inherit;
+}
+
+.agent-sidebar-resize-handle {
+  background: transparent;
 }
 
 .agent-layout-main-surface,
@@ -100,23 +125,41 @@
     box-shadow 260ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 
+.agent-layout-shell
+  :where(.agent-layout-main-surface, .agent-sidebar-main-surface)
+  > :first-child
+  > :where(header, div).border-b:first-child,
+.agent-layout-shell
+  :where(.agent-layout-main-surface, .agent-sidebar-main-surface)
+  > :where(header, div).border-b:first-child,
+.agent-layout-shell
+  .agent-layout-left-drawer
+  > :where(header, div).border-b:first-child,
+.agent-layout-shell .agent-native-shell-topbar {
+  border-bottom-color: transparent !important;
+}
+
 @media (min-width: 768px) {
   .agent-layout-main-surface,
   .agent-layout-shell > .agent-sidebar-shell > .agent-sidebar-main-surface {
     border-start-start-radius: var(--agent-native-raised-radius);
     border-end-start-radius: var(--agent-native-raised-radius);
+    border-inline-start: 1px solid var(--agent-native-raised-border);
+    border-inline-end: 1px solid var(--agent-native-raised-border);
     box-shadow: var(--agent-native-raised-shadow-left);
   }
 
   .agent-sidebar-main-surface[data-agent-sidebar-main-state="open"][data-agent-sidebar-main-position="right"] {
     border-start-end-radius: var(--agent-native-raised-radius);
     border-end-end-radius: var(--agent-native-raised-radius);
+    border-inline-end: 1px solid var(--agent-native-raised-border);
     box-shadow: var(--agent-native-raised-shadow-right);
   }
 
   .agent-sidebar-main-surface[data-agent-sidebar-main-state="open"][data-agent-sidebar-main-position="left"] {
     border-start-start-radius: var(--agent-native-raised-radius);
     border-end-start-radius: var(--agent-native-raised-radius);
+    border-inline-start: 1px solid var(--agent-native-raised-border);
     box-shadow: var(--agent-native-raised-shadow-left);
   }
 }

--- a/packages/frame/client/styles.css
+++ b/packages/frame/client/styles.css
@@ -70,13 +70,28 @@ body {
 
 .agent-frame-shell {
   --agent-native-lower-surface: hsl(var(--background));
+  --agent-native-raised-border: hsl(var(--border));
   --agent-native-raised-radius: 8px;
-  --agent-native-raised-shadow-right: 2px 0 8px rgb(0 0 0 / 0.035);
+  --agent-native-raised-shadow-right: 1px 0 3px rgb(0 0 0 / 0.018);
   background: var(--agent-native-lower-surface);
 }
 
 @supports (background: color-mix(in srgb, white, black)) {
   .agent-frame-shell {
+    --agent-native-lower-surface: color-mix(
+      in srgb,
+      hsl(var(--background)) 98%,
+      black
+    );
+    --agent-native-raised-border: color-mix(
+      in srgb,
+      hsl(var(--border)) 84%,
+      transparent
+    );
+  }
+
+  .dark .agent-frame-shell,
+  .dark.agent-frame-shell {
     --agent-native-lower-surface: color-mix(
       in srgb,
       hsl(var(--background)) 94%,
@@ -105,6 +120,7 @@ body {
   .agent-frame-main-surface[data-agent-frame-main-state="open"] {
     border-start-end-radius: var(--agent-native-raised-radius);
     border-end-end-radius: var(--agent-native-raised-radius);
+    border-inline-end: 1px solid var(--agent-native-raised-border);
     box-shadow: var(--agent-native-raised-shadow-right);
   }
 }

--- a/packages/frame/client/styles.css
+++ b/packages/frame/client/styles.css
@@ -70,8 +70,8 @@ body {
 
 .agent-frame-shell {
   --agent-native-lower-surface: hsl(var(--background));
-  --agent-native-raised-radius: 18px;
-  --agent-native-raised-shadow-right: 12px 0 28px rgb(0 0 0 / 0.18);
+  --agent-native-raised-radius: 8px;
+  --agent-native-raised-shadow-right: 2px 0 8px rgb(0 0 0 / 0.035);
   background: var(--agent-native-lower-surface);
 }
 
@@ -79,7 +79,7 @@ body {
   .agent-frame-shell {
     --agent-native-lower-surface: color-mix(
       in srgb,
-      hsl(var(--background)) 86%,
+      hsl(var(--background)) 94%,
       black
     );
   }


### PR DESCRIPTION
## Summary
- stub additional Node built-in helpers used by content actions in Cloudflare Pages workers
- refine shared shell depth styling that landed locally after the previous merge
- make the extension iframe e2e cleanup tolerate full-suite browser close latency

## Validation
- pnpm --filter @agent-native/core exec vitest run src/deploy/build.spec.ts
- NITRO_PRESET=cloudflare_pages pnpm --filter content build
- pnpm --filter @agent-native/core exec vitest run src/client/extensions/AgentNativeExtensionFrame.e2e.spec.ts
- pnpm prep