### PR TITLE
Make Assets image generation async completely

### DIFF
--- a/templates/assets/.agents/skills/asset-generation/SKILL.md
+++ b/templates/assets/.agents/skills/asset-generation/SKILL.md
@@ -61,10 +61,13 @@ or generated image/video assets that another app can reference by ID and URL.
    library is editable and reusable like any other library.
 2. For one asset, call `generate-image`; for multiple independent slots, call
    `generate-image-batch` with stable `slotId` values.
-3. Image generation actions are synchronous. After `generate-image` or
-   `generate-image-batch` returns, use its returned `images` / asset fields
-   directly; do not call `get-generation-run`, `refresh-generation-run`, or
-   regenerate just to verify image runs.
+3. Image generation actions may return ready assets inline or
+   `status: "processing"` with a `runId`. Use returned asset fields directly
+   for ready results. In normal in-app chat, processing results are collected
+   by the live tray's automatic `refresh-generation-run` polling; tell the user
+   the candidates are finishing and stop. Do not regenerate the same request
+   just to verify or collect slow image runs. Only headless/no-tray callers
+   should call `refresh-generation-run` if they must wait.
 4. For preset-backed work, pass a mentioned or selected `presetId`; for handoff
    work, pass `sessionId`.
 5. Let the server choose a small deterministic reference set unless the user

--- a/templates/assets/.agents/skills/image-generation/SKILL.md
+++ b/templates/assets/.agents/skills/image-generation/SKILL.md
@@ -28,11 +28,14 @@ Use this skill before calling `generate-image`, `generate-image-batch`, or
 - Generate the selected candidate count for open-ended requests, usually 2-4.
   Use `generate-image-batch` with stable `slotId`s so the shared generation tray
   can show live slots.
-- `generate-image` and `generate-image-batch` are synchronous for images. One
-  batch call should produce the requested candidates and return their asset
-  IDs/URLs; do not follow it with `get-generation-run`,
-  `refresh-generation-run`, or more generation unless the user asks for another
-  direction or the returned slot has `ok: false`.
+- `generate-image` and `generate-image-batch` are async-friendly for images.
+  Fast slots still return ready asset IDs/URLs inline. Slow slots return
+  `status: "processing"` with a `runId` and finish through the live variant
+  tray, which polls `refresh-generation-run` automatically in the Assets UI.
+  Do not re-issue the same generation request after a processing result. In
+  normal in-app chat, do not manually poll; tell the user the tray will update
+  when ready. Only headless callers without a visible tray should call
+  `refresh-generation-run` if they must wait for completion.
 - For repeatable deliverables, honor a `preset` @mention as `presetId` or call
   `list-generation-presets` when choosing one. Pass the preset through
   `generate-image`, `generate-image-batch`, `refine-image`, or
@@ -73,8 +76,11 @@ Use this skill before calling `generate-image`, `generate-image-batch`, or
 
 ## Completion
 
-After generation, reply with asset IDs and previews. Ask whether to save,
-iterate, or produce another direction.
+After generation, reply with ready asset IDs and previews. If any slots are
+still processing, preserve their run IDs, say they are finishing in the
+background and will appear in the live tray, then stop. Do not call
+`refresh-generation-run` from normal in-app chat unless the user asks you to
+wait or there is no visible tray.
 
 When the user says a designer should pick up the work, create a generation
 session with `create-generation-session`, including the active `assetId`,

--- a/templates/assets/actions/generate-image-batch.spec.ts
+++ b/templates/assets/actions/generate-image-batch.spec.ts
@@ -202,6 +202,7 @@ describe("generate-image-batch", () => {
       {
         slotId: "slot-1",
         ok: false,
+        status: "dismissed",
         dismissed: true,
         runId: "run-1",
         error: "Candidate was dismissed before it completed.",
@@ -209,6 +210,45 @@ describe("generate-image-batch", () => {
       expect.objectContaining({
         slotId: "slot-2",
         ok: true,
+        id: "asset-2",
+        runId: "run-2",
+      }),
+    ]);
+  });
+
+  it("reports slow slots as processing instead of failed", async () => {
+    generateImageRunMock
+      .mockResolvedValueOnce({
+        runId: "run-1",
+        status: "processing",
+        message: "Image generation is still processing.",
+      })
+      .mockResolvedValueOnce({
+        id: "asset-2",
+        runId: "run-2",
+        status: "ready",
+      });
+
+    const result = await action.run({
+      libraryId: "lib-1",
+      slots: [
+        { slotId: "slot-1", prompt: "First" },
+        { slotId: "slot-2", prompt: "Second" },
+      ],
+    });
+
+    expect(result.images).toEqual([
+      {
+        slotId: "slot-1",
+        ok: true,
+        status: "processing",
+        runId: "run-1",
+        message: "Image generation is still processing.",
+      },
+      expect.objectContaining({
+        slotId: "slot-2",
+        ok: true,
+        status: "ready",
         id: "asset-2",
         runId: "run-2",
       }),

--- a/templates/assets/actions/generate-image-batch.ts
+++ b/templates/assets/actions/generate-image-batch.ts
@@ -24,7 +24,7 @@ import { upsertVariantSlot } from "./variant-slots.js";
 
 export default defineAction({
   description:
-    "Generate several brand-consistent images in parallel from one brand kit/library. Use @brand-kit mentions as libraryId and @preset mentions as presetId when present. This is synchronous for images: one call waits for every slot and returns final image artifacts. Use this for slide decks, landing pages, and multi-slot design work. Do not call get-generation-run or refresh-generation-run after a normal image batch result.",
+    'Generate several brand-consistent images in parallel from one brand kit/library. Use @brand-kit mentions as libraryId and @preset mentions as presetId when present. Fast slots return ready image artifacts; slower slots return status: "processing" with runIds and finish through the live variant tray, which polls refresh-generation-run automatically in the Assets UI. Use this for slide decks, landing pages, and multi-slot design work. Do not re-issue the whole batch after slow processing results. In normal in-app chat, do not manually poll; only headless callers without a visible tray should call refresh-generation-run if they must wait.',
   schema: z.object({
     libraryId: z
       .string()
@@ -194,9 +194,22 @@ function serializeBatchResult(
     return {
       slotId,
       ok: false,
+      status: "dismissed",
       dismissed: true,
       runId: stringValue(result.value.runId),
       error: "Candidate was dismissed before it completed.",
+    };
+  }
+
+  if (result.value.status === "processing") {
+    return {
+      slotId,
+      ok: true,
+      status: "processing",
+      runId: stringValue(result.value.runId),
+      message:
+        stringValue(result.value.message) ??
+        "Image generation is still processing; the live candidate tray will update when it is ready.",
     };
   }
 
@@ -204,12 +217,13 @@ function serializeBatchResult(
     return {
       slotId,
       ok: false,
+      status: "failed",
       runId: stringValue(result.value.runId),
       error: "Image generation finished without an asset.",
     };
   }
 
-  return { slotId, ok: true, ...result.value };
+  return { slotId, ok: true, status: "ready", ...result.value };
 }
 
 function imageAssetId(value: Record<string, unknown>): string | undefined {

--- a/templates/assets/actions/generate-image.spec.ts
+++ b/templates/assets/actions/generate-image.spec.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const assertAccessMock = vi.hoisted(() => vi.fn());
+const getDbMock = vi.hoisted(() => vi.fn());
+const readImageModelDefaultMock = vi.hoisted(() => vi.fn());
+const finalizeImageRunWithinBudgetMock = vi.hoisted(() => vi.fn());
+const upsertVariantSlotMock = vi.hoisted(() => vi.fn());
+const wasVariantSlotDismissedMock = vi.hoisted(() => vi.fn());
+const insertCalls = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+const updateCalls = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+
+const schemaMock = vi.hoisted(() => ({
+  assetLibraries: { id: "libraries.id" },
+  assetGenerationSessions: { id: "sessions.id" },
+  assetGenerationPresets: { id: "presets.id" },
+  assetCollections: { id: "collections.id" },
+  assets: { id: "assets.id" },
+  assetGenerationRuns: { id: "runs.id" },
+}));
+
+vi.mock("@agent-native/core", () => ({
+  defineAction: (entry: unknown) => entry,
+}));
+
+vi.mock("@agent-native/core/action", () => ({}));
+
+vi.mock("@agent-native/core/application-state", () => ({
+  writeAppState: vi.fn(),
+  deleteAppState: vi.fn(async () => undefined),
+}));
+
+vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestUserEmail: vi.fn(() => "designer@example.test"),
+  getRequestOrgId: vi.fn(() => "org-1"),
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  assertAccess: assertAccessMock,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((column, value) => ({ column, value })),
+}));
+
+vi.mock("nanoid", () => ({
+  nanoid: vi.fn(() => "run-1"),
+}));
+
+vi.mock("../server/db/index.js", () => ({
+  getDb: getDbMock,
+  schema: schemaMock,
+}));
+
+vi.mock("../server/lib/generation-presets.js", () => ({
+  applyPromptTemplate: vi.fn((_template, prompt: string) => prompt),
+}));
+
+vi.mock("../server/lib/generation.js", () => ({
+  compilePrompt: vi.fn(() => "Compiled prompt"),
+  DEFAULT_GENERATION_REFERENCE_LIMIT: 6,
+  isImageGenerationSetupError: vi.fn(() => false),
+  selectReferences: vi.fn(async () => []),
+}));
+
+vi.mock("../server/lib/image-runs.js", () => ({
+  finalizeImageRunWithinBudget: finalizeImageRunWithinBudgetMock,
+  IMAGE_GENERATION_INLINE_FAST_PATH_MS: 25,
+  markImageRunFailed: vi.fn(),
+}));
+
+vi.mock("../server/lib/json.js", () => ({
+  nowIso: vi.fn(() => "2026-05-28T12:00:00.000Z"),
+  parseJson: vi.fn((value: string | null | undefined, fallback: unknown) => {
+    if (!value) return fallback;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return fallback;
+    }
+  }),
+  stringifyJson: vi.fn((value: unknown) => JSON.stringify(value)),
+}));
+
+vi.mock("./_helpers.js", () => ({
+  requireGenerationSessionInLibrary: vi.fn(),
+  serializeAsset: vi.fn((asset) => ({
+    id: asset.id,
+    assetId: asset.id,
+    url: `/asset/${asset.id}`,
+    previewUrl: `/api/assets/${asset.id}/content`,
+    thumbnailUrl: `/api/assets/${asset.id}/content?variant=thumb`,
+  })),
+  serializeGenerationRun: vi.fn((run) => run),
+}));
+
+vi.mock("./_image-model-default.js", () => ({
+  readImageModelDefault: readImageModelDefaultMock,
+}));
+
+vi.mock("./variant-slots.js", () => ({
+  upsertVariantSlot: upsertVariantSlotMock,
+  wasVariantSlotDismissed: wasVariantSlotDismissedMock,
+}));
+
+import action from "./generate-image.js";
+
+function createDb() {
+  const rowsFor = (table: unknown) => {
+    if (table === schemaMock.assetLibraries) {
+      return [
+        {
+          id: "library-1",
+          title: "Northstar",
+          styleBrief: "{}",
+          customInstructions: "",
+          canonicalLogoAssetId: null,
+        },
+      ];
+    }
+    return [];
+  };
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => ({
+        where: vi.fn(() => {
+          const rows = rowsFor(table);
+          const promise = Promise.resolve(rows) as Promise<any[]> & {
+            limit: (count: number) => Promise<any[]>;
+          };
+          promise.limit = vi.fn(async (count: number) => rows.slice(0, count));
+          return promise;
+        }),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(async (row: Record<string, unknown>) => {
+        insertCalls.push(row);
+      }),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: Record<string, unknown>) => ({
+        where: vi.fn(async () => {
+          updateCalls.push(values);
+        }),
+      })),
+    })),
+  };
+}
+
+describe("generate-image", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertCalls.length = 0;
+    updateCalls.length = 0;
+    assertAccessMock.mockResolvedValue(undefined);
+    readImageModelDefaultMock.mockResolvedValue(undefined);
+    upsertVariantSlotMock.mockResolvedValue(undefined);
+    wasVariantSlotDismissedMock.mockResolvedValue(false);
+    getDbMock.mockReturnValue(createDb());
+  });
+
+  it("preserves the fast path by returning a ready asset inline", async () => {
+    finalizeImageRunWithinBudgetMock.mockImplementation(async (run) => ({
+      status: "completed",
+      run: { ...run, status: "completed" },
+      asset: {
+        id: "asset-1",
+        libraryId: "library-1",
+        thumbnailObjectKey: "thumb.webp",
+      },
+    }));
+
+    const result = await action.run({
+      libraryId: "library-1",
+      prompt: "Create a hero image",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: "asset-1",
+        assetId: "asset-1",
+        runId: "run-1",
+        status: "ready",
+        artifactType: "image",
+      }),
+    );
+    expect(finalizeImageRunWithinBudgetMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "run-1", status: "processing" }),
+      25,
+    );
+  });
+
+  it("returns processing without failing the run when the inline budget elapses", async () => {
+    finalizeImageRunWithinBudgetMock.mockImplementation(async (run) => ({
+      status: "processing",
+      run,
+    }));
+
+    const result = await action.run({
+      libraryId: "library-1",
+      prompt: "Create a large campaign image",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        runId: "run-1",
+        status: "processing",
+        artifactType: "image",
+      }),
+    );
+    expect(updateCalls).toContainEqual(
+      expect.objectContaining({ status: "processing" }),
+    );
+    expect(updateCalls).not.toContainEqual(
+      expect.objectContaining({ status: "failed" }),
+    );
+    expect(insertCalls).toContainEqual(
+      expect.objectContaining({
+        id: "run-1",
+        status: "pending",
+        mediaType: "image",
+      }),
+    );
+  });
+});

--- a/templates/assets/actions/generate-image.ts
+++ b/templates/assets/actions/generate-image.ts
@@ -14,18 +14,19 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
-import { createAssetFromBuffer } from "../server/lib/assets.js";
 import { applyPromptTemplate } from "../server/lib/generation-presets.js";
 import {
   compilePrompt,
   DEFAULT_GENERATION_REFERENCE_LIMIT,
-  generateWithManagedImageProvider,
   isImageGenerationSetupError,
   selectReferences,
 } from "../server/lib/generation.js";
-import { compositeLogo } from "../server/lib/image-processing.js";
+import {
+  finalizeImageRunWithinBudget,
+  IMAGE_GENERATION_INLINE_FAST_PATH_MS,
+  markImageRunFailed,
+} from "../server/lib/image-runs.js";
 import { nowIso, parseJson, stringifyJson } from "../server/lib/json.js";
-import { getObject } from "../server/lib/storage.js";
 import {
   ASPECT_RATIOS,
   GENERATION_INTENTS,
@@ -42,6 +43,7 @@ import {
 import {
   requireGenerationSessionInLibrary,
   serializeAsset,
+  serializeGenerationRun,
 } from "./_helpers.js";
 import { readImageModelDefault } from "./_image-model-default.js";
 import { upsertVariantSlot, wasVariantSlotDismissed } from "./variant-slots.js";
@@ -60,7 +62,7 @@ function resolveModelForTier(
 
 export default defineAction({
   description:
-    "Generate one brand-consistent image from a brand kit/library. This is synchronous for images and returns the final asset with preview/download/embed URLs. Use @brand-kit mentions as libraryId and @preset mentions as presetId when present. Use generate-image-batch for multiple independent slots; do not poll image runs after this action returns.",
+    'Generate one brand-consistent image from a brand kit/library. Fast images return a ready asset with preview/download/embed URLs; slower images return status: "processing" with a runId and finish through the live variant tray, which polls refresh-generation-run automatically in the Assets UI. Use @brand-kit mentions as libraryId and @preset mentions as presetId when present. Do not re-issue the whole request after a slow processing result. In normal in-app chat, do not manually poll; only headless callers without a visible tray should call refresh-generation-run if they must wait.',
   schema: z.object({
     libraryId: z
       .string()
@@ -352,6 +354,7 @@ export default defineAction({
       threadId: context?.threadId ?? null,
       variantScopeId,
       dismissible: dismissibleSlot,
+      activateSessionAsset: args.activateSessionAsset,
       sourceAssetId: args.sourceAssetId,
       subjectAssetId: args.subjectAssetId,
       intent: args.intent,
@@ -375,6 +378,7 @@ export default defineAction({
       model: resolvedModel,
       aspectRatio: resolvedAspectRatio,
       imageSize: resolvedImageSize,
+      mediaType: "image",
       groundingMode: args.groundingMode,
       referenceAssetIds: stringifyJson(references.map((ref) => ref.id)),
       status: "pending",
@@ -401,165 +405,78 @@ export default defineAction({
     });
 
     try {
-      const generated = await generateWithManagedImageProvider({
-        prompt: promptForRun,
+      const processingMetadata = {
+        ...baseMetadata,
+        mediaType: "image",
+        providerStatus: "processing",
+        startedAt: nowIso(),
+      };
+      const processingRun = {
+        id: runId,
+        libraryId: args.libraryId,
+        collectionId: resolvedCollectionId ?? null,
+        presetId: preset?.id ?? null,
+        sessionId: session?.id ?? null,
+        prompt: args.prompt,
         compiledPrompt,
-        references,
+        mediaType: "image",
         model: resolvedModel,
         aspectRatio: resolvedAspectRatio,
         imageSize: resolvedImageSize,
+        durationSeconds: null,
+        resolution: null,
         groundingMode: args.groundingMode,
-        intent: args.intent,
-        styleStrength: args.styleStrength,
-        runId,
-        libraryId: args.libraryId,
-        collectionId: resolvedCollectionId ?? null,
+        referenceAssetIds: stringifyJson(references.map((ref) => ref.id)),
+        status: "processing",
+        error: null,
+        metadata: stringifyJson(processingMetadata),
+        createdAt: now,
+        completedAt: null,
         source: args.source,
-        callerAppId: args.callerAppId,
-      });
+        callerAppId: args.callerAppId ?? null,
+        ownerEmail,
+        orgId,
+      };
+      await db
+        .update(schema.assetGenerationRuns)
+        .set({ status: "processing", metadata: processingRun.metadata })
+        .where(eq(schema.assetGenerationRuns.id, runId));
+
+      const finalized = await finalizeImageRunWithinBudget(
+        processingRun,
+        IMAGE_GENERATION_INLINE_FAST_PATH_MS,
+      );
       await deleteAppState("image-generation-setup").catch(() => {});
-      let image = generated.image;
-      let mimeType = generated.mimeType;
-      if (args.includeLogo && library.canonicalLogoAssetId) {
-        const [logo] = await db
-          .select()
-          .from(schema.assets)
-          .where(eq(schema.assets.id, library.canonicalLogoAssetId))
-          .limit(1);
-        if (logo) {
-          image = await compositeLogo({
-            image,
-            logo: await getObject(logo.objectKey),
-          });
-          mimeType = "image/png";
-        }
-      }
-      if (
-        dismissibleSlot &&
-        (await wasVariantSlotDismissed(args.libraryId, slotId, {
-          threadId: context?.threadId ?? null,
-          variantScopeId,
-        }))
-      ) {
-        await db
-          .update(schema.assetGenerationRuns)
-          .set({
-            status: "completed",
-            completedAt: nowIso(),
-            metadata: stringifyJson({
-              ...baseMetadata,
-              dismissed: true,
-              slotId,
-              referenceSelection,
-              settingsUsed,
-              provider: generated.provider,
-              providerGenerationId: generated.providerGenerationId,
-              creditsCharged: generated.creditsCharged,
-            }),
-          })
-          .where(eq(schema.assetGenerationRuns.id, runId));
+
+      if (finalized.status === "dismissed") {
         return {
           runId,
+          status: "dismissed",
           dismissed: true,
           artifactType: "image",
           Artifacts: [],
         };
       }
-      const asset = await createAssetFromBuffer({
-        libraryId: args.libraryId,
-        collectionId: resolvedCollectionId ?? null,
-        buffer: image,
-        mimeType,
-        role: "generated",
-        status: "candidate",
-        prompt: args.prompt,
-        model: generated.model,
-        aspectRatio: resolvedAspectRatio,
-        imageSize: resolvedImageSize,
-        generationRunId: runId,
-        metadata: {
-          provider: generated.provider,
-          compiledPrompt,
-          referenceAssetIds: references.map((ref) => ref.id),
-          sourceAssetId: args.sourceAssetId,
-          subjectAssetId: args.subjectAssetId,
-          intent: args.intent,
-          styleStrength: args.styleStrength,
-          tier: resolvedTier,
-          includeLogo: args.includeLogo,
-          presetId: preset?.id,
-          sessionId: session?.id,
-          generated: true,
-          sourceUrl: generated.sourceUrl,
-          providerGenerationId: generated.providerGenerationId,
-          creditsCharged: generated.creditsCharged,
-        },
-        category,
-      });
-      if (session) {
-        const itemCreatedAt = nowIso();
-        await db.insert(schema.assetGenerationSessionItems).values({
-          id: nanoid(),
-          sessionId: session.id,
-          assetId: asset.id,
-          generationRunId: runId,
-          role: args.activateSessionAsset ? "active" : "candidate",
-          note: null,
-          sortOrder: 100,
-          createdAt: itemCreatedAt,
-        });
-        if (args.activateSessionAsset) {
-          await db
-            .update(schema.assetGenerationSessions)
-            .set({ activeAssetId: asset.id, updatedAt: itemCreatedAt })
-            .where(eq(schema.assetGenerationSessions.id, session.id));
-        }
+
+      if (finalized.status === "processing") {
+        return {
+          run: serializeGenerationRun(finalized.run),
+          runId,
+          status: "processing",
+          artifactType: "image",
+          message:
+            "Image generation is still processing. The live candidate tray will poll and update when it is ready; do not re-issue the generation request. Headless callers without the tray may call refresh-generation-run if they must wait.",
+          Artifacts: [],
+        };
       }
-      await db
-        .update(schema.assetGenerationRuns)
-        .set({
-          status: "completed",
-          completedAt: nowIso(),
-          metadata: stringifyJson({
-            ...baseMetadata,
-            assetId: asset.id,
-            outputAssetIds: [asset.id],
-            slotId,
-            sourceAssetId: args.sourceAssetId,
-            subjectAssetId: args.subjectAssetId,
-            intent: args.intent,
-            styleStrength: args.styleStrength,
-            tier: resolvedTier,
-            includeLogo: args.includeLogo,
-            categories: resolvedCategories ?? [],
-            referenceSelection,
-            settingsUsed,
-            provider: generated.provider,
-            providerGenerationId: generated.providerGenerationId,
-            creditsCharged: generated.creditsCharged,
-          }),
-        })
-        .where(eq(schema.assetGenerationRuns.id, runId));
+
+      const asset = finalized.asset;
       const serialized = serializeAsset(asset);
-      await upsertVariantSlot({
-        runId,
-        batchId: args.variantBatchId ?? null,
-        libraryId: args.libraryId,
-        collectionId: resolvedCollectionId ?? null,
-        presetId: preset?.id ?? null,
-        sessionId: session?.id ?? null,
-        threadId: context?.threadId ?? null,
-        variantScopeId,
-        prompt: args.prompt,
-        slotId,
-        status: "ready",
-        assetId: asset.id,
-        previewUrl: serialized.previewUrl,
-        thumbnailUrl: serialized.thumbnailUrl,
-      });
       return {
         ...serialized,
         runId,
+        assetId: asset.id,
+        status: "ready",
         artifactType: "image",
         Artifacts: [
           `Image: ${serialized.url} (ID: ${asset.id}, Run: ${runId})`,
@@ -588,19 +505,34 @@ export default defineAction({
       ) {
         throw err;
       }
-      await upsertVariantSlot({
-        runId,
-        batchId: args.variantBatchId ?? null,
-        libraryId: args.libraryId,
-        collectionId: resolvedCollectionId ?? null,
-        presetId: preset?.id ?? null,
-        sessionId: session?.id ?? null,
-        threadId: context?.threadId ?? null,
-        variantScopeId,
-        prompt: args.prompt,
-        slotId,
-        status: "failed",
-        error: message,
+      await markImageRunFailed({
+        run: {
+          id: runId,
+          libraryId: args.libraryId,
+          collectionId: resolvedCollectionId ?? null,
+          presetId: preset?.id ?? null,
+          sessionId: session?.id ?? null,
+          prompt: args.prompt,
+          compiledPrompt,
+          mediaType: "image",
+          model: resolvedModel,
+          aspectRatio: resolvedAspectRatio,
+          imageSize: resolvedImageSize,
+          durationSeconds: null,
+          resolution: null,
+          groundingMode: args.groundingMode,
+          referenceAssetIds: stringifyJson(references.map((ref) => ref.id)),
+          status: "failed",
+          error: message,
+          metadata: stringifyJson(baseMetadata),
+          createdAt: now,
+          completedAt: null,
+          source: args.source,
+          callerAppId: args.callerAppId ?? null,
+          ownerEmail,
+          orgId,
+        },
+        message,
       });
       throw err;
     }

--- a/templates/assets/actions/get-generation-run.ts
+++ b/templates/assets/actions/get-generation-run.ts
@@ -11,7 +11,7 @@ import {
 
 export default defineAction({
   description:
-    "Get a generation run and all assets produced by that run for history/debugging. Image generation actions already return completed assets; do not call this just to verify generate-image or generate-image-batch results.",
+    "Get a generation run and all assets produced by that run for history/debugging. For slow image runs in the Assets UI, the live variant tray handles polling; use refresh-generation-run only when explicitly advancing completion for headless/no-tray workflows or async video runs.",
   schema: z.object({ runId: z.string() }),
   http: { method: "GET" },
   readOnly: true,

--- a/templates/assets/actions/refresh-generation-run.spec.ts
+++ b/templates/assets/actions/refresh-generation-run.spec.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const assertAccessMock = vi.hoisted(() => vi.fn());
 const getDbMock = vi.hoisted(() => vi.fn());
 const completeVideoGenerationRunMock = vi.hoisted(() => vi.fn());
+const finalizeImageRunWithinBudgetMock = vi.hoisted(() => vi.fn());
+const markImageRunFailedMock = vi.hoisted(() => vi.fn());
 const upsertVariantSlotMock = vi.hoisted(() => vi.fn());
 const updateSetCalls = vi.hoisted(() => [] as Array<Record<string, unknown>>);
 
@@ -31,6 +33,12 @@ vi.mock("drizzle-orm", () => ({
 vi.mock("../server/db/index.js", () => ({
   getDb: getDbMock,
   schema: schemaMock,
+}));
+
+vi.mock("../server/lib/image-runs.js", () => ({
+  finalizeImageRunWithinBudget: finalizeImageRunWithinBudgetMock,
+  IMAGE_GENERATION_REFRESH_ATTEMPT_MS: 25,
+  markImageRunFailed: markImageRunFailedMock,
 }));
 
 vi.mock("../server/lib/video-runs.js", () => ({
@@ -104,6 +112,16 @@ describe("refresh-generation-run", () => {
     updateSetCalls.length = 0;
     assertAccessMock.mockResolvedValue(undefined);
     upsertVariantSlotMock.mockResolvedValue(undefined);
+    finalizeImageRunWithinBudgetMock.mockImplementation(async (run) => ({
+      status: "processing",
+      run,
+    }));
+    markImageRunFailedMock.mockImplementation(async ({ run, message }) => ({
+      ...run,
+      status: "failed",
+      error: message,
+      completedAt: "2026-05-28T12:00:00.000Z",
+    }));
   });
 
   afterEach(() => {
@@ -140,23 +158,13 @@ describe("refresh-generation-run", () => {
     const result = await action.run({ runId: "run-1" });
 
     expect(result.run.status).toBe("failed");
-    expect(updateSetCalls[0]).toEqual(
+    expect(markImageRunFailedMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        status: "failed",
-        completedAt: "2026-05-28T12:00:00.000Z",
+        run: expect.objectContaining({ id: "run-1" }),
+        message: expect.stringContaining("interrupted"),
       }),
     );
-    expect(upsertVariantSlotMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        runId: "run-1",
-        batchId: "batch-1",
-        libraryId: "library-1",
-        threadId: "thread-1",
-        variantScopeId: "thread-1",
-        slotId: "agent-workflow-final",
-        status: "failed",
-      }),
-    );
+    expect(finalizeImageRunWithinBudgetMock).not.toHaveBeenCalled();
     expect(completeVideoGenerationRunMock).not.toHaveBeenCalled();
   });
 
@@ -180,17 +188,59 @@ describe("refresh-generation-run", () => {
       }),
     );
 
+    finalizeImageRunWithinBudgetMock.mockResolvedValueOnce({
+      status: "completed",
+      run: { id: "run-2", status: "completed" },
+      asset: { id: "asset-1" },
+    });
+
     const result = await action.run({ runId: "run-2" });
 
     expect(result.assets).toEqual([expect.objectContaining({ id: "asset-1" })]);
-    expect(upsertVariantSlotMock).toHaveBeenCalledWith(
+    expect(finalizeImageRunWithinBudgetMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        runId: "run-2",
-        slotId: "hero-slot",
-        status: "ready",
-        assetId: "asset-1",
-        previewUrl: "/api/assets/asset-1/content",
+        id: "run-2",
+      }),
+      25,
+    );
+  });
+
+  it("polls an async image run once and leaves it processing when not ready", async () => {
+    getDbMock.mockReturnValue(
+      createDb({
+        run: {
+          id: "run-3",
+          libraryId: "library-1",
+          collectionId: null,
+          presetId: null,
+          sessionId: null,
+          prompt: "Slow image",
+          mediaType: "image",
+          status: "processing",
+          error: null,
+          metadata: JSON.stringify({
+            slotId: "slow-slot",
+            providerStatus: "processing",
+            startedAt: "2026-05-28T11:59:45.000Z",
+          }),
+          createdAt: "2026-05-28T11:59:45.000Z",
+        },
+        assets: [],
       }),
     );
+    finalizeImageRunWithinBudgetMock.mockImplementation(async (run) => ({
+      status: "processing",
+      run,
+    }));
+
+    const result = await action.run({ runId: "run-3" });
+
+    expect(result.run.status).toBe("processing");
+    expect(result.assets).toEqual([]);
+    expect(finalizeImageRunWithinBudgetMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "run-3", status: "processing" }),
+      25,
+    );
+    expect(markImageRunFailedMock).not.toHaveBeenCalled();
   });
 });

--- a/templates/assets/actions/refresh-generation-run.ts
+++ b/templates/assets/actions/refresh-generation-run.ts
@@ -4,7 +4,12 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
-import { nowIso, parseJson } from "../server/lib/json.js";
+import {
+  finalizeImageRunWithinBudget,
+  IMAGE_GENERATION_REFRESH_ATTEMPT_MS,
+  markImageRunFailed,
+} from "../server/lib/image-runs.js";
+import { parseJson } from "../server/lib/json.js";
 import { completeVideoGenerationRun } from "../server/lib/video-runs.js";
 import { serializeAsset, serializeGenerationRun } from "./_helpers.js";
 import { upsertVariantSlot } from "./variant-slots.js";
@@ -69,6 +74,7 @@ async function refreshImageRun(
   run: typeof schema.assetGenerationRuns.$inferSelect,
 ) {
   const db = getDb();
+  const metadata = parseJson<Record<string, unknown>>(run.metadata, {});
   const assets = await db
     .select()
     .from(schema.assets)
@@ -76,17 +82,14 @@ async function refreshImageRun(
 
   const outputAsset = assets[0] ?? null;
   if (outputAsset) {
-    let nextRun = run;
-    if (run.status !== "completed") {
-      const completedAt = nowIso();
-      await db
-        .update(schema.assetGenerationRuns)
-        .set({ status: "completed", completedAt })
-        .where(eq(schema.assetGenerationRuns.id, run.id));
-      nextRun = { ...run, status: "completed", completedAt };
-    }
-    await syncImageVariantSlot(nextRun, "ready", { asset: outputAsset });
-    return { run: nextRun, assets };
+    const completed = await finalizeImageRunWithinBudget(
+      run,
+      IMAGE_GENERATION_REFRESH_ATTEMPT_MS,
+    );
+    return {
+      run: completed.run,
+      assets: completed.status === "completed" ? [completed.asset] : assets,
+    };
   }
 
   if (run.status === "failed") {
@@ -96,26 +99,35 @@ async function refreshImageRun(
     return { run, assets: [] };
   }
 
-  if (imageRunAgeMs(run) >= STALE_IMAGE_RUN_MS) {
-    const completedAt = nowIso();
-    await db
-      .update(schema.assetGenerationRuns)
-      .set({
-        status: "failed",
-        error: INTERRUPTED_IMAGE_RUN_ERROR,
-        completedAt,
-      })
-      .where(eq(schema.assetGenerationRuns.id, run.id));
-    const failedRun = {
-      ...run,
-      status: "failed",
-      error: INTERRUPTED_IMAGE_RUN_ERROR,
-      completedAt,
-    };
-    await syncImageVariantSlot(failedRun, "failed", {
-      error: INTERRUPTED_IMAGE_RUN_ERROR,
-    });
-    return { run: failedRun, assets: [] };
+  const asyncSubmitted =
+    metadata.providerStatus === "processing" ||
+    typeof metadata.startedAt === "string";
+  if (run.status === "pending" || run.status === "processing") {
+    if (asyncSubmitted) {
+      try {
+        const completed = await finalizeImageRunWithinBudget(
+          { ...run, status: "processing" },
+          IMAGE_GENERATION_REFRESH_ATTEMPT_MS,
+        );
+        return {
+          run: completed.run,
+          assets: completed.status === "completed" ? [completed.asset] : [],
+        };
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Image generation failed.";
+        const failedRun = await markImageRunFailed({ run, message });
+        return { run: failedRun, assets: [] };
+      }
+    }
+
+    if (imageRunAgeMs(run) >= STALE_IMAGE_RUN_MS) {
+      const failedRun = await markImageRunFailed({
+        run,
+        message: INTERRUPTED_IMAGE_RUN_ERROR,
+      });
+      return { run: failedRun, assets: [] };
+    }
   }
 
   return { run, assets: [] };
@@ -123,7 +135,7 @@ async function refreshImageRun(
 
 export default defineAction({
   description:
-    "Refresh a generation run. Use this to poll async video runs, and to reconcile an interrupted or stale pending image slot by runId before retrying generation.",
+    "Refresh a generation run by runId until it completes and creates assets. The Assets live variant tray already polls image runs automatically, so normal in-app chat agents should not call this after generate-image or generate-image-batch unless the user asks, there is no visible tray, or the caller is headless. Continue using this for async video runs.",
   schema: z.object({
     runId: z.string(),
   }),
@@ -134,6 +146,17 @@ export default defineAction({
       .from(schema.assetGenerationRuns)
       .where(eq(schema.assetGenerationRuns.id, runId))
       .limit(1);
+    if (!run && runId.startsWith("pending-")) {
+      return {
+        run: {
+          id: runId,
+          status: "pending",
+          mediaType: "image",
+          metadata: { placeholder: true },
+        },
+        assets: [],
+      };
+    }
     if (!run) throw new Error("Generation run not found.");
     await assertAccess("asset-library", run.libraryId, "editor");
     if ((run.mediaType ?? "image") !== "video") {

--- a/templates/assets/app/components/generation/GenerationResults.tsx
+++ b/templates/assets/app/components/generation/GenerationResults.tsx
@@ -44,14 +44,19 @@ function slotTime(slot: AssetVariantState["slots"][number]): number {
   return Number.isNaN(time) ? 0 : time;
 }
 
-function stalePendingRunId(
+const PENDING_SLOT_REFRESH_GRACE_MS = 5_000;
+
+function pollablePendingRunId(
   slot: AssetVariantState["slots"][number],
 ): string | null {
   if (slot.status !== "pending") return null;
   if (!slot.runId) return null;
+  if (slot.runId.startsWith("pending-")) return null;
   const timestamp = slotTime(slot);
   if (!timestamp) return null;
-  return Date.now() - timestamp >= 2 * 60 * 1000 ? slot.runId : null;
+  return Date.now() - timestamp >= PENDING_SLOT_REFRESH_GRACE_MS
+    ? slot.runId
+    : null;
 }
 
 export function GenerationResults({ threadId }: { threadId: string | null }) {
@@ -101,7 +106,7 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
     if (!belongsToThread) return;
     if (!slots.length || refreshGeneration.isPending) return;
     const runId = slots
-      .map(stalePendingRunId)
+      .map(pollablePendingRunId)
       .find((id): id is string =>
         Boolean(id && !refreshingRunIds.current.has(id)),
       );

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -2280,27 +2280,43 @@ export function AssetPickerSurface() {
     {
       onSuccess: (result: any) => {
         const images = Array.isArray(result?.images) ? result.images : [];
-        const generatedCount = images.filter((image: any) => image?.ok).length;
-        const failedCount = images.length - generatedCount;
+        const readyCount = images.filter(
+          (image: any) => image?.status === "ready" || image?.assetId,
+        ).length;
+        const processingCount = images.filter(
+          (image: any) => image?.status === "processing",
+        ).length;
+        const failedCount = images.length - readyCount - processingCount;
         setVisibleCandidateRunIds(
           images
             .map((image: any) =>
-              image?.ok && typeof image.runId === "string" ? image.runId : null,
+              (image?.status === "ready" || image?.assetId) &&
+              typeof image.runId === "string"
+                ? image.runId
+                : null,
             )
             .filter((runId: string | null): runId is string => Boolean(runId)),
         );
-        if (generatedCount > 0) {
+        if (readyCount > 0 || processingCount > 0) {
           toast.success(
-            `Generated ${generatedCount} image candidate${
-              generatedCount === 1 ? "" : "s"
-            }`,
+            readyCount > 0
+              ? `Generated ${readyCount} image candidate${
+                  readyCount === 1 ? "" : "s"
+                }`
+              : `Started ${processingCount} image candidate${
+                  processingCount === 1 ? "" : "s"
+                }`,
             {
               description:
                 failedCount > 0
                   ? `${failedCount} candidate${
                       failedCount === 1 ? "" : "s"
                     } failed.`
-                  : "Pick the one you want to send back.",
+                  : processingCount > 0
+                    ? `${processingCount} candidate${
+                        processingCount === 1 ? " is" : "s are"
+                      } still rendering.`
+                    : "Pick the one you want to send back.",
             },
           );
           setQuery("");

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -2290,7 +2290,9 @@ export function AssetPickerSurface() {
         setVisibleCandidateRunIds(
           images
             .map((image: any) =>
-              (image?.status === "ready" || image?.assetId) &&
+              (image?.status === "ready" ||
+                image?.status === "processing" ||
+                image?.assetId) &&
               typeof image.runId === "string"
                 ? image.runId
                 : null,

--- a/templates/assets/changelog/2026-06-29-image-generation-finishes-in-background.md
+++ b/templates/assets/changelog/2026-06-29-image-generation-finishes-in-background.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-06-29
+---
+
+Image generation no longer times out on slow or large batches; slow images now finish in the background and appear when ready.

--- a/templates/assets/server/lib/generation.test.ts
+++ b/templates/assets/server/lib/generation.test.ts
@@ -413,6 +413,35 @@ describe("generateWithManagedImageProvider", () => {
     expect(requestIdempotencyKeys(fetchMock)).toEqual(["run-single-shot"]);
   });
 
+  it("does not use manual fallback for resumable single-shot image runs", async () => {
+    resolveBuilderCredentialsMock.mockResolvedValue({
+      privateKey: null,
+      publicKey: null,
+      userId: null,
+      orgName: null,
+      orgKind: null,
+    });
+    resolveSecretMock.mockImplementation(async (key: string) =>
+      key === "OPENAI_API_KEY" ? "sk-openai-test" : null,
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      generateWithManagedImageProviderOnce({
+        ...baseInput,
+        runId: "run-manual-fallback",
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: "FeatureNotConfiguredError",
+        requiredCredential: "BUILDER_PRIVATE_KEY",
+        message: expect.stringContaining("resume safely after timeouts"),
+      }),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("uses the bounded action timeout for single-shot provider attempts", async () => {
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
     const fetchMock = vi.fn(async (url: string | URL | Request) => {

--- a/templates/assets/server/lib/generation.test.ts
+++ b/templates/assets/server/lib/generation.test.ts
@@ -4,6 +4,7 @@ import {
   compareReferenceCandidates,
   compilePrompt,
   generateWithManagedImageProvider,
+  generateWithManagedImageProviderOnce,
 } from "./generation.js";
 import type { GenerateProviderInput } from "./generation.js";
 
@@ -393,6 +394,54 @@ describe("generateWithManagedImageProvider", () => {
       "run-poll-1",
       "run-poll-1",
     ]);
+  });
+
+  it("returns processing from the single-shot path when a managed request is still running", async () => {
+    const fetchMock = mockBuilderFailure(409, {
+      code: "request_in_progress",
+      message:
+        "An image generation request with this idempotency key is already in progress.",
+    });
+
+    await expect(
+      generateWithManagedImageProviderOnce({
+        ...baseInput,
+        runId: "run-single-shot",
+      }),
+    ).resolves.toEqual({ status: "processing" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(requestIdempotencyKeys(fetchMock)).toEqual(["run-single-shot"]);
+  });
+
+  it("uses the bounded action timeout for single-shot provider attempts", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      if (String(url).endsWith("/generations")) {
+        return builderGenerationSuccess();
+      }
+      return builderImageBytes();
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      await expect(
+        generateWithManagedImageProviderOnce({
+          ...baseInput,
+          runId: "run-budgeted",
+          requestTimeoutMs: 1234,
+          downloadTimeoutMs: 567,
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          status: "completed",
+          output: expect.objectContaining({ provider: "builder" }),
+        }),
+      );
+      expect(timeoutSpy).toHaveBeenCalledWith(1234);
+      expect(timeoutSpy).toHaveBeenCalledWith(567);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
   });
 
   it("polls after a client-side abort instead of regenerating", async () => {

--- a/templates/assets/server/lib/generation.test.ts
+++ b/templates/assets/server/lib/generation.test.ts
@@ -464,6 +464,7 @@ describe("generateWithManagedImageProvider", () => {
 
   it("uses the bounded action timeout for single-shot provider attempts", async () => {
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const onProviderOutputReady = vi.fn(async () => undefined);
     const fetchMock = vi.fn(async (url: string | URL | Request) => {
       if (String(url).endsWith("/generations")) {
         return builderGenerationSuccess();
@@ -479,6 +480,7 @@ describe("generateWithManagedImageProvider", () => {
           runId: "run-budgeted",
           requestTimeoutMs: 1234,
           downloadTimeoutMs: 567,
+          onProviderOutputReady,
         }),
       ).resolves.toEqual(
         expect.objectContaining({
@@ -488,6 +490,7 @@ describe("generateWithManagedImageProvider", () => {
       );
       expect(timeoutSpy).toHaveBeenCalledWith(1234);
       expect(timeoutSpy).toHaveBeenCalledWith(567);
+      expect(onProviderOutputReady).toHaveBeenCalledTimes(1);
     } finally {
       timeoutSpy.mockRestore();
     }

--- a/templates/assets/server/lib/generation.test.ts
+++ b/templates/assets/server/lib/generation.test.ts
@@ -413,7 +413,7 @@ describe("generateWithManagedImageProvider", () => {
     expect(requestIdempotencyKeys(fetchMock)).toEqual(["run-single-shot"]);
   });
 
-  it("does not use manual fallback for resumable single-shot image runs", async () => {
+  it("uses manual fallback for resumable single-shot image runs after recording the fallback", async () => {
     resolveBuilderCredentialsMock.mockResolvedValue({
       privateKey: null,
       publicKey: null,
@@ -424,22 +424,42 @@ describe("generateWithManagedImageProvider", () => {
     resolveSecretMock.mockImplementation(async (key: string) =>
       key === "OPENAI_API_KEY" ? "sk-openai-test" : null,
     );
-    const fetchMock = vi.fn();
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          data: [{ b64_json: Buffer.from([9, 8, 7]).toString("base64") }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const onManualFallbackStart = vi.fn(async () => undefined);
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
       generateWithManagedImageProviderOnce({
         ...baseInput,
         runId: "run-manual-fallback",
+        onManualFallbackStart,
       }),
-    ).rejects.toEqual(
+    ).resolves.toEqual(
       expect.objectContaining({
-        name: "FeatureNotConfiguredError",
-        requiredCredential: "BUILDER_PRIVATE_KEY",
-        message: expect.stringContaining("resume safely after timeouts"),
+        status: "completed",
+        output: expect.objectContaining({
+          image: Buffer.from([9, 8, 7]),
+          provider: "openai",
+        }),
       }),
     );
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(onManualFallbackStart).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/images/generations",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-openai-test",
+        }),
+      }),
+    );
   });
 
   it("uses the bounded action timeout for single-shot provider attempts", async () => {

--- a/templates/assets/server/lib/generation.test.ts
+++ b/templates/assets/server/lib/generation.test.ts
@@ -413,7 +413,7 @@ describe("generateWithManagedImageProvider", () => {
     expect(requestIdempotencyKeys(fetchMock)).toEqual(["run-single-shot"]);
   });
 
-  it("uses manual fallback for resumable single-shot image runs after recording the fallback", async () => {
+  it("uses manual fallback for resumable single-shot image runs and records it after output", async () => {
     resolveBuilderCredentialsMock.mockResolvedValue({
       privateKey: null,
       publicKey: null,
@@ -424,7 +424,9 @@ describe("generateWithManagedImageProvider", () => {
     resolveSecretMock.mockImplementation(async (key: string) =>
       key === "OPENAI_API_KEY" ? "sk-openai-test" : null,
     );
+    const events: string[] = [];
     const fetchMock = vi.fn(async () => {
+      events.push("manual-output");
       return new Response(
         JSON.stringify({
           data: [{ b64_json: Buffer.from([9, 8, 7]).toString("base64") }],
@@ -432,7 +434,9 @@ describe("generateWithManagedImageProvider", () => {
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
     });
-    const onManualFallbackStart = vi.fn(async () => undefined);
+    const onManualFallbackStart = vi.fn(async () => {
+      events.push("fallback-recorded");
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
@@ -451,6 +455,7 @@ describe("generateWithManagedImageProvider", () => {
       }),
     );
     expect(onManualFallbackStart).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(["manual-output", "fallback-recorded"]);
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.openai.com/v1/images/generations",
       expect.objectContaining({

--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -50,6 +50,8 @@ export interface GenerateProviderInput {
   collectionId?: string | null;
   source?: "chat" | "ui" | "a2a";
   callerAppId?: string;
+  requestTimeoutMs?: number;
+  downloadTimeoutMs?: number;
 }
 
 export interface GenerateProviderOutput {
@@ -65,13 +67,18 @@ export interface GenerateProviderOutput {
 const MANAGED_PROVIDER_MAX_ATTEMPTS = 3;
 const MANAGED_PROVIDER_RETRY_DELAY_MS =
   process.env.NODE_ENV === "test" ? 0 : 2500;
-// A single managed image generation can legitimately run longer than one
-// request's abort window (pro models routinely exceed 90s). The request always
-// carries the run id as an idempotency key, so re-POSTing the same key replays
-// the finished result (or answers 409 "request in progress") instead of
-// starting a second, double-charged generation. When a request aborts client
-// side, hits an upstream gateway timeout, or reports in-progress, we poll the
-// same key until it resolves rather than failing. ~40 polls * 6s ≈ 4 min.
+// 90s is the absolute per-HTTP request ceiling for the managed provider. Hosted
+// action runs have a much smaller ~40s soft budget, so budgeted actions must
+// pass a shorter requestTimeoutMs and use generateWithManagedImageProviderOnce
+// instead of the legacy multi-minute retry loop below.
+const MANAGED_PROVIDER_HTTP_TIMEOUT_MS = 90_000;
+const MANAGED_PROVIDER_IMAGE_DOWNLOAD_TIMEOUT_MS = 30_000;
+// A single managed image generation can legitimately run longer than one action
+// invocation. The request always carries the run id as an idempotency key, so
+// re-POSTing the same key replays the finished result (or answers 409 "request
+// in progress") instead of starting a second, double-charged generation. This
+// legacy loop is only for non-budgeted callers; actions should poll one bounded
+// attempt at a time.
 const MANAGED_PROVIDER_INFLIGHT_MAX_POLLS =
   process.env.NODE_ENV === "test" ? 6 : 40;
 const MANAGED_PROVIDER_INFLIGHT_POLL_MS =
@@ -173,7 +180,7 @@ function isRetryableBuilderImageGenerationError(err: unknown): boolean {
 // 409 "request_in_progress" all mean the generation is still running under this
 // idempotency key. Re-POSTing the same key replays the finished result once the
 // service completes, so these are polled rather than surfaced as failures.
-function isInFlightImageGenerationError(err: unknown): boolean {
+export function isInFlightImageGenerationError(err: unknown): boolean {
   if (!(err instanceof BuilderImageGenerationError)) return false;
   return (
     err.code === "client_timeout" ||
@@ -266,7 +273,9 @@ export async function generateWithBuilderImageApi(
         intent: input.intent,
       },
     }),
-    signal: AbortSignal.timeout(90_000),
+    signal: AbortSignal.timeout(
+      input.requestTimeoutMs ?? MANAGED_PROVIDER_HTTP_TIMEOUT_MS,
+    ),
   }).catch((err) => {
     if ((err as Error)?.name === "AbortError") {
       // The socket aborted, but the service keeps generating under this
@@ -305,7 +314,19 @@ export async function generateWithBuilderImageApi(
 
   const sourceUrl = output.downloadUrl ?? output.url;
   const imageResponse = await fetch(sourceUrl, {
-    signal: AbortSignal.timeout(30_000),
+    signal: AbortSignal.timeout(
+      input.downloadTimeoutMs ?? MANAGED_PROVIDER_IMAGE_DOWNLOAD_TIMEOUT_MS,
+    ),
+  }).catch((err) => {
+    if ((err as Error)?.name === "AbortError") {
+      throw new BuilderImageGenerationError(
+        "Downloading the Builder-managed image timed out.",
+        504,
+        undefined,
+        "client_timeout",
+      );
+    }
+    throw err;
   });
   if (!imageResponse.ok) {
     throw new BuilderImageGenerationError(
@@ -368,6 +389,69 @@ async function generateWithRetryingBuilderImageApi(
   }
 }
 
+export type ManagedImageProviderSingleShotResult =
+  | {
+      status: "completed";
+      output: GenerateProviderOutput;
+    }
+  | {
+      status: "processing";
+    };
+
+function shouldFallbackToManualImageProvider(err: unknown): boolean {
+  return (
+    err instanceof BuilderImageGenerationError &&
+    [401, 402, 403, 429, 503, 504].includes(err.status ?? 0)
+  );
+}
+
+export async function generateWithManagedImageProviderOnce(
+  input: GenerateProviderInput,
+): Promise<ManagedImageProviderSingleShotResult> {
+  if (!isBuilderImageGenerationEnabled()) {
+    if (await isManualImageGenerationConfigured()) {
+      return {
+        status: "completed",
+        output: await generateWithManualImageProvider(input),
+      };
+    }
+    throw new FeatureNotConfiguredError({
+      requiredCredential: "GEMINI_API_KEY or OPENAI_API_KEY",
+      builderConnectUrl: "/_agent-native/builder/connect",
+      byokDocsUrl: "https://aistudio.google.com/apikey",
+      message:
+        "Builder-managed image generation is disabled for this deployment. Open Settings and add a Gemini or OpenAI API key manually, or re-enable Builder-managed generation.",
+    });
+  }
+
+  try {
+    return {
+      status: "completed",
+      output: await generateWithBuilderImageApi(input),
+    };
+  } catch (err) {
+    if (isInFlightImageGenerationError(err)) {
+      return { status: "processing" };
+    }
+    if (
+      shouldFallbackToManualImageProvider(err) &&
+      (await isManualImageGenerationConfigured())
+    ) {
+      return {
+        status: "completed",
+        output: await generateWithManualImageProvider(input),
+      };
+    }
+    if (
+      shouldFallbackToManualImageProvider(err) &&
+      err instanceof BuilderImageGenerationError
+    ) {
+      throw createBuilderImageGenerationFallbackError(err);
+    }
+    throw err;
+  }
+}
+
 export async function generateWithManagedImageProvider(
   input: GenerateProviderInput,
 ): Promise<GenerateProviderOutput> {
@@ -387,13 +471,16 @@ export async function generateWithManagedImageProvider(
   try {
     return await generateWithRetryingBuilderImageApi(input);
   } catch (err) {
-    const shouldFallback =
-      err instanceof BuilderImageGenerationError &&
-      [401, 402, 403, 429, 503, 504].includes(err.status ?? 0);
-    if (shouldFallback && (await isManualImageGenerationConfigured())) {
+    if (
+      shouldFallbackToManualImageProvider(err) &&
+      (await isManualImageGenerationConfigured())
+    ) {
       return generateWithManualImageProvider(input);
     }
-    if (shouldFallback && err instanceof BuilderImageGenerationError) {
+    if (
+      shouldFallbackToManualImageProvider(err) &&
+      err instanceof BuilderImageGenerationError
+    ) {
       throw createBuilderImageGenerationFallbackError(err);
     }
     throw err;

--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -405,15 +405,40 @@ function shouldFallbackToManualImageProvider(err: unknown): boolean {
   );
 }
 
+function canUseManualFallbackForSingleShot(input: GenerateProviderInput) {
+  return !input.runId;
+}
+
+function createSingleShotManualFallbackError(
+  input: GenerateProviderInput,
+  err?: BuilderImageGenerationError,
+): Error {
+  const detail = err?.detail ? ` (${err.detail})` : "";
+  return new FeatureNotConfiguredError({
+    requiredCredential: "BUILDER_PRIVATE_KEY",
+    builderConnectUrl: "/_agent-native/builder/connect",
+    byokDocsUrl: "https://aistudio.google.com/apikey",
+    message: input.runId
+      ? `This image run needs Builder-managed generation to resume safely after timeouts${detail}. Manual OpenAI/Gemini fallback cannot replay the same run id, so reconnect Builder.io or re-enable Builder-managed image generation.`
+      : `Builder-managed image generation is unavailable${detail}. Reconnect Builder.io or add an OpenAI or Gemini API key as the manual fallback.`,
+  });
+}
+
 export async function generateWithManagedImageProviderOnce(
   input: GenerateProviderInput,
 ): Promise<ManagedImageProviderSingleShotResult> {
   if (!isBuilderImageGenerationEnabled()) {
-    if (await isManualImageGenerationConfigured()) {
+    if (
+      canUseManualFallbackForSingleShot(input) &&
+      (await isManualImageGenerationConfigured())
+    ) {
       return {
         status: "completed",
         output: await generateWithManualImageProvider(input),
       };
+    }
+    if (await isManualImageGenerationConfigured()) {
+      throw createSingleShotManualFallbackError(input);
     }
     throw new FeatureNotConfiguredError({
       requiredCredential: "GEMINI_API_KEY or OPENAI_API_KEY",
@@ -433,14 +458,23 @@ export async function generateWithManagedImageProviderOnce(
     if (isInFlightImageGenerationError(err)) {
       return { status: "processing" };
     }
+    const manualFallbackConfigured = await isManualImageGenerationConfigured();
     if (
       shouldFallbackToManualImageProvider(err) &&
-      (await isManualImageGenerationConfigured())
+      manualFallbackConfigured &&
+      canUseManualFallbackForSingleShot(input)
     ) {
       return {
         status: "completed",
         output: await generateWithManualImageProvider(input),
       };
+    }
+    if (
+      shouldFallbackToManualImageProvider(err) &&
+      manualFallbackConfigured &&
+      err instanceof BuilderImageGenerationError
+    ) {
+      throw createSingleShotManualFallbackError(input, err);
     }
     if (
       shouldFallbackToManualImageProvider(err) &&

--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -52,6 +52,7 @@ export interface GenerateProviderInput {
   callerAppId?: string;
   requestTimeoutMs?: number;
   downloadTimeoutMs?: number;
+  onProviderOutputReady?: () => Promise<void>;
   onManualFallbackStart?: () => Promise<void>;
 }
 
@@ -314,6 +315,7 @@ export async function generateWithBuilderImageApi(
   }
 
   const sourceUrl = output.downloadUrl ?? output.url;
+  await input.onProviderOutputReady?.();
   const imageResponse = await fetch(sourceUrl, {
     signal: AbortSignal.timeout(
       input.downloadTimeoutMs ?? MANAGED_PROVIDER_IMAGE_DOWNLOAD_TIMEOUT_MS,

--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -52,6 +52,7 @@ export interface GenerateProviderInput {
   callerAppId?: string;
   requestTimeoutMs?: number;
   downloadTimeoutMs?: number;
+  onManualFallbackStart?: () => Promise<void>;
 }
 
 export interface GenerateProviderOutput {
@@ -405,40 +406,22 @@ function shouldFallbackToManualImageProvider(err: unknown): boolean {
   );
 }
 
-function canUseManualFallbackForSingleShot(input: GenerateProviderInput) {
-  return !input.runId;
-}
-
-function createSingleShotManualFallbackError(
+async function generateWithManualImageProviderForSingleShot(
   input: GenerateProviderInput,
-  err?: BuilderImageGenerationError,
-): Error {
-  const detail = err?.detail ? ` (${err.detail})` : "";
-  return new FeatureNotConfiguredError({
-    requiredCredential: "BUILDER_PRIVATE_KEY",
-    builderConnectUrl: "/_agent-native/builder/connect",
-    byokDocsUrl: "https://aistudio.google.com/apikey",
-    message: input.runId
-      ? `This image run needs Builder-managed generation to resume safely after timeouts${detail}. Manual OpenAI/Gemini fallback cannot replay the same run id, so reconnect Builder.io or re-enable Builder-managed image generation.`
-      : `Builder-managed image generation is unavailable${detail}. Reconnect Builder.io or add an OpenAI or Gemini API key as the manual fallback.`,
-  });
+): Promise<GenerateProviderOutput> {
+  await input.onManualFallbackStart?.();
+  return generateWithManualImageProvider(input);
 }
 
 export async function generateWithManagedImageProviderOnce(
   input: GenerateProviderInput,
 ): Promise<ManagedImageProviderSingleShotResult> {
   if (!isBuilderImageGenerationEnabled()) {
-    if (
-      canUseManualFallbackForSingleShot(input) &&
-      (await isManualImageGenerationConfigured())
-    ) {
+    if (await isManualImageGenerationConfigured()) {
       return {
         status: "completed",
-        output: await generateWithManualImageProvider(input),
+        output: await generateWithManualImageProviderForSingleShot(input),
       };
-    }
-    if (await isManualImageGenerationConfigured()) {
-      throw createSingleShotManualFallbackError(input);
     }
     throw new FeatureNotConfiguredError({
       requiredCredential: "GEMINI_API_KEY or OPENAI_API_KEY",
@@ -459,22 +442,11 @@ export async function generateWithManagedImageProviderOnce(
       return { status: "processing" };
     }
     const manualFallbackConfigured = await isManualImageGenerationConfigured();
-    if (
-      shouldFallbackToManualImageProvider(err) &&
-      manualFallbackConfigured &&
-      canUseManualFallbackForSingleShot(input)
-    ) {
+    if (shouldFallbackToManualImageProvider(err) && manualFallbackConfigured) {
       return {
         status: "completed",
-        output: await generateWithManualImageProvider(input),
+        output: await generateWithManualImageProviderForSingleShot(input),
       };
-    }
-    if (
-      shouldFallbackToManualImageProvider(err) &&
-      manualFallbackConfigured &&
-      err instanceof BuilderImageGenerationError
-    ) {
-      throw createSingleShotManualFallbackError(input, err);
     }
     if (
       shouldFallbackToManualImageProvider(err) &&

--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -411,8 +411,9 @@ function shouldFallbackToManualImageProvider(err: unknown): boolean {
 async function generateWithManualImageProviderForSingleShot(
   input: GenerateProviderInput,
 ): Promise<GenerateProviderOutput> {
+  const output = await generateWithManualImageProvider(input);
   await input.onManualFallbackStart?.();
-  return generateWithManualImageProvider(input);
+  return output;
 }
 
 export async function generateWithManagedImageProviderOnce(

--- a/templates/assets/server/lib/image-runs.spec.ts
+++ b/templates/assets/server/lib/image-runs.spec.ts
@@ -21,6 +21,7 @@ const schemaMock = vi.hoisted(() => ({
   assetGenerationSessionItems: {},
   assetGenerationSessions: {
     id: "sessions.id",
+    activeAssetId: "sessions.activeAssetId",
   },
 }));
 
@@ -77,6 +78,12 @@ import {
 
 type AssetRow = Record<string, any>;
 type RunRow = Record<string, any>;
+type TestState = {
+  assets: AssetRow[];
+  updates: any[];
+  sessions?: Array<Record<string, any>>;
+  sessionItems?: Array<Record<string, any>>;
+};
 
 function runRow(overrides: Partial<RunRow> = {}): RunRow {
   return {
@@ -113,7 +120,7 @@ function runRow(overrides: Partial<RunRow> = {}): RunRow {
   };
 }
 
-function createDb(state: { assets: AssetRow[]; updates: any[] }) {
+function createDb(state: TestState) {
   function rowsFor(table: unknown, condition: any) {
     if (table === schemaMock.assets) {
       if (condition?.op === "inArray") {
@@ -133,6 +140,13 @@ function createDb(state: { assets: AssetRow[]; updates: any[] }) {
     }
     if (table === schemaMock.assetLibraries) {
       return [{ id: "library-1", canonicalLogoAssetId: null }];
+    }
+    if (table === schemaMock.assetGenerationSessions) {
+      const sessions = state.sessions ?? [];
+      if (condition?.column === schemaMock.assetGenerationSessions.id) {
+        return sessions.filter((session) => session.id === condition.value);
+      }
+      return sessions;
     }
     return [];
   }
@@ -157,8 +171,13 @@ function createDb(state: { assets: AssetRow[]; updates: any[] }) {
         }),
       })),
     })),
-    insert: vi.fn(() => ({
+    insert: vi.fn((table: unknown) => ({
       values: vi.fn(async (row: AssetRow) => {
+        if (table === schemaMock.assetGenerationSessionItems) {
+          state.sessionItems ??= [];
+          state.sessionItems.push(row);
+          return;
+        }
         if (row.id && state.assets.some((asset) => asset.id === row.id)) {
           throw new Error("duplicate asset id");
         }
@@ -284,6 +303,60 @@ describe("image run finalization", () => {
     ]);
     expect(state.assets).toHaveLength(1);
     expect(state.assets[0].generationRunId).toBe("run-1");
+  });
+
+  it("promotes a background batch candidate when the session has no active asset", async () => {
+    const state = {
+      assets: [] as AssetRow[],
+      updates: [] as any[],
+      sessions: [{ id: "session-1", activeAssetId: null }],
+      sessionItems: [] as Array<Record<string, any>>,
+    };
+    const db = createDb(state);
+    getDbMock.mockReturnValue(db);
+    createAssetFromBufferMock.mockImplementation(async (input: any) => {
+      const asset = {
+        id: input.id,
+        libraryId: input.libraryId,
+        collectionId: input.collectionId,
+        generationRunId: input.generationRunId,
+      };
+      state.assets.push(asset);
+      return asset;
+    });
+    generateWithManagedImageProviderOnceMock.mockResolvedValue({
+      status: "completed",
+      output: {
+        image: Buffer.from([1, 2, 3]),
+        mimeType: "image/png",
+        model: "builder-image",
+        provider: "builder",
+      },
+    });
+
+    const result = await finalizeImageRun(
+      runRow({
+        sessionId: "session-1",
+        metadata: JSON.stringify({
+          slotId: "slot-1",
+          variantBatchId: "batch-1",
+          activateSessionAsset: false,
+        }),
+      }) as any,
+    );
+
+    expect(result.status).toBe("completed");
+    expect(state.sessionItems).toContainEqual(
+      expect.objectContaining({
+        sessionId: "session-1",
+        assetId: "image_run-1",
+        role: "active",
+      }),
+    );
+    expect(state.updates).toContainEqual({
+      activeAssetId: "image_run-1",
+      updatedAt: "2026-05-28T12:00:00.000Z",
+    });
   });
 
   it("returns processing when the inline budget elapses", async () => {

--- a/templates/assets/server/lib/image-runs.spec.ts
+++ b/templates/assets/server/lib/image-runs.spec.ts
@@ -449,4 +449,44 @@ describe("image run finalization", () => {
     );
     expect(state.assets).toHaveLength(0);
   });
+
+  it("waits past the budget after provider output is ready", async () => {
+    vi.useFakeTimers();
+    const state = { assets: [] as AssetRow[], updates: [] as any[] };
+    getDbMock.mockReturnValue(createDb(state));
+    generateWithManagedImageProviderOnceMock.mockImplementation(
+      async (input: any) => {
+        await input.onProviderOutputReady();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return {
+          status: "completed",
+          output: {
+            image: Buffer.from([1, 2, 3]),
+            mimeType: "image/png",
+            model: "builder-image",
+            provider: "builder",
+          },
+        };
+      },
+    );
+    createAssetFromBufferMock.mockImplementation(async (input: any) => {
+      const asset = {
+        id: input.id,
+        libraryId: input.libraryId,
+        collectionId: input.collectionId,
+        generationRunId: input.generationRunId,
+      };
+      state.assets.push(asset);
+      return asset;
+    });
+
+    const resultPromise = finalizeImageRunWithinBudget(runRow() as any, 10);
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(resultPromise).resolves.toEqual(
+      expect.objectContaining({ status: "completed" }),
+    );
+    expect(state.assets).toHaveLength(1);
+  });
 });

--- a/templates/assets/server/lib/image-runs.spec.ts
+++ b/templates/assets/server/lib/image-runs.spec.ts
@@ -1,0 +1,304 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDbMock = vi.hoisted(() => vi.fn());
+const createAssetFromBufferMock = vi.hoisted(() => vi.fn());
+const generateWithManagedImageProviderOnceMock = vi.hoisted(() => vi.fn());
+const upsertVariantSlotMock = vi.hoisted(() => vi.fn());
+const wasVariantSlotDismissedMock = vi.hoisted(() => vi.fn());
+
+const schemaMock = vi.hoisted(() => ({
+  assetGenerationRuns: {
+    id: "runs.id",
+  },
+  assets: {
+    id: "assets.id",
+    generationRunId: "assets.generationRunId",
+  },
+  assetLibraries: {
+    id: "libraries.id",
+    canonicalLogoAssetId: "libraries.canonicalLogoAssetId",
+  },
+  assetGenerationSessionItems: {},
+  assetGenerationSessions: {
+    id: "sessions.id",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((column, value) => ({ op: "eq", column, value })),
+  inArray: vi.fn((column, values) => ({ op: "inArray", column, values })),
+}));
+
+vi.mock("../db/index.js", () => ({
+  getDb: getDbMock,
+  schema: schemaMock,
+}));
+
+vi.mock("./assets.js", () => ({
+  createAssetFromBuffer: createAssetFromBufferMock,
+}));
+
+vi.mock("./generation.js", () => ({
+  generateWithManagedImageProviderOnce:
+    generateWithManagedImageProviderOnceMock,
+}));
+
+vi.mock("./image-processing.js", () => ({
+  compositeLogo: vi.fn(),
+}));
+
+vi.mock("./json.js", () => ({
+  nowIso: vi.fn(() => "2026-05-28T12:00:00.000Z"),
+  parseJson: vi.fn((value: string | null | undefined, fallback: unknown) => {
+    if (!value) return fallback;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return fallback;
+    }
+  }),
+  stringifyJson: vi.fn((value: unknown) => JSON.stringify(value)),
+}));
+
+vi.mock("./storage.js", () => ({
+  getObject: vi.fn(async () => Buffer.from([1])),
+}));
+
+vi.mock("../../actions/variant-slots.js", () => ({
+  upsertVariantSlot: upsertVariantSlotMock,
+  wasVariantSlotDismissed: wasVariantSlotDismissedMock,
+}));
+
+import {
+  finalizeImageRun,
+  finalizeImageRunWithinBudget,
+} from "./image-runs.js";
+
+type AssetRow = Record<string, any>;
+type RunRow = Record<string, any>;
+
+function runRow(overrides: Partial<RunRow> = {}): RunRow {
+  return {
+    id: "run-1",
+    libraryId: "library-1",
+    collectionId: null,
+    presetId: null,
+    sessionId: null,
+    prompt: "A hero image",
+    compiledPrompt: "Compiled prompt",
+    mediaType: "image",
+    model: "gemini-3.1-flash-image",
+    aspectRatio: "16:9",
+    imageSize: "2K",
+    durationSeconds: null,
+    resolution: null,
+    groundingMode: "auto",
+    referenceAssetIds: "[]",
+    status: "processing",
+    error: null,
+    metadata: JSON.stringify({
+      slotId: "slot-1",
+      variantBatchId: "batch-1",
+      providerStatus: "processing",
+      categories: ["hero"],
+    }),
+    createdAt: "2026-05-28T11:59:00.000Z",
+    completedAt: null,
+    source: "chat",
+    callerAppId: null,
+    ownerEmail: null,
+    orgId: null,
+    ...overrides,
+  };
+}
+
+function createDb(state: { assets: AssetRow[]; updates: any[] }) {
+  function rowsFor(table: unknown, condition: any) {
+    if (table === schemaMock.assets) {
+      if (condition?.op === "inArray") {
+        return state.assets.filter((asset) =>
+          condition.values.includes(asset.id),
+        );
+      }
+      if (condition?.column === schemaMock.assets.generationRunId) {
+        return state.assets.filter(
+          (asset) => asset.generationRunId === condition.value,
+        );
+      }
+      if (condition?.column === schemaMock.assets.id) {
+        return state.assets.filter((asset) => asset.id === condition.value);
+      }
+      return state.assets;
+    }
+    if (table === schemaMock.assetLibraries) {
+      return [{ id: "library-1", canonicalLogoAssetId: null }];
+    }
+    return [];
+  }
+
+  const db = {
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => ({
+        where: vi.fn((condition: any) => {
+          const rows = rowsFor(table, condition);
+          const promise = Promise.resolve(rows) as Promise<AssetRow[]> & {
+            limit: (count: number) => Promise<AssetRow[]>;
+          };
+          promise.limit = vi.fn(async (count: number) => rows.slice(0, count));
+          return promise;
+        }),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: Record<string, unknown>) => ({
+        where: vi.fn(async () => {
+          state.updates.push(values);
+        }),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(async (row: AssetRow) => {
+        if (row.id && state.assets.some((asset) => asset.id === row.id)) {
+          throw new Error("duplicate asset id");
+        }
+        state.assets.push(row);
+      }),
+    })),
+    transaction: vi.fn(async (fn: (tx: typeof db) => unknown) => fn(db)),
+  };
+  return db;
+}
+
+describe("image run finalization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wasVariantSlotDismissedMock.mockResolvedValue(false);
+    upsertVariantSlotMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("finalizes an immediately completed image run and syncs the variant slot", async () => {
+    const state = { assets: [] as AssetRow[], updates: [] as any[] };
+    const db = createDb(state);
+    getDbMock.mockReturnValue(db);
+    createAssetFromBufferMock.mockImplementation(async (input: any) => {
+      const asset = {
+        id: input.id,
+        libraryId: input.libraryId,
+        collectionId: input.collectionId,
+        objectKey: "https://cdn.builder.io/api/v1/image/assets%2Foriginal.png",
+        thumbnailObjectKey:
+          "https://cdn.builder.io/api/v1/image/assets%2Fthumb.webp",
+        generationRunId: input.generationRunId,
+      };
+      state.assets.push(asset);
+      return asset;
+    });
+    generateWithManagedImageProviderOnceMock.mockResolvedValue({
+      status: "completed",
+      output: {
+        image: Buffer.from([1, 2, 3]),
+        mimeType: "image/png",
+        model: "builder-image",
+        provider: "builder",
+        providerGenerationId: "generation-1",
+      },
+    });
+
+    const result = await finalizeImageRun(runRow() as any);
+
+    expect(result.status).toBe("completed");
+    expect(state.assets).toHaveLength(1);
+    expect(state.assets[0].id).toBe("image_run-1");
+    expect(state.updates).toContainEqual(
+      expect.objectContaining({ status: "completed", error: null }),
+    );
+    expect(upsertVariantSlotMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        slotId: "slot-1",
+        status: "ready",
+        assetId: "image_run-1",
+        previewUrl: "https://cdn.builder.io/api/v1/image/assets%2Foriginal.png",
+        thumbnailUrl: "https://cdn.builder.io/api/v1/image/assets%2Fthumb.webp",
+      }),
+    );
+  });
+
+  it("leaves the run processing when the provider is still working", async () => {
+    const state = { assets: [] as AssetRow[], updates: [] as any[] };
+    getDbMock.mockReturnValue(createDb(state));
+    generateWithManagedImageProviderOnceMock.mockResolvedValue({
+      status: "processing",
+    });
+
+    const result = await finalizeImageRun(runRow() as any);
+
+    expect(result.status).toBe("processing");
+    expect(state.assets).toHaveLength(0);
+    expect(state.updates).toContainEqual(
+      expect.objectContaining({ status: "processing" }),
+    );
+    expect(upsertVariantSlotMock).not.toHaveBeenCalled();
+  });
+
+  it("dedupes concurrent completion by reusing one asset for a run", async () => {
+    const state = { assets: [] as AssetRow[], updates: [] as any[] };
+    const db = createDb(state);
+    getDbMock.mockReturnValue(db);
+    createAssetFromBufferMock.mockImplementation(async (input: any) => {
+      const asset = {
+        id: input.id,
+        libraryId: input.libraryId,
+        collectionId: input.collectionId,
+        generationRunId: input.generationRunId,
+      };
+      if (state.assets.some((row) => row.id === asset.id)) {
+        throw new Error("duplicate asset id");
+      }
+      state.assets.push(asset);
+      return asset;
+    });
+    generateWithManagedImageProviderOnceMock.mockResolvedValue({
+      status: "completed",
+      output: {
+        image: Buffer.from([1, 2, 3]),
+        mimeType: "image/png",
+        model: "builder-image",
+        provider: "builder",
+      },
+    });
+
+    const results = await Promise.all([
+      finalizeImageRun(runRow() as any),
+      finalizeImageRun(runRow() as any),
+    ]);
+
+    expect(results.map((result) => result.status)).toEqual([
+      "completed",
+      "completed",
+    ]);
+    expect(state.assets).toHaveLength(1);
+    expect(state.assets[0].generationRunId).toBe("run-1");
+  });
+
+  it("returns processing when the inline budget elapses", async () => {
+    vi.useFakeTimers();
+    const state = { assets: [] as AssetRow[], updates: [] as any[] };
+    getDbMock.mockReturnValue(createDb(state));
+    generateWithManagedImageProviderOnceMock.mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    const resultPromise = finalizeImageRunWithinBudget(runRow() as any, 10);
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(resultPromise).resolves.toEqual(
+      expect.objectContaining({ status: "processing" }),
+    );
+    expect(state.assets).toHaveLength(0);
+  });
+});

--- a/templates/assets/server/lib/image-runs.spec.ts
+++ b/templates/assets/server/lib/image-runs.spec.ts
@@ -265,6 +265,80 @@ describe("image run finalization", () => {
     expect(upsertVariantSlotMock).not.toHaveBeenCalled();
   });
 
+  it("does not restart an active manual fallback attempt", async () => {
+    const state = { assets: [] as AssetRow[], updates: [] as any[] };
+    getDbMock.mockReturnValue(createDb(state));
+
+    const result = await finalizeImageRun(
+      runRow({
+        metadata: JSON.stringify({
+          manualFallbackStartedAt: new Date().toISOString(),
+        }),
+      }) as any,
+    );
+
+    expect(result.status).toBe("processing");
+    expect(generateWithManagedImageProviderOnceMock).not.toHaveBeenCalled();
+    expect(state.assets).toHaveLength(0);
+  });
+
+  it("records manual fallback start before provider fallback runs", async () => {
+    const state = { assets: [] as AssetRow[], updates: [] as any[] };
+    const db = createDb(state);
+    getDbMock.mockReturnValue(db);
+    createAssetFromBufferMock.mockImplementation(async (input: any) => {
+      const asset = {
+        id: input.id,
+        libraryId: input.libraryId,
+        collectionId: input.collectionId,
+        generationRunId: input.generationRunId,
+      };
+      state.assets.push(asset);
+      return asset;
+    });
+    generateWithManagedImageProviderOnceMock.mockImplementation(
+      async (input: any) => {
+        await input.onManualFallbackStart();
+        return {
+          status: "completed",
+          output: {
+            image: Buffer.from([1, 2, 3]),
+            mimeType: "image/png",
+            model: "gpt-image-2",
+            provider: "openai",
+          },
+        };
+      },
+    );
+
+    const result = await finalizeImageRun(runRow() as any);
+
+    expect(result.status).toBe("completed");
+    expect(state.updates).toContainEqual(
+      expect.objectContaining({
+        status: "processing",
+        metadata: expect.stringContaining("manualFallbackStartedAt"),
+      }),
+    );
+  });
+
+  it("does not use the short provider retry budget as the image download timeout", async () => {
+    const state = { assets: [] as AssetRow[], updates: [] as any[] };
+    getDbMock.mockReturnValue(createDb(state));
+    generateWithManagedImageProviderOnceMock.mockResolvedValue({
+      status: "processing",
+    });
+
+    await finalizeImageRun(runRow() as any, {
+      providerAttemptTimeoutMs: 123,
+    });
+
+    const providerInput =
+      generateWithManagedImageProviderOnceMock.mock.calls[0][0];
+    expect(providerInput.requestTimeoutMs).toBe(123);
+    expect("downloadTimeoutMs" in providerInput).toBe(false);
+  });
+
   it("dedupes concurrent completion by reusing one asset for a run", async () => {
     const state = { assets: [] as AssetRow[], updates: [] as any[] };
     const db = createDb(state);

--- a/templates/assets/server/lib/image-runs.spec.ts
+++ b/templates/assets/server/lib/image-runs.spec.ts
@@ -48,6 +48,7 @@ vi.mock("./image-processing.js", () => ({
 }));
 
 vi.mock("./json.js", () => ({
+  absoluteUrl: vi.fn((path: string) => path),
   nowIso: vi.fn(() => "2026-05-28T12:00:00.000Z"),
   parseJson: vi.fn((value: string | null | undefined, fallback: unknown) => {
     if (!value) return fallback;

--- a/templates/assets/server/lib/image-runs.ts
+++ b/templates/assets/server/lib/image-runs.ts
@@ -1,0 +1,622 @@
+import { eq, inArray } from "drizzle-orm";
+
+import {
+  upsertVariantSlot,
+  wasVariantSlotDismissed,
+} from "../../actions/variant-slots.js";
+import type {
+  GenerationIntent,
+  ImageCategory,
+  StyleStrength,
+} from "../../shared/api.js";
+import { getDb, schema } from "../db/index.js";
+import { createAssetFromBuffer } from "./assets.js";
+import {
+  generateWithManagedImageProviderOnce,
+  type GenerateProviderOutput,
+  type ReferenceForGeneration,
+} from "./generation.js";
+import { compositeLogo } from "./image-processing.js";
+import { absoluteUrl, nowIso, parseJson, stringifyJson } from "./json.js";
+import { getObject } from "./storage.js";
+
+const INLINE_WAIT_ENV = Number(process.env.ASSETS_IMAGE_INLINE_WAIT_MS);
+const REFRESH_WAIT_ENV = Number(process.env.ASSETS_IMAGE_REFRESH_WAIT_MS);
+
+export const IMAGE_GENERATION_INLINE_FAST_PATH_MS = Number.isFinite(
+  INLINE_WAIT_ENV,
+)
+  ? INLINE_WAIT_ENV
+  : process.env.NODE_ENV === "test"
+    ? 25
+    : 30_000;
+
+export const IMAGE_GENERATION_REFRESH_ATTEMPT_MS = Number.isFinite(
+  REFRESH_WAIT_ENV,
+)
+  ? REFRESH_WAIT_ENV
+  : process.env.NODE_ENV === "test"
+    ? 25
+    : 8_000;
+
+type ImageRun = typeof schema.assetGenerationRuns.$inferSelect;
+type ImageAsset = typeof schema.assets.$inferSelect;
+type ImageRunDb = Pick<ReturnType<typeof getDb>, "select" | "update">;
+
+export type FinalizeImageRunResult =
+  | {
+      status: "processing";
+      run: ImageRun;
+    }
+  | {
+      status: "completed";
+      run: ImageRun;
+      asset: ImageAsset;
+    }
+  | {
+      status: "dismissed";
+      run: ImageRun;
+    };
+
+async function findAssetForRun(
+  db: ImageRunDb,
+  runId: string,
+): Promise<ImageAsset | undefined> {
+  const [asset] = await db
+    .select()
+    .from(schema.assets)
+    .where(eq(schema.assets.generationRunId, runId))
+    .limit(1);
+  return asset;
+}
+
+async function markRunProcessing(
+  db: ImageRunDb,
+  run: ImageRun,
+  metadata: Record<string, unknown>,
+): Promise<ImageRun> {
+  const nextMetadata = {
+    ...metadata,
+    mediaType: "image",
+    providerStatus: "processing",
+    lastPolledAt: nowIso(),
+  };
+  const nextRun = {
+    ...run,
+    status: "processing",
+    metadata: stringifyJson(nextMetadata),
+  };
+  await db
+    .update(schema.assetGenerationRuns)
+    .set({
+      status: "processing",
+      metadata: nextRun.metadata,
+    })
+    .where(eq(schema.assetGenerationRuns.id, run.id));
+  return nextRun;
+}
+
+async function markRunCompletedWithAsset(
+  db: ImageRunDb,
+  run: ImageRun,
+  metadata: Record<string, unknown>,
+  asset: ImageAsset,
+  generated?: GenerateProviderOutput,
+): Promise<ImageRun> {
+  const nextMetadata = {
+    ...metadata,
+    mediaType: "image",
+    providerStatus: "completed",
+    assetId: asset.id,
+    outputAssetIds: [asset.id],
+    ...(generated?.provider ? { provider: generated.provider } : {}),
+    ...(generated?.sourceUrl ? { sourceUrl: generated.sourceUrl } : {}),
+    ...(generated?.providerGenerationId
+      ? { providerGenerationId: generated.providerGenerationId }
+      : {}),
+    ...(generated?.creditsCharged !== undefined
+      ? { creditsCharged: generated.creditsCharged }
+      : {}),
+  };
+  const completedAt = nowIso();
+  const nextRun = {
+    ...run,
+    status: "completed",
+    completedAt,
+    error: null,
+    metadata: stringifyJson(nextMetadata),
+  };
+  await db
+    .update(schema.assetGenerationRuns)
+    .set({
+      status: "completed",
+      completedAt,
+      error: null,
+      metadata: nextRun.metadata,
+    })
+    .where(eq(schema.assetGenerationRuns.id, run.id));
+  return nextRun;
+}
+
+async function markRunDismissed(
+  db: ImageRunDb,
+  run: ImageRun,
+  metadata: Record<string, unknown>,
+  generated: GenerateProviderOutput,
+): Promise<ImageRun> {
+  const completedAt = nowIso();
+  const nextRun = {
+    ...run,
+    status: "completed",
+    completedAt,
+    error: null,
+    metadata: stringifyJson({
+      ...metadata,
+      mediaType: "image",
+      providerStatus: "completed",
+      dismissed: true,
+      provider: generated.provider,
+      providerGenerationId: generated.providerGenerationId,
+      creditsCharged: generated.creditsCharged,
+    }),
+  };
+  await db
+    .update(schema.assetGenerationRuns)
+    .set({
+      status: "completed",
+      completedAt,
+      error: null,
+      metadata: nextRun.metadata,
+    })
+    .where(eq(schema.assetGenerationRuns.id, run.id));
+  return nextRun;
+}
+
+async function syncImageVariantSlot(
+  run: ImageRun,
+  status: "ready" | "failed",
+  options: {
+    asset?: ImageAsset;
+    error?: string | null;
+  } = {},
+) {
+  const metadata = parseJson<Record<string, unknown>>(run.metadata, {});
+  const slotId =
+    typeof metadata.slotId === "string" && metadata.slotId
+      ? metadata.slotId
+      : run.id;
+  const batchId =
+    typeof metadata.variantBatchId === "string" && metadata.variantBatchId
+      ? metadata.variantBatchId
+      : null;
+  const threadId =
+    typeof metadata.threadId === "string" && metadata.threadId
+      ? metadata.threadId
+      : null;
+  const variantScopeId =
+    typeof metadata.variantScopeId === "string" && metadata.variantScopeId
+      ? metadata.variantScopeId
+      : null;
+  const urls = options.asset ? imageAssetUrls(options.asset) : null;
+
+  await upsertVariantSlot({
+    runId: run.id,
+    batchId,
+    libraryId: run.libraryId,
+    collectionId: run.collectionId ?? null,
+    presetId: run.presetId ?? null,
+    sessionId: run.sessionId ?? null,
+    threadId,
+    variantScopeId,
+    prompt: run.prompt,
+    slotId,
+    status,
+    assetId: options.asset?.id,
+    previewUrl: urls?.previewUrl,
+    thumbnailUrl: urls?.thumbnailUrl,
+    error: options.error ?? undefined,
+  });
+}
+
+function isDirectMediaKey(key: string | null | undefined): key is string {
+  return Boolean(
+    key &&
+    (key.startsWith("http://") ||
+      key.startsWith("https://") ||
+      key.startsWith("/library-presets/") ||
+      key.startsWith("library-presets/")),
+  );
+}
+
+function directMediaUrl(key: string | null | undefined): string | null {
+  if (!isDirectMediaKey(key)) return null;
+  if (key.startsWith("http://") || key.startsWith("https://")) return key;
+  return absoluteUrl(key.startsWith("/") ? key : `/${key}`);
+}
+
+function imageAssetUrls(asset: ImageAsset) {
+  const previewUrl =
+    directMediaUrl(asset.objectKey) ??
+    absoluteUrl(`/api/assets/${asset.id}/content`);
+  const thumbnailUrl =
+    directMediaUrl(asset.thumbnailObjectKey) ??
+    directMediaUrl(asset.objectKey) ??
+    absoluteUrl(
+      `/api/assets/${asset.id}/content${
+        asset.thumbnailObjectKey ? "?variant=thumb" : ""
+      }`,
+    );
+  return { previewUrl, thumbnailUrl };
+}
+
+function metadataString(
+  metadata: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = metadata[key];
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function metadataBoolean(
+  metadata: Record<string, unknown>,
+  key: string,
+): boolean {
+  return metadata[key] === true;
+}
+
+function metadataStringArray(
+  metadata: Record<string, unknown>,
+  key: string,
+): string[] {
+  const value = metadata[key];
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function generationIntent(value: unknown): GenerationIntent | undefined {
+  return value === "generate" || value === "restyle" || value === "edit"
+    ? value
+    : undefined;
+}
+
+function styleStrength(value: unknown): StyleStrength | undefined {
+  return value === "subtle" || value === "balanced" || value === "strong"
+    ? value
+    : undefined;
+}
+
+function imageCategory(value: unknown): ImageCategory | undefined {
+  return typeof value === "string" ? (value as ImageCategory) : undefined;
+}
+
+async function loadReferencesForRun(
+  run: ImageRun,
+): Promise<ReferenceForGeneration[]> {
+  const referenceAssetIds = parseJson<string[]>(run.referenceAssetIds, []);
+  if (!referenceAssetIds.length) return [];
+  const rows = await getDb()
+    .select()
+    .from(schema.assets)
+    .where(inArray(schema.assets.id, referenceAssetIds));
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  const references: ReferenceForGeneration[] = [];
+  for (const id of referenceAssetIds) {
+    const asset = byId.get(id);
+    if (!asset || !asset.mimeType.startsWith("image/")) continue;
+    const metadata = parseJson<Record<string, unknown>>(asset.metadata, {});
+    references.push({
+      id: asset.id,
+      role: asset.role,
+      category:
+        typeof metadata.category === "string" ? metadata.category : undefined,
+      mimeType: asset.mimeType,
+      data: (await getObject(asset.objectKey)).toString("base64"),
+    });
+  }
+  return references;
+}
+
+async function maybeCompositeLogo(input: {
+  run: ImageRun;
+  metadata: Record<string, unknown>;
+  generated: GenerateProviderOutput;
+}): Promise<{ image: Buffer; mimeType: string }> {
+  if (!metadataBoolean(input.metadata, "includeLogo")) {
+    return {
+      image: input.generated.image,
+      mimeType: input.generated.mimeType,
+    };
+  }
+  const [library] = await getDb()
+    .select({
+      canonicalLogoAssetId: schema.assetLibraries.canonicalLogoAssetId,
+    })
+    .from(schema.assetLibraries)
+    .where(eq(schema.assetLibraries.id, input.run.libraryId))
+    .limit(1);
+  if (!library?.canonicalLogoAssetId) {
+    return {
+      image: input.generated.image,
+      mimeType: input.generated.mimeType,
+    };
+  }
+  const [logo] = await getDb()
+    .select()
+    .from(schema.assets)
+    .where(eq(schema.assets.id, library.canonicalLogoAssetId))
+    .limit(1);
+  if (!logo) {
+    return {
+      image: input.generated.image,
+      mimeType: input.generated.mimeType,
+    };
+  }
+  return {
+    image: await compositeLogo({
+      image: input.generated.image,
+      logo: await getObject(logo.objectKey),
+    }),
+    mimeType: "image/png",
+  };
+}
+
+async function createAssetForRun(
+  db: Pick<ReturnType<typeof getDb>, "insert">,
+  run: ImageRun,
+  metadata: Record<string, unknown>,
+  generated: GenerateProviderOutput,
+  image: Buffer,
+  mimeType: string,
+): Promise<ImageAsset> {
+  const referenceAssetIds = parseJson<string[]>(run.referenceAssetIds, []);
+  const categories = metadataStringArray(metadata, "categories");
+  const asset = await createAssetFromBuffer({
+    id: `image_${run.id}`,
+    libraryId: run.libraryId,
+    collectionId: run.collectionId ?? null,
+    buffer: image,
+    mimeType,
+    role: "generated",
+    status: "candidate",
+    prompt: run.prompt,
+    model: generated.model,
+    aspectRatio: run.aspectRatio,
+    imageSize: run.imageSize,
+    generationRunId: run.id,
+    sourceUrl: generated.sourceUrl,
+    db,
+    metadata: {
+      provider: generated.provider,
+      compiledPrompt: run.compiledPrompt,
+      referenceAssetIds,
+      sourceAssetId: metadataString(metadata, "sourceAssetId"),
+      subjectAssetId: metadataString(metadata, "subjectAssetId"),
+      intent: generationIntent(metadata.intent),
+      styleStrength: styleStrength(metadata.styleStrength),
+      tier: metadata.tier,
+      includeLogo: metadataBoolean(metadata, "includeLogo"),
+      presetId: run.presetId ?? metadataString(metadata, "presetId"),
+      sessionId: run.sessionId ?? metadataString(metadata, "sessionId"),
+      generated: true,
+      sourceUrl: generated.sourceUrl,
+      providerGenerationId: generated.providerGenerationId,
+      creditsCharged: generated.creditsCharged,
+    },
+    category: imageCategory(categories[0]),
+  });
+
+  return asset;
+}
+
+async function attachAssetToSessionForRun(
+  db: Pick<ReturnType<typeof getDb>, "insert" | "update">,
+  run: ImageRun,
+  metadata: Record<string, unknown>,
+  asset: ImageAsset,
+) {
+  const sessionId = run.sessionId ?? metadataString(metadata, "sessionId");
+  if (!sessionId) return;
+
+  const activateSessionAsset = metadata.activateSessionAsset !== false;
+  const itemCreatedAt = nowIso();
+  try {
+    await db.insert(schema.assetGenerationSessionItems).values({
+      id: `${run.id}_item`,
+      sessionId,
+      assetId: asset.id,
+      generationRunId: run.id,
+      role: activateSessionAsset ? "active" : "candidate",
+      note: null,
+      sortOrder: 100,
+      createdAt: itemCreatedAt,
+    });
+  } catch (err) {
+    if (!isUniqueConstraintError(err)) throw err;
+  }
+  if (activateSessionAsset) {
+    await db
+      .update(schema.assetGenerationSessions)
+      .set({ activeAssetId: asset.id, updatedAt: itemCreatedAt })
+      .where(eq(schema.assetGenerationSessions.id, sessionId));
+  }
+}
+
+function isUniqueConstraintError(err: unknown): boolean {
+  const anyErr = err as { code?: string; message?: string };
+  return (
+    anyErr.code === "SQLITE_CONSTRAINT_UNIQUE" ||
+    anyErr.code === "SQLITE_CONSTRAINT_PRIMARYKEY" ||
+    /unique constraint|duplicate|primary key/i.test(anyErr.message ?? "")
+  );
+}
+
+export async function finalizeImageRun(
+  run: ImageRun,
+  options: { providerAttemptTimeoutMs?: number } = {},
+): Promise<FinalizeImageRunResult> {
+  const metadata = parseJson<Record<string, unknown>>(run.metadata, {});
+  const existingAsset = await findAssetForRun(getDb(), run.id);
+  if (existingAsset) {
+    const nextRun = await markRunCompletedWithAsset(
+      getDb(),
+      run,
+      metadata,
+      existingAsset,
+    );
+    await syncImageVariantSlot(nextRun, "ready", { asset: existingAsset });
+    return { status: "completed", run: nextRun, asset: existingAsset };
+  }
+
+  const references = await loadReferencesForRun(run);
+  const generated = await generateWithManagedImageProviderOnce({
+    prompt: run.prompt,
+    compiledPrompt: run.compiledPrompt,
+    references,
+    model: run.model as any,
+    aspectRatio: run.aspectRatio as any,
+    imageSize: run.imageSize as any,
+    groundingMode: run.groundingMode as any,
+    intent: generationIntent(metadata.intent),
+    styleStrength: styleStrength(metadata.styleStrength),
+    runId: run.id,
+    libraryId: run.libraryId,
+    collectionId: run.collectionId ?? null,
+    source: run.source as any,
+    callerAppId: run.callerAppId ?? undefined,
+    requestTimeoutMs: options.providerAttemptTimeoutMs,
+    downloadTimeoutMs: options.providerAttemptTimeoutMs,
+  });
+  if (generated.status === "processing") {
+    const nextRun = await markRunProcessing(getDb(), run, metadata);
+    return { status: "processing", run: nextRun };
+  }
+
+  const slotId = metadataString(metadata, "slotId") ?? run.id;
+  const dismissibleSlot = metadata.dismissible !== false && Boolean(slotId);
+  if (
+    dismissibleSlot &&
+    (await wasVariantSlotDismissed(run.libraryId, slotId, {
+      threadId: metadataString(metadata, "threadId") ?? null,
+      variantScopeId: metadataString(metadata, "variantScopeId") ?? null,
+    }))
+  ) {
+    const dismissedRun = await markRunDismissed(
+      getDb(),
+      run,
+      metadata,
+      generated.output,
+    );
+    return { status: "dismissed", run: dismissedRun };
+  }
+
+  const { image, mimeType } = await maybeCompositeLogo({
+    run,
+    metadata,
+    generated: generated.output,
+  });
+
+  let asset: ImageAsset;
+  try {
+    asset = await createAssetForRun(
+      getDb(),
+      run,
+      metadata,
+      generated.output,
+      image,
+      mimeType,
+    );
+  } catch (err) {
+    const existing = await findAssetForRun(getDb(), run.id);
+    if (!existing || !isUniqueConstraintError(err)) throw err;
+    asset = existing;
+  }
+
+  try {
+    const completed = await getDb().transaction(async (tx) => {
+      const existing = await findAssetForRun(tx, run.id);
+      const outputAsset = existing ?? asset;
+      await attachAssetToSessionForRun(tx, run, metadata, outputAsset);
+      const nextRun = await markRunCompletedWithAsset(
+        tx,
+        run,
+        metadata,
+        outputAsset,
+        generated.output,
+      );
+      return { run: nextRun, asset: outputAsset };
+    });
+    await syncImageVariantSlot(completed.run, "ready", {
+      asset: completed.asset,
+    });
+    return {
+      status: "completed",
+      run: completed.run,
+      asset: completed.asset,
+    };
+  } catch (err) {
+    const existing = await findAssetForRun(getDb(), run.id);
+    if (existing) {
+      const nextRun = await markRunCompletedWithAsset(
+        getDb(),
+        run,
+        metadata,
+        existing,
+        generated.output,
+      );
+      await syncImageVariantSlot(nextRun, "ready", { asset: existing });
+      return { status: "completed", run: nextRun, asset: existing };
+    }
+    throw err;
+  }
+}
+
+export async function finalizeImageRunWithinBudget(
+  run: ImageRun,
+  waitMs: number,
+): Promise<FinalizeImageRunResult> {
+  let timedOut = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const completion = finalizeImageRun(run, {
+    providerAttemptTimeoutMs: waitMs,
+  }).catch((err) => {
+    if (timedOut) return { status: "processing" as const, run };
+    throw err;
+  });
+  const timeout = new Promise<FinalizeImageRunResult>((resolve) => {
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      resolve({ status: "processing", run });
+    }, waitMs);
+  });
+  try {
+    return await Promise.race([completion, timeout]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+export async function markImageRunFailed(input: {
+  run: ImageRun;
+  message: string;
+}): Promise<ImageRun> {
+  const completedAt = nowIso();
+  const failedRun = {
+    ...input.run,
+    status: "failed",
+    error: input.message,
+    completedAt,
+  };
+  await getDb()
+    .update(schema.assetGenerationRuns)
+    .set({
+      status: "failed",
+      error: input.message,
+      completedAt,
+    })
+    .where(eq(schema.assetGenerationRuns.id, input.run.id));
+  await syncImageVariantSlot(failedRun, "failed", {
+    error: input.message,
+  });
+  return failedRun;
+}

--- a/templates/assets/server/lib/image-runs.ts
+++ b/templates/assets/server/lib/image-runs.ts
@@ -464,7 +464,10 @@ function isUniqueConstraintError(err: unknown): boolean {
 
 export async function finalizeImageRun(
   run: ImageRun,
-  options: { providerAttemptTimeoutMs?: number } = {},
+  options: {
+    providerAttemptTimeoutMs?: number;
+    onNonInterruptibleWorkStart?: () => void;
+  } = {},
 ): Promise<FinalizeImageRunResult> {
   const metadata = parseJson<Record<string, unknown>>(run.metadata, {});
   const existingAsset = await findAssetForRun(getDb(), run.id);
@@ -509,7 +512,11 @@ export async function finalizeImageRun(
     source: run.source as any,
     callerAppId: run.callerAppId ?? undefined,
     requestTimeoutMs: options.providerAttemptTimeoutMs,
+    onProviderOutputReady: async () => {
+      options.onNonInterruptibleWorkStart?.();
+    },
     onManualFallbackStart: async () => {
+      options.onNonInterruptibleWorkStart?.();
       if (metadataString(metadata, "manualFallbackStartedAt")) return;
       metadata.provider = "manual";
       metadata.manualFallbackStartedAt = nowIso();
@@ -605,16 +612,23 @@ export async function finalizeImageRunWithinBudget(
   waitMs: number,
 ): Promise<FinalizeImageRunResult> {
   let timedOut = false;
+  let nonInterruptibleWorkStarted = false;
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const completion = finalizeImageRun(run, {
     providerAttemptTimeoutMs: waitMs,
+    onNonInterruptibleWorkStart: () => {
+      nonInterruptibleWorkStarted = true;
+    },
   }).catch((err) => {
-    if (timedOut) return { status: "processing" as const, run };
+    if (timedOut && !nonInterruptibleWorkStarted) {
+      return { status: "processing" as const, run };
+    }
     throw err;
   });
   const timeout = new Promise<FinalizeImageRunResult>((resolve) => {
     timeoutId = setTimeout(() => {
       timedOut = true;
+      if (nonInterruptibleWorkStarted) return;
       resolve({ status: "processing", run });
     }, waitMs);
   });

--- a/templates/assets/server/lib/image-runs.ts
+++ b/templates/assets/server/lib/image-runs.ts
@@ -410,7 +410,7 @@ async function createAssetForRun(
 }
 
 async function attachAssetToSessionForRun(
-  db: Pick<ReturnType<typeof getDb>, "insert" | "update">,
+  db: Pick<ReturnType<typeof getDb>, "insert" | "select" | "update">,
   run: ImageRun,
   metadata: Record<string, unknown>,
   asset: ImageAsset,
@@ -418,7 +418,15 @@ async function attachAssetToSessionForRun(
   const sessionId = run.sessionId ?? metadataString(metadata, "sessionId");
   if (!sessionId) return;
 
-  const activateSessionAsset = metadata.activateSessionAsset !== false;
+  let activateSessionAsset = metadata.activateSessionAsset !== false;
+  if (!activateSessionAsset) {
+    const [session] = await db
+      .select({ activeAssetId: schema.assetGenerationSessions.activeAssetId })
+      .from(schema.assetGenerationSessions)
+      .where(eq(schema.assetGenerationSessions.id, sessionId))
+      .limit(1);
+    activateSessionAsset = !session?.activeAssetId;
+  }
   const itemCreatedAt = nowIso();
   try {
     await db.insert(schema.assetGenerationSessionItems).values({

--- a/templates/assets/server/lib/image-runs.ts
+++ b/templates/assets/server/lib/image-runs.ts
@@ -38,6 +38,9 @@ export const IMAGE_GENERATION_REFRESH_ATTEMPT_MS = Number.isFinite(
   : process.env.NODE_ENV === "test"
     ? 25
     : 8_000;
+const MANUAL_IMAGE_FALLBACK_STALE_MS = 2 * 60 * 1000;
+const MANUAL_IMAGE_FALLBACK_STALE_ERROR =
+  "Manual image generation was interrupted before a preview was created. Start a new generation to retry.";
 
 type ImageRun = typeof schema.assetGenerationRuns.$inferSelect;
 type ImageAsset = typeof schema.assets.$inferSelect;
@@ -475,6 +478,19 @@ export async function finalizeImageRun(
     await syncImageVariantSlot(nextRun, "ready", { asset: existingAsset });
     return { status: "completed", run: nextRun, asset: existingAsset };
   }
+  const manualFallbackStartedAt = metadataString(
+    metadata,
+    "manualFallbackStartedAt",
+  );
+  if (manualFallbackStartedAt) {
+    const startedAt = Date.parse(manualFallbackStartedAt);
+    const elapsedMs = Number.isFinite(startedAt) ? Date.now() - startedAt : 0;
+    if (elapsedMs < MANUAL_IMAGE_FALLBACK_STALE_MS) {
+      const nextRun = await markRunProcessing(getDb(), run, metadata);
+      return { status: "processing", run: nextRun };
+    }
+    throw new Error(MANUAL_IMAGE_FALLBACK_STALE_ERROR);
+  }
 
   const references = await loadReferencesForRun(run);
   const generated = await generateWithManagedImageProviderOnce({
@@ -493,7 +509,12 @@ export async function finalizeImageRun(
     source: run.source as any,
     callerAppId: run.callerAppId ?? undefined,
     requestTimeoutMs: options.providerAttemptTimeoutMs,
-    downloadTimeoutMs: options.providerAttemptTimeoutMs,
+    onManualFallbackStart: async () => {
+      if (metadataString(metadata, "manualFallbackStartedAt")) return;
+      metadata.provider = "manual";
+      metadata.manualFallbackStartedAt = nowIso();
+      await markRunProcessing(getDb(), run, metadata);
+    },
   });
   if (generated.status === "processing") {
     const nextRun = await markRunProcessing(getDb(), run, metadata);


### PR DESCRIPTION
### Motivation

Hosted agent actions have a ~40s soft timeout, but image generation could hold the action open for much longer: a single managed provider call had a 90s request ceiling plus an internal multi-minute in-flight poll loop, and batches waited across multiple slots. Slow or large batches could therefore time out even though the provider kept generating successfully in the background.

### Summary

- make `generate-image` / `generate-image-batch` return quickly when images are still processing
- add shared image run finalization that replays provider idempotency keys, dedupes assets, and syncs variant slots
- move slow image processing/storage work outside SQLite transactions
- let the live candidate tray own image polling, while agent guidance avoids manual polling in normal chat
- fix generated candidate previews to use stored CDN object URLs
- update Assets image-generation skills, action descriptions, tests, and changelog
