### PR TITLE
Fix: video playback broken in workspace dev mode

### DIFF
--- a/.changeset/fix-video-playback-dev-mode.md
+++ b/.changeset/fix-video-playback-dev-mode.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix video playback failing in workspace dev mode. When a browser requested video bytes (range/streaming requests), the dev server was stripping the app base path prefix before Nitro's media handler could run, causing Vite to return an error page instead of the video.

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -1087,7 +1087,21 @@ function baseRedirectGuard(): Plugin {
         if (serveMountedEmbedRuntimeModule(server, req, res, base)) {
           return;
         }
-        req.url = stripMountedDevApiPath(req.url, base);
+        // Nitro's pre-middleware only intercepts document/iframe/frame/empty
+        // fetch-dest requests. For video/audio/image etc. it calls next() and
+        // the post-internal Nitro middleware handles them instead. If we strip
+        // the base path here for those requests, Vite's base middleware sees the
+        // stripped path (e.g. /api/video/:id without /clips/) and responds with
+        // a "did you mean /clips/api/video/:id" error before Nitro can handle it.
+        // Only strip when the request type matches Nitro's pre-middleware gate.
+        const secFetchDest = req.headers["sec-fetch-dest"] as
+          | string
+          | undefined;
+        const isNitroPreHandled =
+          !secFetchDest || /^(document|iframe|frame|empty)$/.test(secFetchDest);
+        if (isNitroPreHandled) {
+          req.url = stripMountedDevApiPath(req.url, base);
+        }
         if (
           req.method === "HEAD" &&
           req.url &&


### PR DESCRIPTION
When running the workspace dev server (e.g. Clips at `/clips`), opening a recording in the browser would fail to play. The first request to `/clips/api/video/:id` would succeed, but the browser's second request — sent to actually stream the video — would get back a Vite error page saying "did you mean to visit `/clips/api/video/:id`?" instead of the video bytes.

The Vite dev server has two phases of Nitro middleware. The first phase only handles page navigations. For video requests (`Sec-Fetch-Dest: video`), it skips and defers to the second phase. The problem was that our `baseRedirectGuard` plugin was stripping the base path prefix (`/clips/`) from the URL for all API requests unconditionally. After stripping, Vite's own base path middleware would intercept the now-prefixless URL and return the error - before the second Nitro phase ever got a chance to run.

## What changed

`baseRedirectGuard` now only strips the base path for navigation-style requests (pages, iframes, fetch calls), matching what the first Nitro phase actually handles. For video, audio, and other media requests, the full URL is left intact so it flows through to the second Nitro phase correctly.

This change only affects the Vite dev server - it has no impact on production builds.
