### PR TITLE
fix(core): Windows desktop (Tauri) email/password sign-in

### DIFF
--- a/.changeset/windows-desktop-auth-login.md
+++ b/.changeset/windows-desktop-auth-login.md
@@ -1,0 +1,11 @@
+---
+"@agent-native/core": patch
+---
+
+Fix Windows desktop (Tauri) email/password sign-in. The login endpoint now
+returns the session token to the Windows WebView2 origin
+(`http://tauri.localhost` / `https://tauri.localhost`), which was missing from
+the desktop token allowlist, so sign-in no longer silently bounces back to the
+form. Also stop reporting wrong-password failures as "Enter a valid email
+address" — credential errors now surface as "Invalid email or password" while
+genuine malformed-email input still gets the friendly format message.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ dist
 docs/superpowers
 .DS_Store
 
+.idea/
+
 /*.png
 tmp/
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -842,6 +842,11 @@ function publicAuthError(
 }
 
 function isAuthEmailValidationMessage(message: string): boolean {
+  // Credential failures (e.g. Better Auth's "Invalid email or password") mention
+  // "email" + "invalid" but are NOT email-format errors — don't rewrite them to
+  // the "enter a valid email" message, or every wrong-password attempt looks like
+  // a malformed-email error.
+  if (/password|credential/i.test(message)) return false;
   return (
     /\bemail\b/i.test(message) &&
     /(invalid|input|required|format)/i.test(message)

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1129,6 +1129,8 @@ const _desktopExchanges = new Map<string, DesktopExchangeEntry>();
 const DESKTOP_EXCHANGE_ERROR_PREFIX = "__error__::";
 const DESKTOP_AUTH_TOKEN_BODY_ORIGINS = new Set([
   "tauri://localhost",
+  "http://tauri.localhost",
+  "https://tauri.localhost",
   "http://localhost:1420",
 ]);
 


### PR DESCRIPTION
## What & why

Email/password sign-in from the **Windows desktop (Tauri) app** was completely broken — clicking *Sign in* briefly disabled the button and silently returned to the form. Two bugs in `packages/core/src/server/auth.ts`:

### 1. Windows WebView2 origin not allowed to receive the session token
`/_agent-native/auth/login` only returns the session token in the response body when the request `Origin` is in `DESKTOP_AUTH_TOKEN_BODY_ORIGINS`. That set listed the macOS/Linux origin (`tauri://localhost`) and the vite dev origin (`http://localhost:1420`), but **not** the Windows WebView2 origin (`http(s)://tauri.localhost`). On Windows the server replied `{ ok: true }` with no token, the app saved no session, and `onSignedIn()` bounced straight back to the sign-in form (cross-origin cookies don't stick in the webview).

**Fix:** add `http://tauri.localhost` and `https://tauri.localhost` to the allowlist.

### 2. Wrong password reported as "Enter a valid email address"
`isAuthEmailValidationMessage` rewrote any auth error containing "email" + "invalid/input/required/format" into the friendly *"Enter a valid email address"* message. Better Auth's credential-failure message (`"Invalid email or password"`) matches that heuristic, so **every** failed login with a valid email was mislabeled as a malformed-email error.

**Fix:** skip the rewrite when the message mentions `password`/`credential`. Genuine format errors still get the friendly message; bad credentials now surface as *"Invalid email or password"*.

### 3. (chore) gitignore JetBrains `.idea/`

## How it was verified
Reproduced and confirmed against a local dev server by replaying the desktop login request with each webview origin:

| Origin | Before | After |
| --- | --- | --- |
| `tauri://localhost` (macOS/Linux) | token returned ✅ | token returned ✅ |
| `http://tauri.localhost` (**Windows**) | no token → bounce ❌ | token returned ✅ |
| valid email + wrong password | "Enter a valid email address" ❌ | "Invalid email or password" ✅ |
| genuinely malformed email | — | "Enter a valid email address" ✅ (unchanged) |

Existing `auth.spec.ts` invalid-email tests still pass (they exercise the pre-validation path, not this rewrite).

A changeset is included (`@agent-native/core`, patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)