### PR TITLE
Improve mobile navigation chrome and sidebar drawer motion

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1235,29 +1235,15 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.3))(vite@8.1.0(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
 
-  templates/.retired/calls: {}
-
-  templates/.retired/code: {}
-
-  templates/.retired/contracts: {}
-
-  templates/.retired/images: {}
-
   templates/.retired/issues: {}
 
   templates/.retired/meeting-notes: {}
-
-  templates/.retired/migration: {}
 
   templates/.retired/recruiting: {}
 
   templates/.retired/scheduling: {}
 
-  templates/.retired/visual-plans: {}
-
   templates/.retired/voice: {}
-
-  templates/.retired/workbench: {}
 
   templates/analytics:
     dependencies:

--- a/templates/analytics/app/components/layout/MobileNav.tsx
+++ b/templates/analytics/app/components/layout/MobileNav.tsx
@@ -1,5 +1,5 @@
 import { useT } from "@agent-native/core/client";
-import { IconMenu, IconChartBar } from "@tabler/icons-react";
+import { IconMenu } from "@tabler/icons-react";
 import { useState, useEffect } from "react";
 import { useLocation } from "react-router";
 
@@ -18,7 +18,7 @@ export function MobileNav() {
   }, [location.pathname]);
 
   return (
-    <div className="flex h-12 shrink-0 items-center border-b border-border bg-sidebar px-4 md:hidden">
+    <div className="flex h-12 shrink-0 items-center border-b border-border bg-background px-4 md:hidden">
       <button
         onClick={() => setOpen(true)}
         className="me-3 p-2.5 -ms-1 rounded-md hover:bg-sidebar-accent/50"
@@ -26,14 +26,9 @@ export function MobileNav() {
       >
         <IconMenu className="h-5 w-5 text-foreground" />
       </button>
-      <div className="flex items-center gap-2">
-        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-          <IconChartBar className="h-4 w-4" />
-        </div>
-        <span className="text-base font-bold tracking-tight">
-          {t("navigation.brand")}
-        </span>
-      </div>
+      <span className="text-base font-bold tracking-tight">
+        {t("navigation.brand")}
+      </span>
 
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetContent side="left" className="p-0 w-[280px]">

--- a/templates/analytics/changelog/2026-06-27-mobile-navigation-chrome-and-motion.md
+++ b/templates/analytics/changelog/2026-06-27-mobile-navigation-chrome-and-motion.md
@@ -1,0 +1,5 @@
+---
+type: improved
+date: 2026-06-27
+---
+Improved mobile navigation chrome and sidebar drawer motion.

--- a/templates/assets/app/components/layout/Layout.tsx
+++ b/templates/assets/app/components/layout/Layout.tsx
@@ -87,7 +87,7 @@ export function Layout({ children }: LayoutProps) {
       )}
       <div
         className={cn(
-          "agent-layout-left-drawer fixed inset-y-0 start-0 z-50 md:static md:z-auto",
+          "agent-layout-left-drawer fixed inset-y-0 start-0 z-50 transition-transform duration-200 ease-out md:static md:z-auto md:transition-none",
           mobileSidebarOpen
             ? "translate-x-0"
             : "-translate-x-full md:translate-x-0",

--- a/templates/assets/changelog/2026-06-27-mobile-navigation-chrome-and-motion.md
+++ b/templates/assets/changelog/2026-06-27-mobile-navigation-chrome-and-motion.md
@@ -1,0 +1,5 @@
+---
+type: improved
+date: 2026-06-27
+---
+Improved mobile navigation chrome and sidebar drawer motion.

--- a/templates/design/app/components/layout/Layout.tsx
+++ b/templates/design/app/components/layout/Layout.tsx
@@ -120,7 +120,7 @@ export function Layout({ children }: LayoutProps) {
             )}
             <div
               className={cn(
-                "agent-layout-left-drawer fixed inset-y-0 start-0 z-50 md:static md:z-auto",
+                "agent-layout-left-drawer fixed inset-y-0 start-0 z-50 transition-transform duration-200 ease-out md:static md:z-auto md:transition-none",
                 mobileSidebarOpen
                   ? "translate-x-0"
                   : "-translate-x-full rtl:translate-x-full md:translate-x-0 md:rtl:translate-x-0",

--- a/templates/design/changelog/2026-06-27-mobile-navigation-chrome-and-motion.md
+++ b/templates/design/changelog/2026-06-27-mobile-navigation-chrome-and-motion.md
@@ -1,0 +1,5 @@
+---
+type: improved
+date: 2026-06-27
+---
+Improved mobile navigation chrome and sidebar drawer motion.

--- a/templates/slides/app/components/layout/Layout.tsx
+++ b/templates/slides/app/components/layout/Layout.tsx
@@ -87,7 +87,7 @@ export function Layout({ children }: LayoutProps) {
           )}
           <div
             className={cn(
-              "agent-layout-left-drawer fixed inset-y-0 start-0 z-50 md:static md:z-auto",
+              "agent-layout-left-drawer fixed inset-y-0 start-0 z-50 transition-transform duration-200 ease-out md:static md:z-auto md:transition-none",
               sidebarOpen
                 ? "translate-x-0"
                 : "-translate-x-full rtl:translate-x-full md:translate-x-0 md:rtl:translate-x-0",

--- a/templates/slides/changelog/2026-06-27-mobile-navigation-chrome-and-motion.md
+++ b/templates/slides/changelog/2026-06-27-mobile-navigation-chrome-and-motion.md
@@ -1,0 +1,5 @@
+---
+type: improved
+date: 2026-06-27
+---
+Improved mobile navigation chrome and sidebar drawer motion.


### PR DESCRIPTION
### Motivation

- The Analytics mobile top bar used a contrasting sidebar color and included an app icon that made the header feel visually heavy on mobile, so it should match the main page background and remove the decorative icon for a cleaner chrome. 
- Several template apps (Assets, Design, Slides) used a mobile hamburger drawer that snapped open without motion, creating inconsistent UX compared to Analytics, so they should animate in with a slide transition for parity. 

### Description

- Updated `templates/analytics/app/components/layout/MobileNav.tsx` to remove the app icon and change the top bar background from `bg-sidebar` to `bg-background`. 
- Added CSS transition classes (`transition-transform duration-200 ease-out` and `md:transition-none`) to the mobile drawer container in `templates/assets/app/components/layout/Layout.tsx`, `templates/design/app/components/layout/Layout.tsx`, and `templates/slides/app/components/layout/Layout.tsx` so the drawer slides in/out on mobile. 
- Added pending changelog entries under `templates/{analytics,assets,design,slides}/changelog/2026-06-27-mobile-navigation-chrome-and-motion.md` describing the visible mobile navigation polish. 
- Formatted edited files with `oxfmt` and committed the changes to the current branch with commit message "Improve mobile navigation chrome".

### Testing

- Ran `pnpm oxfmt` on the modified files and it completed successfully. 
- Attempted `pnpm --filter ./templates/analytics typecheck` but the check failed to run in this environment because the local Node version is `v20.20.2` while `agent-native` requires Node `22+`, so typechecking did not complete.

---

⠀

🟡 Changes are committed on the current branch; pushing and full typecheck are blocked by the local environment (no `origin` remote configured and Node 22+ required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fe911cc4c832e9c806dc047bffacc)