### PR TITLE
Fix French docs MDX block mirrors

### DIFF
--- a/.changeset/french-docs-mdx-blocks.md
+++ b/.changeset/french-docs-mdx-blocks.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix French docs MDX block serialization so markdown mirrors do not expose raw component tags.

--- a/packages/core/docs/content/locales/fr-FR/automations.mdx
+++ b/packages/core/docs/content/locales/fr-FR/automations.mdx
@@ -51,7 +51,7 @@ Le troisième chemin (écriture manuelle du fichier `jobs/<name>.md` via `resour
     {
       lines: "2",
       label: "Pas de cron",
-      note: 'Les déclencheurs d'événement définissent `schedule` sur `""` ; le champ cron reste vide.',
+      note: 'Les déclencheurs d\'événement définissent `schedule` sur `""` ; le champ cron reste vide.',
     },
     {
       lines: "4-5",

--- a/packages/core/docs/content/locales/fr-FR/mcp-apps.mdx
+++ b/packages/core/docs/content/locales/fr-FR/mcp-apps.mdx
@@ -76,7 +76,7 @@ export default defineAction({
     {
       lines: "11",
       label: "Étiquette de secours universelle",
-      note: '`openLabel` est le texte visible `"Open in … →"` utilisé comme échappatoire de lien profond lorsqu'un hôte ne rend pas l'iframe intégré.',
+      note: "`openLabel` est le texte visible `\"Open in … →\"` utilisé comme échappatoire de lien profond lorsqu'un hôte ne rend pas l'iframe intégré.",
     },
   ]}
 />

--- a/packages/core/docs/content/locales/fr-FR/onboarding.mdx
+++ b/packages/core/docs/content/locales/fr-FR/onboarding.mdx
@@ -140,7 +140,7 @@ Drives the sidebar checklist — returns each step's id, title, methods, require
     {
       lines: "20-26",
       label: "Chemin du délégué",
-      note: '`kind: "agent-task"` confie la configuration au chat de l'agent avec une invite.',
+      note: '`kind: "agent-task"` confie la configuration au chat de l\'agent avec une invite.',
     },
     {
       lines: "28-31",

--- a/packages/docs/app/components/docBlocks.validate.test.tsx
+++ b/packages/docs/app/components/docBlocks.validate.test.tsx
@@ -165,7 +165,7 @@ describe("docs visual blocks", () => {
   it("does not leave registered MDX block tags behind as prose", () => {
     const failures: string[] = [];
     const rawBlockTagPattern =
-      /^\s*<(?:AnnotatedCode|Callout|Checklist|Columns|DataModel|Diff|Endpoint|FileTree|JsonExplorer|OpenApiSpec|Table|Tabs|Wireframe)(?:\s|>|\/)/;
+      /^\s*<(?:AnnotatedCode|Callout|Checklist|Columns|DataModel|Diff|Endpoint|FileTree|JsonExplorer|OpenApiSpec|Table|Tabs|Wireframe)(?:\s|>|\/|$)/;
     for (const doc of allDocs) {
       const leaked = doc.segments
         .filter((segment) => segment.kind === "markdown")


### PR DESCRIPTION
## Summary
- escape three French docs MDX annotation strings so the localized AnnotatedCode blocks parse
- tighten the docs block guard so bare multiline MDX block openers cannot fall through as prose
- add a patch changeset for @agent-native/core docs content

## Validation
- node --import tsx mirror/parser leak scan across 916 docs
- node_modules/.bin/vitest run app/components/docBlocks.validate.test.tsx lib/docs-markdown-export.test.ts app/components/docs-content.test.ts (packages/docs)
- node_modules/.bin/tsgo --noEmit -p packages/docs/tsconfig.json
- corepack pnpm fmt:check
- corepack pnpm --dir packages/docs build