### PR TITLE
Hide Clips desktop prompts on mobile

### DIFF
--- a/templates/clips/app/hooks/use-desktop-promo.ts
+++ b/templates/clips/app/hooks/use-desktop-promo.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
+import { useIsMobile } from "@/hooks/use-mobile";
+
 const DISMISSED_KEY = "clips.desktop-promo.dismissed";
 
 function detectDesktopApp(): boolean {
@@ -17,6 +19,7 @@ function detectDesktopApp(): boolean {
 }
 
 export function useDesktopPromo() {
+  const isMobile = useIsMobile();
   const [isDesktopApp, setIsDesktopApp] = useState(false);
   const [dismissed, setDismissed] = useState(false);
 
@@ -40,8 +43,9 @@ export function useDesktopPromo() {
 
   return {
     isDesktopApp,
-    shouldShowPromo: !isDesktopApp && !dismissed,
-    shouldShowSidebarLink: !isDesktopApp,
+    isMobile,
+    shouldShowPromo: !isMobile && !isDesktopApp && !dismissed,
+    shouldShowSidebarLink: !isMobile && !isDesktopApp,
     dismiss,
   };
 }

--- a/templates/clips/changelog/2026-06-27-clips-no-longer-shows-desktop-app-prompts-on-mobile-screens.md
+++ b/templates/clips/changelog/2026-06-27-clips-no-longer-shows-desktop-app-prompts-on-mobile-screens.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-06-27
+---
+Clips no longer shows desktop app prompts on mobile screens.


### PR DESCRIPTION
### Motivation
- Mobile users should not see desktop download banners or install buttons because those CTAs are irrelevant and take up scarce vertical space on small screens.

### Description
- Import `useIsMobile` into `templates/clips/app/hooks/use-desktop-promo.ts` and use it to gate promo visibility. 
- Change `shouldShowPromo` and `shouldShowSidebarLink` to return `false` when `isMobile` is true, and expose `isMobile` from the hook. 
- Add a pending Clips changelog entry at `templates/clips/changelog/2026-06-27-clips-no-longer-shows-desktop-app-prompts-on-mobile-screens.md` describing the fix.

### Testing
- Ran formatter: `pnpm exec oxfmt templates/clips/app/hooks/use-desktop-promo.ts`, which completed successfully. 
- Built the framework package and ran type checking: `pnpm --filter @agent-native/core build` followed by `pnpm --dir templates/clips typecheck`, which passed after switching to Node.js v22.22.0 with `nvm`. 
- Verified the hook change by inspecting `templates/clips/app/hooks/use-desktop-promo.ts` and confirming the updated return values for `shouldShowPromo` and `shouldShowSidebarLink`.

---

⠀
🟢 Clips desktop banner and install button are now suppressed on mobile screens and the change is ready on the current branch

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fff74c5a0832e912508447860eb89)