### PR TITLE
Polish dark mode and sidebar surfaces

### DIFF
--- a/.changeset/quiet-language-picker-popover.md
+++ b/.changeset/quiet-language-picker-popover.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Use a compact popover for the shared language picker so icon-only chrome can style it reliably.

--- a/packages/core/src/client/LanguagePicker.spec.tsx
+++ b/packages/core/src/client/LanguagePicker.spec.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AgentNativeI18nProvider,
+  LanguagePicker,
+  LOCALE_STORAGE_KEY,
+} from "./i18n.js";
+
+describe("LanguagePicker", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    window.localStorage.clear();
+    document.documentElement.lang = "en-US";
+    document.documentElement.dir = "ltr";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.body.innerHTML = "";
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  async function renderPicker(variant: "select" | "icon" = "select") {
+    await act(async () => {
+      root.render(
+        <AgentNativeI18nProvider
+          initialLocale="en-US"
+          initialPreference="en-US"
+          persistPreference={false}
+        >
+          <LanguagePicker label="Interface language" variant={variant} />
+        </AgentNativeI18nProvider>,
+      );
+      await Promise.resolve();
+    });
+  }
+
+  async function click(element: Element) {
+    await act(async () => {
+      element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+  }
+
+  it("renders the app picker as a polished popover instead of a combobox menu", async () => {
+    await renderPicker();
+
+    const trigger = document.querySelector("[data-language-picker-trigger]");
+    expect(trigger?.tagName).toBe("BUTTON");
+    expect(trigger?.getAttribute("role")).not.toBe("combobox");
+    expect(trigger?.getAttribute("aria-label")).toBe(
+      "Interface language: English (en-US)",
+    );
+
+    await click(trigger!);
+
+    expect(document.body.querySelector('[role="menu"]')).not.toBeNull();
+    expect(document.body.textContent).toContain("System");
+    expect(document.body.textContent).toContain("Français (fr-FR)");
+    expect(document.body.textContent).toContain("العربية (ar-SA)");
+  });
+
+  it("updates the shared locale preference from a popover row", async () => {
+    await renderPicker();
+
+    await click(document.querySelector("[data-language-picker-trigger]")!);
+    const frenchOption = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>(
+        '[role="menuitemradio"]',
+      ),
+    ).find((button) => button.textContent?.includes("Français"));
+    expect(frenchOption).toBeTruthy();
+
+    await click(frenchOption!);
+
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe("fr-FR");
+    expect(document.documentElement.lang).toBe("fr-FR");
+    expect(document.body.querySelector('[role="menu"]')).toBeNull();
+    expect(
+      document
+        .querySelector("[data-language-picker-trigger]")
+        ?.getAttribute("aria-label"),
+    ).toBe("Interface language: Français (fr-FR)");
+  });
+});

--- a/packages/core/src/client/i18n.tsx
+++ b/packages/core/src/client/i18n.tsx
@@ -1,4 +1,4 @@
-import * as SelectPrimitive from "@radix-ui/react-select";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { IconCheck, IconChevronDown, IconLanguage } from "@tabler/icons-react";
 import i18next, { type i18n as I18nInstance } from "i18next";
 import React, {
@@ -34,6 +34,7 @@ import {
 } from "../localization/shared.js";
 import { setClientAppState } from "./application-state.js";
 import { callAction } from "./use-action.js";
+import { cn } from "./utils.js";
 
 export {
   DEFAULT_LOCALE,
@@ -676,6 +677,7 @@ export function LanguagePicker({
   variant?: "select" | "icon";
 }) {
   const { locale, preference, setPreference } = useLocale();
+  const [open, setOpen] = useState(false);
   const copy =
     LANGUAGE_PICKER_COPY[locale] ?? LANGUAGE_PICKER_COPY[DEFAULT_LOCALE];
   const resolvedLabel = label ?? copy.label;
@@ -691,84 +693,94 @@ export function LanguagePicker({
       : []),
     ...SUPPORTED_LOCALES.map((code) => ({
       value: code,
-      label:
-        LOCALE_METADATA[code].nativeName === LOCALE_METADATA[code].englishName
-          ? LOCALE_METADATA[code].nativeName
-          : `${LOCALE_METADATA[code].nativeName} (${LOCALE_METADATA[code].englishName})`,
+      label: `${LOCALE_METADATA[code].nativeName} (${code})`,
       description: code,
     })),
   ];
   const selected = options.find((option) => option.value === preference);
+  const selectedLabel = selected?.label ?? preference;
+  const triggerLabel = `${resolvedLabel}: ${selectedLabel}`;
+
+  function handleOptionClick(value: LocalePreference) {
+    setOpen(false);
+    void setPreference(normalizeLocalizationPreference(value).locale);
+  }
 
   return (
     <div className={className}>
-      <SelectPrimitive.Root
-        value={preference}
-        onValueChange={(value) =>
-          void setPreference(normalizeLocalizationPreference(value).locale)
-        }
-      >
-        <SelectPrimitive.Trigger
-          className={
-            variant === "icon"
-              ? "flex h-8 w-8 items-center justify-center rounded-md border border-border bg-background text-foreground outline-none transition-colors hover:bg-accent/40 data-[placeholder]:text-muted-foreground"
-              : "flex h-9 w-full items-center justify-between rounded-md border border-border bg-background px-3 text-start text-[12px] text-foreground outline-none transition-colors hover:bg-accent/40 data-[placeholder]:text-muted-foreground"
-          }
-          aria-label={resolvedLabel}
-          title={selected?.label ?? resolvedLabel}
-        >
-          <span className="flex min-w-0 items-center gap-2">
-            <IconLanguage className="h-4 w-4 shrink-0 text-muted-foreground" />
-            {variant === "select" ? (
-              <SelectPrimitive.Value>
-                <span className="truncate">
-                  {selected?.label ?? preference}
-                </span>
-              </SelectPrimitive.Value>
-            ) : null}
-          </span>
-          {variant === "select" ? (
-            <SelectPrimitive.Icon asChild>
-              <IconChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-            </SelectPrimitive.Icon>
-          ) : null}
-        </SelectPrimitive.Trigger>
-        <SelectPrimitive.Portal>
-          <SelectPrimitive.Content
-            position="popper"
-            sideOffset={6}
-            className={
+      <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+        <PopoverPrimitive.Trigger asChild>
+          <button
+            type="button"
+            aria-label={triggerLabel}
+            title={triggerLabel}
+            data-language-picker-trigger
+            className={cn(
+              "shrink-0 rounded-md border border-border bg-background text-foreground outline-none transition-colors hover:border-foreground/30 hover:bg-accent/40 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=open]:border-foreground/30 data-[state=open]:bg-accent/40",
               variant === "icon"
-                ? "z-[9999] min-w-56 overflow-hidden rounded-lg border border-border bg-popover shadow-lg"
-                : "z-[9999] w-[var(--radix-select-trigger-width)] overflow-hidden rounded-lg border border-border bg-popover shadow-lg"
-            }
+                ? "flex h-8 w-8 items-center justify-center"
+                : "flex h-9 w-full items-center justify-between gap-2 px-3 text-start text-sm",
+            )}
           >
-            <SelectPrimitive.Viewport className="p-1">
-              {options.map((option) => (
-                <SelectPrimitive.Item
+            <span className="flex min-w-0 items-center gap-2">
+              <IconLanguage className="h-4 w-4 shrink-0 text-muted-foreground" />
+              {variant === "select" ? (
+                <span className="truncate">{selectedLabel}</span>
+              ) : (
+                <span className="sr-only">{triggerLabel}</span>
+              )}
+            </span>
+            {variant === "select" ? (
+              <IconChevronDown
+                className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+                aria-hidden="true"
+              />
+            ) : null}
+          </button>
+        </PopoverPrimitive.Trigger>
+        <PopoverPrimitive.Portal>
+          <PopoverPrimitive.Content
+            align={variant === "icon" ? "end" : "start"}
+            sideOffset={6}
+            role="menu"
+            className={cn(
+              "z-[9999] max-h-[min(20rem,var(--radix-popover-content-available-height))] overflow-y-auto rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-lg outline-none will-change-[transform,opacity] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:duration-100 data-[state=open]:duration-150 data-[state=closed]:ease-in data-[state=open]:ease-out data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+              variant === "icon"
+                ? "min-w-56"
+                : "w-[min(20rem,calc(100vw-2rem))] min-w-[var(--radix-popover-trigger-width)]",
+            )}
+          >
+            {options.map((option) => {
+              const optionSelected = option.value === preference;
+              return (
+                <button
                   key={option.value}
-                  value={option.value}
-                  className="relative flex w-full cursor-pointer select-none items-start gap-2 rounded-md px-8 py-2.5 text-[12px] outline-none data-[highlighted]:bg-accent/60 data-[state=checked]:bg-accent/40"
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={optionSelected}
+                  title={option.description}
+                  onClick={() => handleOptionClick(option.value)}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-start text-sm outline-none transition-colors hover:bg-accent/60 hover:text-foreground focus-visible:bg-accent/60 focus-visible:text-foreground",
+                    optionSelected
+                      ? "bg-accent/40 text-foreground"
+                      : "text-muted-foreground",
+                  )}
                 >
-                  <span className="absolute start-2 top-2.5 flex h-4 w-4 items-center justify-center text-muted-foreground">
-                    <SelectPrimitive.ItemIndicator>
-                      <IconCheck className="h-3.5 w-3.5" />
-                    </SelectPrimitive.ItemIndicator>
-                  </span>
-                  <div className="flex min-w-0 flex-col">
-                    <SelectPrimitive.ItemText>
-                      <span className="text-foreground">{option.label}</span>
-                    </SelectPrimitive.ItemText>
-                    <span className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
-                      {option.description}
-                    </span>
-                  </div>
-                </SelectPrimitive.Item>
-              ))}
-            </SelectPrimitive.Viewport>
-          </SelectPrimitive.Content>
-        </SelectPrimitive.Portal>
-      </SelectPrimitive.Root>
+                  <IconCheck
+                    className={cn(
+                      "h-3.5 w-3.5 shrink-0",
+                      optionSelected ? "opacity-100" : "opacity-0",
+                    )}
+                    aria-hidden="true"
+                  />
+                  <span className="truncate">{option.label}</span>
+                </button>
+              );
+            })}
+          </PopoverPrimitive.Content>
+        </PopoverPrimitive.Portal>
+      </PopoverPrimitive.Root>
     </div>
   );
 }

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -34,7 +34,7 @@
 }
 
 .dark {
-  --background: 0 0% 4%;
+  --background: 0 0% 0%;
   --foreground: 0 0% 93%;
   --card: 0 0% 4%;
   --card-foreground: 0 0% 93%;

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -2263,7 +2263,7 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
                   <LanguagePicker
                     variant="icon"
                     label={t("settings.languageLabel")}
-                    className="[&_[role=combobox]]:rounded-lg [&_[role=combobox]]:border-0 [&_[role=combobox]]:bg-transparent [&_[role=combobox]]:text-muted-foreground [&_[role=combobox]]:hover:bg-sidebar-accent/50 [&_[role=combobox]]:hover:text-primary"
+                    className="[&_[data-language-picker-trigger]]:rounded-lg [&_[data-language-picker-trigger]]:border-0 [&_[data-language-picker-trigger]]:bg-transparent [&_[data-language-picker-trigger]]:text-muted-foreground [&_[data-language-picker-trigger]]:hover:bg-sidebar-accent/50 [&_[data-language-picker-trigger]]:hover:text-primary"
                   />
                 </div>
               </div>

--- a/templates/analytics/app/global.css
+++ b/templates/analytics/app/global.css
@@ -146,6 +146,19 @@
   display: none;
 }
 
+.dark .analytics-ask-page {
+  background: hsl(var(--secondary) / 0.38);
+}
+
+.dark .analytics-ask-page .analytics-chat-panel {
+  background: transparent;
+}
+
+.dark .agent-sidebar-panel[data-agent-sidebar-layout="desktop"],
+.dark .agent-sidebar-panel[data-agent-sidebar-layout="mobile"] {
+  background: #000 !important;
+}
+
 .analytics-chat-panel
   [data-agent-empty-state="centered"]
   .analytics-chat-intro {
@@ -236,9 +249,11 @@
 }
 
 .dark
+  .analytics-ask-page
   .analytics-chat-panel
   [data-agent-empty-state="centered"]
   .agent-composer-root {
+  background: hsl(var(--secondary) / 0.72);
   box-shadow: none;
 }
 

--- a/templates/analytics/app/pages/Ask.tsx
+++ b/templates/analytics/app/pages/Ask.tsx
@@ -22,7 +22,7 @@ export default function AskPage() {
   }, []);
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-background">
+    <div className="analytics-ask-page flex h-full min-h-0 flex-col bg-background">
       <AgentChatSurface
         mode="page"
         chatViewTransition

--- a/templates/analytics/changelog/2026-06-26-the-ask-tab-uses-a-softer-dark-gray-canvas-while-sidebar-cha.md
+++ b/templates/analytics/changelog/2026-06-26-the-ask-tab-uses-a-softer-dark-gray-canvas-while-sidebar-cha.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-26
+---
+
+The Ask tab uses a softer dark-gray canvas while sidebar chat stays black.

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -233,12 +233,297 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
   ];
 
   return (
-    <div className="flex h-screen overflow-hidden bg-background">
+    <div className="agent-layout-shell flex h-screen overflow-hidden bg-background">
+      {/* Mobile backdrop */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 md:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
+      {/* Left sidebar */}
+      <aside
+        className={cn(
+          "agent-layout-left-drawer fixed inset-y-0 start-0 z-50 flex h-full w-[260px] flex-col overflow-hidden border-e border-border bg-sidebar transition-[width,transform] duration-200 ease-out md:static md:z-auto",
+          showCollapsedSidebar && "md:w-14",
+          sidebarOpen
+            ? "translate-x-0"
+            : "-translate-x-full rtl:translate-x-full md:translate-x-0",
+        )}
+      >
+        <div
+          className={cn(
+            "flex h-12 shrink-0 items-center border-b border-border",
+            showCollapsedSidebar ? "justify-center px-2" : "px-4",
+          )}
+        >
+          <div
+            className={cn(
+              "flex min-w-0 items-center gap-2",
+              !showCollapsedSidebar && "flex-1",
+            )}
+          >
+            {!showCollapsedSidebar && (
+              <>
+                <img
+                  src={appPath("/agent-native-icon-light.svg")}
+                  alt=""
+                  aria-hidden="true"
+                  className="block h-4 w-auto shrink-0 dark:hidden"
+                />
+                <img
+                  src={appPath("/agent-native-icon-dark.svg")}
+                  alt=""
+                  aria-hidden="true"
+                  className="hidden h-4 w-auto shrink-0 dark:block"
+                />
+                <span className="truncate text-sm font-semibold text-foreground">
+                  {t("navigation.brand")}
+                </span>
+              </>
+            )}
+          </div>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="hidden h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground md:inline-flex"
+                aria-label={
+                  showCollapsedSidebar
+                    ? t("navigation.expandSidebar")
+                    : t("navigation.collapseSidebar")
+                }
+                aria-expanded={!showCollapsedSidebar}
+                onClick={() => setSidebarCollapsed((value) => !value)}
+              >
+                {showCollapsedSidebar ? (
+                  <IconLayoutSidebarLeftExpand className="h-4 w-4" />
+                ) : (
+                  <IconLayoutSidebarLeftCollapse className="h-4 w-4" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              {showCollapsedSidebar
+                ? t("navigation.expandSidebar")
+                : t("navigation.collapseSidebar")}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {showCollapsedSidebar ? (
+            <>
+              <div className="flex justify-center px-2 py-3">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <NavLink
+                      to="/record"
+                      aria-label={t("navigation.newRecording")}
+                      className="flex h-9 w-9 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-sm hover:bg-primary/90"
+                    >
+                      <IconPlayerRecord className="h-4 w-4" />
+                    </NavLink>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    {t("navigation.newRecording")}
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+
+              <nav className="mt-3 flex flex-col items-center gap-1 px-2">
+                {navItems.map(({ to, label, icon: Icon, match }) => {
+                  const active = match(location.pathname);
+                  return (
+                    <Tooltip key={to}>
+                      <TooltipTrigger asChild>
+                        <NavLink
+                          to={to}
+                          aria-label={label}
+                          className={cn(
+                            "flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+                            active &&
+                              "bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary",
+                          )}
+                        >
+                          <Icon className="h-4 w-4" />
+                        </NavLink>
+                      </TooltipTrigger>
+                      <TooltipContent side="right">{label}</TooltipContent>
+                    </Tooltip>
+                  );
+                })}
+              </nav>
+            </>
+          ) : (
+            <>
+              <div className="px-3 py-3">
+                <Button
+                  className="w-full gap-1.5 bg-primary text-primary-foreground shadow-sm hover:bg-primary/90"
+                  size="sm"
+                  asChild
+                >
+                  <NavLink to="/record">
+                    <IconPlayerRecord className="h-4 w-4" />
+                    {t("navigation.newRecording")}
+                  </NavLink>
+                </Button>
+              </div>
+
+              <nav className="mt-3 space-y-0.5 px-2">
+                {navItems.map(({ to, label, icon: Icon, match, count }) => {
+                  const active = match(location.pathname);
+                  return (
+                    <NavLink
+                      key={to}
+                      to={to}
+                      className={cn(
+                        "flex items-center gap-2 rounded px-2 py-1.5 text-xs",
+                        active
+                          ? "bg-primary/10 font-medium text-primary"
+                          : "text-foreground hover:bg-accent/60",
+                      )}
+                    >
+                      <Icon className="h-4 w-4" />
+                      <span className="flex-1 truncate">{label}</span>
+                      {count !== undefined && count > 0 && (
+                        <span
+                          className={cn(
+                            "shrink-0 tabular-nums text-[11px]",
+                            active
+                              ? "text-primary/80"
+                              : "text-muted-foreground",
+                          )}
+                        >
+                          {count}
+                        </span>
+                      )}
+                    </NavLink>
+                  );
+                })}
+              </nav>
+
+              <div className="mt-4 space-y-4 px-2 pb-3">
+                <div>
+                  <div className="flex items-center justify-between px-2 pb-1">
+                    <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      {t("navigation.folders")}
+                    </span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label={t("navigation.newFolder")}
+                          className="rounded p-1 text-muted-foreground hover:bg-accent"
+                          onClick={() => setNewFolderOpen(true)}
+                        >
+                          <IconFolderPlus className="h-3.5 w-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {t("navigation.newFolder")}
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <FolderTree
+                    folders={libFolderList}
+                    organizationId={currentOrganizationId}
+                    spaceId={null}
+                    buildPath={(id) => `/library/folder/${id}`}
+                    activeFolderId={folderId ?? null}
+                  />
+                </div>
+
+                <div>
+                  <div className="flex items-center justify-between px-2 pb-1">
+                    <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      {t("navigation.spaces")}
+                    </span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label={t("navigation.spaces")}
+                          className="rounded p-1 text-muted-foreground hover:bg-accent"
+                          onClick={() => setNewSpaceOpen(true)}
+                        >
+                          <IconPlus className="h-3.5 w-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>{t("navigation.spaces")}</TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <ul className="space-y-0.5">
+                    {(spaces?.spaces ?? []).map((s: any) => {
+                      const active = spaceId === s.id;
+                      return (
+                        <li key={s.id}>
+                          <NavLink
+                            to={`/spaces/${s.id}`}
+                            className={cn(
+                              "flex items-center gap-2 rounded px-2 py-1 text-xs",
+                              active
+                                ? "bg-primary/10 text-primary"
+                                : "text-foreground hover:bg-accent/60",
+                            )}
+                          >
+                            <div
+                              className="flex h-4 w-4 items-center justify-center rounded text-[10px]"
+                              style={{
+                                background: s.color ?? "hsl(var(--primary))",
+                                color: "white",
+                              }}
+                            >
+                              {s.iconEmoji ?? s.name.slice(0, 1).toUpperCase()}
+                            </div>
+                            <span className="truncate">{s.name}</span>
+                          </NavLink>
+                        </li>
+                      );
+                    })}
+                    {(spaces?.spaces ?? []).length === 0 && (
+                      <li className="px-2 py-1 text-[11px] text-muted-foreground/70">
+                        {t("navigation.noSpaces")}
+                      </li>
+                    )}
+                  </ul>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {!showCollapsedSidebar && (
+          <>
+            <div className="shrink-0 space-y-1.5 border-t border-border px-2 py-1.5">
+              {shouldShowSidebarLink && (
+                <CaptureInstallInlineLink className="flex items-center gap-2 rounded px-2 py-1.5 text-xs text-foreground hover:bg-accent/60">
+                  <IconAppWindow className="h-4 w-4" />
+                  {t("navigation.desktopCta")}
+                </CaptureInstallInlineLink>
+              )}
+              <SearchBar />
+            </div>
+
+            <div className="shrink-0 border-t border-border px-1 py-1">
+              <ExtensionsSidebarSection />
+            </div>
+
+            <div className="shrink-0 space-y-2 border-t border-border px-3 py-2">
+              <OrgSwitcher settingsPath="/settings/organization" />
+              <DevDatabaseLink />
+              <FeedbackButton />
+            </div>
+          </>
+        )}
+      </aside>
+
       <AgentSidebar
         position="right"
         defaultOpen={!isMobile}
-        animateMobile={false}
-        animateDesktop={false}
         emptyStateText={t("navigation.agentEmptyState")}
         suggestions={[
           t("navigation.agentSuggestionSummary"),
@@ -248,355 +533,62 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
         scope={recordingScope}
         browserTabId={getBrowserTabId()}
       >
-        <div className="agent-layout-shell flex h-full w-full">
-          {/* Mobile backdrop */}
-          {sidebarOpen && (
-            <div
-              className="fixed inset-0 z-40 bg-black/50 md:hidden"
-              onClick={() => setSidebarOpen(false)}
-            />
-          )}
-
-          {/* Left sidebar */}
-          <aside
-            className={cn(
-              "agent-layout-left-drawer fixed inset-y-0 start-0 z-50 flex h-full w-[260px] flex-col overflow-hidden border-e border-border bg-sidebar transition-[width,transform] duration-200 ease-out md:static md:z-auto",
-              showCollapsedSidebar && "md:w-14",
-              sidebarOpen
-                ? "translate-x-0"
-                : "-translate-x-full rtl:translate-x-full md:translate-x-0",
-            )}
-          >
-            <div
-              className={cn(
-                "flex h-12 shrink-0 items-center border-b border-border",
-                showCollapsedSidebar ? "justify-center px-2" : "px-4",
-              )}
-            >
-              <div
-                className={cn(
-                  "flex min-w-0 items-center gap-2",
-                  !showCollapsedSidebar && "flex-1",
-                )}
+        {/* Main content area */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          {!pageOwnsToolbar && (
+            <header className="flex shrink-0 items-center gap-3 border-b border-border px-5 py-3">
+              <button
+                onClick={() => setSidebarOpen(true)}
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground md:hidden"
               >
-                {!showCollapsedSidebar && (
-                  <>
-                    <img
-                      src={appPath("/agent-native-icon-light.svg")}
-                      alt=""
-                      aria-hidden="true"
-                      className="block h-4 w-auto shrink-0 dark:hidden"
-                    />
-                    <img
-                      src={appPath("/agent-native-icon-dark.svg")}
-                      alt=""
-                      aria-hidden="true"
-                      className="hidden h-4 w-auto shrink-0 dark:block"
-                    />
-                    <span className="truncate text-sm font-semibold text-foreground">
-                      {t("navigation.brand")}
-                    </span>
-                  </>
-                )}
+                <IconMenu2 className="h-4 w-4" />
+              </button>
+              <div
+                ref={setHeaderSlot}
+                className="flex min-w-0 flex-1 items-center gap-3 overflow-hidden"
+              />
+              <div className="ms-auto flex items-center gap-2">
+                <ClipsAgentToggleButton />
               </div>
-
+            </header>
+          )}
+          <InvitationBanner />
+          {shouldShowPromo && (
+            <div className="flex items-center gap-3 border-b border-border bg-primary/5 px-5 py-2.5 text-sm">
+              <IconAppWindow className="h-4 w-4 shrink-0 text-primary" />
+              <div className="min-w-0 flex-1">
+                <span className="font-medium">
+                  {t("navigation.desktopTitle")}
+                </span>{" "}
+                <span className="text-muted-foreground">
+                  {t("navigation.desktopBody")}
+                </span>
+              </div>
+              <CaptureInstallButton size="sm" className="shrink-0">
+                Download
+              </CaptureInstallButton>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
-                    type="button"
                     variant="ghost"
                     size="icon"
-                    className="hidden h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground md:inline-flex"
-                    aria-label={
-                      showCollapsedSidebar
-                        ? t("navigation.expandSidebar")
-                        : t("navigation.collapseSidebar")
-                    }
-                    aria-expanded={!showCollapsedSidebar}
-                    onClick={() => setSidebarCollapsed((value) => !value)}
+                    className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+                    onClick={dismiss}
                   >
-                    {showCollapsedSidebar ? (
-                      <IconLayoutSidebarLeftExpand className="h-4 w-4" />
-                    ) : (
-                      <IconLayoutSidebarLeftCollapse className="h-4 w-4" />
-                    )}
+                    <IconX className="h-4 w-4" />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent side="right">
-                  {showCollapsedSidebar
-                    ? t("navigation.expandSidebar")
-                    : t("navigation.collapseSidebar")}
+                <TooltipContent>
+                  {t("clipsFinalRaw.alreadyHaveIt")}
                 </TooltipContent>
               </Tooltip>
             </div>
-            <div className="min-h-0 flex-1 overflow-y-auto">
-              {showCollapsedSidebar ? (
-                <>
-                  <div className="flex justify-center px-2 py-3">
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <NavLink
-                          to="/record"
-                          aria-label={t("navigation.newRecording")}
-                          className="flex h-9 w-9 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-sm hover:bg-primary/90"
-                        >
-                          <IconPlayerRecord className="h-4 w-4" />
-                        </NavLink>
-                      </TooltipTrigger>
-                      <TooltipContent side="right">
-                        {t("navigation.newRecording")}
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-
-                  <nav className="mt-3 flex flex-col items-center gap-1 px-2">
-                    {navItems.map(({ to, label, icon: Icon, match }) => {
-                      const active = match(location.pathname);
-                      return (
-                        <Tooltip key={to}>
-                          <TooltipTrigger asChild>
-                            <NavLink
-                              to={to}
-                              aria-label={label}
-                              className={cn(
-                                "flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/60 hover:text-foreground",
-                                active &&
-                                  "bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary",
-                              )}
-                            >
-                              <Icon className="h-4 w-4" />
-                            </NavLink>
-                          </TooltipTrigger>
-                          <TooltipContent side="right">{label}</TooltipContent>
-                        </Tooltip>
-                      );
-                    })}
-                  </nav>
-                </>
-              ) : (
-                <>
-                  <div className="px-3 py-3">
-                    <Button
-                      className="w-full gap-1.5 bg-primary text-primary-foreground shadow-sm hover:bg-primary/90"
-                      size="sm"
-                      asChild
-                    >
-                      <NavLink to="/record">
-                        <IconPlayerRecord className="h-4 w-4" />
-                        {t("navigation.newRecording")}
-                      </NavLink>
-                    </Button>
-                  </div>
-
-                  <nav className="mt-3 space-y-0.5 px-2">
-                    {navItems.map(({ to, label, icon: Icon, match, count }) => {
-                      const active = match(location.pathname);
-                      return (
-                        <NavLink
-                          key={to}
-                          to={to}
-                          className={cn(
-                            "flex items-center gap-2 rounded px-2 py-1.5 text-xs",
-                            active
-                              ? "bg-primary/10 font-medium text-primary"
-                              : "text-foreground hover:bg-accent/60",
-                          )}
-                        >
-                          <Icon className="h-4 w-4" />
-                          <span className="flex-1 truncate">{label}</span>
-                          {count !== undefined && count > 0 && (
-                            <span
-                              className={cn(
-                                "shrink-0 tabular-nums text-[11px]",
-                                active
-                                  ? "text-primary/80"
-                                  : "text-muted-foreground",
-                              )}
-                            >
-                              {count}
-                            </span>
-                          )}
-                        </NavLink>
-                      );
-                    })}
-                  </nav>
-
-                  <div className="mt-4 space-y-4 px-2 pb-3">
-                    <div>
-                      <div className="flex items-center justify-between px-2 pb-1">
-                        <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                          {t("navigation.folders")}
-                        </span>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label={t("navigation.newFolder")}
-                              className="rounded p-1 text-muted-foreground hover:bg-accent"
-                              onClick={() => setNewFolderOpen(true)}
-                            >
-                              <IconFolderPlus className="h-3.5 w-3.5" />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            {t("navigation.newFolder")}
-                          </TooltipContent>
-                        </Tooltip>
-                      </div>
-                      <FolderTree
-                        folders={libFolderList}
-                        organizationId={currentOrganizationId}
-                        spaceId={null}
-                        buildPath={(id) => `/library/folder/${id}`}
-                        activeFolderId={folderId ?? null}
-                      />
-                    </div>
-
-                    <div>
-                      <div className="flex items-center justify-between px-2 pb-1">
-                        <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                          {t("navigation.spaces")}
-                        </span>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label={t("navigation.spaces")}
-                              className="rounded p-1 text-muted-foreground hover:bg-accent"
-                              onClick={() => setNewSpaceOpen(true)}
-                            >
-                              <IconPlus className="h-3.5 w-3.5" />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            {t("navigation.spaces")}
-                          </TooltipContent>
-                        </Tooltip>
-                      </div>
-                      <ul className="space-y-0.5">
-                        {(spaces?.spaces ?? []).map((s: any) => {
-                          const active = spaceId === s.id;
-                          return (
-                            <li key={s.id}>
-                              <NavLink
-                                to={`/spaces/${s.id}`}
-                                className={cn(
-                                  "flex items-center gap-2 rounded px-2 py-1 text-xs",
-                                  active
-                                    ? "bg-primary/10 text-primary"
-                                    : "text-foreground hover:bg-accent/60",
-                                )}
-                              >
-                                <div
-                                  className="flex h-4 w-4 items-center justify-center rounded text-[10px]"
-                                  style={{
-                                    background:
-                                      s.color ?? "hsl(var(--primary))",
-                                    color: "white",
-                                  }}
-                                >
-                                  {s.iconEmoji ??
-                                    s.name.slice(0, 1).toUpperCase()}
-                                </div>
-                                <span className="truncate">{s.name}</span>
-                              </NavLink>
-                            </li>
-                          );
-                        })}
-                        {(spaces?.spaces ?? []).length === 0 && (
-                          <li className="px-2 py-1 text-[11px] text-muted-foreground/70">
-                            {t("navigation.noSpaces")}
-                          </li>
-                        )}
-                      </ul>
-                    </div>
-                  </div>
-                </>
-              )}
-            </div>
-
-            {!showCollapsedSidebar && (
-              <>
-                <div className="shrink-0 space-y-1.5 border-t border-border px-2 py-1.5">
-                  {shouldShowSidebarLink && (
-                    <CaptureInstallInlineLink className="flex items-center gap-2 rounded px-2 py-1.5 text-xs text-foreground hover:bg-accent/60">
-                      <IconAppWindow className="h-4 w-4" />
-                      {t("navigation.desktopCta")}
-                    </CaptureInstallInlineLink>
-                  )}
-                  <SearchBar />
-                </div>
-
-                <div className="shrink-0 border-t border-border px-1 py-1">
-                  <ExtensionsSidebarSection />
-                </div>
-
-                <div className="shrink-0 space-y-2 border-t border-border px-3 py-2">
-                  <OrgSwitcher settingsPath="/settings/organization" />
-                  <DevDatabaseLink />
-                  <FeedbackButton />
-                </div>
-              </>
-            )}
-          </aside>
-
-          {/* Main content area */}
-          <div className="agent-layout-main-surface flex min-w-0 flex-1 flex-col">
-            {!pageOwnsToolbar && (
-              <header className="flex shrink-0 items-center gap-3 border-b border-border px-5 py-3">
-                <button
-                  onClick={() => setSidebarOpen(true)}
-                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground md:hidden"
-                >
-                  <IconMenu2 className="h-4 w-4" />
-                </button>
-                <div
-                  ref={setHeaderSlot}
-                  className="flex min-w-0 flex-1 items-center gap-3 overflow-hidden"
-                />
-                <div className="ms-auto flex items-center gap-2">
-                  <ClipsAgentToggleButton />
-                </div>
-              </header>
-            )}
-            <InvitationBanner />
-            {shouldShowPromo && (
-              <div className="flex items-center gap-3 border-b border-border bg-primary/5 px-5 py-2.5 text-sm">
-                <IconAppWindow className="h-4 w-4 shrink-0 text-primary" />
-                <div className="min-w-0 flex-1">
-                  <span className="font-medium">
-                    {t("navigation.desktopTitle")}
-                  </span>{" "}
-                  <span className="text-muted-foreground">
-                    {t("navigation.desktopBody")}
-                  </span>
-                </div>
-                <CaptureInstallButton size="sm" className="shrink-0">
-                  Download
-                </CaptureInstallButton>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
-                      onClick={dismiss}
-                    >
-                      <IconX className="h-4 w-4" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {t("clipsFinalRaw.alreadyHaveIt")}
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-            )}
-            <main className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-              <PageHeaderSlotProvider slot={headerSlot}>
-                {children}
-              </PageHeaderSlotProvider>
-            </main>
-          </div>
+          )}
+          <main className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+            <PageHeaderSlotProvider slot={headerSlot}>
+              {children}
+            </PageHeaderSlotProvider>
+          </main>
         </div>
       </AgentSidebar>
 

--- a/templates/clips/app/components/player/delete-recording-menu.tsx
+++ b/templates/clips/app/components/player/delete-recording-menu.tsx
@@ -96,8 +96,8 @@ export function RecordingOptionsMenu({
             >
               <IconDownload className="me-2 h-4 w-4" />
               {downloadPending
-                ? (downloadingLabel ?? t("recordingPage.downloading"))
-                : (downloadLabel ?? t("recordingPage.downloadMp4"))}
+                ? (downloadingLabel ?? t("sharePage.downloading"))
+                : (downloadLabel ?? t("sharePage.downloadMp4"))}
             </DropdownMenuItem>
           ) : null}
           {showDownload && showDelete ? <DropdownMenuSeparator /> : null}

--- a/templates/clips/app/components/player/delete-recording-menu.tsx
+++ b/templates/clips/app/components/player/delete-recording-menu.tsx
@@ -1,5 +1,5 @@
 import { useActionMutation, useT } from "@agent-native/core/client";
-import { IconDots, IconTrash } from "@tabler/icons-react";
+import { IconDots, IconDownload, IconTrash } from "@tabler/icons-react";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 
@@ -18,6 +18,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
@@ -26,12 +27,29 @@ interface DeleteRecordingMenuProps {
   onDeleted?: () => void;
 }
 
-export function DeleteRecordingMenu({
+interface RecordingOptionsMenuProps extends DeleteRecordingMenuProps {
+  canDelete?: boolean;
+  canDownload?: boolean;
+  downloadPending?: boolean;
+  downloadLabel?: string;
+  downloadingLabel?: string;
+  onDownload?: () => void;
+}
+
+export function RecordingOptionsMenu({
   recordingId,
   onDeleted,
-}: DeleteRecordingMenuProps) {
+  canDelete = true,
+  canDownload = false,
+  downloadPending = false,
+  downloadLabel,
+  downloadingLabel,
+  onDownload,
+}: RecordingOptionsMenuProps) {
   const t = useT();
   const [open, setOpen] = useState(false);
+  const showDownload = canDownload && Boolean(onDownload);
+  const showDelete = canDelete;
   const trashRecording = useActionMutation<any, { id: string }>(
     "trash-recording",
     {
@@ -49,6 +67,8 @@ export function DeleteRecordingMenu({
     if (trashRecording.isPending) return;
     trashRecording.mutate({ id: recordingId });
   }, [recordingId, trashRecording]);
+
+  if (!showDownload && !showDelete) return null;
 
   return (
     <AlertDialog
@@ -69,45 +89,65 @@ export function DeleteRecordingMenu({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">
-          <DropdownMenuItem
-            onSelect={(event) => {
-              event.preventDefault();
-              setOpen(true);
-            }}
-            className="text-destructive focus:text-destructive"
-          >
-            <IconTrash className="mr-2 h-4 w-4" />
-            {t("deleteRecordingMenu.delete")}
-          </DropdownMenuItem>
+          {showDownload ? (
+            <DropdownMenuItem
+              onSelect={() => onDownload?.()}
+              disabled={downloadPending}
+            >
+              <IconDownload className="me-2 h-4 w-4" />
+              {downloadPending
+                ? (downloadingLabel ?? t("recordingPage.downloading"))
+                : (downloadLabel ?? t("recordingPage.downloadMp4"))}
+            </DropdownMenuItem>
+          ) : null}
+          {showDownload && showDelete ? <DropdownMenuSeparator /> : null}
+          {showDelete ? (
+            <DropdownMenuItem
+              onSelect={(event) => {
+                event.preventDefault();
+                setOpen(true);
+              }}
+              className="text-destructive focus:text-destructive"
+            >
+              <IconTrash className="me-2 h-4 w-4" />
+              {t("deleteRecordingMenu.delete")}
+            </DropdownMenuItem>
+          ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>
-            {t("deleteRecordingMenu.moveTitle")}
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            {t("deleteRecordingMenu.moveDescription")}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={trashRecording.isPending}>
-            {t("common.cancel")}
-          </AlertDialogCancel>
-          <AlertDialogAction
-            disabled={trashRecording.isPending}
-            onClick={(event) => {
-              event.preventDefault();
-              handleTrashRecording();
-            }}
-            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-          >
-            {trashRecording.isPending
-              ? t("deleteRecordingMenu.deleting")
-              : t("deleteRecordingMenu.moveToTrash")}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
+      {showDelete ? (
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("deleteRecordingMenu.moveTitle")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("deleteRecordingMenu.moveDescription")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={trashRecording.isPending}>
+              {t("common.cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={trashRecording.isPending}
+              onClick={(event) => {
+                event.preventDefault();
+                handleTrashRecording();
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {trashRecording.isPending
+                ? t("deleteRecordingMenu.deleting")
+                : t("deleteRecordingMenu.moveToTrash")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      ) : null}
     </AlertDialog>
   );
+}
+
+export function DeleteRecordingMenu(props: DeleteRecordingMenuProps) {
+  return <RecordingOptionsMenu {...props} canDelete />;
 }

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -34,7 +34,7 @@ import { toast } from "sonner";
 import { EditableRecordingTitle } from "@/components/editable-recording-title";
 import { EditorLayout } from "@/components/editor/editor-layout";
 import { CommentsPanel } from "@/components/player/comments-panel";
-import { DeleteRecordingMenu } from "@/components/player/delete-recording-menu";
+import { RecordingOptionsMenu } from "@/components/player/delete-recording-menu";
 import { InsightsPanel } from "@/components/player/insights-panel";
 import { ReactionsTray } from "@/components/player/reactions-tray";
 import { SettingsPanel } from "@/components/player/settings-panel";
@@ -212,6 +212,7 @@ export default function RecordingPage() {
   // can retry or report the issue instead of staring at a spinner.
   const [processingTimeout, setProcessingTimeout] = useState(false);
   const [retryingFinalize, setRetryingFinalize] = useState(false);
+  const [downloading, setDownloading] = useState(false);
 
   useEffect(() => {
     if (
@@ -306,6 +307,30 @@ export default function RecordingPage() {
   const isLoomRecording = isLoomRecordingSource(recording);
   const canUseNativeEditor = canEdit && !isLoomEmbedBacked;
   const canDelete = role === "owner";
+  const canDownloadRecording = Boolean(
+    recording?.enableDownloads && recording.videoUrl && !isLoomEmbedBacked,
+  );
+  const downloadRecording = useCallback(async () => {
+    if (!recording?.videoUrl) return;
+    setDownloading(true);
+    try {
+      const res = await fetch(recording.videoUrl);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${sanitizeFilename(recording.title || "clip")}.mp4`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      window.open(recording.videoUrl, "_blank", "noopener,noreferrer");
+    } finally {
+      setDownloading(false);
+    }
+  }, [recording?.title, recording?.videoUrl]);
   const retryFinalizeAfterStorage = useCallback(async () => {
     if (!recordingId) return;
     setRetryingFinalize(true);
@@ -1011,9 +1036,15 @@ export default function RecordingPage() {
             </Button>
           </ShareRecordingPopover>
 
-          {canDelete ? (
-            <DeleteRecordingMenu
+          {canDelete || canDownloadRecording ? (
+            <RecordingOptionsMenu
               recordingId={recording.id}
+              canDelete={canDelete}
+              canDownload={canDownloadRecording}
+              downloadPending={downloading}
+              onDownload={() => {
+                void downloadRecording();
+              }}
               onDeleted={() => navigate("/library", { replace: true })}
             />
           ) : null}
@@ -1282,6 +1313,16 @@ function capitalize(s: string) {
 
 function displayRecordingTitle(title: string | null | undefined): string {
   return isDefaultTitle(title) ? "Untitled Clip" : (title ?? "").trim();
+}
+
+function sanitizeFilename(name: string): string {
+  return (
+    name
+      .trim()
+      .replace(/[^\w.-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 80) || "clip"
+  );
 }
 
 function shouldShowGeneratedTitleSkeleton(

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -38,7 +38,7 @@ import { useLoaderData, useNavigate, useParams } from "react-router";
 import { CaptureInstallButton } from "@/components/capture-install-options";
 import { AccessPasswordPrompt } from "@/components/player/access-password-prompt";
 import { CommentsPanel } from "@/components/player/comments-panel";
-import { DeleteRecordingMenu } from "@/components/player/delete-recording-menu";
+import { RecordingOptionsMenu } from "@/components/player/delete-recording-menu";
 import { ReactionsTray } from "@/components/player/reactions-tray";
 import { ShareRecordingPopover } from "@/components/player/share-dialog";
 import { SignInPromptDialog } from "@/components/player/sign-in-prompt-dialog";
@@ -797,8 +797,16 @@ export default function ShareRoute() {
               </DropdownMenu>
             ) : null}
             {viewerIsOwner ? (
-              <DeleteRecordingMenu
+              <RecordingOptionsMenu
                 recordingId={recording.id}
+                canDelete
+                canDownload={canDownloadRecording}
+                downloadPending={downloading}
+                downloadLabel={t("sharePage.downloadMp4")}
+                downloadingLabel={t("sharePage.downloading")}
+                onDownload={() => {
+                  void downloadRecording();
+                }}
                 onDeleted={() => navigate("/library", { replace: true })}
               />
             ) : null}

--- a/templates/clips/changelog/2026-06-26-recording-details-button-stays-at-the-far-right-on-small-screen.md
+++ b/templates/clips/changelog/2026-06-26-recording-details-button-stays-at-the-far-right-on-small-screen.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-06-26
 ---
+
 The recording details button stays at the far right on small screens.

--- a/templates/clips/changelog/2026-06-26-recording-details-button-stays-at-the-far-right-on-small-screen.md
+++ b/templates/clips/changelog/2026-06-26-recording-details-button-stays-at-the-far-right-on-small-screen.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-06-26
+---
+The recording details button stays at the far right on small screens.

--- a/templates/clips/changelog/2026-06-26-the-agent-sidebar-now-slides-in-smoothly-without-duplicate-e.md
+++ b/templates/clips/changelog/2026-06-26-the-agent-sidebar-now-slides-in-smoothly-without-duplicate-e.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-26
+---
+
+The agent sidebar now slides in smoothly without duplicate edge borders.

--- a/templates/plan/app/components/plan/CanvasArea.tsx
+++ b/templates/plan/app/components/plan/CanvasArea.tsx
@@ -43,6 +43,8 @@ const WHEEL_ZOOM_STEP = 0.16;
 const PINCH_ZOOM_SENSITIVITY = 0.01;
 /** Base CSS grid cell, scaled by zoom. */
 const GRID_CELL = 28;
+/** Extra world-space grid on each side so the grid still fills overscrolled pans. */
+const GRID_PADDING = 5000;
 
 type CanvasView = typeof DEFAULT_VIEW;
 export type CanvasViewport = CanvasView;
@@ -385,6 +387,7 @@ export function CanvasArea({
   }, [frameLayoutKey, frames, hasSavedViewport, updateView]);
 
   const { zoom, pan } = view;
+  const worldTransform = `translate3d(${pan.x}px, ${pan.y}px, 0) scale(${zoom})`;
   useEffect(() => {
     queueViewportChange(view);
   }, [queueViewportChange, view]);
@@ -656,8 +659,6 @@ export function CanvasArea({
         tabIndex={0}
         style={
           {
-            backgroundPosition: `${pan.x}px ${pan.y}px`,
-            backgroundSize: `${GRID_CELL * zoom}px ${GRID_CELL * zoom}px`,
             overscrollBehavior: "contain",
             touchAction: "none",
           } as CSSProperties
@@ -724,11 +725,25 @@ export function CanvasArea({
           style={{
             width: board.width,
             height: board.height,
-            transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+            transform: worldTransform,
             transformOrigin: "0 0",
             willChange: "transform",
+            backfaceVisibility: "hidden",
           }}
         >
+          <div
+            aria-hidden="true"
+            className="plan-canvas-grid absolute"
+            data-plan-canvas-grid
+            style={{
+              left: -GRID_PADDING,
+              top: -GRID_PADDING,
+              width: board.width + GRID_PADDING * 2,
+              height: board.height + GRID_PADDING * 2,
+              backgroundSize: `${GRID_CELL}px ${GRID_CELL}px`,
+            }}
+          />
+
           {/* Section containers sit BEHIND the frames (lowest layer) so each
               group reads as one bounded region the artboards rest inside. */}
           {sectionRects.map(({ section, rect }) => (

--- a/templates/plan/app/components/plan/CanvasArea.tsx
+++ b/templates/plan/app/components/plan/CanvasArea.tsx
@@ -158,6 +158,9 @@ export function CanvasArea({
   );
   const latestViewportChangeRef = useRef<CanvasViewport>(initialView);
   const viewportChangeFrameRef = useRef<number | null>(null);
+  // Kept current each render so the central pan clamp (in updateView) can read
+  // the live board size without widening updateView's dependencies.
+  const boardRef = useRef({ width: 0, height: 0 });
   const queueViewportChange = useCallback(
     (nextView: CanvasViewport) => {
       latestViewportChangeRef.current = nextView;
@@ -173,7 +176,11 @@ export function CanvasArea({
   const updateView = useCallback(
     (resolve: (current: CanvasView) => CanvasView) => {
       setView((current) => {
-        const next = resolve(current);
+        const next = clampPanToGrid(
+          resolve(current),
+          boardRef.current,
+          viewportRef.current?.getBoundingClientRect() ?? null,
+        );
         if (sameCanvasView(current, next)) return current;
         queueViewportChange(next);
         return next;
@@ -334,6 +341,7 @@ export function CanvasArea({
     );
     return { width: maxX + 360, height: maxY + 280 };
   }, [frames, annotations, legacyNotes]);
+  boardRef.current = board;
 
   const lastAutoFitKeyRef = useRef<string | null>(null);
   useEffect(() => {
@@ -2307,4 +2315,33 @@ function resolveMarkupComposerPosition(input: {
 
 function clamp(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * Keep the visible viewport inside the rendered grid. The grid is a fixed-size
+ * child of the transformed world (board + GRID_PADDING on every side), so it is
+ * large but finite; without this clamp a far-enough pan scrolls past the grid
+ * edge into a blank void. Screen = pan + world * zoom, and the grid spans world
+ * [-GRID_PADDING, board + GRID_PADDING], so bounding pan to the range below
+ * guarantees the grid always fills the viewport while still allowing the full
+ * GRID_PADDING of overscroll. A no-op until the viewport has been measured.
+ */
+function clampPanToGrid(
+  view: CanvasView,
+  board: { width: number; height: number },
+  rect: DOMRect | null,
+): CanvasView {
+  if (!rect) return view;
+  const { zoom } = view;
+  const minPanX = rect.width - (board.width + GRID_PADDING) * zoom;
+  const maxPanX = GRID_PADDING * zoom;
+  const minPanY = rect.height - (board.height + GRID_PADDING) * zoom;
+  const maxPanY = GRID_PADDING * zoom;
+  return {
+    zoom,
+    pan: {
+      x: minPanX <= maxPanX ? clamp(view.pan.x, minPanX, maxPanX) : view.pan.x,
+      y: minPanY <= maxPanY ? clamp(view.pan.y, minPanY, maxPanY) : view.pan.y,
+    },
+  };
 }

--- a/templates/plan/app/global.css
+++ b/templates/plan/app/global.css
@@ -255,13 +255,18 @@
   touch-action: none;
 }
 
-/* Infinite low-contrast grid (slightly darker than the document bg) that
- * moves on pan via background-position and scales with zoom — both driven
- * inline by CanvasArea. */
+/* Infinite low-contrast grid. The live grid is rendered inside the transformed
+ * canvas world so Chrome can composite grid + artboards together while panning. */
 .plan-canvas-viewport {
+  isolation: isolate;
+}
+
+.plan-canvas-grid {
+  pointer-events: none;
   background-image:
     linear-gradient(var(--plan-grid-line) 1px, transparent 1px),
     linear-gradient(90deg, var(--plan-grid-line) 1px, transparent 1px);
+  backface-visibility: hidden;
 }
 
 /* Fixed-size static artboard frame. No border / shadow / box around the

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -7113,7 +7113,7 @@ function PlanCanvasSkeleton() {
       aria-hidden="true"
     >
       <div
-        className="plan-canvas-viewport absolute inset-0"
+        className="plan-canvas-grid absolute inset-0"
         style={{
           backgroundPosition: "96px 64px",
           backgroundSize: "20px 20px",

--- a/templates/plan/changelog/2026-06-26-canvas-grid-panning-now-stays-smooth-and-fills-the-workspace.md
+++ b/templates/plan/changelog/2026-06-26-canvas-grid-panning-now-stays-smooth-and-fills-the-workspace.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-26
+---
+
+Canvas grid panning now stays smooth and fills the workspace while navigating large plans.


### PR DESCRIPTION
## Summary
- Make docs dark-mode background tokens resolve to black
- Fix Analytics Ask/sidebar dark backgrounds and align language picker styling
- Restore Clips agent sidebar animation and remove duplicate border nesting
- Include branch-local Plan canvas grid and Clips recording options polish with changelogs

## Validation
- ./node_modules/.bin/oxfmt --write packages/core/src/client/i18n.tsx packages/core/src/client/LanguagePicker.spec.tsx packages/docs/app/global.css templates/analytics/app/components/layout/Sidebar.tsx templates/analytics/app/global.css templates/analytics/app/pages/Ask.tsx templates/clips/app/components/library/library-layout.tsx templates/plan/app/components/plan/CanvasArea.tsx templates/plan/app/global.css templates/plan/app/pages/PlansPage.tsx
- git diff --check
- ../../node_modules/.bin/tsgo --noEmit (packages/core)
- ./node_modules/.bin/vitest --run src/client/LanguagePicker.spec.tsx (packages/core)
- ./node_modules/.bin/tsc --noEmit (templates/analytics)
- ./node_modules/.bin/tsc --noEmit (templates/clips)
- ./node_modules/.bin/tsc --noEmit (templates/plan)
- ./node_modules/.bin/tsc --noEmit (packages/docs)
- Docs dev smoke: dark theme computed --background 0 0% 0%, --bg #000, body rgb(0, 0, 0)