### PR TITLE
Clips: Dim active recorder mode and hide screen-capture options on mobile

### DIFF
--- a/templates/clips/app/components/recorder/pre-record-panel.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.tsx
@@ -41,6 +41,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { useIsMobile } from "@/hooks/use-mobile";
 import {
   loadRecorderPreferences,
   saveRecorderPreferences,
@@ -192,6 +193,7 @@ export function PreRecordPanel({
     error: null,
     hasPreview: false,
   });
+  const isMobile = useIsMobile();
 
   const modeOptions = useMemo<ModeOption[]>(
     () => [
@@ -213,6 +215,14 @@ export function PreRecordPanel({
     ],
     [t],
   );
+  const visibleModeOptions = useMemo(
+    () =>
+      isMobile
+        ? modeOptions.filter((option) => option.value === "camera")
+        : modeOptions,
+    [isMobile, modeOptions],
+  );
+
   const surfaceOptions = useMemo<SurfaceOption[]>(
     () => [
       {
@@ -238,8 +248,14 @@ export function PreRecordPanel({
   );
 
   useEffect(() => {
+    if (isMobile) {
+      // Mobile browsers do not support the screen-capture choices this panel
+      // offers on desktop, so keep the setup focused on recording face video.
+      setMode("camera");
+      return;
+    }
     if (initialMode) setMode(initialMode);
-  }, [initialMode]);
+  }, [initialMode, isMobile]);
 
   useEffect(() => {
     if (initialDisplaySurface) setDisplaySurface(initialDisplaySurface);
@@ -586,7 +602,7 @@ export function PreRecordPanel({
     <div className="mx-auto w-full max-w-lg overflow-hidden rounded-2xl border border-border bg-card shadow-lg">
       <div className="p-6">
         <div className="grid gap-2 sm:grid-cols-3">
-          {modeOptions.map((opt) => {
+          {visibleModeOptions.map((opt) => {
             const Icon = opt.icon;
             const active = opt.value === mode;
             return (
@@ -600,7 +616,7 @@ export function PreRecordPanel({
                 className={cn(
                   "flex min-h-20 min-w-0 flex-col justify-between rounded-xl border p-3 text-start transition-colors",
                   active
-                    ? "border-primary bg-primary text-primary-foreground shadow-sm"
+                    ? "border-primary/55 bg-primary/[0.12] text-foreground shadow-sm ring-1 ring-primary/15"
                     : "border-border bg-background text-foreground hover:border-foreground/30 hover:bg-muted/45",
                 )}
                 aria-pressed={active}
@@ -609,7 +625,7 @@ export function PreRecordPanel({
                   className={cn(
                     "mb-3 flex h-9 w-9 items-center justify-center rounded-full",
                     active
-                      ? "bg-primary-foreground/15 text-primary-foreground"
+                      ? "bg-primary/[0.18] text-foreground"
                       : "bg-muted text-muted-foreground",
                   )}
                 >

--- a/templates/clips/changelog/2026-06-27-recorder-setup-mobile-capture-options.md
+++ b/templates/clips/changelog/2026-06-27-recorder-setup-mobile-capture-options.md
@@ -1,0 +1,5 @@
+---
+type: improved
+date: 2026-06-27
+---
+Recorder setup keeps screen-capture choices desktop-only on mobile and tones down the selected mode highlight.


### PR DESCRIPTION
### Motivation
- The active "Screen + cam" mode styling was too visually prominent and competed with the primary "Start recording" CTA, so the selected mode should be visually de-emphasized.
- Mobile browsers often do not support desktop screen-capture flows, so offering screen-capture choices on mobile is confusing and should be removed in favor of a simple face-only recording option.

### Description
- Toned down the active recorder mode styling by replacing the full primary background with a subtle tinted background, muted border, and light ring so the CTA remains the brightest element (`templates/clips/app/components/recorder/pre-record-panel.tsx`).
- Added mobile detection using `useIsMobile()` and restricted the visible recording modes on mobile to camera-only, and force-initialized the panel to `camera` mode on mobile so unsupported screen-capture options are not offered (`templates/clips/app/components/recorder/pre-record-panel.tsx`).
- Replaced the mode list rendering to use `visibleModeOptions` so mobile only shows the camera option (`templates/clips/app/components/recorder/pre-record-panel.tsx`).
- Added a pending Clips changelog entry describing the visible improvement (`templates/clips/changelog/2026-06-27-recorder-setup-mobile-capture-options.md`).

### Testing
- Ran formatting check with `pnpm exec oxfmt --check templates/clips/app/components/recorder/pre-record-panel.tsx` and it passed.
- Ran TypeScript checks; initial `pnpm --filter clips typecheck` failed due to the local Node runtime being v20, so Node 22 was activated and then `pnpm --filter @agent-native/core build && pnpm --filter clips typecheck` was executed, after which the typecheck completed successfully.
- Verified the UI changes by running the local build/typecheck flow for the Clips template and ensuring no formatting or type errors remained.

---

⠀
🟢 Recorder setup highlight and mobile camera-only behavior are updated and ready for review

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fffe79a6c832e9e2a095cc82272a5)